### PR TITLE
Harden profiler resolution semantics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,14 @@ vibe_serve = ["templates/*.j2", "templates/_backend/*/*.j2", "domains/README.md"
 dev = [
     "chardet<6",
     "diff-cover",
+    "hypothesis",
     "matplotlib>=3.10.8",
     "pytest",
     "pytest-cov",
     "ruff>=0.6",
 ]
 test = [
+    "hypothesis",
     "pytest",
     "pytest-cov",
 ]

--- a/src/vibe_serve/backends/base.py
+++ b/src/vibe_serve/backends/base.py
@@ -23,6 +23,7 @@ from typing import Protocol, runtime_checkable
 from deepagents.backends.sandbox import BaseSandbox
 
 from vibe_serve.constants import ComputeBackend
+from vibe_serve.profilers import ProfilerKind
 
 
 class SandboxKind(StrEnum):
@@ -61,7 +62,7 @@ class ComputeBackendImpl(Protocol):
     """Per-platform backend.  See module docstring for the contract."""
 
     name: ComputeBackend
-    profiler_kind: str  # "nsys" / "torch" / etc — picks the Jinja template
+    profiler_kind: ProfilerKind  # picks profiler support, MCP, and prompt template
 
     def make_sandbox(
         self,

--- a/src/vibe_serve/backends/cuda/__init__.py
+++ b/src/vibe_serve/backends/cuda/__init__.py
@@ -25,6 +25,7 @@ from vibe_serve.backends.cuda.gpu_monitor import (
     query_gpu_info,
 )
 from vibe_serve.constants import ComputeBackend
+from vibe_serve.profilers import ProfilerKind
 from vibe_serve.sandbox.docker_sandbox import DockerSandbox
 from vibe_serve.sandbox.modal_sandbox import ModalSandbox
 
@@ -41,7 +42,7 @@ class CudaBackend:
     """
 
     name = ComputeBackend.CUDA
-    profiler_kind = "nsys"
+    profiler_kind = ProfilerKind.NSYS
 
     def __init__(
         self,

--- a/src/vibe_serve/backends/local.py
+++ b/src/vibe_serve/backends/local.py
@@ -28,6 +28,7 @@ from vibe_serve.backends.base import (
     SetupFn,
 )
 from vibe_serve.constants import ComputeBackend
+from vibe_serve.profilers import ProfilerKind
 from vibe_serve.sandbox.docker_sandbox import DockerSandbox
 
 _DEFAULT_CPU_IMAGE = "python:3.12-bookworm"
@@ -36,7 +37,7 @@ _DEFAULT_CPU_IMAGE = "python:3.12-bookworm"
 class LocalBackend:
     """No-device backend (Metal / CPU) — hardware hooks are no-ops."""
 
-    profiler_kind = "torch"
+    profiler_kind = ProfilerKind.TORCH
 
     def __init__(
         self,

--- a/src/vibe_serve/backends/trainium/__init__.py
+++ b/src/vibe_serve/backends/trainium/__init__.py
@@ -36,6 +36,7 @@ from vibe_serve.backends.base import (
     SetupFn,
 )
 from vibe_serve.constants import ComputeBackend
+from vibe_serve.profilers import ProfilerKind
 from vibe_serve.sandbox.docker_sandbox import DockerSandbox
 
 # AWS Neuron DLC.  Tag chosen to match the host's Neuron tools (2.30):
@@ -76,7 +77,7 @@ class TrainiumBackend:
     """AWS Trainium / NeuronCore backend (local or Docker; no Modal)."""
 
     name = ComputeBackend.TRAINIUM
-    profiler_kind = "neuron"
+    profiler_kind = ProfilerKind.NEURON
 
     def __init__(
         self,

--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -28,8 +28,9 @@ from vibe_serve.constants import (
     PROJECT_ROOT,
     ComputeBackend,
 )
-from vibe_serve.domains.base import DEFAULT_DOMAIN
+from vibe_serve.domains.base import DEFAULT_DOMAIN, DomainName
 from vibe_serve.domains.registry import registered_domains
+from vibe_serve.profilers import CLI_PROFILER_CHOICES, ProfilerKind, coerce_profiler_kind
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
@@ -45,6 +46,24 @@ _MODALITIES = (
     "speech_to_text",
     "realtime_audio",
 )
+
+_MODAL_PROFILERS = frozenset({ProfilerKind.AUTO, ProfilerKind.TORCH, ProfilerKind.NONE})
+
+
+def _parse_domain_name(value: str) -> DomainName:
+    try:
+        return DomainName(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"Unknown domain {value!r}. Choose from: {', '.join(registered_domains())}."
+        ) from exc
+
+
+def _parse_profiler_kind(value: str) -> ProfilerKind:
+    try:
+        return coerce_profiler_kind(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -173,15 +192,17 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--profiler",
-        choices=["nsys", "torch", "neuron", "auto"],
-        default="auto",
+        type=_parse_profiler_kind,
+        choices=CLI_PROFILER_CHOICES,
+        default=ProfilerKind.AUTO,
         help=(
             "Which profiler to use between rounds. "
+            "'none' to disable standalone profiling, "
             "'nsys' for NVIDIA Nsight Systems (needs /proc/driver/nvidia), "
             "'torch' for torch.profiler (works in Modal sandboxes), "
             "'neuron' for AWS neuron-explorer (Trainium/NeuronCores), "
-            "'auto' picks the compute backend's profiler (trainium → neuron), "
-            "else torch when --modal is set, else nsys. Default: auto."
+            "'auto' picks a domain/backend/environment-appropriate profiler. "
+            "Default: auto."
         ),
     )
     parser.add_argument(
@@ -427,6 +448,8 @@ def _build_agent_parser() -> argparse.ArgumentParser:
     parser.add_argument("--modality", default=None, choices=_MODALITIES)
     parser.add_argument(
         "--domain",
+        type=_parse_domain_name,
+        choices=tuple(DomainName),
         default=DEFAULT_DOMAIN,
         metavar="NAME",
         help=(
@@ -526,8 +549,11 @@ def _validate_target_inputs(args: argparse.Namespace) -> None:
 
 
 def _validate_agent(args: argparse.Namespace) -> None:
-    if args.modal and args.profiler == "nsys":
-        print("Error: --modal only supports --profiler=torch.", file=sys.stderr)
+    if args.modal and args.profiler not in _MODAL_PROFILERS:
+        print(
+            "Error: --modal only supports --profiler=torch, --profiler=auto, or --profiler=none.",
+            file=sys.stderr,
+        )
         sys.exit(2)
     _validate_target_inputs(args)
 
@@ -665,8 +691,11 @@ def _build_evolve_parser() -> argparse.ArgumentParser:
 
 
 def _validate_evolve(args: argparse.Namespace) -> None:
-    if args.modal and args.profiler == "nsys":
-        print("Error: --modal only supports --profiler=torch.", file=sys.stderr)
+    if args.modal and args.profiler not in _MODAL_PROFILERS:
+        print(
+            "Error: --modal only supports --profiler=torch, --profiler=auto, or --profiler=none.",
+            file=sys.stderr,
+        )
         sys.exit(2)
     _validate_target_inputs(args)
     if args.children_per_generation < 1:
@@ -718,6 +747,7 @@ def _run_evolve(args: argparse.Namespace) -> None:
         bench=str(args.bench) if args.bench else None,
         nsys_profiler=str(args.nsys_profiler) if args.nsys_profiler else None,
         torch_profiler=str(args.torch_profiler) if args.torch_profiler else None,
+        neuron_profiler=str(args.neuron_profiler) if args.neuron_profiler else None,
         profiler_kind=args.profiler,
         skills_dirs=skills,
         run_environment=run_environment_spec_from_args(args),
@@ -760,8 +790,11 @@ def _build_openevolve_parser() -> argparse.ArgumentParser:
 
 
 def _validate_openevolve(args: argparse.Namespace) -> None:
-    if args.modal and args.profiler == "nsys":
-        print("Error: --modal only supports --profiler=torch.", file=sys.stderr)
+    if args.modal and args.profiler not in _MODAL_PROFILERS:
+        print(
+            "Error: --modal only supports --profiler=torch, --profiler=auto, or --profiler=none.",
+            file=sys.stderr,
+        )
         sys.exit(2)
     _validate_target_inputs(args)
     if args.max_iterations < 1:
@@ -800,6 +833,7 @@ def _run_openevolve(args: argparse.Namespace) -> None:
         bench=str(args.bench) if args.bench else None,
         nsys_profiler=str(args.nsys_profiler) if args.nsys_profiler else None,
         torch_profiler=str(args.torch_profiler) if args.torch_profiler else None,
+        neuron_profiler=str(args.neuron_profiler) if args.neuron_profiler else None,
         profiler_kind=args.profiler,
         skills_dirs=skills,
         run_environment=run_environment_spec_from_args(args),
@@ -837,8 +871,11 @@ def _build_plain_parser() -> argparse.ArgumentParser:
 
 
 def _validate_plain(args: argparse.Namespace) -> None:
-    if args.modal and args.profiler == "nsys":
-        print("Error: --modal only supports --profiler=torch.", file=sys.stderr)
+    if args.modal and args.profiler not in _MODAL_PROFILERS:
+        print(
+            "Error: --modal only supports --profiler=torch, --profiler=auto, or --profiler=none.",
+            file=sys.stderr,
+        )
         sys.exit(2)
     _validate_target_inputs(args)
 
@@ -900,7 +937,10 @@ def _run_plain(args: argparse.Namespace) -> None:
         debug=args.debug,
         acc_checker=str(args.acc_checker) if args.acc_checker else None,
         bench=str(args.bench) if args.bench else None,
-        nsys_profiler=str(PROJECT_ROOT / "examples" / "support" / "nsys_profiler"),
+        nsys_profiler=str(args.nsys_profiler) if args.nsys_profiler else None,
+        torch_profiler=str(args.torch_profiler) if args.torch_profiler else None,
+        neuron_profiler=str(args.neuron_profiler) if args.neuron_profiler else None,
+        profiler_kind=args.profiler,
         skills_dirs=skills,
         run_environment=run_environment_spec_from_args(args),
         agent_backend=args.agent_backend,

--- a/src/vibe_serve/context.py
+++ b/src/vibe_serve/context.py
@@ -22,12 +22,14 @@ from vibe_serve.constants import (
     PROJECT_ROOT,
     ComputeBackend,
 )
+from vibe_serve.domains.base import DEFAULT_DOMAIN, DomainName
 from vibe_serve.domains.environment import (
     EnvironmentContext,
     EnvironmentHooks,
     NoopEnvironmentHooks,
 )
 from vibe_serve.llm_client import _build_model
+from vibe_serve.profilers import ProfilerKind, resolve_profiler_kind
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentRequest,
     RunEnvironmentSpec,
@@ -106,7 +108,8 @@ class _RunContext:
         nsys_profiler: str | None = None,
         torch_profiler: str | None = None,
         neuron_profiler: str | None = None,
-        profiler_kind: str = "auto",
+        profiler_kind: ProfilerKind = ProfilerKind.AUTO,
+        profiler_domain: DomainName = DEFAULT_DOMAIN,
         skills_dirs: list[str] | None = None,
         run_environment: RunEnvironmentSpec | None = None,
         git_tracking: bool = False,
@@ -176,29 +179,32 @@ class _RunContext:
         self.torch_profiler_path = self._coerce_dir_path(torch_profiler, "--torch-profiler")
         self.neuron_profiler_path = self._coerce_dir_path(neuron_profiler, "--neuron-profiler")
 
-        # Resolve profiler kind: 'auto' → the compute backend's own profiler
-        # when it dictates one (e.g. Trainium → neuron-explorer), else the run
-        # environment's default (modal → torch, otherwise nsys).
-        resolved_profiler = profiler_kind
-        if resolved_profiler == "auto":
-            backend_profiler = getattr(self.backend_impl, "profiler_kind", None)
-            if backend_profiler == "neuron":
-                resolved_profiler = "neuron"
-            else:
-                resolved_profiler = self.run_environment.default_profiler_kind
-        if resolved_profiler not in ("nsys", "torch", "neuron"):
-            raise ValueError(f"Unknown profiler kind: {profiler_kind!r}")
-        self.profiler_kind = resolved_profiler
+        self.profiler_kind = resolve_profiler_kind(
+            profiler_kind,
+            domain=profiler_domain,
+            backend_profiler_kind=getattr(self.backend_impl, "profiler_kind", None),
+            environment_default_profiler_kind=self.run_environment.default_profiler_kind,
+        )
 
-        # Default torch_profiler_path to examples/support/torch_profiler/ if --profiler=torch
-        # and the user didn't explicitly set --torch-profiler.
-        if self.profiler_kind == "torch" and self.torch_profiler_path is None:
+        if self.profiler_kind is not ProfilerKind.NSYS:
+            self.nsys_profiler_path = None
+        if self.profiler_kind is not ProfilerKind.TORCH:
+            self.torch_profiler_path = None
+        if self.profiler_kind is not ProfilerKind.NEURON:
+            self.neuron_profiler_path = None
+
+        # Default profiler support paths only for the selected profiler.
+        if self.profiler_kind is ProfilerKind.NSYS and self.nsys_profiler_path is None:
+            default_np = PROJECT_ROOT / "examples" / "support" / "nsys_profiler"
+            if default_np.is_dir():
+                self.nsys_profiler_path = str(default_np)
+
+        if self.profiler_kind is ProfilerKind.TORCH and self.torch_profiler_path is None:
             default_tp = PROJECT_ROOT / "examples" / "support" / "torch_profiler"
             if default_tp.is_dir():
                 self.torch_profiler_path = str(default_tp)
 
-        # Likewise default neuron_profiler_path to examples/support/neuron_profiler/.
-        if self.profiler_kind == "neuron" and self.neuron_profiler_path is None:
+        if self.profiler_kind is ProfilerKind.NEURON and self.neuron_profiler_path is None:
             default_np = PROJECT_ROOT / "examples" / "support" / "neuron_profiler"
             if default_np.is_dir():
                 self.neuron_profiler_path = str(default_np)

--- a/src/vibe_serve/domains/registry.py
+++ b/src/vibe_serve/domains/registry.py
@@ -16,14 +16,10 @@ def registered_domains() -> list[str]:
     return sorted(domain.value for domain in DOMAINS)
 
 
-def resolve_domain(spec: str | DomainName) -> DomainDefinition:
-    """Resolve a ``--domain`` value to a registered domain definition."""
-    try:
-        name = spec if isinstance(spec, DomainName) else DomainName(str(spec))
-    except ValueError as exc:
-        raise ValueError(
-            f"Unknown domain {spec!r}. Choose from: {', '.join(registered_domains())}."
-        ) from exc
+def resolve_domain(name: DomainName) -> DomainDefinition:
+    """Resolve a registered domain enum to its definition."""
+    if not isinstance(name, DomainName):
+        raise TypeError(f"domain must be a DomainName, got {type(name).__name__}.")
 
     domain = DOMAINS[name]
     if not domain.prompt_dir.is_dir():

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -21,6 +21,7 @@ from vibe_serve.domains.registry import resolve_domain
 from vibe_serve.domains.rendering import render_domain_section
 from vibe_serve.loops.agent import issue_board
 from vibe_serve.loops.profiler import invoke_profiler
+from vibe_serve.profilers import ProfilerKind, require_profiler_kind
 from vibe_serve.prompts import render_template
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentSpec,
@@ -255,7 +256,7 @@ def _run_pre_round_decision(
     return decision
 
 
-def _profiler_prompt_template(profiler_kind: str, interface: str) -> str:
+def _profiler_prompt_template(profiler_kind: ProfilerKind, interface: str) -> str:
     """Pick the standalone-profiler prompt for the run's profiler + interface.
 
     ``torch`` is a white-box, in-process PyTorch profiler that imports the
@@ -265,12 +266,16 @@ def _profiler_prompt_template(profiler_kind: str, interface: str) -> str:
     ``profiler_kind == "torch" and interface != "service"`` guard so both inner
     loops treat the torch profiler the same way.
     """
-    if interface == "service" and profiler_kind == "torch":
-        profiler_kind = "nsys"
+    kind = require_profiler_kind(profiler_kind)
+    if kind is ProfilerKind.NONE:
+        raise ValueError("No profiler prompt exists when profiling is disabled.")
+    if interface == "service" and kind is ProfilerKind.TORCH:
+        kind = ProfilerKind.NSYS
     return {
-        "torch": "profiler_prompt_torch.j2",
-        "neuron": "profiler_prompt_neuron.j2",
-    }.get(profiler_kind, "profiler_prompt_nsys.j2")
+        ProfilerKind.NSYS: "profiler_prompt_nsys.j2",
+        ProfilerKind.TORCH: "profiler_prompt_torch.j2",
+        ProfilerKind.NEURON: "profiler_prompt_neuron.j2",
+    }[kind]
 
 
 def _run_profiler(
@@ -592,7 +597,7 @@ def run_agent_loop(
     nsys_profiler: str | None = None,
     torch_profiler: str | None = None,
     neuron_profiler: str | None = None,
-    profiler_kind: str = "auto",
+    profiler_kind: ProfilerKind = ProfilerKind.AUTO,
     skills_dirs: list[str] | None = None,
     run_environment: RunEnvironmentSpec | None = None,
     agent_backend: str | None = None,
@@ -600,7 +605,7 @@ def run_agent_loop(
     backend: ComputeBackend = DEFAULT_COMPUTE_BACKEND,
     modality: str | None = None,
     inner_loop: str = "multi-agent",
-    domain: str | DomainName = DEFAULT_DOMAIN,
+    domain: DomainName = DEFAULT_DOMAIN,
     interface: str = DEFAULT_INTERFACE,
 ) -> bool:
     """Run the orchestrator-driven build loop.
@@ -654,6 +659,7 @@ def run_agent_loop(
         torch_profiler=torch_profiler,
         neuron_profiler=neuron_profiler,
         profiler_kind=profiler_kind,
+        profiler_domain=domain_definition.name,
         skills_dirs=skills_dirs,
         run_environment=run_environment,
         git_tracking=True,
@@ -705,20 +711,18 @@ def run_agent_loop(
                             carry=carry,
                             progress_path=progress_path,
                         )
-                        # FORCE-PROFILE override: every non-cold-start round profiles,
-                        # ignoring orchestrator's need_profile decision. Revert this
-                        # block to restore orchestrator-decided profiling.
-                        profiler_summary = _run_profiler(
-                            ctx,
-                            round_number=round_number,
-                            profile_focus=pre_decision.profile_focus
-                            or "general steady-state benchmark hotspots",
-                            modality=modality,
-                            interface=interface,
-                            domain_definition=domain_definition,
-                            progress_path=progress_path,
-                            objective=objective,
-                        )
+                        if pre_decision.need_profile and ctx.profiler_kind is not ProfilerKind.NONE:
+                            profiler_summary = _run_profiler(
+                                ctx,
+                                round_number=round_number,
+                                profile_focus=pre_decision.profile_focus
+                                or "general steady-state benchmark hotspots",
+                                modality=modality,
+                                interface=interface,
+                                domain_definition=domain_definition,
+                                progress_path=progress_path,
+                                objective=objective,
+                            )
                 else:
                     # single-agent: feed the previous round's profile into the
                     # orchestrator as ProfilerSummary so it has a bottleneck signal.

--- a/src/vibe_serve/loops/agent/templates/single_agent_round_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/single_agent_round_prompt.j2
@@ -53,7 +53,9 @@ After (and only after) the implementation passes your self-judge gates, capture 
 {{ domain_profiler }}
 
 {% endif %}
-{% if profiler_kind == "torch" and interface != "service" %}
+{% if profiler_kind == "none" %}
+Standalone profiling is disabled for this run. Use the benchmark's headline metric and judge-visible evidence for the profile fields; do not invoke profiler helper directories or profiler MCP tools.
+{% elif profiler_kind == "torch" and interface != "service" %}
 Use `torch.profiler` via `torch_profiler/analyze_torch_profile.py` (or the `vibeserve-torch-profiler` MCP tools when attached). Start with `tables`, then `kernels` / `operators` / `cpu_overhead` / `memory` / `summary` as relevant.
 
 {% if env_kind == "modal" %}

--- a/src/vibe_serve/loops/evolve/loop.py
+++ b/src/vibe_serve/loops/evolve/loop.py
@@ -43,6 +43,7 @@ from vibe_serve.loops.evolve.population import (
     Population,
 )
 from vibe_serve.loops.profiler import invoke_profiler
+from vibe_serve.profilers import ProfilerKind
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
@@ -224,8 +225,12 @@ def _run_profiler(
     objective: str,
     objectives: list[Objective] | None = None,
 ) -> ProfilerSummary | None:
+    if ctx.profiler_kind is ProfilerKind.NONE:
+        return None
     template = (
-        "profiler_prompt_torch.j2" if ctx.profiler_kind == "torch" else "profiler_prompt_nsys.j2"
+        "profiler_prompt_torch.j2"
+        if ctx.profiler_kind is ProfilerKind.TORCH
+        else "profiler_prompt_nsys.j2"
     )
     base_prompt = _render(
         template,
@@ -279,7 +284,8 @@ def run_evolve_loop(
     bench: str | None = None,
     nsys_profiler: str | None = None,
     torch_profiler: str | None = None,
-    profiler_kind: str = "auto",
+    neuron_profiler: str | None = None,
+    profiler_kind: ProfilerKind = ProfilerKind.AUTO,
     skills_dirs: list[str] | None = None,
     run_environment: RunEnvironmentSpec | None = None,
     agent_backend: str | None = None,
@@ -313,6 +319,7 @@ def run_evolve_loop(
         bench=bench,
         nsys_profiler=nsys_profiler,
         torch_profiler=torch_profiler,
+        neuron_profiler=neuron_profiler,
         profiler_kind=profiler_kind,
         skills_dirs=skills_dirs,
         run_environment=run_environment,

--- a/src/vibe_serve/loops/openevolve/loop.py
+++ b/src/vibe_serve/loops/openevolve/loop.py
@@ -28,6 +28,7 @@ from vibe_serve.loops.evolve.loop import (
 )
 from vibe_serve.loops.evolve.population import Individual, Population
 from vibe_serve.loops.openevolve.archive import MapElitesArchive, compute_features
+from vibe_serve.profilers import ProfilerKind
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
@@ -55,7 +56,8 @@ def run_openevolve_loop(
     bench: str | None = None,
     nsys_profiler: str | None = None,
     torch_profiler: str | None = None,
-    profiler_kind: str = "auto",
+    neuron_profiler: str | None = None,
+    profiler_kind: ProfilerKind = ProfilerKind.AUTO,
     skills_dirs: list[str] | None = None,
     run_environment: RunEnvironmentSpec | None = None,
     agent_backend: str | None = None,
@@ -83,6 +85,7 @@ def run_openevolve_loop(
         bench=bench,
         nsys_profiler=nsys_profiler,
         torch_profiler=torch_profiler,
+        neuron_profiler=neuron_profiler,
         profiler_kind=profiler_kind,
         skills_dirs=skills_dirs,
         run_environment=run_environment,

--- a/src/vibe_serve/loops/plain/loop.py
+++ b/src/vibe_serve/loops/plain/loop.py
@@ -35,6 +35,7 @@ from vibe_serve.context import _RunContext
 from vibe_serve.domains.llm_serving.hooks import LLMServingEnvironmentHooks
 from vibe_serve.loops.plain.render import render_all
 from vibe_serve.loops.plain.runner_ext import PlainLoopAgentRunner
+from vibe_serve.profilers import ProfilerKind
 from vibe_serve.prompts import Prompt
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentSpec,
@@ -351,6 +352,9 @@ def run_plain_loop(
     acc_checker: str | None = None,
     bench: str | None = None,
     nsys_profiler: str | None = None,
+    torch_profiler: str | None = None,
+    neuron_profiler: str | None = None,
+    profiler_kind: ProfilerKind = ProfilerKind.AUTO,
     skills_dirs: list[str] | None = None,
     run_environment: RunEnvironmentSpec | None = None,
     agent_backend: str | None = None,
@@ -379,6 +383,9 @@ def run_plain_loop(
         acc_checker=acc_checker,
         bench=bench,
         nsys_profiler=nsys_profiler,
+        torch_profiler=torch_profiler,
+        neuron_profiler=neuron_profiler,
+        profiler_kind=profiler_kind,
         skills_dirs=skills_dirs,
         run_environment=run_environment,
         git_tracking=git_tracking,

--- a/src/vibe_serve/loops/profiler.py
+++ b/src/vibe_serve/loops/profiler.py
@@ -16,10 +16,11 @@ and decides what to do with the returned summary.
 
 from __future__ import annotations
 
+from vibe_serve.profilers import ProfilerKind, require_profiler_kind
 from vibe_serve.schemas import ProfilerSummary
 
 
-def mcp_spec(profiler_kind: str):
+def mcp_spec(profiler_kind: ProfilerKind):
     """Build an ``MCPServerSpec`` that spawns the analysis MCP server.
 
     Returns ``None`` when ``vibe_serve._agent_cli`` is not importable in the
@@ -27,27 +28,32 @@ def mcp_spec(profiler_kind: str):
     the cli runner).  Callers treat ``None`` as "skip MCP"; the
     profiler agent still runs, just without tool access.
     """
+    kind = require_profiler_kind(profiler_kind)
+    if kind is ProfilerKind.NONE:
+        return None
     try:
-        from vibe_serve._agent_cli import MCPServerSpec
+        from vibe_serve._agent_cli.base import MCPServerSpec
     except Exception:
         return None
-    if profiler_kind == "torch":
+    if kind is ProfilerKind.TORCH:
         return MCPServerSpec(
             name="vibeserve-torch-profiler",
             command="python",
             args=["torch_profiler/server.py"],
         )
-    if profiler_kind == "neuron":
+    if kind is ProfilerKind.NEURON:
         return MCPServerSpec(
             name="vibeserve-neuron-profiler",
             command="python",
             args=["neuron_profiler/server.py"],
         )
-    return MCPServerSpec(
-        name="vibeserve-nsys-profiler",
-        command="python",
-        args=["nsys_profiler/server.py"],
-    )
+    if kind is ProfilerKind.NSYS:
+        return MCPServerSpec(
+            name="vibeserve-nsys-profiler",
+            command="python",
+            args=["nsys_profiler/server.py"],
+        )
+    raise AssertionError(f"Unhandled profiler kind: {kind!r}")
 
 
 def invoke_profiler(
@@ -63,6 +69,8 @@ def invoke_profiler(
     progress.md, snapshotting the workspace, etc. Returns ``None`` on
     exception (the caller decides whether that's fatal).
     """
+    if ctx.profiler_kind is ProfilerKind.NONE:
+        return None
     spec = mcp_spec(ctx.profiler_kind)
     try:
         return ctx.invoke(

--- a/src/vibe_serve/profilers.py
+++ b/src/vibe_serve/profilers.py
@@ -1,0 +1,127 @@
+"""Profiler kinds and resolution policy."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from vibe_serve.domains.base import DomainName
+
+
+class ProfilerKind(StrEnum):
+    """Known profiler modes."""
+
+    AUTO = "auto"
+    NONE = "none"
+    NSYS = "nsys"
+    TORCH = "torch"
+    NEURON = "neuron"
+
+
+ACTIVE_PROFILER_KINDS: frozenset[ProfilerKind] = frozenset(
+    {ProfilerKind.NSYS, ProfilerKind.TORCH, ProfilerKind.NEURON}
+)
+
+CLI_PROFILER_CHOICES: tuple[ProfilerKind, ...] = tuple(ProfilerKind)
+
+_DOMAIN_ALLOWED_PROFILERS: dict[DomainName, frozenset[ProfilerKind]] = {
+    DomainName.GENERIC: frozenset({ProfilerKind.NONE}),
+    DomainName.LLM_SERVING: frozenset(
+        {
+            ProfilerKind.NONE,
+            ProfilerKind.NSYS,
+            ProfilerKind.TORCH,
+            ProfilerKind.NEURON,
+        }
+    ),
+}
+
+
+def coerce_profiler_kind(value: str, *, label: str = "profiler") -> ProfilerKind:
+    """Parse a profiler kind and raise a useful error for unknown values."""
+
+    try:
+        return ProfilerKind(value)
+    except ValueError as exc:
+        choices = ", ".join(kind.value for kind in ProfilerKind)
+        raise ValueError(f"Unknown {label} kind {value!r}; choose from: {choices}.") from exc
+
+
+def require_profiler_kind(value: object, *, label: str = "profiler") -> ProfilerKind:
+    """Require an already-parsed profiler enum at internal API boundaries."""
+
+    if not isinstance(value, ProfilerKind):
+        raise TypeError(f"{label} must be a ProfilerKind, got {type(value).__name__}.")
+    return value
+
+
+def require_domain_name(value: object, *, label: str = "domain") -> DomainName:
+    """Require an already-parsed domain enum at internal API boundaries."""
+
+    if not isinstance(value, DomainName):
+        raise TypeError(f"{label} must be a DomainName, got {type(value).__name__}.")
+    return value
+
+
+def allowed_profiler_kinds(domain: DomainName) -> frozenset[ProfilerKind]:
+    """Profiler kinds allowed by a domain."""
+
+    domain_name = require_domain_name(domain)
+    return _DOMAIN_ALLOWED_PROFILERS[domain_name]
+
+
+def resolve_profiler_kind(
+    requested: ProfilerKind,
+    *,
+    domain: DomainName,
+    backend_profiler_kind: ProfilerKind | None,
+    environment_default_profiler_kind: ProfilerKind,
+) -> ProfilerKind:
+    """Resolve ``--profiler`` into the effective profiler kind.
+
+    ``auto`` is intentionally domain-aware. Generic workloads default to no
+    profiler; LLM-serving workloads pick the backend profiler unless the run
+    environment dictates a remote-safe default such as Modal's torch profiler.
+    """
+
+    requested_kind = require_profiler_kind(requested, label="requested profiler")
+    domain_name = require_domain_name(domain)
+    allowed = allowed_profiler_kinds(domain_name)
+
+    if requested_kind is not ProfilerKind.AUTO:
+        if requested_kind not in allowed:
+            allowed_values = ", ".join(sorted(kind.value for kind in allowed))
+            raise ValueError(
+                f"Profiler {requested_kind.value!r} is not supported for domain "
+                f"{domain_name.value!r}; allowed: {allowed_values}."
+            )
+        return requested_kind
+
+    if domain_name is DomainName.GENERIC:
+        return ProfilerKind.NONE
+
+    environment_default = require_profiler_kind(
+        environment_default_profiler_kind,
+        label="environment default profiler",
+    )
+    backend_profiler = (
+        require_profiler_kind(backend_profiler_kind, label="backend profiler")
+        if backend_profiler_kind is not None
+        else None
+    )
+
+    # Modal runs capture on remote GPUs through torch.profiler; prefer the run
+    # environment's torch default over a local CUDA backend's nsys preference.
+    if environment_default is ProfilerKind.TORCH:
+        candidate = ProfilerKind.TORCH
+    elif backend_profiler in ACTIVE_PROFILER_KINDS:
+        candidate = backend_profiler
+    else:
+        candidate = environment_default
+
+    if candidate not in allowed:
+        allowed_values = ", ".join(sorted(kind.value for kind in allowed))
+        raise ValueError(
+            f"Resolved profiler {candidate.value!r} is not supported for domain "
+            f"{domain_name.value!r}; allowed: {allowed_values}."
+        )
+    return candidate

--- a/src/vibe_serve/sandbox/run_environment.py
+++ b/src/vibe_serve/sandbox/run_environment.py
@@ -40,6 +40,7 @@ from vibe_serve.backends import SandboxKind
 from vibe_serve.backends.base import ComputeBackendImpl, SetupFn
 from vibe_serve.constants import DEFAULT_AGENT_BACKEND, PROJECT_ROOT
 from vibe_serve.domains.environment import EnvironmentBindMount
+from vibe_serve.profilers import ProfilerKind
 
 
 @dataclass(frozen=True)
@@ -114,7 +115,7 @@ class RunEnvironmentSession(Protocol):
 class RunEnvironment(Protocol):
     isolated: bool
     materialize_local_model_weights: bool
-    default_profiler_kind: str
+    default_profiler_kind: ProfilerKind
     backend_image: str | None
 
     def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession: ...
@@ -162,7 +163,7 @@ class _DefaultRunEnvironmentSession:
 class LocalEnvironment(_NoopWorkspaceRecovery):
     isolated = False
     materialize_local_model_weights = True
-    default_profiler_kind = "nsys"
+    default_profiler_kind = ProfilerKind.NSYS
     backend_image = None
 
     def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession:
@@ -198,7 +199,7 @@ class DockerEnvironmentConfig:
 class DockerEnvironment:
     isolated = True
     materialize_local_model_weights = True
-    default_profiler_kind = "nsys"
+    default_profiler_kind = ProfilerKind.NSYS
 
     def __init__(self, config: DockerEnvironmentConfig) -> None:
         self.config = config
@@ -296,7 +297,7 @@ class ModalEnvironmentConfig:
 class ModalEnvironment(_NoopWorkspaceRecovery):
     isolated = True
     materialize_local_model_weights = False
-    default_profiler_kind = "torch"
+    default_profiler_kind = ProfilerKind.TORCH
 
     def __init__(self, config: ModalEnvironmentConfig) -> None:
         self.config = config

--- a/tests/backends/test_cpu_backend.py
+++ b/tests/backends/test_cpu_backend.py
@@ -12,6 +12,7 @@ from vibe_serve.backends import SandboxKind
 from vibe_serve.backends.local import LocalBackend
 from vibe_serve.cli import _add_common_args
 from vibe_serve.constants import ComputeBackend
+from vibe_serve.profilers import ProfilerKind
 from vibe_serve.sandbox.docker_sandbox import DockerSandbox
 
 
@@ -24,7 +25,7 @@ class TestCpuRegistry:
         impl = backends.get(ComputeBackend.CPU, log_dir=tmp_path)
         assert isinstance(impl, LocalBackend)
         assert impl.name is ComputeBackend.CPU
-        assert impl.profiler_kind == "torch"
+        assert impl.profiler_kind is ProfilerKind.TORCH
 
 
 class TestCpuSandbox:

--- a/tests/backends/test_metal_backend.py
+++ b/tests/backends/test_metal_backend.py
@@ -12,6 +12,7 @@ from vibe_serve.backends import SandboxKind
 from vibe_serve.backends.local import LocalBackend
 from vibe_serve.cli import _add_common_args
 from vibe_serve.constants import ComputeBackend
+from vibe_serve.profilers import ProfilerKind
 
 
 def _make_backend(tmp_path) -> LocalBackend:
@@ -23,7 +24,7 @@ class TestMetalRegistry:
         impl = backends.get(ComputeBackend.METAL, log_dir=tmp_path)
         assert isinstance(impl, LocalBackend)
         assert impl.name is ComputeBackend.METAL
-        assert impl.profiler_kind == "torch"
+        assert impl.profiler_kind is ProfilerKind.TORCH
 
 
 class TestMetalSandbox:

--- a/tests/backends/test_trainium_backend.py
+++ b/tests/backends/test_trainium_backend.py
@@ -12,6 +12,7 @@ from vibe_serve.backends import SandboxKind
 from vibe_serve.backends.trainium import TrainiumBackend
 from vibe_serve.cli import _add_common_args
 from vibe_serve.constants import ComputeBackend
+from vibe_serve.profilers import ProfilerKind
 
 
 def _make_backend(tmp_path, devices=("/dev/neuron0",)) -> TrainiumBackend:
@@ -26,7 +27,7 @@ class TestTrainiumRegistry:
         impl = backends.get(ComputeBackend.TRAINIUM, log_dir=tmp_path)
         assert isinstance(impl, TrainiumBackend)
         assert impl.name is ComputeBackend.TRAINIUM
-        assert impl.profiler_kind == "neuron"
+        assert impl.profiler_kind is ProfilerKind.NEURON
 
 
 class TestTrainiumSandbox:

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -54,7 +54,7 @@ def test_registered_domains_present():
 
 
 def test_resolve_registered_name():
-    d = resolve_domain("llm-serving")
+    d = resolve_domain(DomainName.LLM_SERVING)
     assert d.name is DomainName.LLM_SERVING
     assert d.prompt_dir.is_dir()
     assert d.prompt_dir.name == "templates"
@@ -65,7 +65,7 @@ def test_resolve_path_is_not_supported(tmp_path: Path):
     f = tmp_path / "mine"
     f.mkdir()
     (f / "implementer.md").write_text("hello\n")
-    with pytest.raises(ValueError, match="Unknown domain"):
+    with pytest.raises(TypeError, match="DomainName"):
         resolve_domain(str(f))
 
 
@@ -75,10 +75,9 @@ def test_registered_domains_carry_environment_hooks():
 
 
 def test_resolve_unknown_raises():
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(TypeError) as exc:
         resolve_domain("does-not-exist-xyz")
-    # error lists registered domains to guide the user
-    assert "llm-serving" in str(exc.value)
+    assert "DomainName" in str(exc.value)
 
 
 # --------------------------------------------------------------------------- #
@@ -94,13 +93,13 @@ def test_render_missing_role_is_empty(tmp_path: Path):
 
 def test_render_empty_role_is_empty():
     # generic has no role files, so every role injects nothing
-    d = resolve_domain("generic")
+    d = resolve_domain(DomainName.GENERIC)
     for role in (DomainRole.IMPLEMENTER, DomainRole.JUDGE, DomainRole.SINGLE_AGENT):
         assert render_domain_section(d, role) == ""
 
 
 def test_render_llm_serving_has_content():
-    d = resolve_domain("llm-serving")
+    d = resolve_domain(DomainName.LLM_SERVING)
     impl = render_domain_section(
         d, DomainRole.IMPLEMENTER, modality="text_generation", reference_path="/ref"
     )
@@ -138,7 +137,7 @@ def test_role_file_keeps_markdown_headings(tmp_path: Path):
 
 def test_render_role_branches_on_context():
     """A role file rendered with bench_path set should reference it."""
-    d = resolve_domain("llm-serving")
+    d = resolve_domain(DomainName.LLM_SERVING)
     with_bench = render_domain_section(
         d, DomainRole.JUDGE, modality="text_generation", bench_path="/BENCHX"
     )
@@ -166,7 +165,7 @@ def test_render_role_branches_on_interface(tmp_path: Path):
 
 def test_single_agent_uses_explicit_section_when_present():
     # llm-serving ships a bespoke single_agent.md file
-    d = resolve_domain("llm-serving")
+    d = resolve_domain(DomainName.LLM_SERVING)
     sa = render_domain_section(
         d, DomainRole.SINGLE_AGENT, modality="text_generation", reference_path="/ref"
     )
@@ -187,7 +186,7 @@ def test_single_agent_derives_from_implementer_and_judge(tmp_path: Path):
 # --------------------------------------------------------------------------- #
 # end-to-end injection into base prompts
 # --------------------------------------------------------------------------- #
-def _render_implementer(domain: str) -> str:
+def _render_implementer(domain: DomainName) -> str:
     d = resolve_domain(domain)
     section = render_domain_section(
         d, DomainRole.IMPLEMENTER, modality="text_generation", reference_path="/ref"
@@ -206,24 +205,24 @@ def _render_implementer(domain: str) -> str:
 
 
 def test_llm_serving_injects_into_implementer():
-    out = _render_implementer("llm-serving")
+    out = _render_implementer(DomainName.LLM_SERVING)
     # serving-specific prose from the domain package is present
     assert "serving" in out.lower()
     assert "## Progress tracking" in out  # base skeleton intact
 
 
 def test_generic_injects_nothing_extra():
-    generic = _render_implementer("generic")
+    generic = _render_implementer(DomainName.GENERIC)
     # the only serving refs left are from the modality include, not the domain;
     # the generic render must be strictly shorter than llm-serving's.
-    serving = _render_implementer("llm-serving")
+    serving = _render_implementer(DomainName.LLM_SERVING)
     assert len(generic) < len(serving)
     assert "## Progress tracking" in generic  # base skeleton intact
 
 
 def test_no_triple_blank_at_injection_point():
     """Generic (empty injection) must not leave a triple newline gap."""
-    out = _render_implementer("generic")
+    out = _render_implementer(DomainName.GENERIC)
     # The injection point itself ({% if %}...{% endif %}) must collapse cleanly.
     # Locate the workspace->progress transition that brackets the injection.
     idx = out.index("## Progress tracking")
@@ -238,7 +237,7 @@ def test_orchestrator_is_a_domain_role():
     assert DomainRole.ORCHESTRATOR in DOMAIN_ROLES
 
 
-def _render_orchestrator(domain: str) -> str:
+def _render_orchestrator(domain: DomainName) -> str:
     section = render_domain_section(
         resolve_domain(domain), DomainRole.ORCHESTRATOR, modality="text_generation"
     )
@@ -259,21 +258,21 @@ def _render_orchestrator(domain: str) -> str:
 
 def test_llm_serving_provides_orchestrator_optimization_floor():
     section = render_domain_section(
-        resolve_domain("llm-serving"), DomainRole.ORCHESTRATOR, modality="text_generation"
+        resolve_domain(DomainName.LLM_SERVING), DomainRole.ORCHESTRATOR, modality="text_generation"
     )
     assert "Optimization priority" in section
     assert "Continuous batching" in section
 
 
 def test_llm_serving_orchestrator_floor_injected_into_plan():
-    out = _render_orchestrator("llm-serving")
+    out = _render_orchestrator(DomainName.LLM_SERVING)
     assert "Optimization priority" in out
     # the line-39 back-reference resolves when a floor is provided
     assert "the optimization-floor section below" in out
 
 
 def test_generic_orchestrator_has_no_llm_floor():
-    out = _render_orchestrator("generic")
+    out = _render_orchestrator(DomainName.GENERIC)
     # the prescriptive LLM floor is gone, and its back-reference collapses
     assert "Optimization priority" not in out
     assert "Continuous batching" not in out

--- a/tests/loops/agent/test_interface_modes.py
+++ b/tests/loops/agent/test_interface_modes.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import pytest
 
+from vibe_serve.domains.base import DomainName
+from vibe_serve.profilers import ProfilerKind
 from vibe_serve.prompts import render_template
 
 _TEMPLATE_DIR = (
@@ -39,7 +41,7 @@ def test_domain_module_has_no_language_axis():
     assert not hasattr(domain, "DEFAULT_LANGUAGE")
     assert not hasattr(domain, "LANGUAGE_DIR")
     # the domain axis is untouched
-    assert domain.DEFAULT_DOMAIN == "llm-serving"
+    assert domain.DEFAULT_DOMAIN is DomainName.LLM_SERVING
 
 
 def test_no_language_pack_directory():
@@ -109,12 +111,26 @@ def test_standalone_profiler_drops_torch_under_service():
     from vibe_serve.loops.agent.loop import _profiler_prompt_template
 
     # inprocess keeps the white-box torch profiler
-    assert _profiler_prompt_template("torch", "inprocess") == "profiler_prompt_torch.j2"
+    assert _profiler_prompt_template(ProfilerKind.TORCH, "inprocess") == "profiler_prompt_torch.j2"
     # service swaps torch -> nsys (torch imports the implementation)
-    assert _profiler_prompt_template("torch", "service") == "profiler_prompt_nsys.j2"
+    assert _profiler_prompt_template(ProfilerKind.TORCH, "service") == "profiler_prompt_nsys.j2"
     # non-torch kinds are unaffected by the interface
-    assert _profiler_prompt_template("neuron", "service") == "profiler_prompt_neuron.j2"
-    assert _profiler_prompt_template("nsys", "service") == "profiler_prompt_nsys.j2"
+    assert _profiler_prompt_template(ProfilerKind.NEURON, "service") == "profiler_prompt_neuron.j2"
+    assert _profiler_prompt_template(ProfilerKind.NSYS, "service") == "profiler_prompt_nsys.j2"
+
+
+def test_standalone_profiler_none_has_no_prompt_template():
+    from vibe_serve.loops.agent.loop import _profiler_prompt_template
+
+    with pytest.raises(ValueError, match="disabled"):
+        _profiler_prompt_template(ProfilerKind.NONE, "inprocess")
+
+
+def test_standalone_profiler_rejects_unknown_kind():
+    from vibe_serve.loops.agent.loop import _profiler_prompt_template
+
+    with pytest.raises(TypeError, match="ProfilerKind"):
+        _profiler_prompt_template("bogus", "inprocess")
 
 
 # --------------------------------------------------------------------------- #
@@ -205,7 +221,9 @@ def test_service_judge_drops_vibeservemodel():
 # --------------------------------------------------------------------------- #
 # prompt rendering: single-agent
 # --------------------------------------------------------------------------- #
-def _render_single_agent(interface: str, profiler_kind: str = "torch") -> str:
+def _render_single_agent(
+    interface: str, profiler_kind: ProfilerKind = ProfilerKind.TORCH
+) -> str:
     return render_template(
         "single_agent_round_prompt.j2",
         template_dir=_TEMPLATE_DIR,
@@ -229,17 +247,27 @@ def _render_single_agent(interface: str, profiler_kind: str = "torch") -> str:
 
 
 def test_inprocess_single_agent_keeps_uv_and_torch_capture():
-    out = _render_single_agent("inprocess", profiler_kind="torch")
+    out = _render_single_agent("inprocess", profiler_kind=ProfilerKind.TORCH)
     assert "uv" in out
     # torch in-process capture path is offered for Python implementations
     assert "torch.profiler" in out
 
 
 def test_service_single_agent_is_language_free_and_avoids_inprocess_torch():
-    out = _render_single_agent("service", profiler_kind="torch")
+    out = _render_single_agent("service", profiler_kind=ProfilerKind.TORCH)
     assert "uv" not in out
     assert "over the wire" in out
     # torch in-process capture is Python-only; service falls back to nsys /
     # server-driven profiling instead
     assert "torch.profiler" not in out
     assert "nsys" in out
+
+
+def test_single_agent_profiler_none_avoids_profiler_tools():
+    out = _render_single_agent("inprocess", profiler_kind=ProfilerKind.NONE)
+    assert "Standalone profiling is disabled" in out
+    assert "nsys_profiler" not in out
+    assert "torch_profiler" not in out
+    assert "neuron_profiler" not in out
+    assert "vibeserve-nsys-profiler" not in out
+    assert "vibeserve-torch-profiler" not in out

--- a/tests/loops/agent/test_interface_modes.py
+++ b/tests/loops/agent/test_interface_modes.py
@@ -221,9 +221,7 @@ def test_service_judge_drops_vibeservemodel():
 # --------------------------------------------------------------------------- #
 # prompt rendering: single-agent
 # --------------------------------------------------------------------------- #
-def _render_single_agent(
-    interface: str, profiler_kind: ProfilerKind = ProfilerKind.TORCH
-) -> str:
+def _render_single_agent(interface: str, profiler_kind: ProfilerKind = ProfilerKind.TORCH) -> str:
     return render_template(
         "single_agent_round_prompt.j2",
         template_dir=_TEMPLATE_DIR,

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -5,8 +5,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibe_serve.agents import AgentRunner
+from vibe_serve.domains.base import DomainName
 from vibe_serve.loops.agent import issue_board
 from vibe_serve.loops.agent.loop import run_agent_loop
+from vibe_serve.profilers import ProfilerKind
 from vibe_serve.schemas import (
     ImplementerResponse,
     JudgeResponse,
@@ -357,6 +359,72 @@ def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):
     prof_idx = call_order.index("profiler")
     # Profiler must come BEFORE the round-2 plan call.
     assert prof_idx < plan_idx[1]
+
+
+def test_loop_skips_profiler_when_pre_round_decision_says_no(tmp_path, ref_file):
+    runner = _make_orchestrate_runner(
+        pre_decisions=[
+            PreRoundDecision(need_profile=False, profile_focus="", reasoning="benchmark is enough"),
+        ],
+        plans=[
+            OrchestratorPlan(task="Build server", pass_criteria="ok", reasoning="start"),
+            OrchestratorPlan(task="Use benchmark evidence", pass_criteria="ok", reasoning="skip"),
+        ],
+    )
+
+    result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=2)
+
+    assert result is True
+    assert runner.counters["orch_pre"] == 1
+    assert runner.counters["prof"] == 0
+
+
+def test_loop_skips_profiler_when_profiler_kind_is_none(tmp_path, ref_file):
+    runner = _make_orchestrate_runner(
+        pre_decisions=[
+            PreRoundDecision(need_profile=True, profile_focus="kernels", reasoning="would help"),
+        ],
+        plans=[
+            OrchestratorPlan(task="Build server", pass_criteria="ok", reasoning="start"),
+            OrchestratorPlan(task="Use benchmark evidence", pass_criteria="ok", reasoning="disabled"),
+        ],
+    )
+
+    result = _invoke_orchestrate(
+        tmp_path,
+        ref_file,
+        runner,
+        max_rounds=2,
+        profiler_kind=ProfilerKind.NONE,
+    )
+
+    assert result is True
+    assert runner.counters["orch_pre"] == 1
+    assert runner.counters["prof"] == 0
+
+
+def test_loop_generic_auto_profiler_resolves_to_none(tmp_path, ref_file):
+    runner = _make_orchestrate_runner(
+        pre_decisions=[
+            PreRoundDecision(need_profile=True, profile_focus="kernels", reasoning="would help"),
+        ],
+        plans=[
+            OrchestratorPlan(task="Build queue", pass_criteria="ok", reasoning="start"),
+            OrchestratorPlan(task="Use benchmark evidence", pass_criteria="ok", reasoning="generic"),
+        ],
+    )
+
+    result = _invoke_orchestrate(
+        tmp_path,
+        ref_file,
+        runner,
+        max_rounds=2,
+        domain=DomainName.GENERIC,
+    )
+
+    assert result is True
+    assert runner.counters["orch_pre"] == 1
+    assert runner.counters["prof"] == 0
 
 
 def test_loop_runs_full_max_rounds_budget(tmp_path, ref_file):

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -386,7 +386,9 @@ def test_loop_skips_profiler_when_profiler_kind_is_none(tmp_path, ref_file):
         ],
         plans=[
             OrchestratorPlan(task="Build server", pass_criteria="ok", reasoning="start"),
-            OrchestratorPlan(task="Use benchmark evidence", pass_criteria="ok", reasoning="disabled"),
+            OrchestratorPlan(
+                task="Use benchmark evidence", pass_criteria="ok", reasoning="disabled"
+            ),
         ],
     )
 
@@ -410,7 +412,9 @@ def test_loop_generic_auto_profiler_resolves_to_none(tmp_path, ref_file):
         ],
         plans=[
             OrchestratorPlan(task="Build queue", pass_criteria="ok", reasoning="start"),
-            OrchestratorPlan(task="Use benchmark evidence", pass_criteria="ok", reasoning="generic"),
+            OrchestratorPlan(
+                task="Use benchmark evidence", pass_criteria="ok", reasoning="generic"
+            ),
         ],
     )
 

--- a/tests/loops/agent/test_prompt_domain_leakage.py
+++ b/tests/loops/agent/test_prompt_domain_leakage.py
@@ -12,8 +12,10 @@ from pathlib import Path
 
 import pytest
 
+from vibe_serve.domains.base import DomainName
 from vibe_serve.domains.registry import resolve_domain
 from vibe_serve.domains.rendering import render_domain_section
+from vibe_serve.profilers import ProfilerKind
 from vibe_serve.prompts import render_template
 
 _TEMPLATE_DIR = (
@@ -25,16 +27,16 @@ _TEMPLATE_DIR = (
 class DomainLeakCheck:
     """Terms from ``source_domain`` that must not appear in ``target_domains``."""
 
-    source_domain: str
-    target_domains: tuple[str, ...]
+    source_domain: DomainName
+    target_domains: tuple[DomainName, ...]
     keywords: tuple[str, ...]
     modality: str | None = None
 
 
 DOMAIN_LEAK_CHECKS = (
     DomainLeakCheck(
-        source_domain="llm-serving",
-        target_domains=("generic",),
+        source_domain=DomainName.LLM_SERVING,
+        target_domains=(DomainName.GENERIC,),
         keywords=(
             "FastAPI",
             "causal LM",
@@ -84,11 +86,11 @@ def _domain_context(context: dict[str, object]) -> dict[str, object]:
     }
 
 
-def _domain_section(domain: str, role: str, context: dict[str, object]) -> str:
+def _domain_section(domain: DomainName, role: str, context: dict[str, object]) -> str:
     return render_domain_section(resolve_domain(domain), role, **_domain_context(context))
 
 
-def _render_prompt_bundle(domain: str, *, modality: str | None) -> dict[str, str]:
+def _render_prompt_bundle(domain: DomainName, *, modality: str | None) -> dict[str, str]:
     context = _NEUTRAL_CONTEXT | {"modality": modality}
     return {
         "implementer": render_template(
@@ -130,7 +132,7 @@ def _render_prompt_bundle(domain: str, *, modality: str | None) -> dict[str, str
             retry=1,
             feedback=None,
             reference_path=context["reference_path"],
-            profiler_kind="nsys",
+            profiler_kind=ProfilerKind.NSYS,
             profile_focus="",
             domain_single_agent=_domain_section(domain, "single_agent", context),
             domain_profiler=_domain_section(domain, "profiler", context),
@@ -150,7 +152,7 @@ def _render_prompt_bundle(domain: str, *, modality: str | None) -> dict[str, str
             retry=1,
             feedback=None,
             reference_path=context["reference_path"],
-            profiler_kind="torch",
+            profiler_kind=ProfilerKind.TORCH,
             profile_focus="",
             domain_single_agent=_domain_section(domain, "single_agent", context),
             domain_profiler=_domain_section(domain, "profiler", context),

--- a/tests/loops/agent/test_prompt_snapshots.py
+++ b/tests/loops/agent/test_prompt_snapshots.py
@@ -12,8 +12,10 @@ from pathlib import Path
 
 import pytest
 
+from vibe_serve.domains.base import DomainName
 from vibe_serve.domains.registry import resolve_domain
 from vibe_serve.domains.rendering import render_domain_section
+from vibe_serve.profilers import ProfilerKind
 from vibe_serve.prompts import render_template
 
 _ROOT = Path(__file__).resolve().parents[3]
@@ -58,11 +60,11 @@ def _domain_context(context: dict[str, object]) -> dict[str, object]:
     }
 
 
-def _domain_section(domain: str, role: str, context: dict[str, object]) -> str:
+def _domain_section(domain: DomainName, role: str, context: dict[str, object]) -> str:
     return render_domain_section(resolve_domain(domain), role, **_domain_context(context))
 
 
-def _render_prompt(domain: str, role: str, context: dict[str, object]) -> str:
+def _render_prompt(domain: DomainName, role: str, context: dict[str, object]) -> str:
     if role == "implementer":
         return render_template(
             "implementer_prompt.j2",
@@ -102,7 +104,7 @@ def _render_prompt(domain: str, role: str, context: dict[str, object]) -> str:
             retry=1,
             feedback=None,
             reference_path=context["reference_path"],
-            profiler_kind="nsys",
+            profiler_kind=ProfilerKind.NSYS,
             profile_focus="",
             domain_single_agent=_domain_section(domain, "single_agent", context),
             domain_profiler=_domain_section(domain, "profiler", context),
@@ -149,13 +151,13 @@ def _assert_matches_snapshot(domain: str, case_name: str, role: str, rendered: s
 @pytest.mark.parametrize("case_name,context", _CONTEXTS.items())
 @pytest.mark.parametrize("role", _ROLES)
 def test_llm_serving_prompt_snapshot(case_name: str, context: dict[str, object], role: str):
-    rendered = _render_prompt("llm-serving", role, context)
-    _assert_matches_snapshot("llm-serving", case_name, role, rendered)
+    rendered = _render_prompt(DomainName.LLM_SERVING, role, context)
+    _assert_matches_snapshot(DomainName.LLM_SERVING.value, case_name, role, rendered)
 
 
 def test_llm_serving_rendered_prompts_keep_required_domain_content():
     context = _CONTEXTS["full"]
-    prompts = {role: _render_prompt("llm-serving", role, context) for role in _ROLES}
+    prompts = {role: _render_prompt(DomainName.LLM_SERVING, role, context) for role in _ROLES}
 
     assert "Model weights are at `/model`" in prompts["implementer"]
     assert "serving-systems" in prompts["implementer"]
@@ -170,8 +172,8 @@ def test_llm_serving_rendered_prompts_keep_required_domain_content():
 
 def test_minimal_llm_serving_prompt_omits_optional_checker_paths():
     context = _CONTEXTS["minimal"]
-    judge = _render_prompt("llm-serving", "judge", context)
-    single_agent = _render_prompt("llm-serving", "single_agent", context)
+    judge = _render_prompt(DomainName.LLM_SERVING, "judge", context)
+    single_agent = _render_prompt(DomainName.LLM_SERVING, "single_agent", context)
 
     assert "/workspace/bench/benchmark.py" not in judge
     assert "/workspace/acc_checker/checker.py" not in judge
@@ -181,7 +183,7 @@ def test_minimal_llm_serving_prompt_omits_optional_checker_paths():
 
 def test_generic_prompts_do_not_receive_llm_serving_domain_content():
     context = _CONTEXTS["full"]
-    prompts = {role: _render_prompt("generic", role, context) for role in _ROLES}
+    prompts = {role: _render_prompt(DomainName.GENERIC, role, context) for role in _ROLES}
 
     assert "Model weights are at `/model`" not in prompts["implementer"]
     assert "Required: read the relevant skill BEFORE writing code" not in prompts["implementer"]

--- a/tests/loops/test_profiler_mcp.py
+++ b/tests/loops/test_profiler_mcp.py
@@ -14,6 +14,9 @@ from pathlib import Path
 
 import pytest
 
+from vibe_serve.loops.profiler import mcp_spec
+from vibe_serve.profilers import ProfilerKind
+
 
 # The servers live under examples/ (co-located with the analysis scripts) so
 # importing them by file path keeps the tests decoupled from sys.path state.
@@ -37,6 +40,27 @@ def _load_module(name: str, path: Path):
 
 
 _REPO = Path(__file__).resolve().parent.parent.parent
+
+
+def test_profiler_mcp_spec_maps_known_kinds_exactly():
+    assert mcp_spec(ProfilerKind.NONE) is None
+
+    nsys = mcp_spec(ProfilerKind.NSYS)
+    assert nsys.name == "vibeserve-nsys-profiler"
+    assert nsys.args == ["nsys_profiler/server.py"]
+
+    torch = mcp_spec(ProfilerKind.TORCH)
+    assert torch.name == "vibeserve-torch-profiler"
+    assert torch.args == ["torch_profiler/server.py"]
+
+    neuron = mcp_spec(ProfilerKind.NEURON)
+    assert neuron.name == "vibeserve-neuron-profiler"
+    assert neuron.args == ["neuron_profiler/server.py"]
+
+
+def test_profiler_mcp_spec_rejects_unknown_kind():
+    with pytest.raises(TypeError, match="ProfilerKind"):
+        mcp_spec("bogus")
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 import pytest
 
 from vibe_serve.cli import _extract_flag, _extract_loop_selection, _validate_target_inputs, main
+from vibe_serve.domains.base import DomainName
+from vibe_serve.profilers import ProfilerKind
 
 TARGET_ARGS = [
     "--ref",
@@ -88,6 +90,8 @@ def test_target_inputs_default_to_none():
     assert args.ref is None
     assert args.acc_checker is None
     assert args.bench is None
+    assert args.profiler is ProfilerKind.AUTO
+    assert args.domain is DomainName.LLM_SERVING
 
 
 @pytest.mark.parametrize(
@@ -106,6 +110,50 @@ def test_input_arg_is_available_on_all_loop_parsers(builder_name):
     args = parser.parse_args(["--input", "examples/data-structures/queue-default"])
 
     assert args.input == Path("examples/data-structures/queue-default")
+
+
+@pytest.mark.parametrize(
+    "builder_name,validator_name",
+    [
+        ("_build_agent_parser", "_validate_agent"),
+        ("_build_evolve_parser", "_validate_evolve"),
+        ("_build_openevolve_parser", "_validate_openevolve"),
+        ("_build_plain_parser", "_validate_plain"),
+    ],
+)
+def test_profiler_none_is_valid_with_modal(builder_name, validator_name):
+    import vibe_serve.cli as cli
+
+    parser = getattr(cli, builder_name)()
+    validator = getattr(cli, validator_name)
+    args = parser.parse_args(["--modal", "--profiler", "none", *TARGET_ARGS])
+
+    assert args.profiler is ProfilerKind.NONE
+    validator(args)
+
+
+def test_agent_parser_outputs_domain_enum():
+    from vibe_serve.cli import _build_agent_parser
+
+    args = _build_agent_parser().parse_args(["--domain", "generic"])
+
+    assert args.domain is DomainName.GENERIC
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--profiler", "bogus"],
+        ["--domain", "bogus"],
+    ],
+)
+def test_agent_parser_rejects_invalid_enum_args(argv):
+    from vibe_serve.cli import _build_agent_parser
+
+    with pytest.raises(SystemExit) as exc:
+        _build_agent_parser().parse_args(argv)
+
+    assert exc.value.code == 2
 
 
 def test_validate_target_inputs_derives_bundle_paths_from_input(tmp_path):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -3,7 +3,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibe_serve.context import _RunContext
+from vibe_serve.domains.base import DomainName
 from vibe_serve.domains.environment import NoopEnvironmentHooks
+from vibe_serve.profilers import ACTIVE_PROFILER_KINDS, ProfilerKind
 from vibe_serve.sandbox.run_environment import RunEnvironmentSpec
 
 
@@ -11,8 +13,10 @@ class _FakeBackend:
     image = "fake-image"
     selected_device = None
 
-    def __init__(self) -> None:
+    def __init__(self, profiler_kind=None) -> None:
         self.sandbox = MagicMock()
+        if profiler_kind is not None:
+            self.profiler_kind = profiler_kind
 
     def make_sandbox(self, *_args, **_kwargs):
         return self.sandbox
@@ -21,11 +25,35 @@ class _FakeBackend:
         return None
 
 
+def _write_ref(tmp_path):
+    ref_dir = tmp_path / "input"
+    ref_dir.mkdir()
+    ref = ref_dir / "reference.py"
+    ref.write_text("pass\n")
+    return ref
+
+
+def _write_support_dirs(project_root):
+    dirs = {
+        ProfilerKind.NSYS: "nsys_profiler",
+        ProfilerKind.TORCH: "torch_profiler",
+        ProfilerKind.NEURON: "neuron_profiler",
+    }
+    for workspace_name in dirs.values():
+        source_dir = project_root / "examples" / "support" / workspace_name
+        source_dir.mkdir(parents=True)
+        (source_dir / "server.py").write_text("pass\n")
+    return {
+        kind: str(project_root / "examples" / "support" / workspace_name)
+        for kind, workspace_name in dirs.items()
+    }
+
+
 @pytest.mark.parametrize(
     ("profiler_kind", "attr", "workspace_name"),
     [
-        ("torch", "torch_profiler_path", "torch_profiler"),
-        ("neuron", "neuron_profiler_path", "neuron_profiler"),
+        (ProfilerKind.TORCH, "torch_profiler_path", "torch_profiler"),
+        (ProfilerKind.NEURON, "neuron_profiler_path", "neuron_profiler"),
     ],
 )
 def test_run_context_defaults_profiler_support_paths(tmp_path, profiler_kind, attr, workspace_name):
@@ -34,10 +62,7 @@ def test_run_context_defaults_profiler_support_paths(tmp_path, profiler_kind, at
     source_dir.mkdir(parents=True)
     (source_dir / "server.py").write_text("pass\n")
 
-    ref_dir = tmp_path / "input"
-    ref_dir.mkdir()
-    ref = ref_dir / "reference.py"
-    ref.write_text("pass\n")
+    ref = _write_ref(tmp_path)
 
     with (
         patch("vibe_serve.context.PROJECT_ROOT", project_root),
@@ -55,6 +80,128 @@ def test_run_context_defaults_profiler_support_paths(tmp_path, profiler_kind, at
     ):
         assert getattr(ctx, attr) == str(source_dir)
         assert (ctx.workspace / workspace_name / "server.py").is_file()
+
+
+@pytest.mark.parametrize(
+    "selected",
+    [ProfilerKind.NONE, *sorted(ACTIVE_PROFILER_KINDS, key=lambda kind: kind.value)],
+)
+def test_run_context_copies_only_selected_profiler_support(tmp_path, selected):
+    project_root = tmp_path / "project"
+    support_paths = _write_support_dirs(project_root)
+    ref = _write_ref(tmp_path)
+
+    with (
+        patch("vibe_serve.context.PROJECT_ROOT", project_root),
+        patch("vibe_serve.context._build_model", return_value="mock-model"),
+        patch("vibe_serve.context.build_agent_runner", return_value=MagicMock()),
+        patch("vibe_serve.context.backends.get", return_value=_FakeBackend()),
+        _RunContext(
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            exp_name=f"{selected.value}-support",
+            reference_path=str(ref),
+            profiler_kind=selected,
+            nsys_profiler=support_paths[ProfilerKind.NSYS],
+            torch_profiler=support_paths[ProfilerKind.TORCH],
+            neuron_profiler=support_paths[ProfilerKind.NEURON],
+            skills_dirs=[],
+            run_environment=RunEnvironmentSpec("local"),
+        ) as ctx,
+    ):
+        expected = {
+            ProfilerKind.NSYS: selected is ProfilerKind.NSYS,
+            ProfilerKind.TORCH: selected is ProfilerKind.TORCH,
+            ProfilerKind.NEURON: selected is ProfilerKind.NEURON,
+        }
+        assert ctx.profiler_kind is selected
+        assert (ctx.workspace / "nsys_profiler").exists() is expected[ProfilerKind.NSYS]
+        assert (ctx.workspace / "torch_profiler").exists() is expected[ProfilerKind.TORCH]
+        assert (ctx.workspace / "neuron_profiler").exists() is expected[ProfilerKind.NEURON]
+
+
+def test_run_context_generic_auto_resolves_to_none_without_profiler_support(tmp_path):
+    project_root = tmp_path / "project"
+    support_paths = _write_support_dirs(project_root)
+    ref = _write_ref(tmp_path)
+
+    with (
+        patch("vibe_serve.context.PROJECT_ROOT", project_root),
+        patch("vibe_serve.context._build_model", return_value="mock-model"),
+        patch("vibe_serve.context.build_agent_runner", return_value=MagicMock()),
+        patch("vibe_serve.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
+        _RunContext(
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            exp_name="generic-auto-none",
+            reference_path=str(ref),
+            profiler_kind=ProfilerKind.AUTO,
+            profiler_domain=DomainName.GENERIC,
+            nsys_profiler=support_paths[ProfilerKind.NSYS],
+            torch_profiler=support_paths[ProfilerKind.TORCH],
+            neuron_profiler=support_paths[ProfilerKind.NEURON],
+            skills_dirs=[],
+            run_environment=RunEnvironmentSpec("local"),
+            environment_hooks=NoopEnvironmentHooks(),
+        ) as ctx,
+    ):
+        assert ctx.profiler_kind is ProfilerKind.NONE
+        assert ctx.nsys_profiler_path is None
+        assert ctx.torch_profiler_path is None
+        assert ctx.neuron_profiler_path is None
+        assert not (ctx.workspace / "nsys_profiler").exists()
+        assert not (ctx.workspace / "torch_profiler").exists()
+        assert not (ctx.workspace / "neuron_profiler").exists()
+
+
+@pytest.mark.parametrize(
+    "profiler_kind",
+    sorted(ACTIVE_PROFILER_KINDS, key=lambda kind: kind.value),
+)
+def test_run_context_rejects_generic_explicit_active_profilers(tmp_path, profiler_kind):
+    ref = _write_ref(tmp_path)
+
+    with (
+        patch("vibe_serve.context._build_model", return_value="mock-model"),
+        patch("vibe_serve.context.build_agent_runner", return_value=MagicMock()),
+        patch("vibe_serve.context.backends.get", return_value=_FakeBackend(profiler_kind)),
+        pytest.raises(ValueError, match="not supported for domain 'generic'"),
+    ):
+        _RunContext(
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            exp_name=f"generic-{profiler_kind.value}",
+            reference_path=str(ref),
+            profiler_kind=profiler_kind,
+            profiler_domain=DomainName.GENERIC,
+            skills_dirs=[],
+            run_environment=RunEnvironmentSpec("local"),
+            environment_hooks=NoopEnvironmentHooks(),
+        )
+
+
+def test_run_context_llm_auto_uses_backend_profiler_and_defaults_support_dir(tmp_path):
+    project_root = tmp_path / "project"
+    support_paths = _write_support_dirs(project_root)
+    ref = _write_ref(tmp_path)
+
+    with (
+        patch("vibe_serve.context.PROJECT_ROOT", project_root),
+        patch("vibe_serve.context._build_model", return_value="mock-model"),
+        patch("vibe_serve.context.build_agent_runner", return_value=MagicMock()),
+        patch("vibe_serve.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
+        _RunContext(
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            exp_name="llm-auto-nsys",
+            reference_path=str(ref),
+            profiler_kind=ProfilerKind.AUTO,
+            profiler_domain=DomainName.LLM_SERVING,
+            skills_dirs=[],
+            run_environment=RunEnvironmentSpec("local"),
+        ) as ctx,
+    ):
+        assert ctx.profiler_kind is ProfilerKind.NSYS
+        assert ctx.nsys_profiler_path == support_paths[ProfilerKind.NSYS]
+        assert (ctx.workspace / "nsys_profiler" / "server.py").is_file()
+        assert not (ctx.workspace / "torch_profiler").exists()
+        assert not (ctx.workspace / "neuron_profiler").exists()
 
 
 def test_run_context_noop_environment_hooks_do_not_require_model_artifacts(tmp_path):

--- a/tests/test_profilers.py
+++ b/tests/test_profilers.py
@@ -107,9 +107,7 @@ def test_profiler_resolution_invariants(
         assert resolved is ProfilerKind.TORCH
 
 
-@given(
-    value=st.text(min_size=1, max_size=12).filter(lambda text: text not in _PROFILER_VALUES)
-)
+@given(value=st.text(min_size=1, max_size=12).filter(lambda text: text not in _PROFILER_VALUES))
 def test_unknown_profiler_names_raise(value):
     with pytest.raises(ValueError, match="Unknown"):
         coerce_profiler_kind(value)

--- a/tests/test_profilers.py
+++ b/tests/test_profilers.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from vibe_serve.domains.base import DomainName
+from vibe_serve.profilers import (
+    ACTIVE_PROFILER_KINDS,
+    ProfilerKind,
+    allowed_profiler_kinds,
+    coerce_profiler_kind,
+    resolve_profiler_kind,
+)
+
+_DOMAINS = tuple(DomainName)
+_REQUESTED = tuple(ProfilerKind)
+_BACKEND_KINDS = (None, *sorted(ACTIVE_PROFILER_KINDS, key=lambda kind: kind.value))
+_ENVIRONMENT_DEFAULTS = (
+    ProfilerKind.NONE,
+    *sorted(ACTIVE_PROFILER_KINDS, key=lambda kind: kind.value),
+)
+_PROFILER_VALUES = frozenset(kind.value for kind in ProfilerKind)
+
+
+def _expected_resolved(
+    requested: ProfilerKind,
+    *,
+    domain: DomainName,
+    backend_profiler_kind: ProfilerKind | None,
+    environment_default_profiler_kind: ProfilerKind,
+) -> ProfilerKind:
+    allowed = allowed_profiler_kinds(domain)
+    if requested is not ProfilerKind.AUTO:
+        if requested not in allowed:
+            raise ValueError
+        return requested
+    if domain is DomainName.GENERIC:
+        return ProfilerKind.NONE
+    if environment_default_profiler_kind is ProfilerKind.TORCH:
+        return ProfilerKind.TORCH
+    if backend_profiler_kind in ACTIVE_PROFILER_KINDS:
+        return backend_profiler_kind
+    return environment_default_profiler_kind
+
+
+@pytest.mark.parametrize("domain", _DOMAINS)
+@pytest.mark.parametrize("requested", _REQUESTED)
+@pytest.mark.parametrize("backend_profiler_kind", _BACKEND_KINDS)
+@pytest.mark.parametrize("environment_default_profiler_kind", _ENVIRONMENT_DEFAULTS)
+def test_profiler_auto_resolution_exhaustive(
+    domain,
+    requested,
+    backend_profiler_kind,
+    environment_default_profiler_kind,
+):
+    kwargs = dict(
+        domain=domain,
+        backend_profiler_kind=backend_profiler_kind,
+        environment_default_profiler_kind=environment_default_profiler_kind,
+    )
+    try:
+        expected = _expected_resolved(requested, **kwargs)
+    except ValueError:
+        with pytest.raises(ValueError):
+            resolve_profiler_kind(requested, **kwargs)
+    else:
+        assert resolve_profiler_kind(requested, **kwargs) is expected
+
+
+@given(
+    domain=st.sampled_from(_DOMAINS),
+    requested=st.sampled_from(_REQUESTED),
+    backend_profiler_kind=st.sampled_from(_BACKEND_KINDS),
+    environment_default_profiler_kind=st.sampled_from(_ENVIRONMENT_DEFAULTS),
+)
+def test_profiler_resolution_invariants(
+    domain,
+    requested,
+    backend_profiler_kind,
+    environment_default_profiler_kind,
+):
+    kwargs = dict(
+        domain=domain,
+        backend_profiler_kind=backend_profiler_kind,
+        environment_default_profiler_kind=environment_default_profiler_kind,
+    )
+    allowed = allowed_profiler_kinds(domain)
+    if requested is not ProfilerKind.AUTO and requested not in allowed:
+        with pytest.raises(ValueError):
+            resolve_profiler_kind(requested, **kwargs)
+        return
+
+    resolved = resolve_profiler_kind(requested, **kwargs)
+
+    assert resolved is not ProfilerKind.AUTO
+    assert resolved in allowed
+    if domain is DomainName.GENERIC:
+        assert resolved is ProfilerKind.NONE
+    if requested is not ProfilerKind.AUTO:
+        assert resolved is requested
+    if (
+        domain is DomainName.LLM_SERVING
+        and requested is ProfilerKind.AUTO
+        and environment_default_profiler_kind is ProfilerKind.TORCH
+    ):
+        assert resolved is ProfilerKind.TORCH
+
+
+@given(
+    value=st.text(min_size=1, max_size=12).filter(lambda text: text not in _PROFILER_VALUES)
+)
+def test_unknown_profiler_names_raise(value):
+    with pytest.raises(ValueError, match="Unknown"):
+        coerce_profiler_kind(value)
+
+
+@given(
+    backend_profiler_kind=st.text(min_size=1, max_size=12).filter(
+        lambda text: text not in _PROFILER_VALUES
+    )
+)
+def test_resolver_rejects_unparsed_backend_profiler_metadata(backend_profiler_kind):
+    with pytest.raises(TypeError, match="backend profiler"):
+        resolve_profiler_kind(
+            ProfilerKind.AUTO,
+            domain=DomainName.LLM_SERVING,
+            backend_profiler_kind=backend_profiler_kind,
+            environment_default_profiler_kind=ProfilerKind.NSYS,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1596,6 +1596,65 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.156.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/52/22ec531bcc61d55b6858b15c176c9d3284d6447c8618f17e90ca174e8bcf/hypothesis-6.156.4.tar.gz", hash = "sha256:38deb10b31ba18dfdbf9f6803711720148cea5e493a298dfb187c2fe72456791", size = 476287, upload-time = "2026-07-08T21:55:29.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/b2/6ab1506f7540c689916af0ab89c15413656001c991b0da6256b51e54706e/hypothesis-6.156.4-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ba523e6ab93ee51f933ebab5bb62dadfd20762922b93e9f48b31655f1343fbd2", size = 748213, upload-time = "2026-07-08T21:54:01.971Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/d8c44fa442c767d8f2d582da8f5e9efb6719416a1276ed1b61cc70cc7bb8/hypothesis-6.156.4-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:eb225cfab4553913f3bbd535c688ffa684c70432810a0b50555bd8cf70dbdd09", size = 743036, upload-time = "2026-07-08T21:54:55.678Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/68/e99a04ec397f8e9d921249c9fb95c40f3842e889e9de4cbfc5ce77ebee03/hypothesis-6.156.4-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb061eefe1c25a2b3432b2d801f4931510bddc4a6f10c6b23f0c0d8215262bf7", size = 1070425, upload-time = "2026-07-08T21:55:19.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/12/f36f487d2adc08bc0f3159a9083857f1dcfc7f44e76142e56d0f35427202/hypothesis-6.156.4-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3250aa89a3cfacdf601c86d8eafa4a47161e05062afe851a2650d5c6c5fc8a4d", size = 1120438, upload-time = "2026-07-08T21:55:27.882Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d4/e93daa5124d90a43fd2b9ebcbcdd84995b91368c859e4eff4bbf0555bccf/hypothesis-6.156.4-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:60ceff7f4a058eeec032e7ad4e18aeff58860cd5819a88db78b0a49ccce25cc4", size = 1244772, upload-time = "2026-07-08T21:55:03.568Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/48/c77d590fef2888e18abce5de6ba2b022981deb97d175a4e1dffbe35997d1/hypothesis-6.156.4-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7ebada1b9ec964600a68e05a289abd8ee12edde02abc92653783f03346abfa5e", size = 1287496, upload-time = "2026-07-08T21:53:57.7Z" },
+    { url = "https://files.pythonhosted.org/packages/83/18/861ea8097074f99a532439bce6873abfec66d11c4eb727fb2277189afa40/hypothesis-6.156.4-cp310-abi3-win_amd64.whl", hash = "sha256:d0d82e00b61a3866d97cbb43dce54532e352f93bf7f0600b3f1d00a7f24a88f5", size = 640374, upload-time = "2026-07-08T21:54:06.509Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a0/138ac58f597537e531be90cdcc4ef830514bb8fab2756c236c8d37c76730/hypothesis-6.156.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:c6f5e041118701df743c561e22008d1eeecb5305e03291d8a3d3468946a9be5d", size = 749182, upload-time = "2026-07-08T21:53:52.13Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/33/3fb125a988d35464fccc120be644a74e8dcc80e2b532a9413f257c68cc03/hypothesis-6.156.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ce644bf50fc3fec1ca4b993618ece303c7036a3cd833b26b33392a3134dd7070", size = 743700, upload-time = "2026-07-08T21:54:36.016Z" },
+    { url = "https://files.pythonhosted.org/packages/88/08/1ed0e5ec6a8126468345fe4419e6d502025358184bc9428e7f3d772e3b7e/hypothesis-6.156.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77687165ad9fe324112ff098e598b5483c467840f2594feae47ce0e71ba12ff6", size = 1070978, upload-time = "2026-07-08T21:55:05.304Z" },
+    { url = "https://files.pythonhosted.org/packages/24/1a/a45b4288ba88bfa3df02501fe06db505ee7a0e17cc724907be2b6af96996/hypothesis-6.156.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f3ac237d1377e201398d5c81aed0dfca85ecb47538f5df477b27f968123d917", size = 1120668, upload-time = "2026-07-08T21:55:21.627Z" },
+    { url = "https://files.pythonhosted.org/packages/84/50/20265f6419a802ff26c7b6fdb3f1e655d18330695ffb68d7ded976eb65a0/hypothesis-6.156.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c3dd6e9847b738c12d1b9878f7eb6cba5970aec5e30de148aa510c6bdab3d617", size = 1245253, upload-time = "2026-07-08T21:54:29.599Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/57/7cdb87a3d83fbdd1ec38b8fe0c333ba731906b56480544b899af9c2c0e3b/hypothesis-6.156.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:aaa4aa4045e0f7e542af06812feb241af71107b77f73a7e7599d6f70af358f18", size = 1287885, upload-time = "2026-07-08T21:54:34.48Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/b4/a1a6d21b89ce5b5a79b72a9898c61f33816072f0309c6da332bd9a5ebf31/hypothesis-6.156.4-cp311-cp311-win_amd64.whl", hash = "sha256:5b9a53b9c40dff7e6b97d4b0535576c8662dcf42315abc75deb5d190269c574e", size = 640181, upload-time = "2026-07-08T21:54:04.932Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/2f56c1aaa07586897feaac36a07ef68bedca4a410b796e5e0f77ecee0003/hypothesis-6.156.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f6958df0438cf9115fb880afaa9f02fb1ebcbefc763c4c374737ad4ca3f11cae", size = 749016, upload-time = "2026-07-08T21:54:23.132Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/d6b77e95a2cf5b572805491c53cb2c45eec0e7dff65c2310457d6537ad0f/hypothesis-6.156.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ad091a3110fd5c4731251068c049a48fb33a9ef01f5901b88a81c68ab70c943b", size = 741911, upload-time = "2026-07-08T21:55:25.836Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d3/229fdb1dac8dc1c103f95f3d128df3c63c07630778178cf42fbb2dd7376b/hypothesis-6.156.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15de4176d0365c9855898f75cf2986be6f361643c08f0d1bc154a89779a9cb89", size = 1069810, upload-time = "2026-07-08T21:54:57.762Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e1/03be6105682766e090cc6355f09fd461dfb473d952f8f07c2dff3d0fd74e/hypothesis-6.156.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19b70642500369f70743321e03359d2504e5f4d62cfd0046054867f79965d8bb", size = 1119552, upload-time = "2026-07-08T21:54:28.114Z" },
+    { url = "https://files.pythonhosted.org/packages/88/3e/80ad5a0db03e7f07b07c8b1064cdf169695f09f68a3c62b03ae68e687c79/hypothesis-6.156.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7b7232c9ea9f947b6b5b1c317ac9ce988af2fbb076fa5a4836ff8e1d20f1b176", size = 1243862, upload-time = "2026-07-08T21:54:52.276Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/4c/af9661cabb126b8432c43996c925f8c4d174745d61616c8f00e7b6cc08ea/hypothesis-6.156.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bedc54bb398eaf54b9e1d88744c89b559fc8bf165c3e603f821cc53754ade241", size = 1286422, upload-time = "2026-07-08T21:54:39.323Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a8/c9c8e506122cb6cfc634b07ab0d7e8db7d5d51e27d9b937e20d61e1a272e/hypothesis-6.156.4-cp312-cp312-win_amd64.whl", hash = "sha256:b4217076cb7169fc17c32b06206c4503ad71d740eed0b3c20023a11f04418179", size = 637645, upload-time = "2026-07-08T21:54:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4a/a4e797af1ba0cf8cddba7e460294bd25a2d6efc33db898efb288edc993a1/hypothesis-6.156.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:2c799aee207d5ecf5af2fbf86250806245618e58cdb41c4606718a9ed001c706", size = 749445, upload-time = "2026-07-08T21:55:01.697Z" },
+    { url = "https://files.pythonhosted.org/packages/62/02/6c66c992b02aee085b644d0400a75e086ce17c47ff83d7a2e1f48d657d57/hypothesis-6.156.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7af68750ed3ebcf32540e32fe111850fc40e9ba15be2613ef7f04620c51669c", size = 742079, upload-time = "2026-07-08T21:54:43.87Z" },
+    { url = "https://files.pythonhosted.org/packages/79/04/be90e612f4b6e75752f0420d3945893ed0f71a04485867a7ad9c376f161e/hypothesis-6.156.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32e4c6988898e9e21c97f48b941cf1e10a5ea4f31db82e5722c1bf777d17c3dc", size = 1069972, upload-time = "2026-07-08T21:55:13.584Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/71/6e74917b591c56402f726f4c08bd819d586ea20857a029549541c3808330/hypothesis-6.156.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07f7207655919eedda6d888ca6cfcf83eeedff3fc34fc6a83aabe197fed4966b", size = 1119967, upload-time = "2026-07-08T21:54:14.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e7/4619e6acdd4eca4b58dd69b036c61a60714741197be4ca7d3eda6ef616e4/hypothesis-6.156.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1db6caf5718eb90dad5d86254961bf2eda319542e9e0479c562327f649c2115b", size = 1244027, upload-time = "2026-07-08T21:54:42.371Z" },
+    { url = "https://files.pythonhosted.org/packages/30/76/3e7b788502e0c9a5ef6830e63e63ae2b3001f213e6ea5313fde75d4bdadb/hypothesis-6.156.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5afdcd0f320dc4b443c51722860a893dcf03a12e5cd17e68143b28461a1c9da2", size = 1286704, upload-time = "2026-07-08T21:55:23.543Z" },
+    { url = "https://files.pythonhosted.org/packages/72/97/46893ce86e106e00bd8224dc85bd6439c1bd24cf513f73e4719926bd8053/hypothesis-6.156.4-cp313-cp313-win_amd64.whl", hash = "sha256:32f63111e79020e530913673c2ef91642fc297ae552364acde00f70d50142b9a", size = 637938, upload-time = "2026-07-08T21:54:03.307Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ea/f2c4313475f54b55eb160e09fe139b520c1ea77ece9e05a24c8094261e89/hypothesis-6.156.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:a946f12823c004bc02d7cbdc9c2eb1943cb9c7f05c95f014e353d53e9c50ab14", size = 749476, upload-time = "2026-07-08T21:54:40.827Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8b/c364bd4a3504e9c7d895552aa69e4453fa3c2dfa63a4fdf37f97f539b457/hypothesis-6.156.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bedff9adcf0ad5fd8ce4d6ea5dda29ae316b0856beef4236460020a55ed30020", size = 742306, upload-time = "2026-07-08T21:54:21.53Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/53/1e05b2ffed333628656b5e1cee65f5a8dcca259c5be9221c0817dad74f14/hypothesis-6.156.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19aaa6c1f6a1d11b40e97ac62a58b5f2e4481e8c8b1ef132b582dd61dcc0e5b4", size = 1070146, upload-time = "2026-07-08T21:54:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/25c4fd4641497c4f2680ba8d8300c7e8d9c5c8bafea219f597580e587508/hypothesis-6.156.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d058917bdc3c7e575461ba81128d018819061a0291961cf4c90c0c8ed8c21436", size = 1120131, upload-time = "2026-07-08T21:53:55.874Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/18/d59e50d48bfb6697980fc0ff02e3fc1e32a71a4d549a1939be7d90d4b057/hypothesis-6.156.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bbb5ea5be2f9ee115332a896eb45ab4018aee13a702a4562a29947d7206ef65d", size = 1244302, upload-time = "2026-07-08T21:55:15.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/c2/60666d23338fb4e33ff28e87f0579dd16cd99cfe5972448b1b79ec1b96e3/hypothesis-6.156.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ce314d1dff756be7b0173ab8c72697bbe4c831ed765b8ef6b1aeb0a7056da42", size = 1287215, upload-time = "2026-07-08T21:54:17.549Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/39/24410320c5bddf58d72e3c61da91b56f889279d52dc38a3695662f22255b/hypothesis-6.156.4-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:139b9306e84b8c25c0aef9eec67e096f92fa6557a6088e56e58bdcbd7974f0c4", size = 586424, upload-time = "2026-07-08T21:54:45.356Z" },
+    { url = "https://files.pythonhosted.org/packages/83/9a/e1cf9393b3686ceb23b87d8f7f4c5c3e1f4751b974642439e99b70bb0272/hypothesis-6.156.4-cp314-cp314-win_amd64.whl", hash = "sha256:e65d36b2cfb863a15ab3fd81d5de741df9b51f2b56c5f7ecee637b8e9333938d", size = 637751, upload-time = "2026-07-08T21:54:24.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3f/25fa799861ed2c1e32c9064d02ad3090e0f282f2a1efed98d744a4be6970/hypothesis-6.156.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:454b2ea256feda13edd8c9514f2898a949e4f96b0156c67a852cbfe1f777055a", size = 747509, upload-time = "2026-07-08T21:54:11.308Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ac/a2ec42a5fc0789c6a953c98ee299afd0c6fe80a16c0836e3285697614d0e/hypothesis-6.156.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8db65e17fb1e6dcaf34d4ad69a104d1437409e58178fc752b6344394d0a35f71", size = 740865, upload-time = "2026-07-08T21:54:19.761Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/df/e87653a9a1de9fb838237b7f6b22a76cfa52cb21ba4b98622f2b25c00bac/hypothesis-6.156.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44af150302f88aec7f0b90566c0f27edb847f0d23cbe729fe75cfe582089366e", size = 1069164, upload-time = "2026-07-08T21:54:08.121Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/bf1d6d4e783d163434ec3a5a692588f8deee772538de6cb9cd52417c543e/hypothesis-6.156.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f7707302553bddf84826a44821055b2ddf460c9199a92bd60f0da8b39b42872", size = 1119203, upload-time = "2026-07-08T21:53:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/b7802b9db8fa6d2caefb143e9a8fe47145ba9ce74e276eb6abd2fd0b0b8c/hypothesis-6.156.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:618e7edf24c9b1d932f0ba835ee5f8571a197143bbaf5467a5c8f180f96494ee", size = 1243073, upload-time = "2026-07-08T21:55:11.703Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/90/70c5605c35c72dddf2be50e88d017e9139ae68e1ac7aaf29dc90732fa8e5/hypothesis-6.156.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ff172915bafafc827981f3bab3bd076ad96e05d108c43a19373ccf3be085c727", size = 1285526, upload-time = "2026-07-08T21:55:07.271Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/43/a4f1b41e410d8bfe78f17eeaac08cee4e326b341345009802e073d20af71/hypothesis-6.156.4-cp314-cp314t-win_amd64.whl", hash = "sha256:0725c7e2c3bd863e75aae8d5be1f650abc9a3774200055461e1142625af9419c", size = 637843, upload-time = "2026-07-08T21:54:12.858Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ac/c5495b2c4070f80665660cfbc8ee81a1bc3e254565f41d66ecd5c3a4724c/hypothesis-6.156.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:6f3bef67bd9ddce33ee9017f05a3670eac2518f27f80a9ab3112ac4d7772f293", size = 749728, upload-time = "2026-07-08T21:54:31.273Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/58/f46decb99415e08d80d915235899cc7e8ba02ee7f9effebc93fcdcd5315b/hypothesis-6.156.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:0ca6a4785c058257a729daa218d9c9d06d05db42da4f52484c590f57f7905d5b", size = 744371, upload-time = "2026-07-08T21:54:50.653Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ec/c8c19542f6389580e6281f87802849754b8910d29e0a7e36e32ac4e18811/hypothesis-6.156.4-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7338ee15ee84ef994ae3d1a2e71d25c82713bf5ec27f55442755ae15e38369b", size = 1071376, upload-time = "2026-07-08T21:54:54.003Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/10/57cc273baf0cfe722eaa903c72db7ca45e7df4cc0780f80cb5dfe50edbbf/hypothesis-6.156.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:539be6819696560c23ff6c0d0af4e7c1ea4936123f4433b511977a79adc371d5", size = 1121429, upload-time = "2026-07-08T21:55:17.323Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/4b31c31716980972f7b5dfd75fe11021e9b8b6dd09664cc5a82c8c03c2bc/hypothesis-6.156.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b1717bc41d1a0683470f950c565ade33a52c28f600b1aa824d74f651a36e2c7b", size = 640761, upload-time = "2026-07-08T21:54:37.716Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -4098,6 +4157,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "soundfile"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4564,12 +4632,14 @@ dependencies = [
 dev = [
     { name = "chardet" },
     { name = "diff-cover" },
+    { name = "hypothesis" },
     { name = "matplotlib" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
 test = [
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
@@ -4600,12 +4670,14 @@ requires-dist = [
 dev = [
     { name = "chardet", specifier = "<6" },
     { name = "diff-cover" },
+    { name = "hypothesis" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff", specifier = ">=0.6" },
 ]
 test = [
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]


### PR DESCRIPTION
## Summary
- Add a `ProfilerKind` enum and domain-aware profiler resolution policy.
- Make argparse parse `--profiler` and `--domain` directly into enums, rejecting invalid input at parse time.
- Add `--profiler none`, prevent generic workloads from auto-selecting nsys, and skip profiler phases when disabled or when `need_profile` is false.
- Make profiler MCP selection exact instead of falling back to nsys for unknown kinds.
- Add exhaustive and Hypothesis-backed tests for profiler resolution invariants plus coverage for context wiring, MCP mapping, CLI parsing, loop scheduling, prompts, and backend defaults.

## Why
Generic CPU targets like queue optimization should not bundle or invoke nsys by default. Profiler behavior is now explicit, enum-backed, and domain-aware.

## Validation
- `uv run pytest tests/test_cli.py tests/test_profilers.py tests/test_context.py tests/loops/test_profiler_mcp.py tests/loops/agent/test_orchestrate.py tests/loops/agent/test_interface_modes.py tests/loops/agent/test_domain_packs.py tests/loops/agent/test_prompt_domain_leakage.py tests/loops/agent/test_prompt_snapshots.py tests/backends/test_cpu_backend.py tests/backends/test_metal_backend.py tests/backends/test_trainium_backend.py`
- `uv run ruff check src/vibe_serve/profilers.py src/vibe_serve/domains/registry.py src/vibe_serve/context.py src/vibe_serve/cli.py src/vibe_serve/loops/profiler.py src/vibe_serve/loops/agent/loop.py src/vibe_serve/loops/evolve/loop.py src/vibe_serve/loops/openevolve/loop.py src/vibe_serve/loops/plain/loop.py tests/test_profilers.py tests/test_context.py tests/loops/test_profiler_mcp.py tests/loops/agent/test_orchestrate.py tests/loops/agent/test_interface_modes.py tests/loops/agent/test_domain_packs.py tests/loops/agent/test_prompt_domain_leakage.py tests/loops/agent/test_prompt_snapshots.py tests/test_cli.py tests/backends/test_cpu_backend.py tests/backends/test_metal_backend.py tests/backends/test_trainium_backend.py`
- `git diff --check`
