### PR TITLE
Harden KV-store scoring and evaluator contracts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,29 @@ jobs:
         working-directory: examples/evaluators/queue
         run: go test -race ./...
 
+  kv-store-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y default-jre redis-server iproute2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install Python dependencies
+        run: |
+          uv sync --dev
+          uv pip install -r examples/kv-store/requirements.txt
+
+      - name: Run KV-store evaluator smoke test
+        run: examples/kv-store/run_test.sh
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/examples/kv-store/CANDIDATE_CONTRACT.md
+++ b/examples/kv-store/CANDIDATE_CONTRACT.md
@@ -1,0 +1,78 @@
+# KV-store Candidate Contract v1
+
+This document is the normative interface between the trusted evaluators and an
+untrusted candidate implementation. `OBJECTIVE.md` defines the optimization
+goal; this file defines which implementations are valid.
+
+## Required artifact and lifecycle
+
+Candidates must provide an executable `run.sh` in the workspace root. The
+evaluator invokes it as:
+
+```text
+./run.sh <port>
+```
+
+The launcher must keep the server in the launcher's process group, must not
+daemonize, and must not escape into another session or process group. It may
+`exec` a server or create a stable worker pool. The worker set must remain
+stable during a scored interval so the evaluator can account for all server
+CPU. On termination of the process group, all candidate processes must exit.
+
+The server must listen on `127.0.0.1:<port>` and answer `PING` with `PONG`
+within five seconds. It must remain available until terminated by the
+evaluator.
+
+## Wire protocol
+
+The service speaks Redis RESP2 over TCP. It must:
+
+- accept binary-safe RESP2 arrays of bulk-string command arguments;
+- handle requests split across arbitrary TCP reads;
+- handle multiple pipelined requests in one read and return replies in order;
+- emit correctly typed RESP2 replies with valid lengths and CRLF framing;
+- share one logical store across all connections and worker processes.
+
+Command names are case-insensitive. Keys, field names, and values are arbitrary
+byte strings.
+
+## Required commands
+
+The required data commands follow Redis semantics for the supported forms:
+
+- `PING` returns `PONG`.
+- `SET key value` stores a string and returns `OK`.
+- `GET key` returns the string value or a null bulk string.
+- `DEL key [key ...]` returns the number of existing keys removed.
+- `HSET key field value [field value ...]` returns the number of newly created
+  fields.
+- `HMSET key field value [field value ...]` stores the fields and returns `OK`.
+- `HGETALL key` returns all field/value pairs, or an empty array when absent.
+- `DBSIZE` returns the number of top-level keys.
+- `FLUSHDB` clears the store and returns `OK`.
+
+Using a string command on a hash, or a hash command on a string, returns a
+RESP2 `WRONGTYPE` error without changing the stored value. Invalid arity
+returns a RESP2 error and does not mutate state.
+
+The following compatibility commands are required because Redis clients may
+issue them during connection setup:
+
+- `COMMAND`, `CLIENT ...`, and `HELLO 2` must return a valid non-error RESP2
+  reply accepted by the bundled clients.
+
+Commands and options outside this subset are not required.
+
+## Concurrency
+
+Each command is atomic. Completed writes must be visible to later commands on
+every connection. Concurrent operations must be linearizable: their effects
+must be equivalent to some order consistent with non-overlapping calls.
+Implementations must not maintain per-connection or per-process split-brain
+copies of the store.
+
+## Storage scope
+
+The store is in-memory, non-persistent, single-node, and non-replicated.
+Durability, authentication, clustering, eviction, and transactions are outside
+this contract.

--- a/examples/kv-store/OBJECTIVE.md
+++ b/examples/kv-store/OBJECTIVE.md
@@ -5,34 +5,44 @@ client load as efficiently as possible. Build a RESP2-compatible in-memory KV
 server. Do **less server work per operation** — including on the read and update
 paths specifically, not just generic transport.
 
+The normative service, RESP2, concurrency, and lifecycle requirements are in
+[`CANDIDATE_CONTRACT.md`](CANDIDATE_CONTRACT.md).
+
 ## Notes
 
 - Seed baseline: `reference/seed_server.py`, ~10k ops/sec.
-- **Scored metric:** `ops_per_cpu_sec` — operations served per second of server
+- **Headline metric: `ops_per_cpu_sec` (maximize).** This is operations served per second of server
   CPU (its `PERF_CPU_PER_OP:` line is the inverse, µs/op). It is measured
-  *externally* from the server's `/proc` CPU over the run, so — unlike raw
+  *externally* from the stable candidate process group's Linux `/proc` CPU over
+  the run, so — unlike raw
   throughput — it is immune to the YCSB client saturating before the server does,
   and it rewards a genuine per-op efficiency win (e.g. a cheaper read path) even
   when transport-bound throughput is flat. Higher is better.
-- **Throughput and latency are gates, not the score.** Report and preserve
-  `throughput_ops_per_sec` (median over several fixed-duration runs) and keep
+- **Throughput and latency are enforced gates, not the score.** Preserve at
+  least 10,000 `throughput_ops_per_sec` (median over fixed-duration runs) and keep
   **p99 < 1.0 ms** for READ and UPDATE at the concurrent load. Winning efficiency
-  by collapsing throughput or blowing up p99 is a fail. Single-connection numbers
-  are RTT-bound and hide the server; `--threads 1` is a latency reference only.
+  by collapsing throughput or blowing up p99 makes the benchmark exit nonzero.
+  Single-connection numbers are RTT-bound and hide the server; `--threads 1` is
+  a latency reference only.
 - The benchmark drives the server from several independent client JVMs
-  (`--client-procs`) to reach server saturation, reports `server_cpu_cores` as a
-  saturation check, and can isolate per-op-type server cost (`--probe-per-op`) so
-  a read- or update-specific optimization is attributable. Record shape is tunable
-  (`--field-count`/`--field-length`); Workload A stores each record as a **hash**
-  (HSET / HGETALL).
+  (`--client-procs`) and validates the load plateau with a higher-client-count
+  probe. `server_cpu_cores` remains a diagnostic. The benchmark can isolate
+  per-op-type server cost (`--probe-per-op`) so a read- or update-specific
+  optimization is attributable. Record shape is tunable
+  (`--field-count`/`--field-length`); Workload A stores each record as a
+  **hash** (HSET / HGETALL).
 
 ## Agent guidance
 
 - CPU-bound network server — no GPU, model, or tensor work. Scope each round
-  from what the profile shows is the dominant bottleneck.
+  from benchmark CPU/per-op evidence and an actual profile when profiling is
+  available.
 - Judged only over the wire (`--interface service`). A compiled systems language
   (C / Rust / Go) has a decisive edge over an interpreter; prefer building the
   baseline directly in a compiled language rather than iterating on the Python
   seed.
 - Non-persistent (in-memory only) and single-node (no replication).
 - The candidate must listen on a TCP port and be started via `./run.sh <port>`.
+- Scored evaluation is Linux-only because trusted CPU accounting requires
+  procfs. Generic Linux `--profiler auto` currently disables the separate
+  profiler phase; `perf` may still be used manually when permitted.

--- a/examples/kv-store/OBJECTIVE.md
+++ b/examples/kv-store/OBJECTIVE.md
@@ -26,11 +26,10 @@ The normative service, RESP2, concurrency, and lifecycle requirements are in
   a latency reference only.
 - The benchmark drives the server from several independent client JVMs
   (`--client-procs`) and validates the load plateau with a higher-client-count
-  probe. `server_cpu_cores` remains a diagnostic. The benchmark can isolate
-  per-op-type server cost (`--probe-per-op`) so a read- or update-specific
-  optimization is attributable. Record shape is tunable
-  (`--field-count`/`--field-length`); Workload A stores each record as a
-  **hash** (HSET / HGETALL).
+  probe. `server_cpu_cores` remains a diagnostic. Optional non-scoring
+  diagnostics (`--probe-per-op`, `--field-count`/`--field-length`) can attribute
+  per-op CPU or enlarge records; Workload A stores each record as a **hash**
+  (HSET / HGETALL).
 
 ## Agent guidance
 

--- a/examples/kv-store/OBJECTIVE.md
+++ b/examples/kv-store/OBJECTIVE.md
@@ -1,22 +1,30 @@
 # Objective — KV store (Redis RESP2)
 
-Maximize **throughput (ops/sec)** on YCSB Workload A (50% read / 50% update,
-Zipfian keys) under **concurrent** client load. Build a RESP2-compatible
-in-memory KV server.
+Serve YCSB Workload A (50% read / 50% update, Zipfian keys) under **concurrent**
+client load as efficiently as possible. Build a RESP2-compatible in-memory KV
+server. Do **less server work per operation** — including on the read and update
+paths specifically, not just generic transport.
 
 ## Notes
 
 - Seed baseline: `reference/seed_server.py`, ~10k ops/sec.
-- **Headline metric:** the benchmark's `PERF_METRIC:` line — median throughput
-  over several fixed-duration runs at the default concurrency (`--threads 16`).
-  Single-connection numbers are RTT-bound and hide the server's ceiling, so the
-  headline is concurrent; use `--threads 1` only as a latency reference.
-- **Latency SLA (a gate, not a footnote):** the throughput only counts if
-  **p99 < 1.0 ms** for READ and UPDATE at the concurrent load. Winning ops/sec
-  by blowing up p99 is a fail.
-- Workload A stores each record as a **hash** (HSET / HGETALL) and drives
-  concurrent client load (`--threads 16`), so the server's behaviour under
-  contention is what the headline measures.
+- **Scored metric:** `ops_per_cpu_sec` — operations served per second of server
+  CPU (its `PERF_CPU_PER_OP:` line is the inverse, µs/op). It is measured
+  *externally* from the server's `/proc` CPU over the run, so — unlike raw
+  throughput — it is immune to the YCSB client saturating before the server does,
+  and it rewards a genuine per-op efficiency win (e.g. a cheaper read path) even
+  when transport-bound throughput is flat. Higher is better.
+- **Throughput and latency are gates, not the score.** Report and preserve
+  `throughput_ops_per_sec` (median over several fixed-duration runs) and keep
+  **p99 < 1.0 ms** for READ and UPDATE at the concurrent load. Winning efficiency
+  by collapsing throughput or blowing up p99 is a fail. Single-connection numbers
+  are RTT-bound and hide the server; `--threads 1` is a latency reference only.
+- The benchmark drives the server from several independent client JVMs
+  (`--client-procs`) to reach server saturation, reports `server_cpu_cores` as a
+  saturation check, and can isolate per-op-type server cost (`--probe-per-op`) so
+  a read- or update-specific optimization is attributable. Record shape is tunable
+  (`--field-count`/`--field-length`); Workload A stores each record as a **hash**
+  (HSET / HGETALL).
 
 ## Agent guidance
 

--- a/examples/kv-store/README.md
+++ b/examples/kv-store/README.md
@@ -28,7 +28,8 @@ cp agent.toml.example agent.toml            # no API key needed for --cli-provid
 The benchmark downloads a checksum-pinned YCSB 0.17.0 Redis binding into the
 workspace `.cache/` on first run.
 
-Verify the harness end-to-end against the seed: `examples/kv-store/run_test.sh`.
+Verify the harness end-to-end against the seed: `examples/kv-store/run_test.sh`
+(CI-tolerant gates; scored thresholds stay in `vibeserve.input.toml`).
 
 ## Run
 

--- a/examples/kv-store/README.md
+++ b/examples/kv-store/README.md
@@ -53,11 +53,13 @@ process group and clean it up afterward.
 Rounds are scored by `ops_per_cpu_sec` (operations per second of server CPU,
 sampled externally from `/proc`) — a client-saturation-immune efficiency metric,
 with `throughput_ops_per_sec` and READ/UPDATE p99 as gates. The benchmark drives
-the server from several client JVMs (`--client-procs`) to reach saturation and can
-isolate per-op-type server cost (`--probe-per-op`); see `benchmark/benchmark.py`.
-Generic Linux `--profiler auto` currently resolves to no separate framework
-profiler; the benchmark's CPU evidence remains available, and `perf` can be used
-manually when host policy permits.
+the server from several client JVMs (`--client-procs`) to reach saturation.
+Optional diagnostics (`--probe-per-op`, `--field-count`, `--field-length`) live
+on the same CLI but are not part of the scored path; see
+`evaluator_support/` and `benchmark/benchmark.py`. Generic Linux
+`--profiler auto` currently resolves to no separate framework profiler; the
+benchmark's CPU evidence remains available, and `perf` can be used manually when
+host policy permits.
 
 ## Files
 
@@ -67,8 +69,8 @@ examples/kv-store/
 ├── CANDIDATE_CONTRACT.md          # Normative protocol and lifecycle contract
 ├── vibeserve.input.toml           # Manifest: domain, checker, benchmark commands
 ├── run_test.sh                    # Standalone end-to-end test against the seed
-├── evaluator_support/             # Trusted candidate lifecycle helpers
+├── evaluator_support/             # Trusted helpers (lifecycle, procfs CPU, YCSB, validity)
 ├── reference/seed_server.py       # Seed baseline / RESP2 reference
 ├── accuracy_checker/checker.py    # Correctness: candidate vs Redis oracle
-└── benchmark/benchmark.py         # Performance: YCSB wrapper (fetches ycsb/ on first run)
+└── benchmark/benchmark.py         # Scored YCSB orchestration (fetches YCSB on first run)
 ```

--- a/examples/kv-store/README.md
+++ b/examples/kv-store/README.md
@@ -41,6 +41,12 @@ vibe-serve --outer-loop agent \
 may implement it in any language. Each round is a git commit in
 `exp_env/<name>/workspace/`; only rounds that pass the accuracy checker advance.
 
+Rounds are scored by `ops_per_cpu_sec` (operations per second of server CPU,
+sampled externally from `/proc`) — a client-saturation-immune efficiency metric,
+with `throughput_ops_per_sec` and READ/UPDATE p99 as gates. The benchmark drives
+the server from several client JVMs (`--client-procs`) to reach saturation and can
+isolate per-op-type server cost (`--probe-per-op`); see `benchmark/benchmark.py`.
+
 ## Files
 
 ```

--- a/examples/kv-store/README.md
+++ b/examples/kv-store/README.md
@@ -6,10 +6,16 @@ correctness (candidate vs a real Redis oracle) and scored by real YCSB.
 
 ## Prerequisites
 
+- Linux with readable `/proc` (required for trusted process CPU accounting)
 - Python 3.11+ and `uv`
-- Java 8+ — YCSB (`apt install default-jre` / `brew install openjdk`)
-- Redis — the accuracy oracle (`apt install redis-server` / `brew install redis`)
+- Java 8+ — YCSB (`sudo apt install default-jre`)
+- Redis — the accuracy oracle (`sudo apt install redis-server`)
+- `iproute2`; optional `linux-tools`/`perf` for manual profiling
 - Claude Code (`claude`) — drives the agent loop
+
+Scored evaluation is Linux-only. Candidate processes must share the evaluator's
+PID namespace. Manual `perf`/`py-spy`/`strace` capture may additionally require
+adjusting `perf_event_paranoid` or ptrace policy.
 
 ## Setup
 
@@ -19,7 +25,8 @@ uv pip install -r examples/kv-store/requirements.txt
 cp agent.toml.example agent.toml            # no API key needed for --cli-provider claude
 ```
 
-The benchmark auto-downloads YCSB 0.17.0 (Redis binding) on first run; no manual setup.
+The benchmark downloads a checksum-pinned YCSB 0.17.0 Redis binding into the
+workspace `.cache/` on first run.
 
 Verify the harness end-to-end against the seed: `examples/kv-store/run_test.sh`.
 
@@ -40,20 +47,27 @@ vibe-serve --outer-loop agent \
 `--interface service` judges the store only over its RESP2 socket, so the agent
 may implement it in any language. Each round is a git commit in
 `exp_env/<name>/workspace/`; only rounds that pass the accuracy checker advance.
+The trusted checker and benchmark each launch `./run.sh <port>` in an isolated
+process group and clean it up afterward.
 
 Rounds are scored by `ops_per_cpu_sec` (operations per second of server CPU,
 sampled externally from `/proc`) — a client-saturation-immune efficiency metric,
 with `throughput_ops_per_sec` and READ/UPDATE p99 as gates. The benchmark drives
 the server from several client JVMs (`--client-procs`) to reach saturation and can
 isolate per-op-type server cost (`--probe-per-op`); see `benchmark/benchmark.py`.
+Generic Linux `--profiler auto` currently resolves to no separate framework
+profiler; the benchmark's CPU evidence remains available, and `perf` can be used
+manually when host policy permits.
 
 ## Files
 
 ```
 examples/kv-store/
 ├── OBJECTIVE.md                   # Target spec (read by the orchestrator)
+├── CANDIDATE_CONTRACT.md          # Normative protocol and lifecycle contract
 ├── vibeserve.input.toml           # Manifest: domain, checker, benchmark commands
 ├── run_test.sh                    # Standalone end-to-end test against the seed
+├── evaluator_support/             # Trusted candidate lifecycle helpers
 ├── reference/seed_server.py       # Seed baseline / RESP2 reference
 ├── accuracy_checker/checker.py    # Correctness: candidate vs Redis oracle
 └── benchmark/benchmark.py         # Performance: YCSB wrapper (fetches ycsb/ on first run)

--- a/examples/kv-store/accuracy_checker/checker.py
+++ b/examples/kv-store/accuracy_checker/checker.py
@@ -23,6 +23,8 @@ Usage:
     python checker.py --port 6380 --no-concurrent
 """
 
+from __future__ import annotations
+
 import argparse
 import atexit
 import os
@@ -42,34 +44,17 @@ _WORKSPACE = Path(__file__).resolve().parents[1]
 if str(_WORKSPACE) not in sys.path:
     sys.path.insert(0, str(_WORKSPACE))
 
-from evaluator_support import candidate_server  # noqa: E402
+from evaluator_support import candidate_server, free_port, wait_until_listening  # noqa: E402
 
 # One replayed request: the redis-py method to call and its arguments.
 Operation = namedtuple("Operation", ["label", "method", "args", "kwargs"])
 
 
-def _client(port):
+def _client(port: int) -> redis.Redis:
     return redis.Redis(host="127.0.0.1", port=port, decode_responses=True, protocol=2)
 
 
-def _free_port():
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
-
-
-def _wait_until_listening(port, timeout=10):
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        try:
-            socket.create_connection(("127.0.0.1", port), timeout=0.5).close()
-            return True
-        except OSError:
-            time.sleep(0.1)
-    return False
-
-
-def _find_redis_server():
+def _find_redis_server() -> str:
     candidates = [
         shutil.which("redis-server"),
         "/opt/homebrew/opt/redis/bin/redis-server",
@@ -81,10 +66,12 @@ def _find_redis_server():
     sys.exit("ERROR: redis-server not found")
 
 
-def _next_operation(rng, num_keys, prefix=""):
-    """Draw the next random operation from the workload mix. `prefix` gives each
-    concurrent thread a disjoint key namespace so its expected state is
-    deterministic even under load."""
+def _next_operation(rng: random.Random, num_keys: int, prefix: str = "") -> Operation:
+    """Draw the next random operation from the workload mix.
+
+    ``prefix`` gives each concurrent thread a disjoint key namespace so its
+    expected state is deterministic even under load.
+    """
     kind = rng.choices(["SET", "GET", "DEL", "HSET", "HGETALL"], weights=[30, 35, 5, 20, 10])[0]
     key = f"{prefix}key:{rng.randint(0, num_keys - 1):06d}"
 
@@ -100,9 +87,9 @@ def _next_operation(rng, num_keys, prefix=""):
     return Operation(kind, "hgetall", (f"h:{key}",), {})
 
 
-def _start_oracle():
+def _start_oracle() -> tuple[redis.Redis, int]:
     """Launch a throwaway Redis oracle and return (client, port)."""
-    port = _free_port()
+    port = free_port()
     process = subprocess.Popen(
         [
             _find_redis_server(),
@@ -119,11 +106,11 @@ def _start_oracle():
         stderr=subprocess.PIPE,
     )
     atexit.register(lambda: (process.terminate(), process.wait()))
-    assert _wait_until_listening(port), f"Redis oracle failed to start on {port}"
+    assert wait_until_listening(port), f"Redis oracle failed to start on {port}"
     return _client(port), port
 
 
-def _compare_call(label, oracle_call, candidate_call):
+def _compare_call(label: str, oracle_call, candidate_call) -> int:
     """Compare one semantic operation, including matching Redis errors."""
     try:
         expected = oracle_call()
@@ -142,7 +129,7 @@ def _compare_call(label, oracle_call, candidate_call):
     return 0
 
 
-def _raw_round_trip(port, chunks):
+def _raw_round_trip(port: int, chunks: list[bytes]) -> bytes:
     with socket.create_connection(("127.0.0.1", port), timeout=2) as sock:
         for chunk in chunks:
             sock.sendall(chunk)
@@ -160,12 +147,7 @@ def _raw_round_trip(port, chunks):
         return bytes(reply)
 
 
-def _semantic_phase(oracle, candidate, port):
-    """Deterministic command, type, binary, framing, and pipeline coverage."""
-    oracle.flushdb()
-    candidate.flushdb()
-    mismatches = 0
-
+def _check_basic_commands(oracle: redis.Redis, candidate: redis.Redis) -> int:
     cases = [
         ("PING", oracle.ping, candidate.ping),
         ("SET", lambda: oracle.set("k", "v1"), lambda: candidate.set("k", "v1")),
@@ -195,9 +177,14 @@ def _semantic_phase(oracle, candidate, port):
             lambda: candidate.delete("k", "h", "missing"),
         ),
     ]
-    for label, oracle_call, candidate_call in cases:
-        mismatches += _compare_call(label, oracle_call, candidate_call)
+    return sum(
+        _compare_call(label, oracle_call, candidate_call)
+        for label, oracle_call, candidate_call in cases
+    )
 
+
+def _check_wrongtype_and_arity(oracle: redis.Redis, candidate: redis.Redis) -> int:
+    mismatches = 0
     oracle.set("typed", "string")
     candidate.set("typed", "string")
     mismatches += _compare_call(
@@ -225,13 +212,16 @@ def _semantic_phase(oracle, candidate, port):
     if candidate.get("typed") != "string" or candidate.hgetall("typed-hash") != {"f": "v"}:
         print("  invalid-arity command mutated state")
         mismatches += 1
+    return mismatches
 
+
+def _check_binary_values(oracle: redis.Redis, candidate_port: int) -> int:
     oracle_raw = redis.Redis(
         host="127.0.0.1", port=oracle.connection_pool.connection_kwargs["port"]
     )
-    candidate_raw = redis.Redis(host="127.0.0.1", port=port, protocol=2)
+    candidate_raw = redis.Redis(host="127.0.0.1", port=candidate_port, protocol=2)
     binary_key, binary_value = b"\x00key\xff", b"\x00value\r\n\xff"
-    mismatches += _compare_call(
+    mismatches = _compare_call(
         "binary SET",
         lambda: oracle_raw.set(binary_key, binary_value),
         lambda: candidate_raw.set(binary_key, binary_value),
@@ -241,7 +231,11 @@ def _semantic_phase(oracle, candidate, port):
         lambda: oracle_raw.get(binary_key),
         lambda: candidate_raw.get(binary_key),
     )
+    return mismatches
 
+
+def _check_compat_commands(candidate: redis.Redis) -> int:
+    mismatches = 0
     for label, command in (
         ("COMMAND", ("COMMAND",)),
         ("CLIENT", ("CLIENT", "SETNAME", "vibeserve-checker")),
@@ -252,16 +246,33 @@ def _semantic_phase(oracle, candidate, port):
         except (redis.RedisError, IndexError, TypeError, ValueError) as exc:
             print(f"  SEMANTIC ERROR [{label} compatibility]: {exc!r}")
             mismatches += 1
+    return mismatches
 
-    oracle.flushdb()
-    candidate.flushdb()
+
+def _check_framing_and_pipeline(port: int) -> int:
     request = b"*3\r\n$3\r\nSET\r\n$4\r\nfrag\r\n$5\r\nvalue\r\n"
     pipeline = b"*2\r\n$3\r\nGET\r\n$4\r\nfrag\r\n*1\r\n$6\r\nDBSIZE\r\n*1\r\n$3\r\nGET\r\n"
     reply = _raw_round_trip(port, [request[:9], request[9:23], request[23:], pipeline])
     expected_prefix = b"+OK\r\n$5\r\nvalue\r\n:1\r\n-"
     if not reply.startswith(expected_prefix):
         print(f"  RESP framing/pipeline mismatch: {reply!r}")
-        mismatches += 1
+        return 1
+    return 0
+
+
+def _semantic_phase(oracle: redis.Redis, candidate: redis.Redis, port: int) -> int:
+    """Deterministic command, type, binary, framing, and pipeline coverage."""
+    oracle.flushdb()
+    candidate.flushdb()
+    mismatches = 0
+    mismatches += _check_basic_commands(oracle, candidate)
+    mismatches += _check_wrongtype_and_arity(oracle, candidate)
+    mismatches += _check_binary_values(oracle, port)
+    mismatches += _check_compat_commands(candidate)
+
+    oracle.flushdb()
+    candidate.flushdb()
+    mismatches += _check_framing_and_pipeline(port)
 
     candidate.flushdb()
     if candidate.dbsize() != 0:
@@ -270,19 +281,18 @@ def _semantic_phase(oracle, candidate, port):
     return mismatches
 
 
-def _read_key(conn, method, key):
-    """Read `key` from the candidate, turning a RESP/connection error into a
-    comparable sentinel so a candidate failure counts as a mismatch instead of
-    crashing the checker."""
+def _read_key(conn: redis.Redis, method: str, key: str):
+    """Read ``key`` from the candidate, turning errors into comparable sentinels."""
     try:
         return getattr(conn, method)(key)
     except redis.RedisError as exc:
         return f"<error: {exc!r}>"
 
 
-def _sequential_phase(oracle, candidate, num_ops, num_keys, seed):
-    """Deterministic single-connection diff: run each op on oracle then candidate
-    and compare in lock-step. Returns the mismatch count."""
+def _sequential_phase(
+    oracle: redis.Redis, candidate: redis.Redis, num_ops: int, num_keys: int, seed: int
+) -> int:
+    """Deterministic single-connection diff against the oracle."""
     rng = random.Random(seed)
     mismatches = 0
     for i in range(num_ops):
@@ -292,8 +302,6 @@ def _sequential_phase(oracle, candidate, num_ops, num_keys, seed):
         try:
             actual = getattr(candidate, op.method)(*op.args, **op.kwargs)
         except redis.RedisError as exc:
-            # Malformed RESP or a dropped connection is a candidate failure, not a
-            # checker crash — count it and report cleanly instead of a traceback.
             mismatches += 1
             print(f"  ERROR op[{i}] {op.label} {op.args[0]}: candidate raised {exc!r}")
             if isinstance(exc, redis.ConnectionError):
@@ -305,15 +313,16 @@ def _sequential_phase(oracle, candidate, num_ops, num_keys, seed):
             mismatches += 1
             if mismatches <= 10:
                 print(
-                    f"  MISMATCH op[{i}] {op.label} {op.args[0]}: oracle={expected} candidate={actual}"
+                    f"  MISMATCH op[{i}] {op.label} {op.args[0]}: "
+                    f"oracle={expected} candidate={actual}"
                 )
     return mismatches
 
 
-def _stress_client(port, oracle_port, tid, num_ops, num_keys, seed):
-    """One concurrent client: mirror a disjoint-namespace op-mix to both oracle
-    and candidate. The thread-id prefix means no two threads ever touch the same
-    key, so even the in-flight replies must agree. Returns the mismatch count."""
+def _stress_client(
+    port: int, oracle_port: int, tid: int, num_ops: int, num_keys: int, seed: int
+) -> int:
+    """One concurrent client mirroring a disjoint-namespace op mix."""
     oracle, candidate = _client(oracle_port), _client(port)
     rng = random.Random(seed + tid)
     prefix = f"t{tid}:"
@@ -326,19 +335,15 @@ def _stress_client(port, oracle_port, tid, num_ops, num_keys, seed):
         except redis.RedisError as exc:
             mismatches += 1
             if isinstance(exc, redis.ConnectionError):
-                break  # this candidate connection is gone; stop hammering it
+                break
             continue
         if expected != actual:
             mismatches += 1
     return mismatches
 
 
-def _fanin_client(port, oracle_port, tid, hash_keys):
-    """Write a field unique to this thread into every shared hash, mirrored to
-    the oracle. Distinct fields never conflict, so once all threads join each
-    hash must hold every thread's field — a deterministic torture test for the
-    concurrent HSET path that catches lost fields and split-brain. Returns the
-    candidate error count."""
+def _fanin_client(port: int, oracle_port: int, tid: int, hash_keys: list[str]) -> int:
+    """Write a thread-unique field into every shared hash, mirrored to the oracle."""
     oracle, candidate = _client(oracle_port), _client(port)
     field, value = f"f{tid}", f"v{tid}"
     errors = 0
@@ -351,11 +356,10 @@ def _fanin_client(port, oracle_port, tid, hash_keys):
     return errors
 
 
-def _reconcile(oracle, candidate_conns, keys, label):
-    """Compare each key's final state between oracle and candidate, spreading the
-    candidate reads round-robin over several fresh connections so they fan out
-    across candidate worker processes — exposing SO_REUSEPORT split-brain where
-    each process holds an unshared map. Returns the mismatch count."""
+def _reconcile(
+    oracle: redis.Redis, candidate_conns: list[redis.Redis], keys: list[str], label: str
+) -> int:
+    """Compare final state, fanning reads across connections to catch split-brain."""
     mismatches = 0
     for i, key in enumerate(keys):
         conn = candidate_conns[i % len(candidate_conns)]
@@ -370,11 +374,75 @@ def _reconcile(oracle, candidate_conns, keys, label):
     return mismatches
 
 
-def _concurrent_phase(oracle, oracle_port, args):
-    """Concurrent-load phase: disjoint-namespace stress + shared-hash fan-in, each
-    followed by a final-state reconciliation over fresh connections. Runs on a
-    clean db so the reconciliation scan only sees keys this phase wrote. Returns
-    the total mismatch count."""
+def _check_hot_hash_races(port: int, workers: int) -> int:
+    conn = _client(port)
+    conn.flushdb()
+    hash_keys = [f"hot:h:{i}" for i in range(4)]
+    fields = [f"f{i}" for i in range(4)]
+    for key in hash_keys:
+        conn.hset(key, mapping={field: "v0" for field in fields})
+
+    allowed = {f"v{i}" for i in range(workers + 1)}
+
+    def writer(tid: int) -> int:
+        client = _client(port)
+        for key in hash_keys:
+            for field in fields:
+                client.hset(key, field, f"v{tid + 1}")
+        return 0
+
+    def reader(_: int) -> int:
+        client = _client(port)
+        errors = 0
+        for _ in range(32):
+            for key in hash_keys:
+                snapshot = client.hgetall(key)
+                if set(snapshot) != set(fields) or any(
+                    value not in allowed for value in snapshot.values()
+                ):
+                    errors += 1
+        return errors
+
+    with ThreadPoolExecutor(max_workers=workers * 2) as pool:
+        writes = [pool.submit(writer, tid) for tid in range(workers)]
+        reads = [pool.submit(reader, tid) for tid in range(workers)]
+        errors = sum(future.result() for future in writes + reads)
+
+    final_values = {field: f"final:{field}" for field in fields}
+    for key in hash_keys:
+        conn.hset(key, mapping=final_values)
+    for candidate_conn in [_client(port) for _ in range(8)]:
+        for key in hash_keys:
+            if candidate_conn.hgetall(key) != final_values:
+                errors += 1
+    return errors
+
+
+def _check_hot_delete_races(port: int, workers: int) -> int:
+    conn = _client(port)
+    delete_keys = [f"hot:delete:{i}" for i in range(64)]
+    for key in delete_keys:
+        conn.set(key, "value")
+
+    def deleter(tid: int) -> int:
+        client = _client(port)
+        return sum(client.delete(key) for key in delete_keys[tid::workers])
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        deleted = sum(pool.map(deleter, range(workers)))
+    if deleted != len(delete_keys) or any(conn.get(key) is not None for key in delete_keys):
+        return 1
+    return 0
+
+
+def _shared_hot_phase(port: int, threads: int) -> int:
+    """Exercise shared records under racing reads, writes, and deletes."""
+    workers = max(2, threads)
+    return _check_hot_hash_races(port, workers) + _check_hot_delete_races(port, workers)
+
+
+def _concurrent_phase(oracle: redis.Redis, oracle_port: int, args: argparse.Namespace) -> int:
+    """Concurrent-load phase: disjoint stress + shared-hash fan-in + hot races."""
     oracle.flushdb()
     _client(args.port).flushdb()
     per_thread = max(1, args.concurrent_ops // args.threads)
@@ -402,79 +470,19 @@ def _concurrent_phase(oracle, oracle_port, args):
             )
         )
     fanin = fanin_errors + _reconcile(oracle, candidate_conns, hash_keys, "shared-hash")
+    hot = _shared_hot_phase(args.port, args.threads)
 
     print(
         f"  concurrent: threads={args.threads} ops={per_thread * args.threads} "
         f"inflight_mismatches={inflight} reconciled_keys={len(stress_keys)} "
         f"reconcile_mismatches={stress_recon}"
     )
-    hot = _shared_hot_phase(args.port, args.threads)
-
     print(f"  shared-hash: keys={len(hash_keys)} mismatches={fanin}")
     print(f"  shared-hot: mismatches={hot}")
     return inflight + stress_recon + fanin + hot
 
 
-def _shared_hot_phase(port, threads):
-    """Exercise shared records under racing reads, writes, and deletes."""
-    conn = _client(port)
-    conn.flushdb()
-    hash_keys = [f"hot:h:{i}" for i in range(4)]
-    fields = [f"f{i}" for i in range(4)]
-    for key in hash_keys:
-        conn.hset(key, mapping={field: "v0" for field in fields})
-
-    allowed = {f"v{i}" for i in range(threads + 1)}
-
-    def writer(tid):
-        client = _client(port)
-        for key in hash_keys:
-            for field in fields:
-                client.hset(key, field, f"v{tid + 1}")
-        return 0
-
-    def reader(_):
-        client = _client(port)
-        errors = 0
-        for _ in range(32):
-            for key in hash_keys:
-                snapshot = client.hgetall(key)
-                if set(snapshot) != set(fields) or any(
-                    value not in allowed for value in snapshot.values()
-                ):
-                    errors += 1
-        return errors
-
-    workers = max(2, threads)
-    with ThreadPoolExecutor(max_workers=workers * 2) as pool:
-        writes = [pool.submit(writer, tid) for tid in range(workers)]
-        reads = [pool.submit(reader, tid) for tid in range(workers)]
-        errors = sum(future.result() for future in writes + reads)
-
-    final_values = {field: f"final:{field}" for field in fields}
-    for key in hash_keys:
-        conn.hset(key, mapping=final_values)
-    for candidate_conn in [_client(port) for _ in range(8)]:
-        for key in hash_keys:
-            if candidate_conn.hgetall(key) != final_values:
-                errors += 1
-
-    delete_keys = [f"hot:delete:{i}" for i in range(64)]
-    for key in delete_keys:
-        conn.set(key, "value")
-
-    def deleter(tid):
-        client = _client(port)
-        return sum(client.delete(key) for key in delete_keys[tid::workers])
-
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        deleted = sum(pool.map(deleter, range(workers)))
-    if deleted != len(delete_keys) or any(conn.get(key) is not None for key in delete_keys):
-        errors += 1
-    return errors
-
-
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="KV store accuracy checker")
     parser.add_argument(
         "--port",
@@ -489,7 +497,7 @@ def main():
         "--threads",
         type=int,
         default=16,
-        help="Concurrent client threads for the concurrency phase (matches the benchmark headline).",
+        help="Concurrent client threads for the concurrency phase.",
     )
     parser.add_argument(
         "--concurrent-ops", type=int, default=20000, help="Total ops across all concurrent threads."
@@ -498,17 +506,16 @@ def main():
         "--verify-conns",
         type=int,
         default=8,
-        help="Fresh candidate connections used to fan reconciliation reads across worker processes.",
+        help="Fresh candidate connections used to fan reconciliation reads.",
     )
     parser.add_argument(
         "--no-concurrent", action="store_true", help="Run only the sequential phase."
     )
     args = parser.parse_args()
 
-    with candidate_server(workspace=_WORKSPACE, port=args.port) as managed:
-        args.port = managed.port if managed is not None else args.port
-        assert args.port is not None
-        assert _wait_until_listening(args.port, timeout=5), (
+    with candidate_server(workspace=_WORKSPACE, port=args.port) as target:
+        args.port = target.port
+        assert wait_until_listening(args.port, timeout=5), (
             f"Candidate not responding on port {args.port}"
         )
 

--- a/examples/kv-store/accuracy_checker/checker.py
+++ b/examples/kv-store/accuracy_checker/checker.py
@@ -1,11 +1,14 @@
 """Accuracy checker: compare a candidate KV server against a Redis oracle.
 
-The candidate server must already be running. This starts its own Redis oracle
-and runs two correctness phases against both, diffing every reply:
+By default the checker launches ``./run.sh <port>`` and always cleans it up;
+``--port`` targets an already-running candidate. It starts its own Redis oracle
+and runs three correctness phases:
 
-  1. Sequential — a deterministic single-connection operation stream, checked in
+  1. Semantics/RESP2 — required commands, binary values, wrong types, fragmented
+     frames, and pipelines.
+  2. Sequential — a deterministic single-connection operation stream, checked in
      lock-step (per-op semantics).
-  2. Concurrent — many client threads under load, since the objective rewards
+  3. Concurrent — many client threads under load, since the objective rewards
      server-side concurrency (lock sharding, SO_REUSEPORT, multi-process). Each
      thread drives a disjoint key namespace, so the expected final state stays
      deterministic despite concurrency; a final reconciliation reads every key
@@ -13,6 +16,7 @@ and runs two correctness phases against both, diffing every reply:
      unshared maps behind SO_REUSEPORT) and lost concurrent writes.
 
 Usage:
+    python checker.py
     python checker.py --port 6380
     python checker.py --port 6380 --num-ops 10000
     python checker.py --port 6380 --threads 32 --concurrent-ops 40000
@@ -30,8 +34,15 @@ import sys
 import time
 from collections import namedtuple
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import redis
+
+_WORKSPACE = Path(__file__).resolve().parents[1]
+if str(_WORKSPACE) not in sys.path:
+    sys.path.insert(0, str(_WORKSPACE))
+
+from evaluator_support import candidate_server  # noqa: E402
 
 # One replayed request: the redis-py method to call and its arguments.
 Operation = namedtuple("Operation", ["label", "method", "args", "kwargs"])
@@ -110,6 +121,153 @@ def _start_oracle():
     atexit.register(lambda: (process.terminate(), process.wait()))
     assert _wait_until_listening(port), f"Redis oracle failed to start on {port}"
     return _client(port), port
+
+
+def _compare_call(label, oracle_call, candidate_call):
+    """Compare one semantic operation, including matching Redis errors."""
+    try:
+        expected = oracle_call()
+    except redis.ResponseError as exc:
+        expected = ("error", str(exc).split(" ", 1)[0])
+    try:
+        actual = candidate_call()
+    except redis.ResponseError as exc:
+        actual = ("error", str(exc).split(" ", 1)[0])
+    except redis.RedisError as exc:
+        print(f"  SEMANTIC ERROR [{label}]: candidate raised {exc!r}")
+        return 1
+    if expected != actual:
+        print(f"  SEMANTIC MISMATCH [{label}]: oracle={expected!r} candidate={actual!r}")
+        return 1
+    return 0
+
+
+def _raw_round_trip(port, chunks):
+    with socket.create_connection(("127.0.0.1", port), timeout=2) as sock:
+        for chunk in chunks:
+            sock.sendall(chunk)
+            time.sleep(0.005)
+        sock.shutdown(socket.SHUT_WR)
+        reply = bytearray()
+        while True:
+            try:
+                part = sock.recv(4096)
+            except TimeoutError:
+                break
+            if not part:
+                break
+            reply.extend(part)
+        return bytes(reply)
+
+
+def _semantic_phase(oracle, candidate, port):
+    """Deterministic command, type, binary, framing, and pipeline coverage."""
+    oracle.flushdb()
+    candidate.flushdb()
+    mismatches = 0
+
+    cases = [
+        ("PING", oracle.ping, candidate.ping),
+        ("SET", lambda: oracle.set("k", "v1"), lambda: candidate.set("k", "v1")),
+        ("GET", lambda: oracle.get("k"), lambda: candidate.get("k")),
+        ("SET overwrite", lambda: oracle.set("k", "v2"), lambda: candidate.set("k", "v2")),
+        ("GET overwrite", lambda: oracle.get("k"), lambda: candidate.get("k")),
+        (
+            "HSET new fields",
+            lambda: oracle.hset("h", mapping={"a": "1", "b": "2"}),
+            lambda: candidate.hset("h", mapping={"a": "1", "b": "2"}),
+        ),
+        (
+            "HSET existing field",
+            lambda: oracle.hset("h", "a", "3"),
+            lambda: candidate.hset("h", "a", "3"),
+        ),
+        (
+            "HMSET",
+            lambda: oracle.execute_command("HMSET", "hm", "a", "1", "b", "2"),
+            lambda: candidate.execute_command("HMSET", "hm", "a", "1", "b", "2"),
+        ),
+        ("HGETALL", lambda: oracle.hgetall("h"), lambda: candidate.hgetall("h")),
+        ("DBSIZE", oracle.dbsize, candidate.dbsize),
+        (
+            "DEL multiple",
+            lambda: oracle.delete("k", "h", "missing"),
+            lambda: candidate.delete("k", "h", "missing"),
+        ),
+    ]
+    for label, oracle_call, candidate_call in cases:
+        mismatches += _compare_call(label, oracle_call, candidate_call)
+
+    oracle.set("typed", "string")
+    candidate.set("typed", "string")
+    mismatches += _compare_call(
+        "WRONGTYPE hash-on-string",
+        lambda: oracle.hset("typed", "f", "v"),
+        lambda: candidate.hset("typed", "f", "v"),
+    )
+    oracle.hset("typed-hash", "f", "v")
+    candidate.hset("typed-hash", "f", "v")
+    mismatches += _compare_call(
+        "WRONGTYPE string-on-hash",
+        lambda: oracle.get("typed-hash"),
+        lambda: candidate.get("typed-hash"),
+    )
+    mismatches += _compare_call(
+        "invalid SET arity",
+        lambda: oracle.execute_command("SET", "typed"),
+        lambda: candidate.execute_command("SET", "typed"),
+    )
+    mismatches += _compare_call(
+        "invalid HSET arity",
+        lambda: oracle.execute_command("HSET", "typed-hash", "field-only"),
+        lambda: candidate.execute_command("HSET", "typed-hash", "field-only"),
+    )
+    if candidate.get("typed") != "string" or candidate.hgetall("typed-hash") != {"f": "v"}:
+        print("  invalid-arity command mutated state")
+        mismatches += 1
+
+    oracle_raw = redis.Redis(
+        host="127.0.0.1", port=oracle.connection_pool.connection_kwargs["port"]
+    )
+    candidate_raw = redis.Redis(host="127.0.0.1", port=port, protocol=2)
+    binary_key, binary_value = b"\x00key\xff", b"\x00value\r\n\xff"
+    mismatches += _compare_call(
+        "binary SET",
+        lambda: oracle_raw.set(binary_key, binary_value),
+        lambda: candidate_raw.set(binary_key, binary_value),
+    )
+    mismatches += _compare_call(
+        "binary GET",
+        lambda: oracle_raw.get(binary_key),
+        lambda: candidate_raw.get(binary_key),
+    )
+
+    for label, command in (
+        ("COMMAND", ("COMMAND",)),
+        ("CLIENT", ("CLIENT", "SETNAME", "vibeserve-checker")),
+        ("HELLO", ("HELLO", "2")),
+    ):
+        try:
+            candidate.execute_command(*command)
+        except (redis.RedisError, IndexError, TypeError, ValueError) as exc:
+            print(f"  SEMANTIC ERROR [{label} compatibility]: {exc!r}")
+            mismatches += 1
+
+    oracle.flushdb()
+    candidate.flushdb()
+    request = b"*3\r\n$3\r\nSET\r\n$4\r\nfrag\r\n$5\r\nvalue\r\n"
+    pipeline = b"*2\r\n$3\r\nGET\r\n$4\r\nfrag\r\n*1\r\n$6\r\nDBSIZE\r\n*1\r\n$3\r\nGET\r\n"
+    reply = _raw_round_trip(port, [request[:9], request[9:23], request[23:], pipeline])
+    expected_prefix = b"+OK\r\n$5\r\nvalue\r\n:1\r\n-"
+    if not reply.startswith(expected_prefix):
+        print(f"  RESP framing/pipeline mismatch: {reply!r}")
+        mismatches += 1
+
+    candidate.flushdb()
+    if candidate.dbsize() != 0:
+        print("  FLUSHDB mismatch: database is not empty")
+        mismatches += 1
+    return mismatches
 
 
 def _read_key(conn, method, key):
@@ -250,8 +408,70 @@ def _concurrent_phase(oracle, oracle_port, args):
         f"inflight_mismatches={inflight} reconciled_keys={len(stress_keys)} "
         f"reconcile_mismatches={stress_recon}"
     )
+    hot = _shared_hot_phase(args.port, args.threads)
+
     print(f"  shared-hash: keys={len(hash_keys)} mismatches={fanin}")
-    return inflight + stress_recon + fanin
+    print(f"  shared-hot: mismatches={hot}")
+    return inflight + stress_recon + fanin + hot
+
+
+def _shared_hot_phase(port, threads):
+    """Exercise shared records under racing reads, writes, and deletes."""
+    conn = _client(port)
+    conn.flushdb()
+    hash_keys = [f"hot:h:{i}" for i in range(4)]
+    fields = [f"f{i}" for i in range(4)]
+    for key in hash_keys:
+        conn.hset(key, mapping={field: "v0" for field in fields})
+
+    allowed = {f"v{i}" for i in range(threads + 1)}
+
+    def writer(tid):
+        client = _client(port)
+        for key in hash_keys:
+            for field in fields:
+                client.hset(key, field, f"v{tid + 1}")
+        return 0
+
+    def reader(_):
+        client = _client(port)
+        errors = 0
+        for _ in range(32):
+            for key in hash_keys:
+                snapshot = client.hgetall(key)
+                if set(snapshot) != set(fields) or any(
+                    value not in allowed for value in snapshot.values()
+                ):
+                    errors += 1
+        return errors
+
+    workers = max(2, threads)
+    with ThreadPoolExecutor(max_workers=workers * 2) as pool:
+        writes = [pool.submit(writer, tid) for tid in range(workers)]
+        reads = [pool.submit(reader, tid) for tid in range(workers)]
+        errors = sum(future.result() for future in writes + reads)
+
+    final_values = {field: f"final:{field}" for field in fields}
+    for key in hash_keys:
+        conn.hset(key, mapping=final_values)
+    for candidate_conn in [_client(port) for _ in range(8)]:
+        for key in hash_keys:
+            if candidate_conn.hgetall(key) != final_values:
+                errors += 1
+
+    delete_keys = [f"hot:delete:{i}" for i in range(64)]
+    for key in delete_keys:
+        conn.set(key, "value")
+
+    def deleter(tid):
+        client = _client(port)
+        return sum(client.delete(key) for key in delete_keys[tid::workers])
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        deleted = sum(pool.map(deleter, range(workers)))
+    if deleted != len(delete_keys) or any(conn.get(key) is not None for key in delete_keys):
+        errors += 1
+    return errors
 
 
 def main():
@@ -259,8 +479,8 @@ def main():
     parser.add_argument(
         "--port",
         type=int,
-        required=True,
-        help="Port of the candidate server (must be already running)",
+        default=None,
+        help="Port of an already-running candidate. Omit to launch ./run.sh automatically.",
     )
     parser.add_argument("--num-ops", type=int, default=5000, help="Sequential-phase op count.")
     parser.add_argument("--num-keys", type=int, default=200, help="Keyspace size per namespace.")
@@ -285,26 +505,33 @@ def main():
     )
     args = parser.parse_args()
 
-    assert _wait_until_listening(args.port, timeout=5), (
-        f"Candidate not responding on port {args.port}"
-    )
+    with candidate_server(workspace=_WORKSPACE, port=args.port) as managed:
+        args.port = managed.port if managed is not None else args.port
+        assert args.port is not None
+        assert _wait_until_listening(args.port, timeout=5), (
+            f"Candidate not responding on port {args.port}"
+        )
 
-    oracle, oracle_port = _start_oracle()
-    candidate = _client(args.port)
-    oracle.flushdb()
-    candidate.flushdb()
+        oracle, oracle_port = _start_oracle()
+        candidate = _client(args.port)
 
-    print("=== SEQUENTIAL ===")
-    mismatches = _sequential_phase(oracle, candidate, args.num_ops, args.num_keys, args.seed)
-    print(f"  sequential: ops={args.num_ops} mismatches={mismatches}")
+        print("=== SEMANTICS AND RESP2 ===")
+        mismatches = _semantic_phase(oracle, candidate, args.port)
+        print(f"  semantic mismatches={mismatches}")
 
-    if not args.no_concurrent:
-        print("=== CONCURRENT ===")
-        mismatches += _concurrent_phase(oracle, oracle_port, args)
+        oracle.flushdb()
+        candidate.flushdb()
+        print("=== SEQUENTIAL ===")
+        mismatches += _sequential_phase(oracle, candidate, args.num_ops, args.num_keys, args.seed)
+        print(f"  sequential: ops={args.num_ops} total_mismatches={mismatches}")
 
-    print(f"\nTotal mismatches: {mismatches}")
-    print("ALL CHECKS PASSED" if mismatches == 0 else "ACCURACY CHECK FAILED")
-    sys.exit(0 if mismatches == 0 else 1)
+        if not args.no_concurrent:
+            print("=== CONCURRENT ===")
+            mismatches += _concurrent_phase(oracle, oracle_port, args)
+
+        print(f"\nTotal mismatches: {mismatches}")
+        print("ALL CHECKS PASSED" if mismatches == 0 else "ACCURACY CHECK FAILED")
+        sys.exit(0 if mismatches == 0 else 1)
 
 
 if __name__ == "__main__":

--- a/examples/kv-store/benchmark/benchmark.py
+++ b/examples/kv-store/benchmark/benchmark.py
@@ -1,19 +1,21 @@
-"""YCSB benchmark against an already-running candidate server.
+"""Trusted Linux YCSB benchmark for the RESP2 KV-store target.
 
-Requires: Java 8+. Downloads the pinned YCSB 0.17.0 Redis binding to ./ycsb/
-on first run if it is not already present.
+Requires Java 8+ and Linux procfs. By default the benchmark launches
+``./run.sh <port>`` in an isolated process group; ``--port`` targets an
+already-running server for diagnostics. The checksum-pinned YCSB 0.17.0 Redis
+binding is cached under ``.cache/``.
 
 Two families of metrics are reported, both machine-readable:
 
-  1. Throughput (headline) — steady-state ops/sec. One discarded warmup run
-     primes JVM/JIT/connections, then several fixed-duration runs are taken and
+  1. Throughput (validity gate) — steady-state ops/sec. One discarded
+     topology-matched warmup primes the server/workload path, then several runs are taken and
      their median reported. Throughput is load- and client-dependent: on a fast
      loopback server it saturates the *client* long before the server, so a
      single JVM understates the server. `--client-procs M` drives the server
      from M independent JVMs to reach server saturation.
 
   2. server CPU-per-op (`cpu_us_per_op`) — server-core-microseconds spent per
-     operation, measured externally from /proc/<pid>/stat over the run. This is
+     operation, measured across the stable candidate process set via procfs. This is
      the *client-bottleneck-immune, load-independent, workload-agnostic* signal:
      it counts real work the server does per op regardless of how hard the client
      pushes, so a data-path optimization (that a saturated-client throughput
@@ -24,12 +26,14 @@ Two families of metrics are reported, both machine-readable:
      a single aggregate scalar hides. These generalize across every YCSB workload.
 
 Machine-readable outputs (no LLM eyeballing):
-  - stdout ends with `PERF_METRIC: <median_throughput> ops/sec`
+  - stdout ends with `PERF_METRIC: <score> ops_per_cpu_sec`
+  - `PERF_THROUGHPUT: <median_throughput> ops/sec`
   - `PERF_CPU_PER_OP: <median> us` (null if the server PID could not be found)
   - `--output-json PATH` writes all metrics as JSON for the profiler
 
 Usage:
-    python benchmark.py --port 6380
+    python benchmark.py                         # launch ./run.sh automatically
+    python benchmark.py --port 6380             # use an existing server
     python benchmark.py --port 6380 --threads 1               # single-client latency probe
     python benchmark.py --port 6380 --client-procs 8          # drive to server saturation
     python benchmark.py --port 6380 --probe-per-op            # per-op-type server CPU cost
@@ -38,9 +42,11 @@ Usage:
 """
 
 import argparse
+import fcntl
+import hashlib
 import json
+import math
 import os
-import re
 import shutil
 import statistics
 import subprocess
@@ -49,14 +55,23 @@ import tarfile
 import tempfile
 import time
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
+
+_WORKSPACE = Path(__file__).resolve().parents[1]
+if str(_WORKSPACE) not in sys.path:
+    sys.path.insert(0, str(_WORKSPACE))
+
+from evaluator_support import candidate_server  # noqa: E402
 
 YCSB_VERSION = "0.17.0"
 YCSB_URL = (
     f"https://github.com/brianfrankcooper/YCSB/releases/download/"
     f"{YCSB_VERSION}/ycsb-redis-binding-{YCSB_VERSION}.tar.gz"
 )
-YCSB_HOME = Path(__file__).resolve().parent / "ycsb"
+YCSB_SHA256 = "353eb96c12a605c30c94928b85780ae4673578a21e2aa13782cd7f591991e484"
+YCSB_CACHE = _WORKSPACE / ".cache"
+YCSB_HOME = YCSB_CACHE / f"ycsb-redis-binding-{YCSB_VERSION}"
 
 WORKLOADS = {w: f"workloads/workload{w}" for w in ("a", "b", "c", "d", "e", "f")}
 
@@ -78,49 +93,110 @@ _OP_CAP = 1_000_000_000
 _CLK = os.sysconf("SC_CLK_TCK")
 
 
-def _ensure_ycsb() -> None:
-    if (YCSB_HOME / "bin" / "ycsb.sh").is_file():
-        return
-    print(f"Downloading YCSB {YCSB_VERSION} Redis binding...", file=sys.stderr)
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        tmp = Path(tmp_dir)
-        tarball = tmp / f"ycsb-redis-binding-{YCSB_VERSION}.tar.gz"
-        urllib.request.urlretrieve(YCSB_URL, tarball)
-        with tarfile.open(tarball, "r:gz") as tar:
-            tar.extractall(tmp)
-        extracted = tmp / f"ycsb-redis-binding-{YCSB_VERSION}"
-        if YCSB_HOME.exists():
-            shutil.rmtree(YCSB_HOME)
-        shutil.move(str(extracted), str(YCSB_HOME))
+def _linux_preflight(proc_root=Path("/proc")) -> None:
+    if sys.platform != "linux":
+        raise RuntimeError("KV-store CPU scoring requires Linux procfs")
+    if not (proc_root / "net" / "tcp").is_file() or not (proc_root / "self" / "stat").is_file():
+        raise RuntimeError("KV-store CPU scoring requires readable Linux procfs")
 
 
-def _server_pid(port):
-    """Discover the PID listening on `port` so its CPU can be sampled externally.
-
-    The benchmark is only told --port (the server is already running), so CPU
-    attribution — the reward metric's source — has to rediscover the process.
-    Tries `ss` first, then a `/proc/net/tcp` + fd-scan fallback. Returns None if
-    neither works (cpu_us_per_op / ops_per_cpu_sec then report null).
-    """
-    try:
-        out = subprocess.run(
-            ["ss", "-Htanp", f"sport = :{port}"], capture_output=True, text=True, timeout=5
-        ).stdout
-        m = re.search(r"pid=(\d+)", out)
-        if m:
-            return int(m.group(1))
-    except (OSError, subprocess.SubprocessError):
-        pass
-    return _pid_via_proc(port)
-
-
-def _pid_via_proc(port):
-    """Fallback PID discovery: map the listening socket's inode (from /proc/net/tcp[6])
-    to the process that owns it by scanning /proc/<pid>/fd. Same-namespace only."""
-    inodes = set()
-    for table in ("/proc/net/tcp", "/proc/net/tcp6"):
+def _safe_extract(tar: tarfile.TarFile, destination: Path) -> None:
+    root = destination.resolve()
+    members = tar.getmembers()
+    for member in members:
+        target = (destination / member.name).resolve()
         try:
-            lines = Path(table).read_text().splitlines()[1:]
+            target.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"unsafe YCSB archive path: {member.name}") from exc
+        if member.issym() or member.islnk() or member.isdev() or member.isfifo():
+            raise ValueError(f"unsupported YCSB archive member: {member.name}")
+    tar.extractall(destination, members=members)
+
+
+def _ensure_ycsb() -> None:
+    marker = YCSB_HOME / ".vibeserve-sha256"
+    if (YCSB_HOME / "bin" / "ycsb.sh").is_file() and marker.is_file():
+        if marker.read_text().strip() == YCSB_SHA256:
+            return
+
+    YCSB_CACHE.mkdir(parents=True, exist_ok=True)
+    lock_path = YCSB_CACHE / f".ycsb-{YCSB_VERSION}.lock"
+    with lock_path.open("w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        if (YCSB_HOME / "bin" / "ycsb.sh").is_file() and marker.is_file():
+            if marker.read_text().strip() == YCSB_SHA256:
+                return
+        print(f"Downloading YCSB {YCSB_VERSION} Redis binding...", file=sys.stderr)
+        with tempfile.TemporaryDirectory(dir=YCSB_CACHE) as tmp_dir:
+            tmp = Path(tmp_dir)
+            tarball = tmp / "ycsb.tar.gz"
+            digest = hashlib.sha256()
+            with urllib.request.urlopen(YCSB_URL) as response, tarball.open("wb") as output:
+                while chunk := response.read(1024 * 1024):
+                    digest.update(chunk)
+                    output.write(chunk)
+            if digest.hexdigest() != YCSB_SHA256:
+                raise RuntimeError("YCSB archive checksum mismatch")
+            extract_root = tmp / "extract"
+            extract_root.mkdir()
+            with tarfile.open(tarball, "r:gz") as tar:
+                _safe_extract(tar, extract_root)
+            extracted = extract_root / f"ycsb-redis-binding-{YCSB_VERSION}"
+            if not (extracted / "bin" / "ycsb.sh").is_file():
+                raise RuntimeError("YCSB archive is missing bin/ycsb.sh")
+            (extracted / ".vibeserve-sha256").write_text(f"{YCSB_SHA256}\n")
+            staged = YCSB_CACHE / f".{YCSB_HOME.name}.staged"
+            if staged.exists():
+                shutil.rmtree(staged)
+            shutil.move(str(extracted), staged)
+            if YCSB_HOME.exists():
+                shutil.rmtree(YCSB_HOME)
+            staged.replace(YCSB_HOME)
+
+
+@dataclass(frozen=True)
+class ProcessStat:
+    pid: int
+    parent_pid: int
+    process_group: int
+    starttime: int
+    cpu_ticks: int
+
+    @property
+    def identity(self):
+        return (self.pid, self.starttime)
+
+
+def _read_process_stat(pid, proc_root=Path("/proc")):
+    try:
+        raw = (proc_root / str(pid) / "stat").read_text()
+        fields = raw[raw.rindex(")") + 2 :].split()
+        return ProcessStat(
+            pid=int(pid),
+            parent_pid=int(fields[1]),
+            process_group=int(fields[2]),
+            cpu_ticks=int(fields[11]) + int(fields[12]),
+            starttime=int(fields[19]),
+        )
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _all_process_stats(proc_root=Path("/proc")):
+    stats = {}
+    for path in proc_root.iterdir():
+        if path.name.isdigit() and (stat := _read_process_stat(int(path.name), proc_root)):
+            stats[stat.pid] = stat
+    return stats
+
+
+def _listener_pids(port, proc_root=Path("/proc")):
+    """Return every process owning a listening socket for ``port``."""
+    inodes = set()
+    for table in (proc_root / "net" / "tcp", proc_root / "net" / "tcp6"):
+        try:
+            lines = table.read_text().splitlines()[1:]
         except OSError:
             continue
         for line in lines:
@@ -129,54 +205,96 @@ def _pid_via_proc(port):
             if len(f) > 9 and f[3] == "0A" and int(f[1].rsplit(":", 1)[1], 16) == port:
                 inodes.add(f[9])
     if not inodes:
-        return None
-    for pid_dir in Path("/proc").iterdir():
+        return set()
+    pids = set()
+    for pid_dir in proc_root.iterdir():
         if not pid_dir.name.isdigit():
             continue
         try:
             for fd in (pid_dir / "fd").iterdir():
-                if os.readlink(fd).startswith("socket:[") and os.readlink(fd)[8:-1] in inodes:
-                    return int(pid_dir.name)
+                target = os.readlink(fd)
+                if target.startswith("socket:[") and target[8:-1] in inodes:
+                    pids.add(int(pid_dir.name))
+                    break
         except OSError:
             continue
-    return None
+    return pids
 
 
-def _cpu_ticks(pid):
-    """Server CPU jiffies (utime+stime) from /proc/<pid>/stat, or None."""
-    try:
-        stat = (Path("/proc") / str(pid) / "stat").read_text()
-    except OSError:
+def _server_processes(port, process_group=None, proc_root=Path("/proc")):
+    stats = _all_process_stats(proc_root)
+    if process_group is not None:
+        return {pid for pid, stat in stats.items() if stat.process_group == process_group}
+    roots = _listener_pids(port, proc_root)
+    selected = set(roots)
+    changed = True
+    while changed:
+        changed = False
+        for pid, stat in stats.items():
+            if stat.parent_pid in selected and pid not in selected:
+                selected.add(pid)
+                changed = True
+    return selected
+
+
+def _cpu_snapshot(port, process_group=None, proc_root=Path("/proc")):
+    pids = _server_processes(port, process_group, proc_root)
+    if not pids:
         return None
-    # Field 2 (comm) may contain spaces/parens; split after the final ')'.
-    fields = stat[stat.rindex(")") + 2 :].split()
-    return int(fields[11]) + int(fields[12])  # utime + stime
+    stats = [_read_process_stat(pid, proc_root) for pid in sorted(pids)]
+    if any(stat is None for stat in stats):
+        return None
+    return {stat.identity: stat.cpu_ticks for stat in stats}
+
+
+def _cpu_delta_seconds(before, after):
+    if before is None or after is None or set(before) != set(after):
+        return None
+    delta_ticks = sum(after[key] - before[key] for key in before)
+    if delta_ticks <= 0:
+        return None
+    return delta_ticks / _CLK
 
 
 def _ycsb_cmd(phase, workload, port, num_keys, threads, *, duration=None, extra=(), record=()):
     props = [
-        "-p", "redis.host=127.0.0.1",
-        "-p", f"redis.port={port}",
-        "-p", f"recordcount={num_keys}",
-        "-p", f"operationcount={_OP_CAP}",
-        "-p", f"threadcount={threads}",
-        "-p", "hdrhistogram.percentiles=50,95,99,99.9",
+        "-p",
+        "redis.host=127.0.0.1",
+        "-p",
+        f"redis.port={port}",
+        "-p",
+        f"recordcount={num_keys}",
+        "-p",
+        f"operationcount={_OP_CAP}",
+        "-p",
+        f"threadcount={threads}",
+        "-p",
+        "hdrhistogram.percentiles=50,95,99,99.9",
         *record,
     ]
     if duration is not None and phase == "run":
         props += ["-p", f"maxexecutiontime={duration}"]
     props += list(extra)
     return [
-        str(YCSB_HOME / "bin" / "ycsb.sh"), phase, "redis", "-s",
-        "-P", str(YCSB_HOME / workload), *props,
+        str(YCSB_HOME / "bin" / "ycsb.sh"),
+        phase,
+        "redis",
+        "-s",
+        "-P",
+        str(YCSB_HOME / workload),
+        *props,
     ]
 
 
 def _run_ycsb(phase, workload, port, num_keys, threads, *, duration=None, extra=(), record=()):
     """Run a single YCSB phase to completion; return stdout (exits on failure)."""
     result = subprocess.run(
-        _ycsb_cmd(phase, workload, port, num_keys, threads, duration=duration, extra=extra, record=record),
-        capture_output=True, text=True, timeout=600,
+        _ycsb_cmd(
+            phase, workload, port, num_keys, threads, duration=duration, extra=extra, record=record
+        ),
+        capture_output=True,
+        text=True,
+        timeout=600,
     )
     if result.returncode != 0:
         print(f"YCSB {phase} failed:\n{result.stderr[-2000:]}")
@@ -203,7 +321,18 @@ def _pct_key(op, pct):
     return f"{op}.{pct}{suffix}PercentileLatency(us)"
 
 
-def _measure(workload, port, num_keys, threads, duration, procs, pid, *, extra=(), record=()):
+def _measure(
+    workload,
+    port,
+    num_keys,
+    threads,
+    duration,
+    procs,
+    process_group,
+    *,
+    extra=(),
+    record=(),
+):
     """One measured round: `procs` YCSB run JVMs in parallel, bracketed by server
     CPU ticks. Aggregates throughput (sum) and ops (sum) across procs; latency
     percentiles are worst-case (p99/p99.9 = max across procs, p50 = median).
@@ -212,12 +341,16 @@ def _measure(workload, port, num_keys, threads, duration, procs, pid, *, extra=(
     externally-measured cpu_us_per_op / server_cpu_cores (None if no PID).
     """
     cmds = [
-        _ycsb_cmd("run", workload, port, num_keys, threads, duration=duration, extra=extra, record=record)
+        _ycsb_cmd(
+            "run", workload, port, num_keys, threads, duration=duration, extra=extra, record=record
+        )
         for _ in range(procs)
     ]
-    t0 = _cpu_ticks(pid) if pid else None
+    cpu_before = _cpu_snapshot(port, process_group)
     w0 = time.time()
-    ps = [subprocess.Popen(c, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True) for c in cmds]
+    ps = [
+        subprocess.Popen(c, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True) for c in cmds
+    ]
     outs = []
     for p in ps:
         out, err = p.communicate()
@@ -226,7 +359,7 @@ def _measure(workload, port, num_keys, threads, duration, procs, pid, *, extra=(
             sys.exit(1)
         outs.append(out)
     w1 = time.time()
-    t1 = _cpu_ticks(pid) if pid else None
+    cpu_after = _cpu_snapshot(port, process_group)
 
     runs = [_parse_metrics(o) for o in outs]
     agg = {
@@ -247,13 +380,17 @@ def _measure(workload, port, num_keys, threads, duration, procs, pid, *, extra=(
             "p999": _reduce_pct(runs, op, "99.9", max),
         }
 
-    if t0 is not None and t1 is not None and agg["total_ops"]:
-        cpu_s = (t1 - t0) / _CLK
+    cpu_s = _cpu_delta_seconds(cpu_before, cpu_after)
+    if cpu_s is not None and agg["total_ops"]:
         agg["cpu_us_per_op"] = cpu_s / agg["total_ops"] * 1e6
         agg["server_cpu_cores"] = cpu_s / (w1 - w0)
+        agg["server_process_count"] = len(cpu_before)
+        agg["cpu_valid"] = True
     else:
         agg["cpu_us_per_op"] = None
         agg["server_cpu_cores"] = None
+        agg["server_process_count"] = None
+        agg["cpu_valid"] = False
     return agg
 
 
@@ -262,7 +399,17 @@ def _reduce_pct(runs, op, pct, reducer):
     return reducer(vals) if vals else None
 
 
-def _probe_per_op(workload, port, num_keys, threads, duration, procs, pid, present_ops, record=()):
+def _probe_per_op(
+    workload,
+    port,
+    num_keys,
+    threads,
+    duration,
+    procs,
+    process_group,
+    present_ops,
+    record=(),
+):
     """Per-op-type server CPU cost: drive each present op type at 100% and measure
     its cpu_us_per_op in isolation. This is the read/update attribution channel —
     a read-path optimization lowers READ's cpu/op without touching UPDATE's."""
@@ -271,7 +418,17 @@ def _probe_per_op(workload, port, num_keys, threads, duration, procs, pid, prese
         extra = []
         for other, prop in OP_PROPORTION.items():
             extra += ["-p", f"{prop}={'1' if other == op else '0'}"]
-        agg = _measure(workload, port, num_keys, threads, duration, procs, pid, extra=extra, record=record)
+        agg = _measure(
+            workload,
+            port,
+            num_keys,
+            threads,
+            duration,
+            procs,
+            process_group,
+            extra=extra,
+            record=record,
+        )
         out[op] = round(agg["cpu_us_per_op"], 3) if agg["cpu_us_per_op"] is not None else None
     return out
 
@@ -286,37 +443,106 @@ def _med_cov(values):
     return med, cov
 
 
+def _worst_latency_ms(rounds, operation):
+    values = [
+        _to_ms(round_["lat"][operation]["p99"])
+        for round_ in rounds
+        if operation in round_["lat"] and round_["lat"][operation]["p99"] is not None
+    ]
+    return max(values) if values else None
+
+
+def _valid_number(value, *, positive=False):
+    return (
+        isinstance(value, int | float)
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and (value > 0 if positive else True)
+    )
+
+
+def _evaluate_validity(
+    *,
+    throughput,
+    cpu_per_op,
+    rounds,
+    read_p99_ms,
+    update_p99_ms,
+    saturation_gain_pct,
+    min_throughput,
+    max_read_p99_ms,
+    max_update_p99_ms,
+    max_saturation_gain_pct,
+):
+    checks = {
+        "throughput_floor": _valid_number(throughput) and throughput >= min_throughput,
+        "read_p99": _valid_number(read_p99_ms) and read_p99_ms < max_read_p99_ms,
+        "update_p99": _valid_number(update_p99_ms) and update_p99_ms < max_update_p99_ms,
+        "score_available": _valid_number(cpu_per_op, positive=True),
+        "cpu_samples": bool(rounds) and all(round_["cpu_valid"] for round_ in rounds),
+        "saturation": _valid_number(saturation_gain_pct)
+        and abs(saturation_gain_pct) <= max_saturation_gain_pct,
+    }
+    reasons = []
+    labels = {
+        "throughput_floor": f"throughput must be >= {min_throughput:.1f} ops/sec",
+        "read_p99": f"READ p99 must be < {max_read_p99_ms:.3f} ms",
+        "update_p99": f"UPDATE p99 must be < {max_update_p99_ms:.3f} ms",
+        "score_available": "server CPU/op must be finite and positive",
+        "cpu_samples": "every scored repeat must have stable complete CPU accounting",
+        "saturation": (
+            f"higher-load throughput change must be within ±{max_saturation_gain_pct:.1f}%"
+        ),
+    }
+    for name, passed in checks.items():
+        if not passed:
+            reasons.append(labels[name])
+    return checks, reasons
+
+
 def main():
     parser = argparse.ArgumentParser(description="KV store benchmark (YCSB)")
     parser.add_argument(
-        "--port", type=int, required=True,
-        help="Port of the candidate server (must be already running)",
+        "--port",
+        type=int,
+        default=None,
+        help="Port of an already-running candidate. Omit to launch ./run.sh automatically.",
     )
     parser.add_argument("--workload", choices=list(WORKLOADS.keys()), default="a")
     parser.add_argument(
         "--num-keys", type=int, default=20000, help="recordcount loaded into the store"
     )
     parser.add_argument(
-        "--threads", type=int, default=16,
+        "--threads",
+        type=int,
+        default=16,
         help="YCSB client threads per process (pass --threads 1 for the latency probe).",
     )
     parser.add_argument(
-        "--client-procs", type=int, default=1,
+        "--client-procs",
+        type=int,
+        default=1,
         help="Independent YCSB JVMs driven in parallel. >1 defeats the single-client "
         "CPU ceiling on a fast server so the run can reach server saturation.",
     )
     parser.add_argument(
-        "--field-count", type=int, default=None,
+        "--field-count",
+        type=int,
+        default=None,
         help="YCSB fieldcount (fields per record). Raising it scales the read "
         "(HGETALL-all-fields) server work without changing the one-field update — "
         "amplifying a read-path optimization's per-op-type CPU signal.",
     )
     parser.add_argument(
-        "--field-length", type=int, default=None,
+        "--field-length",
+        type=int,
+        default=None,
         help="YCSB fieldlength (bytes per field). Grows record/value size.",
     )
     parser.add_argument(
-        "--duration", type=int, default=5,
+        "--duration",
+        type=int,
+        default=5,
         help="Seconds per measured run (fixed-duration, steady-state).",
     )
     parser.add_argument(
@@ -324,120 +550,213 @@ def main():
     )
     parser.add_argument("--no-warmup", action="store_true", help="Skip the discarded warmup run.")
     parser.add_argument(
-        "--probe-per-op", action="store_true",
+        "--probe-per-op",
+        action="store_true",
         help="Also measure per-op-type server CPU cost (isolates each op at 100%%).",
     )
     parser.add_argument(
-        "--output-json", type=Path, default=None,
+        "--min-throughput-ops-per-sec",
+        type=float,
+        default=10000.0,
+        help="Minimum accepted median throughput.",
+    )
+    parser.add_argument("--max-read-p99-ms", type=float, default=1.0)
+    parser.add_argument("--max-update-p99-ms", type=float, default=1.0)
+    parser.add_argument(
+        "--saturation-probe-client-procs",
+        type=int,
+        default=8,
+        help="Client JVM count for the non-scoring saturation probe.",
+    )
+    parser.add_argument("--max-saturation-gain-pct", type=float, default=10.0)
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
         help="Write all metrics to this path as JSON.",
     )
     args = parser.parse_args()
 
+    _linux_preflight()
     _ensure_ycsb()
 
-    workload_path = WORKLOADS[args.workload]
-    pid = _server_pid(args.port)
-    if pid is None:
-        print(
-            f"WARNING: could not find server PID on port {args.port} (ss/proc); "
-            "cpu_us_per_op will be null.",
-            file=sys.stderr,
-        )
+    with candidate_server(workspace=_WORKSPACE, port=args.port) as managed:
+        args.port = managed.port if managed is not None else args.port
+        process_group = managed.process_group if managed is not None else None
+        assert args.port is not None
 
-    # Record-shape knobs (fieldcount/fieldlength) must match between load and run.
-    record = []
-    if args.field_count is not None:
-        record += ["-p", f"fieldcount={args.field_count}"]
-    if args.field_length is not None:
-        record += ["-p", f"fieldlength={args.field_length}"]
+        workload_path = WORKLOADS[args.workload]
+        record = []
+        if args.field_count is not None:
+            record += ["-p", f"fieldcount={args.field_count}"]
+        if args.field_length is not None:
+            record += ["-p", f"fieldlength={args.field_length}"]
 
-    _run_ycsb("load", workload_path, args.port, args.num_keys, args.threads, record=record)
+        _run_ycsb("load", workload_path, args.port, args.num_keys, args.threads, record=record)
 
-    # Discarded warmup: primes JVM/JIT/connections/page-cache so measured runs
-    # reflect steady state rather than a cold-start transient.
-    if not args.no_warmup:
-        _run_ycsb(
-            "run", workload_path, args.port, args.num_keys, args.threads,
-            duration=min(args.duration, 3), record=record,
-        )
-
-    rounds = [
-        _measure(
-            workload_path, args.port, args.num_keys, args.threads,
-            args.duration, args.client_procs, pid, record=record,
-        )
-        for _ in range(max(1, args.repeats))
-    ]
-
-    throughputs = [r["throughput"] for r in rounds]
-    median_throughput, cov_pct = _med_cov(throughputs)
-    cpu_per_op, cpu_cov = _med_cov([r["cpu_us_per_op"] for r in rounds])
-    server_cores, _ = _med_cov([r["server_cpu_cores"] for r in rounds])
-    # Report per-op latency from the round whose throughput is closest to median.
-    median_round = min(rounds, key=lambda r: abs(r["throughput"] - median_throughput))
-
-    per_op_cpu = None
-    if args.probe_per_op and pid is not None:
-        per_op_cpu = _probe_per_op(
-            workload_path, args.port, args.num_keys, args.threads,
-            args.duration, args.client_procs, pid, list(median_round["ops"]), record=record,
-        )
-
-    label_procs = f" x {args.client_procs} procs" if args.client_procs > 1 else ""
-    print(f"\n{'=' * 60}")
-    print(
-        f"  YCSB Workload {args.workload.upper()} — {args.threads} thread"
-        f"{'s' if args.threads != 1 else ''}{label_procs}, {args.duration}s x {args.repeats} runs"
-    )
-    print(f"{'=' * 60}")
-    print(
-        f"Throughput (median): {median_throughput:.1f} ops/sec   (CoV {cov_pct:.1f}%: "
-        f"{', '.join(f'{t:.0f}' for t in throughputs)})"
-    )
-    if cpu_per_op is not None:
-        print(
-            f"Server CPU/op (median): {cpu_per_op:.3f} us/op   (CoV {cpu_cov:.1f}%)   "
-            f"[{1e6 / cpu_per_op:,.0f} ops/core-sec]"
-        )
-        print(f"Server busy cores (median): {server_cores:.1f}   (saturation check)")
-    for op in median_round["lat"]:
-        lat = median_round["lat"][op]
-        cpu = f"   cpu {per_op_cpu[op]:.3f} us/op" if per_op_cpu and per_op_cpu.get(op) else ""
-        print(
-            f"{op:18s} p50 {_ms(lat['p50'])}  p99 {_ms(lat['p99'])}  "
-            f"p99.9 {_ms(lat['p999'])}{cpu}"
-        )
-
-    if args.output_json:
-        args.output_json.write_text(
-            json.dumps(
-                {
-                    "throughput_ops_per_sec": round(median_throughput, 1),
-                    "cov_pct": round(cov_pct, 1),
-                    "cpu_us_per_op": round(cpu_per_op, 3) if cpu_per_op is not None else None,
-                    "cpu_us_per_op_cov_pct": round(cpu_cov, 1),
-                    "ops_per_cpu_sec": round(1e6 / cpu_per_op, 1) if cpu_per_op else None,
-                    "server_cpu_cores": round(server_cores, 2) if server_cores is not None else None,
-                    "per_op_cpu_us": per_op_cpu,
-                    "read_p99_ms": _lat_ms(median_round, "READ", "p99"),
-                    "update_p99_ms": _lat_ms(median_round, "UPDATE", "p99"),
-                    "latency_ms": {
-                        op: {k: _to_ms(v) for k, v in lat.items()}
-                        for op, lat in median_round["lat"].items()
-                    },
-                    "threads": args.threads,
-                    "client_procs": args.client_procs,
-                    "workload": args.workload,
-                    "runs_ops_per_sec": [round(t, 1) for t in throughputs],
-                },
-                indent=2,
+        # Warm the server and workload path with the same client topology. Each
+        # later measured run starts fresh JVMs, so this does not claim to warm
+        # their JITs or connections.
+        if not args.no_warmup:
+            _measure(
+                workload_path,
+                args.port,
+                args.num_keys,
+                args.threads,
+                min(args.duration, 3),
+                args.client_procs,
+                process_group,
+                record=record,
             )
+
+        rounds = [
+            _measure(
+                workload_path,
+                args.port,
+                args.num_keys,
+                args.threads,
+                args.duration,
+                args.client_procs,
+                process_group,
+                record=record,
+            )
+            for _ in range(max(1, args.repeats))
+        ]
+
+        throughputs = [round_["throughput"] for round_ in rounds]
+        median_throughput, cov_pct = _med_cov(throughputs)
+        cpu_per_op, cpu_cov = _med_cov([round_["cpu_us_per_op"] for round_ in rounds])
+        server_cores, _ = _med_cov([round_["server_cpu_cores"] for round_ in rounds])
+        median_round = min(rounds, key=lambda round_: abs(round_["throughput"] - median_throughput))
+        read_p99_ms = _worst_latency_ms(rounds, "READ")
+        update_p99_ms = _worst_latency_ms(rounds, "UPDATE")
+
+        saturation = _measure(
+            workload_path,
+            args.port,
+            args.num_keys,
+            args.threads,
+            args.duration,
+            args.saturation_probe_client_procs,
+            process_group,
+            record=record,
+        )
+        saturation_gain_pct = (
+            (saturation["throughput"] / median_throughput - 1) * 100 if median_throughput else None
         )
 
-    # Machine-readable headline (parse these lines verbatim; do not eyeball the text above).
-    print(f"\nPERF_METRIC: {median_throughput:.1f} ops/sec")
-    print(f"PERF_COV: {cov_pct:.1f}%")
-    print(f"PERF_CPU_PER_OP: {cpu_per_op:.3f} us" if cpu_per_op is not None else "PERF_CPU_PER_OP: null")
+        per_op_cpu = None
+        if args.probe_per_op:
+            per_op_cpu = _probe_per_op(
+                workload_path,
+                args.port,
+                args.num_keys,
+                args.threads,
+                args.duration,
+                args.client_procs,
+                process_group,
+                list(median_round["ops"]),
+                record=record,
+            )
+
+        checks, invalid_reasons = _evaluate_validity(
+            throughput=median_throughput,
+            cpu_per_op=cpu_per_op,
+            rounds=rounds,
+            read_p99_ms=read_p99_ms,
+            update_p99_ms=update_p99_ms,
+            saturation_gain_pct=saturation_gain_pct,
+            min_throughput=args.min_throughput_ops_per_sec,
+            max_read_p99_ms=args.max_read_p99_ms,
+            max_update_p99_ms=args.max_update_p99_ms,
+            max_saturation_gain_pct=args.max_saturation_gain_pct,
+        )
+        score = 1e6 / cpu_per_op if _valid_number(cpu_per_op, positive=True) else None
+
+        label_procs = f" x {args.client_procs} procs" if args.client_procs > 1 else ""
+        print(f"\n{'=' * 60}")
+        print(
+            f"  YCSB Workload {args.workload.upper()} — {args.threads} thread"
+            f"{'s' if args.threads != 1 else ''}{label_procs}, "
+            f"{args.duration}s x {args.repeats} runs"
+        )
+        print(f"{'=' * 60}")
+        print(
+            f"Throughput (median): {median_throughput:.1f} ops/sec   "
+            f"(CoV {cov_pct:.1f}%: {', '.join(f'{value:.0f}' for value in throughputs)})"
+        )
+        if cpu_per_op is not None:
+            print(
+                f"Server CPU/op (median): {cpu_per_op:.3f} us/op   "
+                f"(CoV {cpu_cov:.1f}%)   [{score:,.0f} ops/core-sec]"
+            )
+            print(f"Server busy cores (median): {server_cores:.1f}   (diagnostic)")
+        for operation, latency in median_round["lat"].items():
+            cpu = (
+                f"   cpu {per_op_cpu[operation]:.3f} us/op"
+                if per_op_cpu and per_op_cpu.get(operation)
+                else ""
+            )
+            print(
+                f"{operation:18s} p50 {_ms(latency['p50'])}  "
+                f"p99 {_ms(latency['p99'])}  p99.9 {_ms(latency['p999'])}{cpu}"
+            )
+        print(
+            f"Saturation probe: {args.client_procs}→"
+            f"{args.saturation_probe_client_procs} client procs, "
+            f"gain {saturation_gain_pct:.1f}%"
+            if saturation_gain_pct is not None
+            else "Saturation probe: invalid"
+        )
+
+        payload = {
+            "throughput_ops_per_sec": round(median_throughput, 1),
+            "cov_pct": round(cov_pct, 1),
+            "cpu_us_per_op": round(cpu_per_op, 3) if cpu_per_op is not None else None,
+            "cpu_us_per_op_cov_pct": round(cpu_cov, 1),
+            "ops_per_cpu_sec": round(score, 1) if score is not None else None,
+            "server_cpu_cores": round(server_cores, 2) if server_cores is not None else None,
+            "server_process_count": median_round["server_process_count"],
+            "per_op_cpu_us": per_op_cpu,
+            "read_p99_ms": read_p99_ms,
+            "update_p99_ms": update_p99_ms,
+            "latency_ms": {
+                operation: {name: _to_ms(value) for name, value in latency.items()}
+                for operation, latency in median_round["lat"].items()
+            },
+            "threads": args.threads,
+            "client_procs": args.client_procs,
+            "workload": args.workload,
+            "runs_ops_per_sec": [round(value, 1) for value in throughputs],
+            "saturation_probe_client_procs": args.saturation_probe_client_procs,
+            "saturation_gain_pct": (
+                round(saturation_gain_pct, 1) if saturation_gain_pct is not None else None
+            ),
+            "score_valid": not invalid_reasons,
+            "invalid_reasons": invalid_reasons,
+            "validity_checks": checks,
+            "validity_thresholds": {
+                "min_throughput_ops_per_sec": args.min_throughput_ops_per_sec,
+                "max_read_p99_ms": args.max_read_p99_ms,
+                "max_update_p99_ms": args.max_update_p99_ms,
+                "max_saturation_gain_pct": args.max_saturation_gain_pct,
+            },
+        }
+        if args.output_json:
+            args.output_json.write_text(json.dumps(payload, indent=2))
+
+        print(f"\nPERF_METRIC: {score:.1f} ops_per_cpu_sec" if score else "PERF_METRIC: null")
+        print(f"PERF_THROUGHPUT: {median_throughput:.1f} ops/sec")
+        print(f"PERF_COV: {cov_pct:.1f}%")
+        print(
+            f"PERF_CPU_PER_OP: {cpu_per_op:.3f} us"
+            if cpu_per_op is not None
+            else "PERF_CPU_PER_OP: null"
+        )
+        if invalid_reasons:
+            for reason in invalid_reasons:
+                print(f"INVALID: {reason}", file=sys.stderr)
+            sys.exit(1)
 
 
 def _to_ms(us):

--- a/examples/kv-store/benchmark/benchmark.py
+++ b/examples/kv-store/benchmark/benchmark.py
@@ -1,33 +1,53 @@
-"""YCSB throughput benchmark against an already-running candidate server.
+"""YCSB benchmark against an already-running candidate server.
 
 Requires: Java 8+. Downloads the pinned YCSB 0.17.0 Redis binding to ./ycsb/
 on first run if it is not already present.
 
-Reports steady-state throughput so the number reflects the server, not JVM/JIT
-warmup: one discarded warmup run primes the JVM/JIT/connections, then several
-fixed-duration (`maxexecutiontime`) runs are taken and their median reported.
-A fixed window keeps the sample comparable as the server speeds up across rounds,
-and the reported coefficient of variation flags when a single run is noisy.
+Two families of metrics are reported, both machine-readable:
+
+  1. Throughput (headline) — steady-state ops/sec. One discarded warmup run
+     primes JVM/JIT/connections, then several fixed-duration runs are taken and
+     their median reported. Throughput is load- and client-dependent: on a fast
+     loopback server it saturates the *client* long before the server, so a
+     single JVM understates the server. `--client-procs M` drives the server
+     from M independent JVMs to reach server saturation.
+
+  2. server CPU-per-op (`cpu_us_per_op`) — server-core-microseconds spent per
+     operation, measured externally from /proc/<pid>/stat over the run. This is
+     the *client-bottleneck-immune, load-independent, workload-agnostic* signal:
+     it counts real work the server does per op regardless of how hard the client
+     pushes, so a data-path optimization (that a saturated-client throughput
+     number cannot see) shows up as fewer core-microseconds per op. `ops_per_cpu_sec`
+     (its inverse) is the per-core goodput. `--probe-per-op` additionally isolates
+     each op type (READ/UPDATE/SCAN/...) by driving it at 100%, exposing which
+     op type an optimization actually made cheaper — the read/update attribution
+     a single aggregate scalar hides. These generalize across every YCSB workload.
 
 Machine-readable outputs (no LLM eyeballing):
   - stdout ends with `PERF_METRIC: <median_throughput> ops/sec`
-  - `--output-json PATH` writes the same metrics as JSON for the profiler
+  - `PERF_CPU_PER_OP: <median> us` (null if the server PID could not be found)
+  - `--output-json PATH` writes all metrics as JSON for the profiler
 
 Usage:
     python benchmark.py --port 6380
-    python benchmark.py --port 6380 --threads 1          # single-client latency probe
-    python benchmark.py --port 6380 --duration 8 --repeats 5
+    python benchmark.py --port 6380 --threads 1               # single-client latency probe
+    python benchmark.py --port 6380 --client-procs 8          # drive to server saturation
+    python benchmark.py --port 6380 --probe-per-op            # per-op-type server CPU cost
+    python benchmark.py --port 6380 --workload e              # scan-heavy
     python benchmark.py --port 6380 --output-json /tmp/bench.json
 """
 
 import argparse
 import json
+import os
+import re
 import shutil
 import statistics
 import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 import urllib.request
 from pathlib import Path
 
@@ -38,13 +58,24 @@ YCSB_URL = (
 )
 YCSB_HOME = Path(__file__).resolve().parent / "ycsb"
 
-WORKLOADS = {"a": "workloads/workloada", "b": "workloads/workloadb", "c": "workloads/workloadc"}
+WORKLOADS = {w: f"workloads/workload{w}" for w in ("a", "b", "c", "d", "e", "f")}
 
 # Metric key YCSB emits for overall throughput; the headline number.
 THROUGHPUT_KEY = "OVERALL.Throughput(ops/sec)"
 
+# Op types YCSB reports, and the CoreWorkload proportion knob that drives each
+# (used by --probe-per-op to isolate one op type at 100%).
+OP_PROPORTION = {
+    "READ": "readproportion",
+    "UPDATE": "updateproportion",
+    "INSERT": "insertproportion",
+    "SCAN": "scanproportion",
+    "READ-MODIFY-WRITE": "readmodifywriteproportion",
+}
+
 # Huge op-count cap so a run ends on maxexecutiontime, not on ops exhausted.
 _OP_CAP = 1_000_000_000
+_CLK = os.sysconf("SC_CLK_TCK")
 
 
 def _ensure_ycsb() -> None:
@@ -63,34 +94,89 @@ def _ensure_ycsb() -> None:
         shutil.move(str(extracted), str(YCSB_HOME))
 
 
-def _run_ycsb(phase, workload, port, num_keys, threads, *, duration=None):
+def _server_pid(port):
+    """Discover the PID listening on `port` so its CPU can be sampled externally.
+
+    The benchmark is only told --port (the server is already running), so CPU
+    attribution — the reward metric's source — has to rediscover the process.
+    Tries `ss` first, then a `/proc/net/tcp` + fd-scan fallback. Returns None if
+    neither works (cpu_us_per_op / ops_per_cpu_sec then report null).
+    """
+    try:
+        out = subprocess.run(
+            ["ss", "-Htanp", f"sport = :{port}"], capture_output=True, text=True, timeout=5
+        ).stdout
+        m = re.search(r"pid=(\d+)", out)
+        if m:
+            return int(m.group(1))
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return _pid_via_proc(port)
+
+
+def _pid_via_proc(port):
+    """Fallback PID discovery: map the listening socket's inode (from /proc/net/tcp[6])
+    to the process that owns it by scanning /proc/<pid>/fd. Same-namespace only."""
+    inodes = set()
+    for table in ("/proc/net/tcp", "/proc/net/tcp6"):
+        try:
+            lines = Path(table).read_text().splitlines()[1:]
+        except OSError:
+            continue
+        for line in lines:
+            f = line.split()
+            # local_address is hex "ADDR:PORT"; st == 0A is LISTEN.
+            if len(f) > 9 and f[3] == "0A" and int(f[1].rsplit(":", 1)[1], 16) == port:
+                inodes.add(f[9])
+    if not inodes:
+        return None
+    for pid_dir in Path("/proc").iterdir():
+        if not pid_dir.name.isdigit():
+            continue
+        try:
+            for fd in (pid_dir / "fd").iterdir():
+                if os.readlink(fd).startswith("socket:[") and os.readlink(fd)[8:-1] in inodes:
+                    return int(pid_dir.name)
+        except OSError:
+            continue
+    return None
+
+
+def _cpu_ticks(pid):
+    """Server CPU jiffies (utime+stime) from /proc/<pid>/stat, or None."""
+    try:
+        stat = (Path("/proc") / str(pid) / "stat").read_text()
+    except OSError:
+        return None
+    # Field 2 (comm) may contain spaces/parens; split after the final ')'.
+    fields = stat[stat.rindex(")") + 2 :].split()
+    return int(fields[11]) + int(fields[12])  # utime + stime
+
+
+def _ycsb_cmd(phase, workload, port, num_keys, threads, *, duration=None, extra=(), record=()):
     props = [
-        "-p",
-        "redis.host=127.0.0.1",
-        "-p",
-        f"redis.port={port}",
-        "-p",
-        f"recordcount={num_keys}",
-        "-p",
-        f"operationcount={_OP_CAP}",
-        "-p",
-        f"threadcount={threads}",
+        "-p", "redis.host=127.0.0.1",
+        "-p", f"redis.port={port}",
+        "-p", f"recordcount={num_keys}",
+        "-p", f"operationcount={_OP_CAP}",
+        "-p", f"threadcount={threads}",
+        "-p", "hdrhistogram.percentiles=50,95,99,99.9",
+        *record,
     ]
     if duration is not None and phase == "run":
         props += ["-p", f"maxexecutiontime={duration}"]
+    props += list(extra)
+    return [
+        str(YCSB_HOME / "bin" / "ycsb.sh"), phase, "redis", "-s",
+        "-P", str(YCSB_HOME / workload), *props,
+    ]
+
+
+def _run_ycsb(phase, workload, port, num_keys, threads, *, duration=None, extra=(), record=()):
+    """Run a single YCSB phase to completion; return stdout (exits on failure)."""
     result = subprocess.run(
-        [
-            str(YCSB_HOME / "bin" / "ycsb.sh"),
-            phase,
-            "redis",
-            "-s",
-            "-P",
-            str(YCSB_HOME / workload),
-            *props,
-        ],
-        capture_output=True,
-        text=True,
-        timeout=600,
+        _ycsb_cmd(phase, workload, port, num_keys, threads, duration=duration, extra=extra, record=record),
+        capture_output=True, text=True, timeout=600,
     )
     if result.returncode != 0:
         print(f"YCSB {phase} failed:\n{result.stderr[-2000:]}")
@@ -111,19 +197,99 @@ def _parse_metrics(output):
     return metrics
 
 
-def _p99_ms(run, op):
-    """p99 latency in ms for an operation, or None if it wasn't exercised."""
-    if not run.get(f"{op}.Operations", 0):
-        return None
-    return run.get(f"{op}.99thPercentileLatency(us)", 0.0) / 1000
+def _pct_key(op, pct):
+    # YCSB emits "50thPercentileLatency(us)" but "99.9PercentileLatency(us)" (no 'th').
+    suffix = "th" if "." not in pct else ""
+    return f"{op}.{pct}{suffix}PercentileLatency(us)"
+
+
+def _measure(workload, port, num_keys, threads, duration, procs, pid, *, extra=(), record=()):
+    """One measured round: `procs` YCSB run JVMs in parallel, bracketed by server
+    CPU ticks. Aggregates throughput (sum) and ops (sum) across procs; latency
+    percentiles are worst-case (p99/p99.9 = max across procs, p50 = median).
+
+    Returns a dict with throughput, total_ops, per-op counts+latency, and
+    externally-measured cpu_us_per_op / server_cpu_cores (None if no PID).
+    """
+    cmds = [
+        _ycsb_cmd("run", workload, port, num_keys, threads, duration=duration, extra=extra, record=record)
+        for _ in range(procs)
+    ]
+    t0 = _cpu_ticks(pid) if pid else None
+    w0 = time.time()
+    ps = [subprocess.Popen(c, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True) for c in cmds]
+    outs = []
+    for p in ps:
+        out, err = p.communicate()
+        if p.returncode != 0:
+            print(f"YCSB run failed:\n{err[-2000:]}")
+            sys.exit(1)
+        outs.append(out)
+    w1 = time.time()
+    t1 = _cpu_ticks(pid) if pid else None
+
+    runs = [_parse_metrics(o) for o in outs]
+    agg = {
+        "throughput": sum(r.get(THROUGHPUT_KEY, 0.0) for r in runs),
+        "total_ops": 0,
+        "ops": {},
+        "lat": {},
+    }
+    for op in OP_PROPORTION:
+        ops = sum(int(r.get(f"{op}.Operations", 0)) for r in runs)
+        if not ops:
+            continue
+        agg["ops"][op] = ops
+        agg["total_ops"] += ops
+        agg["lat"][op] = {
+            "p50": _reduce_pct(runs, op, "50", statistics.median),
+            "p99": _reduce_pct(runs, op, "99", max),
+            "p999": _reduce_pct(runs, op, "99.9", max),
+        }
+
+    if t0 is not None and t1 is not None and agg["total_ops"]:
+        cpu_s = (t1 - t0) / _CLK
+        agg["cpu_us_per_op"] = cpu_s / agg["total_ops"] * 1e6
+        agg["server_cpu_cores"] = cpu_s / (w1 - w0)
+    else:
+        agg["cpu_us_per_op"] = None
+        agg["server_cpu_cores"] = None
+    return agg
+
+
+def _reduce_pct(runs, op, pct, reducer):
+    vals = [r[_pct_key(op, pct)] for r in runs if _pct_key(op, pct) in r]
+    return reducer(vals) if vals else None
+
+
+def _probe_per_op(workload, port, num_keys, threads, duration, procs, pid, present_ops, record=()):
+    """Per-op-type server CPU cost: drive each present op type at 100% and measure
+    its cpu_us_per_op in isolation. This is the read/update attribution channel —
+    a read-path optimization lowers READ's cpu/op without touching UPDATE's."""
+    out = {}
+    for op in present_ops:
+        extra = []
+        for other, prop in OP_PROPORTION.items():
+            extra += ["-p", f"{prop}={'1' if other == op else '0'}"]
+        agg = _measure(workload, port, num_keys, threads, duration, procs, pid, extra=extra, record=record)
+        out[op] = round(agg["cpu_us_per_op"], 3) if agg["cpu_us_per_op"] is not None else None
+    return out
+
+
+def _med_cov(values):
+    """(median, coefficient-of-variation %) over non-None values."""
+    vals = [v for v in values if v is not None]
+    if not vals:
+        return None, 0.0
+    med = statistics.median(vals)
+    cov = (statistics.pstdev(vals) / med * 100) if med and len(vals) > 1 else 0.0
+    return med, cov
 
 
 def main():
     parser = argparse.ArgumentParser(description="KV store benchmark (YCSB)")
     parser.add_argument(
-        "--port",
-        type=int,
-        required=True,
+        "--port", type=int, required=True,
         help="Port of the candidate server (must be already running)",
     )
     parser.add_argument("--workload", choices=list(WORKLOADS.keys()), default="a")
@@ -131,16 +297,26 @@ def main():
         "--num-keys", type=int, default=20000, help="recordcount loaded into the store"
     )
     parser.add_argument(
-        "--threads",
-        type=int,
-        default=16,
-        help="Concurrent YCSB client threads (headline load). "
-        "Pass --threads 1 for the single-client latency probe.",
+        "--threads", type=int, default=16,
+        help="YCSB client threads per process (pass --threads 1 for the latency probe).",
     )
     parser.add_argument(
-        "--duration",
-        type=int,
-        default=5,
+        "--client-procs", type=int, default=1,
+        help="Independent YCSB JVMs driven in parallel. >1 defeats the single-client "
+        "CPU ceiling on a fast server so the run can reach server saturation.",
+    )
+    parser.add_argument(
+        "--field-count", type=int, default=None,
+        help="YCSB fieldcount (fields per record). Raising it scales the read "
+        "(HGETALL-all-fields) server work without changing the one-field update — "
+        "amplifying a read-path optimization's per-op-type CPU signal.",
+    )
+    parser.add_argument(
+        "--field-length", type=int, default=None,
+        help="YCSB fieldlength (bytes per field). Grows record/value size.",
+    )
+    parser.add_argument(
+        "--duration", type=int, default=5,
         help="Seconds per measured run (fixed-duration, steady-state).",
     )
     parser.add_argument(
@@ -148,65 +324,89 @@ def main():
     )
     parser.add_argument("--no-warmup", action="store_true", help="Skip the discarded warmup run.")
     parser.add_argument(
-        "--output-json",
-        type=Path,
-        default=None,
-        help="Write the headline metrics to this path as JSON.",
+        "--probe-per-op", action="store_true",
+        help="Also measure per-op-type server CPU cost (isolates each op at 100%%).",
+    )
+    parser.add_argument(
+        "--output-json", type=Path, default=None,
+        help="Write all metrics to this path as JSON.",
     )
     args = parser.parse_args()
 
     _ensure_ycsb()
 
     workload_path = WORKLOADS[args.workload]
-    _run_ycsb("load", workload_path, args.port, args.num_keys, args.threads)
+    pid = _server_pid(args.port)
+    if pid is None:
+        print(
+            f"WARNING: could not find server PID on port {args.port} (ss/proc); "
+            "cpu_us_per_op will be null.",
+            file=sys.stderr,
+        )
+
+    # Record-shape knobs (fieldcount/fieldlength) must match between load and run.
+    record = []
+    if args.field_count is not None:
+        record += ["-p", f"fieldcount={args.field_count}"]
+    if args.field_length is not None:
+        record += ["-p", f"fieldlength={args.field_length}"]
+
+    _run_ycsb("load", workload_path, args.port, args.num_keys, args.threads, record=record)
 
     # Discarded warmup: primes JVM/JIT/connections/page-cache so measured runs
     # reflect steady state rather than a cold-start transient.
     if not args.no_warmup:
         _run_ycsb(
-            "run",
-            workload_path,
-            args.port,
-            args.num_keys,
-            args.threads,
-            duration=min(args.duration, 3),
+            "run", workload_path, args.port, args.num_keys, args.threads,
+            duration=min(args.duration, 3), record=record,
         )
 
-    runs = [
-        _parse_metrics(
-            _run_ycsb(
-                "run", workload_path, args.port, args.num_keys, args.threads, duration=args.duration
-            )
+    rounds = [
+        _measure(
+            workload_path, args.port, args.num_keys, args.threads,
+            args.duration, args.client_procs, pid, record=record,
         )
         for _ in range(max(1, args.repeats))
     ]
 
-    throughputs = [run.get(THROUGHPUT_KEY, 0.0) for run in runs]
-    median_throughput = statistics.median(throughputs)
-    cov_pct = (
-        (statistics.pstdev(throughputs) / median_throughput * 100)
-        if median_throughput and len(throughputs) > 1
-        else 0.0
-    )
-    # Report latencies from the run whose throughput is closest to the median.
-    median_run = min(runs, key=lambda run: abs(run.get(THROUGHPUT_KEY, 0.0) - median_throughput))
+    throughputs = [r["throughput"] for r in rounds]
+    median_throughput, cov_pct = _med_cov(throughputs)
+    cpu_per_op, cpu_cov = _med_cov([r["cpu_us_per_op"] for r in rounds])
+    server_cores, _ = _med_cov([r["server_cpu_cores"] for r in rounds])
+    # Report per-op latency from the round whose throughput is closest to median.
+    median_round = min(rounds, key=lambda r: abs(r["throughput"] - median_throughput))
 
-    print(f"\n{'=' * 56}")
+    per_op_cpu = None
+    if args.probe_per_op and pid is not None:
+        per_op_cpu = _probe_per_op(
+            workload_path, args.port, args.num_keys, args.threads,
+            args.duration, args.client_procs, pid, list(median_round["ops"]), record=record,
+        )
+
+    label_procs = f" x {args.client_procs} procs" if args.client_procs > 1 else ""
+    print(f"\n{'=' * 60}")
     print(
-        f"  YCSB Workload {args.workload.upper()} — {args.threads} client thread"
-        f"{'s' if args.threads != 1 else ''}, {args.duration}s x {args.repeats} runs"
+        f"  YCSB Workload {args.workload.upper()} — {args.threads} thread"
+        f"{'s' if args.threads != 1 else ''}{label_procs}, {args.duration}s x {args.repeats} runs"
     )
-    print(f"{'=' * 56}")
+    print(f"{'=' * 60}")
     print(
-        f"Throughput (median): {median_throughput:.1f} ops/sec   (CoV {cov_pct:.1f}% over {len(throughputs)} runs: "
+        f"Throughput (median): {median_throughput:.1f} ops/sec   (CoV {cov_pct:.1f}%: "
         f"{', '.join(f'{t:.0f}' for t in throughputs)})"
     )
-    for op in ["READ", "UPDATE", "INSERT"]:
-        if median_run.get(f"{op}.Operations", 0):
-            print(
-                f"{op:7s} p99: {median_run.get(f'{op}.99thPercentileLatency(us)', 0) / 1000:.3f} ms   "
-                f"p95: {median_run.get(f'{op}.95thPercentileLatency(us)', 0) / 1000:.3f} ms"
-            )
+    if cpu_per_op is not None:
+        print(
+            f"Server CPU/op (median): {cpu_per_op:.3f} us/op   (CoV {cpu_cov:.1f}%)   "
+            f"[{1e6 / cpu_per_op:,.0f} ops/core-sec]"
+        )
+        print(f"Server busy cores (median): {server_cores:.1f}   (saturation check)")
+    for op in median_round["lat"]:
+        lat = median_round["lat"][op]
+        cpu = f"   cpu {per_op_cpu[op]:.3f} us/op" if per_op_cpu and per_op_cpu.get(op) else ""
+        print(
+            f"{op:18s} p50 {_ms(lat['p50'])}  p99 {_ms(lat['p99'])}  "
+            f"p99.9 {_ms(lat['p999'])}{cpu}"
+        )
 
     if args.output_json:
         args.output_json.write_text(
@@ -214,9 +414,19 @@ def main():
                 {
                     "throughput_ops_per_sec": round(median_throughput, 1),
                     "cov_pct": round(cov_pct, 1),
-                    "read_p99_ms": _p99_ms(median_run, "READ"),
-                    "update_p99_ms": _p99_ms(median_run, "UPDATE"),
+                    "cpu_us_per_op": round(cpu_per_op, 3) if cpu_per_op is not None else None,
+                    "cpu_us_per_op_cov_pct": round(cpu_cov, 1),
+                    "ops_per_cpu_sec": round(1e6 / cpu_per_op, 1) if cpu_per_op else None,
+                    "server_cpu_cores": round(server_cores, 2) if server_cores is not None else None,
+                    "per_op_cpu_us": per_op_cpu,
+                    "read_p99_ms": _lat_ms(median_round, "READ", "p99"),
+                    "update_p99_ms": _lat_ms(median_round, "UPDATE", "p99"),
+                    "latency_ms": {
+                        op: {k: _to_ms(v) for k, v in lat.items()}
+                        for op, lat in median_round["lat"].items()
+                    },
                     "threads": args.threads,
+                    "client_procs": args.client_procs,
                     "workload": args.workload,
                     "runs_ops_per_sec": [round(t, 1) for t in throughputs],
                 },
@@ -224,9 +434,23 @@ def main():
             )
         )
 
-    # Machine-readable headline (parse this line verbatim; do not eyeball the text above).
+    # Machine-readable headline (parse these lines verbatim; do not eyeball the text above).
     print(f"\nPERF_METRIC: {median_throughput:.1f} ops/sec")
     print(f"PERF_COV: {cov_pct:.1f}%")
+    print(f"PERF_CPU_PER_OP: {cpu_per_op:.3f} us" if cpu_per_op is not None else "PERF_CPU_PER_OP: null")
+
+
+def _to_ms(us):
+    return round(us / 1000, 4) if us is not None else None
+
+
+def _ms(us):
+    return f"{us / 1000:.3f}ms" if us is not None else "  -   "
+
+
+def _lat_ms(round_, op, pct):
+    lat = round_["lat"].get(op)
+    return _to_ms(lat[pct]) if lat else None
 
 
 if __name__ == "__main__":

--- a/examples/kv-store/benchmark/benchmark.py
+++ b/examples/kv-store/benchmark/benchmark.py
@@ -1,375 +1,117 @@
 """Trusted Linux YCSB benchmark for the RESP2 KV-store target.
 
-Requires Java 8+ and Linux procfs. By default the benchmark launches
-``./run.sh <port>`` in an isolated process group; ``--port`` targets an
-already-running server for diagnostics. The checksum-pinned YCSB 0.17.0 Redis
-binding is cached under ``.cache/``.
+Requires Java 8+ and Linux procfs. By default launches ``./run.sh <port>`` in an
+isolated process group; ``--port`` targets an already-running server.
 
-Two families of metrics are reported, both machine-readable:
+Scored path: load Workload A, discard one topology-matched warmup, take several
+fixed-duration runs, enforce throughput / p99 / saturation gates, then emit
+``ops_per_cpu_sec`` from aggregated procfs CPU across the candidate process set.
 
-  1. Throughput (validity gate) — steady-state ops/sec. One discarded
-     topology-matched warmup primes the server/workload path, then several runs are taken and
-     their median reported. Throughput is load- and client-dependent: on a fast
-     loopback server it saturates the *client* long before the server, so a
-     single JVM understates the server. `--client-procs M` drives the server
-     from M independent JVMs to reach server saturation.
+Machine-readable outputs:
+  - ``PERF_METRIC: <score> ops_per_cpu_sec``
+  - ``PERF_THROUGHPUT: <median_throughput> ops/sec``
+  - ``PERF_CPU_PER_OP: <median> us``
+  - ``--output-json PATH`` writes the full payload
 
-  2. server CPU-per-op (`cpu_us_per_op`) — server-core-microseconds spent per
-     operation, measured across the stable candidate process set via procfs. This is
-     the *client-bottleneck-immune, load-independent, workload-agnostic* signal:
-     it counts real work the server does per op regardless of how hard the client
-     pushes, so a data-path optimization (that a saturated-client throughput
-     number cannot see) shows up as fewer core-microseconds per op. `ops_per_cpu_sec`
-     (its inverse) is the per-core goodput. `--probe-per-op` additionally isolates
-     each op type (READ/UPDATE/SCAN/...) by driving it at 100%, exposing which
-     op type an optimization actually made cheaper — the read/update attribution
-     a single aggregate scalar hides. These generalize across every YCSB workload.
-
-Machine-readable outputs (no LLM eyeballing):
-  - stdout ends with `PERF_METRIC: <score> ops_per_cpu_sec`
-  - `PERF_THROUGHPUT: <median_throughput> ops/sec`
-  - `PERF_CPU_PER_OP: <median> us` (null if the server PID could not be found)
-  - `--output-json PATH` writes all metrics as JSON for the profiler
-
-Usage:
-    python benchmark.py                         # launch ./run.sh automatically
-    python benchmark.py --port 6380             # use an existing server
-    python benchmark.py --port 6380 --threads 1               # single-client latency probe
-    python benchmark.py --port 6380 --client-procs 8          # drive to server saturation
-    python benchmark.py --port 6380 --probe-per-op            # per-op-type server CPU cost
-    python benchmark.py --port 6380 --workload e              # scan-heavy
-    python benchmark.py --port 6380 --output-json /tmp/bench.json
+Optional diagnostics (not required for scoring): ``--probe-per-op``,
+``--field-count``, ``--field-length``. See ``OBJECTIVE.md`` and
+``CANDIDATE_CONTRACT.md``.
 """
 
+from __future__ import annotations
+
 import argparse
-import fcntl
-import hashlib
 import json
-import math
-import os
-import shutil
 import statistics
 import subprocess
 import sys
-import tarfile
-import tempfile
 import time
-import urllib.request
-from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 _WORKSPACE = Path(__file__).resolve().parents[1]
 if str(_WORKSPACE) not in sys.path:
     sys.path.insert(0, str(_WORKSPACE))
 
 from evaluator_support import candidate_server  # noqa: E402
-
-YCSB_VERSION = "0.17.0"
-YCSB_URL = (
-    f"https://github.com/brianfrankcooper/YCSB/releases/download/"
-    f"{YCSB_VERSION}/ycsb-redis-binding-{YCSB_VERSION}.tar.gz"
+from evaluator_support.procfs_cpu import (  # noqa: E402
+    cpu_delta_seconds,
+    cpu_snapshot,
+    linux_preflight,
 )
-YCSB_SHA256 = "353eb96c12a605c30c94928b85780ae4673578a21e2aa13782cd7f591991e484"
-YCSB_CACHE = _WORKSPACE / ".cache"
-YCSB_HOME = YCSB_CACHE / f"ycsb-redis-binding-{YCSB_VERSION}"
+from evaluator_support.validity import evaluate_validity, valid_number  # noqa: E402
+from evaluator_support.ycsb import (  # noqa: E402
+    OP_PROPORTION,
+    THROUGHPUT_KEY,
+    WORKLOADS,
+    cache_paths,
+    ensure_ycsb,
+    parse_metrics,
+    pct_key,
+    run_ycsb,
+    ycsb_cmd,
+)
 
-WORKLOADS = {w: f"workloads/workload{w}" for w in ("a", "b", "c", "d", "e", "f")}
-
-# Metric key YCSB emits for overall throughput; the headline number.
-THROUGHPUT_KEY = "OVERALL.Throughput(ops/sec)"
-
-# Op types YCSB reports, and the CoreWorkload proportion knob that drives each
-# (used by --probe-per-op to isolate one op type at 100%).
-OP_PROPORTION = {
-    "READ": "readproportion",
-    "UPDATE": "updateproportion",
-    "INSERT": "insertproportion",
-    "SCAN": "scanproportion",
-    "READ-MODIFY-WRITE": "readmodifywriteproportion",
-}
-
-# Huge op-count cap so a run ends on maxexecutiontime, not on ops exhausted.
-_OP_CAP = 1_000_000_000
-_CLK = os.sysconf("SC_CLK_TCK")
+_YCSB_CACHE, _YCSB_HOME = cache_paths(_WORKSPACE)
 
 
-def _linux_preflight(proc_root=Path("/proc")) -> None:
-    if sys.platform != "linux":
-        raise RuntimeError("KV-store CPU scoring requires Linux procfs")
-    if not (proc_root / "net" / "tcp").is_file() or not (proc_root / "self" / "stat").is_file():
-        raise RuntimeError("KV-store CPU scoring requires readable Linux procfs")
-
-
-def _safe_extract(tar: tarfile.TarFile, destination: Path) -> None:
-    root = destination.resolve()
-    members = tar.getmembers()
-    for member in members:
-        target = (destination / member.name).resolve()
-        try:
-            target.relative_to(root)
-        except ValueError as exc:
-            raise ValueError(f"unsafe YCSB archive path: {member.name}") from exc
-        if member.issym() or member.islnk() or member.isdev() or member.isfifo():
-            raise ValueError(f"unsupported YCSB archive member: {member.name}")
-    tar.extractall(destination, members=members)
-
-
-def _ensure_ycsb() -> None:
-    marker = YCSB_HOME / ".vibeserve-sha256"
-    if (YCSB_HOME / "bin" / "ycsb.sh").is_file() and marker.is_file():
-        if marker.read_text().strip() == YCSB_SHA256:
-            return
-
-    YCSB_CACHE.mkdir(parents=True, exist_ok=True)
-    lock_path = YCSB_CACHE / f".ycsb-{YCSB_VERSION}.lock"
-    with lock_path.open("w") as lock:
-        fcntl.flock(lock, fcntl.LOCK_EX)
-        if (YCSB_HOME / "bin" / "ycsb.sh").is_file() and marker.is_file():
-            if marker.read_text().strip() == YCSB_SHA256:
-                return
-        print(f"Downloading YCSB {YCSB_VERSION} Redis binding...", file=sys.stderr)
-        with tempfile.TemporaryDirectory(dir=YCSB_CACHE) as tmp_dir:
-            tmp = Path(tmp_dir)
-            tarball = tmp / "ycsb.tar.gz"
-            digest = hashlib.sha256()
-            with urllib.request.urlopen(YCSB_URL) as response, tarball.open("wb") as output:
-                while chunk := response.read(1024 * 1024):
-                    digest.update(chunk)
-                    output.write(chunk)
-            if digest.hexdigest() != YCSB_SHA256:
-                raise RuntimeError("YCSB archive checksum mismatch")
-            extract_root = tmp / "extract"
-            extract_root.mkdir()
-            with tarfile.open(tarball, "r:gz") as tar:
-                _safe_extract(tar, extract_root)
-            extracted = extract_root / f"ycsb-redis-binding-{YCSB_VERSION}"
-            if not (extracted / "bin" / "ycsb.sh").is_file():
-                raise RuntimeError("YCSB archive is missing bin/ycsb.sh")
-            (extracted / ".vibeserve-sha256").write_text(f"{YCSB_SHA256}\n")
-            staged = YCSB_CACHE / f".{YCSB_HOME.name}.staged"
-            if staged.exists():
-                shutil.rmtree(staged)
-            shutil.move(str(extracted), staged)
-            if YCSB_HOME.exists():
-                shutil.rmtree(YCSB_HOME)
-            staged.replace(YCSB_HOME)
-
-
-@dataclass(frozen=True)
-class ProcessStat:
-    pid: int
-    parent_pid: int
-    process_group: int
-    starttime: int
-    cpu_ticks: int
-
-    @property
-    def identity(self):
-        return (self.pid, self.starttime)
-
-
-def _read_process_stat(pid, proc_root=Path("/proc")):
-    try:
-        raw = (proc_root / str(pid) / "stat").read_text()
-        fields = raw[raw.rindex(")") + 2 :].split()
-        return ProcessStat(
-            pid=int(pid),
-            parent_pid=int(fields[1]),
-            process_group=int(fields[2]),
-            cpu_ticks=int(fields[11]) + int(fields[12]),
-            starttime=int(fields[19]),
-        )
-    except (OSError, ValueError, IndexError):
-        return None
-
-
-def _all_process_stats(proc_root=Path("/proc")):
-    stats = {}
-    for path in proc_root.iterdir():
-        if path.name.isdigit() and (stat := _read_process_stat(int(path.name), proc_root)):
-            stats[stat.pid] = stat
-    return stats
-
-
-def _listener_pids(port, proc_root=Path("/proc")):
-    """Return every process owning a listening socket for ``port``."""
-    inodes = set()
-    for table in (proc_root / "net" / "tcp", proc_root / "net" / "tcp6"):
-        try:
-            lines = table.read_text().splitlines()[1:]
-        except OSError:
-            continue
-        for line in lines:
-            f = line.split()
-            # local_address is hex "ADDR:PORT"; st == 0A is LISTEN.
-            if len(f) > 9 and f[3] == "0A" and int(f[1].rsplit(":", 1)[1], 16) == port:
-                inodes.add(f[9])
-    if not inodes:
-        return set()
-    pids = set()
-    for pid_dir in proc_root.iterdir():
-        if not pid_dir.name.isdigit():
-            continue
-        try:
-            for fd in (pid_dir / "fd").iterdir():
-                target = os.readlink(fd)
-                if target.startswith("socket:[") and target[8:-1] in inodes:
-                    pids.add(int(pid_dir.name))
-                    break
-        except OSError:
-            continue
-    return pids
-
-
-def _server_processes(port, process_group=None, proc_root=Path("/proc")):
-    stats = _all_process_stats(proc_root)
-    if process_group is not None:
-        return {pid for pid, stat in stats.items() if stat.process_group == process_group}
-    roots = _listener_pids(port, proc_root)
-    selected = set(roots)
-    changed = True
-    while changed:
-        changed = False
-        for pid, stat in stats.items():
-            if stat.parent_pid in selected and pid not in selected:
-                selected.add(pid)
-                changed = True
-    return selected
-
-
-def _cpu_snapshot(port, process_group=None, proc_root=Path("/proc")):
-    pids = _server_processes(port, process_group, proc_root)
-    if not pids:
-        return None
-    stats = [_read_process_stat(pid, proc_root) for pid in sorted(pids)]
-    if any(stat is None for stat in stats):
-        return None
-    return {stat.identity: stat.cpu_ticks for stat in stats}
-
-
-def _cpu_delta_seconds(before, after):
-    if before is None or after is None or set(before) != set(after):
-        return None
-    delta_ticks = sum(after[key] - before[key] for key in before)
-    if delta_ticks <= 0:
-        return None
-    return delta_ticks / _CLK
-
-
-def _ycsb_cmd(phase, workload, port, num_keys, threads, *, duration=None, extra=(), record=()):
-    props = [
-        "-p",
-        "redis.host=127.0.0.1",
-        "-p",
-        f"redis.port={port}",
-        "-p",
-        f"recordcount={num_keys}",
-        "-p",
-        f"operationcount={_OP_CAP}",
-        "-p",
-        f"threadcount={threads}",
-        "-p",
-        "hdrhistogram.percentiles=50,95,99,99.9",
-        *record,
-    ]
-    if duration is not None and phase == "run":
-        props += ["-p", f"maxexecutiontime={duration}"]
-    props += list(extra)
-    return [
-        str(YCSB_HOME / "bin" / "ycsb.sh"),
-        phase,
-        "redis",
-        "-s",
-        "-P",
-        str(YCSB_HOME / workload),
-        *props,
-    ]
-
-
-def _run_ycsb(phase, workload, port, num_keys, threads, *, duration=None, extra=(), record=()):
-    """Run a single YCSB phase to completion; return stdout (exits on failure)."""
-    result = subprocess.run(
-        _ycsb_cmd(
-            phase, workload, port, num_keys, threads, duration=duration, extra=extra, record=record
-        ),
-        capture_output=True,
-        text=True,
-        timeout=600,
-    )
-    if result.returncode != 0:
-        print(f"YCSB {phase} failed:\n{result.stderr[-2000:]}")
-        sys.exit(1)
-    return result.stdout
-
-
-def _parse_metrics(output):
-    """Turn YCSB's `[GROUP], metric, value` CSV lines into {'GROUP.metric': value}."""
-    metrics = {}
-    for line in output.splitlines():
-        parts = [p.strip() for p in line.split(",")]
-        if len(parts) == 3 and parts[0].startswith("["):
-            try:
-                metrics[f"{parts[0].strip('[]')}.{parts[1]}"] = float(parts[2])
-            except ValueError:
-                pass
-    return metrics
-
-
-def _pct_key(op, pct):
-    # YCSB emits "50thPercentileLatency(us)" but "99.9PercentileLatency(us)" (no 'th').
-    suffix = "th" if "." not in pct else ""
-    return f"{op}.{pct}{suffix}PercentileLatency(us)"
+def _reduce_pct(runs: list[dict[str, float]], op: str, pct: str, reducer) -> float | None:
+    vals = [r[pct_key(op, pct)] for r in runs if pct_key(op, pct) in r]
+    return reducer(vals) if vals else None
 
 
 def _measure(
-    workload,
-    port,
-    num_keys,
-    threads,
-    duration,
-    procs,
-    process_group,
+    workload: str,
+    port: int,
+    num_keys: int,
+    threads: int,
+    duration: int,
+    procs: int,
+    process_group: int | None,
     *,
-    extra=(),
-    record=(),
-):
-    """One measured round: `procs` YCSB run JVMs in parallel, bracketed by server
-    CPU ticks. Aggregates throughput (sum) and ops (sum) across procs; latency
-    percentiles are worst-case (p99/p99.9 = max across procs, p50 = median).
-
-    Returns a dict with throughput, total_ops, per-op counts+latency, and
-    externally-measured cpu_us_per_op / server_cpu_cores (None if no PID).
-    """
+    extra: tuple[str, ...] | list[str] = (),
+    record: tuple[str, ...] | list[str] = (),
+) -> dict[str, Any]:
+    """One measured round: ``procs`` YCSB JVMs bracketed by server CPU ticks."""
     cmds = [
-        _ycsb_cmd(
-            "run", workload, port, num_keys, threads, duration=duration, extra=extra, record=record
+        ycsb_cmd(
+            _YCSB_HOME,
+            "run",
+            workload,
+            port,
+            num_keys,
+            threads,
+            duration=duration,
+            extra=extra,
+            record=record,
         )
         for _ in range(procs)
     ]
-    cpu_before = _cpu_snapshot(port, process_group)
-    w0 = time.time()
-    ps = [
-        subprocess.Popen(c, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True) for c in cmds
+    cpu_before = cpu_snapshot(port, process_group)
+    wall0 = time.time()
+    processes = [
+        subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        for cmd in cmds
     ]
-    outs = []
-    for p in ps:
-        out, err = p.communicate()
-        if p.returncode != 0:
+    outs: list[str] = []
+    for process in processes:
+        out, err = process.communicate()
+        if process.returncode != 0:
             print(f"YCSB run failed:\n{err[-2000:]}")
             sys.exit(1)
         outs.append(out)
-    w1 = time.time()
-    cpu_after = _cpu_snapshot(port, process_group)
+    wall1 = time.time()
+    cpu_after = cpu_snapshot(port, process_group)
 
-    runs = [_parse_metrics(o) for o in outs]
-    agg = {
-        "throughput": sum(r.get(THROUGHPUT_KEY, 0.0) for r in runs),
+    runs = [parse_metrics(out) for out in outs]
+    agg: dict[str, Any] = {
+        "throughput": sum(run.get(THROUGHPUT_KEY, 0.0) for run in runs),
         "total_ops": 0,
         "ops": {},
         "lat": {},
     }
     for op in OP_PROPORTION:
-        ops = sum(int(r.get(f"{op}.Operations", 0)) for r in runs)
+        ops = sum(int(run.get(f"{op}.Operations", 0)) for run in runs)
         if not ops:
             continue
         agg["ops"][op] = ops
@@ -380,10 +122,10 @@ def _measure(
             "p999": _reduce_pct(runs, op, "99.9", max),
         }
 
-    cpu_s = _cpu_delta_seconds(cpu_before, cpu_after)
-    if cpu_s is not None and agg["total_ops"]:
+    cpu_s = cpu_delta_seconds(cpu_before, cpu_after)
+    if cpu_s is not None and cpu_before is not None and agg["total_ops"]:
         agg["cpu_us_per_op"] = cpu_s / agg["total_ops"] * 1e6
-        agg["server_cpu_cores"] = cpu_s / (w1 - w0)
+        agg["server_cpu_cores"] = cpu_s / (wall1 - wall0)
         agg["server_process_count"] = len(cpu_before)
         agg["cpu_valid"] = True
     else:
@@ -394,28 +136,21 @@ def _measure(
     return agg
 
 
-def _reduce_pct(runs, op, pct, reducer):
-    vals = [r[_pct_key(op, pct)] for r in runs if _pct_key(op, pct) in r]
-    return reducer(vals) if vals else None
-
-
 def _probe_per_op(
-    workload,
-    port,
-    num_keys,
-    threads,
-    duration,
-    procs,
-    process_group,
-    present_ops,
-    record=(),
-):
-    """Per-op-type server CPU cost: drive each present op type at 100% and measure
-    its cpu_us_per_op in isolation. This is the read/update attribution channel —
-    a read-path optimization lowers READ's cpu/op without touching UPDATE's."""
-    out = {}
+    workload: str,
+    port: int,
+    num_keys: int,
+    threads: int,
+    duration: int,
+    procs: int,
+    process_group: int | None,
+    present_ops: list[str],
+    record: tuple[str, ...] | list[str] = (),
+) -> dict[str, float | None]:
+    """Diagnostic: isolate each present op type at 100% and measure cpu_us_per_op."""
+    out: dict[str, float | None] = {}
     for op in present_ops:
-        extra = []
+        extra: list[str] = []
         for other, prop in OP_PROPORTION.items():
             extra += ["-p", f"{prop}={'1' if other == op else '0'}"]
         agg = _measure(
@@ -433,9 +168,8 @@ def _probe_per_op(
     return out
 
 
-def _med_cov(values):
-    """(median, coefficient-of-variation %) over non-None values."""
-    vals = [v for v in values if v is not None]
+def _med_cov(values: list[float | None]) -> tuple[float | None, float]:
+    vals = [value for value in values if value is not None]
     if not vals:
         return None, 0.0
     med = statistics.median(vals)
@@ -443,7 +177,7 @@ def _med_cov(values):
     return med, cov
 
 
-def _worst_latency_ms(rounds, operation):
+def _worst_latency_ms(rounds: list[dict[str, Any]], operation: str) -> float | None:
     values = [
         _to_ms(round_["lat"][operation]["p99"])
         for round_ in rounds
@@ -452,55 +186,187 @@ def _worst_latency_ms(rounds, operation):
     return max(values) if values else None
 
 
-def _valid_number(value, *, positive=False):
-    return (
-        isinstance(value, int | float)
-        and not isinstance(value, bool)
-        and math.isfinite(value)
-        and (value > 0 if positive else True)
-    )
+def _to_ms(us: float | None) -> float | None:
+    return round(us / 1000, 4) if us is not None else None
 
 
-def _evaluate_validity(
+def _ms(us: float | None) -> str:
+    return f"{us / 1000:.3f}ms" if us is not None else "  -   "
+
+
+def _record_props(field_count: int | None, field_length: int | None) -> list[str]:
+    record: list[str] = []
+    if field_count is not None:
+        record += ["-p", f"fieldcount={field_count}"]
+    if field_length is not None:
+        record += ["-p", f"fieldlength={field_length}"]
+    return record
+
+
+def _run_scored_rounds(
     *,
-    throughput,
-    cpu_per_op,
-    rounds,
-    read_p99_ms,
-    update_p99_ms,
-    saturation_gain_pct,
-    min_throughput,
-    max_read_p99_ms,
-    max_update_p99_ms,
-    max_saturation_gain_pct,
-):
-    checks = {
-        "throughput_floor": _valid_number(throughput) and throughput >= min_throughput,
-        "read_p99": _valid_number(read_p99_ms) and read_p99_ms < max_read_p99_ms,
-        "update_p99": _valid_number(update_p99_ms) and update_p99_ms < max_update_p99_ms,
-        "score_available": _valid_number(cpu_per_op, positive=True),
-        "cpu_samples": bool(rounds) and all(round_["cpu_valid"] for round_ in rounds),
-        "saturation": _valid_number(saturation_gain_pct)
-        and abs(saturation_gain_pct) <= max_saturation_gain_pct,
-    }
-    reasons = []
-    labels = {
-        "throughput_floor": f"throughput must be >= {min_throughput:.1f} ops/sec",
-        "read_p99": f"READ p99 must be < {max_read_p99_ms:.3f} ms",
-        "update_p99": f"UPDATE p99 must be < {max_update_p99_ms:.3f} ms",
-        "score_available": "server CPU/op must be finite and positive",
-        "cpu_samples": "every scored repeat must have stable complete CPU accounting",
-        "saturation": (
-            f"higher-load throughput change must be within ±{max_saturation_gain_pct:.1f}%"
+    workload_path: str,
+    port: int,
+    num_keys: int,
+    threads: int,
+    duration: int,
+    client_procs: int,
+    process_group: int | None,
+    repeats: int,
+    warmup: bool,
+    record: list[str],
+) -> list[dict[str, Any]]:
+    if warmup:
+        _measure(
+            workload_path,
+            port,
+            num_keys,
+            threads,
+            min(duration, 3),
+            client_procs,
+            process_group,
+            record=record,
+        )
+    return [
+        _measure(
+            workload_path,
+            port,
+            num_keys,
+            threads,
+            duration,
+            client_procs,
+            process_group,
+            record=record,
+        )
+        for _ in range(max(1, repeats))
+    ]
+
+
+def _build_payload(
+    *,
+    median_throughput: float,
+    cov_pct: float,
+    cpu_per_op: float | None,
+    cpu_cov: float,
+    score: float | None,
+    server_cores: float | None,
+    median_round: dict[str, Any],
+    per_op_cpu: dict[str, float | None] | None,
+    read_p99_ms: float | None,
+    update_p99_ms: float | None,
+    throughputs: list[float],
+    args: argparse.Namespace,
+    saturation_gain_pct: float | None,
+    invalid_reasons: list[str],
+    checks: dict[str, bool],
+) -> dict[str, Any]:
+    return {
+        "throughput_ops_per_sec": round(median_throughput, 1),
+        "cov_pct": round(cov_pct, 1),
+        "cpu_us_per_op": round(cpu_per_op, 3) if cpu_per_op is not None else None,
+        "cpu_us_per_op_cov_pct": round(cpu_cov, 1),
+        "ops_per_cpu_sec": round(score, 1) if score is not None else None,
+        "server_cpu_cores": round(server_cores, 2) if server_cores is not None else None,
+        "server_process_count": median_round["server_process_count"],
+        "per_op_cpu_us": per_op_cpu,
+        "read_p99_ms": read_p99_ms,
+        "update_p99_ms": update_p99_ms,
+        "latency_ms": {
+            operation: {name: _to_ms(value) for name, value in latency.items()}
+            for operation, latency in median_round["lat"].items()
+        },
+        "threads": args.threads,
+        "client_procs": args.client_procs,
+        "workload": args.workload,
+        "runs_ops_per_sec": [round(value, 1) for value in throughputs],
+        "saturation_probe_client_procs": args.saturation_probe_client_procs,
+        "saturation_gain_pct": (
+            round(saturation_gain_pct, 1) if saturation_gain_pct is not None else None
         ),
+        "score_valid": not invalid_reasons,
+        "invalid_reasons": invalid_reasons,
+        "validity_thresholds": {
+            "min_throughput_ops_per_sec": args.min_throughput_ops_per_sec,
+            "max_read_p99_ms": args.max_read_p99_ms,
+            "max_update_p99_ms": args.max_update_p99_ms,
+            "max_saturation_gain_pct": args.max_saturation_gain_pct,
+        },
+        # Kept for tests / diagnostics; prefer invalid_reasons for humans.
+        "validity_checks": checks,
     }
-    for name, passed in checks.items():
-        if not passed:
-            reasons.append(labels[name])
-    return checks, reasons
 
 
-def main():
+def _emit_report(
+    *,
+    args: argparse.Namespace,
+    median_throughput: float,
+    cov_pct: float,
+    throughputs: list[float],
+    cpu_per_op: float | None,
+    cpu_cov: float,
+    score: float | None,
+    server_cores: float | None,
+    median_round: dict[str, Any],
+    per_op_cpu: dict[str, float | None] | None,
+    saturation_gain_pct: float | None,
+    invalid_reasons: list[str],
+    payload: dict[str, Any],
+) -> None:
+    label_procs = f" x {args.client_procs} procs" if args.client_procs > 1 else ""
+    print(f"\n{'=' * 60}")
+    print(
+        f"  YCSB Workload {args.workload.upper()} — {args.threads} thread"
+        f"{'s' if args.threads != 1 else ''}{label_procs}, "
+        f"{args.duration}s x {args.repeats} runs"
+    )
+    print(f"{'=' * 60}")
+    print(
+        f"Throughput (median): {median_throughput:.1f} ops/sec   "
+        f"(CoV {cov_pct:.1f}%: {', '.join(f'{value:.0f}' for value in throughputs)})"
+    )
+    if cpu_per_op is not None:
+        print(
+            f"Server CPU/op (median): {cpu_per_op:.3f} us/op   "
+            f"(CoV {cpu_cov:.1f}%)   [{score:,.0f} ops/core-sec]"
+        )
+        print(f"Server busy cores (median): {server_cores:.1f}   (diagnostic)")
+    for operation, latency in median_round["lat"].items():
+        cpu = (
+            f"   cpu {per_op_cpu[operation]:.3f} us/op"
+            if per_op_cpu and per_op_cpu.get(operation)
+            else ""
+        )
+        print(
+            f"{operation:18s} p50 {_ms(latency['p50'])}  "
+            f"p99 {_ms(latency['p99'])}  p99.9 {_ms(latency['p999'])}{cpu}"
+        )
+    if saturation_gain_pct is not None:
+        print(
+            f"Saturation probe: {args.client_procs}→"
+            f"{args.saturation_probe_client_procs} client procs, "
+            f"gain {saturation_gain_pct:.1f}%"
+        )
+    else:
+        print("Saturation probe: invalid")
+
+    if args.output_json:
+        args.output_json.write_text(json.dumps(payload, indent=2))
+
+    print(f"\nPERF_METRIC: {score:.1f} ops_per_cpu_sec" if score else "PERF_METRIC: null")
+    print(f"PERF_THROUGHPUT: {median_throughput:.1f} ops/sec")
+    print(f"PERF_COV: {cov_pct:.1f}%")
+    print(
+        f"PERF_CPU_PER_OP: {cpu_per_op:.3f} us"
+        if cpu_per_op is not None
+        else "PERF_CPU_PER_OP: null"
+    )
+    if invalid_reasons:
+        for reason in invalid_reasons:
+            print(f"INVALID: {reason}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="KV store benchmark (YCSB)")
     parser.add_argument(
         "--port",
@@ -522,22 +388,19 @@ def main():
         "--client-procs",
         type=int,
         default=1,
-        help="Independent YCSB JVMs driven in parallel. >1 defeats the single-client "
-        "CPU ceiling on a fast server so the run can reach server saturation.",
+        help="Independent YCSB JVMs in parallel (defeats single-client CPU ceiling).",
     )
     parser.add_argument(
         "--field-count",
         type=int,
         default=None,
-        help="YCSB fieldcount (fields per record). Raising it scales the read "
-        "(HGETALL-all-fields) server work without changing the one-field update — "
-        "amplifying a read-path optimization's per-op-type CPU signal.",
+        help="Optional diagnostic: YCSB fieldcount override.",
     )
     parser.add_argument(
         "--field-length",
         type=int,
         default=None,
-        help="YCSB fieldlength (bytes per field). Grows record/value size.",
+        help="Optional diagnostic: YCSB fieldlength override.",
     )
     parser.add_argument(
         "--duration",
@@ -552,7 +415,7 @@ def main():
     parser.add_argument(
         "--probe-per-op",
         action="store_true",
-        help="Also measure per-op-type server CPU cost (isolates each op at 100%%).",
+        help="Optional diagnostic: measure per-op-type server CPU cost.",
     )
     parser.add_argument(
         "--min-throughput-ops-per-sec",
@@ -575,70 +438,58 @@ def main():
         default=None,
         help="Write all metrics to this path as JSON.",
     )
-    args = parser.parse_args()
+    return parser.parse_args(argv)
 
-    _linux_preflight()
-    _ensure_ycsb()
 
-    with candidate_server(workspace=_WORKSPACE, port=args.port) as managed:
-        args.port = managed.port if managed is not None else args.port
-        process_group = managed.process_group if managed is not None else None
-        assert args.port is not None
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    linux_preflight()
+    ensure_ycsb(cache=_YCSB_CACHE, home=_YCSB_HOME)
 
+    with candidate_server(workspace=_WORKSPACE, port=args.port) as target:
+        record = _record_props(args.field_count, args.field_length)
         workload_path = WORKLOADS[args.workload]
-        record = []
-        if args.field_count is not None:
-            record += ["-p", f"fieldcount={args.field_count}"]
-        if args.field_length is not None:
-            record += ["-p", f"fieldlength={args.field_length}"]
 
-        _run_ycsb("load", workload_path, args.port, args.num_keys, args.threads, record=record)
+        run_ycsb(
+            _YCSB_HOME,
+            "load",
+            workload_path,
+            target.port,
+            args.num_keys,
+            args.threads,
+            record=record,
+        )
 
-        # Warm the server and workload path with the same client topology. Each
-        # later measured run starts fresh JVMs, so this does not claim to warm
-        # their JITs or connections.
-        if not args.no_warmup:
-            _measure(
-                workload_path,
-                args.port,
-                args.num_keys,
-                args.threads,
-                min(args.duration, 3),
-                args.client_procs,
-                process_group,
-                record=record,
-            )
-
-        rounds = [
-            _measure(
-                workload_path,
-                args.port,
-                args.num_keys,
-                args.threads,
-                args.duration,
-                args.client_procs,
-                process_group,
-                record=record,
-            )
-            for _ in range(max(1, args.repeats))
-        ]
+        rounds = _run_scored_rounds(
+            workload_path=workload_path,
+            port=target.port,
+            num_keys=args.num_keys,
+            threads=args.threads,
+            duration=args.duration,
+            client_procs=args.client_procs,
+            process_group=target.process_group,
+            repeats=args.repeats,
+            warmup=not args.no_warmup,
+            record=record,
+        )
 
         throughputs = [round_["throughput"] for round_ in rounds]
         median_throughput, cov_pct = _med_cov(throughputs)
         cpu_per_op, cpu_cov = _med_cov([round_["cpu_us_per_op"] for round_ in rounds])
         server_cores, _ = _med_cov([round_["server_cpu_cores"] for round_ in rounds])
+        assert median_throughput is not None
         median_round = min(rounds, key=lambda round_: abs(round_["throughput"] - median_throughput))
         read_p99_ms = _worst_latency_ms(rounds, "READ")
         update_p99_ms = _worst_latency_ms(rounds, "UPDATE")
 
         saturation = _measure(
             workload_path,
-            args.port,
+            target.port,
             args.num_keys,
             args.threads,
             args.duration,
             args.saturation_probe_client_procs,
-            process_group,
+            target.process_group,
             record=record,
         )
         saturation_gain_pct = (
@@ -649,17 +500,17 @@ def main():
         if args.probe_per_op:
             per_op_cpu = _probe_per_op(
                 workload_path,
-                args.port,
+                target.port,
                 args.num_keys,
                 args.threads,
                 args.duration,
                 args.client_procs,
-                process_group,
+                target.process_group,
                 list(median_round["ops"]),
                 record=record,
             )
 
-        checks, invalid_reasons = _evaluate_validity(
+        checks, invalid_reasons = evaluate_validity(
             throughput=median_throughput,
             cpu_per_op=cpu_per_op,
             rounds=rounds,
@@ -671,105 +522,40 @@ def main():
             max_update_p99_ms=args.max_update_p99_ms,
             max_saturation_gain_pct=args.max_saturation_gain_pct,
         )
-        score = 1e6 / cpu_per_op if _valid_number(cpu_per_op, positive=True) else None
+        score = 1e6 / cpu_per_op if valid_number(cpu_per_op, positive=True) else None
 
-        label_procs = f" x {args.client_procs} procs" if args.client_procs > 1 else ""
-        print(f"\n{'=' * 60}")
-        print(
-            f"  YCSB Workload {args.workload.upper()} — {args.threads} thread"
-            f"{'s' if args.threads != 1 else ''}{label_procs}, "
-            f"{args.duration}s x {args.repeats} runs"
+        payload = _build_payload(
+            median_throughput=median_throughput,
+            cov_pct=cov_pct,
+            cpu_per_op=cpu_per_op,
+            cpu_cov=cpu_cov,
+            score=score,
+            server_cores=server_cores,
+            median_round=median_round,
+            per_op_cpu=per_op_cpu,
+            read_p99_ms=read_p99_ms,
+            update_p99_ms=update_p99_ms,
+            throughputs=throughputs,
+            args=args,
+            saturation_gain_pct=saturation_gain_pct,
+            invalid_reasons=invalid_reasons,
+            checks=checks,
         )
-        print(f"{'=' * 60}")
-        print(
-            f"Throughput (median): {median_throughput:.1f} ops/sec   "
-            f"(CoV {cov_pct:.1f}%: {', '.join(f'{value:.0f}' for value in throughputs)})"
+        _emit_report(
+            args=args,
+            median_throughput=median_throughput,
+            cov_pct=cov_pct,
+            throughputs=throughputs,
+            cpu_per_op=cpu_per_op,
+            cpu_cov=cpu_cov,
+            score=score,
+            server_cores=server_cores,
+            median_round=median_round,
+            per_op_cpu=per_op_cpu,
+            saturation_gain_pct=saturation_gain_pct,
+            invalid_reasons=invalid_reasons,
+            payload=payload,
         )
-        if cpu_per_op is not None:
-            print(
-                f"Server CPU/op (median): {cpu_per_op:.3f} us/op   "
-                f"(CoV {cpu_cov:.1f}%)   [{score:,.0f} ops/core-sec]"
-            )
-            print(f"Server busy cores (median): {server_cores:.1f}   (diagnostic)")
-        for operation, latency in median_round["lat"].items():
-            cpu = (
-                f"   cpu {per_op_cpu[operation]:.3f} us/op"
-                if per_op_cpu and per_op_cpu.get(operation)
-                else ""
-            )
-            print(
-                f"{operation:18s} p50 {_ms(latency['p50'])}  "
-                f"p99 {_ms(latency['p99'])}  p99.9 {_ms(latency['p999'])}{cpu}"
-            )
-        print(
-            f"Saturation probe: {args.client_procs}→"
-            f"{args.saturation_probe_client_procs} client procs, "
-            f"gain {saturation_gain_pct:.1f}%"
-            if saturation_gain_pct is not None
-            else "Saturation probe: invalid"
-        )
-
-        payload = {
-            "throughput_ops_per_sec": round(median_throughput, 1),
-            "cov_pct": round(cov_pct, 1),
-            "cpu_us_per_op": round(cpu_per_op, 3) if cpu_per_op is not None else None,
-            "cpu_us_per_op_cov_pct": round(cpu_cov, 1),
-            "ops_per_cpu_sec": round(score, 1) if score is not None else None,
-            "server_cpu_cores": round(server_cores, 2) if server_cores is not None else None,
-            "server_process_count": median_round["server_process_count"],
-            "per_op_cpu_us": per_op_cpu,
-            "read_p99_ms": read_p99_ms,
-            "update_p99_ms": update_p99_ms,
-            "latency_ms": {
-                operation: {name: _to_ms(value) for name, value in latency.items()}
-                for operation, latency in median_round["lat"].items()
-            },
-            "threads": args.threads,
-            "client_procs": args.client_procs,
-            "workload": args.workload,
-            "runs_ops_per_sec": [round(value, 1) for value in throughputs],
-            "saturation_probe_client_procs": args.saturation_probe_client_procs,
-            "saturation_gain_pct": (
-                round(saturation_gain_pct, 1) if saturation_gain_pct is not None else None
-            ),
-            "score_valid": not invalid_reasons,
-            "invalid_reasons": invalid_reasons,
-            "validity_checks": checks,
-            "validity_thresholds": {
-                "min_throughput_ops_per_sec": args.min_throughput_ops_per_sec,
-                "max_read_p99_ms": args.max_read_p99_ms,
-                "max_update_p99_ms": args.max_update_p99_ms,
-                "max_saturation_gain_pct": args.max_saturation_gain_pct,
-            },
-        }
-        if args.output_json:
-            args.output_json.write_text(json.dumps(payload, indent=2))
-
-        print(f"\nPERF_METRIC: {score:.1f} ops_per_cpu_sec" if score else "PERF_METRIC: null")
-        print(f"PERF_THROUGHPUT: {median_throughput:.1f} ops/sec")
-        print(f"PERF_COV: {cov_pct:.1f}%")
-        print(
-            f"PERF_CPU_PER_OP: {cpu_per_op:.3f} us"
-            if cpu_per_op is not None
-            else "PERF_CPU_PER_OP: null"
-        )
-        if invalid_reasons:
-            for reason in invalid_reasons:
-                print(f"INVALID: {reason}", file=sys.stderr)
-            sys.exit(1)
-
-
-def _to_ms(us):
-    return round(us / 1000, 4) if us is not None else None
-
-
-def _ms(us):
-    return f"{us / 1000:.3f}ms" if us is not None else "  -   "
-
-
-def _lat_ms(round_, op, pct):
-    lat = round_["lat"].get(op)
-    return _to_ms(lat[pct]) if lat else None
 
 
 if __name__ == "__main__":

--- a/examples/kv-store/evaluator_support/__init__.py
+++ b/examples/kv-store/evaluator_support/__init__.py
@@ -1,5 +1,12 @@
 """Shared trusted support for the KV-store evaluators."""
 
-from .lifecycle import CandidateServer, candidate_server
+from .lifecycle import CandidateServer, CandidateTarget, candidate_server
+from .net import free_port, wait_until_listening
 
-__all__ = ["CandidateServer", "candidate_server"]
+__all__ = [
+    "CandidateServer",
+    "CandidateTarget",
+    "candidate_server",
+    "free_port",
+    "wait_until_listening",
+]

--- a/examples/kv-store/evaluator_support/__init__.py
+++ b/examples/kv-store/evaluator_support/__init__.py
@@ -1,0 +1,5 @@
+"""Shared trusted support for the KV-store evaluators."""
+
+from .lifecycle import CandidateServer, candidate_server
+
+__all__ = ["CandidateServer", "candidate_server"]

--- a/examples/kv-store/evaluator_support/lifecycle.py
+++ b/examples/kv-store/evaluator_support/lifecycle.py
@@ -1,0 +1,103 @@
+"""Candidate service lifecycle owned by trusted KV-store evaluators."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import socket
+import subprocess
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CandidateServer:
+    """One evaluator-launched candidate service."""
+
+    port: int
+    pid: int
+    process_group: int
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_until_listening(port: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return True
+        except OSError:
+            time.sleep(0.05)
+    return False
+
+
+def _terminate_group(process: subprocess.Popen[bytes], process_group: int) -> None:
+    if process.poll() is not None:
+        process.wait()
+        return
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(process_group, signal.SIGTERM)
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process_group, signal.SIGKILL)
+        process.wait(timeout=5)
+
+
+@contextlib.contextmanager
+def candidate_server(
+    *,
+    workspace: Path,
+    port: int | None = None,
+    startup_timeout: float = 5.0,
+) -> Iterator[CandidateServer | None]:
+    """Yield an external server or launch and clean up ``./run.sh``.
+
+    When ``port`` is supplied, lifecycle ownership stays with the caller and
+    ``None`` is yielded. Otherwise the evaluator starts the candidate in a new
+    process group and yields its identity for trusted CPU accounting.
+    """
+
+    if port is not None:
+        yield None
+        return
+
+    selected_port = _free_port()
+    launcher = workspace / "run.sh"
+    if not launcher.is_file():
+        raise FileNotFoundError(f"candidate launcher not found: {launcher}")
+
+    process = subprocess.Popen(
+        [str(launcher), str(selected_port)],
+        cwd=workspace,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    process_group = os.getpgid(process.pid)
+    server = CandidateServer(
+        port=selected_port,
+        pid=process.pid,
+        process_group=process_group,
+    )
+    try:
+        if not _wait_until_listening(selected_port, startup_timeout):
+            return_code = process.poll()
+            detail = f" (launcher exited {return_code})" if return_code is not None else ""
+            raise RuntimeError(
+                f"candidate did not listen on port {selected_port} within "
+                f"{startup_timeout:.1f}s{detail}"
+            )
+        yield server
+    finally:
+        _terminate_group(process, process_group)

--- a/examples/kv-store/evaluator_support/lifecycle.py
+++ b/examples/kv-store/evaluator_support/lifecycle.py
@@ -5,38 +5,30 @@ from __future__ import annotations
 import contextlib
 import os
 import signal
-import socket
 import subprocess
-import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
+from .net import free_port, wait_until_listening
+
 
 @dataclass(frozen=True)
-class CandidateServer:
-    """One evaluator-launched candidate service."""
+class CandidateTarget:
+    """Resolved candidate endpoint for an evaluator invocation.
+
+    ``process_group`` is set when the evaluator owns the launcher process group.
+    External ``--port`` mode leaves it ``None`` so CPU accounting falls back to
+    listener discovery.
+    """
 
     port: int
-    pid: int
-    process_group: int
+    process_group: int | None = None
+    pid: int | None = None
 
 
-def _free_port() -> int:
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
-
-
-def _wait_until_listening(port: int, timeout: float) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
-                return True
-        except OSError:
-            time.sleep(0.05)
-    return False
+# Backwards-compatible alias used by older call sites / docs.
+CandidateServer = CandidateTarget
 
 
 def _terminate_group(process: subprocess.Popen[bytes], process_group: int) -> None:
@@ -59,19 +51,18 @@ def candidate_server(
     workspace: Path,
     port: int | None = None,
     startup_timeout: float = 5.0,
-) -> Iterator[CandidateServer | None]:
+) -> Iterator[CandidateTarget]:
     """Yield an external server or launch and clean up ``./run.sh``.
 
-    When ``port`` is supplied, lifecycle ownership stays with the caller and
-    ``None`` is yielded. Otherwise the evaluator starts the candidate in a new
-    process group and yields its identity for trusted CPU accounting.
+    When ``port`` is supplied, lifecycle ownership stays with the caller.
+    Otherwise the evaluator starts the candidate in a new process group.
     """
 
     if port is not None:
-        yield None
+        yield CandidateTarget(port=port)
         return
 
-    selected_port = _free_port()
+    selected_port = free_port()
     launcher = workspace / "run.sh"
     if not launcher.is_file():
         raise FileNotFoundError(f"candidate launcher not found: {launcher}")
@@ -85,19 +76,19 @@ def candidate_server(
         start_new_session=True,
     )
     process_group = os.getpgid(process.pid)
-    server = CandidateServer(
+    target = CandidateTarget(
         port=selected_port,
         pid=process.pid,
         process_group=process_group,
     )
     try:
-        if not _wait_until_listening(selected_port, startup_timeout):
+        if not wait_until_listening(selected_port, startup_timeout):
             return_code = process.poll()
             detail = f" (launcher exited {return_code})" if return_code is not None else ""
             raise RuntimeError(
                 f"candidate did not listen on port {selected_port} within "
                 f"{startup_timeout:.1f}s{detail}"
             )
-        yield server
+        yield target
     finally:
         _terminate_group(process, process_group)

--- a/examples/kv-store/evaluator_support/net.py
+++ b/examples/kv-store/evaluator_support/net.py
@@ -1,0 +1,23 @@
+"""Shared localhost helpers for KV-store evaluators."""
+
+from __future__ import annotations
+
+import socket
+import time
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def wait_until_listening(port: int, timeout: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return True
+        except OSError:
+            time.sleep(0.05)
+    return False

--- a/examples/kv-store/evaluator_support/procfs_cpu.py
+++ b/examples/kv-store/evaluator_support/procfs_cpu.py
@@ -1,0 +1,134 @@
+"""Linux procfs CPU accounting for the KV-store candidate process set."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_CLK = os.sysconf("SC_CLK_TCK")
+
+
+@dataclass(frozen=True)
+class ProcessStat:
+    pid: int
+    parent_pid: int
+    process_group: int
+    starttime: int
+    cpu_ticks: int
+
+    @property
+    def identity(self) -> tuple[int, int]:
+        return (self.pid, self.starttime)
+
+
+def linux_preflight(proc_root: Path = Path("/proc")) -> None:
+    if sys.platform != "linux":
+        raise RuntimeError("KV-store CPU scoring requires Linux procfs")
+    if not (proc_root / "net" / "tcp").is_file() or not (proc_root / "self" / "stat").is_file():
+        raise RuntimeError("KV-store CPU scoring requires readable Linux procfs")
+
+
+def read_process_stat(pid: int, proc_root: Path = Path("/proc")) -> ProcessStat | None:
+    try:
+        raw = (proc_root / str(pid) / "stat").read_text()
+        fields = raw[raw.rindex(")") + 2 :].split()
+        return ProcessStat(
+            pid=int(pid),
+            parent_pid=int(fields[1]),
+            process_group=int(fields[2]),
+            cpu_ticks=int(fields[11]) + int(fields[12]),
+            starttime=int(fields[19]),
+        )
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def all_process_stats(proc_root: Path = Path("/proc")) -> dict[int, ProcessStat]:
+    stats: dict[int, ProcessStat] = {}
+    for path in proc_root.iterdir():
+        if path.name.isdigit() and (stat := read_process_stat(int(path.name), proc_root)):
+            stats[stat.pid] = stat
+    return stats
+
+
+def listener_pids(port: int, proc_root: Path = Path("/proc")) -> set[int]:
+    """Return every process owning a listening socket for ``port``."""
+    inodes: set[str] = set()
+    for table in (proc_root / "net" / "tcp", proc_root / "net" / "tcp6"):
+        try:
+            lines = table.read_text().splitlines()[1:]
+        except OSError:
+            continue
+        for line in lines:
+            fields = line.split()
+            # local_address is hex "ADDR:PORT"; st == 0A is LISTEN.
+            if (
+                len(fields) > 9
+                and fields[3] == "0A"
+                and int(fields[1].rsplit(":", 1)[1], 16) == port
+            ):
+                inodes.add(fields[9])
+    if not inodes:
+        return set()
+    pids: set[int] = set()
+    for pid_dir in proc_root.iterdir():
+        if not pid_dir.name.isdigit():
+            continue
+        try:
+            for fd in (pid_dir / "fd").iterdir():
+                target = os.readlink(fd)
+                if target.startswith("socket:[") and target[8:-1] in inodes:
+                    pids.add(int(pid_dir.name))
+                    break
+        except OSError:
+            continue
+    return pids
+
+
+def server_processes(
+    port: int,
+    process_group: int | None = None,
+    proc_root: Path = Path("/proc"),
+) -> set[int]:
+    stats = all_process_stats(proc_root)
+    if process_group is not None:
+        return {pid for pid, stat in stats.items() if stat.process_group == process_group}
+    roots = listener_pids(port, proc_root)
+    selected = set(roots)
+    changed = True
+    while changed:
+        changed = False
+        for pid, stat in stats.items():
+            if stat.parent_pid in selected and pid not in selected:
+                selected.add(pid)
+                changed = True
+    return selected
+
+
+def cpu_snapshot(
+    port: int,
+    process_group: int | None = None,
+    proc_root: Path = Path("/proc"),
+) -> dict[tuple[int, int], int] | None:
+    pids = server_processes(port, process_group, proc_root)
+    if not pids:
+        return None
+    stats = [read_process_stat(pid, proc_root) for pid in sorted(pids)]
+    resolved = [stat for stat in stats if stat is not None]
+    if len(resolved) != len(pids):
+        return None
+    return {stat.identity: stat.cpu_ticks for stat in resolved}
+
+
+def cpu_delta_seconds(
+    before: dict[tuple[int, int], int] | None,
+    after: dict[tuple[int, int], int] | None,
+) -> float | None:
+    if before is None or after is None or set(before) != set(after):
+        return None
+    delta_ticks = sum(after[key] - before[key] for key in before)
+    if delta_ticks <= 0:
+        return None
+    return delta_ticks / _CLK

--- a/examples/kv-store/evaluator_support/validity.py
+++ b/examples/kv-store/evaluator_support/validity.py
@@ -1,0 +1,51 @@
+"""Score validity gates for the KV-store CPU-efficiency metric."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+def valid_number(value: Any, *, positive: bool = False) -> bool:
+    return (
+        isinstance(value, int | float)
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and (value > 0 if positive else True)
+    )
+
+
+def evaluate_validity(
+    *,
+    throughput: float | None,
+    cpu_per_op: float | None,
+    rounds: list[dict[str, Any]],
+    read_p99_ms: float | None,
+    update_p99_ms: float | None,
+    saturation_gain_pct: float | None,
+    min_throughput: float,
+    max_read_p99_ms: float,
+    max_update_p99_ms: float,
+    max_saturation_gain_pct: float,
+) -> tuple[dict[str, bool], list[str]]:
+    checks = {
+        "throughput_floor": valid_number(throughput) and throughput >= min_throughput,
+        "read_p99": valid_number(read_p99_ms) and read_p99_ms < max_read_p99_ms,
+        "update_p99": valid_number(update_p99_ms) and update_p99_ms < max_update_p99_ms,
+        "score_available": valid_number(cpu_per_op, positive=True),
+        "cpu_samples": bool(rounds) and all(round_["cpu_valid"] for round_ in rounds),
+        "saturation": valid_number(saturation_gain_pct)
+        and abs(saturation_gain_pct) <= max_saturation_gain_pct,
+    }
+    labels = {
+        "throughput_floor": f"throughput must be >= {min_throughput:.1f} ops/sec",
+        "read_p99": f"READ p99 must be < {max_read_p99_ms:.3f} ms",
+        "update_p99": f"UPDATE p99 must be < {max_update_p99_ms:.3f} ms",
+        "score_available": "server CPU/op must be finite and positive",
+        "cpu_samples": "every scored repeat must have stable complete CPU accounting",
+        "saturation": (
+            f"higher-load throughput change must be within ±{max_saturation_gain_pct:.1f}%"
+        ),
+    }
+    reasons = [labels[name] for name, passed in checks.items() if not passed]
+    return checks, reasons

--- a/examples/kv-store/evaluator_support/ycsb.py
+++ b/examples/kv-store/evaluator_support/ycsb.py
@@ -1,0 +1,194 @@
+"""Checksum-pinned YCSB Redis binding install and runners."""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+YCSB_VERSION = "0.17.0"
+YCSB_URL = (
+    f"https://github.com/brianfrankcooper/YCSB/releases/download/"
+    f"{YCSB_VERSION}/ycsb-redis-binding-{YCSB_VERSION}.tar.gz"
+)
+YCSB_SHA256 = "353eb96c12a605c30c94928b85780ae4673578a21e2aa13782cd7f591991e484"
+
+# Huge op-count cap so a run ends on maxexecutiontime, not on ops exhausted.
+_OP_CAP = 1_000_000_000
+
+# Metric key YCSB emits for overall throughput; the headline number.
+THROUGHPUT_KEY = "OVERALL.Throughput(ops/sec)"
+
+# Op types YCSB reports, and the CoreWorkload proportion knob that drives each
+# (used by --probe-per-op to isolate one op type at 100%).
+OP_PROPORTION = {
+    "READ": "readproportion",
+    "UPDATE": "updateproportion",
+    "INSERT": "insertproportion",
+    "SCAN": "scanproportion",
+    "READ-MODIFY-WRITE": "readmodifywriteproportion",
+}
+
+WORKLOADS = {w: f"workloads/workload{w}" for w in ("a", "b", "c", "d", "e", "f")}
+
+
+def cache_paths(workspace: Path) -> tuple[Path, Path]:
+    cache = workspace / ".cache"
+    home = cache / f"ycsb-redis-binding-{YCSB_VERSION}"
+    return cache, home
+
+
+def safe_extract(tar: tarfile.TarFile, destination: Path) -> None:
+    root = destination.resolve()
+    members = tar.getmembers()
+    for member in members:
+        target = (destination / member.name).resolve()
+        try:
+            target.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"unsafe YCSB archive path: {member.name}") from exc
+        if member.issym() or member.islnk() or member.isdev() or member.isfifo():
+            raise ValueError(f"unsupported YCSB archive member: {member.name}")
+    tar.extractall(destination, members=members)
+
+
+def ensure_ycsb(*, cache: Path, home: Path, sha256: str = YCSB_SHA256, url: str = YCSB_URL) -> None:
+    marker = home / ".vibeserve-sha256"
+    if (home / "bin" / "ycsb.sh").is_file() and marker.is_file():
+        if marker.read_text().strip() == sha256:
+            return
+
+    cache.mkdir(parents=True, exist_ok=True)
+    lock_path = cache / f".ycsb-{YCSB_VERSION}.lock"
+    with lock_path.open("w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        if (home / "bin" / "ycsb.sh").is_file() and marker.is_file():
+            if marker.read_text().strip() == sha256:
+                return
+        print(f"Downloading YCSB {YCSB_VERSION} Redis binding...", file=sys.stderr)
+        with tempfile.TemporaryDirectory(dir=cache) as tmp_dir:
+            tmp = Path(tmp_dir)
+            tarball = tmp / "ycsb.tar.gz"
+            digest = hashlib.sha256()
+            with urllib.request.urlopen(url) as response, tarball.open("wb") as output:
+                while chunk := response.read(1024 * 1024):
+                    digest.update(chunk)
+                    output.write(chunk)
+            if digest.hexdigest() != sha256:
+                raise RuntimeError("YCSB archive checksum mismatch")
+            extract_root = tmp / "extract"
+            extract_root.mkdir()
+            with tarfile.open(tarball, "r:gz") as tar:
+                safe_extract(tar, extract_root)
+            extracted = extract_root / f"ycsb-redis-binding-{YCSB_VERSION}"
+            if not (extracted / "bin" / "ycsb.sh").is_file():
+                raise RuntimeError("YCSB archive is missing bin/ycsb.sh")
+            (extracted / ".vibeserve-sha256").write_text(f"{sha256}\n")
+            staged = cache / f".{home.name}.staged"
+            if staged.exists():
+                shutil.rmtree(staged)
+            shutil.move(str(extracted), staged)
+            if home.exists():
+                shutil.rmtree(home)
+            staged.replace(home)
+
+
+def ycsb_cmd(
+    home: Path,
+    phase: str,
+    workload: str,
+    port: int,
+    num_keys: int,
+    threads: int,
+    *,
+    duration: int | None = None,
+    extra: tuple[str, ...] | list[str] = (),
+    record: tuple[str, ...] | list[str] = (),
+) -> list[str]:
+    props = [
+        "-p",
+        "redis.host=127.0.0.1",
+        "-p",
+        f"redis.port={port}",
+        "-p",
+        f"recordcount={num_keys}",
+        "-p",
+        f"operationcount={_OP_CAP}",
+        "-p",
+        f"threadcount={threads}",
+        "-p",
+        "hdrhistogram.percentiles=50,95,99,99.9",
+        *record,
+    ]
+    if duration is not None and phase == "run":
+        props += ["-p", f"maxexecutiontime={duration}"]
+    props += list(extra)
+    return [
+        str(home / "bin" / "ycsb.sh"),
+        phase,
+        "redis",
+        "-s",
+        "-P",
+        str(home / workload),
+        *props,
+    ]
+
+
+def run_ycsb(
+    home: Path,
+    phase: str,
+    workload: str,
+    port: int,
+    num_keys: int,
+    threads: int,
+    *,
+    duration: int | None = None,
+    extra: tuple[str, ...] | list[str] = (),
+    record: tuple[str, ...] | list[str] = (),
+) -> str:
+    """Run a single YCSB phase to completion; return stdout (exits on failure)."""
+    result = subprocess.run(
+        ycsb_cmd(
+            home,
+            phase,
+            workload,
+            port,
+            num_keys,
+            threads,
+            duration=duration,
+            extra=extra,
+            record=record,
+        ),
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    if result.returncode != 0:
+        print(f"YCSB {phase} failed:\n{result.stderr[-2000:]}")
+        sys.exit(1)
+    return result.stdout
+
+
+def parse_metrics(output: str) -> dict[str, float]:
+    """Turn YCSB's `[GROUP], metric, value` CSV lines into {'GROUP.metric': value}."""
+    metrics: dict[str, float] = {}
+    for line in output.splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) == 3 and parts[0].startswith("["):
+            try:
+                metrics[f"{parts[0].strip('[]')}.{parts[1]}"] = float(parts[2])
+            except ValueError:
+                pass
+    return metrics
+
+
+def pct_key(op: str, pct: str) -> str:
+    # YCSB emits "50thPercentileLatency(us)" but "99.9PercentileLatency(us)" (no 'th').
+    suffix = "th" if "." not in pct else ""
+    return f"{op}.{pct}{suffix}PercentileLatency(us)"

--- a/examples/kv-store/reference/seed_server.py
+++ b/examples/kv-store/reference/seed_server.py
@@ -53,6 +53,10 @@ def _err(msg: str) -> bytes:
     return b"-ERR " + msg.encode() + b"\r\n"
 
 
+def _wrongtype() -> bytes:
+    return b"-WRONGTYPE Operation against a key holding the wrong kind of value\r\n"
+
+
 def _int(n: int) -> bytes:
     return b":" + str(n).encode() + b"\r\n"
 
@@ -79,16 +83,18 @@ def handle_command(args: list[bytes]) -> bytes:
     cmd = args[0].upper()
 
     if cmd == b"SET":
-        if len(args) < 3:
+        if len(args) != 3:
             return _err("wrong number of arguments for 'set' command")
         data[args[1]] = args[2]
         return _ok()
 
     elif cmd == b"GET":
-        if len(args) < 2:
+        if len(args) != 2:
             return _err("wrong number of arguments for 'get' command")
         val = data.get(args[1])
-        if not isinstance(val, bytes):
+        if isinstance(val, dict):
+            return _wrongtype()
+        if val is None:
             return _NULL
         return _bulk(val)
 
@@ -101,14 +107,19 @@ def handle_command(args: list[bytes]) -> bytes:
     elif cmd == b"HSET" or cmd == b"HMSET":
         if len(args) < 4 or len(args) % 2 != 0:
             return _err(f"wrong number of arguments for '{cmd.decode().lower()}' command")
+        existing = data.get(args[1])
+        if isinstance(existing, bytes):
+            return _wrongtype()
         created = _hset(args[1], args, 2)
         return _ok() if cmd == b"HMSET" else _int(created)
 
     elif cmd == b"HGETALL":
-        if len(args) < 2:
+        if len(args) != 2:
             return _err("wrong number of arguments for 'hgetall' command")
         h = data.get(args[1])
-        if not isinstance(h, dict):
+        if isinstance(h, bytes):
+            return _wrongtype()
+        if h is None:
             return b"*0\r\n"
         parts = []
         for k, v in h.items():
@@ -117,14 +128,26 @@ def handle_command(args: list[bytes]) -> bytes:
         return b"*" + str(len(parts)).encode() + b"\r\n" + b"".join(parts)
 
     elif cmd == b"DBSIZE":
+        if len(args) != 1:
+            return _err("wrong number of arguments for 'dbsize' command")
         return _int(len(data))
 
     elif cmd == b"FLUSHDB" or cmd == b"FLUSHALL":
+        if len(args) != 1:
+            return _err(f"wrong number of arguments for '{cmd.decode().lower()}' command")
         data.clear()
         return _ok()
 
-    elif cmd in (b"PING", b"COMMAND", b"CLIENT", b"HELLO"):
-        return b"+PONG\r\n" if cmd == b"PING" else _ok()
+    elif cmd == b"PING":
+        if len(args) != 1:
+            return _err("wrong number of arguments for 'ping' command")
+        return b"+PONG\r\n"
+
+    elif cmd == b"COMMAND" or cmd == b"HELLO":
+        return b"*0\r\n"
+
+    elif cmd == b"CLIENT":
+        return _ok()
 
     else:
         return _err(f"unknown command '{cmd.decode()}'")

--- a/examples/kv-store/run.sh
+++ b/examples/kv-store/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Initial candidate launcher. Agents may replace this seed implementation.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+PORT="${1:?usage: ./run.sh <port>}"
+
+exec "${PYTHON:-python3}" "$ROOT/reference/seed_server.py" "$PORT"

--- a/examples/kv-store/run_test.sh
+++ b/examples/kv-store/run_test.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
-# End-to-end test: starts the seed server, runs checker + benchmark, cleans up.
-set -e
+# End-to-end smoke test. Each trusted evaluator owns candidate lifecycle.
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
-PYTHON="${PYTHON:-python3}"
-PORT=6399
-
-cleanup() { kill $SERVER_PID 2>/dev/null || true; }
-trap cleanup EXIT
-
-$PYTHON reference/seed_server.py $PORT &
-SERVER_PID=$!
-sleep 0.5
+OUTPUT_JSON="$(mktemp)"
+trap 'rm -f "$OUTPUT_JSON"' EXIT
 
 echo "=== ACCURACY CHECK ==="
-$PYTHON accuracy_checker/checker.py --port $PORT
+uv run python accuracy_checker/checker.py
 
 echo ""
 echo "=== BENCHMARK ==="
-$PYTHON benchmark/benchmark.py --port $PORT --num-keys 500 --duration 2 --repeats 1 --no-warmup
+uv run python benchmark/benchmark.py \
+  --num-keys 500 \
+  --duration 2 \
+  --repeats 1 \
+  --no-warmup \
+  --client-procs 1 \
+  --saturation-probe-client-procs 1 \
+  --max-saturation-gain-pct 100 \
+  --output-json "$OUTPUT_JSON"

--- a/examples/kv-store/run_test.sh
+++ b/examples/kv-store/run_test.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 # End-to-end smoke test. Each trusted evaluator owns candidate lifecycle.
+#
+# This is a plumbing check for CI and local harness verification, not the
+# scored optimization contract. Latency/throughput gates here are intentionally
+# looser than vibeserve.input.toml so shared CI VMs (noisy, single-client,
+# short runs) do not fail a healthy seed.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -21,4 +26,21 @@ uv run python benchmark/benchmark.py \
   --client-procs 1 \
   --saturation-probe-client-procs 1 \
   --max-saturation-gain-pct 100 \
+  --min-throughput-ops-per-sec 1000 \
+  --max-read-p99-ms 10 \
+  --max-update-p99-ms 10 \
   --output-json "$OUTPUT_JSON"
+
+uv run python - "$OUTPUT_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text())
+score = payload.get("ops_per_cpu_sec")
+if not payload.get("score_valid") or not isinstance(score, (int, float)) or score <= 0:
+    raise SystemExit(
+        f"smoke benchmark did not produce a valid ops_per_cpu_sec score: {payload!r}"
+    )
+print(f"Smoke score OK: {score:.1f} ops_per_cpu_sec")
+PY

--- a/examples/kv-store/vibeserve.input.toml
+++ b/examples/kv-store/vibeserve.input.toml
@@ -11,7 +11,17 @@ timeout_seconds = 120
 # --client-procs drives the server from several independent YCSB JVMs so the run
 # reaches server saturation instead of a single-client CPU ceiling (a fast server
 # saturates one client long before itself). Tune upward on many-core hosts.
-command = ["uv", "run", "python", "benchmark/benchmark.py", "--client-procs", "4"]
+# The 10k throughput floor is a conservative collapse guard for the supported
+# evaluator class; recalibrate it before changing evaluator hardware.
+command = [
+  "uv", "run", "python", "benchmark/benchmark.py",
+  "--client-procs", "4",
+  "--min-throughput-ops-per-sec", "10000",
+  "--max-read-p99-ms", "1.0",
+  "--max-update-p99-ms", "1.0",
+  "--saturation-probe-client-procs", "8",
+  "--max-saturation-gain-pct", "10.0",
+]
 timeout_seconds = 300
 
 [benchmark.result]

--- a/examples/kv-store/vibeserve.input.toml
+++ b/examples/kv-store/vibeserve.input.toml
@@ -8,9 +8,16 @@ command = ["uv", "run", "python", "accuracy_checker/checker.py"]
 timeout_seconds = 120
 
 [benchmark]
-command = ["uv", "run", "python", "benchmark/benchmark.py"]
+# --client-procs drives the server from several independent YCSB JVMs so the run
+# reaches server saturation instead of a single-client CPU ceiling (a fast server
+# saturates one client long before itself). Tune upward on many-core hosts.
+command = ["uv", "run", "python", "benchmark/benchmark.py", "--client-procs", "4"]
 timeout_seconds = 300
 
 [benchmark.result]
 json_argument = "--output-json"
-metric = "throughput_ops_per_sec"
+# Server efficiency (ops served per core-second), measured externally from the
+# server's /proc CPU. Unlike raw throughput it is immune to client-side saturation
+# and rewards doing genuinely less work per op — so a workload-specific data-path
+# optimization is visible here even when transport-bound throughput is flat.
+metric = "ops_per_cpu_sec"

--- a/src/vibe_serve/context.py
+++ b/src/vibe_serve/context.py
@@ -299,6 +299,7 @@ class _RunContext:
                     input_dir,
                     self.workspace,
                     extra_excludes=self.environment_patch.copy_excludes,
+                    respect_source_gitignore=True,
                     reject_collisions=True,
                 )
             else:
@@ -306,6 +307,7 @@ class _RunContext:
                     input_dir,
                     self.workspace,
                     extra_excludes=self.environment_patch.copy_excludes,
+                    respect_source_gitignore=True,
                 )
 
             if self.evaluator_path is not None:
@@ -646,6 +648,14 @@ class _RunContext:
     def _source_gitignored_paths(src: Path) -> frozenset[tuple[str, ...]]:
         """Return untracked paths ignored by Git below ``src``."""
 
+        repository = subprocess.run(
+            ["git", "-C", str(src), "rev-parse", "--is-inside-work-tree"],
+            capture_output=True,
+            check=False,
+        )
+        if repository.returncode != 0:
+            return frozenset()
+
         result = subprocess.run(
             [
                 "git",
@@ -750,10 +760,12 @@ class _RunContext:
 
     _TRUSTED_INPUT_PATHS: tuple[str, ...] = (
         "OBJECTIVE.md",
+        "CANDIDATE_CONTRACT.md",
         "vibeserve.input.toml",
         "reference",
         "accuracy_checker",
         "benchmark",
+        "evaluator_support",
         "_input_libs",
         "_evaluator",
     )

--- a/src/vibe_serve/loops/agent/templates/_modality/kv_store/implementer.j2
+++ b/src/vibe_serve/loops/agent/templates/_modality/kv_store/implementer.j2
@@ -2,10 +2,12 @@ You are building an in-memory key-value store server that speaks the Redis RESP2
 
 ## Required interface
 
+Read `CANDIDATE_CONTRACT.md` before editing; it is the normative protocol,
+lifecycle, concurrency, and process-ownership contract.
+
 Your server must:
 - Listen on the given TCP port speaking Redis RESP2
 - Support commands: GET, SET, DEL, HSET, HMSET, HGETALL, PING, FLUSHDB, DBSIZE, COMMAND, HELLO, CLIENT
-- The HELLO command should return `+OK\r\n` (signals RESP2-only to clients)
 - Ship a `./run.sh <port>` launcher the judge and profiler can use to start the server
 
 ## Constraints
@@ -15,4 +17,7 @@ Your server must:
 
 ## Accuracy-checker compatibility
 
-The accuracy checker (`accuracy_checker/checker.py --port <port>`) drives the same deterministic operation sequence against your server and a Redis oracle. Every response must match byte-for-byte. The checker uses `redis-py` with `protocol=2`.
+The trusted accuracy checker launches `./run.sh` automatically, compares decoded
+command semantics with a Redis oracle, exercises raw RESP2 framing and pipelines,
+and checks shared state under concurrent load. The checker uses `redis-py` with
+`protocol=2`.

--- a/src/vibe_serve/loops/agent/templates/_modality/kv_store/judge.j2
+++ b/src/vibe_serve/loops/agent/templates/_modality/kv_store/judge.j2
@@ -4,19 +4,26 @@ This is a TCP server speaking the Redis RESP2 wire protocol — **not** an HTTP 
 
 ## Two gates: correctness, then the latency SLA
 
-Performance is meaningless until the accuracy checker passes — treat any correctness failure as an automatic round **fail** regardless of throughput, and name the failing operations in `feedback`. The OBJECTIVE's p99 SLA is the second gate: if READ or UPDATE p99 exceeds the bound at the concurrent load, the round **fails** even if throughput improved. Name the regression.
+Performance is meaningless until the accuracy checker passes. Treat any
+correctness failure as an automatic round **fail** and name the failing
+operations in `feedback`. The trusted benchmark enforces the throughput floor,
+READ/UPDATE p99 bounds, complete CPU accounting, and saturation check before the
+framework accepts its `ops_per_cpu_sec` score.
 
-## Reading the performance number (do not eyeball it)
-
-Set `perf_metric` (`perf_unit` = `ops/sec`) from the benchmark's **`PERF_METRIC: <n> ops/sec`** line — the median of several fixed-duration runs. Do **not** read it from the human-readable text, a per-phase line, or `operationcount` (a common mistake is reporting the op count `100000` as throughput). If `PERF_COV:` (run-to-run spread) is high (e.g. > 10%), say so in `analysis` and treat small round-over-round deltas as noise.
+Read `CANDIDATE_CONTRACT.md` and reject implementations that violate its
+protocol, shared-state, or process-ownership requirements.
 
 ## Reward-hack detection (do this even when all checks pass)
 
 Reward-hacking here means the server satisfies the checker's fixed sequence **without a real data structure** — canned/templated responses, a replay of expected outputs, or a constant reply per command. Verify the store is real: after different `SET`s to one key a `GET` must return the most recent value, and a fresh key/value the checker never used must round-trip. A server that passes the deterministic sequence but cannot round-trip a novel key is reward-hacking — **verdict is fail**; name the offending function / branch in `feedback`.
 
-**Accuracy-checker interface** (always required): start the candidate with `./run.sh <port>`, then run `python {{ accuracy_checker_path }}/checker.py --port <port>`. The checker runs sequential and concurrent phases and diffs every response against a Redis oracle.
+**Accuracy checker** (always required): run `{{ accuracy_command }}` exactly as
+shown. It owns candidate startup and runs semantic, raw RESP2, sequential, and
+concurrent checks against a Redis oracle.
 
-**Benchmark**: start the candidate, then run `python {{ bench_path }}/benchmark.py --port <port>`. Requires Java 8+; downloads YCSB 0.17.0 (Redis binding) to `{{ bench_path }}/ycsb/` on first run.
+**Benchmark**: run `{{ benchmark_command }}` exactly as shown. It owns candidate
+startup, writes trusted JSON when requested, and exits nonzero when any validity
+gate fails.
 
 **Protocol compliance**: responses must be valid RESP2 encoding. Malformed responses (wrong type prefix, missing CRLF, incorrect bulk string length) are immediate failures.
 

--- a/src/vibe_serve/loops/agent/templates/_modality/kv_store/profiler.j2
+++ b/src/vibe_serve/loops/agent/templates/_modality/kv_store/profiler.j2
@@ -5,8 +5,10 @@ A CPU-bound TCP server; key axes are **throughput** (ops/sec), **p99 latency** (
 ## How to profile
 
 1. Start the server: `./run.sh 6380 &`
-2. Find its PID: `PID=$(lsof -ti tcp:6380 -s tcp:LISTEN)`
-3. Drive load in the background: `uv run python {{ bench_path }}/benchmark.py --port 6380 &`
+2. Record the launch PID and inspect all processes in its process group; the
+   scored benchmark accounts for the complete stable group, not one PID.
+3. Drive load in the background by appending `--port 6380` to
+   `{{ benchmark_command }}` so the diagnostic run uses the already-running server.
 4. Sample it:
    - Python: `py-spy record -o /tmp/profile.svg --pid $PID --duration 10`
    - Native (C / Rust / Go): `perf record -p $PID -g -- sleep 10 && perf report`
@@ -22,4 +24,6 @@ the measurement pick the optimization, not a prior.
 
 ## Performance metric
 
-Headline is **ops/sec** from YCSB Workload A. Set `perf_metric` from the benchmark's machine-readable `PERF_METRIC: <n> ops/sec` line (not the human-readable throughput text); `perf_unit` is `ops/sec`.
+Headline metric is `ops_per_cpu_sec` from the benchmark JSON (maximize). The
+trusted framework owns the scored run; profiling numbers are diagnostic and
+must not replace that score.

--- a/src/vibe_serve/loops/agent/templates/_modality/kv_store/single_agent.j2
+++ b/src/vibe_serve/loops/agent/templates/_modality/kv_store/single_agent.j2
@@ -1,0 +1,15 @@
+## Modality: KV store (Redis RESP2 compatible)
+
+Read `CANDIDATE_CONTRACT.md` first. Implement a real, shared, binary-safe RESP2
+store launched by `./run.sh <port>`; this is not HTTP and has no `/health`
+endpoint.
+
+Run `{{ accuracy_command }}` before declaring PASS. It owns candidate startup
+and checks command semantics, raw framing, pipelines, wrong types, and
+concurrency. Then run `{{ benchmark_command }}` with its JSON output option.
+The framework accepts only a valid `ops_per_cpu_sec` score after the benchmark's
+throughput, READ/UPDATE p99, CPU-accounting, and saturation gates pass.
+
+Reject canned replies and fixed-sequence implementations: novel keys and values
+must round-trip, overwrites must be visible across connections, and every worker
+must observe one shared store.

--- a/src/vibe_serve/loops/agent/templates/single_agent_round_prompt.j2
+++ b/src/vibe_serve/loops/agent/templates/single_agent_round_prompt.j2
@@ -13,6 +13,9 @@ Do all three before returning. The framework records the structured response bel
 
 {{ objective }}
 {% endif %}
+{% if modality %}
+{% include "_modality/" ~ modality ~ "/single_agent.j2" ignore missing %}
+{% endif %}
 
 {% if runtime_notes %}
 ## Runtime environment

--- a/tests/loops/agent/test_kv_store_modality.py
+++ b/tests/loops/agent/test_kv_store_modality.py
@@ -22,7 +22,7 @@ def test_kv_store_input_bundle_loads():
     bundle = load_input_bundle(_PROJECT_ROOT / "examples" / "kv-store", project_root=_PROJECT_ROOT)
     assert bundle.domain.value == "generic"
     assert bundle.benchmark_result is not None
-    assert bundle.benchmark_result.metric == "throughput_ops_per_sec"
+    assert bundle.benchmark_result.metric == "ops_per_cpu_sec"
 
 
 def test_kv_store_judge_prompt_mentions_resp2_not_http():

--- a/tests/loops/agent/test_kv_store_modality.py
+++ b/tests/loops/agent/test_kv_store_modality.py
@@ -23,26 +23,67 @@ def test_kv_store_input_bundle_loads():
     assert bundle.domain.value == "generic"
     assert bundle.benchmark_result is not None
     assert bundle.benchmark_result.metric == "ops_per_cpu_sec"
+    command = bundle.benchmark_command_display
+    assert "--min-throughput-ops-per-sec 10000" in command
+    assert "--max-read-p99-ms 1.0" in command
+    assert "--saturation-probe-client-procs 8" in command
 
 
-def test_kv_store_judge_prompt_mentions_resp2_not_http():
+def test_kv_store_judge_prompt_uses_production_commands_and_score():
+    accuracy = "uv run python accuracy_checker/checker.py"
+    benchmark = (
+        "uv run python benchmark/benchmark.py --client-procs 4 --min-throughput-ops-per-sec 10000"
+    )
     output = render_template(
         "judge_prompt.j2",
         template_dir=_TEMPLATE_DIR,
         modality="kv_store",
         interface="service",
         domain_judge="",
-        accuracy_command="uv run python accuracy_checker/checker.py",
-        benchmark_command="uv run python benchmark/benchmark.py",
+        accuracy_command=accuracy,
+        benchmark_command=benchmark,
         pass_criteria="PC",
         retry=1,
         runtime_notes="",
         env_kind="local",
         objective="OBJ",
-        accuracy_checker_path="accuracy_checker",
-        bench_path="benchmark",
     )
     assert "RESP2" in output
     assert "HTTP server" in output
     assert "VibeServeModel" not in output
     assert "p99" in output
+    assert accuracy in output
+    assert benchmark in output
+    assert "ops_per_cpu_sec" in output
+    assert "python /checker.py" not in output
+    assert "PERF_METRIC: <n> ops/sec" not in output
+
+
+def test_kv_store_single_agent_includes_modality_contract():
+    output = render_template(
+        "single_agent_round_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        modality="kv_store",
+        interface="service",
+        env_kind="local",
+        domain_single_agent="",
+        domain_profiler="",
+        task="TASK",
+        pass_criteria="PC",
+        retry=1,
+        feedback=None,
+        objective="Headline metric: ops_per_cpu_sec (maximize).",
+        profile_focus="",
+        profiler_kind="none",
+        profiler_support_name=None,
+        profiler_mcp_name=None,
+        supports_torch_profiler=False,
+        benchmark_command="uv run python benchmark/benchmark.py",
+        accuracy_command="uv run python accuracy_checker/checker.py",
+        reference_path="reference/seed_server.py",
+        runtime_notes="",
+    )
+    assert "CANDIDATE_CONTRACT.md" in output
+    assert "RESP2" in output
+    assert "ops_per_cpu_sec" in output
+    assert "canned replies" in output

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -48,6 +48,13 @@ def test_input_copy_respects_source_gitignore(tmp_path):
     (source / "build").mkdir()
     (source / "build" / "cache").write_text("stale")
     subprocess.run(["git", "init", "-q"], cwd=source, check=True)
+    (source / ".git" / "info" / "exclude").write_text("/candidate/\n/benchmark/ycsb/\n")
+    (source / "candidate").mkdir()
+    (source / "candidate" / "run.sh").write_text("stale optimized candidate\n")
+    (source / "benchmark").mkdir()
+    (source / "benchmark" / "benchmark.py").write_text("print('tracked evaluator')\n")
+    (source / "benchmark" / "ycsb").mkdir()
+    (source / "benchmark" / "ycsb" / "download").write_text("stale download\n")
 
     destination = tmp_path / "workspace"
     ctx = _minimal_copy_context(destination)
@@ -56,6 +63,9 @@ def test_input_copy_respects_source_gitignore(tmp_path):
     assert (destination / "main.rs").is_file()
     assert not (destination / "candidate.so").exists()
     assert not (destination / "build").exists()
+    assert not (destination / "candidate").exists()
+    assert (destination / "benchmark" / "benchmark.py").is_file()
+    assert not (destination / "benchmark" / "ycsb").exists()
 
 
 def test_trusted_input_changes_compare_against_initial_commit(tmp_path):

--- a/tests/test_kv_store_bundle.py
+++ b/tests/test_kv_store_bundle.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import os
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_BENCHMARK_PATH = _ROOT / "examples" / "kv-store" / "benchmark" / "benchmark.py"
+_SPEC = importlib.util.spec_from_file_location("kv_store_benchmark", _BENCHMARK_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+benchmark = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = benchmark
+_SPEC.loader.exec_module(benchmark)
+
+
+def _write_proc_stat(
+    proc_root: Path,
+    pid: int,
+    *,
+    parent: int,
+    group: int,
+    starttime: int,
+    user_ticks: int,
+    system_ticks: int,
+) -> None:
+    process = proc_root / str(pid)
+    process.mkdir(parents=True)
+    fields = [
+        "S",
+        str(parent),
+        str(group),
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        str(user_ticks),
+        str(system_ticks),
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",
+        str(starttime),
+    ]
+    (process / "stat").write_text(f"{pid} (worker with parens) {' '.join(fields)}\n")
+
+
+def _valid_round() -> dict:
+    return {
+        "cpu_valid": True,
+        "lat": {
+            "READ": {"p99": 900.0},
+            "UPDATE": {"p99": 800.0},
+        },
+    }
+
+
+def _ycsb_archive() -> bytes:
+    data = io.BytesIO()
+    with tarfile.open(fileobj=data, mode="w:gz") as tar:
+        content = b"#!/bin/sh\n"
+        member = tarfile.TarInfo("ycsb-redis-binding-0.17.0/bin/ycsb.sh")
+        member.mode = 0o755
+        member.size = len(content)
+        tar.addfile(member, io.BytesIO(content))
+    return data.getvalue()
+
+
+def test_process_group_snapshot_aggregates_all_processes(tmp_path):
+    _write_proc_stat(tmp_path, 10, parent=1, group=10, starttime=100, user_ticks=10, system_ticks=2)
+    _write_proc_stat(
+        tmp_path, 11, parent=10, group=10, starttime=101, user_ticks=20, system_ticks=3
+    )
+    _write_proc_stat(tmp_path, 12, parent=1, group=12, starttime=102, user_ticks=99, system_ticks=1)
+
+    assert benchmark._server_processes(6380, process_group=10, proc_root=tmp_path) == {10, 11}
+    assert benchmark._cpu_snapshot(6380, process_group=10, proc_root=tmp_path) == {
+        (10, 100): 12,
+        (11, 101): 23,
+    }
+
+
+def test_listener_discovery_handles_shared_socket_and_descendant(tmp_path):
+    (tmp_path / "net").mkdir()
+    (tmp_path / "net" / "tcp").write_text(
+        "header\n0: 0100007F:18EC 00000000:0000 0A 0 0 0 0 0 12345\n"
+    )
+    (tmp_path / "net" / "tcp6").write_text("header\n")
+    for pid in (20, 21):
+        _write_proc_stat(
+            tmp_path,
+            pid,
+            parent=1 if pid == 20 else 20,
+            group=20,
+            starttime=pid,
+            user_ticks=1,
+            system_ticks=1,
+        )
+        (tmp_path / str(pid) / "fd").mkdir()
+    os.symlink("socket:[12345]", tmp_path / "20" / "fd" / "3")
+
+    assert benchmark._listener_pids(6380, tmp_path) == {20}
+    assert benchmark._server_processes(6380, proc_root=tmp_path) == {20, 21}
+
+
+def test_cpu_delta_rejects_pid_reuse_or_membership_change():
+    assert benchmark._cpu_delta_seconds({(1, 10): 4}, {(1, 11): 8}) is None
+    assert benchmark._cpu_delta_seconds({(1, 10): 4}, {(1, 10): 4}) is None
+
+
+def test_candidate_lifecycle_launches_and_reaps_process_group(tmp_path):
+    launcher = tmp_path / "run.sh"
+    launcher.write_text(
+        "#!/usr/bin/env python3\n"
+        "import socket, sys\n"
+        "sock = socket.socket()\n"
+        "sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\n"
+        "sock.bind(('127.0.0.1', int(sys.argv[1])))\n"
+        "sock.listen()\n"
+        "while True:\n"
+        "    conn, _ = sock.accept()\n"
+        "    conn.close()\n"
+    )
+    launcher.chmod(0o755)
+
+    with benchmark.candidate_server(workspace=tmp_path) as candidate:
+        assert candidate is not None
+        os.kill(candidate.pid, 0)
+        pid = candidate.pid
+
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)
+
+
+def test_validity_threshold_boundaries():
+    checks, reasons = benchmark._evaluate_validity(
+        throughput=10000.0,
+        cpu_per_op=10.0,
+        rounds=[_valid_round()],
+        read_p99_ms=0.999,
+        update_p99_ms=0.5,
+        saturation_gain_pct=10.0,
+        min_throughput=10000.0,
+        max_read_p99_ms=1.0,
+        max_update_p99_ms=1.0,
+        max_saturation_gain_pct=10.0,
+    )
+    assert all(checks.values())
+    assert reasons == []
+
+
+@pytest.mark.parametrize(
+    ("overrides", "failed_check"),
+    [
+        ({"throughput": 9999.9}, "throughput_floor"),
+        ({"read_p99_ms": 1.0}, "read_p99"),
+        ({"update_p99_ms": None}, "update_p99"),
+        ({"cpu_per_op": float("nan")}, "score_available"),
+        ({"saturation_gain_pct": 10.1}, "saturation"),
+        ({"saturation_gain_pct": -10.1}, "saturation"),
+        ({"rounds": [{**_valid_round(), "cpu_valid": False}]}, "cpu_samples"),
+    ],
+)
+def test_validity_rejects_each_invalid_gate(overrides, failed_check):
+    arguments = {
+        "throughput": 10000.0,
+        "cpu_per_op": 10.0,
+        "rounds": [_valid_round()],
+        "read_p99_ms": 0.9,
+        "update_p99_ms": 0.8,
+        "saturation_gain_pct": 10.0,
+        "min_throughput": 10000.0,
+        "max_read_p99_ms": 1.0,
+        "max_update_p99_ms": 1.0,
+        "max_saturation_gain_pct": 10.0,
+    }
+    arguments.update(overrides)
+    checks, reasons = benchmark._evaluate_validity(**arguments)
+    assert checks[failed_check] is False
+    assert reasons
+
+
+def test_worst_latency_uses_all_rounds():
+    rounds = [
+        {"lat": {"READ": {"p99": 500.0}}},
+        {"lat": {"READ": {"p99": 1200.0}}},
+    ]
+    assert benchmark._worst_latency_ms(rounds, "READ") == 1.2
+
+
+def test_safe_extract_rejects_traversal(tmp_path):
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode="w:gz") as tar:
+        member = tarfile.TarInfo("../escape")
+        member.size = 1
+        tar.addfile(member, io.BytesIO(b"x"))
+    archive.seek(0)
+    with tarfile.open(fileobj=archive, mode="r:gz") as tar:
+        with pytest.raises(ValueError, match="unsafe YCSB archive path"):
+            benchmark._safe_extract(tar, tmp_path)
+
+
+def test_safe_extract_rejects_links(tmp_path):
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode="w:gz") as tar:
+        member = tarfile.TarInfo("link")
+        member.type = tarfile.SYMTYPE
+        member.linkname = "target"
+        tar.addfile(member)
+    archive.seek(0)
+    with tarfile.open(fileobj=archive, mode="r:gz") as tar:
+        with pytest.raises(ValueError, match="unsupported YCSB archive member"):
+            benchmark._safe_extract(tar, tmp_path)
+
+
+def test_ycsb_install_is_verified_atomic_and_reused(tmp_path, monkeypatch):
+    archive = _ycsb_archive()
+    cache = tmp_path / ".cache"
+    home = cache / "ycsb-redis-binding-0.17.0"
+    monkeypatch.setattr(benchmark, "YCSB_CACHE", cache)
+    monkeypatch.setattr(benchmark, "YCSB_HOME", home)
+    monkeypatch.setattr(benchmark, "YCSB_SHA256", hashlib.sha256(archive).hexdigest())
+    monkeypatch.setattr(benchmark.urllib.request, "urlopen", lambda _: io.BytesIO(archive))
+    home.mkdir(parents=True)
+    (home / "partial").write_text("incomplete")
+
+    benchmark._ensure_ycsb()
+
+    assert (home / "bin" / "ycsb.sh").is_file()
+    assert not (home / "partial").exists()
+    monkeypatch.setattr(
+        benchmark.urllib.request,
+        "urlopen",
+        lambda _: pytest.fail("verified cache should be reused"),
+    )
+    benchmark._ensure_ycsb()
+
+
+def test_ycsb_checksum_failure_does_not_install(tmp_path, monkeypatch):
+    archive = _ycsb_archive()
+    cache = tmp_path / ".cache"
+    home = cache / "ycsb-redis-binding-0.17.0"
+    monkeypatch.setattr(benchmark, "YCSB_CACHE", cache)
+    monkeypatch.setattr(benchmark, "YCSB_HOME", home)
+    monkeypatch.setattr(benchmark, "YCSB_SHA256", "0" * 64)
+    monkeypatch.setattr(benchmark.urllib.request, "urlopen", lambda _: io.BytesIO(archive))
+
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        benchmark._ensure_ycsb()
+    assert not home.exists()

--- a/tests/test_kv_store_bundle.py
+++ b/tests/test_kv_store_bundle.py
@@ -11,12 +11,26 @@ from pathlib import Path
 import pytest
 
 _ROOT = Path(__file__).resolve().parents[1]
-_BENCHMARK_PATH = _ROOT / "examples" / "kv-store" / "benchmark" / "benchmark.py"
-_SPEC = importlib.util.spec_from_file_location("kv_store_benchmark", _BENCHMARK_PATH)
-assert _SPEC is not None and _SPEC.loader is not None
-benchmark = importlib.util.module_from_spec(_SPEC)
-sys.modules[_SPEC.name] = benchmark
-_SPEC.loader.exec_module(benchmark)
+_KV_STORE = _ROOT / "examples" / "kv-store"
+if str(_KV_STORE) not in sys.path:
+    sys.path.insert(0, str(_KV_STORE))
+
+from evaluator_support import (  # noqa: E402
+    lifecycle,
+    procfs_cpu,
+    validity,
+    ycsb,
+)
+
+
+def _load_benchmark():
+    path = _KV_STORE / "benchmark" / "benchmark.py"
+    spec = importlib.util.spec_from_file_location("kv_store_benchmark", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _write_proc_stat(
@@ -84,8 +98,8 @@ def test_process_group_snapshot_aggregates_all_processes(tmp_path):
     )
     _write_proc_stat(tmp_path, 12, parent=1, group=12, starttime=102, user_ticks=99, system_ticks=1)
 
-    assert benchmark._server_processes(6380, process_group=10, proc_root=tmp_path) == {10, 11}
-    assert benchmark._cpu_snapshot(6380, process_group=10, proc_root=tmp_path) == {
+    assert procfs_cpu.server_processes(6380, process_group=10, proc_root=tmp_path) == {10, 11}
+    assert procfs_cpu.cpu_snapshot(6380, process_group=10, proc_root=tmp_path) == {
         (10, 100): 12,
         (11, 101): 23,
     }
@@ -110,13 +124,13 @@ def test_listener_discovery_handles_shared_socket_and_descendant(tmp_path):
         (tmp_path / str(pid) / "fd").mkdir()
     os.symlink("socket:[12345]", tmp_path / "20" / "fd" / "3")
 
-    assert benchmark._listener_pids(6380, tmp_path) == {20}
-    assert benchmark._server_processes(6380, proc_root=tmp_path) == {20, 21}
+    assert procfs_cpu.listener_pids(6380, tmp_path) == {20}
+    assert procfs_cpu.server_processes(6380, proc_root=tmp_path) == {20, 21}
 
 
 def test_cpu_delta_rejects_pid_reuse_or_membership_change():
-    assert benchmark._cpu_delta_seconds({(1, 10): 4}, {(1, 11): 8}) is None
-    assert benchmark._cpu_delta_seconds({(1, 10): 4}, {(1, 10): 4}) is None
+    assert procfs_cpu.cpu_delta_seconds({(1, 10): 4}, {(1, 11): 8}) is None
+    assert procfs_cpu.cpu_delta_seconds({(1, 10): 4}, {(1, 10): 4}) is None
 
 
 def test_candidate_lifecycle_launches_and_reaps_process_group(tmp_path):
@@ -134,8 +148,9 @@ def test_candidate_lifecycle_launches_and_reaps_process_group(tmp_path):
     )
     launcher.chmod(0o755)
 
-    with benchmark.candidate_server(workspace=tmp_path) as candidate:
-        assert candidate is not None
+    with lifecycle.candidate_server(workspace=tmp_path) as candidate:
+        assert candidate.pid is not None
+        assert candidate.process_group is not None
         os.kill(candidate.pid, 0)
         pid = candidate.pid
 
@@ -143,8 +158,15 @@ def test_candidate_lifecycle_launches_and_reaps_process_group(tmp_path):
         os.kill(pid, 0)
 
 
+def test_external_port_yields_resolved_target_without_ownership():
+    with lifecycle.candidate_server(workspace=Path("/tmp"), port=6380) as candidate:
+        assert candidate.port == 6380
+        assert candidate.process_group is None
+        assert candidate.pid is None
+
+
 def test_validity_threshold_boundaries():
-    checks, reasons = benchmark._evaluate_validity(
+    checks, reasons = validity.evaluate_validity(
         throughput=10000.0,
         cpu_per_op=10.0,
         rounds=[_valid_round()],
@@ -186,12 +208,13 @@ def test_validity_rejects_each_invalid_gate(overrides, failed_check):
         "max_saturation_gain_pct": 10.0,
     }
     arguments.update(overrides)
-    checks, reasons = benchmark._evaluate_validity(**arguments)
+    checks, reasons = validity.evaluate_validity(**arguments)
     assert checks[failed_check] is False
     assert reasons
 
 
 def test_worst_latency_uses_all_rounds():
+    benchmark = _load_benchmark()
     rounds = [
         {"lat": {"READ": {"p99": 500.0}}},
         {"lat": {"READ": {"p99": 1200.0}}},
@@ -208,7 +231,7 @@ def test_safe_extract_rejects_traversal(tmp_path):
     archive.seek(0)
     with tarfile.open(fileobj=archive, mode="r:gz") as tar:
         with pytest.raises(ValueError, match="unsafe YCSB archive path"):
-            benchmark._safe_extract(tar, tmp_path)
+            ycsb.safe_extract(tar, tmp_path)
 
 
 def test_safe_extract_rejects_links(tmp_path):
@@ -221,41 +244,36 @@ def test_safe_extract_rejects_links(tmp_path):
     archive.seek(0)
     with tarfile.open(fileobj=archive, mode="r:gz") as tar:
         with pytest.raises(ValueError, match="unsupported YCSB archive member"):
-            benchmark._safe_extract(tar, tmp_path)
+            ycsb.safe_extract(tar, tmp_path)
 
 
 def test_ycsb_install_is_verified_atomic_and_reused(tmp_path, monkeypatch):
     archive = _ycsb_archive()
     cache = tmp_path / ".cache"
     home = cache / "ycsb-redis-binding-0.17.0"
-    monkeypatch.setattr(benchmark, "YCSB_CACHE", cache)
-    monkeypatch.setattr(benchmark, "YCSB_HOME", home)
-    monkeypatch.setattr(benchmark, "YCSB_SHA256", hashlib.sha256(archive).hexdigest())
-    monkeypatch.setattr(benchmark.urllib.request, "urlopen", lambda _: io.BytesIO(archive))
+    sha = hashlib.sha256(archive).hexdigest()
+    monkeypatch.setattr(ycsb.urllib.request, "urlopen", lambda _: io.BytesIO(archive))
     home.mkdir(parents=True)
     (home / "partial").write_text("incomplete")
 
-    benchmark._ensure_ycsb()
+    ycsb.ensure_ycsb(cache=cache, home=home, sha256=sha)
 
     assert (home / "bin" / "ycsb.sh").is_file()
     assert not (home / "partial").exists()
     monkeypatch.setattr(
-        benchmark.urllib.request,
+        ycsb.urllib.request,
         "urlopen",
         lambda _: pytest.fail("verified cache should be reused"),
     )
-    benchmark._ensure_ycsb()
+    ycsb.ensure_ycsb(cache=cache, home=home, sha256=sha)
 
 
 def test_ycsb_checksum_failure_does_not_install(tmp_path, monkeypatch):
     archive = _ycsb_archive()
     cache = tmp_path / ".cache"
     home = cache / "ycsb-redis-binding-0.17.0"
-    monkeypatch.setattr(benchmark, "YCSB_CACHE", cache)
-    monkeypatch.setattr(benchmark, "YCSB_HOME", home)
-    monkeypatch.setattr(benchmark, "YCSB_SHA256", "0" * 64)
-    monkeypatch.setattr(benchmark.urllib.request, "urlopen", lambda _: io.BytesIO(archive))
+    monkeypatch.setattr(ycsb.urllib.request, "urlopen", lambda _: io.BytesIO(archive))
 
     with pytest.raises(RuntimeError, match="checksum mismatch"):
-        benchmark._ensure_ycsb()
+        ycsb.ensure_ycsb(cache=cache, home=home, sha256="0" * 64)
     assert not home.exists()


### PR DESCRIPTION
## Problem

The KV-store target selected `ops_per_cpu_sec` as its score, but the surrounding evaluator contract was not trustworthy enough to use that metric safely. Prompt text still instructed agents to report throughput, framework-rendered evaluator paths were invalid, throughput and p99 requirements were descriptive rather than enforced, and CPU accounting sampled only one listener PID even though valid candidates may use worker processes or `SO_REUSEPORT`. Fresh workspaces could also inherit ignored local candidates and downloaded YCSB artifacts, contaminating optimization runs.

## Solution

Make the KV-store bundle a self-contained, Linux-only trusted evaluator:

- Add `CANDIDATE_CONTRACT.md` as the normative RESP2, lifecycle, process ownership, and concurrency contract.
- Let the checker and benchmark launch `./run.sh <port>` in an isolated process group and always reap it; retain optional `--port` for diagnostics.
- Aggregate procfs CPU across the complete stable candidate process set, keyed by PID and start time, and reject incomplete or changing accounting.
- Enforce the 10k throughput floor, READ/UPDATE p99 below 1 ms, finite positive CPU score, and a 4→8-client saturation plateau before accepting `ops_per_cpu_sec`.
- Expand correctness coverage for binary RESP2, required commands, wrong types, invalid arity, fragmented/pipelined frames, shared hot records, and split-brain state.
- Align implementer, judge, profiler, and single-agent prompts with manifest commands and framework-owned score extraction.
- Respect source Git ignores while materializing inputs, and checksum, safely extract, lock, and atomically cache YCSB under `.cache`.
- Add a mutable Python seed launcher, focused regression tests, and a Linux KV-store CI smoke job.

The generic benchmark-result schema remains unchanged; KV-specific thresholds and validity policy stay inside the trusted bundle. Generic Linux `--profiler auto` still resolves to `none`, which is now documented rather than hidden by prompt claims.

## Verification

The reference seed passes the expanded semantic/concurrency checker and the self-owned benchmark lifecycle. A five-repeat current-host calibration at the scored 4-client topology produced 32k–49k ops/sec, so the retained 10k floor remains a conservative collapse guard.

Prompt changes are covered by production-context render assertions for judge and single-agent modes; no golden prompt snapshot update was required, and the existing prompt snapshot/domain/interface suites pass.

### Correctness properties

- Every trusted evaluator invocation owns and cleans up its candidate process group unless an explicit diagnostic port is supplied.
- Scored CPU includes every stable process in the candidate group; external-port mode includes all listener owners and descendants, with PID reuse detected by start time.
- Missing, non-finite, zero, unstable, or incomplete CPU accounting fails the benchmark instead of degrading to a misleading score.
- Throughput, worst-run READ/UPDATE p99, and saturation validity are machine-enforced before the framework accepts `ops_per_cpu_sec`.
- RESP2 commands are atomic, binary-safe, correctly framed, and share one logical store across connections and workers.
- Contract, checker, benchmark, reference, and evaluator support remain trusted inputs; ignored local candidates, builds, and YCSB downloads are not copied into fresh workspaces.
- The YCSB archive is version- and SHA-256-pinned, traversal/link members are rejected, and installation is atomic and reusable.

### Testing

- `./scripts/check_format.sh` → passed, 238 files already formatted
- `./scripts/check_lint.sh` → passed
- `git diff --check` → passed
- `uv run pytest -q` → 1,425 passed, 5 skipped
- `uv run pytest tests/test_kv_store_bundle.py tests/loops/agent/test_kv_store_modality.py tests/test_context.py tests/loops/agent/test_prompt_snapshots.py tests/loops/agent/test_prompt_domain_leakage.py tests/loops/agent/test_interface_modes.py -q` → 70 passed
- `examples/kv-store/run_test.sh` → expanded checker passed with 0 mismatches; benchmark emitted a valid CPU-efficiency score
- Five-repeat scored-topology seed calibration → 32,366–48,979 ops/sec; median 35,373 ops/sec
