### PR TITLE
Close coverage scope and granularity gaps (#293)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,7 +212,7 @@ jobs:
 
       - name: Enforce per-module coverage floor
         # Repo-wide --cov-fail-under is an average and can't see a single
-        # near-zero module hiding inside it (issue #293). Reads the floor and
+        # near-zero module hiding inside it (issue #298). Reads the floor and
         # allowlist from [tool.vibesys.per_module_coverage] in pyproject.toml.
         run: uv run python scripts/check_coverage_floor.py coverage.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,7 +204,17 @@ jobs:
         run: uv sync --dev
 
       - name: Run tests
-        run: uv run python -m pytest -v --cov=vibesys --cov=vs_github --cov=vs_issue_board --cov=vs_sandbox --cov-report=term-missing --cov-report=xml --cov-fail-under=75
+        # `addopts` in pyproject.toml already sets `--cov --cov-report=term-missing`
+        # against the source list in `[tool.coverage.run]` (vibesys, vs_feature_flags,
+        # vs_github, vs_issue_board, vs_sandbox). Add the report formats CI needs on
+        # top of that instead of repeating `--cov=...` for each package.
+        run: uv run python -m pytest -v --cov-report=xml --cov-report=json --cov-fail-under=75
+
+      - name: Enforce per-module coverage floor
+        # Repo-wide --cov-fail-under is an average and can't see a single
+        # near-zero module hiding inside it (issue #293). Reads the floor and
+        # allowlist from [tool.vibesys.per_module_coverage] in pyproject.toml.
+        run: uv run python scripts/check_coverage_floor.py coverage.json
 
       - name: Upload coverage report
         if: matrix.python-version == '3.12'

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
 *.cover
 *.py.cover
 .hypothesis/

--- a/libs/vs-issue-board/README.md
+++ b/libs/vs-issue-board/README.md
@@ -137,8 +137,11 @@ When moving code into this package, move or add the tests that define that
 generic behavior here too. App-level compatibility tests can stay in the app
 test tree when they verify old import paths or VibeSys integration wiring.
 
-For the full repository gate, include package coverage with the app coverage:
+For the full repository gate, run the whole suite. `[tool.coverage.run]` in
+the root `pyproject.toml` already measures `vs_issue_board` alongside
+`vibesys` and the other workspace libraries, so a bare `uv run pytest`
+reports combined coverage locally; CI additionally enforces the floor:
 
 ```bash
-uv run python -m pytest -v --cov=vibesys --cov=vs_issue_board --cov-report=term-missing --cov-report=xml --cov-fail-under=75
+uv run pytest --cov-fail-under=75
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,66 @@ test = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "libs/vs-feature-flags/tests", "libs/vs-github/tests", "libs/vs-issue-board/tests", "libs/vs-sandbox/tests"]
-addopts = "-ra"
+# Bare `--cov` measures the packages listed in `[tool.coverage.run] source`
+# below, so `uv run pytest` reports coverage locally without needing the full
+# flag string CI uses. CI layers on `--cov-report=xml`, `--cov-report=json`,
+# and `--cov-fail-under` on top of this; it does not need its own `--cov=...`
+# flags.
+addopts = "-ra --cov --cov-report=term-missing"
 pythonpath = ["."]
+
+[tool.coverage.run]
+branch = true
+source = ["vibesys", "vs_feature_flags", "vs_github", "vs_issue_board", "vs_sandbox"]
+relative_files = true
+omit = [
+    # `python -m vibesys` launcher stub: one import and a guarded call into
+    # `vibesys.main.main`, which is itself measured. Not exercised by unit
+    # tests because doing so would mean invoking the process as a script;
+    # there is no branching logic here for a test to miss.
+    "*/__main__.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+
+[tool.vibesys.per_module_coverage]
+# Per-module coverage floor (percent, statement + branch combined by
+# `coverage`). `--cov-fail-under` below is a repo-wide average and cannot
+# see a single near-zero module hiding inside a healthy total (issue #293).
+# `scripts/check_coverage_floor.py` enforces this floor per file using the
+# `coverage json` report.
+#
+# Chosen from the distribution measured on 2026-08-08 (branch coverage,
+# `vs_feature_flags` included): every module actually exercised by the
+# suite sits at 53%+; the only modules below that are the two allowlisted
+# below, both effectively at 0%. 40 catches modules with no meaningful
+# coverage while leaving comfortable headroom above every module that has
+# real tests, so it does not require an immediate test-writing project.
+floor = 40
+
+# Modules intentionally below the floor. Every entry must be preceded by a
+# comment naming why; do not add bare entries.
+allowlist = [
+    # Zero tests and zero callers anywhere in the repo (verified by
+    # grepping src/, tests/, and libs/). This is an adopt-or-delete
+    # decision, not a test gap, and is tracked separately from coverage
+    # enforcement. See #293.
+    "src/vibesys/_model_config/",
+    # Framework accuracy gate. The agent-loop call site is exercised
+    # directly by tests/loops/agent/test_orchestrate.py (currently ~88%
+    # measured with branch coverage), but the evolve-loop call site mocks
+    # it out entirely (tests/loops/evolve/test_evolutionary_loop.py patches
+    # `_run_framework_accuracy_gate`), and the broad `except Exception`
+    # degradation path this module relies on (gates.py:68-70) is exactly
+    # the untested, agent-visible fallback behavior
+    # docs/coding-best-practices.md warns against. Direct, branch-complete
+    # tests for the gate (pass/fail/error paths) are tracked in #292.
+    # Listed here so a coverage regression on this module is never a
+    # surprise while #292 is open.
+    "src/vibesys/loops/gates.py",
+]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,38 +94,28 @@ skip_covered = false
 [tool.vibesys.per_module_coverage]
 # Per-module coverage floor (percent, statement + branch combined by
 # `coverage`). `--cov-fail-under` below is a repo-wide average and cannot
-# see a single near-zero module hiding inside a healthy total (issue #293).
+# see a single near-zero module hiding inside a healthy total (issue #298).
 # `scripts/check_coverage_floor.py` enforces this floor per file using the
 # `coverage json` report.
 #
 # Chosen from the distribution measured on 2026-08-08 (branch coverage,
 # `vs_feature_flags` included): every module actually exercised by the
-# suite sits at 53%+; the only modules below that are the two allowlisted
-# below, both effectively at 0%. 40 catches modules with no meaningful
-# coverage while leaving comfortable headroom above every module that has
-# real tests, so it does not require an immediate test-writing project.
+# suite sits at 53%+, and the only module below that is the allowlisted
+# one below, at 0%. 40 catches modules with no meaningful coverage while
+# leaving comfortable headroom above every module that has real tests, so
+# it does not require an immediate test-writing project.
 floor = 40
 
 # Modules intentionally below the floor. Every entry must be preceded by a
-# comment naming why; do not add bare entries.
+# comment naming why; do not add bare entries. Only list a module that
+# actually falls below the floor: allowlisting a covered module wrongly
+# implies it is untested.
 allowlist = [
     # Zero tests and zero callers anywhere in the repo (verified by
     # grepping src/, tests/, and libs/). This is an adopt-or-delete
     # decision, not a test gap, and is tracked separately from coverage
-    # enforcement. See #293.
+    # enforcement. See #298.
     "src/vibesys/_model_config/",
-    # Framework accuracy gate. The agent-loop call site is exercised
-    # directly by tests/loops/agent/test_orchestrate.py (currently ~88%
-    # measured with branch coverage), but the evolve-loop call site mocks
-    # it out entirely (tests/loops/evolve/test_evolutionary_loop.py patches
-    # `_run_framework_accuracy_gate`), and the broad `except Exception`
-    # degradation path this module relies on (gates.py:68-70) is exactly
-    # the untested, agent-visible fallback behavior
-    # docs/coding-best-practices.md warns against. Direct, branch-complete
-    # tests for the gate (pass/fail/error paths) are tracked in #292.
-    # Listed here so a coverage regression on this module is never a
-    # surprise while #292 is open.
-    "src/vibesys/loops/gates.py",
 ]
 
 [tool.ruff]

--- a/scripts/check_coverage_floor.py
+++ b/scripts/check_coverage_floor.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Fail when any measured module's coverage falls below a per-module floor.
+
+`coverage`/`pytest-cov` only expose an aggregate `--cov-fail-under`, so a
+module sitting at or near zero coverage can hide behind a healthy repo-wide
+average. This script re-reads a `coverage json` report and enforces a floor
+per source file, with an explicit, commented allowlist for modules that are
+intentionally below it.
+
+Configuration lives in `pyproject.toml` under
+`[tool.vibesys.per_module_coverage]`:
+
+    floor      -- minimum percent-covered (statement + branch, combined by
+                  `coverage`) for any non-allowlisted file.
+    allowlist  -- repo-relative file paths, or directory prefixes ending in
+                  "/", permitted to fall below the floor. Every entry must
+                  be preceded by a comment explaining why it is there.
+
+Usage:
+    uv run python scripts/check_coverage_floor.py coverage.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+DEFAULT_PYPROJECT = Path("pyproject.toml")
+
+
+def load_config(pyproject_path: Path) -> tuple[float, list[str]]:
+    data = tomllib.loads(pyproject_path.read_text())
+    try:
+        section = data["tool"]["vibesys"]["per_module_coverage"]
+    except KeyError as exc:
+        raise SystemExit(
+            f"{pyproject_path}: missing [tool.vibesys.per_module_coverage] section"
+        ) from exc
+    floor = float(section["floor"])
+    allowlist = list(section.get("allowlist", []))
+    return floor, allowlist
+
+
+def is_allowlisted(path: str, allowlist: list[str]) -> bool:
+    for entry in allowlist:
+        if entry.endswith("/"):
+            if path.startswith(entry):
+                return True
+        elif path == entry:
+            return True
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("coverage_json", type=Path, help="Path to a `coverage json` report")
+    parser.add_argument("--pyproject", type=Path, default=DEFAULT_PYPROJECT)
+    args = parser.parse_args()
+
+    floor, allowlist = load_config(args.pyproject)
+    report = json.loads(args.coverage_json.read_text())
+
+    failures: list[tuple[str, float]] = []
+    seen_exact_allowlist_entries: set[str] = set()
+
+    for path, file_report in sorted(report["files"].items()):
+        summary = file_report["summary"]
+        if summary["num_statements"] == 0:
+            # Nothing executable to measure, e.g. an empty __init__.py.
+            continue
+
+        percent = summary["percent_covered"]
+        allowlisted = is_allowlisted(path, allowlist)
+        if allowlisted and path in allowlist:
+            seen_exact_allowlist_entries.add(path)
+        if percent < floor and not allowlisted:
+            failures.append((path, percent))
+
+    # Directory-prefix entries ("foo/") can't go stale the same way an exact
+    # path can, so only flag exact-path entries that named a file the report
+    # no longer contains (renamed, deleted, or a typo).
+    stale = [
+        entry
+        for entry in allowlist
+        if not entry.endswith("/") and entry not in seen_exact_allowlist_entries
+    ]
+
+    exit_code = 0
+
+    if failures:
+        exit_code = 1
+        print(f"Per-module coverage floor ({floor:.0f}%) not met:", file=sys.stderr)
+        for path, percent in failures:
+            print(f"  {path}: {percent:.1f}% < {floor:.0f}%", file=sys.stderr)
+        print(
+            "\nEither add tests to raise coverage, or add the module to the "
+            "explicit, commented allowlist under "
+            "[tool.vibesys.per_module_coverage] in pyproject.toml.",
+            file=sys.stderr,
+        )
+
+    if stale:
+        exit_code = 1
+        print(
+            "Stale [tool.vibesys.per_module_coverage] allowlist entries "
+            "(no matching file in the coverage report):",
+            file=sys.stderr,
+        )
+        for entry in stale:
+            print(f"  {entry}", file=sys.stderr)
+
+    if exit_code == 0:
+        print(f"All measured modules meet the {floor:.0f}% per-module coverage floor.")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

Issue #298 (under the #293 mechanical-enforcement area, part of the #288 codebase-quality roadmap) named three coverage gaps that let the repo's stated standards drift from what CI actually enforces:

1. `vs_feature_flags` is absent from CI's `--cov` flags (`.github/workflows/test.yml:207`), so its ~116 source lines contribute nothing to the measured number even though `pyproject.toml` already runs its tests.
2. There is no `[tool.coverage.run]`/`[tool.coverage.report]` in `pyproject.toml`, so `uv run pytest` reports no coverage locally, and there is no branch coverage anywhere.
3. The 75% global floor is an average, so a module at or near zero coverage can hide inside a healthy total. `src/vibesys/_model_config/` demonstrates this concretely: ~360 lines at **0%** coverage with zero callers anywhere in the repo (verified by grepping `src/`, `tests/`, and `libs/`), and it passes CI today purely because the repo-wide average absorbs it.

`src/vibesys/loops/gates.py` was initially suspected of the same problem, on the grounds that the framework accuracy gate is mocked at its call sites. Measuring it disproved that: it sits at **89%** branch coverage (49 statements, 5 missed), because `tests/loops/agent/test_orchestrate.py` calls `_run_framework_accuracy_gate` directly in seven tests. Only the evolve-loop tests patch it out. It is therefore **not** allowlisted here — allowlisting a module at 89% would wrongly imply it is untested.

That distinction is worth flagging for reviewers, because it shows what a per-module floor does and does not buy: `gates.py` clears any sane floor, yet the specific uncovered lines are the broad `except Exception` degradation path at `gates.py:68-70` — exactly the untested agent-visible fallback behavior `docs/coding-best-practices.md` warns against. A percentage gate cannot see that; only looking at *which* lines are uncovered can. That narrower, real gap is tracked in #292.

## Solution

- Add `[tool.coverage.run]` (`branch = true`, `source` covering all five first-party packages including `vs_feature_flags`, `relative_files = true`, and an `omit` for the `python -m vibesys` launcher stub) and `[tool.coverage.report]` to `pyproject.toml`.
- Add `--cov --cov-report=term-missing` to `[tool.pytest.ini_options] addopts` so a bare `uv run pytest` reports coverage against the same source list, without the CI flag string.
- Simplify CI's `Run tests` step to rely on that source config instead of repeating `--cov=<package>` per package, and add `--cov-report=json` for the new per-module check.
- Add `scripts/check_coverage_floor.py`: reads a `coverage json` report and `[tool.vibesys.per_module_coverage]` from `pyproject.toml` (a `floor` percentage plus an explicit, commented `allowlist` of file paths or directory prefixes), and fails naming any non-allowlisted file below the floor or any stale (no-longer-matching) allowlist entry. Wired in as a new CI step, `Enforce per-module coverage floor`, right after the test step.
- Set the floor to 40% (see Correctness properties for how it was chosen), with `src/vibesys/_model_config/` as the sole allowlist entry, commented with its reason and issue reference.
- Update the `vs-issue-board` README's coverage example to the simplified command now that package coverage is centrally configured.

### Architecture

```mermaid
flowchart LR
  A[uv run pytest] -->|addopts: --cov, source config| B[coverage.py: branch=true, 5 packages]
  B --> C[term-missing report - local]
  B -->|CI only| D[coverage.xml]
  B -->|CI only| E[coverage.json]
  D --> F[diff-cover: 80% patch floor, unchanged]
  E --> G[scripts/check_coverage_floor.py]
  G -->|reads| H["[tool.vibesys.per_module_coverage] in pyproject.toml"]
  H --> I[floor: 40%]
  H --> J["allowlist: _model_config/"]
```

Coverage scope/threshold configuration lives entirely in `pyproject.toml` (one obvious place, per the issue's design ask); the CI workflow and the new script only read it.

## Verification

Ran the exact CI sequence locally (`uv run python -m pytest --cov-report=xml --cov-report=json --cov-fail-under=75 && uv run python scripts/check_coverage_floor.py coverage.json`): 2948 passed, 1 skipped, 75% floor reached at 85.31%, per-module check passed with `_model_config/` as the sole allowlist entry. Also ran `uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=80` locally (passes; this PR's own diff has no coverable lines since it only touches config/CI/a new unmeasured script).

Demonstrated the new gate actually gates: temporarily removed the `_model_config` allowlist entry and reran the check script against the real coverage report — it failed, naming both files at `0.0% < 40%`. Restored the entry and reran — passed again.

### Correctness properties

- **Global floor is unaffected, not silently lowered.** Baseline (current `main`, line coverage only, `vs_feature_flags` excluded, matching the exact CI command before this PR): 2948 passed, 1 skipped, **87.88%** total. After this PR (branch coverage, `vs_feature_flags` included): **85.31%** total. Branch coverage costs ~2.6 points as expected, but the result still clears the existing 75% floor comfortably, so 75% is left unchanged.
- **Per-module floor is set from measured data, not guessed.** The full per-file distribution was captured before choosing a number. Excluding the allowlisted `_model_config/` (0%), every module actually exercised by the suite measures at 53.75% or higher (`src/vibesys/agents/docker_executor.py`, the next-lowest). 40% sits with ~14 points of headroom below that module and well above 0%, so it catches genuinely untested modules without demanding new tests for anything currently passing.
- **The allowlist contains only modules that actually fail the floor.** `src/vibesys/_model_config/` is the sole entry, with an inline comment naming the reason and issue, matching the existing `[tool.ruff.lint] ignore` comment style. `loops/gates.py` measures 89% and is deliberately not listed.
- **Stale allowlist entries fail the build.** The script flags any exact-path entry that no longer matches a file in the coverage report, so an entry cannot silently outlive the module it was written for.
- **80% diff-cover patch floor is untouched** (`.github/workflows/test.yml` patch-coverage job).
- **No new tests were added and no code was deleted** to move these numbers; `_model_config/` and `gates.py` remain exactly as they were, tracked by their own issues (#298 and #292).

### Testing

- `./scripts/check_format.sh` — passed
- `./scripts/check_lint.sh` — passed
- `./scripts/check_types.sh` — passed
- `uv run python -m pytest --cov-report=xml --cov-report=json --cov-fail-under=75` — 2948 passed, 1 skipped, 85.31% total
- `uv run python scripts/check_coverage_floor.py coverage.json` — passed
- `uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=80` — passed (no coverable lines in this diff)
- Manual negative test: removed `src/vibesys/_model_config/` from the allowlist, reran the floor check against the real coverage report — failed, correctly naming `src/vibesys/_model_config/__init__.py: 0.0% < 40%` and `src/vibesys/_model_config/_core.py: 0.0% < 40%`; restored the entry, reran — passed.
- Script logic additionally exercised against synthetic reports for the pass, below-floor, directory-prefix-allowlist, zero-statement-file, and stale-entry cases.

Closes #298. Part of #293 and #288.
