### PR TITLE
add DeathStarBench submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "inputs/show-o2-1.5B-HQ/reference/Show-o"]
 	path = examples/show-o2-1.5B-HQ/reference/Show-o
 	url = https://github.com/showlab/Show-o.git
+[submodule "3rd_party/deathstarbench"]
+	path = 3rd_party/deathstarbench
+	url = https://github.com/delimitrou/DeathStarBench.git


### PR DESCRIPTION
## Summary

- Adds `delimitrou/DeathStarBench` as a git submodule at `3rd_party/deathstarbench`.
- Records the submodule URL in `.gitmodules` and pins the gitlink to `6ecb09706140f8730b5385c08f1386c654c3c526`.

## Validation

- `git diff --cached --check`
- `git submodule status 3rd_party/deathstarbench`
