### PR TITLE
Add Updates section linking VibeServe blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 **An agentic loop that synthesizes bespoke LLM serving systems — one per (model, hardware, workload) target — instead of forcing every deployment through a single general-purpose runtime.**
 
-**Updates**
-
-- **2026-05** — Blog post: [Let AI Agents Write Your Serving Stack with VibeServe](https://syfi.cs.washington.edu/blog/2026-05-12-introducing-vibeserve/).
-
 <p align="center">
   <img src="docs/figures/idea.png" width="85%" alt="Generic serving today vs. VibeServe's per-target bespoke systems">
 </p>
+
+## Updates
+
+- **2026-05** — Blog post: [Let AI Agents Write Your Serving Stack with VibeServe](https://syfi.cs.washington.edu/blog/2026-05-12-introducing-vibeserve/).
+- **2026-05** — Paper released on arXiv: [2605.06068](https://arxiv.org/abs/2605.06068).
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 **An agentic loop that synthesizes bespoke LLM serving systems — one per (model, hardware, workload) target — instead of forcing every deployment through a single general-purpose runtime.**
 
+**Updates**
+
+- **2026-05** — Blog post: [Let AI Agents Write Your Serving Stack with VibeServe](https://syfi.cs.washington.edu/blog/2026-05-12-introducing-vibeserve/).
+
 <p align="center">
   <img src="docs/figures/idea.png" width="85%" alt="Generic serving today vs. VibeServe's per-target bespoke systems">
 </p>


### PR DESCRIPTION
## Summary
- Add an **Updates** section to the README with a dated link to the new VibeServe blog post: https://syfi.cs.washington.edu/blog/2026-05-12-introducing-vibeserve/

## Test plan
- [x] README renders with new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)