### PR TITLE
Harden TUI state, rendering, and transport handling

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -12,3 +12,60 @@ launcher starts the Python VibeSys backend with `python -m vibesys --headless`
 and then attaches the OpenTUI client. Install the Python `vibesys` package in
 the Python environment you want to use, or set `VIBESYS_PYTHON` to that Python
 executable.
+
+## Operator interface
+
+Enter ordinary text to ask the supervision backend about the current run. The
+available slash commands are:
+
+| Command | Behavior |
+| --- | --- |
+| `/help` | Show commands and planned controls. |
+| `/history` | List rounds with agent-active elapsed time. |
+| `/perf` | Plot the recorded performance metric by round. |
+
+The footer shows keyboard navigation. `[` and `]` select rounds, Tab and
+Shift+Tab select agents, Page Up/Page Down scroll the transcript, Ctrl+T expands
+todos, Ctrl+P expands the latest prompt in the current selection, Ctrl+L returns
+to the live view, and Ctrl+C exits. Commands listed under "Planned" in `/help`
+are not accepted yet.
+
+The launcher retains terminal results until the operator exits. If the backend
+fails to start, its log tail is printed before the temporary session directory
+is removed. Requests and subscription setup have bounded timeouts; malformed or
+incompatible protocol messages are shown as errors instead of crashing a socket
+callback.
+
+## Architecture
+
+The Python backend owns the validated, append-only event contract and serves it
+as JSONL over a private Unix socket. `src/generated/` is generated from those
+Pydantic models. The TypeScript client owns framing and request correlation,
+`session-controller.ts` owns effects, `session-model.ts` and `run-map.ts` reduce
+events into presentation state, and `ui/` owns OpenTUI rendering and input.
+
+Conversation state retains at most 1,000 semantic entries. Rendering is keyed
+by entry identity: state-only updates reuse existing cards, streamed tail
+updates replace only the final card, and a full rebuild is reserved for filter
+or history-window changes. Typed tool calls use stable call IDs so parallel
+results return to the correct card; old event logs without IDs use a documented
+FIFO-by-tool fallback.
+
+## Development
+
+From the repository root:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --dir clients/tui generate:protocol
+pnpm --dir clients/tui check
+pnpm --dir clients/tui test
+pnpm --dir clients/tui build
+pnpm check:ts
+uv run pytest tests/test_tui.py tests/agents/test_callbacks.py tests/render/test_sink.py
+```
+
+After changing Python protocol models, regenerate both files in
+`src/generated/` and review their diff. The test suite covers reducer behavior,
+OpenTUI frames and navigation, launcher cleanup, socket fragmentation and
+timeouts, replay/live delivery, and the Python supervision service.

--- a/clients/tui/src/client.test.ts
+++ b/clients/tui/src/client.test.ts
@@ -3,7 +3,7 @@ import {unlink} from 'node:fs/promises';
 import {createServer, type Server, type Socket} from 'node:net';
 import {join} from 'node:path';
 import {afterEach, describe, expect, it} from 'vitest';
-import {SupervisionClient} from './client.js';
+import {SupervisionClient, type SupervisionClientOptions} from './client.js';
 
 let socketPath: string | undefined;
 
@@ -87,16 +87,142 @@ describe('SupervisionClient', () => {
       },
     );
   });
+
+  it('rejects malformed responses instead of throwing from the socket callback', async () => {
+    await withServer(
+      socket => socket.once('data', () => socket.write('{not-json}\n')),
+      async client => {
+        await expect(client.request({type: 'query.snapshot'})).rejects.toThrow(
+          'Invalid supervision response JSON',
+        );
+      },
+    );
+  });
+
+  it('rejects incompatible protocol versions', async () => {
+    await withServer(
+      socket =>
+        respondToLines(socket, request => {
+          socket.write(
+            `${JSON.stringify({...successResponse(request['request_id'] as string), protocol_version: 2})}\n`,
+          );
+        }),
+      async client => {
+        await expect(client.request({type: 'query.snapshot'})).rejects.toThrow(
+          'Unsupported supervision protocol version',
+        );
+      },
+    );
+  });
+
+  it('times out requests that never receive a response', async () => {
+    await withServer(
+      socket => socket.on('data', () => undefined),
+      async client => {
+        await expect(client.request({type: 'query.snapshot'})).rejects.toThrow(
+          'Supervision request timed out after 20ms',
+        );
+      },
+      {requestTimeoutMs: 20},
+    );
+  });
+
+  it('reassembles and validates fragmented subscription messages', async () => {
+    await withServer(
+      socket =>
+        respondToLines(socket, request => {
+          if (request['type'] !== 'subscribe') return;
+          const subscribed = `${JSON.stringify({
+            type: 'subscribed',
+            request_id: request['request_id'],
+            run_id: 'run-1',
+            latest_sequence: 1,
+          })}\n`;
+          const batch = `${JSON.stringify({
+            type: 'event_batch',
+            events: [{sequence: 1, timestamp: new Date().toISOString(), type: 'server_started'}],
+          })}\n`;
+          socket.write(subscribed.slice(0, 10));
+          socket.write(`${subscribed.slice(10)}${batch}`);
+        }),
+      async client => {
+        const messages: string[] = [];
+        const subscription = await client.subscribe(
+          0,
+          message => messages.push(String(message.type)),
+          error => {
+            throw error;
+          },
+        );
+        expect(messages).toEqual(['subscribed', 'event_batch']);
+        await subscription.close();
+      },
+    );
+  });
+
+  it('reports an event-stream disconnect only once', async () => {
+    await withServer(
+      socket =>
+        respondToLines(socket, request => {
+          if (request['type'] !== 'subscribe') return;
+          socket.write(
+            `${JSON.stringify({
+              type: 'subscribed',
+              request_id: request['request_id'],
+              run_id: 'run-1',
+              latest_sequence: 0,
+            })}\n`,
+            () => socket.destroy(),
+          );
+        }),
+      async client => {
+        const disconnects: Error[] = [];
+        await client.subscribe(
+          0,
+          () => undefined,
+          error => disconnects.push(error),
+        );
+        await new Promise(resolve => setTimeout(resolve, 20));
+        expect(disconnects).toHaveLength(1);
+      },
+    );
+  });
+
+  it('reports unknown event-stream message types as protocol errors', async () => {
+    await withServer(
+      socket =>
+        respondToLines(socket, request => {
+          if (request['type'] !== 'subscribe') return;
+          socket.write(
+            `${JSON.stringify({
+              type: 'subscribed',
+              request_id: request['request_id'],
+              run_id: 'run-1',
+              latest_sequence: 0,
+            })}\n${JSON.stringify({type: 'unknown'})}\n`,
+          );
+        }),
+      async client => {
+        const disconnect = new Promise<Error>(resolve => {
+          void client.subscribe(0, () => undefined, resolve);
+        });
+        await expect(disconnect).resolves.toMatchObject({
+          message: expect.stringContaining('Unknown supervision event-stream message'),
+        });
+      },
+    );
+  });
 });
 
 async function withServer(
   onConnection: (socket: Socket) => void,
   test: (client: SupervisionClient) => Promise<void>,
+  options: SupervisionClientOptions = {},
 ): Promise<void> {
   socketPath = join('/tmp', `vs-${randomUUID().slice(0, 8)}.sock`);
   const server = createServer(onConnection);
   await listen(server, socketPath);
-  const client = await SupervisionClient.connect(socketPath);
+  const client = await SupervisionClient.connect(socketPath, options);
   try {
     await test(client);
   } finally {

--- a/clients/tui/src/client.ts
+++ b/clients/tui/src/client.ts
@@ -6,33 +6,68 @@ export interface EventSubscription {
   close(): Promise<void>;
 }
 
+export interface SupervisionClientOptions {
+  connectTimeoutMs?: number;
+  requestTimeoutMs?: number;
+}
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
 export class SupervisionClient {
   readonly #socket: Socket;
   readonly #path: string;
   readonly #pending = new Map<
     string,
-    {resolve: (value: ProtocolResponse) => void; reject: (error: Error) => void}
+    {
+      resolve: (value: ProtocolResponse) => void;
+      reject: (error: Error) => void;
+      timeout: ReturnType<typeof setTimeout>;
+    }
   >();
+  readonly #connectTimeoutMs: number;
+  readonly #requestTimeoutMs: number;
   #buffer = '';
 
-  private constructor(socket: Socket, path: string) {
+  private constructor(socket: Socket, path: string, options: SupervisionClientOptions) {
     this.#socket = socket;
     this.#path = path;
+    this.#connectTimeoutMs = options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+    this.#requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     socket.setEncoding('utf8');
     socket.on('data', chunk => this.#onData(chunk.toString()));
     socket.on('error', error => this.#rejectAll(error));
     socket.on('close', () => this.#rejectAll(new Error('Supervision server disconnected')));
   }
 
-  static connect(path: string): Promise<SupervisionClient> {
+  static connect(path: string, options: SupervisionClientOptions = {}): Promise<SupervisionClient> {
     return new Promise((resolve, reject) => {
       const socket = createConnection(path);
-      socket.once('connect', () => resolve(new SupervisionClient(socket, path)));
-      socket.once('error', reject);
+      const onError = (error: Error): void => {
+        clearTimeout(timeout);
+        reject(error);
+      };
+      const timeout = setTimeout(() => {
+        socket.destroy();
+        reject(
+          new Error(
+            `Timed out connecting to supervision server after ${options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS}ms`,
+          ),
+        );
+      }, options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS);
+      socket.once('connect', () => {
+        clearTimeout(timeout);
+        socket.off('error', onError);
+        resolve(new SupervisionClient(socket, path, options));
+      });
+      socket.once('error', onError);
     });
   }
 
   request(input: RequestInput): Promise<ProtocolResponse> {
+    if (this.#socket.destroyed) {
+      return Promise.reject(new Error('Supervision server is disconnected'));
+    }
     const requestId = randomUUID();
     const request = {
       protocol_version: 1,
@@ -41,8 +76,14 @@ export class SupervisionClient {
       ...input,
     } as ProtocolRequest;
     return new Promise((resolve, reject) => {
-      this.#pending.set(requestId, {resolve, reject});
-      this.#socket.write(`${JSON.stringify(request)}\n`);
+      const timeout = setTimeout(() => {
+        this.#pending.delete(requestId);
+        reject(new Error(`Supervision request timed out after ${this.#requestTimeoutMs}ms`));
+      }, this.#requestTimeoutMs);
+      this.#pending.set(requestId, {resolve, reject, timeout});
+      this.#socket.write(`${JSON.stringify(request)}\n`, error => {
+        if (error) this.#rejectPending(requestId, error);
+      });
     });
   }
 
@@ -56,6 +97,20 @@ export class SupervisionClient {
       let buffer = '';
       let subscribed = false;
       let closing = false;
+      let disconnected = false;
+      const handshakeTimeout = setTimeout(() => {
+        disconnect(
+          new Error(`Supervision subscription timed out after ${this.#connectTimeoutMs}ms`),
+        );
+        socket.destroy();
+      }, this.#connectTimeoutMs);
+      const disconnect = (error: Error): void => {
+        if (disconnected || closing) return;
+        disconnected = true;
+        clearTimeout(handshakeTimeout);
+        if (subscribed) onDisconnect(error);
+        else reject(error);
+      };
       socket.setEncoding('utf8');
       socket.once('connect', () => {
         socket.write(
@@ -76,31 +131,42 @@ export class SupervisionClient {
           if (!line) continue;
           let message: ServerMessage;
           try {
-            message = JSON.parse(line) as ServerMessage;
+            message = parseServerMessage(line);
           } catch (error) {
             const parseError = error instanceof Error ? error : new Error(String(error));
-            if (subscribed) onDisconnect(parseError);
-            else reject(parseError);
+            disconnect(parseError);
             socket.destroy();
             return;
           }
-          onMessage(message);
+          try {
+            onMessage(message);
+          } catch (error) {
+            disconnect(error instanceof Error ? error : new Error(String(error)));
+            socket.destroy();
+            return;
+          }
           if (!subscribed && message.type === 'subscribed') {
             subscribed = true;
+            clearTimeout(handshakeTimeout);
             resolve({
               close: () => {
                 closing = true;
+                clearTimeout(handshakeTimeout);
                 return closeSocket(socket);
               },
             });
           }
         }
       });
-      socket.once('error', error => (subscribed ? onDisconnect(error) : reject(error)));
+      socket.once('error', disconnect);
       socket.once('close', () => {
-        if (subscribed && !closing)
-          onDisconnect(new Error('Supervision event stream disconnected'));
-        else reject(new Error('Supervision event stream disconnected before subscription'));
+        disconnect(
+          new Error(
+            subscribed
+              ? 'Supervision event stream disconnected'
+              : 'Supervision event stream disconnected before subscription',
+          ),
+        );
       });
     });
   }
@@ -119,18 +185,38 @@ export class SupervisionClient {
     this.#buffer = lines.pop() ?? '';
     for (const line of lines) {
       if (!line) continue;
-      const response = JSON.parse(line) as ProtocolResponse;
+      let response: ProtocolResponse;
+      try {
+        response = parseProtocolResponse(line);
+      } catch (error) {
+        const parseError = error instanceof Error ? error : new Error(String(error));
+        this.#rejectAll(parseError);
+        this.#socket.destroy();
+        return;
+      }
       const pending = this.#pending.get(response.request_id);
       if (!pending) continue;
       this.#pending.delete(response.request_id);
+      clearTimeout(pending.timeout);
       if (response.ok) pending.resolve(response);
       else pending.reject(new Error(response.error ?? 'Unknown supervision error'));
     }
   }
 
   #rejectAll(error: Error): void {
-    for (const pending of this.#pending.values()) pending.reject(error);
+    for (const pending of this.#pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
     this.#pending.clear();
+  }
+
+  #rejectPending(requestId: string, error: Error): void {
+    const pending = this.#pending.get(requestId);
+    if (pending === undefined) return;
+    this.#pending.delete(requestId);
+    clearTimeout(pending.timeout);
+    pending.reject(error);
   }
 }
 
@@ -140,4 +226,58 @@ function closeSocket(socket: Socket): Promise<void> {
     socket.once('close', resolve);
     socket.end();
   });
+}
+
+function parseProtocolResponse(line: string): ProtocolResponse {
+  const value = parseRecord(line, 'response');
+  if (value['protocol_version'] !== 1) throw new Error('Unsupported supervision protocol version');
+  if (typeof value['request_id'] !== 'string') {
+    throw new Error('Invalid supervision response: request_id must be a string');
+  }
+  if (typeof value['ok'] !== 'boolean') {
+    throw new Error('Invalid supervision response: ok must be a boolean');
+  }
+  return value as unknown as ProtocolResponse;
+}
+
+function parseServerMessage(line: string): ServerMessage {
+  const value = parseRecord(line, 'event-stream message');
+  const type = value['type'];
+  if (type === 'subscribed') {
+    if (
+      typeof value['request_id'] !== 'string' ||
+      typeof value['run_id'] !== 'string' ||
+      typeof value['latest_sequence'] !== 'number'
+    ) {
+      throw new Error('Invalid subscribed message');
+    }
+  } else if (type === 'event') {
+    if (!isRecord(value['event'])) throw new Error('Invalid event message');
+  } else if (type === 'event_batch') {
+    if (!Array.isArray(value['events'])) throw new Error('Invalid event batch message');
+  } else if (type === 'protocol_error') {
+    if (typeof value['code'] !== 'string' || typeof value['message'] !== 'string') {
+      throw new Error('Invalid protocol error message');
+    }
+  } else {
+    throw new Error(`Unknown supervision event-stream message: ${String(type)}`);
+  }
+  return value as unknown as ServerMessage;
+}
+
+function parseRecord(line: string, description: string): Record<string, unknown> {
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch (error) {
+    throw new Error(
+      `Invalid supervision ${description} JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!isRecord(value)) throw new Error(`Invalid supervision ${description}: expected an object`);
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/clients/tui/src/commands.test.ts
+++ b/clients/tui/src/commands.test.ts
@@ -2,14 +2,20 @@ import {describe, expect, it} from 'vitest';
 import {parseInput, slashCommandRange, suggestSlashCommands} from './commands.js';
 
 describe('parseInput', () => {
-  it('only accepts the intentionally small command surface', () => {
+  it('accepts the intentionally small slash-command surface', () => {
     expect(parseInput('/history').request?.type).toBe('query.history');
     expect(parseInput('/perf')).toMatchObject({
       request: {type: 'query.performance'},
       responseView: 'perf',
     });
-    expect(parseInput('what is happening?').error).toContain('Unknown command');
     expect(parseInput('/steer inspect the cache').error).toContain('Unknown command');
+  });
+
+  it('sends ordinary text to the supervision chat endpoint', () => {
+    expect(parseInput('what is happening?')).toEqual({
+      request: {type: 'query.chat', text: 'what is happening?'},
+    });
+    expect(parseInput('')).toEqual({error: 'Enter a question or use /help.'});
   });
 
   it('keeps inspection commands out of the public command surface', () => {

--- a/clients/tui/src/commands.ts
+++ b/clients/tui/src/commands.ts
@@ -45,5 +45,7 @@ export function parseInput(text: string): ParsedInput {
   if (text === '/help') return {localView: 'help'};
   if (text === '/history') return {request: {type: 'query.history'}, responseView: 'history'};
   if (text === '/perf') return {request: {type: 'query.performance'}, responseView: 'perf'};
-  return {error: `Unknown command: ${text || '(empty)'}. Use /help.`};
+  if (text.startsWith('/')) return {error: `Unknown command: ${text}. Use /help.`};
+  if (text === '') return {error: 'Enter a question or use /help.'};
+  return {request: {type: 'query.chat', text}};
 }

--- a/clients/tui/src/generated/protocol.generated.ts
+++ b/clients/tui/src/generated/protocol.generated.ts
@@ -175,8 +175,10 @@ export type PerfMetric = number | null;
 export type PerfUnit = string | null;
 export type Kind14 = "tool_call";
 export type Tool = string;
+export type CallId = string | null;
 export type Kind15 = "tool_result";
 export type Tool1 = string;
+export type CallId1 = string | null;
 export type Content3 = string;
 export type IsError = boolean;
 export type Kind16 = "todo_update";
@@ -428,6 +430,7 @@ export interface RoundFinishedData {
 export interface ToolCallData {
   kind?: Kind14;
   tool: Tool;
+  call_id?: CallId;
   args?: Args;
   status?: AgentStatusData | null;
   [k: string]: unknown;
@@ -438,6 +441,7 @@ export interface Args {
 export interface ToolResultData {
   kind?: Kind15;
   tool: Tool1;
+  call_id?: CallId1;
   content: Content3;
   is_error?: IsError;
   [k: string]: unknown;

--- a/clients/tui/src/generated/protocol.schema.json
+++ b/clients/tui/src/generated/protocol.schema.json
@@ -1370,6 +1370,18 @@
           "title": "Tool",
           "type": "string"
         },
+        "call_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Call Id"
+        },
         "args": {
           "additionalProperties": true,
           "title": "Args",
@@ -1404,6 +1416,18 @@
         "tool": {
           "title": "Tool",
           "type": "string"
+        },
+        "call_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Call Id"
         },
         "content": {
           "title": "Content",

--- a/clients/tui/src/index.ts
+++ b/clients/tui/src/index.ts
@@ -1,5 +1,6 @@
-import {CliRenderEvents, createCliRenderer} from '@opentui/core';
+import {createCliRenderer} from '@opentui/core';
 import {SupervisionClient} from './client.js';
+import {runTuiSession} from './runtime.js';
 import {SocketSessionController} from './session-controller.js';
 import {createOpenTuiApp} from './ui/app.js';
 
@@ -10,9 +11,4 @@ const client = await SupervisionClient.connect(socketPath);
 const renderer = await createCliRenderer({exitOnCtrlC: true});
 const controller = new SocketSessionController(client);
 const app = createOpenTuiApp(renderer, controller);
-renderer.start();
-await controller.start();
-
-await new Promise<void>(resolve => renderer.once(CliRenderEvents.DESTROY, resolve));
-app.destroy();
-await controller.stop();
+await runTuiSession(renderer, controller, app);

--- a/clients/tui/src/run-map.test.ts
+++ b/clients/tui/src/run-map.test.ts
@@ -25,6 +25,38 @@ describe('run map round timing', () => {
     expect(state.rounds[0]?.activeAgentStarts).toEqual({});
     expect(roundAgentElapsedMs(onlyRound(state), new Date('2026-01-01T00:01:00Z'))).toBe(5000);
   });
+
+  it('does not reopen a completed round when the run finishes', () => {
+    let state = initialRunMapState();
+    state = applyRunMapEvent(state, phaseEvent(1, 'phase_started', '2026-01-01T00:00:00Z'));
+    state = applyRunMapEvent(state, phaseEvent(2, 'phase_finished', '2026-01-01T00:00:05Z'));
+    state = applyRunMapEvent(state, {
+      ...phaseEvent(3, 'phase_finished', '2026-01-01T00:00:06Z'),
+      type: 'round_finished',
+      status: 'completed',
+    });
+    state = applyRunMapEvent(state, {
+      ...phaseEvent(4, 'phase_finished', '2026-01-01T00:00:07Z'),
+      type: 'run_finished',
+      status: 'completed',
+    });
+
+    expect(onlyRound(state).status).toBe('completed');
+  });
+
+  it('fails the active round and phase when the run fails', () => {
+    let state = initialRunMapState();
+    state = applyRunMapEvent(state, phaseEvent(1, 'phase_started', '2026-01-01T00:00:00Z'));
+    state = applyRunMapEvent(state, {
+      ...phaseEvent(2, 'phase_finished', '2026-01-01T00:00:05Z'),
+      type: 'run_failed',
+      status: 'failed',
+    });
+
+    expect(onlyRound(state).status).toBe('failed');
+    expect(state.rounds[0]?.activeAgentStarts).toEqual({});
+    expect(state.phases[0]?.status).toBe('failed');
+  });
 });
 
 function initialRunMapState(): RunMapState {

--- a/clients/tui/src/run-map.ts
+++ b/clients/tui/src/run-map.ts
@@ -71,6 +71,13 @@ function applyPhaseEvent(state: RunMapState, event: RunEvent): AgentPhase[] {
   if (roundNumber !== null && state.outerLoop !== null) {
     phases = seedExpectedPhases(state.outerLoop, phases, roundNumber);
   }
+  if (event.type === 'run_failed' || event.type === 'run_interrupted') {
+    return phases.map(phase =>
+      phase.roundNumber === roundNumber && phase.status === 'active'
+        ? {...phase, status: 'failed', finishedAt: event.timestamp}
+        : phase,
+    );
+  }
   if (event.type !== 'phase_started' && event.type !== 'phase_finished') {
     return ensurePhase(phases, kind, roundNumber);
   }
@@ -92,18 +99,22 @@ function applyRoundEvent(rounds: RoundSummary[], event: RunEvent): RoundSummary[
   const number = roundNumberFromLabel(event.round_label);
   if (number === null) return rounds;
   const existing = rounds.find(round => round.number === number);
-  const status =
-    event.type === 'round_finished'
+  if (event.type === 'run_finished') return rounds;
+  const terminalFailure = event.type === 'run_failed' || event.type === 'run_interrupted';
+  const status = terminalFailure
+    ? 'failed'
+    : event.type === 'round_finished'
       ? event.status === 'failed'
         ? 'failed'
         : 'completed'
-      : 'active';
+      : existing?.status === 'completed' || existing?.status === 'failed'
+        ? existing.status
+        : 'active';
+  const terminal = terminalFailure || event.type === 'round_finished';
   const patch: RoundSummary = {
     number,
     status,
-    ...(event.type === 'round_finished'
-      ? {finishedAt: event.timestamp}
-      : {startedAt: event.timestamp}),
+    ...(terminal ? {finishedAt: event.timestamp} : {startedAt: event.timestamp}),
   };
   const round = existing ? mergeRound(existing, patch) : patch;
   return replaceRound(rounds, updateRoundAgentElapsed(round, event));
@@ -192,7 +203,13 @@ function earliestTimestamp(
 
 function updateRoundAgentElapsed(round: RoundSummary, event: RunEvent): RoundSummary {
   if (event.type !== 'phase_started' && event.type !== 'phase_finished') {
-    if (event.type !== 'round_finished') return round;
+    if (
+      event.type !== 'round_finished' &&
+      event.type !== 'run_failed' &&
+      event.type !== 'run_interrupted'
+    ) {
+      return round;
+    }
     return closeActiveAgentTimings(round, event.timestamp);
   }
   return event.type === 'phase_started'

--- a/clients/tui/src/runtime.test.ts
+++ b/clients/tui/src/runtime.test.ts
@@ -1,0 +1,32 @@
+import {describe, expect, it} from 'vitest';
+import {type RuntimeRenderer, runTuiSession} from './runtime.js';
+
+describe('TUI runtime lifecycle', () => {
+  it('cleans up the renderer, app, and controller when startup fails', async () => {
+    const calls: string[] = [];
+    const renderer: RuntimeRenderer = {
+      start: () => calls.push('renderer.start'),
+      destroy: () => calls.push('renderer.destroy'),
+      once: () => undefined,
+    };
+    const controller = {
+      start: async () => {
+        calls.push('controller.start');
+        throw new Error('subscription failed');
+      },
+      stop: async () => {
+        calls.push('controller.stop');
+      },
+    };
+    const app = {destroy: () => calls.push('app.destroy')};
+
+    await expect(runTuiSession(renderer, controller, app)).rejects.toThrow('subscription failed');
+    expect(calls).toEqual([
+      'renderer.start',
+      'controller.start',
+      'renderer.destroy',
+      'app.destroy',
+      'controller.stop',
+    ]);
+  });
+});

--- a/clients/tui/src/runtime.ts
+++ b/clients/tui/src/runtime.ts
@@ -1,0 +1,31 @@
+import {CliRenderEvents} from '@opentui/core';
+import type {SessionController} from './session-controller.js';
+import type {OpenTuiApp} from './ui/app.js';
+
+export interface RuntimeRenderer {
+  start(): void;
+  destroy(): void;
+  once(event: CliRenderEvents, listener: () => void): unknown;
+}
+
+export async function runTuiSession(
+  renderer: RuntimeRenderer,
+  controller: Pick<SessionController, 'start' | 'stop'>,
+  app: OpenTuiApp,
+): Promise<void> {
+  renderer.start();
+  try {
+    await controller.start();
+    await new Promise<void>(resolve => renderer.once(CliRenderEvents.DESTROY, resolve));
+  } finally {
+    try {
+      renderer.destroy();
+    } finally {
+      try {
+        app.destroy();
+      } finally {
+        await controller.stop();
+      }
+    }
+  }
+}

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -20,6 +20,18 @@ describe('session controller', () => {
     expect(transport.requests).toEqual([]);
   });
 
+  it('sends ordinary text as chat and renders the answer', async () => {
+    const transport = new FakeTransport();
+    const controller = new SocketSessionController(transport);
+
+    await controller.submit('what is happening?');
+
+    expect(transport.requests).toEqual([{type: 'query.chat', text: 'what is happening?'}]);
+    expect(controller.state.overlay?.content).toBe(
+      'you: what is happening?\nvibesys: The implementer is running.',
+    );
+  });
+
   it('reduces replay and live events without depending on OpenTUI', async () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
@@ -28,7 +40,7 @@ describe('session controller', () => {
     transport.emit({type: 'event_batch', events: [event(1, 'agent_output_chunk', 'one\n')]});
     transport.emit({type: 'event', event: event(2, 'agent_output_chunk', 'two\n')});
 
-    expect(controller.state.liveContent).toBe('one\ntwo\n');
+    expect(controller.state.conversation.map(entry => entry.content).join('')).toBe('one\ntwo\n');
     expect(controller.state.sequence).toBe(2);
     await controller.stop();
     expect(transport.closed).toBe(true);
@@ -158,6 +170,15 @@ class FakeTransport implements SupervisionTransport {
       ok: true,
       events: this.responseEvents,
       performance: this.responsePerformance,
+      ...(input.type === 'query.chat'
+        ? {
+            chat: {
+              question: input.text,
+              answer: 'The implementer is running.',
+              effect: 'none' as const,
+            },
+          }
+        : {}),
       snapshot: {run_id: 'run', status: 'running', sequence: 12},
     });
   }

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -42,9 +42,6 @@ describe('session event model', () => {
       }),
     );
 
-    expect(state.liveContent).toContain('[round-1] judge started');
-    expect(state.liveContent).toContain('checking accuracy');
-    expect(state.liveContent).toContain('Judge: PASS');
     expect(state.conversation.map(entry => entry.kind)).toEqual(['status', 'assistant', 'result']);
     expect(state.conversation[1]?.content).toBe('checking accuracy\n');
   });
@@ -209,8 +206,48 @@ describe('session event model', () => {
       toolCall: '→ Bash(command="first")\n',
       toolResponse: 'first result',
     });
-    expect(state.liveContent).toContain('→ Bash(command="first")');
-    expect(state.liveContent).toContain('first result');
+  });
+
+  it('correlates parallel typed tool results by call ID', () => {
+    let state = initialSessionState();
+    state = applyEvent(
+      state,
+      event(
+        1,
+        'tool_call',
+        {kind: 'tool_call', tool: 'Read', call_id: 'call-a', args: {path: 'a'}},
+        'inv-1',
+      ),
+    );
+    state = applyEvent(
+      state,
+      event(
+        2,
+        'tool_call',
+        {kind: 'tool_call', tool: 'Read', call_id: 'call-b', args: {path: 'b'}},
+        'inv-1',
+      ),
+    );
+    state = applyEvent(
+      state,
+      event(
+        3,
+        'tool_result',
+        {kind: 'tool_result', tool: 'Read', call_id: 'call-b', content: 'result b'},
+        'inv-1',
+      ),
+    );
+    state = applyEvent(
+      state,
+      event(
+        4,
+        'tool_result',
+        {kind: 'tool_result', tool: 'Read', call_id: 'call-a', content: 'result a'},
+        'inv-1',
+      ),
+    );
+
+    expect(state.conversation.map(entry => entry.toolResponse)).toEqual(['result a', 'result b']);
   });
 
   it('truncates long typed tool-call arguments and renders non-string args as JSON', () => {
@@ -270,7 +307,6 @@ describe('session event model', () => {
       },
     ]);
     expect(state.conversation).toHaveLength(0);
-    expect(state.liveContent).toBe('Waiting for run events…');
   });
 
   it('keeps each phase’s todo list separate so agents never clobber each other', () => {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -18,7 +18,6 @@ export interface SessionState {
   phases: AgentPhase[];
   selectedRound: number | null;
   selectedAgentKind: string | null;
-  liveContent: string;
   conversation: ConversationEntry[];
   overlay: OverlayPanel | null;
   terminal: boolean;
@@ -82,6 +81,8 @@ export interface ConversationEntry {
   startsTurn?: boolean;
   toolCall?: string;
   toolResponse?: string;
+  toolName?: string;
+  toolCallId?: string;
 }
 
 export function initialSessionState(): SessionState {
@@ -95,7 +96,6 @@ export function initialSessionState(): SessionState {
     phases: [],
     selectedRound: null,
     selectedAgentKind: null,
-    liveContent: 'Waiting for run events…',
     conversation: [],
     overlay: null,
     terminal: false,
@@ -161,8 +161,6 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
   const suppressed =
     data?.kind === 'agent_output_chunk' && data.channel === 'tool' && next.typedToolEvents;
   if (!suppressed) {
-    const line = renderEventForTranscript(event);
-    if (line !== null) next.liveContent = appendTranscript(next.liveContent, line);
     const entry = eventToConversationEntry(event);
     if (entry !== null) next.conversation = appendConversation(next.conversation, entry);
   }
@@ -303,6 +301,8 @@ function eventToConversationEntry(event: RunEvent): ConversationEntry | null {
       ...(invocationId === undefined ? {} : {invocationId}),
       startsTurn: true,
       toolCall: call,
+      toolName: data.tool,
+      ...(data.call_id === null || data.call_id === undefined ? {} : {toolCallId: data.call_id}),
     };
   }
   if (data?.kind === 'tool_result') {
@@ -316,6 +316,8 @@ function eventToConversationEntry(event: RunEvent): ConversationEntry | null {
       ...agentKind,
       ...roundFields,
       turnId: invocationId ?? id,
+      toolName: data.tool,
+      ...(data.call_id === null || data.call_id === undefined ? {} : {toolCallId: data.call_id}),
       ...(invocationId === undefined ? {} : {invocationId}),
     };
   }
@@ -395,6 +397,14 @@ function appendConversation(
   previous: ConversationEntry[],
   incoming: ConversationEntry,
 ): ConversationEntry[] {
+  if (incoming.kind === 'tool' && !incoming.startsTurn && incoming.toolName !== undefined) {
+    const target = findToolCall(previous, incoming);
+    if (target !== -1) {
+      return previous.map((entry, index) =>
+        index === target ? mergeToolResult(entry, incoming) : entry,
+      );
+    }
+  }
   const last = previous.at(-1);
   if (
     last &&
@@ -403,16 +413,7 @@ function appendConversation(
     last.invocationId === incoming.invocationId &&
     !incoming.startsTurn
   ) {
-    const separator = last.content.endsWith('\n') || incoming.content.startsWith('\n') ? '' : '\n';
-    return [
-      ...previous.slice(0, -1),
-      {
-        ...last,
-        content: last.content + separator + incoming.content,
-        toolResponse:
-          (last.toolResponse ?? '') + (last.toolResponse ? separator : '') + incoming.content,
-      },
-    ];
+    return [...previous.slice(0, -1), mergeToolResult(last, incoming)];
   }
   if (
     last &&
@@ -423,6 +424,38 @@ function appendConversation(
     return [...previous.slice(0, -1), {...last, content: last.content + incoming.content}];
   }
   return [...previous, incoming].slice(-1_000);
+}
+
+function findToolCall(previous: ConversationEntry[], result: ConversationEntry): number {
+  const indices = Array.from(previous.keys());
+  if (result.toolCallId !== undefined) indices.reverse();
+  for (const index of indices) {
+    const candidate = previous[index];
+    if (
+      candidate?.kind !== 'tool' ||
+      candidate.toolCall === undefined ||
+      candidate.toolResponse !== undefined ||
+      candidate.invocationId !== result.invocationId
+    ) {
+      continue;
+    }
+    if (result.toolCallId !== undefined) {
+      if (candidate.toolCallId === result.toolCallId) return index;
+      continue;
+    }
+    if (candidate.toolName === result.toolName) return index;
+  }
+  return -1;
+}
+
+function mergeToolResult(call: ConversationEntry, result: ConversationEntry): ConversationEntry {
+  const separator = call.content.endsWith('\n') || result.content.startsWith('\n') ? '' : '\n';
+  return {
+    ...call,
+    content: call.content + separator + result.content,
+    toolResponse: (call.toolResponse ?? '') + (call.toolResponse ? separator : '') + result.content,
+    ...(result.tone === undefined ? {} : {tone: result.tone}),
+  };
 }
 
 export function showLive(state: SessionState): SessionState {
@@ -522,39 +555,4 @@ function formatToolCall(tool: string, args: Record<string, unknown>): string {
     return isString ? `${key}="${rendered}"` : `${key}=${rendered}`;
   });
   return `→ ${tool}(${parts.join(', ')})\n`;
-}
-
-function renderEventForTranscript(event: RunEvent): string | null {
-  const data = event.data;
-  if (data?.kind === 'agent_output_chunk' || data?.kind === 'subprocess_output') {
-    return data.content;
-  }
-  if (data?.kind === 'tool_call') {
-    return formatToolCall(data.tool, data.args ?? {});
-  }
-  if (data?.kind === 'tool_result') {
-    return data.content.endsWith('\n') ? data.content : `${data.content}\n`;
-  }
-  if (data?.kind === 'output') return data.content;
-  if (data?.kind === 'judge_result') {
-    return `Judge: ${data.verdict.toUpperCase()}${data.feedback ? ` — ${data.feedback}` : ''}\n`;
-  }
-  if (data?.kind === 'benchmark_result') {
-    return `Benchmark: ${data.metric}=${data.value} ${data.unit}\n`;
-  }
-  if (data?.kind === 'round_finished') {
-    return `Round finished: ${data.judge_verdict.toUpperCase()} after ${data.attempts} attempt(s)\n`;
-  }
-  if (event.type === 'phase_started') {
-    return `\n[${event.round_label ?? 'run'}] ${event.agent_kind ?? 'phase'} started\n`;
-  }
-  if (event.type === 'run_failed' || event.type === 'run_interrupted') {
-    return `\nRun failed: ${event.text || 'interrupted'}\n`;
-  }
-  return null;
-}
-
-function appendTranscript(previous: string, next: string): string {
-  const current = previous === 'Waiting for run events…' ? '' : previous;
-  return `${current}${next}`.slice(-500_000);
 }

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -93,6 +93,18 @@ describe('OpenTUI presentation', () => {
     expect(controller.submissions).toEqual(['/help']);
   });
 
+  it('submits ordinary text as an operator question', async () => {
+    const testRenderer = await createTestRenderer({width: 80, height: 16});
+    const controller = new FakeController(initialSessionState());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    await testRenderer.mockInput.typeText('what is running?');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.submissions.length === 1);
+    expect(controller.submissions).toEqual(['what is running?']);
+  });
+
   it('suggests and completes slash commands with Tab', async () => {
     const testRenderer = await createTestRenderer({width: 80, height: 16});
     const controller = new FakeController(initialSessionState());
@@ -213,6 +225,78 @@ describe('OpenTUI presentation', () => {
     testRenderer.mockInput.pressKey('p', {ctrl: true});
     const expanded = await testRenderer.waitForFrame(value => value.includes('prompt line 20'));
     expect(expanded).toContain('collapse');
+  });
+
+  it('expands the latest visible prompt without dropping agent filters', async () => {
+    const visiblePrompt = Array.from(
+      {length: 20},
+      (_, index) => `implementer prompt ${index + 1}`,
+    ).join('\n');
+    const hiddenPrompt = Array.from({length: 20}, (_, index) => `judge prompt ${index + 1}`).join(
+      '\n',
+    );
+    const testRenderer = await createTestRenderer({width: 100, height: 20});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      selectedRound: 1,
+      selectedAgentKind: 'implementer',
+      rounds: [{number: 1, status: 'active'}],
+      conversation: [
+        {
+          id: 'implementer-prompt',
+          kind: 'prompt',
+          agentKind: 'implementer',
+          roundNumber: 1,
+          content: visiblePrompt,
+        },
+        {
+          id: 'judge-prompt',
+          kind: 'prompt',
+          agentKind: 'judge',
+          roundNumber: 1,
+          content: hiddenPrompt,
+        },
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    await testRenderer.waitForFrame(value => value.includes('implementer prompt 1'));
+    testRenderer.mockInput.pressKey('p', {ctrl: true});
+    const expanded = await testRenderer.waitForFrame(value =>
+      value.includes('implementer prompt 20'),
+    );
+    expect(expanded).not.toContain('judge prompt');
+  });
+
+  it('preserves existing cards when a large transcript receives state-only and tail updates', async () => {
+    const conversation = Array.from({length: 1_000}, (_, index) => ({
+      id: `entry-${index}`,
+      kind: 'status' as const,
+      content: `event ${index}`,
+    }));
+    const testRenderer = await createTestRenderer({width: 100, height: 20});
+    const controller = new FakeController({...initialSessionState(), conversation});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('event 999'));
+    const firstCard = testRenderer.renderer.root.findDescendantById('event-entry-0');
+    const lastCard = testRenderer.renderer.root.findDescendantById('event-entry-999');
+
+    controller.publish({...controller.state, status: 'paused'});
+    expect(testRenderer.renderer.root.findDescendantById('event-entry-0')).toBe(firstCard);
+    expect(testRenderer.renderer.root.findDescendantById('event-entry-999')).toBe(lastCard);
+
+    const previousLast = conversation.at(-1);
+    if (previousLast === undefined) throw new Error('large transcript is unexpectedly empty');
+    const updatedLast = {...previousLast, content: 'updated tail'};
+    controller.publish({
+      ...controller.state,
+      conversation: [...conversation.slice(0, -1), updatedLast],
+    });
+    await testRenderer.waitForFrame(value => value.includes('updated tail'));
+    expect(testRenderer.renderer.root.findDescendantById('event-entry-0')).toBe(firstCard);
+    expect(testRenderer.renderer.root.findDescendantById('event-entry-999')).not.toBe(lastCard);
   });
 
   it('selects an agent with Tab and filters the transcript', async () => {
@@ -358,6 +442,11 @@ class FakeController implements SessionController {
   liveCalls = 0;
 
   constructor(public state: SessionState) {}
+
+  publish(state: SessionState): void {
+    this.state = state;
+    for (const listener of this.#listeners) listener(this.state);
+  }
 
   start(): Promise<void> {
     return Promise.resolve();

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -15,6 +15,7 @@ export class ConversationView {
   readonly output: BoxRenderable;
   readonly #expandedPrompts = new Set<string>();
   #renderedConversation: ConversationEntry[] = [];
+  #renderedCards: BoxRenderable[] = [];
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -35,10 +36,9 @@ export class ConversationView {
   }
 
   toggleLatestPrompt(): void {
-    const latestPrompt = [...this.controller.state.conversation]
-      .reverse()
-      .find(entry => entry.kind === 'prompt');
-    if (latestPrompt) this.#togglePrompt(latestPrompt.id);
+    const visible = visibleConversation(this.controller.state);
+    const latestPrompt = [...visible].reverse().find(entry => entry.kind === 'prompt');
+    if (latestPrompt) this.#togglePrompt(latestPrompt.id, visible);
   }
 
   #clear(): void {
@@ -46,29 +46,56 @@ export class ConversationView {
       this.output.remove(child);
       child.destroyRecursively();
     }
+    this.#renderedCards = [];
   }
 
   #renderConversation(entries: ConversationEntry[]): void {
-    if (entries === this.#renderedConversation) return;
-    this.#renderedConversation = entries;
-    this.#clear();
-    if (entries.length === 0) {
-      this.output.add(
-        new TextRenderable(this.renderer, {
-          content: 'Waiting for run events…',
-          fg: '#64748b',
-        }),
-      );
+    if (sameEntries(entries, this.#renderedConversation)) return;
+    if (isEntryPrefix(this.#renderedConversation, entries)) {
+      for (const entry of entries.slice(this.#renderedConversation.length)) {
+        const card = this.#renderEntry(entry);
+        this.output.add(card);
+        this.#renderedCards.push(card);
+      }
+      this.#renderedConversation = entries;
       return;
     }
-    for (const entry of entries) this.output.add(this.#renderEntry(entry));
+    const changedIndex = singleChangedEntryIndex(this.#renderedConversation, entries);
+    if (changedIndex !== -1) {
+      const previousCard = this.#renderedCards[changedIndex];
+      const entry = entries[changedIndex];
+      if (previousCard !== undefined && entry !== undefined) {
+        this.output.remove(previousCard);
+        previousCard.destroyRecursively();
+        const card = this.#renderEntry(entry);
+        this.output.add(card, changedIndex);
+        this.#renderedCards[changedIndex] = card;
+        this.#renderedConversation = entries;
+        return;
+      }
+    }
+    this.#clear();
+    this.#renderedConversation = entries;
+    if (entries.length === 0) {
+      const card = new TextRenderable(this.renderer, {
+        content: 'Waiting for run events…',
+        fg: '#64748b',
+      });
+      this.output.add(card);
+      return;
+    }
+    for (const entry of entries) {
+      const card = this.#renderEntry(entry);
+      this.output.add(card);
+      this.#renderedCards.push(card);
+    }
   }
 
-  #togglePrompt(id: string): void {
+  #togglePrompt(id: string, visible = visibleConversation(this.controller.state)): void {
     if (this.#expandedPrompts.has(id)) this.#expandedPrompts.delete(id);
     else this.#expandedPrompts.add(id);
     this.#renderedConversation = [];
-    this.#renderConversation(this.controller.state.conversation);
+    this.#renderConversation(visible);
   }
 
   #renderEntry(entry: ConversationEntry): BoxRenderable {
@@ -155,4 +182,30 @@ export class ConversationView {
       );
     }
   }
+}
+
+function sameEntries(left: ConversationEntry[], right: ConversationEntry[]): boolean {
+  return left.length === right.length && left.every((entry, index) => entry === right[index]);
+}
+
+function isEntryPrefix(prefix: ConversationEntry[], entries: ConversationEntry[]): boolean {
+  return (
+    prefix.length > 0 &&
+    prefix.length < entries.length &&
+    prefix.every((entry, index) => entry === entries[index])
+  );
+}
+
+function singleChangedEntryIndex(
+  previous: ConversationEntry[],
+  entries: ConversationEntry[],
+): number {
+  if (previous.length === 0 || previous.length !== entries.length) return -1;
+  let changedIndex = -1;
+  for (let index = 0; index < entries.length; index += 1) {
+    if (previous[index] === entries[index]) continue;
+    if (changedIndex !== -1 || previous[index]?.id !== entries[index]?.id) return -1;
+    changedIndex = index;
+  }
+  return changedIndex;
 }

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -1,6 +1,8 @@
 import json
 import time
 import traceback
+import uuid
+from collections import defaultdict, deque
 from collections.abc import Callable
 from typing import Any, TextIO
 
@@ -92,6 +94,7 @@ class AgentLogger(BaseCallbackHandler):
         self._latest_usage: dict[str, Any] | None = None
         self._context_window_lookup = context_window_lookup or _default_context_window_lookup
         self._context_window = self._context_window_lookup(model_name)
+        self._pending_tool_calls: dict[str, deque[str]] = defaultdict(deque)
 
     def _status(self) -> AgentStatusData:
         """Snapshot the ``[progress | label | elapsed | tokens/max]`` readings.
@@ -216,7 +219,7 @@ class AgentLogger(BaseCallbackHandler):
             self._publish(text + "\n", "assistant")
             self._log_line(text)
         for tc in msg.tool_calls:
-            self._emit_tool_call(tc["name"], tc["args"])
+            self._emit_tool_call(tc["name"], tc["args"], call_id=tc.get("id"))
 
     # --- Tool execution ---
 
@@ -233,7 +236,12 @@ class AgentLogger(BaseCallbackHandler):
     def on_tool_end(self, output: Any, **kwargs: Any) -> None:
         content = output.content if hasattr(output, "content") else str(output)
         name = getattr(output, "name", None) or "unknown"
-        self._emit_tool_result(name, content)
+        call_id = getattr(output, "tool_call_id", None)
+        self._emit_tool_result(
+            name,
+            content,
+            call_id=call_id if isinstance(call_id, str) and call_id else None,
+        )
 
     def on_tool_error(self, error: Any, **kwargs: Any) -> None:
         lines = [f"Tool error: {error!r}"]
@@ -268,8 +276,12 @@ class AgentLogger(BaseCallbackHandler):
         }
     )
 
-    def _emit_tool_call(self, name: str, args: dict[str, Any]):
-        output_sink().tool_call(name, args, status=self._status())
+    def _emit_tool_call(
+        self, name: str, args: dict[str, Any], *, call_id: str | None = None
+    ) -> None:
+        resolved_call_id = call_id or uuid.uuid4().hex
+        self._pending_tool_calls[name].append(resolved_call_id)
+        output_sink().tool_call(name, args, call_id=resolved_call_id, status=self._status())
         todos = todos_from_tool_call(name, args)
         if todos is not None:
             output_sink().todo_update(todos)
@@ -296,9 +308,25 @@ class AgentLogger(BaseCallbackHandler):
     # readable while still capturing enough output for debugging.
     _LOG_MAX_RESULT_LEN = 2000
 
-    def _emit_tool_result(self, name: str, content: str, *, is_error: bool = False):
+    def _emit_tool_result(
+        self,
+        name: str,
+        content: str,
+        *,
+        call_id: str | None = None,
+        is_error: bool = False,
+    ) -> None:
         full_text = str(content)
-        output_sink().tool_result(name, full_text, is_error=is_error)
+        pending = self._pending_tool_calls[name]
+        resolved_call_id = call_id
+        if resolved_call_id is None and pending:
+            resolved_call_id = pending.popleft()
+        elif resolved_call_id is not None:
+            try:
+                pending.remove(resolved_call_id)
+            except ValueError:
+                pass
+        output_sink().tool_result(name, full_text, call_id=resolved_call_id, is_error=is_error)
 
         # Truncated to log file
         if self._log_file:

--- a/src/vibesys/render/sink.py
+++ b/src/vibesys/render/sink.py
@@ -80,17 +80,25 @@ class OutputSink:
         tool: str,
         args: dict[str, Any],
         *,
+        call_id: str | None = None,
         status: AgentStatusData | None = None,
     ) -> None:
         self._emit(
             EventType.TOOL_CALL,
-            ToolCallData(tool=tool, args=_json_safe(args), status=status),
+            ToolCallData(tool=tool, call_id=call_id, args=_json_safe(args), status=status),
         )
 
-    def tool_result(self, tool: str, content: str, *, is_error: bool = False) -> None:
+    def tool_result(
+        self,
+        tool: str,
+        content: str,
+        *,
+        call_id: str | None = None,
+        is_error: bool = False,
+    ) -> None:
         self._emit(
             EventType.TOOL_RESULT,
-            ToolResultData(tool=tool, content=content, is_error=is_error),
+            ToolResultData(tool=tool, call_id=call_id, content=content, is_error=is_error),
         )
 
     def todo_update(self, todos: list[TodoItemData]) -> None:

--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -137,6 +137,7 @@ class AgentOutputChunkData(BaseModel):
 class ToolCallData(BaseModel):
     kind: Literal["tool_call"] = "tool_call"
     tool: str
+    call_id: str | None = None
     args: dict[str, Any] = Field(default_factory=dict)
     status: AgentStatusData | None = None
 
@@ -144,6 +145,7 @@ class ToolCallData(BaseModel):
 class ToolResultData(BaseModel):
     kind: Literal["tool_result"] = "tool_result"
     tool: str
+    call_id: str | None = None
     content: str
     is_error: bool = False
 

--- a/tests/agents/test_callbacks.py
+++ b/tests/agents/test_callbacks.py
@@ -1,10 +1,13 @@
 import io
 import re
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.progress import RoundProgress
 from vibesys.constants import DIM, GREEN, RED, RESET
+from vibesys.render.sink import output_sink
+from vibesys.server.events import ToolCallData, ToolResultData
 
 _ANSI_RE = re.compile(r"\033\[[0-9;]*m")
 
@@ -108,6 +111,51 @@ class TestOnToolStart:
         logger.on_tool_start(serialized, "", inputs={"cmd": "ls -la"})
         out = capsys.readouterr().out
         assert out == ""
+
+
+class TestToolCorrelation:
+    def test_provider_call_ids_correlate_parallel_results(self):
+        seen = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            logger = AgentLogger()
+            logger.on_llm_end(
+                _make_response(
+                    tool_calls=[
+                        {"id": "call-a", "name": "Read", "args": {"path": "a"}},
+                        {"id": "call-b", "name": "Read", "args": {"path": "b"}},
+                    ]
+                )
+            )
+            logger.on_tool_end(
+                SimpleNamespace(name="Read", tool_call_id="call-b", content="result b")
+            )
+            logger.on_tool_end(
+                SimpleNamespace(name="Read", tool_call_id="call-a", content="result a")
+            )
+        finally:
+            unsubscribe()
+
+        calls = [event.data for event in seen if isinstance(event.data, ToolCallData)]
+        results = [event.data for event in seen if isinstance(event.data, ToolResultData)]
+        assert [call.call_id for call in calls] == ["call-a", "call-b"]
+        assert [result.call_id for result in results] == ["call-b", "call-a"]
+
+    def test_cli_events_get_stable_fifo_call_ids(self):
+        seen = []
+        unsubscribe = output_sink().subscribe(seen.append)
+        try:
+            logger = AgentLogger()
+            logger.on_tool_call("Read", {"path": "a"})
+            logger.on_tool_call("Read", {"path": "b"})
+            logger.on_tool_result("Read", stdout="result a")
+            logger.on_tool_result("Read", stdout="result b")
+        finally:
+            unsubscribe()
+
+        calls = [event.data for event in seen if isinstance(event.data, ToolCallData)]
+        results = [event.data for event in seen if isinstance(event.data, ToolResultData)]
+        assert [result.call_id for result in results] == [call.call_id for call in calls]
 
 
 class TestOnToolEnd:

--- a/tests/render/test_sink.py
+++ b/tests/render/test_sink.py
@@ -55,11 +55,12 @@ class TestTypedEmitters:
     def test_tool_call_event(self):
         sink = OutputSink()
         seen, _ = _collect(sink)
-        sink.tool_call("shell", {"cmd": "ls"})
+        sink.tool_call("shell", {"cmd": "ls"}, call_id="call-1")
         assert seen[0].type == EventType.TOOL_CALL
         data = seen[0].data
         assert isinstance(data, ToolCallData)
         assert data.tool == "shell"
+        assert data.call_id == "call-1"
         assert data.args == {"cmd": "ls"}
 
     def test_tool_call_args_coerced_to_json_safe(self):
@@ -75,10 +76,11 @@ class TestTypedEmitters:
     def test_tool_result_event(self):
         sink = OutputSink()
         seen, _ = _collect(sink)
-        sink.tool_result("shell", "output text", is_error=True)
+        sink.tool_result("shell", "output text", call_id="call-1", is_error=True)
         data = seen[0].data
         assert isinstance(data, ToolResultData)
         assert data.tool == "shell"
+        assert data.call_id == "call-1"
         assert data.content == "output text"
         assert data.is_error is True
 


### PR DESCRIPTION
## Problem

The TUI had several correctness and scaling gaps that made long or concurrent runs unreliable:

- terminal run events could reopen completed rounds or leave active phases and timers unfinished;
- concurrent calls to the same tool could attach results to the wrong call;
- Ctrl+P could replace a filtered conversation with the unfiltered transcript;
- every event rebuilt the full retained conversation, while the model also kept a redundant 500 KB transcript;
- ordinary questions were rejected even though the supervision protocol supports chat; and
- stalled, malformed, or disconnected sockets and startup failures were not consistently bounded or cleaned up.

These issues made the operator interface harder to trust and maintain as run volume and event concurrency increased.

## Solution

- Make round and phase terminal transitions monotonic, and close active phase/timing state on failure or interruption.
- Add an optional `call_id` to tool-call and tool-result events, propagate provider IDs end to end, generate IDs when absent, and retain a FIFO fallback for legacy producers.
- Preserve active round/agent filters when toggling prompts, update only appended or changed conversation cards, and remove the duplicate transcript buffer.
- Route ordinary prompt text through `query.chat` while keeping unknown slash commands strict.
- Validate JSONL response envelopes and versions, bound connection/request/subscription waits, deduplicate disconnect handling, and guarantee lifecycle cleanup after startup failure.
- Document the TUI ownership model, failure behavior, operator controls, and development checks.

The protocol addition is backward compatible because `call_id` is optional in both the Python event models and generated TypeScript bindings.

### Architecture

```mermaid
flowchart LR
  A["Python agent callbacks"] --> B["Typed output sink"]
  B --> C["Supervision JSONL socket"]
  C --> D["Validated TypeScript client"]
  D --> E["Session controller"]
  E --> F["Pure session and run reducers"]
  F --> G["Incremental OpenTUI views"]
```

Tool-call identity is assigned at the callback boundary, carried through the typed event contract, and consumed by the session reducer. Transport concerns remain in the socket client, state transitions remain reducer-owned, and rendering reuses unaffected cards rather than rebuilding the whole view.

## Verification

The complete TypeScript and Python suites pass. Generated protocol artifacts were regenerated twice and remained byte-for-byte stable. A focused terminal-state reproduction also confirmed that a completed round remains completed after `run_finished`.

### Correctness properties

- Completed or failed rounds do not return to active state after terminal run events.
- Failure and interruption close matching active phases and agent timing intervals.
- Results with `call_id` attach only to that call; legacy results without IDs use FIFO matching for the same tool and invocation.
- Ctrl+P expands the latest prompt in the currently visible filtered conversation.
- Append-only and single-entry state updates preserve unaffected renderables; retained conversation remains capped at 1,000 entries.
- Ordinary non-empty text becomes a chat request, while unknown slash commands still return a local error.
- Malformed or unsupported frames fail in a controlled way, pending requests are time-bounded, disconnect callbacks are emitted once, and runtime resources are cleaned up on startup failure.
- Existing event producers and consumers remain compatible because the new tool-call identifier is optional.

### Testing

- `pnpm check:ts` — passed.
- `pnpm --dir clients/tui check` — passed.
- `pnpm --dir clients/tui test` — 79 tests passed across 12 files.
- `pnpm --dir clients/tui build` — passed.
- `./scripts/check_format.sh` — passed.
- `./scripts/check_lint.sh` — passed.
- `./scripts/check_types.sh` — passed with 0 errors.
- `uv run pytest -q` — 1,889 passed, 1 skipped (the macOS-only sandbox test).
- `pnpm --dir clients/tui generate:protocol` — regenerated artifacts reproducibly with no second-run diff.
- `git diff --check` — passed.
