### PR TITLE
Add architecture guidance to PR template

### DIFF
--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -69,6 +69,7 @@ Use this repository's template headings exactly:
 
 - `Problem`: Lead with intent. Explain the maintainer or user pain, why the change is needed, what context led to it, and any issue links. This is the highest-priority section of the PR body.
 - `Solution`: Describe the high-level design, important boundaries, tradeoffs, and what reviewers should inspect.
+- `Architecture`: Use this subsection under `Solution` to describe the ownership model and major components involved in the solution. For nontrivial control flow or cross-boundary changes, include a Mermaid diagram or equivalent sketch that shows how the pieces interact.
 - `Verification`: Summarize automated tests, manual checks, benchmarks, or why a check was not run.
 - `Correctness properties`: List invariants, contracts, expected behaviors, and compatibility constraints preserved or introduced.
 - `Testing`: List exact commands/workflows and their results.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,14 @@ Describe the high-level design. Call out important implementation choices,
 tradeoffs, boundaries, and any behavior that reviewers should inspect closely.
 -->
 
+### Architecture
+
+<!--
+Describe the ownership model and major components involved in the solution.
+For nontrivial control flow or cross-boundary changes, include a Mermaid diagram
+or equivalent sketch that shows how the pieces interact.
+-->
+
 ## Verification
 
 <!--


### PR DESCRIPTION
## Problem

Recent PRs that touch cross-boundary behavior need a clearer place to explain the architecture of the solution. The current PR template asks for high-level design in `Solution`, but it does not explicitly prompt authors to describe ownership, major components, or diagrams for nontrivial control flow. The open-pr skill also does not tell agents to fill such a subsection.

## Solution

Add an `Architecture` subsection under `Solution` in the repository PR template, and update the open-pr skill to require the same subsection when preparing PR bodies.

### Architecture

This is a documentation/tooling-only change with two matching surfaces:

```mermaid
flowchart LR
    Template[.github/pull_request_template.md]
    Skill[.agents/skills/open-pr/SKILL.md]
    Author[PR author or agent]
    PR[Pull request body]

    Template --> Author
    Skill --> Author
    Author --> PR
```

The template now prompts authors to describe ownership and major components, and to include a Mermaid diagram or equivalent sketch for nontrivial control flow or cross-boundary changes. The skill mirrors that instruction so agent-created PRs follow the same convention.

## Verification

Ran the repository's lightweight checks for formatting and linting. This change only edits Markdown guidance.

### Correctness properties

- The existing top-level PR template headings remain unchanged: `Problem`, `Solution`, and `Verification`.
- `Architecture` is a subsection under `Solution`, matching the requested PR body structure.
- The open-pr skill and PR template now give consistent guidance.
- The change does not affect runtime code, tests, packaging, or CI behavior.

### Testing

- `./scripts/check_format.sh` → passed
- `./scripts/check_lint.sh` → passed
