### PR TITLE
Fix data structure reference validation

### DIFF
--- a/examples/data-structures/kvstore-default/README.md
+++ b/examples/data-structures/kvstore-default/README.md
@@ -5,16 +5,19 @@ benchmark driver for a concurrent key-value store workload.
 
 ## Running the correctness checker
 
-    python accuracy_checker/checker.py
-    python accuracy_checker/checker.py --clients 8 --ops 4000 --key-space 32
+    uv run python accuracy_checker/checker.py --use-reference
+    uv run python accuracy_checker/checker.py
+    uv run python accuracy_checker/checker.py --clients 8 --ops 4000 --key-space 32
 
 Notes:
-- The checker records a concurrent operation history from `main.VibeServeKVStore`.
+- Use `--use-reference` to validate the bundled reference implementation.
+- Omit `--use-reference` to check a candidate `main.py` exposing `VibeServeKVStore`.
+- The checker records a concurrent operation history before validating linearizability.
 - Linearizability is checked with [Porcupine](https://github.com/anishathalye/porcupine).
 - Go must be installed locally to run the checker.
 
 ## Running the benchmark
 
-    python benchmark/benchmark.py --duration 10
-    python benchmark/benchmark.py --clients 8 --read-ratio 0.6 --output-json results.json
-    python benchmark/benchmark.py --use-reference
+    uv run python benchmark/benchmark.py --duration 10
+    uv run python benchmark/benchmark.py --clients 8 --read-ratio 0.6 --output-json results.json
+    uv run python benchmark/benchmark.py --use-reference

--- a/examples/data-structures/queue-default/README.md
+++ b/examples/data-structures/queue-default/README.md
@@ -7,10 +7,13 @@ drivers for the five initial VibeServe queue scenarios.
 
 ## Running the correctness checker
 
-    python accuracy_checker/checker.py --scenario all
-    python accuracy_checker/checker.py --scenario mpmc --producers 4 --consumers 4
+    uv run python accuracy_checker/checker.py --use-reference --scenario all
+    uv run python accuracy_checker/checker.py --scenario all
+    uv run python accuracy_checker/checker.py --scenario mpmc --producers 4 --consumers 4
 
 Notes:
+- Use `--use-reference` to validate the bundled reference implementations.
+- Omit `--use-reference` to check a candidate `main.py` exposing `VibeServeQueue`.
 - `spsc`, `mpsc`, and `mpmc` scenarios collect concurrent operation histories and
   validate linearizability with [Porcupine](https://github.com/anishathalye/porcupine).
 - `lossy` and `batch` scenarios use scenario-specific property checks.
@@ -18,9 +21,9 @@ Notes:
 
 ## Running the benchmark
 
-    python benchmark/benchmark.py --scenario spsc --duration 10
-    python benchmark/benchmark.py --scenario all --output-json results.json
-    python benchmark/benchmark.py --scenario spsc --use-reference
+    uv run python benchmark/benchmark.py --scenario spsc --duration 10
+    uv run python benchmark/benchmark.py --scenario all --output-json results.json
+    uv run python benchmark/benchmark.py --scenario spsc --use-reference
 
 ## Acceptance criteria (from #43)
 

--- a/examples/data-structures/queue-default/accuracy_checker/checker.py
+++ b/examples/data-structures/queue-default/accuracy_checker/checker.py
@@ -11,7 +11,7 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "reference"))
-from reference import SCENARIOS
+from reference import SCENARIOS, QueueFactory
 
 
 def _load_candidate():
@@ -224,10 +224,15 @@ def main():
     parser.add_argument("--producers", type=int, default=4)
     parser.add_argument("--consumers", type=int, default=4)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--use-reference", action="store_true")
     args = parser.parse_args()
 
-    print("Loading VibeServeQueue from main.py ...")
-    cls = _load_candidate()
+    if args.use_reference:
+        print("Loading reference QueueFactory ...")
+        cls = QueueFactory
+    else:
+        print("Loading VibeServeQueue from main.py ...")
+        cls = _load_candidate()
     print("  Loaded.")
 
     targets = SCENARIOS if args.scenario == "all" else [args.scenario]


### PR DESCRIPTION
## Summary

- Add `--use-reference` support to the queue data-structure accuracy checker so the bundled queue references can be validated directly.
- Update the queue and KV store data-structure READMEs to use `uv run python` commands and document reference-vs-candidate checker modes.

## Root Cause

The queue checker always attempted to import `VibeServeQueue` from a candidate `main.py`, even though the example acceptance criteria say the bundled reference implementations should pass their scenario checkers. On this machine, the README's literal `python` commands also failed because only the project-managed `uv run python` path is available.

## Validation

- `uv run python accuracy_checker/checker.py --use-reference --scenario all` from `examples/data-structures/queue-default` passed 5/5 scenarios.
- `uv run python accuracy_checker/checker.py --use-reference` from `examples/data-structures/kvstore-default` passed Porcupine linearizability for 3000 operations.
- `uv run python benchmark/benchmark.py --scenario all --duration 0.2 --warmup 0 --use-reference` from `examples/data-structures/queue-default` completed all scenarios.
- `uv run python benchmark/benchmark.py --duration 0.2 --warmup 0 --use-reference` from `examples/data-structures/kvstore-default` completed successfully.
- `git diff --check` passed.
