### PR TITLE
feat(agent): make the orchestrator prompt domain-configurable

### DIFF
--- a/src/vibe_serve/loops/agent/domain.py
+++ b/src/vibe_serve/loops/agent/domain.py
@@ -10,7 +10,9 @@ sections are injected into the neutral base prompts:
     ├── (free-form prose / description — ignored by the loop)
     ├── ## implementer    ← injected as {{ domain_implementer }}
     ├── ## judge          ← injected as {{ domain_judge }}
-    └── ## single_agent   ← injected as {{ domain_single_agent }}
+    ├── ## single_agent   ← injected as {{ domain_single_agent }}
+    ├── ## orchestrator   ← injected as {{ domain_orchestrator }}
+    └── ## roadmap_seed   ← seeds the fresh run's roadmap.md ## Major list
 
 The section heading *is* the address: a line that is exactly ``## <role>`` (for a
 role in :data:`DOMAIN_ROLES`) starts that role's section, which runs until the
@@ -39,9 +41,16 @@ from vibe_serve.prompts import render_string
 DEFAULT_DOMAIN = "llm-serving"
 
 # The roles a domain pack can contribute to. Each maps to a ``## <role>`` section
-# in the domain file and a ``{{ domain_<role> }}`` injection point in the
-# corresponding base prompt.
-DOMAIN_ROLES: tuple[str, ...] = ("implementer", "judge", "single_agent", "orchestrator")
+# in the domain file. Most map to a ``{{ domain_<role> }}`` injection point in the
+# corresponding base prompt; ``roadmap_seed`` instead seeds the fresh-run
+# ``roadmap.md`` (see ``issue_board.ensure_roadmap_file``).
+DOMAIN_ROLES: tuple[str, ...] = (
+    "implementer",
+    "judge",
+    "single_agent",
+    "orchestrator",
+    "roadmap_seed",
+)
 
 _BUILTIN_DOMAINS_DIR = Path(__file__).resolve().parent / "templates" / "_domain"
 

--- a/src/vibe_serve/loops/agent/issue_board.py
+++ b/src/vibe_serve/loops/agent/issue_board.py
@@ -32,6 +32,11 @@ from vibe_serve.schemas import (
 # ---------------------------------------------------------------------------
 
 
+# Domain packs may supply starter Major items via a ``## roadmap_seed`` section;
+# this sentinel marks where they land (or the neutral placeholder when none).
+_MAJOR_SEED_SENTINEL = "__MAJOR_SEED__"
+_MAJOR_SEED_PLACEHOLDER = "(populate on round 1 based on the objective)"
+
 _ROADMAP_HEADER = """# Roadmap
 
 You (the Orchestrator) own this file end-to-end. Update it every round
@@ -40,20 +45,20 @@ your next prompt — it does not parse it, so format it however you find
 useful, but follow these conventions so the structure stays legible:
 
 - **Major** items: structural changes expected to move the headline
-  performance metric meaningfully (e.g. "Implement EAGLE3 speculative
-  decoding", "Add CUDA graphs to verifier decode", "Replace manual
-  attention with FlashAttention"). Usually 1-3 rounds each.
+  performance metric meaningfully (e.g. a rewrite of a hot path, a new
+  algorithm or data structure, a different concurrency model). Usually
+  1-3 rounds each.
 - **Minor** items: bug fixes, polish, gates (correctness recoveries,
-  tiny kernel swaps, accuracy bumps). Usually 1 round each.
+  small swaps, accuracy bumps). Usually 1 round each.
 - Use one of these four statuses, and note rounds spent on each
   in-progress item:
   - `todo` — not started.
   - `in_progress` — actively being worked on this round (or recent rounds).
-  - `done` — implemented, profiler-verified, hitting (close to) predicted impact.
+  - `done` — implemented, verified, hitting (close to) predicted impact.
   - `parked` — implementation is buggy or incomplete, but you believe the
     *direction* is sound. Returnable to `in_progress` later. Use this when
-    the metric isn't moving for an *implementation* reason (zero acceptance
-    on EAGLE3, capture failures on CUDA graphs, …) rather than a workload
+    the metric isn't moving for an *implementation* reason (a new path that
+    never activates, a cache that never hits, …) rather than a workload
     reason.
   - `abandoned` — the *direction* itself doesn't fit this workload. Strict
     requirement (see below) before flipping to this state.
@@ -73,36 +78,32 @@ treat them as one bucket:
 - **`parked`** is the right call when (a) you predicted the technique
   would help, (b) the implementation passes the judge / pytest / accuracy
   gate, but (c) the headline metric didn't move *because the implementation
-  appears to have a bug or is incomplete*. Symptoms: zero acceptance on a
-  speculative decoder, all-fallback paths on what should be the fast path,
-  a CUDA graph capturing but never replaying, etc. The direction itself is
-  still believable; you just couldn't make the implementation good enough
-  in the rounds you spent. Mark `parked` and move to a different Major;
-  return to it when (i) you have a hypothesis for the bug, or (ii) other
-  levers are exhausted.
+  appears to have a bug or is incomplete*. Symptoms: a new fast path that
+  never activates, an always-fallback path, a precomputed step that is
+  captured but never reused, etc. The direction itself is still believable;
+  you just couldn't make the implementation good enough in the rounds you
+  spent. Mark `parked` and move to a different Major; return to it when
+  (i) you have a hypothesis for the bug, or (ii) other levers are exhausted.
 
 - **`abandoned`** is the right call only when the *direction itself* is
-  the wrong fit for this workload. Examples: continuous batching on a
-  workload contractually limited to single-batch, MTP on a model that
-  doesn't ship MTP heads, paged attention when the engine's fixed-shape
-  KV path is already optimal at this batch size. Each requires a
-  *mechanism-level* autopsy explaining why the technique cannot help
-  *here* (not "it didn't pay off in 3 rounds"). If you can't write that
+  the wrong fit for this workload. Each requires a *mechanism-level*
+  autopsy explaining why the technique cannot help *here* (not "it didn't
+  pay off in 3 rounds") — e.g. "the workload's contract fixes the very
+  quantity this technique would improve". If you can't write that
   mechanism, the right status is `parked`, not `abandoned`.
 
 **Hard rule for `abandoned` autopsies:** you must name a code-level or
 hardware-level mechanism — not a behavioral observation. A perf number
-("+0% TPOT") is not a mechanism; "the workload is single-batch by
-contract so continuous batching cannot raise arithmetic intensity" is.
-If acceptance on a speculative decoder is zero, that is *not* a reason
-to abandon — it's a debugging task, and the right status is `parked`
-with a hypothesis. Spec decode acceptance debugging has a checklist in
-`references/algorithms/speculative-decoding.md` ("Debugging 0
-acceptance"); read it before parking or abandoning.
+("+0% change") is not a mechanism; "the workload's contract fixes the
+very quantity this technique would improve, so it cannot help here" is.
+If a new path "isn't doing anything" (never activates, always falls back),
+that is *not* a reason to abandon — it's a debugging task, and the right
+status is `parked` with a hypothesis. Open the technique's reference
+material and fix the wiring before parking or abandoning.
 
 ## Major
 
-(populate on round 1 based on the objective)
+__MAJOR_SEED__
 
 ## Minor
 
@@ -122,14 +123,19 @@ acceptance"); read it before parking or abandoning.
 """
 
 
-def ensure_roadmap_file(roadmap_path: Path) -> None:
+def ensure_roadmap_file(roadmap_path: Path, *, seed_major: str = "") -> None:
     """Create the roadmap with the seed header if it doesn't exist.
+
+    ``seed_major`` is domain-supplied starter content for the ``## Major``
+    section (rendered from a domain pack's ``## roadmap_seed`` section); when
+    empty the neutral "populate on round 1" placeholder is used instead.
 
     Idempotent; safe to call every round.
     """
     if not roadmap_path.exists():
         roadmap_path.parent.mkdir(parents=True, exist_ok=True)
-        roadmap_path.write_text(_ROADMAP_HEADER)
+        major = seed_major.strip() or _MAJOR_SEED_PLACEHOLDER
+        roadmap_path.write_text(_ROADMAP_HEADER.replace(_MAJOR_SEED_SENTINEL, major))
 
 
 def read_roadmap(roadmap_path: Path) -> str:

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -646,7 +646,10 @@ def run_agent_loop(
     issue_board.ensure_progress_file(progress_path)
 
     roadmap_path = ctx.workspace / "roadmap.md"
-    issue_board.ensure_roadmap_file(roadmap_path)
+    roadmap_seed = render_domain_section(
+        domain_path, "roadmap_seed", **_domain_render_context(ctx, modality, interface)
+    )
+    issue_board.ensure_roadmap_file(roadmap_path, seed_major=roadmap_seed)
 
     rounds_state_path = ctx.log_dir / "rounds.json"
     records = _load_rounds_state(rounds_state_path)

--- a/src/vibe_serve/loops/agent/templates/_domain/README.md
+++ b/src/vibe_serve/loops/agent/templates/_domain/README.md
@@ -43,15 +43,20 @@ Combined builder+reviewer context for the single-agent ablation.
 
 ## orchestrator       ← injected as {{ domain_orchestrator }} (optional)
 Planning guidance for the round orchestrator — e.g. the optimization floor it
-should establish before chasing workload-specific wins.
+should establish before chasing workload-specific wins, plus your problem
+space's task examples, skill map, and pass-criteria examples.
+
+## roadmap_seed       ← seeds a fresh run's roadmap.md ## Major list (optional)
+Starter Major items the orchestrator inherits on round 1, one bullet each.
 ```
 
 Rules:
 
 - **The heading is the address.** A line that is exactly `## implementer`,
-  `## judge`, `## single_agent`, or `## orchestrator` starts that role's section;
-  it runs until the next role heading. Your section body can use its own `##`
-  sub-headings — only those four exact names delimit a section.
+  `## judge`, `## single_agent`, `## orchestrator`, or `## roadmap_seed` starts
+  that role's section; it runs until the next role heading. Your section body can
+  use its own `##`/`###` sub-headings — only those exact role names delimit a
+  section.
 - **A missing section injects nothing** for that role.
 - **`## single_agent` is optional.** Omit it and it's derived automatically by
   concatenating your `## implementer` and `## judge` sections — no third copy to
@@ -59,8 +64,18 @@ Rules:
   framing.
 - **`## orchestrator` is optional.** Omit it to inject nothing into the planner
   prompt (its neutral skeleton still applies). Add it to give the planner
-  domain-specific strategy — `llm-serving` uses it for the
-  continuous-batching/attention-kernel/CUDA-graph optimization floor.
+  domain-specific strategy. The base planner prompt is deliberately neutral — it
+  owns only universal loop discipline (roadmap upkeep, task granularity, pass
+  criteria) and delegates every problem-space *example* here. Organize the
+  section with `###` sub-headings (`### Optimization floor`, `### Task examples`,
+  `### Skill map`, `### Pass-criteria examples`, …); `llm-serving` uses them for
+  the continuous-batching/attention-kernel/CUDA-graph playbook, and a domain
+  author "adjusts a section" by editing those `###` blocks — no code change.
+- **`## roadmap_seed` is optional.** Its rendered body is dropped into the fresh
+  run's `roadmap.md` under `## Major` (round 1 only), so the planner starts from
+  a domain-appropriate arc instead of re-deriving one. Omit it and the roadmap
+  seeds a neutral "populate on round 1 based on the objective" placeholder. One
+  bullet per starter Major item.
 - Write normal Markdown prose. The base template owns the surrounding structure
   (task, pass criteria, workspace, output contract); your section owns the
   domain content.
@@ -111,8 +126,8 @@ a private domain is just a path you pass.
 
 ## Scope
 
-Domains cover **implementer + judge (+ single-agent + orchestrator) context**. Two adjacent
-concerns are deliberately *not* part of a domain file:
+Domains cover **implementer + judge (+ single-agent + orchestrator + roadmap seed)
+context**. Two adjacent concerns are deliberately *not* part of a domain file:
 
 - **Language/tooling** (e.g. "use `uv`/`pytest`") is decided by the run's
   `--interface` mode, not the domain: `inprocess` pins Python (uv toolchain +

--- a/src/vibe_serve/loops/agent/templates/_domain/llm-serving.md
+++ b/src/vibe_serve/loops/agent/templates/_domain/llm-serving.md
@@ -13,6 +13,12 @@ output correctness.
   sanity, the accuracy checker's schema + sentinel rates), headline-metric
   performance judging, reward-hack / model-bypass detection, and scope /
   static-inspection discipline.
+- *Orchestrator:* the serving optimization floor (continuous batching → fused
+  attention kernel → CUDA graphs) plus the LLM-serving task examples, skill map,
+  interface (OpenAI-API) contract, and pass-criteria examples the neutral base
+  planner deliberately omits.
+- *Roadmap seed:* seeds a fresh run's `roadmap.md` with the three optimization-
+  floor Major items so the planner starts from the serving arc, not a blank page.
 
 This is the default domain (`--domain llm-serving`); it reproduces vibeserve's
 original serving-oriented prompts. The `single_agent` ablation reuses a bespoke
@@ -157,3 +163,29 @@ The three exceptions that let you skip a floor item:
 - **CUDA graphs**: skip when the decode shapes are genuinely unbucketable (very rare — even speculative-decoding tree depths and chunked-prefill chunk sizes are ≤ 16 buckets).
 
 If you skip a floor item, cite the specific incompatibility in your `reasoning`. Do NOT skip because "the current profile shows something else is the dominant cost" — the floor items *become* the dominant cost in turn once other work lands, and cycling between "revert this, try that" over exotic optimizations without the floor in place is a common failure mode of this loop.
+
+## Task examples
+
+Tasks should be comparable in scope to, e.g.:
+- "Build a self-contained FastAPI server for the reference model."
+- "Add continuous batching to the decode loop."
+- "Replace manual attention with FlashInfer batched decode."
+- "Add CUDA graph capture/replay for the decode path."
+- "Fix the 8 ms launch overhead shown in `linear_layer_N` (top kernel in the last profile)."
+
+## Skill map
+
+Typical roadmap items map to one or two of the installed `serving-systems` skills — e.g. "Add CUDA graphs to verifier decode" → `cuda-graph` and possibly `flashattention` / `flashinfer`; "EAGLE3 wiring" → `speculative-decoding`; "xgrammar fast path" → `structured-output`. Point the implementer at the matching skill in the task.
+
+## Interface contract
+
+The implementer and judge templates do NOT hardcode the full API surface. When your task touches any HTTP endpoint or message-schema work, name the specific endpoint(s) and point the implementer at the authoritative skill file — typically `skills/serving-systems/tooling/openai-api/SKILL.md` (per-modality OpenAI-compatible contracts). Start with a single endpoint (e.g. "`POST /v1/completions` only, streaming SSE") and grow the surface as the roadmap progresses.
+
+## Pass-criteria examples
+
+Feature-level: "CUDA graph replay visible in profile", "`POST /v1/completions` streams SSE frames matching `skills/serving-systems/tooling/openai-api/SKILL.md` and terminates with `[DONE]`". Static-inspection (scope to authored files): "no `torch.profiler.profile(...)` invocations in `main.py` or any module the implementer added", "no per-token `torch.cat` against the KV cache in `main.py`'s decode path". Headline-vs-per-call trap: gate on the objective's headline metric (tok/s), never on "verify_replay_ms < decode_replay_ms" or "graph replay ≤ X ms".
+
+## roadmap_seed
+- **M1 Optimization floor: continuous batching** — `todo`. Why: raises arithmetic intensity under concurrent load; the dominant throughput lever for a batched server (skip only if the objective is single-batch by contract).
+- **M2 Optimization floor: fused attention kernel (FlashInfer / FlashAttention)** — `todo`. Why: removes the naive-attention memory-bandwidth bottleneck on NVIDIA hardware.
+- **M3 Optimization floor: CUDA graphs on the decode path** — `todo`. Why: eliminates per-step kernel-launch overhead in the steady-state decode loop.

--- a/src/vibe_serve/loops/agent/templates/orchestrator_plan_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/orchestrator_plan_prompt.j2
@@ -1,4 +1,4 @@
-You are the Orchestrator agent in an autonomous inference-server build loop. Your sole output is a plan for this round — you do NOT write or modify any code.
+You are the Orchestrator agent in an autonomous performance-optimization build loop. Your sole output is a plan for this round — you do NOT write or modify any code.
 
 ## Objective
 
@@ -29,9 +29,9 @@ You own a free-form markdown file at `roadmap.md` in your working directory. The
 These are not the same thing. Treating them as one bucket is the loop's most common failure mode, because it conflates "this technique has a bug" with "this technique doesn't fit". Use them precisely:
 
 - **`parked`** — implementation appears buggy or incomplete (e.g. wired but acceptance is zero, capture succeeds but never replays, fallback path always triggers), but the *direction* is still believable. Returnable to `in_progress`. This is the right call when the metric isn't moving for an *implementation* reason.
-- **`abandoned`** — the *direction itself* is wrong for this workload. Strict requirement: the autopsy must name a **code-level or hardware-level mechanism** explaining why the technique cannot help *here*, not a behavioral perf observation. A perf delta ("0% improvement", "0 acceptance") is not a mechanism. "Workload is single-batch by contract → continuous batching cannot raise arithmetic intensity" is. If you can't write a mechanism, the right status is **`parked`**, not `abandoned`.
+- **`abandoned`** — the *direction itself* is wrong for this workload. Strict requirement: the autopsy must name a **code-level or hardware-level mechanism** explaining why the technique cannot help *here*, not a behavioral perf observation. A perf delta ("0% improvement", "no measurable change") is not a mechanism. "The workload's contract fixes the very quantity this technique would improve, so it cannot help here" is. If you can't write a mechanism, the right status is **`parked`**, not `abandoned`.
 
-If you're tempted to abandon because of zero acceptance / zero replays / always-fallback, that's a debugging signal — open the relevant `references/...md` "Debugging X" subsection (e.g. `Debugging 0 acceptance` in `references/algorithms/speculative-decoding.md`) and either fix it or park it. Don't abandon.
+If you're tempted to abandon because a technique "isn't doing anything" (no measurable effect, a path that never activates, a fallback that always triggers), that's a debugging signal, not an abandonment reason — open the relevant reference material for that technique, fix the wiring or park it. Don't abandon.
 
 Required this round, in order:
 
@@ -61,7 +61,7 @@ Failing to address this and producing another flat-perf round buys you no inform
 
 ## Skills
 
-A library of curated technique-specific skills is installed in your working directory. Your CLI's native skill mechanism exposes their names + short descriptions; activate (open) the ones whose description matches the work this round needs — typical roadmap items map to one or two skills (e.g. "Add CUDA graphs to verifier decode" → `cuda-graph` and possibly `flashattention` / `flashinfer`; "EAGLE3 wiring" → `speculative-decoding`; "xgrammar fast path" → `structured-output`). Don't try to enumerate or preload them.
+If a curated skills library is installed in your working directory, your CLI's native skill mechanism exposes their names + short descriptions; activate (open) the ones whose description matches the work this round needs — match each roadmap item to the one or two skills that cover it. Don't try to enumerate or preload them. (The domain guidance below may map specific techniques to specific skills.)
 
 {% if profiler_summary %}
 ## Profiler summary (just collected this round)
@@ -102,35 +102,30 @@ The implementer could not pass within the retry budget. Propose a strictly small
 {% endif %}
 ## Task granularity
 
-Tasks should be comparable in scope to, e.g.:
-- "Build a self-contained FastAPI server for the reference model."
-- "Add continuous batching to the decode loop."
-- "Replace manual attention with FlashInfer batched decode."
-- "Add CUDA graph capture/replay for the decode path."
-- "Fix the 8 ms launch overhead shown in `linear_layer_N` (top kernel in the last profile)."
+Size each task to a single coherent, buildable change — one technique, one subsystem, or one fix — not a multi-part rewrite. The domain guidance above lists representative task examples for this problem space.
 
-## Scoping API work
+## Scoping interface work
 
-The implementer and judge templates intentionally do NOT hardcode the full API surface. When your task touches any HTTP endpoint or message-schema work, name the specific endpoint(s) and point the implementer at the authoritative skill file — typically `skills/serving-systems/tooling/openai-api/SKILL.md` (per-modality OpenAI-compatible contracts). The implementer is told to implement ONLY what you name; the judge is told to verify ONLY what your `pass_criteria` mentions. You can start with a single endpoint (e.g. "`POST /v1/completions` only, streaming SSE") and grow the surface as the roadmap progresses.
+The implementer and judge templates intentionally do NOT hardcode the full interface surface. When your task touches the interface (an HTTP endpoint, a wire command, a message schema), name the specific slice you want — the implementer is told to implement ONLY what you name, and the judge to verify ONLY what your `pass_criteria` mentions. Start narrow and grow the surface as the roadmap progresses. When an authoritative contract reference exists for the surface, the domain guidance above names it; point the implementer there.
 
 ## Pass criteria
 
-Criteria must be specific and testable. The framework ALWAYS runs the accuracy checker and a benchmark sanity check, so you only need to specify feature-level criteria (e.g. "CUDA graph replay visible in profile", "no fallback warnings in server log", "`POST /v1/completions` streams SSE frames matching `skills/serving-systems/tooling/openai-api/SKILL.md` and terminates with `[DONE]`"). Do NOT list endpoints you do not want the judge to verify this round.
+Criteria must be specific and testable. The framework ALWAYS runs the accuracy checker and a benchmark sanity check, so you only need to specify feature-level criteria (e.g. "the new fast path is exercised on the steady-state workload, visible in the profile or server log", "no fallback warnings in the server log", "feature X accepts input Y and returns Z per the contract"). Do NOT list requirements you do not want the judge to verify this round.
 
 **Runtime-environment notes are authoritative.** When the runtime-environment block above states a framework-level fact (decorator name, volume-name normalization rule, required entry-point names, namespace-prefix conventions, supported keyword arguments), that fact is **the truth for this round** even if a previous round's judge feedback or implementer summary in `progress.md` says something different. Prior feedback can be stale because the framework's own runtime contract evolved between rounds; do not propagate stale framework-level demands into this round's `pass_criteria`. If you spot a conflict between a prior judge demand and the runtime-environment block, drop the prior demand and write the criterion in terms of what the runtime-environment block says today.
 
-**Performance criteria use the objective's headline metric, end-to-end.** Whatever metric the OBJECTIVE specifies (single-batch tok/s, aggregate throughput, TTFT, p50/p99 latency, …) is the one the framework's plateau detector compares across rounds and the one your `pass_criteria` should reference for any performance gate. Always express it as the benchmark measures it end-to-end — never as a per-call, per-replay, or per-kernel timing.
+**Performance criteria use the objective's headline metric, end-to-end.** Whatever metric the OBJECTIVE specifies (throughput in ops/sec, requests/sec, time-to-first-byte, p50/p99 latency, …) is the one the framework's plateau detector compares across rounds and the one your `pass_criteria` should reference for any performance gate. Always express it as the benchmark measures it end-to-end — never as a per-call, per-replay, or per-kernel timing.
 
-This matters whenever a round adds a path that *trades per-call work for fewer calls* (speculative decoding, xgrammar jump-forward, batched extend, prefix caching, prompt caching, larger CUDA-graph buckets). A wider or heavier kernel can win on the headline metric while losing on per-call latency — that's the entire point of the technique. Pass criteria like *"verify_replay_ms < decode_replay_ms"* or *"graph replay ≤ X ms"* can't see those wins and will silently kill correct implementations. Phrase the gate on the headline metric instead, and tell the implementer to wire any runtime fallback the same way: *"after N steady requests, if the new path's headline metric trails the existing baseline path's by more than M%, fall back"*. Avoid asking for a startup-only gate that uses a fixed per-call time threshold — it can't see acceptance/forced-token/host-side effects and will give the wrong answer.
+This matters whenever a round adds a path that *trades per-call work for fewer calls* (a cache, a batched or fused path, a precompute or prefetch step, a larger work unit). A heavier per-call path can win on the headline metric while losing on per-call latency — that's the entire point of the technique. Pass criteria like *"per_call_time_A < per_call_time_B"* or *"step ≤ X ms"* can't see those wins and will silently kill correct implementations. Phrase the gate on the headline metric instead, and tell the implementer to wire any runtime fallback the same way: *"after N steady requests, if the new path's headline metric trails the existing baseline path's by more than M%, fall back"*. Avoid asking for a startup-only gate that uses a fixed per-call time threshold — it can't see steady-state or host-side effects and will give the wrong answer.
 
-**Scope static-inspection clauses to implementer-authored files.** When you write a "no X in the code" criterion (e.g. preventing a profiler bypass, banning a `torch.cat` KV-growth pattern, forbidding a schema synthesizer), name the file path you mean — typically `main.py` or modules the implementer authored. Phrasings like "no profiler/Nsight code" or "no benchmark code" are over-broad: the workspace contains framework-mounted directories (`bench/`, `acc_checker/`, `nsys_profiler/`, `torch_profiler/`, `reference/`, `skills/`) that the implementer can't delete and that legitimately contain the very keywords you'd grep for. Prefer wordings like:
+**Scope static-inspection clauses to implementer-authored files.** When you write a "no X in the code" criterion (e.g. preventing a profiler bypass, banning a specific hot-path pattern, forbidding a correctness bypass / shortcut), name the file path you mean — the implementer's authored server file(s) and the modules they added. Broad phrasings like "no profiler code" or "no benchmark code" are over-broad: the workspace contains framework-mounted directories (`bench/`, `acc_checker/`, `reference/`, `skills/`, and any profiler directories) that the implementer can't delete and that legitimately contain the very keywords you'd grep for. Prefer wordings like:
 
-- ✅ "no `torch.profiler.profile(...)` invocations in `main.py` or any module the implementer added"
-- ✅ "no per-token `torch.cat` against the KV cache in `main.py`'s decode path"
-- ❌ "no profiler/Nsight code" (will trip on `nsys_profiler/server.py` and burn rounds in retry loops)
+- ✅ "no `<profiler-call>` invocations in the implementer-authored server file or any module they added"
+- ✅ "no `<banned-pattern>` in the authored hot path"
+- ❌ "no profiler code" (will trip on the framework's profiler directory and burn rounds in retry loops)
 - ❌ "no benchmark code" (will trip on `bench/benchmark.py`)
 
-This was a real failure mode in earlier runs: a "no profiler/Nsight code" clause caused the judge to demand deletion of the framework's read-only `nsys_profiler/` mount, which the implementer cannot remove, exhausting the retry budget and forcing a packaging workaround the next round.
+This was a real failure mode in earlier runs: a "no profiler code" clause caused the judge to demand deletion of a framework-mounted profiler directory, which the implementer cannot remove, exhausting the retry budget and forcing a packaging workaround the next round.
 
 ## No early termination
 

--- a/src/vibe_serve/loops/agent/templates/orchestrator_pre_round_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/orchestrator_pre_round_prompt.j2
@@ -1,4 +1,4 @@
-You are the Orchestrator agent in an autonomous inference-server build loop.
+You are the Orchestrator agent in an autonomous performance-optimization build loop.
 
 This call has ONE job: decide whether a profiling pass is needed **before** you plan the next round's task. A full planning call will follow.
 
@@ -32,7 +32,7 @@ A library of curated technique-specific skills is installed in your working dire
 
 ## When to skip profiling
 
-- The next obvious step is clear from code inspection alone (e.g. continuous batching, CUDA graph, swapping a naive attention kernel for FlashInfer).
+- The next obvious step is clear from code inspection alone (e.g. an unbatched loop, a missing cache, an obviously suboptimal data structure or I/O path).
 - A recent profile is still valid — no workspace changes would invalidate it.
 - The previous judge loop exhausted; profiling a failing implementation wastes time — instead, skip the profile and propose an easier task.
 

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/orchestrator.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/orchestrator.md
@@ -1,4 +1,4 @@
-You are the Orchestrator agent in an autonomous inference-server build loop. Your sole output is a plan for this round — you do NOT write or modify any code.
+You are the Orchestrator agent in an autonomous performance-optimization build loop. Your sole output is a plan for this round — you do NOT write or modify any code.
 
 ## Objective
 
@@ -27,9 +27,9 @@ You own a free-form markdown file at `roadmap.md` in your working directory. The
 These are not the same thing. Treating them as one bucket is the loop's most common failure mode, because it conflates "this technique has a bug" with "this technique doesn't fit". Use them precisely:
 
 - **`parked`** — implementation appears buggy or incomplete (e.g. wired but acceptance is zero, capture succeeds but never replays, fallback path always triggers), but the *direction* is still believable. Returnable to `in_progress`. This is the right call when the metric isn't moving for an *implementation* reason.
-- **`abandoned`** — the *direction itself* is wrong for this workload. Strict requirement: the autopsy must name a **code-level or hardware-level mechanism** explaining why the technique cannot help *here*, not a behavioral perf observation. A perf delta ("0% improvement", "0 acceptance") is not a mechanism. "Workload is single-batch by contract → continuous batching cannot raise arithmetic intensity" is. If you can't write a mechanism, the right status is **`parked`**, not `abandoned`.
+- **`abandoned`** — the *direction itself* is wrong for this workload. Strict requirement: the autopsy must name a **code-level or hardware-level mechanism** explaining why the technique cannot help *here*, not a behavioral perf observation. A perf delta ("0% improvement", "no measurable change") is not a mechanism. "The workload's contract fixes the very quantity this technique would improve, so it cannot help here" is. If you can't write a mechanism, the right status is **`parked`**, not `abandoned`.
 
-If you're tempted to abandon because of zero acceptance / zero replays / always-fallback, that's a debugging signal — open the relevant `references/...md` "Debugging X" subsection (e.g. `Debugging 0 acceptance` in `references/algorithms/speculative-decoding.md`) and either fix it or park it. Don't abandon.
+If you're tempted to abandon because a technique "isn't doing anything" (no measurable effect, a path that never activates, a fallback that always triggers), that's a debugging signal, not an abandonment reason — open the relevant reference material for that technique, fix the wiring or park it. Don't abandon.
 
 Required this round, in order:
 
@@ -47,7 +47,7 @@ Required this round, in order:
 
 ## Skills
 
-A library of curated technique-specific skills is installed in your working directory. Your CLI's native skill mechanism exposes their names + short descriptions; activate (open) the ones whose description matches the work this round needs — typical roadmap items map to one or two skills (e.g. "Add CUDA graphs to verifier decode" → `cuda-graph` and possibly `flashattention` / `flashinfer`; "EAGLE3 wiring" → `speculative-decoding`; "xgrammar fast path" → `structured-output`). Don't try to enumerate or preload them.
+If a curated skills library is installed in your working directory, your CLI's native skill mechanism exposes their names + short descriptions; activate (open) the ones whose description matches the work this round needs — match each roadmap item to the one or two skills that cover it. Don't try to enumerate or preload them. (The domain guidance below may map specific techniques to specific skills.)
 
 
 
@@ -70,7 +70,7 @@ The three exceptions that let you skip a floor item:
 
 If you skip a floor item, cite the specific incompatibility in your `reasoning`. Do NOT skip because "the current profile shows something else is the dominant cost" — the floor items *become* the dominant cost in turn once other work lands, and cycling between "revert this, try that" over exotic optimizations without the floor in place is a common failure mode of this loop.
 
-## Task granularity
+## Task examples
 
 Tasks should be comparable in scope to, e.g.:
 - "Build a self-contained FastAPI server for the reference model."
@@ -79,28 +79,44 @@ Tasks should be comparable in scope to, e.g.:
 - "Add CUDA graph capture/replay for the decode path."
 - "Fix the 8 ms launch overhead shown in `linear_layer_N` (top kernel in the last profile)."
 
-## Scoping API work
+## Skill map
 
-The implementer and judge templates intentionally do NOT hardcode the full API surface. When your task touches any HTTP endpoint or message-schema work, name the specific endpoint(s) and point the implementer at the authoritative skill file — typically `skills/serving-systems/tooling/openai-api/SKILL.md` (per-modality OpenAI-compatible contracts). The implementer is told to implement ONLY what you name; the judge is told to verify ONLY what your `pass_criteria` mentions. You can start with a single endpoint (e.g. "`POST /v1/completions` only, streaming SSE") and grow the surface as the roadmap progresses.
+Typical roadmap items map to one or two of the installed `serving-systems` skills — e.g. "Add CUDA graphs to verifier decode" → `cuda-graph` and possibly `flashattention` / `flashinfer`; "EAGLE3 wiring" → `speculative-decoding`; "xgrammar fast path" → `structured-output`. Point the implementer at the matching skill in the task.
+
+## Interface contract
+
+The implementer and judge templates do NOT hardcode the full API surface. When your task touches any HTTP endpoint or message-schema work, name the specific endpoint(s) and point the implementer at the authoritative skill file — typically `skills/serving-systems/tooling/openai-api/SKILL.md` (per-modality OpenAI-compatible contracts). Start with a single endpoint (e.g. "`POST /v1/completions` only, streaming SSE") and grow the surface as the roadmap progresses.
+
+## Pass-criteria examples
+
+Feature-level: "CUDA graph replay visible in profile", "`POST /v1/completions` streams SSE frames matching `skills/serving-systems/tooling/openai-api/SKILL.md` and terminates with `[DONE]`". Static-inspection (scope to authored files): "no `torch.profiler.profile(...)` invocations in `main.py` or any module the implementer added", "no per-token `torch.cat` against the KV cache in `main.py`'s decode path". Headline-vs-per-call trap: gate on the objective's headline metric (tok/s), never on "verify_replay_ms < decode_replay_ms" or "graph replay ≤ X ms".
+
+## Task granularity
+
+Size each task to a single coherent, buildable change — one technique, one subsystem, or one fix — not a multi-part rewrite. The domain guidance above lists representative task examples for this problem space.
+
+## Scoping interface work
+
+The implementer and judge templates intentionally do NOT hardcode the full interface surface. When your task touches the interface (an HTTP endpoint, a wire command, a message schema), name the specific slice you want — the implementer is told to implement ONLY what you name, and the judge to verify ONLY what your `pass_criteria` mentions. Start narrow and grow the surface as the roadmap progresses. When an authoritative contract reference exists for the surface, the domain guidance above names it; point the implementer there.
 
 ## Pass criteria
 
-Criteria must be specific and testable. The framework ALWAYS runs the accuracy checker and a benchmark sanity check, so you only need to specify feature-level criteria (e.g. "CUDA graph replay visible in profile", "no fallback warnings in server log", "`POST /v1/completions` streams SSE frames matching `skills/serving-systems/tooling/openai-api/SKILL.md` and terminates with `[DONE]`"). Do NOT list endpoints you do not want the judge to verify this round.
+Criteria must be specific and testable. The framework ALWAYS runs the accuracy checker and a benchmark sanity check, so you only need to specify feature-level criteria (e.g. "the new fast path is exercised on the steady-state workload, visible in the profile or server log", "no fallback warnings in the server log", "feature X accepts input Y and returns Z per the contract"). Do NOT list requirements you do not want the judge to verify this round.
 
 **Runtime-environment notes are authoritative.** When the runtime-environment block above states a framework-level fact (decorator name, volume-name normalization rule, required entry-point names, namespace-prefix conventions, supported keyword arguments), that fact is **the truth for this round** even if a previous round's judge feedback or implementer summary in `progress.md` says something different. Prior feedback can be stale because the framework's own runtime contract evolved between rounds; do not propagate stale framework-level demands into this round's `pass_criteria`. If you spot a conflict between a prior judge demand and the runtime-environment block, drop the prior demand and write the criterion in terms of what the runtime-environment block says today.
 
-**Performance criteria use the objective's headline metric, end-to-end.** Whatever metric the OBJECTIVE specifies (single-batch tok/s, aggregate throughput, TTFT, p50/p99 latency, …) is the one the framework's plateau detector compares across rounds and the one your `pass_criteria` should reference for any performance gate. Always express it as the benchmark measures it end-to-end — never as a per-call, per-replay, or per-kernel timing.
+**Performance criteria use the objective's headline metric, end-to-end.** Whatever metric the OBJECTIVE specifies (throughput in ops/sec, requests/sec, time-to-first-byte, p50/p99 latency, …) is the one the framework's plateau detector compares across rounds and the one your `pass_criteria` should reference for any performance gate. Always express it as the benchmark measures it end-to-end — never as a per-call, per-replay, or per-kernel timing.
 
-This matters whenever a round adds a path that *trades per-call work for fewer calls* (speculative decoding, xgrammar jump-forward, batched extend, prefix caching, prompt caching, larger CUDA-graph buckets). A wider or heavier kernel can win on the headline metric while losing on per-call latency — that's the entire point of the technique. Pass criteria like *"verify_replay_ms < decode_replay_ms"* or *"graph replay ≤ X ms"* can't see those wins and will silently kill correct implementations. Phrase the gate on the headline metric instead, and tell the implementer to wire any runtime fallback the same way: *"after N steady requests, if the new path's headline metric trails the existing baseline path's by more than M%, fall back"*. Avoid asking for a startup-only gate that uses a fixed per-call time threshold — it can't see acceptance/forced-token/host-side effects and will give the wrong answer.
+This matters whenever a round adds a path that *trades per-call work for fewer calls* (a cache, a batched or fused path, a precompute or prefetch step, a larger work unit). A heavier per-call path can win on the headline metric while losing on per-call latency — that's the entire point of the technique. Pass criteria like *"per_call_time_A < per_call_time_B"* or *"step ≤ X ms"* can't see those wins and will silently kill correct implementations. Phrase the gate on the headline metric instead, and tell the implementer to wire any runtime fallback the same way: *"after N steady requests, if the new path's headline metric trails the existing baseline path's by more than M%, fall back"*. Avoid asking for a startup-only gate that uses a fixed per-call time threshold — it can't see steady-state or host-side effects and will give the wrong answer.
 
-**Scope static-inspection clauses to implementer-authored files.** When you write a "no X in the code" criterion (e.g. preventing a profiler bypass, banning a `torch.cat` KV-growth pattern, forbidding a schema synthesizer), name the file path you mean — typically `main.py` or modules the implementer authored. Phrasings like "no profiler/Nsight code" or "no benchmark code" are over-broad: the workspace contains framework-mounted directories (`bench/`, `acc_checker/`, `nsys_profiler/`, `torch_profiler/`, `reference/`, `skills/`) that the implementer can't delete and that legitimately contain the very keywords you'd grep for. Prefer wordings like:
+**Scope static-inspection clauses to implementer-authored files.** When you write a "no X in the code" criterion (e.g. preventing a profiler bypass, banning a specific hot-path pattern, forbidding a correctness bypass / shortcut), name the file path you mean — the implementer's authored server file(s) and the modules they added. Broad phrasings like "no profiler code" or "no benchmark code" are over-broad: the workspace contains framework-mounted directories (`bench/`, `acc_checker/`, `reference/`, `skills/`, and any profiler directories) that the implementer can't delete and that legitimately contain the very keywords you'd grep for. Prefer wordings like:
 
-- ✅ "no `torch.profiler.profile(...)` invocations in `main.py` or any module the implementer added"
-- ✅ "no per-token `torch.cat` against the KV cache in `main.py`'s decode path"
-- ❌ "no profiler/Nsight code" (will trip on `nsys_profiler/server.py` and burn rounds in retry loops)
+- ✅ "no `<profiler-call>` invocations in the implementer-authored server file or any module they added"
+- ✅ "no `<banned-pattern>` in the authored hot path"
+- ❌ "no profiler code" (will trip on the framework's profiler directory and burn rounds in retry loops)
 - ❌ "no benchmark code" (will trip on `bench/benchmark.py`)
 
-This was a real failure mode in earlier runs: a "no profiler/Nsight code" clause caused the judge to demand deletion of the framework's read-only `nsys_profiler/` mount, which the implementer cannot remove, exhausting the retry budget and forcing a packaging workaround the next round.
+This was a real failure mode in earlier runs: a "no profiler code" clause caused the judge to demand deletion of a framework-mounted profiler directory, which the implementer cannot remove, exhausting the retry budget and forcing a packaging workaround the next round.
 
 ## No early termination
 

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/orchestrator.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/orchestrator.md
@@ -1,4 +1,4 @@
-You are the Orchestrator agent in an autonomous inference-server build loop. Your sole output is a plan for this round — you do NOT write or modify any code.
+You are the Orchestrator agent in an autonomous performance-optimization build loop. Your sole output is a plan for this round — you do NOT write or modify any code.
 
 ## Objective
 
@@ -24,9 +24,9 @@ You own a free-form markdown file at `roadmap.md` in your working directory. The
 These are not the same thing. Treating them as one bucket is the loop's most common failure mode, because it conflates "this technique has a bug" with "this technique doesn't fit". Use them precisely:
 
 - **`parked`** — implementation appears buggy or incomplete (e.g. wired but acceptance is zero, capture succeeds but never replays, fallback path always triggers), but the *direction* is still believable. Returnable to `in_progress`. This is the right call when the metric isn't moving for an *implementation* reason.
-- **`abandoned`** — the *direction itself* is wrong for this workload. Strict requirement: the autopsy must name a **code-level or hardware-level mechanism** explaining why the technique cannot help *here*, not a behavioral perf observation. A perf delta ("0% improvement", "0 acceptance") is not a mechanism. "Workload is single-batch by contract → continuous batching cannot raise arithmetic intensity" is. If you can't write a mechanism, the right status is **`parked`**, not `abandoned`.
+- **`abandoned`** — the *direction itself* is wrong for this workload. Strict requirement: the autopsy must name a **code-level or hardware-level mechanism** explaining why the technique cannot help *here*, not a behavioral perf observation. A perf delta ("0% improvement", "no measurable change") is not a mechanism. "The workload's contract fixes the very quantity this technique would improve, so it cannot help here" is. If you can't write a mechanism, the right status is **`parked`**, not `abandoned`.
 
-If you're tempted to abandon because of zero acceptance / zero replays / always-fallback, that's a debugging signal — open the relevant `references/...md` "Debugging X" subsection (e.g. `Debugging 0 acceptance` in `references/algorithms/speculative-decoding.md`) and either fix it or park it. Don't abandon.
+If you're tempted to abandon because a technique "isn't doing anything" (no measurable effect, a path that never activates, a fallback that always triggers), that's a debugging signal, not an abandonment reason — open the relevant reference material for that technique, fix the wiring or park it. Don't abandon.
 
 Required this round, in order:
 
@@ -44,7 +44,7 @@ Required this round, in order:
 
 ## Skills
 
-A library of curated technique-specific skills is installed in your working directory. Your CLI's native skill mechanism exposes their names + short descriptions; activate (open) the ones whose description matches the work this round needs — typical roadmap items map to one or two skills (e.g. "Add CUDA graphs to verifier decode" → `cuda-graph` and possibly `flashattention` / `flashinfer`; "EAGLE3 wiring" → `speculative-decoding`; "xgrammar fast path" → `structured-output`). Don't try to enumerate or preload them.
+If a curated skills library is installed in your working directory, your CLI's native skill mechanism exposes their names + short descriptions; activate (open) the ones whose description matches the work this round needs — match each roadmap item to the one or two skills that cover it. Don't try to enumerate or preload them. (The domain guidance below may map specific techniques to specific skills.)
 
 
 
@@ -67,7 +67,7 @@ The three exceptions that let you skip a floor item:
 
 If you skip a floor item, cite the specific incompatibility in your `reasoning`. Do NOT skip because "the current profile shows something else is the dominant cost" — the floor items *become* the dominant cost in turn once other work lands, and cycling between "revert this, try that" over exotic optimizations without the floor in place is a common failure mode of this loop.
 
-## Task granularity
+## Task examples
 
 Tasks should be comparable in scope to, e.g.:
 - "Build a self-contained FastAPI server for the reference model."
@@ -76,28 +76,44 @@ Tasks should be comparable in scope to, e.g.:
 - "Add CUDA graph capture/replay for the decode path."
 - "Fix the 8 ms launch overhead shown in `linear_layer_N` (top kernel in the last profile)."
 
-## Scoping API work
+## Skill map
 
-The implementer and judge templates intentionally do NOT hardcode the full API surface. When your task touches any HTTP endpoint or message-schema work, name the specific endpoint(s) and point the implementer at the authoritative skill file — typically `skills/serving-systems/tooling/openai-api/SKILL.md` (per-modality OpenAI-compatible contracts). The implementer is told to implement ONLY what you name; the judge is told to verify ONLY what your `pass_criteria` mentions. You can start with a single endpoint (e.g. "`POST /v1/completions` only, streaming SSE") and grow the surface as the roadmap progresses.
+Typical roadmap items map to one or two of the installed `serving-systems` skills — e.g. "Add CUDA graphs to verifier decode" → `cuda-graph` and possibly `flashattention` / `flashinfer`; "EAGLE3 wiring" → `speculative-decoding`; "xgrammar fast path" → `structured-output`. Point the implementer at the matching skill in the task.
+
+## Interface contract
+
+The implementer and judge templates do NOT hardcode the full API surface. When your task touches any HTTP endpoint or message-schema work, name the specific endpoint(s) and point the implementer at the authoritative skill file — typically `skills/serving-systems/tooling/openai-api/SKILL.md` (per-modality OpenAI-compatible contracts). Start with a single endpoint (e.g. "`POST /v1/completions` only, streaming SSE") and grow the surface as the roadmap progresses.
+
+## Pass-criteria examples
+
+Feature-level: "CUDA graph replay visible in profile", "`POST /v1/completions` streams SSE frames matching `skills/serving-systems/tooling/openai-api/SKILL.md` and terminates with `[DONE]`". Static-inspection (scope to authored files): "no `torch.profiler.profile(...)` invocations in `main.py` or any module the implementer added", "no per-token `torch.cat` against the KV cache in `main.py`'s decode path". Headline-vs-per-call trap: gate on the objective's headline metric (tok/s), never on "verify_replay_ms < decode_replay_ms" or "graph replay ≤ X ms".
+
+## Task granularity
+
+Size each task to a single coherent, buildable change — one technique, one subsystem, or one fix — not a multi-part rewrite. The domain guidance above lists representative task examples for this problem space.
+
+## Scoping interface work
+
+The implementer and judge templates intentionally do NOT hardcode the full interface surface. When your task touches the interface (an HTTP endpoint, a wire command, a message schema), name the specific slice you want — the implementer is told to implement ONLY what you name, and the judge to verify ONLY what your `pass_criteria` mentions. Start narrow and grow the surface as the roadmap progresses. When an authoritative contract reference exists for the surface, the domain guidance above names it; point the implementer there.
 
 ## Pass criteria
 
-Criteria must be specific and testable. The framework ALWAYS runs the accuracy checker and a benchmark sanity check, so you only need to specify feature-level criteria (e.g. "CUDA graph replay visible in profile", "no fallback warnings in server log", "`POST /v1/completions` streams SSE frames matching `skills/serving-systems/tooling/openai-api/SKILL.md` and terminates with `[DONE]`"). Do NOT list endpoints you do not want the judge to verify this round.
+Criteria must be specific and testable. The framework ALWAYS runs the accuracy checker and a benchmark sanity check, so you only need to specify feature-level criteria (e.g. "the new fast path is exercised on the steady-state workload, visible in the profile or server log", "no fallback warnings in the server log", "feature X accepts input Y and returns Z per the contract"). Do NOT list requirements you do not want the judge to verify this round.
 
 **Runtime-environment notes are authoritative.** When the runtime-environment block above states a framework-level fact (decorator name, volume-name normalization rule, required entry-point names, namespace-prefix conventions, supported keyword arguments), that fact is **the truth for this round** even if a previous round's judge feedback or implementer summary in `progress.md` says something different. Prior feedback can be stale because the framework's own runtime contract evolved between rounds; do not propagate stale framework-level demands into this round's `pass_criteria`. If you spot a conflict between a prior judge demand and the runtime-environment block, drop the prior demand and write the criterion in terms of what the runtime-environment block says today.
 
-**Performance criteria use the objective's headline metric, end-to-end.** Whatever metric the OBJECTIVE specifies (single-batch tok/s, aggregate throughput, TTFT, p50/p99 latency, …) is the one the framework's plateau detector compares across rounds and the one your `pass_criteria` should reference for any performance gate. Always express it as the benchmark measures it end-to-end — never as a per-call, per-replay, or per-kernel timing.
+**Performance criteria use the objective's headline metric, end-to-end.** Whatever metric the OBJECTIVE specifies (throughput in ops/sec, requests/sec, time-to-first-byte, p50/p99 latency, …) is the one the framework's plateau detector compares across rounds and the one your `pass_criteria` should reference for any performance gate. Always express it as the benchmark measures it end-to-end — never as a per-call, per-replay, or per-kernel timing.
 
-This matters whenever a round adds a path that *trades per-call work for fewer calls* (speculative decoding, xgrammar jump-forward, batched extend, prefix caching, prompt caching, larger CUDA-graph buckets). A wider or heavier kernel can win on the headline metric while losing on per-call latency — that's the entire point of the technique. Pass criteria like *"verify_replay_ms < decode_replay_ms"* or *"graph replay ≤ X ms"* can't see those wins and will silently kill correct implementations. Phrase the gate on the headline metric instead, and tell the implementer to wire any runtime fallback the same way: *"after N steady requests, if the new path's headline metric trails the existing baseline path's by more than M%, fall back"*. Avoid asking for a startup-only gate that uses a fixed per-call time threshold — it can't see acceptance/forced-token/host-side effects and will give the wrong answer.
+This matters whenever a round adds a path that *trades per-call work for fewer calls* (a cache, a batched or fused path, a precompute or prefetch step, a larger work unit). A heavier per-call path can win on the headline metric while losing on per-call latency — that's the entire point of the technique. Pass criteria like *"per_call_time_A < per_call_time_B"* or *"step ≤ X ms"* can't see those wins and will silently kill correct implementations. Phrase the gate on the headline metric instead, and tell the implementer to wire any runtime fallback the same way: *"after N steady requests, if the new path's headline metric trails the existing baseline path's by more than M%, fall back"*. Avoid asking for a startup-only gate that uses a fixed per-call time threshold — it can't see steady-state or host-side effects and will give the wrong answer.
 
-**Scope static-inspection clauses to implementer-authored files.** When you write a "no X in the code" criterion (e.g. preventing a profiler bypass, banning a `torch.cat` KV-growth pattern, forbidding a schema synthesizer), name the file path you mean — typically `main.py` or modules the implementer authored. Phrasings like "no profiler/Nsight code" or "no benchmark code" are over-broad: the workspace contains framework-mounted directories (`bench/`, `acc_checker/`, `nsys_profiler/`, `torch_profiler/`, `reference/`, `skills/`) that the implementer can't delete and that legitimately contain the very keywords you'd grep for. Prefer wordings like:
+**Scope static-inspection clauses to implementer-authored files.** When you write a "no X in the code" criterion (e.g. preventing a profiler bypass, banning a specific hot-path pattern, forbidding a correctness bypass / shortcut), name the file path you mean — the implementer's authored server file(s) and the modules they added. Broad phrasings like "no profiler code" or "no benchmark code" are over-broad: the workspace contains framework-mounted directories (`bench/`, `acc_checker/`, `reference/`, `skills/`, and any profiler directories) that the implementer can't delete and that legitimately contain the very keywords you'd grep for. Prefer wordings like:
 
-- ✅ "no `torch.profiler.profile(...)` invocations in `main.py` or any module the implementer added"
-- ✅ "no per-token `torch.cat` against the KV cache in `main.py`'s decode path"
-- ❌ "no profiler/Nsight code" (will trip on `nsys_profiler/server.py` and burn rounds in retry loops)
+- ✅ "no `<profiler-call>` invocations in the implementer-authored server file or any module they added"
+- ✅ "no `<banned-pattern>` in the authored hot path"
+- ❌ "no profiler code" (will trip on the framework's profiler directory and burn rounds in retry loops)
 - ❌ "no benchmark code" (will trip on `bench/benchmark.py`)
 
-This was a real failure mode in earlier runs: a "no profiler/Nsight code" clause caused the judge to demand deletion of the framework's read-only `nsys_profiler/` mount, which the implementer cannot remove, exhausting the retry budget and forcing a packaging workaround the next round.
+This was a real failure mode in earlier runs: a "no profiler code" clause caused the judge to demand deletion of a framework-mounted profiler directory, which the implementer cannot remove, exhausting the retry budget and forcing a packaging workaround the next round.
 
 ## No early termination
 

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from vibe_serve.loops.agent import issue_board
 from vibe_serve.loops.agent.domain import (
     DEFAULT_DOMAIN,
     DOMAIN_ROLES,
@@ -239,4 +240,89 @@ def test_generic_orchestrator_has_no_llm_floor():
     assert "Optimization priority" not in out
     assert "Continuous batching" not in out
     assert "the optimization-floor section below" not in out
-    assert "## Task granularity" in out  # base skeleton intact
+    assert "## Task granularity" in out  # neutral base skeleton intact
+    assert "## Output" in out  # base skeleton intact
+
+
+def test_generic_orchestrator_has_no_llm_tokens():
+    """The neutral base carries no LLM/PyTorch specifics — all such examples now
+    live in the llm-serving pack, so the generic render must be domain-free."""
+    out = _render_orchestrator("generic").lower()
+    for token in (
+        "fastapi",
+        "cuda",
+        "flashinfer",
+        "flashattention",
+        "eagle",
+        "torch",
+        "inference-server",
+        "inference server",
+        "speculative",
+        "tok/s",
+        "openai",
+    ):
+        assert token not in out, f"leaked LLM token into neutral base: {token!r}"
+
+
+def test_llm_serving_orchestrator_carries_moved_examples():
+    """The examples removed from the base must resurface via the pack (behaviour
+    preserved for the default domain)."""
+    out = _render_orchestrator("llm-serving")
+    assert "## Task examples" in out
+    assert "FastAPI" in out
+    assert "continuous batching" in out.lower()
+    assert "## Skill map" in out
+    assert "openai-api" in out  # interface contract reference
+    assert "## Pass-criteria examples" in out
+
+
+# --------------------------------------------------------------------------- #
+# roadmap_seed role — de-biases the fresh-run roadmap
+# --------------------------------------------------------------------------- #
+def test_roadmap_seed_is_a_domain_role():
+    assert "roadmap_seed" in DOMAIN_ROLES
+
+
+def test_llm_serving_roadmap_seed_non_empty():
+    seed = render_domain_section(
+        resolve_domain("llm-serving"), "roadmap_seed", modality="text_generation"
+    )
+    assert seed
+    assert "continuous batching" in seed.lower()
+
+
+def test_generic_roadmap_seed_is_empty():
+    seed = render_domain_section(
+        resolve_domain("generic"), "roadmap_seed", modality="text_generation"
+    )
+    assert seed == ""
+
+
+def test_ensure_roadmap_injects_seed_major(tmp_path: Path):
+    roadmap = tmp_path / "roadmap.md"
+    issue_board.ensure_roadmap_file(roadmap, seed_major="- **M1 native RESP server** — todo")
+    text = roadmap.read_text()
+    assert "- **M1 native RESP server** — todo" in text
+    # the seed lands under the ## Major section, not the placeholder
+    major = text.split("## Major", 1)[1]
+    assert "M1 native RESP server" in major
+    assert "(populate on round 1" not in major
+
+
+def test_ensure_roadmap_without_seed_uses_neutral_placeholder(tmp_path: Path):
+    roadmap = tmp_path / "roadmap.md"
+    issue_board.ensure_roadmap_file(roadmap)
+    text = roadmap.read_text()
+    assert "(populate on round 1 based on the objective)" in text
+    # the neutral header must not carry LLM-specific starter items
+    for token in ("EAGLE", "CUDA", "FlashAttention", "FlashInfer"):
+        assert token not in text, f"neutral roadmap header leaked LLM token: {token!r}"
+
+
+def test_ensure_roadmap_is_idempotent(tmp_path: Path):
+    roadmap = tmp_path / "roadmap.md"
+    issue_board.ensure_roadmap_file(roadmap, seed_major="- **M1** — todo")
+    first = roadmap.read_text()
+    # a second call (e.g. a later round) must not clobber orchestrator edits
+    issue_board.ensure_roadmap_file(roadmap, seed_major="- **DIFFERENT** — todo")
+    assert roadmap.read_text() == first


### PR DESCRIPTION
## What

Makes the agent-loop **orchestrator prompt domain-configurable**. The base
planner prompt hardcoded LLM-serving/PyTorch specifics (FastAPI/CUDA task
examples, cuda-graph/EAGLE3 skill hints, openai-api scoping, `torch.*`
pass-criteria examples), and `issue_board` reseeded every fresh `roadmap.md`
with LLM Major items (EAGLE3, CUDA graphs, FlashAttention). These leaked
LLM/Python gravity into **every** domain — the root cause of the kv-store
"always picks Python" bias.

This neutralizes the base and pushes all problem-space specifics into the domain
pack:

- `orchestrator_plan_prompt.j2` / `orchestrator_pre_round_prompt.j2` carry only
  universal loop discipline now; a `generic` render has **zero** LLM tokens.
- New `## roadmap_seed` domain role (`DOMAIN_ROLES`) seeds the fresh
  `roadmap.md` `## Major` list from the pack; `_ROADMAP_HEADER` genericized and
  `ensure_roadmap_file` gains `seed_major=`. Threaded in `loop.py`.
- `llm-serving.md` absorbs the moved task examples / skill map / interface
  contract / pass-criteria examples + a `roadmap_seed`, so the **default domain
  is behavior-preserving** — verified as a pure prompt-snapshot reflow.
- Docs (`_domain/README.md`, `domain.py`) document the orchestrator override
  convention and the `roadmap_seed` role.

## Why

Any domain — LLM serving, C/Rust KV-store, future targets — now supplies its own
orchestrator content via its pack, and `generic` yields a truly neutral
orchestrator. This is the extensible, general fix (vs. a one-line "force C"
hack).

## Testing

- `uv run pytest` — full suite green; +9 tests for the moved examples and the
  `roadmap_seed` role (llm-serving non-empty, generic empty, seed injection,
  neutral header has no EAGLE3/CUDA).
- Prompt snapshots regenerated for the two orchestrator llm-serving cases;
  diff confirmed a reflow, not a behavior change.

## Stack

Based on `pr/interface-modes` (#80). Consumed by the kv-store target PR, which
adds its own compiled-language orchestrator guidance + `roadmap_seed` on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
