### PR TITLE
Fix/reuse deepagents per kind

### DIFF
--- a/src/vibesys/agents/deepagents_runner.py
+++ b/src/vibesys/agents/deepagents_runner.py
@@ -55,18 +55,70 @@ class DeepAgentsRunner:
         self._skills = skills
         self._model_name = model_name
         self._run_log_file = run_log_file
+        # Cache the compiled agent graph separately from conversation state.
+        # Tool objects may close over per-invocation policy (the issue-loop
+        # tools do), so their identities are part of the signature rather
+        # than just their names.
+        self._agents: dict[str, Any] = {}
+        self._agent_signatures: dict[str, tuple[Any, ...]] = {}
+        self._checkpointers: dict[str, MemorySaver] = {}
         self._sessions: dict[str, tuple[MemorySaver, str]] = {}
+
+    def _checkpointer(self, kind: str) -> MemorySaver:
+        """Return the checkpointer shared by one kind's cached graphs."""
+        checkpointer = self._checkpointers.get(kind)
+        if checkpointer is None:
+            checkpointer = MemorySaver()
+            self._checkpointers[kind] = checkpointer
+        return checkpointer
 
     def _session(
         self, *, kind: str, reuse_session: bool | None, session_key: str | None
     ) -> tuple[MemorySaver, str]:
-        """Return fresh state by default, or durable state for an explicit key."""
+        """Return a fresh thread by default, or a durable thread for a key."""
+        checkpointer = self._checkpointer(kind)
         if not reuse_session or kind == "chat":
-            return MemorySaver(), uuid.uuid4().hex
+            return checkpointer, uuid.uuid4().hex
         key = f"{kind}:{session_key}" if session_key else kind
         if key not in self._sessions:
-            self._sessions[key] = (MemorySaver(), uuid.uuid4().hex)
+            self._sessions[key] = (checkpointer, uuid.uuid4().hex)
         return self._sessions[key]
+
+    def _get_agent(
+        self,
+        *,
+        kind: str,
+        system_prompt: str,
+        response_cls: type[BaseModel] | None = None,
+        tools: list[BaseTool] | None = None,
+    ) -> Any:
+        """Return the cached graph, rebuilding it when its inputs change."""
+        tool_signature = tuple(id(tool) for tool in (tools or []))
+        signature = (
+            system_prompt,
+            tuple(self._skills),
+            tool_signature,
+            response_cls,
+            id(self._model),
+            id(self._backends[kind]),
+        )
+        if kind in self._agents and self._agent_signatures.get(kind) == signature:
+            return self._agents[kind]
+
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "backend": self._backends[kind],
+            "system_prompt": system_prompt,
+            "skills": self._skills,
+            "checkpointer": self._checkpointer(kind),
+            "tools": tools,
+        }
+        if response_cls is not None:
+            kwargs["response_format"] = AutoStrategy(response_cls)
+        agent = create_deep_agent(**kwargs)
+        self._agents[kind] = agent
+        self._agent_signatures[kind] = signature
+        return agent
 
     def invoke(
         self,
@@ -88,20 +140,15 @@ class DeepAgentsRunner:
     ) -> T:
         label = _agent_label(kind)
 
-        checkpointer, thread_id = self._session(
+        _, thread_id = self._session(
             kind=kind,
             reuse_session=reuse_session,
             session_key=session_key,
         )
-
-        backend = self._backends[kind]
-        agent = create_deep_agent(
-            model=self._model,
-            backend=backend,
+        agent = self._get_agent(
+            kind=kind,
             system_prompt=system_prompt,
-            skills=self._skills,
-            response_format=AutoStrategy(response_cls),
-            checkpointer=checkpointer,
+            response_cls=response_cls,
             tools=tools,
         )
         log_agent_config(agent, label, self._run_log_file)
@@ -147,18 +194,15 @@ class DeepAgentsRunner:
         session_key: str | None = None,
     ) -> str:
         """Run a conversational agent without imposing a response schema."""
-        checkpointer, thread_id = self._session(
+        _, thread_id = self._session(
             kind=kind,
             reuse_session=reuse_session,
             session_key=session_key,
         )
         label = _agent_label(kind)
-        agent = create_deep_agent(
-            model=self._model,
-            backend=self._backends[kind],
+        agent = self._get_agent(
+            kind=kind,
             system_prompt=system_prompt,
-            skills=self._skills,
-            checkpointer=checkpointer,
             tools=tools,
         )
         log_agent_config(agent, label, self._run_log_file)

--- a/src/vibesys/agents/deepagents_runner.py
+++ b/src/vibesys/agents/deepagents_runner.py
@@ -55,6 +55,55 @@ class DeepAgentsRunner:
         self._skills = skills
         self._model_name = model_name
         self._run_log_file = run_log_file
+        # Cache the built agent graph + its checkpointer per kind, so the
+        # underlying agent graph (tools, model binding, skills wiring) is
+        # only rebuilt when the inputs that actually define it change.
+        # Keyed by (kind, system_prompt, tuple of tool names) so a change
+        # in either triggers a rebuild rather than silently reusing a stale
+        # agent. Each invocation still gets a fresh thread_id (below) so
+        # conversation context does not leak across rounds even though the
+        # graph itself is reused.
+        self._agents: dict[str, Any] = {}
+        self._agent_signatures: dict[str, tuple[str, tuple[str, ...], str | None]] = {}
+        self._checkpointers: dict[str, MemorySaver] = {}
+
+    def _get_agent(
+        self,
+        *,
+        kind: str,
+        system_prompt: str,
+        skills: list[str] | None = None,
+        response_format: Any = None,
+        tools: list[BaseTool] | None = None,
+    ) -> Any:
+        """Return the cached agent for *kind*, rebuilding if inputs changed."""
+        tool_names = tuple(sorted(getattr(t, "name", str(t)) for t in (tools or [])))
+        # Include whether/what response_format was requested: invoke() (typed,
+        # schema-bound) and invoke_text() (untyped) must never share a cached
+        # agent for the same kind, since the underlying graph differs.
+        response_format_key = (
+            type(response_format).__name__ if response_format is not None else None
+        )
+        signature = (system_prompt, tool_names, response_format_key)
+        cached = self._agents.get(kind)
+        if cached is not None and self._agent_signatures.get(kind) == signature:
+            return cached
+
+        checkpointer = self._checkpointers.setdefault(kind, MemorySaver())
+        kwargs: dict[str, Any] = dict(
+            model=self._model,
+            backend=self._backends[kind],
+            system_prompt=system_prompt,
+            skills=skills if skills is not None else self._skills,
+            checkpointer=checkpointer,
+            tools=tools,
+        )
+        if response_format is not None:
+            kwargs["response_format"] = response_format
+        agent = create_deep_agent(**kwargs)
+        self._agents[kind] = agent
+        self._agent_signatures[kind] = signature
+        return agent
 
     def invoke(
         self,
@@ -74,20 +123,16 @@ class DeepAgentsRunner:
     ) -> T:
         label = _agent_label(kind)
 
-        # Fresh checkpointer + thread id per invocation, so the agent starts
-        # with a clean context window each time. Mirrors what the simple loop
-        # did at loop.py:410-411 before the runner abstraction landed.
-        checkpointer = MemorySaver()
+        # Reuse the cached agent graph for this kind when the system prompt
+        # and tools haven't changed (see _get_agent). A fresh thread_id is
+        # still generated per invocation so each round starts with a clean
+        # context window, matching the pre-caching behavior at
+        # loop.py:410-411 — only the graph construction itself is reused.
         thread_id = uuid.uuid4().hex
-
-        backend = self._backends[kind]
-        agent = create_deep_agent(
-            model=self._model,
-            backend=backend,
+        agent = self._get_agent(
+            kind=kind,
             system_prompt=system_prompt,
-            skills=self._skills,
             response_format=AutoStrategy(response_cls),
-            checkpointer=checkpointer,
             tools=tools,
         )
         log_agent_config(agent, label, self._run_log_file)
@@ -131,15 +176,11 @@ class DeepAgentsRunner:
         tools: list[BaseTool] | None = None,
     ) -> str:
         """Run a conversational agent without imposing a response schema."""
-        checkpointer = MemorySaver()
         thread_id = uuid.uuid4().hex
         label = _agent_label(kind)
-        agent = create_deep_agent(
-            model=self._model,
-            backend=self._backends[kind],
+        agent = self._get_agent(
+            kind=kind,
             system_prompt=system_prompt,
-            skills=self._skills,
-            checkpointer=checkpointer,
             tools=tools,
         )
         log_agent_config(agent, label, self._run_log_file)

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -17,6 +17,7 @@ from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config
 from vibesys.constants import ComputeBackend
 from vibesys.schemas import (
+    IssueJudgeResponse,
     JudgeResponse,
     Verdict,
 )
@@ -201,6 +202,168 @@ class TestDeepAgentsRunner:
         assert continued is first
         assert other_role is not first
         assert fresh is not first
+
+    def test_deepagents_runner_reuses_graph_with_fresh_default_threads(self, tmp_path):
+        """Repeated calls reuse construction but keep default conversations isolated."""
+        pass_response = JudgeResponse(
+            analysis="looks good",
+            feedback="",
+            verdict=Verdict.PASS,
+        )
+        with (
+            patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
+            patch(
+                "vibesys.agents.deepagents_runner.run_typed_agent",
+                return_value=pass_response,
+            ) as mock_run,
+        ):
+            mock_create.return_value = MagicMock(name="deep_agent")
+            runner = DeepAgentsRunner(
+                model="m",
+                backends={"judge": MagicMock(name="judge-backend")},
+                skills=[],
+                model_name="m",
+                run_log_file=None,
+            )
+
+            for i in range(2):
+                runner.invoke(
+                    kind="judge",
+                    workspace=tmp_path,
+                    system_prompt="sys",
+                    user_prompt=f"usr {i}",
+                    response_cls=JudgeResponse,
+                    fallback_factory=_judge_fallback,
+                    round_label=f"judge #{i}",
+                )
+
+            assert mock_create.call_count == 1
+            thread_ids = [call.kwargs["thread_id"] for call in mock_run.call_args_list]
+            assert thread_ids[0] != thread_ids[1]
+
+    def test_deepagents_runner_rebuilds_when_response_schema_changes(self, tmp_path):
+        """A different response model must not reuse the old structured graph."""
+        with (
+            patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
+            patch(
+                "vibesys.agents.deepagents_runner.run_typed_agent",
+                return_value=JudgeResponse(analysis="ok", feedback="", verdict=Verdict.PASS),
+            ),
+        ):
+            mock_create.return_value = MagicMock(name="deep_agent")
+            runner = DeepAgentsRunner(
+                model="m",
+                backends={"judge": MagicMock(name="judge-backend")},
+                skills=[],
+                model_name="m",
+                run_log_file=None,
+            )
+
+            runner.invoke(
+                kind="judge",
+                workspace=tmp_path,
+                system_prompt="sys",
+                user_prompt="usr",
+                response_cls=JudgeResponse,
+                fallback_factory=_judge_fallback,
+                round_label="judge #1",
+            )
+            runner.invoke(
+                kind="judge",
+                workspace=tmp_path,
+                system_prompt="sys",
+                user_prompt="usr",
+                response_cls=IssueJudgeResponse,
+                fallback_factory=lambda: IssueJudgeResponse(
+                    issue_id=1,
+                    analysis="fallback",
+                    feedback="fallback",
+                    verdict=Verdict.FAIL,
+                ),
+                round_label="judge #2",
+            )
+
+            assert mock_create.call_count == 2
+            assert "response_format" in mock_create.call_args_list[0].kwargs
+            assert "response_format" in mock_create.call_args_list[1].kwargs
+            assert (
+                mock_create.call_args_list[0].kwargs["response_format"].schema
+                is not mock_create.call_args_list[1].kwargs["response_format"].schema
+            )
+
+    def test_deepagents_runner_rebuilds_when_tool_objects_change(self, tmp_path):
+        """Same-named tools can carry different closure-bound behavior."""
+        with (
+            patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
+            patch(
+                "vibesys.agents.deepagents_runner.run_typed_agent",
+                return_value=JudgeResponse(analysis="ok", feedback="", verdict=Verdict.PASS),
+            ),
+        ):
+            mock_create.return_value = MagicMock(name="deep_agent")
+            runner = DeepAgentsRunner(
+                model="m",
+                backends={"judge": MagicMock(name="judge-backend")},
+                skills=[],
+                model_name="m",
+                run_log_file=None,
+            )
+
+            for tool in (MagicMock(name="same-tool"), MagicMock(name="same-tool")):
+                runner.invoke(
+                    kind="judge",
+                    workspace=tmp_path,
+                    system_prompt="sys",
+                    user_prompt="usr",
+                    response_cls=JudgeResponse,
+                    fallback_factory=_judge_fallback,
+                    round_label="judge",
+                    tools=[tool],
+                )
+
+            assert mock_create.call_count == 2
+
+    def test_deepagents_runner_typed_and_text_graphs_are_separate(self, tmp_path):
+        with (
+            patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
+            patch(
+                "vibesys.agents.deepagents_runner.run_typed_agent",
+                return_value=JudgeResponse(analysis="ok", feedback="", verdict=Verdict.PASS),
+            ),
+            patch(
+                "vibesys.agents.deepagents_runner.run_agent",
+                return_value="plain text",
+            ),
+        ):
+            mock_create.return_value = MagicMock(name="deep_agent")
+            runner = DeepAgentsRunner(
+                model="m",
+                backends={"judge": MagicMock(name="judge-backend")},
+                skills=[],
+                model_name="m",
+                run_log_file=None,
+            )
+
+            runner.invoke(
+                kind="judge",
+                workspace=tmp_path,
+                system_prompt="sys",
+                user_prompt="usr",
+                response_cls=JudgeResponse,
+                fallback_factory=_judge_fallback,
+                round_label="judge",
+            )
+            runner.invoke_text(
+                kind="judge",
+                workspace=tmp_path,
+                system_prompt="sys",
+                user_prompt="usr",
+                round_label="chat",
+            )
+
+            assert mock_create.call_count == 2
+            assert "response_format" in mock_create.call_args_list[0].kwargs
+            assert "response_format" not in mock_create.call_args_list[1].kwargs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -181,6 +181,134 @@ class TestDeepAgentsRunner:
         assert "response_format" not in mock_create.call_args.kwargs
         assert mock_run.call_args.args[1] == "what happened?"
 
+    def test_deepagents_runner_reuses_agent_for_same_kind(self, tmp_path):
+        """Two invoke() calls with the same kind/prompt/tools share one agent."""
+        pass_response = JudgeResponse(
+            analysis="looks good",
+            feedback="",
+            verdict=Verdict.PASS,
+        )
+        with (
+            patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
+            patch(
+                "vibesys.agents.deepagents_runner.run_typed_agent",
+                return_value=pass_response,
+            ),
+        ):
+            mock_create.return_value = MagicMock(name="deep_agent")
+
+            runner = DeepAgentsRunner(
+                model="m",
+                backends={"judge": MagicMock(name="judge-backend")},
+                skills=[],
+                model_name="m",
+                run_log_file=None,
+            )
+
+            for i in range(2):
+                runner.invoke(
+                    kind="judge",
+                    workspace=tmp_path,
+                    system_prompt="sys",
+                    user_prompt=f"usr {i}",
+                    response_cls=JudgeResponse,
+                    fallback_factory=_judge_fallback,
+                    round_label=f"judge #{i}",
+                )
+
+            assert mock_create.call_count == 1
+
+    def test_deepagents_runner_rebuilds_when_system_prompt_changes(self, tmp_path):
+        """A different system_prompt for the same kind triggers a rebuild."""
+        pass_response = JudgeResponse(
+            analysis="looks good",
+            feedback="",
+            verdict=Verdict.PASS,
+        )
+        with (
+            patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
+            patch(
+                "vibesys.agents.deepagents_runner.run_typed_agent",
+                return_value=pass_response,
+            ),
+        ):
+            mock_create.return_value = MagicMock(name="deep_agent")
+
+            runner = DeepAgentsRunner(
+                model="m",
+                backends={"judge": MagicMock(name="judge-backend")},
+                skills=[],
+                model_name="m",
+                run_log_file=None,
+            )
+
+            runner.invoke(
+                kind="judge",
+                workspace=tmp_path,
+                system_prompt="sys v1",
+                user_prompt="usr",
+                response_cls=JudgeResponse,
+                fallback_factory=_judge_fallback,
+                round_label="judge #1",
+            )
+            runner.invoke(
+                kind="judge",
+                workspace=tmp_path,
+                system_prompt="sys v2",
+                user_prompt="usr",
+                response_cls=JudgeResponse,
+                fallback_factory=_judge_fallback,
+                round_label="judge #2",
+            )
+
+            assert mock_create.call_count == 2
+
+    def test_deepagents_runner_invoke_and_invoke_text_do_not_share_cache(self, tmp_path):
+        """invoke() (typed) and invoke_text() (untyped) never reuse each other's agent."""
+        with (
+            patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
+            patch(
+                "vibesys.agents.deepagents_runner.run_typed_agent",
+                return_value=JudgeResponse(analysis="ok", feedback="", verdict=Verdict.PASS),
+            ),
+            patch(
+                "vibesys.agents.deepagents_runner.run_agent",
+                return_value="plain text",
+            ),
+        ):
+            mock_create.return_value = MagicMock(name="deep_agent")
+
+            runner = DeepAgentsRunner(
+                model="m",
+                backends={"judge": MagicMock(name="judge-backend")},
+                skills=[],
+                model_name="m",
+                run_log_file=None,
+            )
+
+            runner.invoke(
+                kind="judge",
+                workspace=tmp_path,
+                system_prompt="sys",
+                user_prompt="usr",
+                response_cls=JudgeResponse,
+                fallback_factory=_judge_fallback,
+                round_label="judge #1",
+            )
+            runner.invoke_text(
+                kind="judge",
+                workspace=tmp_path,
+                system_prompt="sys",
+                user_prompt="usr",
+                round_label="judge #2",
+            )
+
+            assert mock_create.call_count == 2
+            first_kwargs = mock_create.call_args_list[0].kwargs
+            second_kwargs = mock_create.call_args_list[1].kwargs
+            assert "response_format" in first_kwargs
+            assert "response_format" not in second_kwargs
+
 
 # ---------------------------------------------------------------------------
 # Helpers for CLI runner tests


### PR DESCRIPTION
## Problem

Fixes #18.

`DeepAgentsRunner.invoke()` and `invoke_text()` rebuilt the complete deep-agent graph on every call. That repeated model binding, middleware, backend, skills, and tool wiring in the hot loop even when the graph configuration was unchanged.

The original PR also needed to account for changes that landed on `main` after it was opened: explicit session reuse and issue-loop tools whose closures carry per-invocation policy.

## Solution

Cache the compiled graph per agent kind and rebuild it only when graph-defining inputs change. The cache signature includes:

- rendered system prompt and skills
- exact tool object identities, because tools may close over iteration-specific state
- the Pydantic response model, so different structured-output schemas cannot collide
- model and backend identities

Conversation state remains separate from graph construction. A per-kind `MemorySaver` is shared by cached graphs, while default calls and chat receive fresh thread IDs. Explicit keyed sessions continue to reuse their thread IDs.

Typed and plain-text invocations remain separate because only typed calls pass `response_format`.

### Architecture

```mermaid
flowchart LR
    invoke[Agent invocation] --> signature{Graph signature matches?}
    signature -->|yes| cached[Reuse compiled graph]
    signature -->|no| build[Build graph with current inputs]
    build --> cache[Update per-kind cache]
    cached --> run[Run with selected thread]
    cache --> run
```

## Verification

### Correctness properties

- Repeated calls with unchanged graph inputs invoke `create_deep_agent()` only once per kind.
- Changing the prompt, skills, tools, response model, model, or backend rebuilds the graph.
- Same-named tools with different closure state are never reused accidentally.
- Default calls receive distinct thread IDs, so conversation state does not leak between rounds.
- Explicit session keys preserve their existing durable-thread behavior.
- Typed and untyped calls never share a graph with incompatible response-format configuration.

### Testing

- `uv run pytest tests/agents/test_agent_runners.py -k deepagents -q` — 8 passed
- `uv run pytest tests/agents/ -q` — 262 passed
- `uv run pytest tests/loops/plain/ -q` — 66 passed
- `bash scripts/check_format.sh` — passed
- `bash scripts/check_lint.sh` — passed
- `bash scripts/check_types.sh` — 0 errors, 0 warnings
