### PR TITLE
Ignore macOS metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS metadata
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]


### PR DESCRIPTION
## Summary

- Add `.DS_Store` to `.gitignore` so local macOS metadata files stay out of git status and commits.

## Validation

- `git check-ignore -v .DS_Store`
- `git diff --check`
- `git diff --cached --check`
