### PR TITLE
Add multi-turn experiment chat to the TUI

### DIFF
--- a/clients/tui/src/commands.test.ts
+++ b/clients/tui/src/commands.test.ts
@@ -8,6 +8,10 @@ describe('parseInput', () => {
       request: {type: 'query.performance'},
       responseView: 'perf',
     });
+    expect(parseInput('/chat what changed in the latest round?')).toEqual({
+      localView: 'chat',
+      chatMessage: 'what changed in the latest round?',
+    });
     expect(parseInput('what is happening?').error).toContain('Unknown command');
     expect(parseInput('/steer inspect the cache').error).toContain('Unknown command');
   });
@@ -21,12 +25,18 @@ describe('parseInput', () => {
   it('provides local help without a backend request', () => {
     expect(parseInput('/help')).toEqual({localView: 'help'});
   });
+
+  it('opens chat without requiring an initial question', () => {
+    expect(parseInput('/chat')).toEqual({localView: 'chat'});
+    expect(parseInput('/chat   ')).toEqual({localView: 'chat'});
+  });
 });
 
 describe('slash-command input helpers', () => {
   it('suggests available commands from a slash prefix', () => {
     expect(suggestSlashCommands('/').map(command => command.name)).toEqual([
       '/help',
+      '/chat',
       '/history',
       '/perf',
     ]);

--- a/clients/tui/src/commands.ts
+++ b/clients/tui/src/commands.ts
@@ -1,7 +1,8 @@
 import type {RequestInput} from './protocol.js';
 
 export type ParsedInput = {
-  localView?: 'help';
+  localView?: 'chat' | 'help';
+  chatMessage?: string;
   request?: RequestInput;
   responseView?: 'history' | 'perf';
   error?: string;
@@ -14,6 +15,7 @@ export interface SlashCommand {
 
 export const SLASH_COMMANDS: readonly SlashCommand[] = [
   {name: '/help', description: 'Show this help'},
+  {name: '/chat', description: 'Open experiment chat'},
   {name: '/history', description: 'List rounds and their elapsed time'},
   {name: '/perf', description: 'Plot performance by round'},
 ];
@@ -43,6 +45,11 @@ export function slashCommandRange(text: string): {start: number; end: number} | 
 
 export function parseInput(text: string): ParsedInput {
   if (text === '/help') return {localView: 'help'};
+  const chat = text.match(/^\/chat(?:\s+(.*))?$/);
+  if (chat) {
+    const message = chat[1]?.trim();
+    return {localView: 'chat', ...(message ? {chatMessage: message} : {})};
+  }
   if (text === '/history') return {request: {type: 'query.history'}, responseView: 'history'};
   if (text === '/perf') return {request: {type: 'query.performance'}, responseView: 'perf'};
   return {error: `Unknown command: ${text || '(empty)'}. Use /help.`};

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -200,17 +200,19 @@ describe('session controller', () => {
     expect(transport.requests).toEqual([{type: 'query.chat', text: 'why?'}]);
   });
 
-  it('queues messages entered while the chat agent is still working', async () => {
+  it('batches messages queued while the chat agent is still working', async () => {
     const transport = new DeferredChatTransport();
     const controller = new SocketSessionController(transport);
 
     const first = controller.sendChat('first question');
     const second = controller.sendChat('follow-up question');
+    const third = controller.sendChat('one more detail');
 
     expect(transport.requests).toEqual([{type: 'query.chat', text: 'first question'}]);
     expect(controller.state.chatConversation).toMatchObject([
       {kind: 'user', label: 'You', content: 'first question'},
       {kind: 'user', label: 'You · queued', content: 'follow-up question'},
+      {kind: 'user', label: 'You · queued', content: 'one more detail'},
     ]);
 
     transport.resolveNext('first answer');
@@ -219,20 +221,46 @@ describe('session controller', () => {
 
     expect(transport.requests).toEqual([
       {type: 'query.chat', text: 'first question'},
-      {type: 'query.chat', text: 'follow-up question'},
+      {type: 'query.chat', text: 'follow-up question\n\none more detail'},
     ]);
     expect(controller.state.chatConversation[1]?.label).toBe('You');
+    expect(controller.state.chatConversation[2]?.label).toBe('You');
 
     transport.resolveNext('follow-up answer');
-    await Promise.all([first, second]);
+    await Promise.all([first, second, third]);
 
     expect(controller.state.chatPending).toBe(false);
     expect(controller.state.chatConversation.map(entry => entry.content)).toEqual([
       'first question',
       'follow-up question',
+      'one more detail',
       'first answer',
       'follow-up answer',
     ]);
+  });
+
+  it('starts a new batch for messages entered after a queued batch is sent', async () => {
+    const transport = new DeferredChatTransport();
+    const controller = new SocketSessionController(transport);
+
+    const first = controller.sendChat('first');
+    const second = controller.sendChat('second');
+    const third = controller.sendChat('third');
+    transport.resolveNext('first answer');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(transport.requests.at(-1)).toEqual({type: 'query.chat', text: 'second\n\nthird'});
+
+    const fourth = controller.sendChat('fourth');
+    transport.resolveNext('batched answer');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(transport.requests.at(-1)).toEqual({type: 'query.chat', text: 'fourth'});
+
+    transport.resolveNext('fourth answer');
+    await Promise.all([first, second, third, fourth]);
   });
 
   it('shows chat request failures as explicit failed trajectory entries', async () => {

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -136,6 +136,85 @@ describe('session controller', () => {
     expect(controller.state.overlay?.content).toContain('Performance · total_ops_per_sec');
     expect(controller.state.overlay?.content).toContain('best r2 2.4k total_ops_per_sec');
   });
+
+  it('opens a multi-turn chat panel and renders agent answers there', async () => {
+    const transport = new FakeTransport(
+      [
+        chatEvent(1, 'agent_output_chunk', {
+          kind: 'agent_output_chunk',
+          channel: 'analysis',
+          content: 'Reading progress.md',
+        }),
+        chatEvent(2, 'tool_call', {
+          kind: 'tool_call',
+          tool: 'read_file',
+          args: {path: 'progress.md'},
+          status: null,
+        }),
+        chatEvent(3, 'chat', {
+          kind: 'chat',
+          answer: 'Round 2 improved throughput.',
+        }),
+      ],
+      [],
+      {
+        question: 'what changed?',
+        answer: 'Round 2 improved throughput.',
+        effect: 'none',
+      },
+    );
+    const controller = new SocketSessionController(transport);
+
+    await controller.submit('/chat');
+
+    expect(controller.state.chatOpen).toBe(true);
+    expect(transport.requests).toEqual([]);
+
+    await controller.sendChat('what changed?');
+
+    expect(transport.requests).toEqual([{type: 'query.chat', text: 'what changed?'}]);
+    expect(controller.state.chatConversation.map(entry => entry.kind)).toEqual([
+      'user',
+      'analysis',
+      'tool',
+      'assistant',
+    ]);
+    expect(controller.state.chatConversation.at(-1)?.content).toBe('Round 2 improved throughput.');
+
+    controller.closeChat();
+    expect(controller.state.chatOpen).toBe(false);
+    expect(controller.state.chatConversation).toHaveLength(4);
+  });
+
+  it('opens chat and sends an initial message from the command line', async () => {
+    const transport = new FakeTransport([], [], {
+      question: 'why?',
+      answer: 'Because the configuration failed.',
+      effect: 'none',
+    });
+    const controller = new SocketSessionController(transport);
+
+    await controller.submit('/chat why?');
+
+    expect(controller.state.chatOpen).toBe(true);
+    expect(transport.requests).toEqual([{type: 'query.chat', text: 'why?'}]);
+  });
+
+  it('shows chat request failures as explicit failed trajectory entries', async () => {
+    const transport = new FakeTransport([], [], undefined, new Error('Codex exited with code 1'));
+    const controller = new SocketSessionController(transport);
+
+    await controller.submit('/chat');
+    await controller.sendChat('what happened?');
+
+    expect(controller.state.chatPending).toBe(false);
+    expect(controller.state.chatConversation.at(-1)).toMatchObject({
+      kind: 'result',
+      label: 'Chat failed',
+      tone: 'failure',
+      content: 'Error: Codex exited with code 1',
+    });
+  });
 });
 
 class FakeTransport implements SupervisionTransport {
@@ -147,10 +226,13 @@ class FakeTransport implements SupervisionTransport {
   constructor(
     private readonly responseEvents: RunEvent[] = [],
     private readonly responsePerformance: NonNullable<ProtocolResponse['performance']> = [],
+    private readonly responseChat?: NonNullable<ProtocolResponse['chat']>,
+    private readonly responseError?: Error,
   ) {}
 
   request(input: RequestInput): Promise<ProtocolResponse> {
     this.requests.push(input);
+    if (this.responseError) return Promise.reject(this.responseError);
     return Promise.resolve({
       protocol_version: 1,
       request_id: 'request',
@@ -158,6 +240,7 @@ class FakeTransport implements SupervisionTransport {
       ok: true,
       events: this.responseEvents,
       performance: this.responsePerformance,
+      ...(this.responseChat ? {chat: this.responseChat} : {}),
       snapshot: {run_id: 'run', status: 'running', sequence: 12},
     });
   }
@@ -196,5 +279,21 @@ function event(sequence: number, type: RunEvent['type'], content?: string): RunE
       : {
           data: {kind: 'agent_output_chunk', channel: 'assistant', content},
         }),
+  };
+}
+
+function chatEvent(
+  sequence: number,
+  type: RunEvent['type'],
+  data: NonNullable<RunEvent['data']>,
+): RunEvent {
+  return {
+    sequence,
+    timestamp: '2026-01-01T00:00:00Z',
+    type,
+    agent_kind: 'chat',
+    round_label: 'experiment-chat',
+    invocation_id: 'chat-1',
+    data,
   };
 }

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -200,6 +200,41 @@ describe('session controller', () => {
     expect(transport.requests).toEqual([{type: 'query.chat', text: 'why?'}]);
   });
 
+  it('queues messages entered while the chat agent is still working', async () => {
+    const transport = new DeferredChatTransport();
+    const controller = new SocketSessionController(transport);
+
+    const first = controller.sendChat('first question');
+    const second = controller.sendChat('follow-up question');
+
+    expect(transport.requests).toEqual([{type: 'query.chat', text: 'first question'}]);
+    expect(controller.state.chatConversation).toMatchObject([
+      {kind: 'user', label: 'You', content: 'first question'},
+      {kind: 'user', label: 'You · queued', content: 'follow-up question'},
+    ]);
+
+    transport.resolveNext('first answer');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(transport.requests).toEqual([
+      {type: 'query.chat', text: 'first question'},
+      {type: 'query.chat', text: 'follow-up question'},
+    ]);
+    expect(controller.state.chatConversation[1]?.label).toBe('You');
+
+    transport.resolveNext('follow-up answer');
+    await Promise.all([first, second]);
+
+    expect(controller.state.chatPending).toBe(false);
+    expect(controller.state.chatConversation.map(entry => entry.content)).toEqual([
+      'first question',
+      'follow-up question',
+      'first answer',
+      'follow-up answer',
+    ]);
+  });
+
   it('shows chat request failures as explicit failed trajectory entries', async () => {
     const transport = new FakeTransport([], [], undefined, new Error('Codex exited with code 1'));
     const controller = new SocketSessionController(transport);
@@ -266,6 +301,44 @@ class FakeTransport implements SupervisionTransport {
 
   disconnect(error: Error): void {
     this.#disconnect?.(error);
+  }
+}
+
+class DeferredChatTransport implements SupervisionTransport {
+  readonly requests: RequestInput[] = [];
+  readonly #pending: Array<(response: ProtocolResponse) => void> = [];
+
+  request(input: RequestInput): Promise<ProtocolResponse> {
+    this.requests.push(input);
+    return new Promise(resolve => this.#pending.push(resolve));
+  }
+
+  resolveNext(answer: string): void {
+    const resolve = this.#pending.shift();
+    if (!resolve) throw new Error('No pending chat request');
+    resolve({
+      protocol_version: 1,
+      request_id: 'request',
+      timestamp: '2026-01-01T00:00:00Z',
+      ok: true,
+      chat: {
+        question: '',
+        answer,
+        effect: 'none',
+      },
+    });
+  }
+
+  subscribe(
+    _afterSequence: number,
+    _onMessage: (message: ServerMessage) => void,
+    _onDisconnect: (error: Error) => void,
+  ): Promise<EventSubscription> {
+    return Promise.resolve({close: async () => undefined});
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
   }
 }
 

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -12,6 +12,7 @@ import {
 import {
   applyEvent,
   applySnapshot,
+  type ConversationEntry,
   initialSessionState,
   type SessionState,
   selectNextAgent,
@@ -29,6 +30,8 @@ export interface SessionController {
   start(): Promise<void>;
   stop(): Promise<void>;
   submit(value: string): Promise<void>;
+  closeChat(): void;
+  sendChat(value: string): Promise<void>;
   live(): void;
   selectNextAgent(): void;
   selectPreviousAgent(): void;
@@ -53,6 +56,7 @@ export class SocketSessionController implements SessionController {
   #state = initialSessionState();
   readonly #listeners = new Set<(state: SessionState) => void>();
   #eventSubscription: EventSubscription | null = null;
+  #chatMessageId = 0;
 
   constructor(private readonly client: SupervisionTransport) {}
 
@@ -112,11 +116,66 @@ export class SocketSessionController implements SessionController {
     this.#setState(toggleTodos(this.#state));
   }
 
+  closeChat(): void {
+    this.#setState({...this.#state, chatOpen: false});
+  }
+
+  async sendChat(value: string): Promise<void> {
+    const text = value.trim();
+    if (!text || this.#state.chatPending) return;
+    this.#setState({
+      ...this.#state,
+      chatOpen: true,
+      chatPending: true,
+      chatConversation: appendChatEntry(this.#state.chatConversation, {
+        id: `chat-user-${++this.#chatMessageId}`,
+        kind: 'user',
+        label: 'You',
+        content: text,
+      }),
+    });
+    try {
+      const response = await this.client.request({type: 'query.chat', text});
+      const answer = response.chat?.answer ?? 'No chat answer was returned.';
+      let state = {...this.#state, chatPending: false};
+      for (const event of response.events ?? []) state = applyEvent(state, event);
+      if (!(response.events ?? []).some(event => event.data?.kind === 'chat')) {
+        state = {
+          ...state,
+          chatConversation: appendChatEntry(state.chatConversation, {
+            id: `chat-answer-${++this.#chatMessageId}`,
+            kind: 'assistant',
+            label: 'Answer',
+            content: answer,
+          }),
+        };
+      }
+      this.#setState(state);
+    } catch (error) {
+      this.#setState({
+        ...this.#state,
+        chatPending: false,
+        chatConversation: appendChatEntry(this.#state.chatConversation, {
+          id: `chat-error-${++this.#chatMessageId}`,
+          kind: 'result',
+          label: 'Chat failed',
+          tone: 'failure',
+          content: String(error),
+        }),
+      });
+    }
+  }
+
   async submit(value: string): Promise<void> {
     const parsed = parseInput(value.trim());
     if (parsed.error) return this.#setState(showDetail(this.#state, parsed.error, 'error'));
     if (parsed.localView === 'help') {
       return this.#setState(showDetail(this.#state, HELP_TEXT, 'help'));
+    }
+    if (parsed.localView === 'chat') {
+      this.#setState({...this.#state, overlay: null, chatOpen: true});
+      if (parsed.chatMessage) await this.sendChat(parsed.chatMessage);
+      return;
     }
     if (!parsed.request) return;
     try {
@@ -146,13 +205,19 @@ export class SocketSessionController implements SessionController {
   }
 }
 
+function appendChatEntry(
+  conversation: ConversationEntry[],
+  entry: ConversationEntry,
+): ConversationEntry[] {
+  return [...conversation, entry].slice(-500);
+}
+
 function renderResponse(
   request: RequestInput,
   response: ProtocolResponse,
   responseView?: 'history' | 'perf',
 ): string | null {
   if (response.ack) return `${response.ack.action}: ${response.ack.status}`;
-  if (response.chat) return `you: ${response.chat.question}\nvibesys: ${response.chat.answer}`;
   if (request.type === 'query.performance' || responseView === 'perf') {
     return renderPerformanceCurve(response.performance ?? [], response.events ?? []);
   }

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -57,6 +57,8 @@ export class SocketSessionController implements SessionController {
   readonly #listeners = new Set<(state: SessionState) => void>();
   #eventSubscription: EventSubscription | null = null;
   #chatMessageId = 0;
+  readonly #chatQueue: Array<{id: string; text: string}> = [];
+  #chatDrain: Promise<void> | null = null;
 
   constructor(private readonly client: SupervisionTransport) {}
 
@@ -120,24 +122,53 @@ export class SocketSessionController implements SessionController {
     this.#setState({...this.#state, chatOpen: false});
   }
 
-  async sendChat(value: string): Promise<void> {
+  sendChat(value: string): Promise<void> {
     const text = value.trim();
-    if (!text || this.#state.chatPending) return;
+    if (!text) return Promise.resolve();
+    const id = `chat-user-${++this.#chatMessageId}`;
+    const queued = this.#state.chatPending || this.#chatQueue.length > 0;
+    this.#chatQueue.push({id, text});
     this.#setState({
       ...this.#state,
       chatOpen: true,
-      chatPending: true,
       chatConversation: appendChatEntry(this.#state.chatConversation, {
-        id: `chat-user-${++this.#chatMessageId}`,
+        id,
         kind: 'user',
-        label: 'You',
+        label: queued ? 'You · queued' : 'You',
         content: text,
       }),
     });
+    if (this.#chatDrain === null) {
+      const drain = this.#drainChatQueue();
+      this.#chatDrain = drain.finally(() => {
+        this.#chatDrain = null;
+      });
+    }
+    return this.#chatDrain;
+  }
+
+  async #drainChatQueue(): Promise<void> {
+    try {
+      for (let message = this.#chatQueue.shift(); message; message = this.#chatQueue.shift()) {
+        this.#setState({
+          ...this.#state,
+          chatPending: true,
+          chatConversation: this.#state.chatConversation.map(entry =>
+            entry.id === message.id ? {...entry, label: 'You'} : entry,
+          ),
+        });
+        await this.#requestChat(message.text);
+      }
+    } finally {
+      this.#setState({...this.#state, chatPending: false});
+    }
+  }
+
+  async #requestChat(text: string): Promise<void> {
     try {
       const response = await this.client.request({type: 'query.chat', text});
       const answer = response.chat?.answer ?? 'No chat answer was returned.';
-      let state = {...this.#state, chatPending: false};
+      let state = this.#state;
       for (const event of response.events ?? []) state = applyEvent(state, event);
       if (!(response.events ?? []).some(event => event.data?.kind === 'chat')) {
         state = {
@@ -154,7 +185,6 @@ export class SocketSessionController implements SessionController {
     } catch (error) {
       this.#setState({
         ...this.#state,
-        chatPending: false,
         chatConversation: appendChatEntry(this.#state.chatConversation, {
           id: `chat-error-${++this.#chatMessageId}`,
           kind: 'result',

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -149,15 +149,17 @@ export class SocketSessionController implements SessionController {
 
   async #drainChatQueue(): Promise<void> {
     try {
-      for (let message = this.#chatQueue.shift(); message; message = this.#chatQueue.shift()) {
+      while (this.#chatQueue.length > 0) {
+        const messages = this.#chatQueue.splice(0);
+        const messageIds = new Set(messages.map(message => message.id));
         this.#setState({
           ...this.#state,
           chatPending: true,
           chatConversation: this.#state.chatConversation.map(entry =>
-            entry.id === message.id ? {...entry, label: 'You'} : entry,
+            messageIds.has(entry.id) ? {...entry, label: 'You'} : entry,
           ),
         });
-        await this.#requestChat(message.text);
+        await this.#requestChat(messages.map(message => message.text).join('\n\n'));
       }
     } finally {
       this.#setState({...this.#state, chatPending: false});

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -79,6 +79,56 @@ describe('session event model', () => {
     expect(state.conversation[0]?.tone).toBe('failure');
   });
 
+  it('routes chat agent trajectory events away from the experiment transcript', () => {
+    let state = initialSessionState();
+    state = applyEvent(
+      state,
+      chatEvent(1, 'agent_output_chunk', {
+        kind: 'agent_output_chunk',
+        channel: 'analysis',
+        content: 'Inspecting the latest round',
+      }),
+    );
+    state = applyEvent(
+      state,
+      chatEvent(2, 'tool_call', {
+        kind: 'tool_call',
+        tool: 'read_file',
+        args: {path: 'progress.md'},
+        status: null,
+      }),
+    );
+    state = applyEvent(
+      state,
+      chatEvent(3, 'tool_result', {
+        kind: 'tool_result',
+        tool: 'read_file',
+        content: 'Round 2 improved throughput.',
+        is_error: false,
+      }),
+    );
+    state = applyEvent(
+      state,
+      chatEvent(4, 'chat', {
+        kind: 'chat',
+        answer: 'Round 2 improved throughput.',
+      }),
+    );
+
+    expect(state.conversation).toEqual([]);
+    expect(state.agentKind).toBeNull();
+    expect(state.chatConversation.map(entry => entry.kind)).toEqual([
+      'analysis',
+      'tool',
+      'assistant',
+    ]);
+    expect(state.chatConversation[1]).toMatchObject({
+      toolCall: '→ read_file(path="progress.md")\n',
+      toolResponse: 'Round 2 improved throughput.',
+    });
+    expect(state.chatConversation.at(-1)?.content).toBe('Round 2 improved throughput.');
+  });
+
   it('coalesces streamed assistant chunks and pairs each tool call with its result', () => {
     let state = initialSessionState();
     state = applyEvent(
@@ -505,5 +555,17 @@ function event(
     ...(type === 'run_started' ? {} : {agent_kind: 'judge'}),
     ...(invocationId === undefined ? {} : {invocation_id: invocationId}),
     ...(data === undefined ? {} : {data}),
+  };
+}
+
+function chatEvent(
+  sequence: number,
+  type: RunEvent['type'],
+  data: NonNullable<RunEvent['data']>,
+): RunEvent {
+  return {
+    ...event(sequence, type, data, 'chat-1'),
+    agent_kind: 'chat',
+    round_label: 'experiment-chat',
   };
 }

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -21,6 +21,10 @@ export interface SessionState {
   liveContent: string;
   conversation: ConversationEntry[];
   overlay: OverlayPanel | null;
+  chatOpen: boolean;
+  chatConversation: ConversationEntry[];
+  chatPending: boolean;
+  chatTypedToolEvents: boolean;
   terminal: boolean;
   todoPhases: PhaseTodos[];
   todosExpanded: boolean;
@@ -64,6 +68,7 @@ export interface ConversationEntry {
   id: string;
   kind:
     | 'assistant'
+    | 'user'
     | 'prompt'
     | 'analysis'
     | 'tool'
@@ -98,6 +103,10 @@ export function initialSessionState(): SessionState {
     liveContent: 'Waiting for run events…',
     conversation: [],
     overlay: null,
+    chatOpen: false,
+    chatConversation: [],
+    chatPending: false,
+    chatTypedToolEvents: false,
     terminal: false,
     todoPhases: [],
     todosExpanded: false,
@@ -120,6 +129,7 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
   const sequence = event.sequence ?? 0;
   if (sequence > 0 && sequence <= state.sequence) return state;
   const next = {...state, sequence: Math.max(state.sequence, sequence)};
+  if (event.agent_kind === 'chat') return applyChatEvent(next, event);
   if (event.agent_kind) next.agentKind = event.agent_kind;
   if (event.round_label) next.roundLabel = event.round_label;
   const runMap = applyRunMapEvent(
@@ -181,6 +191,22 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
   if (event.type === 'run_failed' || event.type === 'run_interrupted') {
     next.status = 'failed';
     next.terminal = true;
+  }
+  return next;
+}
+
+function applyChatEvent(state: SessionState, event: RunEvent): SessionState {
+  const next = {...state};
+  const data = event.data;
+  if (data?.kind === 'tool_call' || data?.kind === 'tool_result') {
+    next.chatTypedToolEvents = true;
+  }
+  const suppressed =
+    data?.kind === 'agent_output_chunk' && data.channel === 'tool' && next.chatTypedToolEvents;
+  if (suppressed) return next;
+  const entry = eventToConversationEntry(event);
+  if (entry !== null) {
+    next.chatConversation = appendConversation(next.chatConversation, entry);
   }
   return next;
 }
@@ -259,6 +285,16 @@ function eventToConversationEntry(event: RunEvent): ConversationEntry | null {
       content: formatConfigurationFailure(event),
       label: 'Configuration failed',
       tone: 'failure',
+    };
+  }
+  if (data?.kind === 'chat') {
+    return {
+      id,
+      kind: 'assistant',
+      content: data.answer,
+      label: 'Answer',
+      ...agentKind,
+      ...roundFields,
     };
   }
   if (data?.kind === 'agent_output_chunk') {
@@ -426,7 +462,13 @@ function appendConversation(
 }
 
 export function showLive(state: SessionState): SessionState {
-  return {...state, overlay: null, selectedRound: null, selectedAgentKind: null};
+  return {
+    ...state,
+    overlay: null,
+    chatOpen: false,
+    selectedRound: null,
+    selectedAgentKind: null,
+  };
 }
 
 export function showDetail(

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -377,6 +377,28 @@ describe('OpenTUI presentation', () => {
     await testRenderer.waitForFrame(value => !value.includes('Experiment chat'));
     expect(controller.state.chatOpen).toBe(false);
   });
+
+  it('accepts another chat message while an agent turn is pending', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      chatPending: true,
+      chatConversation: [
+        {id: 'active-question', kind: 'user', label: 'You', content: 'first question'},
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    await testRenderer.mockInput.typeText('/chat');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(value => value.includes('Experiment chat'));
+    await testRenderer.mockInput.typeText('queued follow-up');
+    testRenderer.mockInput.pressEnter();
+
+    await testRenderer.waitForFrame(value => value.includes('Recorded diagnostic'));
+    expect(controller.chatSubmissions).toEqual(['queued follow-up']);
+  });
 });
 
 function registerCleanup(

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -340,6 +340,43 @@ describe('OpenTUI presentation', () => {
     await new Promise(resolve => setTimeout(resolve, 150));
     expect(destroyed).toBe(false);
   });
+
+  it('opens a focused chat popup after a configuration failure', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      status: 'failed',
+      terminal: true,
+      conversation: [
+        {
+          id: 'configuration-error',
+          kind: 'result',
+          label: 'Configuration failed',
+          content: 'agent.toml was not found',
+          tone: 'failure',
+        },
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    await testRenderer.mockInput.typeText('/chat');
+    testRenderer.mockInput.pressEnter();
+    const popup = await testRenderer.waitForFrame(value => value.includes('Experiment chat'));
+    expect(popup).toContain('Ask about this experiment');
+    expect(popup).toContain('Message');
+
+    await testRenderer.mockInput.typeText('why did startup fail?');
+    testRenderer.mockInput.pressEnter();
+    const answer = await testRenderer.waitForFrame(value => value.includes('Recorded diagnostic'));
+    expect(controller.chatSubmissions).toEqual(['why did startup fail?']);
+    expect(answer).toContain('Inspecting configuration events');
+    expect(answer).toContain('→ Read(run-events.jsonl)');
+
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await testRenderer.waitForFrame(value => !value.includes('Experiment chat'));
+    expect(controller.state.chatOpen).toBe(false);
+  });
 });
 
 function registerCleanup(
@@ -355,6 +392,7 @@ function registerCleanup(
 class FakeController implements SessionController {
   readonly #listeners = new Set<(state: SessionState) => void>();
   readonly submissions: string[] = [];
+  readonly chatSubmissions: string[] = [];
   liveCalls = 0;
 
   constructor(public state: SessionState) {}
@@ -367,6 +405,46 @@ class FakeController implements SessionController {
   }
   submit(value: string): Promise<void> {
     this.submissions.push(value);
+    if (value.trim() === '/chat') {
+      this.state = {...this.state, chatOpen: true, overlay: null};
+      this.#notify();
+    }
+    return Promise.resolve();
+  }
+  closeChat(): void {
+    this.state = {...this.state, chatOpen: false};
+    this.#notify();
+  }
+  sendChat(value: string): Promise<void> {
+    this.chatSubmissions.push(value);
+    this.state = {
+      ...this.state,
+      chatConversation: [
+        ...this.state.chatConversation,
+        {id: 'chat-user', kind: 'user', label: 'You', content: value},
+        {
+          id: 'chat-analysis',
+          kind: 'analysis',
+          label: 'Chat analysis',
+          content: 'Inspecting configuration events',
+        },
+        {
+          id: 'chat-tool',
+          kind: 'tool',
+          label: 'Chat tool',
+          content: '→ Read(run-events.jsonl)\nFound config_load_failed',
+          toolCall: '→ Read(run-events.jsonl)\n',
+          toolResponse: 'Found config_load_failed',
+        },
+        {
+          id: 'chat-answer',
+          kind: 'assistant',
+          label: 'Answer',
+          content: 'Recorded diagnostic: agent.toml was not found.',
+        },
+      ],
+    };
+    this.#notify();
     return Promise.resolve();
   }
   live(): void {
@@ -412,5 +490,9 @@ class FakeController implements SessionController {
     this.#listeners.add(listener);
     listener(this.state);
     return () => this.#listeners.delete(listener);
+  }
+
+  #notify(): void {
+    for (const listener of this.#listeners) listener(this.state);
   }
 }

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -2,6 +2,7 @@ import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} fr
 import type {SessionController} from '../session-controller.js';
 import {type SessionState, statusText} from '../session-model.js';
 import {AgentMapView} from './agent-map.js';
+import {ChatOverlayView} from './chat-overlay.js';
 import {ConversationView} from './conversation.js';
 import {createInputPanel} from './input.js';
 import {bindKeybindings} from './keybindings.js';
@@ -57,6 +58,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   const agentMap = new AgentMapView(renderer);
   const overlay = new OverlayView(renderer);
   const conversation = new ConversationView(renderer, controller, markdownStyle);
+  const chat = new ChatOverlayView(renderer, controller, markdownStyle);
   const input = createInputPanel(renderer, value => void controller.submit(value));
 
   viewport.add(conversation.output);
@@ -70,11 +72,13 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   root.add(input.suggestions);
   root.add(input.box);
   root.add(overlay.output);
+  root.add(chat.output);
   renderer.root.add(root);
   input.focus();
 
+  let chatWasOpen = false;
   const render = (state: SessionState): void => {
-    const returnHint = state.overlay === null ? '' : ' · Esc: close dialog';
+    const returnHint = state.chatOpen || state.overlay !== null ? ' · Esc: close dialog' : '';
     const selection = state.selectedAgentKind ? ` · selected ${state.selectedAgentKind}` : '';
     header.content = `VibeSys · ${statusText(state)}${selection}${returnHint}`;
     roundStrip.render(state);
@@ -82,9 +86,14 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     agentMap.render(state);
     conversation.render(state);
     overlay.render(state);
+    chat.render(state);
+    if (state.chatOpen && !chatWasOpen) chat.focus();
+    if (!state.chatOpen && chatWasOpen) input.focus();
+    chatWasOpen = state.chatOpen;
   };
   const unbindKeys = bindKeybindings(renderer, controller, viewport, {
     completeInput: () => input.completeSuggestion(),
+    closeChat: () => controller.closeChat(),
     toggleLatestPrompt: () => conversation.toggleLatestPrompt(),
     selectNextAgent: () => controller.selectNextAgent(),
     selectPreviousAgent: () => controller.selectPreviousAgent(),
@@ -99,6 +108,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
       unsubscribe();
       unbindKeys();
       input.destroy();
+      chat.destroy();
       roundStrip.destroy();
       root.destroyRecursively();
       markdownStyle.destroy();

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -103,7 +103,7 @@ export class ChatOverlayView {
   }
 
   readonly #submit = (value: string): void => {
-    if (this.controller.state.chatPending || !value.trim()) return;
+    if (!value.trim()) return;
     this.#input.value = '';
     void this.controller.sendChat(value);
   };

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -1,0 +1,110 @@
+import {
+  BoxRenderable,
+  type CliRenderer,
+  InputRenderable,
+  InputRenderableEvents,
+  ScrollBoxRenderable,
+  type SyntaxStyle,
+  TextRenderable,
+} from '@opentui/core';
+import type {SessionController} from '../session-controller.js';
+import type {SessionState} from '../session-model.js';
+import {ConversationView} from './conversation.js';
+
+export class ChatOverlayView {
+  readonly output: BoxRenderable;
+  readonly #transcript: ScrollBoxRenderable;
+  readonly #conversation: ConversationView;
+  readonly #input: InputRenderable;
+
+  constructor(
+    renderer: CliRenderer,
+    private readonly controller: SessionController,
+    markdownStyle: SyntaxStyle,
+  ) {
+    this.output = new BoxRenderable(renderer, {
+      id: 'chat-overlay',
+      width: '80%',
+      height: '76%',
+      position: 'absolute',
+      left: '10%',
+      top: '10%',
+      flexDirection: 'column',
+      paddingLeft: 1,
+      paddingRight: 1,
+      border: true,
+      borderStyle: 'rounded',
+      borderColor: '#a78bfa',
+      backgroundColor: '#020617',
+      title: ' Experiment chat ',
+      zIndex: 20,
+      visible: false,
+    });
+    this.#transcript = new ScrollBoxRenderable(renderer, {
+      id: 'chat-transcript',
+      width: '100%',
+      flexGrow: 1,
+      stickyScroll: true,
+      stickyStart: 'bottom',
+      viewportCulling: true,
+      verticalScrollbarOptions: {showArrows: true},
+    });
+    this.#conversation = new ConversationView(renderer, controller, markdownStyle, {
+      selectConversation: state => state.chatConversation,
+      emptyContent: 'Ask a question about the current experiment, its progress, or a failure.',
+      renderMarkdown: false,
+    });
+    const inputBox = new BoxRenderable(renderer, {
+      id: 'chat-input-box',
+      height: 3,
+      width: '100%',
+      border: true,
+      borderStyle: 'rounded',
+      borderColor: '#8b5cf6',
+      title: ' Message ',
+      paddingLeft: 1,
+      paddingRight: 1,
+    });
+    this.#input = new InputRenderable(renderer, {
+      id: 'chat-input',
+      width: '100%',
+      placeholder: 'Ask about this experiment',
+      textColor: '#f8fafc',
+      focusedTextColor: '#f8fafc',
+    });
+    this.#input.on(InputRenderableEvents.ENTER, this.#submit);
+    inputBox.add(this.#input);
+    this.#transcript.add(this.#conversation.output);
+    this.output.add(this.#transcript);
+    this.output.add(inputBox);
+    this.output.add(
+      new TextRenderable(renderer, {
+        content: 'Enter to send · Esc to close',
+        fg: '#64748b',
+        height: 1,
+        width: '100%',
+      }),
+    );
+  }
+
+  render(state: SessionState): void {
+    this.output.visible = state.chatOpen;
+    if (!state.chatOpen) return;
+    this.#conversation.render(state);
+    this.#transcript.scrollTo(this.#transcript.scrollHeight);
+  }
+
+  focus(): void {
+    this.#input.focus();
+  }
+
+  destroy(): void {
+    this.#input.off(InputRenderableEvents.ENTER, this.#submit);
+  }
+
+  readonly #submit = (value: string): void => {
+    if (this.controller.state.chatPending || !value.trim()) return;
+    this.#input.value = '';
+    void this.controller.sendChat(value);
+  };
+}

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -11,16 +11,29 @@ import {visibleConversation} from '../session-model.js';
 import {promptPreview, toolOutputPreview} from './previews.js';
 import {entryPalette} from './styles.js';
 
+export interface ConversationViewOptions {
+  selectConversation?: (state: SessionState) => ConversationEntry[];
+  emptyContent?: string;
+  renderMarkdown?: boolean;
+}
+
 export class ConversationView {
   readonly output: BoxRenderable;
   readonly #expandedPrompts = new Set<string>();
+  readonly #selectConversation: (state: SessionState) => ConversationEntry[];
+  readonly #emptyContent: string;
+  readonly #renderMarkdown: boolean;
   #renderedConversation: ConversationEntry[] = [];
 
   constructor(
     private readonly renderer: CliRenderer,
     private readonly controller: SessionController,
     private readonly markdownStyle: SyntaxStyle,
+    options: ConversationViewOptions = {},
   ) {
+    this.#selectConversation = options.selectConversation ?? visibleConversation;
+    this.#emptyContent = options.emptyContent ?? 'Waiting for run events…';
+    this.#renderMarkdown = options.renderMarkdown ?? true;
     this.output = new BoxRenderable(renderer, {
       id: 'output',
       width: '100%',
@@ -31,11 +44,11 @@ export class ConversationView {
   }
 
   render(state: SessionState): void {
-    this.#renderConversation(visibleConversation(state));
+    this.#renderConversation(this.#selectConversation(state));
   }
 
   toggleLatestPrompt(): void {
-    const latestPrompt = [...this.controller.state.conversation]
+    const latestPrompt = [...this.#selectConversation(this.controller.state)]
       .reverse()
       .find(entry => entry.kind === 'prompt');
     if (latestPrompt) this.#togglePrompt(latestPrompt.id);
@@ -55,7 +68,7 @@ export class ConversationView {
     if (entries.length === 0) {
       this.output.add(
         new TextRenderable(this.renderer, {
-          content: 'Waiting for run events…',
+          content: this.#emptyContent,
           fg: '#64748b',
         }),
       );
@@ -68,7 +81,7 @@ export class ConversationView {
     if (this.#expandedPrompts.has(id)) this.#expandedPrompts.delete(id);
     else this.#expandedPrompts.add(id);
     this.#renderedConversation = [];
-    this.#renderConversation(this.controller.state.conversation);
+    this.#renderConversation(this.#selectConversation(this.controller.state));
   }
 
   #renderEntry(entry: ConversationEntry): BoxRenderable {
@@ -93,16 +106,35 @@ export class ConversationView {
         height: 1,
       }),
     );
-    if (entry.kind === 'assistant' || entry.kind === 'prompt') {
+    if (
+      this.#renderMarkdown &&
+      (entry.kind === 'assistant' || entry.kind === 'prompt' || entry.kind === 'user')
+    ) {
       this.#renderMarkdownEntry(card, entry);
     } else if (entry.kind === 'tool' && entry.toolCall) {
       this.#renderToolTurn(card, entry);
     } else {
-      const content =
-        entry.kind === 'tool' || entry.kind === 'diagnostic' || entry.kind === 'subprocess'
+      const prompt =
+        entry.kind === 'prompt'
+          ? promptPreview(entry.content, this.#expandedPrompts.has(entry.id))
+          : null;
+      const content = prompt
+        ? prompt.content
+        : entry.kind === 'tool' || entry.kind === 'diagnostic' || entry.kind === 'subprocess'
           ? toolOutputPreview(entry.content)
           : entry.content;
       card.add(new TextRenderable(this.renderer, {content, fg: palette.content, width: '100%'}));
+      if (prompt && (prompt.hiddenLines > 0 || this.#expandedPrompts.has(entry.id))) {
+        card.add(
+          new TextRenderable(this.renderer, {
+            content: this.#expandedPrompts.has(entry.id)
+              ? '▴ click to collapse'
+              : `▾ ${prompt.hiddenLines} more lines · click to expand`,
+            fg: '#60a5fa',
+            width: '100%',
+          }),
+        );
+      }
     }
     return card;
   }

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -3,6 +3,7 @@ import type {SessionController} from '../session-controller.js';
 
 export interface KeybindingActions {
   completeInput(): boolean;
+  closeChat(): void;
   toggleLatestPrompt(): void;
   selectNextAgent(): void;
   selectPreviousAgent(): void;
@@ -21,6 +22,13 @@ export function bindKeybindings(
     if (key.ctrl && key.name === 'c') {
       key.preventDefault();
       renderer.destroy();
+      return;
+    }
+    if (controller.state.chatOpen) {
+      if (key.name === 'escape') {
+        actions.closeChat();
+        key.preventDefault();
+      }
       return;
     }
     if (key.name === 'escape' && controller.state.overlay !== null) {

--- a/clients/tui/src/ui/styles.ts
+++ b/clients/tui/src/ui/styles.ts
@@ -30,6 +30,9 @@ export function entryPalette(entry: ConversationEntry): EntryPalette {
   if (entry.kind === 'assistant') {
     return {border: '#0891b2', background: '#0f1b24', label: '#67e8f9', content: '#e2e8f0'};
   }
+  if (entry.kind === 'user') {
+    return {border: '#2563eb', background: '#102548', label: '#7dd3fc', content: '#e0f2fe'};
+  }
   if (entry.kind === 'prompt') {
     return {border: '#3b82f6', background: '#102548', label: '#93c5fd', content: '#dbeafe'};
   }

--- a/src/vibesys/agents/base.py
+++ b/src/vibesys/agents/base.py
@@ -50,6 +50,7 @@ class AgentRunner(Protocol):
         response_cls: type[T],
         fallback_factory: Callable[[], T],
         round_label: str,
+        invocation_id: str | None = None,
         progress: AgentProgress | None = None,
         mcp_servers: list[MCPServerSpec] | None = None,
         tools: list[BaseTool] | None = None,
@@ -93,4 +94,21 @@ class AgentRunner(Protocol):
             An instance of ``response_cls``, either parsed from the agent's
             output or produced by ``fallback_factory()``.
         """
+        ...
+
+    def invoke_text(
+        self,
+        *,
+        kind: str,
+        workspace: Path,
+        system_prompt: str,
+        env: dict[str, str] | None = None,
+        user_prompt: str,
+        round_label: str,
+        invocation_id: str | None = None,
+        progress: AgentProgress | None = None,
+        mcp_servers: list[MCPServerSpec] | None = None,
+        tools: list[BaseTool] | None = None,
+    ) -> str:
+        """Run an agent and return its final message without a response schema."""
         ...

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -77,6 +77,9 @@ class AgentLogger(BaseCallbackHandler):
         agent_label: str | None = None,
         progress: AgentProgress | None = None,
         context_window_lookup: ContextWindowLookup | None = None,
+        agent_kind: str | None = None,
+        round_label: str | None = None,
+        invocation_id: str | None = None,
     ):
         self._streaming = False
         self._log_file = log_file
@@ -92,6 +95,9 @@ class AgentLogger(BaseCallbackHandler):
         self._latest_usage: dict[str, Any] | None = None
         self._context_window_lookup = context_window_lookup or _default_context_window_lookup
         self._context_window = self._context_window_lookup(model_name)
+        self._agent_kind = agent_kind
+        self._round_label = round_label
+        self._invocation_id = invocation_id
 
     def _status(self) -> AgentStatusData:
         """Snapshot the ``[progress | label | elapsed | tokens/max]`` readings.
@@ -269,10 +275,22 @@ class AgentLogger(BaseCallbackHandler):
     )
 
     def _emit_tool_call(self, name: str, args: dict[str, Any]):
-        output_sink().tool_call(name, args, status=self._status())
+        output_sink().tool_call(
+            name,
+            args,
+            status=self._status(),
+            agent_kind=self._agent_kind,
+            round_label=self._round_label,
+            invocation_id=self._invocation_id,
+        )
         todos = todos_from_tool_call(name, args)
         if todos is not None:
-            output_sink().todo_update(todos)
+            output_sink().todo_update(
+                todos,
+                agent_kind=self._agent_kind,
+                round_label=self._round_label,
+                invocation_id=self._invocation_id,
+            )
         is_code_tool = name in self._CODE_CHANGE_TOOLS
 
         # Log file: skip code content args for file-writing tools
@@ -298,7 +316,14 @@ class AgentLogger(BaseCallbackHandler):
 
     def _emit_tool_result(self, name: str, content: str, *, is_error: bool = False):
         full_text = str(content)
-        output_sink().tool_result(name, full_text, is_error=is_error)
+        output_sink().tool_result(
+            name,
+            full_text,
+            is_error=is_error,
+            agent_kind=self._agent_kind,
+            round_label=self._round_label,
+            invocation_id=self._invocation_id,
+        )
 
         # Truncated to log file
         if self._log_file:
@@ -423,7 +448,12 @@ class AgentLogger(BaseCallbackHandler):
         status: AgentStatusData | None = None,
     ) -> None:
         output_sink().agent_output(
-            content, channel=channel, status=status if status is not None else self._status()
+            content,
+            channel=channel,
+            status=status if status is not None else self._status(),
+            agent_kind=self._agent_kind,
+            round_label=self._round_label,
+            invocation_id=self._invocation_id,
         )
 
     def _publish_usage(self) -> None:
@@ -431,4 +461,7 @@ class AgentLogger(BaseCallbackHandler):
             self._input_tokens,
             context_window=self._context_window,
             model=self._model_name,
+            agent_kind=self._agent_kind,
+            round_label=self._round_label,
+            invocation_id=self._invocation_id,
         )

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -206,7 +206,9 @@ class CliAgentRunner:
         # tests that don't care about usage).
         self._log_dir = log_dir
         # Cache agent instances per kind so session IDs persist across
-        # invocations (enables conversation continuation).
+        # invocations (enables conversation continuation). Experiment chat is
+        # the exception: its history is carried explicitly in each prompt, so
+        # it must not depend on provider-side session state.
         self._agents: dict[str, CodingAgent] = {}
 
     def invoke(
@@ -220,32 +222,119 @@ class CliAgentRunner:
         response_cls: type[T],
         fallback_factory: Callable[[], T],
         round_label: str,
+        invocation_id: str | None = None,
         progress: AgentProgress | None = None,
         mcp_servers: list[MCPServerSpec] | None = None,
         tools: list[BaseTool] | None = None,  # noqa: ARG002 — deepagents-only injection point; cli uses mcp_servers
     ) -> T:
-        label = _agent_label(kind)
-
-        # 1. Materialize skills into the workspace so the CLI tool can pick
-        #    them up. No-op if no skills were configured.
-        _materialize_skills(workspace, self._skills, log_file=self._run_log_file)
-
-        # 2. Build the combined prompt. CLI tools have no separate system
-        #    slot — prepending the system prompt is the standard workaround.
         schema_hint = _build_schema_hint(response_cls)
         combined_prompt = f"{system_prompt}\n\n{user_prompt}{schema_hint}"
+        text = self._generate(
+            kind=kind,
+            workspace=workspace,
+            env=env,
+            combined_prompt=combined_prompt,
+            round_label=round_label,
+            invocation_id=invocation_id,
+            progress=progress,
+            mcp_servers=mcp_servers,
+        )
+        label = _agent_label(kind)
+        parsed = parse_typed_response_text(text, response_cls)
+        if parsed is None:
+            log_and_print(
+                f"\n=== {label} ROUND OUTPUT (missing response) ===",
+                self._run_log_file,
+            )
+            log_and_print(
+                f"No structured response received from {label.lower()}.",
+                self._run_log_file,
+            )
+            if text:
+                log_and_print(
+                    f"\n=== {label} ROUND OUTPUT (raw output) ===",
+                    self._run_log_file,
+                )
+                log_markdown_and_print(text, self._run_log_file)
+            return fallback_factory()
 
-        # 3. Wire on-screen logging so the cli backend looks like deepagents.
+        log_and_print(
+            f"\n=== {label} ROUND OUTPUT ===",
+            self._run_log_file,
+        )
+        log_json_and_print(parsed.model_dump_json(indent=2), self._run_log_file)
+        return parsed
+
+    def invoke_text(
+        self,
+        *,
+        kind: str,
+        workspace: Path,
+        system_prompt: str,
+        env: dict[str, str] | None = None,
+        user_prompt: str,
+        round_label: str,
+        invocation_id: str | None = None,
+        progress: AgentProgress | None = None,
+        mcp_servers: list[MCPServerSpec] | None = None,
+        tools: list[BaseTool] | None = None,  # noqa: ARG002 — deepagents-only
+    ) -> str:
+        """Run a conversational CLI agent without requesting structured JSON."""
+        text = self._generate(
+            kind=kind,
+            workspace=workspace,
+            env=env,
+            combined_prompt=f"{system_prompt}\n\n{user_prompt}",
+            round_label=round_label,
+            invocation_id=invocation_id,
+            progress=progress,
+            mcp_servers=mcp_servers,
+        )
+        label = _agent_label(kind)
+        if text:
+            log_and_print(f"\n=== {label} ROUND OUTPUT ===", self._run_log_file)
+            log_markdown_and_print(text, self._run_log_file)
+        else:
+            log_and_print(
+                f"\n=== {label} ROUND OUTPUT (missing response) ===",
+                self._run_log_file,
+            )
+            log_and_print(f"No response received from {label.lower()}.", self._run_log_file)
+        return text
+
+    def _generate(
+        self,
+        *,
+        kind: str,
+        workspace: Path,
+        env: dict[str, str] | None,
+        combined_prompt: str,
+        round_label: str,
+        invocation_id: str | None,
+        progress: AgentProgress | None,
+        mcp_servers: list[MCPServerSpec] | None,
+    ) -> str:
+        """Run one CLI generation with shared setup, logging, and cleanup."""
+        label = _agent_label(kind)
+        _materialize_skills(workspace, self._skills, log_file=self._run_log_file)
+
         logger = AgentLogger(
             log_file=self._run_log_file,
             model_name=self._model_name,
             agent_label=label,
             progress=progress,
+            agent_kind=kind,
+            round_label=round_label,
+            invocation_id=invocation_id,
         )
 
-        # 4. Reuse or construct the underlying agent.  Reusing preserves the
-        #    session_id so the CLI tool can resume the conversation.
-        agent = self._agents.get(kind)
+        # Reuse or construct the underlying agent. Reusing preserves the
+        #    session_id so the CLI tool can resume the conversation. Chat owns
+        #    its multi-turn history in the prompt, and provider session IDs can
+        #    become unavailable when a sandbox or process changes, so every
+        #    chat turn deliberately starts a fresh CLI session.
+        reuse_agent = kind != "chat"
+        agent = self._agents.get(kind) if reuse_agent else None
         if agent is not None:
             # Update the event handler for this invocation's logger.
             agent.event_handler = logger
@@ -271,7 +360,8 @@ class CliAgentRunner:
                 event_handler=logger,
                 executor=executor,
             )
-            self._agents[kind] = agent
+            if reuse_agent:
+                self._agents[kind] = agent
         elif self._modal_sandboxes is not None:
             from vibesys.agents.modal_executor import ModalCommandExecutor
 
@@ -290,7 +380,8 @@ class CliAgentRunner:
                     "--config",
                     'forced_login_method="chatgpt"',
                 ]
-            self._agents[kind] = agent
+            if reuse_agent:
+                self._agents[kind] = agent
         else:
             agent = self._provider_cls(model=self._model, event_handler=logger)
             # Host execution path: confine the agent to its workspace at the OS
@@ -303,7 +394,8 @@ class CliAgentRunner:
                 binary_path=getattr(agent, "binary_path", None),
                 log=lambda msg: log_and_print(msg, self._run_log_file),
             )
-            self._agents[kind] = agent
+            if reuse_agent:
+                self._agents[kind] = agent
 
         # Layer GPU env vars on top of the captured interactive env so the
         # spawned subprocess inherits CUDA_VISIBLE_DEVICES. Containerised
@@ -313,14 +405,12 @@ class CliAgentRunner:
             agent.env = {**agent.env, **env}
         workspace_arg = None if _in_container else str(workspace)
 
-        # 5. Install per-provider MCP server config (file under workspace
+        # Install per-provider MCP server config (file under workspace
         #    for claude/gemini/opencode, runtime --config flags for codex).
         #    Wrapped in try/finally so a crash in generate() still cleans up.
         if mcp_servers:
             agent.install_mcp_servers(workspace, mcp_servers)
 
-        # 6. Log the round header so the run log structure mirrors the
-        #    deepagents path.
         log_and_print(
             f"\n=== {label} ROUND START: {round_label} ===",
             self._run_log_file,
@@ -333,7 +423,7 @@ class CliAgentRunner:
         log_and_print("--- input ---", self._run_log_file)
         log_prompt_markdown_and_print(combined_prompt, self._run_log_file)
 
-        # 7. Run the agent. Wrap exceptions to surface them in the run log
+        # Run the agent. Wrap exceptions to surface them in the run log
         #    before re-raising. The ``finally`` clause runs both cleanups —
         #    per-provider MCP config (so the next phase starts clean even
         #    if generate() raises) and the per-invocation usage record
@@ -357,33 +447,7 @@ class CliAgentRunner:
             if mcp_servers:
                 agent.uninstall_mcp_servers(workspace, mcp_servers)
             self._write_usage_record(kind=kind, round_label=round_label, agent=agent)
-
-        # 8. Parse the structured response, falling back if the CLI tool
-        #    didn't produce parseable JSON.
-        parsed = parse_typed_response_text(text, response_cls)
-        if parsed is None:
-            log_and_print(
-                f"\n=== {label} ROUND OUTPUT (missing response) ===",
-                self._run_log_file,
-            )
-            log_and_print(
-                f"No structured response received from {label.lower()}.",
-                self._run_log_file,
-            )
-            if text:
-                log_and_print(
-                    f"\n=== {label} ROUND OUTPUT (raw output) ===",
-                    self._run_log_file,
-                )
-                log_markdown_and_print(text, self._run_log_file)
-            return fallback_factory()
-
-        log_and_print(
-            f"\n=== {label} ROUND OUTPUT ===",
-            self._run_log_file,
-        )
-        log_json_and_print(parsed.model_dump_json(indent=2), self._run_log_file)
-        return parsed
+        return text
 
     def _write_usage_record(self, *, kind: str, round_label: str, agent: Any) -> None:
         """Append one JSONL record to ``<log_dir>/usage.jsonl`` for this call.

--- a/src/vibesys/agents/deepagents_runner.py
+++ b/src/vibesys/agents/deepagents_runner.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel
 from vibesys._agent_cli.base import MCPServerSpec
 from vibesys.agent_runner import (
     log_agent_config,
+    run_agent,
     run_typed_agent,
 )
 from vibesys.agents.callbacks import AgentLogger
@@ -66,6 +67,7 @@ class DeepAgentsRunner:
         response_cls: type[T],
         fallback_factory: Callable[[], T],
         round_label: str,
+        invocation_id: str | None = None,
         progress: AgentProgress | None = None,
         mcp_servers: list[MCPServerSpec] | None = None,  # noqa: ARG002 — cli-only injection point; deepagents uses tools=
         tools: list[BaseTool] | None = None,
@@ -96,6 +98,9 @@ class DeepAgentsRunner:
                 model_name=self._model_name,
                 agent_label=label,
                 progress=progress,
+                agent_kind=kind,
+                round_label=round_label,
+                invocation_id=invocation_id,
             )
         ]
 
@@ -105,6 +110,53 @@ class DeepAgentsRunner:
             response_cls=response_cls,
             label=kind.upper(),
             fallback_factory=fallback_factory,
+            callbacks=callbacks,
+            thread_id=thread_id,
+            round_label=round_label,
+            log_file=self._run_log_file,
+        )
+
+    def invoke_text(
+        self,
+        *,
+        kind: str,
+        workspace: Path,  # noqa: ARG002 — backend already encapsulates cwd
+        system_prompt: str,
+        env: dict[str, str] | None = None,  # noqa: ARG002 — env on the BaseSandbox
+        user_prompt: str,
+        round_label: str,
+        invocation_id: str | None = None,
+        progress: AgentProgress | None = None,
+        mcp_servers: list[MCPServerSpec] | None = None,  # noqa: ARG002 — cli-only
+        tools: list[BaseTool] | None = None,
+    ) -> str:
+        """Run a conversational agent without imposing a response schema."""
+        checkpointer = MemorySaver()
+        thread_id = uuid.uuid4().hex
+        label = _agent_label(kind)
+        agent = create_deep_agent(
+            model=self._model,
+            backend=self._backends[kind],
+            system_prompt=system_prompt,
+            skills=self._skills,
+            checkpointer=checkpointer,
+            tools=tools,
+        )
+        log_agent_config(agent, label, self._run_log_file)
+        callbacks: list[BaseCallbackHandler] = [
+            AgentLogger(
+                log_file=self._run_log_file,
+                model_name=self._model_name,
+                agent_label=label,
+                progress=progress,
+                agent_kind=kind,
+                round_label=round_label,
+                invocation_id=invocation_id,
+            )
+        ]
+        return run_agent(
+            agent,
+            user_prompt,
             callbacks=callbacks,
             thread_id=thread_id,
             round_label=round_label,

--- a/src/vibesys/agents/stub_runner.py
+++ b/src/vibesys/agents/stub_runner.py
@@ -7,8 +7,10 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TypeVar
 
+from langchain_core.tools import BaseTool
 from pydantic import BaseModel
 
+from vibesys._agent_cli.base import MCPServerSpec
 from vibesys.agents.progress import AgentProgress
 
 T = TypeVar("T", bound=BaseModel)
@@ -48,6 +50,33 @@ class StubAgentRunner:
             agent_kind=kind,
         )
         return response_cls.model_validate(response) if response is not None else fallback_factory()
+
+    def invoke_text(
+        self,
+        *,
+        kind: str,
+        workspace: Path,
+        system_prompt: str,
+        env: dict[str, str] | None = None,
+        user_prompt: str,
+        round_label: str,
+        invocation_id: str | None = None,
+        progress: AgentProgress | None = None,
+        mcp_servers: list[MCPServerSpec] | None = None,
+        tools: list[BaseTool] | None = None,
+    ) -> str:
+        """Return a deterministic conversational answer for TUI smoke tests."""
+        del workspace, system_prompt, env, progress, mcp_servers, tools
+        from vibesys.render.sink import output_sink
+
+        output_sink().agent_output(
+            f"[stub-agent] investigating: {user_prompt}\n",
+            channel="analysis",
+            agent_kind=kind,
+            round_label=round_label,
+            invocation_id=invocation_id,
+        )
+        return "Stub chat inspected the available experiment trajectory."
 
 
 def _response_data(model_name: str) -> dict[str, object] | None:

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -1,7 +1,9 @@
 """Shared run context: ``_RunContext``, ``create_run_context``, and ``setup_exp_dir``."""
 
+import json
 import shutil
 import subprocess
+import threading
 import uuid
 from collections.abc import Callable, Generator
 from contextlib import ExitStack, contextmanager
@@ -64,6 +66,33 @@ if TYPE_CHECKING:
     from vibesys.server.supervisor import RunSupervisor
 
 T = TypeVar("T", bound=BaseModel)
+
+_CHAT_STATE_DIR = "_vibesys_chat"
+_CHAT_TRAJECTORY_SUFFIXES = frozenset({".json", ".jsonl", ".log", ".md", ".txt"})
+_EXPERIMENT_CHAT_SYSTEM_PROMPT = """\
+You are the read-only investigation agent for a live VibeSys experiment. Answer the
+user's question by examining evidence instead of relying on a precomputed summary.
+
+Your working directory is the current experiment workspace. Relevant evidence is:
+- `_vibesys_chat/trajectory/`: refreshed snapshots of the experiment event stream,
+  agent run logs, round state, progress, performance metrics, and other textual logs.
+- `_vibesys_chat/conversation.jsonl`: successful earlier exchanges in this chat.
+- the rest of the workspace: the current implementation, evaluator inputs, and git
+  history/diffs when available.
+
+Investigate only what the question requires. Prefer targeted commands such as `rg`,
+`tail`, `jq`, `git status`, and `git diff`; correlate claims with round labels, event
+sequence numbers, tool output, or file contents. Distinguish direct evidence from
+inference, mention important missing evidence, and give a concise answer.
+
+Do not edit files, run mutating commands, start workloads, steer optimization agents,
+or claim actions you did not take. Your role is analysis only.
+"""
+_EXPERIMENT_CHAT_CONTINUATION_PROMPT = """\
+Continue the read-only experiment chat. Follow `_vibesys_chat/instructions.md`,
+consult `_vibesys_chat/conversation.jsonl` when the question depends on an earlier
+exchange, and investigate the refreshed trajectory evidence before making claims.
+"""
 
 
 def setup_exp_dir(
@@ -389,6 +418,8 @@ def create_run_context(
         backends={
             "implementer": session.sandbox,
             "judge": session.sandbox,
+            # TUI chat is a read-only peer agent over the current workspace.
+            "chat": session.sandbox,
             # Perf eval reuses the implementer's backend today (loop.py:564),
             # so the runner picks the same one when kind="perf_eval".
             "perf_eval": session.sandbox,
@@ -533,6 +564,10 @@ class _RunContext:
         self.agent_runner = agent_runner
         self._closed = False
         self._progress_stack: list[AgentProgress] = []
+        self._chat_lock = threading.Lock()
+        self._chat_history = self._load_chat_history()
+        if self.supervisor is not None:
+            self.supervisor.set_chat_handler(self.chat)
 
     # -- path passthroughs ----------------------------------------------------
     # Canonical values live in the frozen ``RunPaths`` record; these
@@ -633,6 +668,102 @@ class _RunContext:
             if supervisor is not None:
                 supervisor.after_agent(kind, round_label, result=result, error=error)
 
+    def chat(self, question: str) -> str:
+        """Ask a read-only peer agent about the live experiment."""
+        from vibesys.server.inspector import RunInspector
+
+        with self._chat_lock:
+            self._sync_chat_trajectory()
+
+            def fallback() -> str:
+                assert self.supervisor is not None
+                diagnostic = RunInspector(self.supervisor).answer(question)
+                return f"Chat agent did not return an answer.\n\nFallback diagnostic:\n{diagnostic}"
+
+            assert self.supervisor is not None
+            invocation_id = uuid.uuid4().hex
+            system_prompt = (
+                _EXPERIMENT_CHAT_CONTINUATION_PROMPT
+                if self._chat_history
+                else _EXPERIMENT_CHAT_SYSTEM_PROMPT
+            )
+            with self.supervisor.presentation_scope(
+                agent_kind="chat",
+                round_label="experiment-chat",
+                invocation_id=invocation_id,
+            ):
+                try:
+                    answer = self.agent_runner.invoke_text(
+                        kind="chat",
+                        workspace=self.workspace,
+                        system_prompt=system_prompt,
+                        env=self.gpu_env(),
+                        user_prompt=question,
+                        round_label="experiment chat",
+                        invocation_id=invocation_id,
+                        progress=self.current_progress(),
+                    )
+                except Exception as exc:
+                    raise RuntimeError(f"Chat agent failed: {type(exc).__name__}: {exc}") from exc
+            if not answer.strip():
+                answer = fallback()
+            self._chat_history.append((question, answer))
+            self._append_chat_exchange(question, answer)
+            return answer
+
+    @property
+    def _chat_state_dir(self) -> Path:
+        return self.workspace / _CHAT_STATE_DIR
+
+    def _load_chat_history(self) -> list[tuple[str, str]]:
+        """Load successful prior exchanges so reopening a run resumes its chat."""
+        transcript = self._chat_state_dir / "conversation.jsonl"
+        if not transcript.is_file():
+            return []
+        history: list[tuple[str, str]] = []
+        try:
+            for line in transcript.read_text(encoding="utf-8").splitlines():
+                payload = json.loads(line)
+                question = payload.get("question")
+                answer = payload.get("answer")
+                if isinstance(question, str) and isinstance(answer, str):
+                    history.append((question, answer))
+        except (OSError, json.JSONDecodeError, AttributeError):
+            return []
+        return history
+
+    def _append_chat_exchange(self, question: str, answer: str) -> None:
+        """Persist one successful exchange for later agent investigation."""
+        try:
+            self._chat_state_dir.mkdir(parents=True, exist_ok=True)
+            with (self._chat_state_dir / "conversation.jsonl").open(
+                "a", encoding="utf-8"
+            ) as transcript:
+                transcript.write(
+                    json.dumps({"question": question, "answer": answer}, ensure_ascii=False) + "\n"
+                )
+        except OSError as exc:
+            self.logger.lprint(f"[warn] could not persist experiment chat: {exc}")
+
+    def _sync_chat_trajectory(self) -> None:
+        """Refresh textual run evidence that the workspace-confined chat can inspect."""
+        trajectory_dir = self._chat_state_dir / "trajectory"
+        try:
+            trajectory_dir.mkdir(parents=True, exist_ok=True)
+            (self._chat_state_dir / "instructions.md").write_text(
+                _EXPERIMENT_CHAT_SYSTEM_PROMPT, encoding="utf-8"
+            )
+            self.run_log_file.flush()
+            for source in self.log_dir.iterdir():
+                if not source.is_file() or source.suffix not in _CHAT_TRAJECTORY_SUFFIXES:
+                    continue
+                destination = trajectory_dir / source.name
+                temporary = trajectory_dir / f".{source.name}.tmp"
+                shutil.copyfile(source, temporary)
+                temporary.replace(destination)
+        except OSError as exc:
+            self.logger.lprint(f"[warn] could not refresh experiment chat trajectory: {exc}")
+
     def wait_for_debug(self, step: str) -> None:
         if self.debug:
             input(f"\n[debug] {step}. Press Enter to continue...")
@@ -720,6 +851,8 @@ class _RunContext:
         if self._closed:
             return
         self._closed = True
+        if self.supervisor is not None:
+            self.supervisor.set_chat_handler(None)
         # Unwinds in reverse construction order: device monitor stop +
         # gpu.json finalization, environment hook teardown, run-environment
         # session exit, stderr restore + log file close.

--- a/src/vibesys/render/sink.py
+++ b/src/vibesys/render/sink.py
@@ -66,6 +66,8 @@ class OutputSink:
         channel: AgentOutputChannel = "assistant",
         status: AgentStatusData | None = None,
         agent_kind: str | None = None,
+        round_label: str | None = None,
+        invocation_id: str | None = None,
     ) -> None:
         if not content:
             return
@@ -73,6 +75,8 @@ class OutputSink:
             EventType.AGENT_OUTPUT_CHUNK,
             AgentOutputChunkData(channel=channel, content=content, status=status),
             agent_kind=agent_kind,
+            round_label=round_label,
+            invocation_id=invocation_id,
         )
 
     def tool_call(
@@ -81,22 +85,53 @@ class OutputSink:
         args: dict[str, Any],
         *,
         status: AgentStatusData | None = None,
+        agent_kind: str | None = None,
+        round_label: str | None = None,
+        invocation_id: str | None = None,
     ) -> None:
         self._emit(
             EventType.TOOL_CALL,
             ToolCallData(tool=tool, args=_json_safe(args), status=status),
+            agent_kind=agent_kind,
+            round_label=round_label,
+            invocation_id=invocation_id,
         )
 
-    def tool_result(self, tool: str, content: str, *, is_error: bool = False) -> None:
+    def tool_result(
+        self,
+        tool: str,
+        content: str,
+        *,
+        is_error: bool = False,
+        agent_kind: str | None = None,
+        round_label: str | None = None,
+        invocation_id: str | None = None,
+    ) -> None:
         self._emit(
             EventType.TOOL_RESULT,
             ToolResultData(tool=tool, content=content, is_error=is_error),
+            agent_kind=agent_kind,
+            round_label=round_label,
+            invocation_id=invocation_id,
         )
 
-    def todo_update(self, todos: list[TodoItemData]) -> None:
+    def todo_update(
+        self,
+        todos: list[TodoItemData],
+        *,
+        agent_kind: str | None = None,
+        round_label: str | None = None,
+        invocation_id: str | None = None,
+    ) -> None:
         if not todos:
             return
-        self._emit(EventType.TODO_UPDATE, TodoUpdateData(todos=todos))
+        self._emit(
+            EventType.TODO_UPDATE,
+            TodoUpdateData(todos=todos),
+            agent_kind=agent_kind,
+            round_label=round_label,
+            invocation_id=invocation_id,
+        )
 
     def usage_update(
         self,
@@ -104,10 +139,16 @@ class OutputSink:
         *,
         context_window: int | None = None,
         model: str | None = None,
+        agent_kind: str | None = None,
+        round_label: str | None = None,
+        invocation_id: str | None = None,
     ) -> None:
         self._emit(
             EventType.USAGE_UPDATE,
             UsageUpdateData(input_tokens=input_tokens, context_window=context_window, model=model),
+            agent_kind=agent_kind,
+            round_label=round_label,
+            invocation_id=invocation_id,
         )
 
     # -- dispatch ------------------------------------------------------------
@@ -118,17 +159,31 @@ class OutputSink:
         data: EventData,
         *,
         agent_kind: str | None = None,
+        round_label: str | None = None,
+        invocation_id: str | None = None,
     ) -> None:
         from vibesys.server.registry import active_supervisor
 
         supervisor = active_supervisor()
         if supervisor is not None:
-            supervisor.publish_presentation(event_type, data, agent_kind=agent_kind)
+            supervisor.publish_presentation(
+                event_type,
+                data,
+                agent_kind=agent_kind,
+                round_label=round_label,
+                invocation_id=invocation_id,
+            )
         with self._lock:
             subscribers = self._subscribers
         if not subscribers:
             return
-        event = make_event(event_type, agent_kind=agent_kind, data=data)
+        event = make_event(
+            event_type,
+            agent_kind=agent_kind,
+            round_label=round_label,
+            invocation_id=invocation_id,
+            data=data,
+        )
         for handler in subscribers:
             handler(event)
 

--- a/src/vibesys/run/workspace.py
+++ b/src/vibesys/run/workspace.py
@@ -30,6 +30,9 @@ if TYPE_CHECKING:
 # /workspace/_opt_vibesys respectively) — not implementer
 # output, and we never want them in git history. ``_mounts`` is
 # the Docker ancestor-mount redirect dir for the same reason.
+# ``_vibesys_chat`` contains the experiment-chat transcript and
+# refreshed trajectory snapshots; it is framework state, not a candidate
+# implementation artifact.
 # ``.cache`` holds any HF-download fallback (drafter, etc.).
 EXCLUDED_WORKSPACE_DIRS: frozenset[str] = frozenset(
     {
@@ -40,6 +43,7 @@ EXCLUDED_WORKSPACE_DIRS: frozenset[str] = frozenset(
         "_auth",
         "_opt_vibesys",
         "_mounts",
+        "_vibesys_chat",
         ".cache",
         ".venv",
         "exp_env",

--- a/src/vibesys/server/inspector.py
+++ b/src/vibesys/server/inspector.py
@@ -7,7 +7,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from vibesys.server.events import EventStatus, EventType, RunEvent
+from vibesys.server.events import ConfigurationFailedData, EventStatus, EventType, RunEvent
 
 if TYPE_CHECKING:
     from vibesys.server.supervisor import RunSupervisor
@@ -20,6 +20,9 @@ class RunInspector:
         self.supervisor = supervisor
 
     def answer(self, question: str) -> str:
+        configuration_failure = self._latest_configuration_failure()
+        if configuration_failure is not None:
+            return self._status_answer(question, configuration_failure)
         query = question.lower()
         if any(word in query for word in ("doing", "current", "status", "now")):
             return self._status_answer(question, self.supervisor.status())
@@ -117,6 +120,19 @@ class RunInspector:
             if agent_kind is not None and event.agent_kind != agent_kind:
                 continue
             return self._format_event(event)
+        return None
+
+    def _latest_configuration_failure(self) -> str | None:
+        for event in reversed(self.supervisor.read_history_events()):
+            if event.type is not EventType.CONFIGURATION_FAILED:
+                continue
+            data = event.data
+            if not isinstance(data, ConfigurationFailedData):
+                continue
+            answer = f"Experiment configuration failed during {data.stage}: {data.message}"
+            if data.usage:
+                answer += f"\n\n{data.usage}"
+            return answer
         return None
 
     def _latest_round_number(self) -> int | None:

--- a/src/vibesys/server/service.py
+++ b/src/vibesys/server/service.py
@@ -45,10 +45,12 @@ class SupervisionService:
                 ack=CommandAck(action="resume", status="consumed"),
             )
         if isinstance(request, ChatQuery):
+            sequence = self.supervisor.snapshot().sequence
             answer = self.supervisor.chat(request.text)
             return Response(
                 request_id=request.request_id,
                 chat=ChatResult(question=request.text, answer=answer),
+                events=self.supervisor.read_events(sequence),
             )
         if isinstance(request, HistoryQuery):
             self.supervisor.record(EventType.STATUS_QUERY, "/history")

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 import threading
 import uuid
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -43,6 +45,8 @@ class RunSupervisor:
         self.log_dir: Path | None = None
         self._current_kind: str | None = None
         self._current_round: str | None = None
+        self._chat_handler: Callable[[str], str] | None = None
+        self._presentation_local = threading.local()
 
     @property
     def current_round(self) -> str | None:
@@ -85,6 +89,7 @@ class RunSupervisor:
         *,
         channel: AgentOutputChannel = "assistant",
         agent_kind: str | None = None,
+        round_label: str | None = None,
         invocation_id: str | None = None,
     ) -> None:
         if not content:
@@ -93,6 +98,7 @@ class RunSupervisor:
             EventType.AGENT_OUTPUT_CHUNK,
             AgentOutputChunkData(channel=channel, content=content),
             agent_kind=agent_kind,
+            round_label=round_label,
             invocation_id=invocation_id,
         )
 
@@ -102,14 +108,18 @@ class RunSupervisor:
         data: EventData,
         *,
         agent_kind: str | None = None,
+        round_label: str | None = None,
         invocation_id: str | None = None,
     ) -> None:
         """Record a presentation event enriched with the active invocation scope."""
+        scoped_kind = getattr(self._presentation_local, "agent_kind", None)
+        scoped_round = getattr(self._presentation_local, "round_label", None)
+        scoped_invocation = getattr(self._presentation_local, "invocation_id", None)
         self.record(
             event_type,
-            agent_kind=agent_kind or self._current_kind,
-            round_label=self._current_round,
-            invocation_id=invocation_id or self._active_invocation,
+            agent_kind=agent_kind or scoped_kind or self._current_kind,
+            round_label=round_label or scoped_round or self._current_round,
+            invocation_id=invocation_id or scoped_invocation or self._active_invocation,
             data=data,
         )
 
@@ -158,16 +168,50 @@ class RunSupervisor:
             )
 
     def chat(self, text: str) -> str:
-        from vibesys.server.inspector import RunInspector
+        with self._condition:
+            handler = self._chat_handler
+        if handler is None:
+            from vibesys.server.inspector import RunInspector
 
-        answer = RunInspector(self).answer(text)
+            answer = RunInspector(self).answer(text)
+        else:
+            answer = handler(text)
         self.record(
             EventType.CHAT,
             text,
             status=EventStatus.ANSWERED,
+            agent_kind="chat",
+            round_label="experiment-chat",
             data=ChatData(answer=answer),
         )
         return answer
+
+    def set_chat_handler(self, handler: Callable[[str], str] | None) -> None:
+        """Install the current experiment's agent-backed chat handler."""
+        with self._condition:
+            self._chat_handler = handler
+
+    @contextmanager
+    def presentation_scope(
+        self, *, agent_kind: str, round_label: str, invocation_id: str
+    ) -> Generator[None]:
+        """Tag side-channel presentation events without changing active run state."""
+        previous = (
+            getattr(self._presentation_local, "agent_kind", None),
+            getattr(self._presentation_local, "round_label", None),
+            getattr(self._presentation_local, "invocation_id", None),
+        )
+        self._presentation_local.agent_kind = agent_kind
+        self._presentation_local.round_label = round_label
+        self._presentation_local.invocation_id = invocation_id
+        try:
+            yield
+        finally:
+            (
+                self._presentation_local.agent_kind,
+                self._presentation_local.round_label,
+                self._presentation_local.invocation_id,
+            ) = previous
 
     def pause_after_call(self) -> None:
         with self._condition:

--- a/src/vibesys/server/transport.py
+++ b/src/vibesys/server/transport.py
@@ -10,7 +10,7 @@ import threading
 import time
 from pathlib import Path
 
-from pydantic import BaseModel, TypeAdapter, ValidationError
+from pydantic import BaseModel, TypeAdapter
 
 from vibesys.server.protocol import (
     EventBatchMessage,
@@ -44,7 +44,7 @@ class _RequestHandler(socketserver.StreamRequestHandler):
                         self.server.client_disconnected.set()  # type: ignore[attr-defined]
                     return
                 response = service.execute(request)
-            except (json.JSONDecodeError, TypeError, ValidationError, ValueError) as exc:
+            except Exception as exc:
                 response = Response(
                     request_id=request_id,
                     ok=False,

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -151,6 +151,35 @@ class TestDeepAgentsRunner:
 
         assert captured_backends == [impl_backend, judge_backend, perf_backend]
 
+    def test_deepagents_runner_returns_plain_text_without_response_format(self, tmp_path):
+        with (
+            patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
+            patch(
+                "vibesys.agents.deepagents_runner.run_agent",
+                return_value="Natural **Markdown** answer.",
+            ) as mock_run,
+        ):
+            mock_create.return_value = MagicMock(name="chat-agent")
+            runner = DeepAgentsRunner(
+                model="m",
+                backends={"chat": MagicMock(name="chat-backend")},
+                skills=[],
+                model_name="m",
+                run_log_file=None,
+            )
+
+            result = runner.invoke_text(
+                kind="chat",
+                workspace=tmp_path,
+                system_prompt="investigate",
+                user_prompt="what happened?",
+                round_label="experiment chat",
+            )
+
+        assert result == "Natural **Markdown** answer."
+        assert "response_format" not in mock_create.call_args.kwargs
+        assert mock_run.call_args.args[1] == "what happened?"
+
 
 # ---------------------------------------------------------------------------
 # Helpers for CLI runner tests
@@ -528,6 +557,44 @@ class TestCliAgentRunner:
         prompt = captured[0].generate_calls[0]["prompt"]
         assert "JudgeResponse" in prompt
         assert prompt.startswith("THE-SYSTEM-PROMPT")
+
+    def test_cli_runner_chat_returns_plain_text_in_a_fresh_session_per_turn(
+        self, monkeypatch, tmp_path
+    ):
+        captured: list = []
+        fake_cls = _make_fake_agent_class(
+            generate_returns="Natural **Markdown** answer.",
+            captured=captured,
+        )
+        monkeypatch.setitem(
+            __import__(
+                "vibesys.agents.cli_runner",
+                fromlist=["_PROVIDER_CLASSES"],
+            )._PROVIDER_CLASSES,
+            "codex",
+            fake_cls,
+        )
+
+        runner = CliAgentRunner(provider="codex", model="m", run_log_file=None)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+
+        for turn in (1, 2):
+            answer = runner.invoke_text(
+                kind="chat",
+                workspace=workspace,
+                system_prompt="sys",
+                user_prompt=f"turn {turn}",
+                round_label="experiment-chat",
+            )
+            assert answer == "Natural **Markdown** answer."
+
+        assert len(captured) == 2
+        assert captured[0] is not captured[1]
+        assert captured[0].generate_calls[0]["prompt"] == "sys\n\nturn 1"
+        assert captured[1].generate_calls[0]["prompt"] == "sys\n\nturn 2"
+        assert "Return EXACTLY" not in captured[0].generate_calls[0]["prompt"]
+        assert "chat" not in runner._agents
 
     def test_cli_runner_prints_prompt_as_rendered_markdown_before_generate(
         self, monkeypatch, tmp_path, capsys

--- a/tests/agents/test_stub_runner.py
+++ b/tests/agents/test_stub_runner.py
@@ -24,6 +24,21 @@ def test_stub_runner_returns_valid_agent_loop_responses(tmp_path):
     assert responses[3].verdict is Verdict.PASS
 
 
+def test_stub_runner_returns_plain_chat_text(tmp_path):
+    runner = StubAgentRunner()
+
+    answer = runner.invoke_text(
+        kind="chat",
+        workspace=tmp_path,
+        system_prompt="investigate",
+        user_prompt="what happened?",
+        round_label="experiment-chat",
+        invocation_id="chat-1",
+    )
+
+    assert answer == "Stub chat inspected the available experiment trajectory."
+
+
 def invoke(runner, workspace, kind, response_cls):
     return runner.invoke(
         kind=kind,

--- a/tests/render/test_sink.py
+++ b/tests/render/test_sink.py
@@ -1,7 +1,9 @@
 """Tests for the process-global OutputSink emission point."""
 
+import threading
 from pathlib import Path
 
+from vibesys.agents.callbacks import AgentLogger
 from vibesys.render.sink import OutputSink
 from vibesys.server.events import (
     AgentOutputChunkData,
@@ -120,3 +122,39 @@ class TestSupervisorForwarding:
     def test_no_supervisor_no_error(self):
         sink = OutputSink()
         sink.agent_output("standalone")  # must not raise without a supervisor
+
+    def test_logger_metadata_routes_subprocess_thread_events_to_chat(self, tmp_path):
+        supervisor = RunSupervisor()
+        supervisor.attach(tmp_path / "logs")
+        logger = AgentLogger(
+            agent_kind="chat",
+            round_label="experiment-chat",
+            invocation_id="chat-invocation",
+        )
+        REGISTRY.activate(supervisor)
+        try:
+            worker = threading.Thread(
+                target=lambda: (
+                    logger.on_tool_call("execute", {"command": "rg throughput"}),
+                    logger.on_tool_result("execute", stdout="round 2: 2400 tok/s"),
+                )
+            )
+            worker.start()
+            worker.join(timeout=2)
+        finally:
+            REGISTRY.deactivate(supervisor)
+
+        events = [
+            event
+            for event in supervisor.read_events()
+            if event.type in (EventType.TOOL_CALL, EventType.TOOL_RESULT)
+        ]
+        assert [event.agent_kind for event in events] == ["chat", "chat"]
+        assert [event.round_label for event in events] == [
+            "experiment-chat",
+            "experiment-chat",
+        ]
+        assert [event.invocation_id for event in events] == [
+            "chat-invocation",
+            "chat-invocation",
+        ]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -20,6 +20,7 @@ from vibesys.server import (
     RunInspector,
     RunSupervisor,
 )
+from vibesys.server.events import ConfigurationFailedData
 from vibesys.server.protocol import (
     ChatQuery,
     EventsQuery,
@@ -101,6 +102,26 @@ def test_general_chat_is_distinct_from_status_query(tmp_path):
     supervisor.chat("hello there")
     event_types = [event["type"] for event in _events(tmp_path / "run-events.jsonl")]
     assert event_types == ["server_started", "chat"]
+
+
+def test_side_channel_chat_output_is_tagged_without_changing_active_agent(tmp_path):
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.before_agent("implementer", "round-1", "work")
+
+    with supervisor.presentation_scope(
+        agent_kind="chat", round_label="experiment-chat", invocation_id="chat-1"
+    ):
+        supervisor.publish_agent_output("private chat output")
+    supervisor.publish_agent_output("experiment output")
+
+    agent_events = [
+        event for event in supervisor.read_events() if event.type is EventType.AGENT_OUTPUT_CHUNK
+    ]
+    assert [event.agent_kind for event in agent_events] == ["chat", "implementer"]
+    assert agent_events[0].round_label == "experiment-chat"
+    assert agent_events[0].invocation_id == "chat-1"
+    assert agent_events[1].data.content == "experiment output"
 
 
 def test_bootstrap_events_migrate_to_run_audit_without_replacing_history(tmp_path):
@@ -220,6 +241,92 @@ def test_service_accepts_chat(tmp_path):
     assert any(event["type"] == "status_query" for event in events)
 
 
+def test_service_routes_chat_to_configured_agent_handler(tmp_path):
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    questions = []
+    supervisor.set_chat_handler(lambda question: questions.append(question) or "agent answer")
+
+    response = SupervisionService(supervisor).execute(ChatQuery(text="what changed?"))
+
+    assert response.chat.answer == "agent answer"
+    assert questions == ["what changed?"]
+    assert response.events[-1].type is EventType.CHAT
+    assert response.events[-1].agent_kind == "chat"
+    assert _events(tmp_path / "run-events.jsonl")[-1]["type"] == "chat"
+
+
+def test_chat_explains_configuration_failure_without_a_run_context(tmp_path):
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.record(
+        EventType.CONFIGURATION_FAILED,
+        status="failed",
+        data=ConfigurationFailedData(
+            code="config_load_failed",
+            stage="config_loading",
+            message="agent.toml was not found",
+            usage=None,
+            exit_code=2,
+        ),
+    )
+
+    response = SupervisionService(supervisor).execute(ChatQuery(text="why did startup fail?"))
+
+    assert "config_loading" in response.chat.answer
+    assert "agent.toml was not found" in response.chat.answer
+
+
+def test_run_context_chat_exposes_trajectory_without_inlining_it_in_prompt(tmp_path):
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path / "logs")
+    (tmp_path / "logs" / "progress.md").write_text("Round 2 improved throughput.")
+    ctx = _RunContext.__new__(_RunContext)
+    ctx.supervisor = supervisor
+    ctx.agent_runner = Mock()
+    ctx.agent_runner.invoke_text.return_value = "It improved in round 2."
+    ctx._paths = RunPaths(
+        exp_dir=tmp_path,
+        log_dir=tmp_path / "logs",
+        workspace=tmp_path / "workspace",
+        run_log_path=tmp_path / "run.log",
+    )
+    ctx.gpu_env = lambda: {}
+    ctx._progress_stack = []
+    ctx._chat_lock = threading.Lock()
+    ctx._chat_history = []
+    ctx.logger = Mock()
+    ctx.logger.file = Mock()
+
+    answer = ctx.chat("what improved?")
+
+    assert answer == "It improved in round 2."
+    invocation = ctx.agent_runner.invoke_text.call_args.kwargs
+    assert invocation["kind"] == "chat"
+    assert "response_cls" not in invocation
+    assert invocation["user_prompt"] == "what improved?"
+    assert "Round 2 improved throughput." not in invocation["user_prompt"]
+    assert "_vibesys_chat/trajectory/" in invocation["system_prompt"]
+    assert "read-only investigation agent" in invocation["system_prompt"]
+    trajectory = tmp_path / "workspace" / "_vibesys_chat" / "trajectory"
+    assert (trajectory / "progress.md").read_text() == "Round 2 improved throughput."
+    transcript = tmp_path / "workspace" / "_vibesys_chat" / "conversation.jsonl"
+    assert json.loads(transcript.read_text()) == {
+        "question": "what improved?",
+        "answer": "It improved in round 2.",
+    }
+
+    ctx.agent_runner.invoke_text.side_effect = RuntimeError("agent unavailable")
+    with pytest.raises(RuntimeError, match="Chat agent failed: RuntimeError: agent unavailable"):
+        ctx.chat("what is the current status?")
+    continuation = ctx.agent_runner.invoke_text.call_args.kwargs
+    assert continuation["user_prompt"] == "what is the current status?"
+    assert "It improved in round 2." not in continuation["user_prompt"]
+    assert "_vibesys_chat/instructions.md" in continuation["system_prompt"]
+    assert "Prefer targeted commands" not in continuation["system_prompt"]
+    assert ctx._load_chat_history() == [("what improved?", "It improved in round 2.")]
+
+
 def test_socket_transport_supports_multiple_clients_and_event_replay(tmp_path):
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path / "logs")
@@ -246,6 +353,28 @@ def test_socket_transport_supports_multiple_clients_and_event_replay(tmp_path):
     assert sequences == sorted(sequences)
     assert len(sequences) == len(set(sequences))
     assert any(event["type"] == "server_started" for event in replay["events"])
+
+
+def test_socket_transport_returns_clear_chat_agent_errors(tmp_path):
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path / "logs")
+
+    def fail_chat(question: str) -> str:
+        raise RuntimeError(f"Chat agent failed while answering: {question}")
+
+    supervisor.set_chat_handler(fail_chat)
+    socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"
+
+    with SupervisionSocketServer(socket_path, SupervisionService(supervisor)):
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.connect(str(socket_path))
+            stream = client.makefile("rwb")
+            stream.write(ChatQuery(text="what happened?").model_dump_json().encode() + b"\n")
+            stream.flush()
+            response = json.loads(stream.readline())
+
+    assert response["ok"] is False
+    assert response["error"] == "Chat agent failed while answering: what happened?"
 
 
 def test_socket_subscription_replays_then_streams_new_events(tmp_path):
@@ -345,6 +474,7 @@ def test_supervision_runtime_streams_configuration_failure_before_exiting():
     session_dir = Path("/tmp") / f"vs-runtime-test-{uuid.uuid4().hex}"
     socket_path = session_dir / "control.sock"
     received_events = []
+    chat_responses = []
 
     def subscribe_until_failure() -> None:
         deadline = time.monotonic() + 5
@@ -364,6 +494,16 @@ def test_supervision_runtime_streams_configuration_failure_before_exiting():
                     received_events.extend(message["events"])
                 if any(event["type"] == "configuration_failed" for event in received_events):
                     break
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as chat_client:
+                chat_client.settimeout(5)
+                chat_client.connect(str(socket_path))
+                chat_stream = chat_client.makefile("rwb")
+                chat_stream.write(
+                    ChatQuery(text="why did startup fail?").model_dump_json().encode() + b"\n"
+                )
+                chat_stream.flush()
+                chat_responses.append(json.loads(chat_stream.readline()))
+                chat_stream.close()
             stream.close()
 
     subscriber = threading.Thread(target=subscribe_until_failure)
@@ -394,6 +534,8 @@ def test_supervision_runtime_streams_configuration_failure_before_exiting():
             "exit_code": 2,
         }
         assert not any(event["type"] == "run_failed" for event in received_events)
+        assert chat_responses[0]["ok"] is True
+        assert "unknown option --bad" in chat_responses[0]["chat"]["answer"]
     finally:
         subscriber.join(timeout=5)
         shutil.rmtree(session_dir, ignore_errors=True)


### PR DESCRIPTION
## Problem

Closes #194, under the CLI improvement roadmap #157.

Operators need a multi-turn way to investigate the current experiment from the TUI, including trajectories, tool activity, and startup failures.

## Solution

Adds a dedicated `/chat` popup backed by the configured agent.

- Keeps chat history across turns and guides the agent to inspect persisted experiment artifacts.
- Shows reasoning, tool calls, tool results, responses, and actionable failures in the transcript.
- Accepts messages during an active turn and batches all waiting messages into one ordered follow-up when the agent is ready.
- Keeps each submitted message separate in the UI; messages arriving after a batch starts form the next batch.
- Provides an inspector context even when normal experiment startup fails.

### Architecture

```mermaid
flowchart LR
    UI["Chat popup + input"] --> Q["FIFO message queue"]
    Q --> B["Ready-message batch"]
    B --> A["Configured agent"]
    A --> E["Trajectory events"]
    E --> UI
    A --> W["Experiment workspace"]
```

## Verification

### Correctness properties

- Chat remains observational and cannot steer the experiment.
- One request runs at a time; messages are neither dropped nor duplicated.
- Batches preserve queued message text and FIFO order.
- Messages submitted after a batch starts wait for the next batch.
- Existing structured experiment-agent response handling is unchanged.

### Testing

- `uv run pytest tests/unit/clients/tui tests/unit/supervisor/test_chat.py tests/unit/agent/test_runner.py tests/unit/agent/test_cli.py -q` — 160 passed
- `cd clients/tui && bun run test` — 73 passed
- `cd clients/tui && bun run check` — passed
- `./scripts/check_format.sh` and `./scripts/check_lint.sh` — passed
