### PR TITLE
Add objective files for missing example targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ examples/<name>/
 └── README.md             # human-readable description
 ```
 
-`OBJECTIVE.md` is read at the start of every run and must live next to `--ref` (sibling, not inside). See `examples/Llama-3-8B/`, `examples/moonshine-streaming/`, `examples/qwen3-32b-code-edit/`, `examples/olmo-hybrid-prefix-caching/`, `examples/Llama-3.1-8B-Instruct-MLX-8bit/`, and `examples/show-o2-1.5B-HQ/` for the six paper scenarios.
+`OBJECTIVE.md` is read at the start of every run and must live next to `--ref` (sibling, not inside). See `examples/Llama-3-8B/`, `examples/moonshine-streaming/`, `examples/qwen3-32b-code-edit/`, `examples/olmo-hybrid-prefix-caching/`, `examples/Llama-3.1-8B-Instruct-MLX-8bit/`, `examples/show-o2-1.5B-HQ-h100/`, and `examples/show-o2-1.5B-HQ-macbook/` for the paper scenarios.
 
 For multi-objective evolutionary runs, drop an `objectives.toml` next to `OBJECTIVE.md` (or pass `--objective name:max|min` flags) — see `vibe-serve --outer-loop evolve --help`.
 

--- a/examples/Llama-3.1-8B-Instruct-MLX-8bit/OBJECTIVE.md
+++ b/examples/Llama-3.1-8B-Instruct-MLX-8bit/OBJECTIVE.md
@@ -1,0 +1,58 @@
+# Objective - Llama-3.1-8B-Instruct MLX 8-bit JSON-schema server
+
+Minimize **end-to-end JSON generation latency** on local Apple Silicon while
+keeping the JSONSchemaBench accuracy checker within tolerance. Build an
+OpenAI-compatible `/v1/completions` server for
+`mlx-community/Meta-Llama-3.1-8B-Instruct-8bit`.
+
+## Workload
+
+The benchmark sends streaming completion requests whose prompts contain a JSON
+Schema from `epfl-dlab/JSONSchemaBench` and whose request body includes:
+
+- `prompt`: plain text instructions plus the schema.
+- `max_tokens`: normally 256.
+- `temperature`: 0.
+- `stream`: true.
+- `response_format`: `{"type": "json_schema", "json_schema": {"schema": ...}}`.
+
+The default benchmark dataset is the `full` subset, `val` split, pinned to
+revision `5bd0f4640badc6f3f02df796421d21cb0ca0b141`. Optimize for this
+schema-constrained generation workload, not for general chatbot serving.
+
+## Headline metric
+
+Use `latency_ms.p50` from `benchmark/benchmark.py`'s JSON output as the primary
+performance metric. Lower is better. `token_throughput`, `ttft_ms`, and
+`tpot_ms` are useful diagnostics, but the objective is closed-loop
+end-to-end latency for valid JSON responses.
+
+## Server contract
+
+- `/health` returns 200 when the server is ready.
+- `/v1/completions` accepts the fields above and streams Server-Sent Events with
+  OpenAI-style completion chunks whose `choices[0].text` field contains
+  non-empty deltas.
+- The response text must parse as JSON and validate against the supplied schema.
+- For schemas that can hold strings, the checker injects a sentinel token into
+  the prompt and requires the generated JSON to include it. Do not hard-code
+  schema-only templates or ignore prompt content.
+- `/v1/chat/completions` may be implemented for compatibility, but the checker
+  and benchmark target `/v1/completions`.
+
+## Optimization guidance
+
+- Use MLX-native model execution for the 8-bit Llama 3.1 target; CUDA-specific
+  optimizations do not apply on this target.
+- JSON-schema constraints are the main algorithmic opportunity. Build or reuse a
+  grammar / automaton that can force deterministic punctuation, object keys, and
+  other schema-implied runs without calling the model for every output token.
+- Speculative decoding is optional but relevant. The paper setup used
+  `mlx-community/Llama-3.2-1B-Instruct-4bit` as a separate draft model against
+  this 8-bit target; keep draft-model setup configurable rather than baked into
+  the request contract.
+- Tune MLX prefill and decode settings for the prompt lengths in
+  JSONSchemaBench. The prompts are often around the low-thousands of tokens, so
+  overly small prefill chunks can dominate latency.
+- Keep output validation honest: optimizations must preserve schema validity,
+  sentinel inclusion, and streaming semantics.

--- a/examples/show-o2-1.5B-HQ-h100/OBJECTIVE.md
+++ b/examples/show-o2-1.5B-HQ-h100/OBJECTIVE.md
@@ -1,0 +1,66 @@
+# Objective - Show-o2 1.5B HQ image generation server on H100
+
+Minimize **p50 text-to-image request latency** on a single NVIDIA H100 for
+`showlab/show-o2-1.5B-HQ` while preserving the image-generation server
+contract. Build an OpenAI-like `/v1/images/generations` HTTP server that
+returns prompt-conditioned PNG images.
+
+## Workload
+
+The benchmark posts image-generation requests with:
+
+- `prompt`: either a fixed prompt or one prompt from the benchmark prompt pool.
+- `num_inference_steps`: default 20, often fixed to a smaller value for smoke
+  and comparison runs.
+- `guidance_scale`: default 5.0.
+- optional `seed` for deterministic requests.
+- optional `include_timings` to return per-request timing diagnostics.
+- optional `postprocess_mode` in `upstream`, `cpu`, or `native`.
+- optional `response_format` in `b64_json`, `png`, or `ppm`.
+
+Warmup requests run before the timed measurement and are excluded from the
+headline result. For performance comparisons, keep prompt, seed, step count,
+guidance scale, output resolution, response format, and postprocess mode fixed
+across variants.
+
+## Headline metric
+
+Use `latency.p50` from `benchmark/benchmark.py`'s measured-result JSON as the
+primary performance metric. Lower is better. `request_throughput`,
+`server_timings`, and per-phase timing fields are secondary diagnostics.
+
+## Server contract
+
+- `/health` returns 200 when the server is ready.
+- `/v1/images/generations` accepts the request fields above.
+- The default response is OpenAI-style JSON with `data[0].b64_json` containing
+  PNG bytes. If `response_format` is `png` or `ppm`, raw image bytes are
+  allowed as implemented by the benchmark.
+- When `include_timings` is true, return phase timings as `timings_ms` for JSON
+  responses or `X-ShowO2-Timings-Ms` for raw-image responses.
+- The accuracy checker is an HTTP smoke test that verifies a valid PNG. Do not
+  exploit that by returning canned images; benchmark runs can save image hashes,
+  dimensions, and images for drift inspection.
+
+## H100 implementation notes
+
+- Show-o2 is a native unified multimodal model, not a conventional diffusion
+  pipeline bolted onto a separate text encoder. The target uses a Qwen2.5-style
+  Transformer body, a text head, a flow-matching image head, and a Wan VAE for
+  image decode.
+- The reference config uses hidden size 1536, 10 diffusion layers, 27 x 27 image
+  latents with 16 channels, and the `showlab/show-o2-1.5B-HQ` checkpoint pinned
+  in `reference/meta.json`.
+- Optimize the fixed text-to-image path first: body forward, diffusion-head
+  steps, VAE decode, image postprocessing, and response encoding.
+- Use CUDA-specific optimizations for the H100 target. Useful directions from
+  the paper setup include CUDA graph replay and prewarm, reducing inactive
+  diffusion-token work, restricting adaptive layer-norm work to active image
+  spans, trimming unused Qwen tail work, and improving VAE/postprocess layout.
+- Validate precision and kernel substitutions carefully. FlashAttention-2, GQA,
+  `torch.compile`, and naive fp16 changes may alter outputs or produce NaNs on
+  this workload; keep them only when the PNG contract and image quality remain
+  acceptable.
+- Precision, operation order, and postprocess changes may alter exact PNG bytes.
+  Treat small image drift as acceptable only when request settings and output
+  resolution stay fixed and the output remains a real prompt-conditioned image.

--- a/examples/show-o2-1.5B-HQ-h100/README.md
+++ b/examples/show-o2-1.5B-HQ-h100/README.md
@@ -1,0 +1,27 @@
+Show-o2 1.5B HQ input bundle.
+
+Use:
+- `--ref inputs/show-o2-1.5B-HQ/reference`
+- `--acc-checker inputs/show-o2-1.5B-HQ/accuracy_checker`
+- `--bench inputs/show-o2-1.5B-HQ/benchmark`
+
+This bundle targets `showlab/show-o2-1.5B-HQ`, a Show-o2 text-to-image
+checkpoint. The reference folder uses a pinned git submodule for the official
+Show-o inference source and keeps model weights out of git. On first real use,
+the loader downloads:
+
+- `showlab/show-o2-1.5B-HQ` into the repo HF cache and links it as
+  `reference/model`
+- `Wan-AI/Wan2.1-T2V-14B/Wan2.1_VAE.pth` through `huggingface_hub`
+- the Qwen2.5 tokenizer/config and SigLIP weights used by the official model
+
+For a local HTTP smoke test that does not download weights:
+
+```bash
+uv run python playground/show_o2_local/serve.py --mock --port 8000
+uv run python inputs/show-o2-1.5B-HQ/benchmark/benchmark.py \
+  --url http://localhost:8000 --warmup-requests 1 --num-requests 1 --steps 1
+```
+
+For a real run, create an environment from `requirements.txt` and start
+`playground/show_o2_local/serve.py` without `--mock`.

--- a/examples/show-o2-1.5B-HQ-h100/accuracy_checker/README.md
+++ b/examples/show-o2-1.5B-HQ-h100/accuracy_checker/README.md
@@ -1,0 +1,11 @@
+Accuracy checker inputs for Show-o2 1.5B HQ.
+
+Run:
+
+```bash
+python checker.py --url http://localhost:8000 --steps 1
+```
+
+This checker performs an HTTP image-generation smoke test and verifies that the
+server returns PNG bytes. It is intentionally output-agnostic because diffusion
+sampling is not token-exact.

--- a/examples/show-o2-1.5B-HQ-h100/accuracy_checker/checker.py
+++ b/examples/show-o2-1.5B-HQ-h100/accuracy_checker/checker.py
@@ -1,0 +1,43 @@
+"""HTTP smoke checker for a Show-o2 image generation server."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+
+import httpx
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check a Show-o2 HTTP server returns a PNG image.")
+    parser.add_argument("--url", default="http://localhost:8000", help="Server base URL")
+    parser.add_argument("--endpoint", default="/v1/images/generations", help="Endpoint path")
+    parser.add_argument("--prompt", default="a readable sign that says VibeServe", help="Prompt")
+    parser.add_argument("--steps", type=int, default=4, help="Diffusion inference steps")
+    parser.add_argument("--guidance-scale", type=float, default=5.0, help="Guidance scale")
+    parser.add_argument("--timeout", type=float, default=600.0, help="Request timeout")
+    args = parser.parse_args()
+
+    url = args.url.rstrip("/") + args.endpoint
+    body = {
+        "prompt": args.prompt,
+        "num_inference_steps": args.steps,
+        "guidance_scale": args.guidance_scale,
+    }
+    try:
+        response = httpx.post(url, json=body, timeout=args.timeout)
+        response.raise_for_status()
+        payload = response.json()
+        image_bytes = base64.b64decode(payload["data"][0]["b64_json"])
+        if not image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+            raise ValueError("response image is not a PNG")
+    except Exception as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    print(f"PASS: received {len(image_bytes)} PNG bytes from {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/show-o2-1.5B-HQ-h100/benchmark/README.md
+++ b/examples/show-o2-1.5B-HQ-h100/benchmark/README.md
@@ -1,0 +1,56 @@
+Benchmark inputs for Show-o2 1.5B HQ.
+
+Run:
+
+```bash
+python benchmark.py \
+  --url http://localhost:8000 \
+  --warmup-requests 1 \
+  --closed-loop \
+  --collect-server-timings \
+  --save-images-dir /tmp/show_o2_images \
+  --postprocess-mode native \
+  --prompt "a small red robot holding a handwritten sign that says VibeServe" \
+  --request-seed 1234 \
+  --fixed-request-seed \
+  --num-requests 5 \
+  --steps 4
+```
+
+The benchmark posts to `/v1/images/generations` and checks that each completed
+request returns a base64 PNG payload. Warmup requests run before timed
+measurement and are reported separately in JSON output. `--closed-loop`
+measures one request at a time without queueing overlap, while
+`--collect-server-timings` asks the server to return phase timings under
+`server_timings`. `--postprocess-mode` can override the server image
+postprocess path per request for comparison runs; supported modes are
+`upstream`, `cpu`, and `native`. JSON output includes PNG SHA-256 hashes so
+comparison runs can spot pixel-level drift across variants, plus PNG dimensions
+so same-resolution comparisons can be checked explicitly. Pass
+`--save-images-dir` to write completed warmup and measured PNG responses to
+disk; measured image paths are included under `image_paths` in JSON output.
+
+Use `compare_images.py` to quantify output drift between saved PNGs:
+
+```bash
+python compare_images.py \
+  --baseline /tmp/show_o2_images_base/request_0000.png \
+  --candidate /tmp/show_o2_images_opt/request_0000.png \
+  --output-json /tmp/show_o2_compare.json
+```
+
+The comparison reports exact hash match, MAE, RMSE, PSNR, changed-pixel
+fraction, and local luminance SSIM. Optional CLIP scoring is available with
+`--clip-model` when the requested CLIP model is already available locally, or
+with `--allow-clip-download` when downloads are acceptable.
+
+When the server is started with `--vae-profile`, `--collect-server-timings`
+also aggregates synchronized VAE decode sub-stage timings under
+`vae_profile_*` keys. Use these for bottleneck diagnosis only; the extra
+synchronization adds measurement overhead.
+
+For performance optimization runs, keep the output shape fixed across variants:
+use the same server resolution, prompt, request seed, inference step count,
+guidance scale, and device profile. Precision/order changes may change final
+pixel bytes; treat that as acceptable drift when the resolution and request
+settings stay fixed.

--- a/examples/show-o2-1.5B-HQ-h100/benchmark/benchmark.py
+++ b/examples/show-o2-1.5B-HQ-h100/benchmark/benchmark.py
@@ -1,0 +1,484 @@
+"""HTTP benchmark for a Show-o2 image generation server.
+
+The server contract is intentionally simple and OpenAI-like:
+
+    POST /v1/images/generations
+    {"prompt": "...", "num_inference_steps": 20, "guidance_scale": 5.0}
+
+The response must include `data[0].b64_json` containing PNG bytes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import json
+import math
+import random
+import struct
+import time
+from pathlib import Path
+from statistics import mean
+
+import httpx
+
+
+PROMPT_POOL = [
+    "a small red robot holding a handwritten sign that says VibeServe",
+    "a studio product photo of a ceramic mug shaped like a rocket",
+    "a watercolor landscape with a lighthouse at sunrise",
+    "a close-up macro photo of a translucent blue mechanical keyboard switch",
+    "a clean app icon for an AI inference server, white background",
+]
+
+
+def select_prompt(args: argparse.Namespace, rng: random.Random, idx: int, *, warmup: bool = False) -> str:
+    if args.prompt is not None:
+        return args.prompt
+    if warmup:
+        return PROMPT_POOL[idx % len(PROMPT_POOL)]
+    return rng.choice(PROMPT_POOL)
+
+
+def request_seed_for(args: argparse.Namespace, idx: int) -> int | None:
+    if args.request_seed is None:
+        return None
+    if args.fixed_request_seed:
+        return args.request_seed
+    return args.request_seed + idx
+
+
+def image_dimensions(image_bytes: bytes) -> tuple[int, int]:
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n") and image_bytes[12:16] == b"IHDR":
+        width, height = struct.unpack(">II", image_bytes[16:24])
+        return int(width), int(height)
+    if image_bytes.startswith(b"P6"):
+        header_parts = image_bytes.split(None, 4)
+        if len(header_parts) >= 4 and header_parts[0] == b"P6" and header_parts[3] == b"255":
+            return int(header_parts[1]), int(header_parts[2])
+    raise ValueError("response image is not a PNG or PPM")
+
+
+async def send_request(
+    client: httpx.AsyncClient,
+    url: str,
+    prompt: str,
+    steps: int,
+    guidance_scale: float,
+    seed: int | None,
+    timeout: float,
+    collect_server_timings: bool,
+    postprocess_mode: str | None,
+    response_format: str,
+    image_save_path: Path | None = None,
+) -> dict:
+    body = {
+        "prompt": prompt,
+        "num_inference_steps": steps,
+        "guidance_scale": guidance_scale,
+    }
+    if seed is not None:
+        body["seed"] = seed
+    if collect_server_timings:
+        body["include_timings"] = True
+    if postprocess_mode is not None:
+        body["postprocess_mode"] = postprocess_mode
+    if response_format != "b64_json":
+        body["response_format"] = response_format
+
+    started = time.perf_counter()
+    try:
+        resp = await client.post(url, json=body, timeout=timeout)
+        resp.raise_for_status()
+        if response_format in {"png", "ppm"}:
+            image_bytes = resp.content
+            timings_header = resp.headers.get("X-ShowO2-Timings-Ms", "{}")
+            server_timings = json.loads(timings_header) if collect_server_timings else {}
+        else:
+            payload = resp.json()
+            b64 = payload["data"][0]["b64_json"]
+            image_bytes = base64.b64decode(b64)
+            server_timings = payload.get("timings_ms", {}) if collect_server_timings else {}
+        width, height = image_dimensions(image_bytes)
+        if image_save_path is not None:
+            image_save_path.parent.mkdir(parents=True, exist_ok=True)
+            image_save_path.write_bytes(image_bytes)
+        return {
+            "error": None,
+            "latency": time.perf_counter() - started,
+            "image_bytes": len(image_bytes),
+            "image_width": width,
+            "image_height": height,
+            "image_sha256": hashlib.sha256(image_bytes).hexdigest(),
+            "image_path": str(image_save_path) if image_save_path is not None else None,
+            "server_timings": server_timings,
+        }
+    except Exception as exc:
+        return {
+            "error": str(exc),
+            "latency": time.perf_counter() - started,
+            "image_bytes": 0,
+            "image_width": 0,
+            "image_height": 0,
+            "image_sha256": None,
+            "image_path": None,
+            "server_timings": {},
+        }
+
+
+def image_save_path(args: argparse.Namespace, phase: str, idx: int) -> Path | None:
+    if args.save_images_dir is None:
+        return None
+    suffix = "ppm" if args.response_format == "ppm" else "png"
+    return Path(args.save_images_dir) / f"{phase}_{idx:04d}.{suffix}"
+
+
+def percentile(sorted_vals: list[float], p: float) -> float:
+    if not sorted_vals:
+        return float("nan")
+    k = (len(sorted_vals) - 1) * p / 100.0
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return sorted_vals[int(k)]
+    return sorted_vals[f] * (c - k) + sorted_vals[c] * (k - f)
+
+
+def stats(values: list[float], multiplier: float = 1.0) -> dict | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    return {
+        "mean": mean(ordered) * multiplier,
+        "p50": percentile(ordered, 50) * multiplier,
+        "p90": percentile(ordered, 90) * multiplier,
+        "p95": percentile(ordered, 95) * multiplier,
+        "p99": percentile(ordered, 99) * multiplier,
+    }
+
+
+def server_timing_stats(results: list[dict]) -> dict[str, dict]:
+    successes = [r for r in results if r["error"] is None]
+    timing_keys = sorted(
+        {
+            key
+            for result in successes
+            for key, value in result.get("server_timings", {}).items()
+            if isinstance(value, (int, float))
+        }
+    )
+    return {
+        key: stats(
+            [
+                float(result["server_timings"][key])
+                for result in successes
+                if isinstance(result.get("server_timings", {}).get(key), (int, float))
+            ]
+        )
+        for key in timing_keys
+    }
+
+
+def summarize_results(results: list[dict], wall_clock: float) -> dict:
+    successes = [r for r in results if r["error"] is None]
+    errors = [r for r in results if r["error"] is not None]
+    latencies = [r["latency"] for r in successes]
+    image_sizes = [r["image_bytes"] for r in successes]
+    image_widths = [r["image_width"] for r in successes]
+    image_heights = [r["image_height"] for r in successes]
+    image_hashes = [r["image_sha256"] for r in successes if r.get("image_sha256")]
+    image_paths = [r["image_path"] for r in successes if r.get("image_path")]
+    return {
+        "num_requests": len(results),
+        "num_completed": len(successes),
+        "num_failed": len(errors),
+        "actual_duration": wall_clock,
+        "request_throughput": len(successes) / wall_clock if wall_clock > 0 else 0,
+        "latency": stats(latencies, multiplier=1000.0),
+        "image_bytes": stats(image_sizes),
+        "image_width": stats(image_widths),
+        "image_height": stats(image_heights),
+        "image_sha256": image_hashes,
+        "unique_image_sha256": sorted(set(image_hashes)),
+        "image_paths": image_paths,
+        "server_timings": server_timing_stats(results),
+    }
+
+
+async def run_warmup(client: httpx.AsyncClient, args: argparse.Namespace, url: str) -> tuple[list[dict], float]:
+    if args.warmup_requests <= 0:
+        return [], 0.0
+
+    results = []
+    warmup_start = time.perf_counter()
+    for idx in range(args.warmup_requests):
+        prompt = select_prompt(args, random.Random(args.seed), idx, warmup=True)
+        request_seed = request_seed_for(args, idx)
+        results.append(
+            await send_request(
+                client,
+                url,
+                prompt,
+                args.steps,
+                args.guidance_scale,
+                request_seed,
+                args.timeout,
+                args.collect_server_timings,
+                args.postprocess_mode,
+                args.response_format,
+                image_save_path(args, "warmup", idx),
+            )
+        )
+    return results, time.perf_counter() - warmup_start
+
+
+async def run_closed_loop(
+    client: httpx.AsyncClient,
+    args: argparse.Namespace,
+    url: str,
+    rng: random.Random,
+    total_requests: int,
+    use_duration: bool,
+    bench_start: float,
+) -> list[dict]:
+    results = []
+    sent = 0
+    while sent < total_requests:
+        if use_duration and (time.perf_counter() - bench_start) >= args.duration:
+            break
+        prompt = select_prompt(args, rng, sent)
+        request_seed = request_seed_for(args, sent)
+        results.append(
+            await send_request(
+                client,
+                url,
+                prompt,
+                args.steps,
+                args.guidance_scale,
+                request_seed,
+                args.timeout,
+                args.collect_server_timings,
+                args.postprocess_mode,
+                args.response_format,
+                image_save_path(args, "request", sent),
+            )
+        )
+        sent += 1
+    return results
+
+
+async def run_open_loop(
+    client: httpx.AsyncClient,
+    args: argparse.Namespace,
+    url: str,
+    rng: random.Random,
+    total_requests: int,
+    use_duration: bool,
+    bench_start: float,
+) -> list[dict]:
+    tasks: list[asyncio.Task] = []
+    sent = 0
+    while sent < total_requests:
+        if use_duration and (time.perf_counter() - bench_start) >= args.duration:
+            break
+        prompt = select_prompt(args, rng, sent)
+        request_seed = request_seed_for(args, sent)
+        tasks.append(
+            asyncio.create_task(
+                send_request(
+                    client,
+                    url,
+                    prompt,
+                    args.steps,
+                    args.guidance_scale,
+                    request_seed,
+                    args.timeout,
+                    args.collect_server_timings,
+                    args.postprocess_mode,
+                    args.response_format,
+                    image_save_path(args, "request", sent),
+                )
+            )
+        )
+        sent += 1
+        if sent < total_requests:
+            delay = -math.log(1.0 - rng.random()) / args.rate
+            if use_duration:
+                remaining = args.duration - (time.perf_counter() - bench_start)
+                if remaining <= 0:
+                    break
+                delay = min(delay, remaining)
+            await asyncio.sleep(delay)
+    return await asyncio.gather(*tasks)
+
+
+async def run_benchmark(args: argparse.Namespace) -> dict:
+    rng = random.Random(args.seed)
+    url = args.url.rstrip("/") + args.endpoint
+    total_requests = args.num_requests if args.num_requests is not None else 10**9
+    use_duration = args.num_requests is None
+
+    async with httpx.AsyncClient() as client:
+        warmup_results, warmup_duration = await run_warmup(client, args, url)
+        bench_start = time.perf_counter()
+        if args.closed_loop:
+            results = await run_closed_loop(
+                client,
+                args,
+                url,
+                rng,
+                total_requests,
+                use_duration,
+                bench_start,
+            )
+        else:
+            results = await run_open_loop(
+                client,
+                args,
+                url,
+                rng,
+                total_requests,
+                use_duration,
+                bench_start,
+            )
+        bench_end = time.perf_counter()
+
+    wall_clock = bench_end - bench_start
+    successes = [r for r in results if r["error"] is None]
+    errors = [r for r in results if r["error"] is not None]
+    latencies = [r["latency"] for r in successes]
+    image_sizes = [r["image_bytes"] for r in successes]
+    measured_summary = summarize_results(results, wall_clock)
+
+    print()
+    print("=" * 40)
+    print("  Show-o2 Benchmark Results")
+    print("=" * 40)
+    print(f"Endpoint:          {url}")
+    print(f"Mode:              {'closed-loop' if args.closed_loop else 'open-loop'}")
+    if warmup_results:
+        warmup_summary = summarize_results(warmup_results, warmup_duration)
+        print(
+            "Warmup:           "
+            f"{warmup_summary['num_completed']}/{warmup_summary['num_requests']} requests "
+            f"({warmup_summary['num_failed']} errors, {warmup_duration:.2f}s)"
+        )
+    print(f"Duration:          {wall_clock:.2f}s")
+    print(f"Completed:         {len(successes)}/{len(results)} requests ({len(errors)} errors)")
+    print(f"Request throughput:{len(successes) / wall_clock if wall_clock > 0 else 0:.2f} req/s")
+    if latencies:
+        latency_ms = stats(latencies, multiplier=1000.0)
+        print(f"Latency mean:      {latency_ms['mean']:.1f} ms")
+        print(f"Latency p90:       {latency_ms['p90']:.1f} ms")
+    if measured_summary["server_timings"]:
+        total_timing = measured_summary["server_timings"].get("total_ms")
+        if total_timing:
+            print(f"Server total mean: {total_timing['mean']:.1f} ms")
+    if errors:
+        print("Errors:")
+        for idx, err in enumerate(errors[:5]):
+            print(f"  [{idx}] {err['error'][:160]}")
+
+    result = {
+        "config": {
+            "url": url,
+            "rate": args.rate,
+            "duration": args.duration,
+            "steps": args.steps,
+            "guidance_scale": args.guidance_scale,
+            "prompt": args.prompt,
+            "seed": args.seed,
+            "request_seed": args.request_seed,
+            "fixed_request_seed": args.fixed_request_seed,
+            "warmup_requests": args.warmup_requests,
+            "closed_loop": args.closed_loop,
+            "collect_server_timings": args.collect_server_timings,
+            "postprocess_mode": args.postprocess_mode,
+            "response_format": args.response_format,
+            "save_images_dir": args.save_images_dir,
+        },
+        "warmup": summarize_results(warmup_results, warmup_duration),
+        "num_requests": len(results),
+        "num_completed": len(successes),
+        "num_failed": len(errors),
+        "actual_duration": wall_clock,
+        "request_throughput": len(successes) / wall_clock if wall_clock > 0 else 0,
+        "latency": stats(latencies, multiplier=1000.0),
+        "image_bytes": stats(image_sizes),
+        "image_width": measured_summary["image_width"],
+        "image_height": measured_summary["image_height"],
+        "image_sha256": measured_summary["image_sha256"],
+        "unique_image_sha256": measured_summary["unique_image_sha256"],
+        "image_paths": measured_summary["image_paths"],
+        "server_timings": measured_summary["server_timings"],
+    }
+
+    if args.output_json:
+        with open(args.output_json, "w") as f:
+            json.dump(result, f, indent=2)
+        print(f"Results written to {args.output_json}")
+
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark a Show-o2 HTTP image server.")
+    parser.add_argument("--url", default="http://localhost:8000", help="Server base URL")
+    parser.add_argument("--endpoint", default="/v1/images/generations", help="Endpoint path")
+    parser.add_argument("--rate", type=float, default=1.0, help="Request rate in req/s")
+    parser.add_argument("--duration", type=float, default=60.0, help="Duration when num requests is unset")
+    parser.add_argument("--num-requests", type=int, default=None, help="Total requests")
+    parser.add_argument(
+        "--closed-loop",
+        action="store_true",
+        help="Send each measured request after the previous one finishes instead of open-loop rate scheduling",
+    )
+    parser.add_argument(
+        "--collect-server-timings",
+        action="store_true",
+        help="Ask the server to include per-request timings_ms and aggregate them",
+    )
+    parser.add_argument(
+        "--postprocess-mode",
+        choices=["upstream", "cpu", "native"],
+        default=None,
+        help="Optional server postprocess mode override for image requests",
+    )
+    parser.add_argument(
+        "--response-format",
+        default="b64_json",
+        choices=["b64_json", "png", "ppm"],
+        help="Response format to request from the server.",
+    )
+    parser.add_argument(
+        "--warmup-requests",
+        type=int,
+        default=0,
+        help="Requests to run before measurement and exclude from latency/throughput stats",
+    )
+    parser.add_argument("--steps", type=int, default=20, help="Diffusion inference steps per request")
+    parser.add_argument("--guidance-scale", type=float, default=5.0, help="Classifier-free guidance scale")
+    parser.add_argument("--prompt", type=str, default=None, help="Fixed prompt for every benchmark request")
+    parser.add_argument("--seed", type=int, default=42, help="Benchmark scheduling seed")
+    parser.add_argument("--request-seed", type=int, default=None, help="Base model seed for deterministic requests")
+    parser.add_argument(
+        "--fixed-request-seed",
+        action="store_true",
+        help="Use request seed unchanged for every request instead of incrementing it by request index",
+    )
+    parser.add_argument("--timeout", type=float, default=600.0, help="Per-request timeout in seconds")
+    parser.add_argument("--output-json", type=str, default=None, help="Write structured result JSON")
+    parser.add_argument(
+        "--save-images-dir",
+        type=str,
+        default=None,
+        help="Save completed warmup and measured response PNGs into this directory",
+    )
+    args = parser.parse_args()
+    asyncio.run(run_benchmark(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/show-o2-1.5B-HQ-h100/benchmark/compare_images.py
+++ b/examples/show-o2-1.5B-HQ-h100/benchmark/compare_images.py
@@ -1,0 +1,192 @@
+"""Compare two generated PNGs for pixel and perceptual drift."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_rgb(path: Path) -> np.ndarray:
+    return np.asarray(Image.open(path).convert("RGB"), dtype=np.float64)
+
+
+def box_filter(image: np.ndarray, size: int) -> np.ndarray:
+    pad_before = size // 2
+    pad_after = size - 1 - pad_before
+    padded = np.pad(image, ((pad_before, pad_after), (pad_before, pad_after)), mode="reflect")
+    integral = np.pad(padded, ((1, 0), (1, 0)), mode="constant").cumsum(axis=0).cumsum(axis=1)
+    return (
+        integral[size:, size:]
+        - integral[:-size, size:]
+        - integral[size:, :-size]
+        + integral[:-size, :-size]
+    ) / float(size * size)
+
+
+def rgb_to_luma(image: np.ndarray) -> np.ndarray:
+    return image[..., 0] * 0.299 + image[..., 1] * 0.587 + image[..., 2] * 0.114
+
+
+def local_ssim(a: np.ndarray, b: np.ndarray, window_size: int = 11) -> float | None:
+    if a.shape != b.shape:
+        return None
+    if min(a.shape[:2]) < window_size:
+        window_size = max(1, min(a.shape[:2]))
+        if window_size % 2 == 0:
+            window_size -= 1
+    if window_size <= 1:
+        return 1.0 if np.array_equal(a, b) else None
+
+    x = rgb_to_luma(a)
+    y = rgb_to_luma(b)
+    c1 = (0.01 * 255.0) ** 2
+    c2 = (0.03 * 255.0) ** 2
+
+    mu_x = box_filter(x, window_size)
+    mu_y = box_filter(y, window_size)
+    mu_x2 = mu_x * mu_x
+    mu_y2 = mu_y * mu_y
+    mu_xy = mu_x * mu_y
+
+    sigma_x2 = box_filter(x * x, window_size) - mu_x2
+    sigma_y2 = box_filter(y * y, window_size) - mu_y2
+    sigma_xy = box_filter(x * y, window_size) - mu_xy
+
+    numerator = (2.0 * mu_xy + c1) * (2.0 * sigma_xy + c2)
+    denominator = (mu_x2 + mu_y2 + c1) * (sigma_x2 + sigma_y2 + c2)
+    return float(np.mean(numerator / denominator))
+
+
+def pixel_metrics(a: np.ndarray, b: np.ndarray) -> dict[str, Any]:
+    if a.shape != b.shape:
+        return {
+            "same_dimensions": False,
+            "baseline_shape": list(a.shape),
+            "candidate_shape": list(b.shape),
+        }
+
+    diff = a - b
+    abs_diff = np.abs(diff)
+    mse = float(np.mean(diff * diff))
+    rmse = math.sqrt(mse)
+    psnr = None if mse == 0.0 else 20.0 * math.log10(255.0 / rmse)
+    changed_channels = abs_diff > 0.0
+    changed_pixels = np.any(changed_channels, axis=2)
+    return {
+        "same_dimensions": True,
+        "width": int(a.shape[1]),
+        "height": int(a.shape[0]),
+        "mae": float(np.mean(abs_diff)),
+        "normalized_mae": float(np.mean(abs_diff) / 255.0),
+        "rmse": rmse,
+        "normalized_rmse": rmse / 255.0,
+        "max_abs_diff": float(np.max(abs_diff)),
+        "changed_channel_fraction": float(np.mean(changed_channels)),
+        "changed_pixel_fraction": float(np.mean(changed_pixels)),
+        "psnr_db": psnr,
+        "psnr_is_infinite": mse == 0.0,
+        "ssim_luma": local_ssim(a, b),
+    }
+
+
+def clip_metrics(
+    baseline: Path,
+    candidate: Path,
+    prompt: str | None,
+    model_name: str,
+    allow_download: bool,
+) -> dict[str, Any]:
+    try:
+        import torch
+        from transformers import CLIPModel, CLIPProcessor
+    except Exception as exc:  # pragma: no cover - depends on optional deps
+        return {"enabled": False, "error": f"CLIP dependencies unavailable: {exc}"}
+
+    try:
+        processor = CLIPProcessor.from_pretrained(model_name, local_files_only=not allow_download)
+        model = CLIPModel.from_pretrained(model_name, local_files_only=not allow_download)
+    except Exception as exc:  # pragma: no cover - depends on local model cache
+        return {"enabled": False, "error": f"CLIP model unavailable: {exc}"}
+
+    images = [Image.open(baseline).convert("RGB"), Image.open(candidate).convert("RGB")]
+    with torch.inference_mode():
+        image_inputs = processor(images=images, return_tensors="pt")
+        image_features = model.get_image_features(**image_inputs)
+        image_features = image_features / image_features.norm(dim=-1, keepdim=True)
+        image_cosine = float((image_features[0] * image_features[1]).sum().item())
+
+        result: dict[str, Any] = {
+            "enabled": True,
+            "model": model_name,
+            "image_cosine": image_cosine,
+        }
+        if prompt:
+            text_inputs = processor(text=[prompt], return_tensors="pt", padding=True)
+            text_features = model.get_text_features(**text_inputs)
+            text_features = text_features / text_features.norm(dim=-1, keepdim=True)
+            result["baseline_prompt_cosine"] = float((image_features[0] * text_features[0]).sum().item())
+            result["candidate_prompt_cosine"] = float((image_features[1] * text_features[0]).sum().item())
+    return result
+
+
+def compare(args: argparse.Namespace) -> dict[str, Any]:
+    baseline = Path(args.baseline)
+    candidate = Path(args.candidate)
+    baseline_array = load_rgb(baseline)
+    candidate_array = load_rgb(candidate)
+    result = {
+        "baseline": str(baseline),
+        "candidate": str(candidate),
+        "baseline_sha256": sha256_file(baseline),
+        "candidate_sha256": sha256_file(candidate),
+        "exact_match": baseline.read_bytes() == candidate.read_bytes(),
+        "pixel": pixel_metrics(baseline_array, candidate_array),
+    }
+    if args.clip_model:
+        result["clip"] = clip_metrics(
+            baseline,
+            candidate,
+            args.prompt,
+            args.clip_model,
+            args.allow_clip_download,
+        )
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare two generated PNG images.")
+    parser.add_argument("--baseline", required=True, help="Baseline PNG path")
+    parser.add_argument("--candidate", required=True, help="Candidate PNG path")
+    parser.add_argument("--prompt", default=None, help="Optional prompt for CLIP prompt-image scoring")
+    parser.add_argument(
+        "--clip-model",
+        default=None,
+        help="Optional local Hugging Face CLIP model id/path, for example openai/clip-vit-base-patch32",
+    )
+    parser.add_argument(
+        "--allow-clip-download",
+        action="store_true",
+        help="Allow downloading the requested CLIP model if it is not already cached locally",
+    )
+    parser.add_argument("--output-json", default=None, help="Write structured comparison JSON")
+    args = parser.parse_args()
+
+    result = compare(args)
+    print(json.dumps(result, indent=2))
+    if args.output_json:
+        Path(args.output_json).write_text(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/show-o2-1.5B-HQ-h100/config.json
+++ b/examples/show-o2-1.5B-HQ-h100/config.json
@@ -1,0 +1,14 @@
+{
+  "model_id": "showlab/show-o2-1.5B-HQ",
+  "revision": "d3a220ec55feaacbdfcb053847edee14edd4e69a",
+  "task": "text-to-image",
+  "reference": "reference",
+  "benchmark": "benchmark",
+  "accuracy_checker": "accuracy_checker",
+  "served_endpoints": [
+    "/health",
+    "/v1/images/generations",
+    "/v1/completions"
+  ],
+  "default_endpoint": "/v1/images/generations"
+}

--- a/examples/show-o2-1.5B-HQ-h100/reference/README.md
+++ b/examples/show-o2-1.5B-HQ-h100/reference/README.md
@@ -1,0 +1,13 @@
+Reference bundle for Show-o2 1.5B HQ.
+
+Required files:
+- `reference.py` — local loader and generation wrapper
+- `config.json` — Show-o2 model config copied from the HF checkpoint
+- `meta.json` — pinned model and Wan VAE metadata
+- `Show-o/` — git submodule for the official Show-o repository, pinned to
+  commit `45a5a2de01d1ebd10cd5864d29310a76476cdf23`; the wrapper imports from
+  its `show-o2/` subdirectory
+
+The wrapper exposes `ShowO2Model.from_pretrained(...)`, `generate_text(...)`,
+and `generate_image(...)`. It lazily downloads weights if `reference/model`
+does not exist.

--- a/examples/show-o2-1.5B-HQ-h100/reference/config.json
+++ b/examples/show-o2-1.5B-HQ-h100/reference/config.json
@@ -1,0 +1,19 @@
+{
+  "_class_name": "Showo2Qwen2_5",
+  "_diffusers_version": "0.31.0",
+  "add_qk_norm": true,
+  "add_time_embeds": true,
+  "clip_latent_dim": 1152,
+  "clip_pretrained_model_path": "google/siglip-so400m-patch14-384",
+  "hidden_size": 1536,
+  "image_latent_dim": 16,
+  "image_latent_height": 27,
+  "image_latent_width": 27,
+  "llm_model_path": "Qwen/Qwen2.5-1.5B-Instruct",
+  "llm_vocab_size": 151669,
+  "load_from_showo": true,
+  "num_diffusion_layers": 10,
+  "patch_size": 2,
+  "video_latent_height": 27,
+  "video_latent_width": 27
+}

--- a/examples/show-o2-1.5B-HQ-h100/reference/meta.json
+++ b/examples/show-o2-1.5B-HQ-h100/reference/meta.json
@@ -1,0 +1,16 @@
+{
+  "model_id": "showlab/show-o2-1.5B-HQ",
+  "revision": "d3a220ec55feaacbdfcb053847edee14edd4e69a",
+  "model_file": "pytorch_model.bin",
+  "official_source": {
+    "repo": "https://github.com/showlab/Show-o",
+    "subdir": "show-o2",
+    "revision": "45a5a2de01d1ebd10cd5864d29310a76476cdf23"
+  },
+  "wan_vae": {
+    "model_id": "Wan-AI/Wan2.1-T2V-14B",
+    "revision": "a064a6c71f5be440641209c07bf2a5ce7a2ff5e4",
+    "filename": "Wan2.1_VAE.pth",
+    "sha256": "38071ab59bd94681c686fa51d75a1968f64e470262043be31f7a094e442fd981"
+  }
+}

--- a/examples/show-o2-1.5B-HQ-h100/reference/reference.py
+++ b/examples/show-o2-1.5B-HQ-h100/reference/reference.py
@@ -1,0 +1,1027 @@
+"""Reference loader and inference wrapper for showlab/show-o2-1.5B-HQ.
+
+The official Show-o2 repository is not packaged on PyPI, so this reference
+bundle imports it from the pinned `Show-o` git submodule. Model weights stay
+outside git and are resolved from Hugging Face using `meta.json`.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+REFERENCE_DIR = Path(__file__).resolve().parent
+DEFAULT_SOURCE_DIR = REFERENCE_DIR / "Show-o" / "show-o2"
+DEFAULT_MODEL_DIR = REFERENCE_DIR / "model"
+DEFAULT_RESOLUTION = 512
+
+
+def _repo_root() -> Path:
+    return REFERENCE_DIR.parent.parent.parent
+
+
+def _read_meta() -> dict[str, Any]:
+    return json.loads((REFERENCE_DIR / "meta.json").read_text())
+
+
+def configure_environment_for_device(device: str) -> None:
+    if device == "auto" or str(device).startswith("mps"):
+        os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+
+def _add_source_to_path(source_dir: Path) -> None:
+    source_dir = source_dir.resolve()
+    if not (source_dir / "models").is_dir() or not (source_dir / "transport").is_dir():
+        raise FileNotFoundError(f"Show-o2 source directory is incomplete: {source_dir}")
+    source_text = str(source_dir)
+    if source_text not in sys.path:
+        sys.path.insert(0, source_text)
+
+
+def _config_path_for_resolution(source_dir: Path, resolution: int) -> Path:
+    configs = {
+        432: "showo2_1.5b_demo_432x432.yaml",
+        512: "showo2_1.5b_demo_512x512.yaml",
+        1024: "showo2_1.5b_demo_1024x1024.yaml",
+    }
+    try:
+        name = configs[int(resolution)]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported Show-o2 resolution: {resolution}") from exc
+    return source_dir / "configs" / name
+
+
+def resolve_device(device: str = "auto"):
+    import torch
+
+    if device != "auto":
+        return torch.device(device)
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def empty_device_cache(device) -> None:
+    import torch
+
+    if device.type == "cuda":
+        torch.cuda.empty_cache()
+    elif device.type == "mps" and hasattr(torch, "mps"):
+        torch.mps.empty_cache()
+
+
+def synchronize_device(device) -> None:
+    import torch
+
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    elif device.type == "mps" and hasattr(torch, "mps") and hasattr(torch.mps, "synchronize"):
+        torch.mps.synchronize()
+
+
+def resolve_dtype(dtype: str = "auto", device=None):
+    import torch
+
+    if dtype == "auto":
+        if device is not None and device.type == "mps":
+            return torch.float16
+        if device is not None and device.type == "cpu":
+            return torch.float32
+        return torch.bfloat16
+    mapping = {
+        "bfloat16": torch.bfloat16,
+        "bf16": torch.bfloat16,
+        "float16": torch.float16,
+        "fp16": torch.float16,
+        "float32": torch.float32,
+        "fp32": torch.float32,
+    }
+    try:
+        return mapping[dtype]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported dtype: {dtype}") from exc
+
+
+def ensure_model_dir(model_dir: str | Path | None = None) -> Path:
+    """Return a local Show-o2 checkpoint directory, downloading if needed."""
+    if model_dir is not None:
+        candidate = Path(model_dir).expanduser().resolve()
+        if candidate.exists():
+            return candidate
+        if candidate != DEFAULT_MODEL_DIR.resolve():
+            raise FileNotFoundError(f"Model directory does not exist: {candidate}")
+
+    if DEFAULT_MODEL_DIR.exists():
+        return DEFAULT_MODEL_DIR.resolve()
+
+    meta = _read_meta()
+    from huggingface_hub import snapshot_download
+
+    downloaded = Path(
+        snapshot_download(
+            meta["model_id"],
+            revision=meta.get("revision"),
+            cache_dir=str(_repo_root() / ".hf_cache"),
+        )
+    )
+    try:
+        DEFAULT_MODEL_DIR.symlink_to(downloaded, target_is_directory=True)
+        return DEFAULT_MODEL_DIR.resolve()
+    except FileExistsError:
+        return DEFAULT_MODEL_DIR.resolve()
+    except OSError:
+        return downloaded
+
+
+def ensure_wan_vae(vae_path: str | Path | None = None) -> Path:
+    """Return a local Wan2.1 VAE weight file, downloading if needed."""
+    if vae_path is not None:
+        candidate = Path(vae_path).expanduser().resolve()
+        if candidate.exists():
+            return candidate
+        raise FileNotFoundError(f"Wan VAE path does not exist: {candidate}")
+
+    local = REFERENCE_DIR / "Wan2.1_VAE.pth"
+    if local.exists():
+        return local.resolve()
+
+    meta = _read_meta()["wan_vae"]
+    from huggingface_hub import hf_hub_download
+
+    return Path(
+        hf_hub_download(
+            repo_id=meta["model_id"],
+            filename=meta["filename"],
+            revision=meta.get("revision"),
+            cache_dir=str(_repo_root() / ".hf_cache"),
+        )
+    )
+
+
+def pil_to_png_bytes(image, *, compress_level: int | None = None) -> bytes:
+    buffer = io.BytesIO()
+    save_kwargs = {}
+    if compress_level is not None:
+        save_kwargs["compress_level"] = int(compress_level)
+    image.save(buffer, format="PNG", **save_kwargs)
+    return buffer.getvalue()
+
+
+def pil_to_base64_png(image, *, compress_level: int | None = None) -> str:
+    return base64.b64encode(
+        pil_to_png_bytes(image, compress_level=compress_level),
+    ).decode("ascii")
+
+
+def resolve_secondary_device(device: str | None, fallback):
+    if device in (None, "same"):
+        return fallback
+    return resolve_device(device)
+
+
+def resolve_secondary_dtype(dtype: str | None, device, fallback):
+    if dtype in (None, "same"):
+        return fallback
+    return resolve_dtype(dtype, device)
+
+
+def denorm_cpu_first(images):
+    import numpy as np
+
+    arrays = images.detach().cpu().permute(0, 2, 3, 1).numpy()
+    return np.clip((arrays + 1.0) * 127.5, 0.0, 255.0).astype(np.uint8)
+
+
+def denorm_float32_first(images):
+    import numpy as np
+    import torch
+
+    images = images.to(torch.float32)
+    images = torch.clamp((images + 1.0) / 2.0, min=0.0, max=1.0)
+    images *= 255.0
+    return images.permute(0, 2, 3, 1).cpu().numpy().astype(np.uint8)
+
+
+def denorm_native(images):
+    import numpy as np
+    import torch
+
+    images = torch.clamp((images + 1.0) * 127.5, min=0.0, max=255.0)
+    images = images.permute(0, 2, 3, 1).cpu()
+    if images.dtype == torch.bfloat16:
+        images = images.to(torch.float32)
+    return images.numpy().astype(np.uint8)
+
+
+def denorm_numpy(images):
+    import numpy as np
+
+    arrays = np.clip((images + 1.0) * 127.5, 0.0, 255.0)
+    return np.transpose(arrays, (0, 2, 3, 1)).astype(np.uint8)
+
+
+@dataclass
+class ShowO2Model:
+    model: Any
+    tokenizer: Any
+    showo_token_ids: dict[str, int]
+    config: Any
+    device: Any
+    dtype: Any
+    source_dir: Path
+    resolution: int = DEFAULT_RESOLUTION
+    vae_path: Path | None = None
+    vae_model: Any | None = None
+    vae_device: Any | None = None
+    vae_dtype: Any | None = None
+    vae_output_dtype: str = "float32"
+    vae_decode_mode: str = "video"
+    vae_conv2d_tail_start: int = 12
+    vae_conv2d_tail_max_modules: int | None = None
+    vae_upsample_mode: str = "default"
+    vae_trace_decoder: bool = False
+    vae_decoder_backend: str = "torch"
+    vae_coreml_model_path: str | None = None
+    vae_coreml_compute_units: str = "all"
+    vae_coreml_optimization_hints: str = "none"
+    vae_coreml_input_rank: int = 5
+    vae_mlx_dtype: str = "float16"
+    vae_mlx_compile: bool = True
+    vae_mlx_low_rank_highres_rank: int = 64
+    vae_mlx_low_rank_highres_min_size: int = 512
+    vae_mlx_low_rank_highres_tail_rank: int | None = 36
+    vae_mlx_low_rank_highres_tail_start_layer: int = 14
+    vae_mlx_low_rank_override_layer: int | None = None
+    vae_mlx_low_rank_override_conv_index: int | None = None
+    vae_mlx_low_rank_override_rank: int | None = None
+    vae_mlx_approx_highres_residual_start_layer: int | None = None
+    vae_mlx_approx_highres_residual_end_layer: int | None = None
+    vae_mlx_approx_highres_residual_mode: str = "full"
+    vae_mlx_low_rank_pointwise_impl: str = "conv2d"
+    vae_profile: bool = False
+    postprocess_mode: str = "upstream"
+    _sample_fn_cache: dict[tuple[int, int], Any] = field(default_factory=dict, repr=False)
+    _attention_base_mask_cache: dict[tuple[int, int, str, str], Any] = field(
+        default_factory=dict,
+        repr=False,
+    )
+    _attention_mask_cache: dict[tuple[Any, ...], Any] = field(default_factory=dict, repr=False)
+    _attention_mask_identity_cache: dict[tuple[Any, ...], Any] = field(default_factory=dict, repr=False)
+    _prepared_prompt_cache: dict[tuple[Any, ...], tuple[Any, Any]] = field(
+        default_factory=dict,
+        repr=False,
+    )
+    last_image_timings_ms: dict[str, float] = field(default_factory=dict, repr=False)
+    prewarm_timings_ms: dict[str, float] | None = field(default=None, repr=False)
+    image_component_prewarm_timings_ms: dict[str, float] | None = field(default=None, repr=False)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_dir: str | Path | None = None,
+        *,
+        source_dir: str | Path | None = None,
+        vae_path: str | Path | None = None,
+        device: str = "auto",
+        dtype: str = "auto",
+        vae_device: str = "same",
+        vae_dtype: str = "same",
+        vae_output_dtype: str = "float32",
+        vae_decode_mode: str = "video",
+        vae_conv2d_tail_start: int = 12,
+        vae_conv2d_tail_max_modules: int | None = None,
+        vae_upsample_mode: str = "default",
+        vae_trace_decoder: bool = False,
+        vae_decoder_backend: str = "torch",
+        vae_coreml_model_path: str | None = None,
+        vae_coreml_compute_units: str = "all",
+        vae_coreml_optimization_hints: str = "none",
+        vae_coreml_input_rank: int = 5,
+        vae_mlx_dtype: str = "float16",
+        vae_mlx_compile: bool = True,
+        vae_mlx_low_rank_highres_rank: int = 64,
+        vae_mlx_low_rank_highres_min_size: int = 512,
+        vae_mlx_low_rank_highres_tail_rank: int | None = 36,
+        vae_mlx_low_rank_highres_tail_start_layer: int = 14,
+        vae_mlx_low_rank_override_layer: int | None = None,
+        vae_mlx_low_rank_override_conv_index: int | None = None,
+        vae_mlx_low_rank_override_rank: int | None = None,
+        vae_mlx_approx_highres_residual_start_layer: int | None = None,
+        vae_mlx_approx_highres_residual_end_layer: int | None = None,
+        vae_mlx_approx_highres_residual_mode: str = "full",
+        vae_mlx_low_rank_pointwise_impl: str = "conv2d",
+        vae_profile: bool = False,
+        postprocess_mode: str = "upstream",
+        resolution: int = DEFAULT_RESOLUTION,
+        load_vae: bool = False,
+    ) -> "ShowO2Model":
+        if postprocess_mode not in {"upstream", "cpu", "native"}:
+            raise ValueError(f"Unsupported postprocess mode: {postprocess_mode}")
+        if vae_output_dtype not in {"float32", "native", "deferred"}:
+            raise ValueError(f"Unsupported VAE output dtype: {vae_output_dtype}")
+        if vae_decode_mode not in {"video", "image", "image-conv2d", "image-conv2d-tail"}:
+            raise ValueError(f"Unsupported VAE decode mode: {vae_decode_mode}")
+        if vae_conv2d_tail_start < 0:
+            raise ValueError(f"Unsupported VAE conv2d tail start: {vae_conv2d_tail_start}")
+        if vae_conv2d_tail_max_modules is not None and vae_conv2d_tail_max_modules < 0:
+            raise ValueError(f"Unsupported VAE conv2d tail max modules: {vae_conv2d_tail_max_modules}")
+        if vae_upsample_mode not in {"default", "convtranspose"}:
+            raise ValueError(f"Unsupported VAE upsample mode: {vae_upsample_mode}")
+        if vae_decoder_backend not in {"torch", "coreml", "mlx"}:
+            raise ValueError(f"Unsupported VAE decoder backend: {vae_decoder_backend}")
+        if vae_decoder_backend == "coreml" and not vae_coreml_model_path:
+            raise ValueError("Core ML VAE decoder backend requires vae_coreml_model_path")
+        if vae_coreml_input_rank not in (4, 5):
+            raise ValueError(f"Unsupported Core ML VAE input rank: {vae_coreml_input_rank}")
+        if vae_mlx_dtype not in {"float32", "float16", "bfloat16"}:
+            raise ValueError(f"Unsupported MLX VAE dtype: {vae_mlx_dtype}")
+        if vae_mlx_low_rank_highres_rank < 0:
+            raise ValueError(f"Unsupported MLX low-rank high-res rank: {vae_mlx_low_rank_highres_rank}")
+        if vae_mlx_low_rank_highres_min_size < 0:
+            raise ValueError(
+                f"Unsupported MLX low-rank high-res min size: {vae_mlx_low_rank_highres_min_size}"
+            )
+        if vae_mlx_low_rank_highres_tail_rank is not None and vae_mlx_low_rank_highres_tail_rank < 0:
+            raise ValueError(
+                f"Unsupported MLX low-rank high-res tail rank: {vae_mlx_low_rank_highres_tail_rank}"
+            )
+        if vae_mlx_low_rank_highres_tail_start_layer < 0:
+            raise ValueError(
+                "Unsupported MLX low-rank high-res tail start layer: "
+                f"{vae_mlx_low_rank_highres_tail_start_layer}"
+            )
+        if vae_mlx_low_rank_override_layer is not None and vae_mlx_low_rank_override_layer < 0:
+            raise ValueError(
+                "Unsupported MLX low-rank override layer: "
+                f"{vae_mlx_low_rank_override_layer}"
+            )
+        if (
+            vae_mlx_low_rank_override_conv_index is not None
+            and vae_mlx_low_rank_override_conv_index not in (0, 1)
+        ):
+            raise ValueError(
+                "Unsupported MLX low-rank override conv index: "
+                f"{vae_mlx_low_rank_override_conv_index}"
+            )
+        if vae_mlx_low_rank_override_rank is not None and vae_mlx_low_rank_override_rank < 0:
+            raise ValueError(
+                "Unsupported MLX low-rank override rank: "
+                f"{vae_mlx_low_rank_override_rank}"
+            )
+        if (
+            vae_mlx_approx_highres_residual_start_layer is not None
+            and vae_mlx_approx_highres_residual_start_layer < 0
+        ):
+            raise ValueError(
+                "Unsupported MLX approximate high-res residual start layer: "
+                f"{vae_mlx_approx_highres_residual_start_layer}"
+            )
+        if (
+            vae_mlx_approx_highres_residual_end_layer is not None
+            and vae_mlx_approx_highres_residual_end_layer < 0
+        ):
+            raise ValueError(
+                "Unsupported MLX approximate high-res residual end layer: "
+                f"{vae_mlx_approx_highres_residual_end_layer}"
+            )
+        if vae_mlx_approx_highres_residual_mode not in {"full", "first-conv", "second-conv"}:
+            raise ValueError(
+                "Unsupported MLX approximate high-res residual mode: "
+                f"{vae_mlx_approx_highres_residual_mode}"
+            )
+        if vae_mlx_low_rank_pointwise_impl not in {"conv2d", "matmul"}:
+            raise ValueError(
+                "Unsupported MLX low-rank pointwise implementation: "
+                f"{vae_mlx_low_rank_pointwise_impl}"
+            )
+        configure_environment_for_device(device)
+        configure_environment_for_device(vae_device)
+        source = Path(source_dir or DEFAULT_SOURCE_DIR).expanduser().resolve()
+        _add_source_to_path(source)
+
+        from models import Showo2Qwen2_5
+        from models.misc import get_text_tokenizer
+        from omegaconf import OmegaConf
+        from utils import get_hyper_params, path_to_llm_name
+
+        resolved_model_dir = ensure_model_dir(model_dir)
+        resolved_device = resolve_device(device)
+        resolved_dtype = resolve_dtype(dtype, resolved_device)
+        resolved_vae_device = resolve_secondary_device(vae_device, resolved_device)
+        resolved_vae_dtype = resolve_secondary_dtype(vae_dtype, resolved_vae_device, resolved_dtype)
+        if vae_decoder_backend == "mlx":
+            import torch
+
+            resolved_vae_device = torch.device("cpu")
+            resolved_vae_dtype = torch.float32
+
+        config = OmegaConf.load(_config_path_for_resolution(source, resolution))
+        config.model.showo.pretrained_model_path = str(resolved_model_dir)
+
+        tokenizer, showo_token_ids = get_text_tokenizer(
+            config.model.showo.llm_model_path,
+            add_showo_tokens=True,
+            return_showo_token_ids=True,
+            llm_name=path_to_llm_name[config.model.showo.llm_model_path],
+        )
+        config.model.showo.llm_vocab_size = len(tokenizer)
+
+        if config.model.showo.add_time_embeds:
+            config.dataset.preprocessing.num_t2i_image_tokens += 1
+            config.dataset.preprocessing.num_mmu_image_tokens += 1
+            config.dataset.preprocessing.num_video_tokens += 1
+
+        model = Showo2Qwen2_5.from_pretrained(
+            str(resolved_model_dir),
+            use_safetensors=False,
+        ).to(resolved_device)
+        model.to(resolved_dtype)
+        model.eval()
+
+        runtime = cls(
+            model=model,
+            tokenizer=tokenizer,
+            showo_token_ids=showo_token_ids,
+            config=config,
+            device=resolved_device,
+            dtype=resolved_dtype,
+            source_dir=source,
+            resolution=resolution,
+            vae_path=(
+                ensure_wan_vae(vae_path)
+                if load_vae and vae_decoder_backend != "coreml"
+                else None
+            ),
+            vae_device=resolved_vae_device,
+            vae_dtype=resolved_vae_dtype,
+            vae_output_dtype=vae_output_dtype,
+            vae_decode_mode=vae_decode_mode,
+            vae_conv2d_tail_start=int(vae_conv2d_tail_start),
+            vae_conv2d_tail_max_modules=vae_conv2d_tail_max_modules,
+            vae_upsample_mode=vae_upsample_mode,
+            vae_trace_decoder=vae_trace_decoder,
+            vae_decoder_backend=vae_decoder_backend,
+            vae_coreml_model_path=vae_coreml_model_path,
+            vae_coreml_compute_units=vae_coreml_compute_units,
+            vae_coreml_optimization_hints=vae_coreml_optimization_hints,
+            vae_coreml_input_rank=int(vae_coreml_input_rank),
+            vae_mlx_dtype=vae_mlx_dtype,
+            vae_mlx_compile=bool(vae_mlx_compile),
+            vae_mlx_low_rank_highres_rank=int(vae_mlx_low_rank_highres_rank),
+            vae_mlx_low_rank_highres_min_size=int(vae_mlx_low_rank_highres_min_size),
+            vae_mlx_low_rank_highres_tail_rank=(
+                None
+                if vae_mlx_low_rank_highres_tail_rank is None
+                else int(vae_mlx_low_rank_highres_tail_rank)
+            ),
+            vae_mlx_low_rank_highres_tail_start_layer=int(vae_mlx_low_rank_highres_tail_start_layer),
+            vae_mlx_low_rank_override_layer=(
+                None
+                if vae_mlx_low_rank_override_layer is None
+                else int(vae_mlx_low_rank_override_layer)
+            ),
+            vae_mlx_low_rank_override_conv_index=(
+                None
+                if vae_mlx_low_rank_override_conv_index is None
+                else int(vae_mlx_low_rank_override_conv_index)
+            ),
+            vae_mlx_low_rank_override_rank=(
+                None
+                if vae_mlx_low_rank_override_rank is None
+                else int(vae_mlx_low_rank_override_rank)
+            ),
+            vae_mlx_approx_highres_residual_start_layer=(
+                None
+                if vae_mlx_approx_highres_residual_start_layer is None
+                else int(vae_mlx_approx_highres_residual_start_layer)
+            ),
+            vae_mlx_approx_highres_residual_end_layer=(
+                None
+                if vae_mlx_approx_highres_residual_end_layer is None
+                else int(vae_mlx_approx_highres_residual_end_layer)
+            ),
+            vae_mlx_approx_highres_residual_mode=vae_mlx_approx_highres_residual_mode,
+            vae_mlx_low_rank_pointwise_impl=vae_mlx_low_rank_pointwise_impl,
+            vae_profile=vae_profile,
+            postprocess_mode=postprocess_mode,
+        )
+        runtime._hyper_params = get_hyper_params(config, tokenizer, showo_token_ids)
+        if load_vae:
+            runtime.load_vae()
+        empty_device_cache(resolved_device)
+        return runtime
+
+    def load_vae(self) -> None:
+        if self.vae_model is not None:
+            return
+        import torch
+
+        _add_source_to_path(self.source_dir)
+        from models import WanVAE
+
+        if self.vae_decoder_backend == "coreml":
+            vae_path = ""
+        else:
+            self.vae_path = self.vae_path or ensure_wan_vae()
+            vae_path = str(self.vae_path)
+        vae_device = "cpu" if self.vae_decoder_backend == "mlx" else (self.vae_device or self.device)
+        vae_dtype = torch.float32 if self.vae_decoder_backend == "mlx" else (self.vae_dtype or self.dtype)
+        self.vae_model = WanVAE(
+            vae_pth=vae_path,
+            dtype=vae_dtype,
+            device=vae_device,
+            output_dtype=self.vae_output_dtype,
+            decode_mode=self.vae_decode_mode,
+            conv2d_tail_start=self.vae_conv2d_tail_start,
+            conv2d_tail_max_modules=self.vae_conv2d_tail_max_modules,
+            upsample_mode=self.vae_upsample_mode,
+            trace_decoder=self.vae_trace_decoder,
+            decoder_backend=self.vae_decoder_backend,
+            coreml_model_path=self.vae_coreml_model_path,
+            coreml_compute_units=self.vae_coreml_compute_units,
+            coreml_optimization_hints=self.vae_coreml_optimization_hints,
+            coreml_input_rank=self.vae_coreml_input_rank,
+            coreml_latent_size=self.resolution // 8,
+            mlx_dtype=self.vae_mlx_dtype,
+            mlx_compile=self.vae_mlx_compile,
+            mlx_low_rank_highres_rank=self.vae_mlx_low_rank_highres_rank,
+            mlx_low_rank_highres_min_size=self.vae_mlx_low_rank_highres_min_size,
+            mlx_low_rank_highres_tail_rank=self.vae_mlx_low_rank_highres_tail_rank,
+            mlx_low_rank_highres_tail_start_layer=self.vae_mlx_low_rank_highres_tail_start_layer,
+            mlx_low_rank_override_layer=self.vae_mlx_low_rank_override_layer,
+            mlx_low_rank_override_conv_index=self.vae_mlx_low_rank_override_conv_index,
+            mlx_low_rank_override_rank=self.vae_mlx_low_rank_override_rank,
+            mlx_approx_highres_residual_start_layer=self.vae_mlx_approx_highres_residual_start_layer,
+            mlx_approx_highres_residual_end_layer=self.vae_mlx_approx_highres_residual_end_layer,
+            mlx_approx_highres_residual_mode=self.vae_mlx_approx_highres_residual_mode,
+            mlx_low_rank_pointwise_impl=self.vae_mlx_low_rank_pointwise_impl,
+            mlx_latent_size=self.resolution // 8,
+            profile=self.vae_profile,
+        )
+
+    def prewarm_vae_decoder(self) -> dict[str, float]:
+        import torch
+
+        timings: dict[str, float] = {}
+        total_started = time.perf_counter()
+
+        load_started = time.perf_counter()
+        self.load_vae()
+        timings["load_vae_ms"] = (time.perf_counter() - load_started) * 1000.0
+
+        hyper_params = getattr(self, "_hyper_params", None)
+        if hyper_params is not None:
+            image_latent_dim = int(hyper_params[5])
+            patch_size = int(hyper_params[6])
+            latent_width = int(hyper_params[7]) * patch_size
+            latent_height = int(hyper_params[8]) * patch_size
+        else:
+            image_latent_dim = 16
+            latent_width = latent_height = self.resolution // 8
+
+        if self.vae_decoder_backend in {"coreml", "mlx"}:
+            latent_device = "cpu"
+            latent_dtype = torch.float32
+        else:
+            latent_device = self.vae_device or self.device
+            latent_dtype = self.vae_dtype or self.dtype
+        latents = torch.zeros(
+            (1, image_latent_dim, 1, latent_height, latent_width),
+            device=latent_device,
+            dtype=latent_dtype,
+        )
+
+        decode_started = time.perf_counter()
+        with torch.inference_mode():
+            decoded = self.vae_model.batch_decode(latents)
+            if self.vae_decoder_backend not in {"coreml", "mlx"}:
+                synchronize_device(torch.device(self.vae_device or self.device))
+        timings["decode_ms"] = (time.perf_counter() - decode_started) * 1000.0
+        timings["total_ms"] = (time.perf_counter() - total_started) * 1000.0
+
+        del decoded, latents
+        self.prewarm_timings_ms = timings
+        return timings
+
+    def prewarm_image_components(
+        self,
+        prompt: str,
+        *,
+        num_inference_steps: int = 1,
+        guidance_scale: float = 5.0,
+    ) -> dict[str, float]:
+        total_started = time.perf_counter()
+        timings: dict[str, float] = {}
+
+        (
+            num_t2i_image_tokens,
+            _num_mmu_image_tokens,
+            _num_video_tokens,
+            max_seq_len,
+            max_text_len,
+            _image_latent_dim,
+            _patch_size,
+            _latent_width,
+            _latent_height,
+            pad_id,
+            bos_id,
+            eos_id,
+            boi_id,
+            eoi_id,
+            _bov_id,
+            _eov_id,
+            img_pad_id,
+            _vid_pad_id,
+            _default_guidance_scale,
+        ) = self._hyper_params
+
+        prepare_started = time.perf_counter()
+        text_tokens, positions, prompt_cache_hit = self._get_prepared_prompt_inputs(
+            prompt,
+            guidance_scale=guidance_scale,
+            num_t2i_image_tokens=num_t2i_image_tokens,
+            max_text_len=max_text_len,
+            bos_id=bos_id,
+            eos_id=eos_id,
+            boi_id=boi_id,
+            eoi_id=eoi_id,
+            pad_id=pad_id,
+            img_pad_id=img_pad_id,
+        )
+        timings["prepare_ms"] = (time.perf_counter() - prepare_started) * 1000.0
+        timings["prepare_cache_hit"] = 1.0 if prompt_cache_hit else 0.0
+
+        mask_started = time.perf_counter()
+        _attention_mask, mask_cache_hit = self._get_attention_mask(
+            text_tokens.size(0),
+            max_seq_len,
+            positions,
+            self.dtype,
+        )
+        timings["mask_ms"] = (time.perf_counter() - mask_started) * 1000.0
+        timings["mask_cache_hit"] = 1.0 if mask_cache_hit else 0.0
+
+        sampler_started = time.perf_counter()
+        self._get_sample_fn(num_inference_steps, num_t2i_image_tokens)
+        timings["sampler_setup_ms"] = (time.perf_counter() - sampler_started) * 1000.0
+        timings["total_ms"] = (time.perf_counter() - total_started) * 1000.0
+        self.image_component_prewarm_timings_ms = timings
+        return timings
+
+    def _prepared_prompt_cache_key(
+        self,
+        prompt: str,
+        *,
+        guidance_scale: float,
+        num_t2i_image_tokens: int,
+        max_text_len: int,
+    ) -> tuple[Any, ...]:
+        return (
+            prompt,
+            bool(guidance_scale > 0),
+            int(num_t2i_image_tokens),
+            int(max_text_len),
+            str(self.device),
+        )
+
+    def _get_prepared_prompt_inputs(
+        self,
+        prompt: str,
+        *,
+        guidance_scale: float,
+        num_t2i_image_tokens: int,
+        max_text_len: int,
+        bos_id: int,
+        eos_id: int,
+        boi_id: int,
+        eoi_id: int,
+        pad_id: int,
+        img_pad_id: int,
+    ):
+        import torch
+        from models.misc import prepare_gen_input
+
+        cache_key = self._prepared_prompt_cache_key(
+            prompt,
+            guidance_scale=guidance_scale,
+            num_t2i_image_tokens=num_t2i_image_tokens,
+            max_text_len=max_text_len,
+        )
+        cached = self._prepared_prompt_cache.get(cache_key)
+        if cached is not None:
+            text_tokens, positions = cached
+            return text_tokens, positions, True
+
+        text_tokens, text_tokens_null, positions, positions_null = prepare_gen_input(
+            [prompt],
+            self.tokenizer,
+            num_t2i_image_tokens,
+            bos_id,
+            eos_id,
+            boi_id,
+            eoi_id,
+            pad_id,
+            img_pad_id,
+            max_text_len,
+            self.device,
+        )
+        if guidance_scale > 0:
+            text_tokens = torch.cat([text_tokens, text_tokens_null], dim=0)
+            positions = torch.cat([positions, positions_null], dim=0)
+        self._prepared_prompt_cache[cache_key] = (text_tokens, positions)
+        return text_tokens, positions, False
+
+    def _get_sample_fn(self, num_inference_steps: int, num_t2i_image_tokens: int):
+        from transport import Sampler, create_transport
+
+        key = (int(num_inference_steps), int(num_t2i_image_tokens))
+        sample_fn = self._sample_fn_cache.get(key)
+        if sample_fn is not None:
+            return sample_fn
+
+        transport = create_transport(
+            path_type=self.config.transport.path_type,
+            prediction=self.config.transport.prediction,
+            loss_weight=self.config.transport.loss_weight,
+            train_eps=self.config.transport.train_eps,
+            sample_eps=self.config.transport.sample_eps,
+            snr_type=self.config.transport.snr_type,
+            do_shift=self.config.transport.do_shift,
+            seq_len=num_t2i_image_tokens,
+        )
+        sampler = Sampler(transport)
+        sample_fn = sampler.sample_ode(
+            sampling_method=self.config.transport.sampling_method,
+            num_steps=num_inference_steps,
+            atol=self.config.transport.atol,
+            rtol=self.config.transport.rtol,
+            reverse=self.config.transport.reverse,
+            time_shifting_factor=self.config.transport.time_shifting_factor,
+        )
+        self._sample_fn_cache[key] = sample_fn
+        return sample_fn
+
+    @staticmethod
+    def _limited_cache_set(cache: dict, key: tuple[Any, ...], value: Any, *, limit: int = 64) -> None:
+        if len(cache) >= limit:
+            cache.clear()
+        cache[key] = value
+
+    def _get_base_attention_mask(self, batch_size: int, max_seq_len: int, dtype):
+        import torch
+
+        key = (int(batch_size), int(max_seq_len), str(self.device), str(dtype))
+        cached = self._attention_base_mask_cache.get(key)
+        if cached is not None:
+            return cached, True
+
+        blocked_value = torch.tensor(torch.iinfo(torch.long).min, dtype=dtype, device=self.device)
+        mask = torch.zeros(
+            (int(batch_size), 1, int(max_seq_len), int(max_seq_len)),
+            dtype=dtype,
+            device=self.device,
+        )
+        upper_triangle = torch.ones(
+            (int(max_seq_len), int(max_seq_len)),
+            dtype=torch.bool,
+            device=self.device,
+        ).triu(diagonal=1)
+        mask.masked_fill_(upper_triangle.view(1, 1, int(max_seq_len), int(max_seq_len)), blocked_value)
+        self._limited_cache_set(self._attention_base_mask_cache, key, mask, limit=16)
+        return mask, False
+
+    def _get_attention_mask(self, batch_size: int, max_seq_len: int, positions, dtype):
+        base_key = (int(batch_size), int(max_seq_len), str(self.device), str(dtype))
+        identity_key = (*base_key, positions)
+        cached = self._attention_mask_identity_cache.get(identity_key)
+        if cached is not None:
+            return cached, True
+
+        position_values = tuple(int(value) for value in positions.detach().cpu().reshape(-1).tolist())
+        key = (*base_key, position_values)
+        cached = self._attention_mask_cache.get(key)
+        if cached is not None:
+            self._limited_cache_set(self._attention_mask_identity_cache, identity_key, cached)
+            return cached, True
+
+        base_mask, _base_hit = self._get_base_attention_mask(batch_size, max_seq_len, dtype)
+        mask = base_mask.clone()
+        for batch_index, modality_batch in enumerate(positions.detach().cpu().tolist()):
+            for offset, length in modality_batch:
+                offset = int(offset)
+                length = int(length)
+                if length > 0:
+                    mask[
+                        batch_index,
+                        :,
+                        offset:offset + length,
+                        offset:offset + length,
+                    ] = 0
+        self._limited_cache_set(self._attention_mask_cache, key, mask)
+        self._limited_cache_set(self._attention_mask_identity_cache, identity_key, mask)
+        return mask, False
+
+    def generate_text(
+        self,
+        prompt: str,
+        *,
+        max_new_tokens: int = 64,
+        temperature: float = 0.0,
+        top_k: int | None = None,
+    ) -> str:
+        import torch
+
+        token_ids = [self.showo_token_ids["bos_id"]]
+        token_ids.extend(self.tokenizer(prompt, add_special_tokens=False).input_ids)
+        output_ids: list[int] = []
+
+        with torch.inference_mode():
+            for _ in range(max_new_tokens):
+                input_ids = torch.tensor([token_ids], device=self.device)
+                outputs = self.model.showo(input_ids=input_ids, return_dict=True)
+                logits = outputs.logits[:, -1, :]
+                if top_k is not None:
+                    values, _ = torch.topk(logits, min(top_k, logits.shape[-1]))
+                    logits = torch.where(
+                        logits < values[:, [-1]],
+                        torch.full_like(logits, float("-inf")),
+                        logits,
+                    )
+                if temperature <= 0:
+                    next_token = int(torch.argmax(logits, dim=-1).item())
+                else:
+                    probs = torch.softmax(logits / temperature, dim=-1)
+                    next_token = int(torch.multinomial(probs, num_samples=1).item())
+                if next_token == self.tokenizer.eos_token_id:
+                    break
+                token_ids.append(next_token)
+                output_ids.append(next_token)
+
+        return self.tokenizer.decode(output_ids, skip_special_tokens=True)
+
+    def generate_image(
+        self,
+        prompt: str,
+        *,
+        num_inference_steps: int = 20,
+        guidance_scale: float = 5.0,
+        seed: int | None = None,
+        postprocess_mode: str | None = None,
+        return_arrays: bool = False,
+    ):
+        import torch
+        from PIL import Image
+        from utils import denorm
+
+        total_started = time.perf_counter()
+        active_postprocess_mode = postprocess_mode or self.postprocess_mode
+        if active_postprocess_mode not in {"upstream", "cpu", "native"}:
+            raise ValueError(f"Unsupported postprocess mode: {active_postprocess_mode}")
+        timings: dict[str, float] = {}
+        load_vae_started = time.perf_counter()
+        self.load_vae()
+        timings["load_vae_ms"] = (time.perf_counter() - load_vae_started) * 1000.0
+        if seed is not None:
+            torch.manual_seed(seed)
+            if self.device.type == "cuda":
+                torch.cuda.manual_seed_all(seed)
+            elif self.device.type == "mps" and hasattr(torch, "mps") and hasattr(torch.mps, "manual_seed"):
+                torch.mps.manual_seed(seed)
+
+        (
+            num_t2i_image_tokens,
+            _num_mmu_image_tokens,
+            _num_video_tokens,
+            max_seq_len,
+            max_text_len,
+            image_latent_dim,
+            patch_size,
+            latent_width,
+            latent_height,
+            pad_id,
+            bos_id,
+            eos_id,
+            boi_id,
+            eoi_id,
+            _bov_id,
+            _eov_id,
+            img_pad_id,
+            _vid_pad_id,
+            _default_guidance_scale,
+        ) = self._hyper_params
+
+        with torch.inference_mode():
+            prepare_started = time.perf_counter()
+            text_tokens, positions, prompt_cache_hit = self._get_prepared_prompt_inputs(
+                prompt,
+                guidance_scale=guidance_scale,
+                num_t2i_image_tokens=num_t2i_image_tokens,
+                max_text_len=max_text_len,
+                bos_id=bos_id,
+                eos_id=eos_id,
+                boi_id=boi_id,
+                eoi_id=eoi_id,
+                pad_id=pad_id,
+                img_pad_id=img_pad_id,
+            )
+            timings["prepare_ms"] = (time.perf_counter() - prepare_started) * 1000.0
+            timings["prepare_cache_hit"] = 1.0 if prompt_cache_hit else 0.0
+
+            latent_started = time.perf_counter()
+            z = torch.randn(
+                (
+                    1,
+                    image_latent_dim,
+                    latent_height * patch_size,
+                    latent_width * patch_size,
+                ),
+                device=self.device,
+                dtype=self.dtype,
+            )
+
+            if guidance_scale > 0:
+                z = torch.cat([z, z], dim=0)
+            timings["latent_ms"] = (time.perf_counter() - latent_started) * 1000.0
+
+            mask_started = time.perf_counter()
+            attention_mask, mask_cache_hit = self._get_attention_mask(
+                text_tokens.size(0),
+                max_seq_len,
+                positions,
+                self.dtype,
+            )
+            timings["mask_ms"] = (time.perf_counter() - mask_started) * 1000.0
+            timings["mask_cache_hit"] = 1.0 if mask_cache_hit else 0.0
+
+            sampler_started = time.perf_counter()
+            sample_fn = None if num_inference_steps == 1 else self._get_sample_fn(
+                num_inference_steps,
+                num_t2i_image_tokens,
+            )
+            timings["sampler_setup_ms"] = (time.perf_counter() - sampler_started) * 1000.0
+
+            sample_started = time.perf_counter()
+            if sample_fn is None:
+                samples = z.float()
+            else:
+                samples = sample_fn(
+                    z,
+                    self.model.t2i_generate,
+                    text_tokens=text_tokens,
+                    attention_mask=attention_mask,
+                    modality_positions=positions,
+                    output_hidden_states=True,
+                    max_seq_len=max_seq_len,
+                    guidance_scale=guidance_scale,
+                )[-1]
+
+            if guidance_scale > 0:
+                samples = torch.chunk(samples, 2)[0]
+            timings["sample_ms"] = (time.perf_counter() - sample_started) * 1000.0
+
+            decode_started = time.perf_counter()
+            samples = samples.unsqueeze(2)
+            if self.vae_decoder_backend == "mlx":
+                decoded = self.vae_model.batch_decode_mlx(samples, output_layout="nhwc_uint8")
+                images = decoded
+            else:
+                decoded = self.vae_model.batch_decode(samples)
+                images = decoded.squeeze(2) if decoded.ndim == 5 else decoded
+            timings["vae_decode_ms"] = (time.perf_counter() - decode_started) * 1000.0
+            profile_timings = getattr(self.vae_model, "last_profile_timings_ms", None)
+            if isinstance(profile_timings, dict):
+                timings.update(profile_timings)
+
+            postprocess_started = time.perf_counter()
+            if self.vae_decoder_backend == "mlx":
+                arrays = images
+            elif self.vae_decoder_backend == "coreml":
+                arrays = denorm_numpy(images)
+            elif active_postprocess_mode == "cpu":
+                arrays = denorm_cpu_first(images)
+            elif active_postprocess_mode == "native":
+                arrays = denorm_native(images)
+            elif self.vae_output_dtype == "deferred":
+                arrays = denorm_float32_first(images)
+            else:
+                arrays = denorm(images)
+            if self.vae_decoder_backend not in {"coreml", "mlx"}:
+                synchronize_device(self.device)
+            timings["postprocess_ms"] = (time.perf_counter() - postprocess_started) * 1000.0
+
+        pil_started = time.perf_counter()
+        result = list(arrays) if return_arrays else [Image.fromarray(image) for image in arrays]
+        timings["pil_ms"] = (time.perf_counter() - pil_started) * 1000.0
+        timings["total_ms"] = (time.perf_counter() - total_started) * 1000.0
+        self.last_image_timings_ms = timings
+        return result

--- a/examples/show-o2-1.5B-HQ-h100/requirements.txt
+++ b/examples/show-o2-1.5B-HQ-h100/requirements.txt
@@ -1,0 +1,18 @@
+torch==2.5.1
+transformers==4.47.0
+diffusers==0.31.0
+accelerate==0.23.0
+huggingface-hub>=0.30.0,<1.0
+hf-xet>=1.1.0
+einops==0.8.0
+omegaconf==2.3.0
+torchdiffeq>=0.2.4
+timm==1.0.12
+sentencepiece>=0.2.0
+numpy>=1.26
+coremltools>=9.0; sys_platform == "darwin"
+mlx>=0.31.0; sys_platform == "darwin" and platform_machine == "arm64"
+pillow>=10.0
+fastapi>=0.115
+uvicorn>=0.30
+httpx>=0.27

--- a/examples/show-o2-1.5B-HQ-macbook/OBJECTIVE.md
+++ b/examples/show-o2-1.5B-HQ-macbook/OBJECTIVE.md
@@ -1,0 +1,72 @@
+# Objective - Show-o2 1.5B HQ image generation server on MacBook
+
+Minimize **p50 text-to-image request latency** on a local Apple Silicon MacBook
+for `showlab/show-o2-1.5B-HQ` while preserving the image-generation server
+contract. Build an OpenAI-like `/v1/images/generations` HTTP server that
+returns prompt-conditioned PNG images.
+
+## Workload
+
+The benchmark posts image-generation requests with:
+
+- `prompt`: either a fixed prompt or one prompt from the benchmark prompt pool.
+- `num_inference_steps`: default 20, often fixed to a smaller value for smoke
+  and comparison runs.
+- `guidance_scale`: default 5.0.
+- optional `seed` for deterministic requests.
+- optional `include_timings` to return per-request timing diagnostics.
+- optional `postprocess_mode` in `upstream`, `cpu`, or `native`.
+- optional `response_format` in `b64_json`, `png`, or `ppm`.
+
+Warmup requests run before the timed measurement and are excluded from the
+headline result. For performance comparisons, keep prompt, seed, step count,
+guidance scale, output resolution, response format, and postprocess mode fixed
+across variants.
+
+## Headline metric
+
+Use `latency.p50` from `benchmark/benchmark.py`'s measured-result JSON as the
+primary performance metric. Lower is better. `request_throughput`,
+`server_timings`, and per-phase timing fields are secondary diagnostics.
+
+## Server contract
+
+- `/health` returns 200 when the server is ready.
+- `/v1/images/generations` accepts the request fields above.
+- The default response is OpenAI-style JSON with `data[0].b64_json` containing
+  PNG bytes. If `response_format` is `png` or `ppm`, raw image bytes are
+  allowed as implemented by the benchmark.
+- When `include_timings` is true, return phase timings as `timings_ms` for JSON
+  responses or `X-ShowO2-Timings-Ms` for raw-image responses.
+- The accuracy checker is an HTTP smoke test that verifies a valid PNG. Do not
+  exploit that by returning canned images; benchmark runs can save image hashes,
+  dimensions, and images for drift inspection.
+
+## MacBook implementation notes
+
+- Show-o2 is a native unified multimodal model, not a conventional diffusion
+  pipeline bolted onto a separate text encoder. The target uses a Qwen2.5-style
+  Transformer body, a text head, a flow-matching image head, and a Wan VAE for
+  image decode.
+- The reference config uses hidden size 1536, 10 diffusion layers, 27 x 27 image
+  latents with 16 channels, and the `showlab/show-o2-1.5B-HQ` checkpoint pinned
+  in `reference/meta.json`.
+- Use Apple Silicon-specific execution with MLX / Metal optimizations.
+- Optimize the fixed text-to-image path first: body forward, diffusion-head
+  steps, VAE decode, image postprocessing, and response encoding.
+- Useful directions from the paper setup include porting the Qwen2.5-style body
+  and 10-block diffusion head to MLX, eliding redundant SigLIP work on noisy
+  latents, adding prefix-KV caches across diffusion steps, trimming prefill work,
+  and using native postprocess paths.
+- Cross-step redundancy is the main algorithmic opportunity on this target.
+  Cache reusable body and head state across diffusion steps when the request
+  shape is fixed.
+- Treat quantization as target-specific tuning. Quantizing the compute-bound
+  body may regress latency, while int4 can help bandwidth-bound head work if
+  output quality remains acceptable.
+- Classifier-free-guidance stride is a useful target-specific optimization:
+  skip the unconditional branch on most steps and reuse the cached unconditional
+  velocity when doing so preserves image quality for the benchmark settings.
+- Precision, operation order, and postprocess changes may alter exact PNG bytes.
+  Treat small image drift as acceptable only when request settings and output
+  resolution stay fixed and the output remains a real prompt-conditioned image.

--- a/examples/show-o2-1.5B-HQ-macbook/README.md
+++ b/examples/show-o2-1.5B-HQ-macbook/README.md
@@ -1,0 +1,27 @@
+Show-o2 1.5B HQ input bundle.
+
+Use:
+- `--ref inputs/show-o2-1.5B-HQ/reference`
+- `--acc-checker inputs/show-o2-1.5B-HQ/accuracy_checker`
+- `--bench inputs/show-o2-1.5B-HQ/benchmark`
+
+This bundle targets `showlab/show-o2-1.5B-HQ`, a Show-o2 text-to-image
+checkpoint. The reference folder uses a pinned git submodule for the official
+Show-o inference source and keeps model weights out of git. On first real use,
+the loader downloads:
+
+- `showlab/show-o2-1.5B-HQ` into the repo HF cache and links it as
+  `reference/model`
+- `Wan-AI/Wan2.1-T2V-14B/Wan2.1_VAE.pth` through `huggingface_hub`
+- the Qwen2.5 tokenizer/config and SigLIP weights used by the official model
+
+For a local HTTP smoke test that does not download weights:
+
+```bash
+uv run python playground/show_o2_local/serve.py --mock --port 8000
+uv run python inputs/show-o2-1.5B-HQ/benchmark/benchmark.py \
+  --url http://localhost:8000 --warmup-requests 1 --num-requests 1 --steps 1
+```
+
+For a real run, create an environment from `requirements.txt` and start
+`playground/show_o2_local/serve.py` without `--mock`.

--- a/examples/show-o2-1.5B-HQ-macbook/accuracy_checker/README.md
+++ b/examples/show-o2-1.5B-HQ-macbook/accuracy_checker/README.md
@@ -1,0 +1,11 @@
+Accuracy checker inputs for Show-o2 1.5B HQ.
+
+Run:
+
+```bash
+python checker.py --url http://localhost:8000 --steps 1
+```
+
+This checker performs an HTTP image-generation smoke test and verifies that the
+server returns PNG bytes. It is intentionally output-agnostic because diffusion
+sampling is not token-exact.

--- a/examples/show-o2-1.5B-HQ-macbook/accuracy_checker/checker.py
+++ b/examples/show-o2-1.5B-HQ-macbook/accuracy_checker/checker.py
@@ -1,0 +1,43 @@
+"""HTTP smoke checker for a Show-o2 image generation server."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+
+import httpx
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check a Show-o2 HTTP server returns a PNG image.")
+    parser.add_argument("--url", default="http://localhost:8000", help="Server base URL")
+    parser.add_argument("--endpoint", default="/v1/images/generations", help="Endpoint path")
+    parser.add_argument("--prompt", default="a readable sign that says VibeServe", help="Prompt")
+    parser.add_argument("--steps", type=int, default=4, help="Diffusion inference steps")
+    parser.add_argument("--guidance-scale", type=float, default=5.0, help="Guidance scale")
+    parser.add_argument("--timeout", type=float, default=600.0, help="Request timeout")
+    args = parser.parse_args()
+
+    url = args.url.rstrip("/") + args.endpoint
+    body = {
+        "prompt": args.prompt,
+        "num_inference_steps": args.steps,
+        "guidance_scale": args.guidance_scale,
+    }
+    try:
+        response = httpx.post(url, json=body, timeout=args.timeout)
+        response.raise_for_status()
+        payload = response.json()
+        image_bytes = base64.b64decode(payload["data"][0]["b64_json"])
+        if not image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+            raise ValueError("response image is not a PNG")
+    except Exception as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    print(f"PASS: received {len(image_bytes)} PNG bytes from {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/show-o2-1.5B-HQ-macbook/benchmark/README.md
+++ b/examples/show-o2-1.5B-HQ-macbook/benchmark/README.md
@@ -1,0 +1,56 @@
+Benchmark inputs for Show-o2 1.5B HQ.
+
+Run:
+
+```bash
+python benchmark.py \
+  --url http://localhost:8000 \
+  --warmup-requests 1 \
+  --closed-loop \
+  --collect-server-timings \
+  --save-images-dir /tmp/show_o2_images \
+  --postprocess-mode native \
+  --prompt "a small red robot holding a handwritten sign that says VibeServe" \
+  --request-seed 1234 \
+  --fixed-request-seed \
+  --num-requests 5 \
+  --steps 4
+```
+
+The benchmark posts to `/v1/images/generations` and checks that each completed
+request returns a base64 PNG payload. Warmup requests run before timed
+measurement and are reported separately in JSON output. `--closed-loop`
+measures one request at a time without queueing overlap, while
+`--collect-server-timings` asks the server to return phase timings under
+`server_timings`. `--postprocess-mode` can override the server image
+postprocess path per request for comparison runs; supported modes are
+`upstream`, `cpu`, and `native`. JSON output includes PNG SHA-256 hashes so
+comparison runs can spot pixel-level drift across variants, plus PNG dimensions
+so same-resolution comparisons can be checked explicitly. Pass
+`--save-images-dir` to write completed warmup and measured PNG responses to
+disk; measured image paths are included under `image_paths` in JSON output.
+
+Use `compare_images.py` to quantify output drift between saved PNGs:
+
+```bash
+python compare_images.py \
+  --baseline /tmp/show_o2_images_base/request_0000.png \
+  --candidate /tmp/show_o2_images_opt/request_0000.png \
+  --output-json /tmp/show_o2_compare.json
+```
+
+The comparison reports exact hash match, MAE, RMSE, PSNR, changed-pixel
+fraction, and local luminance SSIM. Optional CLIP scoring is available with
+`--clip-model` when the requested CLIP model is already available locally, or
+with `--allow-clip-download` when downloads are acceptable.
+
+When the server is started with `--vae-profile`, `--collect-server-timings`
+also aggregates synchronized VAE decode sub-stage timings under
+`vae_profile_*` keys. Use these for bottleneck diagnosis only; the extra
+synchronization adds measurement overhead.
+
+For performance optimization runs, keep the output shape fixed across variants:
+use the same server resolution, prompt, request seed, inference step count,
+guidance scale, and device profile. Precision/order changes may change final
+pixel bytes; treat that as acceptable drift when the resolution and request
+settings stay fixed.

--- a/examples/show-o2-1.5B-HQ-macbook/benchmark/benchmark.py
+++ b/examples/show-o2-1.5B-HQ-macbook/benchmark/benchmark.py
@@ -1,0 +1,484 @@
+"""HTTP benchmark for a Show-o2 image generation server.
+
+The server contract is intentionally simple and OpenAI-like:
+
+    POST /v1/images/generations
+    {"prompt": "...", "num_inference_steps": 20, "guidance_scale": 5.0}
+
+The response must include `data[0].b64_json` containing PNG bytes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import json
+import math
+import random
+import struct
+import time
+from pathlib import Path
+from statistics import mean
+
+import httpx
+
+
+PROMPT_POOL = [
+    "a small red robot holding a handwritten sign that says VibeServe",
+    "a studio product photo of a ceramic mug shaped like a rocket",
+    "a watercolor landscape with a lighthouse at sunrise",
+    "a close-up macro photo of a translucent blue mechanical keyboard switch",
+    "a clean app icon for an AI inference server, white background",
+]
+
+
+def select_prompt(args: argparse.Namespace, rng: random.Random, idx: int, *, warmup: bool = False) -> str:
+    if args.prompt is not None:
+        return args.prompt
+    if warmup:
+        return PROMPT_POOL[idx % len(PROMPT_POOL)]
+    return rng.choice(PROMPT_POOL)
+
+
+def request_seed_for(args: argparse.Namespace, idx: int) -> int | None:
+    if args.request_seed is None:
+        return None
+    if args.fixed_request_seed:
+        return args.request_seed
+    return args.request_seed + idx
+
+
+def image_dimensions(image_bytes: bytes) -> tuple[int, int]:
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n") and image_bytes[12:16] == b"IHDR":
+        width, height = struct.unpack(">II", image_bytes[16:24])
+        return int(width), int(height)
+    if image_bytes.startswith(b"P6"):
+        header_parts = image_bytes.split(None, 4)
+        if len(header_parts) >= 4 and header_parts[0] == b"P6" and header_parts[3] == b"255":
+            return int(header_parts[1]), int(header_parts[2])
+    raise ValueError("response image is not a PNG or PPM")
+
+
+async def send_request(
+    client: httpx.AsyncClient,
+    url: str,
+    prompt: str,
+    steps: int,
+    guidance_scale: float,
+    seed: int | None,
+    timeout: float,
+    collect_server_timings: bool,
+    postprocess_mode: str | None,
+    response_format: str,
+    image_save_path: Path | None = None,
+) -> dict:
+    body = {
+        "prompt": prompt,
+        "num_inference_steps": steps,
+        "guidance_scale": guidance_scale,
+    }
+    if seed is not None:
+        body["seed"] = seed
+    if collect_server_timings:
+        body["include_timings"] = True
+    if postprocess_mode is not None:
+        body["postprocess_mode"] = postprocess_mode
+    if response_format != "b64_json":
+        body["response_format"] = response_format
+
+    started = time.perf_counter()
+    try:
+        resp = await client.post(url, json=body, timeout=timeout)
+        resp.raise_for_status()
+        if response_format in {"png", "ppm"}:
+            image_bytes = resp.content
+            timings_header = resp.headers.get("X-ShowO2-Timings-Ms", "{}")
+            server_timings = json.loads(timings_header) if collect_server_timings else {}
+        else:
+            payload = resp.json()
+            b64 = payload["data"][0]["b64_json"]
+            image_bytes = base64.b64decode(b64)
+            server_timings = payload.get("timings_ms", {}) if collect_server_timings else {}
+        width, height = image_dimensions(image_bytes)
+        if image_save_path is not None:
+            image_save_path.parent.mkdir(parents=True, exist_ok=True)
+            image_save_path.write_bytes(image_bytes)
+        return {
+            "error": None,
+            "latency": time.perf_counter() - started,
+            "image_bytes": len(image_bytes),
+            "image_width": width,
+            "image_height": height,
+            "image_sha256": hashlib.sha256(image_bytes).hexdigest(),
+            "image_path": str(image_save_path) if image_save_path is not None else None,
+            "server_timings": server_timings,
+        }
+    except Exception as exc:
+        return {
+            "error": str(exc),
+            "latency": time.perf_counter() - started,
+            "image_bytes": 0,
+            "image_width": 0,
+            "image_height": 0,
+            "image_sha256": None,
+            "image_path": None,
+            "server_timings": {},
+        }
+
+
+def image_save_path(args: argparse.Namespace, phase: str, idx: int) -> Path | None:
+    if args.save_images_dir is None:
+        return None
+    suffix = "ppm" if args.response_format == "ppm" else "png"
+    return Path(args.save_images_dir) / f"{phase}_{idx:04d}.{suffix}"
+
+
+def percentile(sorted_vals: list[float], p: float) -> float:
+    if not sorted_vals:
+        return float("nan")
+    k = (len(sorted_vals) - 1) * p / 100.0
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return sorted_vals[int(k)]
+    return sorted_vals[f] * (c - k) + sorted_vals[c] * (k - f)
+
+
+def stats(values: list[float], multiplier: float = 1.0) -> dict | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    return {
+        "mean": mean(ordered) * multiplier,
+        "p50": percentile(ordered, 50) * multiplier,
+        "p90": percentile(ordered, 90) * multiplier,
+        "p95": percentile(ordered, 95) * multiplier,
+        "p99": percentile(ordered, 99) * multiplier,
+    }
+
+
+def server_timing_stats(results: list[dict]) -> dict[str, dict]:
+    successes = [r for r in results if r["error"] is None]
+    timing_keys = sorted(
+        {
+            key
+            for result in successes
+            for key, value in result.get("server_timings", {}).items()
+            if isinstance(value, (int, float))
+        }
+    )
+    return {
+        key: stats(
+            [
+                float(result["server_timings"][key])
+                for result in successes
+                if isinstance(result.get("server_timings", {}).get(key), (int, float))
+            ]
+        )
+        for key in timing_keys
+    }
+
+
+def summarize_results(results: list[dict], wall_clock: float) -> dict:
+    successes = [r for r in results if r["error"] is None]
+    errors = [r for r in results if r["error"] is not None]
+    latencies = [r["latency"] for r in successes]
+    image_sizes = [r["image_bytes"] for r in successes]
+    image_widths = [r["image_width"] for r in successes]
+    image_heights = [r["image_height"] for r in successes]
+    image_hashes = [r["image_sha256"] for r in successes if r.get("image_sha256")]
+    image_paths = [r["image_path"] for r in successes if r.get("image_path")]
+    return {
+        "num_requests": len(results),
+        "num_completed": len(successes),
+        "num_failed": len(errors),
+        "actual_duration": wall_clock,
+        "request_throughput": len(successes) / wall_clock if wall_clock > 0 else 0,
+        "latency": stats(latencies, multiplier=1000.0),
+        "image_bytes": stats(image_sizes),
+        "image_width": stats(image_widths),
+        "image_height": stats(image_heights),
+        "image_sha256": image_hashes,
+        "unique_image_sha256": sorted(set(image_hashes)),
+        "image_paths": image_paths,
+        "server_timings": server_timing_stats(results),
+    }
+
+
+async def run_warmup(client: httpx.AsyncClient, args: argparse.Namespace, url: str) -> tuple[list[dict], float]:
+    if args.warmup_requests <= 0:
+        return [], 0.0
+
+    results = []
+    warmup_start = time.perf_counter()
+    for idx in range(args.warmup_requests):
+        prompt = select_prompt(args, random.Random(args.seed), idx, warmup=True)
+        request_seed = request_seed_for(args, idx)
+        results.append(
+            await send_request(
+                client,
+                url,
+                prompt,
+                args.steps,
+                args.guidance_scale,
+                request_seed,
+                args.timeout,
+                args.collect_server_timings,
+                args.postprocess_mode,
+                args.response_format,
+                image_save_path(args, "warmup", idx),
+            )
+        )
+    return results, time.perf_counter() - warmup_start
+
+
+async def run_closed_loop(
+    client: httpx.AsyncClient,
+    args: argparse.Namespace,
+    url: str,
+    rng: random.Random,
+    total_requests: int,
+    use_duration: bool,
+    bench_start: float,
+) -> list[dict]:
+    results = []
+    sent = 0
+    while sent < total_requests:
+        if use_duration and (time.perf_counter() - bench_start) >= args.duration:
+            break
+        prompt = select_prompt(args, rng, sent)
+        request_seed = request_seed_for(args, sent)
+        results.append(
+            await send_request(
+                client,
+                url,
+                prompt,
+                args.steps,
+                args.guidance_scale,
+                request_seed,
+                args.timeout,
+                args.collect_server_timings,
+                args.postprocess_mode,
+                args.response_format,
+                image_save_path(args, "request", sent),
+            )
+        )
+        sent += 1
+    return results
+
+
+async def run_open_loop(
+    client: httpx.AsyncClient,
+    args: argparse.Namespace,
+    url: str,
+    rng: random.Random,
+    total_requests: int,
+    use_duration: bool,
+    bench_start: float,
+) -> list[dict]:
+    tasks: list[asyncio.Task] = []
+    sent = 0
+    while sent < total_requests:
+        if use_duration and (time.perf_counter() - bench_start) >= args.duration:
+            break
+        prompt = select_prompt(args, rng, sent)
+        request_seed = request_seed_for(args, sent)
+        tasks.append(
+            asyncio.create_task(
+                send_request(
+                    client,
+                    url,
+                    prompt,
+                    args.steps,
+                    args.guidance_scale,
+                    request_seed,
+                    args.timeout,
+                    args.collect_server_timings,
+                    args.postprocess_mode,
+                    args.response_format,
+                    image_save_path(args, "request", sent),
+                )
+            )
+        )
+        sent += 1
+        if sent < total_requests:
+            delay = -math.log(1.0 - rng.random()) / args.rate
+            if use_duration:
+                remaining = args.duration - (time.perf_counter() - bench_start)
+                if remaining <= 0:
+                    break
+                delay = min(delay, remaining)
+            await asyncio.sleep(delay)
+    return await asyncio.gather(*tasks)
+
+
+async def run_benchmark(args: argparse.Namespace) -> dict:
+    rng = random.Random(args.seed)
+    url = args.url.rstrip("/") + args.endpoint
+    total_requests = args.num_requests if args.num_requests is not None else 10**9
+    use_duration = args.num_requests is None
+
+    async with httpx.AsyncClient() as client:
+        warmup_results, warmup_duration = await run_warmup(client, args, url)
+        bench_start = time.perf_counter()
+        if args.closed_loop:
+            results = await run_closed_loop(
+                client,
+                args,
+                url,
+                rng,
+                total_requests,
+                use_duration,
+                bench_start,
+            )
+        else:
+            results = await run_open_loop(
+                client,
+                args,
+                url,
+                rng,
+                total_requests,
+                use_duration,
+                bench_start,
+            )
+        bench_end = time.perf_counter()
+
+    wall_clock = bench_end - bench_start
+    successes = [r for r in results if r["error"] is None]
+    errors = [r for r in results if r["error"] is not None]
+    latencies = [r["latency"] for r in successes]
+    image_sizes = [r["image_bytes"] for r in successes]
+    measured_summary = summarize_results(results, wall_clock)
+
+    print()
+    print("=" * 40)
+    print("  Show-o2 Benchmark Results")
+    print("=" * 40)
+    print(f"Endpoint:          {url}")
+    print(f"Mode:              {'closed-loop' if args.closed_loop else 'open-loop'}")
+    if warmup_results:
+        warmup_summary = summarize_results(warmup_results, warmup_duration)
+        print(
+            "Warmup:           "
+            f"{warmup_summary['num_completed']}/{warmup_summary['num_requests']} requests "
+            f"({warmup_summary['num_failed']} errors, {warmup_duration:.2f}s)"
+        )
+    print(f"Duration:          {wall_clock:.2f}s")
+    print(f"Completed:         {len(successes)}/{len(results)} requests ({len(errors)} errors)")
+    print(f"Request throughput:{len(successes) / wall_clock if wall_clock > 0 else 0:.2f} req/s")
+    if latencies:
+        latency_ms = stats(latencies, multiplier=1000.0)
+        print(f"Latency mean:      {latency_ms['mean']:.1f} ms")
+        print(f"Latency p90:       {latency_ms['p90']:.1f} ms")
+    if measured_summary["server_timings"]:
+        total_timing = measured_summary["server_timings"].get("total_ms")
+        if total_timing:
+            print(f"Server total mean: {total_timing['mean']:.1f} ms")
+    if errors:
+        print("Errors:")
+        for idx, err in enumerate(errors[:5]):
+            print(f"  [{idx}] {err['error'][:160]}")
+
+    result = {
+        "config": {
+            "url": url,
+            "rate": args.rate,
+            "duration": args.duration,
+            "steps": args.steps,
+            "guidance_scale": args.guidance_scale,
+            "prompt": args.prompt,
+            "seed": args.seed,
+            "request_seed": args.request_seed,
+            "fixed_request_seed": args.fixed_request_seed,
+            "warmup_requests": args.warmup_requests,
+            "closed_loop": args.closed_loop,
+            "collect_server_timings": args.collect_server_timings,
+            "postprocess_mode": args.postprocess_mode,
+            "response_format": args.response_format,
+            "save_images_dir": args.save_images_dir,
+        },
+        "warmup": summarize_results(warmup_results, warmup_duration),
+        "num_requests": len(results),
+        "num_completed": len(successes),
+        "num_failed": len(errors),
+        "actual_duration": wall_clock,
+        "request_throughput": len(successes) / wall_clock if wall_clock > 0 else 0,
+        "latency": stats(latencies, multiplier=1000.0),
+        "image_bytes": stats(image_sizes),
+        "image_width": measured_summary["image_width"],
+        "image_height": measured_summary["image_height"],
+        "image_sha256": measured_summary["image_sha256"],
+        "unique_image_sha256": measured_summary["unique_image_sha256"],
+        "image_paths": measured_summary["image_paths"],
+        "server_timings": measured_summary["server_timings"],
+    }
+
+    if args.output_json:
+        with open(args.output_json, "w") as f:
+            json.dump(result, f, indent=2)
+        print(f"Results written to {args.output_json}")
+
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark a Show-o2 HTTP image server.")
+    parser.add_argument("--url", default="http://localhost:8000", help="Server base URL")
+    parser.add_argument("--endpoint", default="/v1/images/generations", help="Endpoint path")
+    parser.add_argument("--rate", type=float, default=1.0, help="Request rate in req/s")
+    parser.add_argument("--duration", type=float, default=60.0, help="Duration when num requests is unset")
+    parser.add_argument("--num-requests", type=int, default=None, help="Total requests")
+    parser.add_argument(
+        "--closed-loop",
+        action="store_true",
+        help="Send each measured request after the previous one finishes instead of open-loop rate scheduling",
+    )
+    parser.add_argument(
+        "--collect-server-timings",
+        action="store_true",
+        help="Ask the server to include per-request timings_ms and aggregate them",
+    )
+    parser.add_argument(
+        "--postprocess-mode",
+        choices=["upstream", "cpu", "native"],
+        default=None,
+        help="Optional server postprocess mode override for image requests",
+    )
+    parser.add_argument(
+        "--response-format",
+        default="b64_json",
+        choices=["b64_json", "png", "ppm"],
+        help="Response format to request from the server.",
+    )
+    parser.add_argument(
+        "--warmup-requests",
+        type=int,
+        default=0,
+        help="Requests to run before measurement and exclude from latency/throughput stats",
+    )
+    parser.add_argument("--steps", type=int, default=20, help="Diffusion inference steps per request")
+    parser.add_argument("--guidance-scale", type=float, default=5.0, help="Classifier-free guidance scale")
+    parser.add_argument("--prompt", type=str, default=None, help="Fixed prompt for every benchmark request")
+    parser.add_argument("--seed", type=int, default=42, help="Benchmark scheduling seed")
+    parser.add_argument("--request-seed", type=int, default=None, help="Base model seed for deterministic requests")
+    parser.add_argument(
+        "--fixed-request-seed",
+        action="store_true",
+        help="Use request seed unchanged for every request instead of incrementing it by request index",
+    )
+    parser.add_argument("--timeout", type=float, default=600.0, help="Per-request timeout in seconds")
+    parser.add_argument("--output-json", type=str, default=None, help="Write structured result JSON")
+    parser.add_argument(
+        "--save-images-dir",
+        type=str,
+        default=None,
+        help="Save completed warmup and measured response PNGs into this directory",
+    )
+    args = parser.parse_args()
+    asyncio.run(run_benchmark(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/show-o2-1.5B-HQ-macbook/benchmark/compare_images.py
+++ b/examples/show-o2-1.5B-HQ-macbook/benchmark/compare_images.py
@@ -1,0 +1,192 @@
+"""Compare two generated PNGs for pixel and perceptual drift."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_rgb(path: Path) -> np.ndarray:
+    return np.asarray(Image.open(path).convert("RGB"), dtype=np.float64)
+
+
+def box_filter(image: np.ndarray, size: int) -> np.ndarray:
+    pad_before = size // 2
+    pad_after = size - 1 - pad_before
+    padded = np.pad(image, ((pad_before, pad_after), (pad_before, pad_after)), mode="reflect")
+    integral = np.pad(padded, ((1, 0), (1, 0)), mode="constant").cumsum(axis=0).cumsum(axis=1)
+    return (
+        integral[size:, size:]
+        - integral[:-size, size:]
+        - integral[size:, :-size]
+        + integral[:-size, :-size]
+    ) / float(size * size)
+
+
+def rgb_to_luma(image: np.ndarray) -> np.ndarray:
+    return image[..., 0] * 0.299 + image[..., 1] * 0.587 + image[..., 2] * 0.114
+
+
+def local_ssim(a: np.ndarray, b: np.ndarray, window_size: int = 11) -> float | None:
+    if a.shape != b.shape:
+        return None
+    if min(a.shape[:2]) < window_size:
+        window_size = max(1, min(a.shape[:2]))
+        if window_size % 2 == 0:
+            window_size -= 1
+    if window_size <= 1:
+        return 1.0 if np.array_equal(a, b) else None
+
+    x = rgb_to_luma(a)
+    y = rgb_to_luma(b)
+    c1 = (0.01 * 255.0) ** 2
+    c2 = (0.03 * 255.0) ** 2
+
+    mu_x = box_filter(x, window_size)
+    mu_y = box_filter(y, window_size)
+    mu_x2 = mu_x * mu_x
+    mu_y2 = mu_y * mu_y
+    mu_xy = mu_x * mu_y
+
+    sigma_x2 = box_filter(x * x, window_size) - mu_x2
+    sigma_y2 = box_filter(y * y, window_size) - mu_y2
+    sigma_xy = box_filter(x * y, window_size) - mu_xy
+
+    numerator = (2.0 * mu_xy + c1) * (2.0 * sigma_xy + c2)
+    denominator = (mu_x2 + mu_y2 + c1) * (sigma_x2 + sigma_y2 + c2)
+    return float(np.mean(numerator / denominator))
+
+
+def pixel_metrics(a: np.ndarray, b: np.ndarray) -> dict[str, Any]:
+    if a.shape != b.shape:
+        return {
+            "same_dimensions": False,
+            "baseline_shape": list(a.shape),
+            "candidate_shape": list(b.shape),
+        }
+
+    diff = a - b
+    abs_diff = np.abs(diff)
+    mse = float(np.mean(diff * diff))
+    rmse = math.sqrt(mse)
+    psnr = None if mse == 0.0 else 20.0 * math.log10(255.0 / rmse)
+    changed_channels = abs_diff > 0.0
+    changed_pixels = np.any(changed_channels, axis=2)
+    return {
+        "same_dimensions": True,
+        "width": int(a.shape[1]),
+        "height": int(a.shape[0]),
+        "mae": float(np.mean(abs_diff)),
+        "normalized_mae": float(np.mean(abs_diff) / 255.0),
+        "rmse": rmse,
+        "normalized_rmse": rmse / 255.0,
+        "max_abs_diff": float(np.max(abs_diff)),
+        "changed_channel_fraction": float(np.mean(changed_channels)),
+        "changed_pixel_fraction": float(np.mean(changed_pixels)),
+        "psnr_db": psnr,
+        "psnr_is_infinite": mse == 0.0,
+        "ssim_luma": local_ssim(a, b),
+    }
+
+
+def clip_metrics(
+    baseline: Path,
+    candidate: Path,
+    prompt: str | None,
+    model_name: str,
+    allow_download: bool,
+) -> dict[str, Any]:
+    try:
+        import torch
+        from transformers import CLIPModel, CLIPProcessor
+    except Exception as exc:  # pragma: no cover - depends on optional deps
+        return {"enabled": False, "error": f"CLIP dependencies unavailable: {exc}"}
+
+    try:
+        processor = CLIPProcessor.from_pretrained(model_name, local_files_only=not allow_download)
+        model = CLIPModel.from_pretrained(model_name, local_files_only=not allow_download)
+    except Exception as exc:  # pragma: no cover - depends on local model cache
+        return {"enabled": False, "error": f"CLIP model unavailable: {exc}"}
+
+    images = [Image.open(baseline).convert("RGB"), Image.open(candidate).convert("RGB")]
+    with torch.inference_mode():
+        image_inputs = processor(images=images, return_tensors="pt")
+        image_features = model.get_image_features(**image_inputs)
+        image_features = image_features / image_features.norm(dim=-1, keepdim=True)
+        image_cosine = float((image_features[0] * image_features[1]).sum().item())
+
+        result: dict[str, Any] = {
+            "enabled": True,
+            "model": model_name,
+            "image_cosine": image_cosine,
+        }
+        if prompt:
+            text_inputs = processor(text=[prompt], return_tensors="pt", padding=True)
+            text_features = model.get_text_features(**text_inputs)
+            text_features = text_features / text_features.norm(dim=-1, keepdim=True)
+            result["baseline_prompt_cosine"] = float((image_features[0] * text_features[0]).sum().item())
+            result["candidate_prompt_cosine"] = float((image_features[1] * text_features[0]).sum().item())
+    return result
+
+
+def compare(args: argparse.Namespace) -> dict[str, Any]:
+    baseline = Path(args.baseline)
+    candidate = Path(args.candidate)
+    baseline_array = load_rgb(baseline)
+    candidate_array = load_rgb(candidate)
+    result = {
+        "baseline": str(baseline),
+        "candidate": str(candidate),
+        "baseline_sha256": sha256_file(baseline),
+        "candidate_sha256": sha256_file(candidate),
+        "exact_match": baseline.read_bytes() == candidate.read_bytes(),
+        "pixel": pixel_metrics(baseline_array, candidate_array),
+    }
+    if args.clip_model:
+        result["clip"] = clip_metrics(
+            baseline,
+            candidate,
+            args.prompt,
+            args.clip_model,
+            args.allow_clip_download,
+        )
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare two generated PNG images.")
+    parser.add_argument("--baseline", required=True, help="Baseline PNG path")
+    parser.add_argument("--candidate", required=True, help="Candidate PNG path")
+    parser.add_argument("--prompt", default=None, help="Optional prompt for CLIP prompt-image scoring")
+    parser.add_argument(
+        "--clip-model",
+        default=None,
+        help="Optional local Hugging Face CLIP model id/path, for example openai/clip-vit-base-patch32",
+    )
+    parser.add_argument(
+        "--allow-clip-download",
+        action="store_true",
+        help="Allow downloading the requested CLIP model if it is not already cached locally",
+    )
+    parser.add_argument("--output-json", default=None, help="Write structured comparison JSON")
+    args = parser.parse_args()
+
+    result = compare(args)
+    print(json.dumps(result, indent=2))
+    if args.output_json:
+        Path(args.output_json).write_text(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/show-o2-1.5B-HQ-macbook/config.json
+++ b/examples/show-o2-1.5B-HQ-macbook/config.json
@@ -1,0 +1,14 @@
+{
+  "model_id": "showlab/show-o2-1.5B-HQ",
+  "revision": "d3a220ec55feaacbdfcb053847edee14edd4e69a",
+  "task": "text-to-image",
+  "reference": "reference",
+  "benchmark": "benchmark",
+  "accuracy_checker": "accuracy_checker",
+  "served_endpoints": [
+    "/health",
+    "/v1/images/generations",
+    "/v1/completions"
+  ],
+  "default_endpoint": "/v1/images/generations"
+}

--- a/examples/show-o2-1.5B-HQ-macbook/reference/README.md
+++ b/examples/show-o2-1.5B-HQ-macbook/reference/README.md
@@ -1,0 +1,13 @@
+Reference bundle for Show-o2 1.5B HQ.
+
+Required files:
+- `reference.py` — local loader and generation wrapper
+- `config.json` — Show-o2 model config copied from the HF checkpoint
+- `meta.json` — pinned model and Wan VAE metadata
+- `Show-o/` — git submodule for the official Show-o repository, pinned to
+  commit `45a5a2de01d1ebd10cd5864d29310a76476cdf23`; the wrapper imports from
+  its `show-o2/` subdirectory
+
+The wrapper exposes `ShowO2Model.from_pretrained(...)`, `generate_text(...)`,
+and `generate_image(...)`. It lazily downloads weights if `reference/model`
+does not exist.

--- a/examples/show-o2-1.5B-HQ-macbook/reference/config.json
+++ b/examples/show-o2-1.5B-HQ-macbook/reference/config.json
@@ -1,0 +1,19 @@
+{
+  "_class_name": "Showo2Qwen2_5",
+  "_diffusers_version": "0.31.0",
+  "add_qk_norm": true,
+  "add_time_embeds": true,
+  "clip_latent_dim": 1152,
+  "clip_pretrained_model_path": "google/siglip-so400m-patch14-384",
+  "hidden_size": 1536,
+  "image_latent_dim": 16,
+  "image_latent_height": 27,
+  "image_latent_width": 27,
+  "llm_model_path": "Qwen/Qwen2.5-1.5B-Instruct",
+  "llm_vocab_size": 151669,
+  "load_from_showo": true,
+  "num_diffusion_layers": 10,
+  "patch_size": 2,
+  "video_latent_height": 27,
+  "video_latent_width": 27
+}

--- a/examples/show-o2-1.5B-HQ-macbook/reference/meta.json
+++ b/examples/show-o2-1.5B-HQ-macbook/reference/meta.json
@@ -1,0 +1,16 @@
+{
+  "model_id": "showlab/show-o2-1.5B-HQ",
+  "revision": "d3a220ec55feaacbdfcb053847edee14edd4e69a",
+  "model_file": "pytorch_model.bin",
+  "official_source": {
+    "repo": "https://github.com/showlab/Show-o",
+    "subdir": "show-o2",
+    "revision": "45a5a2de01d1ebd10cd5864d29310a76476cdf23"
+  },
+  "wan_vae": {
+    "model_id": "Wan-AI/Wan2.1-T2V-14B",
+    "revision": "a064a6c71f5be440641209c07bf2a5ce7a2ff5e4",
+    "filename": "Wan2.1_VAE.pth",
+    "sha256": "38071ab59bd94681c686fa51d75a1968f64e470262043be31f7a094e442fd981"
+  }
+}

--- a/examples/show-o2-1.5B-HQ-macbook/reference/reference.py
+++ b/examples/show-o2-1.5B-HQ-macbook/reference/reference.py
@@ -1,0 +1,1027 @@
+"""Reference loader and inference wrapper for showlab/show-o2-1.5B-HQ.
+
+The official Show-o2 repository is not packaged on PyPI, so this reference
+bundle imports it from the pinned `Show-o` git submodule. Model weights stay
+outside git and are resolved from Hugging Face using `meta.json`.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+REFERENCE_DIR = Path(__file__).resolve().parent
+DEFAULT_SOURCE_DIR = REFERENCE_DIR / "Show-o" / "show-o2"
+DEFAULT_MODEL_DIR = REFERENCE_DIR / "model"
+DEFAULT_RESOLUTION = 512
+
+
+def _repo_root() -> Path:
+    return REFERENCE_DIR.parent.parent.parent
+
+
+def _read_meta() -> dict[str, Any]:
+    return json.loads((REFERENCE_DIR / "meta.json").read_text())
+
+
+def configure_environment_for_device(device: str) -> None:
+    if device == "auto" or str(device).startswith("mps"):
+        os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+
+def _add_source_to_path(source_dir: Path) -> None:
+    source_dir = source_dir.resolve()
+    if not (source_dir / "models").is_dir() or not (source_dir / "transport").is_dir():
+        raise FileNotFoundError(f"Show-o2 source directory is incomplete: {source_dir}")
+    source_text = str(source_dir)
+    if source_text not in sys.path:
+        sys.path.insert(0, source_text)
+
+
+def _config_path_for_resolution(source_dir: Path, resolution: int) -> Path:
+    configs = {
+        432: "showo2_1.5b_demo_432x432.yaml",
+        512: "showo2_1.5b_demo_512x512.yaml",
+        1024: "showo2_1.5b_demo_1024x1024.yaml",
+    }
+    try:
+        name = configs[int(resolution)]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported Show-o2 resolution: {resolution}") from exc
+    return source_dir / "configs" / name
+
+
+def resolve_device(device: str = "auto"):
+    import torch
+
+    if device != "auto":
+        return torch.device(device)
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def empty_device_cache(device) -> None:
+    import torch
+
+    if device.type == "cuda":
+        torch.cuda.empty_cache()
+    elif device.type == "mps" and hasattr(torch, "mps"):
+        torch.mps.empty_cache()
+
+
+def synchronize_device(device) -> None:
+    import torch
+
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    elif device.type == "mps" and hasattr(torch, "mps") and hasattr(torch.mps, "synchronize"):
+        torch.mps.synchronize()
+
+
+def resolve_dtype(dtype: str = "auto", device=None):
+    import torch
+
+    if dtype == "auto":
+        if device is not None and device.type == "mps":
+            return torch.float16
+        if device is not None and device.type == "cpu":
+            return torch.float32
+        return torch.bfloat16
+    mapping = {
+        "bfloat16": torch.bfloat16,
+        "bf16": torch.bfloat16,
+        "float16": torch.float16,
+        "fp16": torch.float16,
+        "float32": torch.float32,
+        "fp32": torch.float32,
+    }
+    try:
+        return mapping[dtype]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported dtype: {dtype}") from exc
+
+
+def ensure_model_dir(model_dir: str | Path | None = None) -> Path:
+    """Return a local Show-o2 checkpoint directory, downloading if needed."""
+    if model_dir is not None:
+        candidate = Path(model_dir).expanduser().resolve()
+        if candidate.exists():
+            return candidate
+        if candidate != DEFAULT_MODEL_DIR.resolve():
+            raise FileNotFoundError(f"Model directory does not exist: {candidate}")
+
+    if DEFAULT_MODEL_DIR.exists():
+        return DEFAULT_MODEL_DIR.resolve()
+
+    meta = _read_meta()
+    from huggingface_hub import snapshot_download
+
+    downloaded = Path(
+        snapshot_download(
+            meta["model_id"],
+            revision=meta.get("revision"),
+            cache_dir=str(_repo_root() / ".hf_cache"),
+        )
+    )
+    try:
+        DEFAULT_MODEL_DIR.symlink_to(downloaded, target_is_directory=True)
+        return DEFAULT_MODEL_DIR.resolve()
+    except FileExistsError:
+        return DEFAULT_MODEL_DIR.resolve()
+    except OSError:
+        return downloaded
+
+
+def ensure_wan_vae(vae_path: str | Path | None = None) -> Path:
+    """Return a local Wan2.1 VAE weight file, downloading if needed."""
+    if vae_path is not None:
+        candidate = Path(vae_path).expanduser().resolve()
+        if candidate.exists():
+            return candidate
+        raise FileNotFoundError(f"Wan VAE path does not exist: {candidate}")
+
+    local = REFERENCE_DIR / "Wan2.1_VAE.pth"
+    if local.exists():
+        return local.resolve()
+
+    meta = _read_meta()["wan_vae"]
+    from huggingface_hub import hf_hub_download
+
+    return Path(
+        hf_hub_download(
+            repo_id=meta["model_id"],
+            filename=meta["filename"],
+            revision=meta.get("revision"),
+            cache_dir=str(_repo_root() / ".hf_cache"),
+        )
+    )
+
+
+def pil_to_png_bytes(image, *, compress_level: int | None = None) -> bytes:
+    buffer = io.BytesIO()
+    save_kwargs = {}
+    if compress_level is not None:
+        save_kwargs["compress_level"] = int(compress_level)
+    image.save(buffer, format="PNG", **save_kwargs)
+    return buffer.getvalue()
+
+
+def pil_to_base64_png(image, *, compress_level: int | None = None) -> str:
+    return base64.b64encode(
+        pil_to_png_bytes(image, compress_level=compress_level),
+    ).decode("ascii")
+
+
+def resolve_secondary_device(device: str | None, fallback):
+    if device in (None, "same"):
+        return fallback
+    return resolve_device(device)
+
+
+def resolve_secondary_dtype(dtype: str | None, device, fallback):
+    if dtype in (None, "same"):
+        return fallback
+    return resolve_dtype(dtype, device)
+
+
+def denorm_cpu_first(images):
+    import numpy as np
+
+    arrays = images.detach().cpu().permute(0, 2, 3, 1).numpy()
+    return np.clip((arrays + 1.0) * 127.5, 0.0, 255.0).astype(np.uint8)
+
+
+def denorm_float32_first(images):
+    import numpy as np
+    import torch
+
+    images = images.to(torch.float32)
+    images = torch.clamp((images + 1.0) / 2.0, min=0.0, max=1.0)
+    images *= 255.0
+    return images.permute(0, 2, 3, 1).cpu().numpy().astype(np.uint8)
+
+
+def denorm_native(images):
+    import numpy as np
+    import torch
+
+    images = torch.clamp((images + 1.0) * 127.5, min=0.0, max=255.0)
+    images = images.permute(0, 2, 3, 1).cpu()
+    if images.dtype == torch.bfloat16:
+        images = images.to(torch.float32)
+    return images.numpy().astype(np.uint8)
+
+
+def denorm_numpy(images):
+    import numpy as np
+
+    arrays = np.clip((images + 1.0) * 127.5, 0.0, 255.0)
+    return np.transpose(arrays, (0, 2, 3, 1)).astype(np.uint8)
+
+
+@dataclass
+class ShowO2Model:
+    model: Any
+    tokenizer: Any
+    showo_token_ids: dict[str, int]
+    config: Any
+    device: Any
+    dtype: Any
+    source_dir: Path
+    resolution: int = DEFAULT_RESOLUTION
+    vae_path: Path | None = None
+    vae_model: Any | None = None
+    vae_device: Any | None = None
+    vae_dtype: Any | None = None
+    vae_output_dtype: str = "float32"
+    vae_decode_mode: str = "video"
+    vae_conv2d_tail_start: int = 12
+    vae_conv2d_tail_max_modules: int | None = None
+    vae_upsample_mode: str = "default"
+    vae_trace_decoder: bool = False
+    vae_decoder_backend: str = "torch"
+    vae_coreml_model_path: str | None = None
+    vae_coreml_compute_units: str = "all"
+    vae_coreml_optimization_hints: str = "none"
+    vae_coreml_input_rank: int = 5
+    vae_mlx_dtype: str = "float16"
+    vae_mlx_compile: bool = True
+    vae_mlx_low_rank_highres_rank: int = 64
+    vae_mlx_low_rank_highres_min_size: int = 512
+    vae_mlx_low_rank_highres_tail_rank: int | None = 36
+    vae_mlx_low_rank_highres_tail_start_layer: int = 14
+    vae_mlx_low_rank_override_layer: int | None = None
+    vae_mlx_low_rank_override_conv_index: int | None = None
+    vae_mlx_low_rank_override_rank: int | None = None
+    vae_mlx_approx_highres_residual_start_layer: int | None = None
+    vae_mlx_approx_highres_residual_end_layer: int | None = None
+    vae_mlx_approx_highres_residual_mode: str = "full"
+    vae_mlx_low_rank_pointwise_impl: str = "conv2d"
+    vae_profile: bool = False
+    postprocess_mode: str = "upstream"
+    _sample_fn_cache: dict[tuple[int, int], Any] = field(default_factory=dict, repr=False)
+    _attention_base_mask_cache: dict[tuple[int, int, str, str], Any] = field(
+        default_factory=dict,
+        repr=False,
+    )
+    _attention_mask_cache: dict[tuple[Any, ...], Any] = field(default_factory=dict, repr=False)
+    _attention_mask_identity_cache: dict[tuple[Any, ...], Any] = field(default_factory=dict, repr=False)
+    _prepared_prompt_cache: dict[tuple[Any, ...], tuple[Any, Any]] = field(
+        default_factory=dict,
+        repr=False,
+    )
+    last_image_timings_ms: dict[str, float] = field(default_factory=dict, repr=False)
+    prewarm_timings_ms: dict[str, float] | None = field(default=None, repr=False)
+    image_component_prewarm_timings_ms: dict[str, float] | None = field(default=None, repr=False)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_dir: str | Path | None = None,
+        *,
+        source_dir: str | Path | None = None,
+        vae_path: str | Path | None = None,
+        device: str = "auto",
+        dtype: str = "auto",
+        vae_device: str = "same",
+        vae_dtype: str = "same",
+        vae_output_dtype: str = "float32",
+        vae_decode_mode: str = "video",
+        vae_conv2d_tail_start: int = 12,
+        vae_conv2d_tail_max_modules: int | None = None,
+        vae_upsample_mode: str = "default",
+        vae_trace_decoder: bool = False,
+        vae_decoder_backend: str = "torch",
+        vae_coreml_model_path: str | None = None,
+        vae_coreml_compute_units: str = "all",
+        vae_coreml_optimization_hints: str = "none",
+        vae_coreml_input_rank: int = 5,
+        vae_mlx_dtype: str = "float16",
+        vae_mlx_compile: bool = True,
+        vae_mlx_low_rank_highres_rank: int = 64,
+        vae_mlx_low_rank_highres_min_size: int = 512,
+        vae_mlx_low_rank_highres_tail_rank: int | None = 36,
+        vae_mlx_low_rank_highres_tail_start_layer: int = 14,
+        vae_mlx_low_rank_override_layer: int | None = None,
+        vae_mlx_low_rank_override_conv_index: int | None = None,
+        vae_mlx_low_rank_override_rank: int | None = None,
+        vae_mlx_approx_highres_residual_start_layer: int | None = None,
+        vae_mlx_approx_highres_residual_end_layer: int | None = None,
+        vae_mlx_approx_highres_residual_mode: str = "full",
+        vae_mlx_low_rank_pointwise_impl: str = "conv2d",
+        vae_profile: bool = False,
+        postprocess_mode: str = "upstream",
+        resolution: int = DEFAULT_RESOLUTION,
+        load_vae: bool = False,
+    ) -> "ShowO2Model":
+        if postprocess_mode not in {"upstream", "cpu", "native"}:
+            raise ValueError(f"Unsupported postprocess mode: {postprocess_mode}")
+        if vae_output_dtype not in {"float32", "native", "deferred"}:
+            raise ValueError(f"Unsupported VAE output dtype: {vae_output_dtype}")
+        if vae_decode_mode not in {"video", "image", "image-conv2d", "image-conv2d-tail"}:
+            raise ValueError(f"Unsupported VAE decode mode: {vae_decode_mode}")
+        if vae_conv2d_tail_start < 0:
+            raise ValueError(f"Unsupported VAE conv2d tail start: {vae_conv2d_tail_start}")
+        if vae_conv2d_tail_max_modules is not None and vae_conv2d_tail_max_modules < 0:
+            raise ValueError(f"Unsupported VAE conv2d tail max modules: {vae_conv2d_tail_max_modules}")
+        if vae_upsample_mode not in {"default", "convtranspose"}:
+            raise ValueError(f"Unsupported VAE upsample mode: {vae_upsample_mode}")
+        if vae_decoder_backend not in {"torch", "coreml", "mlx"}:
+            raise ValueError(f"Unsupported VAE decoder backend: {vae_decoder_backend}")
+        if vae_decoder_backend == "coreml" and not vae_coreml_model_path:
+            raise ValueError("Core ML VAE decoder backend requires vae_coreml_model_path")
+        if vae_coreml_input_rank not in (4, 5):
+            raise ValueError(f"Unsupported Core ML VAE input rank: {vae_coreml_input_rank}")
+        if vae_mlx_dtype not in {"float32", "float16", "bfloat16"}:
+            raise ValueError(f"Unsupported MLX VAE dtype: {vae_mlx_dtype}")
+        if vae_mlx_low_rank_highres_rank < 0:
+            raise ValueError(f"Unsupported MLX low-rank high-res rank: {vae_mlx_low_rank_highres_rank}")
+        if vae_mlx_low_rank_highres_min_size < 0:
+            raise ValueError(
+                f"Unsupported MLX low-rank high-res min size: {vae_mlx_low_rank_highres_min_size}"
+            )
+        if vae_mlx_low_rank_highres_tail_rank is not None and vae_mlx_low_rank_highres_tail_rank < 0:
+            raise ValueError(
+                f"Unsupported MLX low-rank high-res tail rank: {vae_mlx_low_rank_highres_tail_rank}"
+            )
+        if vae_mlx_low_rank_highres_tail_start_layer < 0:
+            raise ValueError(
+                "Unsupported MLX low-rank high-res tail start layer: "
+                f"{vae_mlx_low_rank_highres_tail_start_layer}"
+            )
+        if vae_mlx_low_rank_override_layer is not None and vae_mlx_low_rank_override_layer < 0:
+            raise ValueError(
+                "Unsupported MLX low-rank override layer: "
+                f"{vae_mlx_low_rank_override_layer}"
+            )
+        if (
+            vae_mlx_low_rank_override_conv_index is not None
+            and vae_mlx_low_rank_override_conv_index not in (0, 1)
+        ):
+            raise ValueError(
+                "Unsupported MLX low-rank override conv index: "
+                f"{vae_mlx_low_rank_override_conv_index}"
+            )
+        if vae_mlx_low_rank_override_rank is not None and vae_mlx_low_rank_override_rank < 0:
+            raise ValueError(
+                "Unsupported MLX low-rank override rank: "
+                f"{vae_mlx_low_rank_override_rank}"
+            )
+        if (
+            vae_mlx_approx_highres_residual_start_layer is not None
+            and vae_mlx_approx_highres_residual_start_layer < 0
+        ):
+            raise ValueError(
+                "Unsupported MLX approximate high-res residual start layer: "
+                f"{vae_mlx_approx_highres_residual_start_layer}"
+            )
+        if (
+            vae_mlx_approx_highres_residual_end_layer is not None
+            and vae_mlx_approx_highres_residual_end_layer < 0
+        ):
+            raise ValueError(
+                "Unsupported MLX approximate high-res residual end layer: "
+                f"{vae_mlx_approx_highres_residual_end_layer}"
+            )
+        if vae_mlx_approx_highres_residual_mode not in {"full", "first-conv", "second-conv"}:
+            raise ValueError(
+                "Unsupported MLX approximate high-res residual mode: "
+                f"{vae_mlx_approx_highres_residual_mode}"
+            )
+        if vae_mlx_low_rank_pointwise_impl not in {"conv2d", "matmul"}:
+            raise ValueError(
+                "Unsupported MLX low-rank pointwise implementation: "
+                f"{vae_mlx_low_rank_pointwise_impl}"
+            )
+        configure_environment_for_device(device)
+        configure_environment_for_device(vae_device)
+        source = Path(source_dir or DEFAULT_SOURCE_DIR).expanduser().resolve()
+        _add_source_to_path(source)
+
+        from models import Showo2Qwen2_5
+        from models.misc import get_text_tokenizer
+        from omegaconf import OmegaConf
+        from utils import get_hyper_params, path_to_llm_name
+
+        resolved_model_dir = ensure_model_dir(model_dir)
+        resolved_device = resolve_device(device)
+        resolved_dtype = resolve_dtype(dtype, resolved_device)
+        resolved_vae_device = resolve_secondary_device(vae_device, resolved_device)
+        resolved_vae_dtype = resolve_secondary_dtype(vae_dtype, resolved_vae_device, resolved_dtype)
+        if vae_decoder_backend == "mlx":
+            import torch
+
+            resolved_vae_device = torch.device("cpu")
+            resolved_vae_dtype = torch.float32
+
+        config = OmegaConf.load(_config_path_for_resolution(source, resolution))
+        config.model.showo.pretrained_model_path = str(resolved_model_dir)
+
+        tokenizer, showo_token_ids = get_text_tokenizer(
+            config.model.showo.llm_model_path,
+            add_showo_tokens=True,
+            return_showo_token_ids=True,
+            llm_name=path_to_llm_name[config.model.showo.llm_model_path],
+        )
+        config.model.showo.llm_vocab_size = len(tokenizer)
+
+        if config.model.showo.add_time_embeds:
+            config.dataset.preprocessing.num_t2i_image_tokens += 1
+            config.dataset.preprocessing.num_mmu_image_tokens += 1
+            config.dataset.preprocessing.num_video_tokens += 1
+
+        model = Showo2Qwen2_5.from_pretrained(
+            str(resolved_model_dir),
+            use_safetensors=False,
+        ).to(resolved_device)
+        model.to(resolved_dtype)
+        model.eval()
+
+        runtime = cls(
+            model=model,
+            tokenizer=tokenizer,
+            showo_token_ids=showo_token_ids,
+            config=config,
+            device=resolved_device,
+            dtype=resolved_dtype,
+            source_dir=source,
+            resolution=resolution,
+            vae_path=(
+                ensure_wan_vae(vae_path)
+                if load_vae and vae_decoder_backend != "coreml"
+                else None
+            ),
+            vae_device=resolved_vae_device,
+            vae_dtype=resolved_vae_dtype,
+            vae_output_dtype=vae_output_dtype,
+            vae_decode_mode=vae_decode_mode,
+            vae_conv2d_tail_start=int(vae_conv2d_tail_start),
+            vae_conv2d_tail_max_modules=vae_conv2d_tail_max_modules,
+            vae_upsample_mode=vae_upsample_mode,
+            vae_trace_decoder=vae_trace_decoder,
+            vae_decoder_backend=vae_decoder_backend,
+            vae_coreml_model_path=vae_coreml_model_path,
+            vae_coreml_compute_units=vae_coreml_compute_units,
+            vae_coreml_optimization_hints=vae_coreml_optimization_hints,
+            vae_coreml_input_rank=int(vae_coreml_input_rank),
+            vae_mlx_dtype=vae_mlx_dtype,
+            vae_mlx_compile=bool(vae_mlx_compile),
+            vae_mlx_low_rank_highres_rank=int(vae_mlx_low_rank_highres_rank),
+            vae_mlx_low_rank_highres_min_size=int(vae_mlx_low_rank_highres_min_size),
+            vae_mlx_low_rank_highres_tail_rank=(
+                None
+                if vae_mlx_low_rank_highres_tail_rank is None
+                else int(vae_mlx_low_rank_highres_tail_rank)
+            ),
+            vae_mlx_low_rank_highres_tail_start_layer=int(vae_mlx_low_rank_highres_tail_start_layer),
+            vae_mlx_low_rank_override_layer=(
+                None
+                if vae_mlx_low_rank_override_layer is None
+                else int(vae_mlx_low_rank_override_layer)
+            ),
+            vae_mlx_low_rank_override_conv_index=(
+                None
+                if vae_mlx_low_rank_override_conv_index is None
+                else int(vae_mlx_low_rank_override_conv_index)
+            ),
+            vae_mlx_low_rank_override_rank=(
+                None
+                if vae_mlx_low_rank_override_rank is None
+                else int(vae_mlx_low_rank_override_rank)
+            ),
+            vae_mlx_approx_highres_residual_start_layer=(
+                None
+                if vae_mlx_approx_highres_residual_start_layer is None
+                else int(vae_mlx_approx_highres_residual_start_layer)
+            ),
+            vae_mlx_approx_highres_residual_end_layer=(
+                None
+                if vae_mlx_approx_highres_residual_end_layer is None
+                else int(vae_mlx_approx_highres_residual_end_layer)
+            ),
+            vae_mlx_approx_highres_residual_mode=vae_mlx_approx_highres_residual_mode,
+            vae_mlx_low_rank_pointwise_impl=vae_mlx_low_rank_pointwise_impl,
+            vae_profile=vae_profile,
+            postprocess_mode=postprocess_mode,
+        )
+        runtime._hyper_params = get_hyper_params(config, tokenizer, showo_token_ids)
+        if load_vae:
+            runtime.load_vae()
+        empty_device_cache(resolved_device)
+        return runtime
+
+    def load_vae(self) -> None:
+        if self.vae_model is not None:
+            return
+        import torch
+
+        _add_source_to_path(self.source_dir)
+        from models import WanVAE
+
+        if self.vae_decoder_backend == "coreml":
+            vae_path = ""
+        else:
+            self.vae_path = self.vae_path or ensure_wan_vae()
+            vae_path = str(self.vae_path)
+        vae_device = "cpu" if self.vae_decoder_backend == "mlx" else (self.vae_device or self.device)
+        vae_dtype = torch.float32 if self.vae_decoder_backend == "mlx" else (self.vae_dtype or self.dtype)
+        self.vae_model = WanVAE(
+            vae_pth=vae_path,
+            dtype=vae_dtype,
+            device=vae_device,
+            output_dtype=self.vae_output_dtype,
+            decode_mode=self.vae_decode_mode,
+            conv2d_tail_start=self.vae_conv2d_tail_start,
+            conv2d_tail_max_modules=self.vae_conv2d_tail_max_modules,
+            upsample_mode=self.vae_upsample_mode,
+            trace_decoder=self.vae_trace_decoder,
+            decoder_backend=self.vae_decoder_backend,
+            coreml_model_path=self.vae_coreml_model_path,
+            coreml_compute_units=self.vae_coreml_compute_units,
+            coreml_optimization_hints=self.vae_coreml_optimization_hints,
+            coreml_input_rank=self.vae_coreml_input_rank,
+            coreml_latent_size=self.resolution // 8,
+            mlx_dtype=self.vae_mlx_dtype,
+            mlx_compile=self.vae_mlx_compile,
+            mlx_low_rank_highres_rank=self.vae_mlx_low_rank_highres_rank,
+            mlx_low_rank_highres_min_size=self.vae_mlx_low_rank_highres_min_size,
+            mlx_low_rank_highres_tail_rank=self.vae_mlx_low_rank_highres_tail_rank,
+            mlx_low_rank_highres_tail_start_layer=self.vae_mlx_low_rank_highres_tail_start_layer,
+            mlx_low_rank_override_layer=self.vae_mlx_low_rank_override_layer,
+            mlx_low_rank_override_conv_index=self.vae_mlx_low_rank_override_conv_index,
+            mlx_low_rank_override_rank=self.vae_mlx_low_rank_override_rank,
+            mlx_approx_highres_residual_start_layer=self.vae_mlx_approx_highres_residual_start_layer,
+            mlx_approx_highres_residual_end_layer=self.vae_mlx_approx_highres_residual_end_layer,
+            mlx_approx_highres_residual_mode=self.vae_mlx_approx_highres_residual_mode,
+            mlx_low_rank_pointwise_impl=self.vae_mlx_low_rank_pointwise_impl,
+            mlx_latent_size=self.resolution // 8,
+            profile=self.vae_profile,
+        )
+
+    def prewarm_vae_decoder(self) -> dict[str, float]:
+        import torch
+
+        timings: dict[str, float] = {}
+        total_started = time.perf_counter()
+
+        load_started = time.perf_counter()
+        self.load_vae()
+        timings["load_vae_ms"] = (time.perf_counter() - load_started) * 1000.0
+
+        hyper_params = getattr(self, "_hyper_params", None)
+        if hyper_params is not None:
+            image_latent_dim = int(hyper_params[5])
+            patch_size = int(hyper_params[6])
+            latent_width = int(hyper_params[7]) * patch_size
+            latent_height = int(hyper_params[8]) * patch_size
+        else:
+            image_latent_dim = 16
+            latent_width = latent_height = self.resolution // 8
+
+        if self.vae_decoder_backend in {"coreml", "mlx"}:
+            latent_device = "cpu"
+            latent_dtype = torch.float32
+        else:
+            latent_device = self.vae_device or self.device
+            latent_dtype = self.vae_dtype or self.dtype
+        latents = torch.zeros(
+            (1, image_latent_dim, 1, latent_height, latent_width),
+            device=latent_device,
+            dtype=latent_dtype,
+        )
+
+        decode_started = time.perf_counter()
+        with torch.inference_mode():
+            decoded = self.vae_model.batch_decode(latents)
+            if self.vae_decoder_backend not in {"coreml", "mlx"}:
+                synchronize_device(torch.device(self.vae_device or self.device))
+        timings["decode_ms"] = (time.perf_counter() - decode_started) * 1000.0
+        timings["total_ms"] = (time.perf_counter() - total_started) * 1000.0
+
+        del decoded, latents
+        self.prewarm_timings_ms = timings
+        return timings
+
+    def prewarm_image_components(
+        self,
+        prompt: str,
+        *,
+        num_inference_steps: int = 1,
+        guidance_scale: float = 5.0,
+    ) -> dict[str, float]:
+        total_started = time.perf_counter()
+        timings: dict[str, float] = {}
+
+        (
+            num_t2i_image_tokens,
+            _num_mmu_image_tokens,
+            _num_video_tokens,
+            max_seq_len,
+            max_text_len,
+            _image_latent_dim,
+            _patch_size,
+            _latent_width,
+            _latent_height,
+            pad_id,
+            bos_id,
+            eos_id,
+            boi_id,
+            eoi_id,
+            _bov_id,
+            _eov_id,
+            img_pad_id,
+            _vid_pad_id,
+            _default_guidance_scale,
+        ) = self._hyper_params
+
+        prepare_started = time.perf_counter()
+        text_tokens, positions, prompt_cache_hit = self._get_prepared_prompt_inputs(
+            prompt,
+            guidance_scale=guidance_scale,
+            num_t2i_image_tokens=num_t2i_image_tokens,
+            max_text_len=max_text_len,
+            bos_id=bos_id,
+            eos_id=eos_id,
+            boi_id=boi_id,
+            eoi_id=eoi_id,
+            pad_id=pad_id,
+            img_pad_id=img_pad_id,
+        )
+        timings["prepare_ms"] = (time.perf_counter() - prepare_started) * 1000.0
+        timings["prepare_cache_hit"] = 1.0 if prompt_cache_hit else 0.0
+
+        mask_started = time.perf_counter()
+        _attention_mask, mask_cache_hit = self._get_attention_mask(
+            text_tokens.size(0),
+            max_seq_len,
+            positions,
+            self.dtype,
+        )
+        timings["mask_ms"] = (time.perf_counter() - mask_started) * 1000.0
+        timings["mask_cache_hit"] = 1.0 if mask_cache_hit else 0.0
+
+        sampler_started = time.perf_counter()
+        self._get_sample_fn(num_inference_steps, num_t2i_image_tokens)
+        timings["sampler_setup_ms"] = (time.perf_counter() - sampler_started) * 1000.0
+        timings["total_ms"] = (time.perf_counter() - total_started) * 1000.0
+        self.image_component_prewarm_timings_ms = timings
+        return timings
+
+    def _prepared_prompt_cache_key(
+        self,
+        prompt: str,
+        *,
+        guidance_scale: float,
+        num_t2i_image_tokens: int,
+        max_text_len: int,
+    ) -> tuple[Any, ...]:
+        return (
+            prompt,
+            bool(guidance_scale > 0),
+            int(num_t2i_image_tokens),
+            int(max_text_len),
+            str(self.device),
+        )
+
+    def _get_prepared_prompt_inputs(
+        self,
+        prompt: str,
+        *,
+        guidance_scale: float,
+        num_t2i_image_tokens: int,
+        max_text_len: int,
+        bos_id: int,
+        eos_id: int,
+        boi_id: int,
+        eoi_id: int,
+        pad_id: int,
+        img_pad_id: int,
+    ):
+        import torch
+        from models.misc import prepare_gen_input
+
+        cache_key = self._prepared_prompt_cache_key(
+            prompt,
+            guidance_scale=guidance_scale,
+            num_t2i_image_tokens=num_t2i_image_tokens,
+            max_text_len=max_text_len,
+        )
+        cached = self._prepared_prompt_cache.get(cache_key)
+        if cached is not None:
+            text_tokens, positions = cached
+            return text_tokens, positions, True
+
+        text_tokens, text_tokens_null, positions, positions_null = prepare_gen_input(
+            [prompt],
+            self.tokenizer,
+            num_t2i_image_tokens,
+            bos_id,
+            eos_id,
+            boi_id,
+            eoi_id,
+            pad_id,
+            img_pad_id,
+            max_text_len,
+            self.device,
+        )
+        if guidance_scale > 0:
+            text_tokens = torch.cat([text_tokens, text_tokens_null], dim=0)
+            positions = torch.cat([positions, positions_null], dim=0)
+        self._prepared_prompt_cache[cache_key] = (text_tokens, positions)
+        return text_tokens, positions, False
+
+    def _get_sample_fn(self, num_inference_steps: int, num_t2i_image_tokens: int):
+        from transport import Sampler, create_transport
+
+        key = (int(num_inference_steps), int(num_t2i_image_tokens))
+        sample_fn = self._sample_fn_cache.get(key)
+        if sample_fn is not None:
+            return sample_fn
+
+        transport = create_transport(
+            path_type=self.config.transport.path_type,
+            prediction=self.config.transport.prediction,
+            loss_weight=self.config.transport.loss_weight,
+            train_eps=self.config.transport.train_eps,
+            sample_eps=self.config.transport.sample_eps,
+            snr_type=self.config.transport.snr_type,
+            do_shift=self.config.transport.do_shift,
+            seq_len=num_t2i_image_tokens,
+        )
+        sampler = Sampler(transport)
+        sample_fn = sampler.sample_ode(
+            sampling_method=self.config.transport.sampling_method,
+            num_steps=num_inference_steps,
+            atol=self.config.transport.atol,
+            rtol=self.config.transport.rtol,
+            reverse=self.config.transport.reverse,
+            time_shifting_factor=self.config.transport.time_shifting_factor,
+        )
+        self._sample_fn_cache[key] = sample_fn
+        return sample_fn
+
+    @staticmethod
+    def _limited_cache_set(cache: dict, key: tuple[Any, ...], value: Any, *, limit: int = 64) -> None:
+        if len(cache) >= limit:
+            cache.clear()
+        cache[key] = value
+
+    def _get_base_attention_mask(self, batch_size: int, max_seq_len: int, dtype):
+        import torch
+
+        key = (int(batch_size), int(max_seq_len), str(self.device), str(dtype))
+        cached = self._attention_base_mask_cache.get(key)
+        if cached is not None:
+            return cached, True
+
+        blocked_value = torch.tensor(torch.iinfo(torch.long).min, dtype=dtype, device=self.device)
+        mask = torch.zeros(
+            (int(batch_size), 1, int(max_seq_len), int(max_seq_len)),
+            dtype=dtype,
+            device=self.device,
+        )
+        upper_triangle = torch.ones(
+            (int(max_seq_len), int(max_seq_len)),
+            dtype=torch.bool,
+            device=self.device,
+        ).triu(diagonal=1)
+        mask.masked_fill_(upper_triangle.view(1, 1, int(max_seq_len), int(max_seq_len)), blocked_value)
+        self._limited_cache_set(self._attention_base_mask_cache, key, mask, limit=16)
+        return mask, False
+
+    def _get_attention_mask(self, batch_size: int, max_seq_len: int, positions, dtype):
+        base_key = (int(batch_size), int(max_seq_len), str(self.device), str(dtype))
+        identity_key = (*base_key, positions)
+        cached = self._attention_mask_identity_cache.get(identity_key)
+        if cached is not None:
+            return cached, True
+
+        position_values = tuple(int(value) for value in positions.detach().cpu().reshape(-1).tolist())
+        key = (*base_key, position_values)
+        cached = self._attention_mask_cache.get(key)
+        if cached is not None:
+            self._limited_cache_set(self._attention_mask_identity_cache, identity_key, cached)
+            return cached, True
+
+        base_mask, _base_hit = self._get_base_attention_mask(batch_size, max_seq_len, dtype)
+        mask = base_mask.clone()
+        for batch_index, modality_batch in enumerate(positions.detach().cpu().tolist()):
+            for offset, length in modality_batch:
+                offset = int(offset)
+                length = int(length)
+                if length > 0:
+                    mask[
+                        batch_index,
+                        :,
+                        offset:offset + length,
+                        offset:offset + length,
+                    ] = 0
+        self._limited_cache_set(self._attention_mask_cache, key, mask)
+        self._limited_cache_set(self._attention_mask_identity_cache, identity_key, mask)
+        return mask, False
+
+    def generate_text(
+        self,
+        prompt: str,
+        *,
+        max_new_tokens: int = 64,
+        temperature: float = 0.0,
+        top_k: int | None = None,
+    ) -> str:
+        import torch
+
+        token_ids = [self.showo_token_ids["bos_id"]]
+        token_ids.extend(self.tokenizer(prompt, add_special_tokens=False).input_ids)
+        output_ids: list[int] = []
+
+        with torch.inference_mode():
+            for _ in range(max_new_tokens):
+                input_ids = torch.tensor([token_ids], device=self.device)
+                outputs = self.model.showo(input_ids=input_ids, return_dict=True)
+                logits = outputs.logits[:, -1, :]
+                if top_k is not None:
+                    values, _ = torch.topk(logits, min(top_k, logits.shape[-1]))
+                    logits = torch.where(
+                        logits < values[:, [-1]],
+                        torch.full_like(logits, float("-inf")),
+                        logits,
+                    )
+                if temperature <= 0:
+                    next_token = int(torch.argmax(logits, dim=-1).item())
+                else:
+                    probs = torch.softmax(logits / temperature, dim=-1)
+                    next_token = int(torch.multinomial(probs, num_samples=1).item())
+                if next_token == self.tokenizer.eos_token_id:
+                    break
+                token_ids.append(next_token)
+                output_ids.append(next_token)
+
+        return self.tokenizer.decode(output_ids, skip_special_tokens=True)
+
+    def generate_image(
+        self,
+        prompt: str,
+        *,
+        num_inference_steps: int = 20,
+        guidance_scale: float = 5.0,
+        seed: int | None = None,
+        postprocess_mode: str | None = None,
+        return_arrays: bool = False,
+    ):
+        import torch
+        from PIL import Image
+        from utils import denorm
+
+        total_started = time.perf_counter()
+        active_postprocess_mode = postprocess_mode or self.postprocess_mode
+        if active_postprocess_mode not in {"upstream", "cpu", "native"}:
+            raise ValueError(f"Unsupported postprocess mode: {active_postprocess_mode}")
+        timings: dict[str, float] = {}
+        load_vae_started = time.perf_counter()
+        self.load_vae()
+        timings["load_vae_ms"] = (time.perf_counter() - load_vae_started) * 1000.0
+        if seed is not None:
+            torch.manual_seed(seed)
+            if self.device.type == "cuda":
+                torch.cuda.manual_seed_all(seed)
+            elif self.device.type == "mps" and hasattr(torch, "mps") and hasattr(torch.mps, "manual_seed"):
+                torch.mps.manual_seed(seed)
+
+        (
+            num_t2i_image_tokens,
+            _num_mmu_image_tokens,
+            _num_video_tokens,
+            max_seq_len,
+            max_text_len,
+            image_latent_dim,
+            patch_size,
+            latent_width,
+            latent_height,
+            pad_id,
+            bos_id,
+            eos_id,
+            boi_id,
+            eoi_id,
+            _bov_id,
+            _eov_id,
+            img_pad_id,
+            _vid_pad_id,
+            _default_guidance_scale,
+        ) = self._hyper_params
+
+        with torch.inference_mode():
+            prepare_started = time.perf_counter()
+            text_tokens, positions, prompt_cache_hit = self._get_prepared_prompt_inputs(
+                prompt,
+                guidance_scale=guidance_scale,
+                num_t2i_image_tokens=num_t2i_image_tokens,
+                max_text_len=max_text_len,
+                bos_id=bos_id,
+                eos_id=eos_id,
+                boi_id=boi_id,
+                eoi_id=eoi_id,
+                pad_id=pad_id,
+                img_pad_id=img_pad_id,
+            )
+            timings["prepare_ms"] = (time.perf_counter() - prepare_started) * 1000.0
+            timings["prepare_cache_hit"] = 1.0 if prompt_cache_hit else 0.0
+
+            latent_started = time.perf_counter()
+            z = torch.randn(
+                (
+                    1,
+                    image_latent_dim,
+                    latent_height * patch_size,
+                    latent_width * patch_size,
+                ),
+                device=self.device,
+                dtype=self.dtype,
+            )
+
+            if guidance_scale > 0:
+                z = torch.cat([z, z], dim=0)
+            timings["latent_ms"] = (time.perf_counter() - latent_started) * 1000.0
+
+            mask_started = time.perf_counter()
+            attention_mask, mask_cache_hit = self._get_attention_mask(
+                text_tokens.size(0),
+                max_seq_len,
+                positions,
+                self.dtype,
+            )
+            timings["mask_ms"] = (time.perf_counter() - mask_started) * 1000.0
+            timings["mask_cache_hit"] = 1.0 if mask_cache_hit else 0.0
+
+            sampler_started = time.perf_counter()
+            sample_fn = None if num_inference_steps == 1 else self._get_sample_fn(
+                num_inference_steps,
+                num_t2i_image_tokens,
+            )
+            timings["sampler_setup_ms"] = (time.perf_counter() - sampler_started) * 1000.0
+
+            sample_started = time.perf_counter()
+            if sample_fn is None:
+                samples = z.float()
+            else:
+                samples = sample_fn(
+                    z,
+                    self.model.t2i_generate,
+                    text_tokens=text_tokens,
+                    attention_mask=attention_mask,
+                    modality_positions=positions,
+                    output_hidden_states=True,
+                    max_seq_len=max_seq_len,
+                    guidance_scale=guidance_scale,
+                )[-1]
+
+            if guidance_scale > 0:
+                samples = torch.chunk(samples, 2)[0]
+            timings["sample_ms"] = (time.perf_counter() - sample_started) * 1000.0
+
+            decode_started = time.perf_counter()
+            samples = samples.unsqueeze(2)
+            if self.vae_decoder_backend == "mlx":
+                decoded = self.vae_model.batch_decode_mlx(samples, output_layout="nhwc_uint8")
+                images = decoded
+            else:
+                decoded = self.vae_model.batch_decode(samples)
+                images = decoded.squeeze(2) if decoded.ndim == 5 else decoded
+            timings["vae_decode_ms"] = (time.perf_counter() - decode_started) * 1000.0
+            profile_timings = getattr(self.vae_model, "last_profile_timings_ms", None)
+            if isinstance(profile_timings, dict):
+                timings.update(profile_timings)
+
+            postprocess_started = time.perf_counter()
+            if self.vae_decoder_backend == "mlx":
+                arrays = images
+            elif self.vae_decoder_backend == "coreml":
+                arrays = denorm_numpy(images)
+            elif active_postprocess_mode == "cpu":
+                arrays = denorm_cpu_first(images)
+            elif active_postprocess_mode == "native":
+                arrays = denorm_native(images)
+            elif self.vae_output_dtype == "deferred":
+                arrays = denorm_float32_first(images)
+            else:
+                arrays = denorm(images)
+            if self.vae_decoder_backend not in {"coreml", "mlx"}:
+                synchronize_device(self.device)
+            timings["postprocess_ms"] = (time.perf_counter() - postprocess_started) * 1000.0
+
+        pil_started = time.perf_counter()
+        result = list(arrays) if return_arrays else [Image.fromarray(image) for image in arrays]
+        timings["pil_ms"] = (time.perf_counter() - pil_started) * 1000.0
+        timings["total_ms"] = (time.perf_counter() - total_started) * 1000.0
+        self.last_image_timings_ms = timings
+        return result

--- a/examples/show-o2-1.5B-HQ-macbook/requirements.txt
+++ b/examples/show-o2-1.5B-HQ-macbook/requirements.txt
@@ -1,0 +1,18 @@
+torch==2.5.1
+transformers==4.47.0
+diffusers==0.31.0
+accelerate==0.23.0
+huggingface-hub>=0.30.0,<1.0
+hf-xet>=1.1.0
+einops==0.8.0
+omegaconf==2.3.0
+torchdiffeq>=0.2.4
+timm==1.0.12
+sentencepiece>=0.2.0
+numpy>=1.26
+coremltools>=9.0; sys_platform == "darwin"
+mlx>=0.31.0; sys_platform == "darwin" and platform_machine == "arm64"
+pillow>=10.0
+fastapi>=0.115
+uvicorn>=0.30
+httpx>=0.27


### PR DESCRIPTION
## Summary

- Add `OBJECTIVE.md` for the Llama 3.1 8B Instruct MLX 8-bit JSON-schema target.
- Split the Show-o2 target into H100 and MacBook example copies, with hardware-specific `OBJECTIVE.md` files.
- Update the README example list to point at the hardware-specific Show-o2 targets.

Closes #6.

## Validation

- `git diff --cached --check`
- `diff -qr -x OBJECTIVE.md examples/show-o2-1.5B-HQ-h100 examples/show-o2-1.5B-HQ-macbook`
- Objective files checked for ASCII content and trailing whitespace.
