### PR TITLE
[codex] fix queue example CI formatting

### DIFF
--- a/examples/queue-default/accuracy_checker/checker.py
+++ b/examples/queue-default/accuracy_checker/checker.py
@@ -1,34 +1,47 @@
 from __future__ import annotations
-import argparse, random, sys, threading
+
+import argparse
+import random
+import sys
+import threading
+
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent / "reference"))
-from reference import QueueFactory, SCENARIOS
+from reference import SCENARIOS, QueueFactory
+
 
 def _load_candidate():
     try:
         from main import VibeServeQueue
+
         return VibeServeQueue
     except ImportError as exc:
         raise RuntimeError("Could not import VibeServeQueue from main.py") from exc
+
 
 def _build_log(ops, seed=42):
     rng = random.Random(seed)
     return [("enqueue", i) if rng.random() < 0.6 else ("dequeue", None) for i in range(ops)]
 
+
 def _replay(queue, log):
     trace = []
     for kind, item in log:
-        if kind == "enqueue": trace.append(("enqueue", queue.enqueue(item)))
-        else: trace.append(("dequeue", queue.dequeue()))
+        if kind == "enqueue":
+            trace.append(("enqueue", queue.enqueue(item)))
+        else:
+            trace.append(("dequeue", queue.dequeue()))
     return trace
+
 
 def _check_spsc(cls, capacity, ops, seed):
     ref = QueueFactory("spsc", capacity)
     cand = cls(scenario="spsc", capacity=capacity)
     log = _build_log(ops, seed)
-    for i, (r, c) in enumerate(zip(_replay(ref, log), _replay(cand, log))):
+    for i, (r, c) in enumerate(zip(_replay(ref, log), _replay(cand, log), strict=True)):
         if r != c:
             return False, f"SPSC mismatch at op {i}: ref={r!r} cand={c!r}"
     return True, f"SPSC OK ({ops} ops, capacity={capacity})"
+
 
 def _check_mpmc(cls, capacity, ops, producers, consumers, seed):
     ipp = ops // producers
@@ -37,27 +50,36 @@ def _check_mpmc(cls, capacity, ops, producers, consumers, seed):
     cand = cls(scenario="mpmc", capacity=capacity)
     barrier = threading.Barrier(producers + consumers)
     stop = threading.Event()
+
     def producer(pid):
         barrier.wait()
         for i in range(ipp):
             item = pid * ipp + i
             if cand.enqueue(item):
-                with el: enqueued.add(item)
+                with el:
+                    enqueued.add(item)
+
     def consumer(_):
         barrier.wait()
         while not stop.is_set() or cand.size() > 0:
             x = cand.dequeue()
             if x is not None:
-                with dl: dequeued.append(x)
+                with dl:
+                    dequeued.append(x)
+
     ts = [threading.Thread(target=producer, args=(p,), daemon=True) for p in range(producers)]
     ts += [threading.Thread(target=consumer, args=(c,), daemon=True) for c in range(consumers)]
-    for t in ts: t.start()
-    for t in ts[:producers]: t.join()
+    for t in ts:
+        t.start()
+    for t in ts[:producers]:
+        t.join()
     stop.set()
-    for t in ts[producers:]: t.join(timeout=5)
+    for t in ts[producers:]:
+        t.join(timeout=5)
     while True:
         x = cand.dequeue()
-        if x is None: break
+        if x is None:
+            break
         dequeued.append(x)
     dset = set(dequeued)
     dups = len(dequeued) - len(dset)
@@ -65,10 +87,15 @@ def _check_mpmc(cls, capacity, ops, producers, consumers, seed):
     extra = dset - enqueued
     if dups or missing or extra:
         return False, f"MPMC failure: dups={dups}, missing={len(missing)}, extra={len(extra)}"
-    return True, f"MPMC OK ({producers}P/{consumers}C enqueued={len(enqueued)} dequeued={len(dequeued)})"
+    return (
+        True,
+        f"MPMC OK ({producers}P/{consumers}C enqueued={len(enqueued)} dequeued={len(dequeued)})",
+    )
+
 
 def _check_mpsc(cls, capacity, ops, producers, seed):
     return _check_mpmc(cls, capacity, ops, producers, 1, seed)
+
 
 def _check_lossy(cls, capacity, ops, seed):
     cand = cls(scenario="lossy", capacity=capacity)
@@ -77,15 +104,20 @@ def _check_lossy(cls, capacity, ops, seed):
     for i in range(ops):
         if rng.random() < 0.6:
             ok = cand.enqueue(i)
-            if not ok: return False, f"Lossy enqueue returned False at op {i}"
+            if not ok:
+                return False, f"Lossy enqueue returned False at op {i}"
             enqueued.add(i)
         else:
             x = cand.dequeue()
-            if x is not None: dequeued.append(x)
-        if cand.size() > capacity: return False, f"size {cand.size()} > capacity {capacity}"
+            if x is not None:
+                dequeued.append(x)
+        if cand.size() > capacity:
+            return False, f"size {cand.size()} > capacity {capacity}"
     fab = set(dequeued) - enqueued
-    if fab: return False, f"Lossy returned items never enqueued: {list(fab)[:5]}"
+    if fab:
+        return False, f"Lossy returned items never enqueued: {list(fab)[:5]}"
     return True, f"Lossy OK ({ops} ops, capacity={capacity}, dequeued={len(dequeued)})"
+
 
 def _check_batch(cls, capacity, ops, seed):
     cand = cls(scenario="batch", capacity=capacity)
@@ -93,19 +125,26 @@ def _check_batch(cls, capacity, ops, seed):
     enqueued, dequeued = [], []
     for i in range(ops):
         if rng.random() < 0.6:
-            if cand.enqueue(i): enqueued.append(i)
+            if cand.enqueue(i):
+                enqueued.append(i)
         else:
             batch = cand.dequeue()
-            if not isinstance(batch, list): return False, f"Batch dequeue must return list, got {type(batch).__name__}"
+            if not isinstance(batch, list):
+                return False, f"Batch dequeue must return list, got {type(batch).__name__}"
             dequeued.extend(batch)
     fab = set(dequeued) - set(enqueued)
-    if fab: return False, f"Batch returned items never enqueued: {list(fab)[:5]}"
+    if fab:
+        return False, f"Batch returned items never enqueued: {list(fab)[:5]}"
     dups = len(dequeued) - len(set(dequeued))
-    if dups: return False, f"Batch returned {dups} duplicates"
+    if dups:
+        return False, f"Batch returned {dups} duplicates"
     return True, f"Batch OK ({ops} ops, capacity={capacity}, dequeued={len(dequeued)})"
 
+
 def main():
-    parser = argparse.ArgumentParser(description="Correctness checker for VibeServe queue scenarios.")
+    parser = argparse.ArgumentParser(
+        description="Correctness checker for VibeServe queue scenarios."
+    )
     parser.add_argument("--scenario", choices=[*SCENARIOS, "all"], default="all")
     parser.add_argument("--capacity", type=int, default=64)
     parser.add_argument("--ops", type=int, default=2000)
@@ -121,11 +160,18 @@ def main():
     for s in targets:
         print(f"[{s.upper()}] Checking ...")
         try:
-            if s == "spsc":    ok, msg = _check_spsc(cls, args.capacity, args.ops, args.seed)
-            elif s == "mpmc":  ok, msg = _check_mpmc(cls, args.capacity, args.ops, args.producers, args.consumers, args.seed)
-            elif s == "mpsc":  ok, msg = _check_mpsc(cls, args.capacity, args.ops, args.producers, args.seed)
-            elif s == "lossy": ok, msg = _check_lossy(cls, args.capacity, args.ops, args.seed)
-            elif s == "batch": ok, msg = _check_batch(cls, args.capacity, args.ops, args.seed)
+            if s == "spsc":
+                ok, msg = _check_spsc(cls, args.capacity, args.ops, args.seed)
+            elif s == "mpmc":
+                ok, msg = _check_mpmc(
+                    cls, args.capacity, args.ops, args.producers, args.consumers, args.seed
+                )
+            elif s == "mpsc":
+                ok, msg = _check_mpsc(cls, args.capacity, args.ops, args.producers, args.seed)
+            elif s == "lossy":
+                ok, msg = _check_lossy(cls, args.capacity, args.ops, args.seed)
+            elif s == "batch":
+                ok, msg = _check_batch(cls, args.capacity, args.ops, args.seed)
         except Exception as e:
             ok, msg = False, f"Exception: {e}"
         print(f"  PASS - {msg}" if ok else f"  FAIL - {msg}")
@@ -133,6 +179,7 @@ def main():
     passed = sum(results.values())
     print(f"Results: {passed}/{len(results)} passed")
     sys.exit(0 if passed == len(results) else 1)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/queue-default/benchmark/benchmark.py
+++ b/examples/queue-default/benchmark/benchmark.py
@@ -1,28 +1,44 @@
 from __future__ import annotations
-import argparse, json, sys, threading, time
+
+import argparse
+import json
+import sys
+import threading
+import time
+
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent / "reference"))
-from reference import QueueFactory, SCENARIOS
+from reference import SCENARIOS, QueueFactory
+
 
 def _load_candidate():
     try:
         from main import VibeServeQueue
+
         return VibeServeQueue
     except ImportError:
         return None
 
+
 def _producer(queue, item, stop, c, lock):
     enc, drp = 0, 0
     while not stop.is_set():
-        if queue.enqueue(item): enc += 1
-        else: drp += 1
-    with lock: c[0] += enc; c[1] += drp
+        if queue.enqueue(item):
+            enc += 1
+        else:
+            drp += 1
+    with lock:
+        c[0] += enc
+        c[1] += drp
+
 
 def _consumer(queue, stop, c, lock, is_batch):
     dec = 0
     while not stop.is_set() or queue.size() > 0:
         r = queue.dequeue()
         dec += len(r) if is_batch else (1 if r is not None else 0)
-    with lock: c[0] += dec
+    with lock:
+        c[0] += dec
+
 
 def _run(queue, scenario, duration, warmup, producers, consumers, item_bytes):
     is_batch = scenario == "batch"
@@ -30,32 +46,60 @@ def _run(queue, scenario, duration, warmup, producers, consumers, item_bytes):
     stop = threading.Event()
     lock = threading.Lock()
     pc, dc = [0, 0], [0]
+
     def make():
-        ts = [threading.Thread(target=_producer, args=(queue, item, stop, pc, lock), daemon=True) for _ in range(producers)]
-        ts += [threading.Thread(target=_consumer, args=(queue, stop, dc, lock, is_batch), daemon=True) for _ in range(consumers)]
+        ts = [
+            threading.Thread(target=_producer, args=(queue, item, stop, pc, lock), daemon=True)
+            for _ in range(producers)
+        ]
+        ts += [
+            threading.Thread(target=_consumer, args=(queue, stop, dc, lock, is_batch), daemon=True)
+            for _ in range(consumers)
+        ]
         return ts
+
     if warmup > 0:
         wts = make()
-        for t in wts: t.start()
+        for t in wts:
+            t.start()
         time.sleep(warmup)
         stop.set()
-        for t in wts: t.join(timeout=2)
-        stop.clear(); pc[:] = [0, 0]; dc[:] = [0]
+        for t in wts:
+            t.join(timeout=2)
+        stop.clear()
+        pc[:] = [0, 0]
+        dc[:] = [0]
     ts = make()
-    for t in ts: t.start()
+    for t in ts:
+        t.start()
     t0 = time.perf_counter()
     time.sleep(duration)
     stop.set()
-    for t in ts: t.join(timeout=5)
+    for t in ts:
+        t.join(timeout=5)
     elapsed = time.perf_counter() - t0
     enc, drp, dec = pc[0], pc[1], dc[0]
-    print(f"Scenario: {scenario.upper()}  Duration: {elapsed:.1f}s  Prod: {producers}  Cons: {consumers}")
-    print(f"  Enqueued: {enc:,} ({enc/elapsed:,.0f} ops/s)  Dropped: {drp:,}  Dequeued: {dec:,} ({dec/elapsed:,.0f} ops/s)")
-    print(f"  Total: {enc+dec:,} ({(enc+dec)/elapsed:,.0f} ops/s)")
-    return {"scenario": scenario, "enqueued": enc, "dropped": drp, "dequeued": dec, "duration": elapsed, "total_ops_per_sec": (enc+dec)/elapsed}
+    print(
+        f"Scenario: {scenario.upper()}  Duration: {elapsed:.1f}s  Prod: {producers}  Cons: {consumers}"
+    )
+    print(
+        f"  Enqueued: {enc:,} ({enc / elapsed:,.0f} ops/s)  Dropped: {drp:,}  Dequeued: {dec:,} ({dec / elapsed:,.0f} ops/s)"
+    )
+    print(f"  Total: {enc + dec:,} ({(enc + dec) / elapsed:,.0f} ops/s)")
+    return {
+        "scenario": scenario,
+        "enqueued": enc,
+        "dropped": drp,
+        "dequeued": dec,
+        "duration": elapsed,
+        "total_ops_per_sec": (enc + dec) / elapsed,
+    }
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Throughput benchmark for VibeServe queue scenarios.")
+    parser = argparse.ArgumentParser(
+        description="Throughput benchmark for VibeServe queue scenarios."
+    )
     parser.add_argument("--scenario", choices=[*SCENARIOS, "all"], default="spsc")
     parser.add_argument("--capacity", type=int, default=1024)
     parser.add_argument("--item-bytes", type=int, default=64)
@@ -78,8 +122,10 @@ def main():
             q = cls(scenario=s, capacity=args.capacity) if cls else QueueFactory(s, args.capacity)
         results.append(_run(q, s, args.duration, args.warmup, n_prod, n_cons, args.item_bytes))
     if args.output_json:
-        with open(args.output_json, "w") as f: json.dump(results, f, indent=2)
+        with open(args.output_json, "w") as f:
+            json.dump(results, f, indent=2)
         print(f"Results written to {args.output_json}")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/queue-default/reference/reference.py
+++ b/examples/queue-default/reference/reference.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
+
 import threading
 from collections import deque
-from typing import Any
+
 
 class _BoundedQueue:
     def __init__(self, capacity):
-        if capacity <= 0: raise ValueError(f"capacity must be > 0, got {capacity}")
+        if capacity <= 0:
+            raise ValueError(f"capacity must be > 0, got {capacity}")
         self.capacity = capacity
         self._dq = deque()
         self._lock = threading.Lock()
@@ -15,8 +17,12 @@ class _BoundedQueue:
     def enqueue(self, item, block=False, timeout=None):
         with self._not_full:
             if len(self._dq) >= self.capacity:
-                if not block: return False
-                if not self._not_full.wait_for(lambda: len(self._dq) < self.capacity, timeout=timeout): return False
+                if not block:
+                    return False
+                if not self._not_full.wait_for(
+                    lambda: len(self._dq) < self.capacity, timeout=timeout
+                ):
+                    return False
             self._dq.append(item)
             self._not_empty.notify()
             return True
@@ -24,52 +30,90 @@ class _BoundedQueue:
     def dequeue(self, block=False, timeout=None):
         with self._not_empty:
             if not self._dq:
-                if not block: return None
-                if not self._not_empty.wait_for(lambda: bool(self._dq), timeout=timeout): return None
+                if not block:
+                    return None
+                if not self._not_empty.wait_for(lambda: bool(self._dq), timeout=timeout):
+                    return None
             item = self._dq.popleft()
             self._not_full.notify()
             return item
 
     def size(self):
-        with self._lock: return len(self._dq)
+        with self._lock:
+            return len(self._dq)
 
-class SPSCQueue(_BoundedQueue): pass
-class MPMCQueue(_BoundedQueue): pass
-class MPSCQueue(_BoundedQueue): pass
+
+class SPSCQueue(_BoundedQueue):
+    pass
+
+
+class MPMCQueue(_BoundedQueue):
+    pass
+
+
+class MPSCQueue(_BoundedQueue):
+    pass
+
 
 class LossyQueue:
     def __init__(self, capacity):
-        if capacity <= 0: raise ValueError(f"capacity must be > 0, got {capacity}")
+        if capacity <= 0:
+            raise ValueError(f"capacity must be > 0, got {capacity}")
         self.capacity = capacity
         self._dq = deque(maxlen=capacity)
         self._lock = threading.Lock()
+
     def enqueue(self, item, **_):
-        with self._lock: self._dq.append(item)
+        with self._lock:
+            self._dq.append(item)
         return True
+
     def dequeue(self, **_):
-        with self._lock: return self._dq.popleft() if self._dq else None
+        with self._lock:
+            return self._dq.popleft() if self._dq else None
+
     def size(self):
-        with self._lock: return len(self._dq)
+        with self._lock:
+            return len(self._dq)
+
 
 class BatchSPSCQueue:
     def __init__(self, capacity):
-        if capacity <= 0: raise ValueError(f"capacity must be > 0, got {capacity}")
+        if capacity <= 0:
+            raise ValueError(f"capacity must be > 0, got {capacity}")
         self.capacity = capacity
         self._dq = deque()
         self._lock = threading.Lock()
+
     def enqueue(self, item, **_):
         with self._lock:
-            if len(self._dq) >= self.capacity: return False
-            self._dq.append(item); return True
+            if len(self._dq) >= self.capacity:
+                return False
+            self._dq.append(item)
+            return True
+
     def dequeue(self, **_):
         with self._lock:
-            if not self._dq: return []
-            batch = list(self._dq); self._dq.clear(); return batch
-    def size(self):
-        with self._lock: return len(self._dq)
+            if not self._dq:
+                return []
+            batch = list(self._dq)
+            self._dq.clear()
+            return batch
 
-_SCENARIO_MAP = {"spsc": SPSCQueue, "mpmc": MPMCQueue, "mpsc": MPSCQueue, "lossy": LossyQueue, "batch": BatchSPSCQueue}
+    def size(self):
+        with self._lock:
+            return len(self._dq)
+
+
+_SCENARIO_MAP = {
+    "spsc": SPSCQueue,
+    "mpmc": MPMCQueue,
+    "mpsc": MPSCQueue,
+    "lossy": LossyQueue,
+    "batch": BatchSPSCQueue,
+}
 SCENARIOS = list(_SCENARIO_MAP)
+
 
 def QueueFactory(scenario, capacity=1024):
     cls = _SCENARIO_MAP.get(scenario)


### PR DESCRIPTION
## Summary
- format queue example checker, benchmark, and reference files with Ruff
- fix follow-on lint issues in the checker/reference examples

## Root cause
CI failed at the Python formatting step because the queue example files had unsorted imports and compact formatting that Ruff rejects.

## Validation
- ./scripts/check_format.sh
- ./scripts/check_lint.sh
- uv run python -m pytest -v --cov=vibe_serve --cov-report=term-missing --cov-report=xml --cov-fail-under=75