### PR TITLE
Move backend and TUI onto one typed event contract; renderers own all human output

### DIFF
--- a/clients/tui/src/generated/protocol.generated.ts
+++ b/clients/tui/src/generated/protocol.generated.ts
@@ -86,7 +86,11 @@ export type EventType =
   | "round_finished"
   | "run_finished"
   | "run_failed"
-  | "output";
+  | "output"
+  | "tool_call"
+  | "tool_result"
+  | "todo_update"
+  | "usage_update";
 export type Text1 = string;
 export type EventStatus = "active" | "answered" | "pending" | "consumed" | "completed" | "failed";
 export type RoundLabel1 = string | null;
@@ -108,6 +112,10 @@ export type Data =
       | JudgeResultData
       | BenchmarkResultData
       | RoundFinishedData
+      | ToolCallData
+      | ToolResultData
+      | TodoUpdateData
+      | UsageUpdateData
     )
   | null;
 export type Kind = "chat";
@@ -142,6 +150,11 @@ export type Attempt = number | null;
 export type Kind9 = "agent_output_chunk";
 export type Channel = "assistant" | "analysis" | "tool" | "diagnostic" | "prompt";
 export type Content1 = string;
+export type Progress = string | null;
+export type AgentLabel = string | null;
+export type ElapsedSeconds = number;
+export type InputTokens = number;
+export type ContextWindow = number | null;
 export type Kind10 = "subprocess_output";
 export type ProcessId = string;
 export type ProcessKind = string;
@@ -160,6 +173,20 @@ export type Attempts = number;
 export type JudgeVerdict = "pass" | "fail";
 export type PerfMetric = number | null;
 export type PerfUnit = string | null;
+export type Kind14 = "tool_call";
+export type Tool = string;
+export type Kind15 = "tool_result";
+export type Tool1 = string;
+export type Content3 = string;
+export type IsError = boolean;
+export type Kind16 = "todo_update";
+export type Content4 = string;
+export type Status2 = string;
+export type Todos = TodoItemData[];
+export type Kind17 = "usage_update";
+export type InputTokens1 = number;
+export type ContextWindow1 = number | null;
+export type Model = string | null;
 export type Events = RunEvent[];
 export type Round = number;
 export type PerfMetric1 = number;
@@ -350,6 +377,22 @@ export interface AgentOutputChunkData {
   kind?: Kind9;
   channel: Channel;
   content: Content1;
+  status?: AgentStatusData | null;
+  [k: string]: unknown;
+}
+/**
+ * Structured progress readings for one agent invocation.
+ *
+ * Carried on presentation events so renderers can format their own status
+ * prefix (e.g. ``[Round 3/24 | Implementer | 12.3s | 20k/1.0M]``) without
+ * the backend baking any layout or styling into the payload.
+ */
+export interface AgentStatusData {
+  progress?: Progress;
+  agent_label?: AgentLabel;
+  elapsed_seconds?: ElapsedSeconds;
+  input_tokens?: InputTokens;
+  context_window?: ContextWindow;
   [k: string]: unknown;
 }
 export interface SubprocessOutputData {
@@ -380,6 +423,40 @@ export interface RoundFinishedData {
   judge_verdict: JudgeVerdict;
   perf_metric?: PerfMetric;
   perf_unit?: PerfUnit;
+  [k: string]: unknown;
+}
+export interface ToolCallData {
+  kind?: Kind14;
+  tool: Tool;
+  args?: Args;
+  status?: AgentStatusData | null;
+  [k: string]: unknown;
+}
+export interface Args {
+  [k: string]: unknown;
+}
+export interface ToolResultData {
+  kind?: Kind15;
+  tool: Tool1;
+  content: Content3;
+  is_error?: IsError;
+  [k: string]: unknown;
+}
+export interface TodoUpdateData {
+  kind?: Kind16;
+  todos?: Todos;
+  [k: string]: unknown;
+}
+export interface TodoItemData {
+  content: Content4;
+  status: Status2;
+  [k: string]: unknown;
+}
+export interface UsageUpdateData {
+  kind?: Kind17;
+  input_tokens: InputTokens1;
+  context_window?: ContextWindow1;
+  model?: Model;
   [k: string]: unknown;
 }
 export interface PerformanceRound {

--- a/clients/tui/src/generated/protocol.schema.json
+++ b/clients/tui/src/generated/protocol.schema.json
@@ -22,6 +22,17 @@
         "content": {
           "title": "Content",
           "type": "string"
+        },
+        "status": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AgentStatusData"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
@@ -29,6 +40,59 @@
         "content"
       ],
       "title": "AgentOutputChunkData",
+      "type": "object"
+    },
+    "AgentStatusData": {
+      "description": "Structured progress readings for one agent invocation.\n\nCarried on presentation events so renderers can format their own status\nprefix (e.g. ``[Round 3/24 | Implementer | 12.3s | 20k/1.0M]``) without\nthe backend baking any layout or styling into the payload.",
+      "properties": {
+        "progress": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Progress"
+        },
+        "agent_label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Agent Label"
+        },
+        "elapsed_seconds": {
+          "default": 0.0,
+          "title": "Elapsed Seconds",
+          "type": "number"
+        },
+        "input_tokens": {
+          "default": 0,
+          "title": "Input Tokens",
+          "type": "integer"
+        },
+        "context_window": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Context Window"
+        }
+      },
+      "title": "AgentStatusData",
       "type": "object"
     },
     "BenchmarkResultData": {
@@ -287,7 +351,11 @@
         "round_finished",
         "run_finished",
         "run_failed",
-        "output"
+        "output",
+        "tool_call",
+        "tool_result",
+        "todo_update",
+        "usage_update"
       ],
       "title": "EventType",
       "type": "string"
@@ -911,7 +979,11 @@
                   "run_interrupted": "#/$defs/RunInterruptedData",
                   "run_started": "#/$defs/RunStartedData",
                   "server_ready": "#/$defs/ServerReadyData",
-                  "subprocess_output": "#/$defs/SubprocessOutputData"
+                  "subprocess_output": "#/$defs/SubprocessOutputData",
+                  "todo_update": "#/$defs/TodoUpdateData",
+                  "tool_call": "#/$defs/ToolCallData",
+                  "tool_result": "#/$defs/ToolResultData",
+                  "usage_update": "#/$defs/UsageUpdateData"
                 },
                 "propertyName": "kind"
               },
@@ -957,6 +1029,18 @@
                 },
                 {
                   "$ref": "#/$defs/RoundFinishedData"
+                },
+                {
+                  "$ref": "#/$defs/ToolCallData"
+                },
+                {
+                  "$ref": "#/$defs/ToolResultData"
+                },
+                {
+                  "$ref": "#/$defs/TodoUpdateData"
+                },
+                {
+                  "$ref": "#/$defs/UsageUpdateData"
                 }
               ]
             },
@@ -1235,6 +1319,150 @@
         "latest_sequence"
       ],
       "title": "SubscribedMessage",
+      "type": "object"
+    },
+    "TodoItemData": {
+      "properties": {
+        "content": {
+          "title": "Content",
+          "type": "string"
+        },
+        "status": {
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "status"
+      ],
+      "title": "TodoItemData",
+      "type": "object"
+    },
+    "TodoUpdateData": {
+      "properties": {
+        "kind": {
+          "const": "todo_update",
+          "default": "todo_update",
+          "title": "Kind",
+          "type": "string"
+        },
+        "todos": {
+          "items": {
+            "$ref": "#/$defs/TodoItemData"
+          },
+          "title": "Todos",
+          "type": "array"
+        }
+      },
+      "title": "TodoUpdateData",
+      "type": "object"
+    },
+    "ToolCallData": {
+      "properties": {
+        "kind": {
+          "const": "tool_call",
+          "default": "tool_call",
+          "title": "Kind",
+          "type": "string"
+        },
+        "tool": {
+          "title": "Tool",
+          "type": "string"
+        },
+        "args": {
+          "additionalProperties": true,
+          "title": "Args",
+          "type": "object"
+        },
+        "status": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AgentStatusData"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "tool"
+      ],
+      "title": "ToolCallData",
+      "type": "object"
+    },
+    "ToolResultData": {
+      "properties": {
+        "kind": {
+          "const": "tool_result",
+          "default": "tool_result",
+          "title": "Kind",
+          "type": "string"
+        },
+        "tool": {
+          "title": "Tool",
+          "type": "string"
+        },
+        "content": {
+          "title": "Content",
+          "type": "string"
+        },
+        "is_error": {
+          "default": false,
+          "title": "Is Error",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "tool",
+        "content"
+      ],
+      "title": "ToolResultData",
+      "type": "object"
+    },
+    "UsageUpdateData": {
+      "properties": {
+        "kind": {
+          "const": "usage_update",
+          "default": "usage_update",
+          "title": "Kind",
+          "type": "string"
+        },
+        "input_tokens": {
+          "title": "Input Tokens",
+          "type": "integer"
+        },
+        "context_window": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Context Window"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model"
+        }
+      },
+      "required": [
+        "input_tokens"
+      ],
+      "title": "UsageUpdateData",
       "type": "object"
     }
   },

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -6,6 +6,7 @@ import {
   selectNextAgent,
   selectNextRound,
   selectRound,
+  statusText,
   visibleConversation,
   visiblePhases,
 } from './session-model.js';
@@ -166,6 +167,124 @@ describe('session event model', () => {
       toolCall: '→ Bash(command="first")\n',
       toolResponse: 'first result',
     });
+  });
+
+  it('pairs typed tool_call and tool_result events into tool turns', () => {
+    let state = initialSessionState();
+    state = applyEvent(
+      state,
+      event(1, 'tool_call', {kind: 'tool_call', tool: 'Bash', args: {command: 'first'}}, 'inv-1'),
+    );
+    state = applyEvent(
+      state,
+      event(
+        2,
+        'tool_result',
+        {kind: 'tool_result', tool: 'Bash', content: 'first result'},
+        'inv-1',
+      ),
+    );
+    state = applyEvent(
+      state,
+      event(3, 'tool_call', {kind: 'tool_call', tool: 'Bash', args: {command: 'second'}}, 'inv-1'),
+    );
+    state = applyEvent(
+      state,
+      event(
+        4,
+        'tool_result',
+        {kind: 'tool_result', tool: 'Bash', content: 'second result'},
+        'inv-1',
+      ),
+    );
+
+    expect(state.conversation.map(entry => entry.content)).toEqual([
+      '→ Bash(command="first")\nfirst result',
+      '→ Bash(command="second")\nsecond result',
+    ]);
+    expect(state.conversation[0]).toMatchObject({
+      kind: 'tool',
+      toolCall: '→ Bash(command="first")\n',
+      toolResponse: 'first result',
+    });
+    expect(state.liveContent).toContain('→ Bash(command="first")');
+    expect(state.liveContent).toContain('first result');
+  });
+
+  it('truncates long typed tool-call arguments and renders non-string args as JSON', () => {
+    const longArg = 'x'.repeat(200);
+    const state = applyEvent(
+      initialSessionState(),
+      event(1, 'tool_call', {kind: 'tool_call', tool: 'Edit', args: {text: longArg, count: 3}}),
+    );
+
+    expect(state.conversation[0]?.toolCall).toContain(`text="${'x'.repeat(80)}..."`);
+    expect(state.conversation[0]?.toolCall).toContain('count=3');
+    expect(state.conversation[0]?.toolCall).not.toContain(longArg);
+  });
+
+  it('prefers typed tool events over legacy tool-channel chunks', () => {
+    let state = initialSessionState();
+    state = applyEvent(
+      state,
+      event(1, 'tool_call', {kind: 'tool_call', tool: 'Bash', args: {command: 'ls'}}, 'inv-1'),
+    );
+    // A legacy duplicate of the same call must not render a second turn.
+    state = applyEvent(
+      state,
+      event(
+        2,
+        'agent_output_chunk',
+        {kind: 'agent_output_chunk', channel: 'tool', content: '→ Bash(command="ls")\n'},
+        'inv-1',
+      ),
+    );
+
+    expect(state.typedToolEvents).toBe(true);
+    expect(state.conversation).toHaveLength(1);
+    expect(state.conversation[0]?.toolCall).toBe('→ Bash(command="ls")\n');
+  });
+
+  it('stores todo updates as data instead of transcript text', () => {
+    const state = applyEvent(
+      initialSessionState(),
+      event(1, 'todo_update', {
+        kind: 'todo_update',
+        todos: [
+          {content: 'Set up project', status: 'completed'},
+          {content: 'Add tests', status: 'pending'},
+        ],
+      }),
+    );
+
+    expect(state.todos).toEqual([
+      {content: 'Set up project', status: 'completed'},
+      {content: 'Add tests', status: 'pending'},
+    ]);
+    expect(state.conversation).toHaveLength(0);
+    expect(state.liveContent).toBe('Waiting for run events…');
+  });
+
+  it('feeds usage updates into the status token meter', () => {
+    let state = initialSessionState();
+    expect(statusText(state)).not.toContain('tokens');
+    state = applyEvent(
+      state,
+      event(1, 'usage_update', {
+        kind: 'usage_update',
+        input_tokens: 20_100,
+        context_window: 1_000_000,
+        model: 'claude-sonnet-4-6',
+      }),
+    );
+
+    expect(state.usage).toEqual({
+      inputTokens: 20_100,
+      contextWindow: 1_000_000,
+      model: 'claude-sonnet-4-6',
+    });
+    expect(statusText(state)).toContain('20k/1.0M tokens');
+    expect(state.conversation).toHaveLength(0);
   });
 
   it('classifies prompt events as distinct markdown turns', () => {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -22,6 +22,25 @@ export interface SessionState {
   conversation: ConversationEntry[];
   overlay: OverlayPanel | null;
   terminal: boolean;
+  todos: TodoItem[];
+  usage: UsageMeter | null;
+  /**
+   * Set once a typed tool_call/tool_result event is seen. From then on the
+   * legacy tool-channel text chunks (still present in event files recorded
+   * by older backends) are ignored so tool turns never render twice.
+   */
+  typedToolEvents: boolean;
+}
+
+export interface TodoItem {
+  content: string;
+  status: string;
+}
+
+export interface UsageMeter {
+  inputTokens: number;
+  contextWindow: number | null;
+  model: string | null;
 }
 
 export interface OverlayPanel {
@@ -68,6 +87,9 @@ export function initialSessionState(): SessionState {
     conversation: [],
     overlay: null,
     terminal: false,
+    todos: [],
+    usage: null,
+    typedToolEvents: false,
   };
 }
 
@@ -95,10 +117,34 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
   next.rounds = runMap.rounds;
   next.phases = runMap.phases;
 
-  const line = renderEventForTranscript(event);
-  if (line !== null) next.liveContent = appendTranscript(next.liveContent, line);
-  const entry = eventToConversationEntry(event);
-  if (entry !== null) next.conversation = appendConversation(next.conversation, entry);
+  const data = event.data;
+  if (data?.kind === 'tool_call' || data?.kind === 'tool_result') {
+    next.typedToolEvents = true;
+  }
+  if (data?.kind === 'todo_update') {
+    next.todos = (data.todos ?? []).map(todo => ({
+      content: String(todo.content),
+      status: String(todo.status),
+    }));
+  }
+  if (data?.kind === 'usage_update') {
+    next.usage = {
+      inputTokens: data.input_tokens,
+      contextWindow: data.context_window ?? null,
+      model: data.model ?? null,
+    };
+  }
+
+  // Prefer typed tool events; fall back to legacy tool-channel chunks only
+  // for streams that never produce typed events (old event files / replays).
+  const suppressed =
+    data?.kind === 'agent_output_chunk' && data.channel === 'tool' && next.typedToolEvents;
+  if (!suppressed) {
+    const line = renderEventForTranscript(event);
+    if (line !== null) next.liveContent = appendTranscript(next.liveContent, line);
+    const entry = eventToConversationEntry(event);
+    if (entry !== null) next.conversation = appendConversation(next.conversation, entry);
+  }
 
   if (event.type === 'run_started') {
     next.status = 'running';
@@ -222,6 +268,36 @@ function eventToConversationEntry(event: RunEvent): ConversationEntry | null {
         : {}),
     };
   }
+  if (data?.kind === 'tool_call') {
+    const call = formatToolCall(data.tool, data.args ?? {});
+    const invocationId = event.invocation_id ?? undefined;
+    return {
+      id,
+      kind: 'tool',
+      content: call,
+      label: labelFor(event, 'tool'),
+      ...agentKind,
+      ...roundFields,
+      turnId: invocationId ?? id,
+      ...(invocationId === undefined ? {} : {invocationId}),
+      startsTurn: true,
+      toolCall: call,
+    };
+  }
+  if (data?.kind === 'tool_result') {
+    const invocationId = event.invocation_id ?? undefined;
+    return {
+      id,
+      kind: 'tool',
+      content: data.content,
+      label: labelFor(event, 'tool'),
+      ...(data.is_error ? {tone: 'failure' as const} : {}),
+      ...agentKind,
+      ...roundFields,
+      turnId: invocationId ?? id,
+      ...(invocationId === undefined ? {} : {invocationId}),
+    };
+  }
   if (data?.kind === 'subprocess_output') {
     return {
       id,
@@ -341,7 +417,20 @@ export function showDetail(
 }
 
 export function statusText(state: SessionState): string {
-  return `${state.status} · ${state.agentKind ?? 'starting'} · ${state.roundLabel ?? 'no round yet'}`;
+  const base = `${state.status} · ${state.agentKind ?? 'starting'} · ${state.roundLabel ?? 'no round yet'}`;
+  if (state.usage === null) return base;
+  const used = formatTokenCount(state.usage.inputTokens);
+  const meter =
+    state.usage.contextWindow === null
+      ? used
+      : `${used}/${formatTokenCount(state.usage.contextWindow)}`;
+  return `${base} · ${meter} tokens`;
+}
+
+function formatTokenCount(count: number): string {
+  if (count < 1_000) return String(count);
+  if (count < 1_000_000) return `${Math.floor(count / 1_000)}k`;
+  return `${(count / 1_000_000).toFixed(1)}M`;
 }
 
 export function visibleConversation(state: SessionState): ConversationEntry[] {
@@ -363,10 +452,30 @@ export function visibleRoundNumber(state: SessionState): number | null {
   return visibleRunMapRoundNumber(state.rounds, state.selectedRound);
 }
 
+const MAX_TOOL_ARG_LEN = 80;
+
+function formatToolCall(tool: string, args: Record<string, unknown>): string {
+  const parts = Object.entries(args).map(([key, value]) => {
+    const isString = typeof value === 'string';
+    let rendered = isString ? value : (JSON.stringify(value) ?? String(value));
+    if (rendered.length > MAX_TOOL_ARG_LEN) {
+      rendered = `${rendered.slice(0, MAX_TOOL_ARG_LEN)}...`;
+    }
+    return isString ? `${key}="${rendered}"` : `${key}=${rendered}`;
+  });
+  return `→ ${tool}(${parts.join(', ')})\n`;
+}
+
 function renderEventForTranscript(event: RunEvent): string | null {
   const data = event.data;
   if (data?.kind === 'agent_output_chunk' || data?.kind === 'subprocess_output') {
     return data.content;
+  }
+  if (data?.kind === 'tool_call') {
+    return formatToolCall(data.tool, data.args ?? {});
+  }
+  if (data?.kind === 'tool_result') {
+    return data.content.endsWith('\n') ? data.content : `${data.content}\n`;
   }
   if (data?.kind === 'output') return data.content;
   if (data?.kind === 'judge_result') {

--- a/src/vibesys/agent_runner.py
+++ b/src/vibesys/agent_runner.py
@@ -9,7 +9,8 @@ from typing import Any, TextIO, TypeVar
 from langchain_core.callbacks import BaseCallbackHandler
 from pydantic import BaseModel, ValidationError
 
-from vibesys.agents.callbacks import AgentLogger, TodoDisplay
+from vibesys.agents.callbacks import AgentLogger
+from vibesys.render.sink import output_sink
 from vibesys.schemas import (
     ImplementerResponse,
     IssueImplementerResponse,
@@ -22,7 +23,7 @@ from vibesys.schemas import (
     ProfilerResponse,
     Verdict,
 )
-from vibesys.server.events import AgentOutputChannel
+from vibesys.server.events import AgentOutputChannel, TodoItemData
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -30,7 +31,7 @@ T = TypeVar("T", bound=BaseModel)
 # Constants
 # ---------------------------------------------------------------------------
 
-DEFAULT_MAX_TEXT_LEN = 2000
+
 _JUDGE_REVIEW_PROMPT = (
     "Review the implementation. "
     "Write or update pytest tests, run them via `uv run pytest -v`, "
@@ -142,57 +143,36 @@ def log_agent_config(agent: Any, label: str, log_file: TextIO | None) -> None:
 def log_and_print(
     text: str,
     log_file: TextIO | None = None,
-    max_len: int | None = None,
 ) -> None:
-    """Print to stdout (optionally truncated) and write full text to log_file."""
-    from vibesys.server.registry import active_supervisor
+    """Emit *text* as a diagnostic event and write it in full to log_file.
 
-    supervisor = active_supervisor()
-    if supervisor is not None:
-        supervisor.publish_agent_output(text + "\n", channel="diagnostic")
-    if log_file:
-        log_file.write(text + "\n")
-        log_file.flush()
-    if max_len is not None and len(text) > max_len:
-        print(text[:max_len])
-        print(f"... [{len(text) - max_len} more chars, see log for full text]")
-    else:
-        print(text)
+    Display (including any truncation) is the subscribed renderer's job;
+    the log always receives the untruncated text.
+    """
+    log_markdown_and_print(text, log_file=log_file, channel="diagnostic")
 
 
 def log_markdown_and_print(
     text: str,
     log_file: TextIO | None = None,
-    max_len: int | None = None,
     *,
     channel: AgentOutputChannel = "assistant",
 ) -> None:
     """Emit raw Markdown; presentation clients decide how to render it."""
-    from vibesys.server.registry import active_supervisor
-
-    supervisor = active_supervisor()
-    if supervisor is not None:
-        supervisor.publish_agent_output(text + "\n", channel=channel)
+    output_sink().agent_output(text + "\n", channel=channel)
     if log_file:
         log_file.write(text + "\n")
         log_file.flush()
-    if max_len is not None and len(text) > max_len:
-        print(text[:max_len])
-        print(f"... [{len(text) - max_len} more chars, see log for full text]")
-    else:
-        print(text)
 
 
 def log_prompt_markdown_and_print(
     prompt: str,
     log_file: TextIO | None = None,
-    max_len: int | None = None,
 ) -> None:
     """Emit raw prompt Markdown while preserving it in logs."""
     log_markdown_and_print(
         prompt,
         log_file=log_file,
-        max_len=max_len,
         channel="prompt",
     )
 
@@ -200,10 +180,18 @@ def log_prompt_markdown_and_print(
 def log_json_and_print(
     text: str,
     log_file: TextIO | None = None,
-    max_len: int | None = None,
 ) -> None:
     """Emit raw JSON; presentation clients decide how to render it."""
-    log_and_print(text, log_file=log_file, max_len=max_len)
+    log_and_print(text, log_file=log_file)
+
+
+def publish_todos(todos: list[dict[str, Any]]) -> None:
+    """Emit a structured todo-list snapshot extracted from a stream update."""
+    items = [
+        TodoItemData(content=str(t.get("content", "")), status=str(t.get("status", "")))
+        for t in todos
+    ]
+    output_sink().todo_update(items)
 
 
 # ---------------------------------------------------------------------------
@@ -278,24 +266,22 @@ def run_agent(
     thread_id: str | None = None,
     round_label: str = "implementer",
     log_file: TextIO | None = None,
-    max_text_len: int | None = None,
 ) -> str:
     """Run agent, return final AI message text.
 
-    When *log_file* is provided, full input/output/error text is written there
-    while stdout receives a truncated version (controlled by *max_text_len*).
+    When *log_file* is provided, full input/output/error text is written there;
+    terminal display is handled by the subscribed renderer.
     """
     if callbacks is None:
         callbacks = [AgentLogger()]
     callbacks_label = " + ".join(type(cb).__name__ for cb in callbacks)
     if thread_id is None:
         thread_id = uuid.uuid4().hex
-    todo_display = TodoDisplay()
     log_and_print(f"\n=== LLM ROUND START: {round_label} ===", log_file)
     log_and_print(f"callbacks: {callbacks_label}", log_file)
     log_and_print(f"thread_id: {thread_id}", log_file)
     log_and_print("--- input ---", log_file)
-    log_prompt_markdown_and_print(prompt, log_file, max_len=max_text_len)
+    log_prompt_markdown_and_print(prompt, log_file)
     last_ai_message = ""
     try:
         for update in agent.stream(
@@ -305,7 +291,7 @@ def run_agent(
         ):
             todos = _extract_todos(update)
             if todos is not None:
-                todo_display.update(todos)
+                publish_todos(todos)
             if "agent" in update:
                 for msg in update["agent"].get("messages", []):
                     if getattr(msg, "type", None) == "ai" and msg.content:
@@ -313,11 +299,11 @@ def run_agent(
     except Exception as exc:
         error_text = f"error: {type(exc).__name__}: {exc}"
         log_and_print(f"\n=== LLM ROUND ERROR: {round_label} ===", log_file)
-        log_and_print(error_text, log_file, max_len=max_text_len)
+        log_and_print(error_text, log_file)
         raise
     output_text = last_ai_message if last_ai_message else "<no ai message returned>"
     log_and_print("\n=== LLM ROUND OUTPUT (final ai message) ===", log_file)
-    log_markdown_and_print(output_text, log_file, max_len=max_text_len)
+    log_markdown_and_print(output_text, log_file)
     return last_ai_message
 
 
@@ -332,7 +318,6 @@ def run_typed_agent(
     thread_id: str | None = None,
     round_label: str = "agent",
     log_file: TextIO | None = None,
-    max_text_len: int | None = None,
 ) -> T:
     """Generic agent runner returning a structured Pydantic response of *response_cls*.
 
@@ -344,7 +329,6 @@ def run_typed_agent(
         callbacks = [AgentLogger()]
     if thread_id is None:
         thread_id = uuid.uuid4().hex
-    todo_display = TodoDisplay()
     callbacks_label = " + ".join(type(cb).__name__ for cb in callbacks)
     structured_response = None
     last_ai_message = ""
@@ -352,7 +336,7 @@ def run_typed_agent(
     log_and_print(f"callbacks: {callbacks_label}", log_file)
     log_and_print(f"thread_id: {thread_id}", log_file)
     log_and_print("--- input ---", log_file)
-    log_prompt_markdown_and_print(prompt, log_file, max_len=max_text_len)
+    log_prompt_markdown_and_print(prompt, log_file)
     try:
         for update in agent.stream(
             {"messages": [("human", prompt)]},
@@ -361,7 +345,7 @@ def run_typed_agent(
         ):
             todos = _extract_todos(update)
             if todos is not None:
-                todo_display.update(todos)
+                publish_todos(todos)
             structured_response = (
                 _extract_typed_structured_response(update, response_cls) or structured_response
             )
@@ -371,7 +355,7 @@ def run_typed_agent(
     except Exception as exc:
         error_text = f"error: {type(exc).__name__}: {exc}"
         log_and_print(f"\n=== {label} ROUND ERROR: {round_label} ===", log_file)
-        log_and_print(error_text, log_file, max_len=max_text_len)
+        log_and_print(error_text, log_file)
         raise
     if structured_response is None:
         structured_response = parse_typed_response_text(last_ai_message, response_cls)
@@ -380,11 +364,11 @@ def run_typed_agent(
         log_and_print(f"No structured response received from {label.lower()}.", log_file)
         if last_ai_message:
             log_and_print(f"\n=== {label} ROUND OUTPUT (raw ai message) ===", log_file)
-            log_markdown_and_print(last_ai_message, log_file, max_len=max_text_len)
+            log_markdown_and_print(last_ai_message, log_file)
         return fallback_factory()
     output_json = structured_response.model_dump_json(indent=2)
     log_and_print(f"\n=== {label} ROUND OUTPUT ===", log_file)
-    log_json_and_print(output_json, log_file, max_len=max_text_len)
+    log_json_and_print(output_json, log_file)
     return structured_response
 
 
@@ -395,7 +379,6 @@ def run_implementer_agent(
     thread_id: str | None = None,
     round_label: str = "implementer",
     log_file: TextIO | None = None,
-    max_text_len: int | None = None,
 ) -> ImplementerResponse:
     """Run implementer agent, return structured ImplementerResponse."""
     return run_typed_agent(
@@ -411,7 +394,6 @@ def run_implementer_agent(
         thread_id=thread_id,
         round_label=round_label,
         log_file=log_file,
-        max_text_len=max_text_len,
     )
 
 
@@ -422,12 +404,11 @@ def run_judge_agent(
     thread_id: str | None = None,
     round_label: str = "judge",
     log_file: TextIO | None = None,
-    max_text_len: int | None = None,
 ) -> JudgeResponse:
     """Run judge agent, return structured JudgeResponse.
 
-    When *log_file* is provided, full input/output/error text is written there
-    while stdout receives a truncated version (controlled by *max_text_len*).
+    When *log_file* is provided, full input/output/error text is written there;
+    terminal display is handled by the subscribed renderer.
     """
     return run_typed_agent(
         agent,
@@ -443,7 +424,6 @@ def run_judge_agent(
         thread_id=thread_id,
         round_label=round_label,
         log_file=log_file,
-        max_text_len=max_text_len,
     )
 
 
@@ -454,7 +434,6 @@ def run_perf_eval_agent(
     thread_id: str | None = None,
     round_label: str = "perf_eval",
     log_file: TextIO | None = None,
-    max_text_len: int | None = None,
 ) -> PerfEvalResponse:
     """Run perf evaluator agent, return structured PerfEvalResponse."""
     return run_typed_agent(
@@ -474,7 +453,6 @@ def run_perf_eval_agent(
         thread_id=thread_id,
         round_label=round_label,
         log_file=log_file,
-        max_text_len=max_text_len,
     )
 
 
@@ -550,14 +528,12 @@ def run_profiler_agent(
     thread_id: str | None = None,
     round_label: str = "profiler",
     log_file: TextIO | None = None,
-    max_text_len: int | None = None,
 ) -> ProfilerResponse:
     """Run profiler agent, return structured ProfilerResponse."""
     if callbacks is None:
         callbacks = [AgentLogger()]
     if thread_id is None:
         thread_id = uuid.uuid4().hex
-    todo_display = TodoDisplay()
     callbacks_label = " + ".join(type(cb).__name__ for cb in callbacks)
     structured_response = None
     last_ai_message = ""
@@ -565,7 +541,7 @@ def run_profiler_agent(
     log_and_print(f"callbacks: {callbacks_label}", log_file)
     log_and_print(f"thread_id: {thread_id}", log_file)
     log_and_print("--- input ---", log_file)
-    log_prompt_markdown_and_print(prompt, log_file, max_len=max_text_len)
+    log_prompt_markdown_and_print(prompt, log_file)
     try:
         for update in agent.stream(
             {"messages": [("human", prompt)]},
@@ -574,7 +550,7 @@ def run_profiler_agent(
         ):
             todos = _extract_todos(update)
             if todos is not None:
-                todo_display.update(todos)
+                publish_todos(todos)
             structured_response = (
                 _extract_profiler_structured_response(update) or structured_response
             )
@@ -584,7 +560,7 @@ def run_profiler_agent(
     except Exception as exc:
         error_text = f"error: {type(exc).__name__}: {exc}"
         log_and_print(f"\n=== PROFILER ROUND ERROR: {round_label} ===", log_file)
-        log_and_print(error_text, log_file, max_len=max_text_len)
+        log_and_print(error_text, log_file)
         raise
     if structured_response is None:
         structured_response = _parse_profiler_response_text(last_ai_message)
@@ -593,7 +569,7 @@ def run_profiler_agent(
         log_and_print("No structured response received from profiler.", log_file)
         if last_ai_message:
             log_and_print("\n=== PROFILER ROUND OUTPUT (raw ai message) ===", log_file)
-            log_markdown_and_print(last_ai_message, log_file, max_len=max_text_len)
+            log_markdown_and_print(last_ai_message, log_file)
         return ProfilerResponse(
             analysis="No structured response received from profiler.",
             bottlenecks="Profiler did not produce a structured response.",
@@ -601,7 +577,7 @@ def run_profiler_agent(
         )
     output_json = structured_response.model_dump_json(indent=2)
     log_and_print("\n=== PROFILER ROUND OUTPUT ===", log_file)
-    log_json_and_print(output_json, log_file, max_len=max_text_len)
+    log_json_and_print(output_json, log_file)
     return structured_response
 
 
@@ -614,7 +590,6 @@ def run_issue_implementer_agent(
     thread_id: str | None = None,
     round_label: str = "issue_implementer",
     log_file: TextIO | None = None,
-    max_text_len: int | None = None,
 ) -> IssueImplementerResponse:
     """Run the issue-loop implementer agent, return structured IssueImplementerResponse."""
     return run_typed_agent(
@@ -632,7 +607,6 @@ def run_issue_implementer_agent(
         thread_id=thread_id,
         round_label=round_label,
         log_file=log_file,
-        max_text_len=max_text_len,
     )
 
 
@@ -645,7 +619,6 @@ def run_issue_judge_agent(
     thread_id: str | None = None,
     round_label: str = "issue_judge",
     log_file: TextIO | None = None,
-    max_text_len: int | None = None,
 ) -> IssueJudgeResponse:
     """Run the issue-loop judge agent, return structured IssueJudgeResponse."""
     return run_typed_agent(
@@ -664,7 +637,6 @@ def run_issue_judge_agent(
         thread_id=thread_id,
         round_label=round_label,
         log_file=log_file,
-        max_text_len=max_text_len,
     )
 
 
@@ -675,7 +647,6 @@ def run_issue_perf_eval_agent(
     thread_id: str | None = None,
     round_label: str = "issue_perf_eval",
     log_file: TextIO | None = None,
-    max_text_len: int | None = None,
 ) -> IssuePerfEvalResponse:
     """Run the issue-loop performance evaluator agent, return structured IssuePerfEvalResponse."""
     return run_typed_agent(
@@ -695,5 +666,4 @@ def run_issue_perf_eval_agent(
         thread_id=thread_id,
         round_label=round_label,
         log_file=log_file,
-        max_text_len=max_text_len,
     )

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -1,5 +1,4 @@
 import json
-import sys
 import time
 import traceback
 from collections.abc import Callable
@@ -9,8 +8,9 @@ from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages import BaseMessage
 
 from vibesys.agents.progress import AgentProgress
-from vibesys.constants import DIM, GREEN, RESET, YELLOW
-from vibesys.server.events import AgentOutputChannel
+from vibesys.render.format import format_status_prefix
+from vibesys.render.sink import output_sink
+from vibesys.server.events import AgentOutputChannel, AgentStatusData
 
 ContextWindowLookup = Callable[[str | None], int | None]
 """Resolves a model name to its context window size in tokens.
@@ -59,75 +59,18 @@ def _default_context_window_lookup(model_name: str | None) -> int | None:
     return None
 
 
-def _format_token_count(n: int) -> str:
-    """Format a token count compactly: ``999`` / ``20k`` / ``1.0M``."""
-    if n < 1_000:
-        return str(n)
-    if n < 1_000_000:
-        return f"{n // 1000}k"
-    return f"{n / 1_000_000:.1f}M"
-
-
-_STATUS_INDICATORS = {
-    "completed": f"{GREEN}✓{RESET}",
-    "in_progress": f"{YELLOW}▶{RESET}",
-    "pending": f"{DIM}○{RESET}",
-}
-
-
-class TodoDisplay:
-    """Renders a persistent todo list box using ANSI cursor control."""
-
-    def __init__(self, file: TextIO | None = None):
-        self._file = file or sys.stdout
-        self._prev_lines = 0
-
-    def update(self, todos: list[dict[str, Any]]) -> None:
-        if not todos:
-            return
-        # Build box lines
-        items = []
-        for t in todos:
-            indicator = _STATUS_INDICATORS.get(t["status"], "?")
-            items.append(f"│ {indicator} {t['content']}")
-        width = max(len(self._strip_ansi(line)) for line in items) + 2
-        width = max(width, len("─ Todo ─") + 4)
-
-        top = f"┌─ Todo {'─' * (width - 8)}┐"
-        bot = f"└{'─' * (width - 1)}┘"
-        padded = [line + " " * (width - len(self._strip_ansi(line)) - 1) + "│" for line in items]
-        box = [top] + padded + [bot]
-
-        out = self._file
-        # Clear previous block
-        if self._prev_lines > 0:
-            out.write(f"\033[{self._prev_lines}A")
-            for _ in range(self._prev_lines):
-                out.write("\033[2K\n")
-            out.write(f"\033[{self._prev_lines}A")
-
-        for line in box:
-            out.write(line + "\n")
-        out.flush()
-        self._prev_lines = len(box)
-
-    @staticmethod
-    def _strip_ansi(s: str) -> str:
-        import re
-
-        return re.sub(r"\033\[[0-9;]*m", "", s)
-
-
 class AgentLogger(BaseCallbackHandler):
-    """Single callback handler for all agent logging: token streaming, tool calls, and tool results.
+    """Single event adapter for all agent activity: token streaming, tool calls, and tool results.
 
-    When ``log_file`` is provided, full untruncated output is written there while
-    stdout receives the truncated version.
+    Every observation is published as typed events through the process-global
+    :func:`~vibesys.render.sink.output_sink` (rendered by whichever surface is
+    composed — headless terminal renderer or TUI client) and, when ``log_file``
+    is provided, written untruncated as plain text to the durable run log.
+    ``AgentLogger`` itself never writes to the terminal.
     """
 
     def __init__(
         self,
-        max_result_len: int | None = 500,
         log_file: TextIO | None = None,
         model_name: str | None = None,
         agent_label: str | None = None,
@@ -135,8 +78,6 @@ class AgentLogger(BaseCallbackHandler):
         context_window_lookup: ContextWindowLookup | None = None,
     ):
         self._streaming = False
-        self._max_result_len = max_result_len
-        self._output = sys.stdout
         self._log_file = log_file
         self._call_count = 0
         self._model_name = model_name
@@ -151,28 +92,23 @@ class AgentLogger(BaseCallbackHandler):
         self._context_window_lookup = context_window_lookup or _default_context_window_lookup
         self._context_window = self._context_window_lookup(model_name)
 
-    def _format_prefix(self) -> str:
-        """Build the dynamic ``[progress | label | elapsed | tokens/max]`` prefix.
+    def _status(self) -> AgentStatusData:
+        """Snapshot the ``[progress | label | elapsed | tokens/max]`` readings.
 
         Computed lazily on each use so the elapsed-time and token-count
-        readings reflect the latest state when the prefix is printed.
+        readings reflect the latest state when the event is emitted.
         """
-        progress_text = self._progress.label() if self._progress is not None else None
-        if not self._agent_label and not progress_text:
-            return ""
-        elapsed = time.monotonic() - self._start_time
-        used = _format_token_count(self._input_tokens)
-        if self._context_window:
-            tokens_str = f"{used}/{_format_token_count(self._context_window)}"
-        else:
-            tokens_str = used
-        parts = []
-        if progress_text:
-            parts.append(progress_text)
-        if self._agent_label:
-            parts.append(self._agent_label)
-        parts.extend([f"{elapsed:.1f}s", tokens_str])
-        return f"[{' | '.join(parts)}] "
+        return AgentStatusData(
+            progress=self._progress.label() if self._progress is not None else None,
+            agent_label=self._agent_label,
+            elapsed_seconds=time.monotonic() - self._start_time,
+            input_tokens=self._input_tokens,
+            context_window=self._context_window,
+        )
+
+    def _format_prefix(self) -> str:
+        """Render the status snapshot as the plain-text log prefix."""
+        return format_status_prefix(self._status())
 
     # --- LLM call context (log-file only) ---
 
@@ -185,9 +121,9 @@ class AgentLogger(BaseCallbackHandler):
         flat = messages[0] if messages else []
 
         # Separator with call number
-        self._print_log(f"\n{'─' * 60}")
-        self._print_log(f"  LLM call #{self._call_count}")
-        self._print_log(f"{'─' * 60}")
+        self._log_line(f"\n{'─' * 60}")
+        self._log_line(f"  LLM call #{self._call_count}")
+        self._log_line(f"{'─' * 60}")
 
         # First call: log model info and system prompt
         if self._call_count == 1:
@@ -195,11 +131,11 @@ class AgentLogger(BaseCallbackHandler):
             if not model_name:
                 id_parts = serialized.get("id", [])
                 model_name = "/".join(id_parts) if id_parts else "unknown"
-            self._print_log(f"  Model: {model_name}")
+            self._log_line(f"  Model: {model_name}")
 
             for msg in flat:
                 if getattr(msg, "type", None) == "system":
-                    self._print_log(f"\n  System prompt:\n{msg.content}")
+                    self._log_line(f"\n  System prompt:\n{msg.content}")
                     break
 
         # Message type summary
@@ -207,7 +143,7 @@ class AgentLogger(BaseCallbackHandler):
 
         type_counts = Counter(getattr(m, "type", "unknown") for m in flat)
         summary = ", ".join(f"{count} {typ}" for typ, count in sorted(type_counts.items()))
-        self._print_log(f"  Messages: {len(flat)} ({summary})")
+        self._log_line(f"  Messages: {len(flat)} ({summary})")
 
         # Last human or tool message (trigger for this call)
         for msg in reversed(flat):
@@ -215,23 +151,27 @@ class AgentLogger(BaseCallbackHandler):
                 content = str(msg.content)
                 if len(content) > 500:
                     content = content[:500] + "..."
-                self._print_log(f"  Last {msg.type} message: {content}")
+                self._log_line(f"  Last {msg.type} message: {content}")
                 break
 
     # --- LLM token streaming ---
 
     def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
         if token:
-            self._publish(token, "assistant")
-            if not self._streaming and self._agent_label:
-                self._print(f"{self._format_prefix()}", end="", flush=True)
-            self._print(token, end="", flush=True)
+            status = self._status()
+            self._publish(token, "assistant", status=status)
+            if not self._streaming:
+                self._log_write(format_status_prefix(status))
+            self._log_write(token)
             self._streaming = True
 
     def on_llm_end(self, response: Any, **kwargs: Any) -> None:
         was_streaming = self._streaming
         if self._streaming:
-            self._print()
+            # Close the streamed line on every surface: renderers and the
+            # log both need the trailing newline the stream never carried.
+            self._publish("\n", "assistant")
+            self._log_write("\n")
             self._streaming = False
 
         msg = response.generations[0][0].message
@@ -254,6 +194,7 @@ class AgentLogger(BaseCallbackHandler):
         input_tokens = usage.get("input_tokens") or 0
         if input_tokens:
             self._input_tokens = input_tokens
+            self._publish_usage()
 
         content = msg.content
 
@@ -263,18 +204,18 @@ class AgentLogger(BaseCallbackHandler):
                 if isinstance(block, dict) and block.get("type") == "thinking":
                     thinking_text = block.get("thinking", "")
                     if thinking_text:
-                        self._print_thinking(thinking_text)
+                        self._emit_thinking(thinking_text)
 
         if was_streaming:
             return
 
-        # Fallback: print full text for models that don't stream tokens
+        # Fallback: emit full text for models that don't stream tokens
         text = msg.text
         if text:
-            self._publish(text, "assistant")
-            self._print(text)
+            self._publish(text + "\n", "assistant")
+            self._log_line(text)
         for tc in msg.tool_calls:
-            self._print_tool_call(tc["name"], tc["args"])
+            self._emit_tool_call(tc["name"], tc["args"])
 
     # --- Tool execution ---
 
@@ -291,16 +232,19 @@ class AgentLogger(BaseCallbackHandler):
     def on_tool_end(self, output: Any, **kwargs: Any) -> None:
         content = output.content if hasattr(output, "content") else str(output)
         name = getattr(output, "name", None) or "unknown"
-        self._print_tool_result(name, content)
+        self._emit_tool_result(name, content)
 
     def on_tool_error(self, error: Any, **kwargs: Any) -> None:
-        self._print(f"Tool error: {error!r}")
+        lines = [f"Tool error: {error!r}"]
         if isinstance(error, BaseException):
             tb = traceback.format_exception(type(error), error, error.__traceback__)
             if tb:
-                self._print("".join(tb).strip())
+                lines.append("".join(tb).strip())
+        text = "\n".join(lines)
+        self._publish(text + "\n", "diagnostic")
+        self._log_line(text)
 
-    # --- Formatting ---
+    # --- Event emission + log formatting ---
 
     # Tool names whose args contain code content that is already tracked in
     # git — no need to duplicate it in the run log.
@@ -323,8 +267,12 @@ class AgentLogger(BaseCallbackHandler):
         }
     )
 
-    def _print_tool_call(self, name: str, args: dict[str, Any]):
-        self._publish(f"→ {name}({json.dumps(args, default=str)})\n", "tool")
+    def _emit_tool_call(self, name: str, args: dict[str, Any]):
+        # Tool-channel chunk kept alongside the typed TOOL_CALL event for
+        # wire compatibility with existing clients.
+        status = self._status()
+        self._publish(f"→ {name}({json.dumps(args, default=str)})\n", "tool", status=status)
+        output_sink().tool_call(name, args, status=status)
         is_code_tool = name in self._CODE_CHANGE_TOOLS
 
         # Log file: skip code content args for file-writing tools
@@ -336,31 +284,24 @@ class AgentLogger(BaseCallbackHandler):
                     continue
                 s = json.dumps(v) if not isinstance(v, str) else v
                 full_parts.append(f'{k}="{s}"' if isinstance(v, str) else f"{k}={s}")
-            self._print_log(f"\n→ {name}({', '.join(full_parts)})")
+            self._log_line(f"\n→ {name}({', '.join(full_parts)})")
 
-        # Truncated args to stdout
-        parts = []
-        for k, v in args.items():
-            s = json.dumps(v) if not isinstance(v, str) else v
-            if len(s) > 80:
-                s = s[:80] + "..."
-            parts.append(f'{k}="{s}"' if isinstance(v, str) else f"{k}={s}")
-        self._print_stdout(f"\n{self._format_prefix()}→ {name}({', '.join(parts)})")
-
-    def _print_thinking(self, text: str):
+    def _emit_thinking(self, text: str):
         self._publish(text, "analysis")
-        self._print("\n[thinking]")
+        self._log_line("\n[thinking]")
         for line in text.split("\n"):
-            self._print(line)
+            self._log_line(line)
 
     # Maximum chars to write per tool result in the log file.  Keeps logs
     # readable while still capturing enough output for debugging.
     _LOG_MAX_RESULT_LEN = 2000
 
-    def _print_tool_result(self, name: str, content: str, color: str = DIM):
-        del name, color
+    def _emit_tool_result(self, name: str, content: str, *, is_error: bool = False):
         full_text = str(content)
+        # Tool-channel chunk kept alongside the typed TOOL_RESULT event for
+        # wire compatibility with existing clients.
         self._publish(full_text, "tool")
+        output_sink().tool_result(name, full_text, is_error=is_error)
 
         # Truncated to log file
         if self._log_file:
@@ -371,17 +312,14 @@ class AgentLogger(BaseCallbackHandler):
                     + f"... [{len(full_text) - self._LOG_MAX_RESULT_LEN} more chars]"
                 )
             for line in log_preview.split("\n"):
-                self._print_log(f"  {line}")
+                self._log_line(f"  {line}")
 
-        # Truncated to stdout
-        preview = full_text
-        if self._max_result_len is not None and len(preview) > self._max_result_len:
-            preview = preview[: self._max_result_len] + "..."
-        for line in preview.split("\n"):
-            self._print_stdout(f"  {line}")
+    def _log_line(self, text: str = "") -> None:
+        """Write one line to the log file only."""
+        self._log_write(text + "\n")
 
-    def _print(self, *args: Any, **kwargs: Any) -> None:
-        """Write to both stdout and log file.
+    def _log_write(self, text: str) -> None:
+        """Write raw text to the log file.
 
         Flushes the log file after each write so operators tailing
         ``run-*.log`` see agent events as they arrive (e.g. codex reasoning
@@ -389,19 +327,8 @@ class AgentLogger(BaseCallbackHandler):
         regular files with block buffering, so without the explicit flush
         streamed events can sit in the buffer for minutes.
         """
-        print(*args, file=self._output, **kwargs)
-        if self._log_file:
-            print(*args, file=self._log_file, **kwargs)
-            self._log_file.flush()
-
-    def _print_stdout(self, *args: Any, **kwargs: Any) -> None:
-        """Write to stdout only."""
-        print(*args, file=self._output, **kwargs)
-
-    def _print_log(self, *args: Any, **kwargs: Any) -> None:
-        """Write to log file only."""
-        if self._log_file:
-            print(*args, file=self._log_file, **kwargs)
+        if self._log_file and text:
+            self._log_file.write(text)
             self._log_file.flush()
 
     # --- Public hooks for non-langchain event sources ---
@@ -410,14 +337,15 @@ class AgentLogger(BaseCallbackHandler):
     # ``BaseCallbackHandler`` hooks (``on_llm_new_token``, ``on_tool_end``, …).
     # The cli runner in ``vibesys.agents.cli_runner`` receives events
     # from ``vibesys._agent_cli.AgentEventHandler`` directly on this object. Both
-    # paths converge on the same private ``_print_*`` formatters, so on-screen
-    # output is identical regardless of which backend is in use.
+    # paths converge on the same private ``_emit_*`` helpers, so emitted events
+    # and log text are identical regardless of which backend is in use.
 
     def on_thinking(self, text: str) -> None:
         if not text:
             return
-        self._publish(text, "analysis")
-        self._print(f"{self._format_prefix()}{text}")
+        status = self._status()
+        self._publish(text, "analysis", status=status)
+        self._log_line(f"{format_status_prefix(status)}{text}")
 
     def on_tool_call(self, tool: str, args: dict[str, Any] | str | None = None) -> None:
         if isinstance(args, dict):
@@ -462,21 +390,24 @@ class AgentLogger(BaseCallbackHandler):
         input_tokens = usage.get("input_tokens") or 0
         if input_tokens:
             self._input_tokens = input_tokens
+            self._publish_usage()
 
     def log_text(self, text: str) -> None:
-        """Print *text* with the agent's prefix and the standard green styling.
+        """Emit *text* as one complete assistant line.
 
-        Mirrors how ``on_llm_new_token`` renders streamed tokens, but for
-        complete chunks of text emitted by the cli backend.
+        Mirrors how ``on_llm_new_token`` streams tokens, but for complete
+        chunks of text emitted by the cli backend — hence the appended
+        newline, which the streaming path only adds at stream end.
         """
         if not text:
             return
-        self._publish(text, "assistant")
-        self._print(f"{self._format_prefix()}{text}")
+        status = self._status()
+        self._publish(text + "\n", "assistant", status=status)
+        self._log_line(f"{format_status_prefix(status)}{text}")
 
     def log_tool_call(self, name: str, args: dict[str, Any]) -> None:
-        """Format a tool invocation the same way the deepagents path does."""
-        self._print_tool_call(name, args)
+        """Emit a tool invocation the same way the deepagents path does."""
+        self._emit_tool_call(name, args)
 
     def log_tool_result(
         self,
@@ -485,12 +416,22 @@ class AgentLogger(BaseCallbackHandler):
         *,
         is_error: bool = False,
     ) -> None:
-        """Format a tool result the same way ``on_tool_end`` does."""
-        self._print_tool_result(name, content)
+        """Emit a tool result the same way ``on_tool_end`` does."""
+        self._emit_tool_result(name, content, is_error=is_error)
 
-    def _publish(self, content: str, channel: AgentOutputChannel) -> None:
-        from vibesys.server.registry import active_supervisor
+    def _publish(
+        self,
+        content: str,
+        channel: AgentOutputChannel,
+        status: AgentStatusData | None = None,
+    ) -> None:
+        output_sink().agent_output(
+            content, channel=channel, status=status if status is not None else self._status()
+        )
 
-        supervisor = active_supervisor()
-        if supervisor is not None:
-            supervisor.publish_agent_output(content, channel=channel)
+    def _publish_usage(self) -> None:
+        output_sink().usage_update(
+            self._input_tokens,
+            context_window=self._context_window,
+            model=self._model_name,
+        )

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -268,11 +268,7 @@ class AgentLogger(BaseCallbackHandler):
     )
 
     def _emit_tool_call(self, name: str, args: dict[str, Any]):
-        # Tool-channel chunk kept alongside the typed TOOL_CALL event for
-        # wire compatibility with existing clients.
-        status = self._status()
-        self._publish(f"→ {name}({json.dumps(args, default=str)})\n", "tool", status=status)
-        output_sink().tool_call(name, args, status=status)
+        output_sink().tool_call(name, args, status=self._status())
         is_code_tool = name in self._CODE_CHANGE_TOOLS
 
         # Log file: skip code content args for file-writing tools
@@ -298,9 +294,6 @@ class AgentLogger(BaseCallbackHandler):
 
     def _emit_tool_result(self, name: str, content: str, *, is_error: bool = False):
         full_text = str(content)
-        # Tool-channel chunk kept alongside the typed TOOL_RESULT event for
-        # wire compatibility with existing clients.
-        self._publish(full_text, "tool")
         output_sink().tool_result(name, full_text, is_error=is_error)
 
         # Truncated to log file

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -36,7 +36,6 @@ from vibesys._agent_cli.codex import CodexCodingAgent
 from vibesys._agent_cli.gemini import GeminiCodingAgent
 from vibesys._agent_cli.opencode import OpencodeCodingAgent
 from vibesys.agent_runner import (
-    DEFAULT_MAX_TEXT_LEN,
     log_and_print,
     log_json_and_print,
     log_markdown_and_print,
@@ -332,11 +331,7 @@ class CliAgentRunner:
             self._run_log_file,
         )
         log_and_print("--- input ---", self._run_log_file)
-        log_prompt_markdown_and_print(
-            combined_prompt,
-            self._run_log_file,
-            max_len=DEFAULT_MAX_TEXT_LEN,
-        )
+        log_prompt_markdown_and_print(combined_prompt, self._run_log_file)
 
         # 7. Run the agent. Wrap exceptions to surface them in the run log
         #    before re-raising. The ``finally`` clause runs both cleanups —
@@ -356,11 +351,7 @@ class CliAgentRunner:
                 f"\n=== {label} ROUND ERROR: {round_label} ===",
                 self._run_log_file,
             )
-            log_and_print(
-                f"{type(exc).__name__}: {exc}",
-                self._run_log_file,
-                max_len=DEFAULT_MAX_TEXT_LEN,
-            )
+            log_and_print(f"{type(exc).__name__}: {exc}", self._run_log_file)
             raise
         finally:
             if mcp_servers:
@@ -384,18 +375,14 @@ class CliAgentRunner:
                     f"\n=== {label} ROUND OUTPUT (raw output) ===",
                     self._run_log_file,
                 )
-                log_markdown_and_print(text, self._run_log_file, max_len=DEFAULT_MAX_TEXT_LEN)
+                log_markdown_and_print(text, self._run_log_file)
             return fallback_factory()
 
         log_and_print(
             f"\n=== {label} ROUND OUTPUT ===",
             self._run_log_file,
         )
-        log_json_and_print(
-            parsed.model_dump_json(indent=2),
-            self._run_log_file,
-            max_len=DEFAULT_MAX_TEXT_LEN,
-        )
+        log_json_and_print(parsed.model_dump_json(indent=2), self._run_log_file)
         return parsed
 
     def _write_usage_record(self, *, kind: str, round_label: str, agent: Any) -> None:

--- a/src/vibesys/agents/deepagents_runner.py
+++ b/src/vibesys/agents/deepagents_runner.py
@@ -21,7 +21,6 @@ from pydantic import BaseModel
 
 from vibesys._agent_cli.base import MCPServerSpec
 from vibesys.agent_runner import (
-    DEFAULT_MAX_TEXT_LEN,
     log_agent_config,
     run_typed_agent,
 )
@@ -110,5 +109,4 @@ class DeepAgentsRunner:
             thread_id=thread_id,
             round_label=round_label,
             log_file=self._run_log_file,
-            max_text_len=DEFAULT_MAX_TEXT_LEN,
         )

--- a/src/vibesys/agents/stub_runner.py
+++ b/src/vibesys/agents/stub_runner.py
@@ -33,23 +33,20 @@ class StubAgentRunner:
         **kwargs: object,
     ) -> T:
         del workspace, system_prompt, user_prompt, progress, kwargs
-        from vibesys.server.registry import active_supervisor
+        from vibesys.render.sink import output_sink
 
-        supervisor = active_supervisor()
-        if supervisor is not None:
-            supervisor.publish_agent_output(
-                f"[stub-agent] {round_label}: starting {kind}\n",
-                channel="diagnostic",
-                agent_kind=kind,
-            )
+        output_sink().agent_output(
+            f"[stub-agent] {round_label}: starting {kind}\n",
+            channel="diagnostic",
+            agent_kind=kind,
+        )
         time.sleep(0.05)
         response = _response_data(response_cls.__name__)
-        if supervisor is not None:
-            supervisor.publish_agent_output(
-                f"[stub-agent] {round_label}: completed {kind}\n",
-                channel="diagnostic",
-                agent_kind=kind,
-            )
+        output_sink().agent_output(
+            f"[stub-agent] {round_label}: completed {kind}\n",
+            channel="diagnostic",
+            agent_kind=kind,
+        )
         return response_cls.model_validate(response) if response is not None else fallback_factory()
 
 

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -40,6 +40,7 @@ from vibesys.profilers import (
     profiler_definition,
     resolve_profiler_kind,
 )
+from vibesys.render import HeadlessRenderer, output_sink
 from vibesys.run import DeviceLease, GitTracker, RunCommands, RunLogger, RunPaths, Workspace
 from vibesys.sandbox.run_environment import (
     RunEnvironment,
@@ -164,10 +165,24 @@ def create_run_context(
     supervisor = active_supervisor()
     if supervisor is not None:
         supervisor.attach(log_dir)
-    # A full-screen TUI owns the terminal. Its thread-aware stream router
-    # suppresses worker writes; replacing it with a process-global tee here
-    # would both corrupt the display and record terminal escape frames.
-    logger = RunLogger(log_dir, redirect_stderr=supervisor is None)
+    # The stderr tee captures diagnostics into the run log; it never renders,
+    # so it is safe under both the TUI and the headless renderer.
+    logger = RunLogger(log_dir)
+
+    # One teardown stack for the whole context: every component with
+    # cleanup registers here, and close() unwinds it in reverse
+    # construction order (device → environment hooks → session → logs).
+    teardown_stack = ExitStack()
+    teardown_stack.callback(logger.close)
+
+    # Presentation is selected exactly once, here: with a TUI supervisor
+    # attached, events flow to the supervision client; otherwise the
+    # headless renderer subscribes to the same event stream and owns the
+    # terminal for the lifetime of the run.
+    if supervisor is None:
+        renderer = HeadlessRenderer()
+        teardown_stack.callback(output_sink().subscribe(renderer.handle))
+
     paths = RunPaths(
         exp_dir=exp_dir,
         log_dir=log_dir,
@@ -283,11 +298,6 @@ def create_run_context(
     if git_tracking:
         git.init(existing)
 
-    # One teardown stack for the whole context: every component with
-    # cleanup registers here, and close() unwinds it in reverse
-    # construction order (device → environment hooks → session → logs).
-    teardown_stack = ExitStack()
-    teardown_stack.callback(logger.close)
     session = teardown_stack.enter_context(
         environment.open(
             RunEnvironmentRequest(

--- a/src/vibesys/render/__init__.py
+++ b/src/vibesys/render/__init__.py
@@ -1,0 +1,21 @@
+"""Presentation layer: event emission sink and per-surface renderers.
+
+The backend never prints to the terminal directly. It emits typed events
+through :data:`~vibesys.render.sink.OutputSink` (see :func:`output_sink`)
+and writes plain text to the durable run log. Every human-facing surface —
+the headless terminal view, the TUI client — is a renderer subscribed to
+the same event stream.
+"""
+
+from vibesys.render.format import format_status_prefix, format_token_count
+from vibesys.render.headless import HeadlessRenderer, TodoDisplay
+from vibesys.render.sink import OutputSink, output_sink
+
+__all__ = [
+    "HeadlessRenderer",
+    "OutputSink",
+    "TodoDisplay",
+    "format_status_prefix",
+    "format_token_count",
+    "output_sink",
+]

--- a/src/vibesys/render/format.py
+++ b/src/vibesys/render/format.py
@@ -1,0 +1,39 @@
+"""Plain-text formatting shared by the terminal renderer and the run log."""
+
+from __future__ import annotations
+
+from vibesys.server.events import AgentStatusData
+
+
+def format_token_count(n: int) -> str:
+    """Format a token count compactly: ``999`` / ``20k`` / ``1.0M``."""
+    if n < 1_000:
+        return str(n)
+    if n < 1_000_000:
+        return f"{n // 1000}k"
+    return f"{n / 1_000_000:.1f}M"
+
+
+def format_status_prefix(status: AgentStatusData | None) -> str:
+    """Build the ``[progress | label | elapsed | tokens/max] `` status prefix.
+
+    Returns an empty string when there is nothing identifying to show
+    (no progress reading and no agent label), matching the historical
+    behavior of anonymous ``AgentLogger`` instances.
+    """
+    if status is None:
+        return ""
+    if not status.progress and not status.agent_label:
+        return ""
+    used = format_token_count(status.input_tokens)
+    if status.context_window:
+        tokens_str = f"{used}/{format_token_count(status.context_window)}"
+    else:
+        tokens_str = used
+    parts: list[str] = []
+    if status.progress:
+        parts.append(status.progress)
+    if status.agent_label:
+        parts.append(status.agent_label)
+    parts.extend([f"{status.elapsed_seconds:.1f}s", tokens_str])
+    return f"[{' | '.join(parts)}] "

--- a/src/vibesys/render/headless.py
+++ b/src/vibesys/render/headless.py
@@ -133,8 +133,9 @@ class HeadlessRenderer:
 
     def _render_chunk(self, data: AgentOutputChunkData) -> None:
         if data.channel == "tool":
-            # Tool traffic is rendered from the typed TOOL_CALL/TOOL_RESULT
-            # events; the tool-channel chunks exist for client compatibility.
+            # Tool traffic arrives as typed TOOL_CALL/TOOL_RESULT events;
+            # tool-channel chunks only exist in event files recorded by
+            # older backends and never reach a live renderer.
             return
         if data.channel == "assistant":
             self._render_assistant(data)

--- a/src/vibesys/render/headless.py
+++ b/src/vibesys/render/headless.py
@@ -1,0 +1,191 @@
+"""Terminal renderer for headless runs.
+
+Subscribes to the process-global :class:`~vibesys.render.sink.OutputSink`
+and renders the same information the TUI shows: streamed agent output,
+tool calls and results, todo lists, and prompt/diagnostic lines. This is
+the only component that writes presentation output to the terminal; the
+backend itself emits events and plain log text only.
+
+Selection happens once at composition time (``create_run_context``): the
+renderer is subscribed only when no TUI supervisor is attached.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import TextIO
+
+from vibesys.constants import DIM, GREEN, RESET, YELLOW
+from vibesys.render.format import format_status_prefix
+from vibesys.server.events import (
+    AgentOutputChunkData,
+    RunEvent,
+    TodoItemData,
+    TodoUpdateData,
+    ToolCallData,
+    ToolResultData,
+)
+
+_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+
+_COLOR_STATUS_INDICATORS = {
+    "completed": f"{GREEN}✓{RESET}",
+    "in_progress": f"{YELLOW}▶{RESET}",
+    "pending": f"{DIM}○{RESET}",
+}
+_PLAIN_STATUS_INDICATORS = {
+    "completed": "✓",
+    "in_progress": "▶",
+    "pending": "○",
+}
+
+
+class TodoDisplay:
+    """Renders a persistent todo list box using ANSI cursor control."""
+
+    def __init__(self, file: TextIO | None = None, *, color: bool = True):
+        self._file = file
+        self._color = color
+        self._prev_lines = 0
+
+    @property
+    def _out(self) -> TextIO:
+        return self._file if self._file is not None else sys.stdout
+
+    def update(self, todos: list[TodoItemData]) -> None:
+        if not todos:
+            return
+        indicators = _COLOR_STATUS_INDICATORS if self._color else _PLAIN_STATUS_INDICATORS
+        items = [f"│ {indicators.get(t.status, '?')} {t.content}" for t in todos]
+        width = max(len(self._strip_ansi(line)) for line in items) + 2
+        width = max(width, len("─ Todo ─") + 4)
+
+        top = f"┌─ Todo {'─' * (width - 8)}┐"
+        bot = f"└{'─' * (width - 1)}┘"
+        padded = [line + " " * (width - len(self._strip_ansi(line)) - 1) + "│" for line in items]
+        box = [top] + padded + [bot]
+
+        out = self._out
+        # Clear previous block
+        if self._prev_lines > 0:
+            out.write(f"\033[{self._prev_lines}A")
+            for _ in range(self._prev_lines):
+                out.write("\033[2K\n")
+            out.write(f"\033[{self._prev_lines}A")
+
+        for line in box:
+            out.write(line + "\n")
+        out.flush()
+        self._prev_lines = len(box)
+
+    @staticmethod
+    def _strip_ansi(s: str) -> str:
+        return _ANSI_RE.sub("", s)
+
+
+class HeadlessRenderer:
+    """Render run events as colored terminal output for non-TUI runs."""
+
+    # Maximum chars shown per tool result before truncation.
+    DEFAULT_MAX_RESULT_LEN = 500
+    # Maximum chars shown per prompt/diagnostic block before truncation;
+    # the run log always holds the full text.
+    DEFAULT_MAX_TEXT_LEN = 2000
+    # Maximum chars shown per tool-call argument.
+    _MAX_ARG_LEN = 80
+
+    def __init__(
+        self,
+        out: TextIO | None = None,
+        *,
+        color: bool = True,
+        max_result_len: int | None = DEFAULT_MAX_RESULT_LEN,
+        max_text_len: int | None = DEFAULT_MAX_TEXT_LEN,
+    ):
+        self._explicit_out = out
+        self._color = color
+        self.max_result_len = max_result_len
+        self.max_text_len = max_text_len
+        self._at_line_start = True
+        self._todo_display = TodoDisplay(file=out, color=color)
+
+    @property
+    def _out(self) -> TextIO:
+        return self._explicit_out if self._explicit_out is not None else sys.stdout
+
+    def handle(self, event: RunEvent) -> None:
+        data = event.data
+        if isinstance(data, AgentOutputChunkData):
+            self._render_chunk(data)
+        elif isinstance(data, ToolCallData):
+            self._render_tool_call(data)
+        elif isinstance(data, ToolResultData):
+            self._render_tool_result(data)
+        elif isinstance(data, TodoUpdateData):
+            self._break_line()
+            self._todo_display.update(data.todos)
+        # Other event types (usage updates, lifecycle) carry no direct
+        # terminal output; status readings surface through chunk prefixes.
+
+    # -- channel rendering ---------------------------------------------------
+
+    def _render_chunk(self, data: AgentOutputChunkData) -> None:
+        if data.channel == "tool":
+            # Tool traffic is rendered from the typed TOOL_CALL/TOOL_RESULT
+            # events; the tool-channel chunks exist for client compatibility.
+            return
+        if data.channel == "assistant":
+            self._render_assistant(data)
+        elif data.channel == "analysis":
+            self._render_line(format_status_prefix(data.status) + data.content)
+        else:  # "prompt" / "diagnostic"
+            self._render_block(data.content)
+
+    def _render_assistant(self, data: AgentOutputChunkData) -> None:
+        out = self._out
+        if self._at_line_start:
+            prefix = format_status_prefix(data.status)
+            if prefix:
+                out.write(prefix)
+        out.write(data.content)
+        out.flush()
+        self._at_line_start = data.content.endswith("\n")
+
+    def _render_line(self, text: str) -> None:
+        self._break_line()
+        out = self._out
+        out.write(text)
+        if not text.endswith("\n"):
+            out.write("\n")
+        out.flush()
+        self._at_line_start = True
+
+    def _render_block(self, content: str) -> None:
+        body = content[:-1] if content.endswith("\n") else content
+        if self.max_text_len is not None and len(body) > self.max_text_len:
+            hidden = len(body) - self.max_text_len
+            body = f"{body[: self.max_text_len]}\n... [{hidden} more chars, see log for full text]"
+        self._render_line(body)
+
+    def _render_tool_call(self, data: ToolCallData) -> None:
+        parts: list[str] = []
+        for k, v in data.args.items():
+            s = v if isinstance(v, str) else json.dumps(v)
+            if len(s) > self._MAX_ARG_LEN:
+                s = s[: self._MAX_ARG_LEN] + "..."
+            parts.append(f'{k}="{s}"' if isinstance(v, str) else f"{k}={s}")
+        prefix = format_status_prefix(data.status)
+        self._render_line(f"\n{prefix}→ {data.tool}({', '.join(parts)})")
+
+    def _render_tool_result(self, data: ToolResultData) -> None:
+        preview = data.content
+        if self.max_result_len is not None and len(preview) > self.max_result_len:
+            preview = preview[: self.max_result_len] + "..."
+        self._render_line("\n".join(f"  {line}" for line in preview.split("\n")))
+
+    def _break_line(self) -> None:
+        if not self._at_line_start:
+            self._out.write("\n")
+            self._at_line_start = True

--- a/src/vibesys/render/sink.py
+++ b/src/vibesys/render/sink.py
@@ -1,0 +1,141 @@
+"""The single emission point for presentation events.
+
+Emission sites (agent callbacks, runner helpers, ``lprint``) call the
+process-global :class:`OutputSink` unconditionally — headless or TUI. The
+sink forwards each event to the active :class:`~vibesys.server.supervisor.
+RunSupervisor` (when a TUI/supervision client is attached) and to any
+in-process subscribers (the headless renderer). This is the only place
+allowed to consult :func:`~vibesys.server.registry.active_supervisor`;
+call sites never branch on presentation mode.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from vibesys.server.events import (
+    AgentOutputChannel,
+    AgentOutputChunkData,
+    AgentStatusData,
+    EventData,
+    EventType,
+    RunEvent,
+    TodoItemData,
+    TodoUpdateData,
+    ToolCallData,
+    ToolResultData,
+    UsageUpdateData,
+    make_event,
+)
+
+EventHandler = Callable[[RunEvent], None]
+
+
+def _json_safe(args: dict[str, Any]) -> dict[str, Any]:
+    """Coerce tool args to a JSON-serializable dict (events must serialize)."""
+    return json.loads(json.dumps(args, default=repr))
+
+
+class OutputSink:
+    """Fan presentation events out to the supervisor and local subscribers."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._subscribers: tuple[EventHandler, ...] = ()
+
+    def subscribe(self, handler: EventHandler) -> Callable[[], None]:
+        """Register *handler* for every emitted event; returns an unsubscriber."""
+        with self._lock:
+            self._subscribers = (*self._subscribers, handler)
+
+        def unsubscribe() -> None:
+            with self._lock:
+                self._subscribers = tuple(h for h in self._subscribers if h is not handler)
+
+        return unsubscribe
+
+    # -- semantic emitters ---------------------------------------------------
+
+    def agent_output(
+        self,
+        content: str,
+        *,
+        channel: AgentOutputChannel = "assistant",
+        status: AgentStatusData | None = None,
+        agent_kind: str | None = None,
+    ) -> None:
+        if not content:
+            return
+        self._emit(
+            EventType.AGENT_OUTPUT_CHUNK,
+            AgentOutputChunkData(channel=channel, content=content, status=status),
+            agent_kind=agent_kind,
+        )
+
+    def tool_call(
+        self,
+        tool: str,
+        args: dict[str, Any],
+        *,
+        status: AgentStatusData | None = None,
+    ) -> None:
+        self._emit(
+            EventType.TOOL_CALL,
+            ToolCallData(tool=tool, args=_json_safe(args), status=status),
+        )
+
+    def tool_result(self, tool: str, content: str, *, is_error: bool = False) -> None:
+        self._emit(
+            EventType.TOOL_RESULT,
+            ToolResultData(tool=tool, content=content, is_error=is_error),
+        )
+
+    def todo_update(self, todos: list[TodoItemData]) -> None:
+        if not todos:
+            return
+        self._emit(EventType.TODO_UPDATE, TodoUpdateData(todos=todos))
+
+    def usage_update(
+        self,
+        input_tokens: int,
+        *,
+        context_window: int | None = None,
+        model: str | None = None,
+    ) -> None:
+        self._emit(
+            EventType.USAGE_UPDATE,
+            UsageUpdateData(input_tokens=input_tokens, context_window=context_window, model=model),
+        )
+
+    # -- dispatch ------------------------------------------------------------
+
+    def _emit(
+        self,
+        event_type: EventType,
+        data: EventData,
+        *,
+        agent_kind: str | None = None,
+    ) -> None:
+        from vibesys.server.registry import active_supervisor
+
+        supervisor = active_supervisor()
+        if supervisor is not None:
+            supervisor.publish_presentation(event_type, data, agent_kind=agent_kind)
+        with self._lock:
+            subscribers = self._subscribers
+        if not subscribers:
+            return
+        event = make_event(event_type, agent_kind=agent_kind, data=data)
+        for handler in subscribers:
+            handler(event)
+
+
+_SINK = OutputSink()
+
+
+def output_sink() -> OutputSink:
+    """Return the process-global presentation sink."""
+    return _SINK

--- a/src/vibesys/run/logger.py
+++ b/src/vibesys/run/logger.py
@@ -1,5 +1,6 @@
 """Run logging: the per-run log file, ``lprint``, and the stderr tee."""
 
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -7,15 +8,27 @@ from typing import TextIO
 
 from vibesys.agent_runner import log_and_print
 
+# Matches ANSI escape sequences (CSI colors, cursor control, and simple
+# single-character escapes) so the durable log stays plain text even when
+# subprocesses write colored diagnostics to stderr.
+_ANSI_ESCAPE_RE = re.compile(r"\x1b(?:\[[0-9;?]*[ -/]*[@-~]|[@-Z\\-_])")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from *text*."""
+    return _ANSI_ESCAPE_RE.sub("", text)
+
 
 class _TeeWriter:
+    """Pass writes through to the real stream and mirror them, ANSI-free, to the log."""
+
     def __init__(self, primary: TextIO, secondary: TextIO) -> None:
         self._primary = primary
         self._secondary = secondary
 
     def write(self, text: str) -> int:
         self._primary.write(text)
-        self._secondary.write(text)
+        self._secondary.write(strip_ansi(text))
         return len(text)
 
     def flush(self):
@@ -27,22 +40,25 @@ class _TeeWriter:
 
 
 class RunLogger:
-    """Owns the current run log file and the process stderr redirect.
+    """Owns the current run log file and the process stderr tee.
 
     Components that need to log for the lifetime of a run hold
     ``logger.lprint``; it always writes to the *current* log file, so
     log-file switches (``switch``) retarget every holder at once.
+
+    The stderr tee is unconditional: it captures diagnostics (writes still
+    reach the real stderr untouched), so it is safe regardless of which
+    renderer owns the terminal. The log copy has ANSI escapes stripped so
+    ``run-*.log`` stays plain text.
     """
 
-    def __init__(self, log_dir: Path, *, redirect_stderr: bool) -> None:
+    def __init__(self, log_dir: Path) -> None:
         self.log_dir = log_dir
         run_started = datetime.now().strftime("%Y%m%d-%H%M%S")
         self.path = log_dir / f"run-{run_started}.log"
         self.file = self.path.open("a", encoding="utf-8")
         self._original_stderr = sys.stderr
-        self.stderr_redirected = redirect_stderr
-        if self.stderr_redirected:
-            sys.stderr = _TeeWriter(self._original_stderr, self.file)
+        sys.stderr = _TeeWriter(self._original_stderr, self.file)
 
     def lprint(self, text: str) -> None:
         log_and_print(text, self.file)
@@ -57,8 +73,8 @@ class RunLogger:
         a string.
 
         The previous log file is flushed but kept open. A new file becomes
-        ``file``. When stderr logging is enabled, its tee is updated to
-        write to the new file as well.  Returns the new file handle.
+        ``file``. The stderr tee is updated to write to the new file as
+        well.  Returns the new file handle.
         """
         self.file.flush()
         ts = datetime.now().strftime("%Y%m%d-%H%M%S")
@@ -67,11 +83,9 @@ class RunLogger:
         new_file = new_path.open("a", encoding="utf-8")
         self.path = new_path
         self.file = new_file
-        if self.stderr_redirected:
-            sys.stderr = _TeeWriter(self._original_stderr, new_file)
+        sys.stderr = _TeeWriter(self._original_stderr, new_file)
         return new_file
 
     def close(self) -> None:
-        if self.stderr_redirected:
-            sys.stderr = self._original_stderr
+        sys.stderr = self._original_stderr
         self.file.close()

--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -33,6 +33,10 @@ class EventType(StrEnum):
     RUN_FINISHED = "run_finished"
     RUN_FAILED = "run_failed"
     OUTPUT = "output"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    TODO_UPDATE = "todo_update"
+    USAGE_UPDATE = "usage_update"
 
 
 class EventStatus(StrEnum):
@@ -108,10 +112,60 @@ class PhaseData(BaseModel):
     attempt: int | None = None
 
 
+class AgentStatusData(BaseModel):
+    """Structured progress readings for one agent invocation.
+
+    Carried on presentation events so renderers can format their own status
+    prefix (e.g. ``[Round 3/24 | Implementer | 12.3s | 20k/1.0M]``) without
+    the backend baking any layout or styling into the payload.
+    """
+
+    progress: str | None = None
+    agent_label: str | None = None
+    elapsed_seconds: float = 0.0
+    input_tokens: int = 0
+    context_window: int | None = None
+
+
 class AgentOutputChunkData(BaseModel):
     kind: Literal["agent_output_chunk"] = "agent_output_chunk"
     channel: AgentOutputChannel
     content: str
+    status: AgentStatusData | None = None
+
+
+class ToolCallData(BaseModel):
+    kind: Literal["tool_call"] = "tool_call"
+    tool: str
+    args: dict[str, Any] = Field(default_factory=dict)
+    status: AgentStatusData | None = None
+
+
+class ToolResultData(BaseModel):
+    kind: Literal["tool_result"] = "tool_result"
+    tool: str
+    content: str
+    is_error: bool = False
+
+
+class TodoItemData(BaseModel):
+    content: str
+    # Expected values are "pending" / "in_progress" / "completed", but the
+    # field stays open: todo payloads originate from agent tool calls, and an
+    # unknown status must degrade in the renderer, not fail event emission.
+    status: str
+
+
+class TodoUpdateData(BaseModel):
+    kind: Literal["todo_update"] = "todo_update"
+    todos: list[TodoItemData] = Field(default_factory=list)
+
+
+class UsageUpdateData(BaseModel):
+    kind: Literal["usage_update"] = "usage_update"
+    input_tokens: int
+    context_window: int | None = None
+    model: str | None = None
 
 
 class SubprocessOutputData(BaseModel):
@@ -158,7 +212,11 @@ EventData = Annotated[
     | SubprocessOutputData
     | JudgeResultData
     | BenchmarkResultData
-    | RoundFinishedData,
+    | RoundFinishedData
+    | ToolCallData
+    | ToolResultData
+    | TodoUpdateData
+    | UsageUpdateData,
     Field(discriminator="kind"),
 ]
 

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -89,12 +89,28 @@ class RunSupervisor:
     ) -> None:
         if not content:
             return
-        self.record(
+        self.publish_presentation(
             EventType.AGENT_OUTPUT_CHUNK,
+            AgentOutputChunkData(channel=channel, content=content),
+            agent_kind=agent_kind,
+            invocation_id=invocation_id,
+        )
+
+    def publish_presentation(
+        self,
+        event_type: EventType,
+        data: EventData,
+        *,
+        agent_kind: str | None = None,
+        invocation_id: str | None = None,
+    ) -> None:
+        """Record a presentation event enriched with the active invocation scope."""
+        self.record(
+            event_type,
             agent_kind=agent_kind or self._current_kind,
             round_label=self._current_round,
             invocation_id=invocation_id or self._active_invocation,
-            data=AgentOutputChunkData(channel=channel, content=content),
+            data=data,
         )
 
     def record(

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -34,14 +34,14 @@ def _judge_fallback() -> JudgeResponse:
     )
 
 
-def test_prompt_markdown_emitter_preserves_raw_log_and_truncates_stdout(capsys):
+def test_prompt_markdown_emitter_preserves_raw_log_and_truncates_stdout(capsys, headless_renderer):
+    headless_renderer.max_text_len = 20
     log = StringIO()
     prompt = "# Title\n\nUse **markdown** and `code`."
 
-    log_prompt_markdown_and_print(prompt, log_file=log, max_len=20)
+    log_prompt_markdown_and_print(prompt, log_file=log)
 
     stdout = capsys.readouterr().out
-    assert "Title" in stdout
     assert "# Title" in stdout
     assert "... [17 more chars, see log for full text]" in stdout
     assert log.getvalue() == prompt + "\n"

--- a/tests/agents/test_callbacks.py
+++ b/tests/agents/test_callbacks.py
@@ -87,7 +87,18 @@ class TestOnLlmEnd:
         logger.on_llm_end(_make_response(content=content))
         out = capsys.readouterr().out
         assert "let me think..." in out
-        assert "[thinking]" in out
+
+    def test_thinking_blocks_marked_in_log(self):
+        log = io.StringIO()
+        content = [
+            {"type": "thinking", "thinking": "let me think..."},
+            {"type": "text", "text": "answer"},
+        ]
+        logger = AgentLogger(log_file=log)
+        logger.on_llm_end(_make_response(content=content))
+        log_text = log.getvalue()
+        assert "[thinking]" in log_text
+        assert "let me think..." in log_text
 
 
 class TestOnToolStart:
@@ -109,8 +120,9 @@ class TestOnToolEnd:
         out = capsys.readouterr().out
         assert "file1.py" in out
 
-    def test_truncates_long_output(self, capsys):
-        logger = AgentLogger(max_result_len=10)
+    def test_truncates_long_output(self, capsys, headless_renderer):
+        headless_renderer.max_result_len = 10
+        logger = AgentLogger()
         output = MagicMock()
         output.content = "a" * 20
         output.name = "shell"
@@ -118,8 +130,9 @@ class TestOnToolEnd:
         out = capsys.readouterr().out
         assert "..." in out
 
-    def test_exact_limit_no_truncation(self, capsys):
-        logger = AgentLogger(max_result_len=10)
+    def test_exact_limit_no_truncation(self, capsys, headless_renderer):
+        headless_renderer.max_result_len = 10
+        logger = AgentLogger()
         output = MagicMock()
         output.content = "a" * 10
         output.name = "shell"
@@ -127,8 +140,9 @@ class TestOnToolEnd:
         out = capsys.readouterr().out
         assert "..." not in out
 
-    def test_custom_max_result_len(self, capsys):
-        logger = AgentLogger(max_result_len=5)
+    def test_custom_max_result_len(self, capsys, headless_renderer):
+        headless_renderer.max_result_len = 5
+        logger = AgentLogger()
         output = MagicMock()
         output.content = "abcdefghij"
         output.name = "test"
@@ -231,9 +245,10 @@ class TestStateManagement:
 class TestLogFile:
     """AgentLogger with log_file writes full output to log while truncating stdout."""
 
-    def test_tool_result_full_in_log_truncated_on_stdout(self, capsys):
+    def test_tool_result_full_in_log_truncated_on_stdout(self, capsys, headless_renderer):
+        headless_renderer.max_result_len = 10
         log = io.StringIO()
-        logger = AgentLogger(max_result_len=10, log_file=log)
+        logger = AgentLogger(log_file=log)
         output = MagicMock()
         output.content = "a" * 50
         output.name = "shell"
@@ -280,9 +295,10 @@ class TestLogFile:
         log_text = log.getvalue()
         assert "deep thoughts" in log_text
 
-    def test_no_log_file_works_normally(self, capsys):
+    def test_no_log_file_works_normally(self, capsys, headless_renderer):
         """AgentLogger without log_file still works as before."""
-        logger = AgentLogger(max_result_len=10)
+        headless_renderer.max_result_len = 10
+        logger = AgentLogger()
         output = MagicMock()
         output.content = "a" * 20
         output.name = "shell"
@@ -436,34 +452,6 @@ class TestOnChatModelStart:
         logger.on_chat_model_start(serialized, messages)
         second_log = log.getvalue()
         assert system_prompt not in second_log
-
-
-class TestFormatTokenCount:
-    def test_zero(self):
-        from vibesys.agents.callbacks import _format_token_count
-
-        assert _format_token_count(0) == "0"
-
-    def test_under_thousand(self):
-        from vibesys.agents.callbacks import _format_token_count
-
-        assert _format_token_count(523) == "523"
-        assert _format_token_count(999) == "999"
-
-    def test_thousands_boundary(self):
-        from vibesys.agents.callbacks import _format_token_count
-
-        assert _format_token_count(1000) == "1k"
-        assert _format_token_count(20_100) == "20k"
-        assert _format_token_count(199_500) == "199k"
-        assert _format_token_count(999_999) == "999k"
-
-    def test_millions(self):
-        from vibesys.agents.callbacks import _format_token_count
-
-        assert _format_token_count(1_000_000) == "1.0M"
-        assert _format_token_count(1_200_000) == "1.2M"
-        assert _format_token_count(1_048_576) == "1.0M"
 
 
 class TestDefaultContextWindowLookup:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,27 @@
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
 from vibesys.input_manifest import MANIFEST_NAME
+from vibesys.render import HeadlessRenderer, output_sink
+
+
+@pytest.fixture(autouse=True)
+def headless_renderer() -> Iterator[HeadlessRenderer]:
+    """Compose a headless renderer for every test, mirroring production.
+
+    In production ``create_run_context`` subscribes the renderer exactly once
+    per headless run; tests get the same composition so code that emits
+    events through the output sink still produces observable terminal output
+    (e.g. for ``capsys`` assertions).
+    """
+    renderer = HeadlessRenderer()
+    unsubscribe = output_sink().subscribe(renderer.handle)
+    try:
+        yield renderer
+    finally:
+        unsubscribe()
 
 
 @pytest.fixture(scope="session")

--- a/tests/render/test_format.py
+++ b/tests/render/test_format.py
@@ -1,0 +1,51 @@
+"""Tests for the shared plain-text formatting helpers."""
+
+from vibesys.render import format_status_prefix, format_token_count
+from vibesys.server.events import AgentStatusData
+
+
+class TestFormatTokenCount:
+    def test_zero(self):
+        assert format_token_count(0) == "0"
+
+    def test_under_thousand(self):
+        assert format_token_count(523) == "523"
+        assert format_token_count(999) == "999"
+
+    def test_thousands_boundary(self):
+        assert format_token_count(1000) == "1k"
+        assert format_token_count(20_100) == "20k"
+        assert format_token_count(199_500) == "199k"
+        assert format_token_count(999_999) == "999k"
+
+    def test_millions(self):
+        assert format_token_count(1_000_000) == "1.0M"
+        assert format_token_count(1_200_000) == "1.2M"
+        assert format_token_count(1_048_576) == "1.0M"
+
+
+class TestFormatStatusPrefix:
+    def test_none_status_is_empty(self):
+        assert format_status_prefix(None) == ""
+
+    def test_anonymous_status_is_empty(self):
+        status = AgentStatusData(elapsed_seconds=3.2, input_tokens=100)
+        assert format_status_prefix(status) == ""
+
+    def test_full_prefix(self):
+        status = AgentStatusData(
+            progress="Round 3/24",
+            agent_label="Implementer",
+            elapsed_seconds=12.34,
+            input_tokens=20_100,
+            context_window=1_000_000,
+        )
+        assert format_status_prefix(status) == "[Round 3/24 | Implementer | 12.3s | 20k/1.0M] "
+
+    def test_no_context_window_omits_max(self):
+        status = AgentStatusData(agent_label="X", elapsed_seconds=0.0, input_tokens=0)
+        assert format_status_prefix(status) == "[X | 0.0s | 0] "
+
+    def test_progress_only(self):
+        status = AgentStatusData(progress="Round 1/2", elapsed_seconds=1.0, input_tokens=500)
+        assert format_status_prefix(status) == "[Round 1/2 | 1.0s | 500] "

--- a/tests/render/test_headless.py
+++ b/tests/render/test_headless.py
@@ -78,8 +78,8 @@ class TestBlockChannels:
 
 class TestToolEvents:
     def test_tool_channel_chunks_are_ignored(self):
-        # Tool traffic renders from the typed events; the tool-channel chunks
-        # exist only for wire compatibility and must not double-render.
+        # Tool traffic renders from the typed events; tool-channel chunks
+        # (legacy event files only) must not double-render.
         assert _render(_chunk("→ shell({})\n", channel="tool")) == ""
 
     def test_tool_call_line(self):

--- a/tests/render/test_headless.py
+++ b/tests/render/test_headless.py
@@ -1,0 +1,178 @@
+"""Tests for the headless terminal renderer (synthetic events in, text out)."""
+
+from io import StringIO
+
+from vibesys.render import HeadlessRenderer, TodoDisplay
+from vibesys.server.events import (
+    AgentOutputChunkData,
+    AgentStatusData,
+    EventData,
+    EventType,
+    TodoItemData,
+    TodoUpdateData,
+    ToolCallData,
+    ToolResultData,
+    UsageUpdateData,
+    make_event,
+)
+
+
+def _render(*payloads: tuple[EventType, EventData], **kwargs) -> str:
+    out = StringIO()
+    renderer = HeadlessRenderer(out=out, **kwargs)
+    for event_type, data in payloads:
+        renderer.handle(make_event(event_type, data=data))
+    return out.getvalue()
+
+
+def _chunk(content: str, channel: str = "assistant", status: AgentStatusData | None = None):
+    return (
+        EventType.AGENT_OUTPUT_CHUNK,
+        AgentOutputChunkData(channel=channel, content=content, status=status),  # type: ignore[arg-type]
+    )
+
+
+_STATUS = AgentStatusData(
+    agent_label="Implementer",
+    elapsed_seconds=12.34,
+    input_tokens=20_100,
+    context_window=1_000_000,
+)
+
+
+class TestAssistantStreaming:
+    def test_tokens_stream_without_newlines(self):
+        assert _render(_chunk("hel"), _chunk("lo")) == "hello"
+
+    def test_prefix_written_once_at_line_start(self):
+        out = _render(_chunk("hel", status=_STATUS), _chunk("lo", status=_STATUS))
+        assert out == "[Implementer | 12.3s | 20k/1.0M] hello"
+
+    def test_no_prefix_for_anonymous_status(self):
+        assert _render(_chunk("hi")) == "hi"
+
+    def test_line_broken_before_next_surface(self):
+        out = _render(_chunk("partial"), _chunk("diag\n", channel="diagnostic"))
+        assert out == "partial\ndiag\n"
+
+
+class TestAnalysisChannel:
+    def test_rendered_as_prefixed_line(self):
+        out = _render(_chunk("thinking hard", channel="analysis", status=_STATUS))
+        assert out == "[Implementer | 12.3s | 20k/1.0M] thinking hard\n"
+
+
+class TestBlockChannels:
+    def test_diagnostic_rendered_verbatim(self):
+        out = _render(_chunk("=== ROUND START ===\n", channel="diagnostic"))
+        assert out == "=== ROUND START ===\n"
+
+    def test_prompt_truncated_with_pointer_to_log(self):
+        out = _render(_chunk("x" * 30 + "\n", channel="prompt"), max_text_len=20)
+        assert out == "x" * 20 + "\n... [10 more chars, see log for full text]\n"
+
+    def test_short_prompt_not_truncated(self):
+        out = _render(_chunk("short\n", channel="prompt"), max_text_len=20)
+        assert out == "short\n"
+
+
+class TestToolEvents:
+    def test_tool_channel_chunks_are_ignored(self):
+        # Tool traffic renders from the typed events; the tool-channel chunks
+        # exist only for wire compatibility and must not double-render.
+        assert _render(_chunk("→ shell({})\n", channel="tool")) == ""
+
+    def test_tool_call_line(self):
+        out = _render(
+            (EventType.TOOL_CALL, ToolCallData(tool="shell", args={"cmd": "ls"}, status=_STATUS))
+        )
+        assert out == '\n[Implementer | 12.3s | 20k/1.0M] → shell(cmd="ls")\n'
+
+    def test_tool_call_args_truncated(self):
+        long = "x" * 200
+        out = _render((EventType.TOOL_CALL, ToolCallData(tool="shell", args={"cmd": long})))
+        assert long not in out
+        assert "x" * 80 + "..." in out
+
+    def test_non_string_args_rendered_as_json(self):
+        out = _render((EventType.TOOL_CALL, ToolCallData(tool="t", args={"n": 3})))
+        assert "n=3" in out
+
+    def test_tool_result_indented(self):
+        out = _render((EventType.TOOL_RESULT, ToolResultData(tool="shell", content="a\nb")))
+        assert out == "  a\n  b\n"
+
+    def test_tool_result_truncated(self):
+        out = _render(
+            (EventType.TOOL_RESULT, ToolResultData(tool="shell", content="a" * 30)),
+            max_result_len=10,
+        )
+        assert out == "  " + "a" * 10 + "...\n"
+
+
+class TestTodoRendering:
+    def _todos(self):
+        return [
+            TodoItemData(content="Set up project", status="completed"),
+            TodoItemData(content="Implement handlers", status="in_progress"),
+            TodoItemData(content="Add tests", status="pending"),
+        ]
+
+    def test_renders_box_with_items(self):
+        out = _render((EventType.TODO_UPDATE, TodoUpdateData(todos=self._todos())))
+        assert "┌─ Todo" in out
+        assert "Set up project" in out
+        assert "Implement handlers" in out
+        assert "Add tests" in out
+
+    def test_status_indicators(self):
+        out = _render((EventType.TODO_UPDATE, TodoUpdateData(todos=self._todos())))
+        assert "✓" in out  # completed
+        assert "▶" in out  # in_progress
+        assert "○" in out  # pending
+
+    def test_unknown_status_degrades(self):
+        todos = [TodoItemData(content="odd", status="unknown-state")]
+        out = _render((EventType.TODO_UPDATE, TodoUpdateData(todos=todos)))
+        assert "? odd" in out
+
+    def test_plain_mode_has_no_ansi_colors(self):
+        out = _render((EventType.TODO_UPDATE, TodoUpdateData(todos=self._todos())), color=False)
+        assert "\033[3" not in out  # no color codes
+        assert "✓" in out
+
+
+class TestTodoDisplay:
+    def test_clears_previous_lines(self):
+        buf = StringIO()
+        td = TodoDisplay(file=buf)
+        td.update([TodoItemData(content="task one", status="pending")])
+        buf.truncate(0)
+        buf.seek(0)
+        td.update(
+            [
+                TodoItemData(content="task one", status="completed"),
+                TodoItemData(content="task two", status="pending"),
+            ]
+        )
+        second_output = buf.getvalue()
+        # Should contain ANSI cursor-up escape to overwrite previous block
+        assert "\033[" in second_output
+        assert "A" in second_output
+
+    def test_empty_list_prints_nothing(self):
+        buf = StringIO()
+        TodoDisplay(file=buf).update([])
+        assert buf.getvalue() == ""
+
+
+class TestIgnoredEvents:
+    def test_usage_update_produces_no_output(self):
+        out = _render((EventType.USAGE_UPDATE, UsageUpdateData(input_tokens=5)))
+        assert out == ""
+
+    def test_event_without_data_produces_no_output(self):
+        out = StringIO()
+        renderer = HeadlessRenderer(out=out)
+        renderer.handle(make_event(EventType.RUN_STARTED))
+        assert out.getvalue() == ""

--- a/tests/render/test_sink.py
+++ b/tests/render/test_sink.py
@@ -1,0 +1,122 @@
+"""Tests for the process-global OutputSink emission point."""
+
+from pathlib import Path
+
+from vibesys.render.sink import OutputSink
+from vibesys.server.events import (
+    AgentOutputChunkData,
+    EventType,
+    RunEvent,
+    TodoItemData,
+    TodoUpdateData,
+    ToolCallData,
+    ToolResultData,
+    UsageUpdateData,
+)
+from vibesys.server.registry import REGISTRY
+from vibesys.server.supervisor import RunSupervisor
+
+
+def _collect(sink: OutputSink) -> tuple[list[RunEvent], object]:
+    seen: list[RunEvent] = []
+    unsubscribe = sink.subscribe(seen.append)
+    return seen, unsubscribe
+
+
+class TestSubscription:
+    def test_subscriber_receives_events(self):
+        sink = OutputSink()
+        seen, _ = _collect(sink)
+        sink.agent_output("hello", channel="assistant")
+        assert len(seen) == 1
+        assert seen[0].type == EventType.AGENT_OUTPUT_CHUNK
+        data = seen[0].data
+        assert isinstance(data, AgentOutputChunkData)
+        assert data.content == "hello"
+        assert data.channel == "assistant"
+
+    def test_unsubscribe_stops_delivery(self):
+        sink = OutputSink()
+        seen, unsubscribe = _collect(sink)
+        sink.agent_output("one")
+        unsubscribe()
+        sink.agent_output("two")
+        assert [e.data.content for e in seen if isinstance(e.data, AgentOutputChunkData)] == ["one"]
+
+    def test_empty_content_is_not_emitted(self):
+        sink = OutputSink()
+        seen, _ = _collect(sink)
+        sink.agent_output("")
+        sink.todo_update([])
+        assert seen == []
+
+
+class TestTypedEmitters:
+    def test_tool_call_event(self):
+        sink = OutputSink()
+        seen, _ = _collect(sink)
+        sink.tool_call("shell", {"cmd": "ls"})
+        assert seen[0].type == EventType.TOOL_CALL
+        data = seen[0].data
+        assert isinstance(data, ToolCallData)
+        assert data.tool == "shell"
+        assert data.args == {"cmd": "ls"}
+
+    def test_tool_call_args_coerced_to_json_safe(self):
+        sink = OutputSink()
+        seen, _ = _collect(sink)
+        sink.tool_call("write", {"path": Path("/tmp/x")})
+        data = seen[0].data
+        assert isinstance(data, ToolCallData)
+        # Non-JSON values are repr()'d so the event always serializes.
+        assert isinstance(data.args["path"], str)
+        seen[0].model_dump_json()
+
+    def test_tool_result_event(self):
+        sink = OutputSink()
+        seen, _ = _collect(sink)
+        sink.tool_result("shell", "output text", is_error=True)
+        data = seen[0].data
+        assert isinstance(data, ToolResultData)
+        assert data.tool == "shell"
+        assert data.content == "output text"
+        assert data.is_error is True
+
+    def test_todo_update_event(self):
+        sink = OutputSink()
+        seen, _ = _collect(sink)
+        sink.todo_update([TodoItemData(content="a", status="pending")])
+        data = seen[0].data
+        assert isinstance(data, TodoUpdateData)
+        assert data.todos[0].content == "a"
+
+    def test_usage_update_event(self):
+        sink = OutputSink()
+        seen, _ = _collect(sink)
+        sink.usage_update(12_345, context_window=200_000, model="claude-sonnet-4-6")
+        data = seen[0].data
+        assert isinstance(data, UsageUpdateData)
+        assert data.input_tokens == 12_345
+        assert data.context_window == 200_000
+        assert data.model == "claude-sonnet-4-6"
+
+
+class TestSupervisorForwarding:
+    def test_events_forwarded_to_active_supervisor(self, tmp_path):
+        supervisor = RunSupervisor()
+        supervisor.attach(tmp_path / "logs")
+        REGISTRY.activate(supervisor)
+        try:
+            sink = OutputSink()
+            sink.agent_output("streamed", channel="assistant")
+            sink.tool_call("shell", {"cmd": "ls"})
+        finally:
+            REGISTRY.deactivate(supervisor)
+        events = supervisor.read_events()
+        types = [e.type for e in events]
+        assert EventType.AGENT_OUTPUT_CHUNK in types
+        assert EventType.TOOL_CALL in types
+
+    def test_no_supervisor_no_error(self):
+        sink = OutputSink()
+        sink.agent_output("standalone")  # must not raise without a supervisor

--- a/tests/server/test_events.py
+++ b/tests/server/test_events.py
@@ -1,0 +1,106 @@
+"""Serialization tests for the run-event wire contract."""
+
+import pytest
+
+from vibesys.server.events import (
+    AgentOutputChunkData,
+    AgentStatusData,
+    EventType,
+    RunEvent,
+    TodoItemData,
+    TodoUpdateData,
+    ToolCallData,
+    ToolResultData,
+    UsageUpdateData,
+    make_event,
+)
+
+
+def _round_trip(event: RunEvent) -> RunEvent:
+    return RunEvent.model_validate_json(event.model_dump_json())
+
+
+class TestNewEventDataRoundTrip:
+    def test_tool_call(self):
+        status = AgentStatusData(
+            progress="Round 1/2",
+            agent_label="Implementer",
+            elapsed_seconds=1.5,
+            input_tokens=1000,
+            context_window=200_000,
+        )
+        event = make_event(
+            EventType.TOOL_CALL,
+            data=ToolCallData(tool="shell", args={"cmd": "ls", "count": 3}, status=status),
+        )
+        restored = _round_trip(event)
+        assert isinstance(restored.data, ToolCallData)
+        assert restored.data.tool == "shell"
+        assert restored.data.args == {"cmd": "ls", "count": 3}
+        assert restored.data.status == status
+
+    def test_tool_result(self):
+        event = make_event(
+            EventType.TOOL_RESULT,
+            data=ToolResultData(tool="shell", content="out", is_error=True),
+        )
+        restored = _round_trip(event)
+        assert isinstance(restored.data, ToolResultData)
+        assert restored.data.is_error is True
+
+    def test_todo_update(self):
+        event = make_event(
+            EventType.TODO_UPDATE,
+            data=TodoUpdateData(todos=[TodoItemData(content="a", status="pending")]),
+        )
+        restored = _round_trip(event)
+        assert isinstance(restored.data, TodoUpdateData)
+        assert restored.data.todos == [TodoItemData(content="a", status="pending")]
+
+    def test_usage_update(self):
+        event = make_event(
+            EventType.USAGE_UPDATE,
+            data=UsageUpdateData(input_tokens=5_000, context_window=1_000_000, model="m"),
+        )
+        restored = _round_trip(event)
+        assert isinstance(restored.data, UsageUpdateData)
+        assert restored.data.input_tokens == 5_000
+
+    def test_agent_output_chunk_status_is_optional_and_round_trips(self):
+        bare = make_event(
+            EventType.AGENT_OUTPUT_CHUNK,
+            data=AgentOutputChunkData(channel="assistant", content="hi"),
+        )
+        restored = _round_trip(bare)
+        assert isinstance(restored.data, AgentOutputChunkData)
+        assert restored.data.status is None
+
+        status = AgentStatusData(agent_label="Judge", elapsed_seconds=0.5, input_tokens=10)
+        rich = make_event(
+            EventType.AGENT_OUTPUT_CHUNK,
+            data=AgentOutputChunkData(channel="assistant", content="hi", status=status),
+        )
+        restored = _round_trip(rich)
+        assert isinstance(restored.data, AgentOutputChunkData)
+        assert restored.data.status == status
+
+
+class TestBackwardCompatibility:
+    def test_chunk_without_status_field_still_parses(self):
+        """Events recorded by older backends omit the new optional fields."""
+        raw = (
+            '{"protocol_version": 1, "sequence": 3, "run_id": "r", '
+            '"timestamp": "2026-01-01T00:00:00Z", "type": "agent_output_chunk", '
+            '"data": {"kind": "agent_output_chunk", "channel": "tool", "content": "x"}}'
+        )
+        event = RunEvent.model_validate_json(raw)
+        assert isinstance(event.data, AgentOutputChunkData)
+        assert event.data.status is None
+
+    def test_unknown_data_kind_rejected(self):
+        raw = (
+            '{"protocol_version": 1, "timestamp": "2026-01-01T00:00:00Z", '
+            '"type": "output", "data": {"kind": "not_a_kind"}}'
+        )
+        with pytest.raises(ValueError):
+            RunEvent.model_validate_json(raw)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -42,12 +42,10 @@ def test_setup_exp_dir_uses_unique_names_for_concurrent_default_runs(tmp_path):
     assert (second / ".git").is_dir()
 
 
-def test_interactive_log_switch_preserves_supervision_stderr(tmp_path):
+def test_log_switch_retargets_stderr_tee_and_restores_on_close(tmp_path):
     ctx = object.__new__(_RunContext)
     original_stderr = sys.stderr
-    # Supervised (TUI) runs never redirect stderr; switching log files must
-    # keep it that way.
-    ctx.logger = RunLogger(tmp_path, redirect_stderr=False)
+    ctx.logger = RunLogger(tmp_path)
     ctx._paths = RunPaths(
         exp_dir=tmp_path,
         log_dir=tmp_path,
@@ -58,10 +56,16 @@ def test_interactive_log_switch_preserves_supervision_stderr(tmp_path):
 
     ctx.switch_log_file("round001")
 
-    assert sys.stderr is original_stderr
+    # The unconditional tee mirrors stderr into the *current* log file,
+    # stripped of ANSI escapes, while writes still reach the real stderr.
+    print("\033[31mcolored diagnostic\033[0m", file=sys.stderr)
     assert ctx.run_log_path.name.endswith("-round001.log")
+
+    ctx.logger.close()
+    assert sys.stderr is original_stderr
+    assert "colored diagnostic" in ctx.run_log_path.read_text()
+    assert "\033[31m" not in ctx.run_log_path.read_text()
     original_log.close()
-    ctx.run_log_file.close()
 
 
 def test_input_copy_respects_source_gitignore(tmp_path):

--- a/tests/test_todo_display.py
+++ b/tests/test_todo_display.py
@@ -1,84 +1,13 @@
-"""Tests for TodoDisplay rendering and todo extraction in run_agent/run_judge_agent."""
+"""Tests for todo extraction/emission in run_agent/run_judge_agent.
 
-from io import StringIO
+Box rendering itself is covered by ``tests/render/test_headless.py``; here we
+verify the runners publish structured ``TODO_UPDATE`` events from stream
+updates.
+"""
+
 from unittest.mock import MagicMock, patch
 
-from vibesys.agents.callbacks import TodoDisplay
-
-# --- TodoDisplay rendering ---
-
-
-def _make_todo(content: str, status: str) -> dict:
-    return {"content": content, "status": status}
-
-
-def test_todo_display_renders_box():
-    """TodoDisplay.update() prints a bordered box with todo items."""
-    buf = StringIO()
-    td = TodoDisplay(file=buf)
-    todos = [
-        _make_todo("Set up project", "completed"),
-        _make_todo("Implement handlers", "in_progress"),
-        _make_todo("Add tests", "pending"),
-    ]
-    td.update(todos)
-    output = buf.getvalue()
-    assert "Set up project" in output
-    assert "Implement handlers" in output
-    assert "Add tests" in output
-
-
-def test_todo_display_status_indicators():
-    """Each status maps to the correct indicator symbol."""
-    buf = StringIO()
-    td = TodoDisplay(file=buf)
-    todos = [
-        _make_todo("done task", "completed"),
-        _make_todo("active task", "in_progress"),
-        _make_todo("waiting task", "pending"),
-    ]
-    td.update(todos)
-    output = buf.getvalue()
-    assert "✓" in output  # completed
-    assert "▶" in output  # in_progress
-    assert "○" in output  # pending
-
-
-def test_todo_display_clears_previous_lines():
-    """On second update, cursor-up + clear sequences should be emitted."""
-    buf = StringIO()
-    td = TodoDisplay(file=buf)
-    todos1 = [_make_todo("task one", "pending")]
-    todos2 = [_make_todo("task one", "completed"), _make_todo("task two", "pending")]
-
-    td.update(todos1)
-    buf.truncate(0)
-    buf.seek(0)
-
-    td.update(todos2)
-    second_output = buf.getvalue()
-    # Should contain ANSI cursor-up escape to overwrite previous block
-    assert "\033[" in second_output  # contains escape sequences
-    assert "A" in second_output  # cursor up uses \033[<n>A
-
-
-def test_todo_display_empty_list():
-    """Empty todo list should not crash, produces no box."""
-    buf = StringIO()
-    td = TodoDisplay(file=buf)
-    td.update([])
-    output = buf.getvalue()
-    # With empty todos, nothing meaningful should be printed
-    assert output == ""
-
-
-def test_todo_display_with_dict_objects():
-    """Todos as plain dicts (as they arrive from streaming) should work."""
-    buf = StringIO()
-    td = TodoDisplay(file=buf)
-    td.update([{"content": "hello", "status": "completed"}])
-    assert "hello" in buf.getvalue()
-
+from vibesys.server.events import TodoUpdateData
 
 # --- Thread ID for state persistence ---
 
@@ -94,8 +23,7 @@ def test_run_agent_passes_thread_id():
         ]
     )
 
-    with patch("vibesys.agent_runner.TodoDisplay"):
-        run_agent(agent, "do stuff")
+    run_agent(agent, "do stuff")
 
     config = agent.stream.call_args[1].get("config") or agent.stream.call_args[0][1]
     assert "configurable" in config
@@ -123,8 +51,7 @@ def test_run_judge_agent_passes_thread_id():
         ]
     )
 
-    with patch("vibesys.agent_runner.TodoDisplay"):
-        run_judge_agent(agent, "review")
+    run_judge_agent(agent, "review")
 
     config = agent.stream.call_args[1].get("config") or agent.stream.call_args[0][1]
     assert "configurable" in config
@@ -134,11 +61,27 @@ def test_run_judge_agent_passes_thread_id():
 # --- Todo extraction in run_agent ---
 
 
-def test_run_agent_extracts_todos_from_tools_node():
+def _capture_todo_updates():
+    """Patch the runner's todo publisher, recording each emitted snapshot."""
+    updates: list[TodoUpdateData] = []
+
+    def record(todos):
+        from vibesys.agent_runner import TodoItemData
+
+        updates.append(
+            TodoUpdateData(
+                todos=[
+                    TodoItemData(content=str(t["content"]), status=str(t["status"])) for t in todos
+                ]
+            )
+        )
+
+    return updates, patch("vibesys.agent_runner.publish_todos", side_effect=record)
+
+
+def test_run_agent_publishes_todos_from_tools_node():
     """run_agent picks up todos from the tools node (where write_todos Command lands)."""
     from vibesys.agent_runner import run_agent
-
-    todos_seen = []
 
     agent = MagicMock()
     agent.stream.return_value = iter(
@@ -167,21 +110,18 @@ def test_run_agent_extracts_todos_from_tools_node():
         ]
     )
 
-    with patch("vibesys.agent_runner.TodoDisplay") as MockTD:
-        instance = MockTD.return_value
-        instance.update.side_effect = lambda t: todos_seen.append(t)
+    updates, patcher = _capture_todo_updates()
+    with patcher:
         run_agent(agent, "do stuff")
 
-    assert len(todos_seen) == 2
-    assert todos_seen[0][0]["content"] == "Setup"
-    assert len(todos_seen[1]) == 2
+    assert len(updates) == 2
+    assert updates[0].todos[0].content == "Setup"
+    assert len(updates[1].todos) == 2
 
 
-def test_run_agent_extracts_todos_from_any_node():
+def test_run_agent_publishes_todos_from_any_node():
     """run_agent finds todos regardless of which node key they appear under."""
     from vibesys.agent_runner import run_agent
-
-    todos_seen = []
 
     agent = MagicMock()
     agent.stream.return_value = iter(
@@ -194,21 +134,18 @@ def test_run_agent_extracts_todos_from_any_node():
         ]
     )
 
-    with patch("vibesys.agent_runner.TodoDisplay") as MockTD:
-        instance = MockTD.return_value
-        instance.update.side_effect = lambda t: todos_seen.append(t)
+    updates, patcher = _capture_todo_updates()
+    with patcher:
         run_agent(agent, "do stuff")
 
-    assert len(todos_seen) == 1
-    assert todos_seen[0][0]["content"] == "Task A"
+    assert len(updates) == 1
+    assert updates[0].todos[0].content == "Task A"
 
 
-def test_run_judge_agent_extracts_todos():
+def test_run_judge_agent_publishes_todos():
     """run_judge_agent picks up todos from the tools node."""
     from vibesys.agent_runner import run_judge_agent
     from vibesys.schemas import JudgeResponse, Verdict
-
-    todos_seen = []
 
     agent = MagicMock()
     agent.stream.return_value = iter(
@@ -232,10 +169,30 @@ def test_run_judge_agent_extracts_todos():
         ]
     )
 
-    with patch("vibesys.agent_runner.TodoDisplay") as MockTD:
-        instance = MockTD.return_value
-        instance.update.side_effect = lambda t: todos_seen.append(t)
+    updates, patcher = _capture_todo_updates()
+    with patcher:
         run_judge_agent(agent, "review")
 
-    assert len(todos_seen) == 1
-    assert todos_seen[0][0]["content"] == "Review code"
+    assert len(updates) == 1
+    assert updates[0].todos[0].content == "Review code"
+
+
+def test_publish_todos_emits_structured_event():
+    """publish_todos converts raw stream dicts into a typed TODO_UPDATE event."""
+    from vibesys.agent_runner import publish_todos
+    from vibesys.render import output_sink
+    from vibesys.server.events import EventType, RunEvent
+
+    seen: list[RunEvent] = []
+    unsubscribe = output_sink().subscribe(seen.append)
+    try:
+        publish_todos([{"content": "hello", "status": "completed"}])
+    finally:
+        unsubscribe()
+
+    assert len(seen) == 1
+    event = seen[0]
+    assert event.type == EventType.TODO_UPDATE
+    assert isinstance(event.data, TodoUpdateData)
+    assert event.data.todos[0].content == "hello"
+    assert event.data.todos[0].status == "completed"


### PR DESCRIPTION
## Problem

The output path is split in two: `AgentLogger` renders ANSI-formatted text straight to the terminal and the run log, while the *same* callbacks separately publish typed events to the TUI — but only when `active_supervisor()` is checked at each of a half-dozen emission sites. Under the TUI, the print path still executes and is silently discarded (the `context.py` stderr-tee carve-out exists solely to keep that suppressed printing from corrupting the display), headless runs never emit events at all, and information the print path carries (todo lists, tool-call summaries, usage) has no representation in the `server/events.py` contract — the TS client resorts to text-sniffing (`startsWith('→ ')`) on tool-channel chunks to detect tool turns. Every new surface or event type has to be wired twice, and logs can pick up ANSI escapes through the stderr tee.

## Solution

The backend now emits only (a) structured events and (b) plain durable log text. All human rendering — colors, layout, todo chips, tool-call formatting, display truncation — lives in renderers subscribed to the event stream, with `server/events.py` as the single backend↔frontend contract. Backend and TS client move to the typed contract in lockstep in this PR, so the transitional dual-publish of tool traffic never ships.

- **Unconditional emission through one sink.** New `vibesys.render.sink.OutputSink` (process-global) is the only place allowed to consult `active_supervisor()`: it forwards every event to the supervisor (TUI/audit store) when one is attached, and to in-process subscribers. The scattered `active_supervisor() is not None` conditionals in `callbacks.py`, `agent_runner.py`, and `stub_runner.py` are gone.
- **Additive event schema.** New `EventType` members `tool_call`, `tool_result`, `todo_update`, `usage_update` with typed data models, plus a nested `AgentStatusData` (progress / label / elapsed / tokens / context window) carried on chunks and tool calls so renderers can format the status prefix themselves. Existing events are untouched; `AgentOutputChunkData` gains one optional field. TS bindings regenerated.
- **TS TUI consumes typed events natively.** `session-model.ts` builds tool turns structurally from `tool_call`/`tool_result` (call line formatted from `tool` + `args`, results merged by `invocation_id` — the text-sniffing predicate is gone for typed streams), stores `todo_update` snapshots as state data rather than transcript text, and renders `usage_update` as a live token/context meter in the header status line. **Legacy fallback:** event files recorded by older backends contain only tool-channel text chunks; those still render exactly as before. The first typed tool event flips a sticky `typedToolEvents` flag that suppresses tool-channel chunks so mixed recordings never render a turn twice — prefer-typed, fall-back-legacy.
- **Dual-publish deleted.** With the client consuming typed events, `AgentLogger` no longer mirrors tool calls/results as `tool`-channel chunks; live streams carry tool traffic exclusively as typed events (verified at the wire: a supervised `AgentLogger` session records `tool_call`/`tool_result`/`usage_update` and zero tool-channel chunks).
- **`HeadlessRenderer`** (`vibesys/render/headless.py`) subscribes to the same stream and renders what the print path rendered: streamed assistant tokens with the `[round | label | elapsed | tokens/max]` prefix, thinking lines, prompt/diagnostic blocks with see-log truncation, tool-call/result lines, and the ANSI todo box (moved `TodoDisplay`). Selection happens once, in `create_run_context`: renderer subscribed only when no supervisor is attached, unsubscribed on context teardown.
- **Plain logs, unconditional stderr tee.** `AgentLogger` keeps writing full plain text to the run log (the flush-per-write behavior and its codex-buffering rationale are preserved in `_log_write`). With nothing printing to the terminal except the renderer, the TUI stderr-tee carve-out is deleted: `RunLogger` always tees stderr into the log (writes still pass through to real stderr) and strips ANSI escapes from the log copy.
- **Deleted:** suppressed-but-executed printing on the TUI path, `RunLogger(redirect_stderr=...)`, per-call-site supervisor checks, the tool-channel dual-publish, `AgentLogger`'s stdout writes and `max_result_len`, and the display-only `max_len`/`max_text_len` parameters on the log helpers and runner functions (display truncation is renderer policy; logs were always full).
- **Stretch scope:** live token/context meter in the TUI header — done. A dedicated in-place todo panel is **not** included (todos are already held in `SessionState.todos`, so the panel is a small view-only follow-up; skipped here to avoid unverifiable layout churn in the opentui panes).

### Architecture

```mermaid
flowchart LR
    subgraph backend [Backend emits]
        AL[AgentLogger\ncallbacks + cli hooks] --> SINK
        AR[agent_runner log_* helpers\npublish_todos] --> SINK
        SR[StubAgentRunner] --> SINK
        AL -- plain text, flush-per-write --> LOG[run-*.log]
        AR -- plain text --> LOG
        TEE[stderr tee, ANSI-stripped] --> LOG
    end
    SINK[render.sink.OutputSink\nsingle supervisor check] -- supervisor attached --> SUP[RunSupervisor\nevent store] --> TUI[TS session-model\ntyped tool turns, todo state,\nusage meter; legacy-chunk fallback]
    SINK -- headless subscriber --> HR[HeadlessRenderer\nANSI, prefix, todo box,\ntruncation → terminal]
```

Ownership: `server/events.py` owns the wire contract; `vibesys/render/` owns emission fan-out and terminal presentation; `AgentLogger` is a pure adapter from agent callbacks to events + plain log text; `clients/tui/src/session-model.ts` owns the event→view-state reduction; composition (which renderer is live) is decided once in `create_run_context` / `run_server`.

Behavior deltas worth reviewing: streamed responses now publish a terminating `"\n"` assistant chunk and cli `log_text` chunks carry their trailing newline (previously the newline existed only in the suppressed print path); deepagents thinking blocks render as prefixed analysis lines headless-side (the `[thinking]` banner remains in the log); headless runs now show stub-runner/tool-error diagnostics that were previously TUI-only; the TUI header now shows a token meter once usage events arrive.

## Verification

- Full Python suite, pyright strict, lint, and format all pass; TUI `biome check`, `tsc` check, and vitest suite (44 tests, 5 new for typed-event handling and the legacy fallback) pass.
- Runtime: drove a real headless run end-to-end (`uv run python -m vibesys --outer-loop agent --stub-agent --max-rounds 1`) — rendered terminal output shows round banners and per-phase diagnostics via the renderer, and the produced `run-*.log` files contain zero ANSI escape bytes. Wire-level: a supervised `AgentLogger` session records `tool_call`/`tool_result`/`usage_update` events and no legacy tool-channel chunks. (Driving the interactive opentui frontend itself is not feasible in this headless environment; its event handling is covered by the vitest suite.)
- New unit coverage: `tests/render/` (sink subscribe/forwarding, renderer output for synthetic events, shared formatters), `tests/server/test_events.py` (serialization round-trips for the new event types, old-payload backward compatibility — first direct test coverage for `server/events.py`), and vitest cases for typed tool turns, arg truncation, prefer-typed/fallback-legacy, todo state, and the usage meter.

### Correctness properties

- Wire protocol is backward compatible: additive `EventType` members and data models only; existing event shapes unchanged; old JSONL event files still parse (`status` optional) and still render tool turns in the TUI via the legacy tool-channel chunk path.
- Live streams never render a tool turn twice: the backend emits tool traffic only as typed events, and the client suppresses legacy chunks once typed events are seen (covers mixed recordings).
- Events are emitted identically in headless and TUI modes; presentation mode is chosen exactly once at composition time.
- `run-*.log` content is unchanged in structure and remains fully detailed (untruncated prompts/results up to the existing 2000-char tool-result cap) and is now guaranteed ANSI-free, including the stderr tee copy.
- Log writes still flush per event so `tail -f` sees streamed agent output immediately (comment preserved at the write site).
- Headless terminal output preserves today's information and formatting: status prefix, 80-char tool-arg and 500-char tool-result truncation, 2000-char prompt truncation with the "see log" pointer, todo box with colored status indicators. The TUI tool-turn card formatting is unchanged (same `→ tool(args)` line, same result merge).

### Testing

- `uv run pytest` — 1846 passed, 1 skipped (macOS-only sandbox test)
- `./scripts/check_types.sh` — 0 errors (pyright strict)
- `./scripts/check_lint.sh`, `./scripts/check_format.sh` — pass
- `pnpm check:ts` (biome), `pnpm --dir clients/tui check` (tsc), `pnpm --dir clients/tui test` — pass (44 tests)
- `pnpm --dir clients/tui generate:protocol` — regenerated bindings committed; schema-drift test in `tests/test_tui.py` passes
- Manual: headless stub-agent run (above); `grep -c $'\033' run-*.log` → 0; wire-level supervised-session check showing typed-only tool events

🤖 Generated with [Claude Code](https://claude.com/claude-code)