### PR TITLE
[codex] add Train Ticket input scripts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "examples/social-network-read-timeline/3rd_party/deathstarbench"]
 	path = examples/social-network-read-timeline/3rd_party/deathstarbench
 	url = https://github.com/delimitrou/DeathStarBench.git
+[submodule "3rd_party/train-ticket"]
+	path = 3rd_party/train-ticket
+	url = git@github.com:FudanSELab/train-ticket.git

--- a/inputs/train-ticket/README.md
+++ b/inputs/train-ticket/README.md
@@ -1,0 +1,135 @@
+# Train Ticket Scripts
+
+Standalone accuracy and benchmark scripts for a running Train Ticket deployment.
+These scripts do not depend on the `vibe-serve --ref` input contract.
+
+Expected target for a gateway/proxy deployment:
+
+- UI proxy: `http://localhost:8080`
+- Gateway directly: `http://localhost:18888`
+- Kubernetes NodePort UI: `http://<node-ip>:32677`
+
+The scripts call `/api/v1/...` endpoints through whichever base URL you pass.
+
+```bash
+python inputs/train-ticket/accuracy_checker/checker.py --base-url http://localhost:8080
+python inputs/train-ticket/benchmark/benchmark.py --base-url http://localhost:8080 --rate 20 --duration 30 --output-json /tmp/train_ticket_bench.json
+```
+
+Both scripts use only the Python standard library.
+
+For the prebuilt-image local Docker Compose helper below, use
+`--direct-services` or the helper `check`/`bench` commands. The currently
+published gateway image starts, but in the minimal local compose it can return
+`503` while the individual service ports are healthy. With source-built
+`localtrain:source` images, the gateway path was verified successfully too.
+
+## Local Cluster
+
+Use the helper script to start a minimal local Docker Compose cluster with
+prebuilt images:
+
+```bash
+inputs/train-ticket/scripts/start-local-cluster.sh start
+inputs/train-ticket/scripts/start-local-cluster.sh check
+inputs/train-ticket/scripts/start-local-cluster.sh bench
+inputs/train-ticket/scripts/start-local-cluster.sh stop
+```
+
+Defaults:
+
+- Gateway: `http://localhost:18888`
+- Images: `codewisdom/<service>:0.2.0`
+
+The script generates a temporary compose file under `/tmp` that exposes the
+gateway and the core read-only service ports used by the checker. Override
+with `TT_GATEWAY_PORT`, `TT_NAMESPACE`, or `TT_TAG` if needed.
+
+The local helper starts a minimal API cluster: Nacos, Redis, the gateway, and
+the config/station/train/travel/route/price services with their local MongoDB
+and MySQL dependencies. Auth-protected services such as contacts are excluded
+from the default no-auth checker and benchmark. The published dashboard image
+is intentionally not started because its nginx config references additional
+services outside this minimal read-only cluster.
+
+## Build From Source
+
+The source-build path is useful because the public prebuilt image set is stale:
+some images referenced by the upstream compose file are no longer published
+with the expected tags, including services such as `ts-food-delivery-service`
+and `ts-station-food-service`, and the gateway is not published under the same
+`0.2.0` tag as the other images.
+
+Build all Train Ticket service images locally:
+
+```bash
+inputs/train-ticket/scripts/start-local-cluster.sh build-source
+```
+
+That command packages the Java services with a Dockerized Maven/JDK 8 build and
+then runs the upstream `hack/build-image.sh` script with local image names:
+
+- image namespace: `localtrain`
+- image tag: `source`
+
+It also creates local compatibility tags for old upstream Dockerfiles:
+
+- `java:8-jre` -> `eclipse-temurin:8-jre`
+- `python:3` -> `python:3.8-bullseye`
+
+Those tags are needed because the source Dockerfiles still use old floating
+base images. `java:8-jre` is no longer available from Docker Hub, and the
+current `python:3` base no longer has the `libgl1-mesa-glx` package expected by
+`ts-avatar-service`.
+
+Deploy the local source-built images:
+
+```bash
+TT_NAMESPACE=localtrain \
+TT_TAG=source \
+TT_GATEWAY_TAG=source \
+TT_SKIP_PULL=1 \
+inputs/train-ticket/scripts/start-local-cluster.sh start
+```
+
+`TT_SKIP_PULL=1` is required for local source-built images; otherwise Docker
+Compose tries to pull `localtrain/...` from Docker Hub.
+
+`start` waits for these direct service endpoints:
+
+- `http://localhost:15679/api/v1/configservice/welcome`
+- `http://localhost:12345/api/v1/stationservice/welcome`
+- `http://localhost:14567/api/v1/trainservice/trains/welcome`
+- `http://localhost:12346/api/v1/travelservice/welcome`
+- `http://localhost:11178/api/v1/routeservice/welcome`
+- `http://localhost:16579/api/v1/priceservice/prices/welcome`
+
+Manual direct-service runs:
+
+```bash
+python inputs/train-ticket/accuracy_checker/checker.py \
+  --base-url http://localhost:18888 \
+  --direct-services \
+  --allow-empty
+
+python inputs/train-ticket/benchmark/benchmark.py \
+  --base-url http://localhost:18888 \
+  --direct-services \
+  --rate 10 \
+  --duration 30 \
+  --concurrency 32
+```
+
+Manual gateway runs after source-built deployment:
+
+```bash
+python inputs/train-ticket/accuracy_checker/checker.py \
+  --base-url http://localhost:18888 \
+  --allow-empty
+
+python inputs/train-ticket/benchmark/benchmark.py \
+  --base-url http://localhost:18888 \
+  --rate 10 \
+  --duration 30 \
+  --concurrency 32
+```

--- a/inputs/train-ticket/accuracy_checker/README.md
+++ b/inputs/train-ticket/accuracy_checker/README.md
@@ -1,0 +1,15 @@
+# Train Ticket Accuracy Checker
+
+Checks a running Train Ticket deployment through the API gateway. The checker
+uses only read-only endpoints by default:
+
+- service welcome endpoints
+- station, train, travel, route, price, config, and contact list endpoints
+
+Usage:
+
+```bash
+python checker.py --base-url http://localhost:8080
+```
+
+Use `--allow-empty` for deployments without seeded data.

--- a/inputs/train-ticket/accuracy_checker/checker.py
+++ b/inputs/train-ticket/accuracy_checker/checker.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Read-only deployment checker for the Train Ticket microservice app."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    method: str
+    path: str
+    expect_json: bool = False
+    expect_text: str | None = None
+    expect_items: bool = False
+    body: Any | None = None
+
+
+CHECKS = [
+    Check("config welcome", "GET", "/api/v1/configservice/welcome", expect_text="Config Service"),
+    Check("station welcome", "GET", "/api/v1/stationservice/welcome", expect_text="Station Service"),
+    Check("train welcome", "GET", "/api/v1/trainservice/trains/welcome", expect_text="Train Service"),
+    Check("travel welcome", "GET", "/api/v1/travelservice/welcome", expect_text="Travel Service"),
+    Check("route welcome", "GET", "/api/v1/routeservice/welcome", expect_text="Route Service"),
+    Check("price welcome", "GET", "/api/v1/priceservice/prices/welcome", expect_text="Price Service"),
+    Check("stations list", "GET", "/api/v1/stationservice/stations", expect_json=True, expect_items=True),
+    Check("trains list", "GET", "/api/v1/trainservice/trains", expect_json=True, expect_items=True),
+    Check("trips list", "GET", "/api/v1/travelservice/trips", expect_json=True, expect_items=True),
+    Check("routes list", "GET", "/api/v1/routeservice/routes", expect_json=True, expect_items=True),
+    Check("prices list", "GET", "/api/v1/priceservice/prices", expect_json=True, expect_items=True),
+    Check("configs list", "GET", "/api/v1/configservice/configs", expect_json=True),
+]
+
+DIRECT_SERVICE_PORTS = {
+    "configservice": 15679,
+    "stationservice": 12345,
+    "trainservice": 14567,
+    "travelservice": 12346,
+    "routeservice": 11178,
+    "priceservice": 16579,
+}
+
+
+def normalize_base_url(raw: str) -> str:
+    raw = raw.strip()
+    if not raw.startswith(("http://", "https://")):
+        raw = "http://" + raw
+    return raw.rstrip("/") + "/"
+
+
+def check_url(base_url: str, check: Check, direct_services: bool) -> str:
+    if not direct_services:
+        return urljoin(base_url, check.path.lstrip("/"))
+    parts = check.path.strip("/").split("/")
+    if len(parts) < 3 or parts[0] != "api" or parts[1] != "v1":
+        raise RuntimeError(f"{check.name}: cannot map path to direct service URL: {check.path}")
+    service = parts[2]
+    port = DIRECT_SERVICE_PORTS.get(service)
+    if port is None:
+        raise RuntimeError(f"{check.name}: no direct port mapping for service {service!r}")
+    base = urlsplit(base_url)
+    host = base.hostname or "localhost"
+    netloc = f"{host}:{port}"
+    return urlunsplit((base.scheme or "http", netloc, check.path, "", ""))
+
+
+def request_json_or_text(
+    base_url: str,
+    check: Check,
+    timeout: float,
+    direct_services: bool,
+) -> tuple[int, str, Any | None, float]:
+    url = check_url(base_url, check, direct_services)
+    data = None
+    headers = {"Accept": "application/json,text/plain,*/*"}
+    if check.body is not None:
+        data = json.dumps(check.body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = Request(url, data=data, headers=headers, method=check.method)
+    start = time.perf_counter()
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            status = resp.status
+    except HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        status = exc.code
+    except URLError as exc:
+        raise RuntimeError(f"{check.name}: request failed: {exc}") from exc
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+    parsed = None
+    if check.expect_json:
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"{check.name}: response is not valid JSON: {raw[:200]!r}") from exc
+    return status, raw, parsed, elapsed_ms
+
+
+def extract_items(payload: Any) -> list[Any]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        if isinstance(data, list):
+            return data
+        if data is not None:
+            return [data]
+    return []
+
+
+def run_check(
+    base_url: str,
+    check: Check,
+    timeout: float,
+    allow_empty: bool,
+    direct_services: bool,
+) -> dict[str, Any]:
+    status, raw, parsed, elapsed_ms = request_json_or_text(base_url, check, timeout, direct_services)
+    if not (200 <= status < 300):
+        raise RuntimeError(f"{check.name}: HTTP {status}: {raw[:300]!r}")
+    if check.expect_text and check.expect_text not in raw:
+        raise RuntimeError(f"{check.name}: expected text {check.expect_text!r}, got {raw[:200]!r}")
+    item_count = None
+    if check.expect_items:
+        items = extract_items(parsed)
+        item_count = len(items)
+        if not allow_empty and item_count == 0:
+            raise RuntimeError(f"{check.name}: expected seeded data, got empty response")
+    return {
+        "name": check.name,
+        "status": status,
+        "latency_ms": round(elapsed_ms, 3),
+        "item_count": item_count,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check a running Train Ticket deployment.")
+    parser.add_argument("--base-url", default="http://localhost:8080", help="UI proxy or gateway base URL")
+    parser.add_argument("--timeout", type=float, default=5.0, help="per-request timeout in seconds")
+    parser.add_argument("--allow-empty", action="store_true", help="allow list endpoints to return no seeded data")
+    parser.add_argument(
+        "--direct-services",
+        action="store_true",
+        help="bypass the gateway and route each service path to its exposed local service port",
+    )
+    parser.add_argument("--output-json", default=None, help="optional path for structured results")
+    args = parser.parse_args()
+
+    base_url = normalize_base_url(args.base_url)
+    results = []
+    failures = []
+    for check in CHECKS:
+        try:
+            result = run_check(base_url, check, args.timeout, args.allow_empty, args.direct_services)
+            results.append(result)
+            print(f"PASS {check.name} ({result['latency_ms']:.1f} ms)")
+        except Exception as exc:
+            failures.append({"name": check.name, "error": str(exc)})
+            print(f"FAIL {check.name}: {exc}", file=sys.stderr)
+
+    summary = {
+        "base_url": base_url.rstrip("/"),
+        "direct_services": args.direct_services,
+        "passed": len(results),
+        "failed": len(failures),
+        "results": results,
+        "failures": failures,
+    }
+    if args.output_json:
+        with open(args.output_json, "w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2)
+    print(json.dumps({"passed": summary["passed"], "failed": summary["failed"]}, indent=2))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/inputs/train-ticket/benchmark/README.md
+++ b/inputs/train-ticket/benchmark/README.md
@@ -1,0 +1,10 @@
+# Train Ticket Benchmark
+
+Runs a read-only HTTP workload against a Train Ticket deployment and reports
+throughput, latency percentiles, and error rate.
+
+```bash
+python benchmark.py --base-url http://localhost:8080 --rate 20 --duration 30 --output-json /tmp/train_ticket_bench.json
+```
+
+The headline metric is `requests_per_second`.

--- a/inputs/train-ticket/benchmark/benchmark.py
+++ b/inputs/train-ticket/benchmark/benchmark.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Read-only HTTP benchmark for the Train Ticket microservice app."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import random
+import statistics
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    name: str
+    method: str
+    path: str
+    weight: int = 1
+    body: Any | None = None
+    expect_text: str | None = None
+    expect_json: bool = True
+
+
+ENDPOINTS = [
+    Endpoint("stations", "GET", "/api/v1/stationservice/stations", weight=3),
+    Endpoint("trains", "GET", "/api/v1/trainservice/trains", weight=3),
+    Endpoint("trips", "GET", "/api/v1/travelservice/trips", weight=4),
+    Endpoint("routes", "GET", "/api/v1/routeservice/routes", weight=2),
+    Endpoint("prices", "GET", "/api/v1/priceservice/prices", weight=2),
+    Endpoint("configs", "GET", "/api/v1/configservice/configs", weight=1),
+    Endpoint(
+        "travel welcome",
+        "GET",
+        "/api/v1/travelservice/welcome",
+        weight=1,
+        expect_text="Travel Service",
+        expect_json=False,
+    ),
+]
+
+DIRECT_SERVICE_PORTS = {
+    "configservice": 15679,
+    "stationservice": 12345,
+    "trainservice": 14567,
+    "travelservice": 12346,
+    "routeservice": 11178,
+    "priceservice": 16579,
+}
+
+
+def normalize_base_url(raw: str) -> str:
+    raw = raw.strip()
+    if not raw.startswith(("http://", "https://")):
+        raw = "http://" + raw
+    return raw.rstrip("/") + "/"
+
+
+def endpoint_url(base_url: str, endpoint: Endpoint, direct_services: bool) -> str:
+    if not direct_services:
+        return urljoin(base_url, endpoint.path.lstrip("/"))
+    parts = endpoint.path.strip("/").split("/")
+    if len(parts) < 3 or parts[0] != "api" or parts[1] != "v1":
+        raise RuntimeError(f"{endpoint.name}: cannot map path to direct service URL: {endpoint.path}")
+    service = parts[2]
+    port = DIRECT_SERVICE_PORTS.get(service)
+    if port is None:
+        raise RuntimeError(f"{endpoint.name}: no direct port mapping for service {service!r}")
+    base = urlsplit(base_url)
+    host = base.hostname or "localhost"
+    return urlunsplit((base.scheme or "http", f"{host}:{port}", endpoint.path, "", ""))
+
+
+def percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, max(0, round((pct / 100.0) * (len(ordered) - 1))))
+    return ordered[idx]
+
+
+def request_once(base_url: str, endpoint: Endpoint, timeout: float, direct_services: bool) -> dict[str, Any]:
+    url = endpoint_url(base_url, endpoint, direct_services)
+    headers = {"Accept": "application/json,text/plain,*/*"}
+    data = None
+    if endpoint.body is not None:
+        data = json.dumps(endpoint.body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = Request(url, data=data, headers=headers, method=endpoint.method)
+    start = time.perf_counter()
+    status = 0
+    size = 0
+    error = None
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            body = resp.read()
+            status = resp.status
+            size = len(body)
+    except HTTPError as exc:
+        body = exc.read()
+        status = exc.code
+        size = len(body)
+        error = f"HTTP {exc.code}"
+    except URLError as exc:
+        error = str(exc)
+    except TimeoutError as exc:
+        error = str(exc)
+    if error is None and 200 <= status < 300:
+        text = body.decode("utf-8", errors="replace")
+        shape_error = validate_response_shape(endpoint, text)
+        if shape_error:
+            error = shape_error
+    latency_ms = (time.perf_counter() - start) * 1000.0
+    ok = error is None and 200 <= status < 300
+    return {
+        "endpoint": endpoint.name,
+        "status": status,
+        "ok": ok,
+        "latency_ms": latency_ms,
+        "bytes": size,
+        "error": error,
+    }
+
+
+def validate_response_shape(endpoint: Endpoint, text: str) -> str | None:
+    if endpoint.expect_text is not None:
+        if endpoint.expect_text not in text:
+            return f"unexpected response text for {endpoint.name}: {text[:120]!r}"
+        return None
+    if not endpoint.expect_json:
+        return None
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return f"non-JSON response for {endpoint.name}: {text[:120]!r}"
+    if isinstance(payload, list):
+        return None
+    if isinstance(payload, dict):
+        # Some Train Ticket services wrap lists in edu.fudan.common.util.Response.
+        if "data" in payload or ("status" in payload and "msg" in payload) or ("status" in payload and "message" in payload):
+            return None
+        return f"unexpected JSON object for {endpoint.name}: keys={sorted(payload)[:8]}"
+    return f"unexpected JSON type for {endpoint.name}: {type(payload).__name__}"
+
+
+def summarize(results: list[dict[str, Any]], elapsed_s: float) -> dict[str, Any]:
+    successes = [r for r in results if r["ok"]]
+    failures = [r for r in results if not r["ok"]]
+    latencies = [r["latency_ms"] for r in successes]
+    by_endpoint: dict[str, dict[str, Any]] = {}
+    for r in results:
+        bucket = by_endpoint.setdefault(r["endpoint"], {"requests": 0, "successes": 0, "failures": 0})
+        bucket["requests"] += 1
+        if r["ok"]:
+            bucket["successes"] += 1
+        else:
+            bucket["failures"] += 1
+    return {
+        "headline_metric": "requests_per_second",
+        "requests_per_second": len(successes) / elapsed_s if elapsed_s > 0 else 0.0,
+        "attempted_requests_per_second": len(results) / elapsed_s if elapsed_s > 0 else 0.0,
+        "total_requests": len(results),
+        "successful_requests": len(successes),
+        "failed_requests": len(failures),
+        "error_rate": (len(failures) / len(results)) if results else 0.0,
+        "latency_ms": {
+            "mean": statistics.fmean(latencies) if latencies else None,
+            "p50": percentile(latencies, 50),
+            "p90": percentile(latencies, 90),
+            "p95": percentile(latencies, 95),
+            "p99": percentile(latencies, 99),
+            "max": max(latencies) if latencies else None,
+        },
+        "by_endpoint": by_endpoint,
+        "sample_errors": failures[:10],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Benchmark a running Train Ticket deployment.")
+    parser.add_argument("--base-url", default="http://localhost:8080", help="UI proxy or gateway base URL")
+    parser.add_argument("--rate", type=float, default=10.0, help="target request rate per second")
+    parser.add_argument("--duration", type=float, default=30.0, help="benchmark duration in seconds")
+    parser.add_argument("--concurrency", type=int, default=32, help="maximum concurrent in-flight requests")
+    parser.add_argument("--timeout", type=float, default=5.0, help="per-request timeout in seconds")
+    parser.add_argument("--seed", type=int, default=1, help="random seed for endpoint selection")
+    parser.add_argument(
+        "--direct-services",
+        action="store_true",
+        help="bypass the gateway and route each service path to its exposed local service port",
+    )
+    parser.add_argument("--output-json", default=None, help="optional path for structured results")
+    args = parser.parse_args()
+
+    if args.rate <= 0:
+        raise SystemExit("--rate must be > 0")
+    if args.duration <= 0:
+        raise SystemExit("--duration must be > 0")
+    if args.concurrency <= 0:
+        raise SystemExit("--concurrency must be > 0")
+
+    random.seed(args.seed)
+    base_url = normalize_base_url(args.base_url)
+    population = [endpoint for endpoint in ENDPOINTS for _ in range(endpoint.weight)]
+    total = max(1, int(args.rate * args.duration))
+    interval = 1.0 / args.rate
+    results: list[dict[str, Any]] = []
+
+    start = time.perf_counter()
+    futures: list[concurrent.futures.Future] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        for i in range(total):
+            target_time = start + i * interval
+            sleep_s = target_time - time.perf_counter()
+            if sleep_s > 0:
+                time.sleep(sleep_s)
+            endpoint = random.choice(population)
+            futures.append(pool.submit(request_once, base_url, endpoint, args.timeout, args.direct_services))
+        for fut in concurrent.futures.as_completed(futures):
+            results.append(fut.result())
+
+    elapsed_s = time.perf_counter() - start
+    summary = summarize(results, elapsed_s)
+    summary.update(
+        {
+            "base_url": base_url.rstrip("/"),
+            "direct_services": args.direct_services,
+            "target_rate": args.rate,
+            "duration_s": args.duration,
+            "elapsed_s": elapsed_s,
+            "concurrency": args.concurrency,
+        }
+    )
+    if args.output_json:
+        with open(args.output_json, "w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2)
+    print(json.dumps(summary, indent=2))
+    return 1 if summary["failed_requests"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/inputs/train-ticket/scripts/start-local-cluster.sh
+++ b/inputs/train-ticket/scripts/start-local-cluster.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start a local Train Ticket cluster from the upstream prebuilt images.
+#
+# Defaults:
+#   API gateway: http://localhost:18888
+#   Direct services on their Train Ticket ports
+#
+# Override examples:
+#   TT_TAG=0.0.4 inputs/train-ticket/scripts/start-local-cluster.sh start
+#   TT_GATEWAY_PORT=28888 inputs/train-ticket/scripts/start-local-cluster.sh start
+#   inputs/train-ticket/scripts/start-local-cluster.sh build-source
+#   TT_NAMESPACE=localtrain TT_TAG=source TT_GATEWAY_TAG=source TT_SKIP_PULL=1 inputs/train-ticket/scripts/start-local-cluster.sh start
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+INPUT_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd -- "${INPUT_DIR}/../.." && pwd)"
+SOURCE_COMPOSE="${REPO_ROOT}/3rd_party/train-ticket/deployment/docker-compose-manifests/quickstart-docker-compose.yml"
+
+TT_NAMESPACE="${TT_NAMESPACE:-codewisdom}"
+TT_TAG="${TT_TAG:-0.2.0}"
+TT_GATEWAY_TAG="${TT_GATEWAY_TAG:-latest}"
+TT_PROJECT="${TT_PROJECT:-train-ticket-local}"
+TT_GATEWAY_PORT="${TT_GATEWAY_PORT:-18888}"
+TT_COMPOSE_FILE="${TT_COMPOSE_FILE:-/tmp/${TT_PROJECT}-quickstart-docker-compose.yml}"
+TT_SKIP_PULL="${TT_SKIP_PULL:-0}"
+TT_SOURCE_DIR="${TT_SOURCE_DIR:-${REPO_ROOT}/3rd_party/train-ticket}"
+TT_BUILD_REPO="${TT_BUILD_REPO:-localtrain}"
+TT_BUILD_TAG="${TT_BUILD_TAG:-source}"
+
+usage() {
+  cat <<EOF
+Usage: $0 <command>
+
+Commands:
+  start      Generate compose file, pull images, start the cluster, wait for core services
+  stop       Stop and remove the cluster containers/network
+  status     Show compose service status
+  logs       Follow compose logs
+  check      Run the Train Ticket checker against local direct service ports
+  bench      Run a short benchmark against local direct service ports
+  build-source
+             Package Train Ticket from source and build local Docker images
+  config     Generate and print the temporary compose file path
+
+Environment:
+  TT_NAMESPACE      Docker image namespace (default: ${TT_NAMESPACE})
+  TT_TAG            Docker image tag (default: ${TT_TAG})
+  TT_GATEWAY_TAG    Gateway image tag (default: ${TT_GATEWAY_TAG})
+  TT_PROJECT        Docker Compose project name (default: ${TT_PROJECT})
+  TT_GATEWAY_PORT   Host port for API gateway (default: ${TT_GATEWAY_PORT})
+  TT_COMPOSE_FILE   Generated compose path (default: ${TT_COMPOSE_FILE})
+  TT_SKIP_PULL       Set to 1 when using local source-built images
+  TT_SOURCE_DIR      Train Ticket source checkout (default: ${TT_SOURCE_DIR})
+  TT_BUILD_REPO      Local image namespace for build-source (default: ${TT_BUILD_REPO})
+  TT_BUILD_TAG       Local image tag for build-source (default: ${TT_BUILD_TAG})
+
+URLs after start:
+  Gateway: http://localhost:${TT_GATEWAY_PORT}
+  Direct service ports used by check/bench:
+    config=15679 station=12345 train=14567 travel=12346 route=11178 price=16579
+EOF
+}
+
+require_tools() {
+  command -v docker >/dev/null || { echo "docker is required" >&2; exit 127; }
+  docker compose version >/dev/null || { echo "docker compose v2 is required" >&2; exit 127; }
+  command -v python3 >/dev/null || { echo "python3 is required" >&2; exit 127; }
+}
+
+port_in_use() {
+  local port="$1"
+  ss -ltn | awk '{print $4}' | grep -Eq "(:|\\])${port}$"
+}
+
+check_ports() {
+  local failed=0
+  for port in \
+    "${TT_GATEWAY_PORT}" \
+    15679 12345 14567 12346 11178 16579
+  do
+    if port_in_use "${port}"; then
+      echo "Port ${port} is already in use. Override TT_GATEWAY_PORT or stop the process using the port." >&2
+      failed=1
+    fi
+  done
+  if [[ "${failed}" != 0 ]]; then
+    exit 1
+  fi
+}
+
+generate_compose() {
+  [[ -f "${SOURCE_COMPOSE}" ]] || {
+    echo "Missing source compose file: ${SOURCE_COMPOSE}" >&2
+    exit 1
+  }
+  mkdir -p "$(dirname -- "${TT_COMPOSE_FILE}")"
+  python3 - "${SOURCE_COMPOSE}" "${TT_COMPOSE_FILE}" "${TT_GATEWAY_PORT}" "${TT_NAMESPACE}" "${TT_TAG}" "${TT_GATEWAY_TAG}" <<'PY'
+from pathlib import Path
+import sys
+
+src = Path(sys.argv[1])
+dst = Path(sys.argv[2])
+gateway_port = sys.argv[3]
+namespace = sys.argv[4]
+tag = sys.argv[5]
+gateway_tag = sys.argv[6]
+
+# Keep this explicit. The upstream quickstart compose references several
+# optional images that are no longer published, omits Nacos, and leaves MySQL
+# without initialization env. The dashboard image also expects many services
+# that are outside this minimal read-only cluster. This compose is enough for
+# the checker and benchmark workloads in inputs/train-ticket.
+service_ports = {
+    "ts-config-service": 15679,
+    "ts-station-service": 12345,
+    "ts-train-service": 14567,
+    "ts-travel-service": 12346,
+    "ts-route-service": 11178,
+    "ts-price-service": 16579,
+}
+mysql = {
+    "ts-config-mysql": ("root", "ts-config-mysql"),
+    "ts-station-mysql": ("Abcd1234#", "ts-station-mysql"),
+    "ts-train-mysql": ("Abcd1234#", "ts-train-mysql"),
+    "ts-travel-mysql": ("root", "ts-travel-mysql"),
+    "ts-route-mysql": ("Abcd1234#", "ts"),
+    "ts-price-mysql": ("Abcd1234#", "ts"),
+}
+mongo_services = [
+    "ts-config-mongo",
+    "ts-station-mongo",
+    "ts-train-mongo",
+    "ts-travel-mongo",
+    "ts-route-mongo",
+    "ts-price-mongo",
+]
+service_env = {
+    "ts-config-service": {
+        "NACOS_ADDRS": "nacos:8848",
+        "CONFIG_MYSQL_HOST": "ts-config-mysql",
+        "CONFIG_MYSQL_DATABASE": "ts-config-mysql",
+        "CONFIG_MYSQL_PASSWORD": "root",
+    },
+    "ts-station-service": {
+        "NACOS_ADDRS": "nacos:8848",
+        "STATION_MYSQL_HOST": "ts-station-mysql",
+        "STATION_MYSQL_DATABASE": "ts-station-mysql",
+        "STATION_MYSQL_PASSWORD": "Abcd1234#",
+    },
+    "ts-train-service": {
+        "NACOS_ADDRS": "nacos:8848",
+        "TRAIN_MYSQL_HOST": "ts-train-mysql",
+        "TRAIN_MYSQL_DATABASE": "ts-train-mysql",
+        "TRAIN_MYSQL_PASSWORD": "Abcd1234#",
+    },
+    "ts-travel-service": {
+        "NACOS_ADDRS": "nacos:8848",
+        "TRAVEL_MYSQL_HOST": "ts-travel-mysql",
+        "TRAVEL_MYSQL_DATABASE": "ts-travel-mysql",
+        "TRAVEL_MYSQL_PASSWORD": "root",
+        "TRAIN_SERVICE_HOST": "ts-train-service",
+        "ROUTE_SERVICE_HOST": "ts-route-service",
+    },
+    "ts-route-service": {
+        "NACOS_ADDRS": "nacos:8848",
+        "ROUTE_MYSQL_HOST": "ts-route-mysql",
+        "ROUTE_MYSQL_DATABASE": "ts",
+        "ROUTE_MYSQL_PASSWORD": "Abcd1234#",
+    },
+    "ts-price-service": {
+        "NACOS_ADDRS": "nacos:8848",
+        "PRICE_MYSQL_HOST": "ts-price-mysql",
+        "PRICE_MYSQL_DATABASE": "ts",
+        "PRICE_MYSQL_PASSWORD": "Abcd1234#",
+    },
+}
+
+lines = [
+    "services:",
+    "  nacos:",
+    "    image: nacos/nacos-server:v2.0.3",
+    "    environment:",
+    "      MODE: standalone",
+    "    networks:",
+    "      - my-network",
+    "",
+    "  redis:",
+    "    image: redis:latest",
+    "    networks:",
+    "      - my-network",
+    "",
+    "  ts-gateway-service:",
+    f"    image: {namespace}/ts-gateway-service:{gateway_tag}",
+    "    restart: always",
+    "    environment:",
+    "      NACOS_ADDRS: nacos:8848",
+    "    ports:",
+    f"      - {gateway_port}:18888",
+    "    networks:",
+    "      - my-network",
+    "",
+]
+
+for name, (password, database) in mysql.items():
+    lines.extend([
+        f"  {name}:",
+        "    image: mysql:5.7",
+        "    restart: always",
+        "    environment:",
+        f"      MYSQL_ROOT_PASSWORD: {password!r}",
+        f"      MYSQL_DATABASE: {database!r}",
+        "    networks:",
+        "      - my-network",
+        "",
+    ])
+
+for name in mongo_services:
+    lines.extend([
+        f"  {name}:",
+        "    image: mongo:3.4",
+        "    restart: always",
+        "    networks:",
+        "      - my-network",
+        "",
+    ])
+
+for name, port in service_ports.items():
+    lines.extend([
+        f"  {name}:",
+        f"    image: {namespace}/{name}:{tag}",
+        "    restart: always",
+        "    environment:",
+    ])
+    for key, value in service_env[name].items():
+        lines.append(f"      {key}: {value!r}")
+    lines.extend([
+        "    ports:",
+        f"      - {port}:{port}",
+        "    networks:",
+        "      - my-network",
+        "",
+    ])
+
+lines.extend([
+    "networks:",
+    "  my-network:",
+    "    driver: bridge",
+])
+
+dst.write_text("\n".join(lines) + "\n")
+PY
+  echo "${TT_COMPOSE_FILE}"
+}
+
+compose() {
+  NAMESPACE="${TT_NAMESPACE}" TAG="${TT_TAG}" docker compose -p "${TT_PROJECT}" -f "${TT_COMPOSE_FILE}" "$@"
+}
+
+build_source() {
+  [[ -f "${TT_SOURCE_DIR}/pom.xml" ]] || {
+    echo "Missing Train Ticket source checkout: ${TT_SOURCE_DIR}" >&2
+    exit 1
+  }
+
+  # The upstream Dockerfiles still reference old floating base images. Keep the
+  # source tree unchanged and provide compatible local tags instead.
+  docker pull eclipse-temurin:8-jre
+  docker tag eclipse-temurin:8-jre java:8-jre
+  docker pull python:3.8-bullseye
+  docker tag python:3.8-bullseye python:3
+
+  docker run --rm \
+    -v "${TT_SOURCE_DIR}:/workspace" \
+    -v "${HOME}/.m2:/root/.m2" \
+    -w /workspace \
+    maven:3.8.8-eclipse-temurin-8 \
+    mvn clean package -Dmaven.test.skip=true
+
+  (cd "${TT_SOURCE_DIR}" && ./hack/build-image.sh "${TT_BUILD_REPO}" "${TT_BUILD_TAG}")
+}
+
+wait_for_core_services() {
+  local deadline=$((SECONDS + 180))
+  echo "Waiting for core direct services..."
+  while (( SECONDS < deadline )); do
+    if python3 - <<'PY'
+from urllib.request import urlopen
+
+checks = [
+    ("config", "http://localhost:15679/api/v1/configservice/welcome", "Config Service"),
+    ("station", "http://localhost:12345/api/v1/stationservice/welcome", "Station Service"),
+    ("train", "http://localhost:14567/api/v1/trainservice/trains/welcome", "Train Service"),
+    ("travel", "http://localhost:12346/api/v1/travelservice/welcome", "Travel Service"),
+    ("route", "http://localhost:11178/api/v1/routeservice/welcome", "Route Service"),
+    ("price", "http://localhost:16579/api/v1/priceservice/prices/welcome", "Price Service"),
+]
+for _, url, marker in checks:
+    try:
+        with urlopen(url, timeout=3) as response:
+            body = response.read().decode("utf-8", errors="replace")
+        if marker not in body:
+            raise RuntimeError(f"missing marker {marker!r}")
+    except Exception:
+        raise SystemExit(1)
+raise SystemExit(0)
+PY
+    then
+      echo "Core direct services are responding."
+      return 0
+    fi
+    sleep 5
+  done
+  echo "Core direct services did not become ready within 180s. Use '$0 logs' to inspect startup." >&2
+  return 1
+}
+
+cmd="${1:-}"
+case "${cmd}" in
+  start)
+    require_tools
+    generate_compose >/dev/null
+    if ! compose ps -q | grep -q .; then
+      check_ports
+    fi
+    echo "Starting Train Ticket with images ${TT_NAMESPACE}/<service>:${TT_TAG}"
+    echo "Generated compose: ${TT_COMPOSE_FILE}"
+    if [[ "${TT_SKIP_PULL}" == "1" ]]; then
+      echo "Skipping compose pull because TT_SKIP_PULL=1"
+    else
+      compose pull
+    fi
+    compose up -d --remove-orphans
+    wait_for_core_services || true
+    echo "Gateway: http://localhost:${TT_GATEWAY_PORT}"
+    echo "Checker: $0 check"
+    echo "Benchmark: TT_BENCH_RATE=10 TT_BENCH_DURATION=30 TT_BENCH_CONCURRENCY=32 $0 bench"
+    ;;
+  stop)
+    require_tools
+    generate_compose >/dev/null
+    compose down --remove-orphans
+    ;;
+  status)
+    require_tools
+    generate_compose >/dev/null
+    compose ps
+    ;;
+  logs)
+    require_tools
+    generate_compose >/dev/null
+    compose logs -f --tail=200
+    ;;
+  build-source)
+    require_tools
+    build_source
+    echo "Built local Train Ticket images as ${TT_BUILD_REPO}/<service>:${TT_BUILD_TAG}"
+    echo "Start them with:"
+    echo "  TT_NAMESPACE=${TT_BUILD_REPO} TT_TAG=${TT_BUILD_TAG} TT_GATEWAY_TAG=${TT_BUILD_TAG} TT_SKIP_PULL=1 $0 start"
+    ;;
+  check)
+    python3 "${INPUT_DIR}/accuracy_checker/checker.py" \
+      --base-url "http://localhost:${TT_GATEWAY_PORT}" \
+      --direct-services \
+      --allow-empty
+    ;;
+  bench)
+    python3 "${INPUT_DIR}/benchmark/benchmark.py" \
+      --base-url "http://localhost:${TT_GATEWAY_PORT}" \
+      --direct-services \
+      --rate "${TT_BENCH_RATE:-10}" \
+      --duration "${TT_BENCH_DURATION:-30}" \
+      --concurrency "${TT_BENCH_CONCURRENCY:-32}"
+    ;;
+  config)
+    require_tools
+    generate_compose
+    ;;
+  -h|--help|help|"")
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds a Train Ticket input bundle under `inputs/train-ticket` with:

- a read-only accuracy checker for core Train Ticket services
- a read-only benchmark for core list/welcome endpoints
- a local Docker Compose helper for starting, stopping, checking, benchmarking, and source-building Train Ticket images
- documentation for prebuilt-image limitations and the source-build workflow

## Why

The public Train Ticket prebuilt image set is stale. Some services referenced by the upstream compose file are no longer published under the expected tags, and the prebuilt gateway image can return `503` in the minimal local compose even while direct service ports are healthy.

The helper supports building Train Ticket from source into local `localtrain/<service>:source` images. This uses compatibility tags for old upstream Dockerfiles:

- `java:8-jre` -> `eclipse-temurin:8-jre`
- `python:3` -> `python:3.8-bullseye`

## Validation

Ran syntax checks after replaying onto `uw-syfi/vibe-serve` `main`:

```bash
bash -n inputs/train-ticket/scripts/start-local-cluster.sh
python3 -m py_compile inputs/train-ticket/accuracy_checker/checker.py inputs/train-ticket/benchmark/benchmark.py
```

Earlier local source-built deployment validation:

```bash
inputs/train-ticket/scripts/start-local-cluster.sh build-source
TT_NAMESPACE=localtrain TT_TAG=source TT_GATEWAY_TAG=source TT_SKIP_PULL=1 inputs/train-ticket/scripts/start-local-cluster.sh start
```

Accuracy checker results against source-built gateway:

```text
passed: 12
failed: 0
```

Benchmark results against source-built gateway with `--rate 2 --duration 5 --concurrency 4`:

```text
total_requests: 10
successful_requests: 10
failed_requests: 0
error_rate: 0.0
requests_per_second: 2.2116
mean_latency_ms: 32.72
p95_latency_ms: 177.45
```
