### PR TITLE
Add libs to the ruff format target set

### DIFF
--- a/libs/vs-feature-flags/src/vs_feature_flags/config.py
+++ b/libs/vs-feature-flags/src/vs_feature_flags/config.py
@@ -30,9 +30,7 @@ def parse_feature_flag_overrides(
             flag = flag_type(str(key))
         except (TypeError, ValueError):
             valid = _format_valid_flags(flag_type)
-            raise ValueError(
-                f"Unknown feature flag {key!r}. Supported flags: {valid}"
-            ) from None
+            raise ValueError(f"Unknown feature flag {key!r}. Supported flags: {valid}") from None
 
         if not isinstance(value, bool):
             raise ValueError(f"{section_name}.{key} must be true or false")

--- a/libs/vs-issue-board/tests/test_issue_board_core.py
+++ b/libs/vs-issue-board/tests/test_issue_board_core.py
@@ -119,9 +119,7 @@ class TestLoadCorrupt:
             (2, [0], "greater than or equal to 1"),
         ],
     )
-    def test_load_rejects_invalid_issue_identity(
-        self, tmp_path, next_id, issue_ids, message
-    ):
+    def test_load_rejects_invalid_issue_identity(self, tmp_path, next_id, issue_ids, message):
         path = tmp_path / "issues.json"
         issues = [
             {

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -518,10 +518,7 @@ class DockerSandbox(BaseSandbox):
                     removed = (
                         result.returncode == 0
                         or "No such container" in stderr
-                        or (
-                            "removal of container" in stderr
-                            and "is already in progress" in stderr
-                        )
+                        or ("removal of container" in stderr and "is already in progress" in stderr)
                     )
                     if not removed:
                         cleanup_error = RuntimeError(

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -104,9 +104,7 @@ class TestStart:
         assert "abc123container" not in _live_containers
 
     @patch("subprocess.run")
-    def test_start_failure_retains_created_container_when_removal_fails(
-        self, mock_run, sandbox
-    ):
+    def test_start_failure_retains_created_container_when_removal_fails(self, mock_run, sandbox):
         from vs_sandbox.docker_sandbox import _live_containers
 
         mock_run.side_effect = [

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-targets=(src tests examples resources)
+targets=(src tests examples resources libs)
 
 uv run ruff check --select I "${targets[@]}"
 uv run ruff format --check "${targets[@]}"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-targets=(src tests examples resources)
+targets=(src tests examples resources libs)
 
 uv run ruff check --select I --fix "${targets[@]}"
 uv run ruff format "${targets[@]}"


### PR DESCRIPTION
## Problem

`scripts/check_format.sh` and `scripts/format.sh` both set
`targets=(src tests examples resources)`, which omits `libs/` entirely.
That leaves ~6.3k lines of source and test code across the four
workspace libraries (`vs-feature-flags`, `vs-github`, `vs-issue-board`,
`vs-sandbox`) never checked by `ruff format --check`. `ruff check .` in
`scripts/check_lint.sh` already lints these paths (it runs `.` rather
than an explicit target list), so this gap is specific to the
formatter. Tracked by #296, under area #293 and roadmap #288.

## Solution

Added `libs` to the `targets` array in both `scripts/check_format.sh`
and `scripts/format.sh`, keeping the two scripts consistent (they
already shared an identical target list, so no other reconciliation
was needed).

`scripts/` and `clients/` were evaluated for inclusion but contain no
Python files (`find scripts -name '*.py'` and `find clients -name
'*.py'` both return zero results), so they are intentionally left out
of the target set.

### Architecture

Mechanical, single-boundary change: only the formatter's target list
in the two wrapper scripts. No change to `[tool.ruff.lint]`, pyright
config, or CI job structure, per the coordination note that a separate
PR is concurrently expanding the lint rule set and may also touch
`libs/` formatting.

## Verification

Ran `uv run ruff format --check --diff libs` before making any change
to measure scope: 4 files would be reformatted (24 already
compliant). Applied `./scripts/format.sh` with `libs` added, which
reformatted exactly those 4 files. All diffs are line-wrapping only
(long lines collapsed to fit under the 100-column limit); no logic
changed.

### Correctness properties

- Formatting-only change: no behavior, API, or contract changes.
- `scripts/format.sh` and `scripts/check_format.sh` remain in sync
  (identical `targets` arrays).
- Does not touch `[tool.ruff.lint]`, pyright config, or CI job
  structure.

### Testing

- `uv run pytest` (baseline, before change): 2948 passed, 1 skipped.
- `./scripts/format.sh`: reformatted 4 files (all under `libs/`).
- `./scripts/check_format.sh`: all checks passed (338 files).
- `./scripts/check_lint.sh`: all checks passed.
- `./scripts/check_types.sh`: 0 errors, 0 warnings, 0 informations.
- `uv run pytest` (after change): 2948 passed, 1 skipped — no
  regression.

Files reformatted, by path:
- `libs/vs-feature-flags/src/vs_feature_flags/config.py`
- `libs/vs-issue-board/tests/test_issue_board_core.py`
- `libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py`
- `libs/vs-sandbox/tests/test_docker_sandbox.py`

Closes #296.

Part of #293 (mechanical enforcement) and #288 (codebase quality roadmap);
neither is closed by this PR, as both track substantially broader work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
