### PR TITLE
Clean up resources when context construction fails

### DIFF
--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -219,9 +219,22 @@ def create_run_context(
             remote_repo=remote_repo,
             repo_visibility=repo_visibility,
         )
-    except BaseException:
-        teardown_stack.close()
+    except BaseException as construction_error:
+        _close_after_construction_failure(teardown_stack, construction_error)
         raise
+
+
+def _close_after_construction_failure(
+    teardown_stack: ExitStack, construction_error: BaseException
+) -> None:
+    """Unwind partial construction without replacing its root-cause error."""
+    try:
+        teardown_stack.close()
+    except BaseException as cleanup_error:
+        construction_error.add_note(
+            "Additional error while cleaning up partial context construction: "
+            f"{type(cleanup_error).__name__}: {cleanup_error}"
+        )
 
 
 def _assemble_run_context(
@@ -398,6 +411,14 @@ def _assemble_run_context(
     )
     environment_patch = hooks.prepare(environment_context)
 
+    def _teardown_environment_hooks() -> None:
+        try:
+            hooks.teardown(environment_context)
+        except Exception as exc:
+            logger.lprint(f"[warn] environment hook teardown failed: {exc}")
+
+    teardown_stack.callback(_teardown_environment_hooks)
+
     # When resuming an existing run, the plan skips full workspace file
     # setup — the workspace already contains reference files, skills, etc.
     # from the previous run.  Only skills are refreshed and profiler
@@ -450,14 +471,6 @@ def _assemble_run_context(
         profiler_support_agent_path=session.view.paths.profiler_support,
         profiler_benchmark_command=session.view.paths.benchmark_command,
     )
-
-    def _teardown_environment_hooks() -> None:
-        try:
-            hooks.teardown(environment_context)
-        except Exception as exc:
-            logger.lprint(f"[warn] environment hook teardown failed: {exc}")
-
-    teardown_stack.callback(_teardown_environment_hooks)
 
     # Start backend-specific background monitoring (CUDA: nvidia-smi).
     device = DeviceLease(backend_impl, log_dir=log_dir, run_environment_view=session.view)
@@ -574,8 +587,8 @@ def create_candidate_context(
             agent_backend=agent_backend,
             cli_provider=cli_provider,
         )
-    except BaseException:
-        teardown_stack.close()
+    except BaseException as construction_error:
+        _close_after_construction_failure(teardown_stack, construction_error)
         raise
 
 
@@ -599,10 +612,10 @@ def _assemble_candidate_context(
     # Materialize the parent's tree in an isolated worktree (shared object
     # store). `git worktree add` touches the main repo's admin area, so the
     # caller serializes this; the container/agent work afterward is isolated.
-    parent.git.add_worktree(workspace, parent_commit)
     # Remove the worktree only after it has been materialized, including when
-    # any later construction step fails.
+    # git itself reports failure after partially materializing its admin state.
     teardown_stack.callback(lambda: parent.git.remove_worktree(workspace))
+    parent.git.add_worktree(workspace, parent_commit)
 
     logger = RunLogger(log_dir, tee_stderr=False)
     teardown_stack.callback(logger.close)

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -193,6 +193,62 @@ def create_run_context(
     and agent-runner build.  ``_RunContext.__init__`` itself only assigns
     the assembled components.
     """
+    teardown_stack = ExitStack()
+    try:
+        return _assemble_run_context(
+            teardown_stack=teardown_stack,
+            config=config,
+            exp_name=exp_name,
+            input_path=input_path,
+            accuracy_command=accuracy_command,
+            benchmark_command=benchmark_command,
+            workspace_seed=workspace_seed,
+            evaluator_path=evaluator_path,
+            existing=existing,
+            trusted_input_baseline=trusted_input_baseline,
+            debug=debug,
+            profiler_kind=profiler_kind,
+            profiler_domain=profiler_domain,
+            skills_dirs=skills_dirs,
+            run_environment=run_environment,
+            git_tracking=git_tracking,
+            agent_backend=agent_backend,
+            cli_provider=cli_provider,
+            backend=backend,
+            environment_hooks=environment_hooks,
+            remote_repo=remote_repo,
+            repo_visibility=repo_visibility,
+        )
+    except BaseException:
+        teardown_stack.close()
+        raise
+
+
+def _assemble_run_context(
+    *,
+    teardown_stack: ExitStack,
+    config: Config,
+    exp_name: str,
+    input_path: str,
+    accuracy_command: str,
+    benchmark_command: str,
+    workspace_seed: Path | None,
+    evaluator_path: Path | None,
+    existing: bool,
+    trusted_input_baseline: str | None,
+    debug: bool,
+    profiler_kind: ProfilerKind,
+    profiler_domain: DomainName,
+    skills_dirs: list[str] | None,
+    run_environment: RunEnvironmentSpec | None,
+    git_tracking: bool,
+    agent_backend: str | None,
+    cli_provider: str | None,
+    backend: ComputeBackend,
+    environment_hooks: EnvironmentHooks | None,
+    remote_repo: str | None,
+    repo_visibility: RepositoryVisibility,
+) -> "_RunContext":
     config = as_config(config)
     run_environment_spec = run_environment or make_run_environment_spec()
     environment = build_run_environment(run_environment_spec)
@@ -213,14 +269,12 @@ def create_run_context(
     # One teardown stack for the whole context: every component with
     # cleanup registers here, and close() unwinds it in reverse
     # construction order (device → environment hooks → session → logs).
-    teardown_stack = ExitStack()
     teardown_stack.callback(logger.close)
     experiment_repository = ExperimentRepository(exp_dir, logger.lprint)
     if remote_repo is not None:
         try:
             experiment_repository.create_remote(remote_repo, repo_visibility)
         except Exception as exc:
-            teardown_stack.close()
             raise ConfigurationError(
                 ConfigurationDiagnostic(
                     code="repository_setup_failed",
@@ -407,8 +461,8 @@ def create_run_context(
 
     # Start backend-specific background monitoring (CUDA: nvidia-smi).
     device = DeviceLease(backend_impl, log_dir=log_dir, run_environment_view=session.view)
-    device.start_monitor()
     teardown_stack.callback(device.close)
+    device.start_monitor()
 
     # Build the backend-agnostic agent runner. Loops invoke this instead
     # of calling create_deep_agent / vibesys._agent_cli directly. The cli
@@ -508,6 +562,34 @@ def create_candidate_context(
     returned context (or use it as a context manager) to stop the container and
     remove the worktree.
     """
+    teardown_stack = ExitStack()
+    try:
+        return _assemble_candidate_context(
+            teardown_stack=teardown_stack,
+            parent=parent,
+            config=config,
+            generation=generation,
+            child_idx=child_idx,
+            parent_commit=parent_commit,
+            agent_backend=agent_backend,
+            cli_provider=cli_provider,
+        )
+    except BaseException:
+        teardown_stack.close()
+        raise
+
+
+def _assemble_candidate_context(
+    *,
+    teardown_stack: ExitStack,
+    parent: "_RunContext",
+    config: Config,
+    generation: int,
+    child_idx: int,
+    parent_commit: str,
+    agent_backend: str | None,
+    cli_provider: str | None,
+) -> "_RunContext":
     config = as_config(config)
     cand_root = parent.exp_dir / "candidates" / f"{parent.exp_dir.name}-g{generation}c{child_idx}"
     workspace = cand_root / "workspace"
@@ -518,13 +600,12 @@ def create_candidate_context(
     # store). `git worktree add` touches the main repo's admin area, so the
     # caller serializes this; the container/agent work afterward is isolated.
     parent.git.add_worktree(workspace, parent_commit)
+    # Remove the worktree only after it has been materialized, including when
+    # any later construction step fails.
+    teardown_stack.callback(lambda: parent.git.remove_worktree(workspace))
 
     logger = RunLogger(log_dir, tee_stderr=False)
-    teardown_stack = ExitStack()
     teardown_stack.callback(logger.close)
-    # Remove the worktree *after* the session's container is stopped: register
-    # the removal before entering the session so it unwinds afterward (LIFO).
-    teardown_stack.callback(lambda: parent.git.remove_worktree(workspace))
 
     resolved_backend = agent_backend or config.agent.backend or DEFAULT_AGENT_BACKEND
     resolved_cli_provider = cli_provider or config.agent.cli_provider or "codex"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -5,9 +5,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vibesys.context import _RunContext, create_run_context, setup_exp_dir
+from vibesys.context import (
+    _RunContext,
+    create_candidate_context,
+    create_run_context,
+    setup_exp_dir,
+)
 from vibesys.domains.base import DomainName
-from vibesys.domains.environment import NoopEnvironmentHooks
+from vibesys.domains.environment import EnvironmentPatch, NoopEnvironmentHooks
 from vibesys.errors import ConfigurationError
 from vibesys.profilers import ACTIVE_PROFILER_KINDS, ProfilerKind, ProfilerPreflightResult
 from vibesys.run import GitTracker, RunLogger, RunPaths, Workspace
@@ -487,6 +492,83 @@ def test_run_context_noop_environment_hooks_do_not_require_model_artifacts(tmp_p
     ):
         assert (ctx.workspace / "reference" / "reference.py").is_file()
         assert not (ref_dir / "model").exists()
+
+
+def test_candidate_context_cleans_up_when_agent_runner_construction_fails(tmp_path):
+    workspace = tmp_path / "candidates" / f"{tmp_path.name}-g1c2" / "workspace"
+    parent = SimpleNamespace(
+        exp_dir=tmp_path,
+        git=MagicMock(),
+        run_environment=MagicMock(),
+        backend_impl=_FakeBackend(),
+        EXCLUDED_WORKSPACE_DIRS={".git", "target"},
+        accuracy_command="check-accuracy",
+        benchmark_command="run-benchmark",
+        profiler_support_path=None,
+        profiler_support_name=None,
+        environment_patch=SimpleNamespace(bind_mounts=()),
+        skill_source_paths=[],
+        model="mock-model",
+        model_name="claude-sonnet-4-6",
+    )
+    parent.git.add_worktree.side_effect = lambda path, _commit: path.mkdir(parents=True)
+    session = MagicMock()
+    session.__enter__.return_value = session
+    session.view = SimpleNamespace(
+        paths=SimpleNamespace(
+            accuracy_command="check-accuracy",
+            benchmark_command="run-benchmark",
+            profiler_support=None,
+        ),
+        cli_sandboxed=False,
+        cli_modal_sandboxed=False,
+    )
+    session.sandbox = MagicMock()
+    parent.run_environment.open.return_value = session
+
+    with (
+        patch("vibesys.context.build_agent_runner", side_effect=SystemExit("boom")),
+        pytest.raises(SystemExit, match="boom"),
+    ):
+        create_candidate_context(
+            parent,
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            generation=1,
+            child_idx=2,
+            parent_commit="deadbeef",
+        )
+
+    session.__exit__.assert_called_once()
+    parent.git.remove_worktree.assert_called_once_with(workspace)
+
+
+def test_run_context_cleans_up_when_agent_runner_construction_fails(tmp_path):
+    project_root = tmp_path / "project"
+    ref = _write_ref(tmp_path)
+    hooks = MagicMock()
+    hooks.prepare.return_value = EnvironmentPatch()
+    original_stderr = sys.stderr
+
+    with (
+        patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.context.build_model", return_value="mock-model"),
+        patch("vibesys.context.build_agent_runner", side_effect=RuntimeError("boom")),
+        patch("vibesys.context.backends.get", return_value=_FakeBackend()),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        create_run_context(
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            exp_name="failed-construction",
+            input_path=str(ref.parent),
+            accuracy_command="check-accuracy",
+            benchmark_command="run-benchmark",
+            skills_dirs=[],
+            run_environment=RunEnvironmentSpec("local"),
+            environment_hooks=hooks,
+        )
+
+    assert sys.stderr is original_stderr
+    hooks.teardown.assert_called_once()
 
 
 def test_run_context_materializes_input_project_path_dependencies(tmp_path):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,11 +1,13 @@
 import subprocess
 import sys
+from contextlib import ExitStack
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from vibesys.context import (
+    _close_after_construction_failure,
     _RunContext,
     create_candidate_context,
     create_run_context,
@@ -542,6 +544,28 @@ def test_candidate_context_cleans_up_when_agent_runner_construction_fails(tmp_pa
     parent.git.remove_worktree.assert_called_once_with(workspace)
 
 
+def test_candidate_context_cleans_up_when_add_worktree_partially_fails(tmp_path):
+    workspace = tmp_path / "candidates" / f"{tmp_path.name}-g1c2" / "workspace"
+    parent = SimpleNamespace(exp_dir=tmp_path, git=MagicMock())
+
+    def partially_add(path, _commit):
+        path.mkdir(parents=True)
+        raise RuntimeError("git add failed")
+
+    parent.git.add_worktree.side_effect = partially_add
+
+    with pytest.raises(RuntimeError, match="git add failed"):
+        create_candidate_context(
+            parent,
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            generation=1,
+            child_idx=2,
+            parent_commit="deadbeef",
+        )
+
+    parent.git.remove_worktree.assert_called_once_with(workspace)
+
+
 def test_run_context_cleans_up_when_agent_runner_construction_fails(tmp_path):
     project_root = tmp_path / "project"
     ref = _write_ref(tmp_path)
@@ -569,6 +593,49 @@ def test_run_context_cleans_up_when_agent_runner_construction_fails(tmp_path):
 
     assert sys.stderr is original_stderr
     hooks.teardown.assert_called_once()
+
+
+def test_run_context_tears_down_prepared_hooks_when_workspace_setup_fails(tmp_path):
+    project_root = tmp_path / "project"
+    ref = _write_ref(tmp_path)
+    hooks = MagicMock()
+    hooks.prepare.return_value = EnvironmentPatch()
+
+    with (
+        patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.context.build_model", return_value="mock-model"),
+        patch("vibesys.context.backends.get", return_value=_FakeBackend()),
+        patch("vibesys.context.Workspace.setup", side_effect=RuntimeError("setup failed")),
+        pytest.raises(RuntimeError, match="setup failed"),
+    ):
+        create_run_context(
+            config={"model": {"name": "claude-sonnet-4-6"}},
+            exp_name="failed-workspace-setup",
+            input_path=str(ref.parent),
+            accuracy_command="check-accuracy",
+            benchmark_command="run-benchmark",
+            skills_dirs=[],
+            run_environment=RunEnvironmentSpec("local"),
+            environment_hooks=hooks,
+        )
+
+    hooks.teardown.assert_called_once()
+
+
+def test_partial_construction_cleanup_does_not_replace_original_error():
+    stack = ExitStack()
+
+    def fail_cleanup() -> None:
+        raise OSError("cleanup failed")
+
+    stack.callback(fail_cleanup)
+    construction_error = RuntimeError("construction failed")
+
+    _close_after_construction_failure(stack, construction_error)
+
+    assert construction_error.__notes__ == [
+        "Additional error while cleaning up partial context construction: OSError: cleanup failed"
+    ]
 
 
 def test_run_context_materializes_input_project_path_dependencies(tmp_path):


### PR DESCRIPTION
## Problem

Context construction can fail after acquiring logs, hooks, sessions, devices, or candidate worktrees. Cleanup registered too late misses partial acquisitions, and a cleanup exception can replace the construction error that explains the actual failure.

Fixes #218.

## Solution

The public factories own an ExitStack during assembly and transfer it only on success. Hook teardown is registered immediately after preparation, worktree removal before the add attempt, and device cleanup before monitor startup. Failure cleanup annotates—but never replaces—the original exception.

### Architecture

Each resource is registered at its ownership boundary. The factory coordinates LIFO unwinding; resource implementations retain their own idempotent cleanup behavior.

## Verification

Tests cover ordinary errors, SystemExit, workspace setup failure after hook preparation, partially materialized worktree failure, and a cleanup callback that also raises.

### Correctness properties

- Every acquired resource is registered before the next fallible operation.
- Partial worktree state is removed even when Git reports failure.
- BaseException paths receive deterministic LIFO cleanup.
- Cleanup failures preserve the root construction exception.
- Successful contexts retain idempotent close semantics.

### Testing

- `uv run pytest tests/test_context.py -q` — 29 passed.
- `uv run pytest -q` — 2,028 passed, 1 expected platform skip.
- Format, lint, type checking, and `git diff --check` passed.
