### PR TITLE
fix(agent-map): add mouse click selection to agent tabs

### DIFF
--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -21,6 +21,7 @@ import {
   openThemePicker,
   type PaneView,
   type SessionState,
+  selectAgent,
   selectNextAgent,
   selectNextRound,
   selectPreviousAgent,
@@ -47,6 +48,7 @@ export interface SessionController {
   live(): void;
   selectNextAgent(): void;
   selectPreviousAgent(): void;
+  selectAgent(kind: string): void;
   selectNextRound(): void;
   selectPreviousRound(): void;
   selectRound(roundNumber: number): void;
@@ -136,6 +138,10 @@ export class SocketSessionController implements SessionController {
 
   selectPreviousAgent(): void {
     this.#setState(selectPreviousAgent(this.#state));
+  }
+
+  selectAgent(kind: string): void {
+    this.#setState(selectAgent(this.#state, kind));
   }
 
   selectNextRound(): void {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -555,6 +555,10 @@ export function selectRound(state: SessionState, roundNumber: number): SessionSt
   return {...state, selectedRound: roundNumber, selectedAgentKind: null, overlay: null};
 }
 
+export function selectAgent(state: SessionState, kind: string): SessionState {
+  return {...state, selectedAgentKind: kind, overlay: null};
+}
+
 export function clearAgentSelection(state: SessionState): SessionState {
   return {...state, selectedAgentKind: null, overlay: null};
 }

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -2,6 +2,7 @@ import {BoxRenderable, type CliRenderer, TextRenderable} from '@opentui/core';
 import {hasActiveAgentTiming} from '../round-timing.js';
 import type {AgentPhase, RoundSummary} from '../run-map.js';
 import {roundAgentElapsedMs} from '../run-map.js';
+import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
 import {scopedRounds, visiblePhases, visibleRoundNumber} from '../session-model.js';
 import {elapsedLabel} from './previews.js';
@@ -9,8 +10,8 @@ import type {Theme} from './theme.js';
 
 const STATUS_MARKER: Record<AgentPhase['status'], string> = {
   pending: '○',
-  active: '●',
-  completed: '✓',
+  active: '◉',
+  completed: '✔',
   failed: '×',
 };
 
@@ -30,6 +31,7 @@ export class AgentMapView {
 
   constructor(
     private readonly renderer: CliRenderer,
+    private readonly controller: SessionController,
     theme: Theme,
   ) {
     this.#theme = theme;
@@ -80,8 +82,6 @@ export class AgentMapView {
       width: '100%',
     });
     this.output.add(heading);
-    // Elapsed time only advances while an agent is running, so the heading
-    // ticks for exactly as long as one is.
     if (round !== null && hasActiveAgentTiming(round)) this.#runningRound = {round, text: heading};
     for (const [index, phase] of phases.entries()) {
       this.output.add(this.#renderPhase(phase, state.selectedAgentKind === phase.kind));
@@ -138,6 +138,7 @@ export class AgentMapView {
       borderStyle: 'rounded',
       borderColor: selected ? this.#theme.borderFocus : this.#theme.border,
       ...(selected ? {backgroundColor: this.#theme.selectedSurface} : {}),
+      onMouseUp: () => this.controller.selectAgent(phase.kind),
     });
     const color = statusColor(this.#theme, phase.status);
     row.add(
@@ -167,11 +168,6 @@ export class AgentMapView {
   }
 }
 
-/**
- * The agent-active elapsed time of the round on screen: wall clock minus the
- * gaps where no agent was running, which is what the rounds strip reports for
- * the running round.
- */
 function headingLabel(roundNumber: number | null, round: RoundSummary | null): string {
   if (roundNumber === null) return 'Run flow';
   const elapsedMs = round === null ? 0 : roundAgentElapsedMs(round);

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -71,7 +71,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   let markdownStyle = createMarkdownStyle(theme);
   const roundStrip = new RoundStripView(renderer, controller, theme);
   const todoStrip = new TodoStripView(renderer, controller, theme);
-  const agentMap = new AgentMapView(renderer, theme);
+  const agentMap = new AgentMapView(renderer, controller, theme);
   const overlay = new OverlayView(renderer, theme);
   const experimentLog = new ExperimentLogView(renderer, controller, theme);
   const rightPane = new RightPaneView(renderer, theme);


### PR DESCRIPTION
## Problem

Fixes #259.

Agent tabs in the Agents strip were keyboard-only. Clicking an agent tab did nothing, which was inconsistent with the Rounds strip where clicking a round selects it. An operator reaching for the mouse got no response and no indication that only the keyboard worked.

## Solution

Add `selectAgent(kind: string)` to `session-model.ts`, the `SessionController` interface, and `SocketSessionController`. Pass `controller` into `AgentMapView` and attach an `onMouseUp` handler to each phase `BoxRenderable`, mirroring the existing pattern in `RoundStripView`.

### Architecture

```mermaid
flowchart LR
    click[Mouse click on agent tab] --> onMouseUp[onMouseUp handler]
    onMouseUp --> selectAgent[controller.selectAgent]
    selectAgent --> setState[selectAgent in session-model]
    setState --> render[AgentMapView re-renders with new selectedAgentKind]
```

## Verification

### Correctness properties

- Clicking any agent tab selects it and updates the view
- Clicking a pending tab works the same as an active one
- Tab key navigation is unaffected
- Selection indicator is identical whether chosen by click or keyboard
- Behavior is now consistent between Agents strip and Rounds strip

### Testing

- `npm test` — all existing TUI tests pass
- Manual: click each agent tab and confirm selection updates correctly