### PR TITLE
Fix correctness and robustness issues in the train-ticket example

### DIFF
--- a/examples/microservices/train-ticket/README.md
+++ b/examples/microservices/train-ticket/README.md
@@ -19,10 +19,12 @@ python examples/microservices/train-ticket/benchmark/benchmark.py --base-url htt
 Both scripts use only the Python standard library.
 
 For the prebuilt-image local Docker Compose helper below, use
-`--direct-services` or the helper `check`/`bench` commands. The currently
-published gateway image starts, but in the minimal local compose it can return
-`503` while the individual service ports are healthy. With source-built
-`localtrain:source` images, the gateway path was verified successfully too.
+`--direct-services` or the helper `check`/`bench` commands. The prebuilt
+`codewisdom` 0.2.0 service images predate Nacos support and never register
+with the discovery server, so the published gateway image starts but returns
+`503` for every route — deterministically, not transiently. The gateway path
+only works with source-built `localtrain:source` images (verified), which do
+register with Nacos.
 
 ## Local Cluster
 
@@ -39,18 +41,27 @@ examples/microservices/train-ticket/scripts/start-local-cluster.sh stop
 Defaults:
 
 - Gateway: `http://localhost:18888`
-- Images: `codewisdom/<service>:0.2.0`
+- Images: `codewisdom/<service>:0.2.0` (gateway: `codewisdom/ts-gateway-service:latest`,
+  the only tag published for it)
 
 The script generates a temporary compose file under `/tmp` that exposes the
 gateway and the core read-only service ports used by the checker. Override
-with `TT_GATEWAY_PORT`, `TT_NAMESPACE`, or `TT_TAG` if needed.
+with `TT_GATEWAY_PORT`, `TT_NAMESPACE`, `TT_TAG`, or `TT_GATEWAY_TAG` if
+needed.
 
 The local helper starts a minimal API cluster: Nacos, Redis, the gateway, and
 the config/station/train/travel/route/price services with their local MongoDB
-and MySQL dependencies. Auth-protected services such as contacts are excluded
-from the default no-auth checker and benchmark. The published dashboard image
-is intentionally not started because its nginx config references additional
-services outside this minimal read-only cluster.
+and MySQL dependencies. The 0.2.0 prebuilt images store data in MongoDB (the
+MySQL containers and `*_MYSQL_*` env are used by source-built v1.0.0 images
+instead; both datastores are started so either image set works). All services
+self-seed reference data on startup, so `check` runs the checker in strict
+mode (no `--allow-empty`). Auth-protected services such as contacts are
+excluded from the default no-auth checker and benchmark. The published
+dashboard image is intentionally not started because its nginx config
+references additional services outside this minimal read-only cluster.
+
+`stop` removes the containers together with their anonymous data volumes;
+each `start` reseeds from scratch.
 
 ## Build From Source
 
@@ -109,8 +120,7 @@ Manual direct-service runs:
 ```bash
 python examples/microservices/train-ticket/accuracy_checker/checker.py \
   --base-url http://localhost:18888 \
-  --direct-services \
-  --allow-empty
+  --direct-services
 
 python examples/microservices/train-ticket/benchmark/benchmark.py \
   --base-url http://localhost:18888 \
@@ -124,8 +134,7 @@ Manual gateway runs after source-built deployment:
 
 ```bash
 python examples/microservices/train-ticket/accuracy_checker/checker.py \
-  --base-url http://localhost:18888 \
-  --allow-empty
+  --base-url http://localhost:18888
 
 python examples/microservices/train-ticket/benchmark/benchmark.py \
   --base-url http://localhost:18888 \
@@ -133,3 +142,7 @@ python examples/microservices/train-ticket/benchmark/benchmark.py \
   --duration 30 \
   --concurrency 32
 ```
+
+The images self-seed reference data, so the checker runs in strict mode by
+default; pass `--allow-empty` only for deployments known to have no seeded
+data.

--- a/examples/microservices/train-ticket/accuracy_checker/README.md
+++ b/examples/microservices/train-ticket/accuracy_checker/README.md
@@ -1,15 +1,38 @@
 # Train Ticket Accuracy Checker
 
-Checks a running Train Ticket deployment through the API gateway. The checker
-uses only read-only endpoints by default:
+Checks a running Train Ticket deployment using read-only endpoints:
 
-- service welcome endpoints
-- station, train, travel, route, price, config, and contact list endpoints
+- welcome endpoints of the config, station, train, travel, route, and price
+  services (exact service banner text)
+- station, train, trip, route, price, and config list endpoints
+
+For every list endpoint the checker validates the full response contract, not
+just HTTP reachability:
+
+- the `edu.fudan.common.util.Response` envelope reports `status == 1`
+  (an HTTP-200 body with `status: 0` is a service-level failure and fails the
+  check, except for the tolerated empty case under `--allow-empty`)
+- every returned item has the expected fields (restricted to field names that
+  exist in both the 0.2.0 prebuilt images and the v1.0.0 source)
+- referential integrity across services: trips and prices must reference
+  existing routes and trains; on 0.2.0 image deployments trips must also
+  reference existing stations and train types (v1.0.0 renamed those trip
+  fields, so those two checks skip there)
 
 Usage:
 
 ```bash
-python checker.py --base-url http://localhost:8080
+python checker.py --base-url http://localhost:18888 --direct-services
 ```
 
-Use `--allow-empty` for deployments without seeded data.
+- `--base-url` points at the gateway or UI proxy. With `--direct-services`
+  only its hostname is used and each check goes straight to the service's
+  published port (required for the local prebuilt-image cluster, whose gateway
+  cannot route).
+- `--allow-empty` tolerates unseeded deployments: list endpoints may return
+  the `status: 0, msg: "No content"` empty envelope. All other validation
+  still applies. The images used by the local cluster self-seed on startup,
+  so the flag is not needed there.
+
+Exit code is 0 only if every check (including the cross-endpoint consistency
+checks) passes.

--- a/examples/microservices/train-ticket/accuracy_checker/checker.py
+++ b/examples/microservices/train-ticket/accuracy_checker/checker.py
@@ -22,21 +22,48 @@ class Check:
     expect_json: bool = False
     expect_text: str | None = None
     expect_items: bool = False
+    # Keys every returned item must have. Restricted to fields that exist in
+    # both the 0.2.0 prebuilt images and the v1.0.0 source entities.
+    required_item_keys: tuple[str, ...] = ()
     body: Any | None = None
 
 
 CHECKS = [
-    Check("config welcome", "GET", "/api/v1/configservice/welcome", expect_text="Config Service"),
     Check(
-        "station welcome", "GET", "/api/v1/stationservice/welcome", expect_text="Station Service"
+        "config welcome",
+        "GET",
+        "/api/v1/configservice/welcome",
+        expect_text="Welcome to [ Config Service ]",
     ),
     Check(
-        "train welcome", "GET", "/api/v1/trainservice/trains/welcome", expect_text="Train Service"
+        "station welcome",
+        "GET",
+        "/api/v1/stationservice/welcome",
+        expect_text="Welcome to [ Station Service ]",
     ),
-    Check("travel welcome", "GET", "/api/v1/travelservice/welcome", expect_text="Travel Service"),
-    Check("route welcome", "GET", "/api/v1/routeservice/welcome", expect_text="Route Service"),
     Check(
-        "price welcome", "GET", "/api/v1/priceservice/prices/welcome", expect_text="Price Service"
+        "train welcome",
+        "GET",
+        "/api/v1/trainservice/trains/welcome",
+        expect_text="Welcome to [ Train Service ]",
+    ),
+    Check(
+        "travel welcome",
+        "GET",
+        "/api/v1/travelservice/welcome",
+        expect_text="Welcome to [ Travel Service ]",
+    ),
+    Check(
+        "route welcome",
+        "GET",
+        "/api/v1/routeservice/welcome",
+        expect_text="Welcome to [ Route Service ]",
+    ),
+    Check(
+        "price welcome",
+        "GET",
+        "/api/v1/priceservice/prices/welcome",
+        expect_text="Welcome to [ Price Service ]",
     ),
     Check(
         "stations list",
@@ -44,12 +71,68 @@ CHECKS = [
         "/api/v1/stationservice/stations",
         expect_json=True,
         expect_items=True,
+        required_item_keys=("id", "name"),
     ),
-    Check("trains list", "GET", "/api/v1/trainservice/trains", expect_json=True, expect_items=True),
-    Check("trips list", "GET", "/api/v1/travelservice/trips", expect_json=True, expect_items=True),
-    Check("routes list", "GET", "/api/v1/routeservice/routes", expect_json=True, expect_items=True),
-    Check("prices list", "GET", "/api/v1/priceservice/prices", expect_json=True, expect_items=True),
-    Check("configs list", "GET", "/api/v1/configservice/configs", expect_json=True),
+    Check(
+        "trains list",
+        "GET",
+        "/api/v1/trainservice/trains",
+        expect_json=True,
+        expect_items=True,
+        required_item_keys=("id", "averageSpeed"),
+    ),
+    Check(
+        "trips list",
+        "GET",
+        "/api/v1/travelservice/trips",
+        expect_json=True,
+        expect_items=True,
+        required_item_keys=("tripId", "routeId"),
+    ),
+    Check(
+        "routes list",
+        "GET",
+        "/api/v1/routeservice/routes",
+        expect_json=True,
+        expect_items=True,
+        required_item_keys=("id", "stations"),
+    ),
+    Check(
+        "prices list",
+        "GET",
+        "/api/v1/priceservice/prices",
+        expect_json=True,
+        expect_items=True,
+        required_item_keys=("id", "trainType", "routeId", "basicPriceRate"),
+    ),
+    Check(
+        "configs list",
+        "GET",
+        "/api/v1/configservice/configs",
+        expect_json=True,
+        expect_items=True,
+        required_item_keys=("name", "value"),
+    ),
+]
+
+# Referential-integrity checks over the seeded data. Field names are looked up
+# per item because 0.2.0 and v1.0.0 use different names for some references;
+# a check silently skips when the source field is absent. Targets may list
+# several keys: v1.0.0 TrainType has a random UUID id and keeps the human name
+# in a separate "name" field that price configs reference, so train references
+# match against the union of both.
+CONSISTENCY_CHECKS = [
+    ("trips reference routes", "trips list", ("routeId",), "routes list", ("id",)),
+    ("prices reference routes", "prices list", ("routeId",), "routes list", ("id",)),
+    ("prices reference trains", "prices list", ("trainType",), "trains list", ("id", "name")),
+    (
+        "trips reference stations",
+        "trips list",
+        ("startingStationId", "terminalStationId"),
+        "stations list",
+        ("id",),
+    ),
+    ("trips reference trains", "trips list", ("trainTypeId",), "trains list", ("id", "name")),
 ]
 
 DIRECT_SERVICE_PORTS = {
@@ -64,9 +147,16 @@ DIRECT_SERVICE_PORTS = {
 
 def normalize_base_url(raw: str) -> str:
     raw = raw.strip()
-    if not raw.startswith(("http://", "https://")):
+    if not raw.lower().startswith(("http://", "https://")):
         raw = "http://" + raw
     return raw.rstrip("/") + "/"
+
+
+def format_host(hostname: str) -> str:
+    # urlsplit().hostname strips brackets from IPv6 literals; restore them.
+    if ":" in hostname:
+        return f"[{hostname}]"
+    return hostname
 
 
 def check_url(base_url: str, check: Check, direct_services: bool) -> str:
@@ -80,7 +170,7 @@ def check_url(base_url: str, check: Check, direct_services: bool) -> str:
     if port is None:
         raise RuntimeError(f"{check.name}: no direct port mapping for service {service!r}")
     base = urlsplit(base_url)
-    host = base.hostname or "localhost"
+    host = format_host(base.hostname or "localhost")
     netloc = f"{host}:{port}"
     return urlunsplit((base.scheme or "http", netloc, check.path, "", ""))
 
@@ -111,7 +201,7 @@ def request_json_or_text(
     elapsed_ms = (time.perf_counter() - start) * 1000.0
 
     parsed = None
-    if check.expect_json:
+    if check.expect_json or check.expect_items:
         try:
             parsed = json.loads(raw)
         except json.JSONDecodeError as exc:
@@ -131,13 +221,46 @@ def extract_items(payload: Any) -> list[Any]:
     return []
 
 
+def validate_envelope(check: Check, parsed: Any, allow_empty: bool) -> None:
+    """Enforce the edu.fudan.common.util.Response convention: status 1 = success.
+
+    An HTTP 200 body like {"status":0,"msg":"error","data":null} is a
+    service-level failure and must not pass. The only tolerated non-1 status is
+    the "No content" empty result, and only under --allow-empty.
+    """
+    if not isinstance(parsed, dict) or "status" not in parsed:
+        return
+    status = parsed.get("status")
+    if status == 1:
+        return
+    if allow_empty and check.expect_items and not extract_items(parsed):
+        return
+    raise RuntimeError(
+        f"{check.name}: response envelope status={status!r} msg={parsed.get('msg')!r}"
+    )
+
+
+def validate_items(check: Check, items: list[Any]) -> None:
+    for idx, item in enumerate(items):
+        if not isinstance(item, dict):
+            raise RuntimeError(
+                f"{check.name}: item {idx} is {type(item).__name__}, expected object"
+            )
+        missing = [key for key in check.required_item_keys if key not in item]
+        if missing:
+            raise RuntimeError(
+                f"{check.name}: item {idx} is missing expected fields {missing}: "
+                f"{json.dumps(item)[:200]}"
+            )
+
+
 def run_check(
     base_url: str,
     check: Check,
     timeout: float,
     allow_empty: bool,
     direct_services: bool,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], list[Any]]:
     status, raw, parsed, elapsed_ms = request_json_or_text(
         base_url, check, timeout, direct_services
     )
@@ -145,18 +268,65 @@ def run_check(
         raise RuntimeError(f"{check.name}: HTTP {status}: {raw[:300]!r}")
     if check.expect_text and check.expect_text not in raw:
         raise RuntimeError(f"{check.name}: expected text {check.expect_text!r}, got {raw[:200]!r}")
+    validate_envelope(check, parsed, allow_empty)
     item_count = None
+    items: list[Any] = []
     if check.expect_items:
         items = extract_items(parsed)
         item_count = len(items)
         if not allow_empty and item_count == 0:
             raise RuntimeError(f"{check.name}: expected seeded data, got empty response")
-    return {
+        validate_items(check, items)
+    result = {
         "name": check.name,
         "status": status,
         "latency_ms": round(elapsed_ms, 3),
         "item_count": item_count,
     }
+    return result, items
+
+
+def run_consistency_checks(
+    collected: dict[str, list[Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    """Cross-endpoint referential integrity over whatever data was fetched.
+
+    A given check runs only when both sides returned data and the reference
+    field exists in the source items (field names differ across Train Ticket
+    versions); otherwise it is skipped.
+    """
+    results = []
+    failures = []
+    for name, src_name, ref_keys, dst_name, dst_keys in CONSISTENCY_CHECKS:
+        src_items = collected.get(src_name, [])
+        dst_items = collected.get(dst_name, [])
+        refs = {
+            item[key]
+            for item in src_items
+            if isinstance(item, dict)
+            for key in ref_keys
+            if item.get(key) is not None
+        }
+        targets = {
+            item[key]
+            for item in dst_items
+            if isinstance(item, dict)
+            for key in dst_keys
+            if item.get(key) is not None
+        }
+        if not refs or not targets:
+            continue
+        dangling = sorted(str(r) for r in refs - targets)
+        if dangling:
+            failures.append(
+                {
+                    "name": name,
+                    "error": f"{name}: dangling references not in {dst_name}: {dangling[:5]}",
+                }
+            )
+        else:
+            results.append({"name": name, "status": None, "latency_ms": None, "item_count": len(refs)})
+    return results, failures
 
 
 def main() -> int:
@@ -179,16 +349,26 @@ def main() -> int:
     base_url = normalize_base_url(args.base_url)
     results = []
     failures = []
+    collected: dict[str, list[Any]] = {}
     for check in CHECKS:
         try:
-            result = run_check(
+            result, items = run_check(
                 base_url, check, args.timeout, args.allow_empty, args.direct_services
             )
             results.append(result)
+            collected[check.name] = items
             print(f"PASS {check.name} ({result['latency_ms']:.1f} ms)")
         except Exception as exc:
             failures.append({"name": check.name, "error": str(exc)})
             print(f"FAIL {check.name}: {exc}", file=sys.stderr)
+
+    consistency_results, consistency_failures = run_consistency_checks(collected)
+    for result in consistency_results:
+        results.append(result)
+        print(f"PASS {result['name']} ({result['item_count']} references)")
+    for failure in consistency_failures:
+        failures.append(failure)
+        print(f"FAIL {failure['name']}: {failure['error']}", file=sys.stderr)
 
     summary = {
         "base_url": base_url.rstrip("/"),

--- a/examples/microservices/train-ticket/accuracy_checker/checker.py
+++ b/examples/microservices/train-ticket/accuracy_checker/checker.py
@@ -325,7 +325,9 @@ def run_consistency_checks(
                 }
             )
         else:
-            results.append({"name": name, "status": None, "latency_ms": None, "item_count": len(refs)})
+            results.append(
+                {"name": name, "status": None, "latency_ms": None, "item_count": len(refs)}
+            )
     return results, failures
 
 

--- a/examples/microservices/train-ticket/benchmark/README.md
+++ b/examples/microservices/train-ticket/benchmark/README.md
@@ -1,10 +1,43 @@
 # Train Ticket Benchmark
 
-Runs a read-only HTTP workload against a Train Ticket deployment and reports
-throughput, latency percentiles, and error rate.
+Runs a read-only, fixed-rate open-loop HTTP workload (weighted mix of the
+station/train/trip/route/price/config list endpoints plus a welcome endpoint)
+against a Train Ticket deployment and reports throughput, latency
+distributions, and error rate.
 
 ```bash
 python benchmark.py --base-url http://localhost:8080 --rate 20 --duration 30 --output-json /tmp/train_ticket_bench.json
 ```
 
-The headline metric is `requests_per_second`.
+## Metric semantics
+
+- The benchmark schedules `rate * duration` requests at fixed intervals and
+  executes them on a bounded worker pool (`--concurrency`).
+- `latency_ms` (the primary latency distribution) is measured from each
+  request's **scheduled send time**, so when the deployment cannot keep up
+  and requests queue client-side, the queueing delay counts — the numbers do
+  not flatline at per-request service time (no coordinated omission).
+  `service_time_ms` is the HTTP exchange alone and `queue_wait_ms` shows the
+  gap between the two; a large `queue_wait_ms` means the offered rate exceeds
+  what the deployment sustains at this concurrency.
+- Latency distributions cover successful requests only; always read them next
+  to `error_rate` and `timeout_failures`.
+- `requests_per_second` (the headline metric) is completed successful
+  requests over total elapsed time (including the drain of in-flight requests
+  after the last submission). At a fixed offered load it approximates
+  `rate * (1 - error_rate)` and is capped by `--rate`; it only measures
+  capacity when the deployment saturates below the target rate.
+- If the client itself cannot submit at the target rate, a warning is printed
+  and `offered_rate` records what was actually offered.
+- Each request opens a fresh TCP connection (no keep-alive), so connection
+  setup is included in latency; keep that in mind for remote targets.
+
+An HTTP-200 response carrying a Train Ticket error envelope
+(`{"status": 0, "msg": ...}`) counts as a failed request, as do transport
+errors, timeouts, and unexpected response shapes. Individual request failures
+never abort the run; they are recorded and summarized in `errors_by_type` and
+`sample_errors`. Ctrl+C stops the run early and reports the completed portion
+(exit code 130).
+
+Exit code is 0 when `error_rate <= --max-error-rate` (default 0.0: any
+failure makes the run fail).

--- a/examples/microservices/train-ticket/benchmark/benchmark.py
+++ b/examples/microservices/train-ticket/benchmark/benchmark.py
@@ -345,9 +345,7 @@ def main() -> int:
             file=sys.stderr,
         )
         pool.shutdown(wait=False, cancel_futures=True)
-        concurrent.futures.wait(
-            [f for f in futures if not f.done()], timeout=args.timeout
-        )
+        concurrent.futures.wait([f for f in futures if not f.done()], timeout=args.timeout)
         results.clear()
         for fut in futures:
             if fut.done() and not fut.cancelled():

--- a/examples/microservices/train-ticket/benchmark/benchmark.py
+++ b/examples/microservices/train-ticket/benchmark/benchmark.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import json
+import math
 import random
 import statistics
+import sys
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -39,7 +41,7 @@ ENDPOINTS = [
         "GET",
         "/api/v1/travelservice/welcome",
         weight=1,
-        expect_text="Travel Service",
+        expect_text="Welcome to [ Travel Service ]",
         expect_json=False,
     ),
 ]
@@ -56,9 +58,16 @@ DIRECT_SERVICE_PORTS = {
 
 def normalize_base_url(raw: str) -> str:
     raw = raw.strip()
-    if not raw.startswith(("http://", "https://")):
+    if not raw.lower().startswith(("http://", "https://")):
         raw = "http://" + raw
     return raw.rstrip("/") + "/"
+
+
+def format_host(hostname: str) -> str:
+    # urlsplit().hostname strips brackets from IPv6 literals; restore them.
+    if ":" in hostname:
+        return f"[{hostname}]"
+    return hostname
 
 
 def endpoint_url(base_url: str, endpoint: Endpoint, direct_services: bool) -> str:
@@ -74,59 +83,81 @@ def endpoint_url(base_url: str, endpoint: Endpoint, direct_services: bool) -> st
     if port is None:
         raise RuntimeError(f"{endpoint.name}: no direct port mapping for service {service!r}")
     base = urlsplit(base_url)
-    host = base.hostname or "localhost"
+    host = format_host(base.hostname or "localhost")
     return urlunsplit((base.scheme or "http", f"{host}:{port}", endpoint.path, "", ""))
 
 
 def percentile(values: list[float], pct: float) -> float | None:
+    """Linear-interpolated percentile (same convention as numpy's default)."""
     if not values:
         return None
     ordered = sorted(values)
-    idx = min(len(ordered) - 1, max(0, round((pct / 100.0) * (len(ordered) - 1))))
-    return ordered[idx]
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (pct / 100.0) * (len(ordered) - 1)
+    lo = math.floor(rank)
+    hi = math.ceil(rank)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (rank - lo)
 
 
 def request_once(
-    base_url: str, endpoint: Endpoint, timeout: float, direct_services: bool
+    base_url: str,
+    endpoint: Endpoint,
+    timeout: float,
+    direct_services: bool,
+    scheduled_start: float,
 ) -> dict[str, Any]:
-    url = endpoint_url(base_url, endpoint, direct_services)
-    headers = {"Accept": "application/json,text/plain,*/*"}
-    data = None
-    if endpoint.body is not None:
-        data = json.dumps(endpoint.body).encode("utf-8")
-        headers["Content-Type"] = "application/json"
-    req = Request(url, data=data, headers=headers, method=endpoint.method)
-    start = time.perf_counter()
+    """Issue one request and record it; never raises.
+
+    Timing model (open loop): `latency_ms` runs from the *scheduled* send time,
+    so time spent waiting in the client-side queue when the pool is saturated
+    counts against the deployment, exactly as a real arrival at that instant
+    would experience it. `service_time_ms` covers only the HTTP exchange, and
+    `queue_wait_ms` is the difference between the two.
+    """
+    dequeued = time.perf_counter()
     status = 0
-    size = 0
+    body = b""
     error = None
     try:
-        with urlopen(req, timeout=timeout) as resp:
-            body = resp.read()
-            status = resp.status
-            size = len(body)
-    except HTTPError as exc:
-        body = exc.read()
-        status = exc.code
-        size = len(body)
-        error = f"HTTP {exc.code}"
+        url = endpoint_url(base_url, endpoint, direct_services)
+        headers = {"Accept": "application/json,text/plain,*/*"}
+        data = None
+        if endpoint.body is not None:
+            data = json.dumps(endpoint.body).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        req = Request(url, data=data, headers=headers, method=endpoint.method)
+        try:
+            with urlopen(req, timeout=timeout) as resp:
+                body = resp.read()
+                status = resp.status
+        except HTTPError as exc:
+            status = exc.code
+            error = f"HTTP {exc.code}"
+            try:
+                body = exc.read()
+            except Exception:
+                # Keep the HTTP-status attribution even when the error body
+                # itself is truncated or unreadable.
+                body = b""
     except URLError as exc:
-        error = str(exc)
-    except TimeoutError as exc:
-        error = str(exc)
+        error = f"URLError: {exc.reason}"
+    except Exception as exc:  # ConnectionResetError, IncompleteRead, InvalidURL, ...
+        error = f"{type(exc).__name__}: {exc}"
+    end = time.perf_counter()
     if error is None and 200 <= status < 300:
         text = body.decode("utf-8", errors="replace")
-        shape_error = validate_response_shape(endpoint, text)
-        if shape_error:
-            error = shape_error
-    latency_ms = (time.perf_counter() - start) * 1000.0
-    ok = error is None and 200 <= status < 300
+        error = validate_response_shape(endpoint, text)
     return {
         "endpoint": endpoint.name,
         "status": status,
-        "ok": ok,
-        "latency_ms": latency_ms,
-        "bytes": size,
+        "ok": error is None and 200 <= status < 300,
+        "latency_ms": (end - scheduled_start) * 1000.0,
+        "service_time_ms": (end - dequeued) * 1000.0,
+        "queue_wait_ms": (dequeued - scheduled_start) * 1000.0,
+        "bytes": len(body),
         "error": error,
     }
 
@@ -145,31 +176,61 @@ def validate_response_shape(endpoint: Endpoint, text: str) -> str | None:
     if isinstance(payload, list):
         return None
     if isinstance(payload, dict):
-        # Some Train Ticket services wrap lists in edu.fudan.common.util.Response.
-        if (
-            "data" in payload
-            or ("status" in payload and "msg" in payload)
-            or ("status" in payload and "message" in payload)
-        ):
+        # Train Ticket services wrap results in edu.fudan.common.util.Response
+        # {status, msg, data} where status 1 means success. An HTTP-200 body
+        # with status 0 is a service-level failure, not a successful sample.
+        if "status" in payload:
+            if payload.get("status") != 1:
+                msg = payload.get("msg", payload.get("message"))
+                return f"error envelope for {endpoint.name}: status={payload.get('status')!r} msg={msg!r}"
+            return None
+        if "data" in payload:
             return None
         return f"unexpected JSON object for {endpoint.name}: keys={sorted(payload)[:8]}"
     return f"unexpected JSON type for {endpoint.name}: {type(payload).__name__}"
 
 
+def latency_stats(latencies: list[float]) -> dict[str, float | None]:
+    return {
+        "mean": statistics.fmean(latencies) if latencies else None,
+        "p50": percentile(latencies, 50),
+        "p90": percentile(latencies, 90),
+        "p95": percentile(latencies, 95),
+        "p99": percentile(latencies, 99),
+        "max": max(latencies) if latencies else None,
+    }
+
+
 def summarize(results: list[dict[str, Any]], elapsed_s: float) -> dict[str, Any]:
     successes = [r for r in results if r["ok"]]
     failures = [r for r in results if not r["ok"]]
-    latencies = [r["latency_ms"] for r in successes]
+    latencies = [r["latency_ms"] for r in successes if r["latency_ms"] is not None]
+    service_times = [r["service_time_ms"] for r in successes if r["service_time_ms"] is not None]
+    queue_waits = [r["queue_wait_ms"] for r in results if r.get("queue_wait_ms") is not None]
     by_endpoint: dict[str, dict[str, Any]] = {}
     for r in results:
         bucket = by_endpoint.setdefault(
-            r["endpoint"], {"requests": 0, "successes": 0, "failures": 0}
+            r["endpoint"],
+            {"requests": 0, "successes": 0, "failures": 0, "_latencies": []},
         )
         bucket["requests"] += 1
         if r["ok"]:
             bucket["successes"] += 1
+            if r["latency_ms"] is not None:
+                bucket["_latencies"].append(r["latency_ms"])
         else:
             bucket["failures"] += 1
+    for bucket in by_endpoint.values():
+        lats = bucket.pop("_latencies")
+        bucket["latency_ms"] = {
+            "mean": statistics.fmean(lats) if lats else None,
+            "p50": percentile(lats, 50),
+            "p95": percentile(lats, 95),
+        }
+    errors_by_type: dict[str, int] = {}
+    for r in failures:
+        key = (r["error"] or f"HTTP {r['status']}").split(": ", 1)[0][:80]
+        errors_by_type[key] = errors_by_type.get(key, 0) + 1
     return {
         "headline_metric": "requests_per_second",
         "requests_per_second": len(successes) / elapsed_s if elapsed_s > 0 else 0.0,
@@ -178,15 +239,20 @@ def summarize(results: list[dict[str, Any]], elapsed_s: float) -> dict[str, Any]
         "successful_requests": len(successes),
         "failed_requests": len(failures),
         "error_rate": (len(failures) / len(results)) if results else 0.0,
-        "latency_ms": {
-            "mean": statistics.fmean(latencies) if latencies else None,
-            "p50": percentile(latencies, 50),
-            "p90": percentile(latencies, 90),
-            "p95": percentile(latencies, 95),
-            "p99": percentile(latencies, 99),
-            "max": max(latencies) if latencies else None,
+        "timeout_failures": sum(1 for r in failures if "timed out" in (r["error"] or "")),
+        # Latency of successful requests measured from their scheduled send
+        # time (open loop: client-side queue wait counts). service_time_ms is
+        # the HTTP exchange alone. Failed requests (incl. timeouts) are not in
+        # either distribution; check error_rate before comparing latencies.
+        "latency_ms": latency_stats(latencies),
+        "service_time_ms": latency_stats(service_times),
+        "queue_wait_ms": {
+            "mean": statistics.fmean(queue_waits) if queue_waits else None,
+            "p99": percentile(queue_waits, 99),
+            "max": max(queue_waits) if queue_waits else None,
         },
         "by_endpoint": by_endpoint,
+        "errors_by_type": errors_by_type,
         "sample_errors": failures[:10],
     }
 
@@ -205,6 +271,12 @@ def main() -> int:
     )
     parser.add_argument("--timeout", type=float, default=5.0, help="per-request timeout in seconds")
     parser.add_argument("--seed", type=int, default=1, help="random seed for endpoint selection")
+    parser.add_argument(
+        "--max-error-rate",
+        type=float,
+        default=0.0,
+        help="exit non-zero when error_rate exceeds this fraction (default: any failure fails)",
+    )
     parser.add_argument(
         "--direct-services",
         action="store_true",
@@ -226,39 +298,93 @@ def main() -> int:
     total = max(1, int(args.rate * args.duration))
     interval = 1.0 / args.rate
     results: list[dict[str, Any]] = []
+    futures: list[concurrent.futures.Future] = []
+    future_endpoint: dict[concurrent.futures.Future, str] = {}
+    interrupted = False
+    submit_end = None
+
+    def collect(fut: concurrent.futures.Future) -> None:
+        try:
+            results.append(fut.result())
+        except Exception as exc:  # request_once never raises; last-resort guard
+            results.append(
+                {
+                    "endpoint": future_endpoint.get(fut, "?"),
+                    "status": 0,
+                    "ok": False,
+                    "latency_ms": None,
+                    "service_time_ms": None,
+                    "queue_wait_ms": None,
+                    "bytes": 0,
+                    "error": f"internal: {type(exc).__name__}: {exc}",
+                }
+            )
 
     start = time.perf_counter()
-    futures: list[concurrent.futures.Future] = []
-    with concurrent.futures.ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=args.concurrency)
+    try:
         for i in range(total):
             target_time = start + i * interval
             sleep_s = target_time - time.perf_counter()
             if sleep_s > 0:
                 time.sleep(sleep_s)
             endpoint = random.choice(population)
-            futures.append(
-                pool.submit(request_once, base_url, endpoint, args.timeout, args.direct_services)
+            fut = pool.submit(
+                request_once, base_url, endpoint, args.timeout, args.direct_services, target_time
             )
+            future_endpoint[fut] = endpoint.name
+            futures.append(fut)
+        submit_end = time.perf_counter()
         for fut in concurrent.futures.as_completed(futures):
-            results.append(fut.result())
+            collect(fut)
+        pool.shutdown(wait=True)
+    except KeyboardInterrupt:
+        interrupted = True
+        print(
+            "Interrupted: cancelling queued requests, waiting for in-flight ones...",
+            file=sys.stderr,
+        )
+        pool.shutdown(wait=False, cancel_futures=True)
+        concurrent.futures.wait(
+            [f for f in futures if not f.done()], timeout=args.timeout
+        )
+        results.clear()
+        for fut in futures:
+            if fut.done() and not fut.cancelled():
+                collect(fut)
 
     elapsed_s = time.perf_counter() - start
     summary = summarize(results, elapsed_s)
+
+    offered_rate = None
+    if submit_end is not None and submit_end > start and total > 1:
+        # total arrivals span (total - 1) inter-arrival intervals.
+        offered_rate = (total - 1) / (submit_end - start)
+        if offered_rate < 0.95 * args.rate:
+            print(
+                f"WARNING: submission fell behind schedule: offered {offered_rate:.1f} req/s "
+                f"vs target {args.rate:.1f} req/s; results understate the requested load.",
+                file=sys.stderr,
+            )
     summary.update(
         {
             "base_url": base_url.rstrip("/"),
             "direct_services": args.direct_services,
             "target_rate": args.rate,
+            "offered_rate": offered_rate,
             "duration_s": args.duration,
             "elapsed_s": elapsed_s,
             "concurrency": args.concurrency,
+            "interrupted": interrupted,
         }
     )
     if args.output_json:
         with open(args.output_json, "w", encoding="utf-8") as f:
             json.dump(summary, f, indent=2)
     print(json.dumps(summary, indent=2))
-    return 1 if summary["failed_requests"] else 0
+    if interrupted:
+        return 130
+    return 1 if summary["error_rate"] > args.max_error_rate else 0
 
 
 if __name__ == "__main__":

--- a/examples/microservices/train-ticket/scripts/start-local-cluster.sh
+++ b/examples/microservices/train-ticket/scripts/start-local-cluster.sh
@@ -15,15 +15,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 INPUT_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
-REPO_ROOT="$(cd -- "${INPUT_DIR}/../.." && pwd)"
-SOURCE_COMPOSE="${REPO_ROOT}/3rd_party/train-ticket/deployment/docker-compose-manifests/quickstart-docker-compose.yml"
+REPO_ROOT="$(cd -- "${INPUT_DIR}/../../.." && pwd)"
 
 TT_NAMESPACE="${TT_NAMESPACE:-codewisdom}"
 TT_TAG="${TT_TAG:-0.2.0}"
 TT_GATEWAY_TAG="${TT_GATEWAY_TAG:-latest}"
 TT_PROJECT="${TT_PROJECT:-train-ticket-local}"
 TT_GATEWAY_PORT="${TT_GATEWAY_PORT:-18888}"
-TT_COMPOSE_FILE="${TT_COMPOSE_FILE:-/tmp/${TT_PROJECT}-quickstart-docker-compose.yml}"
+TT_COMPOSE_FILE="${TT_COMPOSE_FILE:-/tmp/${TT_PROJECT}-${UID}-quickstart-docker-compose.yml}"
 TT_SKIP_PULL="${TT_SKIP_PULL:-0}"
 TT_SOURCE_DIR="${TT_SOURCE_DIR:-${REPO_ROOT}/3rd_party/train-ticket}"
 TT_BUILD_REPO="${TT_BUILD_REPO:-localtrain}"
@@ -35,7 +34,7 @@ Usage: $0 <command>
 
 Commands:
   start      Generate compose file, pull images, start the cluster, wait for core services
-  stop       Stop and remove the cluster containers/network
+  stop       Stop and remove the cluster containers/network and data volumes
   status     Show compose service status
   logs       Follow compose logs
   check      Run the Train Ticket checker against local direct service ports
@@ -70,8 +69,21 @@ require_tools() {
 }
 
 port_in_use() {
-  local port="$1"
-  ss -ltn | awk '{print $4}' | grep -Eq "(:|\\])${port}$"
+  # Bind test instead of parsing `ss` output: portable and catches listeners
+  # on any local interface.
+  ! python3 -c '
+import socket, sys
+s = socket.socket()
+# SO_REUSEADDR so lingering TIME_WAIT sockets from a recent stop do not
+# report a false conflict; a real listener still fails the bind.
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+try:
+    s.bind(("0.0.0.0", int(sys.argv[1])))
+except OSError:
+    sys.exit(1)
+finally:
+    s.close()
+' "$1"
 }
 
 check_ports() {
@@ -91,21 +103,17 @@ check_ports() {
 }
 
 generate_compose() {
-  [[ -f "${SOURCE_COMPOSE}" ]] || {
-    echo "Missing source compose file: ${SOURCE_COMPOSE}" >&2
-    exit 1
-  }
   mkdir -p "$(dirname -- "${TT_COMPOSE_FILE}")"
-  python3 - "${SOURCE_COMPOSE}" "${TT_COMPOSE_FILE}" "${TT_GATEWAY_PORT}" "${TT_NAMESPACE}" "${TT_TAG}" "${TT_GATEWAY_TAG}" <<'PY'
-from pathlib import Path
+  python3 - "${TT_COMPOSE_FILE}" "${TT_GATEWAY_PORT}" "${TT_NAMESPACE}" "${TT_TAG}" "${TT_GATEWAY_TAG}" <<'PY'
+import json
 import sys
+from pathlib import Path
 
-src = Path(sys.argv[1])
-dst = Path(sys.argv[2])
-gateway_port = sys.argv[3]
-namespace = sys.argv[4]
-tag = sys.argv[5]
-gateway_tag = sys.argv[6]
+dst = Path(sys.argv[1])
+gateway_port = sys.argv[2]
+namespace = sys.argv[3]
+tag = sys.argv[4]
+gateway_tag = sys.argv[5]
 
 # Keep this explicit. The upstream quickstart compose references several
 # optional images that are no longer published, omits Nacos, and leaves MySQL
@@ -209,8 +217,8 @@ for name, (password, database) in mysql.items():
         "    image: mysql:5.7",
         "    restart: always",
         "    environment:",
-        f"      MYSQL_ROOT_PASSWORD: {password!r}",
-        f"      MYSQL_DATABASE: {database!r}",
+        f"      MYSQL_ROOT_PASSWORD: {json.dumps(password)}",
+        f"      MYSQL_DATABASE: {json.dumps(database)}",
         "    networks:",
         "      - my-network",
         "",
@@ -234,7 +242,7 @@ for name, port in service_ports.items():
         "    environment:",
     ])
     for key, value in service_env[name].items():
-        lines.append(f"      {key}: {value!r}")
+        lines.append(f"      {key}: {json.dumps(value)}")
     lines.extend([
         "    ports:",
         f"      - {port}:{port}",
@@ -332,15 +340,21 @@ case "${cmd}" in
       compose pull
     fi
     compose up -d --remove-orphans
-    wait_for_core_services || true
+    wait_for_core_services
     echo "Gateway: http://localhost:${TT_GATEWAY_PORT}"
+    if [[ "${TT_NAMESPACE}" == "codewisdom" ]]; then
+      echo "Note: the prebuilt codewisdom service images do not register with Nacos, so the"
+      echo "gateway returns 503 for all routes; use '$0 check' / '$0 bench' (direct services)."
+    fi
     echo "Checker: $0 check"
     echo "Benchmark: TT_BENCH_RATE=10 TT_BENCH_DURATION=30 TT_BENCH_CONCURRENCY=32 $0 bench"
     ;;
   stop)
     require_tools
     generate_compose >/dev/null
-    compose down --remove-orphans
+    # -v: the anonymous mysql/mongo volumes hold only auto-reseeded data and
+    # would otherwise accumulate ~3GB per stop/start cycle.
+    compose down --remove-orphans -v
     ;;
   status)
     require_tools
@@ -360,10 +374,11 @@ case "${cmd}" in
     echo "  TT_NAMESPACE=${TT_BUILD_REPO} TT_TAG=${TT_BUILD_TAG} TT_GATEWAY_TAG=${TT_BUILD_TAG} TT_SKIP_PULL=1 $0 start"
     ;;
   check)
+    # No --allow-empty: the prebuilt and source-built images both self-seed
+    # reference data on startup, so empty lists indicate a real failure.
     python3 "${INPUT_DIR}/accuracy_checker/checker.py" \
       --base-url "http://localhost:${TT_GATEWAY_PORT}" \
-      --direct-services \
-      --allow-empty
+      --direct-services
     ;;
   bench)
     python3 "${INPUT_DIR}/benchmark/benchmark.py" \


### PR DESCRIPTION
## Summary

Validated `examples/microservices/train-ticket` end-to-end — two multi-agent review passes with adversarial verification of every finding, mock-server fault injection, and repeated full lifecycles of the local Docker Compose cluster — and fixed everything found. Details below; all fixes were re-verified against a live cluster.

### The example was broken at HEAD

`start-local-cluster.sh start` failed immediately: #86 moved the example under `examples/microservices/` but `REPO_ROOT` still climbed two directories. Also removed the source-compose existence check entirely — the compose generator never reads that file, so `stop`/`status`/`logs` now work without the submodule.

### Accuracy checker actually checks accuracy now

- **Envelope validation**: Train Ticket returns HTTP 200 with `Response{status, msg, data}` where `status: 1` means success. Previously `{"status":0,"msg":"database exploded","data":null}` passed every list check (demonstrated with a mock backend). Now `status != 1` fails, with the empty-result envelope tolerated only under `--allow-empty`.
- **Content validation**: required fields on every returned item, plus cross-service referential integrity (trips/prices → routes/trains/stations). Field names restricted to those valid in both the 0.2.0 prebuilt images and v1.0.0 source (they renamed several; train references match `id ∪ name` because v1.0.0 `TrainType.id` is a random UUID).
- **Strict by default in the helper**: the images self-seed on startup (verified: seeding completes before welcome endpoints respond), so `check` no longer weakens itself with `--allow-empty`. Fresh cluster passes 17/17 (12 endpoint + 5 consistency checks).
- Fixed IPv6 `Host:` header corruption in `--direct-services`, case-sensitive scheme detection, and a README claim about contact endpoints that never existed.

### Benchmark crash and measurement-validity fixes

- **No more run-destroying crashes**: `RemoteDisconnected` / `ConnectionResetError` / `IncompleteRead` escape urllib's `URLError` wrapping; a single flaky connection aborted the run with a raw traceback, losing all samples and the `--output-json`. Every failure is now recorded as a sample.
- **Coordinated omission fixed**: latency was timed from worker pickup, excluding client queue wait — a 1s-latency server at 20 rps / concurrency 4 reported p99 ≈ 1.0s when the true open-loop p99 is ~20s. `latency_ms` now runs from the scheduled send time, with `service_time_ms` / `queue_wait_ms` reported separately.
- HTTP-200 error envelopes count as failures; added `offered_rate` + a fall-behind warning, `errors_by_type`, `timeout_failures`, per-endpoint latency, interpolated percentiles (the old `round()` variant returned the min as p50 for n=2), SIGINT partial results (exit 130), and a `--max-error-rate` exit-code gate (default preserves any-failure-fails).

### Cluster script robustness

- `start` no longer reports success when services never come up (`|| true` removed).
- `stop` removes the 18 anonymous data volumes (~3GB leaked per cycle before).
- Port pre-flight uses a portable Python bind test (with `SO_REUSEADDR` so TIME_WAIT doesn't false-positive) instead of `ss`, which is absent on macOS and failed open.
- Docs now state the gateway 503 with prebuilt images is deterministic (0.2.0 services have no Nacos client and never register — verified via Nacos catalog), that those images store data in MongoDB (the MySQL containers only serve source-built v1.0.0 images), and the compose path is per-user.

## Test plan

- `uv run ruff check` clean; `bash -n` clean
- Fresh `start` → strict `check`: 17/17; immediate stop→start cycle re-verified (no seed race)
- Failure injection (route service stopped): checker fails cleanly, benchmark records URLErrors, no crash
- Mock fault servers (connection reset, truncated body, slow server, status-0 envelopes): benchmark completes with recorded errors in all cases; latency reflects queueing
- SIGINT mid-run: partial summary, exit 130, in-flight samples captured
- Saturation sweep drove the fixed benchmark to ~16.5k req/s (16 sharded clients) against the local cluster with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)