### PR TITLE
Replace hand-rolled _load_dotenv_file with python-dotenv

### DIFF
--- a/src/vibe_serve/config.py
+++ b/src/vibe_serve/config.py
@@ -17,6 +17,7 @@ import tomllib
 from pathlib import Path
 from typing import Literal, Mapping
 
+from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict, Field
 
 from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND, PROJECT_ROOT
@@ -237,41 +238,14 @@ def as_config(config: "Config | Mapping") -> "Config":
 
 
 def _load_dotenv_file(path: Path = PROJECT_ROOT / ".env") -> None:
-    """Load environment variables from a .env-style file.
+    """Load environment variables from a ``.env`` file via ``python-dotenv``.
 
-    Supports KEY=VALUE lines with optional quotes. Existing environment variables
-    are preserved and not overwritten.
+    Existing environment variables take precedence (``override=False``); a
+    missing file is a no-op. Delegating to ``python-dotenv`` gets us correct
+    handling of ``export`` prefixes, quoting, inline comments, and multiline
+    values for free.
     """
-    if not path.exists():
-        return
-
-    with path.open(encoding="utf-8") as f:
-        for raw_line in f:
-            line = raw_line.strip()
-            if not line or line.startswith("#"):
-                continue
-
-            if line.startswith("export "):
-                line = line[len("export ") :].strip()
-
-            if "=" not in line:
-                continue
-
-            key, value = line.split("=", 1)
-            key = key.strip()
-            if not key:
-                continue
-
-            value = value.strip()
-            if not value:
-                os.environ.setdefault(key, "")
-                continue
-            if (
-                (value[0] == value[-1] == '"')
-                or (value[0] == value[-1] == "'")
-            ):
-                value = value[1:-1]
-            os.environ.setdefault(key, value)
+    load_dotenv(path, override=False)
 
 
 def _apply_vertex_env_overrides(config: Config) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,6 +190,20 @@ EMPTY=
             _load_dotenv_file(env_file)
             assert os.environ["OPENAI_API_KEY"] == "existing"
 
+    def test_load_dotenv_file_strips_inline_comments(self, tmp_path):
+        # python-dotenv strips trailing inline comments on unquoted values, but
+        # preserves a '#' inside quotes (the prior hand-rolled parser did neither).
+        env_file = tmp_path / ".env"
+        env_file.write_text('PLAIN=value # trailing comment\nQUOTED="val # hash"\n')
+        with patch.dict("os.environ", {}, clear=True):
+            _load_dotenv_file(env_file)
+            assert os.environ["PLAIN"] == "value"
+            assert os.environ["QUOTED"] == "val # hash"
+
+    def test_load_dotenv_file_missing_file_is_noop(self, tmp_path):
+        with patch.dict("os.environ", {}, clear=True):
+            _load_dotenv_file(tmp_path / "does-not-exist.env")  # no error
+
 
 class TestLoadConfigThinking:
     def test_thinking_parsed(self, tmp_path):


### PR DESCRIPTION
Closes #14.

## Problem
`_load_dotenv_file` hand-parsed `.env` line by line (strip `export `, split on first `=`, trim one layer of matching quotes, `setdefault`). It works for the common cases but reimplements a solved problem and silently mishandles others — e.g. a trailing inline comment (`KEY=value # note`) was kept verbatim in the value.

## Change
- Delegate to [`python-dotenv`](https://pypi.org/project/python-dotenv/) via `load_dotenv(path, override=False)`. It was **already a dependency** (`python-dotenv>=1.0.1` in `pyproject.toml`), so no new dependency is added.
- `override=False` preserves the prior "existing env vars win" semantics; a missing file remains a no-op. The function name/signature are unchanged, so callers (`_load_config`) and tests are unaffected.

## Behavior
Existing `TestLoadDotenvFile` cases (comments, single/double quotes, `export ` prefix, empty value, don't-override-existing) still pass unchanged. python-dotenv additionally handles cases the old parser didn't — inline comments, escapes, multiline values, `${VAR}` interpolation.

## Tests
- All prior dotenv tests pass as-is.
- New: `test_load_dotenv_file_strips_inline_comments` (unquoted value drops a trailing `# comment`; a `#` inside quotes is preserved) and `test_load_dotenv_file_missing_file_is_noop`.
- **Full suite: 670 passed** (`uv run python -m pytest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)