### PR TITLE
Add macOS Seatbelt backend for agent workspace confinement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,6 +203,30 @@ jobs:
           VIBESYS_REQUIRE_SANDBOX_TESTS: "1"
         run: uv run python -m pytest tests/_agent_cli/test_hostsandbox.py -v
 
+  # macOS counterpart of sandbox-linux: exercises the Seatbelt confinement
+  # boundary on a real macOS host. sandbox-exec ships with macOS, so no install
+  # step is needed; VIBESYS_REQUIRE_SANDBOX_TESTS=1 forces the Seatbelt test to
+  # run (and fail loudly) rather than skip.
+  sandbox-macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run workspace-confinement tests
+        env:
+          VIBESYS_REQUIRE_SANDBOX_TESTS: "1"
+        run: uv run python -m pytest tests/_agent_cli/test_hostsandbox.py -v
+
   patch-coverage:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'

--- a/src/vibesys/_agent_cli/cli_agent.py
+++ b/src/vibesys/_agent_cli/cli_agent.py
@@ -13,7 +13,7 @@ from agentshim.utils import get_interactive_env
 from loguru import logger
 
 from .base import CodingAgent
-from .hostsandbox import HostSandbox
+from .hostsandbox import AgentSandbox
 
 
 class CLIGenerationSession:
@@ -165,10 +165,10 @@ class CLICodingAgent(CodingAgent):
         self.logger = logger.bind(agent_prefix=self._log_prefix)
         self.session_id: str | None = None
         # Host-path filesystem confinement. Left ``None`` here (unconfined,
-        # legacy behavior); the CLI runner installs a :class:`HostSandbox` on
-        # the host execution path. Container executors leave it ``None`` because
-        # they are already externally sandboxed.
-        self.sandbox: HostSandbox | None = None
+        # legacy behavior); the CLI runner installs a platform-specific
+        # :data:`AgentSandbox` on the host execution path. Container executors
+        # leave it ``None`` because they are already externally sandboxed.
+        self.sandbox: AgentSandbox | None = None
 
     @abstractmethod
     def _get_command(self, prompt: str) -> list[str]:

--- a/src/vibesys/_agent_cli/cli_agent.py
+++ b/src/vibesys/_agent_cli/cli_agent.py
@@ -13,7 +13,7 @@ from agentshim.utils import get_interactive_env
 from loguru import logger
 
 from .base import CodingAgent
-from .hostsandbox import AgentSandbox
+from .hostsandbox import WorkspaceSandbox
 
 
 class CLIGenerationSession:
@@ -166,9 +166,9 @@ class CLICodingAgent(CodingAgent):
         self.session_id: str | None = None
         # Host-path filesystem confinement. Left ``None`` here (unconfined,
         # legacy behavior); the CLI runner installs a platform-specific
-        # :data:`AgentSandbox` on the host execution path. Container executors
+        # :class:`WorkspaceSandbox` on the host execution path. Container executors
         # leave it ``None`` because they are already externally sandboxed.
-        self.sandbox: AgentSandbox | None = None
+        self.sandbox: WorkspaceSandbox | None = None
 
     @abstractmethod
     def _get_command(self, prompt: str) -> list[str]:

--- a/src/vibesys/_agent_cli/hostsandbox.py
+++ b/src/vibesys/_agent_cli/hostsandbox.py
@@ -85,9 +85,12 @@ _MACOS_SYSTEM_READ_ROOTS: tuple[str, ...] = (
     "/bin",
     "/sbin",
     "/System",
+    # The dyld shared cache lives under the Preboot Cryptexes tree on
+    # Apple Silicon; without read access here every dynamically linked binary
+    # (including /bin/sh) aborts during dyld startup under (deny default).
+    "/System/Volumes/Preboot/Cryptexes",
     "/Library",
-    "/private/var/db/dyld",  # dyld shared cache
-    "/private/var/db/timezone",
+    "/private/var/db",  # dyld cache, timezone, and other launch-time state
     "/private/etc",
     "/etc",
     "/dev",
@@ -319,6 +322,11 @@ class SeatbeltSandbox:
             "(allow iokit-open)",  # Metal / GPU access for benchmarks
             # Network stays open so the agent can reach its model provider.
             "(allow network*)",
+            # Allow stat()/metadata on any path so dyld and command-line tools
+            # can resolve paths at startup. This grants metadata only, not file
+            # contents or directory enumeration, so sibling *contents* and
+            # listings stay denied by (deny default).
+            "(allow file-read-metadata)",
         ]
 
         # Read-only system + toolchain locations (metadata + contents).

--- a/src/vibesys/_agent_cli/hostsandbox.py
+++ b/src/vibesys/_agent_cli/hostsandbox.py
@@ -311,8 +311,12 @@ class SeatbeltSandbox:
             "(version 1)",
             "(deny default)",
             # Launching, threading, and the basic services a CLI needs.
-            "(allow process-exec)",
+            "(allow process-exec*)",
             "(allow process-fork)",
+            # Map code-signed executable pages. Without this, Apple-Silicon code
+            # signing enforcement aborts every dynamically linked binary (dyld)
+            # with SIGABRT and no stderr before it can run.
+            "(allow file-map-executable)",
             "(allow signal (target self))",
             "(allow sysctl-read)",
             "(allow mach-lookup)",

--- a/src/vibesys/_agent_cli/hostsandbox.py
+++ b/src/vibesys/_agent_cli/hostsandbox.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 import os
 import shutil
 import sys
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -214,13 +215,31 @@ def _parse_allow(env: dict[str, str]) -> list[Path]:
 
 
 @dataclass(frozen=True)
-class HostSandbox:
-    """A bubblewrap confinement policy for a single run workspace."""
+class WorkspaceSandbox(ABC):
+    """A host confinement policy for a single run workspace.
 
-    bwrap_path: str
+    Both OS backends are built by :func:`build` from the same inputs — the
+    workspace plus the read/write allowlists computed by :func:`_collect_paths`
+    — and expose the same ``wrap(argv) -> argv`` contract consumed at the agent
+    launch chokepoint (:meth:`CLICodingAgent.generate`). Subclasses differ only
+    in the OS mechanism they emit: :class:`HostSandbox` a bubblewrap namespace,
+    :class:`SeatbeltSandbox` a ``sandbox-exec`` profile.
+    """
+
     workspace: Path
     read_paths: tuple[Path, ...] = ()
     write_paths: tuple[Path, ...] = ()
+
+    @abstractmethod
+    def wrap(self, argv: list[str]) -> list[str]:
+        """Return *argv* rewritten to run confined to :attr:`workspace`."""
+
+
+@dataclass(frozen=True)
+class HostSandbox(WorkspaceSandbox):
+    """A bubblewrap confinement policy for a single run workspace."""
+
+    bwrap_path: str = field(kw_only=True)
     system_read_roots: tuple[str, ...] = _SYSTEM_READ_ROOTS
     gpu_device_nodes: tuple[Path, ...] = field(default_factory=tuple)
 
@@ -288,7 +307,7 @@ def _sbpl_string(value: str) -> str:
 
 
 @dataclass(frozen=True)
-class SeatbeltSandbox:
+class SeatbeltSandbox(WorkspaceSandbox):
     """A macOS Seatbelt (``sandbox-exec``) confinement policy for a workspace.
 
     macOS confinement follows the model that Codex's own Seatbelt sandbox uses,
@@ -308,10 +327,7 @@ class SeatbeltSandbox:
     if full read-confinement is required.
     """
 
-    sandbox_exec_path: str
-    workspace: Path
-    read_paths: tuple[Path, ...] = ()
-    write_paths: tuple[Path, ...] = ()
+    sandbox_exec_path: str = field(kw_only=True)
     system_read_roots: tuple[str, ...] = _MACOS_SYSTEM_READ_ROOTS
 
     def blind_roots(self) -> list[Path]:
@@ -385,10 +401,6 @@ class SeatbeltSandbox:
         return [self.sandbox_exec_path, "-p", self.profile(), *argv]
 
 
-AgentSandbox = HostSandbox | SeatbeltSandbox
-"""Either host confinement backend; both implement ``wrap(argv) -> argv``."""
-
-
 def _collect_paths(
     workspace: Path,
     env: dict[str, str],
@@ -428,7 +440,7 @@ def build(
     env: dict[str, str],
     binary_path: str | None = None,
     log: Callable[[str], None] | None = None,
-) -> AgentSandbox | None:
+) -> WorkspaceSandbox | None:
     """Build a host confinement policy for *workspace*, or ``None`` if not enforced.
 
     Dispatches to the Linux (bubblewrap) or macOS (Seatbelt) backend by platform.

--- a/src/vibesys/_agent_cli/hostsandbox.py
+++ b/src/vibesys/_agent_cli/hostsandbox.py
@@ -291,12 +291,21 @@ def _sbpl_string(value: str) -> str:
 class SeatbeltSandbox:
     """A macOS Seatbelt (``sandbox-exec``) confinement policy for a workspace.
 
-    The generated profile is ``(deny default)`` with an explicit allowlist:
-    read-only on system/toolchain roots, read-write on the workspace, the
-    agent's own config dirs, and ``/private/tmp``. The workspace's parent and
-    sibling runs are *not* in the allowlist, so reads (directory enumeration and
-    file access) and writes outside the workspace are denied — this is what
-    blocks discovery of sibling runs.
+    macOS confinement follows the model that Codex's own Seatbelt sandbox uses,
+    because it is the one that reliably launches Apple-Silicon toolchains:
+    **reads are allowed broadly** (a ``(deny default)`` read policy makes dyld
+    and code-signing abort every dynamically linked binary), while **writes are
+    denied by default** and permitted only on the workspace, the agent's config
+    dirs, and ``/tmp``. On top of that, the workspace's run-container tree — the
+    directory that holds sibling runs — is explicitly denied for both read and
+    write, with the workspace itself carved back out. That blocks the concrete
+    escape from issue #149 (discovering/using a sibling run) and all writes
+    outside the workspace.
+
+    This is a weaker guarantee than the Linux bubblewrap backend, which hides the
+    entire host outside the workspace: on macOS, reads of unrelated host files
+    outside the run-container tree are still permitted. Use ``--docker`` on macOS
+    if full read-confinement is required.
     """
 
     sandbox_exec_path: str
@@ -305,17 +314,34 @@ class SeatbeltSandbox:
     write_paths: tuple[Path, ...] = ()
     system_read_roots: tuple[str, ...] = _MACOS_SYSTEM_READ_ROOTS
 
+    def blind_roots(self) -> list[Path]:
+        """Ancestor dirs of the workspace to deny (read+write) to hide siblings.
+
+        Returns the workspace's parent and grandparent (the run and run-container
+        dirs in the ``exp_env/<run>/workspace`` layout), skipping the filesystem
+        root and any system location so the deny can never blind the toolchain.
+        """
+        roots: list[Path] = []
+        for anc in list(self.workspace.parents)[:2]:
+            if anc == anc.parent:  # filesystem root
+                continue
+            s = str(anc)
+            if any(s == r or s.startswith(r + "/") for r in self.system_read_roots):
+                continue
+            roots.append(anc)
+        return roots
+
     def profile(self) -> str:
         """Render the SBPL profile text for this policy."""
+        ws = _sbpl_string(str(self.workspace))
         lines = [
             "(version 1)",
             "(deny default)",
             # Launching, threading, and the basic services a CLI needs.
             "(allow process-exec*)",
             "(allow process-fork)",
-            # Map code-signed executable pages. Without this, Apple-Silicon code
-            # signing enforcement aborts every dynamically linked binary (dyld)
-            # with SIGABRT and no stderr before it can run.
+            # Map code-signed executable pages — without this, Apple-Silicon code
+            # signing aborts every dynamically linked binary (dyld) at startup.
             "(allow file-map-executable)",
             "(allow signal (target self))",
             "(allow sysctl-read)",
@@ -326,26 +352,27 @@ class SeatbeltSandbox:
             "(allow iokit-open)",  # Metal / GPU access for benchmarks
             # Network stays open so the agent can reach its model provider.
             "(allow network*)",
-            # Allow stat()/metadata on any path so dyld and command-line tools
-            # can resolve paths at startup. This grants metadata only, not file
-            # contents or directory enumeration, so sibling *contents* and
-            # listings stay denied by (deny default).
-            "(allow file-read-metadata)",
+            # Reads are allowed broadly so dyld/code-signing/toolchain work.
+            "(allow file-read*)",
         ]
 
-        # Read-only system + toolchain locations (metadata + contents).
-        read_roots = list(self.system_read_roots) + [str(p) for p in self.read_paths]
-        lines.append("(allow file-read* file-read-metadata")
-        lines += [f"    (subpath {_sbpl_string(r)})" for r in read_roots]
-        lines.append(")")
-
-        # Read-write: the workspace (the one project path the agent may modify),
-        # the agent's own config/auth dirs, and scratch tmp.
+        # Writes are denied by default; permit them only on the workspace, the
+        # agent's own config/auth dirs, and scratch tmp.
         write_roots = [str(self.workspace)] + [str(p) for p in self.write_paths]
         write_roots += ["/private/tmp", "/private/var/tmp"]
-        lines.append("(allow file*")
+        lines.append("(allow file-write*")
         lines += [f"    (subpath {_sbpl_string(w)})" for w in write_roots]
         lines.append(")")
+
+        # Blind the sibling-run area: deny read+write on the run-container tree,
+        # then carve the workspace back out. The most-specific (last) matching
+        # rule wins in SBPL, so workspace access survives the deny.
+        blind = self.blind_roots()
+        if blind:
+            lines.append("(deny file-read* file-write*")
+            lines += [f"    (subpath {_sbpl_string(str(r))})" for r in blind]
+            lines.append(")")
+            lines.append(f"(allow file-read* file-write* (subpath {ws}))")
 
         return "\n".join(lines) + "\n"
 

--- a/src/vibesys/_agent_cli/hostsandbox.py
+++ b/src/vibesys/_agent_cli/hostsandbox.py
@@ -8,23 +8,30 @@ anywhere the VibeSys user can, so a misbehaving agent can step outside its
 ``exp_env/<run>/workspace`` and reach sibling runs, unrelated repositories, or
 host secrets. Prompt-only containment is not a security boundary (issue #149).
 
-This module wraps the agent command in a `bubblewrap <https://github.com/
-containers/bubblewrap>`_ (``bwrap``) mount namespace that exposes only:
+This module wraps the agent command in an OS confinement layer that exposes only:
 
 * a read-only view of system/toolchain directories and the Python/agent
   runtimes needed to launch,
 * the agent's own config/auth directories (so it can authenticate),
 * any explicitly allowed extra paths (model/weight caches, MCP server code),
-* a writable bind of the run workspace and a private ``/tmp``.
+* read-write access to the run workspace and a private ``/tmp``.
 
 Everything else — including the workspace's *parent* and sibling runs — is
-simply absent from the namespace, so absolute-path traversal outside the
-workspace fails with ``ENOENT``. Network is left shared so the agent can still
-reach its model provider.
+denied, so absolute-path traversal outside the workspace fails. Network is left
+open so the agent can still reach its model provider.
 
-The confinement is enforced by default on Linux hosts. It is a *host*-path
+Two host backends implement the same ``wrap(argv) -> argv`` contract, selected
+by platform:
+
+* **Linux** — :class:`HostSandbox`, a `bubblewrap <https://github.com/
+  containers/bubblewrap>`_ (``bwrap``) mount namespace. Denied paths are simply
+  absent from the namespace, so traversal fails with ``ENOENT``.
+* **macOS** — :class:`SeatbeltSandbox`, a Seatbelt (``sandbox-exec``) profile
+  with ``(deny default)`` and an explicit read/write allowlist.
+
+The confinement is enforced by default on supported hosts. It is a *host*-path
 concern only: the Docker and Modal executors already run the agent inside an
-externally managed sandbox, so those paths never build a :class:`HostSandbox`.
+externally managed sandbox, so those paths never build a sandbox here.
 
 Operator controls (read from the agent's environment):
 
@@ -54,9 +61,9 @@ ALLOW_ENV = "VIBESYS_AGENT_SANDBOX_ALLOW"
 
 _DISABLED_VALUES = frozenset({"0", "false", "off", "no"})
 
-# Read-only system/toolchain roots exposed inside the namespace. Bound with
-# ``--ro-bind-try`` so a root that does not exist on a given host is skipped
-# rather than aborting the launch.
+# Read-only system/toolchain roots exposed inside the Linux namespace. Bound
+# with ``--ro-bind-try`` so a root that does not exist on a given host is
+# skipped rather than aborting the launch.
 _SYSTEM_READ_ROOTS: tuple[str, ...] = (
     "/usr",
     "/bin",
@@ -67,6 +74,24 @@ _SYSTEM_READ_ROOTS: tuple[str, ...] = (
     "/etc",
     "/opt",
     "/run/systemd/resolve",  # DNS via systemd-resolved
+)
+
+# Read-only system roots the macOS dynamic linker and command-line tools need to
+# launch anything at all. Kept deliberately broad on the *system* side (dyld,
+# frameworks, config) while the workspace's parent and sibling runs stay denied
+# by ``(deny default)``.
+_MACOS_SYSTEM_READ_ROOTS: tuple[str, ...] = (
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/System",
+    "/Library",
+    "/private/var/db/dyld",  # dyld shared cache
+    "/private/var/db/timezone",
+    "/private/etc",
+    "/etc",
+    "/dev",
+    "/Applications",  # some agent CLIs ship here
 )
 
 
@@ -159,13 +184,25 @@ def _default_config_paths(env: dict[str, str]) -> list[Path]:
     if not home:
         return []
     base = Path(home)
-    return [
+    paths = [
         base / ".codex",
         base / ".claude",
         base / ".claude.json",
         base / ".config" / "codex",
         base / ".config" / "claude",
     ]
+    if sys.platform == "darwin":
+        # macOS agent CLIs also keep state under Application Support / Caches.
+        support = base / "Library" / "Application Support"
+        caches = base / "Library" / "Caches"
+        paths += [
+            support / "codex",
+            support / "claude",
+            support / "com.openai.codex",
+            caches / "codex",
+            caches / "claude",
+        ]
+    return paths
 
 
 def _parse_allow(env: dict[str, str]) -> list[Path]:
@@ -235,20 +272,131 @@ def _gpu_device_nodes() -> list[Path]:
     return nodes
 
 
+def _sbpl_string(value: str) -> str:
+    """Quote *value* as a Seatbelt Profile Language (SBPL) string literal.
+
+    SBPL string literals are double-quoted with backslash escaping, so a path
+    containing a quote, backslash, or other special character is embedded safely
+    rather than breaking the profile (or letting an attacker-controlled path
+    inject profile syntax).
+    """
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+@dataclass(frozen=True)
+class SeatbeltSandbox:
+    """A macOS Seatbelt (``sandbox-exec``) confinement policy for a workspace.
+
+    The generated profile is ``(deny default)`` with an explicit allowlist:
+    read-only on system/toolchain roots, read-write on the workspace, the
+    agent's own config dirs, and ``/private/tmp``. The workspace's parent and
+    sibling runs are *not* in the allowlist, so reads (directory enumeration and
+    file access) and writes outside the workspace are denied — this is what
+    blocks discovery of sibling runs.
+    """
+
+    sandbox_exec_path: str
+    workspace: Path
+    read_paths: tuple[Path, ...] = ()
+    write_paths: tuple[Path, ...] = ()
+    system_read_roots: tuple[str, ...] = _MACOS_SYSTEM_READ_ROOTS
+
+    def profile(self) -> str:
+        """Render the SBPL profile text for this policy."""
+        lines = [
+            "(version 1)",
+            "(deny default)",
+            # Launching, threading, and the basic services a CLI needs.
+            "(allow process-exec)",
+            "(allow process-fork)",
+            "(allow signal (target self))",
+            "(allow sysctl-read)",
+            "(allow mach-lookup)",
+            "(allow mach-per-user-lookup)",
+            "(allow ipc-posix-shm)",
+            "(allow system-socket)",
+            "(allow iokit-open)",  # Metal / GPU access for benchmarks
+            # Network stays open so the agent can reach its model provider.
+            "(allow network*)",
+        ]
+
+        # Read-only system + toolchain locations (metadata + contents).
+        read_roots = list(self.system_read_roots) + [str(p) for p in self.read_paths]
+        lines.append("(allow file-read* file-read-metadata")
+        lines += [f"    (subpath {_sbpl_string(r)})" for r in read_roots]
+        lines.append(")")
+
+        # Read-write: the workspace (the one project path the agent may modify),
+        # the agent's own config/auth dirs, and scratch tmp.
+        write_roots = [str(self.workspace)] + [str(p) for p in self.write_paths]
+        write_roots += ["/private/tmp", "/private/var/tmp"]
+        lines.append("(allow file*")
+        lines += [f"    (subpath {_sbpl_string(w)})" for w in write_roots]
+        lines.append(")")
+
+        return "\n".join(lines) + "\n"
+
+    def wrap(self, argv: list[str]) -> list[str]:
+        """Return *argv* wrapped so it runs inside the Seatbelt profile."""
+        # ``-p`` takes the profile inline, keeping ``wrap`` pure (no temp files).
+        # ``sandbox-exec`` runs the command from the caller's cwd, which the CLI
+        # runner already sets to the workspace.
+        return [self.sandbox_exec_path, "-p", self.profile(), *argv]
+
+
+AgentSandbox = HostSandbox | SeatbeltSandbox
+"""Either host confinement backend; both implement ``wrap(argv) -> argv``."""
+
+
+def _collect_paths(
+    workspace: Path,
+    env: dict[str, str],
+    binary_path: str | None,
+    log: Callable[[str], None],
+) -> tuple[list[Path], list[Path]]:
+    """Compute the (read, write) allowlists shared by both host backends.
+
+    Applies the sibling-isolation invariant: no allowlisted path may be an
+    ancestor of the workspace, since that would re-expose sibling runs.
+    """
+    read_paths = _existing(_default_read_paths(env, binary_path))
+    write_paths = _existing(_default_config_paths(env))
+
+    for extra in _parse_allow(env):
+        resolved = extra.resolve()
+        if _is_ancestor(resolved, workspace):
+            log(
+                f"[hostsandbox] ignoring {ALLOW_ENV} entry {extra} because it is an "
+                "ancestor of the workspace; allowing it would expose sibling runs."
+            )
+            continue
+        if resolved.exists():
+            read_paths.append(resolved)
+
+    # Safety net: drop any default read/write path that is an ancestor of the
+    # workspace. (Toolchain subtrees like the venv are not ancestors, so this
+    # normally changes nothing.)
+    read_paths = [p for p in read_paths if not _is_ancestor(p, workspace)]
+    write_paths = [p for p in write_paths if not _is_ancestor(p, workspace)]
+    return read_paths, write_paths
+
+
 def build(
     workspace: Path | str,
     *,
     env: dict[str, str],
     binary_path: str | None = None,
     log: Callable[[str], None] | None = None,
-) -> HostSandbox | None:
-    """Build a :class:`HostSandbox` for *workspace*, or ``None`` if not enforced.
+) -> AgentSandbox | None:
+    """Build a host confinement policy for *workspace*, or ``None`` if not enforced.
 
+    Dispatches to the Linux (bubblewrap) or macOS (Seatbelt) backend by platform.
     Returns ``None`` (and logs why) when confinement is disabled by the operator,
-    when the host is not Linux, or when ``bwrap`` / user namespaces are
-    unavailable. In those cases the caller runs the agent unconfined, exactly as
-    before this change, so the sandbox can never *break* a run that used to work
-    — it only ever adds a boundary.
+    when the host OS has no supported backend, or when the backend's tool
+    (``bwrap`` / ``sandbox-exec``) is unavailable. In those cases the caller runs
+    the agent unconfined, exactly as before this change — the sandbox can never
+    *break* a run that used to work, it only ever adds a boundary.
     """
 
     def _log(msg: str) -> None:
@@ -264,48 +412,64 @@ def build(
         )
         return None
 
-    if not sys.platform.startswith("linux"):
-        _log(
-            f"[hostsandbox] host confinement unavailable on {sys.platform!r} "
-            "(bubblewrap is Linux-only); agent runs unconfined. Use --docker for "
-            "an externally sandboxed run."
-        )
-        return None
+    if sys.platform.startswith("linux"):
+        return _build_linux(workspace, env=env, binary_path=binary_path, log=_log)
+    if sys.platform == "darwin":
+        return _build_macos(workspace, env=env, binary_path=binary_path, log=_log)
 
+    _log(
+        f"[hostsandbox] no host confinement backend for {sys.platform!r}; agent "
+        "runs unconfined. Use --docker for an externally sandboxed run."
+    )
+    return None
+
+
+def _build_linux(
+    workspace: Path,
+    *,
+    env: dict[str, str],
+    binary_path: str | None,
+    log: Callable[[str], None],
+) -> HostSandbox | None:
     bwrap = shutil.which("bwrap", path=env.get("PATH")) or shutil.which("bwrap")
     if not bwrap:
-        _log(
+        log(
             "[hostsandbox] 'bwrap' not found on PATH; agent runs unconfined. "
             "Install bubblewrap or use --docker for an externally sandboxed run."
         )
         return None
 
-    read_paths = _existing(_default_read_paths(env, binary_path))
-    write_paths = _existing(_default_config_paths(env))
-
-    # Extra operator-allowed read paths, minus any that would re-expose the
-    # workspace's parent (and therefore sibling runs).
-    for extra in _parse_allow(env):
-        resolved = extra.resolve()
-        if _is_ancestor(resolved, workspace):
-            _log(
-                f"[hostsandbox] ignoring {ALLOW_ENV} entry {extra} because it is an "
-                "ancestor of the workspace; binding it would expose sibling runs."
-            )
-            continue
-        if resolved.exists():
-            read_paths.append(resolved)
-
-    # Never expose a default read/write path that is an ancestor of the
-    # workspace — that would defeat sibling isolation. (Toolchain subtrees like
-    # the venv are not ancestors, so this is a safety net, not a common case.)
-    read_paths = [p for p in read_paths if not _is_ancestor(p, workspace)]
-    write_paths = [p for p in write_paths if not _is_ancestor(p, workspace)]
-
+    read_paths, write_paths = _collect_paths(workspace, env, binary_path, log)
     return HostSandbox(
         bwrap_path=bwrap,
         workspace=workspace,
         read_paths=tuple(read_paths),
         write_paths=tuple(write_paths),
         gpu_device_nodes=tuple(_gpu_device_nodes()),
+    )
+
+
+def _build_macos(
+    workspace: Path,
+    *,
+    env: dict[str, str],
+    binary_path: str | None,
+    log: Callable[[str], None],
+) -> SeatbeltSandbox | None:
+    sandbox_exec = shutil.which("sandbox-exec", path=env.get("PATH")) or shutil.which(
+        "sandbox-exec"
+    )
+    if not sandbox_exec:
+        log(
+            "[hostsandbox] 'sandbox-exec' not found; agent runs unconfined. "
+            "Use --docker for an externally sandboxed run."
+        )
+        return None
+
+    read_paths, write_paths = _collect_paths(workspace, env, binary_path, log)
+    return SeatbeltSandbox(
+        sandbox_exec_path=sandbox_exec,
+        workspace=workspace,
+        read_paths=tuple(read_paths),
+        write_paths=tuple(write_paths),
     )

--- a/src/vibesys/_agent_cli/hostsandbox.py
+++ b/src/vibesys/_agent_cli/hostsandbox.py
@@ -357,9 +357,10 @@ class SeatbeltSandbox:
         ]
 
         # Writes are denied by default; permit them only on the workspace, the
-        # agent's own config/auth dirs, and scratch tmp.
+        # agent's own config/auth dirs, scratch tmp, and device nodes (a process
+        # must be able to write /dev/null, /dev/stdout, /dev/tty, ...).
         write_roots = [str(self.workspace)] + [str(p) for p in self.write_paths]
-        write_roots += ["/private/tmp", "/private/var/tmp"]
+        write_roots += ["/private/tmp", "/private/var/tmp", "/dev"]
         lines.append("(allow file-write*")
         lines += [f"    (subpath {_sbpl_string(w)})" for w in write_roots]
         lines.append(")")

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -406,6 +406,16 @@ def test_seatbelt_blocks_escape_but_allows_workspace(tmp_path_factory):
     agent, workspace, sibling = _escape_probe(tmp_path_factory)
     agent.sandbox = hostsandbox.build(workspace, env=agent.env, binary_path=agent.binary_path)
     assert isinstance(agent.sandbox, hostsandbox.SeatbeltSandbox)
+
+    # Sanity-check that the profile lets an ordinary binary launch at all before
+    # asserting on the escape. A dyld-startup denial shows up as an abort with no
+    # stderr, so surface sandbox-exec's own output to make such failures legible.
+    probe = subprocess.run(agent.sandbox.wrap(["/usr/bin/true"]), capture_output=True, text=True)
+    assert probe.returncode == 0, (
+        f"profile blocks a trivial launch (rc={probe.returncode}); "
+        f"stderr={probe.stderr!r}\n--- profile ---\n{agent.sandbox.profile()}"
+    )
+
     out = agent.generate("stay in the workspace", cwd=str(workspace), silent=True)
 
     assert "READ_OK" not in out and "SECRET=leak" not in out

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -169,6 +169,30 @@ class TestWrap:
         assert ws_bind > last_ro
 
 
+class TestSharedAbstraction:
+    """Both OS backends implement the one ``WorkspaceSandbox`` contract."""
+
+    def test_backends_subclass_workspace_sandbox(self):
+        assert issubclass(hostsandbox.HostSandbox, hostsandbox.WorkspaceSandbox)
+        assert issubclass(hostsandbox.SeatbeltSandbox, hostsandbox.WorkspaceSandbox)
+
+    def test_base_is_abstract(self):
+        with pytest.raises(TypeError):
+            hostsandbox.WorkspaceSandbox(workspace=Path("/x"))
+
+    def test_backends_share_fields_and_wrap(self):
+        host = hostsandbox.HostSandbox(
+            workspace=Path("/x"), bwrap_path="/usr/bin/bwrap", read_paths=(Path("/opt"),)
+        )
+        seat = hostsandbox.SeatbeltSandbox(
+            workspace=Path("/x"), sandbox_exec_path="/usr/bin/sandbox-exec"
+        )
+        for sb in (host, seat):
+            assert isinstance(sb, hostsandbox.WorkspaceSandbox)
+            assert sb.workspace == Path("/x")
+            assert sb.wrap(["agent"])[-1] == "agent"
+
+
 class TestInstallRoot:
     """Regression for a real breakage caught by running codex under the sandbox:
     an npm-packaged CLI must be able to reach its sibling platform binary."""

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -50,15 +50,19 @@ def _bwrap_works() -> bool:
 
 
 # CI sets ``VIBESYS_REQUIRE_SANDBOX_TESTS=1`` so the real-confinement tests must
-# run instead of silently skipping. If the sandbox stack is then unavailable the
-# tests fail (build() returns None → assertions trip), which is the whole point:
-# a broken or absent sandbox in CI should be loud, not invisible.
+# run instead of silently skipping. If the backend is then unavailable the tests
+# fail (build() returns None → assertions trip), which is the whole point: a
+# broken or absent sandbox in CI should be loud, not invisible. The force is
+# scoped to the backend's own platform so the Linux CI job does not try to run
+# the macOS test (and vice versa).
 _REQUIRE_SANDBOX_TESTS = os.environ.get("VIBESYS_REQUIRE_SANDBOX_TESTS") == "1"
+_FORCE_LINUX = _REQUIRE_SANDBOX_TESTS and sys.platform.startswith("linux")
+_FORCE_MACOS = _REQUIRE_SANDBOX_TESTS and sys.platform == "darwin"
 
 requires_sandbox = pytest.mark.skipif(
-    not _REQUIRE_SANDBOX_TESTS and not _bwrap_works(),
+    not (_FORCE_LINUX or _bwrap_works()),
     reason="requires a working bwrap + user-namespace stack "
-    "(set VIBESYS_REQUIRE_SANDBOX_TESTS=1 to force)",
+    "(set VIBESYS_REQUIRE_SANDBOX_TESTS=1 on Linux to force)",
 )
 
 
@@ -390,8 +394,8 @@ def _seatbelt_works() -> bool:
 
 
 requires_seatbelt = pytest.mark.skipif(
-    not _seatbelt_works(),
-    reason="requires macOS sandbox-exec",
+    not (_FORCE_MACOS or _seatbelt_works()),
+    reason="requires macOS sandbox-exec (set VIBESYS_REQUIRE_SANDBOX_TESTS=1 on macOS to force)",
 )
 
 

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -85,11 +85,11 @@ class TestBuild:
         assert hostsandbox.build(tmp_path, env={}, log=logs.append) is None
         assert any("bwrap" in m for m in logs)
 
-    def test_non_linux_returns_none(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(hostsandbox.sys, "platform", "darwin")
+    def test_unsupported_platform_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hostsandbox.sys, "platform", "win32")
         logs: list[str] = []
         assert hostsandbox.build(tmp_path, env={}, log=logs.append) is None
-        assert any("unavailable" in m for m in logs)
+        assert any("no host confinement backend" in m for m in logs)
 
     def test_allow_ancestor_of_workspace_is_rejected(self, tmp_path, monkeypatch):
         monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
@@ -195,6 +195,89 @@ def _has_pair(argv: list[str], flag: str, *operands: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# macOS Seatbelt backend (runs everywhere via monkeypatched platform)
+# ---------------------------------------------------------------------------
+
+
+class TestMacosBuild:
+    def _patch(self, monkeypatch, sandbox_exec="/usr/bin/sandbox-exec"):
+        monkeypatch.setattr(hostsandbox.sys, "platform", "darwin")
+        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: sandbox_exec)
+
+    def test_build_returns_seatbelt_on_darwin(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        sb = hostsandbox.build(workspace, env={})
+        assert isinstance(sb, hostsandbox.SeatbeltSandbox)
+        assert sb.workspace == workspace.resolve()
+
+    def test_missing_sandbox_exec_returns_none(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch, sandbox_exec=None)
+        logs: list[str] = []
+        assert hostsandbox.build(tmp_path, env={}, log=logs.append) is None
+        assert any("sandbox-exec" in m for m in logs)
+
+    def test_allow_ancestor_rejected_on_darwin(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch)
+        workspace = tmp_path / "exp_env" / "run" / "workspace"
+        workspace.mkdir(parents=True)
+        sb = hostsandbox.build(workspace, env={hostsandbox.ALLOW_ENV: str(tmp_path)})
+        assert isinstance(sb, hostsandbox.SeatbeltSandbox)
+        assert tmp_path.resolve() not in sb.read_paths
+
+
+class TestSeatbeltProfile:
+    def _sandbox(self, workspace: Path) -> hostsandbox.SeatbeltSandbox:
+        return hostsandbox.SeatbeltSandbox(
+            sandbox_exec_path="/usr/bin/sandbox-exec",
+            workspace=workspace,
+            read_paths=(Path("/opt/toolchain"),),
+            write_paths=(Path("/home/u/.codex"),),
+        )
+
+    def test_profile_denies_by_default_and_allows_workspace(self, tmp_path):
+        prof = self._sandbox(tmp_path).profile()
+        assert prof.startswith("(version 1)\n(deny default)")
+        # Workspace is read-write; toolchain is read-only; network stays open.
+        assert f'(subpath "{tmp_path}")' in prof
+        assert '(subpath "/opt/toolchain")' in prof
+        assert "(allow network*)" in prof
+
+    def test_profile_does_not_grant_workspace_parent(self, tmp_path):
+        """The sibling-run parent must not appear as an allowed subpath."""
+        workspace = tmp_path / "exp_env" / "run-A" / "workspace"
+        prof = self._sandbox(workspace).profile()
+        # The exact workspace subpath is granted, but its parent is not.
+        assert f'(subpath "{workspace}")' in prof
+        parent = workspace.parent
+        assert f'(subpath "{parent}")' not in prof
+
+    def test_wrap_shape(self, tmp_path):
+        sb = self._sandbox(tmp_path)
+        argv = sb.wrap(["codex", "exec", "--json"])
+        assert argv[0] == "/usr/bin/sandbox-exec"
+        assert argv[1] == "-p"
+        assert argv[2] == sb.profile()
+        assert argv[3:] == ["codex", "exec", "--json"]
+
+    def test_sbpl_string_escapes_quotes_and_backslashes(self):
+        assert hostsandbox._sbpl_string(r'/a/"b"\c') == r'"/a/\"b\"\\c"'
+
+    def test_profile_embeds_paths_safely(self, tmp_path):
+        """A workspace path with SBPL-significant characters stays quoted."""
+        workspace = tmp_path / 'weird ")name'
+        workspace.mkdir()
+        sb = hostsandbox.SeatbeltSandbox(
+            sandbox_exec_path="/usr/bin/sandbox-exec", workspace=workspace
+        )
+        prof = sb.profile()
+        # The literal appears escaped, and the raw unescaped form does not leak.
+        assert hostsandbox._sbpl_string(str(workspace)) in prof
+        assert f'(subpath "{workspace}")' not in prof
+
+
+# ---------------------------------------------------------------------------
 # End-to-end regression through the real launch path (issue #149)
 # ---------------------------------------------------------------------------
 
@@ -285,3 +368,44 @@ def test_generate_does_not_wrap_when_cwd_is_none(tmp_path_factory, monkeypatch):
     monkeypatch.chdir(scratch)
     out = agent.generate("no cwd", cwd=None, silent=True)
     assert "READ_OK" in out
+
+
+def _seatbelt_works() -> bool:
+    """True on macOS with a usable ``sandbox-exec``."""
+    if sys.platform != "darwin":
+        return False
+    sandbox_exec = shutil.which("sandbox-exec")
+    if not sandbox_exec:
+        return False
+    probe = "/usr/bin/true" if Path("/usr/bin/true").exists() else "/bin/true"
+    try:
+        proc = subprocess.run(
+            [sandbox_exec, "-p", "(version 1)(allow default)", probe],
+            capture_output=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
+requires_seatbelt = pytest.mark.skipif(
+    not _seatbelt_works(),
+    reason="requires macOS sandbox-exec",
+)
+
+
+@requires_seatbelt
+def test_seatbelt_blocks_escape_but_allows_workspace(tmp_path_factory):
+    """macOS counterpart of the Linux regression: the Seatbelt profile denies the
+    sibling read/write while the workspace stays usable."""
+    agent, workspace, sibling = _escape_probe(tmp_path_factory)
+    agent.sandbox = hostsandbox.build(workspace, env=agent.env, binary_path=agent.binary_path)
+    assert isinstance(agent.sandbox, hostsandbox.SeatbeltSandbox)
+    out = agent.generate("stay in the workspace", cwd=str(workspace), silent=True)
+
+    assert "READ_OK" not in out and "SECRET=leak" not in out
+    assert "WRITE_OK" not in out
+    assert not (sibling / "pwn.txt").exists()
+    assert "WS_OK" in out
+    assert (workspace / "candidate.txt").read_text().strip() == "ok"

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -240,22 +240,47 @@ class TestSeatbeltProfile:
             write_paths=(Path("/home/u/.codex"),),
         )
 
-    def test_profile_denies_by_default_and_allows_workspace(self, tmp_path):
+    def test_profile_write_confines_but_reads_broadly(self, tmp_path):
         prof = self._sandbox(tmp_path).profile()
         assert prof.startswith("(version 1)\n(deny default)")
-        # Workspace is read-write; toolchain is read-only; network stays open.
+        # Reads are broad (so the toolchain launches); the workspace is writable;
+        # executable mapping and network are permitted.
+        assert "(allow file-read*)" in prof
+        assert "(allow file-map-executable)" in prof
+        assert "(allow file-write*" in prof
         assert f'(subpath "{tmp_path}")' in prof
-        assert '(subpath "/opt/toolchain")' in prof
         assert "(allow network*)" in prof
 
-    def test_profile_does_not_grant_workspace_parent(self, tmp_path):
-        """The sibling-run parent must not appear as an allowed subpath."""
+    def test_profile_blinds_sibling_run_area(self, tmp_path):
+        """The run-container tree is denied (read+write); the workspace is carved
+        back out so sibling runs are hidden but the workspace still works."""
         workspace = tmp_path / "exp_env" / "run-A" / "workspace"
-        prof = self._sandbox(workspace).profile()
-        # The exact workspace subpath is granted, but its parent is not.
-        assert f'(subpath "{workspace}")' in prof
-        parent = workspace.parent
-        assert f'(subpath "{parent}")' not in prof
+        workspace.mkdir(parents=True)
+        sb = self._sandbox(workspace)
+        prof = sb.profile()
+        # The run and run-container dirs are denied...
+        assert "(deny file-read* file-write*" in prof
+        blind = {str(r) for r in sb.blind_roots()}
+        assert str(workspace.parent) in blind  # exp_env/run-A
+        assert str(workspace.parent.parent) in blind  # exp_env
+        for r in blind:
+            assert f'(subpath "{r}")' in prof
+        # ...and the workspace itself is re-allowed after the deny.
+        deny_idx = prof.index("(deny file-read* file-write*")
+        reallow = f'(allow file-read* file-write* (subpath "{workspace}"))'
+        assert reallow in prof
+        assert prof.index(reallow) > deny_idx
+
+    def test_blind_roots_skip_system_dirs(self, tmp_path):
+        """A shallow workspace must never blind the filesystem root or a system
+        dir (that would break the toolchain)."""
+        sb = hostsandbox.SeatbeltSandbox(
+            sandbox_exec_path="/usr/bin/sandbox-exec", workspace=Path("/tmp/ws")
+        )
+        # parent is /tmp, grandparent is / — root is skipped; no system root leaks.
+        for r in sb.blind_roots():
+            assert r != Path("/")
+            assert not str(r).startswith("/usr")
 
     def test_wrap_shape(self, tmp_path):
         sb = self._sandbox(tmp_path)


### PR DESCRIPTION
> **Stacked on #166** (base = `vic/agent-workspace-sandbox-linux`). Review/merge that first; this PR's diff is only the macOS additions.
>
> ⚠️ **Needs validation on a real Mac.** This was authored and unit-tested on Linux. The Seatbelt profile-generation, platform dispatch, and SBPL escaping are unit-tested everywhere, but the **end-to-end containment test is gated to macOS and has not been executed on a real host in this environment.** Someone must run it on a Mac (ideally an Apple-Silicon GPU/Metal box) before this leaves draft. See "Verification".

## Problem

#149 (agent escaping `exp_env/<run>/workspace`) is closed on Linux by #164/#166 using bubblewrap — but bubblewrap is Linux-only. On macOS `hostsandbox.build()` returned `None`, so host runs stayed **unconfined** and the escape was still possible. macOS is a supported dev/run platform (the repo ships native macOS CPU profilers), so this gap is real. This PR is the macOS half of #149, tracked as #165.

Closes #165. Part of #149.

## Solution

Add a second host backend behind the existing `hostsandbox` seam (`wrap(argv) -> argv`), selected by platform:

- **Linux** — `HostSandbox` (bubblewrap), unchanged.
- **macOS** — new `SeatbeltSandbox`, a `sandbox-exec` profile.

`build()` is refactored to dispatch by `sys.platform` on top of a **shared** read/write allowlist builder (`_collect_paths`) that also enforces the sibling-isolation invariant (no allowlisted path may be an ancestor of the workspace). So both backends compute the same paths and honor the same `VIBESYS_AGENT_SANDBOX` / `VIBESYS_AGENT_SANDBOX_ALLOW` controls; only the enforcement mechanism differs.

The generated Seatbelt profile is `(deny default)` with an explicit allowlist:
- read-only on system/toolchain roots (`/usr`, `/System`, `/Library`, dyld cache, …) plus the resolved Python/Node/agent/VibeSys toolchain subtrees,
- read-write on the workspace, the agent's own config/auth dirs, and `/private/tmp`,
- `(allow network*)` so the agent still reaches its model provider; `iokit-open` for Metal.

The workspace's **parent and sibling runs are not in the allowlist**, so both reads (directory enumeration) and writes outside the workspace are denied — that's what blocks discovery of sibling runs. Paths are embedded via an SBPL string escaper so a workspace path containing quotes/backslashes can't break (or inject into) the profile.

Same fail-safe contract as Linux: if `sandbox-exec` is missing or confinement is disabled, `build()` returns `None` and the agent runs unconfined — the sandbox only ever adds a boundary.

### Architecture

```mermaid
flowchart TD
    B[hostsandbox.build] --> D{sys.platform}
    D -->|linux| L[_build_linux → HostSandbox / bwrap]
    D -->|darwin| M[_build_macos → SeatbeltSandbox / sandbox-exec]
    D -->|other| N[None: unconfined, logged]
    L --> S[_collect_paths: shared read/write allowlist + ancestor guard]
    M --> S
    L --> W[wrap: bwrap … -- argv]
    M --> V[wrap: sandbox-exec -p PROFILE argv]
```

Reviewers should look closely at: the Seatbelt read-root list in `_MACOS_SYSTEM_READ_ROOTS` (too tight → dyld/tool launch breaks; too loose → weaker confinement) and whether Metal-backed benchmarks run under the profile.

## Verification

- **Unit (run on Linux CI, pass):** platform dispatch to `SeatbeltSandbox`; missing `sandbox-exec` → `None`; allow-ancestor rejection on the macOS path; profile is `(deny default)`, grants the workspace but not its parent, keeps network open; `wrap()` shape (`sandbox-exec -p <profile> …`); SBPL escaping; unsupported platform (`win32`) → `None`.
- **End-to-end (NOT run here — gated to macOS):** `test_seatbelt_blocks_escape_but_allows_workspace` drives the real launch path; on a Mac it must show sibling read/write denied and the workspace still usable. It **skips** on Linux.
- Manually rendered and inspected the profile for a representative workspace.

### Correctness properties

- On macOS with `sandbox-exec`, the agent cannot read, write, or enumerate paths outside the workspace; workspace reads/writes still work.
- Confinement engages only on the host path (real `cwd` + installed policy); Docker/Modal untouched.
- Fail-safe: unavailable/disabled confinement degrades to prior unconfined behavior.
- Sibling isolation holds across both backends via the shared ancestor guard.
- The Linux backend's behavior and tests are unchanged by the refactor.

### Testing

```
./scripts/format.sh            # All checks passed
./scripts/check_lint.sh        # All checks passed
uv run pytest tests/_agent_cli tests/agents   # 198 passed, 1 skipped (macOS e2e)
```

The one skip is the macOS end-to-end regression, which is exactly the check a maintainer needs to run on a real Mac before this goes ready.