### PR TITLE
Tear down each candidate's Modal app after evaluation

### DIFF
--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -88,6 +88,23 @@ def _discard_working_tree(ctx: LoopContext) -> None:
         ctx.lprint(f"[warn] discard working tree failed: {exc}")
 
 
+def _teardown_candidate_app(ctx: LoopContext, cand_app: str | None, *, keep: bool) -> None:
+    """Release a candidate's per-evaluation deployment once its judge/profiler are done.
+
+    Every candidate deploys its GPU server to its own per-candidate deployment (so the judge
+    never reads a prior candidate's cumulative logs). Once evaluation is over that deployment
+    is dead weight — nothing reuses it — so hand it back to the run environment to release.
+    The environment decides *how* (e.g. Modal stops the app; local envs are a no-op), so the
+    loop stays agnostic to the backend.
+
+    No-op when ``keep`` is set (the ``--keep-modal-apps`` opt-out, for post-hoc log
+    inspection) or when ``cand_app`` is None (no per-candidate deployment).
+    """
+    if keep or not cand_app:
+        return
+    ctx.run_environment.teardown_deployment(cand_app, log=ctx.lprint)
+
+
 # ---------------------------------------------------------------------------
 # Profiler MCP wiring (reused from orchestrate; kept here to avoid an
 # import-time dependency on the orchestrate loop)
@@ -338,6 +355,7 @@ def _bootstrap_seed(
     rng: random.Random,
     population: Population,
     population_path: Path,
+    keep_modal_apps: bool = False,
 ) -> Individual | None:
     """Iterate implementer → judge until a first *passing* seed exists.
 
@@ -382,103 +400,108 @@ def _bootstrap_seed(
         base_desc = "reference" if wip_seed is None else f"repair-seed #{wip_seed.id}"
         ctx.lprint(f"bootstrap base={base_desc}" + (f" modal-app={cand_app}" if cand_app else ""))
 
-        # 1. Implementer (the mutator in cold-start / from-scratch mode).
-        ctx.reselect_gpu()
-        mutator = _run_mutator(
-            ctx,
-            generation=0,
-            child_idx=attempt,
-            objective=objective,
-            parent=None,
-            inspirations=[],
-            modality=modality,
-            is_cold_start=True,
-            objectives=objectives,
-            failed_lessons=failed_lessons,
-            num_failed_attempts=num_failed_attempts,
-            repair_seed=wip_seed is not None,
-            runtime_notes=cand_notes,
-        )
+        # The attempt deploys its per-candidate Modal app during mutate/judge/
+        # profile; stop it once we're done evaluating, on every exit path.
+        try:
+            # 1. Implementer (the mutator in cold-start / from-scratch mode).
+            ctx.reselect_gpu()
+            mutator = _run_mutator(
+                ctx,
+                generation=0,
+                child_idx=attempt,
+                objective=objective,
+                parent=None,
+                inspirations=[],
+                modality=modality,
+                is_cold_start=True,
+                objectives=objectives,
+                failed_lessons=failed_lessons,
+                num_failed_attempts=num_failed_attempts,
+                repair_seed=wip_seed is not None,
+                runtime_notes=cand_notes,
+            )
 
-        # 2. Judge.
-        ctx.reselect_gpu()
-        verdict = _run_judge(
-            ctx,
-            generation=0,
-            child_idx=attempt,
-            modality=modality,
-            objective=objective,
-            pass_criteria=pass_criteria,
-            runtime_notes=cand_notes,
-        )
+            # 2. Judge.
+            ctx.reselect_gpu()
+            verdict = _run_judge(
+                ctx,
+                generation=0,
+                child_idx=attempt,
+                modality=modality,
+                objective=objective,
+                pass_criteria=pass_criteria,
+                runtime_notes=cand_notes,
+            )
 
-        if verdict.verdict != Verdict.PASS:
-            # Snapshot the failed tree so the next attempt repairs it in place.
-            # Only tag a WIP repair-seed when the snapshot actually committed new
-            # work (the tree changed); an unedited tree is nothing to fix-forward.
-            wip_commit = None
-            try:
-                sha_before = ctx.git.current_sha()
-                ctx.snapshot_workspace(f"wip-seed-bootstrap{attempt}")
-                sha_after = ctx.git.current_sha()
-                if sha_after and sha_after != sha_before:
-                    wip_commit = sha_after
-            except Exception as exc:
-                ctx.lprint(f"[warn] wip-seed snapshot failed: {exc}")
-            failed = Individual(
+            if verdict.verdict != Verdict.PASS:
+                # Snapshot the failed tree so the next attempt repairs it in place.
+                # Only tag a WIP repair-seed when the snapshot actually committed new
+                # work (the tree changed); an unedited tree is nothing to fix-forward.
+                wip_commit = None
+                try:
+                    sha_before = ctx.git.current_sha()
+                    ctx.snapshot_workspace(f"wip-seed-bootstrap{attempt}")
+                    sha_after = ctx.git.current_sha()
+                    if sha_after and sha_after != sha_before:
+                        wip_commit = sha_after
+                except Exception as exc:
+                    ctx.lprint(f"[warn] wip-seed snapshot failed: {exc}")
+                failed = Individual(
+                    id=population.next_id(),
+                    generation=0,
+                    parent_id=None,
+                    inspiration_ids=[],
+                    commit=wip_commit,
+                    perf_metric=None,
+                    perf_unit=None,
+                    passed=False,
+                    summary=mutator.summary,
+                    feedback=verdict.feedback,
+                )
+                population.add(failed)
+                population.save(population_path)
+                ctx.lprint(
+                    f"[bootstrap {attempt}] FAILED — feedback: "
+                    f"{(verdict.feedback or '').splitlines()[0][:120] if verdict.feedback else ''}"
+                )
+                continue
+
+            # 3. PASS → profile, snapshot, and record the generation-0 seed.
+            ctx.reselect_gpu()
+            summary = _run_profiler(
+                ctx,
+                generation=0,
+                child_idx=attempt,
+                modality=modality,
+                objective=objective,
+                objectives=objectives,
+                runtime_notes=cand_notes,
+            )
+            ctx.snapshot_workspace("gen-0-seed")
+            commit = ctx.git.current_sha()
+            seed = Individual(
                 id=population.next_id(),
                 generation=0,
                 parent_id=None,
                 inspiration_ids=[],
-                commit=wip_commit,
-                perf_metric=None,
-                perf_unit=None,
-                passed=False,
+                commit=commit,
+                perf_metric=summary.perf_metric if summary else None,
+                perf_unit=summary.perf_unit if summary else None,
+                metrics=dict(summary.metrics) if summary and summary.metrics else {},
+                passed=True,
                 summary=mutator.summary,
                 feedback=verdict.feedback,
             )
-            population.add(failed)
+            population.add(seed)
             population.save(population_path)
             ctx.lprint(
-                f"[bootstrap {attempt}] FAILED — feedback: "
-                f"{(verdict.feedback or '').splitlines()[0][:120] if verdict.feedback else ''}"
+                f"[bootstrap {attempt}] PASSED — seed #{seed.id} "
+                f"perf={seed.perf_metric} {seed.perf_unit or ''} "
+                f"(commit {commit[:8] if commit else 'n/a'})"
             )
-            continue
-
-        # 3. PASS → profile, snapshot, and record the generation-0 seed.
-        ctx.reselect_gpu()
-        summary = _run_profiler(
-            ctx,
-            generation=0,
-            child_idx=attempt,
-            modality=modality,
-            objective=objective,
-            objectives=objectives,
-            runtime_notes=cand_notes,
-        )
-        ctx.snapshot_workspace("gen-0-seed")
-        commit = ctx.git.current_sha()
-        seed = Individual(
-            id=population.next_id(),
-            generation=0,
-            parent_id=None,
-            inspiration_ids=[],
-            commit=commit,
-            perf_metric=summary.perf_metric if summary else None,
-            perf_unit=summary.perf_unit if summary else None,
-            metrics=dict(summary.metrics) if summary and summary.metrics else {},
-            passed=True,
-            summary=mutator.summary,
-            feedback=verdict.feedback,
-        )
-        population.add(seed)
-        population.save(population_path)
-        ctx.lprint(
-            f"[bootstrap {attempt}] PASSED — seed #{seed.id} "
-            f"perf={seed.perf_metric} {seed.perf_unit or ''} "
-            f"(commit {commit[:8] if commit else 'n/a'})"
-        )
-        return seed
+            return seed
+        finally:
+            _teardown_candidate_app(ctx, cand_app, keep=keep_modal_apps)
 
     ctx.lprint(f"[bootstrap] exhausted {max_attempts} attempt(s) without a passing seed.")
     return None
@@ -522,6 +545,7 @@ def run_evolve_loop(
     objectives: list[Objective] | None = None,
     frontier_bias: float = 0.7,
     bootstrap_max_attempts: int = 5,
+    keep_modal_apps: bool = False,
     remote_repo: str | None = None,
     repo_visibility: RepositoryVisibility = RepositoryVisibility.PRIVATE,
 ) -> bool:
@@ -589,6 +613,7 @@ def run_evolve_loop(
                 rng=rng,
                 population=population,
                 population_path=population_path,
+                keep_modal_apps=keep_modal_apps,
             )
             if seed_individual is None:
                 ctx.lprint(
@@ -659,98 +684,104 @@ def run_evolve_loop(
                         + f"; inspirations={[i.id for i in inspirations]}"
                     )
 
-                    # 3. Mutator edits the workspace, mutating the passing parent.
-                    ctx.reselect_gpu()
-                    mutator = _run_mutator(
-                        ctx,
-                        generation=generation,
-                        child_idx=child_idx,
-                        objective=objective,
-                        parent=parent,
-                        inspirations=inspirations,
-                        modality=modality,
-                        is_cold_start=False,
-                        objectives=objectives,
-                        runtime_notes=cand_notes,
-                    )
+                    # The candidate deploys its per-candidate Modal app during
+                    # mutate/judge/profile; stop it once evaluation is done, on
+                    # every exit path (fail continue, pass fall-through).
+                    try:
+                        # 3. Mutator edits the workspace, mutating the passing parent.
+                        ctx.reselect_gpu()
+                        mutator = _run_mutator(
+                            ctx,
+                            generation=generation,
+                            child_idx=child_idx,
+                            objective=objective,
+                            parent=parent,
+                            inspirations=inspirations,
+                            modality=modality,
+                            is_cold_start=False,
+                            objectives=objectives,
+                            runtime_notes=cand_notes,
+                        )
 
-                    # 4. Judge.
-                    ctx.reselect_gpu()
-                    verdict = _run_judge(
-                        ctx,
-                        generation=generation,
-                        child_idx=child_idx,
-                        modality=modality,
-                        objective=objective,
-                        pass_criteria=pass_criteria,
-                        runtime_notes=cand_notes,
-                    )
+                        # 4. Judge.
+                        ctx.reselect_gpu()
+                        verdict = _run_judge(
+                            ctx,
+                            generation=generation,
+                            child_idx=child_idx,
+                            modality=modality,
+                            objective=objective,
+                            pass_criteria=pass_criteria,
+                            runtime_notes=cand_notes,
+                        )
 
-                    if verdict.verdict != Verdict.PASS:
-                        # The mutation was a dead end: record the failed child so
-                        # its feedback is visible to future mutators (excluded
-                        # from selection because ``passed`` is False, no commit),
-                        # then revert the dirty tree back to the passing parent.
-                        failed = Individual(
+                        if verdict.verdict != Verdict.PASS:
+                            # The mutation was a dead end: record the failed child so
+                            # its feedback is visible to future mutators (excluded
+                            # from selection because ``passed`` is False, no commit),
+                            # then revert the dirty tree back to the passing parent.
+                            failed = Individual(
+                                id=population.next_id(),
+                                generation=generation,
+                                parent_id=parent.id,
+                                inspiration_ids=[i.id for i in inspirations],
+                                commit=None,
+                                perf_metric=None,
+                                perf_unit=None,
+                                passed=False,
+                                summary=mutator.summary,
+                                feedback=verdict.feedback,
+                            )
+                            population.add(failed)
+                            population.save(population_path)
+                            _discard_working_tree(ctx)
+                            ctx.lprint(
+                                f"[Gen {generation}] Cand {failed.id} FAILED — "
+                                f"feedback: {(verdict.feedback or '').splitlines()[0][:120]}"
+                            )
+                            continue
+
+                        # 5. Profile the offspring to get its fitness.
+                        ctx.reselect_gpu()
+                        summary = _run_profiler(
+                            ctx,
+                            generation=generation,
+                            child_idx=child_idx,
+                            modality=modality,
+                            objective=objective,
+                            objectives=objectives,
+                            runtime_notes=cand_notes,
+                        )
+
+                        # 6. Commit + record.
+                        ctx.snapshot_workspace(f"gen-{generation}-child-{child_idx}")
+                        commit = ctx.git.current_sha()
+                        child = Individual(
                             id=population.next_id(),
                             generation=generation,
                             parent_id=parent.id,
                             inspiration_ids=[i.id for i in inspirations],
-                            commit=None,
-                            perf_metric=None,
-                            perf_unit=None,
-                            passed=False,
+                            commit=commit,
+                            perf_metric=summary.perf_metric if summary else None,
+                            perf_unit=summary.perf_unit if summary else None,
+                            metrics=dict(summary.metrics) if summary and summary.metrics else {},
+                            passed=True,
                             summary=mutator.summary,
                             feedback=verdict.feedback,
                         )
-                        population.add(failed)
+                        population.add(child)
                         population.save(population_path)
-                        _discard_working_tree(ctx)
-                        ctx.lprint(
-                            f"[Gen {generation}] Cand {failed.id} FAILED — "
-                            f"feedback: {(verdict.feedback or '').splitlines()[0][:120]}"
+                        metrics_repr = (
+                            " ".join(f"{k}={v:g}" for k, v in child.metrics.items())
+                            if child.metrics
+                            else f"{child.perf_metric} {child.perf_unit or ''}"
                         )
-                        continue
-
-                    # 5. Profile the offspring to get its fitness.
-                    ctx.reselect_gpu()
-                    summary = _run_profiler(
-                        ctx,
-                        generation=generation,
-                        child_idx=child_idx,
-                        modality=modality,
-                        objective=objective,
-                        objectives=objectives,
-                        runtime_notes=cand_notes,
-                    )
-
-                    # 6. Commit + record.
-                    ctx.snapshot_workspace(f"gen-{generation}-child-{child_idx}")
-                    commit = ctx.git.current_sha()
-                    child = Individual(
-                        id=population.next_id(),
-                        generation=generation,
-                        parent_id=parent.id,
-                        inspiration_ids=[i.id for i in inspirations],
-                        commit=commit,
-                        perf_metric=summary.perf_metric if summary else None,
-                        perf_unit=summary.perf_unit if summary else None,
-                        metrics=dict(summary.metrics) if summary and summary.metrics else {},
-                        passed=True,
-                        summary=mutator.summary,
-                        feedback=verdict.feedback,
-                    )
-                    population.add(child)
-                    population.save(population_path)
-                    metrics_repr = (
-                        " ".join(f"{k}={v:g}" for k, v in child.metrics.items())
-                        if child.metrics
-                        else f"{child.perf_metric} {child.perf_unit or ''}"
-                    )
-                    ctx.lprint(
-                        f"[Gen {generation}] Cand {child.id} PASSED — "
-                        f"{metrics_repr} (parent={parent.id})"
-                    )
+                        ctx.lprint(
+                            f"[Gen {generation}] Cand {child.id} PASSED — "
+                            f"{metrics_repr} (parent={parent.id})"
+                        )
+                    finally:
+                        _teardown_candidate_app(ctx, cand_app, keep=keep_modal_apps)
 
         if objectives:
             front = population.frontier(objectives)

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -986,6 +986,15 @@ def _build_evolve_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--frontier-bias", type=float, default=0.7)
     parser.add_argument("--bootstrap-max-attempts", type=int, default=5)
+    parser.add_argument(
+        "--keep-modal-apps",
+        action="store_true",
+        help=(
+            "Do not tear down each candidate's Modal app after evaluation "
+            "(default: stop them so idle apps don't accumulate). Keep them for "
+            "post-hoc log inspection."
+        ),
+    )
     parser.add_argument("--modality", default="text_generation", choices=_MODALITIES)
     return parser
 
@@ -1054,6 +1063,7 @@ def _run_evolve(args: argparse.Namespace) -> None:
         objectives=objectives,
         frontier_bias=args.frontier_bias,
         bootstrap_max_attempts=args.bootstrap_max_attempts,
+        keep_modal_apps=args.keep_modal_apps,
         remote_repo=args.repo,
         repo_visibility=args.repo_visibility,
     )

--- a/src/vibesys/run/protocol.py
+++ b/src/vibesys/run/protocol.py
@@ -34,6 +34,7 @@ class LoopContext(Protocol):
     supervisor: Any
     agent_runner: Any
     judge_backend: Any
+    run_environment: Any
     run_environment_view: Any
     git: GitTracker
 

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -29,6 +29,7 @@ import json
 import os
 import shlex
 import subprocess
+import sys
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -130,6 +131,14 @@ class RunEnvironment(Protocol):
     def remove_workspace_child(
         self, workspace: Path, rel_path: str, *, backend: ComputeBackendImpl
     ) -> bool: ...
+    def teardown_deployment(self, name: str, *, log: Callable[[str], None]) -> None:
+        """Tear down a per-evaluation deployment (e.g. a candidate's Modal app).
+
+        Environments that dispatch each evaluation to its own named remote
+        deployment implement this to release it once the evaluation is done;
+        environments that run everything in-process are a no-op.
+        """
+        ...
 
 
 class _NoopWorkspaceRecovery:
@@ -142,6 +151,9 @@ class _NoopWorkspaceRecovery:
         self, workspace: Path, rel_path: str, *, backend: ComputeBackendImpl
     ) -> bool:
         return False
+
+    def teardown_deployment(self, name: str, *, log: Callable[[str], None]) -> None:
+        return
 
 
 @dataclass
@@ -288,6 +300,10 @@ class DockerEnvironment:
         except Exception:
             pass
         return not (target.exists() or target.is_symlink())
+
+    def teardown_deployment(self, name: str, *, log: Callable[[str], None]) -> None:
+        # The editor container is torn down by the session; nothing per-candidate.
+        return
 
 
 @dataclass(frozen=True)
@@ -460,6 +476,36 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
             local_path=local_path,
             log=request.log or print,
         )
+
+    def teardown_deployment(self, name: str, *, log: Callable[[str], None]) -> None:
+        """Stop an idle candidate app so deployed apps don't accumulate.
+
+        Each candidate deploys its GPU server to its own ``vibesys-…-g<g>c<c>``
+        Modal app; Modal scales the *containers* to zero after
+        ``scaledown_window`` (no ongoing GPU cost), but the app objects and
+        their web endpoints linger until stopped. We stop it on the host via
+        the Modal CLI — the stable public interface, authenticated by the same
+        ``~/.modal.toml`` the SDK path uses. Best-effort: a failed stop just
+        leaves an idle app behind and must never fail a run.
+        """
+        try:
+            result = subprocess.run(
+                [sys.executable, "-m", "modal", "app", "stop", name, "--yes"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except Exception as exc:  # timeout, missing binary, etc.
+            log(f"[warn] modal app stop {name} raised: {exc}")
+            return
+        if result.returncode != 0:
+            log(
+                f"[warn] modal app stop {name} failed "
+                f"(exit {result.returncode}): {result.stderr.strip()[:200]}"
+            )
+        else:
+            log(f"[modal] stopped candidate app {name}")
 
 
 def build_run_environment(spec: RunEnvironmentSpec) -> RunEnvironment:

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -20,6 +20,7 @@ from vibesys.loops.evolve.loop import (
     _candidate_runtime_notes,
     _latest_wip_seed,
     _recent_failure_lessons,
+    _teardown_candidate_app,
     run_evolve_loop,
 )
 from vibesys.loops.evolve.population import (
@@ -632,3 +633,50 @@ def test_candidate_modal_app_name_suffix_and_length():
     name = candidate_modal_app_name(long_base, 12, 7)
     assert name.endswith("-g12c7")
     assert len(name) <= 63
+
+
+# ---------------------------------------------------------------------------
+# Candidate-app teardown
+# ---------------------------------------------------------------------------
+
+
+def test_teardown_candidate_app_delegates_to_run_environment():
+    """The loop stays backend-agnostic: it hands the app name to the run
+    environment, which decides how to release it."""
+    run_env = MagicMock()
+    ctx = SimpleNamespace(run_environment=run_env, lprint=lambda _: None)
+
+    _teardown_candidate_app(ctx, "vibesys-run-g1c2", keep=False)
+
+    run_env.teardown_deployment.assert_called_once_with("vibesys-run-g1c2", log=ctx.lprint)
+
+
+def test_teardown_candidate_app_noop_when_kept_or_no_app():
+    run_env = MagicMock()
+    ctx = SimpleNamespace(run_environment=run_env, lprint=lambda _: None)
+
+    # Opt-out: keep the app for post-hoc inspection.
+    _teardown_candidate_app(ctx, "vibesys-run-g1c2", keep=True)
+    # No per-candidate deployment (non-Modal env).
+    _teardown_candidate_app(ctx, None, keep=False)
+
+    run_env.teardown_deployment.assert_not_called()
+
+
+def test_loop_tears_down_candidate_on_pass_and_fail_paths(tmp_path, ref_file):
+    """Teardown fires exactly once per candidate on every exit path — the
+    bootstrap attempt plus each generation candidate, whether it passes or
+    fails the judge."""
+    # bootstrap passes (1 attempt), gen-1 candidate passes, gen-2 candidate fails.
+    runner = _make_runner(judge_verdicts=["pass", "pass", "fail"])
+    with patch("vibesys.loops.evolve.loop._teardown_candidate_app") as teardown:
+        _invoke_loop(
+            tmp_path,
+            ref_file,
+            runner,
+            max_generations=2,
+            children_per_generation=1,
+        )
+
+    # 1 bootstrap attempt + 2 generation candidates = 3 teardown calls.
+    assert teardown.call_count == 3

--- a/tests/sandbox/test_run_environment.py
+++ b/tests/sandbox/test_run_environment.py
@@ -314,3 +314,68 @@ def test_docker_remove_workspace_child_quotes_path(tmp_path, monkeypatch):
     shell_command = calls[0][-1]
     assert "rm -rf -- " in shell_command
     assert "'/workspace/semi;touch hacked'" in shell_command
+
+
+def test_modal_teardown_deployment_stops_app_via_cli(monkeypatch):
+    import sys as _sys
+
+    env = build_run_environment(RunEnvironmentSpec("modal"))
+    calls = []
+    logs = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr("vibesys.sandbox.run_environment.subprocess.run", fake_run)
+
+    env.teardown_deployment("vibesys-run-g1c2", log=logs.append)
+
+    assert calls == [[_sys.executable, "-m", "modal", "app", "stop", "vibesys-run-g1c2", "--yes"]]
+    assert any("stopped candidate app vibesys-run-g1c2" in line for line in logs)
+
+
+def test_modal_teardown_deployment_is_best_effort_on_nonzero(monkeypatch):
+    env = build_run_environment(RunEnvironmentSpec("modal"))
+    logs = []
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 1
+        result.stderr = "boom"
+        return result
+
+    monkeypatch.setattr("vibesys.sandbox.run_environment.subprocess.run", fake_run)
+
+    # Must not raise.
+    env.teardown_deployment("vibesys-run-g1c2", log=logs.append)
+    assert any("failed" in line for line in logs)
+
+
+def test_modal_teardown_deployment_is_best_effort_on_exception(monkeypatch):
+    env = build_run_environment(RunEnvironmentSpec("modal"))
+    logs = []
+
+    def fake_run(cmd, **kwargs):
+        raise TimeoutError("stuck")
+
+    monkeypatch.setattr("vibesys.sandbox.run_environment.subprocess.run", fake_run)
+
+    env.teardown_deployment("vibesys-run-g1c2", log=logs.append)
+    assert any("raised" in line for line in logs)
+
+
+@pytest.mark.parametrize("name", ["local", "docker"])
+def test_non_modal_teardown_deployment_is_noop(name, monkeypatch):
+    env = build_run_environment(RunEnvironmentSpec(name))
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("subprocess.run should not be called for non-Modal envs")
+
+    monkeypatch.setattr("vibesys.sandbox.run_environment.subprocess.run", fail_run)
+
+    # No deployment to stop — must be a silent no-op.
+    env.teardown_deployment("vibesys-run-g1c2", log=lambda _: None)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -258,6 +258,17 @@ def test_validate_evolve_rejects_nonpositive_bootstrap_attempts(tmp_path):
         cli._validate_evolve(args)
 
 
+def test_keep_modal_apps_flag_defaults_off_and_parses(tmp_path):
+    """--keep-modal-apps opts out of candidate-app teardown; off by default."""
+    import vibesys.main as cli
+
+    bundle = _write_input_bundle(tmp_path)
+    parser = cli._build_evolve_parser()
+
+    assert parser.parse_args(["--input", str(bundle)]).keep_modal_apps is False
+    assert parser.parse_args(["--keep-modal-apps", "--input", str(bundle)]).keep_modal_apps is True
+
+
 @pytest.mark.parametrize(
     "argv",
     [


### PR DESCRIPTION
## Problem

Every evolve candidate — and every bootstrap attempt — deploys its GPU server
to its **own** uniquely-named Modal app (`candidate_modal_app_name` appends
`-g<gen>c<child>`) so the judge never reads a prior candidate's cumulative app
logs. The cost: **nothing ever stopped these apps.** Modal scales the
*containers* to zero after `scaledown_window=120` (so there's no ongoing GPU
cost), but the **app objects and their web endpoints accumulate** — one per
candidate/attempt — over a run, cluttering `modal app list` and eventually
approaching per-workspace app-count limits.

## Solution

Release each candidate's deployment once the framework is done evaluating it
(judge + profiler have read whatever app logs they needed), on **every** exit
path. `--keep-modal-apps` opts out when apps are wanted for post-hoc log
inspection.

The teardown is intentionally **not** tied to the container backend. It's a
polymorphic method on the `RunEnvironment` protocol:

- `ModalEnvironment.teardown_deployment` stops the app on the host via the
  `modal` CLI — the stable public interface (the SDK's `modal app stop` needs
  private async internals), authenticated by the same `~/.modal.toml` the
  existing `vs_sandbox.ensure_model_volume` SDK path uses. Best-effort: a
  timeout / non-zero exit / missing binary is logged and swallowed, never
  fatal.
- `LocalEnvironment` / `DockerEnvironment` are a no-op — they have no
  per-candidate remote deployment.

The evolve loop only decides *when* to release (and honors `--keep-modal-apps`);
it calls `ctx.run_environment.teardown_deployment(cand_app, log=…)` and knows
nothing about Modal, `subprocess`, or the CLI.

Parallelism is **not** in this PR (deferred per prior discussion).

### Architecture

Ownership: the run environment owns *how* a deployment is released; the loop
owns *when*.

```
evolve loop  ──_teardown_candidate_app(ctx, cand_app, keep)──▶ ctx.run_environment
                                                                    │
                          ┌─────────────────────────────────────────┼───────────────────────┐
                   ModalEnvironment                          LocalEnvironment         DockerEnvironment
             teardown_deployment(name):                     teardown_deployment:     teardown_deployment:
             `python -m modal app stop <name> --yes`              no-op                    no-op
             (best-effort, host CLI)
```

Wired at both candidate call sites with `try/finally` so teardown fires exactly
once per candidate on every exit — fail `continue`, pass fall-through, and the
bootstrap pass `return`.

## Verification

### Correctness properties

- **Fires once per candidate on every exit path** — `try/finally` wraps the
  mutate→judge→(fail `continue`)→profile→record block in both the bootstrap
  attempt loop and the generation loop.
- **Best-effort, never fatal** — Modal teardown swallows timeout / non-zero /
  missing-binary and logs a warning; a stuck stop cannot fail a run.
- **Backend-agnostic loop** — the loop calls a `RunEnvironment` method; only
  `ModalEnvironment` knows about the `modal` CLI. Non-Modal envs no-op, and the
  loop still no-ops when `cand_app is None`.
- **Opt-out preserved** — `--keep-modal-apps` (default off) skips teardown.

### Testing

- `uv run ruff check` + `ruff format --check` — clean.
- `uv run pyright src/vibesys/{loops/evolve/loop,sandbox/run_environment,main,run/protocol}.py` — 0 errors.
- `uv run python -m pytest tests/sandbox/test_run_environment.py tests/loops/evolve/test_evolutionary_loop.py tests/test_main.py -q` — **113 passed**.
- `diff-cover` vs `origin/main` — **97%** patch coverage (the 2 uncovered lines are a pre-existing wip-seed `except` only re-indented by the try/finally wrap).

New tests: Modal `teardown_deployment` issues the CLI stop and is best-effort on
non-zero / exception; local & docker envs no-op; the loop delegates to the run
environment (and no-ops on `keep` / `None`); teardown fires once per candidate
across pass and fail paths; `--keep-modal-apps` parses and defaults off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
