### PR TITLE
Add Hotel Reservation microservice scenario

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,6 +180,8 @@ jobs:
           go run ./cmd/servicebench --mode accuracy --workload ../../microservices/train-ticket/benchmark/workload.toml --validate-only
           go run ./cmd/servicebench --workload ../../microservices/train-ticket/benchmark/workload.toml --profile offered-load --validate-only
           go run ./cmd/servicebench --workload ../../microservices/social-network-read-timeline/benchmark/workload.toml --validate-only
+          go run ./cmd/servicebench --workload ../../microservices/hotel-reservation/benchmark/workload.toml --validate-only
+          go run ./cmd/servicebench --mode accuracy --workload ../../microservices/hotel-reservation/benchmark/workload.toml --validate-only
 
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -232,6 +232,7 @@ agent.toml
 
 # Experiment environments
 exp_env/
+examples/microservices/hotel-reservation/hotelReservation/
 
 # HuggingFace model cache
 .hf_cache/

--- a/examples/evaluators/microservice/README.md
+++ b/examples/evaluators/microservice/README.md
@@ -174,6 +174,7 @@ retains one observation per measured logical operation for diagnosis.
 | [`appsupport/`](appsupport/) | Mode-neutral topology, preflight, input, and authentication grammars |
 | [`apps/`](apps/) | Application-adapter extension layer |
 | [`apps/declarative/`](apps/declarative/) | Declarative HTTP request and response adapter |
+| [`apps/hotel/`](apps/hotel/) | Typed DeathStarBench Hotel Reservation adapter |
 | [`apps/socialnetwork/`](apps/socialnetwork/) | Typed DeathStarBench Social Network adapter |
 | [`cmd/`](cmd/) | Executable composition roots |
 | [`cmd/servicebench/`](cmd/servicebench/) | Benchmark and accuracy CLI |
@@ -213,6 +214,7 @@ See the checked-in workloads for complete examples:
 
 - `../../microservices/train-ticket/benchmark/workload.toml`
 - `../../microservices/social-network-read-timeline/benchmark/workload.toml`
+- `../../microservices/hotel-reservation/benchmark/workload.toml`
 
 ## Running the evaluator
 
@@ -236,6 +238,13 @@ go -C examples/evaluators/microservice run ./cmd/servicebench \
 
 Use `go run ./cmd/servicebench --help` from this directory for target, load,
 profile, fixture, and output overrides.
+
+Managed accuracy and benchmark runs may pair `--run-command-json` with
+`--stop-command-json` and `--cleanup-command-json`. The stop command runs from
+the candidate directory whenever the contained process is stopped, including
+accuracy restarts. The cleanup command runs once when the managed lifecycle
+closes, allowing an external supervisor such as Docker Compose to remove the
+remaining project resources after restart-sensitive checks are complete.
 
 ## Testing
 

--- a/examples/evaluators/microservice/accuracyapps/README.md
+++ b/examples/evaluators/microservice/accuracyapps/README.md
@@ -16,3 +16,8 @@ state cardinality and should execute repeated mutation epochs where benchmark
 traffic can revisit the same records. Seed catalogs must be verified through
 their public point and secondary query paths as well as exact list membership;
 a synthesized list is not proof of a usable index.
+
+Applications without a public cleanup API, such as Hotel Reservation, must use
+collision-resistant fixture namespaces and state the residual-mutation contract
+explicitly. They must not register fictional cleanup callbacks or report a
+property as restored when persistent state remains.

--- a/examples/evaluators/microservice/accuracyapps/hotel/application.go
+++ b/examples/evaluators/microservice/accuracyapps/hotel/application.go
@@ -1,0 +1,74 @@
+package hotel
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"vibesys/microservice-evaluator/api"
+	hotelsupport "vibesys/microservice-evaluator/appsupport/hotel"
+)
+
+// Application is the Hotel Reservation accuracy adapter. Seeded response
+// semantics deliberately live here instead of in the mode-neutral appsupport
+// package shared with the benchmark.
+type Application struct {
+	timeout time.Duration
+	seed    int64
+	catalog map[string]profile
+}
+
+func New(workload api.Workload) (api.AccuracyApplication, error) {
+	config, err := hotelsupport.ValidateTopology(workload)
+	if err != nil {
+		return nil, err
+	}
+	catalog, err := seedProfiles()
+	if err != nil {
+		return nil, err
+	}
+	return &Application{timeout: config.Timeout, seed: workload.Load.Seed, catalog: catalog}, nil
+}
+
+func (a *Application) Name() string { return "hotel" }
+
+func (a *Application) Properties() []api.AccuracyProperty {
+	return []api.AccuracyProperty{
+		{Name: "protocol_contract", Required: true},
+		{Name: "persistent_http", Required: true},
+		{Name: "strict_geojson_schema", Required: true},
+		{Name: "seeded_profile_semantics", Required: true},
+		{Name: "search_semantics", Required: true},
+		{Name: "search_availability", Required: true},
+		{Name: "recommendation_semantics", Required: true},
+		{Name: "authentication_semantics", Required: true},
+		{Name: "reservation_optional_number", Required: true},
+		{Name: "reservation_capacity", Required: true},
+		{Name: "read_your_write", Required: true},
+		{Name: "reservation_isolation", Required: true},
+		{Name: "crash_recovery", Required: false},
+	}
+}
+
+func (a *Application) ReadinessProbes() []api.ReadinessProbe {
+	return hotelsupport.ReadinessProbes(a.seed)
+}
+
+func (a *Application) PreflightProbes() []api.ReadinessProbe {
+	return hotelsupport.PreflightProbes()
+}
+
+func (*Application) PreflightProperties() []string {
+	return []string{"protocol_contract", "persistent_http"}
+}
+
+func (*Application) CasePolicy() api.AccuracyCasePolicy {
+	return api.AccuracyCasePolicy{MinimumCases: 4, RandomExtraCases: 3}
+}
+
+func checkContext(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("Hotel accuracy check interrupted: %w", err)
+	}
+	return nil
+}

--- a/examples/evaluators/microservice/accuracyapps/hotel/catalog.go
+++ b/examples/evaluators/microservice/accuracyapps/hotel/catalog.go
@@ -1,0 +1,56 @@
+package hotel
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type profile struct {
+	id, name, phone string
+	lat, lon        float32
+	recommendLat    float64
+	recommendLon    float64
+}
+
+var initialProfiles = []profile{
+	{id: "1", name: "Clift Hotel", phone: "(415) 775-4700", lat: 37.7867, lon: -122.4112, recommendLat: 37.7867, recommendLon: -122.4112},
+	{id: "2", name: "W San Francisco", phone: "(415) 777-5300", lat: 37.7854, lon: -122.4005, recommendLat: 37.7854, recommendLon: -122.4005},
+	{id: "3", name: "Hotel Zetta", phone: "(415) 543-8555", lat: 37.7834, lon: -122.4071, recommendLat: 37.7834, recommendLon: -122.4071},
+	{id: "4", name: "Hotel Vitale", phone: "(415) 278-3700", lat: 37.7936, lon: -122.3930, recommendLat: 37.7936, recommendLon: -122.3930},
+	{id: "5", name: "Phoenix Hotel", phone: "(415) 776-1380", lat: 37.7831, lon: -122.4181, recommendLat: 37.7831, recommendLon: -122.4181},
+	{id: "6", name: "St. Regis San Francisco", phone: "(415) 284-4000", lat: 37.7863, lon: -122.4015, recommendLat: 37.7863, recommendLon: -122.4015},
+}
+
+// seedProfiles independently reproduces cmd/profile/db.go. In particular, the
+// profile service stores generated coordinates as float32 while the
+// recommendation service stores its copy as float64.
+func seedProfiles() (map[string]profile, error) {
+	catalog := make(map[string]profile, 80)
+	for _, item := range initialProfiles {
+		catalog[item.id] = item
+	}
+	for id := 7; id <= 80; id++ {
+		text := strconv.Itoa(id)
+		item := profile{
+			id: text, name: "St. Regis San Francisco",
+			phone:        fmt.Sprintf("(415) 284-40%s", text),
+			lat:          37.7835 + float32(id)/500.0*3,
+			lon:          -122.41 + float32(id)/500.0*4,
+			recommendLat: 37.7835 + float64(id)/500.0*3,
+			recommendLon: -122.41 + float64(id)/500.0*4,
+		}
+		catalog[text] = item
+	}
+	if len(catalog) != 80 {
+		return nil, fmt.Errorf("Hotel seed catalog has %d profiles, expected 80", len(catalog))
+	}
+	return catalog, nil
+}
+
+func rateBackedIDs() map[string]struct{} {
+	result := map[string]struct{}{"1": {}, "2": {}, "3": {}}
+	for id := 9; id <= 80; id += 3 {
+		result[strconv.Itoa(id)] = struct{}{}
+	}
+	return result
+}

--- a/examples/evaluators/microservice/accuracyapps/hotel/client.go
+++ b/examples/evaluators/microservice/accuracyapps/hotel/client.go
@@ -1,0 +1,87 @@
+package hotel
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"vibesys/microservice-evaluator/accuracy/httpcheck"
+	"vibesys/microservice-evaluator/api"
+	hotelsupport "vibesys/microservice-evaluator/appsupport/hotel"
+	"vibesys/microservice-evaluator/wire/httpjson"
+)
+
+type client struct {
+	runtime api.Runtime
+	timeout time.Duration
+}
+
+func (c client) request(ctx context.Context, path string, query map[string]string) api.ProtocolResult {
+	spec := httpjson.MustRequest(http.MethodGet, path, nil, "")
+	spec.Query = query
+	requestContext, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	return c.runtime.Invoke(requestContext, api.Invocation{
+		Target: hotelsupport.GatewayTarget, Operation: "accuracy", Payload: spec,
+	})
+}
+
+func (c client) geoJSON(ctx context.Context, path string, query map[string]string) (map[string]feature, error) {
+	result := c.request(ctx, path, query)
+	response, err := httpcheck.Response(result, http.StatusOK)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", path, err)
+	}
+	decoded, err := httpcheck.DecodeJSON(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", path, err)
+	}
+	features, err := decodeFeatureCollection(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", path, err)
+	}
+	return features, nil
+}
+
+func (c client) exactMessage(ctx context.Context, path string, query map[string]string, expected string) error {
+	message, err := c.message(ctx, path, query)
+	if err != nil {
+		return err
+	}
+	if message != expected {
+		return fmt.Errorf("GET %s message = %q, expected %q", path, message, expected)
+	}
+	return nil
+}
+
+func (c client) message(ctx context.Context, path string, query map[string]string) (string, error) {
+	result := c.request(ctx, path, query)
+	response, err := httpcheck.Response(result, http.StatusOK)
+	if err != nil {
+		return "", fmt.Errorf("GET %s: %w", path, err)
+	}
+	decoded, err := httpcheck.DecodeJSON(response.Body)
+	if err != nil {
+		return "", fmt.Errorf("GET %s: %w", path, err)
+	}
+	object, ok := decoded.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("GET %s response must be an object, got %T", path, decoded)
+	}
+	if err := httpcheck.ExactFields(object, "message"); err != nil {
+		return "", fmt.Errorf("GET %s response: %w", path, err)
+	}
+	message, ok := object["message"].(string)
+	if !ok {
+		return "", fmt.Errorf("GET %s message must be a string, got %T", path, object["message"])
+	}
+	return message, nil
+}
+
+func (c client) badRequest(ctx context.Context, path string, query map[string]string) error {
+	if _, err := httpcheck.Response(c.request(ctx, path, query), http.StatusBadRequest); err != nil {
+		return fmt.Errorf("GET %s negative case: %w", path, err)
+	}
+	return nil
+}

--- a/examples/evaluators/microservice/accuracyapps/hotel/hotel_test.go
+++ b/examples/evaluators/microservice/accuracyapps/hotel/hotel_test.go
@@ -1,0 +1,421 @@
+package hotel
+
+import (
+	"context"
+	"encoding/json"
+	"math/rand"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"vibesys/microservice-evaluator/accuracy/httpcheck"
+	"vibesys/microservice-evaluator/api"
+	hotelsupport "vibesys/microservice-evaluator/appsupport/hotel"
+)
+
+func TestCatalogIsIndependentCompleteAndExact(t *testing.T) {
+	catalog, err := seedProfiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog) != 80 {
+		t.Fatalf("catalog size=%d", len(catalog))
+	}
+	checks := map[string]profile{
+		"1": {name: "Clift Hotel", phone: "(415) 775-4700", lat: 37.7867, lon: -122.4112},
+		"7": {
+			name: "St. Regis San Francisco", phone: "(415) 284-407",
+			lat: 37.7835 + float32(7)/500.0*3, lon: -122.41 + float32(7)/500.0*4,
+		},
+		"80": {
+			name: "St. Regis San Francisco", phone: "(415) 284-4080",
+			lat: 37.7835 + float32(80)/500.0*3, lon: -122.41 + float32(80)/500.0*4,
+		},
+	}
+	for id, want := range checks {
+		got, ok := catalog[id]
+		if !ok || got.name != want.name || got.phone != want.phone || got.lat != want.lat || got.lon != want.lon {
+			t.Fatalf("catalog[%s]=%+v, want %+v", id, got, want)
+		}
+	}
+	backed := rateBackedIDs()
+	for _, id := range []string{"1", "2", "3", "9", "78"} {
+		if _, ok := backed[id]; !ok {
+			t.Fatalf("rate-backed ID %s missing", id)
+		}
+	}
+	for _, id := range []string{"6", "7", "80"} {
+		if _, ok := backed[id]; ok {
+			t.Fatalf("non-rate-backed ID %s accepted", id)
+		}
+	}
+}
+
+func TestGeoJSONStrictSchemaIsOrderIndependent(t *testing.T) {
+	raw := `{
+		"features":[{
+			"geometry":{"coordinates":[-122.4112,37.7867],"type":"Point"},
+			"properties":{"phone_number":"(415) 775-4700","name":"Clift Hotel"},
+			"id":"1","type":"Feature"
+		}],"type":"FeatureCollection"
+	}`
+	decoded, err := httpcheck.DecodeJSON([]byte(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	features, err := decodeFeatureCollection(decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalog, _ := seedProfiles()
+	if err := validateProfiles(features, catalog, "test"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGeoJSONRejectsSchemaValueAndUniquenessMutants(t *testing.T) {
+	base := func() map[string]any {
+		return map[string]any{
+			"type": "FeatureCollection",
+			"features": []any{map[string]any{
+				"type": "Feature", "id": "1",
+				"properties": map[string]any{"name": "Clift Hotel", "phone_number": "(415) 775-4700"},
+				"geometry":   map[string]any{"type": "Point", "coordinates": []any{-122.4112, 37.7867}},
+			}},
+		}
+	}
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+		value  bool
+	}{
+		{"extra root field", func(root map[string]any) { root["extra"] = true }, false},
+		{"wrong coordinate type", func(root map[string]any) {
+			feature := root["features"].([]any)[0].(map[string]any)
+			feature["geometry"].(map[string]any)["coordinates"] = []any{"-122", 37.7867}
+		}, false},
+		{"duplicate id", func(root map[string]any) {
+			items := root["features"].([]any)
+			clone := deepClone(t, items[0])
+			root["features"] = append(items, clone)
+		}, false},
+		{"wrong seeded value", func(root map[string]any) {
+			feature := root["features"].([]any)[0].(map[string]any)
+			feature["properties"].(map[string]any)["name"] = "Impostor"
+		}, true},
+	}
+	catalog, _ := seedProfiles()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := base()
+			test.mutate(root)
+			features, err := decodeFeatureCollection(normalize(t, root))
+			if test.value {
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = validateProfiles(features, catalog, "mutant")
+			}
+			if err == nil {
+				t.Fatal("mutant passed strict validation")
+			}
+		})
+	}
+}
+
+func TestSearchRequiresExactRateBackedSetAndStableResponses(t *testing.T) {
+	catalog, _ := seedProfiles()
+	application := &Application{catalog: catalog}
+	features := make(map[string]feature)
+	for id := range rateBackedIDs() {
+		features[id] = featureFromProfile(t, catalog[id])
+	}
+	if err := application.validateSearchSet(features); err != nil {
+		t.Fatal(err)
+	}
+	if err := sameIDs(features, features); err != nil {
+		t.Fatal(err)
+	}
+	for name, mutate := range map[string]func(map[string]feature){
+		"valid truncation": func(items map[string]feature) { delete(items, "78") },
+		"non-rate extra":   func(items map[string]feature) { items["7"] = featureFromProfile(t, catalog["7"]) },
+		"changed warm set": func(items map[string]feature) { delete(items, "9") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := cloneFeatures(features)
+			mutate(candidate)
+			var err error
+			if name == "changed warm set" {
+				err = sameIDs(features, candidate)
+			} else {
+				err = application.validateSearchSet(candidate)
+			}
+			if err == nil {
+				t.Fatal("search mutant passed")
+			}
+		})
+	}
+}
+
+func TestSearchFuzzingIsSeededVariedAndRepeated(t *testing.T) {
+	catalog, _ := seedProfiles()
+	features := make([]any, 0, len(rateBackedIDs()))
+	for id := range rateBackedIDs() {
+		features = append(features, featureFromProfile(t, catalog[id]).raw)
+	}
+	var requests []api.HTTPRequestSpec
+	runtime := runtimeFunc(func(_ context.Context, invocation api.Invocation) api.ProtocolResult {
+		requests = append(requests, invocation.Payload.(api.HTTPRequestSpec))
+		return httpResult(200, map[string]any{"type": "FeatureCollection", "features": features})
+	})
+	application := &Application{catalog: catalog}
+	checks, err := application.verifySearch(
+		context.Background(),
+		client{runtime: runtime, timeout: time.Second},
+		rand.New(rand.NewSource(91)),
+		4,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checks != 8 || len(requests) != 8 {
+		t.Fatalf("checks=%d requests=%d, want 8", checks, len(requests))
+	}
+	seen := make(map[string]struct{})
+	for index := 0; index < len(requests); index += 2 {
+		if !reflect.DeepEqual(requests[index].Query, requests[index+1].Query) {
+			t.Fatalf("case %d was not repeated exactly", index/2)
+		}
+		query := requests[index].Query
+		seen[query["inDate"]+"/"+query["outDate"]+"/"+query["lat"]+"/"+query["lon"]] = struct{}{}
+	}
+	if len(seen) < 2 {
+		t.Fatalf("fuzzing generated only %d distinct query", len(seen))
+	}
+}
+
+func TestSearchAvailabilityConnectsAcknowledgedReservationsToReads(t *testing.T) {
+	catalog, _ := seedProfiles()
+	var requests []api.HTTPRequestSpec
+	filledID := ""
+	runtime := runtimeFunc(func(_ context.Context, invocation api.Invocation) api.ProtocolResult {
+		spec := invocation.Payload.(api.HTTPRequestSpec)
+		requests = append(requests, spec)
+		if spec.Path == "/reservation" {
+			if filledID == "" {
+				filledID = spec.Query["hotelId"]
+				return httpResult(200, map[string]any{"message": reservationSuccess})
+			}
+			return httpResult(200, map[string]any{"message": reservationFailure})
+		}
+		features := make([]any, 0, len(rateBackedIDs()))
+		for _, id := range sortedRateBackedIDs() {
+			if len(requests) == 3 && id == filledID {
+				continue
+			}
+			features = append(features, featureFromProfile(t, catalog[id]).raw)
+		}
+		return httpResult(200, map[string]any{"type": "FeatureCollection", "features": features})
+	})
+	application := &Application{catalog: catalog}
+	checks, err := application.verifySearchAvailability(
+		context.Background(),
+		client{runtime: runtime, timeout: time.Second},
+		37,
+		rand.New(rand.NewSource(101)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checks != 4 || len(requests) != 4 {
+		t.Fatalf("checks=%d requests=%d, want 4", checks, len(requests))
+	}
+	if requests[0].Query["hotelId"] != filledID || requests[1].Query["number"] != "1" {
+		t.Fatalf("reservation witness is not a fill/read-back pair: %+v", requests[:2])
+	}
+	if requests[2].Query["inDate"] != requests[0].Query["inDate"] {
+		t.Fatal("first search did not query the filled date")
+	}
+	if requests[3].Query["inDate"] != requests[0].Query["outDate"] {
+		t.Fatal("second search did not query the adjacent date")
+	}
+}
+
+func TestApplicationContractAndReservationNamespace(t *testing.T) {
+	workload := api.Workload{
+		Load:    api.Load{TimeoutSeconds: 2, Seed: 19},
+		Targets: []api.Target{{Name: "gateway", Protocol: "http", SessionPolicy: "reuse"}},
+	}
+	application, err := New(workload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if application.Name() != "hotel" {
+		t.Fatalf("name=%q", application.Name())
+	}
+	policy := application.CasePolicy()
+	if policy.MinimumCases != 4 || policy.RandomExtraCases != 3 {
+		t.Fatalf("policy=%+v", policy)
+	}
+	properties := application.Properties()
+	if len(properties) != 13 {
+		t.Fatalf("properties=%v", properties)
+	}
+	for _, property := range properties {
+		if property.Name == "crash_recovery" {
+			if property.Required {
+				t.Fatal("crash_recovery must remain optional without a lifecycle hook")
+			}
+			continue
+		}
+		if !property.Required {
+			t.Fatalf("property %s is unexpectedly optional", property.Name)
+		}
+	}
+	first := reservationDate(19)
+	if !first.Equal(reservationDate(19)) || first.Equal(reservationDate(20)) {
+		t.Fatal("reservation namespace is not deterministic and seed-separated")
+	}
+	if first.Year() < 3000 || first.Year() > 7999 || !first.After(time.Now()) {
+		t.Fatalf("reservation date=%v is outside the collision-resistant future range", first)
+	}
+}
+
+func TestClientRejectsNonExactMessagesAndNon400NegativeCases(t *testing.T) {
+	runtime := runtimeFunc(func(_ context.Context, invocation api.Invocation) api.ProtocolResult {
+		spec := invocation.Payload.(api.HTTPRequestSpec)
+		if spec.Path == "/user" {
+			return httpResult(200, map[string]any{"message": loginSuccess, "extra": true})
+		}
+		return httpResult(200, map[string]any{"message": "ok"})
+	})
+	c := client{runtime: runtime, timeout: time.Second}
+	if err := c.exactMessage(context.Background(), "/user", nil, loginSuccess); err == nil || !strings.Contains(err.Error(), "fields") {
+		t.Fatalf("message error=%v", err)
+	}
+	if err := c.badRequest(context.Background(), "/hotels", nil); err == nil {
+		t.Fatal("HTTP 200 passed a negative case")
+	}
+}
+
+func TestReservationCasesRandomizeHotelsAndExerciseEveryInvariant(t *testing.T) {
+	const cases = 5
+	var requests []api.HTTPRequestSpec
+	runtime := runtimeFunc(func(_ context.Context, invocation api.Invocation) api.ProtocolResult {
+		spec := invocation.Payload.(api.HTTPRequestSpec)
+		requests = append(requests, spec)
+		messages := []string{
+			reservationSuccess,
+			reservationFailure,
+			reservationFailure,
+			reservationSuccess,
+			reservationSuccess,
+		}
+		return httpResult(200, map[string]any{"message": messages[(len(requests)-1)%len(messages)]})
+	})
+	a := &Application{}
+	checks, err := a.verifyReservations(
+		context.Background(),
+		client{runtime: runtime, timeout: time.Second},
+		29,
+		cases,
+		rand.New(rand.NewSource(71)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checks != cases*5 || len(requests) != cases*5 {
+		t.Fatalf("checks=%d requests=%d, want %d", checks, len(requests), cases*5)
+	}
+	seenHotels := make(map[string]struct{})
+	seenDates := make(map[string]struct{})
+	for caseIndex := 0; caseIndex < cases; caseIndex++ {
+		batch := requests[caseIndex*5 : caseIndex*5+5]
+		primary := batch[0].Query["hotelId"]
+		isolation := batch[4].Query["hotelId"]
+		if primary == isolation {
+			t.Fatalf("case %d reused hotel %s for isolation", caseIndex, primary)
+		}
+		for _, id := range []string{primary, isolation} {
+			if _, duplicate := seenHotels[id]; duplicate {
+				t.Fatalf("case %d reused randomized hotel %s", caseIndex, id)
+			}
+			seenHotels[id] = struct{}{}
+		}
+		exactDate := batch[0].Query["inDate"]
+		adjacentDate := batch[2].Query["inDate"]
+		for _, date := range []string{exactDate, adjacentDate} {
+			if _, duplicate := seenDates[date]; duplicate {
+				t.Fatalf("case %d reused date slot %s", caseIndex, date)
+			}
+			seenDates[date] = struct{}{}
+		}
+		if batch[1].Query["inDate"] != exactDate || batch[3].Query["inDate"] != adjacentDate || batch[4].Query["inDate"] != adjacentDate {
+			t.Fatalf("case %d request dates do not exercise same-slot visibility/isolation", caseIndex)
+		}
+		numericID, err := strconv.Atoi(primary)
+		if err != nil {
+			t.Fatal(err)
+		}
+		capacity, err := hotelsupport.Capacity(numericID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if batch[0].Query["number"] != strconv.Itoa(capacity) ||
+			batch[1].Query["number"] != "1" ||
+			batch[2].Query["number"] != strconv.Itoa(capacity+1) ||
+			batch[3].Query["number"] != "1" || batch[4].Query["number"] != "1" {
+			t.Fatalf("case %d room sequence is not exact-cap/+1/over-cap/1/isolation: %+v", caseIndex, batch)
+		}
+	}
+}
+
+type runtimeFunc func(context.Context, api.Invocation) api.ProtocolResult
+
+func (function runtimeFunc) Invoke(ctx context.Context, invocation api.Invocation) api.ProtocolResult {
+	return function(ctx, invocation)
+}
+
+func httpResult(status int, value any) api.ProtocolResult {
+	body, _ := json.Marshal(value)
+	return api.ProtocolResult{TransportSuccess: true, Payload: api.HTTPResponse{StatusCode: status, Body: body}}
+}
+
+func normalize(t *testing.T, value any) any {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := httpcheck.DecodeJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return decoded
+}
+
+func deepClone(t *testing.T, value any) any { return normalize(t, value) }
+
+func featureFromProfile(t *testing.T, item profile) feature {
+	t.Helper()
+	raw := map[string]any{
+		"type": "Feature", "id": item.id,
+		"properties": map[string]any{"name": item.name, "phone_number": item.phone},
+		"geometry":   map[string]any{"type": "Point", "coordinates": []any{item.lon, item.lat}},
+	}
+	decoded, err := decodeFeature(normalize(t, raw), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return decoded
+}
+
+func cloneFeatures(source map[string]feature) map[string]feature {
+	result := make(map[string]feature, len(source))
+	for id, item := range source {
+		result[id] = item
+	}
+	return result
+}

--- a/examples/evaluators/microservice/accuracyapps/hotel/schema.go
+++ b/examples/evaluators/microservice/accuracyapps/hotel/schema.go
@@ -1,0 +1,153 @@
+package hotel
+
+import (
+	"fmt"
+
+	"vibesys/microservice-evaluator/accuracy/httpcheck"
+	"vibesys/microservice-evaluator/accuracy/jsoncheck"
+)
+
+type feature struct {
+	id          string
+	name, phone string
+	lat, lon    float64
+	raw         map[string]any
+}
+
+func decodeFeatureCollection(value any) (map[string]feature, error) {
+	root, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("GeoJSON root must be an object, got %T", value)
+	}
+	if err := httpcheck.ExactFields(root, "type", "features"); err != nil {
+		return nil, fmt.Errorf("GeoJSON root: %w", err)
+	}
+	if root["type"] != "FeatureCollection" {
+		return nil, fmt.Errorf("GeoJSON root type = %v, expected FeatureCollection", root["type"])
+	}
+	items, ok := root["features"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("GeoJSON features must be a list, got %T", root["features"])
+	}
+	indexed := make(map[string]feature, len(items))
+	for index, value := range items {
+		item, err := decodeFeature(value, index)
+		if err != nil {
+			return nil, err
+		}
+		if _, duplicate := indexed[item.id]; duplicate {
+			return nil, fmt.Errorf("GeoJSON features contain duplicate hotel ID %q", item.id)
+		}
+		indexed[item.id] = item
+	}
+	return indexed, nil
+}
+
+func decodeFeature(value any, index int) (feature, error) {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return feature{}, fmt.Errorf("GeoJSON feature %d must be an object, got %T", index, value)
+	}
+	if err := httpcheck.ExactFields(object, "type", "id", "properties", "geometry"); err != nil {
+		return feature{}, fmt.Errorf("GeoJSON feature %d: %w", index, err)
+	}
+	if object["type"] != "Feature" {
+		return feature{}, fmt.Errorf("GeoJSON feature %d type = %v, expected Feature", index, object["type"])
+	}
+	id, ok := object["id"].(string)
+	if !ok || id == "" {
+		return feature{}, fmt.Errorf("GeoJSON feature %d id must be a non-empty string", index)
+	}
+	properties, ok := object["properties"].(map[string]any)
+	if !ok {
+		return feature{}, fmt.Errorf("GeoJSON feature %d properties must be an object", index)
+	}
+	if err := httpcheck.ExactFields(properties, "name", "phone_number"); err != nil {
+		return feature{}, fmt.Errorf("GeoJSON feature %d properties: %w", index, err)
+	}
+	name, nameOK := properties["name"].(string)
+	phone, phoneOK := properties["phone_number"].(string)
+	if !nameOK || name == "" || !phoneOK || phone == "" {
+		return feature{}, fmt.Errorf("GeoJSON feature %d name and phone_number must be non-empty strings", index)
+	}
+	geometry, ok := object["geometry"].(map[string]any)
+	if !ok {
+		return feature{}, fmt.Errorf("GeoJSON feature %d geometry must be an object", index)
+	}
+	if err := httpcheck.ExactFields(geometry, "type", "coordinates"); err != nil {
+		return feature{}, fmt.Errorf("GeoJSON feature %d geometry: %w", index, err)
+	}
+	if geometry["type"] != "Point" {
+		return feature{}, fmt.Errorf("GeoJSON feature %d geometry type = %v, expected Point", index, geometry["type"])
+	}
+	coordinates, ok := geometry["coordinates"].([]any)
+	if !ok || len(coordinates) != 2 {
+		return feature{}, fmt.Errorf("GeoJSON feature %d coordinates must contain exactly longitude and latitude", index)
+	}
+	lon, err := httpcheck.Number(coordinates[0])
+	if err != nil {
+		return feature{}, fmt.Errorf("GeoJSON feature %d longitude: %w", index, err)
+	}
+	lat, err := httpcheck.Number(coordinates[1])
+	if err != nil {
+		return feature{}, fmt.Errorf("GeoJSON feature %d latitude: %w", index, err)
+	}
+	return feature{id: id, name: name, phone: phone, lat: lat, lon: lon, raw: object}, nil
+}
+
+func validateProfiles(actual map[string]feature, catalog map[string]profile, where string) error {
+	for id, item := range actual {
+		expected, ok := catalog[id]
+		if !ok {
+			return fmt.Errorf("%s returned unknown hotel ID %q", where, id)
+		}
+		expectedFeature := map[string]any{
+			"type": "Feature", "id": expected.id,
+			"properties": map[string]any{"name": expected.name, "phone_number": expected.phone},
+			"geometry": map[string]any{
+				"type": "Point", "coordinates": []any{expected.lon, expected.lat},
+			},
+		}
+		equal, err := jsoncheck.Equal(item.raw, expectedFeature)
+		if err != nil {
+			return fmt.Errorf("%s hotel %s: %w", where, id, err)
+		}
+		if !equal {
+			return fmt.Errorf("%s hotel %s does not match the seeded profile: got %v", where, id, item.raw)
+		}
+	}
+	return nil
+}
+
+func exactIDs(actual map[string]feature, expected ...string) error {
+	wanted := make(map[string]struct{}, len(expected))
+	for _, id := range expected {
+		if _, duplicate := wanted[id]; duplicate {
+			return fmt.Errorf("duplicate expected hotel ID %q", id)
+		}
+		wanted[id] = struct{}{}
+	}
+	for id := range wanted {
+		if _, ok := actual[id]; !ok {
+			return fmt.Errorf("missing hotel ID %q", id)
+		}
+	}
+	for id := range actual {
+		if _, ok := wanted[id]; !ok {
+			return fmt.Errorf("unexpected hotel ID %q", id)
+		}
+	}
+	return nil
+}
+
+func sameIDs(left, right map[string]feature) error {
+	if len(left) != len(right) {
+		return fmt.Errorf("hotel ID sets differ in size: first=%d second=%d", len(left), len(right))
+	}
+	for id := range left {
+		if _, ok := right[id]; !ok {
+			return fmt.Errorf("warm response omitted hotel ID %q from the first response", id)
+		}
+	}
+	return nil
+}

--- a/examples/evaluators/microservice/accuracyapps/hotel/suite.go
+++ b/examples/evaluators/microservice/accuracyapps/hotel/suite.go
@@ -1,0 +1,584 @@
+package hotel
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strconv"
+	"time"
+
+	"vibesys/microservice-evaluator/api"
+	hotelsupport "vibesys/microservice-evaluator/appsupport/hotel"
+)
+
+const (
+	loginSuccess       = "Login successfully!"
+	loginFailure       = "Failed. Please check your username and password. "
+	reservationSuccess = "Reserve successfully!"
+	reservationFailure = "Failed. Already reserved. "
+)
+
+func (a *Application) Check(
+	ctx context.Context,
+	runtime api.Runtime,
+	check api.AccuracyContext,
+	recorder api.AccuracyRecorder,
+) error {
+	c := client{runtime: runtime, timeout: a.timeout}
+	random := rand.New(rand.NewSource(check.Seed ^ 0x51f15e))
+
+	checks, err := a.verifySearch(ctx, c, random, max(check.Cases, 4))
+	recorder.AddChecks(checks)
+	if err != nil {
+		return err
+	}
+	if err := recorder.Pass("strict_geojson_schema", "search_semantics"); err != nil {
+		return err
+	}
+
+	checks, err = a.verifyRecommendations(ctx, c, random)
+	recorder.AddChecks(checks)
+	if err != nil {
+		return err
+	}
+	if err := recorder.Pass("seeded_profile_semantics", "recommendation_semantics"); err != nil {
+		return err
+	}
+
+	checks, err = a.verifyAuthentication(ctx, c, random, max(check.Cases, 4))
+	recorder.AddChecks(checks)
+	if err != nil {
+		return err
+	}
+	if err := recorder.Pass("authentication_semantics"); err != nil {
+		return err
+	}
+
+	checks, err = a.verifyNegativeCases(ctx, c, random)
+	recorder.AddChecks(checks)
+	if err != nil {
+		return err
+	}
+
+	checks, err = a.verifySearchAvailability(ctx, c, check.Seed, random)
+	recorder.AddChecks(checks)
+	if err != nil {
+		return err
+	}
+	if err := recorder.Pass("search_availability"); err != nil {
+		return err
+	}
+
+	checks, err = a.verifyOptionalReservationNumber(ctx, c, check.Seed, random)
+	recorder.AddChecks(checks)
+	if err != nil {
+		return err
+	}
+	if err := recorder.Pass("reservation_optional_number"); err != nil {
+		return err
+	}
+
+	checks, err = a.verifyReservations(ctx, c, check.Seed, check.Cases, random)
+	recorder.AddChecks(checks)
+	if err != nil {
+		return err
+	}
+	if err := recorder.Pass("reservation_capacity", "read_your_write", "reservation_isolation"); err != nil {
+		return err
+	}
+	if check.Restart == nil {
+		return nil
+	}
+	checks, err = a.verifyCrashRecovery(ctx, c, check.Seed, random, check.Restart)
+	recorder.AddChecks(checks)
+	if err != nil {
+		return err
+	}
+	return recorder.Pass("crash_recovery")
+}
+
+func (a *Application) verifySearch(ctx context.Context, c client, random *rand.Rand, cases int) (int, error) {
+	checks := 0
+	for caseIndex := 0; caseIndex < cases; caseIndex++ {
+		if err := checkContext(ctx); err != nil {
+			return checks, err
+		}
+		inDay := 9 + random.Intn(15)
+		outDay := inDay + 1 + random.Intn(24-inDay)
+		anchor := a.catalog[strconv.Itoa(7+random.Intn(74))]
+		jitter := func() float64 { return (random.Float64()*2 - 1) / 1000.0 }
+		query := map[string]string{
+			"inDate":  fmt.Sprintf("2015-04-%02d", inDay),
+			"outDate": fmt.Sprintf("2015-04-%02d", outDay),
+			"lat":     strconv.FormatFloat(anchor.recommendLat+jitter(), 'f', 6, 64),
+			"lon":     strconv.FormatFloat(anchor.recommendLon+jitter(), 'f', 6, 64),
+		}
+		if caseIndex%2 == 0 {
+			query["locale"] = "en"
+		}
+		first, err := c.geoJSON(ctx, "/hotels", query)
+		checks++
+		if err != nil {
+			return checks, err
+		}
+		if err := a.validateSearchSet(first); err != nil {
+			return checks, fmt.Errorf("fuzzed search case %d query %v: %w", caseIndex, query, err)
+		}
+		second, err := c.geoJSON(ctx, "/hotels", query)
+		checks++
+		if err != nil {
+			return checks, err
+		}
+		if err := a.validateSearchSet(second); err != nil {
+			return checks, fmt.Errorf("warm fuzzed search case %d query %v: %w", caseIndex, query, err)
+		}
+		if err := sameIDs(first, second); err != nil {
+			return checks, fmt.Errorf("fuzzed search case %d cache stability: %w", caseIndex, err)
+		}
+	}
+	return checks, nil
+}
+
+func (a *Application) validateSearchSet(features map[string]feature) error {
+	if err := validateProfiles(features, a.catalog, "canonical search"); err != nil {
+		return err
+	}
+	expected := rateBackedIDs()
+	ids := make([]string, 0, len(expected))
+	for id := range expected {
+		ids = append(ids, id)
+	}
+	if err := exactIDs(features, ids...); err != nil {
+		return fmt.Errorf("rate-backed result set: %w", err)
+	}
+	return nil
+}
+
+func (a *Application) verifyRecommendations(ctx context.Context, c client, random *rand.Rand) (int, error) {
+	checks := 0
+	queries := []struct {
+		require string
+		ids     []string
+	}{
+		{require: "price", ids: []string{"2"}},
+		{require: "rate", ids: []string{"9", "24", "39", "54", "69"}},
+	}
+	for queryIndex, item := range queries {
+		query := map[string]string{"require": item.require, "lat": "37.7749", "lon": "-122.4194"}
+		if queryIndex%2 == 0 {
+			query["locale"] = "en"
+		}
+		features, err := c.geoJSON(ctx, "/recommendations", query)
+		checks++
+		if err != nil {
+			return checks, err
+		}
+		if err := validateProfiles(features, a.catalog, item.require+" recommendation"); err != nil {
+			return checks, err
+		}
+		if err := exactIDs(features, item.ids...); err != nil {
+			return checks, fmt.Errorf("%s recommendation: %w", item.require, err)
+		}
+	}
+
+	// Query every seeded coordinate in randomized order. This makes the 80-row
+	// catalog observable and proves that distance recommendation returns the
+	// unique exact-location hotel, rather than merely accepting a known subset.
+	ids := make([]int, 80)
+	for index := range ids {
+		ids[index] = index + 1
+	}
+	random.Shuffle(len(ids), func(left, right int) { ids[left], ids[right] = ids[right], ids[left] })
+	for _, numericID := range ids {
+		if err := checkContext(ctx); err != nil {
+			return checks, err
+		}
+		id := strconv.Itoa(numericID)
+		expected := a.catalog[id]
+		query := map[string]string{
+			"require": "dis",
+			"lat":     strconv.FormatFloat(expected.recommendLat, 'f', -1, 64),
+			"lon":     strconv.FormatFloat(expected.recommendLon, 'f', -1, 64),
+		}
+		if numericID%2 == 0 {
+			query["locale"] = "en"
+		}
+		features, err := c.geoJSON(ctx, "/recommendations", query)
+		checks++
+		if err != nil {
+			return checks, err
+		}
+		if err := validateProfiles(features, a.catalog, "distance recommendation"); err != nil {
+			return checks, err
+		}
+		if err := exactIDs(features, id); err != nil {
+			return checks, fmt.Errorf("distance recommendation at hotel %s coordinates: %w", id, err)
+		}
+	}
+
+	// Probe non-catalog coordinates that are derived from the runtime seed.
+	// Each point stays within a tiny neighborhood of a generated hotel, whose
+	// nearest-neighbor margin is much larger than the jitter. This frustrates
+	// lookup tables keyed only by the 80 public seed coordinates while keeping
+	// the oracle independent and unambiguous.
+	for caseIndex := 0; caseIndex < 2*max(4, len(ids)/20); caseIndex++ {
+		numericID := 7 + random.Intn(74)
+		id := strconv.Itoa(numericID)
+		expected := a.catalog[id]
+		jitter := func() float64 { return (random.Float64()*2 - 1) / 100000.0 }
+		query := map[string]string{
+			"require": "dis",
+			"lat":     strconv.FormatFloat(expected.recommendLat+jitter(), 'f', 8, 64),
+			"lon":     strconv.FormatFloat(expected.recommendLon+jitter(), 'f', 8, 64),
+		}
+		if caseIndex%2 == 0 {
+			query["locale"] = "en"
+		}
+		features, err := c.geoJSON(ctx, "/recommendations", query)
+		checks++
+		if err != nil {
+			return checks, err
+		}
+		if err := validateProfiles(features, a.catalog, "fuzzed distance recommendation"); err != nil {
+			return checks, err
+		}
+		if err := exactIDs(features, id); err != nil {
+			return checks, fmt.Errorf("fuzzed distance recommendation near hotel %s: %w", id, err)
+		}
+	}
+	return checks, nil
+}
+
+func (a *Application) verifyAuthentication(ctx context.Context, c client, random *rand.Rand, cases int) (int, error) {
+	checks := 0
+	indices := random.Perm(501)
+	for caseIndex := 0; caseIndex < cases; caseIndex++ {
+		index := indices[caseIndex%len(indices)]
+		if err := checkContext(ctx); err != nil {
+			return checks, err
+		}
+		username, password, err := hotelsupport.User(index)
+		if err != nil {
+			return checks, err
+		}
+		if err := c.exactMessage(ctx, "/user", credentials(username, password), loginSuccess); err != nil {
+			return checks + 1, fmt.Errorf("valid seed user %d: %w", index, err)
+		}
+		checks++
+		if err := c.exactMessage(ctx, "/user", credentials(username, password+"-wrong"), loginFailure); err != nil {
+			return checks + 1, fmt.Errorf("wrong password for seed user %d: %w", index, err)
+		}
+		checks++
+	}
+	if err := c.exactMessage(ctx, "/user", credentials("Cornell_nonexistent", "not-a-password"), loginFailure); err != nil {
+		return checks + 1, fmt.Errorf("nonexistent user: %w", err)
+	}
+	return checks + 1, nil
+}
+
+func (a *Application) verifyNegativeCases(ctx context.Context, c client, random *rand.Rand) (int, error) {
+	username, password := hotelsupport.MustUser(0)
+	checks := 0
+	reservationBase := map[string]string{
+		"inDate": "3000-01-01", "outDate": "3000-01-02", "hotelId": "1",
+		"customerName": "negative-case", "username": username, "password": password, "number": "1",
+	}
+	negative := []struct {
+		path  string
+		query map[string]string
+	}{
+		{"/hotels", map[string]string{"lat": "37", "lon": "-122"}},
+		{"/hotels", map[string]string{"inDate": "2015-04-09", "outDate": "2015-04-10"}},
+		{"/recommendations", map[string]string{"require": "price"}},
+		{"/recommendations", map[string]string{
+			"lat": "37", "lon": "-122", "require": fmt.Sprintf("unknown-%016x", random.Uint64()),
+		}},
+		{"/user", map[string]string{"username": username}},
+		{"/reservation", without(reservationBase, "inDate")},
+		{"/reservation", with(reservationBase, "inDate", fmt.Sprintf("invalid-%016x", random.Uint64()))},
+		{"/reservation", without(reservationBase, "hotelId")},
+		{"/reservation", without(reservationBase, "customerName")},
+		{"/reservation", without(reservationBase, "password")},
+	}
+	random.Shuffle(len(negative), func(left, right int) { negative[left], negative[right] = negative[right], negative[left] })
+	for _, item := range negative {
+		if err := c.badRequest(ctx, item.path, item.query); err != nil {
+			return checks + 1, err
+		}
+		checks++
+	}
+	return checks, nil
+}
+
+func (a *Application) verifyOptionalReservationNumber(
+	ctx context.Context,
+	c client,
+	seed int64,
+	random *rand.Rand,
+) (int, error) {
+	username, password := hotelsupport.MustUser(0)
+	hotelID := 1 + random.Intn(80)
+	capacity, err := hotelsupport.Capacity(hotelID)
+	if err != nil {
+		return 0, err
+	}
+	start := reservationDate(seed).AddDate(0, 0, 180)
+	query := credentials(username, password)
+	query["hotelId"] = strconv.Itoa(hotelID)
+	query["inDate"] = start.Format(time.DateOnly)
+	query["outDate"] = start.AddDate(0, 0, 1).Format(time.DateOnly)
+	query["customerName"] = "optional-number"
+	if err := c.exactMessage(ctx, "/reservation", query, reservationSuccess); err != nil {
+		return 1, fmt.Errorf("reservation without optional number: %w", err)
+	}
+	query["number"] = strconv.Itoa(capacity)
+	query["customerName"] = "optional-number-capacity"
+	if err := c.exactMessage(ctx, "/reservation", query, reservationSuccess); err != nil {
+		return 2, fmt.Errorf("omitted number unexpectedly consumed capacity: %w", err)
+	}
+	query["number"] = "1"
+	query["customerName"] = "optional-number-over-capacity"
+	if err := c.exactMessage(ctx, "/reservation", query, reservationFailure); err != nil {
+		return 3, fmt.Errorf("optional-number capacity read-back: %w", err)
+	}
+	return 3, nil
+}
+
+func (a *Application) verifySearchAvailability(
+	ctx context.Context,
+	c client,
+	seed int64,
+	random *rand.Rand,
+) (int, error) {
+	username, password := hotelsupport.MustUser(0)
+	rateIDs := sortedRateBackedIDs()
+	hotelID := rateIDs[random.Intn(len(rateIDs))]
+	numericID, _ := strconv.Atoi(hotelID)
+	capacity, err := hotelsupport.Capacity(numericID)
+	if err != nil {
+		return 0, err
+	}
+	start := reservationDate(seed).AddDate(0, 0, 365)
+	reservedDate := [2]string{start.Format(time.DateOnly), start.AddDate(0, 0, 1).Format(time.DateOnly)}
+	query := credentials(username, password)
+	query["hotelId"] = hotelID
+	query["inDate"] = reservedDate[0]
+	query["outDate"] = reservedDate[1]
+	query["number"] = strconv.Itoa(capacity)
+	query["customerName"] = "search-availability"
+	if err := c.exactMessage(ctx, "/reservation", query, reservationSuccess); err != nil {
+		return 1, fmt.Errorf("search availability exact-capacity setup: %w", err)
+	}
+	overCapacity := cloneQuery(query)
+	overCapacity["number"] = "1"
+	if err := c.exactMessage(ctx, "/reservation", overCapacity, reservationFailure); err != nil {
+		return 2, fmt.Errorf("search availability setup visibility: %w", err)
+	}
+
+	anchor := a.catalog[hotelID]
+	search := func(date [2]string) (map[string]feature, error) {
+		return c.geoJSON(ctx, "/hotels", map[string]string{
+			"inDate": date[0], "outDate": date[1],
+			"lat":    strconv.FormatFloat(anchor.recommendLat, 'f', -1, 64),
+			"lon":    strconv.FormatFloat(anchor.recommendLon, 'f', -1, 64),
+			"locale": "en",
+		})
+	}
+	reserved, err := search(reservedDate)
+	if err != nil {
+		return 3, err
+	}
+	if err := validateProfiles(reserved, a.catalog, "reserved-date search"); err != nil {
+		return 3, err
+	}
+	wanted := make([]string, 0, len(rateIDs)-1)
+	for _, id := range rateIDs {
+		if id != hotelID {
+			wanted = append(wanted, id)
+		}
+	}
+	if err := exactIDs(reserved, wanted...); err != nil {
+		return 3, fmt.Errorf("reserved-date search for filled hotel %s: %w", hotelID, err)
+	}
+	adjacentDate := [2]string{
+		start.AddDate(0, 0, 1).Format(time.DateOnly),
+		start.AddDate(0, 0, 2).Format(time.DateOnly),
+	}
+	adjacent, err := search(adjacentDate)
+	if err != nil {
+		return 4, err
+	}
+	if err := validateProfiles(adjacent, a.catalog, "adjacent-date search"); err != nil {
+		return 4, err
+	}
+	if err := exactIDs(adjacent, rateIDs...); err != nil {
+		return 4, fmt.Errorf("adjacent-date search after filling hotel %s: %w", hotelID, err)
+	}
+	return 4, nil
+}
+
+func sortedRateBackedIDs() []string {
+	ids := make([]string, 0, len(rateBackedIDs()))
+	for id := range rateBackedIDs() {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(left, right int) bool {
+		leftID, _ := strconv.Atoi(ids[left])
+		rightID, _ := strconv.Atoi(ids[right])
+		return leftID < rightID
+	})
+	return ids
+}
+
+func (a *Application) verifyReservations(
+	ctx context.Context,
+	c client,
+	seed int64,
+	cases int,
+	random *rand.Rand,
+) (int, error) {
+	username, password := hotelsupport.MustUser(0)
+	start := reservationDate(seed)
+	checks := 0
+	reserve := func(hotelID string, date [2]string, rooms int, customer, expected string) error {
+		query := credentials(username, password)
+		query["hotelId"] = hotelID
+		query["inDate"] = date[0]
+		query["outDate"] = date[1]
+		query["number"] = strconv.Itoa(rooms)
+		query["customerName"] = customer
+		checks++
+		return c.exactMessage(ctx, "/reservation", query, expected)
+	}
+
+	// The endpoint has no delete operation. Use shuffled hotel pairs and
+	// hash-namespaced, disjoint future date slots so each case is independent
+	// without claiming cleanup that the application cannot perform.
+	hotelOrder := random.Perm(80)
+	for caseIndex := 0; caseIndex < cases; caseIndex++ {
+		if err := checkContext(ctx); err != nil {
+			return checks, err
+		}
+		primaryID := 1 + hotelOrder[(caseIndex*2)%len(hotelOrder)]
+		isolationID := 1 + hotelOrder[(caseIndex*2+1)%len(hotelOrder)]
+		caseStart := start.AddDate(0, 0, caseIndex*4)
+		exactDate := [2]string{
+			caseStart.Format("2006-01-02"),
+			caseStart.AddDate(0, 0, 1).Format("2006-01-02"),
+		}
+		adjacentDate := [2]string{
+			caseStart.AddDate(0, 0, 2).Format("2006-01-02"),
+			caseStart.AddDate(0, 0, 3).Format("2006-01-02"),
+		}
+		primary := strconv.Itoa(primaryID)
+		isolation := strconv.Itoa(isolationID)
+		capacity, err := hotelsupport.Capacity(primaryID)
+		if err != nil {
+			return checks, err
+		}
+		label := fmt.Sprintf("case-%d", caseIndex)
+		if err := reserve(primary, exactDate, capacity, label+"-exact-capacity", reservationSuccess); err != nil {
+			return checks, fmt.Errorf("reservation case %d exact capacity: %w", caseIndex, err)
+		}
+		if err := reserve(primary, exactDate, 1, label+"-read-your-write", reservationFailure); err != nil {
+			return checks, fmt.Errorf("reservation case %d immediately visible: %w", caseIndex, err)
+		}
+		if err := reserve(primary, adjacentDate, capacity+1, label+"-atomic-rejection", reservationFailure); err != nil {
+			return checks, fmt.Errorf("reservation case %d over capacity: %w", caseIndex, err)
+		}
+		if err := reserve(primary, adjacentDate, 1, label+"-post-rejection", reservationSuccess); err != nil {
+			return checks, fmt.Errorf("reservation case %d rejected request mutated capacity: %w", caseIndex, err)
+		}
+		if err := reserve(isolation, adjacentDate, 1, label+"-hotel-isolation", reservationSuccess); err != nil {
+			return checks, fmt.Errorf("reservation case %d same-date hotel isolation: %w", caseIndex, err)
+		}
+	}
+	return checks, nil
+}
+
+func (a *Application) verifyCrashRecovery(
+	ctx context.Context,
+	c client,
+	seed int64,
+	random *rand.Rand,
+	restart func(context.Context) error,
+) (int, error) {
+	username, password := hotelsupport.MustUser(0)
+	rateIDs := sortedRateBackedIDs()
+	hotelID := rateIDs[random.Intn(len(rateIDs))]
+	numericID, _ := strconv.Atoi(hotelID)
+	capacity, err := hotelsupport.Capacity(numericID)
+	if err != nil {
+		return 0, err
+	}
+	start := reservationDate(seed).AddDate(0, 0, 730)
+	query := credentials(username, password)
+	query["hotelId"] = hotelID
+	query["inDate"] = start.Format(time.DateOnly)
+	query["outDate"] = start.AddDate(0, 0, 1).Format(time.DateOnly)
+	query["number"] = strconv.Itoa(capacity)
+	query["customerName"] = "crash-recovery"
+	if err := c.exactMessage(ctx, "/reservation", query, reservationSuccess); err != nil {
+		return 1, fmt.Errorf("crash recovery setup: %w", err)
+	}
+	if err := restart(ctx); err != nil {
+		return 1, fmt.Errorf("restart candidate for crash recovery: %w", err)
+	}
+	query["number"] = "1"
+	query["customerName"] = "crash-recovery-probe"
+	if err := c.exactMessage(ctx, "/reservation", query, reservationFailure); err != nil {
+		return 2, fmt.Errorf("acknowledged reservation lost after restart: %w", err)
+	}
+	anchor := a.catalog[hotelID]
+	features, err := c.geoJSON(ctx, "/hotels", map[string]string{
+		"inDate":  start.Format(time.DateOnly),
+		"outDate": start.AddDate(0, 0, 1).Format(time.DateOnly),
+		"lat":     strconv.FormatFloat(anchor.recommendLat, 'f', -1, 64),
+		"lon":     strconv.FormatFloat(anchor.recommendLon, 'f', -1, 64),
+		"locale":  "en",
+	})
+	if err != nil {
+		return 3, err
+	}
+	if _, present := features[hotelID]; present {
+		return 3, fmt.Errorf("filled hotel %s reappeared in search after restart", hotelID)
+	}
+	if err := validateProfiles(features, a.catalog, "post-restart search"); err != nil {
+		return 3, err
+	}
+	return 3, nil
+}
+
+func reservationDate(seed int64) time.Time {
+	digest := sha256.Sum256([]byte(fmt.Sprintf("hotel-reservation-accuracy/%d", seed)))
+	year := 3000 + int(binary.BigEndian.Uint16(digest[:2]))%5000
+	day := 1 + int(binary.BigEndian.Uint16(digest[2:4]))%300
+	return time.Date(year, time.January, day, 0, 0, 0, 0, time.UTC)
+}
+
+func credentials(username, password string) map[string]string {
+	return map[string]string{"username": username, "password": password}
+}
+
+func without(source map[string]string, key string) map[string]string {
+	result := cloneQuery(source)
+	delete(result, key)
+	return result
+}
+
+func with(source map[string]string, key, value string) map[string]string {
+	result := cloneQuery(source)
+	result[key] = value
+	return result
+}
+
+func cloneQuery(source map[string]string) map[string]string {
+	result := make(map[string]string, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}

--- a/examples/evaluators/microservice/apps/README.md
+++ b/examples/evaluators/microservice/apps/README.md
@@ -19,6 +19,11 @@ The Train Ticket adapter demonstrates dependent multi-invocation operations.
 It describes update/read and create/read/delete plans, while the engine retains
 exclusive ownership of issuing and measuring every HTTP request.
 
+The Hotel adapter preserves DeathStarBench's canonical mixed workload and
+validates application-level GeoJSON, authentication, and reservation-capacity
+semantics. Its reservation plan uses evaluator-owned future-date namespaces
+because the upstream API has no deletion operation.
+
 Accuracy adapters live separately under `accuracyapps/`. They may share the
 transport, canonical wire encoding, and application input grammar, but must not
 reuse a benchmark adapter's schemas or expected-value calculations. Shared

--- a/examples/evaluators/microservice/apps/hotel/README.md
+++ b/examples/evaluators/microservice/apps/hotel/README.md
@@ -1,0 +1,11 @@
+# Hotel benchmark adapter
+
+This package defines typed benchmark traffic for DeathStarBench's Hotel
+Reservation application. Search and recommendation responses are checked as
+strict GeoJSON against an independently encoded copy of the seeded profile and
+recommendation catalogs. Login responses require exact messages.
+
+`reserve_capacity` reserves the complete seeded capacity for a trial-unique
+future date, then verifies that one additional room is rejected. Reservation
+plans are serialized and workloads must use one repetition because the upstream
+application has no reservation deletion API.

--- a/examples/evaluators/microservice/apps/hotel/application.go
+++ b/examples/evaluators/microservice/apps/hotel/application.go
@@ -1,0 +1,113 @@
+// Package hotel implements the typed benchmark adapter for DeathStarBench's
+// Hotel Reservation application.
+package hotel
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"vibesys/microservice-evaluator/api"
+	hotelsupport "vibesys/microservice-evaluator/appsupport/hotel"
+)
+
+const (
+	operationSearch            = "search_hotels"
+	operationRecommendDistance = "recommend_distance"
+	operationRecommendRate     = "recommend_rate"
+	operationRecommendPrice    = "recommend_price"
+	operationLoginValid        = "login_valid"
+	operationLoginInvalid      = "login_invalid"
+	operationReserveCapacity   = "reserve_capacity"
+)
+
+var knownOperations = map[string]struct{}{
+	operationSearch:            {},
+	operationRecommendDistance: {},
+	operationRecommendRate:     {},
+	operationRecommendPrice:    {},
+	operationLoginValid:        {},
+	operationLoginInvalid:      {},
+	operationReserveCapacity:   {},
+}
+
+type Config = hotelsupport.Config
+
+type Application struct {
+	config Config
+	seed   int64
+
+	// A reservation plan holds this lock until FinishOperation. The service's
+	// capacity check and write are not transactional, so concurrent fill plans
+	// could both observe spare capacity and make the rejection oracle ambiguous.
+	reservationMu sync.Mutex
+}
+
+type fixture struct {
+	dateBase        time.Time
+	hotelOffset     uint64
+	nextReservation atomic.Uint64
+}
+
+const reservationDateBlockDays = 4096
+
+var _ api.Application = (*Application)(nil)
+var _ api.PreflightApplication = (*Application)(nil)
+
+func New(workload api.Workload) (api.Application, error) {
+	config, err := hotelsupport.ValidateTopology(workload)
+	if err != nil {
+		return nil, err
+	}
+	for _, operation := range workload.Operations {
+		if _, ok := knownOperations[operation.Name]; !ok {
+			return nil, fmt.Errorf("unknown Hotel operation %q", operation.Name)
+		}
+		if operation.Target != hotelsupport.GatewayTarget {
+			return nil, fmt.Errorf("Hotel operation %q must target %q", operation.Name, hotelsupport.GatewayTarget)
+		}
+		if operation.HTTP != nil {
+			return nil, fmt.Errorf("Hotel operation %q must not declare operations.http", operation.Name)
+		}
+	}
+	return &Application{config: config, seed: workload.Load.Seed}, nil
+}
+
+func (a *Application) Name() string { return "hotel" }
+
+func (a *Application) ReadinessProbes() []api.ReadinessProbe {
+	return hotelsupport.ReadinessProbes(a.seed)
+}
+
+func (a *Application) PreflightProbes() []api.ReadinessProbe {
+	return hotelsupport.PreflightProbes()
+}
+
+func (a *Application) Prepare(_ context.Context, _ api.Runtime, trial api.TrialContext) (any, error) {
+	// Reserve only future dates, both to avoid the seeded 2015 reservation and
+	// to namespace separate optimization trials without setup-only traffic. A
+	// digest selects an aligned block between years 3000 and 7000; alignment
+	// prevents partially overlapping namespaces.
+	digest := sha256.Sum256([]byte(fmt.Sprintf("%d/%d", trial.FixtureSeed, trial.Index)))
+	rangeStart := time.Date(3000, time.January, 1, 12, 0, 0, 0, time.UTC)
+	// Ten complete Gregorian 400-year cycles avoid time.Duration's roughly
+	// 290-year range limit while retaining exact calendar arithmetic.
+	const availableDays = 10 * 146097
+	blocks := uint64(availableDays / reservationDateBlockDays)
+	block := binary.BigEndian.Uint64(digest[:8]) % blocks
+	return &fixture{
+		dateBase:    rangeStart.AddDate(0, 0, int(block)*reservationDateBlockDays),
+		hotelOffset: binary.BigEndian.Uint64(digest[8:16]) % 80,
+	}, nil
+}
+
+func (a *Application) Reset(context.Context, api.Runtime, api.TrialContext) error {
+	// DeathStarBench exposes no reservation deletion API. The fixture therefore
+	// gives every trial a separate namespace and every scheduled sample
+	// receives a unique date within that trial.
+	return nil
+}

--- a/examples/evaluators/microservice/apps/hotel/hotel_test.go
+++ b/examples/evaluators/microservice/apps/hotel/hotel_test.go
@@ -1,0 +1,723 @@
+package hotel
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"vibesys/microservice-evaluator/api"
+	hotelsupport "vibesys/microservice-evaluator/appsupport/hotel"
+)
+
+func TestNewValidatesHotelContract(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*api.Workload)
+		want   string
+	}{
+		{"missing gateway", func(workload *api.Workload) { workload.Targets = nil }, "target named"},
+		{"wrong protocol", func(workload *api.Workload) { workload.Targets[0].Protocol = "grpc" }, "must use HTTP"},
+		{"non-reused session", func(workload *api.Workload) { workload.Targets[0].SessionPolicy = "new" }, "session_policy reuse"},
+		{"zero timeout", func(workload *api.Workload) { workload.Load.TimeoutSeconds = 0 }, "timeout must be positive"},
+		{"unknown config", func(workload *api.Workload) { workload.ApplicationConfig["rooms"] = int64(2) }, "unknown Hotel application_config"},
+		{"unknown operation", func(workload *api.Workload) { workload.Operations[0].Name = "search" }, "unknown Hotel operation"},
+		{"wrong target", func(workload *api.Workload) { workload.Operations[0].Target = "search" }, "must target"},
+		{"declarative request", func(workload *api.Workload) { workload.Operations[0].HTTP = &api.HTTPRequestSpec{} }, "must not declare"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workload := hotelWorkload(operationSearch)
+			test.mutate(&workload)
+			if _, err := New(workload); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("New() error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestApplicationExposesSharedPreflight(t *testing.T) {
+	applicationValue, err := New(hotelWorkload(operationLoginValid))
+	if err != nil {
+		t.Fatal(err)
+	}
+	preflight, ok := applicationValue.(api.PreflightApplication)
+	if !ok {
+		t.Fatal("Hotel benchmark does not implement api.PreflightApplication")
+	}
+	if len(preflight.ReadinessProbes()) != 3 || len(preflight.PreflightProbes()) != 2 {
+		t.Fatalf("unexpected shared preflight cardinality: readiness=%d protocol=%d",
+			len(preflight.ReadinessProbes()), len(preflight.PreflightProbes()))
+	}
+}
+
+func TestBuildOperationCreatesDeterministicCanonicalQueries(t *testing.T) {
+	tests := []struct {
+		operation string
+		path      string
+		require   string
+		steps     int
+	}{
+		{operationSearch, "/hotels", "", 1},
+		{operationRecommendDistance, "/recommendations", "dis", 1},
+		{operationRecommendRate, "/recommendations", "rate", 1},
+		{operationRecommendPrice, "/recommendations", "price", 1},
+		{operationLoginValid, "/user", "", 1},
+		{operationLoginInvalid, "/user", "", 1},
+		{operationReserveCapacity, "/reservation", "", 2},
+	}
+	for _, test := range tests {
+		t.Run(test.operation, func(t *testing.T) {
+			applicationValue, err := New(hotelWorkload(test.operation))
+			if err != nil {
+				t.Fatal(err)
+			}
+			application := applicationValue.(*Application)
+			prepared, err := application.Prepare(context.Background(), nil, api.TrialContext{Index: 2, FixtureSeed: 99})
+			if err != nil {
+				t.Fatal(err)
+			}
+			operation := api.Operation{Name: test.operation, Target: hotelsupport.GatewayTarget}
+			plan, err := application.BuildOperation(operation, api.Sample{Counter: 7, Random: 12345}, prepared)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer application.FinishOperation(plan)
+			if len(plan.Invocations) != test.steps {
+				t.Fatalf("invocations = %d, want %d", len(plan.Invocations), test.steps)
+			}
+			request := plan.Invocations[0].Payload.(api.HTTPRequestSpec)
+			if request.Method != http.MethodGet || request.Path != test.path || len(request.Form) != 0 || request.Body != "" {
+				t.Fatalf("unexpected canonical request: %+v", request)
+			}
+			if test.operation == operationSearch {
+				assertCanonicalSearchQuery(t, request.Query)
+			}
+			if test.require != "" {
+				assertCanonicalRecommendationQuery(t, request.Query, test.require)
+			}
+			if test.operation == operationLoginValid || test.operation == operationLoginInvalid {
+				username, password, userErr := hotelsupport.User(int(uint64(12345) % 501))
+				if userErr != nil {
+					t.Fatal(userErr)
+				}
+				if test.operation == operationLoginInvalid {
+					password += "-invalid"
+				}
+				if request.Query["username"] != username || request.Query["password"] != password {
+					t.Fatalf("login query = %v", request.Query)
+				}
+			}
+			if test.operation == operationReserveCapacity {
+				first := plan.Invocations[0].Payload.(api.HTTPRequestSpec)
+				second := plan.Invocations[1].Payload.(api.HTTPRequestSpec)
+				hotelID, _ := strconv.Atoi(first.Query["hotelId"])
+				capacity, _ := hotelsupport.Capacity(hotelID)
+				if first.Query["number"] != strconv.Itoa(capacity) || second.Query["number"] != "1" {
+					t.Fatalf("capacity sequence = %q then %q, capacity %d", first.Query["number"], second.Query["number"], capacity)
+				}
+				if first.Query["inDate"] != second.Query["inDate"] || first.Query["outDate"] != second.Query["outDate"] {
+					t.Fatalf("capacity steps use different dates: %v then %v", first.Query, second.Query)
+				}
+			}
+		})
+	}
+}
+
+func TestFuzzedCanonicalQueriesAreDeterministicAndVariable(t *testing.T) {
+	const sampleRandom = uint64(12345)
+	wantSearch := map[string]string{
+		"inDate": "2015-04-23", "outDate": "2015-04-24",
+		"lat": "38.1383", "lon": "-121.9387",
+	}
+	if got := searchRequest(sampleRandom).Query; !reflect.DeepEqual(got, wantSearch) {
+		t.Fatalf("search query for random word %d = %v, want %v", sampleRandom, got, wantSearch)
+	}
+	wantRecommendation := map[string]string{
+		"lat": "38.0020", "lon": "-121.9980", "require": "dis", "locale": "en",
+	}
+	first, _, _ := recommendationRequest(operationRecommendDistance, sampleRandom)
+	second, _, _ := recommendationRequest(operationRecommendDistance, sampleRandom)
+	if !reflect.DeepEqual(first.Query, wantRecommendation) || !reflect.DeepEqual(first, second) {
+		t.Fatalf("distance query is not deterministic: first=%v second=%v want=%v", first.Query, second.Query, wantRecommendation)
+	}
+
+	dates := make(map[string]struct{})
+	locations := make(map[string]struct{})
+	distanceWinners := make(map[string]struct{})
+	locales := make(map[bool]struct{})
+	for random := uint64(0); random < 4096; random++ {
+		search := searchRequest(random)
+		assertCanonicalSearchQuery(t, search.Query)
+		_, hasLocale := search.Query["locale"]
+		locales[hasLocale] = struct{}{}
+		dates[search.Query["inDate"]+"/"+search.Query["outDate"]] = struct{}{}
+		locations[search.Query["lat"]+"/"+search.Query["lon"]] = struct{}{}
+
+		recommendation, lat, lon := recommendationRequest(operationRecommendDistance, random)
+		assertCanonicalRecommendationQuery(t, recommendation.Query, "dis")
+		distanceWinners[strings.Join(nearestRecommendationIDs(lat, lon), ",")] = struct{}{}
+	}
+	if len(dates) < 50 || len(locations) < 3000 || len(distanceWinners) < 20 || len(locales) != 2 {
+		t.Fatalf("insufficient fuzz diversity: dates=%d locations=%d distance winners=%d locale forms=%d", len(dates), len(locations), len(distanceWinners), len(locales))
+	}
+}
+
+func TestDistanceRecommendationOracleCoversFullCatalog(t *testing.T) {
+	for number := 1; number <= 80; number++ {
+		id := strconv.Itoa(number)
+		item, err := profileForID(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := nearestRecommendationIDs(item.recommendLat, item.recommendLon); !reflect.DeepEqual(got, []string{id}) {
+			t.Fatalf("nearest hotel at catalog coordinate for %s = %v, want [%s]", id, got, id)
+		}
+	}
+
+	request, lat, lon := recommendationRequest(operationRecommendDistance, 12345)
+	expected := nearestRecommendationIDs(lat, lon)
+	wrong := "1"
+	if expected[0] == wrong {
+		wrong = "2"
+	}
+	state := &operationState{kind: operationRecommendDistance, expectedIDs: expected}
+	plan := api.OperationPlan{State: state, Invocations: []api.Invocation{{Payload: request}}}
+	application := &Application{}
+	result := httpJSONResult(geoJSON([]map[string]any{feature(wrong)}))
+	validation := application.ValidateOperation(
+		api.Operation{Name: operationRecommendDistance, Target: hotelsupport.GatewayTarget}, plan, []api.ProtocolResult{result},
+	)
+	if validation.Success || validation.ErrorCategory != "response_value" {
+		t.Fatalf("wrong distance winner unexpectedly passed: expected=%v wrong=%s validation=%+v", expected, wrong, validation)
+	}
+}
+
+func assertCanonicalSearchQuery(t *testing.T, query map[string]string) {
+	t.Helper()
+	if err := validateCanonicalSearchQuery(query); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validateCanonicalSearchQuery(query map[string]string) error {
+	locale, hasLocale := query["locale"]
+	if len(query) != 4 && len(query) != 5 || hasLocale && locale != "en" || len(query) == 5 && !hasLocale {
+		return fmt.Errorf("search query has non-canonical fields: %v", query)
+	}
+	inDate, err := time.Parse(time.DateOnly, query["inDate"])
+	if err != nil {
+		return fmt.Errorf("invalid search arrival %q: %w", query["inDate"], err)
+	}
+	outDate, err := time.Parse(time.DateOnly, query["outDate"])
+	if err != nil {
+		return fmt.Errorf("invalid search departure %q: %w", query["outDate"], err)
+	}
+	if inDate.Year() != 2015 || inDate.Month() != time.April ||
+		inDate.Day() < searchArrivalFirstDay || inDate.Day() > searchArrivalLastDay {
+		return fmt.Errorf("search arrival %s lies outside official range", inDate.Format(time.DateOnly))
+	}
+	if outDate.Year() != 2015 || outDate.Month() != time.April ||
+		outDate.Day() <= inDate.Day() || outDate.Day() > searchDepartureLastDay {
+		return fmt.Errorf("search departure %s is not after arrival or lies outside official range", outDate.Format(time.DateOnly))
+	}
+	lat, lon, err := parseCanonicalLocation(query)
+	if err != nil {
+		return err
+	}
+	for id := 20; id <= 60; id++ {
+		anchor, profileErr := profileForID(strconv.Itoa(id))
+		if profileErr != nil {
+			return profileErr
+		}
+		if math.Abs(lat-anchor.recommendLat) <= 0.0010000001 && math.Abs(lon-anchor.recommendLon) <= 0.0010000001 {
+			return nil
+		}
+	}
+	return fmt.Errorf("search location lat=%q lon=%q is not within the seeded anchor jitter window", query["lat"], query["lon"])
+}
+
+func assertCanonicalRecommendationQuery(t *testing.T, query map[string]string, require string) {
+	t.Helper()
+	if err := validateCanonicalRecommendationQuery(query, require); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validateCanonicalRecommendationQuery(query map[string]string, require string) error {
+	locale, hasLocale := query["locale"]
+	if len(query) != 3 && len(query) != 4 || hasLocale && locale != "en" || len(query) == 4 && !hasLocale || query["require"] != require {
+		return fmt.Errorf("recommendation query has non-canonical fields: %v", query)
+	}
+	lat, lon, err := parseCanonicalLocation(query)
+	if err != nil {
+		return err
+	}
+	latStep := math.Round((lat - 37.7830) * 1000)
+	lonStep := math.Round((lon - (-122.2520)) * 1000)
+	if math.Abs(lat-(37.7830+latStep/1000)) > 1e-9 || latStep < 0 || latStep >= latitudeChoices {
+		return fmt.Errorf("latitude %s lies outside official discrete range", query["lat"])
+	}
+	if math.Abs(lon-(-122.2520+lonStep/1000)) > 1e-9 || lonStep < 0 || lonStep >= longitudeChoices {
+		return fmt.Errorf("longitude %s lies outside official discrete range", query["lon"])
+	}
+	return nil
+}
+
+func parseCanonicalLocation(query map[string]string) (float64, float64, error) {
+	lat, latErr := strconv.ParseFloat(query["lat"], 64)
+	lon, lonErr := strconv.ParseFloat(query["lon"], 64)
+	if latErr != nil || lonErr != nil || formatCoordinate(lat) != query["lat"] || formatCoordinate(lon) != query["lon"] {
+		return 0, 0, fmt.Errorf("location is not canonical: lat=%q lon=%q", query["lat"], query["lon"])
+	}
+	if lat < 37.7830 || lat > 38.2640 {
+		return 0, 0, fmt.Errorf("latitude %s lies outside official range", query["lat"])
+	}
+	if lon < -122.2520 || lon > -121.9270 {
+		return 0, 0, fmt.Errorf("longitude %s lies outside official range", query["lon"])
+	}
+	return lat, lon, nil
+}
+
+func TestGeoJSONValidationIsStrictAndOrderInsensitive(t *testing.T) {
+	valid := []map[string]any{feature("3"), feature("1"), feature("2")}
+	if validation := validateGeoJSON(httpJSONResult(geoJSON(valid)), []string{"1", "2", "3"}); !validation.Success {
+		t.Fatalf("valid shuffled GeoJSON failed: %+v", validation)
+	}
+
+	tests := []struct {
+		name     string
+		features []map[string]any
+		want     string
+	}{
+		{"omitted ID", []map[string]any{feature("1"), feature("2")}, "response_value"},
+		{"duplicate ID", []map[string]any{feature("1"), feature("1"), feature("2")}, "response_value"},
+		{"wrong exact set", []map[string]any{feature("1"), feature("2"), feature("9")}, "response_value"},
+		{"unknown catalog ID", []map[string]any{feature("1"), feature("2"), rawFeature("81")}, "response_schema"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			validation := validateGeoJSON(httpJSONResult(geoJSON(test.features)), []string{"1", "2", "3"})
+			if validation.Success || validation.ErrorCategory != test.want {
+				t.Fatalf("adversarial GeoJSON unexpectedly passed: %+v", validation)
+			}
+		})
+	}
+
+	t.Run("extra root field", func(t *testing.T) {
+		body := geoJSON(valid)
+		body["status"] = "ok"
+		validation := validateGeoJSON(httpJSONResult(body), []string{"1", "2", "3"})
+		if validation.Success || validation.ErrorCategory != "response_schema" {
+			t.Fatalf("extra root field unexpectedly passed: %+v", validation)
+		}
+	})
+	t.Run("wrong catalog value", func(t *testing.T) {
+		corrupt := feature("1")
+		corrupt["properties"].(map[string]any)["phone_number"] = "(000) 000-0000"
+		validation := validateGeoJSON(httpJSONResult(geoJSON([]map[string]any{corrupt})), []string{"1"})
+		if validation.Success || validation.ErrorCategory != "response_schema" {
+			t.Fatalf("wrong catalog property unexpectedly passed: %+v", validation)
+		}
+	})
+	t.Run("wrong coordinate", func(t *testing.T) {
+		corrupt := feature("1")
+		corrupt["geometry"].(map[string]any)["coordinates"] = []float32{-122.0, 37.0}
+		validation := validateGeoJSON(httpJSONResult(geoJSON([]map[string]any{corrupt})), []string{"1"})
+		if validation.Success || validation.ErrorCategory != "response_schema" {
+			t.Fatalf("wrong coordinates unexpectedly passed: %+v", validation)
+		}
+	})
+	t.Run("extra feature field", func(t *testing.T) {
+		corrupt := feature("1")
+		corrupt["distance"] = 0
+		validation := validateGeoJSON(httpJSONResult(geoJSON([]map[string]any{corrupt})), []string{"1"})
+		if validation.Success || validation.ErrorCategory != "response_schema" {
+			t.Fatalf("extra feature field unexpectedly passed: %+v", validation)
+		}
+	})
+	t.Run("search requires exact complete rate-backed set", func(t *testing.T) {
+		ids := rateBackedHotelIDs()
+		features := make([]map[string]any, 0, len(ids))
+		for index := len(ids) - 1; index >= 0; index-- {
+			features = append(features, feature(ids[index]))
+		}
+		validation := validateGeoJSON(httpJSONResult(geoJSON(features)), ids)
+		if !validation.Success {
+			t.Fatalf("27-feature reference search response failed: %+v", validation)
+		}
+		for mutationIndex := range features {
+			mutated := append([]map[string]any(nil), features...)
+			mutated = append(mutated[:mutationIndex], mutated[mutationIndex+1:]...)
+			if validation := validateGeoJSON(httpJSONResult(geoJSON(mutated)), ids); validation.Success {
+				t.Fatalf("search response with rate-backed ID %q removed unexpectedly passed", ids[len(ids)-1-mutationIndex])
+			}
+		}
+	})
+}
+
+func TestMessageValidationRequiresExactSchemaAndText(t *testing.T) {
+	if validation := validateMessage(httpJSONResult(map[string]any{"message": loginSuccess}), loginSuccess); !validation.Success {
+		t.Fatalf("valid message failed: %+v", validation)
+	}
+	for _, body := range []any{
+		map[string]any{"message": loginSuccess + " "},
+		map[string]any{"message": loginSuccess, "ok": true},
+		map[string]any{"message": true},
+		[]any{loginSuccess},
+	} {
+		if validation := validateMessage(httpJSONResult(body), loginSuccess); validation.Success {
+			t.Fatalf("non-exact message body unexpectedly passed: %v", body)
+		}
+	}
+}
+
+func TestReservationPlansSerializeAndUseUniqueHotelDateSlots(t *testing.T) {
+	application := &Application{}
+	data := &fixture{dateBase: time.Date(2050, time.January, 1, 12, 0, 0, 0, time.UTC)}
+	operation := api.Operation{Name: operationReserveCapacity, Target: hotelsupport.GatewayTarget}
+	first, err := application.BuildOperation(operation, api.Sample{Counter: 1, Random: 1}, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type outcome struct {
+		plan api.OperationPlan
+		err  error
+	}
+	ready := make(chan outcome, 1)
+	go func() {
+		// Counter deliberately repeats, as it does at the warmup/measurement
+		// boundary. The fixture ordinal must still allocate a new hotel/date slot.
+		plan, buildErr := application.BuildOperation(operation, api.Sample{Counter: 1, Random: 1}, data)
+		ready <- outcome{plan: plan, err: buildErr}
+	}()
+	select {
+	case result := <-ready:
+		if result.err == nil {
+			application.FinishOperation(result.plan)
+		}
+		t.Fatal("conflicting reservation plan was not serialized")
+	case <-time.After(30 * time.Millisecond):
+	}
+	firstQuery := first.Invocations[0].Payload.(api.HTTPRequestSpec).Query
+	application.FinishOperation(first)
+	application.FinishOperation(first)
+	select {
+	case result := <-ready:
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		secondQuery := result.plan.Invocations[0].Payload.(api.HTTPRequestSpec).Query
+		application.FinishOperation(result.plan)
+		if firstQuery["inDate"] == secondQuery["inDate"] && firstQuery["hotelId"] == secondQuery["hotelId"] {
+			t.Fatalf("distinct sequence counters reused reservation slot hotel=%s date=%s", firstQuery["hotelId"], firstQuery["inDate"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("reservation plan did not acquire lock after FinishOperation")
+	}
+}
+
+func TestFixtureDateNamespaceIsDeterministicAndSeedDifferentiated(t *testing.T) {
+	application := &Application{}
+	firstValue, err := application.Prepare(context.Background(), nil, api.TrialContext{Index: 2, FixtureSeed: 99})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sameValue, err := application.Prepare(context.Background(), nil, api.TrialContext{Index: 2, FixtureSeed: 99})
+	if err != nil {
+		t.Fatal(err)
+	}
+	differentSeedValue, err := application.Prepare(context.Background(), nil, api.TrialContext{Index: 2, FixtureSeed: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	differentTrialValue, err := application.Prepare(context.Background(), nil, api.TrialContext{Index: 3, FixtureSeed: 99})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := firstValue.(*fixture).dateBase
+	if first.Year() < 3000 || first.Year() >= 7000 {
+		t.Fatalf("namespace date %s lies outside [3000, 7000)", first.Format(time.DateOnly))
+	}
+	if first != sameValue.(*fixture).dateBase {
+		t.Fatal("same trial context produced a different date namespace")
+	}
+	if first == differentSeedValue.(*fixture).dateBase || first == differentTrialValue.(*fixture).dateBase {
+		t.Fatalf("known distinct trial contexts collided at %s", first.Format(time.DateOnly))
+	}
+	days := daysBeforeYear(first.Year()) - daysBeforeYear(3000) + first.YearDay() - 1
+	if days%reservationDateBlockDays != 0 {
+		t.Fatalf("namespace date %s is not aligned to a %d-day block", first.Format(time.DateOnly), reservationDateBlockDays)
+	}
+}
+
+func daysBeforeYear(year int) int {
+	previous := year - 1
+	return previous*365 + previous/4 - previous/100 + previous/400
+}
+
+func TestAllOperationsAgainstHTTPFake(t *testing.T) {
+	operations := []string{
+		operationSearch, operationRecommendDistance, operationRecommendRate, operationRecommendPrice,
+		operationLoginValid, operationLoginInvalid, operationReserveCapacity,
+	}
+	workload := hotelWorkload(operations...)
+	applicationValue, err := New(workload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	application := applicationValue.(*Application)
+	prepared, err := application.Prepare(context.Background(), nil, api.TrialContext{Index: 3, FixtureSeed: 42})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := newFakeHotel(t)
+	runtime := &handlerRuntime{handler: target}
+	for index, name := range operations {
+		t.Run(name, func(t *testing.T) {
+			operation := api.Operation{Name: name, Target: hotelsupport.GatewayTarget}
+			plan, buildErr := application.BuildOperation(
+				operation, api.Sample{Counter: int64(index + 1), Random: uint64(9182 + index)}, prepared,
+			)
+			if buildErr != nil {
+				t.Fatal(buildErr)
+			}
+			defer application.FinishOperation(plan)
+			results := make([]api.ProtocolResult, len(plan.Invocations))
+			for resultIndex, invocation := range plan.Invocations {
+				results[resultIndex] = runtime.Invoke(context.Background(), invocation)
+			}
+			if validation := application.ValidateOperation(operation, plan, results); !validation.Success {
+				t.Fatalf("validation failed: %+v", validation)
+			}
+		})
+	}
+	if got, want := len(runtime.requests), len(operations)+1; got != want {
+		t.Fatalf("HTTP requests = %d, want %d (reservation has two steps)", got, want)
+	}
+}
+
+type fakeHotel struct {
+	t            *testing.T
+	mu           sync.Mutex
+	reservations map[string]int
+}
+
+func newFakeHotel(t *testing.T) http.Handler {
+	fake := &fakeHotel{t: t, reservations: make(map[string]int)}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hotels", fake.hotels)
+	mux.HandleFunc("/recommendations", fake.recommendations)
+	mux.HandleFunc("/user", fake.user)
+	mux.HandleFunc("/reservation", fake.reservation)
+	return mux
+}
+
+func (f *fakeHotel) hotels(writer http.ResponseWriter, request *http.Request) {
+	query := singleQuery(request.URL.Query())
+	if err := validateCanonicalSearchQuery(query); err != nil {
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+	ids := rateBackedHotelIDs()
+	features := make([]map[string]any, 0, len(ids))
+	for index := len(ids) - 1; index >= 0; index-- {
+		features = append(features, feature(ids[index]))
+	}
+	writeJSON(writer, geoJSON(features))
+}
+
+func (f *fakeHotel) recommendations(writer http.ResponseWriter, request *http.Request) {
+	require := request.URL.Query().Get("require")
+	operation := map[string]string{
+		"dis": operationRecommendDistance, "rate": operationRecommendRate, "price": operationRecommendPrice,
+	}[require]
+	if operation == "" {
+		http.Error(writer, "bad require", http.StatusBadRequest)
+		return
+	}
+	query := singleQuery(request.URL.Query())
+	if err := validateCanonicalRecommendationQuery(query, require); err != nil {
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+	ids := append([]string(nil), expectedRecommendationIDs[operation]...)
+	if operation == operationRecommendDistance {
+		lat, _ := strconv.ParseFloat(query["lat"], 64)
+		lon, _ := strconv.ParseFloat(query["lon"], 64)
+		ids = nearestRecommendationIDs(lat, lon)
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(ids)))
+	features := make([]map[string]any, 0, len(ids))
+	for _, id := range ids {
+		features = append(features, feature(id))
+	}
+	writeJSON(writer, geoJSON(features))
+}
+
+func (f *fakeHotel) user(writer http.ResponseWriter, request *http.Request) {
+	valid := validCredentials(request.URL.Query().Get("username"), request.URL.Query().Get("password"))
+	message := loginFailure
+	if valid {
+		message = loginSuccess
+	}
+	writeJSON(writer, map[string]any{"message": message})
+}
+
+func (f *fakeHotel) reservation(writer http.ResponseWriter, request *http.Request) {
+	query := request.URL.Query()
+	if !validCredentials(query.Get("username"), query.Get("password")) {
+		writeJSON(writer, map[string]any{"message": loginFailure})
+		return
+	}
+	hotelID, idErr := strconv.Atoi(query.Get("hotelId"))
+	number, numberErr := strconv.Atoi(query.Get("number"))
+	capacity, capacityErr := hotelsupport.Capacity(hotelID)
+	if idErr != nil || numberErr != nil || capacityErr != nil || query.Get("inDate") == "" || query.Get("outDate") == "" || query.Get("customerName") == "" {
+		http.Error(writer, "invalid reservation query", http.StatusBadRequest)
+		return
+	}
+	key := fmt.Sprintf("%d/%s/%s", hotelID, query.Get("inDate"), query.Get("outDate"))
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	message := reservationFailure
+	if f.reservations[key]+number <= capacity {
+		f.reservations[key] += number
+		message = reservationSuccess
+	}
+	writeJSON(writer, map[string]any{"message": message})
+}
+
+func validCredentials(username, password string) bool {
+	for index := 0; index <= 500; index++ {
+		wantUsername, wantPassword, err := hotelsupport.User(index)
+		if err != nil {
+			panic(err)
+		}
+		if username == wantUsername {
+			return password == wantPassword
+		}
+	}
+	return false
+}
+
+type handlerRuntime struct {
+	handler  http.Handler
+	requests []api.HTTPRequestSpec
+}
+
+func (r *handlerRuntime) Invoke(_ context.Context, invocation api.Invocation) api.ProtocolResult {
+	request, ok := invocation.Payload.(api.HTTPRequestSpec)
+	if !ok {
+		return api.ProtocolResult{ErrorCategory: "invalid_request", ErrorMessage: fmt.Sprintf("got %T", invocation.Payload)}
+	}
+	if invocation.Target != hotelsupport.GatewayTarget {
+		return api.ProtocolResult{ErrorCategory: "invalid_target", ErrorMessage: invocation.Target}
+	}
+	r.requests = append(r.requests, request)
+	requestURL := "http://hotel.test" + request.Path
+	if len(request.Query) != 0 {
+		query := make(url.Values, len(request.Query))
+		for key, value := range request.Query {
+			query.Set(key, value)
+		}
+		requestURL += "?" + query.Encode()
+	}
+	httpRequest := httptest.NewRequest(request.Method, requestURL, nil)
+	recorder := httptest.NewRecorder()
+	r.handler.ServeHTTP(recorder, httpRequest)
+	return api.ProtocolResult{
+		TransportSuccess: true,
+		NativeStatus:     recorder.Result().Status,
+		Payload: api.HTTPResponse{
+			StatusCode: recorder.Code,
+			Body:       append([]byte(nil), recorder.Body.Bytes()...),
+		},
+	}
+}
+
+func hotelWorkload(operations ...string) api.Workload {
+	values := make([]api.Operation, len(operations))
+	for index, name := range operations {
+		values[index] = api.Operation{Name: name, Target: hotelsupport.GatewayTarget}
+	}
+	return api.Workload{
+		Application: "hotel",
+		Load: api.Load{
+			TimeoutSeconds: 1, Repetitions: 1, Seed: 7,
+		},
+		Targets: []api.Target{{
+			Name: hotelsupport.GatewayTarget, Protocol: "http", Address: "http://hotel.test", SessionPolicy: "reuse",
+		}},
+		Operations:        values,
+		ApplicationConfig: map[string]any{},
+	}
+}
+
+func feature(id string) map[string]any {
+	item, err := profileForID(id)
+	if err != nil {
+		panic(err)
+	}
+	return map[string]any{
+		"type": "Feature",
+		"id":   item.id,
+		"properties": map[string]any{
+			"name": item.name, "phone_number": item.phoneNumber,
+		},
+		"geometry": map[string]any{
+			"type": "Point", "coordinates": []float32{item.lon, item.lat},
+		},
+	}
+}
+
+func rawFeature(id string) map[string]any {
+	return map[string]any{
+		"type": "Feature", "id": id,
+		"properties": map[string]any{"name": "unknown", "phone_number": "unknown"},
+		"geometry":   map[string]any{"type": "Point", "coordinates": []float32{0, 0}},
+	}
+}
+
+func geoJSON(features []map[string]any) map[string]any {
+	return map[string]any{"type": "FeatureCollection", "features": features}
+}
+
+func httpJSONResult(value any) api.ProtocolResult {
+	body, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return api.ProtocolResult{
+		TransportSuccess: true,
+		Payload:          api.HTTPResponse{StatusCode: http.StatusOK, Body: body},
+	}
+}
+
+func writeJSON(writer http.ResponseWriter, value any) {
+	writer.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(writer).Encode(value); err != nil {
+		panic(err)
+	}
+}
+
+func singleQuery(values url.Values) map[string]string {
+	result := make(map[string]string, len(values))
+	for key, entries := range values {
+		if len(entries) == 1 {
+			result[key] = entries[0]
+		}
+	}
+	return result
+}

--- a/examples/evaluators/microservice/apps/hotel/model.go
+++ b/examples/evaluators/microservice/apps/hotel/model.go
@@ -1,0 +1,58 @@
+package hotel
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type operationState struct {
+	kind        string
+	expectedIDs []string
+	release     func()
+}
+
+type profile struct {
+	id           string
+	name         string
+	phoneNumber  string
+	lat          float32
+	lon          float32
+	recommendLat float64
+	recommendLon float64
+}
+
+var fixedProfiles = map[string]profile{
+	"1": {id: "1", name: "Clift Hotel", phoneNumber: "(415) 775-4700", lat: 37.7867, lon: -122.4112, recommendLat: 37.7867, recommendLon: -122.4112},
+	"2": {id: "2", name: "W San Francisco", phoneNumber: "(415) 777-5300", lat: 37.7854, lon: -122.4005, recommendLat: 37.7854, recommendLon: -122.4005},
+	"3": {id: "3", name: "Hotel Zetta", phoneNumber: "(415) 543-8555", lat: 37.7834, lon: -122.4071, recommendLat: 37.7834, recommendLon: -122.4071},
+	"4": {id: "4", name: "Hotel Vitale", phoneNumber: "(415) 278-3700", lat: 37.7936, lon: -122.3930, recommendLat: 37.7936, recommendLon: -122.3930},
+	"5": {id: "5", name: "Phoenix Hotel", phoneNumber: "(415) 776-1380", lat: 37.7831, lon: -122.4181, recommendLat: 37.7831, recommendLon: -122.4181},
+	"6": {id: "6", name: "St. Regis San Francisco", phoneNumber: "(415) 284-4000", lat: 37.7863, lon: -122.4015, recommendLat: 37.7863, recommendLon: -122.4015},
+}
+
+func profileForID(id string) (profile, error) {
+	if item, ok := fixedProfiles[id]; ok {
+		return item, nil
+	}
+	number, err := strconv.Atoi(id)
+	if err != nil || number < 7 || number > 80 || strconv.Itoa(number) != id {
+		return profile{}, fmt.Errorf("unknown Hotel profile ID %q", id)
+	}
+	return profile{
+		id:           id,
+		name:         "St. Regis San Francisco",
+		phoneNumber:  "(415) 284-40" + id,
+		lat:          37.7835 + float32(number)/500.0*3,
+		lon:          -122.41 + float32(number)/500.0*4,
+		recommendLat: 37.7835 + float64(number)/500.0*3,
+		recommendLon: -122.41 + float64(number)/500.0*4,
+	}, nil
+}
+
+func rateBackedHotelIDs() []string {
+	ids := []string{"1", "2", "3"}
+	for id := 9; id <= 78; id += 3 {
+		ids = append(ids, strconv.Itoa(id))
+	}
+	return ids
+}

--- a/examples/evaluators/microservice/apps/hotel/operations.go
+++ b/examples/evaluators/microservice/apps/hotel/operations.go
@@ -1,0 +1,275 @@
+package hotel
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	"vibesys/microservice-evaluator/api"
+	hotelsupport "vibesys/microservice-evaluator/appsupport/hotel"
+)
+
+const (
+	searchArrivalFirstDay  = 9
+	searchArrivalLastDay   = 23
+	searchDepartureLastDay = 24
+	latitudeChoices        = 482
+	longitudeChoices       = 326
+)
+
+var expectedRecommendationIDs = map[string][]string{
+	operationRecommendRate:  {"9", "24", "39", "54", "69"},
+	operationRecommendPrice: {"2"},
+}
+
+func (a *Application) BuildOperation(
+	operation api.Operation,
+	sample api.Sample,
+	prepared any,
+) (api.OperationPlan, error) {
+	data, ok := prepared.(*fixture)
+	if !ok || data == nil {
+		return api.OperationPlan{}, fmt.Errorf("Hotel fixture is not prepared")
+	}
+	switch operation.Name {
+	case operationSearch:
+		return oneRequestPlan(operation, searchRequest(sample.Random), rateBackedHotelIDs()), nil
+	case operationRecommendDistance, operationRecommendRate, operationRecommendPrice:
+		request, lat, lon := recommendationRequest(operation.Name, sample.Random)
+		expectedIDs := expectedRecommendationIDs[operation.Name]
+		if operation.Name == operationRecommendDistance {
+			expectedIDs = nearestRecommendationIDs(lat, lon)
+		}
+		return oneRequestPlan(
+			operation,
+			request,
+			expectedIDs,
+		), nil
+	case operationLoginValid, operationLoginInvalid:
+		return a.loginPlan(operation, sample)
+	case operationReserveCapacity:
+		return a.reservationPlan(operation, sample, data)
+	default:
+		return api.OperationPlan{}, fmt.Errorf("unknown Hotel operation %q", operation.Name)
+	}
+}
+
+func oneRequestPlan(
+	operation api.Operation,
+	request api.HTTPRequestSpec,
+	expectedIDs []string,
+) api.OperationPlan {
+	return api.OperationPlan{
+		Invocations: []api.Invocation{{
+			Target: operation.Target, Operation: operation.Name, Payload: request,
+		}},
+		State: &operationState{
+			kind: operation.Name, expectedIDs: append([]string(nil), expectedIDs...),
+		},
+	}
+}
+
+func searchRequest(random uint64) api.HTTPRequestSpec {
+	inDay := searchArrivalFirstDay + fuzzChoice(random, 0, searchArrivalLastDay-searchArrivalFirstDay+1)
+	outDay := inDay + 1 + fuzzChoice(random, 1, searchDepartureLastDay-inDay)
+	lat, lon := canonicalSearchLocation(random)
+	query := map[string]string{
+		"inDate":  fmt.Sprintf("2015-04-%02d", inDay),
+		"outDate": fmt.Sprintf("2015-04-%02d", outDay),
+		"lat":     formatCoordinate(lat), "lon": formatCoordinate(lon),
+	}
+	if fuzzChoice(random, 5, 2) == 1 {
+		query["locale"] = "en"
+	}
+	return api.HTTPRequestSpec{
+		Method: http.MethodGet,
+		Path:   "/hotels",
+		Query:  query,
+	}
+}
+
+func recommendationRequest(operation string, random uint64) (api.HTTPRequestSpec, float64, float64) {
+	require := map[string]string{
+		operationRecommendDistance: "dis",
+		operationRecommendRate:     "rate",
+		operationRecommendPrice:    "price",
+	}[operation]
+	lat, lon := canonicalRecommendationLocation(random)
+	latText, lonText := formatCoordinate(lat), formatCoordinate(lon)
+	// Calculate the oracle from the values the frontend will parse, not from
+	// pre-format floating-point intermediates that are not sent on the wire.
+	lat = mustParseCoordinate(latText)
+	lon = mustParseCoordinate(lonText)
+	query := map[string]string{
+		"lat": latText, "lon": lonText, "require": require,
+	}
+	if fuzzChoice(random, 4, 2) == 1 {
+		query["locale"] = "en"
+	}
+	return api.HTTPRequestSpec{
+		Method: http.MethodGet,
+		Path:   "/recommendations",
+		Query:  query,
+	}, lat, lon
+}
+
+func canonicalSearchLocation(random uint64) (float64, float64) {
+	// Anchoring the search around a seeded hotel guarantees a geo hit while the
+	// jitter prevents candidates from recognizing a small list of exact inputs.
+	// IDs 20 through 60 keep the entire jitter window inside the official wrk2
+	// coordinate rectangle.
+	anchorID := 20 + fuzzChoice(random, 2, 41)
+	anchor, err := profileForID(strconv.Itoa(anchorID))
+	if err != nil {
+		panic(err)
+	}
+	latJitter := float64(fuzzChoice(random, 3, 21)-10) / 10000
+	lonJitter := float64(fuzzChoice(random, 4, 21)-10) / 10000
+	return anchor.recommendLat + latJitter, anchor.recommendLon + lonJitter
+}
+
+func canonicalRecommendationLocation(random uint64) (float64, float64) {
+	latitudeStep := fuzzChoice(random, 2, latitudeChoices)
+	longitudeStep := fuzzChoice(random, 3, longitudeChoices)
+	lat := 38.0235 + (float64(latitudeStep)-240.5)/1000.0
+	lon := -122.095 + (float64(longitudeStep)-157.0)/1000.0
+	return lat, lon
+}
+
+func fuzzChoice(random, stream uint64, choices int) int {
+	value := random + 0x9e3779b97f4a7c15*(stream+1)
+	value = (value ^ (value >> 30)) * 0xbf58476d1ce4e5b9
+	value = (value ^ (value >> 27)) * 0x94d049bb133111eb
+	value ^= value >> 31
+	return int(value % uint64(choices))
+}
+
+func formatCoordinate(value float64) string {
+	return strconv.FormatFloat(value, 'f', 4, 64)
+}
+
+func mustParseCoordinate(value string) float64 {
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}
+
+func nearestRecommendationIDs(lat, lon float64) []string {
+	minimum := math.MaxFloat64
+	ids := make([]string, 0, 1)
+	for number := 1; number <= 80; number++ {
+		item, err := profileForID(strconv.Itoa(number))
+		if err != nil {
+			panic(err)
+		}
+		distance := recommendationDistance(lat, lon, item.recommendLat, item.recommendLon)
+		switch {
+		case distance < minimum:
+			minimum = distance
+			ids = append(ids[:0], item.id)
+		case distance == minimum:
+			ids = append(ids, item.id)
+		}
+	}
+	return ids
+}
+
+func recommendationDistance(lat1, lon1, lat2, lon2 float64) float64 {
+	toRadians := func(value float64) float64 { return value * math.Pi / 180 }
+	dLat := toRadians(lat2 - lat1)
+	dLon := toRadians(lon2 - lon1)
+	sinLat := math.Sin(dLat / 2)
+	sinLon := math.Sin(dLon / 2)
+	a := math.Pow(sinLat, 2) + math.Pow(sinLon, 2)*math.Cos(toRadians(lat1))*math.Cos(toRadians(lat2))
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	return 6371.0 * c / 1000.0
+}
+
+func (a *Application) loginPlan(operation api.Operation, sample api.Sample) (api.OperationPlan, error) {
+	username, password, err := hotelsupport.User(int(sample.Random % 501))
+	if err != nil {
+		return api.OperationPlan{}, err
+	}
+	if operation.Name == operationLoginInvalid {
+		password += "-invalid"
+	}
+	return oneRequestPlan(operation, api.HTTPRequestSpec{
+		Method: http.MethodGet,
+		Path:   "/user",
+		Query:  map[string]string{"username": username, "password": password},
+	}, nil), nil
+}
+
+func (a *Application) reservationPlan(
+	operation api.Operation,
+	sample api.Sample,
+	data *fixture,
+) (api.OperationPlan, error) {
+	if sample.Counter < 0 {
+		return api.OperationPlan{}, fmt.Errorf("Hotel sample counter must be non-negative")
+	}
+	a.reservationMu.Lock()
+	release := func() { a.reservationMu.Unlock() }
+
+	// Sample.Counter restarts between warmup and measurement. The fixture-owned
+	// ordinal persists across both phases. Pair each date with every hotel before
+	// advancing to the next date, expanding the collision-free namespace without
+	// consuming additional calendar range.
+	ordinal := data.nextReservation.Add(1) - 1
+	const reservationSlots = reservationDateBlockDays * 80
+	if ordinal >= reservationSlots {
+		release()
+		return api.OperationPlan{}, fmt.Errorf(
+			"Hotel trial exceeded its %d unique hotel/date reservation slots",
+			reservationSlots,
+		)
+	}
+	// The fixture-derived rotation changes the hotel-to-ordinal mapping between
+	// independent trials even in the unlikely event that date blocks collide.
+	hotelID := 1 + int((ordinal+data.hotelOffset)%80)
+	capacity, err := hotelsupport.Capacity(hotelID)
+	if err != nil {
+		release()
+		return api.OperationPlan{}, err
+	}
+	username, password, err := hotelsupport.User(int((sample.Random >> 9) % 501))
+	if err != nil {
+		release()
+		return api.OperationPlan{}, err
+	}
+	inDate := data.dateBase.AddDate(0, 0, int(ordinal/80))
+	outDate := inDate.AddDate(0, 0, 1)
+	baseQuery := map[string]string{
+		"inDate": inDate.Format(time.DateOnly), "outDate": outDate.Format(time.DateOnly),
+		"hotelId":      strconv.Itoa(hotelID),
+		"customerName": fmt.Sprintf("vibesys-%016x-%d", sample.Random, sample.Counter),
+		"username":     username, "password": password,
+	}
+	request := func(number int) api.HTTPRequestSpec {
+		query := make(map[string]string, len(baseQuery)+1)
+		for key, value := range baseQuery {
+			query[key] = value
+		}
+		query["number"] = strconv.Itoa(number)
+		return api.HTTPRequestSpec{Method: http.MethodGet, Path: "/reservation", Query: query}
+	}
+	return api.OperationPlan{
+		Invocations: []api.Invocation{
+			{Target: operation.Target, Operation: operation.Name, Payload: request(capacity)},
+			{Target: operation.Target, Operation: operation.Name, Payload: request(1)},
+		},
+		State: &operationState{kind: operation.Name, release: release},
+	}, nil
+}
+
+func (a *Application) FinishOperation(plan api.OperationPlan) {
+	state, ok := plan.State.(*operationState)
+	if ok && state != nil && state.release != nil {
+		state.release()
+		state.release = nil
+	}
+}

--- a/examples/evaluators/microservice/apps/hotel/validation.go
+++ b/examples/evaluators/microservice/apps/hotel/validation.go
@@ -1,0 +1,230 @@
+package hotel
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"reflect"
+	"sort"
+	"strconv"
+
+	"vibesys/microservice-evaluator/api"
+)
+
+const (
+	loginSuccess       = "Login successfully!"
+	loginFailure       = "Failed. Please check your username and password. "
+	reservationSuccess = "Reserve successfully!"
+	reservationFailure = "Failed. Already reserved. "
+)
+
+func (a *Application) ValidateOperation(
+	operation api.Operation,
+	plan api.OperationPlan,
+	results []api.ProtocolResult,
+) api.ValidationResult {
+	state, ok := plan.State.(*operationState)
+	if !ok || state == nil {
+		return invalid("invalid_plan", fmt.Sprintf("unexpected Hotel plan state %T", plan.State))
+	}
+	if state.kind != operation.Name {
+		return invalid("invalid_plan", fmt.Sprintf("plan kind %q does not match operation %q", state.kind, operation.Name))
+	}
+	wantResults := 1
+	if operation.Name == operationReserveCapacity {
+		wantResults = 2
+	}
+	if len(results) != wantResults {
+		return invalid("result_count", fmt.Sprintf("got %d protocol results, want %d", len(results), wantResults))
+	}
+
+	switch operation.Name {
+	case operationSearch, operationRecommendDistance, operationRecommendRate, operationRecommendPrice:
+		return validateGeoJSON(results[0], state.expectedIDs)
+	case operationLoginValid:
+		return validateMessage(results[0], loginSuccess)
+	case operationLoginInvalid:
+		return validateMessage(results[0], loginFailure)
+	case operationReserveCapacity:
+		if validation := validateMessage(results[0], reservationSuccess); !validation.Success {
+			validation.ErrorMessage = "capacity-fill step: " + validation.ErrorMessage
+			return validation
+		}
+		validation := validateMessage(results[1], reservationFailure)
+		if !validation.Success {
+			validation.ErrorMessage = "over-capacity rejection step: " + validation.ErrorMessage
+		}
+		return validation
+	default:
+		return invalid("invalid_plan", fmt.Sprintf("unknown Hotel operation %q", operation.Name))
+	}
+}
+
+func validateMessage(result api.ProtocolResult, expected string) api.ValidationResult {
+	value, validation := decodeHTTPJSON(result)
+	if !validation.Success {
+		return validation
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return invalid("response_schema", fmt.Sprintf("message response must be an object, got %T", value))
+	}
+	if keys := sortedKeys(object); !reflect.DeepEqual(keys, []string{"message"}) {
+		return invalid("response_schema", fmt.Sprintf("message response fields %v, want [message]", keys))
+	}
+	message, ok := object["message"].(string)
+	if !ok {
+		return invalid("response_schema", "message must be a string")
+	}
+	if message != expected {
+		return invalid("response_value", fmt.Sprintf("message = %q, want %q", message, expected))
+	}
+	return api.ValidationResult{Success: true}
+}
+
+func validateGeoJSON(
+	result api.ProtocolResult,
+	expectedIDs []string,
+) api.ValidationResult {
+	value, validation := decodeHTTPJSON(result)
+	if !validation.Success {
+		return validation
+	}
+	root, ok := value.(map[string]any)
+	if !ok {
+		return invalid("response_schema", fmt.Sprintf("GeoJSON root must be an object, got %T", value))
+	}
+	if keys := sortedKeys(root); !reflect.DeepEqual(keys, []string{"features", "type"}) {
+		return invalid("response_schema", fmt.Sprintf("GeoJSON root fields %v, want [features type]", keys))
+	}
+	if root["type"] != "FeatureCollection" {
+		return invalid("response_schema", fmt.Sprintf("GeoJSON type = %v, want FeatureCollection", root["type"]))
+	}
+	features, ok := root["features"].([]any)
+	if !ok {
+		return invalid("response_schema", "GeoJSON features must be an array")
+	}
+	if len(features) != len(expectedIDs) {
+		return invalid(
+			"response_value",
+			fmt.Sprintf("GeoJSON has %d features, want exactly %d", len(features), len(expectedIDs)),
+		)
+	}
+	seen := make(map[string]struct{}, len(features))
+	actualIDs := make([]string, 0, len(features))
+	for index, raw := range features {
+		id, err := validateFeature(raw)
+		if err != nil {
+			return invalid("response_schema", fmt.Sprintf("feature %d: %v", index, err))
+		}
+		if _, duplicate := seen[id]; duplicate {
+			return invalid("response_value", fmt.Sprintf("GeoJSON contains duplicate hotel ID %q", id))
+		}
+		seen[id] = struct{}{}
+		actualIDs = append(actualIDs, id)
+	}
+	sort.Strings(actualIDs)
+	want := append([]string(nil), expectedIDs...)
+	sort.Strings(want)
+	if !reflect.DeepEqual(actualIDs, want) {
+		return invalid("response_value", fmt.Sprintf("hotel IDs %v, want exact set %v", actualIDs, want))
+	}
+	return api.ValidationResult{Success: true}
+}
+
+func validateFeature(raw any) (string, error) {
+	feature, ok := raw.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("must be an object, got %T", raw)
+	}
+	if keys := sortedKeys(feature); !reflect.DeepEqual(keys, []string{"geometry", "id", "properties", "type"}) {
+		return "", fmt.Errorf("fields %v, want [geometry id properties type]", keys)
+	}
+	if feature["type"] != "Feature" {
+		return "", fmt.Errorf("type = %v, want Feature", feature["type"])
+	}
+	id, ok := feature["id"].(string)
+	if !ok {
+		return "", fmt.Errorf("id must be a string")
+	}
+	expected, err := profileForID(id)
+	if err != nil {
+		return "", err
+	}
+	properties, ok := feature["properties"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("properties must be an object")
+	}
+	if keys := sortedKeys(properties); !reflect.DeepEqual(keys, []string{"name", "phone_number"}) {
+		return "", fmt.Errorf("property fields %v, want [name phone_number]", keys)
+	}
+	if properties["name"] != expected.name || properties["phone_number"] != expected.phoneNumber {
+		return "", fmt.Errorf("properties %v do not match catalog for hotel %s", properties, id)
+	}
+	geometry, ok := feature["geometry"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("geometry must be an object")
+	}
+	if keys := sortedKeys(geometry); !reflect.DeepEqual(keys, []string{"coordinates", "type"}) {
+		return "", fmt.Errorf("geometry fields %v, want [coordinates type]", keys)
+	}
+	if geometry["type"] != "Point" {
+		return "", fmt.Errorf("geometry type = %v, want Point", geometry["type"])
+	}
+	coordinates, ok := geometry["coordinates"].([]any)
+	if !ok || len(coordinates) != 2 {
+		return "", fmt.Errorf("coordinates must be a two-element array")
+	}
+	lon, lonOK := coordinates[0].(float64)
+	lat, latOK := coordinates[1].(float64)
+	if !lonOK || !latOK || math.IsNaN(lon) || math.IsInf(lon, 0) || math.IsNaN(lat) || math.IsInf(lat, 0) {
+		return "", fmt.Errorf("coordinates must contain finite numbers")
+	}
+	wantLon := encodedFloat32(expected.lon)
+	wantLat := encodedFloat32(expected.lat)
+	if lon != wantLon || lat != wantLat {
+		return "", fmt.Errorf("coordinates [%v %v], want catalog [%v %v]", lon, lat, wantLon, wantLat)
+	}
+	return id, nil
+}
+
+func encodedFloat32(value float32) float64 {
+	encoded := strconv.FormatFloat(float64(value), 'g', -1, 32)
+	parsed, err := strconv.ParseFloat(encoded, 64)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}
+
+func decodeHTTPJSON(result api.ProtocolResult) (any, api.ValidationResult) {
+	if !result.TransportSuccess {
+		return nil, invalid(result.ErrorCategory, result.ErrorMessage)
+	}
+	response, ok := result.Payload.(api.HTTPResponse)
+	if !ok {
+		return nil, invalid("invalid_response", fmt.Sprintf("expected HTTP response, got %T", result.Payload))
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, invalid("http_status", fmt.Sprintf("HTTP %d, want %d", response.StatusCode, http.StatusOK))
+	}
+	var value any
+	if err := json.Unmarshal(response.Body, &value); err != nil {
+		return nil, invalid("response_json", err.Error())
+	}
+	return value, api.ValidationResult{Success: true}
+}
+
+func sortedKeys(object map[string]any) []string {
+	keys := make([]string, 0, len(object))
+	for key := range object {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func invalid(category, message string) api.ValidationResult {
+	return api.ValidationResult{ErrorCategory: category, ErrorMessage: message}
+}

--- a/examples/evaluators/microservice/appsupport/hotel/config.go
+++ b/examples/evaluators/microservice/appsupport/hotel/config.go
@@ -1,0 +1,45 @@
+// Package hotel owns topology, seed-input, and preflight contracts shared by
+// the independent Hotel benchmark and accuracy adapters.
+package hotel
+
+import (
+	"fmt"
+	"time"
+
+	"vibesys/microservice-evaluator/api"
+)
+
+const GatewayTarget = "gateway"
+
+type Config struct {
+	Timeout time.Duration
+}
+
+// ValidateTopology keeps mode-neutral workload requirements identical in
+// benchmark and accuracy mode. Semantic response oracles intentionally live in
+// the mode-specific packages.
+func ValidateTopology(workload api.Workload) (Config, error) {
+	for key := range workload.ApplicationConfig {
+		return Config{}, fmt.Errorf("unknown Hotel application_config field %q", key)
+	}
+	targetFound := false
+	for _, target := range workload.Targets {
+		if target.Name != GatewayTarget {
+			continue
+		}
+		targetFound = true
+		if target.Protocol != "http" {
+			return Config{}, fmt.Errorf("Hotel gateway target must use HTTP, got %q", target.Protocol)
+		}
+		if target.SessionPolicy != "reuse" {
+			return Config{}, fmt.Errorf("Hotel gateway target must use session_policy reuse")
+		}
+	}
+	if !targetFound {
+		return Config{}, fmt.Errorf("Hotel requires a target named %q", GatewayTarget)
+	}
+	if workload.Load.TimeoutSeconds <= 0 {
+		return Config{}, fmt.Errorf("Hotel timeout must be positive")
+	}
+	return Config{Timeout: time.Duration(workload.Load.TimeoutSeconds * float64(time.Second))}, nil
+}

--- a/examples/evaluators/microservice/appsupport/hotel/config_test.go
+++ b/examples/evaluators/microservice/appsupport/hotel/config_test.go
@@ -1,0 +1,64 @@
+package hotel
+
+import (
+	"reflect"
+	"testing"
+
+	"vibesys/microservice-evaluator/api"
+)
+
+func TestSeedInputs(t *testing.T) {
+	username, password, err := User(12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if username != "Cornell_3132" || password != "12121212121212121212" {
+		t.Fatalf("seed user = (%q, %q)", username, password)
+	}
+	capacities := map[int]int{1: 200, 7: 300, 8: 250, 9: 200, 80: 250}
+	for id, want := range capacities {
+		got, err := Capacity(id)
+		if err != nil || got != want {
+			t.Fatalf("Capacity(%d) = %d, %v; want %d", id, got, err, want)
+		}
+	}
+}
+
+func TestValidateTopology(t *testing.T) {
+	workload := api.Workload{
+		Load:    api.Load{TimeoutSeconds: 2},
+		Targets: []api.Target{{Name: GatewayTarget, Protocol: "http", SessionPolicy: "reuse"}},
+	}
+	if _, err := ValidateTopology(workload); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*api.Workload)
+	}{
+		{"missing", func(w *api.Workload) { w.Targets = nil }},
+		{"protocol", func(w *api.Workload) { w.Targets[0].Protocol = "grpc" }},
+		{"session", func(w *api.Workload) { w.Targets[0].SessionPolicy = "new_per_request" }},
+		{"unknown config", func(w *api.Workload) { w.ApplicationConfig = map[string]any{"x": int64(1)} }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := workload
+			candidate.Targets = append([]api.Target(nil), workload.Targets...)
+			test.mutate(&candidate)
+			if _, err := ValidateTopology(candidate); err == nil {
+				t.Fatal("malformed topology was accepted")
+			}
+		})
+	}
+}
+
+func TestPreflightIsDeterministic(t *testing.T) {
+	left := PreflightProbes()
+	right := PreflightProbes()
+	for index := range left {
+		if left[index].Name != right[index].Name || !reflect.DeepEqual(left[index].Invocation, right[index].Invocation) {
+			t.Fatalf("probe %d differs", index)
+		}
+	}
+}

--- a/examples/evaluators/microservice/appsupport/hotel/cross_mode_test.go
+++ b/examples/evaluators/microservice/appsupport/hotel/cross_mode_test.go
@@ -1,0 +1,60 @@
+package hotel_test
+
+import (
+	"reflect"
+	"testing"
+
+	accuracyhotel "vibesys/microservice-evaluator/accuracyapps/hotel"
+	"vibesys/microservice-evaluator/api"
+	benchmarkhotel "vibesys/microservice-evaluator/apps/hotel"
+	"vibesys/microservice-evaluator/appsupport/hotel"
+)
+
+func workload() api.Workload {
+	return api.Workload{
+		Load: api.Load{TimeoutSeconds: 1, Repetitions: 1, Seed: 73},
+		Targets: []api.Target{{
+			Name: hotel.GatewayTarget, Protocol: "http", SessionPolicy: "reuse",
+		}},
+		Operations: []api.Operation{{
+			Name: "search_hotels", Target: hotel.GatewayTarget,
+		}},
+	}
+}
+
+func TestBenchmarkAndAccuracyRejectSameMalformedSharedConfig(t *testing.T) {
+	candidate := workload()
+	candidate.ApplicationConfig = map[string]any{"unknown": int64(1)}
+	if _, err := benchmarkhotel.New(candidate); err == nil {
+		t.Fatal("benchmark accepted malformed shared config")
+	}
+	if _, err := accuracyhotel.New(candidate); err == nil {
+		t.Fatal("accuracy accepted malformed shared config")
+	}
+}
+
+func TestBenchmarkAndAccuracyUseIdenticalPreflightPlans(t *testing.T) {
+	benchmark, err := benchmarkhotel.New(workload())
+	if err != nil {
+		t.Fatal(err)
+	}
+	accuracy, err := accuracyhotel.New(workload())
+	if err != nil {
+		t.Fatal(err)
+	}
+	benchmarkPreflight := benchmark.(api.PreflightApplication)
+	assertInvocationsEqual(t, benchmarkPreflight.ReadinessProbes(), accuracy.ReadinessProbes())
+	assertInvocationsEqual(t, benchmarkPreflight.PreflightProbes(), accuracy.PreflightProbes())
+}
+
+func assertInvocationsEqual(t *testing.T, left, right []api.ReadinessProbe) {
+	t.Helper()
+	if len(left) != len(right) {
+		t.Fatalf("probe lengths differ: %d != %d", len(left), len(right))
+	}
+	for index := range left {
+		if left[index].Name != right[index].Name || !reflect.DeepEqual(left[index].Invocation, right[index].Invocation) {
+			t.Fatalf("probe %d differs: %+v != %+v", index, left[index], right[index])
+		}
+	}
+}

--- a/examples/evaluators/microservice/appsupport/hotel/fixtures.go
+++ b/examples/evaluators/microservice/appsupport/hotel/fixtures.go
@@ -1,0 +1,41 @@
+package hotel
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// User reproduces the current DeathStarBench seed grammar. The hexadecimal
+// username is intentional: cmd/user/db.go applies %x to the decimal suffix's
+// bytes, so account zero is Cornell_30 rather than Cornell_0.
+func User(index int) (username string, password string, err error) {
+	if index < 0 || index > 500 {
+		return "", "", fmt.Errorf("Hotel seed user index must be in [0, 500], got %d", index)
+	}
+	suffix := strconv.Itoa(index)
+	return "Cornell_" + hex.EncodeToString([]byte(suffix)), strings.Repeat(suffix, 10), nil
+}
+
+func MustUser(index int) (string, string) {
+	username, password, err := User(index)
+	if err != nil {
+		panic(err)
+	}
+	return username, password
+}
+
+// Capacity returns the immutable seeded room capacity for one hotel.
+func Capacity(hotelID int) (int, error) {
+	if hotelID < 1 || hotelID > 80 {
+		return 0, fmt.Errorf("Hotel seed hotel ID must be in [1, 80], got %d", hotelID)
+	}
+	if hotelID <= 6 || hotelID%3 == 0 {
+		return 200, nil
+	}
+	if hotelID%3 == 1 {
+		return 300, nil
+	}
+	return 250, nil
+}

--- a/examples/evaluators/microservice/appsupport/hotel/preflight.go
+++ b/examples/evaluators/microservice/appsupport/hotel/preflight.go
@@ -1,0 +1,107 @@
+package hotel
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+
+	"vibesys/microservice-evaluator/accuracy/httpcheck"
+	"vibesys/microservice-evaluator/api"
+	"vibesys/microservice-evaluator/wire/httpjson"
+)
+
+const loginSuccess = "Login successfully!"
+
+func loginRequest(index int) api.HTTPRequestSpec {
+	username, password := MustUser(index)
+	request := httpjson.MustRequest(http.MethodGet, "/user", nil, "")
+	request.Query = map[string]string{"username": username, "password": password}
+	return request
+}
+
+func validateLogin(result api.ProtocolResult) error {
+	response, err := httpcheck.Response(result, http.StatusOK)
+	if err != nil {
+		return err
+	}
+	value, err := httpcheck.DecodeJSON(response.Body)
+	if err != nil {
+		return err
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return fmt.Errorf("login response must be an object, got %T", value)
+	}
+	if err := httpcheck.ExactFields(object, "message"); err != nil {
+		return fmt.Errorf("login response: %w", err)
+	}
+	message, ok := object["message"].(string)
+	if !ok || message != loginSuccess {
+		return fmt.Errorf("login message = %v, expected %q", object["message"], loginSuccess)
+	}
+	return nil
+}
+
+func statusOK(result api.ProtocolResult) error {
+	_, err := httpcheck.Response(result, http.StatusOK)
+	return err
+}
+
+func readinessRequest(path string, query map[string]string) api.HTTPRequestSpec {
+	request := httpjson.MustRequest(http.MethodGet, path, nil, "")
+	request.Query = query
+	return request
+}
+
+// ReadinessProbes reaches every downstream service used by the canonical
+// workload through the frontend rather than accepting the static root page.
+func ReadinessProbes(seed int64) []api.ReadinessProbe {
+	random := rand.New(rand.NewSource(seed ^ 0x68f07e1))
+	index := random.Intn(501)
+	probe := func(name string, request api.HTTPRequestSpec, validate func(api.ProtocolResult) error) api.ReadinessProbe {
+		return api.ReadinessProbe{
+			Name: name,
+			Invocation: api.Invocation{
+				Target: GatewayTarget, Operation: "preflight", Payload: request,
+			},
+			Validate: validate,
+		}
+	}
+	return []api.ReadinessProbe{
+		probe("readiness-user-service", loginRequest(index), validateLogin),
+		probe("readiness-search-services", readinessRequest("/hotels", map[string]string{
+			"inDate": "2015-04-09", "outDate": "2015-04-10",
+			"lat": "37.7867", "lon": "-122.4112",
+		}), statusOK),
+		probe("readiness-recommendation-service", readinessRequest("/recommendations", map[string]string{
+			"require": "price", "lat": "37.7867", "lon": "-122.4112",
+		}), statusOK),
+	}
+}
+
+// PreflightProbes verifies strict JSON and persistent HTTP with the same
+// request sequence in benchmark and accuracy modes.
+func PreflightProbes() []api.ReadinessProbe {
+	request := loginRequest(0)
+	probe := func(name string, validate func(api.ProtocolResult) error) api.ReadinessProbe {
+		return api.ReadinessProbe{
+			Name: name,
+			Invocation: api.Invocation{
+				Target: GatewayTarget, Operation: "preflight", Payload: request,
+			},
+			Validate: validate,
+		}
+	}
+	return []api.ReadinessProbe{
+		probe("persistent-http-first", validateLogin),
+		probe("persistent-http-second", func(result api.ProtocolResult) error {
+			if err := validateLogin(result); err != nil {
+				return err
+			}
+			if !result.ConnectionKnown || !result.ConnectionReused {
+				return fmt.Errorf("HTTP connection was not reused for sequential requests")
+			}
+			return nil
+		}),
+	}
+}

--- a/examples/evaluators/microservice/cmd/servicebench/main.go
+++ b/examples/evaluators/microservice/cmd/servicebench/main.go
@@ -20,9 +20,11 @@ import (
 	"time"
 
 	"vibesys/microservice-evaluator/accuracy"
+	accuracyhotel "vibesys/microservice-evaluator/accuracyapps/hotel"
 	accuracytrainticket "vibesys/microservice-evaluator/accuracyapps/trainticket"
 	"vibesys/microservice-evaluator/api"
 	"vibesys/microservice-evaluator/apps/declarative"
+	benchmarkhotel "vibesys/microservice-evaluator/apps/hotel"
 	"vibesys/microservice-evaluator/apps/socialnetwork"
 	benchmarktrainticket "vibesys/microservice-evaluator/apps/trainticket"
 	"vibesys/microservice-evaluator/config"
@@ -37,15 +39,17 @@ var version = "dev"
 type targetOverrides map[string]string
 
 type modeFlagConfig struct {
-	mode           string
-	explicit       map[string]bool
-	outputRaw      string
-	casesMin       int
-	casesMax       int
-	startupTimeout float64
-	runCommandJSON string
-	stateDir       string
-	stateEnv       string
+	mode               string
+	explicit           map[string]bool
+	outputRaw          string
+	casesMin           int
+	casesMax           int
+	startupTimeout     float64
+	runCommandJSON     string
+	stopCommandJSON    string
+	cleanupCommandJSON string
+	stateDir           string
+	stateEnv           string
 }
 
 func (o *targetOverrides) String() string {
@@ -68,7 +72,7 @@ func main() {
 	}
 }
 
-func run() error {
+func run() (resultErr error) {
 	var mode string
 	var workloadPath string
 	var profile string
@@ -89,6 +93,8 @@ func run() error {
 	var casesMax int
 	var startupTimeout float64
 	var runCommandJSON string
+	var stopCommandJSON string
+	var cleanupCommandJSON string
 	var candidateDir string
 	var stateDir string
 	var stateEnv string
@@ -112,8 +118,10 @@ func run() error {
 	flag.IntVar(&casesMin, "cases-min", 2, "minimum randomized cases in accuracy mode")
 	flag.IntVar(&casesMax, "cases-max", 5, "maximum randomized cases in accuracy mode")
 	flag.Float64Var(&startupTimeout, "startup-timeout", 15, "candidate readiness timeout in seconds")
-	flag.StringVar(&runCommandJSON, "run-command-json", "", "managed candidate command as a JSON string array in accuracy mode")
-	flag.StringVar(&candidateDir, "candidate-dir", ".", "managed candidate working directory in accuracy mode")
+	flag.StringVar(&runCommandJSON, "run-command-json", "", "managed candidate command as a JSON string array")
+	flag.StringVar(&stopCommandJSON, "stop-command-json", "", "managed candidate stop or restart command as a JSON string array")
+	flag.StringVar(&cleanupCommandJSON, "cleanup-command-json", "", "managed candidate final cleanup command as a JSON string array")
+	flag.StringVar(&candidateDir, "candidate-dir", ".", "managed candidate working directory")
 	flag.StringVar(&stateDir, "state-dir", "", "managed candidate persistent state directory in accuracy mode")
 	flag.StringVar(&stateEnv, "state-env", "VIBESYS_STATE_DIR", "environment variable receiving --state-dir in accuracy mode")
 	flag.Parse()
@@ -122,7 +130,9 @@ func run() error {
 	if err := validateModeFlags(modeFlagConfig{
 		mode: mode, explicit: explicitFlags, outputRaw: outputRaw,
 		casesMin: casesMin, casesMax: casesMax, startupTimeout: startupTimeout,
-		runCommandJSON: runCommandJSON, stateDir: stateDir, stateEnv: stateEnv,
+		runCommandJSON: runCommandJSON, stopCommandJSON: stopCommandJSON,
+		cleanupCommandJSON: cleanupCommandJSON,
+		stateDir:           stateDir, stateEnv: stateEnv,
 	}); err != nil {
 		return err
 	}
@@ -191,6 +201,9 @@ func run() error {
 	if err := registry.RegisterApplication("declarative", declarative.New); err != nil {
 		return err
 	}
+	if err := registry.RegisterApplication("hotel", benchmarkhotel.New); err != nil {
+		return err
+	}
 	if err := registry.RegisterApplication("social-network", socialnetwork.New); err != nil {
 		return err
 	}
@@ -198,6 +211,9 @@ func run() error {
 		return err
 	}
 	if err := registry.RegisterAccuracyApplication("train-ticket", accuracytrainticket.New); err != nil {
+		return err
+	}
+	if err := registry.RegisterAccuracyApplication("hotel", accuracyhotel.New); err != nil {
 		return err
 	}
 	if mode == "benchmark" {
@@ -257,10 +273,45 @@ func run() error {
 			casesMax,
 			startupTimeout,
 			runCommandJSON,
+			stopCommandJSON,
+			cleanupCommandJSON,
 			candidateDir,
 			stateDir,
 			stateEnv,
 		)
+	}
+	var managed *lifecycle.ManagedCandidate
+	if runCommandJSON != "" {
+		command, parseErr := parseCommandJSON(runCommandJSON, "--run-command-json")
+		if parseErr != nil {
+			return parseErr
+		}
+		var stopCommand []string
+		if stopCommandJSON != "" {
+			stopCommand, parseErr = parseCommandJSON(stopCommandJSON, "--stop-command-json")
+			if parseErr != nil {
+				return parseErr
+			}
+		}
+		var cleanupCommand []string
+		if cleanupCommandJSON != "" {
+			cleanupCommand, parseErr = parseCommandJSON(cleanupCommandJSON, "--cleanup-command-json")
+			if parseErr != nil {
+				return parseErr
+			}
+		}
+		managed, err = lifecycle.NewManagedCandidate(command, stopCommand, cleanupCommand, candidateDir, nil)
+		if err != nil {
+			return err
+		}
+		if err := managed.Prepare(ctx); err != nil {
+			return fmt.Errorf("prepare managed candidate: %w", err)
+		}
+		defer func() {
+			if closeErr := managed.Close(context.WithoutCancel(ctx)); closeErr != nil && resultErr == nil {
+				resultErr = fmt.Errorf("close managed candidate: %w", closeErr)
+			}
+		}()
 	}
 	runner := engine.New(registry, engine.Options{
 		EngineVersion:  version,
@@ -300,9 +351,7 @@ func validateModeFlags(config modeFlagConfig) error {
 	if config.startupTimeout <= 0 {
 		return fmt.Errorf("--startup-timeout must be positive")
 	}
-	accuracyOnly := []string{
-		"cases-min", "cases-max", "run-command-json", "candidate-dir", "state-dir", "state-env",
-	}
+	accuracyOnly := []string{"cases-min", "cases-max", "state-dir", "state-env"}
 	benchmarkOnly := []string{
 		"output-raw", "skip-prepare", "fixture-seed", "rate", "duration", "warmup", "concurrency", "repetitions",
 	}
@@ -312,37 +361,50 @@ func validateModeFlags(config modeFlagConfig) error {
 				return fmt.Errorf("--%s is only available in accuracy mode", name)
 			}
 		}
-		if config.runCommandJSON != "" || config.stateDir != "" {
-			return errors.New("managed candidate flags are only available in accuracy mode")
+	} else {
+		for _, name := range benchmarkOnly {
+			if config.explicit[name] {
+				return fmt.Errorf("--%s is only available in benchmark mode", name)
+			}
 		}
-		return nil
-	}
-	for _, name := range benchmarkOnly {
-		if config.explicit[name] {
-			return fmt.Errorf("--%s is only available in benchmark mode", name)
+		if config.outputRaw != "" {
+			return errors.New("--output-raw is only available in benchmark mode")
 		}
-	}
-	if config.outputRaw != "" {
-		return errors.New("--output-raw is only available in benchmark mode")
-	}
-	if config.casesMin < 1 || config.casesMax < config.casesMin {
-		return fmt.Errorf(
-			"accuracy case bounds must satisfy 1 <= min <= max, got %d..%d",
-			config.casesMin,
-			config.casesMax,
-		)
+		if config.casesMin < 1 || config.casesMax < config.casesMin {
+			return fmt.Errorf(
+				"accuracy case bounds must satisfy 1 <= min <= max, got %d..%d",
+				config.casesMin,
+				config.casesMax,
+			)
+		}
 	}
 	if config.runCommandJSON != "" {
-		if _, err := parseCommandJSON(config.runCommandJSON); err != nil {
+		if _, err := parseCommandJSON(config.runCommandJSON, "--run-command-json"); err != nil {
 			return err
 		}
-		if config.stateEnv == "" {
+		if config.stopCommandJSON != "" {
+			if _, err := parseCommandJSON(config.stopCommandJSON, "--stop-command-json"); err != nil {
+				return err
+			}
+		}
+		if config.cleanupCommandJSON != "" {
+			if _, err := parseCommandJSON(config.cleanupCommandJSON, "--cleanup-command-json"); err != nil {
+				return err
+			}
+		}
+		if config.mode == "accuracy" && config.stateEnv == "" {
 			return errors.New("--state-env must not be empty")
 		}
 		return nil
 	}
 	if config.stateDir != "" {
 		return errors.New("--state-dir requires --run-command-json")
+	}
+	if config.stopCommandJSON != "" {
+		return errors.New("--stop-command-json requires --run-command-json")
+	}
+	if config.cleanupCommandJSON != "" {
+		return errors.New("--cleanup-command-json requires --run-command-json")
 	}
 	for _, name := range []string{"candidate-dir", "state-env"} {
 		if config.explicit[name] {
@@ -361,6 +423,8 @@ func runAccuracy(
 	casesMax int,
 	startupTimeoutSeconds float64,
 	runCommandJSON string,
+	stopCommandJSON string,
+	cleanupCommandJSON string,
 	candidateDir string,
 	stateDir string,
 	stateEnv string,
@@ -368,9 +432,23 @@ func runAccuracy(
 	var candidate accuracy.CandidateLifecycle
 	var temporaryState string
 	if runCommandJSON != "" {
-		command, err := parseCommandJSON(runCommandJSON)
+		command, err := parseCommandJSON(runCommandJSON, "--run-command-json")
 		if err != nil {
 			return err
+		}
+		var stopCommand []string
+		if stopCommandJSON != "" {
+			stopCommand, err = parseCommandJSON(stopCommandJSON, "--stop-command-json")
+			if err != nil {
+				return err
+			}
+		}
+		var cleanupCommand []string
+		if cleanupCommandJSON != "" {
+			cleanupCommand, err = parseCommandJSON(cleanupCommandJSON, "--cleanup-command-json")
+			if err != nil {
+				return err
+			}
 		}
 		if stateDir == "" {
 			temporaryState, err = os.MkdirTemp("", "microservice-state-*")
@@ -393,6 +471,8 @@ func runAccuracy(
 		}
 		managed, err := lifecycle.NewManagedCandidate(
 			command,
+			stopCommand,
+			cleanupCommand,
 			candidateDir,
 			map[string]string{stateEnv: stateDir},
 		)
@@ -433,17 +513,17 @@ func runAccuracy(
 	return nil
 }
 
-func parseCommandJSON(raw string) ([]string, error) {
+func parseCommandJSON(raw, flagName string) ([]string, error) {
 	var command []string
 	if err := json.Unmarshal([]byte(raw), &command); err != nil {
-		return nil, fmt.Errorf("--run-command-json must be a JSON string array: %w", err)
+		return nil, fmt.Errorf("%s must be a JSON string array: %w", flagName, err)
 	}
 	if len(command) == 0 {
-		return nil, errors.New("--run-command-json must be a non-empty JSON string array")
+		return nil, fmt.Errorf("%s must be a non-empty JSON string array", flagName)
 	}
 	for index, argument := range command {
 		if argument == "" {
-			return nil, fmt.Errorf("--run-command-json argument %d is empty", index)
+			return nil, fmt.Errorf("%s argument %d is empty", flagName, index)
 		}
 	}
 	return command, nil

--- a/examples/evaluators/microservice/cmd/servicebench/main_test.go
+++ b/examples/evaluators/microservice/cmd/servicebench/main_test.go
@@ -9,11 +9,11 @@ func TestParseCommandJSONRejectsMalformedAndEmptyArguments(t *testing.T) {
 		`["./run.sh",""]`,
 		`["./run.sh",1]`,
 	} {
-		if _, err := parseCommandJSON(raw); err == nil {
+		if _, err := parseCommandJSON(raw, "--run-command-json"); err == nil {
 			t.Fatalf("accepted invalid command %s", raw)
 		}
 	}
-	command, err := parseCommandJSON(`["./run.sh","--port","8080"]`)
+	command, err := parseCommandJSON(`["./run.sh","--port","8080"]`, "--run-command-json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,11 @@ func TestValidateModeFlagsRejectsIgnoredOrMalformedCombinations(t *testing.T) {
 		mode: "accuracy", casesMin: 2, casesMax: 5, startupTimeout: 15,
 		stateEnv: "VIBESYS_STATE_DIR",
 	}
-	validBenchmark := modeFlagConfig{mode: "benchmark", startupTimeout: 15}
+	validBenchmark := modeFlagConfig{
+		mode: "benchmark", startupTimeout: 15,
+		runCommandJSON: `["./run.sh"]`, stopCommandJSON: `["./stop.sh"]`,
+		cleanupCommandJSON: `["./cleanup.sh"]`,
+	}
 	tests := []struct {
 		name   string
 		config modeFlagConfig
@@ -68,9 +72,36 @@ func TestValidateModeFlagsRejectsIgnoredOrMalformedCombinations(t *testing.T) {
 			},
 		},
 		{
+			name: "accuracy stop without command",
+			config: modeFlagConfig{
+				mode: "accuracy", stopCommandJSON: `["./stop.sh"]`,
+				casesMin: 2, casesMax: 5, startupTimeout: 15, stateEnv: "VIBESYS_STATE_DIR",
+			},
+		},
+		{
+			name: "accuracy cleanup without command",
+			config: modeFlagConfig{
+				mode: "accuracy", cleanupCommandJSON: `["./cleanup.sh"]`,
+				casesMin: 2, casesMax: 5, startupTimeout: 15, stateEnv: "VIBESYS_STATE_DIR",
+			},
+		},
+		{
 			name: "benchmark accuracy flag",
 			config: modeFlagConfig{
 				mode: "benchmark", explicit: map[string]bool{"cases-min": true}, startupTimeout: 15,
+			},
+		},
+		{
+			name: "benchmark malformed command",
+			config: modeFlagConfig{
+				mode: "benchmark", runCommandJSON: `"./run.sh"`, startupTimeout: 15,
+			},
+		},
+		{
+			name: "benchmark candidate directory without command",
+			config: modeFlagConfig{
+				mode: "benchmark", explicit: map[string]bool{"candidate-dir": true},
+				startupTimeout: 15,
 			},
 		},
 		{

--- a/examples/evaluators/microservice/lifecycle/managed.go
+++ b/examples/evaluators/microservice/lifecycle/managed.go
@@ -44,10 +44,12 @@ done
 // constructor fails closed when bubblewrap is unavailable: process-tree
 // sampling cannot prove that a fast daemon did not escape before a crash.
 type ManagedCandidate struct {
-	command []string
-	cwd     string
-	env     map[string]string
-	bwrap   string
+	command        []string
+	stopCommand    []string
+	cleanupCommand []string
+	cwd            string
+	env            map[string]string
+	bwrap          string
 
 	mu        sync.Mutex
 	cmd       *exec.Cmd
@@ -60,6 +62,8 @@ type ManagedCandidate struct {
 
 func NewManagedCandidate(
 	command []string,
+	stopCommand []string,
+	cleanupCommand []string,
 	cwd string,
 	environment map[string]string,
 ) (*ManagedCandidate, error) {
@@ -69,6 +73,16 @@ func NewManagedCandidate(
 	for index, argument := range command {
 		if argument == "" {
 			return nil, fmt.Errorf("managed candidate command argument %d is empty", index)
+		}
+	}
+	for index, argument := range stopCommand {
+		if argument == "" {
+			return nil, fmt.Errorf("managed candidate stop command argument %d is empty", index)
+		}
+	}
+	for index, argument := range cleanupCommand {
+		if argument == "" {
+			return nil, fmt.Errorf("managed candidate cleanup command argument %d is empty", index)
 		}
 	}
 	absCWD, err := filepath.Abs(cwd)
@@ -99,12 +113,14 @@ func NewManagedCandidate(
 		return nil, fmt.Errorf("create candidate log: %w", err)
 	}
 	return &ManagedCandidate{
-		command: append([]string(nil), command...),
-		cwd:     absCWD,
-		env:     cloneEnvironment(environment),
-		bwrap:   bwrap,
-		log:     log,
-		logPath: log.Name(),
+		command:        append([]string(nil), command...),
+		stopCommand:    append([]string(nil), stopCommand...),
+		cleanupCommand: append([]string(nil), cleanupCommand...),
+		cwd:            absCWD,
+		env:            cloneEnvironment(environment),
+		bwrap:          bwrap,
+		log:            log,
+		logPath:        log.Name(),
 	}, nil
 }
 
@@ -198,7 +214,7 @@ func (m *ManagedCandidate) Stop(ctx context.Context, hard bool) error {
 	select {
 	case <-waitDone:
 		m.clear(command)
-		return nil
+		return m.runStopCommand(ctx)
 	default:
 	}
 
@@ -216,8 +232,34 @@ func (m *ManagedCandidate) Stop(ctx context.Context, hard bool) error {
 		return fmt.Errorf("contained candidate did not terminate after %s", stopTimeout)
 	}
 	m.clear(command)
+	if err := m.runStopCommand(ctx); err != nil {
+		return err
+	}
 	if err := ctx.Err(); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (m *ManagedCandidate) runStopCommand(ctx context.Context) error {
+	return m.runCommand(ctx, m.stopCommand, "stop")
+}
+
+func (m *ManagedCandidate) runCommand(ctx context.Context, arguments []string, name string) error {
+	if len(arguments) == 0 {
+		return nil
+	}
+	command := exec.CommandContext(ctx, arguments[0], arguments[1:]...)
+	command.Dir = m.cwd
+	command.Env = environmentWithOverrides(os.Environ(), m.env)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf(
+			"managed candidate %s command failed: %w: %s",
+			name,
+			err,
+			strings.TrimSpace(string(output)),
+		)
 	}
 	return nil
 }
@@ -245,9 +287,10 @@ func (m *ManagedCandidate) clear(command *exec.Cmd) {
 func (m *ManagedCandidate) Close(ctx context.Context) error {
 	m.closeOnce.Do(func() {
 		stopErr := m.Stop(ctx, false)
+		cleanupErr := m.runCommand(ctx, m.cleanupCommand, "cleanup")
 		logErr := m.log.Close()
 		removeErr := os.Remove(m.logPath)
-		m.closeErr = errors.Join(stopErr, logErr, removeErr)
+		m.closeErr = errors.Join(stopErr, cleanupErr, logErr, removeErr)
 	})
 	return m.closeErr
 }

--- a/examples/evaluators/microservice/lifecycle/managed_test.go
+++ b/examples/evaluators/microservice/lifecycle/managed_test.go
@@ -28,6 +28,12 @@ func TestManagedCandidateHelper(t *testing.T) {
 	}
 	mode := os.Args[separator+1]
 	pidFile := os.Args[separator+2]
+	if mode == "stop" {
+		if err := os.WriteFile(pidFile, []byte("stopped"), 0o600); err != nil {
+			os.Exit(3)
+		}
+		return
+	}
 	if mode == "child" {
 		if err := os.WriteFile(pidFile, []byte("ready"), 0o600); err != nil {
 			os.Exit(3)
@@ -66,17 +72,20 @@ func TestManagedCandidateKillsImmediatelyDetachedDescendant(t *testing.T) {
 	}
 	t.Setenv("GO_MANAGED_CANDIDATE_HELPER", "1")
 	pidFile := t.TempDir() + "/child.pid"
+	stopFile := t.TempDir() + "/stopped"
+	cleanupFile := t.TempDir() + "/cleaned"
 	managed, err := NewManagedCandidate(
 		[]string{
 			os.Args[0], "-test.run=TestManagedCandidateHelper", "--", "launcher", pidFile,
 		},
+		[]string{os.Args[0], "-test.run=TestManagedCandidateHelper", "--", "stop", stopFile},
+		[]string{os.Args[0], "-test.run=TestManagedCandidateHelper", "--", "stop", cleanupFile},
 		t.TempDir(),
 		map[string]string{"VIBESYS_STATE_DIR": t.TempDir()},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer managed.Close(context.Background())
 	if err := managed.Prepare(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -97,6 +106,9 @@ func TestManagedCandidateKillsImmediatelyDetachedDescendant(t *testing.T) {
 	if err := managed.Stop(context.Background(), true); err != nil {
 		t.Fatalf("stop managed candidate: %v; log=%s", err, managed.LogTail(4000))
 	}
+	if contents, err := os.ReadFile(stopFile); err != nil || string(contents) != "stopped" {
+		t.Fatalf("stop command output=%q error=%v", contents, err)
+	}
 	deadline = time.Now().Add(2 * time.Second)
 	for pidExists(childPID) && time.Now().Before(deadline) {
 		time.Sleep(20 * time.Millisecond)
@@ -105,11 +117,17 @@ func TestManagedCandidateKillsImmediatelyDetachedDescendant(t *testing.T) {
 		_ = syscall.Kill(childPID, syscall.SIGKILL)
 		t.Fatalf("immediately detached child %d survived", childPID)
 	}
+	if err := managed.Close(context.Background()); err != nil {
+		t.Fatalf("close managed candidate: %v", err)
+	}
+	if contents, err := os.ReadFile(cleanupFile); err != nil || string(contents) != "stopped" {
+		t.Fatalf("cleanup command output=%q error=%v", contents, err)
+	}
 }
 
 func TestManagedCandidateFailsClosedWithoutPIDNamespaceLauncher(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
-	if _, err := NewManagedCandidate([]string{os.Args[0]}, t.TempDir(), nil); err == nil ||
+	if _, err := NewManagedCandidate([]string{os.Args[0]}, nil, nil, t.TempDir(), nil); err == nil ||
 		!strings.Contains(err.Error(), "requires bubblewrap") {
 		t.Fatalf("containment error=%v", err)
 	}

--- a/examples/microservices/hotel-reservation/CANDIDATE_CONTRACT.md
+++ b/examples/microservices/hotel-reservation/CANDIDATE_CONTRACT.md
@@ -1,0 +1,48 @@
+# Candidate contract
+
+The mutable candidate is DeathStarBench's `hotelReservation` source tree at the
+bundle top level and must remain deployable with Docker Compose. Immutable
+provenance metadata remains under `reference/`. The frontend listens on HTTP
+port 5000.
+
+## Required frontend API
+
+All inputs are URL query parameters. Handlers may accept GET or POST, matching
+the upstream application.
+
+- `/hotels`: `inDate`, `outDate`, `lat`, `lon`, optional `locale`.
+- `/recommendations`: `require=dis|rate|price`, `lat`, `lon`, optional `locale`.
+- `/user`: `username`, `password`.
+- `/reservation`: `inDate`, `outDate`, `hotelId`, `customerName`, `username`,
+  `password`, and optional `number`.
+
+Search and recommendation responses are strict GeoJSON feature collections.
+Feature order is unspecified, but IDs must be unique and each seeded profile's
+name, phone number, and coordinates must be exact. Login and reservation return
+a JSON object containing exactly `message`; HTTP 200 alone is not success.
+
+The scenario covers the canonical five-service frontend surface used by the
+upstream mixed workload. The newer review and attractions routes are outside
+the contract because the pinned upstream frontend dials those services without
+its Consul resolver and cannot reach them even in the unmodified reference.
+
+Seeded usernames preserve the current upstream grammar. The decimal user suffix
+is hex-encoded as bytes: account zero is `Cornell_30` with password
+`0000000000`. Hotel IDs are `1` through `80`; room capacities are 200 for IDs
+1–6, then 300/250/200 for generated IDs whose remainder modulo three is
+1/2/0.
+
+Authentication semantics are checked through `/user`. The pinned reference
+still invokes the reservation service after a failed credential check, so the
+scenario does not claim that `/reservation` provides an authorization gate.
+
+## State and ownership
+
+Reservations are persistent and have no public deletion API. Accuracy and
+benchmark traffic use collision-resistant future dates, and each evaluation
+must start from a disposable Compose project or be torn down with volumes. A
+plain process restart is not a clean reset. Evaluator-owned files under
+`_evaluator/` and the workload configuration are outside candidate ownership.
+When the accuracy runner is given a managed restart hook, it additionally
+proves that acknowledged capacity consumption and search visibility survive a
+candidate restart; this property is reported as optional otherwise.

--- a/examples/microservices/hotel-reservation/OBJECTIVE.md
+++ b/examples/microservices/hotel-reservation/OBJECTIVE.md
@@ -1,0 +1,31 @@
+# Hotel Reservation mixed-workload optimization
+
+Optimize DeathStarBench's `hotelReservation` application for maximum sustained
+end-to-end logical operations per second on a local CPU server. Preserve the
+public frontend behavior and seeded data semantics verified by the shared
+microservice accuracy evaluator.
+
+The target is the Go/gRPC Hotel Reservation stack at frontend port 5000. The
+canonical mix follows DeathStarBench's workload proportions:
+
+- 60% hotel search;
+- 39% recommendations, split evenly across distance, rating, and price;
+- 0.5% authenticated login; and
+- 0.5% reservation capacity transitions.
+
+The reservation operation is a stateful logical sequence: it fills a uniquely
+namespaced hotel/date slot to its exact capacity and verifies that one
+additional room is rejected. Business failures use HTTP 200, so every response
+must pass application-level validation. The benchmark is valid only with zero
+semantic errors and coverage of every operation type.
+
+Promising directions include removing redundant rate/profile database work,
+improving safe cache reuse, reducing gRPC and JSON overhead, reusing downstream
+connections, and tuning service concurrency. Do not hard-code evaluator inputs,
+weaken the checked availability semantics, or bypass authentication checks
+exercised by the contract. Evaluator requests are seeded and fuzzed; solutions
+must implement the behavior rather than recognize a fixed set of URLs.
+
+The accuracy gate owns candidate startup and restart. Stop any manually started
+Compose deployment before declaring a round ready for judging so the managed
+lifecycle can prove both clean startup and persistence across a restart.

--- a/examples/microservices/hotel-reservation/README.md
+++ b/examples/microservices/hotel-reservation/README.md
@@ -1,0 +1,76 @@
+# Hotel Reservation
+
+This scenario optimizes DeathStarBench's Go/gRPC Hotel Reservation stack under
+its canonical search-heavy mixed workload. Correctness is checked independently
+through the shared microservice evaluator, including strict profile and
+recommendation semantics, randomized authentication cases, negative protocol
+cases, and stateful room-capacity transitions.
+
+## Prepare the candidate
+
+DeathStarBench is pinned by the existing repository submodule. Its upstream
+default branch is `master`; the pinned revision already matches the latest
+remote `master` at the time this scenario was added.
+
+```bash
+git submodule update --init \
+  examples/microservices/social-network-read-timeline/3rd_party/deathstarbench
+examples/microservices/hotel-reservation/scripts/materialize-reference.sh
+```
+
+The materialized source is intentionally ignored by this repository. VibeSys
+copies it into the separate experiment workspace, where optimization commits
+belong; the pull request for this scenario contains only evaluator and bundle
+code.
+
+## Validate locally
+
+From the repository root, let the evaluator own candidate startup and cleanup:
+
+```bash
+go -C examples/evaluators/microservice run ./cmd/servicebench \
+  --mode accuracy \
+  --workload "$PWD/examples/microservices/hotel-reservation/benchmark/workload.toml" \
+  --seed random \
+  --candidate-dir "$PWD/examples/microservices/hotel-reservation/hotelReservation" \
+  --run-command-json '["docker","compose","up","-d","--build"]' \
+  --stop-command-json '["docker","compose","stop","-t","10","frontend","geo","profile","rate","recommendation","reservation","search","user"]' \
+  --cleanup-command-json '["docker","compose","down","-v","--remove-orphans"]' \
+  --startup-timeout 120
+
+go -C examples/evaluators/microservice run ./cmd/servicebench \
+  --workload "$PWD/examples/microservices/hotel-reservation/benchmark/workload.toml" \
+  --seed random \
+  --fixture-seed random \
+  --candidate-dir "$PWD/examples/microservices/hotel-reservation/hotelReservation" \
+  --run-command-json '["docker","compose","up","-d","--build"]' \
+  --stop-command-json '["docker","compose","stop","-t","10","frontend","geo","profile","rate","recommendation","reservation","search","user"]' \
+  --cleanup-command-json '["docker","compose","down","-v","--remove-orphans"]' \
+  --startup-timeout 120 \
+  --output-json /tmp/hotel-benchmark.json
+```
+
+Reservations have no deletion API. Reset all persistent state between clean
+comparisons:
+
+```bash
+docker compose \
+  -f examples/microservices/hotel-reservation/hotelReservation/docker-compose.yml \
+  down -v
+```
+
+## Optimize
+
+```bash
+./vs --outer-loop agent \
+  --input examples/microservices/hotel-reservation \
+  --exp-name hotel-reservation-opt \
+  --backend cpu --interface service \
+  --agent-backend cli --cli-provider codex \
+  --max-rounds 10 --git-tracking --headless
+```
+
+The benchmark reports closed-loop logical operations per second. One logical
+reservation includes both the capacity-filling request and the rejected
+over-capacity read-back, so faster incorrect acknowledgements cannot improve the
+trusted metric.

--- a/examples/microservices/hotel-reservation/benchmark/workload.toml
+++ b/examples/microservices/hotel-reservation/benchmark/workload.toml
@@ -1,0 +1,80 @@
+version = 1
+name = "hotel-reservation-canonical-mixed"
+application = "hotel"
+
+[load]
+model = "closed_loop"
+rate = 0
+duration_seconds = 30
+warmup_seconds = 10
+concurrency = 32
+timeout_seconds = 10
+repetitions = 3
+seed = 48
+fixture_seed = 48
+min_offered_rate_ratio = 0.95
+
+[[targets]]
+name = "gateway"
+protocol = "http"
+address = "http://localhost:5000"
+session_policy = "reuse"
+
+[[operations]]
+name = "search_hotels"
+target = "gateway"
+weight = 600
+tags = ["read", "search"]
+
+[[operations]]
+name = "recommend_distance"
+target = "gateway"
+weight = 130
+tags = ["read", "recommendation"]
+
+[[operations]]
+name = "recommend_rate"
+target = "gateway"
+weight = 130
+tags = ["read", "recommendation"]
+
+[[operations]]
+name = "recommend_price"
+target = "gateway"
+weight = 130
+tags = ["read", "recommendation"]
+
+[[operations]]
+name = "login_valid"
+target = "gateway"
+weight = 3
+tags = ["read", "authentication"]
+
+[[operations]]
+name = "login_invalid"
+target = "gateway"
+weight = 2
+tags = ["read", "authentication"]
+
+[[operations]]
+name = "reserve_capacity"
+target = "gateway"
+weight = 5
+tags = ["write", "read-your-write"]
+
+[profiles.quick]
+duration_seconds = 5
+warmup_seconds = 1
+concurrency = 8
+repetitions = 1
+
+[objective]
+name = "logical_operations_per_second"
+metric = "operations_per_second"
+direction = "maximize"
+unit = "operations/s"
+
+[constraints]
+min_success_rate = 1.0
+max_error_rate = 0.0
+min_operations_per_type = 1

--- a/examples/microservices/hotel-reservation/reference/meta.json
+++ b/examples/microservices/hotel-reservation/reference/meta.json
@@ -1,0 +1,11 @@
+{
+  "scenario": "hotel-reservation",
+  "target": "DeathStarBench hotelReservation",
+  "repo": "https://github.com/delimitrou/DeathStarBench",
+  "revision": "6ecb09706140f8730b5385c08f1386c654c3c526",
+  "subdir": "hotelReservation",
+  "frontend_port": 5000,
+  "deploy_cmd": "docker compose up -d --build",
+  "teardown_cmd": "docker compose down -v",
+  "primary_metric": "logical operations per second"
+}

--- a/examples/microservices/hotel-reservation/scripts/materialize-reference.sh
+++ b/examples/microservices/hotel-reservation/scripts/materialize-reference.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+scenario_dir="$(cd "${script_dir}/.." && pwd)"
+source_dir="${scenario_dir}/../social-network-read-timeline/3rd_party/deathstarbench/hotelReservation"
+destination="${scenario_dir}/hotelReservation"
+
+if [[ ! -f "${source_dir}/docker-compose.yml" ]]; then
+  echo "DeathStarBench is not initialized at ${source_dir}" >&2
+  echo "Run: git submodule update --init examples/microservices/social-network-read-timeline/3rd_party/deathstarbench" >&2
+  exit 1
+fi
+if [[ -e "${destination}" ]]; then
+  echo "Reference already exists at ${destination}; remove it explicitly before refreshing." >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${destination}")"
+cp -a "${source_dir}" "${destination}"
+rm -f "${destination}/.git"
+echo "Materialized Hotel Reservation candidate at ${destination}"

--- a/examples/microservices/hotel-reservation/vibesys.input.toml
+++ b/examples/microservices/hotel-reservation/vibesys.input.toml
@@ -1,0 +1,41 @@
+version = 1
+
+[agent]
+domain = "microservices"
+
+[evaluator]
+source = "../../evaluators/microservice"
+
+[accuracy]
+command = [
+  "go", "-C", "_evaluator/microservice",
+  "run", "./cmd/servicebench",
+  "--mode", "accuracy",
+  "--workload", "../../benchmark/workload.toml",
+  "--seed", "random",
+  "--candidate-dir", "../../hotelReservation",
+  "--run-command-json", "[\"docker\",\"compose\",\"up\",\"-d\",\"--build\"]",
+  "--stop-command-json", "[\"docker\",\"compose\",\"stop\",\"-t\",\"10\",\"frontend\",\"geo\",\"profile\",\"rate\",\"recommendation\",\"reservation\",\"search\",\"user\"]",
+  "--cleanup-command-json", "[\"docker\",\"compose\",\"down\",\"-v\",\"--remove-orphans\"]",
+  "--startup-timeout", "120",
+]
+timeout_seconds = 300
+
+[benchmark]
+command = [
+  "go", "-C", "_evaluator/microservice",
+  "run", "./cmd/servicebench",
+  "--workload", "../../benchmark/workload.toml",
+  "--seed", "random",
+  "--fixture-seed", "random",
+  "--candidate-dir", "../../hotelReservation",
+  "--run-command-json", "[\"docker\",\"compose\",\"up\",\"-d\",\"--build\"]",
+  "--stop-command-json", "[\"docker\",\"compose\",\"stop\",\"-t\",\"10\",\"frontend\",\"geo\",\"profile\",\"rate\",\"recommendation\",\"reservation\",\"search\",\"user\"]",
+  "--cleanup-command-json", "[\"docker\",\"compose\",\"down\",\"-v\",\"--remove-orphans\"]",
+  "--startup-timeout", "120",
+]
+timeout_seconds = 300
+
+[benchmark.result]
+json_argument = "--output-json"
+metric = "primary_value"

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -610,6 +610,7 @@ def _run_framework_accuracy_gate(
     round_number: int,
     retry: int,
     progress_path: Path,
+    timeout_seconds: int | None = None,
 ) -> str | None:
     """Run the immutable manifest accuracy command after an agent reports PASS."""
     changed = ctx.trusted_input_changes()
@@ -632,7 +633,10 @@ def _run_framework_accuracy_gate(
 
     ctx.lprint(f"[framework-accuracy] running: {command}")
     try:
-        result = ctx.judge_backend.execute(command)
+        if timeout_seconds is None:
+            result = ctx.judge_backend.execute(command)
+        else:
+            result = ctx.judge_backend.execute(command, timeout=timeout_seconds)
         output = result.output.strip()
         passed = result.exit_code == 0
         _publish_subprocess_output(
@@ -696,6 +700,7 @@ def _run_framework_benchmark(
     round_number: int,
     retry: int,
     progress_path: Path,
+    timeout_seconds: int | None = None,
 ) -> tuple[str | None, float | None]:
     """Run and parse an opt-in trusted benchmark result contract."""
     if result_spec is None:
@@ -720,7 +725,10 @@ def _run_framework_benchmark(
         passed = False
     else:
         try:
-            result = ctx.judge_backend.execute(command)
+            if timeout_seconds is None:
+                result = ctx.judge_backend.execute(command)
+            else:
+                result = ctx.judge_backend.execute(command, timeout=timeout_seconds)
             output = result.output.strip()
             passed = result.exit_code == 0
             _publish_subprocess_output(
@@ -811,6 +819,8 @@ def _run_framework_gates(
     round_number: int,
     retry: int,
     progress_path: Path,
+    accuracy_timeout_seconds: int | None = None,
+    benchmark_timeout_seconds: int | None = None,
 ) -> tuple[str | None, float | None]:
     if ctx.agent_runner.backend_name == "stub":
         return None, None
@@ -819,6 +829,7 @@ def _run_framework_gates(
         round_number=round_number,
         retry=retry,
         progress_path=progress_path,
+        timeout_seconds=accuracy_timeout_seconds,
     )
     if feedback is not None:
         return feedback, None
@@ -828,6 +839,7 @@ def _run_framework_gates(
         round_number=round_number,
         retry=retry,
         progress_path=progress_path,
+        timeout_seconds=benchmark_timeout_seconds,
     )
 
 
@@ -847,6 +859,8 @@ def run_agent_loop(
     workspace_seed: Path | None = None,
     evaluator_path: Path | None = None,
     benchmark_result: BenchmarkResult | None = None,
+    accuracy_timeout_seconds: int | None = None,
+    benchmark_timeout_seconds: int | None = None,
     max_rounds: int = 24,
     max_retries_per_round: int = 3,
     start_round: int = 1,
@@ -1080,6 +1094,8 @@ def run_agent_loop(
                                 round_number=round_number,
                                 retry=retry,
                                 progress_path=progress_path,
+                                accuracy_timeout_seconds=accuracy_timeout_seconds,
+                                benchmark_timeout_seconds=benchmark_timeout_seconds,
                             )
                             if gate_feedback is None:
                                 passed = True
@@ -1109,6 +1125,8 @@ def run_agent_loop(
                                 round_number=round_number,
                                 retry=retry,
                                 progress_path=progress_path,
+                                accuracy_timeout_seconds=accuracy_timeout_seconds,
+                                benchmark_timeout_seconds=benchmark_timeout_seconds,
                             )
                             if gate_feedback is None:
                                 passed = True

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -905,6 +905,8 @@ def _run_agent(args: argparse.Namespace) -> None:
         workspace_seed=bundle.workspace_seed_path,
         evaluator_path=bundle.evaluator_path,
         benchmark_result=bundle.benchmark_result,
+        accuracy_timeout_seconds=bundle.manifest.accuracy.timeout_seconds,
+        benchmark_timeout_seconds=bundle.manifest.benchmark.timeout_seconds,
         objective=objective,
         max_rounds=args.max_rounds,
         max_retries_per_round=args.max_retries_per_round,

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -285,6 +285,26 @@ def test_framework_accuracy_gate_rejects_checker_failure(tmp_path):
     assert "bad history" in feedback
 
 
+def test_framework_accuracy_gate_uses_manifest_timeout(tmp_path):
+    from vibesys.loops.agent.loop import _run_framework_accuracy_gate
+
+    ctx = MagicMock()
+    ctx.trusted_input_changes.return_value = []
+    ctx.judge_accuracy_command = "trusted-check"
+    ctx.judge_backend.execute.return_value = SimpleNamespace(exit_code=0, output="PASS")
+
+    feedback = _run_framework_accuracy_gate(
+        ctx,
+        round_number=1,
+        retry=1,
+        progress_path=tmp_path / "progress.md",
+        timeout_seconds=300,
+    )
+
+    assert feedback is None
+    ctx.judge_backend.execute.assert_called_once_with("trusted-check", timeout=300)
+
+
 def test_framework_accuracy_gate_rejects_evaluator_changes_without_execution(tmp_path):
     from vibesys.loops.agent.loop import _run_framework_accuracy_gate
 
@@ -350,11 +370,13 @@ def test_framework_benchmark_extracts_declared_metric(tmp_path):
         round_number=3,
         retry=1,
         progress_path=tmp_path / "progress.md",
+        timeout_seconds=300,
     )
 
     assert feedback is None
     assert metric == 42.5
     executed = ctx.judge_backend.execute.call_args.args[0]
+    assert ctx.judge_backend.execute.call_args.kwargs == {"timeout": 300}
     assert "trusted-benchmark --repetitions 3 --output-json" in executed
     assert "cat /tmp/vibesys-framework-benchmark-3-1.json" in executed
     assert _FRAMEWORK_BENCHMARK_END_MARKER in executed

--- a/tests/test_microservice_inputs.py
+++ b/tests/test_microservice_inputs.py
@@ -34,7 +34,11 @@ def test_microservice_scenario_uses_shared_evaluator(scenario_path: Path) -> Non
     assert bundle.benchmark_result is not None
     assert bundle.benchmark_result.json_argument == "--output-json"
     assert bundle.benchmark_result.metric == "primary_value"
-    assert bundle.benchmark_command[-2:] == ("--fixture-seed", "random")
+    assert ("--fixture-seed", "random") in zip(
+        bundle.benchmark_command,
+        bundle.benchmark_command[1:],
+        strict=False,
+    )
     if scenario_path.name == "train-ticket":
         assert ("--seed", "random") in zip(
             bundle.benchmark_command,
@@ -45,6 +49,7 @@ def test_microservice_scenario_uses_shared_evaluator(scenario_path: Path) -> Non
 
 def test_microservice_scenarios_are_discovered() -> None:
     assert {path.name for path in MICROSERVICE_SCENARIOS} == {
+        "hotel-reservation",
         "social-network-read-timeline",
         "train-ticket",
     }
@@ -64,6 +69,74 @@ def test_train_ticket_accuracy_uses_shared_evaluator() -> None:
         "./cmd/servicebench",
     )
     assert bundle.accuracy_command[5:7] == ("--mode", "accuracy")
+
+
+def test_hotel_accuracy_uses_shared_evaluator_with_random_cases() -> None:
+    bundle = load_input_bundle(
+        MICROSERVICE_ROOT / "hotel-reservation",
+        project_root=PROJECT_ROOT,
+    )
+
+    assert bundle.accuracy_command[:7] == (
+        "go",
+        "-C",
+        "_evaluator/microservice",
+        "run",
+        "./cmd/servicebench",
+        "--mode",
+        "accuracy",
+    )
+    assert ("--seed", "random") in zip(
+        bundle.accuracy_command,
+        bundle.accuracy_command[1:],
+        strict=False,
+    )
+    assert ("--seed", "random") in zip(
+        bundle.benchmark_command,
+        bundle.benchmark_command[1:],
+        strict=False,
+    )
+    assert ("--fixture-seed", "random") in zip(
+        bundle.benchmark_command,
+        bundle.benchmark_command[1:],
+        strict=False,
+    )
+    assert ("--candidate-dir", "../../hotelReservation") in zip(
+        bundle.accuracy_command,
+        bundle.accuracy_command[1:],
+        strict=False,
+    )
+    assert (
+        "--run-command-json",
+        '["docker","compose","up","-d","--build"]',
+    ) in zip(bundle.accuracy_command, bundle.accuracy_command[1:], strict=False)
+    assert (
+        "--stop-command-json",
+        '["docker","compose","stop","-t","10","frontend","geo","profile","rate",'
+        '"recommendation","reservation","search","user"]',
+    ) in zip(bundle.accuracy_command, bundle.accuracy_command[1:], strict=False)
+    assert (
+        "--cleanup-command-json",
+        '["docker","compose","down","-v","--remove-orphans"]',
+    ) in zip(bundle.accuracy_command, bundle.accuracy_command[1:], strict=False)
+    assert ("--candidate-dir", "../../hotelReservation") in zip(
+        bundle.benchmark_command,
+        bundle.benchmark_command[1:],
+        strict=False,
+    )
+    assert (
+        "--run-command-json",
+        '["docker","compose","up","-d","--build"]',
+    ) in zip(bundle.benchmark_command, bundle.benchmark_command[1:], strict=False)
+    assert (
+        "--stop-command-json",
+        '["docker","compose","stop","-t","10","frontend","geo","profile","rate",'
+        '"recommendation","reservation","search","user"]',
+    ) in zip(bundle.benchmark_command, bundle.benchmark_command[1:], strict=False)
+    assert (
+        "--cleanup-command-json",
+        '["docker","compose","down","-v","--remove-orphans"]',
+    ) in zip(bundle.benchmark_command, bundle.benchmark_command[1:], strict=False)
 
 
 @pytest.mark.parametrize(
@@ -111,3 +184,29 @@ def test_social_network_workload_uses_stateful_semantic_operation() -> None:
     assert workload["load"]["seed"] == 42
     assert workload["load"]["fixture_seed"] == 42
     assert workload["constraints"]["min_operations_per_type"] == 1
+
+
+def test_hotel_workload_preserves_canonical_mix_and_stateful_gate() -> None:
+    workload_path = MICROSERVICE_ROOT / "hotel-reservation" / "benchmark" / "workload.toml"
+    with workload_path.open("rb") as file:
+        workload = tomllib.load(file)
+
+    operations = {operation["name"]: operation for operation in workload["operations"]}
+    assert {name: operation["weight"] for name, operation in operations.items()} == {
+        "search_hotels": 600,
+        "recommend_distance": 130,
+        "recommend_rate": 130,
+        "recommend_price": 130,
+        "login_valid": 3,
+        "login_invalid": 2,
+        "reserve_capacity": 5,
+    }
+    assert operations["reserve_capacity"]["tags"] == ["write", "read-your-write"]
+    assert workload["load"]["model"] == "closed_loop"
+    assert workload["load"]["repetitions"] == 3
+    assert workload["profiles"]["quick"]["repetitions"] == 1
+    assert workload["constraints"] == {
+        "min_success_rate": 1.0,
+        "max_error_rate": 0.0,
+        "min_operations_per_type": 1,
+    }


### PR DESCRIPTION
## Problem

VibeSys has a shared microservice evaluation framework and DeathStarBench source,
but no scenario for the Hotel Reservation application. That leaves the Hotel
frontend without a reusable accuracy gate, semantic benchmark adapter, or agent
optimization bundle. Long-lived Compose state also needs lifecycle commands that
can preserve data during an intentional crash/restart while removing it after a
complete evaluation run.

## Solution

Add a Hotel Reservation scenario with a canonical 60% search, 39%
recommendation, 0.5% authentication, and 0.5% stateful reservation mix. Register
typed benchmark and accuracy adapters for `application = "hotel"`.

The accuracy suite uses seeded and randomized inputs and exact independent
oracles for strict GeoJSON/profile data, recommendations, authentication,
negative protocol cases, reservation capacity/isolation/read-your-write, and
crash recovery. The benchmark validates application-level response semantics;
HTTP 200 alone is never counted as success.

Managed lifecycle support now works in benchmark mode and accepts separate stop
and final-cleanup commands. Hotel uses `docker compose stop` for the app services
during crash recovery, then `docker compose down -v --remove-orphans` only when
the entire run closes. Agent framework gates also honor the accuracy and
benchmark timeouts declared in the input manifest.

The materialized DeathStarBench source is ignored and copied into experiment
workspaces, so optimization commits remain outside this pull request. The pinned
DeathStarBench revision already matches its latest upstream default branch
(`master`; upstream does not publish a `main` branch).

### Architecture

```mermaid
flowchart LR
  M["Hotel scenario manifest"] --> A["Agent outer loop"]
  M --> E["Shared servicebench evaluator"]
  E --> C["Fuzzed accuracy adapter"]
  E --> B["Typed mixed-workload benchmark"]
  C --> L["Managed Compose lifecycle"]
  B --> L
  L --> H["Hotel frontend :5000"]
  C --> O["Exact semantic oracles"]
  B --> O
```

## Verification

The optimized experiment candidate was checked with the evaluator-managed
lifecycle. A randomized accuracy run passed 167 checks across six generated
cases and all 13 required properties. A fixed-seed, three-trial benchmark passed
with zero semantic errors at a median 8,444.10 logical operations/s.

### Correctness properties

- Search returns the exact rate-backed hotel set with exact seeded profile
  fields, not a truncated or URL-specific response.
- Distance, rating, and price recommendations use exact independently derived
  result sets across catalog and fuzzed coordinates.
- Valid, invalid, and nonexistent-user authentication cases are distinguished.
- Reservation capacity, optional room count, per-slot isolation, read-your-write,
  and acknowledged-write persistence across a managed restart are enforced.
- Every benchmark trial covers all operation types with success rate 1.0 and
  error rate 0.0.
- Final lifecycle cleanup removes persistent Compose volumes without weakening
  the in-run crash-recovery check.

### Testing

- `uv run pytest -q` — 2,023 passed, 1 platform-specific skip.
- `go test -race ./...` — passed in `examples/evaluators/microservice`.
- `go vet ./...` — passed in `examples/evaluators/microservice`.
- `./scripts/check_types.sh` — 0 errors.
- Ruff check/import/format checks over repository-owned source paths — passed.
- Hotel benchmark and accuracy `--validate-only` commands — passed.
- Managed randomized Hotel accuracy — valid, 167 checks, 6 random cases.
- Managed fixed-seed Hotel benchmark — valid; trials 7,464.92, 8,450.78,
  8,444.10 operations/s; zero failures.
