### PR TITLE
Add default queue reference, accuracy checker, and benchmark harness

### DIFF
--- a/examples/queue-default/OBJECTIVE.md
+++ b/examples/queue-default/OBJECTIVE.md
@@ -1,0 +1,20 @@
+# Objective - Queue default harness
+
+Maximize throughput (operations/second) of a concurrent queue under the
+workload defined by the active scenario, while satisfying correctness invariants.
+
+## Scenarios
+
+| Scenario | Description |
+|----------|-------------|
+| spsc | Single-producer single-consumer bounded FIFO |
+| mpmc | Multi-producer multi-consumer bounded FIFO |
+| mpsc | Multi-producer single-consumer bounded FIFO |
+| lossy | Single-writer lossy overwrite (newest item wins on full) |
+| batch | SPSC batched handoff (producer drains into consumer in bulk) |
+
+## Notes
+
+- Reference uses collections.deque with threading.Lock.
+- Protocol: enqueue(item), dequeue(), size(), capacity.
+- No hardware accelerator required; CPU-only.

--- a/examples/queue-default/README.md
+++ b/examples/queue-default/README.md
@@ -1,0 +1,23 @@
+# Queue Default Harness
+
+Resolves #43.
+
+Reusable reference implementations, correctness checkers, and benchmark
+drivers for the five initial VibeServe queue scenarios.
+
+## Running the correctness checker
+
+    python accuracy_checker/checker.py --scenario all
+    python accuracy_checker/checker.py --scenario mpmc --producers 4 --consumers 4
+
+## Running the benchmark
+
+    python benchmark/benchmark.py --scenario spsc --duration 10
+    python benchmark/benchmark.py --scenario all --output-json results.json
+    python benchmark/benchmark.py --scenario spsc --use-reference
+
+## Acceptance criteria (from #43)
+
+- Each reference implementation passes its scenario correctness checker.
+- The benchmark runs each scenario without changing benchmark code.
+- Scenario issues can reference this harness without restating shared terminology.

--- a/examples/queue-default/accuracy_checker/checker.py
+++ b/examples/queue-default/accuracy_checker/checker.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+import argparse, random, sys, threading
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent / "reference"))
+from reference import QueueFactory, SCENARIOS
+
+def _load_candidate():
+    try:
+        from main import VibeServeQueue
+        return VibeServeQueue
+    except ImportError as exc:
+        raise RuntimeError("Could not import VibeServeQueue from main.py") from exc
+
+def _build_log(ops, seed=42):
+    rng = random.Random(seed)
+    return [("enqueue", i) if rng.random() < 0.6 else ("dequeue", None) for i in range(ops)]
+
+def _replay(queue, log):
+    trace = []
+    for kind, item in log:
+        if kind == "enqueue": trace.append(("enqueue", queue.enqueue(item)))
+        else: trace.append(("dequeue", queue.dequeue()))
+    return trace
+
+def _check_spsc(cls, capacity, ops, seed):
+    ref = QueueFactory("spsc", capacity)
+    cand = cls(scenario="spsc", capacity=capacity)
+    log = _build_log(ops, seed)
+    for i, (r, c) in enumerate(zip(_replay(ref, log), _replay(cand, log))):
+        if r != c:
+            return False, f"SPSC mismatch at op {i}: ref={r!r} cand={c!r}"
+    return True, f"SPSC OK ({ops} ops, capacity={capacity})"
+
+def _check_mpmc(cls, capacity, ops, producers, consumers, seed):
+    ipp = ops // producers
+    enqueued, dequeued = set(), []
+    el, dl = threading.Lock(), threading.Lock()
+    cand = cls(scenario="mpmc", capacity=capacity)
+    barrier = threading.Barrier(producers + consumers)
+    stop = threading.Event()
+    def producer(pid):
+        barrier.wait()
+        for i in range(ipp):
+            item = pid * ipp + i
+            if cand.enqueue(item):
+                with el: enqueued.add(item)
+    def consumer(_):
+        barrier.wait()
+        while not stop.is_set() or cand.size() > 0:
+            x = cand.dequeue()
+            if x is not None:
+                with dl: dequeued.append(x)
+    ts = [threading.Thread(target=producer, args=(p,), daemon=True) for p in range(producers)]
+    ts += [threading.Thread(target=consumer, args=(c,), daemon=True) for c in range(consumers)]
+    for t in ts: t.start()
+    for t in ts[:producers]: t.join()
+    stop.set()
+    for t in ts[producers:]: t.join(timeout=5)
+    while True:
+        x = cand.dequeue()
+        if x is None: break
+        dequeued.append(x)
+    dset = set(dequeued)
+    dups = len(dequeued) - len(dset)
+    missing = enqueued - dset
+    extra = dset - enqueued
+    if dups or missing or extra:
+        return False, f"MPMC failure: dups={dups}, missing={len(missing)}, extra={len(extra)}"
+    return True, f"MPMC OK ({producers}P/{consumers}C enqueued={len(enqueued)} dequeued={len(dequeued)})"
+
+def _check_mpsc(cls, capacity, ops, producers, seed):
+    return _check_mpmc(cls, capacity, ops, producers, 1, seed)
+
+def _check_lossy(cls, capacity, ops, seed):
+    cand = cls(scenario="lossy", capacity=capacity)
+    rng = random.Random(seed)
+    enqueued, dequeued = set(), []
+    for i in range(ops):
+        if rng.random() < 0.6:
+            ok = cand.enqueue(i)
+            if not ok: return False, f"Lossy enqueue returned False at op {i}"
+            enqueued.add(i)
+        else:
+            x = cand.dequeue()
+            if x is not None: dequeued.append(x)
+        if cand.size() > capacity: return False, f"size {cand.size()} > capacity {capacity}"
+    fab = set(dequeued) - enqueued
+    if fab: return False, f"Lossy returned items never enqueued: {list(fab)[:5]}"
+    return True, f"Lossy OK ({ops} ops, capacity={capacity}, dequeued={len(dequeued)})"
+
+def _check_batch(cls, capacity, ops, seed):
+    cand = cls(scenario="batch", capacity=capacity)
+    rng = random.Random(seed)
+    enqueued, dequeued = [], []
+    for i in range(ops):
+        if rng.random() < 0.6:
+            if cand.enqueue(i): enqueued.append(i)
+        else:
+            batch = cand.dequeue()
+            if not isinstance(batch, list): return False, f"Batch dequeue must return list, got {type(batch).__name__}"
+            dequeued.extend(batch)
+    fab = set(dequeued) - set(enqueued)
+    if fab: return False, f"Batch returned items never enqueued: {list(fab)[:5]}"
+    dups = len(dequeued) - len(set(dequeued))
+    if dups: return False, f"Batch returned {dups} duplicates"
+    return True, f"Batch OK ({ops} ops, capacity={capacity}, dequeued={len(dequeued)})"
+
+def main():
+    parser = argparse.ArgumentParser(description="Correctness checker for VibeServe queue scenarios.")
+    parser.add_argument("--scenario", choices=[*SCENARIOS, "all"], default="all")
+    parser.add_argument("--capacity", type=int, default=64)
+    parser.add_argument("--ops", type=int, default=2000)
+    parser.add_argument("--producers", type=int, default=4)
+    parser.add_argument("--consumers", type=int, default=4)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+    print("Loading VibeServeQueue from main.py ...")
+    cls = _load_candidate()
+    print("  Loaded.")
+    targets = SCENARIOS if args.scenario == "all" else [args.scenario]
+    results = {}
+    for s in targets:
+        print(f"[{s.upper()}] Checking ...")
+        try:
+            if s == "spsc":    ok, msg = _check_spsc(cls, args.capacity, args.ops, args.seed)
+            elif s == "mpmc":  ok, msg = _check_mpmc(cls, args.capacity, args.ops, args.producers, args.consumers, args.seed)
+            elif s == "mpsc":  ok, msg = _check_mpsc(cls, args.capacity, args.ops, args.producers, args.seed)
+            elif s == "lossy": ok, msg = _check_lossy(cls, args.capacity, args.ops, args.seed)
+            elif s == "batch": ok, msg = _check_batch(cls, args.capacity, args.ops, args.seed)
+        except Exception as e:
+            ok, msg = False, f"Exception: {e}"
+        print(f"  PASS - {msg}" if ok else f"  FAIL - {msg}")
+        results[s] = ok
+    passed = sum(results.values())
+    print(f"Results: {passed}/{len(results)} passed")
+    sys.exit(0 if passed == len(results) else 1)
+
+if __name__ == "__main__":
+    main()

--- a/examples/queue-default/benchmark/benchmark.py
+++ b/examples/queue-default/benchmark/benchmark.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+import argparse, json, sys, threading, time
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent / "reference"))
+from reference import QueueFactory, SCENARIOS
+
+def _load_candidate():
+    try:
+        from main import VibeServeQueue
+        return VibeServeQueue
+    except ImportError:
+        return None
+
+def _producer(queue, item, stop, c, lock):
+    enc, drp = 0, 0
+    while not stop.is_set():
+        if queue.enqueue(item): enc += 1
+        else: drp += 1
+    with lock: c[0] += enc; c[1] += drp
+
+def _consumer(queue, stop, c, lock, is_batch):
+    dec = 0
+    while not stop.is_set() or queue.size() > 0:
+        r = queue.dequeue()
+        dec += len(r) if is_batch else (1 if r is not None else 0)
+    with lock: c[0] += dec
+
+def _run(queue, scenario, duration, warmup, producers, consumers, item_bytes):
+    is_batch = scenario == "batch"
+    item = b"x" * item_bytes
+    stop = threading.Event()
+    lock = threading.Lock()
+    pc, dc = [0, 0], [0]
+    def make():
+        ts = [threading.Thread(target=_producer, args=(queue, item, stop, pc, lock), daemon=True) for _ in range(producers)]
+        ts += [threading.Thread(target=_consumer, args=(queue, stop, dc, lock, is_batch), daemon=True) for _ in range(consumers)]
+        return ts
+    if warmup > 0:
+        wts = make()
+        for t in wts: t.start()
+        time.sleep(warmup)
+        stop.set()
+        for t in wts: t.join(timeout=2)
+        stop.clear(); pc[:] = [0, 0]; dc[:] = [0]
+    ts = make()
+    for t in ts: t.start()
+    t0 = time.perf_counter()
+    time.sleep(duration)
+    stop.set()
+    for t in ts: t.join(timeout=5)
+    elapsed = time.perf_counter() - t0
+    enc, drp, dec = pc[0], pc[1], dc[0]
+    print(f"Scenario: {scenario.upper()}  Duration: {elapsed:.1f}s  Prod: {producers}  Cons: {consumers}")
+    print(f"  Enqueued: {enc:,} ({enc/elapsed:,.0f} ops/s)  Dropped: {drp:,}  Dequeued: {dec:,} ({dec/elapsed:,.0f} ops/s)")
+    print(f"  Total: {enc+dec:,} ({(enc+dec)/elapsed:,.0f} ops/s)")
+    return {"scenario": scenario, "enqueued": enc, "dropped": drp, "dequeued": dec, "duration": elapsed, "total_ops_per_sec": (enc+dec)/elapsed}
+
+def main():
+    parser = argparse.ArgumentParser(description="Throughput benchmark for VibeServe queue scenarios.")
+    parser.add_argument("--scenario", choices=[*SCENARIOS, "all"], default="spsc")
+    parser.add_argument("--capacity", type=int, default=1024)
+    parser.add_argument("--item-bytes", type=int, default=64)
+    parser.add_argument("--producers", type=int, default=1)
+    parser.add_argument("--consumers", type=int, default=1)
+    parser.add_argument("--duration", type=float, default=10.0)
+    parser.add_argument("--warmup", type=float, default=2.0)
+    parser.add_argument("--use-reference", action="store_true")
+    parser.add_argument("--output-json", type=str, default=None)
+    args = parser.parse_args()
+    targets = SCENARIOS if args.scenario == "all" else [args.scenario]
+    results = []
+    for s in targets:
+        n_prod = args.producers if s in ("mpmc", "mpsc") else 1
+        n_cons = args.consumers if s == "mpmc" else 1
+        if args.use_reference:
+            q = QueueFactory(s, args.capacity)
+        else:
+            cls = _load_candidate()
+            q = cls(scenario=s, capacity=args.capacity) if cls else QueueFactory(s, args.capacity)
+        results.append(_run(q, s, args.duration, args.warmup, n_prod, n_cons, args.item_bytes))
+    if args.output_json:
+        with open(args.output_json, "w") as f: json.dump(results, f, indent=2)
+        print(f"Results written to {args.output_json}")
+
+if __name__ == "__main__":
+    main()

--- a/examples/queue-default/reference/reference.py
+++ b/examples/queue-default/reference/reference.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+import threading
+from collections import deque
+from typing import Any
+
+class _BoundedQueue:
+    def __init__(self, capacity):
+        if capacity <= 0: raise ValueError(f"capacity must be > 0, got {capacity}")
+        self.capacity = capacity
+        self._dq = deque()
+        self._lock = threading.Lock()
+        self._not_full = threading.Condition(self._lock)
+        self._not_empty = threading.Condition(self._lock)
+
+    def enqueue(self, item, block=False, timeout=None):
+        with self._not_full:
+            if len(self._dq) >= self.capacity:
+                if not block: return False
+                if not self._not_full.wait_for(lambda: len(self._dq) < self.capacity, timeout=timeout): return False
+            self._dq.append(item)
+            self._not_empty.notify()
+            return True
+
+    def dequeue(self, block=False, timeout=None):
+        with self._not_empty:
+            if not self._dq:
+                if not block: return None
+                if not self._not_empty.wait_for(lambda: bool(self._dq), timeout=timeout): return None
+            item = self._dq.popleft()
+            self._not_full.notify()
+            return item
+
+    def size(self):
+        with self._lock: return len(self._dq)
+
+class SPSCQueue(_BoundedQueue): pass
+class MPMCQueue(_BoundedQueue): pass
+class MPSCQueue(_BoundedQueue): pass
+
+class LossyQueue:
+    def __init__(self, capacity):
+        if capacity <= 0: raise ValueError(f"capacity must be > 0, got {capacity}")
+        self.capacity = capacity
+        self._dq = deque(maxlen=capacity)
+        self._lock = threading.Lock()
+    def enqueue(self, item, **_):
+        with self._lock: self._dq.append(item)
+        return True
+    def dequeue(self, **_):
+        with self._lock: return self._dq.popleft() if self._dq else None
+    def size(self):
+        with self._lock: return len(self._dq)
+
+class BatchSPSCQueue:
+    def __init__(self, capacity):
+        if capacity <= 0: raise ValueError(f"capacity must be > 0, got {capacity}")
+        self.capacity = capacity
+        self._dq = deque()
+        self._lock = threading.Lock()
+    def enqueue(self, item, **_):
+        with self._lock:
+            if len(self._dq) >= self.capacity: return False
+            self._dq.append(item); return True
+    def dequeue(self, **_):
+        with self._lock:
+            if not self._dq: return []
+            batch = list(self._dq); self._dq.clear(); return batch
+    def size(self):
+        with self._lock: return len(self._dq)
+
+_SCENARIO_MAP = {"spsc": SPSCQueue, "mpmc": MPMCQueue, "mpsc": MPSCQueue, "lossy": LossyQueue, "batch": BatchSPSCQueue}
+SCENARIOS = list(_SCENARIO_MAP)
+
+def QueueFactory(scenario, capacity=1024):
+    cls = _SCENARIO_MAP.get(scenario)
+    return cls(capacity=capacity)


### PR DESCRIPTION
Closes #43

## Summary

Adds a reusable harness for the five initial VibeServe queue scenarios: `spsc`, `mpmc`, `mpsc`, `lossy`, and `batch`. This follows the same `reference/ + accuracy_checker/ + benchmark/` layout used by the existing LLM-serving examples, so scenario issues for queues (#40–#42, etc.) can build on a shared contract instead of redefining harness conventions each time.

## What's included

- `reference/reference.py` — baseline implementations for all five scenarios, built on `collections.deque` with `threading.Lock`/`Condition` for blocking variants. All variants expose the same minimal protocol: `enqueue(item)`, `dequeue()`, `size()`, `capacity`.
- `accuracy_checker/checker.py` — verifies a candidate implementation against the reference:
  - `spsc`: replays a randomized op log against both reference and candidate, asserts identical results at every step.
  - `mpmc` / `mpsc`: runs concurrent producer/consumer threads and checks for no lost or duplicated items.
  - `lossy`: checks the queue never exceeds capacity and never returns an item that wasn't enqueued.
  - `batch`: checks batched dequeues never return duplicates or fabricated items.
- `benchmark/benchmark.py` — measures throughput (ops/sec) for each scenario under configurable producer/consumer counts and duration.
- `OBJECTIVE.md` / `README.md` — scenario descriptions and usage instructions for implementers.

## Verification

Ran the checker against the reference implementation itself (sanity baseline — all 5 scenarios pass). I also deliberately broke the SPSC candidate (had it pop from the wrong end of the deque, violating FIFO order) to confirm the checker actually catches incorrect implementations rather than passing everything — it correctly failed and reported the exact operation index where the mismatch occurred.

## Notes

`mpmc` and `mpsc` currently share the same underlying bounded-queue class as `spsc` — the harness doesn't yet enforce scenario-specific concurrency guarantees beyond what the checker tests for. Happy to extend if reviewers want stricter differentiation between these reference variants.