### PR TITLE
Add domain runtime environment hooks

### DIFF
--- a/src/vibe_serve/context.py
+++ b/src/vibe_serve/context.py
@@ -1,4 +1,4 @@
-"""Shared run context: _RunContext, setup_exp_dir, _TeeWriter, _ensure_model_weights."""
+"""Shared run context: _RunContext, setup_exp_dir, and _TeeWriter."""
 
 import json
 import os
@@ -21,6 +21,11 @@ from vibe_serve.constants import (
     DEFAULT_COMPUTE_BACKEND,
     PROJECT_ROOT,
     ComputeBackend,
+)
+from vibe_serve.domain_runtime import (
+    DomainRuntime,
+    DomainSetupContext,
+    NoopDomainRuntime,
 )
 from vibe_serve.llm_client import _build_model
 from vibe_serve.sandbox.run_environment import (
@@ -55,43 +60,6 @@ def setup_exp_dir(
             check=True,
         )
     return exp_dir
-
-
-def _ensure_model_weights(ref_dir: Path) -> None:
-    """Ensure model weights exist in ref_dir/model, downloading if needed."""
-    model_path = ref_dir / "model"
-
-    # Remove broken symlink if present
-    if model_path.is_symlink() and not model_path.exists():
-        model_path.unlink()
-
-    # Already exists (real dir or valid symlink)
-    if model_path.exists():
-        return
-
-    # Read meta.json for download info
-    meta_path = ref_dir / "meta.json"
-    if not meta_path.exists():
-        raise FileNotFoundError(
-            f"Model weights not found at {model_path} and no meta.json to download from. "
-            f"Either create a model/ directory/symlink or add a meta.json with model_id."
-        )
-
-    meta = json.loads(meta_path.read_text())
-    model_id = meta.get("model_id")
-    if not model_id:
-        raise ValueError(f"meta.json at {meta_path} missing required 'model_id' field")
-
-    revision = meta.get("revision")
-
-    cache_dir = PROJECT_ROOT / ".hf_cache"
-    print(f"[model] Weights not found at {model_path}. Downloading {model_id} to {cache_dir}...")
-    from huggingface_hub import snapshot_download
-
-    downloaded_path = snapshot_download(model_id, revision=revision, cache_dir=str(cache_dir))
-
-    model_path.symlink_to(downloaded_path)
-    print(f"[model] Created symlink {model_path} -> {downloaded_path}")
 
 
 class _TeeWriter:
@@ -145,6 +113,7 @@ class _RunContext:
         agent_backend: str | None = None,
         cli_provider: str | None = None,
         backend: ComputeBackend = DEFAULT_COMPUTE_BACKEND,
+        domain_runtime: DomainRuntime | None = None,
     ):
         config = as_config(config)
         self.backend: ComputeBackend = backend
@@ -276,6 +245,18 @@ class _RunContext:
                 log=self.lprint,
             )
 
+        self.domain_runtime = domain_runtime or NoopDomainRuntime()
+        self.domain_setup_context = DomainSetupContext(
+            reference_path=ref_path,
+            workspace=self.workspace,
+            run_environment=self.run_environment,
+            project_root=PROJECT_ROOT,
+            log=self.lprint,
+        )
+        self.domain_environment_patch = self.domain_runtime.prepare_environment(
+            self.domain_setup_context
+        )
+
         # Always refresh skills into the workspace (even on --resume). Skill
         # source is tiny (MB) and copying is cheap; without this, an
         # interrupted run leaves stale skills from the previous CLI version
@@ -306,15 +287,11 @@ class _RunContext:
                     shutil.rmtree(d)
 
             if ref_dir is not None:
-                # Modal handles model weights via a remote Volume, so we
-                # skip the local HF download (saves ~30 GB of local cache).
-                # We still fall back to the local path if meta.json is absent.
-                if (
-                    self.run_environment.materialize_local_model_weights
-                    or (ref_dir / "meta.json").exists() is False
-                ):
-                    _ensure_model_weights(ref_dir)
-                self._copy_excluding_extras(ref_dir, self.workspace / "reference")
+                self._copy_excluding_extras(
+                    ref_dir,
+                    self.workspace / "reference",
+                    extra_excludes=self.domain_environment_patch.copy_excludes,
+                )
             else:
                 if (self.workspace / ref_script.name).exists():
                     (self.workspace / ref_script.name).unlink()
@@ -375,6 +352,7 @@ class _RunContext:
                     nsys_profiler_path=self.nsys_profiler_path,
                     torch_profiler_path=self.torch_profiler_path,
                     neuron_profiler_path=self.neuron_profiler_path,
+                    domain_bind_mounts=self.domain_environment_patch.bind_mounts,
                     log=self.lprint,
                     project_root=PROJECT_ROOT,
                 )
@@ -541,8 +519,14 @@ class _RunContext:
                     path.unlink()
                     marker.write_text(str(target))
 
-    def _copy_excluding_extras(self, src: Path, dst: Path) -> None:
-        skip = self.EXCLUDED_WORKSPACE_DIRS | {"_mounts"}
+    def _copy_excluding_extras(
+        self,
+        src: Path,
+        dst: Path,
+        *,
+        extra_excludes: frozenset[str] = frozenset(),
+    ) -> None:
+        skip = self.EXCLUDED_WORKSPACE_DIRS | {"_mounts"} | set(extra_excludes)
 
         def _ignore(_: str, names: list[str]) -> list[str]:
             return [name for name in names if name in skip]
@@ -901,6 +885,11 @@ class _RunContext:
         if self.gpu_monitor is not None:
             self.gpu_monitor.stop()
         self._finalize_gpu_metadata()
+        if hasattr(self, "domain_runtime") and hasattr(self, "domain_setup_context"):
+            try:
+                self.domain_runtime.teardown_environment(self.domain_setup_context)
+            except Exception as exc:
+                self.lprint(f"[warn] domain teardown failed: {exc}")
         self._run_environment_stack.close()
         sys.stderr = self._original_stderr
         self.run_log_file.close()

--- a/src/vibe_serve/domain_runtime.py
+++ b/src/vibe_serve/domain_runtime.py
@@ -1,0 +1,133 @@
+"""Domain-specific runtime setup hooks.
+
+Prompt domains describe what agents should know. Runtime domains describe what
+the VibeServe environment must prepare before those agents start working.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+
+class RunEnvironmentCapabilities(Protocol):
+    materialize_local_model_weights: bool
+
+
+@dataclass(frozen=True)
+class DomainSetupContext:
+    """Inputs available to a first-party domain runtime during setup."""
+
+    reference_path: Path
+    workspace: Path
+    run_environment: RunEnvironmentCapabilities
+    project_root: Path
+    log: Callable[[str], None]
+
+
+@dataclass(frozen=True)
+class DomainBindMount:
+    """A host path that the domain wants exposed inside the runtime."""
+
+    host_path: Path
+    container_path: str
+    read_only: bool = True
+
+
+@dataclass(frozen=True)
+class DomainEnvironmentPatch:
+    """Declarative changes requested by a domain runtime."""
+
+    copy_excludes: frozenset[str] = frozenset()
+    bind_mounts: tuple[DomainBindMount, ...] = ()
+
+
+class DomainRuntime(Protocol):
+    def prepare_environment(self, ctx: DomainSetupContext) -> DomainEnvironmentPatch: ...
+
+    def teardown_environment(self, ctx: DomainSetupContext) -> None: ...
+
+
+class NoopDomainRuntime:
+    """Runtime policy for domains with no environment-specific setup."""
+
+    def prepare_environment(self, ctx: DomainSetupContext) -> DomainEnvironmentPatch:
+        return DomainEnvironmentPatch()
+
+    def teardown_environment(self, ctx: DomainSetupContext) -> None:
+        return None
+
+
+def _ensure_model_weights(ref_dir: Path, *, project_root: Path, log: Callable[[str], None]) -> None:
+    """Ensure model weights exist in ref_dir/model, downloading if needed."""
+    model_path = ref_dir / "model"
+
+    if model_path.is_symlink() and not model_path.exists():
+        model_path.unlink()
+
+    if model_path.exists():
+        return
+
+    meta_path = ref_dir / "meta.json"
+    if not meta_path.exists():
+        raise FileNotFoundError(
+            f"Model weights not found at {model_path} and no meta.json to download from. "
+            f"Either create a model/ directory/symlink or add a meta.json with model_id."
+        )
+
+    meta = json.loads(meta_path.read_text())
+    model_id = meta.get("model_id")
+    if not model_id:
+        raise ValueError(f"meta.json at {meta_path} missing required 'model_id' field")
+
+    revision = meta.get("revision")
+    cache_dir = project_root / ".hf_cache"
+    log(f"[model] Weights not found at {model_path}. Downloading {model_id} to {cache_dir}...")
+    from huggingface_hub import snapshot_download
+
+    downloaded_path = snapshot_download(model_id, revision=revision, cache_dir=str(cache_dir))
+    model_path.symlink_to(downloaded_path)
+    log(f"[model] Created symlink {model_path} -> {downloaded_path}")
+
+
+class LLMServingDomainRuntime:
+    """Runtime policy for the built-in llm-serving domain."""
+
+    _MODEL_ARTIFACT_NAMES = frozenset({"model", "draft_model"})
+
+    def prepare_environment(self, ctx: DomainSetupContext) -> DomainEnvironmentPatch:
+        ref_path = ctx.reference_path
+        if not ref_path.is_dir():
+            return DomainEnvironmentPatch()
+
+        model_path = ref_path / "model"
+        meta_path = ref_path / "meta.json"
+        if ctx.run_environment.materialize_local_model_weights or (
+            not meta_path.exists() and not model_path.exists()
+        ):
+            _ensure_model_weights(ref_path, project_root=ctx.project_root, log=ctx.log)
+
+        bind_mounts: list[DomainBindMount] = []
+        if model_path.is_dir() or model_path.is_symlink():
+            bind_mounts.append(DomainBindMount(model_path, "/model", True))
+
+        draft_model_path = ref_path / "draft_model"
+        if draft_model_path.is_dir() or draft_model_path.is_symlink():
+            bind_mounts.append(DomainBindMount(draft_model_path, "/draft_model", True))
+
+        return DomainEnvironmentPatch(
+            copy_excludes=self._MODEL_ARTIFACT_NAMES,
+            bind_mounts=tuple(bind_mounts),
+        )
+
+    def teardown_environment(self, ctx: DomainSetupContext) -> None:
+        return None
+
+
+def runtime_for_domain_name(domain_name: str) -> DomainRuntime:
+    if domain_name == "llm-serving":
+        return LLMServingDomainRuntime()
+    return NoopDomainRuntime()

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -16,6 +16,7 @@ from vibe_serve.agents.progress import RoundProgress
 from vibe_serve.config import Config
 from vibe_serve.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibe_serve.context import _RunContext
+from vibe_serve.domain_runtime import runtime_for_domain_name
 from vibe_serve.loops.agent import issue_board
 from vibe_serve.loops.agent.domain import (
     DEFAULT_DOMAIN,
@@ -629,6 +630,7 @@ def run_agent_loop(
     # site. The implementation language is not a pack — ``interface`` carries it
     # (``inprocess`` pins Python; ``service`` leaves it to the agent).
     domain_path = resolve_domain(domain)
+    domain_runtime = runtime_for_domain_name(domain_path.stem)
     if modality is None and domain_path.stem == DEFAULT_DOMAIN:
         modality = "text_generation"
     run_environment = run_environment or make_run_environment_spec()
@@ -650,6 +652,7 @@ def run_agent_loop(
         agent_backend=agent_backend,
         cli_provider=cli_provider,
         backend=backend,
+        domain_runtime=domain_runtime,
     )
     ctx.lprint(f"[log] orchestrate run: {ctx.run_log_path}")
     ctx.lprint(f"[log] experiment root: {ctx.exp_dir}")

--- a/src/vibe_serve/loops/evolve/loop.py
+++ b/src/vibe_serve/loops/evolve/loop.py
@@ -36,6 +36,7 @@ from vibe_serve.agents.progress import CandidateProgress
 from vibe_serve.config import Config
 from vibe_serve.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibe_serve.context import _RunContext
+from vibe_serve.domain_runtime import runtime_for_domain_name
 from vibe_serve.loops.evolve.population import (
     Individual,
     Objective,
@@ -319,6 +320,7 @@ def run_evolve_loop(
         agent_backend=agent_backend,
         cli_provider=cli_provider,
         backend=backend,
+        domain_runtime=runtime_for_domain_name("llm-serving"),
     )
     ctx.lprint(f"[log] evolutionary run: {ctx.run_log_path}")
     ctx.lprint(f"[log] experiment root: {ctx.exp_dir}")

--- a/src/vibe_serve/loops/openevolve/loop.py
+++ b/src/vibe_serve/loops/openevolve/loop.py
@@ -17,6 +17,7 @@ import random
 from vibe_serve.agents.progress import CandidateProgress
 from vibe_serve.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibe_serve.context import _RunContext
+from vibe_serve.domain_runtime import runtime_for_domain_name
 from vibe_serve.loops.evolve.loop import (
     _checkout_commit_tree,
     _current_commit_sha,
@@ -89,6 +90,7 @@ def run_openevolve_loop(
         agent_backend=agent_backend,
         cli_provider=cli_provider,
         backend=backend,
+        domain_runtime=runtime_for_domain_name("llm-serving"),
     )
     ctx.lprint(f"[log] openevolve run: {ctx.run_log_path}")
     ctx.lprint(f"[log] experiment root: {ctx.exp_dir}")

--- a/src/vibe_serve/loops/plain/loop.py
+++ b/src/vibe_serve/loops/plain/loop.py
@@ -32,6 +32,7 @@ from vibe_serve.agents.progress import RoundProgress
 from vibe_serve.config import Config, as_config
 from vibe_serve.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibe_serve.context import _RunContext
+from vibe_serve.domain_runtime import runtime_for_domain_name
 from vibe_serve.loops.plain.render import render_all
 from vibe_serve.loops.plain.runner_ext import PlainLoopAgentRunner
 from vibe_serve.prompts import Prompt
@@ -384,6 +385,7 @@ def run_plain_loop(
         agent_backend=agent_backend,
         cli_provider=cli_provider,
         backend=backend,
+        domain_runtime=runtime_for_domain_name("llm-serving"),
     ) as ctx:
         ctx.lprint(f"[log] experiment log: {ctx.run_log_path}")
         ctx.lprint(f"[log] experiment root: {ctx.exp_dir}")

--- a/src/vibe_serve/sandbox/run_environment.py
+++ b/src/vibe_serve/sandbox/run_environment.py
@@ -39,6 +39,7 @@ from deepagents.backends.sandbox import BaseSandbox
 from vibe_serve.backends import SandboxKind
 from vibe_serve.backends.base import ComputeBackendImpl, SetupFn
 from vibe_serve.constants import DEFAULT_AGENT_BACKEND, PROJECT_ROOT
+from vibe_serve.domain_runtime import DomainBindMount
 
 
 @dataclass(frozen=True)
@@ -96,6 +97,7 @@ class RunEnvironmentRequest:
     nsys_profiler_path: str | None = None
     torch_profiler_path: str | None = None
     neuron_profiler_path: str | None = None
+    domain_bind_mounts: tuple[DomainBindMount, ...] = ()
     log: Callable[[str], None] | None = None
     project_root: Path = PROJECT_ROOT
 
@@ -208,10 +210,9 @@ class DockerEnvironment:
         return cls(DockerEnvironmentConfig(image=str(image) if image else None))
 
     def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession:
-        bind_mounts, docker_symlinks, model_path = _container_mount_plan(request)
+        bind_mounts, docker_symlinks, passthrough = _container_mount_plan(request)
         extra_init_commands, cli_provider_env = _cli_container_setup(request)
         bind_mounts = _dedupe_mounts(bind_mounts)
-        passthrough = ["/model"] if model_path is not None else []
         setup_fns = _symlink_setup_fns(docker_symlinks)
 
         sandbox = request.backend.make_sandbox(
@@ -338,7 +339,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         self._ensure_model_volume(request)
         self._ensure_draft_volume(request)
 
-        bind_mounts, docker_symlinks, _model_path = _container_mount_plan(request)
+        bind_mounts, docker_symlinks, passthrough = _container_mount_plan(request)
         extra_init_commands, cli_provider_env = _cli_container_setup(request)
 
         # Mount host Modal auth so `modal run` inside the container
@@ -363,7 +364,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
             host_workspace=str(request.workspace),
             log_path=request.log_dir / "docker.log",
             bind_mounts=bind_mounts,
-            passthrough_paths=[],  # weights live in Modal Volumes, not on host
+            passthrough_paths=passthrough,
             extra_env=cli_provider_env,
             extra_init_commands=extra_init_commands,
             setup_fns=setup_fns,
@@ -693,7 +694,7 @@ def _container_mount_plan(
     request: RunEnvironmentRequest,
     *,
     include_cli_provider_mounts: bool = True,
-) -> tuple[list[tuple[str, str, bool]], list[tuple[str, str]], Path | None]:
+) -> tuple[list[tuple[str, str, bool]], list[tuple[str, str]], list[str]]:
     """Build the bind mounts + setup symlinks for a sandbox.
 
     ``include_cli_provider_mounts`` controls whether CLI auth dirs and the
@@ -705,7 +706,7 @@ def _container_mount_plan(
     symlinks: list[tuple[str, str]] = []
     ref_dir = request.ref_dir
 
-    skip_model_symlinks = {"model", "draft_model"}
+    skip_domain_mount_symlinks = {mount.host_path.name for mount in request.domain_bind_mounts}
 
     if ref_dir is not None:
         _collect_symlink_mounts(
@@ -713,7 +714,7 @@ def _container_mount_plan(
             "/workspace/reference",
             bind_mounts=bind_mounts,
             symlinks=symlinks,
-            skip=skip_model_symlinks,
+            skip=skip_domain_mount_symlinks,
         )
         if ref_dir.parent != ref_dir:
             _collect_symlink_mounts(
@@ -721,39 +722,23 @@ def _container_mount_plan(
                 "/workspace",
                 bind_mounts=bind_mounts,
                 symlinks=symlinks,
-                skip=skip_model_symlinks,
+                skip=skip_domain_mount_symlinks,
             )
 
-    model_path: Path | None = None
-    if ref_dir is not None:
-        for candidate in (ref_dir / "model", ref_dir.parent / "model"):
-            if candidate.is_symlink() or candidate.is_dir():
-                model_path = candidate
-                break
-    if model_path is not None:
-        resolved = model_path.resolve()
+    passthrough_paths: list[str] = []
+    for mount in request.domain_bind_mounts:
+        resolved = mount.host_path.resolve()
         host_path = _find_mount_root(resolved)
         if host_path == resolved:
-            bind_mounts.append((str(host_path), "/model", True))
+            bind_mounts.append((str(host_path), mount.container_path, mount.read_only))
         else:
             rel = resolved.relative_to(host_path)
-            ancestor_mount = "/workspace/_mounts/model"
-            bind_mounts.append((str(host_path), ancestor_mount, True))
-            symlinks.append(("/model", f"{ancestor_mount}/{rel}"))
-
-    if ref_dir is not None:
-        for candidate in (ref_dir / "draft_model", ref_dir.parent / "draft_model"):
-            if candidate.is_symlink() or candidate.is_dir():
-                resolved = candidate.resolve()
-                host_path = _find_mount_root(resolved)
-                if host_path == resolved:
-                    bind_mounts.append((str(host_path), "/draft_model", True))
-                else:
-                    rel = resolved.relative_to(host_path)
-                    ancestor_mount = "/workspace/_mounts/draft_model"
-                    bind_mounts.append((str(host_path), ancestor_mount, True))
-                    symlinks.append(("/draft_model", f"{ancestor_mount}/{rel}"))
-                break
+            mount_name = mount.container_path.strip("/").replace("/", "_") or "domain_mount"
+            ancestor_mount = f"/workspace/_mounts/{mount_name}"
+            bind_mounts.append((str(host_path), ancestor_mount, mount.read_only))
+            symlinks.append((mount.container_path, f"{ancestor_mount}/{rel}"))
+        if mount.container_path.startswith("/"):
+            passthrough_paths.append(mount.container_path)
 
     if request.acc_checker_path:
         bind_mounts.append((request.acc_checker_path, "/workspace/acc_checker", True))
@@ -776,7 +761,7 @@ def _container_mount_plan(
         bind_mounts.extend(auth_bind_mounts(request.cli_provider))
         bind_mounts.append((str(request.project_root), "/opt/vibeserve", True))
 
-    return bind_mounts, symlinks, model_path
+    return bind_mounts, symlinks, passthrough_paths
 
 
 def _cli_container_setup(

--- a/tests/sandbox/test_run_environment.py
+++ b/tests/sandbox/test_run_environment.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from vibe_serve.backends import SandboxKind
+from vibe_serve.domain_runtime import DomainBindMount
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentRequest,
     RunEnvironmentSpec,
@@ -84,6 +85,37 @@ def test_docker_environment_opens_one_started_sandbox_with_agent_paths(tmp_path)
 
     session.close()
     backend.sandbox.stop.assert_called_once()
+
+
+def test_docker_environment_uses_domain_bind_mounts(tmp_path):
+    backend = FakeBackend()
+    env = build_run_environment(RunEnvironmentSpec("docker"))
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+
+    env.open(
+        _request(
+            tmp_path,
+            backend,
+            domain_bind_mounts=(DomainBindMount(model_dir, "/model", True),),
+        )
+    )
+
+    kwargs = backend.calls[0][1]
+    assert (str(model_dir), "/model", True) in kwargs["bind_mounts"]
+    assert "/model" in kwargs["passthrough_paths"]
+
+
+def test_docker_environment_does_not_infer_model_mount_from_reference_dir(tmp_path):
+    backend = FakeBackend()
+    env = build_run_environment(RunEnvironmentSpec("docker"))
+    ref_dir = tmp_path / "reference"
+    (ref_dir / "model").mkdir(parents=True)
+
+    env.open(_request(tmp_path, backend, ref_dir=ref_dir))
+
+    bind_mounts = backend.calls[0][1]["bind_mounts"]
+    assert all(container_path != "/model" for _, container_path, _ in bind_mounts)
 
 
 def test_environment_session_context_manager_closes(tmp_path):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibe_serve.context import _RunContext
+from vibe_serve.domain_runtime import NoopDomainRuntime
 from vibe_serve.sandbox.run_environment import RunEnvironmentSpec
 
 
@@ -54,3 +55,27 @@ def test_run_context_defaults_profiler_support_paths(tmp_path, profiler_kind, at
     ):
         assert getattr(ctx, attr) == str(source_dir)
         assert (ctx.workspace / workspace_name / "server.py").is_file()
+
+
+def test_run_context_generic_runtime_does_not_require_model_artifacts(tmp_path):
+    project_root = tmp_path / "project"
+    ref_dir = tmp_path / "queue" / "reference"
+    ref_dir.mkdir(parents=True)
+    (ref_dir / "reference.py").write_text("pass\n")
+
+    with (
+        patch("vibe_serve.context.PROJECT_ROOT", project_root),
+        patch("vibe_serve.context._build_model", return_value="mock-model"),
+        patch("vibe_serve.context.build_agent_runner", return_value=MagicMock()),
+        patch("vibe_serve.context.backends.get", return_value=_FakeBackend()),
+        _RunContext(
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            exp_name="generic-reference-dir",
+            reference_path=str(ref_dir),
+            skills_dirs=[],
+            run_environment=RunEnvironmentSpec("local"),
+            domain_runtime=NoopDomainRuntime(),
+        ) as ctx,
+    ):
+        assert (ctx.workspace / "reference" / "reference.py").is_file()
+        assert not (ref_dir / "model").exists()

--- a/tests/test_domain_runtime.py
+++ b/tests/test_domain_runtime.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+
+from vibe_serve.domain_runtime import (
+    DomainBindMount,
+    DomainSetupContext,
+    LLMServingDomainRuntime,
+    NoopDomainRuntime,
+    runtime_for_domain_name,
+)
+
+
+class _RunEnvironment:
+    def __init__(self, *, materialize_local_model_weights: bool) -> None:
+        self.materialize_local_model_weights = materialize_local_model_weights
+
+
+def _ctx(
+    reference_path: Path,
+    tmp_path: Path,
+    *,
+    materialize_local_model_weights: bool = True,
+) -> DomainSetupContext:
+    return DomainSetupContext(
+        reference_path=reference_path,
+        workspace=tmp_path / "workspace",
+        run_environment=_RunEnvironment(
+            materialize_local_model_weights=materialize_local_model_weights
+        ),
+        project_root=tmp_path / "project",
+        log=lambda _msg: None,
+    )
+
+
+def test_generic_domain_runtime_is_noop(tmp_path):
+    ref_dir = tmp_path / "reference"
+    ref_dir.mkdir()
+
+    patch = NoopDomainRuntime().prepare_environment(_ctx(ref_dir, tmp_path))
+
+    assert patch.copy_excludes == frozenset()
+    assert patch.bind_mounts == ()
+
+
+def test_llm_serving_runtime_requires_model_artifacts_for_reference_dir(tmp_path):
+    ref_dir = tmp_path / "reference"
+    ref_dir.mkdir()
+    (ref_dir / "reference.py").write_text("pass\n")
+
+    with pytest.raises(FileNotFoundError, match="Model weights not found"):
+        LLMServingDomainRuntime().prepare_environment(_ctx(ref_dir, tmp_path))
+
+
+def test_llm_serving_runtime_returns_model_mount_and_copy_excludes(tmp_path):
+    ref_dir = tmp_path / "reference"
+    model_dir = ref_dir / "model"
+    model_dir.mkdir(parents=True)
+    (ref_dir / "reference.py").write_text("pass\n")
+
+    patch = LLMServingDomainRuntime().prepare_environment(
+        _ctx(ref_dir, tmp_path, materialize_local_model_weights=False)
+    )
+
+    assert patch.copy_excludes == frozenset({"model", "draft_model"})
+    assert patch.bind_mounts == (DomainBindMount(model_dir, "/model", True),)
+
+
+def test_runtime_for_domain_name_maps_only_llm_serving_to_model_runtime():
+    assert isinstance(runtime_for_domain_name("llm-serving"), LLMServingDomainRuntime)
+    assert isinstance(runtime_for_domain_name("generic"), NoopDomainRuntime)


### PR DESCRIPTION
## Summary

Closes #117.

- Add a first-party domain runtime hook API with `DomainSetupContext`, `DomainEnvironmentPatch`, and no-op/LLM-serving runtime implementations.
- Move model-weight materialization out of generic `_RunContext` and into the LLM-serving runtime policy.
- Pass domain-declared bind mounts into sandbox environment setup so `/model` and `/draft_model` are no longer inferred globally from any `reference/model` directory.
- Preserve legacy model-serving behavior for plain/evolve/openevolve by explicitly using the LLM-serving runtime there.

## Validation

- `./scripts/check_lint.sh`
- `uv run pytest`
- Smoke: `uv run vibe-serve --outer-loop agent --config /tmp/vibeserve-agent-gpt55.toml --agent-backend cli --cli-provider codex --domain generic --backend cpu --interface inprocess --input examples/data-structures/queue-default --no-skills --max-rounds 0 --exp-name generic-setup-smoke`
