### PR TITLE
Extract DeviceLease, add LoopContext protocol, unify teardown on one ExitStack

### DIFF
--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -1,6 +1,5 @@
 """Shared run context: ``_RunContext``, ``create_run_context``, and ``setup_exp_dir``."""
 
-import json
 import shutil
 import subprocess
 import uuid
@@ -36,7 +35,7 @@ from vibesys.profilers import (
     profiler_definition,
     resolve_profiler_kind,
 )
-from vibesys.run import GitTracker, RunCommands, RunLogger, RunPaths, Workspace
+from vibesys.run import DeviceLease, GitTracker, RunCommands, RunLogger, RunPaths, Workspace
 from vibesys.sandbox.run_environment import (
     RunEnvironmentRequest,
     RunEnvironmentSpec,
@@ -272,8 +271,12 @@ def create_run_context(
     if git_tracking:
         git.init(existing)
 
-    run_environment_stack = ExitStack()
-    session = run_environment_stack.enter_context(
+    # One teardown stack for the whole context: every component with
+    # cleanup registers here, and close() unwinds it in reverse
+    # construction order (device → environment hooks → session → logs).
+    teardown_stack = ExitStack()
+    teardown_stack.callback(logger.close)
+    session = teardown_stack.enter_context(
         environment.open(
             RunEnvironmentRequest(
                 log_dir=log_dir,
@@ -301,10 +304,18 @@ def create_run_context(
         profiler_benchmark_command=session.view.paths.benchmark_command,
     )
 
+    def _teardown_environment_hooks() -> None:
+        try:
+            hooks.teardown(environment_context)
+        except Exception as exc:
+            logger.lprint(f"[warn] environment hook teardown failed: {exc}")
+
+    teardown_stack.callback(_teardown_environment_hooks)
+
     # Start backend-specific background monitoring (CUDA: nvidia-smi).
-    gpu_monitor = backend_impl.make_monitor(log_dir)
-    if gpu_monitor is not None:
-        gpu_monitor.start()
+    device = DeviceLease(backend_impl, log_dir=log_dir, run_environment_view=session.view)
+    device.start_monitor()
+    teardown_stack.callback(device.close)
 
     # Build the backend-agnostic agent runner. Loops invoke this instead
     # of calling create_deep_agent / vibesys._agent_cli directly. The cli
@@ -364,10 +375,10 @@ def create_run_context(
         environment_patch=environment_patch,
         workspace_files=workspace_files,
         git=git,
-        run_environment_stack=run_environment_stack,
+        teardown_stack=teardown_stack,
         run_environment_session=session,
         commands=commands,
-        gpu_monitor=gpu_monitor,
+        device=device,
         agent_runner=agent_runner,
     )
 
@@ -416,10 +427,10 @@ class _RunContext:
         environment_patch,
         workspace_files: Workspace,
         git: GitTracker,
-        run_environment_stack: ExitStack,
+        teardown_stack: ExitStack,
         run_environment_session,
         commands: RunCommands,
-        gpu_monitor,
+        device: DeviceLease,
         agent_runner,
     ):
         self.backend = backend
@@ -449,15 +460,15 @@ class _RunContext:
         self.workspace_files = workspace_files
         self.EXCLUDED_WORKSPACE_DIRS = workspace_files.excluded_dirs
         self.git = git
-        self._run_environment_stack = run_environment_stack
+        self._teardown_stack = teardown_stack
         self.run_environment_session = run_environment_session
         self.run_environment_view = run_environment_session.view
         self.implementer_backend = run_environment_session.sandbox
         self.judge_backend = run_environment_session.sandbox
         self.commands = commands
+        self.device = device
         # Expose the picked device for legacy callers (gpu monitor tests etc).
-        self.selected_gpu = getattr(backend_impl, "selected_device", None)
-        self.gpu_monitor = gpu_monitor
+        self.selected_gpu = device.selected_device
         self.agent_runner = agent_runner
         self._closed = False
         self._progress_stack: list[AgentProgress] = []
@@ -487,18 +498,18 @@ class _RunContext:
         """The current open log file handle (owned by ``RunLogger``)."""
         return self.logger.file
 
-    def gpu_env(self) -> dict[str, str]:
-        """Env vars to inject into the host-running cli agent runner.
+    @property
+    def gpu_monitor(self):
+        """The active device monitor (owned by ``DeviceLease``)."""
+        return self.device.monitor
 
-        Today this is just the device pin (``CUDA_VISIBLE_DEVICES`` for cuda),
-        derived from whichever device the backend selected.  The deepagents
-        path ignores this; the cli path layers it onto the spawned subprocess
-        env so it sees the same device the sandbox env was built with.
-        """
-        dev = getattr(self.backend_impl, "selected_device", None)
-        if dev is None:
-            return {}
-        return {"CUDA_VISIBLE_DEVICES": str(dev.index)}
+    @gpu_monitor.setter
+    def gpu_monitor(self, monitor) -> None:
+        self.device.monitor = monitor
+
+    def gpu_env(self) -> dict[str, str]:
+        """Env vars for the host-running cli agent runner — see :meth:`DeviceLease.gpu_env`."""
+        return self.device.gpu_env()
 
     @contextmanager
     def progress(self, progress: AgentProgress) -> Iterator[None]:
@@ -641,53 +652,19 @@ class _RunContext:
             self.agent_runner._run_log_file = new_file  # pyright: ignore[reportAttributeAccessIssue]
 
     def reselect_gpu(self) -> None:
-        """Delegate mid-run device rebalance to the backend.
-
-        Restarted sandboxes re-run their ``setup_fns`` (e.g. docker symlinks)
-        as part of ``start()`` — no replay logic needed here.
-        """
-        run_environment_view = getattr(self, "run_environment_view", None)
-        if run_environment_view is not None and not run_environment_view.host_device_reselect:
-            return
-        self.backend_impl.reselect_device()
+        """Delegate mid-run device rebalance — see :meth:`DeviceLease.reselect`."""
+        self.device.reselect()
         # Mirror backend state on _RunContext for legacy callers/tests.
-        self.selected_gpu = getattr(self.backend_impl, "selected_device", None)
-        self.gpu_monitor = getattr(self.backend_impl, "_monitor", None)
-
-    def _finalize_gpu_metadata(self) -> None:
-        """Update ``gpu.json`` with contention summary before closing."""
-        gpu_json = self.log_dir / "gpu.json"
-        if not gpu_json.exists():
-            return
-
-        data = json.loads(gpu_json.read_text())
-
-        contention_log = self.log_dir / "gpu_contention.jsonl"
-        contention_events = 0
-        if contention_log.exists():
-            text = contention_log.read_text().strip()
-            if text:
-                contention_events = len(text.splitlines())
-
-        data["contention_detected"] = contention_events > 0
-        data["contention_events"] = contention_events
-        data["finished_at"] = datetime.now().isoformat()
-        gpu_json.write_text(json.dumps(data, indent=2))
+        self.selected_gpu = self.device.selected_device
 
     def close(self) -> None:
         if self._closed:
             return
         self._closed = True
-        if self.gpu_monitor is not None:
-            self.gpu_monitor.stop()
-        self._finalize_gpu_metadata()
-        if hasattr(self, "environment_hooks") and hasattr(self, "environment_context"):
-            try:
-                self.environment_hooks.teardown(self.environment_context)
-            except Exception as exc:
-                self.lprint(f"[warn] environment hook teardown failed: {exc}")
-        self._run_environment_stack.close()
-        self.logger.close()
+        # Unwinds in reverse construction order: device monitor stop +
+        # gpu.json finalization, environment hook teardown, run-environment
+        # session exit, stderr restore + log file close.
+        self._teardown_stack.close()
 
     def __enter__(self) -> "_RunContext":
         return self

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config
 from vibesys.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
-from vibesys.context import _RunContext, create_run_context
+from vibesys.context import create_run_context
 from vibesys.domains.base import DomainDefinition, DomainName, DomainRole
 from vibesys.domains.registry import resolve_domain
 from vibesys.domains.rendering import render_domain_section
@@ -30,6 +30,7 @@ from vibesys.profilers import (
     require_profiler_kind,
 )
 from vibesys.prompts import render_template
+from vibesys.run import LoopContext
 from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
@@ -207,7 +208,7 @@ def _is_fresh_cold_start(round_number: int, records: list[_RoundRecord]) -> bool
 
 
 def _run_pre_round_decision(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     round_number: int,
     objective: str,
@@ -273,7 +274,7 @@ def _effective_profiler_definition(
 
 
 def _run_profiler(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     round_number: int,
     profile_focus: str,
@@ -319,7 +320,7 @@ def _run_profiler(
 
 
 def _domain_render_context(
-    ctx: _RunContext, modality: str | None, interface: str
+    ctx: LoopContext, modality: str | None, interface: str
 ) -> dict[str, object]:
     """The uniform variable set every domain role file is rendered with.
 
@@ -342,7 +343,7 @@ def _domain_render_context(
 
 
 def _run_orchestrator_plan(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     round_number: int,
     objective: str,
@@ -390,7 +391,7 @@ def _run_orchestrator_plan(
 
 
 def _run_implementer(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     round_number: int,
     retry: int,
@@ -439,7 +440,7 @@ def _run_implementer(
 
 
 def _run_judge(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     round_number: int,
     retry: int,
@@ -503,7 +504,7 @@ def _run_judge(
 
 
 def _run_single_agent_round(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     round_number: int,
     retry: int,
@@ -603,7 +604,7 @@ def _profiler_summary_from_single_agent(
 
 
 def _run_framework_accuracy_gate(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     round_number: int,
     retry: int,
@@ -687,7 +688,7 @@ def _metric_values(value: object, metric: str) -> list[object]:
 
 
 def _run_framework_benchmark(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     result_spec: BenchmarkResult | None,
     round_number: int,
@@ -793,7 +794,7 @@ def _run_framework_benchmark(
 
 
 def _run_framework_gates(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     benchmark_result: BenchmarkResult | None,
     round_number: int,
@@ -1202,7 +1203,7 @@ def run_agent_loop(
 
 
 def _publish_subprocess_output(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     process_id: str,
     process_kind: str,

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -35,7 +35,7 @@ from jinja2 import Environment, FileSystemLoader
 from vibesys.agents.progress import CandidateProgress
 from vibesys.config import Config
 from vibesys.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
-from vibesys.context import _RunContext, create_run_context
+from vibesys.context import create_run_context
 from vibesys.domains.llm_serving.hooks import LLMServingEnvironmentHooks
 from vibesys.loops.evolve.population import (
     Individual,
@@ -44,6 +44,7 @@ from vibesys.loops.evolve.population import (
 )
 from vibesys.loops.profiler import invoke_profiler
 from vibesys.profilers import ProfilerKind, profiler_definition
+from vibesys.run import LoopContext
 from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
@@ -75,7 +76,7 @@ def _render(name: str, **kwargs) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _discard_working_tree(ctx: _RunContext) -> None:
+def _discard_working_tree(ctx: LoopContext) -> None:
     """Drop any uncommitted changes left by a failed mutation attempt."""
     try:
         ctx.git.run(["git", "checkout", "HEAD", "--", "."], check=False)
@@ -96,7 +97,7 @@ def _discard_working_tree(ctx: _RunContext) -> None:
 
 
 def _run_mutator(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     generation: int,
     child_idx: int,
@@ -137,7 +138,7 @@ def _run_mutator(
 
 
 def _run_judge(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     generation: int,
     child_idx: int,
@@ -190,7 +191,7 @@ def _format_objectives_for_profiler(objectives: list[Objective]) -> str:
 
 
 def _run_profiler(
-    ctx: _RunContext,
+    ctx: LoopContext,
     *,
     generation: int,
     child_idx: int,

--- a/src/vibesys/loops/plain/loop.py
+++ b/src/vibesys/loops/plain/loop.py
@@ -31,12 +31,13 @@ from pathlib import Path
 from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config, as_config
 from vibesys.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
-from vibesys.context import _RunContext, create_run_context
+from vibesys.context import create_run_context
 from vibesys.domains.llm_serving.hooks import LLMServingEnvironmentHooks
 from vibesys.loops.plain.render import render_all
 from vibesys.loops.plain.runner_ext import PlainLoopAgentRunner
 from vibesys.profilers import ProfilerKind
 from vibesys.prompts import Prompt
+from vibesys.run import LoopContext
 from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
@@ -305,7 +306,7 @@ def _ensure_bootstrap_issue(
     *,
     state: PlainLoopState,
     log_dir: Path,
-    ctx: _RunContext,
+    ctx: LoopContext,
     prompt: Prompt,
 ) -> None:
     """Auto-create the initial feature issue on the first run.

--- a/src/vibesys/run/__init__.py
+++ b/src/vibesys/run/__init__.py
@@ -5,9 +5,11 @@ tracking) rather than reusable standalone libraries, so they live under
 ``src/vibesys/run/`` instead of ``libs/``.
 """
 
+from vibesys.run.device import DeviceLease
 from vibesys.run.git_tracker import GitTracker
 from vibesys.run.logger import RunLogger
 from vibesys.run.paths import RunCommands, RunPaths
+from vibesys.run.protocol import LoopContext
 from vibesys.run.workspace import (
     EXCLUDED_WORKSPACE_DIRS,
     CopySpec,
@@ -19,8 +21,10 @@ from vibesys.run.workspace import (
 __all__ = [
     "EXCLUDED_WORKSPACE_DIRS",
     "CopySpec",
+    "DeviceLease",
     "GitTracker",
     "InputProjectSpec",
+    "LoopContext",
     "RunCommands",
     "RunLogger",
     "RunPaths",

--- a/src/vibesys/run/device.py
+++ b/src/vibesys/run/device.py
@@ -1,0 +1,80 @@
+"""Compute-device coordination for one experiment run.
+
+``DeviceLease`` is a thin coordinator around whichever device the compute
+backend selected: env pinning for host-run agents, mid-run reselection,
+the background contention monitor, and end-of-run metadata finalization.
+It legitimately holds refs to the backend impl and (once the session is
+open) the run-environment view; selection logic itself stays in the
+backend.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+
+class DeviceLease:
+    def __init__(self, backend, *, log_dir: Path, run_environment_view=None) -> None:
+        self._backend = backend
+        self._log_dir = log_dir
+        self._view = run_environment_view
+        self.monitor = None
+
+    @property
+    def selected_device(self):
+        return getattr(self._backend, "selected_device", None)
+
+    def start_monitor(self) -> None:
+        """Start backend-specific background monitoring (CUDA: nvidia-smi)."""
+        self.monitor = self._backend.make_monitor(self._log_dir)
+        if self.monitor is not None:
+            self.monitor.start()
+
+    def gpu_env(self) -> dict[str, str]:
+        """Env vars to inject into the host-running cli agent runner.
+
+        Today this is just the device pin (``CUDA_VISIBLE_DEVICES`` for cuda),
+        derived from whichever device the backend selected.  The deepagents
+        path ignores this; the cli path layers it onto the spawned subprocess
+        env so it sees the same device the sandbox env was built with.
+        """
+        dev = self.selected_device
+        if dev is None:
+            return {}
+        return {"CUDA_VISIBLE_DEVICES": str(dev.index)}
+
+    def reselect(self) -> None:
+        """Delegate mid-run device rebalance to the backend.
+
+        Restarted sandboxes re-run their ``setup_fns`` (e.g. docker symlinks)
+        as part of ``start()`` — no replay logic needed here.
+        """
+        if self._view is not None and not self._view.host_device_reselect:
+            return
+        self._backend.reselect_device()
+        self.monitor = getattr(self._backend, "_monitor", None)
+
+    def _finalize_metadata(self) -> None:
+        """Update ``gpu.json`` with contention summary before closing."""
+        gpu_json = self._log_dir / "gpu.json"
+        if not gpu_json.exists():
+            return
+
+        data = json.loads(gpu_json.read_text())
+
+        contention_log = self._log_dir / "gpu_contention.jsonl"
+        contention_events = 0
+        if contention_log.exists():
+            text = contention_log.read_text().strip()
+            if text:
+                contention_events = len(text.splitlines())
+
+        data["contention_detected"] = contention_events > 0
+        data["contention_events"] = contention_events
+        data["finished_at"] = datetime.now().isoformat()
+        gpu_json.write_text(json.dumps(data, indent=2))
+
+    def close(self) -> None:
+        if self.monitor is not None:
+            self.monitor.stop()
+        self._finalize_metadata()

--- a/src/vibesys/run/protocol.py
+++ b/src/vibesys/run/protocol.py
@@ -1,0 +1,86 @@
+"""The run-context surface loops are allowed to depend on.
+
+``LoopContext`` captures what loop implementations actually consume from
+``_RunContext`` (verified by grepping ``ctx.`` usage across ``loops/`` and
+``main.py``).  Loop entry points type against this protocol instead of the
+concrete class, which keeps the facade's construction internals out of the
+loops' contract.
+"""
+
+from contextlib import AbstractContextManager
+from pathlib import Path
+from typing import Any, Protocol
+
+from vibesys.agents.progress import AgentProgress
+from vibesys.constants import ComputeBackend
+from vibesys.profilers import ProfilerKind
+from vibesys.run.git_tracker import GitTracker
+
+
+class LoopContext(Protocol):
+    # -- run identity / configuration -----------------------------------------
+    backend: ComputeBackend
+    model_name: str
+    git_tracking: bool
+    profiler_kind: ProfilerKind
+    ref_name: str
+
+    # -- collaborators --------------------------------------------------------
+    supervisor: Any
+    agent_runner: Any
+    judge_backend: Any
+    run_environment_view: Any
+    git: GitTracker
+
+    # -- paths ----------------------------------------------------------------
+    @property
+    def exp_dir(self) -> Path: ...
+
+    @property
+    def log_dir(self) -> Path: ...
+
+    @property
+    def workspace(self) -> Path: ...
+
+    @property
+    def run_log_path(self) -> Path: ...
+
+    # -- agent-facing commands ------------------------------------------------
+    @property
+    def judge_accuracy_command(self) -> str | None: ...
+
+    @property
+    def judge_benchmark_command(self) -> str | None: ...
+
+    @property
+    def profiler_benchmark_command(self) -> str | None: ...
+
+    # -- services -------------------------------------------------------------
+    def lprint(self, text: str) -> None: ...
+
+    def switch_log_file(self, label: int | str) -> None: ...
+
+    def invoke(
+        self,
+        *,
+        kind: str,
+        system_prompt: str,
+        user_prompt: str,
+        response_cls: Any,
+        fallback_factory: Any = None,
+        round_label: str = "",
+        progress: AgentProgress | None = None,
+        **extra: Any,
+    ) -> Any: ...
+
+    def progress(self, progress: AgentProgress) -> AbstractContextManager[None]: ...
+
+    def snapshot_workspace(self, label: str) -> None: ...
+
+    def trusted_input_changes(self) -> list[str]: ...
+
+    def reselect_gpu(self) -> None: ...
+
+    def wait_for_debug(self, step: str) -> None: ...
+
+    def close(self) -> None: ...

--- a/tests/backends/test_gpu_monitor.py
+++ b/tests/backends/test_gpu_monitor.py
@@ -282,7 +282,6 @@ class TestReselectGpu:
             run_log_path=tmp_path / "run.log",
         )
         ctx.log_dir.mkdir(parents=True, exist_ok=True)
-        ctx.gpu_monitor = None
         ctx._docker_symlinks = []
 
         # Real CudaBackend so reselect_gpu's delegation hits the actual logic;
@@ -290,6 +289,11 @@ class TestReselectGpu:
         backend_impl = CudaBackend(log_dir=ctx.log_dir, log=lambda _msg: None)
         backend_impl.selected_device = selected_gpu
         ctx.backend_impl = backend_impl
+
+        # gpu_env / reselect_gpu / gpu_monitor delegate to the device lease.
+        from vibesys.run import DeviceLease
+
+        ctx.device = DeviceLease(backend_impl, log_dir=ctx.log_dir)
 
         # Sandboxes — DockerSandbox spec'd MagicMock so isinstance checks
         # in reselect_device route through the docker branch.  Register with

--- a/tests/test_device_lease.py
+++ b/tests/test_device_lease.py
@@ -1,0 +1,52 @@
+"""DeviceLease unit tests: env pinning, view gating, and gpu.json finalization."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from vibesys.run import DeviceLease
+
+
+def test_gpu_env_pins_selected_device(tmp_path):
+    backend = SimpleNamespace(selected_device=SimpleNamespace(index=3))
+    lease = DeviceLease(backend, log_dir=tmp_path)
+    assert lease.gpu_env() == {"CUDA_VISIBLE_DEVICES": "3"}
+
+
+def test_gpu_env_empty_without_device(tmp_path):
+    lease = DeviceLease(SimpleNamespace(), log_dir=tmp_path)
+    assert lease.gpu_env() == {}
+
+
+def test_reselect_skipped_when_view_disallows_host_reselect(tmp_path):
+    backend = MagicMock()
+    view = SimpleNamespace(host_device_reselect=False)
+    lease = DeviceLease(backend, log_dir=tmp_path, run_environment_view=view)
+    lease.reselect()
+    backend.reselect_device.assert_not_called()
+
+
+def test_close_stops_monitor_and_finalizes_gpu_json(tmp_path):
+    (tmp_path / "gpu.json").write_text(json.dumps({"name": "H100"}))
+    (tmp_path / "gpu_contention.jsonl").write_text('{"is_contended": true}\n' * 2)
+
+    backend = MagicMock()
+    lease = DeviceLease(backend, log_dir=tmp_path)
+    monitor = MagicMock()
+    lease.monitor = monitor
+
+    lease.close()
+
+    monitor.stop.assert_called_once()
+    data = json.loads((tmp_path / "gpu.json").read_text())
+    assert data["contention_detected"] is True
+    assert data["contention_events"] == 2
+    assert "finished_at" in data
+
+
+def test_close_without_gpu_json_is_a_noop(tmp_path):
+    lease = DeviceLease(MagicMock(), log_dir=tmp_path)
+    lease.close()
+    assert not (tmp_path / "gpu.json").exists()


### PR DESCRIPTION
Closes #173. Part of the `_RunContext` refactor tracked in #170.

**Stack (PR 3 of 3):** PR 1 #175 (base `main`) → PR 2 #176 (base `vic/runctx-git-tracker`) → this PR (base `vic/runctx-workspace-factory`). Please merge in order and do not squash-merge out of order — this branch contains PR 1 and PR 2's commits.

## Problem

After PRs 1–2, `_RunContext` still mixed two concerns into the facade: GPU/device management (`gpu_env`, `reselect_gpu`, monitor lifecycle, `gpu.json` finalization) lived as loose methods reading `backend_impl` internals, and `close()` hand-sequenced four unrelated teardowns. Loops were also still typed against the concrete `_RunContext`, so their contract with the run context was implicit ("whatever the class happens to expose").

## Solution

Pure refactor, no behavior changes.

- **`DeviceLease`** (`run/device.py`): thin coordinator for the selected compute device — `gpu_env()` pinning, `reselect()` (with the run-environment-view `host_device_reselect` gate), background monitor start/stop, and `gpu.json` contention finalization on close. It holds refs to the backend impl and the session view by design; selection logic stays in the backend. The facade keeps `gpu_env`/`reselect_gpu`/`gpu_monitor` delegating (with the `selected_gpu` legacy mirror preserved).
- **`LoopContext`** (`run/protocol.py`): a `Protocol` capturing exactly what loops consume — verified by grepping `ctx.` usage across `loops/` and `main.py` (26 members: paths, judge/profiler commands, `git`, `invoke`/`progress`, `snapshot_workspace`, `reselect_gpu`, logging, `supervisor`, `agent_runner`, `judge_backend`, `run_environment_view`, config fields, `wait_for_debug`, `close`). All loop functions now annotate `ctx: LoopContext`; `_RunContext` no longer appears in any loop module.
- **Unified teardown**: `create_run_context` registers every component's cleanup on one `ExitStack` (logger close → session exit → environment-hook teardown → device close, registered in that order), and `close()` is now just a re-entrancy guard plus `stack.close()`, which unwinds in exactly the previous order: monitor stop + `gpu.json` finalize → hook teardown (still warn-and-continue) → session exit → stderr restore + log close.

### Architecture

```mermaid
graph TD
    loops["loops (typed: LoopContext)"] --> RC[_RunContext facade]
    RC --> D[DeviceLease]
    RC --> L[RunLogger]
    RC --> G[GitTracker]
    RC --> W[Workspace]
    F[create_run_context] -->|"registers teardown (LIFO)"| ES[ExitStack]
    ES -->|1| D
    ES -->|2| H[environment hooks]
    ES -->|3| S[session]
    ES -->|4| L
```

## Verification

### Correctness properties

- Teardown order is byte-for-byte the old `close()` order; hook-teardown failures are still logged as warnings and do not abort close; `close()` stays idempotent.
- `reselect_gpu` gating unchanged: skipped when the view says `host_device_reselect=False`; proceeds when no view is present (matches the old `getattr(..., None)` default used by legacy test stand-ins).
- `gpu.json` finalization semantics unchanged (contention event count from `gpu_contention.jsonl`, `finished_at` stamp, no-op when the file is absent).
- `LoopContext` is typing-only — no runtime behavior attached; loops call the same facade methods as before.

### Testing

- `uv run pytest` — 1779 passed (full suite).
- New `tests/test_device_lease.py`: env pinning, view gating of reselect, monitor stop + `gpu.json` finalization on close (previously uncovered), absent-file no-op.
- `tests/backends/test_gpu_monitor.py` reselect suite passes against the delegating facade (stand-in now carries a real `DeviceLease`).
- `./scripts/check_format.sh`, `./scripts/check_lint.sh` — clean.

No external contracts (manifests, flags, CLI, prompts, skills) are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)