### PR TITLE
Add slash-command highlighting and autocomplete to TUI

### DIFF
--- a/clients/tui/src/commands.test.ts
+++ b/clients/tui/src/commands.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {parseInput} from './commands.js';
+import {parseInput, slashCommandRange, suggestSlashCommands} from './commands.js';
 
 describe('parseInput', () => {
   it('only accepts the intentionally small command surface', () => {
@@ -20,5 +20,25 @@ describe('parseInput', () => {
 
   it('provides local help without a backend request', () => {
     expect(parseInput('/help')).toEqual({localView: 'help'});
+  });
+});
+
+describe('slash-command input helpers', () => {
+  it('suggests available commands from a slash prefix', () => {
+    expect(suggestSlashCommands('/').map(command => command.name)).toEqual([
+      '/help',
+      '/history',
+      '/perf',
+    ]);
+    expect(suggestSlashCommands('/hi').map(command => command.name)).toEqual(['/history']);
+    expect(suggestSlashCommands('/history ')).toEqual([]);
+    expect(suggestSlashCommands('history')).toEqual([]);
+  });
+
+  it('finds a leading slash-command token for syntax highlighting', () => {
+    expect(slashCommandRange('/history')).toEqual({start: 0, end: 8});
+    expect(slashCommandRange('/steer inspect the cache')).toEqual({start: 0, end: 6});
+    expect(slashCommandRange('/')).toBeNull();
+    expect(slashCommandRange('show /history')).toBeNull();
   });
 });

--- a/clients/tui/src/commands.ts
+++ b/clients/tui/src/commands.ts
@@ -7,11 +7,20 @@ export type ParsedInput = {
   error?: string;
 };
 
+export interface SlashCommand {
+  name: string;
+  description: string;
+}
+
+export const SLASH_COMMANDS: readonly SlashCommand[] = [
+  {name: '/help', description: 'Show this help'},
+  {name: '/history', description: 'List rounds and their elapsed time'},
+  {name: '/perf', description: 'Plot performance by round'},
+];
+
 export const HELP_TEXT = [
   'Available',
-  '  /help              Show this help',
-  '  /history           List rounds and their elapsed time',
-  '  /perf              Plot performance by round',
+  ...SLASH_COMMANDS.map(command => `  ${command.name.padEnd(18)} ${command.description}`),
   '',
   'Planned',
   '  /pause             Pause at the next safe point',
@@ -20,6 +29,17 @@ export const HELP_TEXT = [
   '  /round <number>    Inspect a completed round',
   '  /invocation <id>   Inspect an agent invocation',
 ].join('\n');
+
+export function suggestSlashCommands(text: string): readonly SlashCommand[] {
+  if (!text.startsWith('/') || /\s/.test(text)) return [];
+  return SLASH_COMMANDS.filter(command => command.name.startsWith(text));
+}
+
+export function slashCommandRange(text: string): {start: number; end: number} | null {
+  const match = /^\/[a-z][a-z0-9-]*/i.exec(text);
+  if (match === null) return null;
+  return {start: 0, end: match[0].length};
+}
 
 export function parseInput(text: string): ParsedInput {
   if (text === '/help') return {localView: 'help'};

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1,3 +1,4 @@
+import {InputRenderable} from '@opentui/core';
 import {createTestRenderer} from '@opentui/core/testing';
 import {afterEach, describe, expect, it} from 'vitest';
 import type {SessionController} from '../session-controller.js';
@@ -90,6 +91,39 @@ describe('OpenTUI presentation', () => {
     testRenderer.mockInput.pressEnter();
     await testRenderer.waitForFrame(() => controller.submissions.length === 1);
     expect(controller.submissions).toEqual(['/help']);
+  });
+
+  it('suggests and completes slash commands with Tab', async () => {
+    const testRenderer = await createTestRenderer({width: 80, height: 16});
+    const controller = new FakeController(initialSessionState());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    await testRenderer.mockInput.typeText('/hi');
+    const suggestions = await testRenderer.waitForFrame(value => value.includes('[Tab]'));
+    expect(suggestions).toContain('/history');
+    expect(suggestions).not.toContain('/help  ');
+    expect(suggestions).not.toContain('/perf');
+    expect(suggestions.indexOf('/history')).toBeLessThan(suggestions.indexOf('Ask or command'));
+    expect(testRenderer.renderer.root.findDescendantById('input-box')?.height).toBe(3);
+
+    testRenderer.mockInput.pressKey('TAB');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.submissions.length === 1);
+    expect(controller.submissions).toEqual(['/history']);
+  });
+
+  it('highlights a leading slash-command token', async () => {
+    const testRenderer = await createTestRenderer({width: 80, height: 16});
+    const controller = new FakeController(initialSessionState());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    await testRenderer.mockInput.typeText('/steer inspect the cache');
+    const input = testRenderer.renderer.root.findDescendantById('input');
+    expect(input).toBeInstanceOf(InputRenderable);
+    if (!(input instanceof InputRenderable)) throw new Error('input was not rendered');
+    expect(input.getLineHighlights(0)).toMatchObject([{start: 0, end: 6}]);
   });
 
   it('exits on the first Ctrl-C even while the input is focused', async () => {

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -67,6 +67,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   root.add(main);
   root.add(todoStrip.output);
   root.add(help);
+  root.add(input.suggestions);
   root.add(input.box);
   root.add(overlay.output);
   renderer.root.add(root);
@@ -83,6 +84,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     overlay.render(state);
   };
   const unbindKeys = bindKeybindings(renderer, controller, viewport, {
+    completeInput: () => input.completeSuggestion(),
     toggleLatestPrompt: () => conversation.toggleLatestPrompt(),
     selectNextAgent: () => controller.selectNextAgent(),
     selectPreviousAgent: () => controller.selectPreviousAgent(),

--- a/clients/tui/src/ui/input.ts
+++ b/clients/tui/src/ui/input.ts
@@ -3,10 +3,15 @@ import {
   type CliRenderer,
   InputRenderable,
   InputRenderableEvents,
+  SyntaxStyle,
+  TextRenderable,
 } from '@opentui/core';
+import {type SlashCommand, slashCommandRange, suggestSlashCommands} from '../commands.js';
 
 export interface InputPanel {
   box: BoxRenderable;
+  suggestions: BoxRenderable;
+  completeSuggestion(): boolean;
   focus(): void;
   destroy(): void;
 }
@@ -26,22 +31,89 @@ export function createInputPanel(
     paddingLeft: 1,
     paddingRight: 1,
   });
+  const syntaxStyle = SyntaxStyle.fromStyles({
+    'slash-command': {fg: '#22d3ee', bold: true},
+  });
+  const commandStyleId = syntaxStyle.getStyleId('slash-command');
   const input = new InputRenderable(renderer, {
     id: 'input',
     width: '100%',
     placeholder: 'Type a question or /help',
     textColor: '#f8fafc',
     focusedTextColor: '#f8fafc',
+    syntaxStyle,
   });
+  const suggestions = new BoxRenderable(renderer, {
+    id: 'input-suggestions',
+    position: 'absolute',
+    bottom: 3,
+    left: 0,
+    width: '100%',
+    height: 3,
+    visible: false,
+    zIndex: 5,
+    border: true,
+    borderStyle: 'rounded',
+    borderColor: '#475569',
+    backgroundColor: '#0f172a',
+    paddingLeft: 1,
+    paddingRight: 1,
+  });
+  const suggestionList = new TextRenderable(renderer, {
+    id: 'input-suggestion-list',
+    width: '100%',
+    height: 1,
+    fg: '#94a3b8',
+    wrapMode: 'none',
+    truncate: true,
+    content: '',
+  });
+  suggestions.add(suggestionList);
+  let matches: readonly SlashCommand[] = [];
+
+  const updateDecorations = (value: string): void => {
+    input.clearAllHighlights();
+    const range = slashCommandRange(value);
+    if (range !== null && commandStyleId !== null) {
+      input.addHighlightByCharRange({...range, styleId: commandStyleId});
+    }
+
+    matches = suggestSlashCommands(value);
+    const visible = matches.length > 0;
+    suggestions.visible = visible;
+    suggestions.height = matches.length + 2;
+    suggestionList.height = Math.max(1, matches.length);
+    suggestionList.content = matches
+      .map(
+        (command, index) =>
+          `${index === 0 ? '›' : ' '} ${command.name.padEnd(10)} ${command.description}${
+            index === 0 && command.name !== value ? '  [Tab]' : ''
+          }`,
+      )
+      .join('\n');
+  };
   const submit = (value: string): void => {
     input.value = '';
     onSubmit(value);
   };
+  input.on(InputRenderableEvents.INPUT, updateDecorations);
   input.on(InputRenderableEvents.ENTER, submit);
   box.add(input);
   return {
     box,
+    suggestions,
+    completeSuggestion(): boolean {
+      const suggestion = matches[0];
+      if (suggestion === undefined || suggestion.name === input.value) return false;
+      input.value = suggestion.name;
+      return true;
+    },
     focus: () => input.focus(),
-    destroy: () => input.off(InputRenderableEvents.ENTER, submit),
+    destroy(): void {
+      input.off(InputRenderableEvents.INPUT, updateDecorations);
+      input.off(InputRenderableEvents.ENTER, submit);
+      if (!input.isDestroyed) input.syntaxStyle = null;
+      syntaxStyle.destroy();
+    },
   };
 }

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -2,6 +2,7 @@ import type {CliRenderer, KeyEvent, ScrollBoxRenderable} from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
 
 export interface KeybindingActions {
+  completeInput(): boolean;
   toggleLatestPrompt(): void;
   selectNextAgent(): void;
   selectPreviousAgent(): void;
@@ -41,6 +42,10 @@ export function bindKeybindings(
     if (key.ctrl && key.name === 'l') {
       controller.live();
       viewport.scrollTo(viewport.scrollHeight);
+      key.preventDefault();
+      return;
+    }
+    if (key.name === 'tab' && !key.shift && actions.completeInput()) {
       key.preventDefault();
       return;
     }


### PR DESCRIPTION
## Problem

Slash commands in the TUI are difficult to discover while typing: command-shaped input has no visual distinction, and operators must open `/help` to learn the available commands. Suggestions also need to avoid resizing the input area or shifting the transcript as the number of matches changes.

## Solution

<img width="1242" height="455" alt="Screenshot 2026-07-19 at 9 12 55 PM" src="https://github.com/user-attachments/assets/7a7d4da5-31de-4b00-85ad-f36f27267a3a" />

Introduce a shared slash-command catalog that drives help text and prefix suggestions. Highlight a leading `/xxx` token with OpenTUI's native syntax-style API, and render matching available commands in a bordered overlay anchored above the fixed-height input box.

Tab completes the first visible suggestion. When no completion applies, the existing Tab behavior continues to select the next agent.

### Architecture

```mermaid
flowchart LR
  Catalog["Slash-command catalog"] --> Help["/help output"]
  Catalog --> Matcher["Prefix matcher"]
  Input["OpenTUI input events"] --> Matcher
  Input --> Highlighter["Leading-token highlighter"]
  Matcher --> Overlay["Absolute suggestion overlay"]
  Matcher --> Completion["Contextual Tab completion"]
  Completion --> Parser["Existing command parser"]
```

Command metadata and matching remain in `commands.ts`; rendering and syntax styling remain owned by the input panel; application-level keybindings only ask the input panel whether Tab was consumed.

## Verification

The complete TUI test suite, TypeScript checks, formatter/linter checks, production build, and whitespace validation pass.

### Correctness properties

- Only leading slash-command tokens are syntax highlighted.
- Suggestions contain only currently available commands whose names match the typed prefix.
- Suggestions disappear for non-slash input and command arguments.
- The input box remains three rows tall regardless of suggestion count.
- Suggestions render above the input without reflowing the transcript.
- Tab completes a visible prefix match, while preserving agent selection when no completion is available.
- Enter submits the completed command through the existing parser.
- No CLI, protocol, manifest, persisted-state, or evaluator contracts change.

### Testing

- `pnpm --filter @vibesys/tui test` — 58 tests passed.
- `pnpm --filter @vibesys/tui check` — passed.
- `pnpm --filter @vibesys/tui build` — passed.
- `pnpm exec biome check clients/tui/src/commands.ts clients/tui/src/commands.test.ts clients/tui/src/ui/input.ts clients/tui/src/ui/keybindings.ts clients/tui/src/ui/app.ts clients/tui/src/ui/app.test.ts` — passed.
- `git diff --check` — passed.
