### PR TITLE
Count examples in GitHub language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+examples/** -linguist-documentation


### PR DESCRIPTION
## Problem

GitHub Linguist classifies a top-level `examples/` directory as documentation,
so the substantial implementation code in this repository is omitted from the
GitHub language distribution. As a result, the repository overview does not
represent the languages used by its maintained examples and evaluators.

## Solution

Add a root `.gitattributes` override that unsets `linguist-documentation` for
files under `examples/`. This changes only GitHub Linguist classification;
existing generated and vendored detection continues to apply.

### Architecture

Repository-owned Git attributes provide the classification override at the
boundary where GitHub Linguist reads repository metadata. No runtime or package
architecture changes are involved.

## Verification

Compared GitHub Linguist 9.3.0 output for the parent commit and this commit
using the official container image. The new commit includes source from
`examples/`, adding Go, Rust, C++, C, Lua, CMake, and Makefile entries and
increasing counted Python bytes.

### Correctness properties

- Files under `examples/` are no longer excluded solely because Linguist treats
  the directory as documentation.
- Other Linguist heuristics, including generated and vendored classification,
  remain unchanged.
- Runtime behavior and repository contents under `examples/` are unchanged.

### Testing

- `git check-attr linguist-documentation -- examples/evaluators/queue/main.go examples/kv-store/accuracy_checker/checker.py` — both report the attribute as unset.
- `git diff --cached --check` — passed before commit.
- Official Linguist container against `HEAD^` — baseline excludes `examples/`
  languages.
- Official Linguist container against `HEAD` — updated distribution includes
  `examples/` source.
