### PR TITLE
Add structured issue forms and agent filing skill

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: create-issue
+description: Investigate, draft, and file well-scoped VibeSys GitHub issues using the repository issue forms and project conventions. Use when a user asks to create, open, or file a bug report, engineering change, expansion scenario or harness, or research experiment issue, or asks to turn findings, TODOs, or proposed work into GitHub issues.
+---
+
+# Create Issue
+
+## Overview
+
+Create issues only after confirming that the work is not already tracked or
+implemented. Use the same schemas as human reporters, preserve project
+metadata, and leave prioritization to maintainers.
+
+## Workflow
+
+1. Resolve the repository and requested write scope. If the user asks only for
+   a draft, do not create or modify GitHub state.
+2. Read `docs/issue-authoring.md` completely.
+3. Select exactly one matching form and read it completely:
+   - `.github/ISSUE_TEMPLATE/01-bug.yml`
+   - `.github/ISSUE_TEMPLATE/02-engineering-change.yml`
+   - `.github/ISSUE_TEMPLATE/03-expansion-work.yml`
+   - `.github/ISSUE_TEMPLATE/04-experiment.yml`
+4. Search the codebase and both open and closed issues. Check related pull
+   requests when they may show that the behavior is already implemented.
+5. If the request is a duplicate or already implemented, stop before creating
+   an issue. Report the supporting issue, pull request, and code evidence.
+6. Draft an outcome-oriented title and a body with the form's rendered section
+   headings. Keep acceptance criteria observable and testable.
+7. Create the issue through the connected GitHub tooling. Apply the form's
+   labels and redact credentials, tokens, private paths, and sensitive logs.
+8. Add the native parent/sub-issue relationship when a parent is known. A body
+   reference alone is not a substitute for the native relationship.
+9. Verify membership in organization project `uw-syfi/1`. If auto-add did not
+   add the issue and project write access is available, add it explicitly.
+10. Set `Workstream` only when the mapping is unambiguous. Do not set Priority,
+    Effort, assignee, Target date, or milestone unless the user explicitly asks
+    or an established maintainer decision already exists.
+11. Re-read the created issue and verify its title, body, labels, project
+    membership, and parent relationship. Return its URL and any metadata that
+    remains for triage.
+
+## Authoring Rules
+
+- Make one issue represent one independently closable outcome.
+- Lead with the problem, evidence, or research question rather than a proposed
+  implementation.
+- State non-goals for work that could otherwise expand without a clear bound.
+- Use checkboxes for acceptance or success criteria.
+- For expansion work, specify externally observable semantics and correctness
+  checks without prescribing an optimization strategy.
+- For experiments, require a decision, baseline, metric, protocol, stopping
+  condition, and retained artifacts.
+- Link related work using native parents, dependencies, and closing keywords
+  where supported.
+
+## GitHub Boundaries
+
+Prefer connected GitHub tooling for issue search and creation. Use local `gh`
+only for project or hierarchy operations the connector cannot perform. Resolve
+field and option IDs dynamically; never hard-code project item IDs in reusable
+commands.
+
+Do not claim that duplicate searches, code inspection, reproduction, or
+verification occurred unless they actually did.

--- a/.agents/skills/create-issue/agents/openai.yaml
+++ b/.agents/skills/create-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create GitHub Issue"
+  short_description: "File well-scoped VibeSys issues"
+  default_prompt: "Use $create-issue to investigate and file a well-scoped VibeSys GitHub issue."

--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,0 +1,99 @@
+name: Bug report
+description: Report incorrect or unexpected VibeSys behavior.
+labels:
+  - bug
+projects:
+  - uw-syfi/1
+body:
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behavior
+      description: What happened? Include the exact failure or incorrect result.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Provide the smallest command, configuration, or sequence that reproduces the problem.
+      placeholder: |
+        1. Run ...
+        2. Configure ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: subsystem
+    attributes:
+      label: Affected subsystem
+      options:
+        - CLI and packaging
+        - Optimization loop and agents
+        - Backend or execution environment
+        - Profiler or performance evaluation
+        - Evaluator or correctness checker
+        - Example workload
+        - Unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include commit or version, OS, hardware, backend, profiler, and relevant tool versions.
+      placeholder: |
+        Commit:
+        OS:
+        Hardware:
+        Backend:
+        Profiler:
+    validations:
+      required: true
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      description: Describe impact rather than desired priority.
+      options:
+        - Blocks normal use
+        - Major functionality is impaired
+        - Workaround exists
+        - Minor or cosmetic
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Remove credentials, tokens, private paths, and sensitive content.
+      render: shell
+
+  - type: input
+    id: related
+    attributes:
+      label: Related issues or pull requests
+      placeholder: "#123, #456"
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched for an existing issue describing this problem.
+          required: true
+        - label: I removed sensitive information from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/02-engineering-change.yml
+++ b/.github/ISSUE_TEMPLATE/02-engineering-change.yml
@@ -1,0 +1,80 @@
+name: Engineering change
+description: Propose a feature, refactor, performance improvement, or developer-experience change.
+labels:
+  - enhancement
+projects:
+  - uw-syfi/1
+body:
+  - type: dropdown
+    id: workstream
+    attributes:
+      label: Workstream
+      options:
+        - Core/runtime
+        - Platform/backends
+        - CLI/DX
+        - Expansion
+        - Unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is difficult, slow, fragile, missing, or unnecessarily expensive today?
+      placeholder: Include evidence, measurements, code references, or examples when available.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the observable result without unnecessarily prescribing the implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List specific, testable conditions for closing this issue.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+        - [ ] Relevant tests or validation pass
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and non-goals
+      placeholder: |
+        In scope:
+        - ...
+
+        Not in scope:
+        - ...
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints or design considerations
+      description: Record compatibility, architecture, safety, or performance constraints. Proposed solutions are optional.
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification approach
+      description: How should we prove the change works?
+      placeholder: Tests, benchmarks, checker runs, smoke tests, or manual validation.
+    validations:
+      required: true
+
+  - type: input
+    id: dependencies
+    attributes:
+      label: Parent, dependencies, or related work
+      placeholder: "Parent: #123; blocked by: #456"

--- a/.github/ISSUE_TEMPLATE/03-expansion-work.yml
+++ b/.github/ISSUE_TEMPLATE/03-expansion-work.yml
@@ -1,0 +1,93 @@
+name: Expansion scenario or harness
+description: Propose a new VibeSys workload scenario, shared contract, or reusable harness.
+labels:
+  - vibeserve-expansion
+projects:
+  - uw-syfi/1
+body:
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Work item type
+      options:
+        - Scenario
+        - Shared contract or semantics
+        - Reference, benchmark, and checker harness
+    validations:
+      required: true
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent issue
+      description: Identify the area, application, or data-structure parent.
+      placeholder: "#37"
+    validations:
+      required: true
+
+  - type: textarea
+    id: purpose
+    attributes:
+      label: Purpose and motivation
+      description: What realistic system or workload does this represent, and why is it useful?
+    validations:
+      required: true
+
+  - type: textarea
+    id: contract
+    attributes:
+      label: Required behavior or semantic contract
+      description: State what implementations must preserve. Avoid prescribing an optimization strategy.
+      placeholder: |
+        - ...
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: correctness
+    attributes:
+      label: Correctness checks
+      description: What must the checker validate, including failure and concurrency behavior?
+      placeholder: |
+        - ...
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: benchmark
+    attributes:
+      label: Benchmark dimensions
+      description: Identify important workload parameters and reported metrics.
+      placeholder: |
+        Workload parameters:
+        - ...
+
+        Metrics:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: Explicitly exclude adjacent behavior and implementation requirements.
+      placeholder: |
+        - No prescribed implementation strategy.
+        - ...
+
+  - type: textarea
+    id: anchors
+    attributes:
+      label: Research or implementation anchors
+      description: Optional papers, systems, artifacts, or existing examples. These are informative, not prescribed solutions.
+
+  - type: checkboxes
+    id: contract_check
+    attributes:
+      label: Contract check
+      options:
+        - label: The issue defines required behavior without prescribing the implementation.
+          required: true

--- a/.github/ISSUE_TEMPLATE/04-experiment.yml
+++ b/.github/ISSUE_TEMPLATE/04-experiment.yml
@@ -1,0 +1,78 @@
+name: Research experiment
+description: Propose a bounded experiment intended to answer a specific question.
+projects:
+  - uw-syfi/1
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Research question and hypothesis
+      description: State the question and the expected result.
+      placeholder: |
+        Question:
+        Hypothesis:
+    validations:
+      required: true
+
+  - type: textarea
+    id: decision
+    attributes:
+      label: Decision this experiment informs
+      description: What will we do differently depending on the result?
+    validations:
+      required: true
+
+  - type: textarea
+    id: baseline
+    attributes:
+      label: Baseline
+      description: Identify the reference implementation, configuration, and current measurements.
+    validations:
+      required: true
+
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Metrics and success criteria
+      description: Define primary metrics and the threshold for a meaningful result.
+      placeholder: |
+        Primary metric:
+        Secondary metrics:
+        Success threshold:
+    validations:
+      required: true
+
+  - type: textarea
+    id: protocol
+    attributes:
+      label: Experimental protocol
+      description: Describe inputs, hardware, configuration, repetitions, and controlled variables.
+    validations:
+      required: true
+
+  - type: textarea
+    id: stopping
+    attributes:
+      label: Stopping condition
+      description: Define the time, round, cost, or statistical limit that bounds the experiment.
+    validations:
+      required: true
+
+  - type: textarea
+    id: artifacts
+    attributes:
+      label: Required artifacts
+      description: What must be retained so the result can be reviewed or reproduced?
+      placeholder: |
+        - Configuration and commands
+        - Raw measurements
+        - Logs or profiles
+        - Summary and conclusion
+    validations:
+      required: true
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent or related issue
+      placeholder: "#123"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,11 @@ Keep changes narrowly scoped to the requested behavior, preserve existing
 architecture boundaries, and run the smallest relevant checks before handing
 work back.
 
+Before creating a GitHub issue, read
+[`docs/issue-authoring.md`](docs/issue-authoring.md) and the matching form under
+`.github/ISSUE_TEMPLATE/`. Search both the codebase and open and closed issues
+before filing. Use the repo-local `create-issue` skill when it is available.
+
 For `resources/skills/serving-systems/`, also follow the subtree-specific
 authoring guide in
 [`resources/skills/serving-systems/CLAUDE.md`](resources/skills/serving-systems/CLAUDE.md).

--- a/docs/issue-authoring.md
+++ b/docs/issue-authoring.md
@@ -1,0 +1,128 @@
+# Issue Authoring
+
+Use this guide for issues created by people, agents, scripts, or integrations.
+The forms in `.github/ISSUE_TEMPLATE/` are the authoritative schemas.
+
+## Core Rule
+
+One issue describes one independently closable outcome. It should make the
+problem and completion condition clear without requiring the author to choose
+maintainer-owned scheduling metadata.
+
+## Before Filing
+
+1. Search open and closed issues for duplicates and superseded work.
+2. Inspect the relevant code and merged pull requests to confirm the behavior
+   is not already implemented.
+3. Select exactly one issue kind from the routing table below.
+4. Redact credentials, tokens, private paths, and sensitive log content.
+
+If existing code or an issue already resolves the request, update or reference
+that item instead of opening a duplicate.
+
+## Choose an Issue Kind
+
+| Kind | Use for | Form | Default label |
+| --- | --- | --- | --- |
+| Bug report | Incorrect or unexpected behavior | `01-bug.yml` | `bug` |
+| Engineering change | Features, refactors, performance, or developer experience | `02-engineering-change.yml` | `enhancement` |
+| Expansion work | Scenarios, shared contracts, and evaluator harnesses | `03-expansion-work.yml` | `vibeserve-expansion` |
+| Research experiment | A bounded experiment intended to answer a decision-relevant question | `04-experiment.yml` | Set during triage |
+
+Roadmap and area-parent issues are maintainer-authored planning objects. Create
+them only when explicitly requested.
+
+## Titles
+
+Use a specific, outcome-oriented title. Labels already express the issue type,
+so avoid prefixes such as `[Bug]` or `[Feature]`.
+
+Good examples:
+
+- `Skip redundant workspace syncs when inputs are unchanged`
+- `CLI: report missing backend dependencies in vibesys doctor`
+- `Queue: MPMC bounded retryable-BUSY FIFO scenario`
+- `Simulator: validate latency estimates against CUDA traces`
+
+Avoid vague titles such as `Improve performance`, `Fix CLI`, or `Simulator
+work`.
+
+## Required Schemas
+
+API-created issues must render the form labels below as Markdown headings.
+Omit an optional section only when it has no useful content.
+
+### Bug Report
+
+- Observed behavior
+- Expected behavior
+- Reproduction
+- Affected subsystem
+- Environment
+- Impact
+- Relevant logs
+- Related issues or pull requests
+
+### Engineering Change
+
+- Workstream
+- Problem
+- Desired outcome
+- Acceptance criteria
+- Scope and non-goals
+- Constraints or design considerations
+- Verification approach
+- Parent, dependencies, or related work
+
+### Expansion Scenario or Harness
+
+- Work item type
+- Parent issue
+- Purpose and motivation
+- Required behavior or semantic contract
+- Correctness checks
+- Benchmark dimensions
+- Non-goals
+- Research or implementation anchors
+
+### Research Experiment
+
+- Research question and hypothesis
+- Decision this experiment informs
+- Baseline
+- Metrics and success criteria
+- Experimental protocol
+- Stopping condition
+- Required artifacts
+- Parent or related issue
+
+## Metadata
+
+- **Labels** classify durable technical properties and issue kind.
+- **Workstream** identifies the broad organizational home.
+- **Status** records execution state.
+- **Parent/sub-issue relationships** define hierarchy and progress.
+- **Priority, Effort, assignee, milestone, and Target date** are maintainer
+  triage decisions. Do not ask reporters to guess them.
+
+New issues enter `Backlog`. Move an issue to `Ready` only when its outcome and
+acceptance criteria are clear, dependencies are understood, and it can be
+started without another discovery pass.
+
+Use the following Workstream defaults when the mapping is clear:
+
+- Expansion work: `Expansion`
+- Research experiment: `Research/experiments`
+- Engineering change: the exact value selected in its Workstream field
+- Bug report: infer from the affected subsystem, or leave unset for triage
+
+## Agent and API Checklist
+
+When an issue is not submitted through the web form:
+
+1. Follow the matching form's labels and section order.
+2. Create a native parent/sub-issue relationship when a parent is known.
+3. Verify the issue appears in the `uw-syfi/1` VibeSys Work project.
+4. Set Workstream when unambiguous; leave scheduling fields for triage.
+5. Re-read the created issue and verify its title, body, labels, project, and
+   parent relationship.


### PR DESCRIPTION
## Problem

VibeSys expects to file substantially more issues, but the repository has no issue forms or shared authoring contract. Human reports can omit information needed for triage, while API-created agent issues can bypass web-form validation entirely. That increases duplicate issues, already-implemented requests, inconsistent metadata, and open-ended experiment or expansion work.

## Solution

Add one issue-authoring system shared by people and agents:

- four GitHub issue forms for bugs, engineering changes, expansion work, and research experiments;
- a common `docs/issue-authoring.md` contract for titles, schemas, metadata ownership, and API-created issues;
- a repo-local `create-issue` skill that searches code plus open and closed issues before filing and verifies labels, project membership, and native parent relationships;
- root `AGENTS.md` routing so agents discover the guide and skill;
- a chooser configuration that directs contributors through the forms while preserving maintainer-only blank issue access.

The forms route submissions to organization project `uw-syfi/1`. Priority, Effort, assignee, milestone, and Target date remain maintainer triage decisions.

### Architecture

```mermaid
flowchart LR
    H["Human reporter"] --> F["GitHub issue form"]
    A["Agent or API client"] --> S["create-issue skill"]
    S --> G["Authoring guide"]
    S --> F
    F --> I["Structured GitHub issue"]
    I --> P["VibeSys Work project"]
```

The issue forms are the authoritative schemas. The guide explains how non-UI clients render those schemas, and the skill owns the investigation and GitHub mutation workflow without duplicating the form definitions.

## Verification

Validated the skill scaffold and metadata, parsed and structurally checked every issue form, confirmed the referenced project and default labels exist, reviewed the staged behavior diff, and checked whitespace.

### Correctness properties

- Every web form routes to `uw-syfi/1`.
- Bug, engineering, and expansion forms reference labels that already exist.
- Required form controls have unique IDs and supported types.
- Agent-created issues use the same headings and metadata rules as web-created issues.
- Agents stop before filing when code or existing issues show the request is implemented or duplicated.
- Native parent relationships and project membership are verified after agent creation.
- Reporters are not asked to guess maintainer-owned scheduling metadata.
- Experiment and expansion work have explicit correctness or stopping boundaries.

### Testing

- `uv run --with pyyaml python /home/shli/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/create-issue` — passed: `Skill is valid!`
- Custom PyYAML structural validation over all four forms and `config.yml` — passed: `Validated 4 issue forms and config.yml`
- `gh label list --repo uw-syfi/vibesys ...` — confirmed `bug`, `enhancement`, and `vibeserve-expansion`
- `gh project view 1 --owner uw-syfi ...` — confirmed project `VibeSys Work`
- `git diff --staged --check` — passed
