### PR TITLE
feat(agent): add --interface mode (in-process Python vs over-the-wire service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ copying `generic.md` — no code change required.
 
 Full authoring guide: [`src/vibe_serve/loops/agent/templates/_domain/README.md`](src/vibe_serve/loops/agent/templates/_domain/README.md).
 
+## Interface — how the artifact is evaluated (and which language)
+
+The implementation language is **not** a user choice. It falls out of `--interface`,
+which sets the contract by which the accuracy checker and benchmark reach the
+built artifact:
+
+```bash
+vibe-serve --outer-loop agent --interface inprocess ...   # default: in-process Python
+vibe-serve --outer-loop agent --interface service ...     # over-the-wire, any language
+```
+
+- **`inprocess`** (default): the accuracy checker imports `main.py` directly, so
+  the implementation is Python. The prompts carry the `uv` toolchain and the
+  `VibeServeModel` import contract — vibeserve's original behaviour, unchanged.
+- **`service`**: the artifact is exercised only through its network interface, so
+  the agent picks whatever language and toolchain fit. The in-process contract and
+  the Python/torch tooling drop out of the prompts; supply an accuracy checker and
+  benchmark that probe the running service over the wire (e.g. HTTP, or the YCSB
+  harness for a key-value store).
+
 ## Per-target inputs
 
 Each evaluation target lives under `examples/<name>/`:

--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -433,6 +433,20 @@ def _build_agent_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--interface",
+        choices=["inprocess", "service"],
+        default="inprocess",
+        help=(
+            "Evaluation contract for the built artifact, which also fixes the "
+            "implementation language (you never pick a language directly). "
+            "'inprocess' (default): the accuracy checker imports main.py in "
+            "process, so the implementation is Python (uv toolchain + "
+            "VibeServeModel contract). 'service': the artifact is exercised "
+            "only over its network interface, so the agent chooses the "
+            "language; supply a checker/benchmark that probes it over the wire."
+        ),
+    )
+    parser.add_argument(
         "--inner-loop",
         choices=["multi-agent", "single-agent"],
         default="multi-agent",
@@ -497,6 +511,7 @@ def _run_agent(args: argparse.Namespace) -> None:
         backend=backend,
         modality=args.modality,
         domain=args.domain,
+        interface=args.interface,
         inner_loop=args.inner_loop,
     )
 

--- a/src/vibe_serve/loops/agent/domain.py
+++ b/src/vibe_serve/loops/agent/domain.py
@@ -109,9 +109,10 @@ def render_domain_section(domain_file: Path, role: str, **context: object) -> st
     """Render a domain file's ``## <role>`` section, or ``""`` if absent/empty.
 
     The section is rendered through Jinja with ``context`` — the same uniform
-    variable set for every role (``modality``, ``reference_path``, ``bench_path``,
-    ``accuracy_checker_path``, ``runtime_notes``; built by ``_domain_render_context``
-    in ``loop.py``) so authors can branch on the run from any section.
+    variable set for every role (``modality``, ``interface``, ``reference_path``,
+    ``bench_path``, ``accuracy_checker_path``, ``runtime_notes``; built by
+    ``_domain_render_context`` in ``loop.py``) so authors can branch on the run
+    from any section.
     ``single_agent`` falls back to ``implementer`` + ``judge`` when the
     file has no explicit ``## single_agent`` section. Leading and trailing blank
     lines are stripped — the base template owns the spacing around the

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -257,19 +257,35 @@ def _run_pre_round_decision(
     return decision
 
 
+def _profiler_prompt_template(profiler_kind: str, interface: str) -> str:
+    """Pick the standalone-profiler prompt for the run's profiler + interface.
+
+    ``torch`` is a white-box, in-process PyTorch profiler that imports the
+    implementation; under ``--interface service`` the artifact is exercised only
+    over the wire (and may not even be Python), so it falls back to the black-box
+    ``nsys`` profiler. This mirrors the single-agent prompt's
+    ``profiler_kind == "torch" and interface != "service"`` guard so both inner
+    loops treat the torch profiler the same way.
+    """
+    if interface == "service" and profiler_kind == "torch":
+        profiler_kind = "nsys"
+    return {
+        "torch": "profiler_prompt_torch.j2",
+        "neuron": "profiler_prompt_neuron.j2",
+    }.get(profiler_kind, "profiler_prompt_nsys.j2")
+
+
 def _run_profiler(
     ctx: _RunContext,
     *,
     round_number: int,
     profile_focus: str,
     modality: str,
+    interface: str,
     progress_path: Path,
     objective: str,
 ) -> ProfilerSummary | None:
-    template = {
-        "torch": "profiler_prompt_torch.j2",
-        "neuron": "profiler_prompt_neuron.j2",
-    }.get(ctx.profiler_kind, "profiler_prompt_nsys.j2")
+    template = _profiler_prompt_template(ctx.profiler_kind, interface)
     system_prompt = render_template(
         template,
         template_dir=_TEMPLATE_DIR,
@@ -674,6 +690,7 @@ def run_agent_loop(
                             profile_focus=pre_decision.profile_focus
                             or "general latency hotspots on /v1/completions",
                             modality=modality,
+                            interface=interface,
                             progress_path=progress_path,
                             objective=objective,
                         )

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -38,6 +38,13 @@ from vibe_serve.schemas import (
     Verdict,
 )
 
+# Implementation-language modes, selected by ``--interface`` (not a user-facing
+# language choice). ``inprocess`` pins Python so the accuracy checker can import
+# ``main.py`` directly; ``service`` evaluates the artifact only over the wire and
+# leaves the language to the agent.
+_INTERFACES = ("inprocess", "service")
+DEFAULT_INTERFACE = "inprocess"
+
 _INNER_LOOPS = ("multi-agent", "single-agent")
 
 _TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
@@ -285,18 +292,20 @@ def _run_profiler(
     return summary
 
 
-def _domain_render_context(ctx: _RunContext, modality: str) -> dict[str, object]:
+def _domain_render_context(ctx: _RunContext, modality: str, interface: str) -> dict[str, object]:
     """The uniform variable set every domain ``## <role>`` section is rendered with.
 
     One context contract for all roles: a pack author can branch (``{% if … %}``)
     on any of these in any role section without memorizing which the loop happens
     to pass to which role. Variables that don't apply to the current run are
     falsy (``bench_path`` / ``accuracy_checker_path`` when nothing is attached),
-    so ``{% if bench_path %}`` works everywhere. See
-    ``templates/_domain/README.md``.
+    so ``{% if bench_path %}`` works everywhere. ``interface`` lets a
+    language-agnostic pack drop its in-process/Python-specific gates under
+    ``--interface service``. See ``templates/_domain/README.md``.
     """
     return {
         "modality": modality,
+        "interface": interface,
         "reference_path": ctx.ref_name,
         "bench_path": ctx.judge_bench_path,
         "accuracy_checker_path": ctx.judge_acc_checker_path,
@@ -315,10 +324,11 @@ def _run_orchestrator_plan(
     roadmap_text: str,
     plateau_warning: str | None,
     modality: str,
+    interface: str,
     domain_path: Path,
 ) -> OrchestratorPlan:
     domain_orchestrator = render_domain_section(
-        domain_path, "orchestrator", **_domain_render_context(ctx, modality)
+        domain_path, "orchestrator", **_domain_render_context(ctx, modality, interface)
     )
     system_prompt = render_template(
         "orchestrator_plan_prompt.j2",
@@ -356,18 +366,20 @@ def _run_implementer(
     retry: int,
     plan: OrchestratorPlan,
     modality: str,
+    interface: str,
     domain_path: Path,
     feedback: str | None,
     progress_path: Path,
 ) -> ImplementerResponse:
     domain_implementer = render_domain_section(
-        domain_path, "implementer", **_domain_render_context(ctx, modality)
+        domain_path, "implementer", **_domain_render_context(ctx, modality, interface)
     )
     system_prompt = render_template(
         "implementer_prompt.j2",
         template_dir=_TEMPLATE_DIR,
         reference_path=ctx.ref_name,
         modality=modality,
+        interface=interface,
         domain_implementer=domain_implementer,
         task=plan.task,
         pass_criteria=plan.pass_criteria,
@@ -401,12 +413,13 @@ def _run_judge(
     retry: int,
     plan: OrchestratorPlan,
     modality: str,
+    interface: str,
     domain_path: Path,
     progress_path: Path,
     objective: str,
 ) -> JudgeResponse:
     domain_judge = render_domain_section(
-        domain_path, "judge", **_domain_render_context(ctx, modality)
+        domain_path, "judge", **_domain_render_context(ctx, modality, interface)
     )
     system_prompt = render_template(
         "judge_prompt.j2",
@@ -415,6 +428,7 @@ def _run_judge(
         bench_path=ctx.judge_bench_path,
         pass_criteria=plan.pass_criteria,
         modality=modality,
+        interface=interface,
         domain_judge=domain_judge,
         retry=retry,
         runtime_notes=ctx.run_environment_view.prompt_notes,
@@ -447,6 +461,7 @@ def _run_single_agent_round(
     retry: int,
     plan: OrchestratorPlan,
     modality: str,
+    interface: str,
     domain_path: Path,
     feedback: str | None,
     progress_path: Path,
@@ -460,13 +475,14 @@ def _run_single_agent_round(
     workspace write access plus shell access for benchmarks/profiling.
     """
     domain_single_agent = render_domain_section(
-        domain_path, "single_agent", **_domain_render_context(ctx, modality)
+        domain_path, "single_agent", **_domain_render_context(ctx, modality, interface)
     )
     system_prompt = render_template(
         "single_agent_round_prompt.j2",
         template_dir=_TEMPLATE_DIR,
         reference_path=ctx.ref_name,
         modality=modality,
+        interface=interface,
         domain_single_agent=domain_single_agent,
         task=plan.task,
         pass_criteria=plan.pass_criteria,
@@ -548,6 +564,7 @@ def run_agent_loop(
     modality: str = "text_generation",
     inner_loop: str = "multi-agent",
     domain: str = DEFAULT_DOMAIN,
+    interface: str = DEFAULT_INTERFACE,
 ) -> bool:
     """Run the orchestrator-driven build loop.
 
@@ -563,13 +580,27 @@ def run_agent_loop(
       invocation per retry. Pre-round decision and standalone profiler
       passes are skipped; the prior round's profile output is fed to the
       orchestrator as ``profiler_summary``.
+
+    ``interface`` selects the artifact's evaluation contract and, with it, the
+    implementation language (the user never picks a language directly):
+
+    - ``"inprocess"`` (default): the accuracy checker imports ``main.py`` in
+      process, so the implementation must be Python; the prompts carry the
+      ``uv`` toolchain and the ``VibeServeModel`` import contract.
+    - ``"service"``: the artifact is exercised only over its network interface,
+      so the agent may implement it in any language. The in-process contract and
+      the Python/torch tooling are dropped from the prompts.
     """
     if inner_loop not in _INNER_LOOPS:
         raise ValueError(
             f"Unknown inner_loop {inner_loop!r}; choose from {', '.join(_INNER_LOOPS)}"
         )
+    if interface not in _INTERFACES:
+        raise ValueError(f"Unknown interface {interface!r}; choose from {', '.join(_INTERFACES)}")
     # Resolve the domain pack once (fail fast on an unknown name/path). The
-    # per-role sections are parsed and rendered into the prompts at each call site.
+    # per-role sections are parsed and rendered into the prompts at each call
+    # site. The implementation language is not a pack — ``interface`` carries it
+    # (``inprocess`` pins Python; ``service`` leaves it to the agent).
     domain_path = resolve_domain(domain)
     run_environment = run_environment or make_run_environment_spec()
     ctx = _RunContext(
@@ -667,6 +698,7 @@ def run_agent_loop(
                     roadmap_text=roadmap_text,
                     plateau_warning=plateau_warning,
                     modality=modality,
+                    interface=interface,
                     domain_path=domain_path,
                 )
 
@@ -706,6 +738,7 @@ def run_agent_loop(
                             retry=retry,
                             plan=plan,
                             modality=modality,
+                            interface=interface,
                             domain_path=domain_path,
                             feedback=feedback,
                             progress_path=progress_path,
@@ -717,6 +750,7 @@ def run_agent_loop(
                             retry=retry,
                             plan=plan,
                             modality=modality,
+                            interface=interface,
                             domain_path=domain_path,
                             progress_path=progress_path,
                             objective=objective,
@@ -733,6 +767,7 @@ def run_agent_loop(
                             retry=retry,
                             plan=plan,
                             modality=modality,
+                            interface=interface,
                             domain_path=domain_path,
                             feedback=feedback,
                             progress_path=progress_path,

--- a/src/vibe_serve/loops/agent/templates/_domain/README.md
+++ b/src/vibe_serve/loops/agent/templates/_domain/README.md
@@ -75,6 +75,7 @@ use any of these in any section without tracking which role you're in:
 | Variable | Meaning |
 |----------|---------|
 | `modality` | The `--modality` value (e.g. `text_generation`). |
+| `interface` | The `--interface` value: `inprocess` (checker imports the code; Python) or `service` (exercised over the wire; any language). Gate in-process/Python-only requirements with `{% if interface != "service" %}`. |
 | `reference_path` | Path to the reference implementation. |
 | `bench_path` | Benchmark harness dir, or falsy if no benchmark is attached. |
 | `accuracy_checker_path` | Accuracy checker dir, or falsy if not attached. |
@@ -113,8 +114,10 @@ a private domain is just a path you pass.
 Domains cover **implementer + judge (+ single-agent + orchestrator) context**. Two adjacent
 concerns are deliberately *not* part of a domain file:
 
-- **Language/tooling** (e.g. "use `uv`/`pytest`") lives in the base prompt and is
-  the job of the (separate) language-selection work, not the domain.
+- **Language/tooling** (e.g. "use `uv`/`pytest`") is decided by the run's
+  `--interface` mode, not the domain: `inprocess` pins Python (uv toolchain +
+  in-process `VibeServeModel` contract); `service` leaves the language to the
+  agent. It is not a user-facing pack.
 - **Profiling** (nsys/torch GPU capture) is selected by `--profiler` and rendered
   by the profiler prompts, not the domain. Domain-specific profiling is future
   work tied to pluggable profilers.

--- a/src/vibe_serve/loops/agent/templates/_interface/language.j2
+++ b/src/vibe_serve/loops/agent/templates/_interface/language.j2
@@ -1,0 +1,9 @@
+{% if interface == "service" %}
+## Implementation language
+
+You are evaluated **over the wire**: the accuracy checker and benchmark exercise your service through its network interface, not by importing your code. Choose whatever implementation language, framework, and toolchain best fit the task — that decision is yours. The only hard requirement is that your service satisfies the contract the orchestrator and the domain context specify.
+
+{% else %}
+Use `uv` for Python package management. Run `uv init` if `pyproject.toml` doesn't exist yet, and `uv add` for new dependencies. Always execute scripts via `uv run`.
+
+{% endif %}

--- a/src/vibe_serve/loops/agent/templates/_modality/speech_to_text/implementer.j2
+++ b/src/vibe_serve/loops/agent/templates/_modality/speech_to_text/implementer.j2
@@ -2,6 +2,7 @@ You are an ML engineer building a FastAPI inference server for a speech-to-text 
 
 - **Own component implementations**: Implement every component of the model explicitly in your code (audio feature extraction, encoder, decoder, etc.). You may use `transformers` as a utility (e.g. for tokenizer, config parsing, weight loading), but do NOT import ready-made model classes (e.g. `WhisperModel`, `WhisperForConditionalGeneration`). Each component must be defined in your own code so it can be optimized in later rounds.
 
+{% if interface != "service" %}
 ## Accuracy-checker compatibility
 
 Your `main.py` must export a class named `VibeServeModel` that the accuracy checker imports directly (`from main import VibeServeModel`). The class must implement:
@@ -11,6 +12,7 @@ Your `main.py` must export a class named `VibeServeModel` that the accuracy chec
 
 Keep this interface working across all rounds, even as internals change.
 
+{% endif %}
 ## Common pitfalls — read carefully
 
 - **Audio loading**: Do NOT use `torchaudio.load()` — it requires `torchcodec` which is not available in many container images. Use `soundfile` (`import soundfile as sf; audio, sr = sf.read(path)`) or `librosa`. Add `soundfile` to `pyproject.toml`.

--- a/src/vibe_serve/loops/agent/templates/_modality/speech_to_text/judge.j2
+++ b/src/vibe_serve/loops/agent/templates/_modality/speech_to_text/judge.j2
@@ -1,5 +1,7 @@
 ## Modality: speech-to-text (ASR)
 
+{% if interface != "service" %}
 **Accuracy-checker interface** (always required): `main.py` must export a `VibeServeModel` class with `from_pretrained(model_dir, device, dtype)` and `transcribe(audio_path)`.
 
+{% endif %}
 **API contract**: verify whichever endpoints and response shapes the orchestrator's `pass_criteria` for this round specifies. Do NOT flag "missing" endpoints that the orchestrator did not scope in. When you need contract details for a scoped endpoint, consult `skills/serving-systems/tooling/openai-api/SKILL.md`.

--- a/src/vibe_serve/loops/agent/templates/_modality/text_generation/implementer.j2
+++ b/src/vibe_serve/loops/agent/templates/_modality/text_generation/implementer.j2
@@ -2,6 +2,7 @@ You are an ML engineer building a FastAPI inference server for a text generation
 
 - **Own layer implementations**: Implement every layer of the model architecture explicitly in your code (attention, MLP, normalization, positional embeddings, etc.). You may use `transformers` as a utility (e.g. `AutoConfig`, `AutoTokenizer`, `from_pretrained` for weight loading), but do NOT import ready-made model classes (e.g. `LlamaModel`, `LlamaAttention`). Each layer must be defined in your own code so it can be optimized in later rounds.
 
+{% if interface != "service" %}
 ## Accuracy-checker compatibility
 
 Your `main.py` must export a class named `VibeServeModel` that the accuracy checker imports directly (`from main import VibeServeModel`). The class must implement:
@@ -11,6 +12,7 @@ Your `main.py` must export a class named `VibeServeModel` that the accuracy chec
 
 Keep this interface working across all rounds, even as internals change.
 
+{% endif %}
 ## Text-generation decode invariants
 
 These apply to any `/v1/*` endpoint you implement for this modality:

--- a/src/vibe_serve/loops/agent/templates/_modality/text_generation/judge.j2
+++ b/src/vibe_serve/loops/agent/templates/_modality/text_generation/judge.j2
@@ -1,7 +1,9 @@
 ## Modality: text generation (causal LM)
 
+{% if interface != "service" %}
 **Accuracy-checker interface** (always required): `main.py` must export a `VibeServeModel` class with `from_pretrained(model_dir, device, dtype)` and `generate(input_ids, max_new_tokens=N)`.
 
+{% endif %}
 **Decode invariants** (verify on whichever endpoint the orchestrator scoped in): EOS must not appear in emitted text; stop-string truncation must run before emission; `completion_tokens` must count only emitted text, not raw sampled tokens.
 
 **API contract**: the specific endpoints and request/response shapes to verify are whatever the orchestrator's `pass_criteria` for this round specifies. Do NOT flag "missing" endpoints that the orchestrator did not scope in. If a round only scopes `/v1/completions`, do not fail it for lacking `/v1/chat/completions` or `/predict`. When you need contract details for a scoped endpoint, consult `skills/serving-systems/tooling/openai-api/SKILL.md`.

--- a/src/vibe_serve/loops/agent/templates/implementer_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/implementer_prompt.j2
@@ -1,4 +1,5 @@
 {% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
+{% if interface is not defined %}{% set interface = "inprocess" %}{% endif %}
 {% include "_modality/" ~ modality ~ "/implementer.j2" %}
 
 {% if runtime_notes %}
@@ -19,8 +20,7 @@
 
 Your working directory is the shared experiment workspace. All files you create must be here. The reference implementation is at `{{ reference_path }}`.
 
-Use `uv` for Python package management. Run `uv init` if `pyproject.toml` doesn't exist yet, and `uv add` for new dependencies. Always execute scripts via `uv run`.
-
+{% include "_interface/language.j2" %}
 {% if domain_implementer %}
 {{ domain_implementer }}
 

--- a/src/vibe_serve/loops/agent/templates/judge_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/judge_prompt.j2
@@ -1,4 +1,5 @@
 {% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
+{% if interface is not defined %}{% set interface = "inprocess" %}{% endif %}
 You are a senior code reviewer evaluating the candidate implementation.
 
 {% if objective %}

--- a/src/vibe_serve/loops/agent/templates/single_agent_round_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/single_agent_round_prompt.j2
@@ -1,5 +1,6 @@
 {% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
 {% if env_kind is not defined %}{% set env_kind = "local" %}{% endif %}
+{% if interface is not defined %}{% set interface = "inprocess" %}{% endif %}
 You are a senior engineer running ONE complete inner-loop round end-to-end. In this ablation a single agent owns three roles that are normally split across three specialists:
 
 1. **Implementer** — make the code change scoped by the orchestrator's task.
@@ -42,13 +43,14 @@ Address every item above before declaring PASS this attempt.
 
 ## Workspace
 
-The shared experiment workspace is your working directory. Reference implementation: `{{ reference_path }}`. Use `uv` for Python packaging — `uv init` if needed, `uv add` for deps, `uv run` for execution.
+The shared experiment workspace is your working directory. Reference implementation: `{{ reference_path }}`.
 
+{% include "_interface/language.j2" %}
 ## Profiling step
 
 After (and only after) the implementation passes your self-judge gates, capture a profile so the orchestrator has a bottleneck signal for the next round.
 
-{% if profiler_kind == "torch" %}
+{% if profiler_kind == "torch" and interface != "service" %}
 Use `torch.profiler` via `torch_profiler/analyze_torch_profile.py` (or the `vibeserve-torch-profiler` MCP tools when attached). Start with `tables`, then `kernels` / `operators` / `cpu_overhead` / `memory` / `summary` as relevant.
 
 {% if env_kind == "modal" %}

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/single_agent.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/single_agent.md
@@ -43,7 +43,9 @@ Do not introduce a code path that satisfies the schema or accuracy checker witho
 
 ## Workspace
 
-The shared experiment workspace is your working directory. Reference implementation: `/workspace/reference/main.py`. Use `uv` for Python packaging — `uv init` if needed, `uv add` for deps, `uv run` for execution.
+The shared experiment workspace is your working directory. Reference implementation: `/workspace/reference/main.py`.
+
+Use `uv` for Python package management. Run `uv init` if `pyproject.toml` doesn't exist yet, and `uv add` for new dependencies. Always execute scripts via `uv run`.
 
 ## Profiling step
 

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/single_agent.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/single_agent.md
@@ -38,7 +38,9 @@ Do not introduce a code path that satisfies the schema or accuracy checker witho
 
 ## Workspace
 
-The shared experiment workspace is your working directory. Reference implementation: `/workspace/reference/main.py`. Use `uv` for Python packaging — `uv init` if needed, `uv add` for deps, `uv run` for execution.
+The shared experiment workspace is your working directory. Reference implementation: `/workspace/reference/main.py`.
+
+Use `uv` for Python package management. Run `uv init` if `pyproject.toml` doesn't exist yet, and `uv add` for new dependencies. Always execute scripts via `uv run`.
 
 ## Profiling step
 

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -118,6 +118,17 @@ def test_render_role_branches_on_context():
     assert "/BENCHX" not in without_bench
 
 
+def test_render_role_branches_on_interface(tmp_path: Path):
+    """`interface` reaches domain sections, so a language-agnostic pack can drop
+    its in-process/Python-only gates under `--interface service`."""
+    f = tmp_path / "d.md"
+    f.write_text('## judge\n{% if interface != "service" %}IN_PROCESS_GATE{% endif %}\n')
+    inprocess = render_domain_section(f, "judge", interface="inprocess")
+    service = render_domain_section(f, "judge", interface="service")
+    assert "IN_PROCESS_GATE" in inprocess
+    assert "IN_PROCESS_GATE" not in service
+
+
 def test_single_agent_uses_explicit_section_when_present():
     # llm-serving.md ships a bespoke ## single_agent section
     d = resolve_domain("llm-serving")

--- a/tests/loops/agent/test_interface_modes.py
+++ b/tests/loops/agent/test_interface_modes.py
@@ -1,0 +1,225 @@
+"""Tests for ``--interface`` — the in-process-vs-service evaluation contract.
+
+The implementation language is no longer a user-facing axis (there is no
+``--language`` flag and no ``_language/`` packs). Instead the run's
+``--interface`` mode fixes the contract by which the accuracy checker and
+benchmark reach the artifact, and that contract decides the language:
+
+- ``inprocess`` (default): the checker imports ``main.py`` in process, so the
+  implementation is Python — the prompts carry the ``uv`` toolchain and the
+  ``VibeServeModel`` import contract.
+- ``service``: the artifact is exercised only over the wire, so the agent picks
+  the language — the in-process contract and the Python/uv tooling drop out and a
+  language-freedom block takes their place.
+
+These tests pin that behaviour at the prompt layer plus the CLI/loop wiring.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vibe_serve.prompts import render_template
+
+_TEMPLATE_DIR = (
+    Path(__file__).resolve().parents[3] / "src" / "vibe_serve" / "loops" / "agent" / "templates"
+)
+
+
+# --------------------------------------------------------------------------- #
+# no user-facing language axis
+# --------------------------------------------------------------------------- #
+def test_domain_module_has_no_language_axis():
+    """The implementation language is carried by ``--interface``, not a pack.
+    The domain module exposes only the domain axis — no language constants."""
+    import vibe_serve.loops.agent.domain as domain
+
+    assert not hasattr(domain, "DEFAULT_LANGUAGE")
+    assert not hasattr(domain, "LANGUAGE_DIR")
+    # the domain axis is untouched
+    assert domain.DEFAULT_DOMAIN == "llm-serving"
+
+
+def test_no_language_pack_directory():
+    assert not (_TEMPLATE_DIR / "_language").exists()
+
+
+# --------------------------------------------------------------------------- #
+# CLI wiring
+# --------------------------------------------------------------------------- #
+def test_cli_exposes_interface_not_language():
+    from vibe_serve.cli import _build_agent_parser
+
+    parser = _build_agent_parser()
+    # --interface is present with the two modes and defaults to inprocess
+    action = next(a for a in parser._actions if a.dest == "interface")
+    assert set(action.choices) == {"inprocess", "service"}
+    assert action.default == "inprocess"
+    # --language is gone
+    assert all(a.dest != "language" for a in parser._actions)
+
+
+def test_cli_default_interface_is_inprocess():
+    from vibe_serve.cli import _build_agent_parser
+
+    args = _build_agent_parser().parse_args(["--ref", "/x", "--exp-name", "e"])
+    assert args.interface == "inprocess"
+
+
+def test_cli_rejects_unknown_interface():
+    from vibe_serve.cli import _build_agent_parser
+
+    with pytest.raises(SystemExit):
+        _build_agent_parser().parse_args(["--ref", "/x", "--exp-name", "e", "--interface", "rust"])
+
+
+# --------------------------------------------------------------------------- #
+# loop validation
+# --------------------------------------------------------------------------- #
+def test_loop_constants_and_rejects_unknown_interface():
+    from vibe_serve.loops.agent.loop import (
+        _INTERFACES,
+        DEFAULT_INTERFACE,
+        run_agent_loop,
+    )
+
+    assert DEFAULT_INTERFACE == "inprocess"
+    assert _INTERFACES == ("inprocess", "service")
+    # validation happens before any heavy setup, so dummy args are fine
+    with pytest.raises(ValueError, match="interface"):
+        run_agent_loop(
+            config=None,
+            exp_name="e",
+            reference_path="/x",
+            objective="o",
+            interface="rust",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# prompt rendering: implementer
+# --------------------------------------------------------------------------- #
+def _render_implementer(interface: str) -> str:
+    return render_template(
+        "implementer_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        modality="text_generation",
+        interface=interface,
+        domain_implementer="",  # isolate the interface axis
+        task="TASK",
+        pass_criteria="PC",
+        reference_path="/ref",
+        runtime_notes="",
+        feedback=None,
+    )
+
+
+def test_inprocess_implementer_keeps_python_contract():
+    out = _render_implementer("inprocess")
+    # uv toolchain prose and the in-process import contract are both present
+    assert "uv" in out
+    assert "VibeServeModel" in out
+    assert "from main import VibeServeModel" in out
+
+
+def test_service_implementer_is_language_free():
+    out = _render_implementer("service")
+    # the in-process Python contract and uv tooling are gone
+    assert "VibeServeModel" not in out
+    assert "uv" not in out
+    # ...replaced by an explicit language-freedom statement
+    assert "over the wire" in out
+    assert "language" in out.lower()
+
+
+def test_default_interface_matches_inprocess_for_implementer():
+    """Rendering with no interface set must equal explicit inprocess (the
+    template's own default), so existing runs are unchanged."""
+    explicit = _render_implementer("inprocess")
+    implied = render_template(
+        "implementer_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        modality="text_generation",
+        domain_implementer="",
+        task="TASK",
+        pass_criteria="PC",
+        reference_path="/ref",
+        runtime_notes="",
+        feedback=None,
+    )
+    assert explicit == implied
+
+
+# --------------------------------------------------------------------------- #
+# prompt rendering: judge
+# --------------------------------------------------------------------------- #
+def _render_judge(interface: str) -> str:
+    return render_template(
+        "judge_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        modality="text_generation",
+        interface=interface,
+        domain_judge="",
+        accuracy_checker_path="/acc",
+        bench_path="/bench",
+        pass_criteria="PC",
+        retry=1,
+        runtime_notes="",
+        env_kind="local",
+        objective="OBJ",
+    )
+
+
+def test_inprocess_judge_requires_vibeservemodel():
+    assert "VibeServeModel" in _render_judge("inprocess")
+
+
+def test_service_judge_drops_vibeservemodel():
+    out = _render_judge("service")
+    assert "VibeServeModel" not in out
+    # decode invariants (modality content) still render
+    assert "Decode invariants" in out
+
+
+# --------------------------------------------------------------------------- #
+# prompt rendering: single-agent
+# --------------------------------------------------------------------------- #
+def _render_single_agent(interface: str, profiler_kind: str = "torch") -> str:
+    return render_template(
+        "single_agent_round_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        modality="text_generation",
+        interface=interface,
+        env_kind="local",
+        domain_single_agent="",
+        task="TASK",
+        pass_criteria="PC",
+        retry=1,
+        feedback=None,
+        objective="OBJ",
+        profile_focus="focus",
+        profiler_kind=profiler_kind,
+        bench_path="/bench",
+        accuracy_checker_path="/acc",
+        reference_path="/ref",
+        runtime_notes="",
+    )
+
+
+def test_inprocess_single_agent_keeps_uv_and_torch_capture():
+    out = _render_single_agent("inprocess", profiler_kind="torch")
+    assert "uv" in out
+    # torch in-process capture path is offered for Python implementations
+    assert "torch.profiler" in out
+
+
+def test_service_single_agent_is_language_free_and_avoids_inprocess_torch():
+    out = _render_single_agent("service", profiler_kind="torch")
+    assert "uv" not in out
+    assert "over the wire" in out
+    # torch in-process capture is Python-only; service falls back to nsys /
+    # server-driven profiling instead
+    assert "torch.profiler" not in out
+    assert "nsys" in out

--- a/tests/loops/agent/test_interface_modes.py
+++ b/tests/loops/agent/test_interface_modes.py
@@ -99,6 +99,25 @@ def test_loop_constants_and_rejects_unknown_interface():
 
 
 # --------------------------------------------------------------------------- #
+# standalone (multi-agent) profiler selection
+# --------------------------------------------------------------------------- #
+def test_standalone_profiler_drops_torch_under_service():
+    """The multi-agent standalone profiler must treat the torch profiler the
+    same way the single-agent prompt does: torch is a white-box, in-process
+    PyTorch tool, so ``--interface service`` (exercised only over the wire, any
+    language) falls back to the black-box nsys profiler."""
+    from vibe_serve.loops.agent.loop import _profiler_prompt_template
+
+    # inprocess keeps the white-box torch profiler
+    assert _profiler_prompt_template("torch", "inprocess") == "profiler_prompt_torch.j2"
+    # service swaps torch -> nsys (torch imports the implementation)
+    assert _profiler_prompt_template("torch", "service") == "profiler_prompt_nsys.j2"
+    # non-torch kinds are unaffected by the interface
+    assert _profiler_prompt_template("neuron", "service") == "profiler_prompt_neuron.j2"
+    assert _profiler_prompt_template("nsys", "service") == "profiler_prompt_nsys.j2"
+
+
+# --------------------------------------------------------------------------- #
 # prompt rendering: implementer
 # --------------------------------------------------------------------------- #
 def _render_implementer(interface: str) -> str:


### PR DESCRIPTION
## What

Adds `--interface {inprocess,service}` to the agent loop. It fixes how the built artifact is evaluated — and, as a result, its implementation language (the user never picks a language directly).

- **`inprocess`** (default): the accuracy checker imports `main.py`, so the artifact is Python. Original vibeserve behaviour, unchanged.
- **`service`**: the artifact is exercised only over its network interface, so the agent picks whatever language/framework fits; the domain supplies a checker/benchmark that probes the running service over the wire.

## How

The behaviour is **entirely prompt-gated** — the Python side just threads one new `interface` string down to the template layer (CLI flag → `run_agent_loop` → render context). No Python control flow branches on it.

## Worth reviewing

- `src/vibe_serve/loops/agent/templates/_interface/language.j2` — the actual behavioural change; everything else is variable threading
- `tests/loops/agent/test_interface_modes.py` — both modes end-to-end through prompt rendering
