### PR TITLE
Render agent todo lists in the TUI, fed by all agent backends

### DIFF
--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -21,6 +21,7 @@ import {
   selectRound,
   showDetail,
   showLive,
+  toggleTodos,
 } from './session-model.js';
 
 export interface SessionController {
@@ -34,6 +35,7 @@ export interface SessionController {
   selectNextRound(): void;
   selectPreviousRound(): void;
   selectRound(roundNumber: number): void;
+  toggleTodos(): void;
   subscribe(listener: (state: SessionState) => void): () => void;
 }
 
@@ -104,6 +106,10 @@ export class SocketSessionController implements SessionController {
 
   selectRound(roundNumber: number): void {
     this.#setState(selectRound(this.#state, roundNumber));
+  }
+
+  toggleTodos(): void {
+    this.#setState(toggleTodos(this.#state));
   }
 
   async submit(value: string): Promise<void> {

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -7,8 +7,10 @@ import {
   selectNextRound,
   selectRound,
   statusText,
+  toggleTodos,
   visibleConversation,
   visiblePhases,
+  visibleTodos,
 } from './session-model.js';
 
 describe('session event model', () => {
@@ -245,7 +247,7 @@ describe('session event model', () => {
     expect(state.conversation[0]?.toolCall).toBe('→ Bash(command="ls")\n');
   });
 
-  it('stores todo updates as data instead of transcript text', () => {
+  it('stores todo updates as per-phase data instead of transcript text', () => {
     const state = applyEvent(
       initialSessionState(),
       event(1, 'todo_update', {
@@ -257,12 +259,97 @@ describe('session event model', () => {
       }),
     );
 
-    expect(state.todos).toEqual([
-      {content: 'Set up project', status: 'completed'},
-      {content: 'Add tests', status: 'pending'},
+    expect(state.todoPhases).toEqual([
+      {
+        agentKind: 'judge',
+        roundNumber: 1,
+        items: [
+          {content: 'Set up project', status: 'completed'},
+          {content: 'Add tests', status: 'pending'},
+        ],
+      },
     ]);
     expect(state.conversation).toHaveLength(0);
     expect(state.liveContent).toBe('Waiting for run events…');
+  });
+
+  it('keeps each phase’s todo list separate so agents never clobber each other', () => {
+    let state = initialSessionState();
+    state = applyEvent(state, {
+      sequence: 1,
+      timestamp: '2026-01-01T00:00:00Z',
+      type: 'todo_update',
+      agent_kind: 'implementer',
+      round_label: 'round-1',
+      data: {kind: 'todo_update', todos: [{content: 'Edit files', status: 'in_progress'}]},
+    });
+    state = applyEvent(state, {
+      sequence: 2,
+      timestamp: '2026-01-01T00:01:00Z',
+      type: 'todo_update',
+      agent_kind: 'judge',
+      round_label: 'round-1',
+      data: {kind: 'todo_update', todos: [{content: 'Check behavior', status: 'pending'}]},
+    });
+    state = applyEvent(state, {
+      sequence: 3,
+      timestamp: '2026-01-01T00:02:00Z',
+      type: 'todo_update',
+      agent_kind: 'implementer',
+      round_label: 'round-2',
+      data: {kind: 'todo_update', todos: [{content: 'Fix regression', status: 'pending'}]},
+    });
+
+    // Live view follows the currently active agent (round-2 implementer).
+    expect(visibleTodos(state)).toEqual([{content: 'Fix regression', status: 'pending'}]);
+    // Selecting a past agent shows that phase's final list, not the latest one.
+    const withAgent = {...state, selectedRound: 1, selectedAgentKind: 'implementer'};
+    expect(visibleTodos(withAgent)).toEqual([{content: 'Edit files', status: 'in_progress'}]);
+    // Selecting only a round shows the round's most recently updated list.
+    const withRound = {...state, selectedRound: 1};
+    expect(visibleTodos(withRound)).toEqual([{content: 'Check behavior', status: 'pending'}]);
+  });
+
+  it('hides todos when the active phase has not emitted any', () => {
+    let state = initialSessionState();
+    state = applyEvent(state, {
+      sequence: 1,
+      timestamp: '2026-01-01T00:00:00Z',
+      type: 'todo_update',
+      agent_kind: 'implementer',
+      round_label: 'round-1',
+      data: {kind: 'todo_update', todos: [{content: 'Edit files', status: 'completed'}]},
+    });
+    // The judge phase starts without emitting todos; the implementer's
+    // leftovers must not linger in the live view.
+    state = applyEvent(state, {
+      sequence: 2,
+      timestamp: '2026-01-01T00:01:00Z',
+      type: 'phase_started',
+      agent_kind: 'judge',
+      round_label: 'round-1',
+    });
+
+    expect(visibleTodos(state)).toEqual([]);
+  });
+
+  it('preserves unknown todo statuses for the renderer to degrade', () => {
+    const state = applyEvent(
+      initialSessionState(),
+      event(1, 'todo_update', {
+        kind: 'todo_update',
+        todos: [{content: 'Mystery step', status: 'deferred'}],
+      }),
+    );
+
+    expect(state.todoPhases[0]?.items).toEqual([{content: 'Mystery step', status: 'deferred'}]);
+  });
+
+  it('toggles the todo strip between collapsed and expanded', () => {
+    const state = initialSessionState();
+    expect(state.todosExpanded).toBe(false);
+    expect(toggleTodos(state).todosExpanded).toBe(true);
+    expect(toggleTodos(toggleTodos(state)).todosExpanded).toBe(false);
   });
 
   it('feeds usage updates into the status token meter', () => {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -22,7 +22,8 @@ export interface SessionState {
   conversation: ConversationEntry[];
   overlay: OverlayPanel | null;
   terminal: boolean;
-  todos: TodoItem[];
+  todoPhases: PhaseTodos[];
+  todosExpanded: boolean;
   usage: UsageMeter | null;
   /**
    * Set once a typed tool_call/tool_result event is seen. From then on the
@@ -35,6 +36,17 @@ export interface SessionState {
 export interface TodoItem {
   content: string;
   status: string;
+}
+
+/**
+ * One agent phase's latest todo-list snapshot. Todos are keyed per
+ * (round, agent) so concurrent or successive phases never clobber each
+ * other's lists, mirroring how the conversation filter scopes entries.
+ */
+export interface PhaseTodos {
+  agentKind: string | null;
+  roundNumber: number | null;
+  items: TodoItem[];
 }
 
 export interface UsageMeter {
@@ -87,7 +99,8 @@ export function initialSessionState(): SessionState {
     conversation: [],
     overlay: null,
     terminal: false,
-    todos: [],
+    todoPhases: [],
+    todosExpanded: false,
     usage: null,
     typedToolEvents: false,
   };
@@ -122,10 +135,18 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
     next.typedToolEvents = true;
   }
   if (data?.kind === 'todo_update') {
-    next.todos = (data.todos ?? []).map(todo => ({
+    const items = (data.todos ?? []).map(todo => ({
       content: String(todo.content),
       status: String(todo.status),
     }));
+    const agentKind = event.agent_kind ?? null;
+    const roundNumber = roundNumberFromLabel(event.round_label);
+    next.todoPhases = [
+      ...next.todoPhases.filter(
+        phase => phase.agentKind !== agentKind || phase.roundNumber !== roundNumber,
+      ),
+      {agentKind, roundNumber, items},
+    ].slice(-100);
   }
   if (data?.kind === 'usage_update') {
     next.usage = {
@@ -446,6 +467,43 @@ export function visibleConversation(state: SessionState): ConversationEntry[] {
 
 export function visiblePhases(state: SessionState): AgentPhase[] {
   return visibleRunMapPhases(state.phases, visibleRoundNumber(state));
+}
+
+export function toggleTodos(state: SessionState): SessionState {
+  return {...state, todosExpanded: !state.todosExpanded};
+}
+
+/**
+ * The todo list for the phase the operator is looking at, following the same
+ * scoping rules as the conversation filter. Entries whose events carried no
+ * agent or round stamp (legacy streams) match any scope rather than vanish.
+ */
+export function visibleTodos(state: SessionState): TodoItem[] {
+  const roundNumber = visibleRoundNumber(state);
+  const matchesRound = (phase: PhaseTodos): boolean =>
+    roundNumber === null || phase.roundNumber === roundNumber || phase.roundNumber === null;
+  const latestFirst = [...state.todoPhases].reverse();
+  if (state.selectedAgentKind !== null) {
+    const selected = state.selectedAgentKind;
+    return (
+      latestFirst.find(
+        phase => (phase.agentKind === selected || phase.agentKind === null) && matchesRound(phase),
+      )?.items ?? []
+    );
+  }
+  if (state.selectedRound !== null) {
+    // Browsing a round without an agent selected: show the round's most
+    // recently updated list, i.e. its final todo state.
+    return latestFirst.find(matchesRound)?.items ?? [];
+  }
+  // Live view: follow the currently active agent so a phase that never
+  // emits todos shows nothing instead of the previous phase's leftovers.
+  return (
+    latestFirst.find(
+      phase =>
+        (phase.agentKind === state.agentKind || phase.agentKind === null) && matchesRound(phase),
+    )?.items ?? []
+  );
 }
 
 export function visibleRoundNumber(state: SessionState): number | null {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -221,6 +221,61 @@ describe('OpenTUI presentation', () => {
     expect(filtered).not.toContain('checking behavior');
   });
 
+  it('summarizes the active agent’s todos and expands them with Ctrl+T', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      agentKind: 'implementer',
+      todoPhases: [
+        {
+          agentKind: 'implementer',
+          roundNumber: null,
+          items: [
+            {content: 'Profile the hot loop', status: 'completed'},
+            {content: 'Vectorize the kernel', status: 'in_progress'},
+            {content: 'Re-run the benchmark', status: 'pending'},
+          ],
+        },
+      ],
+      conversation: [{id: 'live', kind: 'assistant', label: 'Agent', content: 'live output'}],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const collapsed = await testRenderer.waitForFrame(value => value.includes('Todo 1/3'));
+    expect(collapsed).toContain('▶ Vectorize the kernel');
+    expect(collapsed).not.toContain('Re-run the benchmark');
+
+    testRenderer.mockInput.pressKey('t', {ctrl: true});
+    const expanded = await testRenderer.waitForFrame(value =>
+      value.includes('Re-run the benchmark'),
+    );
+    expect(expanded).toContain('✓ Profile the hot loop');
+    expect(expanded).toContain('○ Re-run the benchmark');
+  });
+
+  it('hides the todo strip when the visible agent has no todos', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 20});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      agentKind: 'judge',
+      todoPhases: [
+        {
+          agentKind: 'implementer',
+          roundNumber: null,
+          items: [{content: 'Edit files', status: 'completed'}],
+        },
+      ],
+      conversation: [{id: 'live', kind: 'assistant', label: 'Agent', content: 'live output'}],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('live output'));
+    expect(frame).not.toContain('Todo');
+    expect(frame).not.toContain('Edit files');
+  });
+
   it('keeps terminal results visible until the operator exits', async () => {
     const testRenderer = await createTestRenderer({width: 80, height: 16});
     const controller = new FakeController({
@@ -312,6 +367,10 @@ class FakeController implements SessionController {
   }
   selectRound(roundNumber: number): void {
     this.state = {...this.state, selectedRound: roundNumber, selectedAgentKind: null};
+    for (const listener of this.#listeners) listener(this.state);
+  }
+  toggleTodos(): void {
+    this.state = {...this.state, todosExpanded: !this.state.todosExpanded};
     for (const listener of this.#listeners) listener(this.state);
   }
 

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -8,6 +8,7 @@ import {bindKeybindings} from './keybindings.js';
 import {OverlayView} from './overlay.js';
 import {RoundStripView} from './round-strip.js';
 import {createMarkdownStyle} from './styles.js';
+import {TodoStripView} from './todo-strip.js';
 
 export interface OpenTuiApp {
   destroy(): void;
@@ -48,10 +49,11 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     id: 'key-help',
     height: 1,
     fg: '#64748b',
-    content: '[/]: round · Tab: agent · PgUp/PgDn · Ctrl+P: prompt · Ctrl+L: live',
+    content: '[/]: round · Tab: agent · PgUp/PgDn · Ctrl+T: todos · Ctrl+P: prompt · Ctrl+L: live',
   });
   const markdownStyle = createMarkdownStyle();
   const roundStrip = new RoundStripView(renderer, controller);
+  const todoStrip = new TodoStripView(renderer, controller);
   const agentMap = new AgentMapView(renderer);
   const overlay = new OverlayView(renderer);
   const conversation = new ConversationView(renderer, controller, markdownStyle);
@@ -63,6 +65,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   root.add(header);
   root.add(roundStrip.output);
   root.add(main);
+  root.add(todoStrip.output);
   root.add(help);
   root.add(input.box);
   root.add(overlay.output);
@@ -74,6 +77,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     const selection = state.selectedAgentKind ? ` · selected ${state.selectedAgentKind}` : '';
     header.content = `VibeSys · ${statusText(state)}${selection}${returnHint}`;
     roundStrip.render(state);
+    todoStrip.render(state);
     agentMap.render(state);
     conversation.render(state);
     overlay.render(state);
@@ -84,6 +88,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     selectPreviousAgent: () => controller.selectPreviousAgent(),
     selectNextRound: () => controller.selectNextRound(),
     selectPreviousRound: () => controller.selectPreviousRound(),
+    toggleTodos: () => controller.toggleTodos(),
   });
   const unsubscribe = controller.subscribe(render);
 

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -7,6 +7,7 @@ export interface KeybindingActions {
   selectPreviousAgent(): void;
   selectNextRound(): void;
   selectPreviousRound(): void;
+  toggleTodos(): void;
 }
 
 export function bindKeybindings(
@@ -29,6 +30,11 @@ export function bindKeybindings(
     }
     if (key.ctrl && key.name === 'p') {
       actions.toggleLatestPrompt();
+      key.preventDefault();
+      return;
+    }
+    if (key.ctrl && key.name === 't') {
+      actions.toggleTodos();
       key.preventDefault();
       return;
     }

--- a/clients/tui/src/ui/todo-strip.test.ts
+++ b/clients/tui/src/ui/todo-strip.test.ts
@@ -1,0 +1,41 @@
+import {describe, expect, it} from 'vitest';
+import {todoItemLine, todoSummaryLine} from './todo-strip.js';
+
+describe('todo strip formatting', () => {
+  it('focuses the summary on the in-progress item', () => {
+    const line = todoSummaryLine(
+      [
+        {content: 'Set up project', status: 'completed'},
+        {content: 'Vectorize the kernel', status: 'in_progress'},
+        {content: 'Add tests', status: 'pending'},
+      ],
+      80,
+    );
+    expect(line).toBe('▸ Todo 1/3 · ▶ Vectorize the kernel');
+  });
+
+  it('falls back to the next pending item and then to all done', () => {
+    expect(
+      todoSummaryLine(
+        [
+          {content: 'Set up project', status: 'completed'},
+          {content: 'Add tests', status: 'pending'},
+        ],
+        80,
+      ),
+    ).toBe('▸ Todo 1/2 · ○ Add tests');
+    expect(todoSummaryLine([{content: 'Set up project', status: 'completed'}], 80)).toBe(
+      '▸ Todo 1/1 · all done',
+    );
+  });
+
+  it('degrades unknown statuses to a neutral marker instead of failing', () => {
+    expect(todoItemLine({content: 'Mystery step', status: 'deferred'}, 80)).toBe('? Mystery step');
+  });
+
+  it('truncates long lines to the available width with an ellipsis', () => {
+    const line = todoItemLine({content: 'x'.repeat(50), status: 'pending'}, 20);
+    expect(line).toHaveLength(20);
+    expect(line.endsWith('…')).toBe(true);
+  });
+});

--- a/clients/tui/src/ui/todo-strip.ts
+++ b/clients/tui/src/ui/todo-strip.ts
@@ -1,0 +1,153 @@
+import {BoxRenderable, type CliRenderer, TextRenderable} from '@opentui/core';
+import type {SessionController} from '../session-controller.js';
+import type {SessionState, TodoItem} from '../session-model.js';
+import {visibleTodos} from '../session-model.js';
+
+const STATUS_MARKER: Record<string, string> = {
+  pending: '○',
+  in_progress: '▶',
+  completed: '✓',
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  pending: '#64748b',
+  in_progress: '#facc15',
+  completed: '#4ade80',
+};
+
+// The todo status field is an open string on the wire; unknown statuses
+// must degrade to a neutral marker, never break rendering.
+const UNKNOWN_MARKER = '?';
+const UNKNOWN_COLOR = '#94a3b8';
+
+const MAX_EXPANDED_ITEMS = 10;
+
+export function todoMarker(status: string): string {
+  return STATUS_MARKER[status] ?? UNKNOWN_MARKER;
+}
+
+export function todoColor(status: string): string {
+  return STATUS_COLOR[status] ?? UNKNOWN_COLOR;
+}
+
+export function todoTitle(todos: TodoItem[]): string {
+  const completed = todos.filter(todo => todo.status === 'completed').length;
+  return `Todo ${completed}/${todos.length}`;
+}
+
+export function todoSummaryLine(todos: TodoItem[], maxWidth: number): string {
+  const current =
+    todos.find(todo => todo.status === 'in_progress') ??
+    todos.find(todo => todo.status !== 'completed');
+  const focus =
+    current === undefined ? 'all done' : `${todoMarker(current.status)} ${current.content}`;
+  return truncate(`▸ ${todoTitle(todos)} · ${focus}`, maxWidth);
+}
+
+export function todoItemLine(todo: TodoItem, maxWidth: number): string {
+  return truncate(`${todoMarker(todo.status)} ${todo.content}`, maxWidth);
+}
+
+function truncate(line: string, maxWidth: number): string {
+  const width = Math.max(8, maxWidth);
+  return line.length <= width ? line : `${line.slice(0, width - 1)}…`;
+}
+
+/**
+ * Full-width strip between the conversation viewport and the input panel.
+ * Collapsed it is a one-line summary of the visible phase's todo list;
+ * Ctrl+T (or a click) expands it into the full list. When the visible phase
+ * has no todos the strip occupies no space at all.
+ */
+export class TodoStripView {
+  readonly output: BoxRenderable;
+  #renderedTodos: TodoItem[] | null = null;
+  #renderedExpanded = false;
+
+  constructor(
+    private readonly renderer: CliRenderer,
+    controller: SessionController,
+  ) {
+    this.output = new BoxRenderable(renderer, {
+      id: 'todo-strip',
+      width: '100%',
+      height: 1,
+      flexDirection: 'column',
+      paddingLeft: 1,
+      paddingRight: 1,
+      borderStyle: 'rounded',
+      borderColor: '#334155',
+      border: false,
+      visible: false,
+      onMouseUp: () => controller.toggleTodos(),
+    });
+  }
+
+  render(state: SessionState): void {
+    const todos = visibleTodos(state);
+    if (todos.length === 0) {
+      this.output.visible = false;
+      this.#renderedTodos = null;
+      return;
+    }
+    this.output.visible = true;
+    if (todos === this.#renderedTodos && state.todosExpanded === this.#renderedExpanded) return;
+    this.#renderedTodos = todos;
+    this.#renderedExpanded = state.todosExpanded;
+    this.#clear();
+    if (state.todosExpanded) this.#renderExpanded(todos);
+    else this.#renderCollapsed(todos);
+  }
+
+  #renderCollapsed(todos: TodoItem[]): void {
+    this.output.border = false;
+    this.output.height = 1;
+    this.output.add(
+      new TextRenderable(this.renderer, {
+        content: todoSummaryLine(todos, this.#contentWidth()),
+        fg: '#cbd5e1',
+        height: 1,
+        width: '100%',
+      }),
+    );
+  }
+
+  #renderExpanded(todos: TodoItem[]): void {
+    const shown = todos.slice(0, MAX_EXPANDED_ITEMS);
+    const hidden = todos.length - shown.length;
+    this.output.border = true;
+    this.output.title = ` ${todoTitle(todos)} `;
+    this.output.height = shown.length + (hidden > 0 ? 1 : 0) + 2;
+    for (const todo of shown) {
+      this.output.add(
+        new TextRenderable(this.renderer, {
+          content: todoItemLine(todo, this.#contentWidth()),
+          fg: todoColor(todo.status),
+          height: 1,
+          width: '100%',
+        }),
+      );
+    }
+    if (hidden > 0) {
+      this.output.add(
+        new TextRenderable(this.renderer, {
+          content: `… +${hidden} more`,
+          fg: '#64748b',
+          height: 1,
+          width: '100%',
+        }),
+      );
+    }
+  }
+
+  #contentWidth(): number {
+    return this.renderer.terminalWidth - 6;
+  }
+
+  #clear(): void {
+    for (const child of [...this.output.getChildren()]) {
+      this.output.remove(child);
+      child.destroyRecursively();
+    }
+  }
+}

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -8,6 +8,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages import BaseMessage
 
 from vibesys.agents.progress import AgentProgress
+from vibesys.agents.todos import todos_from_tool_call
 from vibesys.render.format import format_status_prefix
 from vibesys.render.sink import output_sink
 from vibesys.server.events import AgentOutputChannel, AgentStatusData
@@ -269,6 +270,9 @@ class AgentLogger(BaseCallbackHandler):
 
     def _emit_tool_call(self, name: str, args: dict[str, Any]):
         output_sink().tool_call(name, args, status=self._status())
+        todos = todos_from_tool_call(name, args)
+        if todos is not None:
+            output_sink().todo_update(todos)
         is_code_tool = name in self._CODE_CHANGE_TOOLS
 
         # Log file: skip code content args for file-writing tools

--- a/src/vibesys/agents/todos.py
+++ b/src/vibesys/agents/todos.py
@@ -1,0 +1,110 @@
+"""Translate provider-specific plan/todo tool calls into todo snapshots.
+
+Each CLI provider surfaces the agent's working plan through its own tool
+convention: Claude Code calls ``TodoWrite``, opencode calls ``todowrite``,
+Gemini calls ``write_todos``, and Codex reports either an ``update_plan``
+tool call or a ``todo_list`` stream item. This module owns the mapping from
+those provider vocabularies to the neutral :class:`TodoItemData` contract so
+everything downstream of the output sink (supervisor, renderers, TUI) stays
+agent-agnostic.
+
+The deepagents backend additionally publishes todos from its graph state
+channel in :mod:`vibesys.agent_runner`; its ``write_todos`` tool call also
+matches here, which is harmless because todo updates are full-list snapshots
+and re-publishing the same snapshot is idempotent for every consumer.
+
+Extraction is best-effort by design: payloads originate from agent tool
+calls, so a malformed entry is skipped and an unrecognized payload yields
+"no update" — never an exception into the agent run. Statuses pass through
+as open strings; renderers own the degradation of unknown values (see the
+``TodoItemData.status`` contract in :mod:`vibesys.server.events`).
+"""
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from vibesys.server.events import TodoItemData
+
+_Extractor = Callable[[Mapping[str, Any]], list[TodoItemData] | None]
+
+_COMPLETED = "completed"
+_PENDING = "pending"
+
+
+def todos_from_tool_call(tool: str, args: Mapping[str, Any]) -> list[TodoItemData] | None:
+    """Return the plan snapshot carried by a *tool* invocation.
+
+    Returns ``None`` when *tool* is not a recognized todo/plan tool or the
+    payload does not carry a todo list at all; returns a (possibly empty)
+    snapshot otherwise. Callers publish snapshots and ignore ``None``.
+    """
+    extractor = _EXTRACTORS.get(tool)
+    if extractor is None:
+        return None
+    return extractor(args)
+
+
+def _coerce_item(entry: object, content_keys: tuple[str, ...]) -> TodoItemData | None:
+    """Build one todo item from an untrusted payload entry.
+
+    ``content_keys`` are tried in order because providers name the item text
+    differently (``content``, ``step``, ``text``, …). Entries without usable
+    text are dropped: an unlabeled todo renders as an empty row and carries
+    no information.
+    """
+    if not isinstance(entry, Mapping):
+        return None
+    content = next(
+        (
+            value
+            for key in content_keys
+            if isinstance(value := entry.get(key), str) and value.strip()
+        ),
+        None,
+    )
+    if content is None:
+        return None
+    status = entry.get("status")
+    if isinstance(status, str) and status:
+        return TodoItemData(content=content, status=status)
+    completed = entry.get("completed")
+    if isinstance(completed, bool):
+        return TodoItemData(content=content, status=_COMPLETED if completed else _PENDING)
+    return TodoItemData(content=content, status=_PENDING)
+
+
+def _extract(
+    args: Mapping[str, Any], list_key: str, content_keys: tuple[str, ...]
+) -> list[TodoItemData] | None:
+    raw = args.get(list_key)
+    if not isinstance(raw, list):
+        return None
+    entries: list[Any] = raw
+    items = (_coerce_item(entry, content_keys) for entry in entries)
+    return [item for item in items if item is not None]
+
+
+def _from_todos_arg(args: Mapping[str, Any]) -> list[TodoItemData] | None:
+    """Claude Code ``TodoWrite`` / opencode ``todowrite`` / Gemini and
+    deepagents ``write_todos``: ``{"todos": [{"content", "status"}, …]}``."""
+    return _extract(args, "todos", ("content", "description"))
+
+
+def _from_plan_arg(args: Mapping[str, Any]) -> list[TodoItemData] | None:
+    """Codex ``update_plan`` tool: ``{"plan": [{"step", "status"}, …]}``."""
+    return _extract(args, "plan", ("step",))
+
+
+def _from_items_arg(args: Mapping[str, Any]) -> list[TodoItemData] | None:
+    """Codex ``exec --json`` ``todo_list`` stream item:
+    ``{"items": [{"text", "completed"|"status"}, …]}``."""
+    return _extract(args, "items", ("text",))
+
+
+_EXTRACTORS: dict[str, _Extractor] = {
+    "TodoWrite": _from_todos_arg,
+    "todowrite": _from_todos_arg,
+    "write_todos": _from_todos_arg,
+    "update_plan": _from_plan_arg,
+    "todo_list": _from_items_arg,
+}

--- a/src/vibesys/loops/agent/templates/implementer_prompt.j2
+++ b/src/vibesys/loops/agent/templates/implementer_prompt.j2
@@ -35,7 +35,7 @@ No separate reference implementation is provided. Treat `OBJECTIVE.md` and the i
 
 Read `progress.md` at the start of your work. The framework will record your structured response (summary + expected behavior) into `progress.md` for you — do not duplicate that block manually. The Orchestrator reads it next round.
 
-Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it. The operator's UI mirrors this list as live run progress.
+Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it.
 
 {% if feedback %}
 ## Judge feedback from previous attempt

--- a/src/vibesys/loops/agent/templates/implementer_prompt.j2
+++ b/src/vibesys/loops/agent/templates/implementer_prompt.j2
@@ -35,6 +35,8 @@ No separate reference implementation is provided. Treat `OBJECTIVE.md` and the i
 
 Read `progress.md` at the start of your work. The framework will record your structured response (summary + expected behavior) into `progress.md` for you — do not duplicate that block manually. The Orchestrator reads it next round.
 
+Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it. The operator's UI mirrors this list as live run progress.
+
 {% if feedback %}
 ## Judge feedback from previous attempt
 

--- a/src/vibesys/loops/agent/templates/single_agent_round_prompt.j2
+++ b/src/vibesys/loops/agent/templates/single_agent_round_prompt.j2
@@ -109,6 +109,8 @@ If you could not run the benchmark this round, set `perf_metric: null` rather th
 
 The framework will record your structured response into `progress.md` for you. Read `progress.md` and `roadmap.md` first to understand prior rounds; do NOT duplicate the framework's audit block manually.
 
+Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it. The operator's UI mirrors this list as live run progress.
+
 ## Output
 
 Return exactly one JSON object. Do not wrap in markdown fences.

--- a/src/vibesys/loops/agent/templates/single_agent_round_prompt.j2
+++ b/src/vibesys/loops/agent/templates/single_agent_round_prompt.j2
@@ -109,7 +109,7 @@ If you could not run the benchmark this round, set `perf_metric: null` rather th
 
 The framework will record your structured response into `progress.md` for you. Read `progress.md` and `roadmap.md` first to understand prior rounds; do NOT duplicate the framework's audit block manually.
 
-Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it. The operator's UI mirrors this list as live run progress.
+Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it.
 
 ## Output
 

--- a/tests/agents/test_todos.py
+++ b/tests/agents/test_todos.py
@@ -1,0 +1,136 @@
+"""Tests for provider todo/plan tool-call extraction.
+
+The TUI and headless renderers consume neutral ``todo_update`` events; these
+tests pin the adapter that translates each CLI provider's tool convention
+into that contract, and the ``AgentLogger`` hook that publishes it.
+"""
+
+from vibesys.agents.callbacks import AgentLogger
+from vibesys.agents.todos import todos_from_tool_call
+from vibesys.render.sink import output_sink
+from vibesys.server.events import RunEvent, TodoItemData, TodoUpdateData
+
+
+class TestProviderShapes:
+    def test_claude_code_todo_write(self):
+        items = todos_from_tool_call(
+            "TodoWrite",
+            {
+                "todos": [
+                    {"content": "Profile the hot loop", "status": "completed"},
+                    {"content": "Vectorize", "status": "in_progress", "activeForm": "Vectorizing"},
+                ]
+            },
+        )
+        assert items == [
+            TodoItemData(content="Profile the hot loop", status="completed"),
+            TodoItemData(content="Vectorize", status="in_progress"),
+        ]
+
+    def test_opencode_and_gemini_share_the_todos_shape(self):
+        for tool in ("todowrite", "write_todos"):
+            items = todos_from_tool_call(tool, {"todos": [{"content": "A", "status": "pending"}]})
+            assert items == [TodoItemData(content="A", status="pending")]
+
+    def test_gemini_description_key(self):
+        items = todos_from_tool_call(
+            "write_todos", {"todos": [{"description": "Read the ABI contract"}]}
+        )
+        assert items == [TodoItemData(content="Read the ABI contract", status="pending")]
+
+    def test_codex_update_plan(self):
+        items = todos_from_tool_call(
+            "update_plan",
+            {
+                "explanation": "next steps",
+                "plan": [
+                    {"step": "Run the benchmark", "status": "in_progress"},
+                    {"step": "Tune the queue size", "status": "pending"},
+                ],
+            },
+        )
+        assert items == [
+            TodoItemData(content="Run the benchmark", status="in_progress"),
+            TodoItemData(content="Tune the queue size", status="pending"),
+        ]
+
+    def test_codex_todo_list_item_with_completed_booleans(self):
+        items = todos_from_tool_call(
+            "todo_list",
+            {"items": [{"text": "Build", "completed": True}, {"text": "Test", "completed": False}]},
+        )
+        assert items == [
+            TodoItemData(content="Build", status="completed"),
+            TodoItemData(content="Test", status="pending"),
+        ]
+
+
+class TestDegradation:
+    def test_unrelated_tools_are_not_todo_updates(self):
+        assert todos_from_tool_call("Bash", {"command": "ls"}) is None
+        assert todos_from_tool_call("Write", {"content": "todos: []"}) is None
+
+    def test_payload_without_the_expected_list_is_no_update(self):
+        assert todos_from_tool_call("TodoWrite", {}) is None
+        assert todos_from_tool_call("TodoWrite", {"todos": "not-a-list"}) is None
+        assert todos_from_tool_call("update_plan", {"plan": {"step": "x"}}) is None
+
+    def test_malformed_entries_are_skipped_not_fatal(self):
+        items = todos_from_tool_call(
+            "TodoWrite",
+            {
+                "todos": [
+                    "not-a-dict",
+                    {"status": "pending"},  # no content
+                    {"content": "   ", "status": "pending"},  # blank content
+                    {"content": "Real item", "status": "pending"},
+                ]
+            },
+        )
+        assert items == [TodoItemData(content="Real item", status="pending")]
+
+    def test_unknown_status_strings_pass_through(self):
+        items = todos_from_tool_call(
+            "TodoWrite", {"todos": [{"content": "Odd", "status": "deferred"}]}
+        )
+        assert items == [TodoItemData(content="Odd", status="deferred")]
+
+    def test_missing_status_defaults_to_pending(self):
+        items = todos_from_tool_call("TodoWrite", {"todos": [{"content": "Bare"}]})
+        assert items == [TodoItemData(content="Bare", status="pending")]
+
+
+class TestAgentLoggerPublishing:
+    def test_cli_todo_tool_call_publishes_a_todo_update(self):
+        seen: list[RunEvent] = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            logger = AgentLogger()
+            logger.on_tool_call("TodoWrite", {"todos": [{"content": "A", "status": "pending"}]})
+        finally:
+            unsubscribe()
+        updates = [e.data for e in seen if isinstance(e.data, TodoUpdateData)]
+        assert len(updates) == 1
+        assert updates[0].todos == [TodoItemData(content="A", status="pending")]
+
+    def test_non_todo_tool_call_publishes_no_todo_update(self):
+        seen: list[RunEvent] = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            logger = AgentLogger()
+            logger.on_tool_call("Bash", {"command": "make"})
+        finally:
+            unsubscribe()
+        assert not any(isinstance(e.data, TodoUpdateData) for e in seen)
+
+    def test_empty_snapshot_is_extracted_but_not_published(self):
+        # The sink drops empty lists, so a cleared plan is a no-op on the
+        # wire rather than an event with no payload.
+        seen: list[RunEvent] = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            logger = AgentLogger()
+            logger.on_tool_call("TodoWrite", {"todos": []})
+        finally:
+            unsubscribe()
+        assert not any(isinstance(e.data, TodoUpdateData) for e in seen)

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/implementer.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/implementer.md
@@ -98,5 +98,5 @@ If you cannot identify a relevant reference for a task, search the `references/`
 
 Read `progress.md` at the start of your work. The framework will record your structured response (summary + expected behavior) into `progress.md` for you — do not duplicate that block manually. The Orchestrator reads it next round.
 
-Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it. The operator's UI mirrors this list as live run progress.
+Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it.
 

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/implementer.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/implementer.md
@@ -98,3 +98,5 @@ If you cannot identify a relevant reference for a task, search the `references/`
 
 Read `progress.md` at the start of your work. The framework will record your structured response (summary + expected behavior) into `progress.md` for you — do not duplicate that block manually. The Orchestrator reads it next round.
 
+Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it. The operator's UI mirrors this list as live run progress.
+

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/single_agent.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/single_agent.md
@@ -130,6 +130,8 @@ If you could not run the benchmark this round, set `perf_metric: null` rather th
 
 The framework will record your structured response into `progress.md` for you. Read `progress.md` and `roadmap.md` first to understand prior rounds; do NOT duplicate the framework's audit block manually.
 
+Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it. The operator's UI mirrors this list as live run progress.
+
 ## Output
 
 Return exactly one JSON object. Do not wrap in markdown fences.

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/single_agent.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/single_agent.md
@@ -130,7 +130,7 @@ If you could not run the benchmark this round, set `perf_metric: null` rather th
 
 The framework will record your structured response into `progress.md` for you. Read `progress.md` and `roadmap.md` first to understand prior rounds; do NOT duplicate the framework's audit block manually.
 
-Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it. The operator's UI mirrors this list as live run progress.
+Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it.
 
 ## Output
 

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/implementer.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/implementer.md
@@ -95,5 +95,5 @@ If you cannot identify a relevant reference for a task, search the `references/`
 
 Read `progress.md` at the start of your work. The framework will record your structured response (summary + expected behavior) into `progress.md` for you — do not duplicate that block manually. The Orchestrator reads it next round.
 
-Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it. The operator's UI mirrors this list as live run progress.
+Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it.
 

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/implementer.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/implementer.md
@@ -95,3 +95,5 @@ If you cannot identify a relevant reference for a task, search the `references/`
 
 Read `progress.md` at the start of your work. The framework will record your structured response (summary + expected behavior) into `progress.md` for you — do not duplicate that block manually. The Orchestrator reads it next round.
 
+Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it. The operator's UI mirrors this list as live run progress.
+

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/single_agent.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/single_agent.md
@@ -118,7 +118,7 @@ If you could not run the benchmark this round, set `perf_metric: null` rather th
 
 The framework will record your structured response into `progress.md` for you. Read `progress.md` and `roadmap.md` first to understand prior rounds; do NOT duplicate the framework's audit block manually.
 
-Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it. The operator's UI mirrors this list as live run progress.
+Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it.
 
 ## Output
 

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/single_agent.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/single_agent.md
@@ -118,6 +118,8 @@ If you could not run the benchmark this round, set `perf_metric: null` rather th
 
 The framework will record your structured response into `progress.md` for you. Read `progress.md` and `roadmap.md` first to understand prior rounds; do NOT duplicate the framework's audit block manually.
 
+Maintain a live todo list with your todo/plan tool while you work: record your plan as todo items before making changes, and update each item's status as you complete it. The operator's UI mirrors this list as live run progress.
+
 ## Output
 
 Return exactly one JSON object. Do not wrap in markdown fences.


### PR DESCRIPTION
## Problem

Agents publish their todo lists as typed `todo_update` events, and the Python
headless renderer displays them as a persistent box (`TodoDisplay` in
`src/vibesys/render/headless.py`). The TypeScript TUI lost this surface: it
parsed `todo_update` events into session state but never rendered them, so
operators watching a run had no view of what the agent is working on or how
far through its plan it is.

A plain port of the old display would also be wrong for the TUI: it kept one
global list, so in multi-phase rounds (implementer → judge, across rounds)
each agent's update clobbered the previous one.

## Solution

Example screenshot:

<img width="1608" height="1045" alt="Screenshot 2026-07-19 at 3 53 54 PM" src="https://github.com/user-attachments/assets/6608c353-06ef-43d1-8b9e-d9d203aff100" />


Store todos per `(round, agent)` phase and render them as a collapsible
full-width strip between the conversation viewport and the input panel.

- **Per-phase state**: `session-model.ts` replaces the dead global `todos`
  field with `todoPhases`, upserted by the `(round_label, agent_kind)` stamped
  on each event envelope. A `visibleTodos()` selector follows the same scoping
  rules as the conversation filter: the live view tracks the currently active
  agent (a phase that never emits todos shows nothing, not the previous
  phase's leftovers); selecting an agent or round via the existing Tab/`[`/`]`
  navigation shows that phase's final todo state. Events without envelope
  stamps (legacy streams) match any scope instead of vanishing.
- **Collapsible strip**: `ui/todo-strip.ts` renders one summary line when
  collapsed (`▸ Todo 1/3 · ▶ current item`), and a bordered list with
  per-status colors when expanded (Ctrl+T or click), capped at 10 items with
  `… +N more`. When the visible phase has no todos the strip occupies no
  vertical space.
- **Robust degradation**: the todo status field is an open string on the wire
  (see the comment on `TodoItemData` in `src/vibesys/server/events.py`);
  unknown statuses render as a neutral `?` marker. Item lines truncate to the
  terminal width so they never wrap the fixed-height layout.

- **CLI provider adapters**: previously only the deepagents backend produced
  `todo_update` events (extracted from its graph state channel), so the strip
  would stay empty under every CLI provider. `vibesys/agents/todos.py` now
  maps each provider's plan-tool convention — Claude Code `TodoWrite`,
  opencode `todowrite`, Gemini `write_todos`, Codex `update_plan` and
  `todo_list` — to the neutral `TodoItemData` contract, hooked at the shared
  tool-call emission point in `AgentLogger` so both backends flow through one
  choke point. Extraction is best-effort: malformed entries are skipped,
  unrecognized payloads publish nothing, and it never raises into the agent
  run.

- **Prompt nudge (prompt-output change)**: whether an agent uses its plan
  tool at all is model-discretionary — in live Codex runs against
  `queue-spsc`, one run in four planned. The implementer and single-agent
  prompt templates now ask for a live todo list explicitly, in
  provider-neutral wording, under their existing "Progress tracking"
  section. Judge and orchestrator prompts are deliberately unchanged (short
  analytic phases). The four affected prompt snapshots are regenerated; the
  fixture diff is exactly the one added sentence in each, which is the
  user-visible agent diff to review.

The event contract and the Python headless `TodoDisplay` are untouched.

### Architecture

The strip is a standard view class owning one renderable, re-rendered from
immutable `SessionState` snapshots like every other view. All todo semantics
(keying, scoping, toggle) live in the session model; the view only formats.

```mermaid
flowchart LR
    A1[deepagents graph state<br/>todos channel] --> B[OutputSink]
    A2[CLI plan tool calls<br/>TodoWrite / todowrite / write_todos /<br/>update_plan / todo_list] -->|agents/todos.py adapter| B
    B --> C[RunSupervisor<br/>stamps agent_kind + round_label]
    C -->|socket events| D[session-model.ts<br/>todoPhases upsert per round+agent]
    D -->|visibleTodos selector| E[TodoStripView<br/>collapsed line / expanded list]
    F[Ctrl+T / click] --> G[SessionController.toggleTodos]
    G --> D
```

## Verification

Type check, full vitest suite (54 tests, 7 new), and Biome all pass. The new
app-level tests render real frames through `@opentui/core/testing` and assert
the collapsed summary, Ctrl+T expansion, and that the strip disappears when
the visible agent has no todos.

### Correctness properties

- One agent's `todo_update` never overwrites another phase's list; each
  `(round, agent)` keeps its latest snapshot (bounded at 100 phases).
- The live view shows only the currently active agent's todos; a phase that
  emits none shows nothing rather than stale leftovers.
- Selecting a past round/agent shows that phase's final todo state,
  consistent with the existing conversation filter semantics.
- Unknown todo statuses degrade to a neutral marker; rendering never fails on
  open-schema payloads (statuses and content are coerced to strings at the
  model boundary).
- Event-sequence deduplication and replay behavior are unchanged; `todo_update`
  still produces no transcript entries.
- No wire-contract changes: the generated protocol types and Python event
  models are untouched.
- Provider adapters never raise into the agent run: malformed todo entries
  are skipped, entries without usable text are dropped, and payloads that do
  not carry a todo list publish nothing (an empty snapshot is dropped by the
  sink, matching existing behavior).
- Todo updates are full-list snapshots, so the deepagents `write_todos` tool
  matching both the state-channel extractor and the new adapter re-publishes
  an identical snapshot — idempotent for every consumer.

### Testing

- `pnpm run check` (tsc, `clients/tui`) — passes.
- `pnpm test` (`clients/tui`, vitest via bun) — 10 files, 54 tests passed,
  including new coverage: per-phase clobber protection, live-view agent
  following, hidden-when-no-todos, unknown-status degradation, collapsed/
  expanded frame rendering, and summary/truncation formatting.
- `npx biome check clients/tui/src` — clean.
- `pytest tests/agents/ tests/test_todo_display.py tests/render/` — 172
  passed, including 13 new adapter tests (each provider shape, malformed
  payload degradation, unknown statuses, and sink publishing through
  `AgentLogger`).
- `pyright` on `agents/todos.py` and the new tests — 0 errors (strict).
  `agents/callbacks.py` reports 4 pre-existing unresolved-import errors in
  this venv (`langchain_core` extra not installed); identical before and
  after the change.
- `ruff check` / `ruff format --check` on the changed Python files — clean.
- `pytest tests/loops/agent` — 151 passed (prompt snapshot and domain-leakage
  suites), after regenerating the 4 implementer/single-agent snapshots.
- Adapter validated against real run data: replayed the `todo_list` tool-call
  payloads recorded in a live Codex `queue-spsc` run through
  `todos_from_tool_call` and confirmed correct snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
