### PR TITLE
Run TUI Vitest workers without spawning Bun processes

### DIFF
--- a/clients/tui/vitest.config.ts
+++ b/clients/tui/vitest.config.ts
@@ -1,5 +1,9 @@
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
-  test: {environment: 'node'},
+  test: {
+    environment: 'node',
+    // Avoid forking Bun workers; spawned Bun processes fail with EACCES in CI.
+    pool: 'threads',
+  },
 });


### PR DESCRIPTION
## Problem

PR #265's TUI check fails on GitHub Actions while running `pnpm --dir clients/tui test`. The package intentionally runs Vitest under Bun for OpenTUI's native FFI tests, but Vitest's default `forks` pool asks Tinypool to spawn another Bun process. GitHub Actions rejects that child spawn with `EACCES`, so the TUI suite cannot complete.

This is tracked in #267 and reproduced in the failed job: https://github.com/uw-syfi/vibesys/actions/runs/31008590751/job/92314623453

## Solution

Configure Vitest to use its `threads` pool for the TUI suite. This keeps the tests running under Bun while using `worker_threads` instead of spawning another Bun executable through `child_process`. No production TUI or Python behavior changes.

### Architecture

```mermaid
flowchart LR
  CI[GitHub Actions] --> Script[pnpm --dir clients/tui test]
  Script --> Bun[Bun runtime]
  Bun --> Vitest[Vitest]
  Vitest --> Threads[worker_threads pool]
  Threads --> Tests[TUI tests and OpenTUI FFI]
```

## Verification

### Correctness properties

- TUI tests continue to execute under Bun, preserving OpenTUI's native FFI requirement.
- Vitest no longer relies on a spawned Bun executable for test workers.
- Production TypeScript and Python code are unchanged.
- The existing test command and Vitest configuration entry point remain unchanged.

### Testing

- `pnpm --dir clients/tui check` — passed.
- `pnpm --dir clients/tui build` — passed.
- `pnpm check:ts` — passed.
- Bun/Vitest with the configured thread pool, excluding the OpenTUI native-renderer tests unavailable in this host — 70 tests passed.
- Full local Bun/Vitest run — no Bun `EACCES`; 19 OpenTUI renderer tests remain unavailable because this host's Bun/OpenTUI native FFI cannot initialize.
- GitHub Actions should run the complete TUI suite on the target runner.

Fixes #267