### PR TITLE
Add repository validation command

### DIFF
--- a/clients/tui/src/launcher.test.ts
+++ b/clients/tui/src/launcher.test.ts
@@ -86,6 +86,21 @@ process.exit(0);
     await expect(launch(['--stub-agent'])).resolves.toBe(0);
     await access(backendTerminated);
   });
+
+  it('runs validation directly without starting the interactive client', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'vs-launcher-test-'));
+    const backend = await writeExecutable(
+      'fake-backend.mjs',
+      `
+process.exit(process.argv.includes('validate') ? 0 : 9);
+`,
+    );
+
+    process.env['VIBESYS_PYTHON'] = backend;
+    process.env['VIBESYS_TUI_RUNTIME'] = join(tempDir, 'missing-runtime');
+
+    await expect(launch(['validate'])).resolves.toBe(0);
+  });
 });
 
 async function writeExecutable(name: string, source: string): Promise<string> {

--- a/clients/tui/src/launcher.test.ts
+++ b/clients/tui/src/launcher.test.ts
@@ -92,14 +92,16 @@ process.exit(0);
     const backend = await writeExecutable(
       'fake-backend.mjs',
       `
-process.exit(process.argv.includes('validate') ? 0 : 9);
+process.exit(
+  process.argv.includes('validate') && process.argv.includes('examples/kv-store') ? 0 : 9,
+);
 `,
     );
 
     process.env['VIBESYS_PYTHON'] = backend;
     process.env['VIBESYS_TUI_RUNTIME'] = join(tempDir, 'missing-runtime');
 
-    await expect(launch(['validate'])).resolves.toBe(0);
+    await expect(launch(['validate', 'examples/kv-store'])).resolves.toBe(0);
   });
 });
 

--- a/clients/tui/src/launcher.ts
+++ b/clients/tui/src/launcher.ts
@@ -14,14 +14,16 @@ const SHUTDOWN_TIMEOUT_MS = 10_000;
 const BACKEND_EXIT_GRACE_MS = 2_000;
 
 export async function launch(argv: string[]): Promise<number> {
-  if (argv.some(argument => argument === '-h' || argument === '--help')) {
-    const backend = resolveBackendCommand();
-    if (!backend) return reportMissingPython();
-    return runToCompletion(backend.command, [...backend.args, ...argv, '--headless']);
-  }
-
   const backend = resolveBackendCommand();
   if (!backend) return reportMissingPython();
+
+  if (argv[0] === 'validate') {
+    return runToCompletion(backend.command, [...backend.args, ...argv]);
+  }
+
+  if (argv.some(argument => argument === '-h' || argument === '--help')) {
+    return runToCompletion(backend.command, [...backend.args, ...argv, '--headless']);
+  }
 
   const runtime = process.env['VIBESYS_TUI_RUNTIME'] ?? 'bun';
   if (!(await executableExists(runtime))) {

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -41,30 +41,29 @@ Use `./vs --outer-loop <kind> --help` for loop-specific flags.
 
 ## Repository Validation
 
-Run `vibesys validate` from a configured repository to check its static VibeSys
-contracts without starting the interactive client, an optimization loop, or an
+Run `vibesys validate [INPUT_BUNDLE]` to check an input bundle's static harness
+contract without starting the interactive client, an optimization loop, or an
 agent. From a source checkout, use the equivalent `./vs validate` command.
 
-With no flags, validation reads `agent.toml` and treats the current directory as
-the target input bundle:
+The input bundle is the positional argument. When omitted, it defaults to the
+current directory:
 
 ```bash
 vibesys validate
 ```
 
-Repositories that keep the bundle elsewhere can select both files explicitly:
+Pass another bundle directly:
 
 ```bash
-vibesys validate --config agent.toml --input examples/<target>
+vibesys validate examples/<target>
 ```
 
 The command applies the same strict schemas and path checks as a real run. It
-validates the agent config, `OBJECTIVE.md`, `vibesys.input.toml`, accuracy and
-benchmark command paths, optional workspace seed and evaluator source, and the
-optional benchmark-result contract. A passing repository exits with status 0;
-an invalid repository prints the failing contract and exits with status 1.
-Command-line usage errors exit with status 2. Validation does not execute the
-checker or benchmark and does not probe external tools or credentials.
+validates `OBJECTIVE.md`, `vibesys.input.toml`, accuracy and benchmark command
+paths, optional workspace seed and evaluator source, and the optional
+benchmark-result contract. A valid bundle exits with status 0; an invalid bundle
+prints the failing contract and exits with status 1. Command-line usage errors
+exit with status 2. Validation does not execute the checker or benchmark.
 
 ## Interface
 

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -39,6 +39,33 @@ launcher. For installed npm users, the same launcher is exposed as `vs` and
 `vibesys`.
 Use `./vs --outer-loop <kind> --help` for loop-specific flags.
 
+## Repository Validation
+
+Run `vibesys validate` from a configured repository to check its static VibeSys
+contracts without starting the interactive client, an optimization loop, or an
+agent. From a source checkout, use the equivalent `./vs validate` command.
+
+With no flags, validation reads `agent.toml` and treats the current directory as
+the target input bundle:
+
+```bash
+vibesys validate
+```
+
+Repositories that keep the bundle elsewhere can select both files explicitly:
+
+```bash
+vibesys validate --config agent.toml --input examples/<target>
+```
+
+The command applies the same strict schemas and path checks as a real run. It
+validates the agent config, `OBJECTIVE.md`, `vibesys.input.toml`, accuracy and
+benchmark command paths, optional workspace seed and evaluator source, and the
+optional benchmark-result contract. A passing repository exits with status 0;
+an invalid repository prints the failing contract and exits with status 1.
+Command-line usage errors exit with status 2. Validation does not execute the
+checker or benchmark and does not probe external tools or credentials.
+
 ## Interface
 
 `--interface` applies to the agent loop.

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -482,27 +482,19 @@ def _make_parser(prog: str, description: str) -> argparse.ArgumentParser:
 
 
 # ---------------------------------------------------------------------------
-# Repository validation command
+# Input-bundle validation command
 # ---------------------------------------------------------------------------
 
 
 def _build_validate_parser() -> argparse.ArgumentParser:
     parser = _RunArgumentParser(
         prog="vibesys validate",
-        description=(
-            "Validate the repository's agent configuration and input-bundle "
-            "harness contract without starting an optimization run."
-        ),
+        description="Validate an input-bundle harness contract without starting a run.",
     )
     parser.add_argument(
-        "--config",
+        "input_bundle",
         type=Path,
-        default=None,
-        help="Path to agent TOML config (default: ./agent.toml).",
-    )
-    parser.add_argument(
-        "--input",
-        type=Path,
+        nargs="?",
         default=None,
         help="Path to the input bundle (default: current directory).",
     )
@@ -510,22 +502,10 @@ def _build_validate_parser() -> argparse.ArgumentParser:
 
 
 def _run_validate(argv: list[str]) -> None:
-    """Validate repo-local configuration and harness files, then report readiness."""
+    """Validate one input-bundle contract, then report its resolved paths."""
 
     args = _build_validate_parser().parse_args(argv)
-    repository = Path.cwd().resolve()
-    config_path = (args.config or repository / "agent.toml").expanduser().resolve()
-    input_path = (args.input or repository).expanduser().resolve()
-
-    try:
-        _load_config(config_path)
-    except (FileNotFoundError, ValueError) as exc:
-        _configuration_error(
-            f"Validation failed for agent config {config_path}: {exc}",
-            code="validation_failed",
-            stage="repository_validation",
-            exit_code=1,
-        )
+    input_path = (args.input_bundle or Path.cwd()).expanduser().resolve()
 
     try:
         bundle = load_input_bundle(input_path)
@@ -533,13 +513,11 @@ def _run_validate(argv: list[str]) -> None:
         _configuration_error(
             f"Validation failed for input bundle {input_path}: {exc}",
             code="validation_failed",
-            stage="repository_validation",
+            stage="input_validation",
             exit_code=1,
         )
 
-    print("VibeSys validation passed: repository is ready for a run.")
-    print(f"  repository: {repository}")
-    print(f"  agent config: {config_path}")
+    print("VibeSys validation passed: input bundle is valid.")
     print(f"  input bundle: {bundle.root}")
     print(f"  objective: {bundle.objective_path}")
     print(f"  accuracy command: {bundle.accuracy_command_display}")

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -482,6 +482,77 @@ def _make_parser(prog: str, description: str) -> argparse.ArgumentParser:
 
 
 # ---------------------------------------------------------------------------
+# Repository validation command
+# ---------------------------------------------------------------------------
+
+
+def _build_validate_parser() -> argparse.ArgumentParser:
+    parser = _RunArgumentParser(
+        prog="vibesys validate",
+        description=(
+            "Validate the repository's agent configuration and input-bundle "
+            "harness contract without starting an optimization run."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Path to agent TOML config (default: ./agent.toml).",
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=None,
+        help="Path to the input bundle (default: current directory).",
+    )
+    return parser
+
+
+def _run_validate(argv: list[str]) -> None:
+    """Validate repo-local configuration and harness files, then report readiness."""
+
+    args = _build_validate_parser().parse_args(argv)
+    repository = Path.cwd().resolve()
+    config_path = (args.config or repository / "agent.toml").expanduser().resolve()
+    input_path = (args.input or repository).expanduser().resolve()
+
+    try:
+        _load_config(config_path)
+    except (FileNotFoundError, ValueError) as exc:
+        _configuration_error(
+            f"Validation failed for agent config {config_path}: {exc}",
+            code="validation_failed",
+            stage="repository_validation",
+            exit_code=1,
+        )
+
+    try:
+        bundle = load_input_bundle(input_path)
+    except (FileNotFoundError, ValueError) as exc:
+        _configuration_error(
+            f"Validation failed for input bundle {input_path}: {exc}",
+            code="validation_failed",
+            stage="repository_validation",
+            exit_code=1,
+        )
+
+    print("VibeSys validation passed: repository is ready for a run.")
+    print(f"  repository: {repository}")
+    print(f"  agent config: {config_path}")
+    print(f"  input bundle: {bundle.root}")
+    print(f"  objective: {bundle.objective_path}")
+    print(f"  accuracy command: {bundle.accuracy_command_display}")
+    print(f"  benchmark command: {bundle.benchmark_command_display}")
+    if bundle.workspace_seed_path is not None:
+        print(f"  workspace seed: {bundle.workspace_seed_path}")
+    if bundle.evaluator_path is not None:
+        print(f"  evaluator source: {bundle.evaluator_path}")
+    if bundle.benchmark_result is not None:
+        print(f"  benchmark metric: {bundle.benchmark_result.metric}")
+
+
+# ---------------------------------------------------------------------------
 # Shared input-bundle discovery
 # ---------------------------------------------------------------------------
 
@@ -1025,6 +1096,10 @@ def parse_cli_invocation(argv: list[str]) -> CliInvocation:
 
 
 def _dispatch(argv: list[str]) -> None:
+    if argv and argv[0] == "validate":
+        _run_validate(argv[1:])
+        return
+
     invocation = parse_cli_invocation(argv)
     loop_kind, args = invocation.loop_kind, invocation.args
     runner = globals()[_RUNNERS[loop_kind]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import pytest
+
+from vibesys.input_manifest import MANIFEST_NAME
+
+
+@pytest.fixture(scope="session")
+def repo_root() -> Path:
+    return Path(__file__).parents[1]
+
+
+@pytest.fixture(scope="session")
+def example_input_bundles(repo_root: Path) -> tuple[Path, ...]:
+    bundles = tuple(
+        sorted(manifest.parent for manifest in (repo_root / "examples").glob(f"**/{MANIFEST_NAME}"))
+    )
+    assert bundles, f"No example input bundles found under {repo_root / 'examples'}"
+    return bundles

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,6 +53,12 @@ command = ["uv", "run", "python", "benchmark/benchmark.py"]
     return bundle
 
 
+def _write_agent_config(directory: Path) -> Path:
+    config = directory / "agent.toml"
+    config.write_text('[model]\nname = "gpt-5.4"\n')
+    return config
+
+
 def _write_resume_event(
     exp_dir: Path, input_path: Path, *, event_type: str = "run_started"
 ) -> None:
@@ -376,6 +382,83 @@ def test_missing_config_reports_configuration_error(tmp_path):
 
     assert exc.value.diagnostic.code == "config_load_failed"
     assert exc.value.diagnostic.stage == "config_loading"
+
+
+# ---------------------------------------------------------------------------
+# validate command
+# ---------------------------------------------------------------------------
+
+
+def test_validate_command_defaults_to_current_repository(monkeypatch, tmp_path, capsys):
+    bundle = _write_input_bundle(tmp_path)
+    _write_agent_config(bundle)
+    monkeypatch.chdir(bundle)
+    monkeypatch.setattr(sys, "argv", ["vibesys", "validate"])
+
+    main()
+
+    output = capsys.readouterr().out
+    assert "VibeSys validation passed" in output
+    assert f"agent config: {bundle / 'agent.toml'}" in output
+    assert f"input bundle: {bundle}" in output
+    assert "accuracy command: uv run python accuracy_checker/checker.py" in output
+    assert "benchmark command: uv run python benchmark/benchmark.py" in output
+
+
+def test_validate_command_accepts_explicit_config_and_input(tmp_path, capsys):
+    bundle = _write_input_bundle(tmp_path)
+    config = _write_agent_config(tmp_path)
+    argv = [
+        "vibesys",
+        "validate",
+        "--config",
+        str(config),
+        "--input",
+        str(bundle),
+    ]
+
+    with patch.object(sys, "argv", argv):
+        main()
+
+    output = capsys.readouterr().out
+    assert "repository is ready for a run" in output
+    assert f"agent config: {config}" in output
+    assert f"objective: {bundle / 'OBJECTIVE.md'}" in output
+
+
+def test_validate_command_reports_invalid_agent_config(tmp_path, capsys):
+    bundle = _write_input_bundle(tmp_path)
+    config = tmp_path / "agent.toml"
+    config.write_text("[model]\nprovider = 'openai'\n")
+    argv = ["vibesys", "validate", "--config", str(config), "--input", str(bundle)]
+
+    with patch.object(sys, "argv", argv), pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == 1
+    error = capsys.readouterr().err
+    assert "Validation failed for agent config" in error
+    assert "model.name" in error
+
+
+def test_validate_command_reports_invalid_harness_without_running_agent(tmp_path, capsys):
+    bundle = _write_input_bundle(tmp_path)
+    (bundle / "OBJECTIVE.md").unlink()
+    config = _write_agent_config(tmp_path)
+    argv = ["vibesys", "validate", "--config", str(config), "--input", str(bundle)]
+
+    with (
+        patch.object(sys, "argv", argv),
+        patch("vibesys.main._run_agent") as runner,
+        pytest.raises(SystemExit) as exc,
+    ):
+        main()
+
+    assert exc.value.code == 1
+    runner.assert_not_called()
+    error = capsys.readouterr().err
+    assert "Validation failed for input bundle" in error
+    assert "OBJECTIVE.md not found" in error
 
 
 def test_resume_without_input_infers_original_input(monkeypatch, tmp_path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -426,19 +426,15 @@ def test_validate_command_accepts_explicit_config_and_input(tmp_path, capsys):
     assert f"objective: {bundle / 'OBJECTIVE.md'}" in output
 
 
-def test_all_example_input_bundles_pass_validate(capsys):
-    project_root = Path(__file__).parents[1]
-    input_bundles = sorted(
-        manifest.parent for manifest in (project_root / "examples").glob("**/vibesys.input.toml")
-    )
-
-    assert input_bundles
-    for input_bundle in input_bundles:
+def test_all_example_input_bundles_pass_validate(
+    repo_root: Path, example_input_bundles: tuple[Path, ...], capsys
+):
+    for input_bundle in example_input_bundles:
         argv = [
             "vibesys",
             "validate",
             "--config",
-            str(project_root / "agent.toml.example"),
+            str(repo_root / "agent.toml.example"),
             "--input",
             str(input_bundle),
         ]
@@ -446,7 +442,7 @@ def test_all_example_input_bundles_pass_validate(capsys):
             main()
 
     output = capsys.readouterr().out
-    assert output.count("VibeSys validation passed") == len(input_bundles)
+    assert output.count("VibeSys validation passed") == len(example_input_bundles)
 
 
 def test_validate_command_reports_invalid_agent_config(tmp_path, capsys):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -426,6 +426,29 @@ def test_validate_command_accepts_explicit_config_and_input(tmp_path, capsys):
     assert f"objective: {bundle / 'OBJECTIVE.md'}" in output
 
 
+def test_all_example_input_bundles_pass_validate(capsys):
+    project_root = Path(__file__).parents[1]
+    input_bundles = sorted(
+        manifest.parent for manifest in (project_root / "examples").glob("**/vibesys.input.toml")
+    )
+
+    assert input_bundles
+    for input_bundle in input_bundles:
+        argv = [
+            "vibesys",
+            "validate",
+            "--config",
+            str(project_root / "agent.toml.example"),
+            "--input",
+            str(input_bundle),
+        ]
+        with patch.object(sys, "argv", argv):
+            main()
+
+    output = capsys.readouterr().out
+    assert output.count("VibeSys validation passed") == len(input_bundles)
+
+
 def test_validate_command_reports_invalid_agent_config(tmp_path, capsys):
     bundle = _write_input_bundle(tmp_path)
     config = tmp_path / "agent.toml"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,12 +53,6 @@ command = ["uv", "run", "python", "benchmark/benchmark.py"]
     return bundle
 
 
-def _write_agent_config(directory: Path) -> Path:
-    config = directory / "agent.toml"
-    config.write_text('[model]\nname = "gpt-5.4"\n')
-    return config
-
-
 def _write_resume_event(
     exp_dir: Path, input_path: Path, *, event_type: str = "run_started"
 ) -> None:
@@ -389,9 +383,8 @@ def test_missing_config_reports_configuration_error(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_validate_command_defaults_to_current_repository(monkeypatch, tmp_path, capsys):
+def test_validate_command_defaults_to_current_input_bundle(monkeypatch, tmp_path, capsys):
     bundle = _write_input_bundle(tmp_path)
-    _write_agent_config(bundle)
     monkeypatch.chdir(bundle)
     monkeypatch.setattr(sys, "argv", ["vibesys", "validate"])
 
@@ -399,45 +392,37 @@ def test_validate_command_defaults_to_current_repository(monkeypatch, tmp_path, 
 
     output = capsys.readouterr().out
     assert "VibeSys validation passed" in output
-    assert f"agent config: {bundle / 'agent.toml'}" in output
     assert f"input bundle: {bundle}" in output
     assert "accuracy command: uv run python accuracy_checker/checker.py" in output
     assert "benchmark command: uv run python benchmark/benchmark.py" in output
 
 
-def test_validate_command_accepts_explicit_config_and_input(tmp_path, capsys):
+def test_validate_command_accepts_input_bundle_path(tmp_path, capsys):
     bundle = _write_input_bundle(tmp_path)
-    config = _write_agent_config(tmp_path)
-    argv = [
-        "vibesys",
-        "validate",
-        "--config",
-        str(config),
-        "--input",
-        str(bundle),
-    ]
+    argv = ["vibesys", "validate", str(bundle)]
 
     with patch.object(sys, "argv", argv):
         main()
 
     output = capsys.readouterr().out
-    assert "repository is ready for a run" in output
-    assert f"agent config: {config}" in output
+    assert "input bundle is valid" in output
     assert f"objective: {bundle / 'OBJECTIVE.md'}" in output
 
 
-def test_all_example_input_bundles_pass_validate(
-    repo_root: Path, example_input_bundles: tuple[Path, ...], capsys
-):
+def test_validate_command_rejects_run_input_flag(tmp_path, capsys):
+    bundle = _write_input_bundle(tmp_path)
+    argv = ["vibesys", "validate", "--input", str(bundle)]
+
+    with patch.object(sys, "argv", argv), pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == 2
+    assert "unrecognized arguments" in capsys.readouterr().err
+
+
+def test_all_example_input_bundles_pass_validate(example_input_bundles: tuple[Path, ...], capsys):
     for input_bundle in example_input_bundles:
-        argv = [
-            "vibesys",
-            "validate",
-            "--config",
-            str(repo_root / "agent.toml.example"),
-            "--input",
-            str(input_bundle),
-        ]
+        argv = ["vibesys", "validate", str(input_bundle)]
         with patch.object(sys, "argv", argv):
             main()
 
@@ -445,26 +430,10 @@ def test_all_example_input_bundles_pass_validate(
     assert output.count("VibeSys validation passed") == len(example_input_bundles)
 
 
-def test_validate_command_reports_invalid_agent_config(tmp_path, capsys):
-    bundle = _write_input_bundle(tmp_path)
-    config = tmp_path / "agent.toml"
-    config.write_text("[model]\nprovider = 'openai'\n")
-    argv = ["vibesys", "validate", "--config", str(config), "--input", str(bundle)]
-
-    with patch.object(sys, "argv", argv), pytest.raises(SystemExit) as exc:
-        main()
-
-    assert exc.value.code == 1
-    error = capsys.readouterr().err
-    assert "Validation failed for agent config" in error
-    assert "model.name" in error
-
-
 def test_validate_command_reports_invalid_harness_without_running_agent(tmp_path, capsys):
     bundle = _write_input_bundle(tmp_path)
     (bundle / "OBJECTIVE.md").unlink()
-    config = _write_agent_config(tmp_path)
-    argv = ["vibesys", "validate", "--config", str(config), "--input", str(bundle)]
+    argv = ["vibesys", "validate", str(bundle)]
 
     with (
         patch.object(sys, "argv", argv),

--- a/tests/test_workspace_seed.py
+++ b/tests/test_workspace_seed.py
@@ -86,13 +86,11 @@ def _make_context(input_dir: Path, seed: Path | None = None, **kwargs) -> _RunCo
     )
 
 
-def test_all_repo_example_input_bundles_are_valid():
-    project_root = Path(__file__).parents[1]
-    manifests = sorted((project_root / "examples").glob("**/vibesys.input.toml"))
-
-    assert manifests
-    for manifest in manifests:
-        bundle = load_input_bundle(manifest.parent, project_root=project_root)
+def test_all_repo_example_input_bundles_are_valid(
+    repo_root: Path, example_input_bundles: tuple[Path, ...]
+):
+    for input_bundle in example_input_bundles:
+        bundle = load_input_bundle(input_bundle, project_root=repo_root)
         assert bundle.domain is bundle.manifest.agent.domain
 
 

--- a/vs
+++ b/vs
@@ -16,6 +16,9 @@ interactive=true
 if [[ ! -t 0 || ! -t 1 ]]; then
   interactive=false
 fi
+if [[ "${1:-}" == "validate" ]]; then
+  interactive=false
+fi
 for argument in "$@"; do
   if [[ "$argument" == "--headless" ]]; then
     interactive=false


### PR DESCRIPTION
## Problem

VibeSys currently discovers malformed input-bundle and harness contracts only while starting a run. That makes missing objectives, invalid manifests, and broken evaluator paths surface too late—after users have already entered the optimization workflow.

This PR adds the explicit preflight requested in #161, so users can validate an input bundle before any interactive client, optimization loop, or agent starts.

Closes #161.

## Solution

Add a top-level vibesys validate [INPUT_BUNDLE] command that reuses the existing strict input-bundle loader. The bundle is a positional argument and defaults to the current directory when omitted:

~~~bash
vibesys validate examples/kv-store
~~~

Successful validation reports the resolved bundle, objective, evaluator commands, and optional workspace/evaluator/metric contracts. Invalid bundles print the failing contract and exit with status 1; usage errors retain status 2. Agent configuration is intentionally outside this command's contract.

Both the npm launcher and source-checkout ./vs wrapper recognize validation as a backend-only operation, so the command never starts or requires the interactive TUI. The checker and benchmark are not executed.

CI enumerates every checked-in example bundle through the shared example_input_bundles fixture, which discovers examples/**/vibesys.input.toml using the manifest filename constant. It runs the complete validate command against each one, so adding a new manifest automatically adds it to the regression test.

### Architecture

~~~mermaid
flowchart LR
    User["vibesys validate [INPUT_BUNDLE]"]
    Launcher["TypeScript or checkout launcher"]
    Backend["Python command dispatcher"]
    InputBundle["Strict input-bundle loader"]
    Result["Pass details or actionable failure"]

    User --> Launcher
    Launcher -->|"backend-only"| Backend
    Backend --> InputBundle
    InputBundle --> Result
~~~

The launcher owns interactive-versus-backend routing. The Python backend owns argument parsing, input-bundle validation, output, and exit codes. The existing input-bundle loader remains the single source of truth for run and validation behavior.

## Verification

Validated positional and current-directory command behavior, all 16 checked-in example bundles, both launcher paths, type checking, formatting, lint, and a real bundle smoke test.

### Correctness properties

- validate never starts the TUI, optimization supervisor, loop runner, or agent.
- The command only validates the selected input bundle; it does not load agent.toml.
- The bundle is accepted as the positional third argument and defaults to the current directory.
- The old --input form is rejected as a usage error.
- The command applies the same strict input schema and path checks used by actual runs.
- Valid bundles exit 0, invalid contracts exit 1, and invalid command usage exits 2.
- Static validation does not execute checker or benchmark commands.
- Every checked-in examples/**/vibesys.input.toml bundle is validated automatically in CI.
- Existing loop invocations and interactive launcher behavior remain unchanged.

### Testing

- uv run pytest tests/test_main.py -q → 63 passed
- uv run pytest tests/test_main.py tests/test_workspace_seed.py -q → 86 passed
- pnpm --dir clients/tui exec vitest run src/launcher.test.ts --config vitest.config.ts → 3 passed
- pnpm --dir clients/tui check → passed
- ./scripts/check_format.sh → passed
- ./scripts/check_lint.sh → passed
- bash -n vs → passed
- ./vs validate examples/kv-store → passed
