### PR TITLE
Add README ASCII wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+<div align="center">
+
+<pre>
+VV     VV  III  BBBBBB   EEEEEEE   SSSSSS  YY    YY   SSSSSS
+VV     VV  III  BB   BB  EE       SS    SS  YY    YY  SS    SS
+ VV   VV   III  BBBBBB   EEEEE     SSSS      YY  YY    SSSS
+  VV VV    III  BB   BB  EE           SSSS     YYYY        SSSS
+   VVV     III  BB   BB  EE       SS    SS      YY     SS    SS
+    V      III  BBBBBB   EEEEEEE   SSSSSS       YY      SSSSSS
+</pre>
+
+</div>
+
 # VibeSys: Generating Bespoke Systems with AI Agents
 
 [![arXiv](https://img.shields.io/badge/arXiv-2605.06068-b31b1b.svg)](https://arxiv.org/abs/2605.06068)


### PR DESCRIPTION
## Problem

The README starts directly with the title and badge. Adding a small project wordmark gives the VibeSys landing page a more distinctive first impression without changing any project behavior or documentation content.

## Solution

Add a centered preformatted ASCII `VibeSys` wordmark at the top of `README.md`. The block uses raw HTML `<pre>` inside a centered container so GitHub renders the ASCII art predictably.

## Verification

Verified the README diff manually and ran Git's whitespace check after removing trailing spaces from the ASCII block.

### Correctness properties

- Documentation-only change; no runtime behavior, CLI flags, examples, prompts, manifests, or evaluator interfaces are changed.
- Existing README sections, badges, links, and images remain intact.
- ASCII art is contained in a preformatted block so spacing is preserved by Markdown renderers.

### Testing

- `git diff --check` - passed.
- Python tests were not run because this PR only changes README presentation.
