### PR TITLE
[codex] Add Python formatting checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
+      - name: Check Python formatting
+        run: ./scripts/check_format.sh
+
       - name: Run tests
         run: uv run python -m pytest -v

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ resources/skills/serving-systems/ # Agent Skills library
 ## Development
 
 ```bash
+./scripts/format.sh                                # format src/ and tests/
+./scripts/check_format.sh                          # check formatting for CI
 uv run pytest                                       # full suite
 uv run pytest tests/loops/plain/test_plain_loop.py  # one file
 uv run pytest -k orchestrator                       # by keyword

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ resources/skills/serving-systems/ # Agent Skills library
 ## Development
 
 ```bash
-./scripts/format.sh                                # format src/ and tests/
+./scripts/format.sh                                # format checked Python dirs
 ./scripts/check_format.sh                          # check formatting for CI
 uv run pytest                                       # full suite
 uv run pytest tests/loops/plain/test_plain_loop.py  # one file

--- a/examples/Llama-3-8B-trn2/accuracy_check.py
+++ b/examples/Llama-3-8B-trn2/accuracy_check.py
@@ -17,14 +17,13 @@ import time
 from pathlib import Path
 
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
-
 from step_1_fastapi import load_llama_model
-
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # ---------------------------------------------------------------------------
 # Load .env
 # ---------------------------------------------------------------------------
+
 
 def _load_env():
     env_path = Path(__file__).resolve().parent / ".env"
@@ -46,7 +45,7 @@ _load_env()
 RAW_COMPLETION_SAMPLES: list[tuple[str, int, str]] = [
     ("The capital of France is", 15, "short factual completion"),
     ("Once upon a time, in a land far away,", 50, "story continuation"),
-    ("def fibonacci(n):\n    \"\"\"Return the n-th Fibonacci number.\"\"\"\n", 40, "code completion"),
+    ('def fibonacci(n):\n    """Return the n-th Fibonacci number."""\n', 40, "code completion"),
     ("1 + 1 =", 5, "arithmetic"),
     ("A B C D E F G H I J K L M N O P Q R S T U V W X Y Z A B C D E F G", 20, "alphabet pattern"),
     (
@@ -97,6 +96,7 @@ CHAT_SAMPLES: list[tuple[list[dict[str, str]], int, str]] = [
 # Reference: HuggingFace model.generate()
 # ---------------------------------------------------------------------------
 
+
 @torch.inference_mode()
 def generate_reference(model, tokenizer, prompt_text, max_new_tokens, device):
     inputs = tokenizer(prompt_text, return_tensors="pt").to(device)
@@ -108,6 +108,7 @@ def generate_reference(model, tokenizer, prompt_text, max_new_tokens, device):
 # ---------------------------------------------------------------------------
 # Our implementation: custom model with manual token-by-token loop
 # ---------------------------------------------------------------------------
+
 
 @torch.inference_mode()
 def generate_custom(model, tokenizer, prompt_text, max_new_tokens, device):
@@ -141,6 +142,7 @@ def generate_custom(model, tokenizer, prompt_text, max_new_tokens, device):
 # Comparison logic
 # ---------------------------------------------------------------------------
 
+
 def compare_outputs(ref_ids, custom_ids, tokenizer):
     ref_text = tokenizer.decode(ref_ids, skip_special_tokens=True)
     custom_text = tokenizer.decode(custom_ids, skip_special_tokens=True)
@@ -159,8 +161,8 @@ def compare_outputs(ref_ids, custom_ids, tokenizer):
         f"MISMATCH at token {first_diff}.\n"
         f"  Reference ({len(ref_ids):3d} tokens): {ref_text!r}\n"
         f"  Custom    ({len(custom_ids):3d} tokens): {custom_text!r}\n"
-        f"  Ref  ids[{first_diff}:]: {ref_ids[first_diff:first_diff+10]}\n"
-        f"  Cust ids[{first_diff}:]: {custom_ids[first_diff:first_diff+10]}"
+        f"  Ref  ids[{first_diff}:]: {ref_ids[first_diff : first_diff + 10]}\n"
+        f"  Cust ids[{first_diff}:]: {custom_ids[first_diff : first_diff + 10]}"
     )
     return False, detail
 
@@ -168,6 +170,7 @@ def compare_outputs(ref_ids, custom_ids, tokenizer):
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
 
 def main():
     parser = argparse.ArgumentParser(description="Accuracy checker: custom model vs HF reference")
@@ -188,7 +191,10 @@ def main():
     print(f"Loading HF reference model on {args.device} ...")
     t0 = time.perf_counter()
     ref_model = AutoModelForCausalLM.from_pretrained(
-        args.model, torch_dtype=dtype, device_map=args.device, token=hf_token,
+        args.model,
+        torch_dtype=dtype,
+        device_map=args.device,
+        token=hf_token,
         attn_implementation="eager",
     )
     ref_model.eval()
@@ -206,7 +212,9 @@ def main():
     has_chat_template = hasattr(tokenizer, "apply_chat_template") and tokenizer.chat_template
     for messages, max_tokens, desc in CHAT_SAMPLES:
         if has_chat_template:
-            prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+            prompt = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
         else:
             prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages) + "\nassistant:"
         test_cases.append((prompt, max_tokens, f"[chat] {desc}"))

--- a/examples/Llama-3-8B-trn2/accuracy_checker/checker.py
+++ b/examples/Llama-3-8B-trn2/accuracy_checker/checker.py
@@ -67,7 +67,7 @@ def _load_custom_model_class():
 RAW_COMPLETION_SAMPLES: list[tuple[str, int, str]] = [
     ("The capital of France is", 15, "short factual completion"),
     ("Once upon a time, in a land far away,", 50, "story continuation"),
-    ("def fibonacci(n):\n    \"\"\"Return the n-th Fibonacci number.\"\"\"\n", 40, "code completion"),
+    ('def fibonacci(n):\n    """Return the n-th Fibonacci number."""\n', 40, "code completion"),
     ("1 + 1 =", 5, "arithmetic"),
     ("A B C D E F G H I J K L M N O P Q R S T U V W X Y Z A B C D E F G", 20, "alphabet pattern"),
     (
@@ -118,6 +118,7 @@ CHAT_SAMPLES: list[tuple[list[dict[str, str]], int, str]] = [
 # Reference: HuggingFace model.generate()
 # ---------------------------------------------------------------------------
 
+
 @torch.inference_mode()
 def generate_reference(model, tokenizer, prompt_text, max_new_tokens, device):
     inputs = tokenizer(prompt_text, return_tensors="pt").to(device)
@@ -129,6 +130,7 @@ def generate_reference(model, tokenizer, prompt_text, max_new_tokens, device):
 # ---------------------------------------------------------------------------
 # Custom model: uses VibeServeModel.generate()
 # ---------------------------------------------------------------------------
+
 
 @torch.inference_mode()
 def generate_custom(model, tokenizer, prompt_text, max_new_tokens, device):
@@ -142,6 +144,7 @@ def generate_custom(model, tokenizer, prompt_text, max_new_tokens, device):
 # ---------------------------------------------------------------------------
 # Comparison logic
 # ---------------------------------------------------------------------------
+
 
 def compare_outputs(ref_ids, custom_ids, tokenizer):
     ref_text = tokenizer.decode(ref_ids, skip_special_tokens=True)
@@ -161,8 +164,8 @@ def compare_outputs(ref_ids, custom_ids, tokenizer):
         f"MISMATCH at token {first_diff}.\n"
         f"  Reference ({len(ref_ids):3d} tokens): {ref_text!r}\n"
         f"  Custom    ({len(custom_ids):3d} tokens): {custom_text!r}\n"
-        f"  Ref  ids[{first_diff}:]: {ref_ids[first_diff:first_diff+10]}\n"
-        f"  Cust ids[{first_diff}:]: {custom_ids[first_diff:first_diff+10]}"
+        f"  Ref  ids[{first_diff}:]: {ref_ids[first_diff : first_diff + 10]}\n"
+        f"  Cust ids[{first_diff}:]: {custom_ids[first_diff : first_diff + 10]}"
     )
     return False, detail
 
@@ -171,16 +174,21 @@ def compare_outputs(ref_ids, custom_ids, tokenizer):
 # Main
 # ---------------------------------------------------------------------------
 
+
 def main():
     parser = argparse.ArgumentParser(description="Accuracy checker: custom model vs HF reference")
     parser.add_argument(
-        "--model-dir", type=str, default="../model",
+        "--model-dir",
+        type=str,
+        default="../model",
         help="Local path to model weights directory (default: ../model)",
     )
     parser.add_argument(
-        "--device", type=str, default="auto",
+        "--device",
+        type=str,
+        default="auto",
         help="Device for both reference and custom model. 'auto' (default) "
-             "uses cuda:0 if available, else cpu (Trainium boxes have no CUDA).",
+        "uses cuda:0 if available, else cpu (Trainium boxes have no CUDA).",
     )
     args = parser.parse_args()
 
@@ -201,7 +209,9 @@ def main():
     has_chat_template = hasattr(tokenizer, "apply_chat_template") and tokenizer.chat_template
     for messages, max_tokens, desc in CHAT_SAMPLES:
         if has_chat_template:
-            prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+            prompt = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
         else:
             prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages) + "\nassistant:"
         test_cases.append((prompt, max_tokens, f"[chat] {desc}"))
@@ -212,7 +222,9 @@ def main():
     print(f"\nLoading HF reference model on {device} ...")
     t0 = time.perf_counter()
     ref_model = AutoModelForCausalLM.from_pretrained(
-        model_dir, torch_dtype=dtype, attn_implementation="eager",
+        model_dir,
+        torch_dtype=dtype,
+        attn_implementation="eager",
     )
     ref_model.to(device).eval()
     print(f"  HF model loaded in {time.perf_counter() - t0:.1f}s")

--- a/examples/Llama-3-8B-trn2/benchmark.py
+++ b/examples/Llama-3-8B-trn2/benchmark.py
@@ -55,8 +55,11 @@ def _load_tokenizer(model_path):
 
             tok = AutoTokenizer.from_pretrained(path)
             excluded = set(getattr(tok, "all_special_ids", []) or [])
-            pool = [t for t in range(len(tok))
-                    if t not in excluded and tok.decode([t], skip_special_tokens=True).strip()]
+            pool = [
+                t
+                for t in range(len(tok))
+                if t not in excluded and tok.decode([t], skip_special_tokens=True).strip()
+            ]
             if pool:
                 print(f"[prompt] tokenizer from {path}; pool={len(pool)}")
                 return tok, pool
@@ -68,7 +71,9 @@ def _load_tokenizer(model_path):
 
 def make_prompt(tokenizer, pool, input_len, rng):
     if tokenizer is not None and pool:
-        return tokenizer.decode([rng.choice(pool) for _ in range(input_len)], skip_special_tokens=True)
+        return tokenizer.decode(
+            [rng.choice(pool) for _ in range(input_len)], skip_special_tokens=True
+        )
     return " ".join(["token"] * input_len)
 
 
@@ -98,7 +103,7 @@ async def send_request(client, url, prompt, output_len, temperature):
             async for raw in resp.aiter_lines():
                 if not raw.startswith("data: "):
                     continue
-                payload = raw[len("data: "):]
+                payload = raw[len("data: ") :]
                 if payload.strip() == "[DONE]":
                     break
                 chunk = json.loads(payload)
@@ -116,7 +121,13 @@ async def send_request(client, url, prompt, output_len, temperature):
     gen = usage_tokens if usage_tokens is not None else out_tokens
     ttft = (t_first - t_send) if t_first is not None else None
     tpot = (t_done - t_first) / (gen - 1) if (t_first is not None and gen > 1) else None
-    return {"error": error, "gen_tokens": gen, "ttft_s": ttft, "tpot_s": tpot, "latency_s": t_done - t_send}
+    return {
+        "error": error,
+        "gen_tokens": gen,
+        "ttft_s": ttft,
+        "tpot_s": tpot,
+        "latency_s": t_done - t_send,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +140,7 @@ def _pct(vals, p):
         return None
     s = sorted(vals)
     import math
+
     return s[max(0, min(int(math.ceil(p / 100 * len(s))) - 1, len(s) - 1))]
 
 
@@ -150,15 +162,25 @@ async def measure(client, url, tokenizer, pool, length, concurrency, duration, t
     ttfts = [r["ttft_s"] for r in ok if r["ttft_s"] is not None]
     tpots = [r["tpot_s"] for r in ok if r["tpot_s"] is not None]
     return {
-        "input_len": length, "output_len": length, "concurrency": concurrency,
-        "completed": len(ok), "failed": len(results) - len(ok),
-        "wall_s": wall, "generated_tokens": gen,
+        "input_len": length,
+        "output_len": length,
+        "concurrency": concurrency,
+        "completed": len(ok),
+        "failed": len(results) - len(ok),
+        "wall_s": wall,
+        "generated_tokens": gen,
         "output_tokens_per_s": gen / wall if wall > 0 else 0.0,
         "request_throughput_per_s": len(ok) / wall if wall > 0 else 0.0,
-        "ttft_s": {"p50": _pct(ttfts, 50), "p90": _pct(ttfts, 90),
-                   "mean": statistics.fmean(ttfts) if ttfts else None},
-        "tpot_s": {"p50": _pct(tpots, 50), "p90": _pct(tpots, 90),
-                   "mean": statistics.fmean(tpots) if tpots else None},
+        "ttft_s": {
+            "p50": _pct(ttfts, 50),
+            "p90": _pct(ttfts, 90),
+            "mean": statistics.fmean(ttfts) if ttfts else None,
+        },
+        "tpot_s": {
+            "p50": _pct(tpots, 50),
+            "p90": _pct(tpots, 90),
+            "mean": statistics.fmean(tpots) if tpots else None,
+        },
     }
 
 
@@ -174,9 +196,19 @@ async def run_benchmark(args):
     tokenizer, pool = _load_tokenizer(args.model_path)
     rng = random.Random(args.seed)
 
-    print(json.dumps({"url": url, "lengths": lengths, "concurrency": concs,
-                      "duration_s": args.duration, "warmup_requests": args.warmup_requests}, indent=2),
-          flush=True)
+    print(
+        json.dumps(
+            {
+                "url": url,
+                "lengths": lengths,
+                "concurrency": concs,
+                "duration_s": args.duration,
+                "warmup_requests": args.warmup_requests,
+            },
+            indent=2,
+        ),
+        flush=True,
+    )
 
     scenarios: list[dict] = []
     async with httpx.AsyncClient() as client:
@@ -186,33 +218,52 @@ async def run_benchmark(args):
             warm = []
             for length in lengths:
                 for _ in range(args.warmup_requests):
-                    warm.append(send_request(client, url,
-                                             make_prompt(tokenizer, pool, length, rng),
-                                             length, args.temperature))
+                    warm.append(
+                        send_request(
+                            client,
+                            url,
+                            make_prompt(tokenizer, pool, length, rng),
+                            length,
+                            args.temperature,
+                        )
+                    )
             await asyncio.gather(*warm)
             print("Warm-up done.\n", flush=True)
 
         # --- Timed closed-loop sweep over (length, concurrency). ---
         for length in lengths:
             for c in concs:
-                print(f"MEASURE length={length} concurrency={c} for {args.duration}s ...", flush=True)
-                s = await measure(client, url, tokenizer, pool, length, c,
-                                  args.duration, args.temperature, rng)
+                print(
+                    f"MEASURE length={length} concurrency={c} for {args.duration}s ...", flush=True
+                )
+                s = await measure(
+                    client, url, tokenizer, pool, length, c, args.duration, args.temperature, rng
+                )
                 scenarios.append(s)
-                print(f"  -> {s['output_tokens_per_s']:.1f} tok/s "
-                      f"({s['completed']} reqs, tpot_p50={s['tpot_s']['p50']})", flush=True)
+                print(
+                    f"  -> {s['output_tokens_per_s']:.1f} tok/s "
+                    f"({s['completed']} reqs, tpot_p50={s['tpot_s']['p50']})",
+                    flush=True,
+                )
 
     # Headline: peak sustained output tok/s across the sweep (warm, no overload).
     peak = max((s["output_tokens_per_s"] for s in scenarios), default=0.0)
     best = max(scenarios, key=lambda s: s["output_tokens_per_s"], default=None)
 
     result = {
-        "config": {"url": url, "lengths": lengths, "concurrency": concs,
-                   "duration_s": args.duration, "warmup_requests": args.warmup_requests,
-                   "temperature": args.temperature, "seed": args.seed},
-        "aggregate_throughput": peak,            # headline: peak steady-state tok/s
-        "peak_scenario": {k: best[k] for k in ("input_len", "concurrency",
-                          "output_tokens_per_s")} if best else None,
+        "config": {
+            "url": url,
+            "lengths": lengths,
+            "concurrency": concs,
+            "duration_s": args.duration,
+            "warmup_requests": args.warmup_requests,
+            "temperature": args.temperature,
+            "seed": args.seed,
+        },
+        "aggregate_throughput": peak,  # headline: peak steady-state tok/s
+        "peak_scenario": {k: best[k] for k in ("input_len", "concurrency", "output_tokens_per_s")}
+        if best
+        else None,
         "scenarios": scenarios,
     }
 
@@ -220,8 +271,10 @@ async def run_benchmark(args):
     print("  Benchmark summary (warm, closed-loop)")
     print("=" * 56)
     for s in scenarios:
-        print(f"  len={s['input_len']:>4} c={s['concurrency']:>2}  "
-              f"{s['output_tokens_per_s']:7.1f} tok/s   req/s={s['request_throughput_per_s']:.2f}")
+        print(
+            f"  len={s['input_len']:>4} c={s['concurrency']:>2}  "
+            f"{s['output_tokens_per_s']:7.1f} tok/s   req/s={s['request_throughput_per_s']:.2f}"
+        )
     print(f"\nAggregate throughput (peak steady-state): {peak:.1f} tok/s  (headline)")
 
     if args.output_json:
@@ -232,22 +285,41 @@ async def run_benchmark(args):
 
 
 def main():
-    p = argparse.ArgumentParser(description="Warm, closed-loop benchmark for an OpenAI-compatible server.")
+    p = argparse.ArgumentParser(
+        description="Warm, closed-loop benchmark for an OpenAI-compatible server."
+    )
     p.add_argument("--url", default="http://localhost:8000")
     p.add_argument("--endpoint", default="/v1/completions")
-    p.add_argument("--lengths", default="128,256,512",
-                   help="Comma-separated fixed in/out token lengths (input_len == output_len).")
-    p.add_argument("--concurrency", default="1,2,4,8",
-                   help="Comma-separated closed-loop concurrency levels to sweep.")
-    p.add_argument("--duration", type=float, default=20.0,
-                   help="Seconds to hold each (length, concurrency) measurement.")
-    p.add_argument("--warmup-requests", type=int, default=2,
-                   help="Untimed requests per length to compile buckets before timing.")
+    p.add_argument(
+        "--lengths",
+        default="128,256,512",
+        help="Comma-separated fixed in/out token lengths (input_len == output_len).",
+    )
+    p.add_argument(
+        "--concurrency",
+        default="1,2,4,8",
+        help="Comma-separated closed-loop concurrency levels to sweep.",
+    )
+    p.add_argument(
+        "--duration",
+        type=float,
+        default=20.0,
+        help="Seconds to hold each (length, concurrency) measurement.",
+    )
+    p.add_argument(
+        "--warmup-requests",
+        type=int,
+        default=2,
+        help="Untimed requests per length to compile buckets before timing.",
+    )
     p.add_argument("--temperature", type=float, default=0.0)
     p.add_argument("--model-path", default=None)
     p.add_argument("--seed", type=int, default=1234)
-    p.add_argument("--output-json", default=None,
-                   help="Write structured results (incl. aggregate_throughput) here.")
+    p.add_argument(
+        "--output-json",
+        default=None,
+        help="Write structured results (incl. aggregate_throughput) here.",
+    )
     args = p.parse_args()
     asyncio.run(run_benchmark(args))
 

--- a/examples/Llama-3-8B-trn2/benchmark/benchmark.py
+++ b/examples/Llama-3-8B-trn2/benchmark/benchmark.py
@@ -55,8 +55,11 @@ def _load_tokenizer(model_path):
 
             tok = AutoTokenizer.from_pretrained(path)
             excluded = set(getattr(tok, "all_special_ids", []) or [])
-            pool = [t for t in range(len(tok))
-                    if t not in excluded and tok.decode([t], skip_special_tokens=True).strip()]
+            pool = [
+                t
+                for t in range(len(tok))
+                if t not in excluded and tok.decode([t], skip_special_tokens=True).strip()
+            ]
             if pool:
                 print(f"[prompt] tokenizer from {path}; pool={len(pool)}")
                 return tok, pool
@@ -68,7 +71,9 @@ def _load_tokenizer(model_path):
 
 def make_prompt(tokenizer, pool, input_len, rng):
     if tokenizer is not None and pool:
-        return tokenizer.decode([rng.choice(pool) for _ in range(input_len)], skip_special_tokens=True)
+        return tokenizer.decode(
+            [rng.choice(pool) for _ in range(input_len)], skip_special_tokens=True
+        )
     return " ".join(["token"] * input_len)
 
 
@@ -98,7 +103,7 @@ async def send_request(client, url, prompt, output_len, temperature):
             async for raw in resp.aiter_lines():
                 if not raw.startswith("data: "):
                     continue
-                payload = raw[len("data: "):]
+                payload = raw[len("data: ") :]
                 if payload.strip() == "[DONE]":
                     break
                 chunk = json.loads(payload)
@@ -116,7 +121,13 @@ async def send_request(client, url, prompt, output_len, temperature):
     gen = usage_tokens if usage_tokens is not None else out_tokens
     ttft = (t_first - t_send) if t_first is not None else None
     tpot = (t_done - t_first) / (gen - 1) if (t_first is not None and gen > 1) else None
-    return {"error": error, "gen_tokens": gen, "ttft_s": ttft, "tpot_s": tpot, "latency_s": t_done - t_send}
+    return {
+        "error": error,
+        "gen_tokens": gen,
+        "ttft_s": ttft,
+        "tpot_s": tpot,
+        "latency_s": t_done - t_send,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +140,7 @@ def _pct(vals, p):
         return None
     s = sorted(vals)
     import math
+
     return s[max(0, min(int(math.ceil(p / 100 * len(s))) - 1, len(s) - 1))]
 
 
@@ -150,15 +162,25 @@ async def measure(client, url, tokenizer, pool, length, concurrency, duration, t
     ttfts = [r["ttft_s"] for r in ok if r["ttft_s"] is not None]
     tpots = [r["tpot_s"] for r in ok if r["tpot_s"] is not None]
     return {
-        "input_len": length, "output_len": length, "concurrency": concurrency,
-        "completed": len(ok), "failed": len(results) - len(ok),
-        "wall_s": wall, "generated_tokens": gen,
+        "input_len": length,
+        "output_len": length,
+        "concurrency": concurrency,
+        "completed": len(ok),
+        "failed": len(results) - len(ok),
+        "wall_s": wall,
+        "generated_tokens": gen,
         "output_tokens_per_s": gen / wall if wall > 0 else 0.0,
         "request_throughput_per_s": len(ok) / wall if wall > 0 else 0.0,
-        "ttft_s": {"p50": _pct(ttfts, 50), "p90": _pct(ttfts, 90),
-                   "mean": statistics.fmean(ttfts) if ttfts else None},
-        "tpot_s": {"p50": _pct(tpots, 50), "p90": _pct(tpots, 90),
-                   "mean": statistics.fmean(tpots) if tpots else None},
+        "ttft_s": {
+            "p50": _pct(ttfts, 50),
+            "p90": _pct(ttfts, 90),
+            "mean": statistics.fmean(ttfts) if ttfts else None,
+        },
+        "tpot_s": {
+            "p50": _pct(tpots, 50),
+            "p90": _pct(tpots, 90),
+            "mean": statistics.fmean(tpots) if tpots else None,
+        },
     }
 
 
@@ -174,9 +196,19 @@ async def run_benchmark(args):
     tokenizer, pool = _load_tokenizer(args.model_path)
     rng = random.Random(args.seed)
 
-    print(json.dumps({"url": url, "lengths": lengths, "concurrency": concs,
-                      "duration_s": args.duration, "warmup_requests": args.warmup_requests}, indent=2),
-          flush=True)
+    print(
+        json.dumps(
+            {
+                "url": url,
+                "lengths": lengths,
+                "concurrency": concs,
+                "duration_s": args.duration,
+                "warmup_requests": args.warmup_requests,
+            },
+            indent=2,
+        ),
+        flush=True,
+    )
 
     scenarios: list[dict] = []
     async with httpx.AsyncClient() as client:
@@ -186,33 +218,52 @@ async def run_benchmark(args):
             warm = []
             for length in lengths:
                 for _ in range(args.warmup_requests):
-                    warm.append(send_request(client, url,
-                                             make_prompt(tokenizer, pool, length, rng),
-                                             length, args.temperature))
+                    warm.append(
+                        send_request(
+                            client,
+                            url,
+                            make_prompt(tokenizer, pool, length, rng),
+                            length,
+                            args.temperature,
+                        )
+                    )
             await asyncio.gather(*warm)
             print("Warm-up done.\n", flush=True)
 
         # --- Timed closed-loop sweep over (length, concurrency). ---
         for length in lengths:
             for c in concs:
-                print(f"MEASURE length={length} concurrency={c} for {args.duration}s ...", flush=True)
-                s = await measure(client, url, tokenizer, pool, length, c,
-                                  args.duration, args.temperature, rng)
+                print(
+                    f"MEASURE length={length} concurrency={c} for {args.duration}s ...", flush=True
+                )
+                s = await measure(
+                    client, url, tokenizer, pool, length, c, args.duration, args.temperature, rng
+                )
                 scenarios.append(s)
-                print(f"  -> {s['output_tokens_per_s']:.1f} tok/s "
-                      f"({s['completed']} reqs, tpot_p50={s['tpot_s']['p50']})", flush=True)
+                print(
+                    f"  -> {s['output_tokens_per_s']:.1f} tok/s "
+                    f"({s['completed']} reqs, tpot_p50={s['tpot_s']['p50']})",
+                    flush=True,
+                )
 
     # Headline: peak sustained output tok/s across the sweep (warm, no overload).
     peak = max((s["output_tokens_per_s"] for s in scenarios), default=0.0)
     best = max(scenarios, key=lambda s: s["output_tokens_per_s"], default=None)
 
     result = {
-        "config": {"url": url, "lengths": lengths, "concurrency": concs,
-                   "duration_s": args.duration, "warmup_requests": args.warmup_requests,
-                   "temperature": args.temperature, "seed": args.seed},
-        "aggregate_throughput": peak,            # headline: peak steady-state tok/s
-        "peak_scenario": {k: best[k] for k in ("input_len", "concurrency",
-                          "output_tokens_per_s")} if best else None,
+        "config": {
+            "url": url,
+            "lengths": lengths,
+            "concurrency": concs,
+            "duration_s": args.duration,
+            "warmup_requests": args.warmup_requests,
+            "temperature": args.temperature,
+            "seed": args.seed,
+        },
+        "aggregate_throughput": peak,  # headline: peak steady-state tok/s
+        "peak_scenario": {k: best[k] for k in ("input_len", "concurrency", "output_tokens_per_s")}
+        if best
+        else None,
         "scenarios": scenarios,
     }
 
@@ -220,8 +271,10 @@ async def run_benchmark(args):
     print("  Benchmark summary (warm, closed-loop)")
     print("=" * 56)
     for s in scenarios:
-        print(f"  len={s['input_len']:>4} c={s['concurrency']:>2}  "
-              f"{s['output_tokens_per_s']:7.1f} tok/s   req/s={s['request_throughput_per_s']:.2f}")
+        print(
+            f"  len={s['input_len']:>4} c={s['concurrency']:>2}  "
+            f"{s['output_tokens_per_s']:7.1f} tok/s   req/s={s['request_throughput_per_s']:.2f}"
+        )
     print(f"\nAggregate throughput (peak steady-state): {peak:.1f} tok/s  (headline)")
 
     if args.output_json:
@@ -232,22 +285,41 @@ async def run_benchmark(args):
 
 
 def main():
-    p = argparse.ArgumentParser(description="Warm, closed-loop benchmark for an OpenAI-compatible server.")
+    p = argparse.ArgumentParser(
+        description="Warm, closed-loop benchmark for an OpenAI-compatible server."
+    )
     p.add_argument("--url", default="http://localhost:8000")
     p.add_argument("--endpoint", default="/v1/completions")
-    p.add_argument("--lengths", default="128,256,512",
-                   help="Comma-separated fixed in/out token lengths (input_len == output_len).")
-    p.add_argument("--concurrency", default="1,2,4,8",
-                   help="Comma-separated closed-loop concurrency levels to sweep.")
-    p.add_argument("--duration", type=float, default=20.0,
-                   help="Seconds to hold each (length, concurrency) measurement.")
-    p.add_argument("--warmup-requests", type=int, default=2,
-                   help="Untimed requests per length to compile buckets before timing.")
+    p.add_argument(
+        "--lengths",
+        default="128,256,512",
+        help="Comma-separated fixed in/out token lengths (input_len == output_len).",
+    )
+    p.add_argument(
+        "--concurrency",
+        default="1,2,4,8",
+        help="Comma-separated closed-loop concurrency levels to sweep.",
+    )
+    p.add_argument(
+        "--duration",
+        type=float,
+        default=20.0,
+        help="Seconds to hold each (length, concurrency) measurement.",
+    )
+    p.add_argument(
+        "--warmup-requests",
+        type=int,
+        default=2,
+        help="Untimed requests per length to compile buckets before timing.",
+    )
     p.add_argument("--temperature", type=float, default=0.0)
     p.add_argument("--model-path", default=None)
     p.add_argument("--seed", type=int, default=1234)
-    p.add_argument("--output-json", default=None,
-                   help="Write structured results (incl. aggregate_throughput) here.")
+    p.add_argument(
+        "--output-json",
+        default=None,
+        help="Write structured results (incl. aggregate_throughput) here.",
+    )
     args = p.parse_args()
     asyncio.run(run_benchmark(args))
 

--- a/examples/Llama-3-8B-trn2/reference/reference.py
+++ b/examples/Llama-3-8B-trn2/reference/reference.py
@@ -25,7 +25,11 @@ from torch import nn
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
-from ...integrations import use_kernel_forward_from_hub, use_kernel_func_from_hub, use_kernelized_func
+from ...integrations import (
+    use_kernel_forward_from_hub,
+    use_kernel_func_from_hub,
+    use_kernelized_func,
+)
 from ...masking_utils import create_causal_mask
 from ...modeling_layers import (
     GenericForQuestionAnswering,
@@ -44,7 +48,6 @@ from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, loggi
 from ...utils.generic import maybe_autocast, merge_with_config_defaults
 from ...utils.output_capturing import capture_outputs
 from .configuration_llama import LlamaConfig
-
 
 logger = logging.get_logger(__name__)
 
@@ -115,17 +118,25 @@ class LlamaRotaryEmbedding(nn.Module):
 
         # Compute the inverse frequencies
         inv_freq = 1.0 / (
-            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+            base
+            ** (
+                torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float)
+                / dim
+            )
         )
         return inv_freq, attention_factor
 
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, None, :].float()
 
-        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        device_type = (
+            x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        )
         with maybe_autocast(device_type=device_type, enabled=False):  # Force float32
             freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
             emb = torch.cat((freqs, freqs), dim=-1)
@@ -192,7 +203,9 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     batch, num_key_value_heads, slen, head_dim = hidden_states.shape
     if n_rep == 1:
         return hidden_states
-    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
@@ -229,23 +242,33 @@ class LlamaAttention(nn.Module):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
-        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = True
 
         self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.k_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.v_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.o_proj = nn.Linear(
-            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
         )
 
     def forward(
@@ -270,7 +293,9 @@ class LlamaAttention(nn.Module):
         if past_key_values is not None:
             # sin and cos are specific to RoPE models; cache_position needed for the static cache
             cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+            key_states, value_states = past_key_values.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
 
         attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
             self.config._attn_implementation, eager_attention_forward
@@ -398,7 +423,9 @@ class LlamaModel(LlamaPreTrainedModel):
             past_key_values = DynamicCache(config=self.config)
 
         if cache_position is None:
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
             cache_position: torch.Tensor = (
                 torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
             )
@@ -497,12 +524,16 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
 
         hidden_states = outputs.last_hidden_state
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        slice_indices = (
+            slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        )
         logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
 
         return CausalLMOutputWithPast(
             loss=loss,

--- a/examples/Llama-3-8B-trn2/reference_inference.py
+++ b/examples/Llama-3-8B-trn2/reference_inference.py
@@ -25,7 +25,11 @@ from torch import nn
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
-from ...integrations import use_kernel_forward_from_hub, use_kernel_func_from_hub, use_kernelized_func
+from ...integrations import (
+    use_kernel_forward_from_hub,
+    use_kernel_func_from_hub,
+    use_kernelized_func,
+)
 from ...masking_utils import create_causal_mask
 from ...modeling_layers import (
     GenericForQuestionAnswering,
@@ -44,7 +48,6 @@ from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, loggi
 from ...utils.generic import maybe_autocast, merge_with_config_defaults
 from ...utils.output_capturing import capture_outputs
 from .configuration_llama import LlamaConfig
-
 
 logger = logging.get_logger(__name__)
 
@@ -115,17 +118,25 @@ class LlamaRotaryEmbedding(nn.Module):
 
         # Compute the inverse frequencies
         inv_freq = 1.0 / (
-            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+            base
+            ** (
+                torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float)
+                / dim
+            )
         )
         return inv_freq, attention_factor
 
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, None, :].float()
 
-        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        device_type = (
+            x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        )
         with maybe_autocast(device_type=device_type, enabled=False):  # Force float32
             freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
             emb = torch.cat((freqs, freqs), dim=-1)
@@ -192,7 +203,9 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     batch, num_key_value_heads, slen, head_dim = hidden_states.shape
     if n_rep == 1:
         return hidden_states
-    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
@@ -229,23 +242,33 @@ class LlamaAttention(nn.Module):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
-        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = True
 
         self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.k_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.v_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.o_proj = nn.Linear(
-            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
         )
 
     def forward(
@@ -270,7 +293,9 @@ class LlamaAttention(nn.Module):
         if past_key_values is not None:
             # sin and cos are specific to RoPE models; cache_position needed for the static cache
             cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+            key_states, value_states = past_key_values.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
 
         attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
             self.config._attn_implementation, eager_attention_forward
@@ -398,7 +423,9 @@ class LlamaModel(LlamaPreTrainedModel):
             past_key_values = DynamicCache(config=self.config)
 
         if cache_position is None:
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
             cache_position: torch.Tensor = (
                 torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
             )
@@ -497,12 +524,16 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
 
         hidden_states = outputs.last_hidden_state
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        slice_indices = (
+            slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        )
         logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
 
         return CausalLMOutputWithPast(
             loss=loss,

--- a/examples/Llama-3-8B/accuracy_check.py
+++ b/examples/Llama-3-8B/accuracy_check.py
@@ -17,14 +17,13 @@ import time
 from pathlib import Path
 
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
-
 from step_1_fastapi import load_llama_model
-
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # ---------------------------------------------------------------------------
 # Load .env
 # ---------------------------------------------------------------------------
+
 
 def _load_env():
     env_path = Path(__file__).resolve().parent / ".env"
@@ -46,7 +45,7 @@ _load_env()
 RAW_COMPLETION_SAMPLES: list[tuple[str, int, str]] = [
     ("The capital of France is", 15, "short factual completion"),
     ("Once upon a time, in a land far away,", 50, "story continuation"),
-    ("def fibonacci(n):\n    \"\"\"Return the n-th Fibonacci number.\"\"\"\n", 40, "code completion"),
+    ('def fibonacci(n):\n    """Return the n-th Fibonacci number."""\n', 40, "code completion"),
     ("1 + 1 =", 5, "arithmetic"),
     ("A B C D E F G H I J K L M N O P Q R S T U V W X Y Z A B C D E F G", 20, "alphabet pattern"),
     (
@@ -97,6 +96,7 @@ CHAT_SAMPLES: list[tuple[list[dict[str, str]], int, str]] = [
 # Reference: HuggingFace model.generate()
 # ---------------------------------------------------------------------------
 
+
 @torch.inference_mode()
 def generate_reference(model, tokenizer, prompt_text, max_new_tokens, device):
     inputs = tokenizer(prompt_text, return_tensors="pt").to(device)
@@ -108,6 +108,7 @@ def generate_reference(model, tokenizer, prompt_text, max_new_tokens, device):
 # ---------------------------------------------------------------------------
 # Our implementation: custom model with manual token-by-token loop
 # ---------------------------------------------------------------------------
+
 
 @torch.inference_mode()
 def generate_custom(model, tokenizer, prompt_text, max_new_tokens, device):
@@ -141,6 +142,7 @@ def generate_custom(model, tokenizer, prompt_text, max_new_tokens, device):
 # Comparison logic
 # ---------------------------------------------------------------------------
 
+
 def compare_outputs(ref_ids, custom_ids, tokenizer):
     ref_text = tokenizer.decode(ref_ids, skip_special_tokens=True)
     custom_text = tokenizer.decode(custom_ids, skip_special_tokens=True)
@@ -159,8 +161,8 @@ def compare_outputs(ref_ids, custom_ids, tokenizer):
         f"MISMATCH at token {first_diff}.\n"
         f"  Reference ({len(ref_ids):3d} tokens): {ref_text!r}\n"
         f"  Custom    ({len(custom_ids):3d} tokens): {custom_text!r}\n"
-        f"  Ref  ids[{first_diff}:]: {ref_ids[first_diff:first_diff+10]}\n"
-        f"  Cust ids[{first_diff}:]: {custom_ids[first_diff:first_diff+10]}"
+        f"  Ref  ids[{first_diff}:]: {ref_ids[first_diff : first_diff + 10]}\n"
+        f"  Cust ids[{first_diff}:]: {custom_ids[first_diff : first_diff + 10]}"
     )
     return False, detail
 
@@ -168,6 +170,7 @@ def compare_outputs(ref_ids, custom_ids, tokenizer):
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
 
 def main():
     parser = argparse.ArgumentParser(description="Accuracy checker: custom model vs HF reference")
@@ -188,7 +191,10 @@ def main():
     print(f"Loading HF reference model on {args.device} ...")
     t0 = time.perf_counter()
     ref_model = AutoModelForCausalLM.from_pretrained(
-        args.model, torch_dtype=dtype, device_map=args.device, token=hf_token,
+        args.model,
+        torch_dtype=dtype,
+        device_map=args.device,
+        token=hf_token,
         attn_implementation="eager",
     )
     ref_model.eval()
@@ -206,7 +212,9 @@ def main():
     has_chat_template = hasattr(tokenizer, "apply_chat_template") and tokenizer.chat_template
     for messages, max_tokens, desc in CHAT_SAMPLES:
         if has_chat_template:
-            prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+            prompt = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
         else:
             prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages) + "\nassistant:"
         test_cases.append((prompt, max_tokens, f"[chat] {desc}"))

--- a/examples/Llama-3-8B/accuracy_checker/checker.py
+++ b/examples/Llama-3-8B/accuracy_checker/checker.py
@@ -41,7 +41,7 @@ def _load_custom_model_class():
 RAW_COMPLETION_SAMPLES: list[tuple[str, int, str]] = [
     ("The capital of France is", 15, "short factual completion"),
     ("Once upon a time, in a land far away,", 50, "story continuation"),
-    ("def fibonacci(n):\n    \"\"\"Return the n-th Fibonacci number.\"\"\"\n", 40, "code completion"),
+    ('def fibonacci(n):\n    """Return the n-th Fibonacci number."""\n', 40, "code completion"),
     ("1 + 1 =", 5, "arithmetic"),
     ("A B C D E F G H I J K L M N O P Q R S T U V W X Y Z A B C D E F G", 20, "alphabet pattern"),
     (
@@ -92,6 +92,7 @@ CHAT_SAMPLES: list[tuple[list[dict[str, str]], int, str]] = [
 # Reference: HuggingFace model.generate()
 # ---------------------------------------------------------------------------
 
+
 @torch.inference_mode()
 def generate_reference(model, tokenizer, prompt_text, max_new_tokens, device):
     inputs = tokenizer(prompt_text, return_tensors="pt").to(device)
@@ -103,6 +104,7 @@ def generate_reference(model, tokenizer, prompt_text, max_new_tokens, device):
 # ---------------------------------------------------------------------------
 # Custom model: uses VibeServeModel.generate()
 # ---------------------------------------------------------------------------
+
 
 @torch.inference_mode()
 def generate_custom(model, tokenizer, prompt_text, max_new_tokens, device):
@@ -116,6 +118,7 @@ def generate_custom(model, tokenizer, prompt_text, max_new_tokens, device):
 # ---------------------------------------------------------------------------
 # Comparison logic
 # ---------------------------------------------------------------------------
+
 
 def compare_outputs(ref_ids, custom_ids, tokenizer):
     ref_text = tokenizer.decode(ref_ids, skip_special_tokens=True)
@@ -135,8 +138,8 @@ def compare_outputs(ref_ids, custom_ids, tokenizer):
         f"MISMATCH at token {first_diff}.\n"
         f"  Reference ({len(ref_ids):3d} tokens): {ref_text!r}\n"
         f"  Custom    ({len(custom_ids):3d} tokens): {custom_text!r}\n"
-        f"  Ref  ids[{first_diff}:]: {ref_ids[first_diff:first_diff+10]}\n"
-        f"  Cust ids[{first_diff}:]: {custom_ids[first_diff:first_diff+10]}"
+        f"  Ref  ids[{first_diff}:]: {ref_ids[first_diff : first_diff + 10]}\n"
+        f"  Cust ids[{first_diff}:]: {custom_ids[first_diff : first_diff + 10]}"
     )
     return False, detail
 
@@ -145,10 +148,13 @@ def compare_outputs(ref_ids, custom_ids, tokenizer):
 # Main
 # ---------------------------------------------------------------------------
 
+
 def main():
     parser = argparse.ArgumentParser(description="Accuracy checker: custom model vs HF reference")
     parser.add_argument(
-        "--model-dir", type=str, default="../model",
+        "--model-dir",
+        type=str,
+        default="../model",
         help="Local path to model weights directory (default: ../model)",
     )
     parser.add_argument("--device", type=str, default="cuda:0")
@@ -169,7 +175,9 @@ def main():
     has_chat_template = hasattr(tokenizer, "apply_chat_template") and tokenizer.chat_template
     for messages, max_tokens, desc in CHAT_SAMPLES:
         if has_chat_template:
-            prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+            prompt = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
         else:
             prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages) + "\nassistant:"
         test_cases.append((prompt, max_tokens, f"[chat] {desc}"))
@@ -178,7 +186,9 @@ def main():
     print(f"\nLoading HF reference model on {args.device} ...")
     t0 = time.perf_counter()
     ref_model = AutoModelForCausalLM.from_pretrained(
-        model_dir, torch_dtype=dtype, device_map=args.device,
+        model_dir,
+        torch_dtype=dtype,
+        device_map=args.device,
         attn_implementation="eager",
     )
     ref_model.eval()
@@ -187,7 +197,9 @@ def main():
     print("Generating reference outputs ...")
     ref_outputs: list[list[int]] = []
     for prompt, max_tokens, desc in test_cases:
-        ref_outputs.append(generate_reference(ref_model, tokenizer, prompt, max_tokens, args.device))
+        ref_outputs.append(
+            generate_reference(ref_model, tokenizer, prompt, max_tokens, args.device)
+        )
 
     # Unload HF model to free GPU memory
     del ref_model

--- a/examples/Llama-3-8B/benchmark.py
+++ b/examples/Llama-3-8B/benchmark.py
@@ -86,7 +86,7 @@ async def send_request(
             async for raw_line in resp.aiter_lines():
                 if not raw_line.startswith("data: "):
                     continue
-                payload = raw_line[len("data: "):]
+                payload = raw_line[len("data: ") :]
                 if payload.strip() == "[DONE]":
                     t_done = time.perf_counter()
                     break

--- a/examples/Llama-3-8B/benchmark/benchmark.py
+++ b/examples/Llama-3-8B/benchmark/benchmark.py
@@ -86,7 +86,7 @@ async def send_request(
             async for raw_line in resp.aiter_lines():
                 if not raw_line.startswith("data: "):
                     continue
-                payload = raw_line[len("data: "):]
+                payload = raw_line[len("data: ") :]
                 if payload.strip() == "[DONE]":
                     t_done = time.perf_counter()
                     break

--- a/examples/Llama-3-8B/reference/reference.py
+++ b/examples/Llama-3-8B/reference/reference.py
@@ -25,7 +25,11 @@ from torch import nn
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
-from ...integrations import use_kernel_forward_from_hub, use_kernel_func_from_hub, use_kernelized_func
+from ...integrations import (
+    use_kernel_forward_from_hub,
+    use_kernel_func_from_hub,
+    use_kernelized_func,
+)
 from ...masking_utils import create_causal_mask
 from ...modeling_layers import (
     GenericForQuestionAnswering,
@@ -44,7 +48,6 @@ from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, loggi
 from ...utils.generic import maybe_autocast, merge_with_config_defaults
 from ...utils.output_capturing import capture_outputs
 from .configuration_llama import LlamaConfig
-
 
 logger = logging.get_logger(__name__)
 
@@ -115,17 +118,25 @@ class LlamaRotaryEmbedding(nn.Module):
 
         # Compute the inverse frequencies
         inv_freq = 1.0 / (
-            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+            base
+            ** (
+                torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float)
+                / dim
+            )
         )
         return inv_freq, attention_factor
 
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, None, :].float()
 
-        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        device_type = (
+            x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        )
         with maybe_autocast(device_type=device_type, enabled=False):  # Force float32
             freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
             emb = torch.cat((freqs, freqs), dim=-1)
@@ -192,7 +203,9 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     batch, num_key_value_heads, slen, head_dim = hidden_states.shape
     if n_rep == 1:
         return hidden_states
-    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
@@ -229,23 +242,33 @@ class LlamaAttention(nn.Module):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
-        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = True
 
         self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.k_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.v_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.o_proj = nn.Linear(
-            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
         )
 
     def forward(
@@ -270,7 +293,9 @@ class LlamaAttention(nn.Module):
         if past_key_values is not None:
             # sin and cos are specific to RoPE models; cache_position needed for the static cache
             cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+            key_states, value_states = past_key_values.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
 
         attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
             self.config._attn_implementation, eager_attention_forward
@@ -398,7 +423,9 @@ class LlamaModel(LlamaPreTrainedModel):
             past_key_values = DynamicCache(config=self.config)
 
         if cache_position is None:
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
             cache_position: torch.Tensor = (
                 torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
             )
@@ -497,12 +524,16 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
 
         hidden_states = outputs.last_hidden_state
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        slice_indices = (
+            slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        )
         logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
 
         return CausalLMOutputWithPast(
             loss=loss,

--- a/examples/Llama-3-8B/reference_inference.py
+++ b/examples/Llama-3-8B/reference_inference.py
@@ -25,7 +25,11 @@ from torch import nn
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
-from ...integrations import use_kernel_forward_from_hub, use_kernel_func_from_hub, use_kernelized_func
+from ...integrations import (
+    use_kernel_forward_from_hub,
+    use_kernel_func_from_hub,
+    use_kernelized_func,
+)
 from ...masking_utils import create_causal_mask
 from ...modeling_layers import (
     GenericForQuestionAnswering,
@@ -44,7 +48,6 @@ from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, loggi
 from ...utils.generic import maybe_autocast, merge_with_config_defaults
 from ...utils.output_capturing import capture_outputs
 from .configuration_llama import LlamaConfig
-
 
 logger = logging.get_logger(__name__)
 
@@ -115,17 +118,25 @@ class LlamaRotaryEmbedding(nn.Module):
 
         # Compute the inverse frequencies
         inv_freq = 1.0 / (
-            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+            base
+            ** (
+                torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float)
+                / dim
+            )
         )
         return inv_freq, attention_factor
 
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, None, :].float()
 
-        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        device_type = (
+            x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        )
         with maybe_autocast(device_type=device_type, enabled=False):  # Force float32
             freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
             emb = torch.cat((freqs, freqs), dim=-1)
@@ -192,7 +203,9 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     batch, num_key_value_heads, slen, head_dim = hidden_states.shape
     if n_rep == 1:
         return hidden_states
-    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
@@ -229,23 +242,33 @@ class LlamaAttention(nn.Module):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
-        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = True
 
         self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.k_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.v_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.o_proj = nn.Linear(
-            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
         )
 
     def forward(
@@ -270,7 +293,9 @@ class LlamaAttention(nn.Module):
         if past_key_values is not None:
             # sin and cos are specific to RoPE models; cache_position needed for the static cache
             cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+            key_states, value_states = past_key_values.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
 
         attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
             self.config._attn_implementation, eager_attention_forward
@@ -398,7 +423,9 @@ class LlamaModel(LlamaPreTrainedModel):
             past_key_values = DynamicCache(config=self.config)
 
         if cache_position is None:
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
             cache_position: torch.Tensor = (
                 torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
             )
@@ -497,12 +524,16 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationMixin):
 
         hidden_states = outputs.last_hidden_state
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        slice_indices = (
+            slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        )
         logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
 
         return CausalLMOutputWithPast(
             loss=loss,

--- a/examples/Llama-3.1-8B-Instruct-MLX-8bit/accuracy_checker/checker.py
+++ b/examples/Llama-3.1-8B-Instruct-MLX-8bit/accuracy_checker/checker.py
@@ -13,7 +13,6 @@ from typing import Any
 import httpx
 from jsonschema.validators import validator_for
 
-
 BUNDLE_DIR = Path(__file__).resolve().parents[1]
 DATASET_ID = "epfl-dlab/JSONSchemaBench"
 DATASET_REVISION = "5bd0f4640badc6f3f02df796421d21cb0ca0b141"
@@ -59,7 +58,10 @@ def load_cases(
         cases.append(
             {
                 "unique_id": str(row.get("unique_id") or row.get("id") or idx),
-                "description": row.get("description") or row.get("title") or schema.get("description") or "",
+                "description": row.get("description")
+                or row.get("title")
+                or schema.get("description")
+                or "",
                 "schema": schema,
             }
         )
@@ -85,7 +87,9 @@ def schema_can_hold_sentinel(schema: Any) -> bool:
             isinstance(additional, dict) and schema_can_hold_sentinel(additional)
         )
     for key in ("oneOf", "anyOf", "allOf"):
-        if any(schema_can_hold_sentinel(item) for item in schema.get(key, []) if isinstance(item, dict)):
+        if any(
+            schema_can_hold_sentinel(item) for item in schema.get(key, []) if isinstance(item, dict)
+        ):
             return True
     return False
 
@@ -100,8 +104,7 @@ def build_prompt(schema: dict, description: str, sentinel: str | None) -> str:
     sentinel_text = ""
     if sentinel is not None:
         sentinel_text = (
-            f"\nInclude the exact token {sentinel!r} somewhere inside the JSON "
-            "as a string value."
+            f"\nInclude the exact token {sentinel!r} somewhere inside the JSON as a string value."
         )
     return (
         f"Task: {description or 'Generate one JSON value.'}\n\n"
@@ -178,7 +181,9 @@ def validate_output(text: str, schema: dict) -> tuple[bool, str | None]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Check JSON-schema output from an MLX 8-bit Llama server.")
+    parser = argparse.ArgumentParser(
+        description="Check JSON-schema output from an MLX 8-bit Llama server."
+    )
     parser.add_argument("--url", default="http://localhost:8000")
     parser.add_argument("--endpoint", default="/v1/completions")
     parser.add_argument("--dataset-subset", default="full")
@@ -232,8 +237,10 @@ def main() -> None:
 
     valid_rate = valid / len(cases)
     sentinel_rate = sentinel_ok / sentinel_checked if sentinel_checked else 1.0
-    passed = valid_rate >= args.min_valid_rate and sentinel_rate >= args.min_sentinel_rate and not any(
-        failure.startswith("[") and "request failed" in failure for failure in failures
+    passed = (
+        valid_rate >= args.min_valid_rate
+        and sentinel_rate >= args.min_sentinel_rate
+        and not any(failure.startswith("[") and "request failed" in failure for failure in failures)
     )
 
     print(

--- a/examples/Llama-3.1-8B-Instruct-MLX-8bit/benchmark/benchmark.py
+++ b/examples/Llama-3.1-8B-Instruct-MLX-8bit/benchmark/benchmark.py
@@ -15,7 +15,6 @@ from typing import Any
 import httpx
 from jsonschema.validators import validator_for
 
-
 BUNDLE_DIR = Path(__file__).resolve().parents[1]
 DATASET_ID = "epfl-dlab/JSONSchemaBench"
 DATASET_REVISION = "5bd0f4640badc6f3f02df796421d21cb0ca0b141"
@@ -80,7 +79,10 @@ def load_cases(
         cases.append(
             {
                 "unique_id": str(row.get("unique_id") or row.get("id") or idx),
-                "description": row.get("description") or row.get("title") or schema.get("description") or "",
+                "description": row.get("description")
+                or row.get("title")
+                or schema.get("description")
+                or "",
                 "schema": schema,
             }
         )
@@ -184,7 +186,9 @@ async def send_request(
         "error": None,
         "latency": done - started,
         "ttft": None if first_token is None else first_token - started,
-        "tpot": None if first_token is None or output_tokens <= 1 else (done - first_token) / (output_tokens - 1),
+        "tpot": None
+        if first_token is None or output_tokens <= 1
+        else (done - first_token) / (output_tokens - 1),
         "output_tokens": output_tokens,
         "parse_ok": parse_ok,
         "schema_ok": schema_ok,
@@ -262,7 +266,9 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
     print(f"Endpoint:          {url}")
     print(f"Schemas:           {len(cases)}")
     print(f"Completed:         {summary['num_completed']}/{summary['num_requests']}")
-    print(f"Schema valid:      {summary['schema_ok']}/{summary['num_completed']} ({summary['schema_ok_frac']:.3f})")
+    print(
+        f"Schema valid:      {summary['schema_ok']}/{summary['num_completed']} ({summary['schema_ok_frac']:.3f})"
+    )
     print(f"Token throughput:  {summary['token_throughput']:.2f} tok/s")
     if summary["latency_ms"]:
         print(f"Latency p50:       {summary['latency_ms']['p50']:.1f} ms")
@@ -279,7 +285,9 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Benchmark JSON-schema generation on an MLX 8-bit Llama server.")
+    parser = argparse.ArgumentParser(
+        description="Benchmark JSON-schema generation on an MLX 8-bit Llama server."
+    )
     parser.add_argument("--url", default="http://localhost:8000")
     parser.add_argument("--endpoint", default="/v1/completions")
     parser.add_argument("--dataset-subset", default="full")
@@ -290,7 +298,11 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--max-tokens", type=int, default=256)
     parser.add_argument("--timeout", type=float, default=600.0)
-    parser.add_argument("--closed-loop", action="store_true", help="Send requests sequentially instead of concurrently.")
+    parser.add_argument(
+        "--closed-loop",
+        action="store_true",
+        help="Send requests sequentially instead of concurrently.",
+    )
     parser.add_argument("--output-json", type=str, default=None)
     args = parser.parse_args()
     asyncio.run(run_benchmark(args))

--- a/examples/Llama-3.1-8B-Instruct-MLX-8bit/reference/reference.py
+++ b/examples/Llama-3.1-8B-Instruct-MLX-8bit/reference/reference.py
@@ -17,7 +17,6 @@ import argparse
 import json
 from pathlib import Path
 
-
 REFERENCE_DIR = Path(__file__).resolve().parent
 DEFAULT_MODEL_DIR = REFERENCE_DIR / "model"
 

--- a/examples/moonshine-streaming/accuracy_checker/checker.py
+++ b/examples/moonshine-streaming/accuracy_checker/checker.py
@@ -15,6 +15,7 @@ importable from `main.py` on `sys.path`.
 Usage:
     .venv/bin/python checker.py --model-dir <local model dir>
 """
+
 from __future__ import annotations
 
 import argparse
@@ -45,6 +46,7 @@ def _load_custom_model_class():
 
 # ---------- audio loading ----------
 
+
 def load_test_samples(audio_dir: Path):
     manifest_path = audio_dir / "manifest.json"
     if not manifest_path.exists():
@@ -64,11 +66,13 @@ def load_test_samples(audio_dir: Path):
 
 # ---------- HF reference ----------
 
+
 @torch.inference_mode()
 def transcribe_reference(model, proj_out, tokenizer, audio: np.ndarray, sr: int) -> str:
     """Greedy decode with HF MoonshineStreamingModel + a separately-loaded
     proj_out (lm_head) projection.  Matches the offline-transcribe contract."""
     from transformers.cache_utils import DynamicCache, EncoderDecoderCache
+
     device = next(model.parameters()).device
     dtype = next(model.parameters()).dtype
     audio_t = torch.from_numpy(audio).to(device).to(dtype).unsqueeze(0)
@@ -79,8 +83,9 @@ def transcribe_reference(model, proj_out, tokenizer, audio: np.ndarray, sr: int)
     out: list[int] = []
     pkv = None
     for _ in range(256):
-        d = model.decoder(input_ids=cur, encoder_hidden_states=enc_h,
-                          past_key_values=pkv, use_cache=True)
+        d = model.decoder(
+            input_ids=cur, encoder_hidden_states=enc_h, past_key_values=pkv, use_cache=True
+        )
         nxt = int(proj_out(d.last_hidden_state)[0, -1].argmax().item())
         if nxt == model.config.eos_token_id:
             break
@@ -91,6 +96,7 @@ def transcribe_reference(model, proj_out, tokenizer, audio: np.ndarray, sr: int)
 
 
 # ---------- text comparison ----------
+
 
 def normalize_text(s: str) -> str:
     s = s.lower().strip()
@@ -113,10 +119,7 @@ def compare_outputs(ref_text: str, custom_text: str, threshold: float):
     if normalize_text(ref_text) == normalize_text(custom_text):
         return True, f"EXACT match: {ref_text[:80]!r}"
     overlap = word_overlap_ratio(ref_text, custom_text)
-    detail = (
-        f"  Reference: {ref_text[:100]!r}\n"
-        f"  Custom:    {custom_text[:100]!r}"
-    )
+    detail = f"  Reference: {ref_text[:100]!r}\n  Custom:    {custom_text[:100]!r}"
     if overlap >= threshold:
         return True, f"PASS (word overlap {overlap:.1%} >= {threshold:.0%}):\n{detail}"
     return False, f"MISMATCH (word overlap {overlap:.1%} < {threshold:.0%}):\n{detail}"
@@ -124,15 +127,22 @@ def compare_outputs(ref_text: str, custom_text: str, threshold: float):
 
 # ---------- main ----------
 
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model-dir", type=str, default="../model",
-                        help="Local path to model weights directory")
-    parser.add_argument("--audio-dir", type=str, default=None,
-                        help="Directory with test audio + manifest.json (default: ../test_audio)")
+    parser.add_argument(
+        "--model-dir", type=str, default="../model", help="Local path to model weights directory"
+    )
+    parser.add_argument(
+        "--audio-dir",
+        type=str,
+        default=None,
+        help="Directory with test audio + manifest.json (default: ../test_audio)",
+    )
     parser.add_argument("--device", type=str, default="cuda:0")
-    parser.add_argument("--threshold", type=float, default=0.7,
-                        help="Minimum word overlap ratio to pass")
+    parser.add_argument(
+        "--threshold", type=float, default=0.7, help="Minimum word overlap ratio to pass"
+    )
     args = parser.parse_args()
 
     model_dir = str(Path(args.model_dir).resolve())
@@ -149,11 +159,14 @@ def main():
 
     # ---- HF reference ----
     print(f"Loading HF reference (MoonshineStreamingModel) on {args.device} ...")
-    from transformers import AutoModel
     from safetensors.torch import load_file
     from tokenizers import Tokenizer
+    from transformers import AutoModel
+
     t0 = time.perf_counter()
-    ref_model = AutoModel.from_pretrained(model_dir, torch_dtype=dtype, device_map=args.device).eval()
+    ref_model = AutoModel.from_pretrained(
+        model_dir, torch_dtype=dtype, device_map=args.device
+    ).eval()
     # proj_out (lm_head) is part of MoonshineStreamingForConditionalGeneration; AutoModel
     # loads the base MoonshineStreamingModel without it.  Load the weight separately.
     try:
@@ -161,7 +174,9 @@ def main():
     except FileNotFoundError:
         # fall back to .bin
         sd = torch.load(str(Path(model_dir) / "pytorch_model.bin"), map_location="cpu")
-    proj_out = torch.nn.Linear(ref_model.config.hidden_size, ref_model.config.vocab_size, bias=False)
+    proj_out = torch.nn.Linear(
+        ref_model.config.hidden_size, ref_model.config.vocab_size, bias=False
+    )
     proj_out.weight.data = sd["proj_out.weight"]
     proj_out = proj_out.to(args.device).to(dtype)
     tokenizer = Tokenizer.from_file(str(Path(model_dir) / "tokenizer.json"))

--- a/examples/moonshine-streaming/benchmark/benchmark.py
+++ b/examples/moonshine-streaming/benchmark/benchmark.py
@@ -17,6 +17,7 @@ Usage:
     python benchmark.py --mode streaming --concurrency 4 --chunk-s 2 --duration 30
     python benchmark.py --mode offline   --rate 2 --duration 30
 """
+
 from __future__ import annotations
 
 import argparse
@@ -67,14 +68,16 @@ def load_audio_pool(audio_dir: Path):
             pcm = wf.readframes(n)
         wav_bytes = p.read_bytes()
         meta = manifest_entries.get(p.name, {})
-        pool.append((
-            wav_bytes,
-            pcm,
-            sr,
-            meta.get("duration_s", n / sr),
-            p.name,
-            meta.get("text", ""),
-        ))
+        pool.append(
+            (
+                wav_bytes,
+                pcm,
+                sr,
+                meta.get("duration_s", n / sr),
+                p.name,
+                meta.get("text", ""),
+            )
+        )
     if not pool:
         raise FileNotFoundError(f"No audio files in {audio_dir}")
     return pool
@@ -110,6 +113,7 @@ async def streaming_client(
     t_start = time.perf_counter()
     try:
         async with websockets.connect(url, max_size=None) as ws:
+
             async def reader():
                 nonlocal finalized_at, final_text
                 async for msg in ws:
@@ -126,6 +130,7 @@ async def streaming_client(
                         finalized_at = now
                         final_text = data.get("text", "")
                         return
+
             rd = asyncio.create_task(reader())
 
             for i in range(total_chunks):
@@ -150,8 +155,11 @@ async def streaming_client(
         if future:
             chunk_latencies.append(future[0] - ts)
     ttft = chunk_latencies[0] if chunk_latencies else None
-    tpot = (sum(chunk_latencies[1:]) / max(1, len(chunk_latencies) - 1)
-            if len(chunk_latencies) > 1 else None)
+    tpot = (
+        sum(chunk_latencies[1:]) / max(1, len(chunk_latencies) - 1)
+        if len(chunk_latencies) > 1
+        else None
+    )
     return {
         "name": name,
         "error": error,
@@ -168,8 +176,10 @@ async def streaming_client(
 async def run_streaming(args, audio_pool):
     rng = random.Random(args.seed)
     url = args.ws_url
-    print(f"Streaming benchmark: concurrency={args.concurrency} chunk_s={args.chunk_s}s "
-          f"duration_budget={args.duration}s url={url}")
+    print(
+        f"Streaming benchmark: concurrency={args.concurrency} chunk_s={args.chunk_s}s "
+        f"duration_budget={args.duration}s url={url}"
+    )
 
     log: list[dict] = []
     tasks: list[asyncio.Task] = []
@@ -180,8 +190,9 @@ async def run_streaming(args, audio_pool):
             n_keep = int(args.duration * sr) * 2
             pcm = pcm[:n_keep]
             dur = args.duration
-        tasks.append(asyncio.create_task(streaming_client(
-            f"C{i}", url, pcm, sr, dur, args.chunk_s, log)))
+        tasks.append(
+            asyncio.create_task(streaming_client(f"C{i}", url, pcm, sr, dur, args.chunk_s, log))
+        )
     t0 = time.perf_counter()
     results = await asyncio.gather(*tasks)
     wall = time.perf_counter() - t0
@@ -205,7 +216,7 @@ async def run_streaming(args, audio_pool):
     print(_format_stats(ttfts))
     sorted_ttfts = sorted(ttfts) if ttfts else []
     if sorted_ttfts:
-        print(f"Primary metric: ttft_p50_ms={_percentile(sorted_ttfts, 50)*1000:.1f}")
+        print(f"Primary metric: ttft_p50_ms={_percentile(sorted_ttfts, 50) * 1000:.1f}")
     print()
     print("Secondary:")
     print(f"  audio_s_per_s:   {aud_per_s:.2f}")
@@ -255,7 +266,7 @@ async def offline_request(client: httpx.AsyncClient, url: str, wav_bytes: bytes,
                 async for line in resp.aiter_lines():
                     if not line.startswith("data: "):
                         continue
-                    payload = line[len("data: "):]
+                    payload = line[len("data: ") :]
                     if payload.strip() == "[DONE]":
                         t_done = time.perf_counter()
                         break
@@ -339,7 +350,7 @@ async def run_offline(args, audio_pool):
     print(f"Completed:         {len(succ)}/{len(results)} ({len(fail)} errors)")
     print(f"Streaming SSE:     {args.stream}")
     print()
-    print(f"Throughput: {len(succ)/wall:.2f} req/s, {n_tokens/wall:.1f} tok/s")
+    print(f"Throughput: {len(succ) / wall:.2f} req/s, {n_tokens / wall:.1f} tok/s")
     print()
     print("TTFT:")
     print(_format_stats(ttfts))
@@ -370,7 +381,8 @@ def _percentile(s, p):
     if not s:
         return float("nan")
     k = (len(s) - 1) * p / 100
-    f = math.floor(k); c = math.ceil(k)
+    f = math.floor(k)
+    c = math.ceil(k)
     return s[int(k)] if f == c else s[f] * (c - k) + s[c] * (k - f)
 
 
@@ -379,10 +391,10 @@ def _format_stats(values):
         return "    (no data)\n"
     s = sorted(values)
     return (
-        f"  Mean:    {sum(s)/len(s)*1000:.1f} ms\n"
-        f"  Median:  {_percentile(s, 50)*1000:.1f} ms\n"
-        f"  P90:     {_percentile(s, 90)*1000:.1f} ms\n"
-        f"  P99:     {_percentile(s, 99)*1000:.1f} ms\n"
+        f"  Mean:    {sum(s) / len(s) * 1000:.1f} ms\n"
+        f"  Median:  {_percentile(s, 50) * 1000:.1f} ms\n"
+        f"  P90:     {_percentile(s, 90) * 1000:.1f} ms\n"
+        f"  P99:     {_percentile(s, 99) * 1000:.1f} ms\n"
     )
 
 
@@ -407,21 +419,31 @@ def main():
     p = argparse.ArgumentParser()
     p.add_argument("--mode", choices=["streaming", "offline"], default="streaming")
     # streaming
-    p.add_argument("--ws-url", default="ws://localhost:8000/v1/audio/stream",
-                   help="WebSocket URL (streaming mode)")
+    p.add_argument(
+        "--ws-url",
+        default="ws://localhost:8000/v1/audio/stream",
+        help="WebSocket URL (streaming mode)",
+    )
     p.add_argument("--chunk-s", type=float, default=2.0, help="Audio chunk seconds")
     # offline
-    p.add_argument("--url", default="http://localhost:8000",
-                   help="Server base URL (offline mode)")
+    p.add_argument("--url", default="http://localhost:8000", help="Server base URL (offline mode)")
     p.add_argument("--endpoint", default="/v1/audio/transcriptions")
-    p.add_argument("--num-requests", type=int, default=None,
-                   help="Optional cap on total requests (offline mode)")
+    p.add_argument(
+        "--num-requests",
+        type=int,
+        default=None,
+        help="Optional cap on total requests (offline mode)",
+    )
     p.add_argument("--stream", action="store_true", help="SSE streaming for offline mode")
     # shared
-    p.add_argument("--concurrency", type=int, default=32,
-                   help="Concurrent in-flight requests (streaming: number of "
-                        "live clients; offline: number of workers each looping "
-                        "request→request for the duration)")
+    p.add_argument(
+        "--concurrency",
+        type=int,
+        default=32,
+        help="Concurrent in-flight requests (streaming: number of "
+        "live clients; offline: number of workers each looping "
+        "request→request for the duration)",
+    )
     p.add_argument("--duration", type=float, default=30.0)
     p.add_argument("--audio-dir", type=str, default=None)
     p.add_argument("--seed", type=int, default=42)

--- a/examples/moonshine-streaming/reference/reference.py
+++ b/examples/moonshine-streaming/reference/reference.py
@@ -46,7 +46,10 @@ from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple
 from ...utils.generic import maybe_autocast, merge_with_config_defaults
 from ...utils.output_capturing import OutputRecorder, capture_outputs
-from .configuration_moonshine_streaming import MoonshineStreamingConfig, MoonshineStreamingEncoderConfig
+from .configuration_moonshine_streaming import (
+    MoonshineStreamingConfig,
+    MoonshineStreamingEncoderConfig,
+)
 
 
 @dataclass
@@ -90,7 +93,9 @@ class MoonshineStreamingCausalConv1d(nn.Conv1d):
         dilation: int = 1,
         bias: bool = True,
     ):
-        super().__init__(in_channels, out_channels, kernel_size, stride=stride, dilation=dilation, bias=bias)
+        super().__init__(
+            in_channels, out_channels, kernel_size, stride=stride, dilation=dilation, bias=bias
+        )
         self.left_pad = (kernel_size - 1) * dilation
 
     def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
@@ -145,7 +150,9 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     batch, num_key_value_heads, slen, head_dim = hidden_states.shape
     if n_rep == 1:
         return hidden_states
-    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
@@ -179,23 +186,33 @@ class MoonshineStreamingEncoderAttention(nn.Module):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
-        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = False
 
         self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.k_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.v_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.o_proj = nn.Linear(
-            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
         )
 
     def forward(
@@ -294,7 +311,8 @@ class MoonshineStreamingEncoderEmbedder(nn.Module):
         if padding_mask is not None:
             num_frames = padding_mask.sum(-1) // self.frame_len
             padding_mask = (
-                torch.arange(hidden_states.shape[1], device=padding_mask.device)[None, :] < num_frames[:, None]
+                torch.arange(hidden_states.shape[1], device=padding_mask.device)[None, :]
+                < num_frames[:, None]
             )
             hidden_states *= padding_mask[..., None]
 
@@ -324,7 +342,13 @@ class MoonshineStreamingPreTrainedModel(PreTrainedModel):
         """
         Computes the output length of the convolutional layers
         """
-        frame_len = int(round(self.config.encoder_config.sample_rate * self.config.encoder_config.frame_ms / 1000.0))
+        frame_len = int(
+            round(
+                self.config.encoder_config.sample_rate
+                * self.config.encoder_config.frame_ms
+                / 1000.0
+            )
+        )
         output_lengths = input_lengths // frame_len
         output_lengths = (output_lengths - 1) // 2 + 1
         output_lengths = (output_lengths - 1) // 2 + 1
@@ -356,7 +380,9 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 class MoonshineStreamingEncoder(MoonshineStreamingPreTrainedModel):
     config: MoonshineStreamingEncoderConfig
     _can_record_outputs = {
-        "attentions": OutputRecorder(MoonshineStreamingEncoderAttention, index=1, layer_name="self_attn"),
+        "attentions": OutputRecorder(
+            MoonshineStreamingEncoderAttention, index=1, layer_name="self_attn"
+        ),
         "hidden_states": MoonshineStreamingEncoderLayer,
     }
 
@@ -404,7 +430,9 @@ class MoonshineStreamingEncoder(MoonshineStreamingPreTrainedModel):
             }
             per_layer_attention_mask = [
                 create_bidirectional_mask(
-                    and_mask_function=sliding_window_mask_function(self.config.sliding_windows[layer_idx]),
+                    and_mask_function=sliding_window_mask_function(
+                        self.config.sliding_windows[layer_idx]
+                    ),
                     **mask_kwargs,
                 )
                 for layer_idx in range(self.config.num_hidden_layers)
@@ -414,13 +442,17 @@ class MoonshineStreamingEncoder(MoonshineStreamingPreTrainedModel):
         for layer_idx, encoder_layer in enumerate(self.layers):
             hidden_states = encoder_layer(
                 hidden_states,
-                attention_mask=per_layer_attention_mask[layer_idx] if attention_mask is not None else None,
+                attention_mask=per_layer_attention_mask[layer_idx]
+                if attention_mask is not None
+                else None,
                 **kwargs,
             )
 
         hidden_states = self.final_norm(hidden_states)
 
-        return MoonshineStreamingEncoderModelOutput(last_hidden_state=hidden_states, attention_mask=attention_mask)
+        return MoonshineStreamingEncoderModelOutput(
+            last_hidden_state=hidden_states, attention_mask=attention_mask
+        )
 
 
 class MoonshinMoonshineStreamingDecoderMLP(nn.Module):
@@ -495,24 +527,34 @@ class MoonshineStreamingRotaryEmbedding(nn.Module):
         """
         base = config.rope_parameters["rope_theta"]
         partial_rotary_factor = config.rope_parameters.get("partial_rotary_factor", 1.0)
-        head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        head_dim = (
+            getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        )
         dim = int(head_dim * partial_rotary_factor)
 
         attention_factor = 1.0  # Unused in this type of RoPE
 
         # Compute the inverse frequencies
         inv_freq = 1.0 / (
-            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+            base
+            ** (
+                torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float)
+                / dim
+            )
         )
         return inv_freq, attention_factor
 
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, None, :].float()
 
-        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        device_type = (
+            x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        )
         with maybe_autocast(device_type=device_type, enabled=False):  # Force float32
             freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
             emb = torch.cat((freqs, freqs), dim=-1)
@@ -582,30 +624,44 @@ class MoonshineStreamingAttention(nn.Module):
         num_key_value_heads: int,
     ):
         super().__init__()
-        config.update({"num_attention_heads": num_attention_heads, "num_key_value_heads": num_key_value_heads})
+        config.update(
+            {"num_attention_heads": num_attention_heads, "num_key_value_heads": num_key_value_heads}
+        )
         self.config = config
         self.layer_idx = layer_idx
-        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = is_causal
 
         self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.k_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.v_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
-        self.o_proj = nn.Linear(config.num_attention_heads * self.head_dim, config.hidden_size, bias=False)
+        self.o_proj = nn.Linear(
+            config.num_attention_heads * self.head_dim, config.hidden_size, bias=False
+        )
 
         # Pad head dimension to the next specified multiple.
         if self.config.pad_head_dim_to_multiple_of is not None:
             target_multiple = self.config.pad_head_dim_to_multiple_of
-            target_head_dim = target_multiple * ((self.head_dim + target_multiple - 1) // target_multiple)
+            target_head_dim = target_multiple * (
+                (self.head_dim + target_multiple - 1) // target_multiple
+            )
             self.head_dim_padding = target_head_dim - self.head_dim
         else:
             self.head_dim_padding = 0
@@ -622,7 +678,9 @@ class MoonshineStreamingAttention(nn.Module):
         bsz, q_len = hidden_states.shape[:-1]
 
         query_states = (
-            self.q_proj(hidden_states).view(bsz, q_len, self.config.num_key_value_heads, self.head_dim).transpose(1, 2)
+            self.q_proj(hidden_states)
+            .view(bsz, q_len, self.config.num_key_value_heads, self.head_dim)
+            .transpose(1, 2)
         )
 
         is_cross_attention = key_value_states is not None
@@ -652,14 +710,18 @@ class MoonshineStreamingAttention(nn.Module):
                 .transpose(1, 2)
             )
             if is_cross_attention and past_key_values is not None:
-                key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+                key_states, value_states = past_key_values.update(
+                    key_states, value_states, self.layer_idx
+                )
 
         if not is_cross_attention:
             cos, sin = position_embeddings
             query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
             if past_key_values is not None:
-                key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+                key_states, value_states = past_key_values.update(
+                    key_states, value_states, self.layer_idx
+                )
 
         attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
             self.config._attn_implementation, eager_attention_forward
@@ -770,7 +832,9 @@ class MoonshineStreamingDecoder(MoonshineStreamingPreTrainedModel):
     _can_record_outputs = {
         "attentions": OutputRecorder(MoonshineStreamingAttention, index=1, layer_name="self_attn"),
         "hidden_states": MoonshineStreamingDecoderLayer,
-        "cross_attentions": OutputRecorder(MoonshineStreamingAttention, index=1, layer_name="encoder_attn"),
+        "cross_attentions": OutputRecorder(
+            MoonshineStreamingAttention, index=1, layer_name="encoder_attn"
+        ),
     }
 
     def __init__(self, config):
@@ -785,10 +849,14 @@ class MoonshineStreamingDecoder(MoonshineStreamingPreTrainedModel):
         self.norm = nn.LayerNorm(config.hidden_size, bias=False)
         self.rotary_emb = MoonshineStreamingRotaryEmbedding(config=config)
         self.gradient_checkpointing = False
-        self.pos_emb = nn.Embedding(self.config.max_position_embeddings, config.encoder_config.hidden_size)
+        self.pos_emb = nn.Embedding(
+            self.config.max_position_embeddings, config.encoder_config.hidden_size
+        )
 
         if config.encoder_config.hidden_size != self.config.hidden_size:
-            self.proj = nn.Linear(config.encoder_config.hidden_size, self.config.hidden_size, bias=False)
+            self.proj = nn.Linear(
+                config.encoder_config.hidden_size, self.config.hidden_size, bias=False
+            )
         else:
             self.proj = nn.Identity()
 
@@ -831,11 +899,17 @@ class MoonshineStreamingDecoder(MoonshineStreamingPreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         if use_cache and past_key_values is None:
-            past_key_values = EncoderDecoderCache(DynamicCache(config=self.config), DynamicCache(config=self.config))
+            past_key_values = EncoderDecoderCache(
+                DynamicCache(config=self.config), DynamicCache(config=self.config)
+            )
 
         if position_ids is None:
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
-            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            )
             position_ids = position_ids.unsqueeze(0)
 
         causal_mask = create_causal_mask(
@@ -951,7 +1025,9 @@ class MoonshineStreamingModel(MoonshineStreamingPreTrainedModel):
         ```
         """
         if encoder_outputs is None:
-            encoder_outputs: BaseModelOutput = self.encoder(input_values, attention_mask=attention_mask, **kwargs)
+            encoder_outputs: BaseModelOutput = self.encoder(
+                input_values, attention_mask=attention_mask, **kwargs
+            )
 
         decoder_outputs: BaseModelOutputWithPastAndCrossAttentions = self.decoder(
             input_ids=decoder_input_ids,
@@ -998,7 +1074,9 @@ def shift_tokens_right(input_ids: torch.Tensor, pad_token_id: int, decoder_start
     The MoonshineStreaming Model with a language modeling head. Can be used for automatic speech recognition.
     """
 )
-class MoonshineStreamingForConditionalGeneration(MoonshineStreamingPreTrainedModel, GenerationMixin):
+class MoonshineStreamingForConditionalGeneration(
+    MoonshineStreamingPreTrainedModel, GenerationMixin
+):
     _tied_weights_keys = {"proj_out.weight": "model.decoder.embed_tokens.weight"}
 
     def __init__(self, config: MoonshineStreamingConfig):
@@ -1090,7 +1168,9 @@ class MoonshineStreamingForConditionalGeneration(MoonshineStreamingPreTrainedMod
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.vocab_size
+            )
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/examples/moonshine-streaming/reference_inference.py
+++ b/examples/moonshine-streaming/reference_inference.py
@@ -46,7 +46,10 @@ from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple
 from ...utils.generic import maybe_autocast, merge_with_config_defaults
 from ...utils.output_capturing import OutputRecorder, capture_outputs
-from .configuration_moonshine_streaming import MoonshineStreamingConfig, MoonshineStreamingEncoderConfig
+from .configuration_moonshine_streaming import (
+    MoonshineStreamingConfig,
+    MoonshineStreamingEncoderConfig,
+)
 
 
 @dataclass
@@ -90,7 +93,9 @@ class MoonshineStreamingCausalConv1d(nn.Conv1d):
         dilation: int = 1,
         bias: bool = True,
     ):
-        super().__init__(in_channels, out_channels, kernel_size, stride=stride, dilation=dilation, bias=bias)
+        super().__init__(
+            in_channels, out_channels, kernel_size, stride=stride, dilation=dilation, bias=bias
+        )
         self.left_pad = (kernel_size - 1) * dilation
 
     def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
@@ -145,7 +150,9 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     batch, num_key_value_heads, slen, head_dim = hidden_states.shape
     if n_rep == 1:
         return hidden_states
-    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
@@ -179,23 +186,33 @@ class MoonshineStreamingEncoderAttention(nn.Module):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
-        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = False
 
         self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.k_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.v_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.o_proj = nn.Linear(
-            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
         )
 
     def forward(
@@ -294,7 +311,8 @@ class MoonshineStreamingEncoderEmbedder(nn.Module):
         if padding_mask is not None:
             num_frames = padding_mask.sum(-1) // self.frame_len
             padding_mask = (
-                torch.arange(hidden_states.shape[1], device=padding_mask.device)[None, :] < num_frames[:, None]
+                torch.arange(hidden_states.shape[1], device=padding_mask.device)[None, :]
+                < num_frames[:, None]
             )
             hidden_states *= padding_mask[..., None]
 
@@ -324,7 +342,13 @@ class MoonshineStreamingPreTrainedModel(PreTrainedModel):
         """
         Computes the output length of the convolutional layers
         """
-        frame_len = int(round(self.config.encoder_config.sample_rate * self.config.encoder_config.frame_ms / 1000.0))
+        frame_len = int(
+            round(
+                self.config.encoder_config.sample_rate
+                * self.config.encoder_config.frame_ms
+                / 1000.0
+            )
+        )
         output_lengths = input_lengths // frame_len
         output_lengths = (output_lengths - 1) // 2 + 1
         output_lengths = (output_lengths - 1) // 2 + 1
@@ -356,7 +380,9 @@ def sliding_window_mask_function(sliding_window: tuple[int, int]) -> Callable:
 class MoonshineStreamingEncoder(MoonshineStreamingPreTrainedModel):
     config: MoonshineStreamingEncoderConfig
     _can_record_outputs = {
-        "attentions": OutputRecorder(MoonshineStreamingEncoderAttention, index=1, layer_name="self_attn"),
+        "attentions": OutputRecorder(
+            MoonshineStreamingEncoderAttention, index=1, layer_name="self_attn"
+        ),
         "hidden_states": MoonshineStreamingEncoderLayer,
     }
 
@@ -404,7 +430,9 @@ class MoonshineStreamingEncoder(MoonshineStreamingPreTrainedModel):
             }
             per_layer_attention_mask = [
                 create_bidirectional_mask(
-                    and_mask_function=sliding_window_mask_function(self.config.sliding_windows[layer_idx]),
+                    and_mask_function=sliding_window_mask_function(
+                        self.config.sliding_windows[layer_idx]
+                    ),
                     **mask_kwargs,
                 )
                 for layer_idx in range(self.config.num_hidden_layers)
@@ -414,13 +442,17 @@ class MoonshineStreamingEncoder(MoonshineStreamingPreTrainedModel):
         for layer_idx, encoder_layer in enumerate(self.layers):
             hidden_states = encoder_layer(
                 hidden_states,
-                attention_mask=per_layer_attention_mask[layer_idx] if attention_mask is not None else None,
+                attention_mask=per_layer_attention_mask[layer_idx]
+                if attention_mask is not None
+                else None,
                 **kwargs,
             )
 
         hidden_states = self.final_norm(hidden_states)
 
-        return MoonshineStreamingEncoderModelOutput(last_hidden_state=hidden_states, attention_mask=attention_mask)
+        return MoonshineStreamingEncoderModelOutput(
+            last_hidden_state=hidden_states, attention_mask=attention_mask
+        )
 
 
 class MoonshinMoonshineStreamingDecoderMLP(nn.Module):
@@ -495,24 +527,34 @@ class MoonshineStreamingRotaryEmbedding(nn.Module):
         """
         base = config.rope_parameters["rope_theta"]
         partial_rotary_factor = config.rope_parameters.get("partial_rotary_factor", 1.0)
-        head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        head_dim = (
+            getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        )
         dim = int(head_dim * partial_rotary_factor)
 
         attention_factor = 1.0  # Unused in this type of RoPE
 
         # Compute the inverse frequencies
         inv_freq = 1.0 / (
-            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+            base
+            ** (
+                torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float)
+                / dim
+            )
         )
         return inv_freq, attention_factor
 
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, None, :].float()
 
-        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        device_type = (
+            x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        )
         with maybe_autocast(device_type=device_type, enabled=False):  # Force float32
             freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
             emb = torch.cat((freqs, freqs), dim=-1)
@@ -582,30 +624,44 @@ class MoonshineStreamingAttention(nn.Module):
         num_key_value_heads: int,
     ):
         super().__init__()
-        config.update({"num_attention_heads": num_attention_heads, "num_key_value_heads": num_key_value_heads})
+        config.update(
+            {"num_attention_heads": num_attention_heads, "num_key_value_heads": num_key_value_heads}
+        )
         self.config = config
         self.layer_idx = layer_idx
-        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = is_causal
 
         self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.k_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.v_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
-        self.o_proj = nn.Linear(config.num_attention_heads * self.head_dim, config.hidden_size, bias=False)
+        self.o_proj = nn.Linear(
+            config.num_attention_heads * self.head_dim, config.hidden_size, bias=False
+        )
 
         # Pad head dimension to the next specified multiple.
         if self.config.pad_head_dim_to_multiple_of is not None:
             target_multiple = self.config.pad_head_dim_to_multiple_of
-            target_head_dim = target_multiple * ((self.head_dim + target_multiple - 1) // target_multiple)
+            target_head_dim = target_multiple * (
+                (self.head_dim + target_multiple - 1) // target_multiple
+            )
             self.head_dim_padding = target_head_dim - self.head_dim
         else:
             self.head_dim_padding = 0
@@ -622,7 +678,9 @@ class MoonshineStreamingAttention(nn.Module):
         bsz, q_len = hidden_states.shape[:-1]
 
         query_states = (
-            self.q_proj(hidden_states).view(bsz, q_len, self.config.num_key_value_heads, self.head_dim).transpose(1, 2)
+            self.q_proj(hidden_states)
+            .view(bsz, q_len, self.config.num_key_value_heads, self.head_dim)
+            .transpose(1, 2)
         )
 
         is_cross_attention = key_value_states is not None
@@ -652,14 +710,18 @@ class MoonshineStreamingAttention(nn.Module):
                 .transpose(1, 2)
             )
             if is_cross_attention and past_key_values is not None:
-                key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+                key_states, value_states = past_key_values.update(
+                    key_states, value_states, self.layer_idx
+                )
 
         if not is_cross_attention:
             cos, sin = position_embeddings
             query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
             if past_key_values is not None:
-                key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+                key_states, value_states = past_key_values.update(
+                    key_states, value_states, self.layer_idx
+                )
 
         attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
             self.config._attn_implementation, eager_attention_forward
@@ -770,7 +832,9 @@ class MoonshineStreamingDecoder(MoonshineStreamingPreTrainedModel):
     _can_record_outputs = {
         "attentions": OutputRecorder(MoonshineStreamingAttention, index=1, layer_name="self_attn"),
         "hidden_states": MoonshineStreamingDecoderLayer,
-        "cross_attentions": OutputRecorder(MoonshineStreamingAttention, index=1, layer_name="encoder_attn"),
+        "cross_attentions": OutputRecorder(
+            MoonshineStreamingAttention, index=1, layer_name="encoder_attn"
+        ),
     }
 
     def __init__(self, config):
@@ -785,10 +849,14 @@ class MoonshineStreamingDecoder(MoonshineStreamingPreTrainedModel):
         self.norm = nn.LayerNorm(config.hidden_size, bias=False)
         self.rotary_emb = MoonshineStreamingRotaryEmbedding(config=config)
         self.gradient_checkpointing = False
-        self.pos_emb = nn.Embedding(self.config.max_position_embeddings, config.encoder_config.hidden_size)
+        self.pos_emb = nn.Embedding(
+            self.config.max_position_embeddings, config.encoder_config.hidden_size
+        )
 
         if config.encoder_config.hidden_size != self.config.hidden_size:
-            self.proj = nn.Linear(config.encoder_config.hidden_size, self.config.hidden_size, bias=False)
+            self.proj = nn.Linear(
+                config.encoder_config.hidden_size, self.config.hidden_size, bias=False
+            )
         else:
             self.proj = nn.Identity()
 
@@ -831,11 +899,17 @@ class MoonshineStreamingDecoder(MoonshineStreamingPreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         if use_cache and past_key_values is None:
-            past_key_values = EncoderDecoderCache(DynamicCache(config=self.config), DynamicCache(config=self.config))
+            past_key_values = EncoderDecoderCache(
+                DynamicCache(config=self.config), DynamicCache(config=self.config)
+            )
 
         if position_ids is None:
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
-            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            )
             position_ids = position_ids.unsqueeze(0)
 
         causal_mask = create_causal_mask(
@@ -951,7 +1025,9 @@ class MoonshineStreamingModel(MoonshineStreamingPreTrainedModel):
         ```
         """
         if encoder_outputs is None:
-            encoder_outputs: BaseModelOutput = self.encoder(input_values, attention_mask=attention_mask, **kwargs)
+            encoder_outputs: BaseModelOutput = self.encoder(
+                input_values, attention_mask=attention_mask, **kwargs
+            )
 
         decoder_outputs: BaseModelOutputWithPastAndCrossAttentions = self.decoder(
             input_ids=decoder_input_ids,
@@ -998,7 +1074,9 @@ def shift_tokens_right(input_ids: torch.Tensor, pad_token_id: int, decoder_start
     The MoonshineStreaming Model with a language modeling head. Can be used for automatic speech recognition.
     """
 )
-class MoonshineStreamingForConditionalGeneration(MoonshineStreamingPreTrainedModel, GenerationMixin):
+class MoonshineStreamingForConditionalGeneration(
+    MoonshineStreamingPreTrainedModel, GenerationMixin
+):
     _tied_weights_keys = {"proj_out.weight": "model.decoder.embed_tokens.weight"}
 
     def __init__(self, config: MoonshineStreamingConfig):
@@ -1090,7 +1168,9 @@ class MoonshineStreamingForConditionalGeneration(MoonshineStreamingPreTrainedMod
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.vocab_size
+            )
 
         return Seq2SeqLMOutput(
             loss=loss,

--- a/examples/neuron_profiler/analyze_neuron.py
+++ b/examples/neuron_profiler/analyze_neuron.py
@@ -111,9 +111,13 @@ def cmd_capture(ns) -> None:
     # inspect takes the user script as trailing args; run it via bash -lc so
     # the agent can pass a full pipeline / env-prefixed command as one string.
     cmd = [
-        _explorer(), "inspect",
-        "-o", str(out_dir),
-        "bash", "-lc", workload,
+        _explorer(),
+        "inspect",
+        "-o",
+        str(out_dir),
+        "bash",
+        "-lc",
+        workload,
     ]
     # Run with cwd=out_dir: neuron-explorer drops stray artifacts
     # (system_profile.json, ntrace.pb) into the *current directory* regardless

--- a/examples/nsys_profiler/analyze_nsys.py
+++ b/examples/nsys_profiler/analyze_nsys.py
@@ -26,7 +26,6 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -44,16 +43,18 @@ def _open_db(path: str) -> tuple[sqlite3.Connection, dict[int, str]]:
 
 
 def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
-    return conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
-    ).fetchone() is not None
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+        ).fetchone()
+        is not None
+    )
 
 
 def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
     try:
         return any(
-            row[1] == column
-            for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
+            row[1] == column for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
         )
     except sqlite3.OperationalError:
         return False
@@ -100,7 +101,9 @@ def _ensure_sqlite(path: str) -> str:
             sqlite_path.unlink()
         subprocess.run(
             ["nsys", "export", "--type=sqlite", f"--output={sqlite_path}", str(p)],
-            check=True, capture_output=True, text=True,
+            check=True,
+            capture_output=True,
+            text=True,
         )
         return str(sqlite_path)
     return path
@@ -169,9 +172,9 @@ def cmd_kernels(args):
     for name_id, cnt, tot, avg in rows:
         name = _resolve_name(name_id, strings)
         pct = tot / total_ns * 100 if total_ns else 0
-        print(f"{name:<55s} {cnt:>7d} {tot/1000:>11.1f} {avg/1000:>9.1f} {pct:>5.1f}%")
+        print(f"{name:<55s} {cnt:>7d} {tot / 1000:>11.1f} {avg / 1000:>9.1f} {pct:>5.1f}%")
     total_launches = sum(r[1] for r in rows)
-    print(f"\nTotal GPU kernel time: {total_ns/1e6:.2f} ms")
+    print(f"\nTotal GPU kernel time: {total_ns / 1e6:.2f} ms")
     print(f"Total kernel launches: {total_launches}")
 
 
@@ -193,7 +196,7 @@ def cmd_cpu_overhead(args):
     total_calls, total_ns = row if row else (0, 0)
     total_ns = total_ns or 0
     print(f"Total CUDA runtime API calls: {total_calls}")
-    print(f"Total CPU time in CUDA APIs:  {total_ns/1e6:.2f} ms")
+    print(f"Total CPU time in CUDA APIs:  {total_ns / 1e6:.2f} ms")
 
     has_cbid = _column_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME", "cbid")
     has_nameId = _column_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME", "nameId")
@@ -209,7 +212,7 @@ def cmd_cpu_overhead(args):
             print(f"\n{'API Function':<40s} {'Count':>8s} {'Total(us)':>11s} {'Avg(us)':>9s}")
             print("-" * 72)
             for name, cnt, tot, avg in api_rows:
-                print(f"{(name or '?'):<40s} {cnt:>8d} {tot/1000:>11.1f} {avg/1000:>9.1f}")
+                print(f"{(name or '?'):<40s} {cnt:>8d} {tot / 1000:>11.1f} {avg / 1000:>9.1f}")
 
         # Sync stalls
         sync_rows = conn.execute(
@@ -223,7 +226,7 @@ def cmd_cpu_overhead(args):
         ).fetchall()
         sync_total = sum(r[2] for r in sync_rows) if sync_rows else 0
         sync_count = sum(r[1] for r in sync_rows) if sync_rows else 0
-        print(f"\nSynchronization stalls: {sync_count} calls, {sync_total/1e6:.2f} ms")
+        print(f"\nSynchronization stalls: {sync_count} calls, {sync_total / 1e6:.2f} ms")
 
         # Launch overhead ratio
         launch_filter = (
@@ -232,9 +235,14 @@ def cmd_cpu_overhead(args):
         )
     elif has_cbid:
         cbid_names = {
-            33: "cudaLaunchKernel", 49: "cudaMemcpyAsync", 59: "cudaMalloc",
-            60: "cudaFree", 162: "cudaStreamSynchronize", 163: "cudaDeviceSynchronize",
-            164: "cudaEventSynchronize", 211: "cudaLaunchKernelExC",
+            33: "cudaLaunchKernel",
+            49: "cudaMemcpyAsync",
+            59: "cudaMalloc",
+            60: "cudaFree",
+            162: "cudaStreamSynchronize",
+            163: "cudaDeviceSynchronize",
+            164: "cudaEventSynchronize",
+            211: "cudaLaunchKernelExC",
         }
         api_rows = conn.execute(
             "SELECT cbid, COUNT(*), SUM(end-start), AVG(end-start) "
@@ -244,7 +252,9 @@ def cmd_cpu_overhead(args):
             print(f"\n{'API Function':<40s} {'Count':>8s} {'Total(us)':>11s} {'Avg(us)':>9s}")
             print("-" * 72)
             for cbid, cnt, tot, avg in api_rows:
-                print(f"{cbid_names.get(cbid, f'cbid_{cbid}'):<40s} {cnt:>8d} {tot/1000:>11.1f} {avg/1000:>9.1f}")
+                print(
+                    f"{cbid_names.get(cbid, f'cbid_{cbid}'):<40s} {cnt:>8d} {tot / 1000:>11.1f} {avg / 1000:>9.1f}"
+                )
         sync_cbids = {162, 163, 164}
         sync_rows = conn.execute(
             f"SELECT cbid, COUNT(*), SUM(end-start) FROM CUPTI_ACTIVITY_KIND_RUNTIME "
@@ -252,7 +262,7 @@ def cmd_cpu_overhead(args):
         ).fetchall()
         sync_total = sum(r[2] for r in sync_rows) if sync_rows else 0
         sync_count = sum(r[1] for r in sync_rows) if sync_rows else 0
-        print(f"\nSynchronization stalls: {sync_count} calls, {sync_total/1e6:.2f} ms")
+        print(f"\nSynchronization stalls: {sync_count} calls, {sync_total / 1e6:.2f} ms")
         launch_filter = "r.cbid IN (33, 211)"
     else:
         return
@@ -318,7 +328,7 @@ def cmd_idle_gaps(args):
             gap = merged[i][0] - merged[i - 1][1]
             if gap > 1000:
                 total_idle += gap
-                prev = end_map.get(merged[i-1][1])
+                prev = end_map.get(merged[i - 1][1])
                 nxt = start_map.get(merged[i][0])
                 pn = _resolve_name(prev[0], strings) if prev else "?"
                 nn = _resolve_name(nxt[0], strings) if nxt else "?"
@@ -327,15 +337,15 @@ def cmd_idle_gaps(args):
     gaps.sort(key=lambda x: -x[2])
     total = total_busy + total_idle
     pct = total_idle / total * 100 if total else 0
-    print(f"GPU busy: {total_busy/1e6:.2f} ms")
-    print(f"GPU idle: {total_idle/1e6:.2f} ms ({pct:.1f}%)")
+    print(f"GPU busy: {total_busy / 1e6:.2f} ms")
+    print(f"GPU idle: {total_idle / 1e6:.2f} ms ({pct:.1f}%)")
     print(f"Idle gaps (>1us): {len(gaps)}")
-    if gaps[:args.top]:
+    if gaps[: args.top]:
         print(f"\nTop {min(args.top, len(gaps))} gaps:")
         print(f"  {'Gap(us)':>10s}  {'After':<40s} → {'Before':<40s}")
         print("  " + "-" * 95)
-        for pn, nn, g in gaps[:args.top]:
-            print(f"  {g/1000:>10.1f}  {pn:<40s} → {nn:<40s}")
+        for pn, nn, g in gaps[: args.top]:
+            print(f"  {g / 1000:>10.1f}  {pn:<40s} → {nn:<40s}")
 
 
 # ---------------------------------------------------------------------------
@@ -357,7 +367,9 @@ def cmd_memory(args):
             print(f"{'Dir':<8s} {'Count':>8s} {'Total(us)':>11s} {'Bytes':>14s}")
             print("-" * 45)
             for kind, cnt, tot, byt in rows:
-                print(f"{kinds.get(kind, f'k{kind}'):<8s} {cnt:>8d} {tot/1000:>11.1f} {byt:>14,d}")
+                print(
+                    f"{kinds.get(kind, f'k{kind}'):<8s} {cnt:>8d} {tot / 1000:>11.1f} {byt:>14,d}"
+                )
     else:
         print("(No memcpy data.)")
 
@@ -375,7 +387,7 @@ def cmd_memory(args):
                 print(f"\n{'Alloc API':<25s} {'Count':>8s} {'Total(us)':>11s}")
                 print("-" * 48)
                 for name, cnt, tot in rows:
-                    print(f"{name:<25s} {cnt:>8d} {tot/1000:>11.1f}")
+                    print(f"{name:<25s} {cnt:>8d} {tot / 1000:>11.1f}")
 
 
 # ---------------------------------------------------------------------------
@@ -405,7 +417,9 @@ def cmd_graph_replays(args):
     for s, e, gid, geid in traces:
         by_exec[geid].append(e - s)
 
-    print(f"\n{'GraphExec':>10s} {'Replays':>8s} {'Avg(us)':>10s} {'Min(us)':>10s} {'Max(us)':>10s}")
+    print(
+        f"\n{'GraphExec':>10s} {'Replays':>8s} {'Avg(us)':>10s} {'Min(us)':>10s} {'Max(us)':>10s}"
+    )
     print("-" * 52)
     for geid, durs in sorted(by_exec.items()):
         avg = sum(durs) / len(durs) / 1000
@@ -414,7 +428,9 @@ def cmd_graph_replays(args):
         print(f"{geid:>10d} {len(durs):>8d} {avg:>10.1f} {mn:>10.1f} {mx:>10.1f}")
 
     # Match with CPU-side cudaGraphLaunch
-    if _table_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME") and _column_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME", "nameId"):
+    if _table_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME") and _column_exists(
+        conn, "CUPTI_ACTIVITY_KIND_RUNTIME", "nameId"
+    ):
         launch_rows = conn.execute(
             """SELECT r.start, r.end, r.correlationId
                FROM CUPTI_ACTIVITY_KIND_RUNTIME r
@@ -425,22 +441,22 @@ def cmd_graph_replays(args):
         if launch_rows:
             cpu_durs = [(r[1] - r[0]) / 1000 for r in launch_rows]
             print(f"\ncudaGraphLaunch calls: {len(cpu_durs)}")
-            print(f"  CPU launch avg: {sum(cpu_durs)/len(cpu_durs):.1f} us")
+            print(f"  CPU launch avg: {sum(cpu_durs) / len(cpu_durs):.1f} us")
             print(f"  CPU launch min: {min(cpu_durs):.1f} us")
             print(f"  CPU launch max: {max(cpu_durs):.1f} us")
 
     # Gap between consecutive replays (scheduling overhead)
     if len(traces) >= 2:
-        replay_gaps = [traces[i][0] - traces[i-1][1] for i in range(1, len(traces))]
+        replay_gaps = [traces[i][0] - traces[i - 1][1] for i in range(1, len(traces))]
         replay_gaps = [g for g in replay_gaps if g > 0]
         if replay_gaps:
             avg_gap = sum(replay_gaps) / len(replay_gaps) / 1000
-            med_gap = sorted(replay_gaps)[len(replay_gaps)//2] / 1000
+            med_gap = sorted(replay_gaps)[len(replay_gaps) // 2] / 1000
             print(f"\nGap between replays (scheduling overhead):")
             print(f"  Avg: {avg_gap:.1f} us")
             print(f"  Median: {med_gap:.1f} us")
-            print(f"  Min: {min(replay_gaps)/1000:.1f} us")
-            print(f"  Max: {max(replay_gaps)/1000:.1f} us")
+            print(f"  Min: {min(replay_gaps) / 1000:.1f} us")
+            print(f"  Max: {max(replay_gaps) / 1000:.1f} us")
 
 
 # ---------------------------------------------------------------------------
@@ -478,7 +494,10 @@ def cmd_step_timeline(args):
 
     # Find decode step boundaries: gaps > threshold
     # Adaptive threshold: find the gap that separates intra-step from inter-step
-    all_gaps = sorted([rows[i][1] - rows[i-1][2] for i in range(1, len(rows)) if rows[i][1] > rows[i-1][2]], reverse=True)
+    all_gaps = sorted(
+        [rows[i][1] - rows[i - 1][2] for i in range(1, len(rows)) if rows[i][1] > rows[i - 1][2]],
+        reverse=True,
+    )
     if not all_gaps:
         print("(No gaps between kernels.)")
         return
@@ -488,9 +507,9 @@ def cmd_step_timeline(args):
     best_thresh = None
     for pct in [0.01, 0.02, 0.05, 0.1]:
         thresh = all_gaps[max(0, int(len(all_gaps) * pct))]
-        boundaries = [i for i in range(1, len(rows)) if rows[i][1] - rows[i-1][2] > thresh]
+        boundaries = [i for i in range(1, len(rows)) if rows[i][1] - rows[i - 1][2] > thresh]
         if len(boundaries) >= 3:
-            sizes = [boundaries[j+1] - boundaries[j] for j in range(len(boundaries)-1)]
+            sizes = [boundaries[j + 1] - boundaries[j] for j in range(len(boundaries) - 1)]
             # Check consistency: most steps should be similar size
             if sizes and max(sizes) < 3 * min(sizes):
                 best_thresh = thresh
@@ -498,11 +517,13 @@ def cmd_step_timeline(args):
 
     if best_thresh is None:
         # Fallback: use a fixed threshold
-        best_thresh = all_gaps[min(5, len(all_gaps)-1)] if len(all_gaps) > 5 else 100000
+        best_thresh = all_gaps[min(5, len(all_gaps) - 1)] if len(all_gaps) > 5 else 100000
 
-    boundaries = [i for i in range(1, len(rows)) if rows[i][1] - rows[i-1][2] > best_thresh]
+    boundaries = [i for i in range(1, len(rows)) if rows[i][1] - rows[i - 1][2] > best_thresh]
     if len(boundaries) < 2:
-        print(f"(Could not detect decode step boundaries. Try graph-replays if CUDA graphs are active.)")
+        print(
+            f"(Could not detect decode step boundaries. Try graph-replays if CUDA graphs are active.)"
+        )
         return
 
     # Analyze the Nth step (default: 2nd, to skip any warmup artifact)
@@ -514,16 +535,16 @@ def cmd_step_timeline(args):
     n_kernels = len(step_rows)
     gpu_time = sum(r[2] - r[1] for r in step_rows)
     wall_time = step_rows[-1][2] - step_rows[0][1] if step_rows else 0
-    gap_time = sum(max(0, step_rows[i][1] - step_rows[i-1][2]) for i in range(1, len(step_rows)))
+    gap_time = sum(max(0, step_rows[i][1] - step_rows[i - 1][2]) for i in range(1, len(step_rows)))
 
-    sizes = [boundaries[j+1] - boundaries[j] for j in range(min(5, len(boundaries)-1))]
-    print(f"Detected {len(boundaries)} decode steps (threshold: {best_thresh/1000:.0f} us)")
+    sizes = [boundaries[j + 1] - boundaries[j] for j in range(min(5, len(boundaries) - 1))]
+    print(f"Detected {len(boundaries)} decode steps (threshold: {best_thresh / 1000:.0f} us)")
     print(f"Kernels per step: {sizes}")
     print(f"\n=== Decode step {step_idx} ({n_kernels} kernels) ===")
-    print(f"GPU time:  {gpu_time/1000:.0f} us")
-    print(f"Gap time:  {gap_time/1000:.0f} us")
-    print(f"Wall time: {wall_time/1000:.0f} us")
-    print(f"GPU util:  {gpu_time/wall_time*100:.0f}%" if wall_time else "")
+    print(f"GPU time:  {gpu_time / 1000:.0f} us")
+    print(f"Gap time:  {gap_time / 1000:.0f} us")
+    print(f"Wall time: {wall_time / 1000:.0f} us")
+    print(f"GPU util:  {gpu_time / wall_time * 100:.0f}%" if wall_time else "")
 
     # Kernel breakdown
     kstats = defaultdict(lambda: {"count": 0, "total": 0})
@@ -536,14 +557,16 @@ def cmd_step_timeline(args):
     print("-" * 83)
     for name, s in sorted(kstats.items(), key=lambda x: -x[1]["total"]):
         pct = s["total"] / gpu_time * 100 if gpu_time else 0
-        print(f"{name:<50s} {s['count']:>5d} {s['total']/1000:>10.1f} {s['total']/s['count']/1000:>8.1f} {pct:>5.1f}%")
+        print(
+            f"{name:<50s} {s['count']:>5d} {s['total'] / 1000:>10.1f} {s['total'] / s['count'] / 1000:>8.1f} {pct:>5.1f}%"
+        )
 
     # Top gap transitions
     gstats = defaultdict(lambda: {"count": 0, "total": 0})
     for i in range(1, len(step_rows)):
-        g = step_rows[i][1] - step_rows[i-1][2]
+        g = step_rows[i][1] - step_rows[i - 1][2]
         if g > 0:
-            pn = _resolve_name(step_rows[i-1][0], strings)[:20]
+            pn = _resolve_name(step_rows[i - 1][0], strings)[:20]
             nn = _resolve_name(step_rows[i][0], strings)[:20]
             gstats[f"{pn:20s} → {nn}"]["count"] += 1
             gstats[f"{pn:20s} → {nn}"]["total"] += g
@@ -551,8 +574,10 @@ def cmd_step_timeline(args):
     print(f"\n{'Gap transition':<45s} {'Cnt':>5s} {'Total(us)':>10s} {'Avg(us)':>8s}")
     print("-" * 72)
     for key, s in sorted(gstats.items(), key=lambda x: -x[1]["total"])[:10]:
-        print(f"{key:<45s} {s['count']:>5d} {s['total']/1000:>10.1f} {s['total']/s['count']/1000:>8.1f}")
-    print(f"\nTotal intra-step gap: {gap_time/1000:.0f} us")
+        print(
+            f"{key:<45s} {s['count']:>5d} {s['total'] / 1000:>10.1f} {s['total'] / s['count'] / 1000:>8.1f}"
+        )
+    print(f"\nTotal intra-step gap: {gap_time / 1000:.0f} us")
 
 
 # ---------------------------------------------------------------------------
@@ -570,7 +595,9 @@ def _build_string_map(conn: sqlite3.Connection) -> dict[int, str]:
 
 def _capture_stdout(fn, *a, **kw) -> str:
     """Run fn() and capture its stdout as a string."""
-    import io, contextlib
+    import contextlib
+    import io
+
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         fn(*a, **kw)
@@ -579,9 +606,11 @@ def _capture_stdout(fn, *a, **kw) -> str:
 
 def analyze_kernels(conn, strings, top_n=15):
     """Legacy API — returns analysis as a string."""
+
     class _A:
         report = ":memory:"
         top = top_n
+
     # Monkey-patch _open_db for this call
     saved = globals().get("_open_db")
     globals()["_open_db"] = lambda p: (conn, strings)
@@ -594,6 +623,7 @@ def analyze_kernels(conn, strings, top_n=15):
 def analyze_cpu_overhead(conn, strings):
     class _A:
         report = ":memory:"
+
     saved = globals().get("_open_db")
     globals()["_open_db"] = lambda p: (conn, strings)
     try:
@@ -606,6 +636,7 @@ def analyze_gpu_idle_gaps(conn, strings, top_n=10):
     class _A:
         report = ":memory:"
         top = top_n
+
     saved = globals().get("_open_db")
     globals()["_open_db"] = lambda p: (conn, strings)
     try:
@@ -617,6 +648,7 @@ def analyze_gpu_idle_gaps(conn, strings, top_n=10):
 def analyze_memory_ops(conn):
     class _A:
         report = ":memory:"
+
     saved = globals().get("_open_db")
     globals()["_open_db"] = lambda p: (conn, {})
     try:
@@ -711,7 +743,9 @@ def main():
 
     p = sub.add_parser("step-timeline", help="Per-decode-step kernel breakdown")
     p.add_argument("report")
-    p.add_argument("--step", type=int, default=1, help="Which decode step to analyze (0-indexed, default: 1)")
+    p.add_argument(
+        "--step", type=int, default=1, help="Which decode step to analyze (0-indexed, default: 1)"
+    )
 
     p = sub.add_parser("query", help="Run arbitrary SQL")
     p.add_argument("report")

--- a/examples/nsys_profiler/server.py
+++ b/examples/nsys_profiler/server.py
@@ -23,7 +23,6 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
-
 _HERE = Path(__file__).resolve().parent
 
 # Import the analysis module by path so this file is usable both from inside
@@ -134,7 +133,10 @@ def build_server() -> FastMCP:
     def summary(report: str, top: int = 15, step: int = 1) -> str:
         """All-in-one analysis: kernels + cpu_overhead + idle_gaps + memory + graph_replays + step_timeline."""
         return _capture(
-            analyze_nsys.cmd_summary, report=report, top=top, step=step,
+            analyze_nsys.cmd_summary,
+            report=report,
+            top=top,
+            step=step,
         )
 
     return mcp

--- a/examples/olmo-hybrid-prefix-caching/accuracy_checker/checker.py
+++ b/examples/olmo-hybrid-prefix-caching/accuracy_checker/checker.py
@@ -42,7 +42,7 @@ def _load_custom_model_class():
 RAW_COMPLETION_SAMPLES: list[tuple[str, int, str]] = [
     ("The capital of France is", 15, "short factual completion"),
     ("Once upon a time, in a land far away,", 50, "story continuation"),
-    ("def fibonacci(n):\n    \"\"\"Return the n-th Fibonacci number.\"\"\"\n", 40, "code completion"),
+    ('def fibonacci(n):\n    """Return the n-th Fibonacci number."""\n', 40, "code completion"),
     ("1 + 1 =", 5, "arithmetic"),
     ("A B C D E F G H I J K L M N O P Q R S T U V W X Y Z A B C D E F G", 20, "alphabet pattern"),
     (
@@ -66,6 +66,7 @@ RAW_COMPLETION_SAMPLES: list[tuple[str, int, str]] = [
 # Reference: HuggingFace model.generate()
 # ---------------------------------------------------------------------------
 
+
 @torch.inference_mode()
 def generate_reference(model, tokenizer, prompt_text, max_new_tokens, device):
     inputs = tokenizer(prompt_text, return_tensors="pt").to(device)
@@ -77,6 +78,7 @@ def generate_reference(model, tokenizer, prompt_text, max_new_tokens, device):
 # ---------------------------------------------------------------------------
 # Custom model: uses VibeServeModel.generate()
 # ---------------------------------------------------------------------------
+
 
 @torch.inference_mode()
 def generate_custom(model, tokenizer, prompt_text, max_new_tokens, device):
@@ -90,6 +92,7 @@ def generate_custom(model, tokenizer, prompt_text, max_new_tokens, device):
 # ---------------------------------------------------------------------------
 # Comparison logic
 # ---------------------------------------------------------------------------
+
 
 def compare_outputs(ref_ids, custom_ids, tokenizer):
     ref_text = tokenizer.decode(ref_ids, skip_special_tokens=True)
@@ -109,8 +112,8 @@ def compare_outputs(ref_ids, custom_ids, tokenizer):
         f"MISMATCH at token {first_diff}.\n"
         f"  Reference ({len(ref_ids):3d} tokens): {ref_text!r}\n"
         f"  Custom    ({len(custom_ids):3d} tokens): {custom_text!r}\n"
-        f"  Ref  ids[{first_diff}:]: {ref_ids[first_diff:first_diff+10]}\n"
-        f"  Cust ids[{first_diff}:]: {custom_ids[first_diff:first_diff+10]}"
+        f"  Ref  ids[{first_diff}:]: {ref_ids[first_diff : first_diff + 10]}\n"
+        f"  Cust ids[{first_diff}:]: {custom_ids[first_diff : first_diff + 10]}"
     )
     return False, detail
 
@@ -119,10 +122,13 @@ def compare_outputs(ref_ids, custom_ids, tokenizer):
 # Main
 # ---------------------------------------------------------------------------
 
+
 def main():
     parser = argparse.ArgumentParser(description="Accuracy checker: custom model vs HF reference")
     parser.add_argument(
-        "--model-dir", type=str, default="../model",
+        "--model-dir",
+        type=str,
+        default="../model",
         help="Local path to model weights directory (default: ../model)",
     )
     parser.add_argument("--device", type=str, default="cuda:0")
@@ -144,7 +150,9 @@ def main():
     print(f"\nLoading HF reference model on {args.device} ...")
     t0 = time.perf_counter()
     ref_model = AutoModelForCausalLM.from_pretrained(
-        model_dir, torch_dtype=dtype, device_map=args.device,
+        model_dir,
+        torch_dtype=dtype,
+        device_map=args.device,
         attn_implementation="eager",
     )
     ref_model.eval()
@@ -153,7 +161,9 @@ def main():
     print("Generating reference outputs ...")
     ref_outputs: list[list[int]] = []
     for prompt, max_tokens, desc in test_cases:
-        ref_outputs.append(generate_reference(ref_model, tokenizer, prompt, max_tokens, args.device))
+        ref_outputs.append(
+            generate_reference(ref_model, tokenizer, prompt, max_tokens, args.device)
+        )
 
     # Unload HF model to free GPU memory
     del ref_model

--- a/examples/olmo-hybrid-prefix-caching/benchmark/benchmark.py
+++ b/examples/olmo-hybrid-prefix-caching/benchmark/benchmark.py
@@ -36,11 +36,10 @@ import random
 import statistics
 import sys
 import time
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import httpx
-
 
 DEFAULT_MODEL_ID = "allenai/Olmo-Hybrid-7B"
 
@@ -138,13 +137,12 @@ async def stream_one_request(
             if resp.status_code != 200:
                 body_bytes = await resp.aread()
                 raise RuntimeError(
-                    f"http {resp.status_code}: "
-                    f"{body_bytes.decode('utf-8', errors='replace')[:500]}"
+                    f"http {resp.status_code}: {body_bytes.decode('utf-8', errors='replace')[:500]}"
                 )
             async for line in resp.aiter_lines():
                 if not line or not line.startswith("data: "):
                     continue
-                data = line[len("data: "):]
+                data = line[len("data: ") :]
                 if data == "[DONE]":
                     break
                 try:
@@ -258,15 +256,23 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
         # tokens) then dominates, which is the regime we want to measure.
         if args.warmup > 0:
             warm_shared, warm_uniques = build_token_ids(
-                args.shared_len, args.unique_len, args.warmup, vocab_size,
-                seed=args.seed - 1, shared_seed=args.shared_seed,
+                args.shared_len,
+                args.unique_len,
+                args.warmup,
+                vocab_size,
+                seed=args.seed - 1,
+                shared_seed=args.shared_seed,
             )
             for w in range(args.warmup):
                 warm_prompt = warm_shared + warm_uniques[w]
                 t0 = time.perf_counter()
                 warm = await stream_one_request(
-                    client, base_url, args.model, warm_prompt,
-                    max_tokens=min(8, args.max_tokens), idx=-1 - w,
+                    client,
+                    base_url,
+                    args.model,
+                    warm_prompt,
+                    max_tokens=min(8, args.max_tokens),
+                    idx=-1 - w,
                 )
                 t1 = time.perf_counter()
                 print(
@@ -282,13 +288,19 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
             file=sys.stderr,
         )
         t_run0 = time.perf_counter()
-        results: list[RequestResult] = await asyncio.gather(*[
-            stream_one_request(
-                client, base_url, args.model, prompts[i],
-                args.max_tokens, i,
-            )
-            for i in range(n_requests)
-        ])
+        results: list[RequestResult] = await asyncio.gather(
+            *[
+                stream_one_request(
+                    client,
+                    base_url,
+                    args.model,
+                    prompts[i],
+                    args.max_tokens,
+                    i,
+                )
+                for i in range(n_requests)
+            ]
+        )
         t_run = time.perf_counter() - t_run0
 
     # --- Aggregate ---
@@ -390,47 +402,93 @@ def main() -> None:
     )
     p.add_argument("--url", default="http://localhost:8000", help="Server base URL")
     p.add_argument(
-        "--model", default=DEFAULT_MODEL_ID,
+        "--model",
+        default=DEFAULT_MODEL_ID,
         help="HF model id, used both for tokenizer and the `model` field in completions calls",
     )
-    p.add_argument("--shared-len", type=int, default=32_768,
-                   help="Shared prefix length in tokens (default 32768).")
-    p.add_argument("--unique-len", type=int, default=128,
-                   help="Unique tail length per request in tokens (default 128).")
-    p.add_argument("--max-tokens", type=int, default=128,
-                   help="Output tokens per request (default 128).")
-    p.add_argument("--requests", type=int, default=20,
-                   help="Number of concurrent requests (default 20).")
+    p.add_argument(
+        "--shared-len",
+        type=int,
+        default=32_768,
+        help="Shared prefix length in tokens (default 32768).",
+    )
+    p.add_argument(
+        "--unique-len",
+        type=int,
+        default=128,
+        help="Unique tail length per request in tokens (default 128).",
+    )
+    p.add_argument(
+        "--max-tokens", type=int, default=128, help="Output tokens per request (default 128)."
+    )
+    p.add_argument(
+        "--requests", type=int, default=20, help="Number of concurrent requests (default 20)."
+    )
     # Alias for orchestrate's sanity-check invocation, which uses
     # `--num-requests 2`. Mirrors the convention from other input bundles.
-    p.add_argument("--num-requests", type=int, default=None,
-                   help="Alias for --requests (orchestrate sanity-check uses this name).")
-    p.add_argument("--warmup", type=int, default=1,
-                   help="Number of warmup requests to populate the prefix cache (default 1).")
-    p.add_argument("--seed", type=int, default=int(time.time()),
-                   help="RNG seed for per-request unique tails (default: wall clock).")
-    p.add_argument("--shared-seed", type=int, default=0,
-                   help=("RNG seed for the shared prefix. Default 0 keeps the "
-                         "32k prefix identical across invocations, which is the "
-                         "whole point of measuring shared-prefix caching."))
-    p.add_argument("--output-json", type=str, default=None,
-                   help="Optional path to write structured results.")
+    p.add_argument(
+        "--num-requests",
+        type=int,
+        default=None,
+        help="Alias for --requests (orchestrate sanity-check uses this name).",
+    )
+    p.add_argument(
+        "--warmup",
+        type=int,
+        default=1,
+        help="Number of warmup requests to populate the prefix cache (default 1).",
+    )
+    p.add_argument(
+        "--seed",
+        type=int,
+        default=int(time.time()),
+        help="RNG seed for per-request unique tails (default: wall clock).",
+    )
+    p.add_argument(
+        "--shared-seed",
+        type=int,
+        default=0,
+        help=(
+            "RNG seed for the shared prefix. Default 0 keeps the "
+            "32k prefix identical across invocations, which is the "
+            "whole point of measuring shared-prefix caching."
+        ),
+    )
+    p.add_argument(
+        "--output-json", type=str, default=None, help="Optional path to write structured results."
+    )
 
     # Back-compat no-ops so the orchestrate sanity / profiler invocations
     # (which default to `--rate 1 --num-requests 5 --max-tokens 64`) do not
     # choke on flags this benchmark doesn't need.
-    p.add_argument("--rate", type=float, default=None,
-                   help="Ignored — this benchmark is closed-loop concurrent only.")
-    p.add_argument("--duration", type=float, default=None,
-                   help="Ignored — this benchmark runs to --requests / --num-requests.")
-    p.add_argument("--prompt-len", type=int, default=None,
-                   help="Ignored — prompts are synthesised from --shared-len + --unique-len.")
-    p.add_argument("--temperature", type=float, default=None,
-                   help="Ignored — temperature is fixed at 0 for deterministic decoding.")
-    p.add_argument("--endpoint", type=str, default=None,
-                   help="Ignored — endpoint is /v1/completions.")
-    p.add_argument("--audio-dir", type=str, default=None,
-                   help="Ignored — text-only benchmark.")
+    p.add_argument(
+        "--rate",
+        type=float,
+        default=None,
+        help="Ignored — this benchmark is closed-loop concurrent only.",
+    )
+    p.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="Ignored — this benchmark runs to --requests / --num-requests.",
+    )
+    p.add_argument(
+        "--prompt-len",
+        type=int,
+        default=None,
+        help="Ignored — prompts are synthesised from --shared-len + --unique-len.",
+    )
+    p.add_argument(
+        "--temperature",
+        type=float,
+        default=None,
+        help="Ignored — temperature is fixed at 0 for deterministic decoding.",
+    )
+    p.add_argument(
+        "--endpoint", type=str, default=None, help="Ignored — endpoint is /v1/completions."
+    )
+    p.add_argument("--audio-dir", type=str, default=None, help="Ignored — text-only benchmark.")
 
     args = p.parse_args()
     asyncio.run(run_benchmark(args))

--- a/examples/olmo-hybrid-prefix-caching/reference/reference.py
+++ b/examples/olmo-hybrid-prefix-caching/reference/reference.py
@@ -44,7 +44,6 @@ from ...utils.import_utils import is_flash_linear_attention_available
 from ...utils.output_capturing import capture_outputs
 from .configuration_olmo_hybrid import OlmoHybridConfig
 
-
 if is_flash_linear_attention_available():
     from fla.modules import FusedRMSNormGated, ShortConvolution
     from fla.ops.gated_delta_rule import chunk_gated_delta_rule, fused_recurrent_gated_delta_rule
@@ -72,7 +71,9 @@ class OlmoHybridDynamicCache:
         self.transformer_layers = [
             i for i in range(config.num_hidden_layers) if self.layer_types[i] == "full_attention"
         ]
-        self.last_linear_layer = len(self.layer_types) - 1 - self.layer_types[::-1].index("linear_attention")
+        self.last_linear_layer = (
+            len(self.layer_types) - 1 - self.layer_types[::-1].index("linear_attention")
+        )
         self.recurrent_states = [None for _ in range(config.num_hidden_layers)]
         self.key_cache = [None for _ in range(config.num_hidden_layers)]
         self.value_cache = [None for _ in range(config.num_hidden_layers)]
@@ -96,7 +97,9 @@ class OlmoHybridDynamicCache:
             self.value_cache[layer_idx] = value_states
         else:
             self.key_cache[layer_idx] = torch.cat([self.key_cache[layer_idx], key_states], dim=2)
-            self.value_cache[layer_idx] = torch.cat([self.value_cache[layer_idx], value_states], dim=2)
+            self.value_cache[layer_idx] = torch.cat(
+                [self.value_cache[layer_idx], value_states], dim=2
+            )
 
         return self.key_cache[layer_idx], self.value_cache[layer_idx]
 
@@ -107,11 +110,19 @@ class OlmoHybridDynamicCache:
             if self.key_cache[layer_idx] is not None:
                 if self.key_cache[layer_idx].shape[0] < batch_size:
                     expand_ratio = batch_size // self.key_cache[layer_idx].shape[0]
-                    self.key_cache[layer_idx] = self.key_cache[layer_idx].repeat_interleave(expand_ratio, dim=0)
-                    self.value_cache[layer_idx] = self.value_cache[layer_idx].repeat_interleave(expand_ratio, dim=0)
+                    self.key_cache[layer_idx] = self.key_cache[layer_idx].repeat_interleave(
+                        expand_ratio, dim=0
+                    )
+                    self.value_cache[layer_idx] = self.value_cache[layer_idx].repeat_interleave(
+                        expand_ratio, dim=0
+                    )
                 device = self.key_cache[layer_idx].device
-                self.key_cache[layer_idx] = self.key_cache[layer_idx].index_select(0, beam_idx.to(device))
-                self.value_cache[layer_idx] = self.value_cache[layer_idx].index_select(0, beam_idx.to(device))
+                self.key_cache[layer_idx] = self.key_cache[layer_idx].index_select(
+                    0, beam_idx.to(device)
+                )
+                self.value_cache[layer_idx] = self.value_cache[layer_idx].index_select(
+                    0, beam_idx.to(device)
+                )
             if self.conv_states_q[layer_idx] is not None:
                 if self.conv_states_q[layer_idx].shape[0] < batch_size:
                     expand_ratio = batch_size // self.conv_states_q[layer_idx].shape[0]
@@ -124,13 +135,19 @@ class OlmoHybridDynamicCache:
                     self.conv_states_v[layer_idx] = self.conv_states_v[layer_idx].repeat_interleave(
                         expand_ratio, dim=0
                     )
-                    self.recurrent_states[layer_idx] = self.recurrent_states[layer_idx].repeat_interleave(
-                        expand_ratio, dim=0
-                    )
+                    self.recurrent_states[layer_idx] = self.recurrent_states[
+                        layer_idx
+                    ].repeat_interleave(expand_ratio, dim=0)
                 device = self.conv_states_q[layer_idx].device
-                self.conv_states_q[layer_idx] = self.conv_states_q[layer_idx].index_select(0, beam_idx.to(device))
-                self.conv_states_k[layer_idx] = self.conv_states_k[layer_idx].index_select(0, beam_idx.to(device))
-                self.conv_states_v[layer_idx] = self.conv_states_v[layer_idx].index_select(0, beam_idx.to(device))
+                self.conv_states_q[layer_idx] = self.conv_states_q[layer_idx].index_select(
+                    0, beam_idx.to(device)
+                )
+                self.conv_states_k[layer_idx] = self.conv_states_k[layer_idx].index_select(
+                    0, beam_idx.to(device)
+                )
+                self.conv_states_v[layer_idx] = self.conv_states_v[layer_idx].index_select(
+                    0, beam_idx.to(device)
+                )
                 self.recurrent_states[layer_idx] = self.recurrent_states[layer_idx].index_select(
                     0, beam_idx.to(device)
                 )
@@ -138,7 +155,9 @@ class OlmoHybridDynamicCache:
     def get_seq_length(self, layer_idx: int | None = 0) -> int:
         """Returns the sequence length of the cached states. A layer index can be optionally passed."""
         # take any layer that contains cache and not empty tensor
-        layer_idx = self.transformer_layers[0] if layer_idx not in self.transformer_layers else layer_idx
+        layer_idx = (
+            self.transformer_layers[0] if layer_idx not in self.transformer_layers else layer_idx
+        )
         if len(self.key_cache) <= layer_idx or self.key_cache[layer_idx] is None:
             return 0
         return self.key_cache[layer_idx].shape[-2]
@@ -247,9 +266,13 @@ class OlmoHybridShortConvolution(nn.Conv1d):
                 # sees the correct left-context rather than zero-padding. Dropped from the output
                 # at the end of this branch.
                 hidden_states = torch.cat([cache, hidden_states], dim=-1)
-            out = F.conv1d(hidden_states, self.weight, self.bias, padding=self.conv_kernel_size - 1, groups=dim)
+            out = F.conv1d(
+                hidden_states, self.weight, self.bias, padding=self.conv_kernel_size - 1, groups=dim
+            )
             out = out[:, :, : hidden_states.shape[-1]]
-            conv_state = F.pad(hidden_states, (self.conv_kernel_size - 1 - hidden_states.shape[-1], 0))
+            conv_state = F.pad(
+                hidden_states, (self.conv_kernel_size - 1 - hidden_states.shape[-1], 0)
+            )
             if use_precomputed:
                 out = out[:, :, -seq_len:]
 
@@ -266,7 +289,9 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     batch, num_key_value_heads, slen, head_dim = hidden_states.shape
     if n_rep == 1:
         return hidden_states
-    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
@@ -342,26 +367,40 @@ class OlmoHybridAttention(nn.Module):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
-        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = True
 
         self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.k_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.v_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.o_proj = nn.Linear(
-            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
         )
-        self.q_norm = OlmoHybridRMSNorm(config.num_attention_heads * self.head_dim, config.rms_norm_eps)
-        self.k_norm = OlmoHybridRMSNorm(config.num_key_value_heads * self.head_dim, config.rms_norm_eps)
+        self.q_norm = OlmoHybridRMSNorm(
+            config.num_attention_heads * self.head_dim, config.rms_norm_eps
+        )
+        self.k_norm = OlmoHybridRMSNorm(
+            config.num_key_value_heads * self.head_dim, config.rms_norm_eps
+        )
 
     def forward(
         self,
@@ -389,7 +428,9 @@ class OlmoHybridAttention(nn.Module):
             query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
         if past_key_values is not None:
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+            key_states, value_states = past_key_values.update(
+                key_states, value_states, self.layer_idx
+            )
 
         attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
             self.config._attn_implementation, eager_attention_forward
@@ -460,17 +501,25 @@ class OlmoHybridRotaryEmbedding(nn.Module):
 
         # Compute the inverse frequencies
         inv_freq = 1.0 / (
-            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+            base
+            ** (
+                torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float)
+                / dim
+            )
         )
         return inv_freq, attention_factor
 
     @torch.no_grad()
     @dynamic_rope_update
     def forward(self, x, position_ids):
-        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, None, :].float()
 
-        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        device_type = (
+            x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        )
         with maybe_autocast(device_type=device_type, enabled=False):
             freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
             emb = torch.cat((freqs, freqs), dim=-1)
@@ -534,10 +583,13 @@ def torch_chunk_gated_delta_rule(
     k_beta = key * beta.unsqueeze(-1)
     # reshape to chunks
     query, key, value, k_beta, v_beta = [
-        x.reshape(x.shape[0], x.shape[1], -1, chunk_size, x.shape[-1]) for x in (query, key, value, k_beta, v_beta)
+        x.reshape(x.shape[0], x.shape[1], -1, chunk_size, x.shape[-1])
+        for x in (query, key, value, k_beta, v_beta)
     ]
     g = g.reshape(g.shape[0], g.shape[1], -1, chunk_size)
-    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=0)
+    mask = torch.triu(
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=0
+    )
 
     # chunk decay
     g = g.cumsum(dim=-1)
@@ -551,12 +603,16 @@ def torch_chunk_gated_delta_rule(
     value = attn @ v_beta
     k_cumdecay = attn @ (k_beta * g.exp().unsqueeze(-1))
     last_recurrent_state = (
-        torch.zeros(batch_size, num_heads, k_head_dim, v_head_dim, dtype=value.dtype, device=value.device)
+        torch.zeros(
+            batch_size, num_heads, k_head_dim, v_head_dim, dtype=value.dtype, device=value.device
+        )
         if initial_state is None
         else initial_state.to(value)
     )
     core_attn_out = torch.zeros_like(value)
-    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1)
+    mask = torch.triu(
+        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1
+    )
 
     # for each chunk
     for i in range(0, total_sequence_length // chunk_size):
@@ -573,7 +629,9 @@ def torch_chunk_gated_delta_rule(
 
     if not output_final_state:
         last_recurrent_state = None
-    core_attn_out = core_attn_out.reshape(core_attn_out.shape[0], core_attn_out.shape[1], -1, core_attn_out.shape[-1])
+    core_attn_out = core_attn_out.reshape(
+        core_attn_out.shape[0], core_attn_out.shape[1], -1, core_attn_out.shape[-1]
+    )
     core_attn_out = core_attn_out[:, :, :sequence_length]
     core_attn_out = core_attn_out.transpose(1, 2).contiguous().to(initial_dtype)
     return core_attn_out, last_recurrent_state
@@ -599,7 +657,9 @@ def torch_recurrent_gated_delta_rule(
         batch_size, num_heads, sequence_length, v_head_dim, dtype=value.dtype, device=value.device
     )
     last_recurrent_state = (
-        torch.zeros(batch_size, num_heads, k_head_dim, v_head_dim, dtype=value.dtype, device=value.device)
+        torch.zeros(
+            batch_size, num_heads, k_head_dim, v_head_dim, dtype=value.dtype, device=value.device
+        )
         if initial_state is None
         else initial_state.to(value)
     )
@@ -663,7 +723,9 @@ class OlmoHybridGatedDeltaNet(nn.Module):
 
         self.o_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
 
-        Conv1dClass = ShortConvolution if ShortConvolution is not None else OlmoHybridShortConvolution
+        Conv1dClass = (
+            ShortConvolution if ShortConvolution is not None else OlmoHybridShortConvolution
+        )
 
         self.q_conv1d = Conv1dClass(
             hidden_size=self.key_dim,
@@ -690,7 +752,8 @@ class OlmoHybridGatedDeltaNet(nn.Module):
         self.A_log = nn.Parameter(torch.log(A))
 
         dt = torch.exp(
-            torch.rand(self.num_v_heads) * (math.log(config.linear_dt_max) - math.log(config.linear_dt_min))
+            torch.rand(self.num_v_heads)
+            * (math.log(config.linear_dt_max) - math.log(config.linear_dt_min))
             + math.log(config.linear_dt_min)
         )
         dt = torch.clamp(dt, min=config.linear_dt_init_floor)
@@ -710,7 +773,9 @@ class OlmoHybridGatedDeltaNet(nn.Module):
         )
 
         self.chunk_gated_delta_rule = chunk_gated_delta_rule or torch_chunk_gated_delta_rule
-        self.recurrent_gated_delta_rule = fused_recurrent_gated_delta_rule or torch_recurrent_gated_delta_rule
+        self.recurrent_gated_delta_rule = (
+            fused_recurrent_gated_delta_rule or torch_recurrent_gated_delta_rule
+        )
 
         if not is_fast_path_available:
             logger.warning_once(
@@ -774,7 +839,9 @@ class OlmoHybridGatedDeltaNet(nn.Module):
         if self.allow_neg_eigval:
             beta = beta * 2.0
 
-        g = -self.A_log.float().exp() * F.softplus(self.a_proj(hidden_states).float() + self.dt_bias)
+        g = -self.A_log.float().exp() * F.softplus(
+            self.a_proj(hidden_states).float() + self.dt_bias
+        )
 
         if use_precomputed and seq_len == 1:
             output, new_recurrent_state = self.recurrent_gated_delta_rule(
@@ -836,8 +903,12 @@ class OlmoHybridAttentionDecoderLayer(GradientCheckpointingLayer):
         self.self_attn = OlmoHybridAttention(config=config, layer_idx=layer_idx)
 
         self.mlp = OlmoHybridMLP(config)
-        self.post_attention_layernorm = OlmoHybridRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.post_feedforward_layernorm = OlmoHybridRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = OlmoHybridRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.post_feedforward_layernorm = OlmoHybridRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
         self.layer_type = "full_attention"
 
     def forward(
@@ -877,7 +948,9 @@ class OlmoHybridLinearAttentionDecoderLayer(GradientCheckpointingLayer):
         self.hidden_size = config.hidden_size
         self.mlp = OlmoHybridMLP(config)
         self.input_layernorm = OlmoHybridRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.post_attention_layernorm = OlmoHybridRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = OlmoHybridRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
         self.layer_type = "linear_attention"
         self.linear_attn = OlmoHybridGatedDeltaNet(config, layer_idx=layer_idx)
 
@@ -932,10 +1005,13 @@ class OlmoHybridPreTrainedModel(PreTrainedModel):
             cfg = self.config
             init.copy_(
                 module.A_log,
-                torch.empty_like(module.A_log).uniform_(cfg.linear_a_log_min, cfg.linear_a_log_max).log_(),
+                torch.empty_like(module.A_log)
+                .uniform_(cfg.linear_a_log_min, cfg.linear_a_log_max)
+                .log_(),
             )
             dt = torch.exp(
-                torch.rand_like(module.dt_bias) * (math.log(cfg.linear_dt_max) - math.log(cfg.linear_dt_min))
+                torch.rand_like(module.dt_bias)
+                * (math.log(cfg.linear_dt_max) - math.log(cfg.linear_dt_min))
                 + math.log(cfg.linear_dt_min)
             )
             dt = torch.clamp(dt, min=cfg.linear_dt_init_floor)
@@ -988,8 +1064,12 @@ class OlmoHybridModel(OlmoHybridPreTrainedModel):
             past_key_values = OlmoHybridDynamicCache(config=self.config)
 
         if position_ids is None:
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
-            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            )
             position_ids = position_ids.unsqueeze(0)
 
         causal_mask = create_causal_mask(
@@ -1003,11 +1083,19 @@ class OlmoHybridModel(OlmoHybridPreTrainedModel):
 
         hidden_states = inputs_embeds
         # RoPE or NoPE
-        position_embeddings = self.rotary_emb(hidden_states, position_ids) if self.rotary_emb is not None else None
+        position_embeddings = (
+            self.rotary_emb(hidden_states, position_ids) if self.rotary_emb is not None else None
+        )
 
         for i, decoder_layer in enumerate(self.layers):
-            layer_mask = linear_attn_mask if self.config.layer_types[i] == "linear_attention" else causal_mask
-            layer_position_embeddings = position_embeddings if self.config.layer_types[i] == "full_attention" else None
+            layer_mask = (
+                linear_attn_mask
+                if self.config.layer_types[i] == "linear_attention"
+                else causal_mask
+            )
+            layer_position_embeddings = (
+                position_embeddings if self.config.layer_types[i] == "full_attention" else None
+            )
 
             hidden_states = decoder_layer(
                 hidden_states,
@@ -1099,12 +1187,16 @@ class OlmoHybridForCausalLM(OlmoHybridPreTrainedModel, GenerationMixin):
 
         hidden_states = outputs.last_hidden_state
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        slice_indices = (
+            slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        )
         logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
 
         return CausalLMOutputWithPast(
             loss=loss,

--- a/examples/qwen3-32b-code-edit/accuracy_checker/checker.py
+++ b/examples/qwen3-32b-code-edit/accuracy_checker/checker.py
@@ -37,7 +37,6 @@ from typing import Any
 
 import httpx
 
-
 # ---------------------------------------------------------------------------
 # Dataset loading (mirrors bench/benchmark.py)
 # ---------------------------------------------------------------------------
@@ -52,9 +51,7 @@ def _load_codeeditorbench(
     try:
         from datasets import load_dataset
     except ImportError as exc:
-        raise SystemExit(
-            "The `datasets` library is required — pip install datasets."
-        ) from exc
+        raise SystemExit("The `datasets` library is required — pip install datasets.") from exc
 
     # Pin to the code_debug shards — the only ones with both
     # `incorrect_solutions` and `solutions` columns. The other task
@@ -85,13 +82,15 @@ def _load_codeeditorbench(
         if key in seen:
             continue
         seen.add(key)
-        buffer.append({
-            "unique_id": str(row.get("idx") or i),
-            "language": lang,
-            "incorrect_code": inc,
-            "gold_code": sol,
-            "bug_type": row.get("type") or "",
-        })
+        buffer.append(
+            {
+                "unique_id": str(row.get("idx") or i),
+                "language": lang,
+                "incorrect_code": inc,
+                "gold_code": sol,
+                "bug_type": row.get("type") or "",
+            }
+        )
         if len(buffer) >= max(num_samples * 5, 500):
             break
 
@@ -133,15 +132,15 @@ def _build_prompt(tokenizer, sample: dict) -> str:
         {
             "role": "user",
             "content": _build_user_message(
-                sample["language"], sample["incorrect_code"], sample["bug_type"],
+                sample["language"],
+                sample["incorrect_code"],
+                sample["bug_type"],
             ),
         },
     ]
     kwargs = dict(tokenize=False, add_generation_prompt=True)
     try:
-        return tokenizer.apply_chat_template(
-            messages, enable_thinking=False, **kwargs
-        )
+        return tokenizer.apply_chat_template(messages, enable_thinking=False, **kwargs)
     except TypeError:
         return tokenizer.apply_chat_template(messages, **kwargs)
 
@@ -156,7 +155,7 @@ def _strip_code_fence(text: str) -> str:
     if s.startswith("```"):
         nl = s.find("\n")
         if nl != -1:
-            s = s[nl + 1:]
+            s = s[nl + 1 :]
     if s.endswith("```"):
         s = s[: s.rfind("```")].rstrip()
     return s
@@ -210,13 +209,16 @@ async def _send(
     error: str | None = None
     try:
         async with client.stream(
-            "POST", url, json=body, timeout=request_timeout,
+            "POST",
+            url,
+            json=body,
+            timeout=request_timeout,
         ) as resp:
             resp.raise_for_status()
             async for raw in resp.aiter_lines():
                 if not raw.startswith("data: "):
                     continue
-                payload = raw[len("data: "):]
+                payload = raw[len("data: ") :]
                 if payload.strip() == "[DONE]":
                     break
                 try:
@@ -245,7 +247,10 @@ async def run(args: argparse.Namespace) -> int:
     url = args.url.rstrip("/") + args.endpoint
     languages = [s.strip() for s in args.languages.split(",") if s.strip()]
     samples = _load_codeeditorbench(
-        languages, args.max_input_chars, args.num_samples, args.seed,
+        languages,
+        args.max_input_chars,
+        args.num_samples,
+        args.seed,
     )
     if not samples:
         print("ERROR: no samples loaded from CodeEditorBench.", file=sys.stderr)
@@ -266,7 +271,9 @@ async def run(args: argparse.Namespace) -> int:
         for idx, sample in enumerate(samples):
             prompt = _build_prompt(tokenizer, sample)
             r = await _send(
-                client, url, prompt,
+                client,
+                url,
+                prompt,
                 prediction_content=sample["incorrect_code"],
                 max_tokens=args.max_tokens,
                 temperature=args.temperature,
@@ -277,7 +284,9 @@ async def run(args: argparse.Namespace) -> int:
             r["is_warmup"] = idx < warmup_n
             if r["error"] is None:
                 eval_ = _evaluate(
-                    r["output_text"], sample["gold_code"], args.min_gold_similarity,
+                    r["output_text"],
+                    sample["gold_code"],
+                    args.min_gold_similarity,
                 )
             else:
                 eval_ = {
@@ -311,8 +320,10 @@ async def run(args: argparse.Namespace) -> int:
     print("=" * 60)
     print(f"Samples (steady):    {len(steady)} (warmup discarded: {warmup_n})")
     print(f"Request errors:      {len(errored)}/{len(steady)}")
-    print(f"Gold-similar:        {len(gold_ok)}/{len(steady)} ({gold_rate:.1%})   "
-          f"[min {args.min_gold_rate:.1%} at threshold {args.min_gold_similarity:.2f}]")
+    print(
+        f"Gold-similar:        {len(gold_ok)}/{len(steady)} ({gold_rate:.1%})   "
+        f"[min {args.min_gold_rate:.1%} at threshold {args.min_gold_similarity:.2f}]"
+    )
 
     passed = not errored and gold_rate >= args.min_gold_rate
 
@@ -347,6 +358,7 @@ async def run(args: argparse.Namespace) -> int:
             "results": results,
         }
         from pathlib import Path
+
         Path(args.output_json).write_text(json.dumps(summary, indent=2))
         print(f"\nWrote detailed results to {args.output_json}")
 

--- a/examples/qwen3-32b-code-edit/benchmark/benchmark.py
+++ b/examples/qwen3-32b-code-edit/benchmark/benchmark.py
@@ -49,7 +49,6 @@ from typing import Any
 
 import httpx
 
-
 # ---------------------------------------------------------------------------
 # Dataset loading
 # ---------------------------------------------------------------------------
@@ -74,9 +73,7 @@ def _load_codeeditorbench(
     try:
         from datasets import load_dataset
     except ImportError as exc:
-        raise SystemExit(
-            "The ``datasets`` library is required — pip install datasets."
-        ) from exc
+        raise SystemExit("The ``datasets`` library is required — pip install datasets.") from exc
 
     # The dataset on the hub has four task files at the repo root; their
     # schemas don't unify, so the default loader fails. Pin to the
@@ -111,14 +108,16 @@ def _load_codeeditorbench(
         if key in seen_keys:
             continue
         seen_keys.add(key)
-        buffer.append({
-            "unique_id": str(row.get("idx") or i),
-            "language": lang,
-            "incorrect_code": inc,
-            "gold_code": sol,
-            "bug_type": row.get("type") or "",
-            "difficulty": str(row.get("difficulty") or ""),
-        })
+        buffer.append(
+            {
+                "unique_id": str(row.get("idx") or i),
+                "language": lang,
+                "incorrect_code": inc,
+                "gold_code": sol,
+                "bug_type": row.get("type") or "",
+                "difficulty": str(row.get("difficulty") or ""),
+            }
+        )
         if len(buffer) >= max(num_samples * 5, 500):
             break
 
@@ -181,9 +180,7 @@ def _build_prompt(tokenizer, sample: dict) -> str:
     ]
     kwargs = dict(tokenize=False, add_generation_prompt=True)
     try:
-        return tokenizer.apply_chat_template(
-            messages, enable_thinking=False, **kwargs
-        )
+        return tokenizer.apply_chat_template(messages, enable_thinking=False, **kwargs)
     except TypeError:
         return tokenizer.apply_chat_template(messages, **kwargs)
 
@@ -241,7 +238,9 @@ async def send_request(
     if print_stream:
         header = f"sample={sample_id}" if sample_id else ""
         sys.stderr.write(f"\n===== >>> PROMPT {header} =====\n{prompt}\n")
-        sys.stderr.write(f"===== >>> PREDICTION ({len(prediction_content)} chars) =====\n{prediction_content}\n")
+        sys.stderr.write(
+            f"===== >>> PREDICTION ({len(prediction_content)} chars) =====\n{prediction_content}\n"
+        )
         sys.stderr.write("===== <<< STREAM =====\n")
         sys.stderr.flush()
 
@@ -251,7 +250,7 @@ async def send_request(
             async for raw_line in resp.aiter_lines():
                 if not raw_line.startswith("data: "):
                     continue
-                payload = raw_line[len("data: "):]
+                payload = raw_line[len("data: ") :]
                 if payload.strip() == "[DONE]":
                     t_done = time.perf_counter()
                     break
@@ -288,8 +287,7 @@ async def send_request(
 
     output_text = "".join(text_parts)
     output_tokens = (
-        len(tokenizer.encode(output_text, add_special_tokens=False))
-        if output_text else 0
+        len(tokenizer.encode(output_text, add_special_tokens=False)) if output_text else 0
     )
     result: dict = {
         "error": error,
@@ -328,7 +326,7 @@ def _strip_code_fence(text: str) -> str:
         # drop first line
         nl = s.find("\n")
         if nl != -1:
-            s = s[nl + 1:]
+            s = s[nl + 1 :]
     if s.endswith("```"):
         s = s[: s.rfind("```")].rstrip()
     return s
@@ -384,9 +382,7 @@ def _quality_score(
     """
     out = _strip_code_fence(output_text)
     return {
-        "ratio_to_gold": difflib.SequenceMatcher(
-            None, out, gold_text, autojunk=False
-        ).ratio(),
+        "ratio_to_gold": difflib.SequenceMatcher(None, out, gold_text, autojunk=False).ratio(),
         "ratio_to_input": difflib.SequenceMatcher(
             None, out, incorrect_text, autojunk=False
         ).ratio(),
@@ -448,7 +444,10 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
         file=sys.stderr,
     )
     samples = _load_codeeditorbench(
-        languages, args.max_input_chars, args.num_samples, args.seed,
+        languages,
+        args.max_input_chars,
+        args.num_samples,
+        args.seed,
     )
     if not samples:
         raise SystemExit("No samples could be loaded from CodeEditorBench.")
@@ -467,7 +466,9 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
         for idx, sample in enumerate(samples):
             prompt = _build_prompt(tokenizer, sample)
             result = await send_request(
-                client, url, prompt,
+                client,
+                url,
+                prompt,
                 prediction_content=sample["incorrect_code"],
                 max_tokens=args.max_tokens,
                 temperature=args.temperature,
@@ -484,7 +485,9 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
                 # Token-level alignment vs the prediction (the buggy code)
                 # — this is the input the headroom estimator needs.
                 align = _token_align(
-                    tokenizer, sample["incorrect_code"], result["output_text"],
+                    tokenizer,
+                    sample["incorrect_code"],
+                    result["output_text"],
                 )
                 quality = _quality_score(
                     result["output_text"],
@@ -511,7 +514,8 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
                     f"matched={align['num_matched_tokens']}/{align['num_output_tokens']} "
                     f"longest_run={align['longest_matched_run']} "
                     f"r2gold={qual['ratio_to_gold']:.3f} "
-                    if align is not None else ""
+                    if align is not None
+                    else ""
                 )
                 + (f"err={result['error'][:80]}" if result["error"] else ""),
                 file=sys.stderr,
@@ -541,8 +545,8 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
         all_matched_runs.extend(a["matched_run_lengths"])
         matched_tokens_total += a["num_matched_tokens"]
         diverged_tokens_total += a["num_diverged_tokens"]
-    aggregated_match_rate = (
-        matched_tokens_total / max(1, matched_tokens_total + diverged_tokens_total)
+    aggregated_match_rate = matched_tokens_total / max(
+        1, matched_tokens_total + diverged_tokens_total
     )
     sorted_runs = sorted(all_matched_runs)
     matched_run_pct = {
@@ -554,13 +558,13 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
     }
 
     qual_improved = [
-        r for r in successes
+        r
+        for r in successes
         if r["quality"] is not None
         and r["quality"]["ratio_to_gold"] > r["quality"]["ratio_to_input"]
     ]
     qual_echo = [
-        r for r in successes
-        if r["quality"] is not None and r["quality"]["equals_input_verbatim"]
+        r for r in successes if r["quality"] is not None and r["quality"]["equals_input_verbatim"]
     ]
 
     print()
@@ -569,8 +573,7 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
     print("=" * 60)
     print(f"Backend URL:       {url}")
     print(f"Samples (sent):    {len(results)} (warmup discarded: {args.warmup})")
-    print(f"Completed:         {len(successes)}/{len(steady)} requests "
-          f"({len(errors)} errors)")
+    print(f"Completed:         {len(successes)}/{len(steady)} requests ({len(errors)} errors)")
     print(f"Improved-over-input: {len(qual_improved)}/{len(successes)}")
     print(f"Echoed-input verbatim: {len(qual_echo)}/{len(successes)}  (anti-bypass red flag)")
     print(f"Wall clock:        {wall_clock:.1f}s")
@@ -591,9 +594,11 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
     print()
     print("Token-level diff vs prediction (drives headroom estimator):")
     print(f"  Aggregated match rate:  {aggregated_match_rate:.1%}")
-    print(f"  Matched-run lengths (tokens): "
-          f"p50={matched_run_pct['p50']} p75={matched_run_pct['p75']} "
-          f"p90={matched_run_pct['p90']} p95={matched_run_pct['p95']}")
+    print(
+        f"  Matched-run lengths (tokens): "
+        f"p50={matched_run_pct['p50']} p75={matched_run_pct['p75']} "
+        f"p90={matched_run_pct['p90']} p95={matched_run_pct['p95']}"
+    )
 
     p50_latency_ms = _percentile(sorted(latencies), 50) * 1000 if latencies else float("nan")
     median_tok_per_sec = (
@@ -689,8 +694,8 @@ def main() -> None:
         "--model",
         default="",
         help="Model name to send in the request body (required by vLLM's "
-             "OpenAI-compat endpoint). Leave empty for custom single-model "
-             "servers that ignore the field.",
+        "OpenAI-compat endpoint). Leave empty for custom single-model "
+        "servers that ignore the field.",
     )
     parser.add_argument(
         "--tokenizer-path",
@@ -701,8 +706,8 @@ def main() -> None:
         "--languages",
         default="python3",
         help="Comma-separated list of CodeEditorBench language tags to keep "
-             "(python3, cpp, java). Default: python3 only — token alignment "
-             "is the cleanest there.",
+        "(python3, cpp, java). Default: python3 only — token alignment "
+        "is the cleanest there.",
     )
     parser.add_argument(
         "--max-input-chars",
@@ -710,30 +715,42 @@ def main() -> None:
         default=4000,
         help="Skip rows whose buggy program is longer than this (default: 4000).",
     )
-    parser.add_argument("--num-samples", type=int, default=50,
-                        help="Total samples to send (default: 50).")
-    parser.add_argument("--warmup", type=int, default=3,
-                        help="Number of leading samples to discard from stats (default: 3).")
-    parser.add_argument("--max-tokens", type=int, default=512,
-                        help="Max tokens per response (default: 512).")
-    parser.add_argument("--temperature", type=float, default=0,
-                        help="Sampling temperature (default: 0 — greedy).")
+    parser.add_argument(
+        "--num-samples", type=int, default=50, help="Total samples to send (default: 50)."
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=3,
+        help="Number of leading samples to discard from stats (default: 3).",
+    )
+    parser.add_argument(
+        "--max-tokens", type=int, default=512, help="Max tokens per response (default: 512)."
+    )
+    parser.add_argument(
+        "--temperature", type=float, default=0, help="Sampling temperature (default: 0 — greedy)."
+    )
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--print-stream", action="store_true",
-                        help="Print prompt/prediction and stream output deltas live to stderr.")
-    parser.add_argument("--output-json", type=str, default=None,
-                        help="Optional path to write structured results.")
+    parser.add_argument(
+        "--print-stream",
+        action="store_true",
+        help="Print prompt/prediction and stream output deltas live to stderr.",
+    )
+    parser.add_argument(
+        "--output-json", type=str, default=None, help="Optional path to write structured results."
+    )
     # Back-compat no-ops so the orchestrator's sanity invocation accepts these.
-    parser.add_argument("--rate", type=float, default=None,
-                        help="Ignored — single-batch only.")
-    parser.add_argument("--num-requests", type=int, default=None,
-                        help="Alias for --num-samples.")
-    parser.add_argument("--duration", type=float, default=None,
-                        help="Ignored — runs to --num-samples.")
-    parser.add_argument("--prompt-len", type=int, default=None,
-                        help="Ignored — prompts come from the dataset.")
-    parser.add_argument("--audio-dir", type=str, default=None,
-                        help="Ignored — text-only benchmark.")
+    parser.add_argument("--rate", type=float, default=None, help="Ignored — single-batch only.")
+    parser.add_argument("--num-requests", type=int, default=None, help="Alias for --num-samples.")
+    parser.add_argument(
+        "--duration", type=float, default=None, help="Ignored — runs to --num-samples."
+    )
+    parser.add_argument(
+        "--prompt-len", type=int, default=None, help="Ignored — prompts come from the dataset."
+    )
+    parser.add_argument(
+        "--audio-dir", type=str, default=None, help="Ignored — text-only benchmark."
+    )
 
     args = parser.parse_args()
     if args.num_requests is not None:

--- a/examples/qwen3-32b-code-edit/reference/reference.py
+++ b/examples/qwen3-32b-code-edit/reference/reference.py
@@ -27,7 +27,11 @@ from torch import nn
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
-from ...integrations import use_kernel_forward_from_hub, use_kernel_func_from_hub, use_kernelized_func
+from ...integrations import (
+    use_kernel_forward_from_hub,
+    use_kernel_func_from_hub,
+    use_kernelized_func,
+)
 from ...masking_utils import create_causal_mask, create_sliding_window_causal_mask
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_layers import (
@@ -128,17 +132,25 @@ class Qwen3RotaryEmbedding(nn.Module):
 
         # Compute the inverse frequencies
         inv_freq = 1.0 / (
-            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+            base
+            ** (
+                torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float)
+                / dim
+            )
         )
         return inv_freq, attention_factor
 
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, None, :].float()
 
-        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        device_type = (
+            x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        )
         with maybe_autocast(device_type=device_type, enabled=False):  # Force float32
             freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
             emb = torch.cat((freqs, freqs), dim=-1)
@@ -189,7 +201,9 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     batch, num_key_value_heads, slen, head_dim = hidden_states.shape
     if n_rep == 1:
         return hidden_states
-    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
@@ -227,27 +241,43 @@ class Qwen3Attention(nn.Module):
         self.layer_type = config.layer_types[layer_idx] if hasattr(config, "layer_types") else None
         self.config = config
         self.layer_idx = layer_idx
-        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = True
 
         self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.k_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.v_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.o_proj = nn.Linear(
-            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
         )
-        self.q_norm = Qwen3RMSNorm(self.head_dim, eps=config.rms_norm_eps)  # unlike olmo, only on the head dim!
-        self.k_norm = Qwen3RMSNorm(self.head_dim, eps=config.rms_norm_eps)  # thus post q_norm does not need reshape
-        self.sliding_window = config.sliding_window if self.layer_type == "sliding_attention" else None
+        self.q_norm = Qwen3RMSNorm(
+            self.head_dim, eps=config.rms_norm_eps
+        )  # unlike olmo, only on the head dim!
+        self.k_norm = Qwen3RMSNorm(
+            self.head_dim, eps=config.rms_norm_eps
+        )  # thus post q_norm does not need reshape
+        self.sliding_window = (
+            config.sliding_window if self.layer_type == "sliding_attention" else None
+        )
 
     def forward(
         self,
@@ -268,7 +298,9 @@ class Qwen3Attention(nn.Module):
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
         if past_key_values is not None:
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+            key_states, value_states = past_key_values.update(
+                key_states, value_states, self.layer_idx
+            )
 
         attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
             self.config._attn_implementation, eager_attention_forward
@@ -395,8 +427,12 @@ class Qwen3Model(Qwen3PreTrainedModel):
             past_key_values = DynamicCache(config=self.config)
 
         if position_ids is None:
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
-            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            )
             position_ids = position_ids.unsqueeze(0)
 
         # It may already have been prepared by e.g. `generate`
@@ -415,7 +451,9 @@ class Qwen3Model(Qwen3PreTrainedModel):
             }
             # The sliding window alternating layers are not always activated depending on the config
             if self.has_sliding_layers:
-                causal_mask_mapping["sliding_attention"] = create_sliding_window_causal_mask(**mask_kwargs)
+                causal_mask_mapping["sliding_attention"] = create_sliding_window_causal_mask(
+                    **mask_kwargs
+                )
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
@@ -501,12 +539,16 @@ class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
 
         hidden_states = outputs.last_hidden_state
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        slice_indices = (
+            slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        )
         logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
 
         return CausalLMOutputWithPast(
             loss=loss,

--- a/examples/show-o2-1.5B-HQ-h100/benchmark/benchmark.py
+++ b/examples/show-o2-1.5B-HQ-h100/benchmark/benchmark.py
@@ -24,7 +24,6 @@ from statistics import mean
 
 import httpx
 
-
 PROMPT_POOL = [
     "a small red robot holding a handwritten sign that says VibeServe",
     "a studio product photo of a ceramic mug shaped like a rocket",
@@ -34,7 +33,9 @@ PROMPT_POOL = [
 ]
 
 
-def select_prompt(args: argparse.Namespace, rng: random.Random, idx: int, *, warmup: bool = False) -> str:
+def select_prompt(
+    args: argparse.Namespace, rng: random.Random, idx: int, *, warmup: bool = False
+) -> str:
     if args.prompt is not None:
         return args.prompt
     if warmup:
@@ -207,7 +208,9 @@ def summarize_results(results: list[dict], wall_clock: float) -> dict:
     }
 
 
-async def run_warmup(client: httpx.AsyncClient, args: argparse.Namespace, url: str) -> tuple[list[dict], float]:
+async def run_warmup(
+    client: httpx.AsyncClient, args: argparse.Namespace, url: str
+) -> tuple[list[dict], float]:
     if args.warmup_requests <= 0:
         return [], 0.0
 
@@ -428,7 +431,9 @@ def main() -> None:
     parser.add_argument("--url", default="http://localhost:8000", help="Server base URL")
     parser.add_argument("--endpoint", default="/v1/images/generations", help="Endpoint path")
     parser.add_argument("--rate", type=float, default=1.0, help="Request rate in req/s")
-    parser.add_argument("--duration", type=float, default=60.0, help="Duration when num requests is unset")
+    parser.add_argument(
+        "--duration", type=float, default=60.0, help="Duration when num requests is unset"
+    )
     parser.add_argument("--num-requests", type=int, default=None, help="Total requests")
     parser.add_argument(
         "--closed-loop",
@@ -458,18 +463,30 @@ def main() -> None:
         default=0,
         help="Requests to run before measurement and exclude from latency/throughput stats",
     )
-    parser.add_argument("--steps", type=int, default=20, help="Diffusion inference steps per request")
-    parser.add_argument("--guidance-scale", type=float, default=5.0, help="Classifier-free guidance scale")
-    parser.add_argument("--prompt", type=str, default=None, help="Fixed prompt for every benchmark request")
+    parser.add_argument(
+        "--steps", type=int, default=20, help="Diffusion inference steps per request"
+    )
+    parser.add_argument(
+        "--guidance-scale", type=float, default=5.0, help="Classifier-free guidance scale"
+    )
+    parser.add_argument(
+        "--prompt", type=str, default=None, help="Fixed prompt for every benchmark request"
+    )
     parser.add_argument("--seed", type=int, default=42, help="Benchmark scheduling seed")
-    parser.add_argument("--request-seed", type=int, default=None, help="Base model seed for deterministic requests")
+    parser.add_argument(
+        "--request-seed", type=int, default=None, help="Base model seed for deterministic requests"
+    )
     parser.add_argument(
         "--fixed-request-seed",
         action="store_true",
         help="Use request seed unchanged for every request instead of incrementing it by request index",
     )
-    parser.add_argument("--timeout", type=float, default=600.0, help="Per-request timeout in seconds")
-    parser.add_argument("--output-json", type=str, default=None, help="Write structured result JSON")
+    parser.add_argument(
+        "--timeout", type=float, default=600.0, help="Per-request timeout in seconds"
+    )
+    parser.add_argument(
+        "--output-json", type=str, default=None, help="Write structured result JSON"
+    )
     parser.add_argument(
         "--save-images-dir",
         type=str,

--- a/examples/show-o2-1.5B-HQ-h100/benchmark/compare_images.py
+++ b/examples/show-o2-1.5B-HQ-h100/benchmark/compare_images.py
@@ -135,8 +135,12 @@ def clip_metrics(
             text_inputs = processor(text=[prompt], return_tensors="pt", padding=True)
             text_features = model.get_text_features(**text_inputs)
             text_features = text_features / text_features.norm(dim=-1, keepdim=True)
-            result["baseline_prompt_cosine"] = float((image_features[0] * text_features[0]).sum().item())
-            result["candidate_prompt_cosine"] = float((image_features[1] * text_features[0]).sum().item())
+            result["baseline_prompt_cosine"] = float(
+                (image_features[0] * text_features[0]).sum().item()
+            )
+            result["candidate_prompt_cosine"] = float(
+                (image_features[1] * text_features[0]).sum().item()
+            )
     return result
 
 
@@ -168,7 +172,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Compare two generated PNG images.")
     parser.add_argument("--baseline", required=True, help="Baseline PNG path")
     parser.add_argument("--candidate", required=True, help="Candidate PNG path")
-    parser.add_argument("--prompt", default=None, help="Optional prompt for CLIP prompt-image scoring")
+    parser.add_argument(
+        "--prompt", default=None, help="Optional prompt for CLIP prompt-image scoring"
+    )
     parser.add_argument(
         "--clip-model",
         default=None,

--- a/examples/show-o2-1.5B-HQ-h100/reference/reference.py
+++ b/examples/show-o2-1.5B-HQ-h100/reference/reference.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-
 REFERENCE_DIR = Path(__file__).resolve().parent
 DEFAULT_SOURCE_DIR = REFERENCE_DIR / "Show-o" / "show-o2"
 DEFAULT_MODEL_DIR = REFERENCE_DIR / "model"
@@ -276,7 +275,9 @@ class ShowO2Model:
         repr=False,
     )
     _attention_mask_cache: dict[tuple[Any, ...], Any] = field(default_factory=dict, repr=False)
-    _attention_mask_identity_cache: dict[tuple[Any, ...], Any] = field(default_factory=dict, repr=False)
+    _attention_mask_identity_cache: dict[tuple[Any, ...], Any] = field(
+        default_factory=dict, repr=False
+    )
     _prepared_prompt_cache: dict[tuple[Any, ...], tuple[Any, Any]] = field(
         default_factory=dict,
         repr=False,
@@ -334,7 +335,9 @@ class ShowO2Model:
         if vae_conv2d_tail_start < 0:
             raise ValueError(f"Unsupported VAE conv2d tail start: {vae_conv2d_tail_start}")
         if vae_conv2d_tail_max_modules is not None and vae_conv2d_tail_max_modules < 0:
-            raise ValueError(f"Unsupported VAE conv2d tail max modules: {vae_conv2d_tail_max_modules}")
+            raise ValueError(
+                f"Unsupported VAE conv2d tail max modules: {vae_conv2d_tail_max_modules}"
+            )
         if vae_upsample_mode not in {"default", "convtranspose"}:
             raise ValueError(f"Unsupported VAE upsample mode: {vae_upsample_mode}")
         if vae_decoder_backend not in {"torch", "coreml", "mlx"}:
@@ -346,12 +349,17 @@ class ShowO2Model:
         if vae_mlx_dtype not in {"float32", "float16", "bfloat16"}:
             raise ValueError(f"Unsupported MLX VAE dtype: {vae_mlx_dtype}")
         if vae_mlx_low_rank_highres_rank < 0:
-            raise ValueError(f"Unsupported MLX low-rank high-res rank: {vae_mlx_low_rank_highres_rank}")
+            raise ValueError(
+                f"Unsupported MLX low-rank high-res rank: {vae_mlx_low_rank_highres_rank}"
+            )
         if vae_mlx_low_rank_highres_min_size < 0:
             raise ValueError(
                 f"Unsupported MLX low-rank high-res min size: {vae_mlx_low_rank_highres_min_size}"
             )
-        if vae_mlx_low_rank_highres_tail_rank is not None and vae_mlx_low_rank_highres_tail_rank < 0:
+        if (
+            vae_mlx_low_rank_highres_tail_rank is not None
+            and vae_mlx_low_rank_highres_tail_rank < 0
+        ):
             raise ValueError(
                 f"Unsupported MLX low-rank high-res tail rank: {vae_mlx_low_rank_highres_tail_rank}"
             )
@@ -362,8 +370,7 @@ class ShowO2Model:
             )
         if vae_mlx_low_rank_override_layer is not None and vae_mlx_low_rank_override_layer < 0:
             raise ValueError(
-                "Unsupported MLX low-rank override layer: "
-                f"{vae_mlx_low_rank_override_layer}"
+                f"Unsupported MLX low-rank override layer: {vae_mlx_low_rank_override_layer}"
             )
         if (
             vae_mlx_low_rank_override_conv_index is not None
@@ -375,8 +382,7 @@ class ShowO2Model:
             )
         if vae_mlx_low_rank_override_rank is not None and vae_mlx_low_rank_override_rank < 0:
             raise ValueError(
-                "Unsupported MLX low-rank override rank: "
-                f"{vae_mlx_low_rank_override_rank}"
+                f"Unsupported MLX low-rank override rank: {vae_mlx_low_rank_override_rank}"
             )
         if (
             vae_mlx_approx_highres_residual_start_layer is not None
@@ -458,9 +464,7 @@ class ShowO2Model:
             source_dir=source,
             resolution=resolution,
             vae_path=(
-                ensure_wan_vae(vae_path)
-                if load_vae and vae_decoder_backend != "coreml"
-                else None
+                ensure_wan_vae(vae_path) if load_vae and vae_decoder_backend != "coreml" else None
             ),
             vae_device=resolved_vae_device,
             vae_dtype=resolved_vae_dtype,
@@ -484,7 +488,9 @@ class ShowO2Model:
                 if vae_mlx_low_rank_highres_tail_rank is None
                 else int(vae_mlx_low_rank_highres_tail_rank)
             ),
-            vae_mlx_low_rank_highres_tail_start_layer=int(vae_mlx_low_rank_highres_tail_start_layer),
+            vae_mlx_low_rank_highres_tail_start_layer=int(
+                vae_mlx_low_rank_highres_tail_start_layer
+            ),
             vae_mlx_low_rank_override_layer=(
                 None
                 if vae_mlx_low_rank_override_layer is None
@@ -534,8 +540,12 @@ class ShowO2Model:
         else:
             self.vae_path = self.vae_path or ensure_wan_vae()
             vae_path = str(self.vae_path)
-        vae_device = "cpu" if self.vae_decoder_backend == "mlx" else (self.vae_device or self.device)
-        vae_dtype = torch.float32 if self.vae_decoder_backend == "mlx" else (self.vae_dtype or self.dtype)
+        vae_device = (
+            "cpu" if self.vae_decoder_backend == "mlx" else (self.vae_device or self.device)
+        )
+        vae_dtype = (
+            torch.float32 if self.vae_decoder_backend == "mlx" else (self.vae_dtype or self.dtype)
+        )
         self.vae_model = WanVAE(
             vae_pth=vae_path,
             dtype=vae_dtype,
@@ -772,7 +782,9 @@ class ShowO2Model:
         return sample_fn
 
     @staticmethod
-    def _limited_cache_set(cache: dict, key: tuple[Any, ...], value: Any, *, limit: int = 64) -> None:
+    def _limited_cache_set(
+        cache: dict, key: tuple[Any, ...], value: Any, *, limit: int = 64
+    ) -> None:
         if len(cache) >= limit:
             cache.clear()
         cache[key] = value
@@ -796,7 +808,9 @@ class ShowO2Model:
             dtype=torch.bool,
             device=self.device,
         ).triu(diagonal=1)
-        mask.masked_fill_(upper_triangle.view(1, 1, int(max_seq_len), int(max_seq_len)), blocked_value)
+        mask.masked_fill_(
+            upper_triangle.view(1, 1, int(max_seq_len), int(max_seq_len)), blocked_value
+        )
         self._limited_cache_set(self._attention_base_mask_cache, key, mask, limit=16)
         return mask, False
 
@@ -807,7 +821,9 @@ class ShowO2Model:
         if cached is not None:
             return cached, True
 
-        position_values = tuple(int(value) for value in positions.detach().cpu().reshape(-1).tolist())
+        position_values = tuple(
+            int(value) for value in positions.detach().cpu().reshape(-1).tolist()
+        )
         key = (*base_key, position_values)
         cached = self._attention_mask_cache.get(key)
         if cached is not None:
@@ -824,8 +840,8 @@ class ShowO2Model:
                     mask[
                         batch_index,
                         :,
-                        offset:offset + length,
-                        offset:offset + length,
+                        offset : offset + length,
+                        offset : offset + length,
                     ] = 0
         self._limited_cache_set(self._attention_mask_cache, key, mask)
         self._limited_cache_set(self._attention_mask_identity_cache, identity_key, mask)
@@ -895,7 +911,11 @@ class ShowO2Model:
             torch.manual_seed(seed)
             if self.device.type == "cuda":
                 torch.cuda.manual_seed_all(seed)
-            elif self.device.type == "mps" and hasattr(torch, "mps") and hasattr(torch.mps, "manual_seed"):
+            elif (
+                self.device.type == "mps"
+                and hasattr(torch, "mps")
+                and hasattr(torch.mps, "manual_seed")
+            ):
                 torch.mps.manual_seed(seed)
 
         (
@@ -964,9 +984,13 @@ class ShowO2Model:
             timings["mask_cache_hit"] = 1.0 if mask_cache_hit else 0.0
 
             sampler_started = time.perf_counter()
-            sample_fn = None if num_inference_steps == 1 else self._get_sample_fn(
-                num_inference_steps,
-                num_t2i_image_tokens,
+            sample_fn = (
+                None
+                if num_inference_steps == 1
+                else self._get_sample_fn(
+                    num_inference_steps,
+                    num_t2i_image_tokens,
+                )
             )
             timings["sampler_setup_ms"] = (time.perf_counter() - sampler_started) * 1000.0
 

--- a/examples/show-o2-1.5B-HQ-macbook/benchmark/benchmark.py
+++ b/examples/show-o2-1.5B-HQ-macbook/benchmark/benchmark.py
@@ -24,7 +24,6 @@ from statistics import mean
 
 import httpx
 
-
 PROMPT_POOL = [
     "a small red robot holding a handwritten sign that says VibeServe",
     "a studio product photo of a ceramic mug shaped like a rocket",
@@ -34,7 +33,9 @@ PROMPT_POOL = [
 ]
 
 
-def select_prompt(args: argparse.Namespace, rng: random.Random, idx: int, *, warmup: bool = False) -> str:
+def select_prompt(
+    args: argparse.Namespace, rng: random.Random, idx: int, *, warmup: bool = False
+) -> str:
     if args.prompt is not None:
         return args.prompt
     if warmup:
@@ -207,7 +208,9 @@ def summarize_results(results: list[dict], wall_clock: float) -> dict:
     }
 
 
-async def run_warmup(client: httpx.AsyncClient, args: argparse.Namespace, url: str) -> tuple[list[dict], float]:
+async def run_warmup(
+    client: httpx.AsyncClient, args: argparse.Namespace, url: str
+) -> tuple[list[dict], float]:
     if args.warmup_requests <= 0:
         return [], 0.0
 
@@ -428,7 +431,9 @@ def main() -> None:
     parser.add_argument("--url", default="http://localhost:8000", help="Server base URL")
     parser.add_argument("--endpoint", default="/v1/images/generations", help="Endpoint path")
     parser.add_argument("--rate", type=float, default=1.0, help="Request rate in req/s")
-    parser.add_argument("--duration", type=float, default=60.0, help="Duration when num requests is unset")
+    parser.add_argument(
+        "--duration", type=float, default=60.0, help="Duration when num requests is unset"
+    )
     parser.add_argument("--num-requests", type=int, default=None, help="Total requests")
     parser.add_argument(
         "--closed-loop",
@@ -458,18 +463,30 @@ def main() -> None:
         default=0,
         help="Requests to run before measurement and exclude from latency/throughput stats",
     )
-    parser.add_argument("--steps", type=int, default=20, help="Diffusion inference steps per request")
-    parser.add_argument("--guidance-scale", type=float, default=5.0, help="Classifier-free guidance scale")
-    parser.add_argument("--prompt", type=str, default=None, help="Fixed prompt for every benchmark request")
+    parser.add_argument(
+        "--steps", type=int, default=20, help="Diffusion inference steps per request"
+    )
+    parser.add_argument(
+        "--guidance-scale", type=float, default=5.0, help="Classifier-free guidance scale"
+    )
+    parser.add_argument(
+        "--prompt", type=str, default=None, help="Fixed prompt for every benchmark request"
+    )
     parser.add_argument("--seed", type=int, default=42, help="Benchmark scheduling seed")
-    parser.add_argument("--request-seed", type=int, default=None, help="Base model seed for deterministic requests")
+    parser.add_argument(
+        "--request-seed", type=int, default=None, help="Base model seed for deterministic requests"
+    )
     parser.add_argument(
         "--fixed-request-seed",
         action="store_true",
         help="Use request seed unchanged for every request instead of incrementing it by request index",
     )
-    parser.add_argument("--timeout", type=float, default=600.0, help="Per-request timeout in seconds")
-    parser.add_argument("--output-json", type=str, default=None, help="Write structured result JSON")
+    parser.add_argument(
+        "--timeout", type=float, default=600.0, help="Per-request timeout in seconds"
+    )
+    parser.add_argument(
+        "--output-json", type=str, default=None, help="Write structured result JSON"
+    )
     parser.add_argument(
         "--save-images-dir",
         type=str,

--- a/examples/show-o2-1.5B-HQ-macbook/benchmark/compare_images.py
+++ b/examples/show-o2-1.5B-HQ-macbook/benchmark/compare_images.py
@@ -135,8 +135,12 @@ def clip_metrics(
             text_inputs = processor(text=[prompt], return_tensors="pt", padding=True)
             text_features = model.get_text_features(**text_inputs)
             text_features = text_features / text_features.norm(dim=-1, keepdim=True)
-            result["baseline_prompt_cosine"] = float((image_features[0] * text_features[0]).sum().item())
-            result["candidate_prompt_cosine"] = float((image_features[1] * text_features[0]).sum().item())
+            result["baseline_prompt_cosine"] = float(
+                (image_features[0] * text_features[0]).sum().item()
+            )
+            result["candidate_prompt_cosine"] = float(
+                (image_features[1] * text_features[0]).sum().item()
+            )
     return result
 
 
@@ -168,7 +172,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Compare two generated PNG images.")
     parser.add_argument("--baseline", required=True, help="Baseline PNG path")
     parser.add_argument("--candidate", required=True, help="Candidate PNG path")
-    parser.add_argument("--prompt", default=None, help="Optional prompt for CLIP prompt-image scoring")
+    parser.add_argument(
+        "--prompt", default=None, help="Optional prompt for CLIP prompt-image scoring"
+    )
     parser.add_argument(
         "--clip-model",
         default=None,

--- a/examples/show-o2-1.5B-HQ-macbook/reference/reference.py
+++ b/examples/show-o2-1.5B-HQ-macbook/reference/reference.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-
 REFERENCE_DIR = Path(__file__).resolve().parent
 DEFAULT_SOURCE_DIR = REFERENCE_DIR / "Show-o" / "show-o2"
 DEFAULT_MODEL_DIR = REFERENCE_DIR / "model"
@@ -276,7 +275,9 @@ class ShowO2Model:
         repr=False,
     )
     _attention_mask_cache: dict[tuple[Any, ...], Any] = field(default_factory=dict, repr=False)
-    _attention_mask_identity_cache: dict[tuple[Any, ...], Any] = field(default_factory=dict, repr=False)
+    _attention_mask_identity_cache: dict[tuple[Any, ...], Any] = field(
+        default_factory=dict, repr=False
+    )
     _prepared_prompt_cache: dict[tuple[Any, ...], tuple[Any, Any]] = field(
         default_factory=dict,
         repr=False,
@@ -334,7 +335,9 @@ class ShowO2Model:
         if vae_conv2d_tail_start < 0:
             raise ValueError(f"Unsupported VAE conv2d tail start: {vae_conv2d_tail_start}")
         if vae_conv2d_tail_max_modules is not None and vae_conv2d_tail_max_modules < 0:
-            raise ValueError(f"Unsupported VAE conv2d tail max modules: {vae_conv2d_tail_max_modules}")
+            raise ValueError(
+                f"Unsupported VAE conv2d tail max modules: {vae_conv2d_tail_max_modules}"
+            )
         if vae_upsample_mode not in {"default", "convtranspose"}:
             raise ValueError(f"Unsupported VAE upsample mode: {vae_upsample_mode}")
         if vae_decoder_backend not in {"torch", "coreml", "mlx"}:
@@ -346,12 +349,17 @@ class ShowO2Model:
         if vae_mlx_dtype not in {"float32", "float16", "bfloat16"}:
             raise ValueError(f"Unsupported MLX VAE dtype: {vae_mlx_dtype}")
         if vae_mlx_low_rank_highres_rank < 0:
-            raise ValueError(f"Unsupported MLX low-rank high-res rank: {vae_mlx_low_rank_highres_rank}")
+            raise ValueError(
+                f"Unsupported MLX low-rank high-res rank: {vae_mlx_low_rank_highres_rank}"
+            )
         if vae_mlx_low_rank_highres_min_size < 0:
             raise ValueError(
                 f"Unsupported MLX low-rank high-res min size: {vae_mlx_low_rank_highres_min_size}"
             )
-        if vae_mlx_low_rank_highres_tail_rank is not None and vae_mlx_low_rank_highres_tail_rank < 0:
+        if (
+            vae_mlx_low_rank_highres_tail_rank is not None
+            and vae_mlx_low_rank_highres_tail_rank < 0
+        ):
             raise ValueError(
                 f"Unsupported MLX low-rank high-res tail rank: {vae_mlx_low_rank_highres_tail_rank}"
             )
@@ -362,8 +370,7 @@ class ShowO2Model:
             )
         if vae_mlx_low_rank_override_layer is not None and vae_mlx_low_rank_override_layer < 0:
             raise ValueError(
-                "Unsupported MLX low-rank override layer: "
-                f"{vae_mlx_low_rank_override_layer}"
+                f"Unsupported MLX low-rank override layer: {vae_mlx_low_rank_override_layer}"
             )
         if (
             vae_mlx_low_rank_override_conv_index is not None
@@ -375,8 +382,7 @@ class ShowO2Model:
             )
         if vae_mlx_low_rank_override_rank is not None and vae_mlx_low_rank_override_rank < 0:
             raise ValueError(
-                "Unsupported MLX low-rank override rank: "
-                f"{vae_mlx_low_rank_override_rank}"
+                f"Unsupported MLX low-rank override rank: {vae_mlx_low_rank_override_rank}"
             )
         if (
             vae_mlx_approx_highres_residual_start_layer is not None
@@ -458,9 +464,7 @@ class ShowO2Model:
             source_dir=source,
             resolution=resolution,
             vae_path=(
-                ensure_wan_vae(vae_path)
-                if load_vae and vae_decoder_backend != "coreml"
-                else None
+                ensure_wan_vae(vae_path) if load_vae and vae_decoder_backend != "coreml" else None
             ),
             vae_device=resolved_vae_device,
             vae_dtype=resolved_vae_dtype,
@@ -484,7 +488,9 @@ class ShowO2Model:
                 if vae_mlx_low_rank_highres_tail_rank is None
                 else int(vae_mlx_low_rank_highres_tail_rank)
             ),
-            vae_mlx_low_rank_highres_tail_start_layer=int(vae_mlx_low_rank_highres_tail_start_layer),
+            vae_mlx_low_rank_highres_tail_start_layer=int(
+                vae_mlx_low_rank_highres_tail_start_layer
+            ),
             vae_mlx_low_rank_override_layer=(
                 None
                 if vae_mlx_low_rank_override_layer is None
@@ -534,8 +540,12 @@ class ShowO2Model:
         else:
             self.vae_path = self.vae_path or ensure_wan_vae()
             vae_path = str(self.vae_path)
-        vae_device = "cpu" if self.vae_decoder_backend == "mlx" else (self.vae_device or self.device)
-        vae_dtype = torch.float32 if self.vae_decoder_backend == "mlx" else (self.vae_dtype or self.dtype)
+        vae_device = (
+            "cpu" if self.vae_decoder_backend == "mlx" else (self.vae_device or self.device)
+        )
+        vae_dtype = (
+            torch.float32 if self.vae_decoder_backend == "mlx" else (self.vae_dtype or self.dtype)
+        )
         self.vae_model = WanVAE(
             vae_pth=vae_path,
             dtype=vae_dtype,
@@ -772,7 +782,9 @@ class ShowO2Model:
         return sample_fn
 
     @staticmethod
-    def _limited_cache_set(cache: dict, key: tuple[Any, ...], value: Any, *, limit: int = 64) -> None:
+    def _limited_cache_set(
+        cache: dict, key: tuple[Any, ...], value: Any, *, limit: int = 64
+    ) -> None:
         if len(cache) >= limit:
             cache.clear()
         cache[key] = value
@@ -796,7 +808,9 @@ class ShowO2Model:
             dtype=torch.bool,
             device=self.device,
         ).triu(diagonal=1)
-        mask.masked_fill_(upper_triangle.view(1, 1, int(max_seq_len), int(max_seq_len)), blocked_value)
+        mask.masked_fill_(
+            upper_triangle.view(1, 1, int(max_seq_len), int(max_seq_len)), blocked_value
+        )
         self._limited_cache_set(self._attention_base_mask_cache, key, mask, limit=16)
         return mask, False
 
@@ -807,7 +821,9 @@ class ShowO2Model:
         if cached is not None:
             return cached, True
 
-        position_values = tuple(int(value) for value in positions.detach().cpu().reshape(-1).tolist())
+        position_values = tuple(
+            int(value) for value in positions.detach().cpu().reshape(-1).tolist()
+        )
         key = (*base_key, position_values)
         cached = self._attention_mask_cache.get(key)
         if cached is not None:
@@ -824,8 +840,8 @@ class ShowO2Model:
                     mask[
                         batch_index,
                         :,
-                        offset:offset + length,
-                        offset:offset + length,
+                        offset : offset + length,
+                        offset : offset + length,
                     ] = 0
         self._limited_cache_set(self._attention_mask_cache, key, mask)
         self._limited_cache_set(self._attention_mask_identity_cache, identity_key, mask)
@@ -895,7 +911,11 @@ class ShowO2Model:
             torch.manual_seed(seed)
             if self.device.type == "cuda":
                 torch.cuda.manual_seed_all(seed)
-            elif self.device.type == "mps" and hasattr(torch, "mps") and hasattr(torch.mps, "manual_seed"):
+            elif (
+                self.device.type == "mps"
+                and hasattr(torch, "mps")
+                and hasattr(torch.mps, "manual_seed")
+            ):
                 torch.mps.manual_seed(seed)
 
         (
@@ -964,9 +984,13 @@ class ShowO2Model:
             timings["mask_cache_hit"] = 1.0 if mask_cache_hit else 0.0
 
             sampler_started = time.perf_counter()
-            sample_fn = None if num_inference_steps == 1 else self._get_sample_fn(
-                num_inference_steps,
-                num_t2i_image_tokens,
+            sample_fn = (
+                None
+                if num_inference_steps == 1
+                else self._get_sample_fn(
+                    num_inference_steps,
+                    num_t2i_image_tokens,
+                )
             )
             timings["sampler_setup_ms"] = (time.perf_counter() - sampler_started) * 1000.0
 

--- a/examples/show-o2-1.5B-HQ/benchmark/benchmark.py
+++ b/examples/show-o2-1.5B-HQ/benchmark/benchmark.py
@@ -24,7 +24,6 @@ from statistics import mean
 
 import httpx
 
-
 PROMPT_POOL = [
     "a small red robot holding a handwritten sign that says VibeServe",
     "a studio product photo of a ceramic mug shaped like a rocket",
@@ -34,7 +33,9 @@ PROMPT_POOL = [
 ]
 
 
-def select_prompt(args: argparse.Namespace, rng: random.Random, idx: int, *, warmup: bool = False) -> str:
+def select_prompt(
+    args: argparse.Namespace, rng: random.Random, idx: int, *, warmup: bool = False
+) -> str:
     if args.prompt is not None:
         return args.prompt
     if warmup:
@@ -207,7 +208,9 @@ def summarize_results(results: list[dict], wall_clock: float) -> dict:
     }
 
 
-async def run_warmup(client: httpx.AsyncClient, args: argparse.Namespace, url: str) -> tuple[list[dict], float]:
+async def run_warmup(
+    client: httpx.AsyncClient, args: argparse.Namespace, url: str
+) -> tuple[list[dict], float]:
     if args.warmup_requests <= 0:
         return [], 0.0
 
@@ -428,7 +431,9 @@ def main() -> None:
     parser.add_argument("--url", default="http://localhost:8000", help="Server base URL")
     parser.add_argument("--endpoint", default="/v1/images/generations", help="Endpoint path")
     parser.add_argument("--rate", type=float, default=1.0, help="Request rate in req/s")
-    parser.add_argument("--duration", type=float, default=60.0, help="Duration when num requests is unset")
+    parser.add_argument(
+        "--duration", type=float, default=60.0, help="Duration when num requests is unset"
+    )
     parser.add_argument("--num-requests", type=int, default=None, help="Total requests")
     parser.add_argument(
         "--closed-loop",
@@ -458,18 +463,30 @@ def main() -> None:
         default=0,
         help="Requests to run before measurement and exclude from latency/throughput stats",
     )
-    parser.add_argument("--steps", type=int, default=20, help="Diffusion inference steps per request")
-    parser.add_argument("--guidance-scale", type=float, default=5.0, help="Classifier-free guidance scale")
-    parser.add_argument("--prompt", type=str, default=None, help="Fixed prompt for every benchmark request")
+    parser.add_argument(
+        "--steps", type=int, default=20, help="Diffusion inference steps per request"
+    )
+    parser.add_argument(
+        "--guidance-scale", type=float, default=5.0, help="Classifier-free guidance scale"
+    )
+    parser.add_argument(
+        "--prompt", type=str, default=None, help="Fixed prompt for every benchmark request"
+    )
     parser.add_argument("--seed", type=int, default=42, help="Benchmark scheduling seed")
-    parser.add_argument("--request-seed", type=int, default=None, help="Base model seed for deterministic requests")
+    parser.add_argument(
+        "--request-seed", type=int, default=None, help="Base model seed for deterministic requests"
+    )
     parser.add_argument(
         "--fixed-request-seed",
         action="store_true",
         help="Use request seed unchanged for every request instead of incrementing it by request index",
     )
-    parser.add_argument("--timeout", type=float, default=600.0, help="Per-request timeout in seconds")
-    parser.add_argument("--output-json", type=str, default=None, help="Write structured result JSON")
+    parser.add_argument(
+        "--timeout", type=float, default=600.0, help="Per-request timeout in seconds"
+    )
+    parser.add_argument(
+        "--output-json", type=str, default=None, help="Write structured result JSON"
+    )
     parser.add_argument(
         "--save-images-dir",
         type=str,

--- a/examples/show-o2-1.5B-HQ/benchmark/compare_images.py
+++ b/examples/show-o2-1.5B-HQ/benchmark/compare_images.py
@@ -135,8 +135,12 @@ def clip_metrics(
             text_inputs = processor(text=[prompt], return_tensors="pt", padding=True)
             text_features = model.get_text_features(**text_inputs)
             text_features = text_features / text_features.norm(dim=-1, keepdim=True)
-            result["baseline_prompt_cosine"] = float((image_features[0] * text_features[0]).sum().item())
-            result["candidate_prompt_cosine"] = float((image_features[1] * text_features[0]).sum().item())
+            result["baseline_prompt_cosine"] = float(
+                (image_features[0] * text_features[0]).sum().item()
+            )
+            result["candidate_prompt_cosine"] = float(
+                (image_features[1] * text_features[0]).sum().item()
+            )
     return result
 
 
@@ -168,7 +172,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Compare two generated PNG images.")
     parser.add_argument("--baseline", required=True, help="Baseline PNG path")
     parser.add_argument("--candidate", required=True, help="Candidate PNG path")
-    parser.add_argument("--prompt", default=None, help="Optional prompt for CLIP prompt-image scoring")
+    parser.add_argument(
+        "--prompt", default=None, help="Optional prompt for CLIP prompt-image scoring"
+    )
     parser.add_argument(
         "--clip-model",
         default=None,

--- a/examples/show-o2-1.5B-HQ/reference/reference.py
+++ b/examples/show-o2-1.5B-HQ/reference/reference.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-
 REFERENCE_DIR = Path(__file__).resolve().parent
 DEFAULT_SOURCE_DIR = REFERENCE_DIR / "Show-o" / "show-o2"
 DEFAULT_MODEL_DIR = REFERENCE_DIR / "model"
@@ -276,7 +275,9 @@ class ShowO2Model:
         repr=False,
     )
     _attention_mask_cache: dict[tuple[Any, ...], Any] = field(default_factory=dict, repr=False)
-    _attention_mask_identity_cache: dict[tuple[Any, ...], Any] = field(default_factory=dict, repr=False)
+    _attention_mask_identity_cache: dict[tuple[Any, ...], Any] = field(
+        default_factory=dict, repr=False
+    )
     _prepared_prompt_cache: dict[tuple[Any, ...], tuple[Any, Any]] = field(
         default_factory=dict,
         repr=False,
@@ -334,7 +335,9 @@ class ShowO2Model:
         if vae_conv2d_tail_start < 0:
             raise ValueError(f"Unsupported VAE conv2d tail start: {vae_conv2d_tail_start}")
         if vae_conv2d_tail_max_modules is not None and vae_conv2d_tail_max_modules < 0:
-            raise ValueError(f"Unsupported VAE conv2d tail max modules: {vae_conv2d_tail_max_modules}")
+            raise ValueError(
+                f"Unsupported VAE conv2d tail max modules: {vae_conv2d_tail_max_modules}"
+            )
         if vae_upsample_mode not in {"default", "convtranspose"}:
             raise ValueError(f"Unsupported VAE upsample mode: {vae_upsample_mode}")
         if vae_decoder_backend not in {"torch", "coreml", "mlx"}:
@@ -346,12 +349,17 @@ class ShowO2Model:
         if vae_mlx_dtype not in {"float32", "float16", "bfloat16"}:
             raise ValueError(f"Unsupported MLX VAE dtype: {vae_mlx_dtype}")
         if vae_mlx_low_rank_highres_rank < 0:
-            raise ValueError(f"Unsupported MLX low-rank high-res rank: {vae_mlx_low_rank_highres_rank}")
+            raise ValueError(
+                f"Unsupported MLX low-rank high-res rank: {vae_mlx_low_rank_highres_rank}"
+            )
         if vae_mlx_low_rank_highres_min_size < 0:
             raise ValueError(
                 f"Unsupported MLX low-rank high-res min size: {vae_mlx_low_rank_highres_min_size}"
             )
-        if vae_mlx_low_rank_highres_tail_rank is not None and vae_mlx_low_rank_highres_tail_rank < 0:
+        if (
+            vae_mlx_low_rank_highres_tail_rank is not None
+            and vae_mlx_low_rank_highres_tail_rank < 0
+        ):
             raise ValueError(
                 f"Unsupported MLX low-rank high-res tail rank: {vae_mlx_low_rank_highres_tail_rank}"
             )
@@ -362,8 +370,7 @@ class ShowO2Model:
             )
         if vae_mlx_low_rank_override_layer is not None and vae_mlx_low_rank_override_layer < 0:
             raise ValueError(
-                "Unsupported MLX low-rank override layer: "
-                f"{vae_mlx_low_rank_override_layer}"
+                f"Unsupported MLX low-rank override layer: {vae_mlx_low_rank_override_layer}"
             )
         if (
             vae_mlx_low_rank_override_conv_index is not None
@@ -375,8 +382,7 @@ class ShowO2Model:
             )
         if vae_mlx_low_rank_override_rank is not None and vae_mlx_low_rank_override_rank < 0:
             raise ValueError(
-                "Unsupported MLX low-rank override rank: "
-                f"{vae_mlx_low_rank_override_rank}"
+                f"Unsupported MLX low-rank override rank: {vae_mlx_low_rank_override_rank}"
             )
         if (
             vae_mlx_approx_highres_residual_start_layer is not None
@@ -458,9 +464,7 @@ class ShowO2Model:
             source_dir=source,
             resolution=resolution,
             vae_path=(
-                ensure_wan_vae(vae_path)
-                if load_vae and vae_decoder_backend != "coreml"
-                else None
+                ensure_wan_vae(vae_path) if load_vae and vae_decoder_backend != "coreml" else None
             ),
             vae_device=resolved_vae_device,
             vae_dtype=resolved_vae_dtype,
@@ -484,7 +488,9 @@ class ShowO2Model:
                 if vae_mlx_low_rank_highres_tail_rank is None
                 else int(vae_mlx_low_rank_highres_tail_rank)
             ),
-            vae_mlx_low_rank_highres_tail_start_layer=int(vae_mlx_low_rank_highres_tail_start_layer),
+            vae_mlx_low_rank_highres_tail_start_layer=int(
+                vae_mlx_low_rank_highres_tail_start_layer
+            ),
             vae_mlx_low_rank_override_layer=(
                 None
                 if vae_mlx_low_rank_override_layer is None
@@ -534,8 +540,12 @@ class ShowO2Model:
         else:
             self.vae_path = self.vae_path or ensure_wan_vae()
             vae_path = str(self.vae_path)
-        vae_device = "cpu" if self.vae_decoder_backend == "mlx" else (self.vae_device or self.device)
-        vae_dtype = torch.float32 if self.vae_decoder_backend == "mlx" else (self.vae_dtype or self.dtype)
+        vae_device = (
+            "cpu" if self.vae_decoder_backend == "mlx" else (self.vae_device or self.device)
+        )
+        vae_dtype = (
+            torch.float32 if self.vae_decoder_backend == "mlx" else (self.vae_dtype or self.dtype)
+        )
         self.vae_model = WanVAE(
             vae_pth=vae_path,
             dtype=vae_dtype,
@@ -772,7 +782,9 @@ class ShowO2Model:
         return sample_fn
 
     @staticmethod
-    def _limited_cache_set(cache: dict, key: tuple[Any, ...], value: Any, *, limit: int = 64) -> None:
+    def _limited_cache_set(
+        cache: dict, key: tuple[Any, ...], value: Any, *, limit: int = 64
+    ) -> None:
         if len(cache) >= limit:
             cache.clear()
         cache[key] = value
@@ -796,7 +808,9 @@ class ShowO2Model:
             dtype=torch.bool,
             device=self.device,
         ).triu(diagonal=1)
-        mask.masked_fill_(upper_triangle.view(1, 1, int(max_seq_len), int(max_seq_len)), blocked_value)
+        mask.masked_fill_(
+            upper_triangle.view(1, 1, int(max_seq_len), int(max_seq_len)), blocked_value
+        )
         self._limited_cache_set(self._attention_base_mask_cache, key, mask, limit=16)
         return mask, False
 
@@ -807,7 +821,9 @@ class ShowO2Model:
         if cached is not None:
             return cached, True
 
-        position_values = tuple(int(value) for value in positions.detach().cpu().reshape(-1).tolist())
+        position_values = tuple(
+            int(value) for value in positions.detach().cpu().reshape(-1).tolist()
+        )
         key = (*base_key, position_values)
         cached = self._attention_mask_cache.get(key)
         if cached is not None:
@@ -824,8 +840,8 @@ class ShowO2Model:
                     mask[
                         batch_index,
                         :,
-                        offset:offset + length,
-                        offset:offset + length,
+                        offset : offset + length,
+                        offset : offset + length,
                     ] = 0
         self._limited_cache_set(self._attention_mask_cache, key, mask)
         self._limited_cache_set(self._attention_mask_identity_cache, identity_key, mask)
@@ -895,7 +911,11 @@ class ShowO2Model:
             torch.manual_seed(seed)
             if self.device.type == "cuda":
                 torch.cuda.manual_seed_all(seed)
-            elif self.device.type == "mps" and hasattr(torch, "mps") and hasattr(torch.mps, "manual_seed"):
+            elif (
+                self.device.type == "mps"
+                and hasattr(torch, "mps")
+                and hasattr(torch.mps, "manual_seed")
+            ):
                 torch.mps.manual_seed(seed)
 
         (
@@ -964,9 +984,13 @@ class ShowO2Model:
             timings["mask_cache_hit"] = 1.0 if mask_cache_hit else 0.0
 
             sampler_started = time.perf_counter()
-            sample_fn = None if num_inference_steps == 1 else self._get_sample_fn(
-                num_inference_steps,
-                num_t2i_image_tokens,
+            sample_fn = (
+                None
+                if num_inference_steps == 1
+                else self._get_sample_fn(
+                    num_inference_steps,
+                    num_t2i_image_tokens,
+                )
             )
             timings["sampler_setup_ms"] = (time.perf_counter() - sampler_started) * 1000.0
 

--- a/examples/torch_profiler/analyze_torch_profile.py
+++ b/examples/torch_profiler/analyze_torch_profile.py
@@ -60,7 +60,6 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-
 # ---------------------------------------------------------------------------
 # Capture: in-process (loads VibeServeModel from main.py)
 # ---------------------------------------------------------------------------
@@ -108,9 +107,11 @@ def cmd_capture(args: argparse.Namespace) -> None:
     model_dir = args.model_dir
     weights_dir = args.weights_dir or "/model"
 
-    print(f"[capture] loading VibeServeModel from {model_dir}/main.py "
-          f"(weights: {weights_dir}, device={args.device}, dtype={args.dtype})",
-          file=sys.stderr)
+    print(
+        f"[capture] loading VibeServeModel from {model_dir}/main.py "
+        f"(weights: {weights_dir}, device={args.device}, dtype={args.dtype})",
+        file=sys.stderr,
+    )
 
     module = _load_main_module(model_dir)
     model = module.VibeServeModel.from_pretrained(
@@ -124,6 +125,7 @@ def cmd_capture(args: argparse.Namespace) -> None:
     tokenizer = getattr(model, "tokenizer", None)
     if tokenizer is None:
         from transformers import AutoTokenizer
+
         tokenizer = AutoTokenizer.from_pretrained(weights_dir)
 
     input_ids = tokenizer(args.prompt, return_tensors="pt").input_ids.to(args.device)
@@ -135,8 +137,10 @@ def cmd_capture(args: argparse.Namespace) -> None:
             model.generate(input_ids=input_ids, max_new_tokens=args.max_tokens)
     torch.cuda.synchronize()
 
-    print(f"[capture] profiling ({args.num_iters} iters, max_new_tokens={args.max_tokens})...",
-          file=sys.stderr)
+    print(
+        f"[capture] profiling ({args.num_iters} iters, max_new_tokens={args.max_tokens})...",
+        file=sys.stderr,
+    )
     t0 = time.time()
     with profile(
         activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
@@ -152,21 +156,26 @@ def cmd_capture(args: argparse.Namespace) -> None:
     print(f"[capture] elapsed {wall:.2f}s", file=sys.stderr)
 
     events_json = _summarize_prof(prof, num_iters=args.num_iters)
-    events_json.update({
-        "captured_at": datetime.now(timezone.utc).isoformat(),
-        "mode": "model",
-        "device": args.device,
-        "dtype": args.dtype,
-        "num_iters": args.num_iters,
-        "max_new_tokens": args.max_tokens,
-        "prompt": args.prompt,
-        "wall_time_sec": wall,
-    })
+    events_json.update(
+        {
+            "captured_at": datetime.now(timezone.utc).isoformat(),
+            "mode": "model",
+            "device": args.device,
+            "dtype": args.dtype,
+            "num_iters": args.num_iters,
+            "max_new_tokens": args.max_tokens,
+            "prompt": args.prompt,
+            "wall_time_sec": wall,
+        }
+    )
     Path(args.output).write_text(json.dumps(events_json, indent=2))
-    print(f"[capture] wrote {args.output} "
-          f"({events_json['total_cuda_time_us']:.0f} us CUDA, "
-          f"{events_json['total_cpu_time_us']:.0f} us CPU, "
-          f"{len(events_json['events'])} events)", file=sys.stderr)
+    print(
+        f"[capture] wrote {args.output} "
+        f"({events_json['total_cuda_time_us']:.0f} us CUDA, "
+        f"{events_json['total_cpu_time_us']:.0f} us CPU, "
+        f"{len(events_json['events'])} events)",
+        file=sys.stderr,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -201,8 +210,10 @@ def cmd_capture_server(args: argparse.Namespace) -> None:
     print(f"[capture-server] POST {args.url}/admin/profile/start", file=sys.stderr)
     _post("/admin/profile/start")
 
-    print(f"[capture-server] sending {args.requests} requests "
-          f"(max_tokens={args.max_tokens})...", file=sys.stderr)
+    print(
+        f"[capture-server] sending {args.requests} requests (max_tokens={args.max_tokens})...",
+        file=sys.stderr,
+    )
     for i in range(args.requests):
         _post(
             "/v1/completions",
@@ -250,23 +261,35 @@ def _summarize_prof(prof, num_iters: int) -> dict:
         self_cpu_us = float(getattr(ev, "self_cpu_time_total", 0.0) or 0.0)
         name = ev.key
         # Classify
-        if ev.device_type == torch.autograd.DeviceType.CUDA or "cuda" in name.lower() or cuda_us > 0 and cpu_us < cuda_us / 4:
+        if (
+            ev.device_type == torch.autograd.DeviceType.CUDA
+            or "cuda" in name.lower()
+            or cuda_us > 0
+            and cpu_us < cuda_us / 4
+        ):
             category = "kernel"
         elif name.startswith("aten::") or name.startswith("torch::"):
             category = "operator"
-        elif "memcpy" in name.lower() or "memset" in name.lower() or "malloc" in name.lower() or "free" in name.lower():
+        elif (
+            "memcpy" in name.lower()
+            or "memset" in name.lower()
+            or "malloc" in name.lower()
+            or "free" in name.lower()
+        ):
             category = "memory"
         else:
             category = "cpu"
-        events.append({
-            "name": name,
-            "category": category,
-            "cpu_time_us": cpu_us,
-            "cuda_time_us": cuda_us,
-            "self_cpu_time_us": self_cpu_us,
-            "self_cuda_time_us": self_cuda_us,
-            "count": int(ev.count),
-        })
+        events.append(
+            {
+                "name": name,
+                "category": category,
+                "cpu_time_us": cpu_us,
+                "cuda_time_us": cuda_us,
+                "self_cpu_time_us": self_cpu_us,
+                "self_cuda_time_us": self_cuda_us,
+                "count": int(ev.count),
+            }
+        )
         total_cuda += self_cuda_us
         total_cpu += self_cpu_us
     return {
@@ -335,8 +358,10 @@ def cmd_operators(args: argparse.Namespace) -> None:
         name = ev["name"]
         if len(name) > 48:
             name = name[:45] + "..."
-        print(f"{name:<50}{_fmt_us(ev['self_cpu_time_us']):>14}"
-              f"{_fmt_us(ev['cuda_time_us']):>14}{pct:>9.1f}%{ev['count']:>10}")
+        print(
+            f"{name:<50}{_fmt_us(ev['self_cpu_time_us']):>14}"
+            f"{_fmt_us(ev['cuda_time_us']):>14}{pct:>9.1f}%{ev['count']:>10}"
+        )
 
 
 def cmd_cpu_overhead(args: argparse.Namespace) -> None:
@@ -350,16 +375,21 @@ def cmd_cpu_overhead(args: argparse.Namespace) -> None:
     print(f"CPU/CUDA ratio:       {ratio:.2f}x")
     if ratio > 2.0:
         print()
-        print("Interpretation: CPU time dominates (>2x GPU). Likely launch-bound"
-              " — consider CUDA graphs, fewer kernels, or larger batches.")
+        print(
+            "Interpretation: CPU time dominates (>2x GPU). Likely launch-bound"
+            " — consider CUDA graphs, fewer kernels, or larger batches."
+        )
     elif ratio < 0.5:
         print()
-        print("Interpretation: GPU time dominates (<0.5x CPU). Compute-bound —"
-              " focus on kernel fusion, flash attention, better algorithms.")
+        print(
+            "Interpretation: GPU time dominates (<0.5x CPU). Compute-bound —"
+            " focus on kernel fusion, flash attention, better algorithms."
+        )
     else:
         print()
-        print("Interpretation: CPU and GPU roughly balanced. Both axes may"
-              " benefit from optimization.")
+        print(
+            "Interpretation: CPU and GPU roughly balanced. Both axes may benefit from optimization."
+        )
 
 
 def cmd_memory(args: argparse.Namespace) -> None:
@@ -376,8 +406,10 @@ def cmd_memory(args: argparse.Namespace) -> None:
         name = ev["name"]
         if len(name) > 38:
             name = name[:35] + "..."
-        print(f"{name:<40}{_fmt_us(ev['cuda_time_us']):>14}"
-              f"{_fmt_us(ev['cpu_time_us']):>14}{ev['count']:>10}")
+        print(
+            f"{name:<40}{_fmt_us(ev['cuda_time_us']):>14}"
+            f"{_fmt_us(ev['cpu_time_us']):>14}{ev['count']:>10}"
+        )
 
 
 def cmd_summary(args: argparse.Namespace) -> None:
@@ -441,11 +473,11 @@ def main() -> None:
     cap.add_argument("--prompt", default="The capital of France is")
     cap.add_argument("--max-tokens", type=int, default=32)
     cap.add_argument("--device", default="cuda")
-    cap.add_argument("--dtype", default="bfloat16",
-                     choices=["bfloat16", "float16", "float32"])
+    cap.add_argument("--dtype", default="bfloat16", choices=["bfloat16", "float16", "float32"])
 
-    srv = sub.add_parser("capture-server",
-                         help="Capture a profile against a server with /admin/profile endpoints")
+    srv = sub.add_parser(
+        "capture-server", help="Capture a profile against a server with /admin/profile endpoints"
+    )
     srv.add_argument("--url", required=True, help="Server base URL, e.g. http://localhost:8000")
     srv.add_argument("--output", required=True)
     srv.add_argument("--requests", type=int, default=10)

--- a/examples/torch_profiler/server.py
+++ b/examples/torch_profiler/server.py
@@ -24,7 +24,6 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
-
 _HERE = Path(__file__).resolve().parent
 
 sys.path.insert(0, str(_HERE))

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-profiling/examples/basic-profiling-workflow.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-profiling/examples/basic-profiling-workflow.py
@@ -13,29 +13,29 @@ Run this script on Trainium/Inferentia hardware with the NKI venv activated.
 
 import os
 import subprocess
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 # =============================================================================
 # Step 1: Set profiling environment variables BEFORE any neuronx imports
 # =============================================================================
 
-os.environ['NEURON_RT_INSPECT_ENABLE'] = '1'
-os.environ['NEURON_RT_INSPECT_DEVICE_PROFILE'] = '1'
-os.environ['NEURON_RT_INSPECT_OUTPUT_DIR'] = './output'
-os.environ['NEURON_CC_FLAGS'] = '--target trn2 --lnc 1'
+os.environ["NEURON_RT_INSPECT_ENABLE"] = "1"
+os.environ["NEURON_RT_INSPECT_DEVICE_PROFILE"] = "1"
+os.environ["NEURON_RT_INSPECT_OUTPUT_DIR"] = "./output"
+os.environ["NEURON_CC_FLAGS"] = "--target trn2 --lnc 1"
 
 # Now import neuronx packages
+import nki
+import nki.isa as nisa
+import nki.language as nl
 import torch
 from torch_xla.core import xla_model as xm
-import nki
-import nki.language as nl
-import nki.isa as nisa
-
 
 # =============================================================================
 # Define kernel to profile
 # =============================================================================
+
 
 def kernel_assert(condition, message=""):
     """Validate kernel preconditions (raises at trace time)."""
@@ -43,6 +43,7 @@ def kernel_assert(condition, message=""):
 
 
 os.environ["NEURON_PLATFORM_TARGET_OVERRIDE"] = "trn2"
+
 
 @nki.jit
 def add_kernel(a_input, b_input):
@@ -107,15 +108,15 @@ print(f"Step 3: Created profile directory: {profile_dir}")
 # Step 4: Find NEFF and prepare capture command
 # =============================================================================
 
-output_dir = Path('./output')
-neff_files = list(output_dir.glob('*/*.neff'))
+output_dir = Path("./output")
+neff_files = list(output_dir.glob("*/*.neff"))
 
 if not neff_files:
     print("ERROR: No NEFF files found in output directory")
     exit(1)
 
 neff_path = neff_files[0]
-ntff_path = profile_dir / 'profile.ntff'
+ntff_path = profile_dir / "profile.ntff"
 
 print(f"Step 4: Found NEFF: {neff_path}")
 

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-profiling/scripts/identify-neffs.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-profiling/scripts/identify-neffs.py
@@ -18,7 +18,14 @@ Examples:
 Note: Requires compile workdirs in /tmp/$USER/neuroncc_compile_workdir/ to still exist.
       Run this promptly after kernel execution, before temp cleanup.
 """
-import subprocess, os, re, base64, json, glob, sys
+
+import base64
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
 
 
 def identify_neff(neff_path):

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/examples/associative_scan.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/examples/associative_scan.py
@@ -2,6 +2,7 @@ import nki
 import nki.isa as nisa
 import nki.language as nl
 
+
 def kernel_assert(condition, message=""):
     """Validate kernel preconditions (raises at trace time)."""
     assert condition, message
@@ -49,7 +50,7 @@ def cumulative_product_sum(deltaA, deltaBu):
         data1=deltaBu_tile,
         initial=0,
         op0=nl.multiply,
-        op1=nl.add
+        op1=nl.add,
     )
 
     # Store to HBM
@@ -57,10 +58,12 @@ def cumulative_product_sum(deltaA, deltaBu):
 
     return output
 
+
 # Simple test function
 def test_associative_scan():
     """Test associative scan against PyTorch reference."""
     import torch
+
     channels, seq_len = 128, 256
 
     deltaA = torch.ones(channels, seq_len) * 0.9
@@ -69,7 +72,7 @@ def test_associative_scan():
     # PyTorch reference
     result_torch = torch.zeros(channels, seq_len)
     for i in range(seq_len):
-        prev = result_torch[:, i-1] if i > 0 else 0
+        prev = result_torch[:, i - 1] if i > 0 else 0
         result_torch[:, i] = deltaA[:, i] * prev + deltaBu[:, i]
 
     # NKI kernel
@@ -78,6 +81,7 @@ def test_associative_scan():
     # Compare
     assert torch.allclose(result_torch, result_nki, rtol=1e-3)
     print("✓ Associative scan test passed")
+
 
 if __name__ == "__main__":
     test_associative_scan()

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/examples/elementwise_exp.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/examples/elementwise_exp.py
@@ -11,11 +11,12 @@ import nki
 import nki.isa as nisa
 import nki.language as nl
 
-
 # === Self-contained utilities ===
+
 
 def kernel_assert(condition: bool, error_text: str):
     assert condition, f"[INTERNAL_ERROR] [NCC_INKI016] Kernel validation exception: {error_text}"
+
 
 def div_ceil(n: int, d: int) -> int:
     return (n + d - 1) // d
@@ -125,12 +126,13 @@ if __name__ == "__main__":
     This test validates correctness against PyTorch reference implementation.
     """
     import os
+
     import torch
     from torch_xla.core import xla_model as xm
 
     # Set environment variables for profiling/debugging
-    os.environ['NEURON_RT_INSPECT_ENABLE'] = '1'
-    os.environ['NEURON_RT_INSPECT_DEVICE_PROFILE'] = '1'
+    os.environ["NEURON_RT_INSPECT_ENABLE"] = "1"
+    os.environ["NEURON_RT_INSPECT_DEVICE_PROFILE"] = "1"
     os.environ["NEURON_RT_INSPECT_OUTPUT_DIR"] = "./output_elementwise_exp"
     os.environ["NEURON_CC_FLAGS"] = "--target trn2"
     os.environ["NEURON_PLATFORM_TARGET_OVERRIDE"] = "trn2"

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/examples/simple_matmul.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/examples/simple_matmul.py
@@ -12,11 +12,12 @@ import nki
 import nki.isa as nisa
 import nki.language as nl
 
-
 # === Self-contained utilities ===
+
 
 def kernel_assert(condition: bool, error_text: str):
     assert condition, f"[INTERNAL_ERROR] [NCC_INKI016] Kernel validation exception: {error_text}"
+
 
 def div_ceil(n: int, d: int) -> int:
     return (n + d - 1) // d
@@ -30,9 +31,9 @@ def div_ceil(n: int, d: int) -> int:
 #
 # For lhsT[K,M] @ rhs[K,N] = output[M,N]:
 #   The caller must transpose the left operand before passing it in.
-P_MAX = 128        # Partition dimension max (K for matmul)
-F_STAT_MAX = 128   # Stationary free dimension max (M for matmul)
-F_MOV_MAX = 512    # Moving free dimension max (N for matmul)
+P_MAX = 128  # Partition dimension max (K for matmul)
+F_STAT_MAX = 128  # Stationary free dimension max (M for matmul)
+F_MOV_MAX = 512  # Moving free dimension max (N for matmul)
 
 
 @nki.jit
@@ -105,10 +106,7 @@ def simple_matmul(
     K, M = lhs_T.shape
     K_rhs, N = rhs.shape
 
-    kernel_assert(
-        K == K_rhs,
-        f"Contraction dimension mismatch: lhs_T has K={K}, rhs has K={K_rhs}"
-    )
+    kernel_assert(K == K_rhs, f"Contraction dimension mismatch: lhs_T has K={K}, rhs has K={K_rhs}")
 
     # === Allocate Output ===
     output = nl.ndarray((M, N), dtype=lhs_T.dtype, buffer=nl.shared_hbm)
@@ -197,12 +195,13 @@ if __name__ == "__main__":
     This test validates correctness against PyTorch reference implementation.
     """
     import os
+
     import torch
     from torch_xla.core import xla_model as xm
 
     # Set environment variables for profiling/debugging
-    os.environ['NEURON_RT_INSPECT_ENABLE'] = '1'
-    os.environ['NEURON_RT_INSPECT_DEVICE_PROFILE'] = '1'
+    os.environ["NEURON_RT_INSPECT_ENABLE"] = "1"
+    os.environ["NEURON_RT_INSPECT_DEVICE_PROFILE"] = "1"
     os.environ["NEURON_RT_INSPECT_OUTPUT_DIR"] = "./output_simple_matmul"
     os.environ["NEURON_CC_FLAGS"] = "--target trn2"
     os.environ["NEURON_PLATFORM_TARGET_OVERRIDE"] = "trn2"

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/find_nonzero_indices.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/find_nonzero_indices.py
@@ -92,7 +92,9 @@ def find_nonzero_indices(
     T_DIM, C_DIM = input_tensor.shape
     # Handle col_start_id parameter for processing subset of columns
     if col_start_id != None and n_cols != None:
-        col_start_id_sbuf = nl.ndarray((1, 1), dtype=nl.int32, buffer=nl.sbuf, name="col_start_id_sbuf")
+        col_start_id_sbuf = nl.ndarray(
+            (1, 1), dtype=nl.int32, buffer=nl.sbuf, name="col_start_id_sbuf"
+        )
         nisa.dma_copy(dst=col_start_id_sbuf, src=col_start_id[0:1])
         C = n_cols
     else:
@@ -111,7 +113,9 @@ def find_nonzero_indices(
     # Use chunk_size to limit SBUF usage for large T
     if chunk_size == None:
         chunk_size = T_DIM
-    kernel_assert(T_DIM % chunk_size == 0, f"T_DIM ({T_DIM}) must be divisible by chunk_size ({chunk_size})")
+    kernel_assert(
+        T_DIM % chunk_size == 0, f"T_DIM ({T_DIM}) must be divisible by chunk_size ({chunk_size})"
+    )
     CHUNK_T_TILES = chunk_size // T_TILE_SIZE
     NUM_CHUNKS = T_DIM // chunk_size
 
@@ -121,14 +125,19 @@ def find_nonzero_indices(
     # Initialize indices to -1 when processing in chunks (partial writes need padding)
     if NUM_CHUNKS > 1:
         sbuf_init = nl.ndarray(
-            (P_MAX, C_per_shard * T_DIM // P_MAX), dtype=index_dtype, buffer=nl.sbuf, name="sbuf_init"
+            (P_MAX, C_per_shard * T_DIM // P_MAX),
+            dtype=index_dtype,
+            buffer=nl.sbuf,
+            name="sbuf_init",
         )
         nisa.memset(dst=sbuf_init, value=-1)
         reshaped_dst = indices.reshape((P_MAX * 2, C_per_shard * T_DIM // P_MAX))
         nisa.dma_copy(dst=reshaped_dst[P_MAX * shard_id : P_MAX * (shard_id + 1), :], src=sbuf_init)
 
     nonzero_counts = nl.ndarray((C,), dtype=nl.int32, buffer=nl.shared_hbm)
-    nonzero_counts_local = nl.ndarray((1, C_per_shard), dtype=nl.int32, buffer=nl.sbuf, name="nonzero_counts_local")
+    nonzero_counts_local = nl.ndarray(
+        (1, C_per_shard), dtype=nl.int32, buffer=nl.sbuf, name="nonzero_counts_local"
+    )
     nisa.memset(dst=nonzero_counts_local, value=0)
 
     # Calculate iteration counts
@@ -140,12 +149,17 @@ def find_nonzero_indices(
     nisa.dma_copy(dst=identity_sb, src=identity_hbm)
 
     for column_round_idx in range(n_column_rounds):
-        n_columns_this_round = min(_NUM_GPSIMD_CORES, C_per_shard - _NUM_GPSIMD_CORES * column_round_idx)
+        n_columns_this_round = min(
+            _NUM_GPSIMD_CORES, C_per_shard - _NUM_GPSIMD_CORES * column_round_idx
+        )
         column_start_offset = column_round_idx * _NUM_GPSIMD_CORES + C_offset
 
         # Track cumulative offsets for writing indices
         offsets = nl.ndarray(
-            (1, _NUM_GPSIMD_CORES), dtype=nl.int32, buffer=nl.sbuf, name=f"offsets_er-{column_round_idx}"
+            (1, _NUM_GPSIMD_CORES),
+            dtype=nl.int32,
+            buffer=nl.sbuf,
+            name=f"offsets_er-{column_round_idx}",
         )
         nisa.memset(dst=offsets, value=0)
         for chunk_idx in range(NUM_CHUNKS):
@@ -164,7 +178,9 @@ def find_nonzero_indices(
                 dtype=input_tensor.dtype,
                 buffer=nl.sbuf,
             )
-            indices_sbuf = nl.ndarray((C_TILE_SIZE, 1, chunk_size + 1), dtype=nl.int32, buffer=nl.sbuf)
+            indices_sbuf = nl.ndarray(
+                (C_TILE_SIZE, 1, chunk_size + 1), dtype=nl.int32, buffer=nl.sbuf
+            )
             t_chunk_start = chunk_idx * chunk_size
 
             # --- Load phase: single DMA copy for all T tiles in the chunk ---
@@ -172,7 +188,11 @@ def find_nonzero_indices(
                 nisa.dma_copy(
                     dst=input_sbuf[:, 0:CHUNK_T_TILES, 0:n_columns_this_round],
                     src=input_tensor.ap(
-                        pattern=[[C_DIM, T_TILE_SIZE], [C_DIM * T_TILE_SIZE, CHUNK_T_TILES], [1, n_columns_this_round]],
+                        pattern=[
+                            [C_DIM, T_TILE_SIZE],
+                            [C_DIM * T_TILE_SIZE, CHUNK_T_TILES],
+                            [1, n_columns_this_round],
+                        ],
                         offset=column_start_offset + (t_chunk_start * C_DIM),
                         scalar_offset=col_start_id_sbuf,
                         indirect_dim=1,
@@ -183,7 +203,11 @@ def find_nonzero_indices(
                 nisa.dma_copy(
                     dst=input_sbuf[:, 0:CHUNK_T_TILES, 0:n_columns_this_round],
                     src=input_tensor.ap(
-                        pattern=[[C_DIM, T_TILE_SIZE], [C_DIM * T_TILE_SIZE, CHUNK_T_TILES], [1, n_columns_this_round]],
+                        pattern=[
+                            [C_DIM, T_TILE_SIZE],
+                            [C_DIM * T_TILE_SIZE, CHUNK_T_TILES],
+                            [1, n_columns_this_round],
+                        ],
                         offset=column_start_offset + (t_chunk_start * C_DIM),
                     ),
                 )
@@ -198,7 +222,9 @@ def find_nonzero_indices(
 
             # --- Scatter and transpose phase: per T tile ---
             for t_tile_idx in range(CHUNK_T_TILES):
-                transposed_psum = nl.ndarray((C_TILE_SIZE, T_TILE_SIZE), dtype=nl.float32, buffer=nl.psum)
+                transposed_psum = nl.ndarray(
+                    (C_TILE_SIZE, T_TILE_SIZE), dtype=nl.float32, buffer=nl.psum
+                )
                 nisa.nc_matmul(
                     dst=transposed_psum,
                     stationary=input_gpsimd_aligned_sbuf[:, t_tile_idx, :],
@@ -261,14 +287,18 @@ def find_nonzero_indices(
         # Copy final accumulated counts for this round of columns
         nisa.tensor_copy(
             dst=nonzero_counts_local[
-                0:1, column_round_idx * _NUM_GPSIMD_CORES : column_round_idx * _NUM_GPSIMD_CORES + n_columns_this_round
+                0:1,
+                column_round_idx * _NUM_GPSIMD_CORES : column_round_idx * _NUM_GPSIMD_CORES
+                + n_columns_this_round,
             ],
             src=offsets[0:1, 0:n_columns_this_round],
         )
 
     # Write nonzero counts to HBM
     nonzero_counts_reshape = nonzero_counts.reshape((1, C))
-    nisa.dma_copy(dst=nonzero_counts_reshape[0:1, C_offset : C_offset + C_per_shard], src=nonzero_counts_local)
+    nisa.dma_copy(
+        dst=nonzero_counts_reshape[0:1, C_offset : C_offset + C_per_shard], src=nonzero_counts_local
+    )
 
     return indices, nonzero_counts
 
@@ -328,7 +358,9 @@ def _store_indices_and_count(
     )
     nisa.tensor_copy(
         dst=src_data,
-        src=indices_sbuf[quadrant_idx * _QUADRANT_SIZE : quadrant_idx * _QUADRANT_SIZE + 1, 0, 0:chunk_size],
+        src=indices_sbuf[
+            quadrant_idx * _QUADRANT_SIZE : quadrant_idx * _QUADRANT_SIZE + 1, 0, 0:chunk_size
+        ],
     )
     nisa.dma_copy(
         dst=indices.ap(
@@ -349,7 +381,9 @@ def _store_indices_and_count(
     nisa.tensor_copy(
         dst=count_tile,
         src=indices_sbuf[
-            quadrant_idx * _QUADRANT_SIZE : quadrant_idx * _QUADRANT_SIZE + 1, 0, chunk_size : chunk_size + 1
+            quadrant_idx * _QUADRANT_SIZE : quadrant_idx * _QUADRANT_SIZE + 1,
+            0,
+            chunk_size : chunk_size + 1,
         ],
     )
     nisa.tensor_tensor(

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/indexed_flatten.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/indexed_flatten.py
@@ -90,8 +90,14 @@ def indexed_flatten(
     N = row_offsets.shape[0]
 
     # Input validation
-    kernel_assert(output_len % P_MAX == 0, f"output_len must be divisible by P_MAX ({P_MAX}), got {output_len}")
-    kernel_assert(output_len % f_len == 0, f"output_len must be divisible by f_len, got {output_len=}, {f_len=}")
+    kernel_assert(
+        output_len % P_MAX == 0,
+        f"output_len must be divisible by P_MAX ({P_MAX}), got {output_len}",
+    )
+    kernel_assert(
+        output_len % f_len == 0,
+        f"output_len must be divisible by f_len, got {output_len=}, {f_len=}",
+    )
     kernel_assert(T % f_len == 0, f"T must be divisible by f_len, got {T=}, {f_len=}")
     kernel_assert((T // f_len) % 16 == 0, f"(T // f_len) must be divisible by 16, got {T // f_len}")
 
@@ -120,7 +126,9 @@ def indexed_flatten(
     partition_tile_count = div_ceil(partitions_per_row, P_MAX)
 
     # Each NC has its own private HBM buffer for partial results
-    flattened_array_partial = nl.ndarray((num_output_blocks, f_len), dtype=index_dtype, buffer=nl.private_hbm)
+    flattened_array_partial = nl.ndarray(
+        (num_output_blocks, f_len), dtype=index_dtype, buffer=nl.private_hbm
+    )
 
     """
     Tiling Strategy:
@@ -169,7 +177,9 @@ def indexed_flatten(
 
     for row_idx_local in nl.sequential_range(max_E_per_shard):
         row_offset_sb = nl.ndarray((1, 1), dtype=nl.int32, buffer=nl.sbuf)
-        nisa.dma_copy(dst=row_offset_sb, src=row_offsets_local[0:1, row_idx_local : row_idx_local + 1])
+        nisa.dma_copy(
+            dst=row_offset_sb, src=row_offsets_local[0:1, row_idx_local : row_idx_local + 1]
+        )
 
         # Clamp row_idx to valid range
         row_idx = min(row_idx_local + E_offset, E - 1)
@@ -182,7 +192,9 @@ def indexed_flatten(
                 input_tile = nl.ndarray((partition_count, f_len), dtype=index_dtype, buffer=nl.sbuf)
                 nisa.dma_copy(
                     dst=input_tile,
-                    src=input_tensor_reshape[row_idx, partition_start : partition_start + partition_count, 0:f_len],
+                    src=input_tensor_reshape[
+                        row_idx, partition_start : partition_start + partition_count, 0:f_len
+                    ],
                 )
 
                 # Use nisa.oob_mode.skip to skip writes for out-of-bounds offsets
@@ -199,10 +211,14 @@ def indexed_flatten(
 
     # All-reduce max between the two NCs
     reshaped_reload = flattened_array_partial.reshape((P_MAX, output_len // P_MAX))
-    reshaped_reload_local = nl.ndarray((P_MAX, output_len // P_MAX), dtype=index_dtype, buffer=nl.sbuf)
+    reshaped_reload_local = nl.ndarray(
+        (P_MAX, output_len // P_MAX), dtype=index_dtype, buffer=nl.sbuf
+    )
     nisa.dma_copy(dst=reshaped_reload_local, src=reshaped_reload)
 
-    reshaped_reload_remote = nl.ndarray((P_MAX, output_len // P_MAX), dtype=index_dtype, buffer=nl.sbuf)
+    reshaped_reload_remote = nl.ndarray(
+        (P_MAX, output_len // P_MAX), dtype=index_dtype, buffer=nl.sbuf
+    )
     nisa.sendrecv(
         src=reshaped_reload_local,
         dst=reshaped_reload_remote,
@@ -212,7 +228,9 @@ def indexed_flatten(
     )
 
     result_sb = nl.ndarray((P_MAX, output_len // P_MAX), dtype=index_dtype, buffer=nl.sbuf)
-    nisa.tensor_tensor(dst=result_sb, data1=reshaped_reload_local, data2=reshaped_reload_remote, op=nl.maximum)
+    nisa.tensor_tensor(
+        dst=result_sb, data1=reshaped_reload_local, data2=reshaped_reload_remote, op=nl.maximum
+    )
 
     flattened_array = nl.ndarray((output_len,), dtype=index_dtype, buffer=nl.shared_hbm)
     if shard_id == 0:

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/indexed_flatten_torch.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/indexed_flatten_torch.py
@@ -49,7 +49,9 @@ def indexed_flatten_torch_ref(
     partitions_per_row = T // f_len
     num_output_blocks = output_len // f_len
 
-    output = torch.full((output_len,), padding_val, dtype=input_tensor.dtype, device=input_tensor.device)
+    output = torch.full(
+        (output_len,), padding_val, dtype=input_tensor.dtype, device=input_tensor.device
+    )
     output_blocks = output.reshape(num_output_blocks, f_len)
     input_reshaped = input_tensor.reshape(E, partitions_per_row, f_len)
 

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/layernorm_tkg.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/layernorm_tkg.py
@@ -115,7 +115,9 @@ def layernorm_tkg(
     if not sbm:
         # Calculate required SBUF size: 16*BxS*H1 for intermediates + H0 for constants
         # Factor of 4 accounts for float32 byte size
-        sbm = SbufManager(0, (16 * BxS * H1 + H0) * 4, get_logger("layernorm_tkg"), use_auto_alloc=True)
+        sbm = SbufManager(
+            0, (16 * BxS * H1 + H0) * 4, get_logger("layernorm_tkg"), use_auto_alloc=True
+        )
 
     # Open SBUF memory scope - lv0
     sbm.open_scope(name="layernorm_tkg")
@@ -339,7 +341,9 @@ def layernorm_tkg_llama_impl(
         )
         # input_sb (H0,BxS,H1) -> (H0,BxS,lnc,H2)
         input_load_view = (
-            TensorView(input_sb).reshape_dim(dim=2, shape=[lnc, H2]).slice(dim=1, start=bs_lb, end=bs_lb + BxS)
+            TensorView(input_sb)
+            .reshape_dim(dim=2, shape=[lnc, H2])
+            .slice(dim=1, start=bs_lb, end=bs_lb + BxS)
         )
         nisa.dma_copy(
             dst=input_load_view.get_view(),
@@ -391,14 +395,18 @@ def layernorm_tkg_llama_impl(
 
     # Reduce squares along H1 dimension to compute mean(x^2)
     reduced_input_squared_sb = alloc_tensor((H0, BxS), dtype=inter_dtype, buffer=nl.sbuf)
-    nisa.tensor_reduce(dst=reduced_input_squared_sb[...], op=nl.add, data=input_squared_sb[...], axis=1)
+    nisa.tensor_reduce(
+        dst=reduced_input_squared_sb[...], op=nl.add, data=input_squared_sb[...], axis=1
+    )
     num_allocated_tensor += 1
 
     # Complete mean(x^2) calculation using matrix multiplication with 1/H constant
     if is_auto_alloc:
         input_squared_mean = nl.ndarray((H0, BxS), dtype=inter_dtype, buffer=nl.psum)
     else:  # Manual allocation: use PSUM bank 0
-        input_squared_mean = nl.ndarray((H0, BxS), dtype=inter_dtype, buffer=nl.psum, address=(0, 0))
+        input_squared_mean = nl.ndarray(
+            (H0, BxS), dtype=inter_dtype, buffer=nl.psum, address=(0, 0)
+        )
     nisa.nc_matmul(
         dst=input_squared_mean,
         stationary=reduction_const,
@@ -415,7 +423,9 @@ def layernorm_tkg_llama_impl(
     if is_auto_alloc:
         input_mean = nl.ndarray((H0, BxS), dtype=inter_dtype, buffer=nl.psum)
     else:  # Manual allocation: use PSUM bank 1
-        input_mean = nl.ndarray((H0, BxS), dtype=inter_dtype, buffer=nl.psum, address=(0, 1 * 512 * 4))
+        input_mean = nl.ndarray(
+            (H0, BxS), dtype=inter_dtype, buffer=nl.psum, address=(0, 1 * 512 * 4)
+        )
     nisa.nc_matmul(dst=input_mean, stationary=reduction_const, moving=reduced_input_sb)
 
     # Cleanup intermediate tensors if using heap allocation
@@ -489,7 +499,9 @@ def layernorm_tkg_llama_impl(
 
     # Copy final result to output buffer
     if input_in_sbuf:
-        nisa.tensor_copy(dst=result[0:H0, nl.ds(bs_lb, bs_count), 0:H1], src=input_sb_view.get_view())
+        nisa.tensor_copy(
+            dst=result[0:H0, nl.ds(bs_lb, bs_count), 0:H1], src=input_sb_view.get_view()
+        )
 
     # Cleanup: deallocate heap memory if used
     if use_heap_memory:

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/norm_tkg_utils.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/norm_tkg_utils.py
@@ -136,7 +136,10 @@ def contiguous_load_transpose(
     for bxs_tile in TiledRange(BxS, H0):
         # Load [bxs_tile.size, H] from HBM to SBUF
         input_sbuf_temp = sbm.alloc_heap(
-            (bxs_tile.size, H), dtype=input_hbm.dtype, buffer=nl.sbuf, name=f"cont_load_transpose_buff_{bxs_tile.index}"
+            (bxs_tile.size, H),
+            dtype=input_hbm.dtype,
+            buffer=nl.sbuf,
+            name=f"cont_load_transpose_buff_{bxs_tile.index}",
         )
         input_hbm_tile = input_hbm.slice(
             dim=0, start=bxs_tile.start_offset, end=bxs_tile.end_offset
@@ -144,11 +147,15 @@ def contiguous_load_transpose(
         nisa.dma_copy(src=input_hbm_tile.get_view(), dst=input_sbuf_temp, dge_mode=_DGE_MODE_NONE)
 
         # Reshape [bxs_tile.size, H] -> [bxs_tile.size, num_H_shards, H0, H2]
-        input_temp_view = TensorView(input_sbuf_temp).reshape_dim(dim=1, shape=[num_H_shards, H0, H2])
+        input_temp_view = TensorView(input_sbuf_temp).reshape_dim(
+            dim=1, shape=[num_H_shards, H0, H2]
+        )
 
         # Compute padded tile size for PSUM alignment
         padded_tile_size = (
-            div_ceil(bxs_tile.size * dtype_size, _PSUM_ALIGNMENT_BYTES) * _PSUM_ALIGNMENT_BYTES // dtype_size
+            div_ceil(bxs_tile.size * dtype_size, _PSUM_ALIGNMENT_BYTES)
+            * _PSUM_ALIGNMENT_BYTES
+            // dtype_size
         )
 
         tiles_per_psum = _psum_fmax // padded_tile_size
@@ -179,7 +186,10 @@ def contiguous_load_transpose(
                     .squeeze_dim(dim=2)
                 )
                 # Transpose [bxs_tile.size, H0] -> [H0, bxs_tile.size] in PSUM
-                nisa.nc_transpose(dst=tp_psum[0:H0, col_offset : col_offset + bxs_tile.size], data=src_view.get_view())
+                nisa.nc_transpose(
+                    dst=tp_psum[0:H0, col_offset : col_offset + bxs_tile.size],
+                    data=src_view.get_view(),
+                )
 
             # Copy PSUM -> SBUF
             dst_view = (
@@ -240,7 +250,9 @@ def load_input_to_sbuf(
             .expand_dim(dim=1)
             .expand_dim(dim=1)
         )
-        input_sb_view = input_sb.flatten_dims(start_dim=1, end_dim=2).expand_dim(dim=1).expand_dim(dim=1)
+        input_sb_view = (
+            input_sb.flatten_dims(start_dim=1, end_dim=2).expand_dim(dim=1).expand_dim(dim=1)
+        )
         nisa.dma_transpose(dst=input_sb_view.get_view(), src=input_hbm_view.get_view())
     else:
         # (BxS, H) -> (BxS, num_H_shards, H0, H2) -> (H0, BxS, num_H_shards, H2)
@@ -248,8 +260,12 @@ def load_input_to_sbuf(
             kernel_assert(sbm != None, "sbm required for contiguous load path")
             contiguous_load_transpose(input_hbm, input_sb, num_H_shards, sbm)
         else:
-            input_hbm_view = input_hbm.reshape_dim(dim=1, shape=[num_H_shards, H0, H2]).permute(dims=[2, 0, 1, 3])
-            input_sb_view = input_sb.reshape_dim(dim=2, shape=[num_H_shards, H2])  # (H0, BxS, num_H_shards, H2)
+            input_hbm_view = input_hbm.reshape_dim(dim=1, shape=[num_H_shards, H0, H2]).permute(
+                dims=[2, 0, 1, 3]
+            )
+            input_sb_view = input_sb.reshape_dim(
+                dim=2, shape=[num_H_shards, H2]
+            )  # (H0, BxS, num_H_shards, H2)
             nisa.dma_copy(
                 dst=input_sb_view.get_view(),
                 src=input_hbm_view.get_view(),
@@ -289,12 +305,16 @@ def load_gamma_to_sbuf(
     gamma_hbm = gamma_hbm.flatten_dims(start_dim=0, end_dim=1)
     if hidden_dim_tp:
         # Transpose load: (H) -> (H1, H0) -> (H0, H1)
-        gamma_hbm_view = gamma_hbm.reshape_dim(dim=0, shape=[H1, H0]).expand_dim(dim=1).expand_dim(dim=1)
+        gamma_hbm_view = (
+            gamma_hbm.reshape_dim(dim=0, shape=[H1, H0]).expand_dim(dim=1).expand_dim(dim=1)
+        )
         gamma_sb_dst_view = gamma_sb.expand_dim(dim=1).expand_dim(dim=1)
         nisa.dma_transpose(dst=gamma_sb_dst_view.get_view(), src=gamma_hbm_view.get_view())
     else:
         # Standard layout: (H) -> (num_H_shards, H0, H2) -> (H0, num_H_shards, H2)
-        gamma_hbm_view = gamma_hbm.reshape_dim(dim=0, shape=[num_H_shards, H0, H2]).permute(dims=[1, 0, 2])
+        gamma_hbm_view = gamma_hbm.reshape_dim(dim=0, shape=[num_H_shards, H0, H2]).permute(
+            dims=[1, 0, 2]
+        )
         gamma_sb_view_reshaped = gamma_sb.reshape_dim(dim=1, shape=[num_H_shards, H2])
         nisa.dma_copy(
             dst=gamma_sb_view_reshaped.get_view(),
@@ -375,12 +395,18 @@ def validate_shapes_quantize_mx(
     kernel_assert(output_shape == (H0, BxS, H1), f"Expected output.shape = {(H0, BxS, H1)}")
 
     SUPPORTED_QMX_INPUT_DTYPES = [nl.float16, nl.bfloat16]
-    kernel_assert(output_dtype in SUPPORTED_QMX_INPUT_DTYPES, "output.dtype must be float16 or bfloat16")
+    kernel_assert(
+        output_dtype in SUPPORTED_QMX_INPUT_DTYPES, "output.dtype must be float16 or bfloat16"
+    )
 
     if is_residual_add:
         kernel_assert(input_shape == residual_shape, "input and residual shapes must match")
-        kernel_assert(output_residual_shape is not None, "output_residual required when residual provided")
-        kernel_assert(output_residual_shape == (BxS, H), f"expected output_residual shape (B*S, H)={(BxS, H)}")
+        kernel_assert(
+            output_residual_shape is not None, "output_residual required when residual provided"
+        )
+        kernel_assert(
+            output_residual_shape == (BxS, H), f"expected output_residual shape (B*S, H)={(BxS, H)}"
+        )
         kernel_assert(H1 % 8 == 0, f"Expected H1 divisible by 8 with fused residual add")
         # Residual transpose requires shard_size >= 128 (with LNC=2, BxS >= 256)
         kernel_assert(BxS >= 256, f"Residual add requires BxS >= 256 (got {BxS})")

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/rmsnorm_mx_quantize_tkg.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/rmsnorm_mx_quantize_tkg.py
@@ -105,13 +105,19 @@ def rmsnorm_mx_quantize_tkg(
     # Step 2: LNC sharding setup
     _, num_shards, shard_id = get_verified_program_sharding_info("rmsnorm_mx_quantize_tkg", (0, 1))
     kernel_assert(num_shards == 2, "rmsnorm_mx_quantize_tkg kernel only supports LNC=2")
-    kernel_assert(BxS % 4 == 0, f"BxS must be divisible by 4")  # Required for LNC2 sharding alignment
+    kernel_assert(
+        BxS % 4 == 0, f"BxS must be divisible by 4"
+    )  # Required for LNC2 sharding alignment
 
     shard_size = BxS // num_shards
     BxS_offset = shard_id * shard_size
 
     # Step 3: Allocate buffers and load constants
-    residual_sb = nl.ndarray((H0, shard_size, H1), dtype=residual.dtype, buffer=nl.sbuf) if is_residual_add else None
+    residual_sb = (
+        nl.ndarray((H0, shard_size, H1), dtype=residual.dtype, buffer=nl.sbuf)
+        if is_residual_add
+        else None
+    )
     gamma_sb = nl.ndarray((H0, H1), dtype=gamma.dtype, buffer=nl.sbuf)
     zero_bias = nl.ndarray((H0, 1), dtype=inter_dtype, buffer=nl.sbuf)
     reduction_const_matrix = nl.ndarray((H0, H0), dtype=inter_dtype, buffer=nl.sbuf)
@@ -123,7 +129,9 @@ def rmsnorm_mx_quantize_tkg(
 
     # Load gamma with transpose: (1, H) -> (H) -> (H1, H0) -> (H0, H1)
     gamma_hbm = TensorView(gamma).flatten_dims(start_dim=0, end_dim=1)
-    gamma_hbm_view = gamma_hbm.reshape_dim(dim=0, shape=[H1, H0]).expand_dim(dim=1).expand_dim(dim=1)
+    gamma_hbm_view = (
+        gamma_hbm.reshape_dim(dim=0, shape=[H1, H0]).expand_dim(dim=1).expand_dim(dim=1)
+    )
     gamma_sb_view = TensorView(gamma_sb).expand_dim(dim=1).expand_dim(dim=1)
     nisa.dma_transpose(dst=gamma_sb_view.get_view(), src=gamma_hbm_view.get_view())
 
@@ -161,18 +169,25 @@ def rmsnorm_mx_quantize_tkg(
         dst: (H0, BxS_tile_size, H1) -> flatten -> (H0, 1, 1, BxS_tile_size*H1)
         """
         input_src_view = (
-            input_hbm_view.slice(dim=0, start=hbm_tile_offset, end=hbm_tile_offset + BxS_tile_size * H1)
+            input_hbm_view.slice(
+                dim=0, start=hbm_tile_offset, end=hbm_tile_offset + BxS_tile_size * H1
+            )
             .expand_dim(dim=1)
             .expand_dim(dim=1)
         )
         input_dst_view = (
-            TensorView(input_tile_sb).flatten_dims(start_dim=1, end_dim=2).expand_dim(dim=1).expand_dim(dim=1)
+            TensorView(input_tile_sb)
+            .flatten_dims(start_dim=1, end_dim=2)
+            .expand_dim(dim=1)
+            .expand_dim(dim=1)
         )
 
         if is_residual_add:
             # Transpose load residual
             residual_src_view = (
-                residual_hbm_view.slice(dim=0, start=hbm_tile_offset, end=hbm_tile_offset + BxS_tile_size * H1)
+                residual_hbm_view.slice(
+                    dim=0, start=hbm_tile_offset, end=hbm_tile_offset + BxS_tile_size * H1
+                )
                 .expand_dim(dim=1)
                 .expand_dim(dim=1)
             )
@@ -197,10 +212,17 @@ def rmsnorm_mx_quantize_tkg(
             )
 
             # Input ^2
-            nisa.activation(dst=square, op=nl.square, data=residual_sb[:, residual_tile_BxS_slice, :], bias=zero_bias)
+            nisa.activation(
+                dst=square,
+                op=nl.square,
+                data=residual_sb[:, residual_tile_BxS_slice, :],
+                bias=zero_bias,
+            )
 
             # Input * gamma (broadcast gamma across BxS_tile_size)
-            gamma_sb_view = TensorView(gamma_sb).expand_dim(dim=1).broadcast(dim=1, size=BxS_tile_size)
+            gamma_sb_view = (
+                TensorView(gamma_sb).expand_dim(dim=1).broadcast(dim=1, size=BxS_tile_size)
+            )
             nisa.tensor_tensor(
                 input_tile_sb,
                 residual_sb[:, residual_tile_BxS_slice, :],
@@ -215,7 +237,9 @@ def rmsnorm_mx_quantize_tkg(
             nisa.activation(dst=square, op=nl.square, data=input_tile_sb, bias=zero_bias)
 
             # Input * gamma (broadcast gamma across BxS_tile_size)
-            gamma_sb_view = TensorView(gamma_sb).expand_dim(dim=1).broadcast(dim=1, size=BxS_tile_size)
+            gamma_sb_view = (
+                TensorView(gamma_sb).expand_dim(dim=1).broadcast(dim=1, size=BxS_tile_size)
+            )
             nisa.tensor_tensor(
                 input_tile_sb,
                 input_tile_sb,
@@ -230,7 +254,9 @@ def rmsnorm_mx_quantize_tkg(
         nisa.nc_matmul(dst=final_reduced, stationary=reduction_const_matrix, moving=reduced)
 
         # Compute 1/sqrt(mean(x^2) + eps)
-        nisa.activation(dst=sqrt, op=nl.rsqrt, data=final_reduced, scale=(1.0 / hidden_actual), bias=eps_loaded)
+        nisa.activation(
+            dst=sqrt, op=nl.rsqrt, data=final_reduced, scale=(1.0 / hidden_actual), bias=eps_loaded
+        )
 
         # Compute input * 1/RMS(input)
         sqrt_view = TensorView(sqrt).expand_dim(dim=2).broadcast(dim=2, size=H1)
@@ -252,9 +278,13 @@ def rmsnorm_mx_quantize_tkg(
         # Quantize to MXFP8
         for h512_tile_idx in nl.sequential_range(num_H512_tiles):
             nisa.quantize_mx(
-                src=output_tile_swizzled[0:H0, h512_tile_idx : h512_tile_idx + 1, 0:BxS_tile_size, 0:_q_width],
+                src=output_tile_swizzled[
+                    0:H0, h512_tile_idx : h512_tile_idx + 1, 0:BxS_tile_size, 0:_q_width
+                ],
                 dst=output_quant[0:H0, h512_tile_idx : h512_tile_idx + 1, output_tile_BxS_slice],
-                dst_scale=output_scale[0:H0, h512_tile_idx : h512_tile_idx + 1, output_tile_BxS_slice],
+                dst_scale=output_scale[
+                    0:H0, h512_tile_idx : h512_tile_idx + 1, output_tile_BxS_slice
+                ],
             )
 
     # Step 5: Gather output_quant and output_scale across LNC cores
@@ -293,7 +323,9 @@ def rmsnorm_mx_quantize_tkg(
         AP: [[shard_size*H1, H0], [H1, tile_tokens_actual]], offset = pmax_token_tile_idx * pmax * H1 + H1_idx
         """
 
-        residual_transposed_sb = nl.ndarray((pmax, num_pmax_token_tiles, H), dtype=residual_dtype, buffer=nl.sbuf)
+        residual_transposed_sb = nl.ndarray(
+            (pmax, num_pmax_token_tiles, H), dtype=residual_dtype, buffer=nl.sbuf
+        )
         for pmax_token_tile_idx in nl.affine_range(num_pmax_token_tiles):
             tile_tokens_actual = min(pmax, shard_size - pmax_token_tile_idx * pmax)
             residual_sb_ap = [[shard_size * H1, H0], [H1, tile_tokens_actual]]
@@ -304,8 +336,12 @@ def rmsnorm_mx_quantize_tkg(
                 for h1_in_tile_idx in nl.affine_range(num_H1_per_transpose_tile):
                     H1_idx = transpose_tile_idx * num_H1_per_transpose_tile + h1_in_tile_idx
                     nisa.nc_transpose(
-                        dst=residual_transposed_tile_psum[0:tile_tokens_actual, nl.ds(h1_in_tile_idx * H0, H0)],
-                        data=residual_sb.ap(residual_sb_ap, offset=pmax_token_tile_idx * pmax * H1 + H1_idx),
+                        dst=residual_transposed_tile_psum[
+                            0:tile_tokens_actual, nl.ds(h1_in_tile_idx * H0, H0)
+                        ],
+                        data=residual_sb.ap(
+                            residual_sb_ap, offset=pmax_token_tile_idx * pmax * H1 + H1_idx
+                        ),
                     )
                 # TODO: fine tune the tensor_copy to allow both DVE and ACT engines to perform the copy
                 nisa.tensor_copy(

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/rmsnorm_tkg.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/rmsnorm_tkg.py
@@ -117,7 +117,9 @@ def rmsnorm_tkg(
         output_sb_view = output_view
     else:
         alloc_tensor = sbm.alloc_heap if use_heap_memory else sbm.alloc_stack
-        output_sb = alloc_tensor((H0, BxS, H1), dtype=input_view.dtype, buffer=nl.sbuf, name="rmsnorm_output_sb")
+        output_sb = alloc_tensor(
+            (H0, BxS, H1), dtype=input_view.dtype, buffer=nl.sbuf, name="rmsnorm_output_sb"
+        )
         output_sb_view = TensorView(output_sb)
 
     _, lnc, shard_id = get_verified_program_sharding_info("rmsnorm_tkg", (0, 1))
@@ -135,11 +137,17 @@ def rmsnorm_tkg(
 
     if not input_view.is_sbuf():
         input_view_flat = input_view.flatten_dims(start_dim=0, end_dim=1)
-        input_view_sharded = input_view_flat.slice(dim=0, start=shard_id * shard_size, end=(shard_id + 1) * shard_size)
+        input_view_sharded = input_view_flat.slice(
+            dim=0, start=shard_id * shard_size, end=(shard_id + 1) * shard_size
+        )
     else:
-        input_view_sharded = input_view.slice(dim=1, start=shard_id * shard_size, end=(shard_id + 1) * shard_size)
+        input_view_sharded = input_view.slice(
+            dim=1, start=shard_id * shard_size, end=(shard_id + 1) * shard_size
+        )
 
-    output_view_sharded = output_sb_view.slice(dim=1, start=shard_id * shard_size, end=(shard_id + 1) * shard_size)
+    output_view_sharded = output_sb_view.slice(
+        dim=1, start=shard_id * shard_size, end=(shard_id + 1) * shard_size
+    )
 
     rmsnorm_tkg_llama_impl(
         input=input_view_sharded,
@@ -173,7 +181,9 @@ def rmsnorm_tkg(
         else:
             return output.reshape((H0, BxS, H1))
 
-    output_hbm_view_sharded = output_view.slice(dim=1, start=shard_id * shard_size, end=(shard_id + 1) * shard_size)
+    output_hbm_view_sharded = output_view.slice(
+        dim=1, start=shard_id * shard_size, end=(shard_id + 1) * shard_size
+    )
 
     nisa.dma_copy(dst=output_hbm_view_sharded.get_view(), src=output_view_sharded.get_view())
 
@@ -225,13 +235,17 @@ def process_rmsnorm_tile(
     inter_dtype = nl.float32
 
     kernel_assert(
-        input_sb_view.shape == output_sb_view.shape, "Input and output tensor shapes must match for RMSNorm processing"
+        input_sb_view.shape == output_sb_view.shape,
+        "Input and output tensor shapes must match for RMSNorm processing",
     )
     H0, BxS, H1 = input_sb_view.shape
 
     # Compute x^2 for RMS calculation
     rmsnorm_square = alloc_tensor(
-        shape=(H0, BxS, H1), dtype=inter_dtype, buffer=nl.sbuf, name=f"rmsnorm_square_{bxs_tile.index}"
+        shape=(H0, BxS, H1),
+        dtype=inter_dtype,
+        buffer=nl.sbuf,
+        name=f"rmsnorm_square_{bxs_tile.index}",
     )
     num_allocated_tensor += 1
     nisa.activation(rmsnorm_square[...], op=nl.square, data=input_sb_view.get_view())
@@ -248,7 +262,10 @@ def process_rmsnorm_tile(
 
     # Apply gamma scaling: input * gamma
     gamma_mult = alloc_tensor(
-        shape=(H0, BxS, H1), dtype=inter_dtype, buffer=nl.sbuf, name=f"rmsnorm_gamma_mult_{bxs_tile.index}"
+        shape=(H0, BxS, H1),
+        dtype=inter_dtype,
+        buffer=nl.sbuf,
+        name=f"rmsnorm_gamma_mult_{bxs_tile.index}",
     )
     num_allocated_tensor += 1
     gamma_mult_view = TensorView(gamma_mult)
@@ -363,10 +380,15 @@ def rmsnorm_tkg_llama_impl(
     # Load gamma
     # if hidden_dim_tp is on, rmsnorm_gamma offset needs to be 32B aligned
     gamma_align = 32 if hidden_dim_tp else None
-    gamma_sb = alloc_tensor(shape=(H0, H1), dtype=gamma.dtype, name="rmsnorm_gamma", align=gamma_align)
+    gamma_sb = alloc_tensor(
+        shape=(H0, H1), dtype=gamma.dtype, name="rmsnorm_gamma", align=gamma_align
+    )
     num_allocated_tensor += 1
     gamma_sb_view = load_gamma_to_sbuf(
-        gamma_hbm=gamma, gamma_sb=TensorView(gamma_sb), num_H_shards=num_H_shards, hidden_dim_tp=hidden_dim_tp
+        gamma_hbm=gamma,
+        gamma_sb=TensorView(gamma_sb),
+        num_H_shards=num_H_shards,
+        hidden_dim_tp=hidden_dim_tp,
     )
 
     # Load eps

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/allocator.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/allocator.py
@@ -120,12 +120,14 @@ class SbufManager(nl.NKIObject):
 
         # Log initialization
         total_size = sb_upper_bound - sb_lower_bound
-        self.logger.info(f"SBM initialized: range=[{sb_lower_bound}, {sb_upper_bound}), size={total_size} B")
+        self.logger.info(
+            f"SBM initialized: range=[{sb_lower_bound}, {sb_upper_bound}), size={total_size} B"
+        )
         self.logger.debug(
             f"SBM config: auto_alloc={use_auto_alloc}, default_stack={default_stack_alloc}, "
             f"stack_start={sb_lower_bound}, heap_start={sb_upper_bound}"
         )
-        self.prefix = ''
+        self.prefix = ""
 
     def _get_prefixed_name(self, name):
         """Apply prefix to tensor name."""
@@ -207,7 +209,9 @@ class SbufManager(nl.NKIObject):
         if top_scope.cur_section_id == top_scope.num_sections:
             top_scope.cur_section_id = 0
             self.stack_curr_addr = top_scope.starting_addr
-            self.tree_logger.log(f"↻ section: 0/{top_scope.num_sections} @ {self.stack_curr_addr}", len(self.scopes))
+            self.tree_logger.log(
+                f"↻ section: 0/{top_scope.num_sections} @ {self.stack_curr_addr}", len(self.scopes)
+            )
         else:
             self.tree_logger.log(
                 f"↳ section: {top_scope.cur_section_id}/{top_scope.num_sections} @ {self.stack_curr_addr}",
@@ -223,7 +227,9 @@ class SbufManager(nl.NKIObject):
         self.stack_curr_addr = closing_scope.starting_addr
         self.scopes.pop()
         scope_name = f"'{closing_scope.name}'" if closing_scope.name else "(unnamed)"
-        self.tree_logger.log(f"◀ END {scope_name} freed={freed_bytes} B", len(self.scopes), is_scope_boundary=True)
+        self.tree_logger.log(
+            f"◀ END {scope_name} freed={freed_bytes} B", len(self.scopes), is_scope_boundary=True
+        )
         # Auto-flush when last scope is closed
         if not self.scopes:
             self.tree_logger.flush()
@@ -279,9 +285,14 @@ class SbufManager(nl.NKIObject):
         N = num_elts(shape[1:])
         bytes_per_partition = N * sizeinbytes(dtype)
 
-        if not self.is_auto_alloc() and self.stack_curr_addr + bytes_per_partition > self.heap_curr_addr:
+        if (
+            not self.is_auto_alloc()
+            and self.stack_curr_addr + bytes_per_partition > self.heap_curr_addr
+        ):
             available = self.heap_curr_addr - self.stack_curr_addr
-            self.logger.error(f"Stack OOM: requested={bytes_per_partition} B, available={available} B")
+            self.logger.error(
+                f"Stack OOM: requested={bytes_per_partition} B, available={available} B"
+            )
             self.logger.debug(
                 f"Allocation failure: name={name}, shape={shape}, dtype={dtype}, size={bytes_per_partition} B, "
                 f"stack_addr={self.stack_curr_addr}, heap_addr={self.heap_curr_addr}, "
@@ -315,7 +326,8 @@ class SbufManager(nl.NKIObject):
         self.total_stack_allocs = self.total_stack_allocs + 1
         self._update_stats()
         self.tree_logger.log(
-            f"{tensor_name or '(unnamed)'}: {bytes_per_partition} B @ {addr_start} {shape} {dtype}", len(self.scopes)
+            f"{tensor_name or '(unnamed)'}: {bytes_per_partition} B @ {addr_start} {shape} {dtype}",
+            len(self.scopes),
         )
         self.logger.debug(
             f"Stack allocation: name={name}, shape={shape}, dtype={dtype}, size={bytes_per_partition} B, "
@@ -343,9 +355,14 @@ class SbufManager(nl.NKIObject):
         N = num_elts(shape[1:])
         bytes_per_partition = N * sizeinbytes(dtype)
 
-        if not self.is_auto_alloc() and self.stack_curr_addr + bytes_per_partition > self.heap_curr_addr:
+        if (
+            not self.is_auto_alloc()
+            and self.stack_curr_addr + bytes_per_partition > self.heap_curr_addr
+        ):
             available = self.heap_curr_addr - self.stack_curr_addr
-            self.logger.error(f"Heap OOM: requested={bytes_per_partition} B, available={available} B")
+            self.logger.error(
+                f"Heap OOM: requested={bytes_per_partition} B, available={available} B"
+            )
             self.logger.debug(
                 f"Allocation failure: name={name}, shape={shape}, dtype={dtype}, size={bytes_per_partition} B, "
                 f"stack_addr={self.stack_curr_addr}, heap_addr={self.heap_curr_addr}, "
@@ -359,7 +376,9 @@ class SbufManager(nl.NKIObject):
             self.heap_curr_addr = align_to(self.heap_curr_addr, align)
         base_addr = self.heap_curr_addr - bytes_per_partition
         self.heap_curr_addr -= bytes_per_partition
-        self.heap_curr_addr = align_to(self.heap_curr_addr - 3, 4)  # heap grows down, so should the align
+        self.heap_curr_addr = align_to(
+            self.heap_curr_addr - 3, 4
+        )  # heap grows down, so should the align
 
         tensor_name = self._get_prefixed_name(name)
         if self.use_auto_alloc:
@@ -403,7 +422,8 @@ class SbufManager(nl.NKIObject):
         self.heap.pop()
         self.heap_names.pop()
         self.tree_logger.log(
-            f"[HEAP-] FREE {heap_name}: {bytes_per_partition} B, remaining={len(self.heap)}", len(self.scopes)
+            f"[HEAP-] FREE {heap_name}: {bytes_per_partition} B, remaining={len(self.heap)}",
+            len(self.scopes),
         )
 
     def get_total_space(self):

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/interleave_copy.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/interleave_copy.py
@@ -64,7 +64,8 @@ def interleave_copy(
         )
     if bias is not None:
         kernel_assert(
-            dst.shape[0] == src.shape[0] == bias.shape[0], f"Partition dimension must match across dst, src, and bias."
+            dst.shape[0] == src.shape[0] == bias.shape[0],
+            f"Partition dimension must match across dst, src, and bias.",
         )
 
     # Pure copy operation
@@ -78,7 +79,9 @@ def interleave_copy(
     # Both scale and bias present with vector shapes - use activation engine when possible
     if use_activation_scale and use_activation_bias:
         if use_even_engine:
-            nisa.activation(dst=dst, data=src, scale=scale.get_view(), bias=bias.get_view(), op=nl.copy)
+            nisa.activation(
+                dst=dst, data=src, scale=scale.get_view(), bias=bias.get_view(), op=nl.copy
+            )
         else:
             # Vector engine: broadcast and apply operations sequentially
             scale = scale.broadcast(dim=1, size=src.shape[-1])

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/kernel_assert.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/kernel_assert.py
@@ -14,7 +14,9 @@
 
 
 def kernel_assert(condition: bool, error_text: str):
-    assert condition, f"[INTERNAL_ERROR] [NCC_INKI016] Kernel validation exception: {error_text} - Please check the validation message and adjust kernel inputs accordingly"  # noqa: S101
+    assert condition, (
+        f"[INTERNAL_ERROR] [NCC_INKI016] Kernel validation exception: {error_text} - Please check the validation message and adjust kernel inputs accordingly"
+    )  # noqa: S101
 
 
 def assert_shape(tensor, expected_shape, tensor_name, error_text=""):

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/kernel_helpers.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/kernel_helpers.py
@@ -337,7 +337,9 @@ def get_verified_program_sharding_info(
         return (grid_ndim, n_prgs, prg_id)
     """
     grid_ndim, n_prgs, prg_id = get_program_sharding_info()
-    ndim_check = allowed_ndims is None or (grid_ndim == allowed_ndims[0] if len(allowed_ndims) == 1 else False)
+    ndim_check = allowed_ndims is None or (
+        grid_ndim == allowed_ndims[0] if len(allowed_ndims) == 1 else False
+    )
     return grid_ndim, n_prgs, prg_id
 
 
@@ -394,7 +396,7 @@ def get_max_positive_value_for_dtype(dtype) -> float:
     return result
 
 
-def reduce(op='mul', input: List = None, initial_value=None):
+def reduce(op="mul", input: List = None, initial_value=None):
     """
     Perform reduction operation on a list of values.
 
@@ -432,15 +434,15 @@ def reduce(op='mul', input: List = None, initial_value=None):
     """
     kernel_assert(initial_value is not None, f"initial_value need to set")
     kernel_assert(input is not None, f"input need to be set")
-    kernel_assert(op in ['mul', 'add', 'max', 'min'], f"only op {op} is supported")
+    kernel_assert(op in ["mul", "add", "max", "min"], f"only op {op} is supported")
     for value in input:
-        if op == 'mul':
+        if op == "mul":
             initial_value = initial_value * value
-        elif op == 'add':
+        elif op == "add":
             initial_value = initial_value + value
-        elif op == 'min':
+        elif op == "min":
             initial_value = min(initial_value, value)
-        elif op == 'max':
+        elif op == "max":
             initial_value = max(initial_value, value)
     return initial_value
 
@@ -463,32 +465,32 @@ def resolve_dtype_to_nki(dtype):
         return result
     """
     dtype_str = str(dtype)
-    if dtype_str == 'bool':
+    if dtype_str == "bool":
         return nl.bool
-    elif dtype_str == 'int8':
+    elif dtype_str == "int8":
         return nl.int8
-    elif dtype_str == 'int16':
+    elif dtype_str == "int16":
         return nl.int16
-    elif dtype_str == 'int32':
+    elif dtype_str == "int32":
         return nl.int32
-    elif dtype_str == 'uint8':
+    elif dtype_str == "uint8":
         return nl.uint8
-    elif dtype_str == 'uint16':
+    elif dtype_str == "uint16":
         return nl.uint16
-    elif dtype_str == 'uint32':
+    elif dtype_str == "uint32":
         return nl.uint32
-    elif dtype_str == 'float16':
+    elif dtype_str == "float16":
         return nl.float16
-    elif dtype_str == 'float32':
+    elif dtype_str == "float32":
         return nl.float32
-    elif dtype_str == 'bfloat16':
+    elif dtype_str == "bfloat16":
         return nl.bfloat16
-    elif dtype_str == 'float8_e4m3':
+    elif dtype_str == "float8_e4m3":
         return nl.float8_e4m3
-    elif dtype_str in ['float8_e4m3fn', 'float8e4']:
+    elif dtype_str in ["float8_e4m3fn", "float8e4"]:
         # TODO: switch to nisa.get_nc_version() >= nki.isa.nc_version.gen4 after the comparison support
         return nl.float8_e4m3fn if nisa.get_nc_version() == nisa.nc_version.gen4 else nl.float8_e4m3
-    elif dtype_str in ['float8_e5m2', 'float8e5']:
+    elif dtype_str in ["float8_e5m2", "float8e5"]:
         return nl.float8_e5m2
     elif dtype_str == str(nl.float4_e2m1fn_x4):
         return nl.float4_e2m1fn_x4
@@ -496,4 +498,4 @@ def resolve_dtype_to_nki(dtype):
         return nl.float8_e4m3fn_x4
     elif dtype_str == str(nl.float8_e5m2_x4):
         return nl.float8_e5m2_x4
-    kernel_assert(False, f'Unrecognized dtype {dtype_str}')
+    kernel_assert(False, f"Unrecognized dtype {dtype_str}")

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/lnc_subscriptable.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/lnc_subscriptable.py
@@ -72,7 +72,9 @@ def _verify_protocol_sync(func: Callable, protocol: TorchRefProtocolType):
     )
 
     for (fn, fp), (pn, pp) in zip(func_params, protocol_params):
-        kernel_assert(fn == pn, f"Parameter name mismatch: function has '{fn}', Protocol has '{pn}'")
+        kernel_assert(
+            fn == pn, f"Parameter name mismatch: function has '{fn}', Protocol has '{pn}'"
+        )
         kernel_assert(
             fp.annotation == pp.annotation,
             f"Parameter '{fn}' annotation mismatch: function has {fp.annotation}, Protocol has {pp.annotation}",
@@ -129,7 +131,9 @@ def _extract_var_docstring(source: str, var_name: str) -> str | None:
             if node.target.id == var_name:
                 if i + 1 < len(tree.body):
                     next_node = tree.body[i + 1]
-                    if isinstance(next_node, ast.Expr) and isinstance(next_node.value, ast.Constant):
+                    if isinstance(next_node, ast.Expr) and isinstance(
+                        next_node.value, ast.Constant
+                    ):
                         if isinstance(next_node.value.value, str):
                             return next_node.value.value
     return None

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tensor_view.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tensor_view.py
@@ -237,7 +237,10 @@ class TensorView(nl.NKIObject):
 
         # Validate strides are non-negative (required for valid memory access)
         for i in range(len(view.strides)):
-            kernel_assert(view.strides[i] >= 0, f"Stride at dimension {i} must be non-negative, got {view.strides[i]}")
+            kernel_assert(
+                view.strides[i] >= 0,
+                f"Stride at dimension {i} must be non-negative, got {view.strides[i]}",
+            )
         # Ensure all dimension metadata is consistent
         kernel_assert(len(view.shape) == len(view.strides), "Dimension count mismatch")
         kernel_assert(view.offset >= 0, "Offset must be non-negative")
@@ -304,7 +307,9 @@ class TensorView(nl.NKIObject):
         Raises:
             AssertionError: If slice parameters are invalid
         """
-        kernel_assert(dim < self.get_dim(), f"Dimension {dim} out of range for {self.get_dim()}D tensor")
+        kernel_assert(
+            dim < self.get_dim(), f"Dimension {dim} out of range for {self.get_dim()}D tensor"
+        )
         if self.vector_offset is not None:
             kernel_assert(dim != 0, "Cannot slice vector_select dim (dim 0)")
         kernel_assert(start >= 0, "Start index must be non-negative")
@@ -332,13 +337,23 @@ class TensorView(nl.NKIObject):
 
     @staticmethod
     def validate_permutation(permutation: Tuple[int, ...], dim: int, is_sbuf: bool) -> None:
-        kernel_assert(len(permutation) == dim, f"Permutation length {len(permutation)} != dimension count {dim}")
+        kernel_assert(
+            len(permutation) == dim,
+            f"Permutation length {len(permutation)} != dimension count {dim}",
+        )
         for i in range(dim):
-            kernel_assert(permutation[i] < dim, f"Permutation index {permutation[i]} >= dimension count {dim}")
-            kernel_assert(permutation[i] >= 0, f"Permutation index {permutation[i]} must be non-negative")
+            kernel_assert(
+                permutation[i] < dim, f"Permutation index {permutation[i]} >= dimension count {dim}"
+            )
+            kernel_assert(
+                permutation[i] >= 0, f"Permutation index {permutation[i]} must be non-negative"
+            )
             # Check for duplicates
             for j in range(i):
-                kernel_assert(permutation[i] != permutation[j], f"Duplicate dimension {permutation[i]} in permutation")
+                kernel_assert(
+                    permutation[i] != permutation[j],
+                    f"Duplicate dimension {permutation[i]} in permutation",
+                )
         if is_sbuf:
             kernel_assert(permutation[0] == 0, "Partition dimension stay the outermost dimension")
 
@@ -360,7 +375,9 @@ class TensorView(nl.NKIObject):
         # Reorder shape and strides according to permutation
         for i in range(len(dims)):
             d = dims[i]
-            kernel_assert(d < self.get_dim(), "Dimension index out of range")  # Additional safety check
+            kernel_assert(
+                d < self.get_dim(), "Dimension index out of range"
+            )  # Additional safety check
             new_shape.append(self.shape[d])
             new_strides.append(self.strides[d])
 
@@ -379,11 +396,16 @@ class TensorView(nl.NKIObject):
             Broadcasting sets stride to 0, so the same element is repeated
         """
         kernel_assert(dim < self.get_dim(), f"Dimension {dim} out of range")
-        kernel_assert(self.shape[dim] == 1, f"Can only broadcast size-1 dimensions, got size {self.shape[dim]}")
+        kernel_assert(
+            self.shape[dim] == 1,
+            f"Can only broadcast size-1 dimensions, got size {self.shape[dim]}",
+        )
         if self.vector_offset is not None:
             kernel_assert(dim != 0, "Cannot broadcast vector_select dim (dim 0)")
         if self.is_sbuf():
-            kernel_assert(dim != 0, "Cannot broadcast on partition dimension (dim=0) for SBUF tensors")
+            kernel_assert(
+                dim != 0, "Cannot broadcast on partition dimension (dim=0) for SBUF tensors"
+            )
         new_shape = []
         new_strides = []
         for i in range(self.get_dim()):
@@ -454,7 +476,9 @@ class TensorView(nl.NKIObject):
         size_prod = 1
         for i in range(len(shape)):
             size_prod *= shape[i]
-        kernel_assert(self.shape[dim] == size_prod, f"Size mismatch: {self.shape[dim]} != {size_prod}")
+        kernel_assert(
+            self.shape[dim] == size_prod, f"Size mismatch: {self.shape[dim]} != {size_prod}"
+        )
 
         # Build new shape by replacing the target dimension
         if self.get_dim() > 1:
@@ -464,7 +488,9 @@ class TensorView(nl.NKIObject):
 
         # Compute strides for the reshaped dimensions
         reshaped_strides = TensorView.get_trivial_strides(shape, base_stride=self.strides[dim])
-        new_strides = tuple(list(self.strides[:dim]) + list(reshaped_strides) + list(self.strides[dim + 1 :]))
+        new_strides = tuple(
+            list(self.strides[:dim]) + list(reshaped_strides) + list(self.strides[dim + 1 :])
+        )
 
         return self._copy(shape=new_shape, strides=new_strides)
 
@@ -492,7 +518,7 @@ class TensorView(nl.NKIObject):
         for i in range(start_dim, end_dim):
             kernel_assert(
                 self.strides[i] == self.shape[i + 1] * self.strides[i + 1],
-                f"Dimensions {i} and {i+1} are not contiguous in memory",
+                f"Dimensions {i} and {i + 1} are not contiguous in memory",
             )
 
         # Calculate total size of flattened dimension
@@ -501,9 +527,13 @@ class TensorView(nl.NKIObject):
             flattened_size *= self.shape[i]
 
         # Build new shape and strides
-        new_shape = tuple(list(self.shape[:start_dim]) + [flattened_size] + list(self.shape[end_dim + 1 :]))
+        new_shape = tuple(
+            list(self.shape[:start_dim]) + [flattened_size] + list(self.shape[end_dim + 1 :])
+        )
         new_strides = tuple(
-            list(self.strides[:start_dim]) + [self.strides[end_dim]] + list(self.strides[end_dim + 1 :])
+            list(self.strides[:start_dim])
+            + [self.strides[end_dim]]
+            + list(self.strides[end_dim + 1 :])
         )
 
         return self._copy(shape=new_shape, strides=new_strides)
@@ -544,7 +574,9 @@ class TensorView(nl.NKIObject):
             for shape [X,1,Y,Z] and parameters (dim=1) we will get a shape of [X,Y,Z]
         """
         kernel_assert(dim < self.get_dim(), f"Dimension {dim} out of range")
-        kernel_assert(self.shape[dim] == 1, f"Can only squeeze size-1 dimensions, got size {self.shape[dim]}")
+        kernel_assert(
+            self.shape[dim] == 1, f"Can only squeeze size-1 dimensions, got size {self.shape[dim]}"
+        )
         if self.vector_offset is not None:
             kernel_assert(dim != 0, "Cannot squeeze vector_select dim (dim 0)")
         if self.is_sbuf():
@@ -572,7 +604,9 @@ class TensorView(nl.NKIObject):
             New TensorView with dynamic indexing configured
         """
         kernel_assert(self.indirect_dim is None, "Cannot have multiple dynamic selects")
-        kernel_assert(self.strides[dim] != 0, "Cannot dynamic select on broadcast dimension (stride=0)")
+        kernel_assert(
+            self.strides[dim] != 0, "Cannot dynamic select on broadcast dimension (stride=0)"
+        )
 
         view_stride = self.strides[dim]
         base_tensor, base_dim = self._find_or_create_base_dim_for_stride(view_stride)
@@ -582,7 +616,11 @@ class TensorView(nl.NKIObject):
         new_strides = self.strides[:dim] + self.strides[dim + 1 :]
 
         return self._copy(
-            shape=new_shape, strides=new_strides, scalar_offset=index, indirect_dim=base_dim, base_tensor=base_tensor
+            shape=new_shape,
+            strides=new_strides,
+            scalar_offset=index,
+            indirect_dim=base_dim,
+            base_tensor=base_tensor,
         )
 
     def vector_select(self, dim: int, vector_offset: nl.ndarray) -> "TensorView":
@@ -603,7 +641,9 @@ class TensorView(nl.NKIObject):
         kernel_assert(dim == 0, "vector_select currently only supports dim=0")
         kernel_assert(self.indirect_dim is None, "Cannot have multiple dynamic selects")
         kernel_assert(self.scalar_offset is None, "Cannot combine vector_select with scalar_offset")
-        kernel_assert(self.strides[dim] != 0, "Cannot vector_select on broadcast dimension (stride=0)")
+        kernel_assert(
+            self.strides[dim] != 0, "Cannot vector_select on broadcast dimension (stride=0)"
+        )
         for i in range(len(self.strides)):
             kernel_assert(
                 self.strides[dim] >= self.strides[i],
@@ -658,7 +698,9 @@ class TensorView(nl.NKIObject):
                 can_split = base_shape[i] >= split_factor and base_shape[i] % split_factor == 0
                 if can_split:
                     outer_size = base_shape[i] // split_factor
-                    new_base_shape = tuple(base_shape[:i] + [outer_size, split_factor] + base_shape[i + 1 :])
+                    new_base_shape = tuple(
+                        base_shape[:i] + [outer_size, split_factor] + base_shape[i + 1 :]
+                    )
                     return self.base_tensor.reshape(new_base_shape), i
 
         kernel_assert(False, f"Cannot create base dim with stride {view_stride}")
@@ -711,7 +753,7 @@ class TensorView(nl.NKIObject):
                         shape.append(fixed_sizes[src_pattern[i][j]])
                     else:
                         shape.append(-1)
-                src_reshapes.append({'dim': i + dim_offset, 'shape': tuple(shape)})
+                src_reshapes.append({"dim": i + dim_offset, "shape": tuple(shape)})
                 dim_offset += len(shape) - 1
         return src_reshapes
 
@@ -729,7 +771,12 @@ class TensorView(nl.NKIObject):
         dim_offset = 0
         for i in range(len(dst_pattern)):
             if isinstance(dst_pattern[i], tuple):
-                dst_flattens.append({'start_dim': i + dim_offset, 'end_dim': i + dim_offset + len(dst_pattern[i]) - 1})
+                dst_flattens.append(
+                    {
+                        "start_dim": i + dim_offset,
+                        "end_dim": i + dim_offset + len(dst_pattern[i]) - 1,
+                    }
+                )
                 dim_offset += len(dst_pattern[i]) - 1
         return dst_flattens
 
@@ -753,7 +800,9 @@ class TensorView(nl.NKIObject):
         return tuple(ret)
 
     @staticmethod
-    def _rearrange_get_permutation(src_pattern: Tuple[str], dst_pattern: Tuple[str]) -> Tuple[int, ...]:
+    def _rearrange_get_permutation(
+        src_pattern: Tuple[str], dst_pattern: Tuple[str]
+    ) -> Tuple[int, ...]:
         """Calculate permutation indices to reorder dimensions from source to destination pattern.
 
         Args:
@@ -803,10 +852,10 @@ class TensorView(nl.NKIObject):
 
         t = self._copy()
         for reshape in src_reshapes:
-            t = t.reshape_dim(reshape['dim'], reshape['shape'])
+            t = t.reshape_dim(reshape["dim"], reshape["shape"])
         t = t.permute(permutation)
         for flatten in dst_flattens:
-            t = t.flatten_dims(flatten['start_dim'], flatten['end_dim'])
+            t = t.flatten_dims(flatten["start_dim"], flatten["end_dim"])
         return t
 
     @staticmethod
@@ -872,7 +921,8 @@ class TensorView(nl.NKIObject):
             size = filtered_shape[i]
             j = i
             while (
-                j + 1 < len(filtered_shape) and filtered_strides[j] == filtered_strides[j + 1] * filtered_shape[j + 1]
+                j + 1 < len(filtered_shape)
+                and filtered_strides[j] == filtered_strides[j + 1] * filtered_shape[j + 1]
             ):
                 j += 1
                 size *= filtered_shape[j]
@@ -938,9 +988,15 @@ class TensorView(nl.NKIObject):
         #   1. Remove unit dims — strip size-1 dims whose strides are irrelevant
         #   2. Collapse contiguous — merge adjacent dims with contiguous strides into blocks
         #   3. Repartition — assign new strides by splitting/merging blocks to match new_shape
-        filtered_shape, filtered_strides = TensorView._reshape_remove_unit_dims(self.shape, self.strides, is_hbm)
-        blocks = TensorView._reshape_collapse_contiguous_blocks(filtered_shape, filtered_strides, is_hbm)
-        new_strides = TensorView._reshape_repartition_blocks(blocks, self.shape, self.strides, new_shape)
+        filtered_shape, filtered_strides = TensorView._reshape_remove_unit_dims(
+            self.shape, self.strides, is_hbm
+        )
+        blocks = TensorView._reshape_collapse_contiguous_blocks(
+            filtered_shape, filtered_strides, is_hbm
+        )
+        new_strides = TensorView._reshape_repartition_blocks(
+            blocks, self.shape, self.strides, new_shape
+        )
         return self._copy(shape=new_shape, strides=new_strides)
 
     def has_dynamic_access(self) -> bool:

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tile_info.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tile_info.py
@@ -33,7 +33,9 @@ class TiledDimInfo(NKIObject):
     """
 
     @staticmethod
-    def build(tiled_dim_size: int, tile_size: int, subtile_info: "TiledDimInfo" = None) -> "TiledDimInfo":
+    def build(
+        tiled_dim_size: int, tile_size: int, subtile_info: "TiledDimInfo" = None
+    ) -> "TiledDimInfo":
         tile_count = get_ceil_quotient(tiled_dim_size, tile_size)
         return TiledDimInfo(tiled_dim_size, tile_size, tile_count, subtile_info)
 
@@ -54,7 +56,9 @@ class TiledDimInfo(NKIObject):
 
     # Build a subtiled version
     @staticmethod
-    def build_with_subtiling(tiled_dim_size: int, tile_size: int, subtile_size: int) -> "TiledDimInfo":
+    def build_with_subtiling(
+        tiled_dim_size: int, tile_size: int, subtile_size: int
+    ) -> "TiledDimInfo":
         subtiled_dim_info = TiledDimInfo.build(tile_size, subtile_size)
         return TiledDimInfo.build(tiled_dim_size, tile_size, subtiled_dim_info)
 

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tiled_range.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tiled_range.py
@@ -55,7 +55,9 @@ class TiledRangeIterator(NKIObject):
         return f"TiledRangeIterator(size={self.size}, index={self.index}, start_offset={self.start_offset}, end_offset={self.end_offset})"
 
 
-def TiledRange(size: Union[int, TiledRangeIterator], tile_size: int) -> Tuple[TiledRangeIterator, ...]:
+def TiledRange(
+    size: Union[int, TiledRangeIterator], tile_size: int
+) -> Tuple[TiledRangeIterator, ...]:
     """
     Divides a dimension into tiles and returns a tuple of TiledRangeIterators.
 

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv run ruff check --select I src tests
+uv run ruff format --check src tests

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-uv run ruff check --select I src tests
-uv run ruff format --check src tests
+targets=(src tests examples resources)
+
+uv run ruff check --select I "${targets[@]}"
+uv run ruff format --check "${targets[@]}"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-uv run ruff check --select I --fix src tests
-uv run ruff format src tests
+targets=(src tests examples resources)
+
+uv run ruff check --select I --fix "${targets[@]}"
+uv run ruff format "${targets[@]}"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv run ruff check --select I --fix src tests
+uv run ruff format src tests

--- a/src/vibe_serve/_agent_cli/base.py
+++ b/src/vibe_serve/_agent_cli/base.py
@@ -52,9 +52,7 @@ class CodingAgent(ABC):
             Generated text.
         """
 
-    def install_mcp_servers(
-        self, workspace: Path, servers: list[MCPServerSpec]
-    ) -> None:
+    def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
         """Install per-agent MCP server config so the next :meth:`generate`
         call exposes these stdio servers as tools.
 
@@ -65,9 +63,7 @@ class CodingAgent(ABC):
         """
         return None
 
-    def uninstall_mcp_servers(
-        self, workspace: Path, servers: list[MCPServerSpec]
-    ) -> None:
+    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
         """Remove anything written by :meth:`install_mcp_servers`.
 
         Idempotent. Default implementation is a no-op.

--- a/src/vibe_serve/_agent_cli/claude.py
+++ b/src/vibe_serve/_agent_cli/claude.py
@@ -59,7 +59,8 @@ class ClaudeCodeCodingAgent(CLICodingAgent):
     def _get_resume_command(self, prompt: str, session_id: str) -> list[str]:
         cmd = [
             self.binary_path,
-            "--resume", session_id,
+            "--resume",
+            session_id,
             "-p",  # Print mode, reads prompt from stdin
             "--dangerously-skip-permissions",
             "--output-format",
@@ -93,9 +94,7 @@ class ClaudeCodeCodingAgent(CLICodingAgent):
             executor=self.executor,
         )
 
-    def install_mcp_servers(
-        self, workspace: Path, servers: list[MCPServerSpec]
-    ) -> None:
+    def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
         """Write ``<workspace>/.mcp.json`` so Claude Code auto-discovers
         the MCP servers from cwd."""
         config: dict[str, Any] = {
@@ -108,13 +107,9 @@ class ClaudeCodeCodingAgent(CLICodingAgent):
                 for s in servers
             }
         }
-        (workspace / ".mcp.json").write_text(
-            json.dumps(config, indent=2), encoding="utf-8"
-        )
+        (workspace / ".mcp.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
 
-    def uninstall_mcp_servers(
-        self, workspace: Path, servers: list[MCPServerSpec]
-    ) -> None:
+    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
         """Remove ``<workspace>/.mcp.json``. Idempotent and tolerant of
         files written from inside Docker (root-owned)."""
         target = workspace / ".mcp.json"

--- a/src/vibe_serve/_agent_cli/cli_agent.py
+++ b/src/vibe_serve/_agent_cli/cli_agent.py
@@ -2,8 +2,13 @@ import sys
 from abc import abstractmethod
 from typing import Any
 
-from agentshim.executor import CallbackCommandStreamSink, CommandExecutor, CommandRequest, HostCommandExecutor
 from agentshim.events import AgentEventHandler
+from agentshim.executor import (
+    CallbackCommandStreamSink,
+    CommandExecutor,
+    CommandRequest,
+    HostCommandExecutor,
+)
 from agentshim.utils import get_interactive_env
 from loguru import logger
 
@@ -121,8 +126,7 @@ class CLIGenerationSession:
 
         if result.returncode != 0:
             raise RuntimeError(
-                f"{self.binary_name} exited with code {result.returncode}: "
-                f"{result.stderr}"
+                f"{self.binary_name} exited with code {result.returncode}: {result.stderr}"
             )
 
         return "".join(self.stdout_lines).strip()

--- a/src/vibe_serve/_agent_cli/codex.py
+++ b/src/vibe_serve/_agent_cli/codex.py
@@ -61,7 +61,8 @@ class CodexCodingAgent(CLICodingAgent):
 
     def _get_command(self, prompt: str) -> list[str]:
         cmd = [
-            self.binary_path, "exec",
+            self.binary_path,
+            "exec",
             "--dangerously-bypass-approvals-and-sandbox",
             "--skip-git-repo-check",
             "--json",
@@ -81,7 +82,11 @@ class CodexCodingAgent(CLICodingAgent):
         # stdin is actually consumed. (``codex exec`` is more lenient and
         # treats stdin as the default fallback, so we don't need this there.)
         cmd = [
-            self.binary_path, "exec", "resume", session_id, "-",
+            self.binary_path,
+            "exec",
+            "resume",
+            session_id,
+            "-",
             "--dangerously-bypass-approvals-and-sandbox",
             "--skip-git-repo-check",
             "--json",
@@ -111,9 +116,7 @@ class CodexCodingAgent(CLICodingAgent):
     def _extract_session_id(self, session: CodexGenerationSession) -> str | None:
         return session.session_id
 
-    def install_mcp_servers(
-        self, workspace: Path, servers: list[MCPServerSpec]
-    ) -> None:
+    def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
         """Stash ``--config mcp_servers.<name>.<key>=<value>`` flags on the
         instance for the next ``codex exec`` invocation.
 
@@ -147,8 +150,6 @@ class CodexCodingAgent(CLICodingAgent):
                 )
         self.extra_config_args = flags
 
-    def uninstall_mcp_servers(
-        self, workspace: Path, servers: list[MCPServerSpec]
-    ) -> None:
+    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
         """Clear the runtime ``--config`` flags. Idempotent."""
         self.extra_config_args = []

--- a/src/vibe_serve/_agent_cli/gemini.py
+++ b/src/vibe_serve/_agent_cli/gemini.py
@@ -77,9 +77,7 @@ class GeminiCodingAgent(CLICodingAgent):
             executor=self.executor,
         )
 
-    def install_mcp_servers(
-        self, workspace: Path, servers: list[MCPServerSpec]
-    ) -> None:
+    def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
         """Write ``<workspace>/.gemini/settings.json`` so Gemini CLI
         auto-discovers the MCP servers from cwd. ``trust: true`` skips
         Gemini's per-tool approval prompts for these servers."""
@@ -96,13 +94,9 @@ class GeminiCodingAgent(CLICodingAgent):
                 for s in servers
             }
         }
-        (gemini_dir / "settings.json").write_text(
-            json.dumps(config, indent=2), encoding="utf-8"
-        )
+        (gemini_dir / "settings.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
 
-    def uninstall_mcp_servers(
-        self, workspace: Path, servers: list[MCPServerSpec]
-    ) -> None:
+    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
         """Remove ``<workspace>/.gemini/settings.json``. Leaves the
         ``.gemini/`` directory itself in place because Gemini also writes
         session data into it (e.g. ``.gemini/tmp/``)."""

--- a/src/vibe_serve/_agent_cli/opencode.py
+++ b/src/vibe_serve/_agent_cli/opencode.py
@@ -73,9 +73,7 @@ class OpencodeCodingAgent(CLICodingAgent):
             executor=self.executor,
         )
 
-    def install_mcp_servers(
-        self, workspace: Path, servers: list[MCPServerSpec]
-    ) -> None:
+    def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
         """Write ``<workspace>/opencode.json`` so opencode auto-discovers
         the MCP servers from cwd. opencode uses the ``mcp`` key (not
         ``mcpServers``) and a single combined ``command`` array. Non-
@@ -93,13 +91,9 @@ class OpencodeCodingAgent(CLICodingAgent):
                 for s in servers
             },
         }
-        (workspace / "opencode.json").write_text(
-            json.dumps(config, indent=2), encoding="utf-8"
-        )
+        (workspace / "opencode.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
 
-    def uninstall_mcp_servers(
-        self, workspace: Path, servers: list[MCPServerSpec]
-    ) -> None:
+    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
         """Remove ``<workspace>/opencode.json``. Idempotent."""
         target = workspace / "opencode.json"
         if target.exists():

--- a/src/vibe_serve/_model_config/_core.py
+++ b/src/vibe_serve/_model_config/_core.py
@@ -87,7 +87,9 @@ class ModelConfig:
         if self.thinking_budget is not None and (
             not isinstance(self.thinking_budget, int) or self.thinking_budget <= 0  # pyright: ignore[reportUnnecessaryIsInstance]
         ):
-            raise ValueError(f"thinking_budget must be a positive int, got {self.thinking_budget!r}")
+            raise ValueError(
+                f"thinking_budget must be a positive int, got {self.thinking_budget!r}"
+            )
 
     # ------------------------------------------------------------------
     # Factory: from SDS provider alias + bare model name
@@ -115,8 +117,12 @@ class ModelConfig:
             )
         canonical = _ALIAS_TO_CANONICAL.get(alias)
         if canonical is None:
-            raise ValueError(f"Unknown provider alias {provider!r}. Known aliases: {sorted(_ALIAS_TO_CANONICAL)}")
-        return cls(provider=canonical, model=model, location=location, thinking_budget=thinking_budget)
+            raise ValueError(
+                f"Unknown provider alias {provider!r}. Known aliases: {sorted(_ALIAS_TO_CANONICAL)}"
+            )
+        return cls(
+            provider=canonical, model=model, location=location, thinking_budget=thinking_budget
+        )
 
     # ------------------------------------------------------------------
     # Factory: from model string (with optional hints)
@@ -148,30 +154,62 @@ class ModelConfig:
         for prefix, canonical in _COLON_PREFIX_MAP:
             if lower.startswith(prefix):
                 bare = model_str[len(prefix) :]
-                return cls(provider=canonical, model=bare, location=location, thinking_budget=thinking_budget)
+                return cls(
+                    provider=canonical,
+                    model=bare,
+                    location=location,
+                    thinking_budget=thinking_budget,
+                )
 
         # Step 2: slash-prefix
         for prefix, canonical in _SLASH_PREFIX_MAP:
             if lower.startswith(prefix):
                 bare = model_str[len(prefix) :]
-                return cls(provider=canonical, model=bare, location=location, thinking_budget=thinking_budget)
+                return cls(
+                    provider=canonical,
+                    model=bare,
+                    location=location,
+                    thinking_budget=thinking_budget,
+                )
 
         # Step 3: provider_hint
         if provider_hint is not None and provider_hint.lower() not in _UNRESOLVABLE_ALIASES:
             canonical = _ALIAS_TO_CANONICAL.get(provider_hint.lower())
             if canonical is not None:
-                return cls(provider=canonical, model=model_str, location=location, thinking_budget=thinking_budget)
+                return cls(
+                    provider=canonical,
+                    model=model_str,
+                    location=location,
+                    thinking_budget=thinking_budget,
+                )
 
         # Step 4: heuristics
         if "claude" in lower:
-            return cls(provider="anthropic", model=model_str, location=location, thinking_budget=thinking_budget)
+            return cls(
+                provider="anthropic",
+                model=model_str,
+                location=location,
+                thinking_budget=thinking_budget,
+            )
         if "gpt" in lower or "o1" in lower or "o3" in lower:
-            return cls(provider="openai", model=model_str, location=location, thinking_budget=thinking_budget)
+            return cls(
+                provider="openai",
+                model=model_str,
+                location=location,
+                thinking_budget=thinking_budget,
+            )
         if "gemini" in lower:
-            return cls(provider="gemini", model=model_str, location=location, thinking_budget=thinking_budget)
+            return cls(
+                provider="gemini",
+                model=model_str,
+                location=location,
+                thinking_budget=thinking_budget,
+            )
 
         # Step 5: fallback
-        return cls(provider="openai", model=model_str, location=location, thinking_budget=thinking_budget)
+        return cls(
+            provider="openai", model=model_str, location=location, thinking_budget=thinking_budget
+        )
 
     # ------------------------------------------------------------------
     # Conversion methods
@@ -251,12 +289,21 @@ class ModelConfig:
             if not os.environ.get("GOOGLE_CLOUD_PROJECT"):
                 missing.append("GOOGLE_CLOUD_PROJECT")
             # Location: self.location → GOOGLE_CLOUD_LOCATION → VERTEX_LOCATION
-            location = self.location or os.environ.get("GOOGLE_CLOUD_LOCATION") or os.environ.get("VERTEX_LOCATION")
+            location = (
+                self.location
+                or os.environ.get("GOOGLE_CLOUD_LOCATION")
+                or os.environ.get("VERTEX_LOCATION")
+            )
             if not location:
-                missing.append("location (set ModelConfig.location, GOOGLE_CLOUD_LOCATION, or VERTEX_LOCATION)")
+                missing.append(
+                    "location (set ModelConfig.location, GOOGLE_CLOUD_LOCATION, or VERTEX_LOCATION)"
+                )
 
         if missing:
-            raise OSError(f"Missing required environment for provider {self.provider!r}: " + ", ".join(missing))
+            raise OSError(
+                f"Missing required environment for provider {self.provider!r}: "
+                + ", ".join(missing)
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -287,7 +334,9 @@ def from_provider_and_model(
     thinking_budget: int | None = None,
 ) -> ModelConfig:
     """Convenience wrapper for ``ModelConfig.from_provider_and_model``."""
-    return ModelConfig.from_provider_and_model(provider, model, location=location, thinking_budget=thinking_budget)
+    return ModelConfig.from_provider_and_model(
+        provider, model, location=location, thinking_budget=thinking_budget
+    )
 
 
 def from_string(

--- a/src/vibe_serve/agent_runner.py
+++ b/src/vibe_serve/agent_runner.py
@@ -20,7 +20,6 @@ from vibe_serve.schemas import (
     Verdict,
 )
 
-
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -32,7 +31,7 @@ _JUDGE_REVIEW_PROMPT = (
     "and reflect on the results before giving your verdict. "
     "Return exactly one raw JSON object with keys "
     '"analysis", "feedback", and "verdict". '
-    'Do not use markdown fences or any extra text.'
+    "Do not use markdown fences or any extra text."
 )
 
 
@@ -113,9 +112,9 @@ def _log_agent_config(agent, label: str, log_file) -> None:
     """Write agent configuration (tools list) to log file."""
     if not log_file:
         return
-    log_file.write(f"\n{'='*60}\n")
+    log_file.write(f"\n{'=' * 60}\n")
     log_file.write(f"  Agent Configuration: {label}\n")
-    log_file.write(f"{'='*60}\n")
+    log_file.write(f"{'=' * 60}\n")
 
     # Extract tools
     try:
@@ -529,7 +528,9 @@ def run_profiler_agent(
             todos = _extract_todos(update)
             if todos is not None:
                 todo_display.update(todos)
-            structured_response = _extract_profiler_structured_response(update) or structured_response
+            structured_response = (
+                _extract_profiler_structured_response(update) or structured_response
+            )
             extracted_text = _extract_last_ai_message_text(update)
             if extracted_text:
                 last_ai_message = extracted_text

--- a/src/vibe_serve/agents/base.py
+++ b/src/vibe_serve/agents/base.py
@@ -22,8 +22,9 @@ from pathlib import Path
 from typing import Any, Callable, Protocol, TypeVar
 
 from langchain_core.tools import BaseTool
-from vibe_serve._agent_cli.base import MCPServerSpec
 from pydantic import BaseModel
+
+from vibe_serve._agent_cli.base import MCPServerSpec
 
 T = TypeVar("T", bound=BaseModel)
 

--- a/src/vibe_serve/agents/callbacks.py
+++ b/src/vibe_serve/agents/callbacks.py
@@ -6,8 +6,7 @@ from typing import Any, Callable
 
 from langchain_core.callbacks import BaseCallbackHandler
 
-from vibe_serve.constants import _DIM, _BOLD, _CYAN, _GREEN, _RED, _YELLOW, _RESET
-
+from vibe_serve.constants import _BOLD, _CYAN, _DIM, _GREEN, _RED, _RESET, _YELLOW
 
 ContextWindowLookup = Callable[[str | None], int | None]
 """Resolves a model name to its context window size in tokens.
@@ -26,23 +25,23 @@ queries against the OpenAI/Anthropic models API, or values loaded from
 # Values verified against vendor docs as of 2026-04-08.
 _MODEL_CONTEXT_WINDOWS: tuple[tuple[str, int], ...] = (
     # OpenAI — https://developers.openai.com/api/docs/models/
-    ("gpt-5.4",            1_050_000),  # gpt-5.4, gpt-5.4-pro
-    ("gpt-5",                400_000),  # gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.2
-    ("gpt-4o",               128_000),
-    ("gpt-4-turbo",          128_000),
-    ("o1",                   200_000),
-    ("o3",                   200_000),
-    ("o4",                   200_000),
+    ("gpt-5.4", 1_050_000),  # gpt-5.4, gpt-5.4-pro
+    ("gpt-5", 400_000),  # gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.2
+    ("gpt-4o", 128_000),
+    ("gpt-4-turbo", 128_000),
+    ("o1", 200_000),
+    ("o3", 200_000),
+    ("o4", 200_000),
     # Anthropic — https://platform.claude.com/docs/en/docs/about-claude/models/overview
     # Opus 4.6 and Sonnet 4.6 default to 1M; older 4.x and Haiku 4.5 are 200k.
     # (Pre-4.6 models had a context-1m-2025-08-07 beta header that swapped them
     # to 1M per request, but that's enabled at request time, not by model ID.)
-    ("claude-opus-4-6",    1_000_000),
-    ("claude-sonnet-4-6",  1_000_000),
-    ("claude-",              200_000),
+    ("claude-opus-4-6", 1_000_000),
+    ("claude-sonnet-4-6", 1_000_000),
+    ("claude-", 200_000),
     # Google
-    ("gemini-",            1_048_576),  # Gemini 2.5 / 3.x families default to 1M
-    ("gemma-",                 8_192),
+    ("gemini-", 1_048_576),  # Gemini 2.5 / 3.x families default to 1M
+    ("gemma-", 8_192),
 )
 
 
@@ -111,6 +110,7 @@ class TodoDisplay:
     @staticmethod
     def _strip_ansi(s: str) -> str:
         import re
+
         return re.sub(r"\033\[[0-9;]*m", "", s)
 
 
@@ -170,9 +170,9 @@ class AgentLogger(BaseCallbackHandler):
         flat = messages[0] if messages else []
 
         # Separator with call number
-        self._print_log(f"\n{'─'*60}")
+        self._print_log(f"\n{'─' * 60}")
         self._print_log(f"  LLM call #{self._call_count}")
-        self._print_log(f"{'─'*60}")
+        self._print_log(f"{'─' * 60}")
 
         # First call: log model info and system prompt
         if self._call_count == 1:
@@ -189,6 +189,7 @@ class AgentLogger(BaseCallbackHandler):
 
         # Message type summary
         from collections import Counter
+
         type_counts = Counter(getattr(m, "type", "unknown") for m in flat)
         summary = ", ".join(f"{count} {typ}" for typ, count in sorted(type_counts.items()))
         self._print_log(f"  Messages: {len(flat)} ({summary})")
@@ -281,15 +282,24 @@ class AgentLogger(BaseCallbackHandler):
 
     # Tool names whose args contain code content that is already tracked in
     # git — no need to duplicate it in the run log.
-    _CODE_CHANGE_TOOLS = frozenset({
-        "Write", "Edit",              # Claude Code tools
-        "write_file", "edit_file",    # deepagents tools
-    })
+    _CODE_CHANGE_TOOLS = frozenset(
+        {
+            "Write",
+            "Edit",  # Claude Code tools
+            "write_file",
+            "edit_file",  # deepagents tools
+        }
+    )
     # Args that carry bulk code content and should be omitted from the log.
-    _CODE_CONTENT_ARGS = frozenset({
-        "content", "old_string", "new_string",  # Write/Edit
-        "old_text", "new_text",                  # deepagents edit variants
-    })
+    _CODE_CONTENT_ARGS = frozenset(
+        {
+            "content",
+            "old_string",
+            "new_string",  # Write/Edit
+            "old_text",
+            "new_text",  # deepagents edit variants
+        }
+    )
 
     def _print_tool_call(self, name: str, args: dict):
         is_code_tool = name in self._CODE_CHANGE_TOOLS
@@ -312,7 +322,9 @@ class AgentLogger(BaseCallbackHandler):
             if len(s) > 80:
                 s = s[:80] + "..."
             parts.append(f'{k}="{s}"' if isinstance(v, str) else f"{k}={s}")
-        self._print_stdout(f"\n{self._format_prefix()}{_CYAN}{_BOLD}→ {name}({', '.join(parts)}){_RESET}")
+        self._print_stdout(
+            f"\n{self._format_prefix()}{_CYAN}{_BOLD}→ {name}({', '.join(parts)}){_RESET}"
+        )
 
     def _print_thinking(self, text: str):
         self._print(f"\n{_DIM}[thinking]{_RESET}")
@@ -330,14 +342,17 @@ class AgentLogger(BaseCallbackHandler):
         if self._log_file:
             log_preview = full_text
             if len(log_preview) > self._LOG_MAX_RESULT_LEN:
-                log_preview = log_preview[:self._LOG_MAX_RESULT_LEN] + f"... [{len(full_text) - self._LOG_MAX_RESULT_LEN} more chars]"
+                log_preview = (
+                    log_preview[: self._LOG_MAX_RESULT_LEN]
+                    + f"... [{len(full_text) - self._LOG_MAX_RESULT_LEN} more chars]"
+                )
             for line in log_preview.split("\n"):
                 self._print_log(f"  {color}{line}{_RESET}")
 
         # Truncated to stdout
         preview = full_text
         if self._max_result_len is not None and len(preview) > self._max_result_len:
-            preview = preview[:self._max_result_len] + "..."
+            preview = preview[: self._max_result_len] + "..."
         for line in preview.split("\n"):
             self._print_stdout(f"  {color}{line}{_RESET}")
 

--- a/src/vibe_serve/agents/cli_docker.py
+++ b/src/vibe_serve/agents/cli_docker.py
@@ -44,7 +44,7 @@ def _apt_install(pkgs: str, check_bin: str | None = None) -> str:
         f"command -v {bin_} >/dev/null || "
         "{ for i in 1 2 3 4 5; do "
         f"  apt-get update -qq && apt-get install -y -qq {pkgs} && break || "
-        "  (echo \"apt retry $i...\" >&2; sleep $((i*5))); "
+        '  (echo "apt retry $i..." >&2; sleep $((i*5))); '
         "done; "
         f"command -v {bin_} >/dev/null; }}"
     )
@@ -58,7 +58,7 @@ _NODE_TARBALL_INSTALL = (
     "V=v20.18.1; A=linux-x64; "
     "cd /tmp && "
     "curl -fsSL --retry 5 --retry-delay 5 -o node.tgz "
-    "  \"https://nodejs.org/dist/$V/node-$V-$A.tar.gz\" && "
+    '  "https://nodejs.org/dist/$V/node-$V-$A.tar.gz" && '
     "mkdir -p /opt/node && "
     "tar -xzf node.tgz -C /opt/node --strip-components=1 && "
     "ln -sf /opt/node/bin/node /usr/local/bin/node && "

--- a/src/vibe_serve/agents/cli_runner.py
+++ b/src/vibe_serve/agents/cli_runner.py
@@ -26,13 +26,13 @@ from pathlib import Path
 from typing import Any, Callable, TypeVar
 
 from langchain_core.tools import BaseTool
+from pydantic import BaseModel
+
 from vibe_serve._agent_cli.base import CodingAgent, MCPServerSpec
 from vibe_serve._agent_cli.claude import ClaudeCodeCodingAgent
 from vibe_serve._agent_cli.codex import CodexCodingAgent
 from vibe_serve._agent_cli.gemini import GeminiCodingAgent
 from vibe_serve._agent_cli.opencode import OpencodeCodingAgent
-from pydantic import BaseModel
-
 from vibe_serve.agent_runner import (
     _DEFAULT_MAX_TEXT_LEN,
     _log_and_print,
@@ -165,8 +165,7 @@ class CliAgentRunner:
     ):
         if provider not in _PROVIDER_CLASSES:
             raise SystemExit(
-                f"unknown cli provider {provider!r}; "
-                f"expected one of: {sorted(_PROVIDER_CLASSES)}"
+                f"unknown cli provider {provider!r}; expected one of: {sorted(_PROVIDER_CLASSES)}"
             )
         if docker_sandboxes is not None and modal_sandboxes is not None:
             raise SystemExit(
@@ -327,9 +326,7 @@ class CliAgentRunner:
         finally:
             if mcp_servers:
                 agent.uninstall_mcp_servers(workspace, mcp_servers)
-            self._write_usage_record(
-                kind=kind, round_label=round_label, agent=agent
-            )
+            self._write_usage_record(kind=kind, round_label=round_label, agent=agent)
 
         # 8. Parse the structured response, falling back if the CLI tool
         #    didn't produce parseable JSON.
@@ -348,9 +345,7 @@ class CliAgentRunner:
                     f"\n=== {label} ROUND OUTPUT (raw output) ===",
                     self._run_log_file,
                 )
-                _log_and_print(
-                    text, self._run_log_file, max_len=_DEFAULT_MAX_TEXT_LEN
-                )
+                _log_and_print(text, self._run_log_file, max_len=_DEFAULT_MAX_TEXT_LEN)
             return fallback_factory()
 
         _log_and_print(
@@ -364,9 +359,7 @@ class CliAgentRunner:
         )
         return parsed
 
-    def _write_usage_record(
-        self, *, kind: str, round_label: str, agent: Any
-    ) -> None:
+    def _write_usage_record(self, *, kind: str, round_label: str, agent: Any) -> None:
         """Append one JSONL record to ``<log_dir>/usage.jsonl`` for this call.
 
         Reads ``agent._last_session`` (stashed by
@@ -390,21 +383,13 @@ class CliAgentRunner:
             "provider": self._provider,
             "model": self._model_name,
             "input_tokens": usage.get("input_tokens", 0),
-            "cache_creation_input_tokens": usage.get(
-                "cache_creation_input_tokens", 0
-            ),
+            "cache_creation_input_tokens": usage.get("cache_creation_input_tokens", 0),
             "cache_read_input_tokens": usage.get("cache_read_input_tokens", 0),
             "output_tokens": usage.get("output_tokens", 0),
             "total_cost_usd": (
-                getattr(session, "total_cost_usd", None)
-                if session is not None
-                else None
+                getattr(session, "total_cost_usd", None) if session is not None else None
             ),
-            "duration_ms": (
-                getattr(session, "duration_ms", None)
-                if session is not None
-                else None
-            ),
+            "duration_ms": (getattr(session, "duration_ms", None) if session is not None else None),
         }
         target = self._log_dir / "usage.jsonl"
         try:

--- a/src/vibe_serve/agents/deepagents_runner.py
+++ b/src/vibe_serve/agents/deepagents_runner.py
@@ -15,9 +15,9 @@ from deepagents import create_deep_agent
 from langchain.agents.structured_output import AutoStrategy
 from langchain_core.tools import BaseTool
 from langgraph.checkpoint.memory import MemorySaver
-from vibe_serve._agent_cli.base import MCPServerSpec
 from pydantic import BaseModel
 
+from vibe_serve._agent_cli.base import MCPServerSpec
 from vibe_serve.agent_runner import (
     _DEFAULT_MAX_TEXT_LEN,
     _log_agent_config,

--- a/src/vibe_serve/agents/modal_executor.py
+++ b/src/vibe_serve/agents/modal_executor.py
@@ -77,9 +77,7 @@ class ModalCommandExecutor:
     ) -> CommandResult:
         modal_sb = getattr(self._modal_sandbox, "_sandbox", None)
         if modal_sb is None:
-            raise RuntimeError(
-                "Modal sandbox not started — call ModalSandbox.start() first"
-            )
+            raise RuntimeError("Modal sandbox not started — call ModalSandbox.start() first")
 
         cwd = request.cwd or self._workdir
 
@@ -107,13 +105,9 @@ class ModalCommandExecutor:
                 "HUGGING_FACE_HUB_TOKEN",
                 "PYTHONUNBUFFERED",
             }
-            forwarded = {
-                k: v for k, v in request.env.items() if k in _SAFE_ENV_KEYS
-            }
+            forwarded = {k: v for k, v in request.env.items() if k in _SAFE_ENV_KEYS}
             if forwarded:
-                env_prefix = ["env"] + [
-                    f"{k}={shlex.quote(v)}" for k, v in forwarded.items()
-                ]
+                env_prefix = ["env"] + [f"{k}={shlex.quote(v)}" for k, v in forwarded.items()]
                 argv = env_prefix + argv
 
         container_proc = modal_sb.exec(

--- a/src/vibe_serve/backends/__init__.py
+++ b/src/vibe_serve/backends/__init__.py
@@ -43,7 +43,9 @@ def get(
     if backend not in _REGISTRY:
         raise ValueError(f"No backend impl registered for {backend!r}")
     return _REGISTRY[backend](
-        log_dir=log_dir, log=log, image=image,
+        log_dir=log_dir,
+        log=log,
+        image=image,
     )
 
 

--- a/src/vibe_serve/backends/cuda/__init__.py
+++ b/src/vibe_serve/backends/cuda/__init__.py
@@ -30,6 +30,8 @@ from vibe_serve.sandbox.modal_sandbox import ModalSandbox
 
 # Default container image for the cuda backend.  Carries CUDA toolkit + PyTorch.
 _DEFAULT_IMAGE = "nvcr.io/nvidia/pytorch:25.04-py3"
+
+
 class CudaBackend:
     """CUDA / NVIDIA backend.
 
@@ -140,7 +142,8 @@ class CudaBackend:
         if self.selected_device is None:
             return None
         self._monitor = GpuContentionMonitor(
-            log_dir=log_dir, gpu_uuid=self.selected_device.uuid,
+            log_dir=log_dir,
+            gpu_uuid=self.selected_device.uuid,
         )
         return self._monitor
 
@@ -184,7 +187,8 @@ class CudaBackend:
         if self._monitor is not None:
             self._monitor.stop()
         self._monitor = GpuContentionMonitor(
-            log_dir=self.log_dir, gpu_uuid=new_gpu.uuid,
+            log_dir=self.log_dir,
+            gpu_uuid=new_gpu.uuid,
         )
         self._monitor.start()
 
@@ -193,10 +197,7 @@ class CudaBackend:
     def _pick_device(self) -> GpuInfo | None:
         cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
         if cuda_visible:
-            self._lprint(
-                f"[gpu] CUDA_VISIBLE_DEVICES={cuda_visible} set — "
-                f"skipping auto-selection"
-            )
+            self._lprint(f"[gpu] CUDA_VISIBLE_DEVICES={cuda_visible} set — skipping auto-selection")
             return None
         gpu = pick_gpu()
         if gpu is None:
@@ -249,7 +250,9 @@ class CudaBackend:
         try:
             result = subprocess.run(
                 ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             if result.returncode != 0:
                 return {}

--- a/src/vibe_serve/backends/cuda/gpu_monitor.py
+++ b/src/vibe_serve/backends/cuda/gpu_monitor.py
@@ -21,7 +21,6 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
-
 # ---------------------------------------------------------------------------
 # Data types
 # ---------------------------------------------------------------------------
@@ -83,14 +82,16 @@ def query_gpu_info() -> list[GpuInfo]:
         if len(parts) < 6:
             continue
         try:
-            gpus.append(GpuInfo(
-                index=int(parts[0]),
-                uuid=parts[1],
-                name=parts[2],
-                memory_used_mib=int(parts[3]),
-                memory_total_mib=int(parts[4]),
-                utilization_pct=int(parts[5]),
-            ))
+            gpus.append(
+                GpuInfo(
+                    index=int(parts[0]),
+                    uuid=parts[1],
+                    name=parts[2],
+                    memory_used_mib=int(parts[3]),
+                    memory_total_mib=int(parts[4]),
+                    utilization_pct=int(parts[5]),
+                )
+            )
         except (ValueError, IndexError):
             continue
     return gpus
@@ -145,12 +146,14 @@ def _parse_proc_output(raw: str) -> list[dict]:
             mem = int(mem_str)
         except ValueError:
             mem = 0
-        procs.append({
-            "pid": pid,
-            "process_name": parts[1],
-            "gpu_mem_mib": mem,
-            "gpu_uuid": parts[3],
-        })
+        procs.append(
+            {
+                "pid": pid,
+                "process_name": parts[1],
+                "gpu_mem_mib": mem,
+                "gpu_uuid": parts[3],
+            }
+        )
     return procs
 
 
@@ -199,7 +202,9 @@ class GpuContentionMonitor:
         self._baseline_pids = self._current_pids_on_gpu()
         self._stop_event.clear()
         self._thread = threading.Thread(
-            target=self._run, name="gpu-contention-monitor", daemon=True,
+            target=self._run,
+            name="gpu-contention-monitor",
+            daemon=True,
         )
         self._thread.start()
 
@@ -235,14 +240,13 @@ class GpuContentionMonitor:
                 procs = _parse_proc_output(raw)
                 gpu_procs = [p for p in procs if p["gpu_uuid"] == self._gpu_uuid]
 
-                new_procs = [
-                    p for p in gpu_procs if p["pid"] not in self._baseline_pids
-                ]
+                new_procs = [p for p in gpu_procs if p["pid"] not in self._baseline_pids]
 
                 # Also grab current GPU-level stats
                 gpus = query_gpu_info()
                 gpu_info = next(
-                    (g for g in gpus if g.uuid == self._gpu_uuid), None,
+                    (g for g in gpus if g.uuid == self._gpu_uuid),
+                    None,
                 )
 
                 contention = ContentionStatus(
@@ -264,13 +268,18 @@ class GpuContentionMonitor:
                             "utilization_pct": gpu_info.utilization_pct,
                         }
                     with open(log_path, "a") as f:
-                        f.write(json.dumps({
-                            "timestamp": contention.timestamp,
-                            "is_contended": True,
-                            "gpu_uuid": self._gpu_uuid,
-                            "gpu": gpu_dict,
-                            "new_procs": new_procs,
-                        }) + "\n")
+                        f.write(
+                            json.dumps(
+                                {
+                                    "timestamp": contention.timestamp,
+                                    "is_contended": True,
+                                    "gpu_uuid": self._gpu_uuid,
+                                    "gpu": gpu_dict,
+                                    "new_procs": new_procs,
+                                }
+                            )
+                            + "\n"
+                        )
             except Exception:
                 pass
             self._stop_event.wait(self._interval)

--- a/src/vibe_serve/backends/trainium/__init__.py
+++ b/src/vibe_serve/backends/trainium/__init__.py
@@ -43,8 +43,7 @@ from vibe_serve.sandbox.docker_sandbox import DockerSandbox
 # torch-neuronx, torch_xla, and the neuronx-cc compiler.  Override with
 # ``--docker-image`` if the host SDK differs.
 _DEFAULT_IMAGE = (
-    "public.ecr.aws/neuron/pytorch-inference-neuronx:"
-    "2.9.0-neuronx-py312-sdk2.30.0-ubuntu24.04"
+    "public.ecr.aws/neuron/pytorch-inference-neuronx:2.9.0-neuronx-py312-sdk2.30.0-ubuntu24.04"
 )
 
 # Docker's default /dev/shm is 64 MB; neuronx-cc and the Neuron runtime use
@@ -69,11 +68,7 @@ def _discover_neuron_devices() -> list[str]:
     Matches the numbered device nodes (``/dev/neuron0`` …) and skips the
     control node ``/dev/neuron_*`` if present.
     """
-    devs = [
-        d
-        for d in glob.glob("/dev/neuron*")
-        if d[len("/dev/neuron"):].isdigit()
-    ]
+    devs = [d for d in glob.glob("/dev/neuron*") if d[len("/dev/neuron") :].isdigit()]
     return sorted(devs)
 
 
@@ -99,8 +94,7 @@ class TrainiumBackend:
         self._devices = _discover_neuron_devices()
         if self._devices:
             self._lprint(
-                f"[neuron] Forwarding {len(self._devices)} device(s): "
-                f"{', '.join(self._devices)}"
+                f"[neuron] Forwarding {len(self._devices)} device(s): {', '.join(self._devices)}"
             )
         else:
             self._lprint(

--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -69,7 +69,7 @@ def _extract_flag(argv: list[str], flag: str) -> tuple[str | None, list[str]]:
             i += 2
             continue
         if tok.startswith(eq_form):
-            value = tok[len(eq_form):]
+            value = tok[len(eq_form) :]
             i += 1
             continue
         out.append(tok)
@@ -305,9 +305,11 @@ def load_config_and_skills(
         # implementer can write NeuronCore kernels. Other backends are
         # unaffected; --no-skills still disables everything.
         if backend == ComputeBackend.TRAINIUM:
-            nki_skills = PROJECT_ROOT / "resources" / "skills" / "neuron-agentic-development" / "skills"
+            nki_skills = (
+                PROJECT_ROOT / "resources" / "skills" / "neuron-agentic-development" / "skills"
+            )
             if nki_skills.is_dir():
-                skills = (skills or [])
+                skills = skills or []
                 if str(nki_skills) not in skills:
                     skills.append(str(nki_skills))
     return config, skills, backend
@@ -418,9 +420,7 @@ def _build_agent_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-rounds", type=int, default=24)
     parser.add_argument("--max-retries-per-round", type=int, default=3)
     parser.add_argument("--start-round", type=int, default=None, metavar="N")
-    parser.add_argument(
-        "--modality", default="text_generation", choices=_MODALITIES
-    )
+    parser.add_argument("--modality", default="text_generation", choices=_MODALITIES)
     parser.add_argument(
         "--domain",
         default=DEFAULT_DOMAIN,
@@ -517,9 +517,7 @@ def _parse_cli_objective(spec: str):
     from vibe_serve.loops.evolve.population import Objective
 
     if ":" not in spec:
-        raise argparse.ArgumentTypeError(
-            f"--objective {spec!r} must be 'name:max' or 'name:min'"
-        )
+        raise argparse.ArgumentTypeError(f"--objective {spec!r} must be 'name:max' or 'name:min'")
     name, _, direction = spec.partition(":")
     name = name.strip()
     direction = direction.strip().lower()
@@ -580,9 +578,7 @@ def _build_evolve_parser() -> argparse.ArgumentParser:
         metavar="NAME:DIRECTION",
     )
     parser.add_argument("--frontier-bias", type=float, default=0.7)
-    parser.add_argument(
-        "--modality", default="text_generation", choices=_MODALITIES
-    )
+    parser.add_argument("--modality", default="text_generation", choices=_MODALITIES)
     return parser
 
 
@@ -676,9 +672,7 @@ def _build_openevolve_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-iterations", type=int, default=16)
     parser.add_argument("--k-inspirations", type=int, default=3)
     parser.add_argument("--seed", type=int, default=None)
-    parser.add_argument(
-        "--modality", default="text_generation", choices=_MODALITIES
-    )
+    parser.add_argument("--modality", default="text_generation", choices=_MODALITIES)
     return parser
 
 
@@ -787,7 +781,8 @@ def _run_plain(args: argparse.Namespace) -> None:
 
         if args.start_round is not None:
             resume_state = PlainLoopState(
-                round_idx=args.start_round - 1, bootstrap_done=True,
+                round_idx=args.start_round - 1,
+                bootstrap_done=True,
             )
         else:
             resume_state = _load_state(log_dir)

--- a/src/vibe_serve/config.py
+++ b/src/vibe_serve/config.py
@@ -20,11 +20,9 @@ from typing import Literal, Mapping
 from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict, Field
 
-from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND, PROJECT_ROOT
+from vibe_serve.constants import DEFAULT_COMPUTE_BACKEND, PROJECT_ROOT, ComputeBackend
 
-Provider = Literal[
-    "vertex-ai", "anthropic", "google-genai", "openai", "openai-compatible"
-]
+Provider = Literal["vertex-ai", "anthropic", "google-genai", "openai", "openai-compatible"]
 
 
 class _Strict(BaseModel):
@@ -34,9 +32,7 @@ class _Strict(BaseModel):
 
 
 class ModelCfg(_Strict):
-    name: str = Field(
-        description="Model identifier, e.g. 'claude-sonnet-4-6'. Required."
-    )
+    name: str = Field(description="Model identifier, e.g. 'claude-sonnet-4-6'. Required.")
     provider: Provider | None = Field(
         default=None,
         description=(
@@ -122,9 +118,7 @@ class ProvidersCfg(_Strict):
     openai_compatible: OpenAICompatCfg | None = Field(
         default=None,
         alias="openai-compatible",
-        description=(
-            "OpenAI-compatible endpoint settings ([providers.openai-compatible])."
-        ),
+        description=("OpenAI-compatible endpoint settings ([providers.openai-compatible])."),
     )
     anthropic: _CredEnvProviderCfg | None = Field(
         default=None,
@@ -173,8 +167,7 @@ class AgentCfg(_Strict):
     cli_timeout: int | None = Field(
         default=None,
         description=(
-            "Per-invocation timeout for the CLI agent, in seconds. None → the "
-            "runner default."
+            "Per-invocation timeout for the CLI agent, in seconds. None → the runner default."
         ),
     )
 
@@ -187,9 +180,7 @@ class LoadLevelCfg(_Strict):
 
     rate: int = Field(description="Request rate (requests/sec) for this load level.")
     duration: int = Field(description="Benchmark duration in seconds at this load level.")
-    max_tokens: int = Field(
-        description="Max output tokens per request at this load level."
-    )
+    max_tokens: int = Field(description="Max output tokens per request at this load level.")
 
 
 class PerfEvalCfg(_Strict):
@@ -205,9 +196,7 @@ class PerfEvalCfg(_Strict):
 class Config(_Strict):
     model_config = ConfigDict(extra="forbid", protected_namespaces=())
 
-    model: ModelCfg = Field(
-        description="[model] — model name and provider. Required."
-    )
+    model: ModelCfg = Field(description="[model] — model name and provider. Required.")
     thinking: ThinkingCfg = Field(
         default_factory=ThinkingCfg, description="[thinking] — reasoning/thinking controls."
     )

--- a/src/vibe_serve/constants.py
+++ b/src/vibe_serve/constants.py
@@ -18,6 +18,7 @@ _ANTHROPIC_PREFIXES = ("claude-",)
 _GOOGLE_PREFIXES = ("gemini-", "gemma-")
 _OPENAI_PREFIXES = ("gpt-", "o1", "o3", "o4")
 
+
 class ComputeBackend(StrEnum):
     """Compute backends the agent can target.
 

--- a/src/vibe_serve/context.py
+++ b/src/vibe_serve/context.py
@@ -15,10 +15,10 @@ from vibe_serve.agent_runner import _log_and_print
 from vibe_serve.agents import build_agent_runner
 from vibe_serve.config import Config, as_config
 from vibe_serve.constants import (
-    ComputeBackend,
     DEFAULT_AGENT_BACKEND,
     DEFAULT_COMPUTE_BACKEND,
     PROJECT_ROOT,
+    ComputeBackend,
 )
 from vibe_serve.llm_client import _build_model
 from vibe_serve.sandbox.run_environment import (
@@ -171,8 +171,14 @@ class _RunContext:
         # the Docker ancestor-mount redirect dir for the same reason.
         # ``.cache`` holds any HF-download fallback (drafter, etc.).
         self.EXCLUDED_WORKSPACE_DIRS = {
-            ".claude", "__pycache__", ".git", "repos",
-            "_auth", "_opt_vibeserve", "_mounts", ".cache",
+            ".claude",
+            "__pycache__",
+            ".git",
+            "repos",
+            "_auth",
+            "_opt_vibeserve",
+            "_mounts",
+            ".cache",
         }
         self.debug = debug
         self.git_tracking = git_tracking
@@ -186,9 +192,7 @@ class _RunContext:
         )
         # Resolve agent backend + cli provider early so Docker setup can
         # add provider-specific bind mounts and init commands.
-        self._resolved_backend = (
-            agent_backend or config.agent.backend or DEFAULT_AGENT_BACKEND
-        )
+        self._resolved_backend = agent_backend or config.agent.backend or DEFAULT_AGENT_BACKEND
         self._cli_provider = cli_provider or config.agent.cli_provider or "codex"
 
         self.model = _build_model(config)
@@ -276,7 +280,13 @@ class _RunContext:
         # fresh sandbox volume at start, and codex-cli fails to load them
         # (e.g. skill description exceeds a newer CLI's length limit).
         # Mirrors _materialize_skills destinations inside cli_runner.
-        _cli_skill_dirs = (".agents/skills", ".claude/skills", ".gemini/skills", ".cursor/skills", ".opencode/skills")
+        _cli_skill_dirs = (
+            ".agents/skills",
+            ".claude/skills",
+            ".gemini/skills",
+            ".cursor/skills",
+            ".opencode/skills",
+        )
         for src in skill_source_paths:
             rel = src.name
             if (self.workspace / rel).exists():
@@ -564,10 +574,7 @@ class _RunContext:
                 else:
                     shutil.copy2(child, child_dst)
             except PermissionError:
-                self.lprint(
-                    f"[warn] _copy_excluding_extras: could not copy "
-                    f"{child.name} to {dst}"
-                )
+                self.lprint(f"[warn] _copy_excluding_extras: could not copy {child.name} to {dst}")
         if self.run_environment.isolated:
             # In containerized mode, external symlinks become bind mounts
             # (Docker) or volume uploads (Modal). Remove the broken symlinks
@@ -629,7 +636,9 @@ class _RunContext:
             "GIT_CONFIG_VALUE_0": str(self.workspace),
         }
 
-    def _git_run(self, cmd: list[str], *, check: bool = True, env: dict | None = None) -> subprocess.CompletedProcess:
+    def _git_run(
+        self, cmd: list[str], *, check: bool = True, env: dict | None = None
+    ) -> subprocess.CompletedProcess:
         """Run a git command in workspace, logging stderr on failure."""
         if env is None:
             env = {**os.environ, **self._GIT_ENV}
@@ -647,8 +656,11 @@ class _RunContext:
     # pointed at the workspace (or a torch.compile dump) would otherwise be
     # committed and bloat history across rounds.
     _ARTIFACT_GITIGNORE_PATTERNS: tuple[str, ...] = (
-        "*.neff", "*.ntff", "*.neuron",
-        "neuroncc_compile_workdir/", "neuron-compile-cache/",
+        "*.neff",
+        "*.ntff",
+        "*.neuron",
+        "neuroncc_compile_workdir/",
+        "neuron-compile-cache/",
     )
 
     def _workspace_gitignore(self) -> str:
@@ -737,10 +749,7 @@ class _RunContext:
         prefix = "" if (not existing or existing.endswith("\n")) else "\n"
         exclude_file.write_text(existing + prefix + "\n".join(new) + "\n")
         shown = ", ".join(new[:5]) + ("…" if len(new) > 5 else "")
-        self.lprint(
-            f"[git-tracking] excluded {len(new)} unreadable path(s) from "
-            f"snapshot: {shown}"
-        )
+        self.lprint(f"[git-tracking] excluded {len(new)} unreadable path(s) from snapshot: {shown}")
 
     def _git_add_all(self) -> None:
         """``git add -A``, resilient to files the host user cannot read.
@@ -765,9 +774,13 @@ class _RunContext:
         """Commit current workspace state with *label* as the commit message."""
         self._git_add_all()
         # git diff --cached --quiet exits 1 when there are staged changes
-        has_changes = self._git_run(
-            ["git", "diff", "--cached", "--quiet"], check=False,
-        ).returncode != 0
+        has_changes = (
+            self._git_run(
+                ["git", "diff", "--cached", "--quiet"],
+                check=False,
+            ).returncode
+            != 0
+        )
         if has_changes:
             self._git_run(["git", "commit", "-m", label])
         else:

--- a/src/vibe_serve/llm_client.py
+++ b/src/vibe_serve/llm_client.py
@@ -84,8 +84,7 @@ def _build_openai_compatible_model(model_name: str, config: Config):
     base_url = oc.base_url if oc else None
     if not base_url:
         raise ValueError(
-            "openai-compatible provider requires 'base_url' "
-            "(e.g. 'http://localhost:8000/v1')"
+            "openai-compatible provider requires 'base_url' (e.g. 'http://localhost:8000/v1')"
         )
     api_key = oc.api_key
 

--- a/src/vibe_serve/loops/agent/domain.py
+++ b/src/vibe_serve/loops/agent/domain.py
@@ -50,9 +50,7 @@ def builtin_domains() -> list[str]:
     """Names of the built-in domain packs (``<name>.md`` files under ``_domain/``)."""
     if not _BUILTIN_DOMAINS_DIR.is_dir():
         return []
-    return sorted(
-        p.stem for p in _BUILTIN_DOMAINS_DIR.glob("*.md") if p.name != "README.md"
-    )
+    return sorted(p.stem for p in _BUILTIN_DOMAINS_DIR.glob("*.md") if p.name != "README.md")
 
 
 def resolve_domain(spec: str) -> Path:
@@ -123,9 +121,7 @@ def render_domain_section(domain_file: Path, role: str, **context: object) -> st
     raw = sections.get(role)
     if raw is None and role == "single_agent":
         raw = "\n\n".join(
-            text
-            for text in (sections.get("implementer"), sections.get("judge"))
-            if text
+            text for text in (sections.get("implementer"), sections.get("judge")) if text
         )
     if not raw:
         return ""

--- a/src/vibe_serve/loops/agent/issue_board.py
+++ b/src/vibe_serve/loops/agent/issue_board.py
@@ -19,16 +19,13 @@ from __future__ import annotations
 from pathlib import Path
 
 from vibe_serve.schemas import (
+    ImplementerResponse,
+    JudgeResponse,
     OrchestratorPlan,
     PreRoundDecision,
     ProfilerSummary,
-)
-from vibe_serve.schemas import (
-    ImplementerResponse,
-    JudgeResponse,
     SingleAgentRoundResponse,
 )
-
 
 # ---------------------------------------------------------------------------
 # roadmap.md — orchestrator's strategic memory

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from vibe_serve.config import Config
-from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND
+from vibe_serve.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibe_serve.context import _RunContext
 from vibe_serve.loops.agent import issue_board
 from vibe_serve.loops.agent.domain import (
@@ -24,27 +24,23 @@ from vibe_serve.loops.agent.domain import (
     render_domain_section,
     resolve_domain,
 )
-from vibe_serve.schemas import (
-    OrchestratorPlan,
-    PreRoundDecision,
-    ProfilerSummary,
-)
 from vibe_serve.loops.profiler import invoke_profiler
 from vibe_serve.prompts import render_template
 from vibe_serve.schemas import (
     ImplementerResponse,
     JudgeResponse,
+    OrchestratorPlan,
+    PreRoundDecision,
+    ProfilerSummary,
     SingleAgentRoundResponse,
     Verdict,
 )
-
 
 _INNER_LOOPS = ("multi-agent", "single-agent")
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
 )
-
 
 _TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
 
@@ -142,11 +138,7 @@ def _detect_plateau(
     The orchestrator gets this verbatim in its prompt; phrasing is
     user-facing.
     """
-    fresh = [
-        r
-        for r in records
-        if r.perf_metric is not None and not r.profile_skipped
-    ]
+    fresh = [r for r in records if r.perf_metric is not None and not r.profile_skipped]
     if len(fresh) < min_streak:
         return None
     latest_unit = fresh[-1].perf_unit
@@ -250,7 +242,9 @@ def _run_pre_round_decision(
         ),
         response_cls=PreRoundDecision,
         fallback_factory=lambda: PreRoundDecision(
-            need_profile=False, profile_focus="", reasoning="fallback: default to skip",
+            need_profile=False,
+            profile_focus="",
+            reasoning="fallback: default to skip",
         ),
         round_label=f"round-{round_number}-pre",
     )
@@ -388,8 +382,7 @@ def _run_implementer(
         kind="implementer",
         system_prompt=system_prompt,
         user_prompt=(
-            "Carry out the orchestrator's task above. Append your summary "
-            "to progress.md when done."
+            "Carry out the orchestrator's task above. Append your summary to progress.md when done."
         ),
         response_cls=ImplementerResponse,
         fallback_factory=lambda: ImplementerResponse(
@@ -434,8 +427,7 @@ def _run_judge(
         kind="judge",
         system_prompt=system_prompt,
         user_prompt=(
-            "Review the implementation per the criteria above. Return "
-            "only the JSON verdict."
+            "Review the implementation per the criteria above. Return only the JSON verdict."
         ),
         response_cls=JudgeResponse,
         fallback_factory=lambda: JudgeResponse(
@@ -628,7 +620,7 @@ def run_agent_loop(
     try:
         while round_number <= max_rounds:
             ctx.switch_log_file(f"round{round_number:03d}")
-            ctx.lprint(f"\n{'='*60}\n  Round {round_number}/{max_rounds}\n{'='*60}\n")
+            ctx.lprint(f"\n{'=' * 60}\n  Round {round_number}/{max_rounds}\n{'=' * 60}\n")
 
             # --- Pre-round decision (skip on fresh cold start) ---
             profiler_summary: ProfilerSummary | None = None
@@ -648,7 +640,8 @@ def run_agent_loop(
                     profiler_summary = _run_profiler(
                         ctx,
                         round_number=round_number,
-                        profile_focus=pre_decision.profile_focus or "general latency hotspots on /v1/completions",
+                        profile_focus=pre_decision.profile_focus
+                        or "general latency hotspots on /v1/completions",
                         modality=modality,
                         progress_path=progress_path,
                         objective=objective,
@@ -692,13 +685,11 @@ def run_agent_loop(
                 if target and target.commit:
                     _git_checkout(ctx, target.commit)
                     ctx.lprint(
-                        f"Reverted workspace to round {plan.revert_to_round} "
-                        f"({target.commit[:8]})."
+                        f"Reverted workspace to round {plan.revert_to_round} ({target.commit[:8]})."
                     )
                 else:
                     ctx.lprint(
-                        f"[warn] cannot revert: no commit recorded for round "
-                        f"{plan.revert_to_round}"
+                        f"[warn] cannot revert: no commit recorded for round {plan.revert_to_round}"
                     )
 
             # --- Implementer / Judge retry loop ---
@@ -773,9 +764,7 @@ def run_agent_loop(
                     else None
                 )
                 perf_unit = (
-                    single_agent_response.perf_unit
-                    if (single_agent_response and passed)
-                    else None
+                    single_agent_response.perf_unit if (single_agent_response and passed) else None
                 )
                 # Remember the latest profile for the orchestrator's next plan
                 # and carry forward the implicit profile focus.
@@ -784,15 +773,9 @@ def run_agent_loop(
             else:
                 profile_skipped = profiler_summary is None
                 perf_metric = (
-                    profiler_summary.perf_metric
-                    if (profiler_summary and passed)
-                    else None
+                    profiler_summary.perf_metric if (profiler_summary and passed) else None
                 )
-                perf_unit = (
-                    profiler_summary.perf_unit
-                    if (profiler_summary and passed)
-                    else None
-                )
+                perf_unit = profiler_summary.perf_unit if (profiler_summary and passed) else None
             records.append(
                 _RoundRecord(
                     round_number=round_number,
@@ -807,7 +790,10 @@ def run_agent_loop(
 
             if not passed:
                 issue_board.append_exhaustion_note(
-                    progress_path, round_number, max_retries_per_round, feedback or "",
+                    progress_path,
+                    round_number,
+                    max_retries_per_round,
+                    feedback or "",
                 )
                 carry.exhaustion_info = (
                     f"Round {round_number} did not pass after "

--- a/src/vibe_serve/loops/evolve/loop.py
+++ b/src/vibe_serve/loops/evolve/loop.py
@@ -33,27 +33,22 @@ from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 
 from vibe_serve.config import Config
-from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND
+from vibe_serve.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibe_serve.context import _RunContext
 from vibe_serve.loops.evolve.population import (
     Individual,
     Objective,
     Population,
 )
-from vibe_serve.schemas import MutatorResponse
-from vibe_serve.schemas import ProfilerSummary
 from vibe_serve.loops.profiler import invoke_profiler
-from vibe_serve.schemas import JudgeResponse, Verdict
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
 )
-
+from vibe_serve.schemas import JudgeResponse, MutatorResponse, ProfilerSummary, Verdict
 
 _TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
-_AGENT_TEMPLATE_DIR = (
-    Path(__file__).resolve().parent.parent / "agent" / "templates"
-)
+_AGENT_TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "agent" / "templates"
 
 # Templates here include the orchestrate loop's modality fragments (e.g.
 # `_modality/text_generation/implementer.j2`) and reuse its profiler
@@ -117,8 +112,6 @@ def _current_commit_sha(ctx: _RunContext) -> str | None:
 # Profiler MCP wiring (reused from orchestrate; kept here to avoid an
 # import-time dependency on the orchestrate loop)
 # ---------------------------------------------------------------------------
-
-
 
 
 # ---------------------------------------------------------------------------
@@ -189,10 +182,7 @@ def _run_judge(
     return ctx.invoke(
         kind="judge",
         system_prompt=system_prompt,
-        user_prompt=(
-            "Review the offspring per the criteria above. Return only "
-            "the JSON verdict."
-        ),
+        user_prompt=("Review the offspring per the criteria above. Return only the JSON verdict."),
         response_cls=JudgeResponse,
         fallback_factory=lambda: JudgeResponse(
             analysis="Judge produced no structured response.",
@@ -219,8 +209,7 @@ If the benchmark JSON does not contain a field, set its entry to `null` rather t
 
 def _format_objectives_for_profiler(objectives: list[Objective]) -> str:
     return "\n".join(
-        f"- `{o.name}` ({'maximize' if o.direction == 'max' else 'minimize'})"
-        for o in objectives
+        f"- `{o.name}` ({'maximize' if o.direction == 'max' else 'minimize'})" for o in objectives
     )
 
 
@@ -234,8 +223,7 @@ def _run_profiler(
     objectives: list[Objective] | None = None,
 ) -> ProfilerSummary | None:
     template = (
-        "profiler_prompt_torch.j2" if ctx.profiler_kind == "torch"
-        else "profiler_prompt_nsys.j2"
+        "profiler_prompt_torch.j2" if ctx.profiler_kind == "torch" else "profiler_prompt_nsys.j2"
     )
     base_prompt = _render(
         template,
@@ -349,13 +337,15 @@ def run_evolve_loop(
         for generation in range(1, max_generations + 1):
             ctx.switch_log_file(f"gen{generation:03d}")
             ctx.lprint(
-                f"\n{'='*60}\n  Generation {generation}/{max_generations} — "
+                f"\n{'=' * 60}\n  Generation {generation}/{max_generations} — "
                 f"population={len(population)} (passed={len(population.passed)})\n"
-                f"{'='*60}\n"
+                f"{'=' * 60}\n"
             )
 
             for child_idx in range(1, children_per_generation + 1):
-                ctx.lprint(f"\n--- gen {generation} child {child_idx}/{children_per_generation} ---\n")
+                ctx.lprint(
+                    f"\n--- gen {generation} child {child_idx}/{children_per_generation} ---\n"
+                )
 
                 # 1. Pick parent + inspirations.
                 parent = population.select_parent(
@@ -449,9 +439,7 @@ def run_evolve_loop(
                 )
 
                 # 6. Commit + record.
-                ctx.snapshot_workspace(
-                    f"gen-{generation}-child-{child_idx}"
-                )
+                ctx.snapshot_workspace(f"gen-{generation}-child-{child_idx}")
                 commit = _current_commit_sha(ctx)
                 child = Individual(
                     id=population.next_id(),

--- a/src/vibe_serve/loops/evolve/population.py
+++ b/src/vibe_serve/loops/evolve/population.py
@@ -34,7 +34,6 @@ import random
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
-
 # ---------------------------------------------------------------------------
 # Objective spec + dominance
 # ---------------------------------------------------------------------------
@@ -55,9 +54,7 @@ class Objective:
 
     def __post_init__(self) -> None:
         if self.direction not in ("max", "min"):
-            raise ValueError(
-                f"Objective.direction must be 'max' or 'min', got {self.direction!r}"
-            )
+            raise ValueError(f"Objective.direction must be 'max' or 'min', got {self.direction!r}")
 
     def signed(self, value: float) -> float:
         """Return *value* flipped to "higher is better" semantics.
@@ -207,8 +204,10 @@ class Population:
         for ind in self.passed:
             if ind.perf_metric is None:
                 continue
-            if best is None or ind.perf_metric > best.perf_metric or (
-                ind.perf_metric == best.perf_metric and ind.id > best.id
+            if (
+                best is None
+                or ind.perf_metric > best.perf_metric
+                or (ind.perf_metric == best.perf_metric and ind.id > best.id)
             ):
                 best = ind
         return best
@@ -224,13 +223,12 @@ class Population:
         """
         if not objectives:
             return []
-        eligible = [
-            i for i in self.passed
-            if all(o.name in i.metrics for o in objectives)
-        ]
+        eligible = [i for i in self.passed if all(o.name in i.metrics for o in objectives)]
         non_dominated: list[Individual] = []
         for cand in eligible:
-            if not any(_dominates(other, cand, objectives) for other in eligible if other.id != cand.id):
+            if not any(
+                _dominates(other, cand, objectives) for other in eligible if other.id != cand.id
+            ):
                 non_dominated.append(cand)
         return non_dominated
 

--- a/src/vibe_serve/loops/openevolve/archive.py
+++ b/src/vibe_serve/loops/openevolve/archive.py
@@ -40,20 +40,24 @@ from pathlib import Path
 
 from vibe_serve.loops.evolve.population import Individual, Population
 
-
 # ---------------------------------------------------------------------------
 # Feature extraction
 # ---------------------------------------------------------------------------
 
 _CODE_SIZE_THRESHOLDS = (300, 600, 1000)  # → 4 buckets: <300, <600, <1000, ≥1000
-_TECHNIQUE_THRESHOLDS = (1, 2, 3)         # → 4 buckets: 0, 1, 2, ≥3
+_TECHNIQUE_THRESHOLDS = (1, 2, 3)  # → 4 buckets: 0, 1, 2, ≥3
 _DEFAULT_GRID_SHAPE = (4, 4)
 
 _TECHNIQUE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("cuda_graph", re.compile(r"cuda[_\s\-]?graph", re.IGNORECASE)),
     ("flash_attention", re.compile(r"flash[_\s\-]?attn|flashattention|flashinfer", re.IGNORECASE)),
     ("paged_attention", re.compile(r"paged[_\s\-]?attention|page[_\s\-]?table", re.IGNORECASE)),
-    ("speculative_decoding", re.compile(r"\beagle[0-9]?\b|spec(?:ulative)?[_\s\-]?decod|\bdraft[_\s\-]?model\b", re.IGNORECASE)),
+    (
+        "speculative_decoding",
+        re.compile(
+            r"\beagle[0-9]?\b|spec(?:ulative)?[_\s\-]?decod|\bdraft[_\s\-]?model\b", re.IGNORECASE
+        ),
+    ),
     ("torch_compile", re.compile(r"torch\.compile|@compile\b", re.IGNORECASE)),
     ("continuous_batching", re.compile(r"continuous[_\s\-]?batch", re.IGNORECASE)),
     ("low_precision", re.compile(r"\bfp8\b|\bint8\b|\bawq\b|\bgptq\b|\bbnb\b", re.IGNORECASE)),
@@ -170,9 +174,7 @@ class MapElitesArchive:
                 bins[key] = ind
                 continue
             cur_perf = current.perf_metric or float("-inf")
-            if ind.perf_metric > cur_perf or (
-                ind.perf_metric == cur_perf and ind.id > current.id
-            ):
+            if ind.perf_metric > cur_perf or (ind.perf_metric == cur_perf and ind.id > current.id):
                 bins[key] = ind
         return bins
 
@@ -239,7 +241,8 @@ class MapElitesArchive:
             if parent_id is not None:
                 picked_ids.add(parent_id)
             spare = [
-                ind for ind in self._population.passed
+                ind
+                for ind in self._population.passed
                 if ind.id not in picked_ids and ind.perf_metric is not None
             ]
             rng.shuffle(spare)

--- a/src/vibe_serve/loops/openevolve/loop.py
+++ b/src/vibe_serve/loops/openevolve/loop.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import random
 from pathlib import Path
 
-from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND
+from vibe_serve.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibe_serve.context import _RunContext
 from vibe_serve.loops.evolve.loop import (
     _checkout_commit_tree,
@@ -104,11 +104,11 @@ def run_openevolve_loop(
         for iteration in range(1, max_iterations + 1):
             ctx.switch_log_file(f"iter{iteration:03d}")
             ctx.lprint(
-                f"\n{'='*60}\n  Iteration {iteration}/{max_iterations} — "
+                f"\n{'=' * 60}\n  Iteration {iteration}/{max_iterations} — "
                 f"archive cells={len(archive)} "
                 f"(coverage={archive.coverage():.0%}), "
                 f"population={len(population)} (passed={len(population.passed)})\n"
-                f"{'='*60}\n"
+                f"{'=' * 60}\n"
             )
 
             # 1. Pick parent (cell-uniform) + inspirations (other cells).
@@ -240,8 +240,7 @@ def run_openevolve_loop(
             ctx.lprint("\nNo passing individual produced. Inspect logs.")
 
         ctx.lprint(
-            f"\nFinal archive: {len(archive)} cells filled "
-            f"({archive.coverage():.0%} coverage)"
+            f"\nFinal archive: {len(archive)} cells filled ({archive.coverage():.0%} coverage)"
         )
         return True
     except KeyboardInterrupt:

--- a/src/vibe_serve/loops/plain/loop.py
+++ b/src/vibe_serve/loops/plain/loop.py
@@ -29,17 +29,21 @@ from datetime import datetime
 from pathlib import Path
 
 from vibe_serve.config import Config, as_config
-from vibe_serve.constants import ComputeBackend, DEFAULT_COMPUTE_BACKEND
+from vibe_serve.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibe_serve.context import _RunContext
-from vibe_serve.loops.plain.render import render_all
-from vibe_serve.loops.plain.runner_ext import PlainLoopAgentRunner
 from vibe_serve.loops.plain.issue_board import (
     Issue,
-    IssueStatus,
     IssueBoard,
+    IssueStatus,
     IssueType,
 )
+from vibe_serve.loops.plain.render import render_all
+from vibe_serve.loops.plain.runner_ext import PlainLoopAgentRunner
 from vibe_serve.prompts import Prompt
+from vibe_serve.sandbox.run_environment import (
+    RunEnvironmentSpec,
+    make_run_environment_spec,
+)
 from vibe_serve.schemas import (
     IssueImplementerResponse,
     IssueJudgeResponse,
@@ -47,10 +51,6 @@ from vibe_serve.schemas import (
     PerfMetrics,
     PerfTrend,
     Verdict,
-)
-from vibe_serve.sandbox.run_environment import (
-    RunEnvironmentSpec,
-    make_run_environment_spec,
 )
 
 _TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
@@ -433,7 +433,11 @@ def run_plain_loop(
 
         state = resume_state if resume_state is not None else PlainLoopState()
         _ensure_bootstrap_issue(
-            store, state=state, log_dir=ctx.log_dir, ctx=ctx, prompt=prompt,
+            store,
+            state=state,
+            log_dir=ctx.log_dir,
+            ctx=ctx,
+            prompt=prompt,
         )
 
         # On resume, give every previously BLOCKED issue a fresh attempt
@@ -470,9 +474,9 @@ def run_plain_loop(
 
         while i < end_iteration:
             iter_label = i + 1
-            ctx.lprint(f"\n{'='*60}")
+            ctx.lprint(f"\n{'=' * 60}")
             ctx.lprint(f"  Iteration {iter_label}/{end_iteration}")
-            ctx.lprint(f"{'='*60}\n")
+            ctx.lprint(f"{'=' * 60}\n")
 
             # ---------------------------------------------------------------
             # DRAIN open issues
@@ -496,9 +500,7 @@ def run_plain_loop(
                         iteration=iter_label,
                         note=f"exhausted {max_attempts_per_issue} attempts",
                     )
-                    ctx.lprint(
-                        f"[block] issue #{issue.id} blocked after {issue.attempts} attempts"
-                    )
+                    ctx.lprint(f"[block] issue #{issue.id} blocked after {issue.attempts} attempts")
                     continue
 
                 # Claim the issue
@@ -519,8 +521,10 @@ def run_plain_loop(
                     _save_state(ctx.log_dir, state)
 
                     _sync_workspace_files(
-                        progress_path, perf_metrics_path,
-                        issues_dir, ctx.workspace,
+                        progress_path,
+                        perf_metrics_path,
+                        issues_dir,
+                        ctx.workspace,
                     )
                     ctx.reselect_gpu()
 
@@ -566,12 +570,8 @@ def run_plain_loop(
                     _update_progress_from_implementer(
                         progress_path, iter_label, issue, impl_response
                     )
-                    ctx.snapshot_workspace(
-                        f"iter-{iter_label}-impl-{issue.id}-att{issue.attempts}"
-                    )
-                    ctx.lprint(
-                        f"[snapshot] iter-{iter_label}-impl-{issue.id}-att{issue.attempts}"
-                    )
+                    ctx.snapshot_workspace(f"iter-{iter_label}-impl-{issue.id}-att{issue.attempts}")
+                    ctx.lprint(f"[snapshot] iter-{iter_label}-impl-{issue.id}-att{issue.attempts}")
 
                 # next_phase only kicks in for the first issue we resume on
                 next_phase = ""
@@ -583,8 +583,10 @@ def run_plain_loop(
                 _save_state(ctx.log_dir, state)
 
                 _sync_workspace_files(
-                    progress_path, perf_metrics_path,
-                    issues_dir, ctx.workspace,
+                    progress_path,
+                    perf_metrics_path,
+                    issues_dir,
+                    ctx.workspace,
                 )
                 ctx.reselect_gpu()
 
@@ -630,12 +632,8 @@ def run_plain_loop(
                 store.reload()
                 render_all(issues_dir, store)
 
-                _update_progress_from_judge(
-                    progress_path, iter_label, issue, judge_response
-                )
-                ctx.snapshot_workspace(
-                    f"iter-{iter_label}-judge-{issue.id}-att{issue.attempts}"
-                )
+                _update_progress_from_judge(progress_path, iter_label, issue, judge_response)
+                ctx.snapshot_workspace(f"iter-{iter_label}-judge-{issue.id}-att{issue.attempts}")
                 ctx.lprint(
                     f">>> Judge verdict on #{issue.id}: {judge_response.verdict.value.upper()}"
                 )
@@ -668,13 +666,8 @@ def run_plain_loop(
             # PERF_EVAL phase (after drain complete)
             # ---------------------------------------------------------------
             # Bail-out check: if every remaining issue is BLOCKED, we're stuck.
-            remaining = [
-                iss for iss in store.list()
-                if iss.status not in (IssueStatus.CLOSED,)
-            ]
-            blocked_only = remaining and all(
-                iss.status == IssueStatus.BLOCKED for iss in remaining
-            )
+            remaining = [iss for iss in store.list() if iss.status not in (IssueStatus.CLOSED,)]
+            blocked_only = remaining and all(iss.status == IssueStatus.BLOCKED for iss in remaining)
             if blocked_only:
                 ctx.lprint(
                     f"[stop] all remaining issues are blocked "
@@ -692,8 +685,10 @@ def run_plain_loop(
             _save_state(ctx.log_dir, state)
 
             _sync_workspace_files(
-                progress_path, perf_metrics_path,
-                issues_dir, ctx.workspace,
+                progress_path,
+                perf_metrics_path,
+                issues_dir,
+                ctx.workspace,
             )
             ctx.reselect_gpu()
 

--- a/src/vibe_serve/loops/plain/mcp_config.py
+++ b/src/vibe_serve/loops/plain/mcp_config.py
@@ -14,7 +14,6 @@ MCP path; everything else is provider-agnostic and lives in
 from __future__ import annotations
 
 from vibe_serve._agent_cli.base import MCPServerSpec
-
 from vibe_serve.loops.plain.issue_board import IssueType
 
 

--- a/src/vibe_serve/loops/plain/mcp_server.py
+++ b/src/vibe_serve/loops/plain/mcp_server.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
-from vibe_serve.loops.plain.issue_board import IssueStatus, IssueBoard, IssueType
+from vibe_serve.loops.plain.issue_board import IssueBoard, IssueStatus, IssueType
 from vibe_serve.loops.plain.tool_impl import (
     CreateIssuePolicy,
     create_issue_under_policy,
@@ -31,9 +31,7 @@ from vibe_serve.loops.plain.tool_impl import (
     format_issue_short,
 )
 
-_ALL_TYPES: frozenset[IssueType] = frozenset(
-    {IssueType.BUG, IssueType.FEATURE, IssueType.PERF}
-)
+_ALL_TYPES: frozenset[IssueType] = frozenset({IssueType.BUG, IssueType.FEATURE, IssueType.PERF})
 
 
 def _parse_allowed_types(value: str) -> frozenset[IssueType]:
@@ -41,8 +39,7 @@ def _parse_allowed_types(value: str) -> frozenset[IssueType]:
     parts = [p.strip() for p in value.split(",") if p.strip()]
     if not parts:
         raise argparse.ArgumentTypeError(
-            "--allowed-types may not be empty; pass a comma-separated subset "
-            "of {bug,feature,perf}"
+            "--allowed-types may not be empty; pass a comma-separated subset of {bug,feature,perf}"
         )
     try:
         return frozenset(IssueType(p) for p in parts)
@@ -69,22 +66,19 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--creator",
         default="agent",
-        help="Identity recorded on issues created via this server "
-             "(default: 'agent').",
+        help="Identity recorded on issues created via this server (default: 'agent').",
     )
     parser.add_argument(
         "--iteration",
         type=int,
         default=1,
-        help="1-based iteration number used for per-iteration cap "
-             "accounting (default: 1).",
+        help="1-based iteration number used for per-iteration cap accounting (default: 1).",
     )
     parser.add_argument(
         "--cap",
         type=int,
         default=None,
-        help="Max issues this creator may file in this iteration. "
-             "Omit for no cap.",
+        help="Max issues this creator may file in this iteration. Omit for no cap.",
     )
     parser.add_argument(
         "--allowed-types",
@@ -95,8 +89,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--read-only",
         action="store_true",
-        help="Do not register create_issue. Server exposes only "
-             "list/get/search.",
+        help="Do not register create_issue. Server exposes only list/get/search.",
     )
     return parser
 
@@ -157,6 +150,7 @@ def build_server(args: argparse.Namespace) -> FastMCP:
         return "\n".join(format_issue_short(i) for i in hits)
 
     if not args.read_only:
+
         @mcp.tool()
         def create_issue(type: str, title: str, description: str) -> str:
             """Create a new issue.

--- a/src/vibe_serve/loops/plain/render.py
+++ b/src/vibe_serve/loops/plain/render.py
@@ -30,9 +30,9 @@ from pathlib import Path
 
 from vibe_serve.loops.plain.issue_board import (
     Issue,
+    IssueBoard,
     IssueEvent,
     IssueStatus,
-    IssueBoard,
 )
 
 _DEFAULT_SLUG = "untitled"
@@ -68,9 +68,7 @@ def slugify(title: str, max_len: int = _SLUG_MAX_LEN) -> str:
     # ASCII here — non-decomposable unicode chars (em-dash, etc.) are
     # left in place so the regex below treats them as separators.
     normalised = unicodedata.normalize("NFKD", title)
-    no_marks = "".join(
-        ch for ch in normalised if not unicodedata.combining(ch)
-    )
+    no_marks = "".join(ch for ch in normalised if not unicodedata.combining(ch))
     lowered = no_marks.lower()
     collapsed = re.sub(r"[^a-z0-9]+", "-", lowered)
     stripped = collapsed.strip("-")

--- a/src/vibe_serve/loops/plain/runner_ext.py
+++ b/src/vibe_serve/loops/plain/runner_ext.py
@@ -23,12 +23,12 @@ from __future__ import annotations
 from typing import Any, TypeVar
 
 from langchain_core.tools import BaseTool
-from vibe_serve._agent_cli.base import MCPServerSpec
 from pydantic import BaseModel
 
+from vibe_serve._agent_cli.base import MCPServerSpec
 from vibe_serve.agents.base import AgentRunner
-from vibe_serve.loops.plain.mcp_config import build_issue_mcp_spec
 from vibe_serve.loops.plain.issue_board import IssueBoard, IssueType
+from vibe_serve.loops.plain.mcp_config import build_issue_mcp_spec
 from vibe_serve.loops.plain.tools import build_issue_tools
 
 T = TypeVar("T", bound=BaseModel)

--- a/src/vibe_serve/loops/plain/tool_impl.py
+++ b/src/vibe_serve/loops/plain/tool_impl.py
@@ -70,9 +70,7 @@ def check_create_allowed(
         )
     if policy.cap is not None:
         store.reload()
-        already = store.open_count_by_creator_in_iter(
-            policy.creator, policy.iteration
-        )
+        already = store.open_count_by_creator_in_iter(policy.creator, policy.iteration)
         if already >= policy.cap:
             return (
                 f"error: per-iteration cap reached "
@@ -102,8 +100,7 @@ def create_issue_under_policy(
         type_enum = parse_type(type_str)
     except ValueError:
         return None, (
-            f"error: type must be one of {[t.value for t in IssueType]}, "
-            f"got '{type_str}'"
+            f"error: type must be one of {[t.value for t in IssueType]}, got '{type_str}'"
         )
     err = check_create_allowed(store, type_enum=type_enum, policy=policy)
     if err is not None:

--- a/src/vibe_serve/loops/plain/tools.py
+++ b/src/vibe_serve/loops/plain/tools.py
@@ -24,8 +24,8 @@ from __future__ import annotations
 from langchain_core.tools import BaseTool, tool
 
 from vibe_serve.loops.plain.issue_board import (
-    IssueStatus,
     IssueBoard,
+    IssueStatus,
     IssueType,
 )
 from vibe_serve.loops.plain.tool_impl import (
@@ -105,9 +105,7 @@ def build_issue_tools(
             iteration=iteration,
             cap=create_cap,
             allowed_types=frozenset(
-                allowed_create_types
-                if allowed_create_types is not None
-                else IssueType
+                allowed_create_types if allowed_create_types is not None else IssueType
             ),
         )
 

--- a/src/vibe_serve/loops/profiler.py
+++ b/src/vibe_serve/loops/profiler.py
@@ -69,8 +69,7 @@ def invoke_profiler(
             kind="profiler",
             system_prompt=system_prompt,
             user_prompt=(
-                "Profile the server and return exactly one JSON object "
-                "matching the schema above."
+                "Profile the server and return exactly one JSON object matching the schema above."
             ),
             response_cls=ProfilerSummary,
             fallback_factory=lambda: ProfilerSummary(

--- a/src/vibe_serve/prompts.py
+++ b/src/vibe_serve/prompts.py
@@ -123,11 +123,13 @@ class ComputeBackendFragment(ABC):
     per name in ``NAMES``.
     """
 
-    NAMES: ClassVar[frozenset[str]] = frozenset({
-        "device_dtype",
-        "judge_device_correctness",
-        "profiling_workflow",
-    })
+    NAMES: ClassVar[frozenset[str]] = frozenset(
+        {
+            "device_dtype",
+            "judge_device_correctness",
+            "profiling_workflow",
+        }
+    )
     backend: ClassVar[ComputeBackend]  # set by subclasses
 
     def __init__(self, env: Environment) -> None:
@@ -143,12 +145,10 @@ class ComputeBackendFragment(ABC):
         an extra blank line at every substitution site.
         """
         if name not in self.NAMES:
-            raise ValueError(
-                f"Unknown fragment {name!r}; valid: {sorted(self.NAMES)}"
-            )
-        return self._env.get_template(
-            f"_backend/{self.backend.value}/{name}.j2"
-        ).render().rstrip("\n")
+            raise ValueError(f"Unknown fragment {name!r}; valid: {sorted(self.NAMES)}")
+        return (
+            self._env.get_template(f"_backend/{self.backend.value}/{name}.j2").render().rstrip("\n")
+        )
 
     def render_all(self) -> dict[str, str]:
         """Render every fragment in :attr:`NAMES` keyed by name."""
@@ -160,9 +160,7 @@ class ComputeBackendFragment(ABC):
         :attr:`NAMES`. Raises ``ValueError`` listing missing files.
         """
         backend_dir = _TEMPLATES_DIR / "_backend" / cls.backend.value
-        missing = [
-            n for n in cls.NAMES if not (backend_dir / f"{n}.j2").is_file()
-        ]
+        missing = [n for n in cls.NAMES if not (backend_dir / f"{n}.j2").is_file()]
         if missing:
             raise ValueError(
                 f"{cls.__name__}: missing fragment files under {backend_dir}: "
@@ -173,16 +171,19 @@ class ComputeBackendFragment(ABC):
 
 class CudaComputeBackendFragment(ComputeBackendFragment):
     """Fragments for the CUDA backend (NVIDIA GPUs)."""
+
     backend = ComputeBackend.CUDA
 
 
 class MetalComputeBackendFragment(ComputeBackendFragment):
     """Fragments for the Metal backend (Apple Silicon, MPS)."""
+
     backend = ComputeBackend.METAL
 
 
 class TrainiumComputeBackendFragment(ComputeBackendFragment):
     """Fragments for the Trainium backend (AWS NeuronCores)."""
+
     backend = ComputeBackend.TRAINIUM
 
 

--- a/src/vibe_serve/sandbox/docker_sandbox.py
+++ b/src/vibe_serve/sandbox/docker_sandbox.py
@@ -33,11 +33,17 @@ def _cleanup_containers() -> None:
         try:
             subprocess.run(
                 ["docker", "stop", container_id],
-                capture_output=True, text=True, check=False, timeout=30,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
             )
             subprocess.run(
                 ["docker", "rm", container_id],
-                capture_output=True, text=True, check=False, timeout=10,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
             )
         except Exception:
             pass
@@ -171,7 +177,12 @@ class DockerSandbox(BaseSandbox):
         logger.addHandler(handler)
         return logger
 
-    def _log_cmd(self, cmd: list[str], result: subprocess.CompletedProcess | None = None, error: str | None = None) -> None:
+    def _log_cmd(
+        self,
+        cmd: list[str],
+        result: subprocess.CompletedProcess | None = None,
+        error: str | None = None,
+    ) -> None:
         if self._logger is None:
             return
         self._logger.info("CMD: %s", " ".join(cmd))
@@ -239,27 +250,27 @@ class DockerSandbox(BaseSandbox):
             return WriteResult(path=file_path, error=result.stderr.strip())
         return WriteResult(path=file_path)
 
-    def edit(self, file_path: str, old_string: str, new_string: str,
-             replace_all: bool = False) -> EditResult:
+    def edit(
+        self, file_path: str, old_string: str, new_string: str, replace_all: bool = False
+    ) -> EditResult:
         return super().edit(self._vpath(file_path), old_string, new_string, replace_all)
 
     def glob_info(self, pattern: str, path: str = "/"):
         return super().glob_info(pattern, self._vpath(path))
 
-    def grep_raw(self, pattern: str, path: str | None = None,
-                 glob: str | None = None):
+    def grep_raw(self, pattern: str, path: str | None = None, glob: str | None = None):
         # Check container is still running before issuing grep; a dead
         # container causes docker-exec to emit an error on stderr that the
         # parent parser cannot parse (e.g. "No such container").
         if self._container_id is not None:
             check = subprocess.run(
                 ["docker", "inspect", "--format={{.State.Running}}", self._container_id],
-                capture_output=True, text=True, check=False,
+                capture_output=True,
+                text=True,
+                check=False,
             )
             if check.returncode != 0 or "true" not in check.stdout.lower():
-                raise RuntimeError(
-                    f"Docker container {self._container_id} is no longer running"
-                )
+                raise RuntimeError(f"Docker container {self._container_id} is no longer running")
         return super().grep_raw(
             pattern,
             self._vpath(path) if path is not None else self._CONTAINER_ROOT,
@@ -289,9 +300,13 @@ class DockerSandbox(BaseSandbox):
         """Start the Docker container."""
         self._container_name = f"vibeserve-{uuid.uuid4().hex[:12]}"
         cmd = [
-            "docker", "run", "-d",
-            "--name", self._container_name,
-            "-v", f"{self._host_workspace}:/workspace",
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            self._container_name,
+            "-v",
+            f"{self._host_workspace}:/workspace",
         ]
         if self._auto_remove:
             # Auto-remove the container (and its overlay, which can hold many GB
@@ -321,11 +336,15 @@ class DockerSandbox(BaseSandbox):
         for key, value in self._env.items():
             cmd.extend(["-e", f"{key}={value}"])
 
-        cmd.extend([
-            "--workdir", "/workspace",
-            self._image,
-            "sleep", "infinity",
-        ])
+        cmd.extend(
+            [
+                "--workdir",
+                "/workspace",
+                self._image,
+                "sleep",
+                "infinity",
+            ]
+        )
 
         self._log_cmd(cmd)
         try:
@@ -375,10 +394,7 @@ class DockerSandbox(BaseSandbox):
             "devices": list(self._devices),
             "entrypoint": self._entrypoint,
             "shm_size": self._shm_size,
-            "bind_mounts": [
-                [host, container, ro]
-                for host, container, ro in self._bind_mounts
-            ],
+            "bind_mounts": [[host, container, ro] for host, container, ro in self._bind_mounts],
             "env": dict(self._env),
             "symlink_commands": [],
         }
@@ -403,8 +419,12 @@ class DockerSandbox(BaseSandbox):
         # Unlike uv, these are required — a failure raises RuntimeError.
         for init_cmd_str in self._extra_init_commands:
             init_cmd = [
-                "docker", "exec", self._container_id,
-                "bash", "-c", init_cmd_str,
+                "docker",
+                "exec",
+                self._container_id,
+                "bash",
+                "-c",
+                init_cmd_str,
             ]
             self._log_cmd(init_cmd)
             try:
@@ -425,9 +445,7 @@ class DockerSandbox(BaseSandbox):
                     )
             except subprocess.TimeoutExpired:
                 self._log_cmd(init_cmd, error=f"init command timed out after 600s: {init_cmd_str}")
-                raise RuntimeError(
-                    f"Container init command timed out after 600s: {init_cmd_str}"
-                )
+                raise RuntimeError(f"Container init command timed out after 600s: {init_cmd_str}")
 
         # Run caller-supplied setup functions.  These re-execute on every
         # restart (so e.g. docker symlinks survive ``reselect_device``).
@@ -493,10 +511,14 @@ class DockerSandbox(BaseSandbox):
         effective_timeout = timeout if timeout is not None else self._default_timeout
 
         exec_cmd = [
-            "docker", "exec",
-            "-w", "/workspace",
+            "docker",
+            "exec",
+            "-w",
+            "/workspace",
             self._container_id,
-            "bash", "-c", command,
+            "bash",
+            "-c",
+            command,
         ]
         self._log_cmd(exec_cmd)
         try:
@@ -529,7 +551,10 @@ class DockerSandbox(BaseSandbox):
         truncated = False
 
         if len(output) > self._max_output_bytes:
-            output = output[: self._max_output_bytes] + f"\n... [truncated, {len(result.stdout + result.stderr) - self._max_output_bytes} bytes omitted]"
+            output = (
+                output[: self._max_output_bytes]
+                + f"\n... [truncated, {len(result.stdout + result.stderr) - self._max_output_bytes} bytes omitted]"
+            )
             truncated = True
 
         return ExecuteResponse(

--- a/src/vibe_serve/sandbox/modal_model_setup.py
+++ b/src/vibe_serve/sandbox/modal_model_setup.py
@@ -125,6 +125,7 @@ def ensure_model_volume(
     def _download(mid: str, rev: str | None, sentinel: str) -> None:
         import os as _os
         from pathlib import Path
+
         from huggingface_hub import snapshot_download
 
         snapshot_download(

--- a/src/vibe_serve/sandbox/modal_sandbox.py
+++ b/src/vibe_serve/sandbox/modal_sandbox.py
@@ -60,12 +60,12 @@ _TRANSIENT_FRAGMENTS = (
     "connection refused",
     "connection aborted",
     "broken pipe",
-    "unavailable",           # grpc StatusCode.UNAVAILABLE
-    "deadline_exceeded",     # grpc StatusCode.DEADLINE_EXCEEDED (network, not app timeout)
+    "unavailable",  # grpc StatusCode.UNAVAILABLE
+    "deadline_exceeded",  # grpc StatusCode.DEADLINE_EXCEEDED (network, not app timeout)
     "502 bad gateway",
     "503 service unavailable",
     "504 gateway timeout",
-    "eof occurred",          # TLS handshake failures
+    "eof occurred",  # TLS handshake failures
     "handshake",
 )
 
@@ -296,15 +296,13 @@ class ModalSandbox(BaseSandbox):
     def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> str:
         return super().read(self._vpath(file_path), offset, limit)
 
-    def edit(self, file_path: str, old_string: str, new_string: str,
-             replace_all: bool = False):
+    def edit(self, file_path: str, old_string: str, new_string: str, replace_all: bool = False):
         return super().edit(self._vpath(file_path), old_string, new_string, replace_all)
 
     def glob_info(self, pattern: str, path: str = "/"):
         return super().glob_info(pattern, self._vpath(path))
 
-    def grep_raw(self, pattern: str, path: str | None = None,
-                 glob: str | None = None):
+    def grep_raw(self, pattern: str, path: str | None = None, glob: str | None = None):
         return super().grep_raw(
             pattern,
             self._vpath(path) if path is not None else self._CONTAINER_ROOT,
@@ -319,7 +317,8 @@ class ModalSandbox(BaseSandbox):
         # restart so in-progress agent state survives a sandbox crash.
         self._workspace_volume_name = f"vibeserve-ws-{uuid.uuid4().hex[:12]}"
         self._workspace_volume = modal.Volume.from_name(
-            self._workspace_volume_name, create_if_missing=True,
+            self._workspace_volume_name,
+            create_if_missing=True,
         )
         self._log(f"created workspace volume {self._workspace_volume_name}")
 
@@ -335,7 +334,8 @@ class ModalSandbox(BaseSandbox):
         # the nvcr.io pytorch image ships with a populated /workspace that
         # triggers init_failure when a Volume is mounted on top.
         image = modal.Image.from_registry(
-            self._image_tag, add_python=None,
+            self._image_tag,
+            add_python=None,
         ).run_commands(f"rm -rf {self._CONTAINER_ROOT} && mkdir {self._CONTAINER_ROOT}")
 
         volumes: dict[str, modal.Volume] = {self._CONTAINER_ROOT: self._workspace_volume}
@@ -361,7 +361,8 @@ class ModalSandbox(BaseSandbox):
         # runs and exits, and subsequent execs hit "Sandbox has already
         # shut down". Mirrors DockerSandbox's `sleep infinity` trick.
         self._sandbox = modal.Sandbox.create(
-            "sleep", "infinity",
+            "sleep",
+            "infinity",
             app=app,
             image=image,
             gpu=self._gpu,
@@ -378,8 +379,11 @@ class ModalSandbox(BaseSandbox):
         # Install uv (non-fatal; mirrors DockerSandbox).
         try:
             proc = self._sandbox.exec(
-                "bash", "-c", "pip install uv",
-                workdir=self._CONTAINER_ROOT, timeout=180,
+                "bash",
+                "-c",
+                "pip install uv",
+                workdir=self._CONTAINER_ROOT,
+                timeout=180,
             )
             proc.wait()
         except Exception as exc:
@@ -389,8 +393,11 @@ class ModalSandbox(BaseSandbox):
         for cmd in self._extra_init_commands:
             self._log(f"init command: {cmd}")
             proc = self._sandbox.exec(
-                "bash", "-c", cmd,
-                workdir=self._CONTAINER_ROOT, timeout=600,
+                "bash",
+                "-c",
+                cmd,
+                workdir=self._CONTAINER_ROOT,
+                timeout=600,
             )
             code = proc.wait()
             if code != 0:
@@ -453,9 +460,7 @@ class ModalSandbox(BaseSandbox):
 
         try:
             self._create_container()
-            self._log(
-                f"[fallback] restart succeeded (new id={self._sandbox_id})"
-            )
+            self._log(f"[fallback] restart succeeded (new id={self._sandbox_id})")
             return True
         except Exception as exc:
             self._log(f"[fallback] restart failed: {exc}")
@@ -481,7 +486,7 @@ class ModalSandbox(BaseSandbox):
                             f"skip bind mount outside {self._CONTAINER_ROOT}: {container_path}"
                         )
                         continue
-                    rel = container_path[len(self._CONTAINER_ROOT):].lstrip("/") or "/"
+                    rel = container_path[len(self._CONTAINER_ROOT) :].lstrip("/") or "/"
                     host_p = Path(host_path)
                     remote = "/" + rel if rel != "/" else "/"
                     if ".hf_cache" in host_p.parts:
@@ -582,7 +587,9 @@ class ModalSandbox(BaseSandbox):
         except Exception as exc:
             if _is_sandbox_dead(exc) and self._restart_sandbox():
                 return _retry_transient(
-                    fn, log=self._log, label=f"{label}-after-restart",
+                    fn,
+                    log=self._log,
+                    label=f"{label}-after-restart",
                 )
             raise
 
@@ -602,7 +609,9 @@ class ModalSandbox(BaseSandbox):
 
         def _do_exec() -> tuple[str, str, int]:
             proc = self._sandbox.exec(
-                "bash", "-c", command,
+                "bash",
+                "-c",
+                command,
                 workdir=self._CONTAINER_ROOT,
                 timeout=effective_timeout,
             )
@@ -613,7 +622,8 @@ class ModalSandbox(BaseSandbox):
 
         try:
             stdout, stderr, exit_code = self._run_with_fallback(
-                _do_exec, label="exec",
+                _do_exec,
+                label="exec",
             )
         except TimeoutError:
             self._log(f"exec timeout after {effective_timeout}s")
@@ -661,7 +671,9 @@ class ModalSandbox(BaseSandbox):
             except TypeError:
                 # Older Modal SDKs: make_directory may not accept parents=
                 self._sandbox.exec(
-                    "bash", "-c", f"mkdir -p {parent}",
+                    "bash",
+                    "-c",
+                    f"mkdir -p {parent}",
                     workdir=self._CONTAINER_ROOT,
                 ).wait()
             fs.write_text(content, container_path)
@@ -693,7 +705,9 @@ class ModalSandbox(BaseSandbox):
                 # sandbox's filesystem handle, not a stale reference.
                 fs = self._sandbox.filesystem
                 self._sandbox.exec(
-                    "bash", "-c", f"mkdir -p {_parent}",
+                    "bash",
+                    "-c",
+                    f"mkdir -p {_parent}",
                     workdir=self._CONTAINER_ROOT,
                 ).wait()
                 fs.write_bytes(_content, _path)
@@ -761,7 +775,8 @@ class ModalSandbox(BaseSandbox):
         if self._workspace_volume_name:
             try:
                 modal.Volume.objects.delete(
-                    self._workspace_volume_name, allow_missing=True,
+                    self._workspace_volume_name,
+                    allow_missing=True,
                 )
                 self._log(f"deleted workspace volume {self._workspace_volume_name}")
             except Exception as exc:
@@ -777,8 +792,8 @@ class ModalSandbox(BaseSandbox):
         "__pycache__",
         ".pytest_cache",
         "_mounts",
-        "_auth",            # host CLI auth uploaded from ~/.codex etc.
-        "_opt_vibeserve",   # vibe_serve pkg uploaded for MCP
+        "_auth",  # host CLI auth uploaded from ~/.codex etc.
+        "_opt_vibeserve",  # vibe_serve pkg uploaded for MCP
         "acc_checker",
         "bench",
         "skills",
@@ -803,9 +818,7 @@ class ModalSandbox(BaseSandbox):
         import tarfile
         import tempfile
 
-        exclude_args = " ".join(
-            f"--exclude='{e}'" for e in self._DOWNLOAD_EXCLUDES
-        )
+        exclude_args = " ".join(f"--exclude='{e}'" for e in self._DOWNLOAD_EXCLUDES)
         tar_remote = "/tmp/_vibeserve_ws.tar.gz"
         tar_cmd = (
             f"cd {self._CONTAINER_ROOT} && "
@@ -814,7 +827,9 @@ class ModalSandbox(BaseSandbox):
         )
         try:
             proc = self._sandbox.exec(
-                "bash", "-c", tar_cmd,
+                "bash",
+                "-c",
+                tar_cmd,
                 workdir=self._CONTAINER_ROOT,
                 timeout=300,
             )
@@ -826,7 +841,8 @@ class ModalSandbox(BaseSandbox):
 
             data = _retry_transient(
                 lambda: self._sandbox.filesystem.read_bytes(tar_remote),
-                log=self._log, label="workspace tar download",
+                log=self._log,
+                label="workspace tar download",
             )
         except Exception as exc:
             self._log(f"workspace tar download failed: {exc}")

--- a/src/vibe_serve/sandbox/run_environment.py
+++ b/src/vibe_serve/sandbox/run_environment.py
@@ -115,15 +115,23 @@ class RunEnvironment(Protocol):
     backend_image: str | None
 
     def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession: ...
-    def repair_workspace(self, workspace: Path, *, backend: ComputeBackendImpl, log: Callable[[str], None]) -> None: ...
-    def remove_workspace_child(self, workspace: Path, rel_path: str, *, backend: ComputeBackendImpl) -> bool: ...
+    def repair_workspace(
+        self, workspace: Path, *, backend: ComputeBackendImpl, log: Callable[[str], None]
+    ) -> None: ...
+    def remove_workspace_child(
+        self, workspace: Path, rel_path: str, *, backend: ComputeBackendImpl
+    ) -> bool: ...
 
 
 class _NoopWorkspaceRecovery:
-    def repair_workspace(self, workspace: Path, *, backend: ComputeBackendImpl, log: Callable[[str], None]) -> None:
+    def repair_workspace(
+        self, workspace: Path, *, backend: ComputeBackendImpl, log: Callable[[str], None]
+    ) -> None:
         return
 
-    def remove_workspace_child(self, workspace: Path, rel_path: str, *, backend: ComputeBackendImpl) -> bool:
+    def remove_workspace_child(
+        self, workspace: Path, rel_path: str, *, backend: ComputeBackendImpl
+    ) -> bool:
         return False
 
 
@@ -235,7 +243,9 @@ class DockerEnvironment:
             stop_on_close=True,
         )
 
-    def repair_workspace(self, workspace: Path, *, backend: ComputeBackendImpl, log: Callable[[str], None]) -> None:
+    def repair_workspace(
+        self, workspace: Path, *, backend: ComputeBackendImpl, log: Callable[[str], None]
+    ) -> None:
         """Chown workspace files back to the host user after Docker writes."""
         if not workspace.exists():
             return
@@ -257,7 +267,9 @@ class DockerEnvironment:
         except Exception as exc:
             log(f"[warn] chown failed for {workspace}: {exc}")
 
-    def remove_workspace_child(self, workspace: Path, rel_path: str, *, backend: ComputeBackendImpl) -> bool:
+    def remove_workspace_child(
+        self, workspace: Path, rel_path: str, *, backend: ComputeBackendImpl
+    ) -> bool:
         target = workspace / rel_path
         try:
             _docker_workspace_run(
@@ -296,9 +308,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
                 image=str(options["image"]) if options.get("image") else None,
                 gpu=str(options.get("gpu") or "H100"),
                 model_volume=(
-                    str(options["model_volume"])
-                    if options.get("model_volume")
-                    else None
+                    str(options["model_volume"]) if options.get("model_volume") else None
                 ),
                 app=str(options.get("app") or "vibeserve"),
             )
@@ -394,10 +404,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
                 f"meta.json at {meta_path} missing required 'model_id' field "
                 "(needed for Modal auto-upload)"
             )
-        hf_available = bool(
-            os.environ.get("HF_TOKEN")
-            or os.environ.get("HUGGING_FACE_HUB_TOKEN")
-        )
+        hf_available = bool(os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN"))
         local_model = request.ref_dir / "model"
         local_path = None
         if not hf_available and local_model.exists() and local_model.resolve().is_dir():
@@ -410,7 +417,8 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         )
 
     def _ensure_draft_volume(
-        self, request: RunEnvironmentRequest,
+        self,
+        request: RunEnvironmentRequest,
     ) -> str | None:
         """Auto-provision a Modal Volume for an auxiliary draft model.
 
@@ -430,20 +438,12 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         draft_model_id = draft_meta.get("model_id")
         if not draft_model_id:
             raise ValueError(
-                f"draft_meta.json at {draft_meta_path} missing required "
-                "'model_id' field"
+                f"draft_meta.json at {draft_meta_path} missing required 'model_id' field"
             )
-        hf_available = bool(
-            os.environ.get("HF_TOKEN")
-            or os.environ.get("HUGGING_FACE_HUB_TOKEN")
-        )
+        hf_available = bool(os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN"))
         local_draft = request.ref_dir / "draft_model"
         local_path = None
-        if (
-            not hf_available
-            and local_draft.exists()
-            and local_draft.resolve().is_dir()
-        ):
+        if not hf_available and local_draft.exists() and local_draft.resolve().is_dir():
             local_path = str(local_draft.resolve())
         return ensure_model_volume(
             draft_model_id,
@@ -535,12 +535,12 @@ def _modal_runtime_notes(gpu: str, app_name: str) -> str:
         "queues, or auxiliary volumes:\n"
         f"      • App: `app = modal.App({app_name!r})`\n"
         f"      • Web endpoint labels (if any): "
-        f"`@modal.fastapi_endpoint(label=\"{app_name}-<purpose>\")` — "
+        f'`@modal.fastapi_endpoint(label="{app_name}-<purpose>")` — '
         "without a unique label two runs collide on the same public URL "
         "and the second deploy overwrites the first.\n"
         f"      • Auxiliary Volumes / Dicts / Queues / Secrets you "
         f"create: prefix the name with `{app_name}-` "
-        f"(e.g. `modal.Volume.from_name(\"{app_name}-traces\", "
+        f'(e.g. `modal.Volume.from_name("{app_name}-traces", '
         "create_if_missing=True)`).\n"
         "    Model-weight Volumes that the framework pre-stages "
         "(named `vibeserve-model-<...>`, see below) are intentionally "
@@ -565,7 +565,7 @@ def _modal_runtime_notes(gpu: str, app_name: str) -> str:
         "The framework normalizes each `model_id` into the volume "
         "name with this exact rule (matches "
         "`vibe_serve/modal_model_setup.py::_volume_name_for`):\n"
-        "      `re.sub(r\"[^a-z0-9]+\", \"-\", model_id.lower()).strip(\"-\")`\n"
+        '      `re.sub(r"[^a-z0-9]+", "-", model_id.lower()).strip("-")`\n'
         "    prefixed with `vibeserve-model-`. Every run of non-"
         "alphanumeric characters (slashes, dots, underscores, etc.) "
         "collapses to a single `-`. So `org/Foo-1.2-X` becomes "
@@ -672,10 +672,15 @@ def _docker_workspace_run(
     image = getattr(backend, "image", "ubuntu:latest")
     return subprocess.run(
         [
-            "docker", "run", "--rm",
-            "-v", f"{workspace}:/workspace",
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{workspace}:/workspace",
             image,
-            "bash", "-c", shell_command,
+            "bash",
+            "-c",
+            shell_command,
         ],
         capture_output=True,
         check=False,

--- a/src/vibe_serve/schemas.py
+++ b/src/vibe_serve/schemas.py
@@ -25,7 +25,6 @@ from enum import Enum
 
 from pydantic import BaseModel, Field
 
-
 # ===========================================================================
 # Enums
 # ===========================================================================
@@ -51,14 +50,20 @@ class ImplementerResponse(BaseModel):
     """Structured response from the implementer agent."""
 
     summary: str = Field(description="What was implemented or changed this iteration.")
-    expected_behavior: str = Field(description="What behavior is expected (e.g. 'server starts on port 8000, /health returns 200').")
+    expected_behavior: str = Field(
+        description="What behavior is expected (e.g. 'server starts on port 8000, /health returns 200')."
+    )
 
 
 class JudgeResponse(BaseModel):
     """Structured response from the judge agent."""
 
-    analysis: str = Field(description="Detailed analysis of the implementation covering correctness, completeness, dependencies, tests, and code quality.")
-    feedback: str = Field(description="Specific actionable feedback for the implementer. Empty string if passing.")
+    analysis: str = Field(
+        description="Detailed analysis of the implementation covering correctness, completeness, dependencies, tests, and code quality."
+    )
+    feedback: str = Field(
+        description="Specific actionable feedback for the implementer. Empty string if passing."
+    )
     verdict: Verdict = Field(description="PASS if all criteria are met, FAIL otherwise.")
 
 
@@ -96,7 +101,9 @@ class LoadLevelMetrics(BaseModel):
     throughput: ThroughputStats
     ttft: LatencyStats | None = Field(default=None, description="Time to first token stats.")
     tpot: LatencyStats | None = Field(default=None, description="Time per output token stats.")
-    total_latency: LatencyStats | None = Field(default=None, description="End-to-end latency stats.")
+    total_latency: LatencyStats | None = Field(
+        default=None, description="End-to-end latency stats."
+    )
 
 
 class PerfMetrics(BaseModel):
@@ -109,12 +116,24 @@ class PerfMetrics(BaseModel):
 class PerfEvalResponse(BaseModel):
     """Structured response from the performance evaluator agent."""
 
-    analysis: str = Field(description="What the evaluator observed — trends, bottlenecks, saturation points.")
-    metrics: PerfMetrics = Field(description="Structured performance data collected from benchmark runs.")
-    implementer_feedback: list[str] = Field(description="Bullet-point list of concrete optimization ideas for the implementer to try next iteration.")
-    evaluator_feedback: list[str] = Field(description="Bullet-point list of notes for the next performance evaluator (e.g. benchmarking strategy, load levels to try, metrics to watch).")
-    throughput_trend: PerfTrend = Field(description="Whether throughput (req/s, tok/s) improved, regressed, or is mixed compared to the previous iteration.")
-    latency_trend: PerfTrend = Field(description="Whether latency (TTFT, TPOT, total) improved, regressed, or is mixed compared to the previous iteration.")
+    analysis: str = Field(
+        description="What the evaluator observed — trends, bottlenecks, saturation points."
+    )
+    metrics: PerfMetrics = Field(
+        description="Structured performance data collected from benchmark runs."
+    )
+    implementer_feedback: list[str] = Field(
+        description="Bullet-point list of concrete optimization ideas for the implementer to try next iteration."
+    )
+    evaluator_feedback: list[str] = Field(
+        description="Bullet-point list of notes for the next performance evaluator (e.g. benchmarking strategy, load levels to try, metrics to watch)."
+    )
+    throughput_trend: PerfTrend = Field(
+        description="Whether throughput (req/s, tok/s) improved, regressed, or is mixed compared to the previous iteration."
+    )
+    latency_trend: PerfTrend = Field(
+        description="Whether latency (TTFT, TPOT, total) improved, regressed, or is mixed compared to the previous iteration."
+    )
 
 
 # ===========================================================================
@@ -125,9 +144,15 @@ class PerfEvalResponse(BaseModel):
 class ProfilerResponse(BaseModel):
     """Structured response from the nsys profiler agent."""
 
-    analysis: str = Field(description="Detailed interpretation of the nsys profiling data — what the kernel breakdown, CPU overhead, and GPU idle gaps reveal about the implementation.")
-    bottlenecks: str = Field(description="Top bottlenecks identified, ordered by impact. Each bottleneck should name the specific kernel or operation and its contribution to total time.")
-    suggestions: str = Field(description="Actionable optimization suggestions for the implementer, tied to specific bottlenecks. E.g. 'Fuse the 12 RMSNorm kernel launches into a single FlashInfer call' or 'Enable CUDA graphs to eliminate 6ms of CPU launch overhead'.")
+    analysis: str = Field(
+        description="Detailed interpretation of the nsys profiling data — what the kernel breakdown, CPU overhead, and GPU idle gaps reveal about the implementation."
+    )
+    bottlenecks: str = Field(
+        description="Top bottlenecks identified, ordered by impact. Each bottleneck should name the specific kernel or operation and its contribution to total time."
+    )
+    suggestions: str = Field(
+        description="Actionable optimization suggestions for the implementer, tied to specific bottlenecks. E.g. 'Fuse the 12 RMSNorm kernel launches into a single FlashInfer call' or 'Enable CUDA graphs to eliminate 6ms of CPU launch overhead'."
+    )
 
 
 class ProfilerSummary(BaseModel):
@@ -173,8 +198,12 @@ class IssueImplementerResponse(BaseModel):
 
     issue_id: int = Field(description="ID of the issue this implementer worked on.")
     summary: str = Field(description="What was implemented or changed for this specific issue.")
-    files_touched: list[str] = Field(default_factory=list, description="List of files created or modified.")
-    self_check: str = Field(description="Brief note on how the implementer self-validated the change before declaring done.")
+    files_touched: list[str] = Field(
+        default_factory=list, description="List of files created or modified."
+    )
+    self_check: str = Field(
+        description="Brief note on how the implementer self-validated the change before declaring done."
+    )
 
 
 class IssueJudgeResponse(BaseModel):
@@ -186,10 +215,19 @@ class IssueJudgeResponse(BaseModel):
     """
 
     issue_id: int = Field(description="ID of the issue under review.")
-    analysis: str = Field(description="Detailed analysis covering whether the issue is resolved AND general correctness checks.")
-    feedback: str = Field(description="Specific actionable feedback for the implementer if not resolved. Empty if PASS.")
-    verdict: Verdict = Field(description="PASS if the issue is resolved AND general checks pass, FAIL otherwise.")
-    new_issues_filed: list[int] = Field(default_factory=list, description="IDs of new bug-type issues the judge filed via create_issue for unrelated discoveries.")
+    analysis: str = Field(
+        description="Detailed analysis covering whether the issue is resolved AND general correctness checks."
+    )
+    feedback: str = Field(
+        description="Specific actionable feedback for the implementer if not resolved. Empty if PASS."
+    )
+    verdict: Verdict = Field(
+        description="PASS if the issue is resolved AND general checks pass, FAIL otherwise."
+    )
+    new_issues_filed: list[int] = Field(
+        default_factory=list,
+        description="IDs of new bug-type issues the judge filed via create_issue for unrelated discoveries.",
+    )
 
 
 class IssuePerfEvalResponse(BaseModel):
@@ -199,12 +237,24 @@ class IssuePerfEvalResponse(BaseModel):
     returned in this payload (cf. ``PerfEvalResponse.implementer_feedback``).
     """
 
-    analysis: str = Field(description="What the evaluator observed — trends, bottlenecks, saturation points.")
-    metrics: PerfMetrics = Field(description="Structured performance data collected from benchmark runs.")
-    evaluator_feedback: list[str] = Field(description="Bullet-point list of notes for the next performance evaluator (e.g. benchmarking strategy, load levels to try, metrics to watch).")
-    new_issue_ids: list[int] = Field(default_factory=list, description="IDs of issues filed via create_issue this round.")
-    throughput_trend: PerfTrend = Field(description="Whether throughput (req/s, tok/s) improved, regressed, or is mixed compared to the previous iteration.")
-    latency_trend: PerfTrend = Field(description="Whether latency (TTFT, TPOT, total) improved, regressed, or is mixed compared to the previous iteration.")
+    analysis: str = Field(
+        description="What the evaluator observed — trends, bottlenecks, saturation points."
+    )
+    metrics: PerfMetrics = Field(
+        description="Structured performance data collected from benchmark runs."
+    )
+    evaluator_feedback: list[str] = Field(
+        description="Bullet-point list of notes for the next performance evaluator (e.g. benchmarking strategy, load levels to try, metrics to watch)."
+    )
+    new_issue_ids: list[int] = Field(
+        default_factory=list, description="IDs of issues filed via create_issue this round."
+    )
+    throughput_trend: PerfTrend = Field(
+        description="Whether throughput (req/s, tok/s) improved, regressed, or is mixed compared to the previous iteration."
+    )
+    latency_trend: PerfTrend = Field(
+        description="Whether latency (TTFT, TPOT, total) improved, regressed, or is mixed compared to the previous iteration."
+    )
 
 
 # ===========================================================================
@@ -222,9 +272,7 @@ class PreRoundDecision(BaseModel):
         default="",
         description="Guidance for the profiler (e.g. 'focus on decode-path kernels'). Empty when need_profile is False.",
     )
-    reasoning: str = Field(
-        description="Short explanation of the decision. One or two sentences."
-    )
+    reasoning: str = Field(description="Short explanation of the decision. One or two sentences.")
 
 
 class OrchestratorPlan(BaseModel):
@@ -237,9 +285,7 @@ class OrchestratorPlan(BaseModel):
     orchestrator.
     """
 
-    task: str = Field(
-        description="Well-scoped task description handed to the implementer."
-    )
+    task: str = Field(description="Well-scoped task description handed to the implementer.")
     pass_criteria: str = Field(
         description="Feature-level pass criteria for the judge. The framework always runs the accuracy checker and benchmark sanity in addition."
     )
@@ -268,12 +314,22 @@ class SingleAgentRoundResponse(BaseModel):
     """
 
     summary: str = Field(description="What was implemented or changed this round.")
-    expected_behavior: str = Field(description="What behavior the implementation should exhibit (server contract, etc.).")
-    self_review: str = Field(description="Self-review of correctness, accuracy, benchmark sanity, and reward-hack risk — same gates the judge would enforce.")
-    feedback: str = Field(description="Concrete issues to fix on retry; empty when verdict is PASS.")
-    verdict: Verdict = Field(description="PASS if all gates (orchestrator pass criteria + always-on checks) hold; FAIL otherwise.")
+    expected_behavior: str = Field(
+        description="What behavior the implementation should exhibit (server contract, etc.)."
+    )
+    self_review: str = Field(
+        description="Self-review of correctness, accuracy, benchmark sanity, and reward-hack risk — same gates the judge would enforce."
+    )
+    feedback: str = Field(
+        description="Concrete issues to fix on retry; empty when verdict is PASS."
+    )
+    verdict: Verdict = Field(
+        description="PASS if all gates (orchestrator pass criteria + always-on checks) hold; FAIL otherwise."
+    )
     bottlenecks: str = Field(description="Ranked profile bottlenecks with concrete numbers.")
-    suggestions: str = Field(description="Actionable optimization suggestions for the next round, tied to bottlenecks.")
+    suggestions: str = Field(
+        description="Actionable optimization suggestions for the next round, tied to bottlenecks."
+    )
     profile_analysis: str = Field(description="Detailed interpretation of the captured profile.")
     perf_metric: float | None = Field(
         default=None,
@@ -300,9 +356,7 @@ class MutatorResponse(BaseModel):
     population history.
     """
 
-    summary: str = Field(
-        description="Short description of the change made to the parent."
-    )
+    summary: str = Field(description="Short description of the change made to the parent.")
     hypothesis: str = Field(
         description="Why this change is expected to improve the headline metric.",
     )

--- a/tests/_agent_cli/test_agentshim_compat.py
+++ b/tests/_agent_cli/test_agentshim_compat.py
@@ -7,9 +7,13 @@ import vibe_serve._agent_cli.cli_agent
 
 def test_recorder_api_removed_in_favor_of_agent_event_handler():
     assert not hasattr(agentshim, "trajectory")
-    assert "recorder" not in inspect.signature(
-        vibe_serve._agent_cli.cli_agent.CLICodingAgent.__init__
-    ).parameters
-    assert "recorder" not in inspect.signature(
-        vibe_serve._agent_cli.cli_agent.CLIGenerationSession.__init__
-    ).parameters
+    assert (
+        "recorder"
+        not in inspect.signature(vibe_serve._agent_cli.cli_agent.CLICodingAgent.__init__).parameters
+    )
+    assert (
+        "recorder"
+        not in inspect.signature(
+            vibe_serve._agent_cli.cli_agent.CLIGenerationSession.__init__
+        ).parameters
+    )

--- a/tests/_agent_cli/test_claude.py
+++ b/tests/_agent_cli/test_claude.py
@@ -140,9 +140,7 @@ class TestClaudeGenerationSession:
         session.tool_start_times["t1"] = 1000.0
         session.tool_args["t1"] = {"cmd": "ls"}
 
-        line = (
-            '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"file1.txt"}]}}\n'
-        )
+        line = '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"file1.txt"}]}}\n'
         session._process_stdout(line)
         # Tool result was processed without raising.
 
@@ -196,20 +194,19 @@ class TestClaudeGenerationSession:
             '"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}\n'
         )
         session._process_stdout(line)
-        handler.on_usage.assert_called_once_with({
-            "input_tokens": 14000,
-            "output_tokens": 50,
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 0,
-        })
+        handler.on_usage.assert_called_once_with(
+            {
+                "input_tokens": 14000,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            }
+        )
 
     def test_assistant_without_usage_does_not_call_on_usage(self):
         handler = MagicMock()
         session = self._make_session(event_handler=handler)
-        line = (
-            '{"type":"assistant","message":{"content":'
-            '[{"type":"text","text":"ok"}]}}\n'
-        )
+        line = '{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}\n'
         session._process_stdout(line)
         handler.on_usage.assert_not_called()
 
@@ -232,6 +229,7 @@ class TestClaudeGenerationSession:
         The plan calls out that Protocol is structural, so we guard the
         call site with ``getattr`` for back-compat with older handlers.
         """
+
         # A handler object that only implements the original three hooks.
         class LegacyHandler:
             def __init__(self):

--- a/tests/_agent_cli/test_cleanup.py
+++ b/tests/_agent_cli/test_cleanup.py
@@ -3,8 +3,8 @@
 import subprocess
 
 import pytest
-
 from agentshim.executor import CommandRequest, CommandResult, CommandStreamSink
+
 from vibe_serve._agent_cli.claude import ClaudeCodeCodingAgent
 from vibe_serve._agent_cli.cli_agent import CLICodingAgent
 from vibe_serve._agent_cli.codex import CodexCodingAgent

--- a/tests/_agent_cli/test_codex.py
+++ b/tests/_agent_cli/test_codex.py
@@ -95,7 +95,7 @@ class TestGetResumeCommand:
     def test_resume_command_passes_model_and_extra_config(self):
         agent = _agent()
         agent.model = "gpt-5"
-        agent.extra_config_args = ["--config", "mcp_servers.x.command=\"python\""]
+        agent.extra_config_args = ["--config", 'mcp_servers.x.command="python"']
         cmd = agent._get_resume_command("prompt", "sess-123")
         assert "--model" in cmd and cmd[cmd.index("--model") + 1] == "gpt-5"
         assert cmd[-2:] == ["--config", 'mcp_servers.x.command="python"']
@@ -223,9 +223,7 @@ class TestProcessStdout:
                 }
             )
         )
-        handler.on_tool_call.assert_called_once_with(
-            "error", {"message": "rate limited"}
-        )
+        handler.on_tool_call.assert_called_once_with("error", {"message": "rate limited"})
 
     def test_command_execution_forwards_tool_call_and_result(self):
         handler = MagicMock()
@@ -285,9 +283,7 @@ class TestProcessStdout:
     def test_thread_started_emits_marker(self):
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stdout(
-            json.dumps({"type": "thread.started", "thread_id": "t-1"})
-        )
+        session._process_stdout(json.dumps({"type": "thread.started", "thread_id": "t-1"}))
         assert session.session_id == "t-1"
         handler.on_thinking.assert_called_once_with("[codex thread t-1 started]")
 
@@ -302,7 +298,9 @@ class TestProcessStdout:
         text so nothing codex emits is silently swallowed."""
         handler = MagicMock()
         session = _session(event_handler=handler)
-        raw = json.dumps({"type": "item.updated", "item": {"type": "reasoning", "delta": "thinking..."}})
+        raw = json.dumps(
+            {"type": "item.updated", "item": {"type": "reasoning", "delta": "thinking..."}}
+        )
         session._process_stdout(raw)
         handler.on_thinking.assert_called_once_with(raw)
 
@@ -334,9 +332,7 @@ class TestProcessStderr:
         handler = MagicMock()
         session = _session(event_handler=handler)
         session._process_stderr("panic: index out of bounds\n")
-        handler.on_thinking.assert_called_once_with(
-            "[codex stderr] panic: index out of bounds"
-        )
+        handler.on_thinking.assert_called_once_with("[codex stderr] panic: index out of bounds")
         assert session.stderr_lines == ["panic: index out of bounds\n"]
 
     def test_stderr_empty_line_ignored(self):

--- a/tests/_agent_cli/test_docker_executor.py
+++ b/tests/_agent_cli/test_docker_executor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 
 from agentshim.executor import CallbackCommandStreamSink, CommandRequest
+
 from vibe_serve.agents.docker_executor import DockerCommandExecutor, DockerCommandHandle
 
 

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -8,9 +8,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibe_serve.agents import build_agent_runner
+from vibe_serve.agents.callbacks import AgentLogger
 from vibe_serve.agents.cli_runner import CliAgentRunner
 from vibe_serve.agents.deepagents_runner import DeepAgentsRunner
-from vibe_serve.agents.callbacks import AgentLogger
 from vibe_serve.config import Config
 from vibe_serve.schemas import (
     JudgeResponse,
@@ -40,11 +40,10 @@ class TestDeepAgentsRunner:
             feedback="",
             verdict=Verdict.PASS,
         )
-        with patch(
-            "vibe_serve.agents.deepagents_runner.create_deep_agent"
-        ) as mock_create, patch(
-            "vibe_serve.agents.deepagents_runner._run_typed_agent"
-        ) as mock_run:
+        with (
+            patch("vibe_serve.agents.deepagents_runner.create_deep_agent") as mock_create,
+            patch("vibe_serve.agents.deepagents_runner._run_typed_agent") as mock_run,
+        ):
             mock_create.return_value = MagicMock(name="deep_agent")
             mock_run.return_value = pass_response
 
@@ -87,12 +86,15 @@ class TestDeepAgentsRunner:
             captured_backends.append(kwargs["backend"])
             return MagicMock(name="deep_agent")
 
-        with patch(
-            "vibe_serve.agents.deepagents_runner.create_deep_agent",
-            side_effect=_capture,
-        ), patch(
-            "vibe_serve.agents.deepagents_runner._run_typed_agent",
-            return_value=_judge_fallback(),
+        with (
+            patch(
+                "vibe_serve.agents.deepagents_runner.create_deep_agent",
+                side_effect=_capture,
+            ),
+            patch(
+                "vibe_serve.agents.deepagents_runner._run_typed_agent",
+                return_value=_judge_fallback(),
+            ),
         ):
             runner = DeepAgentsRunner(
                 model="m",
@@ -188,9 +190,7 @@ def _make_fake_agent_class(
 class TestCliAgentRunner:
     """Tests for :class:`CliAgentRunner`."""
 
-    @pytest.mark.parametrize(
-        "provider", ["claude", "gemini", "codex", "opencode"]
-    )
+    @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
     def test_cli_runner_invokes_provider_and_returns_parsed_response(
         self, monkeypatch, tmp_path, provider
     ):
@@ -231,9 +231,7 @@ class TestCliAgentRunner:
         assert len(captured) == 1
         assert captured[0].generate_calls[0]["cwd"] == str(workspace)
 
-    def test_cli_runner_falls_back_on_unparseable_output(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_falls_back_on_unparseable_output(self, monkeypatch, tmp_path):
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns="banana",
@@ -273,11 +271,7 @@ class TestCliAgentRunner:
 
     def test_cli_runner_parses_fenced_json(self, monkeypatch, tmp_path):
         captured: list = []
-        fenced = (
-            '```json\n'
-            '{"analysis": "fenced", "feedback": "", "verdict": "pass"}\n'
-            '```'
-        )
+        fenced = '```json\n{"analysis": "fenced", "feedback": "", "verdict": "pass"}\n```'
         fake_cls = _make_fake_agent_class(
             generate_returns=fenced,
             captured=captured,
@@ -312,9 +306,7 @@ class TestCliAgentRunner:
         assert result.verdict == Verdict.PASS
         assert result.analysis == "fenced"
 
-    def test_cli_runner_materializes_skills_into_workspace(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_materializes_skills_into_workspace(self, monkeypatch, tmp_path):
         # Tier-organized source tree (like vibe-serve-skills):
         #   skill_src/
         #     algorithms/myskill/SKILL.md
@@ -375,9 +367,7 @@ class TestCliAgentRunner:
             assert (workspace / cli_dir / "myskill" / "file.txt").read_text() == "hello skill"
             assert (workspace / cli_dir / "tool-skill" / "SKILL.md").exists()
 
-    def test_cli_runner_materializes_single_skill_with_nested_content(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_materializes_single_skill_with_nested_content(self, monkeypatch, tmp_path):
         # Single-skill source (SKILL.md at the root, sub-dirs are reference
         # material inside the one skill). This mirrors the repo's
         # `serving-systems/` layout.
@@ -423,13 +413,15 @@ class TestCliAgentRunner:
         for cli_dir in (".claude/skills", ".agents/skills", ".gemini/skills"):
             assert (workspace / cli_dir / "serving-systems" / "SKILL.md").exists()
             assert (
-                workspace / cli_dir / "serving-systems"
-                / "algorithms" / "paged-attention" / "SKILL.md"
+                workspace
+                / cli_dir
+                / "serving-systems"
+                / "algorithms"
+                / "paged-attention"
+                / "SKILL.md"
             ).exists()
 
-    def test_cli_runner_appends_json_schema_to_prompt(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_appends_json_schema_to_prompt(self, monkeypatch, tmp_path):
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
@@ -467,9 +459,7 @@ class TestCliAgentRunner:
         assert "JudgeResponse" in prompt
         assert prompt.startswith("THE-SYSTEM-PROMPT")
 
-    def test_cli_runner_writes_usage_jsonl_on_success(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_writes_usage_jsonl_on_success(self, monkeypatch, tmp_path):
         """CliAgentRunner appends one JSON record per invoke() to ``<log_dir>/usage.jsonl``."""
         captured: list = []
         fake_cls = _make_fake_agent_class(
@@ -535,9 +525,7 @@ class TestCliAgentRunner:
         assert record["duration_ms"] == 18_431
         assert "timestamp" in record
 
-    def test_cli_runner_usage_jsonl_appends_across_invocations(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_usage_jsonl_appends_across_invocations(self, monkeypatch, tmp_path):
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
@@ -585,9 +573,7 @@ class TestCliAgentRunner:
         labels = [json.loads(line)["round_label"] for line in lines]
         assert labels == ["round #0", "round #1", "round #2"]
 
-    def test_cli_runner_usage_jsonl_written_on_parse_failure(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_usage_jsonl_written_on_parse_failure(self, monkeypatch, tmp_path):
         """Even when the CLI returns unparseable output, the tokens were spent —
         the usage record must still be appended so the audit log is complete."""
         captured: list = []
@@ -640,9 +626,7 @@ class TestCliAgentRunner:
         assert record["input_tokens"] == 7_000
         assert record["total_cost_usd"] == 0.0034
 
-    def test_cli_runner_usage_jsonl_noop_when_log_dir_none(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_usage_jsonl_noop_when_log_dir_none(self, monkeypatch, tmp_path):
         """Runners built without log_dir (tests, legacy callers) must still succeed."""
         captured: list = []
         fake_cls = _make_fake_agent_class(
@@ -683,9 +667,7 @@ class TestCliAgentRunner:
         )
         assert result.verdict == Verdict.PASS
 
-    def test_cli_runner_layers_env_into_subprocess_env(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_layers_env_into_subprocess_env(self, monkeypatch, tmp_path):
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
@@ -722,9 +704,7 @@ class TestCliAgentRunner:
         assert len(captured) == 1
         assert captured[0].env.get("CUDA_VISIBLE_DEVICES") == "2"
 
-    def test_cli_runner_docker_uses_command_executor(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_docker_uses_command_executor(self, monkeypatch, tmp_path):
         from types import SimpleNamespace
 
         from vibe_serve.agents.docker_executor import DockerCommandExecutor
@@ -805,9 +785,7 @@ class TestCliAgentRunner:
         assert len(captured) == 1
         assert captured[0].executor.container_id == "container-two"
 
-    def test_cli_runner_invokes_install_then_generate_then_uninstall(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_invokes_install_then_generate_then_uninstall(self, monkeypatch, tmp_path):
         """The mcp_servers kwarg triggers a strict install → generate → uninstall sandwich."""
         from vibe_serve._agent_cli.base import MCPServerSpec
 
@@ -850,9 +828,7 @@ class TestCliAgentRunner:
         assert agent.uninstall_calls[0]["workspace"] == workspace
         assert agent.uninstall_calls[0]["servers"] == [spec]
 
-    def test_cli_runner_uninstalls_even_when_generate_raises(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_uninstalls_even_when_generate_raises(self, monkeypatch, tmp_path):
         """uninstall_mcp_servers must run in finally so a crashing generate
         doesn't leave stale config in the workspace."""
         from vibe_serve._agent_cli.base import MCPServerSpec
@@ -892,9 +868,7 @@ class TestCliAgentRunner:
         agent = captured[0]
         assert agent.event_log == ["install", "generate", "uninstall"]
 
-    def test_cli_runner_skips_install_uninstall_when_no_mcp_servers(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cli_runner_skips_install_uninstall_when_no_mcp_servers(self, monkeypatch, tmp_path):
         """When mcp_servers is None or omitted, install/uninstall hooks are
         not called at all."""
         captured: list = []
@@ -974,17 +948,17 @@ class TestBuildAgentRunner:
     def test_build_agent_runner_cli_defaults_to_codex(self):
         """When backend=cli and no provider specified, defaults to codex."""
         runner = build_agent_runner(
-                _agent_config(backend="cli"),
-                agent_backend=None,
-                cli_provider=None,
-                backends=None,
-                skills=[],
-                skill_source_dirs=[],
-                model=None,
-                model_name="m",
-                run_log_file=None,
-                use_docker=False,
-            )
+            _agent_config(backend="cli"),
+            agent_backend=None,
+            cli_provider=None,
+            backends=None,
+            skills=[],
+            skill_source_dirs=[],
+            model=None,
+            model_name="m",
+            run_log_file=None,
+            use_docker=False,
+        )
         assert runner.backend_name == "cli"
         assert runner._provider == "codex"
 
@@ -1096,11 +1070,11 @@ class TestAgentLoggerEventHandler:
             agent_label="Judge",
         )
 
-        with patch.object(logger, "log_text") as mock_text, patch.object(
-            logger, "log_tool_call"
-        ) as mock_tool_call, patch.object(
-            logger, "log_tool_result"
-        ) as mock_tool_result:
+        with (
+            patch.object(logger, "log_text") as mock_text,
+            patch.object(logger, "log_tool_call") as mock_tool_call,
+            patch.object(logger, "log_tool_result") as mock_tool_result,
+        ):
             logger.on_thinking("hello")
             logger.on_tool_call("Bash", {"command": "ls"})
             logger.on_tool_result("Bash", stdout="output", exit_code=0)

--- a/tests/agents/test_callbacks.py
+++ b/tests/agents/test_callbacks.py
@@ -1,13 +1,12 @@
 import io
 import json
 import re
+from unittest.mock import MagicMock
 
 import pytest
-from unittest.mock import MagicMock
 
 from vibe_serve.agents.callbacks import AgentLogger
 from vibe_serve.constants import _BOLD, _CYAN, _DIM, _GREEN, _RED, _RESET, _YELLOW
-
 
 _ANSI_RE = re.compile(r"\033\[[0-9;]*m")
 
@@ -198,6 +197,7 @@ class TestOnToolError:
     def test_prints_error_in_red(self, capsys):
         logger = AgentLogger()
         from uuid import uuid4
+
         logger.on_tool_error(Exception("something broke"), run_id=uuid4())
         out = capsys.readouterr().out
         assert _RED in out
@@ -207,6 +207,7 @@ class TestOnToolError:
     def test_does_not_use_dim(self, capsys):
         logger = AgentLogger()
         from uuid import uuid4
+
         logger.on_tool_error(Exception("fail"), run_id=uuid4())
         out = capsys.readouterr().out
         assert _DIM not in out
@@ -337,7 +338,10 @@ class TestOnChatModelStart:
     def test_first_call_logs_model_info(self, capsys):
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
-        serialized = {"id": ["langchain", "chat_models", "anthropic", "ChatAnthropic"], "kwargs": {"model": "claude-sonnet-4-6"}}
+        serialized = {
+            "id": ["langchain", "chat_models", "anthropic", "ChatAnthropic"],
+            "kwargs": {"model": "claude-sonnet-4-6"},
+        }
         messages = [[self._make_system_message(), self._make_human_message()]]
         logger.on_chat_model_start(serialized, messages)
         log_text = log.getvalue()
@@ -346,7 +350,10 @@ class TestOnChatModelStart:
     def test_first_call_logs_system_prompt(self, capsys):
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
-        serialized = {"id": ["langchain", "chat_models", "anthropic", "ChatAnthropic"], "kwargs": {"model": "claude-sonnet-4-6"}}
+        serialized = {
+            "id": ["langchain", "chat_models", "anthropic", "ChatAnthropic"],
+            "kwargs": {"model": "claude-sonnet-4-6"},
+        }
         system_prompt = "You are an expert ML engineer."
         messages = [[self._make_system_message(system_prompt), self._make_human_message()]]
         logger.on_chat_model_start(serialized, messages)
@@ -357,14 +364,16 @@ class TestOnChatModelStart:
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
         serialized = {"id": ["langchain", "chat_models"], "kwargs": {}}
-        messages = [[
-            self._make_system_message(),
-            self._make_human_message(),
-            self._make_ai_message(),
-            self._make_tool_message(),
-            self._make_tool_message(),
-            self._make_human_message("follow up"),
-        ]]
+        messages = [
+            [
+                self._make_system_message(),
+                self._make_human_message(),
+                self._make_ai_message(),
+                self._make_tool_message(),
+                self._make_tool_message(),
+                self._make_human_message("follow up"),
+            ]
+        ]
         logger.on_chat_model_start(serialized, messages)
         log_text = log.getvalue()
         assert "1 system" in log_text
@@ -387,12 +396,14 @@ class TestOnChatModelStart:
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
         serialized = {"id": ["langchain"], "kwargs": {}}
-        messages = [[
-            self._make_system_message(),
-            self._make_human_message("first question"),
-            self._make_ai_message("first answer"),
-            self._make_human_message("second question"),
-        ]]
+        messages = [
+            [
+                self._make_system_message(),
+                self._make_human_message("first question"),
+                self._make_ai_message("first answer"),
+                self._make_human_message("second question"),
+            ]
+        ]
         logger.on_chat_model_start(serialized, messages)
         log_text = log.getvalue()
         assert "second question" in log_text
@@ -428,15 +439,18 @@ class TestOnChatModelStart:
 class TestFormatTokenCount:
     def test_zero(self):
         from vibe_serve.agents.callbacks import _format_token_count
+
         assert _format_token_count(0) == "0"
 
     def test_under_thousand(self):
         from vibe_serve.agents.callbacks import _format_token_count
+
         assert _format_token_count(523) == "523"
         assert _format_token_count(999) == "999"
 
     def test_thousands_boundary(self):
         from vibe_serve.agents.callbacks import _format_token_count
+
         assert _format_token_count(1000) == "1k"
         assert _format_token_count(20_100) == "20k"
         assert _format_token_count(199_500) == "199k"
@@ -444,6 +458,7 @@ class TestFormatTokenCount:
 
     def test_millions(self):
         from vibe_serve.agents.callbacks import _format_token_count
+
         assert _format_token_count(1_000_000) == "1.0M"
         assert _format_token_count(1_200_000) == "1.2M"
         assert _format_token_count(1_048_576) == "1.0M"
@@ -452,33 +467,39 @@ class TestFormatTokenCount:
 class TestDefaultContextWindowLookup:
     def test_claude_4_6_resolves_to_1m(self):
         from vibe_serve.agents.callbacks import _default_context_window_lookup
+
         assert _default_context_window_lookup("claude-opus-4-6") == 1_000_000
         assert _default_context_window_lookup("claude-sonnet-4-6") == 1_000_000
 
     def test_older_claude_falls_back_to_200k(self):
         # Regression guard: claude- fallback comes after the 4-6 entries
         from vibe_serve.agents.callbacks import _default_context_window_lookup
+
         assert _default_context_window_lookup("claude-haiku-4-5") == 200_000
         assert _default_context_window_lookup("claude-sonnet-4-5") == 200_000
         assert _default_context_window_lookup("claude-opus-4-1") == 200_000
 
     def test_gemini(self):
         from vibe_serve.agents.callbacks import _default_context_window_lookup
+
         assert _default_context_window_lookup("gemini-2.5-flash") == 1_048_576
         assert _default_context_window_lookup("gemini-3-pro") == 1_048_576
 
     def test_gemma(self):
         from vibe_serve.agents.callbacks import _default_context_window_lookup
+
         assert _default_context_window_lookup("gemma-2") == 8_192
 
     def test_gpt5_4_resolves_to_1m(self):
         # Regression guard: gpt-5.4 entry must come before gpt-5
         from vibe_serve.agents.callbacks import _default_context_window_lookup
+
         assert _default_context_window_lookup("gpt-5.4") == 1_050_000
         assert _default_context_window_lookup("gpt-5.4-pro") == 1_050_000
 
     def test_gpt5_family_falls_back_to_400k(self):
         from vibe_serve.agents.callbacks import _default_context_window_lookup
+
         assert _default_context_window_lookup("gpt-5") == 400_000
         assert _default_context_window_lookup("gpt-5-mini") == 400_000
         assert _default_context_window_lookup("gpt-5-nano") == 400_000
@@ -486,6 +507,7 @@ class TestDefaultContextWindowLookup:
 
     def test_gpt4_and_o_series(self):
         from vibe_serve.agents.callbacks import _default_context_window_lookup
+
         assert _default_context_window_lookup("gpt-4o") == 128_000
         assert _default_context_window_lookup("gpt-4-turbo") == 128_000
         assert _default_context_window_lookup("o1") == 200_000
@@ -494,10 +516,12 @@ class TestDefaultContextWindowLookup:
 
     def test_unknown_model_returns_none(self):
         from vibe_serve.agents.callbacks import _default_context_window_lookup
+
         assert _default_context_window_lookup("unknown-model-xyz") is None
 
     def test_none_model_name_returns_none(self):
         from vibe_serve.agents.callbacks import _default_context_window_lookup
+
         assert _default_context_window_lookup(None) is None
 
 
@@ -543,9 +567,15 @@ class TestPrefixFormat:
 
     def test_prefix_updates_after_on_llm_end(self, capsys):
         logger = AgentLogger(agent_label="Implementer", model_name="claude-sonnet-4-6")
-        logger.on_llm_end(_make_response(
-            usage_metadata={"input_tokens": 20_100, "output_tokens": 100, "total_tokens": 20_200}
-        ))
+        logger.on_llm_end(
+            _make_response(
+                usage_metadata={
+                    "input_tokens": 20_100,
+                    "output_tokens": 100,
+                    "total_tokens": 20_200,
+                }
+            )
+        )
         capsys.readouterr()  # discard
         logger.on_llm_new_token("next")
         out = _strip_ansi(capsys.readouterr().out)
@@ -554,10 +584,12 @@ class TestPrefixFormat:
     def test_tool_call_path_uses_dynamic_prefix(self, capsys):
         logger = AgentLogger(agent_label="Implementer", model_name="gpt-5.4")
         tc = [{"name": "shell", "args": {"cmd": "ls"}}]
-        logger.on_llm_end(_make_response(
-            tool_calls=tc,
-            usage_metadata={"input_tokens": 5_000, "output_tokens": 50, "total_tokens": 5_050},
-        ))
+        logger.on_llm_end(
+            _make_response(
+                tool_calls=tc,
+                usage_metadata={"input_tokens": 5_000, "output_tokens": 50, "total_tokens": 5_050},
+            )
+        )
         out = _strip_ansi(capsys.readouterr().out)
         # Tool-call line should carry the dynamic prefix with elapsed and tokens
         assert re.search(r"\[Implementer \| \d+\.\ds \| 5k/1\.\dM\] → shell\(", out), out
@@ -576,6 +608,7 @@ class TestPrefixFormat:
 
     def test_default_lookup_used_when_not_injected(self):
         from vibe_serve.agents.callbacks import _default_context_window_lookup
+
         logger = AgentLogger(agent_label="Test", model_name="gpt-5.4")
         assert logger._context_window_lookup is _default_context_window_lookup
         assert logger._context_window == 1_050_000
@@ -583,6 +616,7 @@ class TestPrefixFormat:
     def test_elapsed_time_advances(self, capsys, monkeypatch):
         # Fake time.monotonic so we can verify the elapsed value reaches the prefix
         from vibe_serve.agents import callbacks
+
         ticks = iter([1000.0, 1308.2])
         monkeypatch.setattr(callbacks.time, "monotonic", lambda: next(ticks))
         logger = AgentLogger(agent_label="Implementer", model_name="claude-sonnet-4-6")
@@ -596,9 +630,15 @@ class TestUsageMetadataExtraction:
     def test_extracts_input_tokens(self):
         logger = AgentLogger(agent_label="X", model_name="claude-sonnet-4-6")
         assert logger._input_tokens == 0
-        logger.on_llm_end(_make_response(
-            usage_metadata={"input_tokens": 12_345, "output_tokens": 100, "total_tokens": 12_445}
-        ))
+        logger.on_llm_end(
+            _make_response(
+                usage_metadata={
+                    "input_tokens": 12_345,
+                    "output_tokens": 100,
+                    "total_tokens": 12_445,
+                }
+            )
+        )
         assert logger._input_tokens == 12_345
 
     def test_no_usage_metadata_keeps_zero(self):
@@ -611,18 +651,22 @@ class TestUsageMetadataExtraction:
         # on_llm_end during streaming must update tokens before its early-return
         logger = AgentLogger(agent_label="X", model_name="claude-sonnet-4-6")
         logger._streaming = True
-        logger.on_llm_end(_make_response(
-            usage_metadata={"input_tokens": 5_000, "output_tokens": 100, "total_tokens": 5_100}
-        ))
+        logger.on_llm_end(
+            _make_response(
+                usage_metadata={"input_tokens": 5_000, "output_tokens": 100, "total_tokens": 5_100}
+            )
+        )
         assert logger._input_tokens == 5_000
 
     def test_zero_input_tokens_does_not_overwrite(self):
         # Defensive: a usage block reporting 0 input tokens should not clobber a real prior value
         logger = AgentLogger(agent_label="X", model_name="claude-sonnet-4-6")
         logger._input_tokens = 1234
-        logger.on_llm_end(_make_response(
-            usage_metadata={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
-        ))
+        logger.on_llm_end(
+            _make_response(
+                usage_metadata={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            )
+        )
         assert logger._input_tokens == 1234
 
 

--- a/tests/backends/test_gpu_monitor.py
+++ b/tests/backends/test_gpu_monitor.py
@@ -15,7 +15,6 @@ from vibe_serve.backends.cuda.gpu_monitor import (
     query_gpu_info,
 )
 
-
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
@@ -26,8 +25,12 @@ GPU_B = "GPU-bbbb"
 
 def _gpu(index: int, uuid: str, used: int = 0, total: int = 81559, util: int = 0) -> GpuInfo:
     return GpuInfo(
-        index=index, uuid=uuid, name="H100",
-        memory_used_mib=used, memory_total_mib=total, utilization_pct=util,
+        index=index,
+        uuid=uuid,
+        name="H100",
+        memory_used_mib=used,
+        memory_total_mib=total,
+        utilization_pct=util,
     )
 
 
@@ -39,10 +42,14 @@ def _gpu(index: int, uuid: str, used: int = 0, total: int = 81559, util: int = 0
 class TestQueryGpuInfo:
     @patch("vibe_serve.backends.cuda.gpu_monitor.subprocess.run")
     def test_parses_csv(self, mock_run):
-        mock_run.return_value = type("R", (), {
-            "returncode": 0,
-            "stdout": f"0, {GPU_A}, H100, 5000, 81559, 30\n1, {GPU_B}, H100, 100, 81559, 0\n",
-        })()
+        mock_run.return_value = type(
+            "R",
+            (),
+            {
+                "returncode": 0,
+                "stdout": f"0, {GPU_A}, H100, 5000, 81559, 30\n1, {GPU_B}, H100, 100, 81559, 0\n",
+            },
+        )()
         gpus = query_gpu_info()
         assert len(gpus) == 2
         assert gpus[0].index == 0
@@ -113,7 +120,9 @@ class TestMonitorLifecycle:
     def test_start_stop(self, mock_procs, _mock_gpus):
         mock_procs.return_value = ""
         mon = GpuContentionMonitor(
-            log_dir=Path("/tmp"), gpu_uuid=GPU_A, interval=0.05,
+            log_dir=Path("/tmp"),
+            gpu_uuid=GPU_A,
+            interval=0.05,
         )
         mon.start()
         assert mon._thread is not None
@@ -128,7 +137,9 @@ class TestMonitorLifecycle:
         """PIDs present at start() time become the baseline."""
         mock_procs.return_value = f"100, python, 4096, {GPU_A}\n"
         mon = GpuContentionMonitor(
-            log_dir=Path("/tmp"), gpu_uuid=GPU_A, interval=0.05,
+            log_dir=Path("/tmp"),
+            gpu_uuid=GPU_A,
+            interval=0.05,
         )
         mon.start()
         assert 100 in mon._baseline_pids
@@ -144,16 +155,15 @@ class TestMonitorLifecycle:
         # Baseline: only PID 100
         mock_procs.return_value = f"100, python, 4096, {GPU_A}\n"
         mon = GpuContentionMonitor(
-            log_dir=Path("/tmp"), gpu_uuid=GPU_A, interval=0.05,
+            log_dir=Path("/tmp"),
+            gpu_uuid=GPU_A,
+            interval=0.05,
         )
         mon.start()
         time.sleep(0.05)
 
         # New PID 200 appears on the same GPU
-        mock_procs.return_value = (
-            f"100, python, 4096, {GPU_A}\n"
-            f"200, train.py, 8192, {GPU_A}\n"
-        )
+        mock_procs.return_value = f"100, python, 4096, {GPU_A}\n200, train.py, 8192, {GPU_A}\n"
         time.sleep(0.15)
         status = mon.status
         mon.stop()
@@ -166,16 +176,15 @@ class TestMonitorLifecycle:
         """A new PID on a different GPU is not contention."""
         mock_procs.return_value = f"100, python, 4096, {GPU_A}\n"
         mon = GpuContentionMonitor(
-            log_dir=Path("/tmp"), gpu_uuid=GPU_A, interval=0.05,
+            log_dir=Path("/tmp"),
+            gpu_uuid=GPU_A,
+            interval=0.05,
         )
         mon.start()
         time.sleep(0.05)
 
         # PID 200 appears but on GPU_B
-        mock_procs.return_value = (
-            f"100, python, 4096, {GPU_A}\n"
-            f"200, train.py, 8192, {GPU_B}\n"
-        )
+        mock_procs.return_value = f"100, python, 4096, {GPU_A}\n200, train.py, 8192, {GPU_B}\n"
         time.sleep(0.15)
         status = mon.status
         mon.stop()
@@ -189,15 +198,14 @@ class TestMonitorLifecycle:
 
         mock_procs.return_value = f"100, python, 4096, {GPU_A}\n"
         mon = GpuContentionMonitor(
-            log_dir=log_dir, gpu_uuid=GPU_A, interval=0.05,
+            log_dir=log_dir,
+            gpu_uuid=GPU_A,
+            interval=0.05,
         )
         mon.start()
         time.sleep(0.05)
 
-        mock_procs.return_value = (
-            f"100, python, 4096, {GPU_A}\n"
-            f"200, train.py, 8192, {GPU_A}\n"
-        )
+        mock_procs.return_value = f"100, python, 4096, {GPU_A}\n200, train.py, 8192, {GPU_A}\n"
         time.sleep(0.2)
         mon.stop()
 
@@ -218,7 +226,9 @@ class TestMonitorLifecycle:
 
         mock_procs.return_value = f"100, python, 4096, {GPU_A}\n"
         mon = GpuContentionMonitor(
-            log_dir=log_dir, gpu_uuid=GPU_A, interval=0.05,
+            log_dir=log_dir,
+            gpu_uuid=GPU_A,
+            interval=0.05,
         )
         mon.start()
         time.sleep(0.15)
@@ -234,7 +244,9 @@ class TestMonitorLifecycle:
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
         mon = GpuContentionMonitor(
-            log_dir=log_dir, gpu_uuid=GPU_A, interval=0.05,
+            log_dir=log_dir,
+            gpu_uuid=GPU_A,
+            interval=0.05,
         )
         mon.start()
         time.sleep(0.15)
@@ -278,12 +290,14 @@ class TestReselectGpu:
         # the backend so reselect_device's iteration over self._sandboxes
         # finds them.
         from vibe_serve.backends.base import SandboxKind
+
         if use_docker:
             ctx.implementer_backend = MagicMock(spec=DockerSandbox)
             ctx.judge_backend = MagicMock(spec=DockerSandbox)
             kind = SandboxKind.DOCKER
         else:
             from deepagents.backends import LocalShellBackend
+
             ctx.implementer_backend = MagicMock(spec=LocalShellBackend)
             ctx.judge_backend = MagicMock(spec=LocalShellBackend)
             # _env mutated by reselect_device — give it a real dict.

--- a/tests/backends/test_trainium_backend.py
+++ b/tests/backends/test_trainium_backend.py
@@ -56,8 +56,7 @@ class TestTrainiumSandbox:
         assert sb._gpus is None
         # Persistent compile cache is bind-mounted and passthrough-registered.
         assert any(
-            container == "/opt/neuron-compile-cache"
-            for _host, container, _ro in sb._bind_mounts
+            container == "/opt/neuron-compile-cache" for _host, container, _ro in sb._bind_mounts
         )
         assert "/opt/neuron-compile-cache" in sb._passthrough_prefixes
         assert sb._env.get("NEURON_COMPILE_CACHE_URL") == "/opt/neuron-compile-cache"

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -22,12 +22,7 @@ from vibe_serve.loops.agent.domain import (
 from vibe_serve.prompts import render_template
 
 _TEMPLATE_DIR = (
-    Path(__file__).resolve().parents[3]
-    / "src"
-    / "vibe_serve"
-    / "loops"
-    / "agent"
-    / "templates"
+    Path(__file__).resolve().parents[3] / "src" / "vibe_serve" / "loops" / "agent" / "templates"
 )
 
 
@@ -117,12 +112,8 @@ def test_deeper_markdown_heading_does_not_delimit_role(tmp_path: Path):
 def test_render_role_branches_on_context():
     """A role section rendered with bench_path set should reference it."""
     d = resolve_domain("llm-serving")
-    with_bench = render_domain_section(
-        d, "judge", modality="text_generation", bench_path="/BENCHX"
-    )
-    without_bench = render_domain_section(
-        d, "judge", modality="text_generation", bench_path=None
-    )
+    with_bench = render_domain_section(d, "judge", modality="text_generation", bench_path="/BENCHX")
+    without_bench = render_domain_section(d, "judge", modality="text_generation", bench_path=None)
     assert "/BENCHX" in with_bench
     assert "/BENCHX" not in without_bench
 
@@ -130,18 +121,14 @@ def test_render_role_branches_on_context():
 def test_single_agent_uses_explicit_section_when_present():
     # llm-serving.md ships a bespoke ## single_agent section
     d = resolve_domain("llm-serving")
-    sa = render_domain_section(
-        d, "single_agent", modality="text_generation", reference_path="/ref"
-    )
+    sa = render_domain_section(d, "single_agent", modality="text_generation", reference_path="/ref")
     assert "do not let yourself cheat" in sa  # text unique to that section
 
 
 def test_single_agent_derives_from_implementer_and_judge(tmp_path: Path):
     # no ## single_agent section -> derived from implementer + judge
     f = tmp_path / "d.md"
-    f.write_text(
-        "# D\n\n## implementer\nIMPL-BODY\n\n## judge\nJUDGE-BODY\n"
-    )
+    f.write_text("# D\n\n## implementer\nIMPL-BODY\n\n## judge\nJUDGE-BODY\n")
     sa = render_domain_section(f, "single_agent")
     assert "IMPL-BODY" in sa
     assert "JUDGE-BODY" in sa

--- a/tests/loops/agent/test_issue_board.py
+++ b/tests/loops/agent/test_issue_board.py
@@ -8,9 +8,9 @@ import pytest
 
 from vibe_serve.loops.plain.issue_board import (
     Issue,
+    IssueBoard,
     IssueEvent,
     IssueStatus,
-    IssueBoard,
     IssueType,
 )
 
@@ -19,11 +19,15 @@ def _make_store(tmp_path) -> IssueBoard:
     return IssueBoard(tmp_path / "issues.json")
 
 
-def _create(store, *, type=IssueType.BUG, title="t", description="d",
-            created_by="perf_eval", iteration=1) -> Issue:
+def _create(
+    store, *, type=IssueType.BUG, title="t", description="d", created_by="perf_eval", iteration=1
+) -> Issue:
     return store.create(
-        type=type, title=title, description=description,
-        created_by=created_by, iteration=iteration,
+        type=type,
+        title=title,
+        description=description,
+        created_by=created_by,
+        iteration=iteration,
     )
 
 
@@ -63,8 +67,11 @@ class TestCreate:
     def test_create_accepts_string_type(self, tmp_path):
         store = _make_store(tmp_path)
         issue = store.create(
-            type="perf", title="p", description="d",
-            created_by="perf_eval", iteration=1,
+            type="perf",
+            title="p",
+            description="d",
+            created_by="perf_eval",
+            iteration=1,
         )
         assert issue.type == IssueType.PERF
 
@@ -78,8 +85,7 @@ class TestLoadCorrupt:
 
     def test_load_wrong_version_starts_empty(self, tmp_path):
         path = tmp_path / "issues.json"
-        path.write_text(json.dumps({"version": 999, "next_id": 1, "issues": []}),
-                        encoding="utf-8")
+        path.write_text(json.dumps({"version": 999, "next_id": 1, "issues": []}), encoding="utf-8")
         store = IssueBoard(path)
         assert store.list() == []
 
@@ -173,8 +179,9 @@ class TestStateTransitions:
     def test_update_status_records_history_event(self, tmp_path):
         store = _make_store(tmp_path)
         issue = _create(store)
-        store.update_status(issue.id, IssueStatus.IN_PROGRESS,
-                             actor="loop", iteration=1, note="claimed")
+        store.update_status(
+            issue.id, IssueStatus.IN_PROGRESS, actor="loop", iteration=1, note="claimed"
+        )
         reloaded = store.get(issue.id)
         assert reloaded.status == IssueStatus.IN_PROGRESS
         assert len(reloaded.history) == 2
@@ -184,10 +191,8 @@ class TestStateTransitions:
     def test_update_status_to_closed_records_closed_iter(self, tmp_path):
         store = _make_store(tmp_path)
         issue = _create(store, iteration=1)
-        store.update_status(issue.id, IssueStatus.IN_PROGRESS,
-                             actor="loop", iteration=2)
-        store.update_status(issue.id, IssueStatus.CLOSED,
-                             actor="judge", iteration=2, note="passed")
+        store.update_status(issue.id, IssueStatus.IN_PROGRESS, actor="loop", iteration=2)
+        store.update_status(issue.id, IssueStatus.CLOSED, actor="judge", iteration=2, note="passed")
         reloaded = store.get(issue.id)
         assert reloaded.status == IssueStatus.CLOSED
         assert reloaded.closed_iter == 2
@@ -195,8 +200,9 @@ class TestStateTransitions:
     def test_update_status_blocked_records_closed_iter(self, tmp_path):
         store = _make_store(tmp_path)
         issue = _create(store, iteration=1)
-        store.update_status(issue.id, IssueStatus.BLOCKED,
-                             actor="loop", iteration=3, note="exhausted retries")
+        store.update_status(
+            issue.id, IssueStatus.BLOCKED, actor="loop", iteration=3, note="exhausted retries"
+        )
         reloaded = store.get(issue.id)
         assert reloaded.status == IssueStatus.BLOCKED
         assert reloaded.closed_iter == 3
@@ -205,10 +211,8 @@ class TestStateTransitions:
         store = _make_store(tmp_path)
         issue = _create(store)
         assert issue.attempts == 0
-        store.increment_attempts(issue.id, actor="implementer",
-                                  iteration=1, note="first try")
-        store.increment_attempts(issue.id, actor="implementer",
-                                  iteration=1, note="retry")
+        store.increment_attempts(issue.id, actor="implementer", iteration=1, note="first try")
+        store.increment_attempts(issue.id, actor="implementer", iteration=1, note="retry")
         reloaded = store.get(issue.id)
         assert reloaded.attempts == 2
         assert sum(1 for e in reloaded.history if e.action == "attempt") == 2
@@ -242,8 +246,7 @@ class TestCapHelper:
         # Closing an issue mid-iteration must NOT free up cap budget.
         store = _make_store(tmp_path)
         a = _create(store, created_by="perf_eval", iteration=1)
-        store.update_status(a.id, IssueStatus.CLOSED,
-                             actor="judge", iteration=1)
+        store.update_status(a.id, IssueStatus.CLOSED, actor="judge", iteration=1)
         assert store.open_count_by_creator_in_iter("perf_eval", 1) == 1
 
 
@@ -260,8 +263,7 @@ class TestNextOpen:
     def test_next_open_returns_none_when_all_closed(self, tmp_path):
         store = _make_store(tmp_path)
         a = _create(store)
-        store.update_status(a.id, IssueStatus.CLOSED,
-                             actor="judge", iteration=1)
+        store.update_status(a.id, IssueStatus.CLOSED, actor="judge", iteration=1)
         assert store.next_open() is None
 
     def test_next_open_orders_bug_before_feature_before_perf(self, tmp_path):
@@ -297,8 +299,7 @@ class TestNextOpen:
         store = _make_store(tmp_path)
         a = _create(store, type=IssueType.BUG, title="claimed")
         b = _create(store, type=IssueType.BUG, title="open")
-        store.update_status(a.id, IssueStatus.IN_PROGRESS,
-                             actor="loop", iteration=1)
+        store.update_status(a.id, IssueStatus.IN_PROGRESS, actor="loop", iteration=1)
         first = store.next_open()
         assert first.id == b.id
 
@@ -318,8 +319,11 @@ class TestEventPayload:
             "self_check": "ok",
         }
         store.increment_attempts(
-            issue.id, actor="implementer", iteration=1,
-            note="first try", payload=payload,
+            issue.id,
+            actor="implementer",
+            iteration=1,
+            note="first try",
+            payload=payload,
         )
         # Reload from disk via a fresh store
         fresh = _make_store(tmp_path)
@@ -333,11 +337,17 @@ class TestEventPayload:
         store = _make_store(tmp_path)
         issue = _create(store)
         store.update_status(
-            issue.id, IssueStatus.IN_PROGRESS,
-            actor="loop", iteration=1, note="claimed",
+            issue.id,
+            IssueStatus.IN_PROGRESS,
+            actor="loop",
+            iteration=1,
+            note="claimed",
         )
         store.increment_attempts(
-            issue.id, actor="implementer", iteration=1, note="ran",
+            issue.id,
+            actor="implementer",
+            iteration=1,
+            note="ran",
         )
         reloaded = store.get(issue.id)
         # create + update_status + increment_attempts = 3 events
@@ -397,8 +407,11 @@ class TestReopenBlocked:
         store.increment_attempts(a.id, actor="implementer", iteration=1)
         store.increment_attempts(a.id, actor="implementer", iteration=1)
         store.update_status(
-            a.id, IssueStatus.BLOCKED,
-            actor="loop", iteration=1, note="exhausted",
+            a.id,
+            IssueStatus.BLOCKED,
+            actor="loop",
+            iteration=1,
+            note="exhausted",
         )
         before = store.get(a.id)
         assert before.status == IssueStatus.BLOCKED
@@ -406,7 +419,9 @@ class TestReopenBlocked:
         assert before.closed_iter == 1
 
         reopened = store.reopen_blocked(
-            actor="loop:resume", iteration=2, note="retried on resume",
+            actor="loop:resume",
+            iteration=2,
+            note="retried on resume",
         )
         assert reopened == [a.id]
 
@@ -426,12 +441,16 @@ class TestReopenBlocked:
         open_issue = _create(store, title="open")
         closed = _create(store, title="closed")
         store.update_status(
-            blocked.id, IssueStatus.BLOCKED,
-            actor="loop", iteration=1,
+            blocked.id,
+            IssueStatus.BLOCKED,
+            actor="loop",
+            iteration=1,
         )
         store.update_status(
-            closed.id, IssueStatus.CLOSED,
-            actor="judge", iteration=1,
+            closed.id,
+            IssueStatus.CLOSED,
+            actor="judge",
+            iteration=1,
         )
 
         reopened = store.reopen_blocked(actor="loop:resume", iteration=2)
@@ -485,13 +504,17 @@ class TestOnChangeCallback:
         assert cb.call_count == 1
 
         store.update_status(
-            issue.id, IssueStatus.IN_PROGRESS,
-            actor="loop", iteration=1,
+            issue.id,
+            IssueStatus.IN_PROGRESS,
+            actor="loop",
+            iteration=1,
         )
         assert cb.call_count == 2
 
         store.increment_attempts(
-            issue.id, actor="implementer", iteration=1,
+            issue.id,
+            actor="implementer",
+            iteration=1,
         )
         assert cb.call_count == 3
 

--- a/tests/loops/agent/test_issue_mcp_config.py
+++ b/tests/loops/agent/test_issue_mcp_config.py
@@ -9,9 +9,8 @@ are encoded correctly into the spec's command-line args list.
 from __future__ import annotations
 
 from vibe_serve._agent_cli.base import MCPServerSpec
-
-from vibe_serve.loops.plain.mcp_config import build_issue_mcp_spec
 from vibe_serve.loops.plain.issue_board import IssueType
+from vibe_serve.loops.plain.mcp_config import build_issue_mcp_spec
 
 
 def test_build_judge_spec_has_correct_shape():
@@ -81,4 +80,7 @@ def test_build_spec_uses_provided_store_relpath():
         allowed_types={IssueType.BUG},
     )
     assert "custom/path/issues.json" in spec.args
-    assert spec.args[spec.args.index("custom/path/issues.json") - 1] == "vibe_serve.loops.plain.mcp_server"
+    assert (
+        spec.args[spec.args.index("custom/path/issues.json") - 1]
+        == "vibe_serve.loops.plain.mcp_server"
+    )

--- a/tests/loops/agent/test_issue_mcp_server.py
+++ b/tests/loops/agent/test_issue_mcp_server.py
@@ -10,8 +10,8 @@ import asyncio
 
 import pytest
 
-from vibe_serve.loops.plain.mcp_server import build_parser, build_server
 from vibe_serve.loops.plain.issue_board import IssueType
+from vibe_serve.loops.plain.mcp_server import build_parser, build_server
 
 
 def _ns(tmp_path, *extra: str):
@@ -45,18 +45,20 @@ class TestArgparse:
         assert args.creator == "agent"
         assert args.iteration == 1
         assert args.cap is None
-        assert args.allowed_types == frozenset(
-            {IssueType.BUG, IssueType.FEATURE, IssueType.PERF}
-        )
+        assert args.allowed_types == frozenset({IssueType.BUG, IssueType.FEATURE, IssueType.PERF})
         assert args.read_only is False
 
     def test_full_judge_policy(self, tmp_path):
         args = _ns(
             tmp_path,
-            "--creator", "judge",
-            "--iteration", "3",
-            "--cap", "1",
-            "--allowed-types", "bug",
+            "--creator",
+            "judge",
+            "--iteration",
+            "3",
+            "--cap",
+            "1",
+            "--allowed-types",
+            "bug",
         )
         assert args.creator == "judge"
         assert args.iteration == 3
@@ -69,9 +71,7 @@ class TestArgparse:
 
     def test_allowed_types_with_whitespace(self, tmp_path):
         args = _ns(tmp_path, "--allowed-types", "bug, perf , feature")
-        assert args.allowed_types == frozenset(
-            {IssueType.BUG, IssueType.FEATURE, IssueType.PERF}
-        )
+        assert args.allowed_types == frozenset({IssueType.BUG, IssueType.FEATURE, IssueType.PERF})
 
     def test_allowed_types_rejects_garbage(self, tmp_path):
         with pytest.raises(SystemExit):
@@ -96,7 +96,10 @@ class TestToolRegistration:
         server = build_server(_ns(tmp_path))
         names = asyncio.run(_list_tool_names(server))
         assert names == {
-            "list_issues", "get_issue", "search_issues", "create_issue",
+            "list_issues",
+            "get_issue",
+            "search_issues",
+            "create_issue",
         }
 
     def test_read_only_omits_create_issue(self, tmp_path):
@@ -121,8 +124,11 @@ class TestEndToEnd:
         server = build_server(_ns(tmp_path, "--creator", "perf_eval"))
         created = asyncio.run(
             _call_tool(
-                server, "create_issue",
-                type="perf", title="paged kv", description="reduce frag",
+                server,
+                "create_issue",
+                type="perf",
+                title="paged kv",
+                description="reduce frag",
             )
         )
         assert created == "created issue #1"
@@ -135,22 +141,31 @@ class TestEndToEnd:
         server = build_server(
             _ns(
                 tmp_path,
-                "--creator", "judge",
-                "--cap", "1",
-                "--allowed-types", "bug",
+                "--creator",
+                "judge",
+                "--cap",
+                "1",
+                "--allowed-types",
+                "bug",
             )
         )
         msg1 = asyncio.run(
             _call_tool(
-                server, "create_issue",
-                type="bug", title="t1", description="d",
+                server,
+                "create_issue",
+                type="bug",
+                title="t1",
+                description="d",
             )
         )
         assert msg1 == "created issue #1"
         msg2 = asyncio.run(
             _call_tool(
-                server, "create_issue",
-                type="bug", title="t2", description="d",
+                server,
+                "create_issue",
+                type="bug",
+                title="t2",
+                description="d",
             )
         )
         assert "cap reached" in msg2
@@ -159,15 +174,21 @@ class TestEndToEnd:
         server = build_server(
             _ns(
                 tmp_path,
-                "--creator", "judge",
-                "--cap", "1",
-                "--allowed-types", "bug",
+                "--creator",
+                "judge",
+                "--cap",
+                "1",
+                "--allowed-types",
+                "bug",
             )
         )
         msg = asyncio.run(
             _call_tool(
-                server, "create_issue",
-                type="perf", title="p", description="d",
+                server,
+                "create_issue",
+                type="perf",
+                title="p",
+                description="d",
             )
         )
         assert "may only file types" in msg
@@ -177,14 +198,20 @@ class TestEndToEnd:
         server = build_server(_ns(tmp_path, "--creator", "perf_eval"))
         asyncio.run(
             _call_tool(
-                server, "create_issue",
-                type="perf", title="Add paged KV", description="d",
+                server,
+                "create_issue",
+                type="perf",
+                title="Add paged KV",
+                description="d",
             )
         )
         asyncio.run(
             _call_tool(
-                server, "create_issue",
-                type="bug", title="unrelated", description="d",
+                server,
+                "create_issue",
+                type="bug",
+                title="unrelated",
+                description="d",
             )
         )
         out = asyncio.run(_call_tool(server, "search_issues", query="paged"))
@@ -195,8 +222,11 @@ class TestEndToEnd:
         server = build_server(_ns(tmp_path, "--creator", "perf_eval"))
         asyncio.run(
             _call_tool(
-                server, "create_issue",
-                type="perf", title="paged kv", description="reduce frag",
+                server,
+                "create_issue",
+                type="perf",
+                title="paged kv",
+                description="reduce frag",
             )
         )
         out = asyncio.run(_call_tool(server, "get_issue", issue_id=1))

--- a/tests/loops/agent/test_issue_render.py
+++ b/tests/loops/agent/test_issue_render.py
@@ -4,6 +4,13 @@ from datetime import datetime
 
 import pytest
 
+from vibe_serve.loops.plain.issue_board import (
+    Issue,
+    IssueBoard,
+    IssueEvent,
+    IssueStatus,
+    IssueType,
+)
 from vibe_serve.loops.plain.render import (
     issue_md_filename,
     issue_md_path,
@@ -13,13 +20,6 @@ from vibe_serve.loops.plain.render import (
     render_issue_file,
     render_issue_markdown,
     slugify,
-)
-from vibe_serve.loops.plain.issue_board import (
-    Issue,
-    IssueEvent,
-    IssueStatus,
-    IssueBoard,
-    IssueType,
 )
 
 
@@ -46,9 +46,13 @@ def _make_issue(
         created_at=now,
         updated_at=now,
         attempts=attempts,
-        history=history or [
+        history=history
+        or [
             IssueEvent(
-                timestamp=now, actor=created_by, action="create", iteration=1,
+                timestamp=now,
+                actor=created_by,
+                action="create",
+                iteration=1,
             )
         ],
     )
@@ -146,7 +150,9 @@ class TestIssueMdFilename:
 class TestRenderIssueMarkdown:
     def test_writes_header_with_id_title_type_status(self):
         issue = _make_issue(
-            id=42, title="Build server", type=IssueType.FEATURE,
+            id=42,
+            title="Build server",
+            type=IssueType.FEATURE,
             status=IssueStatus.OPEN,
         )
         md = render_issue_markdown(issue)
@@ -165,11 +171,13 @@ class TestRenderIssueMarkdown:
         issue = _make_issue(
             history=[
                 _make_event(
-                    actor="loop:bootstrap", action="create",
+                    actor="loop:bootstrap",
+                    action="create",
                     timestamp="2026-04-08T12:00:00",
                 ),
                 _make_event(
-                    actor="loop", action="open->in_progress",
+                    actor="loop",
+                    action="open->in_progress",
                     note="claimed",
                     timestamp="2026-04-08T12:01:00",
                 ),
@@ -240,7 +248,9 @@ class TestRenderIssueMarkdown:
                 _make_event(actor="loop:bootstrap", action="create"),
                 # loop's claim — same arrow format but actor='loop'
                 _make_event(
-                    actor="loop", action="open->in_progress", note="claimed",
+                    actor="loop",
+                    action="open->in_progress",
+                    note="claimed",
                 ),
             ],
         )
@@ -367,16 +377,24 @@ class TestRenderAll:
     def test_render_all_writes_index_and_per_issue_files(self, tmp_path):
         store = IssueBoard(tmp_path / "issues.json")
         a = store.create(
-            type=IssueType.FEATURE, title="Build server",
-            description="d", created_by="loop:bootstrap", iteration=1,
+            type=IssueType.FEATURE,
+            title="Build server",
+            description="d",
+            created_by="loop:bootstrap",
+            iteration=1,
         )
         b = store.create(
-            type=IssueType.BUG, title="Crash on startup",
-            description="d", created_by="judge", iteration=1,
+            type=IssueType.BUG,
+            title="Crash on startup",
+            description="d",
+            created_by="judge",
+            iteration=1,
         )
         store.update_status(a.id, IssueStatus.IN_PROGRESS, actor="loop", iteration=1)
         store.increment_attempts(
-            a.id, actor="implementer", iteration=1,
+            a.id,
+            actor="implementer",
+            iteration=1,
             payload={"summary": "did stuff", "files_touched": ["s.py"], "self_check": "ok"},
         )
 
@@ -398,8 +416,11 @@ class TestRenderAll:
     def test_render_all_creates_issues_dir(self, tmp_path):
         store = IssueBoard(tmp_path / "issues.json")
         store.create(
-            type=IssueType.BUG, title="t", description="d",
-            created_by="judge", iteration=1,
+            type=IssueType.BUG,
+            title="t",
+            description="d",
+            created_by="judge",
+            iteration=1,
         )
         issues_dir = tmp_path / "nested" / "issues"
         assert not issues_dir.exists()
@@ -410,8 +431,11 @@ class TestRenderAll:
     def test_render_all_idempotent(self, tmp_path):
         store = IssueBoard(tmp_path / "issues.json")
         store.create(
-            type=IssueType.BUG, title="repeat", description="d",
-            created_by="judge", iteration=1,
+            type=IssueType.BUG,
+            title="repeat",
+            description="d",
+            created_by="judge",
+            iteration=1,
         )
         issues_dir = tmp_path / "issues"
         render_all(issues_dir, store)

--- a/tests/loops/agent/test_issue_tool_impl.py
+++ b/tests/loops/agent/test_issue_tool_impl.py
@@ -53,12 +53,12 @@ class TestCheckCreateAllowed:
     def test_in_allowlist_no_cap_returns_none(self, tmp_path):
         store = _make_store(tmp_path)
         policy = CreateIssuePolicy(
-            creator="x", iteration=1, cap=None, allowed_types=_all_types(),
+            creator="x",
+            iteration=1,
+            cap=None,
+            allowed_types=_all_types(),
         )
-        assert (
-            check_create_allowed(store, type_enum=IssueType.BUG, policy=policy)
-            is None
-        )
+        assert check_create_allowed(store, type_enum=IssueType.BUG, policy=policy) is None
 
     def test_out_of_allowlist_returns_error(self, tmp_path):
         store = _make_store(tmp_path)
@@ -68,9 +68,7 @@ class TestCheckCreateAllowed:
             cap=1,
             allowed_types=frozenset({IssueType.BUG}),
         )
-        err = check_create_allowed(
-            store, type_enum=IssueType.PERF, policy=policy
-        )
+        err = check_create_allowed(store, type_enum=IssueType.PERF, policy=policy)
         assert err is not None
         assert err.startswith("error:")
         assert "may only file types" in err
@@ -86,10 +84,7 @@ class TestCheckCreateAllowed:
             allowed_types=frozenset({IssueType.BUG}),
         )
         # First creation must be allowed.
-        assert (
-            check_create_allowed(store, type_enum=IssueType.BUG, policy=policy)
-            is None
-        )
+        assert check_create_allowed(store, type_enum=IssueType.BUG, policy=policy) is None
         # Pre-populate the store with one judge-authored issue in iteration 1.
         store.create(
             type=IssueType.BUG,
@@ -99,9 +94,7 @@ class TestCheckCreateAllowed:
             iteration=1,
         )
         # Now the cap is reached.
-        err = check_create_allowed(
-            store, type_enum=IssueType.BUG, policy=policy
-        )
+        err = check_create_allowed(store, type_enum=IssueType.BUG, policy=policy)
         assert err is not None
         assert "cap reached" in err
         assert "(1/1)" in err
@@ -122,10 +115,7 @@ class TestCheckCreateAllowed:
             cap=1,
             allowed_types=frozenset({IssueType.BUG}),
         )
-        assert (
-            check_create_allowed(store, type_enum=IssueType.BUG, policy=policy)
-            is None
-        )
+        assert check_create_allowed(store, type_enum=IssueType.BUG, policy=policy) is None
 
     def test_cap_scoped_per_creator(self, tmp_path):
         store = _make_store(tmp_path)
@@ -143,10 +133,7 @@ class TestCheckCreateAllowed:
             cap=1,
             allowed_types=frozenset({IssueType.BUG}),
         )
-        assert (
-            check_create_allowed(store, type_enum=IssueType.BUG, policy=policy)
-            is None
-        )
+        assert check_create_allowed(store, type_enum=IssueType.BUG, policy=policy) is None
 
 
 # ---------------------------------------------------------------------------
@@ -232,7 +219,10 @@ class TestCreateIssueUnderPolicy:
     def test_unlimited_cap(self, tmp_path):
         store = _make_store(tmp_path)
         policy = CreateIssuePolicy(
-            creator="x", iteration=1, cap=None, allowed_types=_all_types(),
+            creator="x",
+            iteration=1,
+            cap=None,
+            allowed_types=_all_types(),
         )
         for i in range(5):
             issue, msg = create_issue_under_policy(
@@ -261,10 +251,7 @@ class TestFormatHelpers:
             created_by="perf_eval",
             iteration=2,
         )
-        assert (
-            format_issue_short(issue)
-            == "#1 [perf] [open] paged kv"
-        )
+        assert format_issue_short(issue) == "#1 [perf] [open] paged kv"
 
     def test_format_issue_full_byte_for_byte(self, tmp_path):
         store = _make_store(tmp_path)

--- a/tests/loops/agent/test_issue_tools.py
+++ b/tests/loops/agent/test_issue_tools.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from vibe_serve.loops.plain.issue_board import IssueStatus, IssueBoard, IssueType
+from vibe_serve.loops.plain.issue_board import IssueBoard, IssueStatus, IssueType
 from vibe_serve.loops.plain.tools import build_issue_tools
 
 
@@ -35,8 +35,9 @@ class TestReadTools:
 
     def test_list_issues_renders_short_format(self, tmp_path):
         store = _make_store(tmp_path)
-        store.create(type=IssueType.BUG, title="hello",
-                     description="d", created_by="x", iteration=1)
+        store.create(
+            type=IssueType.BUG, title="hello", description="d", created_by="x", iteration=1
+        )
         tools = build_issue_tools(store, iteration=1)
         out = _invoke(_tool_by_name(tools, "list_issues"))
         assert "#1" in out
@@ -46,10 +47,12 @@ class TestReadTools:
 
     def test_list_issues_filters_by_status(self, tmp_path):
         store = _make_store(tmp_path)
-        a = store.create(type=IssueType.BUG, title="open one",
-                         description="d", created_by="x", iteration=1)
-        b = store.create(type=IssueType.BUG, title="closed one",
-                         description="d", created_by="x", iteration=1)
+        a = store.create(
+            type=IssueType.BUG, title="open one", description="d", created_by="x", iteration=1
+        )
+        b = store.create(
+            type=IssueType.BUG, title="closed one", description="d", created_by="x", iteration=1
+        )
         store.update_status(b.id, IssueStatus.CLOSED, actor="x", iteration=1)
         tools = build_issue_tools(store, iteration=1)
         list_tool = _tool_by_name(tools, "list_issues")
@@ -65,9 +68,13 @@ class TestReadTools:
 
     def test_get_issue_by_id(self, tmp_path):
         store = _make_store(tmp_path)
-        store.create(type=IssueType.PERF, title="paged kv",
-                     description="reduce frag", created_by="perf_eval",
-                     iteration=1)
+        store.create(
+            type=IssueType.PERF,
+            title="paged kv",
+            description="reduce frag",
+            created_by="perf_eval",
+            iteration=1,
+        )
         tools = build_issue_tools(store, iteration=1)
         out = _invoke(_tool_by_name(tools, "get_issue"), issue_id=1)
         assert "## Issue #1" in out
@@ -83,10 +90,12 @@ class TestReadTools:
 
     def test_search_issues_returns_matches(self, tmp_path):
         store = _make_store(tmp_path)
-        store.create(type=IssueType.PERF, title="Add paged KV",
-                     description="d", created_by="x", iteration=1)
-        store.create(type=IssueType.BUG, title="unrelated",
-                     description="d", created_by="x", iteration=1)
+        store.create(
+            type=IssueType.PERF, title="Add paged KV", description="d", created_by="x", iteration=1
+        )
+        store.create(
+            type=IssueType.BUG, title="unrelated", description="d", created_by="x", iteration=1
+        )
         tools = build_issue_tools(store, iteration=1)
         out = _invoke(_tool_by_name(tools, "search_issues"), query="paged")
         assert "Add paged KV" in out
@@ -94,8 +103,7 @@ class TestReadTools:
 
     def test_search_issues_no_matches(self, tmp_path):
         store = _make_store(tmp_path)
-        store.create(type=IssueType.BUG, title="hi", description="d",
-                     created_by="x", iteration=1)
+        store.create(type=IssueType.BUG, title="hi", description="d", created_by="x", iteration=1)
         tools = build_issue_tools(store, iteration=1)
         out = _invoke(_tool_by_name(tools, "search_issues"), query="xyzzy")
         assert out == "(no matches)"
@@ -116,8 +124,12 @@ class TestSubsetRouting:
     def test_judge_subset_includes_create(self, tmp_path):
         store = _make_store(tmp_path)
         tools = build_issue_tools(
-            store, iteration=1, can_create=True, creator="judge",
-            create_cap=1, allowed_create_types={IssueType.BUG},
+            store,
+            iteration=1,
+            can_create=True,
+            creator="judge",
+            create_cap=1,
+            allowed_create_types={IssueType.BUG},
         )
         names = {t.name for t in tools}
         assert "create_issue" in names
@@ -125,7 +137,10 @@ class TestSubsetRouting:
     def test_perf_eval_subset_includes_create(self, tmp_path):
         store = _make_store(tmp_path)
         tools = build_issue_tools(
-            store, iteration=1, can_create=True, creator="perf_eval",
+            store,
+            iteration=1,
+            can_create=True,
+            creator="perf_eval",
             create_cap=3,
         )
         names = {t.name for t in tools}
@@ -141,12 +156,17 @@ class TestCreateIssue:
     def test_create_issue_happy_path_returns_id(self, tmp_path):
         store = _make_store(tmp_path)
         tools = build_issue_tools(
-            store, iteration=1, can_create=True, creator="perf_eval",
+            store,
+            iteration=1,
+            can_create=True,
+            creator="perf_eval",
             create_cap=3,
         )
         out = _invoke(
             _tool_by_name(tools, "create_issue"),
-            type="perf", title="t", description="d",
+            type="perf",
+            title="t",
+            description="d",
         )
         assert out == "created issue #1"
         assert store.get(1) is not None
@@ -156,12 +176,17 @@ class TestCreateIssue:
     def test_create_issue_invalid_type_returns_error_string(self, tmp_path):
         store = _make_store(tmp_path)
         tools = build_issue_tools(
-            store, iteration=1, can_create=True, creator="perf_eval",
+            store,
+            iteration=1,
+            can_create=True,
+            creator="perf_eval",
             create_cap=3,
         )
         out = _invoke(
             _tool_by_name(tools, "create_issue"),
-            type="enhancement", title="t", description="d",
+            type="enhancement",
+            title="t",
+            description="d",
         )
         assert out.startswith("error:")
         assert "must be one of" in out
@@ -171,7 +196,10 @@ class TestCreateIssue:
     def test_create_issue_caps_at_three_per_iteration(self, tmp_path):
         store = _make_store(tmp_path)
         tools = build_issue_tools(
-            store, iteration=1, can_create=True, creator="perf_eval",
+            store,
+            iteration=1,
+            can_create=True,
+            creator="perf_eval",
             create_cap=3,
         )
         create = _tool_by_name(tools, "create_issue")
@@ -189,7 +217,10 @@ class TestCreateIssue:
         store = _make_store(tmp_path)
         # iteration 1 — fill cap
         iter1_tools = build_issue_tools(
-            store, iteration=1, can_create=True, creator="perf_eval",
+            store,
+            iteration=1,
+            can_create=True,
+            creator="perf_eval",
             create_cap=3,
         )
         create_iter1 = _tool_by_name(iter1_tools, "create_issue")
@@ -197,7 +228,10 @@ class TestCreateIssue:
             _invoke(create_iter1, type="perf", title=f"i1-{i}", description="d")
         # iteration 2 — fresh cap
         iter2_tools = build_issue_tools(
-            store, iteration=2, can_create=True, creator="perf_eval",
+            store,
+            iteration=2,
+            can_create=True,
+            creator="perf_eval",
             create_cap=3,
         )
         create_iter2 = _tool_by_name(iter2_tools, "create_issue")
@@ -209,8 +243,12 @@ class TestCreateIssue:
         # Judge subset: only bug type allowed.
         store = _make_store(tmp_path)
         tools = build_issue_tools(
-            store, iteration=1, can_create=True, creator="judge",
-            create_cap=1, allowed_create_types={IssueType.BUG},
+            store,
+            iteration=1,
+            can_create=True,
+            creator="judge",
+            create_cap=1,
+            allowed_create_types={IssueType.BUG},
         )
         create = _tool_by_name(tools, "create_issue")
         rejected_perf = _invoke(create, type="perf", title="p", description="d")
@@ -224,8 +262,12 @@ class TestCreateIssue:
     def test_judge_create_cap_is_one(self, tmp_path):
         store = _make_store(tmp_path)
         tools = build_issue_tools(
-            store, iteration=1, can_create=True, creator="judge",
-            create_cap=1, allowed_create_types={IssueType.BUG},
+            store,
+            iteration=1,
+            can_create=True,
+            creator="judge",
+            create_cap=1,
+            allowed_create_types={IssueType.BUG},
         )
         create = _tool_by_name(tools, "create_issue")
         ok = _invoke(create, type="bug", title="first", description="d")
@@ -237,7 +279,10 @@ class TestCreateIssue:
     def test_create_issue_unlimited_cap_when_none(self, tmp_path):
         store = _make_store(tmp_path)
         tools = build_issue_tools(
-            store, iteration=1, can_create=True, creator="x",
+            store,
+            iteration=1,
+            can_create=True,
+            creator="x",
             create_cap=None,
         )
         create = _tool_by_name(tools, "create_issue")

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -6,19 +6,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibe_serve.agents import AgentRunner
-from vibe_serve.loops.agent.loop import run_agent_loop
-from vibe_serve.schemas import (
-    OrchestratorPlan,
-    PreRoundDecision,
-    ProfilerSummary,
-)
 from vibe_serve.loops.agent import issue_board
+from vibe_serve.loops.agent.loop import run_agent_loop
 from vibe_serve.schemas import (
     ImplementerResponse,
     JudgeResponse,
+    OrchestratorPlan,
+    PreRoundDecision,
+    ProfilerSummary,
     Verdict,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures & helpers
@@ -69,9 +66,7 @@ def _make_orchestrate_runner(
             counters["orch_pre"] += 1
             if pre_q:
                 return pre_q.pop(0)
-            return PreRoundDecision(
-                need_profile=False, profile_focus="", reasoning="default skip"
-            )
+            return PreRoundDecision(need_profile=False, profile_focus="", reasoning="default skip")
         if kind == "orchestrator" and response_cls is OrchestratorPlan:
             counters["orch_plan"] += 1
             if plan_q:
@@ -154,8 +149,11 @@ def test_profiler_summary_perf_metric_optional():
     p = ProfilerSummary(analysis="a", bottlenecks="b", suggestions="s")
     assert p.perf_metric is None
     p2 = ProfilerSummary(
-        analysis="a", bottlenecks="b", suggestions="s",
-        perf_metric=12.5, perf_unit="tok/s",
+        analysis="a",
+        bottlenecks="b",
+        suggestions="s",
+        perf_metric=12.5,
+        perf_unit="tok/s",
     )
     assert p2.perf_metric == 12.5
     assert p2.perf_unit == "tok/s"
@@ -199,11 +197,15 @@ def test_progress_writes_profiler_summary_with_perf(tmp_path):
 def test_progress_append_implementer_and_judge(tmp_path):
     progress = tmp_path / "progress.md"
     issue_board.append_implementer(
-        progress, 3, 1,
+        progress,
+        3,
+        1,
         ImplementerResponse(summary="added cuda graph", expected_behavior="replay works"),
     )
     issue_board.append_judge(
-        progress, 3, 1,
+        progress,
+        3,
+        1,
         JudgeResponse(analysis="good", feedback="", verdict=Verdict.PASS),
     )
     text = progress.read_text()
@@ -287,7 +289,11 @@ def test_loop_exhaustion_carries_to_next_round(tmp_path, ref_file):
     original_runner.invoke.side_effect = spy_invoke
 
     result = _invoke_orchestrate(
-        tmp_path, ref_file, original_runner, max_rounds=2, max_retries_per_round=2,
+        tmp_path,
+        ref_file,
+        original_runner,
+        max_rounds=2,
+        max_retries_per_round=2,
     )
     assert result is True
     # 2 attempts on round 1 (both fail) + 1 attempt on round 2 (pass).
@@ -307,11 +313,14 @@ def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):
         plans=[
             # Round 1 cold-start plan (no pre-decision invoked on round 1).
             OrchestratorPlan(
-                task="Build server", pass_criteria="ok", reasoning="start",
+                task="Build server",
+                pass_criteria="ok",
+                reasoning="start",
             ),
             # Round 2 plan — uses profiler summary.
             OrchestratorPlan(
-                task="Optimize decode", pass_criteria="graph replay",
+                task="Optimize decode",
+                pass_criteria="graph replay",
                 reasoning="profile showed launch overhead",
             ),
         ],
@@ -355,9 +364,13 @@ def test_loop_runs_full_max_rounds_budget(tmp_path, ref_file):
     """With the ``done`` field removed, the loop always exhausts max_rounds.
     A single-round budget yields one implementer + judge call, no more."""
     runner = _make_orchestrate_runner(
-        plans=[OrchestratorPlan(
-            task="Build server", pass_criteria="ok", reasoning="round 1",
-        )],
+        plans=[
+            OrchestratorPlan(
+                task="Build server",
+                pass_criteria="ok",
+                reasoning="round 1",
+            )
+        ],
     )
     result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1)
     assert result is True
@@ -368,10 +381,7 @@ def test_loop_runs_full_max_rounds_budget(tmp_path, ref_file):
 def test_loop_max_rounds_terminates(tmp_path, ref_file):
     """Loop exits after max_rounds and reports success (the loop always runs
     to budget; there is no early-stop signal)."""
-    plans = [
-        OrchestratorPlan(task=f"t{i}", pass_criteria="p", reasoning="r")
-        for i in range(10)
-    ]
+    plans = [OrchestratorPlan(task=f"t{i}", pass_criteria="p", reasoning="r") for i in range(10)]
     runner = _make_orchestrate_runner(plans=plans)
     result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=3)
     assert result is True
@@ -413,12 +423,17 @@ def test_cli_rejects_modal_with_nsys_profiler(tmp_path, ref_file):
 
     parser = _build_agent_parser()
     validate_args = _validate_agent
-    args = parser.parse_args([
-        "--ref", ref_file,
-        "--exp-name", "test",
-        "--modal",
-        "--profiler", "nsys",
-    ])
+    args = parser.parse_args(
+        [
+            "--ref",
+            ref_file,
+            "--exp-name",
+            "test",
+            "--modal",
+            "--profiler",
+            "nsys",
+        ]
+    )
     with pytest.raises(SystemExit):
         validate_args(args)
 
@@ -520,7 +535,7 @@ def test_detect_plateau_ignores_rounds_without_perf():
 
     records = [
         _record(1, 41.0),
-        _record(2, None),   # profiler skipped or failed round
+        _record(2, None),  # profiler skipped or failed round
         _record(3, 41.3),
         _record(4, 41.1),
     ]
@@ -538,7 +553,7 @@ def test_detect_plateau_streak_must_be_recent():
         _record(1, 41.0),  # plateau
         _record(2, 41.2),  # plateau
         _record(3, 41.1),  # plateau (would fire here)
-        _record(4, 116.0), # break
+        _record(4, 116.0),  # break
     ]
     # By round 4, the recent streak (rounds 2,3,4) spans 41.2-116.0 → no plateau.
     assert _detect_plateau(records) is None
@@ -599,30 +614,42 @@ def test_loop_threads_plateau_warning_into_prompt(tmp_path, ref_file):
     # flat perf metrics, and round 5 is the round under test (its plan call
     # should see the plateau warning).
     plans = [
-        OrchestratorPlan(task=f"r{i}", pass_criteria="p", reasoning=f"r{i}")
-        for i in range(1, 6)
+        OrchestratorPlan(task=f"r{i}", pass_criteria="p", reasoning=f"r{i}") for i in range(1, 6)
     ]
     runner = _make_orchestrate_runner(
         pre_decisions=[
             PreRoundDecision(need_profile=True, profile_focus="x", reasoning="ok"),
-        ] * 4,  # rounds 2-5
+        ]
+        * 4,  # rounds 2-5
         plans=plans,
         profiler_responses=[
             ProfilerSummary(
-                analysis="a", bottlenecks="b", suggestions="s",
-                perf_metric=42.0, perf_unit="tok/s",
+                analysis="a",
+                bottlenecks="b",
+                suggestions="s",
+                perf_metric=42.0,
+                perf_unit="tok/s",
             ),
             ProfilerSummary(
-                analysis="a", bottlenecks="b", suggestions="s",
-                perf_metric=42.1, perf_unit="tok/s",
+                analysis="a",
+                bottlenecks="b",
+                suggestions="s",
+                perf_metric=42.1,
+                perf_unit="tok/s",
             ),
             ProfilerSummary(
-                analysis="a", bottlenecks="b", suggestions="s",
-                perf_metric=41.9, perf_unit="tok/s",
+                analysis="a",
+                bottlenecks="b",
+                suggestions="s",
+                perf_metric=41.9,
+                perf_unit="tok/s",
             ),
             ProfilerSummary(
-                analysis="a", bottlenecks="b", suggestions="s",
-                perf_metric=42.05, perf_unit="tok/s",
+                analysis="a",
+                bottlenecks="b",
+                suggestions="s",
+                perf_metric=42.05,
+                perf_unit="tok/s",
             ),
         ],
     )
@@ -641,7 +668,7 @@ def test_loop_threads_plateau_warning_into_prompt(tmp_path, ref_file):
     # warning yet (round 1: 0 perf; round 2: 0 perf; round 3: 1 perf; round 4: 2 perf).
     for i in range(4):
         assert "Plateau detected" not in seen_prompts[i], (
-            f"round {i+1} should not yet have plateau warning"
+            f"round {i + 1} should not yet have plateau warning"
         )
     # Round 5 plan call sees rounds 1-4 in records (3 valid perf measurements
     # from rounds 2,3,4 — flat at 41.9-42.1) → warning fires.
@@ -663,21 +690,32 @@ def test_loop_resume_with_round_number_starts_there(tmp_path, ref_file):
     (exp_env / "20260422-000000-test-orch").mkdir(parents=True)
     # Minimal git setup so the context validation accepts the repo.
     import subprocess
+
     subprocess.run(
-        ["git", "init"], cwd=exp_env / "20260422-000000-test-orch",
-        capture_output=True, check=True,
+        ["git", "init"],
+        cwd=exp_env / "20260422-000000-test-orch",
+        capture_output=True,
+        check=True,
     )
     ws = exp_env / "20260422-000000-test-orch" / "workspace"
     ws.mkdir()
     subprocess.run(["git", "init"], cwd=ws, capture_output=True, check=True)
     (ws / "dummy.txt").write_text("x")
-    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
-           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
     subprocess.run(["git", "add", "-A"], cwd=ws, env={**env}, capture_output=True, check=True)
-    subprocess.run(["git", "commit", "-m", "seed"], cwd=ws, env={**env}, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "seed"], cwd=ws, env={**env}, capture_output=True, check=True
+    )
 
     result = _invoke_orchestrate(
-        tmp_path, ref_file, runner,
+        tmp_path,
+        ref_file,
+        runner,
         exp_name="20260422-000000-test-orch",
         existing=True,
         start_round=4,

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -22,10 +22,7 @@ from vibe_serve.loops.evolve.population import (
     Objective,
     Population,
 )
-from vibe_serve.schemas import MutatorResponse
-from vibe_serve.schemas import ProfilerSummary
-from vibe_serve.schemas import JudgeResponse, Verdict
-
+from vibe_serve.schemas import JudgeResponse, MutatorResponse, ProfilerSummary, Verdict
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -152,8 +149,11 @@ def test_cold_start_records_first_individual_with_no_parent(tmp_path, ref_file):
     from the profiler."""
     runner = _make_runner()
     result = _invoke_loop(
-        tmp_path, ref_file, runner,
-        max_generations=1, children_per_generation=1,
+        tmp_path,
+        ref_file,
+        runner,
+        max_generations=1,
+        children_per_generation=1,
     )
     assert result is True
 
@@ -173,8 +173,11 @@ def test_cold_start_skips_profiler_when_judge_fails(tmp_path, ref_file):
     is recorded with passed=False and no commit."""
     runner = _make_runner(judge_verdicts=["fail"])
     result = _invoke_loop(
-        tmp_path, ref_file, runner,
-        max_generations=1, children_per_generation=1,
+        tmp_path,
+        ref_file,
+        runner,
+        max_generations=1,
+        children_per_generation=1,
     )
     assert result is True
     assert runner.counters["mutator"] == 1
@@ -200,8 +203,11 @@ def test_second_generation_uses_first_passing_child_as_parent(tmp_path, ref_file
     with parent_id pointing at that seed."""
     runner = _make_runner()
     result = _invoke_loop(
-        tmp_path, ref_file, runner,
-        max_generations=2, children_per_generation=1,
+        tmp_path,
+        ref_file,
+        runner,
+        max_generations=2,
+        children_per_generation=1,
     )
     assert result is True
 
@@ -222,8 +228,11 @@ def test_failed_child_excluded_from_future_parent_pool(tmp_path, ref_file):
     # 3 mutators, 3 judges (pass, fail, pass), 2 profilers (pass children only).
     runner = _make_runner(judge_verdicts=["pass", "fail", "pass"])
     result = _invoke_loop(
-        tmp_path, ref_file, runner,
-        max_generations=3, children_per_generation=1,
+        tmp_path,
+        ref_file,
+        runner,
+        max_generations=3,
+        children_per_generation=1,
     )
     assert result is True
     assert runner.counters["mutator"] == 3
@@ -251,8 +260,11 @@ def test_cold_start_prompt_uses_cold_start_section(tmp_path, ref_file):
     captured: list[str] = []
     runner = _make_runner(capture_mutator_prompts=captured)
     _invoke_loop(
-        tmp_path, ref_file, runner,
-        max_generations=1, children_per_generation=1,
+        tmp_path,
+        ref_file,
+        runner,
+        max_generations=1,
+        children_per_generation=1,
     )
     assert len(captured) == 1
     prompt = captured[0]
@@ -294,9 +306,13 @@ def test_pareto_mode_records_metrics_dict_on_individuals(tmp_path, ref_file):
     ]
     runner = _make_runner(profiler_responses=profiler_responses)
     result = _invoke_loop(
-        tmp_path, ref_file, runner,
-        max_generations=2, children_per_generation=1,
-        objectives=objectives, frontier_bias=1.0,
+        tmp_path,
+        ref_file,
+        runner,
+        max_generations=2,
+        children_per_generation=1,
+        objectives=objectives,
+        frontier_bias=1.0,
     )
     assert result is True
 
@@ -335,8 +351,10 @@ def test_pareto_addendum_appears_in_profiler_prompt(tmp_path, ref_file):
             if kind == "profiler":
                 captured_profiler_prompts.append(system_prompt)
             return original(
-                kind=kind, response_cls=response_cls,
-                system_prompt=system_prompt, **kwargs,
+                kind=kind,
+                response_cls=response_cls,
+                system_prompt=system_prompt,
+                **kwargs,
             )
 
         runner.invoke.side_effect = spy
@@ -345,9 +363,13 @@ def test_pareto_addendum_appears_in_profiler_prompt(tmp_path, ref_file):
     runner = _make_runner_with_profiler_capture()
     objectives = [Objective("tput", "max"), Objective("lat_ms", "min")]
     _invoke_loop(
-        tmp_path, ref_file, runner,
-        max_generations=1, children_per_generation=1,
-        objectives=objectives, frontier_bias=1.0,
+        tmp_path,
+        ref_file,
+        runner,
+        max_generations=1,
+        children_per_generation=1,
+        objectives=objectives,
+        frontier_bias=1.0,
     )
     assert len(captured_profiler_prompts) == 1
     prompt = captured_profiler_prompts[0]
@@ -362,8 +384,11 @@ def test_no_objectives_keeps_metrics_empty_and_legacy_behavior(tmp_path, ref_fil
     pre-Pareto behavior."""
     runner = _make_runner()
     result = _invoke_loop(
-        tmp_path, ref_file, runner,
-        max_generations=1, children_per_generation=1,
+        tmp_path,
+        ref_file,
+        runner,
+        max_generations=1,
+        children_per_generation=1,
         # Note: no `objectives` kwarg → single-objective mode.
     )
     assert result is True
@@ -378,8 +403,11 @@ def test_second_child_prompt_includes_parent_block(tmp_path, ref_file):
     captured: list[str] = []
     runner = _make_runner(capture_mutator_prompts=captured)
     _invoke_loop(
-        tmp_path, ref_file, runner,
-        max_generations=2, children_per_generation=1,
+        tmp_path,
+        ref_file,
+        runner,
+        max_generations=2,
+        children_per_generation=1,
     )
     assert len(captured) == 2
     gen2_prompt = captured[1]

--- a/tests/loops/evolve/test_evolutionary_population.py
+++ b/tests/loops/evolve/test_evolutionary_population.py
@@ -21,7 +21,6 @@ from vibe_serve.loops.evolve.population import (
     _dominates,
 )
 
-
 # ---------------------------------------------------------------------------
 # Individual: JSON round-trip
 # ---------------------------------------------------------------------------
@@ -137,9 +136,7 @@ def test_select_parent_low_temperature_concentrates_on_best():
     """A near-zero temperature should pick the best almost every time."""
     pop = Population([_passed(1, 1.0), _passed(2, 5.0), _passed(3, 10.0)])
     rng = random.Random(123)
-    counts = Counter(
-        pop.select_parent(rng=rng, temperature=0.01).id for _ in range(200)
-    )
+    counts = Counter(pop.select_parent(rng=rng, temperature=0.01).id for _ in range(200))
     # The best (id=3) should dominate.
     assert counts[3] > 180
 
@@ -148,9 +145,7 @@ def test_select_parent_high_temperature_spreads():
     """High temperature flattens the distribution toward uniform."""
     pop = Population([_passed(1, 1.0), _passed(2, 5.0), _passed(3, 10.0)])
     rng = random.Random(123)
-    counts = Counter(
-        pop.select_parent(rng=rng, temperature=100.0).id for _ in range(600)
-    )
+    counts = Counter(pop.select_parent(rng=rng, temperature=100.0).id for _ in range(600))
     # All three should be picked a meaningful number of times.
     assert all(counts[i] > 100 for i in (1, 2, 3))
 
@@ -193,7 +188,10 @@ def test_select_inspirations_top_first_then_random():
 def test_select_inspirations_handles_small_population():
     pop = Population([_passed(1, 5.0), _passed(2, 6.0)])
     picks = pop.select_inspirations(
-        parent_id=1, k_top=2, k_random=2, rng=random.Random(0),
+        parent_id=1,
+        k_top=2,
+        k_random=2,
+        rng=random.Random(0),
     )
     # Only one other passed individual exists; no dupes / no errors.
     assert [p.id for p in picks] == [2]
@@ -202,7 +200,10 @@ def test_select_inspirations_handles_small_population():
 def test_select_inspirations_empty_when_only_parent_passed():
     pop = Population([_passed(1, 5.0), _failed(2)])
     picks = pop.select_inspirations(
-        parent_id=1, k_top=3, k_random=3, rng=random.Random(0),
+        parent_id=1,
+        k_top=3,
+        k_random=3,
+        rng=random.Random(0),
     )
     assert picks == []
 
@@ -311,22 +312,26 @@ def test_dominates_missing_metric_treats_as_incomparable():
 
 
 def test_frontier_returns_only_non_dominated():
-    pop = Population([
-        _multi(1, {"tput": 100.0, "lat": 80.0}),  # frontier (high tput)
-        _multi(2, {"tput": 80.0, "lat": 50.0}),   # frontier (low lat)
-        _multi(3, {"tput": 70.0, "lat": 90.0}),   # dominated by id=1 and id=2
-        _multi(4, {"tput": 90.0, "lat": 60.0}),   # frontier (middle)
-    ])
+    pop = Population(
+        [
+            _multi(1, {"tput": 100.0, "lat": 80.0}),  # frontier (high tput)
+            _multi(2, {"tput": 80.0, "lat": 50.0}),  # frontier (low lat)
+            _multi(3, {"tput": 70.0, "lat": 90.0}),  # dominated by id=1 and id=2
+            _multi(4, {"tput": 90.0, "lat": 60.0}),  # frontier (middle)
+        ]
+    )
     objs = [Objective("tput", "max"), Objective("lat", "min")]
     front_ids = {i.id for i in pop.frontier(objs)}
     assert front_ids == {1, 2, 4}
 
 
 def test_frontier_excludes_individuals_missing_metrics():
-    pop = Population([
-        _multi(1, {"tput": 100.0, "lat": 80.0}),
-        _multi(2, {"tput": 80.0}),  # missing 'lat'
-    ])
+    pop = Population(
+        [
+            _multi(1, {"tput": 100.0, "lat": 80.0}),
+            _multi(2, {"tput": 80.0}),  # missing 'lat'
+        ]
+    )
     objs = [Objective("tput", "max"), Objective("lat", "min")]
     front_ids = {i.id for i in pop.frontier(objs)}
     # Only id=1 is fully metric'd.
@@ -345,16 +350,17 @@ def test_frontier_empty_when_no_objectives():
 
 def test_select_parent_pareto_mode_draws_from_frontier_with_full_bias():
     """frontier_bias=1.0 → parent always sampled from the Pareto front."""
-    pop = Population([
-        _multi(1, {"tput": 100.0, "lat": 80.0}),  # frontier
-        _multi(2, {"tput": 80.0, "lat": 50.0}),   # frontier
-        _multi(3, {"tput": 50.0, "lat": 200.0}),  # dominated
-    ])
+    pop = Population(
+        [
+            _multi(1, {"tput": 100.0, "lat": 80.0}),  # frontier
+            _multi(2, {"tput": 80.0, "lat": 50.0}),  # frontier
+            _multi(3, {"tput": 50.0, "lat": 200.0}),  # dominated
+        ]
+    )
     objs = [Objective("tput", "max"), Objective("lat", "min")]
     rng = random.Random(0)
     counts = Counter(
-        pop.select_parent(rng=rng, objectives=objs, frontier_bias=1.0).id
-        for _ in range(200)
+        pop.select_parent(rng=rng, objectives=objs, frontier_bias=1.0).id for _ in range(200)
     )
     assert counts[3] == 0  # never the dominated one
 
@@ -364,16 +370,22 @@ def test_select_parent_pareto_mode_falls_back_to_scalar_when_bias_zero():
 
     With temperature near 0, the highest perf_metric (id=1, perf=100) wins.
     """
-    pop = Population([
-        _multi(1, {"tput": 100.0, "lat": 80.0}),
-        _multi(2, {"tput": 80.0, "lat": 50.0}),
-    ])
+    pop = Population(
+        [
+            _multi(1, {"tput": 100.0, "lat": 80.0}),
+            _multi(2, {"tput": 80.0, "lat": 50.0}),
+        ]
+    )
     objs = [Objective("tput", "max"), Objective("lat", "min")]
     rng = random.Random(0)
     counts = Counter(
         pop.select_parent(
-            rng=rng, objectives=objs, frontier_bias=0.0, temperature=0.01,
-        ).id for _ in range(100)
+            rng=rng,
+            objectives=objs,
+            frontier_bias=0.0,
+            temperature=0.01,
+        ).id
+        for _ in range(100)
     )
     assert counts[1] > 90
 
@@ -381,10 +393,12 @@ def test_select_parent_pareto_mode_falls_back_to_scalar_when_bias_zero():
 def test_select_parent_falls_back_when_frontier_is_empty():
     """No individual reports both objectives → frontier is empty →
     even with bias=1.0, scalar softmax kicks in so the loop isn't blocked."""
-    pop = Population([
-        _multi(1, {"tput": 100.0}),  # missing 'lat'
-        _multi(2, {"tput": 80.0}),   # missing 'lat'
-    ])
+    pop = Population(
+        [
+            _multi(1, {"tput": 100.0}),  # missing 'lat'
+            _multi(2, {"tput": 80.0}),  # missing 'lat'
+        ]
+    )
     objs = [Objective("tput", "max"), Objective("lat", "min")]
     rng = random.Random(0)
     pick = pop.select_parent(rng=rng, objectives=objs, frontier_bias=1.0)
@@ -395,13 +409,15 @@ def test_select_parent_falls_back_when_frontier_is_empty():
 
 def test_select_inspirations_pareto_mode_pulls_from_frontier_first():
     """Top slots come from the Pareto frontier sorted by primary objective."""
-    pop = Population([
-        _multi(1, {"tput": 100.0, "lat": 80.0}),  # frontier
-        _multi(2, {"tput": 80.0, "lat": 50.0}),   # frontier
-        _multi(3, {"tput": 90.0, "lat": 60.0}),   # frontier
-        _multi(4, {"tput": 60.0, "lat": 100.0}),  # dominated
-        _multi(5, {"tput": 50.0, "lat": 110.0}),  # dominated
-    ])
+    pop = Population(
+        [
+            _multi(1, {"tput": 100.0, "lat": 80.0}),  # frontier
+            _multi(2, {"tput": 80.0, "lat": 50.0}),  # frontier
+            _multi(3, {"tput": 90.0, "lat": 60.0}),  # frontier
+            _multi(4, {"tput": 60.0, "lat": 100.0}),  # dominated
+            _multi(5, {"tput": 50.0, "lat": 110.0}),  # dominated
+        ]
+    )
     objs = [Objective("tput", "max"), Objective("lat", "min")]
     rng = random.Random(0)
     picks = pop.select_inspirations(
@@ -422,12 +438,14 @@ def test_select_inspirations_pareto_mode_pulls_from_frontier_first():
 def test_select_inspirations_backfills_when_frontier_smaller_than_k_top():
     """When the frontier has only one non-parent member but k_top=3,
     fill the remaining slots from non-frontier passers."""
-    pop = Population([
-        _multi(1, {"tput": 100.0, "lat": 80.0}),  # parent
-        _multi(2, {"tput": 80.0, "lat": 50.0}),   # frontier (only one besides parent)
-        _multi(3, {"tput": 70.0, "lat": 90.0}),   # dominated
-        _multi(4, {"tput": 60.0, "lat": 100.0}),  # dominated
-    ])
+    pop = Population(
+        [
+            _multi(1, {"tput": 100.0, "lat": 80.0}),  # parent
+            _multi(2, {"tput": 80.0, "lat": 50.0}),  # frontier (only one besides parent)
+            _multi(3, {"tput": 70.0, "lat": 90.0}),  # dominated
+            _multi(4, {"tput": 60.0, "lat": 100.0}),  # dominated
+        ]
+    )
     objs = [Objective("tput", "max"), Objective("lat", "min")]
     rng = random.Random(0)
     picks = pop.select_inspirations(

--- a/tests/loops/plain/test_plain_loop.py
+++ b/tests/loops/plain/test_plain_loop.py
@@ -15,8 +15,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibe_serve.agents import AgentRunner
+from vibe_serve.loops.plain.issue_board import IssueBoard, IssueStatus, IssueType
 from vibe_serve.loops.plain.loop import PlainLoopState, run_plain_loop
-from vibe_serve.loops.plain.issue_board import IssueStatus, IssueBoard, IssueType
 from vibe_serve.schemas import (
     IssueImplementerResponse,
     IssueJudgeResponse,
@@ -25,7 +25,6 @@ from vibe_serve.schemas import (
     PerfTrend,
     Verdict,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers — factories and fixtures shared across tests
@@ -67,9 +66,7 @@ def _make_perf_resp(new_issue_ids: list[int] | None = None) -> IssuePerfEvalResp
     )
 
 
-def _make_issue_runner(
-    responses: list, *, backend_name: str = "deepagents"
-) -> MagicMock:
+def _make_issue_runner(responses: list, *, backend_name: str = "deepagents") -> MagicMock:
     """Mock AgentRunner.invoke that yields scripted responses in order.
 
     The script is consumed left-to-right regardless of ``kind``, so the test
@@ -88,9 +85,7 @@ def _make_issue_runner(
         try:
             return next(it)
         except StopIteration as exc:
-            raise AssertionError(
-                f"invoke called beyond scripted responses (kind={kind})"
-            ) from exc
+            raise AssertionError(f"invoke called beyond scripted responses (kind={kind})") from exc
 
     runner.invoke.side_effect = _invoke
     return runner
@@ -219,9 +214,7 @@ def test_bootstrap_idempotent_on_resume(
 @patch("vibe_serve.context._build_model")
 @patch("vibe_serve.backends.cuda.LocalShellBackend")
 @patch("vibe_serve.context.build_agent_runner")
-def test_judge_pass_closes_issue(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
-):
+def test_judge_pass_closes_issue(mock_build_runner, mock_backend, mock_build, ref_file, tmp_path):
     mock_build.return_value = "anthropic:claude-sonnet-4-6"
     mock_build_runner.return_value = _make_issue_runner(
         [
@@ -388,9 +381,7 @@ def test_judge_invoke_receives_tracker_kwargs(
             max_issues_per_perf_eval=3,
         )
 
-    judge_calls = [
-        c for c in runner.invoke.call_args_list if c.kwargs.get("kind") == "judge"
-    ]
+    judge_calls = [c for c in runner.invoke.call_args_list if c.kwargs.get("kind") == "judge"]
     assert len(judge_calls) == 1
     kwargs = judge_calls[0].kwargs
 
@@ -447,9 +438,7 @@ def test_perf_eval_invoke_receives_tracker_kwargs(
             max_issues_per_perf_eval=2,
         )
 
-    perf_calls = [
-        c for c in runner.invoke.call_args_list if c.kwargs.get("kind") == "perf_eval"
-    ]
+    perf_calls = [c for c in runner.invoke.call_args_list if c.kwargs.get("kind") == "perf_eval"]
     assert len(perf_calls) == 1
     kwargs = perf_calls[0].kwargs
 
@@ -512,8 +501,13 @@ def test_judge_phase_calls_store_reload_after_invoke(
     runner.invoke.side_effect = tracking_invoke
     mock_build_runner.return_value = runner
 
-    with patch("vibe_serve.context.PROJECT_ROOT", tmp_path), patch.object(
-        IssueBoard, "reload", tracking_reload,
+    with (
+        patch("vibe_serve.context.PROJECT_ROOT", tmp_path),
+        patch.object(
+            IssueBoard,
+            "reload",
+            tracking_reload,
+        ),
     ):
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},
@@ -561,9 +555,7 @@ def test_implementer_invoke_has_no_tracker_kwargs(
             max_rounds=1,
         )
 
-    impl_calls = [
-        c for c in runner.invoke.call_args_list if c.kwargs.get("kind") == "implementer"
-    ]
+    impl_calls = [c for c in runner.invoke.call_args_list if c.kwargs.get("kind") == "implementer"]
     assert impl_calls, "expected at least one implementer invoke"
     for c in impl_calls:
         # Both injection-point kwargs may be omitted entirely or explicit None.
@@ -572,12 +564,8 @@ def test_implementer_invoke_has_no_tracker_kwargs(
 
     # The judge and perf_eval invokes both DO receive a tracker kwarg.
     # Which one depends on the backend (see PlainLoopAgentRunner).
-    judge_calls = [
-        c for c in runner.invoke.call_args_list if c.kwargs.get("kind") == "judge"
-    ]
-    perf_calls = [
-        c for c in runner.invoke.call_args_list if c.kwargs.get("kind") == "perf_eval"
-    ]
+    judge_calls = [c for c in runner.invoke.call_args_list if c.kwargs.get("kind") == "judge"]
+    perf_calls = [c for c in runner.invoke.call_args_list if c.kwargs.get("kind") == "perf_eval"]
     assert len(judge_calls) == 1
     assert len(perf_calls) == 1
     if backend_name == "cli":
@@ -622,9 +610,7 @@ def test_perf_eval_runs_after_drain_complete(
     assert kinds == ["implementer", "judge", "perf_eval"]
 
     # Check the response_cls keyword for each phase
-    response_classes = [
-        call.kwargs["response_cls"] for call in runner.invoke.call_args_list
-    ]
+    response_classes = [call.kwargs["response_cls"] for call in runner.invoke.call_args_list]
     assert response_classes == [
         IssueImplementerResponse,
         IssueJudgeResponse,
@@ -916,7 +902,8 @@ def test_implementer_retry_user_prompt_includes_prior_judge_feedback(
         [
             _make_impl_resp(1, summary="First attempt."),
             _make_judge_resp(
-                1, verdict="fail",
+                1,
+                verdict="fail",
                 feedback="Add streaming support to the /v1/completions endpoint.",
             ),
             _make_impl_resp(1, summary="Second attempt."),

--- a/tests/loops/plain/test_plain_loop_cli.py
+++ b/tests/loops/plain/test_plain_loop_cli.py
@@ -4,7 +4,8 @@ from unittest.mock import patch
 
 import pytest
 
-from vibe_serve.cli import _build_plain_parser as build_parser, main
+from vibe_serve.cli import _build_plain_parser as build_parser
+from vibe_serve.cli import main
 from vibe_serve.loops.plain.loop import PlainLoopState
 
 
@@ -42,9 +43,14 @@ class TestBuildParser:
     def test_overrides_for_rounds(self):
         parser = build_parser()
         args = parser.parse_args(
-            ["--max-rounds", "10",
-             "--max-attempts-per-issue", "5",
-             "--max-issues-per-perf-eval", "2"]
+            [
+                "--max-rounds",
+                "10",
+                "--max-attempts-per-issue",
+                "5",
+                "--max-issues-per-perf-eval",
+                "2",
+            ]
         )
         assert args.max_rounds == 10
         assert args.max_attempts_per_issue == 5
@@ -94,16 +100,25 @@ class TestMain:
                 assert exc_info.value.code == 1
 
     def test_main_passes_round_args_to_run_loop(self):
-        with patch("sys.argv", [
-            *self._BASE_ARGV,
-            "--max-rounds", "7",
-            "--max-attempts-per-issue", "4",
-            "--max-issues-per-perf-eval", "2",
-        ]):
-            with self._patch_config(), patch(
-                "vibe_serve.loops.plain.loop.run_plain_loop",
-                return_value=True,
-            ) as mock_run:
+        with patch(
+            "sys.argv",
+            [
+                *self._BASE_ARGV,
+                "--max-rounds",
+                "7",
+                "--max-attempts-per-issue",
+                "4",
+                "--max-issues-per-perf-eval",
+                "2",
+            ],
+        ):
+            with (
+                self._patch_config(),
+                patch(
+                    "vibe_serve.loops.plain.loop.run_plain_loop",
+                    return_value=True,
+                ) as mock_run,
+            ):
                 main()
                 kwargs = mock_run.call_args.kwargs
                 assert kwargs["max_rounds"] == 7
@@ -111,18 +126,27 @@ class TestMain:
                 assert kwargs["max_issues_per_perf_eval"] == 2
 
     def test_main_start_round_overrides_loaded_state(self, tmp_path):
-        with patch("sys.argv", [
-            *self._BASE_ARGV,
-            "--resume", "fake-run-dir",
-            "--start-round", "3",
-        ]):
-            with self._patch_config(), patch(
-                "vibe_serve.cli._resolve_run_dir",
-                return_value="fake-run-dir",
-            ), patch(
-                "vibe_serve.loops.plain.loop.run_plain_loop",
-                return_value=True,
-            ) as mock_run:
+        with patch(
+            "sys.argv",
+            [
+                *self._BASE_ARGV,
+                "--resume",
+                "fake-run-dir",
+                "--start-round",
+                "3",
+            ],
+        ):
+            with (
+                self._patch_config(),
+                patch(
+                    "vibe_serve.cli._resolve_run_dir",
+                    return_value="fake-run-dir",
+                ),
+                patch(
+                    "vibe_serve.loops.plain.loop.run_plain_loop",
+                    return_value=True,
+                ) as mock_run,
+            ):
                 main()
                 kwargs = mock_run.call_args.kwargs
                 assert kwargs["existing"] is True
@@ -132,15 +156,23 @@ class TestMain:
                 assert state.bootstrap_done is True
 
     def test_main_forwards_agent_backend_and_cli_provider(self):
-        with patch("sys.argv", [
-            *self._BASE_ARGV,
-            "--agent-backend", "cli",
-            "--cli-provider", "claude",
-        ]):
-            with self._patch_config(), patch(
-                "vibe_serve.loops.plain.loop.run_plain_loop",
-                return_value=True,
-            ) as mock_run:
+        with patch(
+            "sys.argv",
+            [
+                *self._BASE_ARGV,
+                "--agent-backend",
+                "cli",
+                "--cli-provider",
+                "claude",
+            ],
+        ):
+            with (
+                self._patch_config(),
+                patch(
+                    "vibe_serve.loops.plain.loop.run_plain_loop",
+                    return_value=True,
+                ) as mock_run,
+            ):
                 main()
                 kwargs = mock_run.call_args.kwargs
                 assert kwargs["agent_backend"] == "cli"
@@ -148,29 +180,38 @@ class TestMain:
 
     def test_main_defaults_agent_backend_and_cli_provider_to_none(self):
         with patch("sys.argv", list(self._BASE_ARGV)):
-            with self._patch_config(), patch(
-                "vibe_serve.loops.plain.loop.run_plain_loop",
-                return_value=True,
-            ) as mock_run:
+            with (
+                self._patch_config(),
+                patch(
+                    "vibe_serve.loops.plain.loop.run_plain_loop",
+                    return_value=True,
+                ) as mock_run,
+            ):
                 main()
                 kwargs = mock_run.call_args.kwargs
                 assert kwargs["agent_backend"] is None
                 assert kwargs["cli_provider"] is None
 
-    @pytest.mark.parametrize(
-        "provider", ["claude", "gemini", "codex", "opencode"]
-    )
+    @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
     def test_main_accepts_all_cli_providers(self, provider):
         """All four CLI providers must reach run_plain_loop without raising."""
-        with patch("sys.argv", [
-            *self._BASE_ARGV,
-            "--agent-backend", "cli",
-            "--cli-provider", provider,
-        ]):
-            with self._patch_config(), patch(
-                "vibe_serve.loops.plain.loop.run_plain_loop",
-                return_value=True,
-            ) as mock_run:
+        with patch(
+            "sys.argv",
+            [
+                *self._BASE_ARGV,
+                "--agent-backend",
+                "cli",
+                "--cli-provider",
+                provider,
+            ],
+        ):
+            with (
+                self._patch_config(),
+                patch(
+                    "vibe_serve.loops.plain.loop.run_plain_loop",
+                    return_value=True,
+                ) as mock_run,
+            ):
                 main()
                 kwargs = mock_run.call_args.kwargs
                 assert kwargs["agent_backend"] == "cli"

--- a/tests/loops/plain/test_plain_loop_state.py
+++ b/tests/loops/plain/test_plain_loop_state.py
@@ -4,13 +4,13 @@ import json
 
 import pytest
 
+from vibe_serve.loops.plain.issue_board import IssueBoard, IssueStatus, IssueType
 from vibe_serve.loops.plain.loop import (
     PlainLoopState,
     _determine_resume_point,
     _load_state,
     _save_state,
 )
-from vibe_serve.loops.plain.issue_board import IssueStatus, IssueBoard, IssueType
 
 
 def _make_store(tmp_path) -> IssueBoard:
@@ -88,13 +88,16 @@ class TestDetermineResumePoint:
     def test_mid_implementer_re_runs_implementer(self, tmp_path):
         store = _make_store(tmp_path)
         issue = store.create(
-            type=IssueType.BUG, title="t", description="d",
-            created_by="x", iteration=1,
+            type=IssueType.BUG,
+            title="t",
+            description="d",
+            created_by="x",
+            iteration=1,
         )
-        store.update_status(issue.id, IssueStatus.IN_PROGRESS,
-                             actor="loop", iteration=1)
-        state = PlainLoopState(round_idx=0, phase="implementer",
-                               current_issue_id=issue.id, bootstrap_done=True)
+        store.update_status(issue.id, IssueStatus.IN_PROGRESS, actor="loop", iteration=1)
+        state = PlainLoopState(
+            round_idx=0, phase="implementer", current_issue_id=issue.id, bootstrap_done=True
+        )
         i, phase, issue_id = _determine_resume_point(state, store)
         assert i == 0
         assert phase == "implementer"
@@ -103,13 +106,16 @@ class TestDetermineResumePoint:
     def test_mid_judge_re_runs_judge(self, tmp_path):
         store = _make_store(tmp_path)
         issue = store.create(
-            type=IssueType.BUG, title="t", description="d",
-            created_by="x", iteration=1,
+            type=IssueType.BUG,
+            title="t",
+            description="d",
+            created_by="x",
+            iteration=1,
         )
-        store.update_status(issue.id, IssueStatus.IN_PROGRESS,
-                             actor="loop", iteration=1)
-        state = PlainLoopState(round_idx=0, phase="judge",
-                               current_issue_id=issue.id, bootstrap_done=True)
+        store.update_status(issue.id, IssueStatus.IN_PROGRESS, actor="loop", iteration=1)
+        state = PlainLoopState(
+            round_idx=0, phase="judge", current_issue_id=issue.id, bootstrap_done=True
+        )
         i, phase, issue_id = _determine_resume_point(state, store)
         assert i == 0
         assert phase == "judge"
@@ -117,11 +123,11 @@ class TestDetermineResumePoint:
 
     def test_resume_picks_drain_when_open_issues_remain(self, tmp_path):
         store = _make_store(tmp_path)
-        store.create(type=IssueType.BUG, title="t", description="d",
-                     created_by="x", iteration=1)
+        store.create(type=IssueType.BUG, title="t", description="d", created_by="x", iteration=1)
         # Loop was past judge, no current_issue_id
-        state = PlainLoopState(round_idx=1, phase="implementer",
-                               current_issue_id=None, bootstrap_done=True)
+        state = PlainLoopState(
+            round_idx=1, phase="implementer", current_issue_id=None, bootstrap_done=True
+        )
         i, phase, issue_id = _determine_resume_point(state, store)
         assert i == 1
         assert phase == "implementer"
@@ -134,12 +140,13 @@ class TestDetermineResumePoint:
         # perf_eval naturally, so the function never needs to "request"
         # perf_eval explicitly.
         store = _make_store(tmp_path)
-        issue = store.create(type=IssueType.BUG, title="t", description="d",
-                             created_by="x", iteration=1)
-        store.update_status(issue.id, IssueStatus.CLOSED,
-                             actor="judge", iteration=1)
-        state = PlainLoopState(round_idx=1, phase="implementer",
-                               current_issue_id=None, bootstrap_done=True)
+        issue = store.create(
+            type=IssueType.BUG, title="t", description="d", created_by="x", iteration=1
+        )
+        store.update_status(issue.id, IssueStatus.CLOSED, actor="judge", iteration=1)
+        state = PlainLoopState(
+            round_idx=1, phase="implementer", current_issue_id=None, bootstrap_done=True
+        )
         i, phase, issue_id = _determine_resume_point(state, store)
         assert phase == "implementer"
         assert issue_id is None
@@ -150,12 +157,13 @@ class TestDetermineResumePoint:
         drain loop will then immediately exit (next_open() is None) and
         fall through to a fresh perf_eval naturally."""
         store = _make_store(tmp_path)
-        closed = store.create(type=IssueType.BUG, title="t", description="d",
-                               created_by="x", iteration=1)
-        store.update_status(closed.id, IssueStatus.CLOSED,
-                             actor="judge", iteration=1)
-        state = PlainLoopState(round_idx=2, phase="perf_eval",
-                               current_issue_id=None, bootstrap_done=True)
+        closed = store.create(
+            type=IssueType.BUG, title="t", description="d", created_by="x", iteration=1
+        )
+        store.update_status(closed.id, IssueStatus.CLOSED, actor="judge", iteration=1)
+        state = PlainLoopState(
+            round_idx=2, phase="perf_eval", current_issue_id=None, bootstrap_done=True
+        )
         i, phase, issue_id = _determine_resume_point(state, store)
         assert i == 2
         assert phase == "implementer"
@@ -166,14 +174,14 @@ class TestDetermineResumePoint:
         # already CLOSED (race after a crash), we should NOT try to re-run
         # that phase. Instead, drain remaining open issues.
         store = _make_store(tmp_path)
-        closed = store.create(type=IssueType.BUG, title="closed", description="d",
-                              created_by="x", iteration=1)
-        store.update_status(closed.id, IssueStatus.CLOSED,
-                             actor="judge", iteration=1)
-        store.create(type=IssueType.BUG, title="open", description="d",
-                     created_by="x", iteration=1)
-        state = PlainLoopState(round_idx=0, phase="judge",
-                               current_issue_id=closed.id, bootstrap_done=True)
+        closed = store.create(
+            type=IssueType.BUG, title="closed", description="d", created_by="x", iteration=1
+        )
+        store.update_status(closed.id, IssueStatus.CLOSED, actor="judge", iteration=1)
+        store.create(type=IssueType.BUG, title="open", description="d", created_by="x", iteration=1)
+        state = PlainLoopState(
+            round_idx=0, phase="judge", current_issue_id=closed.id, bootstrap_done=True
+        )
         i, phase, issue_id = _determine_resume_point(state, store)
         # Should NOT try to re-run judge on the closed issue
         assert not (phase == "judge" and issue_id == closed.id)

--- a/tests/loops/plain/test_plain_runner_ext.py
+++ b/tests/loops/plain/test_plain_runner_ext.py
@@ -12,9 +12,8 @@ import pytest
 
 from vibe_serve._agent_cli.base import MCPServerSpec
 from vibe_serve.agents.base import AgentRunner
-from vibe_serve.loops.plain.runner_ext import PlainLoopAgentRunner
 from vibe_serve.loops.plain.issue_board import IssueBoard
-
+from vibe_serve.loops.plain.runner_ext import PlainLoopAgentRunner
 
 _EXPECTED_TOOL_NAMES = {"list_issues", "get_issue", "search_issues", "create_issue"}
 
@@ -43,9 +42,7 @@ class TestDeepAgentsBackend:
     def test_judge_receives_in_process_tools(self, tmp_path):
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(
-            inner, store=store, max_issues_per_perf_eval=3
-        )
+        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(kind="judge", iteration=2, round_label="r")
 
@@ -58,9 +55,7 @@ class TestDeepAgentsBackend:
     def test_perf_eval_receives_in_process_tools(self, tmp_path):
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(
-            inner, store=store, max_issues_per_perf_eval=4
-        )
+        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=4)
 
         wrapper.invoke(kind="perf_eval", iteration=5, round_label="r")
 
@@ -74,41 +69,31 @@ class TestDeepAgentsBackend:
         issues and the 6th must be rejected with the cap-reached error."""
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(
-            inner, store=store, max_issues_per_perf_eval=5
-        )
+        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=5)
 
         wrapper.invoke(kind="perf_eval", iteration=1, round_label="r")
         tools = inner.invoke.call_args.kwargs["tools"]
         create = next(t for t in tools if t.name == "create_issue")
 
         for i in range(5):
-            out = create.invoke(
-                {"type": "perf", "title": f"t{i}", "description": "d"}
-            )
+            out = create.invoke({"type": "perf", "title": f"t{i}", "description": "d"})
             assert "created" in out.lower() or "issue" in out.lower()
 
-        sixth = create.invoke(
-            {"type": "perf", "title": "overflow", "description": "d"}
-        )
+        sixth = create.invoke({"type": "perf", "title": "overflow", "description": "d"})
         assert "cap" in sixth.lower() or "limit" in sixth.lower()
 
     def test_judge_create_issue_rejects_non_bug_types(self, tmp_path):
         """Judge is bug-only — feature/perf must be rejected by policy."""
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(
-            inner, store=store, max_issues_per_perf_eval=3
-        )
+        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(kind="judge", iteration=1, round_label="r")
         tools = inner.invoke.call_args.kwargs["tools"]
         create = next(t for t in tools if t.name == "create_issue")
 
         for bad_type in ("feature", "perf"):
-            out = create.invoke(
-                {"type": bad_type, "title": "x", "description": "d"}
-            )
+            out = create.invoke({"type": bad_type, "title": "x", "description": "d"})
             assert "type" in out.lower() or "allowed" in out.lower()
 
 
@@ -121,9 +106,7 @@ class TestCliBackend:
     def test_judge_receives_mcp_server_spec(self, tmp_path):
         store = _make_store(tmp_path)
         inner = _mock_runner("cli")
-        wrapper = PlainLoopAgentRunner(
-            inner, store=store, max_issues_per_perf_eval=3
-        )
+        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(kind="judge", iteration=7, round_label="r")
 
@@ -146,9 +129,7 @@ class TestCliBackend:
     def test_perf_eval_receives_mcp_server_spec_with_all_types(self, tmp_path):
         store = _make_store(tmp_path)
         inner = _mock_runner("cli")
-        wrapper = PlainLoopAgentRunner(
-            inner, store=store, max_issues_per_perf_eval=4
-        )
+        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=4)
 
         wrapper.invoke(kind="perf_eval", iteration=2, round_label="r")
 
@@ -172,9 +153,7 @@ class TestPassThrough:
     def test_implementer_passes_through_under_deepagents(self, tmp_path):
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(
-            inner, store=store, max_issues_per_perf_eval=3
-        )
+        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(kind="implementer", round_label="r")
 
@@ -186,9 +165,7 @@ class TestPassThrough:
     def test_implementer_passes_through_under_cli(self, tmp_path):
         store = _make_store(tmp_path)
         inner = _mock_runner("cli")
-        wrapper = PlainLoopAgentRunner(
-            inner, store=store, max_issues_per_perf_eval=3
-        )
+        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(kind="implementer", round_label="r")
 
@@ -201,9 +178,7 @@ class TestPassThrough:
         inner runner — the AgentRunner Protocol has no such kwarg."""
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(
-            inner, store=store, max_issues_per_perf_eval=3
-        )
+        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(kind="judge", iteration=1, round_label="r")
 
@@ -214,9 +189,7 @@ class TestPassThrough:
         reach the inner runner unchanged."""
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(
-            inner, store=store, max_issues_per_perf_eval=3
-        )
+        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(
             kind="judge",
@@ -260,13 +233,9 @@ class TestBackendName:
     def test_backend_name_proxies_inner(self, tmp_path):
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(
-            inner, store=store, max_issues_per_perf_eval=3
-        )
+        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
         assert wrapper.backend_name == "deepagents"
 
         inner_cli = _mock_runner("cli")
-        wrapper_cli = PlainLoopAgentRunner(
-            inner_cli, store=store, max_issues_per_perf_eval=3
-        )
+        wrapper_cli = PlainLoopAgentRunner(inner_cli, store=store, max_issues_per_perf_eval=3)
         assert wrapper_cli.backend_name == "cli"

--- a/tests/loops/test_profiler.py
+++ b/tests/loops/test_profiler.py
@@ -12,17 +12,16 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from vibe_serve.agent_runner import (
+    _parse_profiler_response_text,
+    run_profiler_agent,
+)
 from vibe_serve.schemas import (
     ImplementerResponse,
     JudgeResponse,
     ProfilerResponse,
     Verdict,
 )
-from vibe_serve.agent_runner import (
-    _parse_profiler_response_text,
-    run_profiler_agent,
-)
-
 
 # ---------------------------------------------------------------------------
 # ProfilerResponse model tests
@@ -119,14 +118,16 @@ def test_run_profiler_agent_structured_response():
         bottlenecks="Attention dominates.",
         suggestions="No action needed.",
     )
-    agent.stream.return_value = iter([
-        {
-            "agent": {
-                "messages": [MagicMock(content="Profiled.", type="ai")],
-                "structured_response": resp_data,
+    agent.stream.return_value = iter(
+        [
+            {
+                "agent": {
+                    "messages": [MagicMock(content="Profiled.", type="ai")],
+                    "structured_response": resp_data,
+                }
             }
-        }
-    ])
+        ]
+    )
     result = run_profiler_agent(agent, "Profile the server.")
     assert result.analysis == "Good profile data."
     assert result.bottlenecks == "Attention dominates."
@@ -136,13 +137,15 @@ def test_run_profiler_agent_fallback_json_parsing():
     """Agent returns JSON text instead of structured response."""
     agent = MagicMock()
     json_text = _profiler_json(analysis="Fallback parsing.")
-    agent.stream.return_value = iter([
-        {
-            "agent": {
-                "messages": [MagicMock(content=json_text, type="ai")],
+    agent.stream.return_value = iter(
+        [
+            {
+                "agent": {
+                    "messages": [MagicMock(content=json_text, type="ai")],
+                }
             }
-        }
-    ])
+        ]
+    )
     result = run_profiler_agent(agent, "Profile the server.")
     assert result.analysis == "Fallback parsing."
 
@@ -150,13 +153,15 @@ def test_run_profiler_agent_fallback_json_parsing():
 def test_run_profiler_agent_no_response():
     """Agent returns no parseable response."""
     agent = MagicMock()
-    agent.stream.return_value = iter([
-        {
-            "agent": {
-                "messages": [MagicMock(content="I couldn't profile.", type="ai")],
+    agent.stream.return_value = iter(
+        [
+            {
+                "agent": {
+                    "messages": [MagicMock(content="I couldn't profile.", type="ai")],
+                }
             }
-        }
-    ])
+        ]
+    )
     result = run_profiler_agent(agent, "Profile the server.")
     assert "No structured response" in result.analysis
 
@@ -188,9 +193,9 @@ def nsys_db(tmp_path):
     """)
     # 3 kernels: flash_fwd (10us), rmsnorm (2us), silu (1us), with gaps
     kernels = [
-        (1, 1000, 11000, 0, 7, 100),   # flash_fwd: 10us
-        (2, 15000, 17000, 0, 7, 101),   # rmsnorm: 2us, gap=4us after flash
-        (3, 20000, 21000, 0, 7, 102),   # silu: 1us, gap=3us after rmsnorm
+        (1, 1000, 11000, 0, 7, 100),  # flash_fwd: 10us
+        (2, 15000, 17000, 0, 7, 101),  # rmsnorm: 2us, gap=4us after flash
+        (3, 20000, 21000, 0, 7, 102),  # silu: 1us, gap=3us after rmsnorm
     ]
     conn.executemany(
         "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (?, ?, ?, ?, ?, ?)",
@@ -205,9 +210,9 @@ def nsys_db(tmp_path):
         )
     """)
     runtime_calls = [
-        (500, 1200, 33, 100, 1, 1),     # cudaLaunchKernel for flash_fwd
-        (14500, 15100, 33, 101, 1, 1),   # cudaLaunchKernel for rmsnorm
-        (19500, 20100, 33, 102, 1, 1),   # cudaLaunchKernel for silu
+        (500, 1200, 33, 100, 1, 1),  # cudaLaunchKernel for flash_fwd
+        (14500, 15100, 33, 101, 1, 1),  # cudaLaunchKernel for rmsnorm
+        (19500, 20100, 33, 102, 1, 1),  # cudaLaunchKernel for silu
         (25000, 25500, 163, 200, 1, 1),  # cudaDeviceSynchronize
     ]
     conn.executemany(
@@ -232,7 +237,7 @@ def nsys_db(tmp_path):
 
 
 def test_analyze_kernels(nsys_db):
-    from examples.nsys_profiler.analyze_nsys import analyze_kernels, _build_string_map
+    from examples.nsys_profiler.analyze_nsys import _build_string_map, analyze_kernels
 
     conn = sqlite3.connect(nsys_db)
     strings = _build_string_map(conn)
@@ -246,7 +251,7 @@ def test_analyze_kernels(nsys_db):
 
 
 def test_analyze_cpu_overhead(nsys_db):
-    from examples.nsys_profiler.analyze_nsys import analyze_cpu_overhead, _build_string_map
+    from examples.nsys_profiler.analyze_nsys import _build_string_map, analyze_cpu_overhead
 
     conn = sqlite3.connect(nsys_db)
     strings = _build_string_map(conn)
@@ -260,7 +265,7 @@ def test_analyze_cpu_overhead(nsys_db):
 
 
 def test_analyze_gpu_idle_gaps(nsys_db):
-    from examples.nsys_profiler.analyze_nsys import analyze_gpu_idle_gaps, _build_string_map
+    from examples.nsys_profiler.analyze_nsys import _build_string_map, analyze_gpu_idle_gaps
 
     conn = sqlite3.connect(nsys_db)
     strings = _build_string_map(conn)
@@ -285,8 +290,9 @@ def test_analyze_memory_ops(nsys_db):
 def test_short_kernel_name():
     from examples.nsys_profiler.analyze_nsys import _short_kernel_name
 
-    assert _short_kernel_name("void at::native::vectorized_elementwise_kernel<4, float>") == "native::vectorized_elementwise_kernel"
+    assert (
+        _short_kernel_name("void at::native::vectorized_elementwise_kernel<4, float>")
+        == "native::vectorized_elementwise_kernel"
+    )
     assert _short_kernel_name("simple_kernel") == "simple_kernel"
     assert _short_kernel_name("a::b::c::func") == "c::func"
-
-

--- a/tests/loops/test_profiler_mcp.py
+++ b/tests/loops/test_profiler_mcp.py
@@ -42,14 +42,16 @@ _REPO = Path(__file__).resolve().parent.parent.parent
 @pytest.fixture(scope="module")
 def nsys_server_mod():
     return _load_module(
-        "_nsys_server", _REPO / "examples" / "nsys_profiler" / "server.py",
+        "_nsys_server",
+        _REPO / "examples" / "nsys_profiler" / "server.py",
     )
 
 
 @pytest.fixture(scope="module")
 def torch_server_mod():
     return _load_module(
-        "_torch_server", _REPO / "examples" / "torch_profiler" / "server.py",
+        "_torch_server",
+        _REPO / "examples" / "torch_profiler" / "server.py",
     )
 
 
@@ -73,8 +75,16 @@ class TestNsysMcpServer:
         server = nsys_server_mod.build_server()
         names = asyncio.run(_list_tool_names(server))
         assert names == {
-            "export", "tables", "kernels", "cpu_overhead", "idle_gaps",
-            "memory", "graph_replays", "step_timeline", "query", "summary",
+            "export",
+            "tables",
+            "kernels",
+            "cpu_overhead",
+            "idle_gaps",
+            "memory",
+            "graph_replays",
+            "step_timeline",
+            "query",
+            "summary",
         }
 
     def test_tables_tool_reports_empty_db(self, nsys_server_mod, tmp_path):
@@ -124,26 +134,47 @@ class TestTorchMcpServer:
         server = torch_server_mod.build_server()
         names = asyncio.run(_list_tool_names(server))
         assert names == {
-            "tables", "kernels", "operators", "cpu_overhead", "memory", "summary",
+            "tables",
+            "kernels",
+            "operators",
+            "cpu_overhead",
+            "memory",
+            "summary",
         }
 
     def test_tables_tool_reports_prof_json_overview(self, torch_server_mod, tmp_path):
         prof = tmp_path / "prof.json"
-        prof.write_text(json.dumps({
-            "version": 1,
-            "captured_at": "2026-04-22T00:00:00Z",
-            "mode": "model",
-            "total_cuda_time_us": 1234.5,
-            "total_cpu_time_us": 567.8,
-            "events": [
-                {"name": "aten::mm", "category": "operator",
-                 "cpu_time_us": 100, "cuda_time_us": 200,
-                 "self_cpu_time_us": 50, "self_cuda_time_us": 200, "count": 3},
-                {"name": "flash_fwd_kernel", "category": "kernel",
-                 "cpu_time_us": 10, "cuda_time_us": 500,
-                 "self_cpu_time_us": 10, "self_cuda_time_us": 500, "count": 2},
-            ],
-        }))
+        prof.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "captured_at": "2026-04-22T00:00:00Z",
+                    "mode": "model",
+                    "total_cuda_time_us": 1234.5,
+                    "total_cpu_time_us": 567.8,
+                    "events": [
+                        {
+                            "name": "aten::mm",
+                            "category": "operator",
+                            "cpu_time_us": 100,
+                            "cuda_time_us": 200,
+                            "self_cpu_time_us": 50,
+                            "self_cuda_time_us": 200,
+                            "count": 3,
+                        },
+                        {
+                            "name": "flash_fwd_kernel",
+                            "category": "kernel",
+                            "cpu_time_us": 10,
+                            "cuda_time_us": 500,
+                            "self_cpu_time_us": 10,
+                            "self_cuda_time_us": 500,
+                            "count": 2,
+                        },
+                    ],
+                }
+            )
+        )
 
         server = torch_server_mod.build_server()
         out = asyncio.run(_call_tool(server, "tables", report=str(prof)))
@@ -153,19 +184,35 @@ class TestTorchMcpServer:
 
     def test_kernels_tool_ranks_by_self_cuda(self, torch_server_mod, tmp_path):
         prof = tmp_path / "prof.json"
-        prof.write_text(json.dumps({
-            "version": 1,
-            "total_cuda_time_us": 700.0,
-            "total_cpu_time_us": 110.0,
-            "events": [
-                {"name": "flash_fwd_kernel", "category": "kernel",
-                 "cpu_time_us": 10, "cuda_time_us": 500,
-                 "self_cpu_time_us": 10, "self_cuda_time_us": 500, "count": 2},
-                {"name": "rms_norm_kernel", "category": "kernel",
-                 "cpu_time_us": 5, "cuda_time_us": 200,
-                 "self_cpu_time_us": 5, "self_cuda_time_us": 200, "count": 8},
-            ],
-        }))
+        prof.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "total_cuda_time_us": 700.0,
+                    "total_cpu_time_us": 110.0,
+                    "events": [
+                        {
+                            "name": "flash_fwd_kernel",
+                            "category": "kernel",
+                            "cpu_time_us": 10,
+                            "cuda_time_us": 500,
+                            "self_cpu_time_us": 10,
+                            "self_cuda_time_us": 500,
+                            "count": 2,
+                        },
+                        {
+                            "name": "rms_norm_kernel",
+                            "category": "kernel",
+                            "cpu_time_us": 5,
+                            "cuda_time_us": 200,
+                            "self_cpu_time_us": 5,
+                            "self_cuda_time_us": 200,
+                            "count": 8,
+                        },
+                    ],
+                }
+            )
+        )
 
         server = torch_server_mod.build_server()
         out = asyncio.run(_call_tool(server, "kernels", report=str(prof), top=5))

--- a/tests/sandbox/test_docker_sandbox.py
+++ b/tests/sandbox/test_docker_sandbox.py
@@ -38,6 +38,7 @@ class TestStart:
     def test_start_runs_docker_run_with_correct_args(self, mock_run, sandbox):
         # Remove CUDA_VISIBLE_DEVICES so fallback to "all" is tested
         import os
+
         os.environ.pop("CUDA_VISIBLE_DEVICES", None)
 
         mock_run.return_value = subprocess.CompletedProcess(
@@ -70,7 +71,8 @@ class TestStart:
     @patch("subprocess.run")
     def test_start_docker_run_timeout_raises_clear_error(self, mock_run, sandbox):
         mock_run.side_effect = subprocess.TimeoutExpired(
-            cmd=["docker", "run"], timeout=120,
+            cmd=["docker", "run"],
+            timeout=120,
         )
 
         with pytest.raises(RuntimeError, match="Timed out starting Docker container"):
@@ -80,7 +82,10 @@ class TestStart:
     def test_start_failure_removes_created_container(self, mock_run, sandbox):
         mock_run.side_effect = [
             subprocess.CompletedProcess(
-                args=[], returncode=125, stdout="abc123container\n", stderr="gpu error",
+                args=[],
+                returncode=125,
+                stdout="abc123container\n",
+                stderr="gpu error",
             ),
             subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
         ]
@@ -240,7 +245,10 @@ class TestSetupFns:
     def test_setup_fns_run_after_start(self, mock_run, tmp_path):
         """setup_fns receive the sandbox and run at the end of start()."""
         mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="abc123container\n", stderr="",
+            args=[],
+            returncode=0,
+            stdout="abc123container\n",
+            stderr="",
         )
         invocations: list[DockerSandbox] = []
 
@@ -259,7 +267,10 @@ class TestSetupFns:
     def test_setup_fns_re_run_on_restart(self, mock_run, tmp_path):
         """A second start() (e.g. after stop() from reselect_device) re-runs."""
         mock_run.return_value = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="abc123container\n", stderr="",
+            args=[],
+            returncode=0,
+            stdout="abc123container\n",
+            stderr="",
         )
         calls = 0
 
@@ -438,9 +449,7 @@ class TestPathTranslation:
             type(sandbox).__bases__[0], "read", return_value="content"
         ) as mock_super_read:
             sandbox.read("/reference/reference.py")
-            mock_super_read.assert_called_once_with(
-                "/workspace/reference/reference.py", 0, 2000
-            )
+            mock_super_read.assert_called_once_with("/workspace/reference/reference.py", 0, 2000)
 
     @patch("subprocess.run")
     def test_ls_translates_path(self, mock_run, sandbox):
@@ -450,9 +459,7 @@ class TestPathTranslation:
         )
         sandbox.start()
 
-        with patch.object(
-            type(sandbox).__bases__[0], "ls_info", return_value=[]
-        ) as mock_super_ls:
+        with patch.object(type(sandbox).__bases__[0], "ls_info", return_value=[]) as mock_super_ls:
             sandbox.ls_info("/")
             mock_super_ls.assert_called_once_with("/workspace/")
 
@@ -462,6 +469,7 @@ class TestCleanupOnExit:
     def _clear_live_containers(self):
         """Isolate the global _live_containers registry between tests."""
         from vibe_serve.sandbox.docker_sandbox import _live_containers
+
         _live_containers.clear()
         yield
         _live_containers.clear()
@@ -527,10 +535,7 @@ class TestWrite:
         assert any("mkdir" in cmd for cmd in cmds)
         assert any("cp" in cmd for cmd in cmds)
         # Should NOT have used docker exec bash -c (which would inline content)
-        exec_bash_calls = [
-            c for c in cmds
-            if "exec" in c and "bash" in c and "-c" in c
-        ]
+        exec_bash_calls = [c for c in cmds if "exec" in c and "bash" in c and "-c" in c]
         assert len(exec_bash_calls) == 0
 
     @patch("subprocess.run")
@@ -659,7 +664,8 @@ class TestShmSize:
     def test_shm_size_emitted(self, mock_run, tmp_path):
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
-            image="img", shm_size="16g",
+            image="img",
+            shm_size="16g",
         )
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
@@ -673,7 +679,9 @@ class TestShmSize:
     @patch("subprocess.run")
     def test_no_shm_size_by_default(self, mock_run, tmp_path):
         sandbox = DockerSandbox(host_workspace=str(tmp_path / "workspace"), image="img")
-        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="abc\n", stderr="")
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc\n", stderr=""
+        )
         sandbox.start()
         assert "--shm-size" not in mock_run.call_args_list[0][0][0]
 
@@ -684,13 +692,17 @@ class TestAutoRemove:
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"), image="img", auto_remove=True
         )
-        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="abc\n", stderr="")
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc\n", stderr=""
+        )
         sandbox.start()
         assert "--rm" in mock_run.call_args_list[0][0][0]
 
     @patch("subprocess.run")
     def test_no_rm_by_default(self, mock_run, tmp_path):
         sandbox = DockerSandbox(host_workspace=str(tmp_path / "workspace"), image="img")
-        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="abc\n", stderr="")
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc\n", stderr=""
+        )
         sandbox.start()
         assert "--rm" not in mock_run.call_args_list[0][0][0]

--- a/tests/sandbox/test_modal_model_setup.py
+++ b/tests/sandbox/test_modal_model_setup.py
@@ -8,6 +8,7 @@ import pytest
 class TestVolumeNameFor:
     def test_sanitizes_slash_and_case(self):
         from vibe_serve.sandbox.modal_model_setup import _volume_name_for
+
         assert (
             _volume_name_for("meta-llama/Llama-3.1-8B-Instruct")
             == "vibeserve-model-meta-llama-llama-3-1-8b-instruct"
@@ -15,9 +16,9 @@ class TestVolumeNameFor:
 
     def test_handles_colons_and_underscores(self):
         from vibe_serve.sandbox.modal_model_setup import _volume_name_for
+
         assert (
-            _volume_name_for("openai/whisper_large-v3")
-            == "vibeserve-model-openai-whisper-large-v3"
+            _volume_name_for("openai/whisper_large-v3") == "vibeserve-model-openai-whisper-large-v3"
         )
 
 
@@ -40,7 +41,9 @@ def mock_modal(monkeypatch):
             wrapped = MagicMock()
             wrapped.remote = MagicMock()
             return wrapped
+
         return wrap
+
     fake_app.function = _function_decorator
 
     monkeypatch.setattr(modal, "App", MagicMock(return_value=fake_app))
@@ -56,6 +59,7 @@ class TestEnsureModelVolume:
             _READY_SENTINEL,
             ensure_model_volume,
         )
+
         # Volume reports the ready sentinel at root.
         entry = MagicMock()
         entry.path = _READY_SENTINEL
@@ -71,6 +75,7 @@ class TestEnsureModelVolume:
 
     def test_triggers_upload_when_volume_empty(self, mock_modal):
         from vibe_serve.sandbox.modal_model_setup import ensure_model_volume
+
         mock_modal["volume"].listdir.return_value = []
 
         logs: list[str] = []
@@ -82,6 +87,7 @@ class TestEnsureModelVolume:
 
     def test_triggers_upload_when_listdir_raises(self, mock_modal):
         from vibe_serve.sandbox.modal_model_setup import ensure_model_volume
+
         mock_modal["volume"].listdir.side_effect = RuntimeError("not found")
 
         name = ensure_model_volume("meta-llama/Llama-3.1-8B-Instruct", log=lambda *_: None)
@@ -91,7 +97,9 @@ class TestEnsureModelVolume:
 
     def test_forwards_hf_token_as_secret(self, mock_modal):
         import modal
+
         from vibe_serve.sandbox.modal_model_setup import ensure_model_volume
+
         mock_modal["volume"].listdir.return_value = []
 
         ensure_model_volume("x/y", hf_token="hf_tok", log=lambda *_: None)
@@ -100,7 +108,9 @@ class TestEnsureModelVolume:
 
     def test_reads_hf_token_from_env(self, mock_modal, monkeypatch):
         import modal
+
         from vibe_serve.sandbox.modal_model_setup import ensure_model_volume
+
         mock_modal["volume"].listdir.return_value = []
         monkeypatch.setenv("HF_TOKEN", "from_env")
         monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)

--- a/tests/sandbox/test_modal_sandbox.py
+++ b/tests/sandbox/test_modal_sandbox.py
@@ -48,6 +48,7 @@ def mock_modal(monkeypatch):
 @pytest.fixture()
 def sandbox(tmp_path, mock_modal):
     from vibe_serve.sandbox.modal_sandbox import ModalSandbox
+
     ws = tmp_path / "workspace"
     ws.mkdir()
     return ModalSandbox(
@@ -66,6 +67,7 @@ class TestVpath:
 
     def test_preserves_passthrough(self, tmp_path, mock_modal):
         from vibe_serve.sandbox.modal_sandbox import ModalSandbox
+
         sb = ModalSandbox(
             host_workspace=str(tmp_path),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
@@ -81,6 +83,7 @@ class TestVpath:
 class TestStart:
     def test_start_creates_sandbox_with_gpu_and_timeout(self, sandbox, mock_modal):
         import modal
+
         sandbox.start()
         modal.Sandbox.create.assert_called_once()
         kwargs = modal.Sandbox.create.call_args.kwargs
@@ -90,6 +93,7 @@ class TestStart:
 
     def test_start_mounts_model_volume_when_name_given(self, tmp_path, mock_modal):
         from vibe_serve.sandbox.modal_sandbox import ModalSandbox
+
         sb = ModalSandbox(
             host_workspace=str(tmp_path),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
@@ -97,13 +101,17 @@ class TestStart:
         )
         sb.start()
         import modal
+
         kwargs = modal.Sandbox.create.call_args.kwargs
         assert "/model" in kwargs["volumes"]
 
     def test_start_uploads_bind_mounts_into_workspace_volume(
-        self, tmp_path, mock_modal,
+        self,
+        tmp_path,
+        mock_modal,
     ):
         from vibe_serve.sandbox.modal_sandbox import ModalSandbox
+
         ws = tmp_path / "ws"
         ws.mkdir()
         bench = tmp_path / "bench"
@@ -120,9 +128,12 @@ class TestStart:
         assert any("bench" in str(c) and "'/bench'" in str(c) for c in calls)
 
     def test_start_skips_model_bind_mount_from_workspace_volume(
-        self, tmp_path, mock_modal,
+        self,
+        tmp_path,
+        mock_modal,
     ):
         from vibe_serve.sandbox.modal_sandbox import ModalSandbox
+
         ws = tmp_path / "ws"
         ws.mkdir()
         sb = ModalSandbox(
@@ -136,7 +147,9 @@ class TestStart:
             assert "/host/model" not in str(c)
 
     def test_start_skips_hf_cache_bind_mount_from_workspace_volume(
-        self, tmp_path, mock_modal,
+        self,
+        tmp_path,
+        mock_modal,
     ):
         from vibe_serve.sandbox.modal_sandbox import ModalSandbox
 
@@ -159,7 +172,9 @@ class TestStart:
             assert ".hf_cache" not in str(c)
 
     def test_start_excludes_local_runtime_dirs_from_workspace_upload(
-        self, tmp_path, mock_modal,
+        self,
+        tmp_path,
+        mock_modal,
     ):
         from vibe_serve.sandbox.modal_sandbox import ModalSandbox
 
@@ -189,7 +204,9 @@ class TestStart:
         assert not any(".git" in c for c in uploaded)
 
     def test_start_uploads_minimal_codex_auth_snapshot(
-        self, tmp_path, mock_modal,
+        self,
+        tmp_path,
+        mock_modal,
     ):
         from vibe_serve.sandbox.modal_sandbox import ModalSandbox
 
@@ -225,7 +242,9 @@ class TestExecute:
         assert resp.exit_code == 0
         assert resp.output == "hello\n"
         mock_modal["sandbox"].exec.assert_called_with(
-            "bash", "-c", "ls",
+            "bash",
+            "-c",
+            "ls",
             workdir="/workspace",
             timeout=300,
         )
@@ -275,6 +294,7 @@ class TestStop:
 class TestTransientRetry:
     def test_is_transient_detects_dns_and_connection_errors(self):
         import socket
+
         from vibe_serve.sandbox.modal_sandbox import _is_transient
 
         assert _is_transient(socket.gaierror(-2, "Name or service not known"))
@@ -291,12 +311,14 @@ class TestTransientRetry:
 
     def test_retry_recovers_after_transient_error(self, monkeypatch):
         import socket
+
         from vibe_serve.sandbox.modal_sandbox import _retry_transient
 
         # Avoid actual sleeping in the test.
         monkeypatch.setattr("vibe_serve.sandbox.modal_sandbox.time.sleep", lambda _: None)
 
         calls = {"n": 0}
+
         def flaky():
             calls["n"] += 1
             if calls["n"] < 3:
@@ -310,6 +332,7 @@ class TestTransientRetry:
         from vibe_serve.sandbox.modal_sandbox import _retry_transient
 
         calls = {"n": 0}
+
         def fatal():
             calls["n"] += 1
             raise ValueError("real bug")
@@ -320,11 +343,13 @@ class TestTransientRetry:
 
     def test_retry_gives_up_after_max_attempts(self, monkeypatch):
         import socket
+
         from vibe_serve.sandbox.modal_sandbox import _retry_transient
 
         monkeypatch.setattr("vibe_serve.sandbox.modal_sandbox.time.sleep", lambda _: None)
 
         calls = {"n": 0}
+
         def always_fails():
             calls["n"] += 1
             raise socket.gaierror(-2, "Name or service not known")
@@ -346,6 +371,7 @@ class TestTransientRetry:
         proc_ok.wait.return_value = 0
 
         attempt = {"n": 0}
+
         def flaky_exec(*args, **kwargs):
             attempt["n"] += 1
             if attempt["n"] < 3:
@@ -367,6 +393,7 @@ class TestModalCommandExecutor:
 
     def _make_executor(self, fake_exec_result=None):
         from vibe_serve.agents.modal_executor import ModalCommandExecutor
+
         fake_sandbox = MagicMock()
         fake_sandbox._sandbox_id = "sb-abc123"
         fake_sandbox._sandbox = MagicMock()
@@ -385,6 +412,7 @@ class TestModalCommandExecutor:
 
     def _request(self, argv, stdin="", cwd="/workspace", env=None, timeout=None):
         from agentshim.executor import CommandRequest
+
         return CommandRequest(
             argv=list(argv),
             stdin=stdin,
@@ -395,6 +423,7 @@ class TestModalCommandExecutor:
 
     def _sink(self):
         from agentshim.executor import CallbackCommandStreamSink
+
         sink = CallbackCommandStreamSink(
             on_stdout=lambda _: None,
             on_stderr=lambda _: None,
@@ -417,6 +446,7 @@ class TestModalCommandExecutor:
 
     def test_run_raises_when_sandbox_not_started(self):
         from vibe_serve.agents.modal_executor import ModalCommandExecutor
+
         fake_sandbox = MagicMock()
         fake_sandbox._sandbox = None
         executor = ModalCommandExecutor(fake_sandbox)
@@ -426,6 +456,7 @@ class TestModalCommandExecutor:
     def test_run_picks_up_restarted_sandbox_lazily(self):
         """A fallback restart that swaps ``_sandbox`` should be used by the next run()."""
         from vibe_serve.agents.modal_executor import ModalCommandExecutor
+
         wrapper = MagicMock()
         wrapper._sandbox = MagicMock()
         wrapper._sandbox.exec.return_value = self._fake_container_proc(stdout_lines=["first\n"])
@@ -469,11 +500,15 @@ class TestSandboxFallbackRestart:
         assert _is_sandbox_dead(RuntimeError("sandbox is not running"))
         # Non-sandbox-dead errors must NOT trigger the restart path.
         import socket
+
         assert not _is_sandbox_dead(socket.gaierror(-2, "Name or service not known"))
         assert not _is_sandbox_dead(ValueError("bad argument"))
 
     def test_execute_restarts_sandbox_on_death_and_retries(
-        self, sandbox, mock_modal, monkeypatch,
+        self,
+        sandbox,
+        mock_modal,
+        monkeypatch,
     ):
         """A dead sandbox should be recreated once, then the command re-run."""
         monkeypatch.setattr("vibe_serve.sandbox.modal_sandbox.time.sleep", lambda _: None)
@@ -485,6 +520,7 @@ class TestSandboxFallbackRestart:
         proc_ok.wait.return_value = 0
 
         call = {"n": 0}
+
         def flaky_exec(*args, **kwargs):
             call["n"] += 1
             if call["n"] == 1:
@@ -522,6 +558,7 @@ class TestSandboxFallbackRestart:
         sb.start()
 
         call = {"n": 0}
+
         def dies(*args, **kwargs):
             call["n"] += 1
             raise RuntimeError("Sandbox has already shut down")
@@ -535,6 +572,7 @@ class TestSandboxFallbackRestart:
     def test_extra_readonly_volumes_are_mounted(self, tmp_path, mock_modal):
         """Auxiliary volumes like /draft_model should be added to volumes dict."""
         import modal
+
         from vibe_serve.sandbox.modal_sandbox import ModalSandbox
 
         sb = ModalSandbox(
@@ -550,9 +588,7 @@ class TestSandboxFallbackRestart:
 class TestPathOverrides:
     def test_read_translates_virtual_path(self, sandbox, mock_modal):
         sandbox.start()
-        mock_modal["proc"].stdout.read.return_value = (
-            "     1\thello\n"
-        )
+        mock_modal["proc"].stdout.read.return_value = "     1\thello\n"
         sandbox.read("/foo.txt")
         # The base class builds a python3 heredoc command — check /workspace/foo.txt appears
         # (it gets base64-encoded; easier to check via _vpath directly).

--- a/tests/sandbox/test_run_environment.py
+++ b/tests/sandbox/test_run_environment.py
@@ -106,9 +106,7 @@ def test_modal_environment_uses_local_docker_for_editing(tmp_path):
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))
 
-    session = env.open(
-        _request(tmp_path, backend, agent_backend="cli", cli_provider="codex")
-    )
+    session = env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="codex"))
 
     # The sandbox is local Docker, not a Modal Sandbox.
     assert backend.calls[0][0] is SandboxKind.DOCKER
@@ -140,9 +138,7 @@ def test_modal_environment_prompt_notes_describe_modal_dispatch(tmp_path):
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))
 
-    session = env.open(
-        _request(tmp_path, backend, agent_backend="cli", cli_provider="codex")
-    )
+    session = env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="codex"))
 
     notes = session.view.prompt_notes
     assert "modal run" in notes
@@ -181,12 +177,20 @@ def test_modal_environment_per_run_namespace_prefix_unique(tmp_path):
     log_b.mkdir(exist_ok=True)
 
     req_a = RunEnvironmentRequest(
-        log_dir=log_a, workspace=ws_a, ref_dir=None, backend=backend_a,
-        agent_backend="cli", cli_provider="codex",
+        log_dir=log_a,
+        workspace=ws_a,
+        ref_dir=None,
+        backend=backend_a,
+        agent_backend="cli",
+        cli_provider="codex",
     )
     req_b = RunEnvironmentRequest(
-        log_dir=log_b, workspace=ws_b, ref_dir=None, backend=backend_b,
-        agent_backend="cli", cli_provider="codex",
+        log_dir=log_b,
+        workspace=ws_b,
+        ref_dir=None,
+        backend=backend_b,
+        agent_backend="cli",
+        cli_provider="codex",
     )
     notes_a = env.open(req_a).view.prompt_notes
     notes_b = env.open(req_b).view.prompt_notes
@@ -205,9 +209,7 @@ def test_modal_environment_runtime_notes_describe_profile_contract(tmp_path):
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))
 
-    session = env.open(
-        _request(tmp_path, backend, agent_backend="cli", cli_provider="codex")
-    )
+    session = env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="codex"))
     notes = session.view.prompt_notes
 
     assert "modal_profile" in notes

--- a/tests/test_agent_cli_mcp.py
+++ b/tests/test_agent_cli_mcp.py
@@ -265,7 +265,7 @@ class TestCodexMCP:
         spec = MCPServerSpec(
             name="weird",
             command='py"thon',
-            args=['back\\slash', 'quoted"value'],
+            args=["back\\slash", 'quoted"value'],
         )
         agent.install_mcp_servers(tmp_path, [spec])
         joined = "\n".join(agent.extra_config_args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,6 @@ import pytest
 
 from vibe_serve.cli import _extract_flag, _extract_loop_selection, main
 
-
 # ---------------------------------------------------------------------------
 # Flag extraction
 # ---------------------------------------------------------------------------
@@ -85,9 +84,7 @@ def test_extract_loop_selection_unknown_outer_loop_exits():
 )
 def test_main_routes_to_runner(loop_name: str, runner_attr: str):
     argv = ["vibe-serve", "--outer-loop", loop_name, "--exp-name", "x"]
-    with patch.object(sys, "argv", argv), patch(
-        f"vibe_serve.cli.{runner_attr}"
-    ) as runner:
+    with patch.object(sys, "argv", argv), patch(f"vibe_serve.cli.{runner_attr}") as runner:
         main()
         runner.assert_called_once()
         args = runner.call_args.args[0]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,9 @@
 import os
-import pytest
 import tomllib
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from vibe_serve.config import _load_config, _load_dotenv_file
 
@@ -88,25 +89,19 @@ class TestLoadConfigStrict:
 
     def test_unknown_top_level_section_rejected(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
-        cfg_file.write_text(
-            '[model]\nname = "claude-sonnet-4-6"\n\n[bogus]\nx = 1\n'
-        )
+        cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n\n[bogus]\nx = 1\n')
         with pytest.raises(ValueError, match="bogus"):
             _load_config(cfg_file)
 
     def test_unknown_key_in_known_section_rejected(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
-        cfg_file.write_text(
-            '[model]\nname = "claude-sonnet-4-6"\n\n[agent]\ncli_modle = "x"\n'
-        )
+        cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n\n[agent]\ncli_modle = "x"\n')
         with pytest.raises(ValueError, match="cli_modle"):
             _load_config(cfg_file)
 
     def test_unknown_backend_rejected(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
-        cfg_file.write_text(
-            '[model]\nname = "claude-sonnet-4-6"\n\n[backend]\nname = "tpu"\n'
-        )
+        cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n\n[backend]\nname = "tpu"\n')
         with pytest.raises(ValueError, match="tpu"):
             _load_config(cfg_file)
 

--- a/tests/test_git_snapshot_resilience.py
+++ b/tests/test_git_snapshot_resilience.py
@@ -24,8 +24,10 @@ def _make_ctx(ws):
         workspace=ws,
         lprint=lambda *a, **k: None,
         _GIT_ENV={
-            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
-            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
         },
     )
     ctx._collect_unreadable = lambda: _RunContext._collect_unreadable(ctx)
@@ -92,7 +94,10 @@ def test_git_add_all_excludes_unreadable_and_succeeds(tmp_path):
         ctx._git_add_all()
         staged = subprocess.run(
             ["git", "diff", "--cached", "--name-only"],
-            cwd=ws, capture_output=True, text=True, check=True,
+            cwd=ws,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.split()
         assert "code.py" in staged
         assert "system_profile.json" not in staged

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
 import pytest
+
 from vibe_serve.llm_client import _is_google_model
 
 

--- a/tests/test_llama_mlx_8bit_bundle.py
+++ b/tests/test_llama_mlx_8bit_bundle.py
@@ -2,7 +2,6 @@ import ast
 import json
 from pathlib import Path
 
-
 BUNDLE = Path("examples/Llama-3.1-8B-Instruct-MLX-8bit")
 
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,7 +1,8 @@
 import json
-import pytest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from vibe_serve.config import Config
 from vibe_serve.llm_client import _build_model
@@ -183,7 +184,9 @@ class TestVertexAIProvider:
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     @patch("langchain_google_genai.ChatGoogleGenerativeAI")
-    def test_vertex_gemini_thinking_level_takes_precedence(self, mock_chat_cls, mock_from_sa, key_file):
+    def test_vertex_gemini_thinking_level_takes_precedence(
+        self, mock_chat_cls, mock_from_sa, key_file
+    ):
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
         config = _make_config(
@@ -202,7 +205,13 @@ class TestVertexAIProvider:
         config = _make_config(
             "claude-sonnet-4-6",
             provider="vertex-ai",
-            providers={"vertex-ai": {"json": "/nonexistent/key.json", "project": None, "region": "us-east5"}},
+            providers={
+                "vertex-ai": {
+                    "json": "/nonexistent/key.json",
+                    "project": None,
+                    "region": "us-east5",
+                }
+            },
         )
         with pytest.raises(ValueError, match="service account key not found"):
             _build_model(config)
@@ -215,7 +224,13 @@ class TestVertexAIProvider:
         config = _make_config(
             "claude-sonnet-4-6",
             provider="vertex-ai",
-            providers={"vertex-ai": {"json": str(key_file), "project": "override-project", "region": "us-east5"}},
+            providers={
+                "vertex-ai": {
+                    "json": str(key_file),
+                    "project": "override-project",
+                    "region": "us-east5",
+                }
+            },
         )
         _build_model(config)
         mock_chat_cls.assert_called_once_with(
@@ -286,7 +301,9 @@ class TestOpenAIProvider:
 
 class TestThinkingNotSupported:
     def test_anthropic_with_thinking_raises(self):
-        config = _make_config("claude-sonnet-4-6", provider="anthropic", thinking={"level": "medium"})
+        config = _make_config(
+            "claude-sonnet-4-6", provider="anthropic", thinking={"level": "medium"}
+        )
         with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
             _build_model(config)
 

--- a/tests/test_skills_wiring.py
+++ b/tests/test_skills_wiring.py
@@ -16,9 +16,7 @@ def _args(tmp_path, backend, *, no_skills=False, skills_dir=None):
     cfg.write_text('[model]\nname = "gpt-5.5"\n')
     if skills_dir is None:
         skills_dir = [Path("resources/skills/serving-systems")]
-    return SimpleNamespace(
-        config=cfg, no_skills=no_skills, skills_dir=skills_dir, backend=backend
-    )
+    return SimpleNamespace(config=cfg, no_skills=no_skills, skills_dir=skills_dir, backend=backend)
 
 
 def test_trainium_auto_includes_nki_skills(tmp_path):
@@ -35,9 +33,7 @@ def test_cuda_does_not_include_nki(tmp_path):
 
 
 def test_no_skills_disables_even_for_trainium(tmp_path):
-    _, skills, _ = load_config_and_skills(
-        _args(tmp_path, ComputeBackend.TRAINIUM, no_skills=True)
-    )
+    _, skills, _ = load_config_and_skills(_args(tmp_path, ComputeBackend.TRAINIUM, no_skills=True))
     assert skills is None
 
 

--- a/tests/test_todo_display.py
+++ b/tests/test_todo_display.py
@@ -7,7 +7,6 @@ import pytest
 
 from vibe_serve.agents.callbacks import TodoDisplay
 
-
 # --- TodoDisplay rendering ---
 
 
@@ -92,9 +91,11 @@ def test_run_agent_passes_thread_id():
     from vibe_serve.agent_runner import run_agent
 
     agent = MagicMock()
-    agent.stream.return_value = iter([
-        {"agent": {"messages": [MagicMock(type="ai", content="Done")]}},
-    ])
+    agent.stream.return_value = iter(
+        [
+            {"agent": {"messages": [MagicMock(type="ai", content="Done")]}},
+        ]
+    )
 
     with patch("vibe_serve.agent_runner.TodoDisplay"):
         run_agent(agent, "do stuff")
@@ -110,14 +111,20 @@ def test_run_judge_agent_passes_thread_id():
     from vibe_serve.schemas import JudgeResponse, Verdict
 
     agent = MagicMock()
-    agent.stream.return_value = iter([
-        {"agent": {
-            "messages": [],
-            "structured_response": JudgeResponse(
-                analysis="Good", feedback="", verdict=Verdict.PASS,
-            ),
-        }},
-    ])
+    agent.stream.return_value = iter(
+        [
+            {
+                "agent": {
+                    "messages": [],
+                    "structured_response": JudgeResponse(
+                        analysis="Good",
+                        feedback="",
+                        verdict=Verdict.PASS,
+                    ),
+                }
+            },
+        ]
+    )
 
     with patch("vibe_serve.agent_runner.TodoDisplay"):
         run_judge_agent(agent, "review")
@@ -137,23 +144,31 @@ def test_run_agent_extracts_todos_from_tools_node():
     todos_seen = []
 
     agent = MagicMock()
-    agent.stream.return_value = iter([
-        # Todos arrive via the tools node (Command update from write_todos)
-        {"tools": {
-            "todos": [{"content": "Setup", "status": "in_progress"}],
-            "messages": [],
-        }},
-        {"tools": {
-            "todos": [
-                {"content": "Setup", "status": "completed"},
-                {"content": "Code", "status": "in_progress"},
-            ],
-            "messages": [],
-        }},
-        {"agent": {
-            "messages": [MagicMock(type="ai", content="Done")],
-        }},
-    ])
+    agent.stream.return_value = iter(
+        [
+            # Todos arrive via the tools node (Command update from write_todos)
+            {
+                "tools": {
+                    "todos": [{"content": "Setup", "status": "in_progress"}],
+                    "messages": [],
+                }
+            },
+            {
+                "tools": {
+                    "todos": [
+                        {"content": "Setup", "status": "completed"},
+                        {"content": "Code", "status": "in_progress"},
+                    ],
+                    "messages": [],
+                }
+            },
+            {
+                "agent": {
+                    "messages": [MagicMock(type="ai", content="Done")],
+                }
+            },
+        ]
+    )
 
     with patch("vibe_serve.agent_runner.TodoDisplay") as MockTD:
         instance = MockTD.return_value
@@ -172,11 +187,15 @@ def test_run_agent_extracts_todos_from_any_node():
     todos_seen = []
 
     agent = MagicMock()
-    agent.stream.return_value = iter([
-        {"some_other_node": {
-            "todos": [{"content": "Task A", "status": "pending"}],
-        }},
-    ])
+    agent.stream.return_value = iter(
+        [
+            {
+                "some_other_node": {
+                    "todos": [{"content": "Task A", "status": "pending"}],
+                }
+            },
+        ]
+    )
 
     with patch("vibe_serve.agent_runner.TodoDisplay") as MockTD:
         instance = MockTD.return_value
@@ -195,18 +214,26 @@ def test_run_judge_agent_extracts_todos():
     todos_seen = []
 
     agent = MagicMock()
-    agent.stream.return_value = iter([
-        {"tools": {
-            "todos": [{"content": "Review code", "status": "in_progress"}],
-            "messages": [],
-        }},
-        {"agent": {
-            "messages": [],
-            "structured_response": JudgeResponse(
-                analysis="Good", feedback="", verdict=Verdict.PASS,
-            ),
-        }},
-    ])
+    agent.stream.return_value = iter(
+        [
+            {
+                "tools": {
+                    "todos": [{"content": "Review code", "status": "in_progress"}],
+                    "messages": [],
+                }
+            },
+            {
+                "agent": {
+                    "messages": [],
+                    "structured_response": JudgeResponse(
+                        analysis="Good",
+                        feedback="",
+                        verdict=Verdict.PASS,
+                    ),
+                }
+            },
+        ]
+    )
 
     with patch("vibe_serve.agent_runner.TodoDisplay") as MockTD:
         instance = MockTD.return_value


### PR DESCRIPTION
## Summary

- Add `scripts/format.sh` for local Ruff import ordering and formatting across `src`, `tests`, `examples`, and `resources`.
- Add `scripts/check_format.sh` for CI-friendly import-order and formatting checks across the same directories.
- Run the formatter across existing checked Python files so the new check passes immediately.
- Document the formatting commands in the README and run the check in GitHub Actions before pytest.

Close #63.

## Notes

This PR intentionally limits CI enforcement to formatting and import ordering. Full `ruff check` currently reports non-format lint findings, so enabling every selected Ruff rule should be handled in a separate lint cleanup.

## Validation

- `./scripts/check_format.sh`
- `uv run python -m pytest -v` (722 passed; the suite emitted existing Modal coroutine RuntimeWarnings after completion)