### PR TITLE
Push experiment state at workspace checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,10 @@ gh auth login
 
 For non-interactive use, `--repo queue-trial` uses the configured owner, while
 `--repo another-org/queue-trial` overrides it explicitly. Durable workspace and
-run state are committed and pushed when the run closes; raw `logs/*.log` files
-stay local. Later runs automatically push again when resumed from a clone with
-an `origin`.
+run state are committed and pushed after each workspace checkpoint and again
+when the run closes; raw `logs/*.log` files stay local. Checkpoint push failures
+are retried without stopping the run. Later runs automatically push again when
+resumed from a clone with an `origin`.
 
 ## Repository layout
 

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -62,9 +62,12 @@ through the authenticated `gh` CLI.
 
 The experiment repository records the materialized workspace and durable state
 needed to continue the loop. Provider/agent `logs/*.log` files and directory
-snapshots are excluded. VibeSys commits and pushes on context shutdown, including
-normal loop failures and keyboard interruption. A non-fast-forward or
-authentication failure is reported rather than force-pushing.
+snapshots are excluded. VibeSys commits and pushes after each workspace
+checkpoint, then performs a final sync on context shutdown, including normal
+loop failures and keyboard interruption. A failed checkpoint push is logged and
+retried at the next checkpoint so a transient remote failure does not stop the
+optimization run. A final non-fast-forward or authentication failure is reported
+rather than force-pushing.
 
 `--resume` accepts all existing run forms plus local experiment directories,
 GitHub `OWNER/NAME` pairs, and cloneable HTTPS/SSH URLs:

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -625,6 +625,9 @@ def create_candidate_context(
         environment_patch=parent.environment_patch,
         workspace_files=workspace_files,
         git=git,
+        # Candidate worktrees share the parent repository and may run in
+        # parallel. Only the parent context owns remote synchronization.
+        experiment_repository=None,
         teardown_stack=teardown_stack,
         run_environment_session=session,
         commands=commands,

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -227,7 +227,9 @@ def create_run_context(
                     message=f"Could not create experiment repository {remote_repo!r}: {exc}",
                 )
             ) from exc
+    tracked_experiment_repository: ExperimentRepository | None = None
     if experiment_repository.has_origin():
+        tracked_experiment_repository = experiment_repository
 
         def _sync_experiment_repository() -> None:
             try:
@@ -467,6 +469,7 @@ def create_run_context(
         environment_patch=environment_patch,
         workspace_files=workspace_files,
         git=git,
+        experiment_repository=tracked_experiment_repository,
         teardown_stack=teardown_stack,
         run_environment_session=session,
         commands=commands,
@@ -519,6 +522,7 @@ class _RunContext:
         environment_patch: EnvironmentPatch,
         workspace_files: Workspace,
         git: GitTracker,
+        experiment_repository: ExperimentRepository | None,
         teardown_stack: ExitStack,
         run_environment_session: RunEnvironmentSession,
         commands: RunCommands,
@@ -552,6 +556,7 @@ class _RunContext:
         self.workspace_files = workspace_files
         self.EXCLUDED_WORKSPACE_DIRS = workspace_files.excluded_dirs
         self.git = git
+        self._experiment_repository = experiment_repository
         self._teardown_stack = teardown_stack
         self.run_environment_session = run_environment_session
         self.run_environment_view = run_environment_session.view
@@ -785,18 +790,30 @@ class _RunContext:
 
         if self.git_tracking:
             self.git.snapshot(label)
-            return
-        dst = self.log_dir / "snapshots" / label
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        if dst.exists():
-            shutil.rmtree(dst)
-        shutil.copytree(
-            self.workspace,
-            dst,
-            symlinks=True,
-            ignore=lambda _, names: [n for n in names if n in self.EXCLUDED_WORKSPACE_DIRS],
-        )
-        self.workspace_files.replace_external_symlinks(dst)
+        else:
+            dst = self.log_dir / "snapshots" / label
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if dst.exists():
+                shutil.rmtree(dst)
+            shutil.copytree(
+                self.workspace,
+                dst,
+                symlinks=True,
+                ignore=lambda _, names: [n for n in names if n in self.EXCLUDED_WORKSPACE_DIRS],
+            )
+            self.workspace_files.replace_external_symlinks(dst)
+
+        # Remote experiment repositories are durability boundaries, not just
+        # publication targets. Push after each existing loop checkpoint so a
+        # long-running agent does not keep all completed phases only on the
+        # host until context shutdown. A transient remote failure must not
+        # discard subsequent optimization work; the next checkpoint and the
+        # final strict teardown sync will retry every local commit.
+        if self._experiment_repository is not None:
+            try:
+                self._experiment_repository.sync()
+            except Exception as exc:
+                self.lprint(f"[warn] experiment repository checkpoint push failed: {exc}")
 
     def trusted_input_changes(self) -> list[str]:
         """Return evaluator-owned paths changed since workspace initialization."""

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -308,8 +308,9 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         metavar="[OWNER/]NAME",
         help=(
             "Create a GitHub repository for this experiment, commit its durable "
-            "state, and push after each run. A configured [repository].owner supplies "
-            "an omitted owner. Requires an authenticated `gh` CLI."
+            "state, and push after each workspace checkpoint and at shutdown. "
+            "A configured [repository].owner supplies an omitted owner. Requires "
+            "an authenticated `gh` CLI."
         ),
     )
     parser.add_argument(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -140,6 +140,23 @@ def test_workspace_snapshot_pushes_remote_experiment_checkpoint(tmp_path):
     ctx._experiment_repository.sync.assert_called_once_with()
 
 
+def test_directory_snapshot_pushes_remote_experiment_checkpoint(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "main.py").write_text("VALUE = 1\n")
+    ctx = _minimal_copy_context(workspace)
+    ctx.git_tracking = False
+    ctx.workspace_files = MagicMock()
+    ctx._experiment_repository = MagicMock()
+
+    ctx.snapshot_workspace("round-1-implementer")
+
+    snapshot = ctx.log_dir / "snapshots" / "round-1-implementer"
+    assert (snapshot / "main.py").read_text() == "VALUE = 1\n"
+    ctx.workspace_files.replace_external_symlinks.assert_called_once_with(snapshot)
+    ctx._experiment_repository.sync.assert_called_once_with()
+
+
 def test_workspace_snapshot_retries_remote_failure_without_stopping_run(tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -28,6 +28,8 @@ def _minimal_copy_context(workspace):
     ctx.backend_impl = MagicMock()
     ctx.lprint = MagicMock()
     ctx.git = GitTracker(workspace, log=ctx.lprint, excluded_dirs=ctx.EXCLUDED_WORKSPACE_DIRS)
+    ctx.implementer_backend = SimpleNamespace()
+    ctx._experiment_repository = None
     return ctx
 
 
@@ -122,6 +124,37 @@ def test_trusted_input_changes_compare_against_initial_commit(tmp_path):
 
     (workspace / "accuracy_checker" / "checker.py").write_text("print('forged')\n")
     assert ctx.trusted_input_changes() == ["accuracy_checker/checker.py"]
+
+
+def test_workspace_snapshot_pushes_remote_experiment_checkpoint(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "main.py").write_text("VALUE = 1\n")
+    ctx = _minimal_copy_context(workspace)
+    ctx.git.init(existing=False)
+    ctx._experiment_repository = MagicMock()
+
+    (workspace / "main.py").write_text("VALUE = 2\n")
+    ctx.snapshot_workspace("round-1-implementer")
+
+    ctx._experiment_repository.sync.assert_called_once_with()
+
+
+def test_workspace_snapshot_retries_remote_failure_without_stopping_run(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "main.py").write_text("VALUE = 1\n")
+    ctx = _minimal_copy_context(workspace)
+    ctx.git.init(existing=False)
+    ctx._experiment_repository = MagicMock()
+    ctx._experiment_repository.sync.side_effect = RuntimeError("network unavailable")
+
+    ctx.snapshot_workspace("round-1-implementer")
+
+    ctx._experiment_repository.sync.assert_called_once_with()
+    ctx.lprint.assert_called_with(
+        "[warn] experiment repository checkpoint push failed: network unavailable"
+    )
 
 
 class _FakeBackend:

--- a/tests/test_experiment_repo.py
+++ b/tests/test_experiment_repo.py
@@ -42,6 +42,20 @@ def test_sync_commits_durable_state_and_pushes_to_origin(tmp_path):
     assert messages == ["[repo] pushed experiment state to origin"]
 
 
+def test_sync_without_origin_is_a_noop(tmp_path):
+    experiment = tmp_path / "experiment"
+    experiment.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)
+    (experiment / "workspace").mkdir()
+    (experiment / "workspace" / "main.py").write_text("VALUE = 1\n")
+
+    messages: list[str] = []
+    ExperimentRepository(experiment, messages.append).sync()
+
+    assert _git(experiment, "status", "--short") == "?? workspace/"
+    assert messages == []
+
+
 def test_create_remote_uses_configurable_slug_and_visibility(tmp_path, monkeypatch):
     experiment = tmp_path / "experiment"
     experiment.mkdir()


### PR DESCRIPTION
## Problem

GitHub-backed experiments only synchronized durable workspace state when the run context shut down. Long-running optimization runs could therefore complete multiple agent phases while their latest recoverable state existed only on the local host. A process or host failure before shutdown could lose that progress even when VibeSys created and attached a GitHub repository for the experiment.

Local-only Git repositories must remain valid and must not be required to configure a remote.

## Solution

Synchronize remote experiment repositories after every existing workspace checkpoint, while retaining the final strict shutdown sync. Checkpoint push failures are logged and treated as retryable so transient network or GitHub failures do not terminate the optimization loop; the next checkpoint retries all local commits. The final shutdown sync continues to surface persistent authentication, divergence, or connectivity failures.

Repositories without an `origin` skip synchronization entirely. CLI help and remote-repository documentation now describe the checkpoint and shutdown behavior.

### Architecture

`_RunContext` owns checkpoint timing and receives an `ExperimentRepository` only when setup detects an `origin`. `snapshot_workspace` first completes the existing local Git or directory snapshot, then invokes remote synchronization. `ExperimentRepository.sync` retains its own no-origin guard as a defensive boundary.

```mermaid
flowchart LR
    A[Workspace checkpoint] --> B[Create local snapshot]
    B --> C{Origin configured?}
    C -->|No| D[Continue run]
    C -->|Yes| E[Commit durable experiment state]
    E --> F[Push current branch]
    F -->|Success| D
    F -->|Checkpoint failure| G[Log warning and retry later]
    G --> D
    H[Context shutdown] --> I[Final strict sync]
```

## Verification

The focused context and experiment-repository tests cover successful checkpoint pushes, transient checkpoint push failures, and local repositories without an origin. The complete repository suite and static checks pass.

### Correctness properties

- A completed workspace checkpoint in a remotely tracked experiment attempts to commit and push durable state.
- A transient checkpoint push failure does not stop subsequent agent work and can be retried by later checkpoints.
- Context shutdown still performs a strict final synchronization and reports persistent failures.
- Git repositories without an `origin` perform no commit or push as part of remote synchronization and do not fail.
- Remote divergence is never resolved with a force push.
- Raw provider logs and directory snapshot artifacts remain excluded from remote history.

### Testing

- `uv run pytest -q tests/test_context.py tests/test_experiment_repo.py` — 26 passed.
- `./scripts/check_format.sh` — passed; 253 files already formatted.
- `./scripts/check_lint.sh` — passed.
- `./scripts/check_types.sh` — passed with 0 errors, 0 warnings, and 0 informational diagnostics.
- `uv run pytest -q` — 1,926 passed, 1 skipped; the skip requires macOS `sandbox-exec`.