### PR TITLE
Collapse model config to a single [model].name; remove [agent].cli_model (closes #78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ name = "cuda"                 # or "metal" for Apple Silicon (local exec only)
 [agent]
 backend = "cli"               # "cli" (codex/claude/gemini/opencode) or "deepagents"
 cli_provider = "codex"        # which coding-agent harness to drive
-# cli_model = "gpt-5-codex"   # override the model the CLI tool uses
+# cli_model = "gpt-5-codex"   # optional override; defaults to model.name
 # cli_timeout = 1800          # per-invocation timeout (seconds)
 
 # Optional: benchmark load levels handed to the perf evaluator.

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ For multi-objective evolutionary runs, drop an `objectives.toml` next to `OBJECT
 
 ```toml
 [model]
-name = "claude-sonnet-4-6"   # auto-detected provider for claude-* / gpt-* / gemini-*
-# provider = "anthropic"     # optional override
+name = "gpt-5.4"             # auto-detected provider for claude-* / gpt-* / gemini-*
+# provider = "openai"        # optional override
 
 [backend]
 name = "cuda"                 # or "metal" for Apple Silicon (local exec only)
@@ -130,7 +130,6 @@ name = "cuda"                 # or "metal" for Apple Silicon (local exec only)
 [agent]
 backend = "cli"               # "cli" (codex/claude/gemini/opencode) or "deepagents"
 cli_provider = "codex"        # which coding-agent harness to drive
-# cli_model = "gpt-5-codex"   # optional override; defaults to model.name
 # cli_timeout = 1800          # per-invocation timeout (seconds)
 
 # Optional: benchmark load levels handed to the perf evaluator.

--- a/examples/queue-default/accuracy_checker/checker.py
+++ b/examples/queue-default/accuracy_checker/checker.py
@@ -1,34 +1,47 @@
 from __future__ import annotations
-import argparse, random, sys, threading
+
+import argparse
+import random
+import sys
+import threading
+
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent / "reference"))
-from reference import QueueFactory, SCENARIOS
+from reference import SCENARIOS, QueueFactory
+
 
 def _load_candidate():
     try:
         from main import VibeServeQueue
+
         return VibeServeQueue
     except ImportError as exc:
         raise RuntimeError("Could not import VibeServeQueue from main.py") from exc
+
 
 def _build_log(ops, seed=42):
     rng = random.Random(seed)
     return [("enqueue", i) if rng.random() < 0.6 else ("dequeue", None) for i in range(ops)]
 
+
 def _replay(queue, log):
     trace = []
     for kind, item in log:
-        if kind == "enqueue": trace.append(("enqueue", queue.enqueue(item)))
-        else: trace.append(("dequeue", queue.dequeue()))
+        if kind == "enqueue":
+            trace.append(("enqueue", queue.enqueue(item)))
+        else:
+            trace.append(("dequeue", queue.dequeue()))
     return trace
+
 
 def _check_spsc(cls, capacity, ops, seed):
     ref = QueueFactory("spsc", capacity)
     cand = cls(scenario="spsc", capacity=capacity)
     log = _build_log(ops, seed)
-    for i, (r, c) in enumerate(zip(_replay(ref, log), _replay(cand, log))):
+    for i, (r, c) in enumerate(zip(_replay(ref, log), _replay(cand, log), strict=True)):
         if r != c:
             return False, f"SPSC mismatch at op {i}: ref={r!r} cand={c!r}"
     return True, f"SPSC OK ({ops} ops, capacity={capacity})"
+
 
 def _check_mpmc(cls, capacity, ops, producers, consumers, seed):
     ipp = ops // producers
@@ -37,27 +50,36 @@ def _check_mpmc(cls, capacity, ops, producers, consumers, seed):
     cand = cls(scenario="mpmc", capacity=capacity)
     barrier = threading.Barrier(producers + consumers)
     stop = threading.Event()
+
     def producer(pid):
         barrier.wait()
         for i in range(ipp):
             item = pid * ipp + i
             if cand.enqueue(item):
-                with el: enqueued.add(item)
+                with el:
+                    enqueued.add(item)
+
     def consumer(_):
         barrier.wait()
         while not stop.is_set() or cand.size() > 0:
             x = cand.dequeue()
             if x is not None:
-                with dl: dequeued.append(x)
+                with dl:
+                    dequeued.append(x)
+
     ts = [threading.Thread(target=producer, args=(p,), daemon=True) for p in range(producers)]
     ts += [threading.Thread(target=consumer, args=(c,), daemon=True) for c in range(consumers)]
-    for t in ts: t.start()
-    for t in ts[:producers]: t.join()
+    for t in ts:
+        t.start()
+    for t in ts[:producers]:
+        t.join()
     stop.set()
-    for t in ts[producers:]: t.join(timeout=5)
+    for t in ts[producers:]:
+        t.join(timeout=5)
     while True:
         x = cand.dequeue()
-        if x is None: break
+        if x is None:
+            break
         dequeued.append(x)
     dset = set(dequeued)
     dups = len(dequeued) - len(dset)
@@ -65,10 +87,15 @@ def _check_mpmc(cls, capacity, ops, producers, consumers, seed):
     extra = dset - enqueued
     if dups or missing or extra:
         return False, f"MPMC failure: dups={dups}, missing={len(missing)}, extra={len(extra)}"
-    return True, f"MPMC OK ({producers}P/{consumers}C enqueued={len(enqueued)} dequeued={len(dequeued)})"
+    return (
+        True,
+        f"MPMC OK ({producers}P/{consumers}C enqueued={len(enqueued)} dequeued={len(dequeued)})",
+    )
+
 
 def _check_mpsc(cls, capacity, ops, producers, seed):
     return _check_mpmc(cls, capacity, ops, producers, 1, seed)
+
 
 def _check_lossy(cls, capacity, ops, seed):
     cand = cls(scenario="lossy", capacity=capacity)
@@ -77,15 +104,20 @@ def _check_lossy(cls, capacity, ops, seed):
     for i in range(ops):
         if rng.random() < 0.6:
             ok = cand.enqueue(i)
-            if not ok: return False, f"Lossy enqueue returned False at op {i}"
+            if not ok:
+                return False, f"Lossy enqueue returned False at op {i}"
             enqueued.add(i)
         else:
             x = cand.dequeue()
-            if x is not None: dequeued.append(x)
-        if cand.size() > capacity: return False, f"size {cand.size()} > capacity {capacity}"
+            if x is not None:
+                dequeued.append(x)
+        if cand.size() > capacity:
+            return False, f"size {cand.size()} > capacity {capacity}"
     fab = set(dequeued) - enqueued
-    if fab: return False, f"Lossy returned items never enqueued: {list(fab)[:5]}"
+    if fab:
+        return False, f"Lossy returned items never enqueued: {list(fab)[:5]}"
     return True, f"Lossy OK ({ops} ops, capacity={capacity}, dequeued={len(dequeued)})"
+
 
 def _check_batch(cls, capacity, ops, seed):
     cand = cls(scenario="batch", capacity=capacity)
@@ -93,19 +125,26 @@ def _check_batch(cls, capacity, ops, seed):
     enqueued, dequeued = [], []
     for i in range(ops):
         if rng.random() < 0.6:
-            if cand.enqueue(i): enqueued.append(i)
+            if cand.enqueue(i):
+                enqueued.append(i)
         else:
             batch = cand.dequeue()
-            if not isinstance(batch, list): return False, f"Batch dequeue must return list, got {type(batch).__name__}"
+            if not isinstance(batch, list):
+                return False, f"Batch dequeue must return list, got {type(batch).__name__}"
             dequeued.extend(batch)
     fab = set(dequeued) - set(enqueued)
-    if fab: return False, f"Batch returned items never enqueued: {list(fab)[:5]}"
+    if fab:
+        return False, f"Batch returned items never enqueued: {list(fab)[:5]}"
     dups = len(dequeued) - len(set(dequeued))
-    if dups: return False, f"Batch returned {dups} duplicates"
+    if dups:
+        return False, f"Batch returned {dups} duplicates"
     return True, f"Batch OK ({ops} ops, capacity={capacity}, dequeued={len(dequeued)})"
 
+
 def main():
-    parser = argparse.ArgumentParser(description="Correctness checker for VibeServe queue scenarios.")
+    parser = argparse.ArgumentParser(
+        description="Correctness checker for VibeServe queue scenarios."
+    )
     parser.add_argument("--scenario", choices=[*SCENARIOS, "all"], default="all")
     parser.add_argument("--capacity", type=int, default=64)
     parser.add_argument("--ops", type=int, default=2000)
@@ -121,11 +160,18 @@ def main():
     for s in targets:
         print(f"[{s.upper()}] Checking ...")
         try:
-            if s == "spsc":    ok, msg = _check_spsc(cls, args.capacity, args.ops, args.seed)
-            elif s == "mpmc":  ok, msg = _check_mpmc(cls, args.capacity, args.ops, args.producers, args.consumers, args.seed)
-            elif s == "mpsc":  ok, msg = _check_mpsc(cls, args.capacity, args.ops, args.producers, args.seed)
-            elif s == "lossy": ok, msg = _check_lossy(cls, args.capacity, args.ops, args.seed)
-            elif s == "batch": ok, msg = _check_batch(cls, args.capacity, args.ops, args.seed)
+            if s == "spsc":
+                ok, msg = _check_spsc(cls, args.capacity, args.ops, args.seed)
+            elif s == "mpmc":
+                ok, msg = _check_mpmc(
+                    cls, args.capacity, args.ops, args.producers, args.consumers, args.seed
+                )
+            elif s == "mpsc":
+                ok, msg = _check_mpsc(cls, args.capacity, args.ops, args.producers, args.seed)
+            elif s == "lossy":
+                ok, msg = _check_lossy(cls, args.capacity, args.ops, args.seed)
+            elif s == "batch":
+                ok, msg = _check_batch(cls, args.capacity, args.ops, args.seed)
         except Exception as e:
             ok, msg = False, f"Exception: {e}"
         print(f"  PASS - {msg}" if ok else f"  FAIL - {msg}")
@@ -133,6 +179,7 @@ def main():
     passed = sum(results.values())
     print(f"Results: {passed}/{len(results)} passed")
     sys.exit(0 if passed == len(results) else 1)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/queue-default/benchmark/benchmark.py
+++ b/examples/queue-default/benchmark/benchmark.py
@@ -1,28 +1,44 @@
 from __future__ import annotations
-import argparse, json, sys, threading, time
+
+import argparse
+import json
+import sys
+import threading
+import time
+
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent / "reference"))
-from reference import QueueFactory, SCENARIOS
+from reference import SCENARIOS, QueueFactory
+
 
 def _load_candidate():
     try:
         from main import VibeServeQueue
+
         return VibeServeQueue
     except ImportError:
         return None
 
+
 def _producer(queue, item, stop, c, lock):
     enc, drp = 0, 0
     while not stop.is_set():
-        if queue.enqueue(item): enc += 1
-        else: drp += 1
-    with lock: c[0] += enc; c[1] += drp
+        if queue.enqueue(item):
+            enc += 1
+        else:
+            drp += 1
+    with lock:
+        c[0] += enc
+        c[1] += drp
+
 
 def _consumer(queue, stop, c, lock, is_batch):
     dec = 0
     while not stop.is_set() or queue.size() > 0:
         r = queue.dequeue()
         dec += len(r) if is_batch else (1 if r is not None else 0)
-    with lock: c[0] += dec
+    with lock:
+        c[0] += dec
+
 
 def _run(queue, scenario, duration, warmup, producers, consumers, item_bytes):
     is_batch = scenario == "batch"
@@ -30,32 +46,60 @@ def _run(queue, scenario, duration, warmup, producers, consumers, item_bytes):
     stop = threading.Event()
     lock = threading.Lock()
     pc, dc = [0, 0], [0]
+
     def make():
-        ts = [threading.Thread(target=_producer, args=(queue, item, stop, pc, lock), daemon=True) for _ in range(producers)]
-        ts += [threading.Thread(target=_consumer, args=(queue, stop, dc, lock, is_batch), daemon=True) for _ in range(consumers)]
+        ts = [
+            threading.Thread(target=_producer, args=(queue, item, stop, pc, lock), daemon=True)
+            for _ in range(producers)
+        ]
+        ts += [
+            threading.Thread(target=_consumer, args=(queue, stop, dc, lock, is_batch), daemon=True)
+            for _ in range(consumers)
+        ]
         return ts
+
     if warmup > 0:
         wts = make()
-        for t in wts: t.start()
+        for t in wts:
+            t.start()
         time.sleep(warmup)
         stop.set()
-        for t in wts: t.join(timeout=2)
-        stop.clear(); pc[:] = [0, 0]; dc[:] = [0]
+        for t in wts:
+            t.join(timeout=2)
+        stop.clear()
+        pc[:] = [0, 0]
+        dc[:] = [0]
     ts = make()
-    for t in ts: t.start()
+    for t in ts:
+        t.start()
     t0 = time.perf_counter()
     time.sleep(duration)
     stop.set()
-    for t in ts: t.join(timeout=5)
+    for t in ts:
+        t.join(timeout=5)
     elapsed = time.perf_counter() - t0
     enc, drp, dec = pc[0], pc[1], dc[0]
-    print(f"Scenario: {scenario.upper()}  Duration: {elapsed:.1f}s  Prod: {producers}  Cons: {consumers}")
-    print(f"  Enqueued: {enc:,} ({enc/elapsed:,.0f} ops/s)  Dropped: {drp:,}  Dequeued: {dec:,} ({dec/elapsed:,.0f} ops/s)")
-    print(f"  Total: {enc+dec:,} ({(enc+dec)/elapsed:,.0f} ops/s)")
-    return {"scenario": scenario, "enqueued": enc, "dropped": drp, "dequeued": dec, "duration": elapsed, "total_ops_per_sec": (enc+dec)/elapsed}
+    print(
+        f"Scenario: {scenario.upper()}  Duration: {elapsed:.1f}s  Prod: {producers}  Cons: {consumers}"
+    )
+    print(
+        f"  Enqueued: {enc:,} ({enc / elapsed:,.0f} ops/s)  Dropped: {drp:,}  Dequeued: {dec:,} ({dec / elapsed:,.0f} ops/s)"
+    )
+    print(f"  Total: {enc + dec:,} ({(enc + dec) / elapsed:,.0f} ops/s)")
+    return {
+        "scenario": scenario,
+        "enqueued": enc,
+        "dropped": drp,
+        "dequeued": dec,
+        "duration": elapsed,
+        "total_ops_per_sec": (enc + dec) / elapsed,
+    }
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Throughput benchmark for VibeServe queue scenarios.")
+    parser = argparse.ArgumentParser(
+        description="Throughput benchmark for VibeServe queue scenarios."
+    )
     parser.add_argument("--scenario", choices=[*SCENARIOS, "all"], default="spsc")
     parser.add_argument("--capacity", type=int, default=1024)
     parser.add_argument("--item-bytes", type=int, default=64)
@@ -78,8 +122,10 @@ def main():
             q = cls(scenario=s, capacity=args.capacity) if cls else QueueFactory(s, args.capacity)
         results.append(_run(q, s, args.duration, args.warmup, n_prod, n_cons, args.item_bytes))
     if args.output_json:
-        with open(args.output_json, "w") as f: json.dump(results, f, indent=2)
+        with open(args.output_json, "w") as f:
+            json.dump(results, f, indent=2)
         print(f"Results written to {args.output_json}")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/queue-default/reference/reference.py
+++ b/examples/queue-default/reference/reference.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
+
 import threading
 from collections import deque
-from typing import Any
+
 
 class _BoundedQueue:
     def __init__(self, capacity):
-        if capacity <= 0: raise ValueError(f"capacity must be > 0, got {capacity}")
+        if capacity <= 0:
+            raise ValueError(f"capacity must be > 0, got {capacity}")
         self.capacity = capacity
         self._dq = deque()
         self._lock = threading.Lock()
@@ -15,8 +17,12 @@ class _BoundedQueue:
     def enqueue(self, item, block=False, timeout=None):
         with self._not_full:
             if len(self._dq) >= self.capacity:
-                if not block: return False
-                if not self._not_full.wait_for(lambda: len(self._dq) < self.capacity, timeout=timeout): return False
+                if not block:
+                    return False
+                if not self._not_full.wait_for(
+                    lambda: len(self._dq) < self.capacity, timeout=timeout
+                ):
+                    return False
             self._dq.append(item)
             self._not_empty.notify()
             return True
@@ -24,52 +30,90 @@ class _BoundedQueue:
     def dequeue(self, block=False, timeout=None):
         with self._not_empty:
             if not self._dq:
-                if not block: return None
-                if not self._not_empty.wait_for(lambda: bool(self._dq), timeout=timeout): return None
+                if not block:
+                    return None
+                if not self._not_empty.wait_for(lambda: bool(self._dq), timeout=timeout):
+                    return None
             item = self._dq.popleft()
             self._not_full.notify()
             return item
 
     def size(self):
-        with self._lock: return len(self._dq)
+        with self._lock:
+            return len(self._dq)
 
-class SPSCQueue(_BoundedQueue): pass
-class MPMCQueue(_BoundedQueue): pass
-class MPSCQueue(_BoundedQueue): pass
+
+class SPSCQueue(_BoundedQueue):
+    pass
+
+
+class MPMCQueue(_BoundedQueue):
+    pass
+
+
+class MPSCQueue(_BoundedQueue):
+    pass
+
 
 class LossyQueue:
     def __init__(self, capacity):
-        if capacity <= 0: raise ValueError(f"capacity must be > 0, got {capacity}")
+        if capacity <= 0:
+            raise ValueError(f"capacity must be > 0, got {capacity}")
         self.capacity = capacity
         self._dq = deque(maxlen=capacity)
         self._lock = threading.Lock()
+
     def enqueue(self, item, **_):
-        with self._lock: self._dq.append(item)
+        with self._lock:
+            self._dq.append(item)
         return True
+
     def dequeue(self, **_):
-        with self._lock: return self._dq.popleft() if self._dq else None
+        with self._lock:
+            return self._dq.popleft() if self._dq else None
+
     def size(self):
-        with self._lock: return len(self._dq)
+        with self._lock:
+            return len(self._dq)
+
 
 class BatchSPSCQueue:
     def __init__(self, capacity):
-        if capacity <= 0: raise ValueError(f"capacity must be > 0, got {capacity}")
+        if capacity <= 0:
+            raise ValueError(f"capacity must be > 0, got {capacity}")
         self.capacity = capacity
         self._dq = deque()
         self._lock = threading.Lock()
+
     def enqueue(self, item, **_):
         with self._lock:
-            if len(self._dq) >= self.capacity: return False
-            self._dq.append(item); return True
+            if len(self._dq) >= self.capacity:
+                return False
+            self._dq.append(item)
+            return True
+
     def dequeue(self, **_):
         with self._lock:
-            if not self._dq: return []
-            batch = list(self._dq); self._dq.clear(); return batch
-    def size(self):
-        with self._lock: return len(self._dq)
+            if not self._dq:
+                return []
+            batch = list(self._dq)
+            self._dq.clear()
+            return batch
 
-_SCENARIO_MAP = {"spsc": SPSCQueue, "mpmc": MPMCQueue, "mpsc": MPSCQueue, "lossy": LossyQueue, "batch": BatchSPSCQueue}
+    def size(self):
+        with self._lock:
+            return len(self._dq)
+
+
+_SCENARIO_MAP = {
+    "spsc": SPSCQueue,
+    "mpmc": MPMCQueue,
+    "mpsc": MPSCQueue,
+    "lossy": LossyQueue,
+    "batch": BatchSPSCQueue,
+}
 SCENARIOS = list(_SCENARIO_MAP)
+
 
 def QueueFactory(scenario, capacity=1024):
     cls = _SCENARIO_MAP.get(scenario)

--- a/src/vibe_serve/agents/__init__.py
+++ b/src/vibe_serve/agents/__init__.py
@@ -135,19 +135,17 @@ def build_agent_runner(
             else:
                 docker_sandboxes = backends
         timeout = agent_cfg.cli_timeout
-        # The CLI tool runs [model].name by default, same as the deepagents
-        # backend. [agent].cli_model is an optional override for the rare case
-        # where the CLI tool needs a different model identifier than the
-        # LangChain/API name. model.name is a required field (and always
-        # validated by _build_model), so cli_model is never None here.
-        cli_model = agent_cfg.cli_model or model_name
+        # The CLI tool runs [model].name, same as the deepagents backend —
+        # it's the single source of truth for the model. model.name is a
+        # required field (and always validated by _build_model), so it is
+        # always a non-empty string here.
         from .cli_runner import CliAgentRunner
 
         return CliAgentRunner(
             provider=provider,
-            model=cli_model,
+            model=model_name,
             skills=skill_source_dirs,
-            model_name=cli_model or provider,
+            model_name=model_name or provider,
             timeout=timeout,
             run_log_file=run_log_file,
             docker_sandboxes=docker_sandboxes,

--- a/src/vibe_serve/agents/__init__.py
+++ b/src/vibe_serve/agents/__init__.py
@@ -135,16 +135,19 @@ def build_agent_runner(
             else:
                 docker_sandboxes = backends
         timeout = agent_cfg.cli_timeout
-        # cli_model overrides model.name for the CLI tool. If not set,
-        # pass None so the CLI tool uses its own default.
-        cli_model = agent_cfg.cli_model
+        # The CLI tool runs [model].name by default, same as the deepagents
+        # backend. [agent].cli_model is an optional override for the rare case
+        # where the CLI tool needs a different model identifier than the
+        # LangChain/API name. model.name is a required field (and always
+        # validated by _build_model), so cli_model is never None here.
+        cli_model = agent_cfg.cli_model or model_name
         from .cli_runner import CliAgentRunner
 
         return CliAgentRunner(
             provider=provider,
             model=cli_model,
             skills=skill_source_dirs,
-            model_name=model_name or cli_model or provider,
+            model_name=cli_model or provider,
             timeout=timeout,
             run_log_file=run_log_file,
             docker_sandboxes=docker_sandboxes,

--- a/src/vibe_serve/config.py
+++ b/src/vibe_serve/config.py
@@ -163,8 +163,9 @@ class AgentCfg(_Strict):
     cli_model: str | None = Field(
         default=None,
         description=(
-            "Model the CLI tool should use; overrides model.name for the CLI agent. "
-            "None → the CLI tool's own default (no --model flag passed)."
+            "Optional override for the model the CLI tool runs. None → the CLI "
+            "agent uses model.name (same as the deepagents backend). Set this "
+            "only when the CLI tool needs a different model id than the API name."
         ),
     )
     cli_timeout: int | None = Field(

--- a/src/vibe_serve/config.py
+++ b/src/vibe_serve/config.py
@@ -160,14 +160,6 @@ class AgentCfg(_Strict):
             "The --cli-provider flag overrides; defaults to 'codex'."
         ),
     )
-    cli_model: str | None = Field(
-        default=None,
-        description=(
-            "Optional override for the model the CLI tool runs. None → the CLI "
-            "agent uses model.name (same as the deepagents backend). Set this "
-            "only when the CLI tool needs a different model id than the API name."
-        ),
-    )
     cli_timeout: int | None = Field(
         default=None,
         description=(

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -1101,10 +1101,9 @@ class TestBuildAgentRunner:
     # --- model resolution for the cli backend ---------------------------------
     #
     # Regression coverage for the config API where [model].name did not reach
-    # the CLI tool: with cli_model unset the runner must fall back to
-    # model.name (not None, which made codex use its own built-in default),
-    # cli_model must override it, and the displayed model_name must equal the
-    # model actually passed so the run-log header can't lie.
+    # the CLI tool. [model].name is the single source of truth: it must be the
+    # model handed to the CLI tool, and the displayed model_name must equal it
+    # so the run-log header can't report a model that isn't running.
 
     @staticmethod
     def _cli_runner(config, *, model_name):
@@ -1122,44 +1121,22 @@ class TestBuildAgentRunner:
         )
 
     @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
-    def test_cli_model_falls_back_to_model_name(self, provider):
+    def test_cli_backend_uses_model_name(self, provider):
         runner = self._cli_runner(
             _agent_config(backend="cli", cli_provider=provider),
             model_name="gpt-5.4",
         )
         assert runner._model == "gpt-5.4"
 
-    def test_cli_model_overrides_model_name(self):
-        runner = self._cli_runner(
-            _agent_config(backend="cli", cli_provider="codex", cli_model="gpt-5.5"),
-            model_name="gpt-5.4",
-        )
-        assert runner._model == "gpt-5.5"
-
     def test_displayed_model_name_matches_model_passed(self):
         # The run-log header prints _model_name; it must equal the model
-        # actually handed to the CLI tool in both the fallback and override
-        # cases so the log never reports a model that isn't running.
-        fallback = self._cli_runner(
+        # actually handed to the CLI tool so the log never reports a model
+        # that isn't running.
+        runner = self._cli_runner(
             _agent_config(backend="cli", cli_provider="codex"),
             model_name="gpt-5.4",
         )
-        assert fallback._model_name == fallback._model == "gpt-5.4"
-
-        override = self._cli_runner(
-            _agent_config(backend="cli", cli_provider="codex", cli_model="gpt-5.5"),
-            model_name="gpt-5.4",
-        )
-        assert override._model_name == override._model == "gpt-5.5"
-
-    def test_empty_cli_model_falls_back_to_model_name(self):
-        # An empty-string override must resolve to model.name, not an empty
-        # --model value handed to the CLI tool.
-        runner = self._cli_runner(
-            _agent_config(backend="cli", cli_provider="codex", cli_model=""),
-            model_name="gpt-5.4",
-        )
-        assert runner._model == "gpt-5.4"
+        assert runner._model_name == runner._model == "gpt-5.4"
 
 
 class TestAgentLoggerEventHandler:

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -1098,6 +1098,69 @@ class TestBuildAgentRunner:
                 use_docker=False,
             )
 
+    # --- model resolution for the cli backend ---------------------------------
+    #
+    # Regression coverage for the config API where [model].name did not reach
+    # the CLI tool: with cli_model unset the runner must fall back to
+    # model.name (not None, which made codex use its own built-in default),
+    # cli_model must override it, and the displayed model_name must equal the
+    # model actually passed so the run-log header can't lie.
+
+    @staticmethod
+    def _cli_runner(config, *, model_name):
+        return build_agent_runner(
+            config,
+            agent_backend=None,
+            cli_provider=None,
+            backends=None,
+            skills=[],
+            skill_source_dirs=[],
+            model=None,
+            model_name=model_name,
+            run_log_file=None,
+            use_docker=False,
+        )
+
+    @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
+    def test_cli_model_falls_back_to_model_name(self, provider):
+        runner = self._cli_runner(
+            _agent_config(backend="cli", cli_provider=provider),
+            model_name="gpt-5.4",
+        )
+        assert runner._model == "gpt-5.4"
+
+    def test_cli_model_overrides_model_name(self):
+        runner = self._cli_runner(
+            _agent_config(backend="cli", cli_provider="codex", cli_model="gpt-5.5"),
+            model_name="gpt-5.4",
+        )
+        assert runner._model == "gpt-5.5"
+
+    def test_displayed_model_name_matches_model_passed(self):
+        # The run-log header prints _model_name; it must equal the model
+        # actually handed to the CLI tool in both the fallback and override
+        # cases so the log never reports a model that isn't running.
+        fallback = self._cli_runner(
+            _agent_config(backend="cli", cli_provider="codex"),
+            model_name="gpt-5.4",
+        )
+        assert fallback._model_name == fallback._model == "gpt-5.4"
+
+        override = self._cli_runner(
+            _agent_config(backend="cli", cli_provider="codex", cli_model="gpt-5.5"),
+            model_name="gpt-5.4",
+        )
+        assert override._model_name == override._model == "gpt-5.5"
+
+    def test_empty_cli_model_falls_back_to_model_name(self):
+        # An empty-string override must resolve to model.name, not an empty
+        # --model value handed to the CLI tool.
+        runner = self._cli_runner(
+            _agent_config(backend="cli", cli_provider="codex", cli_model=""),
+            model_name="gpt-5.4",
+        )
+        assert runner._model == "gpt-5.4"
+
 
 class TestAgentLoggerEventHandler:
     """Tests for :class:`AgentLogger` as a CLI event handler."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -134,6 +134,17 @@ class TestLoadConfigStrict:
         with pytest.raises(ValueError, match="tpu"):
             _load_config(cfg_file)
 
+    def test_removed_cli_model_key_rejected(self, tmp_path):
+        # [agent].cli_model was removed in favour of [model].name driving the
+        # CLI tool directly; stale configs that still set it must error rather
+        # than be silently ignored.
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text(
+            '[model]\nname = "gpt-5.4"\n\n[agent]\ncli_provider = "codex"\ncli_model = "gpt-5-codex"\n'
+        )
+        with pytest.raises(ValueError, match="cli_model"):
+            _load_config(cfg_file)
+
 
 class TestLoadConfigProviderDefault:
     def test_missing_provider_defaults_to_none(self, tmp_path):
@@ -247,9 +258,9 @@ budget = 2048
 
 class TestLoadConfigAgentSection:
     def test_agent_section_preserved(self, tmp_path):
-        # The [agent] table drives build_agent_runner (cli_model, cli_timeout,
-        # backend, cli_provider). _load_config must carry it through; the
-        # previous allowlist loader silently dropped it.
+        # The [agent] table drives build_agent_runner (cli_timeout, backend,
+        # cli_provider). _load_config must carry it through; the previous
+        # allowlist loader silently dropped it.
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("""\
 [model]
@@ -258,11 +269,9 @@ name = "claude-sonnet-4-6"
 [agent]
 backend = "cli"
 cli_provider = "claude"
-cli_model = "claude-opus-4-8[1m]"
 cli_timeout = 1800
 """)
         config = _load_config(cfg_file)
-        assert config.agent.cli_model == "claude-opus-4-8[1m]"
         assert config.agent.cli_timeout == 1800
         assert config.agent.backend == "cli"
         assert config.agent.cli_provider == "claude"
@@ -273,7 +282,6 @@ cli_timeout = 1800
         config = _load_config(cfg_file)
         assert config.agent.backend is None
         assert config.agent.cli_provider is None
-        assert config.agent.cli_model is None
         assert config.agent.cli_timeout is None
 
 


### PR DESCRIPTION
## Summary

Closes #78.

On the `cli` backend, the model the CLI tool ran was driven by `[agent].cli_model`, **not** `[model].name`. When `cli_model` was unset (the common case), `None` was passed and the CLI tool fell back to its own built-in default — e.g. codex ran `gpt-5.3-codex` even though the user set `[model].name = "gpt-5.4"`. The run-log header independently fell back to `[model].name`, so it printed `model: gpt-5.4` while a different model was running.

This collapses the two-model-field API to **one**: `[model].name` is now the single source of truth and drives every backend (deepagents and cli) directly. `[agent].cli_model` is removed. `_build_model(config)` already validates `[model].name` on every run regardless of backend, so this adds no new constraints, and the displayed `model_name` now equals the model actually passed.

## Behavior

| Config | Model the CLI tool runs |
|---|---|
| `[model].name = "gpt-5.4"`, cli + codex | `gpt-5.4` (was: codex's own default, e.g. `gpt-5.3-codex`) |

## Breaking change

`[agent].cli_model` is removed. Configs that still set it are **rejected** at load (strict schema, `extra="forbid"`) rather than silently ignored, so the failure is loud and points at the exact key. Migration: delete `cli_model` and set `[model].name` to the model you want the CLI tool to run.

(We considered keeping `cli_model` as an optional override defaulting to `model.name`, but a second model field is exactly what caused the original confusion; the single-field API is clearer. The CLI tool now always receives `model.name` verbatim.)

## Docs

README config example was internally inconsistent once `[model].name` drives the CLI tool — it paired a `claude-*` model with `cli_provider = "codex"`. Fixed to a codex-consistent `gpt-5.4` and dropped the `cli_model` line.

## Tests

- `tests/agents/test_agent_runners.py`: `[model].name` reaches the CLI tool (parametrized across `claude/gemini/codex/opencode`); displayed `model_name` equals the model passed.
- `tests/test_config.py`: a stale `[agent].cli_model` key is rejected.
- Full sweep: `tests/agents` + `tests/test_config.py` + `tests/loops` — 444 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
