### PR TITLE
Fix documentation drift between docs and current code

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cp agent.toml.example agent.toml
   --modality speech_to_text
 ```
 
-`--outer-loop` defaults to `agent`. Pass `--outer-loop plain` or `--outer-loop evolve` to switch. See `./vs --outer-loop <kind> --help` for loop-specific flags, and [`docs/cli-flags.md`](docs/cli-flags.md) for the supported flag combinations.
+`--outer-loop` defaults to `agent`. Pass `--outer-loop plain`, `--outer-loop evolve`, or `--outer-loop openevolve` to switch. See `./vs --outer-loop <kind> --help` for loop-specific flags, and [`docs/cli-flags.md`](docs/cli-flags.md) for the supported flag combinations.
 
 A separate entry point exposes the issue MCP server used by the plain loop:
 
@@ -154,7 +154,7 @@ workspace, optional trusted evaluator source, and optional benchmark result
 metric.
 
 `OBJECTIVE.md` is read at the start of every run and must live next to the
-`reference/` directory (sibling, not inside). See `examples/model-serving/Llama-3-8B/`, `examples/model-serving/moonshine-streaming/`, `examples/model-serving/qwen3-32b-code-edit/`, `examples/model-serving/olmo-hybrid-prefix-caching/`, `examples/model-serving/Llama-3.1-8B-Instruct-MLX-8bit/`, `examples/model-serving/show-o2-1.5B-HQ-h100/`, and `examples/model-serving/show-o2-1.5B-HQ-macbook/` for the paper scenarios.
+`reference/` directory (sibling, not inside). See `examples/model-serving/Llama-3-8B/`, `examples/model-serving/moonshine-streaming/`, `examples/model-serving/qwen3-32b-code-edit/`, `examples/model-serving/olmo-hybrid-prefix-caching/`, `examples/model-serving/Llama-3.1-8B-Instruct-MLX-8bit/`, `examples/model-serving/show-o2-1.5B-HQ-h100/`, and `examples/model-serving/show-o2-1.5B-HQ-macbook/` for the paper scenarios. Additional bundles live alongside them, including `examples/model-serving/show-o2-1.5B-HQ/` (the original Show-o2 bundle) and `examples/model-serving/Llama-3-8B-trn2/` (the Llama-3-8B bundle retargeted to AWS Trainium).
 
 For multi-objective evolutionary runs, drop an `objectives.toml` next to `OBJECTIVE.md` (or pass `--objective name:max|min` flags) — see `./vs --outer-loop evolve --help`.
 
@@ -226,17 +226,15 @@ src/vibesys/
 ├── llm_client.py                 # LLM client factory
 ├── config.py / constants.py
 │
-├── loops/                        # the three outer-loop search policies
+├── loops/                        # the four outer-loop search policies
 │   ├── agent/                    # issue-tracker (Orchestrator-driven)
 │   ├── plain/                    # Ralph-style queue-drain
 │   ├── evolve/                   # population-based
+│   ├── openevolve/               # MAP-Elites-style evolutionary
 │   └── profiler.py               # shared Performance Evaluator helper
 │
 ├── sandbox/                      # execution-environment policy
-│   ├── docker_sandbox.py
-│   ├── modal_sandbox.py
-│   ├── modal_model_setup.py
-│   └── run_environment.py
+│   └── run_environment.py        # (Docker/Modal backends: libs/vs-sandbox)
 │
 ├── agents/                       # coding-agent harness abstraction
 │   └── callbacks.py              # LangChain logger (deepagents path)
@@ -258,6 +256,8 @@ resources/                        # framework-owned assets exposed to agent runs
   `--frontier-bias`, scalar softmax otherwise) + inspirations →
   `git checkout` parent tree → mutator → judge → profiler → commit.
   No early stop; runs the full `--max-generations × --children-per-generation`.
+- **openevolve**: MAP-Elites-style evolutionary loop over `--max-iterations`
+  iterations; reuses the evolve loop's mutator, judge, and profiler prompts.
 
 ## Development
 

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -65,6 +65,29 @@ benchmark-result contract. A valid bundle exits with status 0; an invalid bundle
 prints the failing contract and exits with status 1. Command-line usage errors
 exit with status 2. Validation does not execute the checker or benchmark.
 
+## Cross-Loop Run Flags
+
+Beyond the axes above, every outer loop accepts run-management and
+agent-harness flags:
+
+| Flag | Meaning |
+| --- | --- |
+| `--exp-name` | Experiment name; each run creates a directory under `exp_env/`. |
+| `--config` | Path to the agent TOML config file (default: `agent.toml`). |
+| `--agent-backend` | Coding-agent backend: `cli` (default) or `deepagents`. Overrides `[agent].backend` in `agent.toml`. |
+| `--cli-provider` | Which coding-agent CLI to drive when `--agent-backend cli`: `claude`, `gemini`, `codex`, or `opencode`. Overrides `[agent].cli_provider`. |
+| `--resume [RUN_DIR]` | Resume a previous run (default: latest). |
+| `--headless` | Disable the interactive client even when attached to a terminal. |
+| `--debug` | Pause for Enter at each step in loop mode. |
+| `--git-tracking` | Track workspace versions via git commits instead of directory snapshots. |
+| `--modal-gpu`, `--modal-model-volume`, `--modal-app` | Modal dispatch details: default GPU spec, pre-existing model-weights Volume, and App name. |
+
+Loop-specific flags — for example the agent loop's `--max-rounds`,
+`--max-retries-per-round`, and `--inner-loop`, the evolve loop's
+`--max-generations`, `--children-per-generation`, and `--objective`, the
+openevolve loop's `--max-iterations`, or the plain loop's
+`--max-attempts-per-issue` — are listed by `./vs --outer-loop <kind> --help`.
+
 ## Interface
 
 `--interface` applies to the agent loop.

--- a/examples/model-serving/Llama-3-8B/README.md
+++ b/examples/model-serving/Llama-3-8B/README.md
@@ -9,13 +9,16 @@ vibesys --input examples/model-serving/Llama-3-8B
 Each folder contains scripts plus a short README.
 - `README.md` — this file.
 
-Expected files (for agent_system orchestrator):
-- reference_inference.py
-- accuracy_check.py
-- benchmark.py
+Expected layout (declared by `vibesys.input.toml`):
+- OBJECTIVE.md — deployment goal for the run
+- vibesys.input.toml — manifest with the accuracy and benchmark commands
+- reference/ — reference implementation (`reference.py`, `config.json`, `meta.json`)
+- accuracy_checker/ — `checker.py`, the correctness gate
+- benchmark/ — `benchmark.py`, emits the metric to optimize
 - config.json
 - requirements.txt (GPU dependencies for verifier/benchmark)
 
-The CLI reads these files from this input bundle.
+The CLI reads the manifest from this input bundle and runs the declared
+accuracy and benchmark commands.
 
 A separate `.venv/` is auto-created here by the verifier using `uv` with the dependencies from `requirements.txt` (torch, transformers, httpx).

--- a/resources/skills/README.md
+++ b/resources/skills/README.md
@@ -1,6 +1,20 @@
 # Skills
 
 This directory contains VibeSys's bundled Agent Skills and reference material.
+It is the default skill candidate root (`--skills-dir`); skills discovered here
+are copied into each run's workspace for the coding agents to read.
+
+## Collections
+
+- [`serving-systems/`](serving-systems/) — LLM and multimodal serving-system
+  development: model architectures, serving algorithms, kernel-library
+  backends, hardware notes, and source maps into vLLM / SGLang / TensorRT-LLM.
+  See its [SKILL.md](serving-systems/SKILL.md) router and
+  [CLAUDE.md](serving-systems/CLAUDE.md) authoring guide.
+- [`neuron-agentic-development/`](neuron-agentic-development/) — vendored,
+  unmodified NKI (Neuron Kernel Interface) skills from AWS's
+  `aws-neuron/neuron-agentic-development`, loaded only for
+  `--backend trainium` via its `.vibesys.toml` sidecar.
 
 For VibeSys-specific, optional sidecar metadata such as backend-scoped skill
 rules, see [Skill Metadata](../../docs/skill-metadata.md).

--- a/resources/skills/serving-systems/OVERVIEW.md
+++ b/resources/skills/serving-systems/OVERVIEW.md
@@ -27,7 +27,7 @@ The foundations (roofline, prefill vs decode, batching-for-intensity, launch ove
 | **Hardware** | The roofline ridge point shifts (H100 ~295 FLOP/byte ≠ H200 ≠ B200 ≠ MI300 ≠ Apple). Kernel library availability differs — FlashInfer / DeepGEMM / DeepEP are NVIDIA-only today. NVLink / Infinity-Fabric / NVL72 / none set different parallelism ceilings. Precision support differs (FP4 is Blackwell+; FP8 is Hopper+; AMD's FP8 story is newer; Apple has unified memory + INT4/INT8). |
 | **Workload** | Long-context RAG stresses KV capacity and prefix-cache hit rate. High-QPS short-form stresses scheduler / launch overhead more than raw kernel speed. Agent-style branching stresses prefix sharing and concurrent decode over divergent suffixes. Multi-turn conversations shift the TTFT / TPOT weighting. Each of these pushes different levers. |
 
-Treat this collection as a set of tools and the tradeoffs between them, **not** a recipe book. The compatibility tables in each `algorithms/*/SKILL.md` and the per-engine pointers exist precisely because the same technique applies differently across these axes. When a recipe doesn't seem to fit your setting, go back to the fundamentals in Part 1 and re-derive which bottleneck you're actually solving for.
+Treat this collection as a set of tools and the tradeoffs between them, **not** a recipe book. The compatibility tables in each `references/algorithms/*.md` note and the per-engine pointers exist precisely because the same technique applies differently across these axes. When a recipe doesn't seem to fit your setting, go back to the fundamentals in Part 1 and re-derive which bottleneck you're actually solving for.
 
 ### Principal techniques, not exhaustive
 
@@ -40,8 +40,8 @@ What the skills capture is the *pattern* and the *decision* behind each techniqu
 When a skill doesn't quite fit your situation:
 
 - Re-read the **fundamentals in Part 1** and re-derive which bottleneck you're actually solving for.
-- Check the **compatibility tables** in each `algorithms/*` skill for how the axes combine.
-- Look at the **engine pointers** in `engines/*` for how production systems actually implemented it — that's often the clearest source of truth.
+- Check the **compatibility tables** in each `references/algorithms/*.md` note for how the axes combine.
+- Look at the **engine pointers** in `references/engines/*` for how production systems actually implemented it — that's often the clearest source of truth.
 - Use the **profiler** ([`tooling/profiler/`](references/tooling/profiler.md)) before and after every change to confirm the technique is helping the bottleneck you think it's helping.
 
 ## Part 1 — Performance foundations

--- a/resources/skills/serving-systems/README.md
+++ b/resources/skills/serving-systems/README.md
@@ -17,36 +17,40 @@ Skills are organized by **abstraction layer** with explicit extensibility axes.
 | [`frameworks/`](references/frameworks/) | programming framework | PyTorch / MLX / (future JAX) idioms for serving. |
 | [`backends/`](references/backends/) | software backend library | How to **use** existing kernel libraries — FlashInfer, FlashAttention, Triton kernels, CUDA graph. Kernel *implementation* is out of scope; see agent-gpu-skills. |
 | [`hardware/`](references/hardware/) | hardware platform | Hopper / Blackwell / MI300 / Apple Silicon specifics — precision, collectives, tuning. |
-| [`engines/`](references/engines/) | reference system | Source-code lookup into vLLM, SGLang, TensorRT-LLM. Short SKILL.md + "where's X" grep tables. |
+| [`engines/`](references/engines/) | reference system | Source-code lookup into vLLM, SGLang, TensorRT-LLM. Short notes + "where's X" grep tables. |
 | [`tooling/`](references/tooling/) | orthogonal workflow | FastAPI serving, accuracy checking, serving benchmarks, profiling, I/O handling. |
 
 ## Extensibility
 
-Each tier is designed so new entries drop in as folders:
+Each tier is designed so new entries drop in as reference files:
 
-- **Add a model** → new folder under `models/` describing arch + features it needs.
-- **Add hardware** → new folder under `hardware/` with precision / collective / profiler notes.
-- **Add a framework or backend** → new folder under `frameworks/` or `backends/`.
-- **Add an engine** → new folder under `engines/` with "where's X" tables.
+- **Add a model** → new note under `references/models/` describing arch + features it needs.
+- **Add hardware** → new note under `references/hardware/` with precision / collective / profiler notes.
+- **Add a framework or backend** → new note under `references/frameworks/` or `references/backends/`.
+- **Add an engine** → new note under `references/engines/` with "where's X" tables.
 
-Because axes are not fully orthogonal (FlashInfer is CUDA-only, MLX is Apple-only, MLA needs a MLA-capable backend), each `algorithms/` skill ends with a compatibility matrix (`algorithm × {backend, hardware, engine}`) so cross-axis constraints are captured where they belong.
+Because axes are not fully orthogonal (FlashInfer is CUDA-only, MLX is Apple-only, MLA needs a MLA-capable backend), each `references/algorithms/` note ends with a compatibility matrix (`algorithm × {backend, hardware, engine}`) so cross-axis constraints are captured where they belong.
 
 ## Kernel-level boundary
 
-This collection assumes existing kernel libraries. Writing new CUDA / Triton / CUTLASS kernels is **out of scope** — those skills live in [agent-gpu-skills](https://github.com/slowlyC/agent-gpu-skills). Each `backends/*` skill ends with a pointer back to the relevant gpu-skills entry.
+This collection assumes existing kernel libraries. Writing new CUDA / Triton / CUTLASS kernels is **out of scope** — those skills live in [agent-gpu-skills](https://github.com/slowlyC/agent-gpu-skills). Each `references/backends/*` note ends with a pointer back to the relevant gpu-skills entry.
 
 ## Setup
 
-The vibesys agent CLIs auto-load this skill from `skills/serving-systems/`
-via the `--skills-dir` flag (default in `vibesys/cli_common.py`),
-copying the skill tree into each workspace's `.claude/skills/` so the
-in-workspace coding agent picks it up.
+Inside an agent workspace, this collection appears as the `serving-systems/`
+skill under the per-CLI skill-discovery paths (`.claude/skills/`,
+`.agents/skills/`, …); every path in this document is relative to that skill
+root. The vibesys agent CLIs copy it there automatically — in the VibeSys
+repo checkout, the collection lives at `resources/skills/serving-systems/`
+and is picked up via the `--skills-dir` flag (default candidate root
+`resources/skills/`, defined in `src/vibesys/skills.py`).
 
 The reference engines (`repos/{vllm,sglang,TensorRT-LLM}/`) are tracked as
-git submodules — initialize with:
+git submodules and are not copied into workspaces — from the repo checkout,
+initialize with:
 
 ```bash
-git submodule update --init skills/serving-systems/repos
+git submodule update --init resources/skills/serving-systems/repos
 ```
 
 `update-repos.sh` is the upstream sparse-checkout helper, kept for parity
@@ -56,27 +60,33 @@ one used here.
 ## Directory structure
 
 ```
-vibesys-skills/
-├── README.md, CLAUDE.md          # overview + guidance for skill authors
+serving-systems/
+├── SKILL.md                      # the single skill; routes to references/
+├── README.md, OVERVIEW.md,       # repo docs + guidance for skill authors
+│   CLAUDE.md
 ├── update-repos.sh               # upstream sparse-checkout helper (parity)
-│
-├── models/                       text-dense, text-moe, ssm-hybrid,
-│                                 vision-language, speech-language,
-│                                 image-generation, video-generation,
-│                                 speech-generation, omni-multimodal
-├── algorithms/                   attention-variants, async-scheduling,
-│                                 continuous-batching, paged-attention,
-│                                 radix-prefix-caching, heterogeneous-kv-cache,
-│                                 chunked-prefill, speculative-decoding,
-│                                 disaggregated-serving, moe-routing-dispatch,
-│                                 quantization-schemes, parallelism,
-│                                 structured-output, batched-sampling
-├── frameworks/                   pytorch, triton, mlx
-├── backends/                     flashinfer, flashattention, sdpa,
-│                                 triton-kernels, cuda-graph
-├── hardware/                     nvidia, amd-mi300, apple-silicon
-├── engines/                      vllm, sglang, trtllm
-├── tooling/                      fastapi-serving, openai-api,
+├── references/
+│   ├── models/                   text-dense, text-moe, ssm-hybrid,
+│   │                             vision-language, speech-language,
+│   │                             image-generation, video-generation,
+│   │                             speech-generation, omni-multimodal
+│   ├── algorithms/               attention-variants, async-scheduling,
+│   │                             continuous-batching, paged-attention,
+│   │                             radix-prefix-caching, heterogeneous-kv-cache,
+│   │                             chunked-prefill, speculative-decoding,
+│   │                             disaggregated-serving, moe-routing-dispatch,
+│   │                             quantization-schemes, parallelism,
+│   │                             structured-output, batched-sampling
+│   ├── frameworks/               pytorch, triton, mlx, neuron-pytorch,
+│   │                             neuron-flash-attention, nxd-inference,
+│   │                             nxd-kv-cache
+│   ├── backends/                 flashinfer, flashattention, sdpa,
+│   │                             triton-kernels, cuda-graph,
+│   │                             attention-backend-comparison
+│   ├── hardware/                 nvidia, amd-mi300, apple-silicon,
+│   │                             aws-trainium
+│   ├── engines/                  vllm, sglang, trtllm
+│   └── tooling/                  fastapi-serving, openai-api,
 │                                 accuracy-checker, serving-benchmark,
 │                                 profiler, io-handling, lora-serving
 └── repos/                        vllm, sglang, TensorRT-LLM (git submodules)


### PR DESCRIPTION
## Problem

Several docs have drifted from the code they describe, which misleads both new users and the agents that consume these files at runtime:

- `README.md` said to pass `--outer-loop plain` or `evolve`, but four outer loops exist (`agent`, `plain`, `evolve`, `openevolve` — see `src/vibesys/loops/`); the repository-layout tree and loop summaries also omitted `openevolve`.
- `docs/cli-flags.md` calls itself the canonical flag map but omitted cross-loop flags the README quickstart uses (`--exp-name`, `--agent-backend`, `--cli-provider`, `--resume`, and friends).
- The README's paper-scenarios list silently omitted the `examples/model-serving/show-o2-1.5B-HQ` and `examples/model-serving/Llama-3-8B-trn2` bundles, which exist in the tree.
- `examples/model-serving/Llama-3-8B/README.md` documented a stale flat-file bundle contract (`reference_inference.py`, `accuracy_check.py`, `benchmark.py`) while the manifest actually declares `reference/`, `accuracy_checker/`, `benchmark/`.
- `resources/skills/README.md` was a stub that did not index the collections beside it.
- `resources/skills/serving-systems/{README,OVERVIEW}.md` referenced files/paths that do not exist (`vibesys/cli_common.py`, `skills/serving-systems/`, per-topic `SKILL.md` files) and a directory tree missing the `references/` level.

## Solution

Docs-only fixes, verified item-by-item against the code (no code changes):

- README: mention all four loops; add an `openevolve/` entry and bullet (MAP-Elites-style, reuses evolve prompts — per `src/vibesys/loops/openevolve/__init__.py`); append a sentence listing the additional bundles (`show-o2-1.5B-HQ` as the original Show-o2 bundle, `Llama-3-8B-trn2` as the Trainium retarget per its own README) after the paper-scenarios list rather than silently relabeling them as paper scenarios.
- `docs/cli-flags.md`: new "Cross-Loop Run Flags" section documenting the flags shared by every loop parser (from `_add_common_args`/`_apply_common_args` in `src/vibesys/main.py`), plus a pointer that loop-specific flags (`--max-rounds`, `--max-generations`, `--max-iterations`, ...) are listed by `./vs --outer-loop <kind> --help`.
- `examples/model-serving/Llama-3-8B/README.md`: document the manifest-declared layout. The stale flat files themselves are being removed in separate work and are untouched here. Checked `moonshine-streaming` and `Llama-3-8B-trn2` READMEs — they do not have the stale contract.
- `resources/skills/README.md`: short index of `serving-systems/` and `neuron-agentic-development/` (trainium-scoped via its `.vibesys.toml` sidecar).
- README repository-layout tree: after rebasing onto the merged `libs/vs-sandbox` extraction (#168), updated the `sandbox/` entry to show only `run_environment.py` with a pointer to `libs/vs-sandbox` for the Docker/Modal backends.
- `resources/skills/serving-systems/`: conservative factual fixes only, per the subtree authoring guide — no consolidation or deletion. Rewrote the Setup section workspace-first: since this skill tree is copied into each agent workspace, the text now describes the skill's location relative to the workspace skill root, and scopes repo-root paths explicitly as repo-checkout facts (collection at `resources/skills/serving-systems/`, default candidate root `resources/skills/` per `src/vibesys/skills.py`; submodule init framed as a repo-checkout operation), the submodule init path (`.gitmodules` paths are `resources/skills/serving-systems/repos/*`), the directory tree (added `SKILL.md`, the `references/` level, and missing topics like `aws-trainium`, `nxd-inference`, `attention-backend-comparison`), and stale `algorithms/*/SKILL.md` phrasing in OVERVIEW.md.

Deliberately not changed: the pervasive `$SERVE_REPOS = <vibesys-root>/skills/serving-systems/repos` convention inside `references/engines/*.md` and the authoring guide `CLAUDE.md` itself — updating that convention consistently across many reference files is beyond a conservative docs pass and is noted for follow-up. Also untouched: the `src/vibesys/main.py` module docstring that lists three loops (code file; this PR is docs-only), and sandbox module paths (in-flight PR moves them to `libs/vs-sandbox`).

### Architecture

No architectural change; documentation only. No prompt templates, manifests, metadata, feature flags, CLI behavior, or skill routing (`SKILL.md`) changed — edits in `resources/skills/serving-systems/` are limited to the repo docs (`README.md`, `OVERVIEW.md`) that the authoring guide classifies as repo docs, following its style rules.

## Verification

Each claim was checked against the source before editing:

- Outer loops: `ls src/vibesys/loops/` (agent, plain, evolve, openevolve) and `docs/cli-flags.md`'s loop table; openevolve description from `src/vibesys/loops/openevolve/{__init__,loop}.py` docstrings (MAP-Elites archive, reuses evolve prompts, `--max-iterations`).
- Cross-loop flags: read `_add_common_args` and `_apply_common_args` in `src/vibesys/main.py` (lines ~170-320, 459-475); every flag, choice list, and default in the new table comes from those argparse definitions. Loop-specific flags cross-checked against each `_build_*_parser`.
- Example bundles: `ls examples/model-serving/` confirms `show-o2-1.5B-HQ` and `Llama-3-8B-trn2` exist; trn2's own README describes it as the Llama-3-8B bundle retargeted to Trainium.
- Bundle contract: `examples/model-serving/Llama-3-8B/vibesys.input.toml` declares `accuracy_checker/checker.py` and `benchmark/benchmark.py`; `ls` of `reference/`, `accuracy_checker/`, `benchmark/` confirms the documented files.
- Skills: `.vibesys.toml` in `neuron-agentic-development/` confirms trainium scoping; `src/vibesys/skills.py` defines `DEFAULT_SKILL_ROOTS = (resources/skills,)`; `vibesys/cli_common.py` does not exist; `.gitmodules` submodule paths are `resources/skills/serving-systems/repos/*`; `find references -name SKILL.md` returns nothing (single top-level SKILL.md only); tier topic lists in the new tree match `ls references/<tier>/`.
- A repo-wide sweep of README/AGENTS.md/docs/ path references against the tree found no other stale paths.

### Correctness properties

- Every path, flag name, choice list, and default stated in the edited docs exists in the current tree/argparse definitions.
- No code, manifest, prompt, or `SKILL.md` routing changes; agent-visible skill discovery behavior is unchanged.
- The serving-systems subtree authoring guide (`resources/skills/serving-systems/CLAUDE.md`) was followed: no consolidation, no new frontmatter, imperative style, tables preserved.

### Testing

- `./scripts/check_format.sh` — All checks passed.
- `./scripts/check_lint.sh` — All checks passed.
- No pytest run: docs-only change with no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
