### PR TITLE
Add input bundle CLI shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,7 @@ cp agent.toml.example agent.toml
 ```bash
 # Issue-tracker outer loop, Codex CLI, Docker on local CUDA, 4 rounds
 vibe-serve \
-  --ref examples/model-serving/moonshine-streaming/reference \
-  --acc-checker examples/model-serving/moonshine-streaming/accuracy_checker \
-  --bench examples/model-serving/moonshine-streaming/benchmark \
+  --input examples/model-serving/moonshine-streaming \
   --exp-name my-experiment \
   --docker \
   --agent-backend cli --cli-provider codex \
@@ -133,7 +131,13 @@ examples/<name>/
 └── README.md             # human-readable description
 ```
 
-`OBJECTIVE.md` is read at the start of every run and must live next to `--ref` (sibling, not inside). See `examples/model-serving/Llama-3-8B/`, `examples/model-serving/moonshine-streaming/`, `examples/model-serving/qwen3-32b-code-edit/`, `examples/model-serving/olmo-hybrid-prefix-caching/`, `examples/model-serving/Llama-3.1-8B-Instruct-MLX-8bit/`, `examples/model-serving/show-o2-1.5B-HQ-h100/`, and `examples/model-serving/show-o2-1.5B-HQ-macbook/` for the paper scenarios.
+Pass the bundle root with `--input examples/<name>/` to derive `--ref`,
+`--acc-checker`, and `--bench` from the standard subdirectory names. You can
+still pass those three flags explicitly; explicit paths override `--input`
+defaults when you need a custom checker or benchmark.
+
+`OBJECTIVE.md` is read at the start of every run and must live next to the
+`reference/` directory (sibling, not inside). See `examples/model-serving/Llama-3-8B/`, `examples/model-serving/moonshine-streaming/`, `examples/model-serving/qwen3-32b-code-edit/`, `examples/model-serving/olmo-hybrid-prefix-caching/`, `examples/model-serving/Llama-3.1-8B-Instruct-MLX-8bit/`, `examples/model-serving/show-o2-1.5B-HQ-h100/`, and `examples/model-serving/show-o2-1.5B-HQ-macbook/` for the paper scenarios.
 
 For multi-objective evolutionary runs, drop an `objectives.toml` next to `OBJECTIVE.md` (or pass `--objective name:max|min` flags) — see `vibe-serve --outer-loop evolve --help`.
 

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -17,7 +17,7 @@ Several flags look independent, but they combine into one execution contract:
 | Profiler | `--profiler` | Bottleneck evidence source: `nsys`, `torch`, `neuron`, or `auto`. |
 | Domain | `--domain` | Agent-loop problem-space prompt pack, such as `llm-serving` or `generic`. |
 | Modality | `--modality` | Per-task I/O contract, such as `text_generation` or `speech_to_text`. |
-| Target inputs | `--ref`, `--acc-checker`, `--bench` | Reference implementation, correctness checker, and benchmark harness for the target. |
+| Target inputs | `--input`, `--ref`, `--acc-checker`, `--bench` | Target bundle directory, reference implementation, correctness checker, and benchmark harness. |
 
 Do not treat these as simple toggles. Some combinations imply a language,
 startup contract, profiler, or sandbox capability.
@@ -99,6 +99,37 @@ Built-ins include:
 speech-to-text. Domains should avoid hardcoding modality or interface
 requirements that are already expressed by `--modality` or `--interface`.
 
+## Target Inputs
+
+Most examples use the standard bundle layout:
+
+```text
+examples/<target>/
+├── OBJECTIVE.md
+├── reference/
+├── accuracy_checker/
+└── benchmark/
+```
+
+For those bundles, pass the root once:
+
+```bash
+vibe-serve --input examples/<target> ...
+```
+
+This derives any missing target path flags as:
+
+- `--ref <input>/reference`
+- `--acc-checker <input>/accuracy_checker`
+- `--bench <input>/benchmark`
+
+Explicit flags override derived values, so a custom benchmark can be mixed in
+without repeating every path:
+
+```bash
+vibe-serve --input examples/<target> --bench /tmp/custom-benchmark ...
+```
+
 ## Common Commands
 
 Default agent loop on local CUDA-compatible host:
@@ -108,9 +139,7 @@ vibe-serve \
   --outer-loop agent \
   --backend cuda \
   --interface inprocess \
-  --ref examples/model-serving/Llama-3-8B/reference \
-  --acc-checker examples/model-serving/Llama-3-8B/accuracy_checker \
-  --bench examples/model-serving/Llama-3-8B/benchmark
+  --input examples/model-serving/Llama-3-8B
 ```
 
 Docker CUDA run:
@@ -138,9 +167,7 @@ vibe-serve \
   --outer-loop agent \
   --interface service \
   --domain generic \
-  --ref examples/<target>/reference \
-  --acc-checker examples/<target>/accuracy_checker \
-  --bench examples/<target>/benchmark
+  --input examples/<target>
 ```
 
 CPU-only target in the current merged code:

--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -112,6 +112,17 @@ def _fail(msg: str) -> None:
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
     """Add CLI arguments shared across every outer-loop parser."""
     parser.add_argument(
+        "--input",
+        type=Path,
+        default=None,
+        help=(
+            "Path to a target input bundle containing reference/, "
+            "accuracy_checker/, and benchmark/. Missing --ref, "
+            "--acc-checker, and --bench values are derived from this layout; "
+            "explicit path flags override the derived defaults."
+        ),
+    )
+    parser.add_argument(
         "--ref",
         default=None,
         help="Path to reference implementation file, or directory containing at least one reference.py.",
@@ -459,7 +470,50 @@ def _build_agent_parser() -> argparse.ArgumentParser:
     return parser
 
 
+_INPUT_TARGETS = (
+    ("ref", "--ref", "reference"),
+    ("acc_checker", "--acc-checker", "accuracy_checker"),
+    ("bench", "--bench", "benchmark"),
+)
+
+
+def _apply_input_defaults(args: argparse.Namespace) -> None:
+    input_arg = getattr(args, "input", None)
+    if input_arg is None:
+        return
+
+    input_dir = Path(input_arg).expanduser().resolve()
+    if not input_dir.exists():
+        print(f"Error: --input path does not exist: {input_arg}", file=sys.stderr)
+        sys.exit(2)
+    if not input_dir.is_dir():
+        print(f"Error: --input path is not a directory: {input_arg}", file=sys.stderr)
+        sys.exit(2)
+
+    missing = []
+    for attr, flag, dirname in _INPUT_TARGETS:
+        if getattr(args, attr) is not None:
+            continue
+        candidate = input_dir / dirname
+        if not candidate.is_dir():
+            missing.append(f"{dirname}/ for {flag}")
+            continue
+        # Keep the historical argparse shape: --ref is a string, while
+        # --acc-checker and --bench are pathlib.Path values.
+        setattr(args, attr, str(candidate) if attr == "ref" else candidate)
+
+    if missing:
+        print(
+            "Error: --input bundle is missing required target subdir(s): "
+            + ", ".join(missing)
+            + f" under {input_dir}.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
 def _validate_target_inputs(args: argparse.Namespace) -> None:
+    _apply_input_defaults(args)
     missing = [
         flag
         for flag, value in (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -83,9 +84,93 @@ def test_target_inputs_default_to_none():
 
     args = _build_agent_parser().parse_args([])
 
+    assert args.input is None
     assert args.ref is None
     assert args.acc_checker is None
     assert args.bench is None
+
+
+@pytest.mark.parametrize(
+    "builder_name",
+    [
+        "_build_agent_parser",
+        "_build_evolve_parser",
+        "_build_openevolve_parser",
+        "_build_plain_parser",
+    ],
+)
+def test_input_arg_is_available_on_all_loop_parsers(builder_name):
+    import vibe_serve.cli as cli
+
+    parser = getattr(cli, builder_name)()
+    args = parser.parse_args(["--input", "examples/data-structures/queue-default"])
+
+    assert args.input == Path("examples/data-structures/queue-default")
+
+
+def test_validate_target_inputs_derives_bundle_paths_from_input(tmp_path):
+    from vibe_serve.cli import _build_agent_parser
+
+    bundle = tmp_path / "queue-default"
+    (bundle / "reference").mkdir(parents=True)
+    (bundle / "accuracy_checker").mkdir()
+    (bundle / "benchmark").mkdir()
+
+    args = _build_agent_parser().parse_args(["--input", str(bundle)])
+
+    _validate_target_inputs(args)
+
+    assert args.ref == str(bundle / "reference")
+    assert args.acc_checker == bundle / "accuracy_checker"
+    assert args.bench == bundle / "benchmark"
+
+
+def test_validate_target_inputs_keeps_explicit_overrides(tmp_path):
+    from vibe_serve.cli import _build_agent_parser
+
+    bundle = tmp_path / "queue-default"
+    (bundle / "reference").mkdir(parents=True)
+    (bundle / "accuracy_checker").mkdir()
+    custom_bench = tmp_path / "custom-benchmark"
+    custom_bench.mkdir()
+
+    args = _build_agent_parser().parse_args(["--input", str(bundle), "--bench", str(custom_bench)])
+
+    _validate_target_inputs(args)
+
+    assert args.ref == str(bundle / "reference")
+    assert args.acc_checker == bundle / "accuracy_checker"
+    assert args.bench == custom_bench
+
+
+def test_validate_target_inputs_rejects_missing_input_dir(tmp_path, capsys):
+    from vibe_serve.cli import _build_agent_parser
+
+    missing = tmp_path / "missing"
+    args = _build_agent_parser().parse_args(["--input", str(missing)])
+
+    with pytest.raises(SystemExit) as exc:
+        _validate_target_inputs(args)
+
+    assert exc.value.code == 2
+    assert "--input path does not exist" in capsys.readouterr().err
+
+
+def test_validate_target_inputs_reports_missing_input_subdirs(tmp_path, capsys):
+    from vibe_serve.cli import _build_agent_parser
+
+    bundle = tmp_path / "incomplete"
+    (bundle / "reference").mkdir(parents=True)
+
+    args = _build_agent_parser().parse_args(["--input", str(bundle)])
+
+    with pytest.raises(SystemExit) as exc:
+        _validate_target_inputs(args)
+
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "accuracy_checker/ for --acc-checker" in err
+    assert "benchmark/ for --bench" in err
 
 
 def test_validate_target_inputs_requires_bundle_paths(capsys):


### PR DESCRIPTION
## Summary

- Add a common `--input` flag that points at a target bundle root.
- Derive missing `--ref`, `--acc-checker`, and `--bench` values from `reference/`, `accuracy_checker/`, and `benchmark/` under that bundle.
- Keep explicit path flags as overrides and document the shorthand in README and CLI flag docs.

Closes #112.

## Validation

- `uv run pytest tests/test_cli.py`
- `./scripts/check_format.sh`
- `./scripts/check_lint.sh`
- `uv run vibe-serve --help | rg -n -- "--input|--ref|--acc-checker|--bench"