### PR TITLE
Enforce native JSON Schema output for the Claude Code provider

### DIFF
--- a/src/vibesys/_agent_cli/base.py
+++ b/src/vibesys/_agent_cli/base.py
@@ -76,6 +76,17 @@ class CodingAgent(ABC):
     supports_native_output_schema = False
     """Whether this provider accepts a per-turn JSON Schema file."""
 
+    native_output_schema_wants_absolute_path = False
+    """Whether :meth:`set_output_schema_path` should receive an absolute path.
+
+    Providers whose CLI resolves the schema file against its own working
+    directory (e.g. Codex's ``--output-schema``) keep the default and get the
+    workspace-relative path. Providers that must read the schema themselves at
+    command-build time (e.g. Claude Code, whose ``--json-schema`` takes the
+    schema inline) set this ``True`` so the path is readable regardless of the
+    subprocess working directory.
+    """
+
     # Declared (not assigned) here: every concrete provider sets these in its
     # ``__init__``.  ``env`` is the subprocess environment the CLI is spawned
     # with; ``executor`` is the agentshim ``CommandExecutor`` (host, docker,
@@ -234,7 +245,10 @@ class CodingAgent(ABC):
         return None
 
     def set_output_schema_path(self, path: str | None) -> None:
-        """Set the workspace-relative schema path for the next generation.
+        """Set the JSON Schema file path for the next generation.
+
+        The path is workspace-relative by default, or absolute when the
+        provider sets :attr:`native_output_schema_wants_absolute_path`.
 
         Providers without a native structured-output facility deliberately do
         nothing here. Their runners retain the portable prompt-level schema

--- a/src/vibesys/_agent_cli/claude.py
+++ b/src/vibesys/_agent_cli/claude.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -11,8 +12,60 @@ if TYPE_CHECKING:
     from agentshim.executor import CommandExecutor
 
 
+class StructuredOutputClaudeSession(ClaudeGenerationSession):
+    """:class:`ClaudeGenerationSession` that also surfaces ``structured_output``.
+
+    When ``--json-schema`` is passed, Claude Code returns the schema-conformant
+    payload in a dedicated ``structured_output`` field of the terminal
+    ``result`` event, separate from the freeform ``result`` text. Upstream
+    agentshim only reads ``result``, so this subclass captures
+    ``structured_output`` from the raw event line and, when present, returns it
+    (serialized) as the session result. Non-schema turns are unaffected: the
+    field is absent, so :meth:`run` falls through to agentshim's ``result``.
+    """
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        # ``None`` means "no schema-enforced payload seen"; a captured value is
+        # any JSON type the schema root produced (always an object for VibeSys
+        # response models).
+        self.structured_output: Any = None
+
+    def _process_stdout(self, line: str) -> None:
+        self._capture_structured_output(line)
+        super()._process_stdout(line)
+
+    def _capture_structured_output(self, line: str) -> None:
+        if not line:
+            return
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            return
+        if (
+            isinstance(data, dict)
+            and data.get("type") == "result"
+            and data.get("structured_output") is not None
+        ):
+            self.structured_output = data["structured_output"]
+
+    def run(self, prompt: str) -> str:
+        result = super().run(prompt)
+        if self.structured_output is not None:
+            return json.dumps(self.structured_output)
+        return result
+
+
 class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
     """Coding agent implementation using the Claude Code CLI tool."""
+
+    supports_native_output_schema = True
+    # Claude Code's ``--json-schema`` flag takes the schema *inline*, not a
+    # path, so the schema file must be read at command-build time. The runner
+    # therefore hands this provider an absolute host path (readable on both the
+    # host and container execution paths, where the workspace is bind-mounted)
+    # rather than the workspace-relative path Codex resolves against its cwd.
+    native_output_schema_wants_absolute_path = True
 
     def __init__(
         self,
@@ -34,6 +87,10 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
             event_handler,
             executor=executor,
         )
+        # Compact inline JSON Schema for ``--json-schema``, or ``None`` to keep
+        # the portable prompt-hint contract. Populated by
+        # :meth:`set_output_schema_path`.
+        self.output_schema_json: str | None = None
 
     @property
     def claude_path(self) -> str:
@@ -44,6 +101,44 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
     def _log_prefix(self) -> str:
         """Return the log prefix for this agent."""
         return "[Claude]"
+
+    def set_output_schema_path(self, path: str | None) -> None:
+        """Apply a native structured-output JSON Schema to the next turn.
+
+        *path* is an absolute path to a JSON Schema file (see
+        :attr:`native_output_schema_wants_absolute_path`). Claude Code's
+        ``--json-schema`` flag requires the schema *inline*, so the file is read
+        and normalized to a compact JSON string here — early enough to fail
+        before a turn is spawned. ``None`` clears it, restoring the portable
+        prompt-hint contract for the next turn.
+
+        Raises:
+            RuntimeError: If the schema file cannot be read or does not contain
+                valid JSON. The message names the offending path but never the
+                subprocess environment.
+        """
+        if path is None:
+            self.output_schema_json = None
+            return
+        try:
+            raw = Path(path).read_text(encoding="utf-8")
+        except OSError as exc:
+            raise RuntimeError(
+                f"claude native output schema unreadable at {path}: {type(exc).__name__}"
+            ) from exc
+        try:
+            schema = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"claude native output schema at {path} is not valid JSON: {exc}"
+            ) from exc
+        # Compact form keeps the process argv small; claude re-validates it as a
+        # JSON Schema and rejects malformed input on its own.
+        self.output_schema_json = json.dumps(schema, separators=(",", ":"))
+
+    def _append_output_schema(self, cmd: list[str]) -> None:
+        if self.output_schema_json is not None:
+            cmd.extend(["--json-schema", self.output_schema_json])
 
     def _get_command(self, prompt: str) -> list[str]:
         cmd = [
@@ -56,6 +151,7 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
         ]
         if self.model:
             cmd.extend(["--model", self.model])
+        self._append_output_schema(cmd)
         return cmd
 
     def _get_resume_command(self, prompt: str, session_id: str) -> list[str]:
@@ -71,6 +167,7 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
         ]
         if self.model:
             cmd.extend(["--model", self.model])
+        self._append_output_schema(cmd)
         return cmd
 
     def _extract_session_id(self, session: ClaudeGenerationSession) -> str | None:
@@ -83,7 +180,7 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
         timeout: int | None = None,
         silent: bool = False,
     ) -> ClaudeGenerationSession:
-        return ClaudeGenerationSession(
+        return StructuredOutputClaudeSession(
             binary_name=self.binary_name,
             env=self.env,
             log_prefix=self._log_prefix,

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -190,6 +190,15 @@ class CliAgentRunner:
                     f"{type(exc).__name__}: {exc}",
                     self._run_log_file,
                 )
+        # Providers that read the schema themselves at command-build time (e.g.
+        # Claude Code's inline ``--json-schema``) need an absolute path that
+        # resolves independently of the subprocess working directory; others
+        # keep the workspace-relative path their CLI resolves against its cwd.
+        schema_arg = native_schema_path
+        if native_schema_path is not None and getattr(
+            self._provider_cls, "native_output_schema_wants_absolute_path", False
+        ):
+            schema_arg = str(workspace / native_schema_path)
         schema_hint = "" if native_schema_path else build_schema_hint(response_cls)
         combined_prompt = f"{system_prompt}\n\n{user_prompt}{schema_hint}"
         text = self._generate(
@@ -203,7 +212,7 @@ class CliAgentRunner:
             mcp_servers=mcp_servers,
             reuse_session=reuse_session,
             session_key=session_key,
-            output_schema_path=native_schema_path,
+            output_schema_path=schema_arg,
         )
         label = agent_label(kind)
         parsed = parse_typed_response_text(text, response_cls)

--- a/tests/_agent_cli/test_claude.py
+++ b/tests/_agent_cli/test_claude.py
@@ -1,8 +1,20 @@
+import json
 from unittest.mock import MagicMock
 
 import pytest
 
-from vibesys._agent_cli.claude import ClaudeCodeCodingAgent, ClaudeGenerationSession
+from vibesys._agent_cli.claude import (
+    ClaudeCodeCodingAgent,
+    ClaudeGenerationSession,
+    StructuredOutputClaudeSession,
+)
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+    "required": ["a", "b"],
+    "additionalProperties": False,
+}
 
 
 class _MockCommandExecutor:
@@ -103,6 +115,82 @@ class TestClaudeCommandConstruction:
         assert "deploy the app" not in cmd
 
 
+class TestClaudeNativeOutputSchema:
+    """Tests for native ``--json-schema`` structured output wiring."""
+
+    def test_advertises_native_output_schema(self):
+        assert ClaudeCodeCodingAgent.supports_native_output_schema is True
+
+    def test_wants_absolute_schema_path(self):
+        # ``--json-schema`` is read inline at build time, so the schema file
+        # path must be resolvable independent of the subprocess cwd.
+        assert ClaudeCodeCodingAgent.native_output_schema_wants_absolute_path is True
+
+    def test_command_omits_json_schema_when_unset(self, agent):
+        cmd = agent._get_command("test prompt")
+        assert "--json-schema" not in cmd
+        # No schema => the streaming envelope is unchanged.
+        assert "stream-json" in cmd
+
+    def test_resume_command_omits_json_schema_when_unset(self, agent):
+        cmd = agent._get_resume_command("test prompt", "sess-1")
+        assert "--json-schema" not in cmd
+
+    def test_set_output_schema_path_reads_and_inlines(self, agent, tmp_path):
+        schema_file = tmp_path / "schema.json"
+        schema_file.write_text(json.dumps(_SCHEMA, indent=2), encoding="utf-8")
+
+        agent.set_output_schema_path(str(schema_file))
+
+        # Stored compactly (no spaces) and semantically equal to the file.
+        assert agent.output_schema_json is not None
+        assert " " not in agent.output_schema_json
+        assert json.loads(agent.output_schema_json) == _SCHEMA
+
+    def test_command_includes_json_schema_when_set(self, agent, tmp_path):
+        schema_file = tmp_path / "schema.json"
+        schema_file.write_text(json.dumps(_SCHEMA), encoding="utf-8")
+        agent.set_output_schema_path(str(schema_file))
+
+        cmd = agent._get_command("test prompt")
+
+        assert "--json-schema" in cmd
+        inline = cmd[cmd.index("--json-schema") + 1]
+        assert json.loads(inline) == _SCHEMA
+        # The streaming transport is retained alongside the schema.
+        assert "stream-json" in cmd
+
+    def test_resume_command_includes_json_schema_when_set(self, agent, tmp_path):
+        schema_file = tmp_path / "schema.json"
+        schema_file.write_text(json.dumps(_SCHEMA), encoding="utf-8")
+        agent.set_output_schema_path(str(schema_file))
+
+        cmd = agent._get_resume_command("test prompt", "sess-1")
+
+        assert "--json-schema" in cmd
+        assert json.loads(cmd[cmd.index("--json-schema") + 1]) == _SCHEMA
+
+    def test_set_output_schema_path_none_clears_previous(self, agent, tmp_path):
+        schema_file = tmp_path / "schema.json"
+        schema_file.write_text(json.dumps(_SCHEMA), encoding="utf-8")
+        agent.set_output_schema_path(str(schema_file))
+        agent.set_output_schema_path(None)
+
+        assert agent.output_schema_json is None
+        assert "--json-schema" not in agent._get_command("test prompt")
+
+    def test_missing_schema_file_raises_actionable_error(self, agent, tmp_path):
+        missing = tmp_path / "does-not-exist.json"
+        with pytest.raises(RuntimeError, match="unreadable"):
+            agent.set_output_schema_path(str(missing))
+
+    def test_invalid_schema_json_raises_actionable_error(self, agent, tmp_path):
+        schema_file = tmp_path / "schema.json"
+        schema_file.write_text("{not valid json", encoding="utf-8")
+        with pytest.raises(RuntimeError, match="not valid JSON"):
+            agent.set_output_schema_path(str(schema_file))
+
+
 class TestClaudeGenerationSession:
     """Tests for ClaudeGenerationSession event processing."""
 
@@ -180,6 +268,80 @@ class TestClaudeGenerationSession:
     def test_create_session_returns_claude_session(self, agent):
         session = agent._create_session(cmd=["claude", "-p"])
         assert isinstance(session, ClaudeGenerationSession)
+        # The structured-output-aware subclass is used for every turn.
+        assert isinstance(session, StructuredOutputClaudeSession)
+
+
+class _ReplayExecutor:
+    """CommandExecutor that replays canned stdout lines through the sink."""
+
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    def run(self, request, sink):
+        from agentshim.executor import CommandResult
+
+        for line in self._lines:
+            sink.stdout(line)
+        return CommandResult(returncode=0, stdout="".join(self._lines), stderr="")
+
+
+class TestStructuredOutputClaudeSession:
+    """Tests for capturing and preferring the ``structured_output`` field."""
+
+    def _make_session(self, event_handler=None, executor=None):
+        return StructuredOutputClaudeSession(
+            binary_name="claude",
+            env={},
+            log_prefix="[Claude]",
+            cmd=["claude", "-p"],
+            logger=MagicMock(),
+            silent=True,
+            event_handler=event_handler,
+            executor=executor,
+        )
+
+    def test_captures_structured_output_from_result_event(self):
+        session = self._make_session()
+        line = (
+            '{"type":"result","result":"{\\"a\\":3,\\"b\\":5}","structured_output":{"a":3,"b":5}}\n'
+        )
+        session._process_stdout(line)
+        # agentshim still records the freeform ``result`` text ...
+        assert session.final_result == '{"a":3,"b":5}'
+        # ... and the schema-enforced payload is captured separately.
+        assert session.structured_output == {"a": 3, "b": 5}
+
+    def test_run_prefers_serialized_structured_output(self):
+        # Even if ``result`` held prose, ``run`` returns the schema payload.
+        line = (
+            '{"type":"result","result":"here is your answer","structured_output":{"a":3,"b":5}}\n'
+        )
+        session = self._make_session(executor=_ReplayExecutor([line]))
+        result = session.run("prompt")
+        assert json.loads(result) == {"a": 3, "b": 5}
+
+    def test_run_falls_back_to_result_without_structured_output(self):
+        line = '{"type":"result","result":"plain text answer"}\n'
+        session = self._make_session(executor=_ReplayExecutor([line]))
+        assert session.run("prompt") == "plain text answer"
+
+    def test_absent_structured_output_leaves_none(self):
+        session = self._make_session()
+        session._process_stdout('{"type":"result","result":"plain text answer"}\n')
+        assert session.structured_output is None
+        assert session.final_result == "plain text answer"
+
+    def test_null_structured_output_is_ignored(self):
+        session = self._make_session()
+        session._process_stdout('{"type":"result","result":"done","structured_output":null}\n')
+        assert session.structured_output is None
+
+    def test_non_json_line_does_not_raise(self):
+        session = self._make_session()
+        session._process_stdout("starting claude...\n")
+        assert session.structured_output is None
+        assert "starting claude..." in session.stdout_lines
 
     def test_assistant_usage_forwarded_to_event_handler(self):
         """Per-turn ``message.usage`` is forwarded via ``on_usage`` so the

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from io import StringIO
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1150,6 +1151,46 @@ class TestCliAgentRunner:
         assert captured[0].output_schema_paths == [None]
         assert "Schema for JudgeResponse" in captured[0].generate_calls[0]["prompt"]
         assert "using prompt fallback" in log.getvalue()
+
+    def test_absolute_schema_path_provider_gets_resolved_path(self, monkeypatch, tmp_path):
+        """Providers reading the schema inline (Claude) get an absolute path,
+        resolvable independent of the subprocess cwd, and drop the prompt hint."""
+        captured: list = []
+        fake_cls = _make_fake_agent_class(
+            generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
+            captured=captured,
+        )
+        fake_cls.supports_native_output_schema = True
+        fake_cls.native_output_schema_wants_absolute_path = True
+        monkeypatch.setitem(
+            __import__(
+                "vibesys.agents.cli_runner",
+                fromlist=["_PROVIDER_CLASSES"],
+            )._PROVIDER_CLASSES,
+            "claude",
+            fake_cls,
+        )
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        runner = CliAgentRunner(provider="claude", model="m", run_log_file=None)
+
+        runner.invoke(
+            kind="judge",
+            workspace=workspace,
+            system_prompt="THE-SYSTEM-PROMPT",
+            user_prompt="usr",
+            response_cls=JudgeResponse,
+            fallback_factory=_judge_fallback,
+            round_label="judge #1",
+        )
+
+        agent = captured[0]
+        passed = agent.output_schema_paths[-1]
+        assert passed is not None
+        assert Path(passed).is_absolute()
+        assert Path(passed).is_file()
+        assert Path(passed).parent == workspace / ".cache/vibesys/response-schemas"
+        assert "Schema for JudgeResponse" not in agent.generate_calls[0]["prompt"]
 
     def test_cli_runner_chat_returns_plain_text_in_a_fresh_session_per_turn(
         self, monkeypatch, tmp_path


### PR DESCRIPTION
## Problem

The CLI agent path coerces every structured agent response back into a Pydantic
model with `parse_typed_response_text` — a regex/fenced-code/`{`…`}` scan over
free-text model output (issue #19). When that recovery fails, the round's
`fallback_factory` default is returned (often `Verdict.FAIL`), wasting the whole
round's LLM spend even when the agent did good work.

Codex already avoids this via native `--output-schema`. The Claude Code provider
did not: it only set `--output-format stream-json` for the transport envelope and
relied on the prompt hint plus the regex fallback. This PR closes that gap for the
Anthropic provider called out in the issue.

Closes #19

## Solution

Make the Claude Code provider request native structured output and consume the
schema-enforced payload:

- `ClaudeCodeCodingAgent.supports_native_output_schema = True`, with
  `set_output_schema_path` and `--json-schema` appended in **both**
  `_get_command` and `_get_resume_command`. Existing non-schema turns are
  byte-for-byte unchanged (still `stream-json`, no `--json-schema`).
- Empirically, `claude`'s `--json-schema` takes the schema **inline**, not a
  file path or `@file` (verified against `claude` 2.1.223). So the provider reads
  the materialized schema file and stores a compact inline copy, failing early
  with an actionable `RuntimeError` on an unreadable/invalid file.
- Claude returns the schema-conformant payload in a dedicated `structured_output`
  field of the terminal `result` event (separate from the freeform `result`
  text). Upstream agentshim only reads `result`, so a thin
  `StructuredOutputClaudeSession` subclass captures `structured_output` and
  prefers it (serialized) as the session result, falling back to agentshim's
  `result` when absent. agentshim is an external, non-editable PyPI dependency;
  no change to it was needed — subclassing its session is the intended extension
  point.
- Because `--json-schema` is read at command-build time, the schema file path
  must resolve independently of the subprocess working directory (the container
  path passes `cwd=None`). A declarative `native_output_schema_wants_absolute_path`
  capability on the provider tells the runner to hand this provider an absolute
  host path (readable on both host and bind-mounted container workspaces); Codex
  keeps the workspace-relative path its CLI resolves against its own cwd.

### Architecture

- **Shared interface** (`_agent_cli/base.py`): declares the neutral
  `supports_native_output_schema` / `native_output_schema_wants_absolute_path`
  defaults and the no-op `set_output_schema_path`.
- **Provider** (`_agent_cli/claude.py`): reads + inlines the schema, appends the
  flag, and surfaces `structured_output` via the session subclass.
- **Wiring** (`agents/cli_runner.py`): materializes the schema once, resolves the
  provider-appropriate path form (absolute vs relative), suppresses the prompt
  hint when native output is used, and parses the returned text with the existing
  `parse_typed_response_text`.

No provider-name branching is introduced; the runner selects behavior from the
declarative capability flags.

## Verification

### Correctness properties

- Non-schema turns are unchanged: no `--json-schema`, `stream-json` retained, and
  the regex fallback remains the documented path for providers/turns without a
  native schema.
- When a schema is set, `--json-schema <inline>` is present in both fresh and
  resume commands, and `stream-json` streaming is preserved.
- The schema-enforced `structured_output` is preferred over freeform `result`;
  when absent or null, the session falls back to `result`.
- Invalid/unreadable schema files fail fast with an actionable error that names
  the path and never leaks environment/credentials.
- Codex behavior is untouched (still receives the workspace-relative path).

### Testing

Real `claude` CLI probes (`claude` 2.1.223, model `claude-haiku-4-5`):
- `--output-format stream-json --verbose --json-schema '<inline>'`: `--json-schema`
  accepted; terminal `result` event carried `"result":"{\"a\":3,\"b\":5}"` **and**
  `"structured_output":{"a":3,"b":5}`.
- `--output-format json --json-schema '<inline>'` (prose-prompt): `result` was
  pure JSON `{"a":3,"b":5}`, `structured_output` the parsed object.
- `--json-schema s.json` and `--json-schema @s.json`: both rejected
  (`--json-schema is not valid JSON`) — confirms inline-only.
- Invalid schema: `Error: --json-schema is not valid JSON`, non-zero exit.
- Full pipeline through `ClaudeCodeCodingAgent` + `materialize_native_output_schema`
  (real `claude`): materialize → `set_output_schema_path(abs)` → `generate` →
  `StructuredOutputClaudeSession` returned `'{"a": 3, "b": 5}'`, which
  `Pair.model_validate_json` parsed to `a=3 b=5`.

Credential-free automated tests:
- `./scripts/format.sh` — reformatted 1 file, all checks passed.
- `./scripts/check_format.sh` — all checks passed.
- `./scripts/check_lint.sh` — all checks passed.
- `uv run pytest tests/_agent_cli/test_claude.py -q` — 40 passed.
- `uv run pytest tests/agents/test_agent_runners.py -q` — 68 passed.
- `uv run pytest tests/agents tests/_agent_cli -q` — 378 passed, 1 skipped.
- `uv run pytest tests/test_agent_cli_mcp.py -q` — 28 passed.

### Limitations

- Only the Anthropic (Claude) provider is added here; Gemini and opencode still
  lack an upstream native-schema flag and keep the prompt-hint + regex path.
- Output mode was **not** switched: `stream-json` works with `--json-schema`, so
  streaming UI events are preserved (no move to `--output-format json`).
- No agentshim change was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)