### PR TITLE
Reject non-finite performance metrics before persistence

### DIFF
--- a/src/vibesys/loops/evolve/population.py
+++ b/src/vibesys/loops/evolve/population.py
@@ -129,6 +129,11 @@ class Individual:
     policy_parent_id: str | None = None
     policy_target_island: int | None = None
 
+    def __post_init__(self) -> None:
+        _require_finite_metric(self.perf_metric, "perf_metric")
+        for name, value in self.metrics.items():
+            _require_finite_metric(value, f"metrics[{name!r}]")
+
     def to_json(self) -> dict[str, Any]:
         return asdict(self)
 
@@ -351,7 +356,9 @@ class Population:
 
     def save(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps([i.to_json() for i in self._individuals], indent=2))
+        path.write_text(
+            json.dumps([i.to_json() for i in self._individuals], indent=2, allow_nan=False)
+        )
 
     @classmethod
     def load(cls, path: Path) -> Population:
@@ -359,3 +366,10 @@ class Population:
             return cls()
         data = json.loads(path.read_text())
         return cls([Individual.from_json(d) for d in data])
+
+
+def _require_finite_metric(value: float | None, field_name: str) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not math.isfinite(value):
+        raise ValueError(f"{field_name} must be a finite number")

--- a/src/vibesys/loops/evolve/population.py
+++ b/src/vibesys/loops/evolve/population.py
@@ -130,6 +130,10 @@ class Individual:
     policy_target_island: int | None = None
 
     def __post_init__(self) -> None:
+        self.validate_fitness()
+
+    def validate_fitness(self) -> None:
+        """Recheck mutable fitness fields before they affect selection."""
         _require_finite_metric(self.perf_metric, "perf_metric")
         for name, value in self.metrics.items():
             _require_finite_metric(value, f"metrics[{name!r}]")
@@ -180,7 +184,10 @@ class Population:
 
     @property
     def passed(self) -> list[Individual]:
-        return [i for i in self._individuals if i.passed and i.commit]
+        passed = [i for i in self._individuals if i.passed and i.commit]
+        for individual in passed:
+            individual.validate_fitness()
+        return passed
 
     def __len__(self) -> int:
         return len(self._individuals)
@@ -195,6 +202,7 @@ class Population:
         return None
 
     def add(self, ind: Individual) -> None:
+        ind.validate_fitness()
         self._individuals.append(ind)
 
     def best(self) -> Individual | None:
@@ -355,6 +363,8 @@ class Population:
     # -- persistence ---------------------------------------------------------
 
     def save(self, path: Path) -> None:
+        for individual in self._individuals:
+            individual.validate_fitness()
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
             json.dumps([i.to_json() for i in self._individuals], indent=2, allow_nan=False)

--- a/src/vibesys/schemas.py
+++ b/src/vibesys/schemas.py
@@ -24,7 +24,7 @@ schemas in without dragging in the rest of the agent runtime.
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, FiniteFloat
 
 # ===========================================================================
 # Enums
@@ -76,29 +76,29 @@ class JudgeResponse(BaseModel):
 class LatencyStats(BaseModel):
     """Percentile breakdown for a latency metric (all values in milliseconds)."""
 
-    mean_ms: float = Field(description="Mean latency in milliseconds.")
-    p50_ms: float = Field(description="50th percentile (median) latency in milliseconds.")
-    p90_ms: float = Field(description="90th percentile latency in milliseconds.")
-    p95_ms: float = Field(description="95th percentile latency in milliseconds.")
-    p99_ms: float = Field(description="99th percentile latency in milliseconds.")
+    mean_ms: FiniteFloat = Field(description="Mean latency in milliseconds.")
+    p50_ms: FiniteFloat = Field(description="50th percentile (median) latency in milliseconds.")
+    p90_ms: FiniteFloat = Field(description="90th percentile latency in milliseconds.")
+    p95_ms: FiniteFloat = Field(description="95th percentile latency in milliseconds.")
+    p99_ms: FiniteFloat = Field(description="99th percentile latency in milliseconds.")
 
 
 class ThroughputStats(BaseModel):
     """Throughput metrics at a given load level."""
 
-    request_throughput: float = Field(description="Requests per second.")
-    token_throughput: float = Field(description="Output tokens per second.")
+    request_throughput: FiniteFloat = Field(description="Requests per second.")
+    token_throughput: FiniteFloat = Field(description="Output tokens per second.")
 
 
 class LoadLevelMetrics(BaseModel):
     """Metrics collected at a single load level (request rate)."""
 
-    target_rate: float = Field(description="Target request rate in req/s.")
-    actual_rate: float = Field(description="Achieved request rate in req/s.")
+    target_rate: FiniteFloat = Field(description="Target request rate in req/s.")
+    actual_rate: FiniteFloat = Field(description="Achieved request rate in req/s.")
     num_requests: int = Field(description="Total requests sent.")
     num_completed: int = Field(description="Requests that completed successfully.")
     num_failed: int = Field(description="Requests that failed.")
-    duration: float = Field(description="Wall-clock duration in seconds.")
+    duration: FiniteFloat = Field(description="Wall-clock duration in seconds.")
     throughput: ThroughputStats
     ttft: LatencyStats | None = Field(default=None, description="Time to first token stats.")
     tpot: LatencyStats | None = Field(default=None, description="Time per output token stats.")
@@ -168,7 +168,7 @@ class ProfilerSummary(BaseModel):
     analysis: str = Field(description="Detailed interpretation of the profile data.")
     bottlenecks: str = Field(description="Ranked bottlenecks with concrete numbers.")
     suggestions: str = Field(description="Actionable optimization suggestions tied to bottlenecks.")
-    perf_metric: float | None = Field(
+    perf_metric: FiniteFloat | None = Field(
         default=None,
         description="Primary performance metric collected during profiling (higher is better). None when unavailable.",
     )
@@ -176,7 +176,7 @@ class ProfilerSummary(BaseModel):
         default=None,
         description="Unit of perf_metric (e.g. 'req/s', 'tok/s'). None when perf_metric is None.",
     )
-    metrics: dict[str, float] = Field(
+    metrics: dict[str, FiniteFloat] = Field(
         default_factory=dict,
         description=(
             "Optional multi-metric dict keyed by metric name (e.g. "
@@ -334,7 +334,7 @@ class SingleAgentRoundResponse(BaseModel):
         description="Actionable optimization suggestions for the next round, tied to bottlenecks."
     )
     profile_analysis: str = Field(description="Detailed interpretation of the captured profile.")
-    perf_metric: float | None = Field(
+    perf_metric: FiniteFloat | None = Field(
         default=None,
         description="Headline perf metric from the benchmark (per OBJECTIVE.md). None if not measured.",
     )

--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, ValidationError
 
 
 class EventType(StrEnum):
@@ -188,7 +188,7 @@ class JudgeResultData(BaseModel):
 class BenchmarkResultData(BaseModel):
     kind: Literal["benchmark_result"] = "benchmark_result"
     metric: str
-    value: float
+    value: FiniteFloat
     unit: str
 
 
@@ -196,7 +196,7 @@ class RoundFinishedData(BaseModel):
     kind: Literal["round_finished"] = "round_finished"
     attempts: int
     judge_verdict: Literal["pass", "fail"]
-    perf_metric: float | None = None
+    perf_metric: FiniteFloat | None = None
     perf_unit: str | None = None
 
 

--- a/src/vibesys/server/protocol.py
+++ b/src/vibesys/server/protocol.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, FiniteFloat
 
 from vibesys.server.events import RunEvent
 
@@ -95,7 +95,7 @@ class ChatResult(ProtocolModel):
 
 class PerformanceRound(ProtocolModel):
     round: int
-    perf_metric: float
+    perf_metric: FiniteFloat
     perf_unit: str
     passed: bool
     profile_skipped: bool = False

--- a/tests/loops/evolve/test_evolutionary_population.py
+++ b/tests/loops/evolve/test_evolutionary_population.py
@@ -471,3 +471,39 @@ def test_population_save_writes_valid_json(tmp_path):
     assert isinstance(data, list)
     assert data[0]["id"] == 1
     assert data[0]["perf_metric"] == 10.0
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_individual_rejects_non_finite_perf_metric(value):
+    with pytest.raises(ValueError, match="perf_metric must be a finite number"):
+        _passed(1, value)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_individual_rejects_non_finite_multi_objective_metric(value):
+    with pytest.raises(ValueError, match=r"metrics\['throughput'\] must be a finite number"):
+        Individual(
+            id=1,
+            generation=1,
+            parent_id=None,
+            commit="sha-1",
+            perf_metric=10.0,
+            metrics={"throughput": value},
+            passed=True,
+        )
+
+
+def test_population_save_rejects_non_finite_metric_added_after_construction(tmp_path):
+    individual = _passed(1, 10.0)
+    individual.perf_metric = float("nan")
+
+    with pytest.raises(ValueError, match="Out of range float values"):
+        Population([individual]).save(tmp_path / "population.json")
+
+
+def test_population_load_rejects_non_finite_metric(tmp_path):
+    path = tmp_path / "population.json"
+    path.write_text('[{"id": 1, "generation": 1, "parent_id": null, "perf_metric": NaN}]')
+
+    with pytest.raises(ValueError, match="perf_metric must be a finite number"):
+        Population.load(path)

--- a/tests/loops/evolve/test_evolutionary_population.py
+++ b/tests/loops/evolve/test_evolutionary_population.py
@@ -497,8 +497,43 @@ def test_population_save_rejects_non_finite_metric_added_after_construction(tmp_
     individual = _passed(1, 10.0)
     individual.perf_metric = float("nan")
 
-    with pytest.raises(ValueError, match="Out of range float values"):
+    with pytest.raises(ValueError, match="perf_metric must be a finite number"):
         Population([individual]).save(tmp_path / "population.json")
+
+
+def test_best_revalidates_mutated_fitness_before_ranking():
+    individual = _passed(1, 10.0)
+    population = Population([individual])
+    individual.perf_metric = float("nan")
+
+    with pytest.raises(ValueError, match="perf_metric must be a finite number"):
+        population.best()
+
+
+def test_frontier_revalidates_mutated_metrics_before_comparison():
+    individual = Individual(
+        id=1,
+        generation=1,
+        parent_id=None,
+        commit="sha-1",
+        perf_metric=10.0,
+        metrics={"throughput": 10.0},
+        passed=True,
+    )
+    population = Population([individual])
+    individual.metrics["throughput"] = float("inf")
+
+    with pytest.raises(ValueError, match=r"metrics\['throughput'\] must be a finite number"):
+        population.frontier([Objective("throughput", "max")])
+
+
+def test_softmax_revalidates_mutated_fitness_before_sampling():
+    individual = _passed(1, 10.0)
+    population = Population([individual])
+    individual.perf_metric = float("-inf")
+
+    with pytest.raises(ValueError, match="perf_metric must be a finite number"):
+        population.select_parent(rng=random.Random(0))
 
 
 def test_population_load_rejects_non_finite_metric(tmp_path):

--- a/tests/server/test_events.py
+++ b/tests/server/test_events.py
@@ -1,11 +1,14 @@
 """Serialization tests for the run-event wire contract."""
 
 import pytest
+from pydantic import ValidationError
 
 from vibesys.server.events import (
     AgentOutputChunkData,
     AgentStatusData,
+    BenchmarkResultData,
     EventType,
+    RoundFinishedData,
     RunEvent,
     TodoItemData,
     TodoUpdateData,
@@ -104,3 +107,20 @@ class TestBackwardCompatibility:
         )
         with pytest.raises(ValueError):
             RunEvent.model_validate_json(raw)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_benchmark_result_rejects_non_finite_value(value):
+    with pytest.raises(ValidationError, match="finite number"):
+        BenchmarkResultData(metric="throughput", value=value, unit="req/s")
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_round_finished_rejects_non_finite_perf_metric(value):
+    with pytest.raises(ValidationError, match="finite number"):
+        RoundFinishedData(
+            attempts=1,
+            judge_verdict="pass",
+            perf_metric=value,
+            perf_unit="req/s",
+        )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,91 @@
+"""Validation tests for shared structured agent-response schemas."""
+
+import pytest
+from pydantic import ValidationError
+
+from vibesys.schemas import (
+    LatencyStats,
+    LoadLevelMetrics,
+    ProfilerSummary,
+    SingleAgentRoundResponse,
+    ThroughputStats,
+    Verdict,
+)
+from vibesys.server.protocol import PerformanceRound
+
+
+def _profiler_summary(
+    *,
+    perf_metric: float | None = None,
+    metrics: dict[str, float] | None = None,
+) -> ProfilerSummary:
+    return ProfilerSummary(
+        analysis="analysis",
+        bottlenecks="bottlenecks",
+        suggestions="suggestions",
+        perf_metric=perf_metric,
+        metrics=metrics or {},
+    )
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_profiler_summary_rejects_non_finite_perf_metric(value):
+    with pytest.raises(ValidationError, match="finite number"):
+        _profiler_summary(perf_metric=value)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_profiler_summary_rejects_non_finite_multi_objective_metric(value):
+    with pytest.raises(ValidationError, match="finite number"):
+        _profiler_summary(metrics={"throughput": value})
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_single_agent_response_rejects_non_finite_perf_metric(value):
+    with pytest.raises(ValidationError, match="finite number"):
+        SingleAgentRoundResponse(
+            summary="summary",
+            expected_behavior="expected behavior",
+            self_review="self review",
+            feedback="",
+            verdict=Verdict.PASS,
+            bottlenecks="bottlenecks",
+            suggestions="suggestions",
+            profile_analysis="analysis",
+            perf_metric=value,
+            perf_unit="req/s",
+        )
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_performance_stats_reject_non_finite_values(value):
+    with pytest.raises(ValidationError, match="finite number"):
+        LatencyStats(
+            mean_ms=value,
+            p50_ms=1.0,
+            p90_ms=1.0,
+            p95_ms=1.0,
+            p99_ms=1.0,
+        )
+
+    with pytest.raises(ValidationError, match="finite number"):
+        ThroughputStats(request_throughput=value, token_throughput=1.0)
+
+    with pytest.raises(ValidationError, match="finite number"):
+        LoadLevelMetrics(
+            target_rate=value,
+            actual_rate=1.0,
+            num_requests=1,
+            num_completed=1,
+            num_failed=0,
+            duration=1.0,
+            throughput=ThroughputStats(request_throughput=1.0, token_throughput=1.0),
+        )
+
+    with pytest.raises(ValidationError, match="finite number"):
+        PerformanceRound(
+            round=1,
+            perf_metric=value,
+            perf_unit="req/s",
+            passed=True,
+        )


### PR DESCRIPTION
## Problem

Non-finite performance values can corrupt JSON contracts and ranking behavior. Construction-time validation alone is insufficient because evolve Individuals expose mutable fitness fields that can be changed before selection.

Fixes #219.

## Solution

Use FiniteFloat at external Pydantic boundaries, validate evolve fitness at construction, and revalidate mutable passed individuals at population add, ranking, Pareto, softmax, inspiration, and persistence boundaries. Strict JSON serialization remains a final defense.

### Architecture

External contracts own schema validation. Population owns the internal selection invariant and rechecks mutable state immediately before it can affect decisions or persistence.

## Verification

Tests cover NaN and infinities across schemas, events, protocols, population load/save, plus mutations immediately before best, frontier, and softmax selection.

### Correctness properties

- Non-finite values cannot enter serialized performance contracts.
- Mutated non-finite fitness cannot participate in selection.
- Optional unavailable metrics remain None.
- Population persistence never emits non-standard numeric tokens.
- Existing finite records retain their behavior.

### Testing

- `uv run pytest tests/loops/evolve/test_evolutionary_population.py tests/test_schemas.py tests/server/test_events.py -q` — 72 passed.
- `uv run pytest -q` — 2,052 passed, 1 expected platform skip.
- Format, lint, type checking, and `git diff --check` passed.
