### PR TITLE
Add TUI round and agent run map

### DIFF
--- a/clients/tui/src/run-map.ts
+++ b/clients/tui/src/run-map.ts
@@ -1,0 +1,167 @@
+import type {RunEvent} from './protocol.js';
+
+export type AgentPhaseStatus = 'pending' | 'active' | 'completed' | 'failed';
+export type RoundStatus = 'active' | 'completed' | 'failed';
+
+export interface RoundSummary {
+  number: number;
+  status: RoundStatus;
+  startedAt?: string;
+  finishedAt?: string;
+}
+
+export interface AgentPhase {
+  kind: string;
+  status: AgentPhaseStatus;
+  roundNumber: number | null;
+  roundLabel: string | null;
+  invocationId?: string;
+  startedAt?: string;
+  finishedAt?: string;
+}
+
+export interface RunMapState {
+  outerLoop: string | null;
+  rounds: RoundSummary[];
+  phases: AgentPhase[];
+}
+
+export function applyRunMapEvent(state: RunMapState, event: RunEvent): RunMapState {
+  const outerLoop =
+    event.type === 'run_started' && event.data?.kind === 'run_started'
+      ? event.data.outer_loop
+      : state.outerLoop;
+  const rounds = applyRoundEvent(state.rounds, event);
+  const phases = applyPhaseEvent({...state, outerLoop, rounds}, event);
+  return {outerLoop, rounds, phases};
+}
+
+export function visibleRoundNumber(
+  rounds: RoundSummary[],
+  selectedRound: number | null,
+): number | null {
+  if (selectedRound !== null) return selectedRound;
+  const active = [...rounds].reverse().find(round => round.status === 'active');
+  if (active) return active.number;
+  return rounds.at(-1)?.number ?? null;
+}
+
+export function visiblePhases(phases: AgentPhase[], roundNumber: number | null): AgentPhase[] {
+  return phases.filter(phase => phase.roundNumber === roundNumber);
+}
+
+export function roundNumberFromLabel(label: string | null | undefined): number | null {
+  if (!label) return null;
+  const match = label.match(/(?:round|iter(?:ation)?)\D*(\d+)/i);
+  return match ? Number(match[1]) : null;
+}
+
+function applyPhaseEvent(state: RunMapState, event: RunEvent): AgentPhase[] {
+  const kind = event.agent_kind;
+  if (!kind) return state.phases;
+  const roundNumber = roundNumberFromLabel(event.round_label);
+  let phases = state.phases;
+  if (roundNumber !== null && state.outerLoop !== null) {
+    phases = seedExpectedPhases(state.outerLoop, phases, roundNumber);
+  }
+  if (event.type !== 'phase_started' && event.type !== 'phase_finished') {
+    return ensurePhase(phases, kind, roundNumber);
+  }
+  const status =
+    event.type === 'phase_started' ? 'active' : event.status === 'failed' ? 'failed' : 'completed';
+  return upsertPhase(phases, {
+    kind,
+    status,
+    roundNumber,
+    roundLabel: event.round_label ?? null,
+    ...(event.invocation_id ? {invocationId: event.invocation_id} : {}),
+    ...(event.type === 'phase_started'
+      ? {startedAt: event.timestamp}
+      : {finishedAt: event.timestamp}),
+  });
+}
+
+function applyRoundEvent(rounds: RoundSummary[], event: RunEvent): RoundSummary[] {
+  const number = roundNumberFromLabel(event.round_label);
+  if (number === null) return rounds;
+  const status =
+    event.type === 'round_finished'
+      ? event.status === 'failed'
+        ? 'failed'
+        : 'completed'
+      : 'active';
+  return upsertRound(rounds, {
+    number,
+    status,
+    ...(event.type === 'round_finished'
+      ? {finishedAt: event.timestamp}
+      : {startedAt: event.timestamp}),
+  });
+}
+
+function seedExpectedPhases(
+  outerLoop: string,
+  current: AgentPhase[],
+  roundNumber: number,
+): AgentPhase[] {
+  const expected = expectedRoles(outerLoop);
+  let phases = current;
+  for (const kind of expected) phases = ensurePhase(phases, kind, roundNumber);
+  return phases;
+}
+
+function expectedRoles(outerLoop: string): string[] {
+  if (outerLoop === 'agent') return ['orchestrator', 'implementer', 'judge', 'profiler'];
+  if (outerLoop === 'plain') return ['implementer', 'judge', 'perf_eval'];
+  if (outerLoop === 'evolve' || outerLoop === 'openevolve') {
+    return ['implementer', 'judge', 'profiler'];
+  }
+  return [];
+}
+
+function ensurePhase(phases: AgentPhase[], kind: string, roundNumber: number | null): AgentPhase[] {
+  if (phases.some(phase => phase.kind === kind && phase.roundNumber === roundNumber)) {
+    return phases;
+  }
+  return [...phases, {kind, status: 'pending', roundNumber, roundLabel: null}];
+}
+
+function upsertPhase(phases: AgentPhase[], patch: AgentPhase): AgentPhase[] {
+  const existing = phases.findIndex(
+    phase => phase.kind === patch.kind && phase.roundNumber === patch.roundNumber,
+  );
+  if (existing === -1) return [...phases, patch];
+  return phases.map((phase, index) =>
+    index === existing
+      ? {
+          ...phase,
+          ...patch,
+          ...((patch.startedAt ?? phase.startedAt)
+            ? {startedAt: patch.startedAt ?? phase.startedAt}
+            : {}),
+          ...((patch.finishedAt ?? phase.finishedAt)
+            ? {finishedAt: patch.finishedAt ?? phase.finishedAt}
+            : {}),
+        }
+      : phase,
+  );
+}
+
+function upsertRound(rounds: RoundSummary[], patch: RoundSummary): RoundSummary[] {
+  const existing = rounds.findIndex(round => round.number === patch.number);
+  if (existing === -1) return [...rounds, patch].sort((a, b) => a.number - b.number);
+  return rounds.map((round, index) =>
+    index === existing
+      ? {
+          ...round,
+          ...patch,
+          ...((patch.startedAt ?? round.startedAt)
+            ? {startedAt: patch.startedAt ?? round.startedAt}
+            : {}),
+          ...((patch.finishedAt ?? round.finishedAt)
+            ? {finishedAt: patch.finishedAt ?? round.finishedAt}
+            : {}),
+        }
+      : round,
+  );
+}

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -14,9 +14,9 @@ describe('session controller', () => {
 
     await controller.submit('/help');
 
-    expect(controller.state.view).toBe('help');
-    expect(controller.state.detailContent).toContain('/history');
-    expect(controller.state.detailContent).toContain('Planned');
+    expect(controller.state.overlay?.kind).toBe('help');
+    expect(controller.state.overlay?.content).toContain('/history');
+    expect(controller.state.overlay?.content).toContain('Planned');
     expect(transport.requests).toEqual([]);
   });
 
@@ -42,7 +42,7 @@ describe('session controller', () => {
     transport.disconnect(new Error('closed'));
 
     expect(controller.state.status).toBe('completed');
-    expect(controller.state.view).toBe('live');
+    expect(controller.state.overlay).toBeNull();
   });
 
   it('summarizes completed and running round durations', () => {
@@ -61,7 +61,11 @@ describe('session controller', () => {
     ];
 
     expect(renderRoundHistory(events, new Date('2026-01-01T00:03:42Z'))).toBe(
-      ['Rounds', 'Round 1 · completed · 2m 5s', 'Round 2 · running · 42s'].join('\n'),
+      [
+        'Rounds',
+        'Round 1 · completed · 2m 5s · no agent phases yet',
+        'Round 2 · running · 42s · no agent phases yet',
+      ].join('\n'),
     );
   });
 });

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -5,6 +5,11 @@ import {
   applyEvent,
   applySnapshot,
   initialSessionState,
+  selectNextAgent,
+  selectNextRound,
+  selectPreviousAgent,
+  selectPreviousRound,
+  selectRound,
   type SessionState,
   showDetail,
   showLive,
@@ -16,6 +21,11 @@ export interface SessionController {
   stop(): Promise<void>;
   submit(value: string): Promise<void>;
   live(): void;
+  selectNextAgent(): void;
+  selectPreviousAgent(): void;
+  selectNextRound(): void;
+  selectPreviousRound(): void;
+  selectRound(roundNumber: number): void;
   subscribe(listener: (state: SessionState) => void): () => void;
 }
 
@@ -68,6 +78,26 @@ export class SocketSessionController implements SessionController {
     this.#setState(showLive(this.#state));
   }
 
+  selectNextAgent(): void {
+    this.#setState(selectNextAgent(this.#state));
+  }
+
+  selectPreviousAgent(): void {
+    this.#setState(selectPreviousAgent(this.#state));
+  }
+
+  selectNextRound(): void {
+    this.#setState(selectNextRound(this.#state));
+  }
+
+  selectPreviousRound(): void {
+    this.#setState(selectPreviousRound(this.#state));
+  }
+
+  selectRound(roundNumber: number): void {
+    this.#setState(selectRound(this.#state, roundNumber));
+  }
+
   async submit(value: string): Promise<void> {
     const parsed = parseInput(value.trim());
     if (parsed.error) return this.#setState(showDetail(this.#state, parsed.error, 'error'));
@@ -110,7 +140,15 @@ function renderResponse(request: RequestInput, response: ProtocolResponse): stri
 }
 
 export function renderRoundHistory(events: ProtocolResponse['events'], now = new Date()): string {
-  const rounds = new Map<number, {startedAt: Date; finishedAt?: Date}>();
+  const rounds = new Map<
+    number,
+    {
+      startedAt: Date;
+      finishedAt?: Date;
+      status: 'running' | 'completed' | 'failed';
+      phases: Set<string>;
+    }
+  >();
   for (const event of events ?? []) {
     const match = event.round_label?.match(/^round-(\d+)/);
     if (!match) continue;
@@ -118,11 +156,25 @@ export function renderRoundHistory(events: ProtocolResponse['events'], now = new
     const timestamp = new Date(event.timestamp);
     const current = rounds.get(round);
     if (!current || timestamp < current.startedAt) {
-      rounds.set(round, {...current, startedAt: timestamp});
+      rounds.set(round, {
+        phases: current?.phases ?? new Set(),
+        status: current?.status ?? 'running',
+        ...(current?.finishedAt ? {finishedAt: current.finishedAt} : {}),
+        startedAt: timestamp,
+      });
+    }
+    const updated = rounds.get(round);
+    if (updated && event.agent_kind) updated.phases.add(event.agent_kind);
+    if (updated && (event.type === 'run_failed' || event.type === 'run_interrupted')) {
+      updated.status = 'failed';
+      updated.finishedAt = timestamp;
     }
     if (event.type === 'round_finished') {
       const updated = rounds.get(round);
-      if (updated) updated.finishedAt = timestamp;
+      if (updated) {
+        updated.finishedAt = timestamp;
+        updated.status = event.status === 'failed' ? 'failed' : 'completed';
+      }
     }
   }
   if (rounds.size === 0) return 'No rounds have started yet.';
@@ -133,9 +185,8 @@ export function renderRoundHistory(events: ProtocolResponse['events'], now = new
       0,
       Math.floor((end.getTime() - timing.startedAt.getTime()) / 1000),
     );
-    lines.push(
-      `Round ${round} · ${timing.finishedAt ? 'completed' : 'running'} · ${formatDuration(elapsedSeconds)}`,
-    );
+    const phases = [...timing.phases].join(' -> ') || 'no agent phases yet';
+    lines.push(`Round ${round} · ${timing.status} · ${formatDuration(elapsedSeconds)} · ${phases}`);
   }
   return lines.join('\n');
 }

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -5,12 +5,12 @@ import {
   applyEvent,
   applySnapshot,
   initialSessionState,
+  type SessionState,
   selectNextAgent,
   selectNextRound,
   selectPreviousAgent,
   selectPreviousRound,
   selectRound,
-  type SessionState,
   showDetail,
   showLive,
 } from './session-model.js';

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -1,6 +1,14 @@
 import {describe, expect, it} from 'vitest';
 import type {RunEvent} from './protocol.js';
-import {applyEvent, initialSessionState} from './session-model.js';
+import {
+  applyEvent,
+  initialSessionState,
+  selectNextAgent,
+  selectNextRound,
+  selectRound,
+  visibleConversation,
+  visiblePhases,
+} from './session-model.js';
 
 describe('session event model', () => {
   it('reduces semantic events into a presentation-neutral transcript', () => {
@@ -62,8 +70,7 @@ describe('session event model', () => {
 
     expect(state.status).toBe('failed');
     expect(state.terminal).toBe(true);
-    expect(state.view).toBe('live');
-    expect(state.detailContent).toBe('');
+    expect(state.overlay).toBeNull();
     expect(state.conversation[0]?.content).toContain('This run has completed 30 rounds.');
     expect(state.conversation[0]?.content).toContain('resume_limit_exhausted');
     expect(state.conversation[0]?.tone).toBe('failure');
@@ -183,6 +190,99 @@ describe('session event model', () => {
       },
     ]);
   });
+
+  it('derives round-scoped agent flow from run and phase events', () => {
+    let state = applyEvent(
+      initialSessionState(),
+      event(1, 'run_started', {
+        kind: 'run_started',
+        outer_loop: 'agent',
+        input: 'examples/kv-store',
+        max_rounds: 5,
+      }),
+    );
+    expect(state.phases).toEqual([]);
+
+    state = applyEvent(state, {
+      ...event(2, 'phase_started', {kind: 'phase', phase: 'orchestrator', attempt: null}),
+      agent_kind: 'orchestrator',
+    });
+    state = applyEvent(state, {
+      ...event(3, 'phase_finished', {kind: 'phase', phase: 'orchestrator', attempt: null}),
+      agent_kind: 'orchestrator',
+    });
+
+    expect(state.rounds).toMatchObject([{number: 1, status: 'active'}]);
+    expect(visiblePhases(state).map(phase => `${phase.kind}:${phase.status}`)).toEqual([
+      'orchestrator:completed',
+      'implementer:pending',
+      'judge:pending',
+      'profiler:pending',
+    ]);
+    expect(visiblePhases(state)[0]).toMatchObject({
+      kind: 'orchestrator',
+      status: 'completed',
+      roundNumber: 1,
+      roundLabel: 'round-1',
+    });
+  });
+
+  it('filters conversation entries by selected round and agent', () => {
+    let state = initialSessionState();
+    state = applyEvent(
+      state,
+      event(
+        1,
+        'agent_output_chunk',
+        {
+          kind: 'agent_output_chunk',
+          channel: 'assistant',
+          content: 'judge output',
+        },
+        'judge-1',
+      ),
+    );
+    state = applyEvent(state, {
+      ...event(
+        2,
+        'agent_output_chunk',
+        {
+          kind: 'agent_output_chunk',
+          channel: 'assistant',
+          content: 'profiler output',
+        },
+        'profiler-1',
+      ),
+      agent_kind: 'profiler',
+    });
+    state = applyEvent(state, {
+      ...event(
+        3,
+        'agent_output_chunk',
+        {
+          kind: 'agent_output_chunk',
+          channel: 'assistant',
+          content: 'round two judge output',
+        },
+        'judge-2',
+      ),
+      round_label: 'round-2',
+    });
+
+    state = selectNextAgent(state);
+    expect(state.selectedAgentKind).toBe('judge');
+    expect(visibleConversation(state).map(entry => entry.content)).toEqual([
+      'round two judge output',
+    ]);
+    state = selectNextRound(state);
+    state = selectNextAgent(state);
+    expect(visibleConversation(state).map(entry => entry.content)).toEqual(['judge output']);
+
+    state = selectRound(state, 2);
+    expect(visibleConversation(state).map(entry => entry.content)).toEqual([
+      'round two judge output',
+    ]);
+  });
 });
 
 function event(
@@ -196,7 +296,7 @@ function event(
     timestamp: '2026-01-01T00:00:00Z',
     type,
     round_label: 'round-1',
-    agent_kind: 'judge',
+    ...(type === 'run_started' ? {} : {agent_kind: 'judge'}),
     ...(invocationId === undefined ? {} : {invocation_id: invocationId}),
     ...(data === undefined ? {} : {data}),
   };

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -1,11 +1,11 @@
 import type {RunEvent, RunSnapshot} from './protocol.js';
 import {
+  type AgentPhase,
   applyRunMapEvent,
+  type RoundSummary,
   roundNumberFromLabel,
   visiblePhases as visibleRunMapPhases,
   visibleRoundNumber as visibleRunMapRoundNumber,
-  type AgentPhase,
-  type RoundSummary,
 } from './run-map.js';
 
 export interface SessionState {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -1,15 +1,32 @@
 import type {RunEvent, RunSnapshot} from './protocol.js';
+import {
+  applyRunMapEvent,
+  roundNumberFromLabel,
+  visiblePhases as visibleRunMapPhases,
+  visibleRoundNumber as visibleRunMapRoundNumber,
+  type AgentPhase,
+  type RoundSummary,
+} from './run-map.js';
 
 export interface SessionState {
   sequence: number;
   status: string;
   agentKind: string | null;
   roundLabel: string | null;
+  outerLoop: string | null;
+  rounds: RoundSummary[];
+  phases: AgentPhase[];
+  selectedRound: number | null;
+  selectedAgentKind: string | null;
   liveContent: string;
   conversation: ConversationEntry[];
-  detailContent: string;
-  view: 'live' | 'detail' | 'help' | 'error';
+  overlay: OverlayPanel | null;
   terminal: boolean;
+}
+
+export interface OverlayPanel {
+  kind: 'detail' | 'help' | 'error';
+  content: string;
 }
 
 export interface ConversationEntry {
@@ -26,6 +43,9 @@ export interface ConversationEntry {
   content: string;
   label?: string;
   tone?: 'normal' | 'success' | 'failure';
+  agentKind?: string;
+  roundLabel?: string;
+  roundNumber?: number;
   turnId?: string;
   invocationId?: string;
   startsTurn?: boolean;
@@ -39,10 +59,14 @@ export function initialSessionState(): SessionState {
     status: 'connecting',
     agentKind: null,
     roundLabel: null,
+    outerLoop: null,
+    rounds: [],
+    phases: [],
+    selectedRound: null,
+    selectedAgentKind: null,
     liveContent: 'Waiting for run events…',
     conversation: [],
-    detailContent: '',
-    view: 'live',
+    overlay: null,
     terminal: false,
   };
 }
@@ -63,13 +87,22 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
   const next = {...state, sequence: Math.max(state.sequence, sequence)};
   if (event.agent_kind) next.agentKind = event.agent_kind;
   if (event.round_label) next.roundLabel = event.round_label;
+  const runMap = applyRunMapEvent(
+    {outerLoop: next.outerLoop, rounds: next.rounds, phases: next.phases},
+    event,
+  );
+  next.outerLoop = runMap.outerLoop;
+  next.rounds = runMap.rounds;
+  next.phases = runMap.phases;
 
   const line = renderEventForTranscript(event);
   if (line !== null) next.liveContent = appendTranscript(next.liveContent, line);
   const entry = eventToConversationEntry(event);
   if (entry !== null) next.conversation = appendConversation(next.conversation, entry);
 
-  if (event.type === 'run_started') next.status = 'running';
+  if (event.type === 'run_started') {
+    next.status = 'running';
+  }
   if (event.type === 'configuration_failed') {
     next.status = 'failed';
     next.terminal = true;
@@ -85,6 +118,54 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
   return next;
 }
 
+export function selectNextAgent(state: SessionState): SessionState {
+  const phases = visiblePhases(state);
+  if (phases.length === 0) return state;
+  const current = state.selectedAgentKind;
+  const index = current === null ? -1 : phases.findIndex(phase => phase.kind === current);
+  const next = phases[(index + 1 + phases.length) % phases.length];
+  return {...state, selectedAgentKind: next?.kind ?? null, overlay: null};
+}
+
+export function selectPreviousAgent(state: SessionState): SessionState {
+  const phases = visiblePhases(state);
+  if (phases.length === 0) return state;
+  const current = state.selectedAgentKind;
+  const index = current === null ? 0 : phases.findIndex(phase => phase.kind === current);
+  const previous = phases[(index - 1 + phases.length) % phases.length];
+  return {...state, selectedAgentKind: previous?.kind ?? null, overlay: null};
+}
+
+export function selectNextRound(state: SessionState): SessionState {
+  if (state.rounds.length === 0) return state;
+  const visible = visibleRoundNumber(state);
+  const index = visible === null ? -1 : state.rounds.findIndex(round => round.number === visible);
+  const next = state.rounds[(index + 1 + state.rounds.length) % state.rounds.length];
+  return {...state, selectedRound: next?.number ?? null, selectedAgentKind: null, overlay: null};
+}
+
+export function selectPreviousRound(state: SessionState): SessionState {
+  if (state.rounds.length === 0) return state;
+  const visible = visibleRoundNumber(state);
+  const index = visible === null ? 0 : state.rounds.findIndex(round => round.number === visible);
+  const previous = state.rounds[(index - 1 + state.rounds.length) % state.rounds.length];
+  return {
+    ...state,
+    selectedRound: previous?.number ?? null,
+    selectedAgentKind: null,
+    overlay: null,
+  };
+}
+
+export function selectRound(state: SessionState, roundNumber: number): SessionState {
+  if (!state.rounds.some(round => round.number === roundNumber)) return state;
+  return {...state, selectedRound: roundNumber, selectedAgentKind: null, overlay: null};
+}
+
+export function clearAgentSelection(state: SessionState): SessionState {
+  return {...state, selectedAgentKind: null, overlay: null};
+}
+
 function formatConfigurationFailure(event: RunEvent): string {
   const data = event.data;
   if (data?.kind !== 'configuration_failed') return event.text || 'Configuration failed.';
@@ -97,6 +178,13 @@ function formatConfigurationFailure(event: RunEvent): string {
 function eventToConversationEntry(event: RunEvent): ConversationEntry | null {
   const data = event.data;
   const id = String(event.sequence ?? `${event.timestamp}-${event.type}`);
+  const agentKind = event.agent_kind ? {agentKind: event.agent_kind} : {};
+  const roundLabel = event.round_label ? {roundLabel: event.round_label} : {};
+  const roundNumber = roundNumberFromLabel(event.round_label);
+  const roundFields = {
+    ...roundLabel,
+    ...(roundNumber === null ? {} : {roundNumber}),
+  };
   if (data?.kind === 'configuration_failed') {
     return {
       id,
@@ -123,6 +211,8 @@ function eventToConversationEntry(event: RunEvent): ConversationEntry | null {
       kind,
       content: data.content,
       label: labelFor(event, data.channel),
+      ...agentKind,
+      ...roundFields,
       turnId: invocationId ?? id,
       ...(invocationId === undefined ? {} : {invocationId}),
       startsTurn:
@@ -138,10 +228,19 @@ function eventToConversationEntry(event: RunEvent): ConversationEntry | null {
       kind: 'subprocess',
       content: data.content,
       label: `${data.process_kind} · ${data.stream}`,
+      ...agentKind,
+      ...roundFields,
     };
   }
   if (event.type === 'phase_started') {
-    return {id, kind: 'status', content: 'started', label: labelFor(event, 'phase')};
+    return {
+      id,
+      kind: 'status',
+      content: 'started',
+      label: labelFor(event, 'phase'),
+      ...agentKind,
+      ...roundFields,
+    };
   }
   if (data?.kind === 'judge_result') {
     return {
@@ -150,6 +249,8 @@ function eventToConversationEntry(event: RunEvent): ConversationEntry | null {
       content: data.feedback || `Judge returned ${data.verdict}.`,
       label: `Judge · ${data.verdict.toUpperCase()}`,
       tone: data.verdict === 'pass' ? 'success' : 'failure',
+      ...agentKind,
+      ...roundFields,
     };
   }
   if (data?.kind === 'benchmark_result') {
@@ -159,6 +260,8 @@ function eventToConversationEntry(event: RunEvent): ConversationEntry | null {
       content: `${data.metric}: ${data.value} ${data.unit}`,
       label: 'Benchmark',
       tone: 'success',
+      ...agentKind,
+      ...roundFields,
     };
   }
   if (data?.kind === 'round_finished') {
@@ -168,6 +271,8 @@ function eventToConversationEntry(event: RunEvent): ConversationEntry | null {
       content: `${data.attempts} attempt(s)`,
       label: `${event.round_label ?? 'Round'} · ${data.judge_verdict.toUpperCase()}`,
       tone: data.judge_verdict === 'pass' ? 'success' : 'failure',
+      ...agentKind,
+      ...roundFields,
     };
   }
   if (event.type === 'run_failed' || event.type === 'run_interrupted') {
@@ -177,6 +282,8 @@ function eventToConversationEntry(event: RunEvent): ConversationEntry | null {
       content: event.text || 'Run interrupted.',
       label: 'Run failed',
       tone: 'failure',
+      ...agentKind,
+      ...roundFields,
     };
   }
   return null;
@@ -222,19 +329,38 @@ function appendConversation(
 }
 
 export function showLive(state: SessionState): SessionState {
-  return {...state, view: 'live'};
+  return {...state, overlay: null, selectedRound: null, selectedAgentKind: null};
 }
 
 export function showDetail(
   state: SessionState,
-  detailContent: string,
-  view: SessionState['view'] = 'detail',
+  content: string,
+  kind: OverlayPanel['kind'] = 'detail',
 ): SessionState {
-  return {...state, detailContent, view};
+  return {...state, overlay: {kind, content}};
 }
 
 export function statusText(state: SessionState): string {
   return `${state.status} · ${state.agentKind ?? 'starting'} · ${state.roundLabel ?? 'no round yet'}`;
+}
+
+export function visibleConversation(state: SessionState): ConversationEntry[] {
+  const roundNumber = visibleRoundNumber(state);
+  return state.conversation.filter(entry => {
+    if (roundNumber !== null && entry.roundNumber !== roundNumber) return false;
+    if (state.selectedAgentKind !== null && entry.agentKind !== state.selectedAgentKind) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function visiblePhases(state: SessionState): AgentPhase[] {
+  return visibleRunMapPhases(state.phases, visibleRoundNumber(state));
+}
+
+export function visibleRoundNumber(state: SessionState): number | null {
+  return visibleRunMapRoundNumber(state.rounds, state.selectedRound);
 }
 
 function renderEventForTranscript(event: RunEvent): string | null {

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -1,0 +1,123 @@
+import {BoxRenderable, type CliRenderer, TextRenderable} from '@opentui/core';
+import type {AgentPhase} from '../run-map.js';
+import type {SessionState} from '../session-model.js';
+import {visiblePhases, visibleRoundNumber} from '../session-model.js';
+
+const STATUS_MARKER: Record<AgentPhase['status'], string> = {
+  pending: '○',
+  active: '●',
+  completed: '✓',
+  failed: '×',
+};
+
+const STATUS_COLOR: Record<AgentPhase['status'], string> = {
+  pending: '#64748b',
+  active: '#22c55e',
+  completed: '#60a5fa',
+  failed: '#f87171',
+};
+
+export class AgentMapView {
+  readonly output: BoxRenderable;
+  #renderedState: SessionState | null = null;
+
+  constructor(private readonly renderer: CliRenderer) {
+    this.output = new BoxRenderable(renderer, {
+      id: 'agent-map',
+      width: 30,
+      height: '100%',
+      flexDirection: 'column',
+      paddingLeft: 1,
+      paddingRight: 1,
+      border: true,
+      borderStyle: 'rounded',
+      borderColor: '#475569',
+      title: ' Agents ',
+    });
+  }
+
+  render(state: SessionState): void {
+    if (state === this.#renderedState) return;
+    this.#renderedState = state;
+    this.#clear();
+    const phases = visiblePhases(state);
+    if (phases.length === 0) {
+      this.output.add(
+        new TextRenderable(this.renderer, {
+          content: 'Waiting for phases…',
+          fg: '#64748b',
+          width: '100%',
+        }),
+      );
+      return;
+    }
+
+    const roundNumber = visibleRoundNumber(state);
+    this.output.add(
+      new TextRenderable(this.renderer, {
+        content: roundNumber === null ? 'Run flow' : `Round ${roundNumber} flow`,
+        fg: '#cbd5e1',
+        width: '100%',
+      }),
+    );
+    for (const [index, phase] of phases.entries()) {
+      this.output.add(this.#renderPhase(phase, state.selectedAgentKind === phase.kind));
+      if (index < phases.length - 1) {
+        this.output.add(
+          new TextRenderable(this.renderer, {
+            content: '        ↓',
+            fg: '#64748b',
+            width: '100%',
+          }),
+        );
+      }
+    }
+  }
+
+  #clear(): void {
+    for (const child of [...this.output.getChildren()]) {
+      this.output.remove(child);
+      child.destroyRecursively();
+    }
+  }
+
+  #renderPhase(phase: AgentPhase, selected: boolean): BoxRenderable {
+    const row = new BoxRenderable(this.renderer, {
+      id: `agent-${phase.kind}`,
+      width: '100%',
+      flexDirection: 'column',
+      marginTop: 1,
+      paddingLeft: 1,
+      paddingRight: 1,
+      border: selected,
+      borderStyle: 'rounded',
+      borderColor: selected ? '#22d3ee' : '#475569',
+      ...(selected ? {backgroundColor: '#0f172a'} : {}),
+    });
+    const statusColor = STATUS_COLOR[phase.status];
+    row.add(
+      new TextRenderable(this.renderer, {
+        content: `${STATUS_MARKER[phase.status]} ${phase.kind}`,
+        fg: selected ? '#f8fafc' : statusColor,
+        width: '100%',
+      }),
+    );
+    row.add(
+      new TextRenderable(this.renderer, {
+        content: phase.status,
+        fg: statusColor,
+        width: '100%',
+      }),
+    );
+    if (phase.roundLabel) {
+      row.add(
+        new TextRenderable(this.renderer, {
+          content: phase.roundLabel,
+          fg: '#94a3b8',
+          width: '100%',
+        }),
+      );
+    }
+    return row;
+  }
+}

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -18,11 +18,20 @@ describe('OpenTUI presentation', () => {
       status: 'running',
       agentKind: 'optimizer',
       roundLabel: 'round 2',
+      phases: [
+        {
+          kind: 'optimizer',
+          status: 'active',
+          roundNumber: null,
+          roundLabel: 'round 2',
+        },
+      ],
       conversation: [
         {
           id: '1',
           kind: 'assistant',
           label: 'optimizer · round 2',
+          agentKind: 'optimizer',
           content: '## Result\n\nUse `fast_path()`.',
         },
       ],
@@ -32,6 +41,8 @@ describe('OpenTUI presentation', () => {
 
     const frame = await testRenderer.waitForFrame(value => value.includes('fast_path()'));
     expect(frame).toContain('running · optimizer · round 2');
+    expect(frame).toContain('Rounds');
+    expect(frame).toContain('● optimizer');
     expect(frame).toContain('Result');
     expect(frame).toContain('Ask or command');
     expect(frame).toContain('Type a question or /help');
@@ -65,15 +76,18 @@ describe('OpenTUI presentation', () => {
     const testRenderer = await createTestRenderer({width: 100, height: 16});
     const controller = new FakeController({
       ...initialSessionState(),
-      view: 'help',
-      detailContent: 'Available commands',
+      overlay: {kind: 'help', content: 'Available commands'},
+      conversation: [{id: 'live', kind: 'assistant', label: 'Agent', content: 'live output'}],
     });
     const app = createOpenTuiApp(testRenderer.renderer, controller);
     registerCleanup(testRenderer.renderer, app);
 
-    await testRenderer.waitForFrame(value => value.includes('Esc: back to live'));
+    const overlay = await testRenderer.waitForFrame(value => value.includes('Esc: close dialog'));
+    expect(overlay).toContain('Available commands');
+    expect(overlay).toContain('Rounds');
+    expect(overlay).toContain('Agents');
     testRenderer.mockInput.pressKey('ESCAPE');
-    await testRenderer.waitForFrame(value => !value.includes('Esc: back to live'));
+    await testRenderer.waitForFrame(value => !value.includes('Esc: close dialog'));
     expect(controller.liveCalls).toBe(1);
   });
 
@@ -115,7 +129,7 @@ describe('OpenTUI presentation', () => {
 
     const frame = await testRenderer.waitForFrame(value => value.includes('2 passed'));
     expect(frame).toContain('→ Bash(command="pytest")');
-    expect(frame.match(/╭/g)).toHaveLength(3);
+    expect(frame.match(/╭/g)).toHaveLength(5);
   });
 
   it('collapses prompts and expands the latest prompt with Ctrl+P', async () => {
@@ -133,6 +147,46 @@ describe('OpenTUI presentation', () => {
     testRenderer.mockInput.pressKey('p', {ctrl: true});
     const expanded = await testRenderer.waitForFrame(value => value.includes('prompt line 20'));
     expect(expanded).toContain('collapse');
+  });
+
+  it('selects an agent with Tab and filters the transcript', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 20});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      phases: [
+        {kind: 'implementer', status: 'completed', roundNumber: 1, roundLabel: 'round-1'},
+        {kind: 'judge', status: 'active', roundNumber: 1, roundLabel: 'round-1'},
+      ],
+      rounds: [{number: 1, status: 'active'}],
+      conversation: [
+        {
+          id: 'implementer',
+          kind: 'assistant',
+          label: 'implementer · round 1',
+          agentKind: 'implementer',
+          roundNumber: 1,
+          content: 'edited files',
+        },
+        {
+          id: 'judge',
+          kind: 'assistant',
+          label: 'judge · round 1',
+          agentKind: 'judge',
+          roundNumber: 1,
+          content: 'checking behavior',
+        },
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    await testRenderer.waitForFrame(value => value.includes('checking behavior'));
+    testRenderer.mockInput.pressKey('TAB');
+    const filtered = await testRenderer.waitForFrame(value =>
+      value.includes('selected implementer'),
+    );
+    expect(filtered).toContain('edited files');
+    expect(filtered).not.toContain('checking behavior');
   });
 
   it('keeps terminal results visible until the operator exits', async () => {
@@ -196,7 +250,36 @@ class FakeController implements SessionController {
   }
   live(): void {
     this.liveCalls += 1;
-    this.state = {...this.state, view: 'live'};
+    this.state = {...this.state, overlay: null, selectedRound: null, selectedAgentKind: null};
+    for (const listener of this.#listeners) listener(this.state);
+  }
+  selectNextAgent(): void {
+    const current = this.state.selectedAgentKind;
+    const visibleRound =
+      this.state.selectedRound ??
+      this.state.rounds.find(round => round.status === 'active')?.number ??
+      null;
+    const phases = this.state.phases.filter(phase => phase.roundNumber === visibleRound);
+    const index = current === null ? -1 : phases.findIndex(phase => phase.kind === current);
+    const next = phases[(index + 1 + phases.length) % phases.length];
+    this.state = {...this.state, selectedAgentKind: next?.kind ?? null, overlay: null};
+    for (const listener of this.#listeners) listener(this.state);
+  }
+  selectPreviousAgent(): void {
+    this.selectNextAgent();
+  }
+  selectNextRound(): void {
+    const index = this.state.rounds.findIndex(round => round.number === this.state.selectedRound);
+    const next =
+      this.state.rounds[(index + 1 + this.state.rounds.length) % this.state.rounds.length];
+    this.state = {...this.state, selectedRound: next?.number ?? null, selectedAgentKind: null};
+    for (const listener of this.#listeners) listener(this.state);
+  }
+  selectPreviousRound(): void {
+    this.selectNextRound();
+  }
+  selectRound(roundNumber: number): void {
+    this.state = {...this.state, selectedRound: roundNumber, selectedAgentKind: null};
     for (const listener of this.#listeners) listener(this.state);
   }
 

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -48,6 +48,31 @@ describe('OpenTUI presentation', () => {
     expect(frame).toContain('Type a question or /help');
   });
 
+  it('renders quiet round labels without status text or symbols', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 18});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      rounds: [
+        {number: 1, status: 'completed'},
+        {number: 2, status: 'active'},
+        {number: 3, status: 'failed'},
+      ],
+      conversation: [{id: 'live', kind: 'assistant', label: 'Agent', content: 'live output'}],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('r2'));
+
+    expect(frame).toContain('r1');
+    expect(frame).toContain('r2');
+    expect(frame).toContain('r3');
+    expect(frame).not.toMatch(/[◐◓◑◒]/);
+    expect(frame).not.toContain('done');
+    expect(frame).not.toContain(':run');
+    expect(frame).not.toContain('fail');
+  });
+
   it('submits typed commands when Enter is pressed', async () => {
     const testRenderer = await createTestRenderer({width: 80, height: 16});
     const controller = new FakeController(initialSessionState());

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -2,8 +2,11 @@ import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} fr
 import type {SessionController} from '../session-controller.js';
 import {type SessionState, statusText} from '../session-model.js';
 import {ConversationView} from './conversation.js';
+import {AgentMapView} from './agent-map.js';
 import {createInputPanel} from './input.js';
 import {bindKeybindings} from './keybindings.js';
+import {RoundStripView} from './round-strip.js';
+import {OverlayView} from './overlay.js';
 import {createMarkdownStyle} from './styles.js';
 
 export interface OpenTuiApp {
@@ -25,7 +28,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   });
   const viewport = new ScrollBoxRenderable(renderer, {
     id: 'viewport',
-    width: '100%',
+    width: 'auto',
     flexGrow: 1,
     border: true,
     borderStyle: 'rounded',
@@ -35,31 +38,52 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     viewportCulling: true,
     verticalScrollbarOptions: {showArrows: true},
   });
+  const main = new BoxRenderable(renderer, {
+    id: 'main',
+    width: '100%',
+    flexGrow: 1,
+    flexDirection: 'row',
+  });
   const help = new TextRenderable(renderer, {
     id: 'key-help',
     height: 1,
     fg: '#64748b',
-    content: '↑/↓ · PgUp/PgDn · Ctrl+P: prompt · Ctrl+L: live · /help',
+    content: '[/]: round · Tab: agent · PgUp/PgDn · Ctrl+P: prompt · Ctrl+L: live',
   });
   const markdownStyle = createMarkdownStyle();
+  const roundStrip = new RoundStripView(renderer, controller);
+  const agentMap = new AgentMapView(renderer);
+  const overlay = new OverlayView(renderer);
   const conversation = new ConversationView(renderer, controller, markdownStyle);
   const input = createInputPanel(renderer, value => void controller.submit(value));
 
   viewport.add(conversation.output);
+  main.add(agentMap.output);
+  main.add(viewport);
   root.add(header);
-  root.add(viewport);
+  root.add(roundStrip.output);
+  root.add(main);
   root.add(help);
   root.add(input.box);
+  root.add(overlay.output);
   renderer.root.add(root);
   input.focus();
 
   const render = (state: SessionState): void => {
-    const returnHint = state.view === 'live' ? '' : ' · Esc: back to live';
-    header.content = `VibeSys · ${statusText(state)}${returnHint}`;
+    const returnHint = state.overlay === null ? '' : ' · Esc: close dialog';
+    const selection = state.selectedAgentKind ? ` · selected ${state.selectedAgentKind}` : '';
+    header.content = `VibeSys · ${statusText(state)}${selection}${returnHint}`;
+    roundStrip.render(state);
+    agentMap.render(state);
     conversation.render(state);
+    overlay.render(state);
   };
   const unbindKeys = bindKeybindings(renderer, controller, viewport, {
     toggleLatestPrompt: () => conversation.toggleLatestPrompt(),
+    selectNextAgent: () => controller.selectNextAgent(),
+    selectPreviousAgent: () => controller.selectPreviousAgent(),
+    selectNextRound: () => controller.selectNextRound(),
+    selectPreviousRound: () => controller.selectPreviousRound(),
   });
   const unsubscribe = controller.subscribe(render);
 

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -1,12 +1,12 @@
 import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
 import {type SessionState, statusText} from '../session-model.js';
-import {ConversationView} from './conversation.js';
 import {AgentMapView} from './agent-map.js';
+import {ConversationView} from './conversation.js';
 import {createInputPanel} from './input.js';
 import {bindKeybindings} from './keybindings.js';
-import {RoundStripView} from './round-strip.js';
 import {OverlayView} from './overlay.js';
+import {RoundStripView} from './round-strip.js';
 import {createMarkdownStyle} from './styles.js';
 
 export interface OpenTuiApp {

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -7,6 +7,7 @@ import {
 } from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
 import type {ConversationEntry, SessionState} from '../session-model.js';
+import {visibleConversation} from '../session-model.js';
 import {promptPreview, toolOutputPreview} from './previews.js';
 import {entryPalette} from './styles.js';
 
@@ -30,8 +31,7 @@ export class ConversationView {
   }
 
   render(state: SessionState): void {
-    if (state.view === 'live') this.#renderConversation(state.conversation);
-    else this.#renderDetail(state.detailContent);
+    this.#renderConversation(visibleConversation(state));
   }
 
   toggleLatestPrompt(): void {
@@ -46,12 +46,6 @@ export class ConversationView {
       this.output.remove(child);
       child.destroyRecursively();
     }
-  }
-
-  #renderDetail(content: string): void {
-    this.#renderedConversation = [];
-    this.#clear();
-    this.output.add(new TextRenderable(this.renderer, {content, fg: '#e2e8f0', width: '100%'}));
   }
 
   #renderConversation(entries: ConversationEntry[]): void {

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -3,6 +3,10 @@ import type {SessionController} from '../session-controller.js';
 
 export interface KeybindingActions {
   toggleLatestPrompt(): void;
+  selectNextAgent(): void;
+  selectPreviousAgent(): void;
+  selectNextRound(): void;
+  selectPreviousRound(): void;
 }
 
 export function bindKeybindings(
@@ -17,7 +21,7 @@ export function bindKeybindings(
       renderer.destroy();
       return;
     }
-    if (key.name === 'escape' && controller.state.view !== 'live') {
+    if (key.name === 'escape' && controller.state.overlay !== null) {
       controller.live();
       viewport.scrollTo(viewport.scrollHeight);
       key.preventDefault();
@@ -30,6 +34,25 @@ export function bindKeybindings(
     }
     if (key.ctrl && key.name === 'l') {
       controller.live();
+      viewport.scrollTo(viewport.scrollHeight);
+      key.preventDefault();
+      return;
+    }
+    if (key.name === 'tab') {
+      if (key.shift) actions.selectPreviousAgent();
+      else actions.selectNextAgent();
+      viewport.scrollTo(viewport.scrollHeight);
+      key.preventDefault();
+      return;
+    }
+    if (key.name === ']') {
+      actions.selectNextRound();
+      viewport.scrollTo(viewport.scrollHeight);
+      key.preventDefault();
+      return;
+    }
+    if (key.name === '[') {
+      actions.selectPreviousRound();
       viewport.scrollTo(viewport.scrollHeight);
       key.preventDefault();
       return;

--- a/clients/tui/src/ui/overlay.ts
+++ b/clients/tui/src/ui/overlay.ts
@@ -1,0 +1,75 @@
+import {BoxRenderable, type CliRenderer, TextRenderable} from '@opentui/core';
+import type {SessionState} from '../session-model.js';
+
+const TITLE: Record<NonNullable<SessionState['overlay']>['kind'], string> = {
+  detail: 'Command',
+  help: 'Help',
+  error: 'Error',
+};
+
+const BORDER: Record<NonNullable<SessionState['overlay']>['kind'], string> = {
+  detail: '#38bdf8',
+  help: '#22c55e',
+  error: '#f87171',
+};
+
+export class OverlayView {
+  readonly output: BoxRenderable;
+  #renderedKind: NonNullable<SessionState['overlay']>['kind'] | null = null;
+  #renderedContent = '';
+
+  constructor(private readonly renderer: CliRenderer) {
+    this.output = new BoxRenderable(renderer, {
+      id: 'overlay',
+      width: '70%',
+      height: '60%',
+      position: 'absolute',
+      left: '15%',
+      top: '18%',
+      flexDirection: 'column',
+      paddingLeft: 1,
+      paddingRight: 1,
+      border: true,
+      borderStyle: 'rounded',
+      borderColor: '#38bdf8',
+      backgroundColor: '#020617',
+      zIndex: 10,
+    });
+  }
+
+  render(state: SessionState): void {
+    const overlay = state.overlay;
+    if (overlay === null) {
+      this.output.visible = false;
+      return;
+    }
+    this.output.visible = true;
+    if (this.#renderedKind === overlay.kind && this.#renderedContent === overlay.content) return;
+    this.#renderedKind = overlay.kind;
+    this.#renderedContent = overlay.content;
+    this.output.borderColor = BORDER[overlay.kind];
+    this.output.title = ` ${TITLE[overlay.kind]} `;
+    this.#clear();
+    this.output.add(
+      new TextRenderable(this.renderer, {
+        content: overlay.content,
+        fg: overlay.kind === 'error' ? '#fecaca' : '#e2e8f0',
+        width: '100%',
+      }),
+    );
+    this.output.add(
+      new TextRenderable(this.renderer, {
+        content: 'Esc to close',
+        fg: '#64748b',
+        width: '100%',
+      }),
+    );
+  }
+
+  #clear(): void {
+    for (const child of [...this.output.getChildren()]) {
+      this.output.remove(child);
+      child.destroyRecursively();
+    }
+  }
+}

--- a/clients/tui/src/ui/round-strip.ts
+++ b/clients/tui/src/ui/round-strip.ts
@@ -1,0 +1,75 @@
+import {BoxRenderable, type CliRenderer, TextRenderable} from '@opentui/core';
+import type {SessionController} from '../session-controller.js';
+import type {RoundSummary} from '../run-map.js';
+import type {SessionState} from '../session-model.js';
+import {visibleRoundNumber} from '../session-model.js';
+
+const ROUND_MARKER: Record<RoundSummary['status'], string> = {
+  active: '●',
+  completed: '✓',
+  failed: '×',
+};
+
+export class RoundStripView {
+  readonly output: BoxRenderable;
+  #renderedState: SessionState | null = null;
+
+  constructor(
+    private readonly renderer: CliRenderer,
+    private readonly controller: SessionController,
+  ) {
+    this.output = new BoxRenderable(renderer, {
+      id: 'round-strip',
+      width: '100%',
+      height: 3,
+      border: true,
+      borderStyle: 'rounded',
+      borderColor: '#334155',
+      paddingLeft: 1,
+      paddingRight: 1,
+      title: ' Rounds ',
+    });
+  }
+
+  render(state: SessionState): void {
+    if (state === this.#renderedState) return;
+    this.#renderedState = state;
+    this.#clear();
+    if (state.rounds.length === 0) {
+      this.output.add(
+        new TextRenderable(this.renderer, {
+          content: 'Waiting for rounds...',
+          fg: '#64748b',
+          width: '100%',
+        }),
+      );
+      return;
+    }
+    const row = new BoxRenderable(this.renderer, {
+      id: 'round-strip-row',
+      width: '100%',
+      flexDirection: 'row',
+    });
+    const selected = visibleRoundNumber(state);
+    for (const round of state.rounds.slice(-8)) row.add(this.#renderRound(round, selected));
+    this.output.add(row);
+  }
+
+  #clear(): void {
+    for (const child of [...this.output.getChildren()]) {
+      this.output.remove(child);
+      child.destroyRecursively();
+    }
+  }
+
+  #renderRound(round: RoundSummary, selected: number | null): TextRenderable {
+    const isSelected = round.number === selected;
+    const label = `${isSelected ? '[' : ' '} ${round.number}${ROUND_MARKER[round.status]} ${isSelected ? ']' : ' '}`;
+    return new TextRenderable(this.renderer, {
+      content: label,
+      fg: isSelected ? '#f8fafc' : '#cbd5e1',
+      ...(isSelected ? {bg: '#0f172a'} : {}),
+      onMouseUp: () => this.controller.selectRound(round.number),
+    });
+  }
+}

--- a/clients/tui/src/ui/round-strip.ts
+++ b/clients/tui/src/ui/round-strip.ts
@@ -1,6 +1,6 @@
 import {BoxRenderable, type CliRenderer, TextRenderable} from '@opentui/core';
-import type {SessionController} from '../session-controller.js';
 import type {RoundSummary} from '../run-map.js';
+import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
 import {visibleRoundNumber} from '../session-model.js';
 

--- a/clients/tui/src/ui/round-strip.ts
+++ b/clients/tui/src/ui/round-strip.ts
@@ -4,11 +4,8 @@ import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
 import {visibleRoundNumber} from '../session-model.js';
 
-const ROUND_MARKER: Record<RoundSummary['status'], string> = {
-  active: '●',
-  completed: '✓',
-  failed: '×',
-};
+const ACTIVE_ROUND_COLOR = '#22c55e';
+const DEFAULT_ROUND_COLOR = '#cbd5e1';
 
 export class RoundStripView {
   readonly output: BoxRenderable;
@@ -51,7 +48,10 @@ export class RoundStripView {
       flexDirection: 'row',
     });
     const selected = visibleRoundNumber(state);
-    for (const round of state.rounds.slice(-8)) row.add(this.#renderRound(round, selected));
+    const runningRound = latestActiveRoundNumber(state.rounds);
+    for (const round of state.rounds.slice(-8)) {
+      row.add(this.#renderRound(round, {selected, runningRound}));
+    }
     this.output.add(row);
   }
 
@@ -62,14 +62,27 @@ export class RoundStripView {
     }
   }
 
-  #renderRound(round: RoundSummary, selected: number | null): TextRenderable {
+  #renderRound(
+    round: RoundSummary,
+    viewState: {selected: number | null; runningRound: number | null},
+  ): TextRenderable {
+    const {selected, runningRound} = viewState;
     const isSelected = round.number === selected;
-    const label = `${isSelected ? '[' : ' '} ${round.number}${ROUND_MARKER[round.status]} ${isSelected ? ']' : ' '}`;
+    const isRunning = round.number === runningRound;
     return new TextRenderable(this.renderer, {
-      content: label,
-      fg: isSelected ? '#f8fafc' : '#cbd5e1',
+      content: this.#roundLabel(round, selected),
+      fg: isRunning ? ACTIVE_ROUND_COLOR : DEFAULT_ROUND_COLOR,
       ...(isSelected ? {bg: '#0f172a'} : {}),
       onMouseUp: () => this.controller.selectRound(round.number),
     });
   }
+
+  #roundLabel(round: RoundSummary, selected: number | null): string {
+    const isSelected = round.number === selected;
+    return `${isSelected ? '[' : ' '} r${round.number} ${isSelected ? ']' : ' '}`;
+  }
+}
+
+function latestActiveRoundNumber(rounds: RoundSummary[]): number | null {
+  return [...rounds].reverse().find(round => round.status === 'active')?.number ?? null;
 }

--- a/src/vibesys/cli.py
+++ b/src/vibesys/cli.py
@@ -352,9 +352,13 @@ def _resolve_run_dir(run_dir_arg: str) -> str:
     """Resolve a run directory name.
 
     If *run_dir_arg* is ``"latest"``, find the most recent experiment
-    directory in ``exp_env/``. Otherwise return *run_dir_arg* as-is.
+    directory in ``exp_env/``. Otherwise accept either a bare run directory
+    name or a path whose final parent is ``exp_env``.
     """
     if run_dir_arg != "latest":
+        run_dir_path = Path(run_dir_arg)
+        if run_dir_path.parent.name == "exp_env":
+            return run_dir_path.name
         return run_dir_arg
     exp_env = PROJECT_ROOT / "exp_env"
     if not exp_env.is_dir():
@@ -369,6 +373,66 @@ def _resolve_run_dir(run_dir_arg: str) -> str:
             stage="resume_resolution",
         )
     return dirs[-1]
+
+
+def _resume_exp_dir(run_dir_name: str) -> Path:
+    return PROJECT_ROOT / "exp_env" / run_dir_name
+
+
+def _infer_resume_input(exp_dir: Path) -> Path:
+    events_path = exp_dir / "logs" / "run-events.jsonl"
+    if not events_path.is_file():
+        _configuration_error(
+            f"Cannot infer --input because resume metadata is missing: {events_path}",
+            code="resume_input_not_found",
+            stage="resume_resolution",
+        )
+
+    for line_number, line in enumerate(events_path.read_text().splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            _configuration_error(
+                f"Cannot infer --input because {events_path}:{line_number} is invalid JSON: {exc}",
+                code="resume_input_invalid",
+                stage="resume_resolution",
+            )
+        if event.get("type") != "run_started":
+            continue
+        data = event.get("data")
+        if not isinstance(data, dict):
+            break
+        input_path = data.get("input")
+        if isinstance(input_path, str) and input_path:
+            return Path(input_path)
+        break
+
+    _configuration_error(
+        f"Cannot infer --input because no run_started input was found in {events_path}",
+        code="resume_input_not_found",
+        stage="resume_resolution",
+    )
+
+
+def _resolve_resume_args(args: argparse.Namespace) -> None:
+    if args.resume is None:
+        return
+
+    run_dir_name = _resolve_run_dir(args.resume)
+    args.resume = run_dir_name
+    if args.input is not None:
+        return
+
+    exp_dir = _resume_exp_dir(run_dir_name)
+    if not exp_dir.is_dir():
+        _configuration_error(
+            f"Run directory does not exist: exp_env/{run_dir_name}",
+            code="resume_not_found",
+            stage="resume_resolution",
+        )
+    args.input = _infer_resume_input(exp_dir)
 
 
 def _apply_common_args(parser: argparse.ArgumentParser) -> None:
@@ -933,6 +997,7 @@ def parse_cli_invocation(argv: list[str]) -> CliInvocation:
     """Parse and validate one invocation without printing or exiting."""
     loop_kind, remaining = _extract_loop_selection(argv)
     args = _PARSER_BUILDERS[loop_kind]().parse_args(remaining)
+    _resolve_resume_args(args)
     globals()[_VALIDATORS[loop_kind]](args)
     return CliInvocation(loop_kind=loop_kind, args=args)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,13 @@ from unittest.mock import patch
 
 import pytest
 
-from vibesys.cli import _extract_flag, _extract_loop_selection, _validate_target_inputs, main
+from vibesys.cli import (
+    _extract_flag,
+    _extract_loop_selection,
+    _validate_target_inputs,
+    main,
+    parse_cli_invocation,
+)
 from vibesys.domains.base import DomainName
 from vibesys.errors import ConfigurationError
 from vibesys.profilers import ProfilerKind
@@ -35,6 +41,20 @@ command = ["uv", "run", "python", "benchmark/benchmark.py"]
 """.lstrip()
     )
     return bundle
+
+
+def _write_resume_event(
+    exp_dir: Path, input_path: Path, *, event_type: str = "run_started"
+) -> None:
+    logs = exp_dir / "logs"
+    logs.mkdir(parents=True)
+    content = (
+        '{"type": "server_started", "data": null}\n'
+        f'{{"type": "{event_type}", "data": '
+        f'{{"kind": "run_started", "outer_loop": "agent", "input": "{input_path}", '
+        '"max_rounds": 2}}\n'
+    )
+    (logs / "run-events.jsonl").write_text(content)
 
 
 # ---------------------------------------------------------------------------
@@ -289,6 +309,67 @@ def test_validate_target_inputs_requires_input():
         _validate_target_inputs(args)
 
     assert "missing required target input: --input" in exc.value.diagnostic.message
+
+
+def test_resume_without_input_infers_original_input(monkeypatch, tmp_path):
+    import vibesys.cli as cli
+
+    bundle = _write_input_bundle(tmp_path)
+    run_dir = tmp_path / "exp_env" / "20260716-180256-test"
+    _write_resume_event(run_dir, bundle)
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+
+    invocation = parse_cli_invocation(["--outer-loop", "agent", "--resume", "20260716-180256-test"])
+
+    assert invocation.args.resume == "20260716-180256-test"
+    assert invocation.args.input == bundle
+    assert invocation.args.input_bundle.root == bundle.resolve()
+
+
+def test_resume_accepts_exp_env_path_without_input(monkeypatch, tmp_path):
+    import vibesys.cli as cli
+
+    bundle = _write_input_bundle(tmp_path)
+    run_dir = tmp_path / "exp_env" / "20260716-180256-test"
+    _write_resume_event(run_dir, bundle)
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+
+    invocation = parse_cli_invocation(
+        ["--outer-loop", "agent", "--resume", str(run_dir.relative_to(tmp_path))]
+    )
+
+    assert invocation.args.resume == "20260716-180256-test"
+    assert invocation.args.input_bundle.root == bundle.resolve()
+
+
+def test_resume_latest_without_input_uses_latest_run_metadata(monkeypatch, tmp_path):
+    import vibesys.cli as cli
+
+    older_bundle = _write_input_bundle(tmp_path / "older")
+    latest_bundle = _write_input_bundle(tmp_path / "latest")
+    older = tmp_path / "exp_env" / "20260716-100000-test"
+    latest = tmp_path / "exp_env" / "20260716-180256-test"
+    _write_resume_event(older, older_bundle)
+    _write_resume_event(latest, latest_bundle)
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+
+    invocation = parse_cli_invocation(["--outer-loop", "agent", "--resume"])
+
+    assert invocation.args.resume == "20260716-180256-test"
+    assert invocation.args.input_bundle.root == latest_bundle.resolve()
+
+
+def test_resume_without_input_reports_missing_metadata(monkeypatch, tmp_path):
+    import vibesys.cli as cli
+
+    (tmp_path / "exp_env" / "20260716-180256-test" / "logs").mkdir(parents=True)
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+
+    with pytest.raises(ConfigurationError) as exc:
+        parse_cli_invocation(["--outer-loop", "agent", "--resume", "20260716-180256-test"])
+
+    assert exc.value.diagnostic.code == "resume_input_not_found"
+    assert exc.value.diagnostic.stage == "resume_resolution"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The interactive TUI showed run output as a flat transcript with only a header-level current agent label. That made it hard for operators to understand the active control-flow structure across rounds, inspect a prior round, or focus on a specific agent role's trajectory without losing context. Slash command output also reused the trajectory pane, mixing operator UI with agent output.

While testing resumed agent runs, the CLI also required `--input` even though resume metadata already records the original input bundle. That made documented resume commands such as `./vs --resume ...` fail with a missing-input error.

## Solution

Add a round-first run map to the TUI while keeping the backend protocol unchanged:

- derive rounds, per-round agent phases, and active/completed/failed state from existing run events;
- render a compact clickable round strip for history navigation, with only the latest running round highlighted in the same green used for active agents;
- render a per-round agent-flow pane with role ordering and arrows;
- filter the trajectory pane by selected round and selected agent role;
- render slash-command/help/error output in an overlay dialog instead of replacing the trajectory pane;
- isolate round/phase derivation in `run-map.ts` so the session model, renderers, and future steering work have clearer boundaries.

The agent-loop visual order is `orchestrator -> implementer -> judge -> profiler`, matching the operator-facing build/evaluate flow. Other loop types keep their own role ordering.

Resume handling now normalizes `--resume ./exp_env/<run>/` to the run name and infers `--input` from the prior run's `logs/run-events.jsonl` when the user omits it. Explicit `--input` still wins.

## Verification

Ran focused CLI checks, TUI checks, formatter/linter checks, and the TUI test suite successfully.

### Correctness properties

- Visualization is derived only from existing supervision events; no backend protocol changes are introduced.
- Slash-command output is operator UI and does not enter the agent trajectory transcript.
- Round selection scopes visible agents and transcript entries to that round.
- Agent selection scopes transcript entries further to the selected role.
- Only the latest active round gets the active visual treatment; selected historical rounds remain selectable without implying they are running.
- Resume without `--input` uses persisted run metadata, and explicit `--input` remains an override.
- Missing resume metadata reports a resume-specific configuration error.

### Testing

- `./scripts/check_format.sh && ./scripts/check_lint.sh && uv run pytest tests/test_cli.py -q` - passed
- `pnpm --filter @vibesys/tui check && pnpm --filter @vibesys/tui test -- --runInBand && pnpm check:format:ts && pnpm lint:ts` - passed
- Earlier PR verification: `pnpm --dir clients/tui build` - passed