### PR TITLE
Fix: preserve [agent] config section so cli_model/cli_timeout take effect

### DIFF
--- a/src/vibe_serve/config.py
+++ b/src/vibe_serve/config.py
@@ -95,6 +95,10 @@ def _load_config(path: Path) -> dict:
         "thinking": thinking,
         "providers": providers,
         "backend": {"name": backend},
+        # Preserve the [agent] section so its settings (cli_model, cli_timeout,
+        # backend, cli_provider) actually reach build_agent_runner. Without this
+        # the table is parsed and silently discarded.
+        "agent": raw.get("agent", {}) or {},
     }
     # Preserve any non-`name` fields the user added to [backend] for forward
     # compatibility (future backends may carry their own sub-config).

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -161,6 +161,36 @@ EMPTY=
             assert os.environ["OPENAI_API_KEY"] == "existing"
 
 
+class TestLoadConfigAgentSection:
+    def test_agent_section_preserved(self, tmp_path):
+        # The [agent] table drives build_agent_runner (cli_model, cli_timeout,
+        # backend, cli_provider). _load_config must carry it through verbatim;
+        # previously it was parsed and silently dropped, so cli_model never
+        # reached the CLI agent (no --model flag was ever passed).
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text("""\
+[model]
+name = "claude-sonnet-4-6"
+
+[agent]
+backend = "cli"
+cli_provider = "claude"
+cli_model = "claude-opus-4-8[1m]"
+cli_timeout = 1800
+""")
+        config = _load_config(cfg_file)
+        assert config["agent"]["cli_model"] == "claude-opus-4-8[1m]"
+        assert config["agent"]["cli_timeout"] == 1800
+        assert config["agent"]["backend"] == "cli"
+        assert config["agent"]["cli_provider"] == "claude"
+
+    def test_agent_section_defaults_to_empty(self, tmp_path):
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
+        config = _load_config(cfg_file)
+        assert config.get("agent") == {}
+
+
 class TestLoadConfigThinking:
     def test_thinking_parsed(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"


### PR DESCRIPTION
## Problem

`_load_config` rebuilds the config from scratch as an explicit allowlist of sections (`model`, `thinking`, `providers`, `backend`). The `[agent]` table was parsed by `tomllib` and then **silently discarded** — it was never copied into the returned dict.

`build_agent_runner` reads all of its settings from `config["agent"]`:

```python
backend   = ... or (config.get("agent") or {}).get("backend")
provider  = cli_provider or (config.get("agent") or {}).get("cli_provider") or "codex"
timeout   = (config.get("agent") or {}).get("cli_timeout")
cli_model = (config.get("agent") or {}).get("cli_model")
```

Since `config` never had an `"agent"` key, every lookup fell back to defaults. `backend` and `cli_provider` were partially masked because they also have CLI-flag overrides (`--agent-backend`, `--cli-provider`), but **`cli_model` and `cli_timeout` have no flag fallback** — they were completely dead. The CLI agent never received a `--model` flag no matter what the config said, despite `[agent]` being a documented section in the README.

## Fix

Carry the `[agent]` section through verbatim, mirroring the existing forward-compat handling of `[backend]`:

```python
"agent": raw.get("agent", {}) or {},
```

## Tests

`uv run python -m pytest tests/test_config.py` → 14 passed (2 new):
- `test_agent_section_preserved` — `cli_model`, `cli_timeout`, `backend`, `cli_provider` all survive load.
- `test_agent_section_defaults_to_empty` — absent `[agent]` yields `{}`, keeping the downstream `.get(...)` chains safe.

## Note (follow-up, not in this hotfix)

The root cause is the allowlist-rebuild pattern in `_load_config`: any section not manually copied is dropped by default. A follow-up could switch to validate/normalize-in-place (returning the parsed dict) so this class of bug can't recur. Out of scope for this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)