### PR TITLE
Fix rollback outcome-vocabulary defect in _FAILED_HYPOTHESIS_OUTCOMES

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -356,7 +356,20 @@ def _backfill_revert_commit(
     return True
 
 
-_FAILED_HYPOTHESIS_OUTCOMES = frozenset({"blocked", "disproven", "inconclusive", "rejected"})
+# `CONTINUE`/`SUPPORTED`/`NOMINATED` name an active or successful hypothesis;
+# every other `HypothesisOutcome` member represents a failed one. Derive the
+# failure set by subtraction so a new enum member defaults to "failed" rather
+# than being silently omitted, as happened with `IMPLEMENTATION_FAILED`.
+# `"rejected"` is a framework-only label (the reviewed-but-not-passed outcome
+# assigned below) with no corresponding enum member, so it is added explicitly.
+_FAILED_HYPOTHESIS_OUTCOMES = (
+    frozenset(outcome.value for outcome in HypothesisOutcome)
+    - {
+        HypothesisOutcome.CONTINUE.value,
+        HypothesisOutcome.SUPPORTED.value,
+        HypothesisOutcome.NOMINATED.value,
+    }
+) | {"rejected"}
 _MAX_CONTINUATION_ROUNDS_WITHOUT_DESIGN_REVIEW = 2
 
 

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -116,6 +116,33 @@ def test_failed_child_rollback_preserves_its_exact_parent_commit():
     assert child_round == 21
 
 
+def test_implementation_failed_child_rollback_preserves_its_exact_parent_commit():
+    historical_parent = _RoundRecord(
+        round_number=20,
+        commit="a" * 40,
+        perf_metric=1400.0,
+        perf_unit="tok/s",
+        passed=True,
+    )
+    failed_child = _RoundRecord(
+        round_number=21,
+        commit="c" * 40,
+        perf_metric=None,
+        perf_unit=None,
+        passed=True,
+        hypothesis_outcome=HypothesisOutcome.IMPLEMENTATION_FAILED.value,
+        hypothesis_parent_round=20,
+        hypothesis_parent_commit="b" * 40,
+    )
+
+    commit, child_round = _resolve_rollback_commit(
+        historical_parent, [historical_parent, failed_child]
+    )
+
+    assert commit == "b" * 40
+    assert child_round == 21
+
+
 def test_distant_rollback_uses_requested_historical_commit():
     historical_parent = _RoundRecord(
         round_number=5,


### PR DESCRIPTION
## Problem

`_FAILED_HYPOTHESIS_OUTCOMES` (`src/vibesys/loops/agent/loop.py:359`) is a hand-maintained string set gating rollback-parent resolution in `_resolve_rollback_commit`. It is out of sync with the `HypothesisOutcome` enum (`src/vibesys/schemas.py:41`) in two directions:

- It **omits** `IMPLEMENTATION_FAILED` (`"implementation_failed"`), a real enum member.
- It **includes** `"rejected"`, which is not an enum member at all — it's a framework-only literal assigned when a round is reviewed but not passed.

Because the set gates the rollback-parent branch at `loop.py:423`, a round whose implementer reported `IMPLEMENTATION_FAILED` is not treated as a failed child: rollback resolves to the historical target commit instead of `hypothesis_parent_commit`, silently corrupting lineage on resume. This is a normal, expected outcome rather than a rare one, so the defect is not rare either.

Closes #291. Named prerequisite for #290 (the `run_agent_loop` decomposition), which explicitly should not carry this bug forward.

## Solution

Derive `_FAILED_HYPOTHESIS_OUTCOMES` from `HypothesisOutcome` by subtraction instead of restating members as literals: every enum member except the active/successful ones (`CONTINUE`, `SUPPORTED`, `NOMINATED`) is treated as a failure. This means a future enum member defaults to "failed" instead of being silently omitted the way `IMPLEMENTATION_FAILED` was. The framework-only `"rejected"` label (no enum counterpart) is added back explicitly, with a comment explaining why it isn't derived.

No other behavior changes. `_resolve_rollback_commit`'s control flow and callers are untouched.

### Architecture

Single-function, single-file change; no new components or ownership boundaries.

## Verification

Added a regression test mirroring the existing `disproven` rollback test but for `hypothesis_outcome="implementation_failed"`, confirming `_resolve_rollback_commit` now returns the recorded `hypothesis_parent_commit` for that case. Ran the full agent-loop suite plus lint/type checks; all pass.

### Correctness properties

- Every `HypothesisOutcome` member representing a failed hypothesis (`DISPROVEN`, `IMPLEMENTATION_FAILED`, `INCONCLUSIVE`, `BLOCKED`) is treated as a failed child for rollback-parent resolution.
- `CONTINUE`, `SUPPORTED`, `NOMINATED` (active/successful hypothesis states) are excluded, matching prior behavior for those cases.
- The framework-only `"rejected"` label continues to be treated as a failure, matching prior behavior.
- No change to `rounds.json` shape, persisted state, or the function's public signature.

### Testing

- `uv run pytest tests/loops/agent/test_orchestrate.py -k rollback` — 3 passed
- `uv run pytest tests/loops/agent/` — 258 passed
- `uv run ruff check src/vibesys/loops/agent/loop.py tests/loops/agent/test_orchestrate.py` — clean
- `uv run ruff format --check src/vibesys/loops/agent/loop.py tests/loops/agent/test_orchestrate.py` — clean
- `uv run pyright src/vibesys/loops/agent/loop.py` — 0 errors, 0 warnings