### PR TITLE
Stabilize OpenEvolve sampling after resume

### DIFF
--- a/src/vibesys/loops/evolve/search_policy.py
+++ b/src/vibesys/loops/evolve/search_policy.py
@@ -147,6 +147,13 @@ class VibeSysSearchPolicy:
         return None
 
 
+class _SortedIterationSet(set[str]):
+    """Set semantics with deterministic iteration for replaying OpenEvolve."""
+
+    def __iter__(self):
+        return iter(sorted(super().__iter__()))
+
+
 class OpenEvolveSearchPolicy:
     """Adapter around OpenEvolve 0.3.1's MAP-Elites/island database.
 
@@ -307,6 +314,18 @@ class OpenEvolveSearchPolicy:
             self._rng.setstate(random.getstate())
             random.setstate(process_state)
 
+    @contextmanager
+    def _deterministic_upstream_iteration(self) -> Generator[None, None, None]:
+        """Normalize unordered OpenEvolve collections for replayable sampling."""
+        self._database.programs = dict(sorted(self._database.programs.items()))
+        self._database.islands = [
+            island if isinstance(island, _SortedIterationSet) else _SortedIterationSet(island)
+            for island in self._database.islands
+        ]
+        if not isinstance(self._database.archive, _SortedIterationSet):
+            self._database.archive = _SortedIterationSet(self._database.archive)
+        yield
+
     def select(
         self,
         population: Population,
@@ -326,10 +345,11 @@ class OpenEvolveSearchPolicy:
         program_ids_before = set(self._database.programs)
         inspiration_count = k_top_inspirations + k_random_inspirations
         with self._upstream_random():
-            parent_program, inspiration_programs = self._database.sample_from_island(
-                island,
-                num_inspirations=inspiration_count,
-            )
+            with self._deterministic_upstream_iteration():
+                parent_program, inspiration_programs = self._database.sample_from_island(
+                    island,
+                    num_inspirations=inspiration_count,
+                )
         self._database.next_island()
 
         individuals_by_id = {individual.id: individual for individual in population.passed}

--- a/src/vibesys/loops/evolve/search_policy.py
+++ b/src/vibesys/loops/evolve/search_policy.py
@@ -8,6 +8,7 @@ agent execution lifecycle.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import random
 import shutil
@@ -314,9 +315,8 @@ class OpenEvolveSearchPolicy:
             self._rng.setstate(random.getstate())
             random.setstate(process_state)
 
-    @contextmanager
-    def _deterministic_upstream_iteration(self) -> Generator[None, None, None]:
-        """Normalize unordered OpenEvolve collections for replayable sampling."""
+    def _normalize_upstream_collections(self) -> None:
+        """Normalize unordered OpenEvolve collections for replayable operations."""
         self._database.programs = dict(sorted(self._database.programs.items()))
         self._database.islands = [
             island if isinstance(island, _SortedIterationSet) else _SortedIterationSet(island)
@@ -324,7 +324,67 @@ class OpenEvolveSearchPolicy:
         ]
         if not isinstance(self._database.archive, _SortedIterationSet):
             self._database.archive = _SortedIterationSet(self._database.archive)
-        yield
+
+    def _canonicalize_new_upstream_programs(self, program_ids_before: set[str]) -> None:
+        """Replace upstream random IDs and timestamps with state-derived values."""
+        new_programs = [
+            program
+            for program_id, program in self._database.programs.items()
+            if program_id not in program_ids_before
+            and (program.metadata.get("migrant") or not program_id.startswith("vibesys-"))
+        ]
+        replacements: dict[str, str] = {}
+        for program in new_programs:
+            kind = "migrant" if program.metadata.get("migrant") else "island-copy"
+            identity = json.dumps(
+                {
+                    "kind": kind,
+                    "parent_id": program.parent_id,
+                    "island": program.metadata.get("island"),
+                    "generation": program.generation,
+                    "iteration_found": program.iteration_found,
+                    "code_sha256": hashlib.sha256(program.code.encode()).hexdigest(),
+                },
+                sort_keys=True,
+            )
+            canonical_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"vibesys-openevolve:{identity}"))
+            if canonical_id in self._database.programs or canonical_id in replacements.values():
+                raise RuntimeError(f"duplicate deterministic OpenEvolve program ID: {canonical_id}")
+            replacements[program.id] = canonical_id
+            program.id = canonical_id
+            program.timestamp = float(program.iteration_found or self._database.last_iteration)
+
+        if not replacements:
+            return
+
+        for old_id, canonical_id in replacements.items():
+            program = self._database.programs.pop(old_id)
+            self._database.programs[canonical_id] = program
+        for program in self._database.programs.values():
+            if program.parent_id in replacements:
+                program.parent_id = replacements[program.parent_id]
+        for island in self._database.islands:
+            for old_id, canonical_id in replacements.items():
+                if old_id in island:
+                    island.discard(old_id)
+                    island.add(canonical_id)
+        for feature_map in self._database.island_feature_maps:
+            for feature, program_id in list(feature_map.items()):
+                feature_map[feature] = replacements.get(program_id, program_id)
+        self._database.archive = _SortedIterationSet(
+            replacements.get(program_id, program_id) for program_id in self._database.archive
+        )
+        if self._database.best_program_id in replacements:
+            self._database.best_program_id = replacements[self._database.best_program_id]
+        self._database.island_best_programs = [
+            replacements.get(program_id, program_id) if program_id is not None else None
+            for program_id in self._database.island_best_programs
+        ]
+        if self._database.prompts_by_program:
+            for old_id, canonical_id in replacements.items():
+                prompts = self._database.prompts_by_program.pop(old_id, None)
+                if prompts is not None:
+                    self._database.prompts_by_program[canonical_id] = prompts
 
     def select(
         self,
@@ -345,11 +405,12 @@ class OpenEvolveSearchPolicy:
         program_ids_before = set(self._database.programs)
         inspiration_count = k_top_inspirations + k_random_inspirations
         with self._upstream_random():
-            with self._deterministic_upstream_iteration():
-                parent_program, inspiration_programs = self._database.sample_from_island(
-                    island,
-                    num_inspirations=inspiration_count,
-                )
+            self._normalize_upstream_collections()
+            parent_program, inspiration_programs = self._database.sample_from_island(
+                island,
+                num_inspirations=inspiration_count,
+            )
+        self._canonicalize_new_upstream_programs(program_ids_before)
         self._database.next_island()
 
         individuals_by_id = {individual.id: individual for individual in population.passed}
@@ -405,6 +466,7 @@ class OpenEvolveSearchPolicy:
             language="multi-file",
             parent_id=policy_parent_id,
             generation=individual.generation,
+            timestamp=float(individual.id),
             metrics=metrics,
             metadata={
                 self._INDIVIDUAL_ID: individual.id,
@@ -412,7 +474,9 @@ class OpenEvolveSearchPolicy:
                 "perf_unit": individual.perf_unit,
             },
         )
+        program_ids_before = set(self._database.programs)
         with self._upstream_random():
+            self._normalize_upstream_collections()
             self._database.add(
                 program,
                 iteration=individual.id,
@@ -427,6 +491,7 @@ class OpenEvolveSearchPolicy:
                 self._database.increment_island_generation(island)
                 if self.config.migration_rate > 0.0 and self._database.should_migrate():
                     self._database.migrate_programs()
+        self._canonicalize_new_upstream_programs(program_ids_before)
         prospective_ids = self._admitted_individual_ids | {individual.id}
         self._save_full_state(admitted_individual_ids=prospective_ids)
         self._admitted_individual_ids = prospective_ids

--- a/tests/loops/evolve/test_search_policy.py
+++ b/tests/loops/evolve/test_search_policy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import random
+from collections.abc import Iterable, Iterator
 from importlib.metadata import version
 from pathlib import Path
 
@@ -14,6 +15,17 @@ from vibesys.loops.evolve.search_policy import (
     OpenEvolveSearchConfig,
     OpenEvolveSearchPolicy,
 )
+
+
+class _IterationOrderSet(set[str]):
+    """Set whose iteration order can model a differently reconstructed process."""
+
+    def __init__(self, values: Iterable[str], iteration_order: Iterable[str]) -> None:
+        super().__init__(values)
+        self._iteration_order = tuple(iteration_order)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._iteration_order)
 
 
 def _individual(
@@ -335,6 +347,14 @@ def test_resume_continues_upstream_random_stream_without_touching_global_rng(tmp
     }
     policy.select(population, **selection_args)
     resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=19, config=None)
+    program_ids = sorted(policy._database.programs)
+    policy._database.config.exploration_ratio = 1.0
+    resumed._database.config.exploration_ratio = 1.0
+    policy._database.islands[0] = _IterationOrderSet(program_ids, program_ids)
+    resumed._database.islands[0] = _IterationOrderSet(
+        program_ids,
+        program_ids[1:] + program_ids[:1],
+    )
     uninterrupted_next = policy.select(population, **selection_args)
     resumed_next = resumed.select(population, **selection_args)
 

--- a/tests/loops/evolve/test_search_policy.py
+++ b/tests/loops/evolve/test_search_policy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import random
+import shutil
 from collections.abc import Iterable, Iterator
 from importlib.metadata import version
 from pathlib import Path
@@ -321,6 +322,68 @@ def test_empty_island_copy_resolves_through_vibesys_ancestry(tmp_path) -> None:
     assert selection.target_island == 1
     copy = policy._database.programs[selection.policy_parent_id]
     assert copy.metadata["vibesys_individual_id"] == seed.id
+
+
+def test_empty_island_copy_has_same_identity_after_resume(tmp_path) -> None:
+    config = _config(migration_interval=50, migration_rate=0.0)
+    seed = _individual(1)
+    population = Population([seed])
+    policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=2, config=config)
+    policy.record(seed, code="seed", policy_parent_id=None, target_island=0, objectives=None)
+    resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=999, config=None)
+    for candidate in (policy, resumed):
+        candidate._database.set_current_island(1)
+        candidate._database.config.exploration_ratio = 1.0
+        candidate._database.config.exploitation_ratio = 0.0
+
+    selection_args = {
+        "rng": random.Random(1),
+        "k_top_inspirations": 0,
+        "k_random_inspirations": 0,
+        "selection_temperature": 0.5,
+        "objectives": None,
+        "frontier_bias": 0.7,
+    }
+    uninterrupted_selection = policy.select(population, **selection_args)
+    resumed_selection = resumed.select(population, **selection_args)
+
+    assert uninterrupted_selection is not None and resumed_selection is not None
+    assert resumed_selection.policy_parent_id == uninterrupted_selection.policy_parent_id
+
+
+def test_migration_has_same_program_identity_after_resume(tmp_path) -> None:
+    initial_dir = tmp_path / "initial"
+    config = _config(num_islands=2, migration_interval=1, migration_rate=1.0)
+    seed = _individual(1)
+    initial = OpenEvolveSearchPolicy(state_dir=initial_dir, seed=3, config=config)
+    initial.record(seed, code="seed", policy_parent_id=None, target_island=0, objectives=None)
+    uninterrupted_dir = tmp_path / "uninterrupted"
+    resumed_dir = tmp_path / "resumed"
+    shutil.copytree(initial_dir, uninterrupted_dir)
+    shutil.copytree(initial_dir, resumed_dir)
+    uninterrupted = OpenEvolveSearchPolicy(state_dir=uninterrupted_dir, seed=3, config=None)
+    resumed = OpenEvolveSearchPolicy(state_dir=resumed_dir, seed=999, config=None)
+    child = _individual(2, parent_id=1, generation=1)
+
+    uninterrupted.record(
+        child,
+        code="child",
+        policy_parent_id="vibesys-1",
+        target_island=0,
+        objectives=None,
+    )
+    resumed.record(
+        child,
+        code="child",
+        policy_parent_id="vibesys-1",
+        target_island=0,
+        objectives=None,
+    )
+
+    assert set(uninterrupted._database.programs) == set(resumed._database.programs)
+    assert {
+        program.id: program.timestamp for program in uninterrupted._database.programs.values()
+    } == {program.id: program.timestamp for program in resumed._database.programs.values()}
 
 
 def test_resume_continues_upstream_random_stream_without_touching_global_rng(tmp_path) -> None:


### PR DESCRIPTION
## Problem

Persisted RNG state did not make OpenEvolve resume reproducible. Set iteration order, empty-island copies, and migration generated process-dependent ordering, UUIDs, and timestamps, allowing uninterrupted and resumed trajectories to diverge.

Fixes #234.

## Solution

Normalize upstream collections before sampling and mutation. Any upstream-created island copy or migrant is canonicalized to a UUID5 derived from semantic state, with a deterministic timestamp; direct VibeSys programs also use their durable individual ID as time identity. All database indexes and lineage references are rewritten consistently.

### Architecture

OpenEvolve retains selection and migration strategy ownership. The adapter provides deterministic ordering and identity at the pinned third-party boundary without changing the public search-policy or persistence schema.

## Verification

Tests intentionally reconstruct different set orders and compare uninterrupted/resumed selection, empty-island copy IDs, migration program IDs, timestamps, and process-global RNG isolation.

### Correctness properties

- Equal snapshot and RNG state produce equal future identities and selection.
- Empty-island and migration paths do not depend on uuid4 or wall time.
- Every database index references the canonical program ID.
- Set membership semantics and upstream strategy remain intact.
- Native VibeSys search behavior is unchanged.

### Testing

- `uv run pytest tests/loops/evolve/test_search_policy.py -q` — 22 passed.
- `uv run pytest -q` — 2,025 passed, 1 expected platform skip.
- Format, lint, type checking, and `git diff --check` passed.
