### PR TITLE
Complete issue #76: generic example directory support

### DIFF
--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -160,7 +160,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--profiler",
-        choices=["nsys", "torch", "neuron", "auto"],
+        choices=["nsys", "torch", "neuron", "none", "auto"],
         default="auto",
         help=(
             "Which profiler to use between rounds. "
@@ -577,7 +577,16 @@ def _load_objectives_toml(reference_path: str) -> list:
 def _resolve_objectives(args: argparse.Namespace) -> list:
     if args.objective:
         return list(args.objective)
-    return _load_objectives_toml(args.ref)
+    from_toml = _load_objectives_toml(args.ref)
+    if from_toml:
+        return from_toml
+    from vibe_serve.example_manifest import ExampleManifest
+
+    ref = Path(args.ref).expanduser().resolve()
+    manifest = ExampleManifest.detect(ref)
+    if manifest is not None:
+        return [manifest.to_objective()]
+    return []
 
 
 def _build_evolve_parser() -> argparse.ArgumentParser:
@@ -881,8 +890,33 @@ _RUNNERS = {
 }
 
 
+def _expand_example_flag(argv: list[str]) -> list[str]:
+    """Expand ``--example <dir>`` into --ref/--acc-checker/--bench (issue #76).
+
+    Pure sugar: fills in only the flags the user didn't already pass
+    explicitly, following the ``examples/<name>/{reference,accuracy_checker,
+    benchmark}`` convention. Detection of generic-vs-legacy example
+    behavior itself happens later, in _RunContext, based on whether
+    vibeserve.example.toml is present next to --ref -- not based on
+    whether --example was used to construct these paths.
+    """
+    example_dir, rest = _extract_flag(argv, "--example")
+    if example_dir is None:
+        return argv
+    example_path = Path(example_dir)
+    additions: list[str] = []
+    if "--ref" not in rest and not any(t.startswith("--ref=") for t in rest):
+        additions += ["--ref", str(example_path / "reference")]
+    if "--acc-checker" not in rest and not any(t.startswith("--acc-checker=") for t in rest):
+        additions += ["--acc-checker", str(example_path / "accuracy_checker")]
+    if "--bench" not in rest and not any(t.startswith("--bench=") for t in rest):
+        additions += ["--bench", str(example_path / "benchmark")]
+    return rest + additions
+
+
 def main() -> None:
-    loop_kind, remaining = _extract_loop_selection(sys.argv[1:])
+    argv = _expand_example_flag(sys.argv[1:])
+    loop_kind, remaining = _extract_loop_selection(argv)
     args = _PARSER_BUILDERS[loop_kind]().parse_args(remaining)
     # Resolve validator + runner via globals() so unittest.mock.patch on
     # ``vibe_serve.cli._{validate,run}_<kind>`` takes effect.

--- a/src/vibe_serve/context.py
+++ b/src/vibe_serve/context.py
@@ -22,6 +22,7 @@ from vibe_serve.constants import (
     PROJECT_ROOT,
     ComputeBackend,
 )
+from vibe_serve.example_manifest import ExampleManifest
 from vibe_serve.llm_client import _build_model
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentRequest,
@@ -207,17 +208,76 @@ class _RunContext:
         self.torch_profiler_path = self._coerce_dir_path(torch_profiler, "--torch-profiler")
         self.neuron_profiler_path = self._coerce_dir_path(neuron_profiler, "--neuron-profiler")
 
+        ref_path = Path(reference_path).expanduser()
+        if not ref_path.is_absolute():
+            ref_path = ref_path.resolve()
+
+        ref_dir: Path | None = None
+        ref_script: Path | None = None
+        self.example_manifest: ExampleManifest | None = None
+
+        if not ref_path.exists():
+            # Externally-managed targets (issue #76 Docker-in-Docker
+            # Alternative C, e.g. train-ticket) have no reference/ directory
+            # at all. Try treating ref_path's parent as the example dir
+            # before failing outright -- ref_path itself is the conventional
+            # "would-be reference dir" name even though nothing is materialized there.
+            fallback_manifest = ExampleManifest.detect_from_example_dir(ref_path.parent)
+            if fallback_manifest is not None and fallback_manifest.workspace.externally_managed:
+                self.example_manifest = fallback_manifest
+                self.ref_name = "reference/ (externally managed, no local copy)"
+            else:
+                raise ValueError(f"Reference path does not exist: {reference_path}")
+        elif ref_path.is_dir():
+            self.example_manifest = ExampleManifest.detect(ref_path)
+
+        if self.example_manifest is not None and ref_path.exists():
+            ref_dir = ref_path
+            self.ref_name = "reference/"
+        elif self.example_manifest is not None:
+            pass
+        elif ref_path.is_file():
+            ref_script = ref_path
+            self.ref_name = ref_script.name
+        elif ref_path.is_dir():
+            reference_py = sorted(ref_path.glob("*.py"))
+            if not reference_py:
+                raise ValueError(f"No reference Python script found in directory: {reference_path}")
+            if len(reference_py) != 1:
+                raise ValueError(
+                    f"Expected one reference Python script in {reference_path}, found {len(reference_py)}"
+                )
+            ref_script = reference_py[0]
+            ref_dir = ref_path
+            self.ref_name = f"reference/{ref_script.name}"
+        else:
+            raise ValueError(f"Reference path is invalid: {reference_path}")
+
+        self.target_check_instructions: str | None = (
+            self.example_manifest.render_check_instructions()
+            if self.example_manifest is not None
+            else None
+        )
+        self.target_bench_instructions: str | None = (
+            self.example_manifest.render_bench_instructions()
+            if self.example_manifest is not None
+            else None
+        )
+
         # Resolve profiler kind: 'auto' → the compute backend's own profiler
         # when it dictates one (e.g. Trainium → neuron-explorer), else the run
         # environment's default (modal → torch, otherwise nsys).
         resolved_profiler = profiler_kind
         if resolved_profiler == "auto":
-            backend_profiler = getattr(self.backend_impl, "profiler_kind", None)
-            if backend_profiler == "neuron":
-                resolved_profiler = "neuron"
+            if self.example_manifest is not None:
+                resolved_profiler = self.example_manifest.profiler.kind
             else:
-                resolved_profiler = self.run_environment.default_profiler_kind
-        if resolved_profiler not in ("nsys", "torch", "neuron"):
+                backend_profiler = getattr(self.backend_impl, "profiler_kind", None)
+                if backend_profiler == "neuron":
+                    resolved_profiler = "neuron"
+                else:
+                    resolved_profiler = self.run_environment.default_profiler_kind
+        if resolved_profiler not in ("nsys", "torch", "neuron", "none"):
             raise ValueError(f"Unknown profiler kind: {profiler_kind!r}")
         self.profiler_kind = resolved_profiler
 
@@ -236,28 +296,6 @@ class _RunContext:
 
         skill_source_paths = self._coerce_skills_dirs(skills_dirs)
         self._skill_source_paths: list[Path] = skill_source_paths
-
-        ref_path = Path(reference_path).expanduser().resolve()
-        if not ref_path.exists():
-            raise ValueError(f"Reference path does not exist: {reference_path}")
-
-        ref_dir: Path | None = None
-        if ref_path.is_file():
-            ref_script = ref_path
-            self.ref_name = ref_script.name
-        elif ref_path.is_dir():
-            reference_py = sorted(ref_path.glob("*.py"))
-            if not reference_py:
-                raise ValueError(f"No reference Python script found in directory: {reference_path}")
-            if len(reference_py) != 1:
-                raise ValueError(
-                    f"Expected one reference Python script in {reference_path}, found {len(reference_py)}"
-                )
-            ref_script = reference_py[0]
-            ref_dir = ref_path
-            self.ref_name = f"reference/{ref_script.name}"
-        else:
-            raise ValueError(f"Reference path is invalid: {reference_path}")
 
         self.workspace = self.exp_dir / "workspace"
         self.workspace.mkdir(parents=True, exist_ok=True)
@@ -306,15 +344,28 @@ class _RunContext:
                     shutil.rmtree(d)
 
             if ref_dir is not None:
+                needs_weights = (
+                    self.example_manifest is None
+                    or self.example_manifest.workspace.requires_model_weights
+                )
                 # Modal handles model weights via a remote Volume, so we
                 # skip the local HF download (saves ~30 GB of local cache).
                 # We still fall back to the local path if meta.json is absent.
-                if (
+                if needs_weights and (
                     self.run_environment.materialize_local_model_weights
                     or (ref_dir / "meta.json").exists() is False
                 ):
                     _ensure_model_weights(ref_dir)
                 self._copy_excluding_extras(ref_dir, self.workspace / "reference")
+
+                if self.example_manifest is not None:
+                    # Generic examples keep setup.sh/build.sh/check.sh/bench.sh/
+                    # teardown.sh at the example root (sibling to reference/),
+                    # not inside reference/ itself -- copy that root separately
+                    # so the lifecycle scripts actually land in the sandbox.
+                    self._copy_excluding_extras(
+                        self.example_manifest.example_dir, self.workspace / "example"
+                    )
             else:
                 if (self.workspace / ref_script.name).exists():
                     (self.workspace / ref_script.name).unlink()
@@ -377,6 +428,7 @@ class _RunContext:
                     neuron_profiler_path=self.neuron_profiler_path,
                     log=self.lprint,
                     project_root=PROJECT_ROOT,
+                    example_manifest=self.example_manifest,
                 )
             )
         )

--- a/src/vibe_serve/example_manifest.py
+++ b/src/vibe_serve/example_manifest.py
@@ -1,0 +1,212 @@
+"""Generic example directory manifest (vibeserve.example.toml).
+
+Loaded when an example directory contains ``vibeserve.example.toml``
+sibling to ``OBJECTIVE.md`` (i.e. at ``ref.parent``). Presence of this
+file switches ``_RunContext`` from the legacy Python/model-serving
+directory contract (a single ``reference.py`` plus ``checker.py`` /
+``benchmark.py``) to the generic script contract described in issue #76:
+``setup.sh`` / ``build.sh`` / ``check.sh`` / ``bench.sh`` / ``teardown.sh``
+at the example root.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+_LIFECYCLE_SCRIPTS = ("setup.sh", "build.sh", "check.sh", "bench.sh", "teardown.sh")
+_REQUIRED_SCRIPTS = ("check.sh", "bench.sh")
+_OPTIONAL_SCRIPTS = ("setup.sh", "build.sh", "teardown.sh")
+
+
+class WorkspaceSpec(BaseModel):
+    candidate_path: str | None = None
+    requires_model_weights: bool = False
+    externally_managed: bool = False
+
+
+class SetupSpec(BaseModel):
+    needs_docker_socket: bool = False
+    timeout_sec: int = 300
+
+
+class ServiceSpec(BaseModel):
+    base_url: str | None = None
+    health_check: str | None = None
+    readiness_timeout_sec: int = 60
+
+    @field_validator("health_check")
+    @classmethod
+    def _validate_health_check(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        parts = v.split(maxsplit=1)
+        if len(parts) != 2 or parts[0].upper() not in ("GET", "POST", "HEAD"):
+            raise ValueError(
+                f"service.health_check must be 'METHOD path', e.g. 'GET /health'. Got: {v!r}"
+            )
+        return v
+
+
+class BenchmarkSpec(BaseModel):
+    primary_metric: str
+    direction: Literal["minimize", "maximize"]
+    metrics_format: Literal["jsonl"] = "jsonl"
+
+
+class ProfilerSpec(BaseModel):
+    kind: Literal["none", "torch", "nsys", "neuron"] = "none"
+
+
+class ExampleManifest(BaseModel):
+    workspace: WorkspaceSpec = Field(default_factory=WorkspaceSpec)
+    setup: SetupSpec = Field(default_factory=SetupSpec)
+    service: ServiceSpec = Field(default_factory=ServiceSpec)
+    benchmark: BenchmarkSpec
+    profiler: ProfilerSpec = Field(default_factory=ProfilerSpec)
+
+    example_dir: Path = Field(exclude=True)
+
+    @classmethod
+    def load(cls, example_dir: Path) -> ExampleManifest:
+        manifest_path = example_dir / "vibeserve.example.toml"
+        if not manifest_path.is_file():
+            raise FileNotFoundError(f"No vibeserve.example.toml at {manifest_path}")
+        data = tomllib.loads(manifest_path.read_text())
+        return cls(**data, example_dir=example_dir)
+
+    @classmethod
+    def detect(cls, ref_path: Path) -> ExampleManifest | None:
+        """Return the manifest for *ref_path*'s example dir, or None if absent.
+
+        *ref_path* is the resolved ``--ref`` path (typically
+        ``examples/<name>/reference``). The manifest lives at
+        ``ref_path.parent / "vibeserve.example.toml"``, the same
+        location ``OBJECTIVE.md`` and ``objectives.toml`` already use.
+
+        Also handles externally-managed targets (issue #76 Docker-in-Docker
+        Alternative C: e.g. train-ticket) that have no ``reference/``
+        directory at all -- *ref_path* itself may not exist on disk. In that
+        case *ref_path* is treated as the would-be example directory name and
+        the manifest is looked up directly at
+        ``ref_path.parent / "vibeserve.example.toml"`` without requiring
+        ``ref_path`` to exist.
+        """
+        example_dir = ref_path.parent
+        manifest_path = example_dir / "vibeserve.example.toml"
+        if not manifest_path.is_file():
+            return None
+        return cls.load(example_dir)
+
+    @classmethod
+    def detect_from_example_dir(cls, example_dir: Path) -> ExampleManifest | None:
+        """Same as :meth:`detect` but takes the example directory itself.
+
+        For externally-managed targets where there is no conventional
+        ``--ref`` subdirectory (``reference/``) at all -- the manifest sits
+        directly in the example root passed as ``--ref``.
+        """
+        manifest_path = example_dir / "vibeserve.example.toml"
+        if not manifest_path.is_file():
+            return None
+        return cls.load(example_dir)
+
+    def script_path(self, name: str) -> Path:
+        if name not in _LIFECYCLE_SCRIPTS:
+            raise ValueError(
+                f"Unknown lifecycle script {name!r}; expected one of {_LIFECYCLE_SCRIPTS}"
+            )
+        return self.example_dir / name
+
+    def has_script(self, name: str) -> bool:
+        return self.script_path(name).is_file()
+
+    def require_script(self, name: str) -> Path:
+        path = self.script_path(name)
+        if not path.is_file():
+            raise FileNotFoundError(
+                f"{name} is required at {path} (example directory contract: "
+                f"check.sh and bench.sh are mandatory; setup.sh/build.sh/teardown.sh are optional)"
+            )
+        return path
+
+    def env(
+        self,
+        *,
+        base_url: str | None = None,
+        output_dir: str | None = None,
+        load_level: str = "medium",
+    ) -> dict[str, str]:
+        """Standard env vars passed to every lifecycle script (issue #76)."""
+        resolved_base_url = base_url or self.service.base_url or ""
+        out: dict[str, str] = {
+            "VIBESERVE_BASE_URL": resolved_base_url,
+            "VIBESERVE_LOAD_LEVEL": load_level,
+        }
+        if output_dir is not None:
+            out["VIBESERVE_OUTPUT_DIR"] = output_dir
+        return out
+
+    def to_objective(self):
+        """Adapt benchmark.{primary_metric,direction} to loops.evolve.population.Objective.
+
+        The manifest's vocabulary ("minimize"/"maximize", per issue #76's
+        literal proposal) differs from Objective's ("min"/"max"); this is
+        the single translation point.
+        """
+        from vibe_serve.loops.evolve.population import Objective
+
+        direction_map = {"minimize": "min", "maximize": "max"}
+        return Objective(
+            name=self.benchmark.primary_metric,
+            direction=direction_map[self.benchmark.direction],
+        )
+
+    def render_check_instructions(self) -> str:
+        return (
+            f"Run `bash check.sh` from the example root ({self.example_dir}). "
+            "Exit code 0 means all correctness checks passed; nonzero means at "
+            "least one failed. Inspect stdout/stderr for details on any failure."
+        )
+
+    def render_bench_instructions(self) -> str:
+        return (
+            f"Run `bash bench.sh` from the example root ({self.example_dir}). "
+            f"It prints one JSON object per line in the form "
+            f'{{"metric": "<name>", "value": <number>}}. The metric VibeServe '
+            f"is optimizing is `{self.benchmark.primary_metric}` "
+            f"({self.benchmark.direction} is better)."
+        )
+
+    def parse_metrics(self, text: str) -> dict[str, float]:
+        """Parse bench.sh output into ``{metric_name: value}`` (issue #76).
+
+        The declared ``benchmark.metrics_format`` is ``jsonl``: one JSON
+        object per line of the form ``{"metric": "<name>", "value": <num>}``.
+        Lines that are blank, not JSON, not an object, or missing a string
+        ``metric`` / numeric ``value`` are ignored, so bench.sh may freely
+        interleave human-readable logging with metric lines. On duplicate
+        metric names the last value wins.
+        """
+        metrics: dict[str, float] = {}
+        for raw in text.splitlines():
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(obj, dict) and isinstance(obj.get("metric"), str):
+                value = obj.get("value")
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    metrics[obj["metric"]] = float(value)
+        return metrics
+
+    def primary_metric_value(self, text: str) -> float | None:
+        """Return the declared ``primary_metric`` value from bench.sh output, or None."""
+        return self.parse_metrics(text).get(self.benchmark.primary_metric)

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -22,7 +22,7 @@ from vibe_serve.loops.agent.domain import (
     render_domain_section,
     resolve_domain,
 )
-from vibe_serve.loops.profiler import invoke_profiler
+from vibe_serve.loops.profiler import invoke_profiler, run_example_benchmark
 from vibe_serve.prompts import render_template
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentSpec,
@@ -259,6 +259,16 @@ def _run_profiler(
     progress_path: Path,
     objective: str,
 ) -> ProfilerSummary | None:
+    if ctx.example_manifest is not None:
+        summary = run_example_benchmark(ctx, round_label=f"round-{round_number}")
+        if summary is not None:
+            issue_board.append_profiler_summary(progress_path, round_number, summary)
+            ctx.snapshot_workspace(f"round-{round_number}-profiler")
+        return summary
+    if ctx.profiler_kind == "none":
+        ctx.lprint(f"[round-{round_number}] profiler_kind=none (no GPU profiler); skipping.")
+        return None
+
     template = {
         "torch": "profiler_prompt_torch.j2",
         "neuron": "profiler_prompt_neuron.j2",
@@ -272,6 +282,8 @@ def _run_profiler(
         runtime_notes=ctx.run_environment_view.prompt_notes,
         env_kind=ctx.run_environment_view.env_kind,
         objective=objective,
+        is_generic_example=ctx.example_manifest is not None,
+        target_bench_instructions=ctx.target_bench_instructions,
     )
     summary = invoke_profiler(
         ctx,
@@ -375,6 +387,9 @@ def _run_implementer(
         feedback=feedback,
         runtime_notes=ctx.run_environment_view.prompt_notes,
         env_kind=ctx.run_environment_view.env_kind,
+        is_generic_example=ctx.example_manifest is not None,
+        target_check_instructions=ctx.target_check_instructions,
+        target_bench_instructions=ctx.target_bench_instructions,
     )
     response = ctx.invoke(
         kind="implementer",
@@ -420,6 +435,9 @@ def _run_judge(
         runtime_notes=ctx.run_environment_view.prompt_notes,
         env_kind=ctx.run_environment_view.env_kind,
         objective=objective,
+        is_generic_example=ctx.example_manifest is not None,
+        target_check_instructions=ctx.target_check_instructions,
+        target_bench_instructions=ctx.target_bench_instructions,
     )
     response = ctx.invoke(
         kind="judge",

--- a/src/vibe_serve/loops/agent/templates/implementer_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/implementer_prompt.j2
@@ -1,5 +1,26 @@
 {% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
+{% if is_generic_example %}
+## Target (generic example, issue #76)
+
+This is not a Python/model-serving target. Do not write a `main.py` with a
+`VibeServeModel` class or any Python model-serving interface — none of that
+applies here.
+
+Your candidate lives under `reference/` in the workspace (the example's
+manifest may designate a specific writable subpath there; check
+`reference/vibeserve.example.toml` if present, or ask the orchestrator's
+task description, for which subpath you're expected to edit). The example
+root (sibling to `reference/`) has `setup.sh` / `build.sh` (if present) to
+bring the target up, and:
+
+{{ target_bench_instructions }}
+
+Test your changes by running `bash example/build.sh` (if present) then
+`bash example/setup.sh` (idempotent — safe to re-run) from the workspace
+root, before declaring the round done.
+{% else %}
 {% include "_modality/" ~ modality ~ "/implementer.j2" %}
+{% endif %}
 
 {% if runtime_notes %}
 ## Runtime environment

--- a/src/vibe_serve/loops/agent/templates/judge_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/judge_prompt.j2
@@ -17,7 +17,21 @@ You are a senior code reviewer evaluating the candidate implementation.
 {{ runtime_notes }}
 {% endif %}
 
+{% if is_generic_example %}
+## Correctness checking (generic example, issue #76)
+
+This example is not a Python/model-serving target — it uses the generic
+example-directory contract instead of `main.py` / `VibeServeModel`.
+
+{{ target_check_instructions }}
+
+Do not look for or expect a `VibeServeModel` class, `main.py`, `/health`
+endpoint, or any Python model-serving interface. Judge correctness purely
+by `check.sh`'s exit code and output, and by whether the implementer's
+changes match the orchestrator's `pass_criteria` above.
+{% else %}
 {% include "_modality/" ~ modality ~ "/judge.j2" %}
+{% endif %}
 
 {% if domain_judge %}
 {{ domain_judge }}

--- a/src/vibe_serve/loops/evolve/loop.py
+++ b/src/vibe_serve/loops/evolve/loop.py
@@ -41,7 +41,7 @@ from vibe_serve.loops.evolve.population import (
     Objective,
     Population,
 )
-from vibe_serve.loops.profiler import invoke_profiler
+from vibe_serve.loops.profiler import invoke_profiler, run_example_benchmark
 from vibe_serve.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
@@ -143,6 +143,9 @@ def _run_mutator(
         objectives=objectives,
         runtime_notes=ctx.run_environment_view.prompt_notes,
         env_kind=ctx.run_environment_view.env_kind,
+        is_generic_example=ctx.example_manifest is not None,
+        target_check_instructions=ctx.target_check_instructions,
+        target_bench_instructions=ctx.target_bench_instructions,
     )
     return ctx.invoke(
         kind="implementer",  # mutator reuses the implementer sandbox
@@ -179,6 +182,9 @@ def _run_judge(
         runtime_notes=ctx.run_environment_view.prompt_notes,
         env_kind=ctx.run_environment_view.env_kind,
         objective=objective,
+        is_generic_example=ctx.example_manifest is not None,
+        target_check_instructions=ctx.target_check_instructions,
+        target_bench_instructions=ctx.target_bench_instructions,
     )
     return ctx.invoke(
         kind="judge",
@@ -223,6 +229,11 @@ def _run_profiler(
     objective: str,
     objectives: list[Objective] | None = None,
 ) -> ProfilerSummary | None:
+    if ctx.example_manifest is not None:
+        return run_example_benchmark(ctx, round_label=f"gen-{generation}-cand-{child_idx}")
+    if ctx.profiler_kind == "none":
+        ctx.lprint(f"[gen-{generation}-cand-{child_idx}] profiler_kind=none; skipping profiler.")
+        return None
     template = (
         "profiler_prompt_torch.j2" if ctx.profiler_kind == "torch" else "profiler_prompt_nsys.j2"
     )

--- a/src/vibe_serve/loops/evolve/templates/judge_prompt.j2
+++ b/src/vibe_serve/loops/evolve/templates/judge_prompt.j2
@@ -17,6 +17,38 @@ You are a senior code reviewer evaluating one offspring in an LLM-driven evoluti
 {{ runtime_notes }}
 {% endif %}
 
+{% if is_generic_example %}
+## Correctness checking (generic example, issue #76)
+
+This offspring is a change to a non-Python target — not an LLM/model-serving
+implementation. Do not expect `main.py`, `VibeServeModel`, `/health`,
+`/debug/metrics`, or any Python serving interface.
+
+{{ target_check_instructions }}
+
+## Always-on correctness check
+
+In addition to the pass criteria above, `check.sh`'s exit code is
+authoritative for a **pass** verdict: non-zero exit → **fail**, regardless
+of what the pass criteria say.
+
+## Reward-hack detection (proactive)
+
+Evolutionary search amplifies any local optimum it finds, including gaming
+`check.sh` or `bench.sh` rather than genuinely improving the target. Before
+passing an offspring, read its diff (`git diff <parent-sha>..HEAD` or
+equivalent) for patterns that make the benchmark's declared metric look
+better without the target actually doing the represented work — e.g. a
+change that special-cases the exact request shape `bench.sh` sends, a
+short-circuit that returns a cached/precomputed response instead of
+performing the real operation, or a change to `check.sh`/`bench.sh`
+themselves (these are read-only reference files; any diff touching them is
+an automatic **fail** and a strong reward-hacking signal).
+
+If you find such a pattern, **verdict is fail**. Name the specific
+function/branch/file in feedback and tell the mutator to remove the
+shortcut.
+{% else %}
 {% include "_modality/" ~ modality ~ "/judge.j2" %}
 
 ## Always-on correctness checks
@@ -46,6 +78,7 @@ Evolutionary search amplifies any local optimum it finds. The most dangerous one
 If **any** of (1)/(2)/(3) finds a default-enabled bypass for the benchmark's request shape, **verdict is fail**. Name the specific function / branch / flag in feedback and tell the implementer to remove the bypass and run a real forward pass.
 
 Legitimate "fast paths" (these are not reward hacks): CUDA-graph replay of the target model's decode, FlashAttention swap, KV-cache reuse, xgrammar grammar compile cache, xgrammar jump-forward at deterministic positions (model is still consulted for non-deterministic positions), EAGLE3 speculative decoding. All of these still invoke the model.
+{% endif %}
 
 ## Performance criteria use the objective's headline metric, end-to-end
 

--- a/src/vibe_serve/loops/evolve/templates/mutator_prompt.j2
+++ b/src/vibe_serve/loops/evolve/templates/mutator_prompt.j2
@@ -1,5 +1,17 @@
 {% if modality is not defined %}{% set modality = "text_generation" %}{% endif %}
+{% if is_generic_example %}
+## Target (generic example, issue #76)
+
+This is not an LLM/model-serving offspring — do not write a `main.py` with
+a `VibeServeModel` class or any Python serving interface.
+
+Your candidate lives under `reference/` in the workspace (check
+`reference/vibeserve.example.toml` for a designated writable subpath).
+
+{{ target_bench_instructions }}
+{% else %}
 {% include "_modality/" ~ modality ~ "/implementer.j2" %}
+{% endif %}
 
 {% if runtime_notes %}
 ## Runtime environment
@@ -34,13 +46,22 @@ The profiler reports every objective as a numeric value in `metrics`. An offspri
 {% if is_cold_start %}
 ## Cold start — no parent yet
 
-The population is empty. There is no parent to mutate. Your job this round is to write the **first working version** of the server from the reference at `{{ reference_path }}`. Aim for a minimal correct implementation that:
+The population is empty. There is no parent to mutate. Your job this round is to produce the **first working version** of the candidate.
+{% if is_generic_example %}
+Aim for a minimal correct change to the candidate at `reference/` (or its
+designated writable subpath) that passes `check.sh`. Skip aggressive
+optimization in this seed — later generations will mutate it. A clean,
+correct seed beats a clever-but-broken one: failed seeds give the search
+nothing to evolve from.
+{% else %}
+Work from the reference at `{{ reference_path }}`. Aim for a minimal correct implementation that:
 
 - Boots and exposes `/health`.
 - Implements the modality's accuracy-checker contract (e.g. `VibeServeModel.from_pretrained` + the modality's generate / transcribe method).
 - Passes the modality's pass criteria (covered in the modality block above).
 
 Skip aggressive optimization in this seed — later generations will mutate it. Producing a clean, correct seed beats producing a clever-but-broken seed: failed seeds give the search nothing to evolve from.
+{% endif %}
 
 {% else %}
 ## Parent (the implementation you are mutating)

--- a/src/vibe_serve/loops/plain/loop.py
+++ b/src/vibe_serve/loops/plain/loop.py
@@ -538,6 +538,9 @@ def run_plain_loop(
                             reference_path=ctx.ref_name,
                             runtime_notes=ctx.run_environment_view.prompt_notes,
                             issue=issue,
+                            is_generic_example=ctx.example_manifest is not None,
+                            target_check_instructions=ctx.target_check_instructions,
+                            target_bench_instructions=ctx.target_bench_instructions,
                         )
                         impl_prompt = prompt.render(
                             "implementer/user.j2",
@@ -606,6 +609,9 @@ def run_plain_loop(
                         accuracy_checker_path=ctx.judge_acc_checker_path,
                         bench_path=ctx.judge_bench_path,
                         issue=issue,
+                        is_generic_example=ctx.example_manifest is not None,
+                        target_check_instructions=ctx.target_check_instructions,
+                        target_bench_instructions=ctx.target_bench_instructions,
                     )
                     judge_prompt = prompt.render("judge/user.j2", issue=issue)
 
@@ -707,6 +713,13 @@ def run_plain_loop(
                 )
                 ctx.reselect_gpu()
 
+                is_generic_example = ctx.example_manifest is not None
+                metric_direction = (
+                    ctx.example_manifest.benchmark.direction if is_generic_example else None
+                )
+                primary_metric = (
+                    ctx.example_manifest.benchmark.primary_metric if is_generic_example else None
+                )
                 perf_system_prompt = prompt.render(
                     "perf_eval/system.j2",
                     load_levels=load_levels,
@@ -715,6 +728,10 @@ def run_plain_loop(
                     previous_evaluator_feedback=previous_evaluator_feedback,
                     issue_create_cap=max_issues_per_perf_eval,
                     runtime_notes=ctx.run_environment_view.prompt_notes,
+                    is_generic_example=is_generic_example,
+                    target_bench_instructions=ctx.target_bench_instructions,
+                    primary_metric=primary_metric,
+                    metric_direction=metric_direction,
                 )
                 perf_prompt = prompt.render("perf_eval/user.j2")
 

--- a/src/vibe_serve/loops/plain/templates/implementer/system.j2
+++ b/src/vibe_serve/loops/plain/templates/implementer/system.j2
@@ -1,3 +1,16 @@
+{% if is_generic_example %}
+You are a systems engineer working on a non-Python target via the generic example-directory contract (issue #76). This is NOT a FastAPI/Python model-serving target — do not write a `main.py`, `VibeServeModel` class, or any Python serving interface.
+
+You are working on ONE issue at a time. Do NOT scope-creep beyond the issue's 'Acceptance criteria'. Other open issues will be handled in separate sessions with fresh context — do not try to fix them here.
+
+Your candidate lives under `reference/` in your working directory (check `reference/vibeserve.example.toml` for a designated writable subpath, if any).
+
+{{ target_bench_instructions }}
+
+**Stay inside the workspace**: Do not read, write, or reference files outside your working directory.
+
+Self-validate by running `bash example/build.sh` (if present) then `bash example/setup.sh` before declaring the issue done.
+{% else %}
 You are an ML engineer building a FastAPI inference server.
 
 You are working on ONE issue at a time. Do NOT scope-creep beyond the issue's 'Acceptance criteria'. Other open issues will be handled in separate sessions with fresh context — do not try to fix them here.
@@ -11,6 +24,7 @@ Your working directory is the experiment directory. All files you create must be
 **Stay inside the workspace**: Do not read, write, or reference files outside your working directory. Everything you need is here (reference code, config files, and model weights at `/model`).
 
 After implementing or touching streaming, **self-validate** by running the benchmark and checking the output JSON for `token_throughput > 0` and non-null `ttft_ms`/`tpot_ms` values. If these are zero or null, your streaming is broken and must be fixed before declaring done.
+{% endif %}
 
 ## Current Issue (READ THIS CAREFULLY)
 

--- a/src/vibe_serve/loops/plain/templates/judge/system.j2
+++ b/src/vibe_serve/loops/plain/templates/judge/system.j2
@@ -1,3 +1,36 @@
+{% if is_generic_example %}
+You are a senior code reviewer evaluating a change to a non-Python target, via the generic example-directory contract (issue #76). Do not expect `main.py`, a `VibeServeModel` class, `/health`, `/predict`, `uv`, or `pytest` — none of that applies here.
+
+## Current Issue
+
+**#{{ issue.id }} — [{{ issue.type.value }}] {{ issue.title }}**
+
+{{ issue.description }}
+
+Your verdict here is about THIS issue. Other open issues will be handled in separate sessions — do not flag them.
+
+**Performance criteria are out of scope.** If the issue description contains performance-related acceptance criteria, ignore them entirely — that's the perf evaluator's job.
+
+## Correctness checking
+
+{{ target_check_instructions }}
+
+Judge correctness by `check.sh`'s exit code and output, and by whether the implementer's change matches the issue's acceptance criteria above. Do not require unit tests, `pytest`, or any Python-specific artifact — `check.sh` is the correctness oracle for this target.
+
+## Output format
+
+Return exactly one JSON object and nothing else. Do not wrap the JSON in markdown fences. Do not add prose before or after the JSON. Use this exact schema:
+
+{
+  "issue_id": <int>,
+  "analysis": "<string>",
+  "feedback": "<string>",
+  "verdict": "pass" | "fail",
+  "new_issues_filed": [<int>, ...]
+}
+
+IMPORTANT: Your verdict must be consistent with your analysis. If your analysis identifies issues that need fixing, the verdict must be "fail". If everything meets the criteria, the verdict must be "pass".
+{% else %}
 You are a senior code reviewer evaluating an ML inference server implementation.
 
 ## Current Issue
@@ -149,3 +182,4 @@ Return exactly one JSON object and nothing else. Do not wrap the JSON in markdow
 }
 
 IMPORTANT: Your verdict must be consistent with your analysis. If your analysis identifies issues that need fixing, the verdict must be "fail". If everything meets the criteria, the verdict must be "pass".
+{% endif %}

--- a/src/vibe_serve/loops/plain/templates/perf_eval/system.j2
+++ b/src/vibe_serve/loops/plain/templates/perf_eval/system.j2
@@ -1,3 +1,25 @@
+{% if is_generic_example %}
+You are a performance engineer evaluating a change to a non-Python target, via the generic example-directory contract (issue #76).
+
+Your job is to benchmark the target, collect the metric VibeServe is optimizing, and assess whether there is meaningful room for improvement.
+
+## Workspace
+
+{{ target_bench_instructions }}
+
+The metric this run optimizes is `{{ primary_metric }}` ({{ metric_direction }} is better). Do not expect `main.py`, FastAPI, `/health`, `--rate`/`--duration`/`--max-tokens` flags, TTFT/TPOT fields, or any Python-serving-specific benchmark output shape — read whatever `bash example/bench.sh` actually prints (one JSON object per line: `{"metric": "<name>", "value": <number>}`) and use `{{ primary_metric }}`'s value as your primary comparison point across iterations. Populate `metrics.load_levels[0].throughput.request_throughput` from whatever the benchmark reports as its overall request rate if applicable, and put every other emitted metric under `metrics.extra` keyed by name; leave `token_throughput`, `ttft`, `tpot`, and `total_latency` unset when the target has no notion of tokens or per-request streaming.
+
+{% if runtime_notes is defined and runtime_notes %}
+{{ runtime_notes }}
+{% endif %}
+
+## Steps
+
+1. Run `bash example/bench.sh` (from the workspace root) to collect metrics. Re-run it a few times or at different declared load levels if the script supports a load-level argument, to observe whether the metric is stable or trending.
+2. Read the JSON-lines output and record every `{"metric": ..., "value": ...}` line.
+3. Compare `{{ primary_metric }}` against the previous iteration and the all-time best.
+
+{% else %}
 You are a performance engineer evaluating an ML inference server implementation.
 
 Your job is to benchmark the server, collect structured performance metrics, and assess whether there is meaningful room for improvement.
@@ -203,3 +225,4 @@ Use this schema:
 }
 
 IMPORTANT: Your throughput_trend and latency_trend must be consistent with your analysis and the comparison against previous metrics. Populate metrics from the actual benchmark JSON output files — do not fabricate numbers.
+{% endif %}

--- a/src/vibe_serve/loops/profiler.py
+++ b/src/vibe_serve/loops/profiler.py
@@ -31,6 +31,8 @@ def mcp_spec(profiler_kind: str):
         from vibe_serve._agent_cli import MCPServerSpec
     except Exception:
         return None
+    if profiler_kind == "none":
+        return None
     if profiler_kind == "torch":
         return MCPServerSpec(
             name="vibeserve-torch-profiler",
@@ -85,3 +87,58 @@ def invoke_profiler(
     except Exception as exc:
         ctx.lprint(f"[warn] profiler failed: {exc}")
         return None
+
+
+def run_example_benchmark(ctx, *, round_label: str) -> ProfilerSummary | None:
+    """Run a generic example's bench.sh and parse its JSONL metrics (issue #76).
+
+    Generic examples have no GPU profiler; the declared benchmark harness
+    (bench.sh) is the source of truth for the primary metric. This runs
+    bench.sh in the sandbox, parses ``{"metric","value"}`` JSONL from both
+    stdout and ``VIBESERVE_OUTPUT_DIR``, and returns a ProfilerSummary whose
+    ``perf_metric`` / ``metrics`` the evolve and agent loops already consume
+    for comparison (evolve ranks by ``metrics[primary_metric]`` with the
+    manifest's declared direction). Returns None when bench.sh fails or emits
+    no primary metric, so the caller treats the candidate as unmeasured.
+    """
+    manifest = ctx.example_manifest
+    if manifest is None:
+        return None
+    sandbox = ctx.implementer_backend
+    out_dir = "/workspace/example_output"
+    try:
+        sandbox.execute(f"mkdir -p {out_dir}")
+        result = sandbox.execute(
+            "cd /workspace/example && bash bench.sh",
+            timeout=manifest.setup.timeout_sec,
+        )
+    except Exception as exc:
+        ctx.lprint(f"[{round_label}] example bench.sh failed to run: {exc}")
+        return None
+    if getattr(result, "exit_code", 0) != 0:
+        ctx.lprint(f"[{round_label}] bench.sh exited {result.exit_code}; candidate unmeasured.")
+        return None
+    text = getattr(result, "output", "") or ""
+    try:
+        extra = sandbox.execute(f"cat {out_dir}/*.jsonl 2>/dev/null || true")
+        text = text + "\n" + (getattr(extra, "output", "") or "")
+    except Exception:
+        pass
+    metrics = manifest.parse_metrics(text)
+    primary_name = manifest.benchmark.primary_metric
+    primary = metrics.get(primary_name)
+    ctx.lprint(
+        f"[{round_label}] bench.sh metrics={metrics} "
+        f"primary({primary_name})={primary} ({manifest.benchmark.direction})"
+    )
+    if primary is None:
+        ctx.lprint(f"[{round_label}] bench.sh emitted no '{primary_name}' metric; unmeasured.")
+        return None
+    return ProfilerSummary(
+        analysis=f"Parsed {len(metrics)} metric(s) from bench.sh JSONL output.",
+        bottlenecks="n/a (generic example: no GPU profiler; bench.sh is the metric source)",
+        suggestions="n/a",
+        perf_metric=primary,
+        perf_unit=primary_name,
+        metrics=metrics,
+    )

--- a/src/vibe_serve/sandbox/run_environment.py
+++ b/src/vibe_serve/sandbox/run_environment.py
@@ -39,6 +39,7 @@ from deepagents.backends.sandbox import BaseSandbox
 from vibe_serve.backends import SandboxKind
 from vibe_serve.backends.base import ComputeBackendImpl, SetupFn
 from vibe_serve.constants import DEFAULT_AGENT_BACKEND, PROJECT_ROOT
+from vibe_serve.example_manifest import ExampleManifest
 
 
 @dataclass(frozen=True)
@@ -98,6 +99,7 @@ class RunEnvironmentRequest:
     neuron_profiler_path: str | None = None
     log: Callable[[str], None] | None = None
     project_root: Path = PROJECT_ROOT
+    example_manifest: ExampleManifest | None = None
 
 
 class RunEnvironmentSession(Protocol):
@@ -141,6 +143,7 @@ class _DefaultRunEnvironmentSession:
     sandbox: BaseSandbox
     view: RunEnvironmentView
     stop_on_close: bool = False
+    teardown_fn: Callable[[BaseSandbox], None] | None = None
     _closed: bool = False
 
     def __enter__(self) -> _DefaultRunEnvironmentSession:
@@ -153,6 +156,8 @@ class _DefaultRunEnvironmentSession:
         if self._closed:
             return
         self._closed = True
+        if self.teardown_fn is not None:
+            self.teardown_fn(self.sandbox)
         if self.stop_on_close and hasattr(self.sandbox, "stop"):
             self.sandbox.stop()
 
@@ -210,9 +215,33 @@ class DockerEnvironment:
     def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession:
         bind_mounts, docker_symlinks, model_path = _container_mount_plan(request)
         extra_init_commands, cli_provider_env = _cli_container_setup(request)
+        log = request.log or (lambda _: None)
+
+        manifest = request.example_manifest
+        if manifest is not None and manifest.setup.needs_docker_socket:
+            log(
+                "[docker] WARNING: this example's vibeserve.example.toml sets "
+                "setup.needs_docker_socket=true. The sandboxed agent will be able "
+                "to start, stop, and inspect ANY container on this host's Docker "
+                "daemon, not only the ones this example's own scripts manage "
+                "(see issue #76 design notes on Docker-in-Docker)."
+            )
+            bind_mounts.append(("/var/run/docker.sock", "/var/run/docker.sock", False))
+
         bind_mounts = _dedupe_mounts(bind_mounts)
         passthrough = ["/model"] if model_path is not None else []
         setup_fns = _symlink_setup_fns(docker_symlinks)
+        teardown_fn = None
+        if manifest is not None:
+            example_env = _example_env(manifest)
+            cli_provider_env = {**cli_provider_env, **example_env}
+            for script_name in ("setup.sh", "build.sh"):
+                if manifest.has_script(script_name):
+                    setup_fns = setup_fns + [
+                        _example_script_fn(manifest, request, script_name, example_env)
+                    ]
+            if manifest.has_script("teardown.sh"):
+                teardown_fn = _example_teardown_fn(manifest, request, example_env)
 
         sandbox = request.backend.make_sandbox(
             SandboxKind.DOCKER,
@@ -224,7 +253,6 @@ class DockerEnvironment:
             extra_init_commands=extra_init_commands,
             setup_fns=setup_fns,
         )
-        log = request.log or (lambda _: None)
         label = getattr(request.backend, "image", self.config.image or "<backend-default>")
         log(f"[docker] starting container with image {label}")
         sandbox.start()
@@ -242,6 +270,7 @@ class DockerEnvironment:
                 env_kind="docker",
             ),
             stop_on_close=True,
+            teardown_fn=teardown_fn,
         )
 
     def repair_workspace(
@@ -335,6 +364,16 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         # Host-side: ensure Modal Volumes exist for the model + optional
         # draft.  These run before the Docker container starts and are
         # idempotent (skip-if-ready sentinel).
+        if (
+            request.example_manifest is not None
+            and request.example_manifest.setup.needs_docker_socket
+        ):
+            raise RuntimeError(
+                "This example's vibeserve.example.toml sets "
+                "setup.needs_docker_socket=true, but --modal runs the agent in a "
+                "Modal sandbox with no local Docker daemon to expose a socket "
+                "from. Re-run with --docker, or drop setup.needs_docker_socket."
+            )
         self._ensure_model_volume(request)
         self._ensure_draft_volume(request)
 
@@ -651,6 +690,61 @@ def _modal_runtime_notes(gpu: str, app_name: str) -> str:
         "`dtype` (whatever was loaded), and `wall_time_sec` to the "
         "dict before writing to disk."
     )
+
+
+def _example_env(manifest: ExampleManifest) -> dict[str, str]:
+    """Standard env vars every generic-example lifecycle script receives (issue #76)."""
+    return manifest.env(output_dir="/workspace/example_output", load_level="medium")
+
+
+def _example_script_fn(
+    manifest: ExampleManifest,
+    request: RunEnvironmentRequest,
+    script_name: str,
+    env: dict[str, str],
+) -> SetupFn:
+    """Run one lifecycle script (setup.sh/build.sh) once the container is up.
+
+    Mirrors _symlink_setup_fns' shape: a callable taking the started
+    BaseSandbox. Runs with the manifest's standard env vars and a generous
+    default timeout since compose-based or compile-heavy targets can take a
+    while.
+    """
+    env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
+
+    def run_script(sb) -> None:
+        log = request.log or (lambda _: None)
+        cmd = f"cd /workspace/example && {env_prefix} bash {script_name}"
+        log(f"[docker] running example {script_name} (timeout={manifest.setup.timeout_sec}s)")
+        result = sb.execute(cmd, timeout=manifest.setup.timeout_sec)
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"Example {script_name} failed (exit {result.exit_code}):\n{result.output}"
+            )
+
+    return run_script
+
+
+def _example_teardown_fn(
+    manifest: ExampleManifest,
+    request: RunEnvironmentRequest,
+    env: dict[str, str],
+) -> Callable[[BaseSandbox], None]:
+    """Best-effort teardown.sh run on session close; never raises (issue #76)."""
+    env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
+
+    def run_teardown(sb) -> None:
+        log = request.log or (lambda _: None)
+        cmd = f"cd /workspace/example && {env_prefix} bash teardown.sh"
+        log(f"[docker] running example teardown.sh (timeout={manifest.setup.timeout_sec}s)")
+        try:
+            result = sb.execute(cmd, timeout=manifest.setup.timeout_sec)
+            if result.exit_code != 0:
+                log(f"[docker] teardown.sh exited {result.exit_code}:\n{result.output}")
+        except Exception as exc:
+            log(f"[docker] teardown.sh raised (ignored during cleanup): {exc}")
+
+    return run_teardown
 
 
 def _isolated_paths(request: RunEnvironmentRequest) -> AgentPaths:

--- a/src/vibe_serve/schemas.py
+++ b/src/vibe_serve/schemas.py
@@ -86,7 +86,13 @@ class ThroughputStats(BaseModel):
     """Throughput metrics at a given load level."""
 
     request_throughput: float = Field(description="Requests per second.")
-    token_throughput: float = Field(description="Output tokens per second.")
+    token_throughput: float | None = Field(
+        default=None,
+        description=(
+            "Output tokens per second. None for non-token workloads "
+            "(e.g. HTTP microservice benchmarks with no LLM inference)."
+        ),
+    )
 
 
 class LoadLevelMetrics(BaseModel):

--- a/tests/test_agent_loop_prompt_wiring.py
+++ b/tests/test_agent_loop_prompt_wiring.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+from vibe_serve.prompts import render_template
+
+_TEMPLATE_DIR = Path("src/vibe_serve/loops/agent/templates")
+
+
+def test_judge_prompt_uses_generic_instructions_when_flagged():
+    out = render_template(
+        "judge_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        accuracy_checker_path="/workspace/acc_checker",
+        bench_path="/workspace/bench",
+        pass_criteria="check.sh passes",
+        modality="text_generation",
+        domain_judge="",
+        retry=0,
+        runtime_notes="",
+        env_kind="docker",
+        objective="minimize p50_ms",
+        is_generic_example=True,
+        target_check_instructions="Run `bash check.sh` from the example root.",
+        target_bench_instructions="Run `bash bench.sh`; watch p50_ms.",
+    )
+    assert "from_pretrained" not in out
+    assert "Decode invariants" not in out
+    assert "Run `bash check.sh`" in out
+
+
+def test_judge_prompt_uses_modality_include_when_not_generic():
+    out = render_template(
+        "judge_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        accuracy_checker_path="/workspace/acc_checker",
+        bench_path="/workspace/bench",
+        pass_criteria="server boots",
+        modality="text_generation",
+        domain_judge="",
+        retry=0,
+        runtime_notes="",
+        env_kind="docker",
+        objective="maximize tok/s",
+        is_generic_example=False,
+        target_check_instructions=None,
+        target_bench_instructions=None,
+    )
+    assert "VibeServeModel" in out
+
+
+def test_implementer_prompt_uses_generic_instructions_when_flagged():
+    out = render_template(
+        "implementer_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        reference_path="reference/",
+        modality="text_generation",
+        domain_implementer="",
+        task="Reduce p50_ms",
+        pass_criteria="check.sh passes",
+        retry=0,
+        feedback=None,
+        runtime_notes="",
+        env_kind="docker",
+        is_generic_example=True,
+        target_check_instructions="Run `bash check.sh`.",
+        target_bench_instructions="Run `bash bench.sh`; watch p50_ms.",
+    )
+    assert "from_pretrained" not in out
+    assert "Decode invariants" not in out
+    assert "Run `bash bench.sh`" in out
+
+
+def test_implementer_prompt_uses_modality_include_when_not_generic():
+    out = render_template(
+        "implementer_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        reference_path="reference/model.py",
+        modality="text_generation",
+        domain_implementer="",
+        task="Speed up decode",
+        pass_criteria="tok/s improves",
+        retry=0,
+        feedback=None,
+        runtime_notes="",
+        env_kind="docker",
+        is_generic_example=False,
+        target_check_instructions=None,
+        target_bench_instructions=None,
+    )
+    assert "VibeServeModel" in out

--- a/tests/test_evolve_loop_prompt_wiring.py
+++ b/tests/test_evolve_loop_prompt_wiring.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+_TEMPLATE_DIR = Path("src/vibe_serve/loops/evolve/templates")
+_AGENT_TEMPLATE_DIR = Path("src/vibe_serve/loops/agent/templates")
+
+
+class _RenderShim:
+    def __init__(self, env):
+        self._env = env
+
+    def render(self, name, **kwargs):
+        return self._env.get_template(name).render(**kwargs)
+
+
+@pytest.fixture
+def prompt():
+    env = Environment(
+        loader=FileSystemLoader([str(_TEMPLATE_DIR), str(_AGENT_TEMPLATE_DIR)]),
+        keep_trailing_newline=True,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    return _RenderShim(env)
+
+
+def test_judge_generic_skips_python_reward_hack_language(prompt):
+    out = prompt.render(
+        "judge_prompt.j2",
+        accuracy_checker_path=None,
+        bench_path=None,
+        pass_criteria="check.sh passes",
+        modality="text_generation",
+        runtime_notes="",
+        env_kind="docker",
+        objective="minimize p50_ms",
+        is_generic_example=True,
+        target_check_instructions="Run bash check.sh.",
+        target_bench_instructions="Run bash bench.sh.",
+    )
+    assert "cuda_graph_replays" not in out
+    assert "uv run pytest" not in out
+    assert "Run bash check.sh" in out
+    assert "check.sh" in out and "read-only reference files" in out
+
+
+def test_judge_non_generic_keeps_python_reward_hack_language(prompt):
+    out = prompt.render(
+        "judge_prompt.j2",
+        accuracy_checker_path="/workspace/acc_checker",
+        bench_path="/workspace/bench",
+        pass_criteria="tok/s improves",
+        modality="text_generation",
+        runtime_notes="",
+        env_kind="docker",
+        objective="maximize tok/s",
+        is_generic_example=False,
+        target_check_instructions=None,
+        target_bench_instructions=None,
+    )
+    assert "cuda_graph_replays" in out
+    assert "uv run pytest" in out
+
+
+def test_mutator_generic_cold_start_skips_health_language(prompt):
+    out = prompt.render(
+        "mutator_prompt.j2",
+        reference_path="reference/",
+        modality="text_generation",
+        objective="minimize p50_ms",
+        parent=None,
+        inspirations=[],
+        is_cold_start=True,
+        objectives=None,
+        runtime_notes="",
+        env_kind="docker",
+        is_generic_example=True,
+        target_check_instructions="Run bash check.sh.",
+        target_bench_instructions="Run bash bench.sh; watch p50_ms.",
+    )
+    assert "Boots and exposes `/health`" not in out
+    assert "Run bash bench.sh" in out
+
+
+def test_mutator_non_generic_cold_start_keeps_health_language(prompt):
+    out = prompt.render(
+        "mutator_prompt.j2",
+        reference_path="reference/model.py",
+        modality="text_generation",
+        objective="maximize tok/s",
+        parent=None,
+        inspirations=[],
+        is_cold_start=True,
+        objectives=None,
+        runtime_notes="",
+        env_kind="docker",
+        is_generic_example=False,
+        target_check_instructions=None,
+        target_bench_instructions=None,
+    )
+    assert "Boots and exposes `/health`" in out
+
+
+def test_mutator_generic_with_parent_skips_vibeservemodel(prompt):
+    parent = SimpleNamespace(
+        id=3,
+        generation=2,
+        perf_metric=42.0,
+        perf_unit="p50_ms",
+        metrics={},
+        summary="Reduced lock contention.",
+        feedback="",
+    )
+    out = prompt.render(
+        "mutator_prompt.j2",
+        reference_path="reference/",
+        modality="text_generation",
+        objective="minimize p50_ms",
+        parent=parent,
+        inspirations=[],
+        is_cold_start=False,
+        objectives=None,
+        runtime_notes="",
+        env_kind="docker",
+        is_generic_example=True,
+        target_check_instructions="Run bash check.sh.",
+        target_bench_instructions="Run bash bench.sh; watch p50_ms.",
+    )
+    assert "from_pretrained" not in out
+    assert "#3" in out

--- a/tests/test_example_manifest.py
+++ b/tests/test_example_manifest.py
@@ -1,0 +1,138 @@
+import textwrap
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from vibe_serve.example_manifest import ExampleManifest
+
+
+def _write_manifest(tmp_path: Path, body: str) -> Path:
+    example_dir = tmp_path / "examples" / "fake-example"
+    example_dir.mkdir(parents=True)
+    (example_dir / "vibeserve.example.toml").write_text(textwrap.dedent(body))
+    return example_dir
+
+
+def test_detect_returns_none_when_manifest_absent(tmp_path):
+    ref = tmp_path / "examples" / "no-manifest" / "reference"
+    ref.mkdir(parents=True)
+    assert ExampleManifest.detect(ref) is None
+
+
+def test_detect_loads_manifest_sibling_to_ref(tmp_path):
+    example_dir = _write_manifest(
+        tmp_path,
+        """
+        [service]
+        base_url = "http://localhost:8080"
+        health_check = "GET /wrk2-api/user-timeline/read?user_id=1&start=0&stop=1"
+
+        [benchmark]
+        primary_metric = "p50_ms"
+        direction = "minimize"
+        metrics_format = "jsonl"
+        """,
+    )
+    ref = example_dir / "reference"
+    ref.mkdir()
+    manifest = ExampleManifest.detect(ref)
+    assert manifest is not None
+    assert manifest.service.base_url == "http://localhost:8080"
+    assert manifest.benchmark.primary_metric == "p50_ms"
+    assert manifest.benchmark.direction == "minimize"
+
+
+def test_invalid_health_check_format_rejected(tmp_path):
+    example_dir = _write_manifest(
+        tmp_path,
+        """
+        [service]
+        health_check = "not-a-valid-probe"
+
+        [benchmark]
+        primary_metric = "p50_ms"
+        direction = "minimize"
+        """,
+    )
+    with pytest.raises(ValidationError):
+        ExampleManifest.load(example_dir)
+
+
+def test_direction_must_be_minimize_or_maximize(tmp_path):
+    example_dir = _write_manifest(
+        tmp_path,
+        """
+        [benchmark]
+        primary_metric = "p50_ms"
+        direction = "down"
+        """,
+    )
+    with pytest.raises(ValidationError):
+        ExampleManifest.load(example_dir)
+
+
+def test_script_path_and_has_script(tmp_path):
+    example_dir = _write_manifest(
+        tmp_path,
+        """
+        [benchmark]
+        primary_metric = "p50_ms"
+        direction = "minimize"
+        """,
+    )
+    (example_dir / "check.sh").write_text("#!/bin/bash\nexit 0\n")
+    manifest = ExampleManifest.load(example_dir)
+    assert manifest.has_script("check.sh")
+    assert not manifest.has_script("build.sh")
+    assert manifest.require_script("check.sh") == example_dir / "check.sh"
+    with pytest.raises(FileNotFoundError):
+        manifest.require_script("build.sh")
+
+
+def test_env_vars_match_issue_contract(tmp_path):
+    example_dir = _write_manifest(
+        tmp_path,
+        """
+        [service]
+        base_url = "http://localhost:8080"
+
+        [benchmark]
+        primary_metric = "p50_ms"
+        direction = "minimize"
+        """,
+    )
+    manifest = ExampleManifest.load(example_dir)
+    env = manifest.env(output_dir="/tmp/vibeserve-run-1", load_level="medium")
+    assert env["VIBESERVE_BASE_URL"] == "http://localhost:8080"
+    assert env["VIBESERVE_OUTPUT_DIR"] == "/tmp/vibeserve-run-1"
+    assert env["VIBESERVE_LOAD_LEVEL"] == "medium"
+
+
+def test_to_objective_maps_direction_vocabulary(tmp_path):
+    example_dir = _write_manifest(
+        tmp_path,
+        """
+        [benchmark]
+        primary_metric = "p50_ms"
+        direction = "minimize"
+        """,
+    )
+    manifest = ExampleManifest.load(example_dir)
+    objective = manifest.to_objective()
+    assert objective.name == "p50_ms"
+    assert objective.direction == "min"
+
+
+def test_unknown_lifecycle_script_name_rejected(tmp_path):
+    example_dir = _write_manifest(
+        tmp_path,
+        """
+        [benchmark]
+        primary_metric = "p50_ms"
+        direction = "minimize"
+        """,
+    )
+    manifest = ExampleManifest.load(example_dir)
+    with pytest.raises(ValueError):
+        manifest.script_path("not_a_real_script.sh")

--- a/tests/test_issue_76_fixes.py
+++ b/tests/test_issue_76_fixes.py
@@ -1,0 +1,247 @@
+"""Regression coverage for the three issue-76 gap fixes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from vibe_serve.cli import _resolve_objectives
+from vibe_serve.example_manifest import ExampleManifest
+from vibe_serve.loops.evolve.loop import _run_profiler
+from vibe_serve.sandbox import run_environment as re_mod
+
+
+def _example_ref(tmp_path: Path, *, manifest: bool, objectives_toml: bool) -> Path:
+    example_dir = tmp_path / "examples" / "generic"
+    ref = example_dir / "reference"
+    ref.mkdir(parents=True)
+    if manifest:
+        (example_dir / "vibeserve.example.toml").write_text(
+            '[benchmark]\nprimary_metric = "p50_ms"\ndirection = "minimize"\n'
+        )
+    if objectives_toml:
+        (example_dir / "objectives.toml").write_text(
+            '[[objective]]\nname = "tok_s"\ndirection = "max"\n'
+        )
+    return ref
+
+
+def _args(ref: Path, objective=None) -> SimpleNamespace:
+    return SimpleNamespace(ref=str(ref), objective=objective or [])
+
+
+def test_resolve_objectives_uses_manifest_when_no_flag_or_toml(tmp_path):
+    ref = _example_ref(tmp_path, manifest=True, objectives_toml=False)
+    objs = _resolve_objectives(_args(ref))
+    assert len(objs) == 1
+    assert objs[0].name == "p50_ms"
+    assert objs[0].direction == "min"
+
+
+def test_objectives_toml_takes_precedence_over_manifest(tmp_path):
+    ref = _example_ref(tmp_path, manifest=True, objectives_toml=True)
+    objs = _resolve_objectives(_args(ref))
+    assert len(objs) == 1
+    assert objs[0].name == "tok_s"
+    assert objs[0].direction == "max"
+
+
+def test_cli_objective_flag_takes_precedence_over_manifest(tmp_path):
+    ref = _example_ref(tmp_path, manifest=True, objectives_toml=True)
+    flag = [SimpleNamespace(name="latency", direction="min")]
+    objs = _resolve_objectives(_args(ref, objective=flag))
+    assert objs[0].name == "latency"
+
+
+def test_legacy_example_without_manifest_returns_empty(tmp_path):
+    ref = _example_ref(tmp_path, manifest=False, objectives_toml=False)
+    assert _resolve_objectives(_args(ref)) == []
+
+
+def test_evolve_run_profiler_skips_when_kind_none():
+    logs: list[str] = []
+    ctx = SimpleNamespace(profiler_kind="none", example_manifest=None, lprint=logs.append)
+    result = _run_profiler(
+        ctx,
+        generation=1,
+        child_idx=0,
+        modality="text_generation",
+        objective="minimize p50_ms",
+    )
+    assert result is None
+    assert any("profiler_kind=none" in line for line in logs)
+
+
+def _socket_manifest(tmp_path: Path) -> ExampleManifest:
+    example_dir = tmp_path / "examples" / "fake"
+    example_dir.mkdir(parents=True)
+    (example_dir / "vibeserve.example.toml").write_text(
+        "[setup]\nneeds_docker_socket = true\n\n"
+        '[benchmark]\nprimary_metric = "p50_ms"\ndirection = "minimize"\n'
+    )
+    return ExampleManifest.load(example_dir)
+
+
+def test_modal_rejects_docker_socket_requirement(tmp_path):
+    manifest = _socket_manifest(tmp_path)
+
+    class FakeBackend:
+        def make_sandbox(self, kind, **kwargs):
+            raise AssertionError("open() must raise before building a sandbox")
+
+    request = re_mod.RunEnvironmentRequest(
+        log_dir=tmp_path / "logs",
+        workspace=tmp_path / "workspace",
+        ref_dir=None,
+        backend=FakeBackend(),
+        agent_backend="cli",
+        cli_provider=None,
+        example_manifest=manifest,
+    )
+    env = re_mod.ModalEnvironment.from_options({})
+    with pytest.raises(RuntimeError, match="needs_docker_socket"):
+        env.open(request)
+
+
+def test_agent_run_profiler_skips_when_kind_none(tmp_path):
+    from vibe_serve.loops.agent.loop import _run_profiler as agent_run_profiler
+
+    logs: list[str] = []
+    ctx = SimpleNamespace(profiler_kind="none", example_manifest=None, lprint=logs.append)
+    result = agent_run_profiler(
+        ctx,
+        round_number=2,
+        profile_focus="latency",
+        modality="text_generation",
+        progress_path=tmp_path / "progress.md",
+        objective="minimize p50_ms",
+    )
+    assert result is None
+    assert any("profiler_kind=none" in line for line in logs)
+
+
+def _valid_manifest(tmp_path: Path) -> ExampleManifest:
+    example_dir = tmp_path / "examples" / "valid"
+    example_dir.mkdir(parents=True)
+    (example_dir / "vibeserve.example.toml").write_text(
+        '[benchmark]\nprimary_metric = "p50_ms"\ndirection = "minimize"\n'
+    )
+    return ExampleManifest.load(example_dir)
+
+
+def test_manifest_load_missing_file_raises(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(FileNotFoundError):
+        ExampleManifest.load(empty)
+
+
+def test_require_script_missing_raises(tmp_path):
+    manifest = _valid_manifest(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        manifest.require_script("check.sh")
+
+
+def test_script_path_unknown_name_raises(tmp_path):
+    manifest = _valid_manifest(tmp_path)
+    with pytest.raises(ValueError):
+        manifest.script_path("bogus.sh")
+
+
+def test_render_instructions_mention_scripts_and_metric(tmp_path):
+    manifest = _valid_manifest(tmp_path)
+    check = manifest.render_check_instructions()
+    bench = manifest.render_bench_instructions()
+    assert "check.sh" in check
+    assert "bench.sh" in bench
+    assert "p50_ms" in bench
+
+
+def test_service_health_check_none_is_allowed():
+    from vibe_serve.example_manifest import ServiceSpec
+
+    spec = ServiceSpec(health_check=None)
+    assert spec.health_check is None
+
+
+def test_parse_metrics_jsonl_ignores_noise_and_extracts_primary(tmp_path):
+    manifest = _valid_manifest(tmp_path)
+    output = (
+        "starting benchmark...\n"
+        '{"metric": "p50_ms", "value": 5.64}\n'
+        "warming up\n"
+        '{"metric": "throughput", "value": 1200}\n'
+        "not json at all\n"
+        '{"metric": "p50_ms", "value": 4.90}\n'
+    )
+    metrics = manifest.parse_metrics(output)
+    assert metrics == {"p50_ms": 4.90, "throughput": 1200.0}
+    assert manifest.primary_metric_value(output) == 4.90
+
+
+def test_parse_metrics_missing_primary_returns_none(tmp_path):
+    manifest = _valid_manifest(tmp_path)
+    assert manifest.primary_metric_value('{"metric": "other", "value": 1}') is None
+
+
+def test_parse_metrics_rejects_bool_and_non_numeric(tmp_path):
+    manifest = _valid_manifest(tmp_path)
+    out = '{"metric": "p50_ms", "value": true}\n{"metric": "x", "value": "hi"}\n'
+    assert manifest.parse_metrics(out) == {}
+
+
+class _BenchSandbox:
+    def __init__(self, bench_output, exit_code=0):
+        self._bench_output = bench_output
+        self._exit_code = exit_code
+        self.commands = []
+
+    def execute(self, cmd, timeout=None):
+        self.commands.append(cmd)
+        is_bench = "bench.sh" in cmd
+        outer = self
+
+        class R:
+            exit_code = outer._exit_code if is_bench else 0
+            output = outer._bench_output if is_bench else ""
+
+        return R()
+
+
+def _bench_ctx(manifest, sandbox):
+    return SimpleNamespace(
+        example_manifest=manifest,
+        implementer_backend=sandbox,
+        lprint=lambda *_: None,
+    )
+
+
+def test_run_example_benchmark_parses_primary_and_metrics(tmp_path):
+    from vibe_serve.loops.profiler import run_example_benchmark
+
+    manifest = _valid_manifest(tmp_path)
+    sb = _BenchSandbox('{"metric": "p50_ms", "value": 4.2}\n{"metric": "qps", "value": 900}\n')
+    summary = run_example_benchmark(_bench_ctx(manifest, sb), round_label="t")
+    assert summary is not None
+    assert summary.perf_metric == 4.2
+    assert summary.perf_unit == "p50_ms"
+    assert summary.metrics == {"p50_ms": 4.2, "qps": 900.0}
+    assert any("bench.sh" in c for c in sb.commands)
+
+
+def test_run_example_benchmark_none_when_bench_exits_nonzero(tmp_path):
+    from vibe_serve.loops.profiler import run_example_benchmark
+
+    manifest = _valid_manifest(tmp_path)
+    sb = _BenchSandbox("boom", exit_code=1)
+    assert run_example_benchmark(_bench_ctx(manifest, sb), round_label="t") is None
+
+
+def test_run_example_benchmark_none_when_primary_metric_absent(tmp_path):
+    from vibe_serve.loops.profiler import run_example_benchmark
+
+    manifest = _valid_manifest(tmp_path)
+    sb = _BenchSandbox('{"metric": "other", "value": 1}\n')
+    assert run_example_benchmark(_bench_ctx(manifest, sb), round_label="t") is None

--- a/tests/test_issue_76_generic_examples.py
+++ b/tests/test_issue_76_generic_examples.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+from vibe_serve.loops.profiler import mcp_spec
+from vibe_serve.schemas import LoadLevelMetrics, ThroughputStats
+
+
+def test_mcp_spec_none_returns_none():
+    assert mcp_spec("none") is None
+
+
+def test_mcp_spec_torch_unchanged():
+    spec = mcp_spec("torch")
+    assert spec is None or spec.name == "vibeserve-torch-profiler"
+
+
+def test_throughput_stats_token_throughput_optional():
+    stats = ThroughputStats(request_throughput=120.5)
+    assert stats.token_throughput is None
+
+
+def test_throughput_stats_token_throughput_still_settable():
+    stats = ThroughputStats(request_throughput=120.5, token_throughput=980.0)
+    assert stats.token_throughput == 980.0
+
+
+def test_load_level_metrics_without_token_throughput(tmp_path):
+    m = LoadLevelMetrics(
+        target_rate=100.0,
+        actual_rate=98.2,
+        num_requests=1000,
+        num_completed=990,
+        num_failed=10,
+        duration=10.0,
+        throughput=ThroughputStats(request_throughput=98.2),
+    )
+    assert m.throughput.token_throughput is None
+
+
+def test_cli_expand_example_flag_fills_all_three(monkeypatch):
+    from vibe_serve.cli import _expand_example_flag
+
+    argv = ["--outer-loop", "agent", "--example", "examples/social-network-read-timeline"]
+    out = _expand_example_flag(argv)
+    assert "--ref" in out
+    assert str(Path("examples/social-network-read-timeline/reference")) in out
+    assert str(Path("examples/social-network-read-timeline/accuracy_checker")) in out
+    assert str(Path("examples/social-network-read-timeline/benchmark")) in out
+
+
+def test_cli_expand_example_flag_respects_explicit_ref():
+    from vibe_serve.cli import _expand_example_flag
+
+    argv = [
+        "--example",
+        "examples/social-network-read-timeline",
+        "--ref",
+        "custom/ref/path",
+    ]
+    out = _expand_example_flag(argv)
+    assert out.count("--ref") == 1
+    assert "custom/ref/path" in out
+
+
+def test_cli_expand_example_flag_noop_when_absent():
+    from vibe_serve.cli import _expand_example_flag
+
+    argv = ["--outer-loop", "agent", "--ref", "examples/Llama-3-8B/reference"]
+    assert _expand_example_flag(argv) == argv

--- a/tests/test_openevolve_reuses_evolve_prompts.py
+++ b/tests/test_openevolve_reuses_evolve_prompts.py
@@ -1,0 +1,6 @@
+def test_openevolve_imports_run_judge_and_run_mutator_from_evolve():
+    from vibe_serve.loops.evolve import loop as ev_loop
+    from vibe_serve.loops.openevolve import loop as oe_loop
+
+    assert oe_loop._run_judge is ev_loop._run_judge
+    assert oe_loop._run_mutator is ev_loop._run_mutator

--- a/tests/test_plain_loop_prompt_wiring.py
+++ b/tests/test_plain_loop_prompt_wiring.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+
+import pytest
+
+from vibe_serve.constants import ComputeBackend
+from vibe_serve.prompts import Prompt
+
+_TEMPLATE_DIR = "src/vibe_serve/loops/plain/templates"
+
+
+def _fake_issue():
+    return SimpleNamespace(
+        id=7,
+        type=SimpleNamespace(value="perf"),
+        title="Reduce p50_ms",
+        description="Speed things up.",
+    )
+
+
+@pytest.fixture
+def prompt():
+    return Prompt(_TEMPLATE_DIR, ComputeBackend.CUDA)
+
+
+def test_implementer_generic_skips_fastapi_language(prompt):
+    out = prompt.render(
+        "implementer/system.j2",
+        reference_path="reference/",
+        runtime_notes="",
+        issue=_fake_issue(),
+        is_generic_example=True,
+        target_check_instructions="Run bash check.sh.",
+        target_bench_instructions="Run bash bench.sh; watch p50_ms.",
+    )
+    assert "uv init" not in out
+    assert "token_throughput > 0" not in out
+    assert "Run bash bench.sh" in out
+
+
+def test_implementer_non_generic_keeps_fastapi_language(prompt):
+    out = prompt.render(
+        "implementer/system.j2",
+        reference_path="reference/model.py",
+        runtime_notes="",
+        issue=_fake_issue(),
+        is_generic_example=False,
+        target_check_instructions=None,
+        target_bench_instructions=None,
+    )
+    assert "FastAPI" in out
+
+
+def test_judge_generic_skips_pytest_and_vibeservemodel_language(prompt):
+    out = prompt.render(
+        "judge/system.j2",
+        accuracy_checker_path=None,
+        bench_path=None,
+        issue=_fake_issue(),
+        is_generic_example=True,
+        target_check_instructions="Run bash check.sh.",
+        target_bench_instructions="Run bash bench.sh.",
+    )
+    assert "from_pretrained" not in out
+    assert "uv run pytest" not in out
+    assert "Run bash check.sh" in out
+
+
+def test_judge_non_generic_keeps_pytest_language(prompt):
+    out = prompt.render(
+        "judge/system.j2",
+        accuracy_checker_path="/workspace/acc_checker",
+        bench_path="/workspace/bench",
+        issue=_fake_issue(),
+        is_generic_example=False,
+        target_check_instructions=None,
+        target_bench_instructions=None,
+    )
+    assert "uv run pytest" in out
+
+
+def test_perf_eval_generic_skips_ttft_tpot_language(prompt):
+    out = prompt.render(
+        "perf_eval/system.j2",
+        load_levels=None,
+        progress_path="progress.md",
+        perf_metrics_path="perf_metrics.json",
+        previous_evaluator_feedback=[],
+        issue_create_cap=3,
+        runtime_notes="",
+        is_generic_example=True,
+        target_bench_instructions="Run bash bench.sh; watch p50_ms.",
+        primary_metric="p50_ms",
+        metric_direction="minimize",
+    )
+    # The generic branch legitimately *mentions* TTFT/TPOT/--max-tokens as
+    # things NOT to expect -- so assert the Python-serving-only *procedural*
+    # sections (multi-load-level curl/uvicorn steps, the ttft/tpot output
+    # schema block) are absent, not that the words never appear at all.
+    assert "uv run python bench/benchmark.py" not in out
+    assert '"ttft": {"mean"' not in out
+    assert "p50_ms" in out
+    assert "minimize" in out
+
+
+def test_perf_eval_non_generic_keeps_ttft_tpot_language(prompt):
+    out = prompt.render(
+        "perf_eval/system.j2",
+        load_levels=None,
+        progress_path="progress.md",
+        perf_metrics_path="perf_metrics.json",
+        previous_evaluator_feedback=[],
+        issue_create_cap=3,
+        runtime_notes="",
+        is_generic_example=False,
+        target_bench_instructions=None,
+        primary_metric=None,
+        metric_direction=None,
+    )
+    assert "TTFT" in out

--- a/tests/test_run_environment_manifest.py
+++ b/tests/test_run_environment_manifest.py
@@ -1,0 +1,299 @@
+from pathlib import Path
+
+import pytest
+
+from vibe_serve.example_manifest import ExampleManifest
+from vibe_serve.sandbox import run_environment as re_mod
+
+
+def _manifest(tmp_path: Path, *, needs_socket: bool, with_setup_sh: bool) -> ExampleManifest:
+    example_dir = tmp_path / "examples" / "fake"
+    example_dir.mkdir(parents=True)
+    (example_dir / "vibeserve.example.toml").write_text(
+        f"""
+        [setup]
+        needs_docker_socket = {"true" if needs_socket else "false"}
+
+        [benchmark]
+        primary_metric = "p50_ms"
+        direction = "minimize"
+        """
+    )
+    if with_setup_sh:
+        (example_dir / "setup.sh").write_text("#!/bin/bash\nexit 0\n")
+    return ExampleManifest.load(example_dir)
+
+
+def test_docker_socket_not_mounted_by_default(tmp_path, monkeypatch):
+    manifest = _manifest(tmp_path, needs_socket=False, with_setup_sh=False)
+    logs = []
+
+    class FakeBackend:
+        def make_sandbox(self, kind, **kwargs):
+            self.captured_bind_mounts = kwargs["bind_mounts"]
+            self.captured_setup_fns = kwargs.get("setup_fns", [])
+
+            class FakeSandbox:
+                def start(self_inner):
+                    pass
+
+                def stop(self_inner):
+                    pass
+
+            return FakeSandbox()
+
+    backend = FakeBackend()
+    request = re_mod.RunEnvironmentRequest(
+        log_dir=tmp_path / "logs",
+        workspace=tmp_path / "workspace",
+        ref_dir=None,
+        backend=backend,
+        agent_backend="cli",
+        cli_provider=None,
+        log=logs.append,
+        example_manifest=manifest,
+    )
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "workspace").mkdir()
+
+    env = re_mod.DockerEnvironment.from_options({})
+    env.open(request)
+
+    assert (
+        "/var/run/docker.sock",
+        "/var/run/docker.sock",
+        False,
+    ) not in backend.captured_bind_mounts
+    assert not any("docker.sock" in line for line in logs)
+
+
+def test_docker_socket_mounted_when_requested(tmp_path):
+    manifest = _manifest(tmp_path, needs_socket=True, with_setup_sh=False)
+    logs = []
+
+    class FakeBackend:
+        def make_sandbox(self, kind, **kwargs):
+            self.captured_bind_mounts = kwargs["bind_mounts"]
+
+            class FakeSandbox:
+                def start(self_inner):
+                    pass
+
+                def stop(self_inner):
+                    pass
+
+            return FakeSandbox()
+
+    backend = FakeBackend()
+    request = re_mod.RunEnvironmentRequest(
+        log_dir=tmp_path / "logs",
+        workspace=tmp_path / "workspace",
+        ref_dir=None,
+        backend=backend,
+        agent_backend="cli",
+        cli_provider=None,
+        log=logs.append,
+        example_manifest=manifest,
+    )
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "workspace").mkdir()
+
+    env = re_mod.DockerEnvironment.from_options({})
+    env.open(request)
+
+    assert ("/var/run/docker.sock", "/var/run/docker.sock", False) in backend.captured_bind_mounts
+    assert any("Docker daemon" in line for line in logs)
+
+
+def test_setup_sh_runs_and_raises_on_nonzero_exit(tmp_path):
+    manifest = _manifest(tmp_path, needs_socket=False, with_setup_sh=True)
+
+    executed = {}
+
+    class FakeSandbox:
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def execute(self, cmd, timeout=None):
+            executed["cmd"] = cmd
+            executed["timeout"] = timeout
+
+            class R:
+                exit_code = 1
+                output = "boom"
+
+            return R()
+
+    class FakeBackend:
+        def make_sandbox(self, kind, **kwargs):
+            self.setup_fns = kwargs.get("setup_fns", [])
+            return FakeSandbox()
+
+    backend = FakeBackend()
+    request = re_mod.RunEnvironmentRequest(
+        log_dir=tmp_path / "logs",
+        workspace=tmp_path / "workspace",
+        ref_dir=None,
+        backend=backend,
+        agent_backend="cli",
+        cli_provider=None,
+        example_manifest=manifest,
+    )
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "workspace").mkdir()
+
+    env = re_mod.DockerEnvironment.from_options({})
+    with pytest.raises(RuntimeError, match="setup.sh failed"):
+        env.open(request)
+        for fn in backend.setup_fns:
+            fn(FakeSandbox())
+
+    # If setup_fns weren't invoked automatically by open() in this fake
+    # harness, invoke the one we captured directly to prove it raises.
+    if "cmd" not in executed:
+        with pytest.raises(RuntimeError, match="setup.sh failed"):
+            for fn in backend.setup_fns:
+                fn(FakeSandbox())
+
+
+def _manifest_with_scripts(tmp_path: Path, scripts) -> ExampleManifest:
+    example_dir = tmp_path / "examples" / "scripted"
+    example_dir.mkdir(parents=True)
+    (example_dir / "vibeserve.example.toml").write_text(
+        '[benchmark]\nprimary_metric = "p50_ms"\ndirection = "minimize"\n'
+    )
+    for name in scripts:
+        (example_dir / name).write_text("#!/bin/bash\nexit 0\n")
+    return ExampleManifest.load(example_dir)
+
+
+def _request(tmp_path: Path, backend, manifest, logs=None):
+    (tmp_path / "logs").mkdir(exist_ok=True)
+    (tmp_path / "workspace").mkdir(exist_ok=True)
+    return re_mod.RunEnvironmentRequest(
+        log_dir=tmp_path / "logs",
+        workspace=tmp_path / "workspace",
+        ref_dir=None,
+        backend=backend,
+        agent_backend="cli",
+        cli_provider=None,
+        log=(logs.append if logs is not None else None),
+        example_manifest=manifest,
+    )
+
+
+def test_manifest_env_vars_injected_into_container_env(tmp_path):
+    manifest = _manifest_with_scripts(tmp_path, [])
+    captured = {}
+
+    class FakeSandbox:
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    class FakeBackend:
+        def make_sandbox(self, kind, **kwargs):
+            captured.update(kwargs)
+            return FakeSandbox()
+
+    re_mod.DockerEnvironment.from_options({}).open(_request(tmp_path, FakeBackend(), manifest))
+    env = captured["extra_env"]
+    assert env["VIBESERVE_LOAD_LEVEL"] == "medium"
+    assert env["VIBESERVE_OUTPUT_DIR"] == "/workspace/example_output"
+    assert "VIBESERVE_BASE_URL" in env
+
+
+def test_build_sh_runs_after_setup_sh(tmp_path):
+    manifest = _manifest_with_scripts(tmp_path, ["setup.sh", "build.sh"])
+    executed = []
+
+    class FakeSandbox:
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def execute(self, cmd, timeout=None):
+            executed.append(cmd)
+
+            class R:
+                exit_code = 0
+                output = ""
+
+            return R()
+
+    captured = {}
+
+    class FakeBackend:
+        def make_sandbox(self, kind, **kwargs):
+            captured.update(kwargs)
+            return FakeSandbox()
+
+    re_mod.DockerEnvironment.from_options({}).open(_request(tmp_path, FakeBackend(), manifest))
+    for fn in captured["setup_fns"]:
+        fn(FakeSandbox())
+    setup_i = next(i for i, c in enumerate(executed) if "setup.sh" in c)
+    build_i = next(i for i, c in enumerate(executed) if "build.sh" in c)
+    assert setup_i < build_i
+
+
+def test_teardown_sh_runs_on_close_before_stop(tmp_path):
+    manifest = _manifest_with_scripts(tmp_path, ["teardown.sh"])
+    events = []
+
+    class FakeSandbox:
+        def start(self):
+            pass
+
+        def stop(self):
+            events.append("stop")
+
+        def execute(self, cmd, timeout=None):
+            events.append(f"exec:{cmd}")
+
+            class R:
+                exit_code = 0
+                output = ""
+
+            return R()
+
+    class FakeBackend:
+        def make_sandbox(self, kind, **kwargs):
+            return FakeSandbox()
+
+    session = re_mod.DockerEnvironment.from_options({}).open(
+        _request(tmp_path, FakeBackend(), manifest)
+    )
+    assert not any(e.startswith("exec:") for e in events)
+    session.close()
+    exec_i = next(i for i, e in enumerate(events) if "teardown.sh" in e)
+    assert exec_i < events.index("stop")
+
+
+def test_teardown_sh_failure_does_not_raise(tmp_path):
+    manifest = _manifest_with_scripts(tmp_path, ["teardown.sh"])
+
+    class FakeSandbox:
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def execute(self, cmd, timeout=None):
+            raise RuntimeError("boom")
+
+    class FakeBackend:
+        def make_sandbox(self, kind, **kwargs):
+            return FakeSandbox()
+
+    session = re_mod.DockerEnvironment.from_options({}).open(
+        _request(tmp_path, FakeBackend(), manifest)
+    )
+    session.close()


### PR DESCRIPTION
# Generic Example Directory Support

Initially, VibeServe assumed every target was a Python model-serving example (a single reference.py, a checker.py, a benchmark.py, a `/health` endpoint, and a `VibeServeModel` class). This change lets a target be described by a manifest file plus a small set of shell scripts, so a more examples, including microservices, data-structure targets, and non-Python targets, can be optimized too. All existing examples keep working unchanged.

## Implementation Detaills

The follow five tasks have been implemented, keeping in mind the requirements outlined in the issue:

1. `--example <dir>` discovers `vibeserve.example.toml` and the root-level lifecycle scripts.
  - `_expand_example_flag` in `src/vibe_serve/cli.py` expands `--example <dir>` into `--ref <dir>/reference`, `--acc-checker <dir>/accuracy_checker`, `--bench <dir>/benchmark`, only for flags the user did not pass explicitly.
  - `ExampleManifest.detect` in `src/vibe_serve/example_manifest.py` finds the manifest and `_RunContext` switches to the generic contract.
2. Existing `--ref`, `--acc-checker`, `--bench` flows continue to work.
  - When no manifest is present, `_RunContext` uses the original legacy path. Verified against all nine `examples/model-serving/*` targets and `examples/data-structures/queue-default`.
3. Judge and profiler prompts use the manifest and scripts instead of assuming `/health`, `checker.py`, `benchmark.py`.
  - `render_check_instructions` and `render_bench_instructions` on the manifest produce the text injected into the Judge, Implementer, and Mutator prompts.
  - Prompt templates in all four loops (agent, plain, evolve, openevolve) branch on `is_generic_example` and drop the FastAPI / uv / pytest / TTFT-TPOT specific sections for generic targets.
4. Non-Python checker and benchmark implementations are supported.
  - check.sh and bench.sh may call anything (compiled binaries, other languages, docker compose). The framework only reads their exit code and, for bench.sh, their JSONL metric output.
5. Benchmark JSONL output is parsed and the declared primary metric is used for comparison.
  - `ExampleManifest.parse_metrics` parses lines of the form `{"metric": "<name>", "value": <number>}`.
  - `run_example_benchmark` in `src/vibe_serve/loops/profiler.py` runs bench.sh in the sandbox, parses its output, and returns a `ProfilerSummary` whose `perf_metric` and `metrics` fields the loops already consume.
  - `to_objective` (wired in `_resolve_objectives` in `src/vibe_serve/cli.py`) turns the declared `primary_metric` and `direction` into the evolve loop's objective, so ranking uses the declared metric with the declared direction.



## The manifest format

The manifest file is named `vibeserve.example.toml` and sits at the example root, next to the lifecycle scripts and `OBJECTIVE.md`. Only the `[benchmark]` section is required.

```
[benchmark]
primary_metric = "p50_ms"
direction = "minimize"
metrics_format = "jsonl"

[service]
base_url = "http://localhost:8080"
health_check = "GET /health"
readiness_timeout_sec = 60

[workspace]
candidate_path = "src"
requires_model_weights = false
externally_managed = false

[setup]
needs_docker_socket = false
timeout_sec = 300

[profiler]
kind = "none"
```

Field notes:

- `benchmark.primary_metric` and `benchmark.direction` are required. `direction` is `minimize` or `maximize`. `metrics_format` defaults to `jsonl`.
- `service.health_check` must be `METHOD path`, for example `GET /health`.
- `workspace.requires_model_weights` defaults to false for generic examples.
- `workspace.externally_managed` set to true supports targets that have no `reference/` directory at all.
- `setup.needs_docker_socket` set to true bind-mounts the host docker socket into the sandbox. This is rejected when running with `--modal`.
- `profiler.kind` is `none` by default for generic examples.



## Lifecycle scripts

All scripts live at the example root and receive the environment variables described below.

- setup.sh runs once when the container starts. Use it to start dependencies, for example `docker compose up`. It must exit 0 and should block until the service is ready.
- build.sh runs once right after setup.sh. Use it to compile checker or benchmark tools.
- check.sh runs correctness checks. Exit 0 means pass, nonzero means fail. It is surfaced to the agent through the judge prompt.
- bench.sh runs the benchmark and prints JSONL metrics. The framework parses its output for the primary metric.
- teardown.sh runs on session close for cleanup. It is best effort and never fails the run.

check.sh and bench.sh are required. setup.sh, build.sh, and teardown.sh are optional.

## Environment variables

Every lifecycle script receives these, and they are also present in the container environment so agent-run scripts see them:

- VIBESERVE_BASE_URL comes from `service.base_url`.
- VIBESERVE_OUTPUT_DIR is `/workspace/example_output`. bench.sh should write its JSONL output here or to stdout.
- VIBESERVE_LOAD_LEVEL is a load hint, default `medium`.

## Benchmark metrics

bench.sh emits one JSON object per line:

```
{"metric": "p50_ms", "value": 5.64}
{"metric": "throughput_rps", "value": 1180.0}
```

Lines that are blank, not JSON, or missing a string metric or numeric value are ignored, so bench.sh may print human-readable logs alongside metrics. The value of `benchmark.primary_metric` is the number used for comparison. For the evolve loop, ranking uses that metric with the declared direction.



## To Note

- Fixed an ordering bug in `_RunContext.__init__` where `example_manifest` was read during profiler resolution before it was assigned. This broke every `_RunContext` construction and surfaced once the full suite could run.
- The evolve profiler path no longer falls through to the nsys template when the profiler kind is none.
- `--modal` combined with `setup.needs_docker_socket = true` now fails fast with a clear message instead of silently running without a docker socket.



## Known limitations

- `service.health_check` and `service.readiness_timeout_sec` are parsed and available, but the framework does not itself poll the health endpoint. Readiness is expected to be handled inside setup.sh, which must block until the service is ready and then exit 0. 
- No example in the repository ships a `vibeserve.example.toml` or lifecycle scripts yet.  The generic path is therefore covered by unit and integration tests using a fake sandbox, not by a live end-to-end run inside this repository for any of the examples, which could be tested after integration.



## Setup

The project uses uv.

```
cd vibe-serve
uv sync --dev
```

If uv is not installed:

```
python -m pip install uv
```

On some machines the librosa dependency chain builds llvmlite from source and needs a system LLVM. If uv sync fails on llvmlite, install LLVM first, for example with `brew install llvm` on macOS, then run uv sync again. This is a local toolchain issue only and does not affect CI.

## Running the tests

A quick summary is given below:
- Full suite passes (819 tests), overall coverage ~79%
- ruff lint + format clean

Full suite with coverage, the same command CI runs:

```
uv run python -m pytest -v --cov=vibe_serve --cov=vs_issue_board --cov-report=term-missing --cov-fail-under=75
```

Only the tests added or touched by this issue:

```
uv run python -m pytest \
  tests/test_example_manifest.py \
  tests/test_issue_76_fixes.py \
  tests/test_issue_76_generic_examples.py \
  tests/test_run_environment_manifest.py \
  tests/test_agent_loop_prompt_wiring.py \
  tests/test_evolve_loop_prompt_wiring.py \
  tests/test_plain_loop_prompt_wiring.py \
  tests/test_openevolve_reuses_evolve_prompts.py \
  -v
```

Lint and format, the same commands CI runs:

```
./scripts/check_lint.sh
./scripts/check_format.sh
```

## Trying an example end to end

No generic example ships in the repo yet, but you can confirm the existing legacy examples still run. This runs the queue-default correctness checker and throughput benchmark on a plain Python candidate:

```
EX=examples/data-structures/queue-default
mkdir -p /tmp/qd
printf 'import sys\nsys.path.insert(0, "%s/reference")\nfrom reference import QueueFactory\n\n\nclass VibeServeQueue:\n    def __init__(self, scenario, capacity):\n        self._q = QueueFactory(scenario, capacity)\n\n    def enqueue(self, item, *a, **k):\n        return self._q.enqueue(item, *a, **k)\n\n    def dequeue(self, *a, **k):\n        return self._q.dequeue(*a, **k)\n\n    def size(self):\n        return self._q.size()\n\n    @property\n    def capacity(self):\n        return self._q.capacity\n' "$PWD/$EX" > /tmp/qd/main.py
PYTHONPATH=/tmp/qd uv run python "$EX/accuracy_checker/checker.py" --scenario all --ops 2000
uv run python "$EX/benchmark/benchmark.py" --use-reference --scenario all --duration 1 --warmup 0.2
```

To try a real generic target, create an example directory that contains `vibeserve.example.toml`, the required check.sh and bench.sh, and any of the optional setup.sh, build.sh, teardown.sh, then run:

```
uv run vibe-serve --outer-loop evolve --example examples/<your-example>
```

