### PR TITLE
Bounded parallel candidate evaluation in the evolve loop

### DIFF
--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -475,6 +475,161 @@ def create_run_context(
     )
 
 
+def create_candidate_context(
+    parent: "_RunContext",
+    *,
+    config: Config,
+    generation: int,
+    child_idx: int,
+    parent_commit: str,
+    agent_backend: str | None = None,
+    cli_provider: str | None = None,
+) -> "_RunContext":
+    """Build an isolated sub-context for evaluating one candidate concurrently.
+
+    The sub-context shares the parent run's identity, model, compute backend,
+    run-environment policy, and — crucially — the parent workspace's **git
+    object store**, so a candidate's commit lands in the one evolutionary
+    lineage. Everything that would collide under concurrency is its own:
+
+    - a **git worktree** checked out at ``parent_commit`` (isolated working
+      tree / index / detached HEAD; edits never touch the shared tree);
+    - a fresh **run-environment session** (its own Modal editor container);
+    - its own **agent runner** (the CLI runner is not thread-safe);
+    - a **no-tee ``RunLogger``** writing only to the candidate's log file — only
+      the top-level run logger may own the process ``sys.stderr``.
+
+    Only Modal mode is supported for parallel evaluation (host GPU reselection
+    is a no-op there); the caller is responsible for that gating. Close the
+    returned context (or use it as a context manager) to stop the container and
+    remove the worktree.
+    """
+    config = as_config(config)
+    cand_root = parent.exp_dir / "candidates" / f"{parent.exp_dir.name}-g{generation}c{child_idx}"
+    workspace = cand_root / "workspace"
+    log_dir = cand_root / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # Materialize the parent's tree in an isolated worktree (shared object
+    # store). `git worktree add` touches the main repo's admin area, so the
+    # caller serializes this; the container/agent work afterward is isolated.
+    parent.git.add_worktree(workspace, parent_commit)
+
+    logger = RunLogger(log_dir, tee_stderr=False)
+    teardown_stack = ExitStack()
+    teardown_stack.callback(logger.close)
+    # Remove the worktree *after* the session's container is stopped: register
+    # the removal before entering the session so it unwinds afterward (LIFO).
+    teardown_stack.callback(lambda: parent.git.remove_worktree(workspace))
+
+    resolved_backend = agent_backend or config.agent.backend or DEFAULT_AGENT_BACKEND
+    resolved_cli_provider = cli_provider or config.agent.cli_provider or "codex"
+
+    git = GitTracker(
+        workspace,
+        log=logger.lprint,
+        excluded_dirs=parent.EXCLUDED_WORKSPACE_DIRS,
+    )
+    workspace_files = Workspace(
+        workspace,
+        run_environment=parent.run_environment,
+        backend=parent.backend_impl,
+        log=logger.lprint,
+        project_root=PROJECT_ROOT,
+    )
+
+    # Reuse the parent's already-provisioned Modal model volume: the shared
+    # run_environment has `model_volume` set from the parent's open(), so this
+    # open() skips re-upload and ref_dir is unneeded.
+    session = teardown_stack.enter_context(
+        parent.run_environment.open(
+            RunEnvironmentRequest(
+                log_dir=log_dir,
+                workspace=workspace,
+                ref_dir=None,
+                backend=parent.backend_impl,
+                agent_backend=resolved_backend,
+                cli_provider=resolved_cli_provider,
+                accuracy_command=parent.accuracy_command,
+                benchmark_command=parent.benchmark_command,
+                profiler_support_path=parent.profiler_support_path,
+                profiler_support_name=parent.profiler_support_name,
+                environment_bind_mounts=parent.environment_patch.bind_mounts,
+                log=logger.lprint,
+                project_root=PROJECT_ROOT,
+            )
+        )
+    )
+    commands = RunCommands(
+        judge_accuracy_command=session.view.paths.accuracy_command,
+        judge_benchmark_command=session.view.paths.benchmark_command,
+        profiler_support_agent_path=session.view.paths.profiler_support,
+        profiler_benchmark_command=session.view.paths.benchmark_command,
+    )
+
+    agent_runner = build_agent_runner(
+        config,
+        agent_backend=agent_backend,
+        cli_provider=cli_provider,
+        backends={
+            "implementer": session.sandbox,
+            "judge": session.sandbox,
+            "chat": session.sandbox,
+            "perf_eval": session.sandbox,
+            "profiler": session.sandbox,
+            "orchestrator": session.sandbox,
+        },
+        skills=[src.name for src in parent.skill_source_paths],
+        skill_source_dirs=parent.skill_source_paths,
+        model=parent.model,
+        model_name=parent.model_name,
+        run_log_file=logger.file,
+        use_docker=(session.view.cli_sandboxed and not session.view.cli_modal_sandboxed),
+        use_modal=session.view.cli_modal_sandboxed,
+        log_dir=log_dir,
+    )
+
+    paths = RunPaths(
+        exp_dir=parent.exp_dir,
+        log_dir=log_dir,
+        workspace=workspace,
+        run_log_path=logger.path,
+    )
+
+    return _RunContext(
+        backend=parent.backend,
+        run_environment=parent.run_environment,
+        supervisor=None,  # candidates never own the TUI/chat handler
+        logger=logger,
+        paths=paths,
+        debug=parent.debug,
+        git_tracking=True,
+        backend_impl=parent.backend_impl,
+        model=parent.model,
+        model_name=parent.model_name,
+        input_path=parent.input_path,
+        workspace_seed_path=None,
+        evaluator_path=parent.evaluator_path,
+        accuracy_command=parent.accuracy_command,
+        benchmark_command=parent.benchmark_command,
+        profiler_kind=parent.profiler_kind,
+        profiler_support_path=parent.profiler_support_path,
+        profiler_support_name=parent.profiler_support_name,
+        skill_source_paths=parent.skill_source_paths,
+        ref_name=parent.ref_name,
+        environment_hooks=parent.environment_hooks,
+        environment_context=parent.environment_context,
+        environment_patch=parent.environment_patch,
+        workspace_files=workspace_files,
+        git=git,
+        teardown_stack=teardown_stack,
+        run_environment_session=session,
+        commands=commands,
+        device=parent.device,  # shared; Modal reselect is a no-op
+        agent_runner=agent_runner,
+    )
+
+
 class _RunContext:
     """Experiment lifecycle owner shared by simple, orchestrate, and issue loops.
 
@@ -593,6 +748,11 @@ class _RunContext:
     def run_log_file(self) -> TextIO:
         """The current open log file handle (owned by ``RunLogger``)."""
         return self.logger.file
+
+    @property
+    def skill_source_paths(self) -> list[Path]:
+        """Skill source directories copied into the workspace for agents."""
+        return self._skill_source_paths
 
     @property
     def gpu_monitor(self) -> "ContentionMonitor | None":

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -30,14 +30,18 @@ left to the user.
 from __future__ import annotations
 
 import random
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, cast
 
 from jinja2 import Environment, FileSystemLoader
 
 from vibesys.agents.progress import CandidateProgress
 from vibesys.config import Config
 from vibesys.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
-from vibesys.context import create_run_context
+from vibesys.context import create_candidate_context, create_run_context
 from vibesys.domains.llm_serving.hooks import LLMServingEnvironmentHooks
 from vibesys.loops.evolve.population import (
     Individual,
@@ -339,6 +343,473 @@ def _run_profiler(
     )
 
 
+@dataclass
+class _CandidateOutcome:
+    """Result of evaluating one candidate against its parent.
+
+    Deliberately carries no ``Population`` state: evaluation runs on a
+    per-candidate context (its own workspace/container in parallel mode), while
+    id assignment and ``Population`` mutation happen serially in the
+    orchestrator via :func:`_record_outcome`. This split is what makes
+    candidate evaluation safe to run concurrently.
+    """
+
+    passed: bool
+    parent_id: int | None
+    inspiration_ids: list[int]
+    summary: str
+    feedback: str | None
+    commit: str | None = None
+    perf_metric: float | None = None
+    perf_unit: str | None = None
+    metrics: dict[str, float] = field(default_factory=dict)
+
+
+def _evaluate_candidate(
+    ctx: LoopContext,
+    *,
+    generation: int,
+    child_idx: int,
+    parent: Individual,
+    inspirations: list[Individual],
+    objective: str,
+    objectives: list[Objective] | None,
+    modality: str,
+    pass_criteria: str,
+    keep_modal_apps: bool,
+    isolated_app: bool = False,
+) -> _CandidateOutcome:
+    """Mutate → judge → (profile → commit) one candidate on ``ctx``.
+
+    Assumes ``ctx``'s workspace is already materialized at the parent commit
+    (serial: the caller checked the shared tree out; parallel: the candidate's
+    worktree was created at the parent sha). Touches only ``ctx`` — never the
+    shared ``Population`` — so distinct contexts can run this concurrently. The
+    per-candidate Modal app is always stopped on the way out.
+
+    ``isolated_app`` selects how the candidate's Modal app is named. In serial
+    mode all candidates share one context/app, so we derive a per-candidate app
+    name by suffixing (``_candidate_runtime_notes``). In parallel mode each
+    candidate already has its own sub-context whose session opened a distinct
+    app, so we use that app/notes directly with no further suffixing.
+    """
+    if isolated_app:
+        cand_notes = ctx.run_environment_view.prompt_notes
+        cand_app = getattr(ctx.run_environment_view, "modal_app_name", None)
+    else:
+        # In Modal mode this gives the mutator/judge/profiler a candidate-unique
+        # app name so the judge never reads a prior candidate's stale app logs.
+        cand_notes, cand_app = _candidate_runtime_notes(ctx, generation, child_idx)
+    ctx.lprint(
+        f"parent=#{parent.id} (perf={parent.perf_metric})"
+        + (f" modal-app={cand_app}" if cand_app else "")
+        + f"; inspirations={[i.id for i in inspirations]}"
+    )
+
+    inspiration_ids = [i.id for i in inspirations]
+    try:
+        # 1. Mutator edits the workspace, mutating the passing parent.
+        ctx.reselect_gpu()
+        mutator = _run_mutator(
+            ctx,
+            generation=generation,
+            child_idx=child_idx,
+            objective=objective,
+            parent=parent,
+            inspirations=inspirations,
+            modality=modality,
+            is_cold_start=False,
+            objectives=objectives,
+            runtime_notes=cand_notes,
+        )
+
+        # 2. Judge.
+        ctx.reselect_gpu()
+        verdict = _run_judge(
+            ctx,
+            generation=generation,
+            child_idx=child_idx,
+            modality=modality,
+            objective=objective,
+            pass_criteria=pass_criteria,
+            runtime_notes=cand_notes,
+        )
+
+        if verdict.verdict != Verdict.PASS:
+            return _CandidateOutcome(
+                passed=False,
+                parent_id=parent.id,
+                inspiration_ids=inspiration_ids,
+                summary=mutator.summary,
+                feedback=verdict.feedback,
+            )
+
+        # 3. Profile the offspring to get its fitness.
+        ctx.reselect_gpu()
+        summary = _run_profiler(
+            ctx,
+            generation=generation,
+            child_idx=child_idx,
+            modality=modality,
+            objective=objective,
+            objectives=objectives,
+            runtime_notes=cand_notes,
+        )
+
+        # 4. Commit the offspring's tree so it can serve as a future parent.
+        ctx.snapshot_workspace(f"gen-{generation}-child-{child_idx}")
+        return _CandidateOutcome(
+            passed=True,
+            parent_id=parent.id,
+            inspiration_ids=inspiration_ids,
+            summary=mutator.summary,
+            feedback=verdict.feedback,
+            commit=ctx.git.current_sha(),
+            perf_metric=summary.perf_metric if summary else None,
+            perf_unit=summary.perf_unit if summary else None,
+            metrics=dict(summary.metrics) if summary and summary.metrics else {},
+        )
+    finally:
+        _teardown_candidate_app(ctx, cand_app, keep=keep_modal_apps)
+
+
+def _record_outcome(
+    ctx: LoopContext,
+    population: Population,
+    population_path: Path,
+    outcome: _CandidateOutcome,
+    *,
+    generation: int,
+) -> Individual:
+    """Assign an id, add the individual to the population, and persist it.
+
+    Serialized by construction — the orchestrator calls this from a single
+    thread after each candidate's evaluation returns, so ``next_id`` and
+    ``Population`` mutation never race even when evaluation ran in parallel.
+    """
+    individual = Individual(
+        id=population.next_id(),
+        generation=generation,
+        parent_id=outcome.parent_id,
+        inspiration_ids=outcome.inspiration_ids,
+        commit=outcome.commit,
+        perf_metric=outcome.perf_metric,
+        perf_unit=outcome.perf_unit,
+        metrics=dict(outcome.metrics),
+        passed=outcome.passed,
+        summary=outcome.summary,
+        feedback=outcome.feedback or "",
+    )
+    population.add(individual)
+    population.save(population_path)
+    if outcome.passed:
+        metrics_repr = (
+            " ".join(f"{k}={v:g}" for k, v in individual.metrics.items())
+            if individual.metrics
+            else f"{individual.perf_metric} {individual.perf_unit or ''}"
+        )
+        ctx.lprint(
+            f"[Gen {generation}] Cand {individual.id} PASSED — "
+            f"{metrics_repr} (parent={outcome.parent_id})"
+        )
+    else:
+        ctx.lprint(
+            f"[Gen {generation}] Cand {individual.id} FAILED — "
+            f"feedback: {(outcome.feedback or '').splitlines()[0][:120] if outcome.feedback else ''}"
+        )
+    return individual
+
+
+def _plan_candidate(
+    ctx: LoopContext,
+    population: Population,
+    rng: random.Random,
+    *,
+    k_top_inspirations: int,
+    k_random_inspirations: int,
+    selection_temperature: float,
+    objectives: list[Objective] | None,
+    frontier_bias: float,
+) -> tuple[Individual, list[Individual]] | None:
+    """Select a (parent, inspirations) pair from the current population.
+
+    Reads ``population`` and advances ``rng`` — must be called from a single
+    thread (the orchestrator), never inside a worker. Returns ``None`` when no
+    passing parent exists yet (the candidate is skipped). Bootstrap guarantees
+    a passing gen-0 seed, so a passer normally always exists; ``select_parent``
+    only returns ``None`` when no passer has a scalar ``perf_metric`` (e.g.
+    profiler disabled), in which case we fall back to the latest passer so the
+    loop never cold-starts.
+    """
+    parent = population.select_parent(
+        rng=rng,
+        temperature=selection_temperature,
+        objectives=objectives,
+        frontier_bias=frontier_bias,
+    )
+    inspirations = population.select_inspirations(
+        parent_id=parent.id if parent else None,
+        k_top=k_top_inspirations,
+        k_random=k_random_inspirations,
+        rng=rng,
+        objectives=objectives,
+    )
+    if parent is None:
+        passers = population.passed
+        if not passers:
+            ctx.lprint("[warn] no passing parent available; skipping candidate")
+            return None
+        parent = passers[-1]
+    return parent, inspirations
+
+
+def _run_generation_serial(
+    ctx: LoopContext,
+    *,
+    generation: int,
+    max_generations: int,
+    children_per_generation: int,
+    population: Population,
+    population_path: Path,
+    rng: random.Random,
+    k_top_inspirations: int,
+    k_random_inspirations: int,
+    selection_temperature: float,
+    objective: str,
+    objectives: list[Objective] | None,
+    frontier_bias: float,
+    modality: str,
+    pass_criteria: str,
+    keep_modal_apps: bool,
+) -> None:
+    """Evaluate a generation's candidates one at a time on the shared context."""
+    for child_idx in range(1, children_per_generation + 1):
+        candidate_progress = CandidateProgress(
+            generation, max_generations, child_idx, children_per_generation
+        )
+        with ctx.progress(candidate_progress):
+            ctx.lprint(f"\n--- {candidate_progress.label()} ---\n")
+            plan = _plan_candidate(
+                ctx,
+                population,
+                rng,
+                k_top_inspirations=k_top_inspirations,
+                k_random_inspirations=k_random_inspirations,
+                selection_temperature=selection_temperature,
+                objectives=objectives,
+                frontier_bias=frontier_bias,
+            )
+            if plan is None:
+                continue
+            parent, inspirations = plan
+            if parent.commit and not ctx.git.checkout_tree(parent.commit, clean=True):
+                ctx.lprint(
+                    f"[warn] could not check out parent {parent.id} "
+                    f"(commit {parent.commit[:8]}); skipping cand"
+                )
+                continue
+
+            outcome = _evaluate_candidate(
+                ctx,
+                generation=generation,
+                child_idx=child_idx,
+                parent=parent,
+                inspirations=inspirations,
+                objective=objective,
+                objectives=objectives,
+                modality=modality,
+                pass_criteria=pass_criteria,
+                keep_modal_apps=keep_modal_apps,
+            )
+            _record_outcome(ctx, population, population_path, outcome, generation=generation)
+            if not outcome.passed:
+                # Dead-end mutation: revert the dirty tree back to the passing
+                # parent for the next candidate.
+                _discard_working_tree(ctx)
+
+
+def _evaluate_in_subcontext(
+    parent_ctx: LoopContext,
+    *,
+    config: Config,
+    agent_backend: str | None,
+    cli_provider: str | None,
+    generation: int,
+    child_idx: int,
+    parent: Individual,
+    inspirations: list[Individual],
+    objective: str,
+    objectives: list[Objective] | None,
+    modality: str,
+    pass_criteria: str,
+    keep_modal_apps: bool,
+    worktree_lock: threading.Lock,
+) -> _CandidateOutcome:
+    """Run one candidate in its own isolated sub-context (worker thread).
+
+    Never raises: setup/evaluation/teardown failures are logged and folded into
+    a failed ``_CandidateOutcome`` so one bad candidate can't sink the pool. The
+    ``worktree_lock`` serializes ``git worktree add`` (which mutates the shared
+    repo's admin area); everything after — the container, agent calls, and the
+    candidate's own commit — is fully isolated per worktree.
+    """
+    inspiration_ids = [i.id for i in inspirations]
+    label = f"g{generation}c{child_idx}"
+    commit = parent.commit
+    if commit is None:
+        parent_ctx.lprint(f"[warn] candidate {label} has no parent commit; skipping")
+        return _CandidateOutcome(
+            passed=False,
+            parent_id=parent.id,
+            inspiration_ids=inspiration_ids,
+            summary="candidate has no parent commit",
+            feedback="parent individual has no commit to branch from",
+        )
+    try:
+        with worktree_lock:
+            subctx = create_candidate_context(
+                cast(Any, parent_ctx),
+                config=config,
+                generation=generation,
+                child_idx=child_idx,
+                parent_commit=commit,
+                agent_backend=agent_backend,
+                cli_provider=cli_provider,
+            )
+    except Exception as exc:
+        parent_ctx.lprint(f"[warn] candidate {label} setup failed: {exc}")
+        return _CandidateOutcome(
+            passed=False,
+            parent_id=parent.id,
+            inspiration_ids=inspiration_ids,
+            summary="candidate setup failed",
+            feedback=str(exc),
+        )
+    try:
+        return _evaluate_candidate(
+            subctx,
+            generation=generation,
+            child_idx=child_idx,
+            parent=parent,
+            inspirations=inspirations,
+            objective=objective,
+            objectives=objectives,
+            modality=modality,
+            pass_criteria=pass_criteria,
+            keep_modal_apps=keep_modal_apps,
+            isolated_app=True,
+        )
+    except Exception as exc:
+        parent_ctx.lprint(f"[warn] candidate {label} evaluation raised: {exc}")
+        return _CandidateOutcome(
+            passed=False,
+            parent_id=parent.id,
+            inspiration_ids=inspiration_ids,
+            summary="candidate evaluation raised",
+            feedback=str(exc),
+        )
+    finally:
+        try:
+            subctx.close()
+        except Exception as exc:
+            parent_ctx.lprint(f"[warn] candidate {label} teardown failed: {exc}")
+
+
+def _run_generation_parallel(
+    parent_ctx: LoopContext,
+    *,
+    config: Config,
+    agent_backend: str | None,
+    cli_provider: str | None,
+    max_parallelism: int,
+    generation: int,
+    children_per_generation: int,
+    population: Population,
+    population_path: Path,
+    rng: random.Random,
+    k_top_inspirations: int,
+    k_random_inspirations: int,
+    selection_temperature: float,
+    objective: str,
+    objectives: list[Objective] | None,
+    frontier_bias: float,
+    modality: str,
+    pass_criteria: str,
+    keep_modal_apps: bool,
+) -> None:
+    """Evaluate a generation's candidates concurrently in isolated sub-contexts.
+
+    Parent/inspiration selection for *all* children happens first, single-
+    threaded, from the pre-generation population snapshot (so ``rng`` and
+    ``Population`` are never touched from a worker). Candidates then run in a
+    bounded pool; results are recorded serially, in deterministic child order,
+    after the pool drains — so id assignment and ``Population`` mutation stay on
+    one thread.
+    """
+    plans: list[tuple[int, Individual, list[Individual]]] = []
+    for child_idx in range(1, children_per_generation + 1):
+        plan = _plan_candidate(
+            parent_ctx,
+            population,
+            rng,
+            k_top_inspirations=k_top_inspirations,
+            k_random_inspirations=k_random_inspirations,
+            selection_temperature=selection_temperature,
+            objectives=objectives,
+            frontier_bias=frontier_bias,
+        )
+        if plan is None:
+            continue
+        parent, inspirations = plan
+        if not parent.commit:
+            parent_ctx.lprint(
+                f"[warn] parent {parent.id} has no commit; cannot isolate "
+                f"candidate g{generation}c{child_idx}; skipping"
+            )
+            continue
+        plans.append((child_idx, parent, inspirations))
+
+    if not plans:
+        return
+
+    cap = max(1, min(max_parallelism, len(plans)))
+    parent_ctx.lprint(
+        f"[parallel] generation {generation}: evaluating {len(plans)} "
+        f"candidate(s), up to {cap} concurrently"
+    )
+    worktree_lock = threading.Lock()
+    outcomes: dict[int, _CandidateOutcome] = {}
+    with ThreadPoolExecutor(max_workers=cap, thread_name_prefix=f"gen{generation}") as pool:
+        futures = {
+            pool.submit(
+                _evaluate_in_subcontext,
+                parent_ctx,
+                config=config,
+                agent_backend=agent_backend,
+                cli_provider=cli_provider,
+                generation=generation,
+                child_idx=child_idx,
+                parent=parent,
+                inspirations=inspirations,
+                objective=objective,
+                objectives=objectives,
+                modality=modality,
+                pass_criteria=pass_criteria,
+                keep_modal_apps=keep_modal_apps,
+                worktree_lock=worktree_lock,
+            ): child_idx
+            for (child_idx, parent, inspirations) in plans
+        }
+        for future in as_completed(futures):
+            outcomes[futures[future]] = future.result()
+
+    # Record serially, in child order, on this (single) thread.
+    for child_idx in sorted(outcomes):
+        _record_outcome(
+            parent_ctx, population, population_path, outcomes[child_idx], generation=generation
+        )
+
+
 # ---------------------------------------------------------------------------
 # Bootstrap
 # ---------------------------------------------------------------------------
@@ -546,6 +1017,7 @@ def run_evolve_loop(
     frontier_bias: float = 0.7,
     bootstrap_max_attempts: int = 5,
     keep_modal_apps: bool = False,
+    max_parallelism: int = 1,
     remote_repo: str | None = None,
     repo_visibility: RepositoryVisibility = RepositoryVisibility.PRIVATE,
 ) -> bool:
@@ -623,6 +1095,19 @@ def run_evolve_loop(
                 )
                 return False
 
+        # Parallelism is Modal-only: host GPU reselection is a no-op there and
+        # each candidate deploys to its own Modal app, so isolated sub-contexts
+        # (worktree + editor container + agent runner) can run concurrently.
+        # Local/Docker backends contend on one physical GPU, so they stay
+        # serial regardless of --max-parallelism.
+        env_kind = getattr(ctx.run_environment_view, "env_kind", "local")
+        parallel = max_parallelism > 1 and env_kind == "modal"
+        if max_parallelism > 1 and not parallel:
+            ctx.lprint(
+                f"[parallel] --max-parallelism={max_parallelism} ignored: parallel "
+                f"candidate evaluation requires Modal (env_kind={env_kind}); running serially"
+            )
+
         for generation in range(1, max_generations + 1):
             ctx.switch_log_file(f"gen{generation:03d}")
             ctx.lprint(
@@ -631,157 +1116,47 @@ def run_evolve_loop(
                 f"{'=' * 60}\n"
             )
 
-            for child_idx in range(1, children_per_generation + 1):
-                candidate_progress = CandidateProgress(
-                    generation,
-                    max_generations,
-                    child_idx,
-                    children_per_generation,
+            if parallel:
+                _run_generation_parallel(
+                    ctx,
+                    config=config,
+                    agent_backend=agent_backend,
+                    cli_provider=cli_provider,
+                    max_parallelism=max_parallelism,
+                    generation=generation,
+                    children_per_generation=children_per_generation,
+                    population=population,
+                    population_path=population_path,
+                    rng=rng,
+                    k_top_inspirations=k_top_inspirations,
+                    k_random_inspirations=k_random_inspirations,
+                    selection_temperature=selection_temperature,
+                    objective=objective,
+                    objectives=objectives,
+                    frontier_bias=frontier_bias,
+                    modality=modality,
+                    pass_criteria=pass_criteria,
+                    keep_modal_apps=keep_modal_apps,
                 )
-                with ctx.progress(candidate_progress):
-                    ctx.lprint(f"\n--- {candidate_progress.label()} ---\n")
-
-                    # 1. Pick parent + inspirations.
-                    parent = population.select_parent(
-                        rng=rng,
-                        temperature=selection_temperature,
-                        objectives=objectives,
-                        frontier_bias=frontier_bias,
-                    )
-                    inspirations = population.select_inspirations(
-                        parent_id=parent.id if parent else None,
-                        k_top=k_top_inspirations,
-                        k_random=k_random_inspirations,
-                        rng=rng,
-                        objectives=objectives,
-                    )
-                    # 2. Materialize the parent's tree. Bootstrap guarantees a
-                    # passing gen-0 seed, so a passing parent always exists.
-                    # select_parent only returns None when no passer has a
-                    # scalar perf_metric (e.g. profiler disabled); fall back to
-                    # the latest passer so the loop never cold-starts.
-                    if parent is None:
-                        passers = population.passed
-                        if not passers:
-                            ctx.lprint("[warn] no passing parent available; skipping candidate")
-                            continue
-                        parent = passers[-1]
-                    if parent.commit and not ctx.git.checkout_tree(parent.commit, clean=True):
-                        ctx.lprint(
-                            f"[warn] could not check out parent {parent.id} "
-                            f"(commit {parent.commit[:8]}); skipping cand"
-                        )
-                        continue
-
-                    # Per-candidate runtime notes: in Modal mode this gives the
-                    # mutator/judge/profiler a candidate-unique app name so the
-                    # judge never reads a prior candidate's stale app logs.
-                    cand_notes, cand_app = _candidate_runtime_notes(ctx, generation, child_idx)
-
-                    ctx.lprint(
-                        f"parent=#{parent.id} (perf={parent.perf_metric})"
-                        + (f" modal-app={cand_app}" if cand_app else "")
-                        + f"; inspirations={[i.id for i in inspirations]}"
-                    )
-
-                    # The candidate deploys its per-candidate Modal app during
-                    # mutate/judge/profile; stop it once evaluation is done, on
-                    # every exit path (fail continue, pass fall-through).
-                    try:
-                        # 3. Mutator edits the workspace, mutating the passing parent.
-                        ctx.reselect_gpu()
-                        mutator = _run_mutator(
-                            ctx,
-                            generation=generation,
-                            child_idx=child_idx,
-                            objective=objective,
-                            parent=parent,
-                            inspirations=inspirations,
-                            modality=modality,
-                            is_cold_start=False,
-                            objectives=objectives,
-                            runtime_notes=cand_notes,
-                        )
-
-                        # 4. Judge.
-                        ctx.reselect_gpu()
-                        verdict = _run_judge(
-                            ctx,
-                            generation=generation,
-                            child_idx=child_idx,
-                            modality=modality,
-                            objective=objective,
-                            pass_criteria=pass_criteria,
-                            runtime_notes=cand_notes,
-                        )
-
-                        if verdict.verdict != Verdict.PASS:
-                            # The mutation was a dead end: record the failed child so
-                            # its feedback is visible to future mutators (excluded
-                            # from selection because ``passed`` is False, no commit),
-                            # then revert the dirty tree back to the passing parent.
-                            failed = Individual(
-                                id=population.next_id(),
-                                generation=generation,
-                                parent_id=parent.id,
-                                inspiration_ids=[i.id for i in inspirations],
-                                commit=None,
-                                perf_metric=None,
-                                perf_unit=None,
-                                passed=False,
-                                summary=mutator.summary,
-                                feedback=verdict.feedback,
-                            )
-                            population.add(failed)
-                            population.save(population_path)
-                            _discard_working_tree(ctx)
-                            ctx.lprint(
-                                f"[Gen {generation}] Cand {failed.id} FAILED — "
-                                f"feedback: {(verdict.feedback or '').splitlines()[0][:120]}"
-                            )
-                            continue
-
-                        # 5. Profile the offspring to get its fitness.
-                        ctx.reselect_gpu()
-                        summary = _run_profiler(
-                            ctx,
-                            generation=generation,
-                            child_idx=child_idx,
-                            modality=modality,
-                            objective=objective,
-                            objectives=objectives,
-                            runtime_notes=cand_notes,
-                        )
-
-                        # 6. Commit + record.
-                        ctx.snapshot_workspace(f"gen-{generation}-child-{child_idx}")
-                        commit = ctx.git.current_sha()
-                        child = Individual(
-                            id=population.next_id(),
-                            generation=generation,
-                            parent_id=parent.id,
-                            inspiration_ids=[i.id for i in inspirations],
-                            commit=commit,
-                            perf_metric=summary.perf_metric if summary else None,
-                            perf_unit=summary.perf_unit if summary else None,
-                            metrics=dict(summary.metrics) if summary and summary.metrics else {},
-                            passed=True,
-                            summary=mutator.summary,
-                            feedback=verdict.feedback,
-                        )
-                        population.add(child)
-                        population.save(population_path)
-                        metrics_repr = (
-                            " ".join(f"{k}={v:g}" for k, v in child.metrics.items())
-                            if child.metrics
-                            else f"{child.perf_metric} {child.perf_unit or ''}"
-                        )
-                        ctx.lprint(
-                            f"[Gen {generation}] Cand {child.id} PASSED — "
-                            f"{metrics_repr} (parent={parent.id})"
-                        )
-                    finally:
-                        _teardown_candidate_app(ctx, cand_app, keep=keep_modal_apps)
+            else:
+                _run_generation_serial(
+                    ctx,
+                    generation=generation,
+                    max_generations=max_generations,
+                    children_per_generation=children_per_generation,
+                    population=population,
+                    population_path=population_path,
+                    rng=rng,
+                    k_top_inspirations=k_top_inspirations,
+                    k_random_inspirations=k_random_inspirations,
+                    selection_temperature=selection_temperature,
+                    objective=objective,
+                    objectives=objectives,
+                    frontier_bias=frontier_bias,
+                    modality=modality,
+                    pass_criteria=pass_criteria,
+                    keep_modal_apps=keep_modal_apps,
+                )
 
         if objectives:
             front = population.frontier(objectives)

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -995,6 +995,17 @@ def _build_evolve_parser() -> argparse.ArgumentParser:
             "post-hoc log inspection."
         ),
     )
+    parser.add_argument(
+        "--max-parallelism",
+        type=int,
+        default=1,
+        help=(
+            "Max candidates to evaluate concurrently within a generation "
+            "(default: 1 = serial). Values >1 take effect only under --modal, "
+            "where each candidate runs in its own isolated worktree + editor "
+            "container + Modal app; local/docker backends stay serial."
+        ),
+    )
     parser.add_argument("--modality", default="text_generation", choices=_MODALITIES)
     return parser
 
@@ -1015,6 +1026,13 @@ def _validate_evolve(args: argparse.Namespace) -> None:
         _configuration_error("--frontier-bias must be in [0, 1].")
     if args.bootstrap_max_attempts < 1:
         _configuration_error("--bootstrap-max-attempts must be >= 1.")
+    if args.max_parallelism < 1:
+        _configuration_error("--max-parallelism must be >= 1.")
+    if args.max_parallelism > 1 and not args.modal:
+        _configuration_error(
+            "--max-parallelism > 1 requires --modal (parallel candidate "
+            "evaluation is Modal-only; other backends contend on one GPU)."
+        )
 
 
 def _run_evolve(args: argparse.Namespace) -> None:
@@ -1064,6 +1082,7 @@ def _run_evolve(args: argparse.Namespace) -> None:
         frontier_bias=args.frontier_bias,
         bootstrap_max_attempts=args.bootstrap_max_attempts,
         keep_modal_apps=args.keep_modal_apps,
+        max_parallelism=args.max_parallelism,
         remote_repo=args.repo,
         repo_visibility=args.repo_visibility,
     )

--- a/src/vibesys/run/git_tracker.py
+++ b/src/vibesys/run/git_tracker.py
@@ -115,6 +115,26 @@ class GitTracker:
         self._add_all()
         self.run(["git", "commit", "-m", "initial: workspace setup"])
 
+    def add_worktree(self, worktree_dir: Path, commit: str) -> None:
+        """Create a detached linked worktree at *commit*.
+
+        The worktree gets its own working tree, index, and (detached) HEAD but
+        shares this repository's object store, so a commit made in the worktree
+        is immediately reachable by sha from the main repo — exactly what a
+        per-candidate evolve worktree needs (isolated edits, one shared
+        lineage). ``git worktree add`` mutates the main repo's
+        ``.git/worktrees`` admin area, so callers must serialize concurrent
+        adds; committing *inside* a worktree afterwards is independent per
+        worktree and safe to run concurrently.
+        """
+        worktree_dir.parent.mkdir(parents=True, exist_ok=True)
+        self.run(["git", "worktree", "add", "--detach", str(worktree_dir), commit])
+
+    def remove_worktree(self, worktree_dir: Path) -> None:
+        """Remove a linked worktree and prune its admin entry (best-effort)."""
+        self.run(["git", "worktree", "remove", "--force", str(worktree_dir)], check=False)
+        self.run(["git", "worktree", "prune"], check=False)
+
     def snapshot(self, label: str) -> None:
         """Commit current workspace state with *label* as the commit message."""
         self._add_all()

--- a/src/vibesys/run/git_tracker.py
+++ b/src/vibesys/run/git_tracker.py
@@ -10,6 +10,7 @@ history; nothing here touches sandboxes or backends.
 
 import os
 import re
+import shutil
 import subprocess
 from collections.abc import Callable, Iterable
 from pathlib import Path
@@ -131,8 +132,21 @@ class GitTracker:
         self.run(["git", "worktree", "add", "--detach", str(worktree_dir), commit])
 
     def remove_worktree(self, worktree_dir: Path) -> None:
-        """Remove a linked worktree and prune its admin entry (best-effort)."""
+        """Unregister a linked worktree and delete its directory (best-effort).
+
+        ``git worktree remove`` unregisters the worktree, but it can leave the
+        directory on disk — e.g. when the editor container wrote scratch files
+        (``__pycache__``, ``.pytest_cache``) into the bind-mounted tree that
+        ``git`` then declines to delete. Follow up with an explicit recursive
+        delete so per-candidate workspaces don't accumulate across a run, then
+        prune any stale admin entry. Both the ``git`` failure and any
+        undeletable leftovers are non-fatal: unregistration is what matters for
+        correctness, so ``ignore_errors`` keeps a stubborn file from sinking the
+        run.
+        """
         self.run(["git", "worktree", "remove", "--force", str(worktree_dir)], check=False)
+        if Path(worktree_dir).exists():
+            shutil.rmtree(worktree_dir, ignore_errors=True)
         self.run(["git", "worktree", "prune"], check=False)
 
     def snapshot(self, label: str) -> None:

--- a/src/vibesys/run/logger.py
+++ b/src/vibesys/run/logger.py
@@ -50,15 +50,23 @@ class RunLogger:
     reach the real stderr untouched), so it is safe regardless of which
     renderer owns the terminal. The log copy has ANSI escapes stripped so
     ``run-*.log`` stays plain text.
+
+    ``tee_stderr=False`` builds a logger that owns only its file and never
+    touches the process-global ``sys.stderr``. This is required for concurrent
+    per-candidate sub-loggers: only the one top-level run logger may own the
+    stderr tee, or overlapping loggers would fight over (and mis-restore) the
+    global handle. A no-tee logger's ``switch``/``close`` leave stderr alone.
     """
 
-    def __init__(self, log_dir: Path) -> None:
+    def __init__(self, log_dir: Path, *, tee_stderr: bool = True) -> None:
         self.log_dir = log_dir
+        self._tee_stderr = tee_stderr
         run_started = datetime.now().strftime("%Y%m%d-%H%M%S")
         self.path = log_dir / f"run-{run_started}.log"
         self.file = self.path.open("a", encoding="utf-8")
         self._original_stderr = sys.stderr
-        sys.stderr = _TeeWriter(self._original_stderr, self.file)
+        if tee_stderr:
+            sys.stderr = _TeeWriter(self._original_stderr, self.file)
 
     def lprint(self, text: str) -> None:
         log_and_print(text, self.file)
@@ -83,9 +91,11 @@ class RunLogger:
         new_file = new_path.open("a", encoding="utf-8")
         self.path = new_path
         self.file = new_file
-        sys.stderr = _TeeWriter(self._original_stderr, new_file)
+        if self._tee_stderr:
+            sys.stderr = _TeeWriter(self._original_stderr, new_file)
         return new_file
 
     def close(self) -> None:
-        sys.stderr = self._original_stderr
+        if self._tee_stderr:
+            sys.stderr = self._original_stderr
         self.file.close()

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -9,6 +9,9 @@ are patched out — same pattern as ``tests/test_orchestrate.py``.
 
 from __future__ import annotations
 
+import random
+import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -16,10 +19,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibesys.agents import AgentRunner
+from vibesys.context import create_run_context
+from vibesys.domains.llm_serving.hooks import LLMServingEnvironmentHooks
+from vibesys.loops.evolve import loop as evolve_loop
 from vibesys.loops.evolve.loop import (
     _candidate_runtime_notes,
+    _CandidateOutcome,
+    _evaluate_in_subcontext,
     _latest_wip_seed,
+    _plan_candidate,
     _recent_failure_lessons,
+    _run_generation_parallel,
     _teardown_candidate_app,
     run_evolve_loop,
 )
@@ -28,7 +38,7 @@ from vibesys.loops.evolve.population import (
     Objective,
     Population,
 )
-from vibesys.sandbox.run_environment import candidate_modal_app_name
+from vibesys.sandbox.run_environment import RunEnvironmentSpec, candidate_modal_app_name
 from vibesys.schemas import JudgeResponse, MutatorResponse, ProfilerSummary, Verdict
 
 # ---------------------------------------------------------------------------
@@ -661,6 +671,303 @@ def test_teardown_candidate_app_noop_when_kept_or_no_app():
     _teardown_candidate_app(ctx, None, keep=False)
 
     run_env.teardown_deployment.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Parallel generation orchestration
+# ---------------------------------------------------------------------------
+
+
+def _passing_seed(commit: str = "seedsha", perf: float = 1.0) -> Individual:
+    return Individual(
+        id=1,
+        generation=0,
+        parent_id=None,
+        commit=commit,
+        perf_metric=perf,
+        perf_unit="tok/s",
+        metrics={"aggregate_throughput": perf},
+        passed=True,
+        summary="seed",
+    )
+
+
+def test_plan_candidate_falls_back_to_latest_passer_then_none():
+    ctx = SimpleNamespace(lprint=lambda _msg: None)
+    rng = random.Random(0)
+
+    # No passers at all → None (candidate skipped).
+    empty = Population([])
+    assert (
+        _plan_candidate(
+            ctx,
+            empty,
+            rng,
+            k_top_inspirations=1,
+            k_random_inspirations=1,
+            selection_temperature=0.5,
+            objectives=None,
+            frontier_bias=0.7,
+        )
+        is None
+    )
+
+    # A passer exists → returned as parent.
+    pop = Population([_passing_seed()])
+    plan = _plan_candidate(
+        ctx,
+        pop,
+        rng,
+        k_top_inspirations=1,
+        k_random_inspirations=1,
+        selection_temperature=0.5,
+        objectives=None,
+        frontier_bias=0.7,
+    )
+    assert plan is not None
+    parent, _inspirations = plan
+    assert parent.id == 1
+
+
+def test_run_generation_parallel_bounds_concurrency_and_records_all(tmp_path, monkeypatch):
+    """Candidates run concurrently up to the cap; every result is recorded once,
+    in child order, on the orchestrator thread (population never races)."""
+    population = Population([_passing_seed()])
+    population_path = tmp_path / "population.json"
+    logs: list[str] = []
+    ctx = SimpleNamespace(lprint=logs.append)
+
+    live = 0
+    peak = 0
+    lock = threading.Lock()
+
+    def fake_eval(parent_ctx, *, generation, child_idx, parent, inspirations, **_kw):
+        nonlocal live, peak
+        with lock:
+            live += 1
+            peak = max(peak, live)
+        time.sleep(0.05)
+        with lock:
+            live -= 1
+        return _CandidateOutcome(
+            passed=True,
+            parent_id=parent.id,
+            inspiration_ids=[i.id for i in inspirations],
+            summary=f"cand-{child_idx}",
+            feedback="",
+            commit=f"child-{child_idx}",
+            perf_metric=float(child_idx),
+            perf_unit="tok/s",
+            metrics={"aggregate_throughput": float(child_idx)},
+        )
+
+    monkeypatch.setattr(evolve_loop, "_evaluate_in_subcontext", fake_eval)
+
+    _run_generation_parallel(
+        ctx,
+        config={"model": {"name": "m"}},
+        agent_backend=None,
+        cli_provider=None,
+        max_parallelism=2,
+        generation=1,
+        children_per_generation=5,
+        population=population,
+        population_path=population_path,
+        rng=random.Random(0),
+        k_top_inspirations=1,
+        k_random_inspirations=1,
+        selection_temperature=0.5,
+        objective="obj",
+        objectives=None,
+        frontier_bias=0.7,
+        modality="text_generation",
+        pass_criteria="crit",
+        keep_modal_apps=False,
+    )
+
+    # Cap respected, never exceeded.
+    assert peak <= 2
+    # All 5 children recorded (ids 2..6) plus the seed.
+    assert len(population) == 6
+    recorded = [i for i in population.all if i.generation == 1]
+    assert len(recorded) == 5
+    assert {i.commit for i in recorded} == {f"child-{c}" for c in range(1, 6)}
+    assert population_path.exists()
+
+
+def test_run_generation_parallel_skips_parent_without_commit(tmp_path, monkeypatch):
+    """A parent with no commit can't be isolated into a worktree → skipped, not
+    dispatched."""
+    seed = _passing_seed()
+    seed.commit = None  # passer but nothing to branch from
+    # ``passed`` requires a commit, so this seed won't be selectable; give the
+    # planner a stub that returns it anyway to exercise the guard.
+    population = Population([_passing_seed(), seed])
+    population_path = tmp_path / "population.json"
+    ctx = SimpleNamespace(lprint=lambda _m: None)
+
+    monkeypatch.setattr(
+        evolve_loop,
+        "_plan_candidate",
+        lambda *a, **k: (seed, []),
+    )
+    called = False
+
+    def fake_eval(*a, **k):
+        nonlocal called
+        called = True
+        return _CandidateOutcome(True, seed.id, [], "s", "")
+
+    monkeypatch.setattr(evolve_loop, "_evaluate_in_subcontext", fake_eval)
+
+    _run_generation_parallel(
+        ctx,
+        config={"model": {"name": "m"}},
+        agent_backend=None,
+        cli_provider=None,
+        max_parallelism=2,
+        generation=1,
+        children_per_generation=2,
+        population=population,
+        population_path=population_path,
+        rng=random.Random(0),
+        k_top_inspirations=1,
+        k_random_inspirations=1,
+        selection_temperature=0.5,
+        objective="obj",
+        objectives=None,
+        frontier_bias=0.7,
+        modality="text_generation",
+        pass_criteria="crit",
+        keep_modal_apps=False,
+    )
+
+    assert called is False  # commit-less parent never dispatched
+    assert all(i.generation == 0 for i in population.all)  # nothing recorded
+
+
+# ---------------------------------------------------------------------------
+# Isolated sub-context evaluation (worktree + own logger/agent-runner)
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_in_subcontext_skips_parent_without_commit():
+    """A parent with no commit can't seed a worktree — folded into a failed
+    outcome without ever building a sub-context."""
+    logs: list[str] = []
+    parent_ctx = SimpleNamespace(lprint=logs.append)
+    parentless = Individual(id=3, generation=1, parent_id=1, commit=None, passed=True, summary="x")
+
+    outcome = _evaluate_in_subcontext(
+        parent_ctx,
+        config={"model": {"name": "m"}},
+        agent_backend=None,
+        cli_provider=None,
+        generation=2,
+        child_idx=1,
+        parent=parentless,
+        inspirations=[],
+        objective="obj",
+        objectives=None,
+        modality="text_generation",
+        pass_criteria="crit",
+        keep_modal_apps=False,
+        worktree_lock=threading.Lock(),
+    )
+
+    assert outcome.passed is False
+    assert outcome.parent_id == 3
+    assert "no parent commit" in outcome.summary
+    assert any("no parent commit" in line for line in logs)
+
+
+def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file):
+    """End-to-end: a real parent context spawns an isolated candidate sub-context
+    (git worktree at the parent commit + its own logger/agent-runner), evaluates
+    it, and the offspring commit lands in the parent's shared object store."""
+    runner = _make_runner(mutator_writes=True)
+    with (
+        patch("vibesys.context.build_model", return_value="mock-model"),
+        patch("vibesys.backends.cuda.LocalShellBackend"),
+        patch("vibesys.context.build_agent_runner", return_value=runner),
+        patch("vibesys.context.PROJECT_ROOT", tmp_path),
+        create_run_context(
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            exp_name="test-parallel-subctx",
+            input_path=str(Path(ref_file).parent),
+            accuracy_command="uv run python accuracy_checker/checker.py",
+            benchmark_command="uv run python benchmark/benchmark.py",
+            skills_dirs=[],
+            run_environment=RunEnvironmentSpec("local"),
+            environment_hooks=LLMServingEnvironmentHooks(),
+            git_tracking=True,
+        ) as parent,
+    ):
+        base_commit = parent.git.current_sha()
+        assert base_commit is not None
+        parent_ind = Individual(
+            id=1,
+            generation=0,
+            parent_id=None,
+            commit=base_commit,
+            perf_metric=1.0,
+            perf_unit="tok/s",
+            passed=True,
+            summary="seed",
+        )
+
+        outcome = _evaluate_in_subcontext(
+            parent,
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            agent_backend=None,
+            cli_provider=None,
+            generation=1,
+            child_idx=1,
+            parent=parent_ind,
+            inspirations=[],
+            objective="Maximize tok/s throughput.",
+            objectives=None,
+            modality="text_generation",
+            pass_criteria="be faster",
+            keep_modal_apps=False,
+            worktree_lock=threading.Lock(),
+        )
+
+        assert outcome.passed is True
+        assert outcome.parent_id == 1
+        assert outcome.perf_metric == 10.0
+        assert outcome.commit and outcome.commit != base_commit
+        # The offspring commit is reachable from the parent repo — the worktree
+        # shared its object store, so the candidate joins the one lineage.
+        assert (
+            parent.git.run(["git", "cat-file", "-e", outcome.commit], check=False).returncode == 0
+        )
+        # The candidate's worktree is torn down when its sub-context closes.
+        cand_ws = parent.exp_dir / "candidates" / f"{parent.exp_dir.name}-g1c1" / "workspace"
+        assert not cand_ws.exists()
+
+
+def test_max_parallelism_ignored_on_non_modal_env(tmp_path, ref_file, monkeypatch):
+    """--max-parallelism > 1 on a non-Modal env logs a downgrade and runs the
+    serial path (parallel orchestrator is never entered)."""
+    called = {"parallel": False}
+    monkeypatch.setattr(
+        evolve_loop,
+        "_run_generation_parallel",
+        lambda *a, **k: called.__setitem__("parallel", True),
+    )
+    runner = _make_runner(judge_verdicts=["pass", "pass", "pass"])
+    _invoke_loop(
+        tmp_path,
+        ref_file,
+        runner,
+        max_generations=1,
+        children_per_generation=1,
+        max_parallelism=4,  # local env → must downgrade to serial
+    )
+    assert called["parallel"] is False
+    pop = _load_population(tmp_path)
+    assert len(pop) == 2  # bootstrap seed + one serial gen-1 candidate
 
 
 def test_loop_tears_down_candidate_on_pass_and_fail_paths(tmp_path, ref_file):

--- a/tests/test_git_tracker.py
+++ b/tests/test_git_tracker.py
@@ -189,7 +189,32 @@ def test_add_worktree_materializes_commit_and_shares_object_store(ws, tmp_path):
     # `git cat-file -e <sha>` in the MAIN repo succeeds → object is shared.
     assert tracker.run(["git", "cat-file", "-e", child_sha], check=False).returncode == 0
 
+    # Untracked files must not block cleanup: the directory is always deleted.
+    (wt / "scratch.log").write_text("editor leftover\n")
     tracker.remove_worktree(wt)
     assert not wt.exists()
     # The child commit object survives worktree removal (shared store).
     assert tracker.run(["git", "cat-file", "-e", child_sha], check=False).returncode == 0
+
+
+def test_remove_worktree_deletes_orphaned_directory(ws, tmp_path):
+    """If `git worktree remove` leaves the directory behind (as observed when a
+    file is still held open by a just-stopped editor container), the explicit
+    recursive delete still clears it."""
+    import shutil
+
+    tracker = _make_tracker(ws)
+    tracker.init(existing=False)
+    base_sha = tracker.current_sha()
+    assert base_sha is not None
+
+    wt = tmp_path / "candidates" / "g2c1"
+    tracker.add_worktree(wt, base_sha)
+    assert wt.exists()
+
+    # Orphan the worktree: drop git's admin registration but leave the tree on
+    # disk. `git worktree remove` then no-ops ("not a working tree"), so only
+    # the rmtree fallback can clear the leftover directory.
+    shutil.rmtree(ws / ".git" / "worktrees")
+    tracker.remove_worktree(wt)
+    assert not wt.exists()

--- a/tests/test_git_tracker.py
+++ b/tests/test_git_tracker.py
@@ -160,3 +160,36 @@ def test_run_is_a_public_escape_hatch(ws):
 
     result = tracker.run(["git", "status", "--porcelain"], check=True)
     assert result.returncode == 0
+
+
+def test_add_worktree_materializes_commit_and_shares_object_store(ws, tmp_path):
+    tracker = _make_tracker(ws)
+    tracker.init(existing=False)
+    base_sha = tracker.current_sha()
+    assert base_sha is not None
+
+    # Advance the main tree so the worktree must reflect the OLD commit, not HEAD.
+    (ws / "main.py").write_text("VALUE = 99\n")
+    tracker.snapshot("advance")
+
+    wt = tmp_path / "candidates" / "g1c1"
+    tracker.add_worktree(wt, base_sha)
+
+    # Worktree holds the parent commit's content, isolated from the main tree.
+    assert (wt / "main.py").read_text() == "VALUE = 1\n"
+    assert (ws / "main.py").read_text() == "VALUE = 99\n"
+
+    # A commit in the worktree lands in the SHARED object store: the main repo
+    # can resolve it by sha.
+    wt_tracker = _make_tracker(wt)
+    (wt / "main.py").write_text("VALUE = 7\n")
+    wt_tracker.snapshot("child")
+    child_sha = wt_tracker.current_sha()
+    assert child_sha is not None and child_sha != base_sha
+    # `git cat-file -e <sha>` in the MAIN repo succeeds → object is shared.
+    assert tracker.run(["git", "cat-file", "-e", child_sha], check=False).returncode == 0
+
+    tracker.remove_worktree(wt)
+    assert not wt.exists()
+    # The child commit object survives worktree removal (shared store).
+    assert tracker.run(["git", "cat-file", "-e", child_sha], check=False).returncode == 0

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,35 @@
+"""RunLogger unit tests — focus on the process-global stderr tee ownership."""
+
+from __future__ import annotations
+
+import sys
+
+from vibesys.run import RunLogger
+
+
+def test_tee_logger_owns_and_restores_stderr(tmp_path):
+    original = sys.stderr
+    logger = RunLogger(tmp_path)
+    try:
+        assert sys.stderr is not original  # tee installed
+        print("diagnostic", file=sys.stderr)
+    finally:
+        logger.close()
+    assert sys.stderr is original  # restored on close
+    assert "diagnostic" in logger.path.read_text()
+
+
+def test_no_tee_logger_leaves_stderr_untouched(tmp_path):
+    original = sys.stderr
+    logger = RunLogger(tmp_path, tee_stderr=False)
+    try:
+        # A no-tee sub-logger must never touch the process-global stderr, so
+        # concurrent per-candidate loggers can't fight over (and mis-restore) it.
+        assert sys.stderr is original
+        logger.switch("gen001")
+        assert sys.stderr is original
+        logger.lprint("candidate line")
+    finally:
+        logger.close()
+    assert sys.stderr is original
+    assert "candidate line" in logger.path.read_text()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -269,6 +269,49 @@ def test_keep_modal_apps_flag_defaults_off_and_parses(tmp_path):
     assert parser.parse_args(["--keep-modal-apps", "--input", str(bundle)]).keep_modal_apps is True
 
 
+def test_max_parallelism_defaults_to_one_and_parses(tmp_path):
+    """--max-parallelism is serial (1) by default and accepts an int override."""
+    import vibesys.main as cli
+
+    bundle = _write_input_bundle(tmp_path)
+    parser = cli._build_evolve_parser()
+
+    assert parser.parse_args(["--input", str(bundle)]).max_parallelism == 1
+    assert (
+        parser.parse_args(["--max-parallelism", "4", "--input", str(bundle)]).max_parallelism == 4
+    )
+
+
+def test_validate_evolve_rejects_nonpositive_parallelism(tmp_path):
+    """--max-parallelism < 1 is a configuration error."""
+    import vibesys.main as cli
+
+    bundle = _write_input_bundle(tmp_path)
+    parser = cli._build_evolve_parser()
+    args = parser.parse_args(["--max-parallelism", "0", "--input", str(bundle)])
+    with pytest.raises(ConfigurationError):
+        cli._validate_evolve(args)
+
+
+def test_validate_evolve_rejects_parallelism_without_modal(tmp_path):
+    """--max-parallelism > 1 requires --modal; local backends stay serial."""
+    import vibesys.main as cli
+
+    bundle = _write_input_bundle(tmp_path)
+    parser = cli._build_evolve_parser()
+
+    # >1 without --modal is rejected...
+    args = parser.parse_args(["--max-parallelism", "4", "--input", str(bundle)])
+    with pytest.raises(ConfigurationError):
+        cli._validate_evolve(args)
+
+    # ...but >1 with --modal is accepted (torch profiler keeps --modal valid).
+    args = parser.parse_args(
+        ["--max-parallelism", "4", "--modal", "--profiler", "torch", "--input", str(bundle)]
+    )
+    cli._validate_evolve(args)
+
+
 @pytest.mark.parametrize(
     "argv",
     [


### PR DESCRIPTION
## Problem

The evolve loop evaluates a generation's candidates strictly one at a time.
Under Modal — where each candidate already deploys its GPU server to its own
uniquely-named app and the host GPU is unused — that serialism leaves most of
the available throughput on the table: N candidates that could run
side-by-side instead run back-to-back, so a generation takes N× longer than it
needs to. This directly gates how many rounds of search we can afford (e.g. the
Llama-3.1-8B Pareto serving run).

## Solution

Add **bounded parallel candidate evaluation**, gated behind a new
`--max-parallelism` flag (default `1` = serial, fully behavior-preserving).
Within a generation, up to `max_parallelism` candidates are evaluated
concurrently, each in its own **isolated sub-context**; parent/inspiration
selection and result recording stay single-threaded on the orchestrator.

Only the `mutate → judge → profile → commit` work fans out. Everything that
would race is kept off the worker threads:

- **Parent/inspiration selection** happens up front, single-threaded, from the
  pre-generation `Population` snapshot (`rng` is never touched from a worker).
- **Result recording** (`_record_outcome`) runs serially after the pool drains,
  in deterministic child order — so `next_id`, `Population` mutation, and
  `population.json` writes never race even though evaluation ran in parallel.

### Per-candidate isolation (`create_candidate_context`)

Each candidate gets its own of everything that isn't thread-safe, while
*sharing* the parent's git object store so its commit joins the one lineage:

- a **git worktree** checked out at the parent commit (isolated working tree /
  index / detached HEAD; edits never touch the shared tree);
- a fresh **run-environment session** (its own Modal editor container + app);
- its own **agent runner** (the CLI runner caches/mutates agents in place);
- a **no-tee `RunLogger`** — only the top-level run logger may own the process
  `sys.stderr`, so concurrent sub-loggers can't fight over (and mis-restore) it.

### Modal-only, by design

Parallelism is enabled only under `--modal`: host GPU reselection is a no-op
there (`host_device_reselect=False`) and each candidate deploys to its own app,
so sub-contexts don't contend on one physical GPU. Local/Docker backends stay
serial regardless of the flag, with a logged downgrade if `>1` is requested.

### Architecture

```mermaid
flowchart TD
    G[generation] --> P["_plan_candidate ×N<br/>(single-threaded: rng + Population)"]
    P --> P{{"ThreadPoolExecutor<br/>cap = min(max_parallelism, N)"}}
    P --> S1["_evaluate_in_subcontext<br/>worktree + container + runner + logger"]
    P --> S2["_evaluate_in_subcontext"]
    P --> S3["_evaluate_in_subcontext …"]
    S1 --> R["_record_outcome (serial, child order)"]
    S2 --> R
    S3 --> R
    R --> Pop[("Population + population.json")]
```

The generation loop was refactored into `_run_generation_serial` /
`_run_generation_parallel` over shared `_plan_candidate` /
`_evaluate_candidate` / `_record_outcome` helpers; the serial path preserves
existing behavior.

## Verification

### Correctness properties

- **Serial default is behavior-preserving**: `--max-parallelism 1` (the default)
  runs the exact serial path; all pre-existing evolve tests are unchanged.
- **No population/rng races**: selection and recording are single-threaded;
  workers only touch their own sub-context.
- **Deterministic recording order**: outcomes are recorded in child index order
  regardless of completion order.
- **Bounded concurrency**: at most `min(max_parallelism, children)` candidates
  run at once.
- **Shared lineage**: a candidate's offspring commit is reachable from the
  parent repo (worktree shares the object store); the worktree is torn down
  after its container stops.
- **Never sinks the pool**: setup/eval/teardown failures in a worker are folded
  into a failed `_CandidateOutcome`, never raised.
- **Modal-only gating**: `>1` without `--modal` is rejected at the CLI and
  downgraded-with-log in the loop.

### Testing

- `uv run ruff check src tests` — clean
- `uv run ruff format --check` — clean
- `uv run pyright` on all changed `src` modules — 0 errors
- `uv run python -m pytest tests/loops/evolve tests/test_main.py tests/test_git_tracker.py tests/test_logger.py tests/test_context.py -q` — **174 passed**
- New tests: bounded-concurrency + serial-recording orchestration, commit-less
  parent skip, end-to-end `_evaluate_in_subcontext` (real worktree + shared
  object store), `add_worktree`/`remove_worktree`, no-tee logger stderr
  ownership, `--max-parallelism` parse + validation.
- diff-cover vs `origin/main`: **91%** patch coverage (≥80% gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)