### PR TITLE
Default fresh experiments to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,56 +200,9 @@ Provider credentials live in `.env` — see `.env.example`. The CLI flags `--age
 
 The config is validated against a typed schema on load (`vibesys/config.py`): unknown sections or keys, unknown providers/backends, and missing required fields are rejected with an error rather than silently ignored.
 
-## Outputs
-
-Every run creates `exp_env/<timestamp>-<name>/`:
-
-```
-exp_env/<run>/
-├── workspace/                # unified, git-tracked candidate workspace
-│   ├── roadmap.md            # or roadmap/index.md
-│   └── progress.md           # or progress/round-NNNN.md
-├── logs/
-│   ├── run-*.log             # top-level run log
-│   ├── run-*-roundNNN.log    # per-round agent log (agent loop)
-│   ├── rounds.json           # per-round audit
-│   ├── active_hypothesis.json # resumable implementer handoff, while active
-│   ├── state.json            # cursor (plain loop)
-│   ├── issues.json           # IssueBoard (plain loop)
-│   ├── population.json       # Individual list (evolve loop)
-│   └── docker.log
-```
-
-Resume any run with `--resume` (defaults to "latest"):
-
-```bash
-./vs --resume                  # newest run
-./vs --resume 20260507-...     # specific dir
-./vs --resume /path/to/clone   # local experiment clone
-./vs --resume owner/repo       # clone a GitHub experiment, then resume it
-```
-
-Fresh runs use GitHub by default. The interactive setup form is populated with
-the input path, an automatically generated experiment name, the configured
-repository owner (or the account from `gh`), repository name, and visibility.
-Use Tab/Shift-Tab to move through the defaults and Enter to launch. Clear the
-owner field, or pass `--local`, to keep a run under `exp_env/` without creating
-or syncing a GitHub repository.
-
-```bash
-gh auth login
-./vs \
-  --input examples/data-structures/queue-spsc \
-  ...
-```
-
-For non-interactive use, the repository name is generated from the input bundle;
-`--repo queue-trial` overrides the name, and `--repo another-org/queue-trial`
-overrides the owner explicitly. Durable workspace and run state are committed
-and pushed after each workspace checkpoint and again when the run closes; raw
-`logs/*.log` files stay local. Checkpoint push failures are retried without
-stopping the run. Later runs automatically push again when resumed from a clone
-with an `origin`.
+Fresh runs use GitHub-backed tracking by default. Pass `--local` for a local-only
+run under `exp_env/`; see [`docs/cli-flags.md`](docs/cli-flags.md) for repository
+and resume options.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ accuracy and performance results.
 ## Installation
 
 1. Install Python 3.12+ and [uv](https://docs.astral.sh/uv/).
-2. Install the [GitHub CLI](https://cli.github.com/) and sign in with
-   `gh auth login` (skip this only if every run uses `--local`).
+2. For the default GitHub-synced runs, install the [GitHub CLI](https://cli.github.com/)
+   and sign in with `gh auth login`. You do not need `gh` when every run uses
+   `--local`.
 3. From the repository root, create the local configuration files:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ accuracy and performance results.
 ## Installation
 
 1. Install Python 3.12+ and [uv](https://docs.astral.sh/uv/).
-2. From the repository root, create the local configuration files:
+2. Install the [GitHub CLI](https://cli.github.com/) and sign in with
+   `gh auth login` (skip this only if every run uses `--local`).
+3. From the repository root, create the local configuration files:
 
 ```bash
 cp .env.example .env       # provider keys for API-backed/deepagents runs
@@ -182,7 +184,8 @@ model = "gpt-5.6-luna"        # implementer calls
 reasoning_effort = "xhigh"
 
 [repository]
-owner = "vibesys-playground"  # any GitHub user/org; enables pre-launch repository setup
+# Optional GitHub user/org override. If omitted, use the account from `gh auth status`.
+# owner = "your-github-user"
 visibility = "private"        # private, public, or internal
 
 # Optional: benchmark load levels handed to the perf evaluator.
@@ -225,14 +228,12 @@ Resume any run with `--resume` (defaults to "latest"):
 ./vs --resume owner/repo       # clone a GitHub experiment, then resume it
 ```
 
-When `[repository].owner` is configured, an interactive fresh run first opens a
-setup form populated with the input path, an automatically generated experiment
-name, owner, repository name, and visibility. Use Tab/Shift-Tab to move through
-the defaults and Enter to launch. Clear the owner field for a local-only run.
-
-The generated repository owner comes only from `agent.toml`; no organization is
-hard-coded. `agent.toml.example` uses `vibesys-playground` as its editable
-default. Authenticate the GitHub CLI before launching a remotely tracked run:
+Fresh runs use GitHub by default. The interactive setup form is populated with
+the input path, an automatically generated experiment name, the configured
+repository owner (or the account from `gh`), repository name, and visibility.
+Use Tab/Shift-Tab to move through the defaults and Enter to launch. Clear the
+owner field, or pass `--local`, to keep a run under `exp_env/` without creating
+or syncing a GitHub repository.
 
 ```bash
 gh auth login
@@ -241,12 +242,13 @@ gh auth login
   ...
 ```
 
-For non-interactive use, `--repo queue-trial` uses the configured owner, while
-`--repo another-org/queue-trial` overrides it explicitly. Durable workspace and
-run state are committed and pushed after each workspace checkpoint and again
-when the run closes; raw `logs/*.log` files stay local. Checkpoint push failures
-are retried without stopping the run. Later runs automatically push again when
-resumed from a clone with an `origin`.
+For non-interactive use, the repository name is generated from the input bundle;
+`--repo queue-trial` overrides the name, and `--repo another-org/queue-trial`
+overrides the owner explicitly. Durable workspace and run state are committed
+and pushed after each workspace checkpoint and again when the run closes; raw
+`logs/*.log` files stay local. Checkpoint push failures are retried without
+stopping the run. Later runs automatically push again when resumed from a clone
+with an `origin`.
 
 ## Citation
 

--- a/agent.toml.example
+++ b/agent.toml.example
@@ -31,9 +31,9 @@ name = "gpt-5.4"
 # cli_timeout = 1800          # per-invocation timeout in seconds
 
 [repository]
-# The interactive setup screen uses these as editable defaults. Change owner
-# to any GitHub user or organization where you are allowed to create repos.
-owner = "vibesys-playground"
+# Optional GitHub user or organization override. If omitted, use the account
+# authenticated with `gh auth login`.
+# owner = "your-github-user"
 visibility = "private"       # private, public, or internal
 
 # [feature_flags]

--- a/clients/tui/src/setup-model.test.ts
+++ b/clients/tui/src/setup-model.test.ts
@@ -50,6 +50,7 @@ describe('interactive setup model', () => {
     const local = {...selection, repositoryOwner: ''};
 
     expect(validateSetupSelection(local)).toBeUndefined();
+    expect(applySetupSelection([], local)).toContain('--local');
     expect(applySetupSelection([], local)).not.toContain('--repo');
   });
 
@@ -63,6 +64,7 @@ describe('interactive setup model', () => {
     expect(shouldOfferInteractiveSetup(['--input', 'example'])).toBe(true);
     expect(shouldOfferInteractiveSetup(['--resume'])).toBe(false);
     expect(shouldOfferInteractiveSetup(['--repo=owner/name'])).toBe(false);
+    expect(shouldOfferInteractiveSetup(['--local'])).toBe(false);
     expect(shouldOfferInteractiveSetup(['--stub-agent'])).toBe(false);
   });
 });

--- a/clients/tui/src/setup-model.ts
+++ b/clients/tui/src/setup-model.ts
@@ -53,7 +53,13 @@ export function validateSetupSelection(selection: SetupSelection): string | unde
 }
 
 export function applySetupSelection(argv: string[], selection: SetupSelection): string[] {
-  const result = withoutOptions(argv, ['--input', '--exp-name', '--repo', '--repo-visibility']);
+  const result = withoutOptions(argv, [
+    '--input',
+    '--exp-name',
+    '--repo',
+    '--repo-visibility',
+    '--local',
+  ]);
   result.push('--input', selection.inputPath.trim());
   result.push('--exp-name', selection.experimentName.trim());
 
@@ -61,6 +67,8 @@ export function applySetupSelection(argv: string[], selection: SetupSelection): 
   if (owner.length > 0) {
     result.push('--repo', `${owner}/${selection.repositoryName.trim()}`);
     result.push('--repo-visibility', selection.visibility.trim());
+  } else {
+    result.push('--local');
   }
   return result;
 }
@@ -72,6 +80,7 @@ export function shouldOfferInteractiveSetup(argv: string[]): boolean {
       argument.startsWith('--resume=') ||
       argument === '--repo' ||
       argument.startsWith('--repo=') ||
+      argument === '--local' ||
       argument === '--stub-agent' ||
       argument === '--headless',
   );

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -19,7 +19,7 @@ Several flags look independent, but they combine into one execution contract:
 | Modality | `--modality` | Per-task I/O contract, such as `text_generation` or `speech_to_text`. |
 | Skills | `--skills-dir`, `--no-skills` | Candidate skill roots and the ablation switch that disables skill loading. |
 | Target inputs | `--input` | Target bundle directory with manifest-declared correctness and benchmark commands. |
-| Experiment repository | `--repo`, `--repo-visibility`, `--resume` | Optionally create and synchronize a remote experiment, or resume from a local path/GitHub repository. |
+| Experiment repository | `--repo`, `--repo-visibility`, `--local`, `--resume` | Fresh runs use GitHub by default; `--local` keeps one under `exp_env/`, and `--resume` accepts local paths or GitHub repositories. |
 
 Do not treat these as simple toggles. Some combinations imply a startup
 contract, profiler, or sandbox capability. Language and artifact requirements
@@ -88,20 +88,24 @@ Configure interactive defaults in `agent.toml`:
 
 ```toml
 [repository]
-owner = "vibesys-playground"
+# Optional GitHub user/org override. If omitted, use the account authenticated with `gh`.
+# owner = "your-github-user"
 visibility = "private"
 ```
 
-The owner can be any GitHub user or organization and is never hard-coded. On a
-fresh interactive run, a pre-launch form opens when `owner` is configured. The
-input path and generated experiment/repository names are prefilled; Tab and
-Shift-Tab move between fields, Enter launches, and clearing the owner keeps the
-run local. Names default to `<input-name>-<UTC timestamp>`.
+Fresh runs use GitHub by default. The owner can be any GitHub user or
+organization; when `owner` is omitted, VibeSys uses the account authenticated
+with `gh`. On a fresh interactive run, a pre-launch form shows the input path,
+generated experiment/repository names, owner, and visibility. Tab and Shift-Tab
+move between fields, Enter launches, and clearing the owner keeps the run local.
+Names default to `<input-name>-<UTC timestamp>`.
 
-For headless use, pass `--repo NAME` to combine the name with the configured
-owner, or `--repo OWNER/NAME` to override the owner explicitly. Repositories use
-`[repository].visibility` unless `--repo-visibility` overrides it. Creation goes
-through the authenticated `gh` CLI.
+For headless use, the generated repository name is used automatically. Pass
+`--repo NAME` to override the name, or `--repo OWNER/NAME` to override the owner
+explicitly. Pass `--local` to keep the experiment under `exp_env/` without a
+GitHub repository. Repositories use `[repository].visibility` unless
+`--repo-visibility` overrides it. Creation goes through the authenticated `gh`
+CLI.
 
 The experiment repository records the materialized workspace and durable state
 needed to continue the loop. Provider/agent `logs/*.log` files and directory

--- a/libs/vs-github/src/vs_github/cli.py
+++ b/libs/vs-github/src/vs_github/cli.py
@@ -46,6 +46,15 @@ class GitHubCLI:
             message += f" GitHub CLI reported: {detail}"
         raise GitHubAuthenticationError(message)
 
+    def current_user(self) -> str:
+        """Return the login for the authenticated GitHub account."""
+        self.ensure_authenticated()
+        result = self._run(["api", "user", "--jq", ".login"])
+        login = result.stdout.strip()
+        if not login:
+            raise GitHubCLIError("GitHub CLI returned an empty authenticated user.")
+        return login
+
     def create_repository(
         self,
         repository: str,

--- a/libs/vs-github/tests/test_cli.py
+++ b/libs/vs-github/tests/test_cli.py
@@ -58,6 +58,23 @@ def test_create_repository_checks_authentication_then_creates(tmp_path):
     ]
 
 
+def test_current_user_checks_authentication_then_reads_login():
+    runner = RecordingRunner([_result(), _result(stdout="octocat\n")])
+
+    assert GitHubCLI(_runner=runner).current_user() == "octocat"
+    assert runner.calls == [
+        (["gh", "auth", "status", "--hostname", "github.com"], None),
+        (["gh", "api", "user", "--jq", ".login"], None),
+    ]
+
+
+def test_current_user_rejects_empty_login():
+    runner = RecordingRunner([_result(), _result(stdout="\n")])
+
+    with pytest.raises(GitHubCLIError, match="empty authenticated user"):
+        GitHubCLI(_runner=runner).current_user()
+
+
 def test_clone_repository_reports_unauthenticated_user(tmp_path):
     runner = RecordingRunner([_result(1, stderr="not logged into any GitHub hosts")])
 

--- a/src/vibesys/config.py
+++ b/src/vibesys/config.py
@@ -210,8 +210,8 @@ class RepositoryCfg(_Strict):
     owner: str | None = Field(
         default=None,
         description=(
-            "Default GitHub user or organization for repositories created by the "
-            "interactive setup screen. None leaves remote tracking opt-in."
+            "Optional default GitHub user or organization for experiment repositories. "
+            "When omitted, use the authenticated account from `gh`."
         ),
     )
     visibility: RepositoryVisibility = Field(

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -436,12 +436,6 @@ def _prepare_experiment_repository(args: argparse.Namespace, config: Config) -> 
         args.exp_name = generate_experiment_name(args.input_bundle.root)
 
     if args.local:
-        if args.repo is not None:
-            _configuration_error(
-                "--local cannot be combined with --repo",
-                code="invalid_repository",
-                stage="repository_setup",
-            )
         return
 
     if args.repo is None:

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -197,8 +197,8 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--exp-name",
         required=False,
-        default="test",
-        help="Experiment name (creates exp_env/<name>/)",
+        default=None,
+        help="Experiment name; generated from the input bundle when omitted.",
     )
     parser.add_argument(
         "--config",
@@ -312,11 +312,15 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         metavar="[OWNER/]NAME",
         help=(
-            "Create a GitHub repository for this experiment, commit its durable "
-            "state, and push after each workspace checkpoint and at shutdown. "
-            "A configured [repository].owner supplies an omitted owner. Requires "
-            "an authenticated `gh` CLI."
+            "Override the generated GitHub repository name for this experiment. "
+            "A configured [repository].owner or authenticated `gh` account supplies "
+            "an omitted owner."
         ),
+    )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Keep this experiment local under exp_env; do not create or sync GitHub.",
     )
     parser.add_argument(
         "--repo-visibility",
@@ -324,7 +328,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         choices=list(RepositoryVisibility),
         default=None,
         help=(
-            "Visibility for a repository created by --repo. Defaults to "
+            "Visibility for the experiment repository. Defaults to "
             "[repository].visibility in agent.toml."
         ),
     )
@@ -373,19 +377,19 @@ def load_config_and_skills(
             _configuration_error(str(e), code="config_load_failed", stage="config_loading")
 
     repository = getattr(args, "repo", None)
+    if getattr(args, "local", False) and repository is not None:
+        _configuration_error(
+            "--local cannot be combined with --repo",
+            code="invalid_repository",
+            stage="repository_setup",
+        )
     if repository is not None:
         if "/" not in repository:
-            owner = config.repository.owner
-            if owner is None:
-                _configuration_error(
-                    f"--repo {repository!r} omits OWNER, but [repository].owner is not set",
-                    code="invalid_repository",
-                    stage="repository_setup",
-                )
+            owner = _resolve_repository_owner(config)
             repository = f"{owner}/{repository}"
         if not REPOSITORY_SLUG.fullmatch(repository):
             _configuration_error(
-                f"--repo must be NAME with [repository].owner configured or an "
+                f"--repo must be NAME with a configured or authenticated owner, or an "
                 f"explicit GitHub OWNER/NAME pair, got {repository!r}",
                 code="invalid_repository",
                 stage="repository_setup",
@@ -407,6 +411,42 @@ def load_config_and_skills(
         )
         skills = resolve_skill_source_dirs(raw_skills, backend=backend, domain=domain)
     return config, skills, backend
+
+
+def _resolve_repository_owner(config: Config) -> str:
+    """Resolve the configured repository owner or the authenticated ``gh`` user."""
+    if config.repository.owner is not None:
+        return config.repository.owner
+    try:
+        return GitHubCLI().current_user()
+    except GitHubCLIError as exc:
+        _configuration_error(
+            str(exc),
+            code="repository_setup_failed",
+            stage="repository_setup",
+        )
+
+
+def _prepare_experiment_repository(args: argparse.Namespace, config: Config) -> None:
+    """Resolve fresh-run naming and remote selection before entering a loop."""
+    if args.resume is not None:
+        return
+
+    if args.exp_name is None:
+        args.exp_name = generate_experiment_name(args.input_bundle.root)
+
+    if args.local:
+        if args.repo is not None:
+            _configuration_error(
+                "--local cannot be combined with --repo",
+                code="invalid_repository",
+                stage="repository_setup",
+            )
+        return
+
+    if args.repo is None:
+        owner = _resolve_repository_owner(config)
+        args.repo = f"{owner}/{repository_name_from_experiment(args.exp_name)}"
 
 
 def _prepare_stub_agent_smoke_defaults(argv: list[str]) -> list[str]:
@@ -691,10 +731,11 @@ def _run_tui_defaults(argv: list[str]) -> None:
 
     input_path = args.input.expanduser().resolve() if args.input is not None else None
     experiment_name = args.exp_name or generate_experiment_name(input_path)
+    repository_owner = _resolve_repository_owner(config)
     defaults = InteractiveSetupDefaults(
         input_path=str(input_path) if input_path is not None else "",
         experiment_name=experiment_name,
-        repository_owner=config.repository.owner,
+        repository_owner=repository_owner,
         repository_name=repository_name_from_experiment(experiment_name),
         visibility=config.repository.visibility,
     )
@@ -935,6 +976,7 @@ def _validate_agent(args: argparse.Namespace) -> None:
 def _run_agent(args: argparse.Namespace) -> None:
     bundle: InputBundle = args.input_bundle
     config, skills, backend = load_config_and_skills(args, domain=bundle.domain)
+    _prepare_experiment_repository(args, config)
     from vibesys.loops.agent.loop import run_agent_loop
 
     objective = _with_operator_constraints(_load_objective(bundle), args.constraint)
@@ -1286,6 +1328,7 @@ def _restore_openevolve_objectives(
 def _run_evolve(args: argparse.Namespace) -> None:
     bundle: InputBundle = args.input_bundle
     config, skills, backend = load_config_and_skills(args, domain=bundle.domain)
+    _prepare_experiment_repository(args, config)
     from vibesys.loops.evolve.loop import run_evolve_loop
 
     objective = _load_objective(bundle)
@@ -1391,6 +1434,7 @@ def _validate_plain(args: argparse.Namespace) -> None:
 def _run_plain(args: argparse.Namespace) -> None:
     bundle: InputBundle = args.input_bundle
     config, skills, backend = load_config_and_skills(args, domain=bundle.domain)
+    _prepare_experiment_repository(args, config)
     from vibesys.loops.plain.loop import (
         PlainLoopState,
         load_state,

--- a/tests/loops/plain/test_plain_loop_cli.py
+++ b/tests/loops/plain/test_plain_loop_cli.py
@@ -71,7 +71,7 @@ class TestBuildParser:
 
 
 class TestMain:
-    _BASE_ARGV = ["vibesys", "--outer-loop", "plain", *TARGET_ARGS]
+    _BASE_ARGV = ["vibesys", "--outer-loop", "plain", "--local", *TARGET_ARGS]
 
     def _patch_run(self, return_value: bool):
         return patch(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,6 +20,7 @@ from vibesys.main import (
     _load_objectives_toml,
     _load_pareto_relative_noise_toml,
     _parse_cli_objective,
+    _prepare_experiment_repository,
     _prepare_stub_agent_smoke_defaults,
     _prune_rounds_state,
     _render_configuration_error,
@@ -225,6 +226,82 @@ visibility = "internal"
 
     assert args.repo == "my-playground/generated-trial"
     assert args.repo_visibility is RepositoryVisibility.INTERNAL
+
+
+def test_fresh_runs_default_to_authenticated_github_account(tmp_path, monkeypatch):
+    import vibesys.main as cli
+
+    bundle = _write_input_bundle(tmp_path)
+    args = cli._build_agent_parser().parse_args(["--input", str(bundle), "--no-skills"])
+    cli._validate_target_inputs(args)
+    config = cli.Config.model_validate({"model": {"name": "gpt-5.5"}})
+    github = Mock()
+    github.current_user.return_value = "octocat"
+    monkeypatch.setattr(cli, "GitHubCLI", Mock(return_value=github))
+
+    _prepare_experiment_repository(args, config)
+
+    assert args.exp_name.startswith("queue-spsc-")
+    assert args.repo == f"octocat/{args.exp_name}"
+    github.current_user.assert_called_once_with()
+
+
+def test_repository_owner_override_does_not_query_gh(tmp_path, monkeypatch):
+    import vibesys.main as cli
+
+    bundle = _write_input_bundle(tmp_path)
+    args = cli._build_agent_parser().parse_args(["--input", str(bundle), "--no-skills"])
+    cli._validate_target_inputs(args)
+    config = cli.Config.model_validate(
+        {"model": {"name": "gpt-5.5"}, "repository": {"owner": "my-org"}}
+    )
+    github = Mock()
+    monkeypatch.setattr(cli, "GitHubCLI", Mock(return_value=github))
+
+    _prepare_experiment_repository(args, config)
+
+    assert args.repo == f"my-org/{args.exp_name}"
+    github.current_user.assert_not_called()
+
+
+def test_local_runs_keep_generated_name_and_skip_github(tmp_path, monkeypatch):
+    import vibesys.main as cli
+
+    bundle = _write_input_bundle(tmp_path)
+    args = cli._build_agent_parser().parse_args(["--input", str(bundle), "--local", "--no-skills"])
+    cli._validate_target_inputs(args)
+    config = cli.Config.model_validate({"model": {"name": "gpt-5.5"}})
+    github = Mock()
+    monkeypatch.setattr(cli, "GitHubCLI", Mock(return_value=github))
+
+    _prepare_experiment_repository(args, config)
+
+    assert args.exp_name.startswith("queue-spsc-")
+    assert args.repo is None
+    github.current_user.assert_not_called()
+
+
+def test_local_and_repo_are_mutually_exclusive(tmp_path):
+    from vibesys.main import _build_agent_parser
+
+    bundle = _write_input_bundle(tmp_path)
+    config_path = tmp_path / "agent.toml"
+    config_path.write_text('[model]\nname = "gpt-5.5"\n')
+    args = _build_agent_parser().parse_args(
+        [
+            "--input",
+            str(bundle),
+            "--config",
+            str(config_path),
+            "--local",
+            "--repo",
+            "owner/name",
+            "--no-skills",
+        ]
+    )
+
+    with pytest.raises(ConfigurationError, match="--local cannot be combined"):
+        load_config_and_skills(args, domain=DomainName.GENERIC)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -281,6 +281,22 @@ def test_local_runs_keep_generated_name_and_skip_github(tmp_path, monkeypatch):
     github.current_user.assert_not_called()
 
 
+def test_missing_gh_credentials_report_repository_setup_error(monkeypatch):
+    import vibesys.main as cli
+
+    config = cli.Config.model_validate({"model": {"name": "gpt-5.5"}})
+    github = Mock()
+    github.current_user.side_effect = cli.GitHubCLIError("run gh auth login")
+    monkeypatch.setattr(cli, "GitHubCLI", Mock(return_value=github))
+
+    with pytest.raises(ConfigurationError) as exc:
+        cli._resolve_repository_owner(config)
+
+    assert exc.value.diagnostic.code == "repository_setup_failed"
+    assert exc.value.diagnostic.stage == "repository_setup"
+    assert "gh auth login" in exc.value.diagnostic.message
+
+
 def test_local_and_repo_are_mutually_exclusive(tmp_path):
     from vibesys.main import _build_agent_parser
 

--- a/tests/test_workspace_seed.py
+++ b/tests/test_workspace_seed.py
@@ -766,7 +766,7 @@ def test_cli_forwards_workspace_sources_to_every_outer_loop(tmp_path, outer_loop
         'dest = "vllm"\n\n'
         '[evaluator]\nsource = "../../evaluators/queue"',
     )
-    argv = ["vibesys", "--outer-loop", outer_loop, "--input", str(bundle)]
+    argv = ["vibesys", "--outer-loop", outer_loop, "--local", "--input", str(bundle)]
 
     with (
         patch("sys.argv", argv),


### PR DESCRIPTION
## Problem
Fresh runs currently remain local unless a repository is explicitly supplied or a configured owner enables the interactive setup. That makes the default tracking behavior inconsistent and leaves the example configuration tied to a sample organization. Users should get a GitHub-backed experiment by default without a repository-specific hard-coded owner, while local `exp_env` runs remain available as an explicit opt-out.

## Solution
- Default every fresh run to a generated GitHub repository slug.
- Use `[repository].owner` when configured, otherwise resolve the authenticated GitHub account through `gh`.
- Add `--local` to preserve the existing local `exp_env` behavior without GitHub setup.
- Make the TUI pass `--local` when the owner is cleared, and skip setup when the flag is supplied directly.
- Remove the `vibesys-playground` default from public configuration examples and update the setup and CLI documentation.

### Architecture
```mermaid
flowchart LR
  A[Fresh run] --> B{--local?}
  B -- yes --> C[exp_env only]
  B -- no --> D{TOML owner?}
  D -- yes --> E[Configured OWNER]
  D -- no --> F[Authenticated gh account]
  E --> G[Generated or explicit OWNER/NAME]
  F --> G
  G --> H[Create and sync GitHub repository]
```

Repository selection stays in the Python CLI before loop dispatch. The existing experiment repository lifecycle continues to decide whether to create and synchronize a remote based on the resolved slug.

## Verification
Python and TUI behavior were tested, including configured-owner, authenticated-`gh` fallback, local opt-out, owner clearing, and incompatible flag cases. Formatting and lint checks pass. The full TUI renderer suite cannot run in this environment because OpenTUI native FFI is unavailable under Node, and the repository Bun runner is not executable here.

## Correctness properties
- Fresh non-local runs always resolve a valid GitHub `OWNER/NAME` before loop construction.
- The TOML owner takes precedence over `gh`; no organization is hard-coded.
- `--local` never queries `gh` and leaves `remote_repo` unset.
- `--local` and `--repo` are rejected together.
- Resume behavior remains unchanged and `--repo` remains fresh-run-only.
- Clearing the interactive owner produces the same explicit local mode as `--local`.

## Testing
- `uv run pytest libs/vs-github/tests/test_cli.py tests/test_main.py tests/loops/plain/test_plain_loop_cli.py` — 122 passed
- `pnpm --dir clients/tui run check` — passed
- `pnpm --dir clients/tui run build` — passed
- `pnpm --dir clients/tui exec vitest run src/setup-model.test.ts src/launcher.test.ts` — 9 passed
- `./scripts/check_format.sh` — passed
- `./scripts/check_lint.sh` — passed
- `pnpm --dir clients/tui run test` — blocked by `bun: Permission denied`; the full Node Vitest run additionally hit the environment's unavailable OpenTUI native FFI in 19 renderer tests
