### PR TITLE
Add Python static type checking with pyright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,24 @@ jobs:
       - name: Check Python lint
         run: ./scripts/check_lint.sh
 
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Check Python types
+        run: ./scripts/check_types.sh
+
   tui:
     runs-on: ubuntu-latest
 

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -102,7 +102,7 @@ class DockerSandbox(BaseSandbox):
         passthrough_paths: list[str] | None = None,
         log_path: str | Path | None = None,
         extra_init_commands: list[str] | None = None,
-        setup_fns: list[Callable[[DockerSandbox], None]] | None = None,
+        setup_fns: list[Callable[[BaseSandbox], None]] | None = None,
     ) -> None:
         """Initialize Docker sandbox configuration.
 
@@ -157,7 +157,7 @@ class DockerSandbox(BaseSandbox):
         self._container_id: str | None = None
         self._logger = self._setup_logger(log_path)
         self._extra_init_commands: list[str] = list(extra_init_commands or [])
-        self._setup_fns: list[Callable[[DockerSandbox], None]] = list(setup_fns or [])
+        self._setup_fns: list[Callable[[BaseSandbox], None]] = list(setup_fns or [])
 
         # Container paths outside /workspace that _vpath must not rewrite.
         self._passthrough_prefixes: list[str] = list(passthrough_paths or [])

--- a/libs/vs-sandbox/src/vs_sandbox/modal_model_setup.py
+++ b/libs/vs-sandbox/src/vs_sandbox/modal_model_setup.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Callable
 
 import modal
 
@@ -43,7 +44,7 @@ def ensure_model_volume(
     hf_token: str | None = None,
     local_path: str | None = None,
     *,
-    log: callable = print,
+    log: Callable[[str], object] = print,
 ) -> str:
     """Ensure a populated Modal Volume exists for *model_id* and return its name.
 

--- a/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
@@ -28,7 +28,7 @@ import time
 import uuid
 from collections.abc import Callable
 from pathlib import Path, PurePosixPath
-from typing import TypeVar
+from typing import TypeVar, cast
 
 import modal
 from deepagents.backends.protocol import (
@@ -38,6 +38,7 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.sandbox import BaseSandbox
+from modal.volume import AbstractVolumeUploadContextManager
 
 # Global registry of live sandboxes for cleanup on exit / SIGINT.
 _live_sandboxes: dict[str, ModalSandbox] = {}
@@ -188,7 +189,7 @@ class ModalSandbox(BaseSandbox):
         extra_writable_volumes: dict[str, str] | None = None,
         log_path: str | Path | None = None,
         extra_init_commands: list[str] | None = None,
-        setup_fns: list[Callable[[ModalSandbox], None]] | None = None,
+        setup_fns: list[Callable[[BaseSandbox], None]] | None = None,
         app_name: str = "vibesys",
         enable_fallback_restart: bool = True,
         max_restart_attempts: int = 2,
@@ -339,7 +340,10 @@ class ModalSandbox(BaseSandbox):
             add_python=None,
         ).run_commands(f"rm -rf {self._CONTAINER_ROOT} && mkdir {self._CONTAINER_ROOT}")
 
-        volumes: dict[str, modal.Volume] = {self._CONTAINER_ROOT: self._workspace_volume}
+        # _workspace_volume is created by start() before _create_container().
+        volumes: dict[str | os.PathLike, modal.Volume | modal.CloudBucketMount] = {
+            self._CONTAINER_ROOT: self._workspace_volume  # pyright: ignore[reportOptionalMemberAccess,reportAssignmentType]
+        }
         if self._model_volume_name:
             model_vol = modal.Volume.from_name(self._model_volume_name).read_only()
             volumes["/model"] = model_vol
@@ -371,7 +375,7 @@ class ModalSandbox(BaseSandbox):
             idle_timeout=self._idle_timeout,
             workdir=self._CONTAINER_ROOT,
             volumes=volumes,
-            env=self._env or None,
+            env=cast("dict[str, str | None] | None", self._env or None),
         )
         self._sandbox_id = self._sandbox.object_id
         _live_sandboxes[self._sandbox_id] = self
@@ -514,7 +518,12 @@ class ModalSandbox(BaseSandbox):
         }
     )
 
-    def _put_workspace_directory(self, batch: object, local_root: Path, remote_root: str) -> None:
+    def _put_workspace_directory(
+        self,
+        batch: AbstractVolumeUploadContextManager,
+        local_root: Path,
+        remote_root: str,
+    ) -> None:
         """Upload workspace files while skipping local-only runtime trees."""
         remote_base = PurePosixPath(remote_root)
         for path in local_root.rglob("*"):
@@ -527,7 +536,7 @@ class ModalSandbox(BaseSandbox):
 
     def _put_bind_mount_directory(
         self,
-        batch: object,
+        batch: AbstractVolumeUploadContextManager,
         local_root: Path,
         remote_root: str,
         tempdirs: list[tempfile.TemporaryDirectory[str]],
@@ -608,8 +617,10 @@ class ModalSandbox(BaseSandbox):
         effective_timeout = timeout if timeout is not None else self._default_timeout
         self._log(f"exec (timeout={effective_timeout}s): {command[:500]}")
 
+        # The closures passed to _run_with_fallback re-read self._sandbox on
+        # every call (a restart swaps it); None is ruled out at method entry.
         def _do_exec() -> tuple[str, str, int]:
-            proc = self._sandbox.exec(
+            proc = self._sandbox.exec(  # pyright: ignore[reportOptionalMemberAccess]
                 "bash",
                 "-c",
                 command,
@@ -665,13 +676,15 @@ class ModalSandbox(BaseSandbox):
         container_path = self._vpath(file_path)
         parent = str(Path(container_path).parent)
 
+        # Closure re-reads self._sandbox on every call (a restart swaps it);
+        # None is ruled out at method entry.
         def _do_write() -> None:
-            fs = self._sandbox.filesystem
+            fs = self._sandbox.filesystem  # pyright: ignore[reportOptionalMemberAccess]
             try:
-                fs.make_directory(parent, parents=True)
+                fs.make_directory(parent, parents=True)  # pyright: ignore[reportCallIssue]
             except TypeError:
                 # Older Modal SDKs: make_directory may not accept parents=
-                self._sandbox.exec(
+                self._sandbox.exec(  # pyright: ignore[reportOptionalMemberAccess]
                     "bash",
                     "-c",
                     f"mkdir -p {parent}",
@@ -704,8 +717,8 @@ class ModalSandbox(BaseSandbox):
             ) -> None:
                 # Re-read fs on each call so post-restart we get the new
                 # sandbox's filesystem handle, not a stale reference.
-                fs = self._sandbox.filesystem
-                self._sandbox.exec(
+                fs = self._sandbox.filesystem  # pyright: ignore[reportOptionalMemberAccess]
+                self._sandbox.exec(  # pyright: ignore[reportOptionalMemberAccess]
                     "bash",
                     "-c",
                     f"mkdir -p {_parent}",
@@ -732,7 +745,8 @@ class ModalSandbox(BaseSandbox):
             container_path = self._vpath(path)
             try:
                 content = self._run_with_fallback(
-                    lambda p=container_path: self._sandbox.filesystem.read_bytes(p),
+                    # Re-reads self._sandbox so a restart is picked up.
+                    lambda p=container_path: self._sandbox.filesystem.read_bytes(p),  # pyright: ignore[reportOptionalMemberAccess]
                     label=f"download {path}",
                 )
                 results.append(FileDownloadResponse(path=path, content=content))
@@ -841,7 +855,8 @@ class ModalSandbox(BaseSandbox):
             self._log(f"workspace tarball size: {size_out.strip()} bytes")
 
             data = _retry_transient(
-                lambda: self._sandbox.filesystem.read_bytes(tar_remote),
+                # Re-reads self._sandbox so a restart is picked up.
+                lambda: self._sandbox.filesystem.read_bytes(tar_remote),  # pyright: ignore[reportOptionalMemberAccess]
                 log=self._log,
                 label="workspace tar download",
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "diff-cover",
     "hypothesis",
     "matplotlib>=3.10.8",
+    "pyright>=1.1.411",
     "pytest",
     "pytest-cov",
     "ruff>=0.6",
@@ -70,6 +71,17 @@ src = ["src", "tests", "libs/vs-feature-flags/src", "libs/vs-feature-flags/tests
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "W"]
 ignore = ["E501"]
+
+[tool.pyright]
+typeCheckingMode = "basic"
+pythonVersion = "3.11"
+include = ["src", "libs/vs-feature-flags/src", "libs/vs-issue-board/src", "libs/vs-sandbox/src"]
+executionEnvironments = [
+    { root = "libs/vs-feature-flags/src" },
+    { root = "libs/vs-issue-board/src" },
+    { root = "libs/vs-sandbox/src" },
+    { root = "src" },
+]
 
 [tool.uv]
 package = true

--- a/scripts/check_types.sh
+++ b/scripts/check_types.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv run pyright

--- a/src/vibesys/_agent_cli/base.py
+++ b/src/vibesys/_agent_cli/base.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .hostsandbox import WorkspaceSandbox
+
 
 @dataclass
 class MCPServerSpec:
@@ -31,6 +33,17 @@ class CodingAgent(ABC):
     """Abstract base class for coding agents."""
 
     event_handler: Any | None = None
+
+    # Declared (not assigned) here: every concrete provider sets these in its
+    # ``__init__``.  ``env`` is the subprocess environment the CLI is spawned
+    # with; ``executor`` is the agentshim ``CommandExecutor`` (host, docker,
+    # or modal) that runs the CLI binary.
+    env: dict[str, str]
+    executor: Any
+
+    # Optional OS-level confinement for host execution (issue #149); set by
+    # the cli runner on the host path, left as None under container executors.
+    sandbox: WorkspaceSandbox | None
 
     @abstractmethod
     def generate(

--- a/src/vibesys/agent_runner.py
+++ b/src/vibesys/agent_runner.py
@@ -19,6 +19,7 @@ from vibesys.schemas import (
     ProfilerResponse,
     Verdict,
 )
+from vibesys.server.events import AgentOutputChannel
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -159,7 +160,7 @@ def _log_markdown_and_print(
     log_file=None,
     max_len: int | None = None,
     *,
-    channel: str = "assistant",
+    channel: AgentOutputChannel = "assistant",
 ) -> None:
     """Emit raw Markdown; presentation clients decide how to render it."""
     from vibesys.server.registry import active_supervisor

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -9,6 +9,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 
 from vibesys.agents.progress import AgentProgress
 from vibesys.constants import _DIM, _GREEN, _RESET, _YELLOW
+from vibesys.server.events import AgentOutputChannel
 
 ContextWindowLookup = Callable[[str | None], int | None]
 """Resolves a model name to its context window size in tokens.
@@ -477,7 +478,7 @@ class AgentLogger(BaseCallbackHandler):
         """Format a tool result the same way ``on_tool_end`` does."""
         self._print_tool_result(name, content)
 
-    def _publish(self, content: str, channel: str) -> None:
+    def _publish(self, content: str, channel: AgentOutputChannel) -> None:
         from vibesys.server.registry import active_supervisor
 
         supervisor = active_supervisor()

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -24,7 +24,7 @@ import shutil
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, Protocol, TypeVar
 
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel
@@ -49,7 +49,19 @@ from vibesys.agents.progress import AgentProgress
 T = TypeVar("T", bound=BaseModel)
 
 
-_PROVIDER_CLASSES: dict[str, type[CodingAgent]] = {
+class _ProviderFactory(Protocol):
+    """Constructor signature shared by every CLI provider agent class."""
+
+    def __call__(
+        self,
+        model: str | None = None,
+        event_handler: Any | None = None,
+        *,
+        executor: Any | None = None,
+    ) -> CodingAgent: ...
+
+
+_PROVIDER_CLASSES: dict[str, _ProviderFactory] = {
     "claude": ClaudeCodeCodingAgent,
     "gemini": GeminiCodingAgent,
     "codex": CodexCodingAgent,
@@ -241,8 +253,10 @@ class CliAgentRunner:
             # Modal sandbox was recreated after a fallback restart); refresh
             # the runner so the next exec targets the live container.
             if self._docker_sandboxes is not None:
+                # Dynamic poke: only the docker path constructs agents with a
+                # DockerCommandExecutor, which carries container_id.
                 executor = getattr(agent, "executor", None)
-                executor.container_id = self._docker_sandboxes[kind]._container_id
+                executor.container_id = self._docker_sandboxes[kind]._container_id  # pyright: ignore[reportOptionalMemberAccess]
             # ModalCommandExecutor reads ``_modal_sandbox._sandbox`` on every
             # ``run()``, so a fallback-triggered sandbox restart is picked up
             # automatically — no per-invocation refresh needed here.
@@ -268,7 +282,8 @@ class CliAgentRunner:
                 executor=executor,
             )
             if self._provider == "codex" and hasattr(agent, "base_config_args"):
-                agent.base_config_args = [
+                # Codex-only attribute, guarded by the hasattr check above.
+                agent.base_config_args = [  # pyright: ignore[reportAttributeAccessIssue]
                     "--config",
                     'cli_auth_credentials_store="file"',
                     "--config",

--- a/src/vibesys/agents/docker_executor.py
+++ b/src/vibesys/agents/docker_executor.py
@@ -8,7 +8,7 @@ import subprocess
 import threading
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from agentshim.executor import CommandRequest, CommandResult, CommandStreamSink
 
@@ -124,7 +124,11 @@ class DockerCommandExecutor:
         except subprocess.TimeoutExpired:
             self._kill_process_group(process)
             process.wait()
-            raise subprocess.TimeoutExpired(list(request.argv), request.timeout) from None
+            # TimeoutExpired is only raised by the wait(timeout=...) branch,
+            # so request.timeout is non-None on this path.
+            raise subprocess.TimeoutExpired(
+                list(request.argv), cast(float, request.timeout)
+            ) from None
         finally:
             if process.poll() is None:
                 self._kill_process_group(process)

--- a/src/vibesys/backends/base.py
+++ b/src/vibesys/backends/base.py
@@ -20,6 +20,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
+from deepagents.backends.protocol import SandboxBackendProtocol
 from deepagents.backends.sandbox import BaseSandbox
 
 from vibesys.constants import ComputeBackend
@@ -76,7 +77,7 @@ class ComputeBackendImpl(Protocol):
         extra_init_commands: list[str],
         setup_fns: list[SetupFn] | None = None,
         modal_options: ModalOptions | None = None,
-    ) -> BaseSandbox:
+    ) -> SandboxBackendProtocol:
         """Construct (do not start) a sandbox configured for this backend.
 
         ``setup_fns`` are invoked by the sandbox at the end of every

--- a/src/vibesys/backends/cuda/__init__.py
+++ b/src/vibesys/backends/cuda/__init__.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from pathlib import Path
 
 from deepagents.backends import LocalShellBackend
-from deepagents.backends.sandbox import BaseSandbox
+from deepagents.backends.protocol import SandboxBackendProtocol
 
 from vibesys.backends.base import (
     ContentionMonitor,
@@ -61,7 +61,7 @@ class CudaBackend:
         # (kind, sandbox) tuples — kind is recorded at registration time so
         # ``reselect_device`` can dispatch without isinstance checks against
         # cross-package types (which break test mocking).
-        self._sandboxes: list[tuple[SandboxKind, BaseSandbox]] = []
+        self._sandboxes: list[tuple[SandboxKind, SandboxBackendProtocol]] = []
 
     # -- ComputeBackendImpl protocol ---------------------------------------------
 
@@ -77,7 +77,7 @@ class CudaBackend:
         extra_init_commands: list[str] | None = None,
         setup_fns: list[SetupFn] | None = None,
         modal_options: ModalOptions | None = None,
-    ) -> BaseSandbox:
+    ) -> SandboxBackendProtocol:
         """Construct a sandbox configured for CUDA execution."""
         bind_mounts = bind_mounts or []
         passthrough_paths = passthrough_paths or []
@@ -171,16 +171,19 @@ class CudaBackend:
         )
         self._save_gpu_metadata(new_gpu)
 
+        # Kind-dispatched pokes at sandbox internals: DOCKER entries are
+        # always DockerSandbox (stop/start/_gpus), LOCAL entries are always
+        # LocalShellBackend (_env).
         for kind, sb in self._sandboxes:
             if kind is SandboxKind.DOCKER:
-                sb.stop()
-                sb._gpus = self._docker_gpu_spec()
-                sb.start()  # re-runs setup_fns
+                sb.stop()  # pyright: ignore[reportAttributeAccessIssue]
+                sb._gpus = self._docker_gpu_spec()  # pyright: ignore[reportAttributeAccessIssue]
+                sb.start()  # re-runs setup_fns  # pyright: ignore[reportAttributeAccessIssue]
             elif kind is SandboxKind.LOCAL:
                 env = getattr(sb, "_env", None)
                 if env is None:
                     env = {}
-                    sb._env = env
+                    sb._env = env  # pyright: ignore[reportAttributeAccessIssue]
                 env["CUDA_VISIBLE_DEVICES"] = str(new_gpu.index)
             # SandboxKind.MODAL: remote GPU, nothing to restart.
 

--- a/src/vibesys/backends/local.py
+++ b/src/vibesys/backends/local.py
@@ -19,7 +19,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from deepagents.backends import LocalShellBackend
-from deepagents.backends.sandbox import BaseSandbox
+from deepagents.backends.protocol import SandboxBackendProtocol
 
 from vibesys.backends.base import (
     ContentionMonitor,
@@ -73,7 +73,7 @@ class LocalBackend:
         extra_init_commands: list[str] | None = None,
         setup_fns: list[SetupFn] | None = None,
         modal_options: ModalOptions | None = None,
-    ) -> BaseSandbox:
+    ) -> SandboxBackendProtocol:
         bind_mounts = list(bind_mounts or [])
         passthrough_paths = list(passthrough_paths or [])
         extra_env = dict(extra_env or {})

--- a/src/vibesys/backends/trainium/__init__.py
+++ b/src/vibesys/backends/trainium/__init__.py
@@ -27,7 +27,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from deepagents.backends import LocalShellBackend
-from deepagents.backends.sandbox import BaseSandbox
+from deepagents.backends.protocol import SandboxBackendProtocol
 
 from vibesys.backends.base import (
     ContentionMonitor,
@@ -117,7 +117,7 @@ class TrainiumBackend:
         extra_init_commands: list[str] | None = None,
         setup_fns: list[SetupFn] | None = None,
         modal_options: ModalOptions | None = None,
-    ) -> BaseSandbox:
+    ) -> SandboxBackendProtocol:
         bind_mounts = list(bind_mounts or [])
         passthrough_paths = list(passthrough_paths or [])
         extra_env = dict(extra_env or {})

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -7,10 +7,11 @@ import shutil
 import subprocess
 import sys
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import ExitStack, contextmanager
 from datetime import datetime
 from pathlib import Path
+from typing import Any, overload
 
 from vibesys import backends
 from vibesys.agent_runner import _log_and_print
@@ -461,7 +462,7 @@ class _RunContext:
         system_prompt: str,
         user_prompt: str,
         response_cls,
-        fallback_factory=None,
+        fallback_factory: Callable[[], Any] | None = None,
         round_label: str = "",
         progress: AgentProgress | None = None,
         **extra,
@@ -487,7 +488,9 @@ class _RunContext:
                 env=self.gpu_env(),
                 user_prompt=user_prompt,
                 response_cls=response_cls,
-                fallback_factory=fallback_factory,
+                # Every live call site supplies a factory; the None default
+                # is a legacy convenience.
+                fallback_factory=fallback_factory,  # pyright: ignore[reportArgumentType]
                 round_label=round_label,
                 progress=progress if progress is not None else self.current_progress(),
                 **extra,
@@ -510,6 +513,12 @@ class _RunContext:
         if not p.is_dir():
             raise ValueError(f"{label} path is not a directory: {raw}")
         return p
+
+    @overload
+    def _coerce_dir_path(self, raw: str, label: str) -> str: ...
+
+    @overload
+    def _coerce_dir_path(self, raw: None, label: str) -> None: ...
 
     def _coerce_dir_path(self, raw: str | None, label: str) -> str | None:
         path = self._coerce_dir(raw, label)
@@ -695,7 +704,7 @@ class _RunContext:
         # run end — so this is safe to run on every snapshot.
         if hasattr(self.implementer_backend, "_download_workspace"):
             try:
-                self.implementer_backend._download_workspace()
+                self.implementer_backend._download_workspace()  # pyright: ignore[reportAttributeAccessIssue]
             except Exception as exc:
                 self.lprint(f"[warn] modal workspace sync to host failed: {exc}")
 
@@ -974,7 +983,7 @@ class _RunContext:
         # Update the agent runner's log file handle so subsequent
         # invoke() calls write to the new step log.
         if hasattr(self, "agent_runner") and hasattr(self.agent_runner, "_run_log_file"):
-            self.agent_runner._run_log_file = new_file
+            self.agent_runner._run_log_file = new_file  # pyright: ignore[reportAttributeAccessIssue]
 
     def reselect_gpu(self) -> None:
         """Delegate mid-run device rebalance to the backend.

--- a/src/vibesys/llm_client.py
+++ b/src/vibesys/llm_client.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+from pydantic import SecretStr
+
 from vibesys.config import Config, ThinkingCfg
 from vibesys.constants import _ANTHROPIC_PREFIXES, _GOOGLE_PREFIXES, _OPENAI_PREFIXES
 
@@ -81,17 +83,15 @@ def _build_openai_compatible_model(model_name: str, config: Config):
     from langchain_openai import ChatOpenAI
 
     oc = config.providers.openai_compatible
-    base_url = oc.base_url if oc else None
-    if not base_url:
+    if oc is None or not oc.base_url:
         raise ValueError(
             "openai-compatible provider requires 'base_url' (e.g. 'http://localhost:8000/v1')"
         )
-    api_key = oc.api_key
 
     return ChatOpenAI(
         model=model_name,
-        base_url=base_url,
-        api_key=api_key,
+        base_url=oc.base_url,
+        api_key=SecretStr(oc.api_key),
     )
 
 

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -117,11 +117,14 @@ def _save_rounds_state(path: Path, records: list[_RoundRecord]) -> None:
 
 def _best_round(records: list[_RoundRecord]) -> _RoundRecord | None:
     best: _RoundRecord | None = None
+    best_metric = float("-inf")
     for r in records:
-        if r.perf_metric is None or not r.passed:
+        metric = r.perf_metric
+        if metric is None or not r.passed:
             continue
-        if best is None or r.perf_metric > best.perf_metric:
+        if best is None or metric > best_metric:
             best = r
+            best_metric = metric
     return best
 
 
@@ -163,7 +166,7 @@ def _detect_plateau(
     if len(same_unit) < min_streak:
         return None
     tail = same_unit[-min_streak:]
-    perfs = [r.perf_metric for r in tail]
+    perfs = [r.perf_metric for r in tail if r.perf_metric is not None]
     hi = max(perfs)
     lo = min(perfs)
     if hi <= 0:
@@ -1203,7 +1206,12 @@ def run_agent_loop(
                     carry.exhaustion_info = None
                     if perf_metric is not None:
                         best = _best_round(records[:-1])
-                        if best is None or perf_metric > best.perf_metric:
+                        # _best_round only returns rounds with a metric.
+                        if (
+                            best is None
+                            or best.perf_metric is None
+                            or perf_metric > best.perf_metric
+                        ):
                             carry.regression_info = None
                         else:
                             carry.regression_info = (

--- a/src/vibesys/loops/evolve/population.py
+++ b/src/vibesys/loops/evolve/population.py
@@ -194,15 +194,14 @@ class Population:
         Ties broken by latest id (most recent wins).
         """
         best: Individual | None = None
+        best_metric = float("-inf")
         for ind in self.passed:
-            if ind.perf_metric is None:
+            metric = ind.perf_metric
+            if metric is None:
                 continue
-            if (
-                best is None
-                or ind.perf_metric > best.perf_metric
-                or (ind.perf_metric == best.perf_metric and ind.id > best.id)
-            ):
+            if best is None or metric > best_metric or (metric == best_metric and ind.id > best.id):
                 best = ind
+                best_metric = metric
         return best
 
     # -- frontier ------------------------------------------------------------
@@ -266,7 +265,7 @@ class Population:
             return None
         if len(ranked) == 1:
             return ranked[0]
-        perfs = [i.perf_metric for i in ranked]
+        perfs = [i.perf_metric for i in ranked if i.perf_metric is not None]
         lo, hi = min(perfs), max(perfs)
         if hi - lo < 1e-12:
             return rng.choice(ranked)
@@ -325,11 +324,17 @@ class Population:
             # Backfill from non-frontier if the frontier is smaller than k_top.
             if len(top) < k_top:
                 non_front = [i for i in pool if i.id not in front_ids and i.perf_metric is not None]
-                non_front.sort(key=lambda i: i.perf_metric, reverse=True)
+                non_front.sort(
+                    key=lambda i: i.perf_metric if i.perf_metric is not None else float("-inf"),
+                    reverse=True,
+                )
                 top.extend(non_front[: k_top - len(top)])
         else:
             ranked = [i for i in pool if i.perf_metric is not None]
-            ranked.sort(key=lambda i: i.perf_metric, reverse=True)
+            ranked.sort(
+                key=lambda i: i.perf_metric if i.perf_metric is not None else float("-inf"),
+                reverse=True,
+            )
             top = ranked[:k_top]
 
         top_ids = {i.id for i in top}

--- a/src/vibesys/loops/plain/loop.py
+++ b/src/vibesys/loops/plain/loop.py
@@ -433,7 +433,9 @@ def run_plain_loop(
         # MCP server spec under cli). The wrapper consumes an extra
         # ``iteration=`` kwarg on invoke() that the loop passes per call.
         # See vibesys/plain/runner_ext.py.
-        ctx.agent_runner = PlainLoopAgentRunner(
+        # Duck-typed wrapper: preserves the AgentRunner surface the issue
+        # loop uses (see PlainLoopAgentRunner docstring).
+        ctx.agent_runner = PlainLoopAgentRunner(  # pyright: ignore[reportAttributeAccessIssue]
             ctx.agent_runner,
             store=store,
             max_issues_per_perf_eval=max_issues_per_perf_eval,

--- a/src/vibesys/profilers.py
+++ b/src/vibesys/profilers.py
@@ -194,7 +194,7 @@ def resolve_profiler_kind(
     # environment's torch default over a local CUDA backend's nsys preference.
     if environment_default is ProfilerKind.TORCH:
         candidate = ProfilerKind.TORCH
-    elif backend_profiler in ACTIVE_PROFILER_KINDS:
+    elif backend_profiler is not None and backend_profiler in ACTIVE_PROFILER_KINDS:
         candidate = backend_profiler
     else:
         candidate = environment_default

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -34,6 +34,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
+from deepagents.backends.protocol import SandboxBackendProtocol
 from deepagents.backends.sandbox import BaseSandbox
 
 from vibesys.backends import SandboxKind
@@ -101,7 +102,7 @@ class RunEnvironmentRequest:
 
 
 class RunEnvironmentSession(Protocol):
-    sandbox: BaseSandbox
+    sandbox: SandboxBackendProtocol
     view: RunEnvironmentView
 
     def __enter__(self) -> RunEnvironmentSession: ...
@@ -138,7 +139,7 @@ class _NoopWorkspaceRecovery:
 
 @dataclass
 class _DefaultRunEnvironmentSession:
-    sandbox: BaseSandbox
+    sandbox: SandboxBackendProtocol
     view: RunEnvironmentView
     stop_on_close: bool = False
     _closed: bool = False
@@ -154,14 +155,14 @@ class _DefaultRunEnvironmentSession:
             return
         self._closed = True
         if self.stop_on_close and hasattr(self.sandbox, "stop"):
-            self.sandbox.stop()
+            self.sandbox.stop()  # pyright: ignore[reportAttributeAccessIssue]
 
 
 class LocalEnvironment(_NoopWorkspaceRecovery):
-    isolated = False
-    materialize_local_model_weights = True
-    default_profiler_kind = ProfilerKind.NSYS
-    backend_image = None
+    isolated: bool = False
+    materialize_local_model_weights: bool = True
+    default_profiler_kind: ProfilerKind = ProfilerKind.NSYS
+    backend_image: str | None = None
 
     def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession:
         sandbox = request.backend.make_sandbox(
@@ -224,7 +225,8 @@ class DockerEnvironment:
         log = request.log or (lambda _: None)
         label = getattr(request.backend, "image", self.config.image or "<backend-default>")
         log(f"[docker] starting container with image {label}")
-        sandbox.start()
+        # DOCKER-kind sandboxes always implement start().
+        sandbox.start()  # pyright: ignore[reportAttributeAccessIssue]
 
         return _DefaultRunEnvironmentSession(
             sandbox=sandbox,
@@ -370,7 +372,8 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
             "[modal] starting local Docker editor; GPU work will dispatch "
             "to Modal via `modal run main.py::<function>`"
         )
-        sandbox.start()
+        # DOCKER-kind sandboxes always implement start().
+        sandbox.start()  # pyright: ignore[reportAttributeAccessIssue]
 
         app_name = _modal_app_name(request.workspace, fallback=self.config.app)
         return _DefaultRunEnvironmentSession(
@@ -793,7 +796,7 @@ def _symlink_setup_fns(symlinks: list[tuple[str, str]]) -> list[SetupFn]:
         for cmd in symlink_cmds:
             sb.execute(cmd)
         if hasattr(sb, "save_symlink_commands"):
-            sb.save_symlink_commands(symlink_cmds)
+            sb.save_symlink_commands(symlink_cmds)  # pyright: ignore[reportAttributeAccessIssue]
 
     return [install_symlinks]
 

--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -44,6 +44,13 @@ class EventStatus(StrEnum):
     FAILED = "failed"
 
 
+OutputStream = Literal["stdout", "stderr"]
+"""Which host stream a captured line of backend output came from."""
+
+AgentOutputChannel = Literal["assistant", "analysis", "tool", "diagnostic", "prompt"]
+"""Presentation channel for streamed agent output."""
+
+
 class ChatData(BaseModel):
     kind: Literal["chat"] = "chat"
     answer: str
@@ -63,7 +70,7 @@ class InvocationFinishedData(BaseModel):
 
 class OutputData(BaseModel):
     kind: Literal["output"] = "output"
-    stream: Literal["stdout", "stderr"]
+    stream: OutputStream
     source: str = "backend"
     content: str
 
@@ -103,7 +110,7 @@ class PhaseData(BaseModel):
 
 class AgentOutputChunkData(BaseModel):
     kind: Literal["agent_output_chunk"] = "agent_output_chunk"
-    channel: Literal["assistant", "analysis", "tool", "diagnostic", "prompt"]
+    channel: AgentOutputChannel
     content: str
 
 
@@ -111,7 +118,7 @@ class SubprocessOutputData(BaseModel):
     kind: Literal["subprocess_output"] = "subprocess_output"
     process_id: str
     process_kind: str
-    stream: Literal["stdout", "stderr"]
+    stream: OutputStream
     content: str
 
 

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from vibesys.server.events import (
+    AgentOutputChannel,
     AgentOutputChunkData,
     ChatData,
     EventData,
@@ -18,6 +19,7 @@ from vibesys.server.events import (
     InvocationFinishedData,
     InvocationStartedData,
     OutputData,
+    OutputStream,
     PhaseData,
     RunEvent,
     json_value,
@@ -69,7 +71,7 @@ class RunSupervisor:
         with self._condition:
             self._run_status = "running"
 
-    def publish_output(self, stream: str, content: str, source: str = "backend") -> None:
+    def publish_output(self, stream: OutputStream, content: str, source: str = "backend") -> None:
         if not content:
             return
         self.record(
@@ -81,7 +83,7 @@ class RunSupervisor:
         self,
         content: str,
         *,
-        channel: str = "assistant",
+        channel: AgentOutputChannel = "assistant",
         agent_kind: str | None = None,
         invocation_id: str | None = None,
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2644,6 +2644,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "numba"
 version = "0.65.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3507,6 +3516,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]
@@ -4637,6 +4659,7 @@ dev = [
     { name = "diff-cover" },
     { name = "hypothesis" },
     { name = "matplotlib" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -4677,6 +4700,7 @@ dev = [
     { name = "diff-cover" },
     { name = "hypothesis" },
     { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "pyright", specifier = ">=1.1.411" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff", specifier = ">=0.6" },


### PR DESCRIPTION
## Problem

The TypeScript client is type-checked in CI (`pnpm --dir clients/tui check`), but the Python core — ~80 modules under `src/vibesys/` plus the `libs/` workspace packages — has no static type gate at all. The codebase is written in a typed style (Pydantic contracts, `StrEnum`/`Literal` closed sets, annotated protocols), yet nothing enforces that the annotations stay truthful, so drift accumulates silently: several sandbox annotations claimed `BaseSandbox` where the object was not one, publisher APIs accepted arbitrary `str` for closed Literal sets, and a handful of `Optional` values were compared or dereferenced without narrowing.

## Solution

Add **pyright in `basic` mode** as the Python type gate, scoped to `src/` and `libs/*/src` (config in `pyproject.toml`, pyright as a uv dev dependency). A new `scripts/check_types.sh` mirrors the existing `check_*` scripts, and a `typecheck` CI job in `.github/workflows/test.yml` runs it with the same uv-based setup as the `format`/`lint` jobs.

The baseline run reported **66 errors**. **43 were fixed properly** (annotations, honest retyping, provably-equivalent `None` narrowing) and **23 are suppressed** with narrowly-scoped, commented `# pyright: ignore[code]` lines at intentionally-dynamic call sites. No modules are excluded; `tests/` and `examples/` are out of scope for this PR to keep it reviewable. No runtime behavior changes.

Highlights of the real fixes:

- `ComputeBackendImpl.make_sandbox` (and impls, and `RunEnvironmentSession.sandbox`) now return `SandboxBackendProtocol` — the actual common base of `DockerSandbox`/`ModalSandbox`/`LocalShellBackend` — instead of `BaseSandbox`, which `LocalShellBackend` never was.
- `DockerSandbox`/`ModalSandbox` `setup_fns` parameters accept `Callable[[BaseSandbox], None]`, matching the `SetupFn` alias callers pass.
- `CodingAgent` ABC declares (annotation-only, no runtime attributes) the `env`/`executor`/`sandbox` contract every provider sets in `__init__`; a `_ProviderFactory` Protocol types the shared provider constructor signature.
- `server/events.py` gains `OutputStream` and `AgentOutputChannel` Literal aliases, threaded through `RunSupervisor.publish_output` / `publish_agent_output` and their callers (generated protocol schema verified byte-identical).
- `float | None` perf-metric comparisons in `loops/agent/loop.py` and `loops/evolve/population.py` rewritten with equivalent narrowing (tracked best-metric locals, non-None comprehension filters).
- Misc: `llm_client` narrows the `openai_compatible` config before use; `profilers` narrows an Optional membership test; `modal_model_setup` fixes a `log: callable` annotation; `_coerce_dir_path` gains overloads.

The 23 suppressions cluster where dynamism is deliberate: `ModalSandbox` closures that re-read `self._sandbox` so restarts are picked up (9), kind-dispatched pokes at sandbox internals in `CudaBackend.reselect_device` and `run_environment` start/stop (8), and hasattr-guarded duck-typing in `context.py`/`cli_runner.py`/`plain/loop.py` (6). Each carries a comment explaining why.

### Architecture

No ownership changes. The type gate sits beside the existing format/lint gates: `pyproject.toml` (`[tool.pyright]`, per-package `executionEnvironments` for `src` and each `libs/*/src`) → `scripts/check_types.sh` → the `typecheck` CI job. All source edits stay inside the module that owns each surface; cross-boundary types were corrected to the contracts the code already implements (deepagents' `SandboxBackendProtocol`, the provider-agent constructor shape, the event Literal sets).

## Verification

### Correctness properties

- No runtime behavior changes: edits are annotations, `Literal`/Protocol declarations, per-line ignores, and control-flow rewrites that are provably equivalent (e.g. dead `None` branches, filters over already-non-None lists, `cast()`).
- The generated TUI protocol schema is byte-identical after the `events.py` Literal-alias refactor (verified via `python -m vibesys.server.schema` + diff).
- `./scripts/check_types.sh` exits non-zero on any pyright error, so the gate fails closed in CI.
- Tightened signatures (`publish_output`, `publish_agent_output`, `_publish`, `_log_markdown_and_print`) only accept values every existing caller already passes as literals.

### Testing

- `./scripts/check_types.sh` — 0 errors (3 pre-existing-pattern warnings; warnings do not fail the gate)
- `./scripts/check_format.sh` — pass
- `./scripts/check_lint.sh` — pass
- `uv run pytest` — full suite green on the pre-#167/#174 rebase (1774 passed); after the final rebase: targeted run `uv run pytest tests -q -k "agent or sandbox or loop or event or supervisor or profil or population or llm or config or cli"` — 1455 passed, 1 skipped (macOS-only), plus a full-suite re-run
- `pnpm`-generated protocol schema diffed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
