### PR TITLE
Llama-3-8B example: Modal-ready accuracy + Pareto serving objective

### DIFF
--- a/examples/model-serving/Llama-3-8B/OBJECTIVE.md
+++ b/examples/model-serving/Llama-3-8B/OBJECTIVE.md
@@ -1,6 +1,65 @@
 # Objective — Llama-3-8B inference server
 
-Maximize **output token throughput (tok/s)** on a single H100 while keeping accuracy within the accuracy checker's tolerance. Build an OpenAI-compatible `/v1/chat/completions` and `/v1/completions` server.
+Serve Llama-3-8B on a single H100 with the best **throughput/latency trade-off**
+under a realistic concurrent load, while keeping accuracy within the accuracy
+checker's tolerance. Build an OpenAI-compatible `/v1/chat/completions` and
+`/v1/completions` server.
+
+This run is scored on a **Pareto frontier over two axes** (see `objectives.toml`),
+both read from the benchmark's `--output-json` output:
+
+- **`aggregate_throughput`** — output tokens/sec, **maximize**.
+- **`p99_latency_ms`** — p99 end-to-end request latency in milliseconds, **minimize**.
+
+A candidate is admitted to the frontier if it is non-dominated: at least as good
+as the parent on both axes and strictly better on one. Raising throughput by
+inflating tail latency (e.g. unbounded batch sizes) is a real trade-off, not a
+free win — it moves you along the frontier, it does not dominate.
+
+## Benchmark protocol — run EXACTLY this
+
+Both axes are only comparable across candidates if every candidate is measured
+under the **same fixed saturating load**. When you (the profiler) run the
+benchmark, use these flags verbatim and change **only** `--url` (the live server)
+and `--output-json` (the output path):
+
+```
+<benchmark_command> --url <SERVER_URL> --concurrency 16 --duration 20 --max-tokens 128 --temperature 0 --output-json <PATH>
+```
+
+- `--concurrency 16` drives a **closed-loop** load of exactly 16 in-flight
+  requests, so `aggregate_throughput` measures true server capacity (not the
+  arrival rate) and `p99_latency_ms` measures tail latency under contention.
+- Do **not** use `--num-requests 1`, do not lower `--concurrency`, and do not
+  shorten `--max-tokens`. A single-request or tiny workload makes throughput
+  degenerate into first-token latency and gives the search no signal about
+  batching or scheduling.
+- The fixed 16-way load is also what bounds the frontier: no candidate can "win"
+  the latency axis by serving fewer requests, because every candidate faces the
+  identical load. A server that fails or starves most requests loses throughput
+  and trips the benchmark-sanity / accuracy gates.
+
+## Headline metric (`perf_metric`) and Pareto metrics — canonical fields, do not leave null
+
+Headline metric: `aggregate_throughput` (output tok/s)
+
+The scalar `perf_metric` (used for plateau detection and the scalar fallback) is
+**`aggregate_throughput`** read directly from the benchmark JSON. In addition,
+because this is a Pareto run, populate `ProfilerSummary.metrics` with **both**
+objective values using these exact keys, read verbatim from the benchmark JSON:
+
+```
+metrics = {
+  "aggregate_throughput": <benchmark JSON aggregate_throughput, float, tok/s>,
+  "p99_latency_ms":       <benchmark JSON p99_latency_ms, float, ms>,
+}
+```
+
+Also set `perf_unit = "tok/s"`. Read every value verbatim — do NOT derive,
+invert, or substitute another field. Only set a metric to `null` if the server
+never served a single successful request (the benchmark produced no data for
+that field). Reporting `null` when a value was measured discards the run's
+fitness and drops the candidate from the frontier.
 
 ## Notes
 
@@ -8,6 +67,9 @@ Maximize **output token throughput (tok/s)** on a single H100 while keeping accu
 - Implement model layers explicitly (own attention / MLP / norm / RoPE); use
   `transformers` only as a utility for config / tokenizer / weight loading.
 - FP16/BF16 is a reasonable baseline; quantization is an optimization, not a
-  prerequisite.
-- Benchmark harness drives the server; it reports req/s and tok/s. Prefer
-  tok/s as the primary metric.
+  prerequisite. Continuous batching / paged-KV / CUDA-graph capture are the
+  levers that move both axes at once under the concurrent load above.
+- Both the benchmark and the accuracy checker drive the **running server over
+  HTTP** (no local model import). The accuracy checker enforces reference-free
+  gates — sentinel-echo, known-answer, and greedy determinism — so a real
+  prompt-conditioned forward pass is required; canned/echoed output fails.

--- a/examples/model-serving/Llama-3-8B/OBJECTIVE.md
+++ b/examples/model-serving/Llama-3-8B/OBJECTIVE.md
@@ -66,9 +66,6 @@ fitness and drops the candidate from the frontier.
 - Text-generation, dense causal LM. Hopper-class hardware assumed.
 - Implement model layers explicitly (own attention / MLP / norm / RoPE); use
   `transformers` only as a utility for config / tokenizer / weight loading.
-- FP16/BF16 is a reasonable baseline; quantization is an optimization, not a
-  prerequisite. Continuous batching / paged-KV / CUDA-graph capture are the
-  levers that move both axes at once under the concurrent load above.
 - Both the benchmark and the accuracy checker drive the **running server over
   HTTP** (no local model import). The accuracy checker enforces reference-free
   gates — sentinel-echo, known-answer, and greedy determinism — so a real

--- a/examples/model-serving/Llama-3-8B/accuracy_checker/README.md
+++ b/examples/model-serving/Llama-3-8B/accuracy_checker/README.md
@@ -1,3 +1,22 @@
-Accuracy checker inputs for Llama-3-8B.
+Accuracy checker for Llama-3-8B (service-style).
 
-Run: `python checker.py`
+The checker drives a **running** OpenAI-compatible server over HTTP — it does
+not import the candidate's model or load weights locally, so it works the same
+against a local, Docker, or remote Modal server. Point it at the server URL:
+
+```
+python checker.py --url http://localhost:8000
+python checker.py --url https://<app>.modal.run --seed 0
+```
+
+Because there is no local GPU reference to diff against, correctness is
+established with three reference-free gates (see `--help` for thresholds):
+
+1. **Sentinel-echo** — each request embeds a random token the prompt tells the
+   model to reproduce; canned/templated servers can't reproduce a fresh token.
+2. **Known-answer** — near-deterministic factual prompts at temperature 0
+   (capital of France → Paris, 1+1 → 2, …); a prompt echoer fails these.
+3. **Greedy determinism** — the same prompt twice at temperature 0 must match.
+
+Exit code 0 iff there are no transport errors and all three gates clear their
+thresholds. Use `--output-json <path>` to dump per-request detail.

--- a/examples/model-serving/Llama-3-8B/accuracy_checker/checker.py
+++ b/examples/model-serving/Llama-3-8B/accuracy_checker/checker.py
@@ -1,256 +1,391 @@
 """
-Accuracy checker: verify that the custom LLaMA model implementation
-produces identical output to the HuggingFace transformers
-AutoModelForCausalLM reference.
+Accuracy checker for the Llama-3-8B serving system (service-style).
 
-Both paths use greedy decoding (temperature=0) so outputs must match exactly.
+This checker drives a *running* OpenAI-compatible server over HTTP — it does
+NOT import the candidate's model or load any weights locally. That makes it
+work identically whether the server runs on the local host, in Docker, or on a
+remote Modal GPU: the checker only needs the server URL.
 
-Usage:
-    CUDA_VISIBLE_DEVICES=0 .venv/bin/python accuracy_checker.py
-    CUDA_VISIBLE_DEVICES=0 .venv/bin/python accuracy_checker.py --model-dir ../model
+Because there is no local GPU reference to diff against, correctness is
+established with three reference-free gates that a real Llama-3 forward pass
+passes and reward-hacking shortcuts (canned text, prompt echoers, schema
+synthesizers) fail:
+
+  1. Sentinel-echo rate  — each request embeds a random sentinel token the
+     prompt instructs the model to reproduce. A server that ignores the prompt
+     and returns canned/templated text cannot reproduce a fresh random token.
+     (This is the framework's canonical anti-reward-hack gate.)
+
+  2. Known-answer rate   — near-deterministic factual prompts at temperature 0
+     whose answer is fixed (capital of France -> Paris, 1+1 -> 2, ...). A
+     prompt echoer passes the sentinel gate but fails this one; a canned
+     "Paris" server fails the sentinel gate. Only a model that actually runs
+     inference passes both.
+
+  3. Greedy determinism  — the same prompt sent twice at temperature 0 must
+     yield identical output. Catches nondeterministic / sampling-when-it-should-
+     not decoders.
+
+Exit code 0 iff there are no transport errors AND all three gates clear their
+thresholds; exit 1 otherwise.
+
+Usage (server must already be running):
+
+    python checker.py --url http://localhost:8000
+    python checker.py --url https://<app>.modal.run --seed 0
 """
 
+from __future__ import annotations
+
 import argparse
+import asyncio
+import json
+import random
+import string
 import sys
-import time
-from pathlib import Path
 
-import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
+import httpx
+
+# ---------------------------------------------------------------------------
+# HTTP helpers — stream SSE from the OpenAI-compatible endpoints
+# ---------------------------------------------------------------------------
 
 
-def _load_custom_model_class():
-    """Import VibeServeModel from main.py."""
+async def _stream_text(
+    client: httpx.AsyncClient,
+    url: str,
+    body: dict,
+    request_timeout: float,
+) -> tuple[str, str | None]:
+    """POST a streaming request and concatenate the generated text.
+
+    Returns ``(text, error)``. ``error`` is None on success. Handles both the
+    completions shape (``choices[0].text``) and the chat shape
+    (``choices[0].delta.content``).
+    """
+    parts: list[str] = []
     try:
-        from main import VibeServeModel
-    except ImportError as exc:
-        raise RuntimeError(
-            "Could not import VibeServeModel from main.py.\n"
-            "Expected main.py to export:\n"
-            "  class VibeServeModel with:\n"
-            "    - VibeServeModel.from_pretrained(model_dir, device, dtype) -> model\n"
-            "    - model.generate(input_ids, max_new_tokens=N) -> token_ids tensor\n"
-        ) from exc
-    return VibeServeModel
+        async with client.stream("POST", url, json=body, timeout=request_timeout) as resp:
+            resp.raise_for_status()
+            async for raw in resp.aiter_lines():
+                if not raw.startswith("data: "):
+                    continue
+                payload = raw[len("data: ") :]
+                if payload.strip() == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                choice = (chunk.get("choices") or [{}])[0]
+                # completions vs chat
+                text = choice.get("text")
+                if text is None:
+                    text = (choice.get("delta") or {}).get("content")
+                if text:
+                    parts.append(text)
+    except Exception as exc:  # noqa: BLE001 - report any transport failure
+        return "".join(parts), f"{type(exc).__name__}: {exc}"
+    return "".join(parts), None
+
+
+async def complete(
+    client: httpx.AsyncClient,
+    base_url: str,
+    endpoint: str,
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+    request_timeout: float,
+) -> tuple[str, str | None]:
+    """Raw /v1/completions call."""
+    url = base_url.rstrip("/") + endpoint
+    body = {
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": True,
+    }
+    return await _stream_text(client, url, body, request_timeout)
+
+
+async def chat(
+    client: httpx.AsyncClient,
+    base_url: str,
+    endpoint: str,
+    messages: list[dict],
+    max_tokens: int,
+    temperature: float,
+    request_timeout: float,
+) -> tuple[str, str | None]:
+    """Chat /v1/chat/completions call."""
+    url = base_url.rstrip("/") + endpoint
+    body = {
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": True,
+    }
+    return await _stream_text(client, url, body, request_timeout)
 
 
 # ---------------------------------------------------------------------------
-# Test samples — diverse prompts covering various scenarios
+# Gate 1: sentinel echo
 # ---------------------------------------------------------------------------
 
-RAW_COMPLETION_SAMPLES: list[tuple[str, int, str]] = [
-    ("The capital of France is", 15, "short factual completion"),
-    ("Once upon a time, in a land far away,", 50, "story continuation"),
-    ('def fibonacci(n):\n    """Return the n-th Fibonacci number."""\n', 40, "code completion"),
-    ("1 + 1 =", 5, "arithmetic"),
-    ("A B C D E F G H I J K L M N O P Q R S T U V W X Y Z A B C D E F G", 20, "alphabet pattern"),
-    (
-        "The following is a detailed explanation of how neural networks work. "
-        "Neural networks are computing systems inspired by biological neural networks. "
-        "They consist of layers of interconnected nodes or neurons. "
-        "Each connection has a weight that adjusts as learning proceeds. "
-        "The network processes information using a connectionist approach. "
-        "In summary, the key takeaway is that",
-        30,
-        "long prompt completion",
-    ),
-    ("Question: What is the speed of light?\nAnswer:", 20, "Q&A format"),
-    ("The year 2024 was followed by the year", 10, "number continuation"),
-    ("Hello", 15, "single word prompt"),
-    ('{"name": "Alice", "age":', 10, "JSON completion"),
+
+def _make_sentinel(rng: random.Random) -> str:
+    """A short, tokenizer-friendly random uppercase word unlikely to be canned."""
+    return "".join(rng.choice(string.ascii_uppercase) for _ in range(8))
+
+
+async def gate_sentinel_echo(
+    client: httpx.AsyncClient,
+    args: argparse.Namespace,
+    rng: random.Random,
+) -> list[dict]:
+    results: list[dict] = []
+    for _ in range(args.num_sentinel):
+        sentinel = _make_sentinel(rng)
+        messages = [
+            {
+                "role": "user",
+                "content": (
+                    f"Repeat the following word exactly once, in uppercase, and "
+                    f"output nothing else: {sentinel}"
+                ),
+            }
+        ]
+        text, err = await chat(
+            client,
+            args.url,
+            args.chat_endpoint,
+            messages,
+            max_tokens=16,
+            temperature=0.0,
+            request_timeout=args.request_timeout,
+        )
+        ok = err is None and sentinel in text.upper()
+        results.append(
+            {
+                "gate": "sentinel",
+                "sentinel": sentinel,
+                "output": text,
+                "error": err,
+                "ok": ok,
+            }
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Gate 2: known-answer factual prompts (chat, temperature 0)
+# ---------------------------------------------------------------------------
+
+# (user message, list of acceptable answer substrings [case-insensitive])
+KNOWN_ANSWERS: list[tuple[str, list[str]]] = [
+    ("What is the capital of France? Answer with a single word.", ["paris"]),
+    ("What is 1 + 1? Answer with a single number.", ["2", "two"]),
+    ("What is the opposite of 'hot'? Answer with a single word.", ["cold"]),
+    ("What color is a clear daytime sky? Answer with a single word.", ["blue"]),
+    ("What is 7 multiplied by 6? Answer with a single number.", ["42", "forty-two", "forty two"]),
+    ("How many days are in a week? Answer with a single number.", ["7", "seven"]),
+    ("What is the chemical symbol for water? Answer with a single token.", ["h2o", "h₂o"]),
+    ("Complete the sequence with one number: 2, 4, 6, 8,", ["10", "ten"]),
 ]
 
-CHAT_SAMPLES: list[tuple[list[dict[str, str]], int, str]] = [
-    (
-        [{"role": "user", "content": "What is 2+2? Answer in one word."}],
-        10,
-        "simple math chat",
-    ),
-    (
-        [{"role": "user", "content": "Write a haiku about programming."}],
-        40,
-        "creative chat",
-    ),
-    (
-        [
-            {"role": "user", "content": "What is Python?"},
-            {"role": "assistant", "content": "Python is a high-level programming language."},
-            {"role": "user", "content": "What are its main features?"},
-        ],
-        40,
-        "multi-turn chat",
-    ),
-    (
-        [{"role": "user", "content": "Translate to French: 'Good morning, how are you?'"}],
-        25,
-        "translation chat",
-    ),
+
+async def gate_known_answers(
+    client: httpx.AsyncClient,
+    args: argparse.Namespace,
+) -> list[dict]:
+    results: list[dict] = []
+    for question, accepted in KNOWN_ANSWERS:
+        messages = [{"role": "user", "content": question}]
+        text, err = await chat(
+            client,
+            args.url,
+            args.chat_endpoint,
+            messages,
+            max_tokens=24,
+            temperature=0.0,
+            request_timeout=args.request_timeout,
+        )
+        low = text.lower()
+        ok = err is None and any(a in low for a in accepted)
+        results.append(
+            {
+                "gate": "known_answer",
+                "question": question,
+                "accepted": accepted,
+                "output": text,
+                "error": err,
+                "ok": ok,
+            }
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Gate 3: greedy determinism (same prompt twice at temperature 0 == identical)
+# ---------------------------------------------------------------------------
+
+DETERMINISM_PROMPTS: list[str] = [
+    "The capital of France is",
+    "Once upon a time, in a land far away,",
+    "def fibonacci(n):\n    # return the n-th Fibonacci number\n",
+    "The following is a list of the planets in the Solar System:",
 ]
 
 
+async def gate_determinism(
+    client: httpx.AsyncClient,
+    args: argparse.Namespace,
+) -> list[dict]:
+    results: list[dict] = []
+    for prompt in DETERMINISM_PROMPTS:
+        out_a, err_a = await complete(
+            client, args.url, args.endpoint, prompt, args.det_max_tokens, 0.0, args.request_timeout
+        )
+        out_b, err_b = await complete(
+            client, args.url, args.endpoint, prompt, args.det_max_tokens, 0.0, args.request_timeout
+        )
+        err = err_a or err_b
+        ok = err is None and out_a == out_b and len(out_a) > 0
+        results.append(
+            {
+                "gate": "determinism",
+                "prompt": prompt,
+                "output_a": out_a,
+                "output_b": out_b,
+                "error": err,
+                "ok": ok,
+            }
+        )
+    return results
+
+
 # ---------------------------------------------------------------------------
-# Reference: HuggingFace model.generate()
+# Driver
 # ---------------------------------------------------------------------------
 
 
-@torch.inference_mode()
-def generate_reference(model, tokenizer, prompt_text, max_new_tokens, device):
-    inputs = tokenizer(prompt_text, return_tensors="pt").to(device)
-    prompt_len = inputs.input_ids.shape[1]
-    output_ids = model.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
-    return output_ids[0, prompt_len:].tolist()
+def _rate(results: list[dict]) -> tuple[int, int, float]:
+    ok = sum(1 for r in results if r["ok"])
+    n = len(results)
+    return ok, n, (ok / n if n else 0.0)
 
 
-# ---------------------------------------------------------------------------
-# Custom model: uses VibeServeModel.generate()
-# ---------------------------------------------------------------------------
-
-
-@torch.inference_mode()
-def generate_custom(model, tokenizer, prompt_text, max_new_tokens, device):
-    """Generate using the custom model's .generate() method."""
-    inputs = tokenizer(prompt_text, return_tensors="pt").to(device)
-    output_ids = model.generate(inputs.input_ids, max_new_tokens=max_new_tokens)
-    prompt_len = inputs.input_ids.shape[1]
-    return output_ids[0, prompt_len:].tolist()
-
-
-# ---------------------------------------------------------------------------
-# Comparison logic
-# ---------------------------------------------------------------------------
-
-
-def compare_outputs(ref_ids, custom_ids, tokenizer):
-    ref_text = tokenizer.decode(ref_ids, skip_special_tokens=True)
-    custom_text = tokenizer.decode(custom_ids, skip_special_tokens=True)
-
-    if ref_ids == custom_ids:
-        return True, f"EXACT match ({len(ref_ids)} tokens): {ref_text!r}"
-
-    min_len = min(len(ref_ids), len(custom_ids))
-    first_diff = min_len
-    for i in range(min_len):
-        if ref_ids[i] != custom_ids[i]:
-            first_diff = i
-            break
-
-    detail = (
-        f"MISMATCH at token {first_diff}.\n"
-        f"  Reference ({len(ref_ids):3d} tokens): {ref_text!r}\n"
-        f"  Custom    ({len(custom_ids):3d} tokens): {custom_text!r}\n"
-        f"  Ref  ids[{first_diff}:]: {ref_ids[first_diff : first_diff + 10]}\n"
-        f"  Cust ids[{first_diff}:]: {custom_ids[first_diff : first_diff + 10]}"
+async def run(args: argparse.Namespace) -> int:
+    rng = random.Random(args.seed)
+    print(f"Accuracy check against {args.url} (seed={args.seed})")
+    print(
+        f"  gates: sentinel-echo (n={args.num_sentinel}, min {args.min_sentinel_rate:.0%}), "
+        f"known-answer (n={len(KNOWN_ANSWERS)}, min {args.min_known_rate:.0%}), "
+        f"determinism (n={len(DETERMINISM_PROMPTS)}, min {args.min_determinism_rate:.0%})"
     )
-    return False, detail
+
+    async with httpx.AsyncClient() as client:
+        sentinel = await gate_sentinel_echo(client, args, rng)
+        known = await gate_known_answers(client, args)
+        determinism = await gate_determinism(client, args)
+
+    all_results = sentinel + known + determinism
+    transport_errors = [r for r in all_results if r["error"] is not None]
+
+    s_ok, s_n, s_rate = _rate(sentinel)
+    k_ok, k_n, k_rate = _rate(known)
+    d_ok, d_n, d_rate = _rate(determinism)
+
+    # Print per-gate detail
+    for label, rows in (
+        ("SENTINEL", sentinel),
+        ("KNOWN-ANSWER", known),
+        ("DETERMINISM", determinism),
+    ):
+        print(f"\n{label}")
+        for r in rows:
+            status = "OK  " if r["ok"] else "FAIL"
+            preview = (r.get("output") or r.get("output_a") or "").strip().replace("\n", " ")[:70]
+            extra = r.get("sentinel") or r.get("question") or r.get("prompt") or ""
+            extra = str(extra).replace("\n", " ")[:50]
+            err = f" err={r['error']}" if r["error"] else ""
+            print(f"  {status} [{extra!r}] -> {preview!r}{err}")
+
+    print("\n" + "=" * 60)
+    print("  Llama-3-8B service accuracy check")
+    print("=" * 60)
+    print(f"Sentinel-echo:   {s_ok}/{s_n} ({s_rate:.0%})   [min {args.min_sentinel_rate:.0%}]")
+    print(f"Known-answer:    {k_ok}/{k_n} ({k_rate:.0%})   [min {args.min_known_rate:.0%}]")
+    print(f"Determinism:     {d_ok}/{d_n} ({d_rate:.0%})   [min {args.min_determinism_rate:.0%}]")
+    print(f"Transport errors: {len(transport_errors)}")
+
+    passed = (
+        not transport_errors
+        and s_rate >= args.min_sentinel_rate
+        and k_rate >= args.min_known_rate
+        and d_rate >= args.min_determinism_rate
+    )
+
+    if args.output_json:
+        from pathlib import Path
+
+        summary = {
+            "url": args.url,
+            "seed": args.seed,
+            "sentinel_rate": s_rate,
+            "known_answer_rate": k_rate,
+            "determinism_rate": d_rate,
+            "num_transport_errors": len(transport_errors),
+            "thresholds": {
+                "min_sentinel_rate": args.min_sentinel_rate,
+                "min_known_rate": args.min_known_rate,
+                "min_determinism_rate": args.min_determinism_rate,
+            },
+            "passed": passed,
+            "results": all_results,
+        }
+        Path(args.output_json).write_text(json.dumps(summary, indent=2))
+        print(f"\nWrote detailed results to {args.output_json}")
+
+    print("\n" + ("ACCURACY CHECK PASSED" if passed else "ACCURACY CHECK FAILED"))
+    return 0 if passed else 1
 
 
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
-
-def main():
-    parser = argparse.ArgumentParser(description="Accuracy checker: custom model vs HF reference")
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Service-style accuracy checker for the Llama-3-8B server. Drives a "
+            "running OpenAI-compatible server over HTTP (no local weights) and "
+            "asserts sentinel-echo, known-answer, and greedy-determinism gates."
+        )
+    )
+    parser.add_argument("--url", default="http://localhost:8000", help="Server base URL")
+    parser.add_argument("--endpoint", default="/v1/completions", help="Completions endpoint path")
     parser.add_argument(
-        "--model-dir",
-        type=str,
-        default="../model",
-        help="Local path to model weights directory (default: ../model)",
+        "--chat-endpoint", default="/v1/chat/completions", help="Chat completions endpoint path"
     )
-    parser.add_argument("--device", type=str, default="cuda:0")
+    parser.add_argument(
+        "--num-sentinel", type=int, default=6, help="Number of sentinel-echo probes"
+    )
+    parser.add_argument(
+        "--det-max-tokens", type=int, default=32, help="Tokens per determinism probe"
+    )
+    parser.add_argument(
+        "--seed",
+        type=lambda s: None if s.lower() in ("none", "random") else int(s),
+        default=0,
+        help="RNG seed for sentinels (int, or 'random').",
+    )
+    parser.add_argument("--min-sentinel-rate", type=float, default=0.90)
+    parser.add_argument("--min-known-rate", type=float, default=0.75)
+    parser.add_argument("--min-determinism-rate", type=float, default=0.90)
+    parser.add_argument("--request-timeout", type=float, default=120.0)
+    parser.add_argument("--output-json", type=str, default=None)
     args = parser.parse_args()
 
-    model_dir = str(Path(args.model_dir).resolve())
-    dtype = torch.float16
-
-    # --- Load tokenizer (from local path) ---
-    print(f"Loading tokenizer from: {model_dir}")
-    tokenizer = AutoTokenizer.from_pretrained(model_dir)
-    if tokenizer.pad_token is None:
-        tokenizer.pad_token = tokenizer.eos_token
-
-    # --- Build test suite (before loading models to save GPU time) ---
-    test_cases: list[tuple[str, int, str]] = list(RAW_COMPLETION_SAMPLES)
-
-    has_chat_template = hasattr(tokenizer, "apply_chat_template") and tokenizer.chat_template
-    for messages, max_tokens, desc in CHAT_SAMPLES:
-        if has_chat_template:
-            prompt = tokenizer.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=True
-            )
-        else:
-            prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages) + "\nassistant:"
-        test_cases.append((prompt, max_tokens, f"[chat] {desc}"))
-
-    # --- Generate reference outputs with HF model, then unload ---
-    print(f"\nLoading HF reference model on {args.device} ...")
-    t0 = time.perf_counter()
-    ref_model = AutoModelForCausalLM.from_pretrained(
-        model_dir,
-        torch_dtype=dtype,
-        device_map=args.device,
-        attn_implementation="eager",
-    )
-    ref_model.eval()
-    print(f"  HF model loaded in {time.perf_counter() - t0:.1f}s")
-
-    print("Generating reference outputs ...")
-    ref_outputs: list[list[int]] = []
-    for prompt, max_tokens, _desc in test_cases:
-        ref_outputs.append(
-            generate_reference(ref_model, tokenizer, prompt, max_tokens, args.device)
-        )
-
-    # Unload HF model to free GPU memory
-    del ref_model
-    torch.cuda.empty_cache()
-    print("  HF model unloaded from GPU.\n")
-
-    # --- Load custom model ---
-    print(f"Loading custom model (VibeServeModel from main.py) on {args.device} ...")
-    t0 = time.perf_counter()
-    VibeServeModel = _load_custom_model_class()
-    custom_model = VibeServeModel.from_pretrained(model_dir, args.device, dtype)
-    print(f"  Custom model loaded in {time.perf_counter() - t0:.1f}s\n")
-
-    # --- Run all tests ---
-    passed = 0
-    failed = 0
-    total = len(test_cases)
-
-    print("=" * 70)
-    print(f"Running {total} test cases (greedy decoding)")
-    print("=" * 70)
-
-    for i, (prompt, max_tokens, desc) in enumerate(test_cases, 1):
-        print(f"\n[{i}/{total}] {desc}  (max_tokens={max_tokens})")
-        prompt_preview = prompt[:80].replace("\n", "\\n")
-        if len(prompt) > 80:
-            prompt_preview += "..."
-        print(f"  Prompt: {prompt_preview!r}")
-
-        ref_ids = ref_outputs[i - 1]
-        custom_ids = generate_custom(custom_model, tokenizer, prompt, max_tokens, args.device)
-
-        match, detail = compare_outputs(ref_ids, custom_ids, tokenizer)
-        if match:
-            print(f"  PASS - {detail}")
-            passed += 1
-        else:
-            print(f"  FAIL - {detail}")
-            failed += 1
-
-    # --- Summary ---
-    print("\n" + "=" * 70)
-    print(f"Results: {passed}/{total} passed, {failed}/{total} failed")
-    print("=" * 70)
-
-    if failed > 0:
-        print("\nACCURACY CHECK FAILED")
-        sys.exit(1)
-    else:
-        print("\nALL CHECKS PASSED")
-        sys.exit(0)
+    rc = asyncio.run(run(args))
+    sys.exit(rc)
 
 
 if __name__ == "__main__":

--- a/examples/model-serving/Llama-3-8B/benchmark/benchmark.py
+++ b/examples/model-serving/Llama-3-8B/benchmark/benchmark.py
@@ -166,6 +166,46 @@ def format_stats(values: list[float], unit: str = "ms", multiplier: float = 1000
 # ---------------------------------------------------------------------------
 
 
+async def run_closed_loop(
+    client: httpx.AsyncClient,
+    url: str,
+    prompts: list[str],
+    args: argparse.Namespace,
+    rng: random.Random,
+    t_bench_start: float,
+) -> list[dict]:
+    """Closed-loop driver: `args.concurrency` workers send requests back-to-back.
+
+    Each worker holds at most one in-flight request, so the number of concurrent
+    requests is bounded to exactly `args.concurrency`. Stops when `--duration`
+    elapses, or (if `--num-requests` is set) once that many requests have been
+    dispatched across all workers.
+    """
+    use_duration = args.num_requests is None
+    total_requests = args.num_requests if not use_duration else None
+    results: list[dict] = []
+    sent = 0
+
+    async def worker() -> None:
+        nonlocal sent
+        while True:
+            if use_duration:
+                if (time.perf_counter() - t_bench_start) >= args.duration:
+                    return
+            else:
+                # Claim a slot before awaiting; increments are atomic between
+                # awaits in a single-threaded event loop, so no lock is needed.
+                if sent >= total_requests:
+                    return
+                sent += 1
+            prompt = rng.choice(prompts)
+            result = await send_request(client, url, prompt, args.max_tokens, args.temperature)
+            results.append(result)
+
+    await asyncio.gather(*[asyncio.create_task(worker()) for _ in range(args.concurrency)])
+    return results
+
+
 async def run_benchmark(args: argparse.Namespace) -> dict:
     rng = random.Random(args.seed)
     url = args.url.rstrip("/") + args.endpoint
@@ -181,38 +221,47 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
     use_duration = args.num_requests is None
     total_requests = args.num_requests if not use_duration else 10**9
 
-    tasks: list[asyncio.Task] = []
     results: list[dict] = []
-    sent = 0
 
     async with httpx.AsyncClient() as client:
         t_bench_start = time.perf_counter()
 
-        while sent < total_requests:
-            # Check duration limit
-            if use_duration and (time.perf_counter() - t_bench_start) >= args.duration:
-                break
+        if args.concurrency:
+            # Closed-loop load: exactly `concurrency` persistent workers, each
+            # sending requests back-to-back. In-flight count is bounded to
+            # `concurrency`, producing a deterministic saturating operating
+            # point (overrides the open-loop Poisson `--rate` path).
+            results = await run_closed_loop(client, url, prompts, args, rng, t_bench_start)
+        else:
+            # Open-loop load: Poisson arrivals at `--rate`, fire-and-forget.
+            tasks: list[asyncio.Task] = []
+            sent = 0
+            while sent < total_requests:
+                # Check duration limit
+                if use_duration and (time.perf_counter() - t_bench_start) >= args.duration:
+                    break
 
-            prompt = rng.choice(prompts)
-            task = asyncio.create_task(
-                send_request(client, url, prompt, args.max_tokens, args.temperature)
-            )
-            tasks.append(task)
-            sent += 1
+                prompt = rng.choice(prompts)
+                task = asyncio.create_task(
+                    send_request(client, url, prompt, args.max_tokens, args.temperature)
+                )
+                tasks.append(task)
+                sent += 1
 
-            # Poisson inter-arrival delay
-            if sent < total_requests:
-                delay = -math.log(1.0 - rng.random()) / args.rate
-                # Cap delay so we don't overshoot duration
-                if use_duration:
-                    remaining = args.duration - (time.perf_counter() - t_bench_start)
-                    if remaining <= 0:
-                        break
-                    delay = min(delay, remaining)
-                await asyncio.sleep(delay)
+                # Poisson inter-arrival delay
+                if sent < total_requests:
+                    delay = -math.log(1.0 - rng.random()) / args.rate
+                    # Cap delay so we don't overshoot duration
+                    if use_duration:
+                        remaining = args.duration - (time.perf_counter() - t_bench_start)
+                        if remaining <= 0:
+                            break
+                        delay = min(delay, remaining)
+                    await asyncio.sleep(delay)
 
-        # Wait for in-flight requests to finish
-        results = await asyncio.gather(*tasks)
+            # Wait for in-flight requests to finish
+            results = await asyncio.gather(*tasks)
+
         t_bench_end = time.perf_counter()
 
     wall_clock = t_bench_end - t_bench_start
@@ -263,6 +312,7 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
         "config": {
             "url": args.url.rstrip("/") + args.endpoint,
             "rate": args.rate,
+            "concurrency": args.concurrency,
             "duration": args.duration,
             "max_tokens": args.max_tokens,
             "temperature": args.temperature,
@@ -293,6 +343,15 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
     result_dict["tpot"] = _pct_block(sorted_tpots)
     result_dict["total_latency"] = _pct_block(sorted_lats)
 
+    # Flat top-level p99 fields (ms) for exact-name objective matching. These
+    # mirror the p99 of the nested blocks above; null when no data.
+    def _p99(block):
+        return block["p99"] if block else None
+
+    result_dict["p99_ttft_ms"] = _p99(result_dict["ttft"])
+    result_dict["p99_tpot_ms"] = _p99(result_dict["tpot"])
+    result_dict["p99_latency_ms"] = _p99(result_dict["total_latency"])
+
     if hasattr(args, "output_json") and args.output_json:
         with open(args.output_json, "w") as f:
             json.dump(result_dict, f, indent=2)
@@ -313,6 +372,16 @@ def main() -> None:
     parser.add_argument("--url", default="http://localhost:8000", help="Server base URL")
     parser.add_argument("--endpoint", default="/v1/completions", help="API endpoint path")
     parser.add_argument("--rate", type=float, default=1.0, help="Request rate (req/s, Poisson)")
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=None,
+        help=(
+            "If set, use a closed-loop load with this many persistent workers "
+            "sending requests back-to-back (bounds in-flight requests to exactly "
+            "this value; overrides --rate)."
+        ),
+    )
     parser.add_argument("--duration", type=float, default=60, help="Benchmark duration in seconds")
     parser.add_argument(
         "--num-requests", type=int, default=None, help="Total requests (overrides --duration)"

--- a/examples/model-serving/Llama-3-8B/objectives.toml
+++ b/examples/model-serving/Llama-3-8B/objectives.toml
@@ -1,0 +1,18 @@
+# Multi-objective (Pareto-frontier) configuration for the evolve loop.
+#
+# Presence of this file next to OBJECTIVE.md switches the run into Pareto mode:
+# candidates are selected by non-domination across the axes below instead of a
+# single scalar. Each `name` MUST exactly match a top-level field emitted by
+# benchmark/benchmark.py --output-json (the profiler reads them verbatim into
+# ProfilerSummary.metrics). A missing/misnamed field drops the candidate from
+# the frontier and silently degrades the run to scalar softmax.
+
+# Primary axis — also drives perf_metric / best() / the scalar fallback.
+[[objective]]
+name = "aggregate_throughput"   # output tok/s, from benchmark JSON
+direction = "max"
+
+# Latency axis — p99 end-to-end request latency under the fixed saturating load.
+[[objective]]
+name = "p99_latency_ms"         # milliseconds, from benchmark JSON
+direction = "min"


### PR DESCRIPTION
## Problem

The Llama-3-8B evolve example optimized a single scalar, `aggregate_throughput`,
but the profiler measured it at **concurrency 1** (`--num-requests 1
--max-tokens 16`). At batch 1 the "throughput" number is ~97% time-to-first-token
of one short request — not serving throughput — and it gives the search **zero
incentive to add batching** (you cannot batch a single request). The accuracy
checker also diffed against a locally-loaded reference model, which does not work
when the candidate server runs remotely on Modal.

## Solution

### Architecture

- **Service-style, reference-free accuracy checker**
  (`accuracy_checker/checker.py`, `README.md`): drives the running
  OpenAI-compatible server over HTTP (no local weight load, so it behaves
  identically against local/Docker/Modal) and gates on three reference-free
  checks — sentinel-echo, known-answer, and greedy determinism — instead of
  diffing a local GPU reference.
- **Closed-loop benchmark load** (`benchmark/benchmark.py`): add `--concurrency N`
  (exactly N persistent in-flight workers) so throughput reflects true server
  capacity under contention, plus flat top-level `p99_latency_ms` / `p99_tpot_ms`
  / `p99_ttft_ms` fields. The existing open-loop `--rate` path is unchanged.
- **Pareto serving objective** (`objectives.toml`, `OBJECTIVE.md`): score
  candidates on a Pareto frontier over `aggregate_throughput` (max) and
  `p99_latency_ms` (min) via a new `objectives.toml` sidecar (uses the existing
  framework Pareto plumbing — no framework change), and pin an authoritative
  saturating benchmark protocol (`--concurrency 16 --duration 20 --max-tokens
  128 --temperature 0`) in `OBJECTIVE.md` so every candidate is scored under the
  identical load.

## Verification

### Correctness properties

- Every candidate is measured under the same fixed 16-way load, so the two
  Pareto axes are comparable across the population and no candidate can "win"
  latency by serving fewer requests.
- The objective field names (`aggregate_throughput`, `p99_latency_ms`) exactly
  match both `objectives.toml` and the benchmark JSON keys, so passing
  candidates are never silently dropped from the frontier.
- `--concurrency` bounds in-flight requests to exactly N; open-loop `--rate`
  behavior is preserved when `--concurrency` is unset.

### Testing

- `benchmark.py` closed-loop mode validated locally against a mock SSE server:
  server-observed max in-flight held at exactly N, and `--output-json` emits the
  flat `p99_*` fields (`p99_latency_ms` equals nested `total_latency.p99`).
- `objectives.toml` loads via the framework's `_load_objectives_toml` with the
  correct axes/directions.
- `ruff check` + `ruff format --check` pass on the touched Python.
- Validated on a fresh 5-generation Modal/H100 run: the log prints
  `pareto objectives: [aggregate_throughput(max), p99_latency_ms(min)]`,
  every profiler benchmark ran at `concurrency=16, max_tokens=128`, and passing
  candidates carry both axes in `metrics`, forming a Pareto frontier. (Run also
  used the framework fixes in the companion PR.)
