### PR TITLE
Confine host-path agent runs to the workspace via bubblewrap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,6 +171,38 @@ jobs:
           name: coverage-xml
           path: coverage.xml
 
+  # Exercises the real Linux workspace-confinement boundary (issue #149). The
+  # main `test` job skips these (no bubblewrap), so this job installs it and
+  # forces the tests to run — VIBESYS_REQUIRE_SANDBOX_TESTS=1 turns a missing or
+  # broken sandbox into a failure instead of a silent skip.
+  sandbox-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bubblewrap
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap
+          # Ubuntu 24.04 restricts unprivileged user namespaces via AppArmor;
+          # relax it so bwrap can create the namespace on the runner.
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run workspace-confinement tests
+        env:
+          VIBESYS_REQUIRE_SANDBOX_TESTS: "1"
+        run: uv run python -m pytest tests/_agent_cli/test_hostsandbox.py -v
+
   patch-coverage:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'

--- a/src/vibesys/_agent_cli/cli_agent.py
+++ b/src/vibesys/_agent_cli/cli_agent.py
@@ -13,6 +13,7 @@ from agentshim.utils import get_interactive_env
 from loguru import logger
 
 from .base import CodingAgent
+from .hostsandbox import HostSandbox
 
 
 class CLIGenerationSession:
@@ -163,6 +164,11 @@ class CLICodingAgent(CodingAgent):
         self.executor.check_binary(self.binary_path, self.env, timeout=10)
         self.logger = logger.bind(agent_prefix=self._log_prefix)
         self.session_id: str | None = None
+        # Host-path filesystem confinement. Left ``None`` here (unconfined,
+        # legacy behavior); the CLI runner installs a :class:`HostSandbox` on
+        # the host execution path. Container executors leave it ``None`` because
+        # they are already externally sandboxed.
+        self.sandbox: HostSandbox | None = None
 
     @abstractmethod
     def _get_command(self, prompt: str) -> list[str]:
@@ -238,6 +244,14 @@ class CLICodingAgent(CodingAgent):
             cmd = self._get_resume_command(prompt, self.session_id)
         if cmd is None:
             cmd = self._get_command(prompt)
+
+        # Confine the agent to its workspace at the OS level. Only applies on the
+        # host path (a real ``cwd`` plus an installed sandbox policy); container
+        # executors pass ``cwd=None`` and leave ``self.sandbox`` unset because
+        # they are already externally sandboxed. bwrap re-establishes the working
+        # directory inside the namespace via ``--chdir``.
+        if self.sandbox is not None and cwd is not None:
+            cmd = self.sandbox.wrap(cmd)
 
         session = self._create_session(cmd, cwd, timeout, silent)
         # Expose the session to callers (e.g. ``CliAgentRunner.invoke``

--- a/src/vibesys/_agent_cli/hostsandbox.py
+++ b/src/vibesys/_agent_cli/hostsandbox.py
@@ -1,0 +1,288 @@
+"""Host-level filesystem confinement for agent CLI subprocesses.
+
+VibeSys launches coding-agent CLIs (codex, claude, ...) with the provider's own
+approval/sandbox bypass flags (``--dangerously-bypass-approvals-and-sandbox``,
+``--dangerously-skip-permissions``) so they can run autonomously. On the host
+execution path that leaves the spawned agent process able to read and write
+anywhere the VibeSys user can, so a misbehaving agent can step outside its
+``exp_env/<run>/workspace`` and reach sibling runs, unrelated repositories, or
+host secrets. Prompt-only containment is not a security boundary (issue #149).
+
+This module wraps the agent command in a `bubblewrap <https://github.com/
+containers/bubblewrap>`_ (``bwrap``) mount namespace that exposes only:
+
+* a read-only view of system/toolchain directories and the Python/agent
+  runtimes needed to launch,
+* the agent's own config/auth directories (so it can authenticate),
+* any explicitly allowed extra paths (model/weight caches, MCP server code),
+* a writable bind of the run workspace and a private ``/tmp``.
+
+Everything else — including the workspace's *parent* and sibling runs — is
+simply absent from the namespace, so absolute-path traversal outside the
+workspace fails with ``ENOENT``. Network is left shared so the agent can still
+reach its model provider.
+
+The confinement is enforced by default on Linux hosts. It is a *host*-path
+concern only: the Docker and Modal executors already run the agent inside an
+externally managed sandbox, so those paths never build a :class:`HostSandbox`.
+
+Operator controls (read from the agent's environment):
+
+``VIBESYS_AGENT_SANDBOX``
+    Set to ``0``/``false``/``off``/``no`` to disable host confinement (e.g. for
+    debugging, or on a host whose toolchain layout the default allowlist does
+    not cover). Disabling is logged loudly.
+
+``VIBESYS_AGENT_SANDBOX_ALLOW``
+    ``os.pathsep``-separated list of extra host paths to expose read-only inside
+    the sandbox (model weights, HF/torch caches, MCP server code, ...). Paths
+    that are ancestors of the workspace are rejected, because binding them would
+    re-expose sibling runs and defeat the confinement.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DISABLE_ENV = "VIBESYS_AGENT_SANDBOX"
+ALLOW_ENV = "VIBESYS_AGENT_SANDBOX_ALLOW"
+
+_DISABLED_VALUES = frozenset({"0", "false", "off", "no"})
+
+# Read-only system/toolchain roots exposed inside the namespace. Bound with
+# ``--ro-bind-try`` so a root that does not exist on a given host is skipped
+# rather than aborting the launch.
+_SYSTEM_READ_ROOTS: tuple[str, ...] = (
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib64",
+    "/lib32",
+    "/etc",
+    "/opt",
+    "/run/systemd/resolve",  # DNS via systemd-resolved
+)
+
+
+def _is_disabled(env: dict[str, str]) -> bool:
+    return env.get(DISABLE_ENV, "").strip().lower() in _DISABLED_VALUES
+
+
+def _is_ancestor(ancestor: Path, path: Path) -> bool:
+    """Return ``True`` if *ancestor* is *path* itself or one of its parents."""
+    try:
+        path.relative_to(ancestor)
+    except ValueError:
+        return False
+    return True
+
+
+def _existing(paths: list[Path]) -> list[Path]:
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for p in paths:
+        if p in seen or not p.exists():
+            continue
+        seen.add(p)
+        out.append(p)
+    return out
+
+
+def _default_read_paths(env: dict[str, str], binary_path: str | None) -> list[Path]:
+    """Toolchain paths the agent needs to *launch* (never the workspace parent).
+
+    These are specific subtrees — the Python runtime, the Node/agent install
+    directory, and the VibeSys package source — rather than broad roots like
+    ``$HOME``, precisely so sibling repositories under the same parent stay
+    invisible.
+    """
+    candidates: list[Path] = [
+        Path(sys.base_prefix),
+        Path(sys.prefix),
+    ]
+
+    # The agent binary and its interpreter (e.g. a Node install under ~/.nvm),
+    # resolved through any symlinks so the real install tree is exposed.
+    if binary_path:
+        real_binary = Path(binary_path).resolve()
+        candidates.append(real_binary.parent)
+    node = shutil.which("node", path=env.get("PATH"))
+    if node:
+        candidates.append(Path(node).resolve().parent)
+
+    # The installed VibeSys source tree, so codex/claude MCP servers launched as
+    # ``python -m ...`` can import the package even under an editable install.
+    try:
+        import vibesys
+
+        pkg_file = getattr(vibesys, "__file__", None)
+        if pkg_file:
+            candidates.append(Path(pkg_file).resolve().parents[1])
+    except Exception:  # pragma: no cover - defensive; import cannot normally fail here
+        pass
+
+    return candidates
+
+
+def _default_config_paths(env: dict[str, str]) -> list[Path]:
+    """Read-write agent config/auth directories (the agent's own state only)."""
+    home = env.get("HOME")
+    if not home:
+        return []
+    base = Path(home)
+    return [
+        base / ".codex",
+        base / ".claude",
+        base / ".claude.json",
+        base / ".config" / "codex",
+        base / ".config" / "claude",
+    ]
+
+
+def _parse_allow(env: dict[str, str]) -> list[Path]:
+    raw = env.get(ALLOW_ENV, "")
+    return [Path(p).expanduser() for p in raw.split(os.pathsep) if p.strip()]
+
+
+@dataclass(frozen=True)
+class HostSandbox:
+    """A bubblewrap confinement policy for a single run workspace."""
+
+    bwrap_path: str
+    workspace: Path
+    read_paths: tuple[Path, ...] = ()
+    write_paths: tuple[Path, ...] = ()
+    system_read_roots: tuple[str, ...] = _SYSTEM_READ_ROOTS
+    gpu_device_nodes: tuple[Path, ...] = field(default_factory=tuple)
+
+    def wrap(self, argv: list[str]) -> list[str]:
+        """Return *argv* wrapped so it runs inside the confinement namespace."""
+        ws = str(self.workspace)
+        cmd: list[str] = [
+            self.bwrap_path,
+            "--die-with-parent",
+            "--unshare-user",
+            "--unshare-ipc",
+            "--unshare-pid",
+            "--unshare-uts",
+            "--unshare-cgroup-try",
+            # Network is intentionally shared: the agent must reach its model
+            # provider. Filesystem confinement is what blocks the escape.
+            "--proc",
+            "/proc",
+            "--dev",
+            "/dev",
+            "--tmpfs",
+            "/tmp",
+        ]
+        for root in self.system_read_roots:
+            cmd += ["--ro-bind-try", root, root]
+        for path in self.read_paths:
+            cmd += ["--ro-bind-try", str(path), str(path)]
+        for node in self.gpu_device_nodes:
+            cmd += ["--dev-bind-try", str(node), str(node)]
+        for path in self.write_paths:
+            cmd += ["--bind-try", str(path), str(path)]
+        # The workspace is the one project path the agent may modify. Bound last
+        # so it wins over any read-only bind that happens to cover it.
+        cmd += ["--bind", ws, ws]
+        cmd += ["--chdir", ws, "--"]
+        cmd += argv
+        return cmd
+
+
+def _gpu_device_nodes() -> list[Path]:
+    """NVIDIA character devices to pass through (``--dev`` hides them otherwise)."""
+    dev = Path("/dev")
+    if not dev.exists():
+        return []
+    nodes: list[Path] = []
+    for pattern in ("nvidia*", "nvidia-uvm*", "nvidia-caps"):
+        nodes.extend(sorted(dev.glob(pattern)))
+    # ``/dev/dri`` (render nodes) for non-NVIDIA / integrated GPUs.
+    dri = dev / "dri"
+    if dri.exists():
+        nodes.append(dri)
+    return nodes
+
+
+def build(
+    workspace: Path | str,
+    *,
+    env: dict[str, str],
+    binary_path: str | None = None,
+    log: Callable[[str], None] | None = None,
+) -> HostSandbox | None:
+    """Build a :class:`HostSandbox` for *workspace*, or ``None`` if not enforced.
+
+    Returns ``None`` (and logs why) when confinement is disabled by the operator,
+    when the host is not Linux, or when ``bwrap`` / user namespaces are
+    unavailable. In those cases the caller runs the agent unconfined, exactly as
+    before this change, so the sandbox can never *break* a run that used to work
+    — it only ever adds a boundary.
+    """
+
+    def _log(msg: str) -> None:
+        if log is not None:
+            log(msg)
+
+    workspace = Path(workspace).resolve()
+
+    if _is_disabled(env):
+        _log(
+            f"[hostsandbox] DISABLED via {DISABLE_ENV}; agent runs with full host "
+            "filesystem access. Sibling runs and host files are reachable."
+        )
+        return None
+
+    if not sys.platform.startswith("linux"):
+        _log(
+            f"[hostsandbox] host confinement unavailable on {sys.platform!r} "
+            "(bubblewrap is Linux-only); agent runs unconfined. Use --docker for "
+            "an externally sandboxed run."
+        )
+        return None
+
+    bwrap = shutil.which("bwrap", path=env.get("PATH")) or shutil.which("bwrap")
+    if not bwrap:
+        _log(
+            "[hostsandbox] 'bwrap' not found on PATH; agent runs unconfined. "
+            "Install bubblewrap or use --docker for an externally sandboxed run."
+        )
+        return None
+
+    read_paths = _existing(_default_read_paths(env, binary_path))
+    write_paths = _existing(_default_config_paths(env))
+
+    # Extra operator-allowed read paths, minus any that would re-expose the
+    # workspace's parent (and therefore sibling runs).
+    for extra in _parse_allow(env):
+        resolved = extra.resolve()
+        if _is_ancestor(resolved, workspace):
+            _log(
+                f"[hostsandbox] ignoring {ALLOW_ENV} entry {extra} because it is an "
+                "ancestor of the workspace; binding it would expose sibling runs."
+            )
+            continue
+        if resolved.exists():
+            read_paths.append(resolved)
+
+    # Never expose a default read/write path that is an ancestor of the
+    # workspace — that would defeat sibling isolation. (Toolchain subtrees like
+    # the venv are not ancestors, so this is a safety net, not a common case.)
+    read_paths = [p for p in read_paths if not _is_ancestor(p, workspace)]
+    write_paths = [p for p in write_paths if not _is_ancestor(p, workspace)]
+
+    return HostSandbox(
+        bwrap_path=bwrap,
+        workspace=workspace,
+        read_paths=tuple(read_paths),
+        write_paths=tuple(write_paths),
+        gpu_device_nodes=tuple(_gpu_device_nodes()),
+    )

--- a/src/vibesys/_agent_cli/hostsandbox.py
+++ b/src/vibesys/_agent_cli/hostsandbox.py
@@ -94,11 +94,29 @@ def _existing(paths: list[Path]) -> list[Path]:
     return out
 
 
+def _install_root(real_path: Path) -> Path:
+    """Directory to expose so *real_path* can find its siblings/dependencies.
+
+    Node CLIs (codex, claude, ...) are shipped as npm packages whose launcher
+    (``.../node_modules/<pkg>/bin/foo.js``) loads a platform binary from a
+    *sibling* ``node_modules`` (e.g. ``@openai/codex-linux-x64``). Binding only
+    the launcher's ``bin/`` dir hides that, so codex fails with "Missing optional
+    dependency". Bind the directory that holds the top-level ``node_modules`` so
+    the whole package tree resolves; otherwise bind the containing directory.
+    """
+    parts = real_path.parts
+    if "node_modules" in parts:
+        idx = parts.index("node_modules")  # top-level node_modules
+        if idx > 0:
+            return Path(*parts[:idx])
+    return real_path.parent
+
+
 def _default_read_paths(env: dict[str, str], binary_path: str | None) -> list[Path]:
     """Toolchain paths the agent needs to *launch* (never the workspace parent).
 
     These are specific subtrees — the Python runtime, the Node/agent install
-    directory, and the VibeSys package source — rather than broad roots like
+    tree, and the VibeSys package source — rather than broad roots like
     ``$HOME``, precisely so sibling repositories under the same parent stay
     invisible.
     """
@@ -107,14 +125,19 @@ def _default_read_paths(env: dict[str, str], binary_path: str | None) -> list[Pa
         Path(sys.prefix),
     ]
 
-    # The agent binary and its interpreter (e.g. a Node install under ~/.nvm),
-    # resolved through any symlinks so the real install tree is exposed.
+    # The agent binary and its full install tree (e.g. the npm package plus its
+    # platform-binary sibling), resolved through symlinks.
     if binary_path:
         real_binary = Path(binary_path).resolve()
+        candidates.append(_install_root(real_binary))
         candidates.append(real_binary.parent)
+    # Node and its install prefix (``<prefix>/bin/node`` -> ``<prefix>``), which
+    # holds the global ``node_modules`` where the agent CLIs live.
     node = shutil.which("node", path=env.get("PATH"))
     if node:
-        candidates.append(Path(node).resolve().parent)
+        real_node = Path(node).resolve()
+        candidates.append(real_node.parent)
+        candidates.append(real_node.parent.parent)
 
     # The installed VibeSys source tree, so codex/claude MCP servers launched as
     # ``python -m ...`` can import the package even under an editable install.

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -29,6 +29,7 @@ from typing import Any, TypeVar
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel
 
+from vibesys._agent_cli import hostsandbox
 from vibesys._agent_cli.base import CodingAgent, MCPServerSpec
 from vibesys._agent_cli.claude import ClaudeCodeCodingAgent
 from vibesys._agent_cli.codex import CodexCodingAgent
@@ -276,6 +277,16 @@ class CliAgentRunner:
             self._agents[kind] = agent
         else:
             agent = self._provider_cls(model=self._model, event_handler=logger)
+            # Host execution path: confine the agent to its workspace at the OS
+            # level so it cannot read or modify sibling runs or unrelated host
+            # files (issue #149). Container executors above are already
+            # externally sandboxed and deliberately skip this.
+            agent.sandbox = hostsandbox.build(
+                Path(workspace),
+                env=agent.env,
+                binary_path=getattr(agent, "binary_path", None),
+                log=lambda msg: _log_and_print(msg, self._run_log_file),
+            )
             self._agents[kind] = agent
 
         # Layer GPU env vars on top of the captured interactive env so the

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -1,0 +1,258 @@
+"""Tests for host-path workspace confinement (issue #149).
+
+Two layers:
+
+* Pure-Python unit tests for the policy builder and ``bwrap`` argv construction
+  (no subprocess, run everywhere).
+* An end-to-end regression that drives the real agent launch chokepoint
+  (:meth:`CLICodingAgent.generate`) with a stub agent that tries to escape its
+  workspace. These are skipped unless a working ``bwrap`` + user-namespace stack
+  is present, since that is what actually enforces the boundary.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vibesys._agent_cli import hostsandbox
+from vibesys._agent_cli.cli_agent import CLICodingAgent
+
+# ---------------------------------------------------------------------------
+# Real-sandbox availability probe
+# ---------------------------------------------------------------------------
+
+
+def _bwrap_works() -> bool:
+    """True if bwrap can actually create a user namespace on this host."""
+    if not sys.platform.startswith("linux"):
+        return False
+    bwrap = shutil.which("bwrap")
+    if not bwrap:
+        return False
+    probe = "/usr/bin/true" if Path("/usr/bin/true").exists() else "/bin/true"
+    argv = [bwrap, "--unshare-user"]
+    for root in ("/usr", "/bin", "/lib", "/lib64"):
+        if Path(root).exists():
+            argv += ["--ro-bind", root, root]
+    argv.append(probe)
+    try:
+        proc = subprocess.run(argv, capture_output=True, timeout=15)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
+requires_sandbox = pytest.mark.skipif(
+    not _bwrap_works(),
+    reason="requires a working bwrap + user-namespace stack",
+)
+
+
+# ---------------------------------------------------------------------------
+# Policy builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuild:
+    def test_disabled_via_env_returns_none(self, tmp_path):
+        logs: list[str] = []
+        sb = hostsandbox.build(tmp_path, env={hostsandbox.DISABLE_ENV: "0"}, log=logs.append)
+        assert sb is None
+        assert any("DISABLED" in m for m in logs)
+
+    @pytest.mark.parametrize("value", ["0", "false", "off", "no", "FALSE", " Off "])
+    def test_disable_values(self, tmp_path, value):
+        assert hostsandbox.build(tmp_path, env={hostsandbox.DISABLE_ENV: value}) is None
+
+    def test_missing_bwrap_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
+        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: None)
+        logs: list[str] = []
+        assert hostsandbox.build(tmp_path, env={}, log=logs.append) is None
+        assert any("bwrap" in m for m in logs)
+
+    def test_non_linux_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hostsandbox.sys, "platform", "darwin")
+        logs: list[str] = []
+        assert hostsandbox.build(tmp_path, env={}, log=logs.append) is None
+        assert any("unavailable" in m for m in logs)
+
+    def test_allow_ancestor_of_workspace_is_rejected(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
+        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")
+        workspace = tmp_path / "exp_env" / "run" / "workspace"
+        workspace.mkdir(parents=True)
+        logs: list[str] = []
+        sb = hostsandbox.build(
+            workspace,
+            env={hostsandbox.ALLOW_ENV: str(tmp_path)},  # ancestor => sibling leak
+            log=logs.append,
+        )
+        assert sb is not None
+        assert tmp_path.resolve() not in sb.read_paths
+        assert any("ancestor" in m for m in logs)
+
+    def test_allow_extra_path_is_bound(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
+        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        weights = tmp_path.parent / f"{tmp_path.name}-weights"
+        weights.mkdir()
+        try:
+            sb = hostsandbox.build(workspace, env={hostsandbox.ALLOW_ENV: str(weights)})
+            assert sb is not None
+            assert weights.resolve() in sb.read_paths
+        finally:
+            weights.rmdir()
+
+
+# ---------------------------------------------------------------------------
+# bwrap argv construction (no subprocess)
+# ---------------------------------------------------------------------------
+
+
+class TestWrap:
+    def _sandbox(self, workspace: Path) -> hostsandbox.HostSandbox:
+        return hostsandbox.HostSandbox(
+            bwrap_path="/usr/bin/bwrap",
+            workspace=workspace,
+            read_paths=(Path("/opt/toolchain"),),
+            write_paths=(Path("/home/u/.codex"),),
+            system_read_roots=("/usr",),
+            gpu_device_nodes=(Path("/dev/nvidia0"),),
+        )
+
+    def test_wrap_shape(self, tmp_path):
+        sb = self._sandbox(tmp_path)
+        argv = sb.wrap(["codex", "exec", "--json"])
+        ws = str(tmp_path)
+        assert argv[0] == "/usr/bin/bwrap"
+        # Workspace is bound read-write and becomes cwd.
+        assert _has_pair(argv, "--bind", ws, ws)
+        assert _has_pair(argv, "--chdir", ws)
+        # Toolchain read-only, config read-write, GPU node passed through.
+        assert _has_pair(argv, "--ro-bind-try", "/opt/toolchain", "/opt/toolchain")
+        assert _has_pair(argv, "--bind-try", "/home/u/.codex", "/home/u/.codex")
+        assert _has_pair(argv, "--dev-bind-try", "/dev/nvidia0", "/dev/nvidia0")
+        # Network is deliberately *not* unshared.
+        assert "--unshare-net" not in argv
+        assert "--unshare-all" not in argv
+        # The wrapped command is preserved verbatim after the ``--`` separator.
+        sep = argv.index("--")
+        assert argv[sep + 1 :] == ["codex", "exec", "--json"]
+
+    def test_workspace_bind_wins_over_readonly(self, tmp_path):
+        """The rw workspace bind must come after ro binds so it takes effect."""
+        sb = self._sandbox(tmp_path)
+        argv = sb.wrap(["agent"])
+        last_ro = max(i for i, a in enumerate(argv) if a == "--ro-bind-try")
+        ws_bind = argv.index("--bind")
+        assert ws_bind > last_ro
+
+
+def _has_pair(argv: list[str], flag: str, *operands: str) -> bool:
+    for i, tok in enumerate(argv):
+        if tok == flag and argv[i + 1 : i + 1 + len(operands)] == list(operands):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end regression through the real launch path (issue #149)
+# ---------------------------------------------------------------------------
+
+
+class _StubAgent(CLICodingAgent):
+    """A concrete CLICodingAgent that runs a fixed script, skipping binary
+    detection — mirrors the pattern in ``test_codex.py``."""
+
+    def __init__(self, script: str):
+        from agentshim.executor import HostCommandExecutor
+
+        self.executor = HostCommandExecutor()
+        self.env = dict(os.environ)
+        self.binary_name = "stub-agent"
+        self.binary_path = script
+        self.model = None
+        self.event_handler = None
+        import loguru
+
+        self.logger = loguru.logger
+        self.session_id = None
+        self.sandbox = None
+        self._script = script
+
+    def _get_command(self, prompt: str) -> list[str]:
+        return [self._script]
+
+
+def _escape_probe(tmp_path_factory) -> tuple[_StubAgent, Path, Path]:
+    """Set up a workspace with a sibling secret and a stub agent (in a separate
+    toolchain dir, like a real agent binary) that tries to read/write it."""
+    host = tmp_path_factory.mktemp("host")
+    tool = tmp_path_factory.mktemp("tool")
+    workspace = host / "exp_env" / "run-A" / "workspace"
+    workspace.mkdir(parents=True)
+    sibling = host / "exp_env" / "run-B-secret"
+    sibling.mkdir(parents=True)
+    (sibling / "creds.txt").write_text("SECRET=leak\n")
+
+    script = tool / "stub_agent.sh"
+    script.write_text(
+        "#!/bin/sh\n"
+        "cat - > /dev/null 2>&1\n"
+        f'cat "{sibling / "creds.txt"}" 2>/dev/null && echo READ_OK\n'
+        f'echo pwn > "{sibling / "pwn.txt"}" 2>/dev/null && echo WRITE_OK\n'
+        "echo ok > ./candidate.txt 2>/dev/null && echo WS_OK\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return _StubAgent(str(script)), workspace, sibling
+
+
+def test_reproduces_escape_without_sandbox(tmp_path_factory):
+    """Without confinement the stub agent reaches the sibling run — the #149 bug."""
+    agent, workspace, _ = _escape_probe(tmp_path_factory)
+    agent.sandbox = None  # legacy behavior
+    out = agent.generate("stay in the workspace", cwd=str(workspace), silent=True)
+    assert "READ_OK" in out and "SECRET=leak" in out
+    assert "WRITE_OK" in out
+
+
+@requires_sandbox
+def test_sandbox_blocks_escape_but_allows_workspace(tmp_path_factory):
+    """With confinement installed the same escape attempts fail, yet the agent
+    can still read and write inside its own workspace."""
+    agent, workspace, sibling = _escape_probe(tmp_path_factory)
+    agent.sandbox = hostsandbox.build(workspace, env=agent.env, binary_path=agent.binary_path)
+    assert agent.sandbox is not None
+    out = agent.generate("stay in the workspace", cwd=str(workspace), silent=True)
+
+    assert "READ_OK" not in out and "SECRET=leak" not in out
+    assert "WRITE_OK" not in out
+    assert not (sibling / "pwn.txt").exists()
+    # Legitimate workspace work is unaffected.
+    assert "WS_OK" in out
+    assert (workspace / "candidate.txt").read_text().strip() == "ok"
+
+
+@requires_sandbox
+def test_generate_does_not_wrap_when_cwd_is_none(tmp_path_factory, monkeypatch):
+    """Container executors pass ``cwd=None``; the sandbox must not engage there
+    (they are already externally sandboxed)."""
+    agent, workspace, _ = _escape_probe(tmp_path_factory)
+    agent.sandbox = hostsandbox.build(workspace, env=agent.env, binary_path=agent.binary_path)
+    # cwd=None => no wrapping => stub runs from the process cwd unconfined. Run
+    # from a scratch dir so the stub's ``./candidate.txt`` doesn't leak into the
+    # repo, and confirm it still reaches the sibling (guard skips confinement).
+    scratch = tmp_path_factory.mktemp("scratch")
+    monkeypatch.chdir(scratch)
+    out = agent.generate("no cwd", cwd=None, silent=True)
+    assert "READ_OK" in out

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -49,9 +49,16 @@ def _bwrap_works() -> bool:
     return proc.returncode == 0
 
 
+# CI sets ``VIBESYS_REQUIRE_SANDBOX_TESTS=1`` so the real-confinement tests must
+# run instead of silently skipping. If the sandbox stack is then unavailable the
+# tests fail (build() returns None → assertions trip), which is the whole point:
+# a broken or absent sandbox in CI should be loud, not invisible.
+_REQUIRE_SANDBOX_TESTS = os.environ.get("VIBESYS_REQUIRE_SANDBOX_TESTS") == "1"
+
 requires_sandbox = pytest.mark.skipif(
-    not _bwrap_works(),
-    reason="requires a working bwrap + user-namespace stack",
+    not _REQUIRE_SANDBOX_TESTS and not _bwrap_works(),
+    reason="requires a working bwrap + user-namespace stack "
+    "(set VIBESYS_REQUIRE_SANDBOX_TESTS=1 to force)",
 )
 
 

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -165,6 +165,28 @@ class TestWrap:
         assert ws_bind > last_ro
 
 
+class TestInstallRoot:
+    """Regression for a real breakage caught by running codex under the sandbox:
+    an npm-packaged CLI must be able to reach its sibling platform binary."""
+
+    def test_node_package_binds_whole_package_tree(self):
+        launcher = Path(
+            "/home/u/.nvm/versions/node/v24/lib/node_modules/@openai/codex/bin/codex.js"
+        )
+        # Must expose the dir holding node_modules, so the sibling
+        # @openai/codex-linux-x64 platform binary resolves.
+        root = hostsandbox._install_root(launcher)
+        assert root == Path("/home/u/.nvm/versions/node/v24/lib")
+        platform_bin = Path(
+            "/home/u/.nvm/versions/node/v24/lib/node_modules/@openai/"
+            "codex/node_modules/@openai/codex-linux-x64/bin/codex"
+        )
+        assert platform_bin.is_relative_to(root)
+
+    def test_plain_binary_binds_its_directory(self):
+        assert hostsandbox._install_root(Path("/opt/tool/bin/agent")) == Path("/opt/tool/bin")
+
+
 def _has_pair(argv: list[str], flag: str, *operands: str) -> bool:
     for i, tok in enumerate(argv):
         if tok == flag and argv[i + 1 : i + 1 + len(operands)] == list(operands):


### PR DESCRIPTION
## Problem

VibeSys launches coding-agent CLIs (codex, claude, …) with the provider's approval/sandbox bypass flags (`--dangerously-bypass-approvals-and-sandbox`, `--dangerously-skip-permissions`) and `cwd=<workspace>`, then relies **only on the prompt** to keep the agent inside `exp_env/<run>/workspace`. On the host execution path there is no runtime boundary at all, so a misbehaving or misdirected inner agent can read, modify, and discover things outside its workspace — sibling runs, unrelated repositories, host secrets. This was observed in practice (an inner agent discovered a directory outside the intended workspace) and reported as #149. Prompt-only containment is not a security boundary.

This PR fixes the **Linux** half of #149 (#164). The **macOS** half (Seatbelt / `sandbox-exec`) is tracked separately in #165, because bubblewrap is Linux-only.

Reproduction (now a regression test): driving the real launch chokepoint `CLICodingAgent.generate` → agentshim `HostCommandExecutor` → subprocess with `cwd=workspace`, a stub agent reads a sibling run's `creds.txt` via an absolute path and prints the secret. The escape is provider-independent — it lives in the launch path, not in any one provider.

Closes #164. Part of #149.

## Solution

Add `vibesys._agent_cli.hostsandbox`, which wraps the agent command in a [bubblewrap](https://github.com/containers/bubblewrap) (`bwrap`) mount namespace exposing only:

- read-only system/toolchain dirs and the Python/Node/agent runtimes needed to launch,
- the agent's own config/auth dirs (writable — its own state only),
- GPU device nodes and any operator-allowed extra paths,
- a writable bind of the run workspace, plus a private `/tmp`.

Everything else — crucially the workspace's **parent** and sibling runs — is simply absent from the namespace, so absolute-path traversal outside the workspace fails with `ENOENT`. Network is left shared so the agent can still reach its model provider.

Design intent: this is a **host-hardening layer that can only ever add a boundary, never break a run**. When confinement cannot be established (non-Linux, no `bwrap`, or disabled), `build()` returns `None` and the agent runs exactly as before, with a logged reason.

Operator controls (read from the agent env):
- `VIBESYS_AGENT_SANDBOX=0|false|off|no` — disable confinement (logged loudly).
- `VIBESYS_AGENT_SANDBOX_ALLOW` — `os.pathsep`-separated extra read-only paths (model weights, HF/torch caches, MCP server code). Entries that are ancestors of the workspace are rejected, since binding them would re-expose sibling runs.

Reviewers should look closely at: the default toolchain allowlist in `_default_read_paths` (covers the common case — venv, Node/agent install, VibeSys source, agent config, NVIDIA nodes — but unusual GPU/model-weight/MCP layouts may need a `VIBESYS_AGENT_SANDBOX_ALLOW` entry or a `--docker` run), and the ancestor-rejection logic that preserves sibling isolation.

The codex/claude bypass flags are intentionally **kept**: bwrap is now the enforced outer jail, and running the provider's own (redundant) sandbox off avoids nesting conflicts. The flag's own docs say it is "intended solely for running in environments that are externally sandboxed" — which is now true.

### Architecture

`hostsandbox.build()` owns policy construction; `HostSandbox.wrap()` owns argv construction. The runner decides *whether* to confine (host branch only); the agent applies it at the single launch chokepoint. Container executors never build a policy.

```mermaid
flowchart TD
    R[CliAgentRunner.invoke] -->|host branch| B[hostsandbox.build]
    R -->|docker / modal branch| N[no sandbox — already externally sandboxed]
    B -->|linux + bwrap + not disabled| P[HostSandbox policy]
    B -->|otherwise| Z[None: run unconfined, logged]
    P --> A[agent.sandbox = policy]
    A --> G[CLICodingAgent.generate]
    G -->|cwd set AND sandbox set| W[HostSandbox.wrap: bwrap … -- argv]
    G -->|cwd None or no sandbox| U[argv unchanged]
    W --> X[executor.run]
    U --> X
```

## Verification

Reproduced the escape end-to-end, applied the fix, and confirmed containment end-to-end against real `bwrap` on a Linux host; then ran lint/format and the agent-CLI suite.

### Correctness properties

- Inner agent cannot read, write, or discover paths outside the workspace (sibling reads → `ENOENT`, sibling writes → blocked).
- Legitimate workspace reads/writes are unaffected, and persist to the host workspace.
- Confinement engages only on the host path (real `cwd` + installed policy); Docker/Modal (cwd=None) are never wrapped.
- Fail-safe: unavailable/disabled confinement degrades to prior unconfined behavior — the sandbox never breaks a previously-working run.
- Sibling isolation is preserved even under operator allowlisting: any allow path that is an ancestor of the workspace is dropped.

### Testing

```
./scripts/format.sh            # All checks passed
./scripts/check_format.sh      # All checks passed
./scripts/check_lint.sh        # All checks passed
uv run pytest tests/_agent_cli # 75 passed
uv run pytest                  # 1691 passed (full suite, pre-branch)
```

`tests/_agent_cli/test_hostsandbox.py` adds 16 tests: policy-builder behavior (disable env, missing bwrap, non-Linux, allowlist ancestor rejection), `bwrap` argv construction, and the #149 end-to-end regression (escape reproduced without the sandbox; blocked with it; container `cwd=None` path left unconfined). The real-`bwrap` tests are gated by a probe and skip cleanly where a working bubblewrap + user-namespace stack is absent (e.g. CI without user namespaces).