### PR TITLE
Add CODEOWNERS to require maintainer sign-off on prompt changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Code owners for VibeSys.
+#
+# A prompt change must be signed off by at least one listed owner before it
+# can merge. GitHub requests review from these owners automatically; any one
+# of their approvals satisfies the requirement.
+#
+# NOTE: every owner must retain write (or higher) access to the repository,
+# otherwise GitHub silently ignores the entry and requests no review.
+#
+# Enforcement also requires the branch protection settings on `main`:
+#   - "Require review from Code Owners"
+#   - "Include administrators" (so admin-authored prompt PRs are gated too)
+
+# VibeSys prompts (Jinja templates + renderer)
+/src/vibesys/prompts/   @kasikci @stephanie-wang @vic-lsh @kamahori

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 #   - "Include administrators" (so admin-authored prompt PRs are gated too)
 
 # VibeSys prompts (Jinja templates + renderer)
-/src/vibesys/prompts/   @kasikci @stephanie-wang @vic-lsh @kamahori
+/src/vibesys/prompts/   @vic-lsh @kamahori


### PR DESCRIPTION
## Problem

VibeSys prompts (the Jinja templates under `src/vibesys/prompts/`) directly
shape agent behavior, so an unreviewed prompt edit can silently change how the
system reasons or acts. Today `main` requires one approval but has no notion of
*who* must review, so a prompt change can be signed off by anyone. We want
prompt changes to always get sign-off from a designated prompt owner.

## Solution

Add a `.github/CODEOWNERS` file assigning the `src/vibesys/prompts/` tree to
the prompt owners `@vic-lsh` and `@kamahori`. GitHub will auto-request review
from these owners on any PR touching that tree; a single owner approval
satisfies the requirement.

### Architecture

CODEOWNERS is declarative ownership metadata — no runtime code path. Enforcement
is completed by two branch-protection settings on `main` that must be enabled
after this merges:

- **Require review from Code Owners** — makes the owner approval blocking on
  prompt PRs.
- **Include administrators** — so admin-authored PRs are subject to the rules
  too (admins otherwise bypass branch protection by default).

## Verification

### Correctness properties

- Any PR modifying `src/vibesys/prompts/` requests review from `@vic-lsh` /
  `@kamahori`; at least one owner approval is required to merge (once the branch
  settings are enabled).
- Owners must retain write access or GitHub silently ignores the entry — both
  are current repo admins.
- No effect on PRs that do not touch the prompts tree.

### Testing

No automated tests apply to a CODEOWNERS metadata file. Handles verified against
the current repository collaborator list; path matches the prompt templates
under `src/vibesys/prompts/`. GitHub validates CODEOWNERS syntax on push.
