### PR TITLE
Add CPU profiler prompt path

### DIFF
--- a/src/vibe_serve/backends/local.py
+++ b/src/vibe_serve/backends/local.py
@@ -35,8 +35,6 @@ from vibe_serve.constants import ComputeBackend
 class LocalBackend:
     """Local-only backend (Metal / CPU) — all hardware hooks are no-ops."""
 
-    profiler_kind = "torch"
-
     def __init__(
         self,
         name: ComputeBackend,
@@ -45,8 +43,10 @@ class LocalBackend:
         log: Callable[[str], None] | None = None,
         image: str | None = None,
         unavailable_reason: str,
+        profiler_kind: str = "torch",
     ) -> None:
         self.name = name
+        self.profiler_kind = profiler_kind
         self.log_dir = Path(log_dir)
         self._lprint = log or print
         self._unavailable_reason = unavailable_reason
@@ -110,6 +110,7 @@ def metal_backend(
         unavailable_reason=(
             "Docker on macOS can't access Metal/MPS, and Modal does not offer Apple GPUs"
         ),
+        profiler_kind="torch",
     )
 
 
@@ -126,4 +127,5 @@ def cpu_backend(
         log=log,
         image=image,
         unavailable_reason="there is no GPU to pass through to a Docker/Modal container",
+        profiler_kind="cpu",
     )

--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -160,14 +160,15 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--profiler",
-        choices=["nsys", "torch", "neuron", "auto"],
+        choices=["nsys", "torch", "neuron", "cpu", "auto"],
         default="auto",
         help=(
             "Which profiler to use between rounds. "
             "'nsys' for NVIDIA Nsight Systems (needs /proc/driver/nvidia), "
             "'torch' for torch.profiler (works in Modal sandboxes), "
             "'neuron' for AWS neuron-explorer (Trainium/NeuronCores), "
-            "'auto' picks the compute backend's profiler (trainium → neuron), "
+            "'cpu' for CPU-bound benchmark/source diagnosis without a GPU profiler, "
+            "'auto' picks the compute backend's profiler (trainium → neuron, cpu → cpu), "
             "else torch when --modal is set, else nsys. Default: auto."
         ),
     )

--- a/src/vibe_serve/context.py
+++ b/src/vibe_serve/context.py
@@ -208,16 +208,17 @@ class _RunContext:
         self.neuron_profiler_path = self._coerce_dir_path(neuron_profiler, "--neuron-profiler")
 
         # Resolve profiler kind: 'auto' → the compute backend's own profiler
-        # when it dictates one (e.g. Trainium → neuron-explorer), else the run
-        # environment's default (modal → torch, otherwise nsys).
+        # when it dictates a non-GPU workflow (e.g. Trainium → neuron-explorer,
+        # CPU → benchmark/source diagnosis), else the run environment's default
+        # (modal → torch, otherwise nsys).
         resolved_profiler = profiler_kind
         if resolved_profiler == "auto":
             backend_profiler = getattr(self.backend_impl, "profiler_kind", None)
-            if backend_profiler == "neuron":
-                resolved_profiler = "neuron"
+            if backend_profiler in ("neuron", "cpu"):
+                resolved_profiler = backend_profiler
             else:
                 resolved_profiler = self.run_environment.default_profiler_kind
-        if resolved_profiler not in ("nsys", "torch", "neuron"):
+        if resolved_profiler not in ("nsys", "torch", "neuron", "cpu"):
             raise ValueError(f"Unknown profiler kind: {profiler_kind!r}")
         self.profiler_kind = resolved_profiler
 

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -22,7 +22,7 @@ from vibe_serve.loops.agent.domain import (
     render_domain_section,
     resolve_domain,
 )
-from vibe_serve.loops.profiler import invoke_profiler
+from vibe_serve.loops.profiler import invoke_profiler, prompt_template
 from vibe_serve.prompts import render_template
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentSpec,
@@ -269,10 +269,7 @@ def _profiler_prompt_template(profiler_kind: str, interface: str) -> str:
     """
     if interface == "service" and profiler_kind == "torch":
         profiler_kind = "nsys"
-    return {
-        "torch": "profiler_prompt_torch.j2",
-        "neuron": "profiler_prompt_neuron.j2",
-    }.get(profiler_kind, "profiler_prompt_nsys.j2")
+    return prompt_template(profiler_kind)
 
 
 def _run_profiler(

--- a/src/vibe_serve/loops/agent/templates/profiler_prompt_cpu.j2
+++ b/src/vibe_serve/loops/agent/templates/profiler_prompt_cpu.j2
@@ -1,0 +1,60 @@
+{% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
+You are a performance engineer diagnosing a CPU-bound service. There is no GPU profiler for this run.
+
+{% if objective %}
+## Objective (verbatim from `OBJECTIVE.md`)
+
+{{ objective }}
+{% endif %}
+
+Your job is to use source inspection, logs, and benchmark measurements to identify bottlenecks and return a structured summary. Do not use NVIDIA Nsight Systems, CUDA kernel analysis, PyTorch CUDA profiling, or Neuron profiling for this CPU backend.
+
+## Orchestrator focus
+
+{{ profile_focus or "General bottleneck analysis." }}
+
+{% if runtime_notes %}
+## Runtime environment
+
+{{ runtime_notes }}
+{% endif %}
+
+## Workspace
+
+Your working directory contains the implementer's code.
+{% if bench_path is defined and bench_path %}
+A benchmark tool is available at `{{ bench_path }}/benchmark.py`.
+{% endif %}
+
+{% include "_backend/cpu/profiling_workflow.j2" %}
+
+## Diagnosis procedure
+
+1. Read the objective and implementation to understand the service startup path, concurrency model, storage/data structures, and request hot path.
+2. Run the benchmark with `--output-json /tmp/bench.json` (or the equivalent flag discovered with `--help`) and record the objective's headline field exactly.
+3. Inspect logs and source for CPU-side bottlenecks such as serialization, locking, allocation churn, syscalls, data-structure choices, and per-request process/thread overhead.
+4. If the implementation exposes counters or tracing, use them to support the bottleneck ranking. Do not fabricate profiler data.
+
+## Performance metric - use the OBJECTIVE's named headline field, exactly
+
+`perf_metric` is the round's headline performance number that the framework's plateau detector and round-over-round comparisons trust. Plateau detection compares the raw float across rounds, so the unit must not change between rounds.
+
+1. The OBJECTIVE block above names the headline field. Look for a line like `Headline metric: <field_name>` referencing a specific JSON field of the benchmark tool's output.
+2. Run the benchmark with `--output-json /tmp/bench.json` or the equivalent flag.
+3. Read that exact field from the benchmark JSON. Set `perf_metric` to its numeric value and `perf_unit` to that field's name.
+
+If you cannot run the benchmark this round, set `perf_metric: null` rather than substituting a derived number.
+
+## Output
+
+Return exactly one JSON object. Do not wrap in markdown fences.
+
+{
+  "analysis": "<detailed interpretation of the benchmark/source evidence>",
+  "bottlenecks": "<ranked bottlenecks with concrete evidence>",
+  "suggestions": "<actionable optimization suggestions tied to bottlenecks>",
+  "perf_metric": <float or null>,
+  "perf_unit": "<unit string or null>"
+}
+
+IMPORTANT: Base your analysis on actual source, logs, counters, and benchmark output. State explicitly when the bottleneck classification is profile-free.

--- a/src/vibe_serve/loops/evolve/loop.py
+++ b/src/vibe_serve/loops/evolve/loop.py
@@ -41,7 +41,7 @@ from vibe_serve.loops.evolve.population import (
     Objective,
     Population,
 )
-from vibe_serve.loops.profiler import invoke_profiler
+from vibe_serve.loops.profiler import invoke_profiler, prompt_template
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
@@ -223,9 +223,7 @@ def _run_profiler(
     objective: str,
     objectives: list[Objective] | None = None,
 ) -> ProfilerSummary | None:
-    template = (
-        "profiler_prompt_torch.j2" if ctx.profiler_kind == "torch" else "profiler_prompt_nsys.j2"
-    )
+    template = prompt_template(ctx.profiler_kind)
     base_prompt = _render(
         template,
         bench_path=ctx.profiler_bench_path,

--- a/src/vibe_serve/loops/profiler.py
+++ b/src/vibe_serve/loops/profiler.py
@@ -43,11 +43,22 @@ def mcp_spec(profiler_kind: str):
             command="python",
             args=["neuron_profiler/server.py"],
         )
+    if profiler_kind == "cpu":
+        return None
     return MCPServerSpec(
         name="vibeserve-nsys-profiler",
         command="python",
         args=["nsys_profiler/server.py"],
     )
+
+
+def prompt_template(profiler_kind: str) -> str:
+    """Return the profiler prompt template for a resolved profiler kind."""
+    return {
+        "torch": "profiler_prompt_torch.j2",
+        "neuron": "profiler_prompt_neuron.j2",
+        "cpu": "profiler_prompt_cpu.j2",
+    }.get(profiler_kind, "profiler_prompt_nsys.j2")
 
 
 def invoke_profiler(

--- a/tests/backends/test_cpu_backend.py
+++ b/tests/backends/test_cpu_backend.py
@@ -23,7 +23,7 @@ class TestCpuRegistry:
         impl = backends.get(ComputeBackend.CPU, log_dir=tmp_path)
         assert isinstance(impl, LocalBackend)
         assert impl.name is ComputeBackend.CPU
-        assert impl.profiler_kind == "torch"
+        assert impl.profiler_kind == "cpu"
 
 
 class TestCpuSandbox:

--- a/tests/loops/agent/test_interface_modes.py
+++ b/tests/loops/agent/test_interface_modes.py
@@ -114,7 +114,26 @@ def test_standalone_profiler_drops_torch_under_service():
     assert _profiler_prompt_template("torch", "service") == "profiler_prompt_nsys.j2"
     # non-torch kinds are unaffected by the interface
     assert _profiler_prompt_template("neuron", "service") == "profiler_prompt_neuron.j2"
+    assert _profiler_prompt_template("cpu", "service") == "profiler_prompt_cpu.j2"
     assert _profiler_prompt_template("nsys", "service") == "profiler_prompt_nsys.j2"
+
+
+def test_cpu_profiler_prompt_is_profile_free():
+    out = render_template(
+        "profiler_prompt_cpu.j2",
+        template_dir=_TEMPLATE_DIR,
+        modality="text_generation",
+        profile_focus="focus",
+        bench_path="/bench",
+        runtime_notes="",
+        env_kind="local",
+        objective="OBJ",
+    )
+    assert "Profiler-guided analysis is not yet wired up for the `cpu` backend" in out
+    assert "Do not use NVIDIA Nsight Systems" in out
+    assert "nsys profile" not in out
+    assert "torch_profiler" not in out
+    assert "profile-free" in out
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/loops/test_profiler.py
+++ b/tests/loops/test_profiler.py
@@ -24,6 +24,13 @@ from vibe_serve.schemas import (
 # ---------------------------------------------------------------------------
 
 
+def test_cpu_profiler_kind_has_no_mcp_and_cpu_prompt():
+    from vibe_serve.loops.profiler import mcp_spec, prompt_template
+
+    assert mcp_spec("cpu") is None
+    assert prompt_template("cpu") == "profiler_prompt_cpu.j2"
+
+
 def test_profiler_response_creation():
     resp = ProfilerResponse(
         analysis="GPU is 85% busy, attention kernels dominate.",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -8,9 +8,11 @@ from vibe_serve.sandbox.run_environment import RunEnvironmentSpec
 
 class _FakeBackend:
     image = "fake-image"
+    profiler_kind = None
     selected_device = None
 
-    def __init__(self) -> None:
+    def __init__(self, profiler_kind=None) -> None:
+        self.profiler_kind = profiler_kind
         self.sandbox = MagicMock()
 
     def make_sandbox(self, *_args, **_kwargs):
@@ -54,3 +56,29 @@ def test_run_context_defaults_profiler_support_paths(tmp_path, profiler_kind, at
     ):
         assert getattr(ctx, attr) == str(source_dir)
         assert (ctx.workspace / workspace_name / "server.py").is_file()
+
+
+def test_run_context_auto_profiler_uses_cpu_backend_profiler(tmp_path):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    ref_dir = tmp_path / "input"
+    ref_dir.mkdir()
+    ref = ref_dir / "reference.py"
+    ref.write_text("pass\n")
+
+    with (
+        patch("vibe_serve.context.PROJECT_ROOT", project_root),
+        patch("vibe_serve.context._build_model", return_value="mock-model"),
+        patch("vibe_serve.context.build_agent_runner", return_value=MagicMock()),
+        patch("vibe_serve.context.backends.get", return_value=_FakeBackend(profiler_kind="cpu")),
+        _RunContext(
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            exp_name="cpu-auto-profiler",
+            reference_path=str(ref),
+            profiler_kind="auto",
+            skills_dirs=[],
+            run_environment=RunEnvironmentSpec("local"),
+        ) as ctx,
+    ):
+        assert ctx.profiler_kind == "cpu"


### PR DESCRIPTION
## Summary

Closes #103.

Adds a first-class `cpu` profiler kind for CPU backend auto-selection, with no profiler MCP server and a CPU-focused profiler prompt for agent/evolve loops.

`--backend cpu --profiler auto` now resolves to benchmark/source/log diagnosis instead of falling through to GPU-oriented nsys/torch profiler prompts. Evolve and openevolve use the same shared prompt-template mapping as the agent loop.

## Validation

- `uv run pytest tests/backends/test_cpu_backend.py tests/backends/test_metal_backend.py tests/test_context.py tests/loops/agent/test_interface_modes.py tests/loops/test_profiler.py`
- `uv run ruff check src/vibe_serve/backends/local.py src/vibe_serve/cli.py src/vibe_serve/context.py src/vibe_serve/loops/agent/loop.py src/vibe_serve/loops/evolve/loop.py src/vibe_serve/loops/profiler.py tests/backends/test_cpu_backend.py tests/loops/agent/test_interface_modes.py tests/loops/test_profiler.py tests/test_context.py`
