### PR TITLE
Delete pyright-strict ignores by fixing the underlying designs

### DIFF
--- a/libs/vs-sandbox/src/vs_sandbox/__init__.py
+++ b/libs/vs-sandbox/src/vs_sandbox/__init__.py
@@ -1,9 +1,37 @@
-from vs_sandbox.docker_sandbox import DockerSandbox
-from vs_sandbox.modal_model_setup import ensure_model_volume
-from vs_sandbox.modal_sandbox import ModalSandbox
+"""Public API of the ``vs_sandbox`` library.
+
+The export list below is the deliberate surface consumers (vibesys) depend
+on; everything else in the submodules is internal. Exports resolve lazily
+via :pep:`562` so importing the package root does not pull in the heavy
+optional dependencies of unused backends (``modal``, in particular, is only
+imported when a Modal-backed export is first accessed).
+"""
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from vs_sandbox.docker_sandbox import DockerSandbox
+    from vs_sandbox.modal_model_setup import ensure_model_volume
+    from vs_sandbox.modal_sandbox import ModalSandbox
 
 __all__ = [
     "DockerSandbox",
     "ModalSandbox",
     "ensure_model_volume",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "DockerSandbox":
+        from vs_sandbox.docker_sandbox import DockerSandbox
+
+        return DockerSandbox
+    if name == "ModalSandbox":
+        from vs_sandbox.modal_sandbox import ModalSandbox
+
+        return ModalSandbox
+    if name == "ensure_model_volume":
+        from vs_sandbox.modal_model_setup import ensure_model_volume
+
+        return ensure_model_volume
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/vibesys/_agent_cli/claude.py
+++ b/src/vibesys/_agent_cli/claude.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from agentshim.executor import CommandExecutor
 
 
-class ClaudeCodeCodingAgent(CLICodingAgent):
+class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
     """Coding agent implementation using the Claude Code CLI tool."""
 
     def __init__(
@@ -74,10 +74,10 @@ class ClaudeCodeCodingAgent(CLICodingAgent):
             cmd.extend(["--model", self.model])
         return cmd
 
-    def _extract_session_id(self, session: ClaudeGenerationSession) -> str | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def _extract_session_id(self, session: ClaudeGenerationSession) -> str | None:
         return session.session_id
 
-    def _create_session(  # pyright: ignore[reportIncompatibleMethodOverride]
+    def _create_session(
         self,
         cmd: list[str],
         cwd: str | None = None,

--- a/src/vibesys/_agent_cli/cli_agent.py
+++ b/src/vibesys/_agent_cli/cli_agent.py
@@ -1,140 +1,30 @@
-import sys
 from abc import abstractmethod
-from typing import Any
+from typing import Generic, TypeVar
 
+# Re-exported so callers (and compat tests) can keep importing
+# ``CLIGenerationSession`` from this module. agentshim's class is the single
+# session implementation; provider modules subclass it per CLI.
+from agentshim.cli_agent import CLIGenerationSession
 from agentshim.events import AgentEventHandler
-from agentshim.executor import (
-    CallbackCommandStreamSink,
-    CommandExecutor,
-    CommandRequest,
-    HostCommandExecutor,
-)
+from agentshim.executor import CommandExecutor, HostCommandExecutor
 from agentshim.utils import get_interactive_env
 from loguru import logger
 
 from .base import CodingAgent
 from .hostsandbox import WorkspaceSandbox
 
+__all__ = ["CLICodingAgent", "CLIGenerationSession"]
 
-class CLIGenerationSession:
-    """Handles a single generation request lifecycle."""
-
-    def __init__(
-        self,
-        binary_name: str,
-        env: dict[str, str],
-        log_prefix: str,
-        cmd: list[str],
-        logger: Any,
-        cwd: str | None = None,
-        timeout: int | None = None,
-        silent: bool = False,
-        event_handler: AgentEventHandler | None = None,
-        executor: CommandExecutor | None = None,
-    ):
-        self.binary_name = binary_name
-        self.env = env
-        self.log_prefix = log_prefix
-        self.cmd = cmd
-        self.logger = logger
-        self.cwd = cwd
-        self.timeout = timeout
-        self.silent = silent
-        self.event_handler = event_handler
-        self.executor = executor or HostCommandExecutor()
-
-        # State initialization
-        self.stdout_lines: list[str] = []
-        self.stderr_lines: list[str] = []
-        self._at_line_start = True
-
-    def _log_raw(self, message: str) -> None:
-        """Log a raw message directly to output if not silent."""
-        if not self.silent:
-            self.logger.opt(raw=True).info(message)
-
-    def _process_stdout(self, line: str) -> None:
-        """Process a line from stdout."""
-        line_stripped = line.rstrip("\n")
-        if not self.silent:
-            self.logger.info(line_stripped)
-
-        if self.event_handler and line_stripped:
-            self.event_handler.on_thinking(line_stripped + "\n")
-
-        self.stdout_lines.append(line)
-
-    def _print_stream_content(self, content: str):
-        """Print streaming content with prefix handling."""
-        if not content:
-            return
-
-        lines = content.split("\n")
-
-        for i, line in enumerate(lines):
-            is_last = i == len(lines) - 1
-
-            if is_last:
-                if line:
-                    if self._at_line_start:
-                        self._log_raw(f"{self.log_prefix} ")
-                        self._at_line_start = False
-                    self._log_raw(line)
-            else:
-                if self._at_line_start:
-                    self._log_raw(f"{self.log_prefix} ")
-                self._log_raw(line)
-                self._log_raw("\n")
-                self._at_line_start = True
-
-    def _process_stderr(self, line: str) -> None:
-        """Process a line from stderr."""
-        line_stripped = line.rstrip("\n")
-        if not self.silent:
-            self.logger.bind(stderr=True).info(f"[STDERR] {line_stripped}")
-        self.stderr_lines.append(line)
-
-    def run(self, prompt: str) -> str:
-        """Execute the generation process."""
-        if not self.silent:
-            self.logger.info(f"Running command: {' '.join(self.cmd)}")
-            self._log_raw("=" * 80 + "\n")
-            sys.stdout.flush()
-
-        on_run_start = getattr(self.event_handler, "on_run_start", None)
-        if on_run_start is not None:
-            on_run_start(self.cmd)
-
-        result = self.executor.run(
-            CommandRequest(
-                argv=self.cmd,
-                stdin=prompt,
-                cwd=self.cwd,
-                env=self.env,
-                timeout=self.timeout,
-            ),
-            CallbackCommandStreamSink(
-                on_stdout=self._process_stdout,
-                on_stderr=self._process_stderr,
-            ),
-        )
-
-        on_run_end = getattr(self.event_handler, "on_run_end", None)
-        if on_run_end is not None:
-            on_run_end(result.returncode)
-
-        self._log_raw("=" * 80 + "\n")
-
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"{self.binary_name} exited with code {result.returncode}: {result.stderr}"
-            )
-
-        return "".join(self.stdout_lines).strip()
+SessionT = TypeVar("SessionT", bound=CLIGenerationSession)
 
 
-class CLICodingAgent(CodingAgent):
-    """Base class for CLI-based coding agents."""
+class CLICodingAgent(CodingAgent, Generic[SessionT]):
+    """Base class for CLI-based coding agents.
+
+    Generic over the provider's :class:`~agentshim.cli_agent.CLIGenerationSession`
+    subclass, so ``_create_session`` / ``_extract_session_id`` overrides stay
+    type-safe per provider.
+    """
 
     def __init__(
         self,
@@ -164,6 +54,7 @@ class CLICodingAgent(CodingAgent):
         self.executor.check_binary(self.binary_path, self.env, timeout=10)
         self.logger = logger.bind(agent_prefix=self._log_prefix)
         self.session_id: str | None = None
+        self._last_session: SessionT | None = None
         # Host-path filesystem confinement. Left ``None`` here (unconfined,
         # legacy behavior); the CLI runner installs a platform-specific
         # :class:`WorkspaceSandbox` on the host execution path. Container executors
@@ -183,7 +74,7 @@ class CLICodingAgent(CodingAgent):
         """
         return None
 
-    def _extract_session_id(self, session: "CLIGenerationSession") -> str | None:
+    def _extract_session_id(self, session: SessionT) -> str | None:
         """Extract a session/conversation ID from the completed session.
 
         Subclasses override this to parse the provider's output format.
@@ -196,29 +87,15 @@ class CLICodingAgent(CodingAgent):
         """Return the log prefix for this agent."""
         return f"[{self.__class__.__name__}]"
 
+    @abstractmethod
     def _create_session(
         self,
         cmd: list[str],
         cwd: str | None = None,
         timeout: int | None = None,
         silent: bool = False,
-    ) -> CLIGenerationSession:
-        """Create a session for a single generation request.
-
-        Can be overridden by subclasses to return specialized sessions.
-        """
-        return CLIGenerationSession(
-            binary_name=self.binary_name,
-            env=self.env,
-            log_prefix=self._log_prefix,
-            cmd=cmd,
-            logger=self.logger,
-            cwd=cwd,
-            timeout=timeout,
-            silent=silent,
-            event_handler=self.event_handler,
-            executor=self.executor,
-        )
+    ) -> SessionT:
+        """Create the provider-specific session for one generation request."""
 
     def generate(
         self,

--- a/src/vibesys/_agent_cli/codex.py
+++ b/src/vibesys/_agent_cli/codex.py
@@ -22,7 +22,7 @@ def _toml_array(values: list[str]) -> str:
     return "[" + ",".join(_toml_str(v) for v in values) + "]"
 
 
-class CodexCodingAgent(CLICodingAgent):
+class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
     """Coding agent implementation using the Codex CLI tool."""
 
     def __init__(
@@ -103,7 +103,7 @@ class CodexCodingAgent(CLICodingAgent):
             cmd.extend(self.extra_config_args)
         return cmd
 
-    def _create_session(  # pyright: ignore[reportIncompatibleMethodOverride]
+    def _create_session(
         self,
         cmd: list[str],
         cwd: str | None = None,
@@ -123,7 +123,7 @@ class CodexCodingAgent(CLICodingAgent):
             executor=self.executor,
         )
 
-    def _extract_session_id(self, session: CodexGenerationSession) -> str | None:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def _extract_session_id(self, session: CodexGenerationSession) -> str | None:
         return session.session_id
 
     def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:

--- a/src/vibesys/_agent_cli/gemini.py
+++ b/src/vibesys/_agent_cli/gemini.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from agentshim.executor import CommandExecutor
 
 
-class GeminiCodingAgent(CLICodingAgent):
+class GeminiCodingAgent(CLICodingAgent[GeminiGenerationSession]):
     """Coding agent implementation using the Gemini CLI tool."""
 
     def __init__(
@@ -60,7 +60,7 @@ class GeminiCodingAgent(CLICodingAgent):
 
         return cmd
 
-    def _create_session(  # pyright: ignore[reportIncompatibleMethodOverride]
+    def _create_session(
         self,
         cmd: list[str],
         cwd: str | None = None,

--- a/src/vibesys/_agent_cli/opencode.py
+++ b/src/vibesys/_agent_cli/opencode.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 OPENCODE_DEFAULT_MODEL = "google-vertex/gemini-3-pro-preview"
 
 
-class OpencodeCodingAgent(CLICodingAgent):
+class OpencodeCodingAgent(CLICodingAgent[OpencodeGenerationSession]):
     """Coding agent implementation using the Opencode CLI tool."""
 
     def __init__(
@@ -56,7 +56,7 @@ class OpencodeCodingAgent(CLICodingAgent):
 
         return cmd
 
-    def _create_session(  # pyright: ignore[reportIncompatibleMethodOverride]
+    def _create_session(
         self,
         cmd: list[str],
         cwd: str | None = None,

--- a/src/vibesys/agent_runner.py
+++ b/src/vibesys/agent_runner.py
@@ -30,7 +30,7 @@ T = TypeVar("T", bound=BaseModel)
 # Constants
 # ---------------------------------------------------------------------------
 
-_DEFAULT_MAX_TEXT_LEN = 2000
+DEFAULT_MAX_TEXT_LEN = 2000
 _JUDGE_REVIEW_PROMPT = (
     "Review the implementation. "
     "Write or update pytest tests, run them via `uv run pytest -v`, "
@@ -114,9 +114,7 @@ def _extract_last_ai_message_text(update: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _log_agent_config(  # pyright: ignore[reportUnusedFunction] — imported by deepagents_runner
-    agent: Any, label: str, log_file: TextIO | None
-) -> None:
+def log_agent_config(agent: Any, label: str, log_file: TextIO | None) -> None:
     """Write agent configuration (tools list) to log file."""
     if not log_file:
         return
@@ -141,7 +139,7 @@ def _log_agent_config(  # pyright: ignore[reportUnusedFunction] — imported by 
     log_file.flush()
 
 
-def _log_and_print(
+def log_and_print(
     text: str,
     log_file: TextIO | None = None,
     max_len: int | None = None,
@@ -162,7 +160,7 @@ def _log_and_print(
         print(text)
 
 
-def _log_markdown_and_print(
+def log_markdown_and_print(
     text: str,
     log_file: TextIO | None = None,
     max_len: int | None = None,
@@ -185,13 +183,13 @@ def _log_markdown_and_print(
         print(text)
 
 
-def _log_prompt_markdown_and_print(
+def log_prompt_markdown_and_print(
     prompt: str,
     log_file: TextIO | None = None,
     max_len: int | None = None,
 ) -> None:
     """Emit raw prompt Markdown while preserving it in logs."""
-    _log_markdown_and_print(
+    log_markdown_and_print(
         prompt,
         log_file=log_file,
         max_len=max_len,
@@ -199,13 +197,13 @@ def _log_prompt_markdown_and_print(
     )
 
 
-def _log_json_and_print(
+def log_json_and_print(
     text: str,
     log_file: TextIO | None = None,
     max_len: int | None = None,
 ) -> None:
     """Emit raw JSON; presentation clients decide how to render it."""
-    _log_and_print(text, log_file=log_file, max_len=max_len)
+    log_and_print(text, log_file=log_file, max_len=max_len)
 
 
 # ---------------------------------------------------------------------------
@@ -213,7 +211,7 @@ def _log_json_and_print(
 # ---------------------------------------------------------------------------
 
 
-def _parse_typed_response_text(text: str, response_cls: type[T]) -> T | None:
+def parse_typed_response_text(text: str, response_cls: type[T]) -> T | None:
     """Best-effort recovery of a typed Pydantic payload from raw model text."""
     if not text:
         return None
@@ -253,7 +251,7 @@ def _coerce_typed_response(payload: Any, response_cls: type[T]) -> T | None:
         except ValidationError:
             return None
     if isinstance(payload, str):
-        return _parse_typed_response_text(payload, response_cls)
+        return parse_typed_response_text(payload, response_cls)
     return None
 
 
@@ -266,16 +264,6 @@ def _extract_typed_structured_response(update: Any, response_cls: type[T]) -> T 
         if response is not None:
             return response
     return None
-
-
-# Backwards-compatible aliases retained for tests that import these names
-# directly. Internal callers should use the generic helpers above.
-def _parse_implementer_response_text(text: str) -> ImplementerResponse | None:  # pyright: ignore[reportUnusedFunction] — imported by tests
-    return _parse_typed_response_text(text, ImplementerResponse)
-
-
-def _parse_perf_eval_response_text(text: str) -> PerfEvalResponse | None:  # pyright: ignore[reportUnusedFunction] — imported by tests
-    return _parse_typed_response_text(text, PerfEvalResponse)
 
 
 # ---------------------------------------------------------------------------
@@ -303,11 +291,11 @@ def run_agent(
     if thread_id is None:
         thread_id = uuid.uuid4().hex
     todo_display = TodoDisplay()
-    _log_and_print(f"\n=== LLM ROUND START: {round_label} ===", log_file)
-    _log_and_print(f"callbacks: {callbacks_label}", log_file)
-    _log_and_print(f"thread_id: {thread_id}", log_file)
-    _log_and_print("--- input ---", log_file)
-    _log_prompt_markdown_and_print(prompt, log_file, max_len=max_text_len)
+    log_and_print(f"\n=== LLM ROUND START: {round_label} ===", log_file)
+    log_and_print(f"callbacks: {callbacks_label}", log_file)
+    log_and_print(f"thread_id: {thread_id}", log_file)
+    log_and_print("--- input ---", log_file)
+    log_prompt_markdown_and_print(prompt, log_file, max_len=max_text_len)
     last_ai_message = ""
     try:
         for update in agent.stream(
@@ -324,16 +312,16 @@ def run_agent(
                         last_ai_message = msg.content
     except Exception as exc:
         error_text = f"error: {type(exc).__name__}: {exc}"
-        _log_and_print(f"\n=== LLM ROUND ERROR: {round_label} ===", log_file)
-        _log_and_print(error_text, log_file, max_len=max_text_len)
+        log_and_print(f"\n=== LLM ROUND ERROR: {round_label} ===", log_file)
+        log_and_print(error_text, log_file, max_len=max_text_len)
         raise
     output_text = last_ai_message if last_ai_message else "<no ai message returned>"
-    _log_and_print("\n=== LLM ROUND OUTPUT (final ai message) ===", log_file)
-    _log_markdown_and_print(output_text, log_file, max_len=max_text_len)
+    log_and_print("\n=== LLM ROUND OUTPUT (final ai message) ===", log_file)
+    log_markdown_and_print(output_text, log_file, max_len=max_text_len)
     return last_ai_message
 
 
-def _run_typed_agent(
+def run_typed_agent(
     agent: Any,
     prompt: str,
     *,
@@ -360,11 +348,11 @@ def _run_typed_agent(
     callbacks_label = " + ".join(type(cb).__name__ for cb in callbacks)
     structured_response = None
     last_ai_message = ""
-    _log_and_print(f"\n=== {label} ROUND START: {round_label} ===", log_file)
-    _log_and_print(f"callbacks: {callbacks_label}", log_file)
-    _log_and_print(f"thread_id: {thread_id}", log_file)
-    _log_and_print("--- input ---", log_file)
-    _log_prompt_markdown_and_print(prompt, log_file, max_len=max_text_len)
+    log_and_print(f"\n=== {label} ROUND START: {round_label} ===", log_file)
+    log_and_print(f"callbacks: {callbacks_label}", log_file)
+    log_and_print(f"thread_id: {thread_id}", log_file)
+    log_and_print("--- input ---", log_file)
+    log_prompt_markdown_and_print(prompt, log_file, max_len=max_text_len)
     try:
         for update in agent.stream(
             {"messages": [("human", prompt)]},
@@ -382,21 +370,21 @@ def _run_typed_agent(
                 last_ai_message = extracted_text
     except Exception as exc:
         error_text = f"error: {type(exc).__name__}: {exc}"
-        _log_and_print(f"\n=== {label} ROUND ERROR: {round_label} ===", log_file)
-        _log_and_print(error_text, log_file, max_len=max_text_len)
+        log_and_print(f"\n=== {label} ROUND ERROR: {round_label} ===", log_file)
+        log_and_print(error_text, log_file, max_len=max_text_len)
         raise
     if structured_response is None:
-        structured_response = _parse_typed_response_text(last_ai_message, response_cls)
+        structured_response = parse_typed_response_text(last_ai_message, response_cls)
     if structured_response is None:
-        _log_and_print(f"\n=== {label} ROUND OUTPUT (missing response) ===", log_file)
-        _log_and_print(f"No structured response received from {label.lower()}.", log_file)
+        log_and_print(f"\n=== {label} ROUND OUTPUT (missing response) ===", log_file)
+        log_and_print(f"No structured response received from {label.lower()}.", log_file)
         if last_ai_message:
-            _log_and_print(f"\n=== {label} ROUND OUTPUT (raw ai message) ===", log_file)
-            _log_markdown_and_print(last_ai_message, log_file, max_len=max_text_len)
+            log_and_print(f"\n=== {label} ROUND OUTPUT (raw ai message) ===", log_file)
+            log_markdown_and_print(last_ai_message, log_file, max_len=max_text_len)
         return fallback_factory()
     output_json = structured_response.model_dump_json(indent=2)
-    _log_and_print(f"\n=== {label} ROUND OUTPUT ===", log_file)
-    _log_json_and_print(output_json, log_file, max_len=max_text_len)
+    log_and_print(f"\n=== {label} ROUND OUTPUT ===", log_file)
+    log_json_and_print(output_json, log_file, max_len=max_text_len)
     return structured_response
 
 
@@ -410,7 +398,7 @@ def run_implementer_agent(
     max_text_len: int | None = None,
 ) -> ImplementerResponse:
     """Run implementer agent, return structured ImplementerResponse."""
-    return _run_typed_agent(
+    return run_typed_agent(
         agent,
         prompt,
         response_cls=ImplementerResponse,
@@ -441,7 +429,7 @@ def run_judge_agent(
     When *log_file* is provided, full input/output/error text is written there
     while stdout receives a truncated version (controlled by *max_text_len*).
     """
-    return _run_typed_agent(
+    return run_typed_agent(
         agent,
         prompt,
         response_cls=JudgeResponse,
@@ -469,7 +457,7 @@ def run_perf_eval_agent(
     max_text_len: int | None = None,
 ) -> PerfEvalResponse:
     """Run perf evaluator agent, return structured PerfEvalResponse."""
-    return _run_typed_agent(
+    return run_typed_agent(
         agent,
         prompt,
         response_cls=PerfEvalResponse,
@@ -573,11 +561,11 @@ def run_profiler_agent(
     callbacks_label = " + ".join(type(cb).__name__ for cb in callbacks)
     structured_response = None
     last_ai_message = ""
-    _log_and_print(f"\n=== PROFILER ROUND START: {round_label} ===", log_file)
-    _log_and_print(f"callbacks: {callbacks_label}", log_file)
-    _log_and_print(f"thread_id: {thread_id}", log_file)
-    _log_and_print("--- input ---", log_file)
-    _log_prompt_markdown_and_print(prompt, log_file, max_len=max_text_len)
+    log_and_print(f"\n=== PROFILER ROUND START: {round_label} ===", log_file)
+    log_and_print(f"callbacks: {callbacks_label}", log_file)
+    log_and_print(f"thread_id: {thread_id}", log_file)
+    log_and_print("--- input ---", log_file)
+    log_prompt_markdown_and_print(prompt, log_file, max_len=max_text_len)
     try:
         for update in agent.stream(
             {"messages": [("human", prompt)]},
@@ -595,25 +583,25 @@ def run_profiler_agent(
                 last_ai_message = extracted_text
     except Exception as exc:
         error_text = f"error: {type(exc).__name__}: {exc}"
-        _log_and_print(f"\n=== PROFILER ROUND ERROR: {round_label} ===", log_file)
-        _log_and_print(error_text, log_file, max_len=max_text_len)
+        log_and_print(f"\n=== PROFILER ROUND ERROR: {round_label} ===", log_file)
+        log_and_print(error_text, log_file, max_len=max_text_len)
         raise
     if structured_response is None:
         structured_response = _parse_profiler_response_text(last_ai_message)
     if structured_response is None:
-        _log_and_print("\n=== PROFILER ROUND OUTPUT (missing response) ===", log_file)
-        _log_and_print("No structured response received from profiler.", log_file)
+        log_and_print("\n=== PROFILER ROUND OUTPUT (missing response) ===", log_file)
+        log_and_print("No structured response received from profiler.", log_file)
         if last_ai_message:
-            _log_and_print("\n=== PROFILER ROUND OUTPUT (raw ai message) ===", log_file)
-            _log_markdown_and_print(last_ai_message, log_file, max_len=max_text_len)
+            log_and_print("\n=== PROFILER ROUND OUTPUT (raw ai message) ===", log_file)
+            log_markdown_and_print(last_ai_message, log_file, max_len=max_text_len)
         return ProfilerResponse(
             analysis="No structured response received from profiler.",
             bottlenecks="Profiler did not produce a structured response.",
             suggestions="Re-run profiling manually.",
         )
     output_json = structured_response.model_dump_json(indent=2)
-    _log_and_print("\n=== PROFILER ROUND OUTPUT ===", log_file)
-    _log_json_and_print(output_json, log_file, max_len=max_text_len)
+    log_and_print("\n=== PROFILER ROUND OUTPUT ===", log_file)
+    log_json_and_print(output_json, log_file, max_len=max_text_len)
     return structured_response
 
 
@@ -629,7 +617,7 @@ def run_issue_implementer_agent(
     max_text_len: int | None = None,
 ) -> IssueImplementerResponse:
     """Run the issue-loop implementer agent, return structured IssueImplementerResponse."""
-    return _run_typed_agent(
+    return run_typed_agent(
         agent,
         prompt,
         response_cls=IssueImplementerResponse,
@@ -660,7 +648,7 @@ def run_issue_judge_agent(
     max_text_len: int | None = None,
 ) -> IssueJudgeResponse:
     """Run the issue-loop judge agent, return structured IssueJudgeResponse."""
-    return _run_typed_agent(
+    return run_typed_agent(
         agent,
         prompt,
         response_cls=IssueJudgeResponse,
@@ -690,7 +678,7 @@ def run_issue_perf_eval_agent(
     max_text_len: int | None = None,
 ) -> IssuePerfEvalResponse:
     """Run the issue-loop performance evaluator agent, return structured IssuePerfEvalResponse."""
-    return _run_typed_agent(
+    return run_typed_agent(
         agent,
         prompt,
         response_cls=IssuePerfEvalResponse,

--- a/src/vibesys/agents/__init__.py
+++ b/src/vibesys/agents/__init__.py
@@ -9,7 +9,7 @@ runner classes are imported, so the public API of this package is::
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, TextIO
+from typing import TYPE_CHECKING, Any, TextIO
 
 from vibesys.config import Config
 from vibesys.constants import DEFAULT_AGENT_BACKEND
@@ -23,18 +23,24 @@ from .progress import AgentProgress, CandidateProgress, RoundProgress
 # concrete runners import back from ``vibesys.agent_runner``. Importing
 # them eagerly here turned the cycle into an ImportError on the first entry
 # point that hits ``agent_runner`` first (e.g. the ``vibesys`` script).
+# The ``TYPE_CHECKING`` imports let pyright resolve the lazily provided
+# names statically without triggering the runtime cycle.
+if TYPE_CHECKING:
+    from .cli_runner import CliAgentRunner
+    from .deepagents_runner import DeepAgentsRunner
+
 __all__ = [
     "AgentProgress",
     "AgentRunner",
     "CandidateProgress",
-    "CliAgentRunner",  # pyright: ignore[reportUnsupportedDunderAll] — provided lazily via __getattr__
-    "DeepAgentsRunner",  # pyright: ignore[reportUnsupportedDunderAll] — provided lazily via __getattr__
+    "CliAgentRunner",
+    "DeepAgentsRunner",
     "RoundProgress",
     "build_agent_runner",
 ]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     if name == "CliAgentRunner":
         from .cli_runner import CliAgentRunner
 
@@ -77,7 +83,7 @@ def build_agent_runner(
         skill_source_dirs: Absolute source paths of skill directories — the
             cli runner copies these into the workspace's ``.claude/skills/``
             on each invoke.
-        model: Result of :func:`vibesys.llm_client._build_model` — only
+        model: Result of :func:`vibesys.llm_client.build_model` — only
             used by the deepagents path. The cli path uses ``model_name``.
         model_name: Bare model id (e.g. ``"claude-sonnet-4-6"``) — used both
             for the cli runner and for the deepagents ``AgentLogger`` prefix.
@@ -142,7 +148,7 @@ def build_agent_runner(
         timeout = agent_cfg.cli_timeout
         # The CLI tool runs [model].name, same as the deepagents backend —
         # it's the single source of truth for the model. model.name is a
-        # required field (and always validated by _build_model), so it is
+        # required field (and always validated by build_model), so it is
         # always a non-empty string here.
         from .cli_runner import CliAgentRunner
 

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -9,7 +9,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages import BaseMessage
 
 from vibesys.agents.progress import AgentProgress
-from vibesys.constants import _DIM, _GREEN, _RESET, _YELLOW  # pyright: ignore[reportPrivateUsage]
+from vibesys.constants import DIM, GREEN, RESET, YELLOW
 from vibesys.server.events import AgentOutputChannel
 
 ContextWindowLookup = Callable[[str | None], int | None]
@@ -69,9 +69,9 @@ def _format_token_count(n: int) -> str:
 
 
 _STATUS_INDICATORS = {
-    "completed": f"{_GREEN}✓{_RESET}",
-    "in_progress": f"{_YELLOW}▶{_RESET}",
-    "pending": f"{_DIM}○{_RESET}",
+    "completed": f"{GREEN}✓{RESET}",
+    "in_progress": f"{YELLOW}▶{RESET}",
+    "pending": f"{DIM}○{RESET}",
 }
 
 
@@ -357,7 +357,7 @@ class AgentLogger(BaseCallbackHandler):
     # readable while still capturing enough output for debugging.
     _LOG_MAX_RESULT_LEN = 2000
 
-    def _print_tool_result(self, name: str, content: str, color: str = _DIM):
+    def _print_tool_result(self, name: str, content: str, color: str = DIM):
         del name, color
         full_text = str(content)
         self._publish(full_text, "tool")

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -13,7 +13,7 @@ Docker command routing and per-invocation MCP install/uninstall. Each
 3. Passes :class:`AgentLogger` as the CLI event handler so on-screen output
    matches the deepagents path.
 4. Calls ``agent.generate(prompt, cwd=workspace, …)``.
-5. Reuses :func:`vibesys.agent_runner._parse_typed_response_text`
+5. Reuses :func:`vibesys.agent_runner.parse_typed_response_text`
    to coerce the returned string back into the requested Pydantic model.
 """
 
@@ -36,12 +36,12 @@ from vibesys._agent_cli.codex import CodexCodingAgent
 from vibesys._agent_cli.gemini import GeminiCodingAgent
 from vibesys._agent_cli.opencode import OpencodeCodingAgent
 from vibesys.agent_runner import (
-    _DEFAULT_MAX_TEXT_LEN,  # pyright: ignore[reportPrivateUsage]
-    _log_and_print,  # pyright: ignore[reportPrivateUsage]
-    _log_json_and_print,  # pyright: ignore[reportPrivateUsage]
-    _log_markdown_and_print,  # pyright: ignore[reportPrivateUsage]
-    _log_prompt_markdown_and_print,  # pyright: ignore[reportPrivateUsage]
-    _parse_typed_response_text,  # pyright: ignore[reportPrivateUsage]
+    DEFAULT_MAX_TEXT_LEN,
+    log_and_print,
+    log_json_and_print,
+    log_markdown_and_print,
+    log_prompt_markdown_and_print,
+    parse_typed_response_text,
 )
 from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.progress import AgentProgress
@@ -146,7 +146,7 @@ def _materialize_skills(
                 shutil.copytree(src_skill, dest, symlinks=True, ignore=skip_ignore)
             except OSError as exc:
                 if log_file is not None:
-                    _log_and_print(
+                    log_and_print(
                         f"[skills] failed to materialize {src_skill} -> "
                         f"{dest}: {type(exc).__name__}: {exc}",
                         log_file,
@@ -302,7 +302,7 @@ class CliAgentRunner:
                 Path(workspace),
                 env=agent.env,
                 binary_path=getattr(agent, "binary_path", None),
-                log=lambda msg: _log_and_print(msg, self._run_log_file),
+                log=lambda msg: log_and_print(msg, self._run_log_file),
             )
             self._agents[kind] = agent
 
@@ -322,20 +322,20 @@ class CliAgentRunner:
 
         # 6. Log the round header so the run log structure mirrors the
         #    deepagents path.
-        _log_and_print(
+        log_and_print(
             f"\n=== {label} ROUND START: {round_label} ===",
             self._run_log_file,
         )
-        _log_and_print(
+        log_and_print(
             f"backend: cli, provider: {self._provider}, model: {self._model_name}, "
             f"cwd: {workspace}",
             self._run_log_file,
         )
-        _log_and_print("--- input ---", self._run_log_file)
-        _log_prompt_markdown_and_print(
+        log_and_print("--- input ---", self._run_log_file)
+        log_prompt_markdown_and_print(
             combined_prompt,
             self._run_log_file,
-            max_len=_DEFAULT_MAX_TEXT_LEN,
+            max_len=DEFAULT_MAX_TEXT_LEN,
         )
 
         # 7. Run the agent. Wrap exceptions to surface them in the run log
@@ -352,14 +352,14 @@ class CliAgentRunner:
                 silent=True,
             )
         except Exception as exc:
-            _log_and_print(
+            log_and_print(
                 f"\n=== {label} ROUND ERROR: {round_label} ===",
                 self._run_log_file,
             )
-            _log_and_print(
+            log_and_print(
                 f"{type(exc).__name__}: {exc}",
                 self._run_log_file,
-                max_len=_DEFAULT_MAX_TEXT_LEN,
+                max_len=DEFAULT_MAX_TEXT_LEN,
             )
             raise
         finally:
@@ -369,32 +369,32 @@ class CliAgentRunner:
 
         # 8. Parse the structured response, falling back if the CLI tool
         #    didn't produce parseable JSON.
-        parsed = _parse_typed_response_text(text, response_cls)
+        parsed = parse_typed_response_text(text, response_cls)
         if parsed is None:
-            _log_and_print(
+            log_and_print(
                 f"\n=== {label} ROUND OUTPUT (missing response) ===",
                 self._run_log_file,
             )
-            _log_and_print(
+            log_and_print(
                 f"No structured response received from {label.lower()}.",
                 self._run_log_file,
             )
             if text:
-                _log_and_print(
+                log_and_print(
                     f"\n=== {label} ROUND OUTPUT (raw output) ===",
                     self._run_log_file,
                 )
-                _log_markdown_and_print(text, self._run_log_file, max_len=_DEFAULT_MAX_TEXT_LEN)
+                log_markdown_and_print(text, self._run_log_file, max_len=DEFAULT_MAX_TEXT_LEN)
             return fallback_factory()
 
-        _log_and_print(
+        log_and_print(
             f"\n=== {label} ROUND OUTPUT ===",
             self._run_log_file,
         )
-        _log_json_and_print(
+        log_json_and_print(
             parsed.model_dump_json(indent=2),
             self._run_log_file,
-            max_len=_DEFAULT_MAX_TEXT_LEN,
+            max_len=DEFAULT_MAX_TEXT_LEN,
         )
         return parsed
 
@@ -435,7 +435,7 @@ class CliAgentRunner:
             with target.open("a", encoding="utf-8") as f:
                 f.write(json.dumps(record) + "\n")
         except OSError as exc:
-            _log_and_print(
+            log_and_print(
                 f"[usage] failed to append {target}: {type(exc).__name__}: {exc}",
                 self._run_log_file,
             )

--- a/src/vibesys/agents/deepagents_runner.py
+++ b/src/vibesys/agents/deepagents_runner.py
@@ -1,7 +1,7 @@
 """Deepagents implementation of :class:`AgentRunner`.
 
 Wraps ``deepagents.create_deep_agent`` and the existing
-``vibesys.agent_runner._run_typed_agent`` plumbing — no behavior
+``vibesys.agent_runner.run_typed_agent`` plumbing — no behavior
 change vs. what the simple loop did before this abstraction landed.
 """
 
@@ -21,9 +21,9 @@ from pydantic import BaseModel
 
 from vibesys._agent_cli.base import MCPServerSpec
 from vibesys.agent_runner import (
-    _DEFAULT_MAX_TEXT_LEN,  # pyright: ignore[reportPrivateUsage]
-    _log_agent_config,  # pyright: ignore[reportPrivateUsage]
-    _run_typed_agent,  # pyright: ignore[reportPrivateUsage]
+    DEFAULT_MAX_TEXT_LEN,
+    log_agent_config,
+    run_typed_agent,
 )
 from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.progress import AgentProgress
@@ -89,7 +89,7 @@ class DeepAgentsRunner:
             checkpointer=checkpointer,
             tools=tools,
         )
-        _log_agent_config(agent, label, self._run_log_file)
+        log_agent_config(agent, label, self._run_log_file)
 
         callbacks: list[BaseCallbackHandler] = [
             AgentLogger(
@@ -100,7 +100,7 @@ class DeepAgentsRunner:
             )
         ]
 
-        return _run_typed_agent(
+        return run_typed_agent(
             agent,
             user_prompt,
             response_cls=response_cls,
@@ -110,5 +110,5 @@ class DeepAgentsRunner:
             thread_id=thread_id,
             round_label=round_label,
             log_file=self._run_log_file,
-            max_text_len=_DEFAULT_MAX_TEXT_LEN,
+            max_text_len=DEFAULT_MAX_TEXT_LEN,
         )

--- a/src/vibesys/backends/cuda/__init__.py
+++ b/src/vibesys/backends/cuda/__init__.py
@@ -26,8 +26,7 @@ from vibesys.backends.cuda.gpu_monitor import (
 )
 from vibesys.constants import ComputeBackend
 from vibesys.profilers import ProfilerKind
-from vs_sandbox.docker_sandbox import DockerSandbox
-from vs_sandbox.modal_sandbox import ModalSandbox
+from vs_sandbox import DockerSandbox, ModalSandbox
 
 # Default container image for the cuda backend.  Carries CUDA toolkit + PyTorch.
 _DEFAULT_IMAGE = "nvcr.io/nvidia/pytorch:25.04-py3"

--- a/src/vibesys/backends/local.py
+++ b/src/vibesys/backends/local.py
@@ -29,7 +29,7 @@ from vibesys.backends.base import (
 )
 from vibesys.constants import ComputeBackend
 from vibesys.profilers import ProfilerKind
-from vs_sandbox.docker_sandbox import DockerSandbox
+from vs_sandbox import DockerSandbox
 
 _DEFAULT_CPU_IMAGE = "python:3.12-bookworm"
 

--- a/src/vibesys/backends/trainium/__init__.py
+++ b/src/vibesys/backends/trainium/__init__.py
@@ -37,7 +37,7 @@ from vibesys.backends.base import (
 )
 from vibesys.constants import ComputeBackend
 from vibesys.profilers import ProfilerKind
-from vs_sandbox.docker_sandbox import DockerSandbox
+from vs_sandbox import DockerSandbox
 
 # AWS Neuron DLC.  Tag chosen to match the host's Neuron tools (2.30):
 # PyTorch 2.9 / Python 3.12 / Neuron SDK 2.30 on Ubuntu 24.04.  Carries

--- a/src/vibesys/config.py
+++ b/src/vibesys/config.py
@@ -1,7 +1,7 @@
 """Typed, schema-driven configuration for ``agent.toml``.
 
 The whole config is described by the :class:`Config` pydantic model and its
-nested sections. ``_load_config`` parses the TOML, validates it against that
+nested sections. ``load_config`` parses the TOML, validates it against that
 schema (fail-fast: missing required fields, unknown providers/backends, wrong
 types, **and unknown keys** all raise), applies environment-variable overrides,
 and returns a typed :class:`Config`. Consumers use attribute access
@@ -258,7 +258,7 @@ def _apply_vertex_env_overrides(config: Config) -> None:
         vx.region = env_region
 
 
-def _load_config(path: Path) -> Config:  # pyright: ignore[reportUnusedFunction]
+def load_config(path: Path) -> Config:
     """Load, validate, and env-override a TOML agent config file."""
     _load_dotenv_file()
     path = Path(path)

--- a/src/vibesys/constants.py
+++ b/src/vibesys/constants.py
@@ -5,18 +5,18 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 SKILLS_DIR = ".agents/skills/"
 
 # ANSI colors
-_DIM = "\033[2m"
-_RED = "\033[31m"
+DIM = "\033[2m"
+RED = "\033[31m"
 _BOLD = "\033[1m"
 _CYAN = "\033[36m"
 _MAGENTA = "\033[35m"
-_YELLOW = "\033[33m"
-_GREEN = "\033[32m"
-_RESET = "\033[0m"
+YELLOW = "\033[33m"
+GREEN = "\033[32m"
+RESET = "\033[0m"
 
-_ANTHROPIC_PREFIXES = ("claude-",)
-_GOOGLE_PREFIXES = ("gemini-", "gemma-")
-_OPENAI_PREFIXES = ("gpt-", "o1", "o3", "o4")
+ANTHROPIC_PREFIXES = ("claude-",)
+GOOGLE_PREFIXES = ("gemini-", "gemma-")
+OPENAI_PREFIXES = ("gpt-", "o1", "o3", "o4")
 
 
 class ComputeBackend(StrEnum):

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -1,23 +1,22 @@
 """Shared run context: ``_RunContext``, ``create_run_context``, and ``setup_exp_dir``."""
 
-# File-scoped strict relaxations to keep churn low while this module is
-# under active refactoring (see the _RunContext extraction PRs); pay down
-# once that work settles.
-# pyright: reportPrivateUsage=false, reportUnknownParameterType=false, reportMissingParameterType=false, reportDeprecated=false
-
 import shutil
 import subprocess
 import uuid
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator
 from contextlib import ExitStack, contextmanager
 from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
-from typing import Any, overload
+from typing import TYPE_CHECKING, Any, TextIO, TypeVar, overload
+
+from pydantic import BaseModel
 
 from vibesys import backends
 from vibesys.agents import build_agent_runner
+from vibesys.agents.base import AgentRunner
 from vibesys.agents.progress import AgentProgress
+from vibesys.backends.base import ComputeBackendImpl, ContentionMonitor
 from vibesys.config import Config, as_config
 from vibesys.constants import (
     DEFAULT_AGENT_BACKEND,
@@ -29,10 +28,11 @@ from vibesys.domains.base import DomainName
 from vibesys.domains.environment import (
     EnvironmentContext,
     EnvironmentHooks,
+    EnvironmentPatch,
     NoopEnvironmentHooks,
 )
 from vibesys.errors import ConfigurationDiagnostic, ConfigurationError
-from vibesys.llm_client import _build_model
+from vibesys.llm_client import build_model
 from vibesys.profilers import (
     ACTIVE_PROFILER_KINDS,
     ProfilerKind,
@@ -42,11 +42,18 @@ from vibesys.profilers import (
 )
 from vibesys.run import DeviceLease, GitTracker, RunCommands, RunLogger, RunPaths, Workspace
 from vibesys.sandbox.run_environment import (
+    RunEnvironment,
     RunEnvironmentRequest,
+    RunEnvironmentSession,
     RunEnvironmentSpec,
     build_run_environment,
     make_run_environment_spec,
 )
+
+if TYPE_CHECKING:
+    from vibesys.server.supervisor import RunSupervisor
+
+T = TypeVar("T", bound=BaseModel)
 
 
 def setup_exp_dir(
@@ -180,7 +187,7 @@ def create_run_context(
     resolved_backend = agent_backend or config.agent.backend or DEFAULT_AGENT_BACKEND
     resolved_cli_provider = cli_provider or config.agent.cli_provider or "codex"
 
-    model = _build_model(config)
+    model = build_model(config)
     model_name = config.model.name
 
     input_path_str = _coerce_dir_path(input_path, "--input")
@@ -408,14 +415,14 @@ class _RunContext:
         self,
         *,
         backend: ComputeBackend,
-        run_environment,
-        supervisor,
+        run_environment: RunEnvironment,
+        supervisor: "RunSupervisor | None",
         logger: RunLogger,
         paths: RunPaths,
         debug: bool,
         git_tracking: bool,
-        backend_impl,
-        model,
+        backend_impl: ComputeBackendImpl,
+        model: Any,
         model_name: str,
         input_path: str | None,
         workspace_seed_path: Path | None,
@@ -429,14 +436,14 @@ class _RunContext:
         ref_name: str,
         environment_hooks: EnvironmentHooks,
         environment_context: EnvironmentContext,
-        environment_patch,
+        environment_patch: EnvironmentPatch,
         workspace_files: Workspace,
         git: GitTracker,
         teardown_stack: ExitStack,
-        run_environment_session,
+        run_environment_session: RunEnvironmentSession,
         commands: RunCommands,
         device: DeviceLease,
-        agent_runner,
+        agent_runner: AgentRunner,
     ):
         self.backend = backend
         self.run_environment = run_environment
@@ -499,17 +506,17 @@ class _RunContext:
         return self._paths.run_log_path
 
     @property
-    def run_log_file(self):
+    def run_log_file(self) -> TextIO:
         """The current open log file handle (owned by ``RunLogger``)."""
         return self.logger.file
 
     @property
-    def gpu_monitor(self):
+    def gpu_monitor(self) -> "ContentionMonitor | None":
         """The active device monitor (owned by ``DeviceLease``)."""
         return self.device.monitor
 
     @gpu_monitor.setter
-    def gpu_monitor(self, monitor) -> None:
+    def gpu_monitor(self, monitor: "ContentionMonitor | None") -> None:
         self.device.monitor = monitor
 
     def gpu_env(self) -> dict[str, str]:
@@ -517,7 +524,7 @@ class _RunContext:
         return self.device.gpu_env()
 
     @contextmanager
-    def progress(self, progress: AgentProgress) -> Iterator[None]:
+    def progress(self, progress: AgentProgress) -> Generator[None]:
         """Temporarily attach loop progress to agent invocations in this context."""
         self._progress_stack.append(progress)
         try:
@@ -537,12 +544,12 @@ class _RunContext:
         kind: str,
         system_prompt: str,
         user_prompt: str,
-        response_cls,
-        fallback_factory: Callable[[], Any] | None = None,
+        response_cls: type[T],
+        fallback_factory: Callable[[], T],
         round_label: str = "",
         progress: AgentProgress | None = None,
-        **extra,
-    ):
+        **extra: Any,
+    ) -> T:
         """Invoke an agent through ``self.agent_runner`` with workspace+env defaults.
 
         Wraps ``self.agent_runner.invoke(...)`` so the per-call boilerplate
@@ -554,8 +561,8 @@ class _RunContext:
         supervisor = getattr(self, "supervisor", None)
         if supervisor is not None:
             supervisor.before_agent(kind, round_label, user_prompt, system_prompt)
-        result = None
-        error = None
+        result: T | None = None
+        error: BaseException | None = None
         try:
             result = self.agent_runner.invoke(
                 kind=kind,
@@ -564,9 +571,7 @@ class _RunContext:
                 env=self.gpu_env(),
                 user_prompt=user_prompt,
                 response_cls=response_cls,
-                # Every live call site supplies a factory; the None default
-                # is a legacy convenience.
-                fallback_factory=fallback_factory,  # pyright: ignore[reportArgumentType]
+                fallback_factory=fallback_factory,
                 round_label=round_label,
                 progress=progress if progress is not None else self.current_progress(),
                 **extra,

--- a/src/vibesys/llm_client.py
+++ b/src/vibesys/llm_client.py
@@ -5,29 +5,29 @@ from pydantic import SecretStr
 
 from vibesys.config import Config, ThinkingCfg
 from vibesys.constants import (
-    _ANTHROPIC_PREFIXES,  # pyright: ignore[reportPrivateUsage]
-    _GOOGLE_PREFIXES,  # pyright: ignore[reportPrivateUsage]
-    _OPENAI_PREFIXES,  # pyright: ignore[reportPrivateUsage]
+    ANTHROPIC_PREFIXES,
+    GOOGLE_PREFIXES,
+    OPENAI_PREFIXES,
 )
 
 
 def _is_google_model(model_name: str) -> bool:
-    return any(model_name.startswith(p) for p in _GOOGLE_PREFIXES)
+    return any(model_name.startswith(p) for p in GOOGLE_PREFIXES)
 
 
 def _is_anthropic_model(model_name: str) -> bool:
-    return any(model_name.startswith(p) for p in _ANTHROPIC_PREFIXES)
+    return any(model_name.startswith(p) for p in ANTHROPIC_PREFIXES)
 
 
 def _is_openai_model(model_name: str) -> bool:
-    return any(model_name.startswith(p) for p in _OPENAI_PREFIXES)
+    return any(model_name.startswith(p) for p in OPENAI_PREFIXES)
 
 
 def _has_thinking(thinking: ThinkingCfg) -> bool:
     return bool(thinking.level or thinking.budget)
 
 
-def _build_model(config: Config):  # pyright: ignore[reportUnusedFunction]
+def build_model(config: Config):
     """Build the chat model from a parsed :class:`Config`."""
     model_name = config.model.name
     provider = config.model.provider

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -882,6 +882,10 @@ def run_agent_loop(
         raise ValueError(
             f"Unknown inner_loop {inner_loop!r}; choose from {', '.join(_INNER_LOOPS)}"
         )
+    if max_retries_per_round < 1:
+        # Guard against a zero-iteration retry loop: with no attempts the
+        # round bookkeeping below would reference an unbound loop variable.
+        raise ValueError(f"max_retries_per_round must be >= 1, got {max_retries_per_round}")
     if interface not in _INTERFACES:
         raise ValueError(f"Unknown interface {interface!r}; choose from {', '.join(_INTERFACES)}")
     if domain is None:
@@ -1022,6 +1026,10 @@ def run_agent_loop(
                 passed = False
                 single_agent_response: SingleAgentRoundResponse | None = None
                 framework_perf_metric: float | None = None
+                # ``max_retries_per_round >= 1`` is validated at entry, so the
+                # loop always runs; the initializer keeps ``retry`` provably
+                # bound for the post-loop round bookkeeping.
+                retry = 0
                 for retry in range(1, max_retries_per_round + 1):
                     ctx.lprint(f"\n--- attempt {retry}/{max_retries_per_round} ---\n")
                     if inner_loop == "multi-agent":
@@ -1155,7 +1163,7 @@ def run_agent_loop(
                         status=EventStatus.COMPLETED if passed else EventStatus.FAILED,
                         round_label=f"round-{round_number}",
                         data=RoundFinishedData(
-                            attempts=retry,  # pyright: ignore[reportPossiblyUnboundVariable]
+                            attempts=retry,
                             judge_verdict="pass" if passed else "fail",
                             perf_metric=perf_metric,
                             perf_unit=perf_unit,

--- a/src/vibesys/loops/plain/loop.py
+++ b/src/vibesys/loops/plain/loop.py
@@ -89,7 +89,7 @@ def _save_state(log_dir: Path, state: PlainLoopState) -> None:
     os.replace(tmp, target)
 
 
-def _load_state(log_dir: Path) -> PlainLoopState | None:  # pyright: ignore[reportUnusedFunction]
+def load_state(log_dir: Path) -> PlainLoopState | None:
     path = log_dir / "state.json"
     if not path.is_file():
         return None

--- a/src/vibesys/loops/plain/runner_ext.py
+++ b/src/vibesys/loops/plain/runner_ext.py
@@ -72,11 +72,12 @@ class PlainLoopAgentRunner:
         self,
         *,
         kind: str,
+        response_cls: type[T],
         iteration: int | None = None,
         mcp_servers: list[MCPServerSpec] | None = None,
         tools: list[BaseTool] | None = None,
         **kwargs: Any,
-    ) -> T:  # pyright: ignore[reportInvalidTypeVarUse]
+    ) -> T:
         if kind in ("judge", "perf_eval"):
             if iteration is None:
                 raise ValueError(
@@ -102,6 +103,7 @@ class PlainLoopAgentRunner:
         # implementer (and any other phase) passes through unmodified.
         return self._inner.invoke(
             kind=kind,
+            response_cls=response_cls,
             mcp_servers=mcp_servers,
             tools=tools,
             **kwargs,

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -21,11 +21,12 @@ import json
 import os
 import sys
 import tomllib
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
-from vibesys.config import Config, _load_config  # pyright: ignore[reportPrivateUsage]
+from vibesys.config import Config, load_config
 from vibesys.constants import (
     KNOWN_COMPUTE_BACKENDS,
     PROJECT_ROOT,
@@ -329,7 +330,7 @@ def load_config_and_skills(
         config = Config.model_validate(tomllib.loads(_STUB_AGENT_DEFAULT_CONFIG_TEXT))
     else:
         try:
-            config = _load_config(args.config)
+            config = load_config(args.config)
         except (ValueError, FileNotFoundError) as e:
             _configuration_error(str(e), code="config_load_failed", stage="config_loading")
 
@@ -627,15 +628,17 @@ def _validate_target_inputs(args: argparse.Namespace) -> None:
         _configuration_error(str(exc), code="invalid_input", stage="input_loading")
 
 
-def _validate_agent(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnusedFunction]
+def _validate_agent(args: argparse.Namespace) -> None:
     if args.modal and args.profiler not in _MODAL_PROFILERS:
         _configuration_error(
             "Error: --modal only supports --profiler=torch, --profiler=auto, or --profiler=none.",
         )
+    if args.max_retries_per_round < 1:
+        _configuration_error("Error: --max-retries-per-round must be >= 1.")
     _validate_target_inputs(args)
 
 
-def _run_agent(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnusedFunction]
+def _run_agent(args: argparse.Namespace) -> None:
     config, skills, backend = load_config_and_skills(args)
     from vibesys.loops.agent.loop import run_agent_loop
 
@@ -785,7 +788,7 @@ def _build_evolve_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _validate_evolve(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnusedFunction]
+def _validate_evolve(args: argparse.Namespace) -> None:
     if args.modal and args.profiler not in _MODAL_PROFILERS:
         _configuration_error(
             "Error: --modal only supports --profiler=torch, --profiler=auto, or --profiler=none.",
@@ -801,7 +804,7 @@ def _validate_evolve(args: argparse.Namespace) -> None:  # pyright: ignore[repor
         _configuration_error("--frontier-bias must be in [0, 1].")
 
 
-def _run_evolve(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnusedFunction]
+def _run_evolve(args: argparse.Namespace) -> None:
     config, skills, backend = load_config_and_skills(args)
     from vibesys.loops.evolve.loop import run_evolve_loop
 
@@ -878,7 +881,7 @@ def _build_plain_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _validate_plain(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnusedFunction]
+def _validate_plain(args: argparse.Namespace) -> None:
     if args.modal and args.profiler not in _MODAL_PROFILERS:
         _configuration_error(
             "Error: --modal only supports --profiler=torch, --profiler=auto, or --profiler=none.",
@@ -886,11 +889,11 @@ def _validate_plain(args: argparse.Namespace) -> None:  # pyright: ignore[report
     _validate_target_inputs(args)
 
 
-def _run_plain(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnusedFunction]
+def _run_plain(args: argparse.Namespace) -> None:
     config, skills, backend = load_config_and_skills(args)
     from vibesys.loops.plain.loop import (
         PlainLoopState,
-        _load_state,  # pyright: ignore[reportPrivateUsage]
+        load_state,
         run_plain_loop,
     )
 
@@ -915,7 +918,7 @@ def _run_plain(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnuse
                 bootstrap_done=True,
             )
         else:
-            resume_state = _load_state(log_dir)
+            resume_state = load_state(log_dir)
             if resume_state is not None:
                 print(
                     f"Auto-detected state: round {resume_state.round_idx + 1}, "
@@ -967,22 +970,19 @@ def _run_plain(args: argparse.Namespace) -> None:  # pyright: ignore[reportUnuse
 # ===========================================================================
 
 
-_PARSER_BUILDERS = {
-    "agent": _build_agent_parser,
-    "plain": _build_plain_parser,
-    "evolve": _build_evolve_parser,
-}
+@dataclass(frozen=True)
+class _LoopCommand:
+    """Typed dispatch record for one ``--outer-loop`` kind."""
 
-_VALIDATORS = {
-    "agent": "_validate_agent",
-    "plain": "_validate_plain",
-    "evolve": "_validate_evolve",
-}
+    build_parser: Callable[[], argparse.ArgumentParser]
+    validate: Callable[[argparse.Namespace], None]
+    run: Callable[[argparse.Namespace], None]
 
-_RUNNERS = {
-    "agent": "_run_agent",
-    "plain": "_run_plain",
-    "evolve": "_run_evolve",
+
+_LOOP_COMMANDS: dict[str, _LoopCommand] = {
+    "agent": _LoopCommand(_build_agent_parser, _validate_agent, _run_agent),
+    "plain": _LoopCommand(_build_plain_parser, _validate_plain, _run_plain),
+    "evolve": _LoopCommand(_build_evolve_parser, _validate_evolve, _run_evolve),
 }
 
 
@@ -990,9 +990,10 @@ def parse_cli_invocation(argv: list[str]) -> CliInvocation:
     """Parse and validate one invocation without printing or exiting."""
     argv = _prepare_stub_agent_smoke_defaults(argv)
     loop_kind, remaining = _extract_loop_selection(argv)
-    args = _PARSER_BUILDERS[loop_kind]().parse_args(remaining)
+    command = _LOOP_COMMANDS[loop_kind]
+    args = command.build_parser().parse_args(remaining)
     _resolve_resume_args(args)
-    globals()[_VALIDATORS[loop_kind]](args)
+    command.validate(args)
     return CliInvocation(loop_kind=loop_kind, args=args)
 
 
@@ -1003,7 +1004,7 @@ def _dispatch(argv: list[str]) -> None:
 
     invocation = parse_cli_invocation(argv)
     loop_kind, args = invocation.loop_kind, invocation.args
-    runner = globals()[_RUNNERS[loop_kind]]
+    runner = _LOOP_COMMANDS[loop_kind].run
     from vibesys.server.events import EventStatus, EventType, RunStartedData
     from vibesys.server.registry import active_supervisor
 

--- a/src/vibesys/run/logger.py
+++ b/src/vibesys/run/logger.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TextIO
 
-from vibesys.agent_runner import _log_and_print  # pyright: ignore[reportPrivateUsage]
+from vibesys.agent_runner import log_and_print
 
 
 class _TeeWriter:
@@ -45,7 +45,7 @@ class RunLogger:
             sys.stderr = _TeeWriter(self._original_stderr, self.file)
 
     def lprint(self, text: str) -> None:
-        _log_and_print(text, self.file)
+        log_and_print(text, self.file)
 
     def switch(self, label: int | str):
         """Switch to a per-phase log file (``run-<datetime>-<label>.log``).

--- a/src/vibesys/run/protocol.py
+++ b/src/vibesys/run/protocol.py
@@ -7,14 +7,19 @@ concrete class, which keeps the facade's construction internals out of the
 loops' contract.
 """
 
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, TypeVar
+
+from pydantic import BaseModel
 
 from vibesys.agents.progress import AgentProgress
 from vibesys.constants import ComputeBackend
 from vibesys.profilers import ProfilerKind
 from vibesys.run.git_tracker import GitTracker
+
+T = TypeVar("T", bound=BaseModel)
 
 
 class LoopContext(Protocol):
@@ -66,12 +71,12 @@ class LoopContext(Protocol):
         kind: str,
         system_prompt: str,
         user_prompt: str,
-        response_cls: Any,
-        fallback_factory: Any = None,
+        response_cls: type[T],
+        fallback_factory: Callable[[], T],
         round_label: str = "",
         progress: AgentProgress | None = None,
         **extra: Any,
-    ) -> Any: ...
+    ) -> T: ...
 
     def progress(self, progress: AgentProgress) -> AbstractContextManager[None]: ...
 

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -396,7 +396,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         meta_path = request.ref_dir / "meta.json"
         if not meta_path.exists():
             return
-        from vs_sandbox.modal_model_setup import ensure_model_volume
+        from vs_sandbox import ensure_model_volume
 
         meta = json.loads(meta_path.read_text())
         model_id = meta.get("model_id")
@@ -433,7 +433,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         draft_meta_path = request.ref_dir / "draft_meta.json"
         if not draft_meta_path.exists():
             return None
-        from vs_sandbox.modal_model_setup import ensure_model_volume
+        from vs_sandbox import ensure_model_volume
 
         draft_meta = json.loads(draft_meta_path.read_text())
         draft_model_id = draft_meta.get("model_id")

--- a/tests/_agent_cli/test_cleanup.py
+++ b/tests/_agent_cli/test_cleanup.py
@@ -6,7 +6,7 @@ import pytest
 from agentshim.executor import CommandRequest, CommandResult, CommandStreamSink
 
 from vibesys._agent_cli.claude import ClaudeCodeCodingAgent
-from vibesys._agent_cli.cli_agent import CLICodingAgent
+from vibesys._agent_cli.cli_agent import CLICodingAgent, CLIGenerationSession
 from vibesys._agent_cli.codex import CodexCodingAgent
 from vibesys._agent_cli.gemini import GeminiCodingAgent
 
@@ -56,12 +56,32 @@ class RecordingExecutor:
         )
 
 
-class DummyAgent(CLICodingAgent):
+class DummyAgent(CLICodingAgent[CLIGenerationSession]):
     def __init__(self, executor: RecordingExecutor):
         super().__init__("dummy", executor=executor)
 
     def _get_command(self, prompt: str) -> list[str]:
         return [self.binary_path, "run"]
+
+    def _create_session(
+        self,
+        cmd: list[str],
+        cwd: str | None = None,
+        timeout: int | None = None,
+        silent: bool = False,
+    ) -> CLIGenerationSession:
+        return CLIGenerationSession(
+            binary_name=self.binary_name,
+            env=self.env,
+            log_prefix=self._log_prefix,
+            cmd=cmd,
+            logger=self.logger,
+            cwd=cwd,
+            timeout=timeout,
+            silent=silent,
+            event_handler=self.event_handler,
+            executor=self.executor,
+        )
 
 
 def test_agent_initialization_uses_command_executor():

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import pytest
 
 from vibesys._agent_cli import hostsandbox
-from vibesys._agent_cli.cli_agent import CLICodingAgent
+from vibesys._agent_cli.cli_agent import CLICodingAgent, CLIGenerationSession
 
 # ---------------------------------------------------------------------------
 # Real-sandbox availability probe
@@ -335,7 +335,7 @@ class TestSeatbeltProfile:
 # ---------------------------------------------------------------------------
 
 
-class _StubAgent(CLICodingAgent):
+class _StubAgent(CLICodingAgent[CLIGenerationSession]):
     """A concrete CLICodingAgent that runs a fixed script, skipping binary
     detection — mirrors the pattern in ``test_codex.py``."""
 
@@ -357,6 +357,26 @@ class _StubAgent(CLICodingAgent):
 
     def _get_command(self, prompt: str) -> list[str]:
         return [self._script]
+
+    def _create_session(
+        self,
+        cmd: list[str],
+        cwd: str | None = None,
+        timeout: int | None = None,
+        silent: bool = False,
+    ) -> CLIGenerationSession:
+        return CLIGenerationSession(
+            binary_name=self.binary_name,
+            env=self.env,
+            log_prefix=self._log_prefix,
+            cmd=cmd,
+            logger=self.logger,
+            cwd=cwd,
+            timeout=timeout,
+            silent=silent,
+            event_handler=self.event_handler,
+            executor=self.executor,
+        )
 
 
 def _escape_probe(tmp_path_factory) -> tuple[_StubAgent, Path, Path]:

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vibesys.agent_runner import _log_json_and_print, _log_prompt_markdown_and_print
+from vibesys.agent_runner import log_json_and_print, log_prompt_markdown_and_print
 from vibesys.agents import build_agent_runner
 from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.cli_runner import CliAgentRunner
@@ -38,7 +38,7 @@ def test_prompt_markdown_emitter_preserves_raw_log_and_truncates_stdout(capsys):
     log = StringIO()
     prompt = "# Title\n\nUse **markdown** and `code`."
 
-    _log_prompt_markdown_and_print(prompt, log_file=log, max_len=20)
+    log_prompt_markdown_and_print(prompt, log_file=log, max_len=20)
 
     stdout = capsys.readouterr().out
     assert "Title" in stdout
@@ -51,7 +51,7 @@ def test_json_emitter_preserves_raw_log(capsys):
     log = StringIO()
     raw_json = '{"analysis":"ok","items":[1,2]}'
 
-    _log_json_and_print(raw_json, log_file=log)
+    log_json_and_print(raw_json, log_file=log)
 
     stdout = capsys.readouterr().out
     assert raw_json in stdout
@@ -69,7 +69,7 @@ class TestDeepAgentsRunner:
         )
         with (
             patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
-            patch("vibesys.agents.deepagents_runner._run_typed_agent") as mock_run,
+            patch("vibesys.agents.deepagents_runner.run_typed_agent") as mock_run,
         ):
             mock_create.return_value = MagicMock(name="deep_agent")
             mock_run.return_value = pass_response
@@ -122,7 +122,7 @@ class TestDeepAgentsRunner:
                 side_effect=_capture,
             ),
             patch(
-                "vibesys.agents.deepagents_runner._run_typed_agent",
+                "vibesys.agents.deepagents_runner.run_typed_agent",
                 return_value=_judge_fallback(),
             ),
         ):

--- a/tests/agents/test_callbacks.py
+++ b/tests/agents/test_callbacks.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.progress import RoundProgress
-from vibesys.constants import _DIM, _GREEN, _RED, _RESET
+from vibesys.constants import DIM, GREEN, RED, RESET
 
 _ANSI_RE = re.compile(r"\033\[[0-9;]*m")
 
@@ -63,7 +63,7 @@ class TestOnLlmEnd:
         logger.on_llm_end(_make_response("some text"))
         out = capsys.readouterr().out
         # Only the newline, no green-wrapped text
-        assert f"{_GREEN}some text{_RESET}" not in out
+        assert f"{GREEN}some text{RESET}" not in out
 
     def test_not_streaming_prints_text(self, capsys):
         logger = AgentLogger()
@@ -151,8 +151,8 @@ class TestOnToolEnd:
         logger.on_tool_end(output)
         out = capsys.readouterr().out
         assert "ok" in out
-        assert _DIM not in out
-        assert _RED not in out
+        assert DIM not in out
+        assert RED not in out
 
     def test_error_status_is_plain_text(self, capsys):
         logger = AgentLogger()
@@ -163,8 +163,8 @@ class TestOnToolEnd:
         logger.on_tool_end(output)
         out = capsys.readouterr().out
         assert "Error: file not found" in out
-        assert _RED not in out
-        assert _DIM not in out
+        assert RED not in out
+        assert DIM not in out
 
     def test_command_failed_exit_code_is_plain_text(self, capsys):
         logger = AgentLogger()
@@ -179,8 +179,8 @@ class TestOnToolEnd:
         logger.on_tool_end(output)
         out = capsys.readouterr().out
         assert "Exit code: 128" in out
-        assert _RED not in out
-        assert _DIM not in out
+        assert RED not in out
+        assert DIM not in out
 
     def test_command_succeeded_exit_code_is_plain_text(self, capsys):
         logger = AgentLogger()
@@ -191,8 +191,8 @@ class TestOnToolEnd:
         logger.on_tool_end(output)
         out = capsys.readouterr().out
         assert "hello world" in out
-        assert _DIM not in out
-        assert _RED not in out
+        assert DIM not in out
+        assert RED not in out
 
 
 class TestOnToolError:
@@ -202,7 +202,7 @@ class TestOnToolError:
 
         logger.on_tool_error(Exception("something broke"), run_id=uuid4())
         out = capsys.readouterr().out
-        assert _RED not in out
+        assert RED not in out
         assert "something broke" in out
         assert "Tool error" in out
 
@@ -212,7 +212,7 @@ class TestOnToolError:
 
         logger.on_tool_error(Exception("fail"), run_id=uuid4())
         out = capsys.readouterr().out
-        assert _DIM not in out
+        assert DIM not in out
 
 
 class TestStateManagement:

--- a/tests/backends/test_cpu_backend.py
+++ b/tests/backends/test_cpu_backend.py
@@ -13,7 +13,7 @@ from vibesys.backends.local import LocalBackend
 from vibesys.constants import ComputeBackend
 from vibesys.main import _add_common_args
 from vibesys.profilers import ProfilerKind
-from vs_sandbox.docker_sandbox import DockerSandbox
+from vs_sandbox import DockerSandbox
 
 
 def _make_backend(tmp_path) -> LocalBackend:

--- a/tests/backends/test_gpu_monitor.py
+++ b/tests/backends/test_gpu_monitor.py
@@ -271,7 +271,7 @@ class TestReselectGpu:
         from vibesys.backends.cuda import CudaBackend
         from vibesys.context import _RunContext
         from vibesys.run import RunPaths
-        from vs_sandbox.docker_sandbox import DockerSandbox
+        from vs_sandbox import DockerSandbox
 
         ctx = object.__new__(_RunContext)
         ctx.selected_gpu = selected_gpu

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -138,7 +138,7 @@ def _invoke_orchestrate(tmp_path, ref_file, runner, **kwargs):
     )
     defaults.update(kwargs)
     with (
-        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.backends.cuda.LocalShellBackend"),
         patch("vibesys.context.build_agent_runner", return_value=runner),
         patch("vibesys.context.PROJECT_ROOT", tmp_path),

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -118,7 +118,7 @@ def _invoke_loop(tmp_path, ref_file, runner, **kwargs):
     )
     defaults.update(kwargs)
     with (
-        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.backends.cuda.LocalShellBackend"),
         patch("vibesys.context.build_agent_runner", return_value=runner),
         patch("vibesys.context.PROJECT_ROOT", tmp_path),

--- a/tests/loops/plain/test_plain_loop.py
+++ b/tests/loops/plain/test_plain_loop.py
@@ -116,7 +116,7 @@ def ref_file(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_bootstrap_creates_initial_feature_issue_on_first_run(
@@ -155,7 +155,7 @@ def test_bootstrap_creates_initial_feature_issue_on_first_run(
     assert "FastAPI" in title or "inference server" in title
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_bootstrap_idempotent_on_resume(
@@ -217,7 +217,7 @@ def test_bootstrap_idempotent_on_resume(
 # ---------------------------------------------------------------------------
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_judge_pass_closes_issue(mock_build_runner, mock_backend, mock_build, ref_file, tmp_path):
@@ -247,7 +247,7 @@ def test_judge_pass_closes_issue(mock_build_runner, mock_backend, mock_build, re
     assert issue1.status == IssueStatus.CLOSED
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_judge_fail_increments_attempts_and_keeps_open(
@@ -286,7 +286,7 @@ def test_judge_fail_increments_attempts_and_keeps_open(
     assert issue1.status == IssueStatus.CLOSED
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_issue_blocks_after_max_attempts_exhausted(
@@ -359,7 +359,7 @@ _EXPECTED_TRACKER_TOOL_NAMES = {
 
 
 @pytest.mark.parametrize("backend_name", ["deepagents", "cli"])
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_judge_invoke_receives_tracker_kwargs(
@@ -419,7 +419,7 @@ def test_judge_invoke_receives_tracker_kwargs(
 
 
 @pytest.mark.parametrize("backend_name", ["deepagents", "cli"])
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_perf_eval_invoke_receives_tracker_kwargs(
@@ -476,7 +476,7 @@ def test_perf_eval_invoke_receives_tracker_kwargs(
         assert {t.name for t in tools} == _EXPECTED_TRACKER_TOOL_NAMES
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_judge_phase_calls_store_reload_after_invoke(
@@ -541,7 +541,7 @@ def test_judge_phase_calls_store_reload_after_invoke(
 
 
 @pytest.mark.parametrize("backend_name", ["deepagents", "cli"])
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_implementer_invoke_has_no_tracker_kwargs(
@@ -601,7 +601,7 @@ def test_implementer_invoke_has_no_tracker_kwargs(
 # ---------------------------------------------------------------------------
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_perf_eval_runs_after_drain_complete(
@@ -650,7 +650,7 @@ def test_perf_eval_runs_after_drain_complete(
 # ---------------------------------------------------------------------------
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_resume_with_bootstrap_done_skips_bootstrap_creation(
@@ -708,7 +708,7 @@ def test_resume_with_bootstrap_done_skips_bootstrap_creation(
     assert kinds == ["perf_eval"]
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_resume_retries_previously_blocked_issue(
@@ -784,7 +784,7 @@ def test_resume_retries_previously_blocked_issue(
 # ---------------------------------------------------------------------------
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_run_returns_true_when_perf_eval_files_no_issues_after_clean_drain(
@@ -820,7 +820,7 @@ def test_run_returns_true_when_perf_eval_files_no_issues_after_clean_drain(
 # ---------------------------------------------------------------------------
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_state_json_written_with_bootstrap_done_after_run(
@@ -861,7 +861,7 @@ def test_state_json_written_with_bootstrap_done_after_run(
 # ---------------------------------------------------------------------------
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_issue_loop_writes_per_issue_markdown_via_callback(
@@ -923,7 +923,7 @@ def test_issue_loop_writes_per_issue_markdown_via_callback(
 # ---------------------------------------------------------------------------
 
 
-@patch("vibesys.context._build_model")
+@patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
 def test_implementer_retry_user_prompt_includes_prior_judge_feedback(

--- a/tests/loops/plain/test_plain_loop_state.py
+++ b/tests/loops/plain/test_plain_loop_state.py
@@ -5,8 +5,8 @@ import json
 from vibesys.loops.plain.loop import (
     PlainLoopState,
     _determine_resume_point,
-    _load_state,
     _save_state,
+    load_state,
 )
 from vs_issue_board import IssueBoard, IssueStatus, IssueType
 
@@ -16,7 +16,7 @@ def _make_store(tmp_path) -> IssueBoard:
 
 
 # ---------------------------------------------------------------------------
-# _save_state / _load_state round-trip
+# _save_state / load_state round-trip
 # ---------------------------------------------------------------------------
 
 
@@ -29,7 +29,7 @@ class TestSaveLoadState:
             bootstrap_done=True,
         )
         _save_state(tmp_path, state)
-        loaded = _load_state(tmp_path)
+        loaded = load_state(tmp_path)
         assert loaded is not None
         assert loaded.round_idx == 2
         assert loaded.phase == "judge"
@@ -37,17 +37,17 @@ class TestSaveLoadState:
         assert loaded.bootstrap_done is True
 
     def test_load_missing(self, tmp_path):
-        assert _load_state(tmp_path) is None
+        assert load_state(tmp_path) is None
 
     def test_load_corrupt_json(self, tmp_path):
         (tmp_path / "state.json").write_text("not json", encoding="utf-8")
-        assert _load_state(tmp_path) is None
+        assert load_state(tmp_path) is None
 
     def test_load_wrong_version(self, tmp_path):
         (tmp_path / "state.json").write_text(
             json.dumps({"version": 999, "iteration": 0}), encoding="utf-8"
         )
-        assert _load_state(tmp_path) is None
+        assert load_state(tmp_path) is None
 
     def test_atomic_write_leaves_no_tmp(self, tmp_path):
         _save_state(tmp_path, PlainLoopState())
@@ -64,7 +64,7 @@ class TestSaveLoadState:
             "extra_field": "ignored",
         }
         (tmp_path / "state.json").write_text(json.dumps(data), encoding="utf-8")
-        loaded = _load_state(tmp_path)
+        loaded = load_state(tmp_path)
         assert loaded is not None
         assert loaded.round_idx == 3
         assert loaded.bootstrap_done is True

--- a/tests/loops/plain/test_plain_runner_ext.py
+++ b/tests/loops/plain/test_plain_runner_ext.py
@@ -9,6 +9,7 @@ LangChain ``@tool`` callables. Implementer phase passes through.
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import BaseModel
 
 from vibesys._agent_cli.base import MCPServerSpec
 from vibesys.agents.base import AgentRunner
@@ -16,6 +17,10 @@ from vibesys.loops.plain.runner_ext import PlainLoopAgentRunner
 from vs_issue_board import IssueBoard
 
 _EXPECTED_TOOL_NAMES = {"list_issues", "get_issue", "search_issues", "create_issue"}
+
+
+class _Resp(BaseModel):
+    """Minimal response model for exercising the wrapper's typed invoke."""
 
 
 def _mock_runner(backend_name: str) -> MagicMock:
@@ -44,7 +49,7 @@ class TestDeepAgentsBackend:
         inner = _mock_runner("deepagents")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
-        wrapper.invoke(kind="judge", iteration=2, round_label="r")
+        wrapper.invoke(response_cls=_Resp, kind="judge", iteration=2, round_label="r")
 
         inner.invoke.assert_called_once()
         kwargs = inner.invoke.call_args.kwargs
@@ -57,7 +62,7 @@ class TestDeepAgentsBackend:
         inner = _mock_runner("deepagents")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=4)
 
-        wrapper.invoke(kind="perf_eval", iteration=5, round_label="r")
+        wrapper.invoke(response_cls=_Resp, kind="perf_eval", iteration=5, round_label="r")
 
         kwargs = inner.invoke.call_args.kwargs
         assert kwargs["kind"] == "perf_eval"
@@ -71,7 +76,7 @@ class TestDeepAgentsBackend:
         inner = _mock_runner("deepagents")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=5)
 
-        wrapper.invoke(kind="perf_eval", iteration=1, round_label="r")
+        wrapper.invoke(response_cls=_Resp, kind="perf_eval", iteration=1, round_label="r")
         tools = inner.invoke.call_args.kwargs["tools"]
         create = next(t for t in tools if t.name == "create_issue")
 
@@ -88,7 +93,7 @@ class TestDeepAgentsBackend:
         inner = _mock_runner("deepagents")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
-        wrapper.invoke(kind="judge", iteration=1, round_label="r")
+        wrapper.invoke(response_cls=_Resp, kind="judge", iteration=1, round_label="r")
         tools = inner.invoke.call_args.kwargs["tools"]
         create = next(t for t in tools if t.name == "create_issue")
 
@@ -108,7 +113,7 @@ class TestCliBackend:
         inner = _mock_runner("cli")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
-        wrapper.invoke(kind="judge", iteration=7, round_label="r")
+        wrapper.invoke(response_cls=_Resp, kind="judge", iteration=7, round_label="r")
 
         kwargs = inner.invoke.call_args.kwargs
         assert kwargs["tools"] is None
@@ -131,7 +136,7 @@ class TestCliBackend:
         inner = _mock_runner("cli")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=4)
 
-        wrapper.invoke(kind="perf_eval", iteration=2, round_label="r")
+        wrapper.invoke(response_cls=_Resp, kind="perf_eval", iteration=2, round_label="r")
 
         kwargs = inner.invoke.call_args.kwargs
         assert kwargs["tools"] is None
@@ -155,7 +160,7 @@ class TestPassThrough:
         inner = _mock_runner("deepagents")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
-        wrapper.invoke(kind="implementer", round_label="r")
+        wrapper.invoke(response_cls=_Resp, kind="implementer", round_label="r")
 
         kwargs = inner.invoke.call_args.kwargs
         assert kwargs["kind"] == "implementer"
@@ -167,7 +172,7 @@ class TestPassThrough:
         inner = _mock_runner("cli")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
-        wrapper.invoke(kind="implementer", round_label="r")
+        wrapper.invoke(response_cls=_Resp, kind="implementer", round_label="r")
 
         kwargs = inner.invoke.call_args.kwargs
         assert kwargs["mcp_servers"] is None
@@ -180,7 +185,7 @@ class TestPassThrough:
         inner = _mock_runner("deepagents")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
-        wrapper.invoke(kind="judge", iteration=1, round_label="r")
+        wrapper.invoke(response_cls=_Resp, kind="judge", iteration=1, round_label="r")
 
         assert "iteration" not in inner.invoke.call_args.kwargs
 
@@ -192,6 +197,7 @@ class TestPassThrough:
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(
+            response_cls=_Resp,
             kind="judge",
             iteration=1,
             workspace="/tmp/ws",
@@ -216,7 +222,7 @@ class TestValidation:
             max_issues_per_perf_eval=3,
         )
         with pytest.raises(ValueError, match="iteration"):
-            wrapper.invoke(kind="judge", round_label="r")
+            wrapper.invoke(response_cls=_Resp, kind="judge", round_label="r")
 
     def test_perf_eval_without_iteration_raises(self, tmp_path):
         store = _make_store(tmp_path)
@@ -226,7 +232,7 @@ class TestValidation:
             max_issues_per_perf_eval=3,
         )
         with pytest.raises(ValueError, match="iteration"):
-            wrapper.invoke(kind="perf_eval", round_label="r")
+            wrapper.invoke(response_cls=_Resp, kind="perf_eval", round_label="r")
 
 
 class TestBackendName:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from vibesys.config import _load_config, _load_dotenv_file
+from vibesys.config import _load_dotenv_file, load_config
 from vibesys.features import FeatureFlag
 
 
@@ -36,7 +36,7 @@ region = "us-east5"
 
 [providers.google-genai]
 """)
-        config = _load_config(cfg_file)
+        config = load_config(cfg_file)
         assert config.model.name == "claude-sonnet-4-6"
         assert config.model.provider == "vertex-ai"
         assert config.thinking.level == "medium"
@@ -48,7 +48,7 @@ region = "us-east5"
     def test_minimal_config(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
-        config = _load_config(cfg_file)
+        config = load_config(cfg_file)
         assert config.model.name == "claude-sonnet-4-6"
         assert config.model.provider is None
         assert config.thinking.level is None
@@ -63,17 +63,17 @@ class TestLoadConfigErrors:
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("[model]\nprovider = 'vertex-ai'\n")
         with pytest.raises(ValueError, match="name"):
-            _load_config(cfg_file)
+            load_config(cfg_file)
 
     def test_missing_file(self):
         with pytest.raises(FileNotFoundError):
-            _load_config(Path("/nonexistent/agent.toml"))
+            load_config(Path("/nonexistent/agent.toml"))
 
     def test_invalid_toml(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("not valid toml [[[")
         with pytest.raises(tomllib.TOMLDecodeError):
-            _load_config(cfg_file)
+            load_config(cfg_file)
 
     def test_unknown_provider(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
@@ -83,7 +83,7 @@ name = "claude-sonnet-4-6"
 provider = "bedrock"
 """)
         with pytest.raises(ValueError, match="bedrock"):
-            _load_config(cfg_file)
+            load_config(cfg_file)
 
     def test_unknown_feature_flag(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
@@ -95,7 +95,7 @@ name = "claude-sonnet-4-6"
 new_loop = true
 """)
         with pytest.raises(ValueError, match="Unknown feature flag 'new_loop'"):
-            _load_config(cfg_file)
+            load_config(cfg_file)
 
 
 class TestLoadConfigFeatureFlags:
@@ -108,7 +108,7 @@ name = "claude-sonnet-4-6"
 [feature_flags]
 example_feature = true
 """)
-        config = _load_config(cfg_file)
+        config = load_config(cfg_file)
 
         assert config.feature_flags == {FeatureFlag.EXAMPLE_FEATURE: True}
 
@@ -120,19 +120,19 @@ class TestLoadConfigStrict:
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n\n[bogus]\nx = 1\n')
         with pytest.raises(ValueError, match="bogus"):
-            _load_config(cfg_file)
+            load_config(cfg_file)
 
     def test_unknown_key_in_known_section_rejected(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n\n[agent]\ncli_modle = "x"\n')
         with pytest.raises(ValueError, match="cli_modle"):
-            _load_config(cfg_file)
+            load_config(cfg_file)
 
     def test_unknown_backend_rejected(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n\n[backend]\nname = "tpu"\n')
         with pytest.raises(ValueError, match="tpu"):
-            _load_config(cfg_file)
+            load_config(cfg_file)
 
     def test_removed_cli_model_key_rejected(self, tmp_path):
         # [agent].cli_model was removed in favour of [model].name driving the
@@ -143,14 +143,14 @@ class TestLoadConfigStrict:
             '[model]\nname = "gpt-5.4"\n\n[agent]\ncli_provider = "codex"\ncli_model = "gpt-5-codex"\n'
         )
         with pytest.raises(ValueError, match="cli_model"):
-            _load_config(cfg_file)
+            load_config(cfg_file)
 
 
 class TestLoadConfigProviderDefault:
     def test_missing_provider_defaults_to_none(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
-        config = _load_config(cfg_file)
+        config = load_config(cfg_file)
         assert config.model.provider is None
 
 
@@ -170,7 +170,7 @@ provider = "vertex-ai"
             "VERTEX_REGION": "us-central1",
         }
         with patch.dict("os.environ", env, clear=False):
-            config = _load_config(cfg_file)
+            config = load_config(cfg_file)
         vx = config.providers.vertex_ai
         assert vx.json_path == "/env/key.json"
         assert vx.project == "env-project"
@@ -194,7 +194,7 @@ region = "us-east5"
             "VERTEX_REGION": "us-central1",
         }
         with patch.dict("os.environ", env, clear=False):
-            config = _load_config(cfg_file)
+            config = load_config(cfg_file)
         vx = config.providers.vertex_ai
         assert vx.json_path == "/env/key.json"
         assert vx.project == "env-project"
@@ -251,7 +251,7 @@ name = "gemini-2.5-pro"
 level = "high"
 budget = 2048
 """)
-        config = _load_config(cfg_file)
+        config = load_config(cfg_file)
         assert config.thinking.level == "high"
         assert config.thinking.budget == 2048
 
@@ -259,7 +259,7 @@ budget = 2048
 class TestLoadConfigAgentSection:
     def test_agent_section_preserved(self, tmp_path):
         # The [agent] table drives build_agent_runner (cli_timeout, backend,
-        # cli_provider). _load_config must carry it through; the previous
+        # cli_provider). load_config must carry it through; the previous
         # allowlist loader silently dropped it.
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("""\
@@ -271,7 +271,7 @@ backend = "cli"
 cli_provider = "claude"
 cli_timeout = 1800
 """)
-        config = _load_config(cfg_file)
+        config = load_config(cfg_file)
         assert config.agent.cli_timeout == 1800
         assert config.agent.backend == "cli"
         assert config.agent.cli_provider == "claude"
@@ -279,7 +279,7 @@ cli_timeout = 1800
     def test_agent_section_defaults_to_empty(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
-        config = _load_config(cfg_file)
+        config = load_config(cfg_file)
         assert config.agent.backend is None
         assert config.agent.cli_provider is None
         assert config.agent.cli_timeout is None
@@ -304,7 +304,7 @@ rate = 8
 duration = 20
 max_tokens = 256
 """)
-        config = _load_config(cfg_file)
+        config = load_config(cfg_file)
         levels = config.perf_eval.load_levels
         assert levels is not None
         assert [lvl.rate for lvl in levels] == [1, 8]
@@ -313,5 +313,5 @@ max_tokens = 256
     def test_perf_eval_defaults_to_none(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
-        config = _load_config(cfg_file)
+        config = load_config(cfg_file)
         assert config.perf_eval.load_levels is None

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -184,7 +184,7 @@ def test_run_context_defaults_profiler_support_paths(tmp_path, profiler_kind, wo
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
-        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
         create_run_context(
@@ -218,7 +218,7 @@ def test_run_context_copies_only_selected_profiler_support(tmp_path, selected):
     )
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
-        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
         create_run_context(
@@ -255,7 +255,7 @@ def test_run_context_generic_auto_resolves_to_macos_profiler(tmp_path):
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
-        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
         patch("vibesys.profilers.platform.system", return_value="Darwin"),
@@ -288,7 +288,7 @@ def test_run_context_generic_auto_resolves_to_linux_profiler(tmp_path):
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
-        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
         patch("vibesys.profilers.platform.system", return_value="Linux"),
@@ -329,7 +329,7 @@ def test_run_context_fails_fast_when_resolved_profiler_is_unusable(tmp_path):
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
-        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
         patch("vibesys.profilers.platform.system", return_value="Linux"),
@@ -361,7 +361,7 @@ def test_run_context_rejects_generic_explicit_active_profilers(tmp_path, profile
     ref = _write_ref(tmp_path)
 
     with (
-        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend(profiler_kind)),
         pytest.raises(ValueError, match="not supported for domain 'generic'"),
@@ -387,7 +387,7 @@ def test_run_context_llm_auto_uses_backend_profiler_and_defaults_support_dir(tmp
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
-        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
         create_run_context(
@@ -417,7 +417,7 @@ def test_run_context_noop_environment_hooks_do_not_require_model_artifacts(tmp_p
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
-        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
         create_run_context(
@@ -466,7 +466,7 @@ def test_run_context_materializes_input_project_path_dependencies(tmp_path):
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
-        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
         create_run_context(

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibesys.config import Config
-from vibesys.llm_client import _build_model
+from vibesys.llm_client import build_model
 
 
 def _make_config(
@@ -13,7 +13,7 @@ def _make_config(
     thinking=None,
     providers=None,
 ):
-    """Helper to build a validated :class:`Config` matching _load_config output."""
+    """Helper to build a validated :class:`Config` matching load_config output."""
     return Config.model_validate(
         {
             "model": {"name": name, "provider": provider},
@@ -48,16 +48,16 @@ def key_file(tmp_path):
 class TestAutoDetectProvider:
     def test_claude_model_returns_anthropic_string(self):
         config = _make_config("claude-sonnet-4-6")
-        assert _build_model(config) == "anthropic:claude-sonnet-4-6"
+        assert build_model(config) == "anthropic:claude-sonnet-4-6"
 
     def test_gemini_model_returns_google_genai_string(self):
         config = _make_config("gemini-2.5-pro")
-        assert _build_model(config) == "google_genai:gemini-2.5-pro"
+        assert build_model(config) == "google_genai:gemini-2.5-pro"
 
     def test_unknown_model_prefix_raises(self):
         config = _make_config("llama-3-70b")
         with pytest.raises(ValueError, match="Cannot auto-detect"):
-            _build_model(config)
+            build_model(config)
 
 
 # --- Direct Anthropic provider ---
@@ -66,12 +66,12 @@ class TestAutoDetectProvider:
 class TestAnthropicProvider:
     def test_anthropic_claude_model(self):
         config = _make_config("claude-sonnet-4-6", provider="anthropic")
-        assert _build_model(config) == "anthropic:claude-sonnet-4-6"
+        assert build_model(config) == "anthropic:claude-sonnet-4-6"
 
     def test_anthropic_non_claude_model_raises(self):
         config = _make_config("gemini-2.5-pro", provider="anthropic")
         with pytest.raises(ValueError, match="not a Claude model"):
-            _build_model(config)
+            build_model(config)
 
 
 # --- Direct Google GenAI provider ---
@@ -80,12 +80,12 @@ class TestAnthropicProvider:
 class TestGoogleGenaiProvider:
     def test_google_genai_gemini_model(self):
         config = _make_config("gemini-2.5-pro", provider="google-genai")
-        assert _build_model(config) == "google_genai:gemini-2.5-pro"
+        assert build_model(config) == "google_genai:gemini-2.5-pro"
 
     def test_google_genai_non_google_model_raises(self):
         config = _make_config("claude-sonnet-4-6", provider="google-genai")
         with pytest.raises(ValueError, match="not a Google model"):
-            _build_model(config)
+            build_model(config)
 
 
 # --- Unknown provider ---
@@ -94,7 +94,7 @@ class TestGoogleGenaiProvider:
 class TestUnknownProvider:
     def test_unknown_provider_rejected_by_schema(self):
         # Provider validation now happens at the Config boundary (fail-fast),
-        # not inside _build_model.
+        # not inside build_model.
         with pytest.raises(ValueError, match="bedrock"):
             _make_config("claude-sonnet-4-6", provider="bedrock")
 
@@ -113,7 +113,7 @@ class TestVertexAIProvider:
             provider="vertex-ai",
             providers={"vertex-ai": {"json": str(key_file), "project": None, "region": "us-east5"}},
         )
-        _build_model(config)
+        build_model(config)
         mock_chat_cls.assert_called_once_with(
             model_name="claude-sonnet-4-6",
             credentials=mock_creds,
@@ -131,7 +131,7 @@ class TestVertexAIProvider:
             provider="vertex-ai",
             providers={"vertex-ai": {"json": str(key_file), "project": None, "region": "us-east5"}},
         )
-        _build_model(config)
+        build_model(config)
         mock_chat_cls.assert_called_once_with(
             model="gemini-2.5-pro",
             credentials=mock_creds,
@@ -150,7 +150,7 @@ class TestVertexAIProvider:
             thinking={"level": "medium"},
             providers={"vertex-ai": {"json": str(key_file), "project": None, "region": "us-east5"}},
         )
-        _build_model(config)
+        build_model(config)
         mock_chat_cls.assert_called_once_with(
             model="gemini-2.5-pro",
             credentials=mock_creds,
@@ -171,7 +171,7 @@ class TestVertexAIProvider:
             thinking={"budget": 1024},
             providers={"vertex-ai": {"json": str(key_file), "project": None, "region": "us-east5"}},
         )
-        _build_model(config)
+        build_model(config)
         mock_chat_cls.assert_called_once_with(
             model="gemini-2.5-pro",
             credentials=mock_creds,
@@ -194,7 +194,7 @@ class TestVertexAIProvider:
             thinking={"level": "high", "budget": 1024},
             providers={"vertex-ai": {"json": str(key_file), "project": None, "region": "us-east5"}},
         )
-        _build_model(config)
+        build_model(config)
         call_kwargs = mock_chat_cls.call_args[1]
         assert call_kwargs["thinking_level"] == "high"
         assert call_kwargs["include_thoughts"] is True
@@ -213,7 +213,7 @@ class TestVertexAIProvider:
             },
         )
         with pytest.raises(ValueError, match="service account key not found"):
-            _build_model(config)
+            build_model(config)
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     @patch("langchain_google_vertexai.model_garden.ChatAnthropicVertex")
@@ -231,7 +231,7 @@ class TestVertexAIProvider:
                 }
             },
         )
-        _build_model(config)
+        build_model(config)
         mock_chat_cls.assert_called_once_with(
             model_name="claude-sonnet-4-6",
             credentials=mock_creds,
@@ -246,15 +246,15 @@ class TestVertexAIProvider:
 class TestConfigToModel:
     def test_full_pipeline_anthropic(self):
         config = _make_config("claude-sonnet-4-6", provider="anthropic")
-        assert _build_model(config) == "anthropic:claude-sonnet-4-6"
+        assert build_model(config) == "anthropic:claude-sonnet-4-6"
 
     def test_full_pipeline_google_genai(self):
         config = _make_config("gemini-2.5-pro", provider="google-genai")
-        assert _build_model(config) == "google_genai:gemini-2.5-pro"
+        assert build_model(config) == "google_genai:gemini-2.5-pro"
 
     def test_full_pipeline_openai(self):
         config = _make_config("gpt-4o", provider="openai")
-        assert _build_model(config) == "openai:gpt-4o"
+        assert build_model(config) == "openai:gpt-4o"
 
 
 # --- OpenAI provider ---
@@ -263,36 +263,36 @@ class TestConfigToModel:
 class TestOpenAIProvider:
     def test_openai_gpt_model(self):
         config = _make_config("gpt-4o", provider="openai")
-        assert _build_model(config) == "openai:gpt-4o"
+        assert build_model(config) == "openai:gpt-4o"
 
     def test_openai_o1_model(self):
         config = _make_config("o1", provider="openai")
-        assert _build_model(config) == "openai:o1"
+        assert build_model(config) == "openai:o1"
 
     def test_openai_o3_model(self):
         config = _make_config("o3-mini", provider="openai")
-        assert _build_model(config) == "openai:o3-mini"
+        assert build_model(config) == "openai:o3-mini"
 
     def test_openai_o4_model(self):
         config = _make_config("o4-mini", provider="openai")
-        assert _build_model(config) == "openai:o4-mini"
+        assert build_model(config) == "openai:o4-mini"
 
     def test_openai_non_openai_model_raises(self):
         config = _make_config("claude-sonnet-4-6", provider="openai")
         with pytest.raises(ValueError, match="not an OpenAI model"):
-            _build_model(config)
+            build_model(config)
 
     def test_auto_detect_openai_gpt(self):
         config = _make_config("gpt-4o")
-        assert _build_model(config) == "openai:gpt-4o"
+        assert build_model(config) == "openai:gpt-4o"
 
     def test_auto_detect_openai_o1(self):
         config = _make_config("o1")
-        assert _build_model(config) == "openai:o1"
+        assert build_model(config) == "openai:o1"
 
     def test_auto_detect_openai_o3(self):
         config = _make_config("o3-mini")
-        assert _build_model(config) == "openai:o3-mini"
+        assert build_model(config) == "openai:o3-mini"
 
 
 # --- Thinking not supported ---
@@ -304,32 +304,32 @@ class TestThinkingNotSupported:
             "claude-sonnet-4-6", provider="anthropic", thinking={"level": "medium"}
         )
         with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
-            _build_model(config)
+            build_model(config)
 
     def test_openai_with_thinking_raises(self):
         config = _make_config("gpt-4o", provider="openai", thinking={"level": "high"})
         with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
-            _build_model(config)
+            build_model(config)
 
     def test_google_genai_with_thinking_raises(self):
         config = _make_config("gemini-2.5-pro", provider="google-genai", thinking={"budget": 1024})
         with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
-            _build_model(config)
+            build_model(config)
 
     def test_auto_detect_anthropic_with_thinking_raises(self):
         config = _make_config("claude-sonnet-4-6", thinking={"level": "low"})
         with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
-            _build_model(config)
+            build_model(config)
 
     def test_auto_detect_openai_with_thinking_raises(self):
         config = _make_config("gpt-4o", thinking={"budget": 512})
         with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
-            _build_model(config)
+            build_model(config)
 
     def test_auto_detect_google_genai_with_thinking_raises(self):
         config = _make_config("gemini-2.5-pro", thinking={"level": "medium"})
         with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
-            _build_model(config)
+            build_model(config)
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     @patch("langchain_google_vertexai.model_garden.ChatAnthropicVertex")
@@ -342,4 +342,4 @@ class TestThinkingNotSupported:
             providers={"vertex-ai": {"json": str(key_file), "project": None, "region": "us-east5"}},
         )
         with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
-            _build_model(config)
+            build_model(config)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -28,6 +28,23 @@ from vibesys.main import (
     parse_cli_invocation,
 )
 from vibesys.profilers import ProfilerKind
+
+
+def _patch_loop_runner(loop_name: str, runner: Mock):
+    """Swap the dispatch entry's ``run`` function for *runner*.
+
+    ``_LOOP_COMMANDS`` holds direct function references, so patching the
+    module-level function name no longer affects dispatch — patch the
+    command record instead.
+    """
+    import dataclasses
+
+    import vibesys.main as cli
+
+    command = cli._LOOP_COMMANDS[loop_name]
+    patched = dataclasses.replace(command, run=runner)
+    return patch.dict(cli._LOOP_COMMANDS, {loop_name: patched})
+
 
 TARGET_ARGS = ["--input", "examples/model-serving/Llama-3-8B"]
 
@@ -433,9 +450,10 @@ def test_validate_command_reports_invalid_harness_without_running_agent(tmp_path
     (bundle / "OBJECTIVE.md").unlink()
     argv = ["vibesys", "validate", str(bundle)]
 
+    runner = Mock()
     with (
         patch.object(sys, "argv", argv),
-        patch("vibesys.main._run_agent") as runner,
+        _patch_loop_runner("agent", runner),
         pytest.raises(SystemExit) as exc,
     ):
         main()
@@ -657,17 +675,11 @@ def test_render_configuration_error_prints_usage(capsys):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "loop_name,runner_attr",
-    [
-        ("agent", "_run_agent"),
-        ("evolve", "_run_evolve"),
-        ("plain", "_run_plain"),
-    ],
-)
-def test_main_routes_to_runner(loop_name: str, runner_attr: str):
+@pytest.mark.parametrize("loop_name", ["agent", "evolve", "plain"])
+def test_main_routes_to_runner(loop_name: str):
     argv = ["vibesys", "--outer-loop", loop_name, "--exp-name", "x", *TARGET_ARGS]
-    with patch.object(sys, "argv", argv), patch(f"vibesys.main.{runner_attr}") as runner:
+    runner = Mock()
+    with patch.object(sys, "argv", argv), _patch_loop_runner(loop_name, runner):
         main()
         runner.assert_called_once()
         args = runner.call_args.args[0]
@@ -684,11 +696,12 @@ def test_main_tty_run_stays_in_python_cli():
         "x",
         *TARGET_ARGS,
     ]
+    runner = Mock()
     with (
         patch.object(sys, "argv", argv),
         patch.object(sys.stdin, "isatty", return_value=True),
         patch.object(sys.stdout, "isatty", return_value=True),
-        patch("vibesys.main._run_agent") as runner,
+        _patch_loop_runner("agent", runner),
     ):
         main()
 
@@ -703,9 +716,10 @@ def test_main_headless_skips_tui():
         "--headless",
         *TARGET_ARGS,
     ]
+    runner = Mock()
     with (
         patch.object(sys, "argv", argv),
-        patch("vibesys.main._run_agent") as runner,
+        _patch_loop_runner("agent", runner),
     ):
         main()
     runner.assert_called_once()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -420,6 +420,7 @@ def test_run_context_records_invocation_boundary(tmp_path):
         system_prompt="system",
         user_prompt="original",
         response_cls=dict,
+        fallback_factory=dict,
         round_label="round 6 attempt 2",
     )
 

--- a/tests/test_workspace_seed.py
+++ b/tests/test_workspace_seed.py
@@ -64,7 +64,7 @@ def _init_git_repo(path: Path) -> None:
 def _patched_context_dependencies(project_root: Path):
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
-        patch("vibesys.context._build_model", return_value="mock-model"),
+        patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
     ):


### PR DESCRIPTION
## Problem

PR #179 turned on pyright strict mode as an annotations-only change: where strict typing surfaced a design problem, it papered over the diagnostic with an inline `# pyright: ignore` (~40 of them) plus a file-scoped four-rule relaxation in `context.py`. Those ignores document real debt the strict pass found:

- Two structurally-compatible-but-nominally-distinct `CLIGenerationSession` classes (local duplicate vs `agentshim`'s), held together by six `reportIncompatibleMethodOverride` ignores.
- `main.py` dispatched loop validators/runners through **name strings** and `globals()`, so typos were runtime failures and pyright saw six "unused" functions.
- ~15 underscore-"private" names that are really cross-module API (`_load_config`, `_build_model`, the `agent_runner` log/parse helpers, color constants), each import site carrying a `reportPrivateUsage` ignore.
- `PlainLoopAgentRunner.invoke() -> T` with the response class hidden in `**kwargs`, so `T` could never bind.
- A possibly-unbound `retry` in the agent loop's round bookkeeping — a **real latent `NameError`** (see below).
- `context.py` relaxing four strict rules file-wide.

## Solution

Fix the underlying designs so the code is clean, Pythonic, and enforced by pyright — then delete the ignores. Inline ignore count: **47 → 28** (remaining ones are documented third-party-surface justifications: untyped deepagents/modal sandbox attrs, runtime-defensive `isinstance`, FastMCP tool closures). `context.py`'s file-scoped relaxation is gone.

| Scenario | Fix chosen |
|---|---|
| Duplicate `CLIGenerationSession` | **Eliminated the local duplicate** (option b). `CLICodingAgent` is now `Generic[SessionT]` with `SessionT` bound to `agentshim.cli_agent.CLIGenerationSession`; `_create_session` is abstract and each provider declares `CLICodingAgent[CodexGenerationSession]` etc. The local class was only reachable via the base default `_create_session`, which every concrete provider overrides — and it lacked `final_usage`/`session_id` that `CliAgentRunner` reads, so the agentshim class was already the only one used at runtime. All 6 override ignores deleted; the name is re-exported from `cli_agent` for compatibility. |
| Name-string dispatch in `main.py` | Frozen `_LoopCommand` dataclass (`build_parser` / `validate` / `run` as typed `Callable`s) in a single `_LOOP_COMMANDS` dict of real function references. 7 `reportUnusedFunction` ignores deleted; typos are now type errors. |
| Underscore names that are cross-module API | Renamed public: `load_config`, `build_model`, `load_state`, `log_and_print` + siblings, `parse_typed_response_text`, `log_agent_config`, `run_typed_agent`, `DEFAULT_MAX_TEXT_LEN`, `ANTHROPIC/GOOGLE/OPENAI_PREFIXES`, `DIM/RED/GREEN/YELLOW/RESET`. Deleted two dead wrappers (`_parse_implementer_response_text`, `_parse_perf_eval_response_text`) whose "imported by tests" comments were stale. Loops already type against `LoopContext` (from #177); remaining `_RunContext` imports are test-only. All ~15 `reportPrivateUsage` ignores deleted. |
| Unbindable TypeVar in `runner_ext.py` | `invoke` now takes `response_cls: type[T]` as a real keyword parameter (mirroring `AgentRunner.invoke`) and forwards it explicitly. Ignore deleted. |
| Possibly-unbound `retry` | **Real bug** — see behavior fix below. |
| `context.py` file-scoped relaxation | Removed. `_RunContext.__init__` fully annotated (`RunEnvironment`, `RunSupervisor \| None`, `ComputeBackendImpl`, `EnvironmentPatch`, `RunEnvironmentSession`, `AgentRunner`, `ContentionMonitor`); `invoke` is generic (`response_cls: type[T]`, `fallback_factory: Callable[[], T]` now required — every live call site already passed one, deleting the `reportArgumentType` ignore); `@contextmanager` return switched from deprecated `Iterator` to `Generator[None]`. `LoopContext.invoke` tightened to the same honest generic signature. Two narrow per-line `reportAttributeAccessIssue` ignores remain for genuinely dynamic modal-sandbox attrs. |
| `vs_sandbox` public API (scope addition) | Same "types enforce boundaries" theme: the package root is now the deliberate API — explicit `__all__` of exactly what vibesys consumes (`DockerSandbox`, `ModalSandbox`, `ensure_model_volume`), resolved lazily via PEP 562 so importing the root no longer drags in the `modal` SDK, with `TYPE_CHECKING` imports for static resolution. vibesys/test consumers now import from the root instead of submodules. The same `TYPE_CHECKING` pattern also deleted the two `reportUnsupportedDunderAll` ignores in `vibesys/agents/__init__.py`. The deepagents `BaseSandbox` type is deliberately **not** wrapped here (future work). |

### Behavior fix: `--max-retries-per-round 0` crashed with a `NameError`

`for retry in range(1, max_retries_per_round + 1)` runs zero times when `max_retries_per_round <= 0`; the round bookkeeping then referenced the unbound `retry` (`attempts=retry`) — the `reportPossiblyUnbound` ignore was masking a reachable crash, since the CLI flag had no validation. Fixed with explicit guards: `_validate_agent` rejects `--max-retries-per-round < 1` with a clean configuration diagnostic, and `run_agent_loop` raises `ValueError` at entry for non-CLI callers; `retry` is explicitly initialized so pyright can prove it bound. This is the only intended runtime behavior change (fail-fast error instead of a deep `NameError`).

### Architecture

Ownership is unchanged; boundaries got honest names and types:

```mermaid
graph LR
    main["main.py<br/>_LOOP_COMMANDS: dict[str, _LoopCommand]"] -->|typed fn refs| loops["loops/{agent,plain,evolve}"]
    loops -->|"LoopContext protocol (generic invoke)"| ctx["context._RunContext"]
    ctx -->|AgentRunner protocol| runners["agents/{cli,deepagents}_runner"]
    runners -->|public helpers| ar["agent_runner (log_*, parse_*)"]
    runners --> cli["_agent_cli.CLICodingAgent[SessionT]"]
    cli -->|"SessionT bound"| shim["agentshim CLIGenerationSession"]
    backends["backends/{cuda,trainium,local}"] -->|root imports only| vs["vs_sandbox __all__ (lazy)"]
```

No external contracts changed: manifests, metadata, feature flags, evaluator interfaces, prompts, and skill routing are untouched. The only CLI-visible change is the new `--max-retries-per-round >= 1` validation.

## Verification

### Correctness properties

- Runtime behavior preserved everywhere except the called-out `--max-retries-per-round < 1` fail-fast.
- `vibesys._agent_cli.cli_agent.CLIGenerationSession` still importable (re-export); compat test passes unchanged.
- `import vs_sandbox` no longer imports `modal` eagerly (verified), and lazy `__getattr__` raises `AttributeError` for unknown names.
- Renames grep-verified across `src/`, `libs/`, `tests/`, `resources/`, `clients/`, `docs/` — zero stragglers.
- All loops satisfy the tightened `LoopContext` protocol statically (pyright proves `_RunContext` conformance).

### Testing

- `./scripts/check_types.sh` — 0 errors, 0 warnings (strict).
- `./scripts/check_format.sh`, `./scripts/check_lint.sh` — pass.
- `uv run pytest` — 1805 passed, 1 skipped (macOS-only sandbox test; expected on Linux).
- Manual smoke: `--max-retries-per-round 0` prints `vibesys: Error: --max-retries-per-round must be >= 1.`; lazy exports of `vs_sandbox` and `vibesys.agents` resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
