### PR TITLE
Harden bounded MPMC queue correctness checks

### DIFF
--- a/examples/baselines/queue-mpmc-locked-ring/Makefile
+++ b/examples/baselines/queue-mpmc-locked-ring/Makefile
@@ -1,0 +1,25 @@
+.PHONY: all clean
+
+CC ?= cc
+ABI_HEADER := $(firstword $(wildcard ../../evaluators/queue/include/vibesys_queue_abi.h ../_evaluator/queue/include/vibesys_queue_abi.h))
+
+ifeq ($(ABI_HEADER),)
+$(error could not locate vibesys_queue_abi.h)
+endif
+
+CFLAGS ?= -O3 -DNDEBUG -march=native
+CFLAGS += -std=c11 -fPIC -Wall -Wextra -Wpedantic -Werror -I$(dir $(ABI_HEADER)) -pthread
+
+ifeq ($(shell uname -s),Darwin)
+SHARED_FLAGS := -dynamiclib
+else
+SHARED_FLAGS := -shared
+endif
+
+all: queue-candidate.so
+
+queue-candidate.so: locked_ring.c $(ABI_HEADER)
+	$(CC) $(CFLAGS) $(SHARED_FLAGS) locked_ring.c -o $@
+
+clean:
+	rm -f queue-candidate.so

--- a/examples/baselines/queue-mpmc-locked-ring/README.md
+++ b/examples/baselines/queue-mpmc-locked-ring/README.md
@@ -1,0 +1,27 @@
+# Locked-ring MPMC baseline
+
+This is the hidden exact-contract baseline for `queue-mpmc`. It stores copied
+values in a fixed, preallocated ring and serializes reservation, copying, and
+publication with one mutex. It serves as the simple exact-contract correctness
+and performance control.
+
+The serialization is intentional. Reserve-then-publish rings such as a direct
+SCQD or bounded sequence-ring adapter can expose a completed `FULL` operation
+followed by a later `EMPTY` while a successful enqueue owns the only free slot
+but has not published its copied bytes. The queue ABI has no `BUSY` result, so
+that history is not linearizable. This baseline keeps each operation's state
+transition atomic with respect to every other operation and remains a simple
+portable implementation verified against the reservation-gap litmus.
+
+The directory is outside the `queue-mpmc` input bundle and is not copied into
+optimization workspaces.
+
+```bash
+make
+go -C ../../evaluators/queue run . check \
+  --workspace ../../baselines/queue-mpmc-locked-ring --scenario mpmc \
+  --operations 24 --trials 100
+go -C ../../evaluators/queue run . benchmark \
+  --workspace ../../baselines/queue-mpmc-locked-ring --scenario mpmc \
+  --repetitions 3
+```

--- a/examples/baselines/queue-mpmc-locked-ring/locked_ring.c
+++ b/examples/baselines/queue-mpmc-locked-ring/locked_ring.c
@@ -1,0 +1,186 @@
+#define _POSIX_C_SOURCE 200112L
+
+#include "vibesys_queue_abi.h"
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct vsq_queue {
+  size_t capacity;
+  size_t max_value_size;
+  uint32_t producer_count;
+  uint32_t consumer_count;
+  uint8_t *storage;
+  size_t *lengths;
+  size_t head;
+  size_t tail;
+  size_t count;
+  pthread_mutex_t lock;
+};
+
+struct vsq_producer {
+  struct vsq_queue *queue;
+};
+
+struct vsq_consumer {
+  struct vsq_queue *queue;
+};
+
+static bool fits_size_t(uint64_t value) {
+  return value <= (uint64_t)SIZE_MAX;
+}
+
+static bool multiply_overflows(size_t left, size_t right) {
+  return right != 0 && left > SIZE_MAX / right;
+}
+
+static void destroy_queue(struct vsq_queue *queue) {
+  if (queue == NULL) {
+    return;
+  }
+  (void)pthread_mutex_destroy(&queue->lock);
+  free(queue->lengths);
+  free(queue->storage);
+  free(queue);
+}
+
+uint32_t vsq_abi_version(void) { return VSQ_ABI_VERSION; }
+
+vsq_status vsq_queue_create(uint64_t capacity, uint64_t max_value_size,
+                            uint32_t producer_count,
+                            uint32_t consumer_count,
+                            struct vsq_queue **queue_out) {
+  if (queue_out == NULL || capacity == 0 || max_value_size == 0 ||
+      producer_count == 0 || consumer_count == 0 || !fits_size_t(capacity) ||
+      !fits_size_t(max_value_size)) {
+    return VSQ_INVALID;
+  }
+  const size_t item_capacity = (size_t)capacity;
+  const size_t value_capacity = (size_t)max_value_size;
+  if (multiply_overflows(item_capacity, value_capacity) ||
+      multiply_overflows(item_capacity, sizeof(size_t))) {
+    return VSQ_INVALID;
+  }
+
+  struct vsq_queue *queue = calloc(1, sizeof(*queue));
+  if (queue == NULL) {
+    return VSQ_INTERNAL_ERROR;
+  }
+  if (pthread_mutex_init(&queue->lock, NULL) != 0) {
+    free(queue);
+    return VSQ_INTERNAL_ERROR;
+  }
+  queue->storage = malloc(item_capacity * value_capacity);
+  queue->lengths = malloc(item_capacity * sizeof(*queue->lengths));
+  if (queue->storage == NULL || queue->lengths == NULL) {
+    destroy_queue(queue);
+    return VSQ_INTERNAL_ERROR;
+  }
+  queue->capacity = item_capacity;
+  queue->max_value_size = value_capacity;
+  queue->producer_count = producer_count;
+  queue->consumer_count = consumer_count;
+  *queue_out = queue;
+  return VSQ_OK;
+}
+
+void vsq_queue_destroy(struct vsq_queue *queue) { destroy_queue(queue); }
+
+vsq_status vsq_producer_create(struct vsq_queue *queue, uint32_t producer_id,
+                               struct vsq_producer **producer_out) {
+  if (queue == NULL || producer_out == NULL ||
+      producer_id >= queue->producer_count) {
+    return VSQ_INVALID;
+  }
+  struct vsq_producer *producer = malloc(sizeof(*producer));
+  if (producer == NULL) {
+    return VSQ_INTERNAL_ERROR;
+  }
+  producer->queue = queue;
+  *producer_out = producer;
+  return VSQ_OK;
+}
+
+void vsq_producer_destroy(struct vsq_producer *producer) { free(producer); }
+
+vsq_status vsq_consumer_create(struct vsq_queue *queue, uint32_t consumer_id,
+                               struct vsq_consumer **consumer_out) {
+  if (queue == NULL || consumer_out == NULL ||
+      consumer_id >= queue->consumer_count) {
+    return VSQ_INVALID;
+  }
+  struct vsq_consumer *consumer = malloc(sizeof(*consumer));
+  if (consumer == NULL) {
+    return VSQ_INTERNAL_ERROR;
+  }
+  consumer->queue = queue;
+  *consumer_out = consumer;
+  return VSQ_OK;
+}
+
+void vsq_consumer_destroy(struct vsq_consumer *consumer) { free(consumer); }
+
+vsq_status vsq_try_enqueue(struct vsq_producer *producer, const uint8_t *data,
+                           uint64_t length) {
+  if (producer == NULL || !fits_size_t(length)) {
+    return VSQ_INVALID;
+  }
+  struct vsq_queue *queue = producer->queue;
+  const size_t value_size = (size_t)length;
+  if (value_size > queue->max_value_size ||
+      (value_size != 0 && data == NULL)) {
+    return VSQ_INVALID;
+  }
+  if (pthread_mutex_lock(&queue->lock) != 0) {
+    return VSQ_INTERNAL_ERROR;
+  }
+  if (queue->count == queue->capacity) {
+    (void)pthread_mutex_unlock(&queue->lock);
+    return VSQ_FULL;
+  }
+  const size_t slot = queue->tail;
+  if (value_size != 0) {
+    memcpy(queue->storage + slot * queue->max_value_size, data, value_size);
+  }
+  queue->lengths[slot] = value_size;
+  queue->tail = slot + 1 == queue->capacity ? 0 : slot + 1;
+  ++queue->count;
+  (void)pthread_mutex_unlock(&queue->lock);
+  return VSQ_OK;
+}
+
+vsq_status vsq_try_dequeue(struct vsq_consumer *consumer, uint8_t *output,
+                           uint64_t output_capacity,
+                           uint64_t *output_length) {
+  if (consumer == NULL || output_length == NULL ||
+      !fits_size_t(output_capacity)) {
+    return VSQ_INVALID;
+  }
+  struct vsq_queue *queue = consumer->queue;
+  const size_t output_size = (size_t)output_capacity;
+  if (pthread_mutex_lock(&queue->lock) != 0) {
+    return VSQ_INTERNAL_ERROR;
+  }
+  if (queue->count == 0) {
+    (void)pthread_mutex_unlock(&queue->lock);
+    return VSQ_EMPTY;
+  }
+  const size_t slot = queue->head;
+  const size_t value_size = queue->lengths[slot];
+  if (value_size > output_size || (value_size != 0 && output == NULL)) {
+    (void)pthread_mutex_unlock(&queue->lock);
+    return VSQ_INVALID;
+  }
+  if (value_size != 0) {
+    memcpy(output, queue->storage + slot * queue->max_value_size, value_size);
+  }
+  *output_length = (uint64_t)value_size;
+  queue->head = slot + 1 == queue->capacity ? 0 : slot + 1;
+  --queue->count;
+  (void)pthread_mutex_unlock(&queue->lock);
+  return VSQ_OK;
+}

--- a/examples/evaluators/queue/CANDIDATE_CONTRACT.md
+++ b/examples/evaluators/queue/CANDIDATE_CONTRACT.md
@@ -68,8 +68,18 @@ sufficient dequeue output, only `VSQ_OK` and `VSQ_EMPTY` are normal results.
 `VSQ_INTERNAL_ERROR`, or `VSQ_INVALID` for otherwise valid arguments, fails
 evaluation.
 
-All operations are nonblocking. Successful operations must form a linearizable
+Operations are try-style: they do not wait for space to become free or for an
+item to arrive. They may synchronize with an operation whose reservation is
+already externally observable. Successful operations must form a linearizable
 bounded FIFO queue. Full and empty observations are part of that history.
+
+Internal reservation is not publication. A reserve-then-copy implementation
+must not let one enqueue complete with `VSQ_FULL` merely because another
+producer reserved the last slot if a later dequeue can still complete with
+`VSQ_EMPTY` before the reserved value is published. The ABI has no `BUSY`
+result, so those completed observations would force contradictory
+linearization orders. An implementation must serialize, wait for, or safely
+help an in-flight publication before returning an externally visible status.
 
 ## Value-size guarantees
 
@@ -85,8 +95,9 @@ the measured implementation.
 
 The correctness gate probes actual lengths 0, 1, 7, 8, 9, intermediate, and
 maximum for 8-byte, 257-byte, and 1 MiB queue profiles. It also checks input
-retention, undersized-output retry, and unchanged output on empty and invalid
-dequeues before running concurrent Porcupine histories.
+retention, undersized-output retry, concurrent short/full-buffer consumers,
+reservation-gap histories, and unchanged output on empty and invalid dequeues
+before running concurrent Porcupine histories.
 
 The evaluator may run multiple independent benchmark repetitions. Its
 `total_ops_per_sec` field is the median repetition, and the JSON output includes

--- a/examples/evaluators/queue/DESIGN.md
+++ b/examples/evaluators/queue/DESIGN.md
@@ -147,7 +147,19 @@ and 1 MiB. It also tests:
 - valid queue and handle lifecycle behavior;
 - status and output-length validation.
 
-Each probe process can fail without corrupting Go-owned checker state.
+MPMC profiles additionally race two consumer handles against one producer with
+alternating 16-byte and 64-byte values. One consumer has only 32 bytes of
+output space while the other can accept every value. The probe checks that
+concurrent `INVALID`/`EMPTY` results leave caller storage untouched and that
+all successfully enqueued values are returned exactly once without corruption.
+
+A capacity-one reservation-gap litmus also overlaps two large enqueues, then
+dequeues while the first producer may still be copying. It rejects the
+contradictory completed history `OK`, `FULL`, `EMPTY` that a reserve-then-copy
+ring can otherwise expose when reservation is mistaken for publication.
+
+Each probe process can fail without corrupting Go-owned checker state. Probe
+processes have a trusted wall-clock deadline.
 
 ### Boundary Histories
 
@@ -221,6 +233,9 @@ correctness. It is deliberately absent from the benchmark hot path.
 Closing all Go-side lanes tells the worker to finish. Early worker exit, broken
 sockets, malformed frames, invalid ABI statuses, and candidate crashes all
 become checker failures with bounded worker logs attached.
+Each correctness request also has a trusted deadline; a candidate operation
+that does not return is terminated and reported as a timeout rather than
+hanging the checker.
 
 ## Benchmark Flow
 
@@ -240,6 +255,10 @@ consumer threads:
 6. Validate every dequeued payload.
 7. Stop all threads, drain the queue, and validate conservation.
 8. Write evaluator-owned JSON for Go to validate and aggregate.
+
+Each native repetition has a deadline derived from its configured warmup and
+measured duration plus a fixed shutdown grace, so a candidate that deadlocks
+during the timed phase or final drain cannot hang the outer evaluator.
 
 Two keyed commutative fingerprints compare the multiset of successfully
 enqueued values with values dequeued during measurement and final drain. Counts

--- a/examples/evaluators/queue/benchmark.go
+++ b/examples/evaluators/queue/benchmark.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,8 @@ import (
 	"strconv"
 	"time"
 )
+
+var nativeBenchmarkShutdownGrace = 15 * time.Second
 
 type benchmarkConfig struct {
 	candidateConfig
@@ -72,12 +75,21 @@ func runNativeBenchmark(config benchmarkConfig) (benchmarkResult, error) {
 		"--duration-ns", strconv.FormatInt(config.duration.Nanoseconds(), 10),
 		"--output", outputPath,
 	)
-	command := exec.Command(runner, args...)
+	timeout := config.warmup + config.duration + nativeBenchmarkShutdownGrace
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	command := exec.CommandContext(ctx, runner, args...)
 	command.Dir = config.workspace
 	log := newBoundedLog(64 * 1024)
 	command.Stdout = io.Writer(log)
 	command.Stderr = io.Writer(log)
 	if err := command.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return benchmarkResult{}, fmt.Errorf(
+				"native benchmark timed out after %s; candidate operation or shutdown did not complete",
+				timeout,
+			)
+		}
 		return benchmarkResult{}, fmt.Errorf(
 			"native benchmark failed: %w\nnative runner output:\n%s",
 			err,

--- a/examples/evaluators/queue/benchmark_test.go
+++ b/examples/evaluators/queue/benchmark_test.go
@@ -2,9 +2,33 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestNativeBenchmarkTimesOutStuckCandidate(t *testing.T) {
+	workspace := compileCandidateFixtureWithDefines(t, "VSQ_TEST_HANG_CAPACITY_ONE")
+	previousGrace := nativeBenchmarkShutdownGrace
+	nativeBenchmarkShutdownGrace = 100 * time.Millisecond
+	t.Cleanup(func() { nativeBenchmarkShutdownGrace = previousGrace })
+
+	_, err := runNativeBenchmark(benchmarkConfig{
+		candidateConfig: candidateConfig{
+			workspace: workspace,
+			candidate: "queue-candidate.so",
+			scenario:  scenarioSPSC,
+			capacity:  1,
+			valueSize: 8,
+		},
+		producers: 1,
+		consumers: 1,
+		duration:  20 * time.Millisecond,
+	})
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("stuck benchmark error = %v, want timeout", err)
+	}
+}
 
 func TestNativeReferenceBenchmark(t *testing.T) {
 	result, err := runNativeBenchmark(benchmarkConfig{

--- a/examples/evaluators/queue/candidate.go
+++ b/examples/evaluators/queue/candidate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +12,12 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"time"
+)
+
+var (
+	candidateOperationTimeout = 5 * time.Second
+	abiProbeTimeout           = 15 * time.Second
 )
 
 type boundedLog struct {
@@ -55,6 +62,8 @@ type candidateSession struct {
 	waitErr   error
 	closeOnce sync.Once
 	closeErr  error
+	process   *os.Process
+	abortOnce sync.Once
 }
 
 type candidateConfig struct {
@@ -115,12 +124,17 @@ func runCandidateABIProbe(config candidateConfig) error {
 		"--producers", strconv.Itoa(config.producerCount),
 		"--consumers", strconv.Itoa(config.consumerCount),
 	)
-	command := exec.Command(runner, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), abiProbeTimeout)
+	defer cancel()
+	command := exec.CommandContext(ctx, runner, args...)
 	command.Dir = config.workspace
 	log := newBoundedLog(64 * 1024)
 	command.Stdout = io.Writer(log)
 	command.Stderr = io.Writer(log)
 	if err := command.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("native ABI probe timed out after %s", abiProbeTimeout)
+		}
 		return fmt.Errorf(
 			"native ABI probe failed: %w\nnative runner output:\n%s",
 			err,
@@ -204,6 +218,7 @@ func startCandidate(config candidateConfig) (*candidateSession, error) {
 		valueSize: config.valueSize,
 		done:      make(chan struct{}),
 		log:       log,
+		process:   command.Process,
 	}
 	for lane, conn := range trustedConnections {
 		session.lanes[lane].conn = conn
@@ -216,6 +231,14 @@ func startCandidate(config candidateConfig) (*candidateSession, error) {
 		close(session.done)
 	}()
 	return session, nil
+}
+
+func (s *candidateSession) abortWorker() {
+	s.abortOnce.Do(func() {
+		if s.process != nil {
+			_ = s.process.Kill()
+		}
+	})
 }
 
 func (s *candidateSession) waitError() error {
@@ -254,11 +277,29 @@ func (s *candidateSession) invoke(laneIndex int, req request) (response, error) 
 	lane := &s.lanes[laneIndex]
 	lane.mu.Lock()
 	defer lane.mu.Unlock()
+	if err := lane.conn.SetDeadline(time.Now().Add(candidateOperationTimeout)); err != nil {
+		return response{}, fmt.Errorf("set candidate operation deadline: %w", err)
+	}
+	defer func() { _ = lane.conn.SetDeadline(time.Time{}) }()
 	if err := writeRequest(lane.conn, req, s.valueSize); err != nil {
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			s.abortWorker()
+			return response{}, fmt.Errorf(
+				"candidate operation timed out after %s while sending a request",
+				candidateOperationTimeout,
+			)
+		}
 		return response{}, s.communicationError("send a correctness request", err)
 	}
 	resp, err := readResponse(lane.conn, s.valueSize)
 	if err != nil {
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			s.abortWorker()
+			return response{}, fmt.Errorf(
+				"candidate operation timed out after %s while waiting for a response",
+				candidateOperationTimeout,
+			)
+		}
 		return response{}, s.communicationError("read a correctness response", err)
 	}
 	if resp.status == statusError {

--- a/examples/evaluators/queue/checker_test.go
+++ b/examples/evaluators/queue/checker_test.go
@@ -5,8 +5,60 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 )
+
+func TestAccuracyTimesOutStuckCandidateOperation(t *testing.T) {
+	workspace := compileCandidateFixtureWithDefines(t, "VSQ_TEST_HANG_CAPACITY_ONE")
+	previousTimeout := candidateOperationTimeout
+	candidateOperationTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { candidateOperationTimeout = previousTimeout })
+
+	started := time.Now()
+	err := runAccuracy(accuracyConfig{
+		candidateConfig: candidateConfig{
+			workspace: workspace,
+			candidate: "queue-candidate.so",
+			scenario:  scenarioSPSC,
+			capacity:  4,
+			valueSize: 64,
+		},
+		operations: 8,
+		trials:     1,
+		producers:  1,
+		consumers:  1,
+		seed:       7,
+	})
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("stuck candidate error = %v, want operation timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("stuck candidate took %s to reject", elapsed)
+	}
+}
+
+func TestAccuracyRejectsReservationGapCandidate(t *testing.T) {
+	workspace := compileCandidateFixtureWithDefines(t, "VSQ_TEST_RESERVATION_GAP")
+	err := runAccuracy(accuracyConfig{
+		candidateConfig: candidateConfig{
+			workspace: workspace,
+			candidate: "queue-candidate.so",
+			scenario:  scenarioMPMC,
+			capacity:  4,
+			valueSize: 64,
+		},
+		operations: 8,
+		trials:     1,
+		producers:  2,
+		consumers:  2,
+		seed:       7,
+	})
+	if err == nil || !strings.Contains(err.Error(), "reservation gap") {
+		t.Fatalf("reservation-gap candidate error = %v, want reservation-gap rejection", err)
+	}
+}
 
 func enqueueRecord(client int, value uint64, ok bool, call int64) recordedOperation {
 	return recordedOperation{

--- a/examples/evaluators/queue/native_runner/src/probe.rs
+++ b/examples/evaluators/queue/native_runner/src/probe.rs
@@ -1,7 +1,15 @@
-use crate::abi::{Api, STATUS_EMPTY, STATUS_INVALID, STATUS_OK};
+use crate::abi::{
+    Api, STATUS_EMPTY, STATUS_FULL, STATUS_INTERNAL_ERROR, STATUS_INVALID, STATUS_OK,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier, Mutex};
+use std::thread;
 
 const SENTINEL_BYTE: u8 = 0xa7;
 const SENTINEL_LENGTH: u64 = u64::MAX;
+const CONCURRENT_PROBE_ITEMS: usize = 2_000;
+const RESERVATION_GAP_VALUE_SIZE: usize = 1 << 20;
+const RESERVATION_GAP_ATTEMPTS: usize = 32;
 
 pub fn run_probe(
     api: Api,
@@ -63,6 +71,242 @@ pub fn run_probe(
 
     check_invalid_output_retains_value(producer, consumer, max_value_size)?;
     check_empty_output_is_unchanged(consumer, max_value_size)?;
+    if consumer_count >= 2 {
+        check_concurrent_undersized_dequeues(&api, producer_count, consumer_count)?;
+    }
+    if producer_count >= 2 && max_value_size == 257 {
+        check_reservation_gap(&api, producer_count, consumer_count)?;
+    }
+    Ok(())
+}
+
+fn check_reservation_gap(
+    api: &Api,
+    producer_count: u32,
+    consumer_count: u32,
+) -> Result<(), String> {
+    let first_value = vec![0x35_u8; RESERVATION_GAP_VALUE_SIZE];
+    let second_value = vec![0xca_u8; RESERVATION_GAP_VALUE_SIZE];
+
+    for _ in 0..RESERVATION_GAP_ATTEMPTS {
+        let queue = api.create_queue(
+            1,
+            RESERVATION_GAP_VALUE_SIZE as u64,
+            producer_count,
+            consumer_count,
+        )?;
+        let mut first_producer = queue.create_producer(0)?;
+        let mut second_producer = queue.create_producer(1)?;
+        let mut consumer = queue.create_consumer(0)?;
+        let start = Arc::new(Barrier::new(2));
+        let worker_start = start.clone();
+
+        let (first_status, second_status, dequeue_status) = thread::scope(|scope| {
+            let first_worker = scope.spawn(|| {
+                worker_start.wait();
+                first_producer.enqueue(&first_value)
+            });
+            start.wait();
+            for _ in 0..64 {
+                std::hint::spin_loop();
+            }
+            let second_status = second_producer.enqueue(&second_value);
+            let mut output = vec![0_u8; RESERVATION_GAP_VALUE_SIZE];
+            let (dequeue_status, _) = consumer.dequeue(&mut output)?;
+            let first_status = first_worker
+                .join()
+                .map_err(|_| "reservation-gap producer panicked".to_string())?;
+            Ok::<(u32, u32, u32), String>((first_status, second_status, dequeue_status))
+        })?;
+
+        if first_status == STATUS_OK
+            && second_status == STATUS_FULL
+            && dequeue_status == STATUS_EMPTY
+        {
+            return Err(
+                "non-linearizable reservation gap: FULL completed before a later EMPTY while the sole slot belonged to a successful enqueue"
+                    .to_string(),
+            );
+        }
+        if !matches!(first_status, STATUS_OK | STATUS_FULL)
+            || !matches!(second_status, STATUS_OK | STATUS_FULL)
+        {
+            return Err(format!(
+                "reservation-gap enqueue statuses were {first_status} and {second_status}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn concurrent_payload(sequence: usize) -> Vec<u8> {
+    let length = if sequence % 2 == 0 { 16 } else { 64 };
+    let mut value = vec![0_u8; length];
+    value[..8].copy_from_slice(&(sequence as u64).to_le_bytes());
+    for (index, byte) in value[8..].iter_mut().enumerate() {
+        *byte = (sequence as u8)
+            .wrapping_mul(31)
+            .wrapping_add((index as u8).wrapping_mul(17))
+            .wrapping_add(0x6d);
+    }
+    value
+}
+
+fn validate_concurrent_payload(value: &[u8]) -> Result<usize, String> {
+    if value.len() != 16 && value.len() != 64 {
+        return Err(format!(
+            "concurrent probe returned {} bytes, expected 16 or 64",
+            value.len()
+        ));
+    }
+    let sequence = u64::from_le_bytes(value[..8].try_into().expect("sequence prefix")) as usize;
+    if sequence >= CONCURRENT_PROBE_ITEMS || concurrent_payload(sequence) != value {
+        return Err("concurrent probe returned a fabricated or corrupted value".to_string());
+    }
+    Ok(sequence)
+}
+
+fn record_concurrent_value(
+    seen: &Mutex<Vec<bool>>,
+    consumed: &AtomicUsize,
+    value: &[u8],
+) -> Result<(), String> {
+    let sequence = validate_concurrent_payload(value)?;
+    let mut observed = seen
+        .lock()
+        .map_err(|_| "concurrent probe observation lock was poisoned".to_string())?;
+    if observed[sequence] {
+        return Err(format!(
+            "concurrent probe returned sequence {sequence} more than once"
+        ));
+    }
+    observed[sequence] = true;
+    consumed.fetch_add(1, Ordering::Release);
+    Ok(())
+}
+
+fn check_concurrent_undersized_dequeues(
+    api: &Api,
+    producer_count: u32,
+    consumer_count: u32,
+) -> Result<(), String> {
+    let queue = api.create_queue(8, 64, producer_count, consumer_count)?;
+    let producer = queue.create_producer(0)?;
+    let short_consumer = queue.create_consumer(0)?;
+    let full_consumer = queue.create_consumer(1)?;
+    let seen = Arc::new(Mutex::new(vec![false; CONCURRENT_PROBE_ITEMS]));
+    let consumed = Arc::new(AtomicUsize::new(0));
+
+    thread::scope(|scope| {
+        let producer_worker = scope.spawn(move || {
+            let mut producer = producer;
+            for sequence in 0..CONCURRENT_PROBE_ITEMS {
+                let value = concurrent_payload(sequence);
+                loop {
+                    match producer.enqueue(&value) {
+                        STATUS_OK => break,
+                        STATUS_FULL => thread::yield_now(),
+                        status => {
+                            return Err(format!(
+                                "concurrent probe enqueue returned ABI status {status}"
+                            ));
+                        }
+                    }
+                }
+            }
+            Ok(())
+        });
+
+        let short_seen = seen.clone();
+        let short_consumed = consumed.clone();
+        let short_worker = scope.spawn(move || {
+            let mut consumer = short_consumer;
+            let mut output = [SENTINEL_BYTE; 32];
+            while short_consumed.load(Ordering::Acquire) < CONCURRENT_PROBE_ITEMS {
+                output.fill(SENTINEL_BYTE);
+                let unchanged = output;
+                let mut output_length = SENTINEL_LENGTH;
+                let status = consumer.dequeue_raw(
+                    output.as_mut_ptr(),
+                    output.len() as u64,
+                    &mut output_length,
+                );
+                match status {
+                    STATUS_OK => {
+                        if output_length != 16 {
+                            return Err(format!(
+                                "short concurrent dequeue returned length {output_length}"
+                            ));
+                        }
+                        record_concurrent_value(
+                            &short_seen,
+                            &short_consumed,
+                            &output[..output_length as usize],
+                        )?;
+                    }
+                    STATUS_INVALID | STATUS_EMPTY => {
+                        if output != unchanged || output_length != SENTINEL_LENGTH {
+                            return Err(
+                                "failed concurrent dequeue modified caller output".to_string()
+                            );
+                        }
+                        thread::yield_now();
+                    }
+                    STATUS_INTERNAL_ERROR => {
+                        return Err(
+                            "concurrent probe candidate reported internal error".to_string()
+                        );
+                    }
+                    status => {
+                        return Err(format!(
+                            "short concurrent dequeue returned ABI status {status}"
+                        ));
+                    }
+                }
+            }
+            Ok(())
+        });
+
+        let full_seen = seen.clone();
+        let full_consumed = consumed.clone();
+        let full_worker = scope.spawn(move || {
+            let mut consumer = full_consumer;
+            let mut output = [0_u8; 64];
+            while full_consumed.load(Ordering::Acquire) < CONCURRENT_PROBE_ITEMS {
+                let (status, length) = consumer.dequeue(&mut output)?;
+                match status {
+                    STATUS_OK => {
+                        record_concurrent_value(&full_seen, &full_consumed, &output[..length])?
+                    }
+                    STATUS_EMPTY => thread::yield_now(),
+                    status => {
+                        return Err(format!(
+                            "full concurrent dequeue returned ABI status {status}"
+                        ));
+                    }
+                }
+            }
+            Ok(())
+        });
+
+        producer_worker
+            .join()
+            .map_err(|_| "concurrent probe producer panicked".to_string())??;
+        short_worker
+            .join()
+            .map_err(|_| "concurrent probe short consumer panicked".to_string())??;
+        full_worker
+            .join()
+            .map_err(|_| "concurrent probe full consumer panicked".to_string())??;
+        Ok::<(), String>(())
+    })?;
+
+    let observed = seen
+        .lock()
+        .map_err(|_| "concurrent probe observation lock was poisoned".to_string())?;
+    if observed.iter().any(|value| !value) {
+        return Err("concurrent probe lost one or more enqueued values".to_string());
+    }
     Ok(())
 }
 

--- a/examples/evaluators/queue/testdata/abi_test_candidate.c
+++ b/examples/evaluators/queue/testdata/abi_test_candidate.c
@@ -1,8 +1,11 @@
 #include "vibesys_queue_abi.h"
 
 #include <pthread.h>
+#include <stdbool.h>
+#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 struct item {
     uint8_t *data;
@@ -18,10 +21,15 @@ struct vsq_queue {
     uint64_t size;
     uint32_t producer_count;
     uint32_t consumer_count;
+#ifdef VSQ_TEST_RESERVATION_GAP
+    atomic_bool producer_one_created;
+    atomic_bool reserved;
+#endif
 };
 
 struct vsq_producer {
     struct vsq_queue *queue;
+    uint32_t id;
 };
 
 struct vsq_consumer {
@@ -90,6 +98,12 @@ vsq_status vsq_producer_create(
         return VSQ_INTERNAL_ERROR;
     }
     producer->queue = queue;
+    producer->id = producer_id;
+#ifdef VSQ_TEST_RESERVATION_GAP
+    if (producer_id == 1) {
+        atomic_store_explicit(&queue->producer_one_created, true, memory_order_release);
+    }
+#endif
     *producer_out = producer;
     return VSQ_OK;
 }
@@ -123,6 +137,36 @@ vsq_status vsq_try_enqueue(vsq_producer *producer, const uint8_t *data, uint64_t
         length > producer->queue->max_value_size) {
         return VSQ_INVALID;
     }
+#ifdef VSQ_TEST_RESERVATION_GAP
+    struct vsq_queue *reservation_queue = producer->queue;
+    if (reservation_queue->capacity == 1 &&
+        reservation_queue->max_value_size == (1u << 20) &&
+        atomic_load_explicit(&reservation_queue->producer_one_created,
+                             memory_order_acquire)) {
+        if (producer->id == 0) {
+            atomic_store_explicit(&reservation_queue->reserved, true,
+                                  memory_order_release);
+            const struct timespec delay = {.tv_sec = 0, .tv_nsec = 25000000};
+            (void)nanosleep(&delay, NULL);
+        } else {
+            const struct timespec delay = {.tv_sec = 0, .tv_nsec = 1000000};
+            for (unsigned int attempt = 0; attempt < 100; ++attempt) {
+                if (atomic_load_explicit(&reservation_queue->reserved,
+                                         memory_order_acquire)) {
+                    return VSQ_FULL;
+                }
+                (void)nanosleep(&delay, NULL);
+            }
+        }
+    }
+#endif
+#ifdef VSQ_TEST_HANG_CAPACITY_ONE
+    if (producer->queue->capacity == 1) {
+        volatile unsigned int keep_running = 1;
+        while (keep_running) {
+        }
+    }
+#endif
 #ifdef VSQ_TEST_FIXED_LENGTH_ONLY
     if (length != producer->queue->max_value_size) {
         return VSQ_INVALID;

--- a/tests/test_queue_evaluator.py
+++ b/tests/test_queue_evaluator.py
@@ -186,6 +186,66 @@ def test_spsc_rigtorp_baseline_uses_pinned_upstream_header():
     assert "rigtorp::SPSCQueue<QueueEntry> entries" in adapter
 
 
+def test_mpmc_locked_ring_baseline_builds_and_passes_accuracy(tmp_path):
+    if shutil.which("go") is None or shutil.which("cc") is None:
+        pytest.skip("Go and a C compiler are required by the MPMC baseline")
+
+    project_root = Path(__file__).parents[1]
+    baseline_source = project_root / "examples" / "baselines" / "queue-mpmc-locked-ring"
+    baseline = tmp_path / "queue-mpmc-locked-ring"
+    shutil.copytree(baseline_source, baseline)
+    evaluator = project_root / "examples" / "evaluators" / "queue"
+    abi_header = evaluator / "include" / "vibesys_queue_abi.h"
+
+    subprocess.run(
+        ["make", "clean", "all", f"ABI_HEADER={abi_header}"],
+        cwd=baseline,
+        check=True,
+    )
+    completed = subprocess.run(
+        [
+            "go",
+            "-C",
+            str(evaluator),
+            "run",
+            ".",
+            "check",
+            "--workspace",
+            str(baseline),
+            "--scenario",
+            "mpmc",
+            "--capacity",
+            "17",
+            "--value-size",
+            "64",
+            "--operations",
+            "16",
+            "--trials",
+            "12",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "PASS - mpmc linearizable" in completed.stdout
+
+
+def test_mpmc_locked_ring_baseline_has_atomic_publication_region():
+    project_root = Path(__file__).parents[1]
+    baseline = project_root / "examples" / "baselines" / "queue-mpmc-locked-ring"
+    adapter = (baseline / "locked_ring.c").read_text()
+
+    enqueue = adapter[adapter.index("vsq_status vsq_try_enqueue") :]
+    enqueue = enqueue[: enqueue.index("vsq_status vsq_try_dequeue")]
+    dequeue = adapter[adapter.index("vsq_status vsq_try_dequeue") :]
+    assert "pthread_mutex_lock(&queue->lock)" in enqueue
+    assert "memcpy(" in enqueue
+    assert enqueue.index("pthread_mutex_lock") < enqueue.index("memcpy(")
+    assert "pthread_mutex_lock(&queue->lock)" in dequeue
+    assert "memcpy(" in dequeue
+    assert dequeue.index("pthread_mutex_lock") < dequeue.index("memcpy(")
+
+
 @pytest.mark.parametrize(("input_name", "scenario"), LINEARIZABLE_QUEUE_INPUTS.items())
 def test_materialized_rust_starter_builds_and_passes_accuracy(tmp_path, input_name, scenario):
     if shutil.which("go") is None or shutil.which("cargo") is None:


### PR DESCRIPTION
## Problem

The bounded queue evaluator lacked targeted coverage for a reserve-copy-publish timing window, concurrent undersized consumers, and stuck candidate operations. Short randomized histories did not reliably exercise those paths, and a hung candidate could block evaluation indefinitely.

At merge time, this PR treated `FULL` and `EMPTY` as exact observations for every queue scenario and added a capacity-one probe that rejected `OK` / `FULL` / `EMPTY` around an unpublished reservation. Follow-up #210 revises that MPMC interpretation to model reservation and publication separately while retaining exact SPSC behavior.

## Solution

- Add bounded deadlines around ABI probes, worker requests, and benchmark shutdown.
- Add concurrent short/full-buffer consumer probes checking output immutability, retention, conservation, duplication, and corruption.
- Add adversarial fixtures for stuck operations and the then-current reservation-gap interpretation.
- Add a preallocated locked-ring MPMC correctness and performance control.
- Document the queue ABI, trust boundary, and probe architecture.

## Verification

- `./scripts/check_format.sh && ./scripts/check_lint.sh` — passed.
- `go test -count=1 ./... && go vet ./...` from `examples/evaluators/queue` — passed.
- `cargo fmt --check && cargo test && cargo clippy --all-targets -- -D warnings` from the native runner — passed.
- `uv run pytest -q tests/test_queue_evaluator.py` — passed; 11 tests.
- All required GitHub Actions checks passed before merge.
