### PR TITLE
Make nsys profiler prompts service-aware

### DIFF
--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -292,6 +292,7 @@ def _run_profiler(
         profile_focus=profile_focus,
         bench_path=ctx.profiler_bench_path,
         modality=modality,
+        interface=interface,
         runtime_notes=ctx.run_environment_view.prompt_notes,
         env_kind=ctx.run_environment_view.env_kind,
         objective=objective,

--- a/src/vibe_serve/loops/agent/templates/profiler_prompt_nsys.j2
+++ b/src/vibe_serve/loops/agent/templates/profiler_prompt_nsys.j2
@@ -1,4 +1,5 @@
 {% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
+{% if interface is not defined %}{% set interface = "inprocess" %}{% endif %}
 You are a GPU performance engineer profiling an ML inference server with NVIDIA Nsight Systems (nsys).
 
 {% if objective %}
@@ -45,15 +46,28 @@ Start with `tables`, then pick the analyses that matter most. If `graph_replays`
 
 Capture is a long-running shell step — do it before calling the MCP tools.
 
+{% if interface == "service" %}
+1. Read the objective, domain notes, README, and run scripts to identify the service startup command and port. Do not assume the implementation is Python or that `main.py` exists.
+2. Stop any prior copy of that service if needed. Use the process name, pid file, or run script the implementation provides; do not use a Python-specific `pkill` unless the implementation is actually Python.
+{% else %}
 1. Read `main.py` to understand startup and port.
 2. Kill prior servers: `pkill -f "python main.py" 2>/dev/null || true; sleep 2`.
+{% endif %}
 3. Pre-warm — first-time kernel compilation or model load can take minutes.
 4. Profile under load. Example:
+{% if interface == "service" %}
+   ```
+   PORT=8077 nsys profile --trace=cuda,nvtx --cuda-memory-usage=true --force-overwrite true -o /tmp/profile \
+     <service startup command> &
+   ```
+   Replace `<service startup command>` with the command discovered above. Drive load using the **Workload** recipe from the modality section above{% if bench_path is defined and bench_path %}, or the benchmark at `{{ bench_path }}/benchmark.py` with flags discovered from `--help`{% endif %}.
+{% else %}
    ```
    PORT=8077 nsys profile --trace=cuda,nvtx --cuda-memory-usage=true --force-overwrite true -o /tmp/profile \
      uv run python main.py &
    ```
    Drive load using the **Workload** recipe from the modality section above{% if bench_path is defined and bench_path %}, or `uv run python {{ bench_path }}/benchmark.py --url http://localhost:8077 --rate 1 --num-requests 5 --max-tokens 64`{% endif %}.
+{% endif %}
 5. Stop the server with `kill -INT $NSYS_PID; wait $NSYS_PID`.
 6. Call `export` (or any analysis tool — they auto-export) to produce the SQLite file.
 

--- a/tests/loops/agent/test_interface_modes.py
+++ b/tests/loops/agent/test_interface_modes.py
@@ -117,6 +117,34 @@ def test_standalone_profiler_drops_torch_under_service():
     assert _profiler_prompt_template("nsys", "service") == "profiler_prompt_nsys.j2"
 
 
+def _render_nsys_profiler(interface: str) -> str:
+    return render_template(
+        "profiler_prompt_nsys.j2",
+        template_dir=_TEMPLATE_DIR,
+        modality="text_generation",
+        interface=interface,
+        profile_focus="focus",
+        bench_path="/bench",
+        runtime_notes="",
+        env_kind="local",
+        objective="OBJ",
+    )
+
+
+def test_service_nsys_profiler_does_not_assume_python_startup():
+    out = _render_nsys_profiler("service")
+    assert "uv run python main.py" not in out
+    assert 'pkill -f "python main.py"' not in out
+    assert "<service startup command>" in out
+    assert "Do not assume the implementation is Python" in out
+
+
+def test_inprocess_nsys_profiler_keeps_python_startup_recipe():
+    out = _render_nsys_profiler("inprocess")
+    assert "uv run python main.py" in out
+    assert 'pkill -f "python main.py"' in out
+
+
 # --------------------------------------------------------------------------- #
 # prompt rendering: implementer
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Closes #101.

Passes `interface` into standalone profiler prompt rendering and makes the nsys capture instructions service-aware.

For `--interface service`, the nsys prompt now tells the profiler to discover the service startup command from objective/domain/docs/run scripts instead of assuming `uv run python main.py`. In-process nsys prompts keep the existing Python startup recipe.

## Validation

- `uv run pytest tests/loops/agent/test_interface_modes.py`
- `uv run ruff check src/vibe_serve/loops/agent/loop.py tests/loops/agent/test_interface_modes.py`
