### PR TITLE
Make EventStore cursor reads independent of history size

### DIFF
--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -250,7 +250,7 @@ class EventStore:
         self.run_id = run_id
         self._lock = threading.RLock()
         self._changed = threading.Condition(self._lock)
-        self._events = self._read_unlocked()
+        self._events, self._malformed_tail_offset = self._read_unlocked()
         self._sequences = [event.sequence for event in self._events]
         self._sequences_monotonic = all(
             previous <= current
@@ -259,11 +259,16 @@ class EventStore:
         self._next_sequence = max(self._sequences, default=0) + 1
 
     def append(self, event: RunEvent) -> RunEvent:
-        with self._changed, self.path.open("a", encoding="utf-8") as stream:
+        with self._changed:
+            if self._malformed_tail_offset is not None:
+                with self.path.open("r+b") as stream:
+                    stream.truncate(self._malformed_tail_offset)
+                self._malformed_tail_offset = None
             event = event.model_copy(
                 update={"sequence": self._next_sequence, "run_id": self.run_id}
             )
-            stream.write(event.model_dump_json() + "\n")
+            with self.path.open("a", encoding="utf-8") as stream:
+                stream.write(event.model_dump_json() + "\n")
             self._next_sequence += 1
             self._events.append(event.model_copy(deep=True))
             self._sequences.append(event.sequence)
@@ -298,12 +303,15 @@ class EventStore:
             events = [event for event in self._events if event.sequence > after_sequence]
         return [event.model_copy(deep=True) for event in events]
 
-    def _read_unlocked(self) -> list[RunEvent]:
+    def _read_unlocked(self) -> tuple[list[RunEvent], int | None]:
         if not self.path.exists():
-            return []
-        lines = self.path.read_text(encoding="utf-8").splitlines()
-        events = []
+            return [], None
+        lines = self.path.read_bytes().splitlines(keepends=True)
+        events: list[RunEvent] = []
+        offset = 0
         for index, line in enumerate(lines):
+            record_offset = offset
+            offset += len(line)
             try:
                 event = RunEvent.model_validate_json(line)
                 events.append(event)
@@ -311,9 +319,9 @@ class EventStore:
                 # Preserve access to earlier audit history if a process was
                 # interrupted during its final append.
                 if index == len(lines) - 1:
-                    continue
+                    return events, record_offset
                 raise
-        return events
+        return events, None
 
 
 def make_event(event_type: EventType, text: str = "", **fields: Any) -> RunEvent:

--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import threading
+from bisect import bisect_right
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -249,17 +250,23 @@ class EventStore:
         self.run_id = run_id
         self._lock = threading.RLock()
         self._changed = threading.Condition(self._lock)
-        self._next_sequence = (
-            max((event.sequence for event in self._read_unlocked()), default=0) + 1
+        self._events = self._read_unlocked()
+        self._sequences = [event.sequence for event in self._events]
+        self._sequences_monotonic = all(
+            previous <= current
+            for previous, current in zip(self._sequences, self._sequences[1:], strict=False)
         )
+        self._next_sequence = max(self._sequences, default=0) + 1
 
     def append(self, event: RunEvent) -> RunEvent:
         with self._changed, self.path.open("a", encoding="utf-8") as stream:
             event = event.model_copy(
                 update={"sequence": self._next_sequence, "run_id": self.run_id}
             )
-            self._next_sequence += 1
             stream.write(event.model_dump_json() + "\n")
+            self._next_sequence += 1
+            self._events.append(event.model_copy(deep=True))
+            self._sequences.append(event.sequence)
             self._changed.notify_all()
             return event
 
@@ -270,16 +277,26 @@ class EventStore:
 
     def read(self, after_sequence: int = 0) -> list[RunEvent]:
         with self._lock:
-            return [event for event in self._read_unlocked() if event.sequence > after_sequence]
+            return self._events_after_unlocked(after_sequence)
 
     def wait(self, after_sequence: int, timeout: float | None = None) -> list[RunEvent]:
         """Block until replayable events exist after a client's cursor."""
         with self._changed:
-            events = [event for event in self._read_unlocked() if event.sequence > after_sequence]
+            events = self._events_after_unlocked(after_sequence)
             if events:
                 return events
             self._changed.wait(timeout)
-            return [event for event in self._read_unlocked() if event.sequence > after_sequence]
+            return self._events_after_unlocked(after_sequence)
+
+    def _events_after_unlocked(self, after_sequence: int) -> list[RunEvent]:
+        if self._sequences_monotonic:
+            start = bisect_right(self._sequences, after_sequence)
+            events = self._events[start:]
+        else:
+            # Preserve the historical file-order filtering semantics for a
+            # manually edited or legacy log whose sequences are not sorted.
+            events = [event for event in self._events if event.sequence > after_sequence]
+        return [event.model_copy(deep=True) for event in events]
 
     def _read_unlocked(self) -> list[RunEvent]:
         if not self.path.exists():

--- a/tests/server/test_event_store.py
+++ b/tests/server/test_event_store.py
@@ -1,0 +1,121 @@
+"""Persistence and cursor tests for the run-event store."""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from vibesys.server.events import EventStore, EventType, RunEvent, make_event
+
+
+def _persisted_event(sequence: int, text: str = "") -> RunEvent:
+    return RunEvent(
+        sequence=sequence,
+        run_id="persisted-run",
+        timestamp=datetime.now(UTC),
+        type=EventType.OUTPUT,
+        text=text,
+    )
+
+
+def _write_events(path: Path, events: list[RunEvent]) -> None:
+    path.write_text("".join(event.model_dump_json() + "\n" for event in events))
+
+
+class TestEventStore:
+    def test_startup_replay_cursor_and_next_sequence(self, tmp_path):
+        path = tmp_path / "events.jsonl"
+        _write_events(path, [_persisted_event(1, "one"), _persisted_event(2, "two")])
+
+        store = EventStore(path, run_id="active-run")
+
+        assert [event.text for event in store.read()] == ["one", "two"]
+        assert [event.text for event in store.read(after_sequence=1)] == ["two"]
+        assert store.read(after_sequence=2) == []
+        appended = store.append(make_event(EventType.OUTPUT, "three"))
+        assert appended.sequence == 3
+        assert appended.run_id == "active-run"
+        assert [event.sequence for event in store.read(after_sequence=1)] == [2, 3]
+
+    def test_legacy_out_of_order_sequences_keep_file_order_filtering(self, tmp_path):
+        path = tmp_path / "events.jsonl"
+        _write_events(
+            path,
+            [_persisted_event(2, "two"), _persisted_event(1, "one"), _persisted_event(3, "three")],
+        )
+
+        store = EventStore(path, run_id="active-run")
+
+        assert [event.text for event in store.read(after_sequence=1)] == ["two", "three"]
+        assert store.append(make_event(EventType.OUTPUT, "four")).sequence == 4
+        assert [event.text for event in store.read(after_sequence=2)] == ["three", "four"]
+
+    def test_repeated_tail_reads_do_not_reparse_history(self, tmp_path, monkeypatch):
+        path = tmp_path / "events.jsonl"
+        event_count = 1_000
+        _write_events(path, [_persisted_event(index) for index in range(1, event_count + 1)])
+        parse_count = 0
+        parse = RunEvent.model_validate_json
+
+        def counting_parse(raw):
+            nonlocal parse_count
+            parse_count += 1
+            return parse(raw)
+
+        monkeypatch.setattr(RunEvent, "model_validate_json", counting_parse)
+        store = EventStore(path, run_id="active-run")
+        assert parse_count == event_count
+
+        for _ in range(20):
+            assert store.read(event_count) == []
+            assert store.wait(event_count, timeout=0) == []
+
+        assert parse_count == event_count
+
+    def test_ignores_only_a_malformed_final_record(self, tmp_path):
+        path = tmp_path / "events.jsonl"
+        valid = _persisted_event(1, "complete").model_dump_json()
+        path.write_text(valid + "\n" + '{"protocol_version":1')
+
+        store = EventStore(path, run_id="active-run")
+
+        assert [event.text for event in store.read()] == ["complete"]
+
+    def test_rejects_a_malformed_record_before_the_tail(self, tmp_path):
+        path = tmp_path / "events.jsonl"
+        first = _persisted_event(1).model_dump_json()
+        last = _persisted_event(2).model_dump_json()
+        path.write_text(first + "\nnot-json\n" + last + "\n")
+
+        with pytest.raises(ValueError):
+            EventStore(path, run_id="active-run")
+
+    def test_append_wakes_multiple_independent_readers(self, tmp_path):
+        store = EventStore(tmp_path / "events.jsonl", run_id="active-run")
+        ready = threading.Barrier(3)
+
+        def wait_for_first_event() -> list[RunEvent]:
+            ready.wait()
+            return store.wait(after_sequence=0, timeout=2)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            readers = [executor.submit(wait_for_first_event) for _ in range(2)]
+            ready.wait()
+            appended = store.append(make_event(EventType.OUTPUT, "visible"))
+
+        batches = [reader.result() for reader in readers]
+        assert [[event.sequence for event in batch] for batch in batches] == [[1], [1]]
+        assert all(batch[0] == appended for batch in batches)
+        assert batches[0][0] is not batches[1][0]
+
+    def test_cached_events_are_isolated_from_reader_mutation(self, tmp_path):
+        store = EventStore(tmp_path / "events.jsonl", run_id="active-run")
+        appended = store.append(make_event(EventType.OUTPUT, "durable"))
+
+        first_read = store.read()
+        first_read[0].text = "mutated"
+
+        assert appended.text == "durable"
+        assert store.read()[0].text == "durable"

--- a/tests/server/test_event_store.py
+++ b/tests/server/test_event_store.py
@@ -83,6 +83,21 @@ class TestEventStore:
 
         assert [event.text for event in store.read()] == ["complete"]
 
+    @pytest.mark.parametrize("tail", ['{"protocol_version":1', '{"protocol_version":1\n'])
+    def test_append_repairs_ignored_malformed_tail_before_writing(self, tmp_path, tail):
+        path = tmp_path / "events.jsonl"
+        valid = _persisted_event(1, "complete").model_dump_json()
+        path.write_text(valid + "\n" + tail)
+        store = EventStore(path, run_id="active-run")
+
+        store.append(make_event(EventType.OUTPUT, "after repair"))
+        reopened = EventStore(path, run_id="reopened-run")
+
+        assert [(event.sequence, event.text) for event in reopened.read()] == [
+            (1, "complete"),
+            (2, "after repair"),
+        ]
+
     def test_rejects_a_malformed_record_before_the_tail(self, tmp_path):
         path = tmp_path / "events.jsonl"
         first = _persisted_event(1).model_dump_json()
@@ -119,3 +134,31 @@ class TestEventStore:
 
         assert appended.text == "durable"
         assert store.read()[0].text == "durable"
+
+    def test_append_does_not_publish_cache_state_when_file_close_fails(self, tmp_path, monkeypatch):
+        path = tmp_path / "events.jsonl"
+        store = EventStore(path, run_id="active-run")
+        real_open = Path.open
+
+        class FailingCloseStream:
+            def __enter__(self):
+                return self
+
+            def write(self, _text):
+                return None
+
+            def __exit__(self, *_args):
+                raise OSError("close failed")
+
+        def open_with_close_failure(target, mode="r", *args, **kwargs):
+            if target == path and mode == "a":
+                return FailingCloseStream()
+            return real_open(target, mode, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "open", open_with_close_failure)
+
+        with pytest.raises(OSError, match="close failed"):
+            store.append(make_event(EventType.OUTPUT, "ghost"))
+
+        assert store.read() == []
+        assert store.last_sequence == 0

--- a/tests/server/test_events.py
+++ b/tests/server/test_events.py
@@ -1,16 +1,10 @@
-"""Serialization and persistence tests for the run-event wire contract."""
-
-import threading
-from concurrent.futures import ThreadPoolExecutor
-from datetime import UTC, datetime
-from pathlib import Path
+"""Serialization tests for the run-event wire contract."""
 
 import pytest
 
 from vibesys.server.events import (
     AgentOutputChunkData,
     AgentStatusData,
-    EventStore,
     EventType,
     RunEvent,
     TodoItemData,
@@ -20,20 +14,6 @@ from vibesys.server.events import (
     UsageUpdateData,
     make_event,
 )
-
-
-def _persisted_event(sequence: int, text: str = "") -> RunEvent:
-    return RunEvent(
-        sequence=sequence,
-        run_id="persisted-run",
-        timestamp=datetime.now(UTC),
-        type=EventType.OUTPUT,
-        text=text,
-    )
-
-
-def _write_events(path: Path, events: list[RunEvent]) -> None:
-    path.write_text("".join(event.model_dump_json() + "\n" for event in events))
 
 
 def _round_trip(event: RunEvent) -> RunEvent:
@@ -124,100 +104,3 @@ class TestBackwardCompatibility:
         )
         with pytest.raises(ValueError):
             RunEvent.model_validate_json(raw)
-
-
-class TestEventStore:
-    def test_startup_replay_cursor_and_next_sequence(self, tmp_path):
-        path = tmp_path / "events.jsonl"
-        _write_events(path, [_persisted_event(1, "one"), _persisted_event(2, "two")])
-
-        store = EventStore(path, run_id="active-run")
-
-        assert [event.text for event in store.read()] == ["one", "two"]
-        assert [event.text for event in store.read(after_sequence=1)] == ["two"]
-        assert store.read(after_sequence=2) == []
-        appended = store.append(make_event(EventType.OUTPUT, "three"))
-        assert appended.sequence == 3
-        assert appended.run_id == "active-run"
-        assert [event.sequence for event in store.read(after_sequence=1)] == [2, 3]
-
-    def test_legacy_out_of_order_sequences_keep_file_order_filtering(self, tmp_path):
-        path = tmp_path / "events.jsonl"
-        _write_events(
-            path,
-            [_persisted_event(2, "two"), _persisted_event(1, "one"), _persisted_event(3, "three")],
-        )
-
-        store = EventStore(path, run_id="active-run")
-
-        assert [event.text for event in store.read(after_sequence=1)] == ["two", "three"]
-        assert store.append(make_event(EventType.OUTPUT, "four")).sequence == 4
-        assert [event.text for event in store.read(after_sequence=2)] == ["three", "four"]
-
-    def test_repeated_tail_reads_do_not_reparse_history(self, tmp_path, monkeypatch):
-        path = tmp_path / "events.jsonl"
-        event_count = 1_000
-        _write_events(path, [_persisted_event(index) for index in range(1, event_count + 1)])
-        parse_count = 0
-        parse = RunEvent.model_validate_json
-
-        def counting_parse(raw):
-            nonlocal parse_count
-            parse_count += 1
-            return parse(raw)
-
-        monkeypatch.setattr(RunEvent, "model_validate_json", counting_parse)
-        store = EventStore(path, run_id="active-run")
-        assert parse_count == event_count
-
-        for _ in range(20):
-            assert store.read(event_count) == []
-            assert store.wait(event_count, timeout=0) == []
-
-        assert parse_count == event_count
-
-    def test_ignores_only_a_malformed_final_record(self, tmp_path):
-        path = tmp_path / "events.jsonl"
-        valid = _persisted_event(1, "complete").model_dump_json()
-        path.write_text(valid + "\n" + '{"protocol_version":1')
-
-        store = EventStore(path, run_id="active-run")
-
-        assert [event.text for event in store.read()] == ["complete"]
-
-    def test_rejects_a_malformed_record_before_the_tail(self, tmp_path):
-        path = tmp_path / "events.jsonl"
-        first = _persisted_event(1).model_dump_json()
-        last = _persisted_event(2).model_dump_json()
-        path.write_text(first + "\nnot-json\n" + last + "\n")
-
-        with pytest.raises(ValueError):
-            EventStore(path, run_id="active-run")
-
-    def test_append_wakes_multiple_independent_readers(self, tmp_path):
-        store = EventStore(tmp_path / "events.jsonl", run_id="active-run")
-        ready = threading.Barrier(3)
-
-        def wait_for_first_event() -> list[RunEvent]:
-            ready.wait()
-            return store.wait(after_sequence=0, timeout=2)
-
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            readers = [executor.submit(wait_for_first_event) for _ in range(2)]
-            ready.wait()
-            appended = store.append(make_event(EventType.OUTPUT, "visible"))
-
-        batches = [reader.result() for reader in readers]
-        assert [[event.sequence for event in batch] for batch in batches] == [[1], [1]]
-        assert all(batch[0] == appended for batch in batches)
-        assert batches[0][0] is not batches[1][0]
-
-    def test_cached_events_are_isolated_from_reader_mutation(self, tmp_path):
-        store = EventStore(tmp_path / "events.jsonl", run_id="active-run")
-        appended = store.append(make_event(EventType.OUTPUT, "durable"))
-
-        first_read = store.read()
-        first_read[0].text = "mutated"
-
-        assert appended.text == "durable"
-        assert store.read()[0].text == "durable"

--- a/tests/server/test_events.py
+++ b/tests/server/test_events.py
@@ -1,10 +1,16 @@
-"""Serialization tests for the run-event wire contract."""
+"""Serialization and persistence tests for the run-event wire contract."""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 
 from vibesys.server.events import (
     AgentOutputChunkData,
     AgentStatusData,
+    EventStore,
     EventType,
     RunEvent,
     TodoItemData,
@@ -14,6 +20,20 @@ from vibesys.server.events import (
     UsageUpdateData,
     make_event,
 )
+
+
+def _persisted_event(sequence: int, text: str = "") -> RunEvent:
+    return RunEvent(
+        sequence=sequence,
+        run_id="persisted-run",
+        timestamp=datetime.now(UTC),
+        type=EventType.OUTPUT,
+        text=text,
+    )
+
+
+def _write_events(path: Path, events: list[RunEvent]) -> None:
+    path.write_text("".join(event.model_dump_json() + "\n" for event in events))
 
 
 def _round_trip(event: RunEvent) -> RunEvent:
@@ -104,3 +124,100 @@ class TestBackwardCompatibility:
         )
         with pytest.raises(ValueError):
             RunEvent.model_validate_json(raw)
+
+
+class TestEventStore:
+    def test_startup_replay_cursor_and_next_sequence(self, tmp_path):
+        path = tmp_path / "events.jsonl"
+        _write_events(path, [_persisted_event(1, "one"), _persisted_event(2, "two")])
+
+        store = EventStore(path, run_id="active-run")
+
+        assert [event.text for event in store.read()] == ["one", "two"]
+        assert [event.text for event in store.read(after_sequence=1)] == ["two"]
+        assert store.read(after_sequence=2) == []
+        appended = store.append(make_event(EventType.OUTPUT, "three"))
+        assert appended.sequence == 3
+        assert appended.run_id == "active-run"
+        assert [event.sequence for event in store.read(after_sequence=1)] == [2, 3]
+
+    def test_legacy_out_of_order_sequences_keep_file_order_filtering(self, tmp_path):
+        path = tmp_path / "events.jsonl"
+        _write_events(
+            path,
+            [_persisted_event(2, "two"), _persisted_event(1, "one"), _persisted_event(3, "three")],
+        )
+
+        store = EventStore(path, run_id="active-run")
+
+        assert [event.text for event in store.read(after_sequence=1)] == ["two", "three"]
+        assert store.append(make_event(EventType.OUTPUT, "four")).sequence == 4
+        assert [event.text for event in store.read(after_sequence=2)] == ["three", "four"]
+
+    def test_repeated_tail_reads_do_not_reparse_history(self, tmp_path, monkeypatch):
+        path = tmp_path / "events.jsonl"
+        event_count = 1_000
+        _write_events(path, [_persisted_event(index) for index in range(1, event_count + 1)])
+        parse_count = 0
+        parse = RunEvent.model_validate_json
+
+        def counting_parse(raw):
+            nonlocal parse_count
+            parse_count += 1
+            return parse(raw)
+
+        monkeypatch.setattr(RunEvent, "model_validate_json", counting_parse)
+        store = EventStore(path, run_id="active-run")
+        assert parse_count == event_count
+
+        for _ in range(20):
+            assert store.read(event_count) == []
+            assert store.wait(event_count, timeout=0) == []
+
+        assert parse_count == event_count
+
+    def test_ignores_only_a_malformed_final_record(self, tmp_path):
+        path = tmp_path / "events.jsonl"
+        valid = _persisted_event(1, "complete").model_dump_json()
+        path.write_text(valid + "\n" + '{"protocol_version":1')
+
+        store = EventStore(path, run_id="active-run")
+
+        assert [event.text for event in store.read()] == ["complete"]
+
+    def test_rejects_a_malformed_record_before_the_tail(self, tmp_path):
+        path = tmp_path / "events.jsonl"
+        first = _persisted_event(1).model_dump_json()
+        last = _persisted_event(2).model_dump_json()
+        path.write_text(first + "\nnot-json\n" + last + "\n")
+
+        with pytest.raises(ValueError):
+            EventStore(path, run_id="active-run")
+
+    def test_append_wakes_multiple_independent_readers(self, tmp_path):
+        store = EventStore(tmp_path / "events.jsonl", run_id="active-run")
+        ready = threading.Barrier(3)
+
+        def wait_for_first_event() -> list[RunEvent]:
+            ready.wait()
+            return store.wait(after_sequence=0, timeout=2)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            readers = [executor.submit(wait_for_first_event) for _ in range(2)]
+            ready.wait()
+            appended = store.append(make_event(EventType.OUTPUT, "visible"))
+
+        batches = [reader.result() for reader in readers]
+        assert [[event.sequence for event in batch] for batch in batches] == [[1], [1]]
+        assert all(batch[0] == appended for batch in batches)
+        assert batches[0][0] is not batches[1][0]
+
+    def test_cached_events_are_isolated_from_reader_mutation(self, tmp_path):
+        store = EventStore(tmp_path / "events.jsonl", run_id="active-run")
+        appended = store.append(make_event(EventType.OUTPUT, "durable"))
+
+        first_read = store.read()
+        first_read[0].text = "mutated"
+
+        assert appended.text == "durable"
+        assert store.read()[0].text == "durable"


### PR DESCRIPTION
## Problem

Repeated EventStore cursor reads reparsed all history. Caching fixes that cost, but an ignored malformed tail must be repaired before append, and cache state must not become visible until buffered output closes successfully.

Fixes #231.

## Solution

Parse persisted history once and maintain a locked event/sequence cache with bisect cursor lookup. Startup records the byte offset of an ignored malformed final record; the first append truncates that tail before writing. Cache sequence updates and waiter notification occur only after the append file context exits successfully.

### Architecture

JSONL remains the durable source of truth. The in-memory cache is published strictly after durable append and returns deep copies to readers.

## Verification

Tests cover replay, out-of-order legacy logs, history-independent reads, newline and unterminated malformed tails followed by append/reopen, close failure, multiple waiters, and mutation isolation.

### Correctness properties

- Cached visibility never precedes successful file close.
- Appending after interrupted output produces replayable JSONL.
- Cursor reads remain exclusive and history-independent.
- Legacy out-of-order filtering remains file ordered.
- Independent readers cannot mutate cached history.

### Testing

- `uv run pytest tests/server/test_event_store.py -q` — 10 passed.
- `uv run pytest -q` — 2,033 passed, 1 expected platform skip.
- Format, lint, type checking, and `git diff --check` passed.
