### PR TITLE
Add native macOS CPU profiling for generic workloads

### DIFF
--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -14,7 +14,7 @@ Several flags look independent, but they combine into one execution contract:
 | Evaluation interface | `--interface` | Agent loop only. Whether evaluator-owned code invokes the candidate directly or communicates with a service. |
 | Compute backend | `--backend` | Hardware/runtime target: `cuda`, `metal`, `trainium`, or `cpu`. |
 | Runtime environment | `--docker`, `--modal` | Where agent commands execute: local shell, Docker container, or Modal-backed workflow. |
-| Profiler | `--profiler` | Bottleneck evidence source: `nsys`, `torch`, `neuron`, or `auto`. |
+| Profiler | `--profiler` | Bottleneck evidence source: `nsys`, `torch`, `neuron`, `macos-cpu`, or `auto`. |
 | Domain | `[agent].domain` in `vibeserve.input.toml` | Agent-loop problem-space package, such as `llm-serving` or `generic`. |
 | Modality | `--modality` | Per-task I/O contract, such as `text_generation` or `speech_to_text`. |
 | Skills | `--skills-dir`, `--no-skills` | Candidate skill roots and the ablation switch that disables skill loading. |
@@ -59,7 +59,7 @@ prompts and input-owned candidate-contract documentation.
 | `cuda` | NVIDIA GPU serving systems. | Local, Docker, Modal. | Selects/reselects a GPU and can monitor contention. | Local/Docker use `nsys`; Modal uses `torch` when `--profiler auto`. |
 | `metal` | Apple Silicon / MPS targets. | Local only. | No device selection or monitor. | Local `auto` resolves through the local runtime default. |
 | `trainium` | AWS Trainium / NeuronCore targets. | Local and Docker; Modal unsupported. | Forwards `/dev/neuron*` in Docker; no per-device selection. | `auto` resolves to `neuron`. |
-| `cpu` | CPU-only service/data-structure targets. | Local only in the current merged code. | No device selection or monitor. | Current agent/evolve `auto` behavior follows runtime defaults; the plain loop has CPU-specific prompt fragments. |
+| `cpu` | CPU-only service/data-structure targets. | Local only in the current merged code. | No device selection or monitor. | Generic workloads on macOS select `macos-cpu`; other systems select no profiler. |
 
 When a backend rejects a runtime environment, it should fail before agent work
 starts with an actionable error.
@@ -83,6 +83,7 @@ Modal is active.
 | `nsys` | NVIDIA Nsight Systems. Requires a CUDA/NVIDIA profiling environment. |
 | `torch` | PyTorch profiler. Used for in-process Python profiling and Modal GPU dispatch. |
 | `neuron` | AWS Neuron profiler for Trainium. |
+| `macos-cpu` | Instruments Time Profiler with a supported `/usr/bin/sample` fallback. |
 
 `--modal --profiler nsys` is rejected by the CLI because Modal runs must use the
 torch profiler path.
@@ -91,6 +92,15 @@ Profiler prompts must match the interface, domain, and backend. In-process
 execution alone does not make the candidate Python or PyTorch-compatible; the
 selected domain must explicitly support Torch profiling. A CPU backend must not
 receive a GPU-kernel workflow.
+
+The macOS backend verifies that the selected developer directory is full Xcode and asks
+`xctrace` for the Time Profiler template; the Command Line Tools shim is not considered
+functional Instruments. Captures are separate diagnostic runs, never scored results.
+They store exact commands, duration, warm-up, OS/CPU/tool data, target PID/topology,
+diagnostics, and the raw `.trace` or `sample` report. Attach failures, including SIP or
+privacy restrictions, are structured diagnostics. Optimized native builds should retain
+debug information; `dsymutil`, `dwarfdump`, `nm`, and `atos` can validate or resolve
+symbols. Reports must state when unavailable Apple hardware counters limit conclusions.
 
 ## Domain and Modality
 

--- a/examples/support/macos_cpu_profiler/server.py
+++ b/examples/support/macos_cpu_profiler/server.py
@@ -1,0 +1,49 @@
+"""MCP tools for collecting a separate macOS native CPU profile."""
+
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from vibe_serve.macos_cpu_profiler import collect, detect_capability, parse_command
+
+
+def build_server() -> FastMCP:
+    mcp = FastMCP("vibeserve-macos-cpu-profiler")
+
+    @mcp.tool()
+    def capabilities() -> dict:
+        """Report whether Instruments, sample, or no native profiler is usable."""
+        capability = detect_capability()
+        return {
+            "selected": capability.tool.value,
+            "xcode_path": capability.xcode_path,
+            "xctrace_path": capability.xctrace_path,
+            "sample_path": capability.sample_path,
+            "tool_version": capability.tool_version,
+            "diagnostics": [item.value for item in capability.diagnostics],
+        }
+
+    @mcp.tool()
+    def profile(
+        command: str,
+        output_dir: str = "logs/macos-cpu-profile",
+        duration: int = 10,
+        warmup: float = 1.0,
+    ) -> dict:
+        """Profile a diagnostic run. This never supplies a scored benchmark result."""
+        result = collect(parse_command(command), Path(output_dir), duration=duration, warmup=warmup)
+        return {
+            "status": result.status,
+            "tool": result.tool.value,
+            "artifact": result.artifact,
+            "metadata": result.metadata,
+            "target_pid": result.target_pid,
+            "diagnostics": [item.value for item in result.diagnostics],
+            "summary": result.summary,
+        }
+
+    return mcp
+
+
+if __name__ == "__main__":
+    build_server().run(transport="stdio")

--- a/src/vibe_serve/cli.py
+++ b/src/vibe_serve/cli.py
@@ -172,6 +172,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
             "'nsys' for NVIDIA Nsight Systems (needs /proc/driver/nvidia), "
             "'torch' for torch.profiler (works in Modal sandboxes), "
             "'neuron' for AWS neuron-explorer (Trainium/NeuronCores), "
+            "'macos-cpu' for Instruments Time Profiler with a sample fallback, "
             "'auto' picks a domain/backend/environment-appropriate profiler. "
             "Default: auto."
         ),

--- a/src/vibe_serve/context.py
+++ b/src/vibe_serve/context.py
@@ -187,6 +187,7 @@ class _RunContext:
         self.nsys_profiler_path = self._coerce_dir_path(nsys_profiler, "--nsys-profiler")
         self.torch_profiler_path = self._coerce_dir_path(torch_profiler, "--torch-profiler")
         self.neuron_profiler_path = self._coerce_dir_path(neuron_profiler, "--neuron-profiler")
+        self.macos_cpu_profiler_path: str | None = None
 
         self.profiler_kind = resolve_profiler_kind(
             profiler_kind,
@@ -201,6 +202,10 @@ class _RunContext:
             self.torch_profiler_path = None
         if self.profiler_kind is not ProfilerKind.NEURON:
             self.neuron_profiler_path = None
+        if self.profiler_kind is ProfilerKind.MACOS_CPU:
+            default_mp = PROJECT_ROOT / "examples" / "support" / "macos_cpu_profiler"
+            if default_mp.is_dir():
+                self.macos_cpu_profiler_path = str(default_mp)
 
         # Default profiler support paths only for the selected profiler.
         if self.profiler_kind is ProfilerKind.NSYS and self.nsys_profiler_path is None:
@@ -346,6 +351,9 @@ class _RunContext:
             if self.neuron_profiler_path:
                 src = Path(self.neuron_profiler_path)
                 self._copy_excluding_extras(src, self.workspace / "neuron_profiler")
+            if self.macos_cpu_profiler_path:
+                src = Path(self.macos_cpu_profiler_path)
+                self._copy_excluding_extras(src, self.workspace / "macos_cpu_profiler")
 
         # Always ensure profiler harnesses are present in the workspace, even
         # when resuming — the original run may not have had them.
@@ -361,6 +369,10 @@ class _RunContext:
             src = Path(self.neuron_profiler_path)
             if not (self.workspace / "neuron_profiler").exists():
                 self._copy_excluding_extras(src, self.workspace / "neuron_profiler")
+        if existing and self.macos_cpu_profiler_path:
+            src = Path(self.macos_cpu_profiler_path)
+            if not (self.workspace / "macos_cpu_profiler").exists():
+                self._copy_excluding_extras(src, self.workspace / "macos_cpu_profiler")
 
         if git_tracking:
             self._init_git_tracking(existing)
@@ -379,6 +391,7 @@ class _RunContext:
                     nsys_profiler_path=self.nsys_profiler_path,
                     torch_profiler_path=self.torch_profiler_path,
                     neuron_profiler_path=self.neuron_profiler_path,
+                    macos_cpu_profiler_path=self.macos_cpu_profiler_path,
                     environment_bind_mounts=self.environment_patch.bind_mounts,
                     log=self.lprint,
                     project_root=PROJECT_ROOT,

--- a/src/vibe_serve/loops/agent/loop.py
+++ b/src/vibe_serve/loops/agent/loop.py
@@ -273,6 +273,7 @@ def _profiler_prompt_template(
         ProfilerKind.NSYS: "profiler_prompt_nsys.j2",
         ProfilerKind.TORCH: "profiler_prompt_torch.j2",
         ProfilerKind.NEURON: "profiler_prompt_neuron.j2",
+        ProfilerKind.MACOS_CPU: "profiler_prompt_macos_cpu.j2",
     }[kind]
 
 

--- a/src/vibe_serve/loops/agent/templates/profiler_prompt_macos_cpu.j2
+++ b/src/vibe_serve/loops/agent/templates/profiler_prompt_macos_cpu.j2
@@ -1,0 +1,12 @@
+You are the native macOS CPU profiler. Use the macOS profiler MCP tools to inspect
+capabilities, then profile a separate diagnostic invocation of the benchmark command.
+Never treat profiling output as the trusted scored benchmark result. Prefer Instruments
+Time Profiler when selected; otherwise use sample. Report the selected tool, actual target
+process, raw artifact and metadata paths, symbols present or missing, hot functions and
+threads, scheduling evidence, and the limits of conclusions without hardware counters.
+
+Benchmark command: {{ benchmark_command }}
+
+Return exactly one JSON object matching the requested ProfilerSummary schema. Keep the
+analysis bounded: summarize the most important hot paths and diagnostics rather than
+embedding the raw report.

--- a/src/vibe_serve/loops/evolve/loop.py
+++ b/src/vibe_serve/loops/evolve/loop.py
@@ -227,11 +227,10 @@ def _run_profiler(
 ) -> ProfilerSummary | None:
     if ctx.profiler_kind is ProfilerKind.NONE:
         return None
-    template = (
-        "profiler_prompt_torch.j2"
-        if ctx.profiler_kind is ProfilerKind.TORCH
-        else "profiler_prompt_nsys.j2"
-    )
+    template = {
+        ProfilerKind.TORCH: "profiler_prompt_torch.j2",
+        ProfilerKind.MACOS_CPU: "profiler_prompt_macos_cpu.j2",
+    }.get(ctx.profiler_kind, "profiler_prompt_nsys.j2")
     base_prompt = _render(
         template,
         benchmark_command=ctx.profiler_benchmark_command,

--- a/src/vibe_serve/loops/evolve/templates/profiler_prompt_macos_cpu.j2
+++ b/src/vibe_serve/loops/evolve/templates/profiler_prompt_macos_cpu.j2
@@ -1,0 +1,8 @@
+You are the native macOS CPU profiler. Use the macOS profiler MCP tools to inspect
+capabilities and profile a separate diagnostic invocation of this benchmark:
+{{ benchmark_command }}
+
+Never use the diagnostic result as the trusted scored result. Report the selected tool,
+actual target child process, artifact and metadata paths, hot functions and threads,
+symbol quality, scheduling evidence, and limitations from unavailable hardware counters.
+Return exactly one JSON object matching the requested ProfilerSummary schema.

--- a/src/vibe_serve/loops/profiler.py
+++ b/src/vibe_serve/loops/profiler.py
@@ -53,6 +53,12 @@ def mcp_spec(profiler_kind: ProfilerKind):
             command="python",
             args=["nsys_profiler/server.py"],
         )
+    if kind is ProfilerKind.MACOS_CPU:
+        return MCPServerSpec(
+            name="vibeserve-macos-cpu-profiler",
+            command="python",
+            args=["macos_cpu_profiler/server.py"],
+        )
     raise AssertionError(f"Unhandled profiler kind: {kind!r}")
 
 

--- a/src/vibe_serve/macos_cpu_profiler.py
+++ b/src/vibe_serve/macos_cpu_profiler.py
@@ -1,0 +1,252 @@
+"""Capability detection and collection for native macOS CPU profiling."""
+
+from __future__ import annotations
+
+import json
+import platform
+import shlex
+import shutil
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from pathlib import Path
+
+
+class MacOSProfilerTool(StrEnum):
+    XCTRACE = "instruments"
+    SAMPLE = "sample"
+    NONE = "none"
+
+
+class DiagnosticCode(StrEnum):
+    NOT_MACOS = "not_macos"
+    COMMAND_LINE_TOOLS_ONLY = "command_line_tools_only"
+    TIME_PROFILER_UNAVAILABLE = "time_profiler_unavailable"
+    SAMPLE_UNAVAILABLE = "sample_unavailable"
+    ATTACH_DENIED = "attach_denied"
+    TARGET_EXITED = "target_exited"
+    COLLECTION_FAILED = "collection_failed"
+    HARDWARE_COUNTERS_UNAVAILABLE = "hardware_counters_unavailable"
+
+
+@dataclass(frozen=True)
+class Capability:
+    tool: MacOSProfilerTool
+    xcode_path: str | None
+    xctrace_path: str | None
+    sample_path: str | None
+    tool_version: str | None
+    diagnostics: tuple[DiagnosticCode, ...] = ()
+
+
+@dataclass(frozen=True)
+class CollectionResult:
+    status: str
+    tool: MacOSProfilerTool
+    artifact: str | None
+    metadata: str
+    target_pid: int | None
+    command: tuple[str, ...]
+    diagnostics: tuple[DiagnosticCode, ...]
+    summary: str
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def detect_capability(
+    *,
+    system: str | None = None,
+    which: Callable[[str], str | None] = shutil.which,
+    run: Runner = subprocess.run,
+) -> Capability:
+    """Select a functional Time Profiler, then ``sample`` as fallback."""
+    if (system or platform.system()) != "Darwin":
+        return Capability(
+            MacOSProfilerTool.NONE, None, None, None, None, (DiagnosticCode.NOT_MACOS,)
+        )
+
+    sample_path = which("sample") or (
+        "/usr/bin/sample" if Path("/usr/bin/sample").is_file() else None
+    )
+    diagnostics: list[DiagnosticCode] = [DiagnosticCode.HARDWARE_COUNTERS_UNAVAILABLE]
+    xcode_path: str | None = None
+    xctrace_path: str | None = None
+    version: str | None = None
+    try:
+        selected = run(["xcode-select", "-p"], capture_output=True, text=True, timeout=5)
+        xcode_path = selected.stdout.strip() if selected.returncode == 0 else None
+        if not xcode_path or "/CommandLineTools" in xcode_path:
+            diagnostics.append(DiagnosticCode.COMMAND_LINE_TOOLS_ONLY)
+        else:
+            candidate = Path(xcode_path) / "usr" / "bin" / "xctrace"
+            xctrace_path = str(candidate) if candidate.is_file() else which("xctrace")
+            if xctrace_path:
+                templates = run(
+                    [xctrace_path, "list", "templates"], capture_output=True, text=True, timeout=15
+                )
+                if templates.returncode == 0 and "Time Profiler" in templates.stdout:
+                    version_result = run(
+                        [xctrace_path, "version"], capture_output=True, text=True, timeout=5
+                    )
+                    version = (version_result.stdout or version_result.stderr).strip() or None
+                    return Capability(
+                        MacOSProfilerTool.XCTRACE,
+                        xcode_path,
+                        xctrace_path,
+                        sample_path,
+                        version,
+                        tuple(diagnostics),
+                    )
+            diagnostics.append(DiagnosticCode.TIME_PROFILER_UNAVAILABLE)
+    except (OSError, subprocess.SubprocessError):
+        diagnostics.append(DiagnosticCode.TIME_PROFILER_UNAVAILABLE)
+
+    if sample_path:
+        return Capability(
+            MacOSProfilerTool.SAMPLE,
+            xcode_path,
+            xctrace_path,
+            sample_path,
+            None,
+            tuple(diagnostics),
+        )
+    diagnostics.append(DiagnosticCode.SAMPLE_UNAVAILABLE)
+    return Capability(
+        MacOSProfilerTool.NONE, xcode_path, xctrace_path, None, None, tuple(diagnostics)
+    )
+
+
+def _descendants(root_pid: int, *, run: Runner = subprocess.run) -> list[int]:
+    result = run(["ps", "-axo", "pid=,ppid="], capture_output=True, text=True, timeout=5)
+    children: dict[int, list[int]] = {}
+    for line in result.stdout.splitlines():
+        try:
+            pid, ppid = (int(value) for value in line.split())
+        except ValueError:
+            continue
+        children.setdefault(ppid, []).append(pid)
+    found, pending, seen = [], [root_pid], {root_pid}
+    while pending:
+        parent = pending.pop(0)
+        for child in children.get(parent, []):
+            if child not in seen:
+                seen.add(child)
+                found.append(child)
+                pending.append(child)
+    return found
+
+
+def collect(
+    command: list[str],
+    output_dir: Path,
+    *,
+    duration: int = 10,
+    warmup: float = 1.0,
+    capability: Capability | None = None,
+) -> CollectionResult:
+    """Run a separate diagnostic workload and persist raw data plus metadata."""
+    capability = capability or detect_capability()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    started = time.time()
+    artifact: Path | None = None
+    target_pid: int | None = None
+    process_topology: list[int] = []
+    diagnostics = list(capability.diagnostics)
+    executed: list[str] = []
+
+    try:
+        if capability.tool is MacOSProfilerTool.XCTRACE:
+            artifact = output_dir / "time-profile.trace"
+            executed = [
+                capability.xctrace_path or "xctrace",
+                "record",
+                "--template",
+                "Time Profiler",
+                "--time-limit",
+                f"{duration}s",
+                "--output",
+                str(artifact),
+                "--launch",
+                "--",
+                *command,
+            ]
+            result = subprocess.run(executed, capture_output=True, text=True, timeout=duration + 30)
+        elif capability.tool is MacOSProfilerTool.SAMPLE:
+            process = subprocess.Popen(
+                command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
+            time.sleep(warmup)
+            descendants = _descendants(process.pid)
+            process_topology = [process.pid, *descendants]
+            target_pid = descendants[-1] if descendants else process.pid
+            artifact = output_dir / "sample.txt"
+            executed = [
+                capability.sample_path or "/usr/bin/sample",
+                str(target_pid),
+                str(duration),
+                "-file",
+                str(artifact),
+            ]
+            result = subprocess.run(executed, capture_output=True, text=True, timeout=duration + 15)
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+        else:
+            result = subprocess.CompletedProcess([], 1, "", "No macOS profiler is available")
+    except (OSError, subprocess.SubprocessError) as exc:
+        result = subprocess.CompletedProcess(executed, 1, "", str(exc))
+
+    stderr = result.stderr or ""
+    if "not permitted" in stderr.lower() or "permission" in stderr.lower():
+        diagnostics.append(DiagnosticCode.ATTACH_DENIED)
+    if result.returncode != 0:
+        diagnostics.append(DiagnosticCode.COLLECTION_FAILED)
+
+    metadata_path = output_dir / "metadata.json"
+    metadata = {
+        "schema_version": 1,
+        "diagnostic_only": True,
+        "scored_benchmark": False,
+        "tool": capability.tool,
+        "tool_version": capability.tool_version,
+        "command": command,
+        "profiler_command": executed,
+        "duration_seconds": duration,
+        "warmup_seconds": warmup,
+        "target_pid": target_pid,
+        "process_topology": process_topology,
+        "os": platform.platform(),
+        "os_build": platform.version(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "symbol_tools": {
+            name: shutil.which(name) for name in ("dsymutil", "atos", "nm", "dwarfdump")
+        },
+        "started_at_epoch": started,
+        "diagnostics": diagnostics,
+        "capability": asdict(capability),
+        "stderr": stderr[-4000:],
+    }
+    metadata_path.write_text(json.dumps(metadata, indent=2, default=str) + "\n")
+    status = "ok" if result.returncode == 0 else "error"
+    summary = f"{capability.tool.value} {status}; target pid {target_pid or 'launched by Instruments'}; artifact {artifact}"
+    return CollectionResult(
+        status,
+        capability.tool,
+        str(artifact) if artifact else None,
+        str(metadata_path),
+        target_pid,
+        tuple(executed),
+        tuple(diagnostics),
+        summary,
+    )
+
+
+def parse_command(command: str) -> list[str]:
+    """Parse an agent-supplied command without invoking a shell."""
+    return shlex.split(command)

--- a/src/vibe_serve/profilers.py
+++ b/src/vibe_serve/profilers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import platform
 from enum import StrEnum
 
 from vibe_serve.domains.base import DomainName
@@ -15,16 +16,17 @@ class ProfilerKind(StrEnum):
     NSYS = "nsys"
     TORCH = "torch"
     NEURON = "neuron"
+    MACOS_CPU = "macos-cpu"
 
 
 ACTIVE_PROFILER_KINDS: frozenset[ProfilerKind] = frozenset(
-    {ProfilerKind.NSYS, ProfilerKind.TORCH, ProfilerKind.NEURON}
+    {ProfilerKind.NSYS, ProfilerKind.TORCH, ProfilerKind.NEURON, ProfilerKind.MACOS_CPU}
 )
 
 CLI_PROFILER_CHOICES: tuple[ProfilerKind, ...] = tuple(ProfilerKind)
 
 _DOMAIN_ALLOWED_PROFILERS: dict[DomainName, frozenset[ProfilerKind]] = {
-    DomainName.GENERIC: frozenset({ProfilerKind.NONE}),
+    DomainName.GENERIC: frozenset({ProfilerKind.NONE, ProfilerKind.MACOS_CPU}),
     DomainName.LLM_SERVING: frozenset(
         {
             ProfilerKind.NONE,
@@ -97,7 +99,7 @@ def resolve_profiler_kind(
         return requested_kind
 
     if domain_name is DomainName.GENERIC:
-        return ProfilerKind.NONE
+        return ProfilerKind.MACOS_CPU if platform.system() == "Darwin" else ProfilerKind.NONE
 
     environment_default = require_profiler_kind(
         environment_default_profiler_kind,

--- a/src/vibe_serve/sandbox/run_environment.py
+++ b/src/vibe_serve/sandbox/run_environment.py
@@ -64,6 +64,7 @@ class AgentPaths:
     nsys_profiler: str | None = None
     torch_profiler: str | None = None
     neuron_profiler: str | None = None
+    macos_cpu_profiler: str | None = None
 
 
 @dataclass(frozen=True)
@@ -98,6 +99,7 @@ class RunEnvironmentRequest:
     nsys_profiler_path: str | None = None
     torch_profiler_path: str | None = None
     neuron_profiler_path: str | None = None
+    macos_cpu_profiler_path: str | None = None
     environment_bind_mounts: tuple[EnvironmentBindMount, ...] = ()
     log: Callable[[str], None] | None = None
     project_root: Path = PROJECT_ROOT
@@ -185,6 +187,7 @@ class LocalEnvironment(_NoopWorkspaceRecovery):
                     nsys_profiler=request.nsys_profiler_path,
                     torch_profiler=request.torch_profiler_path,
                     neuron_profiler=request.neuron_profiler_path,
+                    macos_cpu_profiler=request.macos_cpu_profiler_path,
                 ),
             ),
             stop_on_close=False,
@@ -662,6 +665,7 @@ def _isolated_paths(request: RunEnvironmentRequest) -> AgentPaths:
         nsys_profiler="nsys_profiler" if request.nsys_profiler_path else None,
         torch_profiler="torch_profiler" if request.torch_profiler_path else None,
         neuron_profiler="neuron_profiler" if request.neuron_profiler_path else None,
+        macos_cpu_profiler=("macos_cpu_profiler" if request.macos_cpu_profiler_path else None),
     )
 
 
@@ -749,6 +753,8 @@ def _container_mount_plan(
         bind_mounts.append((request.torch_profiler_path, "/workspace/torch_profiler", True))
     if request.neuron_profiler_path:
         bind_mounts.append((request.neuron_profiler_path, "/workspace/neuron_profiler", True))
+    if request.macos_cpu_profiler_path:
+        bind_mounts.append((request.macos_cpu_profiler_path, "/workspace/macos_cpu_profiler", True))
 
     if (
         include_cli_provider_mounts

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -593,7 +593,7 @@ def test_loop_skips_profiler_when_profiler_kind_is_none(tmp_path, ref_file):
     assert runner.counters["prof"] == 0
 
 
-def test_loop_generic_auto_profiler_resolves_to_none(tmp_path, ref_file):
+def test_loop_generic_auto_profiler_resolves_to_macos_cpu(tmp_path, ref_file):
     runner = _make_orchestrate_runner(
         pre_decisions=[
             PreRoundDecision(need_profile=True, profile_focus="kernels", reasoning="would help"),
@@ -606,17 +606,18 @@ def test_loop_generic_auto_profiler_resolves_to_none(tmp_path, ref_file):
         ],
     )
 
-    result = _invoke_orchestrate(
-        tmp_path,
-        ref_file,
-        runner,
-        max_rounds=2,
-        domain=DomainName.GENERIC,
-    )
+    with patch("vibe_serve.profilers.platform.system", return_value="Darwin"):
+        result = _invoke_orchestrate(
+            tmp_path,
+            ref_file,
+            runner,
+            max_rounds=2,
+            domain=DomainName.GENERIC,
+        )
 
     assert result is True
     assert runner.counters["orch_pre"] == 1
-    assert runner.counters["prof"] == 0
+    assert runner.counters["prof"] == 1
 
 
 def test_loop_runs_full_max_rounds_budget(tmp_path, ref_file):

--- a/tests/loops/test_profiler_mcp.py
+++ b/tests/loops/test_profiler_mcp.py
@@ -57,6 +57,10 @@ def test_profiler_mcp_spec_maps_known_kinds_exactly():
     assert neuron.name == "vibeserve-neuron-profiler"
     assert neuron.args == ["neuron_profiler/server.py"]
 
+    macos = mcp_spec(ProfilerKind.MACOS_CPU)
+    assert macos.name == "vibeserve-macos-cpu-profiler"
+    assert macos.args == ["macos_cpu_profiler/server.py"]
+
 
 def test_profiler_mcp_spec_rejects_unknown_kind():
     with pytest.raises(TypeError, match="ProfilerKind"):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -100,6 +100,7 @@ def _write_support_dirs(project_root):
         ProfilerKind.NSYS: "nsys_profiler",
         ProfilerKind.TORCH: "torch_profiler",
         ProfilerKind.NEURON: "neuron_profiler",
+        ProfilerKind.MACOS_CPU: "macos_cpu_profiler",
     }
     for workspace_name in dirs.values():
         source_dir = project_root / "examples" / "support" / workspace_name
@@ -155,6 +156,7 @@ def test_run_context_copies_only_selected_profiler_support(tmp_path, selected):
     support_paths = _write_support_dirs(project_root)
     ref = _write_ref(tmp_path)
 
+    domain = DomainName.GENERIC if selected is ProfilerKind.MACOS_CPU else DomainName.LLM_SERVING
     with (
         patch("vibe_serve.context.PROJECT_ROOT", project_root),
         patch("vibe_serve.context._build_model", return_value="mock-model"),
@@ -167,6 +169,7 @@ def test_run_context_copies_only_selected_profiler_support(tmp_path, selected):
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
             profiler_kind=selected,
+            profiler_domain=domain,
             nsys_profiler=support_paths[ProfilerKind.NSYS],
             torch_profiler=support_paths[ProfilerKind.TORCH],
             neuron_profiler=support_paths[ProfilerKind.NEURON],
@@ -178,14 +181,16 @@ def test_run_context_copies_only_selected_profiler_support(tmp_path, selected):
             ProfilerKind.NSYS: selected is ProfilerKind.NSYS,
             ProfilerKind.TORCH: selected is ProfilerKind.TORCH,
             ProfilerKind.NEURON: selected is ProfilerKind.NEURON,
+            ProfilerKind.MACOS_CPU: selected is ProfilerKind.MACOS_CPU,
         }
         assert ctx.profiler_kind is selected
         assert (ctx.workspace / "nsys_profiler").exists() is expected[ProfilerKind.NSYS]
         assert (ctx.workspace / "torch_profiler").exists() is expected[ProfilerKind.TORCH]
         assert (ctx.workspace / "neuron_profiler").exists() is expected[ProfilerKind.NEURON]
+        assert (ctx.workspace / "macos_cpu_profiler").exists() is expected[ProfilerKind.MACOS_CPU]
 
 
-def test_run_context_generic_auto_resolves_to_none_without_profiler_support(tmp_path):
+def test_run_context_generic_auto_resolves_to_macos_profiler(tmp_path):
     project_root = tmp_path / "project"
     support_paths = _write_support_dirs(project_root)
     ref = _write_ref(tmp_path)
@@ -195,6 +200,7 @@ def test_run_context_generic_auto_resolves_to_none_without_profiler_support(tmp_
         patch("vibe_serve.context._build_model", return_value="mock-model"),
         patch("vibe_serve.context.build_agent_runner", return_value=MagicMock()),
         patch("vibe_serve.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
+        patch("vibe_serve.profilers.platform.system", return_value="Darwin"),
         _RunContext(
             config={"model": {"name": "claude-sonnet-4-6"}},
             exp_name="generic-auto-none",
@@ -211,18 +217,20 @@ def test_run_context_generic_auto_resolves_to_none_without_profiler_support(tmp_
             environment_hooks=NoopEnvironmentHooks(),
         ) as ctx,
     ):
-        assert ctx.profiler_kind is ProfilerKind.NONE
+        assert ctx.profiler_kind is ProfilerKind.MACOS_CPU
         assert ctx.nsys_profiler_path is None
         assert ctx.torch_profiler_path is None
         assert ctx.neuron_profiler_path is None
+        assert ctx.macos_cpu_profiler_path == support_paths[ProfilerKind.MACOS_CPU]
         assert not (ctx.workspace / "nsys_profiler").exists()
         assert not (ctx.workspace / "torch_profiler").exists()
         assert not (ctx.workspace / "neuron_profiler").exists()
+        assert (ctx.workspace / "macos_cpu_profiler").exists()
 
 
 @pytest.mark.parametrize(
     "profiler_kind",
-    sorted(ACTIVE_PROFILER_KINDS, key=lambda kind: kind.value),
+    sorted(ACTIVE_PROFILER_KINDS - {ProfilerKind.MACOS_CPU}, key=lambda kind: kind.value),
 )
 def test_run_context_rejects_generic_explicit_active_profilers(tmp_path, profiler_kind):
     ref = _write_ref(tmp_path)

--- a/tests/test_macos_cpu_profiler.py
+++ b/tests/test_macos_cpu_profiler.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from vibe_serve.macos_cpu_profiler import (
+    DiagnosticCode,
+    MacOSProfilerTool,
+    collect,
+    detect_capability,
+)
+
+
+class Result:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode, self.stdout, self.stderr = returncode, stdout, stderr
+
+
+def test_command_line_tools_shim_falls_back_to_sample():
+    capability = detect_capability(
+        system="Darwin",
+        which=lambda name: "/usr/bin/sample" if name == "sample" else None,
+        run=lambda *_args, **_kwargs: Result(stdout="/Library/Developer/CommandLineTools\n"),
+    )
+    assert capability.tool is MacOSProfilerTool.SAMPLE
+    assert DiagnosticCode.COMMAND_LINE_TOOLS_ONLY in capability.diagnostics
+
+
+def test_missing_time_profiler_template_falls_back_to_sample():
+    def run(command, **_kwargs):
+        if command[:2] == ["xcode-select", "-p"]:
+            return Result(stdout="/Applications/Xcode.app/Contents/Developer\n")
+        return Result(stdout="Activity Monitor\n")
+
+    capability = detect_capability(system="Darwin", which=lambda name: f"/usr/bin/{name}", run=run)
+    assert capability.tool is MacOSProfilerTool.SAMPLE
+    assert DiagnosticCode.TIME_PROFILER_UNAVAILABLE in capability.diagnostics
+
+
+def test_functional_time_profiler_selects_instruments():
+    def run(command, **_kwargs):
+        if command[:2] == ["xcode-select", "-p"]:
+            return Result(stdout="/Applications/Xcode.app/Contents/Developer\n")
+        if command[-2:] == ["list", "templates"]:
+            return Result(stdout="Time Profiler\n")
+        return Result(stdout="xctrace version 26.0\n")
+
+    capability = detect_capability(system="Darwin", which=lambda name: f"/usr/bin/{name}", run=run)
+    assert capability.tool is MacOSProfilerTool.XCTRACE
+    assert capability.tool_version == "xctrace version 26.0"
+
+
+def test_collection_persists_reproduction_metadata(tmp_path: Path):
+    result = collect(["./benchmark"], tmp_path, capability=detect_capability(system="Linux"))
+    metadata = Path(result.metadata).read_text()
+    assert result.status == "error"
+    assert '"diagnostic_only": true' in metadata
+    assert '"scored_benchmark": false' in metadata
+
+
+def test_permission_failure_and_child_target_are_structured(tmp_path: Path):
+    capability = detect_capability(
+        system="Darwin",
+        which=lambda name: "/usr/bin/sample" if name == "sample" else None,
+        run=lambda *_args, **_kwargs: Result(stdout="/Library/Developer/CommandLineTools\n"),
+    )
+    process = type(
+        "Process",
+        (),
+        {
+            "pid": 123,
+            "terminate": lambda self: None,
+            "wait": lambda self, timeout: 0,
+            "kill": lambda self: None,
+        },
+    )()
+    with (
+        patch("vibe_serve.macos_cpu_profiler.subprocess.Popen", return_value=process),
+        patch("vibe_serve.macos_cpu_profiler._descendants", return_value=[456]),
+        patch("vibe_serve.macos_cpu_profiler.time.sleep"),
+        patch(
+            "vibe_serve.macos_cpu_profiler.subprocess.run",
+            return_value=Result(1, stderr="Operation not permitted"),
+        ),
+    ):
+        result = collect(["./benchmark"], tmp_path, capability=capability)
+    assert result.target_pid == 456
+    assert DiagnosticCode.ATTACH_DENIED in result.diagnostics

--- a/tests/test_macos_cpu_profiler.py
+++ b/tests/test_macos_cpu_profiler.py
@@ -2,10 +2,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 from vibe_serve.macos_cpu_profiler import (
+    Capability,
     DiagnosticCode,
     MacOSProfilerTool,
+    _descendants,
     collect,
     detect_capability,
+    parse_command,
 )
 
 
@@ -48,12 +51,78 @@ def test_functional_time_profiler_selects_instruments():
     assert capability.tool_version == "xctrace version 26.0"
 
 
+def test_detection_reports_unavailable_tools_after_xcode_select_failure():
+    def fail(*_args, **_kwargs):
+        raise OSError("xcode-select unavailable")
+
+    with patch("vibe_serve.macos_cpu_profiler.Path.is_file", return_value=False):
+        capability = detect_capability(system="Darwin", which=lambda _name: None, run=fail)
+    assert capability.tool is MacOSProfilerTool.NONE
+    assert capability.diagnostics[-2:] == (
+        DiagnosticCode.TIME_PROFILER_UNAVAILABLE,
+        DiagnosticCode.SAMPLE_UNAVAILABLE,
+    )
+
+
+def test_descendants_returns_nested_processes_and_ignores_malformed_rows():
+    result = Result(stdout="10 1\n20 10\nmalformed\n30 20\n40 10\n10 30\n")
+    assert _descendants(10, run=lambda *_args, **_kwargs: result) == [20, 40, 30]
+
+
 def test_collection_persists_reproduction_metadata(tmp_path: Path):
     result = collect(["./benchmark"], tmp_path, capability=detect_capability(system="Linux"))
     metadata = Path(result.metadata).read_text()
     assert result.status == "error"
     assert '"diagnostic_only": true' in metadata
     assert '"scored_benchmark": false' in metadata
+
+
+def test_instruments_collection_builds_bounded_launch_command(tmp_path: Path):
+    capability = Capability(
+        MacOSProfilerTool.XCTRACE,
+        "/Applications/Xcode.app/Contents/Developer",
+        "/usr/bin/xctrace",
+        "/usr/bin/sample",
+        "xctrace 26",
+    )
+    with patch(
+        "vibe_serve.macos_cpu_profiler.subprocess.run",
+        return_value=Result(),
+    ) as run:
+        result = collect(
+            ["./benchmark", "--workers", "2"], tmp_path, duration=7, capability=capability
+        )
+
+    assert result.status == "ok"
+    assert result.artifact == str(tmp_path / "time-profile.trace")
+    assert result.command == (
+        "/usr/bin/xctrace",
+        "record",
+        "--template",
+        "Time Profiler",
+        "--time-limit",
+        "7s",
+        "--output",
+        str(tmp_path / "time-profile.trace"),
+        "--launch",
+        "--",
+        "./benchmark",
+        "--workers",
+        "2",
+    )
+    assert run.call_args.kwargs["timeout"] == 37
+
+
+def test_collection_converts_profiler_launch_error_to_diagnostic(tmp_path: Path):
+    capability = Capability(MacOSProfilerTool.XCTRACE, None, "/usr/bin/xctrace", None, None)
+    with patch(
+        "vibe_serve.macos_cpu_profiler.subprocess.run",
+        side_effect=OSError("cannot execute"),
+    ):
+        result = collect(["./benchmark"], tmp_path, capability=capability)
+    assert result.status == "error"
+    assert DiagnosticCode.COLLECTION_FAILED in result.diagnostics
+    assert "cannot execute" in Path(result.metadata).read_text()
 
 
 def test_permission_failure_and_child_target_are_structured(tmp_path: Path):
@@ -84,3 +153,39 @@ def test_permission_failure_and_child_target_are_structured(tmp_path: Path):
         result = collect(["./benchmark"], tmp_path, capability=capability)
     assert result.target_pid == 456
     assert DiagnosticCode.ATTACH_DENIED in result.diagnostics
+
+
+def test_sample_kills_launcher_when_graceful_wait_times_out(tmp_path: Path):
+    capability = Capability(MacOSProfilerTool.SAMPLE, None, None, "/usr/bin/sample", None)
+    process = type(
+        "Process",
+        (),
+        {
+            "pid": 123,
+            "terminate": lambda self: None,
+            "wait": lambda self, timeout: (_ for _ in ()).throw(
+                __import__("subprocess").TimeoutExpired("benchmark", timeout)
+            ),
+            "kill": lambda self: setattr(self, "killed", True),
+            "killed": False,
+        },
+    )()
+    with (
+        patch("vibe_serve.macos_cpu_profiler.subprocess.Popen", return_value=process),
+        patch("vibe_serve.macos_cpu_profiler._descendants", return_value=[]),
+        patch("vibe_serve.macos_cpu_profiler.time.sleep"),
+        patch("vibe_serve.macos_cpu_profiler.subprocess.run", return_value=Result()),
+    ):
+        result = collect(["./benchmark"], tmp_path, capability=capability)
+    assert result.status == "ok"
+    assert result.target_pid == 123
+    assert process.killed
+
+
+def test_parse_command_preserves_quoted_arguments_without_shell_execution():
+    assert parse_command('python bench.py --label "queue run"') == [
+        "python",
+        "bench.py",
+        "--label",
+        "queue run",
+    ]

--- a/tests/test_profilers.py
+++ b/tests/test_profilers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import platform
+
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
@@ -35,13 +37,18 @@ def _expected_resolved(
         if requested not in allowed:
             raise ValueError
         return requested
-    if domain is DomainName.GENERIC:
-        return ProfilerKind.NONE
+    if domain is DomainName.GENERIC and requested is ProfilerKind.AUTO:
+        return ProfilerKind.MACOS_CPU if platform.system() == "Darwin" else ProfilerKind.NONE
     if environment_default_profiler_kind is ProfilerKind.TORCH:
         return ProfilerKind.TORCH
-    if backend_profiler_kind in ACTIVE_PROFILER_KINDS:
-        return backend_profiler_kind
-    return environment_default_profiler_kind
+    candidate = (
+        backend_profiler_kind
+        if backend_profiler_kind in ACTIVE_PROFILER_KINDS
+        else environment_default_profiler_kind
+    )
+    if candidate not in allowed:
+        raise ValueError
+    return candidate
 
 
 @pytest.mark.parametrize("domain", _DOMAINS)
@@ -91,12 +98,17 @@ def test_profiler_resolution_invariants(
             resolve_profiler_kind(requested, **kwargs)
         return
 
-    resolved = resolve_profiler_kind(requested, **kwargs)
+    try:
+        resolved = resolve_profiler_kind(requested, **kwargs)
+    except ValueError:
+        assert requested is ProfilerKind.AUTO
+        return
 
     assert resolved is not ProfilerKind.AUTO
     assert resolved in allowed
-    if domain is DomainName.GENERIC:
-        assert resolved is ProfilerKind.NONE
+    if domain is DomainName.GENERIC and requested is ProfilerKind.AUTO:
+        expected = ProfilerKind.MACOS_CPU if platform.system() == "Darwin" else ProfilerKind.NONE
+        assert resolved is expected
     if requested is not ProfilerKind.AUTO:
         assert resolved is requested
     if (


### PR DESCRIPTION
## Problem

Generic CPU workloads currently resolve `--profiler auto` to `none`, so profiler requests can be silently skipped. On macOS, Instruments Time Profiler is preferred, but `xctrace` may be only a non-functional Command Line Tools shim; workloads such as the native queue evaluator also perform their real work in child processes.

Closes #140.

## Solution

Add a typed `macos-cpu` profiler for generic workloads on Darwin.

- Resolve generic `auto` to the native macOS profiler on Darwin while preserving the existing non-macOS and GPU profiler behavior.
- Validate full Xcode and the Time Profiler template before selecting Instruments; fall back to `/usr/bin/sample`.
- Launch a separate diagnostic workload, discover child workers for `sample` attachment, and persist the raw report plus reproduction metadata.
- Expose capability detection and collection through the existing profiler MCP/agent flow for agent and evolve loops.
- Record structured tool, template, permission, and hardware-counter diagnostics, along with symbolication-tool availability.
- Document selection, fallback, symbol, overhead/separation, and evidence limitations.

The CLI contract gains the explicit `macos-cpu` profiler value. New profiler prompts are additive; existing prompt snapshots are not applicable and existing nsys, torch, and neuron prompts are unchanged.

## Verification

Formatting, lint, focused profiler tests, and the complete test suite pass. On the development Mac, capability detection correctly selected `sample` and reported `command_line_tools_only` because the active developer directory is `/Library/Developer/CommandLineTools`.

A real Instruments capture was not run because full Xcode is unavailable on this machine.

### Correctness properties

- Diagnostic profiling is marked separately and never supplies the trusted scored benchmark result.
- Darwin generic `auto` resolves to `macos-cpu`; non-Darwin generic `auto` remains `none`.
- The Command Line Tools shim is never mistaken for functional Instruments.
- `sample` targets the discovered worker child when one exists.
- Raw artifacts and metadata retain exact commands, timing, platform/tool details, topology, and diagnostics.
- Missing tools, attach restrictions, and hardware-counter limitations are explicit rather than silent.
- Existing nsys, torch, and neuron behavior remains unchanged.

### Testing

- `./scripts/format.sh` — passed
- `./scripts/check_format.sh` — passed
- `./scripts/check_lint.sh` — passed
- `uv run pytest -q` — 1214 passed
- `uv run python -c 'from vibe_serve.macos_cpu_profiler import detect_capability; print(detect_capability())'` — selected `sample`; reported Command Line Tools-only and unavailable hardware counters
