### PR TITLE
Resolve agent domain from input manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,22 +76,19 @@ correctness/performance/integrity gates the judge enforces. It answers *"what
 kind of system is this, and what does 'good' mean here?"* — kept separate from
 the neutral prompt skeleton and from the per-task I/O contract (`--modality`).
 
-Each input bundle declares its domain in `vibeserve.input.toml`. You can
-override it with `--domain` when running the agent loop:
+Each input bundle declares its domain in `vibeserve.input.toml`:
 
-```bash
-vibe-serve --outer-loop agent --domain llm-serving ...
-vibe-serve --outer-loop agent --domain generic ...          # no domain context
+```toml
+[agent]
+domain = "llm-serving"
 ```
 
-If `--domain` differs from the manifest's `[agent].domain`, the CLI prints a
-warning and uses the explicit override. `--domain` takes a registered domain
-name such as `llm-serving` or `generic`. A domain is an in-repo package: prompt
-templates plus optional environment setup/teardown hooks. The package's
-`templates/` directory contains role files such as `implementer.md`, `judge.md`,
-and optionally `single_agent.md`; those files drop into the prompts at labelled
-points. Omit `single_agent.md` and it's derived from `implementer.md` plus
-`judge.md`.
+The domain must be a registered name such as `llm-serving` or `generic`. A
+domain is an in-repo package: prompt templates plus optional environment
+setup/teardown hooks. The package's `templates/` directory contains role files
+such as `implementer.md`, `judge.md`, and optionally `single_agent.md`; those
+files drop into the prompts at labelled points. Omit `single_agent.md` and it's
+derived from `implementer.md` plus `judge.md`.
 
 Full authoring guide: [`src/vibe_serve/domains/README.md`](src/vibe_serve/domains/README.md).
 

--- a/README.md
+++ b/README.md
@@ -76,19 +76,22 @@ correctness/performance/integrity gates the judge enforces. It answers *"what
 kind of system is this, and what does 'good' mean here?"* — kept separate from
 the neutral prompt skeleton and from the per-task I/O contract (`--modality`).
 
-Select one with `--domain` (agent loop):
+Each input bundle declares its domain in `vibeserve.input.toml`. You can
+override it with `--domain` when running the agent loop:
 
 ```bash
-vibe-serve --outer-loop agent --domain llm-serving ...      # default
+vibe-serve --outer-loop agent --domain llm-serving ...
 vibe-serve --outer-loop agent --domain generic ...          # no domain context
 ```
 
-`--domain` takes a registered domain name such as `llm-serving` or `generic`.
-A domain is an in-repo package: prompt templates plus optional environment
-setup/teardown hooks. The package's `templates/` directory contains role files such as
-`implementer.md`, `judge.md`, and optionally `single_agent.md`; those files drop
-into the prompts at labelled points. Omit `single_agent.md` and it's derived
-from `implementer.md` plus `judge.md`.
+If `--domain` differs from the manifest's `[agent].domain`, the CLI prints a
+warning and uses the explicit override. `--domain` takes a registered domain
+name such as `llm-serving` or `generic`. A domain is an in-repo package: prompt
+templates plus optional environment setup/teardown hooks. The package's
+`templates/` directory contains role files such as `implementer.md`, `judge.md`,
+and optionally `single_agent.md`; those files drop into the prompts at labelled
+points. Omit `single_agent.md` and it's derived from `implementer.md` plus
+`judge.md`.
 
 Full authoring guide: [`src/vibe_serve/domains/README.md`](src/vibe_serve/domains/README.md).
 
@@ -122,6 +125,7 @@ Each evaluation target lives under `examples/<name>/`:
 ```
 examples/<name>/
 ├── OBJECTIVE.md          # free-form deployment goal (model + hardware + workload + interface)
+├── vibeserve.input.toml  # manifest-declared domain, checker, benchmark, and optional inputs
 ├── reference/            # reference HuggingFace Transformers implementation
 │   ├── reference.py
 │   ├── config.json
@@ -131,10 +135,10 @@ examples/<name>/
 └── README.md             # human-readable description
 ```
 
-Pass the bundle root with `--input examples/<name>/` to derive `--ref`,
-`--acc-checker`, and `--bench` from the standard subdirectory names. You can
-still pass those three flags explicitly; explicit paths override `--input`
-defaults when you need a custom checker or benchmark.
+Pass the bundle root with `--input examples/<name>/`. The manifest declares the
+agent domain, correctness command, benchmark command, optional starter
+workspace, optional trusted evaluator source, and optional benchmark result
+metric.
 
 `OBJECTIVE.md` is read at the start of every run and must live next to the
 `reference/` directory (sibling, not inside). See `examples/model-serving/Llama-3-8B/`, `examples/model-serving/moonshine-streaming/`, `examples/model-serving/qwen3-32b-code-edit/`, `examples/model-serving/olmo-hybrid-prefix-caching/`, `examples/model-serving/Llama-3.1-8B-Instruct-MLX-8bit/`, `examples/model-serving/show-o2-1.5B-HQ-h100/`, and `examples/model-serving/show-o2-1.5B-HQ-macbook/` for the paper scenarios.

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -15,7 +15,7 @@ Several flags look independent, but they combine into one execution contract:
 | Compute backend | `--backend` | Hardware/runtime target: `cuda`, `metal`, `trainium`, or `cpu`. |
 | Runtime environment | `--docker`, `--modal` | Where agent commands execute: local shell, Docker container, or Modal-backed workflow. |
 | Profiler | `--profiler` | Bottleneck evidence source: `nsys`, `torch`, `neuron`, or `auto`. |
-| Domain | `--domain` | Agent-loop problem-space package, such as `llm-serving` or `generic`. |
+| Domain | `--domain` | Optional agent-loop override for the input manifest's problem-space package, such as `llm-serving` or `generic`. |
 | Modality | `--modality` | Per-task I/O contract, such as `text_generation` or `speech_to_text`. |
 | Skills | `--skills-dir`, `--no-skills` | Candidate skill roots and the ablation switch that disables skill loading. |
 | Target inputs | `--input` | Target bundle directory with manifest-declared correctness and benchmark commands. |
@@ -99,11 +99,14 @@ Registered domains include:
 
 | Domain | Meaning |
 | --- | --- |
-| `llm-serving` | Default LLM-serving guidance, including serving-system skills and judge gates. |
+| `llm-serving` | LLM-serving guidance, including serving-system skills and judge gates. |
 | `generic` | No extra domain guidance. Useful for custom/non-LLM targets. |
 
-New domains are added in source by registering a domain package with optional
-environment setup/teardown hooks.
+Each input bundle must declare `[agent].domain` in `vibeserve.input.toml`.
+When `--domain` is omitted, the agent loop uses that manifest value. When
+`--domain` is provided and differs from the manifest, the CLI warns and uses the
+explicit override. New domains are added in source by registering a domain
+package with optional environment setup/teardown hooks.
 
 `--modality` supplies the task I/O contract, such as text generation or
 speech-to-text. Domains and modalities may define language, toolchain, and
@@ -168,6 +171,9 @@ command:
 
 ```toml
 version = 1
+
+[agent]
+domain = "generic"
 
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -15,7 +15,7 @@ Several flags look independent, but they combine into one execution contract:
 | Compute backend | `--backend` | Hardware/runtime target: `cuda`, `metal`, `trainium`, or `cpu`. |
 | Runtime environment | `--docker`, `--modal` | Where agent commands execute: local shell, Docker container, or Modal-backed workflow. |
 | Profiler | `--profiler` | Bottleneck evidence source: `nsys`, `torch`, `neuron`, or `auto`. |
-| Domain | `--domain` | Optional agent-loop override for the input manifest's problem-space package, such as `llm-serving` or `generic`. |
+| Domain | `[agent].domain` in `vibeserve.input.toml` | Agent-loop problem-space package, such as `llm-serving` or `generic`. |
 | Modality | `--modality` | Per-task I/O contract, such as `text_generation` or `speech_to_text`. |
 | Skills | `--skills-dir`, `--no-skills` | Candidate skill roots and the ablation switch that disables skill loading. |
 | Target inputs | `--input` | Target bundle directory with manifest-declared correctness and benchmark commands. |
@@ -28,7 +28,7 @@ come from the domain and input bundle, not the interface mode.
 
 | Value | Behavior | Notes |
 | --- | --- | --- |
-| `agent` | Orchestrator-driven loop with implementer, judge, and profiler roles. | Default. Supports `--domain`, `--interface`, and `--inner-loop`. |
+| `agent` | Orchestrator-driven loop with implementer, judge, and profiler roles. | Default. Supports `--interface` and `--inner-loop`. |
 | `plain` | Issue-board loop with deterministic issue draining and perf evaluation. | Uses backend prompt fragments from `src/vibe_serve/templates/_backend/`. |
 | `evolve` | Evolutionary search over candidate implementations. | Uses mutator, judge, and profiler roles. |
 | `openevolve` | MAP-Elites-style evolutionary loop. | Reuses evolve mutator, judge, and profiler prompts. |
@@ -94,19 +94,17 @@ receive a GPU-kernel workflow.
 
 ## Domain and Modality
 
-`--domain` supplies cross-cutting problem-space context for the agent loop.
-Registered domains include:
+`[agent].domain` in `vibeserve.input.toml` supplies cross-cutting problem-space
+context for the agent loop. Registered domains include:
 
 | Domain | Meaning |
 | --- | --- |
 | `llm-serving` | LLM-serving guidance, including serving-system skills and judge gates. |
 | `generic` | No extra domain guidance. Useful for custom/non-LLM targets. |
 
-Each input bundle must declare `[agent].domain` in `vibeserve.input.toml`.
-When `--domain` is omitted, the agent loop uses that manifest value. When
-`--domain` is provided and differs from the manifest, the CLI warns and uses the
-explicit override. New domains are added in source by registering a domain
-package with optional environment setup/teardown hooks.
+Each input bundle must declare `[agent].domain`; there is no CLI override. New
+domains are added in source by registering a domain package with optional
+environment setup/teardown hooks.
 
 `--modality` supplies the task I/O contract, such as text generation or
 speech-to-text. Domains and modalities may define language, toolchain, and
@@ -253,7 +251,6 @@ Over-the-wire service target:
 vibe-serve \
   --outer-loop agent \
   --interface service \
-  --domain generic \
   --input examples/<target>
 ```
 

--- a/examples/data-structures/kvstore-default/vibeserve.input.toml
+++ b/examples/data-structures/kvstore-default/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "generic"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 timeout_seconds = 120

--- a/examples/data-structures/queue-mpmc/vibeserve.input.toml
+++ b/examples/data-structures/queue-mpmc/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "generic"
+
 [workspace]
 seed = "../../starters/queue-rs"
 

--- a/examples/data-structures/queue-mpsc/vibeserve.input.toml
+++ b/examples/data-structures/queue-mpsc/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "generic"
+
 [workspace]
 seed = "../../starters/queue-rs"
 

--- a/examples/data-structures/queue-spsc/vibeserve.input.toml
+++ b/examples/data-structures/queue-spsc/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "generic"
+
 [workspace]
 seed = "../../starters/queue-rs"
 

--- a/examples/microservices/social-network-read-timeline/vibeserve.input.toml
+++ b/examples/microservices/social-network-read-timeline/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "generic"
+
 [accuracy]
 command = ["./accuracy_checker/checker"]
 timeout_seconds = 120

--- a/examples/microservices/train-ticket/OBJECTIVE.md
+++ b/examples/microservices/train-ticket/OBJECTIVE.md
@@ -1,0 +1,15 @@
+Optimize a Train Ticket microservice deployment for read-only API throughput
+while preserving response correctness.
+
+Headline metric: `requests_per_second` from `benchmark/benchmark.py` (maximize).
+
+The target is a running Train Ticket gateway or direct-service deployment. The
+candidate must preserve the existing HTTP API behavior checked by
+`accuracy_checker/checker.py`, including service welcome endpoints, list
+response envelopes, expected item fields, and cross-service referential
+integrity.
+
+The benchmark exercises a fixed-rate read-only workload across station, train,
+trip, route, price, config, and welcome endpoints. Improve successful completed
+requests per second without increasing the error rate beyond the benchmark's
+configured threshold.

--- a/examples/microservices/train-ticket/vibeserve.input.toml
+++ b/examples/microservices/train-ticket/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "generic"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 timeout_seconds = 120

--- a/examples/model-serving/Llama-3-8B-trn2/vibeserve.input.toml
+++ b/examples/model-serving/Llama-3-8B-trn2/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "llm-serving"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 timeout_seconds = 120

--- a/examples/model-serving/Llama-3-8B/vibeserve.input.toml
+++ b/examples/model-serving/Llama-3-8B/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "llm-serving"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 timeout_seconds = 120

--- a/examples/model-serving/Llama-3.1-8B-Instruct-MLX-8bit/vibeserve.input.toml
+++ b/examples/model-serving/Llama-3.1-8B-Instruct-MLX-8bit/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "llm-serving"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 timeout_seconds = 120

--- a/examples/model-serving/moonshine-streaming/vibeserve.input.toml
+++ b/examples/model-serving/moonshine-streaming/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "llm-serving"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 timeout_seconds = 120

--- a/examples/model-serving/olmo-hybrid-prefix-caching/vibeserve.input.toml
+++ b/examples/model-serving/olmo-hybrid-prefix-caching/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "llm-serving"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 timeout_seconds = 120

--- a/examples/model-serving/qwen3-32b-code-edit/vibeserve.input.toml
+++ b/examples/model-serving/qwen3-32b-code-edit/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "llm-serving"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 timeout_seconds = 120

--- a/examples/model-serving/show-o2-1.5B-HQ-h100/vibeserve.input.toml
+++ b/examples/model-serving/show-o2-1.5B-HQ-h100/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "llm-serving"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 timeout_seconds = 120

--- a/examples/model-serving/show-o2-1.5B-HQ-macbook/vibeserve.input.toml
+++ b/examples/model-serving/show-o2-1.5B-HQ-macbook/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "llm-serving"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 timeout_seconds = 120

--- a/examples/model-serving/show-o2-1.5B-HQ/OBJECTIVE.md
+++ b/examples/model-serving/show-o2-1.5B-HQ/OBJECTIVE.md
@@ -1,0 +1,15 @@
+Optimize a Show-o2 1.5B HQ text-to-image server while preserving the
+image-generation HTTP contract.
+
+Headline metric: `latency.p50` from `benchmark/benchmark.py` (minimize).
+
+Build an OpenAI-like `/v1/images/generations` service for
+`showlab/show-o2-1.5B-HQ` that returns valid prompt-conditioned PNG images.
+The server must expose `/health`, accept benchmark request fields such as
+`prompt`, `num_inference_steps`, `guidance_scale`, `seed`, `include_timings`,
+`postprocess_mode`, and `response_format`, and return either OpenAI-style JSON
+with `data[0].b64_json` or raw image bytes when requested.
+
+The accuracy checker verifies HTTP readiness and valid image responses. Do not
+exploit the smoke test by returning canned images; benchmark runs may inspect
+image hashes, dimensions, and saved outputs for drift.

--- a/examples/model-serving/show-o2-1.5B-HQ/vibeserve.input.toml
+++ b/examples/model-serving/show-o2-1.5B-HQ/vibeserve.input.toml
@@ -1,5 +1,8 @@
 version = 1
 
+[agent]
+domain = "llm-serving"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 timeout_seconds = 120

--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -28,7 +28,7 @@ from vibe_serve.constants import (
     PROJECT_ROOT,
     ComputeBackend,
 )
-from vibe_serve.domains.base import DEFAULT_DOMAIN, DomainName
+from vibe_serve.domains.base import DomainName
 from vibe_serve.domains.registry import registered_domains
 from vibe_serve.input_manifest import InputBundle, load_input_bundle
 from vibe_serve.profilers import CLI_PROFILER_CHOICES, ProfilerKind, coerce_profiler_kind
@@ -424,12 +424,13 @@ def _build_agent_parser() -> argparse.ArgumentParser:
         "--domain",
         type=_parse_domain_name,
         choices=tuple(DomainName),
-        default=DEFAULT_DOMAIN,
+        default=None,
         metavar="NAME",
         help=(
             "Domain package supplying the implementer/judge context for your "
-            f"problem space. Registered domains: {', '.join(registered_domains())}. Default: "
-            f"{DEFAULT_DOMAIN}. See domains/README.md."
+            "problem space. Optional; defaults to [agent].domain from "
+            "vibeserve.input.toml. "
+            f"Registered domains: {', '.join(registered_domains())}. See domains/README.md."
         ),
     )
     parser.add_argument(
@@ -471,6 +472,26 @@ def _validate_target_inputs(args: argparse.Namespace) -> None:
     except (FileNotFoundError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(2)
+    if hasattr(args, "domain"):
+        _resolve_agent_domain(args)
+
+
+def _resolve_agent_domain(args: argparse.Namespace) -> None:
+    """Resolve optional ``--domain`` against the input manifest."""
+
+    bundle: InputBundle = args.input_bundle
+    manifest_domain = bundle.domain
+    cli_domain = args.domain
+    if cli_domain is None:
+        args.domain = manifest_domain
+        return
+    if cli_domain is not manifest_domain:
+        print(
+            "Warning: --domain "
+            f"{cli_domain.value!r} differs from {bundle.manifest_path}'s "
+            f"[agent].domain {manifest_domain.value!r}; using --domain override.",
+            file=sys.stderr,
+        )
 
 
 def _validate_agent(args: argparse.Namespace) -> None:

--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -28,8 +28,6 @@ from vibe_serve.constants import (
     PROJECT_ROOT,
     ComputeBackend,
 )
-from vibe_serve.domains.base import DomainName
-from vibe_serve.domains.registry import registered_domains
 from vibe_serve.input_manifest import InputBundle, load_input_bundle
 from vibe_serve.profilers import CLI_PROFILER_CHOICES, ProfilerKind, coerce_profiler_kind
 from vibe_serve.sandbox.run_environment import (
@@ -49,15 +47,6 @@ _MODALITIES = (
 )
 
 _MODAL_PROFILERS = frozenset({ProfilerKind.AUTO, ProfilerKind.TORCH, ProfilerKind.NONE})
-
-
-def _parse_domain_name(value: str) -> DomainName:
-    try:
-        return DomainName(value)
-    except ValueError as exc:
-        raise argparse.ArgumentTypeError(
-            f"Unknown domain {value!r}. Choose from: {', '.join(registered_domains())}."
-        ) from exc
 
 
 def _parse_profiler_kind(value: str) -> ProfilerKind:
@@ -421,19 +410,6 @@ def _build_agent_parser() -> argparse.ArgumentParser:
     parser.add_argument("--start-round", type=int, default=None, metavar="N")
     parser.add_argument("--modality", default=None, choices=_MODALITIES)
     parser.add_argument(
-        "--domain",
-        type=_parse_domain_name,
-        choices=tuple(DomainName),
-        default=None,
-        metavar="NAME",
-        help=(
-            "Domain package supplying the implementer/judge context for your "
-            "problem space. Optional; defaults to [agent].domain from "
-            "vibeserve.input.toml. "
-            f"Registered domains: {', '.join(registered_domains())}. See domains/README.md."
-        ),
-    )
-    parser.add_argument(
         "--interface",
         choices=["inprocess", "service"],
         default="inprocess",
@@ -472,26 +448,6 @@ def _validate_target_inputs(args: argparse.Namespace) -> None:
     except (FileNotFoundError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(2)
-    if hasattr(args, "domain"):
-        _resolve_agent_domain(args)
-
-
-def _resolve_agent_domain(args: argparse.Namespace) -> None:
-    """Resolve optional ``--domain`` against the input manifest."""
-
-    bundle: InputBundle = args.input_bundle
-    manifest_domain = bundle.domain
-    cli_domain = args.domain
-    if cli_domain is None:
-        args.domain = manifest_domain
-        return
-    if cli_domain is not manifest_domain:
-        print(
-            "Warning: --domain "
-            f"{cli_domain.value!r} differs from {bundle.manifest_path}'s "
-            f"[agent].domain {manifest_domain.value!r}; using --domain override.",
-            file=sys.stderr,
-        )
 
 
 def _validate_agent(args: argparse.Namespace) -> None:
@@ -553,7 +509,7 @@ def _run_agent(args: argparse.Namespace) -> None:
         cli_provider=args.cli_provider,
         backend=backend,
         modality=args.modality,
-        domain=args.domain,
+        domain=bundle.domain,
         interface=args.interface,
         inner_loop=args.inner_loop,
     )

--- a/src/vibe_serve/context.py
+++ b/src/vibe_serve/context.py
@@ -22,7 +22,7 @@ from vibe_serve.constants import (
     PROJECT_ROOT,
     ComputeBackend,
 )
-from vibe_serve.domains.base import DEFAULT_DOMAIN, DomainName
+from vibe_serve.domains.base import DomainName
 from vibe_serve.domains.environment import (
     EnvironmentContext,
     EnvironmentHooks,
@@ -112,7 +112,7 @@ class _RunContext:
         torch_profiler: str | None = None,
         neuron_profiler: str | None = None,
         profiler_kind: ProfilerKind = ProfilerKind.AUTO,
-        profiler_domain: DomainName = DEFAULT_DOMAIN,
+        profiler_domain: DomainName = DomainName.LLM_SERVING,
         skills_dirs: list[str] | None = None,
         run_environment: RunEnvironmentSpec | None = None,
         git_tracking: bool = False,

--- a/src/vibe_serve/domains/README.md
+++ b/src/vibe_serve/domains/README.md
@@ -7,18 +7,14 @@ workflow details, and the same for the single-agent ablation. It's the answer to
 *"what kind of system is this, and what does 'good' mean here?"* — kept separate
 from the neutral prompt skeleton.
 
-Pick one with `--domain` (agent loop):
+Pick one in the input bundle manifest:
 
-```bash
-vibe-serve --outer-loop agent --domain llm-serving ...
-vibe-serve --outer-loop agent --domain generic ...          # no domain context
+```toml
+[agent]
+domain = "llm-serving"
 ```
 
-When `--domain` is omitted, the agent loop uses `[agent].domain` from the
-input bundle's `vibeserve.input.toml`. If both are provided and differ, the CLI
-prints a warning and uses the explicit `--domain` value.
-
-`--domain` accepts a registered repo domain name:
+`domain` accepts a registered repo domain name:
 
 | Domain        | What it does |
 |---------------|--------------|
@@ -110,7 +106,8 @@ Example (inside `judge.md`):
    needs setup/teardown behavior such as mounts or copy exclusions, implement
    `EnvironmentHooks` in that package and attach it to the definition.
 7. Register the definition in `vibe_serve.domains.registry.DOMAINS`.
-8. Run `vibe-serve --outer-loop agent --domain <name> ...`.
+8. Add `[agent].domain = "<name>"` to the input manifest and run
+   `vibe-serve --outer-loop agent ...`.
 
 Domains are registered explicitly so prompt context, environment hooks, and tests
 stay tied to the same domain identity.

--- a/src/vibe_serve/domains/README.md
+++ b/src/vibe_serve/domains/README.md
@@ -10,15 +10,19 @@ from the neutral prompt skeleton.
 Pick one with `--domain` (agent loop):
 
 ```bash
-vibe-serve --outer-loop agent --domain llm-serving ...      # default
+vibe-serve --outer-loop agent --domain llm-serving ...
 vibe-serve --outer-loop agent --domain generic ...          # no domain context
 ```
+
+When `--domain` is omitted, the agent loop uses `[agent].domain` from the
+input bundle's `vibeserve.input.toml`. If both are provided and differ, the CLI
+prints a warning and uses the explicit `--domain` value.
 
 `--domain` accepts a registered repo domain name:
 
 | Domain        | What it does |
 |---------------|--------------|
-| `llm-serving` | The default. LLM inference server context: the `serving-systems` skill/references, `/model` weights, the accuracy + benchmark + reward-hack judge gates. |
+| `llm-serving` | LLM inference server context: the `serving-systems` skill/references, `/model` weights, the accuracy + benchmark + reward-hack judge gates. |
 | `generic`     | Empty — no domain prose injected. The neutral baseline; copy it to start your own. |
 
 ## Anatomy of a domain package

--- a/src/vibe_serve/domains/base.py
+++ b/src/vibe_serve/domains/base.py
@@ -22,8 +22,6 @@ class DomainRole(StrEnum):
     PROFILER = "profiler"
 
 
-DEFAULT_DOMAIN = DomainName.LLM_SERVING
-
 # The roles a domain can contribute to. Each maps to a ``<role>.md`` file in the
 # domain prompt directory and a ``{{ domain_<role> }}`` injection point in the
 # corresponding base prompt.

--- a/src/vibe_serve/domains/llm_serving/templates/README.md
+++ b/src/vibe_serve/domains/llm_serving/templates/README.md
@@ -15,6 +15,6 @@ output correctness.
   static-inspection discipline.
 
 This reproduces vibeserve's original serving-oriented prompts. Input bundles
-select it with `[agent].domain = "llm-serving"`, or users can override with
-`--domain llm-serving`. The `single_agent` ablation reuses a bespoke combined
-section below rather than the default implementer+judge concatenation.
+select it with `[agent].domain = "llm-serving"`. The `single_agent` ablation
+reuses a bespoke combined section below rather than the default implementer+judge
+concatenation.

--- a/src/vibe_serve/domains/llm_serving/templates/README.md
+++ b/src/vibe_serve/domains/llm_serving/templates/README.md
@@ -14,6 +14,7 @@ output correctness.
   performance judging, reward-hack / model-bypass detection, and scope /
   static-inspection discipline.
 
-This is the default domain (`--domain llm-serving`); it reproduces vibeserve's
-original serving-oriented prompts. The `single_agent` ablation reuses a bespoke
-combined section below rather than the default implementer+judge concatenation.
+This reproduces vibeserve's original serving-oriented prompts. Input bundles
+select it with `[agent].domain = "llm-serving"`, or users can override with
+`--domain llm-serving`. The `single_agent` ablation reuses a bespoke combined
+section below rather than the default implementer+judge concatenation.

--- a/src/vibe_serve/input_manifest.py
+++ b/src/vibe_serve/input_manifest.py
@@ -10,6 +10,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from vibe_serve.constants import PROJECT_ROOT
+from vibe_serve.domains.base import DomainName
 
 MANIFEST_NAME = "vibeserve.input.toml"
 
@@ -98,12 +99,21 @@ class BenchmarkCommand(InputCommand):
     result: BenchmarkResult | None = None
 
 
+class AgentInput(BaseModel):
+    """Agent-loop metadata declared by an input bundle."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    domain: DomainName
+
+
 class InputManifest(BaseModel):
     """Versioned evaluator-command manifest for an input bundle."""
 
     model_config = ConfigDict(extra="forbid")
 
     version: Literal[1]
+    agent: AgentInput
     accuracy: InputCommand
     benchmark: BenchmarkCommand
     workspace: WorkspaceInput | None = None
@@ -134,6 +144,10 @@ class InputBundle(BaseModel):
     @property
     def benchmark_command(self) -> tuple[str, ...]:
         return self.manifest.benchmark.command
+
+    @property
+    def domain(self) -> DomainName:
+        return self.manifest.agent.domain
 
     @property
     def accuracy_command_display(self) -> str:

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -838,7 +838,7 @@ def run_agent_loop(
     if interface not in _INTERFACES:
         raise ValueError(f"Unknown interface {interface!r}; choose from {', '.join(_INTERFACES)}")
     if domain is None:
-        raise ValueError("domain is required; pass --domain or declare [agent].domain")
+        raise ValueError("domain is required; declare [agent].domain in vibeserve.input.toml")
     # Resolve the registered domain once (fail fast on an unknown name). The
     # per-role files carry language, tooling, and use-case-specific contracts.
     domain_definition = resolve_domain(domain)

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -18,7 +18,7 @@ from vibe_serve.agents.progress import RoundProgress
 from vibe_serve.config import Config
 from vibe_serve.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibe_serve.context import _RunContext
-from vibe_serve.domains.base import DEFAULT_DOMAIN, DomainDefinition, DomainName, DomainRole
+from vibe_serve.domains.base import DomainDefinition, DomainName, DomainRole
 from vibe_serve.domains.registry import resolve_domain
 from vibe_serve.domains.rendering import render_domain_section
 from vibe_serve.input_manifest import BenchmarkResult
@@ -803,7 +803,7 @@ def run_agent_loop(
     backend: ComputeBackend = DEFAULT_COMPUTE_BACKEND,
     modality: str | None = None,
     inner_loop: str = "multi-agent",
-    domain: DomainName = DEFAULT_DOMAIN,
+    domain: DomainName | None = None,
     interface: str = DEFAULT_INTERFACE,
 ) -> bool:
     """Run the orchestrator-driven build loop.
@@ -837,6 +837,8 @@ def run_agent_loop(
         )
     if interface not in _INTERFACES:
         raise ValueError(f"Unknown interface {interface!r}; choose from {', '.join(_INTERFACES)}")
+    if domain is None:
+        raise ValueError("domain is required; pass --domain or declare [agent].domain")
     # Resolve the registered domain once (fail fast on an unknown name). The
     # per-role files carry language, tooling, and use-case-specific contracts.
     domain_definition = resolve_domain(domain)

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -13,7 +13,6 @@ from pathlib import Path
 import pytest
 
 from vibe_serve.domains.base import (
-    DEFAULT_DOMAIN,
     DOMAIN_ROLES,
     DomainDefinition,
     DomainName,
@@ -50,7 +49,6 @@ def test_registered_domains_present():
     assert "llm-serving" in names
     assert "generic" in names
     assert "README" not in names  # the authoring guide is not a domain
-    assert DEFAULT_DOMAIN is DomainName.LLM_SERVING
 
 
 def test_resolve_registered_name():

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -1,4 +1,4 @@
-"""Tests for registered domains — the ``--domain`` pluggable-context mechanism.
+"""Tests for registered domains — the manifest-selected pluggable context.
 
 Covers the resolver (registered name / error), the role-file renderer (present,
 empty, missing, ``single_agent`` derivation, context branching), and end-to-end

--- a/tests/loops/agent/test_interface_modes.py
+++ b/tests/loops/agent/test_interface_modes.py
@@ -28,7 +28,7 @@ def test_domain_module_has_no_language_axis():
 
     assert not hasattr(domain, "DEFAULT_LANGUAGE")
     assert not hasattr(domain, "LANGUAGE_DIR")
-    assert domain.DEFAULT_DOMAIN is DomainName.LLM_SERVING
+    assert not hasattr(domain, "DEFAULT_DOMAIN")
 
 
 def test_no_language_pack_directory():

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -42,6 +42,9 @@ def ref_file(tmp_path):
         """
 version = 1
 
+[agent]
+domain = "llm-serving"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 
@@ -130,6 +133,7 @@ def _invoke_orchestrate(tmp_path, ref_file, runner, **kwargs):
         objective="Maximize tok/s throughput.",
         max_rounds=5,
         max_retries_per_round=2,
+        domain=DomainName.LLM_SERVING,
     )
     defaults.update(kwargs)
     with (
@@ -658,6 +662,7 @@ def test_cli_loads_objective_md_from_ref_parent(tmp_path):
     (bundle / "OBJECTIVE.md").write_text("Maximize throughput (tok/s). Prefer CUDA graphs.\n")
     (bundle / "vibeserve.input.toml").write_text(
         "version = 1\n\n"
+        "[agent]\ndomain = 'llm-serving'\n\n"
         "[accuracy]\ncommand = ['uv', 'run', 'python', 'accuracy_checker/checker.py']\n\n"
         "[benchmark]\ncommand = ['uv', 'run', 'python', 'benchmark/benchmark.py']\n"
     )
@@ -673,6 +678,7 @@ def test_cli_missing_objective_md_errors(tmp_path):
     bundle.mkdir()
     (bundle / "vibeserve.input.toml").write_text(
         "version = 1\n\n"
+        "[agent]\ndomain = 'llm-serving'\n\n"
         "[accuracy]\ncommand = ['uv', 'run', 'python', 'accuracy_checker/checker.py']\n\n"
         "[benchmark]\ncommand = ['uv', 'run', 'python', 'benchmark/benchmark.py']\n"
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,9 @@ def _write_input_bundle(tmp_path: Path) -> Path:
         """
 version = 1
 
+[agent]
+domain = "generic"
+
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 
@@ -103,7 +106,7 @@ def test_target_input_defaults_to_none():
     assert not hasattr(args, "acc_checker")
     assert not hasattr(args, "bench")
     assert args.profiler is ProfilerKind.AUTO
-    assert args.domain is DomainName.LLM_SERVING
+    assert args.domain is None
 
 
 @pytest.mark.parametrize(
@@ -188,8 +191,23 @@ def test_validate_target_inputs_loads_manifest(tmp_path):
     _validate_target_inputs(args)
 
     assert args.input_bundle.root == bundle.resolve()
+    assert args.domain is DomainName.GENERIC
     assert args.input_bundle.accuracy_command_display == "uv run python accuracy_checker/checker.py"
     assert args.input_bundle.benchmark_command_display == "uv run python benchmark/benchmark.py"
+
+
+def test_validate_target_inputs_warns_when_cli_domain_overrides_manifest(tmp_path, capsys):
+    from vibe_serve.cli import _build_agent_parser
+
+    bundle = _write_input_bundle(tmp_path)
+    args = _build_agent_parser().parse_args(["--domain", "llm-serving", "--input", str(bundle)])
+
+    _validate_target_inputs(args)
+
+    assert args.domain is DomainName.LLM_SERVING
+    err = capsys.readouterr().err
+    assert "Warning: --domain 'llm-serving' differs" in err
+    assert "[agent].domain 'generic'" in err
 
 
 def test_validate_target_inputs_loads_trusted_benchmark_result_contract(tmp_path):
@@ -250,6 +268,9 @@ def test_validate_target_inputs_reports_missing_command(tmp_path, capsys):
     (bundle / "vibeserve.input.toml").write_text(
         """
 version = 1
+
+[agent]
+domain = "generic"
 
 [accuracy]
 command = ["./tools/check"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,7 +106,7 @@ def test_target_input_defaults_to_none():
     assert not hasattr(args, "acc_checker")
     assert not hasattr(args, "bench")
     assert args.profiler is ProfilerKind.AUTO
-    assert args.domain is None
+    assert not hasattr(args, "domain")
 
 
 @pytest.mark.parametrize(
@@ -149,19 +149,10 @@ def test_profiler_none_is_valid_with_modal(builder_name, validator_name, tmp_pat
     assert args.input_bundle.root == bundle.resolve()
 
 
-def test_agent_parser_outputs_domain_enum():
-    from vibe_serve.cli import _build_agent_parser
-
-    args = _build_agent_parser().parse_args(["--domain", "generic"])
-
-    assert args.domain is DomainName.GENERIC
-
-
 @pytest.mark.parametrize(
     "argv",
     [
         ["--profiler", "bogus"],
-        ["--domain", "bogus"],
     ],
 )
 def test_agent_parser_rejects_invalid_enum_args(argv):
@@ -191,23 +182,18 @@ def test_validate_target_inputs_loads_manifest(tmp_path):
     _validate_target_inputs(args)
 
     assert args.input_bundle.root == bundle.resolve()
-    assert args.domain is DomainName.GENERIC
+    assert args.input_bundle.domain is DomainName.GENERIC
     assert args.input_bundle.accuracy_command_display == "uv run python accuracy_checker/checker.py"
     assert args.input_bundle.benchmark_command_display == "uv run python benchmark/benchmark.py"
 
 
-def test_validate_target_inputs_warns_when_cli_domain_overrides_manifest(tmp_path, capsys):
+def test_agent_parser_rejects_domain_override_flag():
     from vibe_serve.cli import _build_agent_parser
 
-    bundle = _write_input_bundle(tmp_path)
-    args = _build_agent_parser().parse_args(["--domain", "llm-serving", "--input", str(bundle)])
+    with pytest.raises(SystemExit) as exc:
+        _build_agent_parser().parse_args(["--domain", "llm-serving"])
 
-    _validate_target_inputs(args)
-
-    assert args.domain is DomainName.LLM_SERVING
-    err = capsys.readouterr().err
-    assert "Warning: --domain 'llm-serving' differs" in err
-    assert "[agent].domain 'generic'" in err
+    assert exc.value.code == 2
 
 
 def test_validate_target_inputs_loads_trusted_benchmark_result_contract(tmp_path):

--- a/tests/test_queue_evaluator.py
+++ b/tests/test_queue_evaluator.py
@@ -82,6 +82,7 @@ def test_linearizable_queue_manifests_invoke_go_evaluator_directly():
                 "3",
             ],
         }
+        assert manifest["agent"] == {"domain": "generic"}
         assert manifest["evaluator"] == {"source": "../../evaluators/queue"}
         for section, expected_suffix in expected_suffixes.items():
             command = manifest[section]["command"]

--- a/tests/test_workspace_seed.py
+++ b/tests/test_workspace_seed.py
@@ -40,6 +40,9 @@ def _write_bundle(project_root: Path, manifest_blocks: str = "") -> Path:
         f"""
 version = 1
 
+[agent]
+domain = "generic"
+
 [accuracy]
 command = ["accuracy-checker"]
 

--- a/tests/test_workspace_seed.py
+++ b/tests/test_workspace_seed.py
@@ -86,6 +86,16 @@ def _make_context(input_dir: Path, seed: Path | None = None, **kwargs) -> _RunCo
     )
 
 
+def test_all_repo_example_input_bundles_are_valid():
+    project_root = Path(__file__).parents[1]
+    manifests = sorted((project_root / "examples").glob("**/vibeserve.input.toml"))
+
+    assert manifests
+    for manifest in manifests:
+        bundle = load_input_bundle(manifest.parent, project_root=project_root)
+        assert bundle.domain is bundle.manifest.agent.domain
+
+
 def test_manifest_without_workspace_seed_remains_valid(tmp_path):
     project_root = tmp_path / "project"
     bundle = _write_bundle(project_root)


### PR DESCRIPTION
## Problem

Queue and other non-LLM input bundles can be accidentally run under hidden LLM-serving domain semantics. That causes unrelated inference-server judge gates, such as `main.py`, `/health`, and `VibeServeModel`, to be applied to native evaluator workloads.

## Solution

Require input manifests to declare `[agent].domain` and make that manifest value the agent loop's single source of truth. The agent CLI no longer exposes `--domain`, preventing users from accidentally overriding a bundle with the wrong domain.

All repository examples now declare a domain: model-serving examples use `llm-serving`, while data-structure and microservice examples use `generic`. The shared `DEFAULT_DOMAIN = llm-serving` constant was removed so agent-loop callers cannot silently inherit serving semantics.

The test suite now discovers every `examples/**/vibeserve.input.toml` and validates it through `load_input_bundle(...)`, so missing domain metadata, missing `OBJECTIVE.md`, invalid command shapes, and bad seed/evaluator paths are caught in CI.

## Verification

### Correctness properties

- Every `vibeserve.input.toml` in `examples/` declares exactly one `[agent].domain`.
- Every manifest-bearing example input bundle loads successfully through the CLI manifest loader.
- The agent parser no longer accepts `--domain`.
- The agent loop passes the manifest domain into domain resolution.
- Direct `run_agent_loop` calls fail if no domain is supplied, preventing hidden fallback behavior.
- Queue examples resolve to `generic`, avoiding LLM-serving prompt and judge gates.

### Testing

- `uv run pytest tests/test_workspace_seed.py tests/test_queue_evaluator.py tests/test_cli.py` — 60 passed
- `uv run pytest` — 1065 passed
