### PR TITLE
Measure Llama serving at sustainable peak load

### DIFF
--- a/examples/model-serving/Llama-3-8B/OBJECTIVE.md
+++ b/examples/model-serving/Llama-3-8B/OBJECTIVE.md
@@ -25,6 +25,11 @@ sweep. At every point, keep the request shape fixed with `--duration 20`,
 shorten the output length: tiny workloads make throughput degenerate into
 first-token latency and provide no useful batching or scheduling signal.
 
+Wait for the server health endpoint before the sweep and keep the same server
+process alive across every point. The benchmark sends four discarded requests
+before each measured point. Canonical measurements keep this default warm-up so
+one-time request-path initialization is excluded consistently.
+
 Run the benchmark client on the same host as the server and send requests over
 the loopback interface (for example, `http://127.0.0.1:<port>`). This keeps
 external network routing and ingress variability out of TTFT, TPOT, and
@@ -33,21 +38,31 @@ serving path. Provision enough host CPU for the client so load generation does
 not become the bottleneck.
 
 Start at concurrency 1 and double through `2, 4, 8, 16, 32, 64, 128`. If
-throughput is still increasing materially at 128, continue doubling until the
-sweep includes at least one overloaded point beyond the best sustainable point,
-subject to the server's documented admission limit. A point is overloaded when
-requests fail or time out, throughput falls materially below the best earlier
-point, or latency rises sharply without a material throughput gain. Confirm a
-suspected boundary by testing intermediate concurrency values between the last
-rising point and the first overloaded point, then repeat the best point and its
-neighbors. Do not classify ordinary run-to-run noise as overload.
+throughput at 128 is more than 3% above the best earlier point, continue doubling
+until the sweep includes at least one overloaded point beyond the best
+sustainable point, subject to the server's documented admission limit. A point
+is overloaded when requests fail or time out, output throughput is below 95% of
+the best earlier point, or output throughput is no higher than 103% of that best
+point while p99 TTFT or p99 end-to-end latency exceeds 2x the last confirmed
+sustainable point.
+Confirm a suspected boundary by testing intermediate concurrency values between
+the last rising point and the first overloaded point, then repeat the best point
+and its neighbors. Do not classify ordinary run-to-run noise as overload.
 
 Retain and report every sweep row. The canonical `aggregate_throughput` is the
 highest value among non-overloaded points. Report TTFT, TPOT, and
 `p99_latency_ms` from that same concurrency and repetition; do not combine
 throughput from one operating point with latency from another. If the sweep
-stops while throughput is still materially increasing, it has not established
-a peak and must not be reported as one.
+stops while throughput is still rising by more than 3%, it has not established a
+peak and must not be reported as one.
+
+The benchmark result's `load_concurrency` block must show that the client HTTP
+connection limit is at least the requested worker count. Check its observed
+`max_in_flight_requests` and `max_active_streams` values for client-side or
+admission-path bottlenecks before treating a latency cliff as server overload.
+Short targeted checks around a previously confirmed boundary are useful for
+hypothesis testing, but they cannot replace this canonical sweep or establish a
+new peak.
 
 ## Headline metric (`perf_metric`) and Pareto metrics — canonical fields, do not leave null
 

--- a/examples/model-serving/Llama-3-8B/OBJECTIVE.md
+++ b/examples/model-serving/Llama-3-8B/OBJECTIVE.md
@@ -16,37 +16,48 @@ as the parent on both axes and strictly better on one. Raising throughput by
 inflating tail latency (e.g. unbounded batch sizes) is a real trade-off, not a
 free win — it moves you along the frontier, it does not dominate.
 
-## Benchmark protocol — run EXACTLY this
+## Benchmark protocol — sweep to the overload boundary
 
-Both axes are only comparable across candidates if every candidate is measured
-under the **same fixed saturating load**. When you (the profiler) run the
-benchmark, use these flags verbatim and change **only** `--url` (the live server)
-and `--output-json` (the output path):
+The canonical score is the highest sustainable output-token throughput reached
+before the server becomes overloaded. Measure it with a closed-loop concurrency
+sweep. At every point, keep the request shape fixed with `--duration 20`,
+`--max-tokens 128`, and `--temperature 0`. Do not use `--num-requests 1` or
+shorten the output length: tiny workloads make throughput degenerate into
+first-token latency and provide no useful batching or scheduling signal.
 
-```
-<benchmark_command> --url <SERVER_URL> --concurrency 16 --duration 20 --max-tokens 128 --temperature 0 --output-json <PATH>
-```
+Run the benchmark client on the same host as the server and send requests over
+the loopback interface (for example, `http://127.0.0.1:<port>`). This keeps
+external network routing and ingress variability out of TTFT, TPOT, and
+throughput measurements while still exercising the OpenAI-compatible HTTP/SSE
+serving path. Provision enough host CPU for the client so load generation does
+not become the bottleneck.
 
-- `--concurrency 16` drives a **closed-loop** load of exactly 16 in-flight
-  requests, so `aggregate_throughput` measures true server capacity (not the
-  arrival rate) and `p99_latency_ms` measures tail latency under contention.
-- Do **not** use `--num-requests 1`, do not lower `--concurrency`, and do not
-  shorten `--max-tokens`. A single-request or tiny workload makes throughput
-  degenerate into first-token latency and gives the search no signal about
-  batching or scheduling.
-- The fixed 16-way load is also what bounds the frontier: no candidate can "win"
-  the latency axis by serving fewer requests, because every candidate faces the
-  identical load. A server that fails or starves most requests loses throughput
-  and trips the benchmark-sanity / accuracy gates.
+Start at concurrency 1 and double through `2, 4, 8, 16, 32, 64, 128`. If
+throughput is still increasing materially at 128, continue doubling until the
+sweep includes at least one overloaded point beyond the best sustainable point,
+subject to the server's documented admission limit. A point is overloaded when
+requests fail or time out, throughput falls materially below the best earlier
+point, or latency rises sharply without a material throughput gain. Confirm a
+suspected boundary by testing intermediate concurrency values between the last
+rising point and the first overloaded point, then repeat the best point and its
+neighbors. Do not classify ordinary run-to-run noise as overload.
+
+Retain and report every sweep row. The canonical `aggregate_throughput` is the
+highest value among non-overloaded points. Report TTFT, TPOT, and
+`p99_latency_ms` from that same concurrency and repetition; do not combine
+throughput from one operating point with latency from another. If the sweep
+stops while throughput is still materially increasing, it has not established
+a peak and must not be reported as one.
 
 ## Headline metric (`perf_metric`) and Pareto metrics — canonical fields, do not leave null
 
 Headline metric: `aggregate_throughput` (output tok/s)
 
 The scalar `perf_metric` (used for plateau detection and the scalar fallback) is
-**`aggregate_throughput`** read directly from the benchmark JSON. In addition,
-because this is a Pareto run, populate `ProfilerSummary.metrics` with **both**
-objective values using these exact keys, read verbatim from the benchmark JSON:
+the peak sustainable **`aggregate_throughput`** selected by the concurrency
+sweep. In addition, because this is a Pareto run, populate
+`ProfilerSummary.metrics` with **both** objective values using these exact keys
+from the selected operating point in the benchmark JSON:
 
 ```
 metrics = {

--- a/examples/model-serving/Llama-3-8B/accuracy_checker/README.md
+++ b/examples/model-serving/Llama-3-8B/accuracy_checker/README.md
@@ -2,11 +2,11 @@ Accuracy checker for Llama-3-8B (service-style).
 
 The checker drives a **running** OpenAI-compatible server over HTTP — it does
 not import the candidate's model or load weights locally, so it works the same
-against a local, Docker, or remote Modal server. Point it at the server URL:
+against a local, containerized, or remote server. Point it at the server URL:
 
 ```
 python checker.py --url http://localhost:8000
-python checker.py --url https://<app>.modal.run --seed 0
+python checker.py --url https://inference.example.com --seed 0
 ```
 
 Because there is no local GPU reference to diff against, correctness is

--- a/examples/model-serving/Llama-3-8B/accuracy_checker/checker.py
+++ b/examples/model-serving/Llama-3-8B/accuracy_checker/checker.py
@@ -3,8 +3,8 @@ Accuracy checker for the Llama-3-8B serving system (service-style).
 
 This checker drives a *running* OpenAI-compatible server over HTTP — it does
 NOT import the candidate's model or load any weights locally. That makes it
-work identically whether the server runs on the local host, in Docker, or on a
-remote Modal GPU: the checker only needs the server URL.
+work identically whether the server runs on the local host, in a container, or
+on a remote accelerator: the checker only needs the server URL.
 
 Because there is no local GPU reference to diff against, correctness is
 established with three reference-free gates that a real Llama-3 forward pass
@@ -32,7 +32,7 @@ thresholds; exit 1 otherwise.
 Usage (server must already be running):
 
     python checker.py --url http://localhost:8000
-    python checker.py --url https://<app>.modal.run --seed 0
+    python checker.py --url https://inference.example.com --seed 0
 """
 
 from __future__ import annotations
@@ -92,6 +92,7 @@ async def _stream_text(
 async def complete(
     client: httpx.AsyncClient,
     base_url: str,
+    model: str,
     endpoint: str,
     prompt: str,
     max_tokens: int,
@@ -101,6 +102,7 @@ async def complete(
     """Raw /v1/completions call."""
     url = base_url.rstrip("/") + endpoint
     body = {
+        "model": model,
         "prompt": prompt,
         "max_tokens": max_tokens,
         "temperature": temperature,
@@ -112,6 +114,7 @@ async def complete(
 async def chat(
     client: httpx.AsyncClient,
     base_url: str,
+    model: str,
     endpoint: str,
     messages: list[dict],
     max_tokens: int,
@@ -121,6 +124,7 @@ async def chat(
     """Chat /v1/chat/completions call."""
     url = base_url.rstrip("/") + endpoint
     body = {
+        "model": model,
         "messages": messages,
         "max_tokens": max_tokens,
         "temperature": temperature,
@@ -159,6 +163,7 @@ async def gate_sentinel_echo(
         text, err = await chat(
             client,
             args.url,
+            args.model,
             args.chat_endpoint,
             messages,
             max_tokens=16,
@@ -205,6 +210,7 @@ async def gate_known_answers(
         text, err = await chat(
             client,
             args.url,
+            args.model,
             args.chat_endpoint,
             messages,
             max_tokens=24,
@@ -245,10 +251,24 @@ async def gate_determinism(
     results: list[dict] = []
     for prompt in DETERMINISM_PROMPTS:
         out_a, err_a = await complete(
-            client, args.url, args.endpoint, prompt, args.det_max_tokens, 0.0, args.request_timeout
+            client,
+            args.url,
+            args.model,
+            args.endpoint,
+            prompt,
+            args.det_max_tokens,
+            0.0,
+            args.request_timeout,
         )
         out_b, err_b = await complete(
-            client, args.url, args.endpoint, prompt, args.det_max_tokens, 0.0, args.request_timeout
+            client,
+            args.url,
+            args.model,
+            args.endpoint,
+            prompt,
+            args.det_max_tokens,
+            0.0,
+            args.request_timeout,
         )
         err = err_a or err_b
         ok = err is None and out_a == out_b and len(out_a) > 0
@@ -332,6 +352,7 @@ async def run(args: argparse.Namespace) -> int:
 
         summary = {
             "url": args.url,
+            "model": args.model,
             "seed": args.seed,
             "sentinel_rate": s_rate,
             "known_answer_rate": k_rate,
@@ -361,6 +382,11 @@ def main() -> None:
         )
     )
     parser.add_argument("--url", default="http://localhost:8000", help="Server base URL")
+    parser.add_argument(
+        "--model",
+        default="meta-llama/Llama-3.1-8B-Instruct",
+        help="Served model name included in the OpenAI request body",
+    )
     parser.add_argument("--endpoint", default="/v1/completions", help="Completions endpoint path")
     parser.add_argument(
         "--chat-endpoint", default="/v1/chat/completions", help="Chat completions endpoint path"

--- a/examples/model-serving/Llama-3-8B/benchmark/README.md
+++ b/examples/model-serving/Llama-3-8B/benchmark/README.md
@@ -4,6 +4,12 @@ Benchmark inputs for Llama-3-8B. Run the benchmark client on the same host as
 the server and use its loopback URL so external network variability is excluded
 from TTFT, TPOT, and throughput.
 
+Start the server, wait until its health endpoint succeeds, and keep that same
+server process running for the entire sweep. Each benchmark invocation sends
+four discarded warm-up requests by default before starting its measurement
+clock. Use `--warmup-requests 0` only for debugging; canonical measurements use
+the default warm-up.
+
 The canonical candidate score is the highest sustainable tok/s before overload.
 Start with this closed-loop sweep, keeping the other load parameters fixed at
 every point:
@@ -25,5 +31,56 @@ beyond the best sustainable point. Then test intermediate concurrency values
 between the last rising point and the first overloaded point, and repeat the
 best point and its neighbors to confirm the boundary. Retain every result and
 report tok/s, TTFT, and TPOT from the same peak-throughput concurrency and
-repetition. A sweep that ends while throughput is still materially increasing
-has not measured the peak.
+repetition. A sweep that ends with throughput still more than 3% above the best
+earlier point has not measured the peak.
+
+Use these thresholds to identify a suspected overload point relative to the
+best earlier point and the last confirmed sustainable point:
+
+- any request failure or timeout;
+- output throughput below 95% of the best earlier point; or
+- output throughput no higher than 103% of the best earlier point while p99
+  TTFT or p99 end-to-end latency exceeds 2x the last sustainable value.
+
+Repeat the suspected point and its neighbors before classifying it. A single row
+crossing one of these thresholds can be ordinary run-to-run noise.
+
+The client sets its HTTP connection limit to the requested closed-loop
+concurrency. Every result also reports `requested_workers`,
+`client_max_connections`, `max_in_flight_requests`, and `max_active_streams` in
+the `load_concurrency` block. Investigate a row when the observed maxima are
+lower than the requested load; the load generator or server admission path may
+be the bottleneck.
+
+## Quick hypothesis check
+
+After a canonical sweep has established a stable boundary, use the best point
+and its nearest lower and higher neighbors for a fast directional comparison.
+For example, if those levels are `80, 96, 112`, run:
+
+```bash
+for concurrency in 80 96 112; do
+  python benchmark.py \
+    --url http://127.0.0.1:8000 \
+    --concurrency "$concurrency" \
+    --duration 10 \
+    --max-tokens 128 \
+    --temperature 0 \
+    --output-json "quick-c${concurrency}.json"
+done
+```
+
+Replace the example levels with neighbors from the most recent valid canonical
+sweep. Do not reuse a historical boundary after a change that may move it.
+Quick-check results may validate a hypothesis but do not replace the full sweep
+or update the canonical score. A change to scheduling, batching, precision, or
+memory use can move the overload boundary; run the canonical protocol before
+reporting a new peak.
+
+## Runtime expectations
+
+`--duration` controls how long workers start new requests. Requests already in
+flight then drain, so each point takes at least the configured duration and can
+run longer near overload. A sweep with `N` points therefore needs at least
+`N * duration`, plus warm-up, drain, server startup, and readiness time. Keep
+the server alive between points so startup is paid once and caches are not reset.

--- a/examples/model-serving/Llama-3-8B/benchmark/README.md
+++ b/examples/model-serving/Llama-3-8B/benchmark/README.md
@@ -1,3 +1,29 @@
-Benchmark inputs for Llama-3-8B.
+# Benchmark
 
-Run: `python benchmark.py`
+Benchmark inputs for Llama-3-8B. Run the benchmark client on the same host as
+the server and use its loopback URL so external network variability is excluded
+from TTFT, TPOT, and throughput.
+
+The canonical candidate score is the highest sustainable tok/s before overload.
+Start with this closed-loop sweep, keeping the other load parameters fixed at
+every point:
+
+```bash
+for concurrency in 1 2 4 8 16 32 64 128; do
+  python benchmark.py \
+    --url http://127.0.0.1:8000 \
+    --concurrency "$concurrency" \
+    --duration 20 \
+    --max-tokens 128 \
+    --temperature 0 \
+    --output-json "result-c${concurrency}.json"
+done
+```
+
+Continue doubling concurrency until the sweep includes an overloaded point
+beyond the best sustainable point. Then test intermediate concurrency values
+between the last rising point and the first overloaded point, and repeat the
+best point and its neighbors to confirm the boundary. Retain every result and
+report tok/s, TTFT, and TPOT from the same peak-throughput concurrency and
+repetition. A sweep that ends while throughput is still materially increasing
+has not measured the peak.

--- a/examples/model-serving/Llama-3-8B/benchmark/benchmark.py
+++ b/examples/model-serving/Llama-3-8B/benchmark/benchmark.py
@@ -61,12 +61,14 @@ PROMPT_POOL = [
 async def send_request(
     client: httpx.AsyncClient,
     url: str,
+    model: str,
     prompt: str,
     max_tokens: int,
     temperature: float,
 ) -> dict:
     """Send a single streaming completion request and measure timings."""
     body = {
+        "model": model,
         "prompt": prompt,
         "max_tokens": max_tokens,
         "temperature": temperature,
@@ -199,7 +201,14 @@ async def run_closed_loop(
                     return
                 sent += 1
             prompt = rng.choice(prompts)
-            result = await send_request(client, url, prompt, args.max_tokens, args.temperature)
+            result = await send_request(
+                client,
+                url,
+                args.model,
+                prompt,
+                args.max_tokens,
+                args.temperature,
+            )
             results.append(result)
 
     await asyncio.gather(*[asyncio.create_task(worker()) for _ in range(args.concurrency)])
@@ -243,7 +252,14 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
 
                 prompt = rng.choice(prompts)
                 task = asyncio.create_task(
-                    send_request(client, url, prompt, args.max_tokens, args.temperature)
+                    send_request(
+                        client,
+                        url,
+                        args.model,
+                        prompt,
+                        args.max_tokens,
+                        args.temperature,
+                    )
                 )
                 tasks.append(task)
                 sent += 1
@@ -311,6 +327,7 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
     result_dict = {
         "config": {
             "url": args.url.rstrip("/") + args.endpoint,
+            "model": args.model,
             "rate": args.rate,
             "concurrency": args.concurrency,
             "duration": args.duration,
@@ -371,6 +388,11 @@ def main() -> None:
     )
     parser.add_argument("--url", default="http://localhost:8000", help="Server base URL")
     parser.add_argument("--endpoint", default="/v1/completions", help="API endpoint path")
+    parser.add_argument(
+        "--model",
+        default="meta-llama/Llama-3.1-8B-Instruct",
+        help="Served model name included in the OpenAI request body",
+    )
     parser.add_argument("--rate", type=float, default=1.0, help="Request rate (req/s, Poisson)")
     parser.add_argument(
         "--concurrency",

--- a/examples/model-serving/Llama-3-8B/benchmark/benchmark.py
+++ b/examples/model-serving/Llama-3-8B/benchmark/benchmark.py
@@ -17,6 +17,7 @@ import json
 import math
 import random
 import time
+from dataclasses import dataclass
 
 import httpx
 
@@ -58,6 +59,33 @@ PROMPT_POOL = [
 # ---------------------------------------------------------------------------
 
 
+@dataclass
+class ConcurrencyStats:
+    """Track driver tasks separately from active HTTP response streams."""
+
+    in_flight_requests: int = 0
+    max_in_flight_requests: int = 0
+    active_streams: int = 0
+    max_active_streams: int = 0
+
+    def request_started(self) -> None:
+        self.in_flight_requests += 1
+        self.max_in_flight_requests = max(
+            self.max_in_flight_requests,
+            self.in_flight_requests,
+        )
+
+    def request_finished(self) -> None:
+        self.in_flight_requests -= 1
+
+    def stream_opened(self) -> None:
+        self.active_streams += 1
+        self.max_active_streams = max(self.max_active_streams, self.active_streams)
+
+    def stream_closed(self) -> None:
+        self.active_streams -= 1
+
+
 async def send_request(
     client: httpx.AsyncClient,
     url: str,
@@ -65,6 +93,7 @@ async def send_request(
     prompt: str,
     max_tokens: int,
     temperature: float,
+    concurrency_stats: ConcurrencyStats | None = None,
 ) -> dict:
     """Send a single streaming completion request and measure timings."""
     body = {
@@ -82,28 +111,40 @@ async def send_request(
     finish_reason = None
     error = None
 
+    if concurrency_stats is not None:
+        concurrency_stats.request_started()
     try:
-        async with client.stream("POST", url, json=body, timeout=120.0) as resp:
-            resp.raise_for_status()
-            async for raw_line in resp.aiter_lines():
-                if not raw_line.startswith("data: "):
-                    continue
-                payload = raw_line[len("data: ") :]
-                if payload.strip() == "[DONE]":
-                    t_done = time.perf_counter()
-                    break
-                chunk = json.loads(payload)
-                text = chunk["choices"][0]["text"]
-                reason = chunk["choices"][0].get("finish_reason")
-                if reason is not None:
-                    finish_reason = reason
-                if text:
-                    output_tokens += 1
-                    if t_first_token is None:
-                        t_first_token = time.perf_counter()
-    except Exception as exc:
-        error = str(exc)
-        t_done = time.perf_counter()
+        try:
+            async with client.stream("POST", url, json=body, timeout=120.0) as resp:
+                resp.raise_for_status()
+                if concurrency_stats is not None:
+                    concurrency_stats.stream_opened()
+                try:
+                    async for raw_line in resp.aiter_lines():
+                        if not raw_line.startswith("data: "):
+                            continue
+                        payload = raw_line[len("data: ") :]
+                        if payload.strip() == "[DONE]":
+                            t_done = time.perf_counter()
+                            break
+                        chunk = json.loads(payload)
+                        text = chunk["choices"][0]["text"]
+                        reason = chunk["choices"][0].get("finish_reason")
+                        if reason is not None:
+                            finish_reason = reason
+                        if text:
+                            output_tokens += 1
+                            if t_first_token is None:
+                                t_first_token = time.perf_counter()
+                finally:
+                    if concurrency_stats is not None:
+                        concurrency_stats.stream_closed()
+        except Exception as exc:
+            error = str(exc)
+            t_done = time.perf_counter()
+    finally:
+        if concurrency_stats is not None:
+            concurrency_stats.request_finished()
 
     # Compute metrics
     if t_done is None:
@@ -168,6 +209,46 @@ def format_stats(values: list[float], unit: str = "ms", multiplier: float = 1000
 # ---------------------------------------------------------------------------
 
 
+def http_limits_for(concurrency: int | None) -> httpx.Limits:
+    """Return limits that cannot cap a requested closed-loop concurrency."""
+    if concurrency is not None:
+        return httpx.Limits(
+            max_connections=concurrency,
+            max_keepalive_connections=concurrency,
+        )
+    return httpx.Limits(max_connections=None, max_keepalive_connections=100)
+
+
+async def run_warmup(
+    client: httpx.AsyncClient,
+    url: str,
+    prompts: list[str],
+    args: argparse.Namespace,
+    rng: random.Random,
+) -> list[dict]:
+    """Issue discarded requests before measurement using the benchmark shape."""
+    if args.warmup_requests == 0:
+        return []
+
+    warmup_concurrency = min(args.warmup_requests, args.concurrency or 1)
+    semaphore = asyncio.Semaphore(warmup_concurrency)
+
+    async def warmup_request() -> dict:
+        async with semaphore:
+            return await send_request(
+                client,
+                url,
+                args.model,
+                rng.choice(prompts),
+                args.max_tokens,
+                args.temperature,
+            )
+
+    return await asyncio.gather(
+        *[asyncio.create_task(warmup_request()) for _ in range(args.warmup_requests)]
+    )
+
+
 async def run_closed_loop(
     client: httpx.AsyncClient,
     url: str,
@@ -175,6 +256,7 @@ async def run_closed_loop(
     args: argparse.Namespace,
     rng: random.Random,
     t_bench_start: float,
+    concurrency_stats: ConcurrencyStats,
 ) -> list[dict]:
     """Closed-loop driver: `args.concurrency` workers send requests back-to-back.
 
@@ -208,6 +290,7 @@ async def run_closed_loop(
                 prompt,
                 args.max_tokens,
                 args.temperature,
+                concurrency_stats,
             )
             results.append(result)
 
@@ -217,6 +300,7 @@ async def run_closed_loop(
 
 async def run_benchmark(args: argparse.Namespace) -> dict:
     rng = random.Random(args.seed)
+    warmup_rng = random.Random(args.seed)
     url = args.url.rstrip("/") + args.endpoint
 
     # Build prompt list
@@ -231,8 +315,27 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
     total_requests = args.num_requests if not use_duration else 10**9
 
     results: list[dict] = []
+    concurrency_stats = ConcurrencyStats()
+    limits = http_limits_for(args.concurrency)
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(limits=limits) as client:
+        t_warmup_start = time.perf_counter()
+        warmup_results = await run_warmup(client, url, prompts, args, warmup_rng)
+        warmup_duration = time.perf_counter() - t_warmup_start
+        warmup_errors = [r for r in warmup_results if r["error"] is not None]
+        if warmup_results:
+            print(
+                f"Warm-up:           {len(warmup_results) - len(warmup_errors)}/"
+                f"{len(warmup_results)} requests completed in {warmup_duration:.1f}s; "
+                "results discarded"
+            )
+        if warmup_errors:
+            first_error = warmup_errors[0]["error"]
+            raise RuntimeError(
+                f"{len(warmup_errors)} warm-up request(s) failed; measurement not started. "
+                f"First error: {first_error}"
+            )
+
         t_bench_start = time.perf_counter()
 
         if args.concurrency:
@@ -240,7 +343,15 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
             # sending requests back-to-back. In-flight count is bounded to
             # `concurrency`, producing a deterministic saturating operating
             # point (overrides the open-loop Poisson `--rate` path).
-            results = await run_closed_loop(client, url, prompts, args, rng, t_bench_start)
+            results = await run_closed_loop(
+                client,
+                url,
+                prompts,
+                args,
+                rng,
+                t_bench_start,
+                concurrency_stats,
+            )
         else:
             # Open-loop load: Poisson arrivals at `--rate`, fire-and-forget.
             tasks: list[asyncio.Task] = []
@@ -259,6 +370,7 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
                         prompt,
                         args.max_tokens,
                         args.temperature,
+                        concurrency_stats,
                     )
                 )
                 tasks.append(task)
@@ -299,6 +411,10 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
     print(f"Backend URL:       {args.url.rstrip('/')}{args.endpoint}")
     print(f"Duration:          {wall_clock:.1f}s")
     print(f"Completed:         {len(successes)}/{len(results)} requests ({len(errors)} errors)")
+    print(f"Requested workers: {args.concurrency if args.concurrency else 'open-loop'}")
+    print(f"Connection limit:  {limits.max_connections if limits.max_connections else 'unlimited'}")
+    print(f"Max in flight:     {concurrency_stats.max_in_flight_requests}")
+    print(f"Max active streams:{concurrency_stats.max_active_streams:>5}")
     print()
     print("Throughput:")
     print(f"  Request:         {len(successes) / wall_clock:.2f} req/s")
@@ -334,7 +450,17 @@ async def run_benchmark(args: argparse.Namespace) -> dict:
             "max_tokens": args.max_tokens,
             "temperature": args.temperature,
             "seed": args.seed,
+            "warmup_requests": args.warmup_requests,
         },
+        "load_concurrency": {
+            "requested_workers": args.concurrency,
+            "client_max_connections": limits.max_connections,
+            "max_in_flight_requests": concurrency_stats.max_in_flight_requests,
+            "max_active_streams": concurrency_stats.max_active_streams,
+        },
+        "warmup_num_requests": len(warmup_results),
+        "warmup_num_failed": len(warmup_errors),
+        "warmup_actual_duration": warmup_duration,
         "num_requests": len(results),
         "num_completed": len(successes),
         "num_failed": len(errors),
@@ -411,6 +537,12 @@ def main() -> None:
     parser.add_argument("--max-tokens", type=int, default=128, help="Max tokens per request")
     parser.add_argument("--temperature", type=float, default=0, help="Sampling temperature")
     parser.add_argument(
+        "--warmup-requests",
+        type=int,
+        default=4,
+        help="Discard this many requests before starting measurement (default: 4)",
+    )
+    parser.add_argument(
         "--prompt-len",
         type=int,
         default=None,
@@ -424,6 +556,10 @@ def main() -> None:
         help="If set, write structured results to this JSON file path",
     )
     args = parser.parse_args()
+    if args.concurrency is not None and args.concurrency <= 0:
+        parser.error("--concurrency must be greater than zero")
+    if args.warmup_requests < 0:
+        parser.error("--warmup-requests must be zero or greater")
     asyncio.run(run_benchmark(args))
 
 

--- a/tests/test_llama_3_8b_benchmark.py
+++ b/tests/test_llama_3_8b_benchmark.py
@@ -1,0 +1,149 @@
+import argparse
+import asyncio
+import importlib.util
+import random
+import sys
+from pathlib import Path
+
+BENCHMARK_PATH = Path("examples/model-serving/Llama-3-8B/benchmark/benchmark.py")
+SPEC = importlib.util.spec_from_file_location("llama_3_8b_benchmark", BENCHMARK_PATH)
+assert SPEC is not None and SPEC.loader is not None
+BENCHMARK = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = BENCHMARK
+SPEC.loader.exec_module(BENCHMARK)
+
+
+def test_closed_loop_connection_limit_matches_requested_concurrency():
+    limits = BENCHMARK.http_limits_for(256)
+
+    assert limits.max_connections == 256
+    assert limits.max_keepalive_connections == 256
+
+
+def test_open_loop_connection_limit_does_not_cap_active_requests():
+    limits = BENCHMARK.http_limits_for(None)
+
+    assert limits.max_connections is None
+    assert limits.max_keepalive_connections == 100
+
+
+def test_concurrency_stats_track_driver_and_response_streams_separately():
+    stats = BENCHMARK.ConcurrencyStats()
+
+    stats.request_started()
+    stats.request_started()
+    stats.stream_opened()
+    stats.stream_closed()
+    stats.request_finished()
+    stats.request_finished()
+
+    assert stats.max_in_flight_requests == 2
+    assert stats.max_active_streams == 1
+    assert stats.in_flight_requests == 0
+    assert stats.active_streams == 0
+
+
+def test_warmup_is_bounded_and_returns_discardable_results(monkeypatch):
+    active = 0
+    max_active = 0
+
+    async def fake_send_request(
+        client,
+        url,
+        model,
+        prompt,
+        max_tokens,
+        temperature,
+        concurrency_stats=None,
+    ):
+        nonlocal active, max_active
+        assert concurrency_stats is None
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0)
+        active -= 1
+        return {"error": None}
+
+    monkeypatch.setattr(BENCHMARK, "send_request", fake_send_request)
+    args = argparse.Namespace(
+        warmup_requests=7,
+        concurrency=3,
+        model="model",
+        max_tokens=128,
+        temperature=0,
+    )
+
+    results = asyncio.run(
+        BENCHMARK.run_warmup(
+            object(),
+            "http://127.0.0.1:8000/v1/completions",
+            ["prompt"],
+            args,
+            random.Random(42),
+        )
+    )
+
+    assert len(results) == 7
+    assert max_active == 3
+
+
+def test_benchmark_reports_requested_and_observed_concurrency(monkeypatch):
+    class FakeAsyncClient:
+        def __init__(self, *, limits):
+            self.limits = limits
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+    async def fake_send_request(
+        client,
+        url,
+        model,
+        prompt,
+        max_tokens,
+        temperature,
+        concurrency_stats=None,
+    ):
+        concurrency_stats.request_started()
+        concurrency_stats.stream_opened()
+        await asyncio.sleep(0)
+        concurrency_stats.stream_closed()
+        concurrency_stats.request_finished()
+        return {
+            "error": None,
+            "output_tokens": 2,
+            "finish_reason": "length",
+            "total_latency": 0.01,
+            "ttft": 0.001,
+            "tpot": 0.009,
+        }
+
+    monkeypatch.setattr(BENCHMARK.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(BENCHMARK, "send_request", fake_send_request)
+    args = argparse.Namespace(
+        url="http://127.0.0.1:8000",
+        endpoint="/v1/completions",
+        model="model",
+        rate=1.0,
+        concurrency=2,
+        duration=20.0,
+        num_requests=2,
+        max_tokens=128,
+        temperature=0,
+        warmup_requests=0,
+        prompt_len=None,
+        seed=42,
+        output_json=None,
+    )
+
+    result = asyncio.run(BENCHMARK.run_benchmark(args))
+
+    assert result["load_concurrency"] == {
+        "requested_workers": 2,
+        "client_max_connections": 2,
+        "max_in_flight_requests": 2,
+        "max_active_streams": 2,
+    }


### PR DESCRIPTION
## Problem

The Llama-3-8B serving example needs to identify the highest sustainable
throughput rather than score an arbitrary fixed load. The original
fixed-concurrency protocol could underutilize high-throughput servers, and
measurements through external ingress mixed network variability into latency.

The first overload-sweep implementation also left reproducibility gaps: HTTPX's
default 100-connection limit could cap sweeps above concurrency 100 even when
more workers were requested, first-request initialization was measured,
overload terms were subjective, and the example did not distinguish quick
directional checks from canonical peak measurements.

## Solution

Use a same-host closed-loop concurrency sweep whose HTTP connection limit
matches the requested worker count. Send four fixed-shape warm-up requests
before each measured point, abort before measurement if warm-up fails, and
report requested workers, connection capacity, maximum in-flight requests, and
maximum active response streams.

Define suspected overload numerically: any request error, throughput below 95%
of the best earlier point, or throughput no higher than 103% of that best point
while p99 TTFT or p99 end-to-end latency exceeds 2x the last sustainable point.
Repeat the suspected boundary and neighbors before classification.

Document a short neighbor-based hypothesis check separately from the canonical
doubling/refinement sweep, along with drain and startup time expectations. Keep
all instructions independent of serving implementation and infrastructure
provider.

### Architecture

The objective owns canonical scoring semantics and overload thresholds. The
benchmark README owns operator workflows for canonical and quick checks. The
benchmark client owns load generation, warm-up, transport capacity,
measurement, and structured concurrency telemetry. Accuracy checking remains a
separate HTTP client and continues to send the required model selector.

## Verification

Focused tests cover connection limits at concurrency 256, uncapped open-loop
connections, separate request/stream counters, bounded discarded warm-up, and
structured requested-versus-observed concurrency output.

The earlier live c96 result was produced before the client connection-limit
correction and is no longer claimed as a canonical server peak. A new canonical
hardware sweep must use this corrected client.

### Correctness properties

- Closed-loop client capacity equals requested concurrency, including points
  above 100.
- Warm-up uses the measured request shape, is excluded from metrics, and
  prevents measurement after a warm-up failure.
- Requested workers, connection capacity, maximum in-flight requests, and
  maximum active streams are reported separately.
- Canonical throughput and latency still come from the same concurrency and
  repetition.
- Quick checks cannot establish or update a canonical peak.
- Existing OpenAI-compatible endpoints and objective metric names remain
  unchanged.
- Documentation contains no infrastructure-provider-specific instructions.

### Testing

- `uv run ruff format --check examples/model-serving/Llama-3-8B/benchmark/benchmark.py tests/test_llama_3_8b_benchmark.py` — passed.
- `uv run ruff check examples/model-serving/Llama-3-8B/benchmark/benchmark.py tests/test_llama_3_8b_benchmark.py` — passed.
- `uv run python -m py_compile examples/model-serving/Llama-3-8B/benchmark/benchmark.py tests/test_llama_3_8b_benchmark.py` — passed.
- `uv run pytest -q tests/test_llama_3_8b_benchmark.py` — 5 passed.
- `uv run python examples/model-serving/Llama-3-8B/benchmark/benchmark.py --help` — passed.
- `git diff --check` — passed.
- Provider-name scan across changed objective, benchmark, documentation, and
  tests — clean.
- Prompt snapshots are not applicable; this changes benchmark protocol
  documentation and the standalone HTTP benchmark client.
