### PR TITLE
Add microservices domain

### DIFF
--- a/examples/microservices/social-network-read-timeline/vibeserve.input.toml
+++ b/examples/microservices/social-network-read-timeline/vibeserve.input.toml
@@ -1,7 +1,7 @@
 version = 1
 
 [agent]
-domain = "generic"
+domain = "microservices"
 
 [accuracy]
 command = ["./accuracy_checker/checker"]

--- a/examples/microservices/train-ticket/vibeserve.input.toml
+++ b/examples/microservices/train-ticket/vibeserve.input.toml
@@ -1,7 +1,7 @@
 version = 1
 
 [agent]
-domain = "generic"
+domain = "microservices"
 
 [accuracy]
 command = ["uv", "run", "python", "accuracy_checker/checker.py"]

--- a/src/vibe_serve/domains/base.py
+++ b/src/vibe_serve/domains/base.py
@@ -12,6 +12,7 @@ from vibe_serve.domains.environment import EnvironmentHooks
 class DomainName(StrEnum):
     LLM_SERVING = "llm-serving"
     GENERIC = "generic"
+    MICROSERVICES = "microservices"
 
 
 class DomainRole(StrEnum):

--- a/src/vibe_serve/domains/microservices/__init__.py
+++ b/src/vibe_serve/domains/microservices/__init__.py
@@ -1,0 +1,14 @@
+"""Microservices domain definition."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from vibe_serve.domains.base import DomainDefinition, DomainName
+from vibe_serve.domains.environment import NoopEnvironmentHooks
+
+DEFINITION = DomainDefinition(
+    name=DomainName.MICROSERVICES,
+    prompt_dir=Path(__file__).resolve().parent / "templates",
+    environment_hooks=NoopEnvironmentHooks(),
+)

--- a/src/vibe_serve/domains/microservices/templates/README.md
+++ b/src/vibe_serve/domains/microservices/templates/README.md
@@ -1,0 +1,26 @@
+# Microservices
+
+**Use for:** optimizing microservice applications whose correctness and
+performance are evaluated through service APIs such as HTTP, Thrift, gRPC, or
+gateway/proxy routes.
+
+**What this pack adds:**
+- *Implementer:* focuses the agent on the end-to-end request path under test:
+  client endpoint, gateway/proxy, downstream services, caches, databases,
+  queues, service discovery, and load-balancing components. It also highlights
+  common service-performance levers such as connection pooling, cache hit rates,
+  database indexes, concurrency limits, serialization overhead, and gateway
+  upstream tuning.
+- *Judge:* adds always-on API compatibility checks, requires correctness before
+  benchmarking, judges performance with the objective's headline metric plus
+  success/error rates, and rejects microservice-specific reward hacks such as
+  hard-coded responses, stale cache shortcuts, bypassed downstream state, or
+  evaluator-owned file edits.
+- *Orchestrator / Profiler:* suggest round-sized service optimization tasks and
+  profile evidence for the benchmarked network path, including gateway logs,
+  service logs, container/process usage, database/cache stats, and steady-state
+  benchmark output.
+
+Input bundles select it with `[agent].domain = "microservices"`. Task-specific
+API contracts, ports, service startup steps, and workload mixes belong in the
+input bundle's `OBJECTIVE.md` and related candidate contract files.

--- a/src/vibe_serve/domains/microservices/templates/implementer.md
+++ b/src/vibe_serve/domains/microservices/templates/implementer.md
@@ -1,0 +1,36 @@
+You are working on a **microservice system**. Optimize the deployed service path
+while preserving the API and data semantics that the objective, checker, and
+benchmark exercise.
+
+## Development priorities
+
+1. Read the objective, manifest, README, and any candidate contract files before
+   editing code or deployment configuration.
+2. Identify the request path under test: client endpoint, gateway/proxy,
+   downstream services, caches, databases, queues, and any service discovery or
+   load-balancing components.
+3. Run the accuracy checker before relying on benchmark numbers. Performance
+   wins are invalid if response shape, status codes, ordering, visibility,
+   consistency, pagination, or error semantics regress.
+4. Treat benchmark and checker code as evaluator-owned unless the objective
+   explicitly says otherwise. Do not edit them to make a candidate pass.
+5. Keep changes scoped to the candidate service, deployment, or configuration
+   surface required by the task.
+
+## Common optimization levers
+
+Prefer changes that improve the end-to-end workload named by the objective:
+
+- Reduce avoidable network hops, serialization overhead, and connection setup.
+- Reuse clients and connection pools instead of reconnecting per request.
+- Tune concurrency limits, worker pools, queue sizes, timeouts, and runtime
+  settings for the measured load.
+- Improve cache hit rates while preserving invalidation and visibility rules.
+- Add or adjust database indexes only when they match the benchmarked queries.
+- Move repeated pure computation out of hot request paths.
+- Tune gateway/proxy routing, keep-alive, buffering, and upstream pools when the
+  gateway is on the critical path.
+
+Avoid shortcuts that only satisfy the benchmark shape: hard-coded responses,
+skipping required downstream state checks, returning stale data after writes, or
+changing public API behavior.

--- a/src/vibe_serve/domains/microservices/templates/judge.md
+++ b/src/vibe_serve/domains/microservices/templates/judge.md
@@ -1,0 +1,43 @@
+You are reviewing a **microservice optimization**.
+
+## Always-on correctness checks
+
+In addition to the orchestrator's criteria, a pass verdict requires:
+
+1. The candidate preserves the externally visible API contract exercised by the
+   objective and checker: response shape, status codes, ordering, pagination,
+   visibility rules, consistency guarantees, and error semantics.
+{% if accuracy_command %}
+2. Run `{{ accuracy_command }}` with default flags unless the objective gives a
+   stricter command. If it exits non-zero, the round fails.
+{% endif %}
+{% if benchmark_command %}
+3. Run `{{ benchmark_command }}` only after correctness passes. Use the
+   objective's headline metric and read error/success-rate fields alongside
+   latency or throughput.
+{% endif %}
+
+## Reward-hack and regression checks
+
+Reject changes that make the benchmark pass by weakening the system instead of
+optimizing it:
+
+- Hard-coded or prerecorded responses on the benchmarked route.
+- Returning cached data without respecting writes, invalidation, visibility, or
+  pagination rules.
+- Bypassing downstream services or databases when the API contract requires their
+  state.
+- Editing evaluator-owned checker, benchmark, reference, or workload files.
+- Narrowing the accepted workload so only the benchmark's exact inputs succeed.
+
+When performance improves, verify the implementation still uses the real
+service path required by the objective. If the candidate changes deployment
+configuration, inspect logs and health status for hidden failures, retries, or
+traffic silently routed away from the service under test.
+
+## Performance judgment
+
+Judge performance against the objective's end-to-end headline metric, not an
+internal microbenchmark, isolated handler timing, or single-hop latency unless
+the objective explicitly makes that the metric. Include error rate and success
+rate in the analysis whenever they are reported.

--- a/src/vibe_serve/domains/microservices/templates/orchestrator.md
+++ b/src/vibe_serve/domains/microservices/templates/orchestrator.md
@@ -1,0 +1,27 @@
+## Microservice planning guidance
+
+Choose round-sized tasks that improve the measured service path while keeping
+the public API stable.
+
+Good task shapes include:
+
+- Establish a baseline by running the checker and benchmark, then identify the
+  slowest endpoint or dependency from logs, timing headers, or profiler output.
+- Add or tune client connection pooling for a hot downstream service.
+- Tune gateway/proxy upstream pools, keep-alive, buffering, or routing for the
+  benchmarked endpoints.
+- Improve cache usage with explicit invalidation or consistency constraints.
+- Add a database index or query rewrite for the workload's hot read path.
+- Reduce serialization, JSON encoding, Thrift/gRPC conversion, or repeated
+  per-request setup on the hot path.
+- Tune worker counts, queue sizes, runtime settings, and timeouts for the
+  offered load.
+
+Write pass criteria in terms of the objective's headline metric and correctness
+gate. Include acceptable error-rate or success-rate constraints when the
+benchmark reports them. Avoid criteria that reward isolated handler timing while
+the end-to-end service gets worse.
+
+Prefer one change per round. If a service lifecycle step is uncertain, first ask
+the implementer to document and validate startup, health, checker, and benchmark
+commands before attempting optimization.

--- a/src/vibe_serve/domains/microservices/templates/profiler.md
+++ b/src/vibe_serve/domains/microservices/templates/profiler.md
@@ -1,0 +1,21 @@
+## Microservice profile capture
+
+Profile the same network path that the benchmark exercises. Start from the
+objective and manifest to identify the base URL, gateway, service ports, and
+benchmark command.
+
+Useful evidence includes:
+
+- Benchmark output with headline metric, latency percentiles, throughput,
+  success rate, and error rate.
+- Gateway/proxy logs and upstream timing fields.
+- Service logs showing retries, timeouts, connection churn, queueing, or slow
+  dependency calls.
+- Container or process CPU and memory during steady-state load.
+- Database/cache stats such as hit rate, slow queries, connection counts, and
+  pool saturation.
+
+When using a system profiler, capture a steady-state run after warmup. For
+Docker Compose deployments, record the service or container being profiled and
+the benchmark load level used. Do not treat a single internal span or local
+handler timing as the final metric unless the objective defines it that way.

--- a/src/vibe_serve/domains/registry.py
+++ b/src/vibe_serve/domains/registry.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from vibe_serve.domains import generic, llm_serving
+from vibe_serve.domains import generic, llm_serving, microservices
 from vibe_serve.domains.base import DomainDefinition, DomainName
 
 DOMAINS: dict[DomainName, DomainDefinition] = {
     generic.DEFINITION.name: generic.DEFINITION,
     llm_serving.DEFINITION.name: llm_serving.DEFINITION,
+    microservices.DEFINITION.name: microservices.DEFINITION,
 }
 
 

--- a/src/vibe_serve/profilers.py
+++ b/src/vibe_serve/profilers.py
@@ -150,6 +150,9 @@ def resolve_profiler_kind(
     if domain_name is DomainName.GENERIC:
         return ProfilerKind.MACOS_CPU if platform.system() == "Darwin" else ProfilerKind.NONE
 
+    if allowed == frozenset({ProfilerKind.NONE}):
+        return ProfilerKind.NONE
+
     environment_default = require_profiler_kind(
         environment_default_profiler_kind,
         label="environment default profiler",

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -26,11 +26,13 @@ from vibe_serve.domains.registry import (
     resolve_domain,
 )
 from vibe_serve.domains.rendering import render_domain_section
+from vibe_serve.input_manifest import load_input_bundle
 from vibe_serve.prompts import render_template
 
 _TEMPLATE_DIR = (
     Path(__file__).resolve().parents[3] / "src" / "vibe_serve" / "loops" / "agent" / "templates"
 )
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _temporary_domain(prompt_dir: Path) -> DomainDefinition:
@@ -48,6 +50,7 @@ def test_registered_domains_present():
     names = registered_domains()
     assert "llm-serving" in names
     assert "generic" in names
+    assert "microservices" in names
     assert "README" not in names  # the authoring guide is not a domain
 
 
@@ -57,6 +60,14 @@ def test_resolve_registered_name():
     assert d.prompt_dir.is_dir()
     assert d.prompt_dir.name == "templates"
     assert d.prompt_dir.parent.name == "llm_serving"
+
+
+def test_resolve_microservices_domain():
+    d = resolve_domain(DomainName.MICROSERVICES)
+    assert d.name is DomainName.MICROSERVICES
+    assert d.prompt_dir.is_dir()
+    assert d.prompt_dir.name == "templates"
+    assert d.prompt_dir.parent.name == "microservices"
 
 
 def test_resolve_path_is_not_supported(tmp_path: Path):
@@ -70,11 +81,13 @@ def test_resolve_path_is_not_supported(tmp_path: Path):
 def test_registered_domains_carry_environment_hooks():
     assert isinstance(DOMAINS[DomainName.LLM_SERVING].environment_hooks, LLMServingEnvironmentHooks)
     assert isinstance(DOMAINS[DomainName.GENERIC].environment_hooks, NoopEnvironmentHooks)
+    assert isinstance(DOMAINS[DomainName.MICROSERVICES].environment_hooks, NoopEnvironmentHooks)
 
 
 def test_domains_declare_torch_profiler_compatibility():
     assert DOMAINS[DomainName.LLM_SERVING].supports_torch_profiler
     assert not DOMAINS[DomainName.GENERIC].supports_torch_profiler
+    assert not DOMAINS[DomainName.MICROSERVICES].supports_torch_profiler
 
 
 def test_resolve_unknown_raises():
@@ -111,6 +124,21 @@ def test_render_llm_serving_has_content():
     assert impl == impl.strip("\n")
     # the body keeps its own ## sub-headings (not treated as role delimiters)
     assert "## Required:" in impl
+
+
+def test_render_microservices_has_content():
+    d = resolve_domain(DomainName.MICROSERVICES)
+    impl = render_domain_section(d, DomainRole.IMPLEMENTER, interface="service")
+    judge = render_domain_section(
+        d,
+        DomainRole.JUDGE,
+        accuracy_command="./check",
+        benchmark_command="./bench",
+    )
+    assert "networked microservice system" in impl
+    assert "connection pools" in impl
+    assert "./check" in judge
+    assert "./bench" in judge
 
 
 def test_role_file_keeps_markdown_headings(tmp_path: Path):

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -26,13 +26,11 @@ from vibe_serve.domains.registry import (
     resolve_domain,
 )
 from vibe_serve.domains.rendering import render_domain_section
-from vibe_serve.input_manifest import load_input_bundle
 from vibe_serve.prompts import render_template
 
 _TEMPLATE_DIR = (
     Path(__file__).resolve().parents[3] / "src" / "vibe_serve" / "loops" / "agent" / "templates"
 )
-_PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _temporary_domain(prompt_dir: Path) -> DomainDefinition:

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -135,7 +135,7 @@ def test_render_microservices_has_content():
         accuracy_command="./check",
         benchmark_command="./bench",
     )
-    assert "networked microservice system" in impl
+    assert "microservice system" in impl
     assert "connection pools" in impl
     assert "./check" in judge
     assert "./bench" in judge

--- a/tests/test_profilers.py
+++ b/tests/test_profilers.py
@@ -60,6 +60,8 @@ def _expected_resolved(
         return requested
     if domain is DomainName.GENERIC and requested is ProfilerKind.AUTO:
         return ProfilerKind.MACOS_CPU if platform.system() == "Darwin" else ProfilerKind.NONE
+    if allowed == frozenset({ProfilerKind.NONE}):
+        return ProfilerKind.NONE
     if environment_default_profiler_kind is ProfilerKind.TORCH:
         return ProfilerKind.TORCH
     candidate = (


### PR DESCRIPTION
## Problem

VibeServe doesn't yet include a domain for microservices. There are microservice examples in the repo, but they currently use the `generic` domain. Adding the microservices domain base framework allows for reusable templates and broader support of optimization for microservices.

## Solution

Add a registered `microservices` domain with role templates for implementer, judge, orchestrator, and profiler behavior.

This new domain is intentionally lightweight for now, it makes general changes. This means:
- no new manifest schema
- no service lifecycle automation
- no benchmark or telemetry framework changes

These changes will be added in a later PR. Please note that the current template MD files are subject to change as microservice functionality is extended (eg. standardized load balancing + telemetry).

The current PR provides reusable prompt guidance for microservice optimization while keeping task-specific API contracts, ports, startup steps, and workloads in each input bundle. The existing Train Ticket and Social Network microservice examples now select `[agent].domain = "microservices"` in order to move them off the "generic" domain.

Domain tests were extended to cover registration, resolution, prompt rendering, environment hook behavior, profiler compatibility, and the updated microservice example manifests.

## Verification

All the validation tests run + pytest execution of the new tests.

### Correctness properties

- `microservices` is a valid `DomainName`.
- The `microservices` domain is registered and resolves to its template directory.
- The domain uses no-op environment hooks, so it does not change workspace materialization, mounts, or runtime setup.
- The domain does not claim Torch profiler compatibility.
- Existing microservice input bundles load with `domain = "microservices"`.
- Microservice guidance remains prompt-only and does not alter evaluator
  commands, benchmark commands, or checker behavior.

### Testing

`uv run pytest tests/loops/agent/test_domain_packs.py` -> 23 passed