### PR TITLE
Preserve workspace config during temporary MCP injection

### DIFF
--- a/src/vibesys/_agent_cli/base.py
+++ b/src/vibesys/_agent_cli/base.py
@@ -1,4 +1,6 @@
 import json
+import os
+import tempfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -28,6 +30,43 @@ class MCPServerSpec:
 
     env: dict[str, str] = field(default_factory=dict)
     """Optional environment variables for the spawned MCP server process."""
+
+
+@dataclass(frozen=True)
+class _MCPConfigBackup:
+    original_bytes: bytes | None
+    original_config: dict[str, Any]
+    installed_config: dict[str, Any]
+    server_key: str
+
+
+_MISSING = object()
+
+
+def _atomic_write(target: Path, content: bytes) -> None:
+    """Replace *target* without exposing a partially written config file."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    mode = target.stat().st_mode if target.exists() else None
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+        if mode is not None:
+            os.chmod(temporary_path, mode)
+        os.replace(temporary_path, target)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def _load_json_object(raw: bytes, target: Path) -> dict[str, Any]:
+    try:
+        loaded: object = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot merge MCP servers into invalid JSON config: {target}") from exc
+    if not isinstance(loaded, dict):
+        raise ValueError(f"MCP config must contain a JSON object: {target}")
+    return dict(cast(dict[str, Any], loaded))
 
 
 class CodingAgent(ABC):
@@ -64,22 +103,13 @@ class CodingAgent(ABC):
         backups = getattr(self, "_mcp_config_backups", None)
         if backups is None:
             backups = {}
-            self._mcp_config_backups: dict[Path, bytes | None] = backups
+            self._mcp_config_backups: dict[Path, _MCPConfigBackup] = backups
         if target in backups:
             raise RuntimeError(f"temporary MCP config is already installed at {target}")
 
         original = target.read_bytes() if target.exists() else None
-        config: dict[str, Any] = {}
-        if original is not None:
-            try:
-                loaded: object = json.loads(original)
-            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-                raise ValueError(
-                    f"cannot merge MCP servers into invalid JSON config: {target}"
-                ) from exc
-            if not isinstance(loaded, dict):
-                raise ValueError(f"MCP config must contain a JSON object: {target}")
-            config = dict(cast(dict[str, Any], loaded))
+        original_config = _load_json_object(original, target) if original is not None else {}
+        config = dict(original_config)
 
         existing_servers = config.get(server_key, {})
         if not isinstance(existing_servers, dict):
@@ -92,9 +122,18 @@ class CodingAgent(ABC):
             **server_config,
         }
 
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(json.dumps(config, indent=2), encoding="utf-8")
-        backups[target] = original
+        backup = _MCPConfigBackup(
+            original_bytes=original,
+            original_config=original_config,
+            installed_config=config,
+            server_key=server_key,
+        )
+        backups[target] = backup
+        try:
+            _atomic_write(target, json.dumps(config, indent=2).encode())
+        except BaseException:
+            del backups[target]
+            raise
 
     def _restore_mcp_config_file(self, target: Path) -> None:
         """Restore a config saved by :meth:`_install_mcp_config_file`."""
@@ -102,12 +141,63 @@ class CodingAgent(ABC):
         if backups is None or target not in backups:
             return
 
-        original = backups[target]
-        if original is None:
-            if target.exists():
+        backup = backups[target]
+        if not target.exists():
+            # Deletion during the invocation is a workspace edit, not something
+            # cleanup should silently undo.
+            del backups[target]
+            return
+
+        current = _load_json_object(target.read_bytes(), target)
+        if current == backup.installed_config:
+            if backup.original_bytes is None:
                 target.unlink()
+            else:
+                _atomic_write(target, backup.original_bytes)
+            del backups[target]
+            return
+
+        original_servers = backup.original_config.get(backup.server_key, {})
+        installed_servers = backup.installed_config.get(backup.server_key, {})
+        current_servers = current.get(backup.server_key, {})
+        if not all(isinstance(value, dict) for value in (original_servers, installed_servers)):
+            raise ValueError(f"{backup.server_key!r} must be a JSON object in MCP config: {target}")
+        if not isinstance(current_servers, dict):
+            raise ValueError(f"{backup.server_key!r} must be a JSON object in MCP config: {target}")
+
+        restored_servers = dict(cast(dict[str, Any], current_servers))
+        original_server_map = cast(dict[str, Any], original_servers)
+        for name, installed_value in cast(dict[str, Any], installed_servers).items():
+            original_value = original_server_map.get(name, _MISSING)
+            if installed_value == original_value:
+                continue
+            if restored_servers.get(name, _MISSING) != installed_value:
+                continue
+            if original_value is _MISSING:
+                restored_servers.pop(name, None)
+            else:
+                restored_servers[name] = original_value
+
+        if restored_servers or backup.server_key in backup.original_config:
+            current[backup.server_key] = restored_servers
         else:
-            target.write_bytes(original)
+            current.pop(backup.server_key, None)
+
+        for key, installed_value in backup.installed_config.items():
+            if key == backup.server_key:
+                continue
+            original_value = backup.original_config.get(key, _MISSING)
+            if installed_value == original_value or current.get(key, _MISSING) != installed_value:
+                continue
+            if original_value is _MISSING:
+                current.pop(key, None)
+            else:
+                current[key] = original_value
+
+        if current:
+            _atomic_write(target, json.dumps(current, indent=2).encode())
+        else:
+            target.unlink()
         del backups[target]
 
     @abstractmethod

--- a/src/vibesys/_agent_cli/base.py
+++ b/src/vibesys/_agent_cli/base.py
@@ -1,7 +1,8 @@
+import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from vs_sandbox import WorkspaceSandbox
 
@@ -44,6 +45,70 @@ class CodingAgent(ABC):
     # Optional OS-level confinement for host execution (issue #149); set by
     # the cli runner on the host path, left as None under container executors.
     sandbox: WorkspaceSandbox | None
+
+    def _install_mcp_config_file(
+        self,
+        target: Path,
+        *,
+        server_key: str,
+        server_config: dict[str, dict[str, Any]],
+        defaults: dict[str, Any] | None = None,
+    ) -> None:
+        """Temporarily merge MCP servers into a JSON config file.
+
+        The original bytes are retained so :meth:`_restore_mcp_config_file`
+        can put a workspace-owned config back exactly as it was. Keeping the
+        snapshot on the agent also lets reused agents manage different
+        workspaces without sharing restoration state.
+        """
+        backups = getattr(self, "_mcp_config_backups", None)
+        if backups is None:
+            backups = {}
+            self._mcp_config_backups: dict[Path, bytes | None] = backups
+        if target in backups:
+            raise RuntimeError(f"temporary MCP config is already installed at {target}")
+
+        original = target.read_bytes() if target.exists() else None
+        config: dict[str, Any] = {}
+        if original is not None:
+            try:
+                loaded: object = json.loads(original)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise ValueError(
+                    f"cannot merge MCP servers into invalid JSON config: {target}"
+                ) from exc
+            if not isinstance(loaded, dict):
+                raise ValueError(f"MCP config must contain a JSON object: {target}")
+            config = dict(cast(dict[str, Any], loaded))
+
+        existing_servers = config.get(server_key, {})
+        if not isinstance(existing_servers, dict):
+            raise ValueError(f"{server_key!r} must be a JSON object in MCP config: {target}")
+        if defaults:
+            for key, value in defaults.items():
+                config.setdefault(key, value)
+        config[server_key] = {
+            **cast(dict[str, Any], existing_servers),
+            **server_config,
+        }
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(config, indent=2), encoding="utf-8")
+        backups[target] = original
+
+    def _restore_mcp_config_file(self, target: Path) -> None:
+        """Restore a config saved by :meth:`_install_mcp_config_file`."""
+        backups = getattr(self, "_mcp_config_backups", None)
+        if backups is None or target not in backups:
+            return
+
+        original = backups[target]
+        if original is None:
+            if target.exists():
+                target.unlink()
+        else:
+            target.write_bytes(original)
+        del backups[target]
 
     @abstractmethod
     def generate(

--- a/src/vibesys/_agent_cli/claude.py
+++ b/src/vibesys/_agent_cli/claude.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -98,26 +97,21 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
         )
 
     def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
-        """Write ``<workspace>/.mcp.json`` so Claude Code auto-discovers
-        the MCP servers from cwd."""
-        config: dict[str, Any] = {
-            "mcpServers": {
-                s.name: {
-                    "command": s.command,
-                    "args": list(s.args),
-                    **({"env": dict(s.env)} if s.env else {}),
-                }
-                for s in servers
+        """Merge servers into ``<workspace>/.mcp.json`` for auto-discovery."""
+        server_config: dict[str, dict[str, Any]] = {
+            s.name: {
+                "command": s.command,
+                "args": list(s.args),
+                **({"env": dict(s.env)} if s.env else {}),
             }
+            for s in servers
         }
-        (workspace / ".mcp.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
+        self._install_mcp_config_file(
+            workspace / ".mcp.json",
+            server_key="mcpServers",
+            server_config=server_config,
+        )
 
     def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
-        """Remove ``<workspace>/.mcp.json``. Idempotent and tolerant of
-        files written from inside Docker (root-owned)."""
-        target = workspace / ".mcp.json"
-        if target.exists():
-            try:
-                target.unlink()
-            except OSError:
-                pass
+        """Restore the workspace's original ``.mcp.json``. Idempotent."""
+        self._restore_mcp_config_file(workspace / ".mcp.json")

--- a/src/vibesys/_agent_cli/gemini.py
+++ b/src/vibesys/_agent_cli/gemini.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -81,31 +80,25 @@ class GeminiCodingAgent(CLICodingAgent[GeminiGenerationSession]):
         )
 
     def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
-        """Write ``<workspace>/.gemini/settings.json`` so Gemini CLI
-        auto-discovers the MCP servers from cwd. ``trust: true`` skips
+        """Merge servers into ``<workspace>/.gemini/settings.json``.
+
+        Gemini CLI discovers the servers from cwd. ``trust: true`` skips
         Gemini's per-tool approval prompts for these servers."""
-        gemini_dir = workspace / ".gemini"
-        gemini_dir.mkdir(parents=True, exist_ok=True)
-        config: dict[str, Any] = {
-            "mcpServers": {
-                s.name: {
-                    "command": s.command,
-                    "args": list(s.args),
-                    "trust": True,
-                    **({"env": dict(s.env)} if s.env else {}),
-                }
-                for s in servers
+        server_config: dict[str, dict[str, Any]] = {
+            s.name: {
+                "command": s.command,
+                "args": list(s.args),
+                "trust": True,
+                **({"env": dict(s.env)} if s.env else {}),
             }
+            for s in servers
         }
-        (gemini_dir / "settings.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
+        self._install_mcp_config_file(
+            workspace / ".gemini" / "settings.json",
+            server_key="mcpServers",
+            server_config=server_config,
+        )
 
     def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
-        """Remove ``<workspace>/.gemini/settings.json``. Leaves the
-        ``.gemini/`` directory itself in place because Gemini also writes
-        session data into it (e.g. ``.gemini/tmp/``)."""
-        target = workspace / ".gemini" / "settings.json"
-        if target.exists():
-            try:
-                target.unlink()
-            except OSError:
-                pass
+        """Restore the original settings, leaving ``.gemini/`` in place."""
+        self._restore_mcp_config_file(workspace / ".gemini" / "settings.json")

--- a/src/vibesys/_agent_cli/opencode.py
+++ b/src/vibesys/_agent_cli/opencode.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -77,30 +76,28 @@ class OpencodeCodingAgent(CLICodingAgent[OpencodeGenerationSession]):
         )
 
     def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
-        """Write ``<workspace>/opencode.json`` so opencode auto-discovers
-        the MCP servers from cwd. opencode uses the ``mcp`` key (not
+        """Merge servers into ``<workspace>/opencode.json``.
+
+        Opencode discovers the MCP servers from cwd and uses the ``mcp`` key (not
         ``mcpServers``) and a single combined ``command`` array. Non-
         interactive ``opencode run`` already auto-approves all permissions,
         so no extra ``permission`` block is needed."""
-        config: dict[str, Any] = {
-            "$schema": "https://opencode.ai/config.json",
-            "mcp": {
-                s.name: {
-                    "type": "local",
-                    "command": [s.command, *s.args],
-                    "enabled": True,
-                    **({"environment": dict(s.env)} if s.env else {}),
-                }
-                for s in servers
-            },
+        server_config: dict[str, dict[str, Any]] = {
+            s.name: {
+                "type": "local",
+                "command": [s.command, *s.args],
+                "enabled": True,
+                **({"environment": dict(s.env)} if s.env else {}),
+            }
+            for s in servers
         }
-        (workspace / "opencode.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
+        self._install_mcp_config_file(
+            workspace / "opencode.json",
+            server_key="mcp",
+            server_config=server_config,
+            defaults={"$schema": "https://opencode.ai/config.json"},
+        )
 
     def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
-        """Remove ``<workspace>/opencode.json``. Idempotent."""
-        target = workspace / "opencode.json"
-        if target.exists():
-            try:
-                target.unlink()
-            except OSError:
-                pass
+        """Restore the workspace's original ``opencode.json``. Idempotent."""
+        self._restore_mcp_config_file(workspace / "opencode.json")

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -449,6 +449,7 @@ class CliAgentRunner:
         #    if generate() raises) and the per-invocation usage record
         #    (tokens were spent either way, and an audit gap on failure
         #    defeats the purpose).
+        agent_error: BaseException | None = None
         try:
             try:
                 text = agent.generate(
@@ -480,16 +481,27 @@ class CliAgentRunner:
                     timeout=self._timeout,
                     silent=True,
                 )
-        except Exception as exc:
-            log_and_print(
-                f"\n=== {label} ROUND ERROR: {round_label} ===",
-                self._run_log_file,
-            )
-            log_and_print(f"{type(exc).__name__}: {exc}", self._run_log_file)
+        except BaseException as exc:
+            agent_error = exc
+            if isinstance(exc, Exception):
+                log_and_print(
+                    f"\n=== {label} ROUND ERROR: {round_label} ===",
+                    self._run_log_file,
+                )
+                log_and_print(f"{type(exc).__name__}: {exc}", self._run_log_file)
             raise
         finally:
             if mcp_servers:
-                agent.uninstall_mcp_servers(workspace, mcp_servers)
+                try:
+                    agent.uninstall_mcp_servers(workspace, mcp_servers)
+                except Exception as cleanup_exc:
+                    if agent_error is None:
+                        raise
+                    log_and_print(
+                        f"[{label}] MCP config cleanup failed while preserving the "
+                        f"original agent error: {cleanup_exc}",
+                        self._run_log_file,
+                    )
             self._write_usage_record(kind=kind, round_label=round_label, agent=agent)
         return text
 

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -192,6 +192,7 @@ def _make_fake_agent_class(
     generate_returns: str,
     captured: list,
     generate_raises: type[BaseException] | None = None,
+    uninstall_raises: type[Exception] | None = None,
     session_state: dict | None = None,
 ):
     """Build a fake provider class that records its instances and constructor args.
@@ -224,6 +225,8 @@ def _make_fake_agent_class(
         def uninstall_mcp_servers(self, workspace, servers):
             self.uninstall_calls.append({"workspace": workspace, "servers": list(servers)})
             self.event_log.append("uninstall")
+            if uninstall_raises is not None:
+                raise uninstall_raises("cleanup boom")
 
         def generate(self, prompt, cwd=None, timeout=300, silent=False):
             self.generate_calls.append(
@@ -1166,6 +1169,45 @@ class TestCliAgentRunner:
 
         agent = captured[0]
         assert agent.event_log == ["install", "generate", "uninstall"]
+
+    def test_cli_runner_preserves_generate_error_when_uninstall_also_raises(
+        self, monkeypatch, tmp_path
+    ):
+        from vibesys._agent_cli.base import MCPServerSpec
+
+        captured: list = []
+        fake_cls = _make_fake_agent_class(
+            generate_returns="",
+            captured=captured,
+            generate_raises=RuntimeError,
+            uninstall_raises=OSError,
+        )
+        monkeypatch.setitem(
+            __import__(
+                "vibesys.agents.cli_runner",
+                fromlist=["_PROVIDER_CLASSES"],
+            )._PROVIDER_CLASSES,
+            "claude",
+            fake_cls,
+        )
+        runner = CliAgentRunner(provider="claude", model="m", run_log_file=None)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        spec = MCPServerSpec(name="vibesys-issues", command="python", args=["-m", "x"])
+
+        with pytest.raises(RuntimeError, match="boom"):
+            runner.invoke(
+                kind="judge",
+                workspace=workspace,
+                system_prompt="sys",
+                user_prompt="usr",
+                response_cls=JudgeResponse,
+                fallback_factory=_judge_fallback,
+                round_label="judge #1",
+                mcp_servers=[spec],
+            )
+
+        assert captured[0].event_log == ["install", "generate", "uninstall"]
 
     def test_cli_runner_skips_install_uninstall_when_no_mcp_servers(self, monkeypatch, tmp_path):
         """When mcp_servers is None or omitted, install/uninstall hooks are

--- a/tests/test_agent_cli_mcp.py
+++ b/tests/test_agent_cli_mcp.py
@@ -88,6 +88,24 @@ class TestClaudeMCP:
         server = config["mcpServers"]["vibesys-issues"]
         assert server["env"] == {"MY_VAR": "my_value", "OTHER": "x"}
 
+    def test_install_merges_and_uninstall_restores_existing_config(self, tmp_path: Path):
+        target = tmp_path / ".mcp.json"
+        original = (
+            b'{"permissions":{"allow":["Bash(*)"]},"mcpServers":{"existing":{"command":"user"}}}\n'
+        )
+        target.write_bytes(original)
+        agent = self._agent()
+
+        agent.install_mcp_servers(tmp_path, [_spec()])
+
+        config = json.loads(target.read_text())
+        assert config["permissions"] == {"allow": ["Bash(*)"]}
+        assert config["mcpServers"]["existing"] == {"command": "user"}
+        assert "vibesys-issues" in config["mcpServers"]
+
+        agent.uninstall_mcp_servers(tmp_path, [_spec()])
+        assert target.read_bytes() == original
+
     def test_uninstall_removes_file(self, tmp_path: Path):
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec()])
@@ -160,6 +178,23 @@ class TestGeminiMCP:
         server = config["mcpServers"]["vibesys-issues"]
         assert server["env"] == {"MY_VAR": "my_value", "OTHER": "x"}
 
+    def test_install_merges_and_uninstall_restores_existing_config(self, tmp_path: Path):
+        target = tmp_path / ".gemini" / "settings.json"
+        target.parent.mkdir()
+        original = b'{"theme":"dark","mcpServers":{"existing":{"command":"user"}}}\n'
+        target.write_bytes(original)
+        agent = self._agent()
+
+        agent.install_mcp_servers(tmp_path, [_spec()])
+
+        config = json.loads(target.read_text())
+        assert config["theme"] == "dark"
+        assert config["mcpServers"]["existing"] == {"command": "user"}
+        assert "vibesys-issues" in config["mcpServers"]
+
+        agent.uninstall_mcp_servers(tmp_path, [_spec()])
+        assert target.read_bytes() == original
+
 
 # ---------------------------------------------------------------------------
 # Opencode → workspace/opencode.json
@@ -196,6 +231,22 @@ class TestOpencodeMCP:
         # opencode's key is 'environment', not 'env'.
         assert server["environment"] == {"MY_VAR": "my_value", "OTHER": "x"}
         assert "env" not in server
+
+    def test_install_merges_and_uninstall_restores_existing_config(self, tmp_path: Path):
+        target = tmp_path / "opencode.json"
+        original = b'{"theme":"dark","mcp":{"existing":{"type":"local","command":["user"]}}}\n'
+        target.write_bytes(original)
+        agent = self._agent()
+
+        agent.install_mcp_servers(tmp_path, [_spec()])
+
+        config = json.loads(target.read_text())
+        assert config["theme"] == "dark"
+        assert config["mcp"]["existing"] == {"type": "local", "command": ["user"]}
+        assert "vibesys-issues" in config["mcp"]
+
+        agent.uninstall_mcp_servers(tmp_path, [_spec()])
+        assert target.read_bytes() == original
 
     def test_uninstall_removes_file(self, tmp_path: Path):
         agent = self._agent()

--- a/tests/test_agent_cli_mcp.py
+++ b/tests/test_agent_cli_mcp.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from vibesys._agent_cli.base import MCPServerSpec
 from vibesys._agent_cli.claude import ClaudeCodeCodingAgent
 from vibesys._agent_cli.codex import CodexCodingAgent
@@ -105,6 +107,60 @@ class TestClaudeMCP:
 
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
         assert target.read_bytes() == original
+
+    def test_uninstall_preserves_config_edits_made_during_invocation(self, tmp_path: Path):
+        target = tmp_path / ".mcp.json"
+        target.write_text('{"theme":"light","mcpServers":{"existing":{"command":"user"}}}')
+        agent = self._agent()
+        agent.install_mcp_servers(tmp_path, [_spec()])
+
+        config = json.loads(target.read_text())
+        config["theme"] = "dark"
+        config["new_setting"] = True
+        target.write_text(json.dumps(config))
+
+        agent.uninstall_mcp_servers(tmp_path, [_spec()])
+
+        restored = json.loads(target.read_text())
+        assert restored == {
+            "theme": "dark",
+            "new_setting": True,
+            "mcpServers": {"existing": {"command": "user"}},
+        }
+
+    def test_uninstall_preserves_an_in_run_edit_to_an_injected_server(self, tmp_path: Path):
+        target = tmp_path / ".mcp.json"
+        target.write_text('{"mcpServers":{"vibesys-issues":{"command":"user"}}}')
+        agent = self._agent()
+        agent.install_mcp_servers(tmp_path, [_spec()])
+
+        config = json.loads(target.read_text())
+        config["mcpServers"]["vibesys-issues"] = {"command": "agent-edited"}
+        target.write_text(json.dumps(config))
+
+        agent.uninstall_mcp_servers(tmp_path, [_spec()])
+
+        assert json.loads(target.read_text())["mcpServers"]["vibesys-issues"] == {
+            "command": "agent-edited"
+        }
+
+    def test_install_replace_failure_leaves_original_config_intact(
+        self, tmp_path: Path, monkeypatch
+    ):
+        target = tmp_path / ".mcp.json"
+        original = b'{"theme":"dark"}\n'
+        target.write_bytes(original)
+        agent = self._agent()
+
+        def fail_replace(source, destination):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("vibesys._agent_cli.base.os.replace", fail_replace)
+        with pytest.raises(OSError, match="disk full"):
+            agent.install_mcp_servers(tmp_path, [_spec()])
+
+        assert target.read_bytes() == original
+        assert target not in getattr(agent, "_mcp_config_backups", {})
 
     def test_uninstall_removes_file(self, tmp_path: Path):
         agent = self._agent()


### PR DESCRIPTION
## Problem

VibeSys temporarily injects MCP definitions into workspace-owned provider configuration. Replacing or blindly restoring the whole file can destroy settings that existed before the invocation or legitimate edits made while the agent was running. Partial writes and cleanup failures could also corrupt state or mask the agent's original error.

Fixes #217.

## Solution

Use an atomic same-directory replacement for installation and a three-way rollback for cleanup. The rollback removes only unchanged VibeSys-injected values, restores unchanged collisions, and preserves unrelated or deliberately modified in-run settings. Exact original bytes are restored when nothing changed. Cleanup failures no longer replace an active agent error.

### Architecture

Provider adapters still own their JSON schemas. The shared CLI-agent boundary owns the temporary overlay snapshot, atomic file replacement, and three-way rollback. Codex remains runtime-flag-only.

## Verification

Regression tests cover all file-backed providers, in-run edits, collided server edits, atomic replacement failure, idempotence, and simultaneous generation/cleanup failures.

### Correctness properties

- Installation never exposes a partially written config.
- Existing settings remain available during injection.
- Cleanup preserves unrelated changes made during the invocation.
- Cleanup removes only unchanged injected values.
- A cleanup failure cannot replace the original agent failure.
- Runtime-only Codex configuration is unchanged.

### Testing

- `uv run pytest tests/test_agent_cli_mcp.py tests/agents/test_agent_runners.py -q` — 79 passed.
- `uv run pytest -q` — 2,030 passed, 1 expected platform skip.
- Format, lint, type checking, and `git diff --check` passed.
