### PR TITLE
Enforce full Ruff lint in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,8 @@ jobs:
       - name: Check Python formatting
         run: ./scripts/check_format.sh
 
+      - name: Check Python lint
+        run: ./scripts/check_lint.sh
+
       - name: Run tests
         run: uv run python -m pytest -v

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ resources/skills/serving-systems/ # Agent Skills library
 ```bash
 ./scripts/format.sh                                # format checked Python dirs
 ./scripts/check_format.sh                          # check formatting for CI
+./scripts/check_lint.sh                            # check Ruff lint for CI
 uv run pytest                                       # full suite
 uv run pytest tests/loops/plain/test_plain_loop.py  # one file
 uv run pytest -k orchestrator                       # by keyword

--- a/examples/Llama-3-8B-trn2/accuracy_checker/checker.py
+++ b/examples/Llama-3-8B-trn2/accuracy_checker/checker.py
@@ -231,7 +231,7 @@ def main():
 
     print("Generating reference outputs ...")
     ref_outputs: list[list[int]] = []
-    for prompt, max_tokens, desc in test_cases:
+    for prompt, max_tokens, _desc in test_cases:
         ref_outputs.append(generate_reference(ref_model, tokenizer, prompt, max_tokens, device))
 
     # Unload reference model to free memory.

--- a/examples/Llama-3-8B/accuracy_checker/checker.py
+++ b/examples/Llama-3-8B/accuracy_checker/checker.py
@@ -196,7 +196,7 @@ def main():
 
     print("Generating reference outputs ...")
     ref_outputs: list[list[int]] = []
-    for prompt, max_tokens, desc in test_cases:
+    for prompt, max_tokens, _desc in test_cases:
         ref_outputs.append(
             generate_reference(ref_model, tokenizer, prompt, max_tokens, args.device)
         )

--- a/examples/moonshine-streaming/accuracy_checker/checker.py
+++ b/examples/moonshine-streaming/accuracy_checker/checker.py
@@ -71,7 +71,6 @@ def load_test_samples(audio_dir: Path):
 def transcribe_reference(model, proj_out, tokenizer, audio: np.ndarray, sr: int) -> str:
     """Greedy decode with HF MoonshineStreamingModel + a separately-loaded
     proj_out (lm_head) projection.  Matches the offline-transcribe contract."""
-    from transformers.cache_utils import DynamicCache, EncoderDecoderCache
 
     device = next(model.parameters()).device
     dtype = next(model.parameters()).dtype
@@ -184,7 +183,7 @@ def main():
 
     print("Generating reference outputs ...")
     ref_outputs: list[str] = []
-    for desc, audio, sr, _ in test_samples:
+    for _desc, audio, sr, _ in test_samples:
         ref_outputs.append(transcribe_reference(ref_model, proj_out, tokenizer, audio, sr))
 
     del ref_model, proj_out, sd

--- a/examples/moonshine-streaming/benchmark/benchmark.py
+++ b/examples/moonshine-streaming/benchmark/benchmark.py
@@ -25,15 +25,14 @@ import asyncio
 import json
 import math
 import random
-import struct
 import time
 import wave
 from pathlib import Path
 
 try:
     import httpx
-except ImportError:
-    raise ImportError("httpx is required: pip install httpx")
+except ImportError as exc:
+    raise ImportError("httpx is required: pip install httpx") from exc
 try:
     import websockets
 except ImportError:
@@ -150,7 +149,7 @@ async def streaming_client(
 
     # latencies
     chunk_latencies: list[float] = []
-    for i, ts in enumerate(sent_times):
+    for _i, ts in enumerate(sent_times):
         future = [pt for pt in partial_times if pt >= ts]
         if future:
             chunk_latencies.append(future[0] - ts)
@@ -311,7 +310,6 @@ async def run_offline(args, audio_pool):
     seconds.  Each worker picks an audio sample, fires the request, and
     immediately starts the next one when it returns — i.e. measures the
     server's saturation throughput at the chosen concurrency level."""
-    rng = random.Random(args.seed)
     url = args.url.rstrip("/") + args.endpoint
     print(f"Offline benchmark: concurrency={args.concurrency} duration={args.duration}s url={url}")
 

--- a/examples/nsys_profiler/analyze_nsys.py
+++ b/examples/nsys_profiler/analyze_nsys.py
@@ -312,7 +312,7 @@ def cmd_idle_gaps(args):
         by_device[r[3]].append(r)
 
     gaps, total_idle, total_busy = [], 0, 0
-    for device_id, kernels in by_device.items():
+    for _device_id, kernels in by_device.items():
         intervals = sorted((k[1], k[2]) for k in kernels)
         merged = []
         for s, e in intervals:
@@ -414,7 +414,7 @@ def cmd_graph_replays(args):
 
     # Per-graphExecId stats
     by_exec: dict[int, list[int]] = defaultdict(list)
-    for s, e, gid, geid in traces:
+    for s, e, _gid, geid in traces:
         by_exec[geid].append(e - s)
 
     print(
@@ -452,7 +452,7 @@ def cmd_graph_replays(args):
         if replay_gaps:
             avg_gap = sum(replay_gaps) / len(replay_gaps) / 1000
             med_gap = sorted(replay_gaps)[len(replay_gaps) // 2] / 1000
-            print(f"\nGap between replays (scheduling overhead):")
+            print("\nGap between replays (scheduling overhead):")
             print(f"  Avg: {avg_gap:.1f} us")
             print(f"  Median: {med_gap:.1f} us")
             print(f"  Min: {min(replay_gaps) / 1000:.1f} us")
@@ -522,7 +522,7 @@ def cmd_step_timeline(args):
     boundaries = [i for i in range(1, len(rows)) if rows[i][1] - rows[i - 1][2] > best_thresh]
     if len(boundaries) < 2:
         print(
-            f"(Could not detect decode step boundaries. Try graph-replays if CUDA graphs are active.)"
+            "(Could not detect decode step boundaries. Try graph-replays if CUDA graphs are active.)"
         )
         return
 

--- a/examples/olmo-hybrid-prefix-caching/accuracy_checker/checker.py
+++ b/examples/olmo-hybrid-prefix-caching/accuracy_checker/checker.py
@@ -160,7 +160,7 @@ def main():
 
     print("Generating reference outputs ...")
     ref_outputs: list[list[int]] = []
-    for prompt, max_tokens, desc in test_cases:
+    for prompt, max_tokens, _desc in test_cases:
         ref_outputs.append(
             generate_reference(ref_model, tokenizer, prompt, max_tokens, args.device)
         )

--- a/examples/show-o2-1.5B-HQ-h100/reference/reference.py
+++ b/examples/show-o2-1.5B-HQ-h100/reference/reference.py
@@ -325,7 +325,7 @@ class ShowO2Model:
         postprocess_mode: str = "upstream",
         resolution: int = DEFAULT_RESOLUTION,
         load_vae: bool = False,
-    ) -> "ShowO2Model":
+    ) -> ShowO2Model:
         if postprocess_mode not in {"upstream", "cpu", "native"}:
             raise ValueError(f"Unsupported postprocess mode: {postprocess_mode}")
         if vae_output_dtype not in {"float32", "native", "deferred"}:

--- a/examples/show-o2-1.5B-HQ-macbook/reference/reference.py
+++ b/examples/show-o2-1.5B-HQ-macbook/reference/reference.py
@@ -325,7 +325,7 @@ class ShowO2Model:
         postprocess_mode: str = "upstream",
         resolution: int = DEFAULT_RESOLUTION,
         load_vae: bool = False,
-    ) -> "ShowO2Model":
+    ) -> ShowO2Model:
         if postprocess_mode not in {"upstream", "cpu", "native"}:
             raise ValueError(f"Unsupported postprocess mode: {postprocess_mode}")
         if vae_output_dtype not in {"float32", "native", "deferred"}:

--- a/examples/show-o2-1.5B-HQ/reference/reference.py
+++ b/examples/show-o2-1.5B-HQ/reference/reference.py
@@ -325,7 +325,7 @@ class ShowO2Model:
         postprocess_mode: str = "upstream",
         resolution: int = DEFAULT_RESOLUTION,
         load_vae: bool = False,
-    ) -> "ShowO2Model":
+    ) -> ShowO2Model:
         if postprocess_mode not in {"upstream", "cpu", "native"}:
             raise ValueError(f"Unsupported postprocess mode: {postprocess_mode}")
         if vae_output_dtype not in {"float32", "native", "deferred"}:

--- a/examples/torch_profiler/analyze_torch_profile.py
+++ b/examples/torch_profiler/analyze_torch_profile.py
@@ -54,10 +54,9 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
-import os
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -158,7 +157,7 @@ def cmd_capture(args: argparse.Namespace) -> None:
     events_json = _summarize_prof(prof, num_iters=args.num_iters)
     events_json.update(
         {
-            "captured_at": datetime.now(timezone.utc).isoformat(),
+            "captured_at": datetime.now(UTC).isoformat(),
             "mode": "model",
             "device": args.device,
             "dtype": args.dtype,
@@ -214,7 +213,7 @@ def cmd_capture_server(args: argparse.Namespace) -> None:
         f"[capture-server] sending {args.requests} requests (max_tokens={args.max_tokens})...",
         file=sys.stderr,
     )
-    for i in range(args.requests):
+    for _i in range(args.requests):
         _post(
             "/v1/completions",
             {
@@ -233,7 +232,7 @@ def cmd_capture_server(args: argparse.Namespace) -> None:
             "is the server implementing the expected contract?"
         )
 
-    result.setdefault("captured_at", datetime.now(timezone.utc).isoformat())
+    result.setdefault("captured_at", datetime.now(UTC).isoformat())
     result.setdefault("mode", "server")
     result.setdefault("num_iters", args.requests)
     Path(args.output).write_text(json.dumps(result, indent=2))

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-profiling/examples/basic-profiling-workflow.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-profiling/examples/basic-profiling-workflow.py
@@ -12,7 +12,6 @@ Run this script on Trainium/Inferentia hardware with the NKI venv activated.
 """
 
 import os
-import subprocess
 from datetime import datetime
 from pathlib import Path
 

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/find_nonzero_indices.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/find_nonzero_indices.py
@@ -91,7 +91,7 @@ def find_nonzero_indices(
     """
     T_DIM, C_DIM = input_tensor.shape
     # Handle col_start_id parameter for processing subset of columns
-    if col_start_id != None and n_cols != None:
+    if col_start_id is not None and n_cols is not None:
         col_start_id_sbuf = nl.ndarray(
             (1, 1), dtype=nl.int32, buffer=nl.sbuf, name="col_start_id_sbuf"
         )
@@ -111,7 +111,7 @@ def find_nonzero_indices(
     C_TILE_SIZE = P_MAX  # Tile size for the C dimension / SBUF partition count
 
     # Use chunk_size to limit SBUF usage for large T
-    if chunk_size == None:
+    if chunk_size is None:
         chunk_size = T_DIM
     kernel_assert(
         T_DIM % chunk_size == 0, f"T_DIM ({T_DIM}) must be divisible by chunk_size ({chunk_size})"
@@ -184,7 +184,7 @@ def find_nonzero_indices(
             t_chunk_start = chunk_idx * chunk_size
 
             # --- Load phase: single DMA copy for all T tiles in the chunk ---
-            if col_start_id_sbuf != None:
+            if col_start_id_sbuf is not None:
                 nisa.dma_copy(
                     dst=input_sbuf[:, 0:CHUNK_T_TILES, 0:n_columns_this_round],
                     src=input_tensor.ap(

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/indexed_flatten.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/indexed_flatten.py
@@ -14,8 +14,6 @@
 
 """Indexed flatten kernel for MoE blockwise matmul operations."""
 
-from typing import Optional
-
 import nki
 import nki.isa as nisa
 import nki.language as nl
@@ -30,7 +28,7 @@ def indexed_flatten(
     f_len: int,
     output_len: int,
     row_offsets: nl.ndarray,
-    row_offsets_start: Optional[nl.ndarray] = None,
+    row_offsets_start: nl.ndarray | None = None,
     padding_val: int = -1,
 ) -> nl.ndarray:
     """

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/layernorm_tkg.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/layernorm_tkg.py
@@ -14,8 +14,6 @@
 
 """LayerNorm subkernel optimized for token generation (TKG) inference with LNC sharding support."""
 
-from typing import Optional
-
 import nki.isa as nisa
 import nki.language as nl
 
@@ -36,10 +34,10 @@ def layernorm_tkg(
     input: nl.ndarray,
     gamma: nl.ndarray,
     output: nl.ndarray,
-    beta: Optional[nl.ndarray] = None,
+    beta: nl.ndarray | None = None,
     eps: float = 1e-6,
     use_heap_memory: bool = False,
-    sbm: Optional[SbufManager] = None,
+    sbm: SbufManager | None = None,
 ):
     """
     LayerNorm implementation optimized for inference token generation (decoding) phase.
@@ -200,7 +198,7 @@ def layernorm_tkg(
 def layernorm_tkg_llama_impl(
     input: nl.ndarray,
     gamma: nl.ndarray,
-    beta: Optional[nl.ndarray],
+    beta: nl.ndarray | None,
     result: nl.ndarray,
     bs_lb: int,
     bs_count: int,
@@ -279,7 +277,6 @@ def layernorm_tkg_llama_impl(
         H = _H0 * H1
     else:
         B, S, H = input.shape
-        full_BxS = B * S
         kernel_assert(H % H0 == 0, f"inp tensor H dimension must be divisible by {H0}, got {H}")
         H1 = H // H0
 
@@ -296,7 +293,7 @@ def layernorm_tkg_llama_impl(
     )
 
     # Beta check
-    is_beta = beta != None
+    is_beta = beta is not None
 
     # Check if the kernel uses auto or manual allocation
     is_auto_alloc = sbm.is_auto_alloc()

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/norm_tkg_utils.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/norm_tkg_utils.py
@@ -14,8 +14,6 @@
 
 """Utility functions for normalization kernels in token generation mode."""
 
-from typing import Optional, Tuple
-
 import nki.isa as nisa
 import nki.language as nl
 
@@ -42,7 +40,7 @@ def validate_shapes(
     input_view: TensorView,
     gamma_view: TensorView,
     output_view: TensorView,
-) -> Tuple[int, int, int, int]:
+) -> tuple[int, int, int, int]:
     """
     Validate tensor shapes for normalization operations.
 
@@ -215,7 +213,7 @@ def load_input_to_sbuf(
     input_sb: TensorView,
     num_H_shards: int,
     hidden_dim_tp: bool = False,
-    sbm: Optional[SbufManager] = None,
+    sbm: SbufManager | None = None,
 ) -> TensorView:
     """
     Load input data from HBM to SBUF with appropriate layout transformation.
@@ -257,7 +255,7 @@ def load_input_to_sbuf(
     else:
         # (BxS, H) -> (BxS, num_H_shards, H0, H2) -> (H0, BxS, num_H_shards, H2)
         if use_contiguous_load:
-            kernel_assert(sbm != None, "sbm required for contiguous load path")
+            kernel_assert(sbm is not None, "sbm required for contiguous load path")
             contiguous_load_transpose(input_hbm, input_sb, num_H_shards, sbm)
         else:
             input_hbm_view = input_hbm.reshape_dim(dim=1, shape=[num_H_shards, H0, H2]).permute(
@@ -407,10 +405,10 @@ def validate_shapes_quantize_mx(
         kernel_assert(
             output_residual_shape == (BxS, H), f"expected output_residual shape (B*S, H)={(BxS, H)}"
         )
-        kernel_assert(H1 % 8 == 0, f"Expected H1 divisible by 8 with fused residual add")
+        kernel_assert(H1 % 8 == 0, "Expected H1 divisible by 8 with fused residual add")
         # Residual transpose requires shard_size >= 128 (with LNC=2, BxS >= 256)
         kernel_assert(BxS >= 256, f"Residual add requires BxS >= 256 (got {BxS})")
     else:
-        kernel_assert(H1 % 4 == 0, f"Expected H1 divisible by 4")
+        kernel_assert(H1 % 4 == 0, "Expected H1 divisible by 4")
 
     return B, S, H, H0, H1, BxS, n_H512_tiles

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/rmsnorm_mx_quantize_tkg.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/rmsnorm_mx_quantize_tkg.py
@@ -14,8 +14,6 @@
 
 """Fused optional residual add + RMSNorm + MX quantization kernel optimized for token generation (decoding) phase."""
 
-from typing import Optional
-
 import nki.isa as nisa
 import nki.language as nl
 
@@ -32,10 +30,10 @@ def rmsnorm_mx_quantize_tkg(
     output: nl.ndarray,
     output_quant: nl.ndarray,
     output_scale: nl.ndarray,
-    residual: Optional[nl.ndarray] = None,
-    output_residual: Optional[nl.ndarray] = None,
+    residual: nl.ndarray | None = None,
+    output_residual: nl.ndarray | None = None,
     eps: float = 1e-6,
-    hidden_actual: Optional[int] = None,
+    hidden_actual: int | None = None,
     hidden_dim_tp: bool = True,
 ):
     """
@@ -82,7 +80,7 @@ def rmsnorm_mx_quantize_tkg(
     # Configuration
     pmax = H0 = nl.tile_size.pmax
     psum_fmax = nl.tile_size.gemm_moving_fmax
-    is_residual_add = residual != None
+    is_residual_add = residual is not None
     inter_dtype = nl.float32
 
     # Step 1: Validate shapes
@@ -96,17 +94,17 @@ def rmsnorm_mx_quantize_tkg(
         hidden_dim_tp=hidden_dim_tp,
         is_residual_add=is_residual_add,
         residual_shape=residual.shape if is_residual_add else None,
-        output_residual_shape=output_residual.shape if output_residual != None else None,
+        output_residual_shape=output_residual.shape if output_residual is not None else None,
     )
 
-    if hidden_actual == None:
+    if hidden_actual is None:
         hidden_actual = H
 
     # Step 2: LNC sharding setup
     _, num_shards, shard_id = get_verified_program_sharding_info("rmsnorm_mx_quantize_tkg", (0, 1))
     kernel_assert(num_shards == 2, "rmsnorm_mx_quantize_tkg kernel only supports LNC=2")
     kernel_assert(
-        BxS % 4 == 0, f"BxS must be divisible by 4"
+        BxS % 4 == 0, "BxS must be divisible by 4"
     )  # Required for LNC2 sharding alignment
 
     shard_size = BxS // num_shards

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/rmsnorm_tkg.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/rmsnorm_tkg.py
@@ -14,8 +14,6 @@
 
 """RMSNorm kernel optimized for token generation (decoding) phase with efficient sharding and memory management."""
 
-from typing import Optional, Tuple, Union
-
 import nki.isa as nisa
 import nki.language as nl
 
@@ -38,15 +36,15 @@ BxS_FULL_TILE_SIZE = 512
 
 
 def rmsnorm_tkg(
-    input: Union[TensorView, nl.ndarray],
-    gamma: Union[TensorView, nl.ndarray],
-    output: Union[TensorView, nl.ndarray],
+    input: TensorView | nl.ndarray,
+    gamma: TensorView | nl.ndarray,
+    output: TensorView | nl.ndarray,
     eps: float = 1e-6,
-    hidden_actual: Optional[int] = None,
+    hidden_actual: int | None = None,
     hidden_dim_tp: bool = False,
     single_core_forced: bool = False,
     use_heap_memory: bool = False,
-    sbm: Optional[SbufManager] = None,
+    sbm: SbufManager | None = None,
 ):
     """
     RMSNorm implementation optimized for inference token generation (decoding) phase.
@@ -201,7 +199,7 @@ def process_rmsnorm_tile(
     output_sb_view: TensorView,
     eps_view: TensorView,
     matmul_reduction_const_view: TensorView,
-    bxs_tile: Tuple,
+    bxs_tile: tuple,
     hidden_actual: int,
     use_heap_memory: bool = False,
     sbm: SbufManager = None,
@@ -318,7 +316,7 @@ def rmsnorm_tkg_llama_impl(
     gamma: TensorView,
     output: TensorView,
     num_H_shards: int,
-    hidden_actual: Optional[int],
+    hidden_actual: int | None,
     eps: float,
     hidden_dim_tp: bool = False,
     use_heap_memory: bool = False,

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/rmsnorm_torch.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/subkernels/rmsnorm_torch.py
@@ -14,16 +14,14 @@
 
 """PyTorch reference implementations for the rmsnorm_tkg kernel."""
 
-from typing import Optional
-
 import torch
 
 
 def rms_norm_torch_ref(
     hidden: torch.Tensor,
-    gamma: Optional[torch.Tensor],
+    gamma: torch.Tensor | None,
     eps: float = 1e-6,
-    hidden_actual: Optional[int] = None,
+    hidden_actual: int | None = None,
     **_,
 ) -> torch.Tensor:
     """
@@ -58,11 +56,11 @@ def rmsnorm_tkg_torch_ref_lnc1(
     gamma: torch.Tensor,
     output: torch.Tensor,
     eps: float = 1e-6,
-    hidden_actual: Optional[int] = None,
+    hidden_actual: int | None = None,
     hidden_dim_tp: bool = False,
     single_core_forced: bool = False,
     use_heap_memory: bool = False,
-    sbm: Optional[object] = None,
+    sbm: object | None = None,
 ) -> dict[str, torch.Tensor]:
     """Torch reference for rmsnorm_tkg kernel (LNC1 output layout).
 
@@ -108,11 +106,11 @@ def rmsnorm_tkg_torch_ref(
     gamma: torch.Tensor,
     output: torch.Tensor,
     eps: float = 1e-6,
-    hidden_actual: Optional[int] = None,
+    hidden_actual: int | None = None,
     hidden_dim_tp: bool = False,
     single_core_forced: bool = False,
     use_heap_memory: bool = False,
-    sbm: Optional[object] = None,
+    sbm: object | None = None,
 ) -> dict[str, torch.Tensor]:
     """Torch reference for rmsnorm_tkg kernel (LNC2 output layout).
 

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/allocator.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/allocator.py
@@ -20,7 +20,6 @@ The class is implemented to run in a NKI enviornment.
 """
 
 from dataclasses import dataclass
-from typing import Optional
 
 import nki.language as nl
 
@@ -81,7 +80,7 @@ class SbufManager(nl.NKIObject):
         self,
         sb_lower_bound: int,
         sb_upper_bound: int,
-        logger: Optional[Logger] = None,
+        logger: Logger | None = None,
         use_auto_alloc: bool = False,
         default_stack_alloc: bool = True,
     ):
@@ -104,7 +103,7 @@ class SbufManager(nl.NKIObject):
         self.use_auto_alloc = use_auto_alloc
         self.default_stack_alloc = default_stack_alloc
         self.logger = logger
-        if self.logger == None:
+        if self.logger is None:
             self.logger = get_logger("SBM")
         self.scopes = []
         self.heap = []
@@ -307,7 +306,7 @@ class SbufManager(nl.NKIObject):
             self.logger.debug(f"Stack state: no open scopes, stack_addr={self.stack_curr_addr}")
             kernel_assert(False, "Cannot allocate in stack without an open scope")
 
-        if align == None:
+        if align is None:
             align = sizeinbytes(dtype)
         self.stack_curr_addr = align_to(self.stack_curr_addr, align)
         tensor_name = self._get_prefixed_name(name)
@@ -372,7 +371,7 @@ class SbufManager(nl.NKIObject):
             self._print_stats()
             kernel_assert(False, "Heap out of memory")
 
-        if align != None:
+        if align is not None:
             self.heap_curr_addr = align_to(self.heap_curr_addr, align)
         base_addr = self.heap_curr_addr - bytes_per_partition
         self.heap_curr_addr -= bytes_per_partition
@@ -477,6 +476,6 @@ class SbufManager(nl.NKIObject):
         self.tree_logger.flush()
 
 
-def create_auto_alloc_manager(logger: Optional[Logger] = None):
+def create_auto_alloc_manager(logger: Logger | None = None):
     """create a default auto allocated SBM initialized with total SBUF space"""
     return SbufManager(0, nl.tile_size.total_available_sbuf_size, logger, use_auto_alloc=True)

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/interleave_copy.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/interleave_copy.py
@@ -60,12 +60,12 @@ def interleave_copy(
     if scale is not None:
         kernel_assert(
             dst.shape[0] == src.shape[0] == scale.shape[0],
-            f"Partition dimension must match across dst, src, and scale.",
+            "Partition dimension must match across dst, src, and scale.",
         )
     if bias is not None:
         kernel_assert(
             dst.shape[0] == src.shape[0] == bias.shape[0],
-            f"Partition dimension must match across dst, src, and bias.",
+            "Partition dimension must match across dst, src, and bias.",
         )
 
     # Pure copy operation

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/kernel_helpers.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/kernel_helpers.py
@@ -22,8 +22,6 @@ These utilities are designed to be reusable across different kernel types
 and provide consistent behavior for common operations.
 """
 
-from typing import List, Optional, Tuple
-
 import nki.isa as nisa
 import nki.language as nl
 
@@ -275,7 +273,7 @@ def normalization_uses_weights(norm_type: NormType) -> bool:
     return norm_type == NormType.RMS_NORM or norm_type == NormType.LAYER_NORM
 
 
-def get_program_sharding_info() -> Tuple[int, int, int]:
+def get_program_sharding_info() -> tuple[int, int, int]:
     """
     Get program sharding information for current execution.
 
@@ -311,9 +309,9 @@ def get_program_sharding_info() -> Tuple[int, int, int]:
 
 def get_verified_program_sharding_info(
     kernel_name: str = "",
-    allowed_ndims: Optional[Tuple[int, ...]] = None,
-    max_sharding: Optional[int] = None,
-) -> Tuple[int, int, int]:
+    allowed_ndims: tuple[int, ...] | None = None,
+    max_sharding: int | None = None,
+) -> tuple[int, int, int]:
     """
     Get and optionally verify program sharding information.
 
@@ -336,11 +334,7 @@ def get_verified_program_sharding_info(
         # Optional validation checks
         return (grid_ndim, n_prgs, prg_id)
     """
-    grid_ndim, n_prgs, prg_id = get_program_sharding_info()
-    ndim_check = allowed_ndims is None or (
-        grid_ndim == allowed_ndims[0] if len(allowed_ndims) == 1 else False
-    )
-    return grid_ndim, n_prgs, prg_id
+    return get_program_sharding_info()
 
 
 def div_ceil(n, d):
@@ -396,7 +390,7 @@ def get_max_positive_value_for_dtype(dtype) -> float:
     return result
 
 
-def reduce(op="mul", input: List = None, initial_value=None):
+def reduce(op="mul", input: list = None, initial_value=None):
     """
     Perform reduction operation on a list of values.
 
@@ -432,8 +426,8 @@ def reduce(op="mul", input: List = None, initial_value=None):
                 result = max(result, value)
         return result
     """
-    kernel_assert(initial_value is not None, f"initial_value need to set")
-    kernel_assert(input is not None, f"input need to be set")
+    kernel_assert(initial_value is not None, "initial_value need to set")
+    kernel_assert(input is not None, "input need to be set")
     kernel_assert(op in ["mul", "add", "max", "min"], f"only op {op} is supported")
     for value in input:
         if op == "mul":

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/lnc_subscriptable.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/lnc_subscriptable.py
@@ -15,7 +15,8 @@
 import ast
 import inspect
 import textwrap
-from typing import Callable, Generic, TypeAlias, TypeVar
+from collections.abc import Callable
+from typing import Generic, TypeAlias, TypeVar
 
 from .kernel_assert import kernel_assert
 
@@ -71,7 +72,7 @@ def _verify_protocol_sync(func: Callable, protocol: TorchRefProtocolType):
         f"Parameter count mismatch: function has {len(func_params)}, Protocol has {len(protocol_params)}",
     )
 
-    for (fn, fp), (pn, pp) in zip(func_params, protocol_params):
+    for (fn, fp), (pn, pp) in zip(func_params, protocol_params, strict=True):
         kernel_assert(
             fn == pn, f"Parameter name mismatch: function has '{fn}', Protocol has '{pn}'"
         )

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/logging.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/logging.py
@@ -58,7 +58,6 @@ Usage Examples:
 import os
 import sys
 from enum import Enum
-from typing import Optional
 
 import nki.language as nl
 
@@ -125,7 +124,7 @@ _ENV_VAR_NAME = "NKILIB_LOG_LEVEL"
 _ENV_VAR_PREFIX = _ENV_VAR_NAME + "_"
 
 
-def _init_from_env_py() -> tuple[Optional[LogLevel], dict[str, LogLevel]]:
+def _init_from_env_py() -> tuple[LogLevel | None, dict[str, LogLevel]]:
     """Initialize global and specific logger levels from environment variables.
     Checking environment variables here works because this is not part of kernel code.
     """
@@ -177,10 +176,10 @@ def get_logger(name: str, level: LogLevel = _DEFAULT_LOG_LEVEL) -> Logger:
     """
 
     env_log_level = _ENV_LOG_LEVELS.get(name)
-    if env_log_level != None:
+    if env_log_level is not None:
         return Logger(name, env_log_level)
 
-    if _ENV_GLOBAL_LOG_LEVEL != None:
+    if _ENV_GLOBAL_LOG_LEVEL is not None:
         return Logger(name, _ENV_GLOBAL_LOG_LEVEL)
 
     return Logger(name, level)

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/modular_allocator.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/modular_allocator.py
@@ -23,8 +23,6 @@ See `ModularAllocator.alloc_sbuf_tensor` for examples.
 
 """
 
-from typing import List, Tuple, Union
-
 import nki.language as nl
 
 from .allocator import align_to as align_to_fn
@@ -87,13 +85,13 @@ class ModularAllocator(nl.NKIObject):
 
     def alloc_sbuf_tensor(
         self,
-        shape: Tuple[int, ...],
+        shape: tuple[int, ...],
         dtype,
-        block_dim: List[int] = None,
-        num_free_tiles: List[int] = None,
+        block_dim: list[int] = None,
+        num_free_tiles: list[int] = None,
         base_partition: int = 0,
         align_to: int = None,
-    ) -> Union[List, object]:
+    ) -> list | object:
         """
         Allocate SBUF tensors with modular address pattern for circular buffering.
 
@@ -158,15 +156,15 @@ class ModularAllocator(nl.NKIObject):
           # k_loaded[0][j] and k_loaded[2][j] share the same address
         """
         # Apply alignment if requested
-        if align_to != None:
+        if align_to is not None:
             self._current_address = align_to_fn(self._current_address, align_to)
 
         # Handle default block_dim
-        if block_dim == None:
+        if block_dim is None:
             block_dim = []
 
         # Handle default num_free_tiles
-        if num_free_tiles == None:
+        if num_free_tiles is None:
             num_free_tiles = block_dim.copy() if block_dim else []
 
         kernel_assert(
@@ -217,11 +215,11 @@ class ModularAllocator(nl.NKIObject):
 
 
 def _allocate_recursive(
-    indices: List[int],
+    indices: list[int],
     depth: int,
-    block_dim: List[int],
-    num_free_tiles: List[int],
-    shape: Tuple[int, ...],
+    block_dim: list[int],
+    num_free_tiles: list[int],
+    shape: tuple[int, ...],
     dtype,
     base_partition: int,
     sca: int,

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tensor_view.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tensor_view.py
@@ -20,8 +20,6 @@ similar to PyTorch tensor views. It allows for efficient tensor manipulation wit
 data copying by using NKI's array pattern (ap) functionality.
 """
 
-from typing import Dict, List, Optional, Tuple, Union
-
 import nki.language as nl
 
 from .allocator import num_elts, sizeinbytes
@@ -49,12 +47,12 @@ class TensorView(nl.NKIObject):
     """
 
     base_tensor: nl.ndarray
-    shape: Tuple[int, ...]
-    strides: Tuple[int, ...]
+    shape: tuple[int, ...]
+    strides: tuple[int, ...]
     offset: int
     dtype: object
     scalar_offset: nl.ndarray = None
-    indirect_dim: Optional[int] = None
+    indirect_dim: int | None = None
 
     def get_dim(self) -> int:
         return len(self.shape)
@@ -66,7 +64,7 @@ class TensorView(nl.NKIObject):
         return is_hbm_buffer(self.base_tensor)
 
     @staticmethod
-    def get_trivial_strides(shape: Tuple[int, ...], base_stride: int = 1) -> Tuple[int, ...]:
+    def get_trivial_strides(shape: tuple[int, ...], base_stride: int = 1) -> tuple[int, ...]:
         """Compute row-major (C-style) strides for given tensor shape.
         Args:
             shape: Tuple of dimension sizes
@@ -201,12 +199,12 @@ class TensorView(nl.NKIObject):
 
     def _copy(
         self,
-        shape: Tuple[int, ...] = None,
-        strides: Tuple[int, ...] = None,
+        shape: tuple[int, ...] = None,
+        strides: tuple[int, ...] = None,
         offset: int = None,
         scalar_offset: nl.ndarray = None,
         vector_offset: nl.ndarray = None,
-        indirect_dim: Optional[int] = None,
+        indirect_dim: int | None = None,
         dtype: object = None,
         base_tensor: nl.ndarray = None,
     ) -> "TensorView":
@@ -272,7 +270,7 @@ class TensorView(nl.NKIObject):
         # Build array pattern as list of (stride, size) tuples
         ap_pattern, offset = self._get_pattern_and_offset()
 
-        if self.indirect_dim != None:
+        if self.indirect_dim is not None:
             if self.vector_offset is not None:
                 result = self.base_tensor.ap(
                     pattern=ap_pattern,
@@ -336,7 +334,7 @@ class TensorView(nl.NKIObject):
         return self._copy(shape=new_shape, strides=new_strides, offset=new_offset)
 
     @staticmethod
-    def validate_permutation(permutation: Tuple[int, ...], dim: int, is_sbuf: bool) -> None:
+    def validate_permutation(permutation: tuple[int, ...], dim: int, is_sbuf: bool) -> None:
         kernel_assert(
             len(permutation) == dim,
             f"Permutation length {len(permutation)} != dimension count {dim}",
@@ -357,7 +355,7 @@ class TensorView(nl.NKIObject):
         if is_sbuf:
             kernel_assert(permutation[0] == 0, "Partition dimension stay the outermost dimension")
 
-    def permute(self, dims: Tuple[int, ...]) -> "TensorView":
+    def permute(self, dims: tuple[int, ...]) -> "TensorView":
         """Create a permuted view by reordering dimensions.
         Args:
             dims: New order of dimensions (tuple of dimension indices)
@@ -420,7 +418,7 @@ class TensorView(nl.NKIObject):
 
         return self._copy(shape=new_shape, strides=new_strides)
 
-    def _reshape_dim_handle_minus_one(self, dim: int, shape: Tuple[int]) -> Tuple[int]:
+    def _reshape_dim_handle_minus_one(self, dim: int, shape: tuple[int]) -> tuple[int]:
         """Handle -1 in reshape shape by computing the inferred dimension size.
         Args:
             dim: Dimension being reshaped
@@ -451,7 +449,7 @@ class TensorView(nl.NKIObject):
                 new_shape.append(self.shape[dim] // prod_shape)
         return tuple(new_shape)
 
-    def reshape_dim(self, dim: int, shape: Tuple[int, ...]) -> "TensorView":
+    def reshape_dim(self, dim: int, shape: tuple[int, ...]) -> "TensorView":
         """Reshape a single dimension into multiple dimensions.
         Args:
             dim: Dimension to reshape
@@ -705,7 +703,7 @@ class TensorView(nl.NKIObject):
 
         kernel_assert(False, f"Cannot create base dim with stride {view_stride}")
 
-    def select(self, dim: int, index: Union[int, nl.ndarray]) -> "TensorView":
+    def select(self, dim: int, index: int | nl.ndarray) -> "TensorView":
         """Select a single element along a dimension, reducing dimensionality.
         Args:
             dim: Dimension to select from
@@ -732,8 +730,8 @@ class TensorView(nl.NKIObject):
 
     @staticmethod
     def _rearrange_detect_src_reshapes(
-        src_pattern: Tuple[Union[str, Tuple[str]]], fixed_sizes: Dict[str, int]
-    ) -> List[Dict]:
+        src_pattern: tuple[str | tuple[str]], fixed_sizes: dict[str, int]
+    ) -> list[dict]:
         """Detect reshape operations needed in source pattern based on grouped dimensions.
 
         Args:
@@ -758,7 +756,7 @@ class TensorView(nl.NKIObject):
         return src_reshapes
 
     @staticmethod
-    def _rearrange_detect_dst_flattens(dst_pattern: Tuple[Union[str, Tuple[str]]]) -> List[Dict]:
+    def _rearrange_detect_dst_flattens(dst_pattern: tuple[str | tuple[str]]) -> list[dict]:
         """Detect flatten operations needed in destination pattern based on grouped dimensions.
 
         Args:
@@ -781,7 +779,7 @@ class TensorView(nl.NKIObject):
         return dst_flattens
 
     @staticmethod
-    def _rearrange_expand_pattern(pattern: Tuple[Union[str, Tuple[str]]]) -> Tuple[str]:
+    def _rearrange_expand_pattern(pattern: tuple[str | tuple[str]]) -> tuple[str]:
         """Expand grouped dimension patterns into flat list of dimension names.
 
         Args:
@@ -801,8 +799,8 @@ class TensorView(nl.NKIObject):
 
     @staticmethod
     def _rearrange_get_permutation(
-        src_pattern: Tuple[str], dst_pattern: Tuple[str]
-    ) -> Tuple[int, ...]:
+        src_pattern: tuple[str], dst_pattern: tuple[str]
+    ) -> tuple[int, ...]:
         """Calculate permutation indices to reorder dimensions from source to destination pattern.
 
         Args:
@@ -822,9 +820,9 @@ class TensorView(nl.NKIObject):
 
     def rearrange(
         self,
-        src_pattern: Tuple[Union[str, Tuple[str]]],
-        dst_pattern: Tuple[Union[str, Tuple[str]]],
-        fixed_sizes: Dict[str, int] = None,
+        src_pattern: tuple[str | tuple[str]],
+        dst_pattern: tuple[str | tuple[str]],
+        fixed_sizes: dict[str, int] = None,
     ) -> "TensorView":
         """Rearrange tensor dimensions using einops-style patterns.
 
@@ -965,7 +963,7 @@ class TensorView(nl.NKIObject):
 
         return tuple(new_strides)
 
-    def reshape(self, new_shape: Tuple[int, ...]) -> "TensorView":
+    def reshape(self, new_shape: tuple[int, ...]) -> "TensorView":
         """Reshape the tensor to new dimensions without copying data.
 
         Returns a new TensorView with the given shape over the same underlying
@@ -1004,4 +1002,4 @@ class TensorView(nl.NKIObject):
         Returns:
             True if the tensor has dynamic access, False otherwise
         """
-        return self.scalar_offset != None and self.indirect_dim != None
+        return self.scalar_offset is not None and self.indirect_dim is not None

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tile_info.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tile_info.py
@@ -14,7 +14,6 @@
 
 
 from dataclasses import dataclass
-from typing import Optional
 
 import nki.language as nl
 from nki.language import NKIObject
@@ -49,7 +48,7 @@ class TiledDimInfo(NKIObject):
     # The number of tiles needed to cover the dimension being tiled
     tile_count: int
     # Subtile information (if there is any)
-    subtile_dim_info: "Optional[TiledDimInfo]" = None
+    subtile_dim_info: "TiledDimInfo | None" = None
 
     # Factory methods
     # ONLY CONSTRUCT THIS USING THE FACTORY METHODS BELOW
@@ -63,7 +62,7 @@ class TiledDimInfo(NKIObject):
         return TiledDimInfo.build(tiled_dim_size, tile_size, subtiled_dim_info)
 
     def is_subtiled(self) -> bool:
-        return self.subtile_dim_info != None
+        return self.subtile_dim_info is not None
 
     # Calculate indices for the tile given a tile number and offset
     # TODO: Now this only works if last item from mgrid.

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tiled_range.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tiled_range.py
@@ -21,7 +21,6 @@ TiledRangeIterator represents a single tile with size, index, and start_offset p
 """
 
 import math
-from typing import Tuple, Union
 
 from nki.language import NKIObject
 
@@ -55,9 +54,7 @@ class TiledRangeIterator(NKIObject):
         return f"TiledRangeIterator(size={self.size}, index={self.index}, start_offset={self.start_offset}, end_offset={self.end_offset})"
 
 
-def TiledRange(
-    size: Union[int, TiledRangeIterator], tile_size: int
-) -> Tuple[TiledRangeIterator, ...]:
+def TiledRange(size: int | TiledRangeIterator, tile_size: int) -> tuple[TiledRangeIterator, ...]:
     """
     Divides a dimension into tiles and returns a tuple of TiledRangeIterators.
 

--- a/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tree_logger.py
+++ b/resources/skills/neuron-agentic-development/skills/neuron-nki-writing/references/nkilib/core/utils/tree_logger.py
@@ -80,7 +80,7 @@ class TreeLogger(nl.NKIObject):
     def _print_tree(self, logs):
         # First pass: mark which entries are last at their depth
         is_last = []
-        for i in range(len(logs)):
+        for _i in range(len(logs)):
             is_last.append(True)
 
         for i in range(len(logs)):
@@ -98,7 +98,7 @@ class TreeLogger(nl.NKIObject):
             entry = logs[i]
             prefix = ""
             if entry.depth > 0:
-                for d in range(entry.depth - 1):
+                for _d in range(entry.depth - 1):
                     prefix = prefix + "│   "
                 if is_last[i]:
                     prefix = prefix + "└── "

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv run ruff check .

--- a/src/vibe_serve/agent_runner.py
+++ b/src/vibe_serve/agent_runner.py
@@ -542,7 +542,7 @@ def run_profiler_agent(
     if structured_response is None:
         structured_response = _parse_profiler_response_text(last_ai_message)
     if structured_response is None:
-        _log_and_print(f"\n=== PROFILER ROUND OUTPUT (missing response) ===", log_file)
+        _log_and_print("\n=== PROFILER ROUND OUTPUT (missing response) ===", log_file)
         _log_and_print("No structured response received from profiler.", log_file)
         if last_ai_message:
             _log_and_print("\n=== PROFILER ROUND OUTPUT (raw ai message) ===", log_file)

--- a/src/vibe_serve/agents/base.py
+++ b/src/vibe_serve/agents/base.py
@@ -18,8 +18,9 @@ struct or would lie about reuse semantics on one of the backends.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Protocol, TypeVar
+from typing import Protocol, TypeVar
 
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel

--- a/src/vibe_serve/agents/callbacks.py
+++ b/src/vibe_serve/agents/callbacks.py
@@ -2,7 +2,8 @@ import json
 import sys
 import time
 import traceback
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from langchain_core.callbacks import BaseCallbackHandler
 

--- a/src/vibe_serve/agents/cli_runner.py
+++ b/src/vibe_serve/agents/cli_runner.py
@@ -21,9 +21,10 @@ from __future__ import annotations
 
 import json
 import shutil
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
 
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel

--- a/src/vibe_serve/agents/deepagents_runner.py
+++ b/src/vibe_serve/agents/deepagents_runner.py
@@ -8,8 +8,9 @@ change vs. what the simple loop did before this abstraction landed.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
 
 from deepagents import create_deep_agent
 from langchain.agents.structured_output import AutoStrategy

--- a/src/vibe_serve/backends/__init__.py
+++ b/src/vibe_serve/backends/__init__.py
@@ -13,8 +13,8 @@ Add a new backend by:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from vibe_serve.backends.base import (
     ComputeBackendImpl,

--- a/src/vibe_serve/backends/base.py
+++ b/src/vibe_serve/backends/base.py
@@ -15,9 +15,10 @@ compute backend supplies the right values for its platform inside
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from enum import StrEnum
 from pathlib import Path
-from typing import Callable, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from deepagents.backends.sandbox import BaseSandbox
 
@@ -73,7 +74,7 @@ class ComputeBackendImpl(Protocol):
         extra_env: dict[str, str],
         extra_init_commands: list[str],
         setup_fns: list[SetupFn] | None = None,
-        modal_options: "ModalOptions | None" = None,
+        modal_options: ModalOptions | None = None,
     ) -> BaseSandbox:
         """Construct (do not start) a sandbox configured for this backend.
 

--- a/src/vibe_serve/backends/cuda/__init__.py
+++ b/src/vibe_serve/backends/cuda/__init__.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Callable
 
 from deepagents.backends import LocalShellBackend
 from deepagents.backends.sandbox import BaseSandbox

--- a/src/vibe_serve/backends/cuda/gpu_monitor.py
+++ b/src/vibe_serve/backends/cuda/gpu_monitor.py
@@ -18,7 +18,7 @@ import json
 import subprocess
 import threading
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -253,7 +253,7 @@ class GpuContentionMonitor:
                     is_contended=len(new_procs) > 0,
                     new_procs=new_procs,
                     gpu=gpu_info,
-                    timestamp=datetime.now(timezone.utc).isoformat(),
+                    timestamp=datetime.now(UTC).isoformat(),
                 )
                 with self._lock:
                     self._status = contention

--- a/src/vibe_serve/backends/metal/__init__.py
+++ b/src/vibe_serve/backends/metal/__init__.py
@@ -12,8 +12,8 @@ returns ``None``, and ``reselect_device`` is a no-op.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from deepagents.backends import LocalShellBackend
 from deepagents.backends.sandbox import BaseSandbox

--- a/src/vibe_serve/backends/trainium/__init__.py
+++ b/src/vibe_serve/backends/trainium/__init__.py
@@ -23,8 +23,8 @@ is a no-op (parity with :class:`MetalBackend`).
 from __future__ import annotations
 
 import glob
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from deepagents.backends import LocalShellBackend
 from deepagents.backends.sandbox import BaseSandbox

--- a/src/vibe_serve/config.py
+++ b/src/vibe_serve/config.py
@@ -14,8 +14,9 @@ allowlist loader suffered from.
 
 import os
 import tomllib
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Literal, Mapping
+from typing import Literal
 
 from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict, Field

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -9,11 +9,8 @@ collect kernel-level data first.
 from __future__ import annotations
 
 import json
-import os
-import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 from vibe_serve.config import Config
 from vibe_serve.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
@@ -26,6 +23,10 @@ from vibe_serve.loops.agent.domain import (
 )
 from vibe_serve.loops.profiler import invoke_profiler
 from vibe_serve.prompts import render_template
+from vibe_serve.sandbox.run_environment import (
+    RunEnvironmentSpec,
+    make_run_environment_spec,
+)
 from vibe_serve.schemas import (
     ImplementerResponse,
     JudgeResponse,
@@ -37,10 +38,6 @@ from vibe_serve.schemas import (
 )
 
 _INNER_LOOPS = ("multi-agent", "single-agent")
-from vibe_serve.sandbox.run_environment import (
-    RunEnvironmentSpec,
-    make_run_environment_spec,
-)
 
 _TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
 
@@ -75,7 +72,7 @@ class _RoundRecord:
         }
 
     @classmethod
-    def from_json(cls, data: dict) -> "_RoundRecord":
+    def from_json(cls, data: dict) -> _RoundRecord:
         return cls(
             round_number=int(data["round"]),
             commit=data.get("commit"),

--- a/src/vibe_serve/loops/evolve/population.py
+++ b/src/vibe_serve/loops/evolve/population.py
@@ -65,7 +65,7 @@ class Objective:
         return value if self.direction == "max" else -value
 
 
-def _dominates(a: "Individual", b: "Individual", objectives: list[Objective]) -> bool:
+def _dominates(a: Individual, b: Individual, objectives: list[Objective]) -> bool:
     """True if ``a`` Pareto-dominates ``b`` under *objectives*.
 
     Convention: a dominates b iff for every objective, a is at-least-as
@@ -136,7 +136,7 @@ class Individual:
         return asdict(self)
 
     @classmethod
-    def from_json(cls, data: dict) -> "Individual":
+    def from_json(cls, data: dict) -> Individual:
         return cls(
             id=int(data["id"]),
             generation=int(data["generation"]),
@@ -285,7 +285,7 @@ class Population:
         total = sum(exps)
         r = rng.random() * total
         acc = 0.0
-        for ind, w in zip(ranked, exps):
+        for ind, w in zip(ranked, exps, strict=True):
             acc += w
             if r <= acc:
                 return ind
@@ -351,7 +351,7 @@ class Population:
         path.write_text(json.dumps([i.to_json() for i in self._individuals], indent=2))
 
     @classmethod
-    def load(cls, path: Path) -> "Population":
+    def load(cls, path: Path) -> Population:
         if not path.exists():
             return cls()
         data = json.loads(path.read_text())

--- a/src/vibe_serve/loops/openevolve/loop.py
+++ b/src/vibe_serve/loops/openevolve/loop.py
@@ -13,7 +13,6 @@ State persistence reuses ``population.json`` (extended in
 from __future__ import annotations
 
 import random
-from pathlib import Path
 
 from vibe_serve.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibe_serve.context import _RunContext

--- a/src/vibe_serve/loops/plain/issue_board.py
+++ b/src/vibe_serve/loops/plain/issue_board.py
@@ -16,27 +16,26 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import sys
 import traceback
+from collections.abc import Callable
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from threading import RLock
-from typing import Callable
 
 from pydantic import BaseModel, Field
 
 _STORE_VERSION = 1
 
 
-class IssueType(str, Enum):
+class IssueType(StrEnum):
     BUG = "bug"
     FEATURE = "feature"
     PERF = "perf"
 
 
-class IssueStatus(str, Enum):
+class IssueStatus(StrEnum):
     OPEN = "open"
     IN_PROGRESS = "in_progress"
     CLOSED = "closed"

--- a/src/vibe_serve/loops/plain/loop.py
+++ b/src/vibe_serve/loops/plain/loop.py
@@ -551,11 +551,13 @@ def run_plain_loop(
                         system_prompt=impl_system_prompt,
                         user_prompt=impl_prompt,
                         response_cls=IssueImplementerResponse,
-                        fallback_factory=lambda: IssueImplementerResponse(
-                            issue_id=issue_id_for_fallback,
-                            summary="Implementer did not produce a structured response.",
-                            files_touched=[],
-                            self_check="No structured response received.",
+                        fallback_factory=lambda issue_id=issue_id_for_fallback: (
+                            IssueImplementerResponse(
+                                issue_id=issue_id,
+                                summary="Implementer did not produce a structured response.",
+                                files_touched=[],
+                                self_check="No structured response received.",
+                            )
                         ),
                         round_label=f"impl issue #{issue.id} att{issue.attempts + 1}",
                     )
@@ -613,8 +615,8 @@ def run_plain_loop(
                     system_prompt=judge_system_prompt,
                     user_prompt=judge_prompt,
                     response_cls=IssueJudgeResponse,
-                    fallback_factory=lambda: IssueJudgeResponse(
-                        issue_id=judge_issue_id,
+                    fallback_factory=lambda issue_id=judge_issue_id: IssueJudgeResponse(
+                        issue_id=issue_id,
                         analysis="No structured response received from judge.",
                         feedback="Judge did not produce a structured response.",
                         verdict=Verdict.FAIL,

--- a/src/vibe_serve/sandbox/docker_sandbox.py
+++ b/src/vibe_serve/sandbox/docker_sandbox.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import atexit
-import datetime
 import json
 import logging
 import os
@@ -11,8 +10,8 @@ import signal
 import subprocess
 import tempfile
 import uuid
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from deepagents.backends.protocol import (
     EditResult,
@@ -29,7 +28,7 @@ _live_containers: dict[str, str] = {}  # container_id -> container_name
 
 def _cleanup_containers() -> None:
     """Stop and remove all tracked containers."""
-    for container_id, name in list(_live_containers.items()):
+    for container_id, _name in list(_live_containers.items()):
         try:
             subprocess.run(
                 ["docker", "stop", container_id],
@@ -103,7 +102,7 @@ class DockerSandbox(BaseSandbox):
         passthrough_paths: list[str] | None = None,
         log_path: str | Path | None = None,
         extra_init_commands: list[str] | None = None,
-        setup_fns: list[Callable[["DockerSandbox"], None]] | None = None,
+        setup_fns: list[Callable[[DockerSandbox], None]] | None = None,
     ) -> None:
         """Initialize Docker sandbox configuration.
 
@@ -158,7 +157,7 @@ class DockerSandbox(BaseSandbox):
         self._container_id: str | None = None
         self._logger = self._setup_logger(log_path)
         self._extra_init_commands: list[str] = list(extra_init_commands or [])
-        self._setup_fns: list[Callable[["DockerSandbox"], None]] = list(setup_fns or [])
+        self._setup_fns: list[Callable[[DockerSandbox], None]] = list(setup_fns or [])
 
         # Container paths outside /workspace that _vpath must not rewrite.
         self._passthrough_prefixes: list[str] = list(passthrough_paths or [])
@@ -443,9 +442,11 @@ class DockerSandbox(BaseSandbox):
                         f"  stdout: {init_result.stdout.strip()[:500]}\n"
                         f"  stderr: {init_result.stderr.strip()[:500]}"
                     )
-            except subprocess.TimeoutExpired:
+            except subprocess.TimeoutExpired as exc:
                 self._log_cmd(init_cmd, error=f"init command timed out after 600s: {init_cmd_str}")
-                raise RuntimeError(f"Container init command timed out after 600s: {init_cmd_str}")
+                raise RuntimeError(
+                    f"Container init command timed out after 600s: {init_cmd_str}"
+                ) from exc
 
         # Run caller-supplied setup functions.  These re-execute on every
         # restart (so e.g. docker symlinks survive ``reselect_device``).
@@ -582,7 +583,7 @@ class DockerSandbox(BaseSandbox):
                 # Ensure parent dir exists
                 parent = str(Path(container_path).parent)
                 mkdir_cmd = ["docker", "exec", self._container_id, "mkdir", "-p", parent]
-                mkdir_result = subprocess.run(
+                subprocess.run(
                     mkdir_cmd,
                     capture_output=True,
                     check=False,

--- a/src/vibe_serve/sandbox/modal_sandbox.py
+++ b/src/vibe_serve/sandbox/modal_sandbox.py
@@ -26,8 +26,9 @@ import socket
 import tempfile
 import time
 import uuid
+from collections.abc import Callable
 from pathlib import Path, PurePosixPath
-from typing import Callable, TypeVar
+from typing import TypeVar
 
 import modal
 from deepagents.backends.protocol import (
@@ -39,7 +40,7 @@ from deepagents.backends.protocol import (
 from deepagents.backends.sandbox import BaseSandbox
 
 # Global registry of live sandboxes for cleanup on exit / SIGINT.
-_live_sandboxes: dict[str, "ModalSandbox"] = {}
+_live_sandboxes: dict[str, ModalSandbox] = {}
 
 T = TypeVar("T")
 
@@ -187,7 +188,7 @@ class ModalSandbox(BaseSandbox):
         extra_writable_volumes: dict[str, str] | None = None,
         log_path: str | Path | None = None,
         extra_init_commands: list[str] | None = None,
-        setup_fns: list["Callable[[ModalSandbox], None]"] | None = None,
+        setup_fns: list[Callable[[ModalSandbox], None]] | None = None,
         app_name: str = "vibeserve",
         enable_fallback_restart: bool = True,
         max_restart_attempts: int = 2,
@@ -872,7 +873,7 @@ class ModalSandbox(BaseSandbox):
 
     # -- context manager ---------------------------------------------------
 
-    def __enter__(self) -> "ModalSandbox":
+    def __enter__(self) -> ModalSandbox:
         self.start()
         return self
 

--- a/src/vibe_serve/sandbox/run_environment.py
+++ b/src/vibe_serve/sandbox/run_environment.py
@@ -29,13 +29,14 @@ import json
 import os
 import shlex
 import subprocess
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Mapping, Protocol
+from typing import Protocol
 
 from deepagents.backends.sandbox import BaseSandbox
 
-from vibe_serve.backends import ModalOptions, SandboxKind
+from vibe_serve.backends import SandboxKind
 from vibe_serve.backends.base import ComputeBackendImpl, SetupFn
 from vibe_serve.constants import DEFAULT_AGENT_BACKEND, PROJECT_ROOT
 
@@ -103,7 +104,7 @@ class RunEnvironmentSession(Protocol):
     sandbox: BaseSandbox
     view: RunEnvironmentView
 
-    def __enter__(self) -> "RunEnvironmentSession": ...
+    def __enter__(self) -> RunEnvironmentSession: ...
     def __exit__(self, exc_type: object, exc: object, tb: object) -> None: ...
     def close(self) -> None: ...
 
@@ -142,7 +143,7 @@ class _DefaultRunEnvironmentSession:
     stop_on_close: bool = False
     _closed: bool = False
 
-    def __enter__(self) -> "_DefaultRunEnvironmentSession":
+    def __enter__(self) -> _DefaultRunEnvironmentSession:
         return self
 
     def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
@@ -202,7 +203,7 @@ class DockerEnvironment:
         self.backend_image = config.image
 
     @classmethod
-    def from_options(cls, options: Mapping[str, object]) -> "DockerEnvironment":
+    def from_options(cls, options: Mapping[str, object]) -> DockerEnvironment:
         image = options.get("image")
         return cls(DockerEnvironmentConfig(image=str(image) if image else None))
 
@@ -302,7 +303,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         self.backend_image = config.image
 
     @classmethod
-    def from_options(cls, options: Mapping[str, object]) -> "ModalEnvironment":
+    def from_options(cls, options: Mapping[str, object]) -> ModalEnvironment:
         return cls(
             ModalEnvironmentConfig(
                 image=str(options["image"]) if options.get("image") else None,

--- a/src/vibe_serve/schemas.py
+++ b/src/vibe_serve/schemas.py
@@ -21,7 +21,7 @@ This module has no local imports, so templates and tests can pull
 schemas in without dragging in the rest of the agent runtime.
 """
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
@@ -30,12 +30,12 @@ from pydantic import BaseModel, Field
 # ===========================================================================
 
 
-class Verdict(str, Enum):
+class Verdict(StrEnum):
     PASS = "pass"
     FAIL = "fail"
 
 
-class PerfTrend(str, Enum):
+class PerfTrend(StrEnum):
     IMPROVED = "improved"
     REGRESSED = "regressed"
     MIXED = "mixed"

--- a/tests/agents/test_callbacks.py
+++ b/tests/agents/test_callbacks.py
@@ -1,12 +1,9 @@
 import io
-import json
 import re
 from unittest.mock import MagicMock
 
-import pytest
-
 from vibe_serve.agents.callbacks import AgentLogger
-from vibe_serve.constants import _BOLD, _CYAN, _DIM, _GREEN, _RED, _RESET, _YELLOW
+from vibe_serve.constants import _DIM, _GREEN, _RED, _RESET
 
 _ANSI_RE = re.compile(r"\033\[[0-9;]*m")
 

--- a/tests/loops/agent/test_issue_board.py
+++ b/tests/loops/agent/test_issue_board.py
@@ -9,7 +9,6 @@ import pytest
 from vibe_serve.loops.plain.issue_board import (
     Issue,
     IssueBoard,
-    IssueEvent,
     IssueStatus,
     IssueType,
 )

--- a/tests/loops/agent/test_issue_render.py
+++ b/tests/loops/agent/test_issue_render.py
@@ -1,9 +1,5 @@
 """Tests for the per-issue markdown renderer (vibe_serve/plain/render.py)."""
 
-from datetime import datetime
-
-import pytest
-
 from vibe_serve.loops.plain.issue_board import (
     Issue,
     IssueBoard,
@@ -15,7 +11,6 @@ from vibe_serve.loops.plain.render import (
     issue_md_filename,
     issue_md_path,
     render_all,
-    render_index_file,
     render_index_markdown,
     render_issue_file,
     render_issue_markdown,
@@ -383,7 +378,7 @@ class TestRenderAll:
             created_by="loop:bootstrap",
             iteration=1,
         )
-        b = store.create(
+        store.create(
             type=IssueType.BUG,
             title="Crash on startup",
             description="d",

--- a/tests/loops/agent/test_issue_tools.py
+++ b/tests/loops/agent/test_issue_tools.py
@@ -1,7 +1,5 @@
 """Tests for the issue-tracker tools (list/get/search/create)."""
 
-import pytest
-
 from vibe_serve.loops.plain.issue_board import IssueBoard, IssueStatus, IssueType
 from vibe_serve.loops.plain.tools import build_issue_tools
 
@@ -47,7 +45,7 @@ class TestReadTools:
 
     def test_list_issues_filters_by_status(self, tmp_path):
         store = _make_store(tmp_path)
-        a = store.create(
+        store.create(
             type=IssueType.BUG, title="open one", description="d", created_by="x", iteration=1
         )
         b = store.create(

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -1,6 +1,5 @@
 """Tests for vibe_serve.loops.agent — orchestrator-driven build loop."""
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -9,8 +9,6 @@ are patched out — same pattern as ``tests/test_orchestrate.py``.
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -18,7 +16,6 @@ import pytest
 from vibe_serve.agents import AgentRunner
 from vibe_serve.loops.evolve.loop import run_evolve_loop
 from vibe_serve.loops.evolve.population import (
-    Individual,
     Objective,
     Population,
 )

--- a/tests/loops/evolve/test_evolutionary_population.py
+++ b/tests/loops/evolve/test_evolutionary_population.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 import random
 from collections import Counter
-from pathlib import Path
 
 import pytest
 

--- a/tests/loops/plain/test_plain_loop.py
+++ b/tests/loops/plain/test_plain_loop.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibe_serve.agents import AgentRunner
-from vibe_serve.loops.plain.issue_board import IssueBoard, IssueStatus, IssueType
+from vibe_serve.loops.plain.issue_board import IssueBoard, IssueStatus
 from vibe_serve.loops.plain.loop import PlainLoopState, run_plain_loop
 from vibe_serve.schemas import (
     IssueImplementerResponse,

--- a/tests/loops/plain/test_plain_loop_state.py
+++ b/tests/loops/plain/test_plain_loop_state.py
@@ -2,8 +2,6 @@
 
 import json
 
-import pytest
-
 from vibe_serve.loops.plain.issue_board import IssueBoard, IssueStatus, IssueType
 from vibe_serve.loops.plain.loop import (
     PlainLoopState,

--- a/tests/loops/test_profiler.py
+++ b/tests/loops/test_profiler.py
@@ -7,8 +7,7 @@ ProfilerResponse / parser / nsys-toolkit tests.
 
 import json
 import sqlite3
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -17,10 +16,7 @@ from vibe_serve.agent_runner import (
     run_profiler_agent,
 )
 from vibe_serve.schemas import (
-    ImplementerResponse,
-    JudgeResponse,
     ProfilerResponse,
-    Verdict,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/sandbox/test_docker_sandbox.py
+++ b/tests/sandbox/test_docker_sandbox.py
@@ -1,9 +1,8 @@
 """Tests for DockerSandbox — all mock subprocess.run, no Docker required."""
 
 import subprocess
-import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/sandbox/test_modal_model_setup.py
+++ b/tests/sandbox/test_modal_model_setup.py
@@ -1,6 +1,6 @@
 """Tests for the auto-provisioning of Modal Volumes holding model weights."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/sandbox/test_modal_sandbox.py
+++ b/tests/sandbox/test_modal_sandbox.py
@@ -1,7 +1,6 @@
 """Tests for ModalSandbox — all mock modal.Sandbox/Volume, no Modal auth required."""
 
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/test_agent_cli_mcp.py
+++ b/tests/test_agent_cli_mcp.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from vibe_serve._agent_cli.base import MCPServerSpec
 from vibe_serve._agent_cli.claude import ClaudeCodeCodingAgent
 from vibe_serve._agent_cli.codex import CodexCodingAgent
@@ -235,7 +233,7 @@ class TestCodexMCP:
         # We expect pairs of "--config" + "key=value" entries.
         flags = agent.extra_config_args
         # Strip the "--config" sentinels and inspect the value strings.
-        values = [v for f, v in zip(flags[0::2], flags[1::2]) if f == "--config"]
+        values = [v for f, v in zip(flags[0::2], flags[1::2], strict=True) if f == "--config"]
         assert all(f == "--config" for f in flags[0::2])
 
         # name "vibeserve-issues" should snake-case to "vibeserve_issues".

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_todo_display.py
+++ b/tests/test_todo_display.py
@@ -3,8 +3,6 @@
 from io import StringIO
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from vibe_serve.agents.callbacks import TodoDisplay
 
 # --- TodoDisplay rendering ---
@@ -54,7 +52,6 @@ def test_todo_display_clears_previous_lines():
     todos2 = [_make_todo("task one", "completed"), _make_todo("task two", "pending")]
 
     td.update(todos1)
-    first_output = buf.getvalue()
     buf.truncate(0)
     buf.seek(0)
 


### PR DESCRIPTION
Fixes #67

## Summary
- Add scripts/check_lint.sh and run it in CI after formatting.
- Make unrestricted `uv run ruff check .` pass across src, tests, examples, and resources.
- Document the lint helper in README.

## Verification
- `./scripts/check_lint.sh`
- `./scripts/check_format.sh`
- `uv run python -m pytest -v`