### PR TITLE
Add a repository-aware PR review skill

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: review-pr
+description: Review VibeSys pull requests and local diffs for correctness, regressions, architecture violations, insufficient tests, contract or documentation drift, and risky prompt changes. Use when a user asks to review, audit, assess, or find bugs in a VibeSys PR, branch, commit, patch, or working-tree change, including pre-merge reviews and second-pass reviews after updates.
+---
+
+# Review PR
+
+## Overview
+
+Produce a high-signal review of the change, not a general code tour. Prioritize
+specific defects introduced by the diff and verify each finding against the
+repository's contracts, architecture, tests, and affected callers.
+
+## Workflow
+
+1. Resolve the review target and intent.
+   - Read `AGENTS.md`, `docs/coding-best-practices.md`, and every applicable
+     subtree instruction before judging the change.
+   - Inspect repository status before switching branches or fetching a PR.
+     Preserve user changes and prefer reviewing without mutating the worktree.
+   - Read the PR title, body, linked issue, base/head commits, changed files,
+     existing review threads, and check results when available. Use the local
+     branch or merge-base diff when reviewing unpublished work.
+   - Derive the intended behavior and correctness properties. Call out material
+     ambiguity instead of silently choosing an interpretation.
+   - Do not submit a GitHub review, comment, approval, or change request unless
+     the user explicitly asks for that external write.
+
+2. Build a change map before evaluating individual lines.
+   - Classify changed files by owner: framework, reusable library, client,
+     evaluator, example bundle, prompt/template/skill, configuration/schema,
+     generated artifact, test, or documentation.
+   - Read enough surrounding implementation and history to understand the
+     existing pattern. Trace changed interfaces to their producers, consumers,
+     serialization boundaries, and tests with `rg`.
+   - Identify authoritative sources and generated outputs. Review generated
+     diffs as behavior, but request fixes in the source of truth.
+   - Look for coupled artifacts that should have changed but did not: tests,
+     snapshots, schemas, generated types, package data, examples, contracts,
+     migration or compatibility code, and user-facing documentation.
+
+3. Apply the review guide.
+   - Read [references/review-guide.md](references/review-guide.md) completely.
+   - Use only the language and surface sections relevant to the diff, plus the
+     cross-cutting checks.
+   - Review new code placement explicitly. Favor an existing canonical owner;
+     extract a standalone reusable capability into `libs/` only when it has a
+     real interface and reuse boundary. Flag both misplaced shared behavior and
+     abstractions that add indirection without protecting a boundary.
+
+4. Verify candidate findings.
+   - Confirm that the reviewed change introduced or exposed the problem.
+   - State the concrete input, state, platform, or execution path that triggers
+     it and the observable consequence.
+   - Check nearby tests and run the narrowest useful read-only test or
+     reproduction when practical. Never claim a command ran when it did not.
+   - Reject findings based only on taste, hypothetical future needs, or a
+     preference already enforced automatically unless there is a material
+     correctness or maintenance consequence.
+   - Re-read the final diff and each cited line. Distinguish a proven defect
+     from a residual risk that needs more evidence.
+
+5. Report the review.
+   - Lead with findings ordered by severity. Use `[P0]` through `[P3]`, a short
+     actionable title, one compact explanation, and the tightest changed-line
+     range that demonstrates the issue.
+   - Explain why the behavior is wrong and when it occurs; include a fix
+     direction only when it clarifies the required contract. Do not write a
+     patch unless the user also asks for implementation.
+   - Keep summaries brief. After findings, list assumptions or open questions,
+     checks run, and residual risks only when they add information.
+   - If there are no actionable findings, say so plainly and mention meaningful
+     verification gaps. Do not invent low-value findings to populate a review.
+
+## Severity
+
+- `P0`: Release-blocking or broadly catastrophic; immediate action is required.
+- `P1`: A serious, likely defect that should block merge.
+- `P2`: A real defect with limited scope or a meaningful missing safeguard.
+- `P3`: A small but concrete correctness or maintainability problem worth fixing.
+
+Severity reflects impact, likelihood, and blast radius rather than diff size.
+
+## Review Boundaries
+
+- Treat tests, docs, prompts, templates, skills, schemas, and manifests as
+  product behavior when users or agents depend on them.
+- Focus on changed behavior. Mention pre-existing defects separately and only
+  when they materially affect whether this change is safe.
+- Do not expose credentials, private logs, or sensitive paths in review output.
+- Do not approve merely because checks pass; tests demonstrate selected
+  properties, not the absence of regressions.

--- a/.agents/skills/review-pr/agents/openai.yaml
+++ b/.agents/skills/review-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review PR"
+  short_description: "Review VibeSys pull requests rigorously"
+  default_prompt: "Use $review-pr to review this VibeSys pull request for correctness, regressions, and repository-specific risks."

--- a/.agents/skills/review-pr/references/review-guide.md
+++ b/.agents/skills/review-pr/references/review-guide.md
@@ -1,0 +1,221 @@
+# VibeSys Review Guide
+
+Use the cross-cutting sections for every review, then apply only the sections
+matching the changed surfaces.
+
+## Contents
+
+- [Repository Ownership And Architecture](#repository-ownership-and-architecture)
+- [Correctness, Failure, And Lifecycle](#correctness-failure-and-lifecycle)
+- [Contracts And Compatibility](#contracts-and-compatibility)
+- [Python 3.12](#python-312)
+- [TypeScript TUI](#typescript-tui)
+- [Go, Rust, C, And C++ Evaluators](#go-rust-c-and-c-evaluators)
+- [Configuration, Features, And Generated Files](#configuration-features-and-generated-files)
+- [Prompts, Templates, And Agent Skills](#prompts-templates-and-agent-skills)
+- [Documentation And Example Drift](#documentation-and-example-drift)
+- [Tests And Evidence](#tests-and-evidence)
+
+## Repository Ownership And Architecture
+
+- Keep framework behavior under `src/vibesys/` and behavior owned by a loop,
+  domain, backend, renderer, or agent in that package.
+- Put reusable standalone Python capabilities under `libs/` with a focused
+  public interface and their own tests. Prefer the canonical existing module
+  when behavior has one owner; do not create a package solely to split a small
+  function or anticipate reuse.
+- Keep example-specific evaluator, checker, benchmark, and reference behavior
+  in its standard example bundle. Do not move one workload's policy into the
+  framework or create shared infrastructure merely to set up an example.
+- Keep runtime prompt assets under `src/vibesys/prompts/`, organized by loop,
+  domain, and backend. Keep executable domain hooks and definitions in
+  `src/vibesys/domains/`, separate from their prompt context.
+- Keep long-form serving knowledge under `resources/skills/`. Follow
+  `resources/skills/serving-systems/CLAUDE.md` for that subtree.
+- Preserve unidirectional data flow: stable interfaces and typed values feed
+  implementations, which emit semantic results for consumers. Core behavior
+  must not reach back into concrete sandboxes, renderers, clients, or
+  application defaults.
+- Separate shared interfaces, application configuration, implementation, and
+  wiring when they have different owners or reasons to change. Configuration
+  should normally register a new case rather than force concrete-type branches
+  through implementations.
+- Keep compatibility wrappers thin and behavior in the canonical module.
+
+Ask of new abstractions:
+
+1. What contract or ownership boundary does this protect?
+2. Which independent consumers reuse it now?
+3. Does its dependency direction stay one-way?
+4. Can the behavior remain simpler in an existing owner?
+
+## Correctness, Failure, And Lifecycle
+
+- Exercise empty, malformed, duplicate, boundary-size, partial, retry,
+  timeout, cancellation, and concurrent inputs where the code can encounter
+  them.
+- Validate external inputs early and report the offending path, key, flag,
+  backend, or field. Reject unknown config and routing keys rather than
+  silently ignoring them.
+- Check cleanup on success, failure, timeout, and cancellation. The component
+  that creates a sandbox, subprocess, task, thread, temporary resource, or
+  subscription owns deterministic and preferably idempotent cleanup.
+- Look for partial state commits, unsafe retry behavior, check-then-act races,
+  non-atomic persistence, stale caches, unbounded queues, and lost exceptions.
+- Treat subprocesses as integration boundaries: use argument arrays, explicit
+  working directories/environment/encoding/timeouts, actionable domain errors,
+  injectable runners when useful, and redacted diagnostics.
+- Verify security boundaries: path traversal, command injection, unsafe
+  deserialization, secret exposure, untrusted prompt or template interpolation,
+  over-broad filesystem/network access, and trust decisions based on user input.
+
+## Contracts And Compatibility
+
+- Keep one authoritative definition for cross-process and cross-language
+  contracts and generate downstream representations when practical.
+- Prefer additive, backward-compatible evolution. Require an explicit version
+  or compatibility boundary for incompatible protocol changes.
+- Review serialized forms, defaults, optional-versus-missing semantics, enum
+  exhaustiveness, ordering, identifiers, and error representations.
+- Test representative payload round trips and every affected consumer, not only
+  the producer. Backend events remain semantic; clients own presentation,
+  formatting, truncation, colors, and layout.
+- Put nontrivial candidate-facing APIs, ABIs, ownership rules, and service
+  protocols in `CANDIDATE_CONTRACT.md`; keep evaluator internals and trust-model
+  rationale in design docs.
+
+## Python 3.12
+
+- Expect typed Python consistent with strict Pyright. Avoid `Any` or casts that
+  hide an uncertain boundary; preserve type information through registries,
+  callbacks, serialization, and async code.
+- Use Pydantic models for configuration, metadata, persisted state, structured
+  agent output, and other external contracts. Prefer `StrEnum`, `Literal`, and
+  typed registries for closed sets; use small immutable dataclasses for internal
+  values when runtime validation is unnecessary.
+- Normalize `Path`-like inputs once at a boundary. Check path containment and
+  platform behavior rather than relying on string prefixes.
+- Review async code for blocking calls, orphaned tasks, cancellation handling,
+  double completion, and exception retrieval. Review context managers and
+  generators for cleanup across exceptional exits.
+- Favor observable-contract tests with Pytest/Hypothesis over private call
+  structure. When relevant, run focused tests, `./scripts/check_format.sh`,
+  `./scripts/check_lint.sh`, and Pyright for affected typed packages.
+
+## TypeScript TUI
+
+- Preserve the Python event/schema models as the protocol source of truth;
+  regenerate client schema and types instead of hand-editing generated files.
+- Keep protocol data semantic and rendering/UI state in `clients/tui/`.
+  Validate missing, duplicate, out-of-order, reconnect, and terminal events in
+  session state transitions.
+- Respect strict TypeScript settings, including exact optional properties,
+  unchecked indexed access, exhaustive control flow, and unused checks. Do not
+  use assertions or `any` to bypass uncertain protocol states.
+- Check listener/timer/subscription teardown, asynchronous races, stale render
+  state, terminal width and Unicode handling, and non-interactive/headless use.
+- Run root Biome checks plus `pnpm --dir clients/tui run check` and focused
+  Vitest tests when the diff touches the client.
+
+## Go, Rust, C, And C++ Evaluators
+
+- Treat evaluator correctness as adversarial: a candidate must not pass by
+  exploiting timing, undefined behavior, weak validation, fixed fixtures, or
+  knowledge that would be unavailable in the declared contract.
+- For Go concurrency, check goroutine lifetime, channel closure ownership,
+  context cancellation, data races, atomic ordering, lock scope, timeouts, and
+  deterministic error propagation. Run focused `go test` and `go test -race`
+  where feasible.
+- For Rust, check ownership and lifetime boundaries, panic/error behavior,
+  overflow, `unsafe` invariants, FFI layout, and cleanup. Run `cargo fmt
+  --check`, `cargo clippy`, and focused `cargo test` in the owning crate.
+- For C/C++, check ABI/layout/alignment, integer overflow, allocation failure,
+  pointer lifetime, atomics/memory ordering, partial initialization, and all
+  cleanup paths. Use sanitizer or model/conformance tests when available.
+- Keep performance measurements separate from correctness gates. Require fixed
+  seeds or recorded inputs where reproducibility matters, avoid benchmark
+  self-interference, and reject metrics that can improve by skipping work.
+
+## Configuration, Features, And Generated Files
+
+- For TOML/YAML/JSON/manifests, test a representative valid value and unknown,
+  malformed, missing, or conflicting values. Check defaults and precedence.
+- Add `FeatureFlag` enum members and `FeatureDefinition` registrations together;
+  keep typed flag use at call sites and update `src/vibesys/FEATURE_FLAGS.md`.
+- Check package and distribution boundaries when adding templates, data, CLI
+  entry points, workspace libraries, or client outputs. A source-tree test can
+  pass while a built package omits the new file.
+- Locate the generator before accepting generated-looking diffs. Reproduce the
+  output, inspect the semantic diff, and prevent hand-edited drift.
+- For Agent Skills, keep `SKILL.md` frontmatter to `name` and `description`,
+  keep router content concise, move depth to direct references, and put VibeSys
+  routing rules in `.vibesys.toml` sidecars.
+
+## Prompts, Templates, And Agent Skills
+
+Treat every prompt change as a behavior change that needs an explicit audit:
+
+1. Confirm that prompt assets use the public `vibesys.prompts` rendering API and
+   remain in their central loop, domain, or backend owner. Find all render sites
+   and compare the fully rendered before/after prompt, not only the Jinja or
+   Markdown source diff.
+2. Inspect snapshot changes manually. Require updated snapshots when rendered
+   output changes; do not accept regeneration as proof that behavior is right.
+3. Verify placeholder names, defaults, conditionals, whitespace, role/message
+   boundaries, escaping, and behavior for empty, large, or adversarial values.
+4. Check instruction priority and scope. Keep neutral skeletons separate from
+   domain-specific policy and prevent context intended for one backend, loop,
+   modality, or turn from leaking into others.
+5. Identify untrusted content and ensure it is clearly delimited and cannot
+   silently become authoritative instructions. Do not interpolate secrets or
+   unnecessary host state.
+6. Audit downstream parsing and tool expectations. Wording changes can alter
+   structured output, tool selection, stopping behavior, retries, cost, and
+   token usage even when syntax remains valid.
+7. Demand a behavioral rationale and targeted evaluation for consequential
+   prompt changes. Record what changed in agent-visible output and what evidence
+   supports the intended behavior.
+
+For backend prompt fragments, verify the canonical fragment-name registry and
+every backend variant change together; an intentional skip still needs an
+explicit empty or explanatory fragment. For domain prompts, verify role-file
+mapping, optional-role fallback behavior, uniform render variables, and tests
+that prevent domain prose from leaking into neutral or unrelated prompts.
+
+For skill changes, also verify that the frontmatter description triggers on the
+intended requests without being overly broad, instructions are imperative and
+actionable, references are discoverable directly from `SKILL.md`, and
+`quick_validate.py` passes.
+
+## Documentation And Example Drift
+
+Search for every user-visible name, command, field, default, and path changed by
+the PR. Typical coupled documentation includes:
+
+- `README.md`, package READMEs, installation/setup commands, and examples;
+- `docs/cli-flags.md` for CLI flags and `src/vibesys/FEATURE_FLAGS.md` for flags;
+- `CANDIDATE_CONTRACT.md`, protocol/design docs, and evaluator READMEs;
+- example `OBJECTIVE.md`, `vibesys.input.toml`, checker, benchmark, reference,
+  requirements, and run commands;
+- schema outputs and generated TypeScript protocol types;
+- prompt snapshots and skill references.
+
+Flag stale docs when they would cause a user, candidate, maintainer, or agent to
+take the wrong action. Do not require prose churn for a purely internal change.
+
+## Tests And Evidence
+
+- Map each stated correctness property to a test, type/schema check, or focused
+  manual reproduction. A regression test should fail for the old behavior for
+  the reason claimed.
+- Test application configuration and implementation separately, then add a
+  focused wiring test when their connection changes.
+- Use shared contract tests for interchangeable sandboxes, compute backends,
+  and other interface implementations.
+- Cover external CLI adapters with success, missing executable, timeout,
+  nonzero exit, malformed output, and redaction cases as applicable.
+- Prefer the narrowest relevant check first. Broaden when the change crosses an
+  architectural, protocol, packaging, or language boundary.
+- Treat skipped, flaky, environment-gated, or overly mocked tests as evidence
+  gaps, not passes. Separate confirmed findings from risks that require hardware
+  or integration environments to verify.


### PR DESCRIPTION
## Problem

VibeSys pull requests span framework orchestration, standalone libraries, a
strict TypeScript TUI, native evaluators, configuration contracts, generated
artifacts, documentation, and agent-facing prompts. A generic code-review pass
can miss repository-specific ownership boundaries, coupled docs and contracts,
or behavioral risk hidden in a small prompt change.

The repository needs a reusable review workflow that emphasizes concrete,
introduced defects while applying the conventions maintainers already expect.

## Solution

Add a repo-local `$review-pr` skill with:

- a concise workflow for resolving PR intent, mapping changed ownership and
  contracts, verifying candidate findings, and reporting prioritized feedback;
- a directly linked review guide covering architecture and package extraction,
  lifecycle and failure modes, compatibility, Python, TypeScript, Go/Rust/C/C++
  evaluators, configuration, generated files, documentation, and tests;
- an explicit audit for prompt, template, and skill changes, including rendered
  before/after output, snapshots, instruction boundaries, untrusted content,
  downstream parsing, and the centralized loop/domain/backend prompt layout;
- UI metadata for discoverability and direct invocation.

### Architecture

The short router owns the review procedure; detailed, repo-specific checks live
in one reference with a table of contents so the workflow remains easy to scan.

```mermaid
flowchart LR
    A["Review request"] --> B["SKILL.md workflow"]
    B --> C["Intent and change map"]
    C --> D["Repository and stack review guide"]
    D --> E["Verified prioritized findings"]
```

## Verification

The skill was initialized with the standard skill-creator helper, read as
agent-visible behavior, validated structurally, and checked for stale
placeholders, broken local references, invalid UI metadata, and whitespace
errors. Runtime prompt snapshots are not applicable because this PR does not
change VibeSys prompt assets or rendered runtime prompts.

### Correctness properties

- Reviewing is read-only by default; the skill forbids publishing a GitHub
  review or comment without explicit user authorization.
- Findings must identify a concrete triggering path and observable consequence,
  cite a tight changed-line range, and be verified as introduced or exposed by
  the reviewed change.
- New abstractions are evaluated against real ownership and reuse boundaries;
  reusable standalone capabilities belong in `libs/` only when extraction is
  justified.
- Contracts, docs, schemas, generated outputs, prompts, skills, and tests are
  treated as behavior when users, candidates, clients, or agents depend on them.
- Prompt reviews require rendered-output and snapshot inspection plus explicit
  checks for instruction scope, untrusted interpolation, and downstream agent
  behavior.

### Testing

- `/mnt/data/shli/vibesys/.venv/bin/python /home/shli/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/review-pr` — passed (`Skill is valid!`).
- Python YAML/assertion smoke test for frontmatter keys, UI prompt format,
  short-description length, and linked-reference existence — passed.
- `git diff --check origin/main...HEAD` — passed with no whitespace errors.
- `rg` check for template `TODO` markers — passed with no matches.
