### PR TITLE
Speed up Vertex and queue evaluator tests

### DIFF
--- a/src/vibesys/llm_client.py
+++ b/src/vibesys/llm_client.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any
 
 from pydantic import SecretStr
 
@@ -126,8 +127,6 @@ def _build_vertex_model(model_name: str, config: Config, thinking: ThinkingCfg):
         raise ValueError("Thinking is not supported for non-Gemini models on Vertex AI")
 
     if _is_google_model(model_name):
-        from langchain_google_genai import ChatGoogleGenerativeAI
-
         thinking_kwargs = {}
         thinking_level = thinking.level
         thinking_budget = thinking.budget
@@ -138,7 +137,7 @@ def _build_vertex_model(model_name: str, config: Config, thinking: ThinkingCfg):
             thinking_kwargs["thinking_budget"] = thinking_budget
             thinking_kwargs["include_thoughts"] = True
 
-        return ChatGoogleGenerativeAI(
+        return _vertex_gemini_model_class()(
             model=model_name,
             credentials=credentials,
             project=project,
@@ -146,11 +145,23 @@ def _build_vertex_model(model_name: str, config: Config, thinking: ThinkingCfg):
             **thinking_kwargs,
         )
     else:
-        from langchain_google_vertexai.model_garden import ChatAnthropicVertex
-
-        return ChatAnthropicVertex(
+        return _vertex_anthropic_model_class()(
             model_name=model_name,
             credentials=credentials,
             project=project,
             location=vertex_region,
         )
+
+
+def _vertex_anthropic_model_class() -> Any:
+    """Load the optional Vertex Anthropic class only when it is needed."""
+    from langchain_google_vertexai.model_garden import ChatAnthropicVertex
+
+    return ChatAnthropicVertex
+
+
+def _vertex_gemini_model_class() -> Any:
+    """Load the optional Vertex Gemini class only when it is needed."""
+    from langchain_google_genai import ChatGoogleGenerativeAI
+
+    return ChatGoogleGenerativeAI

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -104,16 +104,25 @@ class TestUnknownProvider:
 
 class TestVertexAIProvider:
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
-    @patch("langchain_google_vertexai.model_garden.ChatAnthropicVertex")
-    def test_vertex_claude_model(self, mock_chat_cls, mock_from_sa, key_file):
+    @patch("vibesys.llm_client._vertex_anthropic_model_class")
+    def test_vertex_claude_model(self, mock_model_class, mock_from_sa, key_file):
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
+        constructed_model = object()
+        mock_chat_cls = MagicMock(return_value=constructed_model)
+        mock_model_class.return_value = mock_chat_cls
         config = _make_config(
             "claude-sonnet-4-6",
             provider="vertex-ai",
             providers={"vertex-ai": {"json": str(key_file), "project": None, "region": "us-east5"}},
         )
-        build_model(config)
+        result = build_model(config)
+        assert result is constructed_model
+        mock_model_class.assert_called_once_with()
+        mock_from_sa.assert_called_once_with(
+            FAKE_CREDS_DICT,
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
         mock_chat_cls.assert_called_once_with(
             model_name="claude-sonnet-4-6",
             credentials=mock_creds,
@@ -122,16 +131,20 @@ class TestVertexAIProvider:
         )
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
-    @patch("langchain_google_genai.ChatGoogleGenerativeAI")
-    def test_vertex_gemini_model(self, mock_chat_cls, mock_from_sa, key_file):
+    @patch("vibesys.llm_client._vertex_gemini_model_class")
+    def test_vertex_gemini_model(self, mock_model_class, mock_from_sa, key_file):
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
+        mock_chat_cls = MagicMock()
+        mock_model_class.return_value = mock_chat_cls
         config = _make_config(
             "gemini-2.5-pro",
             provider="vertex-ai",
             providers={"vertex-ai": {"json": str(key_file), "project": None, "region": "us-east5"}},
         )
-        build_model(config)
+        result = build_model(config)
+        assert result is mock_chat_cls.return_value
+        mock_model_class.assert_called_once_with()
         mock_chat_cls.assert_called_once_with(
             model="gemini-2.5-pro",
             credentials=mock_creds,
@@ -140,10 +153,12 @@ class TestVertexAIProvider:
         )
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
-    @patch("langchain_google_genai.ChatGoogleGenerativeAI")
-    def test_vertex_gemini_thinking_level(self, mock_chat_cls, mock_from_sa, key_file):
+    @patch("vibesys.llm_client._vertex_gemini_model_class")
+    def test_vertex_gemini_thinking_level(self, mock_model_class, mock_from_sa, key_file):
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
+        mock_chat_cls = MagicMock()
+        mock_model_class.return_value = mock_chat_cls
         config = _make_config(
             "gemini-2.5-pro",
             provider="vertex-ai",
@@ -161,10 +176,12 @@ class TestVertexAIProvider:
         )
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
-    @patch("langchain_google_genai.ChatGoogleGenerativeAI")
-    def test_vertex_gemini_thinking_budget(self, mock_chat_cls, mock_from_sa, key_file):
+    @patch("vibesys.llm_client._vertex_gemini_model_class")
+    def test_vertex_gemini_thinking_budget(self, mock_model_class, mock_from_sa, key_file):
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
+        mock_chat_cls = MagicMock()
+        mock_model_class.return_value = mock_chat_cls
         config = _make_config(
             "gemini-2.5-pro",
             provider="vertex-ai",
@@ -182,10 +199,12 @@ class TestVertexAIProvider:
         )
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
-    @patch("langchain_google_genai.ChatGoogleGenerativeAI")
-    def test_vertex_gemini_zero_thinking_budget(self, mock_chat_cls, mock_from_sa, key_file):
+    @patch("vibesys.llm_client._vertex_gemini_model_class")
+    def test_vertex_gemini_zero_thinking_budget(self, mock_model_class, mock_from_sa, key_file):
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
+        mock_chat_cls = MagicMock()
+        mock_model_class.return_value = mock_chat_cls
         config = _make_config(
             "gemini-2.5-pro",
             provider="vertex-ai",
@@ -213,10 +232,12 @@ class TestVertexAIProvider:
             build_model(config)
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
-    @patch("langchain_google_vertexai.model_garden.ChatAnthropicVertex")
-    def test_vertex_project_overrides_json(self, mock_chat_cls, mock_from_sa, key_file):
+    @patch("vibesys.llm_client._vertex_anthropic_model_class")
+    def test_vertex_project_overrides_json(self, mock_model_class, mock_from_sa, key_file):
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
+        mock_chat_cls = MagicMock()
+        mock_model_class.return_value = mock_chat_cls
         config = _make_config(
             "claude-sonnet-4-6",
             provider="vertex-ai",
@@ -329,8 +350,7 @@ class TestThinkingNotSupported:
             build_model(config)
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
-    @patch("langchain_google_vertexai.model_garden.ChatAnthropicVertex")
-    def test_vertex_claude_with_thinking_raises(self, mock_chat_cls, mock_from_sa, key_file):
+    def test_vertex_claude_with_thinking_raises(self, mock_from_sa, key_file):
         mock_from_sa.return_value = MagicMock()
         config = _make_config(
             "claude-sonnet-4-6",

--- a/tests/test_queue_evaluator.py
+++ b/tests/test_queue_evaluator.py
@@ -5,6 +5,7 @@ import json
 import shutil
 import subprocess
 import tomllib
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,58 @@ LINEARIZABLE_ACCURACY_SETTINGS = {
     "queue-mpsc": ("24", "50"),
     "queue-mpmc": ("24", "100"),
 }
+
+
+@pytest.fixture(scope="session")
+def compiled_queue_candidate(tmp_path_factory) -> Path:
+    """Build the shared Rust starter once for materialized-input tests."""
+    if shutil.which("cargo") is None:
+        pytest.skip("Rust is required by the trusted queue evaluator")
+
+    project_root = Path(__file__).parents[1]
+    starter = project_root / "examples" / "starters" / "queue-rs"
+    build_dir = tmp_path_factory.mktemp("queue-rs-build") / "starter"
+    shutil.copytree(starter, build_dir)
+    subprocess.run(["make"], cwd=build_dir, check=True)
+
+    candidate = build_dir / "queue-candidate.so"
+    assert candidate.is_file()
+    return candidate
+
+
+@pytest.fixture(scope="session")
+def queue_native_runner(tmp_path_factory) -> Iterator[Path]:
+    """Build the trusted evaluator runner once and reuse it across subprocesses."""
+    if shutil.which("cargo") is None:
+        pytest.skip("Rust is required by the trusted queue evaluator")
+
+    project_root = Path(__file__).parents[1]
+    source = project_root / "examples" / "evaluators" / "queue" / "native_runner"
+    target_dir = tmp_path_factory.mktemp("queue-native-runner") / "target"
+    subprocess.run(
+        [
+            "cargo",
+            "build",
+            "--quiet",
+            "--release",
+            "--locked",
+            "--manifest-path",
+            str(source / "Cargo.toml"),
+            "--target-dir",
+            str(target_dir),
+        ],
+        cwd=source,
+        check=True,
+    )
+    runner = target_dir / "release" / "vibesys-queue-native-runner"
+    assert runner.is_file()
+
+    environment = pytest.MonkeyPatch()
+    environment.setenv("VIBESYS_QUEUE_NATIVE_RUNNER", str(runner))
+    try:
+        yield runner
+    finally:
+        environment.undo()
 
 
 def _copy_input_bundle(source: Path, target: Path) -> None:
@@ -129,6 +182,7 @@ def test_linearizable_queue_inputs_use_shared_editable_rust_starter():
             assert not (input_dir / relative).exists()
 
 
+@pytest.mark.usefixtures("queue_native_runner")
 def test_spsc_rigtorp_baseline_builds_and_passes_accuracy(tmp_path):
     if shutil.which("go") is None or shutil.which("c++") is None:
         pytest.skip("Go and a C++ compiler are required by the SPSC baseline")
@@ -186,6 +240,7 @@ def test_spsc_rigtorp_baseline_uses_pinned_upstream_header():
     assert "rigtorp::SPSCQueue<QueueEntry> entries" in adapter
 
 
+@pytest.mark.usefixtures("queue_native_runner")
 def test_mpmc_locked_ring_baseline_builds_and_passes_accuracy(tmp_path):
     if shutil.which("go") is None or shutil.which("cc") is None:
         pytest.skip("Go and a C compiler are required by the MPMC baseline")
@@ -247,7 +302,13 @@ def test_mpmc_locked_ring_baseline_has_atomic_publication_region():
 
 
 @pytest.mark.parametrize(("input_name", "scenario"), LINEARIZABLE_QUEUE_INPUTS.items())
-def test_materialized_rust_starter_builds_and_passes_accuracy(tmp_path, input_name, scenario):
+@pytest.mark.usefixtures("queue_native_runner")
+def test_materialized_rust_starter_passes_accuracy(
+    tmp_path,
+    input_name,
+    scenario,
+    compiled_queue_candidate,
+):
     if shutil.which("go") is None or shutil.which("cargo") is None:
         pytest.skip("Go and Rust are required by the trusted queue evaluator")
 
@@ -255,16 +316,8 @@ def test_materialized_rust_starter_builds_and_passes_accuracy(tmp_path, input_na
     workspace = tmp_path / "workspace"
     _materialize_linearizable_input(project_root, input_name, workspace)
 
-    subprocess.run(["make"], cwd=workspace, check=True)
+    shutil.copy2(compiled_queue_candidate, workspace / "queue-candidate.so")
     assert (workspace / "queue-candidate.so").is_file()
-    rebuilt = subprocess.run(
-        ["make"],
-        cwd=workspace,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    assert "cargo build --release --locked" in rebuilt.stdout
 
     manifest = tomllib.loads((workspace / "vibesys.input.toml").read_text())
     accuracy = [
@@ -295,6 +348,7 @@ def test_materialized_rust_starter_builds_and_passes_accuracy(tmp_path, input_na
         assert f"PASS - {checked_scenario} {contract}" in completed.stdout
 
 
+@pytest.mark.usefixtures("queue_native_runner")
 def test_materialized_manifest_commands_run_go_evaluator_directly(tmp_path):
     if shutil.which("go") is None or shutil.which("cargo") is None:
         pytest.skip("Go and Rust are required by the trusted queue evaluator")
@@ -340,6 +394,7 @@ def test_materialized_manifest_commands_run_go_evaluator_directly(tmp_path):
     assert all(len(result["total_ops_per_sec_samples"]) == 3 for result in results)
 
 
+@pytest.mark.usefixtures("queue_native_runner")
 def test_queue_evaluator_rejects_adversarial_histories():
     if shutil.which("go") is None or shutil.which("cargo") is None:
         pytest.skip("Go and Rust are required by the trusted queue evaluator")


### PR DESCRIPTION
## Problem

The Python test suite spent about 216.8 seconds in pytest for 2,892 passing tests. The slowest path was a Vertex constructor unit test that imported the full Vertex SDK just to replace the class, while queue evaluator tests repeatedly rebuilt the same Rust candidate and trusted native runner. This made ordinary test feedback disproportionately slow without adding corresponding coverage.

## Solution

- Add lazy local model-class seams in `vibesys.llm_client` so Vertex tests mock VibeSys's boundary without importing heavyweight SDK packages.
- Strengthen the Vertex wiring assertions to cover credentials, scopes, returned model identity, and constructor arguments.
- Remove an unnecessary Vertex SDK patch from the early-failure thinking test.
- Build the shared Rust candidate and trusted queue native runner once per pytest session, then reuse them across queue evaluator tests. The manifest end-to-end test still performs a real starter build.

### Architecture

```mermaid
flowchart LR
    T[Vertex unit tests] --> S[Local lazy model seam]
    S --> M[Mock constructor]
    P[Queue tests] --> C[Session candidate build]
    P --> R[Session native runner build]
    C --> E[Go evaluator]
    R --> E
```

The production SDK imports remain lazy and unchanged at the runtime boundary; only the test injection point moved inward to the owning module.

## Verification

The full suite improved from 216.8s to 119.3s of pytest time while retaining the same test count and coverage threshold.

### Correctness properties

- Vertex provider selection still loads the appropriate Anthropic or Gemini model class only when that branch is used.
- Vertex credentials receive the cloud-platform scope.
- Vertex project fallback and explicit project override remain covered.
- Gemini thinking level/budget behavior remains covered.
- Queue tests still execute trusted accuracy and benchmark commands, with one real starter build and one reusable native runner.
- No production evaluator or model-provider contract is changed.

### Testing

- `uv run pytest -q --durations=50 --durations-min=0.05` — 2,892 passed, 1 skipped in 119.32s.
- `COVERAGE_FILE=/tmp/vibesys-coverage-final uv run pytest -q --cov=vibesys --cov=vs_github --cov=vs_issue_board --cov=vs_sandbox --cov-report= --cov-fail-under=75` — 2,892 passed, 1 skipped, 87.69% coverage in 141.95s.
- `uv run pytest -q tests/test_llm_client.py tests/test_queue_evaluator.py` — 44 passed.
- Ruff format check and lint — passed.
- `uv run pyright src/vibesys/llm_client.py` — passed.
