### PR TITLE
Clean up containers after Docker startup failures

### DIFF
--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -377,14 +377,9 @@ class DockerSandbox(BaseSandbox):
         if result.returncode != 0:
             container_id = result.stdout.strip()
             if container_id:
-                rm_cmd = ["docker", "rm", container_id]
-                rm_result = subprocess.run(
-                    rm_cmd,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-                self._log_cmd(rm_cmd, rm_result)
+                self._container_id = container_id
+                _live_containers[container_id] = self._container_name
+                self._discard_started_container()
             raise RuntimeError(
                 f"Failed to start Docker container (exit {result.returncode}):\n"
                 f"  stdout: {result.stdout.strip()}\n"
@@ -485,7 +480,7 @@ class DockerSandbox(BaseSandbox):
 
     def _stop_and_remove_container(self, container_id: str, *, suppress_errors: bool) -> bool:
         """Stop and remove a container, retaining ownership until removal succeeds."""
-        cleanup_error: BaseException | None = None
+        cleanup_error: Exception | None = None
         commands = (
             (["docker", "stop", container_id], 30),
             (["docker", "rm", "-f", container_id], 10),
@@ -510,12 +505,12 @@ class DockerSandbox(BaseSandbox):
                             f"Failed to remove Docker container {container_id} "
                             f"(exit {result.returncode}): {result.stderr.strip()}"
                         )
-            except BaseException as exc:
+            except Exception as exc:
                 if cmd[1] == "rm":
                     cleanup_error = exc
                 try:
                     self._log_cmd(cmd, error=f"container cleanup failed: {exc}")
-                except BaseException:
+                except Exception:
                     pass
 
         if not removed and cleanup_error is not None and not suppress_errors:

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -41,16 +41,20 @@ def _cleanup_containers() -> None:
                 check=False,
                 timeout=30,
             )
-            subprocess.run(
-                ["docker", "rm", container_id],
+        except Exception:
+            pass
+        try:
+            removed = subprocess.run(
+                ["docker", "rm", "-f", container_id],
                 capture_output=True,
                 text=True,
                 check=False,
                 timeout=10,
             )
         except Exception:
-            pass
-        _live_containers.pop(container_id, None)
+            continue
+        if removed.returncode == 0 or "No such container" in (removed.stderr or ""):
+            _live_containers.pop(container_id, None)
 
 
 atexit.register(_cleanup_containers)
@@ -475,31 +479,48 @@ class DockerSandbox(BaseSandbox):
             return
 
         container_id = self._container_id
-        self._container_id = None
-        _live_containers.pop(container_id, None)
-        self._stop_and_remove_container(container_id, suppress_errors=True)
+        if self._stop_and_remove_container(container_id, suppress_errors=True):
+            self._container_id = None
+            _live_containers.pop(container_id, None)
 
-    def _stop_and_remove_container(self, container_id: str, *, suppress_errors: bool) -> None:
-        """Run both cleanup commands, optionally preserving an earlier error."""
-        errors: list[BaseException] = []
-        for cmd in (["docker", "stop", container_id], ["docker", "rm", container_id]):
+    def _stop_and_remove_container(self, container_id: str, *, suppress_errors: bool) -> bool:
+        """Stop and remove a container, retaining ownership until removal succeeds."""
+        cleanup_error: BaseException | None = None
+        commands = (
+            (["docker", "stop", container_id], 30),
+            (["docker", "rm", "-f", container_id], 10),
+        )
+        removed = False
+        for cmd, timeout in commands:
             try:
                 result = subprocess.run(
                     cmd,
                     capture_output=True,
                     text=True,
                     check=False,
+                    timeout=timeout,
                 )
                 self._log_cmd(cmd, result)
+                if cmd[1] == "rm":
+                    removed = result.returncode == 0 or "No such container" in (
+                        result.stderr or ""
+                    )
+                    if not removed:
+                        cleanup_error = RuntimeError(
+                            f"Failed to remove Docker container {container_id} "
+                            f"(exit {result.returncode}): {result.stderr.strip()}"
+                        )
             except BaseException as exc:
-                errors.append(exc)
+                if cmd[1] == "rm":
+                    cleanup_error = exc
                 try:
                     self._log_cmd(cmd, error=f"container cleanup failed: {exc}")
                 except BaseException:
                     pass
 
-        if errors and not suppress_errors:
-            raise errors[0]
+        if not removed and cleanup_error is not None and not suppress_errors:
+            raise cleanup_error
+        return removed
 
     def _save_metadata(self) -> None:
         """Write metadata to the host workspace (best-effort)."""
@@ -520,9 +541,9 @@ class DockerSandbox(BaseSandbox):
             return
 
         container_id = self._container_id
-        self._container_id = None
-        _live_containers.pop(container_id, None)
-        self._stop_and_remove_container(container_id, suppress_errors=False)
+        if self._stop_and_remove_container(container_id, suppress_errors=False):
+            self._container_id = None
+            _live_containers.pop(container_id, None)
 
     @property
     def id(self) -> str:

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -390,6 +390,18 @@ class DockerSandbox(BaseSandbox):
         self._container_id = result.stdout.strip()
         _live_containers[self._container_id] = self._container_name
 
+        try:
+            self._initialize_started_container()
+        except BaseException:
+            self._discard_started_container()
+            raise
+
+    def _initialize_started_container(self) -> None:
+        """Finish startup after Docker has created and registered the container."""
+        container_id = self._container_id
+        if container_id is None:
+            raise RuntimeError("Container was not created before initialization")
+
         # Save metadata for vibesys-shell to reconstruct the environment
         self._metadata = {
             "image": self._image,
@@ -404,7 +416,7 @@ class DockerSandbox(BaseSandbox):
         self._save_metadata()
 
         # Install uv (with timeout to avoid hanging on network issues)
-        uv_cmd = ["docker", "exec", self._container_id, "bash", "-c", "pip install uv"]
+        uv_cmd = ["docker", "exec", container_id, "bash", "-c", "pip install uv"]
         try:
             uv_result = subprocess.run(
                 uv_cmd,
@@ -424,7 +436,7 @@ class DockerSandbox(BaseSandbox):
             init_cmd = [
                 "docker",
                 "exec",
-                self._container_id,
+                container_id,
                 "bash",
                 "-c",
                 init_cmd_str,
@@ -457,6 +469,38 @@ class DockerSandbox(BaseSandbox):
         for fn in self._setup_fns:
             fn(self)
 
+    def _discard_started_container(self) -> None:
+        """Best-effort rollback for a container whose startup did not finish."""
+        if self._container_id is None:
+            return
+
+        container_id = self._container_id
+        self._container_id = None
+        _live_containers.pop(container_id, None)
+        self._stop_and_remove_container(container_id, suppress_errors=True)
+
+    def _stop_and_remove_container(self, container_id: str, *, suppress_errors: bool) -> None:
+        """Run both cleanup commands, optionally preserving an earlier error."""
+        errors: list[BaseException] = []
+        for cmd in (["docker", "stop", container_id], ["docker", "rm", container_id]):
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self._log_cmd(cmd, result)
+            except BaseException as exc:
+                errors.append(exc)
+                try:
+                    self._log_cmd(cmd, error=f"container cleanup failed: {exc}")
+                except BaseException:
+                    pass
+
+        if errors and not suppress_errors:
+            raise errors[0]
+
     def _save_metadata(self) -> None:
         """Write metadata to the host workspace (best-effort)."""
         try:
@@ -478,23 +522,7 @@ class DockerSandbox(BaseSandbox):
         container_id = self._container_id
         self._container_id = None
         _live_containers.pop(container_id, None)
-
-        stop_cmd = ["docker", "stop", container_id]
-        stop_result = subprocess.run(
-            stop_cmd,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        self._log_cmd(stop_cmd, stop_result)
-        rm_cmd = ["docker", "rm", container_id]
-        rm_result = subprocess.run(
-            rm_cmd,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        self._log_cmd(rm_cmd, rm_result)
+        self._stop_and_remove_container(container_id, suppress_errors=False)
 
     @property
     def id(self) -> str:

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -180,7 +180,7 @@ class TestStart:
             assert sandbox._container_id is None
             assert "abc123" not in _live_containers
             assert mock_run.call_args_list[-2][0][0] == ["docker", "stop", "abc123"]
-            assert mock_run.call_args_list[-1][0][0] == ["docker", "rm", "abc123"]
+            assert mock_run.call_args_list[-1][0][0] == ["docker", "rm", "-f", "abc123"]
         finally:
             _live_containers.pop("abc123", None)
 
@@ -347,9 +347,49 @@ class TestSetupFns:
             assert "abc123" not in _live_containers
             commands = [call.args[0] for call in mock_run.call_args_list]
             assert ["docker", "stop", "abc123"] in commands
-            assert ["docker", "rm", "abc123"] in commands
+            assert ["docker", "rm", "-f", "abc123"] in commands
         finally:
             _live_containers.pop("abc123", None)
+
+    @pytest.mark.parametrize("cleanup_mode", ["raises", "nonzero"])
+    @patch("subprocess.run")
+    def test_setup_failure_retains_container_for_retry_when_removal_fails(
+        self, mock_run, cleanup_mode, tmp_path
+    ):
+        from vs_sandbox.docker_sandbox import _live_containers
+
+        def fail_setup(_sandbox: DockerSandbox) -> None:
+            raise ValueError("setup exploded")
+
+        def run(cmd, **_kwargs):
+            if cmd[:2] == ["docker", "run"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="abc123\n", stderr=""
+                )
+            if cmd[:2] in (["docker", "stop"], ["docker", "rm"]):
+                if cleanup_mode == "raises":
+                    raise OSError("Docker daemon disconnected")
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=1, stdout="", stderr="daemon unavailable"
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = run
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="test-image",
+            setup_fns=[fail_setup],
+        )
+
+        try:
+            with pytest.raises(ValueError, match="setup exploded"):
+                sandbox.start()
+
+            assert sandbox._container_id == "abc123"
+            assert "abc123" in _live_containers
+        finally:
+            _live_containers.pop("abc123", None)
+            sandbox._container_id = None
 
 
 class TestStop:

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -154,6 +154,36 @@ class TestStart:
         cmd_str = " ".join(cmd)
         assert "pip install uv" in cmd_str
 
+    @patch("subprocess.run")
+    def test_init_failure_stops_and_removes_created_container(self, mock_run, tmp_path):
+        from vs_sandbox.docker_sandbox import _live_containers
+
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="test-image",
+            extra_init_commands=["install-required-tool"],
+        )
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(
+                args=[], returncode=17, stdout="partial output", stderr="install failed"
+            ),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ]
+
+        try:
+            with pytest.raises(RuntimeError, match="Container init command failed"):
+                sandbox.start()
+
+            assert sandbox._container_id is None
+            assert "abc123" not in _live_containers
+            assert mock_run.call_args_list[-2][0][0] == ["docker", "stop", "abc123"]
+            assert mock_run.call_args_list[-1][0][0] == ["docker", "rm", "abc123"]
+        finally:
+            _live_containers.pop("abc123", None)
+
 
 class TestExecute:
     @patch("subprocess.run")
@@ -285,6 +315,41 @@ class TestSetupFns:
         s.start()
         s.start()
         assert calls == 2
+
+    @patch("subprocess.run")
+    def test_setup_failure_preserves_error_when_stop_fails(self, mock_run, tmp_path):
+        from vs_sandbox.docker_sandbox import _live_containers
+
+        def fail_setup(_sandbox: DockerSandbox) -> None:
+            raise ValueError("setup exploded")
+
+        def run(cmd, **_kwargs):
+            if cmd[:2] == ["docker", "run"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="abc123\n", stderr=""
+                )
+            if cmd[:2] == ["docker", "stop"]:
+                raise OSError("Docker daemon disconnected")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = run
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="test-image",
+            setup_fns=[fail_setup],
+        )
+
+        try:
+            with pytest.raises(ValueError, match="setup exploded"):
+                sandbox.start()
+
+            assert sandbox._container_id is None
+            assert "abc123" not in _live_containers
+            commands = [call.args[0] for call in mock_run.call_args_list]
+            assert ["docker", "stop", "abc123"] in commands
+            assert ["docker", "rm", "abc123"] in commands
+        finally:
+            _live_containers.pop("abc123", None)
 
 
 class TestStop:

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -79,6 +79,8 @@ class TestStart:
 
     @patch("subprocess.run")
     def test_start_failure_removes_created_container(self, mock_run, sandbox):
+        from vs_sandbox.docker_sandbox import _live_containers
+
         mock_run.side_effect = [
             subprocess.CompletedProcess(
                 args=[],
@@ -87,13 +89,48 @@ class TestStart:
                 stderr="gpu error",
             ),
             subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
         ]
 
         with pytest.raises(RuntimeError, match="Failed to start Docker container"):
             sandbox.start()
 
-        rm_cmd = mock_run.call_args_list[1][0][0]
-        assert rm_cmd == ["docker", "rm", "abc123container"]
+        stop_call, rm_call = mock_run.call_args_list[1:]
+        assert stop_call.args[0] == ["docker", "stop", "abc123container"]
+        assert stop_call.kwargs["timeout"] == 30
+        assert rm_call.args[0] == ["docker", "rm", "-f", "abc123container"]
+        assert rm_call.kwargs["timeout"] == 10
+        assert sandbox._container_id is None
+        assert "abc123container" not in _live_containers
+
+    @patch("subprocess.run")
+    def test_start_failure_retains_created_container_when_removal_fails(
+        self, mock_run, sandbox
+    ):
+        from vs_sandbox.docker_sandbox import _live_containers
+
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=125,
+                stdout="abc123container\n",
+                stderr="gpu error",
+            ),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="daemon unavailable"
+            ),
+        ]
+
+        try:
+            with pytest.raises(RuntimeError, match="Failed to start Docker container"):
+                sandbox.start()
+
+            assert sandbox._container_id == "abc123container"
+            assert "abc123container" in _live_containers
+        finally:
+            _live_containers.pop("abc123container", None)
+            sandbox._container_id = None
 
     @patch.dict("os.environ", {"CUDA_VISIBLE_DEVICES": "3,5,7"})
     @patch("subprocess.run")
@@ -431,6 +468,97 @@ class TestStop:
         sandbox.stop()
         assert mock_run.call_count == 0
 
+    @pytest.mark.parametrize("cleanup_mode", ["raises", "nonzero"])
+    @patch("subprocess.run")
+    def test_failed_removal_retains_ownership_and_can_be_retried(
+        self, mock_run, cleanup_mode, sandbox
+    ):
+        from vs_sandbox.docker_sandbox import _live_containers
+
+        sandbox._container_id = "abc123"
+        _live_containers["abc123"] = "vibesys-test"
+
+        def fail_removal(cmd, **_kwargs):
+            if cmd[1] == "rm":
+                if cleanup_mode == "raises":
+                    raise OSError("Docker daemon disconnected")
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=1, stdout="", stderr="daemon unavailable"
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = fail_removal
+        try:
+            expected_error = OSError if cleanup_mode == "raises" else RuntimeError
+            with pytest.raises(expected_error):
+                sandbox.stop()
+
+            assert sandbox._container_id == "abc123"
+            assert "abc123" in _live_containers
+
+            mock_run.side_effect = None
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
+            sandbox.stop()
+
+            assert sandbox._container_id is None
+            assert "abc123" not in _live_containers
+        finally:
+            _live_containers.pop("abc123", None)
+            sandbox._container_id = None
+
+    @patch("subprocess.run")
+    def test_stop_failure_does_not_prevent_forced_removal(self, mock_run, sandbox):
+        from vs_sandbox.docker_sandbox import _live_containers
+
+        sandbox._container_id = "abc123"
+        _live_containers["abc123"] = "vibesys-test"
+        mock_run.side_effect = [
+            OSError("Docker daemon disconnected"),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ]
+
+        sandbox.stop()
+
+        assert mock_run.call_args_list[1].args[0] == ["docker", "rm", "-f", "abc123"]
+        assert sandbox._container_id is None
+        assert "abc123" not in _live_containers
+
+    @patch("subprocess.run")
+    def test_already_absent_container_clears_ownership(self, mock_run, sandbox):
+        from vs_sandbox.docker_sandbox import _live_containers
+
+        sandbox._container_id = "abc123"
+        _live_containers["abc123"] = "vibesys-test"
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="Error: No such container: abc123"
+        )
+
+        sandbox.stop()
+
+        assert sandbox._container_id is None
+        assert "abc123" not in _live_containers
+
+    @patch("subprocess.run")
+    def test_keyboard_interrupt_is_not_swallowed(self, mock_run, sandbox):
+        from vs_sandbox.docker_sandbox import _live_containers
+
+        sandbox._container_id = "abc123"
+        _live_containers["abc123"] = "vibesys-test"
+        mock_run.side_effect = KeyboardInterrupt()
+
+        try:
+            with pytest.raises(KeyboardInterrupt):
+                sandbox.stop()
+
+            assert mock_run.call_count == 1
+            assert sandbox._container_id == "abc123"
+            assert "abc123" in _live_containers
+        finally:
+            _live_containers.pop("abc123", None)
+            sandbox._container_id = None
+
 
 class TestIdProperty:
     @patch("subprocess.run")
@@ -615,6 +743,46 @@ class TestCleanupOnExit:
         rm_calls = [c for c in mock_run.call_args_list if "rm" in c[0][0]]
         assert len(stop_calls) == 1
         assert len(rm_calls) == 1
+
+    @pytest.mark.parametrize("cleanup_mode", ["raises", "nonzero"])
+    @patch("subprocess.run")
+    def test_cleanup_retains_failed_removal_for_retry(self, mock_run, cleanup_mode):
+        from vs_sandbox.docker_sandbox import _cleanup_containers, _live_containers
+
+        _live_containers["abc123"] = "vibesys-test"
+
+        def fail_removal(cmd, **_kwargs):
+            if cmd[1] == "rm":
+                if cleanup_mode == "raises":
+                    raise OSError("Docker daemon disconnected")
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=1, stdout="", stderr="daemon unavailable"
+                )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = fail_removal
+
+        _cleanup_containers()
+
+        assert "abc123" in _live_containers
+        rm_call = mock_run.call_args_list[1]
+        assert rm_call.args[0] == ["docker", "rm", "-f", "abc123"]
+        assert rm_call.kwargs["timeout"] == 10
+
+    @patch("subprocess.run")
+    def test_cleanup_forces_removal_after_stop_exception(self, mock_run):
+        from vs_sandbox.docker_sandbox import _cleanup_containers, _live_containers
+
+        _live_containers["abc123"] = "vibesys-test"
+        mock_run.side_effect = [
+            OSError("Docker daemon disconnected"),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ]
+
+        _cleanup_containers()
+
+        assert mock_run.call_args_list[1].args[0] == ["docker", "rm", "-f", "abc123"]
+        assert "abc123" not in _live_containers
 
 
 class TestWrite:


### PR DESCRIPTION
## Problem

A Docker container can be created successfully and then fail during initialization. Rollback previously forgot container ownership before proving removal succeeded, and ignored nonzero cleanup results, potentially orphaning a live container.

Fixes #225.

## Solution

Startup rollback and public stop retain local and process-wide ownership until docker rm -f succeeds or confirms the container is absent. Stop and remove are both attempted with bounded timeouts, nonzero removal is actionable, and startup still preserves its original exception while retaining failed cleanup for retry. Operational cleanup catches do not swallow cancellation signals.

### Architecture

DockerSandbox owns its container until confirmed removal. The process registry provides a later SIGINT or atexit retry when immediate rollback cannot reach Docker.

## Verification

Tests cover init/setup failures, partial docker run failures, stop exceptions with successful removal, stop/remove exceptions, nonzero cleanup results, retry success, already-absent containers, cancellation propagation, normal stop, and process-wide cleanup.

### Correctness properties

- Failed removal never clears the last retry owner.
- Nonzero rm results are not treated as success.
- Cleanup subprocesses are bounded.
- Successful or already-absent removal clears ownership exactly once.
- Cleanup failures do not replace startup failures.
- KeyboardInterrupt and SystemExit are not swallowed by operational cleanup.

### Testing

- `uv run pytest libs/vs-sandbox/tests/test_docker_sandbox.py -q` — 55 passed.
- `uv run pytest -q` — 2,036 passed, 1 expected platform skip.
- Format, lint, type checking, and `git diff --check` passed.
