### PR TITLE
Enforce accuracy gates in evolutionary search

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -26,6 +26,7 @@ from vibesys.domains.rendering import render_domain_section
 from vibesys.input_manifest import BenchmarkResult, WorkspaceSource
 from vibesys.loops.agent import issue_board
 from vibesys.loops.evolve.population import Objective
+from vibesys.loops.gates import run_accuracy_gate
 from vibesys.loops.profiler import mcp_spec as profiler_mcp_spec
 from vibesys.profilers import (
     ProfilerKind,
@@ -1998,74 +1999,35 @@ def _run_framework_accuracy_gate(
     release_deployment_after: bool = False,
 ) -> str | None:
     """Run the immutable manifest accuracy command after an agent reports PASS."""
-    changed = ctx.trusted_input_changes()
     command = ctx.judge_accuracy_command
-    if changed:
-        feedback = "Evaluator-owned files were modified: " + ", ".join(changed)
-        issue_board.append_framework_accuracy_gate(
-            progress_path,
-            round_number,
-            retry,
-            command=command or "(not configured)",
-            passed=False,
-            output=feedback,
+    execution_command = None
+    if command:
+        execution_command = _with_candidate_revision(
+            command,
+            candidate_revision,
+            release_deployment_env_var=(
+                _deployment_release_env_var(ctx) if release_deployment_after else None
+            ),
         )
-        ctx.snapshot_workspace(f"round-{round_number}-retry-{retry}-framework-accuracy")
-        ctx.lprint(f"[framework-accuracy] FAIL: {feedback}")
-        return feedback
-    if not command:
-        return None
-
-    ctx.lprint(f"[framework-accuracy] running: {command}")
-    execution_command = _with_candidate_revision(
-        command,
-        candidate_revision,
-        release_deployment_env_var=(
-            _deployment_release_env_var(ctx) if release_deployment_after else None
-        ),
+    result = run_accuracy_gate(
+        ctx,
+        process_id=f"accuracy-{round_number}-{retry}",
+        timeout_seconds=_framework_command_timeout(ctx, timeout_seconds),
+        execution_command=execution_command,
     )
-    try:
-        effective_timeout = _framework_command_timeout(ctx, timeout_seconds)
-        if effective_timeout is None:
-            result = ctx.judge_backend.execute(execution_command)
-        else:
-            result = ctx.judge_backend.execute(execution_command, timeout=effective_timeout)
-        output = result.output.strip()
-        passed = result.exit_code == 0
-        _publish_subprocess_output(
-            ctx,
-            process_id=f"accuracy-{round_number}-{retry}",
-            process_kind="accuracy_checker",
-            content=result.output,
-        )
-    except Exception as exc:
-        output = f"accuracy command could not be executed: {exc}"
-        passed = False
-
-    changed_after_execution = ctx.trusted_input_changes()
-    if changed_after_execution:
-        mutation = "Evaluator-owned files changed during accuracy execution: " + ", ".join(
-            changed_after_execution
-        )
-        output = f"{output}\n{mutation}".strip()
-        passed = False
+    if result.passed and not result.executed:
+        return None
 
     issue_board.append_framework_accuracy_gate(
         progress_path,
         round_number,
         retry,
-        command=command,
-        passed=passed,
-        output=output[-8000:],
+        command=result.command or "(not configured)",
+        passed=result.passed,
+        output=result.output[-8000:],
     )
     ctx.snapshot_workspace(f"round-{round_number}-retry-{retry}-framework-accuracy")
-    if passed:
-        ctx.lprint("[framework-accuracy] PASS")
-        return None
-
-    feedback = f"Framework accuracy gate failed.\n{output[-4000:]}"
-    ctx.lprint(f"[framework-accuracy] FAIL: {output[-1000:]}")
-    return feedback
+    return result.feedback
 
 
 _FRAMEWORK_BENCHMARK_MARKER = "__VIBESYS_FRAMEWORK_BENCHMARK_JSON__"

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -10,17 +10,18 @@ every offspring:
   4. Run the *Mutator* agent (an LLM acting as the mutation operator) to
      edit code in place.
   5. Run the *Judge* on the result.
-  6. If pass, profile to obtain ``perf_metric``. Commit the workspace and
+  6. If the judge passes, run the framework-owned accuracy command.
+  7. If both pass, profile to obtain ``perf_metric``. Commit the workspace and
      record an Individual. Else: discard the dirty tree, record a failed
-     Individual carrying the judge feedback so future mutators can learn.
+     Individual carrying failure feedback so future mutators can learn.
 
 Before the generation loop, a dedicated *bootstrap* phase
-(``_bootstrap_seed``) runs implementer → judge iterations until the first
-judge-passing implementation exists, recorded as a generation-0 seed. So
-the generation loop always starts from a passing parent and never
-cold-starts. The bootstrap phase owns the from-scratch / fix-forward
-repair logic; on ``--resume`` it is skipped when a passing individual is
-already present.
+(``_bootstrap_seed``) runs implementer → judge → accuracy iterations until
+the first framework-verified implementation exists, recorded as a
+generation-0 seed. So the generation loop always starts from a passing
+parent and never cold-starts. The bootstrap phase owns the from-scratch /
+fix-forward repair logic; on ``--resume`` it is skipped when a passing
+individual is already present.
 
 The loop intentionally does NOT have an early-stop signal — generations
 run for the full ``max_generations`` budget. Termination decisions are
@@ -59,6 +60,7 @@ from vibesys.loops.evolve.search_policy import (
     SearchSelection,
     VibeSysSearchPolicy,
 )
+from vibesys.loops.gates import run_accuracy_gate
 from vibesys.loops.profiler import invoke_profiler
 from vibesys.profilers import ProfilerKind, profiler_definition
 from vibesys.run import LoopContext, RepositoryVisibility
@@ -439,6 +441,22 @@ class _CandidateOutcome:
     target_island: int | None = None
 
 
+def _run_framework_accuracy_gate(
+    ctx: LoopContext,
+    *,
+    generation: int,
+    child_idx: int,
+    timeout_seconds: int | None = None,
+) -> str | None:
+    """Run the immutable accuracy command and return retry feedback on failure."""
+    result = run_accuracy_gate(
+        ctx,
+        process_id=f"evolve-accuracy-{generation}-{child_idx}",
+        timeout_seconds=timeout_seconds,
+    )
+    return result.feedback
+
+
 def _evaluate_candidate(
     ctx: LoopContext,
     *,
@@ -455,8 +473,9 @@ def _evaluate_candidate(
     policy_parent_id: str | None = None,
     target_island: int | None = None,
     isolated_deployment: bool = False,
+    accuracy_timeout_seconds: int | None = None,
 ) -> _CandidateOutcome:
-    """Mutate → judge → (profile → commit) one candidate on ``ctx``.
+    """Mutate → judge → accuracy gate → (profile → commit) one candidate on ``ctx``.
 
     Assumes ``ctx``'s workspace is already materialized at the parent commit
     (serial: the caller checked the shared tree out; parallel: the candidate's
@@ -524,7 +543,25 @@ def _evaluate_candidate(
                 target_island=target_island,
             )
 
-        # 3. Profile the offspring to get its fitness.
+        # 3. Framework-owned accuracy gate. The LLM judge cannot waive this.
+        accuracy_feedback = _run_framework_accuracy_gate(
+            ctx,
+            generation=generation,
+            child_idx=child_idx,
+            timeout_seconds=accuracy_timeout_seconds,
+        )
+        if accuracy_feedback is not None:
+            return _CandidateOutcome(
+                passed=False,
+                parent_id=parent.id,
+                inspiration_ids=inspiration_ids,
+                summary=mutator.summary,
+                feedback=accuracy_feedback,
+                policy_parent_id=policy_parent_id,
+                target_island=target_island,
+            )
+
+        # 4. Profile the offspring to get its fitness.
         ctx.reselect_gpu()
         summary = _run_profiler(
             ctx,
@@ -537,7 +574,7 @@ def _evaluate_candidate(
             runtime_notes=cand_notes,
         )
 
-        # 4. Commit the offspring's tree so it can serve as a future parent.
+        # 5. Commit the offspring's tree so it can serve as a future parent.
         ctx.snapshot_workspace(f"gen-{generation}-child-{child_idx}")
         return _CandidateOutcome(
             passed=True,
@@ -674,6 +711,7 @@ def _run_generation_serial(
     pass_criteria: str,
     keep_deployments: bool,
     search_policy: SearchPolicy,
+    accuracy_timeout_seconds: int | None = None,
 ) -> None:
     """Evaluate a generation's candidates one at a time on the shared context."""
     for child_idx in range(1, children_per_generation + 1):
@@ -718,6 +756,7 @@ def _run_generation_serial(
                 keep_deployments=keep_deployments,
                 policy_parent_id=plan.policy_parent_id,
                 target_island=plan.target_island,
+                accuracy_timeout_seconds=accuracy_timeout_seconds,
             )
             _record_outcome(
                 ctx,
@@ -753,6 +792,7 @@ def _evaluate_in_subcontext(
     policy_parent_id: str | None,
     target_island: int | None,
     worktree_lock: threading.Lock,
+    accuracy_timeout_seconds: int | None = None,
 ) -> _CandidateOutcome:
     """Run one candidate in its own isolated sub-context (worker thread).
 
@@ -810,6 +850,7 @@ def _evaluate_in_subcontext(
             policy_parent_id=policy_parent_id,
             target_island=target_island,
             isolated_deployment=True,
+            accuracy_timeout_seconds=accuracy_timeout_seconds,
         )
     except Exception as exc:
         parent_ctx.lprint(f"[warn] candidate {label} evaluation raised: {exc}")
@@ -850,6 +891,7 @@ def _run_generation_parallel(
     pass_criteria: str,
     keep_deployments: bool,
     search_policy: SearchPolicy,
+    accuracy_timeout_seconds: int | None = None,
 ) -> None:
     """Evaluate a generation's candidates concurrently in isolated sub-contexts.
 
@@ -915,6 +957,7 @@ def _run_generation_parallel(
                 policy_parent_id=plan.policy_parent_id,
                 target_island=plan.target_island,
                 worktree_lock=worktree_lock,
+                accuracy_timeout_seconds=accuracy_timeout_seconds,
             ): child_idx
             for (child_idx, plan) in plans
         }
@@ -953,8 +996,9 @@ def _bootstrap_seed(
     population_path: Path,
     search_policy: SearchPolicy,
     keep_deployments: bool = False,
+    accuracy_timeout_seconds: int | None = None,
 ) -> Individual | None:
-    """Iterate implementer → judge until a first *passing* seed exists.
+    """Iterate implementer → judge → accuracy until a first passing seed exists.
 
     Runs BEFORE the generation loop so the search never cold-starts. Attempt 1
     writes a server from scratch; later attempts repair-forward the most-recent
@@ -1034,7 +1078,17 @@ def _bootstrap_seed(
                 runtime_notes=cand_notes,
             )
 
-            if verdict.verdict != Verdict.PASS:
+            if verdict.verdict == Verdict.PASS:
+                failure_feedback = _run_framework_accuracy_gate(
+                    ctx,
+                    generation=0,
+                    child_idx=attempt,
+                    timeout_seconds=accuracy_timeout_seconds,
+                )
+            else:
+                failure_feedback = verdict.feedback
+
+            if failure_feedback is not None:
                 # Snapshot the failed tree so the next attempt repairs it in place.
                 # Only tag a WIP repair-seed when the snapshot actually committed new
                 # work (the tree changed); an unedited tree is nothing to fix-forward.
@@ -1057,17 +1111,17 @@ def _bootstrap_seed(
                     perf_unit=None,
                     passed=False,
                     summary=mutator.summary,
-                    feedback=verdict.feedback,
+                    feedback=failure_feedback,
                 )
                 population.add(failed)
                 population.save(population_path)
                 ctx.lprint(
                     f"[bootstrap {attempt}] FAILED — feedback: "
-                    f"{(verdict.feedback or '').splitlines()[0][:120] if verdict.feedback else ''}"
+                    f"{failure_feedback.splitlines()[0][:120] if failure_feedback else ''}"
                 )
                 continue
 
-            # 3. PASS → profile, snapshot, and record the generation-0 seed.
+            # 4. Both gates passed → profile and record the generation-0 seed.
             ctx.reselect_gpu()
             summary = _run_profiler(
                 ctx,
@@ -1178,6 +1232,7 @@ def run_evolve_loop(
     workspace_seed: Path | None = None,
     workspace_sources: tuple[WorkspaceSource, ...] = (),
     evaluator_path: Path | None = None,
+    accuracy_timeout_seconds: int | None = None,
     max_generations: int = 8,
     children_per_generation: int = 2,
     k_top_inspirations: int = 2,
@@ -1301,6 +1356,7 @@ def run_evolve_loop(
                 population_path=population_path,
                 search_policy=policy,
                 keep_deployments=keep_deployments,
+                accuracy_timeout_seconds=accuracy_timeout_seconds,
             )
             if seed_individual is None:
                 ctx.lprint(
@@ -1354,6 +1410,7 @@ def run_evolve_loop(
                     pass_criteria=pass_criteria,
                     keep_deployments=keep_deployments,
                     search_policy=policy,
+                    accuracy_timeout_seconds=accuracy_timeout_seconds,
                 )
             else:
                 _run_generation_serial(
@@ -1375,6 +1432,7 @@ def run_evolve_loop(
                     pass_criteria=pass_criteria,
                     keep_deployments=keep_deployments,
                     search_policy=policy,
+                    accuracy_timeout_seconds=accuracy_timeout_seconds,
                 )
 
             policy.finish_generation(generation)

--- a/src/vibesys/loops/gates.py
+++ b/src/vibesys/loops/gates.py
@@ -1,0 +1,105 @@
+"""Framework-owned correctness gates shared by optimization loops."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vibesys.run import LoopContext
+from vibesys.server.events import EventType, SubprocessOutputData
+
+
+@dataclass(frozen=True)
+class AccuracyGateResult:
+    """Outcome of running the immutable accuracy command for a candidate."""
+
+    command: str | None
+    passed: bool
+    output: str
+    feedback: str | None
+    executed: bool
+
+
+def run_accuracy_gate(
+    ctx: LoopContext,
+    *,
+    process_id: str,
+    timeout_seconds: int | None = None,
+    execution_command: str | None = None,
+) -> AccuracyGateResult:
+    """Run the trusted accuracy command without delegating acceptance to an agent."""
+    changed = ctx.trusted_input_changes()
+    command = ctx.judge_accuracy_command
+    if changed:
+        output = "Evaluator-owned files were modified: " + ", ".join(changed)
+        ctx.lprint(f"[framework-accuracy] FAIL: {output}")
+        return AccuracyGateResult(
+            command=command,
+            passed=False,
+            output=output,
+            feedback=output,
+            executed=False,
+        )
+    if not command:
+        return AccuracyGateResult(
+            command=None,
+            passed=True,
+            output="",
+            feedback=None,
+            executed=False,
+        )
+
+    ctx.lprint(f"[framework-accuracy] running: {command}")
+    command_to_execute = execution_command or command
+    try:
+        if timeout_seconds is None:
+            result = ctx.judge_backend.execute(command_to_execute)
+        else:
+            result = ctx.judge_backend.execute(command_to_execute, timeout=timeout_seconds)
+        output = result.output.strip()
+        passed = result.exit_code == 0
+        _publish_subprocess_output(ctx, process_id=process_id, content=result.output)
+    except Exception as exc:
+        output = f"accuracy command could not be executed: {exc}"
+        passed = False
+
+    changed_after_execution = ctx.trusted_input_changes()
+    if changed_after_execution:
+        mutation = "Evaluator-owned files changed during accuracy execution: " + ", ".join(
+            changed_after_execution
+        )
+        output = f"{output}\n{mutation}".strip()
+        passed = False
+
+    if passed:
+        ctx.lprint("[framework-accuracy] PASS")
+        feedback = None
+    else:
+        ctx.lprint(f"[framework-accuracy] FAIL: {output[-1000:]}")
+        feedback = f"Framework accuracy gate failed.\n{output[-4000:]}"
+
+    return AccuracyGateResult(
+        command=command,
+        passed=passed,
+        output=output,
+        feedback=feedback,
+        executed=True,
+    )
+
+
+def _publish_subprocess_output(
+    ctx: LoopContext,
+    *,
+    process_id: str,
+    content: str,
+) -> None:
+    if ctx.supervisor is None or not content:
+        return
+    ctx.supervisor.record(
+        EventType.SUBPROCESS_OUTPUT,
+        data=SubprocessOutputData(
+            process_id=process_id,
+            process_kind="accuracy_checker",
+            stream="stdout",
+            content=content,
+        ),
+    )

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -1320,6 +1320,7 @@ def _run_evolve(args: argparse.Namespace) -> None:
         workspace_seed=bundle.workspace_seed_path,
         workspace_sources=bundle.workspace_sources,
         evaluator_path=bundle.evaluator_path,
+        accuracy_timeout_seconds=bundle.manifest.accuracy.timeout_seconds,
         objective=objective,
         max_generations=args.max_generations,
         children_per_generation=args.children_per_generation,

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -155,6 +155,11 @@ def _make_runner(
 
 def _invoke_loop(tmp_path, ref_file, runner, **kwargs):
     """Shared plumbing — patch context globals, run the loop, return result."""
+    accuracy_gate_feedbacks = kwargs.pop("_accuracy_gate_feedbacks", None)
+    accuracy_gate = MagicMock(return_value=None)
+    if accuracy_gate_feedbacks is not None:
+        accuracy_gate.side_effect = list(accuracy_gate_feedbacks)
+    runner.accuracy_gate = accuracy_gate
     defaults = dict(
         config={"model": {"name": "claude-sonnet-4-6"}},
         exp_name="test-evolve",
@@ -173,6 +178,10 @@ def _invoke_loop(tmp_path, ref_file, runner, **kwargs):
         patch("vibesys.backends.cuda.LocalShellBackend"),
         patch("vibesys.context.build_agent_runner", return_value=runner),
         patch("vibesys.context.PROJECT_ROOT", tmp_path),
+        patch(
+            "vibesys.loops.evolve.loop._run_framework_accuracy_gate",
+            accuracy_gate,
+        ),
     ):
         return run_evolve_loop(**defaults)
 
@@ -322,6 +331,40 @@ def test_bootstrap_succeeds_after_repair(tmp_path, ref_file):
     assert seed.commit and seed.commit != failed.commit
 
 
+def test_bootstrap_repairs_after_framework_accuracy_failure(tmp_path, ref_file):
+    """An LLM-approved seed still fails when the trusted oracle rejects it.
+
+    The failed seed is never profiled, its oracle feedback is retained for the
+    repair attempt, and the configured timeout reaches the framework gate.
+    """
+    failure = "Framework accuracy gate failed.\nstatus endpoint diverged"
+    runner = _make_runner(mutator_writes=True)
+    result = _invoke_loop(
+        tmp_path,
+        ref_file,
+        runner,
+        _accuracy_gate_feedbacks=[failure, None],
+        accuracy_timeout_seconds=37,
+        bootstrap_max_attempts=2,
+        max_generations=0,
+    )
+
+    assert result is True
+    assert runner.counters["judge"] == 2
+    assert runner.counters["profiler"] == 1
+    assert runner.accuracy_gate.call_count == 2
+    assert [call.kwargs["timeout_seconds"] for call in runner.accuracy_gate.call_args_list] == [
+        37,
+        37,
+    ]
+
+    failed, seed = _load_population(tmp_path).all
+    assert failed.passed is False
+    assert failed.feedback == failure
+    assert failed.commit
+    assert seed.passed is True
+
+
 def test_bootstrap_prompt_uses_cold_start_section(tmp_path, ref_file):
     """The bootstrap attempt sees the cold-start branch of the mutator prompt
     (no parent block)."""
@@ -427,6 +470,33 @@ def test_failed_child_excluded_from_future_parent_pool(tmp_path, ref_file):
     # The gen-2 child must descend from the seed, NOT from the failed g1
     # (which has no commit and can't be selected).
     assert g2.parent_id == seed.id
+
+
+def test_accuracy_rejected_child_is_not_profiled_or_selected(tmp_path, ref_file):
+    """The framework oracle can overrule an LLM PASS for an offspring."""
+    failure = "Framework accuracy gate failed.\nbooking response diverged"
+    runner = _make_runner()
+    result = _invoke_loop(
+        tmp_path,
+        ref_file,
+        runner,
+        _accuracy_gate_feedbacks=[None, failure, None],
+        max_generations=2,
+        children_per_generation=1,
+    )
+
+    assert result is True
+    assert runner.counters["judge"] == 3
+    assert runner.counters["profiler"] == 2
+    assert runner.accuracy_gate.call_count == 3
+
+    seed, rejected, accepted = _load_population(tmp_path).all
+    assert rejected.passed is False
+    assert rejected.commit is None
+    assert rejected.perf_metric is None
+    assert rejected.feedback == failure
+    assert accepted.passed is True
+    assert accepted.parent_id == seed.id
 
 
 # ---------------------------------------------------------------------------
@@ -1071,6 +1141,7 @@ def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file
         patch("vibesys.backends.cuda.LocalShellBackend"),
         patch("vibesys.context.build_agent_runner", return_value=runner),
         patch("vibesys.context.PROJECT_ROOT", tmp_path),
+        patch("vibesys.loops.evolve.loop._run_framework_accuracy_gate", return_value=None),
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},
             exp_name="test-parallel-subctx",


### PR DESCRIPTION
## Problem

Stacked on #261.

PR #261 adds a differential correctness oracle for Hotel Reservation, but the evolutionary outer loop still trusts the LLM judge to run and interpret the manifest accuracy command. An LLM-reported `PASS` currently advances directly to profiling, so a candidate can receive fitness, be committed, and become a future parent without framework-owned correctness verification.

The evolutionary loop needs the same immutable accuracy boundary already enforced by the agent loop so optimization feedback cannot reward oracle-rejected candidates.

## Solution

Extract the existing trusted accuracy-command execution into a shared loop utility and invoke it after an LLM judge `PASS` in both evolutionary bootstrap and offspring evaluation.

The evolve loop now:

- runs the manifest accuracy command before profiling;
- honors `[accuracy].timeout_seconds`;
- rejects evaluator-owned file changes before or during verification;
- records oracle output as failed-individual feedback for repair-forward attempts;
- skips profiling and candidate commits when the oracle fails; and
- applies the same behavior to serial and isolated parallel candidates.

The agent loop keeps its existing issue-board and snapshot behavior while delegating command execution to the shared utility.

### Architecture

```mermaid
flowchart LR
    M[Mutator edits candidate] --> J[LLM judge]
    J -->|FAIL| F[Record failed individual]
    J -->|PASS| A[Framework accuracy gate]
    A -->|FAIL| F
    A -->|PASS| P[Profiler assigns fitness]
    P --> C[Commit passing candidate]
    C --> S[Eligible future parent]
```

`vibesys.loops.gates` owns trusted accuracy execution and its typed result. Each outer loop owns how that result is persisted: the agent loop writes its issue-board entry, while evolve stores failure feedback in the population and uses bootstrap repair-forward semantics.

## Verification

Focused agent and evolutionary loop tests pass, including bootstrap repair after oracle failure, timeout forwarding, prevention of profiling, feedback persistence, and exclusion from future parent selection. Workspace-source CLI tests also pass after adding the evolve timeout wiring.

The exact coverage-enabled CI suite was attempted locally, but this sandbox stalls in the unrelated existing `TestOsTools::test_dispatcher_executes_a_real_read` test at roughly 10%; that test also stalls when run alone under a 30-second limit. GitHub Actions remains the authoritative full-suite run.

### Correctness properties

- An LLM judge `PASS` is necessary but insufficient for evolutionary acceptance.
- A configured accuracy command must exit successfully before profiling or committing a candidate.
- Accuracy-command exceptions, nonzero exits, and configured timeouts reject the candidate.
- Modifying evaluator-owned files before or during accuracy execution rejects the candidate.
- Rejected candidates have no performance metric or passing commit and cannot enter the parent pool.
- Bootstrap oracle failures are retained as repair feedback and never receive fitness.
- Empty accuracy commands retain the existing no-op behavior when trusted inputs are unchanged.
- Existing agent-loop gate behavior and subprocess telemetry remain preserved.

### Testing

- `.venv/bin/pytest -q tests/loops/agent/test_orchestrate.py tests/loops/evolve/test_evolutionary_loop.py` - 77 passed.
- `.venv/bin/pytest -q tests/test_workspace_seed.py` - 32 passed.
- `.venv/bin/ruff check src tests libs` - passed.
- `.venv/bin/ruff check --select I src tests libs` - passed.
- `.venv/bin/ruff check <changed paths>` - passed.
- `.venv/bin/ruff format --check <changed paths>` - 5 files already formatted.
- Coverage-enabled full pytest command - attempted; interrupted after an unrelated existing OS-tools test stalled in this sandbox.
