### PR TITLE
Validate runtime configuration values

### DIFF
--- a/src/vibesys/config.py
+++ b/src/vibesys/config.py
@@ -16,10 +16,10 @@ import os
 import tomllib
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 from dotenv import load_dotenv
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from vibesys.constants import DEFAULT_COMPUTE_BACKEND, PROJECT_ROOT, ComputeBackend
 from vibesys.features import FeatureFlag
@@ -52,14 +52,23 @@ class ThinkingCfg(_Strict):
         default=None,
         description=(
             "Reasoning effort level passed to the model (provider-specific, e.g. "
-            "'low'/'medium'/'high'). For Gemini on Vertex, mutually exclusive with "
-            "budget."
+            "'low'/'medium'/'high'). Mutually exclusive with budget."
         ),
     )
     budget: int | None = Field(
         default=None,
-        description="Thinking token budget (provider-specific). Alternative to level.",
+        ge=-1,
+        description=(
+            "Thinking token budget (provider-specific). Alternative to level; -1 requests "
+            "a dynamic budget and 0 disables thinking where supported."
+        ),
     )
+
+    @model_validator(mode="after")
+    def _one_thinking_control(self) -> Self:
+        if self.level is not None and self.budget is not None:
+            raise ValueError("thinking.level and thinking.budget are mutually exclusive")
+        return self
 
 
 class VertexCfg(_Strict):
@@ -163,6 +172,7 @@ class AgentCfg(_Strict):
     )
     cli_timeout: int | None = Field(
         default=None,
+        gt=0,
         description=(
             "Per-invocation timeout for the CLI agent, in seconds. None → the runner default."
         ),
@@ -199,9 +209,9 @@ class LoadLevelCfg(_Strict):
     Distinct from the ``LoadLevelMetrics`` *output* schema in ``schemas.py``.
     """
 
-    rate: int = Field(description="Request rate (requests/sec) for this load level.")
-    duration: int = Field(description="Benchmark duration in seconds at this load level.")
-    max_tokens: int = Field(description="Max output tokens per request at this load level.")
+    rate: int = Field(gt=0, description="Request rate (requests/sec) for this load level.")
+    duration: int = Field(gt=0, description="Benchmark duration in seconds at this load level.")
+    max_tokens: int = Field(gt=0, description="Max output tokens per request at this load level.")
 
 
 class PerfEvalCfg(_Strict):

--- a/src/vibesys/llm_client.py
+++ b/src/vibesys/llm_client.py
@@ -24,7 +24,7 @@ def _is_openai_model(model_name: str) -> bool:
 
 
 def _has_thinking(thinking: ThinkingCfg) -> bool:
-    return bool(thinking.level or thinking.budget)
+    return thinking.level is not None or thinking.budget is not None
 
 
 def build_model(config: Config):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,7 +25,6 @@ provider = "vertex-ai"
 
 [thinking]
 level = "medium"
-budget = 1024
 
 [providers.vertex-ai]
 json = "~/keys/vertex.json"
@@ -40,7 +39,7 @@ region = "us-east5"
         assert config.model.name == "claude-sonnet-4-6"
         assert config.model.provider == "vertex-ai"
         assert config.thinking.level == "medium"
-        assert config.thinking.budget == 1024
+        assert config.thinking.budget is None
         assert config.providers.vertex_ai.json_path == "~/keys/vertex.json"
         assert config.providers.vertex_ai.project == "my-project"
         assert config.providers.vertex_ai.region == "us-east5"
@@ -243,7 +242,21 @@ EMPTY=
 
 
 class TestLoadConfigThinking:
-    def test_thinking_parsed(self, tmp_path):
+    @pytest.mark.parametrize("budget", [-1, 0, 2048])
+    def test_thinking_budget_parsed(self, tmp_path, budget):
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text(f"""\
+[model]
+name = "gemini-2.5-pro"
+
+[thinking]
+budget = {budget}
+""")
+        config = load_config(cfg_file)
+        assert config.thinking.level is None
+        assert config.thinking.budget == budget
+
+    def test_thinking_level_and_budget_are_rejected(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("""\
 [model]
@@ -253,9 +266,22 @@ name = "gemini-2.5-pro"
 level = "high"
 budget = 2048
 """)
-        config = load_config(cfg_file)
-        assert config.thinking.level == "high"
-        assert config.thinking.budget == 2048
+
+        with pytest.raises(ValueError, match=r"thinking\.level.*thinking\.budget"):
+            load_config(cfg_file)
+
+    def test_thinking_budget_below_dynamic_sentinel_is_rejected(self, tmp_path):
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text("""\
+[model]
+name = "gemini-2.5-pro"
+
+[thinking]
+budget = -2
+""")
+
+        with pytest.raises(ValueError, match="budget"):
+            load_config(cfg_file)
 
 
 class TestLoadConfigAgentSection:
@@ -285,6 +311,20 @@ cli_timeout = 1800
         assert config.agent.backend is None
         assert config.agent.cli_provider is None
         assert config.agent.cli_timeout is None
+
+    @pytest.mark.parametrize("cli_timeout", [0, -1])
+    def test_non_positive_cli_timeout_is_rejected(self, tmp_path, cli_timeout):
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text(f"""\
+[model]
+name = "claude-sonnet-4-6"
+
+[agent]
+cli_timeout = {cli_timeout}
+""")
+
+        with pytest.raises(ValueError, match="cli_timeout"):
+            load_config(cfg_file)
 
 
 class TestLoadConfigRepositorySection:
@@ -345,3 +385,21 @@ max_tokens = 256
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
         config = load_config(cfg_file)
         assert config.perf_eval.load_levels is None
+
+    @pytest.mark.parametrize("field", ["rate", "duration", "max_tokens"])
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_non_positive_load_level_value_is_rejected(self, tmp_path, field, value):
+        load_level = {"rate": 1, "duration": 20, "max_tokens": 128}
+        load_level[field] = value
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text(
+            "[model]\n"
+            'name = "claude-sonnet-4-6"\n\n'
+            "[[perf_eval.load_levels]]\n"
+            f"rate = {load_level['rate']}\n"
+            f"duration = {load_level['duration']}\n"
+            f"max_tokens = {load_level['max_tokens']}\n"
+        )
+
+        with pytest.raises(ValueError, match=field):
+            load_config(cfg_file)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -183,22 +183,19 @@ class TestVertexAIProvider:
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     @patch("langchain_google_genai.ChatGoogleGenerativeAI")
-    def test_vertex_gemini_thinking_level_takes_precedence(
-        self, mock_chat_cls, mock_from_sa, key_file
-    ):
+    def test_vertex_gemini_zero_thinking_budget(self, mock_chat_cls, mock_from_sa, key_file):
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
         config = _make_config(
             "gemini-2.5-pro",
             provider="vertex-ai",
-            thinking={"level": "high", "budget": 1024},
+            thinking={"budget": 0},
             providers={"vertex-ai": {"json": str(key_file), "project": None, "region": "us-east5"}},
         )
         build_model(config)
         call_kwargs = mock_chat_cls.call_args[1]
-        assert call_kwargs["thinking_level"] == "high"
+        assert call_kwargs["thinking_budget"] == 0
         assert call_kwargs["include_thoughts"] is True
-        assert "thinking_budget" not in call_kwargs
 
     def test_vertex_missing_json_key_raises(self):
         config = _make_config(
@@ -307,7 +304,7 @@ class TestThinkingNotSupported:
             build_model(config)
 
     def test_openai_with_thinking_raises(self):
-        config = _make_config("gpt-4o", provider="openai", thinking={"level": "high"})
+        config = _make_config("gpt-4o", provider="openai", thinking={"budget": 0})
         with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
             build_model(config)
 


### PR DESCRIPTION
## Problem

The typed agent.toml schema accepts contradictory thinking controls and non-positive runtime values. These inputs either change behavior silently or fail only after model, process, or benchmark setup begins.

Closes #230.

## Solution

Validate the affected user-facing fields at the Config boundary:

- require thinking.level and thinking.budget to be mutually exclusive;
- accept provider-defined budget sentinels -1 and 0, but reject values below -1;
- require positive agent.cli_timeout and perf load rate, duration, and max_tokens;
- treat a zero thinking budget as explicitly configured in provider-support checks.

This intentionally does not add model-specific thinking-level enums or budget maxima because those vary by provider and model.

### Architecture

Config remains the single validation boundary. Downstream model construction consumes only validated ThinkingCfg values; benchmark rendering and process execution receive positive numeric settings.

External configuration contract: previously accepted invalid agent.toml values now fail fast with Pydantic validation errors. Valid existing settings are unchanged, including thinking budgets -1 and 0.

## Verification

The focused configuration and model-client regression suite, formatting, lint, type checks, and full repository suite all pass locally.

### Correctness properties

- Exactly zero or one thinking control is configured.
- Thinking budgets are at least -1; -1 and 0 retain their provider-defined meanings.
- A configured zero budget cannot bypass unsupported-provider validation.
- CLI timeouts and benchmark load values are strictly positive when present.
- Errors identify the offending configuration field before runtime setup.

### Testing

- uv run pytest tests/test_config.py tests/test_llm_client.py — 73 passed
- ./scripts/check_format.sh — passed (258 files already formatted)
- ./scripts/check_lint.sh — passed
- ./scripts/check_types.sh — 0 errors, 0 warnings
- uv run pytest — 2,035 passed, 1 platform-specific skip
