### PR TITLE
Isolate Docker CLI writes from host authentication state

### DIFF
--- a/src/vibesys/agents/cli_docker.py
+++ b/src/vibesys/agents/cli_docker.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shlex
+from dataclasses import dataclass
 from pathlib import Path
 
 # Per-provider environment variables to set inside the container.  Used as
@@ -113,29 +115,70 @@ def docker_init_commands(provider: str) -> list[str]:
     return list(_DOCKER_INSTALL_COMMANDS.get(provider, []))
 
 
-# Host paths to bind-mount RW so the in-container CLI inherits the host's
-# login state.  Only entries that actually exist on the host are mounted.
-# Claude paths are well-tested; the other three are best-guesses that may
-# need adjustment after first real run.
-DOCKER_AUTH_PATHS: dict[str, list[Path]] = {
-    "claude": [Path.home() / ".claude", Path.home() / ".claude.json"],
-    "gemini": [Path.home() / ".gemini"],
-    "codex": [Path.home() / ".codex"],
+@dataclass(frozen=True)
+class DockerAuthPath:
+    """Host provider state and its writable location inside the container."""
+
+    host_path: Path
+    container_path: str
+
+
+# Provider state is mounted read-only under ``/opt/vibesys-auth`` and copied
+# into the container's ephemeral writable layer before the CLI starts. This
+# preserves login state without allowing an agent to mutate persistent host
+# credentials, configuration, or history.
+DOCKER_AUTH_PATHS: dict[str, list[DockerAuthPath]] = {
+    "claude": [
+        DockerAuthPath(Path.home() / ".claude", "/root/.claude"),
+        DockerAuthPath(Path.home() / ".claude.json", "/root/.claude.json"),
+    ],
+    "gemini": [DockerAuthPath(Path.home() / ".gemini", "/root/.gemini")],
+    "codex": [DockerAuthPath(Path.home() / ".codex", "/root/.codex")],
     "opencode": [
-        Path.home() / ".local" / "share" / "opencode",
-        Path.home() / ".config" / "opencode",
+        DockerAuthPath(
+            Path.home() / ".local" / "share" / "opencode",
+            "/root/.local/share/opencode",
+        ),
+        DockerAuthPath(
+            Path.home() / ".config" / "opencode",
+            "/root/.config/opencode",
+        ),
     ],
 }
 
 
 def auth_bind_mounts(provider: str) -> list[tuple[str, str, bool]]:
-    """Return ``(host_path, container_path, readonly=False)`` for existing auth paths.
-
-    Auth dirs are mounted into ``/root`` since we run as root inside the
-    container.
-    """
+    """Return read-only staging mounts for existing provider state."""
     out: list[tuple[str, str, bool]] = []
-    for host in DOCKER_AUTH_PATHS.get(provider, []):
-        if host.exists():
-            out.append((str(host), "/root/" + host.name, False))
+    for index, spec in enumerate(DOCKER_AUTH_PATHS.get(provider, [])):
+        if spec.host_path.exists():
+            out.append(
+                (
+                    str(spec.host_path),
+                    f"/opt/vibesys-auth/{index}",
+                    True,
+                )
+            )
     return out
+
+
+def auth_copy_commands(provider: str) -> list[str]:
+    """Return commands that copy staged provider state into writable storage.
+
+    Directories contain runtime state such as sessions and history, so mounting
+    them read-only at their final locations can break otherwise valid CLI runs.
+    Copying from read-only staging keeps those writes inside the disposable
+    container layer.
+    """
+    commands: list[str] = []
+    for index, spec in enumerate(DOCKER_AUTH_PATHS.get(provider, [])):
+        if not spec.host_path.exists():
+            continue
+        source = shlex.quote(f"/opt/vibesys-auth/{index}")
+        destination = shlex.quote(spec.container_path)
+        parent = shlex.quote(str(Path(spec.container_path).parent))
+        if spec.host_path.is_dir():
+            commands.append(f"mkdir -p {destination} && cp -a {source}/. {destination}/")
+        else:
+            commands.append(f"mkdir -p {parent} && cp -a {source} {destination}")
+    return commands

--- a/src/vibesys/agents/cli_docker.py
+++ b/src/vibesys/agents/cli_docker.py
@@ -123,25 +123,75 @@ class DockerAuthPath:
     container_path: str
 
 
-# Provider state is mounted read-only under ``/opt/vibesys-auth`` and copied
-# into the container's ephemeral writable layer before the CLI starts. This
-# preserves login state without allowing an agent to mutate persistent host
-# credentials, configuration, or history.
+# Authentication and user configuration are mounted read-only under
+# ``/opt/vibesys-auth`` and copied into the container's ephemeral writable
+# layer before the CLI starts. Keep this list to provider-owned leaf files:
+# provider homes also contain large caches, worktrees, session history, package
+# installations, and databases that are neither required for authentication
+# nor appropriate to duplicate for every sandbox.
 DOCKER_AUTH_PATHS: dict[str, list[DockerAuthPath]] = {
     "claude": [
-        DockerAuthPath(Path.home() / ".claude", "/root/.claude"),
-        DockerAuthPath(Path.home() / ".claude.json", "/root/.claude.json"),
-    ],
-    "gemini": [DockerAuthPath(Path.home() / ".gemini", "/root/.gemini")],
-    "codex": [DockerAuthPath(Path.home() / ".codex", "/root/.codex")],
-    "opencode": [
         DockerAuthPath(
-            Path.home() / ".local" / "share" / "opencode",
-            "/root/.local/share/opencode",
+            Path.home() / ".claude" / ".credentials.json",
+            "/root/.claude/.credentials.json",
         ),
         DockerAuthPath(
-            Path.home() / ".config" / "opencode",
-            "/root/.config/opencode",
+            Path.home() / ".claude" / "settings.json",
+            "/root/.claude/settings.json",
+        ),
+        DockerAuthPath(
+            Path.home() / ".claude" / "settings.local.json",
+            "/root/.claude/settings.local.json",
+        ),
+        DockerAuthPath(Path.home() / ".claude.json", "/root/.claude.json"),
+    ],
+    "gemini": [
+        DockerAuthPath(
+            Path.home() / ".gemini" / "oauth_creds.json",
+            "/root/.gemini/oauth_creds.json",
+        ),
+        DockerAuthPath(
+            Path.home() / ".gemini" / "google_accounts.json",
+            "/root/.gemini/google_accounts.json",
+        ),
+        DockerAuthPath(
+            Path.home() / ".gemini" / "settings.json",
+            "/root/.gemini/settings.json",
+        ),
+        DockerAuthPath(Path.home() / ".gemini" / ".env", "/root/.gemini/.env"),
+    ],
+    "codex": [
+        DockerAuthPath(Path.home() / ".codex" / "auth.json", "/root/.codex/auth.json"),
+        DockerAuthPath(
+            Path.home() / ".codex" / "config.toml",
+            "/root/.codex/config.toml",
+        ),
+    ],
+    "opencode": [
+        DockerAuthPath(
+            Path.home() / ".local" / "share" / "opencode" / "auth.json",
+            "/root/.local/share/opencode/auth.json",
+        ),
+        DockerAuthPath(
+            Path.home() / ".config" / "opencode" / "opencode.json",
+            "/root/.config/opencode/opencode.json",
+        ),
+        DockerAuthPath(
+            Path.home() / ".config" / "opencode" / "opencode.jsonc",
+            "/root/.config/opencode/opencode.jsonc",
+        ),
+        # Older OpenCode releases used config.json/config.jsonc.
+        DockerAuthPath(
+            Path.home() / ".config" / "opencode" / "config.json",
+            "/root/.config/opencode/config.json",
+        ),
+        DockerAuthPath(
+            Path.home() / ".config" / "opencode" / "config.jsonc",
+            "/root/.config/opencode/config.jsonc",
+        ),
+        DockerAuthPath(
+            Path.home() / ".config" / "opencode" / ".env",
+            "/root/.config/opencode/.env",
         ),
     ],
 }

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -784,10 +784,11 @@ def _container_mount_plan(
 ) -> tuple[list[tuple[str, str, bool]], list[tuple[str, str]], list[str]]:
     """Build the bind mounts + setup symlinks for a sandbox.
 
-    ``include_cli_provider_mounts`` controls whether CLI auth dirs and the
-    full project tree are added under ``/root`` and ``/opt/vibesys``.
-    Defaults to True; both supported environments (local Docker and the
-    Modal-via-Docker mode) bind-mount these directly.
+    ``include_cli_provider_mounts`` controls whether CLI auth state and the
+    full project tree are added under ``/opt/vibesys-auth`` and
+    ``/opt/vibesys``. Defaults to True; both supported environments (local
+    Docker and the Modal-via-Docker mode) bind-mount these read-only and copy
+    auth state into the container's writable layer during setup.
     """
     bind_mounts: list[tuple[str, str, bool]] = []
     symlinks: list[tuple[str, str]] = []
@@ -859,12 +860,13 @@ def _cli_container_setup(
         return [], {}
     from vibesys.agents.cli_docker import (
         DOCKER_PROVIDER_ENV,
+        auth_copy_commands,
         docker_init_commands,
     )
 
     provider = request.cli_provider
     env = dict(DOCKER_PROVIDER_ENV.get(provider, {}))
-    commands = docker_init_commands(provider)
+    commands = [*auth_copy_commands(provider), *docker_init_commands(provider)]
     return commands, env
 
 

--- a/tests/agents/test_cli_docker.py
+++ b/tests/agents/test_cli_docker.py
@@ -32,14 +32,59 @@ def test_auth_import_copies_directories_and_files_to_private_writable_paths(
 
 def test_auth_import_uses_provider_native_container_paths():
     assert {
-        provider: [spec.container_path for spec in specs]
+        provider: [
+            (spec.host_path.relative_to(Path.home()).as_posix(), spec.container_path)
+            for spec in specs
+        ]
         for provider, specs in cli_docker.DOCKER_AUTH_PATHS.items()
     } == {
-        "claude": ["/root/.claude", "/root/.claude.json"],
-        "gemini": ["/root/.gemini"],
-        "codex": ["/root/.codex"],
+        "claude": [
+            (".claude/.credentials.json", "/root/.claude/.credentials.json"),
+            (".claude/settings.json", "/root/.claude/settings.json"),
+            (".claude/settings.local.json", "/root/.claude/settings.local.json"),
+            (".claude.json", "/root/.claude.json"),
+        ],
+        "gemini": [
+            (".gemini/oauth_creds.json", "/root/.gemini/oauth_creds.json"),
+            (".gemini/google_accounts.json", "/root/.gemini/google_accounts.json"),
+            (".gemini/settings.json", "/root/.gemini/settings.json"),
+            (".gemini/.env", "/root/.gemini/.env"),
+        ],
+        "codex": [
+            (".codex/auth.json", "/root/.codex/auth.json"),
+            (".codex/config.toml", "/root/.codex/config.toml"),
+        ],
         "opencode": [
-            "/root/.local/share/opencode",
-            "/root/.config/opencode",
+            (
+                ".local/share/opencode/auth.json",
+                "/root/.local/share/opencode/auth.json",
+            ),
+            (".config/opencode/opencode.json", "/root/.config/opencode/opencode.json"),
+            (
+                ".config/opencode/opencode.jsonc",
+                "/root/.config/opencode/opencode.jsonc",
+            ),
+            (".config/opencode/config.json", "/root/.config/opencode/config.json"),
+            (
+                ".config/opencode/config.jsonc",
+                "/root/.config/opencode/config.jsonc",
+            ),
+            (".config/opencode/.env", "/root/.config/opencode/.env"),
         ],
     }
+
+
+def test_provider_auth_imports_exclude_bulk_runtime_roots():
+    configured_sources = {
+        spec.host_path for specs in cli_docker.DOCKER_AUTH_PATHS.values() for spec in specs
+    }
+
+    assert configured_sources.isdisjoint(
+        {
+            Path.home() / ".claude",
+            Path.home() / ".gemini",
+            Path.home() / ".codex",
+            Path.home() / ".local" / "share" / "opencode",
+            Path.home() / ".config" / "opencode",
+        }
+    )

--- a/tests/agents/test_cli_docker.py
+++ b/tests/agents/test_cli_docker.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from vibesys.agents import cli_docker
+from vibesys.agents.cli_docker import DockerAuthPath
+
+
+def test_auth_import_copies_directories_and_files_to_private_writable_paths(
+    tmp_path: Path, monkeypatch
+):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text('{"synthetic": true}\n')
+    monkeypatch.setitem(
+        cli_docker.DOCKER_AUTH_PATHS,
+        "fixture",
+        [
+            DockerAuthPath(state_dir, "/root/.fixture"),
+            DockerAuthPath(auth_file, "/root/.fixture.json"),
+        ],
+    )
+
+    assert cli_docker.auth_bind_mounts("fixture") == [
+        (str(state_dir), "/opt/vibesys-auth/0", True),
+        (str(auth_file), "/opt/vibesys-auth/1", True),
+    ]
+    assert cli_docker.auth_copy_commands("fixture") == [
+        "mkdir -p /root/.fixture && cp -a /opt/vibesys-auth/0/. /root/.fixture/",
+        "mkdir -p /root && cp -a /opt/vibesys-auth/1 /root/.fixture.json",
+    ]
+
+
+def test_auth_import_uses_provider_native_container_paths():
+    assert {
+        provider: [spec.container_path for spec in specs]
+        for provider, specs in cli_docker.DOCKER_AUTH_PATHS.items()
+    } == {
+        "claude": ["/root/.claude", "/root/.claude.json"],
+        "gemini": ["/root/.gemini"],
+        "codex": ["/root/.codex"],
+        "opencode": [
+            "/root/.local/share/opencode",
+            "/root/.config/opencode",
+        ],
+    }

--- a/tests/sandbox/test_run_environment.py
+++ b/tests/sandbox/test_run_environment.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from vibesys.agents import cli_docker
+from vibesys.agents.cli_docker import DockerAuthPath
 from vibesys.backends import SandboxKind
 from vibesys.domains.environment import EnvironmentBindMount
 from vibesys.sandbox.run_environment import (
@@ -85,6 +87,27 @@ def test_docker_environment_opens_one_started_sandbox_with_agent_paths(tmp_path)
 
     session.close()
     backend.sandbox.stop.assert_called_once()
+
+
+def test_docker_environment_copies_cli_auth_from_readonly_staging(tmp_path, monkeypatch):
+    backend = FakeBackend()
+    env = build_run_environment(RunEnvironmentSpec("docker"))
+    codex_home = tmp_path / "synthetic-codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text('{"synthetic": true}\n')
+    monkeypatch.setitem(
+        cli_docker.DOCKER_AUTH_PATHS,
+        "codex",
+        [DockerAuthPath(codex_home, "/root/.codex")],
+    )
+
+    env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="codex"))
+
+    kwargs = backend.calls[0][1]
+    assert (str(codex_home), "/opt/vibesys-auth/0", True) in kwargs["bind_mounts"]
+    assert kwargs["extra_init_commands"][0] == (
+        "mkdir -p /root/.codex && cp -a /opt/vibesys-auth/0/. /root/.codex/"
+    )
 
 
 def test_docker_environment_uses_environment_bind_mounts(tmp_path):

--- a/tests/sandbox/test_run_environment.py
+++ b/tests/sandbox/test_run_environment.py
@@ -92,21 +92,21 @@ def test_docker_environment_opens_one_started_sandbox_with_agent_paths(tmp_path)
 def test_docker_environment_copies_cli_auth_from_readonly_staging(tmp_path, monkeypatch):
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
-    codex_home = tmp_path / "synthetic-codex-home"
-    codex_home.mkdir()
-    (codex_home / "auth.json").write_text('{"synthetic": true}\n')
+    auth_file = tmp_path / "synthetic-codex-home" / "auth.json"
+    auth_file.parent.mkdir()
+    auth_file.write_text('{"synthetic": true}\n')
     monkeypatch.setitem(
         cli_docker.DOCKER_AUTH_PATHS,
         "codex",
-        [DockerAuthPath(codex_home, "/root/.codex")],
+        [DockerAuthPath(auth_file, "/root/.codex/auth.json")],
     )
 
     env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="codex"))
 
     kwargs = backend.calls[0][1]
-    assert (str(codex_home), "/opt/vibesys-auth/0", True) in kwargs["bind_mounts"]
+    assert (str(auth_file), "/opt/vibesys-auth/0", True) in kwargs["bind_mounts"]
     assert kwargs["extra_init_commands"][0] == (
-        "mkdir -p /root/.codex && cp -a /opt/vibesys-auth/0/. /root/.codex/"
+        "mkdir -p /root/.codex && cp -a /opt/vibesys-auth/0 /root/.codex/auth.json"
     )
 
 


### PR DESCRIPTION
## Problem

Docker and Modal-via-Docker CLI agents previously bind-mounted provider authentication/state paths read-write at their final `/root` locations. A root coding agent could therefore overwrite persistent host credentials, settings, sessions, or history outside the run workspace. Fixes #223.

Mounting provider homes read-only at their final locations is also insufficient because the CLIs legitimately write runtime state. An initial private-copy implementation copied entire provider homes, but live testing showed that `~/.codex` duplicated about 4.48 GiB without launching the agent after more than 3.5 minutes. Provider caches, worktrees, sessions, databases, logs, and package installations are not authentication inputs and must not be copied into every sandbox.

## Solution

Represent each required provider authentication or configuration leaf file together with its provider-native container destination. Existing files are mounted read-only at indexed locations under `/opt/vibesys-auth`, then copied into the container private writable layer before the provider CLI starts.

The allowlists cover Claude credentials/settings, Gemini OAuth/account/settings inputs, Codex `auth.json` and `config.toml`, and OpenCode auth plus current and legacy global config names. Missing optional files remain optional. Large provider runtime roots are never mounted or copied.

### Architecture

```mermaid
flowchart LR
    H["Host auth/config leaf files"] -->|"read-only bind"| S["/opt/vibesys-auth/<index>"]
    S -->|"copy before CLI install"| P["Private writable provider paths"]
    P --> C["Claude / Gemini / Codex / OpenCode"]
```

`vibesys.agents.cli_docker` owns the provider-specific source/destination allowlists, read-only staging mounts, and copy commands. `RunEnvironment` orders those copy commands before provider installation. `DockerSandbox` remains the generic executor. Docker and Modal-via-Docker share the same import policy.

## Verification

Regression tests use synthetic authentication files. They verify directory and leaf-file copy behavior, exact provider-native leaf mappings, exclusion of every bulk provider root, read-only mount bits, and environment-level setup ordering.

A live fixed-path Docker probe used the real Codex `auth.json` and `config.toml` through the unmodified `DockerEnvironment` and `DockerSandbox` path. It staged 10,643 bytes instead of gigabytes, started in 21.956 seconds, reported ChatGPT login, rejected writes to staging, accepted writes to private state, and completed a real `gpt-5.4` coding-agent invocation in 19.829 seconds. The agent returned the exact marker and created the exact requested workspace file.

Host-side live calls also succeeded for Codex, Claude, Gemini, and OpenCode. Gemini required an explicit stable model because the configured preview model currently returns 404; authentication itself succeeded.

### Correctness properties

- Every host CLI authentication/config bind mount is read-only.
- Only explicit provider-owned leaf files are imported; provider runtime roots are excluded.
- Provider state is writable at the native location expected by each CLI inside the container.
- Container writes cannot propagate to host authentication/config files.
- Missing optional host files are neither mounted nor copied.
- Claude, Gemini, Codex, and OpenCode retain their supported authentication/config inputs.
- Docker and Modal-via-Docker use the same import policy.
- No real credentials are read by the automated test suite.

### Testing

- `uv run pytest tests/agents/test_cli_docker.py tests/sandbox/test_run_environment.py libs/vs-sandbox/tests/test_docker_sandbox.py` — 65 passed.
- `./scripts/check_format.sh` — passed.
- `./scripts/check_lint.sh` — passed.
- `./scripts/check_types.sh` — 0 errors, 0 warnings.
- `git diff --check` — passed.
- Live VibeSys Docker Codex authentication/edit probe — passed.
