### PR TITLE
Split CI quality checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,42 @@ on:
     branches: [main]
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Check Python formatting
+        run: ./scripts/check_format.sh
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Check Python lint
+        run: ./scripts/check_lint.sh
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -27,15 +63,39 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
-      - name: Check Python formatting
-        run: ./scripts/check_format.sh
-
-      - name: Check Python lint
-        run: ./scripts/check_lint.sh
-
       - name: Run tests
         run: uv run python -m pytest -v --cov=vibe_serve --cov-report=term-missing --cov-report=xml --cov-fail-under=75
 
+      - name: Upload coverage report
+        if: matrix.python-version == '3.11'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+
+  patch-coverage:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs: test
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-xml
+
       - name: Check patch coverage
-        if: github.event_name == 'pull_request'
         run: uv run diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref }} --fail-under=80


### PR DESCRIPTION
Closes #89.

## Summary
- Split formatting and linting into separate single-version CI jobs.
- Keep the pytest job as the only Python version matrix across 3.11 and 3.12.
- Move patch coverage into its own pull-request-only job that reuses the Python 3.11 coverage artifact.

## Validation
- Parsed `.github/workflows/test.yml` with PyYAML.
- Ran `git diff --check`.

Note: `actionlint` is not installed in this environment.