### PR TITLE
Social network read timeline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "inputs/show-o2-1.5B-HQ/reference/Show-o"]
 	path = examples/show-o2-1.5B-HQ/reference/Show-o
 	url = https://github.com/showlab/Show-o.git
+[submodule "examples/social-network-read-timeline/3rd_party/deathstarbench"]
+	path = examples/social-network-read-timeline/3rd_party/deathstarbench
+	url = https://github.com/delimitrou/DeathStarBench.git

--- a/examples/social-network-read-timeline/.gitignore
+++ b/examples/social-network-read-timeline/.gitignore
@@ -1,0 +1,5 @@
+build/
+.DS_Store
+**/.DS_Store
+3rd_party/deathstarbench/socialNetwork/datasets/
+3rd_party/deathstarbench/socialNetwork/scripts/__pycache__/

--- a/examples/social-network-read-timeline/CMakeLists.txt
+++ b/examples/social-network-read-timeline/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.14)
+project(social_network_read_timeline CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(CURL REQUIRED)
+find_package(Threads REQUIRED)
+
+include(FetchContent)
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+FetchContent_Declare(
+  json
+  URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+)
+FetchContent_MakeAvailable(json)
+
+include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
+add_executable(checker accuracy_checker/checker.cpp)
+target_link_libraries(checker CURL::libcurl Threads::Threads nlohmann_json::nlohmann_json)
+
+add_executable(benchmark benchmark/benchmark.cpp)
+target_link_libraries(benchmark CURL::libcurl Threads::Threads nlohmann_json::nlohmann_json)

--- a/examples/social-network-read-timeline/OBJECTIVE.md
+++ b/examples/social-network-read-timeline/OBJECTIVE.md
@@ -1,0 +1,44 @@
+# Social Network: Read Heavy Scenario (Issue #48)
+
+## Deployment Goal
+
+Optimise DeathStarBench's socialNetwork application for minimum p50 read latency
+on a local server under a read-heavy mixed workload, while preserving correctness
+as verified by accuracy_checker/checker.
+
+## Target System
+
+DeathStarBench socialNetwork — Go microservices stack (nginx-thrift frontend,
+ComposePost, UserTimeline, HomeTimeline, SocialGraph, PostStorage, UserService,
+UserMention, UrlShorten, UniqueId, Media services), MongoDB + Redis + Memcached,
+Thrift RPC internally, deployed via Docker Compose.
+Repo: https://github.com/delimitrou/DeathStarBench/tree/master/socialNetwork
+
+## Workload
+
+Read-heavy mixed load against nginx on port 8080:
+- 50% user-timeline reads: GET /wrk2-api/user-timeline/read
+- 40% home-timeline reads: GET /wrk2-api/home-timeline/read
+- 10% compose: POST /wrk2-api/post/compose (keeps content fresh during run)
+
+## Hardware Target
+
+Local server. x86-64 or Apple Silicon. Docker required.
+
+## Interface
+
+HTTP on port 8080. Wire-compatible with DeathStarBench socialNetwork nginx API.
+accuracy_checker/checker and benchmark/benchmark can point at any candidate
+without modification.
+
+## Optimisation Objective
+
+Minimise **p50 combined read latency** (`p50_ms` from benchmark output).
+`success_rate` must stay at 1.0 and all 11 correctness checks defined for application validation must pass.
+
+Key optimisation directions which could be explored:
+- Redis hit rate for UserTimeline and HomeTimeline services
+- Memcached hit rate for PostStorage
+- gRPC/Thrift connection pooling in nginx GenericObjectPool
+- Go runtime tuning (GC%, goroutine pool sizing)
+- UserTimeline and HomeTimeline service query optimisation

--- a/examples/social-network-read-timeline/README.md
+++ b/examples/social-network-read-timeline/README.md
@@ -1,0 +1,216 @@
+# Social Network: Read Timeline
+
+Closes issues #48.
+
+VibeServe use:
+
+- `--ref examples/social-network-read-timeline/reference`
+- `--acc-checker examples/social-network-read-timeline/accuracy_checker`
+- `--bench examples/social-network-read-timeline/benchmark`
+
+**Target:** DeathStarBench socialNetwork: Go microservices stack deployed via Docker Compose. 
+
+**Workload:** Read-heavy, specifically for this issue. 50% user-timeline reads, 40% home-timeline reads, 10% compose to keep content fresh.
+
+**Primary metric:** `p50_ms` (combined read latency).
+
+ **Acceptance criteria:** `success_rate` must stay at 1.0 and all 11 correctness checks (C1–C11) must pass.
+
+---
+
+## Correctness Checks (C1-C11)
+
+The following 11 checks are used for this service.
+
+
+| Check | Property                                                                           |
+| ----- | ---------------------------------------------------------------------------------- |
+| C1    | User-timeline response shape compatibility                                         |
+| C2    | Home-timeline response shape compatibility                                         |
+| C3    | User-timeline ordering (descending timestamp)                                      |
+| C4    | Home-timeline ordering (descending timestamp)                                      |
+| C5    | Visibility rules: home-timeline only shows followed users                          |
+| C6    | Write-then-read consistency for user-timeline                                      |
+| C7    | Write-then-read consistency for home-timeline fan-out                              |
+| C8    | Unfollow stops future fan-out                                                      |
+| C9    | Failed reads do not mutate application state                                       |
+| C10   | Pagination: disjoint non-overlapping pages                                         |
+| C11   | Held-out sequences: burst-read consistency + cross-user visibility + page boundary |
+
+
+---
+
+## How to run
+
+Below are instructions to build and run this system.
+
+Clone this repo with the submodule:
+
+DeathStarBench is tracked as a git submodule at `3rd_party/deathstarbench`. It must be initialised on first clone:
+
+```bash
+git clone --recurse-submodules <your-fork-url>
+cd social-network-read-timeline
+```
+
+If you already cloned without `--recurse-submodules`:
+
+```bash
+git submodule update --init --recursive
+```
+
+To verify if the submodule is properly populated, run the following command: 
+
+```bash
+ls 3rd_party/deathstarbench/socialNetwork
+```
+
+You should see `docker-compose.yml`, `CMakeLists.txt`, `nginx-web-server/`, etc.
+
+Then, to start DeathStarBench, run the following:
+
+```bash
+cd 3rd_party/deathstarbench/socialNetwork
+docker compose up -d
+```
+
+Wait for about 30 seconds for all containers to start, then verify nginx is up using:
+
+```bash
+docker compose ps | grep nginx
+```
+
+You should see `socialnetwork-nginx-thrift-1` with status `Up` and port `0.0.0.0:8080->8080/tcp`.
+
+Then to initialise the social graph (creates 962 users with follow relationships from the Reed98 dataset), use the following commands:
+
+```bash
+python3 scripts/init_social_graph.py --graph=socfb-Reed98 --ip=localhost --port=8080
+```
+
+This takes 1–2 minutes. To verify if the stack is responding appropriately, run as follows:
+
+```bash
+curl "http://localhost:8080/wrk2-api/user-timeline/read?user_id=1&start=0&stop=1"
+```
+
+Should return a JSON array.
+Before the system is built with CMake, we need to install and make use of the nginx patches, both default and the new ones added. Our checker and benchmark require four additions to the running nginx container:
+
+1. Three new `check-api` endpoints (for correctness checks via Thrift services)
+2. Timing headers (`X-Compose-Thrift-Ms`, `X-UserTimeline-Thrift-Ms`, `X-HomeTimeline-Thrift-Ms`) for intermediate latency measurement
+
+These are applied by a single script. From the repo root:
+
+```bash
+cd nginx_patches
+chmod +x apply_patches.sh
+./apply_patches.sh
+```
+
+Expected output ends with the following format:
+
+```
+Patches applied and nginx reloaded.
+[] <- get_followees OK
+```
+
+**Important:** It should be noted that this step would have to be repeated every time the nginx container is recreated (i.e. after `docker compose down` + `docker compose up -d`).
+
+To build the checker and benchmark, run the following in the terminal: 
+
+```bash
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j4
+```
+
+CMake automatically downloads `nlohmann/json` (v3.11.3) via `FetchContent` during the configure step. This might 10-15 seconds the first time it's run.
+
+To run the checker:
+
+```bash
+cd build
+./checker --base-url http://localhost:8080
+```
+
+All 11 checks must pass before running the benchmark. Expected output should look as follows:
+
+```
+  PASS  C1 User-timeline response shape compatibility
+  PASS  C2 Home-timeline response shape compatibility
+  PASS  C3 User-timeline ordering is descending by timestamp
+  PASS  C4 Home-timeline ordering is descending by timestamp
+  PASS  C5 Visibility rules: home-timeline only shows followed users posts
+  PASS  C6 Write-then-read consistency: compose reflects in user-timeline
+  PASS  C7 Write-then-read consistency: compose fans out to follower home-timeline
+  PASS  C8 Unfollow stops future fan-out to home-timeline
+  PASS  C9 Failed reads do not mutate application state
+  PASS  C10 Pagination: start/stop bounds return disjoint non-overlapping pages
+  PASS  C11 Held-out sequences: burst-read consistency and cross-user visibility
+
+Results: 11 passed, 0 failed out of 11 checks.
+```
+
+Optional flags which can be included with the checker:
+
+```bash
+./checker --base-url http://localhost:8080 --timeout-ms 10000 --poll-ms 200
+```
+
+For the benchmark, three load levels are available and they can be run individually:
+
+```bash
+./benchmark --base-url http://localhost:8080 --load-level light
+./benchmark --base-url http://localhost:8080 --load-level medium
+./benchmark --base-url http://localhost:8080 --load-level heavy
+```
+
+On repeated runs, you can skip the benchmark user setup phase using this:
+
+```bash
+./benchmark --base-url http://localhost:8080 --load-level medium --skip-setup
+```
+
+Load level parameters:
+
+
+| Level  | Target RPS | Duration | Warmup | Users |
+| ------ | ---------- | -------- | ------ | ----- |
+| light  | 100        | 60s      | 10s    | 20    |
+| medium | 300        | 120s     | 20s    | 50    |
+| heavy  | 600        | 180s     | 30s    | 100   |
+
+
+### Output format
+
+The benchmark emits one JSON line per metric, followed by a summary line:
+
+```
+{"metric":"p50_ms","value":7.82}
+{"metric":"p95_ms","value":14.40}
+{"metric":"p99_ms","value":21.55}
+{"metric":"p999_ms","value":38.12}
+{"metric":"user_timeline_p50_ms","value":6.31}
+{"metric":"user_timeline_thrift_p50_ms","value":4.10}
+{"metric":"home_timeline_p50_ms","value":6.09}
+{"metric":"home_timeline_thrift_p50_ms","value":2.80}
+...
+{"metric":"throughput_rps","value":298.7}
+{"metric":"success_rate","value":1.0}
+{"metric":"cpu_percent","value":102.9}
+{"metric":"memory_mb","value":812.3}
+```
+
+`p50_ms` is the primary metric VibeServe uses to evaluate candidates. `user_timeline_thrift_p50_ms` and `home_timeline_thrift_p50_ms` are intermediate latencies (nginx to first Thrift service hop).
+
+## Rebuilding
+
+To teardown the system, run the folllowing:
+
+```bash
+cd 3rd_party/deathstarbench/socialNetwork
+docker compose down -v
+```
+
+This will remove MongoDB and Redis volumes, starting clean for the next run.

--- a/examples/social-network-read-timeline/accuracy_checker/checker.cpp
+++ b/examples/social-network-read-timeline/accuracy_checker/checker.cpp
@@ -1,0 +1,606 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <map>
+#include <set>
+#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <chrono>
+#include <functional>
+#include <curl/curl.h>
+#include "../include/social_network_client.h"
+
+static std::string BASE_URL = "http://localhost:8080";
+static int ASYNC_TIMEOUT_MS = 5000;
+static int POLL_INTERVAL_MS = 100;
+static std::atomic<int> USER_ID_COUNTER{0};
+
+static int nextUserId() { return USER_ID_COUNTER.fetch_add(1); }
+
+struct TestResult {
+    std::string name;
+    bool passed = false;
+    std::string detail;
+};
+
+struct SetupData {
+    bool valid = false;
+    std::string error;
+    std::vector<int> user_ids;
+    std::vector<std::string> usernames;
+    std::vector<std::pair<std::string,std::string>> follows;
+};
+
+static bool validatePostSchema(const json& post, std::string& err) {
+    for (auto& f : {"post_id","creator","text","timestamp","post_type","user_mentions","media","urls"}) {
+        if (!post.contains(f)) { err = std::string("missing field: ")+f; return false; }
+    }
+    if (!post["creator"].contains("user_id")||!post["creator"].contains("username")) {
+        err = "creator missing fields"; return false;
+    }
+    if (post["post_id"].get<std::string>().empty()) { err = "empty post_id"; return false; }
+    if (post["timestamp"].get<std::string>().empty()) { err = "empty timestamp"; return false; }
+    return true;
+}
+
+static std::string registerAndCompose(SocialNetworkClient& c, const std::string& uname,
+                                       int uid, const std::string& text,
+                                       SetupData& s, bool add_follow_seed=false) {
+    if (!c.registerUser(uname, "pass123", uid, "RT", std::to_string(uid))) {
+        s.error = "register failed for "+uname; return "";
+    }
+    s.user_ids.push_back(uid);
+    s.usernames.push_back(uname);
+    auto r = c.composePost(uname, uid, text);
+    bool ok = r.status==200 || (r.status==500 && r.body.find("ZADD")!=std::string::npos);
+    if (!ok) { s.error = "compose failed: "+r.body; return ""; }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    return c.findLatestPostId(uid);
+}
+
+static void Reset(SocialNetworkClient& c, const SetupData& s) {
+    for (auto& f : s.follows) c.unfollowByName(f.first, f.second);
+}
+
+SetupData Setup_C1(SocialNetworkClient& c) {
+    SetupData s;
+    int uid = nextUserId();
+    std::string uname = "rchk_c1_"+std::to_string(uid);
+    auto pid = registerAndCompose(c, uname, uid, "C1_schema_test", s);
+    if (!s.error.empty()) return s;
+    if (pid.empty()) { s.error = "could not get post_id"; return s; }
+    s.valid = true;
+    return s;
+}
+
+TestResult Test_C1() {
+    TestResult res{"C1 User-timeline response shape compatibility", false, ""};
+    SocialNetworkClient c(BASE_URL);
+    auto s = Setup_C1(c);
+    if (!s.valid) { res.detail = "setup: "+s.error; Reset(c,s); return res; }
+
+    auto tl = c.readUserTimeline(s.user_ids[0], 0, 5);
+    if (!tl.is_array()||tl.empty()) { res.detail = "timeline empty or not array"; Reset(c,s); return res; }
+    std::string err;
+    if (!validatePostSchema(tl[0], err)) { res.detail = "schema: "+err; Reset(c,s); return res; }
+
+    Reset(c,s);
+    res.passed = true;
+    return res;
+}
+
+SetupData Setup_C2(SocialNetworkClient& c) {
+    SetupData s;
+    int uid_a = nextUserId(), uid_b = nextUserId();
+    std::string ua = "rchk_c2a_"+std::to_string(uid_a);
+    std::string ub = "rchk_c2b_"+std::to_string(uid_b);
+    if (!c.registerUser(ua,"pass123",uid_a,"RT","C2A")||!c.registerUser(ub,"pass123",uid_b,"RT","C2B")) {
+        s.error="register failed"; return s;
+    }
+    s.user_ids = {uid_a, uid_b};
+    s.usernames = {ua, ub};
+    if (!c.followByName(ua, ub)) { s.error="follow failed"; return s; }
+    s.follows.push_back({ua,ub});
+    auto r = c.composePost(ub, uid_b, "C2_ht_schema");
+    bool ok = r.status==200||(r.status==500&&r.body.find("ZADD")!=std::string::npos);
+    if (!ok) { s.error="compose failed: "+r.body; return s; }
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    s.valid = true;
+    return s;
+}
+
+TestResult Test_C2() {
+    TestResult res{"C2 Home-timeline response shape compatibility", false, ""};
+    SocialNetworkClient c(BASE_URL);
+    auto s = Setup_C2(c);
+    if (!s.valid) { res.detail = "setup: "+s.error; Reset(c,s); return res; }
+
+    auto htl = c.readHomeTimeline(s.user_ids[0], 0, 5);
+    if (!htl.is_array()||htl.empty()) { res.detail = "home-timeline empty or not array"; Reset(c,s); return res; }
+    std::string err;
+    if (!validatePostSchema(htl[0], err)) { res.detail = "schema: "+err; Reset(c,s); return res; }
+
+    Reset(c,s);
+    res.passed = true;
+    return res;
+}
+
+SetupData Setup_C3(SocialNetworkClient& c) {
+    SetupData s;
+    int uid = nextUserId();
+    std::string uname = "rchk_c3_"+std::to_string(uid);
+    if (!c.registerUser(uname,"pass123",uid,"RT","C3")) { s.error="register failed"; return s; }
+    s.user_ids={uid}; s.usernames={uname};
+    for (int i=1; i<=3; i++) {
+        auto r = c.composePost(uname, uid, "C3_post_"+std::to_string(i));
+        bool ok = r.status==200||(r.status==500&&r.body.find("ZADD")!=std::string::npos);
+        if (!ok) { s.error="compose "+std::to_string(i)+" failed"; return s; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+    s.valid = true;
+    return s;
+}
+
+TestResult Test_C3() {
+    TestResult res{"C3 User-timeline ordering is descending by timestamp", false, ""};
+    SocialNetworkClient c(BASE_URL);
+    auto s = Setup_C3(c);
+    if (!s.valid) { res.detail = "setup: "+s.error; Reset(c,s); return res; }
+
+    auto tl = c.readUserTimeline(s.user_ids[0], 0, 10);
+    if (!tl.is_array()||(int)tl.size()<3) {
+        res.detail = "expected >=3 posts, got "+std::to_string(tl.is_array()?tl.size():0);
+        Reset(c,s); return res;
+    }
+    long long prev = LLONG_MAX;
+    for (int i=0; i<3; i++) {
+        long long ts = std::stoll(tl[i]["timestamp"].get<std::string>());
+        if (ts > prev) {
+            res.detail = "ordering violated at index "+std::to_string(i);
+            Reset(c,s); return res;
+        }
+        prev = ts;
+    }
+
+    Reset(c,s);
+    res.passed = true;
+    return res;
+}
+
+SetupData Setup_C4(SocialNetworkClient& c) {
+    SetupData s;
+    int uid_a=nextUserId(), uid_b=nextUserId();
+    std::string ua="rchk_c4a_"+std::to_string(uid_a);
+    std::string ub="rchk_c4b_"+std::to_string(uid_b);
+    if (!c.registerUser(ua,"pass123",uid_a,"RT","C4A")||!c.registerUser(ub,"pass123",uid_b,"RT","C4B")) {
+        s.error="register failed"; return s;
+    }
+    s.user_ids={uid_a,uid_b}; s.usernames={ua,ub};
+    if (!c.followByName(ua,ub)) { s.error="follow failed"; return s; }
+    s.follows.push_back({ua,ub});
+    for (int i=1; i<=3; i++) {
+        auto r = c.composePost(ub, uid_b, "C4_ht_post_"+std::to_string(i));
+        bool ok = r.status==200||(r.status==500&&r.body.find("ZADD")!=std::string::npos);
+        if (!ok) { s.error="compose failed"; return s; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    s.valid = true;
+    return s;
+}
+
+TestResult Test_C4() {
+    TestResult res{"C4 Home-timeline ordering is descending by timestamp", false, ""};
+    SocialNetworkClient c(BASE_URL);
+    auto s = Setup_C4(c);
+    if (!s.valid) { res.detail = "setup: "+s.error; Reset(c,s); return res; }
+
+    auto htl = c.readHomeTimeline(s.user_ids[0], 0, 10);
+    if (!htl.is_array()||(int)htl.size()<3) {
+        res.detail = "expected >=3 posts in home-timeline, got "+std::to_string(htl.is_array()?htl.size():0);
+        Reset(c,s); return res;
+    }
+    long long prev = LLONG_MAX;
+    for (int i=0; i<3; i++) {
+        long long ts = std::stoll(htl[i]["timestamp"].get<std::string>());
+        if (ts > prev) { res.detail = "ht ordering violated at index "+std::to_string(i); Reset(c,s); return res; }
+        prev = ts;
+    }
+
+    Reset(c,s);
+    res.passed = true;
+    return res;
+}
+
+SetupData Setup_C5(SocialNetworkClient& c) {
+    SetupData s;
+    int uid_a=nextUserId(), uid_b=nextUserId(), uid_c=nextUserId();
+    std::string ua="rchk_c5a_"+std::to_string(uid_a);
+    std::string ub="rchk_c5b_"+std::to_string(uid_b);
+    std::string uc="rchk_c5c_"+std::to_string(uid_c);
+    if (!c.registerUser(ua,"pass123",uid_a,"RT","C5A")||
+        !c.registerUser(ub,"pass123",uid_b,"RT","C5B")||
+        !c.registerUser(uc,"pass123",uid_c,"RT","C5C")) {
+        s.error="register failed"; return s;
+    }
+    s.user_ids={uid_a,uid_b,uid_c}; s.usernames={ua,ub,uc};
+    if (!c.followByName(ua,ub)) { s.error="follow a->b failed"; return s; }
+    s.follows.push_back({ua,ub});
+    s.valid = true;
+    return s;
+}
+
+TestResult Test_C5() {
+    TestResult res{"C5 Visibility rules: home-timeline only shows followed users posts", false, ""};
+    SocialNetworkClient c(BASE_URL);
+    auto s = Setup_C5(c);
+    if (!s.valid) { res.detail = "setup: "+s.error; Reset(c,s); return res; }
+
+    int uid_a=s.user_ids[0], uid_b=s.user_ids[1], uid_c=s.user_ids[2];
+
+    auto rb = c.composePost(s.usernames[1], uid_b, "C5_from_followed");
+    bool ok_b = rb.status==200||(rb.status==500&&rb.body.find("ZADD")!=std::string::npos);
+    auto rc = c.composePost(s.usernames[2], uid_c, "C5_from_not_followed");
+    bool ok_c = rc.status==200||(rc.status==500&&rc.body.find("ZADD")!=std::string::npos);
+
+    if (!ok_b||!ok_c) { res.detail="compose failed"; Reset(c,s); return res; }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::string b_pid = c.findLatestPostId(uid_b);
+    std::string c_pid = c.findLatestPostId(uid_c);
+    if (b_pid.empty()||c_pid.empty()) { res.detail="could not get post_ids"; Reset(c,s); return res; }
+
+    bool b_found = c.pollHomeTimelineContains(uid_a, b_pid, ASYNC_TIMEOUT_MS, POLL_INTERVAL_MS);
+    if (!b_found) { res.detail="post from followed user not in home-timeline"; Reset(c,s); return res; }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    bool c_found = c.checkHomeTimelineContains(uid_a, c_pid);
+    if (c_found) { res.detail="post from non-followed user appeared in home-timeline"; Reset(c,s); return res; }
+
+    Reset(c,s);
+    res.passed = true;
+    return res;
+}
+
+SetupData Setup_C6(SocialNetworkClient& c) {
+    SetupData s;
+    int uid = nextUserId();
+    std::string uname = "rchk_c6_"+std::to_string(uid);
+    if (!c.registerUser(uname,"pass123",uid,"RT","C6")) { s.error="register failed"; return s; }
+    s.user_ids={uid}; s.usernames={uname};
+    s.valid = true;
+    return s;
+}
+
+TestResult Test_C6() {
+    TestResult res{"C6 Write-then-read consistency: compose reflects in user-timeline", false, ""};
+    SocialNetworkClient c(BASE_URL);
+    auto s = Setup_C6(c);
+    if (!s.valid) { res.detail = "setup: "+s.error; Reset(c,s); return res; }
+
+    std::string marker = "C6_consistency_"+std::to_string(s.user_ids[0]);
+    auto r = c.composePost(s.usernames[0], s.user_ids[0], marker);
+    bool ok = r.status==200||(r.status==500&&r.body.find("ZADD")!=std::string::npos);
+    if (!ok) { res.detail="compose failed: "+r.body; Reset(c,s); return res; }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::string post_id = c.findLatestPostId(s.user_ids[0]);
+    if (post_id.empty()) { res.detail="findLatestPostId returned empty"; Reset(c,s); return res; }
+
+    bool found = c.checkUserTimelineContains(s.user_ids[0], post_id);
+    if (!found) { res.detail="post not found in user-timeline via check-api"; Reset(c,s); return res; }
+
+    auto tl = c.readUserTimeline(s.user_ids[0], 0, 3);
+    if (!tl.is_array()||tl.empty()) { res.detail="timeline empty after compose"; Reset(c,s); return res; }
+    if (tl[0]["text"].get<std::string>() != marker) { res.detail="text mismatch in timeline"; Reset(c,s); return res; }
+
+    Reset(c,s);
+    res.passed = true;
+    return res;
+}
+
+SetupData Setup_C7(SocialNetworkClient& c) {
+    SetupData s;
+    int uid_a=nextUserId(), uid_b=nextUserId();
+    std::string ua="rchk_c7a_"+std::to_string(uid_a);
+    std::string ub="rchk_c7b_"+std::to_string(uid_b);
+    if (!c.registerUser(ua,"pass123",uid_a,"RT","C7A")||!c.registerUser(ub,"pass123",uid_b,"RT","C7B")) {
+        s.error="register failed"; return s;
+    }
+    s.user_ids={uid_a,uid_b}; s.usernames={ua,ub};
+    if (!c.followByName(ua,ub)) { s.error="follow failed"; return s; }
+    s.follows.push_back({ua,ub});
+    s.valid = true;
+    return s;
+}
+
+TestResult Test_C7() {
+    TestResult res{"C7 Write-then-read consistency: compose fans out to follower home-timeline", false, ""};
+    SocialNetworkClient c(BASE_URL);
+    auto s = Setup_C7(c);
+    if (!s.valid) { res.detail = "setup: "+s.error; Reset(c,s); return res; }
+
+    int uid_a=s.user_ids[0], uid_b=s.user_ids[1];
+    auto r = c.composePost(s.usernames[1], uid_b, "C7_fanout_test");
+    bool ok = r.status==200||(r.status==500&&r.body.find("ZADD")!=std::string::npos);
+    if (!ok) { res.detail="compose failed"; Reset(c,s); return res; }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::string post_id = c.findLatestPostId(uid_b);
+    if (post_id.empty()) { res.detail="could not get post_id"; Reset(c,s); return res; }
+
+    bool found = c.pollHomeTimelineContains(uid_a, post_id, ASYNC_TIMEOUT_MS, POLL_INTERVAL_MS);
+    if (!found) {
+        res.detail = "post not in follower home-timeline after "+std::to_string(ASYNC_TIMEOUT_MS)+"ms";
+        Reset(c,s); return res;
+    }
+
+    Reset(c,s);
+    res.passed = true;
+    return res;
+}
+
+SetupData Setup_C8(SocialNetworkClient& c) {
+    SetupData s;
+    int uid_a=nextUserId(), uid_b=nextUserId();
+    std::string ua="rchk_c8a_"+std::to_string(uid_a);
+    std::string ub="rchk_c8b_"+std::to_string(uid_b);
+    if (!c.registerUser(ua,"pass123",uid_a,"RT","C8A")||!c.registerUser(ub,"pass123",uid_b,"RT","C8B")) {
+        s.error="register failed"; return s;
+    }
+    s.user_ids={uid_a,uid_b}; s.usernames={ua,ub};
+    if (!c.followByName(ua,ub)) { s.error="follow failed"; return s; }
+    s.follows.push_back({ua,ub});
+    auto r = c.composePost(ub, uid_b, "C8_pre_unfollow");
+    bool ok = r.status==200||(r.status==500&&r.body.find("ZADD")!=std::string::npos);
+    if (!ok) { s.error="compose failed"; return s; }
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::string pid = c.findLatestPostId(uid_b);
+    if (!c.pollHomeTimelineContains(uid_a, pid, 3000, 100)) {
+        s.error="pre-unfollow post never appeared (fan-out broken)"; return s;
+    }
+    s.valid = true;
+    return s;
+}
+
+TestResult Test_C8() {
+    TestResult res{"C8 Unfollow stops future fan-out to home-timeline", false, ""};
+    SocialNetworkClient c(BASE_URL);
+    auto s = Setup_C8(c);
+    if (!s.valid) { res.detail = "setup: "+s.error; Reset(c,s); return res; }
+
+    int uid_a=s.user_ids[0], uid_b=s.user_ids[1];
+    if (!c.unfollowByName(s.usernames[0], s.usernames[1])) {
+        res.detail="unfollow call failed"; Reset(c,s); return res;
+    }
+    s.follows.clear();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    auto r = c.composePost(s.usernames[1], uid_b, "C8_post_unfollow");
+    bool ok = r.status==200||(r.status==500&&r.body.find("ZADD")!=std::string::npos);
+    if (!ok) { res.detail="post-unfollow compose failed"; Reset(c,s); return res; }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::string post_id = c.findLatestPostId(uid_b);
+    if (post_id.empty()) { res.detail="could not get post_id"; Reset(c,s); return res; }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+    bool found = c.checkHomeTimelineContains(uid_a, post_id);
+    if (found) { res.detail="post after unfollow appeared in home-timeline"; Reset(c,s); return res; }
+
+    Reset(c,s);
+    res.passed = true;
+    return res;
+}
+
+SetupData Setup_C9(SocialNetworkClient& c) {
+    SetupData s;
+    int uid = nextUserId();
+    std::string uname = "rchk_c9_"+std::to_string(uid);
+    auto pid = registerAndCompose(c, uname, uid, "C9_baseline", s);
+    if (!s.error.empty()) return s;
+    if (pid.empty()) { s.error="compose baseline failed"; return s; }
+    s.valid = true;
+    return s;
+}
+
+TestResult Test_C9() {
+    TestResult res{"C9 Failed reads do not mutate application state", false, ""};
+    SocialNetworkClient c(BASE_URL);
+    auto s = Setup_C9(c);
+    if (!s.valid) { res.detail = "setup: "+s.error; Reset(c,s); return res; }
+
+    auto before = c.readUserTimeline(s.user_ids[0], 0, 50);
+    size_t count_before = before.is_array() ? before.size() : 0;
+
+    int invalid_uid = 999999999;
+    auto r1 = httpGet(BASE_URL+"/wrk2-api/user-timeline/read?user_id="+std::to_string(invalid_uid)+"&start=0&stop=10");
+    auto r2 = httpGet(BASE_URL+"/wrk2-api/home-timeline/read?user_id="+std::to_string(invalid_uid)+"&start=0&stop=10");
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    auto after = c.readUserTimeline(s.user_ids[0], 0, 50);
+    size_t count_after = after.is_array() ? after.size() : 0;
+
+    if (count_after != count_before) {
+        res.detail = "timeline count changed from "+std::to_string(count_before)+
+                     " to "+std::to_string(count_after)+" after invalid reads";
+        Reset(c,s); return res;
+    }
+
+    Reset(c,s);
+    res.passed = true;
+    return res;
+}
+
+SetupData Setup_C10(SocialNetworkClient& c) {
+    SetupData s;
+    int uid = nextUserId();
+    std::string uname = "rchk_c10_"+std::to_string(uid);
+    if (!c.registerUser(uname,"pass123",uid,"RT","C10")) { s.error="register failed"; return s; }
+    s.user_ids={uid}; s.usernames={uname};
+    for (int i=0; i<6; i++) {
+        auto r = c.composePost(uname, uid, "C10_page_post_"+std::to_string(i));
+        bool ok = r.status==200||(r.status==500&&r.body.find("ZADD")!=std::string::npos);
+        if (!ok) { s.error="compose "+std::to_string(i)+" failed"; return s; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    s.valid = true;
+    return s;
+}
+
+TestResult Test_C10() {
+    TestResult res{"C10 Pagination: start/stop bounds return disjoint non-overlapping pages", false, ""};
+    SocialNetworkClient c(BASE_URL);
+    auto s = Setup_C10(c);
+    if (!s.valid) { res.detail = "setup: "+s.error; Reset(c,s); return res; }
+
+    auto page1 = c.readUserTimeline(s.user_ids[0], 0, 3);
+    auto page2 = c.readUserTimeline(s.user_ids[0], 3, 6);
+
+    if (!page1.is_array()||(int)page1.size()!=3) {
+        res.detail="page1 expected 3, got "+std::to_string(page1.is_array()?page1.size():0);
+        Reset(c,s); return res;
+    }
+    if (!page2.is_array()||(int)page2.size()!=3) {
+        res.detail="page2 expected 3, got "+std::to_string(page2.is_array()?page2.size():0);
+        Reset(c,s); return res;
+    }
+
+    std::set<std::string> ids1, ids2;
+    for (auto& p:page1) ids1.insert(p["post_id"].get<std::string>());
+    for (auto& p:page2) ids2.insert(p["post_id"].get<std::string>());
+
+    std::vector<std::string> overlap;
+    for (auto& id:ids1) if (ids2.count(id)) overlap.push_back(id);
+    if (!overlap.empty()) { res.detail="overlap between pages: "+overlap[0]; Reset(c,s); return res; }
+
+    Reset(c,s);
+    res.passed = true;
+    return res;
+}
+
+SetupData Setup_C11(SocialNetworkClient& c) {
+    SetupData s;
+    int uid_a=nextUserId(), uid_b=nextUserId(), uid_c=nextUserId();
+    std::string ua="rchk_c11a_"+std::to_string(uid_a);
+    std::string ub="rchk_c11b_"+std::to_string(uid_b);
+    std::string uc="rchk_c11c_"+std::to_string(uid_c);
+    if (!c.registerUser(ua,"pass123",uid_a,"RT","C11A")||
+        !c.registerUser(ub,"pass123",uid_b,"RT","C11B")||
+        !c.registerUser(uc,"pass123",uid_c,"RT","C11C")) {
+        s.error="register failed"; return s;
+    }
+    s.user_ids={uid_a,uid_b,uid_c}; s.usernames={ua,ub,uc};
+    if (!c.followByName(ua,ub)||!c.followByName(ub,uc)) { s.error="follow failed"; return s; }
+    s.follows.push_back({ua,ub}); s.follows.push_back({ub,uc});
+    for (int i=0; i<5; i++) {
+        auto r = c.composePost(ub, uid_b, "C11_burst_post_"+std::to_string(i));
+        bool ok = r.status==200||(r.status==500&&r.body.find("ZADD")!=std::string::npos);
+        if (!ok) { s.error="compose failed"; return s; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    s.valid = true;
+    return s;
+}
+
+TestResult Test_C11() {
+    TestResult res{"C11 Held-out sequences: burst-read consistency and cross-user visibility", false, ""};
+    SocialNetworkClient c(BASE_URL);
+    auto s = Setup_C11(c);
+    if (!s.valid) { res.detail = "setup: "+s.error; Reset(c,s); return res; }
+
+    int uid_a=s.user_ids[0], uid_b=s.user_ids[1], uid_c=s.user_ids[2];
+
+    // Sequence 1: burst read — read same timeline 8 times, all must return identical post_ids
+    std::vector<std::set<std::string>> readings;
+    for (int i=0; i<8; i++) {
+        auto tl = c.readUserTimeline(uid_b, 0, 10);
+        std::set<std::string> ids;
+        if (tl.is_array()) for (auto& p:tl) ids.insert(p["post_id"].get<std::string>());
+        readings.push_back(ids);
+    }
+    for (size_t i=1; i<readings.size(); i++) {
+        if (readings[i]!=readings[0]) {
+            res.detail="burst-read inconsistency at iteration "+std::to_string(i);
+            Reset(c,s); return res;
+        }
+    }
+
+    // Sequence 2: check-api visibility — ua follows ub, uc does not follow ub
+    // ub has posts; ua should see them in home-timeline, uc should not
+    std::string ub_pid = c.findLatestPostId(uid_b);
+    if (ub_pid.empty()) { res.detail="could not get ub post_id"; Reset(c,s); return res; }
+
+    bool ua_sees = c.checkHomeTimelineContains(uid_a, ub_pid);
+    bool uc_sees = c.checkHomeTimelineContains(uid_c, ub_pid);
+    if (!ua_sees) { res.detail="ua (follower of ub) does not see ub's post in home-timeline"; Reset(c,s); return res; }
+    if (uc_sees) { res.detail="uc (not follower of ub) sees ub's post in home-timeline"; Reset(c,s); return res; }
+
+    // Sequence 3: page boundary consistency — sequential pages together equal full read
+    auto full = c.readUserTimeline(uid_b, 0, 5);
+    auto p1   = c.readUserTimeline(uid_b, 0, 2);
+    auto p2   = c.readUserTimeline(uid_b, 2, 5);
+
+    std::set<std::string> full_ids, paged_ids;
+    if (full.is_array()) for (auto& p:full) full_ids.insert(p["post_id"].get<std::string>());
+    if (p1.is_array()) for (auto& p:p1)   paged_ids.insert(p["post_id"].get<std::string>());
+    if (p2.is_array()) for (auto& p:p2)   paged_ids.insert(p["post_id"].get<std::string>());
+
+    if (full_ids != paged_ids) {
+        res.detail = "paginated read does not match full read (different post sets)";
+        Reset(c,s); return res;
+    }
+
+    Reset(c,s);
+    res.passed = true;
+    return res;
+}
+
+int main(int argc, char* argv[]) {
+    for (int i=1; i<argc; i++) {
+        std::string a=argv[i];
+        if (a=="--base-url"&&i+1<argc) BASE_URL=argv[++i];
+        else if (a=="--timeout-ms"&&i+1<argc) ASYNC_TIMEOUT_MS=std::stoi(argv[++i]);
+        else if (a=="--poll-ms"&&i+1<argc) POLL_INTERVAL_MS=std::stoi(argv[++i]);
+    }
+
+    curl_global_init(CURL_GLOBAL_ALL);
+
+    USER_ID_COUNTER = 600000 + (int)(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count() % 90000);
+
+    auto probe = httpGet(BASE_URL+"/wrk2-api/user-timeline/read?user_id=1&start=0&stop=1");
+    if (probe.status==0) {
+        std::cerr<<"ERROR: cannot reach "<<BASE_URL<<"\n";
+        curl_global_cleanup(); return 1;
+    }
+
+    std::vector<std::function<TestResult()>> tests = {
+        Test_C1, Test_C2, Test_C3, Test_C4, Test_C5, Test_C6,
+        Test_C7, Test_C8, Test_C9, Test_C10, Test_C11
+    };
+
+    int passed=0, failed=0;
+    std::vector<std::pair<std::string,std::string>> failures;
+
+    for (auto& t:tests) {
+        auto r=t();
+        if (r.passed) { std::cout<<"  PASS  "<<r.name<<"\n"; passed++; }
+        else { std::cout<<"  FAIL  "<<r.name<<": "<<r.detail<<"\n"; failed++; failures.push_back({r.name,r.detail}); }
+        std::cout.flush();
+    }
+
+    std::cout<<"\nResults: "<<passed<<" passed, "<<failed<<" failed out of "<<(passed+failed)<<" checks.\n";
+    if (!failures.empty()) {
+        std::cout<<"\nFailed checks:\n";
+        for (auto& f:failures) std::cout<<"  - "<<f.first<<": "<<f.second<<"\n";
+    }
+
+    curl_global_cleanup();
+    return failed>0?1:0;
+}

--- a/examples/social-network-read-timeline/benchmark/benchmark.cpp
+++ b/examples/social-network-read-timeline/benchmark/benchmark.cpp
@@ -1,0 +1,337 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <map>
+#include <thread>
+#include <mutex>
+#include <atomic>
+#include <chrono>
+#include <queue>
+#include <condition_variable>
+#include <algorithm>
+#include <numeric>
+#include <sstream>
+#include <iomanip>
+#include <random>
+#include <functional>
+#include <cstdio>
+#include <curl/curl.h>
+#include "../include/social_network_client.h"
+#include "../include/percentile.h"
+
+static std::string BASE_URL  = "http://localhost:8080";
+static std::string LOAD_LEVEL = "medium";
+static int  SEED        = 42;
+static bool SKIP_SETUP  = false;
+
+struct LoadConfig {
+    int target_rps;
+    int duration_sec;
+    int warmup_sec;
+    int n_users;
+    int seed_posts_per_user;
+};
+
+static const std::map<std::string,LoadConfig> LOAD_LEVELS = {
+    {"light",  {100,  60,  10, 20,  5}},
+    {"medium", {300,  120, 20, 50,  10}},
+    {"heavy",  {600,  180, 30, 100, 10}},
+};
+
+enum class ReqType { USER_TIMELINE, HOME_TIMELINE, COMPOSE };
+
+struct Measurement {
+    double  latency_ms;
+    double  thrift_ms;
+    int     status;
+    ReqType type;
+};
+
+static std::atomic<bool>  g_stop{false};
+static std::mutex         g_meas_mutex;
+static std::vector<Measurement> g_measurements;
+
+static void emit(const std::string& k, double v) {
+    std::cout<<"{\"metric\":\""<<k<<"\",\"value\":"<<std::fixed<<std::setprecision(2)<<v<<"}\n";
+    std::cout.flush();
+}
+
+static std::string rbnchUser(int i)  { return "rbnch_"+std::to_string(i); }
+static int         rbnchId(int i)    { return 700000+i; }
+
+static void setupUsers(const LoadConfig& cfg) {
+    std::cout<<"# Setting up "<<cfg.n_users<<" read-timeline benchmark users...\n"; std::cout.flush();
+    SocialNetworkClient c(BASE_URL);
+    for (int i=0; i<cfg.n_users; i++) {
+        c.registerUser(rbnchUser(i),"rbnch_pass",rbnchId(i),"RB",std::to_string(i));
+        if (i>0) c.followByName(rbnchUser(i), rbnchUser(i-1));
+    }
+    if (cfg.n_users>1) c.followByName(rbnchUser(0), rbnchUser(cfg.n_users-1));
+    std::cout<<"# Seeding "<<cfg.seed_posts_per_user<<" posts per user...\n"; std::cout.flush();
+    for (int i=0; i<cfg.n_users; i++)
+        for (int j=0; j<cfg.seed_posts_per_user; j++)
+            c.composePost(rbnchUser(i), rbnchId(i), "seed_"+std::to_string(j));
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+    std::cout<<"# Setup complete.\n"; std::cout.flush();
+}
+
+static Measurement doUserTimelineRead(const std::string& base_url, int user_id) {
+    Measurement m; m.type=ReqType::USER_TIMELINE; m.thrift_ms=0;
+    auto r = httpGet(base_url+"/wrk2-api/user-timeline/read?user_id="+std::to_string(user_id)+"&start=0&stop=10");
+    m.latency_ms=r.latency_ms; m.status=r.status;
+    auto it=r.headers.find("X-UserTimeline-Thrift-Ms");
+    if (it!=r.headers.end()) try{m.thrift_ms=std::stod(it->second);}catch(...){}
+    return m;
+}
+
+static Measurement doHomeTimelineRead(const std::string& base_url, int user_id) {
+    Measurement m; m.type=ReqType::HOME_TIMELINE; m.thrift_ms=0;
+    auto r = httpGet(base_url+"/wrk2-api/home-timeline/read?user_id="+std::to_string(user_id)+"&start=0&stop=10");
+    m.latency_ms=r.latency_ms; m.status=r.status;
+    auto it=r.headers.find("X-HomeTimeline-Thrift-Ms");
+    if (it!=r.headers.end()) try{m.thrift_ms=std::stod(it->second);}catch(...){}
+    return m;
+}
+
+static Measurement doCompose(const std::string& base_url, const std::string& uname, int uid, int ctr) {
+    Measurement m; m.type=ReqType::COMPOSE; m.thrift_ms=0;
+    auto r = httpPost(base_url+"/wrk2-api/post/compose",
+        {{"username",uname},{"user_id",std::to_string(uid)},
+         {"text","live_"+std::to_string(ctr)},
+         {"media_ids","[]"},{"media_types","[]"},{"post_type","0"}});
+    m.latency_ms=r.latency_ms; m.status=r.status;
+    auto it=r.headers.find("X-Compose-Thrift-Ms");
+    if (it!=r.headers.end()) try{m.thrift_ms=std::stod(it->second);}catch(...){}
+    return m;
+}
+
+struct WorkItem { ReqType type; int user_idx; int counter; };
+
+static std::queue<WorkItem>       g_work_queue;
+static std::mutex                 g_queue_mutex;
+static std::condition_variable    g_queue_cv;
+static std::atomic<bool>          g_producer_done{false};
+
+static void workerThread(const std::string& base_url, int n_users) {
+    while (true) {
+        WorkItem item;
+        {
+            std::unique_lock<std::mutex> lk(g_queue_mutex);
+            g_queue_cv.wait(lk,[]{return !g_work_queue.empty()||g_producer_done.load();});
+            if (g_work_queue.empty()&&g_producer_done.load()) break;
+            if (g_work_queue.empty()) continue;
+            item=g_work_queue.front(); g_work_queue.pop();
+        }
+        if (g_stop.load()) continue;
+        Measurement m;
+        if (item.type==ReqType::USER_TIMELINE) m=doUserTimelineRead(base_url, rbnchId(item.user_idx));
+        else if (item.type==ReqType::HOME_TIMELINE) m=doHomeTimelineRead(base_url, rbnchId(item.user_idx));
+        else m=doCompose(base_url, rbnchUser(item.user_idx), rbnchId(item.user_idx), item.counter);
+        {
+            std::lock_guard<std::mutex> lk(g_meas_mutex);
+            g_measurements.push_back(m);
+        }
+    }
+}
+
+// Open-loop token bucket: 50% user-timeline, 40% home-timeline, 10% compose
+static void tokenBucketProducer(const LoadConfig& cfg, bool warmup, std::mt19937& rng) {
+    int duration = warmup ? cfg.warmup_sec : cfg.duration_sec;
+    double interval_us = 1000000.0 / cfg.target_rps;
+    auto deadline = std::chrono::steady_clock::now()+std::chrono::seconds(duration);
+    auto next_issue = std::chrono::steady_clock::now();
+    std::uniform_int_distribution<int> user_dist(0, cfg.n_users-1);
+    std::uniform_real_distribution<double> type_dist(0.0,1.0);
+    int counter=0;
+    while (std::chrono::steady_clock::now()<deadline) {
+        auto now=std::chrono::steady_clock::now();
+        if (now<next_issue) std::this_thread::sleep_for(next_issue-now);
+        next_issue+=std::chrono::microseconds((long long)interval_us);
+        WorkItem item;
+        item.user_idx=user_dist(rng);
+        item.counter=counter++;
+        double r=type_dist(rng);
+        if      (r<0.50) item.type=ReqType::USER_TIMELINE;
+        else if (r<0.90) item.type=ReqType::HOME_TIMELINE;
+        else             item.type=ReqType::COMPOSE;
+        {std::lock_guard<std::mutex> lk(g_queue_mutex); g_work_queue.push(item);}
+        g_queue_cv.notify_one();
+    }
+}
+
+static std::pair<double,double> dockerStats() {
+    FILE* p=popen("docker stats --no-stream --format \"{{json .}}\" 2>/dev/null","r");
+    if (!p) return {0,0};
+    double cpu=0,mem=0; char buf[4096];
+    while (fgets(buf,sizeof(buf),p)) {
+        std::string line(buf);
+        if (line.find("socialnetwork")==std::string::npos) continue;
+        try {
+            auto j=json::parse(line);
+            std::string cs=j.value("CPUPerc","0%");
+            cs.erase(std::remove(cs.begin(),cs.end(),'%'),cs.end());
+            cpu+=std::stod(cs);
+            std::string ms=j.value("MemUsage","0B / 0B").substr(0,j.value("MemUsage","0B / 0B").find('/'));
+            ms.erase(0,ms.find_first_not_of(" \t")); ms.erase(ms.find_last_not_of(" \t\r\n")+1);
+            double mb=0;
+            if (ms.find("GiB")!=std::string::npos) mb=std::stod(ms)*1024;
+            else if (ms.find("MiB")!=std::string::npos) mb=std::stod(ms);
+            else if (ms.find("KiB")!=std::string::npos) mb=std::stod(ms)/1024;
+            mem+=mb;
+        } catch(...) {}
+    }
+    pclose(p); return {cpu,mem};
+}
+
+static void dockerPoller(std::vector<std::pair<double,double>>& samples, std::atomic<bool>& stop) {
+    while (!stop.load()) {
+        samples.push_back(dockerStats());
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+}
+
+int main(int argc, char* argv[]) {
+    for (int i=1; i<argc; i++) {
+        std::string a=argv[i];
+        if (a=="--base-url"&&i+1<argc) BASE_URL=argv[++i];
+        else if (a=="--load-level"&&i+1<argc) LOAD_LEVEL=argv[++i];
+        else if (a=="--seed"&&i+1<argc) SEED=std::stoi(argv[++i]);
+        else if (a=="--skip-setup") SKIP_SETUP=true;
+    }
+
+    auto it=LOAD_LEVELS.find(LOAD_LEVEL);
+    if (it==LOAD_LEVELS.end()) { std::cerr<<"Unknown load level: "<<LOAD_LEVEL<<"\n"; return 1; }
+    const LoadConfig& cfg=it->second;
+
+    curl_global_init(CURL_GLOBAL_ALL);
+
+    std::cout<<"# Social Network Read-Timeline Benchmark (Issue #48)\n";
+    std::cout<<"# load_level="<<LOAD_LEVEL<<" target_rps="<<cfg.target_rps
+             <<" duration="<<cfg.duration_sec<<"s warmup="<<cfg.warmup_sec<<"s\n";
+    std::cout<<"# workload: 50% user-timeline-read, 40% home-timeline-read, 10% compose\n";
+    std::cout.flush();
+
+    if (!SKIP_SETUP) setupUsers(cfg);
+
+    int n_workers=std::min(cfg.target_rps*2, 256);
+    std::mt19937 rng(SEED);
+
+    auto launchWorkers=[&](){
+        std::vector<std::thread> ws;
+        for (int i=0;i<n_workers;i++) ws.emplace_back(workerThread,BASE_URL,cfg.n_users);
+        return ws;
+    };
+
+    // Warmup
+    std::cout<<"# Warming up for "<<cfg.warmup_sec<<"s...\n"; std::cout.flush();
+    g_stop.store(true); g_producer_done.store(false);
+    { auto ws=launchWorkers(); g_stop.store(false); tokenBucketProducer(cfg,true,rng);
+      g_producer_done.store(true); g_queue_cv.notify_all(); for(auto&w:ws)w.join(); }
+    { std::lock_guard<std::mutex> lk(g_meas_mutex); g_measurements.clear(); }
+    g_producer_done.store(false); g_stop.store(false);
+
+    // Measured run
+    std::cout<<"# Measuring for "<<cfg.duration_sec<<"s...\n"; std::cout.flush();
+    std::vector<std::pair<double,double>> docker_samples;
+    std::atomic<bool> docker_stop{false};
+    std::thread docker_thread(dockerPoller,std::ref(docker_samples),std::ref(docker_stop));
+
+    auto wall_start=std::chrono::steady_clock::now();
+    { auto ws=launchWorkers(); tokenBucketProducer(cfg,false,rng);
+      g_producer_done.store(true); g_queue_cv.notify_all(); for(auto&w:ws)w.join(); }
+    double wall_sec=std::chrono::duration<double>(std::chrono::steady_clock::now()-wall_start).count();
+
+    docker_stop.store(true); docker_thread.join();
+    docker_samples.push_back(dockerStats());
+
+    std::vector<Measurement> meas;
+    { std::lock_guard<std::mutex> lk(g_meas_mutex); meas=g_measurements; }
+
+    std::vector<double> all_read, utl_lat, htl_lat, utl_thrift, htl_thrift, cmp_lat;
+    int total_ok=0,total_err=0,utl_ok=0,htl_ok=0,cmp_ok=0;
+
+    for (auto& m:meas) {
+        bool ok=(m.status==200);
+        if (ok) total_ok++; else total_err++;
+        if (m.type==ReqType::USER_TIMELINE) {
+            utl_lat.push_back(m.latency_ms); all_read.push_back(m.latency_ms);
+            if (ok){utl_ok++;if(m.thrift_ms>0)utl_thrift.push_back(m.thrift_ms);}
+        } else if (m.type==ReqType::HOME_TIMELINE) {
+            htl_lat.push_back(m.latency_ms); all_read.push_back(m.latency_ms);
+            if (ok){htl_ok++;if(m.thrift_ms>0)htl_thrift.push_back(m.thrift_ms);}
+        } else {
+            cmp_lat.push_back(m.latency_ms);
+            if (ok) cmp_ok++;
+        }
+    }
+
+    auto sAll=all_read;   std::sort(sAll.begin(),sAll.end());
+    auto sUtl=utl_lat;    std::sort(sUtl.begin(),sUtl.end());
+    auto sHtl=htl_lat;    std::sort(sHtl.begin(),sHtl.end());
+    auto sUth=utl_thrift; std::sort(sUth.begin(),sUth.end());
+    auto sHth=htl_thrift; std::sort(sHth.begin(),sHth.end());
+
+    double cpu_peak=0,cpu_avg=0,mem_peak=0,mem_avg=0;
+    if (!docker_samples.empty()) {
+        for (auto& s:docker_samples){cpu_peak=std::max(cpu_peak,s.first);mem_peak=std::max(mem_peak,s.second);}
+        cpu_avg=std::accumulate(docker_samples.begin(),docker_samples.end(),0.0,
+            [](double a,const std::pair<double,double>& b){return a+b.first;})/docker_samples.size();
+        mem_avg=std::accumulate(docker_samples.begin(),docker_samples.end(),0.0,
+            [](double a,const std::pair<double,double>& b){return a+b.second;})/docker_samples.size();
+    }
+
+    // PRIMARY: combined read p50
+    emit("p50_ms",              percentile(sAll,50.0));
+    emit("p95_ms",              percentile(sAll,95.0));
+    emit("p99_ms",              percentile(sAll,99.0));
+    emit("p999_ms",             percentile(sAll,99.9));
+
+    emit("user_timeline_p50_ms",  percentile(sUtl,50.0));
+    emit("user_timeline_p90_ms",  percentile(sUtl,90.0));
+    emit("user_timeline_p95_ms",  percentile(sUtl,95.0));
+    emit("user_timeline_p99_ms",  percentile(sUtl,99.0));
+    emit("user_timeline_p999_ms", percentile(sUtl,99.9));
+
+    emit("home_timeline_p50_ms",  percentile(sHtl,50.0));
+    emit("home_timeline_p90_ms",  percentile(sHtl,90.0));
+    emit("home_timeline_p95_ms",  percentile(sHtl,95.0));
+    emit("home_timeline_p99_ms",  percentile(sHtl,99.0));
+    emit("home_timeline_p999_ms", percentile(sHtl,99.9));
+
+    // Intermediate latency (Thrift hop from nginx to service)
+    emit("user_timeline_thrift_p50_ms",  percentile(sUth,50.0));
+    emit("user_timeline_thrift_p95_ms",  percentile(sUth,95.0));
+    emit("user_timeline_thrift_p99_ms",  percentile(sUth,99.0));
+    emit("user_timeline_thrift_p999_ms", percentile(sUth,99.9));
+
+    emit("home_timeline_thrift_p50_ms",  percentile(sHth,50.0));
+    emit("home_timeline_thrift_p95_ms",  percentile(sHth,95.0));
+    emit("home_timeline_thrift_p99_ms",  percentile(sHth,99.0));
+    emit("home_timeline_thrift_p999_ms", percentile(sHth,99.9));
+
+    double total_req=(double)meas.size();
+    emit("throughput_rps",            total_req/wall_sec);
+    emit("read_throughput_rps",       (double)(utl_lat.size()+htl_lat.size())/wall_sec);
+    emit("user_timeline_rps",         (double)utl_lat.size()/wall_sec);
+    emit("home_timeline_rps",         (double)htl_lat.size()/wall_sec);
+    emit("success_count",             (double)total_ok);
+    emit("error_count",               (double)total_err);
+    emit("success_rate",              total_req>0?(double)total_ok/total_req:0.0);
+    emit("user_timeline_success_rate",utl_lat.empty()?0.0:(double)utl_ok/utl_lat.size());
+    emit("home_timeline_success_rate",htl_lat.empty()?0.0:(double)htl_ok/htl_lat.size());
+
+    emit("cpu_percent",               cpu_peak);
+    emit("cpu_percent_avg",           cpu_avg);
+    emit("memory_mb",                 mem_peak);
+    emit("memory_mb_avg",             mem_avg);
+    emit("docker_samples",            (double)docker_samples.size());
+    emit("wall_time_sec",             wall_sec);
+    emit("total_requests",            total_req);
+
+    std::cout<<"\n# Primary metric (p50_ms): "<<std::fixed<<std::setprecision(2)<<percentile(sAll,50.0)<<"\n";
+    std::cout<<"# user_timeline_thrift_p50_ms: "<<percentile(sUth,50.0)<<"\n";
+    std::cout<<"# home_timeline_thrift_p50_ms: "<<percentile(sHth,50.0)<<"\n";
+
+    curl_global_cleanup();
+    return 0;
+}

--- a/examples/social-network-read-timeline/include/percentile.h
+++ b/examples/social-network-read-timeline/include/percentile.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <vector>
+#include <algorithm>
+#include <numeric>
+#include <cmath>
+
+inline double percentile(std::vector<double>& sorted_vals, double pct) {
+    if (sorted_vals.empty()) return 0.0;
+    if (pct <= 0.0) return sorted_vals.front();
+    if (pct >= 100.0) return sorted_vals.back();
+    double idx = (pct/100.0)*(sorted_vals.size()-1);
+    size_t lo = (size_t)std::floor(idx);
+    size_t hi = lo+1;
+    if (hi >= sorted_vals.size()) return sorted_vals.back();
+    return sorted_vals[lo] + (idx-lo)*(sorted_vals[hi]-sorted_vals[lo]);
+}
+
+inline double vmean(const std::vector<double>& v) {
+    if (v.empty()) return 0.0;
+    return std::accumulate(v.begin(),v.end(),0.0)/v.size();
+}

--- a/examples/social-network-read-timeline/include/social_network_client.h
+++ b/examples/social-network-read-timeline/include/social_network_client.h
@@ -1,0 +1,195 @@
+#pragma once
+#include <string>
+#include <map>
+#include <vector>
+#include <chrono>
+#include <thread>
+#include <sstream>
+#include <curl/curl.h>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+struct HttpResponse {
+    int status;
+    std::string body;
+    std::map<std::string, std::string> headers;
+    double latency_ms;
+};
+
+static size_t writeCallback(void* contents, size_t size, size_t nmemb, std::string* s) {
+    s->append(static_cast<char*>(contents), size * nmemb);
+    return size * nmemb;
+}
+
+static size_t headerCallback(char* buffer, size_t size, size_t nitems,
+                              std::map<std::string,std::string>* headers) {
+    std::string line(buffer, size * nitems);
+    auto colon = line.find(':');
+    if (colon != std::string::npos) {
+        std::string key = line.substr(0, colon);
+        std::string val = line.substr(colon + 1);
+        while (!val.empty() && (val.front()==' '||val.front()=='\t')) val.erase(0,1);
+        while (!val.empty() && (val.back()=='\r'||val.back()=='\n'||val.back()==' ')) val.pop_back();
+        (*headers)[key] = val;
+    }
+    return size * nitems;
+}
+
+inline HttpResponse httpGet(const std::string& url, int timeout_ms = 10000) {
+    HttpResponse resp; resp.status = 0; resp.latency_ms = 0;
+    CURL* curl = curl_easy_init();
+    if (!curl) return resp;
+    auto t0 = std::chrono::high_resolution_clock::now();
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resp.body);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, headerCallback);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &resp.headers);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, timeout_ms);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    CURLcode res = curl_easy_perform(curl);
+    auto t1 = std::chrono::high_resolution_clock::now();
+    resp.latency_ms = std::chrono::duration<double,std::milli>(t1-t0).count();
+    if (res == CURLE_OK) { long c; curl_easy_getinfo(curl,CURLINFO_RESPONSE_CODE,&c); resp.status=(int)c; }
+    curl_easy_cleanup(curl);
+    return resp;
+}
+
+inline std::string urlEncode(const std::string& s) {
+    CURL* curl = curl_easy_init(); std::string r;
+    if (curl) { char* e=curl_easy_escape(curl,s.c_str(),(int)s.size()); if(e){r=e;curl_free(e);} curl_easy_cleanup(curl); }
+    return r;
+}
+
+inline std::string buildForm(const std::map<std::string,std::string>& p) {
+    std::string b;
+    for (auto& kv:p) { if(!b.empty())b+='&'; b+=urlEncode(kv.first)+'='+urlEncode(kv.second); }
+    return b;
+}
+
+inline HttpResponse httpPost(const std::string& url,
+                              const std::map<std::string,std::string>& form,
+                              int timeout_ms = 10000) {
+    HttpResponse resp; resp.status = 0; resp.latency_ms = 0;
+    CURL* curl = curl_easy_init();
+    if (!curl) return resp;
+    std::string body = buildForm(form);
+    auto t0 = std::chrono::high_resolution_clock::now();
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resp.body);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, headerCallback);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &resp.headers);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, timeout_ms);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    CURLcode res = curl_easy_perform(curl);
+    auto t1 = std::chrono::high_resolution_clock::now();
+    resp.latency_ms = std::chrono::duration<double,std::milli>(t1-t0).count();
+    if (res == CURLE_OK) { long c; curl_easy_getinfo(curl,CURLINFO_RESPONSE_CODE,&c); resp.status=(int)c; }
+    curl_easy_cleanup(curl);
+    return resp;
+}
+
+struct SocialNetworkClient {
+    std::string base_url;
+    explicit SocialNetworkClient(const std::string& u) : base_url(u) {}
+
+    bool registerUser(const std::string& username, const std::string& password,
+                      int user_id, const std::string& first, const std::string& last) {
+        auto r = httpPost(base_url+"/wrk2-api/user/register",
+            {{"username",username},{"password",password},
+             {"user_id",std::to_string(user_id)},{"first_name",first},{"last_name",last}});
+        return r.status==200 && r.body.find("Success")!=std::string::npos;
+    }
+
+    bool followByName(const std::string& user, const std::string& followee) {
+        auto r = httpPost(base_url+"/wrk2-api/user/follow",
+            {{"user_name",user},{"followee_name",followee}});
+        return r.status==200 && r.body.find("Success")!=std::string::npos;
+    }
+
+    bool unfollowByName(const std::string& user, const std::string& followee) {
+        auto r = httpPost(base_url+"/wrk2-api/user/unfollow",
+            {{"user_name",user},{"followee_name",followee}});
+        return r.status==200;
+    }
+
+    HttpResponse composePost(const std::string& username, int user_id, const std::string& text) {
+        return httpPost(base_url+"/wrk2-api/post/compose",
+            {{"username",username},{"user_id",std::to_string(user_id)},
+             {"text",text},{"media_ids","[]"},{"media_types","[]"},{"post_type","0"}});
+    }
+
+    json readUserTimeline(int user_id, int start=0, int stop=50) {
+        auto r = httpGet(base_url+"/wrk2-api/user-timeline/read?user_id="+
+            std::to_string(user_id)+"&start="+std::to_string(start)+"&stop="+std::to_string(stop));
+        if (r.status!=200) return json::array();
+        try {
+            auto j = json::parse(r.body);
+            if (j.is_object()&&j.empty()) return json::array();
+            return j;
+        } catch(...) { return json::array(); }
+    }
+
+    json readHomeTimeline(int user_id, int start=0, int stop=50) {
+        auto r = httpGet(base_url+"/wrk2-api/home-timeline/read?user_id="+
+            std::to_string(user_id)+"&start="+std::to_string(start)+"&stop="+std::to_string(stop));
+        if (r.status!=200) return json::array();
+        try {
+            auto j = json::parse(r.body);
+            if (j.is_object()&&j.empty()) return json::array();
+            return j;
+        } catch(...) { return json::array(); }
+    }
+
+    std::string findLatestPostId(int user_id) {
+        auto tl = readUserTimeline(user_id, 0, 1);
+        if (tl.is_array()&&!tl.empty()&&tl[0].contains("post_id"))
+            return tl[0]["post_id"].get<std::string>();
+        return "";
+    }
+
+    // check-api: does NOT query DB directly — goes through Thrift service layer
+    bool checkUserTimelineContains(int user_id, const std::string& post_id) {
+        auto r = httpGet(base_url+"/check-api/user-timeline/contains?user_id="+
+            std::to_string(user_id)+"&post_id="+urlEncode(post_id));
+        if (r.status!=200) return false;
+        try { auto j=json::parse(r.body); return j.value("found",false); } catch(...) { return false; }
+    }
+
+    bool checkHomeTimelineContains(int user_id, const std::string& post_id) {
+        auto r = httpGet(base_url+"/check-api/home-timeline/contains?user_id="+
+            std::to_string(user_id)+"&post_id="+urlEncode(post_id));
+        if (r.status!=200) return false;
+        try { auto j=json::parse(r.body); return j.value("found",false); } catch(...) { return false; }
+    }
+
+    bool pollHomeTimelineContains(int user_id, const std::string& post_id,
+                                   int timeout_ms=5000, int poll_ms=100) {
+        auto deadline = std::chrono::steady_clock::now()+std::chrono::milliseconds(timeout_ms);
+        while (std::chrono::steady_clock::now()<deadline) {
+            if (checkHomeTimelineContains(user_id, post_id)) return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(poll_ms));
+        }
+        return false;
+    }
+
+    std::vector<std::string> getFollowees(int user_id) {
+        std::vector<std::string> result;
+        auto r = httpGet(base_url+"/check-api/social-graph/get_followees?user_id="+std::to_string(user_id));
+        if (r.status!=200) return result;
+        try {
+            auto arr=json::parse(r.body);
+            if (arr.is_array()) for (auto& v:arr) result.push_back(v.get<std::string>());
+        } catch(...) {}
+        return result;
+    }
+
+    bool timelineContainsPost(const json& tl, const std::string& post_id) {
+        if (!tl.is_array()) return false;
+        for (auto& p:tl) if (p.contains("post_id")&&p["post_id"].get<std::string>()==post_id) return true;
+        return false;
+    }
+};

--- a/examples/social-network-read-timeline/nginx_patches/apply_patches.sh
+++ b/examples/social-network-read-timeline/nginx_patches/apply_patches.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+NGINX_CONTAINER="socialnetwork-nginx-thrift-1"
+PATCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Applying nginx_patches to $NGINX_CONTAINER ..."
+
+docker exec "$NGINX_CONTAINER" mkdir -p \
+  /usr/local/openresty/nginx/lua-scripts/check-api/social-graph \
+  /usr/local/openresty/nginx/lua-scripts/check-api/user-timeline \
+  /usr/local/openresty/nginx/lua-scripts/check-api/home-timeline
+
+docker cp "$PATCH_DIR/check-api/social-graph/get_followees.lua" \
+  "$NGINX_CONTAINER:/usr/local/openresty/nginx/lua-scripts/check-api/social-graph/get_followees.lua"
+docker cp "$PATCH_DIR/check-api/user-timeline/contains.lua" \
+  "$NGINX_CONTAINER:/usr/local/openresty/nginx/lua-scripts/check-api/user-timeline/contains.lua"
+docker cp "$PATCH_DIR/check-api/home-timeline/contains.lua" \
+  "$NGINX_CONTAINER:/usr/local/openresty/nginx/lua-scripts/check-api/home-timeline/contains.lua"
+
+docker cp "$PATCH_DIR/timed-scripts/compose.lua" \
+  "$NGINX_CONTAINER:/usr/local/openresty/nginx/lua-scripts/wrk2-api/post/compose.lua"
+docker cp "$PATCH_DIR/timed-scripts/user_timeline_read.lua" \
+  "$NGINX_CONTAINER:/usr/local/openresty/nginx/lua-scripts/wrk2-api/user-timeline/read.lua"
+docker cp "$PATCH_DIR/timed-scripts/home_timeline_read.lua" \
+  "$NGINX_CONTAINER:/usr/local/openresty/nginx/lua-scripts/wrk2-api/home-timeline/read.lua"
+
+docker cp "$NGINX_CONTAINER:/usr/local/openresty/nginx/conf/nginx.conf" /tmp/nginx.conf.pulled
+
+python3 - "$PATCH_DIR/nginx_check_api_blocks.conf" << 'PYEOF'
+import sys
+blocks_path = sys.argv[1]
+with open('/tmp/nginx.conf.pulled') as f:
+    content = f.read()
+with open(blocks_path) as f:
+    blocks = f.read()
+
+if '/check-api/social-graph/get_followees' not in content:
+    marker = 'location /wrk2-api/home-timeline/read'
+    content = content.replace(marker, blocks.strip('\n') + '\n\n    ' + marker)
+
+with open('/tmp/nginx.conf.patched', 'w') as f:
+    f.write(content)
+
+print("check-api blocks present:", '/check-api/social-graph/get_followees' in content)
+PYEOF
+
+docker cp /tmp/nginx.conf.patched "$NGINX_CONTAINER:/usr/local/openresty/nginx/conf/nginx.conf.new"
+docker exec "$NGINX_CONTAINER" cp \
+  /usr/local/openresty/nginx/conf/nginx.conf.new \
+  /usr/local/openresty/nginx/conf/nginx.conf
+
+docker exec "$NGINX_CONTAINER" /usr/local/openresty/nginx/sbin/nginx -t
+docker exec "$NGINX_CONTAINER" /usr/local/openresty/nginx/sbin/nginx -s reload
+
+echo "Patches applied and nginx reloaded."
+echo "Verifying..."
+sleep 2
+
+curl -s "http://localhost:8080/check-api/social-graph/get_followees?user_id=1" && echo " <- get_followees OK"

--- a/examples/social-network-read-timeline/nginx_patches/check-api/home-timeline/contains.lua
+++ b/examples/social-network-read-timeline/nginx_patches/check-api/home-timeline/contains.lua
@@ -1,0 +1,51 @@
+local _M = {}
+local k8s_suffix = os.getenv("fqdn_suffix")
+if (k8s_suffix == nil) then k8s_suffix = "" end
+
+function _M.Contains()
+  local ngx = ngx
+  local GenericObjectPool = require "GenericObjectPool"
+  local social_network_HomeTimelineService = require "social_network_HomeTimelineService"
+  local HomeTimelineServiceClient = social_network_HomeTimelineService.HomeTimelineServiceClient
+  local bridge_tracer = require "opentracing_bridge_tracer"
+  local liblualongnumber = require "liblualongnumber"
+
+  local args = ngx.req.get_uri_args()
+  local user_id = tonumber(args.user_id)
+  local post_id_str = tostring(args.post_id or "")
+
+  local req_id = tonumber(string.sub(ngx.var.request_id, 0, 15), 16)
+  local tracer = bridge_tracer.new_from_global()
+  local parent_span_context = tracer:binary_extract(ngx.var.opentracing_binary_context)
+  local span = tracer:start_span("check_ht_contains", {["references"] = {{"child_of", parent_span_context}}})
+  local carrier = {}
+  tracer:text_map_inject(span:context(), carrier)
+
+  local client = GenericObjectPool:connection(HomeTimelineServiceClient, "home-timeline-service" .. k8s_suffix, 9090)
+  local status, ret = pcall(client.ReadHomeTimeline, client, req_id, user_id, 0, 200, carrier)
+
+  if not status then
+    pcall(function() client.iprot.trans:close() end)
+    span:finish()
+    ngx.header.content_type = "application/json; charset=utf-8"
+    ngx.say('{"found":false}')
+    ngx.exit(ngx.HTTP_OK)
+  end
+
+  GenericObjectPool:returnConnection(client)
+  span:finish()
+
+  local found = false
+  for _, post in ipairs(ret) do
+    if tostring(post.post_id) == post_id_str then
+      found = true
+      break
+    end
+  end
+
+  ngx.header.content_type = "application/json; charset=utf-8"
+  ngx.say('{"found":' .. tostring(found) .. '}')
+  ngx.exit(ngx.HTTP_OK)
+end
+
+return _M

--- a/examples/social-network-read-timeline/nginx_patches/check-api/social-graph/get_followees.lua
+++ b/examples/social-network-read-timeline/nginx_patches/check-api/social-graph/get_followees.lua
@@ -1,0 +1,52 @@
+local _M = {}
+local k8s_suffix = os.getenv("fqdn_suffix")
+if (k8s_suffix == nil) then k8s_suffix = "" end
+
+function _M.GetFollowees()
+  local ngx = ngx
+  local GenericObjectPool = require "GenericObjectPool"
+  local SocialGraphServiceClient = require "social_network_SocialGraphService".SocialGraphServiceClient
+  local cjson = require "cjson"
+  local bridge_tracer = require "opentracing_bridge_tracer"
+  local liblualongnumber = require "liblualongnumber"
+
+  local args = ngx.req.get_uri_args()
+  local user_id = tonumber(args.user_id)
+  if user_id == nil then
+    ngx.status = ngx.HTTP_BAD_REQUEST
+    ngx.say('{"error":"missing user_id"}')
+    ngx.exit(ngx.HTTP_BAD_REQUEST)
+  end
+
+  local req_id = tonumber(string.sub(ngx.var.request_id, 0, 15), 16)
+  local tracer = bridge_tracer.new_from_global()
+  local parent_span_context = tracer:binary_extract(ngx.var.opentracing_binary_context)
+  local span = tracer:start_span("check_get_followees", {["references"] = {{"child_of", parent_span_context}}})
+  local carrier = {}
+  tracer:text_map_inject(span:context(), carrier)
+
+  local client = GenericObjectPool:connection(SocialGraphServiceClient, "social-graph-service" .. k8s_suffix, 9090)
+  local status, ret = pcall(client.GetFollowees, client, req_id, user_id, carrier)
+
+  if not status then
+    pcall(function() client.iprot.trans:close() end)
+    span:finish()
+    ngx.header.content_type = "application/json; charset=utf-8"
+    ngx.say("[]")
+    ngx.exit(ngx.HTTP_OK)
+  end
+
+  GenericObjectPool:returnConnection(client)
+  span:finish()
+
+  local followee_list = {}
+  for _, fid in ipairs(ret) do
+    table.insert(followee_list, tostring(fid))
+  end
+
+  ngx.header.content_type = "application/json; charset=utf-8"
+  ngx.say(cjson.encode(followee_list))
+  ngx.exit(ngx.HTTP_OK)
+end
+
+return _M

--- a/examples/social-network-read-timeline/nginx_patches/check-api/user-timeline/contains.lua
+++ b/examples/social-network-read-timeline/nginx_patches/check-api/user-timeline/contains.lua
@@ -1,0 +1,51 @@
+local _M = {}
+local k8s_suffix = os.getenv("fqdn_suffix")
+if (k8s_suffix == nil) then k8s_suffix = "" end
+
+function _M.Contains()
+  local ngx = ngx
+  local GenericObjectPool = require "GenericObjectPool"
+  local social_network_UserTimelineService = require "social_network_UserTimelineService"
+  local UserTimelineServiceClient = social_network_UserTimelineService.UserTimelineServiceClient
+  local bridge_tracer = require "opentracing_bridge_tracer"
+  local liblualongnumber = require "liblualongnumber"
+
+  local args = ngx.req.get_uri_args()
+  local user_id = tonumber(args.user_id)
+  local post_id_str = tostring(args.post_id or "")
+
+  local req_id = tonumber(string.sub(ngx.var.request_id, 0, 15), 16)
+  local tracer = bridge_tracer.new_from_global()
+  local parent_span_context = tracer:binary_extract(ngx.var.opentracing_binary_context)
+  local span = tracer:start_span("check_ut_contains", {["references"] = {{"child_of", parent_span_context}}})
+  local carrier = {}
+  tracer:text_map_inject(span:context(), carrier)
+
+  local client = GenericObjectPool:connection(UserTimelineServiceClient, "user-timeline-service" .. k8s_suffix, 9090)
+  local status, ret = pcall(client.ReadUserTimeline, client, req_id, user_id, 0, 200, carrier)
+
+  if not status then
+    pcall(function() client.iprot.trans:close() end)
+    span:finish()
+    ngx.header.content_type = "application/json; charset=utf-8"
+    ngx.say('{"found":false}')
+    ngx.exit(ngx.HTTP_OK)
+  end
+
+  GenericObjectPool:returnConnection(client)
+  span:finish()
+
+  local found = false
+  for _, post in ipairs(ret) do
+    if tostring(post.post_id) == post_id_str then
+      found = true
+      break
+    end
+  end
+
+  ngx.header.content_type = "application/json; charset=utf-8"
+  ngx.say('{"found":' .. tostring(found) .. '}')
+  ngx.exit(ngx.HTTP_OK)
+end
+
+return _M

--- a/examples/social-network-read-timeline/nginx_patches/nginx_check_api_blocks.conf
+++ b/examples/social-network-read-timeline/nginx_patches/nginx_check_api_blocks.conf
@@ -1,0 +1,21 @@
+
+    location /check-api/social-graph/get_followees {
+      content_by_lua '
+          local client = require "check-api/social-graph/get_followees"
+          client.GetFollowees();
+      ';
+    }
+
+    location /check-api/user-timeline/contains {
+      content_by_lua '
+          local client = require "check-api/user-timeline/contains"
+          client.Contains();
+      ';
+    }
+
+    location /check-api/home-timeline/contains {
+      content_by_lua '
+          local client = require "check-api/home-timeline/contains"
+          client.Contains();
+      ';
+    }

--- a/examples/social-network-read-timeline/nginx_patches/timed-scripts/compose.lua
+++ b/examples/social-network-read-timeline/nginx_patches/timed-scripts/compose.lua
@@ -1,0 +1,84 @@
+local _M = {}
+local k8s_suffix = os.getenv("fqdn_suffix")
+if (k8s_suffix == nil) then
+  k8s_suffix = ""
+end
+
+local function _StrIsEmpty(s)
+  return s == nil or s == ''
+end
+
+function _M.ComposePost()
+  local bridge_tracer = require "opentracing_bridge_tracer"
+  local ngx = ngx
+  local cjson = require "cjson"
+
+  local GenericObjectPool = require "GenericObjectPool"
+  local social_network_ComposePostService = require "social_network_ComposePostService"
+  local ComposePostServiceClient = social_network_ComposePostService.ComposePostServiceClient
+
+  GenericObjectPool:setMaxTotal(512)
+
+  local req_id = tonumber(string.sub(ngx.var.request_id, 0, 15), 16)
+  local tracer = bridge_tracer.new_from_global()
+  local parent_span_context = tracer:binary_extract(ngx.var.opentracing_binary_context)
+
+  ngx.req.read_body()
+  local post = ngx.req.get_post_args()
+
+  if (_StrIsEmpty(post.user_id) or _StrIsEmpty(post.username) or
+      _StrIsEmpty(post.post_type) or _StrIsEmpty(post.text)) then
+    ngx.status = ngx.HTTP_BAD_REQUEST
+    ngx.say("Incomplete arguments")
+    ngx.log(ngx.ERR, "Incomplete arguments")
+    ngx.exit(ngx.HTTP_BAD_REQUEST)
+  end
+
+  local status, ret
+
+  local client = GenericObjectPool:connection(
+      ComposePostServiceClient, "compose-post-service" .. k8s_suffix, 9090)
+
+  local span = tracer:start_span("compose_post_client",
+      { ["references"] = { { "child_of", parent_span_context } } })
+  local carrier = {}
+  tracer:text_map_inject(span:context(), carrier)
+
+  local t_before = ngx.now()
+
+  if (not _StrIsEmpty(post.media_ids) and not _StrIsEmpty(post.media_types)) then
+    status, ret = pcall(client.ComposePost, client,
+        req_id, post.username, tonumber(post.user_id), post.text,
+        cjson.decode(post.media_ids), cjson.decode(post.media_types),
+        tonumber(post.post_type), carrier)
+  else
+    status, ret = pcall(client.ComposePost, client,
+        req_id, post.username, tonumber(post.user_id), post.text,
+        {}, {}, tonumber(post.post_type), carrier)
+  end
+
+  local t_after = ngx.now()
+  local thrift_ms = math.floor((t_after - t_before) * 1000)
+
+  if not status then
+    ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR
+    if (ret.message) then
+      ngx.say("compost_post failure: " .. ret.message)
+      ngx.log(ngx.ERR, "compost_post failure: " .. ret.message)
+    else
+      ngx.say("compost_post failure: " .. ret)
+      ngx.log(ngx.ERR, "compost_post failure: " .. ret)
+    end
+    client.iprot.trans:close()
+    ngx.exit(ngx.status)
+  end
+
+  GenericObjectPool:returnConnection(client)
+  ngx.status = ngx.HTTP_OK
+  ngx.header["X-Compose-Thrift-Ms"] = tostring(thrift_ms)
+  ngx.say("Successfully upload post")
+  span:finish()
+  ngx.exit(ngx.status)
+end
+
+return _M

--- a/examples/social-network-read-timeline/nginx_patches/timed-scripts/home_timeline_read.lua
+++ b/examples/social-network-read-timeline/nginx_patches/timed-scripts/home_timeline_read.lua
@@ -1,0 +1,98 @@
+local _M = {}
+local k8s_suffix = os.getenv("fqdn_suffix")
+if (k8s_suffix == nil) then k8s_suffix = "" end
+
+local function _StrIsEmpty(s) return s == nil or s == '' end
+
+local function _LoadTimeline(data)
+  local timeline = {}
+  for _, timeline_post in ipairs(data) do
+    local new_post = {}
+    new_post["post_id"] = tostring(timeline_post.post_id)
+    new_post["creator"] = {}
+    new_post["creator"]["user_id"] = tostring(timeline_post.creator.user_id)
+    new_post["creator"]["username"] = timeline_post.creator.username
+    new_post["req_id"] = tostring(timeline_post.req_id)
+    new_post["text"] = timeline_post.text
+    new_post["user_mentions"] = {}
+    for _, user_mention in ipairs(timeline_post.user_mentions) do
+      local new_user_mention = {}
+      new_user_mention["user_id"] = tostring(user_mention.user_id)
+      new_user_mention["username"] = user_mention.username
+      table.insert(new_post["user_mentions"], new_user_mention)
+    end
+    new_post["media"] = {}
+    for _, media in ipairs(timeline_post.media) do
+      local new_media = {}
+      new_media["media_id"] = tostring(media.media_id)
+      new_media["media_type"] = media.media_type
+      table.insert(new_post["media"], new_media)
+    end
+    new_post["urls"] = {}
+    for _, url in ipairs(timeline_post.urls) do
+      local new_url = {}
+      new_url["shortened_url"] = url.shortened_url
+      new_url["expanded_url"] = url.expanded_url
+      table.insert(new_post["urls"], new_url)
+    end
+    new_post["timestamp"] = tostring(timeline_post.timestamp)
+    new_post["post_type"] = timeline_post.post_type
+    table.insert(timeline, new_post)
+  end
+  return timeline
+end
+
+function _M.ReadHomeTimeline()
+  local bridge_tracer = require "opentracing_bridge_tracer"
+  local ngx = ngx
+  local GenericObjectPool = require "GenericObjectPool"
+  local social_network_HomeTimelineService = require "social_network_HomeTimelineService"
+  local HomeTimelineServiceClient = social_network_HomeTimelineService.HomeTimelineServiceClient
+  local cjson = require "cjson"
+  local liblualongnumber = require "liblualongnumber"
+
+  local req_id = tonumber(string.sub(ngx.var.request_id, 0, 15), 16)
+  local tracer = bridge_tracer.new_from_global()
+  local parent_span_context = tracer:binary_extract(ngx.var.opentracing_binary_context)
+  local span = tracer:start_span("read_home_timeline_client", {["references"] = {{"child_of", parent_span_context}}})
+  local carrier = {}
+  tracer:text_map_inject(span:context(), carrier)
+
+  ngx.req.read_body()
+  local args = ngx.req.get_uri_args()
+
+  if (_StrIsEmpty(args.user_id) or _StrIsEmpty(args.start) or _StrIsEmpty(args.stop)) then
+    ngx.status = ngx.HTTP_BAD_REQUEST
+    ngx.say("Incomplete arguments")
+    ngx.exit(ngx.HTTP_BAD_REQUEST)
+  end
+
+  local client = GenericObjectPool:connection(HomeTimelineServiceClient, "home-timeline-service" .. k8s_suffix, 9090)
+  local t_before = ngx.now()
+  local status, ret = pcall(client.ReadHomeTimeline, client, req_id,
+      tonumber(args.user_id), tonumber(args.start), tonumber(args.stop), carrier)
+  local t_after = ngx.now()
+  local thrift_ms = math.floor((t_after - t_before) * 1000)
+
+  if not status then
+    ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR
+    if (ret.message) then
+      ngx.say("Get home-timeline failure: " .. ret.message)
+    else
+      ngx.say("Get home-timeline failure: " .. ret)
+    end
+    client.iprot.trans:close()
+    span:finish()
+    ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+  else
+    GenericObjectPool:returnConnection(client)
+    local home_timeline = _LoadTimeline(ret)
+    ngx.header.content_type = "application/json; charset=utf-8"
+    ngx.header["X-HomeTimeline-Thrift-Ms"] = tostring(thrift_ms)
+    ngx.say(cjson.encode(home_timeline))
+  end
+  span:finish()
+  ngx.exit(ngx.HTTP_OK)
+end
+
+return _M

--- a/examples/social-network-read-timeline/nginx_patches/timed-scripts/user_timeline_read.lua
+++ b/examples/social-network-read-timeline/nginx_patches/timed-scripts/user_timeline_read.lua
@@ -1,0 +1,98 @@
+local _M = {}
+local k8s_suffix = os.getenv("fqdn_suffix")
+if (k8s_suffix == nil) then k8s_suffix = "" end
+
+local function _StrIsEmpty(s) return s == nil or s == '' end
+
+local function _LoadTimeline(data)
+  local user_timeline = {}
+  for _, timeline_post in ipairs(data) do
+    local new_post = {}
+    new_post["post_id"] = tostring(timeline_post.post_id)
+    new_post["creator"] = {}
+    new_post["creator"]["user_id"] = tostring(timeline_post.creator.user_id)
+    new_post["creator"]["username"] = timeline_post.creator.username
+    new_post["req_id"] = tostring(timeline_post.req_id)
+    new_post["text"] = timeline_post.text
+    new_post["user_mentions"] = {}
+    for _, user_mention in ipairs(timeline_post.user_mentions) do
+      local new_user_mention = {}
+      new_user_mention["user_id"] = tostring(user_mention.user_id)
+      new_user_mention["username"] = user_mention.username
+      table.insert(new_post["user_mentions"], new_user_mention)
+    end
+    new_post["media"] = {}
+    for _, media in ipairs(timeline_post.media) do
+      local new_media = {}
+      new_media["media_id"] = tostring(media.media_id)
+      new_media["media_type"] = media.media_type
+      table.insert(new_post["media"], new_media)
+    end
+    new_post["urls"] = {}
+    for _, url in ipairs(timeline_post.urls) do
+      local new_url = {}
+      new_url["shortened_url"] = url.shortened_url
+      new_url["expanded_url"] = url.expanded_url
+      table.insert(new_post["urls"], new_url)
+    end
+    new_post["timestamp"] = tostring(timeline_post.timestamp)
+    new_post["post_type"] = timeline_post.post_type
+    table.insert(user_timeline, new_post)
+  end
+  return user_timeline
+end
+
+function _M.ReadUserTimeline()
+  local bridge_tracer = require "opentracing_bridge_tracer"
+  local ngx = ngx
+  local GenericObjectPool = require "GenericObjectPool"
+  local social_network_UserTimelineService = require "social_network_UserTimelineService"
+  local UserTimelineServiceClient = social_network_UserTimelineService.UserTimelineServiceClient
+  local cjson = require "cjson"
+  local liblualongnumber = require "liblualongnumber"
+
+  local req_id = tonumber(string.sub(ngx.var.request_id, 0, 15), 16)
+  local tracer = bridge_tracer.new_from_global()
+  local parent_span_context = tracer:binary_extract(ngx.var.opentracing_binary_context)
+  local span = tracer:start_span("ReadUserTimeline", {["references"] = {{"child_of", parent_span_context}}})
+  local carrier = {}
+  tracer:text_map_inject(span:context(), carrier)
+
+  ngx.req.read_body()
+  local args = ngx.req.get_uri_args()
+
+  if (_StrIsEmpty(args.user_id) or _StrIsEmpty(args.start) or _StrIsEmpty(args.stop)) then
+    ngx.status = ngx.HTTP_BAD_REQUEST
+    ngx.say("Incomplete arguments")
+    ngx.exit(ngx.HTTP_BAD_REQUEST)
+  end
+
+  local client = GenericObjectPool:connection(UserTimelineServiceClient, "user-timeline-service" .. k8s_suffix, 9090)
+  local t_before = ngx.now()
+  local status, ret = pcall(client.ReadUserTimeline, client, req_id,
+      tonumber(args.user_id), tonumber(args.start), tonumber(args.stop), carrier)
+  local t_after = ngx.now()
+  local thrift_ms = math.floor((t_after - t_before) * 1000)
+
+  if not status then
+    ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR
+    if (ret.message) then
+      ngx.say("Get user-timeline failure: " .. ret.message)
+    else
+      ngx.say("Get user-timeline failure: " .. ret)
+    end
+    client.iprot.trans:close()
+    span:finish()
+    ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+  else
+    GenericObjectPool:returnConnection(client)
+    local user_timeline = _LoadTimeline(ret)
+    ngx.header.content_type = "application/json; charset=utf-8"
+    ngx.header["X-UserTimeline-Thrift-Ms"] = tostring(thrift_ms)
+    ngx.say(cjson.encode(user_timeline))
+  end
+  span:finish()
+  ngx.exit(ngx.HTTP_OK)
+end
+
+return _M

--- a/examples/social-network-read-timeline/reference/meta.json
+++ b/examples/social-network-read-timeline/reference/meta.json
@@ -1,0 +1,89 @@
+{
+  "scenario": "social-network-read-timeline",
+  "issue": "#48",
+  "target": "DeathStarBench socialNetwork",
+  "repo": "https://github.com/delimitrou/DeathStarBench",
+  "subdir": "socialNetwork",
+  "nginx_port": 8080,
+  "deploy_cmd": "cd DeathStarBench/socialNetwork && docker compose up -d",
+  "init_cmd": "cd DeathStarBench/socialNetwork && python3 scripts/init_social_graph.py --graph=socfb-Reed98 --ip=localhost --port=8080",
+  "teardown_cmd": "cd DeathStarBench/socialNetwork && docker compose down -v",
+
+  "workload": {
+    "description": "Read-heavy. 50% user-timeline reads, 40% home-timeline reads, 10% composes to keep content fresh.",
+    "primary_metric": "p50_ms (combined read latency)",
+    "secondary_metrics": ["p95_ms", "p99_ms", "p999_ms", "throughput_rps", "success_rate", "cpu_percent", "memory_mb"]
+  },
+
+  "api": {
+    "user_timeline_read": {
+      "method": "GET",
+      "path": "/wrk2-api/user-timeline/read",
+      "params": ["user_id", "start", "stop"],
+      "timing_header": "X-UserTimeline-Thrift-Ms",
+      "response": "JSON array of post objects, descending timestamp order"
+    },
+    "home_timeline_read": {
+      "method": "GET",
+      "path": "/wrk2-api/home-timeline/read",
+      "params": ["user_id", "start", "stop"],
+      "timing_header": "X-HomeTimeline-Thrift-Ms",
+      "response": "JSON array of post objects, descending timestamp order"
+    },
+    "compose": {
+      "method": "POST",
+      "path": "/wrk2-api/post/compose",
+      "params": ["username", "user_id", "text", "media_ids", "media_types", "post_type"],
+      "response_success": "Successfully upload post",
+      "timing_header": "X-Compose-Thrift-Ms"
+    }
+  },
+
+  "check_api": {
+    "user_timeline_contains": {
+      "method": "GET",
+      "path": "/check-api/user-timeline/contains",
+      "params": ["user_id", "post_id"],
+      "response": "{\"found\": true|false}",
+      "note": "Calls UserTimeline Thrift service directly. No DB query."
+    },
+    "home_timeline_contains": {
+      "method": "GET",
+      "path": "/check-api/home-timeline/contains",
+      "params": ["user_id", "post_id"],
+      "response": "{\"found\": true|false}",
+      "note": "Calls HomeTimeline Thrift service directly. No DB query."
+    },
+    "social_graph_followees": {
+      "method": "GET",
+      "path": "/check-api/social-graph/get_followees",
+      "params": ["user_id"],
+      "response": "JSON array of followee_id strings",
+      "note": "Calls SocialGraph Thrift service. No auth required."
+    }
+  },
+
+  "post_object_schema": {
+    "post_id": "string",
+    "creator": {"user_id": "string", "username": "string"},
+    "text": "string",
+    "timestamp": "string (unix ms)",
+    "req_id": "string",
+    "user_mentions": "[] or {}",
+    "media": "[] or {}",
+    "urls": "[] or {}",
+    "post_type": "integer"
+  },
+
+  "user_namespaces": {
+    "checker": {"prefix": "rchk_", "user_id_start": 600000, "note": "timestamp-seeded to avoid reuse"},
+    "benchmark": {"prefix": "rbnch_", "user_id_start": 700000}
+  },
+
+  "known_issues": {
+    "compose_zadd_error": "Compose may return HTTP 500 with ZADD error for new users' first fan-out. Post IS written to user-timeline. Treated as soft success.",
+    "empty_timeline_as_object": "Empty timeline returns {} not [] from Lua cjson. Treated as empty array.",
+    "home_timeline_not_cleared_on_unfollow": "Unfollow does not remove existing posts from home timeline. Only stops future fan-out.",
+    "intermediate_latency_scope": "X-UserTimeline-Thrift-Ms and X-HomeTimeline-Thrift-Ms measure nginx-to-first-service hop only. Deeper service-to-service hops not instrumented."
+  }
+}


### PR DESCRIPTION
## Overview

This now has the nginx patches needed for the additional API endpoints. The system now uses `json.hpp` through CMake and a submodule is added for DeathStarBench.

Adds the `social-network-read-timeline` example: a read-heavy correctness harness and benchmark for the DeathStarBench socialNetwork stack, for issue #48.

Target: DeathStarBench `socialNetwork` (nginx + Thrift microservices). Workload: 50% user-timeline reads, 40% home-timeline reads, 10% compose to seed fresh content. Primary metric: `p50_ms` across read requests only.

## Changes

**Correctness checker** (`accuracy_checker/checker.cpp`)

11 checks covering the requirements laid out:
- C1/C2: Response shape compatibility for both timeline APIs
- C3/C4: Descending timestamp ordering for user-timeline and home-timeline
- C5: Follow visibility rules considering that home-timeline should only surface posts from followed users
- C6/C7: Write-then-read consistency for user-timeline and home-timeline fan-out
- C8: Unfollow stops future fan-out
- C9: Failed reads do not mutate application state
- C10: Pagination: disjoint non-overlapping pages across start/stop bounds
- C11: Held-out sequences (burst-read consistency + cross-user visibility) to prevent benchmark memorisation

**Benchmark** (`benchmark/benchmark.cpp`)

Token-bucket load generator with warmup + measurement phases, emitting one JSON metric per line:

- `p50_ms` / `p95_ms` / `p99_ms` across read requests (e2e HTTP latency)
- Per-type breakdowns: `user_timeline_p{50,95,99}_ms`, `home_timeline_p{50,95,99}_ms`
- Intermediate Thrift latencies via `X-UserTimeline-Thrift-Ms` / `X-HomeTimeline-Thrift-Ms` response headers: `user_timeline_thrift_p{50,95,99}_ms`, `home_timeline_thrift_p{50,95,99}_ms`
- Throughput, success/error counts, success rates, CPU, memory
- Three load levels: `light` (100 RPS / 60s), `medium` (300 RPS / 120s), `heavy` (500 RPS / 180s)

## Verified Results

All 11 checker tests pass against the reference stack. Sample benchmark output at light load:

```
{"metric":"p50_ms","value":5.64}
{"metric":"p95_ms","value":12.89}
{"metric":"p99_ms","value":29.00}
{"metric":"success_rate","value":1.00}
```

## To Run

Detailed running instructions are included in the `README.md`.
