### PR TITLE
Upgrade pyright to strict mode

### DIFF
--- a/libs/vs-issue-board/src/vs_issue_board/core.py
+++ b/libs/vs-issue-board/src/vs_issue_board/core.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
 from threading import RLock
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -46,7 +47,7 @@ class IssueEvent(BaseModel):
     action: str
     iteration: int | None = None
     note: str = ""
-    payload: dict | None = None
+    payload: dict[str, Any] | None = None
 
 
 class Issue(BaseModel):
@@ -78,7 +79,7 @@ class IssueBoard:
         self.path = Path(path)
         self._lock = RLock()
         self._on_change: Callable[[], None] | None = None
-        self._data: dict = {
+        self._data: dict[str, Any] = {
             "version": _STORE_VERSION,
             "next_id": 1,
             "issues": [],
@@ -120,7 +121,7 @@ class IssueBoard:
             if isinstance(loaded, dict) and loaded.get("version") == _STORE_VERSION:
                 self._data = loaded
 
-    def _issue_from_dict(self, raw: dict) -> Issue:
+    def _issue_from_dict(self, raw: dict[str, Any]) -> Issue:
         return Issue.model_validate(raw)
 
     def _replace_issue(self, issue: Issue) -> None:
@@ -183,7 +184,7 @@ class IssueBoard:
         actor: str,
         iteration: int,
         note: str = "",
-        payload: dict | None = None,
+        payload: dict[str, Any] | None = None,
     ) -> Issue:
         if not isinstance(status, IssueStatus):
             status = IssueStatus(status)
@@ -252,7 +253,7 @@ class IssueBoard:
         actor: str,
         iteration: int,
         note: str = "",
-        payload: dict | None = None,
+        payload: dict[str, Any] | None = None,
     ) -> Issue:
         with self._lock:
             issue = self.get(issue_id)

--- a/libs/vs-issue-board/src/vs_issue_board/mcp.py
+++ b/libs/vs-issue-board/src/vs_issue_board/mcp.py
@@ -86,7 +86,7 @@ def build_server(args: argparse.Namespace) -> FastMCP:
     mcp = FastMCP("issue-board")
 
     @mcp.tool()
-    def list_issues(status: str | None = None) -> str:
+    def list_issues(status: str | None = None) -> str:  # pyright: ignore[reportUnusedFunction]
         """List issues. Optional status filter: 'open', 'in_progress', 'closed', 'blocked'."""
         store.reload()
         try:
@@ -102,7 +102,7 @@ def build_server(args: argparse.Namespace) -> FastMCP:
         return "\n".join(format_issue_short(i) for i in issues)
 
     @mcp.tool()
-    def get_issue(issue_id: int) -> str:
+    def get_issue(issue_id: int) -> str:  # pyright: ignore[reportUnusedFunction]
         """Return the full body of an issue by id."""
         store.reload()
         issue = store.get(issue_id)
@@ -111,7 +111,7 @@ def build_server(args: argparse.Namespace) -> FastMCP:
         return format_issue_full(issue)
 
     @mcp.tool()
-    def search_issues(query: str) -> str:
+    def search_issues(query: str) -> str:  # pyright: ignore[reportUnusedFunction]
         """Substring search across all issues' title+description.
 
         Use comma-separated keywords for AND-matching, e.g. 'kv cache, paged'.
@@ -126,7 +126,7 @@ def build_server(args: argparse.Namespace) -> FastMCP:
     if not args.read_only:
 
         @mcp.tool()
-        def create_issue(type: str, title: str, description: str) -> str:
+        def create_issue(type: str, title: str, description: str) -> str:  # pyright: ignore[reportUnusedFunction]
             """Create a new issue.
 
             Args:

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -12,6 +12,7 @@ import tempfile
 import uuid
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from deepagents.backends.protocol import (
     EditResult,
@@ -21,6 +22,9 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.sandbox import BaseSandbox
+
+if TYPE_CHECKING:
+    from types import FrameType
 
 # Global registry of live containers for cleanup on exit / SIGINT.
 _live_containers: dict[str, str] = {}  # container_id -> container_name
@@ -56,7 +60,7 @@ atexit.register(_cleanup_containers)
 _original_sigint = signal.getsignal(signal.SIGINT)
 
 
-def _sigint_handler(signum, frame):
+def _sigint_handler(signum: int, frame: FrameType | None) -> None:
     """Ensure cleanup runs then re-raise the interrupt."""
     # Restore original handler FIRST to prevent recursive re-entry
     # if another SIGINT arrives during cleanup.
@@ -179,7 +183,7 @@ class DockerSandbox(BaseSandbox):
     def _log_cmd(
         self,
         cmd: list[str],
-        result: subprocess.CompletedProcess | None = None,
+        result: subprocess.CompletedProcess[str] | None = None,
         error: str | None = None,
     ) -> None:
         if self._logger is None:
@@ -646,5 +650,5 @@ class DockerSandbox(BaseSandbox):
         self.start()
         return self
 
-    def __exit__(self, *exc) -> None:
+    def __exit__(self, *exc: object) -> None:
         self.stop()

--- a/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
@@ -28,7 +28,7 @@ import time
 import uuid
 from collections.abc import Callable
 from pathlib import Path, PurePosixPath
-from typing import TypeVar, cast
+from typing import TYPE_CHECKING, TypeVar, cast
 
 import modal
 from deepagents.backends.protocol import (
@@ -39,6 +39,9 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.sandbox import BaseSandbox
 from modal.volume import AbstractVolumeUploadContextManager
+
+if TYPE_CHECKING:
+    from types import FrameType
 
 # Global registry of live sandboxes for cleanup on exit / SIGINT.
 _live_sandboxes: dict[str, ModalSandbox] = {}
@@ -150,7 +153,7 @@ atexit.register(_cleanup_sandboxes)
 _original_sigint = signal.getsignal(signal.SIGINT)
 
 
-def _sigint_handler(signum, frame):
+def _sigint_handler(signum: int, frame: FrameType | None) -> None:
     signal.signal(signal.SIGINT, _original_sigint)
     _cleanup_sandboxes()
     if callable(_original_sigint):
@@ -341,7 +344,7 @@ class ModalSandbox(BaseSandbox):
         ).run_commands(f"rm -rf {self._CONTAINER_ROOT} && mkdir {self._CONTAINER_ROOT}")
 
         # _workspace_volume is created by start() before _create_container().
-        volumes: dict[str | os.PathLike, modal.Volume | modal.CloudBucketMount] = {
+        volumes: dict[str | os.PathLike[str], modal.Volume | modal.CloudBucketMount] = {
             self._CONTAINER_ROOT: self._workspace_volume  # pyright: ignore[reportOptionalMemberAccess,reportAssignmentType]
         }
         if self._model_volume_name:
@@ -892,5 +895,5 @@ class ModalSandbox(BaseSandbox):
         self.start()
         return self
 
-    def __exit__(self, *exc) -> None:
+    def __exit__(self, *exc: object) -> None:
         self.stop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,16 @@ select = ["E", "F", "I", "UP", "B", "W"]
 ignore = ["E501"]
 
 [tool.pyright]
-typeCheckingMode = "basic"
+typeCheckingMode = "strict"
+# Strict minus the three rules below: untyped third-party dependencies
+# (deepagents, langchain, modal, docker SDKs) leak Unknown into member
+# accesses, inferred variables, and call arguments throughout the agent
+# runner and loop code. Declared annotations remain fully enforced via
+# reportUnknownParameterType / reportMissingParameterType /
+# reportMissingTypeArgument, which stay at strict defaults.
+reportUnknownMemberType = "none"
+reportUnknownVariableType = "none"
+reportUnknownArgumentType = "none"
 pythonVersion = "3.11"
 include = ["src", "libs/vs-feature-flags/src", "libs/vs-issue-board/src", "libs/vs-sandbox/src"]
 executionEnvironments = [

--- a/src/vibesys/_agent_cli/claude.py
+++ b/src/vibesys/_agent_cli/claude.py
@@ -1,12 +1,15 @@
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from agentshim.claude import ClaudeGenerationSession
 from agentshim.events import AgentEventHandler
 
 from .base import MCPServerSpec
 from .cli_agent import CLICodingAgent
+
+if TYPE_CHECKING:
+    from agentshim.executor import CommandExecutor
 
 
 class ClaudeCodeCodingAgent(CLICodingAgent):
@@ -17,7 +20,7 @@ class ClaudeCodeCodingAgent(CLICodingAgent):
         model: str | None = None,
         event_handler: AgentEventHandler | None = None,
         *,
-        executor=None,
+        executor: "CommandExecutor | None" = None,
     ):
         """Initialize the Claude Code coding agent.
 
@@ -71,10 +74,10 @@ class ClaudeCodeCodingAgent(CLICodingAgent):
             cmd.extend(["--model", self.model])
         return cmd
 
-    def _extract_session_id(self, session: ClaudeGenerationSession) -> str | None:
+    def _extract_session_id(self, session: ClaudeGenerationSession) -> str | None:  # pyright: ignore[reportIncompatibleMethodOverride]
         return session.session_id
 
-    def _create_session(
+    def _create_session(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         cmd: list[str],
         cwd: str | None = None,

--- a/src/vibesys/_agent_cli/codex.py
+++ b/src/vibesys/_agent_cli/codex.py
@@ -1,10 +1,14 @@
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from agentshim.codex import CodexGenerationSession
 from agentshim.events import AgentEventHandler
 
 from .base import MCPServerSpec
 from .cli_agent import CLICodingAgent
+
+if TYPE_CHECKING:
+    from agentshim.executor import CommandExecutor
 
 
 def _toml_str(value: str) -> str:
@@ -26,7 +30,7 @@ class CodexCodingAgent(CLICodingAgent):
         model: str | None = None,
         event_handler: AgentEventHandler | None = None,
         *,
-        executor=None,
+        executor: "CommandExecutor | None" = None,
     ):
         """Initialize the Codex coding agent.
 
@@ -99,7 +103,13 @@ class CodexCodingAgent(CLICodingAgent):
             cmd.extend(self.extra_config_args)
         return cmd
 
-    def _create_session(self, cmd, cwd=None, timeout=None, silent=False):
+    def _create_session(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        cmd: list[str],
+        cwd: str | None = None,
+        timeout: int | None = None,
+        silent: bool = False,
+    ) -> CodexGenerationSession:
         return CodexGenerationSession(
             binary_name=self.binary_name,
             env=self.env,
@@ -113,7 +123,7 @@ class CodexCodingAgent(CLICodingAgent):
             executor=self.executor,
         )
 
-    def _extract_session_id(self, session: CodexGenerationSession) -> str | None:
+    def _extract_session_id(self, session: CodexGenerationSession) -> str | None:  # pyright: ignore[reportIncompatibleMethodOverride]
         return session.session_id
 
     def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:

--- a/src/vibesys/_agent_cli/gemini.py
+++ b/src/vibesys/_agent_cli/gemini.py
@@ -1,12 +1,15 @@
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from agentshim.events import AgentEventHandler
 from agentshim.gemini import GeminiGenerationSession
 
 from .base import MCPServerSpec
 from .cli_agent import CLICodingAgent
+
+if TYPE_CHECKING:
+    from agentshim.executor import CommandExecutor
 
 
 class GeminiCodingAgent(CLICodingAgent):
@@ -17,7 +20,7 @@ class GeminiCodingAgent(CLICodingAgent):
         model: str | None = None,
         event_handler: AgentEventHandler | None = None,
         *,
-        executor=None,
+        executor: "CommandExecutor | None" = None,
     ):
         """Initialize the Gemini coding agent.
 
@@ -57,7 +60,7 @@ class GeminiCodingAgent(CLICodingAgent):
 
         return cmd
 
-    def _create_session(
+    def _create_session(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         cmd: list[str],
         cwd: str | None = None,

--- a/src/vibesys/_agent_cli/opencode.py
+++ b/src/vibesys/_agent_cli/opencode.py
@@ -1,12 +1,15 @@
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from agentshim.events import AgentEventHandler
 from agentshim.opencode import OpencodeGenerationSession
 
 from .base import MCPServerSpec
 from .cli_agent import CLICodingAgent
+
+if TYPE_CHECKING:
+    from agentshim.executor import CommandExecutor
 
 OPENCODE_DEFAULT_MODEL = "google-vertex/gemini-3-pro-preview"
 
@@ -19,7 +22,7 @@ class OpencodeCodingAgent(CLICodingAgent):
         model: str | None = None,
         event_handler: AgentEventHandler | None = None,
         *,
-        executor=None,
+        executor: "CommandExecutor | None" = None,
     ):
         """Initialize the Opencode coding agent.
 
@@ -53,7 +56,7 @@ class OpencodeCodingAgent(CLICodingAgent):
 
         return cmd
 
-    def _create_session(
+    def _create_session(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         cmd: list[str],
         cwd: str | None = None,

--- a/src/vibesys/agent_runner.py
+++ b/src/vibesys/agent_runner.py
@@ -3,8 +3,11 @@
 import json
 import re
 import uuid
+from collections.abc import Callable, Iterator
+from typing import Any, TextIO, TypeVar
 
-from pydantic import ValidationError
+from langchain_core.callbacks import BaseCallbackHandler
+from pydantic import BaseModel, ValidationError
 
 from vibesys.agents.callbacks import AgentLogger, TodoDisplay
 from vibesys.schemas import (
@@ -20,6 +23,8 @@ from vibesys.schemas import (
     Verdict,
 )
 from vibesys.server.events import AgentOutputChannel
+
+T = TypeVar("T", bound=BaseModel)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -49,7 +54,7 @@ _PROFILER_PROMPT = (
 # ---------------------------------------------------------------------------
 
 
-def _extract_todos(update: dict) -> list[dict] | None:
+def _extract_todos(update: dict[str, Any]) -> list[dict[str, Any]] | None:
     """Extract todos from any node in a stream update."""
     for node_data in update.values():
         if isinstance(node_data, dict):
@@ -59,7 +64,7 @@ def _extract_todos(update: dict) -> list[dict] | None:
     return None
 
 
-def _iter_update_dicts(value):
+def _iter_update_dicts(value: Any) -> Iterator[dict[str, Any]]:
     """Yield all nested dict nodes reachable from a stream update payload."""
     if isinstance(value, dict):
         yield value
@@ -70,7 +75,7 @@ def _iter_update_dicts(value):
             yield from _iter_update_dicts(item)
 
 
-def _extract_text_from_message_content(content) -> str:
+def _extract_text_from_message_content(content: Any) -> str:
     """Normalize AI message content that may be a string or a content-block list."""
     if isinstance(content, str):
         return content
@@ -88,7 +93,7 @@ def _extract_text_from_message_content(content) -> str:
     return ""
 
 
-def _extract_last_ai_message_text(update: dict) -> str:
+def _extract_last_ai_message_text(update: dict[str, Any]) -> str:
     """Find the most recent AI message text anywhere in the streamed update tree."""
     last_text = ""
     for node in _iter_update_dicts(update):
@@ -109,7 +114,9 @@ def _extract_last_ai_message_text(update: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _log_agent_config(agent, label: str, log_file) -> None:
+def _log_agent_config(  # pyright: ignore[reportUnusedFunction] — imported by deepagents_runner
+    agent: Any, label: str, log_file: TextIO | None
+) -> None:
     """Write agent configuration (tools list) to log file."""
     if not log_file:
         return
@@ -136,7 +143,7 @@ def _log_agent_config(agent, label: str, log_file) -> None:
 
 def _log_and_print(
     text: str,
-    log_file=None,
+    log_file: TextIO | None = None,
     max_len: int | None = None,
 ) -> None:
     """Print to stdout (optionally truncated) and write full text to log_file."""
@@ -157,7 +164,7 @@ def _log_and_print(
 
 def _log_markdown_and_print(
     text: str,
-    log_file=None,
+    log_file: TextIO | None = None,
     max_len: int | None = None,
     *,
     channel: AgentOutputChannel = "assistant",
@@ -180,7 +187,7 @@ def _log_markdown_and_print(
 
 def _log_prompt_markdown_and_print(
     prompt: str,
-    log_file=None,
+    log_file: TextIO | None = None,
     max_len: int | None = None,
 ) -> None:
     """Emit raw prompt Markdown while preserving it in logs."""
@@ -194,7 +201,7 @@ def _log_prompt_markdown_and_print(
 
 def _log_json_and_print(
     text: str,
-    log_file=None,
+    log_file: TextIO | None = None,
     max_len: int | None = None,
 ) -> None:
     """Emit raw JSON; presentation clients decide how to render it."""
@@ -206,7 +213,7 @@ def _log_json_and_print(
 # ---------------------------------------------------------------------------
 
 
-def _parse_typed_response_text(text: str, response_cls):
+def _parse_typed_response_text(text: str, response_cls: type[T]) -> T | None:
     """Best-effort recovery of a typed Pydantic payload from raw model text."""
     if not text:
         return None
@@ -237,7 +244,7 @@ def _parse_typed_response_text(text: str, response_cls):
     return None
 
 
-def _coerce_typed_response(payload, response_cls):
+def _coerce_typed_response(payload: Any, response_cls: type[T]) -> T | None:
     if isinstance(payload, response_cls):
         return payload
     if isinstance(payload, dict):
@@ -250,7 +257,7 @@ def _coerce_typed_response(payload, response_cls):
     return None
 
 
-def _extract_typed_structured_response(update, response_cls):
+def _extract_typed_structured_response(update: Any, response_cls: type[T]) -> T | None:
     """Find a structured response of the given type anywhere in the streamed update tree."""
     for node in _iter_update_dicts(update):
         if "structured_response" not in node:
@@ -263,11 +270,11 @@ def _extract_typed_structured_response(update, response_cls):
 
 # Backwards-compatible aliases retained for tests that import these names
 # directly. Internal callers should use the generic helpers above.
-def _parse_implementer_response_text(text: str) -> ImplementerResponse | None:
+def _parse_implementer_response_text(text: str) -> ImplementerResponse | None:  # pyright: ignore[reportUnusedFunction] — imported by tests
     return _parse_typed_response_text(text, ImplementerResponse)
 
 
-def _parse_perf_eval_response_text(text: str) -> PerfEvalResponse | None:
+def _parse_perf_eval_response_text(text: str) -> PerfEvalResponse | None:  # pyright: ignore[reportUnusedFunction] — imported by tests
     return _parse_typed_response_text(text, PerfEvalResponse)
 
 
@@ -277,12 +284,12 @@ def _parse_perf_eval_response_text(text: str) -> PerfEvalResponse | None:
 
 
 def run_agent(
-    agent,
+    agent: Any,
     prompt: str,
-    callbacks: list | None = None,
+    callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
     round_label: str = "implementer",
-    log_file=None,
+    log_file: TextIO | None = None,
     max_text_len: int | None = None,
 ) -> str:
     """Run agent, return final AI message text.
@@ -327,18 +334,18 @@ def run_agent(
 
 
 def _run_typed_agent(
-    agent,
+    agent: Any,
     prompt: str,
     *,
-    response_cls,
+    response_cls: type[T],
     label: str,
-    fallback_factory,
-    callbacks: list | None = None,
+    fallback_factory: Callable[[], T],
+    callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
     round_label: str = "agent",
-    log_file=None,
+    log_file: TextIO | None = None,
     max_text_len: int | None = None,
-):
+) -> T:
     """Generic agent runner returning a structured Pydantic response of *response_cls*.
 
     All structured-response runners share this plumbing so the per-agent
@@ -394,12 +401,12 @@ def _run_typed_agent(
 
 
 def run_implementer_agent(
-    agent,
+    agent: Any,
     prompt: str,
-    callbacks: list | None = None,
+    callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
     round_label: str = "implementer",
-    log_file=None,
+    log_file: TextIO | None = None,
     max_text_len: int | None = None,
 ) -> ImplementerResponse:
     """Run implementer agent, return structured ImplementerResponse."""
@@ -421,12 +428,12 @@ def run_implementer_agent(
 
 
 def run_judge_agent(
-    agent,
+    agent: Any,
     prompt: str,
-    callbacks: list | None = None,
+    callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
     round_label: str = "judge",
-    log_file=None,
+    log_file: TextIO | None = None,
     max_text_len: int | None = None,
 ) -> JudgeResponse:
     """Run judge agent, return structured JudgeResponse.
@@ -453,12 +460,12 @@ def run_judge_agent(
 
 
 def run_perf_eval_agent(
-    agent,
+    agent: Any,
     prompt: str,
-    callbacks: list | None = None,
+    callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
     round_label: str = "perf_eval",
-    log_file=None,
+    log_file: TextIO | None = None,
     max_text_len: int | None = None,
 ) -> PerfEvalResponse:
     """Run perf evaluator agent, return structured PerfEvalResponse."""
@@ -519,7 +526,7 @@ def _parse_profiler_response_text(text: str) -> ProfilerResponse | None:
     return None
 
 
-def _coerce_profiler_response(payload) -> ProfilerResponse | None:
+def _coerce_profiler_response(payload: Any) -> ProfilerResponse | None:
     if isinstance(payload, ProfilerResponse):
         return payload
     if isinstance(payload, dict):
@@ -532,7 +539,7 @@ def _coerce_profiler_response(payload) -> ProfilerResponse | None:
     return None
 
 
-def _extract_profiler_structured_response(update: dict) -> ProfilerResponse | None:
+def _extract_profiler_structured_response(update: dict[str, Any]) -> ProfilerResponse | None:
     """Find a structured profiler response anywhere in the streamed update tree."""
     for node in _iter_update_dicts(update):
         if "structured_response" not in node:
@@ -549,12 +556,12 @@ def _extract_profiler_structured_response(update: dict) -> ProfilerResponse | No
 
 
 def run_profiler_agent(
-    agent,
+    agent: Any,
     prompt: str,
-    callbacks: list | None = None,
+    callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
     round_label: str = "profiler",
-    log_file=None,
+    log_file: TextIO | None = None,
     max_text_len: int | None = None,
 ) -> ProfilerResponse:
     """Run profiler agent, return structured ProfilerResponse."""
@@ -611,14 +618,14 @@ def run_profiler_agent(
 
 
 def run_issue_implementer_agent(
-    agent,
+    agent: Any,
     prompt: str,
     *,
     issue_id: int,
-    callbacks: list | None = None,
+    callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
     round_label: str = "issue_implementer",
-    log_file=None,
+    log_file: TextIO | None = None,
     max_text_len: int | None = None,
 ) -> IssueImplementerResponse:
     """Run the issue-loop implementer agent, return structured IssueImplementerResponse."""
@@ -642,14 +649,14 @@ def run_issue_implementer_agent(
 
 
 def run_issue_judge_agent(
-    agent,
+    agent: Any,
     prompt: str,
     *,
     issue_id: int,
-    callbacks: list | None = None,
+    callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
     round_label: str = "issue_judge",
-    log_file=None,
+    log_file: TextIO | None = None,
     max_text_len: int | None = None,
 ) -> IssueJudgeResponse:
     """Run the issue-loop judge agent, return structured IssueJudgeResponse."""
@@ -674,12 +681,12 @@ def run_issue_judge_agent(
 
 
 def run_issue_perf_eval_agent(
-    agent,
+    agent: Any,
     prompt: str,
-    callbacks: list | None = None,
+    callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
     round_label: str = "issue_perf_eval",
-    log_file=None,
+    log_file: TextIO | None = None,
     max_text_len: int | None = None,
 ) -> IssuePerfEvalResponse:
     """Run the issue-loop performance evaluator agent, return structured IssuePerfEvalResponse."""

--- a/src/vibesys/agents/__init__.py
+++ b/src/vibesys/agents/__init__.py
@@ -9,7 +9,7 @@ runner classes are imported, so the public API of this package is::
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 from vibesys.config import Config
 from vibesys.constants import DEFAULT_AGENT_BACKEND
@@ -27,8 +27,8 @@ __all__ = [
     "AgentProgress",
     "AgentRunner",
     "CandidateProgress",
-    "CliAgentRunner",
-    "DeepAgentsRunner",
+    "CliAgentRunner",  # pyright: ignore[reportUnsupportedDunderAll] — provided lazily via __getattr__
+    "DeepAgentsRunner",  # pyright: ignore[reportUnsupportedDunderAll] — provided lazily via __getattr__
     "RoundProgress",
     "build_agent_runner",
 ]
@@ -56,7 +56,7 @@ def build_agent_runner(
     skill_source_dirs: list[Path],
     model: Any,
     model_name: str,
-    run_log_file,
+    run_log_file: TextIO | None,
     use_docker: bool,
     use_modal: bool = False,
     log_dir: Path | None = None,

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -3,12 +3,13 @@ import sys
 import time
 import traceback
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TextIO
 
 from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.messages import BaseMessage
 
 from vibesys.agents.progress import AgentProgress
-from vibesys.constants import _DIM, _GREEN, _RESET, _YELLOW
+from vibesys.constants import _DIM, _GREEN, _RESET, _YELLOW  # pyright: ignore[reportPrivateUsage]
 from vibesys.server.events import AgentOutputChannel
 
 ContextWindowLookup = Callable[[str | None], int | None]
@@ -77,11 +78,11 @@ _STATUS_INDICATORS = {
 class TodoDisplay:
     """Renders a persistent todo list box using ANSI cursor control."""
 
-    def __init__(self, file=None):
+    def __init__(self, file: TextIO | None = None):
         self._file = file or sys.stdout
         self._prev_lines = 0
 
-    def update(self, todos: list[dict]) -> None:
+    def update(self, todos: list[dict[str, Any]]) -> None:
         if not todos:
             return
         # Build box lines
@@ -127,7 +128,7 @@ class AgentLogger(BaseCallbackHandler):
     def __init__(
         self,
         max_result_len: int | None = 500,
-        log_file=None,
+        log_file: TextIO | None = None,
         model_name: str | None = None,
         agent_label: str | None = None,
         progress: AgentProgress | None = None,
@@ -146,7 +147,7 @@ class AgentLogger(BaseCallbackHandler):
         # Most recent usage dict from the cli backend (see ``update_usage``).
         # The deepagents path doesn't populate this — it drives ``_input_tokens``
         # directly via ``on_llm_end``.
-        self._latest_usage: dict | None = None
+        self._latest_usage: dict[str, Any] | None = None
         self._context_window_lookup = context_window_lookup or _default_context_window_lookup
         self._context_window = self._context_window_lookup(model_name)
 
@@ -175,7 +176,9 @@ class AgentLogger(BaseCallbackHandler):
 
     # --- LLM call context (log-file only) ---
 
-    def on_chat_model_start(self, serialized, messages, **kwargs):
+    def on_chat_model_start(
+        self, serialized: dict[str, Any], messages: list[list[BaseMessage]], **kwargs: Any
+    ) -> None:
         if not self._log_file:
             return
         self._call_count += 1
@@ -217,7 +220,7 @@ class AgentLogger(BaseCallbackHandler):
 
     # --- LLM token streaming ---
 
-    def on_llm_new_token(self, token, **kwargs):
+    def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
         if token:
             self._publish(token, "assistant")
             if not self._streaming and self._agent_label:
@@ -225,7 +228,7 @@ class AgentLogger(BaseCallbackHandler):
             self._print(token, end="", flush=True)
             self._streaming = True
 
-    def on_llm_end(self, response, **kwargs):
+    def on_llm_end(self, response: Any, **kwargs: Any) -> None:
         was_streaming = self._streaming
         if self._streaming:
             self._print()
@@ -275,15 +278,22 @@ class AgentLogger(BaseCallbackHandler):
 
     # --- Tool execution ---
 
-    def on_tool_start(self, serialized, input_str, *, inputs=None, **kwargs):
+    def on_tool_start(
+        self,
+        serialized: dict[str, Any],
+        input_str: str,
+        *,
+        inputs: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
         pass  # tool call already logged in on_llm_end
 
-    def on_tool_end(self, output, **kwargs):
+    def on_tool_end(self, output: Any, **kwargs: Any) -> None:
         content = output.content if hasattr(output, "content") else str(output)
         name = getattr(output, "name", None) or "unknown"
         self._print_tool_result(name, content)
 
-    def on_tool_error(self, error, **kwargs):
+    def on_tool_error(self, error: Any, **kwargs: Any) -> None:
         self._print(f"Tool error: {error!r}")
         if isinstance(error, BaseException):
             tb = traceback.format_exception(type(error), error, error.__traceback__)
@@ -313,7 +323,7 @@ class AgentLogger(BaseCallbackHandler):
         }
     )
 
-    def _print_tool_call(self, name: str, args: dict):
+    def _print_tool_call(self, name: str, args: dict[str, Any]):
         self._publish(f"→ {name}({json.dumps(args, default=str)})\n", "tool")
         is_code_tool = name in self._CODE_CHANGE_TOOLS
 
@@ -370,7 +380,7 @@ class AgentLogger(BaseCallbackHandler):
         for line in preview.split("\n"):
             self._print_stdout(f"  {line}")
 
-    def _print(self, *args, **kwargs):
+    def _print(self, *args: Any, **kwargs: Any) -> None:
         """Write to both stdout and log file.
 
         Flushes the log file after each write so operators tailing
@@ -384,11 +394,11 @@ class AgentLogger(BaseCallbackHandler):
             print(*args, file=self._log_file, **kwargs)
             self._log_file.flush()
 
-    def _print_stdout(self, *args, **kwargs):
+    def _print_stdout(self, *args: Any, **kwargs: Any) -> None:
         """Write to stdout only."""
         print(*args, file=self._output, **kwargs)
 
-    def _print_log(self, *args, **kwargs):
+    def _print_log(self, *args: Any, **kwargs: Any) -> None:
         """Write to log file only."""
         if self._log_file:
             print(*args, file=self._log_file, **kwargs)
@@ -433,7 +443,7 @@ class AgentLogger(BaseCallbackHandler):
     def on_usage(self, usage: dict[str, Any]) -> None:
         self.update_usage(usage)
 
-    def update_usage(self, usage: dict | None) -> None:
+    def update_usage(self, usage: dict[str, Any] | None) -> None:
         """Refresh token tracking from a CLI provider's per-turn usage dict.
 
         Mirrors the deepagents path (:meth:`on_llm_end`): we overwrite, not
@@ -464,7 +474,7 @@ class AgentLogger(BaseCallbackHandler):
         self._publish(text, "assistant")
         self._print(f"{self._format_prefix()}{text}")
 
-    def log_tool_call(self, name: str, args: dict) -> None:
+    def log_tool_call(self, name: str, args: dict[str, Any]) -> None:
         """Format a tool invocation the same way the deepagents path does."""
         self._print_tool_call(name, args)
 

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -24,7 +24,7 @@ import shutil
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Protocol, TypeVar
+from typing import Any, Protocol, TextIO, TypeVar
 
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel
@@ -36,12 +36,12 @@ from vibesys._agent_cli.codex import CodexCodingAgent
 from vibesys._agent_cli.gemini import GeminiCodingAgent
 from vibesys._agent_cli.opencode import OpencodeCodingAgent
 from vibesys.agent_runner import (
-    _DEFAULT_MAX_TEXT_LEN,
-    _log_and_print,
-    _log_json_and_print,
-    _log_markdown_and_print,
-    _log_prompt_markdown_and_print,
-    _parse_typed_response_text,
+    _DEFAULT_MAX_TEXT_LEN,  # pyright: ignore[reportPrivateUsage]
+    _log_and_print,  # pyright: ignore[reportPrivateUsage]
+    _log_json_and_print,  # pyright: ignore[reportPrivateUsage]
+    _log_markdown_and_print,  # pyright: ignore[reportPrivateUsage]
+    _log_prompt_markdown_and_print,  # pyright: ignore[reportPrivateUsage]
+    _parse_typed_response_text,  # pyright: ignore[reportPrivateUsage]
 )
 from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.progress import AgentProgress
@@ -99,7 +99,9 @@ def _discover_skill_dirs(root: Path) -> list[Path]:
     return [p.parent for p in root.rglob("SKILL.md")]
 
 
-def _materialize_skills(workspace: Path, skill_dirs: list[Path], log_file=None) -> None:
+def _materialize_skills(
+    workspace: Path, skill_dirs: list[Path], log_file: TextIO | None = None
+) -> None:
     """Copy each skill directory into the per-CLI skill-discovery paths.
 
     Walks each ``skill_dirs`` entry for ``SKILL.md`` files and flattens each
@@ -176,9 +178,9 @@ class CliAgentRunner:
         skills: list[Path] | None = None,
         model_name: str | None = None,
         timeout: int | None = None,
-        run_log_file=None,
-        docker_sandboxes: dict | None = None,
-        modal_sandboxes: dict | None = None,
+        run_log_file: TextIO | None = None,
+        docker_sandboxes: dict[str, Any] | None = None,
+        modal_sandboxes: dict[str, Any] | None = None,
         log_dir: Path | None = None,
     ):
         if provider not in _PROVIDER_CLASSES:

--- a/src/vibesys/agents/deepagents_runner.py
+++ b/src/vibesys/agents/deepagents_runner.py
@@ -10,19 +10,20 @@ from __future__ import annotations
 import uuid
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, TextIO, TypeVar
 
 from deepagents import create_deep_agent
 from langchain.agents.structured_output import AutoStrategy
+from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.tools import BaseTool
 from langgraph.checkpoint.memory import MemorySaver
 from pydantic import BaseModel
 
 from vibesys._agent_cli.base import MCPServerSpec
 from vibesys.agent_runner import (
-    _DEFAULT_MAX_TEXT_LEN,
-    _log_agent_config,
-    _run_typed_agent,
+    _DEFAULT_MAX_TEXT_LEN,  # pyright: ignore[reportPrivateUsage]
+    _log_agent_config,  # pyright: ignore[reportPrivateUsage]
+    _run_typed_agent,  # pyright: ignore[reportPrivateUsage]
 )
 from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.progress import AgentProgress
@@ -47,7 +48,7 @@ class DeepAgentsRunner:
         backends: dict[str, Any],
         skills: list[str],
         model_name: str | None,
-        run_log_file,
+        run_log_file: TextIO | None,
     ):
         self._model = model
         self._backends = backends
@@ -90,7 +91,7 @@ class DeepAgentsRunner:
         )
         _log_agent_config(agent, label, self._run_log_file)
 
-        callbacks = [
+        callbacks: list[BaseCallbackHandler] = [
             AgentLogger(
                 log_file=self._run_log_file,
                 model_name=self._model_name,

--- a/src/vibesys/backends/cuda/__init__.py
+++ b/src/vibesys/backends/cuda/__init__.py
@@ -293,7 +293,7 @@ class CudaBackend:
         (self.log_dir / "gpu.json").write_text(json.dumps(data, indent=2))
 
 
-def _gpu_to_dict(g: GpuInfo) -> dict:
+def _gpu_to_dict(g: GpuInfo) -> dict[str, int | str]:
     return {
         "index": g.index,
         "uuid": g.uuid,

--- a/src/vibesys/backends/cuda/gpu_monitor.py
+++ b/src/vibesys/backends/cuda/gpu_monitor.py
@@ -20,6 +20,7 @@ import threading
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -48,7 +49,7 @@ class ContentionStatus:
 
     is_contended: bool = False
     #: Processes that appeared on the monitored GPU after the baseline.
-    new_procs: list[dict] = field(default_factory=list)
+    new_procs: list[dict[str, Any]] = field(default_factory=list)
     #: Current GPU memory / utilisation.
     gpu: GpuInfo | None = None
     timestamp: str = ""
@@ -128,9 +129,9 @@ def _query_gpu_procs() -> str:
     return result.stdout
 
 
-def _parse_proc_output(raw: str) -> list[dict]:
+def _parse_proc_output(raw: str) -> list[dict[str, Any]]:
     """Parse nvidia-smi compute-apps CSV into process dicts."""
-    procs: list[dict] = []
+    procs: list[dict[str, Any]] = []
     for line in raw.strip().splitlines():
         if not line.strip() or "pid" in line.lower() and "process" in line.lower():
             continue

--- a/src/vibesys/config.py
+++ b/src/vibesys/config.py
@@ -16,7 +16,7 @@ import os
 import tomllib
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -222,7 +222,7 @@ class Config(_Strict):
         return parse_feature_flag_overrides(value, FeatureFlag)
 
 
-def as_config(config: "Config | Mapping") -> "Config":
+def as_config(config: "Config | Mapping[str, Any]") -> "Config":
     """Coerce a mapping to a validated :class:`Config`; pass through instances.
 
     The loop entrypoints accept either a parsed :class:`Config` (the normal CLI
@@ -258,7 +258,7 @@ def _apply_vertex_env_overrides(config: Config) -> None:
         vx.region = env_region
 
 
-def _load_config(path: Path) -> Config:
+def _load_config(path: Path) -> Config:  # pyright: ignore[reportUnusedFunction]
     """Load, validate, and env-override a TOML agent config file."""
     _load_dotenv_file()
     path = Path(path)

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -1,5 +1,10 @@
 """Shared run context: ``_RunContext``, ``create_run_context``, and ``setup_exp_dir``."""
 
+# File-scoped strict relaxations to keep churn low while this module is
+# under active refactoring (see the _RunContext extraction PRs); pay down
+# once that work settles.
+# pyright: reportPrivateUsage=false, reportUnknownParameterType=false, reportMissingParameterType=false, reportDeprecated=false
+
 import shutil
 import subprocess
 import uuid

--- a/src/vibesys/domains/registry.py
+++ b/src/vibesys/domains/registry.py
@@ -19,7 +19,7 @@ def registered_domains() -> list[str]:
 
 def resolve_domain(name: DomainName) -> DomainDefinition:
     """Resolve a registered domain enum to its definition."""
-    if not isinstance(name, DomainName):
+    if not isinstance(name, DomainName):  # pyright: ignore[reportUnnecessaryIsInstance]
         raise TypeError(f"domain must be a DomainName, got {type(name).__name__}.")
 
     domain = DOMAINS[name]

--- a/src/vibesys/linux_cpu_profiler.py
+++ b/src/vibesys/linux_cpu_profiler.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from enum import StrEnum
 from pathlib import Path
+from typing import Any
 
 
 class LinuxProfilerTool(StrEnum):
@@ -409,7 +410,7 @@ def _format_summary(
     )
 
 
-def summarize(output_dir: Path) -> dict:
+def summarize(output_dir: Path) -> dict[str, Any]:
     """Read persisted artifacts and return a bounded machine-readable summary."""
 
     metadata_path = output_dir / "metadata.json"

--- a/src/vibesys/llm_client.py
+++ b/src/vibesys/llm_client.py
@@ -4,7 +4,11 @@ from pathlib import Path
 from pydantic import SecretStr
 
 from vibesys.config import Config, ThinkingCfg
-from vibesys.constants import _ANTHROPIC_PREFIXES, _GOOGLE_PREFIXES, _OPENAI_PREFIXES
+from vibesys.constants import (
+    _ANTHROPIC_PREFIXES,  # pyright: ignore[reportPrivateUsage]
+    _GOOGLE_PREFIXES,  # pyright: ignore[reportPrivateUsage]
+    _OPENAI_PREFIXES,  # pyright: ignore[reportPrivateUsage]
+)
 
 
 def _is_google_model(model_name: str) -> bool:
@@ -23,7 +27,7 @@ def _has_thinking(thinking: ThinkingCfg) -> bool:
     return bool(thinking.level or thinking.budget)
 
 
-def _build_model(config: Config):
+def _build_model(config: Config):  # pyright: ignore[reportUnusedFunction]
     """Build the chat model from a parsed :class:`Config`."""
     model_name = config.model.name
     provider = config.model.provider

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -13,6 +13,7 @@ import math
 import shlex
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config
@@ -82,7 +83,7 @@ class _RoundRecord:
     # real plateau.
     profile_skipped: bool = False
 
-    def to_json(self) -> dict:
+    def to_json(self) -> dict[str, Any]:
         return {
             "round": self.round_number,
             "commit": self.commit,
@@ -93,7 +94,7 @@ class _RoundRecord:
         }
 
     @classmethod
-    def from_json(cls, data: dict) -> _RoundRecord:
+    def from_json(cls, data: dict[str, Any]) -> _RoundRecord:
         return cls(
             round_number=int(data["round"]),
             commit=data.get("commit"),
@@ -1154,7 +1155,7 @@ def run_agent_loop(
                         status=EventStatus.COMPLETED if passed else EventStatus.FAILED,
                         round_label=f"round-{round_number}",
                         data=RoundFinishedData(
-                            attempts=retry,
+                            attempts=retry,  # pyright: ignore[reportPossiblyUnboundVariable]
                             judge_verdict="pass" if passed else "fail",
                             perf_metric=perf_metric,
                             perf_unit=perf_unit,

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -67,7 +67,7 @@ _jinja_env = Environment(
 )
 
 
-def _render(name: str, **kwargs) -> str:
+def _render(name: str, **kwargs: object) -> str:
     return _jinja_env.get_template(name).render(**kwargs)
 
 

--- a/src/vibesys/loops/evolve/population.py
+++ b/src/vibesys/loops/evolve/population.py
@@ -33,6 +33,7 @@ import math
 import random
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # Objective spec + dominance
@@ -126,11 +127,11 @@ class Individual:
     summary: str = ""
     feedback: str = ""
 
-    def to_json(self) -> dict:
+    def to_json(self) -> dict[str, Any]:
         return asdict(self)
 
     @classmethod
-    def from_json(cls, data: dict) -> Individual:
+    def from_json(cls, data: dict[str, Any]) -> Individual:
         return cls(
             id=int(data["id"]),
             generation=int(data["generation"]),

--- a/src/vibesys/loops/plain/loop.py
+++ b/src/vibesys/loops/plain/loop.py
@@ -27,6 +27,7 @@ import shutil
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config, as_config
@@ -88,7 +89,7 @@ def _save_state(log_dir: Path, state: PlainLoopState) -> None:
     os.replace(tmp, target)
 
 
-def _load_state(log_dir: Path) -> PlainLoopState | None:
+def _load_state(log_dir: Path) -> PlainLoopState | None:  # pyright: ignore[reportUnusedFunction]
     path = log_dir / "state.json"
     if not path.is_file():
         return None
@@ -265,7 +266,7 @@ def _sync_workspace_files(
 # ---------------------------------------------------------------------------
 
 
-def _latest_judge_review(issue: Issue) -> dict | None:
+def _latest_judge_review(issue: Issue) -> dict[str, Any] | None:
     """Return the most recent judge FAIL review on this issue, or ``None``.
 
     Walks ``issue.history`` in reverse looking for a status-transition

--- a/src/vibesys/loops/plain/render.py
+++ b/src/vibesys/loops/plain/render.py
@@ -27,6 +27,7 @@ import os
 import re
 import unicodedata
 from pathlib import Path
+from typing import Any
 
 from vs_issue_board import (
     Issue,
@@ -117,7 +118,7 @@ def _render_event_bullet(evt: IssueEvent) -> str:
     return f"- `{evt.timestamp}` **{evt.actor}** {evt.action}{iter_part}{note_part}"
 
 
-def _render_implementer_payload(payload: dict) -> str:
+def _render_implementer_payload(payload: dict[str, Any]) -> str:
     """Render an IssueImplementerResponse payload as a markdown section body."""
     lines: list[str] = []
     summary = payload.get("summary", "").strip()
@@ -137,7 +138,7 @@ def _render_implementer_payload(payload: dict) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _render_judge_payload(payload: dict) -> str:
+def _render_judge_payload(payload: dict[str, Any]) -> str:
     """Render an IssueJudgeResponse payload as a markdown section body."""
     lines: list[str] = []
     verdict = payload.get("verdict", "")

--- a/src/vibesys/loops/plain/runner_ext.py
+++ b/src/vibesys/loops/plain/runner_ext.py
@@ -76,7 +76,7 @@ class PlainLoopAgentRunner:
         mcp_servers: list[MCPServerSpec] | None = None,
         tools: list[BaseTool] | None = None,
         **kwargs: Any,
-    ) -> T:
+    ) -> T:  # pyright: ignore[reportInvalidTypeVarUse]
         if kind in ("judge", "perf_eval"):
             if iteration is None:
                 raise ValueError(

--- a/src/vibesys/loops/profiler.py
+++ b/src/vibesys/loops/profiler.py
@@ -16,8 +16,13 @@ and decides what to do with the returned summary.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from vibesys.profilers import ProfilerKind, profiler_definition, require_profiler_kind
 from vibesys.schemas import ProfilerSummary
+
+if TYPE_CHECKING:
+    from vibesys.run import LoopContext
 
 
 def mcp_spec(profiler_kind: ProfilerKind):
@@ -44,7 +49,7 @@ def mcp_spec(profiler_kind: ProfilerKind):
 
 
 def invoke_profiler(
-    ctx,
+    ctx: LoopContext,
     *,
     system_prompt: str,
     round_label: str,

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -23,9 +23,9 @@ import sys
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import NoReturn
+from typing import TYPE_CHECKING, NoReturn
 
-from vibesys.config import Config, _load_config
+from vibesys.config import Config, _load_config  # pyright: ignore[reportPrivateUsage]
 from vibesys.constants import (
     KNOWN_COMPUTE_BACKENDS,
     PROJECT_ROOT,
@@ -39,6 +39,9 @@ from vibesys.sandbox.run_environment import (
     make_run_environment_spec,
 )
 from vibesys.skills import DEFAULT_SKILL_ROOTS, resolve_skill_source_dirs
+
+if TYPE_CHECKING:
+    from vibesys.loops.evolve.population import Objective
 
 _OUTER_LOOPS = ("agent", "plain", "evolve")
 _MODALITIES = (
@@ -624,7 +627,7 @@ def _validate_target_inputs(args: argparse.Namespace) -> None:
         _configuration_error(str(exc), code="invalid_input", stage="input_loading")
 
 
-def _validate_agent(args: argparse.Namespace) -> None:
+def _validate_agent(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnusedFunction]
     if args.modal and args.profiler not in _MODAL_PROFILERS:
         _configuration_error(
             "Error: --modal only supports --profiler=torch, --profiler=auto, or --profiler=none.",
@@ -632,7 +635,7 @@ def _validate_agent(args: argparse.Namespace) -> None:
     _validate_target_inputs(args)
 
 
-def _run_agent(args: argparse.Namespace) -> None:
+def _run_agent(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnusedFunction]
     config, skills, backend = load_config_and_skills(args)
     from vibesys.loops.agent.loop import run_agent_loop
 
@@ -731,7 +734,7 @@ def _parse_cli_objective(spec: str):
     return Objective(name=name, direction=direction)
 
 
-def _load_objectives_toml(input_path: Path) -> list:
+def _load_objectives_toml(input_path: Path) -> list[Objective]:
     """Read ``objectives.toml`` from the input bundle if present."""
     from vibesys.loops.evolve.population import Objective
 
@@ -753,7 +756,7 @@ def _load_objectives_toml(input_path: Path) -> list:
     return objectives
 
 
-def _resolve_objectives(args: argparse.Namespace) -> list:
+def _resolve_objectives(args: argparse.Namespace) -> list[Objective]:
     if args.objective:
         return list(args.objective)
     return _load_objectives_toml(args.input_bundle.root)
@@ -782,7 +785,7 @@ def _build_evolve_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _validate_evolve(args: argparse.Namespace) -> None:
+def _validate_evolve(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnusedFunction]
     if args.modal and args.profiler not in _MODAL_PROFILERS:
         _configuration_error(
             "Error: --modal only supports --profiler=torch, --profiler=auto, or --profiler=none.",
@@ -798,7 +801,7 @@ def _validate_evolve(args: argparse.Namespace) -> None:
         _configuration_error("--frontier-bias must be in [0, 1].")
 
 
-def _run_evolve(args: argparse.Namespace) -> None:
+def _run_evolve(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnusedFunction]
     config, skills, backend = load_config_and_skills(args)
     from vibesys.loops.evolve.loop import run_evolve_loop
 
@@ -875,7 +878,7 @@ def _build_plain_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _validate_plain(args: argparse.Namespace) -> None:
+def _validate_plain(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnusedFunction]
     if args.modal and args.profiler not in _MODAL_PROFILERS:
         _configuration_error(
             "Error: --modal only supports --profiler=torch, --profiler=auto, or --profiler=none.",
@@ -883,11 +886,11 @@ def _validate_plain(args: argparse.Namespace) -> None:
     _validate_target_inputs(args)
 
 
-def _run_plain(args: argparse.Namespace) -> None:
+def _run_plain(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnusedFunction]
     config, skills, backend = load_config_and_skills(args)
     from vibesys.loops.plain.loop import (
         PlainLoopState,
-        _load_state,
+        _load_state,  # pyright: ignore[reportPrivateUsage]
         run_plain_loop,
     )
 

--- a/src/vibesys/run/device.py
+++ b/src/vibesys/run/device.py
@@ -11,14 +11,25 @@ backend.
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vibesys.backends.base import ComputeBackendImpl, ContentionMonitor
+    from vibesys.sandbox.run_environment import RunEnvironmentView
 
 
 class DeviceLease:
-    def __init__(self, backend, *, log_dir: Path, run_environment_view=None) -> None:
+    def __init__(
+        self,
+        backend: "ComputeBackendImpl",
+        *,
+        log_dir: Path,
+        run_environment_view: "RunEnvironmentView | None" = None,
+    ) -> None:
         self._backend = backend
         self._log_dir = log_dir
         self._view = run_environment_view
-        self.monitor = None
+        self.monitor: ContentionMonitor | None = None
 
     @property
     def selected_device(self):

--- a/src/vibesys/run/git_tracker.py
+++ b/src/vibesys/run/git_tracker.py
@@ -75,8 +75,8 @@ class GitTracker:
         }
 
     def run(
-        self, cmd: list[str], *, check: bool = True, env: dict | None = None
-    ) -> subprocess.CompletedProcess:
+        self, cmd: list[str], *, check: bool = True, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[bytes]:
         """Run a git command in the workspace, logging stderr on failure."""
         if env is None:
             env = {**os.environ, **self._GIT_ENV}

--- a/src/vibesys/run/logger.py
+++ b/src/vibesys/run/logger.py
@@ -3,16 +3,17 @@
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import TextIO
 
-from vibesys.agent_runner import _log_and_print
+from vibesys.agent_runner import _log_and_print  # pyright: ignore[reportPrivateUsage]
 
 
 class _TeeWriter:
-    def __init__(self, primary, secondary):
+    def __init__(self, primary: TextIO, secondary: TextIO) -> None:
         self._primary = primary
         self._secondary = secondary
 
-    def write(self, text):
+    def write(self, text: str) -> int:
         self._primary.write(text)
         self._secondary.write(text)
         return len(text)

--- a/src/vibesys/run/workspace.py
+++ b/src/vibesys/run/workspace.py
@@ -15,8 +15,13 @@ import subprocess
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from vibesys.input_project import materialize_input_project
+
+if TYPE_CHECKING:
+    from vibesys.backends.base import ComputeBackendImpl
+    from vibesys.sandbox.run_environment import RunEnvironment
 
 # Dirs excluded from workspace copy, git tracking, and the
 # Modal-side tar download. ``_auth`` and ``_opt_vibesys`` are
@@ -85,8 +90,8 @@ class Workspace:
         self,
         root: Path,
         *,
-        run_environment,
-        backend,
+        run_environment: "RunEnvironment",
+        backend: "ComputeBackendImpl",
         log: Callable[[str], None],
         project_root: Path,
         excluded_dirs: Iterable[str] = EXCLUDED_WORKSPACE_DIRS,

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -222,7 +222,7 @@ class DockerEnvironment:
             extra_init_commands=extra_init_commands,
             setup_fns=setup_fns,
         )
-        log = request.log or (lambda _: None)
+        log: Callable[[str], None] = request.log or (lambda _: None)
         label = getattr(request.backend, "image", self.config.image or "<backend-default>")
         log(f"[docker] starting container with image {label}")
         # DOCKER-kind sandboxes always implement start().
@@ -367,7 +367,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
             extra_init_commands=extra_init_commands,
             setup_fns=setup_fns,
         )
-        log = request.log or (lambda _: None)
+        log: Callable[[str], None] = request.log or (lambda _: None)
         log(
             "[modal] starting local Docker editor; GPU work will dispatch "
             "to Modal via `modal run main.py::<function>`"
@@ -667,7 +667,7 @@ def _docker_workspace_run(
     backend: ComputeBackendImpl,
     shell_command: str,
     timeout: int,
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[bytes]:
     image = getattr(backend, "image", "ubuntu:latest")
     return subprocess.run(
         [

--- a/src/vibesys/schemas.py
+++ b/src/vibesys/schemas.py
@@ -22,6 +22,7 @@ schemas in without dragging in the rest of the agent runtime.
 """
 
 from enum import StrEnum
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -110,7 +111,9 @@ class PerfMetrics(BaseModel):
     """Top-level metrics container. Supports single or multi-load runs."""
 
     load_levels: list[LoadLevelMetrics] = Field(description="One entry per load level tested.")
-    extra: dict = Field(default_factory=dict, description="Extensible — gpu_mem, batch_stats, etc.")
+    extra: dict[str, Any] = Field(
+        default_factory=dict, description="Extensible — gpu_mem, batch_stats, etc."
+    )
 
 
 class PerfEvalResponse(BaseModel):


### PR DESCRIPTION
## Problem

#178 introduced pyright in `basic` mode, which catches outright type errors but permits unannotated parameters, bare generics, and implicit `Any` throughout the codebase. The repo's coding standards call for typed Python 3.11+ patterns and explicit contracts; `basic` mode cannot enforce them, so annotation debt keeps accruing silently. Upgrading to `strict` makes missing annotations and untyped contracts CI failures instead of review nits.

## Solution

Flip `typeCheckingMode` to `"strict"` in `pyproject.toml` and pay down the resulting debt with real annotations wherever practical, using suppressions only where untyped third-party libraries or in-flight refactors make real fixes impractical.

Initial inventory after the flip: **1021 strict errors** across 41 files (main was basic-clean at 0).

Accounting, in order of preference per rule class:

**Real fixes (~110 sites, no runtime behavior changes):** missing parameter/return annotations, type arguments for bare generics (`dict` → `dict[str, Any]`, etc.), a `TypeVar(bound=BaseModel)` genericization of the typed-response helpers in `agent_runner.py`, `TYPE_CHECKING` imports to type the new `run/` modules (`workspace.py`, `logger.py`, `device.py`), and `invoke_profiler` retyped against the new `LoopContext` protocol from #177. Two callback params (`on_llm_end(response)`, `on_tool_error(error)`) are deliberately `Any`: the bodies are runtime-defensive against multiple shapes.

**Globally relaxed rules (3), documented in `pyproject.toml`:**
- `reportUnknownMemberType` (345 errors), `reportUnknownVariableType` (203), `reportUnknownArgumentType` (169): untyped third-party dependencies (deepagents, langchain, modal, docker SDKs) leak `Unknown` into member accesses, inferred locals, and call arguments across the agent runner and loop code; annotating every touchpoint would mean wrapping those APIs wholesale. Declared-contract enforcement is preserved: `reportUnknownParameterType`, `reportMissingParameterType`, and `reportMissingTypeArgument` stay at strict defaults, so our own signatures cannot silently regress.

**Inline suppressions (43):** 16 `reportUnusedFunction` (decorator-registered FastMCP tools, name-string dispatch tables in `main.py`, test-facing aliases), 16 `reportPrivateUsage` (intentional cross-module private imports), 6 `reportIncompatibleMethodOverride` (`_agent_cli/*` narrowing), 2 `reportUnsupportedDunderAll` (lazy `__getattr__` exports), 1 each `reportUnnecessaryIsInstance` / `reportPossiblyUnboundVariable` / `reportInvalidTypeVarUse` (defensive runtime checks kept as-is).

**File-scoped relaxation (1):** `context.py` carries a file-top `# pyright:` comment relaxing `reportPrivateUsage`, `reportUnknownParameterType`, `reportMissingParameterType`, `reportDeprecated`. This module is mid-refactor (#175/#176/#177 `_RunContext` extraction); the relaxation keeps churn minimal while that work settles, and the strict debt there should be paid down after the extraction completes. The branch was rebased over #176 and #177 as they merged, carrying annotations to the new `vibesys/run/` modules and dropping ignores made moot by the refactor.

**Follow-up (not fixed here):** `CLIGenerationSession` exists as two structurally-compatible but distinct classes (local `cli_agent.py` vs agentshim); they interoperate only via duck typing today. Recommend a follow-up issue to unify them behind a shared protocol rather than papering over it in this PR.

### Architecture

No ownership or module-boundary changes. All edits are annotations, `TYPE_CHECKING` imports, typing-only declarations, and pyright directives; the only policy surface touched is `[tool.pyright]` in `pyproject.toml`.

## Verification

### Correctness properties

- No runtime behavior changes: every edit is an annotation, typing-only import, or pyright directive; signatures keep identical names, order, and defaults.
- `./scripts/check_types.sh` (strict) reports 0 errors on the full include set.
- Own-code contract rules (`reportUnknownParameterType`, `reportMissingParameterType`, `reportMissingTypeArgument`) remain at strict defaults despite the three third-party-driven global relaxations.

### Testing

- `./scripts/check_types.sh`: 0 errors, 0 warnings (97 files)
- `./scripts/check_format.sh`: all checks passed (239 files)
- `./scripts/check_lint.sh`: all checks passed
- `uv run pytest`: 1805 passed, 1 skipped (macOS-only sandbox-exec test; Go/Rust toolchain-dependent skips not triggered on this host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
