### PR TITLE
[codex] Ignore local metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,23 @@
 # macOS metadata
 .DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100/
+.TemporaryItems/
+.Trashes/
+.fseventsd/
+
+# Windows metadata
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# Editor backup/swap files
+*.swp
+*.swo
+*~
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
## Summary

- Expand `.gitignore` coverage for local OS metadata beyond `.DS_Store`.
- Ignore common Windows metadata files and editor backup/swap files.

## Why

Local filesystem metadata and temporary editor files can otherwise show up as untracked noise in development worktrees.

## Validation

- Ran `git check-ignore -v .DS_Store .AppleDouble ._foo Thumbs.db Desktop.ini swap.swp backup~` to confirm the new and existing patterns match.
- No runtime tests were run because this is a `.gitignore`-only change.