### PR TITLE
Add pinned git workspace sources

### DIFF
--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -34,6 +34,7 @@ from vibesys.domains.environment import (
     NoopEnvironmentHooks,
 )
 from vibesys.errors import ConfigurationDiagnostic, ConfigurationError
+from vibesys.input_manifest import WorkspaceSource
 from vibesys.llm_client import build_model
 from vibesys.profilers import (
     ACTIVE_PROFILER_KINDS,
@@ -169,6 +170,7 @@ def create_run_context(
     accuracy_command: str,
     benchmark_command: str,
     workspace_seed: Path | None = None,
+    workspace_sources: tuple[WorkspaceSource, ...] = (),
     evaluator_path: Path | None = None,
     existing: bool = False,
     trusted_input_baseline: str | None = None,
@@ -357,6 +359,7 @@ def create_run_context(
         input_project_dir=input_project_dir,
         profiler_support_path=profiler_support_path,
         profiler_support_name=profiler_support_name,
+        workspace_sources=workspace_sources,
         extra_input_excludes=environment_patch.copy_excludes,
     )
     workspace_files.setup(plan, existing=existing)

--- a/src/vibesys/input_manifest.py
+++ b/src/vibesys/input_manifest.py
@@ -6,8 +6,9 @@ import shlex
 import tomllib
 from pathlib import Path
 from typing import Literal
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from vibesys.constants import PROJECT_ROOT
 from vibesys.domains.base import DomainName
@@ -41,15 +42,70 @@ class WorkspaceInput(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    seed: str
+    seed: str | None = None
+    sources: tuple[WorkspaceSource, ...] = ()
 
     @field_validator("seed")
     @classmethod
-    def _relative_seed(cls, value: str) -> str:
+    def _relative_seed(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         if not value.strip():
             raise ValueError("seed must be a non-empty path")
         if Path(value).is_absolute():
             raise ValueError("seed must be relative to the input bundle")
+        return value
+
+
+class WorkspaceSource(BaseModel):
+    """Pinned git source materialized into the mutable candidate workspace."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    repo: str
+    commit: str
+    dest: str
+    strip_git: bool = True
+
+    @field_validator("name")
+    @classmethod
+    def _valid_name(cls, value: str) -> str:
+        if not value:
+            raise ValueError("name must be non-empty")
+        if any(character.isspace() for character in value):
+            raise ValueError("name must not contain whitespace")
+        return value
+
+    @field_validator("repo")
+    @classmethod
+    def _valid_repo(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("repo must be non-empty")
+        parsed = urlparse(value)
+        if parsed.scheme and parsed.scheme not in {"file", "http", "https", "ssh", "git"}:
+            raise ValueError(f"unsupported repo URL scheme: {parsed.scheme}")
+        return value
+
+    @field_validator("commit")
+    @classmethod
+    def _valid_commit(cls, value: str) -> str:
+        if not value:
+            raise ValueError("commit must be non-empty")
+        if not (7 <= len(value) <= 64) or any(c not in "0123456789abcdefABCDEF" for c in value):
+            raise ValueError("commit must be a 7-64 character hexadecimal hash")
+        return value.lower()
+
+    @field_validator("dest")
+    @classmethod
+    def _relative_dest(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("dest must be a non-empty path")
+        path = Path(value)
+        if path.is_absolute():
+            raise ValueError("dest must be relative to the workspace")
+        if any(part in {"", ".", ".."} for part in path.parts):
+            raise ValueError("dest must not contain empty, current, or parent path components")
         return value
 
 
@@ -119,6 +175,21 @@ class InputManifest(BaseModel):
     workspace: WorkspaceInput | None = None
     evaluator: EvaluatorInput | None = None
 
+    @model_validator(mode="after")
+    def _unique_workspace_source_destinations(self) -> InputManifest:
+        if self.workspace is None:
+            return self
+        seen_names: set[str] = set()
+        seen_dests: set[str] = set()
+        for source in self.workspace.sources:
+            if source.name in seen_names:
+                raise ValueError(f"duplicate workspace source name: {source.name}")
+            if source.dest in seen_dests:
+                raise ValueError(f"duplicate workspace source destination: {source.dest}")
+            seen_names.add(source.name)
+            seen_dests.add(source.dest)
+        return self
+
 
 class InputBundle(BaseModel):
     """Resolved input bundle with manifest commands and conventional files."""
@@ -160,6 +231,12 @@ class InputBundle(BaseModel):
     @property
     def benchmark_result(self) -> BenchmarkResult | None:
         return self.manifest.benchmark.result
+
+    @property
+    def workspace_sources(self) -> tuple[WorkspaceSource, ...]:
+        if self.manifest.workspace is None:
+            return ()
+        return self.manifest.workspace.sources
 
 
 def load_input_bundle(
@@ -223,7 +300,11 @@ def load_input_bundle(
         reference_path = None
 
     workspace_seed_path = None
-    if manifest.workspace is not None and not allow_materialized_sources:
+    if (
+        manifest.workspace is not None
+        and manifest.workspace.seed is not None
+        and not allow_materialized_sources
+    ):
         starters_root = (project_root / "examples" / "starters").resolve()
         workspace_seed_path = (root / manifest.workspace.seed).resolve()
         try:

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -22,7 +22,7 @@ from vibesys.context import create_run_context
 from vibesys.domains.base import DomainDefinition, DomainName, DomainRole
 from vibesys.domains.registry import resolve_domain
 from vibesys.domains.rendering import render_domain_section
-from vibesys.input_manifest import BenchmarkResult
+from vibesys.input_manifest import BenchmarkResult, WorkspaceSource
 from vibesys.loops.agent import issue_board
 from vibesys.loops.profiler import invoke_profiler
 from vibesys.profilers import (
@@ -857,6 +857,7 @@ def run_agent_loop(
     objective: str,
     *,
     workspace_seed: Path | None = None,
+    workspace_sources: tuple[WorkspaceSource, ...] = (),
     evaluator_path: Path | None = None,
     benchmark_result: BenchmarkResult | None = None,
     accuracy_timeout_seconds: int | None = None,
@@ -930,6 +931,7 @@ def run_agent_loop(
         accuracy_command=accuracy_command,
         benchmark_command=benchmark_command,
         workspace_seed=workspace_seed,
+        workspace_sources=workspace_sources,
         evaluator_path=evaluator_path,
         existing=existing,
         trusted_input_baseline=trusted_input_baseline,

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -45,6 +45,7 @@ from vibesys.context import create_candidate_context, create_run_context
 from vibesys.domains.base import DomainDefinition, DomainName, DomainRole
 from vibesys.domains.registry import resolve_domain
 from vibesys.domains.rendering import render_domain_section
+from vibesys.input_manifest import WorkspaceSource
 from vibesys.loops.evolve.population import (
     Individual,
     Objective,
@@ -1182,6 +1183,7 @@ def run_evolve_loop(
     objective: str,
     *,
     workspace_seed: Path | None = None,
+    workspace_sources: tuple[WorkspaceSource, ...] = (),
     evaluator_path: Path | None = None,
     max_generations: int = 8,
     children_per_generation: int = 2,
@@ -1240,6 +1242,7 @@ def run_evolve_loop(
         accuracy_command=accuracy_command,
         benchmark_command=benchmark_command,
         workspace_seed=workspace_seed,
+        workspace_sources=workspace_sources,
         evaluator_path=evaluator_path,
         existing=existing,
         debug=debug,

--- a/src/vibesys/loops/plain/loop.py
+++ b/src/vibesys/loops/plain/loop.py
@@ -34,6 +34,7 @@ from vibesys.config import Config, as_config
 from vibesys.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibesys.context import create_run_context
 from vibesys.domains.llm_serving.hooks import LLMServingEnvironmentHooks
+from vibesys.input_manifest import WorkspaceSource
 from vibesys.loops.plain.render import render_all
 from vibesys.loops.plain.runner_ext import PlainLoopAgentRunner
 from vibesys.profilers import ProfilerKind
@@ -348,6 +349,7 @@ def run_plain_loop(
     benchmark_command: str,
     *,
     workspace_seed: Path | None = None,
+    workspace_sources: tuple[WorkspaceSource, ...] = (),
     evaluator_path: Path | None = None,
     max_rounds: int = 5,
     max_attempts_per_issue: int = 3,
@@ -384,6 +386,7 @@ def run_plain_loop(
         accuracy_command=accuracy_command,
         benchmark_command=benchmark_command,
         workspace_seed=workspace_seed,
+        workspace_sources=workspace_sources,
         evaluator_path=evaluator_path,
         existing=existing,
         debug=debug,

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -726,6 +726,8 @@ def _run_validate(argv: list[str]) -> None:
     print(f"  benchmark command: {bundle.benchmark_command_display}")
     if bundle.workspace_seed_path is not None:
         print(f"  workspace seed: {bundle.workspace_seed_path}")
+    for source in bundle.workspace_sources:
+        print(f"  workspace source: {source.name} -> {source.dest} @ {source.commit}")
     if bundle.evaluator_path is not None:
         print(f"  evaluator source: {bundle.evaluator_path}")
     if bundle.benchmark_result is not None:
@@ -903,6 +905,7 @@ def _run_agent(args: argparse.Namespace) -> None:
         accuracy_command=bundle.accuracy_command_display,
         benchmark_command=bundle.benchmark_command_display,
         workspace_seed=bundle.workspace_seed_path,
+        workspace_sources=bundle.workspace_sources,
         evaluator_path=bundle.evaluator_path,
         benchmark_result=bundle.benchmark_result,
         accuracy_timeout_seconds=bundle.manifest.accuracy.timeout_seconds,
@@ -1217,6 +1220,7 @@ def _run_evolve(args: argparse.Namespace) -> None:
         accuracy_command=bundle.accuracy_command_display,
         benchmark_command=bundle.benchmark_command_display,
         workspace_seed=bundle.workspace_seed_path,
+        workspace_sources=bundle.workspace_sources,
         evaluator_path=bundle.evaluator_path,
         objective=objective,
         max_generations=args.max_generations,
@@ -1337,6 +1341,7 @@ def _run_plain(args: argparse.Namespace) -> None:
         accuracy_command=bundle.accuracy_command_display,
         benchmark_command=bundle.benchmark_command_display,
         workspace_seed=bundle.workspace_seed_path,
+        workspace_sources=bundle.workspace_sources,
         evaluator_path=bundle.evaluator_path,
         max_rounds=args.max_rounds,
         max_attempts_per_issue=args.max_attempts_per_issue,

--- a/src/vibesys/run/workspace.py
+++ b/src/vibesys/run/workspace.py
@@ -9,6 +9,7 @@ declarative :class:`CopySpec` / :class:`InputProjectSpec` records first
 on the plan without materializing anything.
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -17,6 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from vibesys.input_manifest import WorkspaceSource
 from vibesys.input_project import materialize_input_project
 
 if TYPE_CHECKING:
@@ -84,7 +86,14 @@ class InputProjectSpec:
     project_dir: Path
 
 
-WorkspaceStep = CopySpec | InputProjectSpec
+@dataclass(frozen=True)
+class GitSourceSpec:
+    """Materialize a pinned git source into the candidate workspace."""
+
+    source: WorkspaceSource
+
+
+WorkspaceStep = CopySpec | InputProjectSpec | GitSourceSpec
 
 
 class Workspace:
@@ -135,6 +144,7 @@ class Workspace:
         input_project_dir: Path | None,
         profiler_support_path: str | None,
         profiler_support_name: str | None,
+        workspace_sources: tuple[WorkspaceSource, ...] = (),
         extra_input_excludes: frozenset[str] = frozenset(),
     ) -> tuple[WorkspaceStep, ...]:
         """Build the ordered copy plan for ``setup``.
@@ -165,6 +175,9 @@ class Workspace:
         if not existing:
             if seed is not None:
                 steps.append(CopySpec(src=seed, dest=self.root, respect_gitignore=True))
+            for source in workspace_sources:
+                steps.append(GitSourceSpec(source=source))
+            if seed is not None:
                 steps.append(
                     CopySpec(
                         src=input_dir,
@@ -232,6 +245,9 @@ class Workspace:
                     log=self._log,
                 )
                 continue
+            if isinstance(step, GitSourceSpec):
+                self.materialize_git_source(step.source)
+                continue
             if step.require_absent is not None and (
                 step.require_absent.exists() or step.require_absent.is_symlink()
             ):
@@ -243,6 +259,64 @@ class Workspace:
                 respect_source_gitignore=step.respect_gitignore,
                 reject_collisions=step.reject_collisions,
             )
+
+    def materialize_git_source(self, source: WorkspaceSource) -> None:
+        """Clone a pinned git source into the workspace and optionally strip ``.git``."""
+
+        dest = self.root / source.dest
+        try:
+            dest.resolve().relative_to(self.root.resolve())
+        except ValueError as exc:
+            raise ValueError(
+                f"workspace source {source.name!r} escapes workspace: {source.dest}"
+            ) from exc
+        if dest.exists() or dest.is_symlink():
+            raise ValueError(
+                f"workspace source destination already exists for {source.name!r}: {source.dest}"
+            )
+        dest.parent.mkdir(parents=True, exist_ok=True)
+
+        self._run_git(["clone", "--no-checkout", source.repo, str(dest)], cwd=self.root)
+        self._run_git(["checkout", "--detach", source.commit], cwd=dest)
+        actual = self._run_git(["rev-parse", "HEAD"], cwd=dest).strip().lower()
+        expected = source.commit.lower()
+        if actual != expected and not actual.startswith(expected):
+            raise RuntimeError(
+                f"workspace source {source.name!r} checked out {actual}, expected {expected}"
+            )
+
+        metadata_path = self.root / "_vibesys_sources.json"
+        metadata = []
+        if metadata_path.is_file():
+            metadata = json.loads(metadata_path.read_text())
+        metadata.append(
+            {
+                "name": source.name,
+                "repo": source.repo,
+                "commit": actual,
+                "requested_commit": source.commit,
+                "dest": source.dest,
+                "strip_git": source.strip_git,
+            }
+        )
+        metadata_path.write_text(json.dumps(metadata, indent=2) + "\n")
+
+        if source.strip_git:
+            shutil.rmtree(dest / ".git")
+
+    @staticmethod
+    def _run_git(args: list[str], *, cwd: Path) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip()
+            raise RuntimeError(f"git {' '.join(args)} failed: {detail}")
+        return result.stdout
 
     # -- copy machinery -------------------------------------------------------
 

--- a/tests/test_workspace_seed.py
+++ b/tests/test_workspace_seed.py
@@ -13,7 +13,7 @@ from vibesys.constants import DEFAULT_COMPUTE_BACKEND
 from vibesys.context import _RunContext, create_run_context
 from vibesys.domains.base import DomainName
 from vibesys.domains.environment import NoopEnvironmentHooks
-from vibesys.input_manifest import load_input_bundle
+from vibesys.input_manifest import WorkspaceSource, load_input_bundle
 from vibesys.main import main
 from vibesys.profilers import ProfilerKind
 from vibesys.run import Workspace
@@ -61,6 +61,31 @@ def _init_git_repo(path: Path) -> None:
     subprocess.run(["git", "init", "-q", str(path)], check=True)
 
 
+def _commit_all(path: Path, message: str = "init") -> str:
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=VibeSys Test",
+            "-c",
+            "user.email=vibesys@example.invalid",
+            "commit",
+            "-qm",
+            message,
+        ],
+        cwd=path,
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
 @contextmanager
 def _patched_context_dependencies(project_root: Path):
     with (
@@ -80,6 +105,7 @@ def _make_context(input_dir: Path, seed: Path | None = None, **kwargs) -> _RunCo
         accuracy_command="accuracy-checker",
         benchmark_command="benchmark",
         workspace_seed=seed,
+        workspace_sources=kwargs.pop("workspace_sources", ()),
         profiler_kind=ProfilerKind.NONE,
         skills_dirs=[],
         run_environment=RunEnvironmentSpec("local"),
@@ -118,6 +144,98 @@ def test_manifest_resolves_seed_relative_to_bundle(tmp_path):
     loaded = load_input_bundle(bundle, project_root=project_root)
 
     assert loaded.workspace_seed_path == seed.resolve()
+
+
+def test_manifest_resolves_workspace_sources(tmp_path):
+    project_root = tmp_path / "project"
+    seed = project_root / "examples" / "starters" / "queue"
+    seed.mkdir(parents=True)
+    bundle = _write_bundle(
+        project_root,
+        """
+[workspace]
+seed = "../../starters/queue"
+
+[[workspace.sources]]
+name = "vllm"
+repo = "https://github.com/vllm-project/vllm.git"
+commit = "0123456789abcdef0123456789abcdef01234567"
+dest = "vllm"
+""",
+    )
+
+    loaded = load_input_bundle(bundle, project_root=project_root)
+
+    assert loaded.workspace_seed_path == seed.resolve()
+    assert loaded.workspace_sources == (
+        WorkspaceSource(
+            name="vllm",
+            repo="https://github.com/vllm-project/vllm.git",
+            commit="0123456789abcdef0123456789abcdef01234567",
+            dest="vllm",
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("source_block", "error"),
+    [
+        (
+            'name = "vllm"\nrepo = "https://github.com/vllm-project/vllm.git"\n'
+            'commit = "main"\ndest = "vllm"',
+            "commit must be a 7-64 character hexadecimal hash",
+        ),
+        (
+            'name = "vllm"\nrepo = "https://github.com/vllm-project/vllm.git"\n'
+            'commit = "0123456"\ndest = "../vllm"',
+            "dest must not contain",
+        ),
+        (
+            'name = "vllm"\nrepo = "ftp://example.invalid/vllm.git"\n'
+            'commit = "0123456"\ndest = "vllm"',
+            "unsupported repo URL scheme",
+        ),
+    ],
+)
+def test_manifest_rejects_invalid_workspace_sources(tmp_path, source_block, error):
+    project_root = tmp_path / "project"
+    bundle = _write_bundle(
+        project_root,
+        f"""
+[workspace]
+
+[[workspace.sources]]
+{source_block}
+""",
+    )
+
+    with pytest.raises(ValueError, match=error):
+        load_input_bundle(bundle, project_root=project_root)
+
+
+def test_manifest_rejects_duplicate_workspace_source_destinations(tmp_path):
+    project_root = tmp_path / "project"
+    bundle = _write_bundle(
+        project_root,
+        """
+[workspace]
+
+[[workspace.sources]]
+name = "first"
+repo = "https://example.invalid/first.git"
+commit = "0123456"
+dest = "src"
+
+[[workspace.sources]]
+name = "second"
+repo = "https://example.invalid/second.git"
+commit = "abcdef0"
+dest = "src"
+""",
+    )
+
+    with pytest.raises(ValueError, match="duplicate workspace source destination"):
+        load_input_bundle(bundle, project_root=project_root)
 
 
 def test_manifest_resolves_evaluator_relative_to_bundle(tmp_path):
@@ -320,6 +438,107 @@ def test_fresh_workspace_materializes_seed_and_preserves_it_in_initial_commit(tm
             assert ctx.trusted_input_changes() == ["_evaluator/queue/checker.go"]
 
 
+def test_fresh_workspace_materializes_git_source_and_strips_nested_git(tmp_path):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _init_git_repo(project_root)
+
+    source_repo = tmp_path / "source-vllm"
+    source_repo.mkdir()
+    _init_git_repo(source_repo)
+    (source_repo / "vllm").mkdir()
+    (source_repo / "vllm" / "__init__.py").write_text("__version__ = 'test'\n")
+    commit = _commit_all(source_repo)
+
+    seed = project_root / "examples" / "starters" / "vllm-h100"
+    seed.mkdir(parents=True)
+    (seed / "serve.py").write_text("print('serve')\n")
+
+    input_dir = project_root / "examples" / "model-serving" / "llama-vllm"
+    input_dir.mkdir(parents=True)
+    (input_dir / "OBJECTIVE.md").write_text("Optimize vLLM.\n")
+    (input_dir / "vibesys.input.toml").write_text("version = 1\n")
+
+    source = WorkspaceSource(
+        name="vllm",
+        repo=str(source_repo),
+        commit=commit,
+        dest="vllm",
+    )
+
+    with _patched_context_dependencies(project_root):
+        with _make_context(
+            input_dir,
+            seed,
+            workspace_sources=(source,),
+            git_tracking=True,
+        ) as ctx:
+            assert (ctx.workspace / "serve.py").is_file()
+            assert (ctx.workspace / "vllm" / "vllm" / "__init__.py").read_text() == (
+                "__version__ = 'test'\n"
+            )
+            assert not (ctx.workspace / "vllm" / ".git").exists()
+
+            metadata = (ctx.workspace / "_vibesys_sources.json").read_text()
+            assert str(source_repo) in metadata
+            assert commit in metadata
+
+            tracked = subprocess.run(
+                ["git", "ls-files"],
+                cwd=ctx.workspace,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.splitlines()
+            assert "vllm/vllm/__init__.py" in tracked
+            assert "vllm/.git" not in tracked
+
+
+def test_workspace_source_destination_collision_is_rejected(tmp_path):
+    source_repo = tmp_path / "source"
+    source_repo.mkdir()
+    _init_git_repo(source_repo)
+    (source_repo / "src.py").write_text("pass\n")
+    commit = _commit_all(source_repo)
+
+    seed = tmp_path / "seed"
+    input_dir = tmp_path / "input"
+    workspace = tmp_path / "workspace"
+    seed.mkdir()
+    _init_git_repo(seed)
+    input_dir.mkdir()
+    (seed / "vllm").mkdir()
+    (seed / "vllm" / "placeholder.txt").write_text("seed\n")
+    _commit_all(seed)
+    (input_dir / "OBJECTIVE.md").write_text("objective\n")
+
+    workspace_files = Workspace(
+        workspace,
+        run_environment=MagicMock(isolated=False),
+        backend=MagicMock(),
+        log=MagicMock(),
+        project_root=tmp_path,
+        excluded_dirs=set(),
+    )
+    workspace_files.create()
+    plan = workspace_files.plan_setup(
+        existing=False,
+        seed=seed,
+        input_dir=input_dir,
+        evaluator_source=None,
+        skill_sources=[],
+        input_project_dir=None,
+        profiler_support_path=None,
+        profiler_support_name=None,
+        workspace_sources=(
+            WorkspaceSource(name="vllm", repo=str(source_repo), commit=commit, dest="vllm"),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="destination already exists"):
+        workspace_files.setup(plan, existing=False)
+
+
 def test_input_collision_is_rejected_before_overlay(tmp_path):
     seed = tmp_path / "seed"
     input_dir = tmp_path / "input"
@@ -414,6 +633,11 @@ def test_cli_forwards_workspace_sources_to_every_outer_loop(tmp_path, outer_loop
     bundle = _write_bundle(
         project_root,
         '[workspace]\nseed = "../../starters/queue"\n\n'
+        "[[workspace.sources]]\n"
+        'name = "vllm"\n'
+        'repo = "https://github.com/vllm-project/vllm.git"\n'
+        'commit = "0123456789abcdef0123456789abcdef01234567"\n'
+        'dest = "vllm"\n\n'
         '[evaluator]\nsource = "../../evaluators/queue"',
     )
     argv = ["vibesys", "--outer-loop", outer_loop, "--input", str(bundle)]
@@ -434,6 +658,14 @@ def test_cli_forwards_workspace_sources_to_every_outer_loop(tmp_path, outer_loop
         main()
 
     assert runner.call_args.kwargs["workspace_seed"] == seed.resolve()
+    assert runner.call_args.kwargs["workspace_sources"] == (
+        WorkspaceSource(
+            name="vllm",
+            repo="https://github.com/vllm-project/vllm.git",
+            commit="0123456789abcdef0123456789abcdef01234567",
+            dest="vllm",
+        ),
+    )
     assert runner.call_args.kwargs["evaluator_path"] == evaluator.resolve()
     if outer_loop in {"agent", "evolve"}:
         assert runner.call_args.kwargs["domain"] is DomainName.GENERIC


### PR DESCRIPTION
## Problem

Input bundles can currently copy local starter directories, but they cannot declare a pinned external source tree for candidate code. That makes large mutable dependencies like vLLM awkward: vendoring bloats the repo, while cloning manually inside a starter is less reproducible and can leave nested git repos that hide candidate diffs from the experiment history.

## Solution

Add `workspace.sources` to input manifests. Each source declares a name, git repo, hexadecimal commit hash, destination, and whether to strip the nested `.git` directory. Fresh workspace setup now copies the optional seed, materializes pinned git sources, then overlays the input bundle with the existing collision protection.

### Architecture

`input_manifest.py` owns the typed manifest contract and validation. `Workspace.plan_setup()` converts loaded sources into `GitSourceSpec` steps. `Workspace.materialize_git_source()` performs clone, detached checkout, hash verification, metadata recording in `_vibesys_sources.json`, and `.git` removal when requested. The CLI and all outer loops forward the loaded source specs through `create_run_context()`.

## Verification

Ran focused manifest/workspace validation and formatting/lint checks.

### Correctness properties

- Source destinations must be relative workspace paths and cannot contain parent-directory components.
- Source commits must be pinned hexadecimal hashes, not branch names.
- Duplicate source names or destinations are rejected.
- Checkout verifies the resolved HEAD against the requested commit before stripping `.git`.
- Resume behavior remains unchanged: existing workspaces are not recloned or refreshed.

### Testing

- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_workspace_seed.py -q` -> 29 passed
- `./scripts/check_format.sh` -> passed
- `.venv/bin/python -m ruff check src/vibesys/input_manifest.py src/vibesys/run/workspace.py src/vibesys/context.py src/vibesys/loops/agent/loop.py src/vibesys/loops/evolve/loop.py src/vibesys/loops/plain/loop.py tests/test_workspace_seed.py` -> passed