### PR TITLE
Add writing style guidance to agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,19 @@ before filing. Use the repo-local `create-issue` skill when it is available.
 For `resources/skills/serving-systems/`, also follow the subtree-specific
 authoring guide in
 [`resources/skills/serving-systems/CLAUDE.md`](resources/skills/serving-systems/CLAUDE.md).
+
+# Writing style
+
+Applies to both chat replies and docs.
+
+- Be concise. Prefer the shortest version that is still precise. Cut preamble,
+  recaps, and restating the question.
+- Do not over-explain or hand-hold. Assume the reader knows generic CS.
+- Use precise technical CS terms; keep them. Drop inflated or
+  self-congratulatory jargon and piled-up metaphors (e.g. "blast radius", "earn
+  their keep", "the frontier is the feature"). Say the plain precise thing
+  instead.
+- Direct engineering voice: lead with the answer, then support it.
+- Tables and short code are fine when they carry information; keep them small.
+  Put exhaustive detail in an appendix, not at the top of a doc.
+- No em dashes. Use commas, colons, parentheses, or separate sentences instead.


### PR DESCRIPTION
## Problem

`AGENTS.md` (the file `CLAUDE.md` symlinks to) had no guidance on writing style, so agent chat replies and docs drifted toward verbose preamble, inflated jargon, piled-up metaphors, and em dashes. The user wants a concise, direct engineering voice enforced consistently across both chat and docs.

## Solution

Add a `# Writing style` section to `AGENTS.md` codifying the conventions: be concise, assume generic CS knowledge, use precise technical terms while dropping self-congratulatory jargon and metaphors, lead with the answer, keep tables/code small, and avoid em dashes.

### Architecture

Documentation-only change. No code, control flow, or external contracts touched. `AGENTS.md` is the canonical target of the `CLAUDE.md` symlink, so the guidance applies wherever the agent instructions load.

## Verification

No automated checks — the change is prose in a single Markdown file with no runtime surface to exercise.

### Correctness properties

- No behavioral or contract changes; existing sections unchanged.
- Edit applied to the real file (`AGENTS.md`), not the symlink.

### Testing

Not applicable. Docs-only change; no tests exist for this file.