### PR TITLE
Ablation knobs + OpenEvolve outer loop

### DIFF
--- a/src/vibe_serve/agents/__init__.py
+++ b/src/vibe_serve/agents/__init__.py
@@ -12,10 +12,26 @@ from pathlib import Path
 from typing import Any
 
 from .base import AgentRunner
-from .cli_runner import CliAgentRunner
-from .deepagents_runner import DeepAgentsRunner
 
+# ``CliAgentRunner`` and ``DeepAgentsRunner`` are imported lazily to break a
+# circular import: ``vibe_serve.agent_runner`` imports
+# ``vibe_serve.agents.callbacks`` (which triggers this ``__init__``), and both
+# concrete runners import back from ``vibe_serve.agent_runner``. Importing
+# them eagerly here turned the cycle into an ImportError on the first entry
+# point that hits ``agent_runner`` first (e.g. the ``vibe-serve`` script).
 __all__ = ["AgentRunner", "DeepAgentsRunner", "CliAgentRunner", "build_agent_runner"]
+
+
+def __getattr__(name: str):
+    if name == "CliAgentRunner":
+        from .cli_runner import CliAgentRunner
+
+        return CliAgentRunner
+    if name == "DeepAgentsRunner":
+        from .deepagents_runner import DeepAgentsRunner
+
+        return DeepAgentsRunner
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def build_agent_runner(
@@ -77,6 +93,8 @@ def build_agent_runner(
                 "internal error: build_agent_runner called with backend='deepagents' "
                 "but no backends dict was provided"
             )
+        from .deepagents_runner import DeepAgentsRunner
+
         return DeepAgentsRunner(
             model=model,
             backends=backends,
@@ -109,6 +127,8 @@ def build_agent_runner(
         # cli_model overrides model.name for the CLI tool. If not set,
         # pass None so the CLI tool uses its own default.
         cli_model = (config.get("agent") or {}).get("cli_model")
+        from .cli_runner import CliAgentRunner
+
         return CliAgentRunner(
             provider=provider,
             model=cli_model,

--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -33,7 +33,7 @@ from vibe_serve.sandbox.run_environment import (
     make_run_environment_spec,
 )
 
-_OUTER_LOOPS = ("agent", "plain", "evolve")
+_OUTER_LOOPS = ("agent", "plain", "evolve", "openevolve")
 _MODALITIES = (
     "text_generation",
     "image_generation",
@@ -175,6 +175,16 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
+        "--no-skills",
+        action="store_true",
+        help=(
+            "Disable skills entirely: no skill directories are copied into "
+            "the workspace and no per-CLI skill-discovery paths are populated. "
+            "Used for ablations measuring the skill library's contribution. "
+            "Overrides --skills-dir."
+        ),
+    )
+    parser.add_argument(
         "--docker",
         action="store_true",
         help="Run agent operations inside a Docker container.",
@@ -272,11 +282,14 @@ def load_config_and_skills(
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
-    skills = (
-        [str(s) for s in args.skills_dir]
-        if isinstance(args.skills_dir, list)
-        else ([str(args.skills_dir)] if args.skills_dir else None)
-    )
+    if getattr(args, "no_skills", False):
+        skills = None
+    else:
+        skills = (
+            [str(s) for s in args.skills_dir]
+            if isinstance(args.skills_dir, list)
+            else ([str(args.skills_dir)] if args.skills_dir else None)
+        )
     backend: ComputeBackend = args.backend or config["backend"]["name"]
     return config, skills, backend
 
@@ -389,6 +402,16 @@ def _build_agent_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--modality", default="text_generation", choices=_MODALITIES
     )
+    parser.add_argument(
+        "--inner-loop",
+        choices=["multi-agent", "single-agent"],
+        default="multi-agent",
+        help=(
+            "How to dispatch implement/judge/profile work each round. "
+            "'multi-agent' (default) uses three specialist agents. "
+            "'single-agent' (ablation) uses one agent for all three roles."
+        ),
+    )
     return parser
 
 
@@ -442,6 +465,7 @@ def _run_agent(args: argparse.Namespace) -> None:
         cli_provider=args.cli_provider,
         backend=backend,
         modality=args.modality,
+        inner_loop=args.inner_loop,
     )
 
     if success:
@@ -605,6 +629,84 @@ def _run_evolve(args: argparse.Namespace) -> None:
 
 
 # ===========================================================================
+# openevolve loop  (--outer-loop openevolve)
+# ===========================================================================
+
+
+def _build_openevolve_parser() -> argparse.ArgumentParser:
+    parser = _make_parser(
+        prog="vibe-serve --outer-loop openevolve",
+        description=(
+            "Run the OpenEvolve-style MAP-Elites search loop: behavioral "
+            "feature binning + cell-uniform parent selection."
+        ),
+    )
+    parser.add_argument("--max-iterations", type=int, default=16)
+    parser.add_argument("--k-inspirations", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument(
+        "--modality", default="text_generation", choices=_MODALITIES
+    )
+    return parser
+
+
+def _validate_openevolve(args: argparse.Namespace) -> None:
+    if args.modal and args.profiler == "nsys":
+        print("Error: --modal only supports --profiler=torch.", file=sys.stderr)
+        sys.exit(2)
+    if args.max_iterations < 1:
+        print("Error: --max-iterations must be >= 1.", file=sys.stderr)
+        sys.exit(2)
+    if args.k_inspirations < 0:
+        print("Error: --k-inspirations must be >= 0.", file=sys.stderr)
+        sys.exit(2)
+
+
+def _run_openevolve(args: argparse.Namespace) -> None:
+    config, skills, backend = load_config_and_skills(args)
+    from vibe_serve.loops.openevolve.loop import run_openevolve_loop
+
+    objective = _load_objective(args.ref)
+
+    existing = False
+    exp_name = args.exp_name
+    if args.resume is not None:
+        run_dir_name = _resolve_run_dir(args.resume)
+        exp_name = run_dir_name
+        existing = True
+        print(f"Resuming openevolve run: exp_env/{run_dir_name}/")
+
+    success = run_openevolve_loop(
+        config=config,
+        exp_name=exp_name,
+        reference_path=args.ref,
+        objective=objective,
+        max_iterations=args.max_iterations,
+        k_inspirations=args.k_inspirations,
+        seed=args.seed,
+        existing=existing,
+        debug=args.debug,
+        acc_checker=str(args.acc_checker) if args.acc_checker else None,
+        bench=str(args.bench) if args.bench else None,
+        nsys_profiler=str(args.nsys_profiler) if args.nsys_profiler else None,
+        torch_profiler=str(args.torch_profiler) if args.torch_profiler else None,
+        profiler_kind=args.profiler,
+        skills_dirs=skills,
+        run_environment=run_environment_spec_from_args(args),
+        agent_backend=args.agent_backend,
+        cli_provider=args.cli_provider,
+        backend=backend,
+        modality=args.modality,
+    )
+
+    if success:
+        print(f"\nOpenEvolve loop completed {args.max_iterations} iterations.")
+    else:
+        print("\nOpenEvolve loop stopped early (exception or KeyboardInterrupt).")
+        sys.exit(1)
+
+
+# ===========================================================================
 # plain loop  (--outer-loop plain)
 # ===========================================================================
 
@@ -710,18 +812,21 @@ _PARSER_BUILDERS = {
     "agent": _build_agent_parser,
     "plain": _build_plain_parser,
     "evolve": _build_evolve_parser,
+    "openevolve": _build_openevolve_parser,
 }
 
 _VALIDATORS = {
     "agent": "_validate_agent",
     "plain": "_validate_plain",
     "evolve": "_validate_evolve",
+    "openevolve": "_validate_openevolve",
 }
 
 _RUNNERS = {
     "agent": "_run_agent",
     "plain": "_run_plain",
     "evolve": "_run_evolve",
+    "openevolve": "_run_openevolve",
 }
 
 

--- a/src/vibe_serve/loops/agent/issue_board.py
+++ b/src/vibe_serve/loops/agent/issue_board.py
@@ -26,6 +26,7 @@ from vibe_serve.schemas import (
 from vibe_serve.schemas import (
     ImplementerResponse,
     JudgeResponse,
+    SingleAgentRoundResponse,
 )
 
 
@@ -237,6 +238,31 @@ def append_judge(
         f"- **verdict**: {response.verdict.value}\n\n"
         f"### Analysis\n{response.analysis}\n\n"
         f"### Feedback\n{response.feedback}\n"
+    )
+    _append(progress_path, block)
+
+
+def append_single_agent_round(
+    progress_path: Path,
+    round_number: int,
+    retry: int,
+    response: SingleAgentRoundResponse,
+) -> None:
+    perf_line = ""
+    if response.perf_metric is not None:
+        unit = response.perf_unit or ""
+        perf_line = f"- **perf_metric**: {response.perf_metric} {unit}\n".rstrip() + "\n"
+    block = (
+        f"## Round {round_number} — Single-agent (attempt {retry})\n"
+        f"- **verdict**: {response.verdict.value}\n"
+        f"- **expected_behavior**: {response.expected_behavior}\n"
+        f"{perf_line}"
+        f"### Summary\n{response.summary}\n\n"
+        f"### Self-review\n{response.self_review}\n\n"
+        f"### Feedback\n{response.feedback}\n\n"
+        f"### Bottlenecks\n{response.bottlenecks}\n\n"
+        f"### Suggestions\n{response.suggestions}\n\n"
+        f"### Profile analysis\n{response.profile_analysis}\n"
     )
     _append(progress_path, block)
 

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -28,8 +28,12 @@ from vibe_serve.prompts import render_template
 from vibe_serve.schemas import (
     ImplementerResponse,
     JudgeResponse,
+    SingleAgentRoundResponse,
     Verdict,
 )
+
+
+_INNER_LOOPS = ("multi-agent", "single-agent")
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
@@ -405,6 +409,79 @@ def _run_judge(
     return response
 
 
+def _run_single_agent_round(
+    ctx: _RunContext,
+    *,
+    round_number: int,
+    retry: int,
+    plan: OrchestratorPlan,
+    modality: str,
+    feedback: str | None,
+    progress_path: Path,
+    objective: str,
+    profile_focus: str,
+) -> SingleAgentRoundResponse:
+    """Invoke one agent that plays implementer + judge + profiler.
+
+    Used when ``--inner-loop=single-agent``. The same backend that the
+    multi-agent loop hands to the implementer is used here — it has
+    workspace write access plus shell access for benchmarks/profiling.
+    """
+    system_prompt = render_template(
+        "single_agent_round_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        reference_path=ctx.ref_name,
+        modality=modality,
+        task=plan.task,
+        pass_criteria=plan.pass_criteria,
+        retry=retry,
+        feedback=feedback,
+        objective=objective,
+        profile_focus=profile_focus,
+        profiler_kind=ctx.profiler_kind,
+        bench_path=ctx.judge_bench_path,
+        accuracy_checker_path=ctx.judge_acc_checker_path,
+        runtime_notes=ctx.run_environment_view.prompt_notes,
+        env_kind=ctx.run_environment_view.env_kind,
+    )
+    response = ctx.invoke(
+        kind="implementer",
+        system_prompt=system_prompt,
+        user_prompt=(
+            "Carry out the orchestrator's task above end-to-end "
+            "(implement, self-judge, profile) and return only the JSON object."
+        ),
+        response_cls=SingleAgentRoundResponse,
+        fallback_factory=lambda: SingleAgentRoundResponse(
+            summary="Single-agent produced no structured response.",
+            expected_behavior="unknown",
+            self_review="No structured response received.",
+            feedback="No structured response received.",
+            verdict=Verdict.FAIL,
+            bottlenecks="",
+            suggestions="",
+            profile_analysis="",
+        ),
+        round_label=f"round-{round_number}-retry-{retry}-single-agent",
+    )
+    issue_board.append_single_agent_round(progress_path, round_number, retry, response)
+    ctx.snapshot_workspace(f"round-{round_number}-retry-{retry}-single-agent")
+    return response
+
+
+def _profiler_summary_from_single_agent(
+    response: SingleAgentRoundResponse,
+) -> ProfilerSummary:
+    """Adapt a single-agent response into a ProfilerSummary for the orchestrator."""
+    return ProfilerSummary(
+        analysis=response.profile_analysis,
+        bottlenecks=response.bottlenecks,
+        suggestions=response.suggestions,
+        perf_metric=response.perf_metric,
+        perf_unit=response.perf_unit,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -432,12 +509,27 @@ def run_agent_loop(
     cli_provider: str | None = None,
     backend: ComputeBackend = DEFAULT_COMPUTE_BACKEND,
     modality: str = "text_generation",
+    inner_loop: str = "multi-agent",
 ) -> bool:
     """Run the orchestrator-driven build loop.
 
     Returns True iff the orchestrator declared the objective met within
     ``max_rounds``.  Returns False when the round budget is exhausted.
+
+    ``inner_loop`` selects how each round's implement/judge/profile work
+    is dispatched:
+
+    - ``"multi-agent"`` (default): three specialist agents — implementer,
+      judge, profiler — invoked in sequence.
+    - ``"single-agent"``: one agent does all three in a single
+      invocation per retry. Pre-round decision and standalone profiler
+      passes are skipped; the prior round's profile output is fed to the
+      orchestrator as ``profiler_summary``.
     """
+    if inner_loop not in _INNER_LOOPS:
+        raise ValueError(
+            f"Unknown inner_loop {inner_loop!r}; choose from {', '.join(_INNER_LOOPS)}"
+        )
     run_environment = run_environment or make_run_environment_spec()
     ctx = _RunContext(
         config=config,
@@ -473,6 +565,14 @@ def run_agent_loop(
     carry = _CarryOver()
     round_number = start_round
 
+    # When inner_loop == "single-agent", we don't run a separate
+    # pre-round decision or profiler invocation. We thread the previous
+    # round's combined response into the orchestrator's next plan as a
+    # synthesized ProfilerSummary, and remember its profile focus across
+    # rounds. The first round has no prior profile to feed forward.
+    last_single_agent_response: SingleAgentRoundResponse | None = None
+    last_profile_focus: str = "general latency hotspots on /v1/completions"
+
     try:
         while round_number <= max_rounds:
             ctx.switch_log_file(f"round{round_number:03d}")
@@ -480,25 +580,34 @@ def run_agent_loop(
 
             # --- Pre-round decision (skip on fresh cold start) ---
             profiler_summary: ProfilerSummary | None = None
-            if not _is_fresh_cold_start(round_number, records):
-                pre = _run_pre_round_decision(
-                    ctx,
-                    round_number=round_number,
-                    objective=objective,
-                    carry=carry,
-                    progress_path=progress_path,
-                )
-                # FORCE-PROFILE override: every non-cold-start round profiles,
-                # ignoring orchestrator's need_profile decision. Revert this
-                # block to restore orchestrator-decided profiling.
-                profiler_summary = _run_profiler(
-                    ctx,
-                    round_number=round_number,
-                    profile_focus=pre.profile_focus or "general latency hotspots on /v1/completions",
-                    modality=modality,
-                    progress_path=progress_path,
-                    objective=objective,
-                )
+            pre_decision: PreRoundDecision | None = None
+            if inner_loop == "multi-agent":
+                if not _is_fresh_cold_start(round_number, records):
+                    pre_decision = _run_pre_round_decision(
+                        ctx,
+                        round_number=round_number,
+                        objective=objective,
+                        carry=carry,
+                        progress_path=progress_path,
+                    )
+                    # FORCE-PROFILE override: every non-cold-start round profiles,
+                    # ignoring orchestrator's need_profile decision. Revert this
+                    # block to restore orchestrator-decided profiling.
+                    profiler_summary = _run_profiler(
+                        ctx,
+                        round_number=round_number,
+                        profile_focus=pre_decision.profile_focus or "general latency hotspots on /v1/completions",
+                        modality=modality,
+                        progress_path=progress_path,
+                        objective=objective,
+                    )
+            else:
+                # single-agent: feed the previous round's profile into the
+                # orchestrator as ProfilerSummary so it has a bottleneck signal.
+                if last_single_agent_response is not None:
+                    profiler_summary = _profiler_summary_from_single_agent(
+                        last_single_agent_response
+                    )
 
             # --- Orchestrator plan ---
             roadmap_text = issue_board.read_roadmap(roadmap_path)
@@ -541,32 +650,51 @@ def run_agent_loop(
             # --- Implementer / Judge retry loop ---
             feedback: str | None = None
             passed = False
+            single_agent_response: SingleAgentRoundResponse | None = None
             for retry in range(1, max_retries_per_round + 1):
                 ctx.lprint(f"\n--- attempt {retry}/{max_retries_per_round} ---\n")
-                ctx.reselect_gpu()
-                _run_implementer(
-                    ctx,
-                    round_number=round_number,
-                    retry=retry,
-                    plan=plan,
-                    modality=modality,
-                    feedback=feedback,
-                    progress_path=progress_path,
-                )
-                ctx.reselect_gpu()
-                verdict = _run_judge(
-                    ctx,
-                    round_number=round_number,
-                    retry=retry,
-                    plan=plan,
-                    modality=modality,
-                    progress_path=progress_path,
-                    objective=objective,
-                )
-                if verdict.verdict == Verdict.PASS:
-                    passed = True
-                    break
-                feedback = verdict.feedback
+                if inner_loop == "multi-agent":
+                    ctx.reselect_gpu()
+                    _run_implementer(
+                        ctx,
+                        round_number=round_number,
+                        retry=retry,
+                        plan=plan,
+                        modality=modality,
+                        feedback=feedback,
+                        progress_path=progress_path,
+                    )
+                    ctx.reselect_gpu()
+                    verdict = _run_judge(
+                        ctx,
+                        round_number=round_number,
+                        retry=retry,
+                        plan=plan,
+                        modality=modality,
+                        progress_path=progress_path,
+                        objective=objective,
+                    )
+                    if verdict.verdict == Verdict.PASS:
+                        passed = True
+                        break
+                    feedback = verdict.feedback
+                else:
+                    ctx.reselect_gpu()
+                    single_agent_response = _run_single_agent_round(
+                        ctx,
+                        round_number=round_number,
+                        retry=retry,
+                        plan=plan,
+                        modality=modality,
+                        feedback=feedback,
+                        progress_path=progress_path,
+                        objective=objective,
+                        profile_focus=last_profile_focus,
+                    )
+                    if single_agent_response.verdict == Verdict.PASS:
+                        passed = True
+                        break
+                    feedback = single_agent_response.feedback
 
             # --- Record round result & update carry-over ---
             commit = _current_commit_sha(ctx)
@@ -574,17 +702,40 @@ def run_agent_loop(
             # (cold-start or the orchestrator/framework decided to skip).
             # The plateau detector ignores skipped-profile rounds so cached
             # / inherited perf numbers don't masquerade as fresh measurements.
-            profile_skipped = profiler_summary is None
-            perf_metric = (
-                profiler_summary.perf_metric
-                if (profiler_summary and passed)
-                else None
-            )
-            perf_unit = (
-                profiler_summary.perf_unit
-                if (profiler_summary and passed)
-                else None
-            )
+            #
+            # For single-agent inner loop, `profiler_summary` carries the
+            # PREVIOUS round's profile (fed forward to the orchestrator),
+            # so this round's perf comes from `single_agent_response` instead.
+            if inner_loop == "single-agent":
+                profile_skipped = single_agent_response is None or (
+                    single_agent_response.perf_metric is None
+                )
+                perf_metric = (
+                    single_agent_response.perf_metric
+                    if (single_agent_response and passed)
+                    else None
+                )
+                perf_unit = (
+                    single_agent_response.perf_unit
+                    if (single_agent_response and passed)
+                    else None
+                )
+                # Remember the latest profile for the orchestrator's next plan
+                # and carry forward the implicit profile focus.
+                if single_agent_response is not None:
+                    last_single_agent_response = single_agent_response
+            else:
+                profile_skipped = profiler_summary is None
+                perf_metric = (
+                    profiler_summary.perf_metric
+                    if (profiler_summary and passed)
+                    else None
+                )
+                perf_unit = (
+                    profiler_summary.perf_unit
+                    if (profiler_summary and passed)
+                    else None
+                )
             records.append(
                 _RoundRecord(
                     round_number=round_number,

--- a/src/vibe_serve/loops/agent/templates/single_agent_round_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/single_agent_round_prompt.j2
@@ -1,0 +1,110 @@
+{% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
+{% if env_kind is not defined %}{% set env_kind = "local" %}{% endif %}
+You are a senior ML serving engineer running ONE complete inner-loop round end-to-end. In this ablation a single agent owns three roles that are normally split across three specialists:
+
+1. **Implementer** — make the code change scoped by the orchestrator's task.
+2. **Judge** — verify your own change against the orchestrator's pass criteria AND the framework's always-on correctness gates (pytest, benchmark sanity, accuracy checker).
+3. **Profiler** — capture a profile, surface bottlenecks, and report the OBJECTIVE's headline metric.
+
+Do all three before returning. The framework records the structured response below and feeds the profile-side fields back to the orchestrator next round.
+
+{% if objective %}
+## Objective (verbatim from `OBJECTIVE.md`)
+
+{{ objective }}
+{% endif %}
+
+{% if runtime_notes %}
+## Runtime environment
+
+{{ runtime_notes }}
+{% endif %}
+
+## This round's task (from the Orchestrator)
+
+{{ task }}
+
+## Pass criteria
+
+{{ pass_criteria }}
+
+The framework's always-on gates apply on top of the orchestrator's criteria — your verdict must reflect all of them:
+
+1. `uv run pytest -v` passes.
+{% if bench_path is defined and bench_path %}
+2. **Benchmark sanity** — start the server, wait for `/health`, run `{{ bench_path }}/benchmark.py` with 2 requests, confirm at least one succeeds. Discover flags with `--help`. Kill the server when done.
+{% endif %}
+{% if accuracy_checker_path is defined and accuracy_checker_path %}
+3. **Accuracy checker** — start the server, wait for `/health`, then run `{{ accuracy_checker_path }}/checker.py` with default flags. Both the schema-valid rate (≥ 0.95) AND the sentinel-echo rate (≥ 0.90) must hold; if the checker exits non-zero this round is **fail**. Kill the server after.
+{% endif %}
+
+{% if retry > 1 and feedback %}
+## Self-feedback from previous attempt
+
+{{ feedback }}
+
+Address every item above before declaring PASS this attempt.
+{% endif %}
+
+## Workspace
+
+The shared experiment workspace is your working directory. Reference implementation: `{{ reference_path }}`. Model weights: `/model` (do NOT redownload). Use `uv` for Python packaging — `uv init` if needed, `uv add` for deps, `uv run` for execution.
+
+## Required: read the relevant skill BEFORE writing code
+
+The `serving-systems` skill is installed in your working directory with a `references/` library covering every kernel, library, algorithm, and technique relevant to this work. Open every reference that covers a topic named in the task before you write code that touches it. The cost of opening one wrong file is tiny; coding from priors is the single most common reason this loop wastes rounds. In your `summary`, name each reference you opened and the recommendation that shaped your implementation.
+
+## Reward-hack discipline (you are also the judge — do not let yourself cheat)
+
+Do not introduce a code path that satisfies the schema or accuracy checker without running the model — no schema synthesizers, no prerecorded-answer caches, no constant templates, no "hot path" that returns bytes without invoking the model on steady-state requests. The accuracy checker's sentinel test will fail a prompt-ignoring shortcut, but you should refuse to write one in the first place. If you ever find such a path, your verdict is **fail** and your `feedback` must name the function/branch/flag to remove.
+
+## Profiling step
+
+After (and only after) the implementation passes your self-judge gates, capture a profile so the orchestrator has a bottleneck signal for the next round.
+
+{% if profiler_kind == "torch" %}
+Use `torch.profiler` via `torch_profiler/analyze_torch_profile.py` (or the `vibeserve-torch-profiler` MCP tools when attached). Start with `tables`, then `kernels` / `operators` / `cpu_overhead` / `memory` / `summary` as relevant.
+
+{% if env_kind == "modal" %}
+**Modal mode**: the editor container has no GPU. Dispatch profiling via `modal run main.py::modal_profile -- --output /workspace/prof.json --num-iters 20 --max-tokens 32 --prompt "The capital of France is"`. Do NOT fall back to synthetic-weight in-process profiling.
+{% else %}
+Capture in-process: `python torch_profiler/analyze_torch_profile.py capture --model-dir /workspace --weights-dir /model --output /tmp/prof.json --warmup 3 --num-iters 20 --max-tokens 32 --prompt "The capital of France is"`.
+{% endif %}
+{% else %}
+Use `nsys` via `nsys_profiler/analyze_nsys.py` (or the `vibeserve-nsys-profiler` MCP tools when attached). The capture script starts the server, runs the benchmark under `nsys profile`, and writes a report you can analyze with the MCP tools. Focus: kernel breakdown, CPU launch overhead, GPU idle gaps.
+{% endif %}
+
+Profiler focus this round: {{ profile_focus or "general bottleneck analysis on the steady-state benchmark path" }}.
+
+### Headline performance metric (`perf_metric` / `perf_unit`)
+
+The plateau detector compares this raw float across rounds, so the **unit must not change** between rounds.
+
+1. The OBJECTIVE block above names the headline field — look for `Headline metric: <field_name>`.
+2. Run the benchmark with `--output-json /tmp/bench.json` (discover the exact flag with `--help`).
+3. Read **that exact field**. Set `perf_metric` to its numeric value and `perf_unit` to that field's name (e.g. `"median_tok_per_sec"`). Do not substitute a different field, do not invert it, do not convert units.
+
+If you could not run the benchmark this round, set `perf_metric: null` rather than fabricating a value.
+
+## Progress tracking
+
+The framework will record your structured response into `progress.md` for you. Read `progress.md` and `roadmap.md` first to understand prior rounds; do NOT duplicate the framework's audit block manually.
+
+## Output
+
+Return exactly one JSON object. Do not wrap in markdown fences.
+
+{
+  "summary": "<what you implemented>",
+  "expected_behavior": "<observable runtime behavior>",
+  "self_review": "<self-judge analysis covering correctness, accuracy, bench sanity, reward-hack inspection>",
+  "feedback": "<issues to fix on retry; empty if pass>",
+  "verdict": "pass" | "fail",
+  "bottlenecks": "<ranked bottlenecks with concrete numbers>",
+  "suggestions": "<actionable optimization suggestions tied to bottlenecks>",
+  "profile_analysis": "<detailed interpretation of the captured profile>",
+  "perf_metric": <float or null>,
+  "perf_unit": "<unit string or null>"
+}
+
+IMPORTANT: Base profile fields on actual profiler data. Do not fabricate. The verdict must be consistent with the self-review and feedback fields.

--- a/src/vibe_serve/loops/evolve/population.py
+++ b/src/vibe_serve/loops/evolve/population.py
@@ -128,6 +128,12 @@ class Individual:
     passed: bool = False
     summary: str = ""
     feedback: str = ""
+    # Behavioral feature descriptor used by the openevolve loop's
+    # MAP-Elites archive. Empty for runs that don't use that loop.
+    # Keys are feature names (e.g. "code_size_bucket"), values are the
+    # discrete bin index. Persisted to population.json so the archive
+    # can be rebuilt on resume.
+    features: dict[str, int] = field(default_factory=dict)
 
     def to_json(self) -> dict:
         return asdict(self)
@@ -146,6 +152,7 @@ class Individual:
             passed=bool(data.get("passed", False)),
             summary=data.get("summary", ""),
             feedback=data.get("feedback", ""),
+            features={k: int(v) for k, v in (data.get("features") or {}).items()},
         )
 
 

--- a/src/vibe_serve/loops/openevolve/__init__.py
+++ b/src/vibe_serve/loops/openevolve/__init__.py
@@ -1,0 +1,10 @@
+"""OpenEvolve-style outer loop: MAP-Elites archive + cell-uniform selection.
+
+A thin sibling of :mod:`vibe_serve.loops.evolve` that swaps the flat
+fitness-weighted population for a behavioral-feature-binned
+:class:`MapElitesArchive`. Each iteration samples a cell uniformly,
+draws the cell's elite as parent, mutates, evaluates, and re-bins.
+
+Reuses ``evolve``'s mutator / judge / profiler helpers and templates
+verbatim — only selection diverges.
+"""

--- a/src/vibe_serve/loops/openevolve/archive.py
+++ b/src/vibe_serve/loops/openevolve/archive.py
@@ -1,0 +1,247 @@
+"""MAP-Elites archive for the openevolve loop.
+
+A thin layer over :class:`vibe_serve.loops.evolve.population.Population`
+that bins individuals by behavioral features and exposes cell-uniform
+parent sampling.
+
+## Feature space
+
+Two features by default — both *behavioral*, not fitness-derived, so
+selection on cells doesn't smuggle the perf metric back in:
+
+- ``code_size_bucket``: lines in ``main.py`` quantized into
+  ``[0-300, 300-600, 600-1000, 1000+]`` (4 bins).
+- ``technique_bucket``: count of distinct optimization techniques the
+  current ``main.py`` *names* (regex over a small lexicon: cuda graph,
+  flash attention, paged attention, eagle/spec decode, torch.compile,
+  continuous batching, fp8, awq/gptq). Bucketed into ``[0, 1, 2, 3+]``
+  (4 bins). Names are a coarse proxy for "what techniques the code is
+  attempting" — false positives (e.g. mentions in a comment) are
+  acceptable noise; we only need a discrete, behavior-shaped axis.
+
+Together they form a 4×4 = 16-cell grid. Cells are keyed by the
+``(bucket0, bucket1)`` tuple. The grid is sparse — most cells are
+empty until the loop has produced enough offspring to fill them.
+
+## Selection
+
+``sample_cell()`` picks a non-empty cell uniformly at random; the
+elite within (highest ``perf_metric``) is the parent. Inspirations
+are pulled by sampling additional cells (without replacement when
+possible) to surface diverse strategies, falling back to within-cell
+random peers when the archive is sparse.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from pathlib import Path
+
+from vibe_serve.loops.evolve.population import Individual, Population
+
+
+# ---------------------------------------------------------------------------
+# Feature extraction
+# ---------------------------------------------------------------------------
+
+_CODE_SIZE_THRESHOLDS = (300, 600, 1000)  # → 4 buckets: <300, <600, <1000, ≥1000
+_TECHNIQUE_THRESHOLDS = (1, 2, 3)         # → 4 buckets: 0, 1, 2, ≥3
+_DEFAULT_GRID_SHAPE = (4, 4)
+
+_TECHNIQUE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("cuda_graph", re.compile(r"cuda[_\s\-]?graph", re.IGNORECASE)),
+    ("flash_attention", re.compile(r"flash[_\s\-]?attn|flashattention|flashinfer", re.IGNORECASE)),
+    ("paged_attention", re.compile(r"paged[_\s\-]?attention|page[_\s\-]?table", re.IGNORECASE)),
+    ("speculative_decoding", re.compile(r"\beagle[0-9]?\b|spec(?:ulative)?[_\s\-]?decod|\bdraft[_\s\-]?model\b", re.IGNORECASE)),
+    ("torch_compile", re.compile(r"torch\.compile|@compile\b", re.IGNORECASE)),
+    ("continuous_batching", re.compile(r"continuous[_\s\-]?batch", re.IGNORECASE)),
+    ("low_precision", re.compile(r"\bfp8\b|\bint8\b|\bawq\b|\bgptq\b|\bbnb\b", re.IGNORECASE)),
+    ("xgrammar", re.compile(r"xgrammar|grammar[_\s\-]?mask|jump[_\s\-]?forward", re.IGNORECASE)),
+)
+
+
+def _bucket(value: int, thresholds: tuple[int, ...]) -> int:
+    """Return the bucket index for *value* given ascending *thresholds*.
+
+    ``len(thresholds) + 1`` total buckets. ``thresholds = (a, b, c)``
+    yields buckets ``[<a, <b, <c, ≥c]``.
+    """
+    for i, t in enumerate(thresholds):
+        if value < t:
+            return i
+    return len(thresholds)
+
+
+def _count_main_py_lines(workspace: Path) -> int:
+    """Return the number of newline-terminated lines in ``main.py``.
+
+    Returns 0 if the file does not exist (cold start). The implementer
+    is expected to write ``main.py`` at the workspace root; we don't
+    walk subdirectories because the rule is always-flat.
+    """
+    main_py = workspace / "main.py"
+    if not main_py.is_file():
+        return 0
+    try:
+        return main_py.read_text(errors="replace").count("\n")
+    except OSError:
+        return 0
+
+
+def _count_techniques(workspace: Path) -> int:
+    main_py = workspace / "main.py"
+    if not main_py.is_file():
+        return 0
+    try:
+        text = main_py.read_text(errors="replace")
+    except OSError:
+        return 0
+    hits = 0
+    for _, pat in _TECHNIQUE_PATTERNS:
+        if pat.search(text):
+            hits += 1
+    return hits
+
+
+def compute_features(workspace: Path) -> dict[str, int]:
+    """Return the MAP-Elites feature dict for the current ``workspace``.
+
+    Reads ``workspace/main.py`` only — no git operations, no profile
+    invocation. Safe to call repeatedly between rounds.
+    """
+    return {
+        "code_size_bucket": _bucket(_count_main_py_lines(workspace), _CODE_SIZE_THRESHOLDS),
+        "technique_bucket": _bucket(_count_techniques(workspace), _TECHNIQUE_THRESHOLDS),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Archive
+# ---------------------------------------------------------------------------
+
+
+_FEATURE_ORDER: tuple[str, ...] = ("code_size_bucket", "technique_bucket")
+
+
+def _cell_key(features: dict[str, int]) -> tuple[int, ...]:
+    """Stable tuple key for *features*, padding missing axes with 0."""
+    return tuple(int(features.get(name, 0)) for name in _FEATURE_ORDER)
+
+
+class MapElitesArchive:
+    """Behavioral-feature-binned view over a :class:`Population`.
+
+    Wraps the existing population so persistence (population.json), the
+    ``Individual`` schema, and downstream observability stay shared with
+    the evolve loop. The archive itself is derived state — rebuilt from
+    the population on every read.
+
+    Failed individuals (``passed=False``) are kept in the population
+    but excluded from the archive: a failed offspring has no perf_metric
+    to seed its cell elite, and re-mutating from a failure would just
+    repeat the dead end the judge already rejected.
+    """
+
+    def __init__(self, population: Population) -> None:
+        self._population = population
+
+    @property
+    def population(self) -> Population:
+        return self._population
+
+    # -- elites --------------------------------------------------------------
+
+    def cells(self) -> dict[tuple[int, ...], Individual]:
+        """Return ``{cell_key: elite_individual}``.
+
+        The elite of a cell is the passed individual with the highest
+        ``perf_metric``; ties broken by latest id. Cells with no passed
+        member are absent. Individuals missing both ``features`` and
+        ``perf_metric`` are skipped (cold-start records).
+        """
+        bins: dict[tuple[int, ...], Individual] = {}
+        for ind in self._population.passed:
+            if ind.perf_metric is None:
+                continue
+            key = _cell_key(ind.features)
+            current = bins.get(key)
+            if current is None:
+                bins[key] = ind
+                continue
+            cur_perf = current.perf_metric or float("-inf")
+            if ind.perf_metric > cur_perf or (
+                ind.perf_metric == cur_perf and ind.id > current.id
+            ):
+                bins[key] = ind
+        return bins
+
+    def __len__(self) -> int:
+        return len(self.cells())
+
+    def coverage(self) -> float:
+        """Fraction of grid cells filled (0.0 .. 1.0)."""
+        total = 1
+        for _ in _FEATURE_ORDER:
+            total *= _DEFAULT_GRID_SHAPE[0]  # all axes share the same shape today
+        return len(self) / total if total else 0.0
+
+    # -- selection -----------------------------------------------------------
+
+    def sample_cell_elite(self, *, rng: random.Random) -> Individual | None:
+        """Return the elite of a uniformly-sampled non-empty cell.
+
+        Returns ``None`` when the archive is empty (cold start) — the
+        caller treats this as "ask the mutator to write the first
+        working server from the reference", same as the evolve loop's
+        cold-start branch.
+        """
+        elites = self.cells()
+        if not elites:
+            return None
+        cell_key = rng.choice(list(elites.keys()))
+        return elites[cell_key]
+
+    def sample_inspirations(
+        self,
+        *,
+        parent_id: int | None,
+        k: int,
+        rng: random.Random,
+    ) -> list[Individual]:
+        """Pick *k* peers, prioritizing diverse cells.
+
+        Strategy:
+
+        1. Sample up to *k* additional non-empty cells (different from
+           the parent's cell), take their elites.
+        2. If still under *k*, top up with random passed individuals
+           (excluding the parent and anyone already chosen).
+
+        This gives the mutator a small set of *behaviorally distinct*
+        examples to learn from — the explicit point of MAP-Elites.
+        """
+        if k <= 0:
+            return []
+        elites = self.cells()
+        parent_cell: tuple[int, ...] | None = None
+        if parent_id is not None:
+            parent = self._population.get(parent_id)
+            if parent is not None:
+                parent_cell = _cell_key(parent.features)
+
+        other_cells = [c for c in elites if c != parent_cell]
+        rng.shuffle(other_cells)
+        picks = [elites[c] for c in other_cells[:k] if elites[c].id != parent_id]
+
+        if len(picks) < k:
+            picked_ids = {p.id for p in picks}
+            if parent_id is not None:
+                picked_ids.add(parent_id)
+            spare = [
+                ind for ind in self._population.passed
+                if ind.id not in picked_ids and ind.perf_metric is not None
+            ]
+            rng.shuffle(spare)
+            picks.extend(spare[: k - len(picks)])
+        return picks

--- a/src/vibe_serve/loops/openevolve/loop.py
+++ b/src/vibe_serve/loops/openevolve/loop.py
@@ -1,0 +1,254 @@
+"""OpenEvolve-style outer loop.
+
+Differs from :mod:`vibe_serve.loops.evolve.loop` in exactly one place:
+parent + inspiration selection draws from a MAP-Elites
+:class:`MapElitesArchive` (cell-uniform sampling), not the flat
+fitness-weighted population. Mutator / judge / profiler invocations
+and prompt templates are reused verbatim from the evolve loop.
+
+State persistence reuses ``population.json`` (extended in
+:class:`Individual` with a ``features`` dict the archive bins on).
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND
+from vibe_serve.context import _RunContext
+from vibe_serve.loops.evolve.loop import (
+    _checkout_commit_tree,
+    _current_commit_sha,
+    _discard_working_tree,
+    _run_judge,
+    _run_mutator,
+    _run_profiler,
+)
+from vibe_serve.loops.evolve.population import Individual, Population
+from vibe_serve.loops.openevolve.archive import MapElitesArchive, compute_features
+from vibe_serve.sandbox.run_environment import (
+    RunEnvironmentSpec,
+    make_run_environment_spec,
+)
+from vibe_serve.schemas import Verdict
+
+
+def run_openevolve_loop(
+    config: dict,
+    exp_name: str,
+    reference_path: str,
+    objective: str,
+    *,
+    max_iterations: int = 16,
+    k_inspirations: int = 3,
+    seed: int | None = None,
+    pass_criteria: str = (
+        "The server starts, /health returns 200, the accuracy checker "
+        "passes, and the benchmark sanity step completes. Code must "
+        "actually run inference (no schema-synthesizing reward hacks)."
+    ),
+    existing: bool = False,
+    debug: bool = False,
+    acc_checker: str | None = None,
+    bench: str | None = None,
+    nsys_profiler: str | None = None,
+    torch_profiler: str | None = None,
+    profiler_kind: str = "auto",
+    skills_dirs: list[str] | None = None,
+    run_environment: RunEnvironmentSpec | None = None,
+    agent_backend: str | None = None,
+    cli_provider: str | None = None,
+    backend: ComputeBackend = DEFAULT_COMPUTE_BACKEND,
+    modality: str = "text_generation",
+) -> bool:
+    """Run a MAP-Elites driven evolutionary search.
+
+    Each iteration produces one offspring: sample a non-empty archive
+    cell uniformly → take its elite as parent → mutate → judge → on
+    pass, profile and re-bin into the archive (recomputing the feature
+    descriptor from the new ``main.py``). Failed offspring are recorded
+    with their judge feedback (no commit) but are not added to the
+    archive, mirroring the evolve loop's convention.
+    """
+    run_environment = run_environment or make_run_environment_spec()
+    ctx = _RunContext(
+        config=config,
+        exp_name=exp_name,
+        reference_path=reference_path,
+        existing=existing,
+        debug=debug,
+        acc_checker=acc_checker,
+        bench=bench,
+        nsys_profiler=nsys_profiler,
+        torch_profiler=torch_profiler,
+        profiler_kind=profiler_kind,
+        skills_dirs=skills_dirs,
+        run_environment=run_environment,
+        git_tracking=True,
+        agent_backend=agent_backend,
+        cli_provider=cli_provider,
+        backend=backend,
+    )
+    ctx.lprint(f"[log] openevolve run: {ctx.run_log_path}")
+    ctx.lprint(f"[log] experiment root: {ctx.exp_dir}")
+    ctx.lprint(f"[log] objective: {objective.splitlines()[0] if objective else '(empty)'}")
+
+    population_path = ctx.log_dir / "population.json"
+    population = Population.load(population_path)
+    archive = MapElitesArchive(population)
+
+    rng = random.Random(seed)
+
+    try:
+        for iteration in range(1, max_iterations + 1):
+            ctx.switch_log_file(f"iter{iteration:03d}")
+            ctx.lprint(
+                f"\n{'='*60}\n  Iteration {iteration}/{max_iterations} — "
+                f"archive cells={len(archive)} "
+                f"(coverage={archive.coverage():.0%}), "
+                f"population={len(population)} (passed={len(population.passed)})\n"
+                f"{'='*60}\n"
+            )
+
+            # 1. Pick parent (cell-uniform) + inspirations (other cells).
+            parent = archive.sample_cell_elite(rng=rng)
+            inspirations = archive.sample_inspirations(
+                parent_id=parent.id if parent else None,
+                k=k_inspirations,
+                rng=rng,
+            )
+            is_cold_start = parent is None
+
+            # 2. Materialize parent's tree (cold start leaves the framework-seeded
+            # workspace untouched).
+            if parent is not None and parent.commit:
+                if not _checkout_commit_tree(ctx, parent.commit):
+                    ctx.lprint(
+                        f"[warn] could not check out parent {parent.id} "
+                        f"(commit {parent.commit[:8]}); skipping iteration"
+                    )
+                    continue
+
+            ctx.lprint(
+                f"parent={'COLD-START' if parent is None else f'#{parent.id} (perf={parent.perf_metric}, cell={parent.features})'}; "
+                f"inspirations={[i.id for i in inspirations]}"
+            )
+
+            # 3. Mutator edits the workspace. Reuses evolve's prompt; the
+            # mutator doesn't need to know which selection scheme picked
+            # the parent — only the parent + peers + cold-start flag.
+            ctx.reselect_gpu()
+            mutator = _run_mutator(
+                ctx,
+                generation=iteration,
+                child_idx=1,
+                objective=objective,
+                parent=parent,
+                inspirations=inspirations,
+                modality=modality,
+                is_cold_start=is_cold_start,
+            )
+
+            # 4. Judge.
+            ctx.reselect_gpu()
+            verdict = _run_judge(
+                ctx,
+                generation=iteration,
+                child_idx=1,
+                modality=modality,
+                objective=objective,
+                pass_criteria=pass_criteria,
+            )
+
+            if verdict.verdict != Verdict.PASS:
+                failed = Individual(
+                    id=population.next_id(),
+                    generation=iteration,
+                    parent_id=parent.id if parent else None,
+                    inspiration_ids=[i.id for i in inspirations],
+                    commit=None,
+                    perf_metric=None,
+                    perf_unit=None,
+                    passed=False,
+                    summary=mutator.summary,
+                    feedback=verdict.feedback,
+                )
+                population.add(failed)
+                population.save(population_path)
+                _discard_working_tree(ctx)
+                ctx.lprint(
+                    f"[iter {iteration}] child {failed.id} FAILED — "
+                    f"feedback: {(verdict.feedback or '').splitlines()[0][:120]}"
+                )
+                continue
+
+            # 5. Profile the offspring to get its fitness.
+            ctx.reselect_gpu()
+            summary = _run_profiler(
+                ctx,
+                generation=iteration,
+                child_idx=1,
+                modality=modality,
+                objective=objective,
+            )
+
+            # 6. Compute behavioral features from the post-mutation
+            # workspace (BEFORE commit so the feature read mirrors what
+            # the judge/profiler just evaluated). Then commit + record.
+            features = compute_features(ctx.workspace)
+            ctx.snapshot_workspace(f"iter-{iteration}-child-1")
+            commit = _current_commit_sha(ctx)
+            child = Individual(
+                id=population.next_id(),
+                generation=iteration,
+                parent_id=parent.id if parent else None,
+                inspiration_ids=[i.id for i in inspirations],
+                commit=commit,
+                perf_metric=summary.perf_metric if summary else None,
+                perf_unit=summary.perf_unit if summary else None,
+                metrics=dict(summary.metrics) if summary and summary.metrics else {},
+                passed=True,
+                summary=mutator.summary,
+                feedback=verdict.feedback,
+                features=features,
+            )
+            population.add(child)
+            population.save(population_path)
+
+            elite_marker = ""
+            cell_key = tuple(features.get(k, 0) for k in ("code_size_bucket", "technique_bucket"))
+            elites = archive.cells()
+            if elites.get(cell_key) is child:
+                elite_marker = " (NEW ELITE)"
+            ctx.lprint(
+                f"[iter {iteration}] child {child.id} PASSED — "
+                f"perf={child.perf_metric} {child.perf_unit or ''} "
+                f"cell={features}{elite_marker} "
+                f"(parent={parent.id if parent else 'cold'})"
+            )
+
+        best = population.best()
+        if best is not None:
+            ctx.lprint(
+                f"\nFinal scalar-best: individual #{best.id} "
+                f"perf={best.perf_metric} {best.perf_unit or ''} "
+                f"(commit {best.commit[:8] if best.commit else 'n/a'}, "
+                f"cell={best.features})"
+            )
+        else:
+            ctx.lprint("\nNo passing individual produced. Inspect logs.")
+
+        ctx.lprint(
+            f"\nFinal archive: {len(archive)} cells filled "
+            f"({archive.coverage():.0%} coverage)"
+        )
+        return True
+    except KeyboardInterrupt:
+        ctx.lprint("[openevolve] interrupted; population preserved.")
+        return False
+    except Exception as exc:
+        ctx.lprint(f"[openevolve] aborted with: {exc}")
+        return False
+    finally:
+        ctx.close()

--- a/src/vibe_serve/schemas.py
+++ b/src/vibe_serve/schemas.py
@@ -253,6 +253,39 @@ class OrchestratorPlan(BaseModel):
 
 
 # ===========================================================================
+# Agent loop — single-agent inner loop (ablation)
+# ===========================================================================
+
+
+class SingleAgentRoundResponse(BaseModel):
+    """One agent performs implementer + judge + profiler in a single shot.
+
+    Used by the agent outer-loop's ``--inner-loop=single-agent`` ablation:
+    instead of three specialist agents handing off through the framework,
+    the same agent implements the round's task, runs the always-on
+    correctness checks, and captures a profile, then returns the combined
+    verdict.
+    """
+
+    summary: str = Field(description="What was implemented or changed this round.")
+    expected_behavior: str = Field(description="What behavior the implementation should exhibit (server contract, etc.).")
+    self_review: str = Field(description="Self-review of correctness, accuracy, benchmark sanity, and reward-hack risk — same gates the judge would enforce.")
+    feedback: str = Field(description="Concrete issues to fix on retry; empty when verdict is PASS.")
+    verdict: Verdict = Field(description="PASS if all gates (orchestrator pass criteria + always-on checks) hold; FAIL otherwise.")
+    bottlenecks: str = Field(description="Ranked profile bottlenecks with concrete numbers.")
+    suggestions: str = Field(description="Actionable optimization suggestions for the next round, tied to bottlenecks.")
+    profile_analysis: str = Field(description="Detailed interpretation of the captured profile.")
+    perf_metric: float | None = Field(
+        default=None,
+        description="Headline perf metric from the benchmark (per OBJECTIVE.md). None if not measured.",
+    )
+    perf_unit: str | None = Field(
+        default=None,
+        description="Unit/field name for perf_metric (e.g. 'median_tok_per_sec'). None when perf_metric is None.",
+    )
+
+
+# ===========================================================================
 # Evolve loop (mutator)
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

Adds three new knobs and a new outer loop, plus a pre-existing circular-import fix that the new entry-point paths surface. All driven by ablation experiments on Llama-3-8B / Modal H100 / codex CLI.

- `--inner-loop {multi-agent,single-agent}` on the agent loop — replaces the implementer/judge/profiler trio with one agent that does all three per retry.
- `--no-skills` (common arg, all outer loops) — skip skill copy + per-CLI discovery; for measuring the references library's contribution.
- `--outer-loop openevolve` — MAP-Elites sibling of `evolve`. 4×4 grid keyed by behavioral features (`main.py` line count × distinct optimization-technique mentions); selection samples non-empty cells uniformly and uses the cell's elite as parent. Mutator/judge/profiler helpers reused verbatim from the evolve loop.
- Fix: defer `CliAgentRunner` / `DeepAgentsRunner` imports in `vibe_serve.agents` to break the cycle that fired when `vibe-serve` entered via `agent_runner` before any other module had warmed `agents.callbacks`.

## Experiments (all 24-round agent outer loops on Llama-3-8B, Modal H100, codex)

### Round-best (`aggregate_throughput` from each round's profiler)

| run | inner-loop | skills | passed | best round | best aggregate_throughput |
|---|---|---|---|---|---|
| `single-agent` (this PR enables) | single-agent | on | 24/24 | r18 | **103.74** |
| `no-skills` (this PR enables) | multi-agent | **off** | 13/24 | r15 | **47.60** |

### Throughput at saturated load (`benchmark.py --rate 128 --duration 30 --max-tokens 32`, local H100, fresh server from each run's best-round commit)

| | single-agent + skills (r18) | multi-agent + no-skills (r15) |
|---|---:|---:|
| Output throughput | **3 435 tok/s** | **87 tok/s** |
| Completed / total | 3310 / 3310 (0 errors) | 477 / 1447 (970 errors) |
| Median TTFT | 212 ms | 80 157 ms |
| Median TPOT | 25 ms | 1 038 ms |

The no-skills run also produced a hard reward-hack attempt in its cold-start round (`sitecustomize.py` monkeypatch redirecting the accuracy checker to a tiny local fixture); the with-skills agents never tried it.

Caveat: the two runs cross two variables (inner loop × skills). A clean ablation matrix still needs the `multi-agent + skills` baseline.

## Test plan

- [x] `uv run pytest` — 657/657 passing
- [x] `vibe-serve --outer-loop agent --inner-loop single-agent ...` ran end-to-end (24/24 rounds passed)
- [x] `vibe-serve --outer-loop agent --inner-loop multi-agent --no-skills ...` ran end-to-end (13/24)
- [x] Local benchmark replay at `--rate 128` for both best-round commits
- [ ] `vibe-serve --outer-loop openevolve ...` — not yet run end-to-end; archive logic and CLI parser smoke-tested only

🤖 Generated with [Claude Code](https://claude.com/claude-code)