### PR TITLE
Add pull request guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Problem
+
+<!--
+Motivate the change. Explain why we are doing this in the first place, what
+user or maintainer pain it addresses, and link any relevant issues.
+-->
+
+## Solution
+
+<!--
+Describe the high-level design. Call out important implementation choices,
+tradeoffs, boundaries, and any behavior that reviewers should inspect closely.
+-->
+
+## Verification
+
+<!--
+Summarize how you checked the change. Include automated tests, manual checks,
+benchmarks, or reasons a particular check was not run.
+-->
+
+### Correctness properties
+
+<!--
+List the invariants, contracts, or expected behaviors this PR preserves or
+introduces, especially for user-facing behavior and shared interfaces.
+-->
+
+### Testing
+
+<!--
+List the exact commands or workflows run, plus the relevant result.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@ Read [`docs/coding-best-practices.md`](docs/coding-best-practices.md) before
 editing code in this repository. It documents the repo-specific expectations
 for what good code looks like.
 
+When preparing a pull request, use the repository PR template at
+[`.github/pull_request_template.md`](.github/pull_request_template.md). Fill in
+the `Problem`, `Solution`, and `Verification` sections, including correctness
+properties and testing details where relevant.
+
 Keep changes narrowly scoped to the requested behavior, preserve existing
 architecture boundaries, and run the smallest relevant checks before handing
 work back.


### PR DESCRIPTION
## Problem

The repository did not provide a standard PR description format, so contributors and agents had no shared structure for explaining motivation, design, and verification.

## Solution

Add a GitHub pull request template with `Problem`, `Solution`, and `Verification` sections, including prompts for correctness properties and testing. Link that template from `AGENTS.md` so agent workflows discover and follow it.

## Verification

Docs/template-only change; no test suite run.

### Correctness properties

- Future GitHub PRs surface the template automatically.
- `AGENTS.md` points agents at the same template and names the expected sections.

### Testing

- Reviewed the staged diff before committing.
- Confirmed the branch is based on the latest `origin/main` before opening this PR.
