### PR TITLE
Fix stale agent-backend docstring; define the 'cli' default in one place

### DIFF
--- a/src/vibe_serve/agents/__init__.py
+++ b/src/vibe_serve/agents/__init__.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from vibe_serve.constants import DEFAULT_AGENT_BACKEND
+
 from .base import AgentRunner
 from .cli_runner import CliAgentRunner
 from .deepagents_runner import DeepAgentsRunner
@@ -38,7 +40,8 @@ def build_agent_runner(
     Args:
         config: Parsed ``agent.toml`` dict (may contain an ``[agent]`` section).
         agent_backend: CLI override; if set, takes precedence over
-            ``config["agent"]["backend"]``. Falls back to ``"deepagents"``.
+            ``config["agent"]["backend"]``. Falls back to
+            :data:`vibe_serve.constants.DEFAULT_AGENT_BACKEND` (``"cli"``).
         cli_provider: CLI override for ``config["agent"]["cli_provider"]``.
         backends: Mapping ``{"implementer": BaseSandbox, "judge": ..., "perf_eval": ...}``.
             Required for the deepagents path; ignored for the cli path.
@@ -68,7 +71,7 @@ def build_agent_runner(
     backend = (
         agent_backend
         or (config.get("agent") or {}).get("backend")
-        or "cli"
+        or DEFAULT_AGENT_BACKEND
     )
 
     if backend == "deepagents":

--- a/src/vibe_serve/constants.py
+++ b/src/vibe_serve/constants.py
@@ -41,3 +41,8 @@ class ComputeBackend(StrEnum):
 
 DEFAULT_COMPUTE_BACKEND = ComputeBackend.CUDA
 KNOWN_COMPUTE_BACKENDS: tuple[str, ...] = tuple(b.value for b in ComputeBackend)
+
+# Agent backend used when neither the ``--agent-backend`` flag nor an
+# ``[agent].backend`` config key is set. Resolved in a single place so
+# build_agent_runner and ComputeContext cannot drift.
+DEFAULT_AGENT_BACKEND = "cli"

--- a/src/vibe_serve/context.py
+++ b/src/vibe_serve/context.py
@@ -12,7 +12,12 @@ from pathlib import Path
 from vibe_serve import backends
 from vibe_serve.agent_runner import _log_and_print
 from vibe_serve.agents import build_agent_runner
-from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND, PROJECT_ROOT
+from vibe_serve.constants import (
+    ComputeBackend,
+    DEFAULT_AGENT_BACKEND,
+    DEFAULT_COMPUTE_BACKEND,
+    PROJECT_ROOT,
+)
 from vibe_serve.llm_client import _build_model
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentRequest,
@@ -180,7 +185,7 @@ class _RunContext:
         self._resolved_backend = (
             agent_backend
             or (config.get("agent") or {}).get("backend")
-            or "cli"
+            or DEFAULT_AGENT_BACKEND
         )
         self._cli_provider = (
             cli_provider or (config.get("agent") or {}).get("cli_provider")

--- a/src/vibe_serve/sandbox/run_environment.py
+++ b/src/vibe_serve/sandbox/run_environment.py
@@ -37,7 +37,7 @@ from deepagents.backends.sandbox import BaseSandbox
 
 from vibe_serve.backends import ModalOptions, SandboxKind
 from vibe_serve.backends.base import ComputeBackendImpl, SetupFn
-from vibe_serve.constants import PROJECT_ROOT
+from vibe_serve.constants import DEFAULT_AGENT_BACKEND, PROJECT_ROOT
 
 
 @dataclass(frozen=True)
@@ -756,7 +756,7 @@ def _container_mount_plan(
 
     if (
         include_cli_provider_mounts
-        and (request.agent_backend or "cli") == "cli"
+        and (request.agent_backend or DEFAULT_AGENT_BACKEND) == "cli"
         and request.cli_provider
     ):
         from vibe_serve.agents.cli_docker import auth_bind_mounts
@@ -770,7 +770,7 @@ def _container_mount_plan(
 def _cli_container_setup(
     request: RunEnvironmentRequest,
 ) -> tuple[list[str], dict[str, str]]:
-    effective_agent = request.agent_backend or "cli"
+    effective_agent = request.agent_backend or DEFAULT_AGENT_BACKEND
     if effective_agent != "cli" or not request.cli_provider:
         return [], {}
     from vibe_serve.agents.cli_docker import (

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -1132,3 +1132,46 @@ class TestAgentLoggerEventHandler:
 
         assert logger._input_tokens == 12_345
         assert logger._latest_usage == usage
+
+
+class TestBuildAgentRunnerBackendSelection:
+    """``build_agent_runner`` backend resolution.
+
+    The default agent backend is ``"cli"`` (provider ``"codex"``) when neither
+    the ``--agent-backend`` flag nor an ``[agent].backend`` config key is set.
+    Pinned here so the default cannot silently flip.
+    """
+
+    def _build(self, config, *, agent_backend=None, cli_provider=None):
+        return build_agent_runner(
+            config,
+            agent_backend=agent_backend,
+            cli_provider=cli_provider,
+            backends=None,
+            skills=[],
+            skill_source_dirs=[],
+            model=None,
+            model_name="",
+            run_log_file=None,
+            use_docker=False,
+        )
+
+    def test_default_backend_is_cli_with_empty_config(self):
+        runner = self._build({})
+        assert isinstance(runner, CliAgentRunner)
+        assert runner._provider == "codex"
+
+    def test_empty_agent_section_defaults_to_cli(self):
+        runner = self._build({"agent": {}})
+        assert isinstance(runner, CliAgentRunner)
+        assert runner._provider == "codex"
+
+    def test_agent_backend_flag_overrides_config(self):
+        # An explicit --agent-backend flag wins over [agent].backend.
+        runner = self._build({"agent": {"backend": "deepagents"}}, agent_backend="cli")
+        assert isinstance(runner, CliAgentRunner)
+
+    def test_config_can_select_cli_provider(self):
+        runner = self._build({"agent": {"backend": "cli", "cli_provider": "claude"}})
+        assert isinstance(runner, CliAgentRunner)
+        assert runner._provider == "claude"


### PR DESCRIPTION
Closes #10.

## Problem

`build_agent_runner`'s `agent_backend` parameter docstring claimed the fallback was `"deepagents"`:

```
agent_backend: CLI override; if set, takes precedence over
    ``config["agent"]["backend"]``. Falls back to ``"deepagents"``.
```

…but the code falls back to `"cli"`, and `ComputeContext` does the same. The default was duplicated as a bare `"cli"` literal across **four** sites — `build_agent_runner` (`agents/__init__.py`), `context.py`, and two in `sandbox/run_environment.py` — so the copies could (and did) drift. The stale docstring is the visible symptom of that duplication.

## Fix

- Add `constants.DEFAULT_AGENT_BACKEND = "cli"` as the single source of truth.
- Use it at all four resolution sites.
- Correct the `build_agent_runner` docstring to reference the constant / real default.
- Add `TestBuildAgentRunnerBackendSelection` pinning the default to `CliAgentRunner` (provider `"codex"`) when neither `--agent-backend` nor `[agent].backend` is set, plus flag-override and provider-selection cases.

## Behavior

No behavior change — every site already defaulted to `"cli"`; this just removes the drift risk and fixes the docs.

## Tests

`uv run python -m pytest tests/agents/test_agent_runners.py tests/sandbox/test_run_environment.py tests/test_config.py` → 57 passed (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)