### PR TITLE
Add stateful Train Ticket evaluation to servicebench

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,8 +168,8 @@ jobs:
       - name: Validate microservice workloads
         working-directory: examples/evaluators/microservice
         run: |
-          go run ./cmd/microbench --workload ../../microservices/train-ticket/benchmark/workload.toml --validate-only
-          go run ./cmd/microbench --workload ../../microservices/social-network-read-timeline/benchmark/workload.toml --validate-only
+          go run ./cmd/servicebench --workload ../../microservices/train-ticket/benchmark/workload.toml --validate-only
+          go run ./cmd/servicebench --workload ../../microservices/social-network-read-timeline/benchmark/workload.toml --validate-only
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,6 +194,9 @@ jobs:
       - name: Run tests
         run: uv run python -m pytest -v --cov=vibesys --cov=vs_github --cov=vs_issue_board --cov=vs_sandbox --cov-report=term-missing --cov-report=xml --cov-fail-under=75
 
+      - name: Test Train Ticket accuracy checker
+        run: uv run python -m pytest -v examples/microservices/train-ticket/accuracy_checker/tests
+
       - name: Upload coverage report
         if: matrix.python-version == '3.11'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,6 +169,7 @@ jobs:
         working-directory: examples/evaluators/microservice
         run: |
           go run ./cmd/servicebench --workload ../../microservices/train-ticket/benchmark/workload.toml --validate-only
+          go run ./cmd/servicebench --workload ../../microservices/train-ticket/benchmark/workload.toml --profile offered-load --validate-only
           go run ./cmd/servicebench --workload ../../microservices/social-network-read-timeline/benchmark/workload.toml --validate-only
 
   test:

--- a/examples/evaluators/microservice/DESIGN.md
+++ b/examples/evaluators/microservice/DESIGN.md
@@ -61,6 +61,12 @@ The scheduler reports actual offered rate, scheduler lag, and maximum client
 queue depth. A trial is invalid when the client cannot offer the configured
 minimum fraction of target rate.
 
+Closed-loop workloads use the same engine, drivers, observations, and semantic
+validation, but each worker schedules its next logical operation after the
+previous one completes. They are appropriate for saturation-throughput
+objectives where a fixed open-loop rate would cap every successful candidate at
+the same score.
+
 ## Extension points
 
 `api.Driver` opens a target-specific `api.Client`. The client accepts an
@@ -70,7 +76,9 @@ transport fields. This draft implements HTTP. gRPC and Thrift should implement
 the same contract and pass the same engine/driver tests rather than adding
 protocol branches to the scheduler.
 
-`api.Application` prepares fixtures, builds invocations, and validates results.
+`api.Application` prepares fixtures, builds logical-operation plans, and
+validates their collected results. A plan may contain one or more invocations;
+the engine always issues and accounts for each invocation itself.
 The declarative adapter covers ordinary HTTP operations. The Social Network
 adapter demonstrates the typed escape hatch for dynamic users and setup.
 

--- a/examples/evaluators/microservice/DESIGN.md
+++ b/examples/evaluators/microservice/DESIGN.md
@@ -55,7 +55,8 @@ sequenceDiagram
 For open-loop workloads, total latency begins at the scheduled arrival. Client
 queueing therefore remains visible under overload. Semantic validation happens
 after `completed_at`; it can invalidate a request but does not inflate protocol
-latency.
+latency. The separate `validated_at` timestamp bounds logical completion and is
+used for achieved-throughput elapsed time.
 
 The scheduler reports actual offered rate, scheduler lag, and maximum client
 queue depth. A trial is invalid when the client cannot offer the configured
@@ -65,7 +66,8 @@ Closed-loop workloads use the same engine, drivers, observations, and semantic
 validation, but each worker schedules its next logical operation after the
 previous one completes. They are appropriate for saturation-throughput
 objectives where a fixed open-loop rate would cap every successful candidate at
-the same score.
+the same score. Their latency distributions are closed-loop saturation response
+times; use an open-loop workload to characterize queueing under an offered rate.
 
 ## Extension points
 

--- a/examples/evaluators/microservice/README.md
+++ b/examples/evaluators/microservice/README.md
@@ -18,7 +18,7 @@ The system separates four kinds of concern:
 | Layer | Owns | Does not own |
 | --- | --- | --- |
 | Workload | Targets, traffic mix, load, objective, and validity constraints | Scheduling or protocol code |
-| Core engine | Trial lifecycle, open-loop scheduling, timestamps, aggregation, and result validity | Application schemas or wire formats |
+| Core engine | Trial lifecycle, open- or closed-loop scheduling, timestamps, aggregation, and result validity | Application schemas or wire formats |
 | Application adapter | Fixture setup, dynamic request construction, and semantic response validation | Worker scheduling or headline statistics |
 | Protocol driver | Connections, serialization, transport calls, and native response metadata | Application operation meaning |
 
@@ -54,7 +54,7 @@ warmup followed by the measured phase.
 
 ```mermaid
 sequenceDiagram
-    participant CLI as microbench
+    participant CLI as servicebench
     participant App as Application adapter
     participant Engine as Trial engine
     participant Driver as Protocol driver
@@ -71,13 +71,15 @@ sequenceDiagram
             Driver->>Target: Invoke
         end
         loop Scheduled measured arrivals
-            Engine->>App: BuildInvocation(operation, sample)
-            App-->>Engine: Invocation
-            Engine->>Driver: Invoke(invocation)
-            Driver->>Target: Protocol request
-            Target-->>Driver: Native response
-            Driver-->>Engine: ProtocolResult
-            Engine->>App: Validate(operation, result)
+            Engine->>App: BuildOperation(operation, sample)
+            App-->>Engine: OperationPlan
+            loop Every invocation in the plan
+                Engine->>Driver: Invoke(invocation)
+                Driver->>Target: Protocol request
+                Target-->>Driver: Native response
+                Driver-->>Engine: ProtocolResult
+            end
+            Engine->>App: ValidateOperation(operation, plan, results)
             App-->>Engine: Semantic result + custom timings
         end
         Engine->>Engine: Summarize trial and enforce constraints
@@ -118,14 +120,24 @@ does not inflate the recorded protocol latency. The engine also reports actual
 offered rate, scheduler lag, and maximum queue depth so a benchmark can
 distinguish target behavior from load-generator saturation.
 
+### Closed-loop saturation model
+
+Closed-loop workloads keep the configured number of logical operations in
+flight for the measurement duration. Each worker schedules its next operation
+only after the previous operation completes. This measures achieved throughput
+without imposing a fixed offered-rate ceiling. Queue wait and scheduler lag are
+zero by construction; total latency still spans every invocation in the logical
+operation.
+
 ### Correctness and result validity
 
 Transport success is not sufficient. The application adapter validates native
 status and application-level semantics—for example, an HTTP 200 containing a
 Train Ticket error envelope is still a failed request.
 
-Latency distributions contain only semantically successful requests. Error
-counts contain every failed attempt. A trial is invalid when it:
+Latency distributions contain only semantically successful logical operations.
+Error counts contain every failed operation. Physical invocation counts and
+bytes remain visible separately. A trial is invalid when it:
 
 - has no successful samples matching the objective;
 - fails to sustain the workload's minimum offered-rate ratio;
@@ -136,10 +148,10 @@ An invalid run omits `primary_value`, preventing the optimization loop from
 treating a fast-but-incorrect or client-limited result as an improvement.
 
 The summary aggregates trial-level primary values rather than pooling every
-request across trials. It reports median, median absolute deviation (MAD), and
+operation across trials. It reports median, median absolute deviation (MAD), and
 interquartile range (IQR), plus a deterministic bootstrap confidence interval
 when at least two valid trials are available. The optional raw NDJSON output
-retains one observation per measured request for diagnosis.
+retains one observation per measured logical operation for diagnosis.
 
 ## Package map
 
@@ -150,7 +162,7 @@ retains one observation per measured request for diagnosis.
 | [`apps/declarative/`](apps/declarative/) | Declarative HTTP request and response adapter |
 | [`apps/socialnetwork/`](apps/socialnetwork/) | Typed DeathStarBench Social Network adapter |
 | [`cmd/`](cmd/) | Executable composition roots |
-| [`cmd/microbench/`](cmd/microbench/) | Benchmark CLI |
+| [`cmd/servicebench/`](cmd/servicebench/) | Benchmark CLI |
 | [`config/`](config/) | Strict TOML decoding, defaults, profiles, and canonical serialization |
 | [`drivers/`](drivers/) | Protocol-driver extension layer |
 | [`drivers/httpdriver/`](drivers/httpdriver/) | HTTP transport and connection policy |
@@ -170,7 +182,8 @@ A workload declares:
 - one application adapter;
 - one or more named protocol targets;
 - weighted operations and optional objective tags;
-- open-loop rate, duration, warmup, concurrency, timeout, seed, and repetitions;
+- open- or closed-loop model, rate, duration, warmup, concurrency, timeout,
+  seed, and repetitions;
 - the primary metric and direction; and
 - correctness and offered-load constraints.
 
@@ -188,7 +201,7 @@ See the checked-in workloads for complete examples:
 From the repository root:
 
 ```bash
-go -C examples/evaluators/microservice run ./cmd/microbench \
+go -C examples/evaluators/microservice run ./cmd/servicebench \
   --workload "$PWD/examples/microservices/train-ticket/benchmark/workload.toml" \
   --base-url http://localhost:8080 \
   --output-json /tmp/result.json \
@@ -198,12 +211,12 @@ go -C examples/evaluators/microservice run ./cmd/microbench \
 Validate a workload and its registered extensions without running traffic:
 
 ```bash
-go -C examples/evaluators/microservice run ./cmd/microbench \
+go -C examples/evaluators/microservice run ./cmd/servicebench \
   --workload "$PWD/examples/microservices/train-ticket/benchmark/workload.toml" \
   --validate-only
 ```
 
-Use `go run ./cmd/microbench --help` from this directory for target, load,
+Use `go run ./cmd/servicebench --help` from this directory for target, load,
 profile, fixture, and output overrides.
 
 ## Testing

--- a/examples/evaluators/microservice/README.md
+++ b/examples/evaluators/microservice/README.md
@@ -116,9 +116,11 @@ sequenceDiagram
 ```
 
 Application validation runs after `completed_at`. It can reject a response but
-does not inflate the recorded protocol latency. The engine also reports actual
-offered rate, scheduler lag, and maximum queue depth so a benchmark can
-distinguish target behavior from load-generator saturation.
+does not inflate the recorded protocol latency. `validated_at` records when
+semantic validation finishes; achieved-throughput elapsed time includes that
+tail so validator work cannot inflate the primary metric. The engine also
+reports actual offered rate, scheduler lag, and maximum queue depth so a
+benchmark can distinguish target behavior from load-generator saturation.
 
 ### Closed-loop saturation model
 
@@ -127,7 +129,8 @@ flight for the measurement duration. Each worker schedules its next operation
 only after the previous operation completes. This measures achieved throughput
 without imposing a fixed offered-rate ceiling. Queue wait and scheduler lag are
 zero by construction; total latency still spans every invocation in the logical
-operation.
+operation. These are saturation response-time samples, not open-loop latency:
+they intentionally do not model arrivals queueing during a target stall.
 
 ### Correctness and result validity
 
@@ -141,7 +144,7 @@ bytes remain visible separately. A trial is invalid when it:
 
 - has no successful samples matching the objective;
 - fails to sustain the workload's minimum offered-rate ratio;
-- violates a success-rate or error-rate constraint; or
+- violates a success-rate, error-rate, or per-operation coverage constraint; or
 - fails during reset, setup, execution, or interruption.
 
 An invalid run omits `primary_value`, preventing the optimization loop from

--- a/examples/evaluators/microservice/api/README.md
+++ b/examples/evaluators/microservice/api/README.md
@@ -11,9 +11,10 @@ The main contracts are:
 - `Driver` and `Client`, which isolate protocol sessions and invocations;
 - `Application`, which owns fixture lifecycle, request construction, and
   semantic response validation;
-- `Invocation` and `ProtocolResult`, which carry protocol-specific payloads
-  through a protocol-neutral engine; and
-- `Observation`, which records common request outcome and timing fields.
+- `OperationPlan`, `Invocation`, and `ProtocolResult`, which let one scheduled
+  logical operation contain one or more engine-accounted protocol calls; and
+- `Observation`, which records common logical-operation outcome and timing
+  fields together with physical invocation counts.
 
 Protocol-specific data belongs in an invocation payload or protocol result.
 Application-specific data belongs in the application adapter. Adding either to

--- a/examples/evaluators/microservice/api/types.go
+++ b/examples/evaluators/microservice/api/types.go
@@ -27,6 +27,7 @@ type Load struct {
 }
 
 type ProfileOverride struct {
+	Model               *string        `toml:"model"`
 	Rate                *float64       `toml:"rate"`
 	WarmupSeconds       *float64       `toml:"warmup_seconds"`
 	DurationSeconds     *float64       `toml:"duration_seconds"`
@@ -39,6 +40,9 @@ type ProfileOverride struct {
 }
 
 func (o ProfileOverride) Apply(load *Load) {
+	if o.Model != nil {
+		load.Model = *o.Model
+	}
 	if o.Rate != nil {
 		load.Rate = *o.Rate
 	}
@@ -129,8 +133,9 @@ type Objective struct {
 }
 
 type Constraints struct {
-	MinSuccessRate *float64 `toml:"min_success_rate" json:"min_success_rate,omitempty"`
-	MaxErrorRate   *float64 `toml:"max_error_rate" json:"max_error_rate,omitempty"`
+	MinSuccessRate       *float64 `toml:"min_success_rate" json:"min_success_rate,omitempty"`
+	MaxErrorRate         *float64 `toml:"max_error_rate" json:"max_error_rate,omitempty"`
+	MinOperationsPerType int      `toml:"min_operations_per_type" json:"min_operations_per_type,omitempty"`
 }
 
 type Workload struct {
@@ -223,14 +228,17 @@ type Observation struct {
 	DispatchedAt       time.Time                `json:"dispatched_at"`
 	SentAt             time.Time                `json:"sent_at"`
 	CompletedAt        time.Time                `json:"completed_at"`
+	ValidatedAt        time.Time                `json:"validated_at"`
 	QueueWait          time.Duration            `json:"-"`
 	ClientPrepareTime  time.Duration            `json:"-"`
 	ProtocolTime       time.Duration            `json:"-"`
 	TotalLatency       time.Duration            `json:"-"`
+	ValidationTime     time.Duration            `json:"-"`
 	QueueWaitMS        float64                  `json:"queue_wait_ms"`
 	ClientPrepareMS    float64                  `json:"client_prepare_ms"`
 	ProtocolTimeMS     float64                  `json:"protocol_time_ms"`
 	TotalLatencyMS     float64                  `json:"total_latency_ms"`
+	ValidationTimeMS   float64                  `json:"validation_time_ms"`
 	TransportSuccess   bool                     `json:"transport_success"`
 	ApplicationSuccess bool                     `json:"application_success"`
 	NativeStatus       string                   `json:"native_status"`
@@ -245,14 +253,19 @@ type Observation struct {
 }
 
 func (o *Observation) PopulateDurations() {
+	if o.ValidatedAt.IsZero() {
+		o.ValidatedAt = o.CompletedAt
+	}
 	o.QueueWait = o.DispatchedAt.Sub(o.ScheduledAt)
 	o.ClientPrepareTime = o.SentAt.Sub(o.DispatchedAt)
 	o.ProtocolTime = o.CompletedAt.Sub(o.SentAt)
 	o.TotalLatency = o.CompletedAt.Sub(o.ScheduledAt)
+	o.ValidationTime = o.ValidatedAt.Sub(o.CompletedAt)
 	o.QueueWaitMS = durationMS(o.QueueWait)
 	o.ClientPrepareMS = durationMS(o.ClientPrepareTime)
 	o.ProtocolTimeMS = durationMS(o.ProtocolTime)
 	o.TotalLatencyMS = durationMS(o.TotalLatency)
+	o.ValidationTimeMS = durationMS(o.ValidationTime)
 	if len(o.CustomTimings) > 0 {
 		o.CustomTimingsMS = make(map[string]float64, len(o.CustomTimings))
 		for name, value := range o.CustomTimings {

--- a/examples/evaluators/microservice/api/types.go
+++ b/examples/evaluators/microservice/api/types.go
@@ -157,6 +157,15 @@ type Invocation struct {
 	Payload   any
 }
 
+// OperationPlan describes every protocol invocation in one scheduled logical
+// operation. State is opaque application-owned data used to validate the
+// collected results. The engine, rather than the application, always executes
+// and accounts for every invocation.
+type OperationPlan struct {
+	Invocations []Invocation
+	State       any
+}
+
 type ProtocolResult struct {
 	TransportSuccess bool
 	NativeStatus     string
@@ -198,8 +207,9 @@ type Application interface {
 	Name() string
 	Prepare(context.Context, Runtime, TrialContext) (any, error)
 	Reset(context.Context, Runtime, TrialContext) error
-	BuildInvocation(Operation, Sample, any) (Invocation, error)
-	Validate(Operation, ProtocolResult) ValidationResult
+	BuildOperation(Operation, Sample, any) (OperationPlan, error)
+	ValidateOperation(Operation, OperationPlan, []ProtocolResult) ValidationResult
+	FinishOperation(OperationPlan)
 }
 
 type Observation struct {
@@ -226,6 +236,8 @@ type Observation struct {
 	NativeStatus       string                   `json:"native_status"`
 	ErrorCategory      string                   `json:"error_category,omitempty"`
 	ErrorMessage       string                   `json:"error_message,omitempty"`
+	InvocationCount    int                      `json:"invocation_count"`
+	NativeStatuses     []string                 `json:"native_statuses,omitempty"`
 	RequestBytes       int64                    `json:"request_bytes"`
 	ResponseBytes      int64                    `json:"response_bytes"`
 	CustomTimings      map[string]time.Duration `json:"-"`

--- a/examples/evaluators/microservice/apps/README.md
+++ b/examples/evaluators/microservice/apps/README.md
@@ -1,9 +1,9 @@
 # Application adapters
 
 This directory contains application-specific benchmark behavior. Adapters
-translate a workload operation and deterministic sample into a protocol
-invocation, prepare any required fixtures, and decide whether a native response
-is semantically correct.
+translate a workload operation and deterministic sample into a protocol-neutral
+operation plan, prepare any required fixtures, and decide whether the collected
+native responses are semantically correct.
 
 Adapters may understand an application's endpoints, schemas, identifiers, and
 setup sequence. They must not create worker pools, schedule arrivals, calculate
@@ -12,5 +12,9 @@ belong to the engine and protocol drivers.
 
 Use the declarative adapter when operations can be described entirely in the
 workload. Add a typed adapter when request construction or fixture management
-requires application code. Register new adapters in the `microbench` command's
+requires application code. Register new adapters in the `servicebench` command's
 composition root.
+
+The Train Ticket adapter demonstrates dependent multi-invocation operations.
+It describes update/read and create/read/delete plans, while the engine retains
+exclusive ownership of issuing and measuring every HTTP request.

--- a/examples/evaluators/microservice/apps/declarative/declarative.go
+++ b/examples/evaluators/microservice/apps/declarative/declarative.go
@@ -45,9 +45,9 @@ func (a *Application) Reset(context.Context, api.Runtime, api.TrialContext) erro
 	return nil
 }
 
-func (a *Application) BuildInvocation(operation api.Operation, sample api.Sample, _ any) (api.Invocation, error) {
+func (a *Application) BuildOperation(operation api.Operation, sample api.Sample, _ any) (api.OperationPlan, error) {
 	if operation.HTTP == nil {
-		return api.Invocation{}, fmt.Errorf("operation %q has no HTTP request", operation.Name)
+		return api.OperationPlan{}, fmt.Errorf("operation %q has no HTTP request", operation.Name)
 	}
 	request := *operation.HTTP
 	request.Path = expand(request.Path, sample)
@@ -55,10 +55,16 @@ func (a *Application) BuildInvocation(operation api.Operation, sample api.Sample
 	request.Query = expandMap(request.Query, sample)
 	request.Headers = expandMap(request.Headers, sample)
 	request.Form = expandMap(request.Form, sample)
-	return api.Invocation{Target: operation.Target, Operation: operation.Name, Payload: request}, nil
+	return api.OperationPlan{Invocations: []api.Invocation{{
+		Target: operation.Target, Operation: operation.Name, Payload: request,
+	}}}, nil
 }
 
-func (a *Application) Validate(operation api.Operation, result api.ProtocolResult) api.ValidationResult {
+func (a *Application) ValidateOperation(operation api.Operation, _ api.OperationPlan, results []api.ProtocolResult) api.ValidationResult {
+	if len(results) != 1 {
+		return invalid("invalid_response", fmt.Sprintf("expected one protocol result, got %d", len(results)))
+	}
+	result := results[0]
 	if !result.TransportSuccess {
 		return api.ValidationResult{ErrorCategory: result.ErrorCategory, ErrorMessage: result.ErrorMessage}
 	}
@@ -103,6 +109,8 @@ func (a *Application) Validate(operation api.Operation, result api.ProtocolResul
 	}
 	return api.ValidationResult{Success: true, CustomTimings: custom}
 }
+
+func (a *Application) FinishOperation(api.OperationPlan) {}
 
 func invalid(category string, message string) api.ValidationResult {
 	return api.ValidationResult{ErrorCategory: category, ErrorMessage: message}

--- a/examples/evaluators/microservice/apps/declarative/declarative_test.go
+++ b/examples/evaluators/microservice/apps/declarative/declarative_test.go
@@ -14,26 +14,26 @@ func TestValidateRejectsApplicationErrorEnvelope(t *testing.T) {
 		JSON:                true,
 		JSONStatusIfPresent: &status,
 	}}
-	validation := application.Validate(operation, api.ProtocolResult{
+	validation := application.ValidateOperation(operation, api.OperationPlan{}, []api.ProtocolResult{{
 		TransportSuccess: true,
 		Payload:          api.HTTPResponse{StatusCode: 200, Body: []byte(`{"status":0,"msg":"failed"}`)},
-	})
+	}})
 	if validation.Success || validation.ErrorCategory != "application_status" {
 		t.Fatalf("unexpected validation: %+v", validation)
 	}
 }
 
-func TestBuildInvocationExpandsDeterministicVariables(t *testing.T) {
+func TestBuildOperationExpandsDeterministicVariables(t *testing.T) {
 	application := &Application{}
 	operation := api.Operation{
 		Name: "compose", Target: "api",
 		HTTP: &api.HTTPRequestSpec{Path: "/${counter}", Form: map[string]string{"value": "${random}"}},
 	}
-	invocation, err := application.BuildInvocation(operation, api.Sample{Counter: 7, Random: 11}, nil)
+	plan, err := application.BuildOperation(operation, api.Sample{Counter: 7, Random: 11}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	request := invocation.Payload.(api.HTTPRequestSpec)
+	request := plan.Invocations[0].Payload.(api.HTTPRequestSpec)
 	if request.Path != "/7" || request.Form["value"] != "11" {
 		t.Fatalf("variables were not expanded: %+v", request)
 	}

--- a/examples/evaluators/microservice/apps/socialnetwork/socialnetwork.go
+++ b/examples/evaluators/microservice/apps/socialnetwork/socialnetwork.go
@@ -158,7 +158,7 @@ func (a *Application) Prepare(ctx context.Context, runtime api.Runtime, _ api.Tr
 	return nil, nil
 }
 
-func (a *Application) BuildInvocation(operation api.Operation, sample api.Sample, _ any) (api.Invocation, error) {
+func (a *Application) BuildOperation(operation api.Operation, sample api.Sample, _ any) (api.OperationPlan, error) {
 	user := int(sample.Random % uint64(a.config.Users))
 	var request api.HTTPRequestSpec
 	switch operation.Name {
@@ -181,12 +181,18 @@ func (a *Application) BuildInvocation(operation api.Operation, sample api.Sample
 	case composePost:
 		request = a.composeRequest(user, "live_"+strconv.FormatInt(sample.Counter, 10))
 	default:
-		return api.Invocation{}, fmt.Errorf("unknown Social Network operation %q", operation.Name)
+		return api.OperationPlan{}, fmt.Errorf("unknown Social Network operation %q", operation.Name)
 	}
-	return api.Invocation{Target: operation.Target, Operation: operation.Name, Payload: request}, nil
+	return api.OperationPlan{Invocations: []api.Invocation{{
+		Target: operation.Target, Operation: operation.Name, Payload: request,
+	}}}, nil
 }
 
-func (a *Application) Validate(operation api.Operation, result api.ProtocolResult) api.ValidationResult {
+func (a *Application) ValidateOperation(operation api.Operation, _ api.OperationPlan, results []api.ProtocolResult) api.ValidationResult {
+	if len(results) != 1 {
+		return invalid("invalid_response", fmt.Sprintf("expected one protocol result, got %d", len(results)))
+	}
+	result := results[0]
 	if !result.TransportSuccess {
 		return api.ValidationResult{ErrorCategory: result.ErrorCategory, ErrorMessage: result.ErrorMessage}
 	}
@@ -217,6 +223,8 @@ func (a *Application) Validate(operation api.Operation, result api.ProtocolResul
 	}
 	return api.ValidationResult{Success: true, CustomTimings: custom}
 }
+
+func (a *Application) FinishOperation(api.OperationPlan) {}
 
 func (a *Application) follow(ctx context.Context, runtime api.Runtime, user int, followee int) error {
 	err := invokeOK(ctx, runtime, api.HTTPRequestSpec{

--- a/examples/evaluators/microservice/apps/socialnetwork/socialnetwork_test.go
+++ b/examples/evaluators/microservice/apps/socialnetwork/socialnetwork_test.go
@@ -41,9 +41,9 @@ func TestPrepareBuildsDeterministicFixture(t *testing.T) {
 	}
 }
 
-func TestBuildInvocationUsesOperationCatalog(t *testing.T) {
+func TestBuildOperationUsesOperationCatalog(t *testing.T) {
 	application := &Application{config: Config{Users: 2, UserIDBase: 100, UsernamePrefix: "test_"}}
-	invocation, err := application.BuildInvocation(
+	plan, err := application.BuildOperation(
 		api.Operation{Name: userTimelineRead, Target: "gateway"},
 		api.Sample{Random: 1},
 		nil,
@@ -51,7 +51,7 @@ func TestBuildInvocationUsesOperationCatalog(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	request := invocation.Payload.(api.HTTPRequestSpec)
+	request := plan.Invocations[0].Payload.(api.HTTPRequestSpec)
 	if got := request.Query["user_id"]; got != "101" {
 		t.Fatalf("user_id = %q, want 101", got)
 	}

--- a/examples/evaluators/microservice/apps/trainticket/README.md
+++ b/examples/evaluators/microservice/apps/trainticket/README.md
@@ -1,0 +1,15 @@
+# Train Ticket application adapter
+
+This adapter owns the Train Ticket v0.2.0 benchmark contract. It creates a
+randomized connected fixture through public HTTP endpoints and builds strict
+list, read, update/read, and create/read/delete operation plans.
+
+The adapter does not issue measured requests or calculate metrics. It returns
+plans to the shared engine, which executes and accounts for every invocation.
+Per-record leases prevent concurrent updates from corrupting the evaluator's
+expected state and are released through `FinishOperation` on every execution
+path.
+
+All fixture state is removed through public HTTP APIs after each trial. No
+candidate database, process layout, persistence format, or implementation
+language is assumed.

--- a/examples/evaluators/microservice/apps/trainticket/application.go
+++ b/examples/evaluators/microservice/apps/trainticket/application.go
@@ -1,0 +1,198 @@
+package trainticket
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"vibesys/microservice-evaluator/api"
+)
+
+var services = []string{"config", "station", "train", "travel", "route", "price"}
+
+var operationTargets = map[string]string{
+	"list_config": "config", "list_station": "station", "list_train": "train",
+	"list_travel": "travel", "list_route": "route", "list_price": "price",
+	"read_config": "config", "read_station": "station", "read_train": "train",
+	"read_travel": "travel", "read_route": "route", "read_price": "price",
+	"update_read_config": "config", "update_read_station": "station", "update_read_train": "train",
+	"update_read_travel": "travel", "update_read_route": "route", "update_read_price": "price",
+	"create_read_delete_config": "config",
+}
+
+type Config struct {
+	Records int
+}
+
+type Application struct {
+	config Config
+	token  string
+	active *dataset
+}
+
+func New(workload api.Workload) (api.Application, error) {
+	targets := make(map[string]api.Target, len(workload.Targets))
+	for _, target := range workload.Targets {
+		targets[target.Name] = target
+	}
+	for _, service := range services {
+		target, ok := targets[service]
+		if !ok {
+			return nil, fmt.Errorf("Train Ticket requires a target named %q", service)
+		}
+		if target.Protocol != "http" {
+			return nil, fmt.Errorf("Train Ticket target %q must use HTTP, got %q", service, target.Protocol)
+		}
+	}
+	config := Config{Records: 32}
+	for key := range workload.ApplicationConfig {
+		if key != "records" {
+			return nil, fmt.Errorf("unknown application_config field %q", key)
+		}
+	}
+	if raw, ok := workload.ApplicationConfig["records"]; ok {
+		value, ok := integer(raw)
+		if !ok || value < 2 {
+			return nil, fmt.Errorf("application_config.records must be an integer greater than one")
+		}
+		config.Records = value
+	}
+	for _, operation := range workload.Operations {
+		target, ok := operationTargets[operation.Name]
+		if !ok {
+			return nil, fmt.Errorf("unknown Train Ticket operation %q", operation.Name)
+		}
+		if operation.Target != target {
+			return nil, fmt.Errorf("Train Ticket operation %q must target %q", operation.Name, target)
+		}
+		if operation.HTTP != nil {
+			return nil, fmt.Errorf("Train Ticket operation %q must not declare operations.http", operation.Name)
+		}
+	}
+	return &Application{config: config, token: makeAdminToken(time.Now())}, nil
+}
+
+func (a *Application) Name() string { return "train-ticket" }
+
+func (a *Application) Prepare(ctx context.Context, runtime api.Runtime, trial api.TrialContext) (any, error) {
+	if a.active != nil {
+		return nil, fmt.Errorf("previous Train Ticket fixture was not reset")
+	}
+	namespace := fmt.Sprintf("vb%016x%02x", uint64(trial.Seed), trial.Index)
+	data := &dataset{namespace: namespace, records: makeRecords(namespace, trial.Seed, a.config.Records)}
+	a.active = data
+	for index := range data.records {
+		if err := a.createRecord(ctx, runtime, &data.records[index]); err != nil {
+			cleanupErr := a.Reset(ctx, runtime, trial)
+			if cleanupErr != nil {
+				return nil, fmt.Errorf("prepare record %d: %w (cleanup: %v)", index, err, cleanupErr)
+			}
+			return nil, fmt.Errorf("prepare record %d: %w", index, err)
+		}
+		data.prepared++
+	}
+	return data, nil
+}
+
+func (a *Application) Reset(ctx context.Context, runtime api.Runtime, _ api.TrialContext) error {
+	data := a.active
+	a.active = nil
+	if data == nil {
+		return nil
+	}
+	var firstErr error
+	for index := data.prepared - 1; index >= 0; index-- {
+		if err := a.deleteRecord(ctx, runtime, &data.records[index]); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("cleanup record %d: %w", index, err)
+		}
+	}
+	return firstErr
+}
+
+func (a *Application) createRecord(ctx context.Context, runtime api.Runtime, item *record) error {
+	steps := []setupStep{
+		{"config", http.MethodPost, "/api/v1/configservice/configs", item.config, http.StatusCreated},
+		{"station", http.MethodPost, "/api/v1/stationservice/stations", item.stationA, http.StatusCreated},
+		{"station", http.MethodPost, "/api/v1/stationservice/stations", item.stationB, http.StatusCreated},
+		{"train", http.MethodPost, "/api/v1/trainservice/trains", item.train, http.StatusOK},
+		{"route", http.MethodPost, "/api/v1/routeservice/routes", item.routeIn, http.StatusOK},
+		{"price", http.MethodPost, "/api/v1/priceservice/prices", item.price, http.StatusCreated},
+		{"travel", http.MethodPost, "/api/v1/travelservice/trips", item.tripIn, http.StatusCreated},
+	}
+	return a.runSetup(ctx, runtime, steps)
+}
+
+func (a *Application) deleteRecord(ctx context.Context, runtime api.Runtime, item *record) error {
+	steps := []setupStep{
+		{"travel", http.MethodDelete, "/api/v1/travelservice/trips/" + item.tripIn.TripID, nil, http.StatusOK},
+		{"price", http.MethodDelete, "/api/v1/priceservice/prices", item.price, http.StatusOK},
+		{"route", http.MethodDelete, "/api/v1/routeservice/routes/" + item.route.ID, nil, http.StatusOK},
+		{"train", http.MethodDelete, "/api/v1/trainservice/trains/" + item.train.ID, nil, http.StatusOK},
+		{"station", http.MethodDelete, "/api/v1/stationservice/stations", item.stationA, http.StatusOK},
+		{"station", http.MethodDelete, "/api/v1/stationservice/stations", item.stationB, http.StatusOK},
+		{"config", http.MethodDelete, "/api/v1/configservice/configs/" + url.PathEscape(item.config.Name), nil, http.StatusOK},
+	}
+	return a.runSetup(ctx, runtime, steps)
+}
+
+type setupStep struct {
+	target string
+	method string
+	path   string
+	body   any
+	status int
+}
+
+func (a *Application) runSetup(ctx context.Context, runtime api.Runtime, steps []setupStep) error {
+	for _, step := range steps {
+		requestCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+		result := runtime.Invoke(requestCtx, a.invocation(step.target, "fixture", step.method, step.path, step.body))
+		cancel()
+		if validation := validateEnvelopeResult(result, step.status, 1); !validation.Success {
+			return fmt.Errorf("%s %s: %s", step.method, step.path, validation.ErrorMessage)
+		}
+	}
+	return nil
+}
+
+func (a *Application) invocation(target, operation, method, path string, body any) api.Invocation {
+	spec := api.HTTPRequestSpec{
+		Method: method, Path: path,
+		Headers: map[string]string{"Accept": "application/json", "Authorization": "Bearer " + a.token},
+	}
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			panic(fmt.Sprintf("marshal trusted Train Ticket entity: %v", err))
+		}
+		spec.Body = string(encoded)
+		spec.Headers["Content-Type"] = "application/json"
+	}
+	return api.Invocation{Target: target, Operation: operation, Payload: spec}
+}
+
+func integer(value any) (int, bool) {
+	switch number := value.(type) {
+	case int64:
+		return int(number), int64(int(number)) == number
+	case int:
+		return number, true
+	case float64:
+		return int(number), number == float64(int(number))
+	default:
+		return 0, false
+	}
+}
+
+func serviceFromOperation(name string) string {
+	for _, service := range services {
+		if strings.HasSuffix(name, "_"+service) {
+			return service
+		}
+	}
+	return "config"
+}

--- a/examples/evaluators/microservice/apps/trainticket/application.go
+++ b/examples/evaluators/microservice/apps/trainticket/application.go
@@ -2,7 +2,9 @@ package trainticket
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -82,7 +84,8 @@ func (a *Application) Prepare(ctx context.Context, runtime api.Runtime, trial ap
 	if a.active != nil {
 		return nil, fmt.Errorf("previous Train Ticket fixture was not reset")
 	}
-	namespace := fmt.Sprintf("vb%016x%02x", uint64(trial.Seed), trial.Index)
+	namespaceDigest := sha256.Sum256([]byte(fmt.Sprintf("%d/%d", trial.Seed, trial.Index)))
+	namespace := fmt.Sprintf("%x", namespaceDigest[:12])
 	data := &dataset{namespace: namespace, records: makeRecords(namespace, trial.Seed, a.config.Records)}
 	a.active = data
 	for index := range data.records {
@@ -93,50 +96,95 @@ func (a *Application) Prepare(ctx context.Context, runtime api.Runtime, trial ap
 			}
 			return nil, fmt.Errorf("prepare record %d: %w", index, err)
 		}
-		data.prepared++
 	}
 	return data, nil
 }
 
 func (a *Application) Reset(ctx context.Context, runtime api.Runtime, _ api.TrialContext) error {
 	data := a.active
-	a.active = nil
 	if data == nil {
 		return nil
 	}
-	var firstErr error
-	for index := data.prepared - 1; index >= 0; index-- {
-		if err := a.deleteRecord(ctx, runtime, &data.records[index]); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("cleanup record %d: %w", index, err)
+	var cleanupErrors []error
+	for index := len(data.records) - 1; index >= 0; index-- {
+		if err := a.deleteRecord(ctx, runtime, &data.records[index]); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("cleanup record %d: %w", index, err))
 		}
 	}
-	return firstErr
+	if len(cleanupErrors) > 0 {
+		return errors.Join(cleanupErrors...)
+	}
+	a.active = nil
+	return nil
 }
 
 func (a *Application) createRecord(ctx context.Context, runtime api.Runtime, item *record) error {
-	steps := []setupStep{
-		{"config", http.MethodPost, "/api/v1/configservice/configs", item.config, http.StatusCreated},
-		{"station", http.MethodPost, "/api/v1/stationservice/stations", item.stationA, http.StatusCreated},
-		{"station", http.MethodPost, "/api/v1/stationservice/stations", item.stationB, http.StatusCreated},
-		{"train", http.MethodPost, "/api/v1/trainservice/trains", item.train, http.StatusOK},
-		{"route", http.MethodPost, "/api/v1/routeservice/routes", item.routeIn, http.StatusOK},
-		{"price", http.MethodPost, "/api/v1/priceservice/prices", item.price, http.StatusCreated},
-		{"travel", http.MethodPost, "/api/v1/travelservice/trips", item.tripIn, http.StatusCreated},
+	steps := lifecycleSteps(item)
+	for index, step := range steps {
+		if err := a.runStep(ctx, runtime, step.create); err != nil {
+			cleanupErr := a.deleteRecord(ctx, runtime, item)
+			if cleanupErr != nil {
+				return fmt.Errorf("create step %d: %w (partial cleanup: %v)", index, err, cleanupErr)
+			}
+			return fmt.Errorf("create step %d: %w", index, err)
+		}
+		item.created[index] = true
 	}
-	return a.runSetup(ctx, runtime, steps)
+	return nil
 }
 
 func (a *Application) deleteRecord(ctx context.Context, runtime api.Runtime, item *record) error {
-	steps := []setupStep{
-		{"travel", http.MethodDelete, "/api/v1/travelservice/trips/" + item.tripIn.TripID, nil, http.StatusOK},
-		{"price", http.MethodDelete, "/api/v1/priceservice/prices", item.price, http.StatusOK},
-		{"route", http.MethodDelete, "/api/v1/routeservice/routes/" + item.route.ID, nil, http.StatusOK},
-		{"train", http.MethodDelete, "/api/v1/trainservice/trains/" + item.train.ID, nil, http.StatusOK},
-		{"station", http.MethodDelete, "/api/v1/stationservice/stations", item.stationA, http.StatusOK},
-		{"station", http.MethodDelete, "/api/v1/stationservice/stations", item.stationB, http.StatusOK},
-		{"config", http.MethodDelete, "/api/v1/configservice/configs/" + url.PathEscape(item.config.Name), nil, http.StatusOK},
+	steps := lifecycleSteps(item)
+	var cleanupErrors []error
+	for index := len(steps) - 1; index >= 0; index-- {
+		if !item.created[index] {
+			continue
+		}
+		if err := a.runStep(ctx, runtime, steps[index].delete); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("delete step %d: %w", index, err))
+			continue
+		}
+		item.created[index] = false
 	}
-	return a.runSetup(ctx, runtime, steps)
+	return errors.Join(cleanupErrors...)
+}
+
+type lifecycleStep struct {
+	create setupStep
+	delete setupStep
+}
+
+func lifecycleSteps(item *record) []lifecycleStep {
+	return []lifecycleStep{
+		{
+			create: setupStep{"config", http.MethodPost, "/api/v1/configservice/configs", item.config, http.StatusCreated},
+			delete: setupStep{"config", http.MethodDelete, "/api/v1/configservice/configs/" + url.PathEscape(item.config.Name), nil, http.StatusOK},
+		},
+		{
+			create: setupStep{"station", http.MethodPost, "/api/v1/stationservice/stations", item.stationA, http.StatusCreated},
+			delete: setupStep{"station", http.MethodDelete, "/api/v1/stationservice/stations", item.stationA, http.StatusOK},
+		},
+		{
+			create: setupStep{"station", http.MethodPost, "/api/v1/stationservice/stations", item.stationB, http.StatusCreated},
+			delete: setupStep{"station", http.MethodDelete, "/api/v1/stationservice/stations", item.stationB, http.StatusOK},
+		},
+		{
+			create: setupStep{"train", http.MethodPost, "/api/v1/trainservice/trains", item.train, http.StatusOK},
+			delete: setupStep{"train", http.MethodDelete, "/api/v1/trainservice/trains/" + item.train.ID, nil, http.StatusOK},
+		},
+		{
+			create: setupStep{"route", http.MethodPost, "/api/v1/routeservice/routes", item.routeIn, http.StatusOK},
+			delete: setupStep{"route", http.MethodDelete, "/api/v1/routeservice/routes/" + item.route.ID, nil, http.StatusOK},
+		},
+		{
+			create: setupStep{"price", http.MethodPost, "/api/v1/priceservice/prices", item.price, http.StatusCreated},
+			delete: setupStep{"price", http.MethodDelete, "/api/v1/priceservice/prices", item.price, http.StatusOK},
+		},
+		{
+			create: setupStep{"travel", http.MethodPost, "/api/v1/travelservice/trips", item.tripIn, http.StatusCreated},
+			delete: setupStep{"travel", http.MethodDelete, "/api/v1/travelservice/trips/" + item.tripIn.TripID, nil, http.StatusOK},
+		},
+	}
 }
 
 type setupStep struct {
@@ -147,14 +195,12 @@ type setupStep struct {
 	status int
 }
 
-func (a *Application) runSetup(ctx context.Context, runtime api.Runtime, steps []setupStep) error {
-	for _, step := range steps {
-		requestCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
-		result := runtime.Invoke(requestCtx, a.invocation(step.target, "fixture", step.method, step.path, step.body))
-		cancel()
-		if validation := validateEnvelopeResult(result, step.status, 1); !validation.Success {
-			return fmt.Errorf("%s %s: %s", step.method, step.path, validation.ErrorMessage)
-		}
+func (a *Application) runStep(ctx context.Context, runtime api.Runtime, step setupStep) error {
+	requestCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	result := runtime.Invoke(requestCtx, a.invocation(step.target, "fixture", step.method, step.path, step.body))
+	if validation := validateEnvelopeResult(result, step.status, 1); !validation.Success {
+		return fmt.Errorf("%s %s: %s", step.method, step.path, validation.ErrorMessage)
 	}
 	return nil
 }

--- a/examples/evaluators/microservice/apps/trainticket/model.go
+++ b/examples/evaluators/microservice/apps/trainticket/model.go
@@ -2,6 +2,7 @@ package trainticket
 
 import (
 	"crypto/hmac"
+	cryptorand "crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
@@ -83,7 +84,8 @@ type tripEntity struct {
 }
 
 type record struct {
-	mu       sync.Mutex
+	mu       sync.RWMutex
+	created  [7]bool
 	config   configEntity
 	stationA stationEntity
 	stationB stationEntity
@@ -98,7 +100,6 @@ type record struct {
 type dataset struct {
 	namespace string
 	records   []record
-	prepared  int
 }
 
 func makeRecords(namespace string, seed int64, count int) []record {
@@ -106,8 +107,10 @@ func makeRecords(namespace string, seed int64, count int) []record {
 	records := make([]record, count)
 	for index := range records {
 		token := fmt.Sprintf("%s%03x%08x", namespace, index, rng.Uint32())
-		stationA := stationEntity{ID: token + "a", Name: "Station A " + token, StayTime: 1 + rng.Intn(40)}
-		stationB := stationEntity{ID: token + "b", Name: "Station B " + token, StayTime: 1 + rng.Intn(40)}
+		stationANames := []string{"Station A ", "North Hub ", "北站 "}
+		stationBNames := []string{"Station B ", "South Hub ", "南站 "}
+		stationA := stationEntity{ID: token + "a", Name: stationANames[rng.Intn(len(stationANames))] + token, StayTime: 1 + rng.Intn(40)}
+		stationB := stationEntity{ID: token + "b", Name: stationBNames[rng.Intn(len(stationBNames))] + token, StayTime: 1 + rng.Intn(40)}
 		train := trainEntity{ID: "T" + token, EconomyClass: 100 + rng.Intn(800), ConfortClass: 50 + rng.Intn(250), AverageSpeed: 80 + rng.Intn(270)}
 		routeID := deterministicUUID(rng)
 		distance := 100 + rng.Intn(1700)
@@ -123,8 +126,9 @@ func makeRecords(namespace string, seed int64, count int) []record {
 		start := int64(1_700_000_000_000 + rng.Intn(100_000_000))
 		tripIn := tripInput{TripID: tripString, TrainTypeID: train.ID, RouteID: routeID, StartingTime: start, StartingStationID: stationA.ID, StationsID: stationB.ID, TerminalStationID: stationB.ID, EndTime: start + int64(time.Hour/time.Millisecond)}
 		trip := tripEntity{TripID: tripID{Type: kind, Number: number}, TrainTypeID: train.ID, RouteID: routeID, StartingTime: start, StartingStationID: stationA.ID, StationsID: stationB.ID, TerminalStationID: stationB.ID, EndTime: tripIn.EndTime}
+		configNames := []string{token + "Config", "config " + token, "配置-" + token}
 		records[index] = record{
-			config:   configEntity{Name: token + "Config", Value: token + "-v0", Description: "benchmark " + token},
+			config:   configEntity{Name: configNames[rng.Intn(len(configNames))], Value: fmt.Sprintf("v-%016x", rng.Uint64()), Description: fmt.Sprintf("d-%016x", rng.Uint64())},
 			stationA: stationA, stationB: stationB, train: train,
 			routeIn: routeIn, route: route, price: price, tripIn: tripIn, trip: trip,
 		}
@@ -149,10 +153,15 @@ func deterministicUUID(rng *rand.Rand) string {
 }
 
 func makeAdminToken(now time.Time) string {
+	var identityBytes [12]byte
+	if _, err := cryptorand.Read(identityBytes[:]); err != nil {
+		panic(fmt.Sprintf("generate Train Ticket benchmark identity: %v", err))
+	}
+	identity := fmt.Sprintf("%x", identityBytes)
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
 	claims, _ := json.Marshal(map[string]any{
-		"sub": "vibesys-benchmark", "roles": []string{"ROLE_ADMIN"},
-		"id": "vibesys-benchmark", "iat": now.Unix(), "exp": now.Add(time.Hour).Unix(),
+		"sub": identity, "roles": []string{"ROLE_ADMIN"},
+		"id": identity, "iat": now.Unix(), "exp": now.Add(time.Hour).Unix(),
 	})
 	payload := base64.RawURLEncoding.EncodeToString(claims)
 	input := header + "." + payload

--- a/examples/evaluators/microservice/apps/trainticket/model.go
+++ b/examples/evaluators/microservice/apps/trainticket/model.go
@@ -1,0 +1,162 @@
+package trainticket
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+type configEntity struct {
+	Name        string `json:"name"`
+	Value       string `json:"value"`
+	Description string `json:"description"`
+}
+
+type stationEntity struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	StayTime int    `json:"stayTime"`
+}
+
+type trainEntity struct {
+	ID           string `json:"id"`
+	EconomyClass int    `json:"economyClass"`
+	ConfortClass int    `json:"confortClass"`
+	AverageSpeed int    `json:"averageSpeed"`
+}
+
+type routeInput struct {
+	ID           string `json:"id"`
+	StartStation string `json:"startStation"`
+	EndStation   string `json:"endStation"`
+	StationList  string `json:"stationList"`
+	DistanceList string `json:"distanceList"`
+}
+
+type routeEntity struct {
+	ID                string   `json:"id"`
+	Stations          []string `json:"stations"`
+	Distances         []int    `json:"distances"`
+	StartStationID    string   `json:"startStationId"`
+	TerminalStationID string   `json:"terminalStationId"`
+}
+
+type priceEntity struct {
+	ID                  string  `json:"id"`
+	TrainType           string  `json:"trainType"`
+	RouteID             string  `json:"routeId"`
+	BasicPriceRate      float64 `json:"basicPriceRate"`
+	FirstClassPriceRate float64 `json:"firstClassPriceRate"`
+}
+
+type tripID struct {
+	Type   string `json:"type"`
+	Number string `json:"number"`
+}
+
+type tripInput struct {
+	TripID            string `json:"tripId"`
+	TrainTypeID       string `json:"trainTypeId"`
+	RouteID           string `json:"routeId"`
+	StartingTime      int64  `json:"startingTime"`
+	StartingStationID string `json:"startingStationId"`
+	StationsID        string `json:"stationsId"`
+	TerminalStationID string `json:"terminalStationId"`
+	EndTime           int64  `json:"endTime"`
+}
+
+type tripEntity struct {
+	TripID            tripID `json:"tripId"`
+	TrainTypeID       string `json:"trainTypeId"`
+	RouteID           string `json:"routeId"`
+	StartingTime      int64  `json:"startingTime"`
+	StartingStationID string `json:"startingStationId"`
+	StationsID        string `json:"stationsId"`
+	TerminalStationID string `json:"terminalStationId"`
+	EndTime           int64  `json:"endTime"`
+}
+
+type record struct {
+	mu       sync.Mutex
+	config   configEntity
+	stationA stationEntity
+	stationB stationEntity
+	train    trainEntity
+	routeIn  routeInput
+	route    routeEntity
+	price    priceEntity
+	tripIn   tripInput
+	trip     tripEntity
+}
+
+type dataset struct {
+	namespace string
+	records   []record
+	prepared  int
+}
+
+func makeRecords(namespace string, seed int64, count int) []record {
+	rng := rand.New(rand.NewSource(seed))
+	records := make([]record, count)
+	for index := range records {
+		token := fmt.Sprintf("%s%03x%08x", namespace, index, rng.Uint32())
+		stationA := stationEntity{ID: token + "a", Name: "Station A " + token, StayTime: 1 + rng.Intn(40)}
+		stationB := stationEntity{ID: token + "b", Name: "Station B " + token, StayTime: 1 + rng.Intn(40)}
+		train := trainEntity{ID: "T" + token, EconomyClass: 100 + rng.Intn(800), ConfortClass: 50 + rng.Intn(250), AverageSpeed: 80 + rng.Intn(270)}
+		routeID := deterministicUUID(rng)
+		distance := 100 + rng.Intn(1700)
+		route := routeEntity{ID: routeID, Stations: []string{stationA.ID, stationB.ID}, Distances: []int{0, distance}, StartStationID: stationA.ID, TerminalStationID: stationB.ID}
+		routeIn := routeInput{ID: routeID, StartStation: stationA.ID, EndStation: stationB.ID, StationList: stationA.ID + "," + stationB.ID, DistanceList: fmt.Sprintf("0,%d", distance)}
+		price := priceEntity{ID: deterministicUUID(rng), TrainType: train.ID, RouteID: routeID, BasicPriceRate: 0.1 + rng.Float64()*0.8, FirstClassPriceRate: 0.9 + rng.Float64()}
+		kind := "G"
+		if rng.Intn(2) == 0 {
+			kind = "D"
+		}
+		number := fmt.Sprintf("%07d", 1_000_000+rng.Intn(8_999_999))
+		tripString := kind + number
+		start := int64(1_700_000_000_000 + rng.Intn(100_000_000))
+		tripIn := tripInput{TripID: tripString, TrainTypeID: train.ID, RouteID: routeID, StartingTime: start, StartingStationID: stationA.ID, StationsID: stationB.ID, TerminalStationID: stationB.ID, EndTime: start + int64(time.Hour/time.Millisecond)}
+		trip := tripEntity{TripID: tripID{Type: kind, Number: number}, TrainTypeID: train.ID, RouteID: routeID, StartingTime: start, StartingStationID: stationA.ID, StationsID: stationB.ID, TerminalStationID: stationB.ID, EndTime: tripIn.EndTime}
+		records[index] = record{
+			config:   configEntity{Name: token + "Config", Value: token + "-v0", Description: "benchmark " + token},
+			stationA: stationA, stationB: stationB, train: train,
+			routeIn: routeIn, route: route, price: price, tripIn: tripIn, trip: trip,
+		}
+	}
+	return records
+}
+
+func deterministicUUID(rng *rand.Rand) string {
+	var raw [16]byte
+	for index := range raw {
+		raw[index] = byte(rng.Intn(256))
+	}
+	raw[6] = (raw[6] & 0x0f) | 0x40
+	raw[8] = (raw[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		binary.BigEndian.Uint32(raw[0:4]),
+		binary.BigEndian.Uint16(raw[4:6]),
+		binary.BigEndian.Uint16(raw[6:8]),
+		binary.BigEndian.Uint16(raw[8:10]),
+		raw[10:16],
+	)
+}
+
+func makeAdminToken(now time.Time) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	claims, _ := json.Marshal(map[string]any{
+		"sub": "vibesys-benchmark", "roles": []string{"ROLE_ADMIN"},
+		"id": "vibesys-benchmark", "iat": now.Unix(), "exp": now.Add(time.Hour).Unix(),
+	})
+	payload := base64.RawURLEncoding.EncodeToString(claims)
+	input := header + "." + payload
+	mac := hmac.New(sha256.New, []byte("secret"))
+	_, _ = mac.Write([]byte(input))
+	return input + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}

--- a/examples/evaluators/microservice/apps/trainticket/operations.go
+++ b/examples/evaluators/microservice/apps/trainticket/operations.go
@@ -1,0 +1,203 @@
+package trainticket
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"vibesys/microservice-evaluator/api"
+)
+
+type expectationKind int
+
+const (
+	expectEnvelope expectationKind = iota
+	expectExactData
+	expectEntityList
+)
+
+type stepExpectation struct {
+	status    int
+	appStatus int
+	kind      expectationKind
+	service   string
+	expected  any
+}
+
+type operationState struct {
+	expectations []stepExpectation
+	locked       *record
+	commit       func()
+}
+
+func (a *Application) BuildOperation(operation api.Operation, sample api.Sample, prepared any) (api.OperationPlan, error) {
+	data, ok := prepared.(*dataset)
+	if !ok || data == nil || len(data.records) == 0 {
+		return api.OperationPlan{}, fmt.Errorf("Train Ticket fixture is not prepared")
+	}
+	service := serviceFromOperation(operation.Name)
+	item := &data.records[sample.Random%uint64(len(data.records))]
+	switch {
+	case operation.Name == "create_read_delete_config":
+		return a.buildEphemeral(operation, sample, data)
+	case strings.HasPrefix(operation.Name, "list_"):
+		return a.buildList(operation, service), nil
+	case strings.HasPrefix(operation.Name, "read_"):
+		return a.buildRead(operation, service, item), nil
+	case strings.HasPrefix(operation.Name, "update_read_"):
+		return a.buildUpdateRead(operation, service, item, sample), nil
+	default:
+		return api.OperationPlan{}, fmt.Errorf("unsupported Train Ticket operation %q", operation.Name)
+	}
+}
+
+func (a *Application) FinishOperation(plan api.OperationPlan) {
+	state, ok := plan.State.(*operationState)
+	if ok && state.locked != nil {
+		state.locked.mu.Unlock()
+		state.locked = nil
+	}
+}
+
+func (a *Application) buildList(operation api.Operation, service string) api.OperationPlan {
+	paths := map[string]string{
+		"config": "/api/v1/configservice/configs", "station": "/api/v1/stationservice/stations",
+		"train": "/api/v1/trainservice/trains", "travel": "/api/v1/travelservice/trips",
+		"route": "/api/v1/routeservice/routes", "price": "/api/v1/priceservice/prices",
+	}
+	return api.OperationPlan{
+		Invocations: []api.Invocation{a.invocation(service, operation.Name, http.MethodGet, paths[service], nil)},
+		State: &operationState{expectations: []stepExpectation{{
+			status: http.StatusOK, appStatus: 1, kind: expectEntityList, service: service,
+		}}},
+	}
+}
+
+func (a *Application) buildRead(operation api.Operation, service string, item *record) api.OperationPlan {
+	item.mu.Lock()
+	path, expected := readPathAndValue(service, item)
+	return api.OperationPlan{
+		Invocations: []api.Invocation{a.invocation(service, operation.Name, http.MethodGet, path, nil)},
+		State: &operationState{locked: item, expectations: []stepExpectation{{
+			status: http.StatusOK, appStatus: 1, kind: expectExactData, service: service, expected: expected,
+		}}},
+	}
+}
+
+func (a *Application) buildUpdateRead(operation api.Operation, service string, item *record, sample api.Sample) api.OperationPlan {
+	item.mu.Lock()
+	version := sample.Random ^ uint64(sample.Counter)*0x9e3779b97f4a7c15
+	method, path, body, readPath, expected, commit := updatedEntity(service, item, version)
+	return api.OperationPlan{
+		Invocations: []api.Invocation{
+			a.invocation(service, operation.Name, method, path, body),
+			a.invocation(service, operation.Name, http.MethodGet, readPath, nil),
+		},
+		State: &operationState{
+			locked: item,
+			commit: commit,
+			expectations: []stepExpectation{
+				{status: expectedWriteStatus(service, method), appStatus: 1, kind: expectEnvelope, service: service},
+				{status: http.StatusOK, appStatus: 1, kind: expectExactData, service: service, expected: expected},
+			},
+		},
+	}
+}
+
+func (a *Application) buildEphemeral(operation api.Operation, sample api.Sample, data *dataset) (api.OperationPlan, error) {
+	token := fmt.Sprintf("%s-ephemeral-%d-%016x", data.namespace, sample.Counter, sample.Random)
+	item := configEntity{Name: token, Value: strconv.FormatUint(sample.Random, 10), Description: token + "-description"}
+	path := "/api/v1/configservice/configs/" + url.PathEscape(item.Name)
+	return api.OperationPlan{
+		Invocations: []api.Invocation{
+			a.invocation("config", operation.Name, http.MethodPost, "/api/v1/configservice/configs", item),
+			a.invocation("config", operation.Name, http.MethodGet, path, nil),
+			a.invocation("config", operation.Name, http.MethodDelete, path, nil),
+			a.invocation("config", operation.Name, http.MethodGet, path, nil),
+		},
+		State: &operationState{expectations: []stepExpectation{
+			{status: http.StatusCreated, appStatus: 1, kind: expectEnvelope, service: "config"},
+			{status: http.StatusOK, appStatus: 1, kind: expectExactData, service: "config", expected: item},
+			{status: http.StatusOK, appStatus: 1, kind: expectEnvelope, service: "config"},
+			{status: http.StatusOK, appStatus: 0, kind: expectEnvelope, service: "config"},
+		}},
+	}, nil
+}
+
+func readPathAndValue(service string, item *record) (string, any) {
+	switch service {
+	case "config":
+		return "/api/v1/configservice/configs/" + url.PathEscape(item.config.Name), item.config
+	case "station":
+		return "/api/v1/stationservice/stations/name/" + item.stationA.ID, item.stationA.Name
+	case "train":
+		return "/api/v1/trainservice/trains/" + item.train.ID, item.train
+	case "route":
+		return "/api/v1/routeservice/routes/" + item.route.ID, item.route
+	case "price":
+		return "/api/v1/priceservice/prices/" + item.price.RouteID + "/" + item.price.TrainType, item.price
+	default:
+		return "/api/v1/travelservice/trips/" + item.tripIn.TripID, item.trip
+	}
+}
+
+func updatedEntity(service string, item *record, version uint64) (method, path string, body any, readPath string, expected any, commit func()) {
+	switch service {
+	case "config":
+		updated := item.config
+		updated.Value = fmt.Sprintf("v-%016x", version)
+		updated.Description = fmt.Sprintf("d-%016x", version^0xa5a5a5a5a5a5a5a5)
+		return http.MethodPut, "/api/v1/configservice/configs", updated,
+			"/api/v1/configservice/configs/" + url.PathEscape(updated.Name), updated,
+			func() { item.config = updated }
+	case "station":
+		updated := item.stationA
+		updated.Name = fmt.Sprintf("Station-%016x", version)
+		updated.StayTime = 1 + int(version%120)
+		return http.MethodPut, "/api/v1/stationservice/stations", updated,
+			"/api/v1/stationservice/stations/name/" + updated.ID, updated.Name,
+			func() { item.stationA = updated }
+	case "train":
+		updated := item.train
+		updated.AverageSpeed = 80 + int(version%420)
+		updated.EconomyClass = 100 + int((version>>8)%900)
+		return http.MethodPut, "/api/v1/trainservice/trains", updated,
+			"/api/v1/trainservice/trains/" + updated.ID, updated,
+			func() { item.train = updated }
+	case "route":
+		updatedInput := item.routeIn
+		updatedRoute := item.route
+		updatedRoute.Stations = append([]string(nil), item.route.Stations...)
+		updatedRoute.Distances = append([]int(nil), item.route.Distances...)
+		updatedRoute.Distances[1] = 100 + int(version%1800)
+		updatedInput.DistanceList = fmt.Sprintf("0,%d", updatedRoute.Distances[1])
+		return http.MethodPost, "/api/v1/routeservice/routes", updatedInput,
+			"/api/v1/routeservice/routes/" + updatedRoute.ID, updatedRoute,
+			func() { item.routeIn, item.route = updatedInput, updatedRoute }
+	case "price":
+		updated := item.price
+		updated.BasicPriceRate = 0.1 + float64(version%8000)/10000
+		updated.FirstClassPriceRate = 0.9 + float64((version>>8)%10000)/10000
+		return http.MethodPut, "/api/v1/priceservice/prices", updated,
+			"/api/v1/priceservice/prices/" + updated.RouteID + "/" + updated.TrainType, updated,
+			func() { item.price = updated }
+	default:
+		updatedInput := item.tripIn
+		updated := item.trip
+		updatedInput.EndTime = updatedInput.StartingTime + int64(time.Minute/time.Millisecond)*int64(60+version%600)
+		updated.EndTime = updatedInput.EndTime
+		return http.MethodPut, "/api/v1/travelservice/trips", updatedInput,
+			"/api/v1/travelservice/trips/" + updatedInput.TripID, updated,
+			func() { item.tripIn, item.trip = updatedInput, updated }
+	}
+}
+
+func expectedWriteStatus(service, method string) int {
+	if method == http.MethodPost && (service == "config" || service == "station" || service == "price" || service == "travel") {
+		return http.StatusCreated
+	}
+	return http.StatusOK
+}

--- a/examples/evaluators/microservice/apps/trainticket/operations.go
+++ b/examples/evaluators/microservice/apps/trainticket/operations.go
@@ -44,7 +44,7 @@ func (a *Application) BuildOperation(operation api.Operation, sample api.Sample,
 	case operation.Name == "create_read_delete_config":
 		return a.buildEphemeral(operation, sample, data)
 	case strings.HasPrefix(operation.Name, "list_"):
-		return a.buildList(operation, service), nil
+		return a.buildList(operation, service, item), nil
 	case strings.HasPrefix(operation.Name, "read_"):
 		return a.buildRead(operation, service, item), nil
 	case strings.HasPrefix(operation.Name, "update_read_"):
@@ -62,17 +62,36 @@ func (a *Application) FinishOperation(plan api.OperationPlan) {
 	}
 }
 
-func (a *Application) buildList(operation api.Operation, service string) api.OperationPlan {
+func (a *Application) buildList(operation api.Operation, service string, item *record) api.OperationPlan {
 	paths := map[string]string{
 		"config": "/api/v1/configservice/configs", "station": "/api/v1/stationservice/stations",
 		"train": "/api/v1/trainservice/trains", "travel": "/api/v1/travelservice/trips",
 		"route": "/api/v1/routeservice/routes", "price": "/api/v1/priceservice/prices",
 	}
+	item.mu.Lock()
 	return api.OperationPlan{
 		Invocations: []api.Invocation{a.invocation(service, operation.Name, http.MethodGet, paths[service], nil)},
-		State: &operationState{expectations: []stepExpectation{{
-			status: http.StatusOK, appStatus: 1, kind: expectEntityList, service: service,
+		State: &operationState{locked: item, expectations: []stepExpectation{{
+			status: http.StatusOK, appStatus: 1, kind: expectEntityList,
+			service: service, expected: listExpectedValue(service, item),
 		}}},
+	}
+}
+
+func listExpectedValue(service string, item *record) any {
+	switch service {
+	case "config":
+		return item.config
+	case "station":
+		return item.stationA
+	case "train":
+		return item.train
+	case "route":
+		return item.route
+	case "price":
+		return item.price
+	default:
+		return item.trip
 	}
 }
 

--- a/examples/evaluators/microservice/apps/trainticket/operations.go
+++ b/examples/evaluators/microservice/apps/trainticket/operations.go
@@ -17,6 +17,7 @@ const (
 	expectEnvelope expectationKind = iota
 	expectExactData
 	expectEntityList
+	expectEntityAbsent
 )
 
 type stepExpectation struct {
@@ -29,7 +30,7 @@ type stepExpectation struct {
 
 type operationState struct {
 	expectations []stepExpectation
-	locked       *record
+	release      func()
 	commit       func()
 }
 
@@ -39,7 +40,9 @@ func (a *Application) BuildOperation(operation api.Operation, sample api.Sample,
 		return api.OperationPlan{}, fmt.Errorf("Train Ticket fixture is not prepared")
 	}
 	service := serviceFromOperation(operation.Name)
-	item := &data.records[sample.Random%uint64(len(data.records))]
+	itemIndex := sample.Random % uint64(len(data.records))
+	item := &data.records[itemIndex]
+	alternate := &data.records[(itemIndex+1)%uint64(len(data.records))]
 	switch {
 	case operation.Name == "create_read_delete_config":
 		return a.buildEphemeral(operation, sample, data)
@@ -48,7 +51,7 @@ func (a *Application) BuildOperation(operation api.Operation, sample api.Sample,
 	case strings.HasPrefix(operation.Name, "read_"):
 		return a.buildRead(operation, service, item), nil
 	case strings.HasPrefix(operation.Name, "update_read_"):
-		return a.buildUpdateRead(operation, service, item, sample), nil
+		return a.buildUpdateRead(operation, service, item, alternate, sample), nil
 	default:
 		return api.OperationPlan{}, fmt.Errorf("unsupported Train Ticket operation %q", operation.Name)
 	}
@@ -56,9 +59,9 @@ func (a *Application) BuildOperation(operation api.Operation, sample api.Sample,
 
 func (a *Application) FinishOperation(plan api.OperationPlan) {
 	state, ok := plan.State.(*operationState)
-	if ok && state.locked != nil {
-		state.locked.mu.Unlock()
-		state.locked = nil
+	if ok && state.release != nil {
+		state.release()
+		state.release = nil
 	}
 }
 
@@ -68,10 +71,10 @@ func (a *Application) buildList(operation api.Operation, service string, item *r
 		"train": "/api/v1/trainservice/trains", "travel": "/api/v1/travelservice/trips",
 		"route": "/api/v1/routeservice/routes", "price": "/api/v1/priceservice/prices",
 	}
-	item.mu.Lock()
+	item.mu.RLock()
 	return api.OperationPlan{
 		Invocations: []api.Invocation{a.invocation(service, operation.Name, http.MethodGet, paths[service], nil)},
-		State: &operationState{locked: item, expectations: []stepExpectation{{
+		State: &operationState{release: item.mu.RUnlock, expectations: []stepExpectation{{
 			status: http.StatusOK, appStatus: 1, kind: expectEntityList,
 			service: service, expected: listExpectedValue(service, item),
 		}}},
@@ -96,39 +99,72 @@ func listExpectedValue(service string, item *record) any {
 }
 
 func (a *Application) buildRead(operation api.Operation, service string, item *record) api.OperationPlan {
-	item.mu.Lock()
+	item.mu.RLock()
 	path, expected := readPathAndValue(service, item)
 	return api.OperationPlan{
 		Invocations: []api.Invocation{a.invocation(service, operation.Name, http.MethodGet, path, nil)},
-		State: &operationState{locked: item, expectations: []stepExpectation{{
+		State: &operationState{release: item.mu.RUnlock, expectations: []stepExpectation{{
 			status: http.StatusOK, appStatus: 1, kind: expectExactData, service: service, expected: expected,
 		}}},
 	}
 }
 
-func (a *Application) buildUpdateRead(operation api.Operation, service string, item *record, sample api.Sample) api.OperationPlan {
+func (a *Application) buildUpdateRead(operation api.Operation, service string, item, alternate *record, sample api.Sample) api.OperationPlan {
 	item.mu.Lock()
 	version := sample.Random ^ uint64(sample.Counter)*0x9e3779b97f4a7c15
-	method, path, body, readPath, expected, commit := updatedEntity(service, item, version)
+	retiredStationName := item.stationA.Name
+	retiredRouteStart := item.route.StartStationID
+	retiredRouteTerminal := item.route.TerminalStationID
+	retiredPriceRoute := item.price.RouteID
+	retiredPriceTrain := item.price.TrainType
+	method, path, body, readPath, expected, commit := updatedEntity(service, item, alternate, version)
+	invocations := []api.Invocation{
+		a.invocation(service, operation.Name, method, path, body),
+		a.invocation(service, operation.Name, http.MethodGet, readPath, nil),
+	}
+	expectations := []stepExpectation{
+		{status: expectedWriteStatus(service, method), appStatus: 1, kind: expectEnvelope, service: service},
+		{status: http.StatusOK, appStatus: 1, kind: expectExactData, service: service, expected: expected},
+	}
+	switch service {
+	case "station":
+		invocations = append(invocations, a.invocation(
+			service, operation.Name, http.MethodGet,
+			"/api/v1/stationservice/stations/id/"+url.PathEscape(retiredStationName), nil,
+		))
+		expectations = append(expectations, stepExpectation{
+			status: http.StatusOK, appStatus: 0, kind: expectEnvelope, service: service,
+		})
+	case "route":
+		invocations = append(invocations, a.invocation(
+			service, operation.Name, http.MethodGet,
+			"/api/v1/routeservice/routes/"+retiredRouteStart+"/"+retiredRouteTerminal, nil,
+		))
+		expectations = append(expectations, stepExpectation{
+			status: http.StatusOK, appStatus: 0, kind: expectEnvelope, service: service,
+		})
+	case "price":
+		invocations = append(invocations, a.invocation(
+			service, operation.Name, http.MethodGet,
+			"/api/v1/priceservice/prices/"+retiredPriceRoute+"/"+retiredPriceTrain, nil,
+		))
+		expectations = append(expectations, stepExpectation{
+			status: http.StatusOK, appStatus: 0, kind: expectEnvelope, service: service,
+		})
+	}
 	return api.OperationPlan{
-		Invocations: []api.Invocation{
-			a.invocation(service, operation.Name, method, path, body),
-			a.invocation(service, operation.Name, http.MethodGet, readPath, nil),
-		},
+		Invocations: invocations,
 		State: &operationState{
-			locked: item,
-			commit: commit,
-			expectations: []stepExpectation{
-				{status: expectedWriteStatus(service, method), appStatus: 1, kind: expectEnvelope, service: service},
-				{status: http.StatusOK, appStatus: 1, kind: expectExactData, service: service, expected: expected},
-			},
+			release:      item.mu.Unlock,
+			commit:       commit,
+			expectations: expectations,
 		},
 	}
 }
 
 func (a *Application) buildEphemeral(operation api.Operation, sample api.Sample, data *dataset) (api.OperationPlan, error) {
-	token := fmt.Sprintf("%s-ephemeral-%d-%016x", data.namespace, sample.Counter, sample.Random)
-	item := configEntity{Name: token, Value: strconv.FormatUint(sample.Random, 10), Description: token + "-description"}
+	token := fmt.Sprintf("%s%016x%016x", data.namespace, uint64(sample.Counter), sample.Random)
+	item := configEntity{Name: token, Value: strconv.FormatUint(sample.Random, 10), Description: fmt.Sprintf("d-%016x", sample.Random^0xa5a5a5a5a5a5a5a5)}
 	path := "/api/v1/configservice/configs/" + url.PathEscape(item.Name)
 	return api.OperationPlan{
 		Invocations: []api.Invocation{
@@ -136,12 +172,14 @@ func (a *Application) buildEphemeral(operation api.Operation, sample api.Sample,
 			a.invocation("config", operation.Name, http.MethodGet, path, nil),
 			a.invocation("config", operation.Name, http.MethodDelete, path, nil),
 			a.invocation("config", operation.Name, http.MethodGet, path, nil),
+			a.invocation("config", operation.Name, http.MethodGet, "/api/v1/configservice/configs", nil),
 		},
 		State: &operationState{expectations: []stepExpectation{
 			{status: http.StatusCreated, appStatus: 1, kind: expectEnvelope, service: "config"},
 			{status: http.StatusOK, appStatus: 1, kind: expectExactData, service: "config", expected: item},
 			{status: http.StatusOK, appStatus: 1, kind: expectEnvelope, service: "config"},
 			{status: http.StatusOK, appStatus: 0, kind: expectEnvelope, service: "config"},
+			{status: http.StatusOK, appStatus: 1, kind: expectEntityAbsent, service: "config", expected: item},
 		}},
 	}, nil
 }
@@ -163,7 +201,7 @@ func readPathAndValue(service string, item *record) (string, any) {
 	}
 }
 
-func updatedEntity(service string, item *record, version uint64) (method, path string, body any, readPath string, expected any, commit func()) {
+func updatedEntity(service string, item, alternate *record, version uint64) (method, path string, body any, readPath string, expected any, commit func()) {
 	switch service {
 	case "config":
 		updated := item.config
@@ -174,7 +212,8 @@ func updatedEntity(service string, item *record, version uint64) (method, path s
 			func() { item.config = updated }
 	case "station":
 		updated := item.stationA
-		updated.Name = fmt.Sprintf("Station-%016x", version)
+		namePrefixes := []string{"Renamed ", "Transfer Hub ", "换乘站 "}
+		updated.Name = fmt.Sprintf("%s%016x", namePrefixes[version%uint64(len(namePrefixes))], version)
 		updated.StayTime = 1 + int(version%120)
 		return http.MethodPut, "/api/v1/stationservice/stations", updated,
 			"/api/v1/stationservice/stations/name/" + updated.ID, updated.Name,
@@ -189,7 +228,20 @@ func updatedEntity(service string, item *record, version uint64) (method, path s
 	case "route":
 		updatedInput := item.routeIn
 		updatedRoute := item.route
-		updatedRoute.Stations = append([]string(nil), item.route.Stations...)
+		if item.route.StartStationID == item.stationA.ID {
+			updatedRoute.Stations = []string{item.stationB.ID, item.stationA.ID}
+			updatedRoute.StartStationID = item.stationB.ID
+			updatedRoute.TerminalStationID = item.stationA.ID
+			updatedInput.StartStation = item.stationB.ID
+			updatedInput.EndStation = item.stationA.ID
+		} else {
+			updatedRoute.Stations = []string{item.stationA.ID, item.stationB.ID}
+			updatedRoute.StartStationID = item.stationA.ID
+			updatedRoute.TerminalStationID = item.stationB.ID
+			updatedInput.StartStation = item.stationA.ID
+			updatedInput.EndStation = item.stationB.ID
+		}
+		updatedInput.StationList = strings.Join(updatedRoute.Stations, ",")
 		updatedRoute.Distances = append([]int(nil), item.route.Distances...)
 		updatedRoute.Distances[1] = 100 + int(version%1800)
 		updatedInput.DistanceList = fmt.Sprintf("0,%d", updatedRoute.Distances[1])
@@ -198,6 +250,13 @@ func updatedEntity(service string, item *record, version uint64) (method, path s
 			func() { item.routeIn, item.route = updatedInput, updatedRoute }
 	case "price":
 		updated := item.price
+		if updated.RouteID == alternate.route.ID && updated.TrainType == item.train.ID {
+			updated.RouteID = item.route.ID
+			updated.TrainType = item.train.ID
+		} else {
+			updated.RouteID = alternate.route.ID
+			updated.TrainType = item.train.ID
+		}
 		updated.BasicPriceRate = 0.1 + float64(version%8000)/10000
 		updated.FirstClassPriceRate = 0.9 + float64((version>>8)%10000)/10000
 		return http.MethodPut, "/api/v1/priceservice/prices", updated,

--- a/examples/evaluators/microservice/apps/trainticket/trainticket_test.go
+++ b/examples/evaluators/microservice/apps/trainticket/trainticket_test.go
@@ -81,6 +81,44 @@ func TestEphemeralPlanIncludesNegativeReadAfterDelete(t *testing.T) {
 	}
 }
 
+func TestListPlanRejectsSchemaValidListThatOmitsSelectedRuntimeRecord(t *testing.T) {
+	application := &Application{token: "token"}
+	data := &dataset{namespace: "test", records: makeRecords("test", 7, 2)}
+	operation := api.Operation{Name: "list_config", Target: "config"}
+	plan, err := application.BuildOperation(operation, api.Sample{Random: 0}, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validation := application.ValidateOperation(operation, plan, []api.ProtocolResult{
+		httpResult(http.StatusOK, 1, []configEntity{data.records[1].config}),
+	})
+	application.FinishOperation(plan)
+	if validation.Success || validation.ErrorCategory != "response_value" {
+		t.Fatalf("list without selected record unexpectedly passed: %+v", validation)
+	}
+}
+
+func TestEphemeralPlanRejectsNoOpDelete(t *testing.T) {
+	application := &Application{token: "token"}
+	data := &dataset{namespace: "test", records: makeRecords("test", 7, 2)}
+	operation := api.Operation{Name: "create_read_delete_config", Target: "config"}
+	plan, err := application.BuildOperation(operation, api.Sample{Counter: 1, Random: 2}, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := plan.State.(*operationState).expectations[1].expected
+	validation := application.ValidateOperation(operation, plan, []api.ProtocolResult{
+		httpResult(http.StatusCreated, 1, nil),
+		httpResult(http.StatusOK, 1, created),
+		httpResult(http.StatusOK, 1, nil),
+		httpResult(http.StatusOK, 1, created),
+	})
+	application.FinishOperation(plan)
+	if validation.Success || validation.ErrorCategory != "read_your_write" {
+		t.Fatalf("no-op delete unexpectedly passed: %+v", validation)
+	}
+}
+
 func httpResult(status, appStatus int, data any) api.ProtocolResult {
 	body, _ := json.Marshal(map[string]any{"status": appStatus, "msg": "ok", "data": data})
 	return api.ProtocolResult{

--- a/examples/evaluators/microservice/apps/trainticket/trainticket_test.go
+++ b/examples/evaluators/microservice/apps/trainticket/trainticket_test.go
@@ -1,0 +1,102 @@
+package trainticket
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"vibesys/microservice-evaluator/api"
+)
+
+func TestMakeRecordsIsDeterministicAndConnectedWithoutSeedCatalogDependency(t *testing.T) {
+	first := makeRecords("namespace", 42, 3)
+	second := makeRecords("namespace", 42, 3)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("same namespace and seed produced different records")
+	}
+	for index := range first {
+		item := &first[index]
+		if item.route.StartStationID != item.stationA.ID || item.route.TerminalStationID != item.stationB.ID {
+			t.Fatalf("record %d route does not connect its generated stations", index)
+		}
+		if item.price.RouteID != item.route.ID || item.trip.RouteID != item.route.ID {
+			t.Fatalf("record %d price/trip does not reference its route", index)
+		}
+		if item.price.TrainType != item.train.ID || item.trip.TrainTypeID != item.train.ID {
+			t.Fatalf("record %d price/trip does not reference its train", index)
+		}
+	}
+}
+
+func TestNewRejectsUnknownApplicationConfiguration(t *testing.T) {
+	workload := trainTicketWorkload()
+	workload.ApplicationConfig = map[string]any{"recrods": int64(2)}
+	if _, err := New(workload); err == nil {
+		t.Fatal("misspelled application configuration was accepted")
+	}
+}
+
+func TestUpdateReadPlanCommitsAcknowledgedValueAndDetectsStaleRead(t *testing.T) {
+	application := &Application{token: "token"}
+	data := &dataset{namespace: "test", records: makeRecords("test", 7, 2)}
+	operation := api.Operation{Name: "update_read_config", Target: "config"}
+	plan, err := application.BuildOperation(operation, api.Sample{Counter: 3, Random: 9}, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := plan.State.(*operationState)
+	want := state.expectations[1].expected.(configEntity)
+	stale := data.records[1].config
+	validation := application.ValidateOperation(operation, plan, []api.ProtocolResult{
+		httpResult(http.StatusOK, 1, nil),
+		httpResult(http.StatusOK, 1, stale),
+	})
+	application.FinishOperation(plan)
+	if validation.Success || validation.ErrorCategory != "read_your_write" {
+		t.Fatalf("stale read unexpectedly passed: %+v", validation)
+	}
+	if data.records[1].config != want {
+		t.Fatalf("acknowledged write was not committed to the oracle: got %+v, want %+v", data.records[1].config, want)
+	}
+}
+
+func TestEphemeralPlanIncludesNegativeReadAfterDelete(t *testing.T) {
+	application := &Application{token: "token"}
+	data := &dataset{namespace: "test", records: makeRecords("test", 7, 2)}
+	plan, err := application.BuildOperation(
+		api.Operation{Name: "create_read_delete_config", Target: "config"},
+		api.Sample{Counter: 1, Random: 2},
+		data,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Invocations) != 4 {
+		t.Fatalf("ephemeral operation has %d invocations, want 4", len(plan.Invocations))
+	}
+	state := plan.State.(*operationState)
+	if got := state.expectations[3].appStatus; got != 0 {
+		t.Fatalf("negative read expects application status %d, want 0", got)
+	}
+}
+
+func httpResult(status, appStatus int, data any) api.ProtocolResult {
+	body, _ := json.Marshal(map[string]any{"status": appStatus, "msg": "ok", "data": data})
+	return api.ProtocolResult{
+		TransportSuccess: true,
+		NativeStatus:     "test",
+		Payload:          api.HTTPResponse{StatusCode: status, Body: body},
+	}
+}
+
+func trainTicketWorkload() api.Workload {
+	targets := make([]api.Target, 0, len(services))
+	for _, service := range services {
+		targets = append(targets, api.Target{Name: service, Protocol: "http"})
+	}
+	return api.Workload{
+		Targets:    targets,
+		Operations: []api.Operation{{Name: "read_config", Target: "config"}},
+	}
+}

--- a/examples/evaluators/microservice/apps/trainticket/trainticket_test.go
+++ b/examples/evaluators/microservice/apps/trainticket/trainticket_test.go
@@ -1,10 +1,14 @@
 package trainticket
 
 import (
+	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"vibesys/microservice-evaluator/api"
 )
@@ -26,6 +30,33 @@ func TestMakeRecordsIsDeterministicAndConnectedWithoutSeedCatalogDependency(t *t
 		if item.price.TrainType != item.train.ID || item.trip.TrainTypeID != item.train.ID {
 			t.Fatalf("record %d price/trip does not reference its train", index)
 		}
+	}
+}
+
+func TestAdminTokenUsesRandomModeNeutralIdentity(t *testing.T) {
+	first := makeAdminToken(time.Unix(1_000, 0))
+	second := makeAdminToken(time.Unix(1_000, 0))
+	if first == second {
+		t.Fatal("admin token identity was reused")
+	}
+	parts := strings.Split(first, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token has %d parts, want 3", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatal(err)
+	}
+	identity, ok := claims["sub"].(string)
+	if !ok || claims["id"] != identity || len(identity) != 24 {
+		t.Fatalf("unexpected identity claims: %+v", claims)
+	}
+	if strings.Contains(identity, "checker") || strings.Contains(identity, "benchmark") {
+		t.Fatalf("mode-specific identity leaked in %q", identity)
 	}
 }
 
@@ -61,6 +92,111 @@ func TestUpdateReadPlanCommitsAcknowledgedValueAndDetectsStaleRead(t *testing.T)
 	}
 }
 
+func TestReadPlansOnSameFixtureDoNotSerialize(t *testing.T) {
+	application := &Application{token: "token"}
+	data := &dataset{namespace: "test", records: makeRecords("test", 7, 2)}
+	operation := api.Operation{Name: "read_config", Target: "config"}
+	first, err := application.BuildOperation(operation, api.Sample{Random: 0}, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer application.FinishOperation(first)
+
+	secondPlan := make(chan api.OperationPlan, 1)
+	secondError := make(chan error, 1)
+	go func() {
+		plan, buildErr := application.BuildOperation(operation, api.Sample{Random: 0}, data)
+		if buildErr != nil {
+			secondError <- buildErr
+			return
+		}
+		secondPlan <- plan
+	}()
+
+	select {
+	case plan := <-secondPlan:
+		application.FinishOperation(plan)
+	case buildErr := <-secondError:
+		t.Fatal(buildErr)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("read-only plans on the same fixture were serialized")
+	}
+}
+
+type fixtureRuntime struct {
+	failCreateCall int
+	failDeletePath string
+	createCalls    int
+	deletePaths    []string
+}
+
+func (r *fixtureRuntime) Invoke(_ context.Context, invocation api.Invocation) api.ProtocolResult {
+	request := invocation.Payload.(api.HTTPRequestSpec)
+	if request.Method == http.MethodDelete {
+		r.deletePaths = append(r.deletePaths, request.Path)
+		if request.Path == r.failDeletePath {
+			return api.ProtocolResult{ErrorCategory: "injected", ErrorMessage: "delete failed"}
+		}
+	}
+	if request.Method == http.MethodPost {
+		r.createCalls++
+		if r.createCalls == r.failCreateCall {
+			return api.ProtocolResult{ErrorCategory: "injected", ErrorMessage: "create failed"}
+		}
+	}
+	status := http.StatusOK
+	if request.Method == http.MethodPost && (strings.Contains(request.Path, "configservice") ||
+		strings.Contains(request.Path, "stationservice") || strings.Contains(request.Path, "priceservice") ||
+		strings.Contains(request.Path, "travelservice")) {
+		status = http.StatusCreated
+	}
+	return httpResult(status, 1, nil)
+}
+
+func TestPartialFixtureCreationCleansSuccessfulSteps(t *testing.T) {
+	application := &Application{token: "token"}
+	records := makeRecords("test", 7, 1)
+	item := &records[0]
+	runtime := &fixtureRuntime{failCreateCall: 2}
+
+	if err := application.createRecord(context.Background(), runtime, item); err == nil {
+		t.Fatal("injected fixture create failure unexpectedly passed")
+	}
+	if len(runtime.deletePaths) != 1 || !strings.Contains(runtime.deletePaths[0], "configservice") {
+		t.Fatalf("partial fixture cleanup did not delete the created config: %v", runtime.deletePaths)
+	}
+	for index, created := range item.created {
+		if created {
+			t.Fatalf("fixture step %d remained marked created", index)
+		}
+	}
+}
+
+func TestFixtureCleanupContinuesAfterDeleteFailure(t *testing.T) {
+	application := &Application{token: "token"}
+	records := makeRecords("test", 7, 1)
+	item := &records[0]
+	for index := range item.created {
+		item.created[index] = true
+	}
+	runtime := &fixtureRuntime{failDeletePath: "/api/v1/travelservice/trips/" + item.tripIn.TripID}
+
+	if err := application.deleteRecord(context.Background(), runtime, item); err == nil {
+		t.Fatal("injected fixture delete failure unexpectedly passed")
+	}
+	if len(runtime.deletePaths) != len(item.created) {
+		t.Fatalf("cleanup attempted %d deletes, want %d", len(runtime.deletePaths), len(item.created))
+	}
+	if !item.created[6] {
+		t.Fatal("failed delete was incorrectly marked clean")
+	}
+	for index := 0; index < 6; index++ {
+		if item.created[index] {
+			t.Fatalf("successful delete step %d remained marked created", index)
+		}
+	}
+}
+
 func TestEphemeralPlanIncludesNegativeReadAfterDelete(t *testing.T) {
 	application := &Application{token: "token"}
 	data := &dataset{namespace: "test", records: makeRecords("test", 7, 2)}
@@ -72,8 +208,8 @@ func TestEphemeralPlanIncludesNegativeReadAfterDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(plan.Invocations) != 4 {
-		t.Fatalf("ephemeral operation has %d invocations, want 4", len(plan.Invocations))
+	if len(plan.Invocations) != 5 {
+		t.Fatalf("ephemeral operation has %d invocations, want 5", len(plan.Invocations))
 	}
 	state := plan.State.(*operationState)
 	if got := state.expectations[3].appStatus; got != 0 {
@@ -98,6 +234,77 @@ func TestListPlanRejectsSchemaValidListThatOmitsSelectedRuntimeRecord(t *testing
 	}
 }
 
+func TestListPlanRejectsDuplicateEntityKeys(t *testing.T) {
+	application := &Application{token: "token"}
+	data := &dataset{namespace: "test", records: makeRecords("test", 7, 2)}
+	operation := api.Operation{Name: "list_train", Target: "train"}
+	plan, err := application.BuildOperation(operation, api.Sample{Random: 0}, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected := data.records[0].train
+	stale := selected
+	stale.AverageSpeed++
+	validation := application.ValidateOperation(operation, plan, []api.ProtocolResult{
+		httpResult(http.StatusOK, 1, []trainEntity{selected, stale}),
+	})
+	application.FinishOperation(plan)
+	if validation.Success || validation.ErrorCategory != "response_value" {
+		t.Fatalf("duplicate list key unexpectedly passed: %+v", validation)
+	}
+}
+
+func TestListPlanRejectsInvalidValuesInUnselectedRecords(t *testing.T) {
+	application := &Application{token: "token"}
+	data := &dataset{namespace: "test", records: makeRecords("test", 7, 2)}
+	operation := api.Operation{Name: "list_station", Target: "station"}
+	plan, err := application.BuildOperation(operation, api.Sample{Random: 0}, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	corrupt := map[string]any{
+		"id": data.records[1].stationA.ID, "name": data.records[1].stationA.Name, "stayTime": "not-an-integer",
+	}
+	validation := application.ValidateOperation(operation, plan, []api.ProtocolResult{
+		httpResult(http.StatusOK, 1, []any{data.records[0].stationA, corrupt}),
+	})
+	application.FinishOperation(plan)
+	if validation.Success || validation.ErrorCategory != "response_schema" {
+		t.Fatalf("invalid unselected list value unexpectedly passed: %+v", validation)
+	}
+}
+
+func TestUpdatePlansChangeAndProbeMutableSecondaryKeys(t *testing.T) {
+	for _, service := range []string{"station", "route", "price"} {
+		t.Run(service, func(t *testing.T) {
+			application := &Application{token: "token"}
+			data := &dataset{namespace: "test", records: makeRecords("test", 7, 2)}
+			operation := api.Operation{Name: "update_read_" + service, Target: service}
+			plan, err := application.BuildOperation(operation, api.Sample{Counter: 3, Random: 0}, data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer application.FinishOperation(plan)
+			if len(plan.Invocations) != 3 {
+				t.Fatalf("%s update has %d invocations, want update/read/retired-index probe", service, len(plan.Invocations))
+			}
+			retiredProbe := plan.Invocations[2].Payload.(api.HTTPRequestSpec).Path
+			if service == "route" {
+				expected := plan.State.(*operationState).expectations[1].expected.(routeEntity)
+				if strings.Contains(retiredProbe, expected.StartStationID+"/"+expected.TerminalStationID) {
+					t.Fatalf("route retired probe uses the new secondary key: %s", retiredProbe)
+				}
+			}
+			if service == "price" {
+				expected := plan.State.(*operationState).expectations[1].expected.(priceEntity)
+				if strings.Contains(retiredProbe, expected.RouteID+"/"+expected.TrainType) {
+					t.Fatalf("price retired probe uses the new secondary key: %s", retiredProbe)
+				}
+			}
+		})
+	}
+}
+
 func TestEphemeralPlanRejectsNoOpDelete(t *testing.T) {
 	application := &Application{token: "token"}
 	data := &dataset{namespace: "test", records: makeRecords("test", 7, 2)}
@@ -112,10 +319,35 @@ func TestEphemeralPlanRejectsNoOpDelete(t *testing.T) {
 		httpResult(http.StatusOK, 1, created),
 		httpResult(http.StatusOK, 1, nil),
 		httpResult(http.StatusOK, 1, created),
+		httpResult(http.StatusOK, 1, []configEntity{}),
 	})
 	application.FinishOperation(plan)
 	if validation.Success || validation.ErrorCategory != "read_your_write" {
 		t.Fatalf("no-op delete unexpectedly passed: %+v", validation)
+	}
+}
+
+func TestEphemeralPlanRejectsDeletedRecordRetainedOnlyInList(t *testing.T) {
+	application := &Application{token: "token"}
+	data := &dataset{namespace: "test", records: makeRecords("test", 7, 2)}
+	operation := api.Operation{Name: "create_read_delete_config", Target: "config"}
+	plan, err := application.BuildOperation(operation, api.Sample{Counter: 1, Random: 2}, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := plan.State.(*operationState).expectations[1].expected.(configEntity)
+	stale := created
+	stale.Value = "stale-version"
+	validation := application.ValidateOperation(operation, plan, []api.ProtocolResult{
+		httpResult(http.StatusCreated, 1, nil),
+		httpResult(http.StatusOK, 1, created),
+		httpResult(http.StatusOK, 1, nil),
+		httpResult(http.StatusOK, 0, nil),
+		httpResult(http.StatusOK, 1, []configEntity{stale}),
+	})
+	application.FinishOperation(plan)
+	if validation.Success || validation.ErrorCategory != "response_value" {
+		t.Fatalf("list-only delete leak unexpectedly passed: %+v", validation)
 	}
 }
 

--- a/examples/evaluators/microservice/apps/trainticket/validation.go
+++ b/examples/evaluators/microservice/apps/trainticket/validation.go
@@ -1,0 +1,138 @@
+package trainticket
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"vibesys/microservice-evaluator/api"
+)
+
+var entityFields = map[string][]string{
+	"config":  {"description", "name", "value"},
+	"station": {"id", "name", "stayTime"},
+	"train":   {"averageSpeed", "confortClass", "economyClass", "id"},
+	"travel":  {"endTime", "routeId", "startingStationId", "startingTime", "stationsId", "terminalStationId", "trainTypeId", "tripId"},
+	"route":   {"distances", "id", "startStationId", "stations", "terminalStationId"},
+	"price":   {"basicPriceRate", "firstClassPriceRate", "id", "routeId", "trainType"},
+}
+
+func (a *Application) ValidateOperation(operation api.Operation, plan api.OperationPlan, results []api.ProtocolResult) api.ValidationResult {
+	state, ok := plan.State.(*operationState)
+	if !ok {
+		return invalid("invalid_plan", fmt.Sprintf("unexpected Train Ticket plan state %T", plan.State))
+	}
+	if len(results) != len(state.expectations) {
+		return invalid("result_count", fmt.Sprintf("got %d protocol results, want %d", len(results), len(state.expectations)))
+	}
+	for index, expectation := range state.expectations {
+		validation := validateStep(results[index], expectation)
+		if index == 0 && state.commit != nil && validation.Success {
+			state.commit()
+			state.commit = nil
+		}
+		if !validation.Success {
+			isReadYourWrite := strings.HasPrefix(operation.Name, "update_read_") && index == 1
+			isEphemeralRead := operation.Name == "create_read_delete_config" && (index == 1 || index == 3)
+			if isReadYourWrite || isEphemeralRead {
+				validation.ErrorCategory = "read_your_write"
+			}
+			validation.ErrorMessage = fmt.Sprintf("step %d: %s", index+1, validation.ErrorMessage)
+			return validation
+		}
+	}
+	return api.ValidationResult{Success: true}
+}
+
+func validateStep(result api.ProtocolResult, expectation stepExpectation) api.ValidationResult {
+	base := validateEnvelopeResult(result, expectation.status, expectation.appStatus)
+	if !base.Success {
+		return base
+	}
+	response := result.Payload.(api.HTTPResponse)
+	var envelope map[string]any
+	_ = json.Unmarshal(response.Body, &envelope)
+	data := envelope["data"]
+	switch expectation.kind {
+	case expectExactData:
+		expected, err := normalizedJSON(expectation.expected)
+		if err != nil {
+			return invalid("validator", err.Error())
+		}
+		if !reflect.DeepEqual(data, expected) {
+			return invalid("response_value", fmt.Sprintf("data mismatch: got %v, want %v", data, expected))
+		}
+	case expectEntityList:
+		items, ok := data.([]any)
+		if !ok || len(items) == 0 {
+			return invalid("response_shape", fmt.Sprintf("%s list data must be a non-empty array", expectation.service))
+		}
+		want := entityFields[expectation.service]
+		for index, item := range items {
+			object, objectOK := item.(map[string]any)
+			if !objectOK {
+				return invalid("response_shape", fmt.Sprintf("%s list item %d is not an object", expectation.service, index))
+			}
+			keys := make([]string, 0, len(object))
+			for key := range object {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			if !reflect.DeepEqual(keys, want) {
+				return invalid("response_schema", fmt.Sprintf("%s list item %d fields %v, want %v", expectation.service, index, keys, want))
+			}
+		}
+	}
+	return api.ValidationResult{Success: true}
+}
+
+func validateEnvelopeResult(result api.ProtocolResult, httpStatus, appStatus int) api.ValidationResult {
+	if !result.TransportSuccess {
+		return invalid(result.ErrorCategory, result.ErrorMessage)
+	}
+	response, ok := result.Payload.(api.HTTPResponse)
+	if !ok {
+		return invalid("invalid_response", fmt.Sprintf("expected HTTP response, got %T", result.Payload))
+	}
+	if response.StatusCode != httpStatus {
+		return invalid("http_status", fmt.Sprintf("HTTP %d, want %d", response.StatusCode, httpStatus))
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal(response.Body, &envelope); err != nil {
+		return invalid("response_json", err.Error())
+	}
+	keys := make([]string, 0, len(envelope))
+	for key := range envelope {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if !reflect.DeepEqual(keys, []string{"data", "msg", "status"}) {
+		return invalid("response_schema", fmt.Sprintf("envelope fields %v, want [data msg status]", keys))
+	}
+	status, ok := envelope["status"].(float64)
+	if !ok || status != float64(appStatus) {
+		return invalid("application_status", fmt.Sprintf("application status %v, want %d", envelope["status"], appStatus))
+	}
+	if _, ok := envelope["msg"].(string); !ok {
+		return invalid("response_schema", "envelope msg must be a string")
+	}
+	return api.ValidationResult{Success: true}
+}
+
+func normalizedJSON(value any) (any, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode expected value: %w", err)
+	}
+	var normalized any
+	if err := json.Unmarshal(encoded, &normalized); err != nil {
+		return nil, fmt.Errorf("normalize expected value: %w", err)
+	}
+	return normalized, nil
+}
+
+func invalid(category, message string) api.ValidationResult {
+	return api.ValidationResult{ErrorCategory: category, ErrorMessage: message}
+}

--- a/examples/evaluators/microservice/apps/trainticket/validation.go
+++ b/examples/evaluators/microservice/apps/trainticket/validation.go
@@ -3,6 +3,7 @@ package trainticket
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"sort"
 	"strings"
@@ -64,9 +65,12 @@ func validateStep(result api.ProtocolResult, expectation stepExpectation) api.Va
 		if !reflect.DeepEqual(data, expected) {
 			return invalid("response_value", fmt.Sprintf("data mismatch: got %v, want %v", data, expected))
 		}
-	case expectEntityList:
+	case expectEntityList, expectEntityAbsent:
 		items, ok := data.([]any)
-		if !ok || len(items) == 0 {
+		if !ok {
+			return invalid("response_shape", fmt.Sprintf("%s list data must be an array", expectation.service))
+		}
+		if expectation.kind == expectEntityList && len(items) == 0 {
 			return invalid("response_shape", fmt.Sprintf("%s list data must be a non-empty array", expectation.service))
 		}
 		want := entityFields[expectation.service]
@@ -74,7 +78,19 @@ func validateStep(result api.ProtocolResult, expectation stepExpectation) api.Va
 		if err != nil {
 			return invalid("validator", err.Error())
 		}
+		expectedKey := ""
+		if expectation.kind == expectEntityAbsent {
+			expectedObject, objectOK := expected.(map[string]any)
+			if !objectOK {
+				return invalid("validator", fmt.Sprintf("expected %s entity must be an object", expectation.service))
+			}
+			expectedKey, err = entityKey(expectation.service, expectedObject)
+			if err != nil {
+				return invalid("validator", err.Error())
+			}
+		}
 		foundExpected := false
+		seen := make(map[string]struct{}, len(items))
 		for index, item := range items {
 			object, objectOK := item.(map[string]any)
 			if !objectOK {
@@ -88,18 +104,133 @@ func validateStep(result api.ProtocolResult, expectation stepExpectation) api.Va
 			if !reflect.DeepEqual(keys, want) {
 				return invalid("response_schema", fmt.Sprintf("%s list item %d fields %v, want %v", expectation.service, index, keys, want))
 			}
-			if reflect.DeepEqual(item, expected) {
+			if valueErr := validateEntityValue(expectation.service, object); valueErr != nil {
+				return invalid("response_schema", fmt.Sprintf("%s list item %d: %v", expectation.service, index, valueErr))
+			}
+			key, keyErr := entityKey(expectation.service, object)
+			if keyErr != nil {
+				return invalid("response_schema", fmt.Sprintf("%s list item %d: %v", expectation.service, index, keyErr))
+			}
+			if _, duplicate := seen[key]; duplicate {
+				return invalid("response_value", fmt.Sprintf("%s list contains duplicate key %q", expectation.service, key))
+			}
+			seen[key] = struct{}{}
+			if (expectation.kind == expectEntityList && reflect.DeepEqual(item, expected)) ||
+				(expectation.kind == expectEntityAbsent && key == expectedKey) {
 				foundExpected = true
 			}
 		}
-		if !foundExpected {
+		if expectation.kind == expectEntityList && !foundExpected {
 			return invalid(
 				"response_value",
 				fmt.Sprintf("%s list omitted or returned stale selected runtime record", expectation.service),
 			)
 		}
+		if expectation.kind == expectEntityAbsent && foundExpected {
+			return invalid("response_value", fmt.Sprintf("deleted %s record remains visible in list", expectation.service))
+		}
 	}
 	return api.ValidationResult{Success: true}
+}
+
+func validateEntityValue(service string, object map[string]any) error {
+	requireString := func(field string) error {
+		if _, ok := object[field].(string); !ok {
+			return fmt.Errorf("%s must be a string", field)
+		}
+		return nil
+	}
+	requireInteger := func(field string) error {
+		value, ok := object[field].(float64)
+		if !ok || math.Trunc(value) != value {
+			return fmt.Errorf("%s must be an integer", field)
+		}
+		return nil
+	}
+	stringFields := map[string][]string{
+		"config":  {"name", "value", "description"},
+		"station": {"id", "name"},
+		"train":   {"id"},
+		"travel":  {"trainTypeId", "routeId", "startingStationId", "stationsId", "terminalStationId"},
+		"route":   {"id", "startStationId", "terminalStationId"},
+		"price":   {"id", "trainType", "routeId"},
+	}
+	for _, field := range stringFields[service] {
+		if err := requireString(field); err != nil {
+			return err
+		}
+	}
+	switch service {
+	case "station":
+		return requireInteger("stayTime")
+	case "train":
+		for _, field := range []string{"economyClass", "confortClass", "averageSpeed"} {
+			if err := requireInteger(field); err != nil {
+				return err
+			}
+		}
+	case "route":
+		stations, stationsOK := object["stations"].([]any)
+		distances, distancesOK := object["distances"].([]any)
+		if !stationsOK || !distancesOK || len(stations) != len(distances) {
+			return fmt.Errorf("stations and distances must be equal-length arrays")
+		}
+		for _, station := range stations {
+			if _, ok := station.(string); !ok {
+				return fmt.Errorf("stations must contain strings")
+			}
+		}
+		for _, distance := range distances {
+			value, ok := distance.(float64)
+			if !ok || math.Trunc(value) != value {
+				return fmt.Errorf("distances must contain integers")
+			}
+		}
+	case "price":
+		for _, field := range []string{"basicPriceRate", "firstClassPriceRate"} {
+			value, ok := object[field].(float64)
+			if !ok || math.IsNaN(value) || math.IsInf(value, 0) {
+				return fmt.Errorf("%s must be numeric", field)
+			}
+		}
+	case "travel":
+		if _, err := entityKey(service, object); err != nil {
+			return err
+		}
+		for _, field := range []string{"startingTime", "endTime"} {
+			if err := requireInteger(field); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func entityKey(service string, object map[string]any) (string, error) {
+	field := "id"
+	if service == "config" {
+		field = "name"
+	}
+	if service == "travel" {
+		trip, ok := object["tripId"].(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("tripId must be an object")
+		}
+		if len(trip) != 2 {
+			return "", fmt.Errorf("tripId must contain exactly type and number")
+		}
+		kind, kindOK := trip["type"].(string)
+		number, numberOK := trip["number"].(string)
+		if !kindOK || (kind != "G" && kind != "D") || !numberOK || number == "" {
+			return "", fmt.Errorf("tripId must have type G or D and a non-empty string number")
+		}
+		return kind + number, nil
+	}
+	key, ok := object[field].(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string", field)
+	}
+	return key, nil
 }
 
 func validateEnvelopeResult(result api.ProtocolResult, httpStatus, appStatus int) api.ValidationResult {

--- a/examples/evaluators/microservice/apps/trainticket/validation.go
+++ b/examples/evaluators/microservice/apps/trainticket/validation.go
@@ -70,6 +70,11 @@ func validateStep(result api.ProtocolResult, expectation stepExpectation) api.Va
 			return invalid("response_shape", fmt.Sprintf("%s list data must be a non-empty array", expectation.service))
 		}
 		want := entityFields[expectation.service]
+		expected, err := normalizedJSON(expectation.expected)
+		if err != nil {
+			return invalid("validator", err.Error())
+		}
+		foundExpected := false
 		for index, item := range items {
 			object, objectOK := item.(map[string]any)
 			if !objectOK {
@@ -83,6 +88,15 @@ func validateStep(result api.ProtocolResult, expectation stepExpectation) api.Va
 			if !reflect.DeepEqual(keys, want) {
 				return invalid("response_schema", fmt.Sprintf("%s list item %d fields %v, want %v", expectation.service, index, keys, want))
 			}
+			if reflect.DeepEqual(item, expected) {
+				foundExpected = true
+			}
+		}
+		if !foundExpected {
+			return invalid(
+				"response_value",
+				fmt.Sprintf("%s list omitted or returned stale selected runtime record", expectation.service),
+			)
 		}
 	}
 	return api.ValidationResult{Success: true}

--- a/examples/evaluators/microservice/cmd/README.md
+++ b/examples/evaluators/microservice/cmd/README.md
@@ -8,4 +8,4 @@ Reusable scheduling, transport, configuration, and application behavior must
 remain in their owning packages rather than accumulating in a command. This
 keeps the command thin and makes the core testable with fake extensions.
 
-`microbench/` is currently the only command.
+`servicebench/` is currently the only command.

--- a/examples/evaluators/microservice/cmd/servicebench/README.md
+++ b/examples/evaluators/microservice/cmd/servicebench/README.md
@@ -1,4 +1,4 @@
-# `microbench` command
+# `servicebench` command
 
 This package is the CLI entry point for running a microservice workload. It is
 the composition root that registers the built-in HTTP driver and application

--- a/examples/evaluators/microservice/cmd/servicebench/main.go
+++ b/examples/evaluators/microservice/cmd/servicebench/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bufio"
 	"context"
+	cryptorand "crypto/rand"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -19,6 +21,7 @@ import (
 	"vibesys/microservice-evaluator/api"
 	"vibesys/microservice-evaluator/apps/declarative"
 	"vibesys/microservice-evaluator/apps/socialnetwork"
+	"vibesys/microservice-evaluator/apps/trainticket"
 	"vibesys/microservice-evaluator/config"
 	"vibesys/microservice-evaluator/drivers/httpdriver"
 	"vibesys/microservice-evaluator/engine"
@@ -44,7 +47,7 @@ func (o *targetOverrides) Set(value string) error {
 
 func main() {
 	if err := run(); err != nil {
-		fmt.Fprintln(os.Stderr, "microbench:", err)
+		fmt.Fprintln(os.Stderr, "servicebench:", err)
 		os.Exit(1)
 	}
 }
@@ -68,17 +71,17 @@ func run() error {
 	flag.StringVar(&workloadPath, "workload", "", "path to the workload TOML file")
 	flag.StringVar(&profile, "profile", "", "optional named workload profile")
 	flag.StringVar(&outputJSON, "output-json", "", "optional structured result path")
-	flag.StringVar(&outputRaw, "output-raw", "", "optional per-request NDJSON path")
+	flag.StringVar(&outputRaw, "output-raw", "", "optional per-operation NDJSON path")
 	flag.StringVar(&baseURL, "base-url", "", "override every HTTP target address")
 	flag.BoolVar(&skipPrepare, "skip-prepare", false, "skip application fixture preparation")
 	flag.BoolVar(&validateOnly, "validate-only", false, "validate configuration and registered extensions without connecting")
 	flag.Var(&overrides, "target", "override a target address as NAME=ADDRESS (repeatable)")
-	flag.Float64Var(&rate, "rate", 0, "override target requests per second")
+	flag.Float64Var(&rate, "rate", 0, "override open-loop target logical operations per second")
 	flag.Float64Var(&duration, "duration", 0, "override measured duration in seconds")
 	flag.Float64Var(&warmup, "warmup", -1, "override warmup duration in seconds")
-	flag.IntVar(&concurrency, "concurrency", 0, "override maximum in-flight requests")
+	flag.IntVar(&concurrency, "concurrency", 0, "override maximum in-flight logical operations")
 	flag.IntVar(&repetitions, "repetitions", 0, "override independent trial count")
-	flag.StringVar(&seed, "seed", "", "override deterministic random seed")
+	flag.StringVar(&seed, "seed", "", "override deterministic random seed, or use 'random'")
 	flag.Parse()
 	if workloadPath == "" {
 		return errors.New("--workload is required")
@@ -104,9 +107,19 @@ func run() error {
 		workload.Load.Repetitions = repetitions
 	}
 	if seed != "" {
-		parsed, parseErr := strconv.ParseInt(seed, 10, 64)
-		if parseErr != nil {
-			return fmt.Errorf("invalid --seed: %w", parseErr)
+		var parsed int64
+		if seed == "random" {
+			var raw [8]byte
+			if _, randomErr := cryptorand.Read(raw[:]); randomErr != nil {
+				return fmt.Errorf("generate random --seed: %w", randomErr)
+			}
+			parsed = int64(binary.LittleEndian.Uint64(raw[:]) & uint64(^uint64(0)>>1))
+		} else {
+			var parseErr error
+			parsed, parseErr = strconv.ParseInt(seed, 10, 64)
+			if parseErr != nil {
+				return fmt.Errorf("invalid --seed: %w", parseErr)
+			}
 		}
 		workload.Load.Seed = parsed
 	}
@@ -139,6 +152,9 @@ func run() error {
 		return err
 	}
 	if err := registry.RegisterApplication("social-network", socialnetwork.New); err != nil {
+		return err
+	}
+	if err := registry.RegisterApplication("train-ticket", trainticket.New); err != nil {
 		return err
 	}
 	if _, err := registry.Application(workload); err != nil {
@@ -228,7 +244,7 @@ func writeNDJSON(path string, observations []api.Observation) error {
 
 func writeAtomic(path string, data []byte) error {
 	directory := filepath.Dir(path)
-	temporary, err := os.CreateTemp(directory, ".microbench-result-*")
+	temporary, err := os.CreateTemp(directory, ".servicebench-result-*")
 	if err != nil {
 		return fmt.Errorf("create temporary result in %s: %w", directory, err)
 	}

--- a/examples/evaluators/microservice/config/config.go
+++ b/examples/evaluators/microservice/config/config.go
@@ -85,11 +85,14 @@ func Validate(workload api.Workload) error {
 	if strings.TrimSpace(workload.Application) == "" {
 		return fmt.Errorf("application must not be empty")
 	}
-	if workload.Load.Model != "open_loop" {
-		return fmt.Errorf("load.model must be open_loop, got %q", workload.Load.Model)
+	if workload.Load.Model != "open_loop" && workload.Load.Model != "closed_loop" {
+		return fmt.Errorf("load.model must be open_loop or closed_loop, got %q", workload.Load.Model)
 	}
-	if workload.Load.Rate <= 0 {
-		return fmt.Errorf("load.rate must be greater than zero")
+	if workload.Load.Model == "open_loop" && workload.Load.Rate <= 0 {
+		return fmt.Errorf("load.rate must be greater than zero for open_loop workloads")
+	}
+	if workload.Load.Model == "closed_loop" && workload.Load.Rate != 0 {
+		return fmt.Errorf("load.rate must be zero for closed_loop workloads")
 	}
 	if workload.Load.DurationSeconds <= 0 {
 		return fmt.Errorf("load.duration_seconds must be greater than zero")
@@ -161,8 +164,8 @@ func Validate(workload api.Workload) error {
 	if workload.Objective.Name == "" {
 		return fmt.Errorf("objective.name must not be empty")
 	}
-	if workload.Objective.Metric != "latency_ms.p50" && workload.Objective.Metric != "requests_per_second" {
-		return fmt.Errorf("objective.metric must be latency_ms.p50 or requests_per_second")
+	if workload.Objective.Metric != "latency_ms.p50" && workload.Objective.Metric != "operations_per_second" && workload.Objective.Metric != "requests_per_second" {
+		return fmt.Errorf("objective.metric must be latency_ms.p50, operations_per_second, or the legacy requests_per_second alias")
 	}
 	if workload.Objective.Direction != "minimize" && workload.Objective.Direction != "maximize" {
 		return fmt.Errorf("objective.direction must be minimize or maximize")

--- a/examples/evaluators/microservice/config/config.go
+++ b/examples/evaluators/microservice/config/config.go
@@ -180,6 +180,9 @@ func Validate(workload api.Workload) error {
 			return fmt.Errorf("constraints.max_error_rate must be in [0, 1]")
 		}
 	}
+	if workload.Constraints.MinOperationsPerType < 0 {
+		return fmt.Errorf("constraints.min_operations_per_type must not be negative")
+	}
 	return nil
 }
 

--- a/examples/evaluators/microservice/config/config_test.go
+++ b/examples/evaluators/microservice/config/config_test.go
@@ -69,7 +69,8 @@ func TestLoadRejectsUnknownField(t *testing.T) {
 func TestLoadAppliesNamedProfile(t *testing.T) {
 	contents := validWorkload + `
 [profiles.quick]
-rate = 3
+model = "closed_loop"
+rate = 0
 duration_seconds = 0.2
 [profiles.quick.application_config]
 users = 20
@@ -78,7 +79,7 @@ users = 20
 	if err != nil {
 		t.Fatal(err)
 	}
-	if workload.Load.Rate != 3 || workload.Load.DurationSeconds != 0.2 {
+	if workload.Load.Model != "closed_loop" || workload.Load.Rate != 0 || workload.Load.DurationSeconds != 0.2 {
 		t.Fatalf("profile not applied: %+v", workload.Load)
 	}
 	if users := workload.ApplicationConfig["users"]; users != int64(20) {

--- a/examples/evaluators/microservice/engine/README.md
+++ b/examples/evaluators/microservice/engine/README.md
@@ -8,11 +8,11 @@ Its responsibilities include:
 
 - reset, prepare, warmup, measurement, and repetition lifecycle;
 - fixed-rate open-loop arrival scheduling with bounded concurrency;
-- scheduled, dispatched, sent, and completed timestamps;
+- scheduled, dispatched, sent, response-completed, and semantically validated timestamps;
 - queue-wait, protocol-time, and total-latency observations;
 - offered-rate, scheduler-lag, and queue-depth diagnostics;
 - per-operation and per-trial distributions;
-- success/error and load-sustainability constraints; and
+- success/error, operation-coverage, and load-sustainability constraints; and
 - median, MAD, IQR, and bootstrap aggregation across trials.
 
 The engine omits the trusted `primary_value` when any trial is invalid. It must

--- a/examples/evaluators/microservice/engine/engine.go
+++ b/examples/evaluators/microservice/engine/engine.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"strconv"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"vibesys/microservice-evaluator/api"
@@ -73,6 +76,7 @@ func (e *Engine) Run(ctx context.Context, workload api.Workload) (RunResult, err
 			EngineVersion: e.options.EngineVersion,
 			WorkloadName:  workload.Name,
 			WorkloadHash:  e.options.WorkloadHash,
+			Seed:          strconv.FormatInt(workload.Load.Seed, 10),
 			PrimaryMetric: workload.Objective,
 			Constraints: ConstraintResult{
 				Passed:         true,
@@ -90,11 +94,27 @@ func (e *Engine) Run(ctx context.Context, workload api.Workload) (RunResult, err
 			return RunResult{}, fmt.Errorf("reset trial %d: %w", trialIndex, err)
 		}
 		var dataset any
+		prepared := false
 		if !e.options.SkipPrepare {
 			dataset, err = application.Prepare(ctx, runtime, trialContext)
 			if err != nil {
 				return RunResult{}, fmt.Errorf("prepare trial %d: %w", trialIndex, err)
 			}
+			prepared = true
+		}
+		cleanup := func(prior error) error {
+			if !prepared {
+				return prior
+			}
+			prepared = false
+			resetErr := application.Reset(ctx, runtime, trialContext)
+			if resetErr == nil {
+				return prior
+			}
+			if prior != nil {
+				return fmt.Errorf("%w (fixture cleanup: %v)", prior, resetErr)
+			}
+			return fmt.Errorf("fixture cleanup: %w", resetErr)
 		}
 
 		if workload.Load.WarmupSeconds > 0 {
@@ -110,15 +130,15 @@ func (e *Engine) Run(ctx context.Context, workload api.Workload) (RunResult, err
 				workload.Load.Seed+int64(trialIndex*2),
 			)
 			if err != nil {
-				return RunResult{}, fmt.Errorf("warmup trial %d: %w", trialIndex, err)
+				return RunResult{}, cleanup(fmt.Errorf("warmup trial %d: %w", trialIndex, err))
 			}
 			if !warmupGenerator.Sustained {
-				return RunResult{}, fmt.Errorf(
-					"warmup trial %d did not sustain offered load: %.2f < %.2f requests/s",
+				return RunResult{}, cleanup(fmt.Errorf(
+					"warmup trial %d did not sustain offered load: %.2f < %.2f operations/s",
 					trialIndex,
 					warmupGenerator.OfferedRate,
 					warmupGenerator.MinOfferedRate,
-				)
+				))
 			}
 		}
 
@@ -134,7 +154,7 @@ func (e *Engine) Run(ctx context.Context, workload api.Workload) (RunResult, err
 			workload.Load.Seed+int64(trialIndex*2+1),
 		)
 		if err != nil {
-			return RunResult{}, fmt.Errorf("measure trial %d: %w", trialIndex, err)
+			return RunResult{}, cleanup(fmt.Errorf("measure trial %d: %w", trialIndex, err))
 		}
 		result.Observations = append(result.Observations, observations...)
 		trial := summarizeTrial(trialIndex, observations, generator, workload)
@@ -151,6 +171,9 @@ func (e *Engine) Run(ctx context.Context, workload api.Workload) (RunResult, err
 					fmt.Sprintf("trial %d: %s", trialIndex, reason),
 				)
 			}
+		}
+		if err := cleanup(nil); err != nil {
+			return RunResult{}, fmt.Errorf("reset trial %d after measurement: %w", trialIndex, err)
 		}
 	}
 
@@ -201,6 +224,9 @@ func (e *Engine) runPhase(
 	durationSeconds float64,
 	seed int64,
 ) ([]api.Observation, GeneratorReport, error) {
+	if workload.Load.Model == "closed_loop" {
+		return e.runClosedLoopPhase(ctx, phase, trial, workload, application, runtime, dataset, durationSeconds, seed)
+	}
 	requestCount := int(math.Ceil(workload.Load.Rate * durationSeconds))
 	if requestCount <= 0 {
 		return nil, GeneratorReport{}, fmt.Errorf("phase %s schedules no requests", phase)
@@ -290,15 +316,89 @@ func (e *Engine) runPhase(
 	}
 	minimum := workload.Load.Rate * workload.Load.MinOfferedRateRatio
 	report := GeneratorReport{
-		TargetRate:        workload.Load.Rate,
-		OfferedRate:       offeredRate,
-		MinOfferedRate:    minimum,
-		SubmittedRequests: requestCount,
-		MaxQueueDepth:     maxQueueDepth,
-		SchedulerLagMS:    distribution(schedulerLags),
-		Sustained:         offeredRate >= minimum,
+		TargetRate:          workload.Load.Rate,
+		OfferedRate:         offeredRate,
+		MinOfferedRate:      minimum,
+		SubmittedOperations: requestCount,
+		MaxQueueDepth:       maxQueueDepth,
+		SchedulerLagMS:      distribution(schedulerLags),
+		Sustained:           offeredRate >= minimum,
 	}
 	return collected, report, nil
+}
+
+func (e *Engine) runClosedLoopPhase(
+	ctx context.Context,
+	phase api.Phase,
+	trial int,
+	workload api.Workload,
+	application api.Application,
+	runtime *runtime,
+	dataset any,
+	durationSeconds float64,
+	seed int64,
+) ([]api.Observation, GeneratorReport, error) {
+	duration := time.Duration(durationSeconds * float64(time.Second))
+	ready := sync.WaitGroup{}
+	workers := sync.WaitGroup{}
+	var counter atomic.Int64
+	collectedByWorker := make([][]api.Observation, workload.Load.Concurrency)
+	start := time.Now().Add(10 * time.Millisecond)
+	stop := start.Add(duration)
+	for worker := 0; worker < workload.Load.Concurrency; worker++ {
+		ready.Add(1)
+		workers.Add(1)
+		go func(workerIndex int) {
+			defer workers.Done()
+			rng := rand.New(rand.NewSource(seed ^ int64(workerIndex+1)*0x5deece66d))
+			selector := newOperationSelector(workload.Operations)
+			ready.Done()
+			if err := sleepUntil(ctx, start); err != nil {
+				return
+			}
+			local := make([]api.Observation, 0, 1024)
+			for time.Now().Before(stop) {
+				sequence := counter.Add(1) - 1
+				scheduled := time.Now()
+				local = append(local, executeRequest(
+					ctx,
+					phase,
+					trial,
+					workload.Load,
+					scheduledSample{
+						operation: selector.choose(rng.Intn(selector.total)),
+						sample:    api.Sample{Counter: sequence, Random: rng.Uint64()},
+						scheduled: scheduled,
+					},
+					application,
+					runtime,
+					dataset,
+				))
+			}
+			collectedByWorker[workerIndex] = local
+		}(worker)
+	}
+	ready.Wait()
+	workers.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, GeneratorReport{}, err
+	}
+	count := int(counter.Load())
+	collected := make([]api.Observation, 0, count)
+	for _, observations := range collectedByWorker {
+		collected = append(collected, observations...)
+	}
+	elapsed := time.Since(start).Seconds()
+	offeredRate := 0.0
+	if elapsed > 0 {
+		offeredRate = float64(count) / elapsed
+	}
+	return collected, GeneratorReport{
+		OfferedRate:         offeredRate,
+		SubmittedOperations: count,
+		SchedulerLagMS:      distribution(nil),
+		Sustained:           true,
+	}, nil
 }
 
 func executeRequest(
@@ -312,29 +412,59 @@ func executeRequest(
 	dataset any,
 ) api.Observation {
 	dispatched := time.Now()
-	invocation, buildErr := application.BuildInvocation(item.operation, item.sample, dataset)
+	plan, buildErr := application.BuildOperation(item.operation, item.sample, dataset)
+	if buildErr == nil {
+		defer application.FinishOperation(plan)
+		if len(plan.Invocations) == 0 {
+			buildErr = fmt.Errorf("operation %q produced no invocations", item.operation.Name)
+		}
+	}
 	sent := time.Now()
-	result := api.ProtocolResult{}
-	if buildErr != nil {
-		result.ErrorCategory = "request_build"
-		result.ErrorMessage = buildErr.Error()
-	} else {
+	results := make([]api.ProtocolResult, 0, len(plan.Invocations))
+	if buildErr == nil {
 		timeout := time.Duration(load.TimeoutSeconds * float64(time.Second))
-		ctx, cancel := context.WithTimeout(parent, timeout)
-		result = runtime.Invoke(ctx, invocation)
-		cancel()
+		for _, invocation := range plan.Invocations {
+			ctx, cancel := context.WithTimeout(parent, timeout)
+			results = append(results, runtime.Invoke(ctx, invocation))
+			cancel()
+		}
 	}
 	completed := time.Now()
 	validation := api.ValidationResult{}
 	if buildErr == nil {
-		validation = application.Validate(item.operation, result)
+		validation = application.ValidateOperation(item.operation, plan, results)
 	}
-	success := buildErr == nil && result.TransportSuccess && validation.Success
-	errorCategory := result.ErrorCategory
-	errorMessage := result.ErrorMessage
-	if result.TransportSuccess && !validation.Success {
+	transportSuccess := buildErr == nil
+	var requestBytes, responseBytes int64
+	nativeStatuses := make([]string, 0, len(results))
+	errorCategory := ""
+	errorMessage := ""
+	for _, result := range results {
+		requestBytes += result.RequestBytes
+		responseBytes += result.ResponseBytes
+		if result.NativeStatus != "" {
+			nativeStatuses = append(nativeStatuses, result.NativeStatus)
+		}
+		if !result.TransportSuccess {
+			transportSuccess = false
+			if errorCategory == "" {
+				errorCategory = result.ErrorCategory
+				errorMessage = result.ErrorMessage
+			}
+		}
+	}
+	if buildErr != nil {
+		errorCategory = "request_build"
+		errorMessage = buildErr.Error()
+	}
+	success := buildErr == nil && transportSuccess && validation.Success
+	if buildErr == nil && transportSuccess && !validation.Success {
 		errorCategory = validation.ErrorCategory
 		errorMessage = validation.ErrorMessage
+	}
+	nativeStatus := ""
+	if len(nativeStatuses) > 0 {
+		nativeStatus = strings.Join(nativeStatuses, ",")
 	}
 	observation := api.Observation{
 		Trial:              trial,
@@ -347,13 +477,15 @@ func executeRequest(
 		DispatchedAt:       dispatched,
 		SentAt:             sent,
 		CompletedAt:        completed,
-		TransportSuccess:   result.TransportSuccess,
+		TransportSuccess:   transportSuccess,
 		ApplicationSuccess: success,
-		NativeStatus:       result.NativeStatus,
+		NativeStatus:       nativeStatus,
+		NativeStatuses:     nativeStatuses,
 		ErrorCategory:      errorCategory,
 		ErrorMessage:       errorMessage,
-		RequestBytes:       result.RequestBytes,
-		ResponseBytes:      result.ResponseBytes,
+		InvocationCount:    len(results),
+		RequestBytes:       requestBytes,
+		ResponseBytes:      responseBytes,
 		CustomTimings:      validation.CustomTimings,
 	}
 	observation.PopulateDurations()

--- a/examples/evaluators/microservice/engine/engine.go
+++ b/examples/evaluators/microservice/engine/engine.go
@@ -79,9 +79,10 @@ func (e *Engine) Run(ctx context.Context, workload api.Workload) (RunResult, err
 			Seed:          strconv.FormatInt(workload.Load.Seed, 10),
 			PrimaryMetric: workload.Objective,
 			Constraints: ConstraintResult{
-				Passed:         true,
-				MinSuccessRate: workload.Constraints.MinSuccessRate,
-				MaxErrorRate:   workload.Constraints.MaxErrorRate,
+				Passed:               true,
+				MinSuccessRate:       workload.Constraints.MinSuccessRate,
+				MaxErrorRate:         workload.Constraints.MaxErrorRate,
+				MinOperationsPerType: workload.Constraints.MinOperationsPerType,
 			},
 		},
 	}
@@ -434,6 +435,7 @@ func executeRequest(
 	if buildErr == nil {
 		validation = application.ValidateOperation(item.operation, plan, results)
 	}
+	validated := time.Now()
 	transportSuccess := buildErr == nil
 	var requestBytes, responseBytes int64
 	nativeStatuses := make([]string, 0, len(results))
@@ -477,6 +479,7 @@ func executeRequest(
 		DispatchedAt:       dispatched,
 		SentAt:             sent,
 		CompletedAt:        completed,
+		ValidatedAt:        validated,
 		TransportSuccess:   transportSuccess,
 		ApplicationSuccess: success,
 		NativeStatus:       nativeStatus,

--- a/examples/evaluators/microservice/engine/engine_test.go
+++ b/examples/evaluators/microservice/engine/engine_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,7 +38,9 @@ func (c fakeClient) Invoke(ctx context.Context, _ api.Invocation) api.ProtocolRe
 
 func (fakeClient) Close() error { return nil }
 
-type fakeApplication struct{}
+type fakeApplication struct {
+	validationDelay time.Duration
+}
 
 func (fakeApplication) Name() string { return "fake-app" }
 func (fakeApplication) Prepare(context.Context, api.Runtime, api.TrialContext) (any, error) {
@@ -49,7 +52,10 @@ func (fakeApplication) BuildOperation(operation api.Operation, _ api.Sample, _ a
 		Target: operation.Target, Operation: operation.Name, Payload: "opaque-schema",
 	}}}, nil
 }
-func (fakeApplication) ValidateOperation(_ api.Operation, _ api.OperationPlan, results []api.ProtocolResult) api.ValidationResult {
+func (a fakeApplication) ValidateOperation(_ api.Operation, _ api.OperationPlan, results []api.ProtocolResult) api.ValidationResult {
+	if a.validationDelay > 0 {
+		time.Sleep(a.validationDelay)
+	}
 	if len(results) != 1 {
 		return api.ValidationResult{ErrorCategory: "result_count", ErrorMessage: "unexpected result count"}
 	}
@@ -151,6 +157,58 @@ func TestEngineClosedLoopMeasuresSaturationThroughput(t *testing.T) {
 	}
 	if trial.Generator.TargetRate != 0 || !trial.Generator.Sustained || trial.Generator.SubmittedOperations == 0 {
 		t.Fatalf("unexpected closed-loop generator report: %+v", trial.Generator)
+	}
+}
+
+func TestClosedLoopThroughputIncludesSemanticValidationTail(t *testing.T) {
+	registered := registry.New()
+	if err := registered.RegisterDriver(fakeDriver{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := registered.RegisterApplication("fake-app", func(api.Workload) (api.Application, error) {
+		return fakeApplication{validationDelay: 100 * time.Millisecond}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	configured := workload(0, 0.01, 1, 1)
+	configured.Load.Model = "closed_loop"
+	configured.Objective = api.Objective{
+		Name: "operations_per_second", Metric: "operations_per_second", Direction: "maximize", Unit: "operations/s",
+	}
+	run, err := New(registered, Options{EngineVersion: "test"}).Run(context.Background(), configured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trial := run.Summary.Trials[0]
+	if trial.ElapsedSeconds < 0.09 {
+		t.Fatalf("validation tail was omitted from elapsed time: %+v", trial)
+	}
+	if run.Summary.PrimaryValue == nil || *run.Summary.PrimaryValue > 20 {
+		t.Fatalf("validation tail inflated throughput: %+v", run.Summary)
+	}
+	if got := run.Observations[0].ValidationTimeMS; got < 90 {
+		t.Fatalf("validation duration was not retained: %.2fms", got)
+	}
+}
+
+func TestTrialRequiresConfiguredOperationCoverage(t *testing.T) {
+	configured := workload(1, 1, 1, 1)
+	configured.Operations = append(configured.Operations, api.Operation{
+		Name: "uncovered", Target: "service", Weight: 1,
+	})
+	configured.Constraints.MinOperationsPerType = 1
+	now := time.Now()
+	observation := api.Observation{
+		Operation: "read", ScheduledAt: now, CompletedAt: now.Add(time.Millisecond),
+		ValidatedAt: now.Add(time.Millisecond), ApplicationSuccess: true,
+	}
+	observation.PopulateDurations()
+	trial := summarizeTrial(0, []api.Observation{observation}, GeneratorReport{Sustained: true}, configured)
+	if trial.Valid || trial.PrimaryValue != nil {
+		t.Fatalf("missing operation coverage unexpectedly passed: %+v", trial)
+	}
+	if len(trial.InvalidReasons) == 0 || !strings.Contains(strings.Join(trial.InvalidReasons, " "), "uncovered") {
+		t.Fatalf("missing operation was not identified: %+v", trial.InvalidReasons)
 	}
 }
 

--- a/examples/evaluators/microservice/engine/engine_test.go
+++ b/examples/evaluators/microservice/engine/engine_test.go
@@ -31,7 +31,7 @@ func (c fakeClient) Invoke(ctx context.Context, _ api.Invocation) api.ProtocolRe
 	case <-ctx.Done():
 		return api.ProtocolResult{ErrorCategory: "timeout", ErrorMessage: ctx.Err().Error()}
 	case <-timer.C:
-		return api.ProtocolResult{TransportSuccess: true, NativeStatus: "OK"}
+		return api.ProtocolResult{TransportSuccess: true, NativeStatus: "OK", RequestBytes: 2, ResponseBytes: 3}
 	}
 }
 
@@ -44,15 +44,22 @@ func (fakeApplication) Prepare(context.Context, api.Runtime, api.TrialContext) (
 	return nil, nil
 }
 func (fakeApplication) Reset(context.Context, api.Runtime, api.TrialContext) error { return nil }
-func (fakeApplication) BuildInvocation(operation api.Operation, _ api.Sample, _ any) (api.Invocation, error) {
-	return api.Invocation{Target: operation.Target, Operation: operation.Name, Payload: "opaque-schema"}, nil
+func (fakeApplication) BuildOperation(operation api.Operation, _ api.Sample, _ any) (api.OperationPlan, error) {
+	return api.OperationPlan{Invocations: []api.Invocation{{
+		Target: operation.Target, Operation: operation.Name, Payload: "opaque-schema",
+	}}}, nil
 }
-func (fakeApplication) Validate(_ api.Operation, result api.ProtocolResult) api.ValidationResult {
+func (fakeApplication) ValidateOperation(_ api.Operation, _ api.OperationPlan, results []api.ProtocolResult) api.ValidationResult {
+	if len(results) != 1 {
+		return api.ValidationResult{ErrorCategory: "result_count", ErrorMessage: "unexpected result count"}
+	}
+	result := results[0]
 	if !result.TransportSuccess {
 		return api.ValidationResult{ErrorCategory: result.ErrorCategory, ErrorMessage: result.ErrorMessage}
 	}
 	return api.ValidationResult{Success: true}
 }
+func (fakeApplication) FinishOperation(api.OperationPlan) {}
 
 func workload(rate float64, duration float64, concurrency int, repetitions int) api.Workload {
 	zero := 0.0
@@ -128,6 +135,25 @@ func TestEngineExposesQueueDelayAndInvalidatesClientSaturation(t *testing.T) {
 	}
 }
 
+func TestEngineClosedLoopMeasuresSaturationThroughput(t *testing.T) {
+	configured := workload(0, 0.05, 2, 1)
+	configured.Load.Model = "closed_loop"
+	configured.Objective = api.Objective{
+		Name: "operations_per_second", Metric: "operations_per_second", Direction: "maximize", Unit: "operations/s",
+	}
+	run, err := newTestEngine(t, time.Millisecond).Run(context.Background(), configured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	trial := run.Summary.Trials[0]
+	if !run.Summary.Valid || run.Summary.PrimaryValue == nil || *run.Summary.PrimaryValue <= 0 {
+		t.Fatalf("closed-loop throughput was not measured: %+v", run.Summary)
+	}
+	if trial.Generator.TargetRate != 0 || !trial.Generator.Sustained || trial.Generator.SubmittedOperations == 0 {
+		t.Fatalf("unexpected closed-loop generator report: %+v", trial.Generator)
+	}
+}
+
 func TestRegistryRejectsUnregisteredProtocol(t *testing.T) {
 	registered := registry.New()
 	if err := registered.RegisterApplication("fake-app", func(api.Workload) (api.Application, error) {
@@ -141,5 +167,53 @@ func TestRegistryRejectsUnregisteredProtocol(t *testing.T) {
 	}
 	if got := fmt.Sprint(err); got == "" {
 		t.Fatal("empty error")
+	}
+}
+
+type multiStepApplication struct {
+	finished int
+}
+
+func (*multiStepApplication) Name() string { return "multi" }
+func (*multiStepApplication) Prepare(context.Context, api.Runtime, api.TrialContext) (any, error) {
+	return nil, nil
+}
+func (*multiStepApplication) Reset(context.Context, api.Runtime, api.TrialContext) error {
+	return nil
+}
+func (*multiStepApplication) BuildOperation(operation api.Operation, _ api.Sample, _ any) (api.OperationPlan, error) {
+	return api.OperationPlan{Invocations: []api.Invocation{
+		{Target: operation.Target, Operation: operation.Name},
+		{Target: operation.Target, Operation: operation.Name},
+	}}, nil
+}
+func (*multiStepApplication) ValidateOperation(_ api.Operation, _ api.OperationPlan, results []api.ProtocolResult) api.ValidationResult {
+	return api.ValidationResult{Success: len(results) == 2}
+}
+func (a *multiStepApplication) FinishOperation(api.OperationPlan) { a.finished++ }
+
+func TestExecuteRequestAccountsForEveryInvocationInLogicalOperation(t *testing.T) {
+	application := &multiStepApplication{}
+	runtime := &runtime{
+		clients:   map[string]api.Client{"service": fakeClient{delay: time.Millisecond}},
+		protocols: map[string]string{"service": "fake-rpc"},
+	}
+	observation := executeRequest(
+		context.Background(), api.PhaseMeasurement, 0,
+		api.Load{TimeoutSeconds: 1},
+		scheduledSample{
+			operation: api.Operation{Name: "transaction", Target: "service"},
+			scheduled: time.Now(),
+		},
+		application, runtime, nil,
+	)
+	if !observation.ApplicationSuccess {
+		t.Fatalf("logical operation failed: %+v", observation)
+	}
+	if observation.InvocationCount != 2 || observation.RequestBytes != 4 || observation.ResponseBytes != 6 {
+		t.Fatalf("invocations were not aggregated: %+v", observation)
+	}
+	if len(observation.NativeStatuses) != 2 || application.finished != 1 {
+		t.Fatalf("statuses or cleanup were not preserved: observation=%+v finished=%d", observation, application.finished)
 	}
 }

--- a/examples/evaluators/microservice/engine/result.go
+++ b/examples/evaluators/microservice/engine/result.go
@@ -2,7 +2,7 @@ package engine
 
 import "vibesys/microservice-evaluator/api"
 
-const ResultSchemaVersion = 1
+const ResultSchemaVersion = 2
 
 type Distribution struct {
 	Count int      `json:"count"`
@@ -16,7 +16,8 @@ type Distribution struct {
 }
 
 type OperationResult struct {
-	Requests        int                     `json:"requests"`
+	Operations      int                     `json:"operations"`
+	HTTPInvocations int                     `json:"http_invocations"`
 	Successes       int                     `json:"successes"`
 	Failures        int                     `json:"failures"`
 	LatencyMS       Distribution            `json:"latency_ms"`
@@ -26,33 +27,34 @@ type OperationResult struct {
 }
 
 type GeneratorReport struct {
-	TargetRate        float64      `json:"target_rate"`
-	OfferedRate       float64      `json:"offered_rate"`
-	MinOfferedRate    float64      `json:"min_offered_rate"`
-	SubmittedRequests int          `json:"submitted_requests"`
-	MaxQueueDepth     int          `json:"max_queue_depth"`
-	SchedulerLagMS    Distribution `json:"scheduler_lag_ms"`
-	Sustained         bool         `json:"sustained"`
+	TargetRate          float64      `json:"target_operations_per_second"`
+	OfferedRate         float64      `json:"offered_operations_per_second"`
+	MinOfferedRate      float64      `json:"min_offered_operations_per_second"`
+	SubmittedOperations int          `json:"submitted_operations"`
+	MaxQueueDepth       int          `json:"max_queue_depth"`
+	SchedulerLagMS      Distribution `json:"scheduler_lag_ms"`
+	Sustained           bool         `json:"sustained"`
 }
 
 type TrialResult struct {
-	Index              int                        `json:"index"`
-	Valid              bool                       `json:"valid"`
-	InvalidReasons     []string                   `json:"invalid_reasons,omitempty"`
-	PrimaryValue       *float64                   `json:"primary_value,omitempty"`
-	ElapsedSeconds     float64                    `json:"elapsed_seconds"`
-	TotalRequests      int                        `json:"total_requests"`
-	SuccessfulRequests int                        `json:"successful_requests"`
-	FailedRequests     int                        `json:"failed_requests"`
-	SuccessRate        float64                    `json:"success_rate"`
-	ErrorRate          float64                    `json:"error_rate"`
-	LatencyMS          Distribution               `json:"latency_ms"`
-	QueueWaitMS        Distribution               `json:"queue_wait_ms"`
-	ProtocolTimeMS     Distribution               `json:"protocol_time_ms"`
-	CustomTimingsMS    map[string]Distribution    `json:"custom_timings_ms,omitempty"`
-	ByOperation        map[string]OperationResult `json:"by_operation"`
-	ErrorsByCategory   map[string]int             `json:"errors_by_category,omitempty"`
-	Generator          GeneratorReport            `json:"load_generator"`
+	Index                int                        `json:"index"`
+	Valid                bool                       `json:"valid"`
+	InvalidReasons       []string                   `json:"invalid_reasons,omitempty"`
+	PrimaryValue         *float64                   `json:"primary_value,omitempty"`
+	ElapsedSeconds       float64                    `json:"elapsed_seconds"`
+	TotalOperations      int                        `json:"total_operations"`
+	SuccessfulOperations int                        `json:"successful_operations"`
+	FailedOperations     int                        `json:"failed_operations"`
+	HTTPInvocations      int                        `json:"http_invocations"`
+	SuccessRate          float64                    `json:"success_rate"`
+	ErrorRate            float64                    `json:"error_rate"`
+	LatencyMS            Distribution               `json:"latency_ms"`
+	QueueWaitMS          Distribution               `json:"queue_wait_ms"`
+	ProtocolTimeMS       Distribution               `json:"protocol_time_ms"`
+	CustomTimingsMS      map[string]Distribution    `json:"custom_timings_ms,omitempty"`
+	ByOperation          map[string]OperationResult `json:"by_operation"`
+	ErrorsByCategory     map[string]int             `json:"errors_by_category,omitempty"`
+	Generator            GeneratorReport            `json:"load_generator"`
 }
 
 type Aggregate struct {
@@ -75,6 +77,7 @@ type Summary struct {
 	EngineVersion string           `json:"engine_version"`
 	WorkloadName  string           `json:"workload_name"`
 	WorkloadHash  string           `json:"workload_hash"`
+	Seed          string           `json:"seed"`
 	PrimaryValue  *float64         `json:"primary_value,omitempty"`
 	PrimaryMetric api.Objective    `json:"primary_metric"`
 	Valid         bool             `json:"valid"`

--- a/examples/evaluators/microservice/engine/result.go
+++ b/examples/evaluators/microservice/engine/result.go
@@ -2,7 +2,7 @@ package engine
 
 import "vibesys/microservice-evaluator/api"
 
-const ResultSchemaVersion = 2
+const ResultSchemaVersion = 3
 
 type Distribution struct {
 	Count int      `json:"count"`
@@ -66,10 +66,11 @@ type Aggregate struct {
 }
 
 type ConstraintResult struct {
-	Passed         bool     `json:"passed"`
-	Reasons        []string `json:"reasons,omitempty"`
-	MinSuccessRate *float64 `json:"min_success_rate,omitempty"`
-	MaxErrorRate   *float64 `json:"max_error_rate,omitempty"`
+	Passed               bool     `json:"passed"`
+	Reasons              []string `json:"reasons,omitempty"`
+	MinSuccessRate       *float64 `json:"min_success_rate,omitempty"`
+	MaxErrorRate         *float64 `json:"max_error_rate,omitempty"`
+	MinOperationsPerType int      `json:"min_operations_per_type,omitempty"`
 }
 
 type Summary struct {

--- a/examples/evaluators/microservice/engine/summarize.go
+++ b/examples/evaluators/microservice/engine/summarize.go
@@ -33,8 +33,12 @@ func summarizeTrial(
 		if observationIndex == 0 || observation.ScheduledAt.UnixNano() < earliest {
 			earliest = observation.ScheduledAt.UnixNano()
 		}
-		if observation.CompletedAt.UnixNano() > latest {
-			latest = observation.CompletedAt.UnixNano()
+		finishedAt := observation.ValidatedAt
+		if finishedAt.IsZero() {
+			finishedAt = observation.CompletedAt
+		}
+		if finishedAt.UnixNano() > latest {
+			latest = finishedAt.UnixNano()
 		}
 		byOperation[observation.Operation] = append(byOperation[observation.Operation], observation)
 		queueWaits = append(queueWaits, observation.QueueWaitMS)
@@ -113,6 +117,18 @@ func summarizeTrial(
 			result.ErrorRate,
 			*maximum,
 		))
+	}
+	if minimum := workload.Constraints.MinOperationsPerType; minimum > 0 {
+		for _, operation := range workload.Operations {
+			if count := len(byOperation[operation.Name]); count < minimum {
+				result.InvalidReasons = append(result.InvalidReasons, fmt.Sprintf(
+					"operation %q has %d samples, below required %d",
+					operation.Name,
+					count,
+					minimum,
+				))
+			}
+		}
 	}
 	result.Valid = len(result.InvalidReasons) == 0
 	if !result.Valid {

--- a/examples/evaluators/microservice/engine/summarize.go
+++ b/examples/evaluators/microservice/engine/summarize.go
@@ -16,7 +16,7 @@ func summarizeTrial(
 	result := TrialResult{
 		Index:            index,
 		Valid:            true,
-		TotalRequests:    len(observations),
+		TotalOperations:  len(observations),
 		ByOperation:      make(map[string]OperationResult),
 		ErrorsByCategory: make(map[string]int),
 		Generator:        generator,
@@ -29,6 +29,7 @@ func summarizeTrial(
 	byOperation := make(map[string][]api.Observation)
 	var earliest, latest int64
 	for observationIndex, observation := range observations {
+		result.HTTPInvocations += observation.InvocationCount
 		if observationIndex == 0 || observation.ScheduledAt.UnixNano() < earliest {
 			earliest = observation.ScheduledAt.UnixNano()
 		}
@@ -42,13 +43,13 @@ func summarizeTrial(
 			customTimings[name] = append(customTimings[name], value)
 		}
 		if observation.ApplicationSuccess {
-			result.SuccessfulRequests++
+			result.SuccessfulOperations++
 			totalLatencies = append(totalLatencies, observation.TotalLatencyMS)
 			if hasAllTags(observation.Tags, workload.Objective.Tags) {
 				objectiveLatencies = append(objectiveLatencies, observation.TotalLatencyMS)
 			}
 		} else {
-			result.FailedRequests++
+			result.FailedOperations++
 			category := observation.ErrorCategory
 			if category == "" {
 				category = "unknown"
@@ -60,8 +61,8 @@ func summarizeTrial(
 		result.ElapsedSeconds = float64(latest-earliest) / 1e9
 	}
 	if len(observations) > 0 {
-		result.SuccessRate = float64(result.SuccessfulRequests) / float64(len(observations))
-		result.ErrorRate = float64(result.FailedRequests) / float64(len(observations))
+		result.SuccessRate = float64(result.SuccessfulOperations) / float64(len(observations))
+		result.ErrorRate = float64(result.FailedOperations) / float64(len(observations))
 	}
 	result.LatencyMS = distribution(totalLatencies)
 	result.QueueWaitMS = distribution(queueWaits)
@@ -85,16 +86,16 @@ func summarizeTrial(
 			sort.Float64s(objectiveLatencies)
 			result.PrimaryValue = pointer(percentile(objectiveLatencies, 50))
 		}
-	case "requests_per_second":
+	case "operations_per_second", "requests_per_second":
 		if result.ElapsedSeconds <= 0 {
 			result.InvalidReasons = append(result.InvalidReasons, "measurement elapsed time is zero")
 		} else {
-			result.PrimaryValue = pointer(float64(result.SuccessfulRequests) / result.ElapsedSeconds)
+			result.PrimaryValue = pointer(float64(result.SuccessfulOperations) / result.ElapsedSeconds)
 		}
 	}
 	if !generator.Sustained {
 		result.InvalidReasons = append(result.InvalidReasons, fmt.Sprintf(
-			"offered rate %.2f is below required %.2f requests/s",
+			"offered rate %.2f is below required %.2f operations/s",
 			generator.OfferedRate,
 			generator.MinOfferedRate,
 		))
@@ -121,10 +122,11 @@ func summarizeTrial(
 }
 
 func summarizeOperation(observations []api.Observation) OperationResult {
-	result := OperationResult{Requests: len(observations)}
+	result := OperationResult{Operations: len(observations)}
 	var latencies, waits, protocolTimes []float64
 	customTimings := make(map[string][]float64)
 	for _, observation := range observations {
+		result.HTTPInvocations += observation.InvocationCount
 		waits = append(waits, observation.QueueWaitMS)
 		protocolTimes = append(protocolTimes, observation.ProtocolTimeMS)
 		for name, value := range observation.CustomTimingsMS {

--- a/examples/microservices/social-network-read-timeline/README.md
+++ b/examples/microservices/social-network-read-timeline/README.md
@@ -164,7 +164,7 @@ the original medium profile: 300 target RPS, 20 seconds of warmup, 120 seconds
 of measurement, 50 users, and 10 seed posts per user.
 
 ```bash
-go -C examples/evaluators/microservice run ./cmd/microbench \
+go -C examples/evaluators/microservice run ./cmd/servicebench \
   --workload "$PWD/examples/microservices/social-network-read-timeline/benchmark/workload.toml" \
   --base-url http://localhost:8080 \
   --output-json /tmp/social-network.json \
@@ -185,7 +185,7 @@ Select one with `--profile light`, `--profile medium`, or `--profile heavy`.
 On repeated runs against an already-prepared deployment, skip fixture setup:
 
 ```bash
-go -C examples/evaluators/microservice run ./cmd/microbench \
+go -C examples/evaluators/microservice run ./cmd/servicebench \
   --workload "$PWD/examples/microservices/social-network-read-timeline/benchmark/workload.toml" \
   --skip-prepare
 ```

--- a/examples/microservices/social-network-read-timeline/vibesys.input.toml
+++ b/examples/microservices/social-network-read-timeline/vibesys.input.toml
@@ -13,7 +13,7 @@ timeout_seconds = 120
 [benchmark]
 command = [
   "go", "-C", "_evaluator/microservice",
-  "run", "./cmd/microbench",
+  "run", "./cmd/servicebench",
   "--workload", "../../benchmark/workload.toml",
 ]
 timeout_seconds = 300

--- a/examples/microservices/train-ticket/OBJECTIVE.md
+++ b/examples/microservices/train-ticket/OBJECTIVE.md
@@ -1,16 +1,16 @@
-Optimize a Train Ticket microservice deployment for read-only API throughput
-while preserving response correctness.
+Optimize a Train Ticket v0.2.0-compatible deployment for stateful API
+throughput while preserving externally observable behavior.
 
-Headline metric: `requests_per_second` from the shared evaluator result
-(`primary_value`, maximize).
+Headline metric: successful `operations_per_second` from the shared evaluator
+result (`primary_value`, maximize). An operation may contain multiple dependent
+HTTP requests; update/read and create/read/delete sequences are counted once.
 
-The target is a running Train Ticket gateway or direct-service deployment. The
-candidate must preserve the existing HTTP API behavior checked by
-`accuracy_checker/checker.py`, including service welcome endpoints, list
-response envelopes, expected item fields, and cross-service referential
-integrity.
+The candidate may use any implementation language, process topology, database,
+persistence format, or caching strategy. It must preserve the public HTTP
+contract checked by `accuracy_checker/checker.py`, including the startup
+catalog, exact entity schemas, referential integrity, acknowledged mutations,
+read-your-write, deletes, and—when a restart hook is provided—crash recovery.
 
-The benchmark exercises a fixed-rate read-only workload across station, train,
-trip, route, price, config, and welcome endpoints. Improve successful completed
-requests per second without increasing the error rate beyond the benchmark's
-configured threshold.
+Traffic values, namespaces, and operation order are randomized at evaluation
+time. A run is invalid if any measured logical operation fails semantic
+validation or if the load generator cannot sustain the configured offered rate.

--- a/examples/microservices/train-ticket/README.md
+++ b/examples/microservices/train-ticket/README.md
@@ -1,7 +1,7 @@
 # Train Ticket Evaluator Inputs
 
 Accuracy and workload inputs for a running Train Ticket deployment. The checker
-is application-specific; the benchmark uses the shared Go microservice evaluator.
+is application-specific; the benchmark uses the shared Go service evaluator.
 Both can run without a full `vibesys --input` optimization run.
 
 Expected target for a gateway/proxy deployment:
@@ -14,11 +14,10 @@ The scripts call `/api/v1/...` endpoints through whichever base URL you pass.
 
 ```bash
 python examples/microservices/train-ticket/accuracy_checker/checker.py --base-url http://localhost:8080
-go -C examples/evaluators/microservice run ./cmd/microbench \
+go -C examples/evaluators/microservice run ./cmd/servicebench \
   --workload "$PWD/examples/microservices/train-ticket/benchmark/workload.toml" \
   --base-url http://localhost:8080 \
-  --rate 20 \
-  --duration 30 \
+	--duration 30 \
   --output-json /tmp/train_ticket_bench.json
 ```
 
@@ -61,9 +60,9 @@ the config/station/train/travel/route/price services with their local MongoDB
 and MySQL dependencies. The 0.2.0 prebuilt images store data in MongoDB (the
 MySQL containers and `*_MYSQL_*` env are used by source-built v1.0.0 images
 instead; both datastores are started so either image set works). All services
-self-seed reference data on startup, so `check` runs the checker in strict
-mode (no `--allow-empty`). Auth-protected services such as contacts are
-excluded from the default no-auth checker and benchmark. The published
+self-seed reference data on startup, so `check` verifies the exact v0.2.0
+catalog directly through the six service ports. Services outside that contract
+are excluded from the checker and benchmark. The published
 dashboard image is intentionally not started because its nginx config
 references additional services outside this minimal read-only cluster.
 
@@ -127,9 +126,14 @@ Manual direct-service runs:
 ```bash
 python examples/microservices/train-ticket/accuracy_checker/checker.py \
   --base-url http://localhost:18888 \
-  --direct-services
+  --target config=http://localhost:15679 \
+  --target station=http://localhost:12345 \
+  --target train=http://localhost:14567 \
+  --target travel=http://localhost:12346 \
+  --target route=http://localhost:11178 \
+  --target price=http://localhost:16579
 
-go -C examples/evaluators/microservice run ./cmd/microbench \
+go -C examples/evaluators/microservice run ./cmd/servicebench \
   --workload "$PWD/examples/microservices/train-ticket/benchmark/workload.toml" \
   --target config=http://localhost:15679 \
   --target station=http://localhost:12345 \
@@ -137,8 +141,7 @@ go -C examples/evaluators/microservice run ./cmd/microbench \
   --target travel=http://localhost:12346 \
   --target route=http://localhost:11178 \
   --target price=http://localhost:16579 \
-  --rate 10 \
-  --duration 30 \
+	--duration 30 \
   --concurrency 32
 ```
 
@@ -148,14 +151,12 @@ Manual gateway runs after source-built deployment:
 python examples/microservices/train-ticket/accuracy_checker/checker.py \
   --base-url http://localhost:18888
 
-go -C examples/evaluators/microservice run ./cmd/microbench \
+go -C examples/evaluators/microservice run ./cmd/servicebench \
   --workload "$PWD/examples/microservices/train-ticket/benchmark/workload.toml" \
   --base-url http://localhost:18888 \
-  --rate 10 \
-  --duration 30 \
+	--duration 30 \
   --concurrency 32
 ```
 
-The images self-seed reference data, so the checker runs in strict mode by
-default; pass `--allow-empty` only for deployments known to have no seeded
-data.
+The checker requires the exact v0.2.0 seed catalog and does not silently accept
+empty or structurally different startup data.

--- a/examples/microservices/train-ticket/accuracy_checker/README.md
+++ b/examples/microservices/train-ticket/accuracy_checker/README.md
@@ -1,38 +1,49 @@
 # Train Ticket Accuracy Checker
 
-Checks a running Train Ticket deployment using read-only endpoints:
+This black-box checker validates the six mutable Train Ticket v0.2.0 services
+through their public HTTP APIs. It makes no assumptions about process topology,
+implementation language, database, or persistence format.
 
-- welcome endpoints of the config, station, train, travel, route, and price
-  services (exact service banner text)
-- station, train, trip, route, price, and config list endpoints
+Every run uses a fresh cryptographically random namespace, randomized values,
+and shuffled operation order. It verifies:
 
-For every list endpoint the checker validates the full response contract, not
-just HTTP reachability:
+- the exact v0.2.0 startup catalog and response schemas;
+- welcome, list, point-read, and secondary-index routes;
+- connected station, train, route, price, and trip graphs;
+- create, immediate read-your-write, update, and delete behavior; and
+- persistent HTTP connections.
 
-- the `edu.fudan.common.util.Response` envelope reports `status == 1`
-  (an HTTP-200 body with `status: 0` is a service-level failure and fails the
-  check, except for the tolerated empty case under `--allow-empty`)
-- every returned item has the expected fields (restricted to field names that
-  exist in both the 0.2.0 prebuilt images and the v1.0.0 source)
-- referential integrity across services: trips and prices must reference
-  existing routes and trains; on 0.2.0 image deployments trips must also
-  reference existing stations and train types (v1.0.0 renamed those trip
-  fields, so those two checks skip there)
-
-Usage:
+Against an already running candidate:
 
 ```bash
-python checker.py --base-url http://localhost:18888 --direct-services
+python checker.py --base-url http://localhost:8080
 ```
 
-- `--base-url` points at the gateway or UI proxy. With `--direct-services`
-  only its hostname is used and each check goes straight to the service's
-  published port (required for the local prebuilt-image cluster, whose gateway
-  cannot route).
-- `--allow-empty` tolerates unseeded deployments: list endpoints may return
-  the `status: 0, msg: "No content"` empty envelope. All other validation
-  still applies. The images used by the local cluster self-seed on startup,
-  so the flag is not needed there.
+Crash recovery is checked only when the checker owns the candidate lifecycle or
+is given an external restart hook. The structured result reports
+`crash_recovery: false` when no restart mechanism is provided; it never claims
+that unexecuted property.
 
-Exit code is 0 only if every check (including the cross-endpoint consistency
-checks) passes.
+To let the checker start and `SIGKILL` a local candidate, provide its command as
+a JSON argument. The checker reuses the same `TRAIN_TICKET_DATA_DIR` after
+restart:
+
+```bash
+python checker.py \
+  --base-url http://127.0.0.1:18080 \
+  --candidate-dir /path/to/candidate \
+  --run-command-json '["./run.sh"]'
+```
+
+For an externally managed deployment, use `--restart-command-json`. Separate
+service addresses can be supplied by repeating `--target NAME=URL` for
+`config`, `station`, `train`, `travel`, `route`, and `price`.
+
+The exit status is zero only when every property actually exercised passes.
+
+## Testing
+
+```bash
+uv run ruff check examples/microservices/train-ticket/accuracy_checker
+uv run pytest -q examples/microservices/train-ticket/accuracy_checker/tests
+```

--- a/examples/microservices/train-ticket/accuracy_checker/README.md
+++ b/examples/microservices/train-ticket/accuracy_checker/README.md
@@ -10,7 +10,8 @@ and shuffled operation order. It verifies:
 - the exact v0.2.0 startup catalog and response schemas;
 - welcome, list, point-read, and secondary-index routes;
 - connected station, train, route, price, and trip graphs;
-- create, immediate read-your-write, update, and delete behavior; and
+- create, immediate read-your-write, update, and delete behavior;
+- removal of stale station-name indexes after updates and deletes; and
 - persistent HTTP connections.
 
 Against an already running candidate:
@@ -25,8 +26,9 @@ is given an external restart hook. The structured result reports
 that unexecuted property.
 
 To let the checker start and `SIGKILL` a local candidate, provide its command as
-a JSON argument. The checker reuses the same `TRAIN_TICKET_DATA_DIR` after
-restart:
+a JSON argument. The checker starts the command in its own process session,
+kills the entire process group, verifies that it exited, and reuses the same
+`TRAIN_TICKET_DATA_DIR` after restart:
 
 ```bash
 python checker.py \

--- a/examples/microservices/train-ticket/accuracy_checker/README.md
+++ b/examples/microservices/train-ticket/accuracy_checker/README.md
@@ -11,7 +11,9 @@ and shuffled operation order. It verifies:
 - welcome, list, point-read, and secondary-index routes;
 - connected station, train, route, price, and trip graphs;
 - create, immediate read-your-write, update, and delete behavior;
-- removal of stale station-name indexes after updates and deletes; and
+- removal of stale station-name, route-pair, and price-pair indexes after
+  updates and deletes;
+- delete isolation for the seed catalog and other live runtime graphs; and
 - persistent HTTP connections.
 
 Against an already running candidate:

--- a/examples/microservices/train-ticket/accuracy_checker/checker.py
+++ b/examples/microservices/train-ticket/accuracy_checker/checker.py
@@ -107,21 +107,24 @@ class GraphCase:
     trip_input: dict[str, Any]
     trip: dict[str, Any]
     retired_station_names: dict[str, str] = dataclass_field(default_factory=dict)
+    retired_route_keys: list[tuple[str, str]] = dataclass_field(default_factory=list)
+    retired_price_keys: list[tuple[str, str]] = dataclass_field(default_factory=list)
 
 
 def _b64url(raw: bytes) -> str:
     return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
 
 
-def admin_token(now: int | None = None) -> str:
+def admin_token(now: int | None = None, actor: str | None = None) -> str:
     issued = int(time.time()) if now is None else now
+    identity = actor if actor is not None else secrets.token_hex(12)
     header = _b64url(b'{"alg":"HS256","typ":"JWT"}')
     claims = _b64url(
         json.dumps(
             {
-                "sub": "vibesys-checker",
+                "sub": identity,
                 "roles": ["ROLE_ADMIN"],
-                "id": "vibesys-checker",
+                "id": identity,
                 "iat": issued,
                 "exp": issued + 3600,
             },
@@ -138,7 +141,7 @@ class APIClient:
         default = base_url.rstrip("/")
         self._targets = {name: targets.get(name, default).rstrip("/") for name in SERVICE_PATHS}
         self._timeout = timeout
-        self._token = admin_token()
+        self._token = admin_token(actor=secrets.token_hex(12))
 
     def url(self, service: str, path: str) -> str:
         return self._targets[service] + SERVICE_PATHS[service] + path
@@ -296,9 +299,19 @@ def validate_entity(service: str, item: Any, *, where: str) -> dict[str, Any]:
 
 
 def make_case(rng: random.Random, namespace: str, index: int) -> GraphCase:
-    token = f"{namespace}{index:x}{rng.getrandbits(32):08x}"
-    station_a = {"id": token + "a", "name": "A " + token, "stayTime": rng.randint(1, 40)}
-    station_b = {"id": token + "b", "name": "B " + token, "stayTime": rng.randint(1, 40)}
+    token = f"{namespace}{index:03x}{rng.getrandbits(32):08x}"
+    station_a_names = ("Station A ", "North Hub ", "北站 ")
+    station_b_names = ("Station B ", "South Hub ", "南站 ")
+    station_a = {
+        "id": token + "a",
+        "name": rng.choice(station_a_names) + token,
+        "stayTime": rng.randint(1, 40),
+    }
+    station_b = {
+        "id": token + "b",
+        "name": rng.choice(station_b_names) + token,
+        "stayTime": rng.randint(1, 40),
+    }
     train = {
         "id": "T" + token,
         "economyClass": rng.randint(100, 900),
@@ -344,10 +357,11 @@ def make_case(rng: random.Random, namespace: str, index: int) -> GraphCase:
         "endTime": end_time,
     }
     trip = {**trip_input, "tripId": {"type": trip_type, "number": trip_number}}
+    config_names = (token + "Config", "config " + token, "配置-" + token)
     config = {
-        "name": token + "Config",
-        "value": secrets.token_urlsafe(18),
-        "description": "generated " + secrets.token_urlsafe(22),
+        "name": rng.choice(config_names),
+        "value": f"v-{rng.getrandbits(64):016x}",
+        "description": f"d-{rng.getrandbits(64):016x}",
     }
     return GraphCase(
         config=config,
@@ -409,6 +423,24 @@ def verify_seed_catalog(client: APIClient) -> int:
     return checks
 
 
+def verify_seed_catalog_present(client: APIClient) -> int:
+    checks = 0
+    for service, expected_entities in SEED_CATALOG.items():
+        actual = index_entities(service, client.list_entities(service))
+        for expected_entity in expected_entities:
+            key = entity_key(service, expected_entity)
+            if key not in actual:
+                raise CheckFailure(f"seed {service} {key!r} disappeared after a runtime delete")
+            assert_entity(
+                service,
+                actual[key],
+                expected_entity,
+                where=f"surviving seed {service} {key}",
+            )
+            checks += 1
+    return checks
+
+
 def verify_welcomes_and_http(client: APIClient) -> int:
     checks = 0
     for service, (path, expected) in WELCOME_PATHS.items():
@@ -451,15 +483,19 @@ def verify_welcomes_and_http(client: APIClient) -> int:
 
 
 def create_case(client: APIClient, case: GraphCase) -> int:
-    client.envelope("config", "POST", "/configs", case.config, http_status=201)
-    client.envelope("station", "POST", "/stations", case.station_a, http_status=201)
-    client.envelope("station", "POST", "/stations", case.station_b, http_status=201)
-    client.envelope("train", "POST", "/trains", case.train)
-    route_result = client.envelope("route", "POST", "/routes", case.route_input)
-    assert_entity("route", route_result["data"], case.route, where="route create response")
-    price_result = client.envelope("price", "POST", "/prices", case.price, http_status=201)
-    assert_entity("price", price_result["data"], case.price, where="price create response")
-    client.envelope("travel", "POST", "/trips", case.trip_input, http_status=201)
+    try:
+        client.envelope("config", "POST", "/configs", case.config, http_status=201)
+        client.envelope("station", "POST", "/stations", case.station_a, http_status=201)
+        client.envelope("station", "POST", "/stations", case.station_b, http_status=201)
+        client.envelope("train", "POST", "/trains", case.train)
+        route_result = client.envelope("route", "POST", "/routes", case.route_input)
+        assert_entity("route", route_result["data"], case.route, where="route create response")
+        price_result = client.envelope("price", "POST", "/prices", case.price, http_status=201)
+        assert_entity("price", price_result["data"], case.price, where="price create response")
+        client.envelope("travel", "POST", "/trips", case.trip_input, http_status=201)
+    except Exception:
+        cleanup_cases(client, [case])
+        raise
     return 7
 
 
@@ -471,6 +507,8 @@ def verify_case(client: APIClient, case: GraphCase, rng: random.Random) -> int:
             "config", "GET", "/configs/" + urllib.parse.quote(case.config["name"], safe="")
         )["data"]
         assert_entity("config", data, case.config, where="config read-your-write")
+        listed = index_entities("config", client.list_entities("config"))
+        assert_entity("config", listed[case.config["name"]], case.config, where="config list")
 
     def check_station(item: Mapping[str, Any]) -> None:
         entities = index_entities("station", client.list_entities("station"))
@@ -487,6 +525,8 @@ def verify_case(client: APIClient, case: GraphCase, rng: random.Random) -> int:
     def check_train() -> None:
         data = client.envelope("train", "GET", "/trains/" + case.train["id"])["data"]
         assert_entity("train", data, case.train, where="train read-your-write")
+        listed = index_entities("train", client.list_entities("train"))
+        assert_entity("train", listed[case.train["id"]], case.train, where="train list")
 
     def check_route() -> None:
         data = client.envelope("route", "GET", "/routes/" + case.route["id"])["data"]
@@ -498,6 +538,8 @@ def verify_case(client: APIClient, case: GraphCase, rng: random.Random) -> int:
         )["data"]
         if not isinstance(found, list) or case.route["id"] not in index_entities("route", found):
             raise CheckFailure("route start/terminal lookup omitted the newly written route")
+        listed = index_entities("route", client.list_entities("route"))
+        assert_entity("route", listed[case.route["id"]], case.route, where="route list")
 
     def check_price() -> None:
         data = client.envelope(
@@ -506,11 +548,15 @@ def verify_case(client: APIClient, case: GraphCase, rng: random.Random) -> int:
             f"/prices/{case.price['routeId']}/{case.price['trainType']}",
         )["data"]
         assert_entity("price", data, case.price, where="price read-your-write")
+        listed = index_entities("price", client.list_entities("price"))
+        assert_entity("price", listed[case.price["id"]], case.price, where="price list")
 
     def check_trip() -> None:
         key = case.trip_input["tripId"]
         data = client.envelope("travel", "GET", "/trips/" + key)["data"]
         assert_entity("travel", data, case.trip, where="trip read-your-write")
+        listed = index_entities("travel", client.list_entities("travel"))
+        assert_entity("travel", listed[key], case.trip, where="trip list")
 
     checks.extend(
         (
@@ -523,8 +569,8 @@ def verify_case(client: APIClient, case: GraphCase, rng: random.Random) -> int:
             check_trip,
         )
     )
-    if case.retired_station_names:
-        checks.append(lambda: verify_retired_station_names(client, case))
+    if case.retired_station_names or case.retired_route_keys or case.retired_price_keys:
+        checks.append(lambda: verify_retired_secondary_indexes(client, case))
     rng.shuffle(checks)
     for check in checks:
         check()
@@ -541,23 +587,61 @@ def verify_retired_station_names(client: APIClient, case: GraphCase) -> None:
         )
 
 
-def update_case(client: APIClient, case: GraphCase, rng: random.Random) -> int:
+def verify_retired_secondary_indexes(client: APIClient, case: GraphCase) -> None:
+    verify_retired_station_names(client, case)
+    for start_station, terminal_station in case.retired_route_keys:
+        client.envelope(
+            "route",
+            "GET",
+            f"/routes/{start_station}/{terminal_station}",
+            app_status=0,
+        )
+    for route_id, train_type in case.retired_price_keys:
+        client.envelope(
+            "price",
+            "GET",
+            f"/prices/{route_id}/{train_type}",
+            app_status=0,
+        )
+
+
+def update_case(
+    client: APIClient,
+    case: GraphCase,
+    rng: random.Random,
+) -> int:
     suffix = secrets.token_urlsafe(8)
     case.config["value"] = suffix
     case.config["description"] = "updated " + secrets.token_urlsafe(16)
     case.retired_station_names[case.station_a["name"]] = case.station_a["id"]
     case.retired_station_names[case.station_b["name"]] = case.station_b["id"]
-    case.station_a["name"] = "Updated A " + suffix
+    case.station_a["name"] = rng.choice(("Renamed A ", "Transfer Hub A ", "换乘站甲 ")) + suffix
     case.station_a["stayTime"] = rng.randint(41, 90)
-    case.station_b["name"] = "Updated B " + suffix
+    case.station_b["name"] = rng.choice(("Renamed B ", "Terminal Hub B ", "终点站乙 ")) + suffix
     case.station_b["stayTime"] = rng.randint(41, 90)
     case.train["averageSpeed"] = rng.randint(351, 500)
     case.train["economyClass"] += 7
+    case.retired_route_keys.append((case.route["startStationId"], case.route["terminalStationId"]))
+    case.route["stations"] = [case.station_b["id"], case.station_a["id"]]
+    case.route["startStationId"] = case.station_b["id"]
+    case.route["terminalStationId"] = case.station_a["id"]
     case.route["distances"][1] += rng.randint(1, 99)
+    case.route_input["startStation"] = case.station_b["id"]
+    case.route_input["endStation"] = case.station_a["id"]
+    case.route_input["stationList"] = f"{case.station_b['id']},{case.station_a['id']}"
     case.route_input["distanceList"] = f"0,{case.route['distances'][1]}"
+    case.retired_price_keys.append((case.price["routeId"], case.price["trainType"]))
+    case.price["routeId"] = rng.choice(SEED_CATALOG["route"])["id"]
+    case.price["trainType"] = rng.choice(SEED_CATALOG["train"])["id"]
     case.price["basicPriceRate"] = round(rng.uniform(0.11, 0.89), 4)
     case.price["firstClassPriceRate"] = round(rng.uniform(0.91, 1.89), 4)
     case.trip_input["endTime"] += rng.randint(60_000, 3_600_000)
+    case.trip_input["startingStationId"] = case.station_b["id"]
+    case.trip_input["stationsId"] = case.station_a["id"]
+    case.trip_input["terminalStationId"] = case.station_a["id"]
+    case.trip["startingStationId"] = case.station_b["id"]
+    case.trip["stationsId"] = case.station_a["id"]
+    case.trip["terminalStationId"] = case.station_a["id"]
     case.trip["endTime"] = case.trip_input["endTime"]
 
     operations = [
@@ -608,11 +692,24 @@ def verify_deleted(client: APIClient, case: GraphCase) -> int:
     ]
     for service, path in probes:
         client.envelope(service, "GET", path, app_status=0)
-    stations = index_entities("station", client.list_entities("station"))
+    deleted_entities = {
+        "config": (case.config,),
+        "station": (case.station_a, case.station_b),
+        "train": (case.train,),
+        "route": (case.route,),
+        "price": (case.price,),
+        "travel": (case.trip,),
+    }
+    list_checks = 0
+    for service, entities in deleted_entities.items():
+        listed = index_entities(service, client.list_entities(service))
+        for entity in entities:
+            key = entity_key(service, entity)
+            if key in listed:
+                raise CheckFailure(f"deleted {service} {key!r} remains visible in list")
+            list_checks += 1
     station_checks = 0
     for station in (case.station_a, case.station_b):
-        if station["id"] in stations:
-            raise CheckFailure(f"deleted station {station['id']} remains visible")
         client.envelope("station", "GET", "/stations/name/" + station["id"], app_status=0)
         client.envelope(
             "station",
@@ -629,7 +726,7 @@ def verify_deleted(client: APIClient, case: GraphCase) -> int:
             app_status=0,
         )
         station_checks += 1
-    return len(probes) + station_checks
+    return len(probes) + list_checks + station_checks
 
 
 def cleanup_cases(client: APIClient, cases: Sequence[GraphCase]) -> None:
@@ -711,24 +808,34 @@ class ManagedCandidate:
 
     def stop(self, *, kill: bool) -> None:
         process = self._process
-        self._process = None
         if process is None:
             return
         process_group = process.pid
+        descendants = descendant_processes(process.pid)
         requested_signal = signal.SIGKILL if kill else signal.SIGTERM
         signal_process_group(process_group, requested_signal)
+        signal_processes(descendants, requested_signal)
         try:
             process.wait(timeout=5)
         except subprocess.TimeoutExpired:
             pass
         if not wait_process_group_exit(process_group, timeout=5):
             signal_process_group(process_group, signal.SIGKILL)
+            signal_processes(descendants, signal.SIGKILL)
             try:
                 process.wait(timeout=1)
             except subprocess.TimeoutExpired:
                 pass
             if not wait_process_group_exit(process_group, timeout=5):
                 raise CheckFailure(f"candidate process group {process_group} did not terminate")
+        if not wait_candidate_stopped(self._client, timeout=2):
+            signal_processes(descendants, signal.SIGKILL)
+        if not wait_candidate_stopped(self._client, timeout=2):
+            raise CheckFailure(
+                "candidate endpoints remained ready after its process group terminated; "
+                "a detached child may have escaped crash enforcement"
+            )
+        self._process = None
 
     def crash_restart(self) -> None:
         self.stop(kill=True)
@@ -746,12 +853,70 @@ def signal_process_group(process_group: int, requested_signal: signal.Signals) -
         pass
 
 
+def descendant_processes(root_pid: int) -> set[int]:
+    try:
+        result = subprocess.run(
+            ["ps", "-e", "-o", "pid=,ppid="],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    children: dict[int, list[int]] = {}
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        try:
+            pid, parent = (int(field) for field in fields)
+        except ValueError:
+            continue
+        children.setdefault(parent, []).append(pid)
+    descendants: set[int] = set()
+    pending = list(children.get(root_pid, ()))
+    while pending:
+        pid = pending.pop()
+        if pid in descendants:
+            continue
+        descendants.add(pid)
+        pending.extend(children.get(pid, ()))
+    return descendants
+
+
+def signal_processes(processes: Iterable[int], requested_signal: signal.Signals) -> None:
+    for process in processes:
+        try:
+            os.kill(process, requested_signal)
+        except ProcessLookupError:
+            pass
+
+
 def wait_process_group_exit(process_group: int, timeout: float) -> bool:
     deadline = time.monotonic() + timeout
     while True:
         try:
             os.killpg(process_group, 0)
         except ProcessLookupError:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.05)
+
+
+def wait_candidate_stopped(client: APIClient, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while True:
+        any_ready = False
+        for service, (path, _) in WELCOME_PATHS.items():
+            try:
+                if client.request(service, "GET", path).status == 200:
+                    any_ready = True
+                    break
+            except Exception:
+                continue
+        if not any_ready:
             return True
         if time.monotonic() >= deadline:
             return False
@@ -815,9 +980,16 @@ def run_suite(
 
         deletion_order = list(cases)
         rng.shuffle(deletion_order)
+        live_cases = list(cases)
         for case in deletion_order:
             checks += delete_case(client, case, rng)
             checks += verify_deleted(client, case)
+            live_cases.remove(case)
+            checks += verify_seed_catalog_present(client)
+            surviving_order = list(live_cases)
+            rng.shuffle(surviving_order)
+            for surviving_case in surviving_order:
+                checks += verify_case(client, surviving_case, rng)
         created.clear()
     finally:
         cleanup_cases(client, created)
@@ -866,7 +1038,7 @@ def main() -> int:
     client = APIClient(args.base_url, targets, args.timeout)
     seed = secrets.randbits(128)
     rng = random.Random(seed)
-    namespace = "vs" + secrets.token_hex(12)
+    namespace = secrets.token_hex(12)
     case_count = rng.randint(args.cases_min, args.cases_max)
     managed: ManagedCandidate | None = None
     temporary_state: tempfile.TemporaryDirectory[str] | None = None

--- a/examples/microservices/train-ticket/accuracy_checker/checker.py
+++ b/examples/microservices/train-ticket/accuracy_checker/checker.py
@@ -1,390 +1,855 @@
 #!/usr/bin/env python3
-"""Read-only deployment checker for the Train Ticket microservice app."""
+"""Black-box stateful correctness checker for Train Ticket v0.2.0 behavior."""
 
 from __future__ import annotations
 
 import argparse
+import base64
+import hashlib
+import hmac
+import http.client
 import json
+import os
+import random
+import secrets
+import signal
+import subprocess
 import sys
+import tempfile
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
-from urllib.error import HTTPError, URLError
-from urllib.parse import urljoin, urlsplit, urlunsplit
-from urllib.request import Request, urlopen
+
+SERVICE_PATHS = {
+    "config": "/api/v1/configservice",
+    "station": "/api/v1/stationservice",
+    "train": "/api/v1/trainservice",
+    "travel": "/api/v1/travelservice",
+    "route": "/api/v1/routeservice",
+    "price": "/api/v1/priceservice",
+}
+
+WELCOME_PATHS = {
+    "config": ("/welcome", "Welcome to [ Config Service ] !"),
+    "station": ("/welcome", "Welcome to [ Station Service ] !"),
+    "train": ("/trains/welcome", "Welcome to [ Train Service ] !"),
+    "travel": ("/welcome", "Welcome to [ Travel Service ] !"),
+    "route": ("/welcome", "Welcome to [ Route Service ] !"),
+    "price": ("/prices/welcome", "Welcome to [ Price Service ] !"),
+}
+
+LIST_PATHS = {
+    "config": "/configs",
+    "station": "/stations",
+    "train": "/trains",
+    "travel": "/trips",
+    "route": "/routes",
+    "price": "/prices",
+}
+
+ENTITY_FIELDS = {
+    "config": {"name", "value", "description"},
+    "station": {"id", "name", "stayTime"},
+    "train": {"id", "economyClass", "confortClass", "averageSpeed"},
+    "travel": {
+        "tripId",
+        "trainTypeId",
+        "routeId",
+        "startingTime",
+        "startingStationId",
+        "stationsId",
+        "terminalStationId",
+        "endTime",
+    },
+    "route": {"id", "stations", "distances", "startStationId", "terminalStationId"},
+    "price": {
+        "id",
+        "trainType",
+        "routeId",
+        "basicPriceRate",
+        "firstClassPriceRate",
+    },
+}
+
+SEED_CATALOG: dict[str, list[dict[str, Any]]] = json.loads(
+    (Path(__file__).with_name("seed_catalog.json")).read_text(encoding="utf-8")
+)
+
+
+class CheckFailure(RuntimeError):
+    """Raised when an externally observable correctness property is violated."""
 
 
 @dataclass(frozen=True)
-class Check:
-    name: str
-    method: str
-    path: str
-    expect_json: bool = False
-    expect_text: str | None = None
-    expect_items: bool = False
-    # Keys every returned item must have. Restricted to fields that exist in
-    # both the 0.2.0 prebuilt images and the v1.0.0 source entities.
-    required_item_keys: tuple[str, ...] = ()
-    body: Any | None = None
+class HTTPResult:
+    status: int
+    headers: Mapping[str, str]
+    raw: bytes
+    json: Any | None
 
 
-CHECKS = [
-    Check(
-        "config welcome",
-        "GET",
-        "/api/v1/configservice/welcome",
-        expect_text="Welcome to [ Config Service ]",
-    ),
-    Check(
-        "station welcome",
-        "GET",
-        "/api/v1/stationservice/welcome",
-        expect_text="Welcome to [ Station Service ]",
-    ),
-    Check(
-        "train welcome",
-        "GET",
-        "/api/v1/trainservice/trains/welcome",
-        expect_text="Welcome to [ Train Service ]",
-    ),
-    Check(
-        "travel welcome",
-        "GET",
-        "/api/v1/travelservice/welcome",
-        expect_text="Welcome to [ Travel Service ]",
-    ),
-    Check(
-        "route welcome",
-        "GET",
-        "/api/v1/routeservice/welcome",
-        expect_text="Welcome to [ Route Service ]",
-    ),
-    Check(
-        "price welcome",
-        "GET",
-        "/api/v1/priceservice/prices/welcome",
-        expect_text="Welcome to [ Price Service ]",
-    ),
-    Check(
-        "stations list",
-        "GET",
-        "/api/v1/stationservice/stations",
-        expect_json=True,
-        expect_items=True,
-        required_item_keys=("id", "name"),
-    ),
-    Check(
-        "trains list",
-        "GET",
-        "/api/v1/trainservice/trains",
-        expect_json=True,
-        expect_items=True,
-        required_item_keys=("id", "averageSpeed"),
-    ),
-    Check(
-        "trips list",
-        "GET",
-        "/api/v1/travelservice/trips",
-        expect_json=True,
-        expect_items=True,
-        required_item_keys=("tripId", "routeId"),
-    ),
-    Check(
-        "routes list",
-        "GET",
-        "/api/v1/routeservice/routes",
-        expect_json=True,
-        expect_items=True,
-        required_item_keys=("id", "stations"),
-    ),
-    Check(
-        "prices list",
-        "GET",
-        "/api/v1/priceservice/prices",
-        expect_json=True,
-        expect_items=True,
-        required_item_keys=("id", "trainType", "routeId", "basicPriceRate"),
-    ),
-    Check(
-        "configs list",
-        "GET",
-        "/api/v1/configservice/configs",
-        expect_json=True,
-        expect_items=True,
-        required_item_keys=("name", "value"),
-    ),
-]
-
-# Referential-integrity checks over the seeded data. Field names are looked up
-# per item because 0.2.0 and v1.0.0 use different names for some references;
-# a check silently skips when the source field is absent. Targets may list
-# several keys: v1.0.0 TrainType has a random UUID id and keeps the human name
-# in a separate "name" field that price configs reference, so train references
-# match against the union of both.
-CONSISTENCY_CHECKS = [
-    ("trips reference routes", "trips list", ("routeId",), "routes list", ("id",)),
-    ("prices reference routes", "prices list", ("routeId",), "routes list", ("id",)),
-    ("prices reference trains", "prices list", ("trainType",), "trains list", ("id", "name")),
-    (
-        "trips reference stations",
-        "trips list",
-        ("startingStationId", "terminalStationId"),
-        "stations list",
-        ("id",),
-    ),
-    ("trips reference trains", "trips list", ("trainTypeId",), "trains list", ("id", "name")),
-]
-
-DIRECT_SERVICE_PORTS = {
-    "configservice": 15679,
-    "stationservice": 12345,
-    "trainservice": 14567,
-    "travelservice": 12346,
-    "routeservice": 11178,
-    "priceservice": 16579,
-}
+@dataclass
+class GraphCase:
+    config: dict[str, Any]
+    station_a: dict[str, Any]
+    station_b: dict[str, Any]
+    train: dict[str, Any]
+    route_input: dict[str, Any]
+    route: dict[str, Any]
+    price: dict[str, Any]
+    trip_input: dict[str, Any]
+    trip: dict[str, Any]
 
 
-def normalize_base_url(raw: str) -> str:
-    raw = raw.strip()
-    if not raw.lower().startswith(("http://", "https://")):
-        raw = "http://" + raw
-    return raw.rstrip("/") + "/"
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
 
 
-def format_host(hostname: str) -> str:
-    # urlsplit().hostname strips brackets from IPv6 literals; restore them.
-    if ":" in hostname:
-        return f"[{hostname}]"
-    return hostname
+def admin_token(now: int | None = None) -> str:
+    issued = int(time.time()) if now is None else now
+    header = _b64url(b'{"alg":"HS256","typ":"JWT"}')
+    claims = _b64url(
+        json.dumps(
+            {
+                "sub": "vibesys-checker",
+                "roles": ["ROLE_ADMIN"],
+                "id": "vibesys-checker",
+                "iat": issued,
+                "exp": issued + 3600,
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+    )
+    signing_input = f"{header}.{claims}".encode("ascii")
+    signature = _b64url(hmac.new(b"secret", signing_input, hashlib.sha256).digest())
+    return f"{header}.{claims}.{signature}"
 
 
-def check_url(base_url: str, check: Check, direct_services: bool) -> str:
-    if not direct_services:
-        return urljoin(base_url, check.path.lstrip("/"))
-    parts = check.path.strip("/").split("/")
-    if len(parts) < 3 or parts[0] != "api" or parts[1] != "v1":
-        raise RuntimeError(f"{check.name}: cannot map path to direct service URL: {check.path}")
-    service = parts[2]
-    port = DIRECT_SERVICE_PORTS.get(service)
-    if port is None:
-        raise RuntimeError(f"{check.name}: no direct port mapping for service {service!r}")
-    base = urlsplit(base_url)
-    host = format_host(base.hostname or "localhost")
-    netloc = f"{host}:{port}"
-    return urlunsplit((base.scheme or "http", netloc, check.path, "", ""))
+class APIClient:
+    def __init__(self, base_url: str, targets: Mapping[str, str], timeout: float) -> None:
+        default = base_url.rstrip("/")
+        self._targets = {name: targets.get(name, default).rstrip("/") for name in SERVICE_PATHS}
+        self._timeout = timeout
+        self._token = admin_token()
 
+    def url(self, service: str, path: str) -> str:
+        return self._targets[service] + SERVICE_PATHS[service] + path
 
-def request_json_or_text(
-    base_url: str,
-    check: Check,
-    timeout: float,
-    direct_services: bool,
-) -> tuple[int, str, Any | None, float]:
-    url = check_url(base_url, check, direct_services)
-    data = None
-    headers = {"Accept": "application/json,text/plain,*/*"}
-    if check.body is not None:
-        data = json.dumps(check.body).encode("utf-8")
-        headers["Content-Type"] = "application/json"
-    req = Request(url, data=data, headers=headers, method=check.method)
-    start = time.perf_counter()
-    try:
-        with urlopen(req, timeout=timeout) as resp:
-            raw = resp.read().decode("utf-8", errors="replace")
-            status = resp.status
-    except HTTPError as exc:
-        raw = exc.read().decode("utf-8", errors="replace")
-        status = exc.code
-    except URLError as exc:
-        raise RuntimeError(f"{check.name}: request failed: {exc}") from exc
-    elapsed_ms = (time.perf_counter() - start) * 1000.0
-
-    parsed = None
-    if check.expect_json or check.expect_items:
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise RuntimeError(f"{check.name}: response is not valid JSON: {raw[:200]!r}") from exc
-    return status, raw, parsed, elapsed_ms
-
-
-def extract_items(payload: Any) -> list[Any]:
-    if isinstance(payload, list):
-        return payload
-    if isinstance(payload, dict):
-        data = payload.get("data")
-        if isinstance(data, list):
-            return data
+    def request(
+        self,
+        service: str,
+        method: str,
+        path: str,
+        body: Any | None = None,
+        *,
+        authenticated: bool = True,
+    ) -> HTTPResult:
+        data = None if body is None else json.dumps(body, separators=(",", ":")).encode("utf-8")
+        headers = {"Accept": "application/json,text/plain,*/*"}
         if data is not None:
-            return [data]
-    return []
+            headers["Content-Type"] = "application/json"
+        if authenticated:
+            headers["Authorization"] = f"Bearer {self._token}"
+        request = urllib.request.Request(
+            self.url(service, path), data=data, headers=headers, method=method
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self._timeout) as response:
+                status = response.status
+                response_headers = {key.lower(): value for key, value in response.headers.items()}
+                raw = response.read()
+        except urllib.error.HTTPError as exc:
+            status = exc.code
+            response_headers = {key.lower(): value for key, value in exc.headers.items()}
+            raw = exc.read()
+        parsed = None
+        if raw:
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                parsed = None
+        return HTTPResult(status=status, headers=response_headers, raw=raw, json=parsed)
 
-
-def validate_envelope(check: Check, parsed: Any, allow_empty: bool) -> None:
-    """Enforce the edu.fudan.common.util.Response convention: status 1 = success.
-
-    An HTTP 200 body like {"status":0,"msg":"error","data":null} is a
-    service-level failure and must not pass. The only tolerated non-1 status is
-    the "No content" empty result, and only under --allow-empty.
-    """
-    if not isinstance(parsed, dict) or "status" not in parsed:
-        return
-    status = parsed.get("status")
-    if status == 1:
-        return
-    if allow_empty and check.expect_items and not extract_items(parsed):
-        return
-    raise RuntimeError(
-        f"{check.name}: response envelope status={status!r} msg={parsed.get('msg')!r}"
-    )
-
-
-def validate_items(check: Check, items: list[Any]) -> None:
-    for idx, item in enumerate(items):
-        if not isinstance(item, dict):
-            raise RuntimeError(
-                f"{check.name}: item {idx} is {type(item).__name__}, expected object"
+    def envelope(
+        self,
+        service: str,
+        method: str,
+        path: str,
+        body: Any | None = None,
+        *,
+        http_status: int = 200,
+        app_status: int = 1,
+        authenticated: bool = True,
+    ) -> dict[str, Any]:
+        result = self.request(service, method, path, body, authenticated=authenticated)
+        if result.status != http_status:
+            raise CheckFailure(
+                f"{method} {service}{path}: HTTP {result.status}, expected {http_status}; "
+                f"body={result.raw[:300]!r}"
             )
-        missing = [key for key in check.required_item_keys if key not in item]
-        if missing:
-            raise RuntimeError(
-                f"{check.name}: item {idx} is missing expected fields {missing}: "
-                f"{json.dumps(item)[:200]}"
+        if not isinstance(result.json, dict) or set(result.json) != {"status", "msg", "data"}:
+            raise CheckFailure(
+                f"{method} {service}{path}: expected exact response envelope, got {result.json!r}"
             )
+        if result.json["status"] != app_status:
+            raise CheckFailure(
+                f"{method} {service}{path}: application status {result.json['status']!r}, "
+                f"expected {app_status}; envelope={result.json!r}"
+            )
+        return result.json
+
+    def list_entities(self, service: str) -> list[dict[str, Any]]:
+        envelope = self.envelope(service, "GET", LIST_PATHS[service])
+        data = envelope["data"]
+        if not isinstance(data, list):
+            raise CheckFailure(f"GET {service}{LIST_PATHS[service]}: data must be a list")
+        for index, item in enumerate(data):
+            validate_entity(service, item, where=f"{service} list item {index}")
+        return data
 
 
-def run_check(
-    base_url: str,
-    check: Check,
-    timeout: float,
-    allow_empty: bool,
-    direct_services: bool,
-) -> tuple[dict[str, Any], list[Any]]:
-    status, raw, parsed, elapsed_ms = request_json_or_text(
-        base_url, check, timeout, direct_services
-    )
-    if not (200 <= status < 300):
-        raise RuntimeError(f"{check.name}: HTTP {status}: {raw[:300]!r}")
-    if check.expect_text and check.expect_text not in raw:
-        raise RuntimeError(f"{check.name}: expected text {check.expect_text!r}, got {raw[:200]!r}")
-    validate_envelope(check, parsed, allow_empty)
-    item_count = None
-    items: list[Any] = []
-    if check.expect_items:
-        items = extract_items(parsed)
-        item_count = len(items)
-        if not allow_empty and item_count == 0:
-            raise RuntimeError(f"{check.name}: expected seeded data, got empty response")
-        validate_items(check, items)
-    result = {
-        "name": check.name,
-        "status": status,
-        "latency_ms": round(elapsed_ms, 3),
-        "item_count": item_count,
+def _is_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_number(value: Any) -> bool:
+    return (isinstance(value, int) and not isinstance(value, bool)) or isinstance(value, float)
+
+
+def trip_key(item: Mapping[str, Any]) -> str:
+    trip_id = item.get("tripId")
+    if not isinstance(trip_id, dict) or set(trip_id) != {"type", "number"}:
+        raise CheckFailure(f"tripId must be {{type, number}}, got {trip_id!r}")
+    train_type = trip_id["type"]
+    number = trip_id["number"]
+    if train_type not in {"G", "D"} or not isinstance(number, str) or not number:
+        raise CheckFailure(f"invalid tripId components: {trip_id!r}")
+    return train_type + number
+
+
+def entity_key(service: str, item: Mapping[str, Any]) -> str:
+    if service == "config":
+        return str(item["name"])
+    if service == "travel":
+        return trip_key(item)
+    return str(item["id"])
+
+
+def validate_entity(service: str, item: Any, *, where: str) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        raise CheckFailure(f"{where}: expected object, got {type(item).__name__}")
+    expected_fields = ENTITY_FIELDS[service]
+    if set(item) != expected_fields:
+        raise CheckFailure(f"{where}: fields {sorted(item)} do not match {sorted(expected_fields)}")
+    string_fields = {
+        "config": ("name", "value", "description"),
+        "station": ("id", "name"),
+        "train": ("id",),
+        "travel": (
+            "trainTypeId",
+            "routeId",
+            "startingStationId",
+            "stationsId",
+            "terminalStationId",
+        ),
+        "route": ("id", "startStationId", "terminalStationId"),
+        "price": ("id", "trainType", "routeId"),
+    }[service]
+    for field in string_fields:
+        if not isinstance(item[field], str):
+            raise CheckFailure(f"{where}.{field}: expected string, got {item[field]!r}")
+    if service == "station" and not _is_int(item["stayTime"]):
+        raise CheckFailure(f"{where}.stayTime must be an integer")
+    if service == "train":
+        for field in ("economyClass", "confortClass", "averageSpeed"):
+            if not _is_int(item[field]):
+                raise CheckFailure(f"{where}.{field} must be an integer")
+    if service == "route":
+        if not isinstance(item["stations"], list) or not all(
+            isinstance(value, str) for value in item["stations"]
+        ):
+            raise CheckFailure(f"{where}.stations must be a string list")
+        if not isinstance(item["distances"], list) or not all(
+            _is_int(value) for value in item["distances"]
+        ):
+            raise CheckFailure(f"{where}.distances must be an integer list")
+        if len(item["stations"]) != len(item["distances"]):
+            raise CheckFailure(f"{where}: stations and distances lengths differ")
+    if service == "price":
+        for field in ("basicPriceRate", "firstClassPriceRate"):
+            if not _is_number(item[field]):
+                raise CheckFailure(f"{where}.{field} must be numeric")
+    if service == "travel":
+        trip_key(item)
+        for field in ("startingTime", "endTime"):
+            if not _is_int(item[field]):
+                raise CheckFailure(f"{where}.{field} must be epoch milliseconds")
+    return item
+
+
+def make_case(rng: random.Random, namespace: str, index: int) -> GraphCase:
+    token = f"{namespace}{index:x}{rng.getrandbits(32):08x}"
+    station_a = {"id": token + "a", "name": "A " + token, "stayTime": rng.randint(1, 40)}
+    station_b = {"id": token + "b", "name": "B " + token, "stayTime": rng.randint(1, 40)}
+    train = {
+        "id": "T" + token,
+        "economyClass": rng.randint(100, 900),
+        "confortClass": rng.randint(50, 300),
+        "averageSpeed": rng.randint(80, 350),
     }
-    return result, items
+    route_id = str(uuid.UUID(int=rng.getrandbits(128), version=4))
+    distance = rng.randint(100, 1800)
+    route_input = {
+        "id": route_id,
+        "startStation": station_a["id"],
+        "endStation": station_b["id"],
+        "stationList": f"{station_a['id']},{station_b['id']}",
+        "distanceList": f"0,{distance}",
+    }
+    route = {
+        "id": route_id,
+        "stations": [station_a["id"], station_b["id"]],
+        "distances": [0, distance],
+        "startStationId": station_a["id"],
+        "terminalStationId": station_b["id"],
+    }
+    price = {
+        "id": str(uuid.UUID(int=rng.getrandbits(128), version=4)),
+        "trainType": train["id"],
+        "routeId": route_id,
+        "basicPriceRate": round(rng.uniform(0.1, 0.9), 4),
+        "firstClassPriceRate": round(rng.uniform(0.9, 1.9), 4),
+    }
+    trip_type = rng.choice(("G", "D"))
+    trip_number = f"{rng.randint(1000000, 9999999)}"
+    trip_id = trip_type + trip_number
+    starting_time = rng.randint(1_600_000_000_000, 1_900_000_000_000)
+    end_time = starting_time + rng.randint(3_600_000, 43_200_000)
+    trip_input = {
+        "tripId": trip_id,
+        "trainTypeId": train["id"],
+        "routeId": route_id,
+        "startingStationId": station_a["id"],
+        "stationsId": station_b["id"],
+        "terminalStationId": station_b["id"],
+        "startingTime": starting_time,
+        "endTime": end_time,
+    }
+    trip = {**trip_input, "tripId": {"type": trip_type, "number": trip_number}}
+    config = {
+        "name": token + "Config",
+        "value": secrets.token_urlsafe(18),
+        "description": "generated " + secrets.token_urlsafe(22),
+    }
+    return GraphCase(
+        config=config,
+        station_a=station_a,
+        station_b=station_b,
+        train=train,
+        route_input=route_input,
+        route=route,
+        price=price,
+        trip_input=trip_input,
+        trip=trip,
+    )
 
 
-def run_consistency_checks(
-    collected: dict[str, list[Any]],
-) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
-    """Cross-endpoint referential integrity over whatever data was fetched.
+def assert_entity(service: str, actual: Any, expected: Mapping[str, Any], *, where: str) -> None:
+    item = validate_entity(service, actual, where=where)
+    if item != expected:
+        raise CheckFailure(
+            f"{where}: entity mismatch\nactual={item!r}\nexpected={dict(expected)!r}"
+        )
 
-    A given check runs only when both sides returned data and the reference
-    field exists in the source items (field names differ across Train Ticket
-    versions); otherwise it is skipped.
-    """
-    results = []
-    failures = []
-    for name, src_name, ref_keys, dst_name, dst_keys in CONSISTENCY_CHECKS:
-        src_items = collected.get(src_name, [])
-        dst_items = collected.get(dst_name, [])
-        refs = {
-            item[key]
-            for item in src_items
-            if isinstance(item, dict)
-            for key in ref_keys
-            if item.get(key) is not None
-        }
-        targets = {
-            item[key]
-            for item in dst_items
-            if isinstance(item, dict)
-            for key in dst_keys
-            if item.get(key) is not None
-        }
-        if not refs or not targets:
-            continue
-        dangling = sorted(str(r) for r in refs - targets)
-        if dangling:
-            failures.append(
-                {
-                    "name": name,
-                    "error": f"{name}: dangling references not in {dst_name}: {dangling[:5]}",
-                }
+
+def index_entities(
+    service: str, entities: Iterable[Mapping[str, Any]]
+) -> dict[str, Mapping[str, Any]]:
+    return {entity_key(service, item): item for item in entities}
+
+
+def verify_seed_catalog(client: APIClient) -> int:
+    checks = 0
+    for service, expected_entities in SEED_CATALOG.items():
+        expected = index_entities(service, expected_entities)
+        actual = index_entities(service, client.list_entities(service))
+        if actual.keys() != expected.keys():
+            raise CheckFailure(
+                f"{service} seed IDs differ: missing={sorted(expected.keys() - actual.keys())}, "
+                f"unexpected={sorted(actual.keys() - expected.keys())}"
             )
-        else:
-            results.append(
-                {"name": name, "status": None, "latency_ms": None, "item_count": len(refs)}
+        for key, expected_entity in expected.items():
+            assert_entity(
+                service,
+                actual[key],
+                expected_entity,
+                where=f"seed {service} {key}",
             )
-    return results, failures
+            checks += 1
+    return checks
+
+
+def verify_welcomes_and_http(client: APIClient) -> int:
+    checks = 0
+    for service, (path, expected) in WELCOME_PATHS.items():
+        result = client.request(service, "GET", path)
+        if result.status != 200 or result.raw.decode("utf-8") != expected:
+            raise CheckFailure(
+                f"{service} welcome mismatch: HTTP {result.status}, body={result.raw!r}"
+            )
+        checks += 1
+
+    result = client.request("station", "GET", "/stations")
+    cache_control = result.headers.get("cache-control", "").lower()
+    if "public" in cache_control or "immutable" in cache_control:
+        raise CheckFailure(
+            f"mutable station collection has unsafe Cache-Control: {cache_control!r}"
+        )
+
+    parsed = urllib.parse.urlsplit(client.url("station", "/stations"))
+    connection = http.client.HTTPConnection(parsed.hostname, parsed.port, timeout=5)
+    try:
+        connection.request("GET", parsed.path, headers={"Authorization": f"Bearer {admin_token()}"})
+        first = connection.getresponse()
+        first.read()
+        first_socket = connection.sock
+        connection.request("GET", parsed.path, headers={"Authorization": f"Bearer {admin_token()}"})
+        second = connection.getresponse()
+        second.read()
+        if (
+            first.status != 200
+            or second.status != 200
+            or first_socket is None
+            or connection.sock is None
+        ):
+            raise CheckFailure("persistent HTTP connection did not serve two successful requests")
+        if connection.sock is not first_socket:
+            raise CheckFailure("server closed an HTTP/1.1 connection after one request")
+    finally:
+        connection.close()
+    return checks + 2
+
+
+def create_case(client: APIClient, case: GraphCase) -> int:
+    client.envelope("config", "POST", "/configs", case.config, http_status=201)
+    client.envelope("station", "POST", "/stations", case.station_a, http_status=201)
+    client.envelope("station", "POST", "/stations", case.station_b, http_status=201)
+    client.envelope("train", "POST", "/trains", case.train)
+    route_result = client.envelope("route", "POST", "/routes", case.route_input)
+    assert_entity("route", route_result["data"], case.route, where="route create response")
+    price_result = client.envelope("price", "POST", "/prices", case.price, http_status=201)
+    assert_entity("price", price_result["data"], case.price, where="price create response")
+    client.envelope("travel", "POST", "/trips", case.trip_input, http_status=201)
+    return 7
+
+
+def verify_case(client: APIClient, case: GraphCase, rng: random.Random) -> int:
+    checks: list[Callable[[], None]] = []
+
+    def check_config() -> None:
+        data = client.envelope(
+            "config", "GET", "/configs/" + urllib.parse.quote(case.config["name"], safe="")
+        )["data"]
+        assert_entity("config", data, case.config, where="config read-your-write")
+
+    def check_station(item: Mapping[str, Any]) -> None:
+        entities = index_entities("station", client.list_entities("station"))
+        assert_entity("station", entities[item["id"]], item, where="station read-your-write")
+        by_id = client.envelope("station", "GET", "/stations/name/" + item["id"])["data"]
+        if by_id != item["name"]:
+            raise CheckFailure(f"station name lookup returned {by_id!r}, expected {item['name']!r}")
+        by_name = client.envelope(
+            "station", "GET", "/stations/id/" + urllib.parse.quote(item["name"], safe="")
+        )["data"]
+        if by_name != item["id"]:
+            raise CheckFailure(f"station ID lookup returned {by_name!r}, expected {item['id']!r}")
+
+    def check_train() -> None:
+        data = client.envelope("train", "GET", "/trains/" + case.train["id"])["data"]
+        assert_entity("train", data, case.train, where="train read-your-write")
+
+    def check_route() -> None:
+        data = client.envelope("route", "GET", "/routes/" + case.route["id"])["data"]
+        assert_entity("route", data, case.route, where="route read-your-write")
+        found = client.envelope(
+            "route",
+            "GET",
+            f"/routes/{case.route['startStationId']}/{case.route['terminalStationId']}",
+        )["data"]
+        if not isinstance(found, list) or case.route["id"] not in index_entities("route", found):
+            raise CheckFailure("route start/terminal lookup omitted the newly written route")
+
+    def check_price() -> None:
+        data = client.envelope(
+            "price",
+            "GET",
+            f"/prices/{case.price['routeId']}/{case.price['trainType']}",
+        )["data"]
+        assert_entity("price", data, case.price, where="price read-your-write")
+
+    def check_trip() -> None:
+        key = case.trip_input["tripId"]
+        data = client.envelope("travel", "GET", "/trips/" + key)["data"]
+        assert_entity("travel", data, case.trip, where="trip read-your-write")
+
+    checks.extend(
+        (
+            check_config,
+            lambda: check_station(case.station_a),
+            lambda: check_station(case.station_b),
+            check_train,
+            check_route,
+            check_price,
+            check_trip,
+        )
+    )
+    rng.shuffle(checks)
+    for check in checks:
+        check()
+    return len(checks)
+
+
+def update_case(client: APIClient, case: GraphCase, rng: random.Random) -> int:
+    suffix = secrets.token_urlsafe(8)
+    case.config["value"] = suffix
+    case.config["description"] = "updated " + secrets.token_urlsafe(16)
+    case.station_a["name"] = "Updated A " + suffix
+    case.station_a["stayTime"] = rng.randint(41, 90)
+    case.station_b["name"] = "Updated B " + suffix
+    case.station_b["stayTime"] = rng.randint(41, 90)
+    case.train["averageSpeed"] = rng.randint(351, 500)
+    case.train["economyClass"] += 7
+    case.route["distances"][1] += rng.randint(1, 99)
+    case.route_input["distanceList"] = f"0,{case.route['distances'][1]}"
+    case.price["basicPriceRate"] = round(rng.uniform(0.11, 0.89), 4)
+    case.price["firstClassPriceRate"] = round(rng.uniform(0.91, 1.89), 4)
+    case.trip_input["endTime"] += rng.randint(60_000, 3_600_000)
+    case.trip["endTime"] = case.trip_input["endTime"]
+
+    operations = [
+        lambda: client.envelope("config", "PUT", "/configs", case.config),
+        lambda: client.envelope("station", "PUT", "/stations", case.station_a),
+        lambda: client.envelope("station", "PUT", "/stations", case.station_b),
+        lambda: client.envelope("train", "PUT", "/trains", case.train),
+        lambda: client.envelope("route", "POST", "/routes", case.route_input),
+        lambda: client.envelope("price", "PUT", "/prices", case.price),
+        lambda: client.envelope("travel", "PUT", "/trips", case.trip_input),
+    ]
+    rng.shuffle(operations)
+    for operation in operations:
+        operation()
+    return len(operations)
+
+
+def delete_case(client: APIClient, case: GraphCase, rng: random.Random) -> int:
+    dependent = [
+        lambda: client.envelope("travel", "DELETE", "/trips/" + case.trip_input["tripId"]),
+        lambda: client.envelope("price", "DELETE", "/prices", case.price),
+    ]
+    rng.shuffle(dependent)
+    for operation in dependent:
+        operation()
+    client.envelope("route", "DELETE", "/routes/" + case.route["id"])
+    independent = [
+        lambda: client.envelope("train", "DELETE", "/trains/" + case.train["id"]),
+        lambda: client.envelope("station", "DELETE", "/stations", case.station_a),
+        lambda: client.envelope("station", "DELETE", "/stations", case.station_b),
+        lambda: client.envelope(
+            "config", "DELETE", "/configs/" + urllib.parse.quote(case.config["name"], safe="")
+        ),
+    ]
+    rng.shuffle(independent)
+    for operation in independent:
+        operation()
+    return len(dependent) + 1 + len(independent)
+
+
+def verify_deleted(client: APIClient, case: GraphCase) -> int:
+    probes = [
+        ("config", "/configs/" + urllib.parse.quote(case.config["name"], safe="")),
+        ("train", "/trains/" + case.train["id"]),
+        ("route", "/routes/" + case.route["id"]),
+        ("price", f"/prices/{case.price['routeId']}/{case.price['trainType']}"),
+        ("travel", "/trips/" + case.trip_input["tripId"]),
+    ]
+    for service, path in probes:
+        client.envelope(service, "GET", path, app_status=0)
+    stations = index_entities("station", client.list_entities("station"))
+    for station in (case.station_a, case.station_b):
+        if station["id"] in stations:
+            raise CheckFailure(f"deleted station {station['id']} remains visible")
+    return len(probes) + 2
+
+
+def cleanup_cases(client: APIClient, cases: Sequence[GraphCase]) -> None:
+    for case in reversed(cases):
+        best_effort = [
+            ("travel", "DELETE", "/trips/" + case.trip_input["tripId"], None),
+            ("price", "DELETE", "/prices", case.price),
+            ("route", "DELETE", "/routes/" + case.route["id"], None),
+            ("train", "DELETE", "/trains/" + case.train["id"], None),
+            ("station", "DELETE", "/stations", case.station_a),
+            ("station", "DELETE", "/stations", case.station_b),
+            (
+                "config",
+                "DELETE",
+                "/configs/" + urllib.parse.quote(case.config["name"], safe=""),
+                None,
+            ),
+        ]
+        for service, method, path, body in best_effort:
+            try:
+                client.request(service, method, path, body)
+            except Exception:
+                pass
+
+
+def wait_ready(client: APIClient, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = "not attempted"
+    while time.monotonic() < deadline:
+        try:
+            for service, (path, _) in WELCOME_PATHS.items():
+                result = client.request(service, "GET", path)
+                if result.status != 200:
+                    raise RuntimeError(f"{service} returned HTTP {result.status}")
+            return
+        except Exception as exc:
+            last_error = str(exc)
+            time.sleep(0.1)
+    raise CheckFailure(f"candidate/reference did not become ready: {last_error}")
+
+
+class ManagedCandidate:
+    def __init__(
+        self,
+        command: Sequence[str],
+        cwd: Path,
+        state_dir: Path,
+        client: APIClient,
+        startup_timeout: float,
+    ) -> None:
+        self._command = list(command)
+        self._cwd = cwd
+        self._state_dir = state_dir
+        self._client = client
+        self._startup_timeout = startup_timeout
+        self._process: subprocess.Popen[bytes] | None = None
+        self._log = tempfile.NamedTemporaryFile(prefix="train-ticket-candidate-", suffix=".log")
+
+    def start(self) -> None:
+        if self._process is not None:
+            raise RuntimeError("candidate is already running")
+        env = os.environ.copy()
+        env["TRAIN_TICKET_DATA_DIR"] = str(self._state_dir)
+        self._process = subprocess.Popen(
+            self._command,
+            cwd=self._cwd,
+            env=env,
+            stdout=self._log,
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            wait_ready(self._client, self._startup_timeout)
+        except Exception as exc:
+            self.stop(kill=True)
+            self._log.seek(0)
+            log = self._log.read().decode("utf-8", errors="replace")
+            raise CheckFailure(f"candidate startup failed; log:\n{log[:4000]}") from exc
+
+    def stop(self, *, kill: bool) -> None:
+        process = self._process
+        self._process = None
+        if process is None:
+            return
+        if process.poll() is None:
+            if kill:
+                process.send_signal(signal.SIGKILL)
+            else:
+                process.send_signal(signal.SIGTERM)
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+
+    def crash_restart(self) -> None:
+        self.stop(kill=True)
+        self.start()
+
+    def close(self) -> None:
+        self.stop(kill=False)
+        self._log.close()
+
+
+def parse_targets(values: Sequence[str]) -> dict[str, str]:
+    targets: dict[str, str] = {}
+    for value in values:
+        if "=" not in value:
+            raise argparse.ArgumentTypeError(f"target {value!r} must be NAME=URL")
+        name, url = value.split("=", 1)
+        if name not in SERVICE_PATHS:
+            raise argparse.ArgumentTypeError(f"unknown target service {name!r}")
+        targets[name] = url
+    return targets
+
+
+def parse_command(raw: str, name: str) -> list[str]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise argparse.ArgumentTypeError(f"{name} must be a JSON string array: {exc}") from exc
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) for item in value):
+        raise argparse.ArgumentTypeError(f"{name} must be a non-empty JSON string array")
+    return value
+
+
+def run_suite(
+    client: APIClient,
+    restart: Callable[[], None] | None,
+    rng: random.Random,
+    namespace: str,
+    case_count: int,
+) -> dict[str, Any]:
+    checks = verify_welcomes_and_http(client)
+    checks += verify_seed_catalog(client)
+    cases = [make_case(rng, namespace, index) for index in range(case_count)]
+    created: list[GraphCase] = []
+    try:
+        creation_order = list(cases)
+        rng.shuffle(creation_order)
+        for case in creation_order:
+            checks += create_case(client, case)
+            created.append(case)
+            checks += verify_case(client, case, rng)
+
+        update_order = list(cases)
+        rng.shuffle(update_order)
+        for case in update_order:
+            checks += update_case(client, case, rng)
+            checks += verify_case(client, case, rng)
+
+        if restart is not None:
+            restart()
+            wait_ready(client, 30)
+            persistence_order = list(cases)
+            rng.shuffle(persistence_order)
+            for case in persistence_order:
+                checks += verify_case(client, case, rng)
+
+        deletion_order = list(cases)
+        rng.shuffle(deletion_order)
+        for case in deletion_order:
+            checks += delete_case(client, case, rng)
+            checks += verify_deleted(client, case)
+        created.clear()
+    finally:
+        cleanup_cases(client, created)
+    return {
+        "valid": True,
+        "checks": checks,
+        "random_cases": case_count,
+        "namespace_hash": hashlib.sha256(namespace.encode("utf-8")).hexdigest(),
+        "properties": {
+            "exact_seed_catalog": True,
+            "strict_entity_schemas": True,
+            "read_your_write": True,
+            "updates_visible": True,
+            "deletes_visible": True,
+            "cross_entity_graph": True,
+            "crash_recovery": restart is not None,
+            "persistent_http": True,
+        },
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8080")
+    parser.add_argument("--target", action="append", default=[], metavar="NAME=URL")
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--startup-timeout", type=float, default=15.0)
+    parser.add_argument("--cases-min", type=int, default=2)
+    parser.add_argument("--cases-max", type=int, default=5)
+    parser.add_argument("--run-command-json")
+    parser.add_argument("--candidate-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--state-dir", type=Path)
+    parser.add_argument("--restart-command-json")
+    parser.add_argument("--output-json", type=Path)
+    return parser
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Check a running Train Ticket deployment.")
-    parser.add_argument(
-        "--base-url", default="http://localhost:8080", help="UI proxy or gateway base URL"
-    )
-    parser.add_argument("--timeout", type=float, default=5.0, help="per-request timeout in seconds")
-    parser.add_argument(
-        "--allow-empty", action="store_true", help="allow list endpoints to return no seeded data"
-    )
-    parser.add_argument(
-        "--direct-services",
-        action="store_true",
-        help="bypass the gateway and route each service path to its exposed local service port",
-    )
-    parser.add_argument("--output-json", default=None, help="optional path for structured results")
-    args = parser.parse_args()
+    args = build_parser().parse_args()
+    if args.cases_min < 1 or args.cases_max < args.cases_min:
+        raise SystemExit("invalid randomized case bounds")
+    if args.run_command_json and args.restart_command_json:
+        raise SystemExit("provide at most one of --run-command-json or --restart-command-json")
 
-    base_url = normalize_base_url(args.base_url)
-    results = []
-    failures = []
-    collected: dict[str, list[Any]] = {}
-    for check in CHECKS:
-        try:
-            result, items = run_check(
-                base_url, check, args.timeout, args.allow_empty, args.direct_services
+    targets = parse_targets(args.target)
+    client = APIClient(args.base_url, targets, args.timeout)
+    seed = secrets.randbits(128)
+    rng = random.Random(seed)
+    namespace = "vs" + secrets.token_hex(12)
+    case_count = rng.randint(args.cases_min, args.cases_max)
+    managed: ManagedCandidate | None = None
+    temporary_state: tempfile.TemporaryDirectory[str] | None = None
+    try:
+        if args.run_command_json:
+            command = parse_command(args.run_command_json, "--run-command-json")
+            if args.state_dir is None:
+                temporary_state = tempfile.TemporaryDirectory(prefix="train-ticket-state-")
+                state_dir = Path(temporary_state.name)
+            else:
+                state_dir = args.state_dir.resolve()
+                state_dir.mkdir(parents=True, exist_ok=True)
+            managed = ManagedCandidate(
+                command,
+                args.candidate_dir.resolve(),
+                state_dir,
+                client,
+                args.startup_timeout,
             )
-            results.append(result)
-            collected[check.name] = items
-            print(f"PASS {check.name} ({result['latency_ms']:.1f} ms)")
-        except Exception as exc:
-            failures.append({"name": check.name, "error": str(exc)})
-            print(f"FAIL {check.name}: {exc}", file=sys.stderr)
+            managed.start()
+            restart = managed.crash_restart
+        elif args.restart_command_json:
+            restart_command = parse_command(args.restart_command_json, "--restart-command-json")
 
-    consistency_results, consistency_failures = run_consistency_checks(collected)
-    for result in consistency_results:
-        results.append(result)
-        print(f"PASS {result['name']} ({result['item_count']} references)")
-    for failure in consistency_failures:
-        failures.append(failure)
-        print(f"FAIL {failure['name']}: {failure['error']}", file=sys.stderr)
+            def restart() -> None:
+                subprocess.run(restart_command, check=True)
 
-    summary = {
-        "base_url": base_url.rstrip("/"),
-        "direct_services": args.direct_services,
-        "passed": len(results),
-        "failed": len(failures),
-        "results": results,
-        "failures": failures,
-    }
-    if args.output_json:
-        with open(args.output_json, "w", encoding="utf-8") as f:
-            json.dump(summary, f, indent=2)
-    print(json.dumps({"passed": summary["passed"], "failed": summary["failed"]}, indent=2))
-    return 1 if failures else 0
+            wait_ready(client, args.startup_timeout)
+        else:
+            restart = None
+            wait_ready(client, args.startup_timeout)
+
+        result = run_suite(client, restart, rng, namespace, case_count)
+        result["seed_sha256"] = hashlib.sha256(str(seed).encode("ascii")).hexdigest()
+        if args.output_json:
+            args.output_json.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps(result, indent=2))
+        return 0
+    except Exception as exc:
+        failure = {
+            "valid": False,
+            "error": str(exc),
+            "seed_sha256": hashlib.sha256(str(seed).encode("ascii")).hexdigest(),
+        }
+        if args.output_json:
+            args.output_json.write_text(json.dumps(failure, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps(failure, indent=2), file=sys.stderr)
+        return 1
+    finally:
+        if managed is not None:
+            managed.close()
+        if temporary_state is not None:
+            temporary_state.cleanup()
 
 
 if __name__ == "__main__":

--- a/examples/microservices/train-ticket/accuracy_checker/checker.py
+++ b/examples/microservices/train-ticket/accuracy_checker/checker.py
@@ -23,6 +23,7 @@ import urllib.request
 import uuid
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from pathlib import Path
 from typing import Any
 
@@ -105,6 +106,7 @@ class GraphCase:
     price: dict[str, Any]
     trip_input: dict[str, Any]
     trip: dict[str, Any]
+    retired_station_names: dict[str, str] = dataclass_field(default_factory=dict)
 
 
 def _b64url(raw: bytes) -> str:
@@ -371,14 +373,26 @@ def assert_entity(service: str, actual: Any, expected: Mapping[str, Any], *, whe
 def index_entities(
     service: str, entities: Iterable[Mapping[str, Any]]
 ) -> dict[str, Mapping[str, Any]]:
-    return {entity_key(service, item): item for item in entities}
+    indexed: dict[str, Mapping[str, Any]] = {}
+    for index, item in enumerate(entities):
+        key = entity_key(service, item)
+        if key in indexed:
+            raise CheckFailure(f"{service} list contains duplicate key {key!r} at item {index}")
+        indexed[key] = item
+    return indexed
 
 
 def verify_seed_catalog(client: APIClient) -> int:
     checks = 0
     for service, expected_entities in SEED_CATALOG.items():
         expected = index_entities(service, expected_entities)
-        actual = index_entities(service, client.list_entities(service))
+        actual_entities = client.list_entities(service)
+        if len(actual_entities) != len(expected_entities):
+            raise CheckFailure(
+                f"{service} seed count is {len(actual_entities)}, "
+                f"expected exactly {len(expected_entities)}"
+            )
+        actual = index_entities(service, actual_entities)
         if actual.keys() != expected.keys():
             raise CheckFailure(
                 f"{service} seed IDs differ: missing={sorted(expected.keys() - actual.keys())}, "
@@ -509,16 +523,30 @@ def verify_case(client: APIClient, case: GraphCase, rng: random.Random) -> int:
             check_trip,
         )
     )
+    if case.retired_station_names:
+        checks.append(lambda: verify_retired_station_names(client, case))
     rng.shuffle(checks)
     for check in checks:
         check()
     return len(checks)
 
 
+def verify_retired_station_names(client: APIClient, case: GraphCase) -> None:
+    for retired_name in case.retired_station_names:
+        client.envelope(
+            "station",
+            "GET",
+            "/stations/id/" + urllib.parse.quote(retired_name, safe=""),
+            app_status=0,
+        )
+
+
 def update_case(client: APIClient, case: GraphCase, rng: random.Random) -> int:
     suffix = secrets.token_urlsafe(8)
     case.config["value"] = suffix
     case.config["description"] = "updated " + secrets.token_urlsafe(16)
+    case.retired_station_names[case.station_a["name"]] = case.station_a["id"]
+    case.retired_station_names[case.station_b["name"]] = case.station_b["id"]
     case.station_a["name"] = "Updated A " + suffix
     case.station_a["stayTime"] = rng.randint(41, 90)
     case.station_b["name"] = "Updated B " + suffix
@@ -581,10 +609,27 @@ def verify_deleted(client: APIClient, case: GraphCase) -> int:
     for service, path in probes:
         client.envelope(service, "GET", path, app_status=0)
     stations = index_entities("station", client.list_entities("station"))
+    station_checks = 0
     for station in (case.station_a, case.station_b):
         if station["id"] in stations:
             raise CheckFailure(f"deleted station {station['id']} remains visible")
-    return len(probes) + 2
+        client.envelope("station", "GET", "/stations/name/" + station["id"], app_status=0)
+        client.envelope(
+            "station",
+            "GET",
+            "/stations/id/" + urllib.parse.quote(station["name"], safe=""),
+            app_status=0,
+        )
+        station_checks += 3
+    for retired_name in case.retired_station_names:
+        client.envelope(
+            "station",
+            "GET",
+            "/stations/id/" + urllib.parse.quote(retired_name, safe=""),
+            app_status=0,
+        )
+        station_checks += 1
+    return len(probes) + station_checks
 
 
 def cleanup_cases(client: APIClient, cases: Sequence[GraphCase]) -> None:
@@ -654,6 +699,7 @@ class ManagedCandidate:
             env=env,
             stdout=self._log,
             stderr=subprocess.STDOUT,
+            start_new_session=True,
         )
         try:
             wait_ready(self._client, self._startup_timeout)
@@ -668,16 +714,21 @@ class ManagedCandidate:
         self._process = None
         if process is None:
             return
-        if process.poll() is None:
-            if kill:
-                process.send_signal(signal.SIGKILL)
-            else:
-                process.send_signal(signal.SIGTERM)
+        process_group = process.pid
+        requested_signal = signal.SIGKILL if kill else signal.SIGTERM
+        signal_process_group(process_group, requested_signal)
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+        if not wait_process_group_exit(process_group, timeout=5):
+            signal_process_group(process_group, signal.SIGKILL)
             try:
-                process.wait(timeout=5)
+                process.wait(timeout=1)
             except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait(timeout=5)
+                pass
+            if not wait_process_group_exit(process_group, timeout=5):
+                raise CheckFailure(f"candidate process group {process_group} did not terminate")
 
     def crash_restart(self) -> None:
         self.stop(kill=True)
@@ -686,6 +737,25 @@ class ManagedCandidate:
     def close(self) -> None:
         self.stop(kill=False)
         self._log.close()
+
+
+def signal_process_group(process_group: int, requested_signal: signal.Signals) -> None:
+    try:
+        os.killpg(process_group, requested_signal)
+    except ProcessLookupError:
+        pass
+
+
+def wait_process_group_exit(process_group: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            os.killpg(process_group, 0)
+        except ProcessLookupError:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.05)
 
 
 def parse_targets(values: Sequence[str]) -> dict[str, str]:

--- a/examples/microservices/train-ticket/accuracy_checker/seed_catalog.json
+++ b/examples/microservices/train-ticket/accuracy_checker/seed_catalog.json
@@ -1,0 +1,59 @@
+{
+  "config": [
+    {"name": "DirectTicketAllocationProportion", "value": "0.5", "description": "Allocation Proportion Of The Direct Ticket - From Start To End"}
+  ],
+  "station": [
+    {"id": "beijing", "name": "Bei Jing", "stayTime": 10},
+    {"id": "hangzhou", "name": "Hang Zhou", "stayTime": 9},
+    {"id": "jiaxingnan", "name": "Jia Xing Nan", "stayTime": 2},
+    {"id": "jinan", "name": "Ji Nan", "stayTime": 5},
+    {"id": "nanjing", "name": "Nan Jing", "stayTime": 8},
+    {"id": "shanghai", "name": "Shang Hai", "stayTime": 10},
+    {"id": "shanghaihongqiao", "name": "Shang Hai Hong Qiao", "stayTime": 10},
+    {"id": "shijiazhuang", "name": "Shi Jia Zhuang", "stayTime": 8},
+    {"id": "suzhou", "name": "Su Zhou", "stayTime": 3},
+    {"id": "taiyuan", "name": "Tai Yuan", "stayTime": 5},
+    {"id": "wuxi", "name": "Wu Xi", "stayTime": 3},
+    {"id": "xuzhou", "name": "Xu Zhou", "stayTime": 7},
+    {"id": "zhenjiang", "name": "Zhen Jiang", "stayTime": 2}
+  ],
+  "train": [
+    {"id": "TeKuai", "economyClass": 2147483647, "confortClass": 2147483647, "averageSpeed": 120},
+    {"id": "ZhiDa", "economyClass": 2147483647, "confortClass": 2147483647, "averageSpeed": 120},
+    {"id": "DongCheOne", "economyClass": 2147483647, "confortClass": 2147483647, "averageSpeed": 180},
+    {"id": "GaoTieTwo", "economyClass": 2147483647, "confortClass": 2147483647, "averageSpeed": 200},
+    {"id": "GaoTieOne", "economyClass": 2147483647, "confortClass": 2147483647, "averageSpeed": 250},
+    {"id": "KuaiSu", "economyClass": 2147483647, "confortClass": 2147483647, "averageSpeed": 90}
+  ],
+  "travel": [
+    {"tripId": {"type": "G", "number": "1234"}, "trainTypeId": "GaoTieOne", "routeId": "92708982-77af-4318-be25-57ccb0ff69ad", "startingTime": 1367629200000, "startingStationId": "shanghai", "stationsId": "suzhou", "terminalStationId": "taiyuan", "endTime": 1367653912000},
+    {"tripId": {"type": "G", "number": "1237"}, "trainTypeId": "GaoTieTwo", "routeId": "084837bb-53c8-4438-87c8-0321a4d09917", "startingTime": 1367625600000, "startingStationId": "shanghai", "stationsId": "suzhou", "terminalStationId": "taiyuan", "endTime": 1367659312000},
+    {"tripId": {"type": "G", "number": "1235"}, "trainTypeId": "GaoTieOne", "routeId": "aefcef3f-3f42-46e8-afd7-6cb2a928bd3d", "startingTime": 1367640000000, "startingStationId": "shanghai", "stationsId": "suzhou", "terminalStationId": "taiyuan", "endTime": 1367661112000},
+    {"tripId": {"type": "D", "number": "1345"}, "trainTypeId": "DongCheOne", "routeId": "f3d4d4ef-693b-4456-8eed-59c0d717dd08", "startingTime": 1367622000000, "startingStationId": "shanghai", "stationsId": "suzhou", "terminalStationId": "taiyuan", "endTime": 1367668792000},
+    {"tripId": {"type": "G", "number": "1236"}, "trainTypeId": "GaoTieOne", "routeId": "a3f256c1-0e43-4f7d-9c21-121bf258101f", "startingTime": 1367647200000, "startingStationId": "shanghai", "stationsId": "suzhou", "terminalStationId": "taiyuan", "endTime": 1367671912000}
+  ],
+  "route": [
+    {"id": "92708982-77af-4318-be25-57ccb0ff69ad", "stations": ["nanjing", "zhenjiang", "wuxi", "suzhou", "shanghai"], "distances": [0, 100, 150, 200, 250], "startStationId": "nanjing", "terminalStationId": "shanghai"},
+    {"id": "20eb7122-3a11-423f-b10a-be0dc5bce7db", "stations": ["shanghai", "taiyuan"], "distances": [0, 1300], "startStationId": "shanghai", "terminalStationId": "taiyuan"},
+    {"id": "1367db1f-461e-4ab7-87ad-2bcc05fd9cb7", "stations": ["shanghaihongqiao", "jiaxingnan", "hangzhou"], "distances": [0, 150, 300], "startStationId": "shanghaihongqiao", "terminalStationId": "hangzhou"},
+    {"id": "a3f256c1-0e43-4f7d-9c21-121bf258101f", "stations": ["nanjing", "suzhou", "shanghai"], "distances": [0, 200, 250], "startStationId": "nanjing", "terminalStationId": "shanghai"},
+    {"id": "aefcef3f-3f42-46e8-afd7-6cb2a928bd3d", "stations": ["nanjing", "shanghai"], "distances": [0, 250], "startStationId": "nanjing", "terminalStationId": "shanghai"},
+    {"id": "d693a2c5-ef87-4a3c-bef8-600b43f62c68", "stations": ["taiyuan", "shijiazhuang", "nanjing", "shanghai"], "distances": [0, 300, 950, 1300], "startStationId": "taiyuan", "terminalStationId": "shanghai"},
+    {"id": "0b23bd3e-876a-4af3-b920-c50a90c90b04", "stations": ["shanghai", "nanjing", "shijiazhuang", "taiyuan"], "distances": [0, 350, 1000, 1300], "startStationId": "shanghai", "terminalStationId": "taiyuan"},
+    {"id": "9fc9c261-3263-4bfa-82f8-bb44e06b2f52", "stations": ["nanjing", "xuzhou", "jinan", "beijing"], "distances": [0, 500, 700, 1200], "startStationId": "nanjing", "terminalStationId": "beijing"},
+    {"id": "084837bb-53c8-4438-87c8-0321a4d09917", "stations": ["suzhou", "shanghai"], "distances": [0, 50], "startStationId": "suzhou", "terminalStationId": "shanghai"},
+    {"id": "f3d4d4ef-693b-4456-8eed-59c0d717dd08", "stations": ["shanghai", "suzhou"], "distances": [0, 50], "startStationId": "shanghai", "terminalStationId": "suzhou"}
+  ],
+  "price": [
+    {"id": "0eb474c9-f8be-4119-8681-eb538a404a6a", "trainType": "KuaiSu", "routeId": "1367db1f-461e-4ab7-87ad-2bcc05fd9cb7", "basicPriceRate": 0.2, "firstClassPriceRate": 1.0},
+    {"id": "dd0e572e-7443-420c-8280-7d8215636069", "trainType": "TeKuai", "routeId": "20eb7122-3a11-423f-b10a-be0dc5bce7db", "basicPriceRate": 0.3, "firstClassPriceRate": 1.0},
+    {"id": "8b059dc5-01a2-4f8f-8f94-6c886b38bb34", "trainType": "ZhiDa", "routeId": "d693a2c5-ef87-4a3c-bef8-600b43f62c68", "basicPriceRate": 0.32, "firstClassPriceRate": 1.0},
+    {"id": "8fb01829-393f-4af4-9e96-f72866f94d14", "trainType": "ZhiDa", "routeId": "9fc9c261-3263-4bfa-82f8-bb44e06b2f52", "basicPriceRate": 0.35, "firstClassPriceRate": 1.0},
+    {"id": "b90a6ad7-ffad-4624-9655-48e9e185fa6c", "trainType": "ZhiDa", "routeId": "0b23bd3e-876a-4af3-b920-c50a90c90b04", "basicPriceRate": 0.35, "firstClassPriceRate": 1.0},
+    {"id": "6d20b8cb-039c-474c-ae25-b6177ea41152", "trainType": "GaoTieOne", "routeId": "92708982-77af-4318-be25-57ccb0ff69ad", "basicPriceRate": 0.38, "firstClassPriceRate": 1.0},
+    {"id": "d5c4523a-827c-468c-95be-e9024a40572e", "trainType": "DongCheOne", "routeId": "f3d4d4ef-693b-4456-8eed-59c0d717dd08", "basicPriceRate": 0.45, "firstClassPriceRate": 1.0},
+    {"id": "c5679b7e-4a54-4f52-9939-1ae86ba16fa7", "trainType": "GaoTieOne", "routeId": "aefcef3f-3f42-46e8-afd7-6cb2a928bd3d", "basicPriceRate": 0.5, "firstClassPriceRate": 1.0},
+    {"id": "7de18cf8-bb17-4bb2-aeb4-85d8176d3a93", "trainType": "GaoTieTwo", "routeId": "084837bb-53c8-4438-87c8-0321a4d09917", "basicPriceRate": 0.6, "firstClassPriceRate": 1.0},
+    {"id": "719287d6-d3e7-4b54-9a92-71d039748b22", "trainType": "GaoTieOne", "routeId": "a3f256c1-0e43-4f7d-9c21-121bf258101f", "basicPriceRate": 0.7, "firstClassPriceRate": 1.0}
+  ]
+}

--- a/examples/microservices/train-ticket/accuracy_checker/tests/conftest.py
+++ b/examples/microservices/train-ticket/accuracy_checker/tests/conftest.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/microservices/train-ticket/accuracy_checker/tests/test_checker.py
+++ b/examples/microservices/train-ticket/accuracy_checker/tests/test_checker.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import random
 import signal
+import sys
+import time
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -13,13 +15,17 @@ from checker import (
     CheckFailure,
     ManagedCandidate,
     admin_token,
+    create_case,
     index_entities,
     make_case,
     trip_key,
     update_case,
     validate_entity,
+    verify_deleted,
+    verify_retired_secondary_indexes,
     verify_retired_station_names,
     verify_seed_catalog,
+    verify_seed_catalog_present,
 )
 
 
@@ -84,6 +90,20 @@ def test_admin_token_is_runtime_bound() -> None:
     assert len(first.split(".")) == 3
 
 
+def test_admin_token_has_random_mode_neutral_identity() -> None:
+    first = admin_token(now=1_000)
+    second = admin_token(now=1_000)
+
+    assert first != second
+    payload = first.split(".")[1]
+    payload += "=" * (-len(payload) % 4)
+    claims = checker_module.json.loads(checker_module.base64.urlsafe_b64decode(payload))
+    assert claims["sub"] == claims["id"]
+    assert len(claims["sub"]) == 24
+    int(claims["sub"], 16)
+    assert "checker" not in claims["sub"] and "benchmark" not in claims["sub"]
+
+
 def test_seed_catalog_checks_every_value() -> None:
     class CatalogClient:
         def __init__(self, catalog: dict[str, list[dict[str, Any]]]) -> None:
@@ -103,6 +123,11 @@ def test_seed_catalog_checks_every_value() -> None:
     duplicated["station"].append(deepcopy(duplicated["station"][0]))
     with pytest.raises(CheckFailure, match="seed count"):
         verify_seed_catalog(CatalogClient(duplicated))  # type: ignore[arg-type]
+
+    over_deleted = deepcopy(SEED_CATALOG)
+    over_deleted["train"].pop()
+    with pytest.raises(CheckFailure, match="disappeared after a runtime delete"):
+        verify_seed_catalog_present(CatalogClient(over_deleted))  # type: ignore[arg-type]
 
 
 def test_index_entities_rejects_duplicate_keys() -> None:
@@ -142,6 +167,76 @@ def test_station_updates_probe_retired_secondary_index_names() -> None:
     assert all(read[0:2] == ("station", "GET") and read[3] == 0 for read in client.negative_reads)
 
 
+def test_route_and_price_updates_probe_retired_secondary_keys() -> None:
+    class RecordingClient:
+        def __init__(self) -> None:
+            self.reads: list[tuple[str, str, int]] = []
+
+        def envelope(
+            self,
+            service: str,
+            method: str,
+            path: str,
+            body: Any | None = None,
+            *,
+            app_status: int = 1,
+            **_: Any,
+        ) -> dict[str, Any]:
+            if method == "GET":
+                self.reads.append((service, path, app_status))
+            return {"status": app_status, "msg": "ok", "data": [] if service == "route" else body}
+
+    first = make_case(random.Random(7), "0123456789abcdef01234567", 0)
+    old_route_key = (first.route["startStationId"], first.route["terminalStationId"])
+    old_price_key = (first.price["routeId"], first.price["trainType"])
+    client = RecordingClient()
+
+    update_case(client, first, random.Random(9))  # type: ignore[arg-type]
+    verify_retired_secondary_indexes(client, first)  # type: ignore[arg-type]
+
+    assert first.retired_route_keys == [old_route_key]
+    assert first.retired_price_keys == [old_price_key]
+    assert ("route", f"/routes/{old_route_key[0]}/{old_route_key[1]}", 0) in client.reads
+    assert ("price", f"/prices/{old_price_key[0]}/{old_price_key[1]}", 0) in client.reads
+
+
+def test_verify_deleted_rejects_non_station_entity_retained_only_in_list() -> None:
+    class PhantomListClient:
+        def envelope(self, *_: Any, app_status: int = 1, **__: Any) -> dict[str, Any]:
+            return {"status": app_status, "msg": "ok", "data": None}
+
+        def list_entities(self, service: str) -> list[dict[str, Any]]:
+            return [case.train] if service == "train" else []
+
+    case = make_case(random.Random(7), "tt0123456789abcdef01234567", 0)
+    with pytest.raises(CheckFailure, match="deleted train .* remains visible in list"):
+        verify_deleted(PhantomListClient(), case)  # type: ignore[arg-type]
+
+
+def test_partial_case_creation_is_cleaned_up() -> None:
+    class FailingCreateClient:
+        def __init__(self) -> None:
+            self.creates = 0
+            self.cleanup_requests: list[tuple[str, str, str]] = []
+
+        def envelope(self, service: str, method: str, path: str, *_: Any, **__: Any) -> Any:
+            self.creates += 1
+            if self.creates == 3:
+                raise CheckFailure("injected create failure")
+            return {"status": 1, "msg": "ok", "data": None}
+
+        def request(self, service: str, method: str, path: str, *_: Any, **__: Any) -> None:
+            self.cleanup_requests.append((service, method, path))
+
+    client = FailingCreateClient()
+    case = make_case(random.Random(7), "tt0123456789abcdef01234567", 0)
+    with pytest.raises(CheckFailure, match="injected create failure"):
+        create_case(client, case)  # type: ignore[arg-type]
+
+    assert len(client.cleanup_requests) == 7
+    assert all(method == "DELETE" for _, method, _ in client.cleanup_requests)
+
+
 def test_managed_candidate_starts_and_kills_a_process_group(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -175,6 +270,7 @@ def test_managed_candidate_starts_and_kills_a_process_group(
 
     monkeypatch.setattr(checker_module.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(checker_module, "wait_ready", lambda *_: None)
+    monkeypatch.setattr(checker_module, "descendant_processes", lambda *_: set())
     monkeypatch.setattr(checker_module.os, "killpg", fake_killpg)
 
     managed = ManagedCandidate(["./run.sh"], tmp_path, tmp_path, object(), 1)  # type: ignore[arg-type]
@@ -186,3 +282,56 @@ def test_managed_candidate_starts_and_kills_a_process_group(
 
     assert popen_arguments["start_new_session"] is True
     assert delivered_signals == [signal.SIGKILL]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="detached-child probe uses Linux /proc")
+def test_managed_candidate_kills_an_escaping_detached_child(tmp_path: Path) -> None:
+    pid_file = tmp_path / "child.pid"
+    child_code = (
+        "import os,sys,time; open(sys.argv[1], 'w').write(str(os.getpid())); time.sleep(60)"
+    )
+    launcher_code = (
+        "import os,subprocess,sys,time; "
+        "subprocess.Popen([sys.executable, '-c', sys.argv[2], sys.argv[1]], "
+        "start_new_session=True); "
+        "deadline=time.time()+5; "
+        "\nwhile not os.path.exists(sys.argv[1]) and time.time()<deadline: time.sleep(0.01); "
+        "\ntime.sleep(60)"
+    )
+
+    class ProcessProbeClient:
+        def request(self, *_: Any, **__: Any) -> Any:
+            if not pid_file.exists():
+                raise OSError("child has not started")
+            child_pid = int(pid_file.read_text())
+            stat_path = Path(f"/proc/{child_pid}/stat")
+            try:
+                process_state = stat_path.read_text().split()[2]
+            except (FileNotFoundError, ProcessLookupError) as exc:
+                raise OSError("child stopped") from exc
+            if process_state == "Z":
+                raise OSError("child stopped")
+            return checker_module.HTTPResult(status=200, headers={}, raw=b"", json=None)
+
+    managed = ManagedCandidate(
+        [sys.executable, "-c", launcher_code, str(pid_file), child_code],
+        tmp_path,
+        tmp_path,
+        ProcessProbeClient(),  # type: ignore[arg-type]
+        5,
+    )
+    child_pid: int | None = None
+    try:
+        managed.start()
+        child_pid = int(pid_file.read_text())
+        managed.stop(kill=True)
+        with pytest.raises(OSError, match="child stopped"):
+            ProcessProbeClient().request()
+    finally:
+        managed.close()
+        if child_pid is not None:
+            try:
+                checker_module.os.kill(child_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        time.sleep(0.05)

--- a/examples/microservices/train-ticket/accuracy_checker/tests/test_checker.py
+++ b/examples/microservices/train-ticket/accuracy_checker/tests/test_checker.py
@@ -1,17 +1,24 @@
 from __future__ import annotations
 
 import random
+import signal
 from copy import deepcopy
+from pathlib import Path
 from typing import Any
 
+import checker as checker_module
 import pytest
 from checker import (
     SEED_CATALOG,
     CheckFailure,
+    ManagedCandidate,
     admin_token,
+    index_entities,
     make_case,
     trip_key,
+    update_case,
     validate_entity,
+    verify_retired_station_names,
     verify_seed_catalog,
 )
 
@@ -91,3 +98,91 @@ def test_seed_catalog_checks_every_value() -> None:
     corrupted["price"][7]["basicPriceRate"] = 999.0
     with pytest.raises(CheckFailure, match="seed price"):
         verify_seed_catalog(CatalogClient(corrupted))  # type: ignore[arg-type]
+
+    duplicated = deepcopy(SEED_CATALOG)
+    duplicated["station"].append(deepcopy(duplicated["station"][0]))
+    with pytest.raises(CheckFailure, match="seed count"):
+        verify_seed_catalog(CatalogClient(duplicated))  # type: ignore[arg-type]
+
+
+def test_index_entities_rejects_duplicate_keys() -> None:
+    station = {"id": "duplicate", "name": "A", "stayTime": 1}
+
+    with pytest.raises(CheckFailure, match="duplicate key"):
+        index_entities("station", [station, {**station, "name": "B"}])
+
+
+def test_station_updates_probe_retired_secondary_index_names() -> None:
+    class RecordingClient:
+        def __init__(self) -> None:
+            self.negative_reads: list[tuple[str, str, str, int]] = []
+
+        def envelope(
+            self,
+            service: str,
+            method: str,
+            path: str,
+            body: Any | None = None,
+            *,
+            app_status: int = 1,
+            **_: Any,
+        ) -> dict[str, Any]:
+            if method == "GET":
+                self.negative_reads.append((service, method, path, app_status))
+            return {"status": app_status, "msg": "ok", "data": body}
+
+    case = make_case(random.Random(7), "namespace", 0)
+    old_names = {case.station_a["name"], case.station_b["name"]}
+    client = RecordingClient()
+    update_case(client, case, random.Random(8))  # type: ignore[arg-type]
+    verify_retired_station_names(client, case)  # type: ignore[arg-type]
+
+    assert set(case.retired_station_names) == old_names
+    assert len(client.negative_reads) == 2
+    assert all(read[0:2] == ("station", "GET") and read[3] == 0 for read in client.negative_reads)
+
+
+def test_managed_candidate_starts_and_kills_a_process_group(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class FakeProcess:
+        pid = 4312
+
+        def wait(self, timeout: float) -> int:
+            assert timeout == 5
+            return 0
+
+    popen_arguments: dict[str, Any] = {}
+    process = FakeProcess()
+
+    def fake_popen(*args: Any, **kwargs: Any) -> FakeProcess:
+        popen_arguments.update(kwargs)
+        return process
+
+    group_alive = True
+    delivered_signals: list[signal.Signals] = []
+
+    def fake_killpg(process_group: int, requested_signal: signal.Signals | int) -> None:
+        nonlocal group_alive
+        assert process_group == process.pid
+        if requested_signal == 0:
+            if not group_alive:
+                raise ProcessLookupError
+            return
+        delivered_signals.append(signal.Signals(requested_signal))
+        if requested_signal == signal.SIGKILL:
+            group_alive = False
+
+    monkeypatch.setattr(checker_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(checker_module, "wait_ready", lambda *_: None)
+    monkeypatch.setattr(checker_module.os, "killpg", fake_killpg)
+
+    managed = ManagedCandidate(["./run.sh"], tmp_path, tmp_path, object(), 1)  # type: ignore[arg-type]
+    try:
+        managed.start()
+        managed.stop(kill=True)
+    finally:
+        managed.close()
+
+    assert popen_arguments["start_new_session"] is True
+    assert delivered_signals == [signal.SIGKILL]

--- a/examples/microservices/train-ticket/accuracy_checker/tests/test_checker.py
+++ b/examples/microservices/train-ticket/accuracy_checker/tests/test_checker.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import random
+from copy import deepcopy
+from typing import Any
+
+import pytest
+from checker import (
+    SEED_CATALOG,
+    CheckFailure,
+    admin_token,
+    make_case,
+    trip_key,
+    validate_entity,
+    verify_seed_catalog,
+)
+
+
+def test_random_case_is_internally_referentially_consistent() -> None:
+    case = make_case(random.Random(7), "testnamespace", 3)
+
+    assert case.route["stations"] == [case.station_a["id"], case.station_b["id"]]
+    assert case.route["id"] == case.price["routeId"] == case.trip["routeId"]
+    assert case.train["id"] == case.price["trainType"] == case.trip["trainTypeId"]
+    assert trip_key(case.trip) == case.trip_input["tripId"]
+
+    for service, entity in (
+        ("config", case.config),
+        ("station", case.station_a),
+        ("station", case.station_b),
+        ("train", case.train),
+        ("route", case.route),
+        ("price", case.price),
+        ("travel", case.trip),
+    ):
+        assert validate_entity(service, entity, where=service) is entity
+
+
+def test_schema_validation_rejects_missing_and_extra_fields() -> None:
+    station = {"id": "x", "name": "X", "stayTime": 1}
+
+    with pytest.raises(CheckFailure, match="fields"):
+        validate_entity("station", {"id": "x", "name": "X"}, where="station")
+    with pytest.raises(CheckFailure, match="fields"):
+        validate_entity("station", {**station, "unexpected": True}, where="station")
+
+
+def test_schema_validation_rejects_type_substitution() -> None:
+    with pytest.raises(CheckFailure, match="stayTime"):
+        validate_entity(
+            "station",
+            {"id": "x", "name": "X", "stayTime": "1"},
+            where="station",
+        )
+    with pytest.raises(CheckFailure, match="tripId"):
+        validate_entity(
+            "travel",
+            {
+                "tripId": "G1234",
+                "trainTypeId": "GaoTieOne",
+                "routeId": "route",
+                "startingTime": 1,
+                "startingStationId": "a",
+                "stationsId": "b",
+                "terminalStationId": "c",
+                "endTime": 2,
+            },
+            where="trip",
+        )
+
+
+def test_admin_token_is_runtime_bound() -> None:
+    first = admin_token(now=1_000)
+    second = admin_token(now=1_001)
+
+    assert first != second
+    assert len(first.split(".")) == 3
+
+
+def test_seed_catalog_checks_every_value() -> None:
+    class CatalogClient:
+        def __init__(self, catalog: dict[str, list[dict[str, Any]]]) -> None:
+            self.catalog = catalog
+
+        def list_entities(self, service: str) -> list[dict[str, Any]]:
+            return self.catalog[service]
+
+    assert verify_seed_catalog(CatalogClient(deepcopy(SEED_CATALOG))) == 45  # type: ignore[arg-type]
+
+    corrupted = deepcopy(SEED_CATALOG)
+    corrupted["price"][7]["basicPriceRate"] = 999.0
+    with pytest.raises(CheckFailure, match="seed price"):
+        verify_seed_catalog(CatalogClient(corrupted))  # type: ignore[arg-type]

--- a/examples/microservices/train-ticket/benchmark/README.md
+++ b/examples/microservices/train-ticket/benchmark/README.md
@@ -27,11 +27,14 @@ go -C examples/evaluators/microservice run ./cmd/servicebench \
 The configured concurrency is held busy for the measurement duration, so the
 headline operations/sec value reflects achieved throughput instead of a fixed
 offered-rate ceiling. The resolved random seed is written into the result and
-can be replayed with `--seed <value>`. Override individual service targets with repeated
-`--target name=address` flags.
+can be replayed with `--seed <value>`. Override individual service targets with
+repeated `--target name=address` flags.
 
 One observation represents one logical operation and may contain multiple HTTP
 invocations. Total latency starts at the scheduled arrival and ends after the
 last response. Queue wait is reported separately, and the result reports both
 logical-operation counts and physical HTTP invocation counts. Any transport,
 schema, response-value, or read-your-write failure invalidates the run.
+List operations validate every returned record's schema and require the exact
+randomly selected runtime fixture to be present. Delete operations finish with
+a negative point read, so no-op deletes are rejected.

--- a/examples/microservices/train-ticket/benchmark/README.md
+++ b/examples/microservices/train-ticket/benchmark/README.md
@@ -30,11 +30,29 @@ offered-rate ceiling. The resolved random seed is written into the result and
 can be replayed with `--seed <value>`. Override individual service targets with
 repeated `--target name=address` flags.
 
+For diagnostic latency under a fixed offered load, select the open-loop profile
+and choose a rate the candidate can sustain:
+
+```bash
+go -C examples/evaluators/microservice run ./cmd/servicebench \
+  --workload "$PWD/examples/microservices/train-ticket/benchmark/workload.toml" \
+  --profile offered-load \
+  --rate 100 \
+  --base-url http://localhost:8080
+```
+
+The default closed-loop latency fields are saturation response times. They do
+not represent open-loop queueing latency because closed-loop workers issue no
+new arrivals while waiting for a response.
+
 One observation represents one logical operation and may contain multiple HTTP
 invocations. Total latency starts at the scheduled arrival and ends after the
 last response. Queue wait is reported separately, and the result reports both
 logical-operation counts and physical HTTP invocation counts. Any transport,
 schema, response-value, or read-your-write failure invalidates the run.
+Every configured operation type must be sampled at least once. Semantic
+validation completion is included in the throughput denominator, while the
+reported protocol and response latency fields still end at the last response.
 List operations validate every returned record's schema and require the exact
 randomly selected runtime fixture to be present. Delete operations finish with
 a negative point read, so no-op deletes are rejected.

--- a/examples/microservices/train-ticket/benchmark/README.md
+++ b/examples/microservices/train-ticket/benchmark/README.md
@@ -1,27 +1,37 @@
 # Train Ticket Workload
 
-`workload.toml` describes the application-specific portion of the benchmark:
-the seven read endpoints, their weights, Train Ticket response-envelope checks,
-the default load, and the `requests_per_second` objective.
+`workload.toml` defines a randomized stateful workload for the six mutable
+Train Ticket v0.2.0 services. Its measured traffic mix is:
 
-The shared evaluator under `examples/evaluators/microservice` owns scheduling,
-HTTP transport behavior, scheduled-arrival timing, aggregation, and structured
-results.
+- 35% list operations;
+- 25% point or secondary-index reads;
+- 35% update followed by an exact validating read; and
+- 5% create, read, delete, and negative-read operations.
+
+The shared `servicebench` evaluator owns closed-loop saturation scheduling,
+HTTP transport, logical-operation timing, aggregation, and structured results.
+The Train Ticket application adapter owns only fixture construction and
+response semantics.
 
 From the repository root:
 
 ```bash
-go -C examples/evaluators/microservice run ./cmd/microbench \
+go -C examples/evaluators/microservice run ./cmd/servicebench \
   --workload "$PWD/examples/microservices/train-ticket/benchmark/workload.toml" \
   --base-url http://localhost:8080 \
+  --seed random \
   --output-json /tmp/train-ticket.json \
   --output-raw /tmp/train-ticket.ndjson
 ```
 
-The workload preserves the previous fresh-connection policy explicitly with
-`session_policy = "new_per_request"`. Override individual targets with repeated
-`--target name=address` flags for the local direct-service deployment.
+The configured concurrency is held busy for the measurement duration, so the
+headline operations/sec value reflects achieved throughput instead of a fixed
+offered-rate ceiling. The resolved random seed is written into the result and
+can be replayed with `--seed <value>`. Override individual service targets with repeated
+`--target name=address` flags.
 
-Latency starts at each scheduled arrival, so queue wait is included in total
-latency and reported separately. A run is invalid when it cannot sustain at
-least 95% of the requested offered rate or when any request fails.
+One observation represents one logical operation and may contain multiple HTTP
+invocations. Total latency starts at the scheduled arrival and ends after the
+last response. Queue wait is reported separately, and the result reports both
+logical-operation counts and physical HTTP invocation counts. Any transport,
+schema, response-value, or read-your-write failure invalidates the run.

--- a/examples/microservices/train-ticket/benchmark/workload.toml
+++ b/examples/microservices/train-ticket/benchmark/workload.toml
@@ -174,3 +174,9 @@ unit = "operations/s"
 
 [constraints]
 max_error_rate = 0.0
+min_operations_per_type = 1
+
+[profiles.offered-load]
+model = "open_loop"
+rate = 100
+concurrency = 128

--- a/examples/microservices/train-ticket/benchmark/workload.toml
+++ b/examples/microservices/train-ticket/benchmark/workload.toml
@@ -1,148 +1,176 @@
 version = 1
-name = "train-ticket-read-only"
-application = "declarative"
+name = "train-ticket-stateful-randomized"
+application = "train-ticket"
 
 [load]
-model = "open_loop"
-rate = 10
+model = "closed_loop"
+rate = 0
 duration_seconds = 30
-warmup_seconds = 0
-concurrency = 32
+warmup_seconds = 2
+concurrency = 128
 timeout_seconds = 5
 repetitions = 1
 seed = 1
 min_offered_rate_ratio = 0.95
 
-[[targets]]
-name = "station"
-protocol = "http"
-address = "http://localhost:8080"
-session_policy = "new_per_request"
-
-[[targets]]
-name = "train"
-protocol = "http"
-address = "http://localhost:8080"
-session_policy = "new_per_request"
-
-[[targets]]
-name = "travel"
-protocol = "http"
-address = "http://localhost:8080"
-session_policy = "new_per_request"
-
-[[targets]]
-name = "route"
-protocol = "http"
-address = "http://localhost:8080"
-session_policy = "new_per_request"
-
-[[targets]]
-name = "price"
-protocol = "http"
-address = "http://localhost:8080"
-session_policy = "new_per_request"
+[application_config]
+records = 32
 
 [[targets]]
 name = "config"
 protocol = "http"
 address = "http://localhost:8080"
-session_policy = "new_per_request"
+session_policy = "reuse"
+
+[[targets]]
+name = "station"
+protocol = "http"
+address = "http://localhost:8080"
+session_policy = "reuse"
+
+[[targets]]
+name = "train"
+protocol = "http"
+address = "http://localhost:8080"
+session_policy = "reuse"
+
+[[targets]]
+name = "travel"
+protocol = "http"
+address = "http://localhost:8080"
+session_policy = "reuse"
+
+[[targets]]
+name = "route"
+protocol = "http"
+address = "http://localhost:8080"
+session_policy = "reuse"
+
+[[targets]]
+name = "price"
+protocol = "http"
+address = "http://localhost:8080"
+session_policy = "reuse"
 
 [[operations]]
-name = "stations"
+name = "list_config"
+target = "config"
+weight = 6
+tags = ["read", "list"]
+
+[[operations]]
+name = "list_station"
 target = "station"
-weight = 3
-[operations.http]
-method = "GET"
-path = "/api/v1/stationservice/stations"
-[operations.expect]
-statuses = [200]
-json = true
-json_status_if_present = 1
-json_object_requires_status_or_data = true
+weight = 6
+tags = ["read", "list"]
 
 [[operations]]
-name = "trains"
+name = "list_train"
 target = "train"
-weight = 3
-[operations.http]
-method = "GET"
-path = "/api/v1/trainservice/trains"
-[operations.expect]
-statuses = [200]
-json = true
-json_status_if_present = 1
-json_object_requires_status_or_data = true
+weight = 6
+tags = ["read", "list"]
 
 [[operations]]
-name = "trips"
+name = "list_travel"
+target = "travel"
+weight = 6
+tags = ["read", "list"]
+
+[[operations]]
+name = "list_route"
+target = "route"
+weight = 6
+tags = ["read", "list"]
+
+[[operations]]
+name = "list_price"
+target = "price"
+weight = 5
+tags = ["read", "list"]
+
+[[operations]]
+name = "read_config"
+target = "config"
+weight = 5
+tags = ["read", "point"]
+
+[[operations]]
+name = "read_station"
+target = "station"
+weight = 4
+tags = ["read", "secondary-index"]
+
+[[operations]]
+name = "read_train"
+target = "train"
+weight = 4
+tags = ["read", "point"]
+
+[[operations]]
+name = "read_travel"
 target = "travel"
 weight = 4
-[operations.http]
-method = "GET"
-path = "/api/v1/travelservice/trips"
-[operations.expect]
-statuses = [200]
-json = true
-json_status_if_present = 1
-json_object_requires_status_or_data = true
+tags = ["read", "point"]
 
 [[operations]]
-name = "routes"
+name = "read_route"
 target = "route"
-weight = 2
-[operations.http]
-method = "GET"
-path = "/api/v1/routeservice/routes"
-[operations.expect]
-statuses = [200]
-json = true
-json_status_if_present = 1
-json_object_requires_status_or_data = true
+weight = 4
+tags = ["read", "point"]
 
 [[operations]]
-name = "prices"
+name = "read_price"
 target = "price"
-weight = 2
-[operations.http]
-method = "GET"
-path = "/api/v1/priceservice/prices"
-[operations.expect]
-statuses = [200]
-json = true
-json_status_if_present = 1
-json_object_requires_status_or_data = true
+weight = 4
+tags = ["read", "secondary-index"]
 
 [[operations]]
-name = "configs"
+name = "update_read_config"
 target = "config"
-weight = 1
-[operations.http]
-method = "GET"
-path = "/api/v1/configservice/configs"
-[operations.expect]
-statuses = [200]
-json = true
-json_status_if_present = 1
-json_object_requires_status_or_data = true
+weight = 6
+tags = ["write", "read-your-write"]
 
 [[operations]]
-name = "travel_welcome"
+name = "update_read_station"
+target = "station"
+weight = 6
+tags = ["write", "read-your-write", "secondary-index"]
+
+[[operations]]
+name = "update_read_train"
+target = "train"
+weight = 6
+tags = ["write", "read-your-write"]
+
+[[operations]]
+name = "update_read_travel"
 target = "travel"
-weight = 1
-[operations.http]
-method = "GET"
-path = "/api/v1/travelservice/welcome"
-[operations.expect]
-statuses = [200]
-text_contains = "Welcome to [ Travel Service ]"
+weight = 6
+tags = ["write", "read-your-write"]
+
+[[operations]]
+name = "update_read_route"
+target = "route"
+weight = 6
+tags = ["write", "read-your-write"]
+
+[[operations]]
+name = "update_read_price"
+target = "price"
+weight = 5
+tags = ["write", "read-your-write", "secondary-index"]
+
+[[operations]]
+name = "create_read_delete_config"
+target = "config"
+weight = 5
+tags = ["write", "read-your-write", "delete"]
 
 [objective]
-name = "requests_per_second"
-metric = "requests_per_second"
+name = "logical_operations_per_second"
+metric = "operations_per_second"
 direction = "maximize"
-unit = "requests/s"
+unit = "operations/s"
 
 [constraints]
 max_error_rate = 0.0

--- a/examples/microservices/train-ticket/scripts/start-local-cluster.sh
+++ b/examples/microservices/train-ticket/scripts/start-local-cluster.sh
@@ -347,7 +347,7 @@ case "${cmd}" in
       echo "gateway returns 503 for all routes; use '$0 check' / '$0 bench' (direct services)."
     fi
     echo "Checker: $0 check"
-    echo "Benchmark: TT_BENCH_RATE=10 TT_BENCH_DURATION=30 TT_BENCH_CONCURRENCY=32 $0 bench"
+    echo "Benchmark: TT_BENCH_DURATION=30 TT_BENCH_CONCURRENCY=32 $0 bench"
     ;;
   stop)
     require_tools
@@ -374,15 +374,18 @@ case "${cmd}" in
     echo "  TT_NAMESPACE=${TT_BUILD_REPO} TT_TAG=${TT_BUILD_TAG} TT_GATEWAY_TAG=${TT_BUILD_TAG} TT_SKIP_PULL=1 $0 start"
     ;;
   check)
-    # No --allow-empty: the prebuilt and source-built images both self-seed
-    # reference data on startup, so empty lists indicate a real failure.
     python3 "${INPUT_DIR}/accuracy_checker/checker.py" \
       --base-url "http://localhost:${TT_GATEWAY_PORT}" \
-      --direct-services
+      --target "config=http://localhost:15679" \
+      --target "station=http://localhost:12345" \
+      --target "train=http://localhost:14567" \
+      --target "travel=http://localhost:12346" \
+      --target "route=http://localhost:11178" \
+      --target "price=http://localhost:16579"
     ;;
   bench)
     command -v go >/dev/null || { echo "go is required" >&2; exit 127; }
-    go -C "${REPO_ROOT}/examples/evaluators/microservice" run ./cmd/microbench \
+    go -C "${REPO_ROOT}/examples/evaluators/microservice" run ./cmd/servicebench \
       --workload "${INPUT_DIR}/benchmark/workload.toml" \
       --target "config=http://localhost:15679" \
       --target "station=http://localhost:12345" \
@@ -390,8 +393,7 @@ case "${cmd}" in
       --target "travel=http://localhost:12346" \
       --target "route=http://localhost:11178" \
       --target "price=http://localhost:16579" \
-      --rate "${TT_BENCH_RATE:-10}" \
-      --duration "${TT_BENCH_DURATION:-30}" \
+	  --duration "${TT_BENCH_DURATION:-30}" \
       --concurrency "${TT_BENCH_CONCURRENCY:-32}"
     ;;
   config)

--- a/examples/microservices/train-ticket/vibesys.input.toml
+++ b/examples/microservices/train-ticket/vibesys.input.toml
@@ -13,8 +13,9 @@ timeout_seconds = 120
 [benchmark]
 command = [
   "go", "-C", "_evaluator/microservice",
-  "run", "./cmd/microbench",
-  "--workload", "../../benchmark/workload.toml",
+  "run", "./cmd/servicebench",
+	"--workload", "../../benchmark/workload.toml",
+	"--seed", "random",
 ]
 timeout_seconds = 300
 

--- a/tests/test_microservice_inputs.py
+++ b/tests/test_microservice_inputs.py
@@ -28,7 +28,7 @@ def test_microservice_scenario_uses_shared_evaluator(scenario_path: Path) -> Non
         "-C",
         "_evaluator/microservice",
         "run",
-        "./cmd/microbench",
+        "./cmd/servicebench",
     )
     assert bundle.benchmark_result is not None
     assert bundle.benchmark_result.json_argument == "--output-json"


### PR DESCRIPTION
## Problem

The Train Ticket example previously checked only seeded read endpoints and drove a fixed declarative read-only workload. That could not distinguish a correct mutable implementation from one that returns canned data, drops writes, serves stale secondary indexes, or loses acknowledged mutations. Its fixed open-loop rate also capped every successful candidate at approximately the same throughput score, and fixed traffic values gave an optimizer unnecessary opportunity to specialize to evaluator inputs.

The shared benchmark command was also named `microbench` even though it generates application-level HTTP load and measures complete service operations.

## Solution

Extend the shared evaluator instead of maintaining a second Train Ticket benchmark implementation:

- rename the single benchmark command from `microbench` to `servicebench` and update both example manifests;
- add application-neutral logical-operation plans, allowing one scheduled operation to contain multiple engine-issued and engine-accounted protocol invocations;
- add a generic closed-loop load model for discriminative saturation-throughput measurement while preserving the existing open-loop model;
- add a typed Train Ticket adapter that prepares randomized connected fixtures through public APIs and validates lists, point/secondary reads, update-then-read, and create/read/delete/negative-read operations;
- resolve `--seed random` from OS entropy, record the exact replay seed as a JSON string, and hash the fully resolved workload;
- strengthen the independent Python checker in the Train Ticket example with the exact v0.2.0 seed oracle, duplicate-ID rejection, strict schemas, randomized CRUD graphs, stale secondary-index probes, read-your-write, delete, connection-reuse, and whole-process-group SIGKILL/restart validation.

No candidate implementation is included or prescribed.

Five sequential adversarial agent reviews covered correctness and reward-hacking resistance, concurrency and lifecycle behavior, benchmark methodology, implementation independence and API coverage, and CI/regression gaps. Valid findings were fixed and re-reviewed before advancing to the next round.

### Architecture

```mermaid
flowchart LR
    W["Workload + random replay seed"] --> E["servicebench scheduler"]
    A["Train Ticket application adapter"] --> P["Logical operation plan"]
    P --> E
    E --> D["Shared HTTP driver"]
    D --> T["Black-box candidate HTTP API"]
    T --> D
    D --> E
    E --> A
    E --> R["Validated operation latency + throughput"]
    C["Independent Python accuracy checker"] --> T
    C --> K["Optional crash/restart hook"]
    K --> T
```

The engine exclusively owns scheduling, request issuance, timing, byte/request accounting, and headline statistics. The application adapter owns fixture data, request descriptions, per-record leases, and semantic validation. The checker remains a separate implementation so benchmark and correctness validation do not share an oracle bug.

## Verification

The refactored evaluator was tested against the pinned upstream Train Ticket v0.2.0 services through six direct HTTP targets. A closed-loop coverage run exercised all 19 configured operation types with no errors. The independent checker also passed against the same deployment.

### Correctness properties

- Every measured HTTP call is issued and accounted for by the shared engine; adapters cannot hide requests or timing.
- One observation represents one logical operation, with physical invocation counts, bytes, and native statuses retained separately.
- Any transport, envelope, schema, value, delete, or read-your-write mismatch invalidates the operation and therefore the zero-error Train Ticket run. Every list row is type-checked and duplicate keys are rejected.
- Per-record leases serialize expected-state mutations and are released on success, failure, timeout, and cancellation paths.
- Acknowledged updates advance the evaluator oracle even when the following read exposes stale data. Retired station, route, and price secondary keys are probed explicitly.
- Fixture records form runtime-random station/train/route/price/trip graphs without depending on seeded entity IDs.
- The resolved random seed is emitted losslessly and can be replayed with `--seed <value>`.
- Closed-loop throughput is completion-limited rather than capped by a fixed offered rate; semantic validation tails are included in its denominator. An offered-load profile retains scheduled-arrival and queue-wait semantics.
- Fixture setup and cleanup use only public HTTP APIs and are outside measured traffic.
- The checker reports crash recovery as true only when it actually executes a restart hook; managed candidates run in an isolated process session whose entire group must terminate before restart.
- No implementation language, process topology, database, persistence format, or cache design is assumed.

### Testing

- `./scripts/check_format.sh` — passed.
- Clean tracked-files checkout: `uv run pytest -q tests/test_microservice_inputs.py examples/microservices/train-ticket/accuracy_checker/tests` — 18 passed.
- `uv run ruff check examples/microservices/train-ticket/accuracy_checker tests/test_microservice_inputs.py` — passed.
- `go -C examples/evaluators/microservice test -race ./...` — passed.
- `go -C examples/evaluators/microservice vet ./...` — passed.
- Both checked-in workloads validated through `cmd/servicebench`; Train Ticket also validated with `--seed random`.
- Pinned v0.2.0 checker without restart hook — 263 checks passed; all exercised properties true and `crash_recovery` correctly reported false.
- Earlier managed-candidate crash/restart integration of the same checker — 151 checks passed, including acknowledged-mutation recovery after SIGKILL.
- Pinned v0.2.0 closed-loop benchmark smoke — 3,172/3,172 logical operations successful, 5,467 HTTP invocations, all 19 operation types covered, zero errors, approximately 2,860 logical operations/second.
- Full local `./scripts/check_lint.sh` remains noisy only because the unrelated user-modified `3rd_party/train-ticket` checkout contains pre-existing Ruff violations; changed Python paths pass Ruff and CI runs from a clean checkout.


