### PR TITLE
Preserve Codex authentication in nested host sandboxes

### DIFF
--- a/src/vibesys/_agent_cli/hostsandbox.py
+++ b/src/vibesys/_agent_cli/hostsandbox.py
@@ -188,8 +188,15 @@ def _default_config_paths(env: dict[str, str]) -> list[Path]:
     if not home:
         return []
     base = Path(home)
+    codex_home = Path(env.get("CODEX_HOME", base / ".codex")).expanduser()
     paths = [
-        base / ".codex",
+        # Mount the files Codex needs rather than the whole directory. A Codex
+        # checkout may itself live under ``$CODEX_HOME/worktrees``; mounting the
+        # directory would expose sibling tasks, while dropping it makes the CLI
+        # appear logged out inside the sandbox. Bubblewrap creates an ephemeral
+        # parent directory for these leaf mounts in ``HostSandbox.wrap``.
+        codex_home / "auth.json",
+        codex_home / "config.toml",
         base / ".claude",
         base / ".claude.json",
         base / ".config" / "codex",
@@ -263,6 +270,15 @@ class HostSandbox(WorkspaceSandbox):
             "--tmpfs",
             "/tmp",
         ]
+        # Leaf config mounts such as ~/.codex/auth.json need their destination
+        # parents to exist in bubblewrap's otherwise-empty /home tree. These
+        # directories are ephemeral inside the namespace; only the explicitly
+        # bound files below are sourced from the host.
+        parent_dirs = {
+            parent for path in self.write_paths for parent in path.parents if parent != Path("/")
+        }
+        for parent in sorted(parent_dirs, key=lambda path: len(path.parts)):
+            cmd += ["--dir", str(parent)]
         for root in self.system_read_roots:
             cmd += ["--ro-bind-try", root, root]
         for path in self.read_paths:

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -124,6 +124,30 @@ class TestBuild:
         finally:
             weights.rmdir()
 
+    def test_codex_auth_file_survives_nested_codex_worktree_filter(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
+        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")
+        codex_home = tmp_path / ".codex"
+        workspace = codex_home / "worktrees" / "run" / "workspace"
+        workspace.mkdir(parents=True)
+        auth = codex_home / "auth.json"
+        config = codex_home / "config.toml"
+        auth.write_text('{"tokens": {}}\n')
+        config.write_text('model = "gpt-5.4"\n')
+
+        sb = hostsandbox.build(
+            workspace,
+            env={"HOME": str(tmp_path), "CODEX_HOME": str(codex_home)},
+        )
+
+        assert isinstance(sb, hostsandbox.HostSandbox)
+        assert codex_home not in sb.write_paths
+        assert auth in sb.write_paths
+        assert config in sb.write_paths
+        argv = sb.wrap(["codex", "login", "status"])
+        assert _has_pair(argv, "--dir", str(codex_home))
+        assert _has_pair(argv, "--bind-try", str(auth), str(auth))
+
 
 # ---------------------------------------------------------------------------
 # bwrap argv construction (no subprocess)
@@ -426,6 +450,34 @@ def test_sandbox_blocks_escape_but_allows_workspace(tmp_path_factory):
     # Legitimate workspace work is unaffected.
     assert "WS_OK" in out
     assert (workspace / "candidate.txt").read_text().strip() == "ok"
+
+
+@requires_sandbox
+def test_sandbox_exposes_codex_auth_but_not_sibling_worktrees(tmp_path):
+    codex_home = tmp_path / ".codex"
+    workspace = codex_home / "worktrees" / "run-A" / "workspace"
+    sibling = codex_home / "worktrees" / "run-B" / "secret.txt"
+    workspace.mkdir(parents=True)
+    sibling.parent.mkdir(parents=True)
+    sibling.write_text("sibling secret\n")
+    auth = codex_home / "auth.json"
+    auth.write_text("auth token\n")
+    config = codex_home / "config.toml"
+    config.write_text("model = 'gpt-5.4'\n")
+    env = {**os.environ, "HOME": str(tmp_path), "CODEX_HOME": str(codex_home)}
+
+    sandbox = hostsandbox.build(workspace, env=env, binary_path="/bin/sh")
+
+    assert isinstance(sandbox, hostsandbox.HostSandbox)
+    command = sandbox.wrap(
+        [
+            "/bin/sh",
+            "-c",
+            f'test "$(cat {auth})" = "auth token" && test ! -e {sibling}',
+        ]
+    )
+    result = subprocess.run(command, env=env, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
 
 
 @requires_sandbox


### PR DESCRIPTION
## Problem

Resuming a local experiment from a workspace under `$CODEX_HOME/worktrees` caused every Codex invocation to fail with `401 Unauthorized`. The host sandbox intentionally removed the whole `.codex` directory because it was an ancestor of the workspace, which protected sibling worktrees but also hid the active Codex credentials and configuration.

## Solution

Mount only the Codex `auth.json` and `config.toml` files instead of the entire Codex home directory, while honoring an explicit `CODEX_HOME`. Create ephemeral destination parent directories inside the bubblewrap namespace before applying those leaf-file binds.

This preserves authentication for resumed runs without exposing sibling Codex worktrees.

### Architecture

`HostSandbox` remains responsible for discovering allowed host configuration and constructing the bubblewrap command. Configuration discovery now returns the two Codex leaf files, and command construction creates only the namespace directories required to mount those files. No runner, resume, or agent-provider interfaces change.

## Verification

The regression is covered at both command-construction and real bubblewrap execution levels. I also verified the installed Codex CLI reports its host login from the same nested workspace layout that triggered the bug.

### Correctness properties

- Codex authentication and configuration remain visible inside the sandbox when the workspace is nested under `$CODEX_HOME/worktrees`.
- Sibling worktrees under the same Codex home remain inaccessible.
- A user-defined `CODEX_HOME` is honored.
- Only explicit credential/configuration leaf files are mounted; the full Codex home is not exposed.

### Testing

- `./scripts/check_format.sh` — passed
- `./scripts/check_lint.sh` — passed
- `uv run pyright` — 0 errors
- `uv run pytest tests/_agent_cli/test_hostsandbox.py -q` — 32 passed, 1 skipped on macOS
- `uv run pytest tests/_agent_cli tests/agents/test_agent_runners.py -q` — 134 passed, 1 skipped on macOS
- Manual sandboxed `codex login status` from the affected nested worktree — `Logged in using ChatGPT`