### PR TITLE
Preserve issue-board state when persisted JSON is invalid

### DIFF
--- a/libs/vs-issue-board/README.md
+++ b/libs/vs-issue-board/README.md
@@ -19,6 +19,8 @@ orchestration around it.
 - Opening or reloading malformed, structurally invalid, or unsupported-version
   state raises `IssueBoardLoadError` without replacing the file or the last
   valid in-memory snapshot.
+- Reloading a store that has disappeared or cannot be read raises the same
+  error and preserves the last valid in-memory snapshot.
 - `on_change` lets applications attach derived views such as markdown mirrors
   without making rendering part of the core library.
 - `CreateIssuePolicy` keeps role-specific create limits out of application

--- a/libs/vs-issue-board/README.md
+++ b/libs/vs-issue-board/README.md
@@ -16,6 +16,9 @@ orchestration around it.
   models/enums for issue state and history.
 - `IssueBoard.reload()` lets multiple processes coordinate through the same
   file.
+- Opening or reloading malformed, structurally invalid, or unsupported-version
+  state raises `IssueBoardLoadError` without replacing the file or the last
+  valid in-memory snapshot.
 - `on_change` lets applications attach derived views such as markdown mirrors
   without making rendering part of the core library.
 - `CreateIssuePolicy` keeps role-specific create limits out of application

--- a/libs/vs-issue-board/src/vs_issue_board/__init__.py
+++ b/libs/vs-issue-board/src/vs_issue_board/__init__.py
@@ -1,6 +1,7 @@
 from vs_issue_board.core import (
     Issue,
     IssueBoard,
+    IssueBoardLoadError,
     IssueEvent,
     IssueStatus,
     IssueType,
@@ -17,6 +18,7 @@ __all__ = [
     "CreateIssuePolicy",
     "Issue",
     "IssueBoard",
+    "IssueBoardLoadError",
     "IssueEvent",
     "IssueStatus",
     "IssueType",

--- a/libs/vs-issue-board/src/vs_issue_board/core.py
+++ b/libs/vs-issue-board/src/vs_issue_board/core.py
@@ -16,9 +16,9 @@ from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
 from threading import RLock
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 _STORE_VERSION = 1
 
@@ -42,6 +42,8 @@ _TYPE_RANK = {IssueType.BUG: 0, IssueType.FEATURE: 1, IssueType.PERF: 2}
 class IssueEvent(BaseModel):
     """A single state-transition or comment record on an issue."""
 
+    model_config = ConfigDict(extra="forbid")
+
     timestamp: str
     actor: str
     action: str
@@ -53,7 +55,9 @@ class IssueEvent(BaseModel):
 class Issue(BaseModel):
     """A single tracker entry persisted as JSON."""
 
-    id: int
+    model_config = ConfigDict(extra="forbid")
+
+    id: int = Field(ge=1)
     type: IssueType
     title: str
     description: str
@@ -79,6 +83,15 @@ class _IssueBoardData(BaseModel):
     version: Literal[1]
     next_id: int = Field(ge=1)
     issues: list[Issue]
+
+    @model_validator(mode="after")
+    def _valid_issue_identity(self) -> Self:
+        issue_ids = [issue.id for issue in self.issues]
+        if len(issue_ids) != len(set(issue_ids)):
+            raise ValueError("issue IDs must be unique")
+        if issue_ids and self.next_id <= max(issue_ids):
+            raise ValueError("next_id must be greater than every persisted issue ID")
+        return self
 
 
 class IssueBoard:

--- a/libs/vs-issue-board/src/vs_issue_board/core.py
+++ b/libs/vs-issue-board/src/vs_issue_board/core.py
@@ -16,9 +16,9 @@ from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
 from threading import RLock
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 _STORE_VERSION = 1
 
@@ -67,6 +67,20 @@ class Issue(BaseModel):
     closed_iter: int | None = None
 
 
+class IssueBoardLoadError(ValueError):
+    """Raised when persisted issue-board state cannot be loaded safely."""
+
+
+class _IssueBoardData(BaseModel):
+    """Versioned persistence contract for an issue board."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal[1]
+    next_id: int = Field(ge=1)
+    issues: list[Issue]
+
+
 class IssueBoard:
     """Atomic JSON-backed issue tracker."""
 
@@ -84,16 +98,37 @@ class IssueBoard:
             "next_id": 1,
             "issues": [],
         }
-        if self.path.is_file():
-            try:
-                loaded = json.loads(self.path.read_text(encoding="utf-8"))
-                if isinstance(loaded, dict) and loaded.get("version") == _STORE_VERSION:
-                    self._data = loaded
-            except (json.JSONDecodeError, ValueError):
-                pass
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self._save_locked()
+        if self.path.is_file():
+            self._data = self._load_from_disk()
+        else:
+            self._save_locked()
         self._on_change = on_change
+
+    def _load_from_disk(self) -> dict[str, Any]:
+        try:
+            loaded = json.loads(self.path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise IssueBoardLoadError(
+                f"cannot load issue board {self.path}: invalid JSON: {exc}"
+            ) from exc
+        if not isinstance(loaded, dict):
+            raise IssueBoardLoadError(
+                f"cannot load issue board {self.path}: expected a JSON object"
+            )
+        version = loaded.get("version")
+        if version != _STORE_VERSION:
+            raise IssueBoardLoadError(
+                f"cannot load issue board {self.path}: unsupported version "
+                f"{version!r}; expected {_STORE_VERSION}"
+            )
+        try:
+            data = _IssueBoardData.model_validate(loaded)
+        except ValidationError as exc:
+            raise IssueBoardLoadError(
+                f"cannot load issue board {self.path}: invalid store structure: {exc}"
+            ) from exc
+        return data.model_dump(mode="json")
 
     def _save_locked(self) -> None:
         tmp = self.path.with_suffix(self.path.suffix + ".tmp")
@@ -112,14 +147,7 @@ class IssueBoard:
     def reload(self) -> None:
         """Re-read the JSON file from disk, discarding the in-memory copy."""
         with self._lock:
-            if not self.path.is_file():
-                return
-            try:
-                loaded = json.loads(self.path.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, ValueError):
-                return
-            if isinstance(loaded, dict) and loaded.get("version") == _STORE_VERSION:
-                self._data = loaded
+            self._data = self._load_from_disk()
 
     def _issue_from_dict(self, raw: dict[str, Any]) -> Issue:
         return Issue.model_validate(raw)

--- a/libs/vs-issue-board/src/vs_issue_board/core.py
+++ b/libs/vs-issue-board/src/vs_issue_board/core.py
@@ -112,6 +112,10 @@ class IssueBoard:
             raise IssueBoardLoadError(
                 f"cannot load issue board {self.path}: invalid JSON: {exc}"
             ) from exc
+        except OSError as exc:
+            raise IssueBoardLoadError(
+                f"cannot load issue board {self.path}: cannot read store: {exc}"
+            ) from exc
         if not isinstance(loaded, dict):
             raise IssueBoardLoadError(
                 f"cannot load issue board {self.path}: expected a JSON object"

--- a/libs/vs-issue-board/tests/test_issue_board_core.py
+++ b/libs/vs-issue-board/tests/test_issue_board_core.py
@@ -173,6 +173,17 @@ class TestReload:
         assert [issue.title for issue in store.list()] == ["last valid"]
         assert path.read_bytes() == incompatible
 
+    def test_reload_missing_file_raises_and_preserves_last_valid_snapshot(self, tmp_path):
+        path = tmp_path / "issues.json"
+        store = IssueBoard(path)
+        _create(store, title="last valid")
+        path.unlink()
+
+        with pytest.raises(IssueBoardLoadError, match="cannot read store"):
+            store.reload()
+
+        assert [issue.title for issue in store.list()] == ["last valid"]
+
 
 # ---------------------------------------------------------------------------
 # list / filter

--- a/libs/vs-issue-board/tests/test_issue_board_core.py
+++ b/libs/vs-issue-board/tests/test_issue_board_core.py
@@ -111,6 +111,62 @@ class TestLoadCorrupt:
 
         assert path.read_bytes() == original
 
+    @pytest.mark.parametrize(
+        ("next_id", "issue_ids", "message"),
+        [
+            (1, [1], "next_id must be greater"),
+            (3, [1, 1], "issue IDs must be unique"),
+            (2, [0], "greater than or equal to 1"),
+        ],
+    )
+    def test_load_rejects_invalid_issue_identity(
+        self, tmp_path, next_id, issue_ids, message
+    ):
+        path = tmp_path / "issues.json"
+        issues = [
+            {
+                "id": issue_id,
+                "type": "bug",
+                "title": f"issue {index}",
+                "description": "description",
+                "status": "open",
+                "created_by": "agent",
+                "created_iter": 1,
+                "created_at": "2026-01-01",
+                "updated_at": "2026-01-01",
+                "history": [],
+            }
+            for index, issue_id in enumerate(issue_ids)
+        ]
+        path.write_text(json.dumps({"version": 1, "next_id": next_id, "issues": issues}))
+        original = path.read_bytes()
+
+        with pytest.raises(IssueBoardLoadError, match=message):
+            IssueBoard(path)
+
+        assert path.read_bytes() == original
+
+    @pytest.mark.parametrize(
+        "mutate",
+        [
+            lambda payload: payload["issues"][0].update({"external_metadata": "unknown"}),
+            lambda payload: payload["issues"][0]["history"][0].update({"trace_id": "unknown"}),
+        ],
+    )
+    def test_load_rejects_unknown_nested_fields(self, tmp_path, mutate):
+        path = tmp_path / "issues.json"
+        board = IssueBoard(path)
+        _create(board, title="existing")
+        payload = json.loads(path.read_text())
+        mutate(payload)
+        path.write_text(json.dumps(payload))
+        original = path.read_bytes()
+
+        with pytest.raises(IssueBoardLoadError, match="invalid store structure"):
+            IssueBoard(path)
+
+        assert path.read_bytes() == original
+
     def test_open_existing_does_not_overwrite_concurrent_write(self, tmp_path, monkeypatch):
         path = tmp_path / "issues.json"
         writer = IssueBoard(path)

--- a/libs/vs-issue-board/tests/test_issue_board_core.py
+++ b/libs/vs-issue-board/tests/test_issue_board_core.py
@@ -2,6 +2,7 @@
 
 import json
 import time
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from vs_issue_board import (
     Issue,
     IssueBoard,
+    IssueBoardLoadError,
     IssueStatus,
     IssueType,
 )
@@ -76,17 +78,59 @@ class TestCreate:
 
 
 class TestLoadCorrupt:
-    def test_load_corrupt_json_starts_empty(self, tmp_path):
+    def test_load_corrupt_json_raises_without_replacing_file(self, tmp_path):
         path = tmp_path / "issues.json"
         path.write_text("not json", encoding="utf-8")
-        store = IssueBoard(path)
-        assert store.list() == []
+        original = path.read_bytes()
 
-    def test_load_wrong_version_starts_empty(self, tmp_path):
+        with pytest.raises(IssueBoardLoadError, match="invalid JSON"):
+            IssueBoard(path)
+
+        assert path.read_bytes() == original
+
+    def test_load_wrong_version_raises_without_replacing_file(self, tmp_path):
         path = tmp_path / "issues.json"
         path.write_text(json.dumps({"version": 999, "next_id": 1, "issues": []}), encoding="utf-8")
-        store = IssueBoard(path)
-        assert store.list() == []
+        original = path.read_bytes()
+
+        with pytest.raises(IssueBoardLoadError, match="unsupported version 999"):
+            IssueBoard(path)
+
+        assert path.read_bytes() == original
+
+    def test_load_invalid_store_structure_raises_without_replacing_file(self, tmp_path):
+        path = tmp_path / "issues.json"
+        path.write_text(
+            json.dumps({"version": 1, "next_id": 1, "issues": "not-a-list"}),
+            encoding="utf-8",
+        )
+        original = path.read_bytes()
+
+        with pytest.raises(IssueBoardLoadError, match="invalid store structure"):
+            IssueBoard(path)
+
+        assert path.read_bytes() == original
+
+    def test_open_existing_does_not_overwrite_concurrent_write(self, tmp_path, monkeypatch):
+        path = tmp_path / "issues.json"
+        writer = IssueBoard(path)
+        _create(writer, title="existing")
+        original_read_text = Path.read_text
+        wrote_concurrently = False
+
+        def read_then_write(target, *args, **kwargs):
+            nonlocal wrote_concurrently
+            content = original_read_text(target, *args, **kwargs)
+            if target == path and not wrote_concurrently:
+                wrote_concurrently = True
+                _create(writer, title="concurrent")
+            return content
+
+        monkeypatch.setattr(Path, "read_text", read_then_write)
+        opened = IssueBoard(path)
+
+        assert [issue.title for issue in opened.list()] == ["existing"]
+        assert [issue.title for issue in IssueBoard(path).list()] == ["existing", "concurrent"]
 
 
 class TestReload:
@@ -99,6 +143,35 @@ class TestReload:
         store_b.reload()
         assert len(store_b.list()) == 1
         assert store_b.list()[0].title == "written by a"
+
+    def test_reload_corrupt_json_raises_and_preserves_last_valid_snapshot(self, tmp_path):
+        path = tmp_path / "issues.json"
+        store = IssueBoard(path)
+        _create(store, title="last valid")
+        path.write_text("not json", encoding="utf-8")
+        corrupt = path.read_bytes()
+
+        with pytest.raises(IssueBoardLoadError, match="invalid JSON"):
+            store.reload()
+
+        assert [issue.title for issue in store.list()] == ["last valid"]
+        assert path.read_bytes() == corrupt
+
+    def test_reload_wrong_version_raises_and_preserves_last_valid_snapshot(self, tmp_path):
+        path = tmp_path / "issues.json"
+        store = IssueBoard(path)
+        _create(store, title="last valid")
+        path.write_text(
+            json.dumps({"version": 2, "next_id": 1, "issues": []}),
+            encoding="utf-8",
+        )
+        incompatible = path.read_bytes()
+
+        with pytest.raises(IssueBoardLoadError, match="unsupported version 2"):
+            store.reload()
+
+        assert [issue.title for issue in store.list()] == ["last valid"]
+        assert path.read_bytes() == incompatible
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

IssueBoard previously overwrote invalid persisted state. Shape validation alone still accepted identity-corrupt boards such as duplicate IDs or stale next_id values, and silently discarded unknown nested fields on the next write.

Fixes #226.

## Solution

Load through a strict versioned Pydantic contract. Issue and history records forbid unknown fields; issue IDs must be positive and unique; next_id must be greater than every persisted ID. Invalid loads and reloads raise IssueBoardLoadError without changing disk or the last valid snapshot.

### Architecture

The reusable vs-issue-board library owns the complete version-1 persistence contract and semantic invariants. Mutation continues through the existing atomic writer.

## Verification

Tests cover malformed JSON, unsupported versions, missing reload files, invalid structures, duplicate/non-positive IDs, stale next_id, unknown issue/event fields, snapshot preservation, and concurrent constructor reads.

### Correctness properties

- Opening existing state never rewrites it.
- Invalid identity cannot create ambiguous future updates.
- Unknown persisted fields are rejected rather than discarded.
- Failed reload preserves memory and disk.
- Valid legacy records with omitted optional fields continue to load.

### Testing

- `uv run --package vs-issue-board pytest libs/vs-issue-board/tests/test_issue_board_core.py -q` — 46 passed.
- `uv run pytest -q` — 2,033 passed, 1 expected platform skip.
- Format, lint, type checking, and `git diff --check` passed.
