### PR TITLE
Add Linux CPU profiler

### DIFF
--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -14,7 +14,7 @@ Several flags look independent, but they combine into one execution contract:
 | Evaluation interface | `--interface` | Agent loop only. Whether evaluator-owned code invokes the candidate directly or communicates with a service. |
 | Compute backend | `--backend` | Hardware/runtime target: `cuda`, `metal`, `trainium`, or `cpu`. |
 | Runtime environment | `--docker`, `--modal` | Where agent commands execute: local shell, Docker container, or Modal-backed workflow. |
-| Profiler | `--profiler` | Bottleneck evidence source: `nsys`, `torch`, `neuron`, `macos_cpu`, or `auto`. |
+| Profiler | `--profiler` | Bottleneck evidence source: `nsys`, `torch`, `neuron`, `macos_cpu`, `linux_cpu`, or `auto`. |
 | Domain | `[agent].domain` in `vibesys.input.toml` | Agent-loop problem-space package, such as `llm-serving` or `generic`. |
 | Modality | `--modality` | Per-task I/O contract, such as `text_generation` or `speech_to_text`. |
 | Skills | `--skills-dir`, `--no-skills` | Candidate skill roots and the ablation switch that disables skill loading. |
@@ -61,7 +61,7 @@ prompts and input-owned candidate-contract documentation.
 | `cuda` | NVIDIA GPU serving systems. | Local, Docker, Modal. | Selects/reselects a GPU and can monitor contention. | Local/Docker use `nsys`; Modal uses `torch` when `--profiler auto`. |
 | `metal` | Apple Silicon / MPS targets. | Local only. | No device selection or monitor. | Local `auto` resolves through the local runtime default. |
 | `trainium` | AWS Trainium / NeuronCore targets. | Local and Docker; Modal unsupported. | Forwards `/dev/neuron*` in Docker; no per-device selection. | `auto` resolves to `neuron`. |
-| `cpu` | CPU-only service/data-structure targets. | Local only in the current merged code. | No device selection or monitor. | Generic workloads on macOS select `macos_cpu`; other systems select no profiler. |
+| `cpu` | CPU-only service/data-structure targets. | Local and Docker. | No device selection or monitor. | Generic workloads on Linux select `linux_cpu`; macOS selects `macos_cpu`; other systems select no profiler. |
 
 When a backend rejects a runtime environment, it should fail before agent work
 starts with an actionable error.
@@ -86,6 +86,7 @@ Modal is active.
 | `torch` | PyTorch profiler. Used for in-process Python profiling and Modal GPU dispatch. |
 | `neuron` | AWS Neuron profiler for Trainium. |
 | `macos_cpu` | Instruments Time Profiler with a supported `/usr/bin/sample` fallback. |
+| `linux_cpu` | Linux `perf` profiler for native and mixed-language CPU workloads. |
 
 `--modal --profiler nsys` is rejected by the CLI because Modal runs must use the
 torch profiler path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ where = ["src"]
 include = ["vibesys*"]
 
 [tool.setuptools.package-data]
-vibesys = ["templates/*.j2", "templates/_backend/*/*.j2", "domains/README.md", "domains/*/templates/*.md", "loops/agent/templates/*.j2", "loops/agent/templates/_modality/*/*.j2", "loops/evolve/templates/*.j2", "loops/plain/templates/*.j2", "loops/plain/templates/*/*.j2"]
+vibesys = ["templates/*.j2", "templates/_backend/*/*.j2", "domains/README.md", "domains/*/templates/*.md", "loops/agent/templates/*.j2", "loops/agent/templates/profilers/*.j2", "loops/agent/templates/_modality/*/*.j2", "loops/evolve/templates/*.j2", "loops/plain/templates/*.j2", "loops/plain/templates/*/*.j2"]
 
 [dependency-groups]
 dev = [

--- a/resources/profilers/linux_cpu/__init__.py
+++ b/resources/profilers/linux_cpu/__init__.py
@@ -1,0 +1,1 @@
+"""Linux CPU profiler support package."""

--- a/resources/profilers/linux_cpu/server.py
+++ b/resources/profilers/linux_cpu/server.py
@@ -1,0 +1,65 @@
+"""MCP tools for collecting a separate Linux native CPU profile."""
+
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from vibesys.linux_cpu_profiler import collect, detect_capability, parse_command, summarize
+
+
+def build_server() -> FastMCP:
+    mcp = FastMCP("vibesys-linux-cpu-profiler")
+
+    @mcp.tool()
+    def capabilities() -> dict:
+        """Report Linux perf availability and host profiling restrictions."""
+        capability = detect_capability()
+        return {
+            "selected": capability.tool.value,
+            "perf_path": capability.perf_path,
+            "perf_version": capability.perf_version,
+            "perf_event_paranoid": capability.perf_event_paranoid,
+            "kptr_restrict": capability.kptr_restrict,
+            "diagnostics": [item.value for item in capability.diagnostics],
+        }
+
+    @mcp.tool()
+    def profile(
+        command: str,
+        output_dir: str = "logs/linux_cpu_profile",
+        timeout: int | None = None,
+        frequency: int = 99,
+        call_graph: str = "fp",
+    ) -> dict:
+        """Profile a diagnostic run. This never supplies a scored benchmark result."""
+        result = collect(
+            parse_command(command),
+            Path(output_dir),
+            timeout=timeout,
+            frequency=frequency,
+            call_graph=call_graph,
+        )
+        return {
+            "status": result.status,
+            "tool": result.tool.value,
+            "output_dir": result.output_dir,
+            "stat_artifact": result.stat_artifact,
+            "record_artifact": result.record_artifact,
+            "report_artifact": result.report_artifact,
+            "metadata": result.metadata,
+            "diagnostics": [item.value for item in result.diagnostics],
+            "counters": list(result.counters),
+            "hot_symbols": list(result.hot_symbols),
+            "summary": result.summary,
+        }
+
+    @mcp.tool()
+    def summary(output_dir: str = "logs/linux_cpu_profile") -> dict:
+        """Summarize a previously collected Linux CPU profile directory."""
+        return summarize(Path(output_dir))
+
+    return mcp
+
+
+if __name__ == "__main__":
+    build_server().run(transport="stdio")

--- a/src/vibesys/backends/local.py
+++ b/src/vibesys/backends/local.py
@@ -37,8 +37,6 @@ _DEFAULT_CPU_IMAGE = "python:3.12-bookworm"
 class LocalBackend:
     """No-device backend (Metal / CPU) — hardware hooks are no-ops."""
 
-    profiler_kind = ProfilerKind.TORCH
-
     def __init__(
         self,
         name: ComputeBackend,
@@ -47,9 +45,11 @@ class LocalBackend:
         log: Callable[[str], None] | None = None,
         image: str | None = None,
         unavailable_reason: str,
+        profiler_kind: ProfilerKind = ProfilerKind.TORCH,
         supports_docker: bool = False,
     ) -> None:
         self.name = name
+        self.profiler_kind = profiler_kind
         self.log_dir = Path(log_dir)
         self._lprint = log or print
         self.image = image
@@ -134,6 +134,7 @@ def metal_backend(
         log_dir,
         log=log,
         image=image,
+        profiler_kind=ProfilerKind.TORCH,
         unavailable_reason=(
             "Docker on macOS can't access Metal/MPS, and Modal does not offer Apple GPUs"
         ),
@@ -152,6 +153,7 @@ def cpu_backend(
         log_dir,
         log=log,
         image=image or _DEFAULT_CPU_IMAGE,
+        profiler_kind=ProfilerKind.LINUX_CPU,
         unavailable_reason="Modal CPU execution is not wired up for this backend",
         supports_docker=True,
     )

--- a/src/vibesys/cli.py
+++ b/src/vibesys/cli.py
@@ -199,6 +199,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
             "'torch' for torch.profiler (works in Modal sandboxes), "
             "'neuron' for AWS neuron-explorer (Trainium/NeuronCores), "
             "'macos_cpu' for Instruments Time Profiler with a sample fallback, "
+            "'linux_cpu' for Linux perf on native CPU workloads, "
             "'auto' picks a domain/backend/environment-appropriate profiler. "
             "Default: auto."
         ),

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -28,11 +28,13 @@ from vibesys.domains.environment import (
     EnvironmentHooks,
     NoopEnvironmentHooks,
 )
+from vibesys.errors import ConfigurationDiagnostic, ConfigurationError
 from vibesys.input_project import materialize_input_project
 from vibesys.llm_client import _build_model
 from vibesys.profilers import (
     ACTIVE_PROFILER_KINDS,
     ProfilerKind,
+    preflight_profiler_kind,
     profiler_definition,
     resolve_profiler_kind,
 )
@@ -202,6 +204,15 @@ class _RunContext:
             backend_profiler_kind=getattr(self.backend_impl, "profiler_kind", None),
             environment_default_profiler_kind=self.run_environment.default_profiler_kind,
         )
+        profiler_preflight = preflight_profiler_kind(self.profiler_kind)
+        if not profiler_preflight.usable:
+            raise ConfigurationError(
+                ConfigurationDiagnostic(
+                    code="profiler_preflight_failed",
+                    stage="profiler_preflight",
+                    message=profiler_preflight.error_message(),
+                )
+            )
 
         self.profiler_support_path: str | None = None
         self.profiler_support_name: str | None = None

--- a/src/vibesys/linux_cpu_profiler.py
+++ b/src/vibesys/linux_cpu_profiler.py
@@ -1,0 +1,451 @@
+"""Capability detection and collection for native Linux CPU profiling."""
+
+from __future__ import annotations
+
+import csv
+import json
+import platform
+import shlex
+import shutil
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from pathlib import Path
+
+
+class LinuxProfilerTool(StrEnum):
+    PERF = "perf"
+    NONE = "none"
+
+
+class DiagnosticCode(StrEnum):
+    NOT_LINUX = "not_linux"
+    PERF_UNAVAILABLE = "perf_unavailable"
+    PERF_STAT_UNAVAILABLE = "perf_stat_unavailable"
+    PERF_RECORD_UNAVAILABLE = "perf_record_unavailable"
+    PERF_REPORT_UNAVAILABLE = "perf_report_unavailable"
+    PERF_EVENT_PARANOID_RESTRICTIVE = "perf_event_paranoid_restrictive"
+    KERNEL_SYMBOLS_RESTRICTED = "kernel_symbols_restricted"
+    COLLECTION_FAILED = "collection_failed"
+
+
+@dataclass(frozen=True)
+class Capability:
+    tool: LinuxProfilerTool
+    perf_path: str | None
+    perf_version: str | None
+    perf_event_paranoid: int | None
+    kptr_restrict: int | None
+    diagnostics: tuple[DiagnosticCode, ...] = ()
+
+
+@dataclass(frozen=True)
+class CollectionResult:
+    status: str
+    tool: LinuxProfilerTool
+    output_dir: str
+    stat_artifact: str | None
+    record_artifact: str | None
+    report_artifact: str | None
+    metadata: str
+    command: tuple[str, ...]
+    diagnostics: tuple[DiagnosticCode, ...]
+    counters: tuple[dict[str, str], ...]
+    hot_symbols: tuple[str, ...]
+    summary: str
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _read_int(path: Path) -> int | None:
+    try:
+        return int(path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+
+
+def detect_capability(
+    *,
+    system: str | None = None,
+    which: Callable[[str], str | None] = shutil.which,
+    run: Runner = subprocess.run,
+) -> Capability:
+    """Report whether Linux ``perf`` can be invoked for diagnostic profiling."""
+
+    if (system or platform.system()) != "Linux":
+        return Capability(
+            LinuxProfilerTool.NONE,
+            None,
+            None,
+            None,
+            None,
+            (DiagnosticCode.NOT_LINUX,),
+        )
+
+    perf_path = which("perf")
+    perf_event_paranoid = _read_int(Path("/proc/sys/kernel/perf_event_paranoid"))
+    kptr_restrict = _read_int(Path("/proc/sys/kernel/kptr_restrict"))
+    diagnostics: list[DiagnosticCode] = []
+
+    if perf_event_paranoid is not None and perf_event_paranoid > 2:
+        diagnostics.append(DiagnosticCode.PERF_EVENT_PARANOID_RESTRICTIVE)
+    if kptr_restrict is not None and kptr_restrict > 0:
+        diagnostics.append(DiagnosticCode.KERNEL_SYMBOLS_RESTRICTED)
+
+    if not perf_path:
+        diagnostics.append(DiagnosticCode.PERF_UNAVAILABLE)
+        return Capability(
+            LinuxProfilerTool.NONE,
+            None,
+            None,
+            perf_event_paranoid,
+            kptr_restrict,
+            tuple(diagnostics),
+        )
+
+    try:
+        version = run([perf_path, "--version"], capture_output=True, text=True, timeout=5)
+        perf_version = (version.stdout or version.stderr).strip() or None
+    except (OSError, subprocess.SubprocessError):
+        diagnostics.append(DiagnosticCode.PERF_UNAVAILABLE)
+        return Capability(
+            LinuxProfilerTool.NONE,
+            perf_path,
+            None,
+            perf_event_paranoid,
+            kptr_restrict,
+            tuple(diagnostics),
+        )
+
+    try:
+        stat = run(
+            [perf_path, "stat", "-e", "cycles", "--", "true"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if stat.returncode != 0:
+            diagnostics.append(DiagnosticCode.PERF_STAT_UNAVAILABLE)
+    except (OSError, subprocess.SubprocessError):
+        diagnostics.append(DiagnosticCode.PERF_STAT_UNAVAILABLE)
+
+    return Capability(
+        LinuxProfilerTool.PERF,
+        perf_path,
+        perf_version,
+        perf_event_paranoid,
+        kptr_restrict,
+        tuple(diagnostics),
+    )
+
+
+def _run_text(
+    command: list[str],
+    *,
+    timeout: int | None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True, timeout=timeout)
+
+
+def _parse_perf_stat_csv(path: Path) -> tuple[dict[str, str], ...]:
+    if not path.is_file():
+        return ()
+    counters: list[dict[str, str]] = []
+    with path.open(newline="", encoding="utf-8", errors="replace") as fh:
+        for row in csv.reader(fh):
+            if len(row) < 3:
+                continue
+            value, unit, event = (item.strip() for item in row[:3])
+            if not event or value.startswith("#"):
+                continue
+            counters.append({"event": event, "value": value, "unit": unit})
+    return tuple(counters)
+
+
+def _extract_hot_symbols(report_text: str, *, limit: int = 20) -> tuple[str, ...]:
+    hot: list[str] = []
+    for line in report_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        first = stripped.split(maxsplit=1)[0]
+        if not first.endswith("%"):
+            continue
+        hot.append(stripped)
+        if len(hot) >= limit:
+            break
+    return tuple(hot)
+
+
+def collect(
+    command: list[str],
+    output_dir: Path,
+    *,
+    capability: Capability | None = None,
+    timeout: int | None = None,
+    frequency: int = 99,
+    call_graph: str = "fp",
+) -> CollectionResult:
+    """Run separate diagnostic ``perf stat`` and ``perf record`` workloads."""
+
+    capability = capability or detect_capability()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    started = time.time()
+    diagnostics = list(capability.diagnostics)
+    stat_path = output_dir / "perf-stat.csv"
+    record_path = output_dir / "perf.data"
+    report_path = output_dir / "perf-report.txt"
+    executed: dict[str, list[str]] = {}
+    stderr: dict[str, str] = {}
+    returncodes: dict[str, int | None] = {}
+
+    if capability.tool is not LinuxProfilerTool.PERF or not capability.perf_path:
+        metadata_path = _write_metadata(
+            output_dir,
+            command=command,
+            executed=executed,
+            capability=capability,
+            diagnostics=diagnostics,
+            stderr=stderr,
+            returncodes=returncodes,
+            started=started,
+            timeout=timeout,
+            frequency=frequency,
+            call_graph=call_graph,
+        )
+        return CollectionResult(
+            "error",
+            capability.tool,
+            str(output_dir),
+            None,
+            None,
+            None,
+            str(metadata_path),
+            tuple(command),
+            tuple(diagnostics),
+            (),
+            (),
+            "Linux perf is unavailable; see metadata diagnostics.",
+        )
+
+    stat_command = [
+        capability.perf_path,
+        "stat",
+        "-x",
+        ",",
+        "-o",
+        str(stat_path),
+        "-e",
+        "cycles,instructions,branches,branch-misses,cache-misses,context-switches,cpu-migrations",
+        "--",
+        *command,
+    ]
+    record_command = [
+        capability.perf_path,
+        "record",
+        "-F",
+        str(frequency),
+        "-g",
+        "--call-graph",
+        call_graph,
+        "-o",
+        str(record_path),
+        "--",
+        *command,
+    ]
+    report_command = [
+        capability.perf_path,
+        "report",
+        "--stdio",
+        "--no-children",
+        "--sort",
+        "comm,dso,symbol",
+        "--percent-limit",
+        "0.5",
+        "-i",
+        str(record_path),
+    ]
+
+    for name, profiler_command in (("stat", stat_command), ("record", record_command)):
+        executed[name] = profiler_command
+        try:
+            result = _run_text(profiler_command, timeout=timeout)
+            returncodes[name] = result.returncode
+            stderr[name] = result.stderr[-4000:]
+            if result.returncode != 0:
+                diagnostics.append(
+                    DiagnosticCode.PERF_STAT_UNAVAILABLE
+                    if name == "stat"
+                    else DiagnosticCode.PERF_RECORD_UNAVAILABLE
+                )
+        except (OSError, subprocess.SubprocessError) as exc:
+            returncodes[name] = None
+            stderr[name] = str(exc)
+            diagnostics.append(
+                DiagnosticCode.PERF_STAT_UNAVAILABLE
+                if name == "stat"
+                else DiagnosticCode.PERF_RECORD_UNAVAILABLE
+            )
+
+    report_text = ""
+    if record_path.is_file():
+        executed["report"] = report_command
+        try:
+            report = _run_text(report_command, timeout=60)
+            returncodes["report"] = report.returncode
+            stderr["report"] = report.stderr[-4000:]
+            report_text = report.stdout
+            report_path.write_text(report_text, encoding="utf-8")
+            if report.returncode != 0:
+                diagnostics.append(DiagnosticCode.PERF_REPORT_UNAVAILABLE)
+        except (OSError, subprocess.SubprocessError) as exc:
+            returncodes["report"] = None
+            stderr["report"] = str(exc)
+            diagnostics.append(DiagnosticCode.PERF_REPORT_UNAVAILABLE)
+
+    counters = _parse_perf_stat_csv(stat_path)
+    hot_symbols = _extract_hot_symbols(report_text)
+    if any(
+        code.name.startswith("PERF_") and code is not DiagnosticCode.PERF_EVENT_PARANOID_RESTRICTIVE
+        for code in diagnostics
+    ):
+        diagnostics.append(DiagnosticCode.COLLECTION_FAILED)
+
+    metadata_path = _write_metadata(
+        output_dir,
+        command=command,
+        executed=executed,
+        capability=capability,
+        diagnostics=diagnostics,
+        stderr=stderr,
+        returncodes=returncodes,
+        started=started,
+        timeout=timeout,
+        frequency=frequency,
+        call_graph=call_graph,
+    )
+    status = (
+        "ok"
+        if not any(code is DiagnosticCode.COLLECTION_FAILED for code in diagnostics)
+        else "error"
+    )
+    summary = _format_summary(status, counters, hot_symbols, diagnostics, output_dir)
+    return CollectionResult(
+        status,
+        capability.tool,
+        str(output_dir),
+        str(stat_path) if stat_path.exists() else None,
+        str(record_path) if record_path.exists() else None,
+        str(report_path) if report_path.exists() else None,
+        str(metadata_path),
+        tuple(command),
+        tuple(diagnostics),
+        counters,
+        hot_symbols,
+        summary,
+    )
+
+
+def _write_metadata(
+    output_dir: Path,
+    *,
+    command: list[str],
+    executed: dict[str, list[str]],
+    capability: Capability,
+    diagnostics: list[DiagnosticCode],
+    stderr: dict[str, str],
+    returncodes: dict[str, int | None],
+    started: float,
+    timeout: int | None,
+    frequency: int,
+    call_graph: str,
+) -> Path:
+    metadata_path = output_dir / "metadata.json"
+    metadata = {
+        "schema_version": 1,
+        "diagnostic_only": True,
+        "scored_benchmark": False,
+        "tool": capability.tool,
+        "command": command,
+        "profiler_commands": executed,
+        "returncodes": returncodes,
+        "timeout_seconds": timeout,
+        "frequency_hz": frequency,
+        "call_graph": call_graph,
+        "os": platform.platform(),
+        "kernel": platform.release(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "symbol_tools": {name: shutil.which(name) for name in ("addr2line", "nm", "objdump")},
+        "started_at_epoch": started,
+        "diagnostics": diagnostics,
+        "capability": asdict(capability),
+        "stderr": stderr,
+    }
+    metadata_path.write_text(json.dumps(metadata, indent=2, default=str) + "\n")
+    return metadata_path
+
+
+def _format_summary(
+    status: str,
+    counters: tuple[dict[str, str], ...],
+    hot_symbols: tuple[str, ...],
+    diagnostics: list[DiagnosticCode],
+    output_dir: Path,
+) -> str:
+    counter_text = ", ".join(
+        f"{counter['event']}={counter['value']}{counter['unit']}" for counter in counters[:8]
+    )
+    if not counter_text:
+        counter_text = "no perf stat counters parsed"
+    symbol_text = "; ".join(hot_symbols[:5]) if hot_symbols else "no hot symbols parsed"
+    diagnostic_text = ", ".join(code.value for code in diagnostics) or "none"
+    return (
+        f"linux perf {status}; counters: {counter_text}; hot symbols: "
+        f"{symbol_text}; diagnostics: {diagnostic_text}; artifacts: {output_dir}"
+    )
+
+
+def summarize(output_dir: Path) -> dict:
+    """Read persisted artifacts and return a bounded machine-readable summary."""
+
+    metadata_path = output_dir / "metadata.json"
+    report_path = output_dir / "perf-report.txt"
+    metadata = (
+        json.loads(metadata_path.read_text(encoding="utf-8")) if metadata_path.exists() else {}
+    )
+    report_text = (
+        report_path.read_text(encoding="utf-8", errors="replace") if report_path.exists() else ""
+    )
+    counters = _parse_perf_stat_csv(output_dir / "perf-stat.csv")
+    hot_symbols = _extract_hot_symbols(report_text)
+    diagnostics = tuple(DiagnosticCode(item) for item in metadata.get("diagnostics", []))
+    return {
+        "metadata": str(metadata_path) if metadata_path.exists() else None,
+        "stat_artifact": str(output_dir / "perf-stat.csv")
+        if (output_dir / "perf-stat.csv").exists()
+        else None,
+        "record_artifact": str(output_dir / "perf.data")
+        if (output_dir / "perf.data").exists()
+        else None,
+        "report_artifact": str(report_path) if report_path.exists() else None,
+        "counters": list(counters),
+        "hot_symbols": list(hot_symbols),
+        "diagnostics": [item.value for item in diagnostics],
+        "summary": _format_summary(
+            "ok" if DiagnosticCode.COLLECTION_FAILED not in diagnostics else "error",
+            counters,
+            hot_symbols,
+            list(diagnostics),
+            output_dir,
+        ),
+    }
+
+
+def parse_command(command: str) -> list[str]:
+    """Parse an agent-supplied command without invoking a shell."""
+
+    return shlex.split(command)

--- a/src/vibesys/loops/agent/templates/profilers/linux_cpu.j2
+++ b/src/vibesys/loops/agent/templates/profilers/linux_cpu.j2
@@ -1,0 +1,67 @@
+You are the native Linux CPU profiler. Use the `{{ profiler_mcp_name }}` MCP tools
+to inspect capabilities, then profile a separate diagnostic invocation of the
+benchmark command with Linux `perf`.
+
+Never treat profiling output as the trusted scored benchmark result. The profile
+run may use `perf stat` and `perf record -g`, while the headline metric must come
+from the normal benchmark JSON field named in `OBJECTIVE.md`.
+
+{% if objective %}
+## Objective (verbatim from `OBJECTIVE.md`)
+
+{{ objective }}
+{% endif %}
+
+## Orchestrator focus
+
+{{ profile_focus or "General bottleneck analysis." }}
+
+{% if runtime_notes %}
+## Runtime environment
+
+{{ runtime_notes }}
+{% endif %}
+
+## Workspace
+
+Your working directory contains the implementer's code and a `{{ profiler_support_name }}/`
+directory with the Linux CPU profiler MCP server.
+
+Benchmark command: {{ benchmark_command }}
+
+{% if domain_profiler %}
+{{ domain_profiler }}
+
+{% endif %}
+
+## Analysis workflow
+
+1. Call `capabilities()` first. Report `perf_event_paranoid`, `kptr_restrict`,
+   missing `perf`, and unavailable PMU/symbol capabilities explicitly.
+2. Run a diagnostic `profile(command="{{ benchmark_command }}", output_dir="logs/linux_cpu_profile")`.
+   This profiles the actual benchmark process and its loaded native candidate.
+3. Use the returned counters and hot symbols, or call `summary(output_dir=...)`,
+   to identify where CPU time goes.
+4. Separately run the uninstrumented benchmark with its JSON output option and
+   use the OBJECTIVE's headline field for `perf_metric`.
+
+For native queue workloads, distinguish trusted runner overhead from candidate
+library symbols when symbol information permits. Look for producer/consumer hot
+paths, atomic or spin-loop cost, full/empty retry behavior, copy and slot-offset
+cost, context switches, CPU migrations, cache misses, and possible false sharing.
+
+## Output
+
+Return exactly one JSON object. Do not wrap in markdown fences.
+
+{
+  "analysis": "<detailed interpretation of what Linux perf showed>",
+  "bottlenecks": "<ranked bottlenecks with concrete counters/symbols/diagnostics>",
+  "suggestions": "<actionable optimization suggestions tied to bottlenecks>",
+  "perf_metric": <float or null>,
+  "perf_unit": "<unit string or null>"
+}
+
+IMPORTANT: Base your analysis on actual perf data returned by the MCP tools. If
+profiling is unavailable because of permissions, missing tools, container limits,
+or missing symbols, say so plainly and include the diagnostic code.

--- a/src/vibesys/profilers.py
+++ b/src/vibesys/profilers.py
@@ -51,6 +51,25 @@ class ProfilerDefinition:
         return f"vibesys-{self.kind.value.replace('_', '-')}-profiler"
 
 
+@dataclass(frozen=True)
+class ProfilerPreflightResult:
+    """Result of cheap host checks for a resolved profiler."""
+
+    kind: ProfilerKind
+    usable: bool
+    diagnostics: tuple[str, ...] = ()
+    details: tuple[str, ...] = ()
+
+    def error_message(self) -> str:
+        diagnostic_text = ", ".join(self.diagnostics) or "unknown"
+        detail_text = "; ".join(self.details)
+        suffix = f" ({detail_text})" if detail_text else ""
+        return (
+            f"Resolved profiler {self.kind.value!r} is not usable on this host: "
+            f"{diagnostic_text}{suffix}."
+        )
+
+
 PROFILER_DEFINITIONS: dict[ProfilerKind, ProfilerDefinition] = {
     definition.kind: definition
     for definition in (
@@ -187,3 +206,55 @@ def resolve_profiler_kind(
             f"{domain_name.value!r}; allowed: {allowed_values}."
         )
     return candidate
+
+
+def preflight_profiler_kind(kind: ProfilerKind) -> ProfilerPreflightResult:
+    """Run cheap local checks for a resolved profiler.
+
+    Most profiler kinds are validated by their backend/runtime setup. Native CPU
+    profilers run on the local host, so check their command availability before
+    the optimization loop starts.
+    """
+
+    resolved = require_profiler_kind(kind)
+    if resolved is ProfilerKind.NONE:
+        return ProfilerPreflightResult(resolved, True)
+    if resolved is ProfilerKind.LINUX_CPU:
+        from vibesys.linux_cpu_profiler import (  # noqa: PLC0415
+            DiagnosticCode,
+            LinuxProfilerTool,
+            detect_capability,
+        )
+
+        capability = detect_capability()
+        blocking = {
+            DiagnosticCode.NOT_LINUX,
+            DiagnosticCode.PERF_UNAVAILABLE,
+            DiagnosticCode.PERF_STAT_UNAVAILABLE,
+        }
+        diagnostics = tuple(item.value for item in capability.diagnostics)
+        usable = capability.tool is LinuxProfilerTool.PERF and not any(
+            item in blocking for item in capability.diagnostics
+        )
+        details = (
+            f"perf_path={capability.perf_path or 'missing'}",
+            f"perf_event_paranoid={capability.perf_event_paranoid}",
+            f"kptr_restrict={capability.kptr_restrict}",
+        )
+        return ProfilerPreflightResult(resolved, usable, diagnostics, details)
+    if resolved is ProfilerKind.MACOS_CPU:
+        from vibesys.macos_cpu_profiler import (  # noqa: PLC0415
+            MacOSProfilerTool,
+            detect_capability,
+        )
+
+        capability = detect_capability()
+        diagnostics = tuple(item.value for item in capability.diagnostics)
+        usable = capability.tool is not MacOSProfilerTool.NONE
+        details = (
+            f"xcode_path={capability.xcode_path or 'missing'}",
+            f"xctrace_path={capability.xctrace_path or 'missing'}",
+            f"sample_path={capability.sample_path or 'missing'}",
+        )
+        return ProfilerPreflightResult(resolved, usable, diagnostics, details)
+    return ProfilerPreflightResult(resolved, True)

--- a/src/vibesys/profilers.py
+++ b/src/vibesys/profilers.py
@@ -18,6 +18,7 @@ class ProfilerKind(StrEnum):
     TORCH = "torch"
     NEURON = "neuron"
     MACOS_CPU = "macos_cpu"
+    LINUX_CPU = "linux_cpu"
 
 
 @dataclass(frozen=True)
@@ -62,6 +63,7 @@ PROFILER_DEFINITIONS: dict[ProfilerKind, ProfilerDefinition] = {
         ),
         ProfilerDefinition(ProfilerKind.NEURON, frozenset({DomainName.LLM_SERVING})),
         ProfilerDefinition(ProfilerKind.MACOS_CPU, frozenset({DomainName.GENERIC})),
+        ProfilerDefinition(ProfilerKind.LINUX_CPU, frozenset({DomainName.GENERIC})),
     )
 }
 
@@ -129,9 +131,10 @@ def resolve_profiler_kind(
 ) -> ProfilerKind:
     """Resolve ``--profiler`` into the effective profiler kind.
 
-    ``auto`` is intentionally domain-aware. Generic workloads default to no
-    profiler; LLM-serving workloads pick the backend profiler unless the run
-    environment dictates a remote-safe default such as Modal's torch profiler.
+    ``auto`` is intentionally domain-aware. Generic workloads pick a native CPU
+    profiler when the host platform has one; LLM-serving workloads pick the
+    backend profiler unless the run environment dictates a remote-safe default
+    such as Modal's torch profiler.
     """
 
     requested_kind = require_profiler_kind(requested, label="requested profiler")
@@ -148,7 +151,12 @@ def resolve_profiler_kind(
         return requested_kind
 
     if domain_name is DomainName.GENERIC:
-        return ProfilerKind.MACOS_CPU if platform.system() == "Darwin" else ProfilerKind.NONE
+        system = platform.system()
+        if system == "Darwin":
+            return ProfilerKind.MACOS_CPU
+        if system == "Linux":
+            return ProfilerKind.LINUX_CPU
+        return ProfilerKind.NONE
 
     if allowed == frozenset({ProfilerKind.NONE}):
         return ProfilerKind.NONE

--- a/src/vibesys/skills.py
+++ b/src/vibesys/skills.py
@@ -179,6 +179,14 @@ def load_sidecar_rules(sidecar_path: Path) -> list[SkillRule]:
     return rules
 
 
+def _is_in_hidden_dir(path: Path, root: Path) -> bool:
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return False
+    return any(part.startswith(".") for part in relative.parts[:-1])
+
+
 def discover_skill_dirs(root: Path) -> list[Path]:
     """Return skill directories under *root*.
 
@@ -186,7 +194,7 @@ def discover_skill_dirs(root: Path) -> list[Path]:
     """
     if (root / "SKILL.md").is_file():
         return [root]
-    return sorted({p.parent for p in root.rglob("SKILL.md")})
+    return sorted({p.parent for p in root.rglob("SKILL.md") if not _is_in_hidden_dir(p, root)})
 
 
 def discover_sidecar_rules(root: Path) -> list[SkillRule]:
@@ -194,6 +202,7 @@ def discover_sidecar_rules(root: Path) -> list[SkillRule]:
     return [
         rule
         for sidecar_path in sorted(root.rglob(SIDECAR_NAME))
+        if not _is_in_hidden_dir(sidecar_path, root)
         for rule in load_sidecar_rules(sidecar_path)
     ]
 

--- a/tests/backends/test_cpu_backend.py
+++ b/tests/backends/test_cpu_backend.py
@@ -25,7 +25,7 @@ class TestCpuRegistry:
         impl = backends.get(ComputeBackend.CPU, log_dir=tmp_path)
         assert isinstance(impl, LocalBackend)
         assert impl.name is ComputeBackend.CPU
-        assert impl.profiler_kind is ProfilerKind.TORCH
+        assert impl.profiler_kind is ProfilerKind.LINUX_CPU
 
 
 class TestCpuSandbox:

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -11,7 +11,7 @@ from vibesys.domains.base import DomainName
 from vibesys.errors import ConfigurationError
 from vibesys.loops.agent import issue_board
 from vibesys.loops.agent.loop import run_agent_loop
-from vibesys.profilers import ProfilerKind
+from vibesys.profilers import ProfilerKind, ProfilerPreflightResult
 from vibesys.schemas import (
     ImplementerResponse,
     JudgeResponse,
@@ -607,7 +607,13 @@ def test_loop_generic_auto_profiler_resolves_to_macos_cpu(tmp_path, ref_file):
         ],
     )
 
-    with patch("vibesys.profilers.platform.system", return_value="Darwin"):
+    with (
+        patch("vibesys.profilers.platform.system", return_value="Darwin"),
+        patch(
+            "vibesys.context.preflight_profiler_kind",
+            lambda kind: ProfilerPreflightResult(kind, True),
+        ),
+    ):
         result = _invoke_orchestrate(
             tmp_path,
             ref_file,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -8,7 +8,8 @@ import pytest
 from vibesys.context import _RunContext
 from vibesys.domains.base import DomainName
 from vibesys.domains.environment import NoopEnvironmentHooks
-from vibesys.profilers import ACTIVE_PROFILER_KINDS, ProfilerKind
+from vibesys.errors import ConfigurationError
+from vibesys.profilers import ACTIVE_PROFILER_KINDS, ProfilerKind, ProfilerPreflightResult
 from vibesys.sandbox.run_environment import RunEnvironmentSpec
 
 
@@ -102,6 +103,14 @@ class _FakeBackend:
 
     def make_monitor(self, _log_dir):
         return None
+
+
+@pytest.fixture(autouse=True)
+def _native_profiler_preflight_ok(monkeypatch):
+    monkeypatch.setattr(
+        "vibesys.context.preflight_profiler_kind",
+        lambda kind: ProfilerPreflightResult(kind, True),
+    )
 
 
 def _write_ref(tmp_path):
@@ -272,6 +281,42 @@ def test_run_context_generic_auto_resolves_to_linux_profiler(tmp_path):
         assert not (ctx.workspace / "neuron_profiler").exists()
         assert not (ctx.workspace / "macos_cpu_profiler").exists()
         assert (ctx.workspace / "linux_cpu_profiler").exists()
+
+
+def test_run_context_fails_fast_when_resolved_profiler_is_unusable(tmp_path):
+    project_root = tmp_path / "project"
+    _write_support_dirs(project_root)
+    ref = _write_ref(tmp_path)
+
+    def fail_preflight(kind):
+        return ProfilerPreflightResult(
+            kind,
+            False,
+            ("perf_unavailable", "perf_event_paranoid_restrictive"),
+            ("perf_path=missing", "perf_event_paranoid=3"),
+        )
+
+    with (
+        patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
+        patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
+        patch("vibesys.profilers.platform.system", return_value="Linux"),
+        patch("vibesys.context.preflight_profiler_kind", side_effect=fail_preflight),
+        pytest.raises(ConfigurationError, match="Resolved profiler 'linux_cpu' is not usable"),
+    ):
+        _RunContext(
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            exp_name="generic-auto-linux-unusable",
+            input_path=str(ref.parent),
+            accuracy_command="uv run python accuracy_checker/checker.py",
+            benchmark_command="uv run python benchmark/benchmark.py",
+            profiler_kind=ProfilerKind.AUTO,
+            profiler_domain=DomainName.GENERIC,
+            skills_dirs=[],
+            run_environment=RunEnvironmentSpec("local"),
+            environment_hooks=NoopEnvironmentHooks(),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -118,6 +118,7 @@ def _write_support_dirs(project_root):
         ProfilerKind.TORCH: "torch_profiler",
         ProfilerKind.NEURON: "neuron_profiler",
         ProfilerKind.MACOS_CPU: "macos_cpu_profiler",
+        ProfilerKind.LINUX_CPU: "linux_cpu_profiler",
     }
     for kind in dirs:
         source_dir = project_root / "resources" / "profilers" / kind.value
@@ -170,7 +171,11 @@ def test_run_context_copies_only_selected_profiler_support(tmp_path, selected):
     _write_support_dirs(project_root)
     ref = _write_ref(tmp_path)
 
-    domain = DomainName.GENERIC if selected is ProfilerKind.MACOS_CPU else DomainName.LLM_SERVING
+    domain = (
+        DomainName.GENERIC
+        if selected in {ProfilerKind.MACOS_CPU, ProfilerKind.LINUX_CPU}
+        else DomainName.LLM_SERVING
+    )
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
         patch("vibesys.context._build_model", return_value="mock-model"),
@@ -193,12 +198,14 @@ def test_run_context_copies_only_selected_profiler_support(tmp_path, selected):
             ProfilerKind.TORCH: selected is ProfilerKind.TORCH,
             ProfilerKind.NEURON: selected is ProfilerKind.NEURON,
             ProfilerKind.MACOS_CPU: selected is ProfilerKind.MACOS_CPU,
+            ProfilerKind.LINUX_CPU: selected is ProfilerKind.LINUX_CPU,
         }
         assert ctx.profiler_kind is selected
         assert (ctx.workspace / "nsys_profiler").exists() is expected[ProfilerKind.NSYS]
         assert (ctx.workspace / "torch_profiler").exists() is expected[ProfilerKind.TORCH]
         assert (ctx.workspace / "neuron_profiler").exists() is expected[ProfilerKind.NEURON]
         assert (ctx.workspace / "macos_cpu_profiler").exists() is expected[ProfilerKind.MACOS_CPU]
+        assert (ctx.workspace / "linux_cpu_profiler").exists() is expected[ProfilerKind.LINUX_CPU]
 
 
 def test_run_context_generic_auto_resolves_to_macos_profiler(tmp_path):
@@ -231,11 +238,48 @@ def test_run_context_generic_auto_resolves_to_macos_profiler(tmp_path):
         assert not (ctx.workspace / "torch_profiler").exists()
         assert not (ctx.workspace / "neuron_profiler").exists()
         assert (ctx.workspace / "macos_cpu_profiler").exists()
+        assert not (ctx.workspace / "linux_cpu_profiler").exists()
+
+
+def test_run_context_generic_auto_resolves_to_linux_profiler(tmp_path):
+    project_root = tmp_path / "project"
+    support_paths = _write_support_dirs(project_root)
+    ref = _write_ref(tmp_path)
+
+    with (
+        patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
+        patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
+        patch("vibesys.profilers.platform.system", return_value="Linux"),
+        _RunContext(
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            exp_name="generic-auto-linux",
+            input_path=str(ref.parent),
+            accuracy_command="uv run python accuracy_checker/checker.py",
+            benchmark_command="uv run python benchmark/benchmark.py",
+            profiler_kind=ProfilerKind.AUTO,
+            profiler_domain=DomainName.GENERIC,
+            skills_dirs=[],
+            run_environment=RunEnvironmentSpec("local"),
+            environment_hooks=NoopEnvironmentHooks(),
+        ) as ctx,
+    ):
+        assert ctx.profiler_kind is ProfilerKind.LINUX_CPU
+        assert ctx.profiler_support_path == support_paths[ProfilerKind.LINUX_CPU]
+        assert not (ctx.workspace / "nsys_profiler").exists()
+        assert not (ctx.workspace / "torch_profiler").exists()
+        assert not (ctx.workspace / "neuron_profiler").exists()
+        assert not (ctx.workspace / "macos_cpu_profiler").exists()
+        assert (ctx.workspace / "linux_cpu_profiler").exists()
 
 
 @pytest.mark.parametrize(
     "profiler_kind",
-    sorted(ACTIVE_PROFILER_KINDS - {ProfilerKind.MACOS_CPU}, key=lambda kind: kind.value),
+    sorted(
+        ACTIVE_PROFILER_KINDS - {ProfilerKind.MACOS_CPU, ProfilerKind.LINUX_CPU},
+        key=lambda kind: kind.value,
+    ),
 )
 def test_run_context_rejects_generic_explicit_active_profilers(tmp_path, profiler_kind):
     ref = _write_ref(tmp_path)

--- a/tests/test_linux_cpu_profiler.py
+++ b/tests/test_linux_cpu_profiler.py
@@ -8,8 +8,12 @@ from vibesys.linux_cpu_profiler import (
     Capability,
     DiagnosticCode,
     LinuxProfilerTool,
+    _extract_hot_symbols,
+    _parse_perf_stat_csv,
+    _read_int,
     collect,
     detect_capability,
+    parse_command,
     summarize,
 )
 
@@ -27,6 +31,92 @@ def test_detect_capability_reports_missing_perf():
 
     assert capability.tool is LinuxProfilerTool.NONE
     assert DiagnosticCode.PERF_UNAVAILABLE in capability.diagnostics
+
+
+def test_read_int_returns_none_for_missing_or_invalid_values(tmp_path: Path):
+    invalid = tmp_path / "not-an-int"
+    invalid.write_text("restricted\n", encoding="utf-8")
+
+    assert _read_int(invalid) is None
+    assert _read_int(tmp_path / "missing") is None
+
+
+def test_detect_capability_reports_restrictions_and_stat_failure():
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs):
+        calls.append(command)
+        if command[1] == "--version":
+            return subprocess.CompletedProcess(command, 0, "perf version 6.8\n", "")
+        if command[1] == "stat":
+            return subprocess.CompletedProcess(command, 255, "", "No permission")
+        raise AssertionError(command)
+
+    with patch("vibesys.linux_cpu_profiler._read_int", side_effect=[3, 1]):
+        capability = detect_capability(
+            system="Linux",
+            which=lambda _name: "/usr/bin/perf",
+            run=fake_run,
+        )
+
+    assert calls[0] == ["/usr/bin/perf", "--version"]
+    assert capability.tool is LinuxProfilerTool.PERF
+    assert capability.perf_version == "perf version 6.8"
+    assert DiagnosticCode.PERF_EVENT_PARANOID_RESTRICTIVE in capability.diagnostics
+    assert DiagnosticCode.KERNEL_SYMBOLS_RESTRICTED in capability.diagnostics
+    assert DiagnosticCode.PERF_STAT_UNAVAILABLE in capability.diagnostics
+
+
+def test_detect_capability_handles_perf_version_exception():
+    def fake_run(_command: list[str], **_kwargs):
+        raise OSError("cannot execute perf")
+
+    with patch("vibesys.linux_cpu_profiler._read_int", return_value=None):
+        capability = detect_capability(
+            system="Linux",
+            which=lambda _name: "/usr/bin/perf",
+            run=fake_run,
+        )
+
+    assert capability.tool is LinuxProfilerTool.NONE
+    assert capability.perf_path == "/usr/bin/perf"
+    assert DiagnosticCode.PERF_UNAVAILABLE in capability.diagnostics
+
+
+def test_detect_capability_handles_perf_stat_exception():
+    def fake_run(command: list[str], **_kwargs):
+        if command[1] == "--version":
+            return subprocess.CompletedProcess(command, 0, "", "perf version 6.9\n")
+        raise subprocess.TimeoutExpired(command, 10)
+
+    with patch("vibesys.linux_cpu_profiler._read_int", return_value=None):
+        capability = detect_capability(
+            system="Linux",
+            which=lambda _name: "/usr/bin/perf",
+            run=fake_run,
+        )
+
+    assert capability.tool is LinuxProfilerTool.PERF
+    assert capability.perf_version == "perf version 6.9"
+    assert DiagnosticCode.PERF_STAT_UNAVAILABLE in capability.diagnostics
+
+
+def test_perf_parsers_skip_malformed_rows_and_stop_at_limit(tmp_path: Path):
+    stat_path = tmp_path / "perf-stat.csv"
+    stat_path.write_text(
+        "# ignored\ntoo-short\n# comment,,cycles\n10,,cycles\n",
+        encoding="utf-8",
+    )
+    report_text = (
+        "# header\n"
+        "not-a-percent bench [.] setup\n"
+        "  55.00% bench libqueue.so [.] enqueue\n"
+        "  30.00% bench libqueue.so [.] dequeue\n"
+    )
+
+    assert _parse_perf_stat_csv(tmp_path / "missing.csv") == ()
+    assert _parse_perf_stat_csv(stat_path) == ({"event": "cycles", "value": "10", "unit": ""},)
+    assert _extract_hot_symbols(report_text, limit=1) == ("55.00% bench libqueue.so [.] enqueue",)
 
 
 def test_collect_persists_perf_artifacts_and_summary(tmp_path: Path):
@@ -76,6 +166,72 @@ def test_collect_persists_perf_artifacts_and_summary(tmp_path: Path):
     persisted = summarize(tmp_path)
     assert persisted["counters"][1]["event"] == "instructions"
     assert "dequeue" in persisted["hot_symbols"][1]
+
+
+def test_collect_reports_failed_stat_record_and_missing_counters(tmp_path: Path):
+    capability = Capability(
+        tool=LinuxProfilerTool.PERF,
+        perf_path="/usr/bin/perf",
+        perf_version="perf version 6.8",
+        perf_event_paranoid=None,
+        kptr_restrict=None,
+    )
+
+    def fake_run(command: list[str], *, timeout: int | None):
+        del timeout
+        if command[1] == "stat":
+            return subprocess.CompletedProcess(command, 255, "", "stat failed")
+        if command[1] == "record":
+            raise subprocess.TimeoutExpired(command, 3)
+        raise AssertionError(command)
+
+    with patch("vibesys.linux_cpu_profiler._run_text", side_effect=fake_run):
+        result = collect(["bench"], tmp_path, capability=capability, timeout=3)
+
+    assert result.status == "error"
+    assert result.counters == ()
+    assert "no perf stat counters parsed" in result.summary
+    assert DiagnosticCode.PERF_STAT_UNAVAILABLE in result.diagnostics
+    assert DiagnosticCode.PERF_RECORD_UNAVAILABLE in result.diagnostics
+    assert DiagnosticCode.COLLECTION_FAILED in result.diagnostics
+
+
+def test_collect_reports_failed_perf_report(tmp_path: Path):
+    capability = Capability(
+        tool=LinuxProfilerTool.PERF,
+        perf_path="/usr/bin/perf",
+        perf_version="perf version 6.8",
+        perf_event_paranoid=None,
+        kptr_restrict=None,
+    )
+
+    def fake_run(command: list[str], *, timeout: int | None):
+        del timeout
+        if command[1] == "stat":
+            Path(command[command.index("-o") + 1]).write_text("1,,cycles\n", encoding="utf-8")
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command[1] == "record":
+            Path(command[command.index("-o") + 1]).write_bytes(b"perf data")
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command[1] == "report":
+            return subprocess.CompletedProcess(command, 1, "", "report failed")
+        raise AssertionError(command)
+
+    with patch("vibesys.linux_cpu_profiler._run_text", side_effect=fake_run):
+        result = collect(["bench"], tmp_path, capability=capability)
+
+    assert result.status == "error"
+    assert result.report_artifact == str(tmp_path / "perf-report.txt")
+    assert DiagnosticCode.PERF_REPORT_UNAVAILABLE in result.diagnostics
+    assert DiagnosticCode.COLLECTION_FAILED in result.diagnostics
+
+
+def test_summarize_empty_directory_and_parse_command(tmp_path: Path):
+    summary = summarize(tmp_path)
+
+    assert summary["metadata"] is None
+    assert summary["summary"].startswith("linux perf ok; counters: no perf stat counters parsed")
+    assert parse_command("bench --scenario 'spsc queue'") == ["bench", "--scenario", "spsc queue"]
 
 
 def test_collect_degrades_when_perf_unavailable(tmp_path: Path):

--- a/tests/test_linux_cpu_profiler.py
+++ b/tests/test_linux_cpu_profiler.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from vibesys.linux_cpu_profiler import (
+    Capability,
+    DiagnosticCode,
+    LinuxProfilerTool,
+    collect,
+    detect_capability,
+    summarize,
+)
+
+
+def test_detect_capability_rejects_non_linux():
+    capability = detect_capability(system="Darwin")
+
+    assert capability.tool is LinuxProfilerTool.NONE
+    assert capability.diagnostics == (DiagnosticCode.NOT_LINUX,)
+
+
+def test_detect_capability_reports_missing_perf():
+    with patch("vibesys.linux_cpu_profiler._read_int", return_value=1):
+        capability = detect_capability(system="Linux", which=lambda _name: None)
+
+    assert capability.tool is LinuxProfilerTool.NONE
+    assert DiagnosticCode.PERF_UNAVAILABLE in capability.diagnostics
+
+
+def test_collect_persists_perf_artifacts_and_summary(tmp_path: Path):
+    capability = Capability(
+        tool=LinuxProfilerTool.PERF,
+        perf_path="/usr/bin/perf",
+        perf_version="perf version 6.8",
+        perf_event_paranoid=1,
+        kptr_restrict=0,
+    )
+
+    def fake_run(command: list[str], *, timeout: int | None):
+        del timeout
+        if command[1] == "stat":
+            output = Path(command[command.index("-o") + 1])
+            output.write_text(
+                "1000,,cycles\n500,,instructions\n10,,context-switches\n1,,cpu-migrations\n",
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command[1] == "record":
+            output = Path(command[command.index("-o") + 1])
+            output.write_bytes(b"perf data")
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command[1] == "report":
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                "  65.00% bench queue-candidate.so [.] enqueue\n"
+                "  20.00% bench queue-candidate.so [.] dequeue\n",
+                "",
+            )
+        raise AssertionError(command)
+
+    with patch("vibesys.linux_cpu_profiler._run_text", side_effect=fake_run):
+        result = collect(["bench", "--scenario", "spsc"], tmp_path, capability=capability)
+
+    assert result.status == "ok"
+    assert result.stat_artifact == str(tmp_path / "perf-stat.csv")
+    assert result.record_artifact == str(tmp_path / "perf.data")
+    assert result.report_artifact == str(tmp_path / "perf-report.txt")
+    assert result.metadata == str(tmp_path / "metadata.json")
+    assert result.counters[0] == {"event": "cycles", "value": "1000", "unit": ""}
+    assert "enqueue" in result.hot_symbols[0]
+    assert "linux perf ok" in result.summary
+
+    persisted = summarize(tmp_path)
+    assert persisted["counters"][1]["event"] == "instructions"
+    assert "dequeue" in persisted["hot_symbols"][1]
+
+
+def test_collect_degrades_when_perf_unavailable(tmp_path: Path):
+    capability = Capability(
+        tool=LinuxProfilerTool.NONE,
+        perf_path=None,
+        perf_version=None,
+        perf_event_paranoid=None,
+        kptr_restrict=None,
+        diagnostics=(DiagnosticCode.PERF_UNAVAILABLE,),
+    )
+
+    result = collect(["bench"], tmp_path, capability=capability)
+
+    assert result.status == "error"
+    assert result.stat_artifact is None
+    assert result.record_artifact is None
+    assert result.metadata == str(tmp_path / "metadata.json")
+    assert DiagnosticCode.PERF_UNAVAILABLE in result.diagnostics

--- a/tests/test_profilers.py
+++ b/tests/test_profilers.py
@@ -103,6 +103,20 @@ def test_profiler_auto_resolution_exhaustive(
         assert resolve_profiler_kind(requested, **kwargs) is expected
 
 
+def test_generic_auto_uses_none_when_host_has_no_native_cpu_profiler(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "FreeBSD")
+
+    assert (
+        resolve_profiler_kind(
+            ProfilerKind.AUTO,
+            domain=DomainName.GENERIC,
+            backend_profiler_kind=ProfilerKind.LINUX_CPU,
+            environment_default_profiler_kind=ProfilerKind.NSYS,
+        )
+        is ProfilerKind.NONE
+    )
+
+
 @given(
     domain=st.sampled_from(_DOMAINS),
     requested=st.sampled_from(_REQUESTED),

--- a/tests/test_profilers.py
+++ b/tests/test_profilers.py
@@ -14,6 +14,7 @@ from vibesys.profilers import (
     ProfilerKind,
     allowed_profiler_kinds,
     coerce_profiler_kind,
+    preflight_profiler_kind,
     resolve_profiler_kind,
 )
 
@@ -186,3 +187,50 @@ def test_resolver_rejects_unparsed_backend_profiler_metadata(backend_profiler_ki
             backend_profiler_kind=backend_profiler_kind,
             environment_default_profiler_kind=ProfilerKind.NSYS,
         )
+
+
+def test_linux_cpu_preflight_fails_when_perf_is_unavailable(monkeypatch):
+    from vibesys.linux_cpu_profiler import Capability, DiagnosticCode, LinuxProfilerTool
+
+    monkeypatch.setattr(
+        "vibesys.linux_cpu_profiler.detect_capability",
+        lambda: Capability(
+            LinuxProfilerTool.NONE,
+            None,
+            None,
+            3,
+            0,
+            (
+                DiagnosticCode.PERF_EVENT_PARANOID_RESTRICTIVE,
+                DiagnosticCode.PERF_UNAVAILABLE,
+            ),
+        ),
+    )
+
+    result = preflight_profiler_kind(ProfilerKind.LINUX_CPU)
+
+    assert not result.usable
+    assert result.diagnostics == ("perf_event_paranoid_restrictive", "perf_unavailable")
+    assert "perf_path=missing" in result.details
+    assert "perf_unavailable" in result.error_message()
+
+
+def test_linux_cpu_preflight_accepts_perf_with_nonblocking_symbol_restrictions(monkeypatch):
+    from vibesys.linux_cpu_profiler import Capability, DiagnosticCode, LinuxProfilerTool
+
+    monkeypatch.setattr(
+        "vibesys.linux_cpu_profiler.detect_capability",
+        lambda: Capability(
+            LinuxProfilerTool.PERF,
+            "/usr/bin/perf",
+            "perf version 6.8",
+            1,
+            1,
+            (DiagnosticCode.KERNEL_SYMBOLS_RESTRICTED,),
+        ),
+    )
+
+    result = preflight_profiler_kind(ProfilerKind.LINUX_CPU)
+
+    assert result.usable
+    assert result.diagnostics == ("kernel_symbols_restricted",)

--- a/tests/test_profilers.py
+++ b/tests/test_profilers.py
@@ -59,7 +59,12 @@ def _expected_resolved(
             raise ValueError
         return requested
     if domain is DomainName.GENERIC and requested is ProfilerKind.AUTO:
-        return ProfilerKind.MACOS_CPU if platform.system() == "Darwin" else ProfilerKind.NONE
+        system = platform.system()
+        if system == "Darwin":
+            return ProfilerKind.MACOS_CPU
+        if system == "Linux":
+            return ProfilerKind.LINUX_CPU
+        return ProfilerKind.NONE
     if allowed == frozenset({ProfilerKind.NONE}):
         return ProfilerKind.NONE
     if environment_default_profiler_kind is ProfilerKind.TORCH:
@@ -130,7 +135,13 @@ def test_profiler_resolution_invariants(
     assert resolved is not ProfilerKind.AUTO
     assert resolved in allowed
     if domain is DomainName.GENERIC and requested is ProfilerKind.AUTO:
-        expected = ProfilerKind.MACOS_CPU if platform.system() == "Darwin" else ProfilerKind.NONE
+        system = platform.system()
+        if system == "Darwin":
+            expected = ProfilerKind.MACOS_CPU
+        elif system == "Linux":
+            expected = ProfilerKind.LINUX_CPU
+        else:
+            expected = ProfilerKind.NONE
         assert resolved is expected
     if requested is not ProfilerKind.AUTO:
         assert resolved is requested

--- a/tests/test_skills_wiring.py
+++ b/tests/test_skills_wiring.py
@@ -11,6 +11,7 @@ from vibesys.cli import load_config_and_skills
 from vibesys.constants import PROJECT_ROOT, ComputeBackend
 from vibesys.skills import (
     SkillMetadataError,
+    _is_in_hidden_dir,
     discover_sidecar_rules,
     discover_skill_dirs,
     load_sidecar_rules,
@@ -154,6 +155,10 @@ def test_discovery_ignores_hidden_skill_directories(tmp_path):
 
     assert discover_skill_dirs(root) == [visible]
     assert resolve_skill_source_dirs([root], backend=ComputeBackend.CUDA) == [str(visible)]
+
+
+def test_hidden_dir_check_treats_external_paths_as_visible(tmp_path):
+    assert not _is_in_hidden_dir(tmp_path / "other" / ".hidden" / "SKILL.md", tmp_path / "skills")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_skills_wiring.py
+++ b/tests/test_skills_wiring.py
@@ -145,6 +145,17 @@ def test_duplicate_skill_dirs_are_deduped(tmp_path):
     assert [Path(s).name for s in skills] == ["portable"]
 
 
+def test_discovery_ignores_hidden_skill_directories(tmp_path):
+    root = tmp_path / "skills"
+    visible = _write_skill(root, "portable")
+    hidden = root / ".claude" / "skills" / "foreign"
+    hidden.mkdir(parents=True)
+    hidden.joinpath("SKILL.md").write_text("# upstream skill without frontmatter\n")
+
+    assert discover_skill_dirs(root) == [visible]
+    assert resolve_skill_source_dirs([root], backend=ComputeBackend.CUDA) == [str(visible)]
+
+
 @pytest.mark.parametrize(
     ("content", "message"),
     [


### PR DESCRIPTION
## Problem

Generic CPU workloads on Linux currently have no first-class profiler path. For targets like `examples/data-structures/queue-spsc`, `--backend cpu --profiler auto` effectively leaves agents with benchmark-only feedback, even though Linux has a good native profiling stack for mixed Go/Rust/C workloads. This closes #141.

## Solution

Add a `linux_cpu` profiler kind for the generic domain and make CPU generic auto-resolution select it on Linux while preserving `macos_cpu` on macOS.

The profiler is implemented as a diagnostic-only Linux `perf` collector with an MCP wrapper. It exposes capability diagnostics (`perf`, `perf_event_paranoid`, `kptr_restrict`), runs separate `perf stat` and `perf record -g` workload invocations, writes raw artifacts and reproduction metadata, and returns bounded counters/hot-symbol summaries for the profiler agent. The scored benchmark remains separate and authoritative.

This also makes the CPU backend advertise `linux_cpu`, updates CLI/docs text, packages profiler prompt templates, and teaches skill discovery to ignore hidden upstream skill directories such as `.claude/skills` inside initialized submodules.

## Verification

Implemented unit coverage for Linux profiler capability detection, artifact persistence, summaries, unavailable-perf degradation, profiler auto-resolution, context support copying, CPU backend selection, and hidden skill-directory discovery.

### Correctness properties

- `linux_cpu` is only allowed for the generic domain.
- `--backend cpu --profiler auto` resolves to `linux_cpu` on Linux, `macos_cpu` on macOS, and `none` elsewhere.
- Linux profiling is diagnostic-only and does not replace the trusted benchmark metric.
- Missing `perf`, restrictive permissions, and report/record/stat failures are surfaced as structured diagnostics.
- Raw profiler artifacts and metadata are persisted under the requested output directory.
- Hidden upstream skill directories are not treated as VibeSys skill roots.

### Testing

- `uv run ruff check src/vibesys/skills.py tests/test_skills_wiring.py src/vibesys/linux_cpu_profiler.py src/vibesys/profilers.py src/vibesys/backends/local.py src/vibesys/cli.py tests/test_linux_cpu_profiler.py tests/test_profilers.py tests/test_context.py tests/backends/test_cpu_backend.py resources/profilers/linux_cpu/server.py` - passed
- `uv run ruff format --check src/vibesys/linux_cpu_profiler.py src/vibesys/profilers.py src/vibesys/backends/local.py src/vibesys/cli.py tests/test_linux_cpu_profiler.py tests/test_profilers.py tests/test_context.py tests/backends/test_cpu_backend.py resources/profilers/linux_cpu/server.py` - passed
- `uv run --dev python -m pytest tests/test_skills_wiring.py tests/test_linux_cpu_profiler.py tests/test_profilers.py tests/test_context.py tests/backends/test_cpu_backend.py` - 811 passed
- `uv run --dev python -m pytest` - 1726 passed
- `uv run --dev python -m pytest -v --cov=vibesys --cov=vs_issue_board --cov-report=term-missing --cov-report=xml --cov-fail-under=75` - 1726 passed, 82.21% coverage

Note: repo-wide `./scripts/check_lint.sh` and `./scripts/check_format.sh` were not useful in this local checkout because initialized git submodules expose upstream vendored code that CI does not check out by default; targeted ruff checks for all touched Python files passed.
