### PR TITLE
Require explicit target input paths

### DIFF
--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -113,8 +113,8 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     """Add CLI arguments shared across every outer-loop parser."""
     parser.add_argument(
         "--ref",
-        default="examples/Llama-3-8B/reference",
-        help="Path to reference implementation file, or directory containing at least one reference.py (default: examples/Llama-3-8B/reference)",
+        default=None,
+        help="Path to reference implementation file, or directory containing at least one reference.py.",
     )
     parser.add_argument(
         "--exp-name",
@@ -131,14 +131,14 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--acc-checker",
         type=Path,
-        default=Path("examples/Llama-3-8B/accuracy_checker"),
-        help="Path to a directory containing accuracy checker code/documents (default: examples/Llama-3-8B/accuracy_checker).",
+        default=None,
+        help="Path to a directory containing accuracy checker code/documents.",
     )
     parser.add_argument(
         "--bench",
         type=Path,
-        default=Path("examples/Llama-3-8B/benchmark"),
-        help="Path to a directory containing benchmark code/documents (default: examples/Llama-3-8B/benchmark).",
+        default=None,
+        help="Path to a directory containing benchmark code/documents.",
     )
     parser.add_argument(
         "--nsys-profiler",
@@ -445,10 +445,31 @@ def _build_agent_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _validate_target_inputs(args: argparse.Namespace) -> None:
+    missing = [
+        flag
+        for flag, value in (
+            ("--ref", args.ref),
+            ("--acc-checker", args.acc_checker),
+            ("--bench", args.bench),
+        )
+        if value is None
+    ]
+    if missing:
+        print(
+            "Error: missing required target input(s): "
+            + ", ".join(missing)
+            + ". Pass all three paths from the same example bundle.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
 def _validate_agent(args: argparse.Namespace) -> None:
     if args.modal and args.profiler == "nsys":
         print("Error: --modal only supports --profiler=torch.", file=sys.stderr)
         sys.exit(2)
+    _validate_target_inputs(args)
 
 
 def _run_agent(args: argparse.Namespace) -> None:
@@ -586,6 +607,7 @@ def _validate_evolve(args: argparse.Namespace) -> None:
     if args.modal and args.profiler == "nsys":
         print("Error: --modal only supports --profiler=torch.", file=sys.stderr)
         sys.exit(2)
+    _validate_target_inputs(args)
     if args.children_per_generation < 1:
         print("Error: --children-per-generation must be >= 1.", file=sys.stderr)
         sys.exit(2)
@@ -680,6 +702,7 @@ def _validate_openevolve(args: argparse.Namespace) -> None:
     if args.modal and args.profiler == "nsys":
         print("Error: --modal only supports --profiler=torch.", file=sys.stderr)
         sys.exit(2)
+    _validate_target_inputs(args)
     if args.max_iterations < 1:
         print("Error: --max-iterations must be >= 1.", file=sys.stderr)
         sys.exit(2)
@@ -756,6 +779,7 @@ def _validate_plain(args: argparse.Namespace) -> None:
     if args.modal and args.profiler == "nsys":
         print("Error: --modal only supports --profiler=torch.", file=sys.stderr)
         sys.exit(2)
+    _validate_target_inputs(args)
 
 
 def _run_plain(args: argparse.Namespace) -> None:

--- a/tests/loops/plain/test_plain_loop_cli.py
+++ b/tests/loops/plain/test_plain_loop_cli.py
@@ -9,6 +9,16 @@ from vibe_serve.cli import main
 from vibe_serve.loops.plain.loop import PlainLoopState
 
 
+TARGET_ARGS = [
+    "--ref",
+    "examples/Llama-3-8B/reference",
+    "--acc-checker",
+    "examples/Llama-3-8B/accuracy_checker",
+    "--bench",
+    "examples/Llama-3-8B/benchmark",
+]
+
+
 class TestBuildParser:
     def test_default_max_rounds(self):
         parser = build_parser()
@@ -60,14 +70,15 @@ class TestBuildParser:
         parser = build_parser()
         args = parser.parse_args(["--exp-name", "myexp"])
         assert args.exp_name == "myexp"
-        # _add_common_args provides --ref with a default
-        assert hasattr(args, "ref")
+        assert args.ref is None
+        assert args.acc_checker is None
+        assert args.bench is None
         assert hasattr(args, "docker")
         assert hasattr(args, "debug")
 
 
 class TestMain:
-    _BASE_ARGV = ["vibe-serve", "--outer-loop", "plain"]
+    _BASE_ARGV = ["vibe-serve", "--outer-loop", "plain", *TARGET_ARGS]
 
     def _patch_run(self, return_value: bool):
         return patch(

--- a/tests/loops/plain/test_plain_loop_cli.py
+++ b/tests/loops/plain/test_plain_loop_cli.py
@@ -8,7 +8,6 @@ from vibe_serve.cli import _build_plain_parser as build_parser
 from vibe_serve.cli import main
 from vibe_serve.loops.plain.loop import PlainLoopState
 
-
 TARGET_ARGS = [
     "--ref",
     "examples/Llama-3-8B/reference",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,6 @@ import pytest
 
 from vibe_serve.cli import _extract_flag, _extract_loop_selection, _validate_target_inputs, main
 
-
 TARGET_ARGS = [
     "--ref",
     "examples/Llama-3-8B/reference",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,17 @@ from unittest.mock import patch
 
 import pytest
 
-from vibe_serve.cli import _extract_flag, _extract_loop_selection, main
+from vibe_serve.cli import _extract_flag, _extract_loop_selection, _validate_target_inputs, main
+
+
+TARGET_ARGS = [
+    "--ref",
+    "examples/Llama-3-8B/reference",
+    "--acc-checker",
+    "examples/Llama-3-8B/accuracy_checker",
+    "--bench",
+    "examples/Llama-3-8B/benchmark",
+]
 
 # ---------------------------------------------------------------------------
 # Flag extraction
@@ -69,6 +79,30 @@ def test_extract_loop_selection_unknown_outer_loop_exits():
     assert exc.value.code == 2
 
 
+def test_target_inputs_default_to_none():
+    from vibe_serve.cli import _build_agent_parser
+
+    args = _build_agent_parser().parse_args([])
+
+    assert args.ref is None
+    assert args.acc_checker is None
+    assert args.bench is None
+
+
+def test_validate_target_inputs_requires_bundle_paths(capsys):
+    from vibe_serve.cli import _build_agent_parser
+
+    args = _build_agent_parser().parse_args(["--ref", "examples/Llama-3-8B/reference"])
+
+    with pytest.raises(SystemExit) as exc:
+        _validate_target_inputs(args)
+
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "--acc-checker" in err
+    assert "--bench" in err
+
+
 # ---------------------------------------------------------------------------
 # main() routes to the right runner
 # ---------------------------------------------------------------------------
@@ -83,7 +117,7 @@ def test_extract_loop_selection_unknown_outer_loop_exits():
     ],
 )
 def test_main_routes_to_runner(loop_name: str, runner_attr: str):
-    argv = ["vibe-serve", "--outer-loop", loop_name, "--exp-name", "x"]
+    argv = ["vibe-serve", "--outer-loop", loop_name, "--exp-name", "x", *TARGET_ARGS]
     with patch.object(sys, "argv", argv), patch(f"vibe_serve.cli.{runner_attr}") as runner:
         main()
         runner.assert_called_once()


### PR DESCRIPTION
## Summary

- Remove implicit Llama target defaults from `--ref`, `--acc-checker`, and `--bench`.
- Add shared validation that requires all three target inputs and tells users to pass paths from the same bundle.
- Update CLI tests to cover the missing-input validation and explicit target paths.

Closes #85.

## Validation

- `uv run pytest tests/test_cli.py tests/loops/plain/test_plain_loop_cli.py tests/loops/agent/test_orchestrate.py::test_cli_rejects_modal_with_nsys_profiler tests/backends/test_metal_backend.py::TestMetalCli::test_argparse_accepts_metal tests/backends/test_trainium_backend.py::TestTrainiumCli::test_argparse_accepts_trainium`
- `uv run pytest`
