### PR TITLE
Schema-driven config: typed pydantic Config, fail-fast, no silent drops

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,19 @@ name = "cuda"                 # or "metal" for Apple Silicon (local exec only)
 [agent]
 backend = "cli"               # "cli" (codex/claude/gemini/opencode) or "deepagents"
 cli_provider = "codex"        # which coding-agent harness to drive
+# cli_model = "gpt-5-codex"   # override the model the CLI tool uses
+# cli_timeout = 1800          # per-invocation timeout (seconds)
+
+# Optional: benchmark load levels handed to the perf evaluator.
+# [[perf_eval.load_levels]]
+# rate = 1
+# duration = 20
+# max_tokens = 128
 ```
 
 Provider credentials live in `.env` — see `.env.example`. The CLI flags `--agent-backend` / `--cli-provider` / `--backend` override these.
+
+The config is validated against a typed schema on load (`vibe_serve/config.py`): unknown sections or keys, unknown providers/backends, and missing required fields are rejected with an error rather than silently ignored.
 
 ## Skills library
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "langchain-openai",
     "huggingface_hub",
     "openai>=1.28.0",
+    "pydantic>=2",
     "python-dotenv>=1.0.1",
     "loguru>=0.7.2",
     "mcp>=1.0",

--- a/src/vibe_serve/agents/__init__.py
+++ b/src/vibe_serve/agents/__init__.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from vibe_serve.config import Config
+
 from .base import AgentRunner
 from .cli_runner import CliAgentRunner
 from .deepagents_runner import DeepAgentsRunner
@@ -19,7 +21,7 @@ __all__ = ["AgentRunner", "DeepAgentsRunner", "CliAgentRunner", "build_agent_run
 
 
 def build_agent_runner(
-    config: dict,
+    config: Config,
     *,
     agent_backend: str | None,
     cli_provider: str | None,
@@ -36,10 +38,11 @@ def build_agent_runner(
     """Construct the right :class:`AgentRunner` for the requested backend.
 
     Args:
-        config: Parsed ``agent.toml`` dict (may contain an ``[agent]`` section).
+        config: Parsed :class:`~vibe_serve.config.Config`; the ``[agent]``
+            section drives backend/provider/model/timeout selection.
         agent_backend: CLI override; if set, takes precedence over
-            ``config["agent"]["backend"]``. Falls back to ``"deepagents"``.
-        cli_provider: CLI override for ``config["agent"]["cli_provider"]``.
+            ``config.agent.backend``. Falls back to ``"cli"``.
+        cli_provider: CLI override for ``config.agent.cli_provider``.
         backends: Mapping ``{"implementer": BaseSandbox, "judge": ..., "perf_eval": ...}``.
             Required for the deepagents path; ignored for the cli path.
         skills: Skill directory names already materialized in the workspace,
@@ -65,11 +68,8 @@ def build_agent_runner(
             combined with ``--docker``, or the cli backend was selected
             without a provider.
     """
-    backend = (
-        agent_backend
-        or (config.get("agent") or {}).get("backend")
-        or "cli"
-    )
+    agent_cfg = config.agent
+    backend = agent_backend or agent_cfg.backend or "cli"
 
     if backend == "deepagents":
         if backends is None:
@@ -86,7 +86,7 @@ def build_agent_runner(
         )
 
     if backend == "cli":
-        provider = cli_provider or (config.get("agent") or {}).get("cli_provider") or "codex"
+        provider = cli_provider or agent_cfg.cli_provider or "codex"
         docker_sandboxes = None
         modal_sandboxes = None
         if use_docker or use_modal:
@@ -105,10 +105,10 @@ def build_agent_runner(
                 modal_sandboxes = backends
             else:
                 docker_sandboxes = backends
-        timeout = (config.get("agent") or {}).get("cli_timeout")
+        timeout = agent_cfg.cli_timeout
         # cli_model overrides model.name for the CLI tool. If not set,
         # pass None so the CLI tool uses its own default.
-        cli_model = (config.get("agent") or {}).get("cli_model")
+        cli_model = agent_cfg.cli_model
         return CliAgentRunner(
             provider=provider,
             model=cli_model,

--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -22,7 +22,7 @@ import sys
 import tomllib
 from pathlib import Path
 
-from vibe_serve.config import _load_config
+from vibe_serve.config import Config, _load_config
 from vibe_serve.constants import (
     ComputeBackend,
     KNOWN_COMPUTE_BACKENDS,
@@ -264,7 +264,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
 
 def load_config_and_skills(
     args: argparse.Namespace,
-) -> tuple[dict, list[str] | None, ComputeBackend]:
+) -> tuple[Config, list[str] | None, ComputeBackend]:
     """Load config from args.config, process skills_dir, and resolve the backend."""
     try:
         config = _load_config(args.config)
@@ -277,7 +277,7 @@ def load_config_and_skills(
         if isinstance(args.skills_dir, list)
         else ([str(args.skills_dir)] if args.skills_dir else None)
     )
-    backend: ComputeBackend = args.backend or config["backend"]["name"]
+    backend: ComputeBackend = args.backend or config.backend.name
     return config, skills, backend
 
 

--- a/src/vibe_serve/config.py
+++ b/src/vibe_serve/config.py
@@ -1,10 +1,129 @@
+"""Typed, schema-driven configuration for ``agent.toml``.
+
+The whole config is described by the :class:`Config` pydantic model and its
+nested sections. ``_load_config`` parses the TOML, validates it against that
+schema (fail-fast: missing required fields, unknown providers/backends, wrong
+types, **and unknown keys** all raise), applies environment-variable overrides,
+and returns a typed :class:`Config`. Consumers use attribute access
+(``config.model.name``) — there is no dict-style access anywhere.
+
+Every section is ``extra="forbid"``: a stray or misspelled key is an error
+rather than being silently dropped, which is the failure mode the previous
+allowlist loader suffered from.
+"""
+
 import os
 import tomllib
 from pathlib import Path
+from typing import Literal, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND, PROJECT_ROOT
 
-_KNOWN_PROVIDERS = {"vertex-ai", "anthropic", "google-genai", "openai", "openai-compatible"}
+Provider = Literal[
+    "vertex-ai", "anthropic", "google-genai", "openai", "openai-compatible"
+]
+
+
+class _Strict(BaseModel):
+    """Base for every config section: reject unknown keys."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ModelCfg(_Strict):
+    name: str
+    # When None the provider is auto-detected from the model name prefix.
+    provider: Provider | None = None
+
+
+class ThinkingCfg(_Strict):
+    level: str | None = None
+    budget: int | None = None
+
+
+class VertexCfg(_Strict):
+    # TOML key is ``json`` (path to the service-account key file); the attribute
+    # is renamed to avoid shadowing ``BaseModel.json``.
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    json_path: str | None = Field(default=None, alias="json")
+    project: str | None = None
+    region: str = "us-east5"
+
+
+class OpenAICompatCfg(_Strict):
+    base_url: str | None = None
+    api_key: str = "no-key"
+
+
+class _CredEnvProviderCfg(_Strict):
+    """A provider whose credentials come from the environment (``.env``).
+
+    The ``[providers.<name>]`` table carries no keys; it exists only as a marker.
+    Declared so the table validates under ``extra="forbid"`` while still
+    rejecting stray keys placed under it.
+    """
+
+
+class ProvidersCfg(_Strict):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    vertex_ai: VertexCfg | None = Field(default=None, alias="vertex-ai")
+    openai_compatible: OpenAICompatCfg | None = Field(
+        default=None, alias="openai-compatible"
+    )
+    anthropic: _CredEnvProviderCfg | None = None
+    google_genai: _CredEnvProviderCfg | None = Field(default=None, alias="google-genai")
+    openai: _CredEnvProviderCfg | None = None
+
+
+class BackendCfg(_Strict):
+    # Coerced from the TOML string (e.g. "cuda") into the enum.
+    name: ComputeBackend = DEFAULT_COMPUTE_BACKEND
+
+
+class AgentCfg(_Strict):
+    backend: str | None = None
+    cli_provider: str | None = None
+    cli_model: str | None = None
+    cli_timeout: int | None = None
+
+
+class LoadLevelCfg(_Strict):
+    """One benchmark load level fed to the perf_eval prompt template.
+
+    Distinct from the ``LoadLevelMetrics`` *output* schema in ``schemas.py``.
+    """
+
+    rate: int
+    duration: int
+    max_tokens: int
+
+
+class PerfEvalCfg(_Strict):
+    load_levels: list[LoadLevelCfg] | None = None
+
+
+class Config(_Strict):
+    model_config = ConfigDict(extra="forbid", protected_namespaces=())
+
+    model: ModelCfg
+    thinking: ThinkingCfg = Field(default_factory=ThinkingCfg)
+    providers: ProvidersCfg = Field(default_factory=ProvidersCfg)
+    backend: BackendCfg = Field(default_factory=BackendCfg)
+    agent: AgentCfg = Field(default_factory=AgentCfg)
+    perf_eval: PerfEvalCfg = Field(default_factory=PerfEvalCfg)
+
+
+def as_config(config: "Config | Mapping") -> "Config":
+    """Coerce a mapping to a validated :class:`Config`; pass through instances.
+
+    The loop entrypoints accept either a parsed :class:`Config` (the normal CLI
+    path) or a raw mapping (tests, programmatic callers) and normalize here.
+    """
+    return config if isinstance(config, Config) else Config.model_validate(config)
 
 
 def _load_dotenv_file(path: Path = PROJECT_ROOT / ".env") -> None:
@@ -45,60 +164,29 @@ def _load_dotenv_file(path: Path = PROJECT_ROOT / ".env") -> None:
             os.environ.setdefault(key, value)
 
 
-def _load_config(path: Path) -> dict:
-    """Load and validate a TOML agent config file."""
+def _apply_vertex_env_overrides(config: Config) -> None:
+    """Let ``VERTEX_*`` env vars override the ``[providers.vertex-ai]`` table.
+
+    Only applied when the section is present, matching prior behavior.
+    """
+    vx = config.providers.vertex_ai
+    if vx is None:
+        return
+    if env_json := os.environ.get("VERTEX_SERVICE_ACCOUNT_JSON"):
+        vx.json_path = env_json
+    if env_project := os.environ.get("VERTEX_PROJECT"):
+        vx.project = env_project
+    if env_region := os.environ.get("VERTEX_REGION"):
+        vx.region = env_region
+
+
+def _load_config(path: Path) -> Config:
+    """Load, validate, and env-override a TOML agent config file."""
     _load_dotenv_file()
     path = Path(path)
     with open(path, "rb") as f:
         raw = tomllib.load(f)
 
-    model = raw.get("model", {})
-    if "name" not in model:
-        raise ValueError("Config missing required field: model.name")
-
-    provider = model.get("provider")
-    if provider is not None and provider not in _KNOWN_PROVIDERS:
-        raise ValueError(
-            f"Unknown provider {provider!r} in config. "
-            f"Supported providers: {', '.join(sorted(_KNOWN_PROVIDERS))}"
-        )
-
-    thinking = raw.get("thinking", {})
-    providers = raw.get("providers", {})
-
-    backend_section = raw.get("backend", {}) or {}
-    raw_backend = backend_section.get("name", DEFAULT_COMPUTE_BACKEND)
-    try:
-        backend = ComputeBackend(raw_backend)
-    except ValueError:
-        raise ValueError(
-            f"Unknown backend {raw_backend!r} in config. "
-            f"Supported backends: {', '.join(b.value for b in ComputeBackend)}"
-        ) from None
-
-    # Apply env var overrides for vertex-ai
-    if "vertex-ai" in providers:
-        vx = providers["vertex-ai"]
-        env_json = os.environ.get("VERTEX_SERVICE_ACCOUNT_JSON")
-        env_project = os.environ.get("VERTEX_PROJECT")
-        env_region = os.environ.get("VERTEX_REGION")
-        if env_json:
-            vx["json"] = env_json
-        if env_project:
-            vx["project"] = env_project
-        if env_region:
-            vx["region"] = env_region
-
-    # Normalize provider to None if not set
-    config = {
-        "model": {"name": model["name"], "provider": provider},
-        "thinking": thinking,
-        "providers": providers,
-        "backend": {"name": backend},
-    }
-    # Preserve any non-`name` fields the user added to [backend] for forward
-    # compatibility (future backends may carry their own sub-config).
-    for key, value in backend_section.items():
-        if key != "name":
-            config["backend"][key] = value
+    config = Config.model_validate(raw)
+    _apply_vertex_env_overrides(config)
     return config

--- a/src/vibe_serve/config.py
+++ b/src/vibe_serve/config.py
@@ -33,29 +33,72 @@ class _Strict(BaseModel):
 
 
 class ModelCfg(_Strict):
-    name: str
-    # When None the provider is auto-detected from the model name prefix.
-    provider: Provider | None = None
+    name: str = Field(
+        description="Model identifier, e.g. 'claude-sonnet-4-6'. Required."
+    )
+    provider: Provider | None = Field(
+        default=None,
+        description=(
+            "Provider override. When omitted, auto-detected from the model-name "
+            "prefix: claude-* → anthropic, gpt-*/o1/o3/o4 → openai, "
+            "gemini-*/gemma-* → google-genai."
+        ),
+    )
 
 
 class ThinkingCfg(_Strict):
-    level: str | None = None
-    budget: int | None = None
+    level: str | None = Field(
+        default=None,
+        description=(
+            "Reasoning effort level passed to the model (provider-specific, e.g. "
+            "'low'/'medium'/'high'). For Gemini on Vertex, mutually exclusive with "
+            "budget."
+        ),
+    )
+    budget: int | None = Field(
+        default=None,
+        description="Thinking token budget (provider-specific). Alternative to level.",
+    )
 
 
 class VertexCfg(_Strict):
-    # TOML key is ``json`` (path to the service-account key file); the attribute
-    # is renamed to avoid shadowing ``BaseModel.json``.
+    # The attribute is ``json_path`` to avoid shadowing ``BaseModel.json``; the
+    # TOML key stays ``json`` via the alias.
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
-    json_path: str | None = Field(default=None, alias="json")
-    project: str | None = None
-    region: str = "us-east5"
+    json_path: str | None = Field(
+        default=None,
+        alias="json",
+        description=(
+            "Path to the Vertex AI service-account JSON key file. Overridable via "
+            "$VERTEX_SERVICE_ACCOUNT_JSON."
+        ),
+    )
+    project: str | None = Field(
+        default=None,
+        description=(
+            "GCP project id. Falls back to the key file's project_id when unset. "
+            "Overridable via $VERTEX_PROJECT."
+        ),
+    )
+    region: str = Field(
+        default="us-east5",
+        description="Vertex AI region/location. Overridable via $VERTEX_REGION.",
+    )
 
 
 class OpenAICompatCfg(_Strict):
-    base_url: str | None = None
-    api_key: str = "no-key"
+    base_url: str | None = Field(
+        default=None,
+        description=(
+            "Base URL of the OpenAI-compatible endpoint "
+            "(e.g. 'http://localhost:8000/v1'). Required for this provider."
+        ),
+    )
+    api_key: str = Field(
+        default="no-key",
+        description="API key for the endpoint; 'no-key' for unauthenticated local servers.",
+    )
 
 
 class _CredEnvProviderCfg(_Strict):
@@ -70,25 +113,69 @@ class _CredEnvProviderCfg(_Strict):
 class ProvidersCfg(_Strict):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
-    vertex_ai: VertexCfg | None = Field(default=None, alias="vertex-ai")
-    openai_compatible: OpenAICompatCfg | None = Field(
-        default=None, alias="openai-compatible"
+    vertex_ai: VertexCfg | None = Field(
+        default=None,
+        alias="vertex-ai",
+        description="Vertex AI provider settings ([providers.vertex-ai]).",
     )
-    anthropic: _CredEnvProviderCfg | None = None
-    google_genai: _CredEnvProviderCfg | None = Field(default=None, alias="google-genai")
-    openai: _CredEnvProviderCfg | None = None
+    openai_compatible: OpenAICompatCfg | None = Field(
+        default=None,
+        alias="openai-compatible",
+        description=(
+            "OpenAI-compatible endpoint settings ([providers.openai-compatible])."
+        ),
+    )
+    anthropic: _CredEnvProviderCfg | None = Field(
+        default=None,
+        description="Anthropic provider marker; credentials from $ANTHROPIC_API_KEY.",
+    )
+    google_genai: _CredEnvProviderCfg | None = Field(
+        default=None,
+        alias="google-genai",
+        description="Google GenAI provider marker; credentials from $GOOGLE_API_KEY.",
+    )
+    openai: _CredEnvProviderCfg | None = Field(
+        default=None,
+        description="OpenAI provider marker; credentials from $OPENAI_API_KEY.",
+    )
 
 
 class BackendCfg(_Strict):
-    # Coerced from the TOML string (e.g. "cuda") into the enum.
-    name: ComputeBackend = DEFAULT_COMPUTE_BACKEND
+    name: ComputeBackend = Field(
+        default=DEFAULT_COMPUTE_BACKEND,
+        description="Compute backend, coerced from the TOML string. One of: cuda, metal.",
+    )
 
 
 class AgentCfg(_Strict):
-    backend: str | None = None
-    cli_provider: str | None = None
-    cli_model: str | None = None
-    cli_timeout: int | None = None
+    backend: str | None = Field(
+        default=None,
+        description=(
+            "Agent runner backend: 'cli' (drive an external coding-agent CLI) or "
+            "'deepagents'. The --agent-backend flag overrides; defaults to 'cli'."
+        ),
+    )
+    cli_provider: str | None = Field(
+        default=None,
+        description=(
+            "Which CLI coding-agent to drive: codex | claude | gemini | opencode. "
+            "The --cli-provider flag overrides; defaults to 'codex'."
+        ),
+    )
+    cli_model: str | None = Field(
+        default=None,
+        description=(
+            "Model the CLI tool should use; overrides model.name for the CLI agent. "
+            "None → the CLI tool's own default (no --model flag passed)."
+        ),
+    )
+    cli_timeout: int | None = Field(
+        default=None,
+        description=(
+            "Per-invocation timeout for the CLI agent, in seconds. None → the "
+            "runner default."
+        ),
+    )
 
 
 class LoadLevelCfg(_Strict):
@@ -97,24 +184,47 @@ class LoadLevelCfg(_Strict):
     Distinct from the ``LoadLevelMetrics`` *output* schema in ``schemas.py``.
     """
 
-    rate: int
-    duration: int
-    max_tokens: int
+    rate: int = Field(description="Request rate (requests/sec) for this load level.")
+    duration: int = Field(description="Benchmark duration in seconds at this load level.")
+    max_tokens: int = Field(
+        description="Max output tokens per request at this load level."
+    )
 
 
 class PerfEvalCfg(_Strict):
-    load_levels: list[LoadLevelCfg] | None = None
+    load_levels: list[LoadLevelCfg] | None = Field(
+        default=None,
+        description=(
+            "Benchmark load levels handed to the perf evaluator. None → the "
+            "evaluator uses its built-in default ladder."
+        ),
+    )
 
 
 class Config(_Strict):
     model_config = ConfigDict(extra="forbid", protected_namespaces=())
 
-    model: ModelCfg
-    thinking: ThinkingCfg = Field(default_factory=ThinkingCfg)
-    providers: ProvidersCfg = Field(default_factory=ProvidersCfg)
-    backend: BackendCfg = Field(default_factory=BackendCfg)
-    agent: AgentCfg = Field(default_factory=AgentCfg)
-    perf_eval: PerfEvalCfg = Field(default_factory=PerfEvalCfg)
+    model: ModelCfg = Field(
+        description="[model] — model name and provider. Required."
+    )
+    thinking: ThinkingCfg = Field(
+        default_factory=ThinkingCfg, description="[thinking] — reasoning/thinking controls."
+    )
+    providers: ProvidersCfg = Field(
+        default_factory=ProvidersCfg,
+        description="[providers.*] — per-provider credentials and endpoints.",
+    )
+    backend: BackendCfg = Field(
+        default_factory=BackendCfg, description="[backend] — compute backend selection."
+    )
+    agent: AgentCfg = Field(
+        default_factory=AgentCfg,
+        description="[agent] — agent runner backend and CLI-agent settings.",
+    )
+    perf_eval: PerfEvalCfg = Field(
+        default_factory=PerfEvalCfg,
+        description="[perf_eval] — performance-evaluation settings.",
+    )
 
 
 def as_config(config: "Config | Mapping") -> "Config":

--- a/src/vibe_serve/context.py
+++ b/src/vibe_serve/context.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from vibe_serve import backends
 from vibe_serve.agent_runner import _log_and_print
 from vibe_serve.agents import build_agent_runner
+from vibe_serve.config import Config, as_config
 from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND, PROJECT_ROOT
 from vibe_serve.llm_client import _build_model
 from vibe_serve.sandbox.run_environment import (
@@ -119,7 +120,7 @@ class _RunContext:
 
     def __init__(
         self,
-        config: dict,
+        config: Config,
         exp_name: str,
         reference_path: str,
         existing: bool = False,
@@ -136,6 +137,7 @@ class _RunContext:
         cli_provider: str | None = None,
         backend: ComputeBackend = DEFAULT_COMPUTE_BACKEND,
     ):
+        config = as_config(config)
         self.backend: ComputeBackend = backend
         run_environment = run_environment or make_run_environment_spec()
         self.run_environment = build_run_environment(run_environment)
@@ -177,18 +179,11 @@ class _RunContext:
         )
         # Resolve agent backend + cli provider early so Docker setup can
         # add provider-specific bind mounts and init commands.
-        self._resolved_backend = (
-            agent_backend
-            or (config.get("agent") or {}).get("backend")
-            or "cli"
-        )
-        self._cli_provider = (
-            cli_provider or (config.get("agent") or {}).get("cli_provider")
-            or "codex"
-        )
+        self._resolved_backend = agent_backend or config.agent.backend or "cli"
+        self._cli_provider = cli_provider or config.agent.cli_provider or "codex"
 
         self.model = _build_model(config)
-        self.model_name = config.get("model", {}).get("name", "unknown")
+        self.model_name = config.model.name
 
         self.acc_checker_path = self._coerce_dir_path(acc_checker, "--acc-checker")
         self.bench_path = self._coerce_dir_path(bench, "--bench")

--- a/src/vibe_serve/llm_client.py
+++ b/src/vibe_serve/llm_client.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from vibe_serve.config import Config, ThinkingCfg
 from vibe_serve.constants import _ANTHROPIC_PREFIXES, _GOOGLE_PREFIXES, _OPENAI_PREFIXES
 
 
@@ -16,15 +17,15 @@ def _is_openai_model(model_name: str) -> bool:
     return any(model_name.startswith(p) for p in _OPENAI_PREFIXES)
 
 
-def _has_thinking(thinking: dict) -> bool:
-    return bool(thinking.get("level") or thinking.get("budget"))
+def _has_thinking(thinking: ThinkingCfg) -> bool:
+    return bool(thinking.level or thinking.budget)
 
 
-def _build_model(config: dict):
-    """Build the chat model from a parsed config dict."""
-    model_name = config["model"]["name"]
-    provider = config["model"].get("provider")
-    thinking = config.get("thinking", {})
+def _build_model(config: Config):
+    """Build the chat model from a parsed :class:`Config`."""
+    model_name = config.model.name
+    provider = config.model.provider
+    thinking = config.thinking
 
     if provider == "vertex-ai":
         return _build_vertex_model(model_name, config, thinking)
@@ -75,18 +76,18 @@ def _build_model(config: dict):
     raise NotImplementedError(f"Provider {provider!r} is not yet supported")
 
 
-def _build_openai_compatible_model(model_name: str, config: dict):
+def _build_openai_compatible_model(model_name: str, config: Config):
     """Build a model using an OpenAI-compatible API (e.g. vLLM, Ollama)."""
     from langchain_openai import ChatOpenAI
 
-    oc = config.get("providers", {}).get("openai-compatible", {})
-    base_url = oc.get("base_url")
+    oc = config.providers.openai_compatible
+    base_url = oc.base_url if oc else None
     if not base_url:
         raise ValueError(
             "openai-compatible provider requires 'base_url' "
             "(e.g. 'http://localhost:8000/v1')"
         )
-    api_key = oc.get("api_key", "no-key")
+    api_key = oc.api_key
 
     return ChatOpenAI(
         model=model_name,
@@ -95,14 +96,14 @@ def _build_openai_compatible_model(model_name: str, config: dict):
     )
 
 
-def _build_vertex_model(model_name: str, config: dict, thinking: dict):
+def _build_vertex_model(model_name: str, config: Config, thinking: ThinkingCfg):
     """Build a Vertex AI model (Claude via Model Garden or Gemini via GenAI)."""
     from google.oauth2 import service_account
 
-    vx = config.get("providers", {}).get("vertex-ai", {})
-    vertex_json = vx.get("json")
-    vertex_project = vx.get("project")
-    vertex_region = vx.get("region", "us-east5")
+    vx = config.providers.vertex_ai
+    vertex_json = vx.json_path if vx else None
+    vertex_project = vx.project if vx else None
+    vertex_region = vx.region if vx else "us-east5"
 
     if not vertex_json:
         raise ValueError("vertex-ai provider requires 'json' key path")
@@ -125,8 +126,8 @@ def _build_vertex_model(model_name: str, config: dict, thinking: dict):
         from langchain_google_genai import ChatGoogleGenerativeAI
 
         thinking_kwargs = {}
-        thinking_level = thinking.get("level")
-        thinking_budget = thinking.get("budget")
+        thinking_level = thinking.level
+        thinking_budget = thinking.budget
         if thinking_level is not None:
             thinking_kwargs["thinking_level"] = thinking_level
             thinking_kwargs["include_thoughts"] = True

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from vibe_serve.config import Config
 from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND
 from vibe_serve.context import _RunContext
 from vibe_serve.loops.agent import issue_board
@@ -411,7 +412,7 @@ def _run_judge(
 
 
 def run_agent_loop(
-    config: dict,
+    config: Config,
     exp_name: str,
     reference_path: str,
     objective: str,

--- a/src/vibe_serve/loops/evolve/loop.py
+++ b/src/vibe_serve/loops/evolve/loop.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 
+from vibe_serve.config import Config
 from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND
 from vibe_serve.context import _RunContext
 from vibe_serve.loops.evolve.population import (
@@ -266,7 +267,7 @@ def _run_profiler(
 
 
 def run_evolve_loop(
-    config: dict,
+    config: Config,
     exp_name: str,
     reference_path: str,
     objective: str,

--- a/src/vibe_serve/loops/plain/loop.py
+++ b/src/vibe_serve/loops/plain/loop.py
@@ -28,6 +28,7 @@ from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
 
+from vibe_serve.config import Config, as_config
 from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND
 from vibe_serve.context import _RunContext
 from vibe_serve.loops.plain.render import render_all
@@ -335,7 +336,7 @@ def _ensure_bootstrap_issue(
 
 
 def run_plain_loop(
-    config: dict,
+    config: Config,
     exp_name: str,
     reference_path: str,
     *,
@@ -361,6 +362,7 @@ def run_plain_loop(
     exhausted with open work remaining, or if the run gets stuck (every
     remaining issue is BLOCKED).
     """
+    config = as_config(config)
     # Issue loop always uses git tracking so judge test scripts and the
     # issue tracker mirror persist across iterations.
     git_tracking = True
@@ -463,8 +465,7 @@ def run_plain_loop(
                 + f", running up to {max_rounds} more rounds"
             )
 
-        perf_eval_config = config.get("perf_eval", {})
-        load_levels = perf_eval_config.get("load_levels")
+        load_levels = config.perf_eval.load_levels
         previous_evaluator_feedback: list[str] | None = None
 
         while i < end_iteration:

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -11,10 +11,16 @@ from vibe_serve.agents import build_agent_runner
 from vibe_serve.agents.cli_runner import CliAgentRunner
 from vibe_serve.agents.deepagents_runner import DeepAgentsRunner
 from vibe_serve.agents.callbacks import AgentLogger
+from vibe_serve.config import Config
 from vibe_serve.schemas import (
     JudgeResponse,
     Verdict,
 )
+
+
+def _agent_config(**agent) -> Config:
+    """Minimal valid Config carrying just an ``[agent]`` section for runner tests."""
+    return Config.model_validate({"model": {"name": "m"}, "agent": agent})
 
 
 def _judge_fallback() -> JudgeResponse:
@@ -931,7 +937,7 @@ class TestBuildAgentRunner:
 
     def test_build_agent_runner_default_is_cli(self):
         runner = build_agent_runner(
-            {},
+            _agent_config(),
             agent_backend=None,
             cli_provider=None,
             backends={
@@ -951,7 +957,7 @@ class TestBuildAgentRunner:
 
     def test_build_agent_runner_cli_provider_from_config(self):
         runner = build_agent_runner(
-            {"agent": {"backend": "cli", "cli_provider": "claude"}},
+            _agent_config(backend="cli", cli_provider="claude"),
             agent_backend=None,
             cli_provider=None,
             backends=None,
@@ -968,7 +974,7 @@ class TestBuildAgentRunner:
     def test_build_agent_runner_cli_defaults_to_codex(self):
         """When backend=cli and no provider specified, defaults to codex."""
         runner = build_agent_runner(
-                {"agent": {"backend": "cli"}},
+                _agent_config(backend="cli"),
                 agent_backend=None,
                 cli_provider=None,
                 backends=None,
@@ -992,7 +998,7 @@ class TestBuildAgentRunner:
             "perf_eval": MagicMock(),
         }
         runner = build_agent_runner(
-            {},
+            _agent_config(),
             agent_backend="cli",
             cli_provider="claude",
             backends=mock_backends,
@@ -1016,7 +1022,7 @@ class TestBuildAgentRunner:
             "perf_eval": MagicMock(),
         }
         runner = build_agent_runner(
-            {},
+            _agent_config(),
             agent_backend="cli",
             cli_provider="codex",
             backends=mock_backends,
@@ -1035,7 +1041,7 @@ class TestBuildAgentRunner:
     def test_build_agent_runner_rejects_unsupported_modal_provider(self):
         with pytest.raises(SystemExit, match="not yet supported with --modal"):
             build_agent_runner(
-                {},
+                _agent_config(),
                 agent_backend="cli",
                 cli_provider="nonexistent",
                 backends={},
@@ -1051,7 +1057,7 @@ class TestBuildAgentRunner:
     def test_build_agent_runner_rejects_unsupported_docker_provider(self):
         with pytest.raises(SystemExit, match="not yet supported with --docker"):
             build_agent_runner(
-                {},
+                _agent_config(),
                 agent_backend="cli",
                 cli_provider="nonexistent",
                 backends={},
@@ -1066,7 +1072,7 @@ class TestBuildAgentRunner:
     def test_build_agent_runner_rejects_unknown_backend(self):
         with pytest.raises(SystemExit, match="unknown agent backend"):
             build_agent_runner(
-                {},
+                _agent_config(),
                 agent_backend="bogus",
                 cli_provider=None,
                 backends=None,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,29 +35,31 @@ region = "us-east5"
 [providers.google-genai]
 """)
         config = _load_config(cfg_file)
-        assert config["model"]["name"] == "claude-sonnet-4-6"
-        assert config["model"]["provider"] == "vertex-ai"
-        assert config["thinking"]["level"] == "medium"
-        assert config["thinking"]["budget"] == 1024
-        assert config["providers"]["vertex-ai"]["json"] == "~/keys/vertex.json"
-        assert config["providers"]["vertex-ai"]["project"] == "my-project"
-        assert config["providers"]["vertex-ai"]["region"] == "us-east5"
+        assert config.model.name == "claude-sonnet-4-6"
+        assert config.model.provider == "vertex-ai"
+        assert config.thinking.level == "medium"
+        assert config.thinking.budget == 1024
+        assert config.providers.vertex_ai.json_path == "~/keys/vertex.json"
+        assert config.providers.vertex_ai.project == "my-project"
+        assert config.providers.vertex_ai.region == "us-east5"
 
     def test_minimal_config(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
         config = _load_config(cfg_file)
-        assert config["model"]["name"] == "claude-sonnet-4-6"
-        assert config["model"].get("provider") is None
-        assert config.get("thinking") == {}
-        assert config.get("providers") == {}
+        assert config.model.name == "claude-sonnet-4-6"
+        assert config.model.provider is None
+        assert config.thinking.level is None
+        assert config.thinking.budget is None
+        assert config.providers.vertex_ai is None
+        assert config.providers.openai_compatible is None
 
 
 class TestLoadConfigErrors:
     def test_missing_model_name(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("[model]\nprovider = 'vertex-ai'\n")
-        with pytest.raises(ValueError, match="model.name"):
+        with pytest.raises(ValueError, match="name"):
             _load_config(cfg_file)
 
     def test_missing_file(self):
@@ -81,12 +83,40 @@ provider = "bedrock"
             _load_config(cfg_file)
 
 
+class TestLoadConfigStrict:
+    """Unknown sections/keys are rejected (fail-fast), not silently dropped."""
+
+    def test_unknown_top_level_section_rejected(self, tmp_path):
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text(
+            '[model]\nname = "claude-sonnet-4-6"\n\n[bogus]\nx = 1\n'
+        )
+        with pytest.raises(ValueError, match="bogus"):
+            _load_config(cfg_file)
+
+    def test_unknown_key_in_known_section_rejected(self, tmp_path):
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text(
+            '[model]\nname = "claude-sonnet-4-6"\n\n[agent]\ncli_modle = "x"\n'
+        )
+        with pytest.raises(ValueError, match="cli_modle"):
+            _load_config(cfg_file)
+
+    def test_unknown_backend_rejected(self, tmp_path):
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text(
+            '[model]\nname = "claude-sonnet-4-6"\n\n[backend]\nname = "tpu"\n'
+        )
+        with pytest.raises(ValueError, match="tpu"):
+            _load_config(cfg_file)
+
+
 class TestLoadConfigProviderDefault:
     def test_missing_provider_defaults_to_none(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
         config = _load_config(cfg_file)
-        assert config["model"].get("provider") is None
+        assert config.model.provider is None
 
 
 class TestLoadConfigEnvVars:
@@ -106,10 +136,10 @@ provider = "vertex-ai"
         }
         with patch.dict("os.environ", env, clear=False):
             config = _load_config(cfg_file)
-        vx = config["providers"]["vertex-ai"]
-        assert vx["json"] == "/env/key.json"
-        assert vx["project"] == "env-project"
-        assert vx["region"] == "us-central1"
+        vx = config.providers.vertex_ai
+        assert vx.json_path == "/env/key.json"
+        assert vx.project == "env-project"
+        assert vx.region == "us-central1"
 
     def test_env_vars_override_toml(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
@@ -130,10 +160,10 @@ region = "us-east5"
         }
         with patch.dict("os.environ", env, clear=False):
             config = _load_config(cfg_file)
-        vx = config["providers"]["vertex-ai"]
-        assert vx["json"] == "/env/key.json"
-        assert vx["project"] == "env-project"
-        assert vx["region"] == "us-central1"
+        vx = config.providers.vertex_ai
+        assert vx.json_path == "/env/key.json"
+        assert vx.project == "env-project"
+        assert vx.region == "us-central1"
 
 
 class TestLoadDotenvFile:
@@ -173,5 +203,69 @@ level = "high"
 budget = 2048
 """)
         config = _load_config(cfg_file)
-        assert config["thinking"]["level"] == "high"
-        assert config["thinking"]["budget"] == 2048
+        assert config.thinking.level == "high"
+        assert config.thinking.budget == 2048
+
+
+class TestLoadConfigAgentSection:
+    def test_agent_section_preserved(self, tmp_path):
+        # The [agent] table drives build_agent_runner (cli_model, cli_timeout,
+        # backend, cli_provider). _load_config must carry it through; the
+        # previous allowlist loader silently dropped it.
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text("""\
+[model]
+name = "claude-sonnet-4-6"
+
+[agent]
+backend = "cli"
+cli_provider = "claude"
+cli_model = "claude-opus-4-8[1m]"
+cli_timeout = 1800
+""")
+        config = _load_config(cfg_file)
+        assert config.agent.cli_model == "claude-opus-4-8[1m]"
+        assert config.agent.cli_timeout == 1800
+        assert config.agent.backend == "cli"
+        assert config.agent.cli_provider == "claude"
+
+    def test_agent_section_defaults_to_empty(self, tmp_path):
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
+        config = _load_config(cfg_file)
+        assert config.agent.backend is None
+        assert config.agent.cli_provider is None
+        assert config.agent.cli_model is None
+        assert config.agent.cli_timeout is None
+
+
+class TestLoadConfigPerfEval:
+    def test_load_levels_preserved(self, tmp_path):
+        # [perf_eval].load_levels feeds the perf_eval prompt template; the
+        # allowlist loader dropped this section entirely.
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text("""\
+[model]
+name = "claude-sonnet-4-6"
+
+[[perf_eval.load_levels]]
+rate = 1
+duration = 20
+max_tokens = 128
+
+[[perf_eval.load_levels]]
+rate = 8
+duration = 20
+max_tokens = 256
+""")
+        config = _load_config(cfg_file)
+        levels = config.perf_eval.load_levels
+        assert levels is not None
+        assert [lvl.rate for lvl in levels] == [1, 8]
+        assert levels[1].max_tokens == 256
+
+    def test_perf_eval_defaults_to_none(self, tmp_path):
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
+        config = _load_config(cfg_file)
+        assert config.perf_eval.load_levels is None

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -3,6 +3,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+from vibe_serve.config import Config
 from vibe_serve.llm_client import _build_model
 
 
@@ -12,12 +13,14 @@ def _make_config(
     thinking=None,
     providers=None,
 ):
-    """Helper to build a config dict matching _load_config output."""
-    return {
-        "model": {"name": name, "provider": provider},
-        "thinking": thinking or {},
-        "providers": providers or {},
-    }
+    """Helper to build a validated :class:`Config` matching _load_config output."""
+    return Config.model_validate(
+        {
+            "model": {"name": name, "provider": provider},
+            "thinking": thinking or {},
+            "providers": providers or {},
+        }
+    )
 
 
 FAKE_CREDS_DICT = {
@@ -89,10 +92,11 @@ class TestGoogleGenaiProvider:
 
 
 class TestUnknownProvider:
-    def test_unknown_provider_raises(self):
-        config = _make_config("claude-sonnet-4-6", provider="bedrock")
-        with pytest.raises(NotImplementedError, match="bedrock"):
-            _build_model(config)
+    def test_unknown_provider_rejected_by_schema(self):
+        # Provider validation now happens at the Config boundary (fail-fast),
+        # not inside _build_model.
+        with pytest.raises(ValueError, match="bedrock"):
+            _make_config("claude-sonnet-4-6", provider="bedrock")
 
 
 # --- Vertex AI provider ---
@@ -227,27 +231,15 @@ class TestVertexAIProvider:
 
 class TestConfigToModel:
     def test_full_pipeline_anthropic(self):
-        config = {
-            "model": {"name": "claude-sonnet-4-6", "provider": "anthropic"},
-            "thinking": {},
-            "providers": {},
-        }
+        config = _make_config("claude-sonnet-4-6", provider="anthropic")
         assert _build_model(config) == "anthropic:claude-sonnet-4-6"
 
     def test_full_pipeline_google_genai(self):
-        config = {
-            "model": {"name": "gemini-2.5-pro", "provider": "google-genai"},
-            "thinking": {},
-            "providers": {},
-        }
+        config = _make_config("gemini-2.5-pro", provider="google-genai")
         assert _build_model(config) == "google_genai:gemini-2.5-pro"
 
     def test_full_pipeline_openai(self):
-        config = {
-            "model": {"name": "gpt-4o", "provider": "openai"},
-            "thinking": {},
-            "providers": {},
-        }
+        config = _make_config("gpt-4o", provider="openai")
         assert _build_model(config) == "openai:gpt-4o"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -4364,6 +4364,7 @@ dependencies = [
     { name = "mcp" },
     { name = "modal" },
     { name = "openai" },
+    { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "soundfile" },
 ]
@@ -4392,6 +4393,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.0" },
     { name = "modal", specifier = ">=1.4.2" },
     { name = "openai", specifier = ">=1.28.0" },
+    { name = "pydantic", specifier = ">=2" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "soundfile", specifier = ">=0.13.1" },
 ]


### PR DESCRIPTION
Closes #11.

## Problem

`_load_config` rebuilt the parsed TOML into a hand-maintained allowlist dict, so any section a consumer read but the author forgot to copy was **silently dropped**. This shipped two real bugs — `[agent]` (PR #9) and the still-latent `[perf_eval]`/`load_levels` drop — and left config-value resolution scattered across modules.

## Approach

A single source of truth: the `Config` pydantic v2 model and its nested sections (`model`, `thinking`, `providers`, `backend`, `agent`, `perf_eval`). `_load_config` parses → validates → env-overrides into a typed `Config`.

Implements the decisions agreed in #11:

- **Pydantic v2**, promoted to a direct dependency.
- **Fail-fast (`extra="forbid"`)**: unknown sections/keys, unknown providers/backends, missing required fields, and wrong types all raise instead of being silently dropped. `pydantic.ValidationError` subclasses `ValueError`, so the existing `cli.py` `except (ValueError, FileNotFoundError)` boundary and error UX are preserved.
- **Typed attribute access, all consumers migrated now**: `llm_client`, `context`, `cli`, `build_agent_runner`, and the plain loop's `perf_eval` read all move off `config["x"]` / `(config.get("x") or {})` chains to `config.model.name`, `config.agent.cli_model`, etc.
- **`as_config()`** coerces a raw mapping → validated `Config` at the loop/context entrypoints, so programmatic and test callers can still pass a dict.

### Latent bug fixed
`[perf_eval].load_levels` now actually reaches the plain loop (typed as `LoadLevelCfg`); it was dropped by the old allowlist.

### Notes / deliberate behavior changes
- The old `[backend]` "preserve arbitrary extra keys" forward-compat path is **replaced** by explicit schema fields (per the #11 decision to reject unknown keys). A misspelled key like `[agent].cli_modle` is now an error.
- Provider validation moved to the schema boundary; the `bedrock` test now asserts the schema rejects it (fail-fast) rather than `_build_model` raising late.
- The `VertexCfg` attribute is `json_path` (TOML key stays `json`) to avoid shadowing `BaseModel.json`.
- `[providers]` is modeled strictly (each known provider declared). The open-map alternative flagged in #11 is left as a follow-up if desired.

## Tests

- New: schema fail-fast (unknown section/key/backend), round-trip preservation of `[agent]` / `[perf_eval]` / `[providers]`, env-override.
- Migrated: `test_llm_client` (`_make_config` returns `Config`), the 8 `build_agent_runner` tests (typed `Config` via a helper).
- **Full suite: 664 passed** (`uv run python -m pytest`).

## Out of scope (follow-ups)
- Replacing the hand-rolled `_load_dotenv_file` with `python-dotenv`.
- Open-map modeling for `[providers]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)