### PR TITLE
Extract GitTracker and run path/command records from _RunContext

### DIFF
--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -2,13 +2,13 @@
 
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
 import uuid
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 
@@ -39,6 +39,7 @@ from vibesys.profilers import (
     profiler_definition,
     resolve_profiler_kind,
 )
+from vibesys.run import GitTracker, RunCommands, RunPaths
 from vibesys.sandbox.run_environment import (
     RunEnvironmentRequest,
     RunEnvironmentSpec,
@@ -131,17 +132,22 @@ class _RunContext:
         run_environment = run_environment or make_run_environment_spec()
         self.run_environment = build_run_environment(run_environment)
 
-        self.exp_dir = setup_exp_dir(exp_name, PROJECT_ROOT, existing)
+        exp_dir = setup_exp_dir(exp_name, PROJECT_ROOT, existing)
 
-        self.log_dir = self.exp_dir / "logs"
-        self.log_dir.mkdir(parents=True, exist_ok=True)
+        log_dir = exp_dir / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
         from vibesys.server.registry import active_supervisor
 
         self.supervisor = active_supervisor()
         if self.supervisor is not None:
-            self.supervisor.attach(self.log_dir)
+            self.supervisor.attach(log_dir)
         run_started = datetime.now().strftime("%Y%m%d-%H%M%S")
-        self.run_log_path = self.log_dir / f"run-{run_started}.log"
+        self._paths = RunPaths(
+            exp_dir=exp_dir,
+            log_dir=log_dir,
+            workspace=exp_dir / "workspace",
+            run_log_path=log_dir / f"run-{run_started}.log",
+        )
         self.run_log_file = self.run_log_path.open("a", encoding="utf-8")
 
         self._original_stderr = sys.stderr
@@ -245,7 +251,6 @@ class _RunContext:
         environment_reference = ref_dir or (input_dir / "reference")
         input_project_dir = input_dir if (input_dir / "pyproject.toml").is_file() else None
 
-        self.workspace = self.exp_dir / "workspace"
         self.workspace.mkdir(parents=True, exist_ok=True)
 
         # When resuming an existing run, skip workspace file setup — the
@@ -357,8 +362,17 @@ class _RunContext:
             if not destination.exists():
                 self._copy_excluding_extras(src, destination)
 
+        # Git snapshot tracking over the workspace. The tracker is always
+        # constructed (construction is side-effect free), so loops can call
+        # e.g. ``ctx.git.current_sha()`` unconditionally; ``init`` only runs
+        # when --git-tracking is enabled.
+        self.git = GitTracker(
+            self.workspace,
+            log=self.lprint,
+            excluded_dirs=self.EXCLUDED_WORKSPACE_DIRS,
+        )
         if git_tracking:
-            self._init_git_tracking(existing)
+            self.git.init(existing)
 
         self.run_environment_session = self._run_environment_stack.enter_context(
             self.run_environment.open(
@@ -380,6 +394,14 @@ class _RunContext:
             )
         )
         self.run_environment_view = self.run_environment_session.view
+        # Snapshot the agent-facing commands once the session is open; the
+        # view's paths are fixed for the session lifetime.
+        self.commands = RunCommands(
+            judge_accuracy_command=self.run_environment_view.paths.accuracy_command,
+            judge_benchmark_command=self.run_environment_view.paths.benchmark_command,
+            profiler_support_agent_path=self.run_environment_view.paths.profiler_support,
+            profiler_benchmark_command=self.run_environment_view.paths.benchmark_command,
+        )
         self.implementer_backend = self.run_environment_session.sandbox
         self.judge_backend = self.run_environment_session.sandbox
 
@@ -425,6 +447,26 @@ class _RunContext:
             use_modal=self.run_environment_view.cli_modal_sandboxed,
             log_dir=self.log_dir,
         )
+
+    # -- path passthroughs ----------------------------------------------------
+    # Canonical values live in the frozen ``RunPaths`` record; these
+    # properties keep existing ``ctx.exp_dir``-style call sites working.
+
+    @property
+    def exp_dir(self) -> Path:
+        return self._paths.exp_dir
+
+    @property
+    def log_dir(self) -> Path:
+        return self._paths.log_dir
+
+    @property
+    def workspace(self) -> Path:
+        return self._paths.workspace
+
+    @property
+    def run_log_path(self) -> Path:
+        return self._paths.run_log_path
 
     def gpu_env(self) -> dict[str, str]:
         """Env vars to inject into the host-running cli agent runner.
@@ -700,7 +742,7 @@ class _RunContext:
                 self.lprint(f"[warn] modal workspace sync to host failed: {exc}")
 
         if self.git_tracking:
-            self._git_snapshot(label)
+            self.git.snapshot(label)
             return
         dst = self.log_dir / "snapshots" / label
         dst.parent.mkdir(parents=True, exist_ok=True)
@@ -714,237 +756,36 @@ class _RunContext:
         )
         self._replace_external_symlinks(dst)
 
-    # -- git tracking helpers -------------------------------------------------
-
-    _GIT_ENV_STATIC = {
-        "GIT_AUTHOR_NAME": "vibesys",
-        "GIT_AUTHOR_EMAIL": "vibesys@local",
-        "GIT_COMMITTER_NAME": "vibesys",
-        "GIT_COMMITTER_EMAIL": "vibesys@local",
-    }
-
-    @property
-    def _GIT_ENV(self) -> dict[str, str]:
-        """Git env with safe.directory set to workspace to avoid ownership errors."""
-        return {
-            **self._GIT_ENV_STATIC,
-            "GIT_CONFIG_COUNT": "1",
-            "GIT_CONFIG_KEY_0": "safe.directory",
-            "GIT_CONFIG_VALUE_0": str(self.workspace),
-        }
-
-    def _git_run(
-        self, cmd: list[str], *, check: bool = True, env: dict | None = None
-    ) -> subprocess.CompletedProcess:
-        """Run a git command in workspace, logging stderr on failure."""
-        if env is None:
-            env = {**os.environ, **self._GIT_ENV}
-        result = subprocess.run(cmd, cwd=self.workspace, capture_output=True, env=env)
-        if check and result.returncode != 0:
-            stderr = result.stderr.decode(errors="replace").strip()
-            self.lprint(f"[git-tracking] command failed: {' '.join(cmd)}")
-            self.lprint(f"[git-tracking] exit code {result.returncode}: {stderr}")
-            result.check_returncode()
-        return result
-
-    # Compiled-accelerator artifacts an agent may emit into the workspace.
-    # Large and never wanted in a per-round checkpoint. The Neuron compile cache
-    # is bind-mounted *outside* the workspace, but a stray trace/compile call
-    # pointed at the workspace (or a torch.compile dump) would otherwise be
-    # committed and bloat history across rounds.
-    _ARTIFACT_GITIGNORE_PATTERNS: tuple[str, ...] = (
-        "*.neff",
-        "*.ntff",
-        "*.neuron",
-        "neuroncc_compile_workdir/",
-        "neuron-compile-cache/",
-    )
-
-    _TRUSTED_INPUT_PATHS: tuple[str, ...] = (
-        "OBJECTIVE.md",
-        "vibesys.input.toml",
-        "reference",
-        "accuracy_checker",
-        "benchmark",
-        "_input_libs",
-        "_evaluator",
-    )
-
     def trusted_input_changes(self) -> list[str]:
         """Return evaluator-owned paths changed since workspace initialization."""
         if not self.git_tracking:
             return []
+        return self.git.trusted_input_changes()
 
-        root = self._git_run(["git", "rev-list", "--max-parents=0", "HEAD"])
-        root_commit = root.stdout.decode().strip()
-        if not root_commit:
-            return ["unable to resolve the initial workspace commit"]
-
-        pathspec = ["--", *self._TRUSTED_INPUT_PATHS]
-        committed = self._git_run(["git", "diff", "--name-only", f"{root_commit}..HEAD", *pathspec])
-        pending = self._git_run(
-            [
-                "git",
-                "status",
-                "--porcelain=v1",
-                "--untracked-files=all",
-                *pathspec,
-            ]
-        )
-
-        changes = {line for line in committed.stdout.decode(errors="replace").splitlines() if line}
-        changes.update(
-            line[3:]
-            for line in pending.stdout.decode(errors="replace").splitlines()
-            if len(line) > 3
-        )
-        return sorted(changes)
-
-    def _workspace_gitignore(self) -> str:
-        """Contents of the workspace ``.gitignore`` (excluded dirs + artifacts)."""
-        lines = sorted(self.EXCLUDED_WORKSPACE_DIRS) + list(self._ARTIFACT_GITIGNORE_PATTERNS)
-        return "\n".join(lines) + "\n"
-
-    def _init_git_tracking(self, existing: bool) -> None:
-        """Initialize or validate the git repo in the unified workspace."""
-        if existing:
-            if not (self.workspace / ".git").is_dir():
-                raise ValueError(
-                    f"--git-tracking with --resume but no git repository in {self.workspace}"
-                )
-            return
-
-        self._git_run(["git", "init"])
-
-        gitignore = self.workspace / ".gitignore"
-        existing_gitignore = gitignore.read_text() if gitignore.is_file() else ""
-        if existing_gitignore and not existing_gitignore.endswith("\n"):
-            existing_gitignore += "\n"
-        gitignore.write_text(existing_gitignore + self._workspace_gitignore())
-
-        self._git_add_all()
-        self._git_run(["git", "commit", "-m", "initial: workspace setup"])
-
-    # -- snapshot resilience --------------------------------------------------
-    #
-    # On the Docker/Modal paths the sandbox runs as root and writes files into
-    # the bind-mounted workspace.  Most land mode-644 (host-readable), but a
-    # tool may emit a restrictive file the *host* user running `git add` cannot
-    # read (e.g. neuron-explorer's mode-600 ``system_profile.json``).  A single
-    # such file makes ``git add -A`` exit 128 and would otherwise abort the whole
-    # run.  These are always transient scratch artifacts we never want in a
-    # checkpoint, so we exclude them (local-only, via ``.git/info/exclude``)
-    # rather than fail.
-
-    def _collect_unreadable(self) -> list[str]:
-        """Workspace-relative paths the snapshotting user cannot read.
-
-        Walks the worktree (skipping ``.git``, never following symlinks) and
-        records files lacking ``R_OK`` and directories lacking ``R_OK|X_OK``
-        (an unsearchable dir hides its whole subtree from ``git add`` too).
-        """
-        unreadable: list[str] = []
-        root = str(self.workspace)
-        for dirpath, dirnames, filenames in os.walk(root):
-            if ".git" in dirnames:
-                dirnames.remove(".git")
-            kept = []
-            for d in dirnames:
-                full = os.path.join(dirpath, d)
-                if os.access(full, os.R_OK | os.X_OK):
-                    kept.append(d)
-                else:
-                    unreadable.append(os.path.relpath(full, root))
-            dirnames[:] = kept  # prune unsearchable dirs from the walk
-            for f in filenames:
-                full = os.path.join(dirpath, f)
-                if not os.access(full, os.R_OK):
-                    unreadable.append(os.path.relpath(full, root))
-        return unreadable
-
-    @staticmethod
-    def _unreadable_from_stderr(stderr: str) -> list[str]:
-        """Parse paths git reported it could not index from *stderr*.
-
-        Git prints e.g. ``error: open("foo"): Permission denied`` and
-        ``error: unable to index file 'foo'``.
-        """
-        paths: list[str] = []
-        for m in re.finditer(r'(?:open\("|unable to index file \')([^"\']+)', stderr):
-            paths.append(m.group(1))
-        return paths
-
-    def _exclude_paths(self, rel_paths: list[str]) -> None:
-        """Append *rel_paths* to ``.git/info/exclude`` (local, untracked)."""
-        rel_paths = [p for p in dict.fromkeys(rel_paths) if p]
-        if not rel_paths:
-            return
-        exclude_file = self.workspace / ".git" / "info" / "exclude"
-        exclude_file.parent.mkdir(parents=True, exist_ok=True)
-        existing = exclude_file.read_text() if exclude_file.exists() else ""
-        have = set(existing.splitlines())
-        new = [p for p in rel_paths if p not in have]
-        if not new:
-            return
-        prefix = "" if (not existing or existing.endswith("\n")) else "\n"
-        exclude_file.write_text(existing + prefix + "\n".join(new) + "\n")
-        shown = ", ".join(new[:5]) + ("…" if len(new) > 5 else "")
-        self.lprint(f"[git-tracking] excluded {len(new)} unreadable path(s) from snapshot: {shown}")
-
-    def _git_add_all(self) -> None:
-        """``git add -A``, resilient to files the host user cannot read.
-
-        Excludes unreadable paths up front, then retries on any residual
-        permission failure (a file may appear between the scan and the add).
-        """
-        self._exclude_paths(self._collect_unreadable())
-        for _ in range(3):
-            result = self._git_run(["git", "add", "-A"], check=False)
-            if result.returncode == 0:
-                return
-            stderr = result.stderr.decode(errors="replace")
-            offenders = self._unreadable_from_stderr(stderr)
-            if not offenders:
-                break  # failure unrelated to unreadable files — surface it
-            self._exclude_paths(offenders)
-        # Final attempt: let _git_run raise with full diagnostics if it still fails.
-        self._git_run(["git", "add", "-A"])
-
-    def _git_snapshot(self, label: str) -> None:
-        """Commit current workspace state with *label* as the commit message."""
-        self._git_add_all()
-        # git diff --cached --quiet exits 1 when there are staged changes
-        has_changes = (
-            self._git_run(
-                ["git", "diff", "--cached", "--quiet"],
-                check=False,
-            ).returncode
-            != 0
-        )
-        if has_changes:
-            self._git_run(["git", "commit", "-m", label])
-        else:
-            self.lprint(f"[git-tracking] no changes to commit for '{label}'")
+    # -- command passthroughs -------------------------------------------------
+    # Canonical values live in the frozen ``RunCommands`` snapshot; these
+    # properties keep existing ``ctx.judge_accuracy_command``-style call
+    # sites working.
 
     @property
     def judge_accuracy_command(self) -> str | None:
         """Return the accuracy command as seen by the judge agent."""
-        return self.run_environment_view.paths.accuracy_command
+        return self.commands.judge_accuracy_command
 
     @property
     def judge_benchmark_command(self) -> str | None:
         """Return the benchmark command as seen by the judge agent."""
-        return self.run_environment_view.paths.benchmark_command
+        return self.commands.judge_benchmark_command
 
     @property
     def profiler_support_agent_path(self) -> str | None:
         """Return the selected profiler support path as seen by its agent."""
-        return self.run_environment_view.paths.profiler_support
+        return self.commands.profiler_support_agent_path
 
     @property
     def profiler_benchmark_command(self) -> str | None:
         """Return the benchmark command as seen by the profiler agent."""
-        return self.run_environment_view.paths.benchmark_command
+        return self.commands.profiler_benchmark_command
 
     def lprint(self, text: str) -> None:
         _log_and_print(text, self.run_log_file)
@@ -967,7 +808,7 @@ class _RunContext:
         suffix = f"step{label}" if isinstance(label, int) else label
         new_path = self.log_dir / f"run-{ts}-{suffix}.log"
         new_file = new_path.open("a", encoding="utf-8")
-        self.run_log_path = new_path
+        self._paths = replace(self._paths, run_log_path=new_path)
         self.run_log_file = new_file
         if self._stderr_redirected:
             sys.stderr = _TeeWriter(self._original_stderr, new_file)

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -183,38 +183,6 @@ def _detect_plateau(
 
 
 # ---------------------------------------------------------------------------
-# Git helpers
-# ---------------------------------------------------------------------------
-
-
-def _current_commit_sha(ctx: _RunContext) -> str | None:
-    if not ctx.git_tracking:
-        return None
-    try:
-        result = ctx._git_run(["git", "rev-parse", "HEAD"], check=False)
-        if result.returncode != 0:
-            return None
-        return result.stdout.decode(errors="replace").strip()
-    except Exception:
-        return None
-
-
-def _git_checkout(ctx: _RunContext, sha: str) -> bool:
-    """Check out *sha* into the working tree.
-
-    Uses ``git checkout -- .`` style (non-branch) so subsequent commits
-    continue to land on the current branch as new commits after the
-    reverted state.
-    """
-    try:
-        ctx._git_run(["git", "checkout", sha, "--", "."])
-        return True
-    except Exception as exc:
-        ctx.lprint(f"[warn] git checkout {sha[:8]} failed: {exc}")
-        return False
-
-
-# ---------------------------------------------------------------------------
 # Carry-over state between rounds
 # ---------------------------------------------------------------------------
 
@@ -1032,7 +1000,10 @@ def run_agent_loop(
                         None,
                     )
                     if target and target.commit:
-                        _git_checkout(ctx, target.commit)
+                        # Non-branch checkout so subsequent commits continue
+                        # to land on the current branch as new commits after
+                        # the reverted state.
+                        ctx.git.checkout_tree(target.commit)
                         ctx.lprint(
                             f"Reverted workspace to round {plan.revert_to_round} ({target.commit[:8]})."
                         )
@@ -1118,7 +1089,7 @@ def run_agent_loop(
                         feedback = single_agent_response.feedback
 
                 # --- Record round result & update carry-over ---
-                commit = _current_commit_sha(ctx)
+                commit = ctx.git.current_sha() if ctx.git_tracking else None
                 # `profile_skipped` is True when no fresh profile ran this round
                 # (cold-start or the orchestrator/framework decided to skip).
                 # The plateau detector ignores skipped-profile rounds so cached

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -71,44 +71,17 @@ def _render(name: str, **kwargs) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Git checkout helpers (parent materialization + dirty-tree discard)
+# Git helpers (dirty-tree discard)
 # ---------------------------------------------------------------------------
-
-
-def _checkout_commit_tree(ctx: _RunContext, commit: str) -> bool:
-    """Materialize *commit*'s tree into the working directory.
-
-    Uses ``git checkout <sha> -- .`` so HEAD stays where it is and the
-    next ``git commit`` produces a new child commit (rather than
-    rewriting history). Untracked files left over from a prior failed
-    attempt are removed via ``git clean -fd``.
-    """
-    try:
-        ctx._git_run(["git", "checkout", commit, "--", "."])
-        ctx._git_run(["git", "clean", "-fd"], check=False)
-        return True
-    except Exception as exc:
-        ctx.lprint(f"[warn] git checkout {commit[:8]} failed: {exc}")
-        return False
 
 
 def _discard_working_tree(ctx: _RunContext) -> None:
     """Drop any uncommitted changes left by a failed mutation attempt."""
     try:
-        ctx._git_run(["git", "checkout", "HEAD", "--", "."], check=False)
-        ctx._git_run(["git", "clean", "-fd"], check=False)
+        ctx.git.run(["git", "checkout", "HEAD", "--", "."], check=False)
+        ctx.git.run(["git", "clean", "-fd"], check=False)
     except Exception as exc:
         ctx.lprint(f"[warn] discard working tree failed: {exc}")
-
-
-def _current_commit_sha(ctx: _RunContext) -> str | None:
-    try:
-        result = ctx._git_run(["git", "rev-parse", "HEAD"], check=False)
-        if result.returncode != 0:
-            return None
-        return result.stdout.decode(errors="replace").strip()
-    except Exception:
-        return None
 
 
 # ---------------------------------------------------------------------------
@@ -378,7 +351,7 @@ def run_evolve_loop(
                     # 2. Materialize parent's tree (skip on cold start —
                     # _RunContext seeded the workspace from the reference).
                     if parent is not None and parent.commit:
-                        if not _checkout_commit_tree(ctx, parent.commit):
+                        if not ctx.git.checkout_tree(parent.commit, clean=True):
                             ctx.lprint(
                                 f"[warn] could not check out parent {parent.id} "
                                 f"(commit {parent.commit[:8]}); skipping cand"
@@ -452,7 +425,7 @@ def run_evolve_loop(
 
                     # 6. Commit + record.
                     ctx.snapshot_workspace(f"gen-{generation}-child-{child_idx}")
-                    commit = _current_commit_sha(ctx)
+                    commit = ctx.git.current_sha()
                     child = Individual(
                         id=population.next_id(),
                         generation=generation,

--- a/src/vibesys/run/__init__.py
+++ b/src/vibesys/run/__init__.py
@@ -1,0 +1,11 @@
+"""Run-lifecycle components extracted from ``_RunContext``.
+
+These are experiment-lifecycle concerns (per-run paths, git snapshot
+tracking) rather than reusable standalone libraries, so they live under
+``src/vibesys/run/`` instead of ``libs/``.
+"""
+
+from vibesys.run.git_tracker import GitTracker
+from vibesys.run.paths import RunCommands, RunPaths
+
+__all__ = ["GitTracker", "RunCommands", "RunPaths"]

--- a/src/vibesys/run/git_tracker.py
+++ b/src/vibesys/run/git_tracker.py
@@ -1,0 +1,269 @@
+"""Git snapshot tracking over an experiment workspace.
+
+``GitTracker`` owns the repo-over-workspace history kept when
+``--git-tracking`` is enabled: per-round snapshot commits, checkout of prior
+round trees, and detection of tampering with evaluator-owned inputs.  It is
+deliberately independent of the rest of the run context — construction takes
+the workspace root, a log callback, and the directory names to keep out of
+history; nothing here touches sandboxes or backends.
+"""
+
+import os
+import re
+import subprocess
+from collections.abc import Callable, Iterable
+from pathlib import Path
+
+
+class GitTracker:
+    """Snapshot tracking for one workspace directory.
+
+    Construction is side-effect free; ``init`` creates (or, on resume,
+    validates) the repository.  ``run`` is the public escape hatch for
+    loop-specific git plumbing that has no dedicated method yet.
+    """
+
+    _GIT_ENV_STATIC = {
+        "GIT_AUTHOR_NAME": "vibesys",
+        "GIT_AUTHOR_EMAIL": "vibesys@local",
+        "GIT_COMMITTER_NAME": "vibesys",
+        "GIT_COMMITTER_EMAIL": "vibesys@local",
+    }
+
+    # Compiled-accelerator artifacts an agent may emit into the workspace.
+    # Large and never wanted in a per-round checkpoint. The Neuron compile cache
+    # is bind-mounted *outside* the workspace, but a stray trace/compile call
+    # pointed at the workspace (or a torch.compile dump) would otherwise be
+    # committed and bloat history across rounds.
+    _ARTIFACT_GITIGNORE_PATTERNS: tuple[str, ...] = (
+        "*.neff",
+        "*.ntff",
+        "*.neuron",
+        "neuroncc_compile_workdir/",
+        "neuron-compile-cache/",
+    )
+
+    _TRUSTED_INPUT_PATHS: tuple[str, ...] = (
+        "OBJECTIVE.md",
+        "vibesys.input.toml",
+        "reference",
+        "accuracy_checker",
+        "benchmark",
+        "_input_libs",
+        "_evaluator",
+    )
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        log: Callable[[str], None],
+        excluded_dirs: Iterable[str] = (),
+    ) -> None:
+        self.root = root
+        self._log = log
+        self._excluded_dirs = frozenset(excluded_dirs)
+
+    @property
+    def _GIT_ENV(self) -> dict[str, str]:
+        """Git env with safe.directory set to workspace to avoid ownership errors."""
+        return {
+            **self._GIT_ENV_STATIC,
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "safe.directory",
+            "GIT_CONFIG_VALUE_0": str(self.root),
+        }
+
+    def run(
+        self, cmd: list[str], *, check: bool = True, env: dict | None = None
+    ) -> subprocess.CompletedProcess:
+        """Run a git command in the workspace, logging stderr on failure."""
+        if env is None:
+            env = {**os.environ, **self._GIT_ENV}
+        result = subprocess.run(cmd, cwd=self.root, capture_output=True, env=env)
+        if check and result.returncode != 0:
+            stderr = result.stderr.decode(errors="replace").strip()
+            self._log(f"[git-tracking] command failed: {' '.join(cmd)}")
+            self._log(f"[git-tracking] exit code {result.returncode}: {stderr}")
+            result.check_returncode()
+        return result
+
+    def init(self, existing: bool) -> None:
+        """Initialize or validate the git repo in the unified workspace."""
+        if existing:
+            if not (self.root / ".git").is_dir():
+                raise ValueError(
+                    f"--git-tracking with --resume but no git repository in {self.root}"
+                )
+            return
+
+        self.run(["git", "init"])
+
+        gitignore = self.root / ".gitignore"
+        existing_gitignore = gitignore.read_text() if gitignore.is_file() else ""
+        if existing_gitignore and not existing_gitignore.endswith("\n"):
+            existing_gitignore += "\n"
+        gitignore.write_text(existing_gitignore + self._workspace_gitignore())
+
+        self._add_all()
+        self.run(["git", "commit", "-m", "initial: workspace setup"])
+
+    def snapshot(self, label: str) -> None:
+        """Commit current workspace state with *label* as the commit message."""
+        self._add_all()
+        # git diff --cached --quiet exits 1 when there are staged changes
+        has_changes = (
+            self.run(
+                ["git", "diff", "--cached", "--quiet"],
+                check=False,
+            ).returncode
+            != 0
+        )
+        if has_changes:
+            self.run(["git", "commit", "-m", label])
+        else:
+            self._log(f"[git-tracking] no changes to commit for '{label}'")
+
+    def current_sha(self) -> str | None:
+        """Return the HEAD commit sha, or ``None`` if it cannot be resolved."""
+        try:
+            result = self.run(["git", "rev-parse", "HEAD"], check=False)
+            if result.returncode != 0:
+                return None
+            return result.stdout.decode(errors="replace").strip()
+        except Exception:
+            return None
+
+    def checkout_tree(self, sha: str, *, clean: bool = False) -> bool:
+        """Materialize *sha*'s tree into the working directory.
+
+        Uses ``git checkout <sha> -- .`` so HEAD stays where it is and the
+        next ``git commit`` produces a new child commit (rather than
+        rewriting history).  With ``clean=True``, untracked files left over
+        from a prior failed attempt are removed via ``git clean -fd``.
+        """
+        try:
+            self.run(["git", "checkout", sha, "--", "."])
+            if clean:
+                self.run(["git", "clean", "-fd"], check=False)
+            return True
+        except Exception as exc:
+            self._log(f"[warn] git checkout {sha[:8]} failed: {exc}")
+            return False
+
+    def trusted_input_changes(self) -> list[str]:
+        """Return evaluator-owned paths changed since workspace initialization."""
+        root = self.run(["git", "rev-list", "--max-parents=0", "HEAD"])
+        root_commit = root.stdout.decode().strip()
+        if not root_commit:
+            return ["unable to resolve the initial workspace commit"]
+
+        pathspec = ["--", *self._TRUSTED_INPUT_PATHS]
+        committed = self.run(["git", "diff", "--name-only", f"{root_commit}..HEAD", *pathspec])
+        pending = self.run(
+            [
+                "git",
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=all",
+                *pathspec,
+            ]
+        )
+
+        changes = {line for line in committed.stdout.decode(errors="replace").splitlines() if line}
+        changes.update(
+            line[3:]
+            for line in pending.stdout.decode(errors="replace").splitlines()
+            if len(line) > 3
+        )
+        return sorted(changes)
+
+    def _workspace_gitignore(self) -> str:
+        """Contents of the workspace ``.gitignore`` (excluded dirs + artifacts)."""
+        lines = sorted(self._excluded_dirs) + list(self._ARTIFACT_GITIGNORE_PATTERNS)
+        return "\n".join(lines) + "\n"
+
+    # -- snapshot resilience --------------------------------------------------
+    #
+    # On the Docker/Modal paths the sandbox runs as root and writes files into
+    # the bind-mounted workspace.  Most land mode-644 (host-readable), but a
+    # tool may emit a restrictive file the *host* user running `git add` cannot
+    # read (e.g. neuron-explorer's mode-600 ``system_profile.json``).  A single
+    # such file makes ``git add -A`` exit 128 and would otherwise abort the whole
+    # run.  These are always transient scratch artifacts we never want in a
+    # checkpoint, so we exclude them (local-only, via ``.git/info/exclude``)
+    # rather than fail.
+
+    def _collect_unreadable(self) -> list[str]:
+        """Workspace-relative paths the snapshotting user cannot read.
+
+        Walks the worktree (skipping ``.git``, never following symlinks) and
+        records files lacking ``R_OK`` and directories lacking ``R_OK|X_OK``
+        (an unsearchable dir hides its whole subtree from ``git add`` too).
+        """
+        unreadable: list[str] = []
+        root = str(self.root)
+        for dirpath, dirnames, filenames in os.walk(root):
+            if ".git" in dirnames:
+                dirnames.remove(".git")
+            kept = []
+            for d in dirnames:
+                full = os.path.join(dirpath, d)
+                if os.access(full, os.R_OK | os.X_OK):
+                    kept.append(d)
+                else:
+                    unreadable.append(os.path.relpath(full, root))
+            dirnames[:] = kept  # prune unsearchable dirs from the walk
+            for f in filenames:
+                full = os.path.join(dirpath, f)
+                if not os.access(full, os.R_OK):
+                    unreadable.append(os.path.relpath(full, root))
+        return unreadable
+
+    @staticmethod
+    def _unreadable_from_stderr(stderr: str) -> list[str]:
+        """Parse paths git reported it could not index from *stderr*.
+
+        Git prints e.g. ``error: open("foo"): Permission denied`` and
+        ``error: unable to index file 'foo'``.
+        """
+        paths: list[str] = []
+        for m in re.finditer(r'(?:open\("|unable to index file \')([^"\']+)', stderr):
+            paths.append(m.group(1))
+        return paths
+
+    def _exclude_paths(self, rel_paths: list[str]) -> None:
+        """Append *rel_paths* to ``.git/info/exclude`` (local, untracked)."""
+        rel_paths = [p for p in dict.fromkeys(rel_paths) if p]
+        if not rel_paths:
+            return
+        exclude_file = self.root / ".git" / "info" / "exclude"
+        exclude_file.parent.mkdir(parents=True, exist_ok=True)
+        existing = exclude_file.read_text() if exclude_file.exists() else ""
+        have = set(existing.splitlines())
+        new = [p for p in rel_paths if p not in have]
+        if not new:
+            return
+        prefix = "" if (not existing or existing.endswith("\n")) else "\n"
+        exclude_file.write_text(existing + prefix + "\n".join(new) + "\n")
+        shown = ", ".join(new[:5]) + ("…" if len(new) > 5 else "")
+        self._log(f"[git-tracking] excluded {len(new)} unreadable path(s) from snapshot: {shown}")
+
+    def _add_all(self) -> None:
+        """``git add -A``, resilient to files the host user cannot read.
+
+        Excludes unreadable paths up front, then retries on any residual
+        permission failure (a file may appear between the scan and the add).
+        """
+        self._exclude_paths(self._collect_unreadable())
+        for _ in range(3):
+            result = self.run(["git", "add", "-A"], check=False)
+            if result.returncode == 0:
+                return
+            stderr = result.stderr.decode(errors="replace")
+            offenders = self._unreadable_from_stderr(stderr)
+            if not offenders:
+                break  # failure unrelated to unreadable files — surface it
+            self._exclude_paths(offenders)
+        # Final attempt: let run() raise with full diagnostics if it still fails.
+        self.run(["git", "add", "-A"])

--- a/src/vibesys/run/paths.py
+++ b/src/vibesys/run/paths.py
@@ -1,0 +1,33 @@
+"""Frozen value objects for per-run paths and agent-facing commands."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RunPaths:
+    """Host-side directories and files owned by one experiment run.
+
+    ``run_log_path`` is the *current* log file.  ``switch_log_file``
+    replaces the whole record (the dataclass is frozen) rather than
+    mutating the field in place.
+    """
+
+    exp_dir: Path
+    log_dir: Path
+    workspace: Path
+    run_log_path: Path
+
+
+@dataclass(frozen=True)
+class RunCommands:
+    """Evaluator commands and helper paths as agents should see them.
+
+    Snapshot of ``RunEnvironmentView.paths`` taken once the run-environment
+    session is open; the view's paths are fixed for the session lifetime.
+    """
+
+    judge_accuracy_command: str | None
+    judge_benchmark_command: str | None
+    profiler_support_agent_path: str | None
+    profiler_benchmark_command: str | None

--- a/tests/backends/test_gpu_monitor.py
+++ b/tests/backends/test_gpu_monitor.py
@@ -270,11 +270,17 @@ class TestReselectGpu:
         """Build a minimal _RunContext-like object for reselect_gpu testing."""
         from vibesys.backends.cuda import CudaBackend
         from vibesys.context import _RunContext
+        from vibesys.run import RunPaths
         from vs_sandbox.docker_sandbox import DockerSandbox
 
         ctx = object.__new__(_RunContext)
         ctx.selected_gpu = selected_gpu
-        ctx.log_dir = tmp_path / "logs"
+        ctx._paths = RunPaths(
+            exp_dir=tmp_path,
+            log_dir=tmp_path / "logs",
+            workspace=tmp_path / "workspace",
+            run_log_path=tmp_path / "run.log",
+        )
         ctx.log_dir.mkdir(parents=True, exist_ok=True)
         ctx.gpu_monitor = None
         ctx._docker_symlinks = []

--- a/tests/test_agent_progress.py
+++ b/tests/test_agent_progress.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 from vibesys.agents.progress import CandidateProgress, RoundProgress
 from vibesys.context import _RunContext
+from vibesys.run import RunPaths
 from vibesys.schemas import JudgeResponse, Verdict
 
 
@@ -16,7 +17,12 @@ def _judge_fallback() -> JudgeResponse:
 def _make_context(tmp_path):
     ctx = object.__new__(_RunContext)
     ctx._progress_stack = []
-    ctx.workspace = tmp_path
+    ctx._paths = RunPaths(
+        exp_dir=tmp_path,
+        log_dir=tmp_path / "logs",
+        workspace=tmp_path,
+        run_log_path=tmp_path / "run.log",
+    )
     ctx.gpu_env = lambda: {}
     ctx.agent_runner = MagicMock()
     ctx.agent_runner.invoke.return_value = _judge_fallback()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -10,17 +10,24 @@ from vibesys.domains.base import DomainName
 from vibesys.domains.environment import NoopEnvironmentHooks
 from vibesys.errors import ConfigurationError
 from vibesys.profilers import ACTIVE_PROFILER_KINDS, ProfilerKind, ProfilerPreflightResult
+from vibesys.run import GitTracker, RunPaths
 from vibesys.sandbox.run_environment import RunEnvironmentSpec
 
 
 def _minimal_copy_context(workspace):
     ctx = object.__new__(_RunContext)
-    ctx.workspace = workspace
+    ctx._paths = RunPaths(
+        exp_dir=workspace.parent,
+        log_dir=workspace.parent / "logs",
+        workspace=workspace,
+        run_log_path=workspace.parent / "run.log",
+    )
     ctx.git_tracking = True
     ctx.EXCLUDED_WORKSPACE_DIRS = {".git", "target"}
     ctx.run_environment = SimpleNamespace(isolated=False)
     ctx.backend_impl = MagicMock()
     ctx.lprint = MagicMock()
+    ctx.git = GitTracker(workspace, log=ctx.lprint, excluded_dirs=ctx.EXCLUDED_WORKSPACE_DIRS)
     return ctx
 
 
@@ -37,9 +44,13 @@ def test_setup_exp_dir_uses_unique_names_for_concurrent_default_runs(tmp_path):
 
 def test_interactive_log_switch_preserves_supervision_stderr(tmp_path):
     ctx = object.__new__(_RunContext)
-    ctx.log_dir = tmp_path
+    ctx._paths = RunPaths(
+        exp_dir=tmp_path,
+        log_dir=tmp_path,
+        workspace=tmp_path / "workspace",
+        run_log_path=tmp_path / "run.log",
+    )
     ctx.run_log_file = (tmp_path / "run.log").open("a", encoding="utf-8")
-    ctx.run_log_path = tmp_path / "run.log"
     ctx._stderr_redirected = False
     ctx._original_stderr = sys.stderr
     original_log = ctx.run_log_file

--- a/tests/test_git_snapshot_resilience.py
+++ b/tests/test_git_snapshot_resilience.py
@@ -7,42 +7,23 @@ from __future__ import annotations
 
 import os
 import subprocess
-from types import SimpleNamespace
 
 import pytest
 
-from vibesys.context import _RunContext
+from vibesys.run import GitTracker
 
 
 def _git(ws, *args):
     subprocess.run(["git", *args], cwd=ws, check=True, capture_output=True)
 
 
-def _make_ctx(ws):
-    """A minimal stand-in exposing just the git-snapshot helpers."""
-    ctx = SimpleNamespace(
-        workspace=ws,
-        lprint=lambda *a, **k: None,
-        _GIT_ENV={
-            "GIT_AUTHOR_NAME": "t",
-            "GIT_AUTHOR_EMAIL": "t@t",
-            "GIT_COMMITTER_NAME": "t",
-            "GIT_COMMITTER_EMAIL": "t@t",
-        },
-    )
-    ctx._collect_unreadable = lambda: _RunContext._collect_unreadable(ctx)
-    ctx._exclude_paths = lambda p: _RunContext._exclude_paths(ctx, p)
-    ctx._git_run = lambda cmd, check=True: _RunContext._git_run(ctx, cmd, check=check)
-    ctx._unreadable_from_stderr = _RunContext._unreadable_from_stderr
-    return ctx
+def _make_tracker(ws, excluded_dirs=()):
+    return GitTracker(ws, log=lambda *a, **k: None, excluded_dirs=excluded_dirs)
 
 
-def test_workspace_gitignore_excludes_compiled_artifacts():
-    ctx = SimpleNamespace(
-        EXCLUDED_WORKSPACE_DIRS={".git", "__pycache__", "_mounts", "target"},
-        _ARTIFACT_GITIGNORE_PATTERNS=_RunContext._ARTIFACT_GITIGNORE_PATTERNS,
-    )
-    gi = _RunContext._workspace_gitignore(ctx)
+def test_workspace_gitignore_excludes_compiled_artifacts(tmp_path):
+    tracker = _make_tracker(tmp_path, excluded_dirs={".git", "__pycache__", "_mounts", "target"})
+    gi = tracker._workspace_gitignore()
     # accelerator artifacts an agent might drop into the workspace
     for pat in ("*.neff", "*.ntff", "neuron-compile-cache/"):
         assert pat in gi
@@ -56,7 +37,7 @@ def test_unreadable_from_stderr_parses_git_output():
         "error: unable to index file 'sub/ntrace.pb'\n"
         "fatal: adding files failed\n"
     )
-    assert _RunContext._unreadable_from_stderr(stderr) == [
+    assert GitTracker._unreadable_from_stderr(stderr) == [
         "system_profile.json",
         "sub/ntrace.pb",
     ]
@@ -70,8 +51,8 @@ def test_collect_unreadable_finds_mode000_file(tmp_path):
     secret.write_text("x")
     os.chmod(secret, 0o000)
     try:
-        ctx = _make_ctx(ws)
-        assert ctx._collect_unreadable() == ["secret.bin"]
+        tracker = _make_tracker(ws)
+        assert tracker._collect_unreadable() == ["secret.bin"]
     finally:
         os.chmod(secret, 0o644)  # let pytest clean up
 
@@ -87,11 +68,10 @@ def test_git_add_all_excludes_unreadable_and_succeeds(tmp_path):
     os.chmod(secret, 0o600)  # owner-read, but pytest runs as the owner...
     os.chmod(secret, 0o000)  # ...so make it truly unreadable
 
-    ctx = _make_ctx(ws)
+    tracker = _make_tracker(ws)
     try:
         # Plain `git add -A` would exit 128 here; the resilient path must not.
-        ctx._git_add_all = lambda: _RunContext._git_add_all(ctx)
-        ctx._git_add_all()
+        tracker._add_all()
         staged = subprocess.run(
             ["git", "diff", "--cached", "--name-only"],
             cwd=ws,

--- a/tests/test_git_tracker.py
+++ b/tests/test_git_tracker.py
@@ -1,0 +1,145 @@
+"""GitTracker unit tests against real temporary git repos (no mocks)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from vibesys.run import GitTracker
+
+_EXCLUDED = {".git", "__pycache__", "target"}
+
+
+def _make_tracker(ws, logs=None):
+    log = logs.append if logs is not None else (lambda _msg: None)
+    return GitTracker(ws, log=log, excluded_dirs=_EXCLUDED)
+
+
+def _git_stdout(ws, *args) -> str:
+    return subprocess.run(["git", *args], cwd=ws, check=True, capture_output=True, text=True).stdout
+
+
+@pytest.fixture
+def ws(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "main.py").write_text("VALUE = 1\n")
+    return ws
+
+
+def test_init_creates_repo_gitignore_and_initial_commit(ws):
+    tracker = _make_tracker(ws)
+    tracker.init(existing=False)
+
+    assert (ws / ".git").is_dir()
+    gitignore = (ws / ".gitignore").read_text()
+    assert "target" in gitignore
+    assert "*.neff" in gitignore
+    log = _git_stdout(ws, "log", "--format=%s")
+    assert log.strip() == "initial: workspace setup"
+
+
+def test_init_appends_to_existing_gitignore(ws):
+    (ws / ".gitignore").write_text("custom-entry")  # no trailing newline
+    tracker = _make_tracker(ws)
+    tracker.init(existing=False)
+
+    gitignore = (ws / ".gitignore").read_text()
+    assert gitignore.startswith("custom-entry\n")
+    assert "*.neff" in gitignore
+
+
+def test_init_existing_requires_repo(ws):
+    tracker = _make_tracker(ws)
+    with pytest.raises(ValueError, match="no git repository"):
+        tracker.init(existing=True)
+
+    tracker.init(existing=False)
+    tracker.init(existing=True)  # now valid; must not re-init or commit
+    log = _git_stdout(ws, "log", "--format=%s")
+    assert log.strip() == "initial: workspace setup"
+
+
+def test_snapshot_commits_changes_and_skips_clean_tree(ws):
+    logs: list[str] = []
+    tracker = _make_tracker(ws, logs)
+    tracker.init(existing=False)
+
+    (ws / "main.py").write_text("VALUE = 2\n")
+    tracker.snapshot("round 1")
+    assert _git_stdout(ws, "log", "-1", "--format=%s").strip() == "round 1"
+
+    tracker.snapshot("round 2")  # nothing changed — no commit, only a log line
+    assert _git_stdout(ws, "log", "-1", "--format=%s").strip() == "round 1"
+    assert any("no changes to commit for 'round 2'" in line for line in logs)
+
+
+def test_current_sha_matches_head_and_is_none_without_repo(ws):
+    tracker = _make_tracker(ws)
+    assert tracker.current_sha() is None  # no repo yet
+
+    tracker.init(existing=False)
+    assert tracker.current_sha() == _git_stdout(ws, "rev-parse", "HEAD").strip()
+
+
+def test_checkout_tree_restores_snapshot_without_moving_head(ws):
+    tracker = _make_tracker(ws)
+    tracker.init(existing=False)
+    first = tracker.current_sha()
+
+    (ws / "main.py").write_text("VALUE = 2\n")
+    tracker.snapshot("round 1")
+    second = tracker.current_sha()
+
+    assert tracker.checkout_tree(first) is True
+    assert (ws / "main.py").read_text() == "VALUE = 1\n"
+    # HEAD stays put so the next commit lands as a new child commit.
+    assert tracker.current_sha() == second
+
+
+def test_checkout_tree_clean_removes_untracked_files(ws):
+    tracker = _make_tracker(ws)
+    tracker.init(existing=False)
+    first = tracker.current_sha()
+
+    (ws / "leftover.txt").write_text("scratch\n")
+    assert tracker.checkout_tree(first, clean=True) is True
+    assert not (ws / "leftover.txt").exists()
+
+
+def test_checkout_tree_returns_false_and_logs_on_bad_sha(ws):
+    logs: list[str] = []
+    tracker = _make_tracker(ws, logs)
+    tracker.init(existing=False)
+
+    assert tracker.checkout_tree("0000000000000000000000000000000000000000") is False
+    assert any("git checkout 00000000 failed" in line for line in logs)
+
+
+def test_trusted_input_changes_reports_committed_and_pending_edits(ws):
+    (ws / "accuracy_checker").mkdir()
+    (ws / "accuracy_checker" / "checker.py").write_text("print('ok')\n")
+    tracker = _make_tracker(ws)
+    tracker.init(existing=False)
+
+    # Non-evaluator edits are not reported, committed or not.
+    (ws / "main.py").write_text("VALUE = 2\n")
+    tracker.snapshot("round 1")
+    assert tracker.trusted_input_changes() == []
+
+    # Pending (uncommitted) evaluator edits are reported...
+    (ws / "accuracy_checker" / "checker.py").write_text("print('forged')\n")
+    assert tracker.trusted_input_changes() == ["accuracy_checker/checker.py"]
+
+    # ...and stay reported once committed (diff against the root commit).
+    tracker.snapshot("round 2")
+    assert tracker.trusted_input_changes() == ["accuracy_checker/checker.py"]
+
+
+def test_run_is_a_public_escape_hatch(ws):
+    tracker = _make_tracker(ws)
+    tracker.init(existing=False)
+
+    result = tracker.run(["git", "status", "--porcelain"], check=True)
+    assert result.returncode == 0

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -14,6 +14,7 @@ import pytest
 
 from vibesys.context import _RunContext
 from vibesys.errors import ConfigurationDiagnostic, ConfigurationError
+from vibesys.run import RunPaths
 from vibesys.server import (
     EventType,
     RunInspector,
@@ -405,7 +406,12 @@ def test_run_context_records_invocation_boundary(tmp_path):
     ctx.supervisor = supervisor
     ctx.agent_runner = Mock()
     ctx.agent_runner.invoke.return_value = {"summary": "measured"}
-    ctx.workspace = tmp_path
+    ctx._paths = RunPaths(
+        exp_dir=tmp_path,
+        log_dir=tmp_path / "logs",
+        workspace=tmp_path,
+        run_log_path=tmp_path / "run.log",
+    )
     ctx.gpu_env = lambda: {}
     ctx._progress_stack = []
 


### PR DESCRIPTION
Closes #171. Part of the `_RunContext` refactor tracked in #170.

**Stack (PR 1 of 3):** this PR (base `main`) → PR 2 (`Workspace` + factory) → PR 3 (`RunLogger`/`DeviceLease`/`LoopContext`). Please merge in order and do not squash-merge out of order — the later PRs are branched off this one.

## Problem

`_RunContext` (`src/vibesys/context.py`) is the composition root and lifecycle owner for one experiment run, and has accreted five unrelated method clusters. The git-tracking cluster in particular leaks across module boundaries: loops call the private `ctx._git_run` seven times, `_current_commit_sha` is duplicated byte-identically in `loops/agent/loop.py` and `loops/evolve/loop.py`, and checkout logic is duplicated as `_git_checkout` (agent) vs `_checkout_commit_tree` (evolve). Path and command passthroughs are loose attributes/properties with no grouped value object.

## Solution

Pure refactor, no behavior changes.

- New `src/vibesys/run/` package (experiment-lifecycle concerns; deliberately not `libs/` — these are not reusable standalone libraries).
- `GitTracker` (`run/git_tracker.py`) owns repo-over-workspace snapshot tracking: `init(existing)`, `snapshot(label)`, `current_sha()`, `checkout_tree(sha, *, clean=False)`, `trusted_input_changes()`, and a public `run(...)` escape hatch replacing loops' `ctx._git_run`. The git env, workspace `.gitignore` contents, and unreadable-path exclusion resilience (`.git/info/exclude`) are now implementation details of the tracker.
- `RunPaths` / `RunCommands` (`run/paths.py`) are frozen dataclasses; `_RunContext` keeps delegating properties (`ctx.workspace`, `ctx.judge_accuracy_command`, …) so call sites don't churn. `switch_log_file` replaces the frozen `RunPaths` record instead of mutating a field.
- Loops migrate to `ctx.git.…`; the duplicated `_current_commit_sha`, `_git_checkout`, and `_checkout_commit_tree` helpers are deleted. The behavioral difference between the two checkout helpers (evolve ran `git clean -fd`; agent did not) is preserved explicitly via the `clean=` flag. (The openevolve loop, which shared evolve's helpers, was removed upstream in #174 while this PR was in flight; this branch is rebased on that removal.)

### Architecture

```mermaid
graph LR
    loops["loops/agent, evolve"] -->|"ctx.git.current_sha / checkout_tree / run"| GT[GitTracker]
    RC[_RunContext facade] -->|owns| GT
    RC -->|"delegating properties"| RP[RunPaths]
    RC -->|"delegating properties"| CMD[RunCommands]
    GT -->|"git subprocess, cwd=workspace"| WS[(workspace repo)]
```

`_RunContext` remains the composition root; `GitTracker` is constructed side-effect-free (workspace root + log callback + excluded dir names) and is always present on `ctx.git`, with `init` gated on `--git-tracking` exactly as before. `trusted_input_changes()` on the facade keeps the `git_tracking` guard and delegates.

## Verification

### Correctness properties

- No behavior change: snapshot commit semantics (add-all resilience, no-op commit logging), workspace `.gitignore` contents, trusted-input tamper detection, git env (`safe.directory`), and checkout semantics (HEAD stays put; evolve-side `git clean -fd`) are preserved verbatim — the method bodies moved, with their comments.
- The agent loop's `git_tracking` guard on sha lookup is preserved at the call site; the evolve sha lookup remains unguarded, as before.
- `RunPaths`/`RunCommands` are immutable snapshots; `RunCommands` is taken once after the run-environment session opens, matching the previous property reads (the view's paths are fixed for the session lifetime).
- No remaining `_git_run`/`_git_snapshot`/`_init_git_tracking` references outside `run/`.

### Testing

- `uv run pytest` — 1766 passed.
- `uv run pytest tests/test_context.py tests/test_git_snapshot_resilience.py tests/test_git_tracker.py tests/loops …` — 391 passed.
- New `tests/test_git_tracker.py`: GitTracker unit tests against real temp git repos (no mocks) — init/gitignore/initial-commit, resume validation, snapshot + clean-tree no-op, `current_sha`, `checkout_tree` with and without `clean`, bad-sha failure logging, `trusted_input_changes` for pending and committed edits.
- `tests/test_git_snapshot_resilience.py` ported to GitTracker (same behavioral assertions).
- `./scripts/check_format.sh`, `./scripts/check_lint.sh` — clean.

No external contracts (manifests, flags, CLI, prompts, skills) are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
