### PR TITLE
Support Docker for CPU backend

### DIFF
--- a/src/vibe_serve/backends/local.py
+++ b/src/vibe_serve/backends/local.py
@@ -1,4 +1,4 @@
-"""Local-only compute backend, shared by Metal and CPU.
+"""No-device compute backend, shared by Metal and CPU.
 
 Some targets run on the host with no accelerator the sandbox layer can reach:
 
@@ -6,11 +6,9 @@ Some targets run on the host with no accelerator the sandbox layer can reach:
   Modal offers no Apple GPUs.
 - ``CPU`` — no GPU at all (CPU-bound targets: KV stores, networking servers).
 
-Both execute identically — a ``LocalShellBackend`` via ``SandboxKind.LOCAL``,
-with no device to select, no contention monitor, and no device migration.
-They differ only in identity (``name``) and the message shown when
-``DOCKER`` / ``MODAL`` is requested, so both are instances of this one class,
-bound to their platform at registration in :mod:`backends`. Per-platform
+Both have no device to select, no contention monitor, and no device migration.
+Metal remains local-only because Docker/Modal cannot expose MPS. CPU can also
+run inside Docker because it needs no accelerator passthrough. Per-platform
 *prompt* guidance (MPS vs pure-CPU) lives in the backend fragments under
 ``templates/_backend/<name>/`` — not here.
 """
@@ -30,10 +28,13 @@ from vibe_serve.backends.base import (
     SetupFn,
 )
 from vibe_serve.constants import ComputeBackend
+from vibe_serve.sandbox.docker_sandbox import DockerSandbox
+
+_DEFAULT_CPU_IMAGE = "python:3.12-bookworm"
 
 
 class LocalBackend:
-    """Local-only backend (Metal / CPU) — all hardware hooks are no-ops."""
+    """No-device backend (Metal / CPU) — hardware hooks are no-ops."""
 
     profiler_kind = "torch"
 
@@ -45,11 +46,14 @@ class LocalBackend:
         log: Callable[[str], None] | None = None,
         image: str | None = None,
         unavailable_reason: str,
+        supports_docker: bool = False,
     ) -> None:
         self.name = name
         self.log_dir = Path(log_dir)
         self._lprint = log or print
+        self.image = image
         self._unavailable_reason = unavailable_reason
+        self._supports_docker = supports_docker
         # No accelerator to pick — kept for protocol parity with other backends
         # (e.g. _RunContext reads ``selected_device``).
         self.selected_device = None
@@ -69,17 +73,39 @@ class LocalBackend:
         setup_fns: list[SetupFn] | None = None,
         modal_options: ModalOptions | None = None,
     ) -> BaseSandbox:
-        if kind is not SandboxKind.LOCAL:
+        bind_mounts = list(bind_mounts or [])
+        passthrough_paths = list(passthrough_paths or [])
+        extra_env = dict(extra_env or {})
+        extra_init_commands = list(extra_init_commands or [])
+        setup_fns = setup_fns or []
+
+        if kind is SandboxKind.LOCAL:
+            return LocalShellBackend(
+                root_dir=host_workspace,
+                virtual_mode=True,
+                inherit_env=True,
+                env=extra_env,
+            )
+        if kind is SandboxKind.DOCKER and self._supports_docker:
+            if self.image is None:
+                raise ValueError(f"{self.name.value} backend requires a Docker image")
+            return DockerSandbox(
+                host_workspace=host_workspace,
+                image=self.image,
+                gpus=None,
+                bind_mounts=bind_mounts,
+                passthrough_paths=passthrough_paths,
+                env=extra_env,
+                log_path=log_path,
+                extra_init_commands=extra_init_commands,
+                setup_fns=setup_fns,
+            )
+        if kind in (SandboxKind.DOCKER, SandboxKind.MODAL):
             raise ValueError(
                 f"{self.name.value} backend only supports local execution; "
                 f"SandboxKind.{kind.name} is unavailable ({self._unavailable_reason})."
             )
-        return LocalShellBackend(
-            root_dir=host_workspace,
-            virtual_mode=True,
-            inherit_env=True,
-            env=dict(extra_env or {}),
-        )
+        raise ValueError(f"Unknown sandbox kind: {kind!r}")
 
     def make_monitor(self, log_dir: Path) -> ContentionMonitor | None:
         return None
@@ -124,6 +150,7 @@ def cpu_backend(
         ComputeBackend.CPU,
         log_dir,
         log=log,
-        image=image,
-        unavailable_reason="there is no GPU to pass through to a Docker/Modal container",
+        image=image or _DEFAULT_CPU_IMAGE,
+        unavailable_reason="Modal CPU execution is not wired up for this backend",
+        supports_docker=True,
     )

--- a/tests/backends/test_cpu_backend.py
+++ b/tests/backends/test_cpu_backend.py
@@ -12,6 +12,7 @@ from vibe_serve.backends import SandboxKind
 from vibe_serve.backends.local import LocalBackend
 from vibe_serve.cli import _add_common_args
 from vibe_serve.constants import ComputeBackend
+from vibe_serve.sandbox.docker_sandbox import DockerSandbox
 
 
 def _make_backend(tmp_path) -> LocalBackend:
@@ -39,19 +40,22 @@ class TestCpuSandbox:
         )
         assert isinstance(sb, LocalShellBackend)
 
-    def test_docker_raises(self, tmp_path):
+    def test_docker_returns_docker_sandbox_without_gpus(self, tmp_path):
         impl = _make_backend(tmp_path)
-        # CPU-specific identity: message names cpu + the no-GPU reason.
-        with pytest.raises(ValueError, match="cpu backend only supports local execution"):
-            impl.make_sandbox(
-                SandboxKind.DOCKER,
-                host_workspace=str(tmp_path),
-                log_path=None,
-            )
+        sb = impl.make_sandbox(
+            SandboxKind.DOCKER,
+            host_workspace=str(tmp_path),
+            log_path=None,
+            extra_env={"FOO": "bar"},
+        )
+        assert isinstance(sb, DockerSandbox)
+        assert sb._gpus is None
+        assert sb._image == impl.image
+        assert sb._env["FOO"] == "bar"
 
     def test_modal_raises(self, tmp_path):
         impl = _make_backend(tmp_path)
-        with pytest.raises(ValueError, match="local execution"):
+        with pytest.raises(ValueError, match="Modal CPU execution is not wired up"):
             impl.make_sandbox(
                 SandboxKind.MODAL,
                 host_workspace=str(tmp_path),


### PR DESCRIPTION
## Summary

Closes #102.

Keeps Metal local-only while allowing the CPU backend to construct a Docker sandbox with no GPU passthrough. CPU Docker uses a general Python base image by default and still rejects Modal with an explicit CPU-specific message.

The shared local/no-device backend now carries per-platform Docker capability instead of treating CPU and Metal as identical local-only targets.

## Validation

- `uv run pytest tests/backends/test_cpu_backend.py tests/backends/test_metal_backend.py`
- `uv run ruff check src/vibe_serve/backends/local.py tests/backends/test_cpu_backend.py`
