### PR TITLE
Close superseded run log files on switch

### DIFF
--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -438,7 +438,7 @@ def create_run_context(
         skill_source_dirs=skill_source_paths,
         model=model,
         model_name=model_name,
-        run_log_file=logger.file,
+        run_log_file=logger.writer,
         use_docker=(session.view.cli_sandboxed and not session.view.cli_modal_sandboxed),
         use_modal=session.view.cli_modal_sandboxed,
         log_dir=log_dir,
@@ -587,7 +587,7 @@ def create_candidate_context(
         skill_source_dirs=parent.skill_source_paths,
         model=parent.model,
         model_name=parent.model_name,
-        run_log_file=logger.file,
+        run_log_file=logger.writer,
         use_docker=(session.view.cli_sandboxed and not session.view.cli_modal_sandboxed),
         use_modal=session.view.cli_modal_sandboxed,
         log_dir=log_dir,
@@ -756,7 +756,7 @@ class _RunContext:
     @property
     def run_log_file(self) -> TextIO:
         """The current open log file handle (owned by ``RunLogger``)."""
-        return self.logger.file
+        return self.logger.writer
 
     @property
     def skill_source_paths(self) -> list[Path]:
@@ -1015,12 +1015,12 @@ class _RunContext:
 
     def switch_log_file(self, label: int | str) -> None:
         """Switch to a per-phase log file — see :meth:`RunLogger.switch`."""
-        new_file = self.logger.switch(label)
+        self.logger.switch(label)
         self._paths = replace(self._paths, run_log_path=self.logger.path)
         # Update the agent runner's log file handle so subsequent
         # invoke() calls write to the new step log.
         if hasattr(self, "agent_runner") and hasattr(self.agent_runner, "_run_log_file"):
-            self.agent_runner._run_log_file = new_file  # pyright: ignore[reportAttributeAccessIssue]
+            self.agent_runner._run_log_file = self.logger.writer  # pyright: ignore[reportAttributeAccessIssue]
 
     def reselect_gpu(self) -> None:
         """Delegate mid-run device rebalance — see :meth:`DeviceLease.reselect`."""

--- a/src/vibesys/run/logger.py
+++ b/src/vibesys/run/logger.py
@@ -2,9 +2,11 @@
 
 import re
 import sys
+import threading
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import TextIO
+from typing import TextIO, cast
 
 from vibesys.agent_runner import log_and_print
 
@@ -39,6 +41,33 @@ class _TeeWriter:
         return False
 
 
+class _CurrentLogWriter:
+    """Stable writer that follows a :class:`RunLogger` across file switches."""
+
+    def __init__(
+        self,
+        write: Callable[[str], int],
+        flush: Callable[[], None],
+        is_closed: Callable[[], bool],
+    ) -> None:
+        self._write = write
+        self._flush = flush
+        self._is_closed = is_closed
+
+    def write(self, text: str) -> int:
+        return self._write(text)
+
+    def flush(self) -> None:
+        self._flush()
+
+    def isatty(self) -> bool:
+        return False
+
+    @property
+    def closed(self) -> bool:
+        return self._is_closed()
+
+
 class RunLogger:
     """Owns the current run log file and the process stderr tee.
 
@@ -61,15 +90,34 @@ class RunLogger:
     def __init__(self, log_dir: Path, *, tee_stderr: bool = True) -> None:
         self.log_dir = log_dir
         self._tee_stderr = tee_stderr
+        self._lock = threading.RLock()
         run_started = datetime.now().strftime("%Y%m%d-%H%M%S")
         self.path = log_dir / f"run-{run_started}.log"
         self.file = self.path.open("a", encoding="utf-8")
+        self.writer = cast(
+            TextIO,
+            _CurrentLogWriter(self._write_current, self._flush_current, self._current_closed),
+        )
         self._original_stderr = sys.stderr
+        self._stderr_tee: _TeeWriter | None = None
         if tee_stderr:
-            sys.stderr = _TeeWriter(self._original_stderr, self.file)
+            self._stderr_tee = _TeeWriter(self._original_stderr, self.writer)
+            sys.stderr = self._stderr_tee
+
+    def _write_current(self, text: str) -> int:
+        with self._lock:
+            return self.file.write(text)
+
+    def _flush_current(self) -> None:
+        with self._lock:
+            self.file.flush()
+
+    def _current_closed(self) -> bool:
+        with self._lock:
+            return self.file.closed
 
     def lprint(self, text: str) -> None:
-        log_and_print(text, self.file)
+        log_and_print(text, self.writer)
 
     def switch(self, label: int | str):
         """Switch to a per-phase log file (``run-<datetime>-<label>.log``).
@@ -84,20 +132,20 @@ class RunLogger:
         ``file``. The stderr tee is updated to write to the new file as well.
         Returns the new file handle.
         """
-        previous_file = self.file
-        previous_file.flush()
-        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-        suffix = f"step{label}" if isinstance(label, int) else label
-        new_path = self.log_dir / f"run-{ts}-{suffix}.log"
-        new_file = new_path.open("a", encoding="utf-8")
-        self.path = new_path
-        self.file = new_file
-        if self._tee_stderr:
-            sys.stderr = _TeeWriter(self._original_stderr, new_file)
-        previous_file.close()
-        return new_file
+        with self._lock:
+            previous_file = self.file
+            previous_file.flush()
+            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+            suffix = f"step{label}" if isinstance(label, int) else label
+            new_path = self.log_dir / f"run-{ts}-{suffix}.log"
+            new_file = new_path.open("a", encoding="utf-8")
+            self.path = new_path
+            self.file = new_file
+            previous_file.close()
+            return new_file
 
     def close(self) -> None:
-        if self._tee_stderr:
-            sys.stderr = self._original_stderr
-        self.file.close()
+        with self._lock:
+            if self._stderr_tee is not None and sys.stderr is self._stderr_tee:
+                sys.stderr = self._original_stderr
+            self.file.close()

--- a/src/vibesys/run/logger.py
+++ b/src/vibesys/run/logger.py
@@ -80,11 +80,12 @@ class RunLogger:
         Callers that want a different prefix (e.g. ``round007``) should pass
         a string.
 
-        The previous log file is flushed but kept open. A new file becomes
-        ``file``. The stderr tee is updated to write to the new file as
-        well.  Returns the new file handle.
+        The previous log file is flushed and closed after the new file becomes
+        ``file``. The stderr tee is updated to write to the new file as well.
+        Returns the new file handle.
         """
-        self.file.flush()
+        previous_file = self.file
+        previous_file.flush()
         ts = datetime.now().strftime("%Y%m%d-%H%M%S")
         suffix = f"step{label}" if isinstance(label, int) else label
         new_path = self.log_dir / f"run-{ts}-{suffix}.log"
@@ -93,6 +94,7 @@ class RunLogger:
         self.file = new_file
         if self._tee_stderr:
             sys.stderr = _TeeWriter(self._original_stderr, new_file)
+        previous_file.close()
         return new_file
 
     def close(self) -> None:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -54,12 +54,12 @@ def test_log_switch_retargets_stderr_tee_and_restores_on_close(tmp_path):
         workspace=tmp_path / "workspace",
         run_log_path=ctx.logger.path,
     )
-    original_log = ctx.run_log_file
-    ctx.agent_runner = SimpleNamespace(_run_log_file=original_log)
+    original_file = ctx.logger.file
+    ctx.agent_runner = SimpleNamespace(_run_log_file=ctx.run_log_file)
 
     ctx.switch_log_file("round001")
 
-    assert original_log.closed
+    assert original_file.closed
     assert ctx.agent_runner._run_log_file is ctx.run_log_file
     # The unconditional tee mirrors stderr into the *current* log file,
     # stripped of ANSI escapes, while writes still reach the real stderr.

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -55,9 +55,12 @@ def test_log_switch_retargets_stderr_tee_and_restores_on_close(tmp_path):
         run_log_path=ctx.logger.path,
     )
     original_log = ctx.run_log_file
+    ctx.agent_runner = SimpleNamespace(_run_log_file=original_log)
 
     ctx.switch_log_file("round001")
 
+    assert original_log.closed
+    assert ctx.agent_runner._run_log_file is ctx.run_log_file
     # The unconditional tee mirrors stderr into the *current* log file,
     # stripped of ANSI escapes, while writes still reach the real stderr.
     print("\033[31mcolored diagnostic\033[0m", file=sys.stderr)
@@ -67,7 +70,6 @@ def test_log_switch_retargets_stderr_tee_and_restores_on_close(tmp_path):
     assert sys.stderr is original_stderr
     assert "colored diagnostic" in ctx.run_log_path.read_text()
     assert "\033[31m" not in ctx.run_log_path.read_text()
-    original_log.close()
 
 
 def test_input_copy_respects_source_gitignore(tmp_path):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -33,3 +33,20 @@ def test_no_tee_logger_leaves_stderr_untouched(tmp_path):
         logger.close()
     assert sys.stderr is original
     assert "candidate line" in logger.path.read_text()
+
+
+def test_switch_closes_each_superseded_log_file(tmp_path):
+    logger = RunLogger(tmp_path, tee_stderr=False)
+    first = logger.file
+
+    second = logger.switch("round001")
+    assert first.closed
+    assert not second.closed
+
+    third = logger.switch("round002")
+    assert second.closed
+    assert not third.closed
+
+    logger.close()
+    assert third.closed
+    logger.close()  # Cleanup remains idempotent.

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -50,3 +50,17 @@ def test_switch_closes_each_superseded_log_file(tmp_path):
     logger.close()
     assert third.closed
     logger.close()  # Cleanup remains idempotent.
+
+
+def test_stable_writer_follows_switch_after_old_file_is_closed(tmp_path):
+    logger = RunLogger(tmp_path, tee_stderr=False)
+    writer = logger.writer
+    first = logger.file
+
+    logger.switch("round001")
+    writer.write("written after switch\n")
+    writer.flush()
+
+    assert first.closed
+    assert "written after switch" in logger.path.read_text()
+    logger.close()


### PR DESCRIPTION
## Problem

Long-running loops switch run logs repeatedly. Retaining old files leaks descriptors, but closing them immediately breaks concurrent callbacks that captured a raw old handle, such as live experiment chat.

Fixes #215.

## Solution

RunLogger now exposes a stable synchronized writer that resolves the current file for every write. Switching atomically installs the new file and closes the old raw handle under the same lock. Agent runners and stderr keep the stable writer, so in-flight consumers continue safely across switches.

### Architecture

RunLogger remains the sole file owner. Consumers receive a stable forwarding writer rather than ownership of a phase-specific raw descriptor.

## Verification

Tests cover repeated handle closure, stable-writer writes after switching, stderr restoration, context retargeting, and full concurrent-consumer-compatible behavior.

### Correctness properties

- Superseded raw handles close after every successful switch.
- In-flight consumers never write through a closed phase handle.
- Writes and switches are serialized.
- stderr follows the current log and restores safely.
- Final close remains idempotent.

### Testing

- `uv run pytest tests/test_logger.py tests/test_context.py -q` — 28 passed.
- `uv run pytest -q` — 2,025 passed, 1 expected platform skip.
- Format, lint, type checking, and `git diff --check` passed.
