### PR TITLE
Move LLM serving guidance into domain prompts

### DIFF
--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -431,7 +431,7 @@ def _build_agent_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-rounds", type=int, default=24)
     parser.add_argument("--max-retries-per-round", type=int, default=3)
     parser.add_argument("--start-round", type=int, default=None, metavar="N")
-    parser.add_argument("--modality", default="text_generation", choices=_MODALITIES)
+    parser.add_argument("--modality", default=None, choices=_MODALITIES)
     parser.add_argument(
         "--domain",
         default=DEFAULT_DOMAIN,

--- a/src/vibe_serve/loops/agent/domain.py
+++ b/src/vibe_serve/loops/agent/domain.py
@@ -11,6 +11,7 @@ sections are injected into the neutral base prompts:
     ├── ## implementer    ← injected as {{ domain_implementer }}
     ├── ## judge          ← injected as {{ domain_judge }}
     ├── ## single_agent   ← injected as {{ domain_single_agent }}
+    ├── ## orchestrator   ← injected as {{ domain_orchestrator }}
     └── ## profiler       ← injected as {{ domain_profiler }}
 
 The section heading *is* the address: a line that is exactly ``## <role>`` (for a

--- a/src/vibe_serve/loops/agent/domain.py
+++ b/src/vibe_serve/loops/agent/domain.py
@@ -10,7 +10,8 @@ sections are injected into the neutral base prompts:
     ├── (free-form prose / description — ignored by the loop)
     ├── ## implementer    ← injected as {{ domain_implementer }}
     ├── ## judge          ← injected as {{ domain_judge }}
-    └── ## single_agent   ← injected as {{ domain_single_agent }}
+    ├── ## single_agent   ← injected as {{ domain_single_agent }}
+    └── ## profiler       ← injected as {{ domain_profiler }}
 
 The section heading *is* the address: a line that is exactly ``## <role>`` (for a
 role in :data:`DOMAIN_ROLES`) starts that role's section, which runs until the
@@ -41,7 +42,13 @@ DEFAULT_DOMAIN = "llm-serving"
 # The roles a domain pack can contribute to. Each maps to a ``## <role>`` section
 # in the domain file and a ``{{ domain_<role> }}`` injection point in the
 # corresponding base prompt.
-DOMAIN_ROLES: tuple[str, ...] = ("implementer", "judge", "single_agent", "orchestrator")
+DOMAIN_ROLES: tuple[str, ...] = (
+    "implementer",
+    "judge",
+    "single_agent",
+    "orchestrator",
+    "profiler",
+)
 
 _BUILTIN_DOMAINS_DIR = Path(__file__).resolve().parent / "templates" / "_domain"
 

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -500,6 +500,9 @@ def _run_single_agent_round(
     domain_single_agent = render_domain_section(
         domain_path, "single_agent", **_domain_render_context(ctx, modality, interface)
     )
+    domain_profiler = render_domain_section(
+        domain_path, "profiler", **_domain_render_context(ctx, modality, interface)
+    )
     system_prompt = render_template(
         "single_agent_round_prompt.j2",
         template_dir=_TEMPLATE_DIR,
@@ -507,6 +510,7 @@ def _run_single_agent_round(
         modality=modality,
         interface=interface,
         domain_single_agent=domain_single_agent,
+        domain_profiler=domain_profiler,
         task=plan.task,
         pass_criteria=plan.pass_criteria,
         retry=retry,

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -280,18 +280,23 @@ def _run_profiler(
     *,
     round_number: int,
     profile_focus: str,
-    modality: str,
+    modality: str | None,
     interface: str,
+    domain_path: Path,
     progress_path: Path,
     objective: str,
 ) -> ProfilerSummary | None:
     template = _profiler_prompt_template(ctx.profiler_kind, interface)
+    domain_profiler = render_domain_section(
+        domain_path, "profiler", **_domain_render_context(ctx, modality, interface)
+    )
     system_prompt = render_template(
         template,
         template_dir=_TEMPLATE_DIR,
         profile_focus=profile_focus,
         bench_path=ctx.profiler_bench_path,
         modality=modality,
+        domain_profiler=domain_profiler,
         runtime_notes=ctx.run_environment_view.prompt_notes,
         env_kind=ctx.run_environment_view.env_kind,
         objective=objective,
@@ -308,7 +313,9 @@ def _run_profiler(
     return summary
 
 
-def _domain_render_context(ctx: _RunContext, modality: str, interface: str) -> dict[str, object]:
+def _domain_render_context(
+    ctx: _RunContext, modality: str | None, interface: str
+) -> dict[str, object]:
     """The uniform variable set every domain ``## <role>`` section is rendered with.
 
     One context contract for all roles: a pack author can branch (``{% if … %}``)
@@ -339,7 +346,7 @@ def _run_orchestrator_plan(
     progress_path: Path,
     roadmap_text: str,
     plateau_warning: str | None,
-    modality: str,
+    modality: str | None,
     interface: str,
     domain_path: Path,
 ) -> OrchestratorPlan:
@@ -381,7 +388,7 @@ def _run_implementer(
     round_number: int,
     retry: int,
     plan: OrchestratorPlan,
-    modality: str,
+    modality: str | None,
     interface: str,
     domain_path: Path,
     feedback: str | None,
@@ -428,7 +435,7 @@ def _run_judge(
     round_number: int,
     retry: int,
     plan: OrchestratorPlan,
-    modality: str,
+    modality: str | None,
     interface: str,
     domain_path: Path,
     progress_path: Path,
@@ -476,7 +483,7 @@ def _run_single_agent_round(
     round_number: int,
     retry: int,
     plan: OrchestratorPlan,
-    modality: str,
+    modality: str | None,
     interface: str,
     domain_path: Path,
     feedback: str | None,
@@ -577,7 +584,7 @@ def run_agent_loop(
     agent_backend: str | None = None,
     cli_provider: str | None = None,
     backend: ComputeBackend = DEFAULT_COMPUTE_BACKEND,
-    modality: str = "text_generation",
+    modality: str | None = None,
     inner_loop: str = "multi-agent",
     domain: str = DEFAULT_DOMAIN,
     interface: str = DEFAULT_INTERFACE,
@@ -618,6 +625,8 @@ def run_agent_loop(
     # site. The implementation language is not a pack — ``interface`` carries it
     # (``inprocess`` pins Python; ``service`` leaves it to the agent).
     domain_path = resolve_domain(domain)
+    if modality is None and domain_path.stem == DEFAULT_DOMAIN:
+        modality = "text_generation"
     run_environment = run_environment or make_run_environment_spec()
     ctx = _RunContext(
         config=config,
@@ -688,9 +697,10 @@ def run_agent_loop(
                             ctx,
                             round_number=round_number,
                             profile_focus=pre_decision.profile_focus
-                            or "general latency hotspots on /v1/completions",
+                            or "general steady-state benchmark hotspots",
                             modality=modality,
                             interface=interface,
+                            domain_path=domain_path,
                             progress_path=progress_path,
                             objective=objective,
                         )

--- a/src/vibe_serve/loops/agent/templates/_domain/README.md
+++ b/src/vibe_serve/loops/agent/templates/_domain/README.md
@@ -2,9 +2,10 @@
 
 A **domain** bundles the cross-cutting context the agents need for whatever
 you're building: the background knowledge the implementer must read, the
-correctness/performance/integrity gates the judge must enforce, and the same for
-the single-agent ablation. It's the answer to *"what kind of system is this, and
-what does 'good' mean here?"* — kept separate from the neutral prompt skeleton.
+correctness/performance/integrity gates the judge must enforce, profiling
+workflow details, and the same for the single-agent ablation. It's the answer to
+*"what kind of system is this, and what does 'good' mean here?"* — kept separate
+from the neutral prompt skeleton.
 
 Pick one with `--domain` (agent loop):
 
@@ -44,14 +45,18 @@ Combined builder+reviewer context for the single-agent ablation.
 ## orchestrator       ← injected as {{ domain_orchestrator }} (optional)
 Planning guidance for the round orchestrator — e.g. the optimization floor it
 should establish before chasing workload-specific wins.
+
+## profiler           ← injected as {{ domain_profiler }} (optional)
+Domain-specific capture workflow details for whichever profiler strategy is
+selected.
 ```
 
 Rules:
 
 - **The heading is the address.** A line that is exactly `## implementer`,
-  `## judge`, `## single_agent`, or `## orchestrator` starts that role's section;
-  it runs until the next role heading. Your section body can use its own `##`
-  sub-headings — only those four exact names delimit a section.
+  `## judge`, `## single_agent`, `## orchestrator`, or `## profiler` starts that
+  role's section; it runs until the next role heading. Your section body can use
+  its own `##` sub-headings — only those exact names delimit a section.
 - **A missing section injects nothing** for that role.
 - **`## single_agent` is optional.** Omit it and it's derived automatically by
   concatenating your `## implementer` and `## judge` sections — no third copy to
@@ -61,6 +66,9 @@ Rules:
   prompt (its neutral skeleton still applies). Add it to give the planner
   domain-specific strategy — `llm-serving` uses it for the
   continuous-batching/attention-kernel/CUDA-graph optimization floor.
+- **`## profiler` is optional.** Omit it to use only the selected profiler's
+  neutral mechanics. Add it when the domain needs a specific capture recipe,
+  server startup contract, benchmark shape, or remote profiling entry point.
 - Write normal Markdown prose. The base template owns the surrounding structure
   (task, pass criteria, workspace, output contract); your section owns the
   domain content.
@@ -104,20 +112,19 @@ Example (inside a `## judge` section):
    (what to check). Leave a section out to inject nothing for that role.
 4. Optionally add `## single_agent` for the `--inner-loop single-agent` ablation;
    omit it to derive it from the other two.
-5. Run `vibe-serve --outer-loop agent --domain <name-or-path> ...`.
+5. Optionally add `## orchestrator` and `## profiler` when the neutral planning
+   or profiling skeleton needs domain-specific examples or capture commands.
+6. Run `vibe-serve --outer-loop agent --domain <name-or-path> ...`.
 
 That's it — no code change. A new built-in domain is just a new `.md` file here;
 a private domain is just a path you pass.
 
 ## Scope
 
-Domains cover **implementer + judge (+ single-agent + orchestrator) context**. Two adjacent
-concerns are deliberately *not* part of a domain file:
+Domains cover **implementer + judge + profiler (+ single-agent + orchestrator) context**.
+One adjacent concern is deliberately *not* part of a domain file:
 
 - **Language/tooling** (e.g. "use `uv`/`pytest`") is decided by the run's
   `--interface` mode, not the domain: `inprocess` pins Python (uv toolchain +
-  in-process `VibeServeModel` contract); `service` leaves the language to the
-  agent. It is not a user-facing pack.
-- **Profiling** (nsys/torch GPU capture) is selected by `--profiler` and rendered
-  by the profiler prompts, not the domain. Domain-specific profiling is future
-  work tied to pluggable profilers.
+  the in-process accuracy-checker contract); `service` leaves the language to
+  the agent. It is not a user-facing pack.

--- a/src/vibe_serve/loops/agent/templates/_domain/llm-serving.md
+++ b/src/vibe_serve/loops/agent/templates/_domain/llm-serving.md
@@ -157,3 +157,65 @@ The three exceptions that let you skip a floor item:
 - **CUDA graphs**: skip when the decode shapes are genuinely unbucketable (very rare — even speculative-decoding tree depths and chunked-prefill chunk sizes are ≤ 16 buckets).
 
 If you skip a floor item, cite the specific incompatibility in your `reasoning`. Do NOT skip because "the current profile shows something else is the dominant cost" — the floor items *become* the dominant cost in turn once other work lands, and cycling between "revert this, try that" over exotic optimizations without the floor in place is a common failure mode of this loop.
+
+## LLM-serving task examples
+
+Good round-sized tasks for this domain include:
+- "Build a self-contained FastAPI server for the reference model."
+- "Add continuous batching to the decode loop."
+- "Replace manual attention with FlashInfer batched decode."
+- "Add CUDA graph capture/replay for the decode path."
+- "Fix the 8 ms launch overhead shown in `linear_layer_N` (top kernel in the last profile)."
+
+## Scoping API work
+
+When your task touches HTTP endpoint or message-schema work, name the specific endpoint(s) and point the implementer at the authoritative skill file — typically `skills/serving-systems/tooling/openai-api/SKILL.md` (per-modality OpenAI-compatible contracts). You can start with a single endpoint (e.g. "`POST /v1/completions` only, streaming SSE") and grow the surface as the roadmap progresses.
+
+## LLM-serving performance criteria
+
+This matters whenever a round adds a path that *trades per-call work for fewer calls* (speculative decoding, xgrammar jump-forward, batched extend, prefix caching, prompt caching, larger CUDA-graph buckets). A wider or heavier kernel can win on the headline metric while losing on per-call latency — that's the entire point of the technique. Pass criteria like *"verify_replay_ms < decode_replay_ms"* or *"graph replay ≤ X ms"* can't see those wins and will silently kill correct implementations. Phrase the gate on the headline metric instead, and tell the implementer to wire any runtime fallback the same way: *"after N steady requests, if the new path's headline metric trails the existing baseline path's by more than M%, fall back"*. Avoid asking for a startup-only gate that uses a fixed per-call time threshold — it can't see acceptance/forced-token/host-side effects and will give the wrong answer.
+
+For static-inspection criteria, prefer wordings like:
+
+- "no `torch.profiler.profile(...)` invocations in `main.py` or any module the implementer added"
+- "no per-token `torch.cat` against the KV cache in `main.py`'s decode path"
+
+Avoid broad clauses like "no profiler/Nsight code"; those trip on framework-provided profiler directories.
+
+## profiler
+## LLM-serving profile capture
+
+Use the benchmark's steady-state serving path when collecting profile evidence. If the profiler strategy supports only one process, run the server under the profiler and drive load with the benchmark in a second shell. Discover flags with `--help`; do not assume every benchmark accepts the same request-count or token flags.
+
+For local server-style captures, the usual shape is:
+
+1. Read `main.py` to understand startup and port.
+2. Kill prior servers: `pkill -f "python main.py" 2>/dev/null || true; sleep 2`.
+3. Pre-warm — first-time kernel compilation or model load can take minutes.
+4. Start the candidate server under the profiler.
+5. Drive load using the benchmark, for example `uv run python {{ bench_path or 'bench' }}/benchmark.py --url http://localhost:8077 --rate 1 --num-requests 5 --max-tokens 64` when those flags exist.
+6. Stop the profiled server and analyze the report.
+
+For torch in-process captures, the reference harness is designed around `VibeServeModel.from_pretrained(...)` and `.generate(...)`:
+
+```
+python torch_profiler/analyze_torch_profile.py capture \
+  --model-dir /workspace --weights-dir /model \
+  --output /tmp/prof.json \
+  --warmup 3 --num-iters 20 --max-tokens 32 \
+  --prompt "The capital of France is"
+```
+
+Use this mode for kernel-level optimization (fused norm/rope/attention, CUDA graphs, dtypes). It does not cover HTTP, batching, or queueing overhead.
+
+For Modal torch profiling, the implementer's `main.py` is required to expose `@app.local_entrypoint() modal_profile(output, num_iters, max_tokens, prompt)`. Invoke it from the editor container:
+
+```
+modal run main.py::modal_profile -- \
+  --output /workspace/prof.json \
+  --num-iters 20 \
+  --max-tokens 32 \
+  --prompt "The capital of France is"
+```
+
+This dispatches to a `@app.function profile_remote(...)` running on the Modal GPU, which wraps the same workload the benchmark exercises in `torch.profiler` and returns the analyzer-compatible JSON.

--- a/src/vibe_serve/loops/agent/templates/implementer_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/implementer_prompt.j2
@@ -1,6 +1,7 @@
-{% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
 {% if interface is not defined %}{% set interface = "inprocess" %}{% endif %}
+{% if modality %}
 {% include "_modality/" ~ modality ~ "/implementer.j2" %}
+{% endif %}
 
 {% if runtime_notes %}
 ## Runtime environment

--- a/src/vibe_serve/loops/agent/templates/judge_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/judge_prompt.j2
@@ -1,4 +1,3 @@
-{% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
 {% if interface is not defined %}{% set interface = "inprocess" %}{% endif %}
 You are a senior code reviewer evaluating the candidate implementation.
 
@@ -18,7 +17,9 @@ You are a senior code reviewer evaluating the candidate implementation.
 {{ runtime_notes }}
 {% endif %}
 
+{% if modality %}
 {% include "_modality/" ~ modality ~ "/judge.j2" %}
+{% endif %}
 
 {% if domain_judge %}
 {{ domain_judge }}

--- a/src/vibe_serve/loops/agent/templates/orchestrator_plan_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/orchestrator_plan_prompt.j2
@@ -1,4 +1,4 @@
-You are the Orchestrator agent in an autonomous inference-server build loop. Your sole output is a plan for this round — you do NOT write or modify any code.
+You are the Orchestrator agent in an autonomous optimization loop. Your sole output is a plan for this round — you do NOT write or modify any code.
 
 ## Objective
 
@@ -29,9 +29,9 @@ You own a free-form markdown file at `roadmap.md` in your working directory. The
 These are not the same thing. Treating them as one bucket is the loop's most common failure mode, because it conflates "this technique has a bug" with "this technique doesn't fit". Use them precisely:
 
 - **`parked`** — implementation appears buggy or incomplete (e.g. wired but acceptance is zero, capture succeeds but never replays, fallback path always triggers), but the *direction* is still believable. Returnable to `in_progress`. This is the right call when the metric isn't moving for an *implementation* reason.
-- **`abandoned`** — the *direction itself* is wrong for this workload. Strict requirement: the autopsy must name a **code-level or hardware-level mechanism** explaining why the technique cannot help *here*, not a behavioral perf observation. A perf delta ("0% improvement", "0 acceptance") is not a mechanism. "Workload is single-batch by contract → continuous batching cannot raise arithmetic intensity" is. If you can't write a mechanism, the right status is **`parked`**, not `abandoned`.
+- **`abandoned`** — the *direction itself* is wrong for this workload. Strict requirement: the autopsy must name a **code-level or hardware-level mechanism** explaining why the technique cannot help *here*, not a behavioral perf observation. A perf delta ("0% improvement", "0 acceptance") is not a mechanism. If you can't write a mechanism, the right status is **`parked`**, not `abandoned`.
 
-If you're tempted to abandon because of zero acceptance / zero replays / always-fallback, that's a debugging signal — open the relevant `references/...md` "Debugging X" subsection (e.g. `Debugging 0 acceptance` in `references/algorithms/speculative-decoding.md`) and either fix it or park it. Don't abandon.
+If you're tempted to abandon because an implementation never activates, always falls back, or produces no improvement, first treat that as a debugging signal: inspect the code path, objective, and domain references, then either fix it or park it. Don't abandon without a mechanism-level reason.
 
 Required this round, in order:
 
@@ -61,7 +61,7 @@ Failing to address this and producing another flat-perf round buys you no inform
 
 ## Skills
 
-A library of curated technique-specific skills is installed in your working directory. Your CLI's native skill mechanism exposes their names + short descriptions; activate (open) the ones whose description matches the work this round needs — typical roadmap items map to one or two skills (e.g. "Add CUDA graphs to verifier decode" → `cuda-graph` and possibly `flashattention` / `flashinfer`; "EAGLE3 wiring" → `speculative-decoding`; "xgrammar fast path" → `structured-output`). Don't try to enumerate or preload them.
+A library of curated technique-specific skills may be installed in your working directory. Your CLI's native skill mechanism exposes their names + short descriptions; activate (open) only the ones whose description matches the work this round needs. Don't try to enumerate or preload them.
 
 {% if profiler_summary %}
 ## Profiler summary (just collected this round)
@@ -102,39 +102,38 @@ The implementer could not pass within the retry budget. Propose a strictly small
 {% endif %}
 ## Task granularity
 
-Tasks should be comparable in scope to, e.g.:
-- "Build a self-contained FastAPI server for the reference model."
-- "Add continuous batching to the decode loop."
-- "Replace manual attention with FlashInfer batched decode."
-- "Add CUDA graph capture/replay for the decode path."
-- "Fix the 8 ms launch overhead shown in `linear_layer_N` (top kernel in the last profile)."
+Tasks should be one concrete implementation slice, small enough for the implementer to finish and the judge to verify in one round. Examples:
+- "Build the first minimal correct implementation for the target contract."
+- "Replace the identified hot path with a lower-overhead implementation."
+- "Add a benchmark-visible fast path for the active workload shape."
+- "Fix the correctness failure reported by the previous judge attempt."
 
-## Scoping API work
+## Scoping interface work
 
-The implementer and judge templates intentionally do NOT hardcode the full API surface. When your task touches any HTTP endpoint or message-schema work, name the specific endpoint(s) and point the implementer at the authoritative skill file — typically `skills/serving-systems/tooling/openai-api/SKILL.md` (per-modality OpenAI-compatible contracts). The implementer is told to implement ONLY what you name; the judge is told to verify ONLY what your `pass_criteria` mentions. You can start with a single endpoint (e.g. "`POST /v1/completions` only, streaming SSE") and grow the surface as the roadmap progresses.
+The implementer and judge templates intentionally do NOT hardcode the full interface surface. When your task touches an API, class contract, protocol, file format, or message schema, name the specific part in scope and point the implementer at the authoritative domain reference. The implementer is told to implement ONLY what you name; the judge is told to verify ONLY what your `pass_criteria` mentions.
 
 ## Pass criteria
 
-Criteria must be specific and testable. The framework ALWAYS runs the accuracy checker and a benchmark sanity check, so you only need to specify feature-level criteria (e.g. "CUDA graph replay visible in profile", "no fallback warnings in server log", "`POST /v1/completions` streams SSE frames matching `skills/serving-systems/tooling/openai-api/SKILL.md` and terminates with `[DONE]`"). Do NOT list endpoints you do not want the judge to verify this round.
+Criteria must be specific and testable. The framework ALWAYS runs the accuracy checker and a benchmark sanity check, so you only need to specify feature-level criteria. Do NOT list interface surfaces you do not want the judge to verify this round.
 
 **Runtime-environment notes are authoritative.** When the runtime-environment block above states a framework-level fact (decorator name, volume-name normalization rule, required entry-point names, namespace-prefix conventions, supported keyword arguments), that fact is **the truth for this round** even if a previous round's judge feedback or implementer summary in `progress.md` says something different. Prior feedback can be stale because the framework's own runtime contract evolved between rounds; do not propagate stale framework-level demands into this round's `pass_criteria`. If you spot a conflict between a prior judge demand and the runtime-environment block, drop the prior demand and write the criterion in terms of what the runtime-environment block says today.
 
 **Performance criteria use the objective's headline metric, end-to-end.** Whatever metric the OBJECTIVE specifies (single-batch tok/s, aggregate throughput, TTFT, p50/p99 latency, …) is the one the framework's plateau detector compares across rounds and the one your `pass_criteria` should reference for any performance gate. Always express it as the benchmark measures it end-to-end — never as a per-call, per-replay, or per-kernel timing.
 
-This matters whenever a round adds a path that *trades per-call work for fewer calls* (speculative decoding, xgrammar jump-forward, batched extend, prefix caching, prompt caching, larger CUDA-graph buckets). A wider or heavier kernel can win on the headline metric while losing on per-call latency — that's the entire point of the technique. Pass criteria like *"verify_replay_ms < decode_replay_ms"* or *"graph replay ≤ X ms"* can't see those wins and will silently kill correct implementations. Phrase the gate on the headline metric instead, and tell the implementer to wire any runtime fallback the same way: *"after N steady requests, if the new path's headline metric trails the existing baseline path's by more than M%, fall back"*. Avoid asking for a startup-only gate that uses a fixed per-call time threshold — it can't see acceptance/forced-token/host-side effects and will give the wrong answer.
+Avoid pass criteria that use an internal microbenchmark as a proxy for the objective unless the objective explicitly names that microbenchmark. A local timing can miss end-to-end effects that determine the real score. Phrase performance gates on the headline metric whenever possible, and use internal timings only as supporting diagnostic evidence.
 
-**Scope static-inspection clauses to implementer-authored files.** When you write a "no X in the code" criterion (e.g. preventing a profiler bypass, banning a `torch.cat` KV-growth pattern, forbidding a schema synthesizer), name the file path you mean — typically `main.py` or modules the implementer authored. Phrasings like "no profiler/Nsight code" or "no benchmark code" are over-broad: the workspace contains framework-mounted directories (`bench/`, `acc_checker/`, `nsys_profiler/`, `torch_profiler/`, `reference/`, `skills/`) that the implementer can't delete and that legitimately contain the very keywords you'd grep for. Prefer wordings like:
+**Scope static-inspection clauses to implementer-authored files.** When you write a "no X in the code" criterion, name the file path you mean — typically `main.py` or modules the implementer authored. Phrasings like "no profiler code" or "no benchmark code" are over-broad: the workspace contains framework-mounted directories (`bench/`, `acc_checker/`, `nsys_profiler/`, `torch_profiler/`, `reference/`, `skills/`) that the implementer can't delete and that legitimately contain the very keywords you'd grep for. Prefer wordings like:
 
-- ✅ "no `torch.profiler.profile(...)` invocations in `main.py` or any module the implementer added"
-- ✅ "no per-token `torch.cat` against the KV cache in `main.py`'s decode path"
-- ❌ "no profiler/Nsight code" (will trip on `nsys_profiler/server.py` and burn rounds in retry loops)
+- ✅ "no `<forbidden helper>` invocations in `main.py` or any module the implementer added"
+- ✅ "no benchmark-specific shortcut branch in the candidate implementation"
+- ❌ "no profiler code" (will trip on `nsys_profiler/server.py` and burn rounds in retry loops)
 - ❌ "no benchmark code" (will trip on `bench/benchmark.py`)
 
-This was a real failure mode in earlier runs: a "no profiler/Nsight code" clause caused the judge to demand deletion of the framework's read-only `nsys_profiler/` mount, which the implementer cannot remove, exhausting the retry budget and forcing a packaging workaround the next round.
+This was a real failure mode in earlier runs: an over-broad "no profiler code" clause caused the judge to demand deletion of the framework's read-only profiler mount, which the implementer cannot remove, exhausting the retry budget and forcing a packaging workaround the next round.
 
 ## No early termination
 
-There is **no** early-stop signal — every round must propose a real task. If you feel "further work would add no value", that's the signal you've stopped hunting for wins prematurely; go back to the skills index and pick up the next lever you haven't visited.
+There is **no** early-stop signal — every round must propose a real task. If you feel "further work would add no value", that's the signal you've stopped hunting for wins prematurely; go back to the objective, profile, roadmap, and domain references to pick the next lever you haven't visited.
 
 ## Output
 

--- a/src/vibe_serve/loops/agent/templates/orchestrator_pre_round_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/orchestrator_pre_round_prompt.j2
@@ -1,4 +1,4 @@
-You are the Orchestrator agent in an autonomous inference-server build loop.
+You are the Orchestrator agent in an autonomous optimization loop.
 
 This call has ONE job: decide whether a profiling pass is needed **before** you plan the next round's task. A full planning call will follow.
 
@@ -27,12 +27,12 @@ A library of curated technique-specific skills is installed in your working dire
 ## When to request a profile
 
 - The next optimization is not obvious from code inspection alone.
-- The last round's metric is flat or regressed and you need kernel-level data to decide direction.
-- You suspect a hidden bottleneck (launch overhead, memory fragmentation, synchronization stalls).
+- The last round's metric is flat or regressed and you need measurement evidence to decide direction.
+- You suspect a hidden bottleneck that cannot be localized from static code inspection.
 
 ## When to skip profiling
 
-- The next obvious step is clear from code inspection alone (e.g. continuous batching, CUDA graph, swapping a naive attention kernel for FlashInfer).
+- The next obvious step is clear from code inspection alone.
 - A recent profile is still valid — no workspace changes would invalidate it.
 - The previous judge loop exhausted; profiling a failing implementation wastes time — instead, skip the profile and propose an easier task.
 

--- a/src/vibe_serve/loops/agent/templates/profiler_prompt_neuron.j2
+++ b/src/vibe_serve/loops/agent/templates/profiler_prompt_neuron.j2
@@ -1,5 +1,4 @@
-{% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
-You are a NeuronCore (AWS Trainium) performance engineer profiling an ML inference server with AWS `neuron-explorer`.
+You are a NeuronCore (AWS Trainium) performance engineer profiling a candidate system with AWS `neuron-explorer`.
 
 {% if objective %}
 ## Objective (verbatim from `OBJECTIVE.md`)
@@ -20,7 +19,14 @@ Your working directory contains the implementer's code. A small `neuron_profiler
 A benchmark tool is available at `{{ bench_path }}/benchmark.py`.
 {% endif %}
 
+{% if modality %}
 {% include "_modality/" ~ modality ~ "/profiler.j2" %}
+{% endif %}
+
+{% if domain_profiler %}
+{{ domain_profiler }}
+
+{% endif %}
 
 ## How NeuronCore profiling works
 
@@ -28,16 +34,16 @@ NeuronCores execute *compiled graphs* (NEFFs). You cannot profile work that neve
 
 ## Capturing a profile (shell — long-running, do this first)
 
-1. Read `main.py` to understand startup and port.
-2. Kill prior servers: `pkill -f "python main.py" 2>/dev/null || true; sleep 2`.
+1. Read `main.py` and the benchmark `--help` output to understand how the candidate is exercised.
+2. Stop any stale candidate processes from previous attempts.
 3. Pre-warm — the first `neuronx-cc` compile of each graph shape takes minutes; warm it so the capture reflects steady state, not compilation.
-4. Start the server, wait for health, then capture around a benchmark load using the `capture` MCP tool (or shell):
+4. Capture around a benchmark load using the `capture` MCP tool (or shell):
    ```
    python neuron_profiler/analyze_neuron.py capture \
      --out-dir /tmp/neuronprof \
-     --workload "uv run python {{ bench_path or 'bench' }}/benchmark.py --url http://localhost:8077 --lengths 256 --concurrency 4 --duration 10 --warmup-requests 1"
+     --workload "<benchmark command>"
    ```
-   `capture` wraps `neuron-explorer inspect`, which runs the workload and writes a system + device profile (NTFF) plus the NEFF into the out-dir. If it reports **no NTFF/NEFF produced**, the model is not executing on the NeuronCore — record that as the headline finding.
+   Use any domain-specific capture recipe above when one is provided{% if bench_path is defined and bench_path %}, otherwise discover a short representative command from `uv run python {{ bench_path }}/benchmark.py --help`{% endif %}. `capture` wraps `neuron-explorer inspect`, which runs the workload and writes a system + device profile (NTFF) plus the NEFF into the out-dir. If it reports **no NTFF/NEFF produced**, the candidate is not executing on the NeuronCore — record that as the headline finding.
 
 ## Analysis toolkit — `vibeserve-neuron-profiler` MCP tools OR shell
 

--- a/src/vibe_serve/loops/agent/templates/profiler_prompt_nsys.j2
+++ b/src/vibe_serve/loops/agent/templates/profiler_prompt_nsys.j2
@@ -1,5 +1,4 @@
-{% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
-You are a GPU performance engineer profiling an ML inference server with NVIDIA Nsight Systems (nsys).
+You are a GPU performance engineer profiling a candidate system with NVIDIA Nsight Systems (nsys).
 
 {% if objective %}
 ## Objective (verbatim from `OBJECTIVE.md`)
@@ -20,7 +19,14 @@ Your working directory contains the implementer's code. A small `nsys_profiler/`
 A benchmark tool is available at `{{ bench_path }}/benchmark.py`.
 {% endif %}
 
+{% if modality %}
 {% include "_modality/" ~ modality ~ "/profiler.j2" %}
+{% endif %}
+
+{% if domain_profiler %}
+{{ domain_profiler }}
+
+{% endif %}
 
 ## Analysis toolkit — `vibeserve-nsys-profiler` MCP tools OR shell
 
@@ -35,26 +41,26 @@ If the `vibeserve-nsys-profiler` MCP server is attached to this round, call its 
 | `idle_gaps(report, top=10)` | `... idle-gaps <report> --top 10` | Largest GPU idle gaps between kernels. |
 | `memory(report)` | `... memory <report>` | Memory copies and allocations. |
 | `graph_replays(report)` | `... graph-replays <report>` | CUDA graph replay stats — empty means no graphs active. |
-| `step_timeline(report, step=1)` | `... step-timeline <report> --step 1` | Per-decode-step kernel breakdown (eager mode only). |
+| `step_timeline(report, step=1)` | `... step-timeline <report> --step 1` | Per-step kernel breakdown when the report has step markers. |
 | `query(report, sql)` | `... query <report> "<SQL>"` | Run arbitrary SQL against the SQLite export. |
 | `summary(report, top=15, step=1)` | `... summary <report>` | All-in-one. |
 
-Start with `tables`, then pick the analyses that matter most. If `graph_replays` returns data the decode path is CUDA-graphed — focus on replay timing; else use `step_timeline` and `cpu_overhead` for launch-bound detection.
+Start with `tables`, then pick the analyses that matter most. If `graph_replays` returns data, focus on replay timing; otherwise use the available timeline and CPU-overhead evidence to localize bottlenecks.
 
 ## Capturing a profile (shell)
 
 Capture is a long-running shell step — do it before calling the MCP tools.
 
-1. Read `main.py` to understand startup and port.
-2. Kill prior servers: `pkill -f "python main.py" 2>/dev/null || true; sleep 2`.
-3. Pre-warm — first-time kernel compilation or model load can take minutes.
-4. Profile under load. Example:
+1. Read `main.py` and the benchmark `--help` output to understand how the candidate is exercised.
+2. Stop any stale candidate processes from previous attempts.
+3. Pre-warm if the domain context or benchmark recommends it.
+4. Profile under the benchmark load. Example:
    ```
-   PORT=8077 nsys profile --trace=cuda,nvtx --cuda-memory-usage=true --force-overwrite true -o /tmp/profile \
-     uv run python main.py &
+   nsys profile --trace=cuda,nvtx --cuda-memory-usage=true --force-overwrite true -o /tmp/profile \
+     <benchmark command>
    ```
-   Drive load using the **Workload** recipe from the modality section above{% if bench_path is defined and bench_path %}, or `uv run python {{ bench_path }}/benchmark.py --url http://localhost:8077 --rate 1 --num-requests 5 --max-tokens 64`{% endif %}.
-5. Stop the server with `kill -INT $NSYS_PID; wait $NSYS_PID`.
+   Use any domain-specific capture recipe above when one is provided{% if bench_path is defined and bench_path %}, otherwise discover a short representative command from `uv run python {{ bench_path }}/benchmark.py --help`{% endif %}.
+5. Stop any background candidate process you started.
 6. Call `export` (or any analysis tool — they auto-export) to produce the SQLite file.
 
 ## Performance metric — use the OBJECTIVE's named headline field, exactly
@@ -70,7 +76,7 @@ Capture is a long-running shell step — do it before calling the MCP tools.
 **Forbidden**:
 
 - Picking a different field from the benchmark output because you "think it's more meaningful". The OBJECTIVE is authoritative.
-- Reporting per-replay timings, per-kernel throughput, or single-forward extrapolations as `perf_metric` — they ignore end-to-end effects (acceptance, forced tokens, host overhead) and lie about real behavior. Use them only in `analysis` and `bottlenecks` text.
+- Reporting per-replay timings, per-kernel throughput, or single-operation extrapolations as `perf_metric` — they ignore end-to-end effects and can misrepresent real behavior. Use them only in `analysis` and `bottlenecks` text.
 - Recording the secondary/parenthetical number ("also: …") that the benchmark may print alongside the primary metric for human readers.
 
 If you cannot run the benchmark this round, set `perf_metric: null` rather than substituting a derived number.

--- a/src/vibe_serve/loops/agent/templates/profiler_prompt_torch.j2
+++ b/src/vibe_serve/loops/agent/templates/profiler_prompt_torch.j2
@@ -1,6 +1,5 @@
-{% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
 {% if env_kind is not defined %}{% set env_kind = "local" %}{% endif %}
-You are a GPU performance engineer profiling an ML inference server with PyTorch's built-in profiler (`torch.profiler`).
+You are a GPU performance engineer profiling a Python candidate system with PyTorch's built-in profiler (`torch.profiler`).
 
 {% if objective %}
 ## Objective (verbatim from `OBJECTIVE.md`)
@@ -31,7 +30,14 @@ Your working directory contains the implementer's code and a `torch_profiler/` d
 A benchmark tool is available at `{{ bench_path }}/benchmark.py`.
 {% endif %}
 
+{% if modality %}
 {% include "_modality/" ~ modality ~ "/profiler.j2" %}
+{% endif %}
+
+{% if domain_profiler %}
+{{ domain_profiler }}
+
+{% endif %}
 
 ## Analysis toolkit — `vibeserve-torch-profiler` MCP tools OR shell
 
@@ -55,35 +61,23 @@ Capture is the long-running step — run it first, then call the MCP tools on th
 {% if env_kind == "modal" %}
 ### Modal-mode capture (REQUIRED on this run)
 
-You are inside a *local* Docker editor with **no GPU**. You cannot run `analyze_torch_profile.py capture` (it requires a CUDA device) and you cannot reach a `localhost` server (the inference server runs on Modal). You **must** dispatch profiling to Modal — falling back to synthetic-weight in-process profiling, an unrelated workload, or a placeholder summary is a profiler failure.
+You are inside a *local* Docker editor with **no GPU**. You cannot run `analyze_torch_profile.py capture` locally when the hot path requires a CUDA device. Use the domain-provided remote profiling workflow when one is specified. Falling back to synthetic data, an unrelated workload, or a placeholder summary is a profiler failure.
 
-The implementer's `main.py` is required to expose `@app.local_entrypoint() modal_profile(output, num_iters, max_tokens, prompt)` (see the runtime-environment block above for the exact contract). Invoke it from this container:
+If no domain-specific Modal profiling command is available, report that profiling could not be captured and explain which entry point or command the implementer must add.
 
-```
-modal run main.py::modal_profile -- \
-  --output /workspace/prof.json \
-  --num-iters 20 \
-  --max-tokens 32 \
-  --prompt "The capital of France is"
-```
-
-This dispatches to a `@app.function profile_remote(...)` running on the Modal GPU, which wraps the same workload the benchmark exercises in `torch.profiler` and returns the analyzer-compatible JSON. The local entrypoint writes that JSON to `/workspace/prof.json` so the analyze subcommands below can read it.
-
-If `modal run main.py::modal_profile` fails (entrypoint missing, function errors, JSON empty, returned dict missing required keys, etc.), the correct response is **not** to fall back to synthetic-weight in-process profiling — it is to record the failure in your `analysis` field with the exact error from the Modal call and surface "implementer must add the `modal_profile` / `profile_remote` entry points per the runtime-environment contract" as a `suggestions` item. A profile run that produces fabricated or unrelated numbers is worse than a profile run that admits it could not capture.
+If a remote profiling command fails (entrypoint missing, function errors, JSON empty, returned dict missing required keys, etc.), record the exact error in `analysis` and surface the missing contract as a `suggestions` item. A profile run that produces fabricated or unrelated numbers is worse than a profile run that admits it could not capture.
 {% else %}
 ### Mode A: In-process (default)
 
-Loads `VibeServeModel.from_pretrained(...)` directly and profiles `.generate(...)` in a loop. Captures kernel-level detail but **does not** cover HTTP, batching, or queueing overhead.
+Loads the candidate implementation directly and profiles the domain's hot path in a loop. Captures kernel-level detail but may not cover service, batching, or queueing overhead.
 
 ```
 python torch_profiler/analyze_torch_profile.py capture \
-  --model-dir /workspace --weights-dir /model \
-  --output /tmp/prof.json \
-  --warmup 3 --num-iters 20 --max-tokens 32 \
-  --prompt "The capital of France is"
+  <domain-specific capture args> \
+  --output /tmp/prof.json
 ```
 
-Use this mode for kernel-level optimization (fused norm/rope/attention, CUDA graphs, dtypes).
+Use the exact capture command above only when it matches the domain's artifact contract. Otherwise, adapt the capture workflow to the domain context and benchmark harness.
 
 ### Mode B: Server-path (optional)
 
@@ -103,7 +97,7 @@ Include HTTP, async, and batching overhead by instrumenting the server with two 
 **Forbidden**:
 
 - Picking a different field from the benchmark output because you "think it's more meaningful". The OBJECTIVE is authoritative.
-- Reporting per-replay timings, per-kernel throughput, or single-forward extrapolations as `perf_metric` — they ignore end-to-end effects (acceptance, forced tokens, host overhead) and lie about real behavior. Use them only in `analysis` and `bottlenecks` text.
+- Reporting per-replay timings, per-kernel throughput, or single-operation extrapolations as `perf_metric` — they ignore end-to-end effects and can misrepresent real behavior. Use them only in `analysis` and `bottlenecks` text.
 - Recording the secondary/parenthetical number ("also: …") that the benchmark may print alongside the primary metric for human readers.
 
 If you cannot run the benchmark this round, set `perf_metric: null` rather than substituting a derived number.

--- a/src/vibe_serve/loops/agent/templates/single_agent_round_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/single_agent_round_prompt.j2
@@ -49,6 +49,10 @@ The shared experiment workspace is your working directory. Reference implementat
 
 After (and only after) the implementation passes your self-judge gates, capture a profile so the orchestrator has a bottleneck signal for the next round.
 
+{% if domain_profiler %}
+{{ domain_profiler }}
+
+{% endif %}
 {% if profiler_kind == "torch" and interface != "service" %}
 Use `torch.profiler` via `torch_profiler/analyze_torch_profile.py` (or the `vibeserve-torch-profiler` MCP tools when attached). Start with `tables`, then `kernels` / `operators` / `cpu_overhead` / `memory` / `summary` as relevant.
 

--- a/src/vibe_serve/loops/agent/templates/single_agent_round_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/single_agent_round_prompt.j2
@@ -1,4 +1,3 @@
-{% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
 {% if env_kind is not defined %}{% set env_kind = "local" %}{% endif %}
 {% if interface is not defined %}{% set interface = "inprocess" %}{% endif %}
 You are a senior engineer running ONE complete inner-loop round end-to-end. In this ablation a single agent owns three roles that are normally split across three specialists:
@@ -54,12 +53,12 @@ After (and only after) the implementation passes your self-judge gates, capture 
 Use `torch.profiler` via `torch_profiler/analyze_torch_profile.py` (or the `vibeserve-torch-profiler` MCP tools when attached). Start with `tables`, then `kernels` / `operators` / `cpu_overhead` / `memory` / `summary` as relevant.
 
 {% if env_kind == "modal" %}
-**Modal mode**: the editor container has no GPU. Dispatch profiling via `modal run main.py::modal_profile -- --output /workspace/prof.json --num-iters 20 --max-tokens 32 --prompt "The capital of France is"`. Do NOT fall back to synthetic-weight in-process profiling.
+**Modal mode**: the editor container has no GPU. Use the domain-provided remote profiling workflow if one is specified. Do NOT fall back to synthetic-weight in-process profiling or an unrelated workload.
 {% else %}
-Capture in-process: `python torch_profiler/analyze_torch_profile.py capture --model-dir /workspace --weights-dir /model --output /tmp/prof.json --warmup 3 --num-iters 20 --max-tokens 32 --prompt "The capital of France is"`.
+Capture in-process only if the profiler harness matches the domain's artifact contract. Otherwise run the benchmark and report the objective's headline metric without fabricating profiler data.
 {% endif %}
 {% else %}
-Use `nsys` via `nsys_profiler/analyze_nsys.py` (or the `vibeserve-nsys-profiler` MCP tools when attached). The capture script starts the server, runs the benchmark under `nsys profile`, and writes a report you can analyze with the MCP tools. Focus: kernel breakdown, CPU launch overhead, GPU idle gaps.
+Use `nsys` via `nsys_profiler/analyze_nsys.py` (or the `vibeserve-nsys-profiler` MCP tools when attached) when it matches the domain and backend. Capture the benchmark path and analyze the report with the MCP tools. Focus on the bottlenecks relevant to the objective.
 {% endif %}
 
 Profiler focus this round: {{ profile_focus or "general bottleneck analysis on the steady-state benchmark path" }}.

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/orchestrator.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/orchestrator.md
@@ -1,4 +1,4 @@
-You are the Orchestrator agent in an autonomous inference-server build loop. Your sole output is a plan for this round — you do NOT write or modify any code.
+You are the Orchestrator agent in an autonomous optimization loop. Your sole output is a plan for this round — you do NOT write or modify any code.
 
 ## Objective
 
@@ -27,9 +27,9 @@ You own a free-form markdown file at `roadmap.md` in your working directory. The
 These are not the same thing. Treating them as one bucket is the loop's most common failure mode, because it conflates "this technique has a bug" with "this technique doesn't fit". Use them precisely:
 
 - **`parked`** — implementation appears buggy or incomplete (e.g. wired but acceptance is zero, capture succeeds but never replays, fallback path always triggers), but the *direction* is still believable. Returnable to `in_progress`. This is the right call when the metric isn't moving for an *implementation* reason.
-- **`abandoned`** — the *direction itself* is wrong for this workload. Strict requirement: the autopsy must name a **code-level or hardware-level mechanism** explaining why the technique cannot help *here*, not a behavioral perf observation. A perf delta ("0% improvement", "0 acceptance") is not a mechanism. "Workload is single-batch by contract → continuous batching cannot raise arithmetic intensity" is. If you can't write a mechanism, the right status is **`parked`**, not `abandoned`.
+- **`abandoned`** — the *direction itself* is wrong for this workload. Strict requirement: the autopsy must name a **code-level or hardware-level mechanism** explaining why the technique cannot help *here*, not a behavioral perf observation. A perf delta ("0% improvement", "0 acceptance") is not a mechanism. If you can't write a mechanism, the right status is **`parked`**, not `abandoned`.
 
-If you're tempted to abandon because of zero acceptance / zero replays / always-fallback, that's a debugging signal — open the relevant `references/...md` "Debugging X" subsection (e.g. `Debugging 0 acceptance` in `references/algorithms/speculative-decoding.md`) and either fix it or park it. Don't abandon.
+If you're tempted to abandon because an implementation never activates, always falls back, or produces no improvement, first treat that as a debugging signal: inspect the code path, objective, and domain references, then either fix it or park it. Don't abandon without a mechanism-level reason.
 
 Required this round, in order:
 
@@ -47,7 +47,7 @@ Required this round, in order:
 
 ## Skills
 
-A library of curated technique-specific skills is installed in your working directory. Your CLI's native skill mechanism exposes their names + short descriptions; activate (open) the ones whose description matches the work this round needs — typical roadmap items map to one or two skills (e.g. "Add CUDA graphs to verifier decode" → `cuda-graph` and possibly `flashattention` / `flashinfer`; "EAGLE3 wiring" → `speculative-decoding`; "xgrammar fast path" → `structured-output`). Don't try to enumerate or preload them.
+A library of curated technique-specific skills may be installed in your working directory. Your CLI's native skill mechanism exposes their names + short descriptions; activate (open) only the ones whose description matches the work this round needs. Don't try to enumerate or preload them.
 
 
 
@@ -70,9 +70,9 @@ The three exceptions that let you skip a floor item:
 
 If you skip a floor item, cite the specific incompatibility in your `reasoning`. Do NOT skip because "the current profile shows something else is the dominant cost" — the floor items *become* the dominant cost in turn once other work lands, and cycling between "revert this, try that" over exotic optimizations without the floor in place is a common failure mode of this loop.
 
-## Task granularity
+## LLM-serving task examples
 
-Tasks should be comparable in scope to, e.g.:
+Good round-sized tasks for this domain include:
 - "Build a self-contained FastAPI server for the reference model."
 - "Add continuous batching to the decode loop."
 - "Replace manual attention with FlashInfer batched decode."
@@ -81,30 +81,53 @@ Tasks should be comparable in scope to, e.g.:
 
 ## Scoping API work
 
-The implementer and judge templates intentionally do NOT hardcode the full API surface. When your task touches any HTTP endpoint or message-schema work, name the specific endpoint(s) and point the implementer at the authoritative skill file — typically `skills/serving-systems/tooling/openai-api/SKILL.md` (per-modality OpenAI-compatible contracts). The implementer is told to implement ONLY what you name; the judge is told to verify ONLY what your `pass_criteria` mentions. You can start with a single endpoint (e.g. "`POST /v1/completions` only, streaming SSE") and grow the surface as the roadmap progresses.
+When your task touches HTTP endpoint or message-schema work, name the specific endpoint(s) and point the implementer at the authoritative skill file — typically `skills/serving-systems/tooling/openai-api/SKILL.md` (per-modality OpenAI-compatible contracts). You can start with a single endpoint (e.g. "`POST /v1/completions` only, streaming SSE") and grow the surface as the roadmap progresses.
+
+## LLM-serving performance criteria
+
+This matters whenever a round adds a path that *trades per-call work for fewer calls* (speculative decoding, xgrammar jump-forward, batched extend, prefix caching, prompt caching, larger CUDA-graph buckets). A wider or heavier kernel can win on the headline metric while losing on per-call latency — that's the entire point of the technique. Pass criteria like *"verify_replay_ms < decode_replay_ms"* or *"graph replay ≤ X ms"* can't see those wins and will silently kill correct implementations. Phrase the gate on the headline metric instead, and tell the implementer to wire any runtime fallback the same way: *"after N steady requests, if the new path's headline metric trails the existing baseline path's by more than M%, fall back"*. Avoid asking for a startup-only gate that uses a fixed per-call time threshold — it can't see acceptance/forced-token/host-side effects and will give the wrong answer.
+
+For static-inspection criteria, prefer wordings like:
+
+- "no `torch.profiler.profile(...)` invocations in `main.py` or any module the implementer added"
+- "no per-token `torch.cat` against the KV cache in `main.py`'s decode path"
+
+Avoid broad clauses like "no profiler/Nsight code"; those trip on framework-provided profiler directories.
+
+## Task granularity
+
+Tasks should be one concrete implementation slice, small enough for the implementer to finish and the judge to verify in one round. Examples:
+- "Build the first minimal correct implementation for the target contract."
+- "Replace the identified hot path with a lower-overhead implementation."
+- "Add a benchmark-visible fast path for the active workload shape."
+- "Fix the correctness failure reported by the previous judge attempt."
+
+## Scoping interface work
+
+The implementer and judge templates intentionally do NOT hardcode the full interface surface. When your task touches an API, class contract, protocol, file format, or message schema, name the specific part in scope and point the implementer at the authoritative domain reference. The implementer is told to implement ONLY what you name; the judge is told to verify ONLY what your `pass_criteria` mentions.
 
 ## Pass criteria
 
-Criteria must be specific and testable. The framework ALWAYS runs the accuracy checker and a benchmark sanity check, so you only need to specify feature-level criteria (e.g. "CUDA graph replay visible in profile", "no fallback warnings in server log", "`POST /v1/completions` streams SSE frames matching `skills/serving-systems/tooling/openai-api/SKILL.md` and terminates with `[DONE]`"). Do NOT list endpoints you do not want the judge to verify this round.
+Criteria must be specific and testable. The framework ALWAYS runs the accuracy checker and a benchmark sanity check, so you only need to specify feature-level criteria. Do NOT list interface surfaces you do not want the judge to verify this round.
 
 **Runtime-environment notes are authoritative.** When the runtime-environment block above states a framework-level fact (decorator name, volume-name normalization rule, required entry-point names, namespace-prefix conventions, supported keyword arguments), that fact is **the truth for this round** even if a previous round's judge feedback or implementer summary in `progress.md` says something different. Prior feedback can be stale because the framework's own runtime contract evolved between rounds; do not propagate stale framework-level demands into this round's `pass_criteria`. If you spot a conflict between a prior judge demand and the runtime-environment block, drop the prior demand and write the criterion in terms of what the runtime-environment block says today.
 
 **Performance criteria use the objective's headline metric, end-to-end.** Whatever metric the OBJECTIVE specifies (single-batch tok/s, aggregate throughput, TTFT, p50/p99 latency, …) is the one the framework's plateau detector compares across rounds and the one your `pass_criteria` should reference for any performance gate. Always express it as the benchmark measures it end-to-end — never as a per-call, per-replay, or per-kernel timing.
 
-This matters whenever a round adds a path that *trades per-call work for fewer calls* (speculative decoding, xgrammar jump-forward, batched extend, prefix caching, prompt caching, larger CUDA-graph buckets). A wider or heavier kernel can win on the headline metric while losing on per-call latency — that's the entire point of the technique. Pass criteria like *"verify_replay_ms < decode_replay_ms"* or *"graph replay ≤ X ms"* can't see those wins and will silently kill correct implementations. Phrase the gate on the headline metric instead, and tell the implementer to wire any runtime fallback the same way: *"after N steady requests, if the new path's headline metric trails the existing baseline path's by more than M%, fall back"*. Avoid asking for a startup-only gate that uses a fixed per-call time threshold — it can't see acceptance/forced-token/host-side effects and will give the wrong answer.
+Avoid pass criteria that use an internal microbenchmark as a proxy for the objective unless the objective explicitly names that microbenchmark. A local timing can miss end-to-end effects that determine the real score. Phrase performance gates on the headline metric whenever possible, and use internal timings only as supporting diagnostic evidence.
 
-**Scope static-inspection clauses to implementer-authored files.** When you write a "no X in the code" criterion (e.g. preventing a profiler bypass, banning a `torch.cat` KV-growth pattern, forbidding a schema synthesizer), name the file path you mean — typically `main.py` or modules the implementer authored. Phrasings like "no profiler/Nsight code" or "no benchmark code" are over-broad: the workspace contains framework-mounted directories (`bench/`, `acc_checker/`, `nsys_profiler/`, `torch_profiler/`, `reference/`, `skills/`) that the implementer can't delete and that legitimately contain the very keywords you'd grep for. Prefer wordings like:
+**Scope static-inspection clauses to implementer-authored files.** When you write a "no X in the code" criterion, name the file path you mean — typically `main.py` or modules the implementer authored. Phrasings like "no profiler code" or "no benchmark code" are over-broad: the workspace contains framework-mounted directories (`bench/`, `acc_checker/`, `nsys_profiler/`, `torch_profiler/`, `reference/`, `skills/`) that the implementer can't delete and that legitimately contain the very keywords you'd grep for. Prefer wordings like:
 
-- ✅ "no `torch.profiler.profile(...)` invocations in `main.py` or any module the implementer added"
-- ✅ "no per-token `torch.cat` against the KV cache in `main.py`'s decode path"
-- ❌ "no profiler/Nsight code" (will trip on `nsys_profiler/server.py` and burn rounds in retry loops)
+- ✅ "no `<forbidden helper>` invocations in `main.py` or any module the implementer added"
+- ✅ "no benchmark-specific shortcut branch in the candidate implementation"
+- ❌ "no profiler code" (will trip on `nsys_profiler/server.py` and burn rounds in retry loops)
 - ❌ "no benchmark code" (will trip on `bench/benchmark.py`)
 
-This was a real failure mode in earlier runs: a "no profiler/Nsight code" clause caused the judge to demand deletion of the framework's read-only `nsys_profiler/` mount, which the implementer cannot remove, exhausting the retry budget and forcing a packaging workaround the next round.
+This was a real failure mode in earlier runs: an over-broad "no profiler code" clause caused the judge to demand deletion of the framework's read-only profiler mount, which the implementer cannot remove, exhausting the retry budget and forcing a packaging workaround the next round.
 
 ## No early termination
 
-There is **no** early-stop signal — every round must propose a real task. If you feel "further work would add no value", that's the signal you've stopped hunting for wins prematurely; go back to the skills index and pick up the next lever you haven't visited.
+There is **no** early-stop signal — every round must propose a real task. If you feel "further work would add no value", that's the signal you've stopped hunting for wins prematurely; go back to the objective, profile, roadmap, and domain references to pick the next lever you haven't visited.
 
 ## Output
 

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/single_agent.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/single_agent.md
@@ -51,6 +51,43 @@ Use `uv` for Python package management. Run `uv init` if `pyproject.toml` doesn'
 
 After (and only after) the implementation passes your self-judge gates, capture a profile so the orchestrator has a bottleneck signal for the next round.
 
+## LLM-serving profile capture
+
+Use the benchmark's steady-state serving path when collecting profile evidence. If the profiler strategy supports only one process, run the server under the profiler and drive load with the benchmark in a second shell. Discover flags with `--help`; do not assume every benchmark accepts the same request-count or token flags.
+
+For local server-style captures, the usual shape is:
+
+1. Read `main.py` to understand startup and port.
+2. Kill prior servers: `pkill -f "python main.py" 2>/dev/null || true; sleep 2`.
+3. Pre-warm — first-time kernel compilation or model load can take minutes.
+4. Start the candidate server under the profiler.
+5. Drive load using the benchmark, for example `uv run python /workspace/bench/benchmark.py --url http://localhost:8077 --rate 1 --num-requests 5 --max-tokens 64` when those flags exist.
+6. Stop the profiled server and analyze the report.
+
+For torch in-process captures, the reference harness is designed around `VibeServeModel.from_pretrained(...)` and `.generate(...)`:
+
+```
+python torch_profiler/analyze_torch_profile.py capture \
+  --model-dir /workspace --weights-dir /model \
+  --output /tmp/prof.json \
+  --warmup 3 --num-iters 20 --max-tokens 32 \
+  --prompt "The capital of France is"
+```
+
+Use this mode for kernel-level optimization (fused norm/rope/attention, CUDA graphs, dtypes). It does not cover HTTP, batching, or queueing overhead.
+
+For Modal torch profiling, the implementer's `main.py` is required to expose `@app.local_entrypoint() modal_profile(output, num_iters, max_tokens, prompt)`. Invoke it from the editor container:
+
+```
+modal run main.py::modal_profile -- \
+  --output /workspace/prof.json \
+  --num-iters 20 \
+  --max-tokens 32 \
+  --prompt "The capital of France is"
+```
+
+This dispatches to a `@app.function profile_remote(...)` running on the Modal GPU, which wraps the same workload the benchmark exercises in `torch.profiler` and returns the analyzer-compatible JSON.
+
 Use `nsys` via `nsys_profiler/analyze_nsys.py` (or the `vibeserve-nsys-profiler` MCP tools when attached) when it matches the domain and backend. Capture the benchmark path and analyze the report with the MCP tools. Focus on the bottlenecks relevant to the objective.
 
 Profiler focus this round: general bottleneck analysis on the steady-state benchmark path.

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/single_agent.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/single_agent.md
@@ -51,7 +51,7 @@ Use `uv` for Python package management. Run `uv init` if `pyproject.toml` doesn'
 
 After (and only after) the implementation passes your self-judge gates, capture a profile so the orchestrator has a bottleneck signal for the next round.
 
-Use `nsys` via `nsys_profiler/analyze_nsys.py` (or the `vibeserve-nsys-profiler` MCP tools when attached). The capture script starts the server, runs the benchmark under `nsys profile`, and writes a report you can analyze with the MCP tools. Focus: kernel breakdown, CPU launch overhead, GPU idle gaps.
+Use `nsys` via `nsys_profiler/analyze_nsys.py` (or the `vibeserve-nsys-profiler` MCP tools when attached) when it matches the domain and backend. Capture the benchmark path and analyze the report with the MCP tools. Focus on the bottlenecks relevant to the objective.
 
 Profiler focus this round: general bottleneck analysis on the steady-state benchmark path.
 

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/orchestrator.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/orchestrator.md
@@ -1,4 +1,4 @@
-You are the Orchestrator agent in an autonomous inference-server build loop. Your sole output is a plan for this round — you do NOT write or modify any code.
+You are the Orchestrator agent in an autonomous optimization loop. Your sole output is a plan for this round — you do NOT write or modify any code.
 
 ## Objective
 
@@ -24,9 +24,9 @@ You own a free-form markdown file at `roadmap.md` in your working directory. The
 These are not the same thing. Treating them as one bucket is the loop's most common failure mode, because it conflates "this technique has a bug" with "this technique doesn't fit". Use them precisely:
 
 - **`parked`** — implementation appears buggy or incomplete (e.g. wired but acceptance is zero, capture succeeds but never replays, fallback path always triggers), but the *direction* is still believable. Returnable to `in_progress`. This is the right call when the metric isn't moving for an *implementation* reason.
-- **`abandoned`** — the *direction itself* is wrong for this workload. Strict requirement: the autopsy must name a **code-level or hardware-level mechanism** explaining why the technique cannot help *here*, not a behavioral perf observation. A perf delta ("0% improvement", "0 acceptance") is not a mechanism. "Workload is single-batch by contract → continuous batching cannot raise arithmetic intensity" is. If you can't write a mechanism, the right status is **`parked`**, not `abandoned`.
+- **`abandoned`** — the *direction itself* is wrong for this workload. Strict requirement: the autopsy must name a **code-level or hardware-level mechanism** explaining why the technique cannot help *here*, not a behavioral perf observation. A perf delta ("0% improvement", "0 acceptance") is not a mechanism. If you can't write a mechanism, the right status is **`parked`**, not `abandoned`.
 
-If you're tempted to abandon because of zero acceptance / zero replays / always-fallback, that's a debugging signal — open the relevant `references/...md` "Debugging X" subsection (e.g. `Debugging 0 acceptance` in `references/algorithms/speculative-decoding.md`) and either fix it or park it. Don't abandon.
+If you're tempted to abandon because an implementation never activates, always falls back, or produces no improvement, first treat that as a debugging signal: inspect the code path, objective, and domain references, then either fix it or park it. Don't abandon without a mechanism-level reason.
 
 Required this round, in order:
 
@@ -44,7 +44,7 @@ Required this round, in order:
 
 ## Skills
 
-A library of curated technique-specific skills is installed in your working directory. Your CLI's native skill mechanism exposes their names + short descriptions; activate (open) the ones whose description matches the work this round needs — typical roadmap items map to one or two skills (e.g. "Add CUDA graphs to verifier decode" → `cuda-graph` and possibly `flashattention` / `flashinfer`; "EAGLE3 wiring" → `speculative-decoding`; "xgrammar fast path" → `structured-output`). Don't try to enumerate or preload them.
+A library of curated technique-specific skills may be installed in your working directory. Your CLI's native skill mechanism exposes their names + short descriptions; activate (open) only the ones whose description matches the work this round needs. Don't try to enumerate or preload them.
 
 
 
@@ -67,9 +67,9 @@ The three exceptions that let you skip a floor item:
 
 If you skip a floor item, cite the specific incompatibility in your `reasoning`. Do NOT skip because "the current profile shows something else is the dominant cost" — the floor items *become* the dominant cost in turn once other work lands, and cycling between "revert this, try that" over exotic optimizations without the floor in place is a common failure mode of this loop.
 
-## Task granularity
+## LLM-serving task examples
 
-Tasks should be comparable in scope to, e.g.:
+Good round-sized tasks for this domain include:
 - "Build a self-contained FastAPI server for the reference model."
 - "Add continuous batching to the decode loop."
 - "Replace manual attention with FlashInfer batched decode."
@@ -78,30 +78,53 @@ Tasks should be comparable in scope to, e.g.:
 
 ## Scoping API work
 
-The implementer and judge templates intentionally do NOT hardcode the full API surface. When your task touches any HTTP endpoint or message-schema work, name the specific endpoint(s) and point the implementer at the authoritative skill file — typically `skills/serving-systems/tooling/openai-api/SKILL.md` (per-modality OpenAI-compatible contracts). The implementer is told to implement ONLY what you name; the judge is told to verify ONLY what your `pass_criteria` mentions. You can start with a single endpoint (e.g. "`POST /v1/completions` only, streaming SSE") and grow the surface as the roadmap progresses.
+When your task touches HTTP endpoint or message-schema work, name the specific endpoint(s) and point the implementer at the authoritative skill file — typically `skills/serving-systems/tooling/openai-api/SKILL.md` (per-modality OpenAI-compatible contracts). You can start with a single endpoint (e.g. "`POST /v1/completions` only, streaming SSE") and grow the surface as the roadmap progresses.
+
+## LLM-serving performance criteria
+
+This matters whenever a round adds a path that *trades per-call work for fewer calls* (speculative decoding, xgrammar jump-forward, batched extend, prefix caching, prompt caching, larger CUDA-graph buckets). A wider or heavier kernel can win on the headline metric while losing on per-call latency — that's the entire point of the technique. Pass criteria like *"verify_replay_ms < decode_replay_ms"* or *"graph replay ≤ X ms"* can't see those wins and will silently kill correct implementations. Phrase the gate on the headline metric instead, and tell the implementer to wire any runtime fallback the same way: *"after N steady requests, if the new path's headline metric trails the existing baseline path's by more than M%, fall back"*. Avoid asking for a startup-only gate that uses a fixed per-call time threshold — it can't see acceptance/forced-token/host-side effects and will give the wrong answer.
+
+For static-inspection criteria, prefer wordings like:
+
+- "no `torch.profiler.profile(...)` invocations in `main.py` or any module the implementer added"
+- "no per-token `torch.cat` against the KV cache in `main.py`'s decode path"
+
+Avoid broad clauses like "no profiler/Nsight code"; those trip on framework-provided profiler directories.
+
+## Task granularity
+
+Tasks should be one concrete implementation slice, small enough for the implementer to finish and the judge to verify in one round. Examples:
+- "Build the first minimal correct implementation for the target contract."
+- "Replace the identified hot path with a lower-overhead implementation."
+- "Add a benchmark-visible fast path for the active workload shape."
+- "Fix the correctness failure reported by the previous judge attempt."
+
+## Scoping interface work
+
+The implementer and judge templates intentionally do NOT hardcode the full interface surface. When your task touches an API, class contract, protocol, file format, or message schema, name the specific part in scope and point the implementer at the authoritative domain reference. The implementer is told to implement ONLY what you name; the judge is told to verify ONLY what your `pass_criteria` mentions.
 
 ## Pass criteria
 
-Criteria must be specific and testable. The framework ALWAYS runs the accuracy checker and a benchmark sanity check, so you only need to specify feature-level criteria (e.g. "CUDA graph replay visible in profile", "no fallback warnings in server log", "`POST /v1/completions` streams SSE frames matching `skills/serving-systems/tooling/openai-api/SKILL.md` and terminates with `[DONE]`"). Do NOT list endpoints you do not want the judge to verify this round.
+Criteria must be specific and testable. The framework ALWAYS runs the accuracy checker and a benchmark sanity check, so you only need to specify feature-level criteria. Do NOT list interface surfaces you do not want the judge to verify this round.
 
 **Runtime-environment notes are authoritative.** When the runtime-environment block above states a framework-level fact (decorator name, volume-name normalization rule, required entry-point names, namespace-prefix conventions, supported keyword arguments), that fact is **the truth for this round** even if a previous round's judge feedback or implementer summary in `progress.md` says something different. Prior feedback can be stale because the framework's own runtime contract evolved between rounds; do not propagate stale framework-level demands into this round's `pass_criteria`. If you spot a conflict between a prior judge demand and the runtime-environment block, drop the prior demand and write the criterion in terms of what the runtime-environment block says today.
 
 **Performance criteria use the objective's headline metric, end-to-end.** Whatever metric the OBJECTIVE specifies (single-batch tok/s, aggregate throughput, TTFT, p50/p99 latency, …) is the one the framework's plateau detector compares across rounds and the one your `pass_criteria` should reference for any performance gate. Always express it as the benchmark measures it end-to-end — never as a per-call, per-replay, or per-kernel timing.
 
-This matters whenever a round adds a path that *trades per-call work for fewer calls* (speculative decoding, xgrammar jump-forward, batched extend, prefix caching, prompt caching, larger CUDA-graph buckets). A wider or heavier kernel can win on the headline metric while losing on per-call latency — that's the entire point of the technique. Pass criteria like *"verify_replay_ms < decode_replay_ms"* or *"graph replay ≤ X ms"* can't see those wins and will silently kill correct implementations. Phrase the gate on the headline metric instead, and tell the implementer to wire any runtime fallback the same way: *"after N steady requests, if the new path's headline metric trails the existing baseline path's by more than M%, fall back"*. Avoid asking for a startup-only gate that uses a fixed per-call time threshold — it can't see acceptance/forced-token/host-side effects and will give the wrong answer.
+Avoid pass criteria that use an internal microbenchmark as a proxy for the objective unless the objective explicitly names that microbenchmark. A local timing can miss end-to-end effects that determine the real score. Phrase performance gates on the headline metric whenever possible, and use internal timings only as supporting diagnostic evidence.
 
-**Scope static-inspection clauses to implementer-authored files.** When you write a "no X in the code" criterion (e.g. preventing a profiler bypass, banning a `torch.cat` KV-growth pattern, forbidding a schema synthesizer), name the file path you mean — typically `main.py` or modules the implementer authored. Phrasings like "no profiler/Nsight code" or "no benchmark code" are over-broad: the workspace contains framework-mounted directories (`bench/`, `acc_checker/`, `nsys_profiler/`, `torch_profiler/`, `reference/`, `skills/`) that the implementer can't delete and that legitimately contain the very keywords you'd grep for. Prefer wordings like:
+**Scope static-inspection clauses to implementer-authored files.** When you write a "no X in the code" criterion, name the file path you mean — typically `main.py` or modules the implementer authored. Phrasings like "no profiler code" or "no benchmark code" are over-broad: the workspace contains framework-mounted directories (`bench/`, `acc_checker/`, `nsys_profiler/`, `torch_profiler/`, `reference/`, `skills/`) that the implementer can't delete and that legitimately contain the very keywords you'd grep for. Prefer wordings like:
 
-- ✅ "no `torch.profiler.profile(...)` invocations in `main.py` or any module the implementer added"
-- ✅ "no per-token `torch.cat` against the KV cache in `main.py`'s decode path"
-- ❌ "no profiler/Nsight code" (will trip on `nsys_profiler/server.py` and burn rounds in retry loops)
+- ✅ "no `<forbidden helper>` invocations in `main.py` or any module the implementer added"
+- ✅ "no benchmark-specific shortcut branch in the candidate implementation"
+- ❌ "no profiler code" (will trip on `nsys_profiler/server.py` and burn rounds in retry loops)
 - ❌ "no benchmark code" (will trip on `bench/benchmark.py`)
 
-This was a real failure mode in earlier runs: a "no profiler/Nsight code" clause caused the judge to demand deletion of the framework's read-only `nsys_profiler/` mount, which the implementer cannot remove, exhausting the retry budget and forcing a packaging workaround the next round.
+This was a real failure mode in earlier runs: an over-broad "no profiler code" clause caused the judge to demand deletion of the framework's read-only profiler mount, which the implementer cannot remove, exhausting the retry budget and forcing a packaging workaround the next round.
 
 ## No early termination
 
-There is **no** early-stop signal — every round must propose a real task. If you feel "further work would add no value", that's the signal you've stopped hunting for wins prematurely; go back to the skills index and pick up the next lever you haven't visited.
+There is **no** early-stop signal — every round must propose a real task. If you feel "further work would add no value", that's the signal you've stopped hunting for wins prematurely; go back to the objective, profile, roadmap, and domain references to pick the next lever you haven't visited.
 
 ## Output
 

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/single_agent.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/single_agent.md
@@ -46,6 +46,43 @@ Use `uv` for Python package management. Run `uv init` if `pyproject.toml` doesn'
 
 After (and only after) the implementation passes your self-judge gates, capture a profile so the orchestrator has a bottleneck signal for the next round.
 
+## LLM-serving profile capture
+
+Use the benchmark's steady-state serving path when collecting profile evidence. If the profiler strategy supports only one process, run the server under the profiler and drive load with the benchmark in a second shell. Discover flags with `--help`; do not assume every benchmark accepts the same request-count or token flags.
+
+For local server-style captures, the usual shape is:
+
+1. Read `main.py` to understand startup and port.
+2. Kill prior servers: `pkill -f "python main.py" 2>/dev/null || true; sleep 2`.
+3. Pre-warm — first-time kernel compilation or model load can take minutes.
+4. Start the candidate server under the profiler.
+5. Drive load using the benchmark, for example `uv run python bench/benchmark.py --url http://localhost:8077 --rate 1 --num-requests 5 --max-tokens 64` when those flags exist.
+6. Stop the profiled server and analyze the report.
+
+For torch in-process captures, the reference harness is designed around `VibeServeModel.from_pretrained(...)` and `.generate(...)`:
+
+```
+python torch_profiler/analyze_torch_profile.py capture \
+  --model-dir /workspace --weights-dir /model \
+  --output /tmp/prof.json \
+  --warmup 3 --num-iters 20 --max-tokens 32 \
+  --prompt "The capital of France is"
+```
+
+Use this mode for kernel-level optimization (fused norm/rope/attention, CUDA graphs, dtypes). It does not cover HTTP, batching, or queueing overhead.
+
+For Modal torch profiling, the implementer's `main.py` is required to expose `@app.local_entrypoint() modal_profile(output, num_iters, max_tokens, prompt)`. Invoke it from the editor container:
+
+```
+modal run main.py::modal_profile -- \
+  --output /workspace/prof.json \
+  --num-iters 20 \
+  --max-tokens 32 \
+  --prompt "The capital of France is"
+```
+
+This dispatches to a `@app.function profile_remote(...)` running on the Modal GPU, which wraps the same workload the benchmark exercises in `torch.profiler` and returns the analyzer-compatible JSON.
+
 Use `nsys` via `nsys_profiler/analyze_nsys.py` (or the `vibeserve-nsys-profiler` MCP tools when attached) when it matches the domain and backend. Capture the benchmark path and analyze the report with the MCP tools. Focus on the bottlenecks relevant to the objective.
 
 Profiler focus this round: general bottleneck analysis on the steady-state benchmark path.

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/single_agent.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/single_agent.md
@@ -46,7 +46,7 @@ Use `uv` for Python package management. Run `uv init` if `pyproject.toml` doesn'
 
 After (and only after) the implementation passes your self-judge gates, capture a profile so the orchestrator has a bottleneck signal for the next round.
 
-Use `nsys` via `nsys_profiler/analyze_nsys.py` (or the `vibeserve-nsys-profiler` MCP tools when attached). The capture script starts the server, runs the benchmark under `nsys profile`, and writes a report you can analyze with the MCP tools. Focus: kernel breakdown, CPU launch overhead, GPU idle gaps.
+Use `nsys` via `nsys_profiler/analyze_nsys.py` (or the `vibeserve-nsys-profiler` MCP tools when attached) when it matches the domain and backend. Capture the benchmark path and analyze the report with the MCP tools. Focus on the bottlenecks relevant to the objective.
 
 Profiler focus this round: general bottleneck analysis on the steady-state benchmark path.
 

--- a/tests/loops/agent/test_interface_modes.py
+++ b/tests/loops/agent/test_interface_modes.py
@@ -213,6 +213,7 @@ def _render_single_agent(interface: str, profiler_kind: str = "torch") -> str:
         interface=interface,
         env_kind="local",
         domain_single_agent="",
+        domain_profiler="",
         task="TASK",
         pass_criteria="PC",
         retry=1,

--- a/tests/loops/agent/test_prompt_domain_leakage.py
+++ b/tests/loops/agent/test_prompt_domain_leakage.py
@@ -1,0 +1,228 @@
+"""Regression tests for keeping domain-specific prompt knowledge scoped.
+
+The checks are data-driven on purpose: add one ``DomainLeakCheck`` when a domain
+gets new distinctive terminology, or add target domains to vet more neutral
+packs against an existing keyword set.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from vibe_serve.loops.agent.domain import render_domain_section, resolve_domain
+from vibe_serve.prompts import render_template
+
+_TEMPLATE_DIR = (
+    Path(__file__).resolve().parents[3] / "src" / "vibe_serve" / "loops" / "agent" / "templates"
+)
+
+
+@dataclass(frozen=True)
+class DomainLeakCheck:
+    """Terms from ``source_domain`` that must not appear in ``target_domains``."""
+
+    source_domain: str
+    target_domains: tuple[str, ...]
+    keywords: tuple[str, ...]
+    modality: str | None = None
+
+
+DOMAIN_LEAK_CHECKS = (
+    DomainLeakCheck(
+        source_domain="llm-serving",
+        target_domains=("generic",),
+        keywords=(
+            "FastAPI",
+            "causal LM",
+            "VibeServeModel",
+            "/v1/completions",
+            "OpenAI-compatible",
+            "serving-systems",
+            "model weights",
+            "/model",
+            "decode invariants",
+            "continuous batching",
+            "KV cache",
+            "FlashInfer",
+            "FlashAttention",
+            "CUDA graphs",
+            "EAGLE",
+            "xgrammar",
+            "speculative decoding",
+            "modal_profile",
+        ),
+    ),
+)
+
+_NEUTRAL_CONTEXT: dict[str, object] = {
+    "modality": None,
+    "interface": "inprocess",
+    "reference_path": "/workspace/reference/main.py",
+    "bench_path": "/workspace/bench",
+    "accuracy_checker_path": "/workspace/acc_checker",
+    "runtime_notes": "",
+    "task": "TASK: optimize a queue implementation for steady-state throughput.",
+    "pass_criteria": "PASS: preserve FIFO behavior and improve the benchmark headline metric.",
+    "objective": "OBJECTIVE: maximize operations per second for the queue benchmark.",
+    "roadmap_text": "- major-1: todo - identify the next data-structure bottleneck.",
+    "env_kind": "local",
+}
+
+
+def _domain_context(context: dict[str, object]) -> dict[str, object]:
+    return {
+        "modality": context["modality"],
+        "interface": context["interface"],
+        "reference_path": context["reference_path"],
+        "bench_path": context["bench_path"],
+        "accuracy_checker_path": context["accuracy_checker_path"],
+        "runtime_notes": context["runtime_notes"],
+    }
+
+
+def _domain_section(domain: str, role: str, context: dict[str, object]) -> str:
+    return render_domain_section(resolve_domain(domain), role, **_domain_context(context))
+
+
+def _render_prompt_bundle(domain: str, *, modality: str | None) -> dict[str, str]:
+    context = _NEUTRAL_CONTEXT | {"modality": modality}
+    return {
+        "implementer": render_template(
+            "implementer_prompt.j2",
+            template_dir=_TEMPLATE_DIR,
+            modality=context["modality"],
+            interface=context["interface"],
+            reference_path=context["reference_path"],
+            runtime_notes=context["runtime_notes"],
+            task=context["task"],
+            pass_criteria=context["pass_criteria"],
+            feedback=None,
+            domain_implementer=_domain_section(domain, "implementer", context),
+        ),
+        "judge": render_template(
+            "judge_prompt.j2",
+            template_dir=_TEMPLATE_DIR,
+            modality=context["modality"],
+            interface=context["interface"],
+            objective=context["objective"],
+            pass_criteria=context["pass_criteria"],
+            runtime_notes=context["runtime_notes"],
+            bench_path=context["bench_path"],
+            accuracy_checker_path=context["accuracy_checker_path"],
+            domain_judge=_domain_section(domain, "judge", context),
+        ),
+        "single_agent_nsys": render_template(
+            "single_agent_round_prompt.j2",
+            template_dir=_TEMPLATE_DIR,
+            modality=context["modality"],
+            interface=context["interface"],
+            env_kind=context["env_kind"],
+            objective=context["objective"],
+            runtime_notes=context["runtime_notes"],
+            task=context["task"],
+            pass_criteria=context["pass_criteria"],
+            bench_path=context["bench_path"],
+            accuracy_checker_path=context["accuracy_checker_path"],
+            retry=1,
+            feedback=None,
+            reference_path=context["reference_path"],
+            profiler_kind="nsys",
+            profile_focus="",
+            domain_single_agent=_domain_section(domain, "single_agent", context),
+        ),
+        "single_agent_torch": render_template(
+            "single_agent_round_prompt.j2",
+            template_dir=_TEMPLATE_DIR,
+            modality=context["modality"],
+            interface=context["interface"],
+            env_kind=context["env_kind"],
+            objective=context["objective"],
+            runtime_notes=context["runtime_notes"],
+            task=context["task"],
+            pass_criteria=context["pass_criteria"],
+            bench_path=context["bench_path"],
+            accuracy_checker_path=context["accuracy_checker_path"],
+            retry=1,
+            feedback=None,
+            reference_path=context["reference_path"],
+            profiler_kind="torch",
+            profile_focus="",
+            domain_single_agent=_domain_section(domain, "single_agent", context),
+        ),
+        "orchestrator_pre_round": render_template(
+            "orchestrator_pre_round_prompt.j2",
+            template_dir=_TEMPLATE_DIR,
+            objective=context["objective"],
+            regression_info=None,
+            exhaustion_info=None,
+        ),
+        "orchestrator_plan": render_template(
+            "orchestrator_plan_prompt.j2",
+            template_dir=_TEMPLATE_DIR,
+            objective=context["objective"],
+            profiler_summary=None,
+            regression_info=None,
+            exhaustion_info=None,
+            roadmap_text=context["roadmap_text"],
+            plateau_warning=None,
+            runtime_notes=context["runtime_notes"],
+            env_kind=context["env_kind"],
+            domain_orchestrator=_domain_section(domain, "orchestrator", context),
+        ),
+        "profiler_nsys": render_template(
+            "profiler_prompt_nsys.j2",
+            template_dir=_TEMPLATE_DIR,
+            profile_focus="queue benchmark hotspots",
+            bench_path=context["bench_path"],
+            modality=context["modality"],
+            domain_profiler=_domain_section(domain, "profiler", context),
+            runtime_notes=context["runtime_notes"],
+            env_kind=context["env_kind"],
+            objective=context["objective"],
+        ),
+        "profiler_torch": render_template(
+            "profiler_prompt_torch.j2",
+            template_dir=_TEMPLATE_DIR,
+            profile_focus="queue benchmark hotspots",
+            bench_path=context["bench_path"],
+            modality=context["modality"],
+            domain_profiler=_domain_section(domain, "profiler", context),
+            runtime_notes=context["runtime_notes"],
+            env_kind=context["env_kind"],
+            objective=context["objective"],
+        ),
+        "profiler_neuron": render_template(
+            "profiler_prompt_neuron.j2",
+            template_dir=_TEMPLATE_DIR,
+            profile_focus="queue benchmark hotspots",
+            bench_path=context["bench_path"],
+            modality=context["modality"],
+            domain_profiler=_domain_section(domain, "profiler", context),
+            runtime_notes=context["runtime_notes"],
+            env_kind=context["env_kind"],
+            objective=context["objective"],
+        ),
+    }
+
+
+@pytest.mark.parametrize("leak_check", DOMAIN_LEAK_CHECKS, ids=lambda check: check.source_domain)
+def test_domain_specific_keywords_do_not_leak_to_vetted_domains(
+    leak_check: DomainLeakCheck,
+):
+    failures: list[str] = []
+    keywords = tuple((keyword, keyword.casefold()) for keyword in leak_check.keywords)
+
+    for target_domain in leak_check.target_domains:
+        prompts = _render_prompt_bundle(target_domain, modality=leak_check.modality)
+        for prompt_name, rendered in prompts.items():
+            rendered_folded = rendered.casefold()
+            for keyword, keyword_folded in keywords:
+                if keyword_folded in rendered_folded:
+                    failures.append(f"{target_domain}/{prompt_name}: {keyword!r}")
+
+    assert not failures, (
+        f"{leak_check.source_domain} knowledge leaked into vetted prompts:\n" + "\n".join(failures)
+    )

--- a/tests/loops/agent/test_prompt_domain_leakage.py
+++ b/tests/loops/agent/test_prompt_domain_leakage.py
@@ -132,6 +132,7 @@ def _render_prompt_bundle(domain: str, *, modality: str | None) -> dict[str, str
             profiler_kind="nsys",
             profile_focus="",
             domain_single_agent=_domain_section(domain, "single_agent", context),
+            domain_profiler=_domain_section(domain, "profiler", context),
         ),
         "single_agent_torch": render_template(
             "single_agent_round_prompt.j2",
@@ -151,6 +152,7 @@ def _render_prompt_bundle(domain: str, *, modality: str | None) -> dict[str, str
             profiler_kind="torch",
             profile_focus="",
             domain_single_agent=_domain_section(domain, "single_agent", context),
+            domain_profiler=_domain_section(domain, "profiler", context),
         ),
         "orchestrator_pre_round": render_template(
             "orchestrator_pre_round_prompt.j2",

--- a/tests/loops/agent/test_prompt_snapshots.py
+++ b/tests/loops/agent/test_prompt_snapshots.py
@@ -104,6 +104,7 @@ def _render_prompt(domain: str, role: str, context: dict[str, object]) -> str:
             profiler_kind="nsys",
             profile_focus="",
             domain_single_agent=_domain_section(domain, "single_agent", context),
+            domain_profiler=_domain_section(domain, "profiler", context),
         )
     if role == "orchestrator":
         return render_template(


### PR DESCRIPTION
## Summary

- Keeps the default no-`--domain` agent behavior on `llm-serving`, but stops defaulting `--modality` for non-default domains.
- Moves LLM-serving orchestration and profiling guidance into the `llm-serving` domain pack, including the new optional `## profiler` section.
- Makes the shared implementer, judge, orchestrator, single-agent, and profiler templates domain-neutral when no modality is selected.
- Updates the existing LLM-serving prompt snapshots to reflect the rendered prompts after the refactor.

## Why

Passing an alternate domain should not mix that domain's prompt context with LLM-serving assumptions like `/v1/completions`, model weights, or serving-specific optimization examples. The neutral templates now provide the general loop structure, while the `llm-serving` domain owns those details.

## Validation

- `uv run pytest tests/loops/agent/test_domain_packs.py tests/loops/agent/test_prompt_snapshots.py tests/loops/agent/test_interface_modes.py tests/test_cli.py -q`
- Generic/no-modality prompt render smoke check for implementer, judge, single-agent, orchestrator, and profiler prompts
- `./scripts/check_format.sh`
- `./scripts/check_lint.sh`
- `uv run pytest -q`
