### PR TITLE
Bootstrap a passing seed before the evolve loop; harden Modal runs

### DIFF
--- a/src/vibesys/loops/agent/templates/_modality/text_generation/implementer.j2
+++ b/src/vibesys/loops/agent/templates/_modality/text_generation/implementer.j2
@@ -2,6 +2,8 @@ You are an ML engineer building a FastAPI inference server for a text generation
 
 - **Own layer implementations**: Implement every layer of the model architecture explicitly in your code (attention, MLP, normalization, positional embeddings, etc.). You may use `transformers` as a utility (e.g. `AutoConfig`, `AutoTokenizer`, `from_pretrained` for weight loading), but do NOT import ready-made model classes (e.g. `LlamaModel`, `LlamaAttention`). Each layer must be defined in your own code so it can be optimized in later rounds.
 
+- **Weight loading — materialize *computed* buffers, not just checkpoint tensors**: if you build the model under `with torch.device("meta")` (or otherwise defer allocation) and then load the state dict, only parameters present in the checkpoint get real storage. **Computed buffers you register yourself — RoPE `inv_freq`, causal masks, precomputed sin/cos tables — are NOT in the checkpoint and stay on the meta device**, which crashes at first forward with `NotImplementedError: Cannot copy out of meta tensor; no data!`. After loading, rebuild/re-materialize every such buffer on the real device (e.g. recompute `inv_freq` in `to_empty()`/post-load, or register it with `persistent=False` and recompute on the target device). Verify the model runs a real forward pass before serving.
+
 {% if interface == "inprocess" %}
 ## Accuracy-checker compatibility
 

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -6,8 +6,7 @@ every offspring:
   1. Sample a parent from the passed-population, weighted by perf_metric.
   2. Sample a small set of peer "inspirations" so the mutator sees
      diverse strategies, not just the current best.
-  3. Check the workspace out to the parent's commit (or, on cold start,
-     leave the workspace as the framework seeded it).
+  3. Check the workspace out to the parent's commit.
   4. Run the *Mutator* agent (an LLM acting as the mutation operator) to
      edit code in place.
   5. Run the *Judge* on the result.
@@ -15,10 +14,13 @@ every offspring:
      record an Individual. Else: discard the dirty tree, record a failed
      Individual carrying the judge feedback so future mutators can learn.
 
-Cold start (empty population) bypasses parent selection: the framework
-asks the mutator to write the first working server from the reference,
-just like the cold-start round in ``orchestrate``. Once that first
-individual passes, evolution proper begins on round 2.
+Before the generation loop, a dedicated *bootstrap* phase
+(``_bootstrap_seed``) runs implementer → judge iterations until the first
+judge-passing implementation exists, recorded as a generation-0 seed. So
+the generation loop always starts from a passing parent and never
+cold-starts. The bootstrap phase owns the from-scratch / fix-forward
+repair logic; on ``--resume`` it is skipped when a passing individual is
+already present.
 
 The loop intentionally does NOT have an early-stop signal — generations
 run for the full ``max_generations`` budget. Termination decisions are
@@ -47,6 +49,7 @@ from vibesys.profilers import ProfilerKind, profiler_definition
 from vibesys.run import LoopContext, RepositoryVisibility
 from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
+    candidate_modal_app_name,
     make_run_environment_spec,
 )
 from vibesys.schemas import JudgeResponse, MutatorResponse, ProfilerSummary, Verdict
@@ -96,6 +99,79 @@ def _discard_working_tree(ctx: LoopContext) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _recent_failure_lessons(
+    population: Population, *, limit: int = 3, max_chars: int = 700
+) -> list[str]:
+    """Distinct feedback from the most-recent failed individuals.
+
+    While the population has no passing parent, every child is a cold start
+    that re-writes the server from scratch. Without this memory the search
+    repeats the same bug on every seed (e.g. an identical model-init crash),
+    burning generations while the population stays empty. Surfacing the recent
+    distinct failure feedback lets each new seed avoid traps earlier seeds hit.
+
+    De-duplicates on a normalized prefix so N identical failures collapse to a
+    single lesson, and truncates each to keep the prompt bounded.
+    """
+    seen: set[str] = set()
+    lessons: list[str] = []
+    for ind in reversed(population.all):  # most recent first
+        if ind.passed:
+            continue
+        fb = (ind.feedback or "").strip()
+        if not fb:
+            continue
+        key = " ".join(fb[:160].lower().split())
+        if key in seen:
+            continue
+        seen.add(key)
+        lessons.append(fb if len(fb) <= max_chars else fb[:max_chars].rstrip() + " …")
+        if len(lessons) >= limit:
+            break
+    return lessons
+
+
+def _latest_wip_seed(population: Population) -> Individual | None:
+    """Most-recent failed cold-start seed whose work was snapshotted.
+
+    While the population has no passing parent, each round is a cold start.
+    Rather than throw the failed seed away and rebuild from scratch every
+    round (which makes the search re-hit the same bug forever, unable to
+    bootstrap its first green candidate), we snapshot each failed seed to a
+    WIP commit and let the next cold start *repair it in place* — fix-forward
+    instead of restart. This returns that most-recent WIP seed so its tree can
+    be checked out as the base for the next attempt.
+
+    A WIP seed is a failed individual (``passed=False``) with ``parent_id is
+    None`` that nonetheless carries a ``commit`` (its snapshotted tree).
+    """
+    for ind in reversed(population.all):  # most recent first
+        if not ind.passed and ind.parent_id is None and ind.commit:
+            return ind
+    return None
+
+
+def _candidate_runtime_notes(
+    ctx: LoopContext, generation: int, child_idx: int
+) -> tuple[str, str | None]:
+    """Runtime notes for one candidate, with a per-candidate Modal app name.
+
+    In Modal mode every candidate must deploy to its own app so the judge
+    never reads a prior (broken) candidate's cumulative app logs. We derive a
+    ``-g<gen>c<child>`` app name and substitute it for the per-run base name
+    throughout the notes (the base name is a unique token, so a plain replace
+    swaps every occurrence — App name, endpoint labels, aux-volume prefixes).
+    For non-Modal envs the notes are returned unchanged and the app name is
+    ``None``.
+    """
+    base = getattr(ctx.run_environment_view, "modal_app_name", None)
+    notes = ctx.run_environment_view.prompt_notes
+    if not base:
+        return notes, None
+    cand_app = candidate_modal_app_name(base, generation, child_idx)
+    return notes.replace(base, cand_app), cand_app
+
+
 def _run_mutator(
     ctx: LoopContext,
     *,
@@ -107,6 +183,10 @@ def _run_mutator(
     modality: str,
     is_cold_start: bool,
     objectives: list[Objective] | None = None,
+    failed_lessons: list[str] | None = None,
+    num_failed_attempts: int = 0,
+    repair_seed: bool = False,
+    runtime_notes: str | None = None,
 ) -> MutatorResponse:
     system_prompt = _render(
         "mutator_prompt.j2",
@@ -117,8 +197,15 @@ def _run_mutator(
         inspirations=inspirations,
         is_cold_start=is_cold_start,
         objectives=objectives,
-        runtime_notes=ctx.run_environment_view.prompt_notes,
+        runtime_notes=(
+            runtime_notes if runtime_notes is not None else ctx.run_environment_view.prompt_notes
+        ),
         env_kind=ctx.run_environment_view.env_kind,
+        accuracy_command=ctx.judge_accuracy_command,
+        benchmark_command=ctx.judge_benchmark_command,
+        failed_lessons=failed_lessons or [],
+        num_failed_attempts=num_failed_attempts,
+        repair_seed=repair_seed,
     )
     return ctx.invoke(
         kind="implementer",  # mutator reuses the implementer sandbox
@@ -145,6 +232,7 @@ def _run_judge(
     modality: str,
     objective: str,
     pass_criteria: str,
+    runtime_notes: str | None = None,
 ) -> JudgeResponse:
     system_prompt = _render(
         "judge_prompt.j2",
@@ -152,7 +240,9 @@ def _run_judge(
         benchmark_command=ctx.judge_benchmark_command,
         pass_criteria=pass_criteria,
         modality=modality,
-        runtime_notes=ctx.run_environment_view.prompt_notes,
+        runtime_notes=(
+            runtime_notes if runtime_notes is not None else ctx.run_environment_view.prompt_notes
+        ),
         env_kind=ctx.run_environment_view.env_kind,
         objective=objective,
     )
@@ -198,6 +288,7 @@ def _run_profiler(
     modality: str,
     objective: str,
     objectives: list[Objective] | None = None,
+    runtime_notes: str | None = None,
 ) -> ProfilerSummary | None:
     if ctx.profiler_kind is ProfilerKind.NONE:
         return None
@@ -207,7 +298,9 @@ def _run_profiler(
         template,
         benchmark_command=ctx.profiler_benchmark_command,
         modality=modality,
-        runtime_notes=ctx.run_environment_view.prompt_notes,
+        runtime_notes=(
+            runtime_notes if runtime_notes is not None else ctx.run_environment_view.prompt_notes
+        ),
         env_kind=ctx.run_environment_view.env_kind,
         objective=objective,
         profile_focus="Measure the headline metric for this candidate; rank top kernel-level bottlenecks.",
@@ -227,6 +320,168 @@ def _run_profiler(
         round_label=f"gen-{generation}-cand-{child_idx}-profiler",
         fallback_suggestions="n/a",
     )
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_seed(
+    ctx: LoopContext,
+    *,
+    objective: str,
+    objectives: list[Objective] | None,
+    modality: str,
+    pass_criteria: str,
+    max_attempts: int,
+    rng: random.Random,
+    population: Population,
+    population_path: Path,
+) -> Individual | None:
+    """Iterate implementer → judge until a first *passing* seed exists.
+
+    Runs BEFORE the generation loop so the search never cold-starts. Attempt 1
+    writes a server from scratch; later attempts repair-forward the most-recent
+    failed WIP seed (fix-forward, not restart). On PASS: profile, snapshot, and
+    record a passing generation-0 ``Individual`` (``parent_id=None``), then
+    return it. On FAIL: snapshot the WIP tree and record a failed generation-0
+    ``Individual`` so the next attempt can repair it in place. Returns ``None``
+    if every attempt fails — the caller aborts the run.
+
+    ``rng`` is accepted for signature parity with the generation loop (bootstrap
+    does no parent/inspiration sampling) and forward-compatibility.
+    """
+    ctx.switch_log_file("bootstrap")
+    ctx.lprint(
+        f"\n{'=' * 60}\n  Bootstrap — first passing seed "
+        f"(up to {max_attempts} attempt(s))\n{'=' * 60}\n"
+    )
+
+    for attempt in range(1, max_attempts + 1):
+        ctx.lprint(f"\n--- bootstrap attempt {attempt}/{max_attempts} ---\n")
+
+        # Fix-forward from the most-recent failed WIP seed, if one was
+        # snapshotted; otherwise the workspace stays as the framework seeded it
+        # (the bare reference tree).
+        wip_seed = _latest_wip_seed(population)
+        if wip_seed is not None and wip_seed.commit:
+            if not ctx.git.checkout_tree(wip_seed.commit, clean=True):
+                ctx.lprint(
+                    f"[warn] could not check out WIP seed {wip_seed.id} "
+                    f"(commit {wip_seed.commit[:8]}); starting from reference"
+                )
+                wip_seed = None
+
+        # Per-candidate Modal app name so a failed attempt's cumulative app logs
+        # never poison the next attempt's judge (same isolation the generation
+        # loop uses).
+        cand_notes, cand_app = _candidate_runtime_notes(ctx, 0, attempt)
+        failed_lessons = _recent_failure_lessons(population)
+        num_failed_attempts = sum(1 for i in population.all if not i.passed)
+        base_desc = "reference" if wip_seed is None else f"repair-seed #{wip_seed.id}"
+        ctx.lprint(f"bootstrap base={base_desc}" + (f" modal-app={cand_app}" if cand_app else ""))
+
+        # 1. Implementer (the mutator in cold-start / from-scratch mode).
+        ctx.reselect_gpu()
+        mutator = _run_mutator(
+            ctx,
+            generation=0,
+            child_idx=attempt,
+            objective=objective,
+            parent=None,
+            inspirations=[],
+            modality=modality,
+            is_cold_start=True,
+            objectives=objectives,
+            failed_lessons=failed_lessons,
+            num_failed_attempts=num_failed_attempts,
+            repair_seed=wip_seed is not None,
+            runtime_notes=cand_notes,
+        )
+
+        # 2. Judge.
+        ctx.reselect_gpu()
+        verdict = _run_judge(
+            ctx,
+            generation=0,
+            child_idx=attempt,
+            modality=modality,
+            objective=objective,
+            pass_criteria=pass_criteria,
+            runtime_notes=cand_notes,
+        )
+
+        if verdict.verdict != Verdict.PASS:
+            # Snapshot the failed tree so the next attempt repairs it in place.
+            # Only tag a WIP repair-seed when the snapshot actually committed new
+            # work (the tree changed); an unedited tree is nothing to fix-forward.
+            wip_commit = None
+            try:
+                sha_before = ctx.git.current_sha()
+                ctx.snapshot_workspace(f"wip-seed-bootstrap{attempt}")
+                sha_after = ctx.git.current_sha()
+                if sha_after and sha_after != sha_before:
+                    wip_commit = sha_after
+            except Exception as exc:
+                ctx.lprint(f"[warn] wip-seed snapshot failed: {exc}")
+            failed = Individual(
+                id=population.next_id(),
+                generation=0,
+                parent_id=None,
+                inspiration_ids=[],
+                commit=wip_commit,
+                perf_metric=None,
+                perf_unit=None,
+                passed=False,
+                summary=mutator.summary,
+                feedback=verdict.feedback,
+            )
+            population.add(failed)
+            population.save(population_path)
+            ctx.lprint(
+                f"[bootstrap {attempt}] FAILED — feedback: "
+                f"{(verdict.feedback or '').splitlines()[0][:120] if verdict.feedback else ''}"
+            )
+            continue
+
+        # 3. PASS → profile, snapshot, and record the generation-0 seed.
+        ctx.reselect_gpu()
+        summary = _run_profiler(
+            ctx,
+            generation=0,
+            child_idx=attempt,
+            modality=modality,
+            objective=objective,
+            objectives=objectives,
+            runtime_notes=cand_notes,
+        )
+        ctx.snapshot_workspace("gen-0-seed")
+        commit = ctx.git.current_sha()
+        seed = Individual(
+            id=population.next_id(),
+            generation=0,
+            parent_id=None,
+            inspiration_ids=[],
+            commit=commit,
+            perf_metric=summary.perf_metric if summary else None,
+            perf_unit=summary.perf_unit if summary else None,
+            metrics=dict(summary.metrics) if summary and summary.metrics else {},
+            passed=True,
+            summary=mutator.summary,
+            feedback=verdict.feedback,
+        )
+        population.add(seed)
+        population.save(population_path)
+        ctx.lprint(
+            f"[bootstrap {attempt}] PASSED — seed #{seed.id} "
+            f"perf={seed.perf_metric} {seed.perf_unit or ''} "
+            f"(commit {commit[:8] if commit else 'n/a'})"
+        )
+        return seed
+
+    ctx.lprint(f"[bootstrap] exhausted {max_attempts} attempt(s) without a passing seed.")
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -266,6 +521,7 @@ def run_evolve_loop(
     modality: str = "text_generation",
     objectives: list[Objective] | None = None,
     frontier_bias: float = 0.7,
+    bootstrap_max_attempts: int = 5,
     remote_repo: str | None = None,
     repo_visibility: RepositoryVisibility = RepositoryVisibility.PRIVATE,
 ) -> bool:
@@ -319,6 +575,29 @@ def run_evolve_loop(
     rng = random.Random(seed)
 
     try:
+        # Bootstrap phase: guarantee a passing generation-0 seed before the
+        # generation loop, so evolution never cold-starts. Skipped when a
+        # passing individual already exists (e.g. --resume).
+        if not population.passed:
+            seed_individual = _bootstrap_seed(
+                ctx,
+                objective=objective,
+                objectives=objectives,
+                modality=modality,
+                pass_criteria=pass_criteria,
+                max_attempts=bootstrap_max_attempts,
+                rng=rng,
+                population=population,
+                population_path=population_path,
+            )
+            if seed_individual is None:
+                ctx.lprint(
+                    "[evolutionary] bootstrap could not produce a passing seed in "
+                    f"{bootstrap_max_attempts} attempt(s); aborting before the "
+                    "generation loop."
+                )
+                return False
+
         for generation in range(1, max_generations + 1):
             ctx.switch_log_file(f"gen{generation:03d}")
             ctx.lprint(
@@ -351,24 +630,36 @@ def run_evolve_loop(
                         rng=rng,
                         objectives=objectives,
                     )
-                    is_cold_start = parent is None
-
-                    # 2. Materialize parent's tree (skip on cold start —
-                    # _RunContext seeded the workspace from the reference).
-                    if parent is not None and parent.commit:
-                        if not ctx.git.checkout_tree(parent.commit, clean=True):
-                            ctx.lprint(
-                                f"[warn] could not check out parent {parent.id} "
-                                f"(commit {parent.commit[:8]}); skipping cand"
-                            )
+                    # 2. Materialize the parent's tree. Bootstrap guarantees a
+                    # passing gen-0 seed, so a passing parent always exists.
+                    # select_parent only returns None when no passer has a
+                    # scalar perf_metric (e.g. profiler disabled); fall back to
+                    # the latest passer so the loop never cold-starts.
+                    if parent is None:
+                        passers = population.passed
+                        if not passers:
+                            ctx.lprint("[warn] no passing parent available; skipping candidate")
                             continue
+                        parent = passers[-1]
+                    if parent.commit and not ctx.git.checkout_tree(parent.commit, clean=True):
+                        ctx.lprint(
+                            f"[warn] could not check out parent {parent.id} "
+                            f"(commit {parent.commit[:8]}); skipping cand"
+                        )
+                        continue
+
+                    # Per-candidate runtime notes: in Modal mode this gives the
+                    # mutator/judge/profiler a candidate-unique app name so the
+                    # judge never reads a prior candidate's stale app logs.
+                    cand_notes, cand_app = _candidate_runtime_notes(ctx, generation, child_idx)
 
                     ctx.lprint(
-                        f"parent={'COLD-START' if parent is None else f'#{parent.id} (perf={parent.perf_metric})'}; "
-                        f"inspirations={[i.id for i in inspirations]}"
+                        f"parent=#{parent.id} (perf={parent.perf_metric})"
+                        + (f" modal-app={cand_app}" if cand_app else "")
+                        + f"; inspirations={[i.id for i in inspirations]}"
                     )
 
-                    # 3. Mutator edits the workspace.
+                    # 3. Mutator edits the workspace, mutating the passing parent.
                     ctx.reselect_gpu()
                     mutator = _run_mutator(
                         ctx,
@@ -378,8 +669,9 @@ def run_evolve_loop(
                         parent=parent,
                         inspirations=inspirations,
                         modality=modality,
-                        is_cold_start=is_cold_start,
+                        is_cold_start=False,
                         objectives=objectives,
+                        runtime_notes=cand_notes,
                     )
 
                     # 4. Judge.
@@ -391,15 +683,18 @@ def run_evolve_loop(
                         modality=modality,
                         objective=objective,
                         pass_criteria=pass_criteria,
+                        runtime_notes=cand_notes,
                     )
 
                     if verdict.verdict != Verdict.PASS:
-                        # Record the failed child (no commit) so its feedback
-                        # is visible to future mutators reading the population.
+                        # The mutation was a dead end: record the failed child so
+                        # its feedback is visible to future mutators (excluded
+                        # from selection because ``passed`` is False, no commit),
+                        # then revert the dirty tree back to the passing parent.
                         failed = Individual(
                             id=population.next_id(),
                             generation=generation,
-                            parent_id=parent.id if parent else None,
+                            parent_id=parent.id,
                             inspiration_ids=[i.id for i in inspirations],
                             commit=None,
                             perf_metric=None,
@@ -426,6 +721,7 @@ def run_evolve_loop(
                         modality=modality,
                         objective=objective,
                         objectives=objectives,
+                        runtime_notes=cand_notes,
                     )
 
                     # 6. Commit + record.
@@ -434,7 +730,7 @@ def run_evolve_loop(
                     child = Individual(
                         id=population.next_id(),
                         generation=generation,
-                        parent_id=parent.id if parent else None,
+                        parent_id=parent.id,
                         inspiration_ids=[i.id for i in inspirations],
                         commit=commit,
                         perf_metric=summary.perf_metric if summary else None,
@@ -453,7 +749,7 @@ def run_evolve_loop(
                     )
                     ctx.lprint(
                         f"[Gen {generation}] Cand {child.id} PASSED — "
-                        f"{metrics_repr} (parent={parent.id if parent else 'cold'})"
+                        f"{metrics_repr} (parent={parent.id})"
                     )
 
         if objectives:

--- a/src/vibesys/loops/evolve/templates/mutator_prompt.j2
+++ b/src/vibesys/loops/evolve/templates/mutator_prompt.j2
@@ -5,6 +5,9 @@
 ## Runtime environment
 
 {{ runtime_notes }}
+{% if env_kind == "modal" %}
+> **Per-candidate Modal app name — set it exactly.** The app name in the notes above is unique to *this* offspring. If you are editing an existing `main.py` (repairing a seed or mutating a parent), it will contain a *different* app name from a previous candidate — you MUST update `modal.App(...)` (and any `@modal.fastapi_endpoint(label=...)` / auxiliary-volume prefixes) to the app name given above, exactly. A stale name means your deploy and the judge's health probe target different apps and the offspring fails.
+{% endif %}
 {% endif %}
 
 ## Your role: Mutator in an evolutionary search
@@ -16,6 +19,17 @@ This is not a redo of the parent. It is a **single, focused change** that you be
 ## Objective (verbatim from `OBJECTIVE.md`)
 
 {{ objective }}
+
+## Always-on gates (every offspring is checked against ALL of these)
+
+The judge discards any offspring that fails **any** of the framework's always-on gates, no matter how good its perf number is. These hold for the cold-start seed *and* every mutation:
+
+1. **Unit tests** — `uv run pytest -v` must collect and pass. A repo with **no** tests exits code 5 and is treated as a FAIL, so you must ship at least a minimal `tests/` suite and keep it green as you mutate.
+{% if benchmark_command %}2. **Benchmark sanity** — the server must start, `/health` must return 200, and `{{ benchmark_command }}` must complete at least one request without error (discover flags with `{{ benchmark_command }} --help`).
+{% endif %}{% if accuracy_command %}3. **Accuracy checker** — `{{ accuracy_command }}` must pass when run against the live server. Discover its gates with `{{ accuracy_command }} --help`; do not guess. For this modality it drives the server over HTTP, so a real prompt-conditioned forward pass is required — canned/echoed/templated output fails it.
+{% endif %}
+
+If a change would break any gate, it is not worth the perf win — a failed offspring contributes nothing to the search.
 
 {% if objectives %}
 ## Pareto-frontier mode
@@ -33,14 +47,33 @@ The profiler reports every objective as a numeric value in `metrics`. An offspri
 
 {% if is_cold_start %}
 ## Cold start — no parent yet
+{% if repair_seed %}
+The population is empty, but a **previous cold-start seed's files are already in the workspace** — it failed the judge and was snapshotted for you to fix. **Do NOT rewrite it from scratch and do NOT recreate files that already exist.** Read the current `main.py` / server modules, find why it failed (see the lessons below), and **repair it in place** with the smallest change that clears the gate it tripped. Rebuilding from zero throws away working progress and re-introduces the same bug — fix forward instead.
 
+Your repaired seed must still satisfy all of these:
+{% else %}
 The population is empty. There is no parent to mutate. Your job this round is to write the **first working version** of the server from the reference at `{{ reference_path }}`. Aim for a minimal correct implementation that:
+{% endif %}
 
-- Boots and exposes `/health`.
-- Implements the modality's accuracy-checker contract (e.g. `VibeServeModel.from_pretrained` + the modality's generate / transcribe method).
-- Passes the modality's pass criteria (covered in the modality block above).
+- Boots and exposes `/health` (returns 200 once the model is loaded).
+- Serves the OpenAI-compatible endpoints the objective requires (`/v1/completions` and `/v1/chat/completions`) with correct streaming (SSE) semantics — the accuracy checker and benchmark both drive the server **over HTTP**, so these must work end-to-end against the running server.
+- Runs a real model forward pass with your own layer implementations (per the modality block above); no canned, echoed, or templated output.
+- Ships a minimal `tests/` suite so `uv run pytest -v` collects and passes at least one test (see "Always-on gates" above — an empty repo fails this gate).
+- Clears the always-on accuracy and benchmark-sanity gates listed above.
 
 Skip aggressive optimization in this seed — later generations will mutate it. Producing a clean, correct seed beats producing a clever-but-broken seed: failed seeds give the search nothing to evolve from.
+
+{% if failed_lessons %}
+### Lessons from {{ num_failed_attempts }} previous failed seed attempt(s) — do NOT repeat these
+
+Earlier cold-start seeds were **discarded by the judge** for the reasons below. The population is still empty because of them. Read each one and make sure your implementation does not fall into the same trap — especially recurring model-init / runtime crashes that keep `/health` up but break inference:
+
+{% for lesson in failed_lessons %}
+{{ loop.index }}. {{ lesson }}
+{% endfor %}
+
+Before you finish, sanity-check your seed against every lesson above.
+{% endif %}
 
 {% else %}
 ## Parent (the implementation you are mutating)

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -985,6 +985,7 @@ def _build_evolve_parser() -> argparse.ArgumentParser:
         metavar="NAME:DIRECTION",
     )
     parser.add_argument("--frontier-bias", type=float, default=0.7)
+    parser.add_argument("--bootstrap-max-attempts", type=int, default=5)
     parser.add_argument("--modality", default="text_generation", choices=_MODALITIES)
     return parser
 
@@ -1003,6 +1004,8 @@ def _validate_evolve(args: argparse.Namespace) -> None:
         _configuration_error("--selection-temperature must be > 0.")
     if not (0.0 <= args.frontier_bias <= 1.0):
         _configuration_error("--frontier-bias must be in [0, 1].")
+    if args.bootstrap_max_attempts < 1:
+        _configuration_error("--bootstrap-max-attempts must be >= 1.")
 
 
 def _run_evolve(args: argparse.Namespace) -> None:
@@ -1050,6 +1053,7 @@ def _run_evolve(args: argparse.Namespace) -> None:
         modality=args.modality,
         objectives=objectives,
         frontier_bias=args.frontier_bias,
+        bootstrap_max_attempts=args.bootstrap_max_attempts,
         remote_repo=args.repo,
         repo_visibility=args.repo_visibility,
     )

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -82,6 +82,13 @@ class RunEnvironmentView:
     # Coarse environment label for prompt-template branching:
     # ``"local"`` | ``"docker"`` | ``"modal"``.
     env_kind: str = "local"
+    # Modal only: the per-run Modal app namespace prefix embedded in
+    # ``prompt_notes`` (``None`` for non-Modal envs).  Loops that evaluate
+    # many candidates against Modal use this to derive a *per-candidate* app
+    # name so each candidate deploys to a pristine app — otherwise all
+    # candidates share one app and the judge reads stale logs from the first
+    # (possibly broken) deploy for every later candidate.
+    modal_app_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -386,6 +393,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
                 cli_modal_sandboxed=False,  # codex no longer runs inside Modal
                 host_device_reselect=False,
                 env_kind="modal",
+                modal_app_name=app_name,
             ),
             stop_on_close=True,
         )
@@ -513,6 +521,23 @@ def _modal_app_name(workspace: Path, fallback: str) -> str:
     return name[:63].rstrip("-") or "vibesys"
 
 
+def candidate_modal_app_name(base_app_name: str, generation: int, child_idx: int) -> str:
+    """Derive a per-candidate Modal app name from the per-run base name.
+
+    Every candidate in a run must deploy to its *own* Modal app: Modal app
+    logs are cumulative per app name, so if all candidates share one name the
+    judge reads the first (often broken) deploy's crash for every later
+    candidate and fails them identically.  We append a ``-g<gen>c<child>``
+    suffix, truncating the base to keep the whole name within Modal's 63-char
+    limit.  The leading timestamp+uuid in the base keeps it unique per run
+    even after truncation.
+    """
+    suffix = f"-g{generation}c{child_idx}"
+    keep = 63 - len(suffix)
+    trimmed = base_app_name[:keep].rstrip("-")
+    return f"{trimmed}{suffix}"
+
+
 def _modal_runtime_notes(gpu: str, app_name: str) -> str:
     """Render the Modal-mode runtime instructions for agent prompts.
 
@@ -576,6 +601,25 @@ def _modal_runtime_notes(gpu: str, app_name: str) -> str:
         "Use `modal.Volume.from_name(<that-name>)` and mount it at "
         "whatever container path you prefer (no fixed convention is "
         "required).\n"
+        "  - **The `reference/` directory (meta.json, config.json, "
+        "reference.py) exists ONLY in this local editor container — it is "
+        "NOT present inside the deployed Modal container.** Reading "
+        "`reference/meta.json` or `reference/config.json` from a relative "
+        "path at `@app.cls`/module import or `@modal.enter()` time will "
+        "crash the container with `FileNotFoundError` before `/health` can "
+        "serve, which fails every gate. Do NOT read local `reference/` "
+        "files at container runtime. Instead: (a) the pre-staged "
+        "model-weight Volume already contains the full HuggingFace snapshot "
+        "— `config.json`, tokenizer files, and the safetensors — so load "
+        "the model config and tokenizer from the *mounted volume path* at "
+        "runtime; and (b) if you need a value only found in "
+        "`reference/meta.json` (e.g. the `model_id`), read it in the editor "
+        "at build time and embed it as a module-level constant, or bake the "
+        "file into the image explicitly "
+        "(`image.add_local_file('reference/meta.json', "
+        "'/root/reference/meta.json')`). Verify startup with "
+        "`modal run main.py::<fn>` or a deploy + `/health` probe BEFORE "
+        "relying on the endpoint.\n"
         "  - Use `scaledown_window=120` on `@app.cls` so back-to-back "
         "benchmark calls reuse the warm container (KV cache, CUDA graphs, "
         "compiled grammars, etc. preserved between invocations within the "

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/implementer.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/implementer.md
@@ -2,6 +2,8 @@ You are an ML engineer building a FastAPI inference server for a text generation
 
 - **Own layer implementations**: Implement every layer of the model architecture explicitly in your code (attention, MLP, normalization, positional embeddings, etc.). You may use `transformers` as a utility (e.g. `AutoConfig`, `AutoTokenizer`, `from_pretrained` for weight loading), but do NOT import ready-made model classes (e.g. `LlamaModel`, `LlamaAttention`). Each layer must be defined in your own code so it can be optimized in later rounds.
 
+- **Weight loading — materialize *computed* buffers, not just checkpoint tensors**: if you build the model under `with torch.device("meta")` (or otherwise defer allocation) and then load the state dict, only parameters present in the checkpoint get real storage. **Computed buffers you register yourself — RoPE `inv_freq`, causal masks, precomputed sin/cos tables — are NOT in the checkpoint and stay on the meta device**, which crashes at first forward with `NotImplementedError: Cannot copy out of meta tensor; no data!`. After loading, rebuild/re-materialize every such buffer on the real device (e.g. recompute `inv_freq` in `to_empty()`/post-load, or register it with `persistent=False` and recompute on the target device). Verify the model runs a real forward pass before serving.
+
 ## Accuracy-checker compatibility
 
 Your `main.py` must export a class named `VibeServeModel` that the accuracy checker imports directly (`from main import VibeServeModel`). The class must implement:

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/implementer.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/implementer.md
@@ -2,6 +2,8 @@ You are an ML engineer building a FastAPI inference server for a text generation
 
 - **Own layer implementations**: Implement every layer of the model architecture explicitly in your code (attention, MLP, normalization, positional embeddings, etc.). You may use `transformers` as a utility (e.g. `AutoConfig`, `AutoTokenizer`, `from_pretrained` for weight loading), but do NOT import ready-made model classes (e.g. `LlamaModel`, `LlamaAttention`). Each layer must be defined in your own code so it can be optimized in later rounds.
 
+- **Weight loading — materialize *computed* buffers, not just checkpoint tensors**: if you build the model under `with torch.device("meta")` (or otherwise defer allocation) and then load the state dict, only parameters present in the checkpoint get real storage. **Computed buffers you register yourself — RoPE `inv_freq`, causal masks, precomputed sin/cos tables — are NOT in the checkpoint and stay on the meta device**, which crashes at first forward with `NotImplementedError: Cannot copy out of meta tensor; no data!`. After loading, rebuild/re-materialize every such buffer on the real device (e.g. recompute `inv_freq` in `to_empty()`/post-load, or register it with `persistent=False` and recompute on the target device). Verify the model runs a real forward pass before serving.
+
 ## Accuracy-checker compatibility
 
 Your `main.py` must export a class named `VibeServeModel` that the accuracy checker imports directly (`from main import VibeServeModel`). The class must implement:

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -10,16 +10,24 @@ are patched out — same pattern as ``tests/test_orchestrate.py``.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from vibesys.agents import AgentRunner
-from vibesys.loops.evolve.loop import run_evolve_loop
+from vibesys.loops.evolve.loop import (
+    _candidate_runtime_notes,
+    _latest_wip_seed,
+    _recent_failure_lessons,
+    run_evolve_loop,
+)
 from vibesys.loops.evolve.population import (
+    Individual,
     Objective,
     Population,
 )
+from vibesys.sandbox.run_environment import candidate_modal_app_name
 from vibesys.schemas import JudgeResponse, MutatorResponse, ProfilerSummary, Verdict
 
 # ---------------------------------------------------------------------------
@@ -48,6 +56,7 @@ def _make_runner(
     judge_verdicts: list[str] | None = None,
     profiler_responses: list[ProfilerSummary] | None = None,
     capture_mutator_prompts: list[str] | None = None,
+    mutator_writes: bool = False,
 ):
     """Build a MagicMock AgentRunner with scripted responses.
 
@@ -68,6 +77,15 @@ def _make_runner(
             counters["mutator"] += 1
             if capture_mutator_prompts is not None:
                 capture_mutator_prompts.append(system_prompt)
+            # Simulate a real edit so the cold-start snapshot has something to
+            # commit (a WIP repair-seed). Without a file change the snapshot is
+            # a no-op and no commit is recorded.
+            if mutator_writes:
+                workspace = kwargs.get("workspace")
+                if workspace is not None:
+                    (Path(workspace) / f"mutant_{counters['mutator']}.py").write_text(
+                        f"# mutant {counters['mutator']}\n"
+                    )
             return MutatorResponse(
                 summary=f"mutator call {counters['mutator']}",
                 hypothesis="should be faster",
@@ -139,21 +157,24 @@ def _load_population(tmp_path) -> Population:
 
 
 # ---------------------------------------------------------------------------
-# Cold start
+# Bootstrap phase (runs before the generation loop)
 # ---------------------------------------------------------------------------
+#
+# ``max_generations=0`` runs the bootstrap phase only (the generation loop is
+# an empty ``range(1, 1)``), which isolates bootstrap behavior. The mock runner
+# counts calls globally, so every multi-generation run has one extra gen-0
+# bootstrap round (one mutator + one judge + one profiler) in front.
 
 
-def test_cold_start_records_first_individual_with_no_parent(tmp_path, ref_file):
-    """Generation 1 child 1 has no parent (population empty); a passing
-    judge produces an Individual with parent_id=None and a perf_metric
-    from the profiler."""
+def test_bootstrap_succeeds_first_try(tmp_path, ref_file):
+    """Bootstrap produces the first passing implementation as a generation-0
+    seed with parent_id=None and a perf_metric from the profiler."""
     runner = _make_runner()
     result = _invoke_loop(
         tmp_path,
         ref_file,
         runner,
-        max_generations=1,
-        children_per_generation=1,
+        max_generations=0,  # bootstrap only
     )
     assert result is True
 
@@ -161,6 +182,7 @@ def test_cold_start_records_first_individual_with_no_parent(tmp_path, ref_file):
     assert len(pop) == 1
     seed = pop.all[0]
     assert seed.id == 1
+    assert seed.generation == 0
     assert seed.parent_id is None
     assert seed.passed is True
     assert seed.perf_metric == 10.0
@@ -168,10 +190,162 @@ def test_cold_start_records_first_individual_with_no_parent(tmp_path, ref_file):
     assert seed.commit  # an actual git SHA was recorded
 
 
-def test_cold_start_skips_profiler_when_judge_fails(tmp_path, ref_file):
-    """A failed cold-start child doesn't get profiled — its Individual
-    is recorded with passed=False and no commit."""
-    runner = _make_runner(judge_verdicts=["fail"])
+def test_bootstrap_fails_all_attempts_returns_false(tmp_path, ref_file):
+    """When every bootstrap attempt fails the judge, the run aborts before the
+    generation loop and returns False. Failed attempts are never profiled, and
+    with no mutator edits they record no commit."""
+    runner = _make_runner(judge_verdicts=["fail", "fail"])
+    result = _invoke_loop(
+        tmp_path,
+        ref_file,
+        runner,
+        bootstrap_max_attempts=2,
+        max_generations=0,
+    )
+    assert result is False
+    assert runner.counters["mutator"] == 2
+    assert runner.counters["judge"] == 2
+    assert runner.counters["profiler"] == 0  # judged-fail attempts skip profiling
+
+    pop = _load_population(tmp_path)
+    assert len(pop) == 2
+    for ind in pop.all:
+        assert ind.passed is False
+        assert ind.generation == 0
+        assert ind.commit is None  # no edits → no WIP snapshot
+    assert "needs work" in pop.all[0].feedback
+
+
+def test_bootstrap_failed_attempt_records_wip_seed_commit(tmp_path, ref_file):
+    """A failed bootstrap attempt whose mutator actually edited the workspace is
+    snapshotted to a WIP commit, so a later attempt can repair it in place."""
+    runner = _make_runner(judge_verdicts=["fail"], mutator_writes=True)
+    result = _invoke_loop(
+        tmp_path,
+        ref_file,
+        runner,
+        bootstrap_max_attempts=1,
+        max_generations=0,
+    )
+    assert result is False  # single attempt, failed → no seed
+
+    pop = _load_population(tmp_path)
+    assert len(pop) == 1
+    failed = pop.all[0]
+    assert failed.passed is False
+    assert failed.generation == 0
+    assert failed.parent_id is None
+    assert failed.commit  # WIP snapshot recorded because the tree changed
+
+
+def test_bootstrap_repairs_wip_seed_across_attempts(tmp_path, ref_file):
+    """A second bootstrap attempt fix-forwards from the most-recent WIP seed:
+    it checks that commit out and mutates on top, yielding a fresh WIP commit
+    distinct from the first."""
+    runner = _make_runner(judge_verdicts=["fail", "fail"], mutator_writes=True)
+    result = _invoke_loop(
+        tmp_path,
+        ref_file,
+        runner,
+        bootstrap_max_attempts=2,
+        max_generations=0,
+    )
+    assert result is False
+
+    pop = _load_population(tmp_path)
+    assert len(pop) == 2
+    first, second = pop.all
+    assert first.passed is False and second.passed is False
+    assert first.generation == 0 and second.generation == 0
+    assert first.parent_id is None and second.parent_id is None
+    # Both attempts snapshotted their (distinct) trees.
+    assert first.commit and second.commit
+    assert first.commit != second.commit
+
+
+def test_bootstrap_succeeds_after_repair(tmp_path, ref_file):
+    """Bootstrap that fails once then passes: the failed attempt is snapshotted,
+    the passing attempt repairs it in place and becomes the gen-0 seed. Only the
+    passing attempt is profiled."""
+    runner = _make_runner(judge_verdicts=["fail", "pass"], mutator_writes=True)
+    result = _invoke_loop(
+        tmp_path,
+        ref_file,
+        runner,
+        bootstrap_max_attempts=3,
+        max_generations=0,
+    )
+    assert result is True
+    assert runner.counters["profiler"] == 1  # only the passing attempt profiled
+
+    pop = _load_population(tmp_path)
+    assert len(pop) == 2
+    failed, seed = pop.all
+    assert failed.passed is False and failed.commit
+    assert seed.passed is True
+    assert seed.generation == 0
+    assert seed.parent_id is None
+    # The passing seed built on the repaired WIP tree → distinct commit.
+    assert seed.commit and seed.commit != failed.commit
+
+
+def test_bootstrap_prompt_uses_cold_start_section(tmp_path, ref_file):
+    """The bootstrap attempt sees the cold-start branch of the mutator prompt
+    (no parent block)."""
+    captured: list[str] = []
+    runner = _make_runner(capture_mutator_prompts=captured)
+    _invoke_loop(
+        tmp_path,
+        ref_file,
+        runner,
+        max_generations=0,
+    )
+    assert len(captured) == 1
+    prompt = captured[0]
+    assert "Cold start" in prompt
+    assert "Parent (the implementation you are mutating)" not in prompt
+
+
+def test_evolve_with_preexisting_passing_seed_skips_bootstrap(tmp_path, ref_file):
+    """A resumed run whose population already has a passing seed skips the
+    bootstrap phase entirely and evolves straight off the seed."""
+    # First run: bootstrap-only, creates a passing gen-0 seed with a real commit.
+    _invoke_loop(tmp_path, ref_file, _make_runner(), max_generations=0)
+    exp_envs = list((tmp_path / "exp_env").iterdir())
+    assert len(exp_envs) == 1
+    exp_name = exp_envs[0].name
+
+    # Second run resumes that exp dir; bootstrap must NOT be called, and a
+    # gen-1 child must be appended off the seed.
+    with patch("vibesys.loops.evolve.loop._bootstrap_seed") as spy:
+        result = _invoke_loop(
+            tmp_path,
+            ref_file,
+            _make_runner(),
+            exp_name=exp_name,
+            existing=True,
+            max_generations=1,
+            children_per_generation=1,
+        )
+        spy.assert_not_called()
+    assert result is True
+
+    pop = _load_population(tmp_path)
+    assert len(pop) == 2  # gen-0 seed + one gen-1 child (same exp dir, resumed)
+    seed, child = pop.all
+    assert seed.generation == 0 and seed.parent_id is None
+    assert child.parent_id == seed.id
+
+
+# ---------------------------------------------------------------------------
+# Multi-generation: parent selection + lineage tracking
+# ---------------------------------------------------------------------------
+
+
+def test_first_generation_uses_bootstrap_seed_as_parent(tmp_path, ref_file):
+    """Gen 1's child must be tagged with parent_id pointing at the bootstrap
+    seed."""
+    runner = _make_runner()
     result = _invoke_loop(
         tmp_path,
         ref_file,
@@ -180,28 +354,24 @@ def test_cold_start_skips_profiler_when_judge_fails(tmp_path, ref_file):
         children_per_generation=1,
     )
     assert result is True
-    assert runner.counters["mutator"] == 1
-    assert runner.counters["judge"] == 1
-    assert runner.counters["profiler"] == 0  # judged-fail children skip profiling
 
     pop = _load_population(tmp_path)
-    assert len(pop) == 1
-    failed = pop.all[0]
-    assert failed.passed is False
-    assert failed.commit is None
-    assert failed.perf_metric is None
-    assert "needs work" in failed.feedback
+    assert len(pop) == 2  # bootstrap seed + one gen-1 child
+    seed, child = pop.all
+    assert seed.generation == 0
+    assert seed.parent_id is None
+    assert child.parent_id == seed.id
+    assert child.passed is True
+    # Seed and child were profiled separately; two distinct stub values.
+    assert {seed.perf_metric, child.perf_metric} == {10.0, 11.0}
 
 
-# ---------------------------------------------------------------------------
-# Multi-generation: parent selection + lineage tracking
-# ---------------------------------------------------------------------------
-
-
-def test_second_generation_uses_first_passing_child_as_parent(tmp_path, ref_file):
-    """After gen 1 produces a passing seed, gen 2's child must be tagged
-    with parent_id pointing at that seed."""
-    runner = _make_runner()
+def test_failed_child_excluded_from_future_parent_pool(tmp_path, ref_file):
+    """Bootstrap: pass (the seed). Gen 1: fail (no commit, not eligible as
+    parent). Gen 2: must still parent off the seed — never off the failed
+    Gen 1 child."""
+    # Judge order: bootstrap(pass), gen1(fail), gen2(pass).
+    runner = _make_runner(judge_verdicts=["pass", "fail", "pass"])
     result = _invoke_loop(
         tmp_path,
         ref_file,
@@ -210,67 +380,24 @@ def test_second_generation_uses_first_passing_child_as_parent(tmp_path, ref_file
         children_per_generation=1,
     )
     assert result is True
-
-    pop = _load_population(tmp_path)
-    assert len(pop) == 2
-    seed, child = pop.all
-    assert seed.parent_id is None
-    assert child.parent_id == seed.id
-    assert child.passed is True
-    # Both individuals were profiled separately; their perf numbers should
-    # be the two distinct values our stub generated (10.0 and 11.0).
-    assert {seed.perf_metric, child.perf_metric} == {10.0, 11.0}
-
-
-def test_failed_child_excluded_from_future_parent_pool(tmp_path, ref_file):
-    """Gen 1: pass. Gen 2: fail (no commit, not eligible as parent).
-    Gen 3: must still parent off Gen 1 — never off the failed Gen 2."""
-    # 3 mutators, 3 judges (pass, fail, pass), 2 profilers (pass children only).
-    runner = _make_runner(judge_verdicts=["pass", "fail", "pass"])
-    result = _invoke_loop(
-        tmp_path,
-        ref_file,
-        runner,
-        max_generations=3,
-        children_per_generation=1,
-    )
-    assert result is True
     assert runner.counters["mutator"] == 3
     assert runner.counters["judge"] == 3
-    assert runner.counters["profiler"] == 2  # only the passes
+    assert runner.counters["profiler"] == 2  # only the passes (seed + gen2)
 
     pop = _load_population(tmp_path)
     assert len(pop) == 3
-    g1, g2, g3 = pop.all
-    assert g1.passed is True
-    assert g2.passed is False
-    assert g2.commit is None
-    # The third child must descend from the seed (id=1), NOT from the
-    # failed g2 (id=2). g2 had no commit, so it can't be selected.
-    assert g3.parent_id == g1.id
+    seed, g1, g2 = pop.all
+    assert seed.passed is True
+    assert g1.passed is False
+    assert g1.commit is None
+    # The gen-2 child must descend from the seed, NOT from the failed g1
+    # (which has no commit and can't be selected).
+    assert g2.parent_id == seed.id
 
 
 # ---------------------------------------------------------------------------
 # Mutator prompt content
 # ---------------------------------------------------------------------------
-
-
-def test_cold_start_prompt_uses_cold_start_section(tmp_path, ref_file):
-    """The first child sees the cold-start branch of the mutator prompt."""
-    captured: list[str] = []
-    runner = _make_runner(capture_mutator_prompts=captured)
-    _invoke_loop(
-        tmp_path,
-        ref_file,
-        runner,
-        max_generations=1,
-        children_per_generation=1,
-    )
-    assert len(captured) == 1
-    prompt = captured[0]
-    assert "Cold start" in prompt
-    # No parent block when the population is empty.
-    assert "Parent (the implementation you are mutating)" not in prompt
 
 
 # ---------------------------------------------------------------------------
@@ -309,7 +436,7 @@ def test_pareto_mode_records_metrics_dict_on_individuals(tmp_path, ref_file):
         tmp_path,
         ref_file,
         runner,
-        max_generations=2,
+        max_generations=1,  # bootstrap seed + one gen-1 child
         children_per_generation=1,
         objectives=objectives,
         frontier_bias=1.0,
@@ -366,8 +493,7 @@ def test_pareto_addendum_appears_in_profiler_prompt(tmp_path, ref_file):
         tmp_path,
         ref_file,
         runner,
-        max_generations=1,
-        children_per_generation=1,
+        max_generations=0,  # only the bootstrap seed is profiled
         objectives=objectives,
         frontier_bias=1.0,
     )
@@ -387,8 +513,7 @@ def test_no_objectives_keeps_metrics_empty_and_legacy_behavior(tmp_path, ref_fil
         tmp_path,
         ref_file,
         runner,
-        max_generations=1,
-        children_per_generation=1,
+        max_generations=0,
         # Note: no `objectives` kwarg → single-objective mode.
     )
     assert result is True
@@ -398,21 +523,112 @@ def test_no_objectives_keeps_metrics_empty_and_legacy_behavior(tmp_path, ref_fil
 
 
 def test_second_child_prompt_includes_parent_block(tmp_path, ref_file):
-    """Gen 2's mutator prompt mentions the parent's perf_metric — one of
-    the few signals the mutator has to ground its change in fitness."""
+    """Gen 1's mutator prompt mentions the parent (bootstrap seed) perf_metric —
+    one of the few signals the mutator has to ground its change in fitness."""
     captured: list[str] = []
     runner = _make_runner(capture_mutator_prompts=captured)
     _invoke_loop(
         tmp_path,
         ref_file,
         runner,
-        max_generations=2,
+        max_generations=1,
         children_per_generation=1,
     )
-    assert len(captured) == 2
-    gen2_prompt = captured[1]
-    assert "Cold start" not in gen2_prompt
-    assert "Parent (the implementation you are mutating)" in gen2_prompt
+    assert len(captured) == 2  # bootstrap (cold-start) + gen-1 (parent block)
+    gen1_prompt = captured[1]
+    assert "Cold start" not in gen1_prompt
+    assert "Parent (the implementation you are mutating)" in gen1_prompt
     # The seed's perf_metric (10.0) was emitted by the profiler and should
     # appear in the parent block.
-    assert "10.0" in gen2_prompt
+    assert "10.0" in gen1_prompt
+
+
+# ---------------------------------------------------------------------------
+# Helper units: failure lessons, WIP-seed lookup, per-candidate Modal app
+# ---------------------------------------------------------------------------
+
+
+def _ind(id_, *, passed=False, parent_id=None, commit=None, feedback=""):
+    return Individual(
+        id=id_,
+        generation=1,
+        parent_id=parent_id,
+        passed=passed,
+        commit=commit,
+        feedback=feedback,
+    )
+
+
+def test_recent_failure_lessons_dedupes_and_orders_most_recent_first():
+    pop = Population()
+    pop.add(_ind(1, feedback="crash: CUDA out of memory"))
+    pop.add(_ind(2, feedback="crash: CUDA out of memory"))  # duplicate → collapsed
+    pop.add(_ind(3, feedback="server never bound to port"))
+    pop.add(_ind(4, passed=True, feedback="ignored because it passed"))
+
+    lessons = _recent_failure_lessons(pop, limit=3)
+    assert lessons == ["server never bound to port", "crash: CUDA out of memory"]
+
+
+def test_recent_failure_lessons_truncates_long_feedback():
+    pop = Population()
+    pop.add(_ind(1, feedback="x" * 5000))
+    (lesson,) = _recent_failure_lessons(pop, limit=1, max_chars=100)
+    assert lesson.endswith("…")
+    assert len(lesson) <= 102  # 100 chars + space + ellipsis
+
+
+def test_latest_wip_seed_returns_most_recent_failed_seed_with_commit():
+    pop = Population()
+    pop.add(_ind(1, commit="aaa"))  # failed cold-start seed
+    pop.add(_ind(2, commit="bbb"))  # newer failed cold-start seed
+    pop.add(_ind(3, passed=True, commit="ccc"))  # passing → not a WIP seed
+    pop.add(_ind(4, parent_id=2, commit="ddd"))  # has a parent → not cold-start
+
+    seed = _latest_wip_seed(pop)
+    assert seed is not None and seed.id == 2
+
+
+def test_latest_wip_seed_none_when_no_snapshotted_failure():
+    pop = Population()
+    pop.add(_ind(1, commit=None))  # failed but never snapshotted
+    pop.add(_ind(2, passed=True, commit="ccc"))
+    assert _latest_wip_seed(pop) is None
+
+
+def test_candidate_runtime_notes_substitutes_per_candidate_app_name():
+    base = "run-20260720-abcd1234-llama3"
+    ctx = SimpleNamespace(
+        run_environment_view=SimpleNamespace(
+            modal_app_name=base,
+            prompt_notes=f"Deploy to Modal app {base}; endpoint {base}-web.",
+        )
+    )
+    notes, app = _candidate_runtime_notes(ctx, generation=3, child_idx=2)
+    expected_app = candidate_modal_app_name(base, 3, 2)
+    assert app == expected_app
+    # Every occurrence of the base name is swapped for the candidate app name
+    # (which itself starts with the base + suffix, so the base survives only as
+    # that prefix — there is no bare, un-suffixed occurrence left).
+    assert notes == f"Deploy to Modal app {expected_app}; endpoint {expected_app}-web."
+    assert notes.count(expected_app) == 2
+
+
+def test_candidate_runtime_notes_noop_without_modal_app():
+    notes_in = "Local run; no Modal app."
+    ctx = SimpleNamespace(
+        run_environment_view=SimpleNamespace(modal_app_name=None, prompt_notes=notes_in)
+    )
+    notes, app = _candidate_runtime_notes(ctx, generation=1, child_idx=1)
+    assert app is None
+    assert notes == notes_in
+
+
+def test_candidate_modal_app_name_suffix_and_length():
+    short = candidate_modal_app_name("run-abc", 2, 5)
+    assert short == "run-abc-g2c5"
+
+    long_base = "r" * 80
+    name = candidate_modal_app_name(long_base, 12, 7)
+    assert name.endswith("-g12c7")
+    assert len(name) <= 63

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -246,6 +246,18 @@ def test_profiler_none_is_valid_with_modal(builder_name, validator_name, tmp_pat
     assert args.input_bundle.root == bundle.resolve()
 
 
+def test_validate_evolve_rejects_nonpositive_bootstrap_attempts(tmp_path):
+    """--bootstrap-max-attempts must be >= 1; 0 is a configuration error."""
+    import vibesys.main as cli
+
+    bundle = _write_input_bundle(tmp_path)
+    parser = cli._build_evolve_parser()
+    args = parser.parse_args(["--bootstrap-max-attempts", "0", "--input", str(bundle)])
+    assert args.bootstrap_max_attempts == 0
+    with pytest.raises(ConfigurationError):
+        cli._validate_evolve(args)
+
+
 @pytest.mark.parametrize(
     "argv",
     [


### PR DESCRIPTION
## Problem

On a fresh run the evolve population is empty, so the first children had to
**cold-start** — write an entire server from scratch in one mutator step, which
usually fails the judge. The in-loop fix-forward heuristic that papered over this
interleaved the subtlest code in `run_evolve_loop` (WIP snapshotting, fix-forward
checkout, `is_cold_start` special-casing) into the generation loop.

Two orthogonal Modal problems also broke runs:
- A **shared Modal app name** meant one candidate's cumulative app logs poisoned
  the next candidate's judge (every candidate judged identically).
- **Meta-tensor loads** gave the implementer no guidance, so from-scratch servers
  failed to materialize weights.

## Solution

Cleanly separate *bootstrapping a working seed* from *optimizing it*.

- **New bootstrap phase (`_bootstrap_seed`)** runs implementer → judge (→ profiler)
  iterations **before** the generation loop until the first judge-passing
  implementation exists, recorded as a **generation-0 seed**. Attempt 1 writes from
  scratch; later attempts repair-forward the most-recent failed WIP seed
  (fix-forward, not restart). Bounded by `--bootstrap-max-attempts` (default 5);
  exhausting it aborts the run before the generation loop. Skipped on `--resume`
  when a passing individual already exists.
- **Simplified generation loop:** a passing parent always exists after bootstrap,
  so the cold-start / WIP / `is_cold_start` branches are gone. `select_parent`
  returning `None` (no passer with a scalar perf_metric) falls back to the latest
  passer instead of cold-starting.
- **Kept the two orthogonal Modal fixes:** per-candidate Modal app name
  (`_candidate_runtime_notes` / `run_environment.py`) and the meta-tensor
  implementer lesson.

### Architecture

`_bootstrap_seed` reuses the existing evolve helpers verbatim (`_run_mutator`,
`_run_judge`, `_run_profiler`, `_candidate_runtime_notes`, `_latest_wip_seed`,
`_recent_failure_lessons`) and owns all from-scratch / fix-forward repair logic.
The generation loop is reduced to "mutate a passing parent."

## Verification

### Correctness properties

- The generation loop never runs without a passing parent (bootstrap guarantees a
  gen-0 seed, or the run aborts).
- Failed bootstrap attempts are recorded as `passed=False` individuals (excluded
  from selection) and only tagged with a WIP commit when the tree actually changed.
- `--resume` with an existing passing seed skips bootstrap; `--resume` with only
  failed WIP seeds re-enters bootstrap and fix-forwards.
- `--bootstrap-max-attempts < 1` is a configuration error.

### Testing

- `uv run ruff check` + `uv run ruff format --check` + `uv run pyright` — clean on touched files.
- `uv run python -m pytest tests/loops/evolve` — 56 passed.
- `uv run python -m pytest tests/test_main.py` — green (added the bootstrap-arg validation test).
- `diff-cover` vs `origin/main` — **89%** patch coverage (≥ 80% gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)