### PR TITLE
Adopt a stricter ruff lint configuration with a self-tightening suppression baseline

### DIFF
--- a/libs/vs-feature-flags/src/vs_feature_flags/__init__.py
+++ b/libs/vs-feature-flags/src/vs_feature_flags/__init__.py
@@ -1,4 +1,4 @@
-from vs_feature_flags.config import parse_feature_flag_overrides
+from vs_feature_flags.config import parse_feature_flag_overrides  # noqa: D104  # tracked: #288
 from vs_feature_flags.core import FeatureDefinition, FeatureRegistry
 
 __all__ = [

--- a/libs/vs-feature-flags/src/vs_feature_flags/config.py
+++ b/libs/vs-feature-flags/src/vs_feature_flags/config.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations  # noqa: D100  # tracked: #288
 
 from collections.abc import Mapping
 from enum import StrEnum
@@ -22,7 +22,7 @@ def parse_feature_flag_overrides(
         return {}
 
     if not isinstance(raw, Mapping):
-        raise ValueError(f"{section_name} must be a TOML table")
+        raise ValueError(f"{section_name} must be a TOML table")  # noqa: TRY003, TRY004  # tracked: #288
 
     parsed: dict[FlagT, bool] = {}
     for key, value in raw.items():
@@ -30,10 +30,10 @@ def parse_feature_flag_overrides(
             flag = flag_type(str(key))
         except (TypeError, ValueError):
             valid = _format_valid_flags(flag_type)
-            raise ValueError(f"Unknown feature flag {key!r}. Supported flags: {valid}") from None
+            raise ValueError(f"Unknown feature flag {key!r}. Supported flags: {valid}") from None  # noqa: TRY003  # tracked: #288
 
         if not isinstance(value, bool):
-            raise ValueError(f"{section_name}.{key} must be true or false")
+            raise ValueError(f"{section_name}.{key} must be true or false")  # noqa: TRY003, TRY004  # tracked: #288
 
         parsed[flag] = value
 

--- a/libs/vs-feature-flags/src/vs_feature_flags/config.py
+++ b/libs/vs-feature-flags/src/vs_feature_flags/config.py
@@ -30,9 +30,7 @@ def parse_feature_flag_overrides(
             flag = flag_type(str(key))
         except (TypeError, ValueError):
             valid = _format_valid_flags(flag_type)
-            raise ValueError(
-                f"Unknown feature flag {key!r}. Supported flags: {valid}"
-            ) from None
+            raise ValueError(f"Unknown feature flag {key!r}. Supported flags: {valid}") from None
 
         if not isinstance(value, bool):
             raise ValueError(f"{section_name}.{key} must be true or false")

--- a/libs/vs-feature-flags/src/vs_feature_flags/core.py
+++ b/libs/vs-feature-flags/src/vs_feature_flags/core.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
+from __future__ import annotations  # noqa: D100  # tracked: #288
 
-from collections.abc import Mapping
+from collections.abc import Mapping  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass
 from enum import StrEnum
 from types import MappingProxyType
@@ -10,7 +10,7 @@ FlagT = TypeVar("FlagT", bound=StrEnum)
 
 
 @dataclass(frozen=True)
-class FeatureDefinition:
+class FeatureDefinition:  # noqa: D101  # tracked: #288
     description: str
     default: bool = False
 
@@ -18,7 +18,7 @@ class FeatureDefinition:
 class FeatureRegistry(Generic[FlagT]):
     """Registry for a project's typed feature flag manifest."""
 
-    def __init__(
+    def __init__(  # noqa: D107  # tracked: #288
         self,
         flag_type: type[FlagT],
         definitions: Mapping[FlagT, FeatureDefinition],
@@ -28,17 +28,17 @@ class FeatureRegistry(Generic[FlagT]):
         self._validate_definitions()
 
     @property
-    def flag_type(self) -> type[FlagT]:
+    def flag_type(self) -> type[FlagT]:  # noqa: D102  # tracked: #288
         return self._flag_type
 
     @property
-    def definitions(self) -> Mapping[FlagT, FeatureDefinition]:
+    def definitions(self) -> Mapping[FlagT, FeatureDefinition]:  # noqa: D102  # tracked: #288
         return MappingProxyType(self._definitions)
 
-    def default_for(self, flag: FlagT) -> bool:
+    def default_for(self, flag: FlagT) -> bool:  # noqa: D102  # tracked: #288
         return self._definitions[flag].default
 
-    def is_enabled(
+    def is_enabled(  # noqa: D102  # tracked: #288
         self,
         flag: FlagT,
         overrides: Mapping[FlagT, bool] | None = None,
@@ -50,10 +50,10 @@ class FeatureRegistry(Generic[FlagT]):
     def _validate_definitions(self) -> None:
         for flag in self._definitions:
             if not isinstance(flag, self._flag_type):
-                raise TypeError(
+                raise TypeError(  # noqa: TRY003  # tracked: #288
                     f"Feature definition key {flag!r} is not a {self._flag_type.__name__}"
                 )
 
         missing = [flag.value for flag in self._flag_type if flag not in self._definitions]
         if missing:
-            raise ValueError(f"Missing feature definitions for: {', '.join(missing)}")
+            raise ValueError(f"Missing feature definitions for: {', '.join(missing)}")  # noqa: TRY003  # tracked: #288

--- a/libs/vs-feature-flags/tests/test_core.py
+++ b/libs/vs-feature-flags/tests/test_core.py
@@ -30,21 +30,21 @@ def _registry() -> FeatureRegistry[ExampleFlag]:
     )
 
 
-def test_registry_uses_defaults():
+def test_registry_uses_defaults():  # noqa: ANN201  # tracked: #288
     registry = _registry()
 
     assert registry.is_enabled(ExampleFlag.NEW_LOOP) is False
     assert registry.is_enabled(ExampleFlag.STRICT_MODE) is True
 
 
-def test_registry_uses_typed_overrides():
+def test_registry_uses_typed_overrides():  # noqa: ANN201  # tracked: #288
     registry = _registry()
 
     assert registry.is_enabled(ExampleFlag.NEW_LOOP, {ExampleFlag.NEW_LOOP: True}) is True
     assert registry.is_enabled(ExampleFlag.STRICT_MODE, {ExampleFlag.STRICT_MODE: False}) is False
 
 
-def test_registry_requires_every_enum_member_to_have_definition():
+def test_registry_requires_every_enum_member_to_have_definition():  # noqa: ANN201  # tracked: #288
     with pytest.raises(ValueError, match="Missing feature definitions for: strict_mode"):
         FeatureRegistry(
             ExampleFlag,
@@ -54,7 +54,7 @@ def test_registry_requires_every_enum_member_to_have_definition():
         )
 
 
-def test_registry_rejects_definitions_for_another_enum():
+def test_registry_rejects_definitions_for_another_enum():  # noqa: ANN201  # tracked: #288
     with pytest.raises(TypeError, match="is not a ExampleFlag"):
         FeatureRegistry(
             ExampleFlag,
@@ -66,7 +66,7 @@ def test_registry_rejects_definitions_for_another_enum():
         )
 
 
-def test_definitions_mapping_is_read_only():
+def test_definitions_mapping_is_read_only():  # noqa: ANN201  # tracked: #288
     registry = _registry()
 
     with pytest.raises(TypeError):

--- a/libs/vs-feature-flags/tests/test_feature_flag_config.py
+++ b/libs/vs-feature-flags/tests/test_feature_flag_config.py
@@ -10,26 +10,26 @@ class ExampleFlag(StrEnum):
     STRICT_MODE = "strict_mode"
 
 
-def test_parse_feature_flag_overrides_returns_typed_flags():
+def test_parse_feature_flag_overrides_returns_typed_flags():  # noqa: ANN201  # tracked: #288
     parsed = parse_feature_flag_overrides({"new_loop": True}, ExampleFlag)
 
     assert parsed == {ExampleFlag.NEW_LOOP: True}
 
 
-def test_parse_feature_flag_overrides_accepts_missing_section():
+def test_parse_feature_flag_overrides_accepts_missing_section():  # noqa: ANN201  # tracked: #288
     assert parse_feature_flag_overrides(None, ExampleFlag) == {}
 
 
-def test_parse_feature_flag_overrides_rejects_non_table():
+def test_parse_feature_flag_overrides_rejects_non_table():  # noqa: ANN201  # tracked: #288
     with pytest.raises(ValueError, match="feature_flags must be a TOML table"):
-        parse_feature_flag_overrides(True, ExampleFlag)
+        parse_feature_flag_overrides(True, ExampleFlag)  # noqa: FBT003  # tracked: #288
 
 
-def test_parse_feature_flag_overrides_rejects_unknown_flag():
+def test_parse_feature_flag_overrides_rejects_unknown_flag():  # noqa: ANN201  # tracked: #288
     with pytest.raises(ValueError, match="Unknown feature flag 'nope'"):
         parse_feature_flag_overrides({"nope": True}, ExampleFlag)
 
 
-def test_parse_feature_flag_overrides_rejects_non_bool_value():
-    with pytest.raises(ValueError, match="feature_flags.new_loop must be true or false"):
+def test_parse_feature_flag_overrides_rejects_non_bool_value():  # noqa: ANN201  # tracked: #288
+    with pytest.raises(ValueError, match="feature_flags.new_loop must be true or false"):  # noqa: RUF043  # tracked: #288
         parse_feature_flag_overrides({"new_loop": "true"}, ExampleFlag)

--- a/libs/vs-github/src/vs_github/cli.py
+++ b/libs/vs-github/src/vs_github/cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import subprocess
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 Runner = Callable[..., subprocess.CompletedProcess[str]]
 
@@ -52,7 +52,7 @@ class GitHubCLI:
         result = self._run(["api", "user", "--jq", ".login"])
         login = result.stdout.strip()
         if not login:
-            raise GitHubCLIError("GitHub CLI returned an empty authenticated user.")
+            raise GitHubCLIError("GitHub CLI returned an empty authenticated user.")  # noqa: TRY003  # tracked: #288
         return login
 
     def create_repository(
@@ -95,13 +95,13 @@ class GitHubCLI:
         try:
             result = self._runner(command, cwd=cwd, capture_output=True, text=True)
         except FileNotFoundError as exc:
-            raise GitHubCLIUnavailableError(
+            raise GitHubCLIUnavailableError(  # noqa: TRY003  # tracked: #288
                 "GitHub CLI (`gh`) is required for remote experiment repositories. "
                 "Install it from https://cli.github.com/ and retry."
             ) from exc
         if check and result.returncode != 0:
             detail = _command_detail(result) or "unknown error"
-            raise GitHubCLIError(f"GitHub CLI command failed ({' '.join(command)}): {detail}")
+            raise GitHubCLIError(f"GitHub CLI command failed ({' '.join(command)}): {detail}")  # noqa: TRY003  # tracked: #288
         return result
 
 

--- a/libs/vs-github/tests/test_cli.py
+++ b/libs/vs-github/tests/test_cli.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 import pytest
 
@@ -20,16 +20,16 @@ class RecordingRunner:
         self.results = iter(results)
         self.calls: list[tuple[list[str], Path | None]] = []
 
-    def __call__(self, command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+    def __call__(self, command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:  # noqa: ANN003  # tracked: #288
         self.calls.append((command, kwargs.get("cwd")))
         return next(self.results)
 
 
-def _result(returncode: int = 0, stdout: str = "", stderr: str = ""):
+def _result(returncode: int = 0, stdout: str = "", stderr: str = ""):  # noqa: ANN202  # tracked: #288
     return subprocess.CompletedProcess(["gh"], returncode, stdout, stderr)
 
 
-def test_create_repository_checks_authentication_then_creates(tmp_path):
+def test_create_repository_checks_authentication_then_creates(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     runner = RecordingRunner([_result(), _result()])
     github = GitHubCLI(_runner=runner)
 
@@ -58,7 +58,7 @@ def test_create_repository_checks_authentication_then_creates(tmp_path):
     ]
 
 
-def test_current_user_checks_authentication_then_reads_login():
+def test_current_user_checks_authentication_then_reads_login():  # noqa: ANN201  # tracked: #288
     runner = RecordingRunner([_result(), _result(stdout="octocat\n")])
 
     assert GitHubCLI(_runner=runner).current_user() == "octocat"
@@ -68,14 +68,14 @@ def test_current_user_checks_authentication_then_reads_login():
     ]
 
 
-def test_current_user_rejects_empty_login():
+def test_current_user_rejects_empty_login():  # noqa: ANN201  # tracked: #288
     runner = RecordingRunner([_result(), _result(stdout="\n")])
 
     with pytest.raises(GitHubCLIError, match="empty authenticated user"):
         GitHubCLI(_runner=runner).current_user()
 
 
-def test_clone_repository_reports_unauthenticated_user(tmp_path):
+def test_clone_repository_reports_unauthenticated_user(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     runner = RecordingRunner([_result(1, stderr="not logged into any GitHub hosts")])
 
     with pytest.raises(GitHubAuthenticationError, match=r"gh auth login.*not logged"):
@@ -84,16 +84,16 @@ def test_clone_repository_reports_unauthenticated_user(tmp_path):
     assert len(runner.calls) == 1
 
 
-def test_repository_error_includes_gh_detail(tmp_path):
+def test_repository_error_includes_gh_detail(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     runner = RecordingRunner([_result(), _result(1, stderr="name already exists")])
 
     with pytest.raises(GitHubCLIError, match="name already exists"):
         GitHubCLI(_runner=runner).clone_repository("owner/trial", tmp_path / "trial")
 
 
-def test_missing_gh_has_install_guidance():
-    def missing_runner(*_args, **_kwargs):
+def test_missing_gh_has_install_guidance():  # noqa: ANN201  # tracked: #288
+    def missing_runner(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202  # tracked: #288
         raise FileNotFoundError("gh")
 
-    with pytest.raises(GitHubCLIUnavailableError, match="https://cli.github.com"):
+    with pytest.raises(GitHubCLIUnavailableError, match="https://cli.github.com"):  # noqa: RUF043  # tracked: #288
         GitHubCLI(_runner=missing_runner).ensure_authenticated()

--- a/libs/vs-issue-board/src/vs_issue_board/__init__.py
+++ b/libs/vs-issue-board/src/vs_issue_board/__init__.py
@@ -1,4 +1,4 @@
-from vs_issue_board.core import (
+from vs_issue_board.core import (  # noqa: D104  # tracked: #288
     Issue,
     IssueBoard,
     IssueBoardLoadError,

--- a/libs/vs-issue-board/src/vs_issue_board/core.py
+++ b/libs/vs-issue-board/src/vs_issue_board/core.py
@@ -11,7 +11,7 @@ import json
 import os
 import sys
 import traceback
-from collections.abc import Callable
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from datetime import datetime
 from enum import StrEnum
 from pathlib import Path
@@ -23,13 +23,13 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_valida
 _STORE_VERSION = 1
 
 
-class IssueType(StrEnum):
+class IssueType(StrEnum):  # noqa: D101  # tracked: #288
     BUG = "bug"
     FEATURE = "feature"
     PERF = "perf"
 
 
-class IssueStatus(StrEnum):
+class IssueStatus(StrEnum):  # noqa: D101  # tracked: #288
     OPEN = "open"
     IN_PROGRESS = "in_progress"
     CLOSED = "closed"
@@ -88,16 +88,16 @@ class _IssueBoardData(BaseModel):
     def _valid_issue_identity(self) -> Self:
         issue_ids = [issue.id for issue in self.issues]
         if len(issue_ids) != len(set(issue_ids)):
-            raise ValueError("issue IDs must be unique")
+            raise ValueError("issue IDs must be unique")  # noqa: TRY003  # tracked: #288
         if issue_ids and self.next_id <= max(issue_ids):
-            raise ValueError("next_id must be greater than every persisted issue ID")
+            raise ValueError("next_id must be greater than every persisted issue ID")  # noqa: TRY003  # tracked: #288
         return self
 
 
 class IssueBoard:
     """Atomic JSON-backed issue tracker."""
 
-    def __init__(
+    def __init__(  # noqa: D107  # tracked: #288
         self,
         path: Path,
         *,
@@ -122,27 +122,27 @@ class IssueBoard:
         try:
             loaded = json.loads(self.path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-            raise IssueBoardLoadError(
+            raise IssueBoardLoadError(  # noqa: TRY003  # tracked: #288
                 f"cannot load issue board {self.path}: invalid JSON: {exc}"
             ) from exc
         except OSError as exc:
-            raise IssueBoardLoadError(
+            raise IssueBoardLoadError(  # noqa: TRY003  # tracked: #288
                 f"cannot load issue board {self.path}: cannot read store: {exc}"
             ) from exc
         if not isinstance(loaded, dict):
-            raise IssueBoardLoadError(
+            raise IssueBoardLoadError(  # noqa: TRY003  # tracked: #288
                 f"cannot load issue board {self.path}: expected a JSON object"
             )
         version = loaded.get("version")
         if version != _STORE_VERSION:
-            raise IssueBoardLoadError(
+            raise IssueBoardLoadError(  # noqa: TRY003  # tracked: #288
                 f"cannot load issue board {self.path}: unsupported version "
                 f"{version!r}; expected {_STORE_VERSION}"
             )
         try:
             data = _IssueBoardData.model_validate(loaded)
         except ValidationError as exc:
-            raise IssueBoardLoadError(
+            raise IssueBoardLoadError(  # noqa: TRY003  # tracked: #288
                 f"cannot load issue board {self.path}: invalid store structure: {exc}"
             ) from exc
         return data.model_dump(mode="json")
@@ -150,12 +150,12 @@ class IssueBoard:
     def _save_locked(self) -> None:
         tmp = self.path.with_suffix(self.path.suffix + ".tmp")
         tmp.write_text(json.dumps(self._data, indent=2), encoding="utf-8")
-        os.replace(tmp, self.path)
+        os.replace(tmp, self.path)  # noqa: PTH105  # tracked: #288
         if self._on_change is not None:
             try:
                 self._on_change()
             except Exception:  # noqa: BLE001
-                print(
+                print(  # noqa: T201  # tracked: #288
                     "[IssueBoard] on_change callback raised; ignoring:",
                     file=sys.stderr,
                 )
@@ -174,21 +174,21 @@ class IssueBoard:
             if raw.get("id") == issue.id:
                 self._data["issues"][idx] = issue.model_dump(mode="json")
                 return
-        raise KeyError(f"issue #{issue.id} not found")
+        raise KeyError(f"issue #{issue.id} not found")  # noqa: TRY003  # tracked: #288
 
-    def create(
+    def create(  # noqa: D102  # tracked: #288
         self,
         *,
-        type: IssueType | str,
+        type: IssueType | str,  # noqa: A002  # tracked: #288
         title: str,
         description: str,
         created_by: str,
         iteration: int,
     ) -> Issue:
         if not isinstance(type, IssueType):
-            type = IssueType(type)
+            type = IssueType(type)  # noqa: A001  # tracked: #288
         with self._lock:
-            now = datetime.now().isoformat()
+            now = datetime.now().isoformat()  # noqa: DTZ005  # tracked: #288
             issue = Issue(
                 id=self._data["next_id"],
                 type=type,
@@ -214,14 +214,14 @@ class IssueBoard:
             self._save_locked()
             return issue
 
-    def get(self, issue_id: int) -> Issue | None:
+    def get(self, issue_id: int) -> Issue | None:  # noqa: D102  # tracked: #288
         with self._lock:
             for raw in self._data["issues"]:
                 if raw.get("id") == issue_id:
                     return self._issue_from_dict(raw)
         return None
 
-    def update_status(
+    def update_status(  # noqa: D102, PLR0913  # tracked: #288
         self,
         issue_id: int,
         status: IssueStatus | str,
@@ -236,8 +236,8 @@ class IssueBoard:
         with self._lock:
             issue = self.get(issue_id)
             if issue is None:
-                raise KeyError(f"issue #{issue_id} not found")
-            now = datetime.now().isoformat()
+                raise KeyError(f"issue #{issue_id} not found")  # noqa: TRY003  # tracked: #288
+            now = datetime.now().isoformat()  # noqa: DTZ005  # tracked: #288
             old_status = issue.status
             issue.status = status
             issue.updated_at = now
@@ -271,7 +271,7 @@ class IssueBoard:
                 if raw.get("status") != IssueStatus.BLOCKED.value:
                     continue
                 issue = self._issue_from_dict(raw)
-                now = datetime.now().isoformat()
+                now = datetime.now().isoformat()  # noqa: DTZ005  # tracked: #288
                 issue.status = IssueStatus.OPEN
                 issue.attempts = 0
                 issue.closed_iter = None
@@ -291,7 +291,7 @@ class IssueBoard:
                 self._save_locked()
         return reopened
 
-    def increment_attempts(
+    def increment_attempts(  # noqa: D102  # tracked: #288
         self,
         issue_id: int,
         *,
@@ -303,8 +303,8 @@ class IssueBoard:
         with self._lock:
             issue = self.get(issue_id)
             if issue is None:
-                raise KeyError(f"issue #{issue_id} not found")
-            now = datetime.now().isoformat()
+                raise KeyError(f"issue #{issue_id} not found")  # noqa: TRY003  # tracked: #288
+            now = datetime.now().isoformat()  # noqa: DTZ005  # tracked: #288
             issue.attempts += 1
             issue.updated_at = now
             issue.history.append(
@@ -321,16 +321,16 @@ class IssueBoard:
             self._save_locked()
             return issue
 
-    def list(
+    def list(  # noqa: D102  # tracked: #288
         self,
         *,
         status: IssueStatus | str | None = None,
-        type: IssueType | str | None = None,
+        type: IssueType | str | None = None,  # noqa: A002  # tracked: #288
     ) -> list[Issue]:
         if status is not None and not isinstance(status, IssueStatus):
             status = IssueStatus(status)
         if type is not None and not isinstance(type, IssueType):
-            type = IssueType(type)
+            type = IssueType(type)  # noqa: A001  # tracked: #288
         with self._lock:
             out: list[Issue] = []
             for raw in self._data["issues"]:

--- a/libs/vs-issue-board/src/vs_issue_board/format.py
+++ b/libs/vs-issue-board/src/vs_issue_board/format.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
+from __future__ import annotations  # noqa: D100  # tracked: #288
 
-from vs_issue_board.core import Issue
+from vs_issue_board.core import Issue  # noqa: TC001  # tracked: #288
 
 
 def format_issue_short(issue: Issue) -> str:

--- a/libs/vs-issue-board/src/vs_issue_board/mcp.py
+++ b/libs/vs-issue-board/src/vs_issue_board/mcp.py
@@ -18,19 +18,19 @@ def _parse_allowed_types(value: str) -> frozenset[IssueType]:
     """Argparse type= callable for ``--allowed-types``."""
     parts = [p.strip() for p in value.split(",") if p.strip()]
     if not parts:
-        raise argparse.ArgumentTypeError(
+        raise argparse.ArgumentTypeError(  # noqa: TRY003  # tracked: #288
             "--allowed-types may not be empty; pass a comma-separated subset of {bug,feature,perf}"
         )
     try:
         return frozenset(IssueType(p) for p in parts)
     except ValueError as exc:
-        raise argparse.ArgumentTypeError(
+        raise argparse.ArgumentTypeError(  # noqa: TRY003  # tracked: #288
             f"--allowed-types must be a comma-separated subset of "
             f"{{bug,feature,perf}}; got {value!r}"
         ) from exc
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser() -> argparse.ArgumentParser:  # noqa: D103  # tracked: #288
     parser = argparse.ArgumentParser(
         prog="vs-issue-board-mcp",
         description=(
@@ -126,7 +126,7 @@ def build_server(args: argparse.Namespace) -> FastMCP:
     if not args.read_only:
 
         @mcp.tool()
-        def create_issue(type: str, title: str, description: str) -> str:  # pyright: ignore[reportUnusedFunction]
+        def create_issue(type: str, title: str, description: str) -> str:  # pyright: ignore[reportUnusedFunction]  # noqa: A002  # tracked: #288
             """Create a new issue.
 
             Args:
@@ -146,7 +146,7 @@ def build_server(args: argparse.Namespace) -> FastMCP:
     return mcp
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: list[str] | None = None) -> None:  # noqa: D103  # tracked: #288
     args = build_parser().parse_args(argv)
     mcp = build_server(args)
     mcp.run(transport="stdio")

--- a/libs/vs-issue-board/src/vs_issue_board/mcp.py
+++ b/libs/vs-issue-board/src/vs_issue_board/mcp.py
@@ -15,7 +15,7 @@ _ALL_TYPES: frozenset[IssueType] = frozenset({IssueType.BUG, IssueType.FEATURE, 
 
 
 def _parse_allowed_types(value: str) -> frozenset[IssueType]:
-    """argparse type= callable for ``--allowed-types``."""
+    """Argparse type= callable for ``--allowed-types``."""
     parts = [p.strip() for p in value.split(",") if p.strip()]
     if not parts:
         raise argparse.ArgumentTypeError(

--- a/libs/vs-issue-board/src/vs_issue_board/policy.py
+++ b/libs/vs-issue-board/src/vs_issue_board/policy.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations  # noqa: D100  # tracked: #288
 
 from dataclasses import dataclass
 

--- a/libs/vs-issue-board/tests/test_issue_board_core.py
+++ b/libs/vs-issue-board/tests/test_issue_board_core.py
@@ -119,9 +119,7 @@ class TestLoadCorrupt:
             (2, [0], "greater than or equal to 1"),
         ],
     )
-    def test_load_rejects_invalid_issue_identity(
-        self, tmp_path, next_id, issue_ids, message
-    ):
+    def test_load_rejects_invalid_issue_identity(self, tmp_path, next_id, issue_ids, message):
         path = tmp_path / "issues.json"
         issues = [
             {

--- a/libs/vs-issue-board/tests/test_issue_board_core.py
+++ b/libs/vs-issue-board/tests/test_issue_board_core.py
@@ -16,12 +16,18 @@ from vs_issue_board import (
 )
 
 
-def _make_store(tmp_path) -> IssueBoard:
+def _make_store(tmp_path) -> IssueBoard:  # noqa: ANN001  # tracked: #288
     return IssueBoard(tmp_path / "issues.json")
 
 
-def _create(
-    store, *, type=IssueType.BUG, title="t", description="d", created_by="perf_eval", iteration=1
+def _create(  # noqa: PLR0913  # tracked: #288
+    store,  # noqa: ANN001  # tracked: #288
+    *,
+    type=IssueType.BUG,  # noqa: A002, ANN001  # tracked: #288
+    title="t",  # noqa: ANN001  # tracked: #288
+    description="d",  # noqa: ANN001  # tracked: #288
+    created_by="perf_eval",  # noqa: ANN001  # tracked: #288
+    iteration=1,  # noqa: A002, ANN001, RUF100  # tracked: #288
 ) -> Issue:
     return store.create(
         type=type,
@@ -38,14 +44,14 @@ def _create(
 
 
 class TestCreate:
-    def test_create_assigns_sequential_ids(self, tmp_path):
+    def test_create_assigns_sequential_ids(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         a = _create(store, title="a")
         b = _create(store, title="b")
         c = _create(store, title="c")
         assert (a.id, b.id, c.id) == (1, 2, 3)
 
-    def test_create_persists_atomically_to_disk(self, tmp_path):
+    def test_create_persists_atomically_to_disk(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         _create(store, title="persist me")
         # Reload from disk via a fresh store
@@ -56,7 +62,7 @@ class TestCreate:
         # No tmp file left behind
         assert not (tmp_path / "issues.json.tmp").exists()
 
-    def test_create_records_create_event_in_history(self, tmp_path):
+    def test_create_records_create_event_in_history(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         issue = _create(store, created_by="perf_eval", iteration=2)
         assert len(issue.history) == 1
@@ -65,7 +71,7 @@ class TestCreate:
         assert evt.action == "create"
         assert evt.iteration == 2
 
-    def test_create_accepts_string_type(self, tmp_path):
+    def test_create_accepts_string_type(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         issue = store.create(
             type="perf",
@@ -78,7 +84,7 @@ class TestCreate:
 
 
 class TestLoadCorrupt:
-    def test_load_corrupt_json_raises_without_replacing_file(self, tmp_path):
+    def test_load_corrupt_json_raises_without_replacing_file(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "issues.json"
         path.write_text("not json", encoding="utf-8")
         original = path.read_bytes()
@@ -88,7 +94,7 @@ class TestLoadCorrupt:
 
         assert path.read_bytes() == original
 
-    def test_load_wrong_version_raises_without_replacing_file(self, tmp_path):
+    def test_load_wrong_version_raises_without_replacing_file(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "issues.json"
         path.write_text(json.dumps({"version": 999, "next_id": 1, "issues": []}), encoding="utf-8")
         original = path.read_bytes()
@@ -98,7 +104,7 @@ class TestLoadCorrupt:
 
         assert path.read_bytes() == original
 
-    def test_load_invalid_store_structure_raises_without_replacing_file(self, tmp_path):
+    def test_load_invalid_store_structure_raises_without_replacing_file(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "issues.json"
         path.write_text(
             json.dumps({"version": 1, "next_id": 1, "issues": "not-a-list"}),
@@ -119,7 +125,7 @@ class TestLoadCorrupt:
             (2, [0], "greater than or equal to 1"),
         ],
     )
-    def test_load_rejects_invalid_issue_identity(self, tmp_path, next_id, issue_ids, message):
+    def test_load_rejects_invalid_issue_identity(self, tmp_path, next_id, issue_ids, message):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "issues.json"
         issues = [
             {
@@ -151,7 +157,7 @@ class TestLoadCorrupt:
             lambda payload: payload["issues"][0]["history"][0].update({"trace_id": "unknown"}),
         ],
     )
-    def test_load_rejects_unknown_nested_fields(self, tmp_path, mutate):
+    def test_load_rejects_unknown_nested_fields(self, tmp_path, mutate):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "issues.json"
         board = IssueBoard(path)
         _create(board, title="existing")
@@ -165,14 +171,14 @@ class TestLoadCorrupt:
 
         assert path.read_bytes() == original
 
-    def test_open_existing_does_not_overwrite_concurrent_write(self, tmp_path, monkeypatch):
+    def test_open_existing_does_not_overwrite_concurrent_write(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "issues.json"
         writer = IssueBoard(path)
         _create(writer, title="existing")
         original_read_text = Path.read_text
         wrote_concurrently = False
 
-        def read_then_write(target, *args, **kwargs):
+        def read_then_write(target, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202  # tracked: #288
             nonlocal wrote_concurrently
             content = original_read_text(target, *args, **kwargs)
             if target == path and not wrote_concurrently:
@@ -188,7 +194,7 @@ class TestLoadCorrupt:
 
 
 class TestReload:
-    def test_reload_picks_up_external_writes(self, tmp_path):
+    def test_reload_picks_up_external_writes(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store_a = _make_store(tmp_path)
         store_b = _make_store(tmp_path)
         _create(store_a, title="written by a")
@@ -198,7 +204,7 @@ class TestReload:
         assert len(store_b.list()) == 1
         assert store_b.list()[0].title == "written by a"
 
-    def test_reload_corrupt_json_raises_and_preserves_last_valid_snapshot(self, tmp_path):
+    def test_reload_corrupt_json_raises_and_preserves_last_valid_snapshot(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "issues.json"
         store = IssueBoard(path)
         _create(store, title="last valid")
@@ -211,7 +217,7 @@ class TestReload:
         assert [issue.title for issue in store.list()] == ["last valid"]
         assert path.read_bytes() == corrupt
 
-    def test_reload_wrong_version_raises_and_preserves_last_valid_snapshot(self, tmp_path):
+    def test_reload_wrong_version_raises_and_preserves_last_valid_snapshot(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "issues.json"
         store = IssueBoard(path)
         _create(store, title="last valid")
@@ -227,7 +233,7 @@ class TestReload:
         assert [issue.title for issue in store.list()] == ["last valid"]
         assert path.read_bytes() == incompatible
 
-    def test_reload_missing_file_raises_and_preserves_last_valid_snapshot(self, tmp_path):
+    def test_reload_missing_file_raises_and_preserves_last_valid_snapshot(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "issues.json"
         store = IssueBoard(path)
         _create(store, title="last valid")
@@ -245,7 +251,7 @@ class TestReload:
 
 
 class TestList:
-    def test_list_filters_by_status(self, tmp_path):
+    def test_list_filters_by_status(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         a = _create(store, title="a")
         b = _create(store, title="b")
@@ -255,16 +261,16 @@ class TestList:
         assert {i.id for i in opens} == {b.id}
         assert {i.id for i in closeds} == {a.id}
 
-    def test_list_filters_by_type(self, tmp_path):
+    def test_list_filters_by_type(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         _create(store, type=IssueType.BUG, title="bug")
         _create(store, type=IssueType.PERF, title="perf")
         bugs = store.list(type=IssueType.BUG)
         perfs = store.list(type=IssueType.PERF)
-        assert len(bugs) == 1 and bugs[0].title == "bug"
-        assert len(perfs) == 1 and perfs[0].title == "perf"
+        assert len(bugs) == 1 and bugs[0].title == "bug"  # noqa: PT018  # tracked: #288
+        assert len(perfs) == 1 and perfs[0].title == "perf"  # noqa: PT018  # tracked: #288
 
-    def test_list_accepts_string_filters(self, tmp_path):
+    def test_list_accepts_string_filters(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         _create(store, type=IssueType.BUG)
         bugs = store.list(status="open", type="bug")
@@ -277,7 +283,7 @@ class TestList:
 
 
 class TestSearch:
-    def test_search_substring_case_insensitive(self, tmp_path):
+    def test_search_substring_case_insensitive(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         _create(store, title="Add Paged KV cache", description="Reduce frag")
         _create(store, title="Other thing", description="unrelated")
@@ -285,7 +291,7 @@ class TestSearch:
         assert len(hits) == 1
         assert hits[0].title == "Add Paged KV cache"
 
-    def test_search_keyword_and_match(self, tmp_path):
+    def test_search_keyword_and_match(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         _create(store, title="Paged KV cache", description="memory frag")
         _create(store, title="Continuous batching", description="paged scheduler")
@@ -294,14 +300,14 @@ class TestSearch:
         assert len(hits) == 1
         assert hits[0].title == "Paged KV cache"
 
-    def test_search_empty_query_returns_empty(self, tmp_path):
+    def test_search_empty_query_returns_empty(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         _create(store)
         assert store.search("") == []
         assert store.search("   ") == []
         assert store.search(",,") == []
 
-    def test_search_no_match(self, tmp_path):
+    def test_search_no_match(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         _create(store, title="hello", description="world")
         assert store.search("xyzzy") == []
@@ -313,7 +319,7 @@ class TestSearch:
 
 
 class TestStateTransitions:
-    def test_update_status_records_history_event(self, tmp_path):
+    def test_update_status_records_history_event(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         issue = _create(store)
         store.update_status(
@@ -325,7 +331,7 @@ class TestStateTransitions:
         assert reloaded.history[-1].action == "open->in_progress"
         assert reloaded.history[-1].note == "claimed"
 
-    def test_update_status_to_closed_records_closed_iter(self, tmp_path):
+    def test_update_status_to_closed_records_closed_iter(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         issue = _create(store, iteration=1)
         store.update_status(issue.id, IssueStatus.IN_PROGRESS, actor="loop", iteration=2)
@@ -334,7 +340,7 @@ class TestStateTransitions:
         assert reloaded.status == IssueStatus.CLOSED
         assert reloaded.closed_iter == 2
 
-    def test_update_status_blocked_records_closed_iter(self, tmp_path):
+    def test_update_status_blocked_records_closed_iter(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         issue = _create(store, iteration=1)
         store.update_status(
@@ -344,7 +350,7 @@ class TestStateTransitions:
         assert reloaded.status == IssueStatus.BLOCKED
         assert reloaded.closed_iter == 3
 
-    def test_increment_attempts_appends_event(self, tmp_path):
+    def test_increment_attempts_appends_event(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         issue = _create(store)
         assert issue.attempts == 0
@@ -354,7 +360,7 @@ class TestStateTransitions:
         assert reloaded.attempts == 2
         assert sum(1 for e in reloaded.history if e.action == "attempt") == 2
 
-    def test_update_unknown_id_raises(self, tmp_path):
+    def test_update_unknown_id_raises(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         with pytest.raises(KeyError):
             store.update_status(999, IssueStatus.CLOSED, actor="x", iteration=1)
@@ -368,7 +374,7 @@ class TestStateTransitions:
 
 
 class TestCapHelper:
-    def test_open_count_by_creator_in_iter_counts_only_creator_and_iter(self, tmp_path):
+    def test_open_count_by_creator_in_iter_counts_only_creator_and_iter(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         _create(store, created_by="perf_eval", iteration=1)
         _create(store, created_by="perf_eval", iteration=1)
@@ -379,7 +385,7 @@ class TestCapHelper:
         assert store.open_count_by_creator_in_iter("judge", 1) == 1
         assert store.open_count_by_creator_in_iter("nobody", 1) == 0
 
-    def test_cap_helper_counts_closed_issues_too(self, tmp_path):
+    def test_cap_helper_counts_closed_issues_too(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         # Closing an issue mid-iteration must NOT free up cap budget.
         store = _make_store(tmp_path)
         a = _create(store, created_by="perf_eval", iteration=1)
@@ -393,17 +399,17 @@ class TestCapHelper:
 
 
 class TestNextOpen:
-    def test_next_open_returns_none_when_empty(self, tmp_path):
+    def test_next_open_returns_none_when_empty(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         assert store.next_open() is None
 
-    def test_next_open_returns_none_when_all_closed(self, tmp_path):
+    def test_next_open_returns_none_when_all_closed(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         a = _create(store)
         store.update_status(a.id, IssueStatus.CLOSED, actor="judge", iteration=1)
         assert store.next_open() is None
 
-    def test_next_open_orders_bug_before_feature_before_perf(self, tmp_path):
+    def test_next_open_orders_bug_before_feature_before_perf(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         # Insert in reverse priority order
         perf = _create(store, type=IssueType.PERF, title="perf")
@@ -418,7 +424,7 @@ class TestNextOpen:
         third = store.next_open()
         assert third.id == perf.id
 
-    def test_next_open_fifo_within_type(self, tmp_path):
+    def test_next_open_fifo_within_type(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         a = _create(store, type=IssueType.BUG, title="first bug")
         # Ensure a strict timestamp gap so created_at sort is stable
@@ -432,7 +438,7 @@ class TestNextOpen:
         store.update_status(b.id, IssueStatus.CLOSED, actor="x", iteration=1)
         assert store.next_open().id == c.id
 
-    def test_next_open_skips_in_progress(self, tmp_path):
+    def test_next_open_skips_in_progress(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         a = _create(store, type=IssueType.BUG, title="claimed")
         b = _create(store, type=IssueType.BUG, title="open")
@@ -447,7 +453,7 @@ class TestNextOpen:
 
 
 class TestEventPayload:
-    def test_payload_round_trip_through_disk(self, tmp_path):
+    def test_payload_round_trip_through_disk(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         issue = _create(store, title="payload test")
         payload = {
@@ -470,7 +476,7 @@ class TestEventPayload:
         assert last.action == "attempt"
         assert last.payload == payload
 
-    def test_payload_default_none_for_existing_call_sites(self, tmp_path):
+    def test_payload_default_none_for_existing_call_sites(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         issue = _create(store)
         store.update_status(
@@ -492,7 +498,7 @@ class TestEventPayload:
         for evt in reloaded.history:
             assert evt.payload is None
 
-    def test_load_old_json_without_payload_key(self, tmp_path):
+    def test_load_old_json_without_payload_key(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """A pre-feature issues.json whose history events lack the payload
         key must still load cleanly with payload=None defaults."""
         path = tmp_path / "issues.json"
@@ -538,7 +544,7 @@ class TestEventPayload:
 
 
 class TestReopenBlocked:
-    def test_reopens_blocked_issue_resets_attempts_and_status(self, tmp_path):
+    def test_reopens_blocked_issue_resets_attempts_and_status(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         a = _create(store, title="will block", iteration=1)
         store.increment_attempts(a.id, actor="implementer", iteration=1)
@@ -572,7 +578,7 @@ class TestReopenBlocked:
         assert last.iteration == 2
         assert last.note == "retried on resume"
 
-    def test_reopen_blocked_only_touches_blocked_issues(self, tmp_path):
+    def test_reopen_blocked_only_touches_blocked_issues(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         blocked = _create(store, title="blocked")
         open_issue = _create(store, title="open")
@@ -596,17 +602,19 @@ class TestReopenBlocked:
         assert store.get(open_issue.id).status == IssueStatus.OPEN
         assert store.get(closed.id).status == IssueStatus.CLOSED
 
-    def test_reopen_blocked_no_blocked_is_noop(self, tmp_path):
+    def test_reopen_blocked_no_blocked_is_noop(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         _create(store)
         cb = Mock()
-        store._on_change = cb  # bypass constructor wiring for this assertion
+        store._on_change = (  # noqa: SLF001  # tracked: #288
+            cb  # bypass constructor wiring for this assertion  # noqa: RUF100, SLF001  # tracked: #288
+        )
         reopened = store.reopen_blocked(actor="loop:resume", iteration=1)
         assert reopened == []
         # No mutation -> no callback fired (and importantly no save).
         assert cb.call_count == 0
 
-    def test_reopen_blocked_persists_to_disk(self, tmp_path):
+    def test_reopen_blocked_persists_to_disk(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         a = _create(store)
         store.update_status(a.id, IssueStatus.BLOCKED, actor="loop", iteration=1)
@@ -619,7 +627,7 @@ class TestReopenBlocked:
         assert reloaded.closed_iter is None
         assert reloaded.history[-1].action == "blocked->open"
 
-    def test_reopen_blocked_picked_by_next_open(self, tmp_path):
+    def test_reopen_blocked_picked_by_next_open(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         a = _create(store, type=IssueType.BUG)
         store.update_status(a.id, IssueStatus.BLOCKED, actor="loop", iteration=1)
@@ -631,7 +639,7 @@ class TestReopenBlocked:
 
 
 class TestOnChangeCallback:
-    def test_callback_fires_on_each_mutation(self, tmp_path):
+    def test_callback_fires_on_each_mutation(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cb = Mock()
         store = IssueBoard(tmp_path / "issues.json", on_change=cb)
         # Bootstrap save in __init__ must NOT fire the callback.
@@ -655,7 +663,7 @@ class TestOnChangeCallback:
         )
         assert cb.call_count == 3
 
-    def test_callback_failure_does_not_corrupt_store(self, tmp_path):
+    def test_callback_failure_does_not_corrupt_store(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "issues.json"
         cb = Mock(side_effect=RuntimeError("renderer exploded"))
         store = IssueBoard(path, on_change=cb)

--- a/libs/vs-issue-board/tests/test_mcp.py
+++ b/libs/vs-issue-board/tests/test_mcp.py
@@ -14,16 +14,16 @@ from vs_issue_board import IssueType
 from vs_issue_board.mcp import build_parser, build_server
 
 
-def _ns(tmp_path, *extra: str):
+def _ns(tmp_path, *extra: str):  # noqa: ANN001, ANN202  # tracked: #288
     return build_parser().parse_args([str(tmp_path / "issues.json"), *extra])
 
 
-async def _list_tool_names(server) -> set[str]:
+async def _list_tool_names(server) -> set[str]:  # noqa: ANN001  # tracked: #288
     tools = await server.list_tools()
     return {t.name for t in tools}
 
 
-async def _call_tool(server, name: str, **kwargs) -> str:
+async def _call_tool(server, name: str, **kwargs) -> str:  # noqa: ANN001, ANN003  # tracked: #288
     """Invoke an MCP tool and return its string result.
 
     FastMCP.call_tool returns ``(content_blocks, structured_dict)``; for our
@@ -39,7 +39,7 @@ async def _call_tool(server, name: str, **kwargs) -> str:
 
 
 class TestArgparse:
-    def test_defaults(self, tmp_path):
+    def test_defaults(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         args = _ns(tmp_path)
         assert args.store_path == tmp_path / "issues.json"
         assert args.creator == "agent"
@@ -48,7 +48,7 @@ class TestArgparse:
         assert args.allowed_types == frozenset({IssueType.BUG, IssueType.FEATURE, IssueType.PERF})
         assert args.read_only is False
 
-    def test_full_judge_policy(self, tmp_path):
+    def test_full_judge_policy(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         args = _ns(
             tmp_path,
             "--creator",
@@ -65,23 +65,23 @@ class TestArgparse:
         assert args.cap == 1
         assert args.allowed_types == frozenset({IssueType.BUG})
 
-    def test_allowed_types_subset(self, tmp_path):
+    def test_allowed_types_subset(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         args = _ns(tmp_path, "--allowed-types", "bug,perf")
         assert args.allowed_types == frozenset({IssueType.BUG, IssueType.PERF})
 
-    def test_allowed_types_with_whitespace(self, tmp_path):
+    def test_allowed_types_with_whitespace(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         args = _ns(tmp_path, "--allowed-types", "bug, perf , feature")
         assert args.allowed_types == frozenset({IssueType.BUG, IssueType.FEATURE, IssueType.PERF})
 
-    def test_allowed_types_rejects_garbage(self, tmp_path):
+    def test_allowed_types_rejects_garbage(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         with pytest.raises(SystemExit):
             _ns(tmp_path, "--allowed-types", "bug,nonsense")
 
-    def test_allowed_types_rejects_empty(self, tmp_path):
+    def test_allowed_types_rejects_empty(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         with pytest.raises(SystemExit):
             _ns(tmp_path, "--allowed-types", " , ")
 
-    def test_read_only_flag(self, tmp_path):
+    def test_read_only_flag(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         args = _ns(tmp_path, "--read-only")
         assert args.read_only is True
 
@@ -92,7 +92,7 @@ class TestArgparse:
 
 
 class TestToolRegistration:
-    def test_writable_registers_all_four(self, tmp_path):
+    def test_writable_registers_all_four(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         server = build_server(_ns(tmp_path))
         names = asyncio.run(_list_tool_names(server))
         assert names == {
@@ -102,7 +102,7 @@ class TestToolRegistration:
             "create_issue",
         }
 
-    def test_read_only_omits_create_issue(self, tmp_path):
+    def test_read_only_omits_create_issue(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         server = build_server(_ns(tmp_path, "--read-only"))
         names = asyncio.run(_list_tool_names(server))
         assert names == {"list_issues", "get_issue", "search_issues"}
@@ -115,12 +115,12 @@ class TestToolRegistration:
 
 
 class TestEndToEnd:
-    def test_list_empty_store(self, tmp_path):
+    def test_list_empty_store(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         server = build_server(_ns(tmp_path))
         out = asyncio.run(_call_tool(server, "list_issues"))
         assert out == "(no issues)"
 
-    def test_create_then_list(self, tmp_path):
+    def test_create_then_list(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         server = build_server(_ns(tmp_path, "--creator", "perf_eval"))
         created = asyncio.run(
             _call_tool(
@@ -137,7 +137,7 @@ class TestEndToEnd:
         assert "[perf]" in listed
         assert "paged kv" in listed
 
-    def test_judge_policy_caps_at_one(self, tmp_path):
+    def test_judge_policy_caps_at_one(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         server = build_server(
             _ns(
                 tmp_path,
@@ -170,7 +170,7 @@ class TestEndToEnd:
         )
         assert "cap reached" in msg2
 
-    def test_judge_policy_rejects_disallowed_type(self, tmp_path):
+    def test_judge_policy_rejects_disallowed_type(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         server = build_server(
             _ns(
                 tmp_path,
@@ -194,7 +194,7 @@ class TestEndToEnd:
         assert "may only file types" in msg
         assert "'judge'" in msg
 
-    def test_search_returns_short_lines(self, tmp_path):
+    def test_search_returns_short_lines(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         server = build_server(_ns(tmp_path, "--creator", "perf_eval"))
         asyncio.run(
             _call_tool(
@@ -218,7 +218,7 @@ class TestEndToEnd:
         assert "Add paged KV" in out
         assert "unrelated" not in out
 
-    def test_get_issue_returns_full_body(self, tmp_path):
+    def test_get_issue_returns_full_body(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         server = build_server(_ns(tmp_path, "--creator", "perf_eval"))
         asyncio.run(
             _call_tool(
@@ -235,12 +235,12 @@ class TestEndToEnd:
         assert "paged kv" in out
         assert "reduce frag" in out
 
-    def test_get_issue_unknown_id(self, tmp_path):
+    def test_get_issue_unknown_id(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         server = build_server(_ns(tmp_path))
         out = asyncio.run(_call_tool(server, "get_issue", issue_id=999))
         assert out == "(no issue #999)"
 
-    def test_list_invalid_status_returns_error(self, tmp_path):
+    def test_list_invalid_status_returns_error(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         server = build_server(_ns(tmp_path))
         out = asyncio.run(_call_tool(server, "list_issues", status="banana"))
         assert out.startswith("error:")

--- a/libs/vs-issue-board/tests/test_policy_and_format.py
+++ b/libs/vs-issue-board/tests/test_policy_and_format.py
@@ -16,7 +16,7 @@ from vs_issue_board.policy import (
 )
 
 
-def _make_store(tmp_path) -> IssueBoard:
+def _make_store(tmp_path) -> IssueBoard:  # noqa: ANN001  # tracked: #288
     return IssueBoard(tmp_path / "issues.json")
 
 
@@ -30,13 +30,13 @@ def _all_types() -> frozenset[IssueType]:
 
 
 class TestParseType:
-    def test_parse_each_value(self):
+    def test_parse_each_value(self):  # noqa: ANN201  # tracked: #288
         assert parse_type("bug") is IssueType.BUG
         assert parse_type("feature") is IssueType.FEATURE
         assert parse_type("perf") is IssueType.PERF
 
-    def test_garbage_raises_value_error(self):
-        with pytest.raises(ValueError):
+    def test_garbage_raises_value_error(self):  # noqa: ANN201  # tracked: #288
+        with pytest.raises(ValueError):  # noqa: PT011  # tracked: #288
             parse_type("enhancement")
 
 
@@ -46,7 +46,7 @@ class TestParseType:
 
 
 class TestCheckCreateAllowed:
-    def test_in_allowlist_no_cap_returns_none(self, tmp_path):
+    def test_in_allowlist_no_cap_returns_none(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         policy = CreateIssuePolicy(
             creator="x",
@@ -56,7 +56,7 @@ class TestCheckCreateAllowed:
         )
         assert check_create_allowed(store, type_enum=IssueType.BUG, policy=policy) is None
 
-    def test_out_of_allowlist_returns_error(self, tmp_path):
+    def test_out_of_allowlist_returns_error(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         policy = CreateIssuePolicy(
             creator="judge",
@@ -71,7 +71,7 @@ class TestCheckCreateAllowed:
         assert "'judge'" in err
         assert "'perf'" in err
 
-    def test_cap_enforced_against_persisted_store(self, tmp_path):
+    def test_cap_enforced_against_persisted_store(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         policy = CreateIssuePolicy(
             creator="judge",
@@ -95,7 +95,7 @@ class TestCheckCreateAllowed:
         assert "cap reached" in err
         assert "(1/1)" in err
 
-    def test_cap_scoped_per_iteration(self, tmp_path):
+    def test_cap_scoped_per_iteration(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         store.create(
             type=IssueType.BUG,
@@ -113,7 +113,7 @@ class TestCheckCreateAllowed:
         )
         assert check_create_allowed(store, type_enum=IssueType.BUG, policy=policy) is None
 
-    def test_cap_scoped_per_creator(self, tmp_path):
+    def test_cap_scoped_per_creator(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         store.create(
             type=IssueType.BUG,
@@ -138,7 +138,7 @@ class TestCheckCreateAllowed:
 
 
 class TestCreateIssueUnderPolicy:
-    def test_happy_path_returns_issue_and_message(self, tmp_path):
+    def test_happy_path_returns_issue_and_message(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         policy = CreateIssuePolicy(
             creator="perf_eval",
@@ -159,7 +159,7 @@ class TestCreateIssueUnderPolicy:
         assert issue.created_iter == 1
         assert msg == "created issue #1"
 
-    def test_invalid_type_returns_none_and_error(self, tmp_path):
+    def test_invalid_type_returns_none_and_error(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         policy = CreateIssuePolicy(
             creator="perf_eval",
@@ -181,7 +181,7 @@ class TestCreateIssueUnderPolicy:
         # Nothing was written.
         assert store.list() == []
 
-    def test_cap_rejects_after_full(self, tmp_path):
+    def test_cap_rejects_after_full(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         policy = CreateIssuePolicy(
             creator="perf_eval",
@@ -212,7 +212,7 @@ class TestCreateIssueUnderPolicy:
         # Store still has only 2.
         assert len(store.list()) == 2
 
-    def test_unlimited_cap(self, tmp_path):
+    def test_unlimited_cap(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         policy = CreateIssuePolicy(
             creator="x",
@@ -238,7 +238,7 @@ class TestCreateIssueUnderPolicy:
 
 
 class TestFormatHelpers:
-    def test_format_issue_short_byte_for_byte(self, tmp_path):
+    def test_format_issue_short_byte_for_byte(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         issue = store.create(
             type=IssueType.PERF,
@@ -249,7 +249,7 @@ class TestFormatHelpers:
         )
         assert format_issue_short(issue) == "#1 [perf] [open] paged kv"
 
-    def test_format_issue_full_byte_for_byte(self, tmp_path):
+    def test_format_issue_full_byte_for_byte(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         issue = store.create(
             type=IssueType.BUG,

--- a/libs/vs-sandbox/src/vs_sandbox/__init__.py
+++ b/libs/vs-sandbox/src/vs_sandbox/__init__.py
@@ -45,9 +45,9 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> Any:  # noqa: ANN401  # tracked: #288
     if name == "DockerSandbox":
-        from vs_sandbox.docker_sandbox import DockerSandbox
+        from vs_sandbox.docker_sandbox import DockerSandbox  # noqa: PLC0415  # tracked: #288
 
         return DockerSandbox
     if name in {
@@ -57,23 +57,25 @@ def __getattr__(name: str) -> Any:
         "HostResourceDeclarer",
         "declare_resources",
     }:
-        from vs_sandbox import host_resources
+        from vs_sandbox import host_resources  # noqa: PLC0415  # tracked: #288
 
         return getattr(host_resources, name)
     if name in {"HostSandbox", "SeatbeltSandbox", "WorkspaceSandbox"}:
-        from vs_sandbox import host_sandbox
+        from vs_sandbox import host_sandbox  # noqa: PLC0415  # tracked: #288
 
         return getattr(host_sandbox, name)
     if name == "build_host_sandbox":
-        from vs_sandbox.host_sandbox import build
+        from vs_sandbox.host_sandbox import build  # noqa: PLC0415  # tracked: #288
 
         return build
     if name == "ModalSandbox":
-        from vs_sandbox.modal_sandbox import ModalSandbox
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415  # tracked: #288
 
         return ModalSandbox
     if name == "ensure_model_volume":
-        from vs_sandbox.modal_model_setup import ensure_model_volume
+        from vs_sandbox.modal_model_setup import (  # noqa: PLC0415  # tracked: #288
+            ensure_model_volume,
+        )
 
         return ensure_model_volume
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # noqa: TRY003  # tracked: #288

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -518,10 +518,7 @@ class DockerSandbox(BaseSandbox):
                     removed = (
                         result.returncode == 0
                         or "No such container" in stderr
-                        or (
-                            "removal of container" in stderr
-                            and "is already in progress" in stderr
-                        )
+                        or ("removal of container" in stderr and "is already in progress" in stderr)
                     )
                     if not removed:
                         cleanup_error = RuntimeError(

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -10,7 +10,7 @@ import signal
 import subprocess
 import tempfile
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -33,25 +33,25 @@ _live_containers: dict[str, str] = {}  # container_id -> container_name
 def _cleanup_containers() -> None:
     """Stop and remove all tracked containers."""
     for container_id, _name in list(_live_containers.items()):
-        try:
-            subprocess.run(
-                ["docker", "stop", container_id],
+        try:  # noqa: SIM105  # tracked: #288
+            subprocess.run(  # noqa: S603  # tracked: #288
+                ["docker", "stop", container_id],  # noqa: S607  # tracked: #288
                 capture_output=True,
                 text=True,
                 check=False,
                 timeout=30,
             )
-        except Exception:
+        except Exception:  # noqa: BLE001, S110  # tracked: #288
             pass
         try:
-            removed = subprocess.run(
-                ["docker", "rm", "-f", container_id],
+            removed = subprocess.run(  # noqa: S603  # tracked: #288
+                ["docker", "rm", "-f", container_id],  # noqa: S607  # tracked: #288
                 capture_output=True,
                 text=True,
                 check=False,
                 timeout=10,
             )
-        except Exception:
+        except Exception:  # noqa: BLE001, S112  # tracked: #288
             continue
         if removed.returncode == 0 or "No such container" in (removed.stderr or ""):
             _live_containers.pop(container_id, None)
@@ -99,7 +99,7 @@ class DockerSandbox(BaseSandbox):
 
     _CONTAINER_ROOT = "/workspace"
 
-    def __init__(
+    def __init__(  # noqa: D417, PLR0913  # tracked: #288
         self,
         host_workspace: str,
         image: str,
@@ -108,7 +108,7 @@ class DockerSandbox(BaseSandbox):
         group_add: list[str] | None = None,
         entrypoint: str | None = None,
         shm_size: str | None = None,
-        auto_remove: bool = False,
+        auto_remove: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
         default_timeout: int = 300,
         start_timeout: int = 120,
         max_output_bytes: int = 100_000,
@@ -235,10 +235,10 @@ class DockerSandbox(BaseSandbox):
             return self._CONTAINER_ROOT + path
         return path  # relative — resolved against workdir by the shell
 
-    def ls_info(self, path: str):
+    def ls_info(self, path: str):  # noqa: ANN201, D102  # tracked: #288
         return super().ls_info(self._vpath(path))
 
-    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> str:
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> str:  # noqa: D102  # tracked: #288
         return super().read(self._vpath(file_path), offset, limit)
 
     def write(self, file_path: str, content: str) -> WriteResult:
@@ -249,48 +249,52 @@ class DockerSandbox(BaseSandbox):
         (``E2BIG``).  Using ``docker cp`` via a temp file avoids the limit.
         """
         if self._container_id is None:
-            raise RuntimeError("Container not started — call start() first")
+            raise RuntimeError("Container not started — call start() first")  # noqa: TRY003  # tracked: #288
 
         container_path = self._vpath(file_path)
 
         # Ensure parent directory exists inside the container
         parent = str(Path(container_path).parent)
         mkdir_cmd = ["docker", "exec", self._container_id, "mkdir", "-p", parent]
-        subprocess.run(mkdir_cmd, capture_output=True, check=False)
+        subprocess.run(mkdir_cmd, capture_output=True, check=False)  # noqa: S603  # tracked: #288
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".tmp", delete=True) as tmp:
             tmp.write(content)
             tmp.flush()
             cp_cmd = ["docker", "cp", tmp.name, f"{self._container_id}:{container_path}"]
             self._log_cmd(cp_cmd)
-            result = subprocess.run(cp_cmd, capture_output=True, text=True, check=False)
+            result = subprocess.run(cp_cmd, capture_output=True, text=True, check=False)  # noqa: S603  # tracked: #288
             self._log_cmd(cp_cmd, result)
 
         if result.returncode != 0:
             return WriteResult(path=file_path, error=result.stderr.strip())
         return WriteResult(path=file_path)
 
-    def edit(
-        self, file_path: str, old_string: str, new_string: str, replace_all: bool = False
+    def edit(  # noqa: D102  # tracked: #288
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> EditResult:
         return super().edit(self._vpath(file_path), old_string, new_string, replace_all)
 
-    def glob_info(self, pattern: str, path: str = "/"):
+    def glob_info(self, pattern: str, path: str = "/"):  # noqa: ANN201, D102  # tracked: #288
         return super().glob_info(pattern, self._vpath(path))
 
-    def grep_raw(self, pattern: str, path: str | None = None, glob: str | None = None):
+    def grep_raw(self, pattern: str, path: str | None = None, glob: str | None = None):  # noqa: ANN201, D102  # tracked: #288
         # Check container is still running before issuing grep; a dead
         # container causes docker-exec to emit an error on stderr that the
         # parent parser cannot parse (e.g. "No such container").
         if self._container_id is not None:
-            check = subprocess.run(
-                ["docker", "inspect", "--format={{.State.Running}}", self._container_id],
+            check = subprocess.run(  # noqa: S603  # tracked: #288
+                ["docker", "inspect", "--format={{.State.Running}}", self._container_id],  # noqa: S607  # tracked: #288
                 capture_output=True,
                 text=True,
                 check=False,
             )
             if check.returncode != 0 or "true" not in check.stdout.lower():
-                raise RuntimeError(f"Docker container {self._container_id} is no longer running")
+                raise RuntimeError(f"Docker container {self._container_id} is no longer running")  # noqa: TRY003  # tracked: #288
         return super().grep_raw(
             pattern,
             self._vpath(path) if path is not None else self._CONTAINER_ROOT,
@@ -316,7 +320,7 @@ class DockerSandbox(BaseSandbox):
         # Fallback: pass through as-is (e.g. user explicitly set gpus="device=0")
         return gpus
 
-    def start(self) -> None:
+    def start(self) -> None:  # noqa: C901, PLR0912  # tracked: #288
         """Start the Docker container."""
         self._container_name = f"vibesys-{uuid.uuid4().hex[:12]}"
         cmd = [
@@ -371,7 +375,7 @@ class DockerSandbox(BaseSandbox):
 
         self._log_cmd(cmd)
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # noqa: S603  # tracked: #288
                 cmd,
                 capture_output=True,
                 text=True,
@@ -383,7 +387,7 @@ class DockerSandbox(BaseSandbox):
                 cmd,
                 error=f"docker run timed out after {self._start_timeout}s",
             )
-            raise RuntimeError(
+            raise RuntimeError(  # noqa: TRY003  # tracked: #288
                 "Timed out starting Docker container after "
                 f"{self._start_timeout}s. If this is the first run, pre-pull "
                 f"the image with `docker pull {self._image}`; otherwise check "
@@ -396,7 +400,7 @@ class DockerSandbox(BaseSandbox):
                 self._container_id = container_id
                 _live_containers[container_id] = self._container_name
                 self._discard_started_container()
-            raise RuntimeError(
+            raise RuntimeError(  # noqa: TRY003  # tracked: #288
                 f"Failed to start Docker container (exit {result.returncode}):\n"
                 f"  stdout: {result.stdout.strip()}\n"
                 f"  stderr: {result.stderr.strip()}\n"
@@ -415,7 +419,7 @@ class DockerSandbox(BaseSandbox):
         """Finish startup after Docker has created and registered the container."""
         container_id = self._container_id
         if container_id is None:
-            raise RuntimeError("Container was not created before initialization")
+            raise RuntimeError("Container was not created before initialization")  # noqa: TRY003  # tracked: #288
 
         # Save metadata for vibesys-shell to reconstruct the environment
         self._metadata = {
@@ -434,7 +438,7 @@ class DockerSandbox(BaseSandbox):
         # Install uv (with timeout to avoid hanging on network issues)
         uv_cmd = ["docker", "exec", container_id, "bash", "-c", "pip install uv"]
         try:
-            uv_result = subprocess.run(
+            uv_result = subprocess.run(  # noqa: S603  # tracked: #288
                 uv_cmd,
                 capture_output=True,
                 text=True,
@@ -459,7 +463,7 @@ class DockerSandbox(BaseSandbox):
             ]
             self._log_cmd(init_cmd)
             try:
-                init_result = subprocess.run(
+                init_result = subprocess.run(  # noqa: S603  # tracked: #288
                     init_cmd,
                     capture_output=True,
                     text=True,
@@ -468,7 +472,7 @@ class DockerSandbox(BaseSandbox):
                 )
                 self._log_cmd(init_cmd, init_result)
                 if init_result.returncode != 0:
-                    raise RuntimeError(
+                    raise RuntimeError(  # noqa: TRY003  # tracked: #288
                         f"Container init command failed (exit {init_result.returncode}):\n"
                         f"  command: {init_cmd_str}\n"
                         f"  stdout: {init_result.stdout.strip()[:500]}\n"
@@ -476,7 +480,7 @@ class DockerSandbox(BaseSandbox):
                     )
             except subprocess.TimeoutExpired as exc:
                 self._log_cmd(init_cmd, error=f"init command timed out after 600s: {init_cmd_str}")
-                raise RuntimeError(
+                raise RuntimeError(  # noqa: TRY003  # tracked: #288
                     f"Container init command timed out after 600s: {init_cmd_str}"
                 ) from exc
 
@@ -505,7 +509,7 @@ class DockerSandbox(BaseSandbox):
         removed = False
         for cmd, timeout in commands:
             try:
-                result = subprocess.run(
+                result = subprocess.run(  # noqa: S603  # tracked: #288
                     cmd,
                     capture_output=True,
                     text=True,
@@ -525,12 +529,12 @@ class DockerSandbox(BaseSandbox):
                             f"Failed to remove Docker container {container_id} "
                             f"(exit {result.returncode}): {result.stderr.strip()}"
                         )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001  # tracked: #288
                 if cmd[1] == "rm":
                     cleanup_error = exc
-                try:
+                try:  # noqa: SIM105  # tracked: #288
                     self._log_cmd(cmd, error=f"container cleanup failed: {exc}")
-                except Exception:
+                except Exception:  # noqa: BLE001, S110  # tracked: #288
                     pass
 
         if not removed and cleanup_error is not None and not suppress_errors:
@@ -575,7 +579,7 @@ class DockerSandbox(BaseSandbox):
     ) -> ExecuteResponse:
         """Execute a command inside the Docker container."""
         if self._container_id is None:
-            raise RuntimeError("Container not started — call start() first")
+            raise RuntimeError("Container not started — call start() first")  # noqa: TRY003  # tracked: #288
 
         effective_timeout = timeout if timeout is not None else self._default_timeout
 
@@ -591,7 +595,7 @@ class DockerSandbox(BaseSandbox):
         ]
         self._log_cmd(exec_cmd)
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # noqa: PLW1510, S603  # tracked: #288
                 exec_cmd,
                 capture_output=True,
                 text=True,
@@ -638,7 +642,7 @@ class DockerSandbox(BaseSandbox):
     ) -> list[FileUploadResponse]:
         """Upload files into the container using docker cp."""
         if self._container_id is None:
-            raise RuntimeError("Container not started — call start() first")
+            raise RuntimeError("Container not started — call start() first")  # noqa: TRY003  # tracked: #288
 
         results: list[FileUploadResponse] = []
 
@@ -651,7 +655,7 @@ class DockerSandbox(BaseSandbox):
                 # Ensure parent dir exists
                 parent = str(Path(container_path).parent)
                 mkdir_cmd = ["docker", "exec", self._container_id, "mkdir", "-p", parent]
-                subprocess.run(
+                subprocess.run(  # noqa: S603  # tracked: #288
                     mkdir_cmd,
                     capture_output=True,
                     check=False,
@@ -659,7 +663,7 @@ class DockerSandbox(BaseSandbox):
                 self._log_cmd(mkdir_cmd)
 
                 cp_cmd = ["docker", "cp", tmp.name, f"{self._container_id}:{container_path}"]
-                result = subprocess.run(
+                result = subprocess.run(  # noqa: S603  # tracked: #288
                     cp_cmd,
                     capture_output=True,
                     text=True,
@@ -680,7 +684,7 @@ class DockerSandbox(BaseSandbox):
     ) -> list[FileDownloadResponse]:
         """Download files from the container using docker cp."""
         if self._container_id is None:
-            raise RuntimeError("Container not started — call start() first")
+            raise RuntimeError("Container not started — call start() first")  # noqa: TRY003  # tracked: #288
 
         results: list[FileDownloadResponse] = []
 
@@ -691,7 +695,7 @@ class DockerSandbox(BaseSandbox):
                 tmp_path = tmp.name
 
             cp_cmd = ["docker", "cp", f"{self._container_id}:{container_path}", tmp_path]
-            result = subprocess.run(
+            result = subprocess.run(  # noqa: S603  # tracked: #288
                 cp_cmd,
                 capture_output=True,
                 text=True,
@@ -710,9 +714,9 @@ class DockerSandbox(BaseSandbox):
 
         return results
 
-    def __enter__(self) -> DockerSandbox:
+    def __enter__(self) -> DockerSandbox:  # noqa: D105  # tracked: #288
         self.start()
         return self
 
-    def __exit__(self, *exc: object) -> None:
+    def __exit__(self, *exc: object) -> None:  # noqa: D105  # tracked: #288
         self.stop()

--- a/libs/vs-sandbox/src/vs_sandbox/host_resource_importer.py
+++ b/libs/vs-sandbox/src/vs_sandbox/host_resource_importer.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 from vs_sandbox.host_resources import HostResource, HostResourceAccess
 

--- a/libs/vs-sandbox/src/vs_sandbox/host_resources.py
+++ b/libs/vs-sandbox/src/vs_sandbox/host_resources.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 
 class HostResourceAccess(StrEnum):

--- a/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
@@ -50,12 +50,12 @@ from __future__ import annotations
 import shutil
 import sys
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from vs_sandbox.host_resource_importer import prepare_host_resource_imports
-from vs_sandbox.host_resources import HostResource
+from vs_sandbox.host_resources import HostResource  # noqa: TC001  # tracked: #288
 
 DISABLE_ENV = "VIBESYS_AGENT_SANDBOX"
 
@@ -149,7 +149,7 @@ class HostSandbox(WorkspaceSandbox):
             "--dev",
             "/dev",
             "--tmpfs",
-            "/tmp",
+            "/tmp",  # noqa: S108  # tracked: #288
         ]
         # Leaf config mounts such as ~/.codex/auth.json need their destination
         # parents to exist in bubblewrap's otherwise-empty /home tree. These

--- a/libs/vs-sandbox/src/vs_sandbox/modal_model_setup.py
+++ b/libs/vs-sandbox/src/vs_sandbox/modal_model_setup.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import os
 import re
-from collections.abc import Callable
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
 
 import modal
 
@@ -32,7 +32,7 @@ def _volume_is_ready(volume: modal.Volume) -> bool:
     """Return True if the volume has a ``_READY_SENTINEL`` marker at its root."""
     try:
         entries = volume.listdir("/")
-    except Exception:
+    except Exception:  # noqa: BLE001  # tracked: #288
         return False
     ready_name = _READY_SENTINEL.lstrip("/")
     return any(e.path.lstrip("/") == ready_name for e in entries)
@@ -72,7 +72,7 @@ def ensure_model_volume(
         The name of the Modal Volume that was ensured.  Pass this as
         ``--modal-model-volume``.
     """
-    from pathlib import Path
+    from pathlib import Path  # noqa: PLC0415  # tracked: #288
 
     vol_name = _volume_name_for(model_id)
     volume = modal.Volume.from_name(vol_name, create_if_missing=True)
@@ -124,10 +124,10 @@ def ensure_model_volume(
         serialized=True,
     )
     def _download(mid: str, rev: str | None, sentinel: str) -> None:
-        import os as _os
-        from pathlib import Path
+        import os as _os  # noqa: PLC0415  # tracked: #288
+        from pathlib import Path  # noqa: PLC0415  # tracked: #288
 
-        from huggingface_hub import snapshot_download
+        from huggingface_hub import snapshot_download  # noqa: PLC0415  # tracked: #288
 
         snapshot_download(
             mid,

--- a/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
@@ -333,7 +333,8 @@ class ModalSandbox(BaseSandbox):
     def _create_container(self) -> None:
         """Create (or recreate) the Modal sandbox container on top of the
         already-populated workspace volume. Shared by ``start`` and
-        ``_restart_sandbox``."""
+        ``_restart_sandbox``.
+        """
         app = modal.App.lookup(self._app_name, create_if_missing=True)
         # Clear the image's /workspace dir so our Volume can mount there —
         # the nvcr.io pytorch image ships with a populated /workspace that

--- a/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
@@ -26,7 +26,7 @@ import socket
 import tempfile
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, TypeVar, cast
 
@@ -38,7 +38,7 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.sandbox import BaseSandbox
-from modal.volume import AbstractVolumeUploadContextManager
+from modal.volume import AbstractVolumeUploadContextManager  # noqa: TC002  # tracked: #288
 
 if TYPE_CHECKING:
     from types import FrameType
@@ -134,16 +134,16 @@ def _retry_transient(
                     f"{exc}; retrying in {delay:.1f}s"
                 )
             time.sleep(delay)
-    assert last_exc is not None  # unreachable
+    assert last_exc is not None  # unreachable  # noqa: S101  # tracked: #288
     raise last_exc
 
 
 def _cleanup_sandboxes() -> None:
     """Terminate all tracked sandboxes and delete their ephemeral volumes."""
     for sb_id, sb in list(_live_sandboxes.items()):
-        try:
+        try:  # noqa: SIM105  # tracked: #288
             sb.stop()
-        except Exception:
+        except Exception:  # noqa: BLE001, S110  # tracked: #288
             pass
         _live_sandboxes.pop(sb_id, None)
 
@@ -175,7 +175,7 @@ class ModalSandbox(BaseSandbox):
 
     _CONTAINER_ROOT = "/workspace"
 
-    def __init__(
+    def __init__(  # noqa: D417, PLR0913  # tracked: #288
         self,
         host_workspace: str,
         image: str,
@@ -194,7 +194,7 @@ class ModalSandbox(BaseSandbox):
         extra_init_commands: list[str] | None = None,
         setup_fns: list[Callable[[BaseSandbox], None]] | None = None,
         app_name: str = "vibesys",
-        enable_fallback_restart: bool = True,
+        enable_fallback_restart: bool = True,  # noqa: FBT001, FBT002  # tracked: #288
         max_restart_attempts: int = 2,
     ) -> None:
         """Initialize the Modal sandbox configuration.
@@ -295,19 +295,19 @@ class ModalSandbox(BaseSandbox):
             return self._CONTAINER_ROOT + path
         return path
 
-    def ls_info(self, path: str):
+    def ls_info(self, path: str):  # noqa: ANN201, D102  # tracked: #288
         return super().ls_info(self._vpath(path))
 
-    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> str:
+    def read(self, file_path: str, offset: int = 0, limit: int = 2000) -> str:  # noqa: D102  # tracked: #288
         return super().read(self._vpath(file_path), offset, limit)
 
-    def edit(self, file_path: str, old_string: str, new_string: str, replace_all: bool = False):
+    def edit(self, file_path: str, old_string: str, new_string: str, replace_all: bool = False):  # noqa: ANN201, D102, FBT001, FBT002  # tracked: #288
         return super().edit(self._vpath(file_path), old_string, new_string, replace_all)
 
-    def glob_info(self, pattern: str, path: str = "/"):
+    def glob_info(self, pattern: str, path: str = "/"):  # noqa: ANN201, D102  # tracked: #288
         return super().glob_info(pattern, self._vpath(path))
 
-    def grep_raw(self, pattern: str, path: str | None = None, glob: str | None = None):
+    def grep_raw(self, pattern: str, path: str | None = None, glob: str | None = None):  # noqa: ANN201, D102  # tracked: #288
         return super().grep_raw(
             pattern,
             self._vpath(path) if path is not None else self._CONTAINER_ROOT,
@@ -330,11 +330,11 @@ class ModalSandbox(BaseSandbox):
         self._populate_workspace_volume()
         self._create_container()
 
-    def _create_container(self) -> None:
+    def _create_container(self) -> None:  # noqa: C901  # tracked: #288
         """Create (or recreate) the Modal sandbox container on top of the
         already-populated workspace volume. Shared by ``start`` and
         ``_restart_sandbox``.
-        """
+        """  # noqa: D205  # tracked: #288
         app = modal.App.lookup(self._app_name, create_if_missing=True)
         # Clear the image's /workspace dir so our Volume can mount there —
         # the nvcr.io pytorch image ships with a populated /workspace that
@@ -395,7 +395,7 @@ class ModalSandbox(BaseSandbox):
                 timeout=180,
             )
             proc.wait()
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             self._log(f"pip install uv failed: {exc}")
 
         # Run required init commands — fatal on failure.
@@ -412,9 +412,9 @@ class ModalSandbox(BaseSandbox):
             if code != 0:
                 try:
                     err = proc.stderr.read() if proc.stderr else ""
-                except Exception:
+                except Exception:  # noqa: BLE001  # tracked: #288
                     err = ""
-                raise RuntimeError(
+                raise RuntimeError(  # noqa: TRY003  # tracked: #288
                     f"Modal sandbox init command failed (exit {code}):\n"
                     f"  command: {cmd}\n"
                     f"  stderr: {err[:500]}"
@@ -422,7 +422,7 @@ class ModalSandbox(BaseSandbox):
             if "codex login status" in cmd:
                 try:
                     out = proc.stdout.read() if proc.stdout else ""
-                except Exception:
+                except Exception:  # noqa: BLE001  # tracked: #288
                     out = ""
                 if out:
                     self._log(f"init command stdout: {out.strip()[:500]}")
@@ -457,9 +457,9 @@ class ModalSandbox(BaseSandbox):
         old_id = self._sandbox_id
         try:
             if self._sandbox is not None:
-                try:
+                try:  # noqa: SIM105  # tracked: #288
                     self._sandbox.terminate()
-                except Exception:
+                except Exception:  # noqa: BLE001, S110  # tracked: #288
                     pass
         finally:
             if old_id is not None:
@@ -470,8 +470,8 @@ class ModalSandbox(BaseSandbox):
         try:
             self._create_container()
             self._log(f"[fallback] restart succeeded (new id={self._sandbox_id})")
-            return True
-        except Exception as exc:
+            return True  # noqa: TRY300  # tracked: #288
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             self._log(f"[fallback] restart failed: {exc}")
             return False
 
@@ -579,7 +579,7 @@ class ModalSandbox(BaseSandbox):
         shutil.copytree(local_root, snapshot, symlinks=True)
 
     @property
-    def id(self) -> str:
+    def id(self) -> str:  # noqa: D102  # tracked: #288
         return self._sandbox_id or "modal-not-started"
 
     # -- shared fallback wrapper ------------------------------------------
@@ -609,14 +609,14 @@ class ModalSandbox(BaseSandbox):
 
     # -- execute -----------------------------------------------------------
 
-    def execute(
+    def execute(  # noqa: D102  # tracked: #288
         self,
         command: str,
         *,
         timeout: int | None = None,
     ) -> ExecuteResponse:
         if self._sandbox is None:
-            raise RuntimeError("Sandbox not started — call start() first")
+            raise RuntimeError("Sandbox not started — call start() first")  # noqa: TRY003  # tracked: #288
 
         effective_timeout = timeout if timeout is not None else self._default_timeout
         self._log(f"exec (timeout={effective_timeout}s): {command[:500]}")
@@ -648,7 +648,7 @@ class ModalSandbox(BaseSandbox):
                 exit_code=-1,
                 truncated=False,
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             self._log(f"exec error: {exc}")
             return ExecuteResponse(
                 output=f"Modal exec error: {exc}",
@@ -676,7 +676,7 @@ class ModalSandbox(BaseSandbox):
     def write(self, file_path: str, content: str) -> WriteResult:
         """Override BaseSandbox.write to avoid ARG_MAX limits on large files."""
         if self._sandbox is None:
-            raise RuntimeError("Sandbox not started — call start() first")
+            raise RuntimeError("Sandbox not started — call start() first")  # noqa: TRY003  # tracked: #288
         container_path = self._vpath(file_path)
         parent = str(Path(container_path).parent)
 
@@ -698,17 +698,17 @@ class ModalSandbox(BaseSandbox):
 
         try:
             self._run_with_fallback(_do_write, label=f"write {file_path}")
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             self._log(f"write {file_path} failed: {exc}")
             return WriteResult(path=file_path, error=str(exc))
         return WriteResult(path=file_path)
 
-    def upload_files(
+    def upload_files(  # noqa: D102  # tracked: #288
         self,
         files: list[tuple[str, bytes]],
     ) -> list[FileUploadResponse]:
         if self._sandbox is None:
-            raise RuntimeError("Sandbox not started — call start() first")
+            raise RuntimeError("Sandbox not started — call start() first")  # noqa: TRY003  # tracked: #288
         results: list[FileUploadResponse] = []
         for path, content in files:
             container_path = self._vpath(path)
@@ -733,17 +733,17 @@ class ModalSandbox(BaseSandbox):
             try:
                 self._run_with_fallback(_do_upload, label=f"upload {path}")
                 results.append(FileUploadResponse(path=path))
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001  # tracked: #288
                 self._log(f"upload {path} failed: {exc}")
                 results.append(FileUploadResponse(path=path, error="permission_denied"))
         return results
 
-    def download_files(
+    def download_files(  # noqa: D102  # tracked: #288
         self,
         paths: list[str],
     ) -> list[FileDownloadResponse]:
         if self._sandbox is None:
-            raise RuntimeError("Sandbox not started — call start() first")
+            raise RuntimeError("Sandbox not started — call start() first")  # noqa: TRY003  # tracked: #288
         results: list[FileDownloadResponse] = []
         for path in paths:
             container_path = self._vpath(path)
@@ -754,14 +754,14 @@ class ModalSandbox(BaseSandbox):
                     label=f"download {path}",
                 )
                 results.append(FileDownloadResponse(path=path, content=content))
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001  # tracked: #288
                 self._log(f"download {path} failed: {exc}")
                 results.append(FileDownloadResponse(path=path, error="file_not_found"))
         return results
 
     # -- compat shims for vibesys-shell metadata (DockerSandbox has these) --
 
-    def save_symlink_commands(self, symlink_commands: list[str]) -> None:
+    def save_symlink_commands(self, symlink_commands: list[str]) -> None:  # noqa: ARG002  # tracked: #288
         """No-op: vibesys-shell reattachment isn't supported for Modal yet."""
         return
 
@@ -776,7 +776,7 @@ class ModalSandbox(BaseSandbox):
         # early-returns when self._sandbox is None.
         try:
             self._download_workspace()
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             self._log(f"workspace download failed: {exc}")
 
         sandbox = self._sandbox
@@ -788,7 +788,7 @@ class ModalSandbox(BaseSandbox):
 
         try:
             sandbox.terminate()
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             self._log(f"terminate failed: {exc}")
 
         if self._workspace_volume_name:
@@ -798,7 +798,7 @@ class ModalSandbox(BaseSandbox):
                     allow_missing=True,
                 )
                 self._log(f"deleted workspace volume {self._workspace_volume_name}")
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001  # tracked: #288
                 self._log(f"volume delete failed: {exc}")
             self._workspace_volume_name = None
             self._workspace_volume = None
@@ -834,11 +834,11 @@ class ModalSandbox(BaseSandbox):
         if not self._host_workspace.exists():
             self._host_workspace.mkdir(parents=True, exist_ok=True)
 
-        import tarfile
-        import tempfile
+        import tarfile  # noqa: PLC0415  # tracked: #288
+        import tempfile  # noqa: PLC0415  # tracked: #288
 
         exclude_args = " ".join(f"--exclude='{e}'" for e in self._DOWNLOAD_EXCLUDES)
-        tar_remote = "/tmp/_vibesys_ws.tar.gz"
+        tar_remote = "/tmp/_vibesys_ws.tar.gz"  # noqa: S108  # tracked: #288
         tar_cmd = (
             f"cd {self._CONTAINER_ROOT} && "
             f"tar {exclude_args} -czf {tar_remote} . 2>/dev/null && "
@@ -864,7 +864,7 @@ class ModalSandbox(BaseSandbox):
                 log=self._log,
                 label="workspace tar download",
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             self._log(f"workspace tar download failed: {exc}")
             return
 
@@ -885,16 +885,16 @@ class ModalSandbox(BaseSandbox):
                         continue
                     tar.extract(member, str(host_root), set_attrs=False)
         finally:
-            try:
-                os.unlink(tmp_path)
+            try:  # noqa: SIM105  # tracked: #288
+                os.unlink(tmp_path)  # noqa: PTH108  # tracked: #288
             except OSError:
                 pass
 
     # -- context manager ---------------------------------------------------
 
-    def __enter__(self) -> ModalSandbox:
+    def __enter__(self) -> ModalSandbox:  # noqa: D105  # tracked: #288
         self.start()
         return self
 
-    def __exit__(self, *exc: object) -> None:
+    def __exit__(self, *exc: object) -> None:  # noqa: D105  # tracked: #288
         self.stop()

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -10,7 +10,7 @@ from vs_sandbox.docker_sandbox import DockerSandbox
 
 
 @pytest.fixture
-def sandbox(tmp_path):
+def sandbox(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     return DockerSandbox(
         host_workspace=str(tmp_path / "workspace"),
         image="nvcr.io/nvidia/pytorch:25.04-py3",
@@ -19,7 +19,7 @@ def sandbox(tmp_path):
 
 
 @pytest.fixture
-def sandbox_with_mounts(tmp_path):
+def sandbox_with_mounts(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     return DockerSandbox(
         host_workspace=str(tmp_path / "workspace"),
         image="nvcr.io/nvidia/pytorch:25.04-py3",
@@ -34,9 +34,9 @@ def sandbox_with_mounts(tmp_path):
 class TestStart:
     @patch.dict("os.environ", {}, clear=False)
     @patch("subprocess.run")
-    def test_start_runs_docker_run_with_correct_args(self, mock_run, sandbox):
+    def test_start_runs_docker_run_with_correct_args(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         # Remove CUDA_VISIBLE_DEVICES so fallback to "all" is tested
-        import os
+        import os  # noqa: PLC0415  # tracked: #288
 
         os.environ.pop("CUDA_VISIBLE_DEVICES", None)
 
@@ -68,7 +68,7 @@ class TestStart:
         assert docker_run_call.kwargs["timeout"] == 120
 
     @patch("subprocess.run")
-    def test_start_docker_run_timeout_raises_clear_error(self, mock_run, sandbox):
+    def test_start_docker_run_timeout_raises_clear_error(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.side_effect = subprocess.TimeoutExpired(
             cmd=["docker", "run"],
             timeout=120,
@@ -78,8 +78,8 @@ class TestStart:
             sandbox.start()
 
     @patch("subprocess.run")
-    def test_start_failure_removes_created_container(self, mock_run, sandbox):
-        from vs_sandbox.docker_sandbox import _live_containers
+    def test_start_failure_removes_created_container(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
         mock_run.side_effect = [
             subprocess.CompletedProcess(
@@ -100,12 +100,12 @@ class TestStart:
         assert stop_call.kwargs["timeout"] == 30
         assert rm_call.args[0] == ["docker", "rm", "-f", "abc123container"]
         assert rm_call.kwargs["timeout"] == 10
-        assert sandbox._container_id is None
+        assert sandbox._container_id is None  # noqa: SLF001  # tracked: #288
         assert "abc123container" not in _live_containers
 
     @patch("subprocess.run")
-    def test_start_failure_retains_created_container_when_removal_fails(self, mock_run, sandbox):
-        from vs_sandbox.docker_sandbox import _live_containers
+    def test_start_failure_retains_created_container_when_removal_fails(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
         mock_run.side_effect = [
             subprocess.CompletedProcess(
@@ -124,15 +124,15 @@ class TestStart:
             with pytest.raises(RuntimeError, match="Failed to start Docker container"):
                 sandbox.start()
 
-            assert sandbox._container_id == "abc123container"
+            assert sandbox._container_id == "abc123container"  # noqa: SLF001  # tracked: #288
             assert "abc123container" in _live_containers
         finally:
             _live_containers.pop("abc123container", None)
-            sandbox._container_id = None
+            sandbox._container_id = None  # noqa: SLF001  # tracked: #288
 
     @patch.dict("os.environ", {"CUDA_VISIBLE_DEVICES": "3,5,7"})
     @patch("subprocess.run")
-    def test_start_uses_first_cuda_visible_device(self, mock_run, sandbox):
+    def test_start_uses_first_cuda_visible_device(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123container\n", stderr=""
         )
@@ -146,7 +146,7 @@ class TestStart:
         # backend supplies it via env=. The shape was tested above.
 
     @patch("subprocess.run")
-    def test_start_bind_mounts_workspace(self, mock_run, sandbox):
+    def test_start_bind_mounts_workspace(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
         )
@@ -156,10 +156,10 @@ class TestStart:
         cmd = mock_run.call_args_list[0][0][0]
         # Should have -v for workspace mount
         cmd_str = " ".join(cmd)
-        assert f"{sandbox._host_workspace}:/workspace" in cmd_str
+        assert f"{sandbox._host_workspace}:/workspace" in cmd_str  # noqa: SLF001  # tracked: #288
 
     @patch("subprocess.run")
-    def test_start_bind_mounts_extra(self, mock_run, sandbox_with_mounts):
+    def test_start_bind_mounts_extra(self, mock_run, sandbox_with_mounts):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
         )
@@ -173,7 +173,7 @@ class TestStart:
         assert "/workspace/accuracy_checker:ro" in cmd_str
 
     @patch("subprocess.run")
-    def test_start_installs_uv(self, mock_run, sandbox):
+    def test_start_installs_uv(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
         )
@@ -190,8 +190,8 @@ class TestStart:
         assert "pip install uv" in cmd_str
 
     @patch("subprocess.run")
-    def test_init_failure_stops_and_removes_created_container(self, mock_run, tmp_path):
-        from vs_sandbox.docker_sandbox import _live_containers
+    def test_init_failure_stops_and_removes_created_container(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
@@ -212,7 +212,7 @@ class TestStart:
             with pytest.raises(RuntimeError, match="Container init command failed"):
                 sandbox.start()
 
-            assert sandbox._container_id is None
+            assert sandbox._container_id is None  # noqa: SLF001  # tracked: #288
             assert "abc123" not in _live_containers
             assert mock_run.call_args_list[-2][0][0] == ["docker", "stop", "abc123"]
             assert mock_run.call_args_list[-1][0][0] == ["docker", "rm", "-f", "abc123"]
@@ -222,7 +222,7 @@ class TestStart:
 
 class TestExecute:
     @patch("subprocess.run")
-    def test_execute_runs_docker_exec(self, mock_run, sandbox):
+    def test_execute_runs_docker_exec(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         # Start first
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123container\n", stderr=""
@@ -246,7 +246,7 @@ class TestExecute:
         assert result.exit_code == 0
 
     @patch("subprocess.run")
-    def test_execute_timeout(self, mock_run, sandbox):
+    def test_execute_timeout(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
         )
@@ -261,7 +261,7 @@ class TestExecute:
         assert "timed out" in result.output.lower()
 
     @patch("subprocess.run")
-    def test_execute_output_truncation(self, mock_run, sandbox):
+    def test_execute_output_truncation(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
         )
@@ -269,7 +269,7 @@ class TestExecute:
         mock_run.reset_mock()
 
         # Set small max_output_bytes
-        sandbox._max_output_bytes = 50
+        sandbox._max_output_bytes = 50  # noqa: SLF001  # tracked: #288
         big_output = "x" * 200
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=big_output, stderr=""
@@ -281,7 +281,7 @@ class TestExecute:
         assert len(result.output) <= 50 + 100  # some overhead for truncation message
 
     @patch("subprocess.run")
-    def test_execute_combines_stdout_stderr(self, mock_run, sandbox):
+    def test_execute_combines_stdout_stderr(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
         )
@@ -299,14 +299,14 @@ class TestExecute:
         assert result.exit_code == 1
 
     @patch("subprocess.run")
-    def test_execute_without_start_raises(self, mock_run, sandbox):
+    def test_execute_without_start_raises(self, mock_run, sandbox):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         with pytest.raises(RuntimeError, match="not started"):
             sandbox.execute("echo hello")
 
 
 class TestSetupFns:
     @patch("subprocess.run")
-    def test_setup_fns_run_after_start(self, mock_run, tmp_path):
+    def test_setup_fns_run_after_start(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """setup_fns receive the sandbox and run at the end of start()."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
@@ -328,7 +328,7 @@ class TestSetupFns:
         assert invocations == [s]
 
     @patch("subprocess.run")
-    def test_setup_fns_re_run_on_restart(self, mock_run, tmp_path):
+    def test_setup_fns_re_run_on_restart(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """A second start() (e.g. after stop() from reselect_device) re-runs."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
@@ -352,19 +352,19 @@ class TestSetupFns:
         assert calls == 2
 
     @patch("subprocess.run")
-    def test_setup_failure_preserves_error_when_stop_fails(self, mock_run, tmp_path):
-        from vs_sandbox.docker_sandbox import _live_containers
+    def test_setup_failure_preserves_error_when_stop_fails(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
         def fail_setup(_sandbox: DockerSandbox) -> None:
-            raise ValueError("setup exploded")
+            raise ValueError("setup exploded")  # noqa: TRY003  # tracked: #288
 
-        def run(cmd, **_kwargs):
+        def run(cmd, **_kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
             if cmd[:2] == ["docker", "run"]:
                 return subprocess.CompletedProcess(
                     args=cmd, returncode=0, stdout="abc123\n", stderr=""
                 )
             if cmd[:2] == ["docker", "stop"]:
-                raise OSError("Docker daemon disconnected")
+                raise OSError("Docker daemon disconnected")  # noqa: TRY003  # tracked: #288
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         mock_run.side_effect = run
@@ -378,7 +378,7 @@ class TestSetupFns:
             with pytest.raises(ValueError, match="setup exploded"):
                 sandbox.start()
 
-            assert sandbox._container_id is None
+            assert sandbox._container_id is None  # noqa: SLF001  # tracked: #288
             assert "abc123" not in _live_containers
             commands = [call.args[0] for call in mock_run.call_args_list]
             assert ["docker", "stop", "abc123"] in commands
@@ -388,22 +388,25 @@ class TestSetupFns:
 
     @pytest.mark.parametrize("cleanup_mode", ["raises", "nonzero"])
     @patch("subprocess.run")
-    def test_setup_failure_retains_container_for_retry_when_removal_fails(
-        self, mock_run, cleanup_mode, tmp_path
+    def test_setup_failure_retains_container_for_retry_when_removal_fails(  # noqa: ANN201  # tracked: #288
+        self,
+        mock_run,  # noqa: ANN001  # tracked: #288
+        cleanup_mode,  # noqa: ANN001  # tracked: #288
+        tmp_path,  # noqa: ANN001  # tracked: #288
     ):
-        from vs_sandbox.docker_sandbox import _live_containers
+        from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
         def fail_setup(_sandbox: DockerSandbox) -> None:
-            raise ValueError("setup exploded")
+            raise ValueError("setup exploded")  # noqa: TRY003  # tracked: #288
 
-        def run(cmd, **_kwargs):
+        def run(cmd, **_kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
             if cmd[:2] == ["docker", "run"]:
                 return subprocess.CompletedProcess(
                     args=cmd, returncode=0, stdout="abc123\n", stderr=""
                 )
             if cmd[:2] in (["docker", "stop"], ["docker", "rm"]):
                 if cleanup_mode == "raises":
-                    raise OSError("Docker daemon disconnected")
+                    raise OSError("Docker daemon disconnected")  # noqa: TRY003  # tracked: #288
                 return subprocess.CompletedProcess(
                     args=cmd, returncode=1, stdout="", stderr="daemon unavailable"
                 )
@@ -420,16 +423,16 @@ class TestSetupFns:
             with pytest.raises(ValueError, match="setup exploded"):
                 sandbox.start()
 
-            assert sandbox._container_id == "abc123"
+            assert sandbox._container_id == "abc123"  # noqa: SLF001  # tracked: #288
             assert "abc123" in _live_containers
         finally:
             _live_containers.pop("abc123", None)
-            sandbox._container_id = None
+            sandbox._container_id = None  # noqa: SLF001  # tracked: #288
 
 
 class TestStop:
     @patch("subprocess.run")
-    def test_stop_removes_container(self, mock_run, sandbox):
+    def test_stop_removes_container(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123container\n", stderr=""
         )
@@ -445,11 +448,11 @@ class TestStop:
         assert mock_run.call_count == 2
         stop_cmd = mock_run.call_args_list[0][0][0]
         rm_cmd = mock_run.call_args_list[1][0][0]
-        assert stop_cmd[0] == "docker" and "stop" in stop_cmd
-        assert rm_cmd[0] == "docker" and "rm" in rm_cmd
+        assert stop_cmd[0] == "docker" and "stop" in stop_cmd  # noqa: PT018  # tracked: #288
+        assert rm_cmd[0] == "docker" and "rm" in rm_cmd  # noqa: PT018  # tracked: #288
 
     @patch("subprocess.run")
-    def test_stop_idempotent(self, mock_run, sandbox):
+    def test_stop_idempotent(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
         )
@@ -468,18 +471,21 @@ class TestStop:
 
     @pytest.mark.parametrize("cleanup_mode", ["raises", "nonzero"])
     @patch("subprocess.run")
-    def test_failed_removal_retains_ownership_and_can_be_retried(
-        self, mock_run, cleanup_mode, sandbox
+    def test_failed_removal_retains_ownership_and_can_be_retried(  # noqa: ANN201  # tracked: #288
+        self,
+        mock_run,  # noqa: ANN001  # tracked: #288
+        cleanup_mode,  # noqa: ANN001  # tracked: #288
+        sandbox,  # noqa: ANN001  # tracked: #288
     ):
-        from vs_sandbox.docker_sandbox import _live_containers
+        from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
-        sandbox._container_id = "abc123"
+        sandbox._container_id = "abc123"  # noqa: SLF001  # tracked: #288
         _live_containers["abc123"] = "vibesys-test"
 
-        def fail_removal(cmd, **_kwargs):
+        def fail_removal(cmd, **_kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
             if cmd[1] == "rm":
                 if cleanup_mode == "raises":
-                    raise OSError("Docker daemon disconnected")
+                    raise OSError("Docker daemon disconnected")  # noqa: TRY003  # tracked: #288
                 return subprocess.CompletedProcess(
                     args=cmd, returncode=1, stdout="", stderr="daemon unavailable"
                 )
@@ -491,7 +497,7 @@ class TestStop:
             with pytest.raises(expected_error):
                 sandbox.stop()
 
-            assert sandbox._container_id == "abc123"
+            assert sandbox._container_id == "abc123"  # noqa: SLF001  # tracked: #288
             assert "abc123" in _live_containers
 
             mock_run.side_effect = None
@@ -500,17 +506,17 @@ class TestStop:
             )
             sandbox.stop()
 
-            assert sandbox._container_id is None
+            assert sandbox._container_id is None  # noqa: SLF001  # tracked: #288
             assert "abc123" not in _live_containers
         finally:
             _live_containers.pop("abc123", None)
-            sandbox._container_id = None
+            sandbox._container_id = None  # noqa: SLF001  # tracked: #288
 
     @patch("subprocess.run")
-    def test_stop_failure_does_not_prevent_forced_removal(self, mock_run, sandbox):
-        from vs_sandbox.docker_sandbox import _live_containers
+    def test_stop_failure_does_not_prevent_forced_removal(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
-        sandbox._container_id = "abc123"
+        sandbox._container_id = "abc123"  # noqa: SLF001  # tracked: #288
         _live_containers["abc123"] = "vibesys-test"
         mock_run.side_effect = [
             OSError("Docker daemon disconnected"),
@@ -520,14 +526,14 @@ class TestStop:
         sandbox.stop()
 
         assert mock_run.call_args_list[1].args[0] == ["docker", "rm", "-f", "abc123"]
-        assert sandbox._container_id is None
+        assert sandbox._container_id is None  # noqa: SLF001  # tracked: #288
         assert "abc123" not in _live_containers
 
     @patch("subprocess.run")
-    def test_already_absent_container_clears_ownership(self, mock_run, sandbox):
-        from vs_sandbox.docker_sandbox import _live_containers
+    def test_already_absent_container_clears_ownership(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
-        sandbox._container_id = "abc123"
+        sandbox._container_id = "abc123"  # noqa: SLF001  # tracked: #288
         _live_containers["abc123"] = "vibesys-test"
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=1, stdout="", stderr="Error: No such container: abc123"
@@ -535,14 +541,14 @@ class TestStop:
 
         sandbox.stop()
 
-        assert sandbox._container_id is None
+        assert sandbox._container_id is None  # noqa: SLF001  # tracked: #288
         assert "abc123" not in _live_containers
 
     @patch("subprocess.run")
-    def test_removal_already_in_progress_clears_ownership(self, mock_run, sandbox):
-        from vs_sandbox.docker_sandbox import _live_containers
+    def test_removal_already_in_progress_clears_ownership(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
-        sandbox._container_id = "abc123"
+        sandbox._container_id = "abc123"  # noqa: SLF001  # tracked: #288
         _live_containers["abc123"] = "vibesys-test"
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
@@ -555,14 +561,14 @@ class TestStop:
 
         sandbox.stop()
 
-        assert sandbox._container_id is None
+        assert sandbox._container_id is None  # noqa: SLF001  # tracked: #288
         assert "abc123" not in _live_containers
 
     @patch("subprocess.run")
-    def test_keyboard_interrupt_is_not_swallowed(self, mock_run, sandbox):
-        from vs_sandbox.docker_sandbox import _live_containers
+    def test_keyboard_interrupt_is_not_swallowed(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
-        sandbox._container_id = "abc123"
+        sandbox._container_id = "abc123"  # noqa: SLF001  # tracked: #288
         _live_containers["abc123"] = "vibesys-test"
         mock_run.side_effect = KeyboardInterrupt()
 
@@ -571,16 +577,16 @@ class TestStop:
                 sandbox.stop()
 
             assert mock_run.call_count == 1
-            assert sandbox._container_id == "abc123"
+            assert sandbox._container_id == "abc123"  # noqa: SLF001  # tracked: #288
             assert "abc123" in _live_containers
         finally:
             _live_containers.pop("abc123", None)
-            sandbox._container_id = None
+            sandbox._container_id = None  # noqa: SLF001  # tracked: #288
 
 
 class TestIdProperty:
     @patch("subprocess.run")
-    def test_id_property(self, mock_run, sandbox):
+    def test_id_property(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123def456ghi789\n", stderr=""
         )
@@ -592,7 +598,7 @@ class TestIdProperty:
 
 class TestUploadFiles:
     @patch("subprocess.run")
-    def test_upload_files(self, mock_run, sandbox):
+    def test_upload_files(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
         )
@@ -614,7 +620,7 @@ class TestUploadFiles:
 
 class TestDownloadFiles:
     @patch("subprocess.run")
-    def test_download_files(self, mock_run, sandbox, tmp_path):
+    def test_download_files(self, mock_run, sandbox, tmp_path):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
         )
@@ -622,7 +628,7 @@ class TestDownloadFiles:
         mock_run.reset_mock()
 
         # Mock docker cp to create the file
-        def mock_docker_cp(cmd, **kwargs):
+        def mock_docker_cp(cmd, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288
             # Simulate docker cp by creating the file in the temp dir
             if "cp" in cmd:
                 # Extract dest path from command
@@ -642,48 +648,48 @@ class TestDownloadFiles:
 
 class TestContextManager:
     @patch("subprocess.run")
-    def test_context_manager(self, mock_run, sandbox):
+    def test_context_manager(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
         )
 
         with sandbox:
-            assert sandbox._container_id is not None
+            assert sandbox._container_id is not None  # noqa: SLF001  # tracked: #288
 
         # After exit, container should be stopped
-        assert sandbox._container_id is None
+        assert sandbox._container_id is None  # noqa: SLF001  # tracked: #288
 
 
 class TestPathTranslation:
-    def test_absolute_virtual_path_gets_workspace_prefix(self, sandbox):
-        assert sandbox._vpath("/reference/model") == "/workspace/reference/model"
+    def test_absolute_virtual_path_gets_workspace_prefix(self, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        assert sandbox._vpath("/reference/model") == "/workspace/reference/model"  # noqa: SLF001  # tracked: #288
 
-    def test_root_path_maps_to_workspace(self, sandbox):
-        assert sandbox._vpath("/") == "/workspace/"
+    def test_root_path_maps_to_workspace(self, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        assert sandbox._vpath("/") == "/workspace/"  # noqa: SLF001  # tracked: #288
 
-    def test_already_workspace_path_unchanged(self, sandbox):
-        assert sandbox._vpath("/workspace/foo") == "/workspace/foo"
+    def test_already_workspace_path_unchanged(self, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        assert sandbox._vpath("/workspace/foo") == "/workspace/foo"  # noqa: SLF001  # tracked: #288
 
-    def test_workspace_root_unchanged(self, sandbox):
-        assert sandbox._vpath("/workspace") == "/workspace"
+    def test_workspace_root_unchanged(self, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        assert sandbox._vpath("/workspace") == "/workspace"  # noqa: SLF001  # tracked: #288
 
-    def test_relative_path_unchanged(self, sandbox):
-        assert sandbox._vpath("reference/model") == "reference/model"
+    def test_relative_path_unchanged(self, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        assert sandbox._vpath("reference/model") == "reference/model"  # noqa: SLF001  # tracked: #288
 
-    def test_passthrough_path_not_rewritten(self, tmp_path):
+    def test_passthrough_path_not_rewritten(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Paths in passthrough_paths should not get /workspace prepended."""
         s = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
             passthrough_paths=["/model"],
         )
-        assert s._vpath("/model") == "/model"
-        assert s._vpath("/model/config.json") == "/model/config.json"
+        assert s._vpath("/model") == "/model"  # noqa: SLF001  # tracked: #288
+        assert s._vpath("/model/config.json") == "/model/config.json"  # noqa: SLF001  # tracked: #288
         # Other absolute paths should still be rewritten
-        assert s._vpath("/other") == "/workspace/other"
+        assert s._vpath("/other") == "/workspace/other"  # noqa: SLF001  # tracked: #288
 
     @patch("subprocess.run")
-    def test_read_translates_path(self, mock_run, sandbox):
+    def test_read_translates_path(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         """read() should translate the path before delegating to BaseSandbox."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
@@ -702,7 +708,7 @@ class TestPathTranslation:
             mock_super_read.assert_called_once_with("/workspace/reference/reference.py", 0, 2000)
 
     @patch("subprocess.run")
-    def test_ls_translates_path(self, mock_run, sandbox):
+    def test_ls_translates_path(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         """ls_info('/') should translate to /workspace/."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
@@ -716,31 +722,34 @@ class TestPathTranslation:
 
 class TestCleanupOnExit:
     @pytest.fixture(autouse=True)
-    def _clear_live_containers(self):
+    def _clear_live_containers(self):  # noqa: ANN202  # tracked: #288
         """Isolate the global _live_containers registry between tests."""
-        from vs_sandbox.docker_sandbox import _live_containers
+        from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
         _live_containers.clear()
         yield
         _live_containers.clear()
 
     @patch("subprocess.run")
-    def test_live_containers_tracked(self, mock_run, sandbox):
-        from vs_sandbox.docker_sandbox import _live_containers
+    def test_live_containers_tracked(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
         )
         sandbox.start()
 
-        assert sandbox._container_id in _live_containers
+        assert sandbox._container_id in _live_containers  # noqa: SLF001  # tracked: #288
 
         sandbox.stop()
         assert "abc123" not in _live_containers
 
     @patch("subprocess.run")
-    def test_cleanup_containers_stops_all(self, mock_run, sandbox):
-        from vs_sandbox.docker_sandbox import _cleanup_containers, _live_containers
+    def test_cleanup_containers_stops_all(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.docker_sandbox import (  # noqa: PLC0415  # tracked: #288
+            _cleanup_containers,
+            _live_containers,
+        )
 
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="container_xyz\n", stderr=""
@@ -764,15 +773,18 @@ class TestCleanupOnExit:
 
     @pytest.mark.parametrize("cleanup_mode", ["raises", "nonzero"])
     @patch("subprocess.run")
-    def test_cleanup_retains_failed_removal_for_retry(self, mock_run, cleanup_mode):
-        from vs_sandbox.docker_sandbox import _cleanup_containers, _live_containers
+    def test_cleanup_retains_failed_removal_for_retry(self, mock_run, cleanup_mode):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.docker_sandbox import (  # noqa: PLC0415  # tracked: #288
+            _cleanup_containers,
+            _live_containers,
+        )
 
         _live_containers["abc123"] = "vibesys-test"
 
-        def fail_removal(cmd, **_kwargs):
+        def fail_removal(cmd, **_kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
             if cmd[1] == "rm":
                 if cleanup_mode == "raises":
-                    raise OSError("Docker daemon disconnected")
+                    raise OSError("Docker daemon disconnected")  # noqa: TRY003  # tracked: #288
                 return subprocess.CompletedProcess(
                     args=cmd, returncode=1, stdout="", stderr="daemon unavailable"
                 )
@@ -788,8 +800,11 @@ class TestCleanupOnExit:
         assert rm_call.kwargs["timeout"] == 10
 
     @patch("subprocess.run")
-    def test_cleanup_forces_removal_after_stop_exception(self, mock_run):
-        from vs_sandbox.docker_sandbox import _cleanup_containers, _live_containers
+    def test_cleanup_forces_removal_after_stop_exception(self, mock_run):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.docker_sandbox import (  # noqa: PLC0415  # tracked: #288
+            _cleanup_containers,
+            _live_containers,
+        )
 
         _live_containers["abc123"] = "vibesys-test"
         mock_run.side_effect = [
@@ -802,13 +817,13 @@ class TestCleanupOnExit:
         assert mock_run.call_args_list[1].args[0] == ["docker", "rm", "-f", "abc123"]
         assert "abc123" not in _live_containers
 
-    def test_sigint_defers_container_cleanup_until_stack_unwinds(self, monkeypatch):
-        from vs_sandbox import docker_sandbox
+    def test_sigint_defers_container_cleanup_until_stack_unwinds(self, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox import docker_sandbox  # noqa: PLC0415  # tracked: #288
 
         cleanup_calls: list[bool] = []
         original_calls: list[tuple[int, object]] = []
 
-        def original_handler(signum, frame):
+        def original_handler(signum, frame):  # noqa: ANN001, ANN202  # tracked: #288
             original_calls.append((signum, frame))
             raise KeyboardInterrupt
 
@@ -819,9 +834,9 @@ class TestCleanupOnExit:
         )
         monkeypatch.setattr(docker_sandbox, "_original_sigint", original_handler)
 
-        with patch.object(docker_sandbox.signal, "signal") as restore_handler:
+        with patch.object(docker_sandbox.signal, "signal") as restore_handler:  # noqa: SIM117  # tracked: #288
             with pytest.raises(KeyboardInterrupt):
-                docker_sandbox._sigint_handler(2, None)
+                docker_sandbox._sigint_handler(2, None)  # noqa: SLF001  # tracked: #288
 
         restore_handler.assert_called_once_with(
             docker_sandbox.signal.SIGINT,
@@ -833,7 +848,7 @@ class TestCleanupOnExit:
 
 class TestWrite:
     @patch("subprocess.run")
-    def test_write_uses_docker_cp(self, mock_run, sandbox):
+    def test_write_uses_docker_cp(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         """write() should use docker cp instead of shelling out content."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
@@ -857,7 +872,7 @@ class TestWrite:
         assert len(exec_bash_calls) == 0
 
     @patch("subprocess.run")
-    def test_write_large_content(self, mock_run, sandbox):
+    def test_write_large_content(self, mock_run, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         """write() should handle content larger than shell arg limit."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc123\n", stderr=""
@@ -875,14 +890,14 @@ class TestWrite:
         assert result.error is None
 
     @patch("subprocess.run")
-    def test_write_without_start_raises(self, mock_run, sandbox):
+    def test_write_without_start_raises(self, mock_run, sandbox):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         with pytest.raises(RuntimeError, match="not started"):
             sandbox.write("/test.py", "content")
 
 
 class TestEnvVars:
     @patch("subprocess.run")
-    def test_env_vars_passed_to_docker_run(self, mock_run, tmp_path):
+    def test_env_vars_passed_to_docker_run(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="pytorch:latest",
@@ -904,7 +919,7 @@ class TestEnvVars:
 
 class TestDevicePassthrough:
     @patch("subprocess.run")
-    def test_devices_emit_device_flags_and_no_gpus(self, mock_run, tmp_path):
+    def test_devices_emit_device_flags_and_no_gpus(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="public.ecr.aws/neuron/pytorch-inference-neuronx:latest",
@@ -924,10 +939,10 @@ class TestDevicePassthrough:
         for dev in ("/dev/neuron0", "/dev/neuron1"):
             i = cmd.index(dev)
             assert cmd[i - 1] == "--device"
-        assert sandbox._metadata["devices"] == ["/dev/neuron0", "/dev/neuron1"]
+        assert sandbox._metadata["devices"] == ["/dev/neuron0", "/dev/neuron1"]  # noqa: SLF001  # tracked: #288
 
     @patch("subprocess.run")
-    def test_group_add_emits_group_add_flags(self, mock_run, tmp_path):
+    def test_group_add_emits_group_add_flags(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """AMD /dev/kfd and /dev/dri/* are group-owned; without --group-add the
         container user cannot open them and every HIP call fails at runtime."""
         sandbox = DockerSandbox(
@@ -951,10 +966,10 @@ class TestDevicePassthrough:
         # Recorded so a reattaching shell reconstructs the same device access;
         # without it the container user cannot open /dev/kfd and every HIP call
         # fails — the exact failure --group-add exists to prevent.
-        assert sandbox._metadata["group_add"] == ["video", "render"]
+        assert sandbox._metadata["group_add"] == ["video", "render"]  # noqa: SLF001  # tracked: #288
 
     @patch("subprocess.run")
-    def test_no_group_add_by_default(self, mock_run, tmp_path):
+    def test_no_group_add_by_default(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="img",
@@ -967,7 +982,7 @@ class TestDevicePassthrough:
         assert "--group-add" not in cmd
 
     @patch("subprocess.run")
-    def test_no_devices_by_default(self, mock_run, tmp_path):
+    def test_no_devices_by_default(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="img",
@@ -982,7 +997,7 @@ class TestDevicePassthrough:
 
 class TestEntrypointOverride:
     @patch("subprocess.run")
-    def test_entrypoint_override_emitted_before_image(self, mock_run, tmp_path):
+    def test_entrypoint_override_emitted_before_image(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="public.ecr.aws/neuron/pytorch-inference-neuronx:latest",
@@ -998,13 +1013,13 @@ class TestEntrypointOverride:
         ep_idx = cmd.index("--entrypoint")
         assert cmd[ep_idx + 1] == ""
         # Override must precede the image positional, which precedes the command.
-        img_idx = cmd.index(sandbox._image)
+        img_idx = cmd.index(sandbox._image)  # noqa: SLF001  # tracked: #288
         assert ep_idx < img_idx
         assert cmd[-2:] == ["sleep", "infinity"]
-        assert sandbox._metadata["entrypoint"] == ""
+        assert sandbox._metadata["entrypoint"] == ""  # noqa: SLF001  # tracked: #288
 
     @patch("subprocess.run")
-    def test_no_entrypoint_flag_by_default(self, mock_run, tmp_path):
+    def test_no_entrypoint_flag_by_default(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="img",
@@ -1019,7 +1034,7 @@ class TestEntrypointOverride:
 
 class TestShmSize:
     @patch("subprocess.run")
-    def test_shm_size_emitted(self, mock_run, tmp_path):
+    def test_shm_size_emitted(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="img",
@@ -1032,10 +1047,10 @@ class TestShmSize:
         cmd = mock_run.call_args_list[0][0][0]
         assert "--shm-size" in cmd
         assert cmd[cmd.index("--shm-size") + 1] == "16g"
-        assert sandbox._metadata["shm_size"] == "16g"
+        assert sandbox._metadata["shm_size"] == "16g"  # noqa: SLF001  # tracked: #288
 
     @patch("subprocess.run")
-    def test_no_shm_size_by_default(self, mock_run, tmp_path):
+    def test_no_shm_size_by_default(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox = DockerSandbox(host_workspace=str(tmp_path / "workspace"), image="img")
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc\n", stderr=""
@@ -1046,7 +1061,7 @@ class TestShmSize:
 
 class TestAutoRemove:
     @patch("subprocess.run")
-    def test_auto_remove_emits_rm_flag(self, mock_run, tmp_path):
+    def test_auto_remove_emits_rm_flag(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"), image="img", auto_remove=True
         )
@@ -1057,7 +1072,7 @@ class TestAutoRemove:
         assert "--rm" in mock_run.call_args_list[0][0][0]
 
     @patch("subprocess.run")
-    def test_no_rm_by_default(self, mock_run, tmp_path):
+    def test_no_rm_by_default(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox = DockerSandbox(host_workspace=str(tmp_path / "workspace"), image="img")
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="abc\n", stderr=""

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -9,7 +9,7 @@ import pytest
 from vs_sandbox.docker_sandbox import DockerSandbox
 
 
-@pytest.fixture()
+@pytest.fixture
 def sandbox(tmp_path):
     return DockerSandbox(
         host_workspace=str(tmp_path / "workspace"),
@@ -18,7 +18,7 @@ def sandbox(tmp_path):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def sandbox_with_mounts(tmp_path):
     return DockerSandbox(
         host_workspace=str(tmp_path / "workspace"),
@@ -104,9 +104,7 @@ class TestStart:
         assert "abc123container" not in _live_containers
 
     @patch("subprocess.run")
-    def test_start_failure_retains_created_container_when_removal_fails(
-        self, mock_run, sandbox
-    ):
+    def test_start_failure_retains_created_container_when_removal_fails(self, mock_run, sandbox):
         from vs_sandbox.docker_sandbox import _live_containers
 
         mock_run.side_effect = [
@@ -805,7 +803,7 @@ class TestCleanupOnExit:
         assert "abc123" not in _live_containers
 
     def test_sigint_defers_container_cleanup_until_stack_unwinds(self, monkeypatch):
-        import vs_sandbox.docker_sandbox as docker_sandbox
+        from vs_sandbox import docker_sandbox
 
         cleanup_calls: list[bool] = []
         original_calls: list[tuple[int, object]] = []

--- a/libs/vs-sandbox/tests/test_host_resource_importer.py
+++ b/libs/vs-sandbox/tests/test_host_resource_importer.py
@@ -6,7 +6,7 @@ from vs_sandbox import host_resource_importer
 from vs_sandbox.host_resources import HostResource, HostResourceAccess
 
 
-def test_importer_partitions_access_and_write_wins(tmp_path):
+def test_importer_partitions_access_and_write_wins(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     workspace = tmp_path / "runs" / "current" / "workspace"
     readonly = tmp_path / "readonly"
     writable = tmp_path / "writable"
@@ -27,7 +27,7 @@ def test_importer_partitions_access_and_write_wins(tmp_path):
     assert imports.write_paths == (writable,)
 
 
-def test_importer_rejects_relative_and_symlinked_workspace_ancestors(tmp_path):
+def test_importer_rejects_relative_and_symlinked_workspace_ancestors(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     run_root = tmp_path / "runs"
     workspace = run_root / "current" / "workspace"
     workspace.mkdir(parents=True)

--- a/libs/vs-sandbox/tests/test_host_resources.py
+++ b/libs/vs-sandbox/tests/test_host_resources.py
@@ -10,11 +10,11 @@ from vs_sandbox import (
 )
 
 
-def test_declaration_sdk_collects_resources_without_importing_them(tmp_path):
+def test_declaration_sdk_collects_resources_without_importing_them(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     toolchain = tmp_path / "toolchain"
     context = HostResourceContext(env={"PROFILE": "test"})
 
-    def declare(ctx: HostResourceContext):
+    def declare(ctx: HostResourceContext):  # noqa: ANN202  # tracked: #288
         assert ctx == context
         return (HostResource(toolchain, purpose="test toolchain"),)
 

--- a/libs/vs-sandbox/tests/test_modal_model_setup.py
+++ b/libs/vs-sandbox/tests/test_modal_model_setup.py
@@ -6,16 +6,16 @@ import pytest
 
 
 class TestVolumeNameFor:
-    def test_sanitizes_slash_and_case(self):
-        from vs_sandbox.modal_model_setup import _volume_name_for
+    def test_sanitizes_slash_and_case(self):  # noqa: ANN201  # tracked: #288
+        from vs_sandbox.modal_model_setup import _volume_name_for  # noqa: PLC0415  # tracked: #288
 
         assert (
             _volume_name_for("meta-llama/Llama-3.1-8B-Instruct")
             == "vibesys-model-meta-llama-llama-3-1-8b-instruct"
         )
 
-    def test_handles_colons_and_underscores(self):
-        from vs_sandbox.modal_model_setup import _volume_name_for
+    def test_handles_colons_and_underscores(self):  # noqa: ANN201  # tracked: #288
+        from vs_sandbox.modal_model_setup import _volume_name_for  # noqa: PLC0415  # tracked: #288
 
         assert (
             _volume_name_for("openai/whisper_large-v3") == "vibesys-model-openai-whisper-large-v3"
@@ -23,8 +23,8 @@ class TestVolumeNameFor:
 
 
 @pytest.fixture
-def mock_modal(monkeypatch):
-    import modal
+def mock_modal(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    import modal  # noqa: PLC0415  # tracked: #288
 
     fake_volume = MagicMock()
     fake_app = MagicMock()
@@ -36,8 +36,8 @@ def mock_modal(monkeypatch):
 
     # app.function is a decorator — return the wrapped callable unchanged but
     # expose .remote as a MagicMock we can assert against.
-    def _function_decorator(**kwargs):
-        def wrap(fn):
+    def _function_decorator(**kwargs):  # noqa: ANN003, ANN202, ARG001  # tracked: #288
+        def wrap(fn):  # noqa: ANN001, ANN202, ARG001  # tracked: #288
             wrapped = MagicMock()
             wrapped.remote = MagicMock()
             return wrapped
@@ -54,8 +54,8 @@ def mock_modal(monkeypatch):
 
 
 class TestEnsureModelVolume:
-    def test_skips_upload_when_sentinel_present(self, mock_modal):
-        from vs_sandbox.modal_model_setup import (
+    def test_skips_upload_when_sentinel_present(self, mock_modal):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.modal_model_setup import (  # noqa: PLC0415  # tracked: #288
             _READY_SENTINEL,
             ensure_model_volume,
         )
@@ -73,8 +73,10 @@ class TestEnsureModelVolume:
         mock_modal["app"].run.assert_not_called()
         assert any("ready" in line for line in logs)
 
-    def test_triggers_upload_when_volume_empty(self, mock_modal):
-        from vs_sandbox.modal_model_setup import ensure_model_volume
+    def test_triggers_upload_when_volume_empty(self, mock_modal):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.modal_model_setup import (  # noqa: PLC0415  # tracked: #288
+            ensure_model_volume,
+        )
 
         mock_modal["volume"].listdir.return_value = []
 
@@ -85,8 +87,10 @@ class TestEnsureModelVolume:
         mock_modal["app"].run.assert_called_once()
         assert any("populating" in line for line in logs)
 
-    def test_triggers_upload_when_listdir_raises(self, mock_modal):
-        from vs_sandbox.modal_model_setup import ensure_model_volume
+    def test_triggers_upload_when_listdir_raises(self, mock_modal):  # noqa: ANN001, ANN201  # tracked: #288
+        from vs_sandbox.modal_model_setup import (  # noqa: PLC0415  # tracked: #288
+            ensure_model_volume,
+        )
 
         mock_modal["volume"].listdir.side_effect = RuntimeError("not found")
 
@@ -95,21 +99,25 @@ class TestEnsureModelVolume:
         assert name.startswith("vibesys-model-")
         mock_modal["app"].run.assert_called_once()
 
-    def test_forwards_hf_token_as_secret(self, mock_modal):
-        import modal
+    def test_forwards_hf_token_as_secret(self, mock_modal):  # noqa: ANN001, ANN201  # tracked: #288
+        import modal  # noqa: PLC0415  # tracked: #288
 
-        from vs_sandbox.modal_model_setup import ensure_model_volume
+        from vs_sandbox.modal_model_setup import (  # noqa: PLC0415  # tracked: #288
+            ensure_model_volume,
+        )
 
         mock_modal["volume"].listdir.return_value = []
 
-        ensure_model_volume("x/y", hf_token="hf_tok", log=lambda *_: None)
+        ensure_model_volume("x/y", hf_token="hf_tok", log=lambda *_: None)  # noqa: S106  # tracked: #288
 
         modal.Secret.from_dict.assert_called_once_with({"HF_TOKEN": "hf_tok"})
 
-    def test_reads_hf_token_from_env(self, mock_modal, monkeypatch):
-        import modal
+    def test_reads_hf_token_from_env(self, mock_modal, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+        import modal  # noqa: PLC0415  # tracked: #288
 
-        from vs_sandbox.modal_model_setup import ensure_model_volume
+        from vs_sandbox.modal_model_setup import (  # noqa: PLC0415  # tracked: #288
+            ensure_model_volume,
+        )
 
         mock_modal["volume"].listdir.return_value = []
         monkeypatch.setenv("HF_TOKEN", "from_env")

--- a/libs/vs-sandbox/tests/test_modal_model_setup.py
+++ b/libs/vs-sandbox/tests/test_modal_model_setup.py
@@ -22,7 +22,7 @@ class TestVolumeNameFor:
         )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_modal(monkeypatch):
     import modal
 

--- a/libs/vs-sandbox/tests/test_modal_sandbox.py
+++ b/libs/vs-sandbox/tests/test_modal_sandbox.py
@@ -6,11 +6,11 @@ import pytest
 
 
 @pytest.fixture
-def mock_modal(monkeypatch):
+def mock_modal(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     """Patch modal.Sandbox.create, Image.from_registry, App.lookup, Volume.from_name/delete."""
-    import modal
+    import modal  # noqa: PLC0415  # tracked: #288
 
-    from vs_sandbox.modal_sandbox import _live_sandboxes
+    from vs_sandbox.modal_sandbox import _live_sandboxes  # noqa: PLC0415  # tracked: #288
 
     _live_sandboxes.clear()
 
@@ -53,8 +53,8 @@ def mock_modal(monkeypatch):
 
 
 @pytest.fixture
-def sandbox(tmp_path, mock_modal):
-    from vs_sandbox.modal_sandbox import ModalSandbox
+def sandbox(tmp_path, mock_modal):  # noqa: ANN001, ANN201, ARG001  # tracked: #288
+    from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415  # tracked: #288
 
     ws = tmp_path / "workspace"
     ws.mkdir()
@@ -70,30 +70,30 @@ def sandbox(tmp_path, mock_modal):
 
 
 class TestVpath:
-    def test_rewrites_virtual_root_paths(self, sandbox):
-        assert sandbox._vpath("/foo/bar.py") == "/workspace/foo/bar.py"
+    def test_rewrites_virtual_root_paths(self, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        assert sandbox._vpath("/foo/bar.py") == "/workspace/foo/bar.py"  # noqa: SLF001  # tracked: #288
 
-    def test_preserves_container_root_paths(self, sandbox):
-        assert sandbox._vpath("/workspace/foo") == "/workspace/foo"
+    def test_preserves_container_root_paths(self, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        assert sandbox._vpath("/workspace/foo") == "/workspace/foo"  # noqa: SLF001  # tracked: #288
 
-    def test_preserves_passthrough(self, tmp_path, mock_modal):
-        from vs_sandbox.modal_sandbox import ModalSandbox
+    def test_preserves_passthrough(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415  # tracked: #288
 
         sb = ModalSandbox(
             host_workspace=str(tmp_path),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
             passthrough_paths=["/model"],
         )
-        assert sb._vpath("/model/weights.bin") == "/model/weights.bin"
-        assert sb._vpath("/foo") == "/workspace/foo"
+        assert sb._vpath("/model/weights.bin") == "/model/weights.bin"  # noqa: SLF001  # tracked: #288
+        assert sb._vpath("/foo") == "/workspace/foo"  # noqa: SLF001  # tracked: #288
 
-    def test_relative_paths_untouched(self, sandbox):
-        assert sandbox._vpath("foo/bar.py") == "foo/bar.py"
+    def test_relative_paths_untouched(self, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
+        assert sandbox._vpath("foo/bar.py") == "foo/bar.py"  # noqa: SLF001  # tracked: #288
 
 
 class TestStart:
-    def test_start_creates_sandbox_with_gpu_and_timeout(self, sandbox, mock_modal):
-        import modal
+    def test_start_creates_sandbox_with_gpu_and_timeout(self, sandbox, mock_modal):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
+        import modal  # noqa: PLC0415  # tracked: #288
 
         sandbox.start()
         modal.Sandbox.create.assert_called_once()
@@ -102,10 +102,10 @@ class TestStart:
         assert kwargs["workdir"] == "/workspace"
         assert "/workspace" in kwargs["volumes"]
 
-    def test_start_mounts_model_volume_when_name_given(self, tmp_path, mock_modal):
-        import modal
+    def test_start_mounts_model_volume_when_name_given(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
+        import modal  # noqa: PLC0415  # tracked: #288
 
-        from vs_sandbox.modal_sandbox import ModalSandbox
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415  # tracked: #288
 
         with ModalSandbox(
             host_workspace=str(tmp_path),
@@ -115,12 +115,12 @@ class TestStart:
             kwargs = modal.Sandbox.create.call_args.kwargs
             assert "/model" in kwargs["volumes"]
 
-    def test_start_uploads_bind_mounts_into_workspace_volume(
+    def test_start_uploads_bind_mounts_into_workspace_volume(  # noqa: ANN201  # tracked: #288
         self,
-        tmp_path,
-        mock_modal,
+        tmp_path,  # noqa: ANN001  # tracked: #288
+        mock_modal,  # noqa: ANN001  # tracked: #288
     ):
-        from vs_sandbox.modal_sandbox import ModalSandbox
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415  # tracked: #288
 
         ws = tmp_path / "ws"
         ws.mkdir()
@@ -136,12 +136,12 @@ class TestStart:
             calls = upload_cm.put_directory.call_args_list
             assert any("bench" in str(c) and "'/bench'" in str(c) for c in calls)
 
-    def test_start_skips_model_bind_mount_from_workspace_volume(
+    def test_start_skips_model_bind_mount_from_workspace_volume(  # noqa: ANN201  # tracked: #288
         self,
-        tmp_path,
-        mock_modal,
+        tmp_path,  # noqa: ANN001  # tracked: #288
+        mock_modal,  # noqa: ANN001  # tracked: #288
     ):
-        from vs_sandbox.modal_sandbox import ModalSandbox
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415  # tracked: #288
 
         ws = tmp_path / "ws"
         ws.mkdir()
@@ -154,12 +154,12 @@ class TestStart:
             for c in upload_cm.put_directory.call_args_list:
                 assert "/host/model" not in str(c)
 
-    def test_start_skips_hf_cache_bind_mount_from_workspace_volume(
+    def test_start_skips_hf_cache_bind_mount_from_workspace_volume(  # noqa: ANN201  # tracked: #288
         self,
-        tmp_path,
-        mock_modal,
+        tmp_path,  # noqa: ANN001  # tracked: #288
+        mock_modal,  # noqa: ANN001  # tracked: #288
     ):
-        from vs_sandbox.modal_sandbox import ModalSandbox
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415  # tracked: #288
 
         ws = tmp_path / "ws"
         ws.mkdir()
@@ -177,12 +177,12 @@ class TestStart:
             for c in upload_cm.put_directory.call_args_list:
                 assert ".hf_cache" not in str(c)
 
-    def test_start_excludes_local_runtime_dirs_from_workspace_upload(
+    def test_start_excludes_local_runtime_dirs_from_workspace_upload(  # noqa: ANN201  # tracked: #288
         self,
-        tmp_path,
-        mock_modal,
+        tmp_path,  # noqa: ANN001  # tracked: #288
+        mock_modal,  # noqa: ANN001  # tracked: #288
     ):
-        from vs_sandbox.modal_sandbox import ModalSandbox
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415  # tracked: #288
 
         ws = tmp_path / "ws"
         ws.mkdir()
@@ -207,12 +207,12 @@ class TestStart:
             assert not any(".venv" in c for c in uploaded)
             assert not any(".git" in c for c in uploaded)
 
-    def test_start_uploads_minimal_codex_auth_snapshot(
+    def test_start_uploads_minimal_codex_auth_snapshot(  # noqa: ANN201  # tracked: #288
         self,
-        tmp_path,
-        mock_modal,
+        tmp_path,  # noqa: ANN001  # tracked: #288
+        mock_modal,  # noqa: ANN001, ARG002  # tracked: #288
     ):
-        from vs_sandbox.modal_sandbox import ModalSandbox
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415  # tracked: #288
 
         ws = tmp_path / "ws"
         ws.mkdir()
@@ -230,7 +230,7 @@ class TestStart:
             image="nvcr.io/nvidia/pytorch:25.04-py3",
         )
         snapshot = tmp_path / "snapshot"
-        sb._copy_bind_mount_snapshot(codex, snapshot)
+        sb._copy_bind_mount_snapshot(codex, snapshot)  # noqa: SLF001  # tracked: #288
 
         assert (snapshot / "auth.json").exists()
         assert (snapshot / "config.toml").exists()
@@ -240,7 +240,7 @@ class TestStart:
 
 
 class TestExecute:
-    def test_execute_runs_bash_command_in_workspace(self, sandbox, mock_modal):
+    def test_execute_runs_bash_command_in_workspace(self, sandbox, mock_modal):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox.start()
         resp = sandbox.execute("ls")
         assert resp.exit_code == 0
@@ -253,42 +253,42 @@ class TestExecute:
             timeout=300,
         )
 
-    def test_execute_respects_custom_timeout(self, sandbox, mock_modal):
+    def test_execute_respects_custom_timeout(self, sandbox, mock_modal):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox.start()
         sandbox.execute("sleep 1", timeout=42)
         # Last exec call should have timeout=42
         call = mock_modal["sandbox"].exec.call_args_list[-1]
         assert call.kwargs["timeout"] == 42
 
-    def test_execute_truncates_long_output(self, sandbox, mock_modal):
+    def test_execute_truncates_long_output(self, sandbox, mock_modal):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox.start()
         mock_modal["proc"].stdout.read.return_value = "a" * 200_000
         mock_modal["proc"].stderr.read.return_value = ""
-        sandbox._max_output_bytes = 1000
+        sandbox._max_output_bytes = 1000  # noqa: SLF001  # tracked: #288
         resp = sandbox.execute("big")
         assert resp.truncated
         assert "truncated" in resp.output
 
-    def test_execute_handles_exception_gracefully(self, sandbox, mock_modal):
+    def test_execute_handles_exception_gracefully(self, sandbox, mock_modal):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox.start()
         mock_modal["sandbox"].exec.side_effect = RuntimeError("boom")
         resp = sandbox.execute("x")
         assert resp.exit_code == -1
         assert "boom" in resp.output
 
-    def test_execute_raises_when_not_started(self, sandbox):
+    def test_execute_raises_when_not_started(self, sandbox):  # noqa: ANN001, ANN201  # tracked: #288
         with pytest.raises(RuntimeError, match="not started"):
             sandbox.execute("ls")
 
 
 class TestStop:
-    def test_stop_terminates_and_deletes_volume(self, sandbox, mock_modal):
+    def test_stop_terminates_and_deletes_volume(self, sandbox, mock_modal):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox.start()
         sandbox.stop()
         mock_modal["sandbox"].terminate.assert_called_once()
         mock_modal["objects"].delete.assert_called_once()
 
-    def test_stop_is_idempotent(self, sandbox, mock_modal):
+    def test_stop_is_idempotent(self, sandbox, mock_modal):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox.start()
         sandbox.stop()
         sandbox.stop()  # should not raise
@@ -296,10 +296,10 @@ class TestStop:
 
 
 class TestTransientRetry:
-    def test_is_transient_detects_dns_and_connection_errors(self):
-        import socket
+    def test_is_transient_detects_dns_and_connection_errors(self):  # noqa: ANN201  # tracked: #288
+        import socket  # noqa: PLC0415  # tracked: #288
 
-        from vs_sandbox.modal_sandbox import _is_transient
+        from vs_sandbox.modal_sandbox import _is_transient  # noqa: PLC0415  # tracked: #288
 
         assert _is_transient(socket.gaierror(-2, "Name or service not known"))
         assert _is_transient(ConnectionResetError("Connection reset"))
@@ -313,17 +313,17 @@ class TestTransientRetry:
         assert not _is_transient(FileNotFoundError("/nowhere"))
         assert not _is_transient(RuntimeError("something specific"))
 
-    def test_retry_recovers_after_transient_error(self, monkeypatch):
-        import socket
+    def test_retry_recovers_after_transient_error(self, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+        import socket  # noqa: PLC0415  # tracked: #288
 
-        from vs_sandbox.modal_sandbox import _retry_transient
+        from vs_sandbox.modal_sandbox import _retry_transient  # noqa: PLC0415  # tracked: #288
 
         # Avoid actual sleeping in the test.
         monkeypatch.setattr("vs_sandbox.modal_sandbox.time.sleep", lambda _: None)
 
         calls = {"n": 0}
 
-        def flaky():
+        def flaky():  # noqa: ANN202  # tracked: #288
             calls["n"] += 1
             if calls["n"] < 3:
                 raise socket.gaierror(-2, "Name or service not known")
@@ -332,29 +332,29 @@ class TestTransientRetry:
         assert _retry_transient(flaky, base_delay=0.01) == "ok"
         assert calls["n"] == 3
 
-    def test_retry_reraises_non_transient_immediately(self):
-        from vs_sandbox.modal_sandbox import _retry_transient
+    def test_retry_reraises_non_transient_immediately(self):  # noqa: ANN201  # tracked: #288
+        from vs_sandbox.modal_sandbox import _retry_transient  # noqa: PLC0415  # tracked: #288
 
         calls = {"n": 0}
 
-        def fatal():
+        def fatal():  # noqa: ANN202  # tracked: #288
             calls["n"] += 1
-            raise ValueError("real bug")
+            raise ValueError("real bug")  # noqa: TRY003  # tracked: #288
 
         with pytest.raises(ValueError, match="real bug"):
             _retry_transient(fatal, base_delay=0.01)
         assert calls["n"] == 1  # no retries for non-transient
 
-    def test_retry_gives_up_after_max_attempts(self, monkeypatch):
-        import socket
+    def test_retry_gives_up_after_max_attempts(self, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+        import socket  # noqa: PLC0415  # tracked: #288
 
-        from vs_sandbox.modal_sandbox import _retry_transient
+        from vs_sandbox.modal_sandbox import _retry_transient  # noqa: PLC0415  # tracked: #288
 
         monkeypatch.setattr("vs_sandbox.modal_sandbox.time.sleep", lambda _: None)
 
         calls = {"n": 0}
 
-        def always_fails():
+        def always_fails():  # noqa: ANN202  # tracked: #288
             calls["n"] += 1
             raise socket.gaierror(-2, "Name or service not known")
 
@@ -362,9 +362,9 @@ class TestTransientRetry:
             _retry_transient(always_fails, max_attempts=3, base_delay=0.01)
         assert calls["n"] == 3
 
-    def test_execute_retries_on_transient_then_succeeds(self, sandbox, mock_modal, monkeypatch):
+    def test_execute_retries_on_transient_then_succeeds(self, sandbox, mock_modal, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         """Integration: a flaky sandbox.exec should be transparently retried."""
-        import socket
+        import socket  # noqa: PLC0415  # tracked: #288
 
         monkeypatch.setattr("vs_sandbox.modal_sandbox.time.sleep", lambda _: None)
         sandbox.start()
@@ -376,7 +376,7 @@ class TestTransientRetry:
 
         attempt = {"n": 0}
 
-        def flaky_exec(*args, **kwargs):
+        def flaky_exec(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001  # tracked: #288
             attempt["n"] += 1
             if attempt["n"] < 3:
                 raise socket.gaierror(-2, "Name or service not known")
@@ -393,23 +393,23 @@ class TestTransientRetry:
 class TestSandboxFallbackRestart:
     """Verify the sandbox-dead fallback path: recreate + retry, preserving the volume."""
 
-    def test_is_sandbox_dead_recognizes_shutdown_messages(self):
-        from vs_sandbox.modal_sandbox import _is_sandbox_dead
+    def test_is_sandbox_dead_recognizes_shutdown_messages(self):  # noqa: ANN201  # tracked: #288
+        from vs_sandbox.modal_sandbox import _is_sandbox_dead  # noqa: PLC0415  # tracked: #288
 
         assert _is_sandbox_dead(RuntimeError("Sandbox has already shut down"))
         assert _is_sandbox_dead(Exception("Sandbox has exited"))
         assert _is_sandbox_dead(RuntimeError("sandbox is not running"))
         # Non-sandbox-dead errors must NOT trigger the restart path.
-        import socket
+        import socket  # noqa: PLC0415  # tracked: #288
 
         assert not _is_sandbox_dead(socket.gaierror(-2, "Name or service not known"))
         assert not _is_sandbox_dead(ValueError("bad argument"))
 
-    def test_execute_restarts_sandbox_on_death_and_retries(
+    def test_execute_restarts_sandbox_on_death_and_retries(  # noqa: ANN201  # tracked: #288
         self,
-        sandbox,
-        mock_modal,
-        monkeypatch,
+        sandbox,  # noqa: ANN001  # tracked: #288
+        mock_modal,  # noqa: ANN001  # tracked: #288
+        monkeypatch,  # noqa: ANN001  # tracked: #288
     ):
         """A dead sandbox should be recreated once, then the command re-run."""
         monkeypatch.setattr("vs_sandbox.modal_sandbox.time.sleep", lambda _: None)
@@ -422,10 +422,10 @@ class TestSandboxFallbackRestart:
 
         call = {"n": 0}
 
-        def flaky_exec(*args, **kwargs):
+        def flaky_exec(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001  # tracked: #288
             call["n"] += 1
             if call["n"] == 1:
-                raise RuntimeError("Sandbox has already shut down")
+                raise RuntimeError("Sandbox has already shut down")  # noqa: TRY003  # tracked: #288
             return proc_ok
 
         mock_modal["sandbox"].exec.side_effect = flaky_exec
@@ -436,19 +436,19 @@ class TestSandboxFallbackRestart:
         # 1 failing call (sandbox-dead) + init commands on restart + 1 successful call
         assert call["n"] >= 2
 
-    def test_restart_attempts_capped_by_max(self, sandbox, mock_modal, monkeypatch):
+    def test_restart_attempts_capped_by_max(self, sandbox, mock_modal, monkeypatch):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         """After max_restart_attempts, further restarts are refused."""
         monkeypatch.setattr("vs_sandbox.modal_sandbox.time.sleep", lambda _: None)
-        sandbox._max_restart_attempts = 1
+        sandbox._max_restart_attempts = 1  # noqa: SLF001  # tracked: #288
         sandbox.start()
 
         # First restart succeeds, a second attempted restart must be refused.
-        assert sandbox._restart_sandbox() is True
-        assert sandbox._restart_sandbox() is False  # capped
+        assert sandbox._restart_sandbox() is True  # noqa: SLF001  # tracked: #288
+        assert sandbox._restart_sandbox() is False  # capped  # noqa: SLF001  # tracked: #288
 
-    def test_restart_can_be_disabled(self, tmp_path, mock_modal, monkeypatch):
+    def test_restart_can_be_disabled(self, tmp_path, mock_modal, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         """enable_fallback_restart=False disables the recovery path entirely."""
-        from vs_sandbox.modal_sandbox import ModalSandbox
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415  # tracked: #288
 
         with ModalSandbox(
             host_workspace=str(tmp_path),
@@ -459,9 +459,9 @@ class TestSandboxFallbackRestart:
 
             call = {"n": 0}
 
-            def dies(*args, **kwargs):
+            def dies(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001  # tracked: #288
                 call["n"] += 1
-                raise RuntimeError("Sandbox has already shut down")
+                raise RuntimeError("Sandbox has already shut down")  # noqa: TRY003  # tracked: #288
 
             mock_modal["sandbox"].exec.side_effect = dies
 
@@ -469,11 +469,11 @@ class TestSandboxFallbackRestart:
             assert resp.exit_code == -1
             assert "already shut down" in resp.output.lower()
 
-    def test_extra_readonly_volumes_are_mounted(self, tmp_path, mock_modal):
+    def test_extra_readonly_volumes_are_mounted(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         """Auxiliary volumes like /draft_model should be added to volumes dict."""
-        import modal
+        import modal  # noqa: PLC0415  # tracked: #288
 
-        from vs_sandbox.modal_sandbox import ModalSandbox
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415  # tracked: #288
 
         with ModalSandbox(
             host_workspace=str(tmp_path),
@@ -485,10 +485,10 @@ class TestSandboxFallbackRestart:
 
 
 class TestPathOverrides:
-    def test_read_translates_virtual_path(self, sandbox, mock_modal):
+    def test_read_translates_virtual_path(self, sandbox, mock_modal):  # noqa: ANN001, ANN201  # tracked: #288
         sandbox.start()
         mock_modal["proc"].stdout.read.return_value = "     1\thello\n"
         sandbox.read("/foo.txt")
         # The base class builds a python3 heredoc command — check /workspace/foo.txt appears
         # (it gets base64-encoded; easier to check via _vpath directly).
-        assert sandbox._vpath("/foo.txt") == "/workspace/foo.txt"
+        assert sandbox._vpath("/foo.txt") == "/workspace/foo.txt"  # noqa: SLF001  # tracked: #288

--- a/libs/vs-sandbox/tests/test_modal_sandbox.py
+++ b/libs/vs-sandbox/tests/test_modal_sandbox.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_modal(monkeypatch):
     """Patch modal.Sandbox.create, Image.from_registry, App.lookup, Volume.from_name/delete."""
     import modal
@@ -52,7 +52,7 @@ def mock_modal(monkeypatch):
     assert not leaked, f"ModalSandbox tests leaked live sandboxes: {leaked}"
 
 
-@pytest.fixture()
+@pytest.fixture
 def sandbox(tmp_path, mock_modal):
     from vs_sandbox.modal_sandbox import ModalSandbox
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,9 @@ dev = [
     "pyright>=1.1.411",
     "pytest",
     "pytest-cov",
-    "ruff>=0.6",
+    # Pinned exactly (not `>=`): a routine lock refresh with a floating bound
+    # could silently change what CI enforces under the strict rule set below.
+    "ruff==0.15.12",
     # Optional for users, required for contributors: without it pyright cannot
     # resolve the Omnigent backend and its tests silently skip. `uv sync --dev`
     # (what CI runs) therefore installs it. Version comes from the extra, so
@@ -74,9 +76,19 @@ pythonpath = ["."]
 line-length = 100
 target-version = "py312"
 src = ["src", "tests", "libs/vs-feature-flags/src", "libs/vs-feature-flags/tests", "libs/vs-github/src", "libs/vs-github/tests", "libs/vs-issue-board/src", "libs/vs-issue-board/tests", "libs/vs-sandbox/src", "libs/vs-sandbox/tests"]
+# resources/skills/ vendors reference code (submodule checkouts and copied
+# reference material) that VibeSys does not own and does not hold to repo
+# lint standards; see the UP040/UP046/UP047 note below.
+extend-exclude = ["resources/skills"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B", "W"]
+select = [
+    "E", "F", "I", "UP", "B", "W",
+    "SIM", "RUF", "C4", "PIE", "ISC", "RSE", "INT", "FLY", "PERF", "FURB", "RET",
+    "A", "DTZ", "LOG", "G", "N", "PTH", "YTT", "EXE", "ASYNC", "ERA", "T10", "T20", "TID", "ICN", "INP",
+    "FBT", "FIX", "TD", "PGH",
+    "ANN", "BLE", "SLF", "C901", "PL", "S", "PT", "ARG", "TRY", "TC", "D",
+]
 ignore = [
     "E501",
     # PEP 695 type-parameter syntax (`def f[T]()`, `class C[T]`, `type X = ...`)
@@ -88,6 +100,30 @@ ignore = [
     "UP040",
     "UP046",
     "UP047",
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-type-checking]
+runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101", "PLR2004", "D", "INP001"]
+"libs/*/tests/**" = ["S101", "PLR2004", "D", "INP001"]
+# examples/ ships candidate reference implementations, benchmark harnesses,
+# and vendored submodule checkouts (transformers, DeathStarBench, TensorRT-LLM,
+# Show-o, train-ticket, TraceLab) rather than first-party framework code. Keep
+# it held to the pre-existing baseline (E, F, I, UP, B, W) but do not apply the
+# newly added rule families here.
+"examples/**" = [
+    "SIM", "RUF", "C4", "PIE", "ISC", "RSE", "INT", "FLY", "PERF", "FURB", "RET",
+    "A", "DTZ", "LOG", "G", "N", "PTH", "YTT", "EXE", "ASYNC", "ERA", "T10", "T20", "TID", "ICN", "INP",
+    "FBT", "FIX", "TD", "PGH",
+    "ANN", "BLE", "SLF", "C901", "PL", "S", "PT", "ARG", "TRY", "TC", "D",
 ]
 
 [tool.pyright]

--- a/resources/profilers/linux_cpu/server.py
+++ b/resources/profilers/linux_cpu/server.py
@@ -7,7 +7,7 @@ from mcp.server.fastmcp import FastMCP
 from vibesys.linux_cpu_profiler import collect, detect_capability, parse_command, summarize
 
 
-def build_server() -> FastMCP:
+def build_server() -> FastMCP:  # noqa: D103  # tracked: #288
     mcp = FastMCP("vibesys-linux-cpu-profiler")
 
     @mcp.tool()

--- a/resources/profilers/macos_cpu/server.py
+++ b/resources/profilers/macos_cpu/server.py
@@ -1,4 +1,4 @@
-"""MCP tools for collecting a separate macOS native CPU profile."""
+"""MCP tools for collecting a separate macOS native CPU profile."""  # noqa: INP001  # tracked: #288
 
 from pathlib import Path
 
@@ -7,7 +7,7 @@ from mcp.server.fastmcp import FastMCP
 from vibesys.macos_cpu_profiler import collect, detect_capability, parse_command
 
 
-def build_server() -> FastMCP:
+def build_server() -> FastMCP:  # noqa: D103  # tracked: #288
     mcp = FastMCP("vibesys-macos_cpu-profiler")
 
     @mcp.tool()

--- a/resources/profilers/neuron/analyze_neuron.py
+++ b/resources/profilers/neuron/analyze_neuron.py
@@ -51,9 +51,9 @@ def _explorer() -> str:
 
 def _run(cmd: list[str], *, timeout: int = 1800, cwd: str | None = None) -> int:
     """Run *cmd*, streaming combined output to stdout. Returns exit code."""
-    print(f"$ {' '.join(cmd)}", flush=True)
+    print(f"$ {' '.join(cmd)}", flush=True)  # noqa: T201  # tracked: #288
     try:
-        proc = subprocess.run(
+        proc = subprocess.run(  # noqa: PLW1510, S603  # tracked: #288
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -62,18 +62,18 @@ def _run(cmd: list[str], *, timeout: int = 1800, cwd: str | None = None) -> int:
             cwd=cwd,
         )
     except FileNotFoundError:
-        print(
+        print(  # noqa: T201  # tracked: #288
             "ERROR: neuron-explorer not found. It ships with aws-neuronx-tools; "
             "ensure /opt/aws/neuron/bin is on PATH inside the container.",
         )
         return 127
     except subprocess.TimeoutExpired:
-        print(f"ERROR: command timed out after {timeout}s")
+        print(f"ERROR: command timed out after {timeout}s")  # noqa: T201  # tracked: #288
         return 124
     if proc.stdout:
-        print(proc.stdout)
+        print(proc.stdout)  # noqa: T201  # tracked: #288
     if proc.returncode != 0:
-        print(f"(neuron-explorer exited with code {proc.returncode})")
+        print(f"(neuron-explorer exited with code {proc.returncode})")  # noqa: T201  # tracked: #288
     return proc.returncode
 
 
@@ -94,7 +94,7 @@ def _session_dir(report: str) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def cmd_capture(ns) -> None:
+def cmd_capture(ns) -> None:  # noqa: ANN001  # tracked: #288
     """Capture a system + device profile around a workload command.
 
     Runs ``neuron-explorer inspect -o <out_dir> <workload>``. The workload
@@ -106,7 +106,7 @@ def cmd_capture(ns) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     workload = ns.workload
     if not workload:
-        print("ERROR: --workload is required (the command that drives the model).")
+        print("ERROR: --workload is required (the command that drives the model).")  # noqa: T201  # tracked: #288
         return
     # inspect takes the user script as trailing args; run it via bash -lc so
     # the agent can pass a full pipeline / env-prefixed command as one string.
@@ -127,12 +127,12 @@ def cmd_capture(ns) -> None:
     rc = _run(cmd, timeout=ns.timeout, cwd=str(out_dir))
     ntff = _find_one(out_dir, ".ntff")
     neff = _find_one(out_dir, ".neff")
-    print("\n--- capture artifacts ---")
-    print(f"output dir : {out_dir}")
-    print(f"NTFF       : {ntff or '(none found — was the model executed on a NeuronCore?)'}")
-    print(f"NEFF       : {neff or '(none found — did the model compile + run on device?)'}")
+    print("\n--- capture artifacts ---")  # noqa: T201  # tracked: #288
+    print(f"output dir : {out_dir}")  # noqa: T201  # tracked: #288
+    print(f"NTFF       : {ntff or '(none found — was the model executed on a NeuronCore?)'}")  # noqa: T201  # tracked: #288
+    print(f"NEFF       : {neff or '(none found — did the model compile + run on device?)'}")  # noqa: T201  # tracked: #288
     if rc == 0 and ntff is None:
-        print(
+        print(  # noqa: T201  # tracked: #288
             "WARNING: inspect succeeded but produced no NTFF. The workload likely "
             "did not run a compiled graph on the NeuronCore (CPU fallback?)."
         )
@@ -152,7 +152,7 @@ def _view(session: Path, output_format: str, extra: list[str] | None = None) -> 
     _run(cmd)
 
 
-def cmd_summary(ns) -> None:
+def cmd_summary(ns) -> None:  # noqa: ANN001  # tracked: #288
     """High-level report: engine utilization, top operators, DMA totals.
 
     Wraps ``neuron-explorer view --output-format summary-text`` over the
@@ -160,21 +160,21 @@ def cmd_summary(ns) -> None:
     """
     session = _session_dir(ns.report)
     if not session.exists():
-        print(f"ERROR: session path does not exist: {session}")
+        print(f"ERROR: session path does not exist: {session}")  # noqa: T201  # tracked: #288
         return
     _view(session, "summary-text")
 
 
-def cmd_summary_json(ns) -> None:
+def cmd_summary_json(ns) -> None:  # noqa: ANN001  # tracked: #288
     """Machine-readable summary (``view --output-format summary-json``)."""
     session = _session_dir(ns.report)
     if not session.exists():
-        print(f"ERROR: session path does not exist: {session}")
+        print(f"ERROR: session path does not exist: {session}")  # noqa: T201  # tracked: #288
         return
     _view(session, "summary-json")
 
 
-def cmd_operators(ns) -> None:
+def cmd_operators(ns) -> None:  # noqa: ANN001  # tracked: #288
     """Per-operator / per-instruction breakdown from the device profile.
 
     Uses ``show-session -j`` (JSON) over the captured NTFF and prints the
@@ -183,35 +183,35 @@ def cmd_operators(ns) -> None:
     session = _session_dir(ns.report)
     ntff = _find_one(session, ".ntff")
     if ntff is None:
-        print(f"ERROR: no .ntff found under {session}")
+        print(f"ERROR: no .ntff found under {session}")  # noqa: T201  # tracked: #288
         return
     cmd = [_explorer(), "show-session", "-s", str(ntff), "-j"]
     # Capture JSON to summarize the top entries rather than dumping it whole.
-    print(f"$ {' '.join(cmd)}")
+    print(f"$ {' '.join(cmd)}")  # noqa: T201  # tracked: #288
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=600)  # noqa: PLW1510, S603  # tracked: #288
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-        print(f"ERROR running show-session: {exc}")
+        print(f"ERROR running show-session: {exc}")  # noqa: T201  # tracked: #288
         return
     if proc.returncode != 0:
-        print(proc.stdout)
-        print(proc.stderr)
+        print(proc.stdout)  # noqa: T201  # tracked: #288
+        print(proc.stderr)  # noqa: T201  # tracked: #288
         return
     try:
         data = json.loads(proc.stdout)
     except json.JSONDecodeError:
         # Not JSON we can parse — show it raw so the agent still gets signal.
-        print(proc.stdout[:20000])
+        print(proc.stdout[:20000])  # noqa: T201  # tracked: #288
         return
-    print(json.dumps(data, indent=2)[:20000])
+    print(json.dumps(data, indent=2)[:20000])  # noqa: T201  # tracked: #288
 
 
-def cmd_show(ns) -> None:
+def cmd_show(ns) -> None:  # noqa: ANN001  # tracked: #288
     """Raw session info (``show-session``), optionally with DMA/trace."""
     session = _session_dir(ns.report)
     ntff = _find_one(session, ".ntff")
     if ntff is None:
-        print(f"ERROR: no .ntff found under {session}")
+        print(f"ERROR: no .ntff found under {session}")  # noqa: T201  # tracked: #288
         return
     cmd = [_explorer(), "show-session", "-s", str(ntff)]
     if ns.dma:
@@ -221,11 +221,11 @@ def cmd_show(ns) -> None:
     _run(cmd)
 
 
-def cmd_view(ns) -> None:
+def cmd_view(ns) -> None:  # noqa: ANN001  # tracked: #288
     """Escape hatch: pass an explicit ``--output-format`` to ``view``."""
     session = _session_dir(ns.report)
     if not session.exists():
-        print(f"ERROR: session path does not exist: {session}")
+        print(f"ERROR: session path does not exist: {session}")  # noqa: T201  # tracked: #288
         return
     _view(session, ns.output_format)
 
@@ -235,7 +235,7 @@ def cmd_view(ns) -> None:
 # ---------------------------------------------------------------------------
 
 
-def build_parser() -> argparse.ArgumentParser:
+def build_parser() -> argparse.ArgumentParser:  # noqa: D103  # tracked: #288
     parser = argparse.ArgumentParser(
         prog="analyze_neuron",
         description="Capture and analyze NeuronCore profiles via neuron-explorer.",
@@ -243,7 +243,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     p = sub.add_parser("capture", help="Run a workload under neuron-explorer inspect.")
-    p.add_argument("--out-dir", default="/tmp/neuronprof", help="Output dir for profiles.")
+    p.add_argument("--out-dir", default="/tmp/neuronprof", help="Output dir for profiles.")  # noqa: S108  # tracked: #288
     p.add_argument("--workload", required=True, help="Shell command that drives the model.")
     p.add_argument("--timeout", type=int, default=1800)
     p.set_defaults(func=cmd_capture)
@@ -282,13 +282,13 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _with(ns, **overrides):
+def _with(ns, **overrides):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
     for k, v in overrides.items():
         setattr(ns, k, v)
     return ns
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: list[str] | None = None) -> int:  # noqa: D103  # tracked: #288
     # Make sure the Neuron tools dir is reachable for child processes too.
     for d in _NEURON_BIN_DIRS:
         if Path(d).is_dir() and d not in os.environ.get("PATH", ""):

--- a/resources/profilers/neuron/server.py
+++ b/resources/profilers/neuron/server.py
@@ -27,7 +27,7 @@ sys.path.insert(0, str(_HERE))
 import analyze_neuron  # noqa: E402  (sys.path setup above)
 
 
-def _capture(fn, **kwargs) -> str:
+def _capture(fn, **kwargs) -> str:  # noqa: ANN001, ANN003  # tracked: #288
     ns = types.SimpleNamespace(**kwargs)
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
@@ -35,11 +35,11 @@ def _capture(fn, **kwargs) -> str:
     return buf.getvalue() or "(no output)"
 
 
-def build_server() -> FastMCP:
+def build_server() -> FastMCP:  # noqa: D103  # tracked: #288
     mcp = FastMCP("vibesys-neuron-profiler")
 
     @mcp.tool()
-    def capture(workload: str, out_dir: str = "/tmp/neuronprof", timeout: int = 1800) -> str:
+    def capture(workload: str, out_dir: str = "/tmp/neuronprof", timeout: int = 1800) -> str:  # noqa: S108  # tracked: #288
         """Run a workload under ``neuron-explorer inspect`` and capture profiles.
 
         Args:
@@ -90,7 +90,7 @@ def build_server() -> FastMCP:
     return mcp
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: list[str] | None = None) -> None:  # noqa: D103  # tracked: #288
     parser = argparse.ArgumentParser(
         prog="vibesys-neuron-mcp",
         description="Stdio MCP server exposing neuron-explorer profile analyses.",

--- a/resources/profilers/nsys/analyze_nsys.py
+++ b/resources/profilers/nsys/analyze_nsys.py
@@ -15,7 +15,7 @@ Usage:
     python analyze_nsys.py step-timeline profile.sqlite    # Per-decode-step breakdown
     python analyze_nsys.py query profile.sqlite "SQL"      # Run arbitrary SQL
     python analyze_nsys.py summary profile.sqlite          # All-in-one (legacy)
-"""
+"""  # noqa: EXE001  # tracked: #288
 
 from __future__ import annotations
 
@@ -35,7 +35,7 @@ def _open_db(path: str) -> tuple[sqlite3.Connection, dict[int, str]]:
     """Open the SQLite file and build the string map."""
     conn = sqlite3.connect(path)
     strings: dict[int, str] = {}
-    try:
+    try:  # noqa: SIM105  # tracked: #288
         strings = dict(conn.execute("SELECT id, value FROM StringIds").fetchall())
     except sqlite3.OperationalError:
         pass
@@ -72,12 +72,12 @@ def _short_kernel_name(raw: str) -> str:
             result.append(ch)
     name = "".join(result).strip()
     parts = name.split("::")
-    if len(parts) > 2:
+    if len(parts) > 2:  # noqa: PLR2004  # tracked: #288
         name = "::".join(parts[-2:])
     return name
 
 
-def _resolve_name(name_val, strings: dict[int, str]) -> str:
+def _resolve_name(name_val, strings: dict[int, str]) -> str:  # noqa: ANN001  # tracked: #288
     if isinstance(name_val, int) and name_val in strings:
         return _short_kernel_name(strings[name_val])
     if isinstance(name_val, str):
@@ -99,8 +99,8 @@ def _ensure_sqlite(path: str) -> str:
         sqlite_path = p.with_suffix(".sqlite")
         if sqlite_path.exists():
             sqlite_path.unlink()
-        subprocess.run(
-            ["nsys", "export", "--type=sqlite", f"--output={sqlite_path}", str(p)],
+        subprocess.run(  # noqa: S603  # tracked: #288
+            ["nsys", "export", "--type=sqlite", f"--output={sqlite_path}", str(p)],  # noqa: S607  # tracked: #288
             check=True,
             capture_output=True,
             text=True,
@@ -110,22 +110,24 @@ def _ensure_sqlite(path: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Subcommand: export
+# tracked: #288
+# Subcommand: export  # noqa: ERA001
 # ---------------------------------------------------------------------------
 
 
-def cmd_export(args):
+def cmd_export(args):  # noqa: ANN001, ANN201  # tracked: #288
     """Export .nsys-rep to .sqlite."""
     out = _ensure_sqlite(args.report)
-    print(f"Exported to: {out}")
+    print(f"Exported to: {out}")  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
-# Subcommand: tables
+# tracked: #288
+# Subcommand: tables  # noqa: ERA001
 # ---------------------------------------------------------------------------
 
 
-def cmd_tables(args):
+def cmd_tables(args):  # noqa: ANN001, ANN201  # tracked: #288
     """List non-empty tables in the SQLite export."""
     conn, _ = _open_db(_ensure_sqlite(args.report))
     tables = conn.execute(
@@ -133,61 +135,63 @@ def cmd_tables(args):
     ).fetchall()
     for (name,) in tables:
         try:
-            cnt = conn.execute(f"SELECT COUNT(*) FROM [{name}]").fetchone()[0]
+            cnt = conn.execute(f"SELECT COUNT(*) FROM [{name}]").fetchone()[0]  # noqa: S608  # tracked: #288
         except sqlite3.OperationalError:
             cnt = "?"
         if cnt and cnt != "?" and int(cnt) > 0:
-            print(f"  {name}: {cnt} rows")
+            print(f"  {name}: {cnt} rows")  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
-# Subcommand: kernels
+# tracked: #288
+# Subcommand: kernels  # noqa: ERA001
 # ---------------------------------------------------------------------------
 
 
-def cmd_kernels(args):
+def cmd_kernels(args):  # noqa: ANN001, ANN201  # tracked: #288
     """Top GPU kernels by total execution time."""
     conn, strings = _open_db(_ensure_sqlite(args.report))
     if not _table_exists(conn, "CUPTI_ACTIVITY_KIND_KERNEL"):
-        print("(No kernel data found.)")
+        print("(No kernel data found.)")  # noqa: T201  # tracked: #288
         return
     name_col = _kernel_name_col(conn)
     if not name_col:
-        print("(No kernel name column found.)")
+        print("(No kernel name column found.)")  # noqa: T201  # tracked: #288
         return
 
     rows = conn.execute(
         f"""SELECT {name_col}, COUNT(*), SUM(end-start), AVG(end-start)
             FROM CUPTI_ACTIVITY_KIND_KERNEL
-            GROUP BY {name_col} ORDER BY SUM(end-start) DESC LIMIT ?""",
+            GROUP BY {name_col} ORDER BY SUM(end-start) DESC LIMIT ?""",  # noqa: S608  # tracked: #288
         (args.top,),
     ).fetchall()
     if not rows:
-        print("(No kernels recorded.)")
+        print("(No kernels recorded.)")  # noqa: T201  # tracked: #288
         return
 
     total_ns = sum(r[2] for r in rows)
-    print(f"{'Kernel':<55s} {'Count':>7s} {'Total(us)':>11s} {'Avg(us)':>9s} {'%GPU':>6s}")
-    print("-" * 92)
+    print(f"{'Kernel':<55s} {'Count':>7s} {'Total(us)':>11s} {'Avg(us)':>9s} {'%GPU':>6s}")  # noqa: T201  # tracked: #288
+    print("-" * 92)  # noqa: T201  # tracked: #288
     for name_id, cnt, tot, avg in rows:
         name = _resolve_name(name_id, strings)
         pct = tot / total_ns * 100 if total_ns else 0
-        print(f"{name:<55s} {cnt:>7d} {tot / 1000:>11.1f} {avg / 1000:>9.1f} {pct:>5.1f}%")
+        print(f"{name:<55s} {cnt:>7d} {tot / 1000:>11.1f} {avg / 1000:>9.1f} {pct:>5.1f}%")  # noqa: T201  # tracked: #288
     total_launches = sum(r[1] for r in rows)
-    print(f"\nTotal GPU kernel time: {total_ns / 1e6:.2f} ms")
-    print(f"Total kernel launches: {total_launches}")
+    print(f"\nTotal GPU kernel time: {total_ns / 1e6:.2f} ms")  # noqa: T201  # tracked: #288
+    print(f"Total kernel launches: {total_launches}")  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
-# Subcommand: cpu-overhead
+# tracked: #288
+# Subcommand: cpu-overhead  # noqa: ERA001
 # ---------------------------------------------------------------------------
 
 
-def cmd_cpu_overhead(args):
+def cmd_cpu_overhead(args):  # noqa: ANN001, ANN201, C901  # tracked: #288
     """CPU-side CUDA runtime overhead and launch-bound detection."""
-    conn, strings = _open_db(_ensure_sqlite(args.report))
+    conn, strings = _open_db(_ensure_sqlite(args.report))  # noqa: RUF059  # tracked: #288
     if not _table_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME"):
-        print("(No CUDA runtime data.)")
+        print("(No CUDA runtime data.)")  # noqa: T201  # tracked: #288
         return
 
     row = conn.execute(
@@ -195,11 +199,11 @@ def cmd_cpu_overhead(args):
     ).fetchone()
     total_calls, total_ns = row or (0, 0)
     total_ns = total_ns or 0
-    print(f"Total CUDA runtime API calls: {total_calls}")
-    print(f"Total CPU time in CUDA APIs:  {total_ns / 1e6:.2f} ms")
+    print(f"Total CUDA runtime API calls: {total_calls}")  # noqa: T201  # tracked: #288
+    print(f"Total CPU time in CUDA APIs:  {total_ns / 1e6:.2f} ms")  # noqa: T201  # tracked: #288
 
     has_cbid = _column_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME", "cbid")
-    has_nameId = _column_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME", "nameId")
+    has_nameId = _column_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME", "nameId")  # noqa: N806  # tracked: #288
 
     if has_nameId:
         api_rows = conn.execute(
@@ -209,10 +213,10 @@ def cmd_cpu_overhead(args):
                GROUP BY r.nameId ORDER BY SUM(r.end-r.start) DESC LIMIT 10"""
         ).fetchall()
         if api_rows:
-            print(f"\n{'API Function':<40s} {'Count':>8s} {'Total(us)':>11s} {'Avg(us)':>9s}")
-            print("-" * 72)
+            print(f"\n{'API Function':<40s} {'Count':>8s} {'Total(us)':>11s} {'Avg(us)':>9s}")  # noqa: T201  # tracked: #288
+            print("-" * 72)  # noqa: T201  # tracked: #288
             for name, cnt, tot, avg in api_rows:
-                print(f"{(name or '?'):<40s} {cnt:>8d} {tot / 1000:>11.1f} {avg / 1000:>9.1f}")
+                print(f"{(name or '?'):<40s} {cnt:>8d} {tot / 1000:>11.1f} {avg / 1000:>9.1f}")  # noqa: T201  # tracked: #288
 
         # Sync stalls
         sync_rows = conn.execute(
@@ -226,7 +230,7 @@ def cmd_cpu_overhead(args):
         ).fetchall()
         sync_total = sum(r[2] for r in sync_rows) if sync_rows else 0
         sync_count = sum(r[1] for r in sync_rows) if sync_rows else 0
-        print(f"\nSynchronization stalls: {sync_count} calls, {sync_total / 1e6:.2f} ms")
+        print(f"\nSynchronization stalls: {sync_count} calls, {sync_total / 1e6:.2f} ms")  # noqa: T201  # tracked: #288
 
         # Launch overhead ratio
         launch_filter = (
@@ -249,20 +253,20 @@ def cmd_cpu_overhead(args):
             "FROM CUPTI_ACTIVITY_KIND_RUNTIME GROUP BY cbid ORDER BY SUM(end-start) DESC LIMIT 10"
         ).fetchall()
         if api_rows:
-            print(f"\n{'API Function':<40s} {'Count':>8s} {'Total(us)':>11s} {'Avg(us)':>9s}")
-            print("-" * 72)
+            print(f"\n{'API Function':<40s} {'Count':>8s} {'Total(us)':>11s} {'Avg(us)':>9s}")  # noqa: T201  # tracked: #288
+            print("-" * 72)  # noqa: T201  # tracked: #288
             for cbid, cnt, tot, avg in api_rows:
-                print(
+                print(  # noqa: T201  # tracked: #288
                     f"{cbid_names.get(cbid, f'cbid_{cbid}'):<40s} {cnt:>8d} {tot / 1000:>11.1f} {avg / 1000:>9.1f}"
                 )
         sync_cbids = {162, 163, 164}
         sync_rows = conn.execute(
-            f"SELECT cbid, COUNT(*), SUM(end-start) FROM CUPTI_ACTIVITY_KIND_RUNTIME "
+            f"SELECT cbid, COUNT(*), SUM(end-start) FROM CUPTI_ACTIVITY_KIND_RUNTIME "  # noqa: S608  # tracked: #288
             f"WHERE cbid IN ({','.join(str(c) for c in sync_cbids)}) GROUP BY cbid"
         ).fetchall()
         sync_total = sum(r[2] for r in sync_rows) if sync_rows else 0
         sync_count = sum(r[1] for r in sync_rows) if sync_rows else 0
-        print(f"\nSynchronization stalls: {sync_count} calls, {sync_total / 1e6:.2f} ms")
+        print(f"\nSynchronization stalls: {sync_count} calls, {sync_total / 1e6:.2f} ms")  # noqa: T201  # tracked: #288
         launch_filter = "r.cbid IN (33, 211)"
     else:
         return
@@ -272,39 +276,40 @@ def cmd_cpu_overhead(args):
             f"""SELECT AVG(r.end-r.start), AVG(k.end-k.start), COUNT(*)
                 FROM CUPTI_ACTIVITY_KIND_KERNEL k
                 JOIN CUPTI_ACTIVITY_KIND_RUNTIME r ON k.correlationId = r.correlationId
-                WHERE {launch_filter}"""
+                WHERE {launch_filter}"""  # noqa: S608  # tracked: #288
         ).fetchone()
         if joined and joined[2] > 0:
             avg_cpu = joined[0] / 1000
             avg_gpu = joined[1] / 1000
-            print(f"\nKernel launch overhead ({joined[2]} matched):")
-            print(f"  Avg CPU launch: {avg_cpu:.1f} us")
-            print(f"  Avg GPU exec:   {avg_gpu:.1f} us")
+            print(f"\nKernel launch overhead ({joined[2]} matched):")  # noqa: T201  # tracked: #288
+            print(f"  Avg CPU launch: {avg_cpu:.1f} us")  # noqa: T201  # tracked: #288
+            print(f"  Avg GPU exec:   {avg_gpu:.1f} us")  # noqa: T201  # tracked: #288
             if avg_gpu > 0:
                 ratio = avg_cpu / avg_gpu
-                print(f"  CPU/GPU ratio:  {ratio:.2f}x")
+                print(f"  CPU/GPU ratio:  {ratio:.2f}x")  # noqa: T201  # tracked: #288
                 if ratio > 1.0:
-                    print("  *** LAUNCH-BOUND — CPU slower than GPU ***")
+                    print("  *** LAUNCH-BOUND — CPU slower than GPU ***")  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
-# Subcommand: idle-gaps
+# tracked: #288
+# Subcommand: idle-gaps  # noqa: ERA001
 # ---------------------------------------------------------------------------
 
 
-def cmd_idle_gaps(args):
+def cmd_idle_gaps(args):  # noqa: ANN001, ANN201, C901  # tracked: #288
     """Find largest GPU idle gaps between kernels."""
     conn, strings = _open_db(_ensure_sqlite(args.report))
     if not _table_exists(conn, "CUPTI_ACTIVITY_KIND_KERNEL"):
-        print("(No kernel data.)")
+        print("(No kernel data.)")  # noqa: T201  # tracked: #288
         return
     name_col = _kernel_name_col(conn)
 
     rows = conn.execute(
-        f"SELECT {name_col}, start, end, deviceId FROM CUPTI_ACTIVITY_KIND_KERNEL ORDER BY deviceId, start"
+        f"SELECT {name_col}, start, end, deviceId FROM CUPTI_ACTIVITY_KIND_KERNEL ORDER BY deviceId, start"  # noqa: S608  # tracked: #288
     ).fetchall()
-    if len(rows) < 2:
-        print("(Fewer than 2 kernels.)")
+    if len(rows) < 2:  # noqa: PLR2004  # tracked: #288
+        print("(Fewer than 2 kernels.)")  # noqa: T201  # tracked: #288
         return
 
     by_device: dict[int, list] = defaultdict(list)
@@ -312,7 +317,7 @@ def cmd_idle_gaps(args):
         by_device[r[3]].append(r)
 
     gaps, total_idle, total_busy = [], 0, 0
-    for _device_id, kernels in by_device.items():
+    for _device_id, kernels in by_device.items():  # noqa: PERF102  # tracked: #288
         intervals = sorted((k[1], k[2]) for k in kernels)
         merged = []
         for s, e in intervals:
@@ -326,7 +331,7 @@ def cmd_idle_gaps(args):
         start_map = {k[1]: k for k in kernels}
         for i in range(1, len(merged)):
             gap = merged[i][0] - merged[i - 1][1]
-            if gap > 1000:
+            if gap > 1000:  # noqa: PLR2004  # tracked: #288
                 total_idle += gap
                 prev = end_map.get(merged[i - 1][1])
                 nxt = start_map.get(merged[i][0])
@@ -337,23 +342,24 @@ def cmd_idle_gaps(args):
     gaps.sort(key=lambda x: -x[2])
     total = total_busy + total_idle
     pct = total_idle / total * 100 if total else 0
-    print(f"GPU busy: {total_busy / 1e6:.2f} ms")
-    print(f"GPU idle: {total_idle / 1e6:.2f} ms ({pct:.1f}%)")
-    print(f"Idle gaps (>1us): {len(gaps)}")
+    print(f"GPU busy: {total_busy / 1e6:.2f} ms")  # noqa: T201  # tracked: #288
+    print(f"GPU idle: {total_idle / 1e6:.2f} ms ({pct:.1f}%)")  # noqa: T201  # tracked: #288
+    print(f"Idle gaps (>1us): {len(gaps)}")  # noqa: T201  # tracked: #288
     if gaps[: args.top]:
-        print(f"\nTop {min(args.top, len(gaps))} gaps:")
-        print(f"  {'Gap(us)':>10s}  {'After':<40s} → {'Before':<40s}")
-        print("  " + "-" * 95)
+        print(f"\nTop {min(args.top, len(gaps))} gaps:")  # noqa: T201  # tracked: #288
+        print(f"  {'Gap(us)':>10s}  {'After':<40s} → {'Before':<40s}")  # noqa: T201  # tracked: #288
+        print("  " + "-" * 95)  # noqa: T201  # tracked: #288
         for pn, nn, g in gaps[: args.top]:
-            print(f"  {g / 1000:>10.1f}  {pn:<40s} → {nn:<40s}")
+            print(f"  {g / 1000:>10.1f}  {pn:<40s} → {nn:<40s}")  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
-# Subcommand: memory
+# tracked: #288
+# Subcommand: memory  # noqa: ERA001
 # ---------------------------------------------------------------------------
 
 
-def cmd_memory(args):
+def cmd_memory(args):  # noqa: ANN001, ANN201  # tracked: #288
     """Memory copy and allocation operations."""
     conn, _ = _open_db(_ensure_sqlite(args.report))
 
@@ -364,17 +370,17 @@ def cmd_memory(args):
             "FROM CUPTI_ACTIVITY_KIND_MEMCPY GROUP BY copyKind ORDER BY SUM(end-start) DESC"
         ).fetchall()
         if rows:
-            print(f"{'Dir':<8s} {'Count':>8s} {'Total(us)':>11s} {'Bytes':>14s}")
-            print("-" * 45)
+            print(f"{'Dir':<8s} {'Count':>8s} {'Total(us)':>11s} {'Bytes':>14s}")  # noqa: T201  # tracked: #288
+            print("-" * 45)  # noqa: T201  # tracked: #288
             for kind, cnt, tot, byt in rows:
-                print(
+                print(  # noqa: T201  # tracked: #288
                     f"{kinds.get(kind, f'k{kind}'):<8s} {cnt:>8d} {tot / 1000:>11.1f} {byt:>14,d}"
                 )
     else:
-        print("(No memcpy data.)")
+        print("(No memcpy data.)")  # noqa: T201  # tracked: #288
 
     if _table_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME"):
-        has_nameId = _column_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME", "nameId")
+        has_nameId = _column_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME", "nameId")  # noqa: N806  # tracked: #288
         if has_nameId:
             rows = conn.execute(
                 """SELECT s.value, COUNT(*), SUM(r.end-r.start)
@@ -384,48 +390,49 @@ def cmd_memory(args):
                    GROUP BY s.value"""
             ).fetchall()
             if rows:
-                print(f"\n{'Alloc API':<25s} {'Count':>8s} {'Total(us)':>11s}")
-                print("-" * 48)
+                print(f"\n{'Alloc API':<25s} {'Count':>8s} {'Total(us)':>11s}")  # noqa: T201  # tracked: #288
+                print("-" * 48)  # noqa: T201  # tracked: #288
                 for name, cnt, tot in rows:
-                    print(f"{name:<25s} {cnt:>8d} {tot / 1000:>11.1f}")
+                    print(f"{name:<25s} {cnt:>8d} {tot / 1000:>11.1f}")  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
-# Subcommand: graph-replays
+# tracked: #288
+# Subcommand: graph-replays  # noqa: ERA001
 # ---------------------------------------------------------------------------
 
 
-def cmd_graph_replays(args):
+def cmd_graph_replays(args):  # noqa: ANN001, ANN201  # tracked: #288
     """CUDA graph replay statistics from CUPTI_ACTIVITY_KIND_GRAPH_TRACE."""
-    conn, strings = _open_db(_ensure_sqlite(args.report))
+    conn, strings = _open_db(_ensure_sqlite(args.report))  # noqa: RUF059  # tracked: #288
 
     if not _table_exists(conn, "CUPTI_ACTIVITY_KIND_GRAPH_TRACE"):
-        print("(No graph trace data — CUDA graphs may not be active.)")
+        print("(No graph trace data — CUDA graphs may not be active.)")  # noqa: T201  # tracked: #288
         return
 
     traces = conn.execute(
         "SELECT start, end, graphId, graphExecId FROM CUPTI_ACTIVITY_KIND_GRAPH_TRACE ORDER BY start"
     ).fetchall()
     if not traces:
-        print("(Graph trace table is empty.)")
+        print("(Graph trace table is empty.)")  # noqa: T201  # tracked: #288
         return
 
-    print(f"Total graph replays: {len(traces)}")
+    print(f"Total graph replays: {len(traces)}")  # noqa: T201  # tracked: #288
 
     # Per-graphExecId stats
     by_exec: dict[int, list[int]] = defaultdict(list)
     for s, e, _gid, geid in traces:
         by_exec[geid].append(e - s)
 
-    print(
+    print(  # noqa: T201  # tracked: #288
         f"\n{'GraphExec':>10s} {'Replays':>8s} {'Avg(us)':>10s} {'Min(us)':>10s} {'Max(us)':>10s}"
     )
-    print("-" * 52)
+    print("-" * 52)  # noqa: T201  # tracked: #288
     for geid, durs in sorted(by_exec.items()):
         avg = sum(durs) / len(durs) / 1000
         mn = min(durs) / 1000
         mx = max(durs) / 1000
-        print(f"{geid:>10d} {len(durs):>8d} {avg:>10.1f} {mn:>10.1f} {mx:>10.1f}")
+        print(f"{geid:>10d} {len(durs):>8d} {avg:>10.1f} {mn:>10.1f} {mx:>10.1f}")  # noqa: T201  # tracked: #288
 
     # Match with CPU-side cudaGraphLaunch
     if _table_exists(conn, "CUPTI_ACTIVITY_KIND_RUNTIME") and _column_exists(
@@ -440,31 +447,32 @@ def cmd_graph_replays(args):
         ).fetchall()
         if launch_rows:
             cpu_durs = [(r[1] - r[0]) / 1000 for r in launch_rows]
-            print(f"\ncudaGraphLaunch calls: {len(cpu_durs)}")
-            print(f"  CPU launch avg: {sum(cpu_durs) / len(cpu_durs):.1f} us")
-            print(f"  CPU launch min: {min(cpu_durs):.1f} us")
-            print(f"  CPU launch max: {max(cpu_durs):.1f} us")
+            print(f"\ncudaGraphLaunch calls: {len(cpu_durs)}")  # noqa: T201  # tracked: #288
+            print(f"  CPU launch avg: {sum(cpu_durs) / len(cpu_durs):.1f} us")  # noqa: T201  # tracked: #288
+            print(f"  CPU launch min: {min(cpu_durs):.1f} us")  # noqa: T201  # tracked: #288
+            print(f"  CPU launch max: {max(cpu_durs):.1f} us")  # noqa: T201  # tracked: #288
 
     # Gap between consecutive replays (scheduling overhead)
-    if len(traces) >= 2:
+    if len(traces) >= 2:  # noqa: PLR2004  # tracked: #288
         replay_gaps = [traces[i][0] - traces[i - 1][1] for i in range(1, len(traces))]
         replay_gaps = [g for g in replay_gaps if g > 0]
         if replay_gaps:
             avg_gap = sum(replay_gaps) / len(replay_gaps) / 1000
             med_gap = sorted(replay_gaps)[len(replay_gaps) // 2] / 1000
-            print("\nGap between replays (scheduling overhead):")
-            print(f"  Avg: {avg_gap:.1f} us")
-            print(f"  Median: {med_gap:.1f} us")
-            print(f"  Min: {min(replay_gaps) / 1000:.1f} us")
-            print(f"  Max: {max(replay_gaps) / 1000:.1f} us")
+            print("\nGap between replays (scheduling overhead):")  # noqa: T201  # tracked: #288
+            print(f"  Avg: {avg_gap:.1f} us")  # noqa: T201  # tracked: #288
+            print(f"  Median: {med_gap:.1f} us")  # noqa: T201  # tracked: #288
+            print(f"  Min: {min(replay_gaps) / 1000:.1f} us")  # noqa: T201  # tracked: #288
+            print(f"  Max: {max(replay_gaps) / 1000:.1f} us")  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
-# Subcommand: step-timeline
+# tracked: #288
+# Subcommand: step-timeline  # noqa: ERA001
 # ---------------------------------------------------------------------------
 
 
-def cmd_step_timeline(args):
+def cmd_step_timeline(args):  # noqa: ANN001, ANN201, C901, PLR0912, PLR0915  # tracked: #288
     """Per-decode-step kernel breakdown.
 
     Detects repeating kernel patterns to identify individual decode steps,
@@ -474,22 +482,22 @@ def cmd_step_timeline(args):
     """
     conn, strings = _open_db(_ensure_sqlite(args.report))
     if not _table_exists(conn, "CUPTI_ACTIVITY_KIND_KERNEL"):
-        print("(No kernel data.)")
+        print("(No kernel data.)")  # noqa: T201  # tracked: #288
         return
     name_col = _kernel_name_col(conn)
     if not name_col:
-        print("(No kernel name column.)")
+        print("(No kernel name column.)")  # noqa: T201  # tracked: #288
         return
 
     # Load steady-state kernels (skip first 60% which is likely warmup/loading)
     total = conn.execute("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_KERNEL").fetchone()[0]
     offset = max(0, int(total * 0.6))
     rows = conn.execute(
-        f"SELECT {name_col}, start, end FROM CUPTI_ACTIVITY_KIND_KERNEL ORDER BY start LIMIT 5000 OFFSET ?",
+        f"SELECT {name_col}, start, end FROM CUPTI_ACTIVITY_KIND_KERNEL ORDER BY start LIMIT 5000 OFFSET ?",  # noqa: S608  # tracked: #288
         (offset,),
     ).fetchall()
-    if len(rows) < 100:
-        print("(Not enough steady-state kernels to detect decode steps.)")
+    if len(rows) < 100:  # noqa: PLR2004  # tracked: #288
+        print("(Not enough steady-state kernels to detect decode steps.)")  # noqa: T201  # tracked: #288
         return
 
     # Find decode step boundaries: gaps > threshold
@@ -499,7 +507,7 @@ def cmd_step_timeline(args):
         reverse=True,
     )
     if not all_gaps:
-        print("(No gaps between kernels.)")
+        print("(No gaps between kernels.)")  # noqa: T201  # tracked: #288
         return
 
     # Use the largest gap cluster as step boundaries
@@ -508,7 +516,7 @@ def cmd_step_timeline(args):
     for pct in [0.01, 0.02, 0.05, 0.1]:
         thresh = all_gaps[max(0, int(len(all_gaps) * pct))]
         boundaries = [i for i in range(1, len(rows)) if rows[i][1] - rows[i - 1][2] > thresh]
-        if len(boundaries) >= 3:
+        if len(boundaries) >= 3:  # noqa: PLR2004  # tracked: #288
             sizes = [boundaries[j + 1] - boundaries[j] for j in range(len(boundaries) - 1)]
             # Check consistency: most steps should be similar size
             if sizes and max(sizes) < 3 * min(sizes):
@@ -517,11 +525,11 @@ def cmd_step_timeline(args):
 
     if best_thresh is None:
         # Fallback: use a fixed threshold
-        best_thresh = all_gaps[min(5, len(all_gaps) - 1)] if len(all_gaps) > 5 else 100000
+        best_thresh = all_gaps[min(5, len(all_gaps) - 1)] if len(all_gaps) > 5 else 100000  # noqa: PLR2004  # tracked: #288
 
     boundaries = [i for i in range(1, len(rows)) if rows[i][1] - rows[i - 1][2] > best_thresh]
-    if len(boundaries) < 2:
-        print(
+    if len(boundaries) < 2:  # noqa: PLR2004  # tracked: #288
+        print(  # noqa: T201  # tracked: #288
             "(Could not detect decode step boundaries. Try graph-replays if CUDA graphs are active.)"
         )
         return
@@ -538,13 +546,13 @@ def cmd_step_timeline(args):
     gap_time = sum(max(0, step_rows[i][1] - step_rows[i - 1][2]) for i in range(1, len(step_rows)))
 
     sizes = [boundaries[j + 1] - boundaries[j] for j in range(min(5, len(boundaries) - 1))]
-    print(f"Detected {len(boundaries)} decode steps (threshold: {best_thresh / 1000:.0f} us)")
-    print(f"Kernels per step: {sizes}")
-    print(f"\n=== Decode step {step_idx} ({n_kernels} kernels) ===")
-    print(f"GPU time:  {gpu_time / 1000:.0f} us")
-    print(f"Gap time:  {gap_time / 1000:.0f} us")
-    print(f"Wall time: {wall_time / 1000:.0f} us")
-    print(f"GPU util:  {gpu_time / wall_time * 100:.0f}%" if wall_time else "")
+    print(f"Detected {len(boundaries)} decode steps (threshold: {best_thresh / 1000:.0f} us)")  # noqa: T201  # tracked: #288
+    print(f"Kernels per step: {sizes}")  # noqa: T201  # tracked: #288
+    print(f"\n=== Decode step {step_idx} ({n_kernels} kernels) ===")  # noqa: T201  # tracked: #288
+    print(f"GPU time:  {gpu_time / 1000:.0f} us")  # noqa: T201  # tracked: #288
+    print(f"Gap time:  {gap_time / 1000:.0f} us")  # noqa: T201  # tracked: #288
+    print(f"Wall time: {wall_time / 1000:.0f} us")  # noqa: T201  # tracked: #288
+    print(f"GPU util:  {gpu_time / wall_time * 100:.0f}%" if wall_time else "")  # noqa: T201  # tracked: #288
 
     # Kernel breakdown
     kstats = defaultdict(lambda: {"count": 0, "total": 0})
@@ -553,11 +561,11 @@ def cmd_step_timeline(args):
         kstats[name]["count"] += 1
         kstats[name]["total"] += r[2] - r[1]
 
-    print(f"\n{'Kernel':<50s} {'Cnt':>5s} {'Total(us)':>10s} {'Avg(us)':>8s} {'%step':>6s}")
-    print("-" * 83)
+    print(f"\n{'Kernel':<50s} {'Cnt':>5s} {'Total(us)':>10s} {'Avg(us)':>8s} {'%step':>6s}")  # noqa: T201  # tracked: #288
+    print("-" * 83)  # noqa: T201  # tracked: #288
     for name, s in sorted(kstats.items(), key=lambda x: -x[1]["total"]):
         pct = s["total"] / gpu_time * 100 if gpu_time else 0
-        print(
+        print(  # noqa: T201  # tracked: #288
             f"{name:<50s} {s['count']:>5d} {s['total'] / 1000:>10.1f} {s['total'] / s['count'] / 1000:>8.1f} {pct:>5.1f}%"
         )
 
@@ -571,13 +579,13 @@ def cmd_step_timeline(args):
             gstats[f"{pn:20s} → {nn}"]["count"] += 1
             gstats[f"{pn:20s} → {nn}"]["total"] += g
 
-    print(f"\n{'Gap transition':<45s} {'Cnt':>5s} {'Total(us)':>10s} {'Avg(us)':>8s}")
-    print("-" * 72)
+    print(f"\n{'Gap transition':<45s} {'Cnt':>5s} {'Total(us)':>10s} {'Avg(us)':>8s}")  # noqa: T201  # tracked: #288
+    print("-" * 72)  # noqa: T201  # tracked: #288
     for key, s in sorted(gstats.items(), key=lambda x: -x[1]["total"])[:10]:
-        print(
+        print(  # noqa: T201  # tracked: #288
             f"{key:<45s} {s['count']:>5d} {s['total'] / 1000:>10.1f} {s['total'] / s['count'] / 1000:>8.1f}"
         )
-    print(f"\nTotal intra-step gap: {gap_time / 1000:.0f} us")
+    print(f"\nTotal intra-step gap: {gap_time / 1000:.0f} us")  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
@@ -593,10 +601,10 @@ def _build_string_map(conn: sqlite3.Connection) -> dict[int, str]:
         return {}
 
 
-def _capture_stdout(fn, *a, **kw) -> str:
+def _capture_stdout(fn, *a, **kw) -> str:  # noqa: ANN001, ANN002, ANN003  # tracked: #288
     """Run fn() and capture its stdout as a string."""
-    import contextlib
-    import io
+    import contextlib  # noqa: PLC0415  # tracked: #288
+    import io  # noqa: PLC0415  # tracked: #288
 
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
@@ -604,7 +612,7 @@ def _capture_stdout(fn, *a, **kw) -> str:
     return buf.getvalue()
 
 
-def analyze_kernels(conn, strings, top_n=15):
+def analyze_kernels(conn, strings, top_n=15):  # noqa: ANN001, ANN201  # tracked: #288
     """Legacy API — returns analysis as a string."""
 
     class _A:
@@ -613,44 +621,44 @@ def analyze_kernels(conn, strings, top_n=15):
 
     # Monkey-patch _open_db for this call
     saved = globals().get("_open_db")
-    globals()["_open_db"] = lambda p: (conn, strings)
+    globals()["_open_db"] = lambda p: (conn, strings)  # noqa: ARG005  # tracked: #288
     try:
         return _capture_stdout(cmd_kernels, _A())
     finally:
         globals()["_open_db"] = saved
 
 
-def analyze_cpu_overhead(conn, strings):
+def analyze_cpu_overhead(conn, strings):  # noqa: ANN001, ANN201, D103  # tracked: #288
     class _A:
         report = ":memory:"
 
     saved = globals().get("_open_db")
-    globals()["_open_db"] = lambda p: (conn, strings)
+    globals()["_open_db"] = lambda p: (conn, strings)  # noqa: ARG005  # tracked: #288
     try:
         return _capture_stdout(cmd_cpu_overhead, _A())
     finally:
         globals()["_open_db"] = saved
 
 
-def analyze_gpu_idle_gaps(conn, strings, top_n=10):
+def analyze_gpu_idle_gaps(conn, strings, top_n=10):  # noqa: ANN001, ANN201, D103  # tracked: #288
     class _A:
         report = ":memory:"
         top = top_n
 
     saved = globals().get("_open_db")
-    globals()["_open_db"] = lambda p: (conn, strings)
+    globals()["_open_db"] = lambda p: (conn, strings)  # noqa: ARG005  # tracked: #288
     try:
         return _capture_stdout(cmd_idle_gaps, _A())
     finally:
         globals()["_open_db"] = saved
 
 
-def analyze_memory_ops(conn):
+def analyze_memory_ops(conn):  # noqa: ANN001, ANN201, D103  # tracked: #288
     class _A:
         report = ":memory:"
 
     saved = globals().get("_open_db")
-    globals()["_open_db"] = lambda p: (conn, {})
+    globals()["_open_db"] = lambda p: (conn, {})  # noqa: ARG005  # tracked: #288
     try:
         return _capture_stdout(cmd_memory, _A())
     finally:
@@ -658,24 +666,25 @@ def analyze_memory_ops(conn):
 
 
 # ---------------------------------------------------------------------------
-# Subcommand: query
+# tracked: #288
+# Subcommand: query  # noqa: ERA001
 # ---------------------------------------------------------------------------
 
 
-def cmd_query(args):
+def cmd_query(args):  # noqa: ANN001, ANN201  # tracked: #288
     """Run arbitrary SQL against the nsys SQLite export."""
     conn, _ = _open_db(_ensure_sqlite(args.report))
     try:
         cur = conn.execute(args.sql)
         if cur.description:
             headers = [d[0] for d in cur.description]
-            print("\t".join(headers))
+            print("\t".join(headers))  # noqa: T201  # tracked: #288
             for row in cur.fetchall():
-                print("\t".join(str(v) for v in row))
+                print("\t".join(str(v) for v in row))  # noqa: T201  # tracked: #288
         else:
-            print("(No results.)")
+            print("(No results.)")  # noqa: T201  # tracked: #288
     except sqlite3.OperationalError as e:
-        print(f"SQL error: {e}", file=sys.stderr)
+        print(f"SQL error: {e}", file=sys.stderr)  # noqa: T201  # tracked: #288
         sys.exit(1)
 
 
@@ -684,24 +693,24 @@ def cmd_query(args):
 # ---------------------------------------------------------------------------
 
 
-def cmd_summary(args):
+def cmd_summary(args):  # noqa: ANN001, ANN201  # tracked: #288
     """All-in-one analysis (legacy mode)."""
     args.top = getattr(args, "top", 15)
     args.step = getattr(args, "step", 1)
-    print("=" * 70)
-    print("  NSYS PROFILE ANALYSIS")
-    print("=" * 70)
-    print("\n## GPU Kernel Summary\n")
+    print("=" * 70)  # noqa: T201  # tracked: #288
+    print("  NSYS PROFILE ANALYSIS")  # noqa: T201  # tracked: #288
+    print("=" * 70)  # noqa: T201  # tracked: #288
+    print("\n## GPU Kernel Summary\n")  # noqa: T201  # tracked: #288
     cmd_kernels(args)
-    print("\n## CPU Overhead Analysis\n")
+    print("\n## CPU Overhead Analysis\n")  # noqa: T201  # tracked: #288
     cmd_cpu_overhead(args)
-    print("\n## GPU Idle Gap Analysis\n")
+    print("\n## GPU Idle Gap Analysis\n")  # noqa: T201  # tracked: #288
     cmd_idle_gaps(args)
-    print("\n## Memory Operations\n")
+    print("\n## Memory Operations\n")  # noqa: T201  # tracked: #288
     cmd_memory(args)
-    print("\n## CUDA Graph Replays\n")
+    print("\n## CUDA Graph Replays\n")  # noqa: T201  # tracked: #288
     cmd_graph_replays(args)
-    print("\n## Decode Step Timeline\n")
+    print("\n## Decode Step Timeline\n")  # noqa: T201  # tracked: #288
     cmd_step_timeline(args)
 
 
@@ -710,7 +719,7 @@ def cmd_summary(args):
 # ---------------------------------------------------------------------------
 
 
-def main():
+def main():  # noqa: ANN201, D103  # tracked: #288
     parser = argparse.ArgumentParser(
         description="Nsys profile analysis toolkit.",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/resources/profilers/nsys/analyze_nsys.py
+++ b/resources/profilers/nsys/analyze_nsys.py
@@ -80,7 +80,7 @@ def _short_kernel_name(raw: str) -> str:
 def _resolve_name(name_val, strings: dict[int, str]) -> str:
     if isinstance(name_val, int) and name_val in strings:
         return _short_kernel_name(strings[name_val])
-    elif isinstance(name_val, str):
+    if isinstance(name_val, str):
         return _short_kernel_name(name_val)
     return str(name_val)
 
@@ -193,7 +193,7 @@ def cmd_cpu_overhead(args):
     row = conn.execute(
         "SELECT COUNT(*), SUM(end-start) FROM CUPTI_ACTIVITY_KIND_RUNTIME"
     ).fetchone()
-    total_calls, total_ns = row if row else (0, 0)
+    total_calls, total_ns = row or (0, 0)
     total_ns = total_ns or 0
     print(f"Total CUDA runtime API calls: {total_calls}")
     print(f"Total CPU time in CUDA APIs:  {total_ns / 1e6:.2f} ms")

--- a/resources/profilers/nsys/server.py
+++ b/resources/profilers/nsys/server.py
@@ -31,14 +31,14 @@ sys.path.insert(0, str(_HERE))
 import analyze_nsys  # noqa: E402  (sys.path setup above)
 
 
-def _capture(fn, **kwargs) -> str:
+def _capture(fn, **kwargs) -> str:  # noqa: ANN001, ANN003  # tracked: #288
     """Run an ``analyze_nsys.cmd_*`` with an argparse-like namespace and
     capture stdout as a string.
 
     The ``cmd_*`` helpers print their results to stdout; we intercept
     and return the buffered text so the MCP client gets a structured
     reply.
-    """
+    """  # noqa: D205  # tracked: #288
     ns = types.SimpleNamespace(**kwargs)
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
@@ -47,7 +47,7 @@ def _capture(fn, **kwargs) -> str:
     return out or "(no output)"
 
 
-def build_server() -> FastMCP:
+def build_server() -> FastMCP:  # noqa: C901  # tracked: #288
     """Construct the FastMCP instance with nsys analysis tools.
 
     Exposed separately so unit tests can introspect registered tools
@@ -142,7 +142,7 @@ def build_server() -> FastMCP:
     return mcp
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: list[str] | None = None) -> None:  # noqa: D103  # tracked: #288
     parser = argparse.ArgumentParser(
         prog="vibesys-nsys-mcp",
         description="Stdio MCP server exposing nsys profile analyses.",

--- a/resources/profilers/otel/server.py
+++ b/resources/profilers/otel/server.py
@@ -10,7 +10,7 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, model_validator
 
 
-class LatencyRow(BaseModel):
+class LatencyRow(BaseModel):  # noqa: D101  # tracked: #288
     model_config = ConfigDict(extra="forbid")
 
     name: str = Field(min_length=1)
@@ -23,33 +23,33 @@ class LatencyRow(BaseModel):
     max_ms: StrictFloat = Field(ge=0)
 
     @model_validator(mode="after")
-    def validate_distribution(self) -> "LatencyRow":
+    def validate_distribution(self) -> "LatencyRow":  # noqa: D102  # tracked: #288
         if self.error_count > self.count:
-            raise ValueError("error_count must not exceed count")
+            raise ValueError("error_count must not exceed count")  # noqa: TRY003  # tracked: #288
         values = (self.mean_ms, self.p50_ms, self.p95_ms, self.p99_ms, self.max_ms)
         if not all(math.isfinite(value) for value in values):
-            raise ValueError("latency values must be finite")
+            raise ValueError("latency values must be finite")  # noqa: TRY003  # tracked: #288
         if not (self.p50_ms <= self.p95_ms <= self.p99_ms <= self.max_ms):
-            raise ValueError("latency percentiles must be ordered")
+            raise ValueError("latency percentiles must be ordered")  # noqa: TRY003  # tracked: #288
         return self
 
 
-class MeasurementWindow(BaseModel):
+class MeasurementWindow(BaseModel):  # noqa: D101  # tracked: #288
     model_config = ConfigDict(extra="forbid")
 
     start: str
     end: str
 
     @model_validator(mode="after")
-    def validate_bounds(self) -> "MeasurementWindow":
+    def validate_bounds(self) -> "MeasurementWindow":  # noqa: D102  # tracked: #288
         start = _parse_timestamp(self.start, "start")
         end = _parse_timestamp(self.end, "end")
         if end < start:
-            raise ValueError("measurement window end must not precede start")
+            raise ValueError("measurement window end must not precede start")  # noqa: TRY003  # tracked: #288
         return self
 
 
-class TelemetryReport(BaseModel):
+class TelemetryReport(BaseModel):  # noqa: D101  # tracked: #288
     model_config = ConfigDict(extra="forbid")
 
     schema_version: Literal[1]
@@ -65,12 +65,12 @@ class TelemetryReport(BaseModel):
     datastores_by_p95: list[LatencyRow] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def validate_report(self) -> "TelemetryReport":
+    def validate_report(self) -> "TelemetryReport":  # noqa: D102  # tracked: #288
         _parse_timestamp(self.collected_at, "collected_at")
         if not self.measurement_windows:
-            raise ValueError("measurement_windows must not be empty")
+            raise ValueError("measurement_windows must not be empty")  # noqa: TRY003  # tracked: #288
         if self.error_count > self.span_count:
-            raise ValueError("error_count must not exceed span_count")
+            raise ValueError("error_count must not exceed span_count")  # noqa: TRY003  # tracked: #288
         for label, rows in (
             ("services_by_p95", self.services_by_p95),
             ("spans_by_p95", self.spans_by_p95),
@@ -78,9 +78,9 @@ class TelemetryReport(BaseModel):
         ):
             names = [row.name for row in rows]
             if len(names) != len(set(names)):
-                raise ValueError(f"{label} contains duplicate names")
+                raise ValueError(f"{label} contains duplicate names")  # noqa: TRY003  # tracked: #288
         if not self.services_by_p95 or not self.spans_by_p95:
-            raise ValueError("services_by_p95 and spans_by_p95 must not be empty")
+            raise ValueError("services_by_p95 and spans_by_p95 must not be empty")  # noqa: TRY003  # tracked: #288
         return self
 
 
@@ -129,11 +129,11 @@ class ReportComparison(BaseModel):
     datastore_p95_changes: list[RowChange]
 
 
-def load_report(path: str) -> TelemetryReport:
+def load_report(path: str) -> TelemetryReport:  # noqa: D103  # tracked: #288
     return TelemetryReport.model_validate_json(Path(path).read_text(encoding="utf-8"))
 
 
-def summarize_report(path: str, *, top: int = 10) -> ReportSummary:
+def summarize_report(path: str, *, top: int = 10) -> ReportSummary:  # noqa: D103  # tracked: #288
     _validate_top(top)
     report = load_report(path)
     return ReportSummary(
@@ -150,12 +150,12 @@ def summarize_report(path: str, *, top: int = 10) -> ReportSummary:
     )
 
 
-def compare_reports(before_path: str, after_path: str, *, top: int = 10) -> ReportComparison:
+def compare_reports(before_path: str, after_path: str, *, top: int = 10) -> ReportComparison:  # noqa: D103  # tracked: #288
     _validate_top(top)
     before = load_report(before_path)
     after = load_report(after_path)
     if _report_identity(before) != _report_identity(after):
-        raise ValueError("reports must have matching workload identity and window count")
+        raise ValueError("reports must have matching workload identity and window count")  # noqa: TRY003  # tracked: #288
     return ReportComparison(
         before_span_count=before.span_count,
         after_span_count=after.span_count,
@@ -175,19 +175,19 @@ def _report_identity(report: TelemetryReport) -> tuple:
 
 def _parse_timestamp(value: str, label: str) -> datetime:
     if not value:
-        raise ValueError(f"measurement window {label} must not be empty")
+        raise ValueError(f"measurement window {label} must not be empty")  # noqa: TRY003  # tracked: #288
     try:
-        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))  # noqa: FURB162  # tracked: #288
     except ValueError as exc:
-        raise ValueError(f"measurement window {label} must be an RFC3339 timestamp") from exc
+        raise ValueError(f"measurement window {label} must be an RFC3339 timestamp") from exc  # noqa: TRY003  # tracked: #288
     if timestamp.tzinfo is None:
-        raise ValueError(f"measurement window {label} must include a timezone")
+        raise ValueError(f"measurement window {label} must include a timezone")  # noqa: TRY003  # tracked: #288
     return timestamp
 
 
 def _validate_top(top: int) -> None:
     if top <= 0:
-        raise ValueError("top must be positive")
+        raise ValueError("top must be positive")  # noqa: TRY003  # tracked: #288
 
 
 def _compare_rows(
@@ -236,7 +236,7 @@ def _change_magnitude(change: RowChange) -> float:
     return 0.0
 
 
-def find_reports(root: str = ".") -> list[str]:
+def find_reports(root: str = ".") -> list[str]:  # noqa: D103  # tracked: #288
     base = Path(root)
     reports = []
     for path in base.rglob("*.json"):
@@ -259,7 +259,7 @@ def find_reports(root: str = ".") -> list[str]:
     return sorted(reports)
 
 
-def build_server() -> FastMCP:
+def build_server() -> FastMCP:  # noqa: D103  # tracked: #288
     mcp = FastMCP("vibesys-otel-profiler")
 
     @mcp.tool()

--- a/resources/profilers/torch/analyze_torch_profile.py
+++ b/resources/profilers/torch/analyze_torch_profile.py
@@ -263,8 +263,7 @@ def _summarize_prof(prof, num_iters: int) -> dict:
         if (
             ev.device_type == torch.autograd.DeviceType.CUDA
             or "cuda" in name.lower()
-            or cuda_us > 0
-            and cpu_us < cuda_us / 4
+            or (cuda_us > 0 and cpu_us < cuda_us / 4)
         ):
             category = "kernel"
         elif name.startswith("aten::") or name.startswith("torch::"):
@@ -302,7 +301,7 @@ def _summarize_prof(prof, num_iters: int) -> dict:
 
 # Lazy import to keep module importable without torch
 try:
-    import torch  # noqa: F401
+    import torch
 except ImportError:  # pragma: no cover
     torch = None  # type: ignore
 

--- a/resources/profilers/torch/analyze_torch_profile.py
+++ b/resources/profilers/torch/analyze_torch_profile.py
@@ -47,7 +47,7 @@ Output schema (``prof.json``):
             ...
         ]
     }
-"""
+"""  # noqa: D301, EXE001  # tracked: #288
 
 from __future__ import annotations
 
@@ -64,7 +64,7 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 
 
-def _load_main_module(model_dir: str):
+def _load_main_module(model_dir: str):  # noqa: ANN202  # tracked: #288
     """Import ``main.py`` from *model_dir* and return the module.
 
     The agent's server always exports ``VibeServeModel`` from ``main.py``,
@@ -72,7 +72,7 @@ def _load_main_module(model_dir: str):
     """
     main_path = Path(model_dir) / "main.py"
     if not main_path.is_file():
-        raise FileNotFoundError(
+        raise FileNotFoundError(  # noqa: TRY003  # tracked: #288
             f"main.py not found at {main_path} — pass --model-dir pointing "
             f"to the workspace root that contains main.py."
         )
@@ -85,7 +85,7 @@ def _load_main_module(model_dir: str):
         if str(main_path.parent) in sys.path:
             sys.path.remove(str(main_path.parent))
     if not hasattr(module, "VibeServeModel"):
-        raise AttributeError(
+        raise AttributeError(  # noqa: TRY003  # tracked: #288
             f"main.py at {main_path} does not export VibeServeModel. "
             f"The accuracy-checker interface requires this symbol."
         )
@@ -94,8 +94,8 @@ def _load_main_module(model_dir: str):
 
 def cmd_capture(args: argparse.Namespace) -> None:
     """Profile VibeServeModel.generate under torch.profiler, dump JSON."""
-    import torch
-    from torch.profiler import ProfilerActivity, profile
+    import torch  # noqa: PLC0415  # tracked: #288
+    from torch.profiler import ProfilerActivity, profile  # noqa: PLC0415  # tracked: #288
 
     dtype = {
         "bfloat16": torch.bfloat16,
@@ -106,7 +106,7 @@ def cmd_capture(args: argparse.Namespace) -> None:
     model_dir = args.model_dir
     weights_dir = args.weights_dir or "/model"
 
-    print(
+    print(  # noqa: T201  # tracked: #288
         f"[capture] loading VibeServeModel from {model_dir}/main.py "
         f"(weights: {weights_dir}, device={args.device}, dtype={args.dtype})",
         file=sys.stderr,
@@ -123,20 +123,20 @@ def cmd_capture(args: argparse.Namespace) -> None:
     # transformers directly against weights_dir.
     tokenizer = getattr(model, "tokenizer", None)
     if tokenizer is None:
-        from transformers import AutoTokenizer
+        from transformers import AutoTokenizer  # noqa: PLC0415  # tracked: #288
 
         tokenizer = AutoTokenizer.from_pretrained(weights_dir)
 
     input_ids = tokenizer(args.prompt, return_tensors="pt").input_ids.to(args.device)
 
     # Warmup — first call compiles kernels, allocates KV cache, etc.
-    print(f"[capture] warmup ({args.warmup} iters)...", file=sys.stderr)
+    print(f"[capture] warmup ({args.warmup} iters)...", file=sys.stderr)  # noqa: T201  # tracked: #288
     for _ in range(args.warmup):
         with torch.no_grad():
             model.generate(input_ids=input_ids, max_new_tokens=args.max_tokens)
     torch.cuda.synchronize()
 
-    print(
+    print(  # noqa: T201  # tracked: #288
         f"[capture] profiling ({args.num_iters} iters, max_new_tokens={args.max_tokens})...",
         file=sys.stderr,
     )
@@ -152,7 +152,7 @@ def cmd_capture(args: argparse.Namespace) -> None:
                 model.generate(input_ids=input_ids, max_new_tokens=args.max_tokens)
         torch.cuda.synchronize()
     wall = time.time() - t0
-    print(f"[capture] elapsed {wall:.2f}s", file=sys.stderr)
+    print(f"[capture] elapsed {wall:.2f}s", file=sys.stderr)  # noqa: T201  # tracked: #288
 
     events_json = _summarize_prof(prof, num_iters=args.num_iters)
     events_json.update(
@@ -168,7 +168,7 @@ def cmd_capture(args: argparse.Namespace) -> None:
         }
     )
     Path(args.output).write_text(json.dumps(events_json, indent=2))
-    print(
+    print(  # noqa: T201  # tracked: #288
         f"[capture] wrote {args.output} "
         f"({events_json['total_cuda_time_us']:.0f} us CUDA, "
         f"{events_json['total_cpu_time_us']:.0f} us CPU, "
@@ -193,23 +193,23 @@ def cmd_capture_server(args: argparse.Namespace) -> None:
     server-path profiling (captures HTTP/batching overhead).  When
     absent, use ``capture`` (in-process) instead.
     """
-    import urllib.request
+    import urllib.request  # noqa: PLC0415  # tracked: #288
 
     def _post(path: str, body: dict | None = None) -> dict:
         data = json.dumps(body or {}).encode("utf-8")
-        req = urllib.request.Request(
+        req = urllib.request.Request(  # noqa: S310  # tracked: #288
             args.url.rstrip("/") + path,
             data=data,
             headers={"Content-Type": "application/json"},
             method="POST",
         )
-        with urllib.request.urlopen(req, timeout=args.timeout) as resp:
+        with urllib.request.urlopen(req, timeout=args.timeout) as resp:  # noqa: S310  # tracked: #288
             return json.loads(resp.read())
 
-    print(f"[capture-server] POST {args.url}/admin/profile/start", file=sys.stderr)
+    print(f"[capture-server] POST {args.url}/admin/profile/start", file=sys.stderr)  # noqa: T201  # tracked: #288
     _post("/admin/profile/start")
 
-    print(
+    print(  # noqa: T201  # tracked: #288
         f"[capture-server] sending {args.requests} requests (max_tokens={args.max_tokens})...",
         file=sys.stderr,
     )
@@ -223,11 +223,11 @@ def cmd_capture_server(args: argparse.Namespace) -> None:
             },
         )
 
-    print(f"[capture-server] POST {args.url}/admin/profile/stop", file=sys.stderr)
+    print(f"[capture-server] POST {args.url}/admin/profile/stop", file=sys.stderr)  # noqa: T201  # tracked: #288
     result = _post("/admin/profile/stop")
 
     if "events" not in result:
-        raise RuntimeError(
+        raise RuntimeError(  # noqa: TRY003  # tracked: #288
             "/admin/profile/stop response missing 'events' key — "
             "is the server implementing the expected contract?"
         )
@@ -236,7 +236,7 @@ def cmd_capture_server(args: argparse.Namespace) -> None:
     result.setdefault("mode", "server")
     result.setdefault("num_iters", args.requests)
     Path(args.output).write_text(json.dumps(result, indent=2))
-    print(f"[capture-server] wrote {args.output}", file=sys.stderr)
+    print(f"[capture-server] wrote {args.output}", file=sys.stderr)  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +244,7 @@ def cmd_capture_server(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _summarize_prof(prof, num_iters: int) -> dict:
+def _summarize_prof(prof, num_iters: int) -> dict:  # noqa: ANN001, ARG001  # tracked: #288
     """Extract a structured summary from a torch.profiler profile object."""
     totals = prof.key_averages()
     events: list[dict] = []
@@ -266,7 +266,7 @@ def _summarize_prof(prof, num_iters: int) -> dict:
             or (cuda_us > 0 and cpu_us < cuda_us / 4)
         ):
             category = "kernel"
-        elif name.startswith("aten::") or name.startswith("torch::"):
+        elif name.startswith("aten::") or name.startswith("torch::"):  # noqa: PIE810  # tracked: #288
             category = "operator"
         elif (
             "memcpy" in name.lower()
@@ -303,7 +303,7 @@ def _summarize_prof(prof, num_iters: int) -> dict:
 try:
     import torch
 except ImportError:  # pragma: no cover
-    torch = None  # type: ignore
+    torch = None  # type: ignore  # noqa: PGH003  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
@@ -316,9 +316,9 @@ def _load(path: str) -> dict:
 
 
 def _fmt_us(us: float) -> str:
-    if us >= 1_000_000:
+    if us >= 1_000_000:  # noqa: PLR2004  # tracked: #288
         return f"{us / 1_000_000:.2f} s"
-    if us >= 1000:
+    if us >= 1000:  # noqa: PLR2004  # tracked: #288
         return f"{us / 1000:.2f} ms"
     return f"{us:.1f} us"
 
@@ -329,16 +329,16 @@ def cmd_kernels(args: argparse.Namespace) -> None:
     kernels = [e for e in data["events"] if e["self_cuda_time_us"] > 0]
     kernels.sort(key=lambda e: e["self_cuda_time_us"], reverse=True)
     total = data["total_cuda_time_us"] or 1.0
-    print(f"Total self-CUDA time: {_fmt_us(total)}")
-    print()
-    print(f"{'Name':<60}{'Self CUDA':>14}{'% of total':>12}{'Count':>10}")
-    print("-" * 96)
+    print(f"Total self-CUDA time: {_fmt_us(total)}")  # noqa: T201  # tracked: #288
+    print()  # noqa: T201  # tracked: #288
+    print(f"{'Name':<60}{'Self CUDA':>14}{'% of total':>12}{'Count':>10}")  # noqa: T201  # tracked: #288
+    print("-" * 96)  # noqa: T201  # tracked: #288
     for ev in kernels[: args.top]:
         pct = 100.0 * ev["self_cuda_time_us"] / total
         name = ev["name"]
-        if len(name) > 58:
+        if len(name) > 58:  # noqa: PLR2004  # tracked: #288
             name = name[:55] + "..."
-        print(f"{name:<60}{_fmt_us(ev['self_cuda_time_us']):>14}{pct:>11.1f}%{ev['count']:>10}")
+        print(f"{name:<60}{_fmt_us(ev['self_cuda_time_us']):>14}{pct:>11.1f}%{ev['count']:>10}")  # noqa: T201  # tracked: #288
 
 
 def cmd_operators(args: argparse.Namespace) -> None:
@@ -347,16 +347,16 @@ def cmd_operators(args: argparse.Namespace) -> None:
     ops = [e for e in data["events"] if e["category"] == "operator"]
     ops.sort(key=lambda e: e["self_cpu_time_us"], reverse=True)
     total_cpu = data["total_cpu_time_us"] or 1.0
-    print(f"Total self-CPU time: {_fmt_us(total_cpu)}")
-    print()
-    print(f"{'Operator':<50}{'Self CPU':>14}{'CUDA time':>14}{'% CPU':>10}{'Count':>10}")
-    print("-" * 98)
+    print(f"Total self-CPU time: {_fmt_us(total_cpu)}")  # noqa: T201  # tracked: #288
+    print()  # noqa: T201  # tracked: #288
+    print(f"{'Operator':<50}{'Self CPU':>14}{'CUDA time':>14}{'% CPU':>10}{'Count':>10}")  # noqa: T201  # tracked: #288
+    print("-" * 98)  # noqa: T201  # tracked: #288
     for ev in ops[: args.top]:
         pct = 100.0 * ev["self_cpu_time_us"] / total_cpu
         name = ev["name"]
-        if len(name) > 48:
+        if len(name) > 48:  # noqa: PLR2004  # tracked: #288
             name = name[:45] + "..."
-        print(
+        print(  # noqa: T201  # tracked: #288
             f"{name:<50}{_fmt_us(ev['self_cpu_time_us']):>14}"
             f"{_fmt_us(ev['cuda_time_us']):>14}{pct:>9.1f}%{ev['count']:>10}"
         )
@@ -368,24 +368,24 @@ def cmd_cpu_overhead(args: argparse.Namespace) -> None:
     total_cpu = data["total_cpu_time_us"]
     total_cuda = data["total_cuda_time_us"]
     ratio = total_cpu / total_cuda if total_cuda else float("inf")
-    print(f"Total self-CPU time:  {_fmt_us(total_cpu)}")
-    print(f"Total self-CUDA time: {_fmt_us(total_cuda)}")
-    print(f"CPU/CUDA ratio:       {ratio:.2f}x")
-    if ratio > 2.0:
-        print()
-        print(
+    print(f"Total self-CPU time:  {_fmt_us(total_cpu)}")  # noqa: T201  # tracked: #288
+    print(f"Total self-CUDA time: {_fmt_us(total_cuda)}")  # noqa: T201  # tracked: #288
+    print(f"CPU/CUDA ratio:       {ratio:.2f}x")  # noqa: T201  # tracked: #288
+    if ratio > 2.0:  # noqa: PLR2004  # tracked: #288
+        print()  # noqa: T201  # tracked: #288
+        print(  # noqa: T201  # tracked: #288
             "Interpretation: CPU time dominates (>2x GPU). Likely launch-bound"
             " — consider CUDA graphs, fewer kernels, or larger batches."
         )
-    elif ratio < 0.5:
-        print()
-        print(
+    elif ratio < 0.5:  # noqa: PLR2004  # tracked: #288
+        print()  # noqa: T201  # tracked: #288
+        print(  # noqa: T201  # tracked: #288
             "Interpretation: GPU time dominates (<0.5x CPU). Compute-bound —"
             " focus on kernel fusion, flash attention, better algorithms."
         )
     else:
-        print()
-        print(
+        print()  # noqa: T201  # tracked: #288
+        print(  # noqa: T201  # tracked: #288
             "Interpretation: CPU and GPU roughly balanced. Both axes may benefit from optimization."
         )
 
@@ -396,15 +396,15 @@ def cmd_memory(args: argparse.Namespace) -> None:
     mem = [e for e in data["events"] if e["category"] == "memory"]
     mem.sort(key=lambda e: e["cuda_time_us"] + e["cpu_time_us"], reverse=True)
     if not mem:
-        print("(no memory events recorded)")
+        print("(no memory events recorded)")  # noqa: T201  # tracked: #288
         return
-    print(f"{'Operation':<40}{'Total CUDA':>14}{'Total CPU':>14}{'Count':>10}")
-    print("-" * 78)
+    print(f"{'Operation':<40}{'Total CUDA':>14}{'Total CPU':>14}{'Count':>10}")  # noqa: T201  # tracked: #288
+    print("-" * 78)  # noqa: T201  # tracked: #288
     for ev in mem:
         name = ev["name"]
-        if len(name) > 38:
+        if len(name) > 38:  # noqa: PLR2004  # tracked: #288
             name = name[:35] + "..."
-        print(
+        print(  # noqa: T201  # tracked: #288
             f"{name:<40}{_fmt_us(ev['cuda_time_us']):>14}"
             f"{_fmt_us(ev['cpu_time_us']):>14}{ev['count']:>10}"
         )
@@ -413,22 +413,22 @@ def cmd_memory(args: argparse.Namespace) -> None:
 def cmd_summary(args: argparse.Namespace) -> None:
     """All-in-one: overhead + kernels + operators + memory."""
     args.top = getattr(args, "top", 15)
-    print("=" * 80)
-    print("  TORCH PROFILER SUMMARY")
-    print("=" * 80)
+    print("=" * 80)  # noqa: T201  # tracked: #288
+    print("  TORCH PROFILER SUMMARY")  # noqa: T201  # tracked: #288
+    print("=" * 80)  # noqa: T201  # tracked: #288
     data = _load(args.report)
-    print(f"\nCaptured: {data.get('captured_at', '?')}")
-    print(f"Mode:     {data.get('mode', '?')}")
-    print(f"Device:   {data.get('device', '?')} ({data.get('dtype', '?')})")
+    print(f"\nCaptured: {data.get('captured_at', '?')}")  # noqa: T201  # tracked: #288
+    print(f"Mode:     {data.get('mode', '?')}")  # noqa: T201  # tracked: #288
+    print(f"Device:   {data.get('device', '?')} ({data.get('dtype', '?')})")  # noqa: T201  # tracked: #288
     if "wall_time_sec" in data:
-        print(f"Wall:     {data['wall_time_sec']:.2f}s over {data.get('num_iters', '?')} iters")
-    print("\n## CPU / GPU Overhead\n")
+        print(f"Wall:     {data['wall_time_sec']:.2f}s over {data.get('num_iters', '?')} iters")  # noqa: T201  # tracked: #288
+    print("\n## CPU / GPU Overhead\n")  # noqa: T201  # tracked: #288
     cmd_cpu_overhead(args)
-    print("\n## Top GPU Kernels\n")
+    print("\n## Top GPU Kernels\n")  # noqa: T201  # tracked: #288
     cmd_kernels(args)
-    print("\n## Top Operators\n")
+    print("\n## Top Operators\n")  # noqa: T201  # tracked: #288
     cmd_operators(args)
-    print("\n## Memory Operations\n")
+    print("\n## Memory Operations\n")  # noqa: T201  # tracked: #288
     cmd_memory(args)
 
 
@@ -438,15 +438,15 @@ def cmd_tables(args: argparse.Namespace) -> None:
     categories: dict[str, int] = {}
     for ev in data["events"]:
         categories[ev["category"]] = categories.get(ev["category"], 0) + 1
-    print(f"Captured:   {data.get('captured_at', '?')}")
-    print(f"Mode:       {data.get('mode', '?')}")
-    print(f"Num events: {data.get('num_events', len(data.get('events', [])))}")
-    print(f"Total CUDA: {_fmt_us(data.get('total_cuda_time_us', 0))}")
-    print(f"Total CPU:  {_fmt_us(data.get('total_cpu_time_us', 0))}")
-    print("\nEvent categories:")
+    print(f"Captured:   {data.get('captured_at', '?')}")  # noqa: T201  # tracked: #288
+    print(f"Mode:       {data.get('mode', '?')}")  # noqa: T201  # tracked: #288
+    print(f"Num events: {data.get('num_events', len(data.get('events', [])))}")  # noqa: T201  # tracked: #288
+    print(f"Total CUDA: {_fmt_us(data.get('total_cuda_time_us', 0))}")  # noqa: T201  # tracked: #288
+    print(f"Total CPU:  {_fmt_us(data.get('total_cpu_time_us', 0))}")  # noqa: T201  # tracked: #288
+    print("\nEvent categories:")  # noqa: T201  # tracked: #288
     for cat, n in sorted(categories.items(), key=lambda kv: -kv[1]):
-        print(f"  {cat:<10} {n:>6} events")
-    print("\nAvailable subcommands: kernels, operators, cpu-overhead, memory, summary")
+        print(f"  {cat:<10} {n:>6} events")  # noqa: T201  # tracked: #288
+    print("\nAvailable subcommands: kernels, operators, cpu-overhead, memory, summary")  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
@@ -454,7 +454,7 @@ def cmd_tables(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 
-def main() -> None:
+def main() -> None:  # noqa: D103  # tracked: #288
     p = argparse.ArgumentParser(
         description="Torch profiler analysis toolkit.",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/resources/profilers/torch/server.py
+++ b/resources/profilers/torch/server.py
@@ -30,7 +30,7 @@ sys.path.insert(0, str(_HERE))
 import analyze_torch_profile  # noqa: E402
 
 
-def _capture(fn, **kwargs) -> str:
+def _capture(fn, **kwargs) -> str:  # noqa: ANN001, ANN003  # tracked: #288
     ns = types.SimpleNamespace(**kwargs)
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
@@ -99,7 +99,7 @@ def build_server() -> FastMCP:
     return mcp
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: list[str] | None = None) -> None:  # noqa: D103  # tracked: #288
     parser = argparse.ArgumentParser(
         prog="vibesys-torch-mcp",
         description="Stdio MCP server exposing torch.profiler analyses.",

--- a/src/vibesys/_agent_cli/base.py
+++ b/src/vibesys/_agent_cli/base.py
@@ -66,7 +66,7 @@ def _load_json_object(raw: bytes, target: Path) -> dict[str, Any]:
         raise ValueError(f"cannot merge MCP servers into invalid JSON config: {target}") from exc
     if not isinstance(loaded, dict):
         raise ValueError(f"MCP config must contain a JSON object: {target}")
-    return dict(cast(dict[str, Any], loaded))
+    return dict(cast("dict[str, Any]", loaded))
 
 
 class CodingAgent(ABC):
@@ -131,7 +131,7 @@ class CodingAgent(ABC):
             for key, value in defaults.items():
                 config.setdefault(key, value)
         config[server_key] = {
-            **cast(dict[str, Any], existing_servers),
+            **cast("dict[str, Any]", existing_servers),
             **server_config,
         }
 
@@ -178,9 +178,9 @@ class CodingAgent(ABC):
         if not isinstance(current_servers, dict):
             raise ValueError(f"{backup.server_key!r} must be a JSON object in MCP config: {target}")
 
-        restored_servers = dict(cast(dict[str, Any], current_servers))
-        original_server_map = cast(dict[str, Any], original_servers)
-        for name, installed_value in cast(dict[str, Any], installed_servers).items():
+        restored_servers = dict(cast("dict[str, Any]", current_servers))
+        original_server_map = cast("dict[str, Any]", original_servers)
+        for name, installed_value in cast("dict[str, Any]", installed_servers).items():
             original_value = original_server_map.get(name, _MISSING)
             if installed_value == original_value:
                 continue
@@ -242,7 +242,7 @@ class CodingAgent(ABC):
         file under *workspace*, or (in Codex's case) to stash runtime
         ``--config`` flags on the instance.
         """
-        return None
+        return
 
     def set_output_schema_path(self, path: str | None) -> None:
         """Set the JSON Schema file path for the next generation.
@@ -254,11 +254,11 @@ class CodingAgent(ABC):
         nothing here. Their runners retain the portable prompt-level schema
         instruction instead.
         """
-        return None
+        return
 
     def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
         """Remove anything written by :meth:`install_mcp_servers`.
 
         Idempotent. Default implementation is a no-op.
         """
-        return None
+        return

--- a/src/vibesys/_agent_cli/base.py
+++ b/src/vibesys/_agent_cli/base.py
@@ -53,8 +53,8 @@ def _atomic_write(target: Path, content: bytes) -> None:
         with os.fdopen(fd, "wb") as stream:
             stream.write(content)
         if mode is not None:
-            os.chmod(temporary_path, mode)
-        os.replace(temporary_path, target)
+            os.chmod(temporary_path, mode)  # noqa: PTH101  # tracked: #288
+        os.replace(temporary_path, target)  # noqa: PTH105  # tracked: #288
     finally:
         temporary_path.unlink(missing_ok=True)
 
@@ -63,9 +63,9 @@ def _load_json_object(raw: bytes, target: Path) -> dict[str, Any]:
     try:
         loaded: object = json.loads(raw)
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise ValueError(f"cannot merge MCP servers into invalid JSON config: {target}") from exc
+        raise ValueError(f"cannot merge MCP servers into invalid JSON config: {target}") from exc  # noqa: TRY003  # tracked: #288
     if not isinstance(loaded, dict):
-        raise ValueError(f"MCP config must contain a JSON object: {target}")
+        raise ValueError(f"MCP config must contain a JSON object: {target}")  # noqa: TRY003, TRY004  # tracked: #288
     return dict(cast("dict[str, Any]", loaded))
 
 
@@ -118,7 +118,7 @@ class CodingAgent(ABC):
             backups = {}
             self._mcp_config_backups: dict[Path, _MCPConfigBackup] = backups
         if target in backups:
-            raise RuntimeError(f"temporary MCP config is already installed at {target}")
+            raise RuntimeError(f"temporary MCP config is already installed at {target}")  # noqa: TRY003  # tracked: #288
 
         original = target.read_bytes() if target.exists() else None
         original_config = _load_json_object(original, target) if original is not None else {}
@@ -126,7 +126,7 @@ class CodingAgent(ABC):
 
         existing_servers = config.get(server_key, {})
         if not isinstance(existing_servers, dict):
-            raise ValueError(f"{server_key!r} must be a JSON object in MCP config: {target}")
+            raise ValueError(f"{server_key!r} must be a JSON object in MCP config: {target}")  # noqa: TRY003, TRY004  # tracked: #288
         if defaults:
             for key, value in defaults.items():
                 config.setdefault(key, value)
@@ -148,7 +148,7 @@ class CodingAgent(ABC):
             del backups[target]
             raise
 
-    def _restore_mcp_config_file(self, target: Path) -> None:
+    def _restore_mcp_config_file(self, target: Path) -> None:  # noqa: C901, PLR0912  # tracked: #288
         """Restore a config saved by :meth:`_install_mcp_config_file`."""
         backups = getattr(self, "_mcp_config_backups", None)
         if backups is None or target not in backups:
@@ -174,9 +174,9 @@ class CodingAgent(ABC):
         installed_servers = backup.installed_config.get(backup.server_key, {})
         current_servers = current.get(backup.server_key, {})
         if not all(isinstance(value, dict) for value in (original_servers, installed_servers)):
-            raise ValueError(f"{backup.server_key!r} must be a JSON object in MCP config: {target}")
+            raise ValueError(f"{backup.server_key!r} must be a JSON object in MCP config: {target}")  # noqa: TRY003  # tracked: #288
         if not isinstance(current_servers, dict):
-            raise ValueError(f"{backup.server_key!r} must be a JSON object in MCP config: {target}")
+            raise ValueError(f"{backup.server_key!r} must be a JSON object in MCP config: {target}")  # noqa: TRY003, TRY004  # tracked: #288
 
         restored_servers = dict(cast("dict[str, Any]", current_servers))
         original_server_map = cast("dict[str, Any]", original_servers)
@@ -219,7 +219,7 @@ class CodingAgent(ABC):
         prompt: str,
         cwd: str | None = None,
         timeout: int | None = None,
-        silent: bool = False,
+        silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> str:
         """Generate text/code based on a prompt.
 
@@ -233,7 +233,7 @@ class CodingAgent(ABC):
             Generated text.
         """
 
-    def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
+    def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:  # noqa: ARG002  # tracked: #288
         """Install per-agent MCP server config so the next :meth:`generate`
         call exposes these stdio servers as tools.
 
@@ -241,10 +241,10 @@ class CodingAgent(ABC):
         support MCP. Subclasses override to write the appropriate config
         file under *workspace*, or (in Codex's case) to stash runtime
         ``--config`` flags on the instance.
-        """
+        """  # noqa: D205  # tracked: #288
         return
 
-    def set_output_schema_path(self, path: str | None) -> None:
+    def set_output_schema_path(self, path: str | None) -> None:  # noqa: ARG002  # tracked: #288
         """Set the JSON Schema file path for the next generation.
 
         The path is workspace-relative by default, or absolute when the
@@ -256,7 +256,7 @@ class CodingAgent(ABC):
         """
         return
 
-    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
+    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:  # noqa: ARG002  # tracked: #288
         """Remove anything written by :meth:`install_mcp_servers`.
 
         Idempotent. Default implementation is a no-op.

--- a/src/vibesys/_agent_cli/claude.py
+++ b/src/vibesys/_agent_cli/claude.py
@@ -24,7 +24,7 @@ class StructuredOutputClaudeSession(ClaudeGenerationSession):
     field is absent, so :meth:`run` falls through to agentshim's ``result``.
     """
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, **kwargs: Any):  # noqa: ANN204, ANN401  # tracked: #288
         super().__init__(**kwargs)
         # ``None`` means "no schema-enforced payload seen"; a captured value is
         # any JSON type the schema root produced (always an object for VibeSys
@@ -67,7 +67,7 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
     # rather than the workspace-relative path Codex resolves against its cwd.
     native_output_schema_wants_absolute_path = True
 
-    def __init__(
+    def __init__(  # noqa: ANN204  # tracked: #288
         self,
         model: str | None = None,
         event_handler: AgentEventHandler | None = None,
@@ -123,13 +123,13 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
         try:
             raw = Path(path).read_text(encoding="utf-8")
         except OSError as exc:
-            raise RuntimeError(
+            raise RuntimeError(  # noqa: TRY003  # tracked: #288
                 f"claude native output schema unreadable at {path}: {type(exc).__name__}"
             ) from exc
         try:
             schema = json.loads(raw)
         except json.JSONDecodeError as exc:
-            raise RuntimeError(
+            raise RuntimeError(  # noqa: TRY003  # tracked: #288
                 f"claude native output schema at {path} is not valid JSON: {exc}"
             ) from exc
         # Compact form keeps the process argv small; claude re-validates it as a
@@ -140,7 +140,7 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
         if self.output_schema_json is not None:
             cmd.extend(["--json-schema", self.output_schema_json])
 
-    def _get_command(self, prompt: str) -> list[str]:
+    def _get_command(self, prompt: str) -> list[str]:  # noqa: ARG002  # tracked: #288
         cmd = [
             self.binary_path,
             "-p",  # Print mode, reads prompt from stdin
@@ -154,7 +154,7 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
         self._append_output_schema(cmd)
         return cmd
 
-    def _get_resume_command(self, prompt: str, session_id: str) -> list[str]:
+    def _get_resume_command(self, prompt: str, session_id: str) -> list[str]:  # noqa: ARG002  # tracked: #288
         cmd = [
             self.binary_path,
             "--resume",
@@ -178,7 +178,7 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
         cmd: list[str],
         cwd: str | None = None,
         timeout: int | None = None,
-        silent: bool = False,
+        silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> ClaudeGenerationSession:
         return StructuredOutputClaudeSession(
             binary_name=self.binary_name,
@@ -209,6 +209,6 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
             server_config=server_config,
         )
 
-    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
+    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:  # noqa: ARG002  # tracked: #288
         """Restore the workspace's original ``.mcp.json``. Idempotent."""
         self._restore_mcp_config_file(workspace / ".mcp.json")

--- a/src/vibesys/_agent_cli/cli_agent.py
+++ b/src/vibesys/_agent_cli/cli_agent.py
@@ -10,7 +10,7 @@ from agentshim.executor import CommandExecutor, HostCommandExecutor
 from agentshim.utils import get_interactive_env
 from loguru import logger
 
-from vs_sandbox import WorkspaceSandbox
+from vs_sandbox import WorkspaceSandbox  # noqa: TC001  # tracked: #288
 
 from .base import CodingAgent
 
@@ -27,7 +27,7 @@ class CLICodingAgent(CodingAgent, Generic[SessionT]):
     type-safe per provider.
     """
 
-    def __init__(
+    def __init__(  # noqa: ANN204  # tracked: #288
         self,
         binary_name: str,
         model: str | None = None,
@@ -66,7 +66,7 @@ class CLICodingAgent(CodingAgent, Generic[SessionT]):
     def _get_command(self, prompt: str) -> list[str]:
         """Construct the command line arguments for a fresh session."""
 
-    def _get_resume_command(self, prompt: str, session_id: str) -> list[str] | None:
+    def _get_resume_command(self, prompt: str, session_id: str) -> list[str] | None:  # noqa: ARG002  # tracked: #288
         """Construct the command to resume a previous session.
 
         Returns ``None`` if the provider does not support session resumption,
@@ -75,7 +75,7 @@ class CLICodingAgent(CodingAgent, Generic[SessionT]):
         """
         return None
 
-    def _extract_session_id(self, session: SessionT) -> str | None:
+    def _extract_session_id(self, session: SessionT) -> str | None:  # noqa: ARG002  # tracked: #288
         """Extract a session/conversation ID from the completed session.
 
         Subclasses override this to parse the provider's output format.
@@ -94,7 +94,7 @@ class CLICodingAgent(CodingAgent, Generic[SessionT]):
         cmd: list[str],
         cwd: str | None = None,
         timeout: int | None = None,
-        silent: bool = False,
+        silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> SessionT:
         """Create the provider-specific session for one generation request."""
 
@@ -103,7 +103,7 @@ class CLICodingAgent(CodingAgent, Generic[SessionT]):
         prompt: str,
         cwd: str | None = None,
         timeout: int | None = None,
-        silent: bool = False,
+        silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> str:
         """Generate text using the CLI tool.
 

--- a/src/vibesys/_agent_cli/codex.py
+++ b/src/vibesys/_agent_cli/codex.py
@@ -35,7 +35,7 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
 
     supports_native_output_schema = True
 
-    def __init__(
+    def __init__(  # noqa: ANN204  # tracked: #288
         self,
         model: str | None = None,
         event_handler: AgentEventHandler | None = None,
@@ -87,7 +87,7 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
         """Return the log prefix for this agent."""
         return "[Codex]"
 
-    def _get_command(self, prompt: str) -> list[str]:
+    def _get_command(self, prompt: str) -> list[str]:  # noqa: ARG002  # tracked: #288
         cmd = [
             self.binary_path,
             "exec",
@@ -104,7 +104,7 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
         self._append_output_schema(cmd)
         return cmd
 
-    def _get_resume_command(self, prompt: str, session_id: str) -> list[str]:
+    def _get_resume_command(self, prompt: str, session_id: str) -> list[str]:  # noqa: ARG002  # tracked: #288
         # ``codex exec resume`` does NOT fall back to stdin when the ``[PROMPT]``
         # positional is omitted — only the literal ``-`` sentinel makes it read
         # from stdin. Pass ``-`` so the prompt we write to the subprocess's
@@ -134,7 +134,7 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
         cmd: list[str],
         cwd: str | None = None,
         timeout: int | None = None,
-        silent: bool = False,
+        silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> CodexGenerationSession:
         return CodexGenerationSession(
             binary_name=self.binary_name,
@@ -152,7 +152,7 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
     def _extract_session_id(self, session: CodexGenerationSession) -> str | None:
         return session.session_id
 
-    def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
+    def install_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:  # noqa: ARG002  # tracked: #288
         """Stash ``--config mcp_servers.<name>.<key>=<value>`` flags on the
         instance for the next ``codex exec`` invocation.
 
@@ -165,7 +165,7 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
 
         TOML table keys are snake_case by convention, so ``"vibesys-issues"``
         becomes ``mcp_servers.vibesys_issues``.
-        """
+        """  # noqa: D205  # tracked: #288
         flags: list[str] = []
         for s in servers:
             key = s.name.replace("-", "_")
@@ -186,6 +186,6 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
                 )
         self.extra_config_args = flags
 
-    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
+    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:  # noqa: ARG002  # tracked: #288
         """Clear the runtime ``--config`` flags. Idempotent."""
         self.extra_config_args = []

--- a/src/vibesys/_agent_cli/gemini.py
+++ b/src/vibesys/_agent_cli/gemini.py
@@ -83,7 +83,8 @@ class GeminiCodingAgent(CLICodingAgent[GeminiGenerationSession]):
         """Merge servers into ``<workspace>/.gemini/settings.json``.
 
         Gemini CLI discovers the servers from cwd. ``trust: true`` skips
-        Gemini's per-tool approval prompts for these servers."""
+        Gemini's per-tool approval prompts for these servers.
+        """
         server_config: dict[str, dict[str, Any]] = {
             s.name: {
                 "command": s.command,

--- a/src/vibesys/_agent_cli/gemini.py
+++ b/src/vibesys/_agent_cli/gemini.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class GeminiCodingAgent(CLICodingAgent[GeminiGenerationSession]):
     """Coding agent implementation using the Gemini CLI tool."""
 
-    def __init__(
+    def __init__(  # noqa: ANN204  # tracked: #288
         self,
         model: str | None = None,
         event_handler: AgentEventHandler | None = None,
@@ -45,7 +45,7 @@ class GeminiCodingAgent(CLICodingAgent[GeminiGenerationSession]):
         """Return the log prefix for this agent."""
         return "[Gemini]"
 
-    def _get_command(self, prompt: str) -> list[str]:
+    def _get_command(self, prompt: str) -> list[str]:  # noqa: ARG002  # tracked: #288
         cmd = [self.binary_path]
 
         # Enable yolo mode
@@ -64,7 +64,7 @@ class GeminiCodingAgent(CLICodingAgent[GeminiGenerationSession]):
         cmd: list[str],
         cwd: str | None = None,
         timeout: int | None = None,
-        silent: bool = False,
+        silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> GeminiGenerationSession:
         return GeminiGenerationSession(
             binary_name=self.binary_name,
@@ -100,6 +100,6 @@ class GeminiCodingAgent(CLICodingAgent[GeminiGenerationSession]):
             server_config=server_config,
         )
 
-    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
+    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:  # noqa: ARG002  # tracked: #288
         """Restore the original settings, leaving ``.gemini/`` in place."""
         self._restore_mcp_config_file(workspace / ".gemini" / "settings.json")

--- a/src/vibesys/_agent_cli/opencode.py
+++ b/src/vibesys/_agent_cli/opencode.py
@@ -16,7 +16,7 @@ OPENCODE_DEFAULT_MODEL = "google-vertex/gemini-3-pro-preview"
 class OpencodeCodingAgent(CLICodingAgent[OpencodeGenerationSession]):
     """Coding agent implementation using the Opencode CLI tool."""
 
-    def __init__(
+    def __init__(  # noqa: ANN204  # tracked: #288
         self,
         model: str | None = None,
         event_handler: AgentEventHandler | None = None,
@@ -60,7 +60,7 @@ class OpencodeCodingAgent(CLICodingAgent[OpencodeGenerationSession]):
         cmd: list[str],
         cwd: str | None = None,
         timeout: int | None = None,
-        silent: bool = False,
+        silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> OpencodeGenerationSession:
         return OpencodeGenerationSession(
             binary_name=self.binary_name,
@@ -99,6 +99,6 @@ class OpencodeCodingAgent(CLICodingAgent[OpencodeGenerationSession]):
             defaults={"$schema": "https://opencode.ai/config.json"},
         )
 
-    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:
+    def uninstall_mcp_servers(self, workspace: Path, servers: list[MCPServerSpec]) -> None:  # noqa: ARG002  # tracked: #288
         """Restore the workspace's original ``opencode.json``. Idempotent."""
         self._restore_mcp_config_file(workspace / "opencode.json")

--- a/src/vibesys/_agent_cli/opencode.py
+++ b/src/vibesys/_agent_cli/opencode.py
@@ -81,7 +81,8 @@ class OpencodeCodingAgent(CLICodingAgent[OpencodeGenerationSession]):
         Opencode discovers the MCP servers from cwd and uses the ``mcp`` key (not
         ``mcpServers``) and a single combined ``command`` array. Non-
         interactive ``opencode run`` already auto-approves all permissions,
-        so no extra ``permission`` block is needed."""
+        so no extra ``permission`` block is needed.
+        """
         server_config: dict[str, dict[str, Any]] = {
             s.name: {
                 "type": "local",

--- a/src/vibesys/_model_config/_core.py
+++ b/src/vibesys/_model_config/_core.py
@@ -78,16 +78,16 @@ class ModelConfig:
 
     def __post_init__(self) -> None:
         if self.provider not in _CANONICAL_PROVIDERS:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"provider must be one of {sorted(_CANONICAL_PROVIDERS)}, got {self.provider!r}. "
                 "Use from_provider_and_model() or from_string() to map SDS aliases."
             )
         if not self.model or not self.model.strip():
-            raise ValueError("model must be a non-empty string")
+            raise ValueError("model must be a non-empty string")  # noqa: TRY003  # tracked: #288
         if self.thinking_budget is not None and (
             not isinstance(self.thinking_budget, int) or self.thinking_budget <= 0  # pyright: ignore[reportUnnecessaryIsInstance]
         ):
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"thinking_budget must be a positive int, got {self.thinking_budget!r}"
             )
 
@@ -111,13 +111,13 @@ class ModelConfig:
         """
         alias = provider.lower()
         if alias in _UNRESOLVABLE_ALIASES:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"Provider {provider!r} has no canonical family mapping. "
                 "Use from_string() with provider_hint for heuristic resolution."
             )
         canonical = _ALIAS_TO_CANONICAL.get(alias)
         if canonical is None:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"Unknown provider alias {provider!r}. Known aliases: {sorted(_ALIAS_TO_CANONICAL)}"
             )
         return cls(
@@ -129,7 +129,7 @@ class ModelConfig:
     # ------------------------------------------------------------------
 
     @classmethod
-    def from_string(
+    def from_string(  # noqa: PLR0911  # tracked: #288
         cls,
         model_str: str,
         *,
@@ -263,7 +263,7 @@ class ModelConfig:
     # Environment validation
     # ------------------------------------------------------------------
 
-    def validate_env(self) -> None:
+    def validate_env(self) -> None:  # noqa: C901  # tracked: #288
         """Check that required environment variables are present for this provider.
 
         Raises:
@@ -319,10 +319,10 @@ def normalize_provider(alias: str) -> str:
     """
     a = alias.lower()
     if a in _UNRESOLVABLE_ALIASES:
-        raise ValueError(f"Provider {alias!r} has no canonical family mapping.")
+        raise ValueError(f"Provider {alias!r} has no canonical family mapping.")  # noqa: TRY003  # tracked: #288
     canonical = _ALIAS_TO_CANONICAL.get(a)
     if canonical is None:
-        raise ValueError(f"Unknown provider alias {alias!r}. Known: {sorted(_ALIAS_TO_CANONICAL)}")
+        raise ValueError(f"Unknown provider alias {alias!r}. Known: {sorted(_ALIAS_TO_CANONICAL)}")  # noqa: TRY003  # tracked: #288
     return canonical
 
 

--- a/src/vibesys/agent_runner.py
+++ b/src/vibesys/agent_runner.py
@@ -65,7 +65,7 @@ def _extract_todos(update: dict[str, Any]) -> list[dict[str, Any]] | None:
     return None
 
 
-def _iter_update_dicts(value: Any) -> Iterator[dict[str, Any]]:
+def _iter_update_dicts(value: Any) -> Iterator[dict[str, Any]]:  # noqa: ANN401  # tracked: #288
     """Yield all nested dict nodes reachable from a stream update payload."""
     if isinstance(value, dict):
         yield value
@@ -76,7 +76,7 @@ def _iter_update_dicts(value: Any) -> Iterator[dict[str, Any]]:
             yield from _iter_update_dicts(item)
 
 
-def _extract_text_from_message_content(content: Any) -> str:
+def _extract_text_from_message_content(content: Any) -> str:  # noqa: ANN401  # tracked: #288
     """Normalize AI message content that may be a string or a content-block list."""
     if isinstance(content, str):
         return content
@@ -115,7 +115,7 @@ def _extract_last_ai_message_text(update: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def log_agent_config(agent: Any, label: str, log_file: TextIO | None) -> None:
+def log_agent_config(agent: Any, label: str, log_file: TextIO | None) -> None:  # noqa: ANN401  # tracked: #288
     """Write agent configuration (tools list) to log file."""
     if not log_file:
         return
@@ -230,7 +230,7 @@ def parse_typed_response_text(text: str, response_cls: type[T]) -> T | None:
     return None
 
 
-def _coerce_typed_response(payload: Any, response_cls: type[T]) -> T | None:
+def _coerce_typed_response(payload: Any, response_cls: type[T]) -> T | None:  # noqa: ANN401  # tracked: #288
     if isinstance(payload, response_cls):
         return payload
     if isinstance(payload, dict):
@@ -243,7 +243,7 @@ def _coerce_typed_response(payload: Any, response_cls: type[T]) -> T | None:
     return None
 
 
-def _extract_typed_structured_response(update: Any, response_cls: type[T]) -> T | None:
+def _extract_typed_structured_response(update: Any, response_cls: type[T]) -> T | None:  # noqa: ANN401  # tracked: #288
     """Find a structured response of the given type anywhere in the streamed update tree."""
     for node in _iter_update_dicts(update):
         if "structured_response" not in node:
@@ -259,8 +259,8 @@ def _extract_typed_structured_response(update: Any, response_cls: type[T]) -> T 
 # ---------------------------------------------------------------------------
 
 
-def run_agent(
-    agent: Any,
+def run_agent(  # noqa: PLR0913  # tracked: #288
+    agent: Any,  # noqa: ANN401  # tracked: #288
     prompt: str,
     callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
@@ -307,8 +307,8 @@ def run_agent(
     return last_ai_message
 
 
-def run_typed_agent(
-    agent: Any,
+def run_typed_agent(  # noqa: PLR0913  # tracked: #288
+    agent: Any,  # noqa: ANN401  # tracked: #288
     prompt: str,
     *,
     response_cls: type[T],
@@ -372,8 +372,8 @@ def run_typed_agent(
     return structured_response
 
 
-def run_implementer_agent(
-    agent: Any,
+def run_implementer_agent(  # noqa: PLR0913  # tracked: #288
+    agent: Any,  # noqa: ANN401  # tracked: #288
     prompt: str,
     callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
@@ -397,8 +397,8 @@ def run_implementer_agent(
     )
 
 
-def run_judge_agent(
-    agent: Any,
+def run_judge_agent(  # noqa: PLR0913  # tracked: #288
+    agent: Any,  # noqa: ANN401  # tracked: #288
     prompt: str,
     callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
@@ -427,8 +427,8 @@ def run_judge_agent(
     )
 
 
-def run_perf_eval_agent(
-    agent: Any,
+def run_perf_eval_agent(  # noqa: PLR0913  # tracked: #288
+    agent: Any,  # noqa: ANN401  # tracked: #288
     prompt: str,
     callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
@@ -492,7 +492,7 @@ def _parse_profiler_response_text(text: str) -> ProfilerResponse | None:
     return None
 
 
-def _coerce_profiler_response(payload: Any) -> ProfilerResponse | None:
+def _coerce_profiler_response(payload: Any) -> ProfilerResponse | None:  # noqa: ANN401  # tracked: #288
     if isinstance(payload, ProfilerResponse):
         return payload
     if isinstance(payload, dict):
@@ -521,8 +521,8 @@ def _extract_profiler_structured_response(update: dict[str, Any]) -> ProfilerRes
 # ---------------------------------------------------------------------------
 
 
-def run_profiler_agent(
-    agent: Any,
+def run_profiler_agent(  # noqa: PLR0913  # tracked: #288
+    agent: Any,  # noqa: ANN401  # tracked: #288
     prompt: str,
     callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,
@@ -581,8 +581,8 @@ def run_profiler_agent(
     return structured_response
 
 
-def run_issue_implementer_agent(
-    agent: Any,
+def run_issue_implementer_agent(  # noqa: PLR0913  # tracked: #288
+    agent: Any,  # noqa: ANN401  # tracked: #288
     prompt: str,
     *,
     issue_id: int,
@@ -610,8 +610,8 @@ def run_issue_implementer_agent(
     )
 
 
-def run_issue_judge_agent(
-    agent: Any,
+def run_issue_judge_agent(  # noqa: PLR0913  # tracked: #288
+    agent: Any,  # noqa: ANN401  # tracked: #288
     prompt: str,
     *,
     issue_id: int,
@@ -640,8 +640,8 @@ def run_issue_judge_agent(
     )
 
 
-def run_issue_perf_eval_agent(
-    agent: Any,
+def run_issue_perf_eval_agent(  # noqa: PLR0913  # tracked: #288
+    agent: Any,  # noqa: ANN401  # tracked: #288
     prompt: str,
     callbacks: list[BaseCallbackHandler] | None = None,
     thread_id: str | None = None,

--- a/src/vibesys/agent_runner.py
+++ b/src/vibesys/agent_runner.py
@@ -301,7 +301,7 @@ def run_agent(
         log_and_print(f"\n=== LLM ROUND ERROR: {round_label} ===", log_file)
         log_and_print(error_text, log_file)
         raise
-    output_text = last_ai_message if last_ai_message else "<no ai message returned>"
+    output_text = last_ai_message or "<no ai message returned>"
     log_and_print("\n=== LLM ROUND OUTPUT (final ai message) ===", log_file)
     log_markdown_and_print(output_text, log_file)
     return last_ai_message

--- a/src/vibesys/agents/__init__.py
+++ b/src/vibesys/agents/__init__.py
@@ -8,11 +8,11 @@ runner classes are imported, so the public API of this package is::
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-from pathlib import Path
+from collections.abc import Iterable  # noqa: TC003  # tracked: #288
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import TYPE_CHECKING, Any, TextIO
 
-from vibesys.config import Config
+from vibesys.config import Config  # noqa: TC001  # tracked: #288
 from vibesys.constants import DEFAULT_AGENT_BACKEND, ComputeBackend
 from vibesys.features import FeatureFlag, is_feature_enabled
 
@@ -44,19 +44,19 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> Any:  # noqa: ANN401  # tracked: #288
     if name == "CliAgentRunner":
-        from .cli_runner import CliAgentRunner
+        from .cli_runner import CliAgentRunner  # noqa: PLC0415  # tracked: #288
 
         return CliAgentRunner
     if name == "DeepAgentsRunner":
-        from .deepagents_runner import DeepAgentsRunner
+        from .deepagents_runner import DeepAgentsRunner  # noqa: PLC0415  # tracked: #288
 
         return DeepAgentsRunner
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # noqa: TRY003  # tracked: #288
 
 
-def build_agent_runner(
+def build_agent_runner(  # noqa: D417, PLR0913  # tracked: #288
     config: Config,
     *,
     agent_backend: str | None,
@@ -65,7 +65,7 @@ def build_agent_runner(
     skills: list[str],
     skill_source_dirs: list[Path],
     compute_backend: ComputeBackend | None = None,
-    model: Any,
+    model: Any,  # noqa: ANN401  # tracked: #288
     model_name: str,
     run_log_file: TextIO | None,
     use_docker: bool,
@@ -118,11 +118,11 @@ def build_agent_runner(
 
     if backend == "deepagents":
         if backends is None:
-            raise SystemExit(
+            raise SystemExit(  # noqa: TRY003  # tracked: #288
                 "internal error: build_agent_runner called with backend='deepagents' "
                 "but no backends dict was provided"
             )
-        from .deepagents_runner import DeepAgentsRunner
+        from .deepagents_runner import DeepAgentsRunner  # noqa: PLC0415  # tracked: #288
 
         return DeepAgentsRunner(
             model=model,
@@ -133,7 +133,7 @@ def build_agent_runner(
         )
 
     if backend == "stub":
-        from .stub_runner import StubAgentRunner
+        from .stub_runner import StubAgentRunner  # noqa: PLC0415  # tracked: #288
 
         return StubAgentRunner()
 
@@ -146,10 +146,13 @@ def build_agent_runner(
             # so an unsupported provider or a missing optional dependency
             # fails before the loop starts. With the flag off (the default)
             # this branch is never entered and nothing imports omnigent.
-            from .omnigent.runner import OmnigentAgentRunner, OmnigentUnavailableError
+            from .omnigent.runner import (  # noqa: PLC0415  # tracked: #288
+                OmnigentAgentRunner,
+                OmnigentUnavailableError,
+            )
 
             if use_docker:
-                raise OmnigentUnavailableError(
+                raise OmnigentUnavailableError(  # noqa: TRY003  # tracked: #288
                     "feature flag 'omnigent_agent_backend' is not supported with "
                     "--docker; this integration has no container-launcher "
                     "support. Drop --docker or disable the flag."
@@ -162,7 +165,7 @@ def build_agent_runner(
                 # translate them, so honouring the request is impossible and
                 # dropping it silently would weaken a security boundary the
                 # caller asked for.
-                raise OmnigentUnavailableError(
+                raise OmnigentUnavailableError(  # noqa: TRY003  # tracked: #288
                     "the Omnigent backend cannot honour the requested host "
                     f"resource grants ({[str(r.path) for r in extra_resources]}); "
                     "it confines the agent to the workspace only. Disable "
@@ -184,10 +187,10 @@ def build_agent_runner(
             # The Docker CLI path reuses the DOCKER_PROVIDER_ENV registry for
             # per-provider install + env requirements (node/npm, codex binary,
             # PYTHONPATH, etc).
-            from .cli_docker import DOCKER_PROVIDER_ENV
+            from .cli_docker import DOCKER_PROVIDER_ENV  # noqa: PLC0415  # tracked: #288
 
             if provider not in DOCKER_PROVIDER_ENV:
-                raise SystemExit(
+                raise SystemExit(  # noqa: TRY003  # tracked: #288
                     f"--cli-provider {provider!r} is not yet supported with --docker; "
                     f"supported: {sorted(DOCKER_PROVIDER_ENV)}"
                 )
@@ -196,7 +199,7 @@ def build_agent_runner(
         # it's the single source of truth for the model. model.name is a
         # required field (and always validated by build_model), so it is
         # always a non-empty string here.
-        from .cli_runner import CliAgentRunner
+        from .cli_runner import CliAgentRunner  # noqa: PLC0415  # tracked: #288
 
         return CliAgentRunner(
             provider=provider,
@@ -228,4 +231,4 @@ def build_agent_runner(
             },
         )
 
-    raise SystemExit(f"unknown agent backend: {backend!r}")
+    raise SystemExit(f"unknown agent backend: {backend!r}")  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/agents/base.py
+++ b/src/vibesys/agents/base.py
@@ -12,19 +12,19 @@ Two implementations live alongside this module:
 Loops call a single ``invoke()`` method per (iteration × phase). Callers can
 request a durable session by key without depending on a backend-specific
 session object; the default remains each runner's historical behavior.
-"""
+"""  # noqa: RUF002  # tracked: #288
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from pathlib import Path
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Protocol, TypeVar
 
-from langchain_core.tools import BaseTool
+from langchain_core.tools import BaseTool  # noqa: TC002  # tracked: #288
 from pydantic import BaseModel
 
-from vibesys._agent_cli.base import MCPServerSpec
-from vibesys.agents.progress import AgentProgress
+from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #288
+from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -35,7 +35,7 @@ class AgentRunner(Protocol):
     backend_name: str
     """Diagnostic identifier — ``"deepagents"`` or ``"cli"``."""
 
-    def invoke(
+    def invoke(  # noqa: D417, PLR0913  # tracked: #288
         self,
         *,
         # static per-task config
@@ -101,7 +101,7 @@ class AgentRunner(Protocol):
         """
         ...
 
-    def invoke_text(
+    def invoke_text(  # noqa: PLR0913  # tracked: #288
         self,
         *,
         kind: str,

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -1,4 +1,4 @@
-import json
+import json  # noqa: D100  # tracked: #288
 import time
 import traceback
 import uuid
@@ -72,7 +72,7 @@ class AgentLogger(BaseCallbackHandler):
     ``AgentLogger`` itself never writes to the terminal.
     """
 
-    def __init__(
+    def __init__(  # noqa: ANN204, D107, PLR0913  # tracked: #288
         self,
         log_file: TextIO | None = None,
         model_name: str | None = None,
@@ -122,8 +122,11 @@ class AgentLogger(BaseCallbackHandler):
 
     # --- LLM call context (log-file only) ---
 
-    def on_chat_model_start(
-        self, serialized: dict[str, Any], messages: list[list[BaseMessage]], **kwargs: Any
+    def on_chat_model_start(  # noqa: D102  # tracked: #288
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[BaseMessage]],
+        **kwargs: Any,  # noqa: ANN401, ARG002  # tracked: #288
     ) -> None:
         if not self._log_file:
             return
@@ -149,7 +152,7 @@ class AgentLogger(BaseCallbackHandler):
                     break
 
         # Message type summary
-        from collections import Counter
+        from collections import Counter  # noqa: PLC0415  # tracked: #288
 
         type_counts = Counter(getattr(m, "type", "unknown") for m in flat)
         summary = ", ".join(f"{count} {typ}" for typ, count in sorted(type_counts.items()))
@@ -159,14 +162,14 @@ class AgentLogger(BaseCallbackHandler):
         for msg in reversed(flat):
             if getattr(msg, "type", None) in ("human", "tool"):
                 content = str(msg.content)
-                if len(content) > 500:
+                if len(content) > 500:  # noqa: PLR2004  # tracked: #288
                     content = content[:500] + "..."
                 self._log_line(f"  Last {msg.type} message: {content}")
                 break
 
     # --- LLM token streaming ---
 
-    def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
+    def on_llm_new_token(self, token: str, **kwargs: Any) -> None:  # noqa: ANN401, ARG002, D102  # tracked: #288
         if token:
             status = self._status()
             self._publish(token, "assistant", status=status)
@@ -175,7 +178,7 @@ class AgentLogger(BaseCallbackHandler):
             self._log_write(token)
             self._streaming = True
 
-    def on_llm_end(self, response: Any, **kwargs: Any) -> None:
+    def on_llm_end(self, response: Any, **kwargs: Any) -> None:  # noqa: ANN401, ARG002, D102  # tracked: #288
         was_streaming = self._streaming
         if self._streaming:
             # Close the streamed line on every surface: renderers and the
@@ -229,17 +232,17 @@ class AgentLogger(BaseCallbackHandler):
 
     # --- Tool execution ---
 
-    def on_tool_start(
+    def on_tool_start(  # noqa: D102  # tracked: #288
         self,
         serialized: dict[str, Any],
         input_str: str,
         *,
         inputs: dict[str, Any] | None = None,
-        **kwargs: Any,
+        **kwargs: Any,  # noqa: ANN401  # tracked: #288
     ) -> None:
         pass  # tool call already logged in on_llm_end
 
-    def on_tool_end(self, output: Any, **kwargs: Any) -> None:
+    def on_tool_end(self, output: Any, **kwargs: Any) -> None:  # noqa: ANN401, ARG002, D102  # tracked: #288
         content = output.content if hasattr(output, "content") else str(output)
         name = getattr(output, "name", None) or "unknown"
         call_id = getattr(output, "tool_call_id", None)
@@ -249,7 +252,7 @@ class AgentLogger(BaseCallbackHandler):
             call_id=call_id if isinstance(call_id, str) and call_id else None,
         )
 
-    def on_tool_error(self, error: Any, **kwargs: Any) -> None:
+    def on_tool_error(self, error: Any, **kwargs: Any) -> None:  # noqa: ANN401, ARG002, D102  # tracked: #288
         lines = [f"Tool error: {error!r}"]
         if isinstance(error, BaseException):
             tb = traceback.format_exception(type(error), error, error.__traceback__)
@@ -317,7 +320,7 @@ class AgentLogger(BaseCallbackHandler):
                 full_parts.append(f'{k}="{s}"' if isinstance(v, str) else f"{k}={s}")
             self._log_line(f"\n→ {name}({', '.join(full_parts)})")
 
-    def _emit_thinking(self, text: str):
+    def _emit_thinking(self, text: str):  # noqa: ANN202  # tracked: #288
         self._publish(text, "analysis")
         self._log_line("\n[thinking]")
         for line in text.split("\n"):
@@ -341,7 +344,7 @@ class AgentLogger(BaseCallbackHandler):
         if resolved_call_id is None and pending:
             resolved_call_id = pending.popleft()
         elif resolved_call_id is not None:
-            try:
+            try:  # noqa: SIM105  # tracked: #288
                 pending.remove(resolved_call_id)
             except ValueError:
                 pass
@@ -392,14 +395,14 @@ class AgentLogger(BaseCallbackHandler):
     # paths converge on the same private ``_emit_*`` helpers, so emitted events
     # and log text are identical regardless of which backend is in use.
 
-    def on_thinking(self, text: str) -> None:
+    def on_thinking(self, text: str) -> None:  # noqa: D102  # tracked: #288
         if not text:
             return
         status = self._status()
         self._publish(text, "analysis", status=status)
         self._log_line(f"{format_status_prefix(status)}{text}")
 
-    def on_tool_call(self, tool: str, args: dict[str, Any] | str | None = None) -> None:
+    def on_tool_call(self, tool: str, args: dict[str, Any] | str | None = None) -> None:  # noqa: D102  # tracked: #288
         if isinstance(args, dict):
             normalized = args
         elif args is None:
@@ -408,7 +411,7 @@ class AgentLogger(BaseCallbackHandler):
             normalized = {"args": str(args)}
         self.log_tool_call(tool, normalized)
 
-    def on_tool_result(
+    def on_tool_result(  # noqa: D102  # tracked: #288
         self,
         tool: str,
         stdout: str = "",
@@ -420,7 +423,7 @@ class AgentLogger(BaseCallbackHandler):
         content = stdout or stderr
         self.log_tool_result(tool, content, is_error=is_error)
 
-    def on_usage(self, usage: dict[str, Any]) -> None:
+    def on_usage(self, usage: dict[str, Any]) -> None:  # noqa: D102  # tracked: #288
         self.update_usage(usage)
 
     def update_usage(self, usage: dict[str, Any] | None) -> None:

--- a/src/vibesys/agents/cli_common.py
+++ b/src/vibesys/agents/cli_common.py
@@ -18,14 +18,14 @@ import json
 import os
 import shutil
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from pathlib import Path
 from typing import TextIO
 
-from pydantic import BaseModel
+from pydantic import BaseModel  # noqa: TC002  # tracked: #288
 
 from vibesys.agent_runner import log_and_print
-from vibesys.constants import ComputeBackend
+from vibesys.constants import ComputeBackend  # noqa: TC001  # tracked: #288
 from vibesys.skills import foreign_platform_names, is_platforms_parent
 
 # Per-provider CLI skill-discovery paths, matching upstream
@@ -73,7 +73,7 @@ _UNSUPPORTED_NATIVE_SCHEMA_KEYWORDS = frozenset(
 )
 
 
-def _validate_native_output_schema(schema: object) -> dict[str, object]:
+def _validate_native_output_schema(schema: object) -> dict[str, object]:  # noqa: C901  # tracked: #288
     """Normalize and validate the strict JSON Schema subset used by Codex.
 
     Native structured output requires every declared object property and
@@ -83,9 +83,9 @@ def _validate_native_output_schema(schema: object) -> dict[str, object]:
     falls back to the portable prompt contract.
     """
     if not isinstance(schema, dict) or schema.get("type") != "object":
-        raise ValueError("native output schema must have an object root")
+        raise ValueError("native output schema must have an object root")  # noqa: TRY003  # tracked: #288
 
-    def visit(node: object, location: str) -> None:
+    def visit(node: object, location: str) -> None:  # noqa: C901, PLR0912  # tracked: #288
         if isinstance(node, list):
             for index, value in enumerate(node):
                 visit(value, f"{location}/{index}")
@@ -95,7 +95,7 @@ def _validate_native_output_schema(schema: object) -> dict[str, object]:
         reference = node.get("$ref")
         if reference is not None:
             if not isinstance(reference, str) or not reference.startswith("#/"):
-                raise ValueError(f"native output schema uses a non-local $ref at {location}")
+                raise ValueError(f"native output schema uses a non-local $ref at {location}")  # noqa: TRY003  # tracked: #288
             # Codex follows the older strict subset where a reference may not
             # have annotation or validation siblings.
             node.clear()
@@ -105,27 +105,27 @@ def _validate_native_output_schema(schema: object) -> dict[str, object]:
         properties = node.get("properties")
         if properties is not None:
             if not isinstance(properties, dict):
-                raise ValueError(f"native output schema {location}/properties must be an object")
+                raise ValueError(f"native output schema {location}/properties must be an object")  # noqa: TRY003  # tracked: #288
             additional = node.get("additionalProperties")
             if additional not in (None, False):
-                raise ValueError(f"native output schema uses arbitrary object keys at {location}")
+                raise ValueError(f"native output schema uses arbitrary object keys at {location}")  # noqa: TRY003  # tracked: #288
             node["additionalProperties"] = False
             node["required"] = list(properties)
         elif node.get("type") == "object":
             additional = node.get("additionalProperties")
             if additional not in (None, False):
-                raise ValueError(f"native output schema uses arbitrary object keys at {location}")
+                raise ValueError(f"native output schema uses arbitrary object keys at {location}")  # noqa: TRY003  # tracked: #288
             node["additionalProperties"] = False
             node["required"] = []
         for key, value in node.items():
             if key in {"properties", "$defs", "definitions"}:
                 if not isinstance(value, dict):
-                    raise ValueError(f"native output schema {location}/{key} must be an object")
+                    raise ValueError(f"native output schema {location}/{key} must be an object")  # noqa: TRY003  # tracked: #288
                 for name, subschema in value.items():
                     visit(subschema, f"{location}/{key}/{name}")
                 continue
             if key in _UNSUPPORTED_NATIVE_SCHEMA_KEYWORDS:
-                raise ValueError(
+                raise ValueError(  # noqa: TRY003  # tracked: #288
                     f"native output schema uses unsupported keyword {key!r} at {location}"
                 )
             visit(value, f"{location}/{key}")
@@ -149,7 +149,7 @@ def materialize_native_output_schema(workspace: Path, response_cls: type[BaseMod
             stream.write(encoded)
             stream.flush()
             os.fsync(stream.fileno())
-        os.replace(temporary, target)
+        os.replace(temporary, target)  # noqa: PTH105  # tracked: #288
     finally:
         temporary.unlink(missing_ok=True)
     return relative.as_posix()
@@ -189,7 +189,7 @@ def _platform_prune_ignore(
     return _ignore
 
 
-def materialize_skills(
+def materialize_skills(  # noqa: C901  # tracked: #288
     workspace: Path,
     skill_dirs: list[Path],
     *,

--- a/src/vibesys/agents/cli_docker.py
+++ b/src/vibesys/agents/cli_docker.py
@@ -52,7 +52,7 @@ RUST_DOCKER_TOOLCHAIN_VERSION = "1.92.0"
 # return transient "connection timed out" / "mirror sync in progress"
 # errors that fail a single-shot `apt-get update`.
 def _apt_install(pkgs: str, check_bin: str | None = None) -> str:
-    bin_ = check_bin or pkgs.split()[0]
+    bin_ = check_bin or pkgs.split(maxsplit=1)[0]
     return (
         f"command -v {bin_} >/dev/null || "
         "{ for i in 1 2 3 4 5; do "

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -390,7 +390,7 @@ class CliAgentRunner:
                 "state remains authoritative.",
                 self._run_log_file,
             )
-            cast(CodexCodingAgent, agent).session_id = None
+            cast("CodexCodingAgent", agent).session_id = None
             self._session_turn_counts[cache_key] = 0
 
         # Set this on every turn, including plain-text turns, so a reused
@@ -463,7 +463,7 @@ class CliAgentRunner:
                     "retrying with a fresh thread.",
                     self._run_log_file,
                 )
-                cast(CodexCodingAgent, agent).session_id = None
+                cast("CodexCodingAgent", agent).session_id = None
                 self._session_turn_counts[cache_key] = 0
                 text = agent.generate(
                     combined_prompt,
@@ -529,7 +529,7 @@ class CliAgentRunner:
     def _configure_reasoning_effort(self, agent: CodingAgent, reasoning_effort: str | None) -> None:
         """Apply provider-specific reasoning controls to a newly built CLI agent."""
         if self._provider == "codex" and reasoning_effort is not None:
-            cast(CodexCodingAgent, agent).set_reasoning_effort(reasoning_effort)
+            cast("CodexCodingAgent", agent).set_reasoning_effort(reasoning_effort)
 
     def _write_usage_record(
         self,

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -21,15 +21,15 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable  # noqa: TC003  # tracked: #288
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol, TextIO, TypeVar, cast
 
-from langchain_core.tools import BaseTool
+from langchain_core.tools import BaseTool  # noqa: TC002  # tracked: #288
 from pydantic import BaseModel
 
-from vibesys._agent_cli.base import CodingAgent, MCPServerSpec
+from vibesys._agent_cli.base import CodingAgent, MCPServerSpec  # noqa: TC001  # tracked: #288
 from vibesys._agent_cli.claude import ClaudeCodeCodingAgent
 from vibesys._agent_cli.codex import CodexCodingAgent
 from vibesys._agent_cli.gemini import GeminiCodingAgent
@@ -49,8 +49,8 @@ from vibesys.agents.cli_common import (
     materialize_skills,
 )
 from vibesys.agents.host_resource_declarations import declare_agent_host_resources
-from vibesys.agents.progress import AgentProgress
-from vibesys.constants import ComputeBackend
+from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
+from vibesys.constants import ComputeBackend  # noqa: TC001  # tracked: #288
 from vs_sandbox import HostResource, build_host_sandbox
 
 T = TypeVar("T", bound=BaseModel)
@@ -62,9 +62,9 @@ class _ProviderFactory(Protocol):
     def __call__(
         self,
         model: str | None = None,
-        event_handler: Any | None = None,
+        event_handler: Any | None = None,  # noqa: ANN401  # tracked: #288
         *,
-        executor: Any | None = None,
+        executor: Any | None = None,  # noqa: ANN401  # tracked: #288
     ) -> CodingAgent: ...
 
 
@@ -109,7 +109,7 @@ class CliAgentRunner:
 
     backend_name = "cli"
 
-    def __init__(
+    def __init__(  # noqa: ANN204, D107, PLR0913  # tracked: #288
         self,
         *,
         provider: str,
@@ -127,7 +127,7 @@ class CliAgentRunner:
         role_reasoning_efforts: dict[str, str] | None = None,
     ):
         if provider not in _PROVIDER_CLASSES:
-            raise SystemExit(
+            raise SystemExit(  # noqa: TRY003  # tracked: #288
                 f"unknown cli provider {provider!r}; expected one of: {sorted(_PROVIDER_CLASSES)}"
             )
         self._provider = provider
@@ -157,7 +157,7 @@ class CliAgentRunner:
         self._agents: dict[str, CodingAgent] = {}
         self._session_turn_counts: dict[str, int] = {}
 
-    def invoke(
+    def invoke(  # noqa: D102, PLR0913  # tracked: #288
         self,
         *,
         kind: str,
@@ -240,7 +240,7 @@ class CliAgentRunner:
         log_json_and_print(parsed.model_dump_json(indent=2), self._run_log_file)
         return parsed
 
-    def invoke_text(
+    def invoke_text(  # noqa: PLR0913  # tracked: #288
         self,
         *,
         kind: str,
@@ -282,7 +282,7 @@ class CliAgentRunner:
             log_and_print(f"No response received from {label.lower()}.", self._run_log_file)
         return text
 
-    def _generate(
+    def _generate(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
         self,
         *,
         kind: str,
@@ -342,12 +342,14 @@ class CliAgentRunner:
                 # Dynamic poke: only the docker path constructs agents with a
                 # DockerCommandExecutor, which carries container_id.
                 executor = getattr(agent, "executor", None)
-                executor.container_id = self._docker_sandboxes[kind]._container_id  # pyright: ignore[reportOptionalMemberAccess]
+                executor.container_id = self._docker_sandboxes[kind]._container_id  # pyright: ignore[reportOptionalMemberAccess]  # noqa: SLF001  # tracked: #288
         elif self._docker_sandboxes is not None:
-            from vibesys.agents.docker_executor import DockerCommandExecutor
+            from vibesys.agents.docker_executor import (  # noqa: PLC0415  # tracked: #288
+                DockerCommandExecutor,
+            )
 
             sandbox = self._docker_sandboxes[kind]
-            executor = DockerCommandExecutor(sandbox._container_id)
+            executor = DockerCommandExecutor(sandbox._container_id)  # noqa: SLF001  # tracked: #288
             agent = self._provider_cls(
                 model=selected_model,
                 event_handler=logger,
@@ -399,7 +401,7 @@ class CliAgentRunner:
         if callable(schema_setter):
             schema_setter(output_schema_path)
         elif output_schema_path is not None:
-            raise RuntimeError(
+            raise RuntimeError(  # noqa: TRY003  # tracked: #288
                 f"{type(agent).__name__} advertised native output schemas "
                 "without implementing set_output_schema_path()"
             )
@@ -489,7 +491,7 @@ class CliAgentRunner:
             if mcp_servers:
                 try:
                     agent.uninstall_mcp_servers(workspace, mcp_servers)
-                except Exception as cleanup_exc:
+                except Exception as cleanup_exc:  # noqa: BLE001  # tracked: #288
                     cleanup_error = cleanup_exc
                     if agent_error is not None:
                         log_and_print(
@@ -501,7 +503,7 @@ class CliAgentRunner:
                 try:
                     executor = agent.executor
                     executor.repair_workspace_ownership(uid=os.getuid(), gid=os.getgid())
-                except Exception as cleanup_exc:
+                except Exception as cleanup_exc:  # noqa: BLE001  # tracked: #288
                     if cleanup_error is None:
                         cleanup_error = cleanup_exc
                     else:
@@ -536,7 +538,7 @@ class CliAgentRunner:
         *,
         kind: str,
         round_label: str,
-        agent: Any,
+        agent: Any,  # noqa: ANN401  # tracked: #288
         model_name: str | None,
         reasoning_effort: str | None,
     ) -> None:

--- a/src/vibesys/agents/deepagents_runner.py
+++ b/src/vibesys/agents/deepagents_runner.py
@@ -8,25 +8,25 @@ change vs. what the simple loop did before this abstraction landed.
 from __future__ import annotations
 
 import uuid
-from collections.abc import Callable
-from pathlib import Path
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any, TextIO, TypeVar
 
 from deepagents import create_deep_agent
 from langchain.agents.structured_output import AutoStrategy
-from langchain_core.callbacks import BaseCallbackHandler
-from langchain_core.tools import BaseTool
+from langchain_core.callbacks import BaseCallbackHandler  # noqa: TC002  # tracked: #288
+from langchain_core.tools import BaseTool  # noqa: TC002  # tracked: #288
 from langgraph.checkpoint.memory import MemorySaver
 from pydantic import BaseModel
 
-from vibesys._agent_cli.base import MCPServerSpec
+from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #288
 from vibesys.agent_runner import (
     log_agent_config,
     run_agent,
     run_typed_agent,
 )
 from vibesys.agents.callbacks import AgentLogger
-from vibesys.agents.progress import AgentProgress
+from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -41,10 +41,10 @@ class DeepAgentsRunner:
 
     backend_name = "deepagents"
 
-    def __init__(
+    def __init__(  # noqa: ANN204, D107  # tracked: #288
         self,
         *,
-        model: Any,
+        model: Any,  # noqa: ANN401  # tracked: #288
         backends: dict[str, Any],
         skills: list[str],
         model_name: str | None,
@@ -91,7 +91,7 @@ class DeepAgentsRunner:
         system_prompt: str,
         response_cls: type[BaseModel] | None = None,
         tools: list[BaseTool] | None = None,
-    ) -> Any:
+    ) -> Any:  # noqa: ANN401  # tracked: #288
         """Return the cached graph, rebuilding it when its inputs change."""
         tool_signature = tuple(id(tool) for tool in (tools or []))
         signature = (
@@ -120,7 +120,7 @@ class DeepAgentsRunner:
         self._agent_signatures[kind] = signature
         return agent
 
-    def invoke(
+    def invoke(  # noqa: D102, PLR0913  # tracked: #288
         self,
         *,
         kind: str,
@@ -177,7 +177,7 @@ class DeepAgentsRunner:
             log_file=self._run_log_file,
         )
 
-    def invoke_text(
+    def invoke_text(  # noqa: PLR0913  # tracked: #288
         self,
         *,
         kind: str,

--- a/src/vibesys/agents/docker_executor.py
+++ b/src/vibesys/agents/docker_executor.py
@@ -212,7 +212,7 @@ class DockerCommandExecutor:
             # TimeoutExpired is only raised by the wait(timeout=...) branch,
             # so request.timeout is non-None on this path.
             raise subprocess.TimeoutExpired(
-                list(request.argv), cast(float, request.timeout)
+                list(request.argv), cast("float", request.timeout)
             ) from None
         finally:
             if process.poll() is None:
@@ -400,7 +400,7 @@ class DockerCommandExecutor:
             payload_type = payload.get("type")
             if payload_type in {"task_started", "task_complete"}:
                 last_lifecycle_index = index
-                last_lifecycle_type = cast(str, payload_type)
+                last_lifecycle_type = cast("str", payload_type)
         if last_lifecycle_type != "task_complete":
             return None
 

--- a/src/vibesys/agents/docker_executor.py
+++ b/src/vibesys/agents/docker_executor.py
@@ -9,7 +9,7 @@ import signal
 import subprocess
 import threading
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Sequence  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -22,13 +22,13 @@ class DockerCommandHandle:
 
     process: subprocess.Popen[str]
 
-    def terminate(self) -> None:
+    def terminate(self) -> None:  # noqa: D102  # tracked: #288
         try:
             os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
         except (ProcessLookupError, OSError):
             self.process.terminate()
 
-    def kill(self) -> None:
+    def kill(self) -> None:  # noqa: D102  # tracked: #288
         try:
             os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
         except (ProcessLookupError, OSError):
@@ -75,19 +75,19 @@ class DockerCommandExecutor:
     _CODEX_ROLLOUT_POLL_SECONDS = 15.0
     _CODEX_COMPLETION_GRACE_SECONDS = 30.0
 
-    def __init__(self, container_id: str) -> None:
+    def __init__(self, container_id: str) -> None:  # noqa: D107  # tracked: #288
         self.container_id = container_id
         self._codex_rollout_paths: dict[str, str] = {}
 
-    def find_binary(self, binary_name: str, env: dict[str, str]) -> str:
+    def find_binary(self, binary_name: str, env: dict[str, str]) -> str:  # noqa: ARG002, D102  # tracked: #288
         return binary_name
 
-    def check_binary(
+    def check_binary(  # noqa: D102  # tracked: #288
         self,
-        binary_path: str,
-        env: dict[str, str],
+        binary_path: str,  # noqa: ARG002  # tracked: #288
+        env: dict[str, str],  # noqa: ARG002  # tracked: #288
         *,
-        timeout: int,
+        timeout: int,  # noqa: ARG002  # tracked: #288
     ) -> None:
         return None
 
@@ -100,8 +100,8 @@ class DockerCommandExecutor:
         before control returns to the framework rather than waiting until a
         later resume.
         """
-        result = subprocess.run(
-            [
+        result = subprocess.run(  # noqa: S603  # tracked: #288
+            [  # noqa: S607  # tracked: #288
                 "docker",
                 "exec",
                 self.container_id,
@@ -129,7 +129,7 @@ class DockerCommandExecutor:
                 + (f": {detail}" if detail else "")
             )
 
-    def run(
+    def run(  # noqa: C901, D102  # tracked: #288
         self,
         request: CommandRequest,
         sink: CommandStreamSink,
@@ -143,7 +143,7 @@ class DockerCommandExecutor:
             self.container_id,
             *request.argv,
         ]
-        process = subprocess.Popen(
+        process = subprocess.Popen(  # noqa: S603  # tracked: #288
             docker_cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -159,7 +159,7 @@ class DockerCommandExecutor:
         stdout_lines: list[str] = []
         stderr_lines: list[str] = []
 
-        def read_pipe(pipe: Any, callback: Callable[[str], None], sink: list[str]) -> None:
+        def read_pipe(pipe: Any, callback: Callable[[str], None], sink: list[str]) -> None:  # noqa: ANN401  # tracked: #288
             try:
                 for line in iter(pipe.readline, ""):
                     if not line:
@@ -169,7 +169,7 @@ class DockerCommandExecutor:
             except (OSError, ValueError):
                 pass
             finally:
-                try:
+                try:  # noqa: SIM105  # tracked: #288
                     pipe.close()
                 except (OSError, ValueError):
                     pass
@@ -229,7 +229,7 @@ class DockerCommandExecutor:
             stderr="".join(stderr_lines),
         )
 
-    def _wait_with_docker_exec_watchdog(
+    def _wait_with_docker_exec_watchdog(  # noqa: C901  # tracked: #288
         self,
         process: subprocess.Popen[str],
         cmd: Sequence[str],
@@ -238,7 +238,7 @@ class DockerCommandExecutor:
         stdout_lines: list[str],
         timeout: float | None,
     ) -> bool:
-        child_binary = os.path.basename(cmd[0]) if cmd else ""
+        child_binary = os.path.basename(cmd[0]) if cmd else ""  # noqa: PTH119  # tracked: #288
         watchdog_killed = False
         codex_thread_id = self._codex_resume_thread_id(cmd)
         watch_codex_rollout = self._is_codex_json_command(cmd)
@@ -249,16 +249,16 @@ class DockerCommandExecutor:
         while True:
             now = time.monotonic()
             if deadline is not None and now >= deadline:
-                assert timeout is not None
+                assert timeout is not None  # noqa: S101  # tracked: #288
                 raise subprocess.TimeoutExpired(list(cmd), timeout)
             wait_seconds = 5.0 if deadline is None else min(5.0, deadline - now)
             try:
                 process.wait(timeout=wait_seconds)
-                return watchdog_killed
+                return watchdog_killed  # noqa: TRY300  # tracked: #288
             except subprocess.TimeoutExpired:
                 now = time.monotonic()
                 if deadline is not None and now >= deadline:
-                    assert timeout is not None
+                    assert timeout is not None  # noqa: S101  # tracked: #288
                     raise subprocess.TimeoutExpired(list(cmd), timeout) from None
                 if codex_thread_id is None and watch_codex_rollout:
                     codex_thread_id = self._codex_started_thread_id(stdout_lines)
@@ -284,8 +284,8 @@ class DockerCommandExecutor:
                             process.wait()
                         return True
 
-                check = subprocess.run(
-                    [
+                check = subprocess.run(  # noqa: S603  # tracked: #288
+                    [  # noqa: S607  # tracked: #288
                         "docker",
                         "exec",
                         self.container_id,
@@ -306,7 +306,7 @@ class DockerCommandExecutor:
     @staticmethod
     def _is_codex_json_command(cmd: Sequence[str]) -> bool:
         """Return whether *cmd* is a machine-readable Codex exec invocation."""
-        if not cmd or os.path.basename(cmd[0]) != "codex" or "--json" not in cmd:
+        if not cmd or os.path.basename(cmd[0]) != "codex" or "--json" not in cmd:  # noqa: PTH119  # tracked: #288
             return False
         return "exec" in cmd
 
@@ -339,15 +339,15 @@ class DockerCommandExecutor:
                 return thread_id
         return None
 
-    def _read_codex_rollout_completion(
+    def _read_codex_rollout_completion(  # noqa: C901, PLR0912  # tracked: #288
         self,
         thread_id: str,
     ) -> _CodexRolloutCompletion | None:
         """Read stable terminal evidence from a resumed Codex rollout, if any."""
         rollout_path = self._codex_rollout_paths.get(thread_id)
         if rollout_path is None:
-            located = subprocess.run(
-                [
+            located = subprocess.run(  # noqa: S603  # tracked: #288
+                [  # noqa: S607  # tracked: #288
                     "docker",
                     "exec",
                     self.container_id,
@@ -370,8 +370,8 @@ class DockerCommandExecutor:
             rollout_path = max(paths)
             self._codex_rollout_paths[thread_id] = rollout_path
 
-        result = subprocess.run(
-            ["docker", "exec", self.container_id, "tail", "-n", "512", rollout_path],
+        result = subprocess.run(  # noqa: S603  # tracked: #288
+            ["docker", "exec", self.container_id, "tail", "-n", "512", rollout_path],  # noqa: S607  # tracked: #288
             capture_output=True,
             text=True,
             timeout=5,
@@ -450,8 +450,8 @@ class DockerCommandExecutor:
 
     def _terminate_codex_resume(self, thread_id: str) -> None:
         """Stop only the completed resumed Codex process inside this container."""
-        subprocess.run(
-            [
+        subprocess.run(  # noqa: S603  # tracked: #288
+            [  # noqa: S607  # tracked: #288
                 "docker",
                 "exec",
                 self.container_id,
@@ -467,7 +467,7 @@ class DockerCommandExecutor:
         )
 
     def _kill_process_group(self, process: subprocess.Popen[str]) -> None:
-        try:
+        try:  # noqa: SIM105  # tracked: #288
             os.killpg(os.getpgid(process.pid), signal.SIGKILL)
         except (ProcessLookupError, OSError):
             pass

--- a/src/vibesys/agents/host_resource_declarations.py
+++ b/src/vibesys/agents/host_resource_declarations.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import os
 import shutil
 import sys
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping  # noqa: TC003  # tracked: #288
 from pathlib import Path
 
 from vs_sandbox import (
@@ -97,12 +97,12 @@ def _agent_runtime(ctx: HostResourceContext) -> Iterable[HostResource]:
         paths.extend((real_node.parent, real_node.parent.parent))
 
     try:
-        import vibesys
+        import vibesys  # noqa: PLC0415  # tracked: #288
 
         pkg_file = getattr(vibesys, "__file__", None)
         if pkg_file:
             paths.append(Path(pkg_file).resolve().parents[1])
-    except Exception:  # pragma: no cover - defensive; import cannot normally fail here
+    except Exception:  # pragma: no cover - defensive; import cannot normally fail here  # noqa: BLE001, S110  # tracked: #288
         pass
 
     return _resources(paths, purpose="agent and VibeSys runtime")

--- a/src/vibesys/agents/omnigent/__init__.py
+++ b/src/vibesys/agents/omnigent/__init__.py
@@ -40,7 +40,7 @@ def __getattr__(name: str) -> object:
     # not pull in langchain/pydantic wiring for callers that only need the
     # provider table (e.g. build_agent_runner's validation path).
     if name in {"OmnigentAgentRunner", "OmnigentUnavailableError"}:
-        from vibesys.agents.omnigent import runner
+        from vibesys.agents.omnigent import runner  # noqa: PLC0415  # tracked: #288
 
         return getattr(runner, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/agents/omnigent/providers.py
+++ b/src/vibesys/agents/omnigent/providers.py
@@ -27,7 +27,7 @@ depends on.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass
 from types import MappingProxyType
 

--- a/src/vibesys/agents/omnigent/runner.py
+++ b/src/vibesys/agents/omnigent/runner.py
@@ -32,16 +32,16 @@ import contextlib
 import json
 import os
 import sys
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator  # noqa: TC003  # tracked: #288
 from datetime import UTC, datetime
 from importlib import import_module
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any, TextIO, TypeVar
 
-from langchain_core.tools import BaseTool
+from langchain_core.tools import BaseTool  # noqa: TC002  # tracked: #288
 from pydantic import BaseModel
 
-from vibesys._agent_cli.base import MCPServerSpec
+from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #288
 from vibesys.agent_runner import (
     log_and_print,
     log_json_and_print,
@@ -60,7 +60,7 @@ from vibesys.agents.omnigent.providers import (
     OmnigentExecutorSpec,
     supported_providers,
 )
-from vibesys.agents.progress import AgentProgress
+from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -102,7 +102,7 @@ def resolve_executor_spec(provider: str) -> OmnigentExecutorSpec:
     """
     spec = OMNIGENT_PROVIDER_EXECUTORS.get(provider)
     if spec is None:
-        raise OmnigentUnavailableError(
+        raise OmnigentUnavailableError(  # noqa: TRY003  # tracked: #288
             f"feature flag 'omnigent_agent_backend' is enabled but cli provider "
             f"{provider!r} has no Omnigent executor; supported: "
             f"{supported_providers()}. Disable the flag to use the agentshim "
@@ -145,7 +145,7 @@ def _sandbox_backend_for_platform() -> str:
         return "darwin_seatbelt"
     if os.name == "nt":
         return "windows_jobobject"
-    raise OmnigentUnavailableError(
+    raise OmnigentUnavailableError(  # noqa: TRY003  # tracked: #288
         f"no Omnigent sandbox backend is available on platform {sys.platform!r}, "
         "and the Omnigent backend will not run an agent unconfined. Disable "
         "'omnigent_agent_backend' to use the agentshim backend."
@@ -179,7 +179,7 @@ def _patched_environ(overrides: dict[str, str] | None) -> Generator[None]:
                 os.environ[key] = str(old)
 
 
-def _flatten_tool_schema(tool: Any) -> dict[str, Any]:
+def _flatten_tool_schema(tool: Any) -> dict[str, Any]:  # noqa: ANN401  # tracked: #288
     """Convert a ``Tool.get_schema()`` payload into executor ``ToolSpec`` shape.
 
     ``get_schema()`` returns OpenAI-function shape
@@ -197,7 +197,7 @@ def _flatten_tool_schema(tool: Any) -> dict[str, Any]:
     }
 
 
-def _build_os_tools(os_env_spec: Any, workspace: Path) -> tuple[list[dict[str, Any]], Any]:
+def _build_os_tools(os_env_spec: Any, workspace: Path) -> tuple[list[dict[str, Any]], Any]:  # noqa: ANN401  # tracked: #288
     """Build Omnigent's ``sys_os_*`` tools and a dispatcher for them.
 
     Passing ``os_env`` to an executor confines the agent, but it does **not**
@@ -224,11 +224,13 @@ def _build_os_tools(os_env_spec: Any, workspace: Path) -> tuple[list[dict[str, A
             backend is unusable, most often a missing ``bwrap`` binary.
     """
     try:
-        from omnigent.inner.os_env import create_os_environment
-        from omnigent.tools.base import ToolContext
-        from omnigent.tools.builtins.os_env import build_os_env_tools
+        from omnigent.inner.os_env import create_os_environment  # noqa: PLC0415  # tracked: #288
+        from omnigent.tools.base import ToolContext  # noqa: PLC0415  # tracked: #288
+        from omnigent.tools.builtins.os_env import (  # noqa: PLC0415  # tracked: #288
+            build_os_env_tools,
+        )
     except ImportError as exc:
-        raise _missing_omnigent("omnigent's OS-environment tools", exc) from exc
+        raise _missing_omnigent("omnigent's OS-environment tools", exc) from exc  # noqa: TRY003  # tracked: #288
 
     try:
         os_env = create_os_environment(os_env_spec)
@@ -237,7 +239,7 @@ def _build_os_tools(os_env_spec: Any, workspace: Path) -> tuple[list[dict[str, A
         # OSError when it is absent. Translate it: the operator needs to know
         # this came from the opt-in flag and what the two remedies are.
         # Running the agent unconfined is deliberately not one of them.
-        raise OmnigentUnavailableError(
+        raise OmnigentUnavailableError(  # noqa: TRY003  # tracked: #288
             "feature flag 'omnigent_agent_backend' is enabled but this host "
             f"cannot provide the {_sandbox_backend_for_platform()!r} sandbox "
             f"the Omnigent backend confines agents with ({exc}). Install the "
@@ -246,7 +248,7 @@ def _build_os_tools(os_env_spec: Any, workspace: Path) -> tuple[list[dict[str, A
         ) from exc
 
     if os_env is None:
-        raise OmnigentUnavailableError(
+        raise OmnigentUnavailableError(  # noqa: TRY003  # tracked: #288
             "Omnigent could not resolve an OS environment for workspace "
             f"{workspace}; the agent would start with no file or shell tools. "
             "Disable 'omnigent_agent_backend' to use the agentshim backend."
@@ -257,7 +259,7 @@ def _build_os_tools(os_env_spec: Any, workspace: Path) -> tuple[list[dict[str, A
     schemas = [_flatten_tool_schema(tool) for tool in tools]
     context = ToolContext(task_id="vibesys", agent_id="vibesys", workspace=workspace)
 
-    async def dispatch(name: str, args: dict[str, Any]) -> Any:
+    async def dispatch(name: str, args: dict[str, Any]) -> Any:  # noqa: ANN401  # tracked: #288
         tool = by_name.get(name)
         if tool is None:
             return {"error": f"unknown tool {name!r}"}
@@ -269,7 +271,7 @@ def _build_os_tools(os_env_spec: Any, workspace: Path) -> tuple[list[dict[str, A
 
 
 async def _drive_turn(
-    executor: Any,
+    executor: Any,  # noqa: ANN401  # tracked: #288
     *,
     prompt: str,
     system_prompt: str,
@@ -287,9 +289,14 @@ async def _drive_turn(
     that stream without repeating the full response at the end.
     """
     try:
-        from omnigent import TextChunk, ToolCallComplete, ToolCallRequest, TurnComplete
+        from omnigent import (  # noqa: PLC0415  # tracked: #288
+            TextChunk,
+            ToolCallComplete,
+            ToolCallRequest,
+            TurnComplete,
+        )
     except ImportError as exc:
-        raise _missing_omnigent("omnigent's executor event types", exc) from exc
+        raise _missing_omnigent("omnigent's executor event types", exc) from exc  # noqa: TRY003  # tracked: #288
 
     chunks: list[str] = []
     response: str | None = None
@@ -335,7 +342,7 @@ class OmnigentAgentRunner:
 
     backend_name = "omnigent"
 
-    def __init__(
+    def __init__(  # noqa: D107, PLR0913  # tracked: #288
         self,
         *,
         provider: str,
@@ -364,7 +371,7 @@ class OmnigentAgentRunner:
         # loop — observed live as "Event loop is closed" during teardown.
         self._loop: asyncio.AbstractEventLoop | None = None
 
-    def _run_async(self, coro: Any) -> Any:
+    def _run_async(self, coro: Any) -> Any:  # noqa: ANN401  # tracked: #288
         """Drive *coro* on this runner's long-lived event loop."""
         loop = self._loop
         if loop is None or loop.is_closed():
@@ -399,7 +406,7 @@ class OmnigentAgentRunner:
             loop.close()
         self._loop = None
 
-    def _close_executor(self, executor: Any) -> None:
+    def _close_executor(self, executor: Any) -> None:  # noqa: ANN401  # tracked: #288
         """Close one cached or intentionally one-shot executor safely."""
         close = getattr(executor, "close", None)
         if close is None:
@@ -430,7 +437,7 @@ class OmnigentAgentRunner:
         try:
             return getattr(module, self._spec.class_name)
         except AttributeError as exc:
-            raise OmnigentUnavailableError(
+            raise OmnigentUnavailableError(  # noqa: TRY003  # tracked: #288
                 f"omnigent module {self._spec.module!r} has no "
                 f"{self._spec.class_name!r}; the installed omnigent version is "
                 "incompatible with this integration (expected the 0.6.0 "
@@ -438,7 +445,7 @@ class OmnigentAgentRunner:
                 "agentshim backend."
             ) from exc
 
-    def _build_os_env(self, workspace: Path) -> Any:
+    def _build_os_env(self, workspace: Path) -> Any:  # noqa: ANN401  # tracked: #288
         """Confine the agent to *workspace* using Omnigent's own sandbox.
 
         The agentshim host path wraps every agent in a ``vs_sandbox`` host
@@ -469,9 +476,12 @@ class OmnigentAgentRunner:
         been proven equivalent.
         """
         try:
-            from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+            from omnigent.inner.datamodel import (  # noqa: PLC0415  # tracked: #288
+                OSEnvSandboxSpec,
+                OSEnvSpec,
+            )
         except ImportError as exc:
-            raise _missing_omnigent("omnigent's OS-environment datamodel", exc) from exc
+            raise _missing_omnigent("omnigent's OS-environment datamodel", exc) from exc  # noqa: TRY003  # tracked: #288
 
         return OSEnvSpec(
             type="caller_process",
@@ -520,14 +530,14 @@ class OmnigentAgentRunner:
             # text is useful, so keep it, but attribute it to the flag — the
             # operator otherwise has no hint which setting pulled in a
             # dependency on a binary they do not have.
-            raise OmnigentUnavailableError(
+            raise OmnigentUnavailableError(  # noqa: TRY003  # tracked: #288
                 f"feature flag 'omnigent_agent_backend' is enabled but the "
                 f"{self._provider!r} provider is not usable: {exc} Install the "
                 "CLI, switch provider, or disable the flag to use the agentshim "
                 "backend."
             ) from exc
         if not hasattr(executor, _TOOL_EXECUTOR_ATTR):
-            raise OmnigentUnavailableError(
+            raise OmnigentUnavailableError(  # noqa: TRY003  # tracked: #288
                 f"{executor_cls.__name__} has no {_TOOL_EXECUTOR_ATTR!r} slot, so "
                 "VibeSys cannot give the agent its file and shell tools. The "
                 "installed omnigent has moved this seam away from what this "
@@ -538,7 +548,7 @@ class OmnigentAgentRunner:
         setattr(executor, _TOOL_EXECUTOR_ATTR, dispatch)
         return executor, schemas
 
-    def invoke(
+    def invoke(  # noqa: D102, PLR0913  # tracked: #288
         self,
         *,
         kind: str,
@@ -593,7 +603,7 @@ class OmnigentAgentRunner:
         log_json_and_print(parsed.model_dump_json(indent=2), self._run_log_file)
         return parsed
 
-    def invoke_text(
+    def invoke_text(  # noqa: D102, PLR0913  # tracked: #288
         self,
         *,
         kind: str,
@@ -634,7 +644,7 @@ class OmnigentAgentRunner:
             log_and_print(f"No response received from {label.lower()}.", self._run_log_file)
         return text
 
-    def _generate(
+    def _generate(  # noqa: PLR0913  # tracked: #288
         self,
         *,
         kind: str,
@@ -657,7 +667,7 @@ class OmnigentAgentRunner:
             # Omnigent owns MCP wiring through its own agent spec, which this
             # integration does not construct. Failing loudly beats silently
             # dropping tools the loop believes the agent can reach.
-            raise OmnigentUnavailableError(
+            raise OmnigentUnavailableError(  # noqa: TRY003  # tracked: #288
                 f"the Omnigent backend cannot inject MCP servers "
                 f"({[s.name for s in mcp_servers]}) for the {label.lower()} agent; "
                 "disable 'omnigent_agent_backend' to use the agentshim backend, "

--- a/src/vibesys/agents/progress.py
+++ b/src/vibesys/agents/progress.py
@@ -21,7 +21,7 @@ class RoundProgress:
     round_number: int
     total_rounds: int
 
-    def label(self) -> str:
+    def label(self) -> str:  # noqa: D102  # tracked: #288
         return f"Round {self.round_number}/{self.total_rounds}"
 
 
@@ -34,7 +34,7 @@ class CandidateProgress:
     candidate_number: int
     total_candidates: int
 
-    def label(self) -> str:
+    def label(self) -> str:  # noqa: D102  # tracked: #288
         return (
             f"Round {self.round_number}/{self.total_rounds} "
             f"Cand {self.candidate_number}/{self.total_candidates}"

--- a/src/vibesys/agents/stub_runner.py
+++ b/src/vibesys/agents/stub_runner.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
-from pathlib import Path
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import TypeVar
 
-from langchain_core.tools import BaseTool
+from langchain_core.tools import BaseTool  # noqa: TC002  # tracked: #288
 from pydantic import BaseModel
 
-from vibesys._agent_cli.base import MCPServerSpec
-from vibesys.agents.progress import AgentProgress
+from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #288
+from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -21,7 +21,7 @@ class StubAgentRunner:
 
     backend_name = "stub"
 
-    def invoke(
+    def invoke(  # noqa: D102, PLR0913  # tracked: #288
         self,
         *,
         kind: str,
@@ -35,7 +35,7 @@ class StubAgentRunner:
         **kwargs: object,
     ) -> T:
         del workspace, system_prompt, user_prompt, progress, kwargs
-        from vibesys.render.sink import output_sink
+        from vibesys.render.sink import output_sink  # noqa: PLC0415  # tracked: #288
 
         output_sink().agent_output(
             f"[stub-agent] {round_label}: starting {kind}\n",
@@ -51,7 +51,7 @@ class StubAgentRunner:
         )
         return response_cls.model_validate(response) if response is not None else fallback_factory()
 
-    def invoke_text(
+    def invoke_text(  # noqa: PLR0913  # tracked: #288
         self,
         *,
         kind: str,
@@ -78,7 +78,7 @@ class StubAgentRunner:
             reuse_session,
             session_key,
         )
-        from vibesys.render.sink import output_sink
+        from vibesys.render.sink import output_sink  # noqa: PLC0415  # tracked: #288
 
         output_sink().agent_output(
             f"[stub-agent] investigating: {user_prompt}\n",

--- a/src/vibesys/agents/todos.py
+++ b/src/vibesys/agents/todos.py
@@ -87,7 +87,7 @@ def _extract(
 def _from_todos_arg(args: Mapping[str, Any]) -> list[TodoItemData] | None:
     """Claude Code ``TodoWrite`` / opencode ``todowrite`` / Gemini and
     deepagents ``write_todos``: ``{"todos": [{"content", "status"}, …]}``.
-    """
+    """  # noqa: D205  # tracked: #288
     return _extract(args, "todos", ("content", "description"))
 
 
@@ -99,7 +99,7 @@ def _from_plan_arg(args: Mapping[str, Any]) -> list[TodoItemData] | None:
 def _from_items_arg(args: Mapping[str, Any]) -> list[TodoItemData] | None:
     """Codex ``exec --json`` ``todo_list`` stream item:
     ``{"items": [{"text", "completed"|"status"}, …]}``.
-    """
+    """  # noqa: D205  # tracked: #288
     return _extract(args, "items", ("text",))
 
 

--- a/src/vibesys/agents/todos.py
+++ b/src/vibesys/agents/todos.py
@@ -86,7 +86,8 @@ def _extract(
 
 def _from_todos_arg(args: Mapping[str, Any]) -> list[TodoItemData] | None:
     """Claude Code ``TodoWrite`` / opencode ``todowrite`` / Gemini and
-    deepagents ``write_todos``: ``{"todos": [{"content", "status"}, …]}``."""
+    deepagents ``write_todos``: ``{"todos": [{"content", "status"}, …]}``.
+    """
     return _extract(args, "todos", ("content", "description"))
 
 
@@ -97,7 +98,8 @@ def _from_plan_arg(args: Mapping[str, Any]) -> list[TodoItemData] | None:
 
 def _from_items_arg(args: Mapping[str, Any]) -> list[TodoItemData] | None:
     """Codex ``exec --json`` ``todo_list`` stream item:
-    ``{"items": [{"text", "completed"|"status"}, …]}``."""
+    ``{"items": [{"text", "completed"|"status"}, …]}``.
+    """
     return _extract(args, "items", ("text",))
 
 

--- a/src/vibesys/backends/__init__.py
+++ b/src/vibesys/backends/__init__.py
@@ -17,8 +17,8 @@ Add a new backend by:
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from pathlib import Path
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 from vibesys.backends.base import (
     ComputeBackendImpl,
@@ -35,7 +35,7 @@ from vibesys.constants import ComputeBackend
 _REGISTRY: dict[ComputeBackend, Callable[..., ComputeBackendImpl]] = {}
 
 
-def register(backend: ComputeBackend, factory: Callable[..., ComputeBackendImpl]) -> None:
+def register(backend: ComputeBackend, factory: Callable[..., ComputeBackendImpl]) -> None:  # noqa: D103  # tracked: #288
     _REGISTRY[backend] = factory
 
 
@@ -48,7 +48,7 @@ def get(
 ) -> ComputeBackendImpl:
     """Construct the ComputeBackendImpl for *backend*."""
     if backend not in _REGISTRY:
-        raise ValueError(f"No backend impl registered for {backend!r}")
+        raise ValueError(f"No backend impl registered for {backend!r}")  # noqa: TRY003  # tracked: #288
     return _REGISTRY[backend](
         log_dir=log_dir,
         log=log,
@@ -59,10 +59,10 @@ def get(
 # Default registration.  Imported lazily to avoid pulling deepagents/Modal
 # into modules that just want the protocol types.
 def _register_defaults() -> None:
-    from vibesys.backends.cuda import CudaBackend
-    from vibesys.backends.local import cpu_backend, metal_backend
-    from vibesys.backends.rocm import RocmBackend
-    from vibesys.backends.trainium import TrainiumBackend
+    from vibesys.backends.cuda import CudaBackend  # noqa: PLC0415  # tracked: #288
+    from vibesys.backends.local import cpu_backend, metal_backend  # noqa: PLC0415  # tracked: #288
+    from vibesys.backends.rocm import RocmBackend  # noqa: PLC0415  # tracked: #288
+    from vibesys.backends.trainium import TrainiumBackend  # noqa: PLC0415  # tracked: #288
 
     register(ComputeBackend.CUDA, CudaBackend)
     register(ComputeBackend.METAL, metal_backend)

--- a/src/vibesys/backends/base.py
+++ b/src/vibesys/backends/base.py
@@ -17,14 +17,14 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from enum import StrEnum
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Protocol, runtime_checkable
 
-from deepagents.backends.protocol import SandboxBackendProtocol
+from deepagents.backends.protocol import SandboxBackendProtocol  # noqa: TC002  # tracked: #288
 from deepagents.backends.sandbox import BaseSandbox
 
-from vibesys.constants import ComputeBackend
-from vibesys.profilers import ProfilerKind
+from vibesys.constants import ComputeBackend  # noqa: TC001  # tracked: #288
+from vibesys.profilers import ProfilerKind  # noqa: TC001  # tracked: #288
 
 
 class SandboxKind(StrEnum):
@@ -45,8 +45,8 @@ class Device(Protocol):
 class ContentionMonitor(Protocol):
     """Background thread that reports platform contention (e.g. shared-GPU use)."""
 
-    def start(self) -> None: ...
-    def stop(self) -> None: ...
+    def start(self) -> None: ...  # noqa: D102  # tracked: #288
+    def stop(self) -> None: ...  # noqa: D102  # tracked: #288
 
 
 SetupFn = Callable[[BaseSandbox], None]
@@ -65,7 +65,7 @@ class ComputeBackendImpl(Protocol):
     name: ComputeBackend
     profiler_kind: ProfilerKind  # picks profiler support, MCP, and prompt template
 
-    def make_sandbox(
+    def make_sandbox(  # noqa: PLR0913  # tracked: #288
         self,
         kind: SandboxKind,
         *,
@@ -90,7 +90,7 @@ class ComputeBackendImpl(Protocol):
         """
         ...
 
-    def make_monitor(self, log_dir: Path) -> ContentionMonitor | None: ...
+    def make_monitor(self, log_dir: Path) -> ContentionMonitor | None: ...  # noqa: D102  # tracked: #288
 
     def reselect_device(self) -> None:
         """Re-pick the optimal device for this backend (e.g. migrate to a
@@ -98,7 +98,7 @@ class ComputeBackendImpl(Protocol):
 
         Each restarted sandbox re-runs its ``setup_fns`` automatically as
         part of ``start()``.  No-op for backends without rebalancing.
-        """
+        """  # noqa: D205  # tracked: #288
         ...
 
 
@@ -110,7 +110,7 @@ class ModalOptions:
     container so future backends can ignore it without typing gymnastics.
     """
 
-    def __init__(
+    def __init__(  # noqa: D107, PLR0913  # tracked: #288
         self,
         *,
         gpu: str | None = "H100",

--- a/src/vibesys/backends/cuda/__init__.py
+++ b/src/vibesys/backends/cuda/__init__.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from datetime import datetime
 from pathlib import Path
 
 from deepagents.backends import LocalShellBackend
-from deepagents.backends.protocol import SandboxBackendProtocol
+from deepagents.backends.protocol import SandboxBackendProtocol  # noqa: TC002  # tracked: #288
 
 from vibesys.backends.base import (
     ContentionMonitor,
@@ -43,7 +43,7 @@ class CudaBackend:
     name = ComputeBackend.CUDA
     profiler_kind = ProfilerKind.NSYS
 
-    def __init__(
+    def __init__(  # noqa: D107  # tracked: #288
         self,
         log_dir: Path,
         *,
@@ -64,7 +64,7 @@ class CudaBackend:
 
     # -- ComputeBackendImpl protocol ---------------------------------------------
 
-    def make_sandbox(
+    def make_sandbox(  # noqa: PLR0913  # tracked: #288
         self,
         kind: SandboxKind,
         *,
@@ -119,7 +119,7 @@ class CudaBackend:
             )
         elif kind is SandboxKind.MODAL:
             if modal_options is None:
-                raise ValueError("modal_options is required for SandboxKind.MODAL")
+                raise ValueError("modal_options is required for SandboxKind.MODAL")  # noqa: TRY003  # tracked: #288
             sandbox = ModalSandbox(
                 host_workspace=host_workspace,
                 image=self.image,
@@ -138,12 +138,12 @@ class CudaBackend:
                 app_name=modal_options.app_name,
             )
         else:
-            raise ValueError(f"Unknown sandbox kind: {kind!r}")
+            raise ValueError(f"Unknown sandbox kind: {kind!r}")  # noqa: TRY003  # tracked: #288
 
         self._sandboxes.append((kind, sandbox))
         return sandbox
 
-    def make_monitor(self, log_dir: Path) -> ContentionMonitor | None:
+    def make_monitor(self, log_dir: Path) -> ContentionMonitor | None:  # noqa: D102  # tracked: #288
         if self.selected_device is None:
             return None
         self._monitor = GpuContentionMonitor(
@@ -181,13 +181,13 @@ class CudaBackend:
         for kind, sb in self._sandboxes:
             if kind is SandboxKind.DOCKER:
                 sb.stop()  # pyright: ignore[reportAttributeAccessIssue]
-                sb._gpus = self._docker_gpu_spec()  # pyright: ignore[reportAttributeAccessIssue]
+                sb._gpus = self._docker_gpu_spec()  # pyright: ignore[reportAttributeAccessIssue]  # noqa: SLF001  # tracked: #288
                 sb.start()  # re-runs setup_fns  # pyright: ignore[reportAttributeAccessIssue]
             elif kind is SandboxKind.LOCAL:
                 env = getattr(sb, "_env", None)
                 if env is None:
                     env = {}
-                    sb._env = env  # pyright: ignore[reportAttributeAccessIssue]
+                    sb._env = env  # pyright: ignore[reportAttributeAccessIssue]  # noqa: SLF001  # tracked: #288
                 env["CUDA_VISIBLE_DEVICES"] = str(new_gpu.index)
             # SandboxKind.MODAL: remote GPU, nothing to restart.
 
@@ -262,8 +262,8 @@ class CudaBackend:
         Empty dict if nvidia-smi is missing or the driver version is unknown.
         """
         try:
-            result = subprocess.run(
-                ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
+            result = subprocess.run(  # noqa: PLW1510  # tracked: #288
+                ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],  # noqa: S607  # tracked: #288
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -296,7 +296,7 @@ class CudaBackend:
         data = {
             "selected_gpu": _gpu_to_dict(gpu),
             "all_gpus_at_selection": [_gpu_to_dict(g) for g in all_gpus],
-            "selected_at": datetime.now().isoformat(),
+            "selected_at": datetime.now().isoformat(),  # noqa: DTZ005  # tracked: #288
             "contention_detected": False,
             "contention_events": 0,
         }

--- a/src/vibesys/backends/cuda/gpu_monitor.py
+++ b/src/vibesys/backends/cuda/gpu_monitor.py
@@ -19,7 +19,7 @@ import subprocess
 import threading
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any
 
 # ---------------------------------------------------------------------------
@@ -39,7 +39,7 @@ class GpuInfo:
     utilization_pct: int
 
     @property
-    def memory_free_mib(self) -> int:
+    def memory_free_mib(self) -> int:  # noqa: D102  # tracked: #288
         return self.memory_total_mib - self.memory_used_mib
 
 
@@ -63,8 +63,8 @@ class ContentionStatus:
 def query_gpu_info() -> list[GpuInfo]:
     """Query ``nvidia-smi`` for per-GPU memory and utilisation."""
     try:
-        result = subprocess.run(
-            [
+        result = subprocess.run(  # noqa: PLW1510  # tracked: #288
+            [  # noqa: S607  # tracked: #288
                 "nvidia-smi",
                 "--query-gpu=index,uuid,name,memory.used,memory.total,utilization.gpu",
                 "--format=csv,noheader,nounits",
@@ -80,7 +80,7 @@ def query_gpu_info() -> list[GpuInfo]:
     gpus: list[GpuInfo] = []
     for line in result.stdout.strip().splitlines():
         parts = [p.strip() for p in line.split(",")]
-        if len(parts) < 6:
+        if len(parts) < 6:  # noqa: PLR2004  # tracked: #288
             continue
         try:
             gpus.append(
@@ -114,8 +114,8 @@ def pick_gpu(gpus: list[GpuInfo] | None = None) -> GpuInfo | None:
 
 def _query_gpu_procs() -> str:
     """Run ``nvidia-smi`` and return CSV of GPU compute processes."""
-    result = subprocess.run(
-        [
+    result = subprocess.run(  # noqa: PLW1510  # tracked: #288
+        [  # noqa: S607  # tracked: #288
             "nvidia-smi",
             "--query-compute-apps=pid,process_name,used_gpu_memory,gpu_uuid",
             "--format=csv,noheader,nounits",
@@ -136,7 +136,7 @@ def _parse_proc_output(raw: str) -> list[dict[str, Any]]:
         if not line.strip() or ("pid" in line.lower() and "process" in line.lower()):
             continue
         parts = [p.strip() for p in line.split(",")]
-        if len(parts) < 4:
+        if len(parts) < 4:  # noqa: PLR2004  # tracked: #288
             continue
         try:
             pid = int(parts[0])
@@ -180,7 +180,7 @@ class GpuContentionMonitor:
         Seconds between checks (default 30).
     """
 
-    def __init__(
+    def __init__(  # noqa: D107  # tracked: #288
         self,
         log_dir: Path,
         gpu_uuid: str,
@@ -228,7 +228,7 @@ class GpuContentionMonitor:
         try:
             raw = _query_gpu_procs()
             procs = _parse_proc_output(raw)
-        except Exception:
+        except Exception:  # noqa: BLE001  # tracked: #288
             return set()
         return {p["pid"] for p in procs if p["gpu_uuid"] == self._gpu_uuid}
 
@@ -268,7 +268,7 @@ class GpuContentionMonitor:
                             "memory_total_mib": gpu_info.memory_total_mib,
                             "utilization_pct": gpu_info.utilization_pct,
                         }
-                    with open(log_path, "a") as f:
+                    with open(log_path, "a") as f:  # noqa: PTH123  # tracked: #288
                         f.write(
                             json.dumps(
                                 {
@@ -281,6 +281,6 @@ class GpuContentionMonitor:
                             )
                             + "\n"
                         )
-            except Exception:
+            except Exception:  # noqa: BLE001, S110  # tracked: #288
                 pass
             self._stop_event.wait(self._interval)

--- a/src/vibesys/backends/cuda/gpu_monitor.py
+++ b/src/vibesys/backends/cuda/gpu_monitor.py
@@ -133,7 +133,7 @@ def _parse_proc_output(raw: str) -> list[dict[str, Any]]:
     """Parse nvidia-smi compute-apps CSV into process dicts."""
     procs: list[dict[str, Any]] = []
     for line in raw.strip().splitlines():
-        if not line.strip() or "pid" in line.lower() and "process" in line.lower():
+        if not line.strip() or ("pid" in line.lower() and "process" in line.lower()):
             continue
         parts = [p.strip() for p in line.split(",")]
         if len(parts) < 4:

--- a/src/vibesys/backends/local.py
+++ b/src/vibesys/backends/local.py
@@ -15,11 +15,11 @@ run inside Docker because it needs no accelerator passthrough. Per-platform
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from pathlib import Path
 
 from deepagents.backends import LocalShellBackend
-from deepagents.backends.protocol import SandboxBackendProtocol
+from deepagents.backends.protocol import SandboxBackendProtocol  # noqa: TC002  # tracked: #288
 
 from vibesys.backends.base import (
     ContentionMonitor,
@@ -37,7 +37,7 @@ _DEFAULT_CPU_IMAGE = "python:3.12-bookworm"
 class LocalBackend:
     """No-device backend (Metal / CPU) — hardware hooks are no-ops."""
 
-    def __init__(
+    def __init__(  # noqa: D107, PLR0913  # tracked: #288
         self,
         name: ComputeBackend,
         log_dir: Path,
@@ -61,7 +61,7 @@ class LocalBackend:
 
     # -- ComputeBackendImpl protocol -----------------------------------------
 
-    def make_sandbox(
+    def make_sandbox(  # noqa: D102, PLR0913  # tracked: #288
         self,
         kind: SandboxKind,
         *,
@@ -72,7 +72,7 @@ class LocalBackend:
         extra_env: dict[str, str] | None = None,
         extra_init_commands: list[str] | None = None,
         setup_fns: list[SetupFn] | None = None,
-        modal_options: ModalOptions | None = None,
+        modal_options: ModalOptions | None = None,  # noqa: ARG002  # tracked: #288
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
         del attach_accelerator
@@ -91,7 +91,7 @@ class LocalBackend:
             )
         if kind is SandboxKind.DOCKER and self._supports_docker:
             if self.image is None:
-                raise ValueError(f"{self.name.value} backend requires a Docker image")
+                raise ValueError(f"{self.name.value} backend requires a Docker image")  # noqa: TRY003  # tracked: #288
             return DockerSandbox(
                 host_workspace=host_workspace,
                 image=self.image,
@@ -104,16 +104,16 @@ class LocalBackend:
                 setup_fns=setup_fns,
             )
         if kind in (SandboxKind.DOCKER, SandboxKind.MODAL):
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"{self.name.value} backend only supports local execution; "
                 f"SandboxKind.{kind.name} is unavailable ({self._unavailable_reason})."
             )
-        raise ValueError(f"Unknown sandbox kind: {kind!r}")
+        raise ValueError(f"Unknown sandbox kind: {kind!r}")  # noqa: TRY003  # tracked: #288
 
-    def make_monitor(self, log_dir: Path) -> ContentionMonitor | None:
+    def make_monitor(self, log_dir: Path) -> ContentionMonitor | None:  # noqa: ARG002, D102  # tracked: #288
         return None
 
-    def reselect_device(self) -> None:
+    def reselect_device(self) -> None:  # noqa: D102  # tracked: #288
         return None
 
 

--- a/src/vibesys/backends/rocm/__init__.py
+++ b/src/vibesys/backends/rocm/__init__.py
@@ -32,11 +32,11 @@ from __future__ import annotations
 import glob
 import os
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from pathlib import Path
 
 from deepagents.backends import LocalShellBackend
-from deepagents.backends.protocol import SandboxBackendProtocol
+from deepagents.backends.protocol import SandboxBackendProtocol  # noqa: TC002  # tracked: #288
 
 from vibesys.backends.base import (
     ContentionMonitor,
@@ -82,17 +82,17 @@ def _discover_rocm_devices() -> list[str]:
     host has no AMD GPU, in which case the container starts without an
     accelerator (parity with the Trainium backend's behaviour).
     """
-    if not os.path.exists(_KFD_DEVICE):
+    if not os.path.exists(_KFD_DEVICE):  # noqa: PTH110  # tracked: #288
         return []
-    render_nodes = sorted(glob.glob("/dev/dri/render*"))
+    render_nodes = sorted(glob.glob("/dev/dri/render*"))  # noqa: PTH207  # tracked: #288
     return [_KFD_DEVICE, *render_nodes]
 
 
 def _query_rocm_gpu_count() -> int | None:
     """Return the number of GPUs ``rocm-smi`` reports, or None if unavailable."""
     try:
-        result = subprocess.run(
-            ["rocm-smi", "--showid", "--csv"],
+        result = subprocess.run(  # noqa: PLW1510  # tracked: #288
+            ["rocm-smi", "--showid", "--csv"],  # noqa: S607  # tracked: #288
             capture_output=True,
             text=True,
             timeout=10,
@@ -115,7 +115,7 @@ class RocmBackend:
     name = ComputeBackend.ROCM
     profiler_kind = ProfilerKind.TORCH
 
-    def __init__(
+    def __init__(  # noqa: D107  # tracked: #288
         self,
         log_dir: Path,
         *,
@@ -145,7 +145,7 @@ class RocmBackend:
 
     # -- ComputeBackendImpl protocol ---------------------------------------
 
-    def make_sandbox(
+    def make_sandbox(  # noqa: D102, PLR0913  # tracked: #288
         self,
         kind: SandboxKind,
         *,
@@ -156,7 +156,7 @@ class RocmBackend:
         extra_env: dict[str, str] | None = None,
         extra_init_commands: list[str] | None = None,
         setup_fns: list[SetupFn] | None = None,
-        modal_options: ModalOptions | None = None,
+        modal_options: ModalOptions | None = None,  # noqa: ARG002  # tracked: #288
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
         bind_mounts = list(bind_mounts or [])
@@ -166,7 +166,7 @@ class RocmBackend:
         setup_fns = setup_fns or []
 
         if kind is SandboxKind.MODAL:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 "rocm backend does not support Modal — Modal offers no AMD "
                 "GPUs. Use --docker (Instinct GPUs via /dev/kfd) or local "
                 "execution."
@@ -198,14 +198,14 @@ class RocmBackend:
                 setup_fns=setup_fns,
             )
 
-        raise ValueError(f"Unknown sandbox kind: {kind!r}")
+        raise ValueError(f"Unknown sandbox kind: {kind!r}")  # noqa: TRY003  # tracked: #288
 
-    def make_monitor(self, log_dir: Path) -> ContentionMonitor | None:
+    def make_monitor(self, log_dir: Path) -> ContentionMonitor | None:  # noqa: ARG002, D102  # tracked: #288
         # rocm-smi can report utilization, but shared-device contention
         # handling isn't wired up yet; skip rather than fake it.
         return None
 
-    def reselect_device(self) -> None:
+    def reselect_device(self) -> None:  # noqa: D102  # tracked: #288
         return None
 
     # -- internal ----------------------------------------------------------

--- a/src/vibesys/backends/trainium/__init__.py
+++ b/src/vibesys/backends/trainium/__init__.py
@@ -23,11 +23,11 @@ is a no-op (parity with :class:`LocalBackend`).
 from __future__ import annotations
 
 import glob
-from collections.abc import Callable
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from pathlib import Path
 
 from deepagents.backends import LocalShellBackend
-from deepagents.backends.protocol import SandboxBackendProtocol
+from deepagents.backends.protocol import SandboxBackendProtocol  # noqa: TC002  # tracked: #288
 
 from vibesys.backends.base import (
     ContentionMonitor,
@@ -69,7 +69,7 @@ def _discover_neuron_devices() -> list[str]:
     Matches the numbered device nodes (``/dev/neuron0`` …) and skips the
     control node ``/dev/neuron_*`` if present.
     """
-    devs = [d for d in glob.glob("/dev/neuron*") if d[len("/dev/neuron") :].isdigit()]
+    devs = [d for d in glob.glob("/dev/neuron*") if d[len("/dev/neuron") :].isdigit()]  # noqa: PTH207  # tracked: #288
     return sorted(devs)
 
 
@@ -79,7 +79,7 @@ class TrainiumBackend:
     name = ComputeBackend.TRAINIUM
     profiler_kind = ProfilerKind.NEURON
 
-    def __init__(
+    def __init__(  # noqa: D107  # tracked: #288
         self,
         log_dir: Path,
         *,
@@ -105,7 +105,7 @@ class TrainiumBackend:
 
     # -- ComputeBackendImpl protocol ---------------------------------------
 
-    def make_sandbox(
+    def make_sandbox(  # noqa: D102, PLR0913  # tracked: #288
         self,
         kind: SandboxKind,
         *,
@@ -116,7 +116,7 @@ class TrainiumBackend:
         extra_env: dict[str, str] | None = None,
         extra_init_commands: list[str] | None = None,
         setup_fns: list[SetupFn] | None = None,
-        modal_options: ModalOptions | None = None,
+        modal_options: ModalOptions | None = None,  # noqa: ARG002  # tracked: #288
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
         bind_mounts = list(bind_mounts or [])
@@ -126,7 +126,7 @@ class TrainiumBackend:
         setup_fns = setup_fns or []
 
         if kind is SandboxKind.MODAL:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 "trainium backend does not support Modal — Modal offers no "
                 "Trainium hardware. Use --docker (NeuronCores via "
                 "/dev/neuron*) or local execution."
@@ -182,14 +182,14 @@ class TrainiumBackend:
                 setup_fns=setup_fns,
             )
 
-        raise ValueError(f"Unknown sandbox kind: {kind!r}")
+        raise ValueError(f"Unknown sandbox kind: {kind!r}")  # noqa: TRY003  # tracked: #288
 
-    def make_monitor(self, log_dir: Path) -> ContentionMonitor | None:
+    def make_monitor(self, log_dir: Path) -> ContentionMonitor | None:  # noqa: ARG002, D102  # tracked: #288
         # neuron-monitor exists, but shared-device contention handling
         # isn't wired up yet; skip rather than fake it.
         return None
 
-    def reselect_device(self) -> None:
+    def reselect_device(self) -> None:  # noqa: D102  # tracked: #288
         return None
 
     # -- internal ----------------------------------------------------------

--- a/src/vibesys/config.py
+++ b/src/vibesys/config.py
@@ -14,7 +14,7 @@ allowlist loader suffered from.
 
 import os
 import tomllib
-from collections.abc import Mapping
+from collections.abc import Mapping  # noqa: TC003  # tracked: #288
 from pathlib import Path
 from typing import Any, Literal, Self
 
@@ -36,7 +36,7 @@ class _Strict(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class ModelCfg(_Strict):
+class ModelCfg(_Strict):  # noqa: D101  # tracked: #288
     name: str = Field(description="Model identifier, e.g. 'claude-sonnet-4-6'. Required.")
     provider: Provider | None = Field(
         default=None,
@@ -48,7 +48,7 @@ class ModelCfg(_Strict):
     )
 
 
-class ThinkingCfg(_Strict):
+class ThinkingCfg(_Strict):  # noqa: D101  # tracked: #288
     level: str | None = Field(
         default=None,
         description=(
@@ -68,11 +68,11 @@ class ThinkingCfg(_Strict):
     @model_validator(mode="after")
     def _one_thinking_control(self) -> Self:
         if self.level is not None and self.budget is not None:
-            raise ValueError("thinking.level and thinking.budget are mutually exclusive")
+            raise ValueError("thinking.level and thinking.budget are mutually exclusive")  # noqa: TRY003  # tracked: #288
         return self
 
 
-class VertexCfg(_Strict):
+class VertexCfg(_Strict):  # noqa: D101  # tracked: #288
     # The attribute is ``json_path`` to avoid shadowing ``BaseModel.json``; the
     # TOML key stays ``json`` via the alias.
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
@@ -98,7 +98,7 @@ class VertexCfg(_Strict):
     )
 
 
-class OpenAICompatCfg(_Strict):
+class OpenAICompatCfg(_Strict):  # noqa: D101  # tracked: #288
     base_url: str | None = Field(
         default=None,
         description=(
@@ -121,7 +121,7 @@ class _CredEnvProviderCfg(_Strict):
     """
 
 
-class ProvidersCfg(_Strict):
+class ProvidersCfg(_Strict):  # noqa: D101  # tracked: #288
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     vertex_ai: VertexCfg | None = Field(
@@ -149,7 +149,7 @@ class ProvidersCfg(_Strict):
     )
 
 
-class BackendCfg(_Strict):
+class BackendCfg(_Strict):  # noqa: D101  # tracked: #288
     name: ComputeBackend = Field(
         default=DEFAULT_COMPUTE_BACKEND,
         description=(
@@ -175,7 +175,7 @@ class AgentRoleCfg(_Strict):
     )
 
 
-class AgentCfg(_Strict):
+class AgentCfg(_Strict):  # noqa: D101  # tracked: #288
     backend: str | None = Field(
         default=None,
         description=(
@@ -207,7 +207,7 @@ class AgentCfg(_Strict):
     )
 
 
-class RepositoryCfg(_Strict):
+class RepositoryCfg(_Strict):  # noqa: D101  # tracked: #288
     owner: str | None = Field(
         default=None,
         description=(
@@ -227,11 +227,11 @@ class RepositoryCfg(_Strict):
             return None
         owner = value.strip()
         if not REPOSITORY_COMPONENT.fullmatch(owner):
-            raise ValueError("repository owner must be one GitHub user or organization name")
+            raise ValueError("repository owner must be one GitHub user or organization name")  # noqa: TRY003  # tracked: #288
         return owner
 
 
-class TuiCfg(_Strict):
+class TuiCfg(_Strict):  # noqa: D101  # tracked: #288
     theme: TuiTheme = Field(
         default=DEFAULT_TUI_THEME,
         description=(
@@ -253,7 +253,7 @@ class LoadLevelCfg(_Strict):
     max_tokens: int = Field(gt=0, description="Max output tokens per request at this load level.")
 
 
-class PerfEvalCfg(_Strict):
+class PerfEvalCfg(_Strict):  # noqa: D101  # tracked: #288
     load_levels: list[LoadLevelCfg] | None = Field(
         default=None,
         description=(
@@ -263,7 +263,7 @@ class PerfEvalCfg(_Strict):
     )
 
 
-class Config(_Strict):
+class Config(_Strict):  # noqa: D101  # tracked: #288
     model_config = ConfigDict(extra="forbid", protected_namespaces=())
 
     model: ModelCfg = Field(description="[model] — model name and provider. Required.")
@@ -344,7 +344,7 @@ def load_config(path: Path) -> Config:
     """Load, validate, and env-override a TOML agent config file."""
     _load_dotenv_file()
     path = Path(path)
-    with open(path, "rb") as f:
+    with open(path, "rb") as f:  # noqa: PTH123  # tracked: #288
         raw = tomllib.load(f)
 
     config = Config.model_validate(raw)

--- a/src/vibesys/constants.py
+++ b/src/vibesys/constants.py
@@ -1,4 +1,4 @@
-from enum import StrEnum
+from enum import StrEnum  # noqa: D100  # tracked: #288
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -100,22 +100,22 @@ exchange, and investigate the refreshed trajectory evidence before making claims
 def setup_exp_dir(
     exp_name: str,
     project_root: Path = PROJECT_ROOT,
-    existing: bool = False,
+    existing: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
 ) -> Path:
     """Create or validate exp_env/<timestamp>-<exp_name>/ directory with git init."""
     if existing:
         exp_dir = project_root / "exp_env" / exp_name
     else:
-        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")  # noqa: DTZ005  # tracked: #288
         exp_dir = project_root / "exp_env" / f"{timestamp}-{uuid.uuid4().hex[:8]}-{exp_name}"
     if existing:
         if not exp_dir.is_dir():
-            raise FileNotFoundError(f"Experiment directory not found: {exp_dir}")
+            raise FileNotFoundError(f"Experiment directory not found: {exp_dir}")  # noqa: TRY003  # tracked: #288
         return exp_dir
     exp_dir.mkdir(parents=True, exist_ok=False)
     if not (exp_dir / ".git").is_dir():
         subprocess.run(
-            ["git", "init", "-b", "main"],
+            ["git", "init", "-b", "main"],  # noqa: S607  # tracked: #288
             cwd=exp_dir,
             capture_output=True,
             check=True,
@@ -128,9 +128,9 @@ def _coerce_dir(raw: str | Path | None, label: str) -> Path | None:
         return None
     p = Path(raw).expanduser().resolve()
     if not p.exists():
-        raise ValueError(f"{label} path does not exist: {raw}")
+        raise ValueError(f"{label} path does not exist: {raw}")  # noqa: TRY003  # tracked: #288
     if not p.is_dir():
-        raise ValueError(f"{label} path is not a directory: {raw}")
+        raise ValueError(f"{label} path is not a directory: {raw}")  # noqa: TRY003  # tracked: #288
     return p
 
 
@@ -224,14 +224,14 @@ def _coerce_skills_dirs(raw_dirs: list[str] | None) -> list[Path]:
             p = PROJECT_ROOT / p
         p = p.resolve()
         if not p.exists():
-            raise ValueError(f"--skills-dir path does not exist: {raw}")
+            raise ValueError(f"--skills-dir path does not exist: {raw}")  # noqa: TRY003  # tracked: #288
         if not p.is_dir():
-            raise ValueError(f"--skills-dir path is not a directory: {raw}")
+            raise ValueError(f"--skills-dir path is not a directory: {raw}")  # noqa: TRY003  # tracked: #288
         result.append(p)
     return result
 
 
-def create_run_context(
+def create_run_context(  # noqa: PLR0913  # tracked: #288
     config: Config,
     exp_name: str,
     input_path: str,
@@ -242,14 +242,14 @@ def create_run_context(
     evaluator_path: Path | None = None,
     hidden_evaluator_path: Path | None = None,
     objective: str | None = None,
-    existing: bool = False,
+    existing: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     trusted_input_baseline: str | None = None,
-    debug: bool = False,
+    debug: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     profiler_kind: ProfilerKind = ProfilerKind.AUTO,
     profiler_domain: DomainName = DomainName.LLM_SERVING,
     skills_dirs: list[str] | None = None,
     run_environment: RunEnvironmentSpec | None = None,
-    git_tracking: bool = False,
+    git_tracking: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     agent_backend: str | None = None,
     cli_provider: str | None = None,
     backend: ComputeBackend = DEFAULT_COMPUTE_BACKEND,
@@ -305,14 +305,14 @@ def _close_after_construction_failure(
     """Unwind partial construction without replacing its root-cause error."""
     try:
         teardown_stack.close()
-    except BaseException as cleanup_error:
+    except BaseException as cleanup_error:  # noqa: BLE001  # tracked: #288
         construction_error.add_note(
             "Additional error while cleaning up partial context construction: "
             f"{type(cleanup_error).__name__}: {cleanup_error}"
         )
 
 
-def _assemble_run_context(
+def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     *,
     teardown_stack: ExitStack,
     config: Config,
@@ -369,7 +369,7 @@ def _assemble_run_context(
 
     log_dir = exp_dir / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
-    from vibesys.server.registry import active_supervisor
+    from vibesys.server.registry import active_supervisor  # noqa: PLC0415  # tracked: #288
 
     supervisor = active_supervisor()
     if supervisor is not None:
@@ -487,7 +487,7 @@ def _assemble_run_context(
     ref_dir: Path | None = input_dir / "reference"
     if ref_dir.exists():
         if not ref_dir.is_dir():
-            raise ValueError(f"reference path is not a directory: {ref_dir}")
+            raise ValueError(f"reference path is not a directory: {ref_dir}")  # noqa: TRY003  # tracked: #288
         reference_py = sorted(ref_dir.glob("*.py"))
         ref_name = f"reference/{reference_py[0].name}" if len(reference_py) == 1 else "reference"
     else:
@@ -525,7 +525,7 @@ def _assemble_run_context(
     def _teardown_environment_hooks() -> None:
         try:
             hooks.teardown(environment_context)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             logger.lprint(f"[warn] environment hook teardown failed: {exc}")
 
     teardown_stack.callback(_teardown_environment_hooks)
@@ -677,7 +677,7 @@ def _assemble_run_context(
     )
 
 
-def create_candidate_context(
+def create_candidate_context(  # noqa: PLR0913  # tracked: #288
     parent: "_RunContext",
     *,
     config: Config,
@@ -722,7 +722,7 @@ def create_candidate_context(
         raise
 
 
-def _assemble_candidate_context(
+def _assemble_candidate_context(  # noqa: PLR0913  # tracked: #288
     *,
     teardown_stack: ExitStack,
     parent: "_RunContext",
@@ -897,7 +897,7 @@ class _RunContext:
     sandbox session.
     """
 
-    def __init__(
+    def __init__(  # noqa: ANN204, PLR0913  # tracked: #288
         self,
         *,
         backend: ComputeBackend,
@@ -908,14 +908,14 @@ class _RunContext:
         debug: bool,
         git_tracking: bool,
         backend_impl: ComputeBackendImpl,
-        model: Any,
+        model: Any,  # noqa: ANN401  # tracked: #288
         model_name: str,
         input_path: str | None,
         workspace_seed_path: Path | None,
         workspace_sources: tuple[WorkspaceSource, ...],
         evaluator_path: Path | None,
         hidden_evaluator_path: Path | None,
-        framework_judge_backend: Any,
+        framework_judge_backend: Any,  # noqa: ANN401  # tracked: #288
         effective_objective: str | None,
         accuracy_command: str,
         benchmark_command: str,
@@ -1047,7 +1047,7 @@ class _RunContext:
             return None
         return self._progress_stack[-1]
 
-    def invoke(
+    def invoke(  # noqa: PLR0913  # tracked: #288
         self,
         *,
         kind: str,
@@ -1057,7 +1057,7 @@ class _RunContext:
         fallback_factory: Callable[[], T],
         round_label: str = "",
         progress: AgentProgress | None = None,
-        **extra: Any,
+        **extra: Any,  # noqa: ANN401  # tracked: #288
     ) -> T:
         """Invoke an agent through ``self.agent_runner`` with workspace+env defaults.
 
@@ -1085,7 +1085,7 @@ class _RunContext:
                 progress=progress if progress is not None else self.current_progress(),
                 **extra,
             )
-            return result
+            return result  # noqa: RET504, TRY300  # tracked: #288
         except BaseException as exc:
             error = exc
             raise
@@ -1095,17 +1095,17 @@ class _RunContext:
 
     def chat(self, question: str) -> str:
         """Ask a read-only peer agent about the live experiment."""
-        from vibesys.server.inspector import RunInspector
+        from vibesys.server.inspector import RunInspector  # noqa: PLC0415  # tracked: #288
 
         with self._chat_lock:
             self._sync_chat_trajectory()
 
             def fallback() -> str:
-                assert self.supervisor is not None
+                assert self.supervisor is not None  # noqa: S101  # tracked: #288
                 diagnostic = RunInspector(self.supervisor).answer(question)
                 return f"Chat agent did not return an answer.\n\nFallback diagnostic:\n{diagnostic}"
 
-            assert self.supervisor is not None
+            assert self.supervisor is not None  # noqa: S101  # tracked: #288
             invocation_id = uuid.uuid4().hex
             system_prompt = (
                 _EXPERIMENT_CHAT_CONTINUATION_PROMPT
@@ -1129,7 +1129,7 @@ class _RunContext:
                         progress=self.current_progress(),
                     )
                 except Exception as exc:
-                    raise RuntimeError(f"Chat agent failed: {type(exc).__name__}: {exc}") from exc
+                    raise RuntimeError(f"Chat agent failed: {type(exc).__name__}: {exc}") from exc  # noqa: TRY003  # tracked: #288
             if not answer.strip():
                 answer = fallback()
             self._chat_history.append((question, answer))
@@ -1218,7 +1218,7 @@ class _RunContext:
         if self._experiment_repository is not None:
             try:
                 self._experiment_repository.sync()
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001  # tracked: #288
                 self.lprint(f"[warn] experiment repository checkpoint push failed: {exc}")
 
     def trusted_input_changes(self) -> list[str]:
@@ -1267,7 +1267,7 @@ class _RunContext:
         # Update the agent runner's log file handle so subsequent
         # invoke() calls write to the new step log.
         if hasattr(self, "agent_runner") and hasattr(self.agent_runner, "_run_log_file"):
-            self.agent_runner._run_log_file = self.logger.writer  # pyright: ignore[reportAttributeAccessIssue]
+            self.agent_runner._run_log_file = self.logger.writer  # pyright: ignore[reportAttributeAccessIssue]  # noqa: SLF001  # tracked: #288
 
     def reselect_gpu(self) -> None:
         """Delegate mid-run device rebalance — see :meth:`DeviceLease.reselect`."""

--- a/src/vibesys/domains/base.py
+++ b/src/vibesys/domains/base.py
@@ -4,18 +4,18 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
-from vibesys.domains.environment import EnvironmentHooks
+from vibesys.domains.environment import EnvironmentHooks  # noqa: TC001  # tracked: #288
 
 
-class DomainName(StrEnum):
+class DomainName(StrEnum):  # noqa: D101  # tracked: #288
     LLM_SERVING = "llm-serving"
     GENERIC = "generic"
     MICROSERVICES = "microservices"
 
 
-class DomainRole(StrEnum):
+class DomainRole(StrEnum):  # noqa: D101  # tracked: #288
     IMPLEMENTER = "implementer"
     JUDGE = "judge"
     SINGLE_AGENT = "single_agent"
@@ -30,7 +30,7 @@ DOMAIN_ROLES: tuple[DomainRole, ...] = tuple(DomainRole)
 
 
 @dataclass(frozen=True)
-class DomainDefinition:
+class DomainDefinition:  # noqa: D101  # tracked: #288
     name: DomainName
     prompt_dir: Path
     environment_hooks: EnvironmentHooks

--- a/src/vibesys/domains/environment.py
+++ b/src/vibesys/domains/environment.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Protocol
 
 
-class RunEnvironmentCapabilities(Protocol):
+class RunEnvironmentCapabilities(Protocol):  # noqa: D101  # tracked: #288
     isolated: bool
     materialize_local_model_weights: bool
 
 
 @dataclass(frozen=True)
-class EnvironmentContext:
+class EnvironmentContext:  # noqa: D101  # tracked: #288
     reference_path: Path
     workspace: Path
     run_environment: RunEnvironmentCapabilities
@@ -23,27 +23,27 @@ class EnvironmentContext:
 
 
 @dataclass(frozen=True)
-class EnvironmentBindMount:
+class EnvironmentBindMount:  # noqa: D101  # tracked: #288
     host_path: Path
     container_path: str
     read_only: bool = True
 
 
 @dataclass(frozen=True)
-class EnvironmentPatch:
+class EnvironmentPatch:  # noqa: D101  # tracked: #288
     copy_excludes: frozenset[str] = frozenset()
     bind_mounts: tuple[EnvironmentBindMount, ...] = ()
 
 
-class EnvironmentHooks(Protocol):
-    def prepare(self, ctx: EnvironmentContext) -> EnvironmentPatch: ...
+class EnvironmentHooks(Protocol):  # noqa: D101  # tracked: #288
+    def prepare(self, ctx: EnvironmentContext) -> EnvironmentPatch: ...  # noqa: D102  # tracked: #288
 
-    def teardown(self, ctx: EnvironmentContext) -> None: ...
+    def teardown(self, ctx: EnvironmentContext) -> None: ...  # noqa: D102  # tracked: #288
 
 
-class NoopEnvironmentHooks:
-    def prepare(self, ctx: EnvironmentContext) -> EnvironmentPatch:
+class NoopEnvironmentHooks:  # noqa: D101  # tracked: #288
+    def prepare(self, ctx: EnvironmentContext) -> EnvironmentPatch:  # noqa: ARG002, D102  # tracked: #288
         return EnvironmentPatch()
 
-    def teardown(self, ctx: EnvironmentContext) -> None:
+    def teardown(self, ctx: EnvironmentContext) -> None:  # noqa: ARG002, D102  # tracked: #288
         return None

--- a/src/vibesys/domains/llm_serving/hooks.py
+++ b/src/vibesys/domains/llm_serving/hooks.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
-from pathlib import Path
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 from vibesys.domains.environment import (
     EnvironmentBindMount,
@@ -30,7 +30,7 @@ def _ensure_model_weights(
 
     meta_path = ref_dir / "meta.json"
     if not meta_path.exists():
-        raise FileNotFoundError(
+        raise FileNotFoundError(  # noqa: TRY003  # tracked: #288
             f"Model weights not found at {model_path} and no meta.json to download from. "
             f"Either create a model/ directory/symlink or add a meta.json with model_id."
         )
@@ -38,22 +38,22 @@ def _ensure_model_weights(
     meta = json.loads(meta_path.read_text())
     model_id = meta.get("model_id")
     if not model_id:
-        raise ValueError(f"meta.json at {meta_path} missing required 'model_id' field")
+        raise ValueError(f"meta.json at {meta_path} missing required 'model_id' field")  # noqa: TRY003  # tracked: #288
 
     revision = meta.get("revision")
     cache_dir = project_root / ".hf_cache"
     log(f"[model] Weights not found at {model_path}. Downloading {model_id} to {cache_dir}...")
-    from huggingface_hub import snapshot_download
+    from huggingface_hub import snapshot_download  # noqa: PLC0415  # tracked: #288
 
     downloaded_path = snapshot_download(model_id, revision=revision, cache_dir=str(cache_dir))
     model_path.symlink_to(downloaded_path)
     log(f"[model] Created symlink {model_path} -> {downloaded_path}")
 
 
-class LLMServingEnvironmentHooks:
+class LLMServingEnvironmentHooks:  # noqa: D101  # tracked: #288
     _MODEL_ARTIFACT_NAMES = frozenset({"model", "draft_model"})
 
-    def prepare(self, ctx: EnvironmentContext) -> EnvironmentPatch:
+    def prepare(self, ctx: EnvironmentContext) -> EnvironmentPatch:  # noqa: D102  # tracked: #288
         ref_path = ctx.reference_path
         if not ref_path.is_dir():
             return EnvironmentPatch()
@@ -65,11 +65,11 @@ class LLMServingEnvironmentHooks:
 
         bind_mounts: list[EnvironmentBindMount] = []
         if model_path.is_dir() or model_path.is_symlink():
-            bind_mounts.append(EnvironmentBindMount(model_path, "/model", True))
+            bind_mounts.append(EnvironmentBindMount(model_path, "/model", True))  # noqa: FBT003  # tracked: #288
 
         draft_model_path = ref_path / "draft_model"
         if draft_model_path.is_dir() or draft_model_path.is_symlink():
-            bind_mounts.append(EnvironmentBindMount(draft_model_path, "/draft_model", True))
+            bind_mounts.append(EnvironmentBindMount(draft_model_path, "/draft_model", True))  # noqa: FBT003  # tracked: #288
 
         return EnvironmentPatch(
             copy_excludes=self._MODEL_ARTIFACT_NAMES
@@ -78,5 +78,5 @@ class LLMServingEnvironmentHooks:
             bind_mounts=tuple(bind_mounts),
         )
 
-    def teardown(self, ctx: EnvironmentContext) -> None:
+    def teardown(self, ctx: EnvironmentContext) -> None:  # noqa: ARG002, D102  # tracked: #288
         return None

--- a/src/vibesys/domains/registry.py
+++ b/src/vibesys/domains/registry.py
@@ -20,11 +20,11 @@ def registered_domains() -> list[str]:
 def resolve_domain(name: DomainName) -> DomainDefinition:
     """Resolve a registered domain enum to its definition."""
     if not isinstance(name, DomainName):  # pyright: ignore[reportUnnecessaryIsInstance]
-        raise TypeError(f"domain must be a DomainName, got {type(name).__name__}.")
+        raise TypeError(f"domain must be a DomainName, got {type(name).__name__}.")  # noqa: TRY003  # tracked: #288
 
     domain = DOMAINS[name]
     if not domain.prompt_dir.is_dir():
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003  # tracked: #288
             f"Registered domain {name.value!r} has no prompt directory: {domain.prompt_dir}"
         )
     return domain

--- a/src/vibesys/domains/rendering.py
+++ b/src/vibesys/domains/rendering.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 from vibesys.domains.base import DOMAIN_ROLES, DomainDefinition, DomainRole
 from vibesys.prompts import render_string
@@ -12,7 +12,7 @@ def _coerce_role(role: DomainRole | str) -> DomainRole:
     try:
         return role if isinstance(role, DomainRole) else DomainRole(role)
     except ValueError as exc:
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003  # tracked: #288
             f"Unknown domain role {role!r}. Choose from: "
             f"{', '.join(domain_role.value for domain_role in DOMAIN_ROLES)}."
         ) from exc

--- a/src/vibesys/errors.py
+++ b/src/vibesys/errors.py
@@ -19,6 +19,6 @@ class ConfigurationDiagnostic:
 class ConfigurationError(Exception):
     """Raised when user input cannot be resolved into a runnable session."""
 
-    def __init__(self, diagnostic: ConfigurationDiagnostic):
+    def __init__(self, diagnostic: ConfigurationDiagnostic):  # noqa: ANN204, D107  # tracked: #288
         super().__init__(diagnostic.message)
         self.diagnostic = diagnostic

--- a/src/vibesys/features.py
+++ b/src/vibesys/features.py
@@ -12,7 +12,7 @@ from enum import StrEnum
 from vs_feature_flags import FeatureDefinition, FeatureRegistry
 
 
-class FeatureFlag(StrEnum):
+class FeatureFlag(StrEnum):  # noqa: D101  # tracked: #288
     EXAMPLE_FEATURE = "example_feature"
     OMNIGENT_AGENT_BACKEND = "omnigent_agent_backend"
 
@@ -37,7 +37,7 @@ FEATURES = FeatureRegistry(
 )
 
 
-def is_feature_enabled(
+def is_feature_enabled(  # noqa: D103  # tracked: #288
     flag: FeatureFlag,
     config: object | None = None,
 ) -> bool:
@@ -55,6 +55,6 @@ def _feature_flag_overrides(config: object | None) -> Mapping[FeatureFlag, bool]
     if raw_overrides is None:
         raw_overrides = {}
     if not isinstance(raw_overrides, Mapping):
-        raise ValueError("config.feature_flags must be a mapping")
+        raise ValueError("config.feature_flags must be a mapping")  # noqa: TRY003, TRY004  # tracked: #288
 
     return raw_overrides

--- a/src/vibesys/input_manifest.py
+++ b/src/vibesys/input_manifest.py
@@ -28,12 +28,12 @@ class InputCommand(BaseModel):
     @classmethod
     def _non_empty_command(cls, value: tuple[str, ...]) -> tuple[str, ...]:
         if not value:
-            raise ValueError("command must contain at least one argv element")
+            raise ValueError("command must contain at least one argv element")  # noqa: TRY003  # tracked: #288
         if any(not part for part in value):
-            raise ValueError("command elements must be non-empty strings")
+            raise ValueError("command elements must be non-empty strings")  # noqa: TRY003  # tracked: #288
         return value
 
-    def display(self) -> str:
+    def display(self) -> str:  # noqa: D102  # tracked: #288
         return " ".join(shlex.quote(part) for part in self.command)
 
 
@@ -51,9 +51,9 @@ class WorkspaceInput(BaseModel):
         if value is None:
             return None
         if not value.strip():
-            raise ValueError("seed must be a non-empty path")
+            raise ValueError("seed must be a non-empty path")  # noqa: TRY003  # tracked: #288
         if Path(value).is_absolute():
-            raise ValueError("seed must be relative to the input bundle")
+            raise ValueError("seed must be relative to the input bundle")  # noqa: TRY003  # tracked: #288
         return value
 
 
@@ -72,40 +72,40 @@ class WorkspaceSource(BaseModel):
     @classmethod
     def _valid_name(cls, value: str) -> str:
         if not value:
-            raise ValueError("name must be non-empty")
+            raise ValueError("name must be non-empty")  # noqa: TRY003  # tracked: #288
         if any(character.isspace() for character in value):
-            raise ValueError("name must not contain whitespace")
+            raise ValueError("name must not contain whitespace")  # noqa: TRY003  # tracked: #288
         return value
 
     @field_validator("repo")
     @classmethod
     def _valid_repo(cls, value: str) -> str:
         if not value.strip():
-            raise ValueError("repo must be non-empty")
+            raise ValueError("repo must be non-empty")  # noqa: TRY003  # tracked: #288
         parsed = urlparse(value)
         if parsed.scheme and parsed.scheme not in {"file", "http", "https", "ssh", "git"}:
-            raise ValueError(f"unsupported repo URL scheme: {parsed.scheme}")
+            raise ValueError(f"unsupported repo URL scheme: {parsed.scheme}")  # noqa: TRY003  # tracked: #288
         return value
 
     @field_validator("commit")
     @classmethod
     def _valid_commit(cls, value: str) -> str:
         if not value:
-            raise ValueError("commit must be non-empty")
-        if not (7 <= len(value) <= 64) or any(c not in "0123456789abcdefABCDEF" for c in value):
-            raise ValueError("commit must be a 7-64 character hexadecimal hash")
+            raise ValueError("commit must be non-empty")  # noqa: TRY003  # tracked: #288
+        if not (7 <= len(value) <= 64) or any(c not in "0123456789abcdefABCDEF" for c in value):  # noqa: PLR2004  # tracked: #288
+            raise ValueError("commit must be a 7-64 character hexadecimal hash")  # noqa: TRY003  # tracked: #288
         return value.lower()
 
     @field_validator("dest")
     @classmethod
     def _relative_dest(cls, value: str) -> str:
         if not value.strip():
-            raise ValueError("dest must be a non-empty path")
+            raise ValueError("dest must be a non-empty path")  # noqa: TRY003  # tracked: #288
         path = Path(value)
         if path.is_absolute():
-            raise ValueError("dest must be relative to the workspace")
+            raise ValueError("dest must be relative to the workspace")  # noqa: TRY003  # tracked: #288
         if any(part in {"", ".", ".."} for part in path.parts):
-            raise ValueError("dest must not contain empty, current, or parent path components")
+            raise ValueError("dest must not contain empty, current, or parent path components")  # noqa: TRY003  # tracked: #288
         return value
 
 
@@ -120,9 +120,9 @@ class EvaluatorInput(BaseModel):
     @classmethod
     def _relative_source(cls, value: str) -> str:
         if not value.strip():
-            raise ValueError("source must be a non-empty path")
+            raise ValueError("source must be a non-empty path")  # noqa: TRY003  # tracked: #288
         if Path(value).is_absolute():
-            raise ValueError("source must be relative to the input bundle")
+            raise ValueError("source must be relative to the input bundle")  # noqa: TRY003  # tracked: #288
         return value
 
 
@@ -137,9 +137,9 @@ class HiddenEvaluatorInput(BaseModel):
     @classmethod
     def _relative_source(cls, value: str) -> str:
         if not value.strip():
-            raise ValueError("source must be a non-empty path")
+            raise ValueError("source must be a non-empty path")  # noqa: TRY003  # tracked: #288
         if Path(value).is_absolute():
-            raise ValueError("source must be relative to the input bundle")
+            raise ValueError("source must be relative to the input bundle")  # noqa: TRY003  # tracked: #288
         return value
 
 
@@ -155,14 +155,14 @@ class BenchmarkResult(BaseModel):
     @classmethod
     def _single_option(cls, value: str) -> str:
         if not value.startswith("-") or any(character.isspace() for character in value):
-            raise ValueError("json_argument must be one option-style argv element")
+            raise ValueError("json_argument must be one option-style argv element")  # noqa: TRY003  # tracked: #288
         return value
 
     @field_validator("metric")
     @classmethod
     def _metric_name(cls, value: str) -> str:
         if not value or any(character.isspace() for character in value):
-            raise ValueError("metric must be a non-empty JSON field name without whitespace")
+            raise ValueError("metric must be a non-empty JSON field name without whitespace")  # noqa: TRY003  # tracked: #288
         return value
 
 
@@ -201,9 +201,9 @@ class InputManifest(BaseModel):
         seen_dests: set[str] = set()
         for source in self.workspace.sources:
             if source.name in seen_names:
-                raise ValueError(f"duplicate workspace source name: {source.name}")
+                raise ValueError(f"duplicate workspace source name: {source.name}")  # noqa: TRY003  # tracked: #288
             if source.dest in seen_dests:
-                raise ValueError(f"duplicate workspace source destination: {source.dest}")
+                raise ValueError(f"duplicate workspace source destination: {source.dest}")  # noqa: TRY003  # tracked: #288
             seen_names.add(source.name)
             seen_dests.add(source.dest)
         return self
@@ -224,41 +224,41 @@ class InputBundle(BaseModel):
     manifest: InputManifest
 
     @property
-    def objective(self) -> str:
+    def objective(self) -> str:  # noqa: D102  # tracked: #288
         return self.objective_path.read_text()
 
     @property
-    def accuracy_command(self) -> tuple[str, ...]:
+    def accuracy_command(self) -> tuple[str, ...]:  # noqa: D102  # tracked: #288
         return self.manifest.accuracy.command
 
     @property
-    def benchmark_command(self) -> tuple[str, ...]:
+    def benchmark_command(self) -> tuple[str, ...]:  # noqa: D102  # tracked: #288
         return self.manifest.benchmark.command
 
     @property
-    def domain(self) -> DomainName:
+    def domain(self) -> DomainName:  # noqa: D102  # tracked: #288
         return self.manifest.agent.domain
 
     @property
-    def accuracy_command_display(self) -> str:
+    def accuracy_command_display(self) -> str:  # noqa: D102  # tracked: #288
         return self.manifest.accuracy.display()
 
     @property
-    def benchmark_command_display(self) -> str:
+    def benchmark_command_display(self) -> str:  # noqa: D102  # tracked: #288
         return self.manifest.benchmark.display()
 
     @property
-    def benchmark_result(self) -> BenchmarkResult | None:
+    def benchmark_result(self) -> BenchmarkResult | None:  # noqa: D102  # tracked: #288
         return self.manifest.benchmark.result
 
     @property
-    def workspace_sources(self) -> tuple[WorkspaceSource, ...]:
+    def workspace_sources(self) -> tuple[WorkspaceSource, ...]:  # noqa: D102  # tracked: #288
         if self.manifest.workspace is None:
             return ()
         return self.manifest.workspace.sources
 
 
-def load_input_bundle(
+def load_input_bundle(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
     path: Path,
     *,
     project_root: Path | None = None,
@@ -273,22 +273,22 @@ def load_input_bundle(
     project_root = (project_root or PROJECT_ROOT).resolve()
     root = path.expanduser().resolve()
     if not root.exists():
-        raise FileNotFoundError(f"--input path does not exist: {path}")
+        raise FileNotFoundError(f"--input path does not exist: {path}")  # noqa: TRY003  # tracked: #288
     if not root.is_dir():
-        raise ValueError(f"--input path is not a directory: {path}")
+        raise ValueError(f"--input path is not a directory: {path}")  # noqa: TRY003  # tracked: #288
 
     manifest_path = root / MANIFEST_NAME
     if not manifest_path.is_file():
-        raise FileNotFoundError(f"Input manifest not found: {manifest_path}")
+        raise FileNotFoundError(f"Input manifest not found: {manifest_path}")  # noqa: TRY003  # tracked: #288
 
     objective_path = root / "OBJECTIVE.md"
     if not objective_path.is_file():
-        raise FileNotFoundError(f"OBJECTIVE.md not found: {objective_path}")
+        raise FileNotFoundError(f"OBJECTIVE.md not found: {objective_path}")  # noqa: TRY003  # tracked: #288
 
     try:
         manifest = InputManifest.model_validate(tomllib.loads(manifest_path.read_text()))
     except ValidationError as exc:
-        raise ValueError(f"Invalid input manifest {manifest_path}: {exc}") from exc
+        raise ValueError(f"Invalid input manifest {manifest_path}: {exc}") from exc  # noqa: TRY003  # tracked: #288
 
     for label, command in (
         ("accuracy.command", manifest.accuracy.command),
@@ -296,7 +296,7 @@ def load_input_bundle(
     ):
         executable = Path(command[0])
         if executable.is_absolute():
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"{label} executable must be relative to the input bundle: {command[0]}"
             )
         if "/" not in command[0]:
@@ -305,15 +305,15 @@ def load_input_bundle(
         try:
             resolved.relative_to(root)
         except ValueError as exc:
-            raise ValueError(f"{label} executable escapes the input bundle: {command[0]}") from exc
+            raise ValueError(f"{label} executable escapes the input bundle: {command[0]}") from exc  # noqa: TRY003  # tracked: #288
         if not resolved.exists():
-            raise FileNotFoundError(f"{label} executable does not exist: {resolved}")
+            raise FileNotFoundError(f"{label} executable does not exist: {resolved}")  # noqa: TRY003  # tracked: #288
         if not resolved.is_file():
-            raise ValueError(f"{label} executable is not a file: {resolved}")
+            raise ValueError(f"{label} executable is not a file: {resolved}")  # noqa: TRY003  # tracked: #288
 
     reference_path = root / "reference"
     if reference_path.exists() and not reference_path.is_dir():
-        raise ValueError(f"reference path is not a directory: {reference_path}")
+        raise ValueError(f"reference path is not a directory: {reference_path}")  # noqa: TRY003  # tracked: #288
     if not reference_path.exists():
         reference_path = None
 
@@ -328,13 +328,13 @@ def load_input_bundle(
         try:
             workspace_seed_path.relative_to(starters_root)
         except ValueError as exc:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"workspace.seed must resolve inside {starters_root}: {manifest.workspace.seed}"
             ) from exc
         if not workspace_seed_path.exists():
-            raise FileNotFoundError(f"workspace.seed path does not exist: {workspace_seed_path}")
+            raise FileNotFoundError(f"workspace.seed path does not exist: {workspace_seed_path}")  # noqa: TRY003  # tracked: #288
         if not workspace_seed_path.is_dir():
-            raise ValueError(f"workspace.seed path is not a directory: {workspace_seed_path}")
+            raise ValueError(f"workspace.seed path is not a directory: {workspace_seed_path}")  # noqa: TRY003  # tracked: #288
 
     evaluator_path = None
     if manifest.evaluator is not None and not allow_materialized_sources:
@@ -343,14 +343,14 @@ def load_input_bundle(
         try:
             evaluator_path.relative_to(evaluators_root)
         except ValueError as exc:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"evaluator.source must resolve inside {evaluators_root}: "
                 f"{manifest.evaluator.source}"
             ) from exc
         if not evaluator_path.exists():
-            raise FileNotFoundError(f"evaluator.source path does not exist: {evaluator_path}")
+            raise FileNotFoundError(f"evaluator.source path does not exist: {evaluator_path}")  # noqa: TRY003  # tracked: #288
         if not evaluator_path.is_dir():
-            raise ValueError(f"evaluator.source path is not a directory: {evaluator_path}")
+            raise ValueError(f"evaluator.source path is not a directory: {evaluator_path}")  # noqa: TRY003  # tracked: #288
 
     hidden_evaluator_path = None
     if manifest.hidden_evaluator is not None and not allow_materialized_sources:
@@ -359,16 +359,16 @@ def load_input_bundle(
         try:
             hidden_evaluator_path.relative_to(evaluators_root)
         except ValueError as exc:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"hidden_evaluator.source must resolve inside {evaluators_root}: "
                 f"{manifest.hidden_evaluator.source}"
             ) from exc
         if not hidden_evaluator_path.exists():
-            raise FileNotFoundError(
+            raise FileNotFoundError(  # noqa: TRY003  # tracked: #288
                 f"hidden_evaluator.source path does not exist: {hidden_evaluator_path}"
             )
         if not hidden_evaluator_path.is_dir():
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"hidden_evaluator.source path is not a directory: {hidden_evaluator_path}"
             )
 

--- a/src/vibesys/input_manifest.py
+++ b/src/vibesys/input_manifest.py
@@ -270,7 +270,6 @@ def load_input_bundle(
     from its copied workspace. Starter and evaluator sources may have lived
     outside the original bundle and are no longer needed once materialized.
     """
-
     project_root = (project_root or PROJECT_ROOT).resolve()
     root = path.expanduser().resolve()
     if not root.exists():

--- a/src/vibesys/input_project.py
+++ b/src/vibesys/input_project.py
@@ -34,7 +34,6 @@ LogFn = Callable[[str], None]
 
 def discover_input_project(reference_dir: Path | None) -> Path | None:
     """Return the input project directory for a conventional ``reference/`` path."""
-
     if reference_dir is None or reference_dir.name != "reference":
         return None
     candidate = reference_dir.parent
@@ -57,7 +56,6 @@ def materialize_input_project(
     workspace copy is rewritten so every explicit ``examples/libs`` path dep
     points at ``workspace/_input_libs/<relative-lib-path>``.
     """
-
     pyproject = input_project_dir / "pyproject.toml"
     if not pyproject.is_file():
         return []

--- a/src/vibesys/input_project.py
+++ b/src/vibesys/input_project.py
@@ -22,7 +22,7 @@ class InputProjectError(ValueError):
 
 
 @dataclass(frozen=True)
-class InputDependency:
+class InputDependency:  # noqa: D101  # tracked: #288
     name: str
     source_path: Path
     workspace_path: Path
@@ -110,17 +110,17 @@ def _collect_examples_lib_dependencies(project_dir: Path, examples_libs: Path) -
     def visit(current: Path) -> None:
         current = current.resolve()
         if current in visiting:
-            raise InputProjectError(f"Cyclic input dependency involving {current}")
+            raise InputProjectError(f"Cyclic input dependency involving {current}")  # noqa: TRY003  # tracked: #288
         visiting.add(current)
         try:
             for dep_name, raw_path in _path_sources(current).items():
                 dep_path = (current / raw_path).resolve()
                 if not _is_relative_to(dep_path, examples_libs):
-                    raise InputProjectError(
+                    raise InputProjectError(  # noqa: TRY003  # tracked: #288
                         f"Input dependency {dep_name!r} points outside examples/libs: {raw_path}"
                     )
                 if not (dep_path / "pyproject.toml").is_file():
-                    raise InputProjectError(
+                    raise InputProjectError(  # noqa: TRY003  # tracked: #288
                         f"Input dependency {dep_name!r} has no pyproject.toml: {dep_path}"
                     )
                 if dep_path not in collected:
@@ -193,7 +193,7 @@ def _rewrite_pyproject_text(
         if in_uv_sources:
             for source_name, (old_path, new_path) in replacements.items():
                 if re.match(rf"\s*{re.escape(source_name)}\s*=", line):
-                    line = re.sub(
+                    line = re.sub(  # noqa: PLW2901  # tracked: #288
                         rf"(path\s*=\s*['\"]){re.escape(old_path)}(['\"])",
                         lambda match, replacement=new_path: (
                             f"{match.group(1)}{replacement}{match.group(2)}"
@@ -224,6 +224,6 @@ def _project_name(project_dir: Path) -> str:
 def _is_relative_to(path: Path, parent: Path) -> bool:
     try:
         path.relative_to(parent)
-        return True
+        return True  # noqa: TRY300  # tracked: #288
     except ValueError:
         return False

--- a/src/vibesys/linux_cpu_profiler.py
+++ b/src/vibesys/linux_cpu_profiler.py
@@ -75,7 +75,6 @@ def detect_capability(
     run: Runner = subprocess.run,
 ) -> Capability:
     """Report whether Linux ``perf`` can be invoked for diagnostic profiling."""
-
     if (system or platform.system()) != "Linux":
         return Capability(
             LinuxProfilerTool.NONE,
@@ -191,7 +190,6 @@ def collect(
     call_graph: str = "fp",
 ) -> CollectionResult:
     """Run separate diagnostic ``perf stat`` and ``perf record`` workloads."""
-
     capability = capability or detect_capability()
     output_dir.mkdir(parents=True, exist_ok=True)
     started = time.time()
@@ -412,7 +410,6 @@ def _format_summary(
 
 def summarize(output_dir: Path) -> dict[str, Any]:
     """Read persisted artifacts and return a bounded machine-readable summary."""
-
     metadata_path = output_dir / "metadata.json"
     report_path = output_dir / "perf-report.txt"
     metadata = (
@@ -448,5 +445,4 @@ def summarize(output_dir: Path) -> dict[str, Any]:
 
 def parse_command(command: str) -> list[str]:
     """Parse an agent-supplied command without invoking a shell."""
-
     return shlex.split(command)

--- a/src/vibesys/linux_cpu_profiler.py
+++ b/src/vibesys/linux_cpu_profiler.py
@@ -16,12 +16,12 @@ from pathlib import Path
 from typing import Any
 
 
-class LinuxProfilerTool(StrEnum):
+class LinuxProfilerTool(StrEnum):  # noqa: D101  # tracked: #288
     PERF = "perf"
     NONE = "none"
 
 
-class DiagnosticCode(StrEnum):
+class DiagnosticCode(StrEnum):  # noqa: D101  # tracked: #288
     NOT_LINUX = "not_linux"
     PERF_UNAVAILABLE = "perf_unavailable"
     PERF_STAT_UNAVAILABLE = "perf_stat_unavailable"
@@ -33,7 +33,7 @@ class DiagnosticCode(StrEnum):
 
 
 @dataclass(frozen=True)
-class Capability:
+class Capability:  # noqa: D101  # tracked: #288
     tool: LinuxProfilerTool
     perf_path: str | None
     perf_version: str | None
@@ -43,7 +43,7 @@ class Capability:
 
 
 @dataclass(frozen=True)
-class CollectionResult:
+class CollectionResult:  # noqa: D101  # tracked: #288
     status: str
     tool: LinuxProfilerTool
     output_dir: str
@@ -90,7 +90,7 @@ def detect_capability(
     kptr_restrict = _read_int(Path("/proc/sys/kernel/kptr_restrict"))
     diagnostics: list[DiagnosticCode] = []
 
-    if perf_event_paranoid is not None and perf_event_paranoid > 2:
+    if perf_event_paranoid is not None and perf_event_paranoid > 2:  # noqa: PLR2004  # tracked: #288
         diagnostics.append(DiagnosticCode.PERF_EVENT_PARANOID_RESTRICTIVE)
     if kptr_restrict is not None and kptr_restrict > 0:
         diagnostics.append(DiagnosticCode.KERNEL_SYMBOLS_RESTRICTED)
@@ -147,7 +147,7 @@ def _run_text(
     *,
     timeout: int | None,
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(command, capture_output=True, text=True, timeout=timeout)
+    return subprocess.run(command, capture_output=True, text=True, timeout=timeout)  # noqa: PLW1510, S603  # tracked: #288
 
 
 def _parse_perf_stat_csv(path: Path) -> tuple[dict[str, str], ...]:
@@ -156,7 +156,7 @@ def _parse_perf_stat_csv(path: Path) -> tuple[dict[str, str], ...]:
     counters: list[dict[str, str]] = []
     with path.open(newline="", encoding="utf-8", errors="replace") as fh:
         for row in csv.reader(fh):
-            if len(row) < 3:
+            if len(row) < 3:  # noqa: PLR2004  # tracked: #288
                 continue
             value, unit, event = (item.strip() for item in row[:3])
             if not event or value.startswith("#"):
@@ -180,7 +180,7 @@ def _extract_hot_symbols(report_text: str, *, limit: int = 20) -> tuple[str, ...
     return tuple(hot)
 
 
-def collect(
+def collect(  # noqa: PLR0913  # tracked: #288
     command: list[str],
     output_dir: Path,
     *,
@@ -348,7 +348,7 @@ def collect(
     )
 
 
-def _write_metadata(
+def _write_metadata(  # noqa: PLR0913  # tracked: #288
     output_dir: Path,
     *,
     command: list[str],

--- a/src/vibesys/llm_client.py
+++ b/src/vibesys/llm_client.py
@@ -144,13 +144,12 @@ def _build_vertex_model(model_name: str, config: Config, thinking: ThinkingCfg):
             location=vertex_region,
             **thinking_kwargs,
         )
-    else:
-        return _vertex_anthropic_model_class()(
-            model_name=model_name,
-            credentials=credentials,
-            project=project,
-            location=vertex_region,
-        )
+    return _vertex_anthropic_model_class()(
+        model_name=model_name,
+        credentials=credentials,
+        project=project,
+        location=vertex_region,
+    )
 
 
 def _vertex_anthropic_model_class() -> Any:

--- a/src/vibesys/llm_client.py
+++ b/src/vibesys/llm_client.py
@@ -1,4 +1,4 @@
-import json
+import json  # noqa: D100  # tracked: #288
 from pathlib import Path
 from typing import Any
 
@@ -28,7 +28,7 @@ def _has_thinking(thinking: ThinkingCfg) -> bool:
     return thinking.level is not None or thinking.budget is not None
 
 
-def build_model(config: Config):
+def build_model(config: Config):  # noqa: ANN201, C901, PLR0911, PLR0912  # tracked: #288
     """Build the chat model from a parsed :class:`Config`."""
     model_name = config.model.name
     provider = config.model.provider
@@ -39,23 +39,23 @@ def build_model(config: Config):
 
     if provider == "anthropic":
         if not _is_anthropic_model(model_name):
-            raise ValueError(f"{model_name!r} is not a Claude model (provider='anthropic')")
+            raise ValueError(f"{model_name!r} is not a Claude model (provider='anthropic')")  # noqa: TRY003  # tracked: #288
         if _has_thinking(thinking):
-            raise ValueError("Thinking is not supported for provider 'anthropic'")
+            raise ValueError("Thinking is not supported for provider 'anthropic'")  # noqa: TRY003  # tracked: #288
         return f"anthropic:{model_name}"
 
     if provider == "google-genai":
         if not _is_google_model(model_name):
-            raise ValueError(f"{model_name!r} is not a Google model (provider='google-genai')")
+            raise ValueError(f"{model_name!r} is not a Google model (provider='google-genai')")  # noqa: TRY003  # tracked: #288
         if _has_thinking(thinking):
-            raise ValueError("Thinking is not supported for provider 'google-genai'")
+            raise ValueError("Thinking is not supported for provider 'google-genai'")  # noqa: TRY003  # tracked: #288
         return f"google_genai:{model_name}"
 
     if provider == "openai":
         if not _is_openai_model(model_name):
-            raise ValueError(f"{model_name!r} is not an OpenAI model (provider='openai')")
+            raise ValueError(f"{model_name!r} is not an OpenAI model (provider='openai')")  # noqa: TRY003  # tracked: #288
         if _has_thinking(thinking):
-            raise ValueError("Thinking is not supported for provider 'openai'")
+            raise ValueError("Thinking is not supported for provider 'openai'")  # noqa: TRY003  # tracked: #288
         return f"openai:{model_name}"
 
     if provider == "openai-compatible":
@@ -65,17 +65,17 @@ def build_model(config: Config):
         # Auto-detect from model name
         if _is_anthropic_model(model_name):
             if _has_thinking(thinking):
-                raise ValueError("Thinking is not supported for provider 'anthropic'")
+                raise ValueError("Thinking is not supported for provider 'anthropic'")  # noqa: TRY003  # tracked: #288
             return f"anthropic:{model_name}"
         if _is_google_model(model_name):
             if _has_thinking(thinking):
-                raise ValueError("Thinking is not supported for provider 'google-genai'")
+                raise ValueError("Thinking is not supported for provider 'google-genai'")  # noqa: TRY003  # tracked: #288
             return f"google_genai:{model_name}"
         if _is_openai_model(model_name):
             if _has_thinking(thinking):
-                raise ValueError("Thinking is not supported for provider 'openai'")
+                raise ValueError("Thinking is not supported for provider 'openai'")  # noqa: TRY003  # tracked: #288
             return f"openai:{model_name}"
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003  # tracked: #288
             f"Cannot auto-detect provider for model {model_name!r}. "
             f"Set model.provider in your config."
         )
@@ -83,13 +83,13 @@ def build_model(config: Config):
     raise NotImplementedError(f"Provider {provider!r} is not yet supported")
 
 
-def _build_openai_compatible_model(model_name: str, config: Config):
+def _build_openai_compatible_model(model_name: str, config: Config):  # noqa: ANN202  # tracked: #288
     """Build a model using an OpenAI-compatible API (e.g. vLLM, Ollama)."""
-    from langchain_openai import ChatOpenAI
+    from langchain_openai import ChatOpenAI  # noqa: PLC0415  # tracked: #288
 
     oc = config.providers.openai_compatible
     if oc is None or not oc.base_url:
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003  # tracked: #288
             "openai-compatible provider requires 'base_url' (e.g. 'http://localhost:8000/v1')"
         )
 
@@ -100,9 +100,9 @@ def _build_openai_compatible_model(model_name: str, config: Config):
     )
 
 
-def _build_vertex_model(model_name: str, config: Config, thinking: ThinkingCfg):
+def _build_vertex_model(model_name: str, config: Config, thinking: ThinkingCfg):  # noqa: ANN202  # tracked: #288
     """Build a Vertex AI model (Claude via Model Garden or Gemini via GenAI)."""
-    from google.oauth2 import service_account
+    from google.oauth2 import service_account  # noqa: PLC0415  # tracked: #288
 
     vx = config.providers.vertex_ai
     vertex_json = vx.json_path if vx else None
@@ -110,11 +110,11 @@ def _build_vertex_model(model_name: str, config: Config, thinking: ThinkingCfg):
     vertex_region = vx.region if vx else "us-east5"
 
     if not vertex_json:
-        raise ValueError("vertex-ai provider requires 'json' key path")
+        raise ValueError("vertex-ai provider requires 'json' key path")  # noqa: TRY003  # tracked: #288
 
     key_path = Path(vertex_json).expanduser()
     if not key_path.exists():
-        raise ValueError(f"Vertex AI service account key not found: {key_path}")
+        raise ValueError(f"Vertex AI service account key not found: {key_path}")  # noqa: TRY003  # tracked: #288
 
     creds_dict = json.loads(key_path.read_text())
     credentials = service_account.Credentials.from_service_account_info(
@@ -124,7 +124,7 @@ def _build_vertex_model(model_name: str, config: Config, thinking: ThinkingCfg):
     project = vertex_project or creds_dict.get("project_id")
 
     if not _is_google_model(model_name) and _has_thinking(thinking):
-        raise ValueError("Thinking is not supported for non-Gemini models on Vertex AI")
+        raise ValueError("Thinking is not supported for non-Gemini models on Vertex AI")  # noqa: TRY003  # tracked: #288
 
     if _is_google_model(model_name):
         thinking_kwargs = {}
@@ -152,15 +152,17 @@ def _build_vertex_model(model_name: str, config: Config, thinking: ThinkingCfg):
     )
 
 
-def _vertex_anthropic_model_class() -> Any:
+def _vertex_anthropic_model_class() -> Any:  # noqa: ANN401  # tracked: #288
     """Load the optional Vertex Anthropic class only when it is needed."""
-    from langchain_google_vertexai.model_garden import ChatAnthropicVertex
+    from langchain_google_vertexai.model_garden import (  # noqa: PLC0415  # tracked: #288
+        ChatAnthropicVertex,
+    )
 
     return ChatAnthropicVertex
 
 
-def _vertex_gemini_model_class() -> Any:
+def _vertex_gemini_model_class() -> Any:  # noqa: ANN401  # tracked: #288
     """Load the optional Vertex Gemini class only when it is needed."""
-    from langchain_google_genai import ChatGoogleGenerativeAI
+    from langchain_google_genai import ChatGoogleGenerativeAI  # noqa: PLC0415  # tracked: #288
 
     return ChatGoogleGenerativeAI

--- a/src/vibesys/loops/agent/issue_board.py
+++ b/src/vibesys/loops/agent/issue_board.py
@@ -72,7 +72,6 @@ def _structured_artifact_root(progress_path: Path) -> Path:
     ``progress.md`` runs use a sibling directory so the existing Markdown file
     remains untouched.
     """
-
     if progress_path.suffix == ".md":
         return progress_path.with_name(f"{progress_path.stem}-artifacts")
     return progress_path
@@ -80,7 +79,6 @@ def _structured_artifact_root(progress_path: Path) -> Path:
 
 def _write_json_atomic(path: Path, payload: object) -> Path:
     """Atomically replace a framework-owned JSON handoff artifact."""
-
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
     temporary = Path(temporary_name)
@@ -97,7 +95,6 @@ def _write_json_atomic(path: Path, payload: object) -> Path:
 
 def write_plan_artifact(progress_path: Path, round_number: int, plan: OrchestratorPlan) -> Path:
     """Persist the exact typed plan used by the framework for one round."""
-
     path = _structured_artifact_root(progress_path) / "plans" / f"round-{round_number:04d}.json"
     return _write_json_atomic(path, plan.model_dump(mode="json"))
 
@@ -109,7 +106,6 @@ def write_implementer_artifact(
     response: ImplementerResponse,
 ) -> Path:
     """Persist parsed implementer claims as untrusted data for Judge audit."""
-
     path = (
         _structured_artifact_root(progress_path)
         / "evidence"
@@ -120,25 +116,21 @@ def write_implementer_artifact(
 
 def validation_artifact_root(progress_path: Path) -> Path:
     """Return the framework-owned validation ledger directory."""
-
     return _structured_artifact_root(progress_path) / "validation"
 
 
 def profiler_artifact_root(progress_path: Path, round_number: int) -> Path:
     """Return the only durable output directory writable by a Profiler turn."""
-
     return _structured_artifact_root(progress_path) / "profiles" / f"round-{round_number:04d}"
 
 
 def validation_recipe_schema_path(progress_path: Path) -> Path:
     """Return the framework-owned candidate recipe-schema path."""
-
     return validation_artifact_root(progress_path) / "recipe-schema.json"
 
 
 def write_validation_recipe_schema(progress_path: Path) -> Path:
     """Publish the authoritative recipe contract for on-demand agent reads."""
-
     return _write_json_atomic(
         validation_recipe_schema_path(progress_path),
         ValidationRecipeArtifact.model_json_schema(mode="validation"),
@@ -152,7 +144,6 @@ def write_validation_result_artifact(
     results: list[FrameworkValidationResult],
 ) -> Path:
     """Persist framework-executed validation results for replay and reuse."""
-
     path = (
         validation_artifact_root(progress_path)
         / f"round-{round_number:04d}-attempt-{retry:02d}.json"
@@ -167,13 +158,11 @@ def write_validation_result_artifact(
 
 def validation_result_artifact_paths(progress_path: Path) -> list[Path]:
     """Return validation result artifacts in deterministic creation order."""
-
     return sorted(validation_artifact_root(progress_path).glob("round-*-attempt-*.json"))
 
 
 def implementer_artifact_paths(progress_path: Path, round_number: int) -> list[Path]:
     """Return persisted implementer attempts for one round in attempt order."""
-
     evidence_root = _structured_artifact_root(progress_path) / "evidence"
     pattern = f"round-{round_number:04d}-attempt-*-implementer.json"
     return sorted(evidence_root.glob(pattern))
@@ -181,7 +170,6 @@ def implementer_artifact_paths(progress_path: Path, round_number: int) -> list[P
 
 def next_implementer_attempt(progress_path: Path, round_number: int) -> int:
     """Return the next durable attempt number for an interrupted round."""
-
     attempts: list[int] = []
     prefix = f"round-{round_number:04d}-attempt-"
     suffix = "-implementer.json"
@@ -620,7 +608,6 @@ def append_framework_validation_gate(
     results: list[FrameworkValidationResult],
 ) -> None:
     """Record the deterministic local validation gate in the progress ledger."""
-
     passed = bool(results) and all(result.passed for result in results)
     lines = [
         f"## Round {round_number} — Framework local validation (attempt {retry})",

--- a/src/vibesys/loops/agent/issue_board.py
+++ b/src/vibesys/loops/agent/issue_board.py
@@ -39,7 +39,7 @@ _RECENT_PROGRESS_ROUNDS = 4
 def resolve_paths(workspace: Path, layout: str) -> tuple[Path, Path]:
     """Resolve both memory locations, preserving the layout of resumed runs."""
     if layout not in MEMORY_LAYOUTS:
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003  # tracked: #288
             f"Unknown memory layout {layout!r}; choose from {', '.join(MEMORY_LAYOUTS)}"
         )
 
@@ -47,7 +47,7 @@ def resolve_paths(workspace: Path, layout: str) -> tuple[Path, Path]:
         legacy = workspace / f"{name}.md"
         directory = workspace / name
         if legacy.exists() and directory.exists():
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"Both {legacy.name} and {directory.name}/ exist; keep only one {name} layout"
             )
         if legacy.exists():
@@ -390,7 +390,7 @@ def _append(progress_path: Path, block: str, round_number: int) -> None:
     replacement.replace(document)
 
 
-def append_pre_round_decision(
+def append_pre_round_decision(  # noqa: D103  # tracked: #288
     progress_path: Path, round_number: int, decision: PreRoundDecision
 ) -> None:
     block = (
@@ -402,7 +402,7 @@ def append_pre_round_decision(
     _append(progress_path, block, round_number)
 
 
-def append_profiler_summary(
+def append_profiler_summary(  # noqa: D103  # tracked: #288
     progress_path: Path, round_number: int, summary: ProfilerSummary
 ) -> None:
     perf_line = ""
@@ -419,7 +419,7 @@ def append_profiler_summary(
     _append(progress_path, block, round_number)
 
 
-def append_orchestrator_plan(
+def append_orchestrator_plan(  # noqa: D103  # tracked: #288
     progress_path: Path, round_number: int, plan: OrchestratorPlan
 ) -> None:
     revert_line = ""
@@ -443,7 +443,7 @@ def append_orchestrator_plan(
     _append(progress_path, block, round_number)
 
 
-def append_hypothesis_continuation(
+def append_hypothesis_continuation(  # noqa: D103  # tracked: #288
     progress_path: Path,
     round_number: int,
     *,
@@ -462,7 +462,7 @@ def append_hypothesis_continuation(
     _append(progress_path, block, round_number)
 
 
-def append_implementer(
+def append_implementer(  # noqa: D103  # tracked: #288
     progress_path: Path, round_number: int, retry: int, response: ImplementerResponse
 ) -> None:
     perf_line = ""
@@ -496,7 +496,7 @@ def append_implementer(
     _append(progress_path, block, round_number)
 
 
-def append_judge(
+def append_judge(  # noqa: D103  # tracked: #288
     progress_path: Path, round_number: int, retry: int, response: JudgeResponse
 ) -> None:
     block = (
@@ -508,7 +508,7 @@ def append_judge(
     _append(progress_path, block, round_number)
 
 
-def append_judge_skipped(
+def append_judge_skipped(  # noqa: D103  # tracked: #288
     progress_path: Path,
     round_number: int,
     *,
@@ -524,7 +524,7 @@ def append_judge_skipped(
     _append(progress_path, block, round_number)
 
 
-def append_official_evaluation_decision(
+def append_official_evaluation_decision(  # noqa: D103, PLR0913  # tracked: #288
     progress_path: Path,
     round_number: int,
     retry: int,
@@ -545,7 +545,7 @@ def append_official_evaluation_decision(
     _append(progress_path, block, round_number)
 
 
-def append_single_agent_round(
+def append_single_agent_round(  # noqa: D103  # tracked: #288
     progress_path: Path,
     round_number: int,
     retry: int,
@@ -580,7 +580,7 @@ def append_single_agent_round(
     _append(progress_path, block, round_number)
 
 
-def append_framework_accuracy_gate(
+def append_framework_accuracy_gate(  # noqa: D103, PLR0913  # tracked: #288
     progress_path: Path,
     round_number: int,
     retry: int,
@@ -623,7 +623,7 @@ def append_framework_validation_gate(
     _append(progress_path, "\n".join(lines) + "\n", round_number)
 
 
-def append_framework_benchmark(
+def append_framework_benchmark(  # noqa: D103, PLR0913  # tracked: #288
     progress_path: Path,
     round_number: int,
     retry: int,
@@ -646,7 +646,7 @@ def append_framework_benchmark(
     _append(progress_path, block, round_number)
 
 
-def append_exhaustion_note(
+def append_exhaustion_note(  # noqa: D103  # tracked: #288
     progress_path: Path, round_number: int, attempts: int, last_feedback: str
 ) -> None:
     block = (

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -1290,7 +1290,6 @@ def _validate_skill_selections(
     the corresponding agent-visible paths.  Invalid recommendations are
     diagnostic, never a reason to abort an otherwise useful experiment.
     """
-
     if not selections:
         return [], []
     skill_sources = ctx.skill_source_paths
@@ -1746,7 +1745,6 @@ def _profiler_summary_from_single_agent(
 
 def _validation_input_digest(workspace: Path, recipe: ValidationRecipe) -> str:
     """Hash the declared workspace inputs that determine recipe reuse."""
-
     digest = hashlib.sha256()
     workspace_root = workspace.resolve()
     total_files = 0
@@ -1789,7 +1787,6 @@ def _reusable_validation_result(
     input_digest: str,
 ) -> FrameworkValidationResult | None:
     """Return the newest matching framework PASS, if one exists."""
-
     for artifact in reversed(issue_board.validation_result_artifact_paths(progress_path)):
         try:
             payload = json.loads(artifact.read_text())
@@ -1808,7 +1805,6 @@ def _reusable_validation_result(
 
 def _load_validation_recipes(workspace: Path, artifact: str) -> list[ValidationRecipe]:
     """Load and validate a candidate-authored recipe file inside the workspace."""
-
     workspace_root = workspace.resolve()
     path = (workspace / artifact).resolve()
     if not path.is_relative_to(workspace_root):
@@ -1840,7 +1836,6 @@ def _run_framework_validation_gate(
     can reach this function. Commands must be non-mutating; any workspace write
     fails the gate and is restored to the pre-validation checkpoint.
     """
-
     if recipe_artifact is None:
         return None
 
@@ -3237,11 +3232,12 @@ def run_agent_loop(
                         else None
                     )
                     active_hypothesis.continuation_rounds += 1
-                elif reviewed:
-                    active_hypothesis = None
-                elif implementation is not None and not _implementation_keeps_hypothesis_active(
-                    implementation,
-                    continuation_rounds=active_hypothesis.continuation_rounds,
+                elif reviewed or (
+                    implementation is not None
+                    and not _implementation_keeps_hypothesis_active(
+                        implementation,
+                        continuation_rounds=active_hypothesis.continuation_rounds,
+                    )
                 ):
                     active_hypothesis = None
                 else:

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -12,19 +12,19 @@ import json
 import math
 import shlex
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any
 
 from vibesys.agents.progress import RoundProgress
-from vibesys.config import Config
+from vibesys.config import Config  # noqa: TC001  # tracked: #288
 from vibesys.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibesys.context import create_run_context
 from vibesys.domains.base import DomainDefinition, DomainName, DomainRole
 from vibesys.domains.registry import resolve_domain
 from vibesys.domains.rendering import render_domain_section
-from vibesys.input_manifest import BenchmarkResult, WorkspaceSource
+from vibesys.input_manifest import BenchmarkResult, WorkspaceSource  # noqa: TC001  # tracked: #288
 from vibesys.loops.agent import issue_board
-from vibesys.loops.evolve.population import Objective
+from vibesys.loops.evolve.population import Objective  # noqa: TC001  # tracked: #288
 from vibesys.loops.gates import run_accuracy_gate
 from vibesys.loops.profiler import mcp_spec as profiler_mcp_spec
 from vibesys.profilers import (
@@ -601,7 +601,7 @@ def _pareto_archive_summary(
     if frontier:
         lines.append("Trusted frontier parents:")
         for record in frontier:
-            assert record.commit is not None
+            assert record.commit is not None  # noqa: S101  # tracked: #288
             evidence = "official" if record.official_evaluation else "reviewed provisional"
             operating_point = record.candidate_operating_point or "canonical workload row"
             artifact = record.candidate_evaluation_artifact or record.evaluation_artifact
@@ -630,7 +630,7 @@ def _pareto_archive_summary(
             "do not treat it as a trusted parent until its hard invariants pass):"
         )
         for record in pending[-8:]:
-            assert record.commit is not None
+            assert record.commit is not None  # noqa: S101  # tracked: #288
             lines.append(
                 f"- round {record.round_number}, commit {record.commit[:12]}: "
                 f"{_format_metric_row(record.candidate_metrics, objectives)}; "
@@ -697,7 +697,7 @@ def _detect_plateau(
 
     The orchestrator gets this verbatim in its prompt; phrasing is
     user-facing.
-    """
+    """  # noqa: D205  # tracked: #288
     fresh = [
         r
         for r in records
@@ -725,7 +725,7 @@ def _detect_plateau(
     rounds = [r.round_number for r in tail]
     return (
         f"The last {min_streak} rounds with a fresh perf measurement (rounds "
-        f"{rounds[0]}–{rounds[-1]}) all landed in {lo:.2f}–{hi:.2f}{unit_suffix} "
+        f"{rounds[0]}–{rounds[-1]}) all landed in {lo:.2f}–{hi:.2f}{unit_suffix} "  # noqa: RUF001  # tracked: #288
         f"— a {spread_pct:.2f}% spread, well within bench noise. Whatever you've "
         f"been working on for those rounds is not actually moving the headline "
         f"metric."
@@ -807,7 +807,7 @@ def _provisional_candidates_since_official(records: list[_RoundRecord]) -> int:
     return count
 
 
-def _official_evaluation_reason(
+def _official_evaluation_reason(  # noqa: PLR0913  # tracked: #288
     *,
     records: list[_RoundRecord],
     round_number: int,
@@ -937,8 +937,8 @@ def _invoke_read_only_role(
     role: str,
     checkpoint_label: str,
     allowed_workspace_paths: tuple[str, ...] = (),
-    **invoke_kwargs: Any,
-) -> Any:
+    **invoke_kwargs: Any,  # noqa: ANN401  # tracked: #288
+) -> Any:  # noqa: ANN401  # tracked: #288
     """Invoke an evidence-reading role and undo unauthorized mutations.
 
     Prompt-level role boundaries are useful guidance, but they are not an
@@ -951,7 +951,7 @@ def _invoke_read_only_role(
     ctx.snapshot_workspace(checkpoint_label)
     checkpoint = ctx.git.current_sha()
     if checkpoint is None:
-        raise RuntimeError(f"Cannot isolate {role}: workspace checkpoint is unavailable")
+        raise RuntimeError(f"Cannot isolate {role}: workspace checkpoint is unavailable")  # noqa: TRY003  # tracked: #288
 
     try:
         return ctx.invoke(**invoke_kwargs)
@@ -970,18 +970,18 @@ def _invoke_read_only_role(
             if allowed_workspace_paths:
                 checkout_kwargs["preserve_paths"] = allowed_workspace_paths
             if not ctx.git.checkout_tree(checkpoint, **checkout_kwargs):
-                raise RuntimeError(
+                raise RuntimeError(  # noqa: TRY003  # tracked: #288
                     f"Cannot isolate {role}: failed to restore workspace checkpoint "
                     f"{checkpoint[:12]}"
                 )
             remaining = [path for path in ctx.git.pending_changes() if not is_allowed(path)]
             if remaining:
-                raise RuntimeError(
+                raise RuntimeError(  # noqa: TRY003  # tracked: #288
                     f"Cannot isolate {role}: workspace is still modified after restore: "
                     f"{', '.join(remaining[:8])}"
                 )
             shown = ", ".join(unauthorized[:8])
-            suffix = "" if len(unauthorized) <= 8 else f", ... (+{len(unauthorized) - 8} more)"
+            suffix = "" if len(unauthorized) <= 8 else f", ... (+{len(unauthorized) - 8} more)"  # noqa: PLR2004  # tracked: #288
             ctx.lprint(
                 f"[role-isolation] reverted {len(unauthorized)} workspace change(s) "
                 f"attempted by {role}: {shown}{suffix}"
@@ -993,7 +993,7 @@ def _is_fresh_cold_start(round_number: int, records: list[_RoundRecord]) -> bool
     return round_number == 1 and not records
 
 
-def _run_pre_round_decision(
+def _run_pre_round_decision(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     round_number: int,
@@ -1048,7 +1048,7 @@ def _profiler_prompt_template(
     ).prompt_template
 
 
-def _effective_profiler_definition(
+def _effective_profiler_definition(  # noqa: ANN202  # tracked: #288
     profiler_kind: ProfilerKind,
     *,
     supports_torch_profiler: bool = False,
@@ -1062,14 +1062,14 @@ def _effective_profiler_definition(
     """
     kind = require_profiler_kind(profiler_kind)
     if kind is ProfilerKind.NONE:
-        raise ValueError("No profiler prompt exists when profiling is disabled.")
+        raise ValueError("No profiler prompt exists when profiling is disabled.")  # noqa: TRY003  # tracked: #288
     definition = profiler_definition(kind)
     if definition.requires_domain_torch_support and not supports_torch_profiler:
-        raise ValueError("The selected domain does not provide Torch profiler support.")
+        raise ValueError("The selected domain does not provide Torch profiler support.")  # noqa: TRY003  # tracked: #288
     return definition
 
 
-def _run_profiler(
+def _run_profiler(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     round_number: int,
@@ -1155,7 +1155,7 @@ Write bounded durable profile evidence only below
             round_label=f"round-{round_number}-profiler",
             mcp_servers=[spec] if spec is not None else None,
         )
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001  # tracked: #288
         ctx.lprint(f"[warn] profiler failed: {exc}")
         return None
     if summary is None:
@@ -1191,7 +1191,7 @@ def _domain_render_context(
     }
 
 
-def _run_orchestrator_plan(
+def _run_orchestrator_plan(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     round_number: int,
@@ -1251,7 +1251,7 @@ def _run_orchestrator_plan(
         response_cls=OrchestratorPlan,
         fallback_factory=lambda: OrchestratorPlan(
             task="Re-check minimal server boots and /health returns 200.",
-            pass_criteria="/health returns 200.",
+            pass_criteria="/health returns 200.",  # noqa: S106  # tracked: #288
             reasoning="fallback: orchestrator produced no structured response",
         ),
         round_label=f"round-{round_number}-plan",
@@ -1321,7 +1321,7 @@ def _validate_skill_selections(
     return validated, resolved
 
 
-def _run_implementer(
+def _run_implementer(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     round_number: int,
@@ -1434,7 +1434,7 @@ def _run_implementer(
     return response
 
 
-def _run_judge(
+def _run_judge(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     round_number: int,
@@ -1587,7 +1587,7 @@ def _run_judge(
     return response
 
 
-def _run_single_agent_round(
+def _run_single_agent_round(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     round_number: int,
@@ -1752,12 +1752,12 @@ def _validation_input_digest(workspace: Path, recipe: ValidationRecipe) -> str:
     for relative in sorted(recipe.input_paths):
         unresolved = workspace / relative
         if unresolved.is_symlink():
-            raise ValueError(f"validation input must not be a symlink: {relative}")
+            raise ValueError(f"validation input must not be a symlink: {relative}")  # noqa: TRY003  # tracked: #288
         path = unresolved.resolve()
         if not path.is_relative_to(workspace_root):
-            raise ValueError(f"validation input escapes workspace: {relative}")
+            raise ValueError(f"validation input escapes workspace: {relative}")  # noqa: TRY003  # tracked: #288
         if not path.exists():
-            raise ValueError(f"validation input does not exist: {relative}")
+            raise ValueError(f"validation input does not exist: {relative}")  # noqa: TRY003  # tracked: #288
         digest.update(relative.encode("utf-8"))
         digest.update(b"\0dir\0" if path.is_dir() else b"\0file\0")
         entries = [path]
@@ -1765,11 +1765,11 @@ def _validation_input_digest(workspace: Path, recipe: ValidationRecipe) -> str:
             entries = sorted(candidate for candidate in path.rglob("*") if candidate.is_file())
         for entry in entries:
             if entry.is_symlink():
-                raise ValueError(f"validation input must not be a symlink: {relative}")
+                raise ValueError(f"validation input must not be a symlink: {relative}")  # noqa: TRY003  # tracked: #288
             total_files += 1
             total_bytes += entry.stat().st_size
-            if total_files > 4096 or total_bytes > 256 * 1024 * 1024:
-                raise ValueError("validation inputs exceed the 4096-file/256-MiB reuse-hash limit")
+            if total_files > 4096 or total_bytes > 256 * 1024 * 1024:  # noqa: PLR2004  # tracked: #288
+                raise ValueError("validation inputs exceed the 4096-file/256-MiB reuse-hash limit")  # noqa: TRY003  # tracked: #288
             entry_relative = entry.relative_to(workspace_root).as_posix()
             digest.update(entry_relative.encode("utf-8"))
             digest.update(b"\0")
@@ -1808,20 +1808,20 @@ def _load_validation_recipes(workspace: Path, artifact: str) -> list[ValidationR
     workspace_root = workspace.resolve()
     path = (workspace / artifact).resolve()
     if not path.is_relative_to(workspace_root):
-        raise ValueError("validation recipe artifact escapes the workspace")
+        raise ValueError("validation recipe artifact escapes the workspace")  # noqa: TRY003  # tracked: #288
     if not path.is_file():
-        raise ValueError(f"validation recipe artifact does not exist: {artifact}")
+        raise ValueError(f"validation recipe artifact does not exist: {artifact}")  # noqa: TRY003  # tracked: #288
     try:
         payload = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError) as exc:
-        raise ValueError(f"validation recipe artifact is not valid JSON: {exc}") from exc
+        raise ValueError(f"validation recipe artifact is not valid JSON: {exc}") from exc  # noqa: TRY003  # tracked: #288
     try:
         return ValidationRecipeArtifact.model_validate(payload).recipes
     except (TypeError, ValueError) as exc:
-        raise ValueError(f"validation recipe artifact does not match version 1: {exc}") from exc
+        raise ValueError(f"validation recipe artifact does not match version 1: {exc}") from exc  # noqa: TRY003  # tracked: #288
 
 
-def _run_framework_validation_gate(
+def _run_framework_validation_gate(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
     ctx: LoopContext,
     *,
     recipe_artifact: str | None,
@@ -1891,7 +1891,7 @@ def _run_framework_validation_gate(
                 output=output[-8000:],
                 error=None if passed else "command exited nonzero",
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             result = FrameworkValidationResult(
                 recipe=recipe,
                 input_digest=input_digest,
@@ -1903,7 +1903,7 @@ def _run_framework_validation_gate(
         if changes:
             restore_required = True
             shown = ", ".join(changes[:8])
-            suffix = "" if len(changes) <= 8 else f", ... (+{len(changes) - 8} more)"
+            suffix = "" if len(changes) <= 8 else f", ... (+{len(changes) - 8} more)"  # noqa: PLR2004  # tracked: #288
             result = result.model_copy(
                 update={
                     "passed": False,
@@ -1914,7 +1914,7 @@ def _run_framework_validation_gate(
         if not result.passed:
             break
 
-    if restore_required:
+    if restore_required:  # noqa: SIM102  # tracked: #288
         if not ctx.git.checkout_tree(checkpoint, clean=True):
             results[-1] = results[-1].model_copy(
                 update={
@@ -1983,7 +1983,7 @@ def _with_candidate_revision(
     return f"env {' '.join(environment)} {command}"
 
 
-def _run_framework_accuracy_gate(
+def _run_framework_accuracy_gate(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     round_number: int,
@@ -2046,7 +2046,7 @@ def _metric_values(value: object, metric: str) -> list[object]:
     return []
 
 
-def _run_framework_benchmark(
+def _run_framework_benchmark(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     ctx: LoopContext,
     *,
     result_spec: BenchmarkResult | None,
@@ -2067,7 +2067,7 @@ def _run_framework_benchmark(
     if not base_command:
         return "Benchmark result contract is configured without a benchmark command.", None
 
-    output_path = f"/tmp/vibesys-framework-benchmark-{round_number}-{retry}.json"
+    output_path = f"/tmp/vibesys-framework-benchmark-{round_number}-{retry}.json"  # noqa: S108  # tracked: #288
     execution_base = _with_candidate_revision(
         base_command,
         candidate_revision,
@@ -2102,7 +2102,7 @@ def _run_framework_benchmark(
                 process_kind="benchmark",
                 content=result.output,
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             output = f"benchmark command could not be executed: {exc}"
             passed = False
 
@@ -2124,15 +2124,15 @@ def _run_framework_benchmark(
                 else:
                     values = _metric_values(payload, result_spec.metric)
                 if len(values) != 1:
-                    raise ValueError(
+                    raise ValueError(  # noqa: TRY003, TRY301  # tracked: #288
                         f"expected exactly one {result_spec.metric!r} field, found {len(values)}"
                     )
                 value = values[0]
                 if isinstance(value, bool) or not isinstance(value, int | float):
-                    raise ValueError(f"{result_spec.metric!r} is not numeric")
+                    raise ValueError(f"{result_spec.metric!r} is not numeric")  # noqa: TRY003, TRY004, TRY301  # tracked: #288
                 metric_value = float(value)
                 if not math.isfinite(metric_value):
-                    raise ValueError(f"{result_spec.metric!r} is not finite")
+                    raise ValueError(f"{result_spec.metric!r} is not finite")  # noqa: TRY003, TRY301  # tracked: #288
             except (ValueError, TypeError, json.JSONDecodeError) as exc:
                 output = f"{output}\ninvalid benchmark result: {exc}".strip()
                 passed = False
@@ -2177,7 +2177,7 @@ def _run_framework_benchmark(
     return feedback, None
 
 
-def _run_framework_gates(
+def _run_framework_gates(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     benchmark_result: BenchmarkResult | None,
@@ -2234,7 +2234,7 @@ def _run_framework_gates(
 # ---------------------------------------------------------------------------
 
 
-def run_agent_loop(
+def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     config: Config,
     exp_name: str,
     input_path: str,
@@ -2299,28 +2299,28 @@ def run_agent_loop(
     bundle rather than the process-boundary mode.
     """
     if inner_loop not in _INNER_LOOPS:
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003  # tracked: #288
             f"Unknown inner_loop {inner_loop!r}; choose from {', '.join(_INNER_LOOPS)}"
         )
     if max_retries_per_round < 1:
         # Guard against a zero-iteration retry loop: with no attempts the
         # round bookkeeping below would reference an unbound loop variable.
-        raise ValueError(f"max_retries_per_round must be >= 1, got {max_retries_per_round}")
+        raise ValueError(f"max_retries_per_round must be >= 1, got {max_retries_per_round}")  # noqa: TRY003  # tracked: #288
     if judge_every < 1:
-        raise ValueError(f"judge_every must be >= 1, got {judge_every}")
+        raise ValueError(f"judge_every must be >= 1, got {judge_every}")  # noqa: TRY003  # tracked: #288
     if official_eval_every < 1:
-        raise ValueError(f"official_eval_every must be >= 1, got {official_eval_every}")
+        raise ValueError(f"official_eval_every must be >= 1, got {official_eval_every}")  # noqa: TRY003  # tracked: #288
     if not 0 <= pareto_relative_noise < 1:
-        raise ValueError(f"pareto_relative_noise must be in [0, 1), got {pareto_relative_noise}")
+        raise ValueError(f"pareto_relative_noise must be in [0, 1), got {pareto_relative_noise}")  # noqa: TRY003  # tracked: #288
     if memory_layout not in issue_board.MEMORY_LAYOUTS:
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003  # tracked: #288
             f"Unknown memory_layout {memory_layout!r}; "
             f"choose from {', '.join(issue_board.MEMORY_LAYOUTS)}"
         )
     if interface not in _INTERFACES:
-        raise ValueError(f"Unknown interface {interface!r}; choose from {', '.join(_INTERFACES)}")
+        raise ValueError(f"Unknown interface {interface!r}; choose from {', '.join(_INTERFACES)}")  # noqa: TRY003  # tracked: #288
     if domain is None:
-        raise ValueError("domain is required; declare [agent].domain in vibesys.input.toml")
+        raise ValueError("domain is required; declare [agent].domain in vibesys.input.toml")  # noqa: TRY003  # tracked: #288
     # Resolve the registered domain once (fail fast on an unknown name). The
     # per-role files carry language, tooling, and use-case-specific contracts.
     domain_definition = resolve_domain(domain)
@@ -2510,7 +2510,7 @@ def run_agent_loop(
                         rollback_commit, failed_child_round = _resolve_rollback_commit(
                             target, records
                         )
-                        assert rollback_commit is not None
+                        assert rollback_commit is not None  # noqa: S101  # tracked: #288
                         # Restore the tree without moving HEAD so subsequent
                         # commits land on the current branch as new commits
                         # after the reverted state.
@@ -2568,7 +2568,7 @@ def run_agent_loop(
                 retry = 0
                 first_retry = issue_board.next_implementer_attempt(progress_path, round_number)
                 if first_retry > max_retries_per_round:
-                    raise RuntimeError(
+                    raise RuntimeError(  # noqa: TRY003  # tracked: #288
                         f"Round {round_number} already persisted "
                         f"{first_retry - 1} implementer attempts, exhausting "
                         f"max_retries_per_round={max_retries_per_round}; refusing "
@@ -3210,7 +3210,7 @@ def run_agent_loop(
                     continuation_rounds=active_hypothesis.continuation_rounds,
                 ):
                     active_hypothesis.feedback = feedback if reviewed and not passed else None
-                    assert implementation is not None
+                    assert implementation is not None  # noqa: S101  # tracked: #288
                     active_hypothesis.next_step = implementation.next_step
                     active_hypothesis.continuation_rounds += 1
                 elif passed:

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -34,19 +34,19 @@ import random
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any, cast
 
 from jinja2 import Environment, FileSystemLoader
 
 from vibesys.agents.progress import CandidateProgress
-from vibesys.config import Config
+from vibesys.config import Config  # noqa: TC001  # tracked: #288
 from vibesys.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibesys.context import create_candidate_context, create_run_context
 from vibesys.domains.base import DomainDefinition, DomainName, DomainRole
 from vibesys.domains.registry import resolve_domain
 from vibesys.domains.rendering import render_domain_section
-from vibesys.input_manifest import WorkspaceSource
+from vibesys.input_manifest import WorkspaceSource  # noqa: TC001  # tracked: #288
 from vibesys.loops.evolve.population import (
     Individual,
     Objective,
@@ -78,7 +78,7 @@ _INTERFACE = "inprocess"
 # Evolve owns its top-level mutator and judge prompts but reuses the agent
 # loop's modality fragments and profiler prompts. Domain role files are rendered
 # separately and injected into both sets of neutral templates.
-_jinja_env = Environment(
+_jinja_env = Environment(  # noqa: S701  # tracked: #288
     loader=FileSystemLoader([str(_TEMPLATE_DIR), str(_AGENT_TEMPLATE_DIR)]),
     keep_trailing_newline=True,
     trim_blocks=True,
@@ -118,7 +118,7 @@ def _discard_working_tree(ctx: LoopContext) -> None:
     try:
         ctx.git.run(["git", "checkout", "HEAD", "--", "."], check=False)
         ctx.git.run(["git", "clean", "-fd"], check=False)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001  # tracked: #288
         ctx.lprint(f"[warn] discard working tree failed: {exc}")
 
 
@@ -132,7 +132,7 @@ def _candidate_code(ctx: LoopContext, commit: str) -> str:
         .splitlines()
     )
     if not roots:
-        raise ValueError(f"cannot resolve workspace baseline for commit {commit}")
+        raise ValueError(f"cannot resolve workspace baseline for commit {commit}")  # noqa: TRY003  # tracked: #288
     return ctx.git.run(
         [
             "git",
@@ -241,7 +241,7 @@ def _candidate_runtime_notes(
     return runtime.prompt_notes, runtime.deployment_name
 
 
-def _run_mutator(
+def _run_mutator(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     generation: int,
@@ -302,7 +302,7 @@ def _run_mutator(
     )
 
 
-def _run_judge(
+def _run_judge(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     generation: int,
@@ -367,7 +367,7 @@ def _format_objectives_for_profiler(objectives: list[Objective]) -> str:
     )
 
 
-def _run_profiler(
+def _run_profiler(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     generation: int,
@@ -458,7 +458,7 @@ def _run_framework_accuracy_gate(
     return result.feedback
 
 
-def _evaluate_candidate(
+def _evaluate_candidate(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     generation: int,
@@ -594,7 +594,7 @@ def _evaluate_candidate(
         _teardown_candidate_deployment(ctx, cand_deployment, keep=keep_deployments)
 
 
-def _record_outcome(
+def _record_outcome(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     population: Population,
     population_path: Path,
@@ -655,7 +655,7 @@ def _record_outcome(
     return individual
 
 
-def _plan_candidate(
+def _plan_candidate(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     population: Population,
     rng: random.Random,
@@ -692,7 +692,7 @@ def _plan_candidate(
     return selection
 
 
-def _run_generation_serial(
+def _run_generation_serial(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     generation: int,
@@ -774,7 +774,7 @@ def _run_generation_serial(
                 _discard_working_tree(ctx)
 
 
-def _evaluate_in_subcontext(
+def _evaluate_in_subcontext(  # noqa: PLR0913  # tracked: #288
     parent_ctx: LoopContext,
     *,
     config: Config,
@@ -826,7 +826,7 @@ def _evaluate_in_subcontext(
                 agent_backend=agent_backend,
                 cli_provider=cli_provider,
             )
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001  # tracked: #288
         parent_ctx.lprint(f"[warn] candidate {label} setup failed: {exc}")
         return _CandidateOutcome(
             passed=False,
@@ -853,7 +853,7 @@ def _evaluate_in_subcontext(
             isolated_deployment=True,
             accuracy_timeout_seconds=accuracy_timeout_seconds,
         )
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001  # tracked: #288
         parent_ctx.lprint(f"[warn] candidate {label} evaluation raised: {exc}")
         return _CandidateOutcome(
             passed=False,
@@ -865,11 +865,11 @@ def _evaluate_in_subcontext(
     finally:
         try:
             subctx.close()
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             parent_ctx.lprint(f"[warn] candidate {label} teardown failed: {exc}")
 
 
-def _run_generation_parallel(
+def _run_generation_parallel(  # noqa: PLR0913  # tracked: #288
     parent_ctx: LoopContext,
     *,
     config: Config,
@@ -983,7 +983,7 @@ def _run_generation_parallel(
 # ---------------------------------------------------------------------------
 
 
-def _bootstrap_seed(
+def _bootstrap_seed(  # noqa: PLR0913, PLR0915  # tracked: #288
     ctx: LoopContext,
     *,
     objective: str,
@@ -992,7 +992,7 @@ def _bootstrap_seed(
     domain_definition: DomainDefinition,
     pass_criteria: str,
     max_attempts: int,
-    rng: random.Random,
+    rng: random.Random,  # noqa: ARG001  # tracked: #288
     population: Population,
     population_path: Path,
     search_policy: SearchPolicy,
@@ -1025,7 +1025,7 @@ def _bootstrap_seed(
         # snapshotted; otherwise the workspace stays as the framework seeded it
         # (the bare reference tree).
         wip_seed = _latest_wip_seed(population)
-        if wip_seed is not None and wip_seed.commit:
+        if wip_seed is not None and wip_seed.commit:  # noqa: SIM102  # tracked: #288
             if not ctx.git.checkout_tree(wip_seed.commit, clean=True):
                 ctx.lprint(
                     f"[warn] could not check out WIP seed {wip_seed.id} "
@@ -1100,7 +1100,7 @@ def _bootstrap_seed(
                     sha_after = ctx.git.current_sha()
                     if sha_after and sha_after != sha_before:
                         wip_commit = sha_after
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001  # tracked: #288
                     ctx.lprint(f"[warn] wip-seed snapshot failed: {exc}")
                 failed = Individual(
                     id=population.next_id(),
@@ -1177,7 +1177,7 @@ def _bootstrap_seed(
 # ---------------------------------------------------------------------------
 
 
-def _initialize_search_policy(
+def _initialize_search_policy(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     population: Population,
     *,
@@ -1196,7 +1196,7 @@ def _initialize_search_policy(
     else:
         policy_name = SearchPolicyName(requested)
         if policy_name is SearchPolicyName.VIBESYS and config is not None:
-            raise ValueError("OpenEvolve configuration requires the OpenEvolve search policy")
+            raise ValueError("OpenEvolve configuration requires the OpenEvolve search policy")  # noqa: TRY003  # tracked: #288
     if policy_name is not SearchPolicyName.OPENEVOLVE:
         return policy_name, VibeSysSearchPolicy()
 
@@ -1222,7 +1222,7 @@ def _initialize_search_policy(
     return policy_name, policy
 
 
-def run_evolve_loop(
+def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     config: Config,
     exp_name: str,
     input_path: str,
@@ -1242,7 +1242,7 @@ def run_evolve_loop(
     selection_temperature: float = 0.5,
     seed: int | None = None,
     pass_criteria: str = (
-        "The candidate obeys the input bundle's contract, the accuracy "
+        "The candidate obeys the input bundle's contract, the accuracy "  # noqa: S107  # tracked: #288
         "command passes, and the benchmark sanity step completes without "
         "modifying evaluator-owned files."
     ),
@@ -1280,7 +1280,7 @@ def run_evolve_loop(
     behavior, kept for back-compat.
     """
     if domain is None:
-        raise ValueError("domain is required; declare [agent].domain in vibesys.input.toml")
+        raise ValueError("domain is required; declare [agent].domain in vibesys.input.toml")  # noqa: TRY003  # tracked: #288
     domain_definition = resolve_domain(domain)
     if modality is None and domain_definition.name is DomainName.LLM_SERVING:
         modality = "text_generation"
@@ -1333,13 +1333,13 @@ def run_evolve_loop(
         ctx.lprint("[evolutionary] interrupted during search-policy initialization.")
         ctx.close()
         return False
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001  # tracked: #288
         ctx.lprint(f"[evolutionary] search-policy initialization failed: {exc}")
         ctx.close()
         return False
     ctx.lprint(f"[log] search policy: {policy_name.value}")
 
-    rng = random.Random(seed)
+    rng = random.Random(seed)  # noqa: S311  # tracked: #288
 
     try:
         # Bootstrap phase: guarantee a passing generation-0 seed before the
@@ -1467,11 +1467,11 @@ def run_evolve_loop(
             )
         else:
             ctx.lprint("\nNo passing individual produced. Inspect logs.")
-        return True
+        return True  # noqa: TRY300  # tracked: #288
     except KeyboardInterrupt:
         ctx.lprint("[evolutionary] interrupted; population preserved.")
         return False
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001  # tracked: #288
         ctx.lprint(f"[evolutionary] aborted with: {exc}")
         return False
     finally:

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -818,7 +818,7 @@ def _evaluate_in_subcontext(
     try:
         with worktree_lock:
             subctx = create_candidate_context(
-                cast(Any, parent_ctx),
+                cast("Any", parent_ctx),
                 config=config,
                 generation=generation,
                 child_idx=child_idx,

--- a/src/vibesys/loops/evolve/population.py
+++ b/src/vibesys/loops/evolve/population.py
@@ -30,9 +30,9 @@ from __future__ import annotations
 
 import json
 import math
-import random
+import random  # noqa: TC003  # tracked: #288
 from dataclasses import asdict, dataclass, field
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any
 
 # ---------------------------------------------------------------------------
@@ -53,9 +53,9 @@ class Objective:
     name: str
     direction: str  # "max" or "min"
 
-    def __post_init__(self) -> None:
+    def __post_init__(self) -> None:  # noqa: D105  # tracked: #288
         if self.direction not in ("max", "min"):
-            raise ValueError(f"Objective.direction must be 'max' or 'min', got {self.direction!r}")
+            raise ValueError(f"Objective.direction must be 'max' or 'min', got {self.direction!r}")  # noqa: TRY003  # tracked: #288
 
     def signed(self, value: float) -> float:
         """Return *value* flipped to "higher is better" semantics.
@@ -129,7 +129,7 @@ class Individual:
     policy_parent_id: str | None = None
     policy_target_island: int | None = None
 
-    def __post_init__(self) -> None:
+    def __post_init__(self) -> None:  # noqa: D105  # tracked: #288
         self.validate_fitness()
 
     def validate_fitness(self) -> None:
@@ -138,11 +138,11 @@ class Individual:
         for name, value in self.metrics.items():
             _require_finite_metric(value, f"metrics[{name!r}]")
 
-    def to_json(self) -> dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:  # noqa: D102  # tracked: #288
         return asdict(self)
 
     @classmethod
-    def from_json(cls, data: dict[str, Any]) -> Individual:
+    def from_json(cls, data: dict[str, Any]) -> Individual:  # noqa: D102  # tracked: #288
         return cls(
             id=int(data["id"]),
             generation=int(data["generation"]),
@@ -171,37 +171,37 @@ class Population:
 
     Failed individuals (``passed=False``) are kept but excluded from
     selection so the mutator only ever evolves from a working baseline.
-    """
+    """  # noqa: D205  # tracked: #288
 
-    def __init__(self, individuals: list[Individual] | None = None) -> None:
+    def __init__(self, individuals: list[Individual] | None = None) -> None:  # noqa: D107  # tracked: #288
         self._individuals: list[Individual] = list(individuals or [])
 
     # -- accessors -----------------------------------------------------------
 
     @property
-    def all(self) -> list[Individual]:
+    def all(self) -> list[Individual]:  # noqa: D102  # tracked: #288
         return list(self._individuals)
 
     @property
-    def passed(self) -> list[Individual]:
+    def passed(self) -> list[Individual]:  # noqa: D102  # tracked: #288
         passed = [i for i in self._individuals if i.passed and i.commit]
         for individual in passed:
             individual.validate_fitness()
         return passed
 
-    def __len__(self) -> int:
+    def __len__(self) -> int:  # noqa: D105  # tracked: #288
         return len(self._individuals)
 
-    def next_id(self) -> int:
+    def next_id(self) -> int:  # noqa: D102  # tracked: #288
         return (max((i.id for i in self._individuals), default=0)) + 1
 
-    def get(self, ind_id: int) -> Individual | None:
+    def get(self, ind_id: int) -> Individual | None:  # noqa: D102  # tracked: #288
         for i in self._individuals:
             if i.id == ind_id:
                 return i
         return None
 
-    def add(self, ind: Individual) -> None:
+    def add(self, ind: Individual) -> None:  # noqa: D102  # tracked: #288
         ind.validate_fitness()
         self._individuals.append(ind)
 
@@ -239,7 +239,7 @@ class Population:
             if not any(
                 _dominates(other, cand, objectives) for other in eligible if other.id != cand.id
             ):
-                non_dominated.append(cand)
+                non_dominated.append(cand)  # noqa: PERF401  # tracked: #288
         return non_dominated
 
     # -- selection -----------------------------------------------------------
@@ -285,7 +285,7 @@ class Population:
             return ranked[0]
         perfs = [i.perf_metric for i in ranked if i.perf_metric is not None]
         lo, hi = min(perfs), max(perfs)
-        if hi - lo < 1e-12:
+        if hi - lo < 1e-12:  # noqa: PLR2004  # tracked: #288
             return rng.choice(ranked)
         normed = [(p - lo) / (hi - lo) for p in perfs]
         t = max(temperature, 1e-6)
@@ -362,7 +362,7 @@ class Population:
 
     # -- persistence ---------------------------------------------------------
 
-    def save(self, path: Path) -> None:
+    def save(self, path: Path) -> None:  # noqa: D102  # tracked: #288
         for individual in self._individuals:
             individual.validate_fitness()
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -371,7 +371,7 @@ class Population:
         )
 
     @classmethod
-    def load(cls, path: Path) -> Population:
+    def load(cls, path: Path) -> Population:  # noqa: D102  # tracked: #288
         if not path.exists():
             return cls()
         data = json.loads(path.read_text())
@@ -382,4 +382,4 @@ def _require_finite_metric(value: float | None, field_name: str) -> None:
     if value is None:
         return
     if isinstance(value, bool) or not math.isfinite(value):
-        raise ValueError(f"{field_name} must be a finite number")
+        raise ValueError(f"{field_name} must be a finite number")  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/loops/evolve/search_policy.py
+++ b/src/vibesys/loops/evolve/search_policy.py
@@ -187,7 +187,7 @@ class OpenEvolveSearchPolicy:
         saved_state = self._load_adapter_state()
         saved_config = (
             OpenEvolveSearchConfig(
-                **cast(dict[str, Any], saved_state["config"]),
+                **cast("dict[str, Any]", saved_state["config"]),
             )
             if saved_state is not None
             else None
@@ -206,11 +206,11 @@ class OpenEvolveSearchPolicy:
                 f"saved={saved_objectives}, requested={self._objective_signature}"
             )
         self._admitted_individual_ids = set(
-            cast(list[int], saved_state.get("admitted_individual_ids", [])) if saved_state else []
+            cast("list[int]", saved_state.get("admitted_individual_ids", [])) if saved_state else []
         )
         self._rng = random.Random(seed)
         if saved_state is not None and "rng_state" in saved_state:
-            self._rng.setstate(cast(tuple[Any, ...], self._tuple_tree(saved_state["rng_state"])))
+            self._rng.setstate(cast("tuple[Any, ...]", self._tuple_tree(saved_state["rng_state"])))
 
         process_random_state = random.getstate()
         try:
@@ -234,7 +234,7 @@ class OpenEvolveSearchPolicy:
             random.setstate(process_random_state)
 
         if saved_state is not None:
-            active_ids = set(cast(list[str], saved_state.get("active_program_ids", [])))
+            active_ids = set(cast("list[str]", saved_state.get("active_program_ids", [])))
             self._database.programs = {
                 program_id: program
                 for program_id, program in self._database.programs.items()
@@ -257,7 +257,7 @@ class OpenEvolveSearchPolicy:
         payload = json.loads(state_path.read_text())
         if payload.get("schema_version") != cls._STATE_SCHEMA_VERSION:
             raise ValueError(f"unsupported OpenEvolve adapter state in {state_path}")
-        return OpenEvolveSearchConfig(**cast(dict[str, Any], payload["config"]))
+        return OpenEvolveSearchConfig(**cast("dict[str, Any]", payload["config"]))
 
     @classmethod
     def persisted_objectives(cls, state_dir: Path) -> list[Objective] | None:
@@ -268,7 +268,7 @@ class OpenEvolveSearchPolicy:
         payload = json.loads(state_path.read_text())
         if payload.get("schema_version") != cls._STATE_SCHEMA_VERSION:
             raise ValueError(f"unsupported OpenEvolve adapter state in {state_path}")
-        signature = cast(list[dict[str, str]], payload.get("objective_signature", []))
+        signature = cast("list[dict[str, str]]", payload.get("objective_signature", []))
         return [Objective(item["name"], item["direction"]) for item in signature]
 
     @staticmethod
@@ -596,7 +596,7 @@ class OpenEvolveSearchPolicy:
         if payload.get("snapshot") != self._snapshot_dir.name:
             return
         self._database.set_current_island(int(payload["current_island"]))
-        self._rng.setstate(cast(tuple[Any, ...], self._tuple_tree(payload["rng_state"])))
+        self._rng.setstate(cast("tuple[Any, ...]", self._tuple_tree(payload["rng_state"])))
 
     @staticmethod
     def _combined_score(

--- a/src/vibesys/loops/evolve/search_policy.py
+++ b/src/vibesys/loops/evolve/search_policy.py
@@ -13,11 +13,11 @@ import json
 import random
 import shutil
 import uuid
-from collections.abc import Generator
+from collections.abc import Generator  # noqa: TC003  # tracked: #288
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from enum import StrEnum
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any, Protocol, cast
 
 from openevolve.config import DatabaseConfig  # pyright: ignore[reportMissingTypeStubs]
@@ -26,7 +26,7 @@ from openevolve.database import Program, ProgramDatabase  # pyright: ignore[repo
 from vibesys.loops.evolve.population import Individual, Objective, Population
 
 
-class SearchPolicyName(StrEnum):
+class SearchPolicyName(StrEnum):  # noqa: D101  # tracked: #288
     VIBESYS = "vibesys"
     OPENEVOLVE = "openevolve"
 
@@ -51,26 +51,26 @@ class OpenEvolveSearchConfig:
     migration_interval: int = 50
     migration_rate: float = 0.1
 
-    def __post_init__(self) -> None:
+    def __post_init__(self) -> None:  # noqa: D105  # tracked: #288
         if self.population_size < 1:
-            raise ValueError("OpenEvolve population_size must be >= 1")
+            raise ValueError("OpenEvolve population_size must be >= 1")  # noqa: TRY003  # tracked: #288
         if self.archive_size < 1:
-            raise ValueError("OpenEvolve archive_size must be >= 1")
+            raise ValueError("OpenEvolve archive_size must be >= 1")  # noqa: TRY003  # tracked: #288
         if self.num_islands < 1:
-            raise ValueError("OpenEvolve num_islands must be >= 1")
+            raise ValueError("OpenEvolve num_islands must be >= 1")  # noqa: TRY003  # tracked: #288
         if self.migration_interval < 1:
-            raise ValueError("OpenEvolve migration_interval must be >= 1")
+            raise ValueError("OpenEvolve migration_interval must be >= 1")  # noqa: TRY003  # tracked: #288
         if not 0.0 <= self.migration_rate <= 1.0:
-            raise ValueError("OpenEvolve migration_rate must be in [0, 1]")
+            raise ValueError("OpenEvolve migration_rate must be in [0, 1]")  # noqa: TRY003  # tracked: #288
 
 
 class SearchPolicy(Protocol):
     """Selection/persistence surface consumed by the VibeSys evolve loop."""
 
     @property
-    def requires_code(self) -> bool: ...
+    def requires_code(self) -> bool: ...  # noqa: D102  # tracked: #288
 
-    def select(
+    def select(  # noqa: D102, PLR0913  # tracked: #288
         self,
         population: Population,
         *,
@@ -82,7 +82,7 @@ class SearchPolicy(Protocol):
         frontier_bias: float,
     ) -> SearchSelection | None: ...
 
-    def record(
+    def record(  # noqa: D102  # tracked: #288
         self,
         individual: Individual,
         *,
@@ -92,17 +92,17 @@ class SearchPolicy(Protocol):
         objectives: list[Objective] | None,
     ) -> None: ...
 
-    def finish_generation(self, generation: int) -> None: ...
+    def finish_generation(self, generation: int) -> None: ...  # noqa: D102  # tracked: #288
 
 
 class VibeSysSearchPolicy:
     """Existing scalar/Pareto population selection."""
 
     @property
-    def requires_code(self) -> bool:
+    def requires_code(self) -> bool:  # noqa: D102  # tracked: #288
         return False
 
-    def select(
+    def select(  # noqa: D102, PLR0913  # tracked: #288
         self,
         population: Population,
         *,
@@ -133,25 +133,25 @@ class VibeSysSearchPolicy:
             parent = passers[-1]
         return SearchSelection(parent=parent, inspirations=inspirations)
 
-    def record(
+    def record(  # noqa: D102  # tracked: #288
         self,
-        individual: Individual,
+        individual: Individual,  # noqa: ARG002  # tracked: #288
         *,
-        code: str,
-        policy_parent_id: str | None,
-        target_island: int | None,
-        objectives: list[Objective] | None,
+        code: str,  # noqa: ARG002  # tracked: #288
+        policy_parent_id: str | None,  # noqa: ARG002  # tracked: #288
+        target_island: int | None,  # noqa: ARG002  # tracked: #288
+        objectives: list[Objective] | None,  # noqa: ARG002  # tracked: #288
     ) -> None:
         return None
 
-    def finish_generation(self, generation: int) -> None:
+    def finish_generation(self, generation: int) -> None:  # noqa: ARG002, D102  # tracked: #288
         return None
 
 
 class _SortedIterationSet(set[str]):
     """Set semantics with deterministic iteration for replaying OpenEvolve."""
 
-    def __iter__(self):
+    def __iter__(self):  # noqa: ANN204  # tracked: #288
         return iter(sorted(super().__iter__()))
 
 
@@ -171,10 +171,10 @@ class OpenEvolveSearchPolicy:
     _STATE_SCHEMA_VERSION = 1
 
     @property
-    def requires_code(self) -> bool:
+    def requires_code(self) -> bool:  # noqa: D102  # tracked: #288
         return True
 
-    def __init__(
+    def __init__(  # noqa: D107  # tracked: #288
         self,
         *,
         state_dir: Path,
@@ -193,7 +193,7 @@ class OpenEvolveSearchPolicy:
             else None
         )
         if config is not None and saved_config is not None and config != saved_config:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 "OpenEvolve search configuration does not match the resumed run: "
                 f"saved={saved_config}, requested={config}"
             )
@@ -201,14 +201,14 @@ class OpenEvolveSearchPolicy:
         self._objective_signature = self._objectives_signature(objectives)
         saved_objectives = saved_state.get("objective_signature") if saved_state else None
         if saved_objectives is not None and saved_objectives != self._objective_signature:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 "OpenEvolve fitness objective does not match the resumed run: "
                 f"saved={saved_objectives}, requested={self._objective_signature}"
             )
         self._admitted_individual_ids = set(
             cast("list[int]", saved_state.get("admitted_individual_ids", [])) if saved_state else []
         )
-        self._rng = random.Random(seed)
+        self._rng = random.Random(seed)  # noqa: S311  # tracked: #288
         if saved_state is not None and "rng_state" in saved_state:
             self._rng.setstate(cast("tuple[Any, ...]", self._tuple_tree(saved_state["rng_state"])))
 
@@ -245,34 +245,34 @@ class OpenEvolveSearchPolicy:
             self._save_full_state()
 
     @classmethod
-    def has_state(cls, state_dir: Path) -> bool:
+    def has_state(cls, state_dir: Path) -> bool:  # noqa: D102  # tracked: #288
         return cls._resolve_snapshot_dir(state_dir) is not None
 
     @classmethod
-    def persisted_config(cls, state_dir: Path) -> OpenEvolveSearchConfig | None:
+    def persisted_config(cls, state_dir: Path) -> OpenEvolveSearchConfig | None:  # noqa: D102  # tracked: #288
         snapshot_dir = cls._resolve_snapshot_dir(state_dir)
         if snapshot_dir is None:
             return None
         state_path = snapshot_dir / cls._STATE_FILE
         payload = json.loads(state_path.read_text())
         if payload.get("schema_version") != cls._STATE_SCHEMA_VERSION:
-            raise ValueError(f"unsupported OpenEvolve adapter state in {state_path}")
+            raise ValueError(f"unsupported OpenEvolve adapter state in {state_path}")  # noqa: TRY003  # tracked: #288
         return OpenEvolveSearchConfig(**cast("dict[str, Any]", payload["config"]))
 
     @classmethod
-    def persisted_objectives(cls, state_dir: Path) -> list[Objective] | None:
+    def persisted_objectives(cls, state_dir: Path) -> list[Objective] | None:  # noqa: D102  # tracked: #288
         snapshot_dir = cls._resolve_snapshot_dir(state_dir)
         if snapshot_dir is None:
             return None
         state_path = snapshot_dir / cls._STATE_FILE
         payload = json.loads(state_path.read_text())
         if payload.get("schema_version") != cls._STATE_SCHEMA_VERSION:
-            raise ValueError(f"unsupported OpenEvolve adapter state in {state_path}")
+            raise ValueError(f"unsupported OpenEvolve adapter state in {state_path}")  # noqa: TRY003  # tracked: #288
         signature = cast("list[dict[str, str]]", payload.get("objective_signature", []))
         return [Objective(item["name"], item["direction"]) for item in signature]
 
     @staticmethod
-    def _tuple_tree(value: Any) -> Any:
+    def _tuple_tree(value: Any) -> Any:  # noqa: ANN401  # tracked: #288
         if isinstance(value, list):
             return tuple(OpenEvolveSearchPolicy._tuple_tree(item) for item in value)
         return value
@@ -283,7 +283,7 @@ class OpenEvolveSearchPolicy:
         state_path = self._snapshot_dir / self._STATE_FILE
         payload = json.loads(state_path.read_text())
         if payload.get("schema_version") != self._STATE_SCHEMA_VERSION:
-            raise ValueError(f"unsupported OpenEvolve adapter state in {state_path}")
+            raise ValueError(f"unsupported OpenEvolve adapter state in {state_path}")  # noqa: TRY003  # tracked: #288
         return payload
 
     @classmethod
@@ -294,7 +294,7 @@ class OpenEvolveSearchPolicy:
         snapshot_name = current_path.read_text().strip()
         snapshot_dir = state_dir / "snapshots" / snapshot_name
         if not snapshot_name or not snapshot_dir.is_dir():
-            raise ValueError(f"invalid OpenEvolve snapshot pointer in {current_path}")
+            raise ValueError(f"invalid OpenEvolve snapshot pointer in {current_path}")  # noqa: TRY003  # tracked: #288
         return snapshot_dir
 
     @staticmethod
@@ -325,7 +325,7 @@ class OpenEvolveSearchPolicy:
         if not isinstance(self._database.archive, _SortedIterationSet):
             self._database.archive = _SortedIterationSet(self._database.archive)
 
-    def _canonicalize_new_upstream_programs(self, program_ids_before: set[str]) -> None:
+    def _canonicalize_new_upstream_programs(self, program_ids_before: set[str]) -> None:  # noqa: C901, PLR0912  # tracked: #288
         """Replace upstream random IDs and timestamps with state-derived values."""
         new_programs = [
             program
@@ -349,7 +349,7 @@ class OpenEvolveSearchPolicy:
             )
             canonical_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"vibesys-openevolve:{identity}"))
             if canonical_id in self._database.programs or canonical_id in replacements.values():
-                raise RuntimeError(f"duplicate deterministic OpenEvolve program ID: {canonical_id}")
+                raise RuntimeError(f"duplicate deterministic OpenEvolve program ID: {canonical_id}")  # noqa: TRY003  # tracked: #288
             replacements[program.id] = canonical_id
             program.id = canonical_id
             program.timestamp = float(program.iteration_found or self._database.last_iteration)
@@ -386,7 +386,7 @@ class OpenEvolveSearchPolicy:
                 if prompts is not None:
                     self._database.prompts_by_program[canonical_id] = prompts
 
-    def select(
+    def select(  # noqa: D102, PLR0913  # tracked: #288
         self,
         population: Population,
         *,
@@ -436,7 +436,7 @@ class OpenEvolveSearchPolicy:
             target_island=island,
         )
 
-    def record(
+    def record(  # noqa: D102  # tracked: #288
         self,
         individual: Individual,
         *,
@@ -448,7 +448,7 @@ class OpenEvolveSearchPolicy:
         if not individual.passed or not individual.commit:
             return
         if self._objectives_signature(objectives) != self._objective_signature:
-            raise ValueError("OpenEvolve fitness objective changed during the run")
+            raise ValueError("OpenEvolve fitness objective changed during the run")  # noqa: TRY003  # tracked: #288
         if individual.id in self._admitted_individual_ids:
             return
         program_id = f"vibesys-{individual.id}"
@@ -496,7 +496,7 @@ class OpenEvolveSearchPolicy:
         self._save_full_state(admitted_individual_ids=prospective_ids)
         self._admitted_individual_ids = prospective_ids
 
-    def finish_generation(self, generation: int) -> None:
+    def finish_generation(self, generation: int) -> None:  # noqa: D102  # tracked: #288
         del generation
         self._save_selection_state()
 

--- a/src/vibesys/loops/gates.py
+++ b/src/vibesys/loops/gates.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from vibesys.run import LoopContext
+from vibesys.run import LoopContext  # noqa: TC001  # tracked: #288
 from vibesys.server.events import EventType, SubprocessOutputData
 
 
@@ -65,7 +65,7 @@ def run_accuracy_gate(
         output = result.output.strip()
         passed = result.exit_code == 0
         _publish_subprocess_output(ctx, process_id=process_id, content=result.output)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001  # tracked: #288
         output = f"accuracy command could not be executed: {exc}"
         passed = False
 

--- a/src/vibesys/loops/plain/loop.py
+++ b/src/vibesys/loops/plain/loop.py
@@ -26,7 +26,7 @@ import os
 import shutil
 from dataclasses import asdict, dataclass
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any
 
 from vibesys.agents.progress import RoundProgress
@@ -34,7 +34,7 @@ from vibesys.config import Config, as_config
 from vibesys.constants import DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibesys.context import create_run_context
 from vibesys.domains.llm_serving.hooks import LLMServingEnvironmentHooks
-from vibesys.input_manifest import WorkspaceSource
+from vibesys.input_manifest import WorkspaceSource  # noqa: TC001  # tracked: #288
 from vibesys.loops.plain.render import render_all
 from vibesys.loops.plain.runner_ext import PlainLoopAgentRunner
 from vibesys.profilers import ProfilerKind
@@ -87,10 +87,10 @@ def _save_state(log_dir: Path, state: PlainLoopState) -> None:
     target = log_dir / "state.json"
     tmp = log_dir / "state.json.tmp"
     tmp.write_text(json.dumps(asdict(state), indent=2), encoding="utf-8")
-    os.replace(tmp, target)
+    os.replace(tmp, target)  # noqa: PTH105  # tracked: #288
 
 
-def load_state(log_dir: Path) -> PlainLoopState | None:
+def load_state(log_dir: Path) -> PlainLoopState | None:  # noqa: D103  # tracked: #288
     path = log_dir / "state.json"
     if not path.is_file():
         return None
@@ -207,7 +207,7 @@ def _save_perf_metrics(
     existing = json.loads(perf_metrics_path.read_text(encoding="utf-8"))
     entry = {
         "iteration": iteration,
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now().isoformat(),  # noqa: DTZ005  # tracked: #288
         "throughput_trend": response.throughput_trend.value,
         "latency_trend": response.latency_trend.value,
         "metrics": response.metrics.model_dump(),
@@ -255,7 +255,7 @@ def _sync_workspace_files(
     The canonical ``issues.json`` lives in the workspace root so the MCP
     server, the loop's ``IssueBoard``, and a human inspecting the workspace
     all see the same file. We do not copy it here.
-    """
+    """  # noqa: D205  # tracked: #288
     shutil.copy2(progress_path, workspace / "progress.md")
     shutil.copy2(perf_metrics_path, workspace / "perf_metrics.json")
     if issues_dir.is_dir():
@@ -341,7 +341,7 @@ def _ensure_bootstrap_issue(
 # ---------------------------------------------------------------------------
 
 
-def run_plain_loop(
+def run_plain_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     config: Config,
     exp_name: str,
     input_path: str,
@@ -420,7 +420,7 @@ def run_plain_loop(
         store_path = ctx.workspace / "issues.json"
         log_link = ctx.log_dir / "issues.json"
         if not log_link.exists() and not log_link.is_symlink():
-            try:
+            try:  # noqa: SIM105  # tracked: #288
                 log_link.symlink_to(os.path.relpath(store_path, ctx.log_dir))
             except OSError:
                 pass  # symlink is convenience-only
@@ -697,7 +697,7 @@ def run_plain_loop(
                 # PERF_EVAL phase (after drain complete)
                 # ---------------------------------------------------------------
                 # Bail-out check: if every remaining issue is BLOCKED, we're stuck.
-                remaining = [iss for iss in store.list() if iss.status not in (IssueStatus.CLOSED,)]
+                remaining = [iss for iss in store.list() if iss.status not in (IssueStatus.CLOSED,)]  # noqa: FURB171  # tracked: #288
                 blocked_only = remaining and all(
                     iss.status == IssueStatus.BLOCKED for iss in remaining
                 )

--- a/src/vibesys/loops/plain/mcp_config.py
+++ b/src/vibesys/loops/plain/mcp_config.py
@@ -14,7 +14,7 @@ MCP path; everything else is provider-agnostic and lives in
 from __future__ import annotations
 
 from vibesys._agent_cli.base import MCPServerSpec
-from vs_issue_board import IssueType
+from vs_issue_board import IssueType  # noqa: TC001  # tracked: #288
 
 
 def build_issue_mcp_spec(

--- a/src/vibesys/loops/plain/render.py
+++ b/src/vibesys/loops/plain/render.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import os
 import re
 import unicodedata
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any
 
 from vs_issue_board import (
@@ -103,7 +103,7 @@ def _atomic_write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(text, encoding="utf-8")
-    os.replace(tmp, path)
+    os.replace(tmp, path)  # noqa: PTH105  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
@@ -129,7 +129,7 @@ def _render_implementer_payload(payload: dict[str, Any]) -> str:
     if files_touched:
         lines.append("**Files touched**:")
         for fp in files_touched:
-            lines.append(f"- `{fp}`")
+            lines.append(f"- `{fp}`")  # noqa: PERF401  # tracked: #288
         lines.append("")
     self_check = payload.get("self_check", "").strip()
     if self_check:
@@ -200,7 +200,7 @@ def render_issue_markdown(issue: Issue) -> str:
     parts.append("## Timeline\n")
     if issue.history:
         for evt in issue.history:
-            parts.append(_render_event_bullet(evt))
+            parts.append(_render_event_bullet(evt))  # noqa: PERF401  # tracked: #288
     else:
         parts.append("_(no events recorded)_")
     parts.append("")

--- a/src/vibesys/loops/plain/runner_ext.py
+++ b/src/vibesys/loops/plain/runner_ext.py
@@ -22,11 +22,11 @@ from __future__ import annotations
 
 from typing import Any, TypeVar
 
-from langchain_core.tools import BaseTool
+from langchain_core.tools import BaseTool  # noqa: TC002  # tracked: #288
 from pydantic import BaseModel
 
-from vibesys._agent_cli.base import MCPServerSpec
-from vibesys.agents.base import AgentRunner
+from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #288
+from vibesys.agents.base import AgentRunner  # noqa: TC001  # tracked: #288
 from vibesys.loops.plain.mcp_config import build_issue_mcp_spec
 from vibesys.loops.plain.tools import build_issue_tools
 from vs_issue_board import IssueBoard, IssueType
@@ -53,7 +53,7 @@ class PlainLoopAgentRunner:
     determines the per-iteration cap scope) and does not forward.
     """
 
-    def __init__(
+    def __init__(  # noqa: ANN204, D107  # tracked: #288
         self,
         inner: AgentRunner,
         *,
@@ -65,10 +65,10 @@ class PlainLoopAgentRunner:
         self._perf_eval_cap = max_issues_per_perf_eval
 
     @property
-    def backend_name(self) -> str:
+    def backend_name(self) -> str:  # noqa: D102  # tracked: #288
         return self._inner.backend_name
 
-    def invoke(
+    def invoke(  # noqa: D102  # tracked: #288
         self,
         *,
         kind: str,
@@ -76,11 +76,11 @@ class PlainLoopAgentRunner:
         iteration: int | None = None,
         mcp_servers: list[MCPServerSpec] | None = None,
         tools: list[BaseTool] | None = None,
-        **kwargs: Any,
+        **kwargs: Any,  # noqa: ANN401  # tracked: #288
     ) -> T:
         if kind in ("judge", "perf_eval"):
             if iteration is None:
-                raise ValueError(
+                raise ValueError(  # noqa: TRY003  # tracked: #288
                     f"PlainLoopAgentRunner.invoke(kind={kind!r}) requires "
                     "iteration= so the cap can be scoped per-iteration"
                 )

--- a/src/vibesys/loops/plain/tools.py
+++ b/src/vibesys/loops/plain/tools.py
@@ -33,7 +33,7 @@ from vs_issue_board import (
 )
 
 
-def build_issue_tools(
+def build_issue_tools(  # noqa: PLR0913  # tracked: #288
     store: IssueBoard,
     *,
     iteration: int,
@@ -107,7 +107,7 @@ def build_issue_tools(
         )
 
         @tool
-        def create_issue(type: str, title: str, description: str) -> str:
+        def create_issue(type: str, title: str, description: str) -> str:  # noqa: A002  # tracked: #288
             """Create a new issue.
 
             Args:

--- a/src/vibesys/loops/profiler.py
+++ b/src/vibesys/loops/profiler.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from vibesys.run import LoopContext
 
 
-def mcp_spec(profiler_kind: ProfilerKind):
+def mcp_spec(profiler_kind: ProfilerKind):  # noqa: ANN201  # tracked: #288
     """Build an ``MCPServerSpec`` that spawns the analysis MCP server.
 
     Returns ``None`` when ``vibesys._agent_cli`` is not importable in the
@@ -37,8 +37,8 @@ def mcp_spec(profiler_kind: ProfilerKind):
     if kind is ProfilerKind.NONE:
         return None
     try:
-        from vibesys._agent_cli.base import MCPServerSpec
-    except Exception:
+        from vibesys._agent_cli.base import MCPServerSpec  # noqa: PLC0415  # tracked: #288
+    except Exception:  # noqa: BLE001  # tracked: #288
         return None
     definition = profiler_definition(kind)
     return MCPServerSpec(
@@ -82,6 +82,6 @@ def invoke_profiler(
             round_label=round_label,
             mcp_servers=[spec] if spec is not None else None,
         )
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001  # tracked: #288
         ctx.lprint(f"[warn] profiler failed: {exc}")
         return None

--- a/src/vibesys/macos_cpu_profiler.py
+++ b/src/vibesys/macos_cpu_profiler.py
@@ -14,13 +14,13 @@ from enum import StrEnum
 from pathlib import Path
 
 
-class MacOSProfilerTool(StrEnum):
+class MacOSProfilerTool(StrEnum):  # noqa: D101  # tracked: #288
     XCTRACE = "instruments"
     SAMPLE = "sample"
     NONE = "none"
 
 
-class DiagnosticCode(StrEnum):
+class DiagnosticCode(StrEnum):  # noqa: D101  # tracked: #288
     NOT_MACOS = "not_macos"
     COMMAND_LINE_TOOLS_ONLY = "command_line_tools_only"
     TIME_PROFILER_UNAVAILABLE = "time_profiler_unavailable"
@@ -32,7 +32,7 @@ class DiagnosticCode(StrEnum):
 
 
 @dataclass(frozen=True)
-class Capability:
+class Capability:  # noqa: D101  # tracked: #288
     tool: MacOSProfilerTool
     xcode_path: str | None
     xctrace_path: str | None
@@ -42,7 +42,7 @@ class Capability:
 
 
 @dataclass(frozen=True)
-class CollectionResult:
+class CollectionResult:  # noqa: D101  # tracked: #288
     status: str
     tool: MacOSProfilerTool
     artifact: str | None
@@ -173,9 +173,9 @@ def collect(
                 "--",
                 *command,
             ]
-            result = subprocess.run(executed, capture_output=True, text=True, timeout=duration + 30)
+            result = subprocess.run(executed, capture_output=True, text=True, timeout=duration + 30)  # noqa: PLW1510, S603  # tracked: #288
         elif capability.tool is MacOSProfilerTool.SAMPLE:
-            process = subprocess.Popen(
+            process = subprocess.Popen(  # noqa: S603  # tracked: #288
                 command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )
             time.sleep(warmup)
@@ -190,7 +190,7 @@ def collect(
                 "-file",
                 str(artifact),
             ]
-            result = subprocess.run(executed, capture_output=True, text=True, timeout=duration + 15)
+            result = subprocess.run(executed, capture_output=True, text=True, timeout=duration + 15)  # noqa: PLW1510, S603  # tracked: #288
             process.terminate()
             try:
                 process.wait(timeout=5)

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -483,7 +483,6 @@ def run_environment_spec_from_args(args: argparse.Namespace) -> RunEnvironmentSp
 
 def _validate_run_environment_profiler(args: argparse.Namespace) -> None:
     """Validate profiler compatibility through the selected adapter contract."""
-
     spec = run_environment_spec_from_args(args)
     supported = build_run_environment(spec).supported_profiler_kinds
     if supported is None or args.profiler in supported:
@@ -547,8 +546,7 @@ def _clone_experiment(remote: str) -> str:
     repository_name = remote.rstrip("/").rsplit("/", 1)[-1]
     if ":" in repository_name:
         repository_name = repository_name.rsplit(":", 1)[-1]
-    if repository_name.endswith(".git"):
-        repository_name = repository_name[:-4]
+    repository_name = repository_name.removesuffix(".git")
     if not repository_name:
         _configuration_error(
             f"Cannot determine a local directory name from --resume {remote!r}",
@@ -773,7 +771,6 @@ def _build_validate_parser() -> argparse.ArgumentParser:
 
 def _run_validate(argv: list[str]) -> None:
     """Validate one input-bundle contract, then report its resolved paths."""
-
     args = _build_validate_parser().parse_args(argv)
     input_path = (args.input_bundle or Path.cwd()).expanduser().resolve()
 
@@ -835,7 +832,7 @@ def _detect_resume_round(exp_dir: Path) -> int:
         return 1
     try:
         data = json.loads(rounds_json.read_text())
-        return int(len(data)) + 1
+        return len(data) + 1
     except Exception:
         return 1
 

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -23,7 +23,7 @@ import os
 import subprocess
 import sys
 import tomllib
-from collections.abc import Callable
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
@@ -34,7 +34,7 @@ from vibesys.constants import (
     PROJECT_ROOT,
     ComputeBackend,
 )
-from vibesys.domains.base import DomainName
+from vibesys.domains.base import DomainName  # noqa: TC001  # tracked: #288
 from vibesys.errors import ConfigurationDiagnostic, ConfigurationError
 from vibesys.input_manifest import InputBundle, load_input_bundle
 from vibesys.profilers import CLI_PROFILER_CHOICES, ProfilerKind, coerce_profiler_kind
@@ -88,7 +88,7 @@ class _RunArgumentParser(argparse.ArgumentParser):
 
 
 @dataclass(frozen=True)
-class CliInvocation:
+class CliInvocation:  # noqa: D101  # tracked: #288
     loop_kind: str
     args: argparse.Namespace
 
@@ -458,7 +458,8 @@ def _prepare_experiment_repository(args: argparse.Namespace, config: Config) -> 
 
 def _prepare_stub_agent_smoke_defaults(argv: list[str]) -> list[str]:
     if "--stub-agent" not in argv or any(
-        token == "--input" or token.startswith("--input=") for token in argv
+        token == "--input" or token.startswith("--input=")  # noqa: S105  # tracked: #288
+        for token in argv  # noqa: RUF100, S105  # tracked: #288
     ):
         return argv
     return [
@@ -470,7 +471,7 @@ def _prepare_stub_agent_smoke_defaults(argv: list[str]) -> list[str]:
     ]
 
 
-def run_environment_spec_from_args(args: argparse.Namespace) -> RunEnvironmentSpec:
+def run_environment_spec_from_args(args: argparse.Namespace) -> RunEnvironmentSpec:  # noqa: D103  # tracked: #288
     return make_run_environment_spec(
         use_docker=args.docker,
         docker_image=args.docker_image,
@@ -494,7 +495,7 @@ def _validate_run_environment_profiler(args: argparse.Namespace) -> None:
     )
 
 
-def _resolve_run_dir(run_dir_arg: str) -> str:
+def _resolve_run_dir(run_dir_arg: str) -> str:  # noqa: PLR0911  # tracked: #288
     """Resolve a run directory name.
 
     If *run_dir_arg* is ``"latest"``, find the most recent experiment
@@ -563,8 +564,8 @@ def _clone_experiment(remote: str) -> str:
                 code="resume_clone_failed",
                 stage="resume_resolution",
             )
-        existing_origin = subprocess.run(
-            ["git", "remote", "get-url", "origin"],
+        existing_origin = subprocess.run(  # noqa: PLW1510  # tracked: #288
+            ["git", "remote", "get-url", "origin"],  # noqa: S607  # tracked: #288
             cwd=destination,
             capture_output=True,
             text=True,
@@ -572,7 +573,7 @@ def _clone_experiment(remote: str) -> str:
         expected_suffix = remote.removesuffix(".git").rstrip("/")
         origin = existing_origin.stdout.strip().removesuffix(".git").rstrip("/")
         if existing_origin.returncode == 0 and (
-            origin == expected_suffix
+            origin == expected_suffix  # noqa: PIE810  # tracked: #288
             or origin.endswith(f"/{expected_suffix}")
             or origin.endswith(f":{expected_suffix}")
         ):
@@ -596,7 +597,7 @@ def _clone_experiment(remote: str) -> str:
 
     command = ["git", "clone", remote, str(destination)]
     try:
-        result = subprocess.run(command, capture_output=True, text=True)
+        result = subprocess.run(command, capture_output=True, text=True)  # noqa: PLW1510, S603  # tracked: #288
     except FileNotFoundError as exc:
         tool = command[0]
         _configuration_error(
@@ -746,7 +747,7 @@ def _run_tui_defaults(argv: list[str]) -> None:
         visibility=config.repository.visibility,
         theme=args.theme or config.tui.theme,
     )
-    print(defaults.model_dump_json())
+    print(defaults.model_dump_json())  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
@@ -784,21 +785,21 @@ def _run_validate(argv: list[str]) -> None:
             exit_code=1,
         )
 
-    print("VibeSys validation passed: input bundle is valid.")
-    print(f"  input bundle: {bundle.root}")
-    print(f"  objective: {bundle.objective_path}")
-    print(f"  accuracy command: {bundle.accuracy_command_display}")
-    print(f"  benchmark command: {bundle.benchmark_command_display}")
+    print("VibeSys validation passed: input bundle is valid.")  # noqa: T201  # tracked: #288
+    print(f"  input bundle: {bundle.root}")  # noqa: T201  # tracked: #288
+    print(f"  objective: {bundle.objective_path}")  # noqa: T201  # tracked: #288
+    print(f"  accuracy command: {bundle.accuracy_command_display}")  # noqa: T201  # tracked: #288
+    print(f"  benchmark command: {bundle.benchmark_command_display}")  # noqa: T201  # tracked: #288
     if bundle.workspace_seed_path is not None:
-        print(f"  workspace seed: {bundle.workspace_seed_path}")
+        print(f"  workspace seed: {bundle.workspace_seed_path}")  # noqa: T201  # tracked: #288
     for source in bundle.workspace_sources:
-        print(f"  workspace source: {source.name} -> {source.dest} @ {source.commit}")
+        print(f"  workspace source: {source.name} -> {source.dest} @ {source.commit}")  # noqa: T201  # tracked: #288
     if bundle.evaluator_path is not None:
-        print(f"  evaluator source: {bundle.evaluator_path}")
+        print(f"  evaluator source: {bundle.evaluator_path}")  # noqa: T201  # tracked: #288
     if bundle.hidden_evaluator_path is not None:
-        print(f"  hidden evaluator source: {bundle.hidden_evaluator_path}")
+        print(f"  hidden evaluator source: {bundle.hidden_evaluator_path}")  # noqa: T201  # tracked: #288
     if bundle.benchmark_result is not None:
-        print(f"  benchmark metric: {bundle.benchmark_result.metric}")
+        print(f"  benchmark metric: {bundle.benchmark_result.metric}")  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
@@ -833,7 +834,7 @@ def _detect_resume_round(exp_dir: Path) -> int:
     try:
         data = json.loads(rounds_json.read_text())
         return len(data) + 1
-    except Exception:
+    except Exception:  # noqa: BLE001  # tracked: #288
         return 1
 
 
@@ -850,7 +851,7 @@ def _prune_rounds_state(exp_dir: Path, keep_up_to: int) -> None:
         return
     try:
         data = json.loads(rounds_json.read_text())
-    except Exception:
+    except Exception:  # noqa: BLE001  # tracked: #288
         return
     kept = [d for d in data if int(d.get("round", 0)) < keep_up_to]
     rounds_json.write_text(json.dumps(kept, indent=2))
@@ -983,7 +984,7 @@ def _run_agent(args: argparse.Namespace) -> None:
     bundle: InputBundle = args.input_bundle
     config, skills, backend = load_config_and_skills(args, domain=bundle.domain)
     _prepare_experiment_repository(args, config)
-    from vibesys.loops.agent.loop import run_agent_loop
+    from vibesys.loops.agent.loop import run_agent_loop  # noqa: PLC0415  # tracked: #288
 
     objective = _with_operator_constraints(_load_objective(bundle), args.constraint)
 
@@ -995,7 +996,7 @@ def _run_agent(args: argparse.Namespace) -> None:
         run_dir_name = _resolve_run_dir(args.resume)
         exp_name = run_dir_name
         existing = True
-        print(f"Resuming agent run: exp_env/{run_dir_name}/")
+        print(f"Resuming agent run: exp_env/{run_dir_name}/")  # noqa: T201  # tracked: #288
         exp_dir = PROJECT_ROOT / "exp_env" / run_dir_name
         if not exp_dir.is_dir():
             _configuration_error(
@@ -1003,16 +1004,16 @@ def _run_agent(args: argparse.Namespace) -> None:
                 code="resume_not_found",
                 stage="resume_resolution",
             )
-        from vibesys.server.registry import active_supervisor
+        from vibesys.server.registry import active_supervisor  # noqa: PLC0415  # tracked: #288
 
         supervisor = active_supervisor()
         if supervisor is not None:
             supervisor.attach(exp_dir / "logs")
         if args.start_round is None:
             start_round = _detect_resume_round(exp_dir)
-            print(f"Auto-detected next round: {start_round}")
+            print(f"Auto-detected next round: {start_round}")  # noqa: T201  # tracked: #288
         else:
-            print(f"Resetting to round {start_round} (discarding later rounds).")
+            print(f"Resetting to round {start_round} (discarding later rounds).")  # noqa: T201  # tracked: #288
             _prune_rounds_state(exp_dir, keep_up_to=start_round)
         if start_round > args.max_rounds:
             _configuration_error(
@@ -1062,9 +1063,9 @@ def _run_agent(args: argparse.Namespace) -> None:
     )
 
     if success:
-        print(f"\nAgent loop completed {args.max_rounds} rounds.")
+        print(f"\nAgent loop completed {args.max_rounds} rounds.")  # noqa: T201  # tracked: #288
     else:
-        print("\nAgent loop stopped early (exception or KeyboardInterrupt).")
+        print("\nAgent loop stopped early (exception or KeyboardInterrupt).")  # noqa: T201  # tracked: #288
         sys.exit(1)
 
 
@@ -1073,19 +1074,19 @@ def _run_agent(args: argparse.Namespace) -> None:
 # ===========================================================================
 
 
-def _parse_cli_objective(spec: str):
+def _parse_cli_objective(spec: str):  # noqa: ANN202  # tracked: #288
     """Parse a ``--objective`` flag value (``name:direction``)."""
-    from vibesys.loops.evolve.population import Objective
+    from vibesys.loops.evolve.population import Objective  # noqa: PLC0415  # tracked: #288
 
     if ":" not in spec:
-        raise argparse.ArgumentTypeError(f"--objective {spec!r} must be 'name:max' or 'name:min'")
+        raise argparse.ArgumentTypeError(f"--objective {spec!r} must be 'name:max' or 'name:min'")  # noqa: TRY003  # tracked: #288
     name, _, direction = spec.partition(":")
     name = name.strip()
     direction = direction.strip().lower()
     if not name:
-        raise argparse.ArgumentTypeError(f"--objective {spec!r}: metric name is empty")
+        raise argparse.ArgumentTypeError(f"--objective {spec!r}: metric name is empty")  # noqa: TRY003  # tracked: #288
     if direction not in ("max", "min"):
-        raise argparse.ArgumentTypeError(
+        raise argparse.ArgumentTypeError(  # noqa: TRY003  # tracked: #288
             f"--objective {spec!r}: direction must be 'max' or 'min', got {direction!r}"
         )
     return Objective(name=name, direction=direction)
@@ -1093,7 +1094,7 @@ def _parse_cli_objective(spec: str):
 
 def _load_objectives_toml(input_path: Path) -> list[Objective]:
     """Read loop-independent Pareto axes from an input bundle when present."""
-    from vibesys.loops.evolve.population import Objective
+    from vibesys.loops.evolve.population import Objective  # noqa: PLC0415  # tracked: #288
 
     path = input_path / "objectives.toml"
     if not path.exists():
@@ -1105,7 +1106,7 @@ def _load_objectives_toml(input_path: Path) -> list[Objective]:
         name = entry.get("name")
         direction = entry.get("direction")
         if not name or direction not in ("max", "min"):
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"Malformed entry in {path}: {entry!r}. Each [[objective]] "
                 f"must set name and direction (max|min)."
             )
@@ -1126,13 +1127,13 @@ def _load_pareto_relative_noise_toml(input_path: Path) -> float:
     data = tomllib.loads(path.read_text())
     raw_value = (data.get("pareto") or {}).get("relative_noise", 0.0)
     if isinstance(raw_value, bool):
-        raise ValueError(f"Malformed pareto.relative_noise in {path}: {raw_value!r}")
+        raise ValueError(f"Malformed pareto.relative_noise in {path}: {raw_value!r}")  # noqa: TRY003, TRY004  # tracked: #288
     try:
         value = float(raw_value)
     except (TypeError, ValueError) as exc:
-        raise ValueError(f"Malformed pareto.relative_noise in {path}: {raw_value!r}") from exc
+        raise ValueError(f"Malformed pareto.relative_noise in {path}: {raw_value!r}") from exc  # noqa: TRY003  # tracked: #288
     if not math.isfinite(value) or not 0 <= value < 1:
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003  # tracked: #288
             f"Malformed pareto.relative_noise in {path}: expected a finite value "
             f"in [0, 1), got {raw_value!r}"
         )
@@ -1229,7 +1230,7 @@ def _build_evolve_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _validate_evolve(args: argparse.Namespace) -> None:
+def _validate_evolve(args: argparse.Namespace) -> None:  # noqa: C901  # tracked: #288
     _validate_run_environment_profiler(args)
     _validate_target_inputs(args)
     if args.children_per_generation < 1:
@@ -1275,7 +1276,7 @@ def _resolve_openevolve_options(
     existing: bool,
     exp_name: str,
 ) -> tuple[str | None, OpenEvolveSearchConfig | None]:
-    from vibesys.loops.evolve.search_policy import (
+    from vibesys.loops.evolve.search_policy import (  # noqa: PLC0415  # tracked: #288
         OpenEvolveSearchConfig,
         OpenEvolveSearchPolicy,
     )
@@ -1323,7 +1324,9 @@ def _restore_openevolve_objectives(
 ) -> list[Objective]:
     if not existing or objectives:
         return objectives
-    from vibesys.loops.evolve.search_policy import OpenEvolveSearchPolicy
+    from vibesys.loops.evolve.search_policy import (  # noqa: PLC0415  # tracked: #288
+        OpenEvolveSearchPolicy,
+    )
 
     persisted = OpenEvolveSearchPolicy.persisted_objectives(
         _resume_exp_dir(exp_name) / "logs" / "openevolve"
@@ -1335,7 +1338,7 @@ def _run_evolve(args: argparse.Namespace) -> None:
     bundle: InputBundle = args.input_bundle
     config, skills, backend = load_config_and_skills(args, domain=bundle.domain)
     _prepare_experiment_repository(args, config)
-    from vibesys.loops.evolve.loop import run_evolve_loop
+    from vibesys.loops.evolve.loop import run_evolve_loop  # noqa: PLC0415  # tracked: #288
 
     objective = _load_objective(bundle)
     objectives = _resolve_objectives(args)
@@ -1346,7 +1349,7 @@ def _run_evolve(args: argparse.Namespace) -> None:
         run_dir_name = _resolve_run_dir(args.resume)
         exp_name = run_dir_name
         existing = True
-        print(f"Resuming evolve run: exp_env/{run_dir_name}/")
+        print(f"Resuming evolve run: exp_env/{run_dir_name}/")  # noqa: T201  # tracked: #288
 
     objectives = _restore_openevolve_objectives(
         objectives,
@@ -1355,7 +1358,7 @@ def _run_evolve(args: argparse.Namespace) -> None:
     )
     if objectives:
         spec = ", ".join(f"{o.name}({o.direction})" for o in objectives)
-        print(f"Pareto mode active: [{spec}]; frontier_bias={args.frontier_bias}")
+        print(f"Pareto mode active: [{spec}]; frontier_bias={args.frontier_bias}")  # noqa: T201  # tracked: #288
 
     search_policy, openevolve_config = _resolve_openevolve_options(
         args,
@@ -1403,12 +1406,12 @@ def _run_evolve(args: argparse.Namespace) -> None:
     )
 
     if success:
-        print(
+        print(  # noqa: T201  # tracked: #288
             f"\nEvolve loop completed {args.max_generations} generations "
-            f"× {args.children_per_generation} cands."
+            f"× {args.children_per_generation} cands."  # noqa: RUF001  # tracked: #288
         )
     else:
-        print("\nEvolve loop stopped early (exception or KeyboardInterrupt).")
+        print("\nEvolve loop stopped early (exception or KeyboardInterrupt).")  # noqa: T201  # tracked: #288
         sys.exit(1)
 
 
@@ -1441,7 +1444,7 @@ def _run_plain(args: argparse.Namespace) -> None:
     bundle: InputBundle = args.input_bundle
     config, skills, backend = load_config_and_skills(args, domain=bundle.domain)
     _prepare_experiment_repository(args, config)
-    from vibesys.loops.plain.loop import (
+    from vibesys.loops.plain.loop import (  # noqa: PLC0415  # tracked: #288
         PlainLoopState,
         load_state,
         run_plain_loop,
@@ -1455,7 +1458,7 @@ def _run_plain(args: argparse.Namespace) -> None:
         run_dir_name = _resolve_run_dir(args.resume)
         exp_name = run_dir_name
         existing = True
-        print(f"Resuming from: exp_env/{run_dir_name}/")
+        print(f"Resuming from: exp_env/{run_dir_name}/")  # noqa: T201  # tracked: #288
 
         exp_dir = PROJECT_ROOT / "exp_env" / run_dir_name
         log_dir = exp_dir / "logs"
@@ -1468,7 +1471,7 @@ def _run_plain(args: argparse.Namespace) -> None:
         else:
             resume_state = load_state(log_dir)
             if resume_state is not None:
-                print(
+                print(  # noqa: T201  # tracked: #288
                     f"Auto-detected state: round {resume_state.round_idx + 1}, "
                     f"phase '{resume_state.phase}'"
                     + (
@@ -1479,7 +1482,7 @@ def _run_plain(args: argparse.Namespace) -> None:
                 )
             else:
                 resume_state = PlainLoopState(bootstrap_done=True)
-                print(
+                print(  # noqa: T201  # tracked: #288
                     "Warning: state.json not found. Starting fresh "
                     "(bootstrap will be skipped because existing run)."
                 )
@@ -1511,9 +1514,9 @@ def _run_plain(args: argparse.Namespace) -> None:
     )
 
     if success:
-        print("\nPlain loop completed: no remaining open issues.")
+        print("\nPlain loop completed: no remaining open issues.")  # noqa: T201  # tracked: #288
     else:
-        print(f"\nPlain loop did not complete after {args.max_rounds} rounds.")
+        print(f"\nPlain loop did not complete after {args.max_rounds} rounds.")  # noqa: T201  # tracked: #288
         sys.exit(1)
 
 
@@ -1560,8 +1563,12 @@ def _dispatch(argv: list[str]) -> None:
     invocation = parse_cli_invocation(argv)
     loop_kind, args = invocation.loop_kind, invocation.args
     runner = _LOOP_COMMANDS[loop_kind].run
-    from vibesys.server.events import EventStatus, EventType, RunStartedData
-    from vibesys.server.registry import active_supervisor
+    from vibesys.server.events import (  # noqa: PLC0415  # tracked: #288
+        EventStatus,
+        EventType,
+        RunStartedData,
+    )
+    from vibesys.server.registry import active_supervisor  # noqa: PLC0415  # tracked: #288
 
     supervisor = active_supervisor()
     if supervisor is not None:
@@ -1584,24 +1591,24 @@ def _control_socket_from_argv(argv: list[str]) -> Path | None:
         if token.startswith("--control-socket="):
             value = token.partition("=")[2]
             return Path(value) if value else None
-        if token == "--control-socket" and index + 1 < len(argv):
+        if token == "--control-socket" and index + 1 < len(argv):  # noqa: S105  # tracked: #288
             return Path(argv[index + 1])
     return None
 
 
 def _render_configuration_error(error: ConfigurationError) -> NoReturn:
     diagnostic = error.diagnostic
-    print(f"vibesys: {diagnostic.message}", file=sys.stderr)
+    print(f"vibesys: {diagnostic.message}", file=sys.stderr)  # noqa: T201  # tracked: #288
     if diagnostic.usage:
-        print(diagnostic.usage, file=sys.stderr)
+        print(diagnostic.usage, file=sys.stderr)  # noqa: T201  # tracked: #288
     raise SystemExit(diagnostic.exit_code)
 
 
-def main() -> None:
+def main() -> None:  # noqa: D103  # tracked: #288
     argv = sys.argv[1:]
     control_socket = _control_socket_from_argv(argv)
     if control_socket is not None:
-        from vibesys.server.runtime import run_server
+        from vibesys.server.runtime import run_server  # noqa: PLC0415  # tracked: #288
 
         try:
             run_server(lambda: _dispatch(argv), socket_path=control_socket)

--- a/src/vibesys/profilers.py
+++ b/src/vibesys/profilers.py
@@ -93,7 +93,6 @@ CLI_PROFILER_CHOICES: tuple[ProfilerKind, ...] = tuple(ProfilerKind)
 
 def profiler_definition(kind: ProfilerKind) -> ProfilerDefinition:
     """Return the declaration for a runnable profiler kind."""
-
     kind = require_profiler_kind(kind)
     try:
         return PROFILER_DEFINITIONS[kind]
@@ -103,7 +102,6 @@ def profiler_definition(kind: ProfilerKind) -> ProfilerDefinition:
 
 def coerce_profiler_kind(value: str, *, label: str = "profiler") -> ProfilerKind:
     """Parse a profiler kind and raise a useful error for unknown values."""
-
     try:
         return ProfilerKind(value)
     except ValueError as exc:
@@ -113,7 +111,6 @@ def coerce_profiler_kind(value: str, *, label: str = "profiler") -> ProfilerKind
 
 def require_profiler_kind(value: object, *, label: str = "profiler") -> ProfilerKind:
     """Require an already-parsed profiler enum at internal API boundaries."""
-
     if not isinstance(value, ProfilerKind):
         raise TypeError(f"{label} must be a ProfilerKind, got {type(value).__name__}.")
     return value
@@ -121,7 +118,6 @@ def require_profiler_kind(value: object, *, label: str = "profiler") -> Profiler
 
 def require_domain_name(value: object, *, label: str = "domain") -> DomainName:
     """Require an already-parsed domain enum at internal API boundaries."""
-
     if not isinstance(value, DomainName):
         raise TypeError(f"{label} must be a DomainName, got {type(value).__name__}.")
     return value
@@ -129,7 +125,6 @@ def require_domain_name(value: object, *, label: str = "domain") -> DomainName:
 
 def allowed_profiler_kinds(domain: DomainName) -> frozenset[ProfilerKind]:
     """Profiler kinds allowed by a domain."""
-
     domain_name = require_domain_name(domain)
     return frozenset(
         {ProfilerKind.NONE}
@@ -155,7 +150,6 @@ def resolve_profiler_kind(
     profiler when the host platform has one; LLM-serving workloads pick the
     backend profiler unless the run environment dictates another safe default.
     """
-
     requested_kind = require_profiler_kind(requested, label="requested profiler")
     domain_name = require_domain_name(domain)
     allowed = allowed_profiler_kinds(domain_name)
@@ -272,7 +266,6 @@ def preflight_profiler_kind(kind: ProfilerKind) -> ProfilerPreflightResult:
     profilers run on the local host, so check their command availability before
     the optimization loop starts.
     """
-
     resolved = require_profiler_kind(kind)
     if resolved is ProfilerKind.NONE:
         return ProfilerPreflightResult(resolved, True)

--- a/src/vibesys/profilers.py
+++ b/src/vibesys/profilers.py
@@ -35,19 +35,19 @@ class ProfilerDefinition:
     requires_domain_torch_support: bool = False
 
     @property
-    def support_name(self) -> str:
+    def support_name(self) -> str:  # noqa: D102  # tracked: #288
         return f"{self.kind.value}_profiler"
 
     @property
-    def server_path(self) -> str:
+    def server_path(self) -> str:  # noqa: D102  # tracked: #288
         return f"{self.support_name}/server.py"
 
     @property
-    def prompt_template(self) -> str:
+    def prompt_template(self) -> str:  # noqa: D102  # tracked: #288
         return f"profilers/{self.kind.value}.j2"
 
     @property
-    def mcp_name(self) -> str:
+    def mcp_name(self) -> str:  # noqa: D102  # tracked: #288
         return f"vibesys-{self.kind.value.replace('_', '-')}-profiler"
 
 
@@ -60,7 +60,7 @@ class ProfilerPreflightResult:
     diagnostics: tuple[str, ...] = ()
     details: tuple[str, ...] = ()
 
-    def error_message(self) -> str:
+    def error_message(self) -> str:  # noqa: D102  # tracked: #288
         diagnostic_text = ", ".join(self.diagnostics) or "unknown"
         detail_text = "; ".join(self.details)
         suffix = f" ({detail_text})" if detail_text else ""
@@ -97,7 +97,7 @@ def profiler_definition(kind: ProfilerKind) -> ProfilerDefinition:
     try:
         return PROFILER_DEFINITIONS[kind]
     except KeyError as exc:
-        raise ValueError(f"Profiler {kind.value!r} is not runnable.") from exc
+        raise ValueError(f"Profiler {kind.value!r} is not runnable.") from exc  # noqa: TRY003  # tracked: #288
 
 
 def coerce_profiler_kind(value: str, *, label: str = "profiler") -> ProfilerKind:
@@ -106,20 +106,20 @@ def coerce_profiler_kind(value: str, *, label: str = "profiler") -> ProfilerKind
         return ProfilerKind(value)
     except ValueError as exc:
         choices = ", ".join(kind.value for kind in ProfilerKind)
-        raise ValueError(f"Unknown {label} kind {value!r}; choose from: {choices}.") from exc
+        raise ValueError(f"Unknown {label} kind {value!r}; choose from: {choices}.") from exc  # noqa: TRY003  # tracked: #288
 
 
 def require_profiler_kind(value: object, *, label: str = "profiler") -> ProfilerKind:
     """Require an already-parsed profiler enum at internal API boundaries."""
     if not isinstance(value, ProfilerKind):
-        raise TypeError(f"{label} must be a ProfilerKind, got {type(value).__name__}.")
+        raise TypeError(f"{label} must be a ProfilerKind, got {type(value).__name__}.")  # noqa: TRY003  # tracked: #288
     return value
 
 
 def require_domain_name(value: object, *, label: str = "domain") -> DomainName:
     """Require an already-parsed domain enum at internal API boundaries."""
     if not isinstance(value, DomainName):
-        raise TypeError(f"{label} must be a DomainName, got {type(value).__name__}.")
+        raise TypeError(f"{label} must be a DomainName, got {type(value).__name__}.")  # noqa: TRY003  # tracked: #288
     return value
 
 
@@ -136,7 +136,7 @@ def allowed_profiler_kinds(domain: DomainName) -> frozenset[ProfilerKind]:
     )
 
 
-def resolve_profiler_kind(
+def resolve_profiler_kind(  # noqa: C901, PLR0911, PLR0912  # tracked: #288
     requested: ProfilerKind,
     *,
     domain: DomainName,
@@ -157,7 +157,7 @@ def resolve_profiler_kind(
     if requested_kind is not ProfilerKind.AUTO:
         if requested_kind not in allowed:
             allowed_values = ", ".join(sorted(kind.value for kind in allowed))
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"Profiler {requested_kind.value!r} is not supported for domain "
                 f"{domain_name.value!r}; allowed: {allowed_values}."
             )
@@ -168,7 +168,7 @@ def resolve_profiler_kind(
             supported_values = ", ".join(
                 sorted(kind.value for kind in environment_supported_profiler_kinds)
             )
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"Profiler {requested_kind.value!r} is not supported by the selected "
                 f"run environment; allowed: {supported_values}."
             )
@@ -200,7 +200,7 @@ def resolve_profiler_kind(
         supported_values = ", ".join(
             sorted(kind.value for kind in environment_supported_profiler_kinds)
         )
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003  # tracked: #288
             "No profiler supported by both the generic domain and selected run "
             f"environment; environment allows: {supported_values}."
         )
@@ -241,7 +241,7 @@ def resolve_profiler_kind(
 
     if candidate not in allowed:
         allowed_values = ", ".join(sorted(kind.value for kind in allowed))
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003  # tracked: #288
             f"Resolved profiler {candidate.value!r} is not supported for domain "
             f"{domain_name.value!r}; allowed: {allowed_values}."
         )
@@ -252,7 +252,7 @@ def resolve_profiler_kind(
         supported_values = ", ".join(
             sorted(kind.value for kind in environment_supported_profiler_kinds)
         )
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003  # tracked: #288
             f"Resolved profiler {candidate.value!r} is not supported by the selected "
             f"run environment; allowed: {supported_values}."
         )
@@ -268,7 +268,7 @@ def preflight_profiler_kind(kind: ProfilerKind) -> ProfilerPreflightResult:
     """
     resolved = require_profiler_kind(kind)
     if resolved is ProfilerKind.NONE:
-        return ProfilerPreflightResult(resolved, True)
+        return ProfilerPreflightResult(resolved, True)  # noqa: FBT003  # tracked: #288
     if resolved is ProfilerKind.LINUX_CPU:
         from vibesys.linux_cpu_profiler import (  # noqa: PLC0415
             DiagnosticCode,
@@ -307,4 +307,4 @@ def preflight_profiler_kind(kind: ProfilerKind) -> ProfilerPreflightResult:
             f"sample_path={capability.sample_path or 'missing'}",
         )
         return ProfilerPreflightResult(resolved, usable, diagnostics, details)
-    return ProfilerPreflightResult(resolved, True)
+    return ProfilerPreflightResult(resolved, True)  # noqa: FBT003  # tracked: #288

--- a/src/vibesys/prompts/renderer.py
+++ b/src/vibesys/prompts/renderer.py
@@ -40,7 +40,7 @@ from vibesys.constants import ComputeBackend
 
 PROMPTS_DIR = Path(__file__).resolve().parent
 
-_env = Environment(
+_env = Environment(  # noqa: S701  # tracked: #288
     loader=FileSystemLoader(str(PROMPTS_DIR)),
     keep_trailing_newline=True,
     trim_blocks=True,
@@ -65,7 +65,7 @@ def _build_env(template_dir: Path | str | None = None) -> Environment:
         search_paths = [key]
         if key != str(PROMPTS_DIR):
             search_paths.append(str(PROMPTS_DIR))
-        _env_cache[key] = Environment(
+        _env_cache[key] = Environment(  # noqa: S701  # tracked: #288
             loader=FileSystemLoader(search_paths),
             keep_trailing_newline=True,
             trim_blocks=True,
@@ -118,7 +118,7 @@ class ComputeBackendFragment(ABC):
 
     :meth:`validate` checks the on-disk contract — one ``.j2`` file
     per name in ``NAMES``.
-    """
+    """  # noqa: D205  # tracked: #288
 
     NAMES: ClassVar[frozenset[str]] = frozenset(
         {
@@ -129,7 +129,7 @@ class ComputeBackendFragment(ABC):
     )
     backend: ClassVar[ComputeBackend]  # set by subclasses
 
-    def __init__(self, env: Environment) -> None:
+    def __init__(self, env: Environment) -> None:  # noqa: D107  # tracked: #288
         self._env = env
 
     def render(self, name: str) -> str:
@@ -142,7 +142,7 @@ class ComputeBackendFragment(ABC):
         an extra blank line at every substitution site.
         """
         if name not in self.NAMES:
-            raise ValueError(f"Unknown fragment {name!r}; valid: {sorted(self.NAMES)}")
+            raise ValueError(f"Unknown fragment {name!r}; valid: {sorted(self.NAMES)}")  # noqa: TRY003  # tracked: #288
         return (
             self._env.get_template(f"backend/{self.backend.value}/{name}.j2").render().rstrip("\n")
         )
@@ -155,11 +155,11 @@ class ComputeBackendFragment(ABC):
     def validate(cls) -> None:
         """Verify a ``.j2`` file exists for every fragment in
         :attr:`NAMES`. Raises ``ValueError`` listing missing files.
-        """
+        """  # noqa: D205  # tracked: #288
         backend_dir = PROMPTS_DIR / "backend" / cls.backend.value
         missing = [n for n in cls.NAMES if not (backend_dir / f"{n}.j2").is_file()]
         if missing:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"{cls.__name__}: missing fragment files under {backend_dir}: "
                 f"{', '.join(f'{n}.j2' for n in sorted(missing))}. "
                 f"Use an empty file for a deliberate skip."
@@ -208,7 +208,7 @@ _FRAGMENT_IMPLS: dict[ComputeBackend, type[ComputeBackendFragment]] = {
 def get_backend_fragment(backend: ComputeBackend, env: Environment) -> ComputeBackendFragment:
     """Construct the :class:`ComputeBackendFragment` impl for the given backend."""
     if backend not in _FRAGMENT_IMPLS:
-        raise ValueError(
+        raise ValueError(  # noqa: TRY003  # tracked: #288
             f"No ComputeBackendFragment registered for {backend!r}. "
             f"Registered: {sorted(_FRAGMENT_IMPLS.keys(), key=lambda b: b.value)}"
         )
@@ -238,9 +238,9 @@ class Prompt:
         Hardware backend the run targets. Selects the
         :class:`ComputeBackendFragment` impl whose fragments get
         auto-injected.
-    """
+    """  # noqa: D205  # tracked: #288
 
-    def __init__(self, template_dir: Path | str, backend: ComputeBackend) -> None:
+    def __init__(self, template_dir: Path | str, backend: ComputeBackend) -> None:  # noqa: D107  # tracked: #288
         self._env = _build_env(template_dir)
         self._fragments = get_backend_fragment(backend, self._env)
         type(self._fragments).validate()

--- a/src/vibesys/render/format.py
+++ b/src/vibesys/render/format.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from vibesys.server.events import AgentStatusData
+from vibesys.server.events import AgentStatusData  # noqa: TC001  # tracked: #288
 
 
 def format_token_count(n: int) -> str:
     """Format a token count compactly: ``999`` / ``20k`` / ``1.0M``."""
-    if n < 1_000:
+    if n < 1_000:  # noqa: PLR2004  # tracked: #288
         return str(n)
-    if n < 1_000_000:
+    if n < 1_000_000:  # noqa: PLR2004  # tracked: #288
         return f"{n // 1000}k"
     return f"{n / 1_000_000:.1f}M"
 

--- a/src/vibesys/render/headless.py
+++ b/src/vibesys/render/headless.py
@@ -164,7 +164,7 @@ class HeadlessRenderer:
         self._at_line_start = True
 
     def _render_block(self, content: str) -> None:
-        body = content[:-1] if content.endswith("\n") else content
+        body = content.removesuffix("\n")
         if self.max_text_len is not None and len(body) > self.max_text_len:
             hidden = len(body) - self.max_text_len
             body = f"{body[: self.max_text_len]}\n... [{hidden} more chars, see log for full text]"

--- a/src/vibesys/render/headless.py
+++ b/src/vibesys/render/headless.py
@@ -45,7 +45,7 @@ _PLAIN_STATUS_INDICATORS = {
 class TodoDisplay:
     """Renders a persistent todo list box using ANSI cursor control."""
 
-    def __init__(self, file: TextIO | None = None, *, color: bool = True):
+    def __init__(self, file: TextIO | None = None, *, color: bool = True):  # noqa: ANN204, D107  # tracked: #288
         self._file = file
         self._color = color
         self._prev_lines = 0
@@ -54,7 +54,7 @@ class TodoDisplay:
     def _out(self) -> TextIO:
         return self._file if self._file is not None else sys.stdout
 
-    def update(self, todos: list[TodoItemData]) -> None:
+    def update(self, todos: list[TodoItemData]) -> None:  # noqa: D102  # tracked: #288
         if not todos:
             return
         indicators = _COLOR_STATUS_INDICATORS if self._color else _PLAIN_STATUS_INDICATORS
@@ -65,7 +65,7 @@ class TodoDisplay:
         top = f"┌─ Todo {'─' * (width - 8)}┐"
         bot = f"└{'─' * (width - 1)}┘"
         padded = [line + " " * (width - len(self._strip_ansi(line)) - 1) + "│" for line in items]
-        box = [top] + padded + [bot]
+        box = [top] + padded + [bot]  # noqa: RUF005  # tracked: #288
 
         out = self._out
         # Clear previous block
@@ -96,7 +96,7 @@ class HeadlessRenderer:
     # Maximum chars shown per tool-call argument.
     _MAX_ARG_LEN = 80
 
-    def __init__(
+    def __init__(  # noqa: ANN204, D107  # tracked: #288
         self,
         out: TextIO | None = None,
         *,
@@ -115,7 +115,7 @@ class HeadlessRenderer:
     def _out(self) -> TextIO:
         return self._explicit_out if self._explicit_out is not None else sys.stdout
 
-    def handle(self, event: RunEvent) -> None:
+    def handle(self, event: RunEvent) -> None:  # noqa: D102  # tracked: #288
         data = event.data
         if isinstance(data, AgentOutputChunkData):
             self._render_chunk(data)

--- a/src/vibesys/render/sink.py
+++ b/src/vibesys/render/sink.py
@@ -42,7 +42,7 @@ def _json_safe(args: dict[str, Any]) -> dict[str, Any]:
 class OutputSink:
     """Fan presentation events out to the supervisor and local subscribers."""
 
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # noqa: D107  # tracked: #288
         self._lock = threading.Lock()
         self._subscribers: tuple[EventHandler, ...] = ()
 
@@ -59,7 +59,7 @@ class OutputSink:
 
     # -- semantic emitters ---------------------------------------------------
 
-    def agent_output(
+    def agent_output(  # noqa: D102, PLR0913  # tracked: #288
         self,
         content: str,
         *,
@@ -79,7 +79,7 @@ class OutputSink:
             invocation_id=invocation_id,
         )
 
-    def tool_call(
+    def tool_call(  # noqa: D102, PLR0913  # tracked: #288
         self,
         tool: str,
         args: dict[str, Any],
@@ -98,7 +98,7 @@ class OutputSink:
             invocation_id=invocation_id,
         )
 
-    def tool_result(
+    def tool_result(  # noqa: D102, PLR0913  # tracked: #288
         self,
         tool: str,
         content: str,
@@ -117,7 +117,7 @@ class OutputSink:
             invocation_id=invocation_id,
         )
 
-    def todo_update(
+    def todo_update(  # noqa: D102  # tracked: #288
         self,
         todos: list[TodoItemData],
         *,
@@ -135,7 +135,7 @@ class OutputSink:
             invocation_id=invocation_id,
         )
 
-    def usage_update(
+    def usage_update(  # noqa: D102, PLR0913  # tracked: #288
         self,
         input_tokens: int,
         *,
@@ -164,7 +164,7 @@ class OutputSink:
         round_label: str | None = None,
         invocation_id: str | None = None,
     ) -> None:
-        from vibesys.server.registry import active_supervisor
+        from vibesys.server.registry import active_supervisor  # noqa: PLC0415  # tracked: #288
 
         supervisor = active_supervisor()
         if supervisor is not None:

--- a/src/vibesys/repository.py
+++ b/src/vibesys/repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime
 from enum import StrEnum
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 from pydantic import BaseModel, ConfigDict
 

--- a/src/vibesys/run/__init__.py
+++ b/src/vibesys/run/__init__.py
@@ -28,10 +28,10 @@ __all__ = [
     "GitTracker",
     "InputProjectSpec",
     "LoopContext",
+    "RepositoryVisibility",
     "RunCommands",
     "RunLogger",
     "RunPaths",
-    "RepositoryVisibility",
     "Workspace",
     "WorkspaceStep",
 ]

--- a/src/vibesys/run/device.py
+++ b/src/vibesys/run/device.py
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
     from vibesys.sandbox.run_environment import RunEnvironmentView
 
 
-class DeviceLease:
-    def __init__(
+class DeviceLease:  # noqa: D101  # tracked: #288
+    def __init__(  # noqa: D107  # tracked: #288
         self,
         backend: "ComputeBackendImpl",
         *,
@@ -32,7 +32,7 @@ class DeviceLease:
         self.monitor: ContentionMonitor | None = None
 
     @property
-    def selected_device(self):
+    def selected_device(self):  # noqa: ANN201, D102  # tracked: #288
         return getattr(self._backend, "selected_device", None)
 
     def start_monitor(self) -> None:
@@ -82,10 +82,10 @@ class DeviceLease:
 
         data["contention_detected"] = contention_events > 0
         data["contention_events"] = contention_events
-        data["finished_at"] = datetime.now().isoformat()
+        data["finished_at"] = datetime.now().isoformat()  # noqa: DTZ005  # tracked: #288
         gpu_json.write_text(json.dumps(data, indent=2))
 
-    def close(self) -> None:
+    def close(self) -> None:  # noqa: D102  # tracked: #288
         if self.monitor is not None:
             self.monitor.stop()
         self._finalize_metadata()

--- a/src/vibesys/run/experiment_repo.py
+++ b/src/vibesys/run/experiment_repo.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import os
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 from vibesys.repository import REPOSITORY_SLUG, RepositoryVisibility
 from vs_github import GitHubCLI
@@ -26,7 +26,7 @@ class ExperimentRepository:
     log: Callable[[str], None]
     github: GitHubCLI = field(default_factory=GitHubCLI)
 
-    _GIT_IDENTITY = {
+    _GIT_IDENTITY = {  # noqa: RUF012  # tracked: #288
         "GIT_AUTHOR_NAME": "vibesys",
         "GIT_AUTHOR_EMAIL": "vibesys@local",
         "GIT_COMMITTER_NAME": "vibesys",
@@ -36,9 +36,9 @@ class ExperimentRepository:
     def create_remote(self, slug: str, visibility: RepositoryVisibility) -> None:
         """Create a GitHub repository and attach it as ``origin``."""
         if not REPOSITORY_SLUG.fullmatch(slug):
-            raise ValueError(f"--repo must be a GitHub OWNER/NAME pair, got {slug!r}")
+            raise ValueError(f"--repo must be a GitHub OWNER/NAME pair, got {slug!r}")  # noqa: TRY003  # tracked: #288
         if self.has_origin():
-            raise ValueError(f"experiment repository already has an origin remote: {self.root}")
+            raise ValueError(f"experiment repository already has an origin remote: {self.root}")  # noqa: TRY003  # tracked: #288
 
         self._ensure_gitignore()
         self.github.create_repository(
@@ -95,7 +95,7 @@ class ExperimentRepository:
     ) -> subprocess.CompletedProcess[str]:
         env = {**os.environ, **self._GIT_IDENTITY}
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # noqa: PLW1510, S603  # tracked: #288
                 command,
                 cwd=self.root,
                 capture_output=True,
@@ -103,8 +103,8 @@ class ExperimentRepository:
                 env=env,
             )
         except FileNotFoundError as exc:
-            raise RuntimeError(f"{tool} is required for experiment repository tracking") from exc
+            raise RuntimeError(f"{tool} is required for experiment repository tracking") from exc  # noqa: TRY003  # tracked: #288
         if check and result.returncode != 0:
             detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
-            raise RuntimeError(f"{tool} command failed ({' '.join(command)}): {detail}")
+            raise RuntimeError(f"{tool} command failed ({' '.join(command)}): {detail}")  # noqa: TRY003  # tracked: #288
         return result

--- a/src/vibesys/run/git_tracker.py
+++ b/src/vibesys/run/git_tracker.py
@@ -294,7 +294,7 @@ class GitTracker:
         preserved: dict[Path, bytes] = {}
         for raw_path in paths:
             relative = Path(raw_path)
-            if relative.is_absolute() or relative == Path(".") or ".." in relative.parts:
+            if relative.is_absolute() or relative == Path() or ".." in relative.parts:
                 raise ValueError(f"preserved path must be workspace-relative: {raw_path}")
             source = self.root / relative
             if source.is_file():

--- a/src/vibesys/run/git_tracker.py
+++ b/src/vibesys/run/git_tracker.py
@@ -24,7 +24,7 @@ class GitTracker:
     loop-specific git plumbing that has no dedicated method yet.
     """
 
-    _GIT_ENV_STATIC = {
+    _GIT_ENV_STATIC = {  # noqa: RUF012  # tracked: #288
         "GIT_AUTHOR_NAME": "vibesys",
         "GIT_AUTHOR_EMAIL": "vibesys@local",
         "GIT_COMMITTER_NAME": "vibesys",
@@ -55,7 +55,7 @@ class GitTracker:
         "_evaluator",
     )
 
-    def __init__(
+    def __init__(  # noqa: D107  # tracked: #288
         self,
         root: Path,
         *,
@@ -74,7 +74,7 @@ class GitTracker:
         self._exclude_file = self.root.parent / ".vibesys-git-excludes" / self.root.name
 
     @property
-    def _GIT_ENV(self) -> dict[str, str]:
+    def _GIT_ENV(self) -> dict[str, str]:  # noqa: N802  # tracked: #288
         """Git env pinned to the repository selected during initialization."""
         safe_directory = self._work_tree or self.root
         config = (
@@ -99,7 +99,7 @@ class GitTracker:
         """Run a git command in the workspace, logging stderr on failure."""
         if env is None:
             env = {**os.environ, **self._GIT_ENV}
-        result = subprocess.run(cmd, cwd=self.root, capture_output=True, env=env)
+        result = subprocess.run(cmd, cwd=self.root, capture_output=True, env=env)  # noqa: PLW1510, S603  # tracked: #288
         if check and result.returncode != 0:
             stderr = result.stderr.decode(errors="replace").strip()
             self._log(f"[git-tracking] command failed: {' '.join(cmd)}")
@@ -107,7 +107,7 @@ class GitTracker:
             result.check_returncode()
         return result
 
-    def init(self, existing: bool, *, trusted_input_baseline: str | None = None) -> None:
+    def init(self, existing: bool, *, trusted_input_baseline: str | None = None) -> None:  # noqa: FBT001  # tracked: #288
         """Initialize or validate Git tracking for the unified workspace.
 
         Experiment directories are themselves Git repositories. When the
@@ -117,7 +117,7 @@ class GitTracker:
         """
         if existing:
             if not self._inside_work_tree():
-                raise ValueError(
+                raise ValueError(  # noqa: TRY003  # tracked: #288
                     f"--git-tracking with --resume but no git repository in {self.root}"
                 )
             self._bind_repository()
@@ -131,7 +131,7 @@ class GitTracker:
             return
 
         if trusted_input_baseline is not None:
-            raise ValueError("trusted input baseline is only valid when resuming a run")
+            raise ValueError("trusted input baseline is only valid when resuming a run")  # noqa: TRY003  # tracked: #288
 
         if not self._inside_work_tree():
             self.run(["git", "init"])
@@ -202,7 +202,7 @@ class GitTracker:
             if result.returncode != 0:
                 return None
             return result.stdout.decode(errors="replace").strip()
-        except Exception:
+        except Exception:  # noqa: BLE001  # tracked: #288
             return None
 
     @property
@@ -239,7 +239,7 @@ class GitTracker:
         return sorted(
             line[3:].removeprefix(prefix) if prefix else line[3:]
             for line in result.stdout.decode(errors="replace").splitlines()
-            if len(line) > 3
+            if len(line) > 3  # noqa: PLR2004  # tracked: #288
         )
 
     def checkout_tree(
@@ -277,11 +277,11 @@ class GitTracker:
             if clean:
                 self.run(["git", "clean", "-fd", "--", "."], check=False)
             self._restore_preserved_paths(preserved)
-            return True
-        except Exception as exc:
+            return True  # noqa: TRY300  # tracked: #288
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             try:
                 self._restore_preserved_paths(preserved)
-            except Exception as preserve_exc:
+            except Exception as preserve_exc:  # noqa: BLE001  # tracked: #288
                 self._log(
                     "[warn] failed to restore preserved workspace memory after "
                     f"tree restore error: {preserve_exc}"
@@ -295,7 +295,7 @@ class GitTracker:
         for raw_path in paths:
             relative = Path(raw_path)
             if relative.is_absolute() or relative == Path() or ".." in relative.parts:
-                raise ValueError(f"preserved path must be workspace-relative: {raw_path}")
+                raise ValueError(f"preserved path must be workspace-relative: {raw_path}")  # noqa: TRY003  # tracked: #288
             source = self.root / relative
             if source.is_file():
                 preserved[relative] = source.read_bytes()
@@ -358,7 +358,7 @@ class GitTracker:
         changes.update(
             workspace_relative(line[3:])
             for line in pending.stdout.decode(errors="replace").splitlines()
-            if len(line) > 3
+            if len(line) > 3  # noqa: PLR2004  # tracked: #288
         )
         return sorted(changes)
 
@@ -374,14 +374,14 @@ class GitTracker:
             check=False,
         )
         if resolved.returncode != 0:
-            raise ValueError(f"trusted input baseline {revision!r} is not a commit")
+            raise ValueError(f"trusted input baseline {revision!r} is not a commit")  # noqa: TRY003  # tracked: #288
         commit = resolved.stdout.decode(errors="replace").strip()
         ancestor = self.run(
             ["git", "merge-base", "--is-ancestor", commit, "HEAD"],
             check=False,
         )
         if ancestor.returncode != 0:
-            raise ValueError(f"trusted input baseline {revision!r} is not an ancestor of HEAD")
+            raise ValueError(f"trusted input baseline {revision!r} is not an ancestor of HEAD")  # noqa: TRY003  # tracked: #288
         return commit
 
     def _workspace_gitignore(self) -> str:
@@ -423,14 +423,14 @@ class GitTracker:
             for d in dirnames:
                 if d in ignored_dirs:
                     continue
-                full = os.path.join(dirpath, d)
+                full = os.path.join(dirpath, d)  # noqa: PTH118  # tracked: #288
                 if os.access(full, os.R_OK | os.X_OK):
                     kept.append(d)
                 else:
                     unreadable.append(os.path.relpath(full, root))
             dirnames[:] = kept  # prune unsearchable dirs from the walk
             for f in filenames:
-                full = os.path.join(dirpath, f)
+                full = os.path.join(dirpath, f)  # noqa: PTH118  # tracked: #288
                 if not os.access(full, os.R_OK):
                     unreadable.append(os.path.relpath(full, root))
         return unreadable
@@ -444,7 +444,7 @@ class GitTracker:
         """
         paths: list[str] = []
         for m in re.finditer(r'(?:open\("|unable to index file \')([^"\']+)', stderr):
-            paths.append(m.group(1))
+            paths.append(m.group(1))  # noqa: PERF401  # tracked: #288
         return paths
 
     def _exclude_paths(self, rel_paths: list[str]) -> None:
@@ -462,7 +462,7 @@ class GitTracker:
             return
         prefix = "" if (not existing or existing.endswith("\n")) else "\n"
         exclude_file.write_text(existing + prefix + "\n".join(new) + "\n")
-        shown = ", ".join(new[:5]) + ("…" if len(new) > 5 else "")
+        shown = ", ".join(new[:5]) + ("…" if len(new) > 5 else "")  # noqa: PLR2004  # tracked: #288
         self._log(f"[git-tracking] excluded {len(new)} unreadable path(s) from snapshot: {shown}")
 
     def _add_all(self) -> None:

--- a/src/vibesys/run/logger.py
+++ b/src/vibesys/run/logger.py
@@ -33,11 +33,11 @@ class _TeeWriter:
         self._secondary.write(strip_ansi(text))
         return len(text)
 
-    def flush(self):
+    def flush(self):  # noqa: ANN202  # tracked: #288
         self._primary.flush()
         self._secondary.flush()
 
-    def isatty(self):
+    def isatty(self):  # noqa: ANN202  # tracked: #288
         return False
 
 
@@ -87,11 +87,11 @@ class RunLogger:
     global handle. A no-tee logger's ``switch``/``close`` leave stderr alone.
     """
 
-    def __init__(self, log_dir: Path, *, tee_stderr: bool = True) -> None:
+    def __init__(self, log_dir: Path, *, tee_stderr: bool = True) -> None:  # noqa: D107  # tracked: #288
         self.log_dir = log_dir
         self._tee_stderr = tee_stderr
         self._lock = threading.RLock()
-        run_started = datetime.now().strftime("%Y%m%d-%H%M%S")
+        run_started = datetime.now().strftime("%Y%m%d-%H%M%S")  # noqa: DTZ005  # tracked: #288
         self.path = log_dir / f"run-{run_started}.log"
         self.file = self.path.open("a", encoding="utf-8")
         self.writer = cast(
@@ -116,10 +116,10 @@ class RunLogger:
         with self._lock:
             return self.file.closed
 
-    def lprint(self, text: str) -> None:
+    def lprint(self, text: str) -> None:  # noqa: D102  # tracked: #288
         log_and_print(text, self.writer)
 
-    def switch(self, label: int | str):
+    def switch(self, label: int | str):  # noqa: ANN201  # tracked: #288
         """Switch to a per-phase log file (``run-<datetime>-<label>.log``).
 
         *label* is stringified into the file name.  Integer labels get a
@@ -135,7 +135,7 @@ class RunLogger:
         with self._lock:
             previous_file = self.file
             previous_file.flush()
-            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+            ts = datetime.now().strftime("%Y%m%d-%H%M%S")  # noqa: DTZ005  # tracked: #288
             suffix = f"step{label}" if isinstance(label, int) else label
             new_path = self.log_dir / f"run-{ts}-{suffix}.log"
             new_file = new_path.open("a", encoding="utf-8")
@@ -144,7 +144,7 @@ class RunLogger:
             previous_file.close()
             return new_file
 
-    def close(self) -> None:
+    def close(self) -> None:  # noqa: D102  # tracked: #288
         with self._lock:
             if self._stderr_tee is not None and sys.stderr is self._stderr_tee:
                 sys.stderr = self._original_stderr

--- a/src/vibesys/run/logger.py
+++ b/src/vibesys/run/logger.py
@@ -95,7 +95,7 @@ class RunLogger:
         self.path = log_dir / f"run-{run_started}.log"
         self.file = self.path.open("a", encoding="utf-8")
         self.writer = cast(
-            TextIO,
+            "TextIO",
             _CurrentLogWriter(self._write_current, self._flush_current, self._current_closed),
         )
         self._original_stderr = sys.stderr

--- a/src/vibesys/run/protocol.py
+++ b/src/vibesys/run/protocol.py
@@ -23,7 +23,7 @@ from vibesys.run.git_tracker import GitTracker
 T = TypeVar("T", bound=BaseModel)
 
 
-class LoopContext(Protocol):
+class LoopContext(Protocol):  # noqa: D101  # tracked: #288
     # -- run identity / configuration -----------------------------------------
     backend: ComputeBackend
     model_name: str
@@ -43,39 +43,39 @@ class LoopContext(Protocol):
 
     # -- paths ----------------------------------------------------------------
     @property
-    def exp_dir(self) -> Path: ...
+    def exp_dir(self) -> Path: ...  # noqa: D102  # tracked: #288
 
     @property
-    def log_dir(self) -> Path: ...
+    def log_dir(self) -> Path: ...  # noqa: D102  # tracked: #288
 
     @property
-    def workspace(self) -> Path: ...
+    def workspace(self) -> Path: ...  # noqa: D102  # tracked: #288
 
     @property
-    def run_log_path(self) -> Path: ...
+    def run_log_path(self) -> Path: ...  # noqa: D102  # tracked: #288
 
     @property
-    def skill_source_paths(self) -> list[Path]: ...
+    def skill_source_paths(self) -> list[Path]: ...  # noqa: D102  # tracked: #288
 
     # -- agent-facing commands ------------------------------------------------
     @property
-    def objective_location(self) -> str: ...
+    def objective_location(self) -> str: ...  # noqa: D102  # tracked: #288
 
     @property
-    def judge_accuracy_command(self) -> str | None: ...
+    def judge_accuracy_command(self) -> str | None: ...  # noqa: D102  # tracked: #288
 
     @property
-    def judge_benchmark_command(self) -> str | None: ...
+    def judge_benchmark_command(self) -> str | None: ...  # noqa: D102  # tracked: #288
 
     @property
-    def profiler_benchmark_command(self) -> str | None: ...
+    def profiler_benchmark_command(self) -> str | None: ...  # noqa: D102  # tracked: #288
 
     # -- services -------------------------------------------------------------
-    def lprint(self, text: str) -> None: ...
+    def lprint(self, text: str) -> None: ...  # noqa: D102  # tracked: #288
 
-    def switch_log_file(self, label: int | str) -> None: ...
+    def switch_log_file(self, label: int | str) -> None: ...  # noqa: D102  # tracked: #288
 
-    def invoke(
+    def invoke(  # noqa: D102, PLR0913  # tracked: #288
         self,
         *,
         kind: str,
@@ -85,17 +85,17 @@ class LoopContext(Protocol):
         fallback_factory: Callable[[], T],
         round_label: str = "",
         progress: AgentProgress | None = None,
-        **extra: Any,
+        **extra: Any,  # noqa: ANN401  # tracked: #288
     ) -> T: ...
 
-    def progress(self, progress: AgentProgress) -> AbstractContextManager[None]: ...
+    def progress(self, progress: AgentProgress) -> AbstractContextManager[None]: ...  # noqa: D102  # tracked: #288
 
-    def snapshot_workspace(self, label: str) -> None: ...
+    def snapshot_workspace(self, label: str) -> None: ...  # noqa: D102  # tracked: #288
 
-    def trusted_input_changes(self) -> list[str]: ...
+    def trusted_input_changes(self) -> list[str]: ...  # noqa: D102  # tracked: #288
 
-    def reselect_gpu(self) -> None: ...
+    def reselect_gpu(self) -> None: ...  # noqa: D102  # tracked: #288
 
-    def wait_for_debug(self, step: str) -> None: ...
+    def wait_for_debug(self, step: str) -> None: ...  # noqa: D102  # tracked: #288
 
-    def close(self) -> None: ...
+    def close(self) -> None: ...  # noqa: D102  # tracked: #288

--- a/src/vibesys/run/workspace.py
+++ b/src/vibesys/run/workspace.py
@@ -105,7 +105,7 @@ WorkspaceStep = CopySpec | InputProjectSpec | GitSourceSpec
 class Workspace:
     """The unified run workspace and every rule for populating it."""
 
-    def __init__(
+    def __init__(  # noqa: D107, PLR0913  # tracked: #288
         self,
         root: Path,
         *,
@@ -124,7 +124,7 @@ class Workspace:
         self._log = log
         self._project_root = project_root
 
-    def create(self) -> None:
+    def create(self) -> None:  # noqa: D102  # tracked: #288
         self.root.mkdir(parents=True, exist_ok=True)
 
     def repair(self) -> None:
@@ -141,7 +141,7 @@ class Workspace:
 
     # -- setup planning -------------------------------------------------------
 
-    def plan_setup(
+    def plan_setup(  # noqa: C901, PLR0912, PLR0913  # tracked: #288
         self,
         *,
         existing: bool,
@@ -184,7 +184,7 @@ class Workspace:
             if seed is not None:
                 steps.append(CopySpec(src=seed, dest=self.root, respect_gitignore=True))
             for source in workspace_sources:
-                steps.append(GitSourceSpec(source=source))
+                steps.append(GitSourceSpec(source=source))  # noqa: PERF401  # tracked: #288
             # When the workspace is pre-populated (seed and/or git sources),
             # the input copy must not clear existing children: copy_dir wipes
             # the destination unless collisions are rejected, which would
@@ -218,7 +218,7 @@ class Workspace:
                 )
 
             for src in skill_sources:
-                steps.append(CopySpec(src=src, dest=self.root / src.name, prune_platforms=True))
+                steps.append(CopySpec(src=src, dest=self.root / src.name, prune_platforms=True))  # noqa: PERF401  # tracked: #288
 
             if input_project_dir is not None:
                 steps.append(InputProjectSpec(project_dir=input_project_dir))
@@ -279,11 +279,11 @@ class Workspace:
         try:
             dest.resolve().relative_to(self.root.resolve())
         except ValueError as exc:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"workspace source {source.name!r} escapes workspace: {source.dest}"
             ) from exc
         if dest.exists() or dest.is_symlink():
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"workspace source destination already exists for {source.name!r}: {source.dest}"
             )
         # Excluded names match at any depth (copy ignores, git info/exclude,
@@ -291,7 +291,7 @@ class Workspace:
         # snapshots and sandboxes even though the clone succeeds.
         colliding = [part for part in Path(source.dest).parts if part in self.excluded_dirs]
         if colliding:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"workspace source {source.name!r} dest {source.dest!r} contains excluded "
                 f"path component(s) {colliding}: files under it would be invisible to "
                 "workspace copies, git tracking, and sandbox uploads. Pick another dest."
@@ -303,7 +303,7 @@ class Workspace:
         actual = self._run_git(["rev-parse", "HEAD"], cwd=dest).strip().lower()
         expected = source.commit.lower()
         if actual != expected and not actual.startswith(expected):
-            raise RuntimeError(
+            raise RuntimeError(  # noqa: TRY003  # tracked: #288
                 f"workspace source {source.name!r} checked out {actual}, expected {expected}"
             )
 
@@ -328,8 +328,8 @@ class Workspace:
 
     @staticmethod
     def _run_git(args: list[str], *, cwd: Path) -> str:
-        result = subprocess.run(
-            ["git", *args],
+        result = subprocess.run(  # noqa: S603  # tracked: #288
+            ["git", *args],  # noqa: S607  # tracked: #288
             cwd=cwd,
             check=False,
             capture_output=True,
@@ -337,7 +337,7 @@ class Workspace:
         )
         if result.returncode != 0:
             detail = result.stderr.strip() or result.stdout.strip()
-            raise RuntimeError(f"git {' '.join(args)} failed: {detail}")
+            raise RuntimeError(f"git {' '.join(args)} failed: {detail}")  # noqa: TRY003  # tracked: #288
         return result.stdout
 
     # -- copy machinery -------------------------------------------------------
@@ -369,7 +369,7 @@ class Workspace:
                     path.unlink()
                     marker.write_text(str(target))
 
-    def copy_dir(
+    def copy_dir(  # noqa: C901, D102, PLR0912, PLR0913, PLR0915  # tracked: #288
         self,
         src: Path,
         dst: Path,
@@ -422,7 +422,7 @@ class Workspace:
             )
             if collisions:
                 paths = ", ".join(collisions)
-                raise ValueError(f"workspace seed and input bundle contain the same paths: {paths}")
+                raise ValueError(f"workspace seed and input bundle contain the same paths: {paths}")  # noqa: TRY003  # tracked: #288
 
         if dst.exists() and not reject_collisions:
             # Remove children individually so we can skip mount points and
@@ -459,7 +459,7 @@ class Workspace:
                     continue
             try:
                 if child.is_symlink():
-                    os.symlink(os.readlink(child), child_dst)
+                    os.symlink(os.readlink(child), child_dst)  # noqa: PTH115, PTH211  # tracked: #288
                 elif child.is_dir():
                     shutil.copytree(child, child_dst, symlinks=True, ignore=_ignore)
                 else:
@@ -477,8 +477,8 @@ class Workspace:
     @staticmethod
     def _source_gitignored_paths(src: Path) -> frozenset[tuple[str, ...]]:
         """Return untracked paths ignored by Git below ``src``."""
-        result = subprocess.run(
-            [
+        result = subprocess.run(  # noqa: S603  # tracked: #288
+            [  # noqa: S607  # tracked: #288
                 "git",
                 "-C",
                 str(src),
@@ -494,7 +494,7 @@ class Workspace:
         )
         if result.returncode != 0:
             detail = result.stderr.decode(errors="replace").strip()
-            raise RuntimeError(f"could not evaluate Git ignores for workspace.seed: {detail}")
+            raise RuntimeError(f"could not evaluate Git ignores for workspace.seed: {detail}")  # noqa: TRY003  # tracked: #288
         return frozenset(
             Path(os.fsdecode(raw).rstrip("/")).parts for raw in result.stdout.split(b"\0") if raw
         )

--- a/src/vibesys/run/workspace.py
+++ b/src/vibesys/run/workspace.py
@@ -275,7 +275,6 @@ class Workspace:
 
     def materialize_git_source(self, source: WorkspaceSource) -> None:
         """Clone a pinned git source into the workspace and optionally strip ``.git``."""
-
         dest = self.root / source.dest
         try:
             dest.resolve().relative_to(self.root.resolve())
@@ -478,7 +477,6 @@ class Workspace:
     @staticmethod
     def _source_gitignored_paths(src: Path) -> frozenset[tuple[str, ...]]:
         """Return untracked paths ignored by Git below ``src``."""
-
         result = subprocess.run(
             [
                 "git",

--- a/src/vibesys/sandbox/modal_evaluator.py
+++ b/src/vibesys/sandbox/modal_evaluator.py
@@ -19,7 +19,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Generator, Sequence
+from collections.abc import Generator, Sequence  # noqa: TC003  # tracked: #288
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,8 +30,8 @@ _MODAL_DEPLOYMENT = re.compile(
     r"https://modal\.com/apps/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/deployed/"
     r"([a-zA-Z0-9_.-]+)"
 )
-_LOCK_PATH = "/tmp/vibesys-modal-evaluator.lock"
-_DEPLOYMENT_LEASE_PATH = Path("/tmp/vibesys-modal-evaluator-deployment.json")
+_LOCK_PATH = "/tmp/vibesys-modal-evaluator.lock"  # noqa: S108  # tracked: #288
+_DEPLOYMENT_LEASE_PATH = Path("/tmp/vibesys-modal-evaluator-deployment.json")  # noqa: S108  # tracked: #288
 _CANDIDATE_REVISION_ENV = "VIBESYS_CANDIDATE_REVISION"
 _RELEASE_DEPLOYMENT_ENV = "VIBESYS_RELEASE_MODAL_DEPLOYMENT"
 _MAX_DIAGNOSTIC_CHARS = 20_000
@@ -57,7 +57,7 @@ def _compact_rich_output(output: str) -> str:
 @contextmanager
 def _exclusive_evaluation() -> Generator[None]:
     """Serialize deploy-and-evaluate callers sharing the editor container."""
-    with open(_LOCK_PATH, "w") as lock_file:
+    with open(_LOCK_PATH, "w") as lock_file:  # noqa: PTH123  # tracked: #288
         fcntl.flock(lock_file, fcntl.LOCK_EX)
         try:
             yield
@@ -73,7 +73,7 @@ def extract_modal_web_url(output: str) -> str:
     compact = _compact_rich_output(output)
     matches = _MODAL_WEB_URL.findall(compact)
     if not matches:
-        raise ValueError("modal deploy did not print a *.modal.run web endpoint")
+        raise ValueError("modal deploy did not print a *.modal.run web endpoint")  # noqa: TRY003  # tracked: #288
     return matches[-1]
 
 
@@ -82,15 +82,15 @@ def extract_modal_app_identifier(output: str) -> str:
     compact = _compact_rich_output(output)
     matches = _MODAL_DEPLOYMENT.findall(compact)
     if not matches:
-        raise ValueError("modal deploy did not print a deployment URL")
+        raise ValueError("modal deploy did not print a deployment URL")  # noqa: TRY003  # tracked: #288
     return matches[-1]
 
 
 def recent_modal_logs(app_identifier: str, *, workspace: str) -> str:
     """Fetch a bounded recent-log excerpt for a failed readiness check."""
     try:
-        result = subprocess.run(
-            [
+        result = subprocess.run(  # noqa: S603  # tracked: #288
+            [  # noqa: S607  # tracked: #288
                 "uv",
                 "run",
                 "modal",
@@ -127,21 +127,21 @@ def wait_for_health(base_url: str, *, timeout_seconds: float) -> None:
     last_error = "no response"
     while time.monotonic() < deadline:
         try:
-            with urllib.request.urlopen(health_url, timeout=10) as response:
-                if response.status == 200:
+            with urllib.request.urlopen(health_url, timeout=10) as response:  # noqa: S310  # tracked: #288
+                if response.status == 200:  # noqa: PLR2004  # tracked: #288
                     return
                 last_error = f"HTTP {response.status}"
         except (OSError, urllib.error.URLError) as exc:
             last_error = f"{type(exc).__name__}: {exc}"
         time.sleep(2)
-    raise TimeoutError(f"{health_url} did not become ready: {last_error}")
+    raise TimeoutError(f"{health_url} did not become ready: {last_error}")  # noqa: TRY003  # tracked: #288
 
 
 def _healthy_now(base_url: str) -> bool:
     """Return whether an existing deployment is immediately reusable."""
     try:
-        with urllib.request.urlopen(f"{base_url.rstrip('/')}/health", timeout=5) as response:
-            return response.status == 200
+        with urllib.request.urlopen(f"{base_url.rstrip('/')}/health", timeout=5) as response:  # noqa: S310  # tracked: #288
+            return response.status == 200  # noqa: PLR2004  # tracked: #288
     except (OSError, urllib.error.URLError):
         return False
 
@@ -184,8 +184,8 @@ def _release_requested() -> bool:
 def _stop_modal_app(app_identifier: str, *, workspace: str) -> bool:
     """Stop a deployed app without prompting, returning whether it succeeded."""
     try:
-        result = subprocess.run(
-            ["uv", "run", "modal", "app", "stop", app_identifier, "--yes"],
+        result = subprocess.run(  # noqa: S603  # tracked: #288
+            ["uv", "run", "modal", "app", "stop", app_identifier, "--yes"],  # noqa: S607  # tracked: #288
             cwd=workspace,
             capture_output=True,
             text=True,
@@ -193,16 +193,16 @@ def _stop_modal_app(app_identifier: str, *, workspace: str) -> bool:
             timeout=60,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
-        print(
+        print(  # noqa: T201  # tracked: #288
             f"Could not stop Modal app {app_identifier}: {type(exc).__name__}: {exc}",
             file=sys.stderr,
         )
         return False
     if result.returncode == 0:
-        print(f"Stopped Modal app {app_identifier}.", file=sys.stderr)
+        print(f"Stopped Modal app {app_identifier}.", file=sys.stderr)  # noqa: T201  # tracked: #288
         return True
     output = f"{result.stdout}\n{result.stderr}".strip()
-    print(
+    print(  # noqa: T201  # tracked: #288
         f"Could not stop Modal app {app_identifier} (exit {result.returncode}): {output[-2000:]}",
         file=sys.stderr,
     )
@@ -224,7 +224,7 @@ def run_evaluator(
 ) -> int:
     """Deploy the candidate and run ``command`` against its live URL."""
     if not command:
-        raise ValueError("missing evaluator command after '--'")
+        raise ValueError("missing evaluator command after '--'")  # noqa: TRY003  # tracked: #288
 
     with _exclusive_evaluation():
         return _run_evaluator_unlocked(
@@ -234,7 +234,7 @@ def run_evaluator(
         )
 
 
-def _run_evaluator_unlocked(
+def _run_evaluator_unlocked(  # noqa: C901, PLR0912  # tracked: #288
     command: Sequence[str],
     *,
     workspace: str,
@@ -245,13 +245,13 @@ def _run_evaluator_unlocked(
         lease = _read_deployment_lease()
         if lease is not None:
             if lease.candidate_revision == candidate_revision and _healthy_now(lease.base_url):
-                print(
+                print(  # noqa: T201  # tracked: #288
                     "Reusing healthy Modal deployment for candidate revision "
                     f"{candidate_revision}.",
                     file=sys.stderr,
                 )
                 try:
-                    result = subprocess.run(
+                    result = subprocess.run(  # noqa: S603  # tracked: #288
                         [*command, "--url", lease.base_url],
                         cwd=workspace,
                         check=False,
@@ -262,8 +262,8 @@ def _run_evaluator_unlocked(
                         _retire_deployment(lease, workspace=workspace)
             _retire_deployment(lease, workspace=workspace)
 
-    deploy = subprocess.run(
-        ["uv", "run", "modal", "deploy", f"{workspace}/main.py"],
+    deploy = subprocess.run(  # noqa: S603  # tracked: #288
+        ["uv", "run", "modal", "deploy", f"{workspace}/main.py"],  # noqa: S607  # tracked: #288
         cwd=workspace,
         capture_output=True,
         text=True,
@@ -271,26 +271,26 @@ def _run_evaluator_unlocked(
     )
     deploy_output = f"{deploy.stdout}\n{deploy.stderr}".strip()
     if deploy_output:
-        print(deploy_output, file=sys.stderr)
+        print(deploy_output, file=sys.stderr)  # noqa: T201  # tracked: #288
     if deploy.returncode != 0:
         return deploy.returncode
 
     app_identifier: str | None = None
     try:
         base_url = extract_modal_web_url(deploy_output)
-        try:
+        try:  # noqa: SIM105  # tracked: #288
             app_identifier = extract_modal_app_identifier(deploy_output)
         except ValueError:
             pass
         wait_for_health(base_url, timeout_seconds=readiness_timeout_seconds)
     except (TimeoutError, ValueError) as exc:
-        print(f"Modal evaluator setup failed: {exc}", file=sys.stderr)
+        print(f"Modal evaluator setup failed: {exc}", file=sys.stderr)  # noqa: T201  # tracked: #288
         try:
             app_identifier = extract_modal_app_identifier(deploy_output)
         except ValueError:
             pass
         else:
-            print(
+            print(  # noqa: T201  # tracked: #288
                 f"Recent Modal logs:\n{recent_modal_logs(app_identifier, workspace=workspace)}",
                 file=sys.stderr,
             )
@@ -301,7 +301,7 @@ def _run_evaluator_unlocked(
         _write_deployment_lease(candidate_revision, base_url, app_identifier)
 
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603  # tracked: #288
             [*command, "--url", base_url],
             cwd=workspace,
             check=False,
@@ -328,7 +328,7 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:  # noqa: D103  # tracked: #288
     args = _parser().parse_args(argv)
     command = list(args.command)
     if command[:1] == ["--"]:

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -30,19 +30,19 @@ import os
 import shlex
 import subprocess
 import sys
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Protocol
 
-from deepagents.backends.protocol import SandboxBackendProtocol
-from deepagents.backends.sandbox import BaseSandbox
+from deepagents.backends.protocol import SandboxBackendProtocol  # noqa: TC002  # tracked: #288
+from deepagents.backends.sandbox import BaseSandbox  # noqa: TC002  # tracked: #288
 
 from vibesys.backends import SandboxKind
-from vibesys.backends.base import ComputeBackendImpl, SetupFn
+from vibesys.backends.base import ComputeBackendImpl, SetupFn  # noqa: TC001  # tracked: #288
 from vibesys.constants import DEFAULT_AGENT_BACKEND, PROJECT_ROOT
-from vibesys.domains.environment import EnvironmentBindMount
-from vibesys.input_manifest import WorkspaceSource
+from vibesys.domains.environment import EnvironmentBindMount  # noqa: TC001  # tracked: #288
+from vibesys.input_manifest import WorkspaceSource  # noqa: TC001  # tracked: #288
 from vibesys.profilers import ProfilerKind
 
 
@@ -106,7 +106,7 @@ class CandidateRuntime:
 
 
 @dataclass(frozen=True)
-class RunEnvironmentRequest:
+class RunEnvironmentRequest:  # noqa: D101  # tracked: #288
     log_dir: Path
     workspace: Path
     ref_dir: Path | None
@@ -125,27 +125,27 @@ class RunEnvironmentRequest:
     project_root: Path = PROJECT_ROOT
 
 
-class RunEnvironmentSession(Protocol):
+class RunEnvironmentSession(Protocol):  # noqa: D101  # tracked: #288
     sandbox: SandboxBackendProtocol
     view: RunEnvironmentView
 
-    def __enter__(self) -> RunEnvironmentSession: ...
-    def __exit__(self, exc_type: object, exc: object, tb: object) -> None: ...
-    def close(self) -> None: ...
+    def __enter__(self) -> RunEnvironmentSession: ...  # noqa: D105  # tracked: #288
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None: ...  # noqa: D105  # tracked: #288
+    def close(self) -> None: ...  # noqa: D102  # tracked: #288
 
 
-class RunEnvironment(Protocol):
+class RunEnvironment(Protocol):  # noqa: D101  # tracked: #288
     isolated: bool
     materialize_local_model_weights: bool
     default_profiler_kind: ProfilerKind
     supported_profiler_kinds: frozenset[ProfilerKind] | None
     backend_image: str | None
 
-    def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession: ...
-    def repair_workspace(
+    def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession: ...  # noqa: D102  # tracked: #288
+    def repair_workspace(  # noqa: D102  # tracked: #288
         self, workspace: Path, *, backend: ComputeBackendImpl, log: Callable[[str], None]
     ) -> None: ...
-    def remove_workspace_child(
+    def remove_workspace_child(  # noqa: D102  # tracked: #288
         self, workspace: Path, rel_path: str, *, backend: ComputeBackendImpl
     ) -> bool: ...
     def teardown_deployment(self, name: str, *, log: Callable[[str], None]) -> None:
@@ -166,20 +166,31 @@ class RunEnvironment(Protocol):
 
 class _NoopWorkspaceRecovery:
     def repair_workspace(
-        self, workspace: Path, *, backend: ComputeBackendImpl, log: Callable[[str], None]
+        self,
+        workspace: Path,  # noqa: ARG002  # tracked: #288
+        *,
+        backend: ComputeBackendImpl,  # noqa: ARG002  # tracked: #288
+        log: Callable[[str], None],  # noqa: ARG002  # tracked: #288
     ) -> None:
         return
 
     def remove_workspace_child(
-        self, workspace: Path, rel_path: str, *, backend: ComputeBackendImpl
+        self,
+        workspace: Path,  # noqa: ARG002  # tracked: #288
+        rel_path: str,  # noqa: ARG002  # tracked: #288
+        *,
+        backend: ComputeBackendImpl,  # noqa: ARG002  # tracked: #288
     ) -> bool:
         return False
 
-    def teardown_deployment(self, name: str, *, log: Callable[[str], None]) -> None:
+    def teardown_deployment(self, name: str, *, log: Callable[[str], None]) -> None:  # noqa: ARG002  # tracked: #288
         return
 
     def candidate_runtime(
-        self, view: RunEnvironmentView, generation: int, child_idx: int
+        self,
+        view: RunEnvironmentView,
+        generation: int,  # noqa: ARG002  # tracked: #288
+        child_idx: int,  # noqa: ARG002  # tracked: #288
     ) -> CandidateRuntime:
         return CandidateRuntime(view.prompt_notes, view.deployment_namespace)
 
@@ -205,14 +216,14 @@ class _DefaultRunEnvironmentSession:
             self.sandbox.stop()  # pyright: ignore[reportAttributeAccessIssue]
 
 
-class LocalEnvironment(_NoopWorkspaceRecovery):
+class LocalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
     isolated: bool = False
     materialize_local_model_weights: bool = True
     default_profiler_kind: ProfilerKind = ProfilerKind.NSYS
     supported_profiler_kinds: frozenset[ProfilerKind] | None = None
     backend_image: str | None = None
 
-    def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession:
+    def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession:  # noqa: D102  # tracked: #288
         objective_document = _materialize_effective_objective(request)
         sandbox = request.backend.make_sandbox(
             SandboxKind.LOCAL,
@@ -242,26 +253,26 @@ class LocalEnvironment(_NoopWorkspaceRecovery):
 
 
 @dataclass(frozen=True)
-class DockerEnvironmentConfig:
+class DockerEnvironmentConfig:  # noqa: D101  # tracked: #288
     image: str | None = None
 
 
-class DockerEnvironment:
+class DockerEnvironment:  # noqa: D101  # tracked: #288
     isolated = True
     materialize_local_model_weights = True
     default_profiler_kind = ProfilerKind.NSYS
     supported_profiler_kinds: frozenset[ProfilerKind] | None = None
 
-    def __init__(self, config: DockerEnvironmentConfig) -> None:
+    def __init__(self, config: DockerEnvironmentConfig) -> None:  # noqa: D107  # tracked: #288
         self.config = config
         self.backend_image = config.image
 
     @classmethod
-    def from_options(cls, options: Mapping[str, object]) -> DockerEnvironment:
+    def from_options(cls, options: Mapping[str, object]) -> DockerEnvironment:  # noqa: D102  # tracked: #288
         image = options.get("image")
         return cls(DockerEnvironmentConfig(image=str(image) if image else None))
 
-    def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession:
+    def open(self, request: RunEnvironmentRequest) -> RunEnvironmentSession:  # noqa: D102  # tracked: #288
         bind_mounts, docker_symlinks, passthrough = _container_mount_plan(request)
         extra_init_commands, cli_provider_env = _cli_container_setup(request)
         cli_provider_env.setdefault("UV_CACHE_DIR", "/workspace/.cache/uv")
@@ -323,43 +334,46 @@ class DockerEnvironment:
                     f"(rc={result.returncode}): "
                     f"{result.stderr.decode(errors='replace').strip()}"
                 )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
             log(f"[warn] chown failed for {workspace}: {exc}")
 
-    def remove_workspace_child(
+    def remove_workspace_child(  # noqa: D102  # tracked: #288
         self, workspace: Path, rel_path: str, *, backend: ComputeBackendImpl
     ) -> bool:
         target = workspace / rel_path
-        try:
+        try:  # noqa: SIM105  # tracked: #288
             _docker_workspace_run(
                 workspace,
                 backend=backend,
                 shell_command=f"rm -rf -- {shlex.quote(f'/workspace/{rel_path}')}",
                 timeout=120,
             )
-        except Exception:
+        except Exception:  # noqa: BLE001, S110  # tracked: #288
             pass
         return not (target.exists() or target.is_symlink())
 
-    def teardown_deployment(self, name: str, *, log: Callable[[str], None]) -> None:
+    def teardown_deployment(self, name: str, *, log: Callable[[str], None]) -> None:  # noqa: ARG002, D102  # tracked: #288
         # The editor container is torn down by the session; nothing per-candidate.
         return
 
-    def candidate_runtime(
-        self, view: RunEnvironmentView, generation: int, child_idx: int
+    def candidate_runtime(  # noqa: D102  # tracked: #288
+        self,
+        view: RunEnvironmentView,
+        generation: int,  # noqa: ARG002  # tracked: #288
+        child_idx: int,  # noqa: ARG002  # tracked: #288
     ) -> CandidateRuntime:
         return CandidateRuntime(view.prompt_notes, view.deployment_namespace)
 
 
 @dataclass(frozen=True)
-class ModalEnvironmentConfig:
+class ModalEnvironmentConfig:  # noqa: D101  # tracked: #288
     image: str | None = None
     gpu: str = "H100!"
     model_volume: str | None = None
     app: str = "vibesys"
 
 
-class ModalEnvironment(_NoopWorkspaceRecovery):
+class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
     isolated = True
     materialize_local_model_weights = False
     default_profiler_kind = ProfilerKind.TORCH
@@ -367,13 +381,13 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         {ProfilerKind.AUTO, ProfilerKind.TORCH, ProfilerKind.NONE}
     )
 
-    def __init__(self, config: ModalEnvironmentConfig) -> None:
+    def __init__(self, config: ModalEnvironmentConfig) -> None:  # noqa: D107  # tracked: #288
         self.config = config
         self.model_volume: str | None = config.model_volume
         self.backend_image = config.image
 
     @classmethod
-    def from_options(cls, options: Mapping[str, object]) -> ModalEnvironment:
+    def from_options(cls, options: Mapping[str, object]) -> ModalEnvironment:  # noqa: D102  # tracked: #288
         return cls(
             ModalEnvironmentConfig(
                 image=str(options["image"]) if options.get("image") else None,
@@ -507,12 +521,12 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         meta_path = request.ref_dir / "meta.json"
         if not meta_path.exists():
             return
-        from vs_sandbox import ensure_model_volume
+        from vs_sandbox import ensure_model_volume  # noqa: PLC0415  # tracked: #288
 
         meta = json.loads(meta_path.read_text())
         model_id = meta.get("model_id")
         if not model_id:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"meta.json at {meta_path} missing required 'model_id' field "
                 "(needed for Modal auto-upload)"
             )
@@ -544,12 +558,12 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         draft_meta_path = request.ref_dir / "draft_meta.json"
         if not draft_meta_path.exists():
             return None
-        from vs_sandbox import ensure_model_volume
+        from vs_sandbox import ensure_model_volume  # noqa: PLC0415  # tracked: #288
 
         draft_meta = json.loads(draft_meta_path.read_text())
         draft_model_id = draft_meta.get("model_id")
         if not draft_model_id:
-            raise ValueError(
+            raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"draft_meta.json at {draft_meta_path} missing required 'model_id' field"
             )
         hf_available = bool(os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN"))
@@ -576,14 +590,14 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         leaves an idle app behind and must never fail a run.
         """
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # noqa: S603  # tracked: #288
                 [sys.executable, "-m", "modal", "app", "stop", name, "--yes"],
                 capture_output=True,
                 text=True,
                 timeout=60,
                 check=False,
             )
-        except Exception as exc:  # timeout, missing binary, etc.
+        except Exception as exc:  # timeout, missing binary, etc.  # noqa: BLE001  # tracked: #288
             log(f"[warn] modal app stop {name} raised: {exc}")
             return
         if result.returncode != 0:
@@ -594,7 +608,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         else:
             log(f"[modal] stopped candidate app {name}")
 
-    def candidate_runtime(
+    def candidate_runtime(  # noqa: D102  # tracked: #288
         self, view: RunEnvironmentView, generation: int, child_idx: int
     ) -> CandidateRuntime:
         base_name = view.deployment_namespace
@@ -612,17 +626,17 @@ class ModalEnvironment(_NoopWorkspaceRecovery):
         )
 
 
-def build_run_environment(spec: RunEnvironmentSpec) -> RunEnvironment:
+def build_run_environment(spec: RunEnvironmentSpec) -> RunEnvironment:  # noqa: D103  # tracked: #288
     if spec.name == "local":
         return LocalEnvironment()
     if spec.name == "docker":
         return DockerEnvironment.from_options(spec.options)
     if spec.name == "modal":
         return ModalEnvironment.from_options(spec.options)
-    raise ValueError(f"unknown run environment: {spec.name!r}")
+    raise ValueError(f"unknown run environment: {spec.name!r}")  # noqa: TRY003  # tracked: #288
 
 
-def make_run_environment_spec(
+def make_run_environment_spec(  # noqa: PLR0913  # tracked: #288
     *,
     use_docker: bool = False,
     docker_image: str | None = None,
@@ -641,7 +655,7 @@ def make_run_environment_spec(
     decorators instead.
     """
     if use_docker and use_modal:
-        raise ValueError("--docker and --modal are mutually exclusive")
+        raise ValueError("--docker and --modal are mutually exclusive")  # noqa: TRY003  # tracked: #288
     if use_modal:
         return RunEnvironmentSpec(
             name="modal",
@@ -929,8 +943,8 @@ def _docker_workspace_run(
     timeout: int,
 ) -> subprocess.CompletedProcess[bytes]:
     image = getattr(backend, "image", "ubuntu:latest")
-    return subprocess.run(
-        [
+    return subprocess.run(  # noqa: S603  # tracked: #288
+        [  # noqa: S607  # tracked: #288
             "docker",
             "run",
             "--rm",
@@ -1021,7 +1035,7 @@ def _container_mount_plan(
         and (request.agent_backend or DEFAULT_AGENT_BACKEND) == "cli"
         and request.cli_provider
     ):
-        from vibesys.agents.cli_docker import auth_bind_mounts
+        from vibesys.agents.cli_docker import auth_bind_mounts  # noqa: PLC0415  # tracked: #288
 
         bind_mounts.extend(auth_bind_mounts(request.cli_provider))
         bind_mounts.append((str(request.project_root), "/opt/vibesys", True))
@@ -1068,7 +1082,7 @@ def _cli_container_setup(
     effective_agent = request.agent_backend or DEFAULT_AGENT_BACKEND
     if effective_agent != "cli" or not request.cli_provider:
         return [], {}
-    from vibesys.agents.cli_docker import (
+    from vibesys.agents.cli_docker import (  # noqa: PLC0415  # tracked: #288
         DOCKER_PROVIDER_ENV,
         auth_copy_commands,
         docker_init_commands,

--- a/src/vibesys/schemas.py
+++ b/src/vibesys/schemas.py
@@ -33,8 +33,8 @@ from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, field_validator
 # ===========================================================================
 
 
-class Verdict(StrEnum):
-    PASS = "pass"
+class Verdict(StrEnum):  # noqa: D101  # tracked: #288
+    PASS = "pass"  # noqa: S105  # tracked: #288
     FAIL = "fail"
 
 
@@ -73,7 +73,7 @@ class CandidateDisposition(StrEnum):
     PARETO_FRONTIER = "pareto_frontier"
 
 
-class PerfTrend(StrEnum):
+class PerfTrend(StrEnum):  # noqa: D101  # tracked: #288
     IMPROVED = "improved"
     REGRESSED = "regressed"
     MIXED = "mixed"
@@ -108,7 +108,7 @@ class SkillResourceSelection(BaseModel):
     def _strip_required_text(cls, value: str) -> str:
         value = value.strip()
         if not value:
-            raise ValueError("must contain non-whitespace text")
+            raise ValueError("must contain non-whitespace text")  # noqa: TRY003  # tracked: #288
         return value
 
 
@@ -163,7 +163,7 @@ class ValidationRecipe(BaseModel):
     def _strip_recipe_text(cls, value: str) -> str:
         value = value.strip()
         if not value:
-            raise ValueError("must contain non-whitespace text")
+            raise ValueError("must contain non-whitespace text")  # noqa: TRY003  # tracked: #288
         return value
 
     @field_validator("input_paths")
@@ -174,13 +174,13 @@ class ValidationRecipe(BaseModel):
             value = raw.strip()
             path = PurePosixPath(value)
             if not value or path.is_absolute() or value == "." or ".." in path.parts:
-                raise ValueError(
+                raise ValueError(  # noqa: TRY003  # tracked: #288
                     "input_paths must contain non-empty workspace-relative paths "
                     "without parent traversal"
                 )
             normalized.append(path.as_posix())
         if len(set(normalized)) != len(normalized):
-            raise ValueError("input_paths must not contain duplicates")
+            raise ValueError("input_paths must not contain duplicates")  # noqa: TRY003  # tracked: #288
         return normalized
 
 

--- a/src/vibesys/server/__init__.py
+++ b/src/vibesys/server/__init__.py
@@ -11,13 +11,13 @@ from vibesys.server.supervisor import RunSupervisor
 __all__ = [
     "EventStatus",
     "EventType",
+    "ProtocolRequest",
+    "Response",
     "RunEvent",
     "RunInspector",
     "RunSnapshot",
     "RunSupervisor",
     "SupervisionService",
-    "ProtocolRequest",
-    "Response",
     "active_supervisor",
     "run_server",
 ]

--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -7,13 +7,13 @@ import threading
 from bisect import bisect_right
 from datetime import UTC, datetime
 from enum import StrEnum
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, ValidationError
 
 
-class EventType(StrEnum):
+class EventType(StrEnum):  # noqa: D101  # tracked: #288
     SERVER_STARTED = "server_started"
     SERVER_READY = "server_ready"
     CONFIGURATION_FAILED = "configuration_failed"
@@ -40,7 +40,7 @@ class EventType(StrEnum):
     USAGE_UPDATE = "usage_update"
 
 
-class EventStatus(StrEnum):
+class EventStatus(StrEnum):  # noqa: D101  # tracked: #288
     ACTIVE = "active"
     ANSWERED = "answered"
     PENDING = "pending"
@@ -56,49 +56,49 @@ AgentOutputChannel = Literal["assistant", "analysis", "tool", "diagnostic", "pro
 """Presentation channel for streamed agent output."""
 
 
-class ChatData(BaseModel):
+class ChatData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["chat"] = "chat"
     answer: str
 
 
-class InvocationStartedData(BaseModel):
+class InvocationStartedData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["invocation_started"] = "invocation_started"
     system_prompt: str
     user_prompt: str
 
 
-class InvocationFinishedData(BaseModel):
+class InvocationFinishedData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["invocation_finished"] = "invocation_finished"
     result: Any = None
     error: str | None = None
 
 
-class OutputData(BaseModel):
+class OutputData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["output"] = "output"
     stream: OutputStream
     source: str = "backend"
     content: str
 
 
-class ServerReadyData(BaseModel):
+class ServerReadyData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["server_ready"] = "server_ready"
     socket_protocol: Literal["jsonl"] = "jsonl"
 
 
-class RunStartedData(BaseModel):
+class RunStartedData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["run_started"] = "run_started"
     outer_loop: str
     input: str
     max_rounds: int
 
 
-class RunInterruptedData(BaseModel):
+class RunInterruptedData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["run_interrupted"] = "run_interrupted"
     reason: str
     signal: str | None = None
 
 
-class ConfigurationFailedData(BaseModel):
+class ConfigurationFailedData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["configuration_failed"] = "configuration_failed"
     code: str
     stage: str
@@ -107,7 +107,7 @@ class ConfigurationFailedData(BaseModel):
     exit_code: int
 
 
-class PhaseData(BaseModel):
+class PhaseData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["phase"] = "phase"
     phase: str
     attempt: int | None = None
@@ -128,14 +128,14 @@ class AgentStatusData(BaseModel):
     context_window: int | None = None
 
 
-class AgentOutputChunkData(BaseModel):
+class AgentOutputChunkData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["agent_output_chunk"] = "agent_output_chunk"
     channel: AgentOutputChannel
     content: str
     status: AgentStatusData | None = None
 
 
-class ToolCallData(BaseModel):
+class ToolCallData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["tool_call"] = "tool_call"
     tool: str
     call_id: str | None = None
@@ -143,7 +143,7 @@ class ToolCallData(BaseModel):
     status: AgentStatusData | None = None
 
 
-class ToolResultData(BaseModel):
+class ToolResultData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["tool_result"] = "tool_result"
     tool: str
     call_id: str | None = None
@@ -151,7 +151,7 @@ class ToolResultData(BaseModel):
     is_error: bool = False
 
 
-class TodoItemData(BaseModel):
+class TodoItemData(BaseModel):  # noqa: D101  # tracked: #288
     content: str
     # Expected values are "pending" / "in_progress" / "completed", but the
     # field stays open: todo payloads originate from agent tool calls, and an
@@ -159,19 +159,19 @@ class TodoItemData(BaseModel):
     status: str
 
 
-class TodoUpdateData(BaseModel):
+class TodoUpdateData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["todo_update"] = "todo_update"
     todos: list[TodoItemData] = Field(default_factory=list)
 
 
-class UsageUpdateData(BaseModel):
+class UsageUpdateData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["usage_update"] = "usage_update"
     input_tokens: int
     context_window: int | None = None
     model: str | None = None
 
 
-class SubprocessOutputData(BaseModel):
+class SubprocessOutputData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["subprocess_output"] = "subprocess_output"
     process_id: str
     process_kind: str
@@ -179,21 +179,21 @@ class SubprocessOutputData(BaseModel):
     content: str
 
 
-class JudgeResultData(BaseModel):
+class JudgeResultData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["judge_result"] = "judge_result"
     verdict: Literal["pass", "fail"]
     feedback: str
     attempt: int
 
 
-class BenchmarkResultData(BaseModel):
+class BenchmarkResultData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["benchmark_result"] = "benchmark_result"
     metric: str
     value: FiniteFloat
     unit: str
 
 
-class RoundFinishedData(BaseModel):
+class RoundFinishedData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["round_finished"] = "round_finished"
     attempts: int
     judge_verdict: Literal["pass", "fail", "skipped"]
@@ -245,7 +245,7 @@ class RunEvent(BaseModel):
 class EventStore:
     """Serialize event access so readers never observe partial JSONL writes."""
 
-    def __init__(self, path: Path, run_id: str):
+    def __init__(self, path: Path, run_id: str):  # noqa: ANN204, D107  # tracked: #288
         self.path = path
         self.run_id = run_id
         self._lock = threading.RLock()
@@ -258,7 +258,7 @@ class EventStore:
         )
         self._next_sequence = max(self._sequences, default=0) + 1
 
-    def append(self, event: RunEvent) -> RunEvent:
+    def append(self, event: RunEvent) -> RunEvent:  # noqa: D102  # tracked: #288
         with self._changed:
             if self._malformed_tail_offset is not None:
                 with self.path.open("r+b") as stream:
@@ -276,11 +276,11 @@ class EventStore:
             return event
 
     @property
-    def last_sequence(self) -> int:
+    def last_sequence(self) -> int:  # noqa: D102  # tracked: #288
         with self._lock:
             return self._next_sequence - 1
 
-    def read(self, after_sequence: int = 0) -> list[RunEvent]:
+    def read(self, after_sequence: int = 0) -> list[RunEvent]:  # noqa: D102  # tracked: #288
         with self._lock:
             return self._events_after_unlocked(after_sequence)
 
@@ -324,15 +324,15 @@ class EventStore:
         return events, None
 
 
-def make_event(event_type: EventType, text: str = "", **fields: Any) -> RunEvent:
+def make_event(event_type: EventType, text: str = "", **fields: Any) -> RunEvent:  # noqa: ANN401, D103  # tracked: #288
     return RunEvent(timestamp=datetime.now(UTC), type=event_type, text=text, **fields)
 
 
-def json_value(value: Any) -> Any:
+def json_value(value: Any) -> Any:  # noqa: ANN401, D103  # tracked: #288
     if isinstance(value, BaseModel):
         return value.model_dump(mode="json")
     try:
         json.dumps(value)
-        return value
+        return value  # noqa: TRY300  # tracked: #288
     except TypeError:
         return repr(value)

--- a/src/vibesys/server/inspector.py
+++ b/src/vibesys/server/inspector.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import TYPE_CHECKING
 
 from vibesys.server.events import ConfigurationFailedData, EventStatus, EventType, RunEvent
@@ -16,10 +16,10 @@ if TYPE_CHECKING:
 class RunInspector:
     """Answer operator questions without mutating agent behavior."""
 
-    def __init__(self, supervisor: RunSupervisor):
+    def __init__(self, supervisor: RunSupervisor):  # noqa: ANN204, D107  # tracked: #288
         self.supervisor = supervisor
 
-    def answer(self, question: str) -> str:
+    def answer(self, question: str) -> str:  # noqa: D102, PLR0911  # tracked: #288
         configuration_failure = self._latest_configuration_failure()
         if configuration_failure is not None:
             return self._status_answer(question, configuration_failure)
@@ -64,7 +64,7 @@ class RunInspector:
             "use /history for the event timeline."
         )
 
-    def round_detail(self, number: int) -> str:
+    def round_detail(self, number: int) -> str:  # noqa: D102  # tracked: #288
         pattern = re.compile(rf"(?i)(round|iter(?:ation)?)\D*{number}\b")
         chunks = []
         for path in self._history_files():
@@ -76,7 +76,7 @@ class RunInspector:
                 chunks.append(f"--- {path.name} ---\n" + "\n".join(lines[start : start + 80]))
         return "\n\n".join(chunks) or f"No persisted detail found for round {number}."
 
-    def latest_run_log(self) -> Path | None:
+    def latest_run_log(self) -> Path | None:  # noqa: D102  # tracked: #288
         log_dir = self.supervisor.log_dir
         if log_dir is None:
             return None

--- a/src/vibesys/server/protocol.py
+++ b/src/vibesys/server/protocol.py
@@ -13,49 +13,49 @@ from vibesys.server.events import RunEvent
 PROTOCOL_VERSION = 1
 
 
-class ProtocolModel(BaseModel):
+class ProtocolModel(BaseModel):  # noqa: D101  # tracked: #288
     model_config = ConfigDict(extra="forbid")
 
 
-class Request(ProtocolModel):
+class Request(ProtocolModel):  # noqa: D101  # tracked: #288
     protocol_version: Literal[1] = PROTOCOL_VERSION
     request_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 
-class PauseCommand(Request):
+class PauseCommand(Request):  # noqa: D101  # tracked: #288
     type: Literal["command.pause"] = "command.pause"
     mode: Literal["after_current_agent_call"] = "after_current_agent_call"
 
 
-class ResumeCommand(Request):
+class ResumeCommand(Request):  # noqa: D101  # tracked: #288
     type: Literal["command.resume"] = "command.resume"
 
 
-class SnapshotQuery(Request):
+class SnapshotQuery(Request):  # noqa: D101  # tracked: #288
     type: Literal["query.snapshot"] = "query.snapshot"
 
 
-class ChatQuery(Request):
+class ChatQuery(Request):  # noqa: D101  # tracked: #288
     type: Literal["query.chat"] = "query.chat"
     text: str
 
 
-class HistoryQuery(Request):
+class HistoryQuery(Request):  # noqa: D101  # tracked: #288
     type: Literal["query.history"] = "query.history"
 
 
-class PerformanceQuery(Request):
+class PerformanceQuery(Request):  # noqa: D101  # tracked: #288
     type: Literal["query.performance"] = "query.performance"
 
 
-class EventsQuery(Request):
+class EventsQuery(Request):  # noqa: D101  # tracked: #288
     type: Literal["query.events"] = "query.events"
     after_sequence: int = Field(default=0, ge=0)
     timeout_ms: int = Field(default=0, ge=0, le=30_000)
 
 
-class SubscribeRequest(Request):
+class SubscribeRequest(Request):  # noqa: D101  # tracked: #288
     type: Literal["subscribe"] = "subscribe"
     after_sequence: int = Field(default=0, ge=0)
 
@@ -73,7 +73,7 @@ ProtocolRequest = Annotated[
 ]
 
 
-class RunSnapshot(ProtocolModel):
+class RunSnapshot(ProtocolModel):  # noqa: D101  # tracked: #288
     protocol_version: Literal[1] = PROTOCOL_VERSION
     run_id: str
     sequence: int
@@ -82,18 +82,18 @@ class RunSnapshot(ProtocolModel):
     round_label: str | None = None
 
 
-class CommandAck(ProtocolModel):
+class CommandAck(ProtocolModel):  # noqa: D101  # tracked: #288
     action: Literal["pause", "resume"]
     status: Literal["pending", "consumed"]
 
 
-class ChatResult(ProtocolModel):
+class ChatResult(ProtocolModel):  # noqa: D101  # tracked: #288
     question: str
     answer: str
     effect: Literal["none"] = "none"
 
 
-class PerformanceRound(ProtocolModel):
+class PerformanceRound(ProtocolModel):  # noqa: D101  # tracked: #288
     round: int
     perf_metric: FiniteFloat
     perf_unit: str
@@ -101,7 +101,7 @@ class PerformanceRound(ProtocolModel):
     profile_skipped: bool = False
 
 
-class Response(ProtocolModel):
+class Response(ProtocolModel):  # noqa: D101  # tracked: #288
     protocol_version: Literal[1] = PROTOCOL_VERSION
     request_id: str
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
@@ -114,24 +114,24 @@ class Response(ProtocolModel):
     performance: list[PerformanceRound] = Field(default_factory=list)
 
 
-class SubscribedMessage(ProtocolModel):
+class SubscribedMessage(ProtocolModel):  # noqa: D101  # tracked: #288
     type: Literal["subscribed"] = "subscribed"
     request_id: str
     run_id: str
     latest_sequence: int
 
 
-class EventMessage(ProtocolModel):
+class EventMessage(ProtocolModel):  # noqa: D101  # tracked: #288
     type: Literal["event"] = "event"
     event: RunEvent
 
 
-class EventBatchMessage(ProtocolModel):
+class EventBatchMessage(ProtocolModel):  # noqa: D101  # tracked: #288
     type: Literal["event_batch"] = "event_batch"
     events: list[RunEvent]
 
 
-class ProtocolErrorMessage(ProtocolModel):
+class ProtocolErrorMessage(ProtocolModel):  # noqa: D101  # tracked: #288
     type: Literal["protocol_error"] = "protocol_error"
     request_id: str | None = None
     code: str

--- a/src/vibesys/server/registry.py
+++ b/src/vibesys/server/registry.py
@@ -4,25 +4,25 @@ from __future__ import annotations
 
 import threading
 
-from vibesys.server.supervisor import RunSupervisor
+from vibesys.server.supervisor import RunSupervisor  # noqa: TC001  # tracked: #288
 
 
-class SupervisorRegistry:
-    def __init__(self) -> None:
+class SupervisorRegistry:  # noqa: D101  # tracked: #288
+    def __init__(self) -> None:  # noqa: D107  # tracked: #288
         self._lock = threading.Lock()
         self._active: RunSupervisor | None = None
 
-    def activate(self, supervisor: RunSupervisor) -> None:
+    def activate(self, supervisor: RunSupervisor) -> None:  # noqa: D102  # tracked: #288
         with self._lock:
             if self._active is not None:
-                raise RuntimeError("A TUI-supervised run is already active in this process")
+                raise RuntimeError("A TUI-supervised run is already active in this process")  # noqa: TRY003  # tracked: #288
             self._active = supervisor
 
-    def get(self) -> RunSupervisor | None:
+    def get(self) -> RunSupervisor | None:  # noqa: D102  # tracked: #288
         with self._lock:
             return self._active
 
-    def deactivate(self, supervisor: RunSupervisor) -> None:
+    def deactivate(self, supervisor: RunSupervisor) -> None:  # noqa: D102  # tracked: #288
         with self._lock:
             if self._active is supervisor:
                 self._active = None
@@ -31,5 +31,5 @@ class SupervisorRegistry:
 REGISTRY = SupervisorRegistry()
 
 
-def active_supervisor() -> RunSupervisor | None:
+def active_supervisor() -> RunSupervisor | None:  # noqa: D103  # tracked: #288
     return REGISTRY.get()

--- a/src/vibesys/server/runtime.py
+++ b/src/vibesys/server/runtime.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import signal
-from collections.abc import Callable
-from pathlib import Path
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any
 
 from vibesys.errors import ConfigurationError
@@ -25,7 +25,7 @@ def run_server(
     run: Callable[[], Any],
     *,
     socket_path: Path,
-) -> Any:
+) -> Any:  # noqa: ANN401  # tracked: #288
     """Run a headless backend that exposes supervision over a Unix socket."""
     supervisor = RunSupervisor()
     previous_sigterm = signal.getsignal(signal.SIGTERM)
@@ -46,7 +46,7 @@ def run_server(
     try:
         with SupervisionSocketServer(socket_path, service) as server:
             if not server.wait_for_subscriber(timeout=30.0):
-                raise RuntimeError("Timed out waiting for a supervision client")
+                raise RuntimeError("Timed out waiting for a supervision client")  # noqa: TRY003  # tracked: #288
             try:
                 value = run()
             except KeyboardInterrupt:

--- a/src/vibesys/server/schema.py
+++ b/src/vibesys/server/schema.py
@@ -12,7 +12,7 @@ from vibesys.server.events import RunEvent
 from vibesys.server.protocol import ProtocolRequest, Response, RunSnapshot, ServerMessage
 
 
-class ProtocolDocument(BaseModel):
+class ProtocolDocument(BaseModel):  # noqa: D101  # tracked: #288
     request: ProtocolRequest
     response: Response
     event: RunEvent
@@ -20,9 +20,9 @@ class ProtocolDocument(BaseModel):
     server_message: ServerMessage
 
 
-def main() -> None:
-    if len(sys.argv) != 2:
-        raise SystemExit("usage: python -m vibesys.server.schema OUTPUT.json")
+def main() -> None:  # noqa: D103  # tracked: #288
+    if len(sys.argv) != 2:  # noqa: PLR2004  # tracked: #288
+        raise SystemExit("usage: python -m vibesys.server.schema OUTPUT.json")  # noqa: TRY003  # tracked: #288
     output = Path(sys.argv[1])
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(ProtocolDocument.model_json_schema(), indent=2) + "\n")

--- a/src/vibesys/server/service.py
+++ b/src/vibesys/server/service.py
@@ -21,17 +21,17 @@ from vibesys.server.protocol import (
     RunSnapshot,
     SnapshotQuery,
 )
-from vibesys.server.supervisor import RunSupervisor
+from vibesys.server.supervisor import RunSupervisor  # noqa: TC001  # tracked: #288
 
 
 class SupervisionService:
     """Authoritative message API consumed by every presentation client."""
 
-    def __init__(self, supervisor: RunSupervisor):
+    def __init__(self, supervisor: RunSupervisor):  # noqa: ANN204, D107  # tracked: #288
         self.supervisor = supervisor
         self.inspector = RunInspector(supervisor)
 
-    def execute(self, request: ProtocolRequest) -> Response:
+    def execute(self, request: ProtocolRequest) -> Response:  # noqa: D102, PLR0911  # tracked: #288
         if isinstance(request, PauseCommand):
             self.supervisor.pause_after_call()
             return Response(
@@ -68,18 +68,18 @@ class SupervisionService:
                 else self.events(request.after_sequence)
             )
             return Response(request_id=request.request_id, events=events)
-        raise TypeError(f"Unsupported protocol request: {type(request).__name__}")
+        raise TypeError(f"Unsupported protocol request: {type(request).__name__}")  # noqa: TRY003  # tracked: #288
 
-    def snapshot(self) -> RunSnapshot:
+    def snapshot(self) -> RunSnapshot:  # noqa: D102  # tracked: #288
         return self.supervisor.snapshot()
 
-    def events(self, after_sequence: int = 0) -> list[RunEvent]:
+    def events(self, after_sequence: int = 0) -> list[RunEvent]:  # noqa: D102  # tracked: #288
         return self.supervisor.read_events(after_sequence)
 
-    def history_events(self) -> list[RunEvent]:
+    def history_events(self) -> list[RunEvent]:  # noqa: D102  # tracked: #288
         return self.supervisor.read_history_events()
 
-    def performance_rounds(self) -> list[PerformanceRound]:
+    def performance_rounds(self) -> list[PerformanceRound]:  # noqa: D102  # tracked: #288
         log_dir = self.supervisor.log_dir
         if log_dir is None:
             return []
@@ -103,5 +103,5 @@ class SupervisionService:
             )
         return rounds
 
-    def wait_for_events(self, after_sequence: int, timeout: float | None = None) -> list[RunEvent]:
+    def wait_for_events(self, after_sequence: int, timeout: float | None = None) -> list[RunEvent]:  # noqa: D102  # tracked: #288
         return self.supervisor.wait_for_events(after_sequence, timeout)

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import re
 import threading
 import uuid
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator  # noqa: TC003  # tracked: #288
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any
 
 from vibesys.server.events import (
@@ -33,7 +33,7 @@ from vibesys.server.protocol import RunSnapshot
 class RunSupervisor:
     """Own pause state, invocation metadata, and the run audit store."""
 
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # noqa: D107  # tracked: #288
         self._condition = threading.Condition()
         self._pause_after_call = False
         self._paused = False
@@ -49,11 +49,11 @@ class RunSupervisor:
         self._presentation_local = threading.local()
 
     @property
-    def current_round(self) -> str | None:
+    def current_round(self) -> str | None:  # noqa: D102  # tracked: #288
         with self._condition:
             return self._current_round
 
-    def attach(self, log_dir: Path) -> None:
+    def attach(self, log_dir: Path) -> None:  # noqa: D102  # tracked: #288
         log_dir.mkdir(parents=True, exist_ok=True)
         self.log_dir = log_dir
         events_path = log_dir / "run-events.jsonl"
@@ -75,7 +75,7 @@ class RunSupervisor:
         with self._condition:
             self._run_status = "running"
 
-    def publish_output(self, stream: OutputStream, content: str, source: str = "backend") -> None:
+    def publish_output(self, stream: OutputStream, content: str, source: str = "backend") -> None:  # noqa: D102  # tracked: #288
         if not content:
             return
         self.record(
@@ -83,7 +83,7 @@ class RunSupervisor:
             data=OutputData(stream=stream, source=source, content=content),
         )
 
-    def publish_agent_output(
+    def publish_agent_output(  # noqa: D102  # tracked: #288
         self,
         content: str,
         *,
@@ -123,13 +123,13 @@ class RunSupervisor:
             data=data,
         )
 
-    def record(
+    def record(  # noqa: D102  # tracked: #288
         self,
         event_type: EventType,
         text: str = "",
         *,
         data: EventData | None = None,
-        **fields: Any,
+        **fields: Any,  # noqa: ANN401  # tracked: #288
     ) -> RunEvent | None:
         event = make_event(event_type, text, data=data, **fields)
         with self._condition:
@@ -143,7 +143,7 @@ class RunSupervisor:
             audit_store.append(event)
         return recorded
 
-    def read_events(self, after_sequence: int = 0) -> list[RunEvent]:
+    def read_events(self, after_sequence: int = 0) -> list[RunEvent]:  # noqa: D102  # tracked: #288
         store = self._store
         return store.read(after_sequence) if store else []
 
@@ -152,11 +152,11 @@ class RunSupervisor:
         store = self._audit_store or self._store
         return store.read() if store else []
 
-    def wait_for_events(self, after_sequence: int, timeout: float | None = None) -> list[RunEvent]:
+    def wait_for_events(self, after_sequence: int, timeout: float | None = None) -> list[RunEvent]:  # noqa: D102  # tracked: #288
         store = self._store
         return store.wait(after_sequence, timeout) if store else []
 
-    def snapshot(self) -> RunSnapshot:
+    def snapshot(self) -> RunSnapshot:  # noqa: D102  # tracked: #288
         with self._condition:
             store = self._store
             return RunSnapshot(
@@ -167,11 +167,11 @@ class RunSupervisor:
                 round_label=self._current_round,
             )
 
-    def chat(self, text: str) -> str:
+    def chat(self, text: str) -> str:  # noqa: D102  # tracked: #288
         with self._condition:
             handler = self._chat_handler
         if handler is None:
-            from vibesys.server.inspector import RunInspector
+            from vibesys.server.inspector import RunInspector  # noqa: PLC0415  # tracked: #288
 
             answer = RunInspector(self).answer(text)
         else:
@@ -213,19 +213,19 @@ class RunSupervisor:
                 self._presentation_local.invocation_id,
             ) = previous
 
-    def pause_after_call(self) -> None:
+    def pause_after_call(self) -> None:  # noqa: D102  # tracked: #288
         with self._condition:
             self._pause_after_call = True
         self.record(EventType.CONTROL, "/pause", status=EventStatus.PENDING)
 
-    def resume(self) -> None:
+    def resume(self) -> None:  # noqa: D102  # tracked: #288
         with self._condition:
             self._paused = False
             self._pause_after_call = False
             self._condition.notify_all()
         self.record(EventType.CONTROL, "/resume", status=EventStatus.CONSUMED)
 
-    def before_agent(
+    def before_agent(  # noqa: D102  # tracked: #288
         self, kind: str, round_label: str, user_prompt: str, system_prompt: str = ""
     ) -> None:
         with self._condition:
@@ -253,8 +253,13 @@ class RunSupervisor:
             data=InvocationStartedData(system_prompt=system_prompt, user_prompt=user_prompt),
         )
 
-    def after_agent(
-        self, kind: str, round_label: str, *, result: Any = None, error: BaseException | None = None
+    def after_agent(  # noqa: D102  # tracked: #288
+        self,
+        kind: str,
+        round_label: str,
+        *,
+        result: Any = None,  # noqa: ANN401  # tracked: #288
+        error: BaseException | None = None,  # noqa: ANN401, RUF100  # tracked: #288
     ) -> None:
         with self._condition:
             invocation_id = self._active_invocation
@@ -292,14 +297,14 @@ class RunSupervisor:
                 invocation_id=invocation_id,
             )
 
-    def status(self) -> str:
+    def status(self) -> str:  # noqa: D102  # tracked: #288
         with self._condition:
             state = "paused" if self._paused else self._run_status
             kind = self._current_kind or "starting"
             round_label = self._current_round or "no round yet"
         return f"{state} · {kind} · {round_label}"
 
-    def finish(self, error: BaseException | None = None, *, record_event: bool = True) -> None:
+    def finish(self, error: BaseException | None = None, *, record_event: bool = True) -> None:  # noqa: D102  # tracked: #288
         with self._condition:
             self._run_status = "failed" if error else "completed"
             self._condition.notify_all()

--- a/src/vibesys/server/transport.py
+++ b/src/vibesys/server/transport.py
@@ -8,7 +8,7 @@ import socket
 import socketserver
 import threading
 import time
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 from pydantic import BaseModel, TypeAdapter
 
@@ -20,7 +20,7 @@ from vibesys.server.protocol import (
     SubscribedMessage,
     SubscribeRequest,
 )
-from vibesys.server.service import SupervisionService
+from vibesys.server.service import SupervisionService  # noqa: TC001  # tracked: #288
 
 _REQUEST_ADAPTER = TypeAdapter(ProtocolRequest)
 
@@ -44,7 +44,7 @@ class _RequestHandler(socketserver.StreamRequestHandler):
                         self.server.client_disconnected.set()  # type: ignore[attr-defined]
                     return
                 response = service.execute(request)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001  # tracked: #288
                 response = Response(
                     request_id=request_id,
                     ok=False,
@@ -97,7 +97,7 @@ class _UnixServer(socketserver.ThreadingUnixStreamServer):
     daemon_threads = True
     allow_reuse_address = True
 
-    def __init__(self, path: Path, service: SupervisionService):
+    def __init__(self, path: Path, service: SupervisionService):  # noqa: ANN204  # tracked: #288
         self.service = service
         super().__init__(str(path), _RequestHandler)
 
@@ -105,7 +105,7 @@ class _UnixServer(socketserver.ThreadingUnixStreamServer):
 class SupervisionSocketServer:
     """Own a private Unix socket serving one or more concurrent clients."""
 
-    def __init__(self, path: Path, service: SupervisionService):
+    def __init__(self, path: Path, service: SupervisionService):  # noqa: ANN204, D107  # tracked: #288
         self.path = path
         self.service = service
         self._server: _UnixServer | None = None
@@ -113,13 +113,13 @@ class SupervisionSocketServer:
         self._client_subscribed = threading.Event()
         self._client_disconnected = threading.Event()
 
-    def start(self) -> None:
+    def start(self) -> None:  # noqa: D102  # tracked: #288
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.path.unlink(missing_ok=True)
         self._server = _UnixServer(self.path, self.service)
         self._server.client_subscribed = self._client_subscribed  # type: ignore[attr-defined]
         self._server.client_disconnected = self._client_disconnected  # type: ignore[attr-defined]
-        os.chmod(self.path, 0o600)
+        os.chmod(self.path, 0o600)  # noqa: PTH101  # tracked: #288
         self._thread = threading.Thread(
             target=self._server.serve_forever,
             name="vibesys-supervision-server",
@@ -135,7 +135,7 @@ class SupervisionSocketServer:
         """Keep terminal events queryable until the attached client exits."""
         self._client_disconnected.wait()
 
-    def close(self) -> None:
+    def close(self) -> None:  # noqa: D102  # tracked: #288
         if self._server is not None:
             self._server.shutdown()
             self._server.server_close()
@@ -145,9 +145,9 @@ class SupervisionSocketServer:
             self._thread = None
         self.path.unlink(missing_ok=True)
 
-    def __enter__(self) -> SupervisionSocketServer:
+    def __enter__(self) -> SupervisionSocketServer:  # noqa: D105  # tracked: #288
         self.start()
         return self
 
-    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:  # noqa: D105  # tracked: #288
         self.close()

--- a/src/vibesys/skills.py
+++ b/src/vibesys/skills.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import tomllib
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Sequence  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -12,7 +12,7 @@ import yaml
 
 from vibesys.constants import PROJECT_ROOT, ComputeBackend
 from vibesys.domains.base import DomainName
-from vibesys.schemas import SkillResourceSelection
+from vibesys.schemas import SkillResourceSelection  # noqa: TC001  # tracked: #288
 
 DEFAULT_SKILL_ROOTS: tuple[Path, ...] = (Path("resources/skills"),)
 SIDECAR_NAME = ".vibesys.toml"
@@ -71,7 +71,7 @@ class SkillRule:
         """Rule precedence: deeper target paths are more specific."""
         return len(self.target_path.parts)
 
-    def applies_to(self, skill_dir: Path) -> bool:
+    def applies_to(self, skill_dir: Path) -> bool:  # noqa: D102  # tracked: #288
         try:
             skill_dir.resolve().relative_to(self.target_path)
         except ValueError:
@@ -306,9 +306,9 @@ def coerce_skill_root(raw: str | Path, *, project_root: Path = PROJECT_ROOT) -> 
         path = project_root / path
     path = path.resolve()
     if not path.exists():
-        raise ValueError(f"--skills-dir path does not exist: {raw}")
+        raise ValueError(f"--skills-dir path does not exist: {raw}")  # noqa: TRY003  # tracked: #288
     if not path.is_dir():
-        raise ValueError(f"--skills-dir path is not a directory: {raw}")
+        raise ValueError(f"--skills-dir path is not a directory: {raw}")  # noqa: TRY003  # tracked: #288
     return path
 
 
@@ -341,7 +341,7 @@ def build_skill_catalog(skill_dirs: Iterable[str | Path]) -> dict[str, SkillCata
     return catalog
 
 
-def _resolve_skill_resource(
+def _resolve_skill_resource(  # noqa: PLR0911  # tracked: #288
     entry: SkillCatalogEntry,
     raw_resource: str,
 ) -> tuple[str | None, str | None]:
@@ -404,7 +404,7 @@ def resolve_skill_selections(
                     f"selection #{index} skill {skill!r} resource {raw_resource!r}: {error}"
                 )
                 continue
-            assert workspace_path is not None
+            assert workspace_path is not None  # noqa: S101  # tracked: #288
             if workspace_path == entry.router_path or workspace_path in resources:
                 continue
             resources.append(workspace_path)

--- a/src/vibesys/skills.py
+++ b/src/vibesys/skills.py
@@ -320,7 +320,6 @@ def build_skill_catalog(skill_dirs: Iterable[str | Path]) -> dict[str, SkillCata
     A skill's frontmatter name must match its materialized directory name so an
     outer-loop recommendation cannot resolve differently across providers.
     """
-
     catalog: dict[str, SkillCatalogEntry] = {}
     for raw_root in skill_dirs:
         root = Path(raw_root).expanduser().resolve()
@@ -347,7 +346,6 @@ def _resolve_skill_resource(
     raw_resource: str,
 ) -> tuple[str | None, str | None]:
     """Resolve one skill-relative file to its agent-visible path and diagnostic."""
-
     resource = raw_resource.strip()
     if not resource:
         return None, "resource path must be a non-empty string"
@@ -387,7 +385,6 @@ def resolve_skill_selections(
     selections for one skill are merged in first-seen order to keep continuation
     prompts compact and deterministic.
     """
-
     merged: dict[str, tuple[str, list[str]]] = {}
     diagnostics: list[str] = []
     for index, selection in enumerate(selections, start=1):

--- a/tests/_agent_cli/fixtures/agents.py
+++ b/tests/_agent_cli/fixtures/agents.py
@@ -303,11 +303,10 @@ class ScriptGeneratingAgent(CodingAgent):
                     content = "#!/bin/bash\necho 'Deployment successful'\nexit 0\n"
                 else:
                     content = "#!/bin/bash\necho 'Health check passed'\nexit 0\n"
+            elif filename == "deploy.sh":
+                content = "#!/bin/bash\necho 'Deployment failed'\nexit 1\n"
             else:
-                if filename == "deploy.sh":
-                    content = "#!/bin/bash\necho 'Deployment failed'\nexit 1\n"
-                else:
-                    content = "#!/bin/bash\necho 'Health check failed'\nexit 1\n"
+                content = "#!/bin/bash\necho 'Health check failed'\nexit 1\n"
 
             script_path.write_text(content, encoding="utf-8")
             script_path.chmod(0o755)

--- a/tests/_agent_cli/fixtures/agents.py
+++ b/tests/_agent_cli/fixtures/agents.py
@@ -29,7 +29,7 @@ class StubAgent(CodingAgent):
     succeeds without extra mocking.
     """
 
-    def __init__(self, response: str = "stub response", model=None):
+    def __init__(self, response: str = "stub response", model=None):  # noqa: ANN001, ANN204  # tracked: #288
         """Initialize the stub agent.
 
         Args:
@@ -41,7 +41,7 @@ class StubAgent(CodingAgent):
         self.calls: list[dict[str, Any]] = []
         self.generate_calls: list[dict[str, Any]] = []
 
-    def generate(self, prompt: str, cwd=None, timeout=300, silent=False, **kwargs) -> str:
+    def generate(self, prompt: str, cwd=None, timeout=300, silent=False, **kwargs) -> str:  # noqa: ANN001, ANN003, FBT002  # tracked: #288
         """Return a stub response and record the call.
 
         When the prompt looks like a health assessment request, returns a
@@ -67,11 +67,11 @@ class StubAgent(CodingAgent):
             return HEALTH_VERDICT_HEALTHY
         return self.response
 
-    def run(self, *args, **kwargs):
+    def run(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG002  # tracked: #288
         """No-op run method for operator tests."""
         return {}
 
-    def start_event_stream(self, *args, **kwargs):
+    def start_event_stream(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN202  # tracked: #288
         """No-op event stream for operator tests."""
 
 
@@ -81,7 +81,7 @@ class ErrorAgent(CodingAgent):
     Use this to test error handling paths.
     """
 
-    def __init__(self, error_message: str = "Simulated agent error"):
+    def __init__(self, error_message: str = "Simulated agent error"):  # noqa: ANN204  # tracked: #288
         """Initialize the error agent.
 
         Args:
@@ -89,7 +89,7 @@ class ErrorAgent(CodingAgent):
         """
         self.error_message = error_message
 
-    def generate(self, prompt: str, **kwargs) -> str:  # type: ignore[override]
+    def generate(self, prompt: str, **kwargs) -> str:  # type: ignore[override]  # noqa: ANN003, ARG002  # tracked: #288
         """Raise a RuntimeError.
 
         Args:
@@ -108,7 +108,7 @@ class TimeoutAgent(CodingAgent):
     Use this to test timeout handling.
     """
 
-    def __init__(self, sleep_duration: float = 999999):
+    def __init__(self, sleep_duration: float = 999999):  # noqa: ANN204  # tracked: #288
         """Initialize the timeout agent.
 
         Args:
@@ -116,7 +116,7 @@ class TimeoutAgent(CodingAgent):
         """
         self.sleep_duration = sleep_duration
 
-    def generate(self, prompt: str, timeout: int = 300, **kwargs) -> str:  # type: ignore[override]
+    def generate(self, prompt: str, timeout: int = 300, **kwargs) -> str:  # type: ignore[override]  # noqa: ANN003, ARG002  # tracked: #288
         """Sleep longer than the timeout.
 
         Args:
@@ -137,7 +137,7 @@ class TrackingAgent(CodingAgent):
     Use this to verify agent interactions without relying on mocks.
     """
 
-    def __init__(self, response: str = "tracking response"):
+    def __init__(self, response: str = "tracking response"):  # noqa: ANN204  # tracked: #288
         """Initialize the tracking agent.
 
         Args:
@@ -148,7 +148,7 @@ class TrackingAgent(CodingAgent):
         self.generation_count = 0
         self.response = response
 
-    def generate(self, prompt: str, **kwargs) -> str:  # type: ignore[override]
+    def generate(self, prompt: str, **kwargs) -> str:  # type: ignore[override]  # noqa: ANN003  # tracked: #288
         """Track the call and return a response.
 
         Args:
@@ -169,7 +169,7 @@ class TrackingAgent(CodingAgent):
             return HEALTH_VERDICT_HEALTHY
         return self.response
 
-    def reset(self):
+    def reset(self):  # noqa: ANN202  # tracked: #288
         """Reset all tracking state."""
         self.calls.clear()
         self.fix_request_count = 0
@@ -183,13 +183,13 @@ class ConfigurableAgent(CodingAgent):
     for different prompts.
     """
 
-    def __init__(self):
+    def __init__(self):  # noqa: ANN204  # tracked: #288
         """Initialize the configurable agent."""
         self.responses: dict[str, str] = {}
         self.default_response = "default response"
         self.calls: list[dict[str, Any]] = []
 
-    def set_response(self, keyword: str, response: str):
+    def set_response(self, keyword: str, response: str):  # noqa: ANN202  # tracked: #288
         """Configure a response for prompts containing a keyword.
 
         Args:
@@ -198,7 +198,7 @@ class ConfigurableAgent(CodingAgent):
         """
         self.responses[keyword.lower()] = response
 
-    def set_default_response(self, response: str):
+    def set_default_response(self, response: str):  # noqa: ANN202  # tracked: #288
         """Set the default response for unmatched prompts.
 
         Args:
@@ -206,7 +206,7 @@ class ConfigurableAgent(CodingAgent):
         """
         self.default_response = response
 
-    def generate(self, prompt: str, **kwargs) -> str:  # type: ignore[override]
+    def generate(self, prompt: str, **kwargs) -> str:  # type: ignore[override]  # noqa: ANN003  # tracked: #288
         """Return a configured response based on the prompt.
 
         Args:
@@ -234,9 +234,9 @@ class ScriptGeneratingAgent(CodingAgent):
     integration testing the deployment flow.
     """
 
-    def __init__(
+    def __init__(  # noqa: ANN204  # tracked: #288
         self,
-        generate_valid_scripts: bool = True,
+        generate_valid_scripts: bool = True,  # noqa: FBT001, FBT002  # tracked: #288
         responses: list[str] | None = None,
     ):
         """Initialize the script generating agent.
@@ -254,7 +254,7 @@ class ScriptGeneratingAgent(CodingAgent):
         ]
         self.call_count = 0
 
-    def generate(self, prompt: str, cwd: str | None = None, timeout: int = 300, **kwargs) -> str:  # type: ignore[override]
+    def generate(self, prompt: str, cwd: str | None = None, timeout: int = 300, **kwargs) -> str:  # type: ignore[override]  # noqa: ANN003, ARG002  # tracked: #288
         """Generate scripts based on the prompt.
 
         Args:
@@ -271,7 +271,7 @@ class ScriptGeneratingAgent(CodingAgent):
         if cwd is None:
             return "No working directory specified"
 
-        from pathlib import Path
+        from pathlib import Path  # noqa: PLC0415  # tracked: #288
 
         cwd_path = Path(cwd)
         sds_dir = cwd_path / ".sds"

--- a/tests/_agent_cli/test_agentshim_compat.py
+++ b/tests/_agent_cli/test_agentshim_compat.py
@@ -5,15 +5,15 @@ import agentshim
 import vibesys._agent_cli.cli_agent
 
 
-def test_recorder_api_removed_in_favor_of_agent_event_handler():
+def test_recorder_api_removed_in_favor_of_agent_event_handler():  # noqa: ANN202  # tracked: #288
     assert not hasattr(agentshim, "trajectory")
     assert (
         "recorder"
-        not in inspect.signature(vibesys._agent_cli.cli_agent.CLICodingAgent.__init__).parameters
+        not in inspect.signature(vibesys._agent_cli.cli_agent.CLICodingAgent.__init__).parameters  # noqa: SLF001  # tracked: #288
     )
     assert (
         "recorder"
         not in inspect.signature(
-            vibesys._agent_cli.cli_agent.CLIGenerationSession.__init__
+            vibesys._agent_cli.cli_agent.CLIGenerationSession.__init__  # noqa: SLF001  # tracked: #288
         ).parameters
     )

--- a/tests/_agent_cli/test_claude.py
+++ b/tests/_agent_cli/test_claude.py
@@ -20,7 +20,7 @@ _SCHEMA = {
 class _MockCommandExecutor:
     """CommandExecutor that avoids real binary lookups."""
 
-    def find_binary(self, binary_name: str, env: dict[str, str]) -> str:
+    def find_binary(self, binary_name: str, env: dict[str, str]) -> str:  # noqa: ARG002  # tracked: #288
         return f"/usr/local/bin/{binary_name}"
 
     def check_binary(
@@ -32,18 +32,18 @@ class _MockCommandExecutor:
     ) -> None:
         pass
 
-    def run(self, request, sink):
+    def run(self, request, sink):  # noqa: ANN001, ANN202  # tracked: #288
         raise NotImplementedError("should not be called in these tests")
 
 
 @pytest.fixture
-def mock_binaries():
+def mock_binaries():  # noqa: ANN202  # tracked: #288
     """Provide a mock CommandExecutor that bypasses real binary discovery."""
     return _MockCommandExecutor()
 
 
 @pytest.fixture
-def agent(mock_binaries):
+def agent(mock_binaries):  # noqa: ANN001, ANN202  # tracked: #288
     """Create a ClaudeCodeCodingAgent with mocked binaries."""
     return ClaudeCodeCodingAgent(model="test-model", executor=mock_binaries)
 
@@ -51,30 +51,30 @@ def agent(mock_binaries):
 class TestClaudeCodeCodingAgentInit:
     """Tests for ClaudeCodeCodingAgent initialization."""
 
-    def test_binary_name_is_claude(self, agent):
+    def test_binary_name_is_claude(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
         assert agent.binary_name == "claude"
 
-    def test_binary_path_resolved(self, agent):
+    def test_binary_path_resolved(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
         assert agent.binary_path == "/usr/local/bin/claude"
 
-    def test_claude_path_property(self, agent):
+    def test_claude_path_property(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
         """claude_path is a backward-compatible alias for binary_path."""
         assert agent.claude_path == agent.binary_path
 
-    def test_model_stored(self, agent):
+    def test_model_stored(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
         assert agent.model == "test-model"
 
-    def test_default_model_is_none(self, mock_binaries):
+    def test_default_model_is_none(self, mock_binaries):  # noqa: ANN001, ANN202  # tracked: #288
         agent = ClaudeCodeCodingAgent(executor=mock_binaries)
         assert agent.model is None
 
-    def test_log_prefix(self, agent):
-        assert agent._log_prefix == "[Claude]"
+    def test_log_prefix(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
+        assert agent._log_prefix == "[Claude]"  # noqa: SLF001  # tracked: #288
 
-    def test_binary_not_found_raises_runtime_error(self):
+    def test_binary_not_found_raises_runtime_error(self):  # noqa: ANN202  # tracked: #288
         class _FailExecutor(_MockCommandExecutor):
-            def find_binary(self, binary_name, env):
-                raise RuntimeError(f"{binary_name} binary not found in PATH.")
+            def find_binary(self, binary_name, env):  # noqa: ANN001, ANN202, ARG002  # tracked: #288
+                raise RuntimeError(f"{binary_name} binary not found in PATH.")  # noqa: TRY003  # tracked: #288
 
         with pytest.raises(RuntimeError, match="claude binary not found"):
             ClaudeCodeCodingAgent(executor=_FailExecutor())
@@ -83,8 +83,8 @@ class TestClaudeCodeCodingAgentInit:
 class TestClaudeCommandConstruction:
     """Tests for _get_command method."""
 
-    def test_command_includes_required_flags(self, agent):
-        cmd = agent._get_command("test prompt")
+    def test_command_includes_required_flags(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
+        cmd = agent._get_command("test prompt")  # noqa: SLF001  # tracked: #288
         assert agent.binary_path in cmd
         assert "-p" in cmd
         assert "--dangerously-skip-permissions" in cmd
@@ -92,18 +92,18 @@ class TestClaudeCommandConstruction:
         assert "stream-json" in cmd
         assert "--verbose" in cmd
 
-    def test_command_includes_model_when_set(self, agent):
-        cmd = agent._get_command("test prompt")
+    def test_command_includes_model_when_set(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
+        cmd = agent._get_command("test prompt")  # noqa: SLF001  # tracked: #288
         assert "--model" in cmd
         idx = cmd.index("--model")
         assert cmd[idx + 1] == "test-model"
 
-    def test_command_omits_model_when_none(self, mock_binaries):
+    def test_command_omits_model_when_none(self, mock_binaries):  # noqa: ANN001, ANN202  # tracked: #288
         agent = ClaudeCodeCodingAgent(model=None, executor=mock_binaries)
-        cmd = agent._get_command("test prompt")
+        cmd = agent._get_command("test prompt")  # noqa: SLF001  # tracked: #288
         assert "--model" not in cmd
 
-    def test_command_omits_prompt_from_argv(self, agent):
+    def test_command_omits_prompt_from_argv(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
         """Prompt is piped via stdin, not embedded in argv.
 
         Keeping the prompt out of /proc/<pid>/cmdline matters because the
@@ -111,32 +111,32 @@ class TestClaudeCommandConstruction:
         otherwise match the running ``claude`` process by command-line
         substring and SIGTERM it (see commit 794627c).
         """
-        cmd = agent._get_command("deploy the app")
+        cmd = agent._get_command("deploy the app")  # noqa: SLF001  # tracked: #288
         assert "deploy the app" not in cmd
 
 
 class TestClaudeNativeOutputSchema:
     """Tests for native ``--json-schema`` structured output wiring."""
 
-    def test_advertises_native_output_schema(self):
+    def test_advertises_native_output_schema(self):  # noqa: ANN202  # tracked: #288
         assert ClaudeCodeCodingAgent.supports_native_output_schema is True
 
-    def test_wants_absolute_schema_path(self):
+    def test_wants_absolute_schema_path(self):  # noqa: ANN202  # tracked: #288
         # ``--json-schema`` is read inline at build time, so the schema file
         # path must be resolvable independent of the subprocess cwd.
         assert ClaudeCodeCodingAgent.native_output_schema_wants_absolute_path is True
 
-    def test_command_omits_json_schema_when_unset(self, agent):
-        cmd = agent._get_command("test prompt")
+    def test_command_omits_json_schema_when_unset(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
+        cmd = agent._get_command("test prompt")  # noqa: SLF001  # tracked: #288
         assert "--json-schema" not in cmd
         # No schema => the streaming envelope is unchanged.
         assert "stream-json" in cmd
 
-    def test_resume_command_omits_json_schema_when_unset(self, agent):
-        cmd = agent._get_resume_command("test prompt", "sess-1")
+    def test_resume_command_omits_json_schema_when_unset(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
+        cmd = agent._get_resume_command("test prompt", "sess-1")  # noqa: SLF001  # tracked: #288
         assert "--json-schema" not in cmd
 
-    def test_set_output_schema_path_reads_and_inlines(self, agent, tmp_path):
+    def test_set_output_schema_path_reads_and_inlines(self, agent, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         schema_file = tmp_path / "schema.json"
         schema_file.write_text(json.dumps(_SCHEMA, indent=2), encoding="utf-8")
 
@@ -147,12 +147,12 @@ class TestClaudeNativeOutputSchema:
         assert " " not in agent.output_schema_json
         assert json.loads(agent.output_schema_json) == _SCHEMA
 
-    def test_command_includes_json_schema_when_set(self, agent, tmp_path):
+    def test_command_includes_json_schema_when_set(self, agent, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         schema_file = tmp_path / "schema.json"
         schema_file.write_text(json.dumps(_SCHEMA), encoding="utf-8")
         agent.set_output_schema_path(str(schema_file))
 
-        cmd = agent._get_command("test prompt")
+        cmd = agent._get_command("test prompt")  # noqa: SLF001  # tracked: #288
 
         assert "--json-schema" in cmd
         inline = cmd[cmd.index("--json-schema") + 1]
@@ -160,31 +160,31 @@ class TestClaudeNativeOutputSchema:
         # The streaming transport is retained alongside the schema.
         assert "stream-json" in cmd
 
-    def test_resume_command_includes_json_schema_when_set(self, agent, tmp_path):
+    def test_resume_command_includes_json_schema_when_set(self, agent, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         schema_file = tmp_path / "schema.json"
         schema_file.write_text(json.dumps(_SCHEMA), encoding="utf-8")
         agent.set_output_schema_path(str(schema_file))
 
-        cmd = agent._get_resume_command("test prompt", "sess-1")
+        cmd = agent._get_resume_command("test prompt", "sess-1")  # noqa: SLF001  # tracked: #288
 
         assert "--json-schema" in cmd
         assert json.loads(cmd[cmd.index("--json-schema") + 1]) == _SCHEMA
 
-    def test_set_output_schema_path_none_clears_previous(self, agent, tmp_path):
+    def test_set_output_schema_path_none_clears_previous(self, agent, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         schema_file = tmp_path / "schema.json"
         schema_file.write_text(json.dumps(_SCHEMA), encoding="utf-8")
         agent.set_output_schema_path(str(schema_file))
         agent.set_output_schema_path(None)
 
         assert agent.output_schema_json is None
-        assert "--json-schema" not in agent._get_command("test prompt")
+        assert "--json-schema" not in agent._get_command("test prompt")  # noqa: SLF001  # tracked: #288
 
-    def test_missing_schema_file_raises_actionable_error(self, agent, tmp_path):
+    def test_missing_schema_file_raises_actionable_error(self, agent, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         missing = tmp_path / "does-not-exist.json"
         with pytest.raises(RuntimeError, match="unreadable"):
             agent.set_output_schema_path(str(missing))
 
-    def test_invalid_schema_json_raises_actionable_error(self, agent, tmp_path):
+    def test_invalid_schema_json_raises_actionable_error(self, agent, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         schema_file = tmp_path / "schema.json"
         schema_file.write_text("{not valid json", encoding="utf-8")
         with pytest.raises(RuntimeError, match="not valid JSON"):
@@ -194,7 +194,7 @@ class TestClaudeNativeOutputSchema:
 class TestClaudeGenerationSession:
     """Tests for ClaudeGenerationSession event processing."""
 
-    def _make_session(self, event_handler=None):
+    def _make_session(self, event_handler=None):  # noqa: ANN001, ANN202  # tracked: #288
         return ClaudeGenerationSession(
             binary_name="claude",
             env={},
@@ -205,23 +205,23 @@ class TestClaudeGenerationSession:
             event_handler=event_handler,
         )
 
-    def test_process_stdout_parses_text_event(self):
+    def test_process_stdout_parses_text_event(self):  # noqa: ANN202  # tracked: #288
         session = self._make_session()
         line = '{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}\n'
-        session._process_stdout(line)
+        session._process_stdout(line)  # noqa: SLF001  # tracked: #288
         assert "hello" in session.stdout_lines
 
-    def test_process_stdout_parses_tool_use_event(self):
+    def test_process_stdout_parses_tool_use_event(self):  # noqa: ANN202  # tracked: #288
         session = self._make_session()
         line = (
             '{"type":"assistant","message":{"content":'
             '[{"type":"tool_use","name":"Bash","id":"t1","input":{"cmd":"ls"}}]}}\n'
         )
-        session._process_stdout(line)
+        session._process_stdout(line)  # noqa: SLF001  # tracked: #288
         assert "t1" in session.tool_map
         assert session.tool_map["t1"] == "Bash"
 
-    def test_process_stdout_parses_tool_result_event(self):
+    def test_process_stdout_parses_tool_result_event(self):  # noqa: ANN202  # tracked: #288
         session = self._make_session()
         # Set up tool map first
         session.tool_map["t1"] = "Bash"
@@ -229,44 +229,44 @@ class TestClaudeGenerationSession:
         session.tool_args["t1"] = {"cmd": "ls"}
 
         line = '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"file1.txt"}]}}\n'
-        session._process_stdout(line)
+        session._process_stdout(line)  # noqa: SLF001  # tracked: #288
         # Tool result was processed without raising.
 
-    def test_process_stdout_parses_result_event(self):
+    def test_process_stdout_parses_result_event(self):  # noqa: ANN202  # tracked: #288
         session = self._make_session()
         line = '{"type":"result","result":"all done"}\n'
-        session._process_stdout(line)
+        session._process_stdout(line)  # noqa: SLF001  # tracked: #288
         assert session.final_result == "all done"
 
-    def test_process_stdout_handles_non_json(self):
+    def test_process_stdout_handles_non_json(self):  # noqa: ANN202  # tracked: #288
         session = self._make_session()
-        session._process_stdout("some plain text\n")
+        session._process_stdout("some plain text\n")  # noqa: SLF001  # tracked: #288
         assert "some plain text" in session.stdout_lines
 
-    def test_process_stdout_skips_empty_lines(self):
+    def test_process_stdout_skips_empty_lines(self):  # noqa: ANN202  # tracked: #288
         session = self._make_session()
-        session._process_stdout("")
+        session._process_stdout("")  # noqa: SLF001  # tracked: #288
         assert session.stdout_lines == []
 
-    def test_event_handler_on_thinking_called(self):
+    def test_event_handler_on_thinking_called(self):  # noqa: ANN202  # tracked: #288
         handler = MagicMock()
         session = self._make_session(event_handler=handler)
         line = '{"type":"assistant","message":{"content":[{"type":"text","text":"thinking..."}]}}\n'
-        session._process_stdout(line)
+        session._process_stdout(line)  # noqa: SLF001  # tracked: #288
         handler.on_thinking.assert_called_once_with("thinking...")
 
-    def test_event_handler_on_tool_call_called(self):
+    def test_event_handler_on_tool_call_called(self):  # noqa: ANN202  # tracked: #288
         handler = MagicMock()
         session = self._make_session(event_handler=handler)
         line = (
             '{"type":"assistant","message":{"content":'
             '[{"type":"tool_use","name":"Read","id":"t2","input":{"path":"/tmp"}}]}}\n'
         )
-        session._process_stdout(line)
-        handler.on_tool_call.assert_called_once_with("Read", {"path": "/tmp"})
+        session._process_stdout(line)  # noqa: SLF001  # tracked: #288
+        handler.on_tool_call.assert_called_once_with("Read", {"path": "/tmp"})  # noqa: S108  # tracked: #288
 
-    def test_create_session_returns_claude_session(self, agent):
-        session = agent._create_session(cmd=["claude", "-p"])
+    def test_create_session_returns_claude_session(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
+        session = agent._create_session(cmd=["claude", "-p"])  # noqa: SLF001  # tracked: #288
         assert isinstance(session, ClaudeGenerationSession)
         # The structured-output-aware subclass is used for every turn.
         assert isinstance(session, StructuredOutputClaudeSession)
@@ -275,11 +275,11 @@ class TestClaudeGenerationSession:
 class _ReplayExecutor:
     """CommandExecutor that replays canned stdout lines through the sink."""
 
-    def __init__(self, lines):
+    def __init__(self, lines):  # noqa: ANN001, ANN204  # tracked: #288
         self._lines = list(lines)
 
-    def run(self, request, sink):
-        from agentshim.executor import CommandResult
+    def run(self, request, sink):  # noqa: ANN001, ANN202, ARG002  # tracked: #288
+        from agentshim.executor import CommandResult  # noqa: PLC0415  # tracked: #288
 
         for line in self._lines:
             sink.stdout(line)
@@ -289,7 +289,7 @@ class _ReplayExecutor:
 class TestStructuredOutputClaudeSession:
     """Tests for capturing and preferring the ``structured_output`` field."""
 
-    def _make_session(self, event_handler=None, executor=None):
+    def _make_session(self, event_handler=None, executor=None):  # noqa: ANN001, ANN202  # tracked: #288
         return StructuredOutputClaudeSession(
             binary_name="claude",
             env={},
@@ -301,18 +301,18 @@ class TestStructuredOutputClaudeSession:
             executor=executor,
         )
 
-    def test_captures_structured_output_from_result_event(self):
+    def test_captures_structured_output_from_result_event(self):  # noqa: ANN202  # tracked: #288
         session = self._make_session()
         line = (
             '{"type":"result","result":"{\\"a\\":3,\\"b\\":5}","structured_output":{"a":3,"b":5}}\n'
         )
-        session._process_stdout(line)
+        session._process_stdout(line)  # noqa: SLF001  # tracked: #288
         # agentshim still records the freeform ``result`` text ...
         assert session.final_result == '{"a":3,"b":5}'
         # ... and the schema-enforced payload is captured separately.
         assert session.structured_output == {"a": 3, "b": 5}
 
-    def test_run_prefers_serialized_structured_output(self):
+    def test_run_prefers_serialized_structured_output(self):  # noqa: ANN202  # tracked: #288
         # Even if ``result`` held prose, ``run`` returns the schema payload.
         line = (
             '{"type":"result","result":"here is your answer","structured_output":{"a":3,"b":5}}\n'
@@ -321,29 +321,29 @@ class TestStructuredOutputClaudeSession:
         result = session.run("prompt")
         assert json.loads(result) == {"a": 3, "b": 5}
 
-    def test_run_falls_back_to_result_without_structured_output(self):
+    def test_run_falls_back_to_result_without_structured_output(self):  # noqa: ANN202  # tracked: #288
         line = '{"type":"result","result":"plain text answer"}\n'
         session = self._make_session(executor=_ReplayExecutor([line]))
         assert session.run("prompt") == "plain text answer"
 
-    def test_absent_structured_output_leaves_none(self):
+    def test_absent_structured_output_leaves_none(self):  # noqa: ANN202  # tracked: #288
         session = self._make_session()
-        session._process_stdout('{"type":"result","result":"plain text answer"}\n')
+        session._process_stdout('{"type":"result","result":"plain text answer"}\n')  # noqa: SLF001  # tracked: #288
         assert session.structured_output is None
         assert session.final_result == "plain text answer"
 
-    def test_null_structured_output_is_ignored(self):
+    def test_null_structured_output_is_ignored(self):  # noqa: ANN202  # tracked: #288
         session = self._make_session()
-        session._process_stdout('{"type":"result","result":"done","structured_output":null}\n')
+        session._process_stdout('{"type":"result","result":"done","structured_output":null}\n')  # noqa: SLF001  # tracked: #288
         assert session.structured_output is None
 
-    def test_non_json_line_does_not_raise(self):
+    def test_non_json_line_does_not_raise(self):  # noqa: ANN202  # tracked: #288
         session = self._make_session()
-        session._process_stdout("starting claude...\n")
+        session._process_stdout("starting claude...\n")  # noqa: SLF001  # tracked: #288
         assert session.structured_output is None
         assert "starting claude..." in session.stdout_lines
 
-    def test_assistant_usage_forwarded_to_event_handler(self):
+    def test_assistant_usage_forwarded_to_event_handler(self):  # noqa: ANN202  # tracked: #288
         """Per-turn ``message.usage`` is forwarded via ``on_usage`` so the
         agent prefix can refresh on every assistant event — including
         tool-only turns with no text blocks."""
@@ -355,7 +355,7 @@ class TestStructuredOutputClaudeSession:
             '"usage":{"input_tokens":14000,"output_tokens":50,'
             '"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}\n'
         )
-        session._process_stdout(line)
+        session._process_stdout(line)  # noqa: SLF001  # tracked: #288
         handler.on_usage.assert_called_once_with(
             {
                 "input_tokens": 14000,
@@ -365,27 +365,27 @@ class TestStructuredOutputClaudeSession:
             }
         )
 
-    def test_assistant_without_usage_does_not_call_on_usage(self):
+    def test_assistant_without_usage_does_not_call_on_usage(self):  # noqa: ANN202  # tracked: #288
         handler = MagicMock()
         session = self._make_session(event_handler=handler)
         line = '{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}\n'
-        session._process_stdout(line)
+        session._process_stdout(line)  # noqa: SLF001  # tracked: #288
         handler.on_usage.assert_not_called()
 
-    def test_result_event_captures_final_usage_and_cost(self):
+    def test_result_event_captures_final_usage_and_cost(self):  # noqa: ANN202  # tracked: #288
         session = self._make_session()
         line = (
             '{"type":"result","result":"done",'
             '"usage":{"input_tokens":7000,"output_tokens":120},'
             '"total_cost_usd":0.0456,"duration_ms":12345}\n'
         )
-        session._process_stdout(line)
+        session._process_stdout(line)  # noqa: SLF001  # tracked: #288
         assert session.final_result == "done"
         assert session.final_usage == {"input_tokens": 7000, "output_tokens": 120}
         assert session.total_cost_usd == 0.0456
         assert session.duration_ms == 12345
 
-    def test_legacy_event_handler_without_on_usage_still_works(self):
+    def test_legacy_event_handler_without_on_usage_still_works(self):  # noqa: ANN202  # tracked: #288
         """Handlers that don't implement ``on_usage`` must not crash the session.
 
         The plan calls out that Protocol is structural, so we guard the
@@ -394,16 +394,16 @@ class TestStructuredOutputClaudeSession:
 
         # A handler object that only implements the original three hooks.
         class LegacyHandler:
-            def __init__(self):
+            def __init__(self):  # noqa: ANN204  # tracked: #288
                 self.text_calls = []
 
-            def on_thinking(self, text):
+            def on_thinking(self, text):  # noqa: ANN001, ANN202  # tracked: #288
                 self.text_calls.append(text)
 
-            def on_tool_call(self, tool, args=None):
+            def on_tool_call(self, tool, args=None):  # noqa: ANN001, ANN202  # tracked: #288
                 pass
 
-            def on_tool_result(self, tool, stdout="", stderr="", exit_code=None, duration=None):
+            def on_tool_result(self, tool, stdout="", stderr="", exit_code=None, duration=None):  # noqa: ANN001, ANN202  # tracked: #288
                 pass
 
         handler = LegacyHandler()
@@ -414,5 +414,5 @@ class TestStructuredOutputClaudeSession:
             '"usage":{"input_tokens":500,"output_tokens":10}}}\n'
         )
         # Must not raise even though LegacyHandler has no on_usage method.
-        session._process_stdout(line)
+        session._process_stdout(line)  # noqa: SLF001  # tracked: #288
         assert handler.text_calls == ["hi"]

--- a/tests/_agent_cli/test_cleanup.py
+++ b/tests/_agent_cli/test_cleanup.py
@@ -57,10 +57,10 @@ class RecordingExecutor:
 
 
 class DummyAgent(CLICodingAgent[CLIGenerationSession]):
-    def __init__(self, executor: RecordingExecutor):
+    def __init__(self, executor: RecordingExecutor):  # noqa: ANN204  # tracked: #288
         super().__init__("dummy", executor=executor)
 
-    def _get_command(self, prompt: str) -> list[str]:
+    def _get_command(self, prompt: str) -> list[str]:  # noqa: ARG002  # tracked: #288
         return [self.binary_path, "run"]
 
     def _create_session(
@@ -68,7 +68,7 @@ class DummyAgent(CLICodingAgent[CLIGenerationSession]):
         cmd: list[str],
         cwd: str | None = None,
         timeout: int | None = None,
-        silent: bool = False,
+        silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> CLIGenerationSession:
         return CLIGenerationSession(
             binary_name=self.binary_name,
@@ -84,7 +84,7 @@ class DummyAgent(CLICodingAgent[CLIGenerationSession]):
         )
 
 
-def test_agent_initialization_uses_command_executor():
+def test_agent_initialization_uses_command_executor():  # noqa: ANN202  # tracked: #288
     executor = RecordingExecutor()
 
     agent = DummyAgent(executor)
@@ -94,13 +94,13 @@ def test_agent_initialization_uses_command_executor():
     assert executor.check_calls == [("/usr/bin/dummy", agent.env, 10)]
 
 
-def test_generate_routes_command_through_executor():
+def test_generate_routes_command_through_executor():  # noqa: ANN202  # tracked: #288
     executor = RecordingExecutor(stdout=["hello\n", "world\n"])
     agent = DummyAgent(executor)
 
     result = agent.generate(
         "prompt text",
-        cwd="/tmp/workspace",
+        cwd="/tmp/workspace",  # noqa: S108  # tracked: #288
         timeout=123,
         silent=True,
     )
@@ -109,12 +109,12 @@ def test_generate_routes_command_through_executor():
     call = executor.run_calls[0]
     assert call.argv == ["/usr/bin/dummy", "run"]
     assert call.stdin == "prompt text"
-    assert call.cwd == "/tmp/workspace"
+    assert call.cwd == "/tmp/workspace"  # noqa: S108  # tracked: #288
     assert call.env is agent.env
     assert call.timeout == 123
 
 
-def test_generate_raises_on_nonzero_executor_result():
+def test_generate_raises_on_nonzero_executor_result():  # noqa: ANN202  # tracked: #288
     executor = RecordingExecutor(stderr=["bad\n"], returncode=17)
     agent = DummyAgent(executor)
 
@@ -122,7 +122,7 @@ def test_generate_raises_on_nonzero_executor_result():
         agent.generate("prompt", silent=True)
 
 
-def test_generate_propagates_executor_timeout():
+def test_generate_propagates_executor_timeout():  # noqa: ANN202  # tracked: #288
     timeout = subprocess.TimeoutExpired(cmd=["dummy"], timeout=1)
     executor = RecordingExecutor(run_error=timeout)
     agent = DummyAgent(executor)
@@ -131,7 +131,7 @@ def test_generate_propagates_executor_timeout():
         agent.generate("prompt", timeout=1, silent=True)
 
 
-def test_multiple_generates_reuse_executor():
+def test_multiple_generates_reuse_executor():  # noqa: ANN202  # tracked: #288
     executor = RecordingExecutor()
     agent = DummyAgent(executor)
 
@@ -149,7 +149,7 @@ def test_multiple_generates_reuse_executor():
         ("gemini", GeminiCodingAgent),
     ],
 )
-def test_provider_agents_accept_command_executor(binary_name, agent_class):
+def test_provider_agents_accept_command_executor(binary_name, agent_class):  # noqa: ANN001, ANN202  # tracked: #288
     executor = RecordingExecutor()
 
     agent = agent_class(executor=executor)

--- a/tests/_agent_cli/test_codex.py
+++ b/tests/_agent_cli/test_codex.py
@@ -35,7 +35,7 @@ def _agent() -> CodexCodingAgent:
     return agent
 
 
-def _session(event_handler=None) -> CodexGenerationSession:
+def _session(event_handler=None) -> CodexGenerationSession:  # noqa: ANN001  # tracked: #288
     """Build a CodexGenerationSession without opening pipes."""
     return CodexGenerationSession(
         binary_name="codex",
@@ -54,17 +54,17 @@ def _session(event_handler=None) -> CodexGenerationSession:
 
 
 class TestGetCommand:
-    def test_shell_path_config_preserves_launcher_path(self):
+    def test_shell_path_config_preserves_launcher_path(self):  # noqa: ANN202  # tracked: #288
         assert _shell_path_config_args({"PATH": '/opt/go/bin:/path/with"quote'}) == [
             "--config",
             'shell_environment_policy.set.PATH="/opt/go/bin:/path/with\\"quote"',
         ]
 
-    def test_shell_path_config_omits_missing_path(self):
+    def test_shell_path_config_omits_missing_path(self):  # noqa: ANN202  # tracked: #288
         assert _shell_path_config_args({}) == []
 
-    def test_initial_command_includes_skip_git_repo_check(self):
-        cmd = _agent()._get_command("hello")
+    def test_initial_command_includes_skip_git_repo_check(self):  # noqa: ANN202  # tracked: #288
+        cmd = _agent()._get_command("hello")  # noqa: SLF001  # tracked: #288
         assert "--skip-git-repo-check" in cmd
         assert "--dangerously-bypass-approvals-and-sandbox" in cmd
         assert "--json" in cmd
@@ -72,30 +72,30 @@ class TestGetCommand:
         assert cmd[1] == "exec"
         assert "resume" not in cmd
 
-    def test_initial_command_includes_model_when_set(self):
+    def test_initial_command_includes_model_when_set(self):  # noqa: ANN202  # tracked: #288
         agent = _agent()
         agent.model = "gpt-5"
-        cmd = agent._get_command("hello")
+        cmd = agent._get_command("hello")  # noqa: SLF001  # tracked: #288
         assert "--model" in cmd
         assert cmd[cmd.index("--model") + 1] == "gpt-5"
 
-    def test_initial_command_appends_extra_config_args(self):
+    def test_initial_command_appends_extra_config_args(self):  # noqa: ANN202  # tracked: #288
         agent = _agent()
         agent.extra_config_args = ["--config", "foo=1"]
-        cmd = agent._get_command("hello")
+        cmd = agent._get_command("hello")  # noqa: SLF001  # tracked: #288
         assert cmd[-2:] == ["--config", "foo=1"]
 
-    def test_reasoning_effort_is_passed_as_codex_config(self):
+    def test_reasoning_effort_is_passed_as_codex_config(self):  # noqa: ANN202  # tracked: #288
         agent = _agent()
         agent.set_reasoning_effort("xhigh")
-        cmd = agent._get_command("hello")
+        cmd = agent._get_command("hello")  # noqa: SLF001  # tracked: #288
         assert 'model_reasoning_effort="xhigh"' in cmd
 
-    def test_initial_command_includes_native_output_schema(self):
+    def test_initial_command_includes_native_output_schema(self):  # noqa: ANN202  # tracked: #288
         agent = _agent()
         agent.set_output_schema_path(".cache/vibesys/response-schemas/judge.json")
 
-        cmd = agent._get_command("hello")
+        cmd = agent._get_command("hello")  # noqa: SLF001  # tracked: #288
 
         assert cmd[cmd.index("--output-schema") + 1] == (
             ".cache/vibesys/response-schemas/judge.json"
@@ -103,9 +103,9 @@ class TestGetCommand:
 
 
 class TestGetResumeCommand:
-    def test_resume_passes_dash_positional(self):
+    def test_resume_passes_dash_positional(self):  # noqa: ANN202  # tracked: #288
         """Without ``-``, codex exec resume silently ignores stdin."""
-        cmd = _agent()._get_resume_command("prompt", "sess-123")
+        cmd = _agent()._get_resume_command("prompt", "sess-123")  # noqa: SLF001  # tracked: #288
         # The positional args come right after the subcommand path:
         #   codex exec resume <session_id> <prompt>
         assert cmd[:5] == [
@@ -116,25 +116,25 @@ class TestGetResumeCommand:
             "-",
         ]
 
-    def test_resume_command_includes_skip_git_repo_check(self):
-        cmd = _agent()._get_resume_command("prompt", "sess-123")
+    def test_resume_command_includes_skip_git_repo_check(self):  # noqa: ANN202  # tracked: #288
+        cmd = _agent()._get_resume_command("prompt", "sess-123")  # noqa: SLF001  # tracked: #288
         assert "--skip-git-repo-check" in cmd
         assert "--dangerously-bypass-approvals-and-sandbox" in cmd
         assert "--json" in cmd
 
-    def test_resume_command_passes_model_and_extra_config(self):
+    def test_resume_command_passes_model_and_extra_config(self):  # noqa: ANN202  # tracked: #288
         agent = _agent()
         agent.model = "gpt-5"
         agent.extra_config_args = ["--config", 'mcp_servers.x.command="python"']
-        cmd = agent._get_resume_command("prompt", "sess-123")
-        assert "--model" in cmd and cmd[cmd.index("--model") + 1] == "gpt-5"
+        cmd = agent._get_resume_command("prompt", "sess-123")  # noqa: SLF001  # tracked: #288
+        assert "--model" in cmd and cmd[cmd.index("--model") + 1] == "gpt-5"  # noqa: PT018  # tracked: #288
         assert cmd[-2:] == ["--config", 'mcp_servers.x.command="python"']
 
-    def test_resume_command_includes_native_output_schema(self):
+    def test_resume_command_includes_native_output_schema(self):  # noqa: ANN202  # tracked: #288
         agent = _agent()
         agent.set_output_schema_path(".cache/vibesys/response-schemas/implementer.json")
 
-        cmd = agent._get_resume_command("prompt", "sess-123")
+        cmd = agent._get_resume_command("prompt", "sess-123")  # noqa: SLF001  # tracked: #288
 
         assert cmd[cmd.index("--output-schema") + 1] == (
             ".cache/vibesys/response-schemas/implementer.json"
@@ -147,14 +147,14 @@ class TestGetResumeCommand:
 
 
 class TestProcessStdout:
-    def test_thread_started_captures_thread_id(self):
+    def test_thread_started_captures_thread_id(self):  # noqa: ANN202  # tracked: #288
         session = _session()
-        session._process_stdout(json.dumps({"type": "thread.started", "thread_id": "t-1"}))
+        session._process_stdout(json.dumps({"type": "thread.started", "thread_id": "t-1"}))  # noqa: SLF001  # tracked: #288
         assert session.session_id == "t-1"
 
-    def test_agent_message_captures_last_text(self):
+    def test_agent_message_captures_last_text(self):  # noqa: ANN202  # tracked: #288
         session = _session()
-        session._process_stdout(
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
             json.dumps(
                 {
                     "type": "item.completed",
@@ -164,11 +164,11 @@ class TestProcessStdout:
         )
         assert session.final_result == "final answer"
 
-    def test_agent_message_streams_through_on_thinking(self):
+    def test_agent_message_streams_through_on_thinking(self):  # noqa: ANN202  # tracked: #288
         """Assistant text should land in the log as soon as it arrives."""
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stdout(
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
             json.dumps(
                 {
                     "type": "item.completed",
@@ -178,10 +178,10 @@ class TestProcessStdout:
         )
         handler.on_thinking.assert_called_once_with("final answer")
 
-    def test_multiple_agent_messages_keep_last(self):
+    def test_multiple_agent_messages_keep_last(self):  # noqa: ANN202  # tracked: #288
         session = _session()
         for text in ["first", "second", "third"]:
-            session._process_stdout(
+            session._process_stdout(  # noqa: SLF001  # tracked: #288
                 json.dumps(
                     {
                         "type": "item.completed",
@@ -191,10 +191,10 @@ class TestProcessStdout:
             )
         assert session.final_result == "third"
 
-    def test_reasoning_forwards_to_on_thinking(self):
+    def test_reasoning_forwards_to_on_thinking(self):  # noqa: ANN202  # tracked: #288
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stdout(
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
             json.dumps(
                 {
                     "type": "item.completed",
@@ -204,12 +204,12 @@ class TestProcessStdout:
         )
         handler.on_thinking.assert_called_once_with("I should grep for X")
 
-    def test_unknown_item_types_fall_back_to_tool_call(self):
+    def test_unknown_item_types_fall_back_to_tool_call(self):  # noqa: ANN202  # tracked: #288
         """file_change / mcp_tool_call / todo_list / web_search / error …
         all surface through ``on_tool_call`` so their payloads land in the log."""
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stdout(
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
             json.dumps(
                 {
                     "type": "item.completed",
@@ -225,10 +225,10 @@ class TestProcessStdout:
             "file_change", {"path": "engine.py", "kind": "update"}
         )
 
-    def test_mcp_tool_call_falls_back_with_full_args(self):
+    def test_mcp_tool_call_falls_back_with_full_args(self):  # noqa: ANN202  # tracked: #288
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stdout(
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
             json.dumps(
                 {
                     "type": "item.completed",
@@ -252,10 +252,10 @@ class TestProcessStdout:
             },
         )
 
-    def test_error_item_surfaces_message(self):
+    def test_error_item_surfaces_message(self):  # noqa: ANN202  # tracked: #288
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stdout(
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
             json.dumps(
                 {
                     "type": "item.completed",
@@ -265,10 +265,10 @@ class TestProcessStdout:
         )
         handler.on_tool_call.assert_called_once_with("error", {"message": "rate limited"})
 
-    def test_command_execution_forwards_tool_call_and_result(self):
+    def test_command_execution_forwards_tool_call_and_result(self):  # noqa: ANN202  # tracked: #288
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stdout(
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
             json.dumps(
                 {
                     "type": "item.completed",
@@ -285,10 +285,10 @@ class TestProcessStdout:
             tool="execute", stdout="file.txt\n", exit_code=None, duration=None
         )
 
-    def test_turn_completed_captures_usage_and_normalizes_fields(self):
+    def test_turn_completed_captures_usage_and_normalizes_fields(self):  # noqa: ANN202  # tracked: #288
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stdout(
+        session._process_stdout(  # noqa: SLF001  # tracked: #288
             json.dumps(
                 {
                     "type": "turn.completed",
@@ -312,28 +312,28 @@ class TestProcessStdout:
         thinking_calls = [c.args[0] for c in handler.on_thinking.call_args_list]
         assert any("turn complete" in t for t in thinking_calls)
 
-    def test_turn_completed_without_usage_leaves_none(self):
+    def test_turn_completed_without_usage_leaves_none(self):  # noqa: ANN202  # tracked: #288
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stdout(json.dumps({"type": "turn.completed"}))
+        session._process_stdout(json.dumps({"type": "turn.completed"}))  # noqa: SLF001  # tracked: #288
         assert session.final_usage is None
         # Still emits a marker so the log shows the turn boundary.
         handler.on_thinking.assert_called_once_with("[codex turn complete]")
 
-    def test_thread_started_emits_marker(self):
+    def test_thread_started_emits_marker(self):  # noqa: ANN202  # tracked: #288
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stdout(json.dumps({"type": "thread.started", "thread_id": "t-1"}))
+        session._process_stdout(json.dumps({"type": "thread.started", "thread_id": "t-1"}))  # noqa: SLF001  # tracked: #288
         assert session.session_id == "t-1"
         handler.on_thinking.assert_called_once_with("[codex thread t-1 started]")
 
-    def test_turn_started_emits_marker(self):
+    def test_turn_started_emits_marker(self):  # noqa: ANN202  # tracked: #288
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stdout(json.dumps({"type": "turn.started"}))
+        session._process_stdout(json.dumps({"type": "turn.started"}))  # noqa: SLF001  # tracked: #288
         handler.on_thinking.assert_called_once_with("[codex turn started]")
 
-    def test_unknown_event_types_forward_raw_line(self):
+    def test_unknown_event_types_forward_raw_line(self):  # noqa: ANN202  # tracked: #288
         """item.started / item.updated / future events pass through as thinking
         text so nothing codex emits is silently swallowed."""
         handler = MagicMock()
@@ -341,42 +341,42 @@ class TestProcessStdout:
         raw = json.dumps(
             {"type": "item.updated", "item": {"type": "reasoning", "delta": "thinking..."}}
         )
-        session._process_stdout(raw)
+        session._process_stdout(raw)  # noqa: SLF001  # tracked: #288
         handler.on_thinking.assert_called_once_with(raw)
 
-    def test_non_json_line_forwarded_to_event_handler(self):
+    def test_non_json_line_forwarded_to_event_handler(self):  # noqa: ANN202  # tracked: #288
         """Codex prints banners/warnings as plain text; these must hit the log
         even when ``silent=True`` (the legacy loguru path is gated on silent)."""
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stdout("starting codex 1.2.3\n")
+        session._process_stdout("starting codex 1.2.3\n")  # noqa: SLF001  # tracked: #288
         handler.on_thinking.assert_called_once_with("starting codex 1.2.3")
         assert "starting codex 1.2.3" in session.stdout_lines[0]
 
-    def test_non_json_line_is_still_recorded(self):
+    def test_non_json_line_is_still_recorded(self):  # noqa: ANN202  # tracked: #288
         session = _session()
-        session._process_stdout("not json at all\n")
+        session._process_stdout("not json at all\n")  # noqa: SLF001  # tracked: #288
         assert "not json at all" in session.stdout_lines[0]
 
-    def test_blank_line_is_ignored(self):
+    def test_blank_line_is_ignored(self):  # noqa: ANN202  # tracked: #288
         session = _session()
-        session._process_stdout("   \n")
+        session._process_stdout("   \n")  # noqa: SLF001  # tracked: #288
         assert session.stdout_lines == []
 
 
 class TestProcessStderr:
-    def test_stderr_forwarded_to_event_handler(self):
+    def test_stderr_forwarded_to_event_handler(self):  # noqa: ANN202  # tracked: #288
         """Stderr must surface in the log regardless of ``silent``; cli_runner
         always passes ``silent=True`` and the base class's stderr path is
         gated on it."""
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stderr("panic: index out of bounds\n")
+        session._process_stderr("panic: index out of bounds\n")  # noqa: SLF001  # tracked: #288
         handler.on_thinking.assert_called_once_with("[codex stderr] panic: index out of bounds")
         assert session.stderr_lines == ["panic: index out of bounds\n"]
 
-    def test_stderr_empty_line_ignored(self):
+    def test_stderr_empty_line_ignored(self):  # noqa: ANN202  # tracked: #288
         handler = MagicMock()
         session = _session(event_handler=handler)
-        session._process_stderr("\n")
+        session._process_stderr("\n")  # noqa: SLF001  # tracked: #288
         handler.on_thinking.assert_not_called()

--- a/tests/_agent_cli/test_docker_executor.py
+++ b/tests/_agent_cli/test_docker_executor.py
@@ -63,11 +63,11 @@ class _HungProcess(_FakeProcess):
         return self.returncode
 
 
-def test_docker_executor_runs_command_request_and_streams_to_sink(monkeypatch):
+def test_docker_executor_runs_command_request_and_streams_to_sink(monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
     process = _FakeProcess()
     popen_calls = []
 
-    def fake_popen(cmd, **kwargs):
+    def fake_popen(cmd, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
         popen_calls.append((cmd, kwargs))
         return process
 
@@ -113,10 +113,10 @@ def test_docker_executor_runs_command_request_and_streams_to_sink(monkeypatch):
     assert result.stderr == "err\n"
 
 
-def test_docker_executor_repairs_workspace_ownership(monkeypatch):
+def test_docker_executor_repairs_workspace_ownership(monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
     calls = []
 
-    def fake_run(cmd, **kwargs):
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
         calls.append((cmd, kwargs))
         return subprocess.CompletedProcess(cmd, 0, "", "")
 
@@ -152,7 +152,7 @@ def test_docker_executor_repairs_workspace_ownership(monkeypatch):
     ]
 
 
-def test_docker_executor_recovers_stable_completed_codex_rollout(monkeypatch):
+def test_docker_executor_recovers_stable_completed_codex_rollout(monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
     process = _HungProcess()
     thread_id = "019fc654-87f2-7702-8bf2-05b6f4f006dc"
     completion = _CodexRolloutCompletion(
@@ -160,16 +160,16 @@ def test_docker_executor_recovers_stable_completed_codex_rollout(monkeypatch):
         message='{"hypothesis_outcome":"inconclusive"}',
     )
     executor = DockerCommandExecutor("container-123")
-    executor._CODEX_ROLLOUT_POLL_SECONDS = 0
-    executor._CODEX_COMPLETION_GRACE_SECONDS = 0
+    executor._CODEX_ROLLOUT_POLL_SECONDS = 0  # noqa: SLF001  # tracked: #288
+    executor._CODEX_COMPLETION_GRACE_SECONDS = 0  # noqa: SLF001  # tracked: #288
 
     monkeypatch.setattr(
         "vibesys.agents.docker_executor.subprocess.Popen",
-        lambda *args, **kwargs: process,
+        lambda *args, **kwargs: process,  # noqa: ARG005  # tracked: #288
     )
     monkeypatch.setattr(
         "vibesys.agents.docker_executor.subprocess.run",
-        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, "24190\n", ""),
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, "24190\n", ""),  # noqa: ARG005  # tracked: #288
     )
     monkeypatch.setattr(executor, "_read_codex_rollout_completion", lambda _: completion)
 
@@ -213,25 +213,25 @@ def test_docker_executor_recovers_stable_completed_codex_rollout(monkeypatch):
     ]
 
 
-def test_codex_rollout_watchdog_requires_resumed_json_thread():
+def test_codex_rollout_watchdog_requires_resumed_json_thread():  # noqa: ANN202  # tracked: #288
     thread_id = "019fc654-87f2-7702-8bf2-05b6f4f006dc"
 
     assert (
-        DockerCommandExecutor._codex_resume_thread_id(
+        DockerCommandExecutor._codex_resume_thread_id(  # noqa: SLF001  # tracked: #288
             ["codex", "exec", "resume", thread_id, "-", "--json"]
         )
         == thread_id
     )
-    assert DockerCommandExecutor._codex_resume_thread_id(["codex", "exec", "--json"]) is None
+    assert DockerCommandExecutor._codex_resume_thread_id(["codex", "exec", "--json"]) is None  # noqa: SLF001  # tracked: #288
     assert (
-        DockerCommandExecutor._codex_resume_thread_id(
+        DockerCommandExecutor._codex_resume_thread_id(  # noqa: SLF001  # tracked: #288
             ["claude", "exec", "resume", thread_id, "--json"]
         )
         is None
     )
 
 
-def test_codex_rollout_watchdog_learns_fresh_thread_from_stream():
+def test_codex_rollout_watchdog_learns_fresh_thread_from_stream():  # noqa: ANN202  # tracked: #288
     thread_id = "019fc654-87f2-7702-8bf2-05b6f4f006dc"
     stdout_lines = [
         "not-json\n",
@@ -239,9 +239,9 @@ def test_codex_rollout_watchdog_learns_fresh_thread_from_stream():
         json.dumps({"type": "turn.started"}) + "\n",
     ]
 
-    assert DockerCommandExecutor._codex_started_thread_id(stdout_lines) == thread_id
+    assert DockerCommandExecutor._codex_started_thread_id(stdout_lines) == thread_id  # noqa: SLF001  # tracked: #288
     assert (
-        DockerCommandExecutor._codex_started_thread_id(
+        DockerCommandExecutor._codex_started_thread_id(  # noqa: SLF001  # tracked: #288
             [json.dumps({"type": "thread.started", "thread_id": "../../unsafe"})]
         )
         is None

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -59,7 +59,7 @@ def _bwrap_works() -> bool:
             argv += ["--ro-bind", root, root]
     argv.append(probe)
     try:
-        proc = subprocess.run(argv, capture_output=True, timeout=15)
+        proc = subprocess.run(argv, capture_output=True, timeout=15)  # noqa: PLW1510, S603  # tracked: #288
     except (OSError, subprocess.SubprocessError):
         return False
     return proc.returncode == 0
@@ -88,32 +88,32 @@ requires_sandbox = pytest.mark.skipif(
 
 
 class TestBuild:
-    def test_disabled_via_env_returns_none(self, tmp_path):
+    def test_disabled_via_env_returns_none(self, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         logs: list[str] = []
         sb = hostsandbox.build(tmp_path, env={hostsandbox.DISABLE_ENV: "0"}, log=logs.append)
         assert sb is None
         assert any("DISABLED" in m for m in logs)
 
     @pytest.mark.parametrize("value", ["0", "false", "off", "no", "FALSE", " Off "])
-    def test_disable_values(self, tmp_path, value):
+    def test_disable_values(self, tmp_path, value):  # noqa: ANN001, ANN202  # tracked: #288
         assert hostsandbox.build(tmp_path, env={hostsandbox.DISABLE_ENV: value}) is None
 
-    def test_missing_bwrap_returns_none(self, tmp_path, monkeypatch):
+    def test_missing_bwrap_returns_none(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
-        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: None)
+        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: None)  # noqa: ARG005  # tracked: #288
         logs: list[str] = []
         assert hostsandbox.build(tmp_path, env={}, log=logs.append) is None
         assert any("bwrap" in m for m in logs)
 
-    def test_unsupported_platform_returns_none(self, tmp_path, monkeypatch):
+    def test_unsupported_platform_returns_none(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         monkeypatch.setattr(hostsandbox.sys, "platform", "win32")
         logs: list[str] = []
         assert hostsandbox.build(tmp_path, env={}, log=logs.append) is None
         assert any("no host confinement backend" in m for m in logs)
 
-    def test_allow_ancestor_of_workspace_is_rejected(self, tmp_path, monkeypatch):
+    def test_allow_ancestor_of_workspace_is_rejected(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
-        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")
+        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")  # noqa: ARG005  # tracked: #288
         workspace = tmp_path / "exp_env" / "run" / "workspace"
         workspace.mkdir(parents=True)
         logs: list[str] = []
@@ -128,9 +128,9 @@ class TestBuild:
         assert tmp_path.resolve() not in sb.read_paths
         assert any("ancestor" in m for m in logs)
 
-    def test_allow_extra_path_is_bound(self, tmp_path, monkeypatch):
+    def test_allow_extra_path_is_bound(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
-        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")
+        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")  # noqa: ARG005  # tracked: #288
         workspace = tmp_path / "ws"
         workspace.mkdir()
         weights = tmp_path.parent / f"{tmp_path.name}-weights"
@@ -147,9 +147,9 @@ class TestBuild:
         finally:
             weights.rmdir()
 
-    def test_programmatic_resources_are_imported_by_access(self, tmp_path, monkeypatch):
+    def test_programmatic_resources_are_imported_by_access(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
-        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")
+        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")  # noqa: ARG005  # tracked: #288
         workspace = tmp_path / "workspace"
         readonly = tmp_path / "compiler"
         writable = tmp_path / "agent-state"
@@ -173,9 +173,9 @@ class TestBuild:
         assert readonly in sb.read_paths
         assert writable in sb.write_paths
 
-    def test_codex_auth_file_survives_nested_codex_worktree_filter(self, tmp_path, monkeypatch):
+    def test_codex_auth_file_survives_nested_codex_worktree_filter(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
-        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")
+        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")  # noqa: ARG005  # tracked: #288
         codex_home = tmp_path / ".codex"
         workspace = codex_home / "worktrees" / "run" / "workspace"
         workspace.mkdir(parents=True)
@@ -215,7 +215,7 @@ class TestWrap:
             gpu_device_nodes=(Path("/dev/nvidia0"),),
         )
 
-    def test_wrap_shape(self, tmp_path):
+    def test_wrap_shape(self, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         sb = self._sandbox(tmp_path)
         argv = sb.wrap(["codex", "exec", "--json"])
         ws = str(tmp_path)
@@ -234,7 +234,7 @@ class TestWrap:
         sep = argv.index("--")
         assert argv[sep + 1 :] == ["codex", "exec", "--json"]
 
-    def test_workspace_bind_wins_over_readonly(self, tmp_path):
+    def test_workspace_bind_wins_over_readonly(self, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         """The rw workspace bind must come after ro binds so it takes effect."""
         sb = self._sandbox(tmp_path)
         argv = sb.wrap(["agent"])
@@ -246,15 +246,15 @@ class TestWrap:
 class TestSharedAbstraction:
     """Both OS backends implement the one ``WorkspaceSandbox`` contract."""
 
-    def test_backends_subclass_workspace_sandbox(self):
+    def test_backends_subclass_workspace_sandbox(self):  # noqa: ANN202  # tracked: #288
         assert issubclass(hostsandbox.HostSandbox, hostsandbox.WorkspaceSandbox)
         assert issubclass(hostsandbox.SeatbeltSandbox, hostsandbox.WorkspaceSandbox)
 
-    def test_base_is_abstract(self):
+    def test_base_is_abstract(self):  # noqa: ANN202  # tracked: #288
         with pytest.raises(TypeError):
             hostsandbox.WorkspaceSandbox(workspace=Path("/x"))
 
-    def test_backends_share_fields_and_wrap(self):
+    def test_backends_share_fields_and_wrap(self):  # noqa: ANN202  # tracked: #288
         host = hostsandbox.HostSandbox(
             workspace=Path("/x"), bwrap_path="/usr/bin/bwrap", read_paths=(Path("/opt"),)
         )
@@ -280,11 +280,11 @@ def _has_pair(argv: list[str], flag: str, *operands: str) -> bool:
 
 
 class TestMacosBuild:
-    def _patch(self, monkeypatch, sandbox_exec="/usr/bin/sandbox-exec"):
+    def _patch(self, monkeypatch, sandbox_exec="/usr/bin/sandbox-exec"):  # noqa: ANN001, ANN202  # tracked: #288
         monkeypatch.setattr(hostsandbox.sys, "platform", "darwin")
-        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: sandbox_exec)
+        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: sandbox_exec)  # noqa: ARG005  # tracked: #288
 
-    def test_build_returns_seatbelt_on_darwin(self, tmp_path, monkeypatch):
+    def test_build_returns_seatbelt_on_darwin(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         self._patch(monkeypatch)
         workspace = tmp_path / "ws"
         workspace.mkdir()
@@ -292,13 +292,13 @@ class TestMacosBuild:
         assert isinstance(sb, hostsandbox.SeatbeltSandbox)
         assert sb.workspace == workspace.resolve()
 
-    def test_missing_sandbox_exec_returns_none(self, tmp_path, monkeypatch):
+    def test_missing_sandbox_exec_returns_none(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         self._patch(monkeypatch, sandbox_exec=None)
         logs: list[str] = []
         assert hostsandbox.build(tmp_path, env={}, log=logs.append) is None
         assert any("sandbox-exec" in m for m in logs)
 
-    def test_allow_ancestor_rejected_on_darwin(self, tmp_path, monkeypatch):
+    def test_allow_ancestor_rejected_on_darwin(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         self._patch(monkeypatch)
         workspace = tmp_path / "exp_env" / "run" / "workspace"
         workspace.mkdir(parents=True)
@@ -321,7 +321,7 @@ class TestSeatbeltProfile:
             write_paths=(Path("/home/u/.codex"),),
         )
 
-    def test_profile_write_confines_but_reads_broadly(self, tmp_path):
+    def test_profile_write_confines_but_reads_broadly(self, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         prof = self._sandbox(tmp_path).profile()
         assert prof.startswith("(version 1)\n(deny default)")
         # Reads are broad (so the toolchain launches); the workspace is writable;
@@ -332,7 +332,7 @@ class TestSeatbeltProfile:
         assert f'(subpath "{tmp_path}")' in prof
         assert "(allow network*)" in prof
 
-    def test_profile_blinds_sibling_run_area(self, tmp_path):
+    def test_profile_blinds_sibling_run_area(self, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         """The run-container tree is denied (read+write); the workspace is carved
         back out so sibling runs are hidden but the workspace still works."""
         workspace = tmp_path / "exp_env" / "run-A" / "workspace"
@@ -352,18 +352,19 @@ class TestSeatbeltProfile:
         assert reallow in prof
         assert prof.index(reallow) > deny_idx
 
-    def test_blind_roots_skip_system_dirs(self, tmp_path):
+    def test_blind_roots_skip_system_dirs(self, tmp_path):  # noqa: ANN001, ANN202, ARG002  # tracked: #288
         """A shallow workspace must never blind the filesystem root or a system
         dir (that would break the toolchain)."""
         sb = hostsandbox.SeatbeltSandbox(
-            sandbox_exec_path="/usr/bin/sandbox-exec", workspace=Path("/tmp/ws")
+            sandbox_exec_path="/usr/bin/sandbox-exec",
+            workspace=Path("/tmp/ws"),  # noqa: S108  # tracked: #288
         )
         # parent is /tmp, grandparent is / — root is skipped; no system root leaks.
         for r in sb.blind_roots():
             assert r != Path("/")
             assert not str(r).startswith("/usr")
 
-    def test_wrap_shape(self, tmp_path):
+    def test_wrap_shape(self, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         sb = self._sandbox(tmp_path)
         argv = sb.wrap(["codex", "exec", "--json"])
         assert argv[0] == "/usr/bin/sandbox-exec"
@@ -371,10 +372,10 @@ class TestSeatbeltProfile:
         assert argv[2] == sb.profile()
         assert argv[3:] == ["codex", "exec", "--json"]
 
-    def test_sbpl_string_escapes_quotes_and_backslashes(self):
-        assert hostsandbox._sbpl_string(r'/a/"b"\c') == r'"/a/\"b\"\\c"'
+    def test_sbpl_string_escapes_quotes_and_backslashes(self):  # noqa: ANN202  # tracked: #288
+        assert hostsandbox._sbpl_string(r'/a/"b"\c') == r'"/a/\"b\"\\c"'  # noqa: SLF001  # tracked: #288
 
-    def test_profile_embeds_paths_safely(self, tmp_path):
+    def test_profile_embeds_paths_safely(self, tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         """A workspace path with SBPL-significant characters stays quoted."""
         workspace = tmp_path / 'weird ")name'
         workspace.mkdir()
@@ -383,7 +384,7 @@ class TestSeatbeltProfile:
         )
         prof = sb.profile()
         # The literal appears escaped, and the raw unescaped form does not leak.
-        assert hostsandbox._sbpl_string(str(workspace)) in prof
+        assert hostsandbox._sbpl_string(str(workspace)) in prof  # noqa: SLF001  # tracked: #288
         assert f'(subpath "{workspace}")' not in prof
 
 
@@ -396,8 +397,8 @@ class _StubAgent(CLICodingAgent[CLIGenerationSession]):
     """A concrete CLICodingAgent that runs a fixed script, skipping binary
     detection — mirrors the pattern in ``test_codex.py``."""
 
-    def __init__(self, script: str):
-        from agentshim.executor import HostCommandExecutor
+    def __init__(self, script: str):  # noqa: ANN204  # tracked: #288
+        from agentshim.executor import HostCommandExecutor  # noqa: PLC0415  # tracked: #288
 
         self.executor = HostCommandExecutor()
         self.env = dict(os.environ)
@@ -405,14 +406,14 @@ class _StubAgent(CLICodingAgent[CLIGenerationSession]):
         self.binary_path = script
         self.model = None
         self.event_handler = None
-        import loguru
+        import loguru  # noqa: PLC0415  # tracked: #288
 
         self.logger = loguru.logger
         self.session_id = None
         self.sandbox = None
         self._script = script
 
-    def _get_command(self, prompt: str) -> list[str]:
+    def _get_command(self, prompt: str) -> list[str]:  # noqa: ARG002  # tracked: #288
         return [self._script]
 
     def _create_session(
@@ -420,7 +421,7 @@ class _StubAgent(CLICodingAgent[CLIGenerationSession]):
         cmd: list[str],
         cwd: str | None = None,
         timeout: int | None = None,
-        silent: bool = False,
+        silent: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
     ) -> CLIGenerationSession:
         return CLIGenerationSession(
             binary_name=self.binary_name,
@@ -436,7 +437,7 @@ class _StubAgent(CLICodingAgent[CLIGenerationSession]):
         )
 
 
-def _escape_probe(tmp_path_factory) -> tuple[_StubAgent, Path, Path]:
+def _escape_probe(tmp_path_factory) -> tuple[_StubAgent, Path, Path]:  # noqa: ANN001  # tracked: #288
     """Set up a workspace with a sibling secret and a stub agent (in a separate
     toolchain dir, like a real agent binary) that tries to read/write it."""
     host = tmp_path_factory.mktemp("host")
@@ -459,17 +460,17 @@ def _escape_probe(tmp_path_factory) -> tuple[_StubAgent, Path, Path]:
     return _StubAgent(str(script)), workspace, sibling
 
 
-def test_reproduces_escape_without_sandbox(tmp_path_factory):
+def test_reproduces_escape_without_sandbox(tmp_path_factory):  # noqa: ANN001, ANN202  # tracked: #288
     """Without confinement the stub agent reaches the sibling run — the #149 bug."""
     agent, workspace, _ = _escape_probe(tmp_path_factory)
     agent.sandbox = None  # legacy behavior
     out = agent.generate("stay in the workspace", cwd=str(workspace), silent=True)
-    assert "READ_OK" in out and "SECRET=leak" in out
+    assert "READ_OK" in out and "SECRET=leak" in out  # noqa: PT018  # tracked: #288
     assert "WRITE_OK" in out
 
 
 @requires_sandbox
-def test_sandbox_blocks_escape_but_allows_workspace(tmp_path_factory):
+def test_sandbox_blocks_escape_but_allows_workspace(tmp_path_factory):  # noqa: ANN001, ANN202  # tracked: #288
     """With confinement installed the same escape attempts fail, yet the agent
     can still read and write inside its own workspace."""
     agent, workspace, sibling = _escape_probe(tmp_path_factory)
@@ -481,7 +482,7 @@ def test_sandbox_blocks_escape_but_allows_workspace(tmp_path_factory):
     assert agent.sandbox is not None
     out = agent.generate("stay in the workspace", cwd=str(workspace), silent=True)
 
-    assert "READ_OK" not in out and "SECRET=leak" not in out
+    assert "READ_OK" not in out and "SECRET=leak" not in out  # noqa: PT018  # tracked: #288
     assert "WRITE_OK" not in out
     assert not (sibling / "pwn.txt").exists()
     # Legitimate workspace work is unaffected.
@@ -490,7 +491,7 @@ def test_sandbox_blocks_escape_but_allows_workspace(tmp_path_factory):
 
 
 @requires_sandbox
-def test_sandbox_exposes_codex_auth_but_not_sibling_worktrees(tmp_path):
+def test_sandbox_exposes_codex_auth_but_not_sibling_worktrees(tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
     codex_home = tmp_path / ".codex"
     workspace = codex_home / "worktrees" / "run-A" / "workspace"
     sibling = codex_home / "worktrees" / "run-B" / "secret.txt"
@@ -517,12 +518,12 @@ def test_sandbox_exposes_codex_auth_but_not_sibling_worktrees(tmp_path):
             f'test "$(cat {auth})" = "auth token" && test ! -e {sibling}',
         ]
     )
-    result = subprocess.run(command, env=env, capture_output=True, text=True)
+    result = subprocess.run(command, env=env, capture_output=True, text=True)  # noqa: PLW1510, S603  # tracked: #288
     assert result.returncode == 0, result.stderr
 
 
 @requires_sandbox
-def test_generate_does_not_wrap_when_cwd_is_none(tmp_path_factory, monkeypatch):
+def test_generate_does_not_wrap_when_cwd_is_none(tmp_path_factory, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
     """Container executors pass ``cwd=None``; the sandbox must not engage there
     (they are already externally sandboxed)."""
     agent, workspace, _ = _escape_probe(tmp_path_factory)
@@ -549,7 +550,7 @@ def _seatbelt_works() -> bool:
         return False
     probe = "/usr/bin/true" if Path("/usr/bin/true").exists() else "/bin/true"
     try:
-        proc = subprocess.run(
+        proc = subprocess.run(  # noqa: PLW1510, S603  # tracked: #288
             [sandbox_exec, "-p", "(version 1)(allow default)", probe],
             capture_output=True,
             timeout=15,
@@ -566,7 +567,7 @@ requires_seatbelt = pytest.mark.skipif(
 
 
 @requires_seatbelt
-def test_seatbelt_blocks_escape_but_allows_workspace(tmp_path_factory):
+def test_seatbelt_blocks_escape_but_allows_workspace(tmp_path_factory):  # noqa: ANN001, ANN202  # tracked: #288
     """macOS counterpart of the Linux regression: the Seatbelt profile denies the
     sibling read/write while the workspace stays usable."""
     agent, workspace, sibling = _escape_probe(tmp_path_factory)
@@ -580,7 +581,7 @@ def test_seatbelt_blocks_escape_but_allows_workspace(tmp_path_factory):
     # Sanity-check that the profile lets an ordinary binary launch at all before
     # asserting on the escape. A dyld-startup denial shows up as an abort with no
     # stderr, so surface sandbox-exec's own output to make such failures legible.
-    probe = subprocess.run(agent.sandbox.wrap(["/usr/bin/true"]), capture_output=True, text=True)
+    probe = subprocess.run(agent.sandbox.wrap(["/usr/bin/true"]), capture_output=True, text=True)  # noqa: PLW1510, S603  # tracked: #288
     assert probe.returncode == 0, (
         f"profile blocks a trivial launch (rc={probe.returncode}); "
         f"stderr={probe.stderr!r}\n--- profile ---\n{agent.sandbox.profile()}"
@@ -588,7 +589,7 @@ def test_seatbelt_blocks_escape_but_allows_workspace(tmp_path_factory):
 
     out = agent.generate("stay in the workspace", cwd=str(workspace), silent=True)
 
-    assert "READ_OK" not in out and "SECRET=leak" not in out
+    assert "READ_OK" not in out and "SECRET=leak" not in out  # noqa: PT018  # tracked: #288
     assert "WRITE_OK" not in out
     assert not (sibling / "pwn.txt").exists()
     assert "WS_OK" in out

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -25,7 +25,7 @@ from vibesys.schemas import (
 from vs_sandbox import HostResource
 
 
-def _agent_config(**agent) -> Config:
+def _agent_config(**agent) -> Config:  # noqa: ANN003  # tracked: #288
     """Minimal valid Config carrying just an ``[agent]`` section for runner tests."""
     return Config.model_validate({"model": {"name": "m"}, "agent": agent})
 
@@ -38,7 +38,7 @@ def _judge_fallback() -> JudgeResponse:
     )
 
 
-def test_prompt_markdown_emitter_preserves_raw_log_and_truncates_stdout(capsys, headless_renderer):
+def test_prompt_markdown_emitter_preserves_raw_log_and_truncates_stdout(capsys, headless_renderer):  # noqa: ANN001, ANN201  # tracked: #288
     headless_renderer.max_text_len = 20
     log = StringIO()
     prompt = "# Title\n\nUse **markdown** and `code`."
@@ -51,7 +51,7 @@ def test_prompt_markdown_emitter_preserves_raw_log_and_truncates_stdout(capsys, 
     assert log.getvalue() == prompt + "\n"
 
 
-def test_json_emitter_preserves_raw_log(capsys):
+def test_json_emitter_preserves_raw_log(capsys):  # noqa: ANN001, ANN201  # tracked: #288
     log = StringIO()
     raw_json = '{"analysis":"ok","items":[1,2]}'
 
@@ -65,7 +65,7 @@ def test_json_emitter_preserves_raw_log(capsys):
 class TestDeepAgentsRunner:
     """Tests for :class:`DeepAgentsRunner`."""
 
-    def test_deepagents_runner_invoke_returns_structured_response(self, tmp_path):
+    def test_deepagents_runner_invoke_returns_structured_response(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         pass_response = JudgeResponse(
             analysis="looks good",
             feedback="",
@@ -107,16 +107,16 @@ class TestDeepAgentsRunner:
         assert kwargs["response_cls"] is JudgeResponse
         assert kwargs["fallback_factory"] is _judge_fallback
         callbacks = kwargs["callbacks"]
-        assert callbacks[0]._progress.label() == "Round 1/5"
+        assert callbacks[0]._progress.label() == "Round 1/5"  # noqa: SLF001  # tracked: #288
 
-    def test_deepagents_runner_picks_backend_by_kind(self, tmp_path):
+    def test_deepagents_runner_picks_backend_by_kind(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl_backend = MagicMock(name="impl-backend")
         judge_backend = MagicMock(name="judge-backend")
         perf_backend = MagicMock(name="perf-backend")
 
         captured_backends: list = []
 
-        def _capture(**kwargs):
+        def _capture(**kwargs):  # noqa: ANN003, ANN202  # tracked: #288
             captured_backends.append(kwargs["backend"])
             return MagicMock(name="deep_agent")
 
@@ -155,7 +155,7 @@ class TestDeepAgentsRunner:
 
         assert captured_backends == [impl_backend, judge_backend, perf_backend]
 
-    def test_deepagents_runner_returns_plain_text_without_response_format(self, tmp_path):
+    def test_deepagents_runner_returns_plain_text_without_response_format(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         with (
             patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
             patch(
@@ -184,7 +184,7 @@ class TestDeepAgentsRunner:
         assert "response_format" not in mock_create.call_args.kwargs
         assert mock_run.call_args.args[1] == "what happened?"
 
-    def test_deepagents_runner_sessions_are_explicit_and_role_scoped(self):
+    def test_deepagents_runner_sessions_are_explicit_and_role_scoped(self):  # noqa: ANN201  # tracked: #288
         runner = DeepAgentsRunner(
             model="m",
             backends={},
@@ -193,18 +193,18 @@ class TestDeepAgentsRunner:
             run_log_file=None,
         )
 
-        first = runner._session(kind="implementer", reuse_session=True, session_key="hypothesis:a")
-        continued = runner._session(
+        first = runner._session(kind="implementer", reuse_session=True, session_key="hypothesis:a")  # noqa: SLF001  # tracked: #288
+        continued = runner._session(  # noqa: SLF001  # tracked: #288
             kind="implementer", reuse_session=True, session_key="hypothesis:a"
         )
-        other_role = runner._session(kind="judge", reuse_session=True, session_key="hypothesis:a")
-        fresh = runner._session(kind="implementer", reuse_session=False, session_key="hypothesis:a")
+        other_role = runner._session(kind="judge", reuse_session=True, session_key="hypothesis:a")  # noqa: SLF001  # tracked: #288
+        fresh = runner._session(kind="implementer", reuse_session=False, session_key="hypothesis:a")  # noqa: SLF001  # tracked: #288
 
         assert continued is first
         assert other_role is not first
         assert fresh is not first
 
-    def test_deepagents_runner_reuses_graph_with_fresh_default_threads(self, tmp_path):
+    def test_deepagents_runner_reuses_graph_with_fresh_default_threads(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Repeated calls reuse construction but keep default conversations isolated."""
         pass_response = JudgeResponse(
             analysis="looks good",
@@ -242,7 +242,7 @@ class TestDeepAgentsRunner:
             thread_ids = [call.kwargs["thread_id"] for call in mock_run.call_args_list]
             assert thread_ids[0] != thread_ids[1]
 
-    def test_deepagents_runner_rebuilds_when_response_schema_changes(self, tmp_path):
+    def test_deepagents_runner_rebuilds_when_response_schema_changes(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """A different response model must not reuse the old structured graph."""
         with (
             patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
@@ -292,7 +292,7 @@ class TestDeepAgentsRunner:
                 is not mock_create.call_args_list[1].kwargs["response_format"].schema
             )
 
-    def test_deepagents_runner_rebuilds_when_tool_objects_change(self, tmp_path):
+    def test_deepagents_runner_rebuilds_when_tool_objects_change(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Same-named tools can carry different closure-bound behavior."""
         with (
             patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
@@ -324,7 +324,7 @@ class TestDeepAgentsRunner:
 
             assert mock_create.call_count == 2
 
-    def test_deepagents_runner_typed_and_text_graphs_are_separate(self, tmp_path):
+    def test_deepagents_runner_typed_and_text_graphs_are_separate(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         with (
             patch("vibesys.agents.deepagents_runner.create_deep_agent") as mock_create,
             patch(
@@ -372,7 +372,7 @@ class TestDeepAgentsRunner:
 # ---------------------------------------------------------------------------
 
 
-def _make_fake_agent_class(
+def _make_fake_agent_class(  # noqa: ANN202  # tracked: #288
     *,
     generate_returns: str,
     captured: list,
@@ -389,12 +389,12 @@ def _make_fake_agent_class(
     ``generate()`` returns.
     """
 
-    from types import SimpleNamespace
+    from types import SimpleNamespace  # noqa: PLC0415  # tracked: #288
 
     class FakeAgent:
         supports_native_output_schema = False
 
-        def __init__(self, model=None, event_handler=None):
+        def __init__(self, model=None, event_handler=None):  # noqa: ANN001, ANN204  # tracked: #288
             self.model = model
             self.event_handler = event_handler
             self.env: dict[str, str] = {}
@@ -407,23 +407,23 @@ def _make_fake_agent_class(
             self.output_schema_paths: list[str | None] = []
             captured.append(self)
 
-        def set_reasoning_effort(self, effort):
+        def set_reasoning_effort(self, effort):  # noqa: ANN001, ANN202  # tracked: #288
             self.reasoning_effort = effort
 
-        def set_output_schema_path(self, path):
+        def set_output_schema_path(self, path):  # noqa: ANN001, ANN202  # tracked: #288
             self.output_schema_paths.append(path)
 
-        def install_mcp_servers(self, workspace, servers):
+        def install_mcp_servers(self, workspace, servers):  # noqa: ANN001, ANN202  # tracked: #288
             self.install_calls.append({"workspace": workspace, "servers": list(servers)})
             self.event_log.append("install")
 
-        def uninstall_mcp_servers(self, workspace, servers):
+        def uninstall_mcp_servers(self, workspace, servers):  # noqa: ANN001, ANN202  # tracked: #288
             self.uninstall_calls.append({"workspace": workspace, "servers": list(servers)})
             self.event_log.append("uninstall")
             if uninstall_raises is not None:
-                raise uninstall_raises("cleanup boom")
+                raise uninstall_raises("cleanup boom")  # noqa: TRY003  # tracked: #288
 
-        def generate(self, prompt, cwd=None, timeout=300, silent=False):
+        def generate(self, prompt, cwd=None, timeout=300, silent=False):  # noqa: ANN001, ANN202, FBT002  # tracked: #288
             self.generate_calls.append(
                 {
                     "prompt": prompt,
@@ -449,8 +449,11 @@ class TestCliAgentRunner:
     """Tests for :class:`CliAgentRunner`."""
 
     @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
-    def test_cli_runner_invokes_provider_and_returns_parsed_response(
-        self, monkeypatch, tmp_path, provider
+    def test_cli_runner_invokes_provider_and_returns_parsed_response(  # noqa: ANN201  # tracked: #288
+        self,
+        monkeypatch,  # noqa: ANN001  # tracked: #288
+        tmp_path,  # noqa: ANN001  # tracked: #288
+        provider,  # noqa: ANN001  # tracked: #288
     ):
         captured: list = []
         fake_cls = _make_fake_agent_class(
@@ -458,7 +461,7 @@ class TestCliAgentRunner:
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -489,14 +492,14 @@ class TestCliAgentRunner:
         assert len(captured) == 1
         assert captured[0].generate_calls[0]["cwd"] == str(workspace)
 
-    def test_cli_runner_obeys_explicit_session_policy(self, monkeypatch, tmp_path):
+    def test_cli_runner_obeys_explicit_session_policy(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -528,7 +531,7 @@ class TestCliAgentRunner:
         invoke(session_key="hypothesis:a", reuse_session=False)
         assert len(captured) == 3
 
-    def test_codex_persistent_session_renews_before_third_turn(self, monkeypatch, tmp_path):
+    def test_codex_persistent_session_renews_before_third_turn(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
@@ -536,7 +539,7 @@ class TestCliAgentRunner:
         )
         original_generate = fake_cls.generate
 
-        def generate(self, *args, **kwargs):
+        def generate(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202  # tracked: #288
             if getattr(self, "session_id", None) is None:
                 self.session_id = f"thread-{len(self.generate_calls) + 1}"
             session_ids.append(self.session_id)
@@ -544,7 +547,7 @@ class TestCliAgentRunner:
 
         fake_cls.generate = generate
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -585,8 +588,11 @@ class TestCliAgentRunner:
             },
         ],
     )
-    def test_codex_persistent_session_renews_after_heavy_turn(
-        self, monkeypatch, tmp_path, session_state
+    def test_codex_persistent_session_renews_after_heavy_turn(  # noqa: ANN201  # tracked: #288
+        self,
+        monkeypatch,  # noqa: ANN001  # tracked: #288
+        tmp_path,  # noqa: ANN001  # tracked: #288
+        session_state,  # noqa: ANN001  # tracked: #288
     ):
         captured: list = []
         fake_cls = _make_fake_agent_class(
@@ -596,7 +602,7 @@ class TestCliAgentRunner:
         )
         original_generate = fake_cls.generate
 
-        def generate(self, *args, **kwargs):
+        def generate(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202  # tracked: #288
             if getattr(self, "session_id", None) is None:
                 self.session_id = f"thread-{len(self.generate_calls) + 1}"
             session_ids.append(self.session_id)
@@ -604,7 +610,7 @@ class TestCliAgentRunner:
 
         fake_cls.generate = generate
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -631,14 +637,14 @@ class TestCliAgentRunner:
 
         assert session_ids == ["thread-1", "thread-2"]
 
-    def test_cli_runner_selects_models_and_effort_by_loop_role(self, monkeypatch, tmp_path):
+    def test_cli_runner_selects_models_and_effort_by_loop_role(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -678,8 +684,11 @@ class TestCliAgentRunner:
         assert [agent.reasoning_effort for agent in captured] == ["xhigh", "xhigh", "high"]
 
     @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
-    def test_host_resource_declarations_apply_to_every_local_cli_provider(
-        self, monkeypatch, tmp_path, provider
+    def test_host_resource_declarations_apply_to_every_local_cli_provider(  # noqa: ANN201  # tracked: #288
+        self,
+        monkeypatch,  # noqa: ANN001  # tracked: #288
+        tmp_path,  # noqa: ANN001  # tracked: #288
+        provider,  # noqa: ANN001  # tracked: #288
     ):
         captured: list = []
         fake_cls = _make_fake_agent_class(
@@ -687,7 +696,7 @@ class TestCliAgentRunner:
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -727,14 +736,14 @@ class TestCliAgentRunner:
         assert result.verdict == Verdict.PASS
         assert resource in builds[0]["resources"]
 
-    def test_cli_runner_falls_back_on_unparseable_output(self, monkeypatch, tmp_path, capsys):
+    def test_cli_runner_falls_back_on_unparseable_output(self, monkeypatch, tmp_path, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns="# Failure\n\nCould not produce **JSON**.",
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -769,14 +778,14 @@ class TestCliAgentRunner:
         assert "# Failure" in stdout
         assert "**JSON**" in stdout
 
-    def test_cli_runner_passes_progress_to_logger(self, monkeypatch, tmp_path):
+    def test_cli_runner_passes_progress_to_logger(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -803,9 +812,9 @@ class TestCliAgentRunner:
             progress=RoundProgress(2, 5),
         )
 
-        assert captured[0].event_handler._progress.label() == "Round 2/5"
+        assert captured[0].event_handler._progress.label() == "Round 2/5"  # noqa: SLF001  # tracked: #288
 
-    def test_cli_runner_parses_fenced_json(self, monkeypatch, tmp_path):
+    def test_cli_runner_parses_fenced_json(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []
         fenced = '```json\n{"analysis": "fenced", "feedback": "", "verdict": "pass"}\n```'
         fake_cls = _make_fake_agent_class(
@@ -813,7 +822,7 @@ class TestCliAgentRunner:
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -842,7 +851,7 @@ class TestCliAgentRunner:
         assert result.verdict == Verdict.PASS
         assert result.analysis == "fenced"
 
-    def test_cli_runner_materializes_skills_into_workspace(self, monkeypatch, tmp_path):
+    def test_cli_runner_materializes_skills_into_workspace(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         # Tier-organized source tree (like vibesys-skills):
         #   skill_src/
         #     algorithms/myskill/SKILL.md
@@ -863,7 +872,7 @@ class TestCliAgentRunner:
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -903,7 +912,7 @@ class TestCliAgentRunner:
             assert (workspace / cli_dir / "myskill" / "file.txt").read_text() == "hello skill"
             assert (workspace / cli_dir / "tool-skill" / "SKILL.md").exists()
 
-    def _run_with_platform_skill(self, monkeypatch, tmp_path, compute_backend):
+    def _run_with_platform_skill(self, monkeypatch, tmp_path, compute_backend):  # noqa: ANN001, ANN202  # tracked: #288
         """Materialize a skill carrying references/platforms/<backend>/ trees."""
         skill_src = tmp_path / "serving-systems"
         skill_src.mkdir()
@@ -929,7 +938,7 @@ class TestCliAgentRunner:
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -960,7 +969,7 @@ class TestCliAgentRunner:
     @pytest.mark.parametrize(
         "selected", [ComputeBackend.CUDA, ComputeBackend.TRAINIUM, ComputeBackend.METAL]
     )
-    def test_materialize_prunes_foreign_platform_dirs(self, monkeypatch, tmp_path, selected):
+    def test_materialize_prunes_foreign_platform_dirs(self, monkeypatch, tmp_path, selected):  # noqa: ANN001, ANN201  # tracked: #288
         """Only the selected backend's platform guidance reaches the agent.
 
         Applying one platform's floor to another produces wrong work — the
@@ -973,7 +982,7 @@ class TestCliAgentRunner:
         assert {p.name for p in platforms.iterdir()} == {selected.value}
         assert (platforms / selected.value / "floor.md").exists()
 
-    def test_materialize_keeps_portable_tiers_and_same_named_dirs(self, monkeypatch, tmp_path):
+    def test_materialize_keeps_portable_tiers_and_same_named_dirs(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Pruning is scoped to references/platforms/, not to directory names."""
         refs = self._run_with_platform_skill(monkeypatch, tmp_path, ComputeBackend.TRAINIUM)
 
@@ -981,13 +990,13 @@ class TestCliAgentRunner:
         # `models/cuda/` shares a name with a backend but is not a platform dir.
         assert (refs / "models" / "cuda" / "note.md").exists()
 
-    def test_materialize_without_backend_keeps_every_platform(self, monkeypatch, tmp_path):
+    def test_materialize_without_backend_keeps_every_platform(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """No selected backend (e.g. non-run tooling) copies the tree intact."""
         refs = self._run_with_platform_skill(monkeypatch, tmp_path, None)
 
         assert {p.name for p in (refs / "platforms").iterdir()} == {b.value for b in ComputeBackend}
 
-    def test_cli_runner_materializes_single_skill_with_nested_content(self, monkeypatch, tmp_path):
+    def test_cli_runner_materializes_single_skill_with_nested_content(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         # Single-skill source (SKILL.md at the root, sub-dirs are reference
         # material inside the one skill). This mirrors the repo's
         # `serving-systems/` layout.
@@ -1003,7 +1012,7 @@ class TestCliAgentRunner:
             captured=[],
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1041,14 +1050,14 @@ class TestCliAgentRunner:
                 / "SKILL.md"
             ).exists()
 
-    def test_cli_runner_appends_json_schema_to_prompt(self, monkeypatch, tmp_path):
+    def test_cli_runner_appends_json_schema_to_prompt(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1079,7 +1088,7 @@ class TestCliAgentRunner:
         assert "JudgeResponse" in prompt
         assert prompt.startswith("THE-SYSTEM-PROMPT")
 
-    def test_codex_uses_native_schema_without_prompt_duplication(self, monkeypatch, tmp_path):
+    def test_codex_uses_native_schema_without_prompt_duplication(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
@@ -1087,7 +1096,7 @@ class TestCliAgentRunner:
         )
         fake_cls.supports_native_output_schema = True
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1115,7 +1124,7 @@ class TestCliAgentRunner:
         assert (workspace / relative).is_file()
         assert "Schema for JudgeResponse" not in agent.generate_calls[0]["prompt"]
 
-    def test_codex_schema_materialization_failure_uses_prompt_fallback(self, monkeypatch, tmp_path):
+    def test_codex_schema_materialization_failure_uses_prompt_fallback(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
@@ -1126,7 +1135,7 @@ class TestCliAgentRunner:
             "vibesys.agents.cli_runner",
             fromlist=["_PROVIDER_CLASSES"],
         )
-        monkeypatch.setitem(runner_module._PROVIDER_CLASSES, "codex", fake_cls)
+        monkeypatch.setitem(runner_module._PROVIDER_CLASSES, "codex", fake_cls)  # noqa: SLF001  # tracked: #288
         monkeypatch.setattr(
             runner_module,
             "materialize_native_output_schema",
@@ -1152,7 +1161,7 @@ class TestCliAgentRunner:
         assert "Schema for JudgeResponse" in captured[0].generate_calls[0]["prompt"]
         assert "using prompt fallback" in log.getvalue()
 
-    def test_absolute_schema_path_provider_gets_resolved_path(self, monkeypatch, tmp_path):
+    def test_absolute_schema_path_provider_gets_resolved_path(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Providers reading the schema inline (Claude) get an absolute path,
         resolvable independent of the subprocess cwd, and drop the prompt hint."""
         captured: list = []
@@ -1163,7 +1172,7 @@ class TestCliAgentRunner:
         fake_cls.supports_native_output_schema = True
         fake_cls.native_output_schema_wants_absolute_path = True
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1192,8 +1201,10 @@ class TestCliAgentRunner:
         assert Path(passed).parent == workspace / ".cache/vibesys/response-schemas"
         assert "Schema for JudgeResponse" not in agent.generate_calls[0]["prompt"]
 
-    def test_cli_runner_chat_returns_plain_text_in_a_fresh_session_per_turn(
-        self, monkeypatch, tmp_path
+    def test_cli_runner_chat_returns_plain_text_in_a_fresh_session_per_turn(  # noqa: ANN201  # tracked: #288
+        self,
+        monkeypatch,  # noqa: ANN001  # tracked: #288
+        tmp_path,  # noqa: ANN001  # tracked: #288
     ):
         captured: list = []
         fake_cls = _make_fake_agent_class(
@@ -1201,7 +1212,7 @@ class TestCliAgentRunner:
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1228,13 +1239,13 @@ class TestCliAgentRunner:
         assert captured[0].generate_calls[0]["prompt"] == "sys\n\nturn 1"
         assert captured[1].generate_calls[0]["prompt"] == "sys\n\nturn 2"
         assert "Return EXACTLY" not in captured[0].generate_calls[0]["prompt"]
-        assert "chat" not in runner._agents
+        assert "chat" not in runner._agents  # noqa: SLF001  # tracked: #288
 
-    def test_cli_runner_retries_missing_codex_rollout_as_fresh_thread(self, monkeypatch, tmp_path):
+    def test_cli_runner_retries_missing_codex_rollout_as_fresh_thread(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []
 
         class FakeCodexAgent:
-            def __init__(self, model=None, event_handler=None):
+            def __init__(self, model=None, event_handler=None):  # noqa: ANN001, ANN204  # tracked: #288
                 self.model = model
                 self.event_handler = event_handler
                 self.env: dict[str, str] = {}
@@ -1243,24 +1254,24 @@ class TestCliAgentRunner:
                 self._last_session = None
                 captured.append(self)
 
-            def install_mcp_servers(self, workspace, servers):
+            def install_mcp_servers(self, workspace, servers):  # noqa: ANN001, ANN202  # tracked: #288
                 pass
 
-            def uninstall_mcp_servers(self, workspace, servers):
+            def uninstall_mcp_servers(self, workspace, servers):  # noqa: ANN001, ANN202  # tracked: #288
                 pass
 
-            def generate(self, prompt, cwd=None, timeout=300, silent=False):
+            def generate(self, prompt, cwd=None, timeout=300, silent=False):  # noqa: ANN001, ANN202, ARG002, FBT002  # tracked: #288
                 self.generate_calls.append(
                     {"prompt": prompt, "cwd": cwd, "session_id": self.session_id}
                 )
                 if self.session_id is not None:
-                    raise RuntimeError(
+                    raise RuntimeError(  # noqa: TRY003  # tracked: #288
                         "thread/resume failed: no rollout found for thread id stale-thread"
                     )
                 return '{"analysis": "ok", "feedback": "", "verdict": "pass"}'
 
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1288,29 +1299,32 @@ class TestCliAgentRunner:
             None,
         ]
 
-    def test_cli_runner_prints_prompt_as_rendered_markdown_before_generate(
-        self, monkeypatch, tmp_path, capsys
+    def test_cli_runner_prints_prompt_as_rendered_markdown_before_generate(  # noqa: ANN201  # tracked: #288
+        self,
+        monkeypatch,  # noqa: ANN001  # tracked: #288
+        tmp_path,  # noqa: ANN001  # tracked: #288
+        capsys,  # noqa: ANN001  # tracked: #288
     ):
         stdout_before_generate: list[str] = []
 
         class FakeAgent:
-            def __init__(self, model=None, event_handler=None):
+            def __init__(self, model=None, event_handler=None):  # noqa: ANN001, ANN204  # tracked: #288
                 self.model = model
                 self.event_handler = event_handler
                 self.env: dict[str, str] = {}
 
-            def install_mcp_servers(self, workspace, servers):
+            def install_mcp_servers(self, workspace, servers):  # noqa: ANN001, ANN202  # tracked: #288
                 pass
 
-            def uninstall_mcp_servers(self, workspace, servers):
+            def uninstall_mcp_servers(self, workspace, servers):  # noqa: ANN001, ANN202  # tracked: #288
                 pass
 
-            def generate(self, prompt, cwd=None, timeout=300, silent=False):
+            def generate(self, prompt, cwd=None, timeout=300, silent=False):  # noqa: ANN001, ANN202, ARG002, FBT002  # tracked: #288
                 stdout_before_generate.append(capsys.readouterr().out)
                 return '{"analysis": "ok", "feedback": "", "verdict": "pass"}'
 
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1341,7 +1355,7 @@ class TestCliAgentRunner:
         assert "User Prompt" in stdout_before_generate[0][input_idx:]
         assert "**bold**" in stdout_before_generate[0][input_idx:]
 
-    def test_cli_runner_writes_usage_jsonl_on_success(self, monkeypatch, tmp_path):
+    def test_cli_runner_writes_usage_jsonl_on_success(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """CliAgentRunner appends one JSON record per invoke() to ``<log_dir>/usage.jsonl``."""
         captured: list = []
         fake_cls = _make_fake_agent_class(
@@ -1359,7 +1373,7 @@ class TestCliAgentRunner:
             },
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1407,7 +1421,7 @@ class TestCliAgentRunner:
         assert record["duration_ms"] == 18_431
         assert "timestamp" in record
 
-    def test_cli_runner_usage_jsonl_appends_across_invocations(self, monkeypatch, tmp_path):
+    def test_cli_runner_usage_jsonl_appends_across_invocations(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
@@ -1419,7 +1433,7 @@ class TestCliAgentRunner:
             },
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1455,7 +1469,7 @@ class TestCliAgentRunner:
         labels = [json.loads(line)["round_label"] for line in lines]
         assert labels == ["round #0", "round #1", "round #2"]
 
-    def test_cli_runner_usage_jsonl_written_on_parse_failure(self, monkeypatch, tmp_path):
+    def test_cli_runner_usage_jsonl_written_on_parse_failure(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Even when the CLI returns unparseable output, the tokens were spent —
         the usage record must still be appended so the audit log is complete."""
         captured: list = []
@@ -1469,7 +1483,7 @@ class TestCliAgentRunner:
             },
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1508,7 +1522,7 @@ class TestCliAgentRunner:
         assert record["input_tokens"] == 7_000
         assert record["total_cost_usd"] == 0.0034
 
-    def test_cli_runner_usage_jsonl_noop_when_log_dir_none(self, monkeypatch, tmp_path):
+    def test_cli_runner_usage_jsonl_noop_when_log_dir_none(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Runners built without log_dir (tests, legacy callers) must still succeed."""
         captured: list = []
         fake_cls = _make_fake_agent_class(
@@ -1521,7 +1535,7 @@ class TestCliAgentRunner:
             },
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1549,14 +1563,14 @@ class TestCliAgentRunner:
         )
         assert result.verdict == Verdict.PASS
 
-    def test_cli_runner_layers_env_into_subprocess_env(self, monkeypatch, tmp_path):
+    def test_cli_runner_layers_env_into_subprocess_env(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []
         fake_cls = _make_fake_agent_class(
             generate_returns='{"analysis": "ok", "feedback": "", "verdict": "pass"}',
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1586,10 +1600,12 @@ class TestCliAgentRunner:
         assert len(captured) == 1
         assert captured[0].env.get("CUDA_VISIBLE_DEVICES") == "2"
 
-    def test_cli_runner_docker_uses_command_executor(self, monkeypatch, tmp_path):
-        from types import SimpleNamespace
+    def test_cli_runner_docker_uses_command_executor(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from types import SimpleNamespace  # noqa: PLC0415  # tracked: #288
 
-        from vibesys.agents.docker_executor import DockerCommandExecutor
+        from vibesys.agents.docker_executor import (  # noqa: PLC0415  # tracked: #288
+            DockerCommandExecutor,
+        )
 
         captured: list = []
         ownership_repairs: list[tuple[str, int, int]] = []
@@ -1601,7 +1617,7 @@ class TestCliAgentRunner:
         )
 
         class FakeAgent:
-            def __init__(self, model=None, event_handler=None, executor=None):
+            def __init__(self, model=None, event_handler=None, executor=None):  # noqa: ANN001, ANN204  # tracked: #288
                 self.model = model
                 self.event_handler = event_handler
                 self.executor = executor
@@ -1610,13 +1626,13 @@ class TestCliAgentRunner:
                 self._last_session = SimpleNamespace()
                 captured.append(self)
 
-            def install_mcp_servers(self, workspace, servers):
+            def install_mcp_servers(self, workspace, servers):  # noqa: ANN001, ANN202, ARG002  # tracked: #288
                 return None
 
-            def uninstall_mcp_servers(self, workspace, servers):
+            def uninstall_mcp_servers(self, workspace, servers):  # noqa: ANN001, ANN202, ARG002  # tracked: #288
                 return None
 
-            def generate(self, prompt, cwd=None, timeout=300, silent=False):
+            def generate(self, prompt, cwd=None, timeout=300, silent=False):  # noqa: ANN001, ANN202, FBT002  # tracked: #288
                 self.generate_calls.append(
                     {
                         "prompt": prompt,
@@ -1628,7 +1644,7 @@ class TestCliAgentRunner:
                 return '{"analysis": "ok", "feedback": "", "verdict": "pass"}'
 
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1660,7 +1676,7 @@ class TestCliAgentRunner:
         assert captured[0].executor.container_id == "container-one"
         assert captured[0].generate_calls[0]["cwd"] is None
 
-        sandbox._container_id = "container-two"
+        sandbox._container_id = "container-two"  # noqa: SLF001  # tracked: #288
         runner.invoke(
             kind="judge",
             workspace=workspace,
@@ -1678,9 +1694,9 @@ class TestCliAgentRunner:
             "container-two",
         ]
 
-    def test_cli_runner_invokes_install_then_generate_then_uninstall(self, monkeypatch, tmp_path):
+    def test_cli_runner_invokes_install_then_generate_then_uninstall(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """The mcp_servers kwarg triggers a strict install → generate → uninstall sandwich."""
-        from vibesys._agent_cli.base import MCPServerSpec
+        from vibesys._agent_cli.base import MCPServerSpec  # noqa: PLC0415  # tracked: #288
 
         captured: list = []
         fake_cls = _make_fake_agent_class(
@@ -1688,7 +1704,7 @@ class TestCliAgentRunner:
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1721,10 +1737,10 @@ class TestCliAgentRunner:
         assert agent.uninstall_calls[0]["workspace"] == workspace
         assert agent.uninstall_calls[0]["servers"] == [spec]
 
-    def test_cli_runner_uninstalls_even_when_generate_raises(self, monkeypatch, tmp_path):
+    def test_cli_runner_uninstalls_even_when_generate_raises(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """uninstall_mcp_servers must run in finally so a crashing generate
         doesn't leave stale config in the workspace."""
-        from vibesys._agent_cli.base import MCPServerSpec
+        from vibesys._agent_cli.base import MCPServerSpec  # noqa: PLC0415  # tracked: #288
 
         captured: list = []
         fake_cls = _make_fake_agent_class(
@@ -1733,7 +1749,7 @@ class TestCliAgentRunner:
             generate_raises=RuntimeError,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1761,10 +1777,12 @@ class TestCliAgentRunner:
         agent = captured[0]
         assert agent.event_log == ["install", "generate", "uninstall"]
 
-    def test_cli_runner_preserves_generate_error_when_uninstall_also_raises(
-        self, monkeypatch, tmp_path
+    def test_cli_runner_preserves_generate_error_when_uninstall_also_raises(  # noqa: ANN201  # tracked: #288
+        self,
+        monkeypatch,  # noqa: ANN001  # tracked: #288
+        tmp_path,  # noqa: ANN001  # tracked: #288
     ):
-        from vibesys._agent_cli.base import MCPServerSpec
+        from vibesys._agent_cli.base import MCPServerSpec  # noqa: PLC0415  # tracked: #288
 
         captured: list = []
         fake_cls = _make_fake_agent_class(
@@ -1774,7 +1792,7 @@ class TestCliAgentRunner:
             uninstall_raises=OSError,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1800,7 +1818,7 @@ class TestCliAgentRunner:
 
         assert captured[0].event_log == ["install", "generate", "uninstall"]
 
-    def test_cli_runner_skips_install_uninstall_when_no_mcp_servers(self, monkeypatch, tmp_path):
+    def test_cli_runner_skips_install_uninstall_when_no_mcp_servers(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """When mcp_servers is None or omitted, install/uninstall hooks are
         not called at all."""
         captured: list = []
@@ -1809,7 +1827,7 @@ class TestCliAgentRunner:
             captured=captured,
         )
         monkeypatch.setitem(
-            __import__(
+            __import__(  # noqa: SLF001  # tracked: #288
                 "vibesys.agents.cli_runner",
                 fromlist=["_PROVIDER_CLASSES"],
             )._PROVIDER_CLASSES,
@@ -1841,7 +1859,7 @@ class TestCliAgentRunner:
 class TestBuildAgentRunner:
     """Tests for :func:`build_agent_runner`."""
 
-    def test_build_agent_runner_default_is_cli(self):
+    def test_build_agent_runner_default_is_cli(self):  # noqa: ANN201  # tracked: #288
         runner = build_agent_runner(
             _agent_config(),
             agent_backend=None,
@@ -1859,9 +1877,9 @@ class TestBuildAgentRunner:
             use_docker=False,
         )
         assert runner.backend_name == "cli"
-        assert runner._provider == "codex"
+        assert runner._provider == "codex"  # noqa: SLF001  # tracked: #288
 
-    def test_build_agent_runner_cli_provider_from_config(self):
+    def test_build_agent_runner_cli_provider_from_config(self):  # noqa: ANN201  # tracked: #288
         runner = build_agent_runner(
             _agent_config(backend="cli", cli_provider="claude"),
             agent_backend=None,
@@ -1875,9 +1893,9 @@ class TestBuildAgentRunner:
             use_docker=False,
         )
         assert runner.backend_name == "cli"
-        assert runner._provider == "claude"
+        assert runner._provider == "claude"  # noqa: SLF001  # tracked: #288
 
-    def test_build_agent_runner_cli_defaults_to_codex(self):
+    def test_build_agent_runner_cli_defaults_to_codex(self):  # noqa: ANN201  # tracked: #288
         """When backend=cli and no provider specified, defaults to codex."""
         runner = build_agent_runner(
             _agent_config(backend="cli"),
@@ -1892,11 +1910,11 @@ class TestBuildAgentRunner:
             use_docker=False,
         )
         assert runner.backend_name == "cli"
-        assert runner._provider == "codex"
+        assert runner._provider == "codex"  # noqa: SLF001  # tracked: #288
 
-    def test_build_agent_runner_cli_docker_returns_cli_runner(self):
+    def test_build_agent_runner_cli_docker_returns_cli_runner(self):  # noqa: ANN201  # tracked: #288
         """cli backend + docker now returns a CliAgentRunner with docker_sandboxes."""
-        from unittest.mock import MagicMock
+        from unittest.mock import MagicMock  # noqa: PLC0415  # tracked: #288
 
         mock_backends = {
             "implementer": MagicMock(),
@@ -1916,9 +1934,9 @@ class TestBuildAgentRunner:
             use_docker=True,
         )
         assert isinstance(runner, CliAgentRunner)
-        assert runner._docker_sandboxes is mock_backends
+        assert runner._docker_sandboxes is mock_backends  # noqa: SLF001  # tracked: #288
 
-    def test_build_agent_runner_rejects_unsupported_docker_provider(self):
+    def test_build_agent_runner_rejects_unsupported_docker_provider(self):  # noqa: ANN201  # tracked: #288
         with pytest.raises(SystemExit, match="not yet supported with --docker"):
             build_agent_runner(
                 _agent_config(),
@@ -1933,7 +1951,7 @@ class TestBuildAgentRunner:
                 use_docker=True,
             )
 
-    def test_build_agent_runner_rejects_unknown_backend(self):
+    def test_build_agent_runner_rejects_unknown_backend(self):  # noqa: ANN201  # tracked: #288
         with pytest.raises(SystemExit, match="unknown agent backend"):
             build_agent_runner(
                 _agent_config(),
@@ -1956,7 +1974,7 @@ class TestBuildAgentRunner:
     # so the run-log header can't report a model that isn't running.
 
     @staticmethod
-    def _cli_runner(config, *, model_name):
+    def _cli_runner(config, *, model_name):  # noqa: ANN001, ANN205  # tracked: #288
         return build_agent_runner(
             config,
             agent_backend=None,
@@ -1971,14 +1989,14 @@ class TestBuildAgentRunner:
         )
 
     @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
-    def test_cli_backend_uses_model_name(self, provider):
+    def test_cli_backend_uses_model_name(self, provider):  # noqa: ANN001, ANN201  # tracked: #288
         runner = self._cli_runner(
             _agent_config(backend="cli", cli_provider=provider),
             model_name="gpt-5.4",
         )
-        assert runner._model == "gpt-5.4"
+        assert runner._model == "gpt-5.4"  # noqa: SLF001  # tracked: #288
 
-    def test_displayed_model_name_matches_model_passed(self):
+    def test_displayed_model_name_matches_model_passed(self):  # noqa: ANN201  # tracked: #288
         # The run-log header prints _model_name; it must equal the model
         # actually handed to the CLI tool so the log never reports a model
         # that isn't running.
@@ -1986,9 +2004,9 @@ class TestBuildAgentRunner:
             _agent_config(backend="cli", cli_provider="codex"),
             model_name="gpt-5.4",
         )
-        assert runner._model_name == runner._model == "gpt-5.4"
+        assert runner._model_name == runner._model == "gpt-5.4"  # noqa: SLF001  # tracked: #288
 
-    def test_cli_backend_carries_outer_and_inner_role_configuration(self):
+    def test_cli_backend_carries_outer_and_inner_role_configuration(self):  # noqa: ANN201  # tracked: #288
         config = _agent_config(
             backend="cli",
             cli_provider="codex",
@@ -1998,12 +2016,12 @@ class TestBuildAgentRunner:
         config.thinking.level = "high"
         runner = self._cli_runner(config, model_name="gpt-5.6-sol")
 
-        assert runner._default_reasoning_effort == "high"
-        assert runner._role_models == {
+        assert runner._default_reasoning_effort == "high"  # noqa: SLF001  # tracked: #288
+        assert runner._role_models == {  # noqa: SLF001  # tracked: #288
             "orchestrator": "gpt-5.6-sol",
             "implementer": "gpt-5.6-luna",
         }
-        assert runner._role_reasoning_efforts == {
+        assert runner._role_reasoning_efforts == {  # noqa: SLF001  # tracked: #288
             "orchestrator": "xhigh",
             "implementer": "xhigh",
         }
@@ -2012,7 +2030,7 @@ class TestBuildAgentRunner:
 class TestAgentLoggerEventHandler:
     """Tests for :class:`AgentLogger` as a CLI event handler."""
 
-    def test_agent_logger_event_handler_methods_drive_formatters(self):
+    def test_agent_logger_event_handler_methods_drive_formatters(self):  # noqa: ANN201  # tracked: #288
         log_file = MagicMock()
         logger = AgentLogger(
             log_file=log_file,
@@ -2042,7 +2060,7 @@ class TestAgentLoggerEventHandler:
         assert err_call.args[1] == "boom"
         assert err_call.kwargs.get("is_error") is True
 
-    def test_agent_logger_event_handler_forwards_usage(self):
+    def test_agent_logger_event_handler_forwards_usage(self):  # noqa: ANN201  # tracked: #288
         log_file = MagicMock()
         logger = AgentLogger(
             log_file=log_file,
@@ -2058,8 +2076,8 @@ class TestAgentLoggerEventHandler:
         }
         logger.on_usage(usage)
 
-        assert logger._input_tokens == 12_345
-        assert logger._latest_usage == usage
+        assert logger._input_tokens == 12_345  # noqa: SLF001  # tracked: #288
+        assert logger._latest_usage == usage  # noqa: SLF001  # tracked: #288
 
 
 class TestBuildAgentRunnerBackendSelection:
@@ -2070,7 +2088,7 @@ class TestBuildAgentRunnerBackendSelection:
     Pinned here so the default cannot silently flip.
     """
 
-    def _build(self, config, *, agent_backend=None, cli_provider=None):
+    def _build(self, config, *, agent_backend=None, cli_provider=None):  # noqa: ANN001, ANN202  # tracked: #288
         return build_agent_runner(
             config,
             agent_backend=agent_backend,
@@ -2084,22 +2102,22 @@ class TestBuildAgentRunnerBackendSelection:
             use_docker=False,
         )
 
-    def test_default_backend_is_cli_with_empty_config(self):
+    def test_default_backend_is_cli_with_empty_config(self):  # noqa: ANN201  # tracked: #288
         runner = self._build(_agent_config())
         assert isinstance(runner, CliAgentRunner)
-        assert runner._provider == "codex"
+        assert runner._provider == "codex"  # noqa: SLF001  # tracked: #288
 
-    def test_empty_agent_section_defaults_to_cli(self):
+    def test_empty_agent_section_defaults_to_cli(self):  # noqa: ANN201  # tracked: #288
         runner = self._build(_agent_config())
         assert isinstance(runner, CliAgentRunner)
-        assert runner._provider == "codex"
+        assert runner._provider == "codex"  # noqa: SLF001  # tracked: #288
 
-    def test_agent_backend_flag_overrides_config(self):
+    def test_agent_backend_flag_overrides_config(self):  # noqa: ANN201  # tracked: #288
         # An explicit --agent-backend flag wins over [agent].backend.
         runner = self._build(_agent_config(backend="deepagents"), agent_backend="cli")
         assert isinstance(runner, CliAgentRunner)
 
-    def test_config_can_select_cli_provider(self):
+    def test_config_can_select_cli_provider(self):  # noqa: ANN201  # tracked: #288
         runner = self._build(_agent_config(backend="cli", cli_provider="claude"))
         assert isinstance(runner, CliAgentRunner)
-        assert runner._provider == "claude"
+        assert runner._provider == "claude"  # noqa: SLF001  # tracked: #288

--- a/tests/agents/test_callbacks.py
+++ b/tests/agents/test_callbacks.py
@@ -16,7 +16,7 @@ def _strip_ansi(s: str) -> str:
     return _ANSI_RE.sub("", s)
 
 
-def _make_response(text="", tool_calls=None, content=None, usage_metadata=None):
+def _make_response(text="", tool_calls=None, content=None, usage_metadata=None):  # noqa: ANN001, ANN202  # tracked: #288
     """Build a mock LLM response matching langchain structure."""
     msg = MagicMock()
     msg.text = text
@@ -32,56 +32,56 @@ def _make_response(text="", tool_calls=None, content=None, usage_metadata=None):
 
 
 class TestOnLlmNewToken:
-    def test_prints_token_and_sets_streaming(self, capsys):
+    def test_prints_token_and_sets_streaming(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
         logger.on_llm_new_token("hello")
-        assert logger._streaming is True
+        assert logger._streaming is True  # noqa: SLF001  # tracked: #288
         assert "hello" in capsys.readouterr().out
 
-    def test_empty_token_no_output(self, capsys):
+    def test_empty_token_no_output(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
         logger.on_llm_new_token("")
-        assert logger._streaming is False
+        assert logger._streaming is False  # noqa: SLF001  # tracked: #288
         assert capsys.readouterr().out == ""
 
-    def test_none_token_no_output(self, capsys):
+    def test_none_token_no_output(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
         logger.on_llm_new_token(None)
-        assert logger._streaming is False
+        assert logger._streaming is False  # noqa: SLF001  # tracked: #288
         assert capsys.readouterr().out == ""
 
 
 class TestOnLlmEnd:
-    def test_streaming_prints_newline_and_resets(self, capsys):
+    def test_streaming_prints_newline_and_resets(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
-        logger._streaming = True
+        logger._streaming = True  # noqa: SLF001  # tracked: #288
         logger.on_llm_end(_make_response("some text"))
         out = capsys.readouterr().out
         assert out.startswith("\n")
-        assert logger._streaming is False
+        assert logger._streaming is False  # noqa: SLF001  # tracked: #288
 
-    def test_streaming_does_not_reprint_text(self, capsys):
+    def test_streaming_does_not_reprint_text(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
-        logger._streaming = True
+        logger._streaming = True  # noqa: SLF001  # tracked: #288
         logger.on_llm_end(_make_response("some text"))
         out = capsys.readouterr().out
         # Only the newline, no green-wrapped text
         assert f"{GREEN}some text{RESET}" not in out
 
-    def test_not_streaming_prints_text(self, capsys):
+    def test_not_streaming_prints_text(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
         logger.on_llm_end(_make_response("hello world"))
         out = capsys.readouterr().out
         assert "hello world" in out
 
-    def test_not_streaming_prints_tool_calls(self, capsys):
+    def test_not_streaming_prints_tool_calls(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         tc = [{"name": "shell", "args": {"cmd": "ls"}}]
         logger = AgentLogger()
         logger.on_llm_end(_make_response(tool_calls=tc))
         out = capsys.readouterr().out
         assert "shell(" in out
 
-    def test_thinking_blocks_printed(self, capsys):
+    def test_thinking_blocks_printed(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         content = [
             {"type": "thinking", "thinking": "let me think..."},
             {"type": "text", "text": "answer"},
@@ -91,7 +91,7 @@ class TestOnLlmEnd:
         out = capsys.readouterr().out
         assert "let me think..." in out
 
-    def test_thinking_blocks_marked_in_log(self):
+    def test_thinking_blocks_marked_in_log(self):  # noqa: ANN201  # tracked: #288
         log = io.StringIO()
         content = [
             {"type": "thinking", "thinking": "let me think..."},
@@ -105,7 +105,7 @@ class TestOnLlmEnd:
 
 
 class TestOnToolStart:
-    def test_is_noop(self, capsys):
+    def test_is_noop(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
         serialized = {"name": "shell"}
         logger.on_tool_start(serialized, "", inputs={"cmd": "ls -la"})
@@ -114,7 +114,7 @@ class TestOnToolStart:
 
 
 class TestToolCorrelation:
-    def test_provider_call_ids_correlate_parallel_results(self):
+    def test_provider_call_ids_correlate_parallel_results(self):  # noqa: ANN201  # tracked: #288
         seen = []
         unsubscribe = output_sink().subscribe(seen.append)
         try:
@@ -141,7 +141,7 @@ class TestToolCorrelation:
         assert [call.call_id for call in calls] == ["call-a", "call-b"]
         assert [result.call_id for result in results] == ["call-b", "call-a"]
 
-    def test_cli_events_get_stable_fifo_call_ids(self):
+    def test_cli_events_get_stable_fifo_call_ids(self):  # noqa: ANN201  # tracked: #288
         seen = []
         unsubscribe = output_sink().subscribe(seen.append)
         try:
@@ -159,7 +159,7 @@ class TestToolCorrelation:
 
 
 class TestOnToolEnd:
-    def test_prints_result_with_name(self, capsys):
+    def test_prints_result_with_name(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
         output = MagicMock()
         output.content = "file1.py\nfile2.py"
@@ -168,7 +168,7 @@ class TestOnToolEnd:
         out = capsys.readouterr().out
         assert "file1.py" in out
 
-    def test_truncates_long_output(self, capsys, headless_renderer):
+    def test_truncates_long_output(self, capsys, headless_renderer):  # noqa: ANN001, ANN201  # tracked: #288
         headless_renderer.max_result_len = 10
         logger = AgentLogger()
         output = MagicMock()
@@ -178,7 +178,7 @@ class TestOnToolEnd:
         out = capsys.readouterr().out
         assert "..." in out
 
-    def test_exact_limit_no_truncation(self, capsys, headless_renderer):
+    def test_exact_limit_no_truncation(self, capsys, headless_renderer):  # noqa: ANN001, ANN201  # tracked: #288
         headless_renderer.max_result_len = 10
         logger = AgentLogger()
         output = MagicMock()
@@ -188,7 +188,7 @@ class TestOnToolEnd:
         out = capsys.readouterr().out
         assert "..." not in out
 
-    def test_custom_max_result_len(self, capsys, headless_renderer):
+    def test_custom_max_result_len(self, capsys, headless_renderer):  # noqa: ANN001, ANN201  # tracked: #288
         headless_renderer.max_result_len = 5
         logger = AgentLogger()
         output = MagicMock()
@@ -198,13 +198,13 @@ class TestOnToolEnd:
         out = capsys.readouterr().out
         assert "abcde..." in out
 
-    def test_plain_string_fallback(self, capsys):
+    def test_plain_string_fallback(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
         logger.on_tool_end("raw string output")
         out = capsys.readouterr().out
         assert "raw string output" in out
 
-    def test_normal_output_is_plain_text(self, capsys):
+    def test_normal_output_is_plain_text(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
         output = MagicMock()
         output.content = "ok"
@@ -216,7 +216,7 @@ class TestOnToolEnd:
         assert DIM not in out
         assert RED not in out
 
-    def test_error_status_is_plain_text(self, capsys):
+    def test_error_status_is_plain_text(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
         output = MagicMock()
         output.content = "Error: file not found"
@@ -228,7 +228,7 @@ class TestOnToolEnd:
         assert RED not in out
         assert DIM not in out
 
-    def test_command_failed_exit_code_is_plain_text(self, capsys):
+    def test_command_failed_exit_code_is_plain_text(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
         output = MagicMock()
         output.content = (
@@ -244,7 +244,7 @@ class TestOnToolEnd:
         assert RED not in out
         assert DIM not in out
 
-    def test_command_succeeded_exit_code_is_plain_text(self, capsys):
+    def test_command_succeeded_exit_code_is_plain_text(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
         output = MagicMock()
         output.content = "hello world\n[Command succeeded with exit code 0]"
@@ -258,9 +258,9 @@ class TestOnToolEnd:
 
 
 class TestOnToolError:
-    def test_prints_plain_error(self, capsys):
+    def test_prints_plain_error(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
-        from uuid import uuid4
+        from uuid import uuid4  # noqa: PLC0415  # tracked: #288
 
         logger.on_tool_error(Exception("something broke"), run_id=uuid4())
         out = capsys.readouterr().out
@@ -268,9 +268,9 @@ class TestOnToolError:
         assert "something broke" in out
         assert "Tool error" in out
 
-    def test_does_not_use_dim(self, capsys):
+    def test_does_not_use_dim(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger()
-        from uuid import uuid4
+        from uuid import uuid4  # noqa: PLC0415  # tracked: #288
 
         logger.on_tool_error(Exception("fail"), run_id=uuid4())
         out = capsys.readouterr().out
@@ -278,22 +278,22 @@ class TestOnToolError:
 
 
 class TestStateManagement:
-    def test_streaming_starts_false(self):
-        assert AgentLogger()._streaming is False
+    def test_streaming_starts_false(self):  # noqa: ANN201  # tracked: #288
+        assert AgentLogger()._streaming is False  # noqa: SLF001  # tracked: #288
 
-    def test_streaming_lifecycle(self, capsys):
+    def test_streaming_lifecycle(self, capsys):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         logger = AgentLogger()
-        assert logger._streaming is False
+        assert logger._streaming is False  # noqa: SLF001  # tracked: #288
         logger.on_llm_new_token("tok")
-        assert logger._streaming is True
+        assert logger._streaming is True  # noqa: SLF001  # tracked: #288
         logger.on_llm_end(_make_response())
-        assert logger._streaming is False
+        assert logger._streaming is False  # noqa: SLF001  # tracked: #288
 
 
 class TestLogFile:
     """AgentLogger with log_file writes full output to log while truncating stdout."""
 
-    def test_tool_result_full_in_log_truncated_on_stdout(self, capsys, headless_renderer):
+    def test_tool_result_full_in_log_truncated_on_stdout(self, capsys, headless_renderer):  # noqa: ANN001, ANN201  # tracked: #288
         headless_renderer.max_result_len = 10
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
@@ -311,7 +311,7 @@ class TestLogFile:
         assert "a" * 50 in log_text
         assert "..." not in log_text
 
-    def test_tool_call_full_args_in_log(self, capsys):
+    def test_tool_call_full_args_in_log(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
         long_arg = "x" * 200
@@ -325,14 +325,14 @@ class TestLogFile:
         # log has full args
         assert long_arg in log_text
 
-    def test_tokens_written_to_log(self, capsys):
+    def test_tokens_written_to_log(self, capsys):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
         logger.on_llm_new_token("hello")
         log_text = log.getvalue()
         assert "hello" in log_text
 
-    def test_thinking_written_to_log(self, capsys):
+    def test_thinking_written_to_log(self, capsys):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
         content = [
@@ -343,7 +343,7 @@ class TestLogFile:
         log_text = log.getvalue()
         assert "deep thoughts" in log_text
 
-    def test_no_log_file_works_normally(self, capsys, headless_renderer):
+    def test_no_log_file_works_normally(self, capsys, headless_renderer):  # noqa: ANN001, ANN201  # tracked: #288
         """AgentLogger without log_file still works as before."""
         headless_renderer.max_result_len = 10
         logger = AgentLogger()
@@ -355,7 +355,7 @@ class TestLogFile:
         stdout = capsys.readouterr().out
         assert "..." in stdout
 
-    def test_log_text_flushes_log_file(self):
+    def test_log_text_flushes_log_file(self):  # noqa: ANN201  # tracked: #288
         """Streamed events must hit disk immediately so ``tail -f`` on the run
         log shows codex output as it arrives, not in buffered bursts."""
         log = MagicMock()
@@ -363,7 +363,7 @@ class TestLogFile:
         logger.log_text("streamed chunk")
         assert log.flush.called
 
-    def test_tool_result_flushes_log_file(self):
+    def test_tool_result_flushes_log_file(self):  # noqa: ANN201  # tracked: #288
         log = MagicMock()
         logger = AgentLogger(log_file=log)
         output = MagicMock()
@@ -377,31 +377,31 @@ class TestLogFile:
 class TestOnChatModelStart:
     """Tests for on_chat_model_start callback that logs LLM call context to log_file."""
 
-    def _make_system_message(self, content="You are a helpful assistant."):
+    def _make_system_message(self, content="You are a helpful assistant."):  # noqa: ANN001, ANN202  # tracked: #288
         msg = MagicMock()
         msg.type = "system"
         msg.content = content
         return msg
 
-    def _make_human_message(self, content="Hello"):
+    def _make_human_message(self, content="Hello"):  # noqa: ANN001, ANN202  # tracked: #288
         msg = MagicMock()
         msg.type = "human"
         msg.content = content
         return msg
 
-    def _make_ai_message(self, content="Hi there"):
+    def _make_ai_message(self, content="Hi there"):  # noqa: ANN001, ANN202  # tracked: #288
         msg = MagicMock()
         msg.type = "ai"
         msg.content = content
         return msg
 
-    def _make_tool_message(self, content="result"):
+    def _make_tool_message(self, content="result"):  # noqa: ANN001, ANN202  # tracked: #288
         msg = MagicMock()
         msg.type = "tool"
         msg.content = content
         return msg
 
-    def test_first_call_logs_model_info(self, capsys):
+    def test_first_call_logs_model_info(self, capsys):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
         serialized = {
@@ -413,7 +413,7 @@ class TestOnChatModelStart:
         log_text = log.getvalue()
         assert "claude-sonnet-4-6" in log_text
 
-    def test_first_call_logs_system_prompt(self, capsys):
+    def test_first_call_logs_system_prompt(self, capsys):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
         serialized = {
@@ -426,7 +426,7 @@ class TestOnChatModelStart:
         log_text = log.getvalue()
         assert system_prompt in log_text
 
-    def test_every_call_logs_message_type_summary(self, capsys):
+    def test_every_call_logs_message_type_summary(self, capsys):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
         serialized = {"id": ["langchain", "chat_models"], "kwargs": {}}
@@ -447,7 +447,7 @@ class TestOnChatModelStart:
         assert "1 ai" in log_text
         assert "2 tool" in log_text
 
-    def test_every_call_logs_separator_with_call_number(self, capsys):
+    def test_every_call_logs_separator_with_call_number(self, capsys):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
         serialized = {"id": ["langchain"], "kwargs": {}}
@@ -458,7 +458,7 @@ class TestOnChatModelStart:
         assert "LLM call #1" in log_text
         assert "LLM call #2" in log_text
 
-    def test_logs_last_human_message(self, capsys):
+    def test_logs_last_human_message(self, capsys):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
         serialized = {"id": ["langchain"], "kwargs": {}}
@@ -474,7 +474,7 @@ class TestOnChatModelStart:
         log_text = log.getvalue()
         assert "second question" in log_text
 
-    def test_no_log_file_is_noop(self, capsys):
+    def test_no_log_file_is_noop(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         """Without log_file, on_chat_model_start should not write to stdout."""
         logger = AgentLogger()
         serialized = {"id": ["langchain"], "kwargs": {"model": "test-model"}}
@@ -484,7 +484,7 @@ class TestOnChatModelStart:
         assert "test-model" not in stdout
         assert "LLM call" not in stdout
 
-    def test_system_prompt_only_logged_on_first_call(self, capsys):
+    def test_system_prompt_only_logged_on_first_call(self, capsys):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         log = io.StringIO()
         logger = AgentLogger(log_file=log)
         serialized = {"id": ["langchain"], "kwargs": {}}
@@ -503,48 +503,62 @@ class TestOnChatModelStart:
 
 
 class TestDefaultContextWindowLookup:
-    def test_claude_4_6_resolves_to_1m(self):
-        from vibesys.agents.callbacks import _default_context_window_lookup
+    def test_claude_4_6_resolves_to_1m(self):  # noqa: ANN201  # tracked: #288
+        from vibesys.agents.callbacks import (  # noqa: PLC0415  # tracked: #288
+            _default_context_window_lookup,
+        )
 
         assert _default_context_window_lookup("claude-opus-4-6") == 1_000_000
         assert _default_context_window_lookup("claude-sonnet-4-6") == 1_000_000
 
-    def test_older_claude_falls_back_to_200k(self):
+    def test_older_claude_falls_back_to_200k(self):  # noqa: ANN201  # tracked: #288
         # Regression guard: claude- fallback comes after the 4-6 entries
-        from vibesys.agents.callbacks import _default_context_window_lookup
+        from vibesys.agents.callbacks import (  # noqa: PLC0415  # tracked: #288
+            _default_context_window_lookup,
+        )
 
         assert _default_context_window_lookup("claude-haiku-4-5") == 200_000
         assert _default_context_window_lookup("claude-sonnet-4-5") == 200_000
         assert _default_context_window_lookup("claude-opus-4-1") == 200_000
 
-    def test_gemini(self):
-        from vibesys.agents.callbacks import _default_context_window_lookup
+    def test_gemini(self):  # noqa: ANN201  # tracked: #288
+        from vibesys.agents.callbacks import (  # noqa: PLC0415  # tracked: #288
+            _default_context_window_lookup,
+        )
 
         assert _default_context_window_lookup("gemini-2.5-flash") == 1_048_576
         assert _default_context_window_lookup("gemini-3-pro") == 1_048_576
 
-    def test_gemma(self):
-        from vibesys.agents.callbacks import _default_context_window_lookup
+    def test_gemma(self):  # noqa: ANN201  # tracked: #288
+        from vibesys.agents.callbacks import (  # noqa: PLC0415  # tracked: #288
+            _default_context_window_lookup,
+        )
 
         assert _default_context_window_lookup("gemma-2") == 8_192
 
-    def test_gpt5_4_resolves_to_1m(self):
+    def test_gpt5_4_resolves_to_1m(self):  # noqa: ANN201  # tracked: #288
         # Regression guard: gpt-5.4 entry must come before gpt-5
-        from vibesys.agents.callbacks import _default_context_window_lookup
+        from vibesys.agents.callbacks import (  # noqa: PLC0415  # tracked: #288
+            _default_context_window_lookup,
+        )
 
         assert _default_context_window_lookup("gpt-5.4") == 1_050_000
         assert _default_context_window_lookup("gpt-5.4-pro") == 1_050_000
 
-    def test_gpt5_family_falls_back_to_400k(self):
-        from vibesys.agents.callbacks import _default_context_window_lookup
+    def test_gpt5_family_falls_back_to_400k(self):  # noqa: ANN201  # tracked: #288
+        from vibesys.agents.callbacks import (  # noqa: PLC0415  # tracked: #288
+            _default_context_window_lookup,
+        )
 
         assert _default_context_window_lookup("gpt-5") == 400_000
         assert _default_context_window_lookup("gpt-5-mini") == 400_000
         assert _default_context_window_lookup("gpt-5-nano") == 400_000
         assert _default_context_window_lookup("gpt-5.2") == 400_000
 
-    def test_gpt4_and_o_series(self):
-        from vibesys.agents.callbacks import _default_context_window_lookup
+    def test_gpt4_and_o_series(self):  # noqa: ANN201  # tracked: #288
+        from vibesys.agents.callbacks import (  # noqa: PLC0415  # tracked: #288
+            _default_context_window_lookup,
+        )
 
         assert _default_context_window_lookup("gpt-4o") == 128_000
         assert _default_context_window_lookup("gpt-4-turbo") == 128_000
@@ -552,19 +566,23 @@ class TestDefaultContextWindowLookup:
         assert _default_context_window_lookup("o3-mini") == 200_000
         assert _default_context_window_lookup("o4-mini") == 200_000
 
-    def test_unknown_model_returns_none(self):
-        from vibesys.agents.callbacks import _default_context_window_lookup
+    def test_unknown_model_returns_none(self):  # noqa: ANN201  # tracked: #288
+        from vibesys.agents.callbacks import (  # noqa: PLC0415  # tracked: #288
+            _default_context_window_lookup,
+        )
 
         assert _default_context_window_lookup("unknown-model-xyz") is None
 
-    def test_none_model_name_returns_none(self):
-        from vibesys.agents.callbacks import _default_context_window_lookup
+    def test_none_model_name_returns_none(self):  # noqa: ANN201  # tracked: #288
+        from vibesys.agents.callbacks import (  # noqa: PLC0415  # tracked: #288
+            _default_context_window_lookup,
+        )
 
         assert _default_context_window_lookup(None) is None
 
 
 class TestPrefixFormat:
-    def test_no_label_no_prefix_on_streaming(self, capsys):
+    def test_no_label_no_prefix_on_streaming(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         # Existing behavior preserved: AgentLogger without agent_label produces no prefix
         logger = AgentLogger()
         logger.on_llm_new_token("hello")
@@ -572,14 +590,14 @@ class TestPrefixFormat:
         assert "[" not in out
         assert "hello" in out
 
-    def test_prefix_with_label_and_known_model(self, capsys):
+    def test_prefix_with_label_and_known_model(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger(agent_label="Implementer", model_name="claude-sonnet-4-6")
         logger.on_llm_new_token("hi")
         out = _strip_ansi(capsys.readouterr().out)
         # Format: [Implementer | <float>s | 0/1.0M] hi
         assert re.search(r"\[Implementer \| \d+\.\ds \| 0/1\.0M\]", out), out
 
-    def test_prefix_includes_progress(self, capsys):
+    def test_prefix_includes_progress(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger(
             agent_label="Implementer",
             progress=RoundProgress(3, 24),
@@ -592,14 +610,14 @@ class TestPrefixFormat:
             out,
         ), out
 
-    def test_prefix_with_gpt5_4(self, capsys):
+    def test_prefix_with_gpt5_4(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger(agent_label="Judge", model_name="gpt-5.4")
         logger.on_llm_new_token("hi")
         out = _strip_ansi(capsys.readouterr().out)
         # 1_050_000 -> "1.0M" or "1.1M" depending on float rounding; accept either
         assert re.search(r"\[Judge \| \d+\.\ds \| 0/1\.\dM\]", out), out
 
-    def test_prefix_omits_max_when_model_unknown(self, capsys):
+    def test_prefix_omits_max_when_model_unknown(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger(agent_label="X", model_name="unknown-future-model")
         logger.on_llm_new_token("y")
         out = _strip_ansi(capsys.readouterr().out)
@@ -608,7 +626,7 @@ class TestPrefixFormat:
         assert match, out
         assert match.group(1) == "0"
 
-    def test_prefix_omits_max_when_no_model_name(self, capsys):
+    def test_prefix_omits_max_when_no_model_name(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger(agent_label="X")
         logger.on_llm_new_token("y")
         out = _strip_ansi(capsys.readouterr().out)
@@ -616,7 +634,7 @@ class TestPrefixFormat:
         assert match, out
         assert match.group(1) == "0"
 
-    def test_prefix_updates_after_on_llm_end(self, capsys):
+    def test_prefix_updates_after_on_llm_end(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger(agent_label="Implementer", model_name="claude-sonnet-4-6")
         logger.on_llm_end(
             _make_response(
@@ -632,7 +650,7 @@ class TestPrefixFormat:
         out = _strip_ansi(capsys.readouterr().out)
         assert "20k/1.0M" in out, out
 
-    def test_tool_call_path_uses_dynamic_prefix(self, capsys):
+    def test_tool_call_path_uses_dynamic_prefix(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger(agent_label="Implementer", model_name="gpt-5.4")
         tc = [{"name": "shell", "args": {"cmd": "ls"}}]
         logger.on_llm_end(
@@ -645,7 +663,7 @@ class TestPrefixFormat:
         # Tool-call line should carry the dynamic prefix with elapsed and tokens
         assert re.search(r"\[Implementer \| \d+\.\ds \| 5k/1\.\dM\] → shell\(", out), out
 
-    def test_lookup_injection_overrides_default(self, capsys):
+    def test_lookup_injection_overrides_default(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         # The user explicitly asked for an abstraction so the lookup can be stubbed.
         logger = AgentLogger(
             agent_label="Test",
@@ -657,16 +675,18 @@ class TestPrefixFormat:
         # Used tokens still 0 (no on_llm_end yet); max is the injected 999_999 → "999k"
         assert "0/999k" in out, out
 
-    def test_default_lookup_used_when_not_injected(self):
-        from vibesys.agents.callbacks import _default_context_window_lookup
+    def test_default_lookup_used_when_not_injected(self):  # noqa: ANN201  # tracked: #288
+        from vibesys.agents.callbacks import (  # noqa: PLC0415  # tracked: #288
+            _default_context_window_lookup,
+        )
 
         logger = AgentLogger(agent_label="Test", model_name="gpt-5.4")
-        assert logger._context_window_lookup is _default_context_window_lookup
-        assert logger._context_window == 1_050_000
+        assert logger._context_window_lookup is _default_context_window_lookup  # noqa: SLF001  # tracked: #288
+        assert logger._context_window == 1_050_000  # noqa: SLF001  # tracked: #288
 
-    def test_elapsed_time_advances(self, capsys, monkeypatch):
+    def test_elapsed_time_advances(self, capsys, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         # Fake time.monotonic so we can verify the elapsed value reaches the prefix
-        from vibesys.agents import callbacks
+        from vibesys.agents import callbacks  # noqa: PLC0415  # tracked: #288
 
         ticks = iter([1000.0, 1308.2])
         monkeypatch.setattr(callbacks.time, "monotonic", lambda: next(ticks))
@@ -678,9 +698,9 @@ class TestPrefixFormat:
 
 
 class TestUsageMetadataExtraction:
-    def test_extracts_input_tokens(self):
+    def test_extracts_input_tokens(self):  # noqa: ANN201  # tracked: #288
         logger = AgentLogger(agent_label="X", model_name="claude-sonnet-4-6")
-        assert logger._input_tokens == 0
+        assert logger._input_tokens == 0  # noqa: SLF001  # tracked: #288
         logger.on_llm_end(
             _make_response(
                 usage_metadata={
@@ -690,35 +710,35 @@ class TestUsageMetadataExtraction:
                 }
             )
         )
-        assert logger._input_tokens == 12_345
+        assert logger._input_tokens == 12_345  # noqa: SLF001  # tracked: #288
 
-    def test_no_usage_metadata_keeps_zero(self):
+    def test_no_usage_metadata_keeps_zero(self):  # noqa: ANN201  # tracked: #288
         # vLLM / openai-compatible servers may omit usage entirely
         logger = AgentLogger(agent_label="X", model_name="gpt-5.4")
         logger.on_llm_end(_make_response(usage_metadata=None))
-        assert logger._input_tokens == 0
+        assert logger._input_tokens == 0  # noqa: SLF001  # tracked: #288
 
-    def test_streaming_path_still_extracts_usage(self):
+    def test_streaming_path_still_extracts_usage(self):  # noqa: ANN201  # tracked: #288
         # on_llm_end during streaming must update tokens before its early-return
         logger = AgentLogger(agent_label="X", model_name="claude-sonnet-4-6")
-        logger._streaming = True
+        logger._streaming = True  # noqa: SLF001  # tracked: #288
         logger.on_llm_end(
             _make_response(
                 usage_metadata={"input_tokens": 5_000, "output_tokens": 100, "total_tokens": 5_100}
             )
         )
-        assert logger._input_tokens == 5_000
+        assert logger._input_tokens == 5_000  # noqa: SLF001  # tracked: #288
 
-    def test_zero_input_tokens_does_not_overwrite(self):
+    def test_zero_input_tokens_does_not_overwrite(self):  # noqa: ANN201  # tracked: #288
         # Defensive: a usage block reporting 0 input tokens should not clobber a real prior value
         logger = AgentLogger(agent_label="X", model_name="claude-sonnet-4-6")
-        logger._input_tokens = 1234
+        logger._input_tokens = 1234  # noqa: SLF001  # tracked: #288
         logger.on_llm_end(
             _make_response(
                 usage_metadata={"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
             )
         )
-        assert logger._input_tokens == 1234
+        assert logger._input_tokens == 1234  # noqa: SLF001  # tracked: #288
 
 
 class TestUpdateUsagePublicHook:
@@ -730,47 +750,47 @@ class TestUpdateUsagePublicHook:
     ``_input_tokens`` from ``on_llm_end``.
     """
 
-    def test_update_usage_sets_input_tokens(self):
+    def test_update_usage_sets_input_tokens(self):  # noqa: ANN201  # tracked: #288
         logger = AgentLogger(agent_label="Implementer", model_name="claude-sonnet-4-6")
-        assert logger._input_tokens == 0
+        assert logger._input_tokens == 0  # noqa: SLF001  # tracked: #288
         logger.update_usage({"input_tokens": 12_345, "output_tokens": 42})
-        assert logger._input_tokens == 12_345
-        assert logger._latest_usage == {"input_tokens": 12_345, "output_tokens": 42}
+        assert logger._input_tokens == 12_345  # noqa: SLF001  # tracked: #288
+        assert logger._latest_usage == {"input_tokens": 12_345, "output_tokens": 42}  # noqa: SLF001  # tracked: #288
 
-    def test_update_usage_overwrites_previous_value(self):
+    def test_update_usage_overwrites_previous_value(self):  # noqa: ANN201  # tracked: #288
         """Semantics mirror ``on_llm_end``: latest turn overwrites — no accumulation."""
         logger = AgentLogger(agent_label="X", model_name="claude-sonnet-4-6")
         logger.update_usage({"input_tokens": 1_000})
         logger.update_usage({"input_tokens": 5_000})
-        assert logger._input_tokens == 5_000
+        assert logger._input_tokens == 5_000  # noqa: SLF001  # tracked: #288
 
-    def test_update_usage_empty_dict_is_noop(self):
+    def test_update_usage_empty_dict_is_noop(self):  # noqa: ANN201  # tracked: #288
         logger = AgentLogger(agent_label="X", model_name="claude-sonnet-4-6")
-        logger._input_tokens = 500
+        logger._input_tokens = 500  # noqa: SLF001  # tracked: #288
         logger.update_usage({})
-        assert logger._input_tokens == 500
+        assert logger._input_tokens == 500  # noqa: SLF001  # tracked: #288
 
-    def test_update_usage_none_is_noop(self):
+    def test_update_usage_none_is_noop(self):  # noqa: ANN201  # tracked: #288
         logger = AgentLogger(agent_label="X", model_name="claude-sonnet-4-6")
-        logger._input_tokens = 500
+        logger._input_tokens = 500  # noqa: SLF001  # tracked: #288
         logger.update_usage(None)
-        assert logger._input_tokens == 500
+        assert logger._input_tokens == 500  # noqa: SLF001  # tracked: #288
 
-    def test_update_usage_zero_input_tokens_does_not_overwrite(self):
+    def test_update_usage_zero_input_tokens_does_not_overwrite(self):  # noqa: ANN201  # tracked: #288
         """A zero-count usage dict should not clobber a real prior value."""
         logger = AgentLogger(agent_label="X", model_name="claude-sonnet-4-6")
-        logger._input_tokens = 2_500
+        logger._input_tokens = 2_500  # noqa: SLF001  # tracked: #288
         logger.update_usage({"input_tokens": 0, "output_tokens": 50})
-        assert logger._input_tokens == 2_500
+        assert logger._input_tokens == 2_500  # noqa: SLF001  # tracked: #288
 
-    def test_update_usage_reflected_in_prefix(self, capsys):
+    def test_update_usage_reflected_in_prefix(self, capsys):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         """The formatted prefix includes the compact token count after an update."""
         logger = AgentLogger(agent_label="Implementer", model_name="claude-sonnet-4-6")
         logger.update_usage({"input_tokens": 12_345})
-        prefix = _strip_ansi(logger._format_prefix())
+        prefix = _strip_ansi(logger._format_prefix())  # noqa: SLF001  # tracked: #288
         assert "12k/1.0M" in prefix
 
-    def test_update_usage_drives_tool_call_prefix(self, capsys):
+    def test_update_usage_drives_tool_call_prefix(self, capsys):  # noqa: ANN001, ANN201  # tracked: #288
         logger = AgentLogger(agent_label="Implementer", model_name="claude-sonnet-4-6")
         logger.update_usage({"input_tokens": 14_000})
         logger.log_tool_call("Bash", {"command": "ls"})

--- a/tests/agents/test_cli_common.py
+++ b/tests/agents/test_cli_common.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 from io import StringIO
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 import pytest
 
@@ -42,35 +42,35 @@ class TestAgentLabel:
         ("kind", "expected"),
         [("perf_eval", "Perf Eval"), ("judge", "Judge"), ("implementer", "Implementer")],
     )
-    def test_snake_case_becomes_title_case(self, kind, expected):
+    def test_snake_case_becomes_title_case(self, kind, expected):  # noqa: ANN001, ANN201  # tracked: #288
         assert agent_label(kind) == expected
 
 
 class TestDiscoverSkillDirs:
-    def test_a_root_that_is_itself_a_skill(self, tmp_path):
+    def test_a_root_that_is_itself_a_skill(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         (tmp_path / "SKILL.md").write_text("# s\n")
 
         assert discover_skill_dirs(tmp_path) == [tmp_path]
 
-    def test_flat_layout(self, tmp_path):
+    def test_flat_layout(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         a = _skill(tmp_path, "alpha")
         b = _skill(tmp_path, "beta")
 
         assert sorted(discover_skill_dirs(tmp_path)) == sorted([a, b])
 
-    def test_tier_organized_layout(self, tmp_path):
+    def test_tier_organized_layout(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         deep = _skill(tmp_path, "tier1/nested")
 
         assert discover_skill_dirs(tmp_path) == [deep]
 
-    def test_a_root_with_no_skills(self, tmp_path):
+    def test_a_root_with_no_skills(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         (tmp_path / "notes.txt").write_text("x")
 
         assert discover_skill_dirs(tmp_path) == []
 
 
 class TestMaterializeSkills:
-    def test_copies_into_every_cli_discovery_path(self, tmp_path):
+    def test_copies_into_every_cli_discovery_path(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         src = tmp_path / "src"
         _skill(src, "alpha")
         ws = tmp_path / "ws"
@@ -82,7 +82,7 @@ class TestMaterializeSkills:
         for rel in CLI_SKILL_DIRS:
             assert (ws / rel / "alpha" / "SKILL.md").is_file()
 
-    def test_no_sources_is_a_noop(self, tmp_path):
+    def test_no_sources_is_a_noop(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         ws = tmp_path / "ws"
         ws.mkdir()
 
@@ -90,7 +90,7 @@ class TestMaterializeSkills:
 
         assert list(ws.iterdir()) == []
 
-    def test_sources_without_skills_create_nothing(self, tmp_path):
+    def test_sources_without_skills_create_nothing(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         src = tmp_path / "src"
         src.mkdir()
         (src / "readme.txt").write_text("x")
@@ -101,7 +101,7 @@ class TestMaterializeSkills:
 
         assert list(ws.iterdir()) == []
 
-    def test_re_materializing_replaces_stale_content(self, tmp_path):
+    def test_re_materializing_replaces_stale_content(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         src = tmp_path / "src"
         _skill(src, "alpha", "# v1\n")
         ws = tmp_path / "ws"
@@ -114,7 +114,7 @@ class TestMaterializeSkills:
         assert (ws / "alpha/SKILL.md").read_text() == "# v2\n"
         assert (ws / ".claude/skills/alpha/SKILL.md").read_text() == "# v2\n"
 
-    def test_source_already_at_workspace_root_is_not_replaced(self, tmp_path):
+    def test_source_already_at_workspace_root_is_not_replaced(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         ws = tmp_path / "ws"
         skill = _skill(ws, "alpha", "# local\n")
 
@@ -122,7 +122,7 @@ class TestMaterializeSkills:
 
         assert (skill / "SKILL.md").read_text() == "# local\n"
 
-    def test_later_source_wins_on_a_name_collision(self, tmp_path):
+    def test_later_source_wins_on_a_name_collision(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         first = tmp_path / "a"
         second = tmp_path / "b"
         _skill(first, "dup", "# first\n")
@@ -134,7 +134,7 @@ class TestMaterializeSkills:
 
         assert (ws / ".claude/skills/dup/SKILL.md").read_text() == "# second\n"
 
-    def test_a_copy_failure_is_logged_not_raised(self, tmp_path, monkeypatch):
+    def test_a_copy_failure_is_logged_not_raised(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         """The loop must still make progress if one skill fails to copy."""
         src = tmp_path / "src"
         _skill(src, "alpha")
@@ -142,8 +142,8 @@ class TestMaterializeSkills:
         ws.mkdir()
         log = StringIO()
 
-        def _boom(*_args, **_kwargs):
-            raise OSError("disk on fire")
+        def _boom(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202  # tracked: #288
+            raise OSError("disk on fire")  # noqa: TRY003  # tracked: #288
 
         monkeypatch.setattr("vibesys.agents.cli_common.shutil.copytree", _boom)
 
@@ -153,19 +153,19 @@ class TestMaterializeSkills:
         assert "failed to materialize" in written
         assert "disk on fire" in written
 
-    def test_a_copy_failure_without_a_log_is_swallowed(self, tmp_path, monkeypatch):
+    def test_a_copy_failure_without_a_log_is_swallowed(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         src = tmp_path / "src"
         _skill(src, "alpha")
         ws = tmp_path / "ws"
         ws.mkdir()
         monkeypatch.setattr(
             "vibesys.agents.cli_common.shutil.copytree",
-            lambda *a, **k: (_ for _ in ()).throw(OSError("nope")),
+            lambda *a, **k: (_ for _ in ()).throw(OSError("nope")),  # noqa: ARG005  # tracked: #288
         )
 
         materialize_skills(ws, [src])  # must not raise
 
-    def test_a_stale_symlink_destination_is_replaced(self, tmp_path):
+    def test_a_stale_symlink_destination_is_replaced(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         src = tmp_path / "src"
         _skill(src, "alpha")
         ws = tmp_path / "ws"
@@ -180,14 +180,14 @@ class TestMaterializeSkills:
 
 
 class TestBuildSchemaHint:
-    def test_names_the_model_and_embeds_its_schema(self):
+    def test_names_the_model_and_embeds_its_schema(self):  # noqa: ANN201  # tracked: #288
         hint = build_schema_hint(JudgeResponse)
 
         assert "JudgeResponse" in hint
         assert "EXACTLY one JSON object" in hint
         assert "verdict" in hint
 
-    def test_forbids_markdown_fences(self):
+    def test_forbids_markdown_fences(self):  # noqa: ANN201  # tracked: #288
         """CLI tools wrap JSON in fences unless told not to."""
         assert "Do not wrap it in markdown fences" in build_schema_hint(JudgeResponse)
 
@@ -197,12 +197,12 @@ class TestMaterializeNativeOutputSchema:
         "response_cls",
         [PreRoundDecision, OrchestratorPlan, JudgeResponse],
     )
-    def test_active_agent_schemas_materialize_atomically(self, tmp_path, response_cls):
+    def test_active_agent_schemas_materialize_atomically(self, tmp_path, response_cls):  # noqa: ANN001, ANN201  # tracked: #288
         relative = materialize_native_output_schema(tmp_path, response_cls)
         target = tmp_path / relative
         schema = json.loads(target.read_text())
 
-        def assert_strict_objects(node):
+        def assert_strict_objects(node):  # noqa: ANN001, ANN202  # tracked: #288
             if isinstance(node, list):
                 for value in node:
                     assert_strict_objects(value)
@@ -220,16 +220,16 @@ class TestMaterializeNativeOutputSchema:
         assert "default" not in target.read_text()
         assert not list(target.parent.glob(f".{target.name}.*"))
 
-    def test_schema_valued_mapping_falls_back_before_writing(self, tmp_path):
+    def test_schema_valued_mapping_falls_back_before_writing(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         with pytest.raises(ValueError, match="arbitrary object keys"):
             materialize_native_output_schema(tmp_path, ImplementerResponse)
 
         assert not (tmp_path / ".cache/vibesys/response-schemas").exists()
 
-    def test_rejects_unsupported_schema_constructs_before_writing(self, tmp_path):
+    def test_rejects_unsupported_schema_constructs_before_writing(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         class UnsupportedResponse(JudgeResponse):
             @classmethod
-            def model_json_schema(cls, *args, **kwargs):
+            def model_json_schema(cls, *args, **kwargs):  # noqa: ANN002, ANN003, ANN206, ARG003  # tracked: #288
                 return {
                     "type": "object",
                     "properties": {"analysis": {"type": "string"}},

--- a/tests/agents/test_cli_docker.py
+++ b/tests/agents/test_cli_docker.py
@@ -6,8 +6,9 @@ from vibesys.agents import cli_docker
 from vibesys.agents.cli_docker import DockerAuthPath
 
 
-def test_auth_import_copies_directories_and_files_to_private_writable_paths(
-    tmp_path: Path, monkeypatch
+def test_auth_import_copies_directories_and_files_to_private_writable_paths(  # noqa: ANN201  # tracked: #288
+    tmp_path: Path,
+    monkeypatch,  # noqa: ANN001  # tracked: #288
 ):
     state_dir = tmp_path / "state"
     state_dir.mkdir()
@@ -32,7 +33,7 @@ def test_auth_import_copies_directories_and_files_to_private_writable_paths(
     ]
 
 
-def test_auth_import_uses_provider_native_container_paths():
+def test_auth_import_uses_provider_native_container_paths():  # noqa: ANN201  # tracked: #288
     assert {
         provider: [
             (spec.host_path.relative_to(Path.home()).as_posix(), spec.container_path)
@@ -76,7 +77,7 @@ def test_auth_import_uses_provider_native_container_paths():
     }
 
 
-def test_provider_auth_imports_exclude_bulk_runtime_roots():
+def test_provider_auth_imports_exclude_bulk_runtime_roots():  # noqa: ANN201  # tracked: #288
     configured_sources = {
         spec.host_path for specs in cli_docker.DOCKER_AUTH_PATHS.values() for spec in specs
     }
@@ -92,7 +93,7 @@ def test_provider_auth_imports_exclude_bulk_runtime_roots():
     )
 
 
-def test_codex_container_installs_luna_capable_cli_version():
+def test_codex_container_installs_luna_capable_cli_version():  # noqa: ANN201  # tracked: #288
     commands = cli_docker.docker_init_commands("codex")
 
     assert (
@@ -102,7 +103,7 @@ def test_codex_container_installs_luna_capable_cli_version():
 
 
 @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
-def test_editor_container_installs_pinned_rust_toolchain(provider: str):
+def test_editor_container_installs_pinned_rust_toolchain(provider: str):  # noqa: ANN201  # tracked: #288
     commands = cli_docker.docker_init_commands(provider)
     rust_install = next(command for command in commands if "rustup-init.sh" in command)
 

--- a/tests/agents/test_host_resource_declarations.py
+++ b/tests/agents/test_host_resource_declarations.py
@@ -11,11 +11,11 @@ from vs_sandbox import HostResourceAccess
 class TestInstallRoot:
     """Agent packages may need binaries from sibling installation paths."""
 
-    def test_node_package_imports_whole_package_tree(self):
+    def test_node_package_imports_whole_package_tree(self):  # noqa: ANN201  # tracked: #288
         launcher = Path(
             "/home/u/.nvm/versions/node/v24/lib/node_modules/@openai/codex/bin/codex.js"
         )
-        root = host_resource_declarations._install_root(launcher)
+        root = host_resource_declarations._install_root(launcher)  # noqa: SLF001  # tracked: #288
 
         assert root == Path("/home/u/.nvm/versions/node/v24/lib")
         platform_bin = Path(
@@ -24,13 +24,13 @@ class TestInstallRoot:
         )
         assert platform_bin.is_relative_to(root)
 
-    def test_plain_binary_imports_its_directory(self):
-        assert host_resource_declarations._install_root(Path("/opt/tool/bin/agent")) == Path(
+    def test_plain_binary_imports_its_directory(self):  # noqa: ANN201  # tracked: #288
+        assert host_resource_declarations._install_root(Path("/opt/tool/bin/agent")) == Path(  # noqa: SLF001  # tracked: #288
             "/opt/tool/bin"
         )
 
 
-def test_defaults_declare_path_rust_and_shell_resources(tmp_path):
+def test_defaults_declare_path_rust_and_shell_resources(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     home = tmp_path / "home"
     tool_bin = home / "tools" / "bin"
     cargo_bin = home / ".cargo" / "bin"
@@ -60,7 +60,7 @@ def test_defaults_declare_path_rust_and_shell_resources(tmp_path):
         ("opencode", ".config/opencode", ".codex/auth.json"),
     ],
 )
-def test_provider_state_is_scoped_to_selected_agent(tmp_path, provider, expected, forbidden):
+def test_provider_state_is_scoped_to_selected_agent(tmp_path, provider, expected, forbidden):  # noqa: ANN001, ANN201  # tracked: #288
     declarations = host_resource_declarations.declare_agent_host_resources(
         {"HOME": str(tmp_path)},
         binary_path=None,

--- a/tests/agents/test_omnigent_backend.py
+++ b/tests/agents/test_omnigent_backend.py
@@ -47,7 +47,7 @@ from vibesys.schemas import JudgeResponse, Verdict
 from vs_sandbox import HostResource, HostResourceAccess
 
 
-def _config(*, omnigent: bool | None = None, **agent) -> Config:
+def _config(*, omnigent: bool | None = None, **agent) -> Config:  # noqa: ANN003  # tracked: #288
     """Minimal Config, optionally overriding the omnigent feature flag."""
     payload: dict = {"model": {"name": "m"}, "agent": agent}
     if omnigent is not None:
@@ -55,7 +55,7 @@ def _config(*, omnigent: bool | None = None, **agent) -> Config:
     return Config.model_validate(payload)
 
 
-def _build(config: Config, **overrides):
+def _build(config: Config, **overrides):  # noqa: ANN003, ANN202  # tracked: #288
     kwargs = {
         "agent_backend": None,
         "cli_provider": None,
@@ -78,31 +78,31 @@ def _judge_fallback() -> JudgeResponse:
 class TestFlagDefaultsOff:
     """The agentshim path must be untouched unless the flag is set."""
 
-    def test_flag_defaults_to_disabled(self):
+    def test_flag_defaults_to_disabled(self):  # noqa: ANN201  # tracked: #288
         assert is_feature_enabled(FeatureFlag.OMNIGENT_AGENT_BACKEND, _config()) is False
 
-    def test_flag_absent_from_config_yields_cli_runner(self):
+    def test_flag_absent_from_config_yields_cli_runner(self):  # noqa: ANN201  # tracked: #288
         runner = _build(_config(backend="cli", cli_provider="claude"))
 
         assert isinstance(runner, CliAgentRunner)
         assert runner.backend_name == "cli"
-        assert runner._provider == "claude"
+        assert runner._provider == "claude"  # noqa: SLF001  # tracked: #288
 
-    def test_flag_explicitly_false_yields_cli_runner(self):
+    def test_flag_explicitly_false_yields_cli_runner(self):  # noqa: ANN201  # tracked: #288
         runner = _build(_config(omnigent=False, backend="cli", cli_provider="codex"))
 
         assert isinstance(runner, CliAgentRunner)
         assert runner.backend_name == "cli"
 
     @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
-    def test_every_agentshim_provider_still_builds_with_flag_off(self, provider):
+    def test_every_agentshim_provider_still_builds_with_flag_off(self, provider):  # noqa: ANN001, ANN201  # tracked: #288
         """Providers omnigent cannot run must keep working on the default path."""
         runner = _build(_config(backend="cli", cli_provider=provider))
 
         assert isinstance(runner, CliAgentRunner)
-        assert runner._provider == provider
+        assert runner._provider == provider  # noqa: SLF001  # tracked: #288
 
-    def test_docker_path_unchanged_with_flag_off(self):
+    def test_docker_path_unchanged_with_flag_off(self):  # noqa: ANN201  # tracked: #288
         backends = {"implementer": MagicMock(), "judge": MagicMock(), "perf_eval": MagicMock()}
 
         runner = _build(
@@ -112,29 +112,29 @@ class TestFlagDefaultsOff:
         )
 
         assert isinstance(runner, CliAgentRunner)
-        assert runner._docker_sandboxes is backends
+        assert runner._docker_sandboxes is backends  # noqa: SLF001  # tracked: #288
 
 
 class TestFlagOnSelection:
-    def test_flag_on_yields_omnigent_runner(self):
+    def test_flag_on_yields_omnigent_runner(self):  # noqa: ANN201  # tracked: #288
         runner = _build(_config(omnigent=True, backend="cli", cli_provider="claude"))
 
         assert isinstance(runner, OmnigentAgentRunner)
         assert runner.backend_name == "omnigent"
-        assert runner._provider == "claude"
+        assert runner._provider == "claude"  # noqa: SLF001  # tracked: #288
 
-    def test_flag_on_passes_through_model_and_log_dir(self, tmp_path):
+    def test_flag_on_passes_through_model_and_log_dir(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         runner = _build(
             _config(omnigent=True, backend="cli", cli_provider="codex"),
             model_name="gpt-5",
             log_dir=tmp_path,
         )
 
-        assert runner._model == "gpt-5"
-        assert runner._model_name == "gpt-5"
-        assert runner._log_dir == tmp_path
+        assert runner._model == "gpt-5"  # noqa: SLF001  # tracked: #288
+        assert runner._model_name == "gpt-5"  # noqa: SLF001  # tracked: #288
+        assert runner._log_dir == tmp_path  # noqa: SLF001  # tracked: #288
 
-    def test_flag_on_does_not_affect_deepagents_backend(self):
+    def test_flag_on_does_not_affect_deepagents_backend(self):  # noqa: ANN201  # tracked: #288
         """The flag scopes to the cli backend only."""
         runner = _build(
             _config(omnigent=True, backend="deepagents"),
@@ -143,23 +143,23 @@ class TestFlagOnSelection:
 
         assert runner.backend_name == "deepagents"
 
-    def test_flag_on_does_not_affect_stub_backend(self):
+    def test_flag_on_does_not_affect_stub_backend(self):  # noqa: ANN201  # tracked: #288
         runner = _build(_config(omnigent=True, backend="stub"))
 
         assert runner.backend_name == "stub"
 
     @pytest.mark.parametrize("provider", ["gemini", "opencode"])
-    def test_unsupported_provider_names_the_remedy(self, provider):
+    def test_unsupported_provider_names_the_remedy(self, provider):  # noqa: ANN001, ANN201  # tracked: #288
         with pytest.raises(OmnigentUnavailableError) as exc:
             _build(_config(omnigent=True, backend="cli", cli_provider=provider))
 
         message = str(exc.value)
         assert provider in message
         assert "omnigent_agent_backend" in message
-        assert "claude" in message and "codex" in message
+        assert "claude" in message and "codex" in message  # noqa: PT018  # tracked: #288
         assert "agentshim" in message
 
-    def test_docker_combination_is_rejected(self):
+    def test_docker_combination_is_rejected(self):  # noqa: ANN201  # tracked: #288
         backends = {"implementer": MagicMock(), "judge": MagicMock(), "perf_eval": MagicMock()}
 
         with pytest.raises(OmnigentUnavailableError) as exc:
@@ -171,7 +171,7 @@ class TestFlagOnSelection:
 
         assert "--docker" in str(exc.value)
 
-    def test_host_resource_grants_are_refused_rather_than_dropped(self, tmp_path):
+    def test_host_resource_grants_are_refused_rather_than_dropped(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Silently dropping an operator's grant would weaken a security boundary."""
         grant = HostResource(tmp_path / "models", HostResourceAccess.READ_ONLY, "weights")
 
@@ -185,7 +185,7 @@ class TestFlagOnSelection:
         assert "models" in message
         assert "agentshim" in message
 
-    def test_empty_host_resources_are_fine(self):
+    def test_empty_host_resources_are_fine(self):  # noqa: ANN201  # tracked: #288
         runner = _build(
             _config(omnigent=True, backend="cli", cli_provider="claude"),
             host_resources=(),
@@ -195,18 +195,18 @@ class TestFlagOnSelection:
 
 
 class TestProviderRegistry:
-    def test_supported_providers_are_claude_and_codex(self):
+    def test_supported_providers_are_claude_and_codex(self):  # noqa: ANN201  # tracked: #288
         assert supported_providers() == ["claude", "codex"]
 
     @pytest.mark.parametrize("provider", ["claude", "codex"])
-    def test_specs_point_at_omnigent_inner_executors(self, provider):
+    def test_specs_point_at_omnigent_inner_executors(self, provider):  # noqa: ANN001, ANN201  # tracked: #288
         spec = OMNIGENT_PROVIDER_EXECUTORS[provider]
 
         assert spec.module.startswith("omnigent.inner.")
         assert spec.class_name.endswith("Executor")
         assert spec.harness
 
-    def test_resolve_rejects_unknown_provider(self):
+    def test_resolve_rejects_unknown_provider(self):  # noqa: ANN201  # tracked: #288
         with pytest.raises(OmnigentUnavailableError):
             resolve_executor_spec("does-not-exist")
 
@@ -214,7 +214,7 @@ class TestProviderRegistry:
 class TestMissingDependency:
     _MODULE = "omnigent.inner.claude_sdk_executor"
 
-    def test_import_error_names_the_extra(self, monkeypatch):
+    def test_import_error_names_the_extra(self, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         runner = OmnigentAgentRunner(provider="claude")
         monkeypatch.setattr(
             "vibesys.agents.omnigent.runner.import_module",
@@ -222,7 +222,7 @@ class TestMissingDependency:
         )
 
         with pytest.raises(OmnigentUnavailableError) as exc:
-            runner._executor_class()
+            runner._executor_class()  # noqa: SLF001  # tracked: #288
 
         message = str(exc.value)
         # Must name both remedies: install the extra, or turn the flag off.
@@ -231,7 +231,7 @@ class TestMissingDependency:
         assert "agentshim" in message
         assert self._MODULE in message
 
-    def test_incompatible_version_names_the_class(self, monkeypatch):
+    def test_incompatible_version_names_the_class(self, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         runner = OmnigentAgentRunner(provider="codex")
         monkeypatch.setattr(
             "vibesys.agents.omnigent.runner.import_module",
@@ -239,13 +239,13 @@ class TestMissingDependency:
         )
 
         with pytest.raises(OmnigentUnavailableError) as exc:
-            runner._executor_class()
+            runner._executor_class()  # noqa: SLF001  # tracked: #288
 
         assert "CodexExecutor" in str(exc.value)
 
 
 class TestPatchedEnviron:
-    def test_sets_and_restores_a_new_key(self):
+    def test_sets_and_restores_a_new_key(self):  # noqa: ANN201  # tracked: #288
         key = "VIBESYS_OMNIGENT_TEST_UNSET"
         os.environ.pop(key, None)
 
@@ -254,7 +254,7 @@ class TestPatchedEnviron:
 
         assert key not in os.environ
 
-    def test_restores_a_preexisting_value(self, monkeypatch):
+    def test_restores_a_preexisting_value(self, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
 
         with _patched_environ({"CUDA_VISIBLE_DEVICES": "3"}):
@@ -262,7 +262,7 @@ class TestPatchedEnviron:
 
         assert os.environ["CUDA_VISIBLE_DEVICES"] == "0"
 
-    def test_restores_on_exception(self, monkeypatch):
+    def test_restores_on_exception(self, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
 
         with pytest.raises(RuntimeError), _patched_environ({"CUDA_VISIBLE_DEVICES": "3"}):
@@ -270,7 +270,7 @@ class TestPatchedEnviron:
 
         assert os.environ["CUDA_VISIBLE_DEVICES"] == "0"
 
-    def test_none_is_a_noop(self):
+    def test_none_is_a_noop(self):  # noqa: ANN201  # tracked: #288
         before = dict(os.environ)
 
         with _patched_environ(None):
@@ -280,7 +280,7 @@ class TestPatchedEnviron:
 
 
 class TestMcpRejection:
-    def test_mcp_servers_are_refused_rather_than_dropped(self, tmp_path):
+    def test_mcp_servers_are_refused_rather_than_dropped(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         runner = OmnigentAgentRunner(provider="claude")
         server = MagicMock()
         server.name = "issue-board"
@@ -299,10 +299,10 @@ class TestMcpRejection:
 
 
 class TestUsageRecord:
-    def test_record_matches_the_agentshim_schema(self, tmp_path):
+    def test_record_matches_the_agentshim_schema(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         runner = OmnigentAgentRunner(provider="claude", model_name="m", log_dir=tmp_path)
 
-        runner._write_usage_record(
+        runner._write_usage_record(  # noqa: SLF001  # tracked: #288
             kind="judge",
             round_label="judge #1",
             usage={"input_tokens": 11, "output_tokens": 22},
@@ -321,10 +321,10 @@ class TestUsageRecord:
         assert record["total_cost_usd"] is None
         assert record["duration_ms"] is None
 
-    def test_no_log_dir_writes_nothing(self, tmp_path):
+    def test_no_log_dir_writes_nothing(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         runner = OmnigentAgentRunner(provider="claude")
 
-        runner._write_usage_record(kind="judge", round_label="r", usage={})
+        runner._write_usage_record(kind="judge", round_label="r", usage={})  # noqa: SLF001  # tracked: #288
 
         assert list(tmp_path.iterdir()) == []
 
@@ -363,14 +363,14 @@ requires_sandbox_backend = pytest.mark.skipif(
 class _FakeExecutor:
     """Stands in for an Omnigent executor, emitting a scripted event stream."""
 
-    def __init__(self, events):
+    def __init__(self, events):  # noqa: ANN001, ANN204  # tracked: #288
         self._events = events
         self.calls: list[tuple] = []
 
-    def run_turn(self, messages, tools, system_prompt, config=None):
+    def run_turn(self, messages, tools, system_prompt, config=None):  # noqa: ANN001, ANN202  # tracked: #288
         self.calls.append((messages, tools, system_prompt, config))
 
-        async def _stream():
+        async def _stream():  # noqa: ANN202  # tracked: #288
             for event in self._events:
                 yield event
 
@@ -381,11 +381,11 @@ class _FakeExecutor:
 class TestDriveTurn:
     """Exercises the real Omnigent event types against the adapter."""
 
-    def _run(self, events, log=None):
-        import asyncio
+    def _run(self, events, log=None):  # noqa: ANN001, ANN202  # tracked: #288
+        import asyncio  # noqa: PLC0415  # tracked: #288
 
-        from vibesys.agents.callbacks import AgentLogger
-        from vibesys.agents.omnigent.runner import _drive_turn
+        from vibesys.agents.callbacks import AgentLogger  # noqa: PLC0415  # tracked: #288
+        from vibesys.agents.omnigent.runner import _drive_turn  # noqa: PLC0415  # tracked: #288
 
         executor = _FakeExecutor(events)
         logger = AgentLogger(log_file=log, agent_label="Judge")
@@ -394,15 +394,15 @@ class TestDriveTurn:
         )
         return executor, text, usage
 
-    def test_turn_complete_response_wins_over_chunks(self):
-        from omnigent import TextChunk, TurnComplete
+    def test_turn_complete_response_wins_over_chunks(self):  # noqa: ANN201  # tracked: #288
+        from omnigent import TextChunk, TurnComplete  # noqa: PLC0415  # tracked: #288
 
         _, text, _ = self._run([TextChunk(text="partial"), TurnComplete(response="final answer")])
 
         assert text == "final answer"
 
-    def test_chunks_are_the_fallback_when_response_is_absent(self):
-        from omnigent import TextChunk, TurnComplete
+    def test_chunks_are_the_fallback_when_response_is_absent(self):  # noqa: ANN201  # tracked: #288
+        from omnigent import TextChunk, TurnComplete  # noqa: PLC0415  # tracked: #288
 
         _, text, _ = self._run(
             [TextChunk(text="one "), TextChunk(text="two"), TurnComplete(response=None)]
@@ -410,8 +410,8 @@ class TestDriveTurn:
 
         assert text == "one two"
 
-    def test_usage_is_returned_for_the_audit_record(self):
-        from omnigent import TurnComplete
+    def test_usage_is_returned_for_the_audit_record(self):  # noqa: ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         _, _, usage = self._run(
             [TurnComplete(response="x", usage={"input_tokens": 5, "output_tokens": 7})]
@@ -419,7 +419,7 @@ class TestDriveTurn:
 
         assert usage == {"input_tokens": 5, "output_tokens": 7}
 
-    def test_prompt_and_system_prompt_reach_run_turn(self):
+    def test_prompt_and_system_prompt_reach_run_turn(self):  # noqa: ANN201  # tracked: #288
         """Messages must be plain dicts.
 
         ``run_turn`` is annotated ``list[Message]``, but 0.6.0's executors read
@@ -427,7 +427,7 @@ class TestDriveTurn:
         ``AttributeError: 'Message' object has no attribute 'get'`` on a live
         turn, which no fake-executor test would catch.
         """
-        from omnigent import TurnComplete
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         executor, _, _ = self._run([TurnComplete(response="x")])
 
@@ -439,14 +439,14 @@ class TestDriveTurn:
         assert messages[0]["role"] == "user"
         assert messages[0]["content"] == "p"
 
-    def test_tool_schemas_are_forwarded(self):
+    def test_tool_schemas_are_forwarded(self):  # noqa: ANN201  # tracked: #288
         """An empty tool list leaves the agent with no filesystem access."""
-        import asyncio
+        import asyncio  # noqa: PLC0415  # tracked: #288
 
-        from omnigent import TurnComplete
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
-        from vibesys.agents.callbacks import AgentLogger
-        from vibesys.agents.omnigent.runner import _drive_turn
+        from vibesys.agents.callbacks import AgentLogger  # noqa: PLC0415  # tracked: #288
+        from vibesys.agents.omnigent.runner import _drive_turn  # noqa: PLC0415  # tracked: #288
 
         executor = _FakeExecutor([TurnComplete(response="x")])
         schemas = [{"name": "sys_os_read", "description": "d", "parameters": {}}]
@@ -463,8 +463,12 @@ class TestDriveTurn:
         _, tools, _, _ = executor.calls[0]
         assert tools == schemas
 
-    def test_tool_events_are_logged(self):
-        from omnigent import ToolCallComplete, ToolCallRequest, TurnComplete
+    def test_tool_events_are_logged(self):  # noqa: ANN201  # tracked: #288
+        from omnigent import (  # noqa: PLC0415  # tracked: #288
+            ToolCallComplete,
+            ToolCallRequest,
+            TurnComplete,
+        )
 
         log = StringIO()
         self._run(
@@ -479,7 +483,7 @@ class TestDriveTurn:
         written = log.getvalue()
         assert "Bash" in written
 
-    def test_empty_stream_yields_empty_text(self):
+    def test_empty_stream_yields_empty_text(self):  # noqa: ANN201  # tracked: #288
         _, text, usage = self._run([])
 
         assert text == ""
@@ -491,29 +495,29 @@ class TestExecutorResolution:
     """Only runs where omnigent is installed — proves the registry is accurate."""
 
     @pytest.mark.parametrize("provider", ["claude", "codex"])
-    def test_registered_classes_actually_exist(self, provider):
+    def test_registered_classes_actually_exist(self, provider):  # noqa: ANN001, ANN201  # tracked: #288
         runner = OmnigentAgentRunner(provider=provider)
 
-        executor_cls = runner._executor_class()
+        executor_cls = runner._executor_class()  # noqa: SLF001  # tracked: #288
 
         assert executor_cls.__name__ == OMNIGENT_PROVIDER_EXECUTORS[provider].class_name
 
     @pytest.mark.parametrize("provider", ["claude", "codex"])
-    def test_registered_classes_accept_cwd_and_model(self, provider):
+    def test_registered_classes_accept_cwd_and_model(self, provider):  # noqa: ANN001, ANN201  # tracked: #288
         """The constructor shape _build_executor depends on."""
-        import inspect
+        import inspect  # noqa: PLC0415  # tracked: #288
 
         runner = OmnigentAgentRunner(provider=provider)
-        params = inspect.signature(runner._executor_class().__init__).parameters
+        params = inspect.signature(runner._executor_class().__init__).parameters  # noqa: SLF001  # tracked: #288
 
         assert "cwd" in params
         assert "model" in params
 
     @requires_sandbox_backend
-    def test_build_executor_attaches_os_tools_and_dispatcher(self, tmp_path):
+    def test_build_executor_attaches_os_tools_and_dispatcher(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         runner = OmnigentAgentRunner(provider="claude", model="claude-sonnet-4-6")
 
-        executor, schemas = runner._build_executor(Path(tmp_path))
+        executor, schemas = runner._build_executor(Path(tmp_path))  # noqa: SLF001  # tracked: #288
 
         assert executor is not None
         # Without these the agent has no filesystem access at all.
@@ -523,7 +527,7 @@ class TestExecutorResolution:
             "sys_os_edit",
             "sys_os_shell",
         }
-        assert executor._tool_executor is not None
+        assert executor._tool_executor is not None  # noqa: SLF001  # tracked: #288
         runner.close()
 
 
@@ -531,8 +535,8 @@ class TestExecutorResolution:
 class TestMissingSandboxBackend:
     """A host without bwrap must get the flag's error, not a bare OSError."""
 
-    def test_missing_backend_binary_is_translated(self, tmp_path, monkeypatch):
-        from vibesys.agents.omnigent.runner import _build_os_tools
+    def test_missing_backend_binary_is_translated(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+        from vibesys.agents.omnigent.runner import _build_os_tools  # noqa: PLC0415  # tracked: #288
 
         monkeypatch.setattr(
             "omnigent.inner.os_env.create_os_environment",
@@ -540,7 +544,7 @@ class TestMissingSandboxBackend:
                 side_effect=OSError("linux_bwrap sandbox requires the 'bwrap' binary on PATH.")
             ),
         )
-        spec = OmnigentAgentRunner(provider="claude")._build_os_env(Path(tmp_path))
+        spec = OmnigentAgentRunner(provider="claude")._build_os_env(Path(tmp_path))  # noqa: SLF001  # tracked: #288
 
         with pytest.raises(OmnigentUnavailableError) as exc:
             _build_os_tools(spec, Path(tmp_path))
@@ -552,14 +556,14 @@ class TestMissingSandboxBackend:
         assert "agentshim" in message
         assert "disable the flag" in message
 
-    def test_declining_to_build_an_env_is_also_an_error(self, tmp_path, monkeypatch):
+    def test_declining_to_build_an_env_is_also_an_error(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         """A None env would mean a sandboxed but toolless agent."""
-        from vibesys.agents.omnigent.runner import _build_os_tools
+        from vibesys.agents.omnigent.runner import _build_os_tools  # noqa: PLC0415  # tracked: #288
 
         monkeypatch.setattr(
             "omnigent.inner.os_env.create_os_environment", MagicMock(return_value=None)
         )
-        spec = OmnigentAgentRunner(provider="claude")._build_os_env(Path(tmp_path))
+        spec = OmnigentAgentRunner(provider="claude")._build_os_env(Path(tmp_path))  # noqa: SLF001  # tracked: #288
 
         with pytest.raises(OmnigentUnavailableError) as exc:
             _build_os_tools(spec, Path(tmp_path))
@@ -572,15 +576,15 @@ class TestMissingSandboxBackend:
 class TestOsTools:
     """Covers the tool layer a live turn proved was missing."""
 
-    def test_schemas_are_flat_not_openai_function_shaped(self, tmp_path):
+    def test_schemas_are_flat_not_openai_function_shaped(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """`run_turn` reads name/description off the top level.
 
         Passing `get_schema()` verbatim registers MCP tools with empty names,
         and the agent reports having no file tools.
         """
-        from vibesys.agents.omnigent.runner import _build_os_tools
+        from vibesys.agents.omnigent.runner import _build_os_tools  # noqa: PLC0415  # tracked: #288
 
-        spec = OmnigentAgentRunner(provider="claude")._build_os_env(Path(tmp_path))
+        spec = OmnigentAgentRunner(provider="claude")._build_os_env(Path(tmp_path))  # noqa: SLF001  # tracked: #288
         schemas, _ = _build_os_tools(spec, Path(tmp_path))
 
         for schema in schemas:
@@ -588,26 +592,26 @@ class TestOsTools:
             assert "function" not in schema
             assert schema["parameters"]["type"] == "object"
 
-    def test_dispatcher_executes_a_real_read(self, tmp_path):
-        import asyncio
+    def test_dispatcher_executes_a_real_read(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        import asyncio  # noqa: PLC0415  # tracked: #288
 
-        from vibesys.agents.omnigent.runner import _build_os_tools
+        from vibesys.agents.omnigent.runner import _build_os_tools  # noqa: PLC0415  # tracked: #288
 
         (tmp_path / "NOTES.md").write_text("launch code 4417\n")
-        spec = OmnigentAgentRunner(provider="claude")._build_os_env(Path(tmp_path))
+        spec = OmnigentAgentRunner(provider="claude")._build_os_env(Path(tmp_path))  # noqa: SLF001  # tracked: #288
         _, dispatch = _build_os_tools(spec, Path(tmp_path))
 
         result = asyncio.run(dispatch("sys_os_read", {"path": "NOTES.md"}))
 
         assert "4417" in str(result)
 
-    def test_dispatcher_reports_unknown_tools(self):
-        import asyncio
+    def test_dispatcher_reports_unknown_tools(self):  # noqa: ANN201  # tracked: #288
+        import asyncio  # noqa: PLC0415  # tracked: #288
 
-        from vibesys.agents.omnigent.runner import _build_os_tools
+        from vibesys.agents.omnigent.runner import _build_os_tools  # noqa: PLC0415  # tracked: #288
 
         with tempfile.TemporaryDirectory() as tmp:
-            spec = OmnigentAgentRunner(provider="claude")._build_os_env(Path(tmp))
+            spec = OmnigentAgentRunner(provider="claude")._build_os_env(Path(tmp))  # noqa: SLF001  # tracked: #288
             _, dispatch = _build_os_tools(spec, Path(tmp))
 
             result = asyncio.run(dispatch("nope", {}))
@@ -618,29 +622,29 @@ class TestOsTools:
 @requires_omnigent
 @requires_sandbox_backend
 class TestLifecycle:
-    def test_close_is_idempotent(self, tmp_path):
+    def test_close_is_idempotent(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         runner = OmnigentAgentRunner(provider="claude")
-        runner._build_executor(Path(tmp_path))
+        runner._build_executor(Path(tmp_path))  # noqa: SLF001  # tracked: #288
 
         runner.close()
         runner.close()
 
-        assert runner._executors == {}
-        assert runner._loop is None
+        assert runner._executors == {}  # noqa: SLF001  # tracked: #288
+        assert runner._loop is None  # noqa: SLF001  # tracked: #288
 
-    def test_turns_share_one_loop(self, tmp_path):
+    def test_turns_share_one_loop(self, tmp_path):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         """A per-turn asyncio.run would strand cached executors on a dead loop."""
         runner = OmnigentAgentRunner(provider="claude")
 
         async def _noop() -> str:
             return "ok"
 
-        runner._run_async(_noop())
-        first = runner._loop
-        runner._run_async(_noop())
+        runner._run_async(_noop())  # noqa: SLF001  # tracked: #288
+        first = runner._loop  # noqa: SLF001  # tracked: #288
+        runner._run_async(_noop())  # noqa: SLF001  # tracked: #288
 
-        assert runner._loop is first
-        assert first is not None and not first.is_closed()
+        assert runner._loop is first  # noqa: SLF001  # tracked: #288
+        assert first is not None and not first.is_closed()  # noqa: PT018  # tracked: #288
         runner.close()
 
 
@@ -648,30 +652,30 @@ class TestLifecycle:
 class TestWorkspaceConfinement:
     """The opt-in path must not be a silent downgrade from vs_sandbox."""
 
-    def test_os_env_confines_writes_to_the_workspace(self, tmp_path):
+    def test_os_env_confines_writes_to_the_workspace(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         runner = OmnigentAgentRunner(provider="claude")
 
-        os_env = runner._build_os_env(Path(tmp_path))
+        os_env = runner._build_os_env(Path(tmp_path))  # noqa: SLF001  # tracked: #288
 
         assert os_env.cwd == str(tmp_path)
         assert os_env.sandbox is not None
         assert os_env.sandbox.write_paths == [str(tmp_path)]
 
-    def test_sandbox_is_never_disabled(self, tmp_path):
+    def test_sandbox_is_never_disabled(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """`type="none"` would run the agent unconfined."""
         runner = OmnigentAgentRunner(provider="codex")
 
-        os_env = runner._build_os_env(Path(tmp_path))
+        os_env = runner._build_os_env(Path(tmp_path))  # noqa: SLF001  # tracked: #288
 
         assert os_env.sandbox.type != "none"
 
-    def test_sandbox_backend_matches_the_host_platform(self, tmp_path):
+    def test_sandbox_backend_matches_the_host_platform(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """The dataclass default is linux_bwrap, which is wrong on macOS."""
-        import sys
+        import sys  # noqa: PLC0415  # tracked: #288
 
         runner = OmnigentAgentRunner(provider="claude")
 
-        os_env = runner._build_os_env(Path(tmp_path))
+        os_env = runner._build_os_env(Path(tmp_path))  # noqa: SLF001  # tracked: #288
 
         expected = {
             "linux": "linux_bwrap",
@@ -680,15 +684,15 @@ class TestWorkspaceConfinement:
         if expected is not None:
             assert os_env.sandbox.type == expected
 
-    def test_two_workspaces_do_not_share_a_grant(self, tmp_path):
+    def test_two_workspaces_do_not_share_a_grant(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Sibling runs must not be writable from one another."""
         a, b = tmp_path / "a", tmp_path / "b"
         a.mkdir()
         b.mkdir()
         runner = OmnigentAgentRunner(provider="claude")
 
-        env_a = runner._build_os_env(a)
-        env_b = runner._build_os_env(b)
+        env_a = runner._build_os_env(a)  # noqa: SLF001  # tracked: #288
+        env_b = runner._build_os_env(b)  # noqa: SLF001  # tracked: #288
 
         assert env_a.sandbox.write_paths == [str(a)]
         assert env_b.sandbox.write_paths == [str(b)]
@@ -706,16 +710,16 @@ class TestTurnPathWithFakeExecutor:
     """
 
     @staticmethod
-    def _runner(tmp_path, events, **kwargs):
+    def _runner(tmp_path, events, **kwargs):  # noqa: ANN001, ANN003, ANN205, ARG004  # tracked: #288
         runner = OmnigentAgentRunner(provider="claude", model_name="m", **kwargs)
         executor = _FakeExecutor(events)
         schemas = [{"name": "sys_os_read", "description": "d", "parameters": {}}]
         # Bypass _build_executor so no OS environment (and so no bwrap) is needed.
-        runner._build_executor = lambda _ws: (executor, schemas)  # type: ignore[method-assign]
+        runner._build_executor = lambda _ws: (executor, schemas)  # type: ignore[method-assign]  # noqa: SLF001  # tracked: #288
         return runner, executor
 
-    def test_invoke_parses_a_structured_response(self, tmp_path):
-        from omnigent import TurnComplete
+    def test_invoke_parses_a_structured_response(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         payload = '{"analysis":"a","feedback":"f","verdict":"pass"}'
         runner, _ = self._runner(tmp_path, [TurnComplete(response=payload)])
@@ -734,8 +738,8 @@ class TestTurnPathWithFakeExecutor:
         assert result.verdict == Verdict.PASS
         runner.close()
 
-    def test_invoke_falls_back_on_unparseable_output(self, tmp_path):
-        from omnigent import TurnComplete
+    def test_invoke_falls_back_on_unparseable_output(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         runner, _ = self._runner(tmp_path, [TurnComplete(response="not json at all")])
 
@@ -753,8 +757,8 @@ class TestTurnPathWithFakeExecutor:
         assert result.analysis == "fb"
         runner.close()
 
-    def test_invoke_sends_the_schema_hint(self, tmp_path):
-        from omnigent import TurnComplete
+    def test_invoke_sends_the_schema_hint(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         runner, executor = self._runner(tmp_path, [TurnComplete(response="{}")])
 
@@ -773,8 +777,8 @@ class TestTurnPathWithFakeExecutor:
         assert "JudgeResponse" in messages[0]["content"]
         runner.close()
 
-    def test_invoke_text_returns_the_raw_response(self, tmp_path):
-        from omnigent import TurnComplete
+    def test_invoke_text_returns_the_raw_response(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         runner, _ = self._runner(tmp_path, [TurnComplete(response="hello there")])
 
@@ -789,8 +793,8 @@ class TestTurnPathWithFakeExecutor:
         assert text == "hello there"
         runner.close()
 
-    def test_invoke_text_handles_an_empty_turn(self, tmp_path):
-        from omnigent import TurnComplete
+    def test_invoke_text_handles_an_empty_turn(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         runner, _ = self._runner(tmp_path, [TurnComplete(response=None)])
 
@@ -805,19 +809,19 @@ class TestTurnPathWithFakeExecutor:
         assert text == ""
         runner.close()
 
-    def test_env_overrides_apply_during_the_turn_and_are_restored(self, tmp_path):
-        from omnigent import TurnComplete
+    def test_env_overrides_apply_during_the_turn_and_are_restored(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         seen: list[str | None] = []
 
         class _EnvProbe(_FakeExecutor):
-            def run_turn(self, messages, tools, system_prompt, config=None):
+            def run_turn(self, messages, tools, system_prompt, config=None):  # noqa: ANN001, ANN202  # tracked: #288
                 seen.append(os.environ.get("CUDA_VISIBLE_DEVICES"))
                 return super().run_turn(messages, tools, system_prompt, config)
 
         runner = OmnigentAgentRunner(provider="claude", model_name="m")
         executor = _EnvProbe([TurnComplete(response="ok")])
-        runner._build_executor = lambda _ws: (executor, [])  # type: ignore[method-assign]
+        runner._build_executor = lambda _ws: (executor, [])  # type: ignore[method-assign]  # noqa: SLF001  # tracked: #288
         os.environ.pop("CUDA_VISIBLE_DEVICES", None)
 
         runner.invoke_text(
@@ -833,8 +837,8 @@ class TestTurnPathWithFakeExecutor:
         assert "CUDA_VISIBLE_DEVICES" not in os.environ
         runner.close()
 
-    def test_usage_record_is_written_per_turn(self, tmp_path):
-        from omnigent import TurnComplete
+    def test_usage_record_is_written_per_turn(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
@@ -858,17 +862,17 @@ class TestTurnPathWithFakeExecutor:
         assert record["provider"] == "claude"
         runner.close()
 
-    def test_a_failed_turn_still_writes_its_usage_record(self, tmp_path):
+    def test_a_failed_turn_still_writes_its_usage_record(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Tokens were spent either way; an audit gap on failure defeats the point."""
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
 
         class _Boom(_FakeExecutor):
-            def run_turn(self, messages, tools, system_prompt, config=None):
-                raise RuntimeError("harness exploded")
+            def run_turn(self, messages, tools, system_prompt, config=None):  # noqa: ANN001, ANN202, ARG002  # tracked: #288
+                raise RuntimeError("harness exploded")  # noqa: TRY003  # tracked: #288
 
         runner = OmnigentAgentRunner(provider="claude", model_name="m", log_dir=log_dir)
-        runner._build_executor = lambda _ws: (_Boom([]), [])  # type: ignore[method-assign]
+        runner._build_executor = lambda _ws: (_Boom([]), [])  # type: ignore[method-assign]  # noqa: SLF001  # tracked: #288
 
         with pytest.raises(RuntimeError, match="harness exploded"):
             runner.invoke_text(
@@ -882,8 +886,8 @@ class TestTurnPathWithFakeExecutor:
         assert (log_dir / "usage.jsonl").read_text().strip()
         runner.close()
 
-    def test_the_run_log_records_the_backend_and_provider(self, tmp_path):
-        from omnigent import TurnComplete
+    def test_the_run_log_records_the_backend_and_provider(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         log = StringIO()
         runner, _ = self._runner(tmp_path, [TurnComplete(response="ok")], run_log_file=log)
@@ -902,17 +906,17 @@ class TestTurnPathWithFakeExecutor:
         assert "harness: claude-sdk" in written
         runner.close()
 
-    def test_executors_are_reused_per_kind_but_not_for_chat(self, tmp_path):
-        from omnigent import TurnComplete
+    def test_executors_are_reused_per_kind_but_not_for_chat(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         built: list[str] = []
 
-        def _build(_ws):
+        def _build(_ws):  # noqa: ANN001, ANN202  # tracked: #288
             built.append("x")
             return _FakeExecutor([TurnComplete(response="ok")]), []
 
         runner = OmnigentAgentRunner(provider="claude", model_name="m")
-        runner._build_executor = _build  # type: ignore[method-assign]
+        runner._build_executor = _build  # type: ignore[method-assign]  # noqa: SLF001  # tracked: #288
 
         for _ in range(2):
             runner.invoke_text(
@@ -931,23 +935,23 @@ class TestTurnPathWithFakeExecutor:
         assert len(built) == 3, "chat must start a fresh session each turn"
         runner.close()
 
-    def test_explicit_session_keys_reuse_and_fresh_sessions_close(self, tmp_path):
-        from omnigent import TurnComplete
+    def test_explicit_session_keys_reuse_and_fresh_sessions_close(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         built: list[_FakeExecutor] = []
         closed: list[_FakeExecutor] = []
 
         class _Closable(_FakeExecutor):
-            async def close(self):
+            async def close(self):  # noqa: ANN202  # tracked: #288
                 closed.append(self)
 
-        def _build(_ws):
+        def _build(_ws):  # noqa: ANN001, ANN202  # tracked: #288
             executor = _Closable([TurnComplete(response="ok")])
             built.append(executor)
             return executor, []
 
         runner = OmnigentAgentRunner(provider="claude", model_name="m")
-        runner._build_executor = _build  # type: ignore[method-assign]
+        runner._build_executor = _build  # type: ignore[method-assign]  # noqa: SLF001  # tracked: #288
 
         for _ in range(2):
             runner.invoke_text(
@@ -976,17 +980,17 @@ class TestTurnPathWithFakeExecutor:
         runner.close()
         assert closed == [built[1], built[0]]
 
-    def test_close_awaits_executor_close(self, tmp_path):
-        from omnigent import TurnComplete
+    def test_close_awaits_executor_close(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         closed: list[bool] = []
 
         class _Closable(_FakeExecutor):
-            async def close(self):
+            async def close(self):  # noqa: ANN202  # tracked: #288
                 closed.append(True)
 
         runner = OmnigentAgentRunner(provider="claude", model_name="m")
-        runner._build_executor = lambda _ws: (_Closable([TurnComplete(response="ok")]), [])  # type: ignore[method-assign]
+        runner._build_executor = lambda _ws: (_Closable([TurnComplete(response="ok")]), [])  # type: ignore[method-assign]  # noqa: SLF001  # tracked: #288
         runner.invoke_text(
             kind="implementer",
             workspace=tmp_path,
@@ -999,16 +1003,16 @@ class TestTurnPathWithFakeExecutor:
 
         assert closed == [True]
 
-    def test_close_survives_a_failing_executor_close(self, tmp_path):
-        from omnigent import TurnComplete
+    def test_close_survives_a_failing_executor_close(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        from omnigent import TurnComplete  # noqa: PLC0415  # tracked: #288
 
         class _BadClose(_FakeExecutor):
-            async def close(self):
-                raise RuntimeError("close blew up")
+            async def close(self):  # noqa: ANN202  # tracked: #288
+                raise RuntimeError("close blew up")  # noqa: TRY003  # tracked: #288
 
         log = StringIO()
         runner = OmnigentAgentRunner(provider="claude", model_name="m", run_log_file=log)
-        runner._build_executor = lambda _ws: (_BadClose([TurnComplete(response="ok")]), [])  # type: ignore[method-assign]
+        runner._build_executor = lambda _ws: (_BadClose([TurnComplete(response="ok")]), [])  # type: ignore[method-assign]  # noqa: SLF001  # tracked: #288
         runner.invoke_text(
             kind="implementer",
             workspace=tmp_path,
@@ -1020,19 +1024,19 @@ class TestTurnPathWithFakeExecutor:
         runner.close()  # must not raise
 
         assert "executor close failed" in log.getvalue()
-        assert runner._loop is None
+        assert runner._loop is None  # noqa: SLF001  # tracked: #288
 
 
 @requires_omnigent
 class TestLazyPackageExports:
-    def test_runner_symbols_resolve_through_package_getattr(self):
-        import vibesys.agents.omnigent as pkg
+    def test_runner_symbols_resolve_through_package_getattr(self):  # noqa: ANN201  # tracked: #288
+        import vibesys.agents.omnigent as pkg  # noqa: PLC0415  # tracked: #288
 
         assert pkg.OmnigentAgentRunner is OmnigentAgentRunner
         assert pkg.OmnigentUnavailableError is OmnigentUnavailableError
 
-    def test_unknown_attribute_still_raises(self):
-        import vibesys.agents.omnigent as pkg
+    def test_unknown_attribute_still_raises(self):  # noqa: ANN201  # tracked: #288
+        import vibesys.agents.omnigent as pkg  # noqa: PLC0415  # tracked: #288
 
         with pytest.raises(AttributeError, match="no attribute"):
             _ = pkg.NoSuchThing
@@ -1052,19 +1056,21 @@ class TestToolExecutorSeam:
     # Provider -> the CLI binary its executor needs at construction time.
     # CodexExecutor raises ImportError without it; ClaudeSDKExecutor falls back
     # to the SDK's bundled CLI, so it constructs anywhere.
-    _PROVIDER_BINARY = {"claude": None, "codex": "codex"}
+    _PROVIDER_BINARY = {"claude": None, "codex": "codex"}  # noqa: RUF012  # tracked: #288
 
     @pytest.mark.parametrize("provider", ["claude", "codex"])
-    def test_the_seam_exists_on_the_pinned_version(self, provider):
+    def test_the_seam_exists_on_the_pinned_version(self, provider):  # noqa: ANN001, ANN201  # tracked: #288
         """Fails loudly if a version bump moves the attribute."""
-        from vibesys.agents.omnigent.runner import _TOOL_EXECUTOR_ATTR
+        from vibesys.agents.omnigent.runner import (  # noqa: PLC0415  # tracked: #288
+            _TOOL_EXECUTOR_ATTR,
+        )
 
         binary = self._PROVIDER_BINARY[provider]
         if binary is not None and shutil.which(binary) is None:
             pytest.skip(f"{provider} executor needs the {binary!r} CLI to construct")
 
         runner = OmnigentAgentRunner(provider=provider)
-        executor_cls = runner._executor_class()
+        executor_cls = runner._executor_class()  # noqa: SLF001  # tracked: #288
 
         # Constructed without os_env so no sandbox backend is needed here.
         executor = executor_cls(cwd=".", model=None)
@@ -1074,18 +1080,18 @@ class TestToolExecutorSeam:
             "the Omnigent backend can no longer give agents their tools"
         )
 
-    def test_a_missing_provider_cli_is_attributed_to_the_flag(self, tmp_path, monkeypatch):
+    def test_a_missing_provider_cli_is_attributed_to_the_flag(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         """Omnigent reports a missing CLI as ImportError from the constructor."""
 
         class _NeedsCli:
-            def __init__(self, **_kwargs):
-                raise ImportError("CodexExecutor requires the 'codex' CLI on PATH.")
+            def __init__(self, **_kwargs):  # noqa: ANN003, ANN204  # tracked: #288
+                raise ImportError("CodexExecutor requires the 'codex' CLI on PATH.")  # noqa: TRY003  # tracked: #288
 
         runner = OmnigentAgentRunner(provider="codex")
         monkeypatch.setattr(runner, "_executor_class", lambda: _NeedsCli)
 
         with pytest.raises(OmnigentUnavailableError) as exc:
-            runner._build_executor(Path(tmp_path))
+            runner._build_executor(Path(tmp_path))  # noqa: SLF001  # tracked: #288
 
         message = str(exc.value)
         assert "omnigent_agent_backend" in message
@@ -1094,13 +1100,13 @@ class TestToolExecutorSeam:
         assert "CLI on PATH" in message
         assert "agentshim" in message
 
-    def test_a_moved_seam_fails_at_construction(self, tmp_path, monkeypatch):
-        from vibesys.agents.omnigent import runner as runner_mod
+    def test_a_moved_seam_fails_at_construction(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+        from vibesys.agents.omnigent import runner as runner_mod  # noqa: PLC0415  # tracked: #288
 
         class _Renamed:
             """An executor whose dispatch slot has been renamed upstream."""
 
-            def __init__(self, **_kwargs):
+            def __init__(self, **_kwargs):  # noqa: ANN003, ANN204  # tracked: #288
                 self._dispatch_callback = None  # not _tool_executor
 
         runner = OmnigentAgentRunner(provider="claude")
@@ -1110,7 +1116,7 @@ class TestToolExecutorSeam:
         )
 
         with pytest.raises(OmnigentUnavailableError) as exc:
-            runner._build_executor(Path(tmp_path))
+            runner._build_executor(Path(tmp_path))  # noqa: SLF001  # tracked: #288
 
         message = str(exc.value)
         assert "_tool_executor" in message

--- a/tests/agents/test_stub_runner.py
+++ b/tests/agents/test_stub_runner.py
@@ -8,7 +8,7 @@ from vibesys.schemas import (
 )
 
 
-def test_stub_runner_returns_valid_agent_loop_responses(tmp_path):
+def test_stub_runner_returns_valid_agent_loop_responses(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     runner = StubAgentRunner()
 
     responses = [
@@ -24,7 +24,7 @@ def test_stub_runner_returns_valid_agent_loop_responses(tmp_path):
     assert responses[3].verdict is Verdict.PASS
 
 
-def test_stub_runner_returns_plain_chat_text(tmp_path):
+def test_stub_runner_returns_plain_chat_text(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     runner = StubAgentRunner()
 
     answer = runner.invoke_text(
@@ -39,7 +39,7 @@ def test_stub_runner_returns_plain_chat_text(tmp_path):
     assert answer == "Stub chat inspected the available experiment trajectory."
 
 
-def invoke(runner, workspace, kind, response_cls):
+def invoke(runner, workspace, kind, response_cls):  # noqa: ANN001, ANN201  # tracked: #288
     return runner.invoke(
         kind=kind,
         workspace=workspace,

--- a/tests/agents/test_todos.py
+++ b/tests/agents/test_todos.py
@@ -12,7 +12,7 @@ from vibesys.server.events import RunEvent, TodoItemData, TodoUpdateData
 
 
 class TestProviderShapes:
-    def test_claude_code_todo_write(self):
+    def test_claude_code_todo_write(self):  # noqa: ANN201  # tracked: #288
         items = todos_from_tool_call(
             "TodoWrite",
             {
@@ -27,18 +27,18 @@ class TestProviderShapes:
             TodoItemData(content="Vectorize", status="in_progress"),
         ]
 
-    def test_opencode_and_gemini_share_the_todos_shape(self):
+    def test_opencode_and_gemini_share_the_todos_shape(self):  # noqa: ANN201  # tracked: #288
         for tool in ("todowrite", "write_todos"):
             items = todos_from_tool_call(tool, {"todos": [{"content": "A", "status": "pending"}]})
             assert items == [TodoItemData(content="A", status="pending")]
 
-    def test_gemini_description_key(self):
+    def test_gemini_description_key(self):  # noqa: ANN201  # tracked: #288
         items = todos_from_tool_call(
             "write_todos", {"todos": [{"description": "Read the ABI contract"}]}
         )
         assert items == [TodoItemData(content="Read the ABI contract", status="pending")]
 
-    def test_codex_update_plan(self):
+    def test_codex_update_plan(self):  # noqa: ANN201  # tracked: #288
         items = todos_from_tool_call(
             "update_plan",
             {
@@ -54,7 +54,7 @@ class TestProviderShapes:
             TodoItemData(content="Tune the queue size", status="pending"),
         ]
 
-    def test_codex_todo_list_item_with_completed_booleans(self):
+    def test_codex_todo_list_item_with_completed_booleans(self):  # noqa: ANN201  # tracked: #288
         items = todos_from_tool_call(
             "todo_list",
             {"items": [{"text": "Build", "completed": True}, {"text": "Test", "completed": False}]},
@@ -66,16 +66,16 @@ class TestProviderShapes:
 
 
 class TestDegradation:
-    def test_unrelated_tools_are_not_todo_updates(self):
+    def test_unrelated_tools_are_not_todo_updates(self):  # noqa: ANN201  # tracked: #288
         assert todos_from_tool_call("Bash", {"command": "ls"}) is None
         assert todos_from_tool_call("Write", {"content": "todos: []"}) is None
 
-    def test_payload_without_the_expected_list_is_no_update(self):
+    def test_payload_without_the_expected_list_is_no_update(self):  # noqa: ANN201  # tracked: #288
         assert todos_from_tool_call("TodoWrite", {}) is None
         assert todos_from_tool_call("TodoWrite", {"todos": "not-a-list"}) is None
         assert todos_from_tool_call("update_plan", {"plan": {"step": "x"}}) is None
 
-    def test_malformed_entries_are_skipped_not_fatal(self):
+    def test_malformed_entries_are_skipped_not_fatal(self):  # noqa: ANN201  # tracked: #288
         items = todos_from_tool_call(
             "TodoWrite",
             {
@@ -89,19 +89,19 @@ class TestDegradation:
         )
         assert items == [TodoItemData(content="Real item", status="pending")]
 
-    def test_unknown_status_strings_pass_through(self):
+    def test_unknown_status_strings_pass_through(self):  # noqa: ANN201  # tracked: #288
         items = todos_from_tool_call(
             "TodoWrite", {"todos": [{"content": "Odd", "status": "deferred"}]}
         )
         assert items == [TodoItemData(content="Odd", status="deferred")]
 
-    def test_missing_status_defaults_to_pending(self):
+    def test_missing_status_defaults_to_pending(self):  # noqa: ANN201  # tracked: #288
         items = todos_from_tool_call("TodoWrite", {"todos": [{"content": "Bare"}]})
         assert items == [TodoItemData(content="Bare", status="pending")]
 
 
 class TestAgentLoggerPublishing:
-    def test_cli_todo_tool_call_publishes_a_todo_update(self):
+    def test_cli_todo_tool_call_publishes_a_todo_update(self):  # noqa: ANN201  # tracked: #288
         seen: list[RunEvent] = []
         unsubscribe = output_sink().subscribe(seen.append)
         try:
@@ -113,7 +113,7 @@ class TestAgentLoggerPublishing:
         assert len(updates) == 1
         assert updates[0].todos == [TodoItemData(content="A", status="pending")]
 
-    def test_non_todo_tool_call_publishes_no_todo_update(self):
+    def test_non_todo_tool_call_publishes_no_todo_update(self):  # noqa: ANN201  # tracked: #288
         seen: list[RunEvent] = []
         unsubscribe = output_sink().subscribe(seen.append)
         try:
@@ -123,7 +123,7 @@ class TestAgentLoggerPublishing:
             unsubscribe()
         assert not any(isinstance(e.data, TodoUpdateData) for e in seen)
 
-    def test_empty_snapshot_is_extracted_but_not_published(self):
+    def test_empty_snapshot_is_extracted_but_not_published(self):  # noqa: ANN201  # tracked: #288
         # The sink drops empty lists, so a cleared plan is a no-op on the
         # wire rather than an event with no payload.
         seen: list[RunEvent] = []

--- a/tests/backends/test_cpu_backend.py
+++ b/tests/backends/test_cpu_backend.py
@@ -16,12 +16,12 @@ from vibesys.profilers import ProfilerKind
 from vs_sandbox import DockerSandbox
 
 
-def _make_backend(tmp_path) -> LocalBackend:
+def _make_backend(tmp_path) -> LocalBackend:  # noqa: ANN001  # tracked: #288
     return backends.get(ComputeBackend.CPU, log_dir=tmp_path / "logs")
 
 
 class TestCpuRegistry:
-    def test_cpu_in_registry(self, tmp_path):
+    def test_cpu_in_registry(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = backends.get(ComputeBackend.CPU, log_dir=tmp_path)
         assert isinstance(impl, LocalBackend)
         assert impl.name is ComputeBackend.CPU
@@ -29,7 +29,7 @@ class TestCpuRegistry:
 
 
 class TestCpuSandbox:
-    def test_local_returns_local_shell_backend(self, tmp_path):
+    def test_local_returns_local_shell_backend(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         workspace = tmp_path / "ws"
         workspace.mkdir()
@@ -41,7 +41,7 @@ class TestCpuSandbox:
         )
         assert isinstance(sb, LocalShellBackend)
 
-    def test_docker_returns_docker_sandbox_without_gpus(self, tmp_path):
+    def test_docker_returns_docker_sandbox_without_gpus(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         sb = impl.make_sandbox(
             SandboxKind.DOCKER,
@@ -50,11 +50,11 @@ class TestCpuSandbox:
             extra_env={"FOO": "bar"},
         )
         assert isinstance(sb, DockerSandbox)
-        assert sb._gpus is None
-        assert sb._image == impl.image
-        assert sb._env["FOO"] == "bar"
+        assert sb._gpus is None  # noqa: SLF001  # tracked: #288
+        assert sb._image == impl.image  # noqa: SLF001  # tracked: #288
+        assert sb._env["FOO"] == "bar"  # noqa: SLF001  # tracked: #288
 
-    def test_modal_raises(self, tmp_path):
+    def test_modal_raises(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         with pytest.raises(ValueError, match="Modal CPU execution is not wired up"):
             impl.make_sandbox(
@@ -65,10 +65,10 @@ class TestCpuSandbox:
 
 
 class TestCpuDevice:
-    def test_no_monitor(self, tmp_path):
+    def test_no_monitor(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         assert _make_backend(tmp_path).make_monitor(tmp_path) is None
 
-    def test_reselect_is_noop(self, tmp_path):
+    def test_reselect_is_noop(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         # No-op: doesn't raise, doesn't change selected_device.
         impl.reselect_device()
@@ -76,7 +76,7 @@ class TestCpuDevice:
 
 
 class TestCpuCli:
-    def test_argparse_accepts_cpu(self):
+    def test_argparse_accepts_cpu(self):  # noqa: ANN201  # tracked: #288
         parser = argparse.ArgumentParser()
         _add_common_args(parser)
         ns = parser.parse_args(["--backend", "cpu"])

--- a/tests/backends/test_cuda_backend.py
+++ b/tests/backends/test_cuda_backend.py
@@ -23,5 +23,5 @@ def test_cpu_only_control_plane_docker_skips_gpu_runtime(
     )
 
     pick_device.assert_not_called()
-    assert sandbox._gpus is None  # pyright: ignore[reportAttributeAccessIssue]
+    assert sandbox._gpus is None  # pyright: ignore[reportAttributeAccessIssue]  # noqa: SLF001  # tracked: #288
     assert backend.selected_device is None

--- a/tests/backends/test_gpu_monitor.py
+++ b/tests/backends/test_gpu_monitor.py
@@ -41,7 +41,7 @@ def _gpu(index: int, uuid: str, used: int = 0, total: int = 81559, util: int = 0
 
 class TestQueryGpuInfo:
     @patch("vibesys.backends.cuda.gpu_monitor.subprocess.run")
-    def test_parses_csv(self, mock_run):
+    def test_parses_csv(self, mock_run):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = type(
             "R",
             (),
@@ -58,18 +58,18 @@ class TestQueryGpuInfo:
         assert gpus[1].memory_free_mib == 81559 - 100
 
     @patch("vibesys.backends.cuda.gpu_monitor.subprocess.run")
-    def test_returns_empty_on_failure(self, mock_run):
+    def test_returns_empty_on_failure(self, mock_run):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = type("R", (), {"returncode": 1, "stdout": ""})()
         assert query_gpu_info() == []
 
     @patch("vibesys.backends.cuda.gpu_monitor.subprocess.run")
-    def test_returns_empty_on_missing_nvidia_smi(self, mock_run):
+    def test_returns_empty_on_missing_nvidia_smi(self, mock_run):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.side_effect = FileNotFoundError
         assert query_gpu_info() == []
 
 
 class TestPickGpu:
-    def test_picks_most_free_memory(self):
+    def test_picks_most_free_memory(self):  # noqa: ANN201  # tracked: #288
         gpus = [
             _gpu(0, GPU_A, used=70000),
             _gpu(1, GPU_B, used=100),
@@ -78,10 +78,10 @@ class TestPickGpu:
         assert best is not None
         assert best.index == 1
 
-    def test_empty_list(self):
+    def test_empty_list(self):  # noqa: ANN201  # tracked: #288
         assert pick_gpu([]) is None
 
-    def test_single_gpu(self):
+    def test_single_gpu(self):  # noqa: ANN201  # tracked: #288
         g = _gpu(0, GPU_A, used=5000)
         assert pick_gpu([g]) is g
 
@@ -92,20 +92,20 @@ class TestPickGpu:
 
 
 class TestParseProcOutput:
-    def test_parses_four_columns(self):
+    def test_parses_four_columns(self):  # noqa: ANN201  # tracked: #288
         raw = f"1000, python, 4096, {GPU_A}\n"
         procs = _parse_proc_output(raw)
         assert len(procs) == 1
         assert procs[0]["gpu_uuid"] == GPU_A
         assert procs[0]["pid"] == 1000
 
-    def test_empty(self):
+    def test_empty(self):  # noqa: ANN201  # tracked: #288
         assert _parse_proc_output("") == []
 
-    def test_skips_header(self):
+    def test_skips_header(self):  # noqa: ANN201  # tracked: #288
         assert _parse_proc_output("pid, process_name, used_memory, gpu_uuid\n") == []
 
-    def test_skips_short_rows(self):
+    def test_skips_short_rows(self):  # noqa: ANN201  # tracked: #288
         assert _parse_proc_output("100, python, 4096\n") == []
 
 
@@ -117,32 +117,32 @@ class TestParseProcOutput:
 class TestMonitorLifecycle:
     @patch("vibesys.backends.cuda.gpu_monitor.query_gpu_info", return_value=[])
     @patch("vibesys.backends.cuda.gpu_monitor._query_gpu_procs")
-    def test_start_stop(self, mock_procs, _mock_gpus):
+    def test_start_stop(self, mock_procs, _mock_gpus):  # noqa: ANN001, ANN201, PT019  # tracked: #288
         mock_procs.return_value = ""
         mon = GpuContentionMonitor(
-            log_dir=Path("/tmp"),
+            log_dir=Path("/tmp"),  # noqa: S108  # tracked: #288
             gpu_uuid=GPU_A,
             interval=0.05,
         )
         mon.start()
-        assert mon._thread is not None
-        assert mon._thread.is_alive()
+        assert mon._thread is not None  # noqa: SLF001  # tracked: #288
+        assert mon._thread.is_alive()  # noqa: SLF001  # tracked: #288
         time.sleep(0.15)
         mon.stop()
-        assert not mon._thread.is_alive()
+        assert not mon._thread.is_alive()  # noqa: SLF001  # tracked: #288
 
     @patch("vibesys.backends.cuda.gpu_monitor.query_gpu_info", return_value=[])
     @patch("vibesys.backends.cuda.gpu_monitor._query_gpu_procs")
-    def test_baseline_captured_on_start(self, mock_procs, _mock_gpus):
+    def test_baseline_captured_on_start(self, mock_procs, _mock_gpus):  # noqa: ANN001, ANN201, PT019  # tracked: #288
         """PIDs present at start() time become the baseline."""
         mock_procs.return_value = f"100, python, 4096, {GPU_A}\n"
         mon = GpuContentionMonitor(
-            log_dir=Path("/tmp"),
+            log_dir=Path("/tmp"),  # noqa: S108  # tracked: #288
             gpu_uuid=GPU_A,
             interval=0.05,
         )
         mon.start()
-        assert 100 in mon._baseline_pids
+        assert 100 in mon._baseline_pids  # noqa: SLF001  # tracked: #288
         time.sleep(0.1)
         # Same PID still there → no contention
         assert not mon.status.is_contended
@@ -150,12 +150,12 @@ class TestMonitorLifecycle:
 
     @patch("vibesys.backends.cuda.gpu_monitor.query_gpu_info", return_value=[])
     @patch("vibesys.backends.cuda.gpu_monitor._query_gpu_procs")
-    def test_new_pid_triggers_contention(self, mock_procs, _mock_gpus):
+    def test_new_pid_triggers_contention(self, mock_procs, _mock_gpus):  # noqa: ANN001, ANN201, PT019  # tracked: #288
         """A PID that wasn't in the baseline triggers contention."""
         # Baseline: only PID 100
         mock_procs.return_value = f"100, python, 4096, {GPU_A}\n"
         mon = GpuContentionMonitor(
-            log_dir=Path("/tmp"),
+            log_dir=Path("/tmp"),  # noqa: S108  # tracked: #288
             gpu_uuid=GPU_A,
             interval=0.05,
         )
@@ -172,11 +172,11 @@ class TestMonitorLifecycle:
 
     @patch("vibesys.backends.cuda.gpu_monitor.query_gpu_info", return_value=[])
     @patch("vibesys.backends.cuda.gpu_monitor._query_gpu_procs")
-    def test_new_pid_on_different_gpu_ignored(self, mock_procs, _mock_gpus):
+    def test_new_pid_on_different_gpu_ignored(self, mock_procs, _mock_gpus):  # noqa: ANN001, ANN201, PT019  # tracked: #288
         """A new PID on a different GPU is not contention."""
         mock_procs.return_value = f"100, python, 4096, {GPU_A}\n"
         mon = GpuContentionMonitor(
-            log_dir=Path("/tmp"),
+            log_dir=Path("/tmp"),  # noqa: S108  # tracked: #288
             gpu_uuid=GPU_A,
             interval=0.05,
         )
@@ -192,7 +192,7 @@ class TestMonitorLifecycle:
 
     @patch("vibesys.backends.cuda.gpu_monitor.query_gpu_info", return_value=[])
     @patch("vibesys.backends.cuda.gpu_monitor._query_gpu_procs")
-    def test_contention_logged_to_file(self, mock_procs, _mock_gpus, tmp_path):
+    def test_contention_logged_to_file(self, mock_procs, _mock_gpus, tmp_path):  # noqa: ANN001, ANN201, PT019  # tracked: #288
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
 
@@ -220,7 +220,7 @@ class TestMonitorLifecycle:
 
     @patch("vibesys.backends.cuda.gpu_monitor.query_gpu_info", return_value=[])
     @patch("vibesys.backends.cuda.gpu_monitor._query_gpu_procs")
-    def test_no_log_when_no_contention(self, mock_procs, _mock_gpus, tmp_path):
+    def test_no_log_when_no_contention(self, mock_procs, _mock_gpus, tmp_path):  # noqa: ANN001, ANN201, PT019  # tracked: #288
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
 
@@ -239,7 +239,7 @@ class TestMonitorLifecycle:
             assert log_file.read_text().strip() == ""
 
     @patch("vibesys.backends.cuda.gpu_monitor._query_gpu_procs")
-    def test_smi_failure_does_not_crash(self, mock_procs, tmp_path):
+    def test_smi_failure_does_not_crash(self, mock_procs, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         mock_procs.side_effect = Exception("nvidia-smi not found")
         log_dir = tmp_path / "logs"
         log_dir.mkdir()
@@ -251,10 +251,10 @@ class TestMonitorLifecycle:
         mon.start()
         time.sleep(0.15)
         mon.stop()
-        assert not mon._thread.is_alive()
+        assert not mon._thread.is_alive()  # noqa: SLF001  # tracked: #288
 
-    def test_stop_without_start(self):
-        mon = GpuContentionMonitor(log_dir=Path("/tmp"), gpu_uuid=GPU_A)
+    def test_stop_without_start(self):  # noqa: ANN201  # tracked: #288
+        mon = GpuContentionMonitor(log_dir=Path("/tmp"), gpu_uuid=GPU_A)  # noqa: S108  # tracked: #288
         mon.stop()  # should not raise
 
 
@@ -266,23 +266,23 @@ class TestMonitorLifecycle:
 class TestReselectGpu:
     """Tests for _RunContext.reselect_gpu()."""
 
-    def _make_ctx(self, tmp_path, selected_gpu=None, use_docker=False):
+    def _make_ctx(self, tmp_path, selected_gpu=None, use_docker=False):  # noqa: ANN001, ANN202, FBT002  # tracked: #288
         """Build a minimal _RunContext-like object for reselect_gpu testing."""
-        from vibesys.backends.cuda import CudaBackend
-        from vibesys.context import _RunContext
-        from vibesys.run import RunPaths
-        from vs_sandbox import DockerSandbox
+        from vibesys.backends.cuda import CudaBackend  # noqa: PLC0415  # tracked: #288
+        from vibesys.context import _RunContext  # noqa: PLC0415  # tracked: #288
+        from vibesys.run import RunPaths  # noqa: PLC0415  # tracked: #288
+        from vs_sandbox import DockerSandbox  # noqa: PLC0415  # tracked: #288
 
         ctx = object.__new__(_RunContext)
         ctx.selected_gpu = selected_gpu
-        ctx._paths = RunPaths(
+        ctx._paths = RunPaths(  # noqa: SLF001  # tracked: #288
             exp_dir=tmp_path,
             log_dir=tmp_path / "logs",
             workspace=tmp_path / "workspace",
             run_log_path=tmp_path / "run.log",
         )
         ctx.log_dir.mkdir(parents=True, exist_ok=True)
-        ctx._docker_symlinks = []
+        ctx._docker_symlinks = []  # noqa: SLF001  # tracked: #288
 
         # Real CudaBackend so reselect_gpu's delegation hits the actual logic;
         # tests patch pick_gpu / query_gpu_info to control device selection.
@@ -291,7 +291,7 @@ class TestReselectGpu:
         ctx.backend_impl = backend_impl
 
         # gpu_env / reselect_gpu / gpu_monitor delegate to the device lease.
-        from vibesys.run import DeviceLease
+        from vibesys.run import DeviceLease  # noqa: PLC0415  # tracked: #288
 
         ctx.device = DeviceLease(backend_impl, log_dir=ctx.log_dir)
 
@@ -299,22 +299,22 @@ class TestReselectGpu:
         # in reselect_device route through the docker branch.  Register with
         # the backend so reselect_device's iteration over self._sandboxes
         # finds them.
-        from vibesys.backends.base import SandboxKind
+        from vibesys.backends.base import SandboxKind  # noqa: PLC0415  # tracked: #288
 
         if use_docker:
             ctx.implementer_backend = MagicMock(spec=DockerSandbox)
             ctx.judge_backend = MagicMock(spec=DockerSandbox)
             kind = SandboxKind.DOCKER
         else:
-            from deepagents.backends import LocalShellBackend
+            from deepagents.backends import LocalShellBackend  # noqa: PLC0415  # tracked: #288
 
             ctx.implementer_backend = MagicMock(spec=LocalShellBackend)
             ctx.judge_backend = MagicMock(spec=LocalShellBackend)
             # _env mutated by reselect_device — give it a real dict.
-            ctx.implementer_backend._env = {}
-            ctx.judge_backend._env = {}
+            ctx.implementer_backend._env = {}  # noqa: SLF001  # tracked: #288
+            ctx.judge_backend._env = {}  # noqa: SLF001  # tracked: #288
             kind = SandboxKind.LOCAL
-        backend_impl._sandboxes = [
+        backend_impl._sandboxes = [  # noqa: SLF001  # tracked: #288
             (kind, ctx.implementer_backend),
             (kind, ctx.judge_backend),
         ]
@@ -323,20 +323,20 @@ class TestReselectGpu:
         return ctx
 
     @patch("vibesys.backends.cuda.pick_gpu")
-    def test_noop_when_cuda_visible_set(self, mock_pick, tmp_path):
+    def test_noop_when_cuda_visible_set(self, mock_pick, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         ctx = self._make_ctx(tmp_path, selected_gpu=_gpu(0, GPU_A))
         with patch.dict("os.environ", {"CUDA_VISIBLE_DEVICES": "0"}):
             ctx.reselect_gpu()
         mock_pick.assert_not_called()
 
     @patch("vibesys.backends.cuda.pick_gpu", return_value=None)
-    def test_noop_when_no_gpus(self, mock_pick, tmp_path):
+    def test_noop_when_no_gpus(self, mock_pick, tmp_path):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         ctx = self._make_ctx(tmp_path, selected_gpu=_gpu(0, GPU_A))
         ctx.reselect_gpu()
         assert ctx.selected_gpu.index == 0  # unchanged
 
     @patch("vibesys.backends.cuda.pick_gpu")
-    def test_noop_when_same_gpu(self, mock_pick, tmp_path):
+    def test_noop_when_same_gpu(self, mock_pick, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         gpu0 = _gpu(0, GPU_A, used=100)
         ctx = self._make_ctx(tmp_path, selected_gpu=gpu0)
         mock_pick.return_value = _gpu(0, GPU_A, used=200)
@@ -347,25 +347,25 @@ class TestReselectGpu:
     @patch("vibesys.backends.cuda.gpu_monitor.query_gpu_info", return_value=[])
     @patch("vibesys.backends.cuda.pick_gpu")
     @patch("vibesys.backends.cuda.gpu_monitor._query_gpu_procs", return_value="")
-    def test_local_backend_env_updated(self, _mock_procs, mock_pick, _mock_query, tmp_path):
+    def test_local_backend_env_updated(self, _mock_procs, mock_pick, _mock_query, tmp_path):  # noqa: ANN001, ANN201, PT019  # tracked: #288
         """When GPU changes, local backends get updated CUDA_VISIBLE_DEVICES."""
         gpu0 = _gpu(0, GPU_A, used=5000)
         gpu1 = _gpu(1, GPU_B, used=100)
         ctx = self._make_ctx(tmp_path, selected_gpu=gpu0, use_docker=False)
-        ctx.implementer_backend._env["CUDA_VISIBLE_DEVICES"] = "0"
-        ctx.judge_backend._env["CUDA_VISIBLE_DEVICES"] = "0"
+        ctx.implementer_backend._env["CUDA_VISIBLE_DEVICES"] = "0"  # noqa: SLF001  # tracked: #288
+        ctx.judge_backend._env["CUDA_VISIBLE_DEVICES"] = "0"  # noqa: SLF001  # tracked: #288
 
         mock_pick.return_value = gpu1
         ctx.reselect_gpu()
 
         assert ctx.selected_gpu is gpu1
-        assert ctx.implementer_backend._env["CUDA_VISIBLE_DEVICES"] == "1"
-        assert ctx.judge_backend._env["CUDA_VISIBLE_DEVICES"] == "1"
+        assert ctx.implementer_backend._env["CUDA_VISIBLE_DEVICES"] == "1"  # noqa: SLF001  # tracked: #288
+        assert ctx.judge_backend._env["CUDA_VISIBLE_DEVICES"] == "1"  # noqa: SLF001  # tracked: #288
 
     @patch("vibesys.backends.cuda.gpu_monitor.query_gpu_info", return_value=[])
     @patch("vibesys.backends.cuda.pick_gpu")
     @patch("vibesys.backends.cuda.gpu_monitor._query_gpu_procs", return_value="")
-    def test_contention_monitor_restarted(self, _mock_procs, mock_pick, _mock_query, tmp_path):
+    def test_contention_monitor_restarted(self, _mock_procs, mock_pick, _mock_query, tmp_path):  # noqa: ANN001, ANN201, PT019  # tracked: #288
         """Contention monitor switches to the new GPU UUID."""
         gpu0 = _gpu(0, GPU_A, used=5000)
         gpu1 = _gpu(1, GPU_B, used=100)
@@ -374,7 +374,7 @@ class TestReselectGpu:
         # Initial monitor lives on the backend (matches the production flow
         # where _RunContext.__init__ binds ctx.gpu_monitor to the same object).
         old_monitor = MagicMock()
-        ctx.backend_impl._monitor = old_monitor
+        ctx.backend_impl._monitor = old_monitor  # noqa: SLF001  # tracked: #288
         ctx.gpu_monitor = old_monitor
 
         mock_pick.return_value = gpu1
@@ -382,14 +382,14 @@ class TestReselectGpu:
 
         old_monitor.stop.assert_called_once()
         assert ctx.gpu_monitor is not old_monitor
-        assert ctx.gpu_monitor._gpu_uuid == GPU_B
+        assert ctx.gpu_monitor._gpu_uuid == GPU_B  # noqa: SLF001  # tracked: #288
         # Clean up
         ctx.gpu_monitor.stop()
 
     @patch("vibesys.backends.cuda.gpu_monitor.query_gpu_info", return_value=[])
     @patch("vibesys.backends.cuda.pick_gpu")
     @patch("vibesys.backends.cuda.gpu_monitor._query_gpu_procs", return_value="")
-    def test_docker_backends_restarted(self, _mock_procs, mock_pick, _mock_query, tmp_path):
+    def test_docker_backends_restarted(self, _mock_procs, mock_pick, _mock_query, tmp_path):  # noqa: ANN001, ANN201, PT019  # tracked: #288
         """Docker backends are stopped, updated, and restarted on GPU change."""
         gpu0 = _gpu(0, GPU_A, used=5000)
         gpu1 = _gpu(1, GPU_B, used=100)
@@ -400,8 +400,8 @@ class TestReselectGpu:
 
         ctx.implementer_backend.stop.assert_called_once()
         ctx.judge_backend.stop.assert_called_once()
-        assert ctx.implementer_backend._gpus == "device=1"
-        assert ctx.judge_backend._gpus == "device=1"
+        assert ctx.implementer_backend._gpus == "device=1"  # noqa: SLF001  # tracked: #288
+        assert ctx.judge_backend._gpus == "device=1"  # noqa: SLF001  # tracked: #288
         ctx.implementer_backend.start.assert_called_once()
         ctx.judge_backend.start.assert_called_once()
         # Clean up
@@ -415,7 +415,7 @@ class TestReselectGpu:
     @patch("vibesys.backends.cuda.gpu_monitor.query_gpu_info", return_value=[])
     @patch("vibesys.backends.cuda.pick_gpu")
     @patch("vibesys.backends.cuda.gpu_monitor._query_gpu_procs", return_value="")
-    def test_first_selection_from_none(self, _mock_procs, mock_pick, _mock_query, tmp_path):
+    def test_first_selection_from_none(self, _mock_procs, mock_pick, _mock_query, tmp_path):  # noqa: ANN001, ANN201, PT019  # tracked: #288
         """Works when selected_gpu was initially None (no GPU at startup)."""
         gpu1 = _gpu(1, GPU_B, used=100)
         ctx = self._make_ctx(tmp_path, selected_gpu=None, use_docker=False)
@@ -424,6 +424,6 @@ class TestReselectGpu:
         ctx.reselect_gpu()
 
         assert ctx.selected_gpu is gpu1
-        assert ctx.implementer_backend._env["CUDA_VISIBLE_DEVICES"] == "1"
+        assert ctx.implementer_backend._env["CUDA_VISIBLE_DEVICES"] == "1"  # noqa: SLF001  # tracked: #288
         # Clean up
         ctx.gpu_monitor.stop()

--- a/tests/backends/test_metal_backend.py
+++ b/tests/backends/test_metal_backend.py
@@ -15,12 +15,12 @@ from vibesys.main import _add_common_args
 from vibesys.profilers import ProfilerKind
 
 
-def _make_backend(tmp_path) -> LocalBackend:
+def _make_backend(tmp_path) -> LocalBackend:  # noqa: ANN001  # tracked: #288
     return backends.get(ComputeBackend.METAL, log_dir=tmp_path / "logs")
 
 
 class TestMetalRegistry:
-    def test_metal_in_registry(self, tmp_path):
+    def test_metal_in_registry(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = backends.get(ComputeBackend.METAL, log_dir=tmp_path)
         assert isinstance(impl, LocalBackend)
         assert impl.name is ComputeBackend.METAL
@@ -28,7 +28,7 @@ class TestMetalRegistry:
 
 
 class TestMetalSandbox:
-    def test_local_returns_local_shell_backend(self, tmp_path):
+    def test_local_returns_local_shell_backend(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         workspace = tmp_path / "ws"
         workspace.mkdir()
@@ -40,7 +40,7 @@ class TestMetalSandbox:
         )
         assert isinstance(sb, LocalShellBackend)
 
-    def test_docker_raises(self, tmp_path):
+    def test_docker_raises(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         # Metal-specific identity: message names metal + the MPS/Apple reason.
         with pytest.raises(ValueError, match="metal backend only supports local execution"):
@@ -50,7 +50,7 @@ class TestMetalSandbox:
                 log_path=None,
             )
 
-    def test_modal_raises(self, tmp_path):
+    def test_modal_raises(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         with pytest.raises(ValueError, match="local execution"):
             impl.make_sandbox(
@@ -61,11 +61,11 @@ class TestMetalSandbox:
 
 
 class TestMetalDevice:
-    def test_no_monitor(self, tmp_path):
+    def test_no_monitor(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         assert impl.make_monitor(tmp_path) is None
 
-    def test_reselect_is_noop(self, tmp_path):
+    def test_reselect_is_noop(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         # No-op: doesn't raise, doesn't change selected_device.
         impl.reselect_device()
@@ -73,7 +73,7 @@ class TestMetalDevice:
 
 
 class TestMetalCli:
-    def test_argparse_accepts_metal(self):
+    def test_argparse_accepts_metal(self):  # noqa: ANN201  # tracked: #288
         parser = argparse.ArgumentParser()
         _add_common_args(parser)
         ns = parser.parse_args(["--backend", "metal"])

--- a/tests/backends/test_rocm_backend.py
+++ b/tests/backends/test_rocm_backend.py
@@ -17,15 +17,15 @@ from vibesys.prompts import PROMPTS_DIR, RocmComputeBackendFragment
 from vibesys.prompts.renderer import _FRAGMENT_IMPLS, ComputeBackendFragment
 
 
-def _make_backend(tmp_path, devices=("/dev/kfd", "/dev/dri/renderD128")) -> RocmBackend:
+def _make_backend(tmp_path, devices=("/dev/kfd", "/dev/dri/renderD128")) -> RocmBackend:  # noqa: ANN001  # tracked: #288
     impl = backends.get(ComputeBackend.ROCM, log_dir=tmp_path / "logs")
     # Pin a deterministic device set so tests don't depend on host hardware.
-    impl._devices = list(devices)
+    impl._devices = list(devices)  # noqa: SLF001  # tracked: #288
     return impl
 
 
 class TestRocmRegistry:
-    def test_rocm_in_registry(self, tmp_path):
+    def test_rocm_in_registry(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = backends.get(ComputeBackend.ROCM, log_dir=tmp_path)
         assert isinstance(impl, RocmBackend)
         assert impl.name is ComputeBackend.ROCM
@@ -34,7 +34,7 @@ class TestRocmRegistry:
 
 
 class TestRocmSandbox:
-    def test_local_returns_local_shell_backend(self, tmp_path):
+    def test_local_returns_local_shell_backend(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         workspace = tmp_path / "ws"
         workspace.mkdir()
@@ -46,7 +46,7 @@ class TestRocmSandbox:
         )
         assert isinstance(sb, LocalShellBackend)
 
-    def test_docker_forwards_kfd_and_dri_without_gpus_flag(self, tmp_path):
+    def test_docker_forwards_kfd_and_dri_without_gpus_flag(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """AMD GPUs come in via --device, not the NVIDIA-only --gpus."""
         impl = _make_backend(tmp_path, devices=["/dev/kfd", "/dev/dri/renderD128"])
         workspace = tmp_path / "ws"
@@ -56,10 +56,10 @@ class TestRocmSandbox:
             host_workspace=str(workspace),
             log_path=None,
         )
-        assert sb._devices == ["/dev/kfd", "/dev/dri/renderD128"]
-        assert sb._gpus is None
+        assert sb._devices == ["/dev/kfd", "/dev/dri/renderD128"]  # noqa: SLF001  # tracked: #288
+        assert sb._gpus is None  # noqa: SLF001  # tracked: #288
 
-    def test_docker_can_skip_accelerator_for_control_plane(self, tmp_path):
+    def test_docker_can_skip_accelerator_for_control_plane(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         workspace = tmp_path / "ws"
         workspace.mkdir()
@@ -71,9 +71,9 @@ class TestRocmSandbox:
             attach_accelerator=False,
         )
 
-        assert sb._devices == []
+        assert sb._devices == []  # noqa: SLF001  # tracked: #288
 
-    def test_docker_adds_device_groups(self, tmp_path):
+    def test_docker_adds_device_groups(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """/dev/kfd and /dev/dri/* are group-owned; without these the container
         user cannot open them and every HIP call fails at runtime."""
         impl = _make_backend(tmp_path)
@@ -84,9 +84,9 @@ class TestRocmSandbox:
             host_workspace=str(workspace),
             log_path=None,
         )
-        assert sb._group_add == ["video", "render"]
+        assert sb._group_add == ["video", "render"]  # noqa: SLF001  # tracked: #288
 
-    def test_modal_raises(self, tmp_path):
+    def test_modal_raises(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Modal has no AMD GPUs — fail loudly rather than silently on CPU."""
         impl = _make_backend(tmp_path)
         with pytest.raises(ValueError, match="does not support Modal"):
@@ -96,7 +96,7 @@ class TestRocmSandbox:
                 log_path=None,
             )
 
-    def test_torch_wheel_index_targets_rocm(self, tmp_path):
+    def test_torch_wheel_index_targets_rocm(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Without this, `uv add torch` in the agent's fresh venv resolves the
         default PyPI (CUDA) wheel and the run silently falls back to CPU."""
         impl = _make_backend(tmp_path)
@@ -107,15 +107,15 @@ class TestRocmSandbox:
             host_workspace=str(workspace),
             log_path=None,
         )
-        assert "rocm" in sb._env["UV_EXTRA_INDEX_URL"]
+        assert "rocm" in sb._env["UV_EXTRA_INDEX_URL"]  # noqa: SLF001  # tracked: #288
 
-    def test_default_image_is_pinned(self):
+    def test_default_image_is_pinned(self):  # noqa: ANN201  # tracked: #288
         """A floating :latest tag can drift past the host kernel driver."""
-        from vibesys.backends.rocm import _DEFAULT_IMAGE
+        from vibesys.backends.rocm import _DEFAULT_IMAGE  # noqa: PLC0415  # tracked: #288
 
         assert not _DEFAULT_IMAGE.endswith(":latest")
 
-    def test_hip_visible_devices_is_respected(self, tmp_path, monkeypatch):
+    def test_hip_visible_devices_is_respected(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         monkeypatch.setenv("HIP_VISIBLE_DEVICES", "2")
         impl = _make_backend(tmp_path)
         workspace = tmp_path / "ws"
@@ -125,9 +125,9 @@ class TestRocmSandbox:
             host_workspace=str(workspace),
             log_path=None,
         )
-        assert sb._env.get("HIP_VISIBLE_DEVICES") == "2"
+        assert sb._env.get("HIP_VISIBLE_DEVICES") == "2"  # noqa: SLF001  # tracked: #288
 
-    def test_caller_env_overrides_backend_env(self, tmp_path, monkeypatch):
+    def test_caller_env_overrides_backend_env(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         monkeypatch.setenv("HIP_VISIBLE_DEVICES", "2")
         impl = _make_backend(tmp_path)
         workspace = tmp_path / "ws"
@@ -138,16 +138,16 @@ class TestRocmSandbox:
             log_path=None,
             extra_env={"HIP_VISIBLE_DEVICES": "0"},
         )
-        assert sb._env.get("HIP_VISIBLE_DEVICES") == "0"
+        assert sb._env.get("HIP_VISIBLE_DEVICES") == "0"  # noqa: SLF001  # tracked: #288
 
 
 class TestRocmDeviceDiscovery:
-    def test_no_kfd_means_no_devices(self, tmp_path, monkeypatch):
+    def test_no_kfd_means_no_devices(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         """A host without /dev/kfd yields an empty list rather than raising."""
         monkeypatch.setattr("vibesys.backends.rocm.os.path.exists", lambda _p: False)
         assert _discover_rocm_devices() == []
 
-    def test_kfd_leads_and_render_nodes_follow(self, monkeypatch):
+    def test_kfd_leads_and_render_nodes_follow(self, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         monkeypatch.setattr("vibesys.backends.rocm.os.path.exists", lambda _p: True)
         monkeypatch.setattr(
             "vibesys.backends.rocm.glob.glob",
@@ -161,18 +161,18 @@ class TestRocmDeviceDiscovery:
 
 
 class TestRocmDevice:
-    def test_no_monitor(self, tmp_path):
+    def test_no_monitor(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         assert impl.make_monitor(tmp_path) is None
 
-    def test_reselect_is_noop(self, tmp_path):
+    def test_reselect_is_noop(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         impl.reselect_device()
         assert impl.selected_device is None
 
 
 class TestRocmCli:
-    def test_argparse_accepts_rocm(self):
+    def test_argparse_accepts_rocm(self):  # noqa: ANN201  # tracked: #288
         parser = argparse.ArgumentParser()
         _add_common_args(parser)
         ns = parser.parse_args(["--backend", "rocm"])
@@ -180,19 +180,19 @@ class TestRocmCli:
 
 
 class TestRocmPromptFragments:
-    def test_every_fragment_name_exists_for_rocm(self):
+    def test_every_fragment_name_exists_for_rocm(self):  # noqa: ANN201  # tracked: #288
         """`Prompt.__init__` calls validate(); a missing .j2 fails the run."""
         RocmComputeBackendFragment.validate()
 
-    def test_rocm_is_registered_in_the_fragment_impl_table(self):
+    def test_rocm_is_registered_in_the_fragment_impl_table(self):  # noqa: ANN201  # tracked: #288
         """An unregistered backend raises at prompt construction time."""
         assert _FRAGMENT_IMPLS[ComputeBackend.ROCM] is RocmComputeBackendFragment
 
-    def test_every_backend_has_a_fragment_impl(self):
+    def test_every_backend_has_a_fragment_impl(self):  # noqa: ANN201  # tracked: #288
         """Adding a ComputeBackend without fragments breaks every run on it."""
         assert set(_FRAGMENT_IMPLS) == set(ComputeBackend)
 
-    def test_rocm_fragments_are_non_empty(self):
+    def test_rocm_fragments_are_non_empty(self):  # noqa: ANN201  # tracked: #288
         """Empty .j2 is a legal 'hard skip', but ROCm has real content for all
         three — an accidental empty file would silently drop prompt guidance."""
         backend_dir = PROMPTS_DIR / "backend" / ComputeBackend.ROCM.value

--- a/tests/backends/test_trainium_backend.py
+++ b/tests/backends/test_trainium_backend.py
@@ -15,15 +15,15 @@ from vibesys.main import _add_common_args
 from vibesys.profilers import ProfilerKind
 
 
-def _make_backend(tmp_path, devices=("/dev/neuron0",)) -> TrainiumBackend:
+def _make_backend(tmp_path, devices=("/dev/neuron0",)) -> TrainiumBackend:  # noqa: ANN001  # tracked: #288
     impl = backends.get(ComputeBackend.TRAINIUM, log_dir=tmp_path / "logs")
     # Pin a deterministic device set so tests don't depend on host hardware.
-    impl._devices = list(devices)
+    impl._devices = list(devices)  # noqa: SLF001  # tracked: #288
     return impl
 
 
 class TestTrainiumRegistry:
-    def test_trainium_in_registry(self, tmp_path):
+    def test_trainium_in_registry(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = backends.get(ComputeBackend.TRAINIUM, log_dir=tmp_path)
         assert isinstance(impl, TrainiumBackend)
         assert impl.name is ComputeBackend.TRAINIUM
@@ -31,7 +31,7 @@ class TestTrainiumRegistry:
 
 
 class TestTrainiumSandbox:
-    def test_local_returns_local_shell_backend(self, tmp_path):
+    def test_local_returns_local_shell_backend(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         workspace = tmp_path / "ws"
         workspace.mkdir()
@@ -43,7 +43,7 @@ class TestTrainiumSandbox:
         )
         assert isinstance(sb, LocalShellBackend)
 
-    def test_docker_forwards_neuron_devices_and_no_gpus(self, tmp_path):
+    def test_docker_forwards_neuron_devices_and_no_gpus(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path, devices=["/dev/neuron0", "/dev/neuron1"])
         workspace = tmp_path / "ws"
         workspace.mkdir()
@@ -53,20 +53,21 @@ class TestTrainiumSandbox:
             log_path=None,
         )
         # DockerSandbox stores the device list and skips --gpus.
-        assert sb._devices == ["/dev/neuron0", "/dev/neuron1"]
-        assert sb._gpus is None
+        assert sb._devices == ["/dev/neuron0", "/dev/neuron1"]  # noqa: SLF001  # tracked: #288
+        assert sb._gpus is None  # noqa: SLF001  # tracked: #288
         # Persistent compile cache is bind-mounted and passthrough-registered.
         assert any(
-            container == "/opt/neuron-compile-cache" for _host, container, _ro in sb._bind_mounts
+            container == "/opt/neuron-compile-cache"
+            for _host, container, _ro in sb._bind_mounts  # noqa: SLF001  # tracked: #288
         )
-        assert "/opt/neuron-compile-cache" in sb._passthrough_prefixes
-        assert sb._env.get("NEURON_COMPILE_CACHE_URL") == "/opt/neuron-compile-cache"
+        assert "/opt/neuron-compile-cache" in sb._passthrough_prefixes  # noqa: SLF001  # tracked: #288
+        assert sb._env.get("NEURON_COMPILE_CACHE_URL") == "/opt/neuron-compile-cache"  # noqa: SLF001  # tracked: #288
         # auto-remove container + host-mounted neuronx-cc temp (TMPDIR)
-        assert sb._auto_remove is True
-        assert sb._env.get("TMPDIR") == "/opt/neuron-tmp"
-        assert any(c == "/opt/neuron-tmp" for _h, c, _ro in sb._bind_mounts)
+        assert sb._auto_remove is True  # noqa: SLF001  # tracked: #288
+        assert sb._env.get("TMPDIR") == "/opt/neuron-tmp"  # noqa: SLF001  # tracked: #288
+        assert any(c == "/opt/neuron-tmp" for _h, c, _ro in sb._bind_mounts)  # noqa: SLF001  # tracked: #288
 
-    def test_modal_raises(self, tmp_path):
+    def test_modal_raises(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         with pytest.raises(ValueError, match="does not support Modal"):
             impl.make_sandbox(
@@ -77,18 +78,18 @@ class TestTrainiumSandbox:
 
 
 class TestTrainiumDevice:
-    def test_no_monitor(self, tmp_path):
+    def test_no_monitor(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         assert impl.make_monitor(tmp_path) is None
 
-    def test_reselect_is_noop(self, tmp_path):
+    def test_reselect_is_noop(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)
         impl.reselect_device()
         assert impl.selected_device is None
 
 
 class TestTrainiumCli:
-    def test_argparse_accepts_trainium(self):
+    def test_argparse_accepts_trainium(self):  # noqa: ANN201  # tracked: #288
         parser = argparse.ArgumentParser()
         _add_common_args(parser)
         ns = parser.parse_args(["--backend", "trainium"])

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -8,7 +8,7 @@ carries serving prose; ``generic`` injects nothing of its own).
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 import pytest
 
@@ -42,7 +42,7 @@ def _temporary_domain(prompt_dir: Path) -> DomainDefinition:
 # --------------------------------------------------------------------------- #
 # resolver
 # --------------------------------------------------------------------------- #
-def test_registered_domains_present():
+def test_registered_domains_present():  # noqa: ANN201  # tracked: #288
     names = registered_domains()
     assert "llm-serving" in names
     assert "generic" in names
@@ -50,7 +50,7 @@ def test_registered_domains_present():
     assert "README" not in names  # the authoring guide is not a domain
 
 
-def test_resolve_registered_name():
+def test_resolve_registered_name():  # noqa: ANN201  # tracked: #288
     d = resolve_domain(DomainName.LLM_SERVING)
     assert d.name is DomainName.LLM_SERVING
     assert d.prompt_dir.is_dir()
@@ -58,7 +58,7 @@ def test_resolve_registered_name():
     assert d.prompt_dir.parent.name == "domains"
 
 
-def test_resolve_microservices_domain():
+def test_resolve_microservices_domain():  # noqa: ANN201  # tracked: #288
     d = resolve_domain(DomainName.MICROSERVICES)
     assert d.name is DomainName.MICROSERVICES
     assert d.prompt_dir.is_dir()
@@ -66,7 +66,7 @@ def test_resolve_microservices_domain():
     assert d.prompt_dir.parent.name == "domains"
 
 
-def test_resolve_path_is_not_supported(tmp_path: Path):
+def test_resolve_path_is_not_supported(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     f = tmp_path / "mine"
     f.mkdir()
     (f / "implementer.md").write_text("hello\n")
@@ -74,19 +74,19 @@ def test_resolve_path_is_not_supported(tmp_path: Path):
         resolve_domain(str(f))
 
 
-def test_registered_domains_carry_environment_hooks():
+def test_registered_domains_carry_environment_hooks():  # noqa: ANN201  # tracked: #288
     assert isinstance(DOMAINS[DomainName.LLM_SERVING].environment_hooks, LLMServingEnvironmentHooks)
     assert isinstance(DOMAINS[DomainName.GENERIC].environment_hooks, NoopEnvironmentHooks)
     assert isinstance(DOMAINS[DomainName.MICROSERVICES].environment_hooks, NoopEnvironmentHooks)
 
 
-def test_domains_declare_torch_profiler_compatibility():
+def test_domains_declare_torch_profiler_compatibility():  # noqa: ANN201  # tracked: #288
     assert DOMAINS[DomainName.LLM_SERVING].supports_torch_profiler
     assert not DOMAINS[DomainName.GENERIC].supports_torch_profiler
     assert not DOMAINS[DomainName.MICROSERVICES].supports_torch_profiler
 
 
-def test_resolve_unknown_raises():
+def test_resolve_unknown_raises():  # noqa: ANN201  # tracked: #288
     with pytest.raises(TypeError) as exc:
         resolve_domain("does-not-exist-xyz")
     assert "DomainName" in str(exc.value)
@@ -95,7 +95,7 @@ def test_resolve_unknown_raises():
 # --------------------------------------------------------------------------- #
 # role-file renderer
 # --------------------------------------------------------------------------- #
-def test_render_missing_role_is_empty(tmp_path: Path):
+def test_render_missing_role_is_empty(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     # a domain directory with no matching <role>.md file injects nothing
     domain_dir = tmp_path / "domain"
     domain_dir.mkdir()
@@ -103,14 +103,14 @@ def test_render_missing_role_is_empty(tmp_path: Path):
     assert render_domain_section(_temporary_domain(domain_dir), DomainRole.IMPLEMENTER) == ""
 
 
-def test_render_empty_role_is_empty():
+def test_render_empty_role_is_empty():  # noqa: ANN201  # tracked: #288
     # generic has no role files, so every role injects nothing
     d = resolve_domain(DomainName.GENERIC)
     for role in (DomainRole.IMPLEMENTER, DomainRole.JUDGE, DomainRole.SINGLE_AGENT):
         assert render_domain_section(d, role) == ""
 
 
-def test_render_llm_serving_has_content():
+def test_render_llm_serving_has_content():  # noqa: ANN201  # tracked: #288
     d = resolve_domain(DomainName.LLM_SERVING)
     impl = render_domain_section(
         d, DomainRole.IMPLEMENTER, modality="text_generation", reference_path="/ref"
@@ -122,7 +122,7 @@ def test_render_llm_serving_has_content():
     assert "## Use references as implementation support" in impl
 
 
-def test_render_microservices_has_content():
+def test_render_microservices_has_content():  # noqa: ANN201  # tracked: #288
     d = resolve_domain(DomainName.MICROSERVICES)
     impl = render_domain_section(d, DomainRole.IMPLEMENTER, interface="service")
     judge = render_domain_section(
@@ -137,7 +137,7 @@ def test_render_microservices_has_content():
     assert "./bench" in judge
 
 
-def test_role_file_keeps_markdown_headings(tmp_path: Path):
+def test_role_file_keeps_markdown_headings(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     """Role files are normal Markdown; headings inside them are preserved."""
     domain_dir = tmp_path / "domain"
     domain_dir.mkdir()
@@ -162,7 +162,7 @@ def test_role_file_keeps_markdown_headings(tmp_path: Path):
     assert judge == "JUDGE-BODY"
 
 
-def test_llm_serving_judge_does_not_duplicate_framework_benchmark():
+def test_llm_serving_judge_does_not_duplicate_framework_benchmark():  # noqa: ANN201  # tracked: #288
     """The LLM judge audits evidence instead of rerunning a trusted gate."""
     d = resolve_domain(DomainName.LLM_SERVING)
     with_bench = render_domain_section(
@@ -177,7 +177,7 @@ def test_llm_serving_judge_does_not_duplicate_framework_benchmark():
     assert "audit the implementer's retained performance evidence" in without_bench
 
 
-def test_render_role_branches_on_interface(tmp_path: Path):
+def test_render_role_branches_on_interface(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     """The process boundary reaches domain role files."""
     domain_dir = tmp_path / "domain"
     domain_dir.mkdir()
@@ -191,7 +191,7 @@ def test_render_role_branches_on_interface(tmp_path: Path):
     assert "IN_PROCESS_GATE" not in service
 
 
-def test_single_agent_uses_explicit_section_when_present():
+def test_single_agent_uses_explicit_section_when_present():  # noqa: ANN201  # tracked: #288
     # llm-serving ships a bespoke single_agent.md file
     d = resolve_domain(DomainName.LLM_SERVING)
     sa = render_domain_section(
@@ -200,7 +200,7 @@ def test_single_agent_uses_explicit_section_when_present():
     assert "do not let yourself cheat" in sa  # text unique to that section
 
 
-def test_single_agent_derives_from_implementer_and_judge(tmp_path: Path):
+def test_single_agent_derives_from_implementer_and_judge(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     # no single_agent.md -> derived from implementer + judge
     domain_dir = tmp_path / "domain"
     domain_dir.mkdir()
@@ -225,21 +225,21 @@ def _render_implementer(domain: DomainName) -> str:
         modality="text_generation",
         domain_implementer=section,
         task="TASK",
-        pass_criteria="PC",
+        pass_criteria="PC",  # noqa: S106  # tracked: #288
         reference_path="/ref",
         runtime_notes="",
         feedback=None,
     )
 
 
-def test_llm_serving_injects_into_implementer():
+def test_llm_serving_injects_into_implementer():  # noqa: ANN201  # tracked: #288
     out = _render_implementer(DomainName.LLM_SERVING)
     # serving-specific prose from the domain package is present
     assert "serving" in out.lower()
     assert "## Progress tracking" in out  # base skeleton intact
 
 
-def test_generic_injects_nothing_extra():
+def test_generic_injects_nothing_extra():  # noqa: ANN201  # tracked: #288
     generic = _render_implementer(DomainName.GENERIC)
     # the only serving refs left are from the modality include, not the domain;
     # the generic render must be strictly shorter than llm-serving's.
@@ -248,7 +248,7 @@ def test_generic_injects_nothing_extra():
     assert "## Progress tracking" in generic  # base skeleton intact
 
 
-def test_no_triple_blank_at_injection_point():
+def test_no_triple_blank_at_injection_point():  # noqa: ANN201  # tracked: #288
     """Generic (empty injection) must not leave a triple newline gap."""
     out = _render_implementer(DomainName.GENERIC)
     # The injection point itself ({% if %}...{% endif %}) must collapse cleanly.
@@ -261,7 +261,7 @@ def test_no_triple_blank_at_injection_point():
 # --------------------------------------------------------------------------- #
 # orchestrator role
 # --------------------------------------------------------------------------- #
-def test_orchestrator_is_a_domain_role():
+def test_orchestrator_is_a_domain_role():  # noqa: ANN201  # tracked: #288
     assert DomainRole.ORCHESTRATOR in DOMAIN_ROLES
 
 
@@ -284,7 +284,7 @@ def _render_orchestrator(domain: DomainName) -> str:
     )
 
 
-def test_llm_serving_provides_evidence_led_orchestrator_method():
+def test_llm_serving_provides_evidence_led_orchestrator_method():  # noqa: ANN201  # tracked: #288
     section = render_domain_section(
         resolve_domain(DomainName.LLM_SERVING), DomainRole.ORCHESTRATOR, modality="text_generation"
     )
@@ -295,13 +295,13 @@ def test_llm_serving_provides_evidence_led_orchestrator_method():
     assert "current-architecture ceiling" in section
 
 
-def test_llm_serving_method_is_injected_into_plan():
+def test_llm_serving_method_is_injected_into_plan():  # noqa: ANN201  # tracked: #288
     out = _render_orchestrator(DomainName.LLM_SERVING)
     assert "Evidence-led optimization method" in out
     assert "measured end-to-end evidence" in out
 
 
-def test_generic_orchestrator_has_no_llm_serving_method():
+def test_generic_orchestrator_has_no_llm_serving_method():  # noqa: ANN201  # tracked: #288
     out = _render_orchestrator(DomainName.GENERIC)
     assert "Evidence-led optimization method" not in out
     assert "Continuous batching" not in out
@@ -309,7 +309,7 @@ def test_generic_orchestrator_has_no_llm_serving_method():
     assert "## Task granularity" in out  # base skeleton intact
 
 
-def test_llm_serving_profiler_branches_on_remote_execution_not_provider():
+def test_llm_serving_profiler_branches_on_remote_execution_not_provider():  # noqa: ANN201  # tracked: #288
     domain = resolve_domain(DomainName.LLM_SERVING)
 
     local = render_domain_section(domain, DomainRole.PROFILER, profile_execution="local")
@@ -323,7 +323,7 @@ def test_llm_serving_profiler_branches_on_remote_execution_not_provider():
     assert "Modal" not in remote
 
 
-def test_torch_profiler_remote_capture_is_provider_neutral():
+def test_torch_profiler_remote_capture_is_provider_neutral():  # noqa: ANN201  # tracked: #288
     common = {
         "objective": "Measure service throughput.",
         "profile_focus": "Find the dominant accelerator bottleneck.",

--- a/tests/loops/agent/test_interface_modes.py
+++ b/tests/loops/agent/test_interface_modes.py
@@ -21,38 +21,38 @@ from vibesys.prompts import PROMPTS_DIR, render_template
 _TEMPLATE_DIR = PROMPTS_DIR / "loops" / "agent"
 
 
-def test_domain_module_has_no_language_axis():
-    import vibesys.domains.base as domain
+def test_domain_module_has_no_language_axis():  # noqa: ANN201  # tracked: #288
+    import vibesys.domains.base as domain  # noqa: PLC0415  # tracked: #288
 
     assert not hasattr(domain, "DEFAULT_LANGUAGE")
     assert not hasattr(domain, "LANGUAGE_DIR")
     assert not hasattr(domain, "DEFAULT_DOMAIN")
 
 
-def test_no_language_pack_directory():
+def test_no_language_pack_directory():  # noqa: ANN201  # tracked: #288
     assert not (_TEMPLATE_DIR / "_language").exists()
 
 
-def test_cli_exposes_only_process_boundary_modes():
-    from vibesys.main import _build_agent_parser
+def test_cli_exposes_only_process_boundary_modes():  # noqa: ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     parser = _build_agent_parser()
-    action = next(action for action in parser._actions if action.dest == "interface")
+    action = next(action for action in parser._actions if action.dest == "interface")  # noqa: SLF001  # tracked: #288
     assert set(action.choices) == {"inprocess", "service"}
     assert action.default == "inprocess"
-    assert all(action.dest != "language" for action in parser._actions)
+    assert all(action.dest != "language" for action in parser._actions)  # noqa: SLF001  # tracked: #288
 
 
-def test_cli_default_interface_is_inprocess():
-    from vibesys.main import _build_agent_parser
+def test_cli_default_interface_is_inprocess():  # noqa: ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     args = _build_agent_parser().parse_args(["--input", "/x", "--exp-name", "e"])
     assert args.interface == "inprocess"
 
 
 @pytest.mark.parametrize("interface", ["native", "rust"])
-def test_cli_rejects_unknown_interface(interface):
-    from vibesys.main import _build_agent_parser
+def test_cli_rejects_unknown_interface(interface):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     with pytest.raises(ConfigurationError):
         _build_agent_parser().parse_args(
@@ -60,8 +60,8 @@ def test_cli_rejects_unknown_interface(interface):
         )
 
 
-def test_loop_constants_and_rejects_unknown_interface():
-    from vibesys.loops.agent.loop import (
+def test_loop_constants_and_rejects_unknown_interface():  # noqa: ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
         _INTERFACES,
         DEFAULT_INTERFACE,
         run_agent_loop,
@@ -81,8 +81,8 @@ def test_loop_constants_and_rejects_unknown_interface():
         )
 
 
-def test_torch_profiler_honors_resolved_environment_capability():
-    from vibesys.loops.agent.loop import _profiler_prompt_template
+def test_torch_profiler_honors_resolved_environment_capability():  # noqa: ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import _profiler_prompt_template  # noqa: PLC0415  # tracked: #288
 
     assert (
         _profiler_prompt_template(
@@ -98,22 +98,22 @@ def test_torch_profiler_honors_resolved_environment_capability():
         )
 
 
-def test_non_torch_profilers_use_the_resolved_kind():
-    from vibesys.loops.agent.loop import _profiler_prompt_template
+def test_non_torch_profilers_use_the_resolved_kind():  # noqa: ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import _profiler_prompt_template  # noqa: PLC0415  # tracked: #288
 
     assert _profiler_prompt_template(ProfilerKind.NEURON) == "profilers/neuron.j2"
     assert _profiler_prompt_template(ProfilerKind.NSYS) == "profilers/nsys.j2"
 
 
-def test_standalone_profiler_none_has_no_prompt_template():
-    from vibesys.loops.agent.loop import _profiler_prompt_template
+def test_standalone_profiler_none_has_no_prompt_template():  # noqa: ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import _profiler_prompt_template  # noqa: PLC0415  # tracked: #288
 
     with pytest.raises(ValueError, match="disabled"):
         _profiler_prompt_template(ProfilerKind.NONE)
 
 
-def test_standalone_profiler_rejects_unknown_kind():
-    from vibesys.loops.agent.loop import _profiler_prompt_template
+def test_standalone_profiler_rejects_unknown_kind():  # noqa: ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import _profiler_prompt_template  # noqa: PLC0415  # tracked: #288
 
     with pytest.raises(TypeError, match="ProfilerKind"):
         _profiler_prompt_template("bogus")
@@ -127,14 +127,14 @@ def _render_implementer(interface: str, *, modality: str | None = None) -> str:
         interface=interface,
         domain_implementer="",
         task="TASK",
-        pass_criteria="PC",
+        pass_criteria="PC",  # noqa: S106  # tracked: #288
         reference_path="/ref",
         runtime_notes="",
         feedback=None,
     )
 
 
-def test_inprocess_prompt_describes_direct_invocation_without_language_assumptions():
+def test_inprocess_prompt_describes_direct_invocation_without_language_assumptions():  # noqa: ANN201  # tracked: #288
     output = _render_implementer("inprocess")
 
     assert "invokes the candidate directly" in output
@@ -144,7 +144,7 @@ def test_inprocess_prompt_describes_direct_invocation_without_language_assumptio
     assert "native artifact" not in output
 
 
-def test_service_prompt_describes_network_boundary_without_language_assumptions():
+def test_service_prompt_describes_network_boundary_without_language_assumptions():  # noqa: ANN201  # tracked: #288
     output = _render_implementer("service")
 
     assert "running candidate service" in output
@@ -153,7 +153,7 @@ def test_service_prompt_describes_network_boundary_without_language_assumptions(
     assert "VibeServeModel" not in output
 
 
-def test_inprocess_implementer_handles_missing_reference_explicitly():
+def test_inprocess_implementer_handles_missing_reference_explicitly():  # noqa: ANN201  # tracked: #288
     output = render_template(
         "implementer_prompt.j2",
         template_dir=_TEMPLATE_DIR,
@@ -161,7 +161,7 @@ def test_inprocess_implementer_handles_missing_reference_explicitly():
         interface="inprocess",
         domain_implementer="",
         task="TASK",
-        pass_criteria="PC",
+        pass_criteria="PC",  # noqa: S106  # tracked: #288
         reference_path=".",
         runtime_notes="",
         feedback=None,
@@ -170,7 +170,7 @@ def test_inprocess_implementer_handles_missing_reference_explicitly():
     assert "Reference implementation is at `.`" not in output
 
 
-def test_default_interface_matches_inprocess_for_implementer():
+def test_default_interface_matches_inprocess_for_implementer():  # noqa: ANN201  # tracked: #288
     explicit = _render_implementer("inprocess")
     implied = render_template(
         "implementer_prompt.j2",
@@ -178,7 +178,7 @@ def test_default_interface_matches_inprocess_for_implementer():
         modality=None,
         domain_implementer="",
         task="TASK",
-        pass_criteria="PC",
+        pass_criteria="PC",  # noqa: S106  # tracked: #288
         reference_path="/ref",
         runtime_notes="",
         feedback=None,
@@ -186,7 +186,7 @@ def test_default_interface_matches_inprocess_for_implementer():
     assert explicit == implied
 
 
-def test_llm_domain_owns_python_tooling():
+def test_llm_domain_owns_python_tooling():  # noqa: ANN201  # tracked: #288
     llm_domain = resolve_domain(DomainName.LLM_SERVING)
     generic_domain = resolve_domain(DomainName.GENERIC)
 
@@ -214,7 +214,7 @@ def _render_judge(interface: str) -> str:
         domain_judge="",
         accuracy_command="accuracy-checker",
         benchmark_command="benchmark",
-        pass_criteria="PC",
+        pass_criteria="PC",  # noqa: S106  # tracked: #288
         retry=1,
         runtime_notes="",
         profile_execution="local",
@@ -222,11 +222,11 @@ def _render_judge(interface: str) -> str:
     )
 
 
-def test_text_generation_use_case_owns_inprocess_python_contract():
+def test_text_generation_use_case_owns_inprocess_python_contract():  # noqa: ANN201  # tracked: #288
     assert "VibeServeModel" in _render_judge("inprocess")
 
 
-def test_service_judge_drops_direct_import_contract():
+def test_service_judge_drops_direct_import_contract():  # noqa: ANN201  # tracked: #288
     output = _render_judge("service")
     assert "VibeServeModel" not in output
     assert "Decode invariants" in output
@@ -255,7 +255,7 @@ def _render_single_agent(
         domain_single_agent="",
         domain_profiler="",
         task="TASK",
-        pass_criteria="PC",
+        pass_criteria="PC",  # noqa: S106  # tracked: #288
         retry=1,
         feedback=None,
         objective="OBJ",
@@ -271,7 +271,7 @@ def _render_single_agent(
     )
 
 
-def test_inprocess_single_agent_uses_torch_only_for_supporting_domain():
+def test_inprocess_single_agent_uses_torch_only_for_supporting_domain():  # noqa: ANN201  # tracked: #288
     supported = _render_single_agent(
         "inprocess",
         supports_torch_profiler=True,
@@ -284,7 +284,7 @@ def test_inprocess_single_agent_uses_torch_only_for_supporting_domain():
         )
 
 
-def test_service_single_agent_honors_environment_resolved_torch():
+def test_service_single_agent_honors_environment_resolved_torch():  # noqa: ANN201  # tracked: #288
     output = _render_single_agent(
         "service",
         supports_torch_profiler=True,
@@ -293,7 +293,7 @@ def test_service_single_agent_honors_environment_resolved_torch():
     assert "nsys" not in output
 
 
-def test_single_agent_profiler_none_avoids_profiler_tools():
+def test_single_agent_profiler_none_avoids_profiler_tools():  # noqa: ANN201  # tracked: #288
     output = _render_single_agent("inprocess", profiler_kind=ProfilerKind.NONE)
     assert "Standalone profiling is disabled" in output
     assert "nsys_profiler" not in output

--- a/tests/loops/agent/test_issue_mcp_config.py
+++ b/tests/loops/agent/test_issue_mcp_config.py
@@ -13,7 +13,7 @@ from vibesys.loops.plain.mcp_config import build_issue_mcp_spec
 from vs_issue_board import IssueType
 
 
-def test_build_judge_spec_has_correct_shape():
+def test_build_judge_spec_has_correct_shape():  # noqa: ANN201  # tracked: #288
     spec = build_issue_mcp_spec(
         store_relpath="issues.json",
         creator="judge",
@@ -41,7 +41,7 @@ def test_build_judge_spec_has_correct_shape():
     assert spec.env == {}
 
 
-def test_build_perf_eval_spec_sorts_allowed_types_alphabetically():
+def test_build_perf_eval_spec_sorts_allowed_types_alphabetically():  # noqa: ANN201  # tracked: #288
     spec = build_issue_mcp_spec(
         store_relpath="issues.json",
         creator="perf_eval",
@@ -58,7 +58,7 @@ def test_build_perf_eval_spec_sorts_allowed_types_alphabetically():
     assert args[args.index("--allowed-types") + 1] == "bug,feature,perf"
 
 
-def test_build_spec_omits_cap_flag_when_none():
+def test_build_spec_omits_cap_flag_when_none():  # noqa: ANN201  # tracked: #288
     spec = build_issue_mcp_spec(
         store_relpath="issues.json",
         creator="agent",
@@ -71,7 +71,7 @@ def test_build_spec_omits_cap_flag_when_none():
     assert "--cap" not in spec.args
 
 
-def test_build_spec_uses_provided_store_relpath():
+def test_build_spec_uses_provided_store_relpath():  # noqa: ANN201  # tracked: #288
     spec = build_issue_mcp_spec(
         store_relpath="custom/path/issues.json",
         creator="judge",

--- a/tests/loops/agent/test_issue_render.py
+++ b/tests/loops/agent/test_issue_render.py
@@ -18,12 +18,12 @@ from vs_issue_board import (
 )
 
 
-def _make_issue(
+def _make_issue(  # noqa: PLR0913  # tracked: #288
     *,
-    id: int = 1,
+    id: int = 1,  # noqa: A002  # tracked: #288
     title: str = "Test issue",
     description: str = "A test issue.",
-    type: IssueType = IssueType.FEATURE,
+    type: IssueType = IssueType.FEATURE,  # noqa: A002  # tracked: #288
     status: IssueStatus = IssueStatus.OPEN,
     attempts: int = 0,
     created_by: str = "loop:bootstrap",
@@ -53,7 +53,7 @@ def _make_issue(
     )
 
 
-def _make_event(
+def _make_event(  # noqa: PLR0913  # tracked: #288
     *,
     actor: str,
     action: str,
@@ -78,42 +78,42 @@ def _make_event(
 
 
 class TestSlugify:
-    def test_basic_lowercases_and_dashes(self):
+    def test_basic_lowercases_and_dashes(self):  # noqa: ANN201  # tracked: #288
         assert slugify("Add Paged KV cache") == "add-paged-kv-cache"
 
-    def test_empty_title_falls_back_to_untitled(self):
+    def test_empty_title_falls_back_to_untitled(self):  # noqa: ANN201  # tracked: #288
         assert slugify("") == "untitled"
 
-    def test_punctuation_only_falls_back_to_untitled(self):
+    def test_punctuation_only_falls_back_to_untitled(self):  # noqa: ANN201  # tracked: #288
         assert slugify("!!!") == "untitled"
         assert slugify("---") == "untitled"
 
-    def test_whitespace_only_falls_back_to_untitled(self):
+    def test_whitespace_only_falls_back_to_untitled(self):  # noqa: ANN201  # tracked: #288
         assert slugify("   ") == "untitled"
 
-    def test_collapses_multiple_separators(self):
+    def test_collapses_multiple_separators(self):  # noqa: ANN201  # tracked: #288
         assert slugify("foo  BAR___baz") == "foo-bar-baz"
 
-    def test_strips_leading_and_trailing_dashes(self):
+    def test_strips_leading_and_trailing_dashes(self):  # noqa: ANN201  # tracked: #288
         assert slugify("--foo-bar--") == "foo-bar"
 
-    def test_handles_unicode_via_normalisation(self):
+    def test_handles_unicode_via_normalisation(self):  # noqa: ANN201  # tracked: #288
         # em-dash and accented chars should not blow up
         assert slugify("foo  BAR—baz") == "foo-bar-baz"
         assert slugify("café au lait") == "cafe-au-lait"
 
-    def test_truncation_to_max_len(self):
+    def test_truncation_to_max_len(self):  # noqa: ANN201  # tracked: #288
         long_title = "a" * 200
         slug = slugify(long_title)
         assert len(slug) <= 40
 
-    def test_truncation_strips_trailing_dash(self):
+    def test_truncation_strips_trailing_dash(self):  # noqa: ANN201  # tracked: #288
         # 39 letters then a separator, truncated to 40 → "...x-" → strip → "...x"
         title = "abcdefghij" * 4 + "-end"  # 44 chars; truncates inside the dash
         slug = slugify(title)
         assert not slug.endswith("-")
 
-    def test_custom_max_len(self):
+    def test_custom_max_len(self):  # noqa: ANN201  # tracked: #288
         assert slugify("abcdefghij", max_len=5) == "abcde"
 
 
@@ -123,15 +123,15 @@ class TestSlugify:
 
 
 class TestIssueMdFilename:
-    def test_filename_format_uses_zero_padded_id_and_slug(self):
+    def test_filename_format_uses_zero_padded_id_and_slug(self):  # noqa: ANN201  # tracked: #288
         issue = _make_issue(id=7, title="Add streaming completions")
         assert issue_md_filename(issue) == "0007-add-streaming-completions.md"
 
-    def test_filename_for_high_id(self):
+    def test_filename_for_high_id(self):  # noqa: ANN201  # tracked: #288
         issue = _make_issue(id=12345, title="x")
         assert issue_md_filename(issue) == "12345-x.md"
 
-    def test_path_lives_under_issues_dir(self, tmp_path):
+    def test_path_lives_under_issues_dir(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         issue = _make_issue(id=3, title="hello world")
         path = issue_md_path(tmp_path / "issues", issue)
         assert path == tmp_path / "issues" / "0003-hello-world.md"
@@ -143,7 +143,7 @@ class TestIssueMdFilename:
 
 
 class TestRenderIssueMarkdown:
-    def test_writes_header_with_id_title_type_status(self):
+    def test_writes_header_with_id_title_type_status(self):  # noqa: ANN201  # tracked: #288
         issue = _make_issue(
             id=42,
             title="Build server",
@@ -156,13 +156,13 @@ class TestRenderIssueMarkdown:
         assert "**Status**: open" in md
         assert "**Attempts**: 0" in md
 
-    def test_includes_description(self):
+    def test_includes_description(self):  # noqa: ANN201  # tracked: #288
         issue = _make_issue(description="Run a FastAPI server on port 8000.")
         md = render_issue_markdown(issue)
         assert "## Description" in md
         assert "Run a FastAPI server on port 8000." in md
 
-    def test_includes_timeline_with_events(self):
+    def test_includes_timeline_with_events(self):  # noqa: ANN201  # tracked: #288
         issue = _make_issue(
             history=[
                 _make_event(
@@ -185,7 +185,7 @@ class TestRenderIssueMarkdown:
         assert "open->in_progress" in md
         assert "claimed" in md
 
-    def test_renders_implementer_payload_section(self):
+    def test_renders_implementer_payload_section(self):  # noqa: ANN201  # tracked: #288
         issue = _make_issue(
             attempts=1,
             history=[
@@ -211,7 +211,7 @@ class TestRenderIssueMarkdown:
         assert "`tests/test_x.py`" in md
         assert "all green" in md
 
-    def test_renders_judge_payload_section(self):
+    def test_renders_judge_payload_section(self):  # noqa: ANN201  # tracked: #288
         issue = _make_issue(
             history=[
                 _make_event(actor="loop:bootstrap", action="create"),
@@ -236,7 +236,7 @@ class TestRenderIssueMarkdown:
         assert "the endpoint is missing" in md
         assert "add /v1/completions" in md
 
-    def test_judge_event_disambiguated_from_loop_status_change(self):
+    def test_judge_event_disambiguated_from_loop_status_change(self):  # noqa: ANN201  # tracked: #288
         """A loop-actor open->in_progress (claim) must NOT be rendered as a judge review."""
         issue = _make_issue(
             history=[
@@ -256,7 +256,7 @@ class TestRenderIssueMarkdown:
         # And no Attempt detail section if there are no payloads
         assert "## Attempt detail" not in md
 
-    def test_handles_events_without_payload(self):
+    def test_handles_events_without_payload(self):  # noqa: ANN201  # tracked: #288
         """Events with payload=None must render plain timeline rows without raising."""
         issue = _make_issue(
             history=[
@@ -270,7 +270,7 @@ class TestRenderIssueMarkdown:
         # Timeline still mentions it
         assert "attempt" in md
 
-    def test_idempotent_no_duplicate_sections(self, tmp_path):
+    def test_idempotent_no_duplicate_sections(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         issue = _make_issue(
             attempts=1,
             history=[
@@ -291,13 +291,13 @@ class TestRenderIssueMarkdown:
         # Only one occurrence of the heading
         assert second.count("### Implementer attempt 1") == 1
 
-    def test_closed_iter_appears_when_set(self):
+    def test_closed_iter_appears_when_set(self):  # noqa: ANN201  # tracked: #288
         issue = _make_issue(status=IssueStatus.CLOSED)
         issue.closed_iter = 3
         md = render_issue_markdown(issue)
         assert "**Closed at iter**: 3" in md
 
-    def test_long_description_is_not_escaped(self):
+    def test_long_description_is_not_escaped(self):  # noqa: ANN201  # tracked: #288
         """Markdown special chars in the description pass through unmodified
         (matches the existing progress.md behaviour at vibesys/plain/loop.py:147)."""
         issue = _make_issue(description="# A markdown heading\n\n- a list")
@@ -312,12 +312,12 @@ class TestRenderIssueMarkdown:
 
 
 class TestRenderIndexMarkdown:
-    def test_empty_store_renders_placeholder(self):
+    def test_empty_store_renders_placeholder(self):  # noqa: ANN201  # tracked: #288
         md = render_index_markdown([])
         assert "# Issue Index" in md
         assert "no issues yet" in md
 
-    def test_groups_issues_by_status_in_display_order(self):
+    def test_groups_issues_by_status_in_display_order(self):  # noqa: ANN201  # tracked: #288
         issues = [
             _make_issue(id=1, title="open one", status=IssueStatus.OPEN),
             _make_issue(id=2, title="closed one", status=IssueStatus.CLOSED),
@@ -332,12 +332,12 @@ class TestRenderIndexMarkdown:
         cl = md.find("## closed")
         assert -1 < ip < op < bl < cl
 
-    def test_index_links_to_per_issue_files(self):
+    def test_index_links_to_per_issue_files(self):  # noqa: ANN201  # tracked: #288
         issues = [_make_issue(id=7, title="Add streaming")]
         md = render_index_markdown(issues)
         assert "[Add streaming](0007-add-streaming.md)" in md
 
-    def test_within_status_sorted_by_id(self):
+    def test_within_status_sorted_by_id(self):  # noqa: ANN201  # tracked: #288
         issues = [
             _make_issue(id=3, title="three", status=IssueStatus.OPEN),
             _make_issue(id=1, title="one", status=IssueStatus.OPEN),
@@ -350,13 +350,13 @@ class TestRenderIndexMarkdown:
         p3 = md.find("[three]")
         assert -1 < p1 < p2 < p3
 
-    def test_table_columns_present(self):
+    def test_table_columns_present(self):  # noqa: ANN201  # tracked: #288
         issues = [_make_issue(id=1, title="x", attempts=2)]
         md = render_index_markdown(issues)
         assert "| ID | Type | Title | Attempts | Created iter | Updated |" in md
         assert "| 1 |" in md
 
-    def test_pipe_in_title_is_escaped(self):
+    def test_pipe_in_title_is_escaped(self):  # noqa: ANN201  # tracked: #288
         issues = [_make_issue(id=1, title="foo | bar")]
         md = render_index_markdown(issues)
         # Escaped pipe so the markdown table cell still parses as one cell
@@ -369,7 +369,7 @@ class TestRenderIndexMarkdown:
 
 
 class TestRenderAll:
-    def test_render_all_writes_index_and_per_issue_files(self, tmp_path):
+    def test_render_all_writes_index_and_per_issue_files(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = IssueBoard(tmp_path / "issues.json")
         a = store.create(
             type=IssueType.FEATURE,
@@ -408,7 +408,7 @@ class TestRenderAll:
         assert "did stuff" in per_a
         assert "`s.py`" in per_a
 
-    def test_render_all_creates_issues_dir(self, tmp_path):
+    def test_render_all_creates_issues_dir(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = IssueBoard(tmp_path / "issues.json")
         store.create(
             type=IssueType.BUG,
@@ -423,7 +423,7 @@ class TestRenderAll:
         assert issues_dir.is_dir()
         assert (issues_dir / "INDEX.md").is_file()
 
-    def test_render_all_idempotent(self, tmp_path):
+    def test_render_all_idempotent(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = IssueBoard(tmp_path / "issues.json")
         store.create(
             type=IssueType.BUG,

--- a/tests/loops/agent/test_issue_tools.py
+++ b/tests/loops/agent/test_issue_tools.py
@@ -4,18 +4,18 @@ from vibesys.loops.plain.tools import build_issue_tools
 from vs_issue_board import IssueBoard, IssueStatus, IssueType
 
 
-def _make_store(tmp_path) -> IssueBoard:
+def _make_store(tmp_path) -> IssueBoard:  # noqa: ANN001  # tracked: #288
     return IssueBoard(tmp_path / "issues.json")
 
 
-def _tool_by_name(tools, name: str):
+def _tool_by_name(tools, name: str):  # noqa: ANN001, ANN202  # tracked: #288
     for t in tools:
         if t.name == name:
             return t
-    raise AssertionError(f"tool {name!r} not in {[t.name for t in tools]}")
+    raise AssertionError(f"tool {name!r} not in {[t.name for t in tools]}")  # noqa: TRY003  # tracked: #288
 
 
-def _invoke(tool, **kwargs) -> str:
+def _invoke(tool, **kwargs) -> str:  # noqa: ANN001, ANN003  # tracked: #288
     return tool.invoke(kwargs)
 
 
@@ -25,13 +25,13 @@ def _invoke(tool, **kwargs) -> str:
 
 
 class TestReadTools:
-    def test_list_issues_empty_returns_placeholder(self, tmp_path):
+    def test_list_issues_empty_returns_placeholder(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         tools = build_issue_tools(store, iteration=1)
         out = _invoke(_tool_by_name(tools, "list_issues"))
         assert out == "(no issues)"
 
-    def test_list_issues_renders_short_format(self, tmp_path):
+    def test_list_issues_renders_short_format(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         store.create(
             type=IssueType.BUG, title="hello", description="d", created_by="x", iteration=1
@@ -43,7 +43,7 @@ class TestReadTools:
         assert "[open]" in out
         assert "hello" in out
 
-    def test_list_issues_filters_by_status(self, tmp_path):
+    def test_list_issues_filters_by_status(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         store.create(
             type=IssueType.BUG, title="open one", description="d", created_by="x", iteration=1
@@ -58,13 +58,13 @@ class TestReadTools:
         assert "open one" in opens
         assert "closed one" not in opens
 
-    def test_list_issues_invalid_status_returns_error(self, tmp_path):
+    def test_list_issues_invalid_status_returns_error(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         tools = build_issue_tools(store, iteration=1)
         out = _invoke(_tool_by_name(tools, "list_issues"), status="banana")
         assert out.startswith("error:")
 
-    def test_get_issue_by_id(self, tmp_path):
+    def test_get_issue_by_id(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         store.create(
             type=IssueType.PERF,
@@ -80,13 +80,13 @@ class TestReadTools:
         assert "reduce frag" in out
         assert "type: perf" in out
 
-    def test_get_issue_unknown_id_returns_placeholder(self, tmp_path):
+    def test_get_issue_unknown_id_returns_placeholder(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         tools = build_issue_tools(store, iteration=1)
         out = _invoke(_tool_by_name(tools, "get_issue"), issue_id=999)
         assert out == "(no issue #999)"
 
-    def test_search_issues_returns_matches(self, tmp_path):
+    def test_search_issues_returns_matches(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         store.create(
             type=IssueType.PERF, title="Add paged KV", description="d", created_by="x", iteration=1
@@ -99,7 +99,7 @@ class TestReadTools:
         assert "Add paged KV" in out
         assert "unrelated" not in out
 
-    def test_search_issues_no_matches(self, tmp_path):
+    def test_search_issues_no_matches(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         store.create(type=IssueType.BUG, title="hi", description="d", created_by="x", iteration=1)
         tools = build_issue_tools(store, iteration=1)
@@ -113,13 +113,13 @@ class TestReadTools:
 
 
 class TestSubsetRouting:
-    def test_implementer_subset_excludes_create(self, tmp_path):
+    def test_implementer_subset_excludes_create(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         tools = build_issue_tools(store, iteration=1, can_create=False)
         names = {t.name for t in tools}
         assert names == {"list_issues", "get_issue", "search_issues"}
 
-    def test_judge_subset_includes_create(self, tmp_path):
+    def test_judge_subset_includes_create(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         tools = build_issue_tools(
             store,
@@ -132,7 +132,7 @@ class TestSubsetRouting:
         names = {t.name for t in tools}
         assert "create_issue" in names
 
-    def test_perf_eval_subset_includes_create(self, tmp_path):
+    def test_perf_eval_subset_includes_create(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         tools = build_issue_tools(
             store,
@@ -151,7 +151,7 @@ class TestSubsetRouting:
 
 
 class TestCreateIssue:
-    def test_create_issue_happy_path_returns_id(self, tmp_path):
+    def test_create_issue_happy_path_returns_id(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         tools = build_issue_tools(
             store,
@@ -171,7 +171,7 @@ class TestCreateIssue:
         assert store.get(1).created_by == "perf_eval"
         assert store.get(1).created_iter == 1
 
-    def test_create_issue_invalid_type_returns_error_string(self, tmp_path):
+    def test_create_issue_invalid_type_returns_error_string(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         tools = build_issue_tools(
             store,
@@ -191,7 +191,7 @@ class TestCreateIssue:
         # No issue should have been created
         assert len(store.list()) == 0
 
-    def test_create_issue_caps_at_three_per_iteration(self, tmp_path):
+    def test_create_issue_caps_at_three_per_iteration(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         tools = build_issue_tools(
             store,
@@ -211,7 +211,7 @@ class TestCreateIssue:
         # Store still has only 3
         assert len(store.list()) == 3
 
-    def test_create_issue_cap_resets_per_iteration(self, tmp_path):
+    def test_create_issue_cap_resets_per_iteration(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         # iteration 1 — fill cap
         iter1_tools = build_issue_tools(
@@ -237,7 +237,7 @@ class TestCreateIssue:
         assert out.startswith("created issue #")
         assert len(store.list()) == 4
 
-    def test_create_issue_allowed_types_filter(self, tmp_path):
+    def test_create_issue_allowed_types_filter(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         # Judge subset: only bug type allowed.
         store = _make_store(tmp_path)
         tools = build_issue_tools(
@@ -257,7 +257,7 @@ class TestCreateIssue:
         ok = _invoke(create, type="bug", title="b", description="d")
         assert ok.startswith("created issue #")
 
-    def test_judge_create_cap_is_one(self, tmp_path):
+    def test_judge_create_cap_is_one(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         tools = build_issue_tools(
             store,
@@ -274,7 +274,7 @@ class TestCreateIssue:
         assert rejected.startswith("error:")
         assert "cap reached" in rejected
 
-    def test_create_issue_unlimited_cap_when_none(self, tmp_path):
+    def test_create_issue_unlimited_cap_when_none(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         tools = build_issue_tools(
             store,

--- a/tests/loops/agent/test_kv_store_modality.py
+++ b/tests/loops/agent/test_kv_store_modality.py
@@ -12,18 +12,18 @@ _TEMPLATE_DIR = PROMPTS_DIR / "loops" / "agent"
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
-def test_kv_store_is_a_registered_modality():
+def test_kv_store_is_a_registered_modality():  # noqa: ANN201  # tracked: #288
     assert "kv_store" in _MODALITIES
 
 
-def test_kv_store_input_bundle_loads():
+def test_kv_store_input_bundle_loads():  # noqa: ANN201  # tracked: #288
     bundle = load_input_bundle(_PROJECT_ROOT / "examples" / "kv-store", project_root=_PROJECT_ROOT)
     assert bundle.domain.value == "generic"
     assert bundle.benchmark_result is not None
     assert bundle.benchmark_result.metric == "throughput_ops_per_sec"
 
 
-def test_kv_store_judge_prompt_mentions_resp2_not_http():
+def test_kv_store_judge_prompt_mentions_resp2_not_http():  # noqa: ANN201  # tracked: #288
     output = render_template(
         "judge_prompt.j2",
         template_dir=_TEMPLATE_DIR,
@@ -32,7 +32,7 @@ def test_kv_store_judge_prompt_mentions_resp2_not_http():
         domain_judge="",
         accuracy_command="uv run python accuracy_checker/checker.py",
         benchmark_command="uv run python benchmark/benchmark.py",
-        pass_criteria="PC",
+        pass_criteria="PC",  # noqa: S106  # tracked: #288
         retry=1,
         runtime_notes="",
         profile_execution="local",

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -53,7 +53,7 @@ from vibesys.schemas import (
 # ---------------------------------------------------------------------------
 
 
-def test_missing_implementer_response_fails_closed():
+def test_missing_implementer_response_fails_closed():  # noqa: ANN201  # tracked: #288
     response = _missing_implementer_response()
 
     assert response.hypothesis_outcome is HypothesisOutcome.INCONCLUSIVE
@@ -62,11 +62,11 @@ def test_missing_implementer_response_fails_closed():
     assert "schema-valid" in response.next_step
 
 
-def test_legacy_active_hypothesis_backfills_framework_revert_commit():
+def test_legacy_active_hypothesis_backfills_framework_revert_commit():  # noqa: ANN201  # tracked: #288
     state = _ActiveHypothesis(
         plan=OrchestratorPlan(
             task="restore parent",
-            pass_criteria="review",
+            pass_criteria="review",  # noqa: S106  # tracked: #288
             revert_to_round=28,
             reasoning="resume an older run",
         ),
@@ -89,7 +89,7 @@ def test_legacy_active_hypothesis_backfills_framework_revert_commit():
     assert _backfill_revert_commit(state, records) is False
 
 
-def test_failed_child_rollback_preserves_its_exact_parent_commit():
+def test_failed_child_rollback_preserves_its_exact_parent_commit():  # noqa: ANN201  # tracked: #288
     historical_parent = _RoundRecord(
         round_number=20,
         commit="a" * 40,
@@ -116,7 +116,7 @@ def test_failed_child_rollback_preserves_its_exact_parent_commit():
     assert child_round == 21
 
 
-def test_distant_rollback_uses_requested_historical_commit():
+def test_distant_rollback_uses_requested_historical_commit():  # noqa: ANN201  # tracked: #288
     historical_parent = _RoundRecord(
         round_number=5,
         commit="a" * 40,
@@ -144,7 +144,7 @@ def test_distant_rollback_uses_requested_historical_commit():
 
 
 @pytest.fixture
-def ref_file(tmp_path):
+def ref_file(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Create a reference *file* (not dir) + an OBJECTIVE.md sibling.
 
     Using a single file avoids the model-weight lookup that a reference
@@ -173,7 +173,7 @@ command = ["uv", "run", "python", "benchmark/benchmark.py"]
     return str(ref)
 
 
-def _make_orchestrate_runner(
+def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     *,
     pre_decisions: list[PreRoundDecision] | None = None,
     plans: list[OrchestratorPlan] | None = None,
@@ -206,7 +206,7 @@ def _make_orchestrate_runner(
     runner = MagicMock(spec=AgentRunner)
     runner.backend_name = "deepagents"
 
-    def _invoke(*, kind, response_cls, fallback_factory, **kwargs):
+    def _invoke(*, kind, response_cls, fallback_factory, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001, PLR0911  # tracked: #288
         if kind == "orchestrator" and response_cls is PreRoundDecision:
             counters["orch_pre"] += 1
             if pre_q:
@@ -218,7 +218,7 @@ def _make_orchestrate_runner(
                 return plan_q.pop(0)
             return OrchestratorPlan(
                 task="noop (harness default)",
-                pass_criteria="no criteria",
+                pass_criteria="no criteria",  # noqa: S106  # tracked: #288
                 reasoning="default noop plan — the loop's max_rounds bounds the test",
             )
         if kind == "implementer":
@@ -274,17 +274,17 @@ def _make_orchestrate_runner(
                 bottlenecks="none",
                 suggestions="none",
             )
-        raise AssertionError(f"unexpected kind: {kind}, response_cls={response_cls}")
+        raise AssertionError(f"unexpected kind: {kind}, response_cls={response_cls}")  # noqa: TRY003  # tracked: #288
 
     runner.invoke.side_effect = _invoke
     runner.counters = counters  # test introspection
     return runner
 
 
-def _invoke_orchestrate(tmp_path, ref_file, runner, **kwargs):
+def _invoke_orchestrate(tmp_path, ref_file, runner, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
     """Shared plumbing: patch context globals, run the loop, return result."""
     accuracy_gate_results = kwargs.pop("_accuracy_gate_results", None)
-    defaults = dict(
+    defaults = dict(  # noqa: C408  # tracked: #288
         config={"model": {"name": "claude-sonnet-4-6"}},
         exp_name="test-orch",
         input_path=str(Path(ref_file).parent),
@@ -315,7 +315,7 @@ def _invoke_orchestrate(tmp_path, ref_file, runner, **kwargs):
 # ---------------------------------------------------------------------------
 
 
-def test_validation_recipe_rejects_non_workspace_inputs():
+def test_validation_recipe_rejects_non_workspace_inputs():  # noqa: ANN201  # tracked: #288
     with pytest.raises(ValueError, match="workspace-relative"):
         ValidationRecipe(
             name="focused-tests",
@@ -325,7 +325,7 @@ def test_validation_recipe_rejects_non_workspace_inputs():
         )
 
 
-def test_validation_recipe_artifact_rejects_invented_top_level_shape():
+def test_validation_recipe_artifact_rejects_invented_top_level_shape():  # noqa: ANN201  # tracked: #288
     with pytest.raises(ValueError, match="recipes"):
         ValidationRecipeArtifact.model_validate(
             {
@@ -340,7 +340,7 @@ def test_validation_recipe_artifact_rejects_invented_top_level_shape():
         )
 
 
-def test_issue_board_publishes_authoritative_validation_recipe_schema(tmp_path):
+def test_issue_board_publishes_authoritative_validation_recipe_schema(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     progress = tmp_path / "progress"
 
     path = issue_board.write_validation_recipe_schema(progress)
@@ -353,13 +353,15 @@ def test_issue_board_publishes_authoritative_validation_recipe_schema(tmp_path):
     assert schema["examples"][0]["recipes"][0]["name"] == "focused-tests"
 
 
-def test_read_only_role_reverts_workspace_mutations_and_keeps_response():
+def test_read_only_role_reverts_workspace_mutations_and_keeps_response():  # noqa: ANN201  # tracked: #288
     ctx = MagicMock()
     ctx.git.current_sha.return_value = "a" * 40
     ctx.git.pending_changes.side_effect = [["roadmap/index.md", "scratch.txt"], []]
     ctx.git.checkout_tree.return_value = True
     expected = OrchestratorPlan(
-        task="next", pass_criteria="passes", reasoning="evidence supports next"
+        task="next",
+        pass_criteria="passes",  # noqa: S106  # tracked: #288
+        reasoning="evidence supports next",  # noqa: RUF100, S106  # tracked: #288
     )
     ctx.invoke.return_value = expected
 
@@ -380,7 +382,7 @@ def test_read_only_role_reverts_workspace_mutations_and_keeps_response():
     ctx.lprint.assert_called_once()
 
 
-def test_read_only_role_does_not_restore_clean_turn():
+def test_read_only_role_does_not_restore_clean_turn():  # noqa: ANN201  # tracked: #288
     ctx = MagicMock()
     ctx.git.current_sha.return_value = "b" * 40
     ctx.git.pending_changes.return_value = []
@@ -403,21 +405,23 @@ def test_read_only_role_does_not_restore_clean_turn():
     ctx.lprint.assert_not_called()
 
 
-def test_read_only_role_preserves_allowed_roadmap_and_reverts_other_writes(tmp_path):
+def test_read_only_role_preserves_allowed_roadmap_and_reverts_other_writes(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     experiment = tmp_path / "experiment"
     workspace = experiment / "workspace"
     roadmap = workspace / "roadmap" / "index.md"
     roadmap.parent.mkdir(parents=True)
     roadmap.write_text("initial roadmap\n")
-    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)  # noqa: S607  # tracked: #288
     tracker = GitTracker(workspace, log=lambda _message: None)
     tracker.init(existing=False)
 
     expected = OrchestratorPlan(
-        task="next", pass_criteria="passes", reasoning="evidence supports next"
+        task="next",
+        pass_criteria="passes",  # noqa: S106  # tracked: #288
+        reasoning="evidence supports next",  # noqa: RUF100, S106  # tracked: #288
     )
 
-    def invoke(**_kwargs):
+    def invoke(**_kwargs):  # noqa: ANN003, ANN202  # tracked: #288
         roadmap.write_text("updated roadmap\n")
         (workspace / "main.py").write_text("unauthorized candidate edit\n")
         return expected
@@ -450,19 +454,19 @@ def test_read_only_role_preserves_allowed_roadmap_and_reverts_other_writes(tmp_p
     assert any("main.py" in line for line in logs)
 
 
-def test_read_only_role_preserves_allowed_directory_and_reverts_candidate_edits(tmp_path):
+def test_read_only_role_preserves_allowed_directory_and_reverts_candidate_edits(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     experiment = tmp_path / "experiment"
     workspace = experiment / "workspace"
     workspace.mkdir(parents=True)
     main = workspace / "main.py"
     main.write_text("accepted candidate\n")
-    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)  # noqa: S607  # tracked: #288
     tracker = GitTracker(workspace, log=lambda _message: None)
     tracker.init(existing=False)
 
     expected = ProfilerSummary(analysis="done", bottlenecks="b", suggestions="s")
 
-    def invoke(**_kwargs):
+    def invoke(**_kwargs):  # noqa: ANN003, ANN202  # tracked: #288
         main.write_text("profiler instrumentation\n")
         artifact = workspace / "progress" / "profiles" / "round-0002" / "summary.json"
         artifact.parent.mkdir(parents=True)
@@ -497,28 +501,28 @@ def test_read_only_role_preserves_allowed_directory_and_reverts_candidate_edits(
     assert any("main.py" in line for line in logs)
 
 
-def test_pre_round_decision_accepts_booleans():
+def test_pre_round_decision_accepts_booleans():  # noqa: ANN201  # tracked: #288
     d = PreRoundDecision(need_profile=True, profile_focus="decode kernels", reasoning="ok")
     assert d.need_profile is True
     assert d.profile_focus == "decode kernels"
 
 
-def test_orchestrator_plan_revert_round_optional():
+def test_orchestrator_plan_revert_round_optional():  # noqa: ANN201  # tracked: #288
     p = OrchestratorPlan(
         task="redo",
-        pass_criteria="passes tests",
+        pass_criteria="passes tests",  # noqa: S106  # tracked: #288
         revert_to_round=3,
         reasoning="step back",
     )
     assert p.revert_to_round == 3
 
 
-def test_official_evaluation_cadence_counts_candidate_checkpoints_not_rounds():
+def test_official_evaluation_cadence_counts_candidate_checkpoints_not_rounds():  # noqa: ANN201  # tracked: #288
     records = [
-        _RoundRecord(1, "a", None, None, False, reviewed=False, hypothesis_outcome="continue"),
-        _RoundRecord(2, "b", None, None, True, reviewed=True, hypothesis_outcome="proven"),
-        _RoundRecord(3, "c", None, None, False, reviewed=True, hypothesis_outcome="rejected"),
-        _RoundRecord(4, "d", None, None, True, reviewed=True, hypothesis_outcome="proven"),
+        _RoundRecord(1, "a", None, None, False, reviewed=False, hypothesis_outcome="continue"),  # noqa: FBT003  # tracked: #288
+        _RoundRecord(2, "b", None, None, True, reviewed=True, hypothesis_outcome="proven"),  # noqa: FBT003  # tracked: #288
+        _RoundRecord(3, "c", None, None, False, reviewed=True, hypothesis_outcome="rejected"),  # noqa: FBT003  # tracked: #288
+        _RoundRecord(4, "d", None, None, True, reviewed=True, hypothesis_outcome="proven"),  # noqa: FBT003  # tracked: #288
     ]
 
     assert _provisional_candidates_since_official(records) == 2
@@ -535,7 +539,7 @@ def test_official_evaluation_cadence_counts_candidate_checkpoints_not_rounds():
     )
 
 
-def test_frontier_candidate_forces_review_outside_sparse_cadence():
+def test_frontier_candidate_forces_review_outside_sparse_cadence():  # noqa: ANN201  # tracked: #288
     assert _review_due(
         round_number=5,
         max_rounds=20,
@@ -545,7 +549,7 @@ def test_frontier_candidate_forces_review_outside_sparse_cadence():
     )
 
 
-def test_measured_candidate_forces_review_even_when_disposition_is_downgraded():
+def test_measured_candidate_forces_review_even_when_disposition_is_downgraded():  # noqa: ANN201  # tracked: #288
     assert _review_due(
         round_number=5,
         max_rounds=20,
@@ -555,7 +559,7 @@ def test_measured_candidate_forces_review_even_when_disposition_is_downgraded():
     )
 
 
-def test_reused_candidate_evidence_does_not_bypass_sparse_review():
+def test_reused_candidate_evidence_does_not_bypass_sparse_review():  # noqa: ANN201  # tracked: #288
     metrics = {"throughput": 6205.0, "latency": 10660.0}
     record = _RoundRecord(
         round_number=75,
@@ -588,7 +592,7 @@ def test_reused_candidate_evidence_does_not_bypass_sparse_review():
     )
 
 
-def test_changed_candidate_row_is_fresh_even_when_artifact_name_is_reused():
+def test_changed_candidate_row_is_fresh_even_when_artifact_name_is_reused():  # noqa: ANN201  # tracked: #288
     record = _RoundRecord(
         round_number=4,
         commit="a" * 40,
@@ -610,14 +614,14 @@ def test_changed_candidate_row_is_fresh_even_when_artifact_name_is_reused():
     assert _candidate_evidence_is_fresh(implementation, [record])
 
 
-def test_official_evaluation_cadence_counts_reviewed_frontier_tradeoff():
+def test_official_evaluation_cadence_counts_reviewed_frontier_tradeoff():  # noqa: ANN201  # tracked: #288
     records = [
         _RoundRecord(
             2,
             "b",
             None,
             None,
-            True,
+            True,  # noqa: FBT003  # tracked: #288
             reviewed=True,
             hypothesis_outcome="disproven",
             candidate_disposition=CandidateDisposition.PARETO_FRONTIER.value,
@@ -628,7 +632,7 @@ def test_official_evaluation_cadence_counts_reviewed_frontier_tradeoff():
     assert _provisional_candidates_since_official(records) == 1
 
 
-def test_noise_aware_dominance_preserves_sub_noise_alternatives():
+def test_noise_aware_dominance_preserves_sub_noise_alternatives():  # noqa: ANN201  # tracked: #288
     objectives = [Objective("throughput", "max"), Objective("latency", "min")]
 
     assert not _noise_aware_dominates(
@@ -645,7 +649,7 @@ def test_noise_aware_dominance_preserves_sub_noise_alternatives():
     )
 
 
-def test_pareto_frontier_keeps_throughput_latency_tradeoff_and_drops_dominated_point():
+def test_pareto_frontier_keeps_throughput_latency_tradeoff_and_drops_dominated_point():  # noqa: ANN201  # tracked: #288
     objectives = [Objective("throughput", "max"), Objective("latency", "min")]
 
     def candidate(round_number: int, throughput: float, latency: float) -> _RoundRecord:
@@ -654,7 +658,7 @@ def test_pareto_frontier_keeps_throughput_latency_tradeoff_and_drops_dominated_p
             str(round_number) * 40,
             None,
             None,
-            True,
+            True,  # noqa: FBT003  # tracked: #288
             reviewed=True,
             candidate_disposition=CandidateDisposition.PARETO_FRONTIER.value,
             candidate_metrics={"throughput": throughput, "latency": latency},
@@ -671,8 +675,8 @@ def test_pareto_frontier_keeps_throughput_latency_tradeoff_and_drops_dominated_p
     assert [record.round_number for record in frontier] == [1, 2]
 
 
-def test_live_archive_rejects_stale_frontier_claim_for_dominated_candidate():
-    from vibesys.loops.agent.loop import _pareto_archive_conflict
+def test_live_archive_rejects_stale_frontier_claim_for_dominated_candidate():  # noqa: ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import _pareto_archive_conflict  # noqa: PLC0415  # tracked: #288
 
     objectives = [Objective("throughput", "max"), Objective("latency", "min")]
     trusted = _RoundRecord(
@@ -680,7 +684,7 @@ def test_live_archive_rejects_stale_frontier_claim_for_dominated_candidate():
         "a" * 40,
         None,
         None,
-        True,
+        True,  # noqa: FBT003  # tracked: #288
         reviewed=True,
         candidate_disposition=CandidateDisposition.PARETO_FRONTIER.value,
         candidate_metrics={"throughput": 8795.8, "latency": 7724.0},
@@ -698,8 +702,8 @@ def test_live_archive_rejects_stale_frontier_claim_for_dominated_candidate():
     assert "frozen into the hypothesis plan" in conflict
 
 
-def test_live_archive_preserves_real_throughput_latency_tradeoff():
-    from vibesys.loops.agent.loop import _pareto_archive_conflict
+def test_live_archive_preserves_real_throughput_latency_tradeoff():  # noqa: ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import _pareto_archive_conflict  # noqa: PLC0415  # tracked: #288
 
     objectives = [Objective("throughput", "max"), Objective("latency", "min")]
     trusted = _RoundRecord(
@@ -707,7 +711,7 @@ def test_live_archive_preserves_real_throughput_latency_tradeoff():
         "a" * 40,
         None,
         None,
-        True,
+        True,  # noqa: FBT003  # tracked: #288
         reviewed=True,
         candidate_disposition=CandidateDisposition.PARETO_FRONTIER.value,
         candidate_metrics={"throughput": 100.0, "latency": 80.0},
@@ -724,14 +728,14 @@ def test_live_archive_preserves_real_throughput_latency_tradeoff():
     )
 
 
-def test_pareto_archive_distinguishes_trusted_and_pending_candidates():
+def test_pareto_archive_distinguishes_trusted_and_pending_candidates():  # noqa: ANN201  # tracked: #288
     objectives = [Objective("throughput", "max"), Objective("latency", "min")]
     trusted = _RoundRecord(
         49,
         "a" * 40,
         None,
         None,
-        True,
+        True,  # noqa: FBT003  # tracked: #288
         reviewed=True,
         candidate_disposition=CandidateDisposition.PARETO_FRONTIER.value,
         candidate_metrics={"throughput": 5307.2, "latency": 3289.7},
@@ -743,7 +747,7 @@ def test_pareto_archive_distinguishes_trusted_and_pending_candidates():
         "b" * 40,
         None,
         None,
-        False,
+        False,  # noqa: FBT003  # tracked: #288
         reviewed=False,
         candidate_disposition=CandidateDisposition.PARETO_FRONTIER.value,
         candidate_metrics={"throughput": 6827.7, "latency": 3628.7},
@@ -760,20 +764,20 @@ def test_pareto_archive_distinguishes_trusted_and_pending_candidates():
     assert "round 51" in summary
 
 
-def test_official_evaluation_cadence_resets_at_verified_checkpoint():
+def test_official_evaluation_cadence_resets_at_verified_checkpoint():  # noqa: ANN201  # tracked: #288
     records = [
         _RoundRecord(
             1,
             "a",
             10.0,
             "tok/s",
-            True,
+            True,  # noqa: FBT003  # tracked: #288
             reviewed=True,
             hypothesis_outcome="proven",
             official_evaluation=True,
             official_evaluation_reason="orchestrator_request",
         ),
-        _RoundRecord(2, "b", None, None, True, reviewed=True, hypothesis_outcome="proven"),
+        _RoundRecord(2, "b", None, None, True, reviewed=True, hypothesis_outcome="proven"),  # noqa: FBT003  # tracked: #288
     ]
 
     assert _provisional_candidates_since_official(records) == 1
@@ -790,15 +794,15 @@ def test_official_evaluation_cadence_resets_at_verified_checkpoint():
     )
 
 
-def test_terminal_workspace_notice_points_designer_to_hypothesis_parent():
+def test_terminal_workspace_notice_points_designer_to_hypothesis_parent():  # noqa: ANN201  # tracked: #288
     records = [
-        _RoundRecord(28, "a" * 40, None, None, False),
+        _RoundRecord(28, "a" * 40, None, None, False),  # noqa: FBT003  # tracked: #288
         _RoundRecord(
             29,
             "b" * 40,
             None,
             None,
-            False,
+            False,  # noqa: FBT003  # tracked: #288
             reviewed=True,
             hypothesis_id="bad-scheduler",
             hypothesis_outcome="rejected",
@@ -808,7 +812,7 @@ def test_terminal_workspace_notice_points_designer_to_hypothesis_parent():
             "c" * 40,
             None,
             None,
-            False,
+            False,  # noqa: FBT003  # tracked: #288
             reviewed=False,
             hypothesis_id="bad-scheduler",
             hypothesis_outcome="disproven",
@@ -824,13 +828,13 @@ def test_terminal_workspace_notice_points_designer_to_hypothesis_parent():
     assert "revert_to_round=28" in notice
 
 
-def test_terminal_workspace_notice_preserves_pareto_tradeoff_commit():
+def test_terminal_workspace_notice_preserves_pareto_tradeoff_commit():  # noqa: ANN201  # tracked: #288
     record = _RoundRecord(
         51,
         "b" * 40,
         None,
         None,
-        False,
+        False,  # noqa: FBT003  # tracked: #288
         reviewed=False,
         hypothesis_id="capacity-192",
         hypothesis_outcome="disproven",
@@ -846,15 +850,15 @@ def test_terminal_workspace_notice_preserves_pareto_tradeoff_commit():
     assert "do not erase a credible throughput/latency tradeoff" in notice
 
 
-def test_terminal_workspace_notice_preserves_credible_continuation_checkpoint():
+def test_terminal_workspace_notice_preserves_credible_continuation_checkpoint():  # noqa: ANN201  # tracked: #288
     records = [
-        _RoundRecord(28, "a" * 40, None, None, False),
+        _RoundRecord(28, "a" * 40, None, None, False),  # noqa: FBT003  # tracked: #288
         _RoundRecord(
             34,
             "b" * 40,
             None,
             None,
-            False,
+            False,  # noqa: FBT003  # tracked: #288
             reviewed=False,
             hypothesis_id="host-autopsy",
             hypothesis_outcome="continue",
@@ -865,7 +869,7 @@ def test_terminal_workspace_notice_preserves_credible_continuation_checkpoint():
             "c" * 40,
             None,
             None,
-            False,
+            False,  # noqa: FBT003  # tracked: #288
             reviewed=False,
             hypothesis_id="host-autopsy",
             hypothesis_outcome="continue",
@@ -876,7 +880,7 @@ def test_terminal_workspace_notice_preserves_credible_continuation_checkpoint():
             "d" * 40,
             None,
             None,
-            True,
+            True,  # noqa: FBT003  # tracked: #288
             reviewed=True,
             hypothesis_id="host-autopsy",
             hypothesis_outcome="disproven",
@@ -893,15 +897,15 @@ def test_terminal_workspace_notice_preserves_credible_continuation_checkpoint():
     assert "An older implementation cannot be required to reproduce" in notice
 
 
-def test_terminal_workspace_notice_keeps_original_parent_after_same_id_reproposal():
+def test_terminal_workspace_notice_keeps_original_parent_after_same_id_reproposal():  # noqa: ANN201  # tracked: #288
     records = [
-        _RoundRecord(60, "a" * 40, None, None, True),
+        _RoundRecord(60, "a" * 40, None, None, True),  # noqa: FBT003  # tracked: #288
         _RoundRecord(
             61,
             "b" * 40,
             None,
             None,
-            True,
+            True,  # noqa: FBT003  # tracked: #288
             reviewed=True,
             hypothesis_id="quantum-decode",
             hypothesis_outcome="implementation_failed",
@@ -912,7 +916,7 @@ def test_terminal_workspace_notice_keeps_original_parent_after_same_id_reproposa
             "c" * 40,
             None,
             None,
-            True,
+            True,  # noqa: FBT003  # tracked: #288
             reviewed=True,
             hypothesis_id="quantum-decode",
             hypothesis_outcome="blocked",
@@ -923,7 +927,7 @@ def test_terminal_workspace_notice_keeps_original_parent_after_same_id_reproposa
             "d" * 40,
             None,
             None,
-            True,
+            True,  # noqa: FBT003  # tracked: #288
             reviewed=True,
             hypothesis_id="quantum-decode",
             hypothesis_outcome="inconclusive",
@@ -939,7 +943,7 @@ def test_terminal_workspace_notice_keeps_original_parent_after_same_id_reproposa
     assert "recorded pre-hypothesis parent is round 62" not in notice
 
 
-def test_profiler_summary_perf_metric_optional():
+def test_profiler_summary_perf_metric_optional():  # noqa: ANN201  # tracked: #288
     p = ProfilerSummary(analysis="a", bottlenecks="b", suggestions="s")
     assert p.perf_metric is None
     p2 = ProfilerSummary(
@@ -958,11 +962,11 @@ def test_profiler_summary_perf_metric_optional():
 # ---------------------------------------------------------------------------
 
 
-def test_progress_writes_orchestrator_plan(tmp_path):
+def test_progress_writes_orchestrator_plan(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     progress = tmp_path / "progress.md"
     plan = OrchestratorPlan(
         task="Build FastAPI server",
-        pass_criteria="/health returns 200",
+        pass_criteria="/health returns 200",  # noqa: S106  # tracked: #288
         reasoning="Round 1 cold start",
         expected_effect="Forecast 1.3x to 1.6x throughput",
         minimum_acceptance_criteria="Retain at >=1.15x with no latency regression",
@@ -980,12 +984,12 @@ def test_progress_writes_orchestrator_plan(tmp_path):
     ("progress_name", "artifact_root"),
     [("progress", "progress"), ("progress.md", "progress-artifacts")],
 )
-def test_progress_writes_typed_role_handoffs_atomically(tmp_path, progress_name, artifact_root):
+def test_progress_writes_typed_role_handoffs_atomically(tmp_path, progress_name, artifact_root):  # noqa: ANN001, ANN201  # tracked: #288
     progress = tmp_path / progress_name
     plan = OrchestratorPlan(
         hypothesis_id="transport-boundary",
         task="Replace the request-local queue.",
-        pass_criteria="The direct path activates.",
+        pass_criteria="The direct path activates.",  # noqa: S106  # tracked: #288
         reasoning="The retained profile leaves a service residual.",
     )
     implementation = ImplementerResponse(
@@ -1006,7 +1010,7 @@ def test_progress_writes_typed_role_handoffs_atomically(tmp_path, progress_name,
     assert not list((tmp_path / artifact_root).rglob(".*.tmp*"))
 
 
-def test_persisted_implementer_attempts_define_resume_boundary(tmp_path):
+def test_persisted_implementer_attempts_define_resume_boundary(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     progress = tmp_path / "progress"
     implementation = ImplementerResponse(
         summary="Retained the first target run.",
@@ -1020,7 +1024,7 @@ def test_persisted_implementer_attempts_define_resume_boundary(tmp_path):
     assert issue_board.next_implementer_attempt(progress, 9) == 1
 
 
-def test_agent_memory_paths_distinguish_files_from_directories(tmp_path):
+def test_agent_memory_paths_distinguish_files_from_directories(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     workspace = tmp_path / "workspace"
     directory = workspace / "progress"
     artifact = directory / "plans" / "round-0012.json"
@@ -1031,7 +1035,7 @@ def test_agent_memory_paths_distinguish_files_from_directories(tmp_path):
     assert issue_board.display_path(artifact, workspace) == "progress/plans/round-0012.json"
 
 
-def test_progress_replaces_interrupted_stage_instead_of_duplicating_it(tmp_path):
+def test_progress_replaces_interrupted_stage_instead_of_duplicating_it(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     progress = tmp_path / "progress"
     issue_board.append_pre_round_decision(
         progress,
@@ -1047,7 +1051,7 @@ def test_progress_replaces_interrupted_stage_instead_of_duplicating_it(tmp_path)
         7,
         OrchestratorPlan(
             task="Keep this plan",
-            pass_criteria="plan remains",
+            pass_criteria="plan remains",  # noqa: S106  # tracked: #288
             reasoning="retained plan",
         ),
     )
@@ -1070,7 +1074,7 @@ def test_progress_replaces_interrupted_stage_instead_of_duplicating_it(tmp_path)
     assert "Keep this plan" in text
 
 
-def test_progress_replacement_preserves_operator_recovery_section(tmp_path):
+def test_progress_replacement_preserves_operator_recovery_section(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     progress = tmp_path / "progress"
     issue_board.append_hypothesis_continuation(
         progress,
@@ -1079,7 +1083,7 @@ def test_progress_replacement_preserves_operator_recovery_section(tmp_path):
             hypothesis_id="transport",
             hypothesis="remove queue fanout",
             task="stale initial implementation task",
-            pass_criteria="source is recoverable",
+            pass_criteria="source is recoverable",  # noqa: S106  # tracked: #288
             reasoning="continue interrupted work",
         ),
         started_round=6,
@@ -1099,7 +1103,7 @@ def test_progress_replacement_preserves_operator_recovery_section(tmp_path):
             hypothesis_id="transport",
             hypothesis="remove queue fanout",
             task="stale initial implementation task",
-            pass_criteria="source is recoverable",
+            pass_criteria="source is recoverable",  # noqa: S106  # tracked: #288
             reasoning="resume interrupted work",
         ),
         started_round=6,
@@ -1116,7 +1120,7 @@ def test_progress_replacement_preserves_operator_recovery_section(tmp_path):
     assert "Exact measured bytes are retained" in text
 
 
-def test_progress_preserves_distinct_attempts_but_replaces_same_attempt(tmp_path):
+def test_progress_preserves_distinct_attempts_but_replaces_same_attempt(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     progress = tmp_path / "progress.md"
     issue_board.append_implementer(
         progress,
@@ -1145,7 +1149,7 @@ def test_progress_preserves_distinct_attempts_but_replaces_same_attempt(tmp_path
     assert "retry" in text
 
 
-def test_progress_writes_profiler_summary_with_perf(tmp_path):
+def test_progress_writes_profiler_summary_with_perf(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     progress = tmp_path / "progress.md"
     summary = ProfilerSummary(
         analysis="launch-bound",
@@ -1161,7 +1165,7 @@ def test_progress_writes_profiler_summary_with_perf(tmp_path):
     assert "flashinfer" in text
 
 
-def test_progress_append_implementer_and_judge(tmp_path):
+def test_progress_append_implementer_and_judge(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     progress = tmp_path / "progress.md"
     issue_board.append_implementer(
         progress,
@@ -1181,7 +1185,7 @@ def test_progress_append_implementer_and_judge(tmp_path):
     assert "verdict**: pass" in text
 
 
-def test_directory_memory_layout_splits_rounds_and_bounds_reads(tmp_path):
+def test_directory_memory_layout_splits_rounds_and_bounds_reads(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     roadmap, progress = issue_board.resolve_paths(tmp_path, "directories")
     issue_board.ensure_roadmap_file(roadmap)
     for round_number in range(1, 16):
@@ -1204,8 +1208,10 @@ def test_directory_memory_layout_splits_rounds_and_bounds_reads(tmp_path):
     assert "## Round 15 —" in recent
 
 
-def test_framework_accuracy_gate_runs_manifest_command_and_records_pass(tmp_path):
-    from vibesys.loops.agent.loop import _run_framework_accuracy_gate
+def test_framework_accuracy_gate_runs_manifest_command_and_records_pass(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
+        _run_framework_accuracy_gate,
+    )
 
     ctx = MagicMock()
     ctx.trusted_input_changes.return_value = []
@@ -1229,7 +1235,7 @@ def test_framework_accuracy_gate_runs_manifest_command_and_records_pass(tmp_path
     ctx.snapshot_workspace.assert_called_once_with("round-2-retry-1-framework-accuracy")
 
 
-def test_framework_local_validation_executes_and_reuses_exact_inputs(tmp_path):
+def test_framework_local_validation_executes_and_reuses_exact_inputs(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "server.py").write_text("READY = True\n")
@@ -1281,7 +1287,7 @@ def test_framework_local_validation_executes_and_reuses_exact_inputs(tmp_path):
     assert '"reused": true' in second.read_text()
 
 
-def test_framework_local_validation_fails_and_restores_mutation(tmp_path):
+def test_framework_local_validation_fails_and_restores_mutation(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "server.py").write_text("READY = True\n")
@@ -1317,7 +1323,7 @@ def test_framework_local_validation_fails_and_restores_mutation(tmp_path):
     assert '"passed": false' in artifact.read_text()
 
 
-def test_loop_runs_local_validation_only_after_judge_pass(tmp_path, ref_file):
+def test_loop_runs_local_validation_only_after_judge_pass(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         implementer_outcomes=[HypothesisOutcome.NOMINATED],
         implementer_validation_artifacts=["validation-recipes.json"],
@@ -1342,8 +1348,10 @@ def test_loop_runs_local_validation_only_after_judge_pass(tmp_path, ref_file):
     assert runner.counters["judge"] == 1
 
 
-def test_framework_accuracy_gate_rejects_checker_failure(tmp_path):
-    from vibesys.loops.agent.loop import _run_framework_accuracy_gate
+def test_framework_accuracy_gate_rejects_checker_failure(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
+        _run_framework_accuracy_gate,
+    )
 
     ctx = MagicMock()
     ctx.trusted_input_changes.return_value = []
@@ -1361,8 +1369,10 @@ def test_framework_accuracy_gate_rejects_checker_failure(tmp_path):
     assert "bad history" in feedback
 
 
-def test_framework_accuracy_gate_uses_manifest_timeout(tmp_path):
-    from vibesys.loops.agent.loop import _run_framework_accuracy_gate
+def test_framework_accuracy_gate_uses_manifest_timeout(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
+        _run_framework_accuracy_gate,
+    )
 
     ctx = MagicMock()
     ctx.trusted_input_changes.return_value = []
@@ -1380,8 +1390,10 @@ def test_framework_accuracy_gate_uses_manifest_timeout(tmp_path):
     ctx.judge_backend.execute.assert_called_once_with("trusted-check", timeout=300)
 
 
-def test_framework_accuracy_gate_passes_candidate_revision_to_environment(tmp_path):
-    from vibesys.loops.agent.loop import _run_framework_accuracy_gate
+def test_framework_accuracy_gate_passes_candidate_revision_to_environment(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
+        _run_framework_accuracy_gate,
+    )
 
     ctx = MagicMock()
     ctx.trusted_input_changes.return_value = []
@@ -1402,8 +1414,10 @@ def test_framework_accuracy_gate_passes_candidate_revision_to_environment(tmp_pa
     )
 
 
-def test_framework_accuracy_gate_can_release_final_deployment(tmp_path):
-    from vibesys.loops.agent.loop import _run_framework_accuracy_gate
+def test_framework_accuracy_gate_can_release_final_deployment(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
+        _run_framework_accuracy_gate,
+    )
 
     ctx = MagicMock()
     ctx.trusted_input_changes.return_value = []
@@ -1426,8 +1440,10 @@ def test_framework_accuracy_gate_can_release_final_deployment(tmp_path):
     )
 
 
-def test_framework_accuracy_gate_rejects_evaluator_changes_without_execution(tmp_path):
-    from vibesys.loops.agent.loop import _run_framework_accuracy_gate
+def test_framework_accuracy_gate_rejects_evaluator_changes_without_execution(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
+        _run_framework_accuracy_gate,
+    )
 
     ctx = MagicMock()
     ctx.trusted_input_changes.return_value = ["_input_libs/checker.go"]
@@ -1444,8 +1460,10 @@ def test_framework_accuracy_gate_rejects_evaluator_changes_without_execution(tmp
     ctx.judge_backend.execute.assert_not_called()
 
 
-def test_framework_accuracy_gate_rejects_changes_during_execution(tmp_path):
-    from vibesys.loops.agent.loop import _run_framework_accuracy_gate
+def test_framework_accuracy_gate_rejects_changes_during_execution(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
+        _run_framework_accuracy_gate,
+    )
 
     ctx = MagicMock()
     ctx.trusted_input_changes.side_effect = [[], ["_input_libs/checker.go"]]
@@ -1462,8 +1480,8 @@ def test_framework_accuracy_gate_rejects_changes_during_execution(tmp_path):
     assert "changed during accuracy execution" in feedback
 
 
-def test_framework_gates_reuse_accuracy_pass_after_later_gate_failure(tmp_path):
-    from vibesys.loops.agent.loop import _run_framework_gates
+def test_framework_gates_reuse_accuracy_pass_after_later_gate_failure(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import _run_framework_gates  # noqa: PLC0415  # tracked: #288
 
     ctx = MagicMock()
     ctx.agent_runner.backend_name = "deepagents"
@@ -1502,9 +1520,9 @@ def test_framework_gates_reuse_accuracy_pass_after_later_gate_failure(tmp_path):
     assert "Reused the prior framework-owned PASS" in progress.read_text()
 
 
-def test_framework_benchmark_extracts_declared_metric(tmp_path):
-    from vibesys.input_manifest import BenchmarkResult
-    from vibesys.loops.agent.loop import (
+def test_framework_benchmark_extracts_declared_metric(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.input_manifest import BenchmarkResult  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
         _FRAMEWORK_BENCHMARK_END_MARKER,
         _FRAMEWORK_BENCHMARK_MARKER,
         _run_framework_benchmark,
@@ -1544,9 +1562,9 @@ def test_framework_benchmark_extracts_declared_metric(tmp_path):
     assert "total_ops_per_sec**: 42.5" in (tmp_path / "progress.md").read_text()
 
 
-def test_framework_benchmark_prefers_top_level_metric_over_trial_diagnostics(tmp_path):
-    from vibesys.input_manifest import BenchmarkResult
-    from vibesys.loops.agent.loop import (
+def test_framework_benchmark_prefers_top_level_metric_over_trial_diagnostics(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.input_manifest import BenchmarkResult  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
         _FRAMEWORK_BENCHMARK_END_MARKER,
         _FRAMEWORK_BENCHMARK_MARKER,
         _run_framework_benchmark,
@@ -1577,9 +1595,9 @@ def test_framework_benchmark_prefers_top_level_metric_over_trial_diagnostics(tmp
     assert metric == 42.5
 
 
-def test_framework_benchmark_rejects_ambiguous_metric(tmp_path):
-    from vibesys.input_manifest import BenchmarkResult
-    from vibesys.loops.agent.loop import (
+def test_framework_benchmark_rejects_ambiguous_metric(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.input_manifest import BenchmarkResult  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
         _FRAMEWORK_BENCHMARK_END_MARKER,
         _FRAMEWORK_BENCHMARK_MARKER,
         _run_framework_benchmark,
@@ -1613,14 +1631,14 @@ def test_framework_benchmark_rejects_ambiguous_metric(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_loop_round_one_no_profile_runs_one_round(tmp_path, ref_file):
+def test_loop_round_one_no_profile_runs_one_round(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """Round 1 skips pre-round-decision (no existing code), proposes one task,
     implementer+judge both pass. With max_rounds=1 the loop stops there."""
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 task="Build FastAPI server",
-                pass_criteria="/health returns 200",
+                pass_criteria="/health returns 200",  # noqa: S106  # tracked: #288
                 reasoning="cold start",
             ),
         ],
@@ -1633,7 +1651,7 @@ def test_loop_round_one_no_profile_runs_one_round(tmp_path, ref_file):
     assert runner.counters["judge"] == 1
 
 
-def test_agent_roles_reference_framework_owned_effective_objective(tmp_path, ref_file):
+def test_agent_roles_reference_framework_owned_effective_objective(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     effective = (
         "Optimize the service.\n\n## Operator constraints\n\n- simultaneous exact H100/BF16\n"
     )
@@ -1641,7 +1659,7 @@ def test_agent_roles_reference_framework_owned_effective_objective(tmp_path, ref
         plans=[
             OrchestratorPlan(
                 task="Optimize the BF16 path",
-                pass_criteria="BF16 remains active",
+                pass_criteria="BF16 remains active",  # noqa: S106  # tracked: #288
                 reasoning="respect the hard precision constraint",
             )
         ],
@@ -1665,7 +1683,7 @@ def test_agent_roles_reference_framework_owned_effective_objective(tmp_path, ref
         assert "simultaneous exact H100/BF16" not in prompt
 
 
-def test_implementer_skill_updates_survive_a_renewed_continuation_prompt(tmp_path, ref_file):
+def test_implementer_skill_updates_survive_a_renewed_continuation_prompt(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     skill = tmp_path / "skills" / "portable"
     reference = skill / "references" / "transport.md"
     reference.parent.mkdir(parents=True)
@@ -1683,7 +1701,7 @@ def test_implementer_skill_updates_survive_a_renewed_continuation_prompt(tmp_pat
             OrchestratorPlan(
                 hypothesis_id="transport-boundary",
                 task="Replace request-local fanout.",
-                pass_criteria="The direct path activates.",
+                pass_criteria="The direct path activates.",  # noqa: S106  # tracked: #288
                 reasoning="The residual is host-side.",
             )
         ],
@@ -1716,13 +1734,13 @@ def test_implementer_skill_updates_survive_a_renewed_continuation_prompt(tmp_pat
     assert runner.counters["prof"] == 0
 
 
-def test_loop_judge_retry_then_pass(tmp_path, ref_file):
+def test_loop_judge_retry_then_pass(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """Judge fails once, implementer retries, judge passes. Loop bounded by max_rounds=1."""
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 task="Build server",
-                pass_criteria="tests pass",
+                pass_criteria="tests pass",  # noqa: S106  # tracked: #288
                 reasoning="cold start",
             ),
         ],
@@ -1744,14 +1762,14 @@ def test_loop_judge_retry_then_pass(tmp_path, ref_file):
     assert "remains consumed" in retry_prompt
 
 
-def test_loop_defers_judge_until_cadence_and_always_reviews_final_round(tmp_path, ref_file):
+def test_loop_defers_judge_until_cadence_and_always_reviews_final_round(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="graph-decode",
                 hypothesis="graph replay removes launch overhead",
                 task=f"continue graph work {round_number}",
-                pass_criteria="activation evidence is real",
+                pass_criteria="activation evidence is real",  # noqa: S106  # tracked: #288
                 reasoning="continue one causal experiment",
             )
             for round_number in range(1, 4)
@@ -1777,7 +1795,7 @@ def test_loop_defers_judge_until_cadence_and_always_reviews_final_round(tmp_path
     assert "Independent review deferred" in progress_files[0].read_text()
 
 
-def test_nominated_candidate_gets_early_review(tmp_path, ref_file):
+def test_nominated_candidate_gets_early_review(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         implementer_outcomes=[HypothesisOutcome.NOMINATED],
     )
@@ -1793,7 +1811,7 @@ def test_nominated_candidate_gets_early_review(tmp_path, ref_file):
     assert runner.counters["judge"] >= 1
 
 
-def test_official_gates_run_on_candidate_cadence_and_final_round(tmp_path, ref_file):
+def test_official_gates_run_on_candidate_cadence_and_final_round(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         implementer_outcomes=[HypothesisOutcome.NOMINATED] * 4,
         implementer_perf_metrics=[10.0, 20.0, 30.0, 40.0],
@@ -1826,20 +1844,20 @@ def test_official_gates_run_on_candidate_cadence_and_final_round(tmp_path, ref_f
     assert [record["perf_metric"] for record in rounds] == [None, None, 30.0, 40.0]
 
 
-def test_orchestrator_can_request_official_evaluation_before_cadence(tmp_path, ref_file):
+def test_orchestrator_can_request_official_evaluation_before_cadence(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="checkpoint-now",
                 task="finish a likely new best",
-                pass_criteria="targeted comparison passes",
+                pass_criteria="targeted comparison passes",  # noqa: S106  # tracked: #288
                 request_official_evaluation=True,
                 reasoning="the next branch needs a verified parent",
             ),
             OrchestratorPlan(
                 hypothesis_id="continue-after-checkpoint",
                 task="make another improvement",
-                pass_criteria="targeted comparison passes",
+                pass_criteria="targeted comparison passes",  # noqa: S106  # tracked: #288
                 reasoning="continue from verified evidence",
             ),
         ],
@@ -1863,21 +1881,21 @@ def test_orchestrator_can_request_official_evaluation_before_cadence(tmp_path, r
     ]
 
 
-def test_supported_hypothesis_is_reviewed_without_global_gates_and_closes(tmp_path, ref_file):
+def test_supported_hypothesis_is_reviewed_without_global_gates_and_closes(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="diagnostic-one",
                 hypothesis="the diagnostic identifies the bottleneck",
                 task="collect the scoped evidence",
-                pass_criteria="retain the diagnostic artifact",
+                pass_criteria="retain the diagnostic artifact",  # noqa: S106  # tracked: #288
                 reasoning="finish one bounded diagnostic",
             ),
             OrchestratorPlan(
                 hypothesis_id="mechanism-two",
                 hypothesis="a new mechanism can use that evidence",
                 task="start the next experiment",
-                pass_criteria="retain causal evidence",
+                pass_criteria="retain causal evidence",  # noqa: S106  # tracked: #288
                 reasoning="the prior diagnostic is complete",
             ),
         ],
@@ -1909,14 +1927,14 @@ def test_supported_hypothesis_is_reviewed_without_global_gates_and_closes(tmp_pa
     assert rounds[-1]["official_evaluation_reason"] == "final_round"
 
 
-def test_cadence_pass_keeps_a_continuing_hypothesis_active(tmp_path, ref_file):
+def test_cadence_pass_keeps_a_continuing_hypothesis_active(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="multi-round-experiment",
                 hypothesis="one causal claim needs multiple rounds",
                 task="run the experiment",
-                pass_criteria="retain auditable evidence",
+                pass_criteria="retain auditable evidence",  # noqa: S106  # tracked: #288
                 reasoning="start one bounded experiment",
             )
         ],
@@ -1950,14 +1968,14 @@ def test_cadence_pass_keeps_a_continuing_hypothesis_active(tmp_path, ref_file):
     ]
 
 
-def test_implementation_failure_with_repair_keeps_hypothesis_active(tmp_path, ref_file):
+def test_implementation_failure_with_repair_keeps_hypothesis_active(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="repairable-mechanism",
                 hypothesis="the mechanism helps after its runtime defect is repaired",
                 task="implement and test the mechanism",
-                pass_criteria="retain causal evidence",
+                pass_criteria="retain causal evidence",  # noqa: S106  # tracked: #288
                 reasoning="one persistent hypothesis",
             )
         ],
@@ -1989,21 +2007,21 @@ def test_implementation_failure_with_repair_keeps_hypothesis_active(tmp_path, re
     ]
 
 
-def test_repeated_implementation_failures_return_control_to_designer(tmp_path, ref_file):
+def test_repeated_implementation_failures_return_control_to_designer(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="repair-lease",
                 hypothesis="the mechanism helps after target-only repairs",
                 task="implement and repair the mechanism",
-                pass_criteria="retain causal evidence",
+                pass_criteria="retain causal evidence",  # noqa: S106  # tracked: #288
                 reasoning="start one persistent implementation lease",
             ),
             OrchestratorPlan(
                 hypothesis_id="designer-review",
                 hypothesis="compare the stalled repair against alternatives",
                 task="choose the next bounded experiment",
-                pass_criteria="retain a reviewed direction",
+                pass_criteria="retain a reviewed direction",  # noqa: S106  # tracked: #288
                 reasoning="the repair lease expired",
             ),
         ],
@@ -2034,21 +2052,21 @@ def test_repeated_implementation_failures_return_control_to_designer(tmp_path, r
     ]
 
 
-def test_repeated_continue_outcomes_return_control_to_designer(tmp_path, ref_file):
+def test_repeated_continue_outcomes_return_control_to_designer(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="self-renewing-lease",
                 hypothesis="the mechanism needs several implementation steps",
                 task="implement and test the mechanism",
-                pass_criteria="retain causal evidence",
+                pass_criteria="retain causal evidence",  # noqa: S106  # tracked: #288
                 reasoning="start one bounded implementation lease",
             ),
             OrchestratorPlan(
                 hypothesis_id="review-after-continue",
                 hypothesis="compare the unfinished mechanism against alternatives",
                 task="choose the next bounded experiment",
-                pass_criteria="retain a reviewed direction",
+                pass_criteria="retain a reviewed direction",  # noqa: S106  # tracked: #288
                 reasoning="the continuation lease expired",
             ),
         ],
@@ -2079,21 +2097,21 @@ def test_repeated_continue_outcomes_return_control_to_designer(tmp_path, ref_fil
     ]
 
 
-def test_repeated_rejected_reviews_return_control_to_designer(tmp_path, ref_file):
+def test_repeated_rejected_reviews_return_control_to_designer(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="rejected-review-lease",
                 hypothesis="the candidate needs bounded evidence repair",
                 task="repair and present the evidence",
-                pass_criteria="retain causal evidence",
+                pass_criteria="retain causal evidence",  # noqa: S106  # tracked: #288
                 reasoning="start one bounded review-repair lease",
             ),
             OrchestratorPlan(
                 hypothesis_id="review-after-rejections",
                 hypothesis="compare the repeatedly rejected work against alternatives",
                 task="choose the next bounded experiment",
-                pass_criteria="retain a reviewed direction",
+                pass_criteria="retain a reviewed direction",  # noqa: S106  # tracked: #288
                 reasoning="the review-repair lease expired",
             ),
         ],
@@ -2121,14 +2139,14 @@ def test_repeated_rejected_reviews_return_control_to_designer(tmp_path, ref_file
     ]
 
 
-def test_resolvable_inconclusive_result_keeps_hypothesis_active(tmp_path, ref_file):
+def test_resolvable_inconclusive_result_keeps_hypothesis_active(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="variance-boundary",
                 hypothesis="one repeat resolves the causal classification",
                 task="measure and repeat only if ambiguous",
-                pass_criteria="retain a variance-aware classification",
+                pass_criteria="retain a variance-aware classification",  # noqa: S106  # tracked: #288
                 reasoning="one persistent hypothesis",
             )
         ],
@@ -2160,21 +2178,21 @@ def test_resolvable_inconclusive_result_keeps_hypothesis_active(tmp_path, ref_fi
     ]
 
 
-def test_cadence_review_is_not_duplicated_for_provisional_retry(tmp_path, ref_file):
+def test_cadence_review_is_not_duplicated_for_provisional_retry(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="stable-hypothesis",
                 hypothesis="same causal claim",
                 task="continue the experiment",
-                pass_criteria="retain causal evidence",
+                pass_criteria="retain causal evidence",  # noqa: S106  # tracked: #288
                 reasoning="one hypothesis across rounds",
             ),
             OrchestratorPlan(
                 hypothesis_id="replacement-hypothesis",
                 hypothesis="next causal claim",
                 task="finish the replacement experiment",
-                pass_criteria="retain causal evidence",
+                pass_criteria="retain causal evidence",  # noqa: S106  # tracked: #288
                 reasoning="the prior claim passed review",
             ),
         ],
@@ -2204,21 +2222,21 @@ def test_cadence_review_is_not_duplicated_for_provisional_retry(tmp_path, ref_fi
     assert runner.counters["judge"] == 2
 
 
-def test_unreviewed_terminal_outcome_returns_control_to_designer(tmp_path, ref_file):
+def test_unreviewed_terminal_outcome_returns_control_to_designer(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="falsified-path",
                 hypothesis="first claim",
                 task="test first claim",
-                pass_criteria="collect evidence",
+                pass_criteria="collect evidence",  # noqa: S106  # tracked: #288
                 reasoning="first experiment",
             ),
             OrchestratorPlan(
                 hypothesis_id="replacement-path",
                 hypothesis="second claim",
                 task="test second claim",
-                pass_criteria="collect evidence",
+                pass_criteria="collect evidence",  # noqa: S106  # tracked: #288
                 reasoning="replacement experiment",
             ),
         ],
@@ -2258,7 +2276,7 @@ def test_unreviewed_terminal_outcome_returns_control_to_designer(tmp_path, ref_f
     )
 
 
-def test_reviewed_disproof_skips_framework_gates(tmp_path, ref_file):
+def test_reviewed_disproof_skips_framework_gates(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         implementer_outcomes=[HypothesisOutcome.DISPROVEN],
         judge_verdicts=["pass"],
@@ -2282,21 +2300,21 @@ def test_reviewed_disproof_skips_framework_gates(tmp_path, ref_file):
     assert rounds[0]["official_evaluation_reason"] == "final_round"
 
 
-def test_disproven_retry_after_failed_review_returns_control_to_designer(tmp_path, ref_file):
+def test_disproven_retry_after_failed_review_returns_control_to_designer(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="falsified-after-review",
                 hypothesis="first claim",
                 task="test first claim",
-                pass_criteria="collect evidence",
+                pass_criteria="collect evidence",  # noqa: S106  # tracked: #288
                 reasoning="first experiment",
             ),
             OrchestratorPlan(
                 hypothesis_id="replacement-after-review",
                 hypothesis="second claim",
                 task="test second claim",
-                pass_criteria="collect evidence",
+                pass_criteria="collect evidence",  # noqa: S106  # tracked: #288
                 reasoning="replacement experiment",
             ),
         ],
@@ -2333,21 +2351,21 @@ def test_disproven_retry_after_failed_review_returns_control_to_designer(tmp_pat
     ]
 
 
-def test_role_session_policy_is_explicit_and_hypothesis_scoped(tmp_path, ref_file):
+def test_role_session_policy_is_explicit_and_hypothesis_scoped(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="stable-hypothesis",
                 hypothesis="same claim",
                 task="continue",
-                pass_criteria="review",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
                 reasoning="same experiment",
             ),
             OrchestratorPlan(
                 hypothesis_id="stable-hypothesis",
                 hypothesis="same claim",
                 task="finish",
-                pass_criteria="review",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
                 reasoning="same experiment",
             ),
         ],
@@ -2400,8 +2418,9 @@ def test_role_session_policy_is_explicit_and_hypothesis_scoped(tmp_path, ref_fil
     ]
 
 
-def test_rejected_terminal_submission_cannot_schedule_framework_gate_as_next_step(
-    tmp_path, ref_file
+def test_rejected_terminal_submission_cannot_schedule_framework_gate_as_next_step(  # noqa: ANN201  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
 ):
     forbidden_step = "Run the framework-owned accuracy evaluation."
     runner = _make_orchestrate_runner(
@@ -2410,7 +2429,7 @@ def test_rejected_terminal_submission_cannot_schedule_framework_gate_as_next_ste
                 hypothesis_id="gate-ownership",
                 hypothesis="candidate is ready",
                 task="prepare candidate evidence",
-                pass_criteria="review",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
                 reasoning="framework owns official gates",
             )
         ],
@@ -2444,19 +2463,19 @@ def test_rejected_terminal_submission_cannot_schedule_framework_gate_as_next_ste
     assert "do not duplicate framework-owned commands" in retry_prompt
 
 
-def test_hypothesis_revert_is_applied_once_across_continuation_rounds(tmp_path, ref_file):
+def test_hypothesis_revert_is_applied_once_across_continuation_rounds(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="seed",
                 task="establish parent",
-                pass_criteria="review",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
                 reasoning="seed checkpoint",
             ),
             OrchestratorPlan(
                 hypothesis_id="continued-repair",
                 task="start from parent and continue",
-                pass_criteria="review",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
                 revert_to_round=1,
                 reasoning="discard a later branch once",
             ),
@@ -2531,19 +2550,19 @@ def test_hypothesis_revert_is_applied_once_across_continuation_rounds(tmp_path, 
     )
 
 
-def test_failed_hypothesis_revert_is_retried_and_not_claimed_as_applied(tmp_path, ref_file):
+def test_failed_hypothesis_revert_is_retried_and_not_claimed_as_applied(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 hypothesis_id="seed",
                 task="establish parent",
-                pass_criteria="review",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
                 reasoning="seed checkpoint",
             ),
             OrchestratorPlan(
                 hypothesis_id="retry-rollback",
                 task="start from parent",
-                pass_criteria="review",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
                 revert_to_round=1,
                 reasoning="restore parent",
             ),
@@ -2579,7 +2598,7 @@ def test_failed_hypothesis_revert_is_retried_and_not_claimed_as_applied(tmp_path
     assert "framework already materialized" in retry_calls[1].kwargs["system_prompt"].lower()
 
 
-def test_judge_audited_implementer_metrics_are_recorded(tmp_path, ref_file):
+def test_judge_audited_implementer_metrics_are_recorded(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(implementer_perf_metrics=[321.5])
 
     _invoke_orchestrate(
@@ -2624,9 +2643,9 @@ def test_judge_audited_implementer_metrics_are_recorded(tmp_path, ref_file):
     )
 
 
-def test_loop_retries_when_framework_accuracy_gate_fails(tmp_path, ref_file):
+def test_loop_retries_when_framework_accuracy_gate_fails(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
-        plans=[OrchestratorPlan(task="Build", pass_criteria="tests", reasoning="start")],
+        plans=[OrchestratorPlan(task="Build", pass_criteria="tests", reasoning="start")],  # noqa: S106  # tracked: #288
         judge_verdicts=["pass", "pass"],
     )
 
@@ -2644,9 +2663,9 @@ def test_loop_retries_when_framework_accuracy_gate_fails(tmp_path, ref_file):
     assert runner.counters["judge"] == 2
 
 
-def test_framework_gate_retry_preserves_judge_approved_metrics(tmp_path, ref_file):
+def test_framework_gate_retry_preserves_judge_approved_metrics(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
-        plans=[OrchestratorPlan(task="Build", pass_criteria="tests", reasoning="start")],
+        plans=[OrchestratorPlan(task="Build", pass_criteria="tests", reasoning="start")],  # noqa: S106  # tracked: #288
         judge_verdicts=["pass", "pass"],
         implementer_perf_metrics=[321.5, None],
     )
@@ -2685,7 +2704,7 @@ def test_framework_gate_retry_preserves_judge_approved_metrics(tmp_path, ref_fil
     assert "do not duplicate the canonical run" in retry_prompt
 
 
-def test_loop_exhaustion_carries_to_next_round(tmp_path, ref_file):
+def test_loop_exhaustion_carries_to_next_round(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """Review exhaustion returns to the same implementer, not the designer."""
     seen_plan_prompts: list[str] = []
     seen_implementer_prompts: list[str] = []
@@ -2693,12 +2712,12 @@ def test_loop_exhaustion_carries_to_next_round(tmp_path, ref_file):
         plans=[
             OrchestratorPlan(
                 task="Build the whole server with every optimization",
-                pass_criteria="impossibly strict",
+                pass_criteria="impossibly strict",  # noqa: S106  # tracked: #288
                 reasoning="ambitious",
             ),
             OrchestratorPlan(
                 task="Just get /health working",
-                pass_criteria="/health returns 200",
+                pass_criteria="/health returns 200",  # noqa: S106  # tracked: #288
                 reasoning="backed off after exhaustion",
             ),
         ],
@@ -2708,7 +2727,7 @@ def test_loop_exhaustion_carries_to_next_round(tmp_path, ref_file):
     # Wrap invoke so we can capture the orchestrator plan prompts.
     real_invoke = original_runner.invoke.side_effect
 
-    def spy_invoke(*, kind, response_cls, **kwargs):
+    def spy_invoke(*, kind, response_cls, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
         if kind == "orchestrator" and response_cls is OrchestratorPlan:
             seen_plan_prompts.append(kwargs.get("system_prompt", ""))
         if kind == "implementer" and response_cls is ImplementerResponse:
@@ -2733,7 +2752,7 @@ def test_loop_exhaustion_carries_to_next_round(tmp_path, ref_file):
     assert "needs work" in seen_implementer_prompts[2]
 
 
-def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):
+def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """If PreRoundDecision.need_profile is True, profiler runs before the plan call."""
     call_order: list[str] = []
     profiler_prompts: list[str] = []
@@ -2745,13 +2764,13 @@ def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):
             # Round 1 cold-start plan (no pre-decision invoked on round 1).
             OrchestratorPlan(
                 task="Build server",
-                pass_criteria="ok",
+                pass_criteria="ok",  # noqa: S106  # tracked: #288
                 reasoning="start",
             ),
             # Round 2 plan — uses profiler summary.
             OrchestratorPlan(
                 task="Optimize decode",
-                pass_criteria="graph replay",
+                pass_criteria="graph replay",  # noqa: S106  # tracked: #288
                 reasoning="profile showed launch overhead",
             ),
         ],
@@ -2768,7 +2787,7 @@ def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):
 
     real_invoke = runner.invoke.side_effect
 
-    def spy_invoke(*, kind, response_cls, **kwargs):
+    def spy_invoke(*, kind, response_cls, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
         if kind == "orchestrator" and response_cls is OrchestratorPlan:
             call_order.append("plan")
         elif kind == "profiler":
@@ -2796,14 +2815,14 @@ def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):
     assert "Do not launch a duplicate expensive evaluation" in profiler_prompts[0]
 
 
-def test_loop_skips_profiler_when_pre_round_decision_says_no(tmp_path, ref_file):
+def test_loop_skips_profiler_when_pre_round_decision_says_no(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         pre_decisions=[
             PreRoundDecision(need_profile=False, profile_focus="", reasoning="benchmark is enough"),
         ],
         plans=[
-            OrchestratorPlan(task="Build server", pass_criteria="ok", reasoning="start"),
-            OrchestratorPlan(task="Use benchmark evidence", pass_criteria="ok", reasoning="skip"),
+            OrchestratorPlan(task="Build server", pass_criteria="ok", reasoning="start"),  # noqa: S106  # tracked: #288
+            OrchestratorPlan(task="Use benchmark evidence", pass_criteria="ok", reasoning="skip"),  # noqa: S106  # tracked: #288
         ],
     )
 
@@ -2814,15 +2833,17 @@ def test_loop_skips_profiler_when_pre_round_decision_says_no(tmp_path, ref_file)
     assert runner.counters["prof"] == 0
 
 
-def test_loop_skips_profiler_when_profiler_kind_is_none(tmp_path, ref_file):
+def test_loop_skips_profiler_when_profiler_kind_is_none(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         pre_decisions=[
             PreRoundDecision(need_profile=True, profile_focus="kernels", reasoning="would help"),
         ],
         plans=[
-            OrchestratorPlan(task="Build server", pass_criteria="ok", reasoning="start"),
+            OrchestratorPlan(task="Build server", pass_criteria="ok", reasoning="start"),  # noqa: S106  # tracked: #288
             OrchestratorPlan(
-                task="Use benchmark evidence", pass_criteria="ok", reasoning="disabled"
+                task="Use benchmark evidence",
+                pass_criteria="ok",  # noqa: S106  # tracked: #288
+                reasoning="disabled",  # noqa: RUF100, S106  # tracked: #288
             ),
         ],
     )
@@ -2840,15 +2861,17 @@ def test_loop_skips_profiler_when_profiler_kind_is_none(tmp_path, ref_file):
     assert runner.counters["prof"] == 0
 
 
-def test_loop_generic_auto_profiler_resolves_to_macos_cpu(tmp_path, ref_file):
+def test_loop_generic_auto_profiler_resolves_to_macos_cpu(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         pre_decisions=[
             PreRoundDecision(need_profile=True, profile_focus="kernels", reasoning="would help"),
         ],
         plans=[
-            OrchestratorPlan(task="Build queue", pass_criteria="ok", reasoning="start"),
+            OrchestratorPlan(task="Build queue", pass_criteria="ok", reasoning="start"),  # noqa: S106  # tracked: #288
             OrchestratorPlan(
-                task="Use benchmark evidence", pass_criteria="ok", reasoning="generic"
+                task="Use benchmark evidence",
+                pass_criteria="ok",  # noqa: S106  # tracked: #288
+                reasoning="generic",  # noqa: RUF100, S106  # tracked: #288
             ),
         ],
     )
@@ -2857,7 +2880,7 @@ def test_loop_generic_auto_profiler_resolves_to_macos_cpu(tmp_path, ref_file):
         patch("vibesys.profilers.platform.system", return_value="Darwin"),
         patch(
             "vibesys.context.preflight_profiler_kind",
-            lambda kind: ProfilerPreflightResult(kind, True),
+            lambda kind: ProfilerPreflightResult(kind, True),  # noqa: FBT003  # tracked: #288
         ),
     ):
         result = _invoke_orchestrate(
@@ -2873,14 +2896,14 @@ def test_loop_generic_auto_profiler_resolves_to_macos_cpu(tmp_path, ref_file):
     assert runner.counters["prof"] == 1
 
 
-def test_loop_runs_full_max_rounds_budget(tmp_path, ref_file):
+def test_loop_runs_full_max_rounds_budget(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """With the ``done`` field removed, the loop always exhausts max_rounds.
     A single-round budget yields one implementer + judge call, no more."""
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 task="Build server",
-                pass_criteria="ok",
+                pass_criteria="ok",  # noqa: S106  # tracked: #288
                 reasoning="round 1",
             )
         ],
@@ -2891,10 +2914,10 @@ def test_loop_runs_full_max_rounds_budget(tmp_path, ref_file):
     assert runner.counters["judge"] == 1
 
 
-def test_loop_max_rounds_terminates(tmp_path, ref_file):
+def test_loop_max_rounds_terminates(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """Loop exits after max_rounds and reports success (the loop always runs
     to budget; there is no early-stop signal)."""
-    plans = [OrchestratorPlan(task=f"t{i}", pass_criteria="p", reasoning="r") for i in range(10)]
+    plans = [OrchestratorPlan(task=f"t{i}", pass_criteria="p", reasoning="r") for i in range(10)]  # noqa: S106  # tracked: #288
     runner = _make_orchestrate_runner(plans=plans)
     result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=3)
     assert result is True
@@ -2907,9 +2930,9 @@ def test_loop_max_rounds_terminates(tmp_path, ref_file):
 # ---------------------------------------------------------------------------
 
 
-def test_cli_loads_objective_md_from_ref_parent(tmp_path):
-    from vibesys.input_manifest import load_input_bundle
-    from vibesys.main import _load_objective
+def test_cli_loads_objective_md_from_ref_parent(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.input_manifest import load_input_bundle  # noqa: PLC0415  # tracked: #288
+    from vibesys.main import _load_objective  # noqa: PLC0415  # tracked: #288
 
     bundle = tmp_path / "modelA"
     bundle.mkdir()
@@ -2925,8 +2948,8 @@ def test_cli_loads_objective_md_from_ref_parent(tmp_path):
     assert "Maximize throughput" in objective
 
 
-def test_cli_missing_objective_md_errors(tmp_path):
-    from vibesys.input_manifest import load_input_bundle
+def test_cli_missing_objective_md_errors(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.input_manifest import load_input_bundle  # noqa: PLC0415  # tracked: #288
 
     bundle = tmp_path / "modelB"
     bundle.mkdir()
@@ -2937,13 +2960,13 @@ def test_cli_missing_objective_md_errors(tmp_path):
         "[benchmark]\ncommand = ['uv', 'run', 'python', 'benchmark/benchmark.py']\n"
     )
 
-    with pytest.raises(FileNotFoundError, match="OBJECTIVE.md"):
+    with pytest.raises(FileNotFoundError, match="OBJECTIVE.md"):  # noqa: RUF043  # tracked: #288
         load_input_bundle(bundle)
 
 
-def test_cli_rejects_modal_with_nsys_profiler(tmp_path, ref_file):
+def test_cli_rejects_modal_with_nsys_profiler(tmp_path, ref_file):  # noqa: ANN001, ANN201, ARG001  # tracked: #288
     """--modal only supports torch profiler."""
-    from vibesys.main import _build_agent_parser, _validate_agent
+    from vibesys.main import _build_agent_parser, _validate_agent  # noqa: PLC0415  # tracked: #288
 
     parser = _build_agent_parser()
     validate_args = _validate_agent
@@ -2972,8 +2995,8 @@ def test_cli_rejects_modal_with_nsys_profiler(tmp_path, ref_file):
 # ---------------------------------------------------------------------------
 
 
-def test_ensure_roadmap_seeds_header_when_missing(tmp_path):
-    from vibesys.loops.agent import issue_board
+def test_ensure_roadmap_seeds_header_when_missing(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.loops.agent import issue_board  # noqa: PLC0415  # tracked: #288
 
     p = tmp_path / "roadmap.md"
     assert not p.exists()
@@ -2988,8 +3011,8 @@ def test_ensure_roadmap_seeds_header_when_missing(tmp_path):
     assert "## Abandoned" in text
 
 
-def test_ensure_roadmap_does_not_overwrite_existing(tmp_path):
-    from vibesys.loops.agent import issue_board
+def test_ensure_roadmap_does_not_overwrite_existing(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.loops.agent import issue_board  # noqa: PLC0415  # tracked: #288
 
     p = tmp_path / "roadmap.md"
     p.write_text("# my custom plan\n")
@@ -2997,22 +3020,22 @@ def test_ensure_roadmap_does_not_overwrite_existing(tmp_path):
     assert p.read_text() == "# my custom plan\n"
 
 
-def test_read_roadmap_returns_text(tmp_path):
-    from vibesys.loops.agent import issue_board
+def test_read_roadmap_returns_text(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.loops.agent import issue_board  # noqa: PLC0415  # tracked: #288
 
     p = tmp_path / "roadmap.md"
     p.write_text("hello\n")
     assert issue_board.read_roadmap(p) == "hello\n"
 
 
-def test_read_roadmap_missing_returns_empty(tmp_path):
-    from vibesys.loops.agent import issue_board
+def test_read_roadmap_missing_returns_empty(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.loops.agent import issue_board  # noqa: PLC0415  # tracked: #288
 
     p = tmp_path / "nope.md"
     assert issue_board.read_roadmap(p) == ""
 
 
-def test_outer_prompts_reference_memory_paths_without_embedding_contents():
+def test_outer_prompts_reference_memory_paths_without_embedding_contents():  # noqa: ANN201  # tracked: #288
     template_dir = PROMPTS_DIR / "loops" / "agent"
     plan_prompt = (template_dir / "orchestrator_plan_prompt.j2").read_text()
     pre_prompt = (template_dir / "orchestrator_pre_round_prompt.j2").read_text()
@@ -3038,9 +3061,9 @@ def test_outer_prompts_reference_memory_paths_without_embedding_contents():
 
 @pytest.mark.parametrize(
     ("progress_name", "expected"),
-    (("progress.md", "pareto-frontier.md"), ("progress", "progress/pareto-frontier.md")),
+    (("progress.md", "pareto-frontier.md"), ("progress", "progress/pareto-frontier.md")),  # noqa: PT007  # tracked: #288
 )
-def test_pareto_archive_is_materialized_beside_progress(tmp_path, progress_name, expected):
+def test_pareto_archive_is_materialized_beside_progress(tmp_path, progress_name, expected):  # noqa: ANN001, ANN201  # tracked: #288
     progress_path = tmp_path / progress_name
 
     document = issue_board.write_pareto_archive(progress_path, "Trusted frontier: round 4")
@@ -3049,9 +3072,9 @@ def test_pareto_archive_is_materialized_beside_progress(tmp_path, progress_name,
     assert document.read_text() == "# Pareto frontier\n\nTrusted frontier: round 4\n"
 
 
-def _record(round_number: int, perf: float | None, unit: str = "tok/s"):
+def _record(round_number: int, perf: float | None, unit: str = "tok/s"):  # noqa: ANN202  # tracked: #288
     """Build a _RoundRecord shorthand for plateau tests."""
-    from vibesys.loops.agent.loop import _RoundRecord
+    from vibesys.loops.agent.loop import _RoundRecord  # noqa: PLC0415  # tracked: #288
 
     return _RoundRecord(
         round_number=round_number,
@@ -3064,37 +3087,37 @@ def _record(round_number: int, perf: float | None, unit: str = "tok/s"):
     )
 
 
-def test_detect_plateau_returns_none_when_too_few_rounds():
-    from vibesys.loops.agent.loop import _detect_plateau
+def test_detect_plateau_returns_none_when_too_few_rounds():  # noqa: ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import _detect_plateau  # noqa: PLC0415  # tracked: #288
 
     # Two rounds is below the 3-round minimum streak.
     records = [_record(1, 40.0), _record(2, 41.0)]
     assert _detect_plateau(records) is None
 
 
-def test_detect_plateau_fires_on_flat_perf_streak():
-    from vibesys.loops.agent.loop import _detect_plateau
+def test_detect_plateau_fires_on_flat_perf_streak():  # noqa: ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import _detect_plateau  # noqa: PLC0415  # tracked: #288
 
     # 41.0 vs 41.5 is ~1.2% spread — well under the 5% threshold.
     records = [_record(1, 41.0), _record(2, 41.5), _record(3, 41.2)]
     warning = _detect_plateau(records)
     assert warning is not None
-    assert "rounds 1–3" in warning
+    assert "rounds 1–3" in warning  # noqa: RUF001  # tracked: #288
     assert "tok/s" in warning
 
 
-def test_detect_plateau_skips_when_perf_diverges():
-    from vibesys.loops.agent.loop import _detect_plateau
+def test_detect_plateau_skips_when_perf_diverges():  # noqa: ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import _detect_plateau  # noqa: PLC0415  # tracked: #288
 
     # 41.0 vs 116.0 is ~64% spread — clearly off-plateau.
     records = [_record(1, 41.0), _record(2, 116.0), _record(3, 114.5)]
     assert _detect_plateau(records) is None
 
 
-def test_detect_plateau_ignores_rounds_without_perf():
+def test_detect_plateau_ignores_rounds_without_perf():  # noqa: ANN201  # tracked: #288
     """Rounds where the profiler skipped or the round failed (perf=None) must
     not interrupt the streak — only valid measurements count."""
-    from vibesys.loops.agent.loop import _detect_plateau
+    from vibesys.loops.agent.loop import _detect_plateau  # noqa: PLC0415  # tracked: #288
 
     records = [
         _record(1, 41.0),
@@ -3104,13 +3127,13 @@ def test_detect_plateau_ignores_rounds_without_perf():
     ]
     warning = _detect_plateau(records)
     assert warning is not None
-    assert "rounds 1–4" in warning
+    assert "rounds 1–4" in warning  # noqa: RUF001  # tracked: #288
 
 
-def test_detect_plateau_ignores_failed_official_measurements():
+def test_detect_plateau_ignores_failed_official_measurements():  # noqa: ANN201  # tracked: #288
     """A measured row rejected by the judge or another round gate is not
     trusted trajectory evidence, even when the framework evaluator ran."""
-    from vibesys.loops.agent.loop import _detect_plateau
+    from vibesys.loops.agent.loop import _detect_plateau  # noqa: PLC0415  # tracked: #288
 
     failed = _record(2, 100.0)
     failed.passed = False
@@ -3122,21 +3145,21 @@ def test_detect_plateau_ignores_failed_official_measurements():
     ]
     warning = _detect_plateau(records)
     assert warning is not None
-    assert "rounds 1–4" in warning
+    assert "rounds 1–4" in warning  # noqa: RUF001  # tracked: #288
 
 
-def test_failed_official_measurement_cannot_complete_plateau_streak():
-    from vibesys.loops.agent.loop import _detect_plateau
+def test_failed_official_measurement_cannot_complete_plateau_streak():  # noqa: ANN201  # tracked: #288
+    from vibesys.loops.agent.loop import _detect_plateau  # noqa: PLC0415  # tracked: #288
 
     failed = _record(3, 41.1)
     failed.passed = False
     assert _detect_plateau([_record(1, 41.0), _record(2, 41.2), failed]) is None
 
 
-def test_detect_plateau_streak_must_be_recent():
+def test_detect_plateau_streak_must_be_recent():  # noqa: ANN201  # tracked: #288
     """A plateau early in the run that's followed by a clear win must NOT
     fire a warning on the next round — only the *last N* matter."""
-    from vibesys.loops.agent.loop import _detect_plateau
+    from vibesys.loops.agent.loop import _detect_plateau  # noqa: PLC0415  # tracked: #288
 
     records = [
         _record(1, 41.0),  # plateau
@@ -3148,13 +3171,13 @@ def test_detect_plateau_streak_must_be_recent():
     assert _detect_plateau(records) is None
 
 
-def test_loop_creates_roadmap_md_in_workspace(tmp_path, ref_file):
+def test_loop_creates_roadmap_md_in_workspace(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """The first round of a fresh run must seed roadmap.md in the workspace."""
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
                 task="Build server",
-                pass_criteria="/health 200",
+                pass_criteria="/health 200",  # noqa: S106  # tracked: #288
                 reasoning="cold start",
             ),
         ],
@@ -3168,7 +3191,7 @@ def test_loop_creates_roadmap_md_in_workspace(tmp_path, ref_file):
     assert "## Major" in text
 
 
-def test_loop_can_create_scannable_directory_memory(tmp_path, ref_file):
+def test_loop_can_create_scannable_directory_memory(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner()
 
     result = _invoke_orchestrate(
@@ -3188,18 +3211,18 @@ def test_loop_can_create_scannable_directory_memory(tmp_path, ref_file):
     assert "Framework" not in round_log.read_text()  # stub skips official commands
 
 
-def test_loop_threads_roadmap_into_orchestrator_prompt(tmp_path, ref_file):
+def test_loop_threads_roadmap_into_orchestrator_prompt(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """The orchestrator's plan prompt must include the current roadmap.md
     contents so the orchestrator can update them."""
     seen_prompts: list[str] = []
     runner = _make_orchestrate_runner(
         plans=[
-            OrchestratorPlan(task="t", pass_criteria="p", reasoning="r"),
+            OrchestratorPlan(task="t", pass_criteria="p", reasoning="r"),  # noqa: S106  # tracked: #288
         ],
     )
     real = runner.invoke.side_effect
 
-    def spy(*, kind, response_cls, **kwargs):
+    def spy(*, kind, response_cls, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
         if kind == "orchestrator" and response_cls is OrchestratorPlan:
             seen_prompts.append(kwargs.get("system_prompt", ""))
         return real(kind=kind, response_cls=response_cls, **kwargs)
@@ -3215,7 +3238,7 @@ def test_loop_threads_roadmap_into_orchestrator_prompt(tmp_path, ref_file):
     assert "roadmap.md" in prompt
 
 
-def test_loop_threads_plateau_warning_into_prompt(tmp_path, ref_file):
+def test_loop_threads_plateau_warning_into_prompt(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """When the prior rounds plateau on perf, the orchestrator's next prompt
     must include the plateau warning."""
     seen_prompts: list[str] = []
@@ -3223,7 +3246,8 @@ def test_loop_threads_plateau_warning_into_prompt(tmp_path, ref_file):
     # flat perf metrics, and round 5 is the round under test (its plan call
     # should see the plateau warning).
     plans = [
-        OrchestratorPlan(task=f"r{i}", pass_criteria="p", reasoning=f"r{i}") for i in range(1, 6)
+        OrchestratorPlan(task=f"r{i}", pass_criteria="p", reasoning=f"r{i}")  # noqa: S106  # tracked: #288
+        for i in range(1, 6)  # noqa: RUF100, S106  # tracked: #288
     ]
     runner = _make_orchestrate_runner(
         pre_decisions=[
@@ -3265,7 +3289,7 @@ def test_loop_threads_plateau_warning_into_prompt(tmp_path, ref_file):
     )
     real = runner.invoke.side_effect
 
-    def spy(*, kind, response_cls, **kwargs):
+    def spy(*, kind, response_cls, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
         if kind == "orchestrator" and response_cls is OrchestratorPlan:
             seen_prompts.append(kwargs.get("system_prompt", ""))
         return real(kind=kind, response_cls=response_cls, **kwargs)
@@ -3293,12 +3317,12 @@ def test_loop_threads_plateau_warning_into_prompt(tmp_path, ref_file):
     assert "unexplained residual" in seen_prompts[4]
 
 
-def test_loop_resume_with_round_number_starts_there(tmp_path, ref_file):
+def test_loop_resume_with_round_number_starts_there(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """--resume 4 starts the loop at round 4 (prior rounds were committed by previous run)."""
     # With start_round=4 and max_rounds=5 only rounds 4 and 5 execute.
     plans = [
-        OrchestratorPlan(task="keep going", pass_criteria="tests pass", reasoning="round 4"),
-        OrchestratorPlan(task="more work", pass_criteria="tests pass", reasoning="round 5"),
+        OrchestratorPlan(task="keep going", pass_criteria="tests pass", reasoning="round 4"),  # noqa: S106  # tracked: #288
+        OrchestratorPlan(task="more work", pass_criteria="tests pass", reasoning="round 5"),  # noqa: S106  # tracked: #288
     ]
     runner = _make_orchestrate_runner(plans=plans)
 
@@ -3307,17 +3331,17 @@ def test_loop_resume_with_round_number_starts_there(tmp_path, ref_file):
     exp_env = tmp_path / "exp_env"
     (exp_env / "20260422-000000-test-orch").mkdir(parents=True)
     # Minimal git setup so the context validation accepts the repo.
-    import subprocess
+    import subprocess  # noqa: PLC0415  # tracked: #288
 
     subprocess.run(
-        ["git", "init"],
+        ["git", "init"],  # noqa: S607  # tracked: #288
         cwd=exp_env / "20260422-000000-test-orch",
         capture_output=True,
         check=True,
     )
     ws = exp_env / "20260422-000000-test-orch" / "workspace"
     ws.mkdir()
-    subprocess.run(["git", "init"], cwd=ws, capture_output=True, check=True)
+    subprocess.run(["git", "init"], cwd=ws, capture_output=True, check=True)  # noqa: S607  # tracked: #288
     (ws / "dummy.txt").write_text("x")
     env = {
         "GIT_AUTHOR_NAME": "t",
@@ -3325,9 +3349,13 @@ def test_loop_resume_with_round_number_starts_there(tmp_path, ref_file):
         "GIT_COMMITTER_NAME": "t",
         "GIT_COMMITTER_EMAIL": "t@t",
     }
-    subprocess.run(["git", "add", "-A"], cwd=ws, env={**env}, capture_output=True, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=ws, env={**env}, capture_output=True, check=True)  # noqa: S607  # tracked: #288
     subprocess.run(
-        ["git", "commit", "-m", "seed"], cwd=ws, env={**env}, capture_output=True, check=True
+        ["git", "commit", "-m", "seed"],  # noqa: S607  # tracked: #288
+        cwd=ws,
+        env={**env},
+        capture_output=True,
+        check=True,  # noqa: RUF100, S607  # tracked: #288
     )
 
     result = _invoke_orchestrate(

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -143,7 +143,7 @@ def test_distant_rollback_uses_requested_historical_commit():
     assert child_round is None
 
 
-@pytest.fixture()
+@pytest.fixture
 def ref_file(tmp_path):
     """Create a reference *file* (not dir) + an OBJECTIVE.md sibling.
 

--- a/tests/loops/agent/test_prompt_domain_leakage.py
+++ b/tests/loops/agent/test_prompt_domain_leakage.py
@@ -8,7 +8,7 @@ packs against an existing keyword set.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 import pytest
 
@@ -239,7 +239,7 @@ def _render_prompt_bundle(domain: DomainName, *, modality: str | None) -> dict[s
 
 
 @pytest.mark.parametrize("leak_check", DOMAIN_LEAK_CHECKS, ids=lambda check: check.source_domain)
-def test_domain_specific_keywords_do_not_leak_to_vetted_domains(
+def test_domain_specific_keywords_do_not_leak_to_vetted_domains(  # noqa: ANN201  # tracked: #288
     leak_check: DomainLeakCheck,
 ):
     failures: list[str] = []
@@ -258,7 +258,7 @@ def test_domain_specific_keywords_do_not_leak_to_vetted_domains(
     )
 
 
-def test_profiler_prompts_calibrate_observer_effects():
+def test_profiler_prompts_calibrate_observer_effects():  # noqa: ANN201  # tracked: #288
     prompts = _render_prompt_bundle(DomainName.LLM_SERVING, modality="text_generation")
 
     for prompt_name in (

--- a/tests/loops/agent/test_prompt_snapshots.py
+++ b/tests/loops/agent/test_prompt_snapshots.py
@@ -231,7 +231,7 @@ def _render_prompt(domain: DomainName, role: str, context: dict[str, object]) ->
             provisional_candidates=context.get("provisional_candidates", 0),
             official_eval_cadence_due=context.get("official_eval_cadence_due", False),
         )
-    raise AssertionError(f"unknown prompt role: {role}")
+    raise AssertionError(f"unknown prompt role: {role}")  # noqa: TRY003  # tracked: #288
 
 
 def _snapshot_path(domain: str, case_name: str, role: str) -> Path:
@@ -257,14 +257,14 @@ def _assert_matches_snapshot(domain: str, case_name: str, role: str, rendered: s
     pytest.fail(f"Rendered prompt changed: {snapshot}\n{diff}")
 
 
-@pytest.mark.parametrize("case_name,context", _CONTEXTS.items())
+@pytest.mark.parametrize("case_name,context", _CONTEXTS.items())  # noqa: PT006  # tracked: #288
 @pytest.mark.parametrize("role", _ROLES)
-def test_llm_serving_prompt_snapshot(case_name: str, context: dict[str, object], role: str):
+def test_llm_serving_prompt_snapshot(case_name: str, context: dict[str, object], role: str):  # noqa: ANN201  # tracked: #288
     rendered = _render_prompt(DomainName.LLM_SERVING, role, context)
     _assert_matches_snapshot(DomainName.LLM_SERVING.value, case_name, role, rendered)
 
 
-def test_multi_agent_prompts_use_paths_without_embedding_durable_content():
+def test_multi_agent_prompts_use_paths_without_embedding_durable_content():  # noqa: ANN201  # tracked: #288
     context = _CONTEXTS["full"]
     prompts = {role: _render_prompt(DomainName.LLM_SERVING, role, context) for role in _ROLES}
     forbidden = (
@@ -295,7 +295,7 @@ def test_multi_agent_prompts_use_paths_without_embedding_durable_content():
     assert "production startup must select the retained arm" in prompts["orchestrator"]
 
 
-def test_llm_serving_prompts_preserve_irreducible_contracts():
+def test_llm_serving_prompts_preserve_irreducible_contracts():  # noqa: ANN201  # tracked: #288
     context = _CONTEXTS["full"]
     prompts = {
         role: " ".join(_render_prompt(DomainName.LLM_SERVING, role, context).split())
@@ -335,7 +335,7 @@ def test_llm_serving_prompts_preserve_irreducible_contracts():
     assert "same scope/owner" in prompts["single_agent"]
 
 
-def test_seeded_llm_serving_prompts_require_adaptation_without_fixed_filename():
+def test_seeded_llm_serving_prompts_require_adaptation_without_fixed_filename():  # noqa: ANN201  # tracked: #288
     prompts = {
         role: _render_prompt(DomainName.LLM_SERVING, role, _CONTEXTS["seeded"])
         for role in ("implementer", "judge", "orchestrator", "single_agent")
@@ -350,7 +350,7 @@ def test_seeded_llm_serving_prompts_require_adaptation_without_fixed_filename():
     assert "Inspect and adapt" in prompts["single_agent"]
 
 
-def test_implementer_continuation_is_delta_only_and_fresh_session_safe():
+def test_implementer_continuation_is_delta_only_and_fresh_session_safe():  # noqa: ANN201  # tracked: #288
     context = _CONTEXTS["full"]
     rendered = _render_prompt(DomainName.LLM_SERVING, "implementer_continuation", context)
 
@@ -366,7 +366,7 @@ def test_implementer_continuation_is_delta_only_and_fresh_session_safe():
     assert "empty `next_step`" in rendered
 
 
-def test_multi_agent_roles_do_not_let_continuations_mint_paid_authority():
+def test_multi_agent_roles_do_not_let_continuations_mint_paid_authority():  # noqa: ANN201  # tracked: #288
     context = _CONTEXTS["full"]
     prompts = {
         role: " ".join(_render_prompt(DomainName.LLM_SERVING, role, context).split())
@@ -384,7 +384,7 @@ def test_multi_agent_roles_do_not_let_continuations_mint_paid_authority():
     assert "checkpoint plus validation-input hashes" in prompts["implementer_continuation"]
 
 
-def test_implementer_continuation_formats_materialized_parent_identity():
+def test_implementer_continuation_formats_materialized_parent_identity():  # noqa: ANN201  # tracked: #288
     context = _CONTEXTS["full"] | {
         "framework_revert_applied": True,
         "framework_revert_round": 95,
@@ -397,7 +397,7 @@ def test_implementer_continuation_formats_materialized_parent_identity():
     assert "parentfrom" not in rendered
 
 
-def test_implementer_retry_references_prior_evidence_and_cumulative_budget():
+def test_implementer_retry_references_prior_evidence_and_cumulative_budget():  # noqa: ANN201  # tracked: #288
     context = _CONTEXTS["full"] | {
         "retry": 2,
         "prior_attempt_artifact_locations": (
@@ -411,7 +411,7 @@ def test_implementer_retry_references_prior_evidence_and_cumulative_budget():
     assert "remains consumed" in rendered
 
 
-def test_judge_references_framework_evidence_without_embedding_implementer_prose():
+def test_judge_references_framework_evidence_without_embedding_implementer_prose():  # noqa: ANN201  # tracked: #288
     context = _CONTEXTS["full"] | {"retry": 2}
     rendered = _render_prompt(DomainName.LLM_SERVING, "judge", context)
 
@@ -422,7 +422,7 @@ def test_judge_references_framework_evidence_without_embedding_implementer_prose
     assert "do not repeat unrelated expensive suites" in rendered.lower()
 
 
-def test_orchestrator_routes_profile_and_failure_details_through_progress():
+def test_orchestrator_routes_profile_and_failure_details_through_progress():  # noqa: ANN201  # tracked: #288
     context = _CONTEXTS["full"]
     sentinels = {
         "regression": "REGRESSION_DETAIL_MUST_NOT_BE_EMBEDDED",
@@ -457,7 +457,7 @@ def test_orchestrator_routes_profile_and_failure_details_through_progress():
     assert "defer trajectory/roofline refresh until" in rendered.lower()
 
 
-def test_orchestrator_keeps_profiler_advice_non_blocking_without_fresh_capture():
+def test_orchestrator_keeps_profiler_advice_non_blocking_without_fresh_capture():  # noqa: ANN201  # tracked: #288
     rendered = _render_prompt(
         DomainName.LLM_SERVING,
         "orchestrator",
@@ -470,7 +470,7 @@ def test_orchestrator_keeps_profiler_advice_non_blocking_without_fresh_capture()
     assert "pareto gain, or diagnostic value cannot excuse a violation" in rendered.lower()
 
 
-def test_pre_round_prompt_is_path_only_and_skips_future_rollback_target():
+def test_pre_round_prompt_is_path_only_and_skips_future_rollback_target():  # noqa: ANN201  # tracked: #288
     rendered = render_template(
         "orchestrator_pre_round_prompt.j2",
         template_dir=_TEMPLATE_DIR,
@@ -492,7 +492,7 @@ def test_pre_round_prompt_is_path_only_and_skips_future_rollback_target():
     assert "Do not request a different profiler" in rendered
 
 
-def test_pre_round_prompt_disables_none_profiler_without_fake_capture_path():
+def test_pre_round_prompt_disables_none_profiler_without_fake_capture_path():  # noqa: ANN201  # tracked: #288
     rendered = render_template(
         "orchestrator_pre_round_prompt.j2",
         template_dir=_TEMPLATE_DIR,
@@ -508,7 +508,7 @@ def test_pre_round_prompt_disables_none_profiler_without_fake_capture_path():
     assert "`remote` capture path" not in rendered
 
 
-def test_official_evaluation_due_changes_agent_measurement_contract():
+def test_official_evaluation_due_changes_agent_measurement_contract():  # noqa: ANN201  # tracked: #288
     context = _CONTEXTS["full"] | {
         "official_evaluation_due": True,
         "official_evaluation_reason": "cadence",
@@ -524,7 +524,7 @@ def test_official_evaluation_due_changes_agent_measurement_contract():
     assert "fresh canonical artifact" in judge
 
 
-def test_minimal_llm_serving_prompt_omits_optional_checker_paths():
+def test_minimal_llm_serving_prompt_omits_optional_checker_paths():  # noqa: ANN201  # tracked: #288
     context = _CONTEXTS["minimal"]
     judge = _render_prompt(DomainName.LLM_SERVING, "judge", context)
     single_agent = _render_prompt(DomainName.LLM_SERVING, "single_agent", context)
@@ -535,7 +535,7 @@ def test_minimal_llm_serving_prompt_omits_optional_checker_paths():
     assert "/workspace/acc_checker/checker.py" not in single_agent
 
 
-def test_generic_prompts_do_not_receive_llm_serving_domain_content():
+def test_generic_prompts_do_not_receive_llm_serving_domain_content():  # noqa: ANN201  # tracked: #288
     context = _CONTEXTS["full"]
     prompts = {role: _render_prompt(DomainName.GENERIC, role, context) for role in _ROLES}
 
@@ -574,7 +574,7 @@ _FALLBACK_PROMPT_BYTE_BUDGETS = {
 
 
 @pytest.mark.parametrize("role", _ROLES)
-def test_realistic_llm_serving_native_prompt_byte_budgets(role: str):
+def test_realistic_llm_serving_native_prompt_byte_budgets(role: str):  # noqa: ANN201  # tracked: #288
     rendered = _render_prompt(DomainName.LLM_SERVING, role, _CONTEXTS["full"])
     complete = rendered + "\n\nReturn only the JSON object."
 
@@ -582,7 +582,7 @@ def test_realistic_llm_serving_native_prompt_byte_budgets(role: str):
 
 
 @pytest.mark.parametrize("role", _ROLES)
-def test_realistic_llm_serving_fallback_prompt_byte_budgets(role: str):
+def test_realistic_llm_serving_fallback_prompt_byte_budgets(role: str):  # noqa: ANN201  # tracked: #288
     rendered = _render_prompt(DomainName.LLM_SERVING, role, _CONTEXTS["full"])
     complete = (
         rendered + "\n\nReturn only the JSON object." + build_schema_hint(_RESPONSE_TYPES[role])
@@ -591,7 +591,7 @@ def test_realistic_llm_serving_fallback_prompt_byte_budgets(role: str):
     assert len(complete.encode("utf-8")) <= _FALLBACK_PROMPT_BYTE_BUDGETS[role]
 
 
-def test_pre_round_prompt_byte_budgets():
+def test_pre_round_prompt_byte_budgets():  # noqa: ANN201  # tracked: #288
     rendered = render_template(
         "orchestrator_pre_round_prompt.j2",
         template_dir=_TEMPLATE_DIR,

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -61,7 +61,7 @@ _LLM_SERVING_DOMAIN = resolve_domain(DomainName.LLM_SERVING)
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture()
+@pytest.fixture
 def ref_file(tmp_path):
     """Reference *file* + sibling OBJECTIVE.md.
 

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -62,7 +62,7 @@ _LLM_SERVING_DOMAIN = resolve_domain(DomainName.LLM_SERVING)
 
 
 @pytest.fixture
-def ref_file(tmp_path):
+def ref_file(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Reference *file* + sibling OBJECTIVE.md.
 
     A single-file reference avoids the model-weight resolution that a
@@ -77,7 +77,7 @@ def ref_file(tmp_path):
     return str(ref)
 
 
-def _make_runner(
+def _make_runner(  # noqa: ANN202, C901, PLR0913  # tracked: #288
     *,
     judge_verdicts: list[str] | None = None,
     profiler_responses: list[ProfilerSummary] | None = None,
@@ -100,7 +100,7 @@ def _make_runner(
     runner = MagicMock(spec=AgentRunner)
     runner.backend_name = "deepagents"
 
-    def _invoke(*, kind, response_cls, fallback_factory, system_prompt="", **kwargs):
+    def _invoke(*, kind, response_cls, fallback_factory, system_prompt="", **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288
         if response_cls is MutatorResponse:
             counters["mutator"] += 1
             if capture_mutator_prompts is not None:
@@ -144,7 +144,7 @@ def _make_runner(
                 perf_metric=10.0 + idx,
                 perf_unit="tok/s",
             )
-        raise AssertionError(
+        raise AssertionError(  # noqa: TRY003  # tracked: #288
             f"unexpected agent_runner.invoke call: kind={kind} response_cls={response_cls}"
         )
 
@@ -153,14 +153,14 @@ def _make_runner(
     return runner
 
 
-def _invoke_loop(tmp_path, ref_file, runner, **kwargs):
+def _invoke_loop(tmp_path, ref_file, runner, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
     """Shared plumbing — patch context globals, run the loop, return result."""
     accuracy_gate_feedbacks = kwargs.pop("_accuracy_gate_feedbacks", None)
     accuracy_gate = MagicMock(return_value=None)
     if accuracy_gate_feedbacks is not None:
         accuracy_gate.side_effect = list(accuracy_gate_feedbacks)
     runner.accuracy_gate = accuracy_gate
-    defaults = dict(
+    defaults = dict(  # noqa: C408  # tracked: #288
         config={"model": {"name": "claude-sonnet-4-6"}},
         exp_name="test-evolve",
         input_path=str(Path(ref_file).parent),
@@ -186,7 +186,7 @@ def _invoke_loop(tmp_path, ref_file, runner, **kwargs):
         return run_evolve_loop(**defaults)
 
 
-def _load_population(tmp_path) -> Population:
+def _load_population(tmp_path) -> Population:  # noqa: ANN001  # tracked: #288
     """Find the population.json the loop wrote and load it back.
 
     The exp_dir is named ``<timestamp>-<exp_name>`` so we glob for the
@@ -208,7 +208,7 @@ def _load_population(tmp_path) -> Population:
 # bootstrap round (one mutator + one judge + one profiler) in front.
 
 
-def test_bootstrap_succeeds_first_try(tmp_path, ref_file):
+def test_bootstrap_succeeds_first_try(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """Bootstrap produces the first passing implementation as a generation-0
     seed with parent_id=None and a perf_metric from the profiler."""
     runner = _make_runner()
@@ -232,7 +232,7 @@ def test_bootstrap_succeeds_first_try(tmp_path, ref_file):
     assert seed.commit  # an actual git SHA was recorded
 
 
-def test_bootstrap_fails_all_attempts_returns_false(tmp_path, ref_file):
+def test_bootstrap_fails_all_attempts_returns_false(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """When every bootstrap attempt fails the judge, the run aborts before the
     generation loop and returns False. Failed attempts are never profiled, and
     with no mutator edits they record no commit."""
@@ -258,7 +258,7 @@ def test_bootstrap_fails_all_attempts_returns_false(tmp_path, ref_file):
     assert "needs work" in pop.all[0].feedback
 
 
-def test_bootstrap_failed_attempt_records_wip_seed_commit(tmp_path, ref_file):
+def test_bootstrap_failed_attempt_records_wip_seed_commit(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """A failed bootstrap attempt whose mutator actually edited the workspace is
     snapshotted to a WIP commit, so a later attempt can repair it in place."""
     runner = _make_runner(judge_verdicts=["fail"], mutator_writes=True)
@@ -280,7 +280,7 @@ def test_bootstrap_failed_attempt_records_wip_seed_commit(tmp_path, ref_file):
     assert failed.commit  # WIP snapshot recorded because the tree changed
 
 
-def test_bootstrap_repairs_wip_seed_across_attempts(tmp_path, ref_file):
+def test_bootstrap_repairs_wip_seed_across_attempts(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """A second bootstrap attempt fix-forwards from the most-recent WIP seed:
     it checks that commit out and mutates on top, yielding a fresh WIP commit
     distinct from the first."""
@@ -297,15 +297,15 @@ def test_bootstrap_repairs_wip_seed_across_attempts(tmp_path, ref_file):
     pop = _load_population(tmp_path)
     assert len(pop) == 2
     first, second = pop.all
-    assert first.passed is False and second.passed is False
-    assert first.generation == 0 and second.generation == 0
-    assert first.parent_id is None and second.parent_id is None
+    assert first.passed is False and second.passed is False  # noqa: PT018  # tracked: #288
+    assert first.generation == 0 and second.generation == 0  # noqa: PT018  # tracked: #288
+    assert first.parent_id is None and second.parent_id is None  # noqa: PT018  # tracked: #288
     # Both attempts snapshotted their (distinct) trees.
-    assert first.commit and second.commit
+    assert first.commit and second.commit  # noqa: PT018  # tracked: #288
     assert first.commit != second.commit
 
 
-def test_bootstrap_succeeds_after_repair(tmp_path, ref_file):
+def test_bootstrap_succeeds_after_repair(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """Bootstrap that fails once then passes: the failed attempt is snapshotted,
     the passing attempt repairs it in place and becomes the gen-0 seed. Only the
     passing attempt is profiled."""
@@ -323,15 +323,15 @@ def test_bootstrap_succeeds_after_repair(tmp_path, ref_file):
     pop = _load_population(tmp_path)
     assert len(pop) == 2
     failed, seed = pop.all
-    assert failed.passed is False and failed.commit
+    assert failed.passed is False and failed.commit  # noqa: PT018  # tracked: #288
     assert seed.passed is True
     assert seed.generation == 0
     assert seed.parent_id is None
     # The passing seed built on the repaired WIP tree → distinct commit.
-    assert seed.commit and seed.commit != failed.commit
+    assert seed.commit and seed.commit != failed.commit  # noqa: PT018  # tracked: #288
 
 
-def test_bootstrap_repairs_after_framework_accuracy_failure(tmp_path, ref_file):
+def test_bootstrap_repairs_after_framework_accuracy_failure(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """An LLM-approved seed still fails when the trusted oracle rejects it.
 
     The failed seed is never profiled, its oracle feedback is retained for the
@@ -365,7 +365,7 @@ def test_bootstrap_repairs_after_framework_accuracy_failure(tmp_path, ref_file):
     assert seed.passed is True
 
 
-def test_bootstrap_prompt_uses_cold_start_section(tmp_path, ref_file):
+def test_bootstrap_prompt_uses_cold_start_section(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """The bootstrap attempt sees the cold-start branch of the mutator prompt
     (no parent block)."""
     captured: list[str] = []
@@ -383,7 +383,7 @@ def test_bootstrap_prompt_uses_cold_start_section(tmp_path, ref_file):
     assert "LLM-serving implementation invariants" in prompt
 
 
-def test_evolve_with_preexisting_passing_seed_skips_bootstrap(tmp_path, ref_file):
+def test_evolve_with_preexisting_passing_seed_skips_bootstrap(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """A resumed run whose population already has a passing seed skips the
     bootstrap phase entirely and evolves straight off the seed."""
     # First run: bootstrap-only, creates a passing gen-0 seed with a real commit.
@@ -410,7 +410,7 @@ def test_evolve_with_preexisting_passing_seed_skips_bootstrap(tmp_path, ref_file
     pop = _load_population(tmp_path)
     assert len(pop) == 2  # gen-0 seed + one gen-1 child (same exp dir, resumed)
     seed, child = pop.all
-    assert seed.generation == 0 and seed.parent_id is None
+    assert seed.generation == 0 and seed.parent_id is None  # noqa: PT018  # tracked: #288
     assert child.parent_id == seed.id
 
 
@@ -419,7 +419,7 @@ def test_evolve_with_preexisting_passing_seed_skips_bootstrap(tmp_path, ref_file
 # ---------------------------------------------------------------------------
 
 
-def test_first_generation_uses_bootstrap_seed_as_parent(tmp_path, ref_file):
+def test_first_generation_uses_bootstrap_seed_as_parent(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """Gen 1's child must be tagged with parent_id pointing at the bootstrap
     seed."""
     runner = _make_runner()
@@ -443,7 +443,7 @@ def test_first_generation_uses_bootstrap_seed_as_parent(tmp_path, ref_file):
     assert {seed.perf_metric, child.perf_metric} == {10.0, 11.0}
 
 
-def test_failed_child_excluded_from_future_parent_pool(tmp_path, ref_file):
+def test_failed_child_excluded_from_future_parent_pool(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """Bootstrap: pass (the seed). Gen 1: fail (no commit, not eligible as
     parent). Gen 2: must still parent off the seed — never off the failed
     Gen 1 child."""
@@ -472,7 +472,7 @@ def test_failed_child_excluded_from_future_parent_pool(tmp_path, ref_file):
     assert g2.parent_id == seed.id
 
 
-def test_accuracy_rejected_child_is_not_profiled_or_selected(tmp_path, ref_file):
+def test_accuracy_rejected_child_is_not_profiled_or_selected(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """The framework oracle can overrule an LLM PASS for an offspring."""
     failure = "Framework accuracy gate failed.\nbooking response diverged"
     runner = _make_runner()
@@ -509,7 +509,7 @@ def test_accuracy_rejected_child_is_not_profiled_or_selected(tmp_path, ref_file)
 # ---------------------------------------------------------------------------
 
 
-def test_pareto_mode_records_metrics_dict_on_individuals(tmp_path, ref_file):
+def test_pareto_mode_records_metrics_dict_on_individuals(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """When objectives are configured the loop should pass `objectives` through
     to selection AND copy `ProfilerSummary.metrics` onto every passing
     Individual so the frontier can be computed across the run."""
@@ -558,12 +558,12 @@ def test_pareto_mode_records_metrics_dict_on_individuals(tmp_path, ref_file):
     assert front_ids == {seed.id, child.id}
 
 
-def test_pareto_addendum_appears_in_profiler_prompt(tmp_path, ref_file):
+def test_pareto_addendum_appears_in_profiler_prompt(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """When Pareto mode is on, the profiler system prompt gets an addendum
     explicitly listing the metric keys to emit. The judge stays unaffected."""
     captured_profiler_prompts: list[str] = []
 
-    def _make_runner_with_profiler_capture():
+    def _make_runner_with_profiler_capture():  # noqa: ANN202  # tracked: #288
         runner = _make_runner(
             profiler_responses=[
                 ProfilerSummary(
@@ -578,7 +578,7 @@ def test_pareto_addendum_appears_in_profiler_prompt(tmp_path, ref_file):
         )
         original = runner.invoke.side_effect
 
-        def spy(*, kind, response_cls, system_prompt="", **kwargs):
+        def spy(*, kind, response_cls, system_prompt="", **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
             if kind == "profiler":
                 captured_profiler_prompts.append(system_prompt)
             return original(
@@ -608,7 +608,7 @@ def test_pareto_addendum_appears_in_profiler_prompt(tmp_path, ref_file):
     assert "`lat_ms`" in prompt
 
 
-def test_no_objectives_keeps_metrics_empty_and_legacy_behavior(tmp_path, ref_file):
+def test_no_objectives_keeps_metrics_empty_and_legacy_behavior(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """Single-objective mode (no objectives passed) keeps `Individual.metrics`
     empty even if the profiler stub doesn't supply one — preserves the
     pre-Pareto behavior."""
@@ -626,7 +626,7 @@ def test_no_objectives_keeps_metrics_empty_and_legacy_behavior(tmp_path, ref_fil
     assert pop.all[0].metrics == {}
 
 
-def test_second_child_prompt_includes_parent_block(tmp_path, ref_file):
+def test_second_child_prompt_includes_parent_block(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """Gen 1's mutator prompt mentions the parent (bootstrap seed) perf_metric —
     one of the few signals the mutator has to ground its change in fitness."""
     captured: list[str] = []
@@ -647,7 +647,7 @@ def test_second_child_prompt_includes_parent_block(tmp_path, ref_file):
     assert "10.0" in gen1_prompt
 
 
-def test_generic_domain_prompts_exclude_llm_serving_contracts(tmp_path, ref_file):
+def test_generic_domain_prompts_exclude_llm_serving_contracts(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """The evolve loop uses registered domain sections instead of baking the
     LLM-serving contract into its mutator and judge base prompts."""
     mutator_prompts: list[str] = []
@@ -678,7 +678,7 @@ def test_generic_domain_prompts_exclude_llm_serving_contracts(tmp_path, ref_file
     assert "OpenAI-compatible" not in combined
 
 
-def test_openevolve_policy_persists_multi_file_search_state(tmp_path, ref_file):
+def test_openevolve_policy_persists_multi_file_search_state(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_runner(mutator_writes=True)
 
     result = _invoke_loop(
@@ -716,7 +716,7 @@ def test_openevolve_policy_persists_multi_file_search_state(tmp_path, ref_file):
     assert child["policy_target_island"] == 0
 
 
-def test_candidate_code_is_multi_file_but_excludes_runtime_logs(tmp_path):
+def test_candidate_code_is_multi_file_but_excludes_runtime_logs(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = GitTracker(tmp_path, log=lambda _message: None)
     (tmp_path / "src").mkdir()
     (tmp_path / "logs").mkdir()
@@ -738,7 +738,7 @@ def test_candidate_code_is_multi_file_but_excludes_runtime_logs(tmp_path):
     assert "logs/profile.txt" not in code
 
 
-def test_search_policy_initialization_failure_closes_context(tmp_path):
+def test_search_policy_initialization_failure_closes_context(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
     ctx = MagicMock(
@@ -770,7 +770,7 @@ def test_search_policy_initialization_failure_closes_context(tmp_path):
     ctx.close.assert_called_once_with()
 
 
-def test_programmatic_openevolve_config_infers_policy(tmp_path):
+def test_programmatic_openevolve_config_infers_policy(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ctx = SimpleNamespace(log_dir=tmp_path)
     config = OpenEvolveSearchConfig(num_islands=1)
 
@@ -788,7 +788,7 @@ def test_programmatic_openevolve_config_infers_policy(tmp_path):
     assert policy.config == config
 
 
-def test_programmatic_openevolve_config_rejects_vibesys_policy(tmp_path):
+def test_programmatic_openevolve_config_rejects_vibesys_policy(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ctx = SimpleNamespace(log_dir=tmp_path)
 
     with pytest.raises(ValueError, match="requires the OpenEvolve search policy"):
@@ -807,7 +807,7 @@ def test_programmatic_openevolve_config_rejects_vibesys_policy(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _ind(id_, *, passed=False, parent_id=None, commit=None, feedback=""):
+def _ind(id_, *, passed=False, parent_id=None, commit=None, feedback=""):  # noqa: ANN001, ANN202  # tracked: #288
     return Individual(
         id=id_,
         generation=1,
@@ -818,7 +818,7 @@ def _ind(id_, *, passed=False, parent_id=None, commit=None, feedback=""):
     )
 
 
-def test_recent_failure_lessons_dedupes_and_orders_most_recent_first():
+def test_recent_failure_lessons_dedupes_and_orders_most_recent_first():  # noqa: ANN201  # tracked: #288
     pop = Population()
     pop.add(_ind(1, feedback="crash: CUDA out of memory"))
     pop.add(_ind(2, feedback="crash: CUDA out of memory"))  # duplicate → collapsed
@@ -829,7 +829,7 @@ def test_recent_failure_lessons_dedupes_and_orders_most_recent_first():
     assert lessons == ["server never bound to port", "crash: CUDA out of memory"]
 
 
-def test_recent_failure_lessons_truncates_long_feedback():
+def test_recent_failure_lessons_truncates_long_feedback():  # noqa: ANN201  # tracked: #288
     pop = Population()
     pop.add(_ind(1, feedback="x" * 5000))
     (lesson,) = _recent_failure_lessons(pop, limit=1, max_chars=100)
@@ -837,7 +837,7 @@ def test_recent_failure_lessons_truncates_long_feedback():
     assert len(lesson) <= 102  # 100 chars + space + ellipsis
 
 
-def test_latest_wip_seed_returns_most_recent_failed_seed_with_commit():
+def test_latest_wip_seed_returns_most_recent_failed_seed_with_commit():  # noqa: ANN201  # tracked: #288
     pop = Population()
     pop.add(_ind(1, commit="aaa"))  # failed cold-start seed
     pop.add(_ind(2, commit="bbb"))  # newer failed cold-start seed
@@ -845,17 +845,17 @@ def test_latest_wip_seed_returns_most_recent_failed_seed_with_commit():
     pop.add(_ind(4, parent_id=2, commit="ddd"))  # has a parent → not cold-start
 
     seed = _latest_wip_seed(pop)
-    assert seed is not None and seed.id == 2
+    assert seed is not None and seed.id == 2  # noqa: PT018  # tracked: #288
 
 
-def test_latest_wip_seed_none_when_no_snapshotted_failure():
+def test_latest_wip_seed_none_when_no_snapshotted_failure():  # noqa: ANN201  # tracked: #288
     pop = Population()
     pop.add(_ind(1, commit=None))  # failed but never snapshotted
     pop.add(_ind(2, passed=True, commit="ccc"))
     assert _latest_wip_seed(pop) is None
 
 
-def test_candidate_runtime_notes_delegates_deployment_naming_to_environment():
+def test_candidate_runtime_notes_delegates_deployment_naming_to_environment():  # noqa: ANN201  # tracked: #288
     base = "run-20260720-abcd1234-llama3"
     ctx = SimpleNamespace(
         run_environment_view=SimpleNamespace(
@@ -863,7 +863,7 @@ def test_candidate_runtime_notes_delegates_deployment_naming_to_environment():
             prompt_notes=f"Deploy to Modal app {base}; endpoint {base}-web.",
         ),
         run_environment=SimpleNamespace(
-            candidate_runtime=lambda view, generation, child_idx: CandidateRuntime(
+            candidate_runtime=lambda view, generation, child_idx: CandidateRuntime(  # noqa: ARG005  # tracked: #288
                 prompt_notes="provider-owned candidate instructions",
                 deployment_name=f"candidate-{generation}-{child_idx}",
             )
@@ -874,12 +874,12 @@ def test_candidate_runtime_notes_delegates_deployment_naming_to_environment():
     assert notes == "provider-owned candidate instructions"
 
 
-def test_candidate_runtime_notes_noop_without_named_deployment():
+def test_candidate_runtime_notes_noop_without_named_deployment():  # noqa: ANN201  # tracked: #288
     notes_in = "Local run; no named deployment."
     ctx = SimpleNamespace(
         run_environment_view=SimpleNamespace(deployment_namespace=None, prompt_notes=notes_in),
         run_environment=SimpleNamespace(
-            candidate_runtime=lambda view, generation, child_idx: CandidateRuntime(
+            candidate_runtime=lambda view, generation, child_idx: CandidateRuntime(  # noqa: ARG005  # tracked: #288
                 prompt_notes=view.prompt_notes
             )
         ),
@@ -894,7 +894,7 @@ def test_candidate_runtime_notes_noop_without_named_deployment():
 # ---------------------------------------------------------------------------
 
 
-def test_teardown_candidate_deployment_delegates_to_run_environment():
+def test_teardown_candidate_deployment_delegates_to_run_environment():  # noqa: ANN201  # tracked: #288
     """The loop stays backend-agnostic: it hands the deployment name to the run
     environment, which decides how to release it."""
     run_env = MagicMock()
@@ -905,7 +905,7 @@ def test_teardown_candidate_deployment_delegates_to_run_environment():
     run_env.teardown_deployment.assert_called_once_with("vibesys-run-g1c2", log=ctx.lprint)
 
 
-def test_teardown_candidate_deployment_noop_when_kept_or_absent():
+def test_teardown_candidate_deployment_noop_when_kept_or_absent():  # noqa: ANN201  # tracked: #288
     run_env = MagicMock()
     ctx = SimpleNamespace(run_environment=run_env, lprint=lambda _: None)
 
@@ -936,9 +936,9 @@ def _passing_seed(commit: str = "seedsha", perf: float = 1.0) -> Individual:
     )
 
 
-def test_plan_candidate_falls_back_to_latest_passer_then_none():
+def test_plan_candidate_falls_back_to_latest_passer_then_none():  # noqa: ANN201  # tracked: #288
     ctx = SimpleNamespace(lprint=lambda _msg: None)
-    rng = random.Random(0)
+    rng = random.Random(0)  # noqa: S311  # tracked: #288
 
     # No passers at all → None (candidate skipped).
     empty = Population([])
@@ -972,7 +972,7 @@ def test_plan_candidate_falls_back_to_latest_passer_then_none():
     assert plan.parent.id == 1
 
 
-def test_run_generation_parallel_bounds_concurrency_and_records_all(tmp_path, monkeypatch):
+def test_run_generation_parallel_bounds_concurrency_and_records_all(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     """Candidates run concurrently up to the cap; every result is recorded once,
     in child order, on the orchestrator thread (population never races)."""
     population = Population([_passing_seed()])
@@ -984,7 +984,7 @@ def test_run_generation_parallel_bounds_concurrency_and_records_all(tmp_path, mo
     peak = 0
     lock = threading.Lock()
 
-    def fake_eval(parent_ctx, *, generation, child_idx, parent, inspirations, **_kw):
+    def fake_eval(parent_ctx, *, generation, child_idx, parent, inspirations, **_kw):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288
         nonlocal live, peak
         with lock:
             live += 1
@@ -1016,7 +1016,7 @@ def test_run_generation_parallel_bounds_concurrency_and_records_all(tmp_path, mo
         children_per_generation=5,
         population=population,
         population_path=population_path,
-        rng=random.Random(0),
+        rng=random.Random(0),  # noqa: S311  # tracked: #288
         k_top_inspirations=1,
         k_random_inspirations=1,
         selection_temperature=0.5,
@@ -1025,7 +1025,7 @@ def test_run_generation_parallel_bounds_concurrency_and_records_all(tmp_path, mo
         frontier_bias=0.7,
         modality="text_generation",
         domain_definition=_LLM_SERVING_DOMAIN,
-        pass_criteria="crit",
+        pass_criteria="crit",  # noqa: S106  # tracked: #288
         keep_deployments=False,
         search_policy=VibeSysSearchPolicy(),
     )
@@ -1040,7 +1040,7 @@ def test_run_generation_parallel_bounds_concurrency_and_records_all(tmp_path, mo
     assert population_path.exists()
 
 
-def test_run_generation_parallel_skips_parent_without_commit(tmp_path, monkeypatch):
+def test_run_generation_parallel_skips_parent_without_commit(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     """A parent with no commit can't be isolated into a worktree → skipped, not
     dispatched."""
     seed = _passing_seed()
@@ -1054,14 +1054,14 @@ def test_run_generation_parallel_skips_parent_without_commit(tmp_path, monkeypat
     monkeypatch.setattr(
         evolve_loop,
         "_plan_candidate",
-        lambda *a, **k: SearchSelection(parent=seed, inspirations=[]),
+        lambda *a, **k: SearchSelection(parent=seed, inspirations=[]),  # noqa: ARG005  # tracked: #288
     )
     called = False
 
-    def fake_eval(*a, **k):
+    def fake_eval(*a, **k):  # noqa: ANN002, ANN003, ANN202, ARG001  # tracked: #288
         nonlocal called
         called = True
-        return _CandidateOutcome(True, seed.id, [], "s", "")
+        return _CandidateOutcome(True, seed.id, [], "s", "")  # noqa: FBT003  # tracked: #288
 
     monkeypatch.setattr(evolve_loop, "_evaluate_in_subcontext", fake_eval)
 
@@ -1075,7 +1075,7 @@ def test_run_generation_parallel_skips_parent_without_commit(tmp_path, monkeypat
         children_per_generation=2,
         population=population,
         population_path=population_path,
-        rng=random.Random(0),
+        rng=random.Random(0),  # noqa: S311  # tracked: #288
         k_top_inspirations=1,
         k_random_inspirations=1,
         selection_temperature=0.5,
@@ -1084,7 +1084,7 @@ def test_run_generation_parallel_skips_parent_without_commit(tmp_path, monkeypat
         frontier_bias=0.7,
         modality="text_generation",
         domain_definition=_LLM_SERVING_DOMAIN,
-        pass_criteria="crit",
+        pass_criteria="crit",  # noqa: S106  # tracked: #288
         keep_deployments=False,
         search_policy=VibeSysSearchPolicy(),
     )
@@ -1098,7 +1098,7 @@ def test_run_generation_parallel_skips_parent_without_commit(tmp_path, monkeypat
 # ---------------------------------------------------------------------------
 
 
-def test_evaluate_in_subcontext_skips_parent_without_commit():
+def test_evaluate_in_subcontext_skips_parent_without_commit():  # noqa: ANN201  # tracked: #288
     """A parent with no commit can't seed a worktree — folded into a failed
     outcome without ever building a sub-context."""
     logs: list[str] = []
@@ -1118,7 +1118,7 @@ def test_evaluate_in_subcontext_skips_parent_without_commit():
         objectives=None,
         modality="text_generation",
         domain_definition=_LLM_SERVING_DOMAIN,
-        pass_criteria="crit",
+        pass_criteria="crit",  # noqa: S106  # tracked: #288
         keep_deployments=False,
         policy_parent_id=None,
         target_island=None,
@@ -1131,7 +1131,7 @@ def test_evaluate_in_subcontext_skips_parent_without_commit():
     assert any("no parent commit" in line for line in logs)
 
 
-def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file):
+def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """End-to-end: a real parent context spawns an isolated candidate sub-context
     (git worktree at the parent commit + its own logger/agent-runner), evaluates
     it, and the offspring commit lands in the parent's shared object store."""
@@ -1180,7 +1180,7 @@ def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file
             objectives=None,
             modality="text_generation",
             domain_definition=_LLM_SERVING_DOMAIN,
-            pass_criteria="be faster",
+            pass_criteria="be faster",  # noqa: S106  # tracked: #288
             keep_deployments=False,
             policy_parent_id=None,
             target_island=None,
@@ -1190,7 +1190,7 @@ def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file
         assert outcome.passed is True
         assert outcome.parent_id == 1
         assert outcome.perf_metric == 10.0
-        assert outcome.commit and outcome.commit != base_commit
+        assert outcome.commit and outcome.commit != base_commit  # noqa: PT018  # tracked: #288
         # The offspring commit is reachable from the parent repo — the worktree
         # shared its object store, so the candidate joins the one lineage.
         assert (
@@ -1201,13 +1201,13 @@ def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file
         assert not cand_ws.exists()
 
 
-def test_max_parallelism_ignored_without_environment_capability(tmp_path, ref_file, monkeypatch):
+def test_max_parallelism_ignored_without_environment_capability(tmp_path, ref_file, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     """An environment without isolated evaluation support stays serial."""
     called = {"parallel": False}
     monkeypatch.setattr(
         evolve_loop,
         "_run_generation_parallel",
-        lambda *a, **k: called.__setitem__("parallel", True),
+        lambda *a, **k: called.__setitem__("parallel", True),  # noqa: ARG005, FBT003  # tracked: #288
     )
     runner = _make_runner(judge_verdicts=["pass", "pass", "pass"])
     _invoke_loop(
@@ -1223,7 +1223,7 @@ def test_max_parallelism_ignored_without_environment_capability(tmp_path, ref_fi
     assert len(pop) == 2  # bootstrap seed + one serial gen-1 candidate
 
 
-def test_loop_tears_down_candidate_on_pass_and_fail_paths(tmp_path, ref_file):
+def test_loop_tears_down_candidate_on_pass_and_fail_paths(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """Teardown fires exactly once per candidate on every exit path — the
     fails the judge."""
     # bootstrap passes (1 attempt), gen-1 candidate passes, gen-2 candidate fails.

--- a/tests/loops/evolve/test_evolutionary_population.py
+++ b/tests/loops/evolve/test_evolutionary_population.py
@@ -25,7 +25,7 @@ from vibesys.loops.evolve.population import (
 # ---------------------------------------------------------------------------
 
 
-def test_individual_json_round_trip():
+def test_individual_json_round_trip():  # noqa: ANN201  # tracked: #288
     ind = Individual(
         id=7,
         generation=3,
@@ -43,7 +43,7 @@ def test_individual_json_round_trip():
     assert restored == ind
 
 
-def test_individual_from_json_tolerates_missing_optional_fields():
+def test_individual_from_json_tolerates_missing_optional_fields():  # noqa: ANN201  # tracked: #288
     """Older population.json files might omit defaults — load anyway."""
     ind = Individual.from_json({"id": 1, "generation": 1, "parent_id": None})
     assert ind.id == 1
@@ -82,14 +82,14 @@ def _failed(id_: int, parent_id: int | None = None, gen: int = 1) -> Individual:
     )
 
 
-def test_next_id_starts_at_one_and_increments():
+def test_next_id_starts_at_one_and_increments():  # noqa: ANN201  # tracked: #288
     pop = Population()
     assert pop.next_id() == 1
     pop.add(_passed(1, 10.0))
     assert pop.next_id() == 2
 
 
-def test_passed_filter_excludes_no_commit_and_failed():
+def test_passed_filter_excludes_no_commit_and_failed():  # noqa: ANN201  # tracked: #288
     pop = Population([_passed(1, 10.0), _failed(2), _passed(3, 11.0)])
     # Add a synthetic "passed but no commit" — shouldn't be selectable.
     pop.add(Individual(id=4, generation=1, parent_id=None, passed=True, commit=None))
@@ -97,17 +97,17 @@ def test_passed_filter_excludes_no_commit_and_failed():
     assert ids == [1, 3]
 
 
-def test_best_picks_highest_perf_metric():
+def test_best_picks_highest_perf_metric():  # noqa: ANN201  # tracked: #288
     pop = Population([_passed(1, 10.0), _passed(2, 12.0), _passed(3, 11.0)])
     assert pop.best().id == 2
 
 
-def test_best_returns_none_with_no_passed_individuals():
+def test_best_returns_none_with_no_passed_individuals():  # noqa: ANN201  # tracked: #288
     pop = Population([_failed(1), _failed(2)])
     assert pop.best() is None
 
 
-def test_best_breaks_ties_by_id():
+def test_best_breaks_ties_by_id():  # noqa: ANN201  # tracked: #288
     pop = Population([_passed(1, 10.0), _passed(2, 10.0)])
     assert pop.best().id == 2
 
@@ -117,41 +117,41 @@ def test_best_breaks_ties_by_id():
 # ---------------------------------------------------------------------------
 
 
-def test_select_parent_empty_returns_none():
-    assert Population().select_parent(rng=random.Random(0)) is None
+def test_select_parent_empty_returns_none():  # noqa: ANN201  # tracked: #288
+    assert Population().select_parent(rng=random.Random(0)) is None  # noqa: S311  # tracked: #288
 
 
-def test_select_parent_only_failed_returns_none():
+def test_select_parent_only_failed_returns_none():  # noqa: ANN201  # tracked: #288
     pop = Population([_failed(1), _failed(2)])
-    assert pop.select_parent(rng=random.Random(0)) is None
+    assert pop.select_parent(rng=random.Random(0)) is None  # noqa: S311  # tracked: #288
 
 
-def test_select_parent_single_passed_returns_it():
+def test_select_parent_single_passed_returns_it():  # noqa: ANN201  # tracked: #288
     pop = Population([_failed(1), _passed(2, 10.0)])
-    assert pop.select_parent(rng=random.Random(0)).id == 2
+    assert pop.select_parent(rng=random.Random(0)).id == 2  # noqa: S311  # tracked: #288
 
 
-def test_select_parent_low_temperature_concentrates_on_best():
+def test_select_parent_low_temperature_concentrates_on_best():  # noqa: ANN201  # tracked: #288
     """A near-zero temperature should pick the best almost every time."""
     pop = Population([_passed(1, 1.0), _passed(2, 5.0), _passed(3, 10.0)])
-    rng = random.Random(123)
+    rng = random.Random(123)  # noqa: S311  # tracked: #288
     counts = Counter(pop.select_parent(rng=rng, temperature=0.01).id for _ in range(200))
     # The best (id=3) should dominate.
     assert counts[3] > 180
 
 
-def test_select_parent_high_temperature_spreads():
+def test_select_parent_high_temperature_spreads():  # noqa: ANN201  # tracked: #288
     """High temperature flattens the distribution toward uniform."""
     pop = Population([_passed(1, 1.0), _passed(2, 5.0), _passed(3, 10.0)])
-    rng = random.Random(123)
+    rng = random.Random(123)  # noqa: S311  # tracked: #288
     counts = Counter(pop.select_parent(rng=rng, temperature=100.0).id for _ in range(600))
     # All three should be picked a meaningful number of times.
     assert all(counts[i] > 100 for i in (1, 2, 3))
 
 
-def test_select_parent_uniform_when_all_perfs_equal():
+def test_select_parent_uniform_when_all_perfs_equal():  # noqa: ANN201  # tracked: #288
     pop = Population([_passed(1, 7.0), _passed(2, 7.0), _passed(3, 7.0)])
-    rng = random.Random(42)
+    rng = random.Random(42)  # noqa: S311  # tracked: #288
     counts = Counter(pop.select_parent(rng=rng).id for _ in range(300))
     assert all(counts[i] > 50 for i in (1, 2, 3))
 
@@ -161,20 +161,20 @@ def test_select_parent_uniform_when_all_perfs_equal():
 # ---------------------------------------------------------------------------
 
 
-def test_select_inspirations_excludes_parent_and_dedupes():
+def test_select_inspirations_excludes_parent_and_dedupes():  # noqa: ANN201  # tracked: #288
     pop = Population(
         [_passed(i, float(i)) for i in range(1, 8)]  # ids 1..7, perf 1..7
     )
-    rng = random.Random(0)
+    rng = random.Random(0)  # noqa: S311  # tracked: #288
     picks = pop.select_inspirations(parent_id=7, k_top=2, k_random=2, rng=rng)
     ids = [i.id for i in picks]
     assert 7 not in ids  # parent excluded
     assert len(set(ids)) == len(ids)  # no dupes
 
 
-def test_select_inspirations_top_first_then_random():
+def test_select_inspirations_top_first_then_random():  # noqa: ANN201  # tracked: #288
     pop = Population([_passed(i, float(i)) for i in range(1, 8)])
-    rng = random.Random(0)
+    rng = random.Random(0)  # noqa: S311  # tracked: #288
     picks = pop.select_inspirations(parent_id=1, k_top=2, k_random=2, rng=rng)
     # First two should be the top-2 highest-perf (ids 7 and 6).
     assert picks[0].id == 7
@@ -184,25 +184,25 @@ def test_select_inspirations_top_first_then_random():
     assert rest.issubset({2, 3, 4, 5})
 
 
-def test_select_inspirations_handles_small_population():
+def test_select_inspirations_handles_small_population():  # noqa: ANN201  # tracked: #288
     pop = Population([_passed(1, 5.0), _passed(2, 6.0)])
     picks = pop.select_inspirations(
         parent_id=1,
         k_top=2,
         k_random=2,
-        rng=random.Random(0),
+        rng=random.Random(0),  # noqa: S311  # tracked: #288
     )
     # Only one other passed individual exists; no dupes / no errors.
     assert [p.id for p in picks] == [2]
 
 
-def test_select_inspirations_empty_when_only_parent_passed():
+def test_select_inspirations_empty_when_only_parent_passed():  # noqa: ANN201  # tracked: #288
     pop = Population([_passed(1, 5.0), _failed(2)])
     picks = pop.select_inspirations(
         parent_id=1,
         k_top=3,
         k_random=3,
-        rng=random.Random(0),
+        rng=random.Random(0),  # noqa: S311  # tracked: #288
     )
     assert picks == []
 
@@ -212,7 +212,7 @@ def test_select_inspirations_empty_when_only_parent_passed():
 # ---------------------------------------------------------------------------
 
 
-def test_population_save_and_load_round_trip(tmp_path):
+def test_population_save_and_load_round_trip(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     src = Population([_passed(1, 10.0), _failed(2), _passed(3, 11.5)])
     path = tmp_path / "subdir" / "population.json"  # exercises mkdir
     src.save(path)
@@ -225,7 +225,7 @@ def test_population_save_and_load_round_trip(tmp_path):
     assert loaded.get(1).parent_id is None
 
 
-def test_population_load_missing_returns_empty(tmp_path):
+def test_population_load_missing_returns_empty(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     pop = Population.load(tmp_path / "does-not-exist.json")
     assert len(pop) == 0
     assert pop.best() is None
@@ -256,20 +256,20 @@ def _multi(id_: int, metrics: dict[str, float], parent_id: int | None = None) ->
     )
 
 
-def test_objective_rejects_unknown_direction():
-    with pytest.raises(ValueError):
+def test_objective_rejects_unknown_direction():  # noqa: ANN201  # tracked: #288
+    with pytest.raises(ValueError):  # noqa: PT011  # tracked: #288
         Objective(name="foo", direction="bigger")
 
 
-def test_objective_signed_max_passes_through():
+def test_objective_signed_max_passes_through():  # noqa: ANN201  # tracked: #288
     assert Objective("x", "max").signed(5.0) == 5.0
 
 
-def test_objective_signed_min_negates():
+def test_objective_signed_min_negates():  # noqa: ANN201  # tracked: #288
     assert Objective("x", "min").signed(5.0) == -5.0
 
 
-def test_dominates_max_objective():
+def test_dominates_max_objective():  # noqa: ANN201  # tracked: #288
     a = _multi(1, {"throughput": 100.0})
     b = _multi(2, {"throughput": 80.0})
     objs = [Objective("throughput", "max")]
@@ -277,14 +277,14 @@ def test_dominates_max_objective():
     assert _dominates(b, a, objs) is False
 
 
-def test_dominates_min_objective():
+def test_dominates_min_objective():  # noqa: ANN201  # tracked: #288
     a = _multi(1, {"latency_ms": 50.0})
     b = _multi(2, {"latency_ms": 80.0})
     objs = [Objective("latency_ms", "min")]
     assert _dominates(a, b, objs) is True
 
 
-def test_dominates_requires_strictly_better_on_at_least_one():
+def test_dominates_requires_strictly_better_on_at_least_one():  # noqa: ANN201  # tracked: #288
     """Equal on every axis → no domination either way."""
     a = _multi(1, {"x": 5.0, "y": 5.0})
     b = _multi(2, {"x": 5.0, "y": 5.0})
@@ -293,7 +293,7 @@ def test_dominates_requires_strictly_better_on_at_least_one():
     assert _dominates(b, a, objs) is False
 
 
-def test_dominates_two_axis_mixed_is_non_dominated():
+def test_dominates_two_axis_mixed_is_non_dominated():  # noqa: ANN201  # tracked: #288
     """Throughput/latency tradeoff: neither dominates."""
     a = _multi(1, {"tput": 100.0, "lat": 80.0})
     b = _multi(2, {"tput": 80.0, "lat": 50.0})
@@ -302,7 +302,7 @@ def test_dominates_two_axis_mixed_is_non_dominated():
     assert _dominates(b, a, objs) is False
 
 
-def test_dominates_missing_metric_treats_as_incomparable():
+def test_dominates_missing_metric_treats_as_incomparable():  # noqa: ANN201  # tracked: #288
     a = _multi(1, {"tput": 100.0})  # missing 'lat'
     b = _multi(2, {"tput": 80.0, "lat": 50.0})
     objs = [Objective("tput", "max"), Objective("lat", "min")]
@@ -310,7 +310,7 @@ def test_dominates_missing_metric_treats_as_incomparable():
     assert _dominates(b, a, objs) is False
 
 
-def test_frontier_returns_only_non_dominated():
+def test_frontier_returns_only_non_dominated():  # noqa: ANN201  # tracked: #288
     pop = Population(
         [
             _multi(1, {"tput": 100.0, "lat": 80.0}),  # frontier (high tput)
@@ -324,7 +324,7 @@ def test_frontier_returns_only_non_dominated():
     assert front_ids == {1, 2, 4}
 
 
-def test_frontier_excludes_individuals_missing_metrics():
+def test_frontier_excludes_individuals_missing_metrics():  # noqa: ANN201  # tracked: #288
     pop = Population(
         [
             _multi(1, {"tput": 100.0, "lat": 80.0}),
@@ -337,7 +337,7 @@ def test_frontier_excludes_individuals_missing_metrics():
     assert front_ids == {1}
 
 
-def test_frontier_empty_when_no_objectives():
+def test_frontier_empty_when_no_objectives():  # noqa: ANN201  # tracked: #288
     pop = Population([_multi(1, {"tput": 100.0})])
     assert pop.frontier([]) == []
 
@@ -347,7 +347,7 @@ def test_frontier_empty_when_no_objectives():
 # ---------------------------------------------------------------------------
 
 
-def test_select_parent_pareto_mode_draws_from_frontier_with_full_bias():
+def test_select_parent_pareto_mode_draws_from_frontier_with_full_bias():  # noqa: ANN201  # tracked: #288
     """frontier_bias=1.0 → parent always sampled from the Pareto front."""
     pop = Population(
         [
@@ -357,14 +357,14 @@ def test_select_parent_pareto_mode_draws_from_frontier_with_full_bias():
         ]
     )
     objs = [Objective("tput", "max"), Objective("lat", "min")]
-    rng = random.Random(0)
+    rng = random.Random(0)  # noqa: S311  # tracked: #288
     counts = Counter(
         pop.select_parent(rng=rng, objectives=objs, frontier_bias=1.0).id for _ in range(200)
     )
     assert counts[3] == 0  # never the dominated one
 
 
-def test_select_parent_pareto_mode_falls_back_to_scalar_when_bias_zero():
+def test_select_parent_pareto_mode_falls_back_to_scalar_when_bias_zero():  # noqa: ANN201  # tracked: #288
     """frontier_bias=0.0 → bypasses the frontier branch, scalar softmax used.
 
     With temperature near 0, the highest perf_metric (id=1, perf=100) wins.
@@ -376,7 +376,7 @@ def test_select_parent_pareto_mode_falls_back_to_scalar_when_bias_zero():
         ]
     )
     objs = [Objective("tput", "max"), Objective("lat", "min")]
-    rng = random.Random(0)
+    rng = random.Random(0)  # noqa: S311  # tracked: #288
     counts = Counter(
         pop.select_parent(
             rng=rng,
@@ -389,7 +389,7 @@ def test_select_parent_pareto_mode_falls_back_to_scalar_when_bias_zero():
     assert counts[1] > 90
 
 
-def test_select_parent_falls_back_when_frontier_is_empty():
+def test_select_parent_falls_back_when_frontier_is_empty():  # noqa: ANN201  # tracked: #288
     """No individual reports both objectives → frontier is empty →
     even with bias=1.0, scalar softmax kicks in so the loop isn't blocked."""
     pop = Population(
@@ -399,14 +399,14 @@ def test_select_parent_falls_back_when_frontier_is_empty():
         ]
     )
     objs = [Objective("tput", "max"), Objective("lat", "min")]
-    rng = random.Random(0)
+    rng = random.Random(0)  # noqa: S311  # tracked: #288
     pick = pop.select_parent(rng=rng, objectives=objs, frontier_bias=1.0)
     # We get *some* individual via scalar fallback rather than None.
     assert pick is not None
     assert pick.id in (1, 2)
 
 
-def test_select_inspirations_pareto_mode_pulls_from_frontier_first():
+def test_select_inspirations_pareto_mode_pulls_from_frontier_first():  # noqa: ANN201  # tracked: #288
     """Top slots come from the Pareto frontier sorted by primary objective."""
     pop = Population(
         [
@@ -418,7 +418,7 @@ def test_select_inspirations_pareto_mode_pulls_from_frontier_first():
         ]
     )
     objs = [Objective("tput", "max"), Objective("lat", "min")]
-    rng = random.Random(0)
+    rng = random.Random(0)  # noqa: S311  # tracked: #288
     picks = pop.select_inspirations(
         parent_id=1,
         k_top=2,
@@ -434,7 +434,7 @@ def test_select_inspirations_pareto_mode_pulls_from_frontier_first():
     assert picks[2].id in (4, 5)
 
 
-def test_select_inspirations_backfills_when_frontier_smaller_than_k_top():
+def test_select_inspirations_backfills_when_frontier_smaller_than_k_top():  # noqa: ANN201  # tracked: #288
     """When the frontier has only one non-parent member but k_top=3,
     fill the remaining slots from non-frontier passers."""
     pop = Population(
@@ -446,7 +446,7 @@ def test_select_inspirations_backfills_when_frontier_smaller_than_k_top():
         ]
     )
     objs = [Objective("tput", "max"), Objective("lat", "min")]
-    rng = random.Random(0)
+    rng = random.Random(0)  # noqa: S311  # tracked: #288
     picks = pop.select_inspirations(
         parent_id=1,
         k_top=3,
@@ -462,7 +462,7 @@ def test_select_inspirations_backfills_when_frontier_smaller_than_k_top():
     assert ids[1:] == [3, 4]
 
 
-def test_population_save_writes_valid_json(tmp_path):
+def test_population_save_writes_valid_json(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Sanity: the persisted file is a JSON list of records."""
     src = Population([_passed(1, 10.0)])
     path = tmp_path / "population.json"
@@ -474,13 +474,13 @@ def test_population_save_writes_valid_json(tmp_path):
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
-def test_individual_rejects_non_finite_perf_metric(value):
+def test_individual_rejects_non_finite_perf_metric(value):  # noqa: ANN001, ANN201  # tracked: #288
     with pytest.raises(ValueError, match="perf_metric must be a finite number"):
         _passed(1, value)
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
-def test_individual_rejects_non_finite_multi_objective_metric(value):
+def test_individual_rejects_non_finite_multi_objective_metric(value):  # noqa: ANN001, ANN201  # tracked: #288
     with pytest.raises(ValueError, match=r"metrics\['throughput'\] must be a finite number"):
         Individual(
             id=1,
@@ -493,7 +493,7 @@ def test_individual_rejects_non_finite_multi_objective_metric(value):
         )
 
 
-def test_population_save_rejects_non_finite_metric_added_after_construction(tmp_path):
+def test_population_save_rejects_non_finite_metric_added_after_construction(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     individual = _passed(1, 10.0)
     individual.perf_metric = float("nan")
 
@@ -501,7 +501,7 @@ def test_population_save_rejects_non_finite_metric_added_after_construction(tmp_
         Population([individual]).save(tmp_path / "population.json")
 
 
-def test_best_revalidates_mutated_fitness_before_ranking():
+def test_best_revalidates_mutated_fitness_before_ranking():  # noqa: ANN201  # tracked: #288
     individual = _passed(1, 10.0)
     population = Population([individual])
     individual.perf_metric = float("nan")
@@ -510,7 +510,7 @@ def test_best_revalidates_mutated_fitness_before_ranking():
         population.best()
 
 
-def test_frontier_revalidates_mutated_metrics_before_comparison():
+def test_frontier_revalidates_mutated_metrics_before_comparison():  # noqa: ANN201  # tracked: #288
     individual = Individual(
         id=1,
         generation=1,
@@ -527,16 +527,16 @@ def test_frontier_revalidates_mutated_metrics_before_comparison():
         population.frontier([Objective("throughput", "max")])
 
 
-def test_softmax_revalidates_mutated_fitness_before_sampling():
+def test_softmax_revalidates_mutated_fitness_before_sampling():  # noqa: ANN201  # tracked: #288
     individual = _passed(1, 10.0)
     population = Population([individual])
     individual.perf_metric = float("-inf")
 
     with pytest.raises(ValueError, match="perf_metric must be a finite number"):
-        population.select_parent(rng=random.Random(0))
+        population.select_parent(rng=random.Random(0))  # noqa: S311  # tracked: #288
 
 
-def test_population_load_rejects_non_finite_metric(tmp_path):
+def test_population_load_rejects_non_finite_metric(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     path = tmp_path / "population.json"
     path.write_text('[{"id": 1, "generation": 1, "parent_id": null, "perf_metric": NaN}]')
 

--- a/tests/loops/evolve/test_evolve_prompt_snapshots.py
+++ b/tests/loops/evolve/test_evolve_prompt_snapshots.py
@@ -152,7 +152,7 @@ def _render_prompt(case: _Case, role: str) -> str:
             "judge_prompt.j2",
             **common,
             domain_judge=_domain_section(case, DomainRole.JUDGE),
-            pass_criteria="The candidate passes correctness and improves the headline metric.",
+            pass_criteria="The candidate passes correctness and improves the headline metric.",  # noqa: S106  # tracked: #288
         )
     if role == "profiler":
         definition = profiler_definition(case.profiler)
@@ -164,7 +164,7 @@ def _render_prompt(case: _Case, role: str) -> str:
             profiler_support_name=definition.support_name,
             profiler_mcp_name=definition.mcp_name,
         )
-    raise AssertionError(f"unknown prompt role: {role}")
+    raise AssertionError(f"unknown prompt role: {role}")  # noqa: TRY003  # tracked: #288
 
 
 def _snapshot_path(case: _Case, role: str) -> Path:

--- a/tests/loops/evolve/test_search_policy.py
+++ b/tests/loops/evolve/test_search_policy.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import json
 import random
 import shutil
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator  # noqa: TC003  # tracked: #288
 from importlib.metadata import version
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 import pytest
 
@@ -70,17 +70,17 @@ def test_dependency_is_pinned_to_requested_release() -> None:
     assert version("openevolve") == "0.3.1"
 
 
-def test_initialization_persists_empty_policy_for_bootstrap_resume(tmp_path) -> None:
+def test_initialization_persists_empty_policy_for_bootstrap_resume(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     config = _config()
     OpenEvolveSearchPolicy(state_dir=tmp_path, seed=7, config=config)
 
     assert OpenEvolveSearchPolicy.has_state(tmp_path)
     assert OpenEvolveSearchPolicy.persisted_config(tmp_path) == config
     resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=999, config=None)
-    assert resumed._database.programs == {}
+    assert resumed._database.programs == {}  # noqa: SLF001  # tracked: #288
 
 
-def test_openevolve_selection_maps_programs_back_to_vibesys_individuals(tmp_path) -> None:
+def test_openevolve_selection_maps_programs_back_to_vibesys_individuals(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     population = Population([_individual(1)])
     policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=7, config=_config())
     seed = population.passed[0]
@@ -94,7 +94,7 @@ def test_openevolve_selection_maps_programs_back_to_vibesys_individuals(tmp_path
 
     selection = policy.select(
         population,
-        rng=random.Random(99),
+        rng=random.Random(99),  # noqa: S311  # tracked: #288
         k_top_inspirations=1,
         k_random_inspirations=1,
         selection_temperature=0.5,
@@ -111,7 +111,7 @@ def test_openevolve_selection_maps_programs_back_to_vibesys_individuals(tmp_path
     assert (persisted / "programs" / "vibesys-1.json").is_file()
 
 
-def test_migrants_keep_vibesys_identity_and_state_resumes(tmp_path) -> None:
+def test_migrants_keep_vibesys_identity_and_state_resumes(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     seed = _individual(1)
     population = Population([seed])
     policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=3, config=_config())
@@ -133,10 +133,10 @@ def test_migrants_keep_vibesys_identity_and_state_resumes(tmp_path) -> None:
     )
 
     resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=3, config=_config())
-    resumed._database.set_current_island(1)
+    resumed._database.set_current_island(1)  # noqa: SLF001  # tracked: #288
     selection = resumed.select(
         population,
-        rng=random.Random(1),
+        rng=random.Random(1),  # noqa: S311  # tracked: #288
         k_top_inspirations=0,
         k_random_inspirations=0,
         selection_temperature=0.5,
@@ -147,12 +147,12 @@ def test_migrants_keep_vibesys_identity_and_state_resumes(tmp_path) -> None:
     assert selection is not None
     assert selection.parent.id in {seed.id, child.id}
     assert selection.target_island == 1
-    selected_program = resumed._database.programs[selection.policy_parent_id]
+    selected_program = resumed._database.programs[selection.policy_parent_id]  # noqa: SLF001  # tracked: #288
     assert selected_program.metadata["vibesys_individual_id"] == selection.parent.id
     assert selected_program.metadata["migrant"] is True
 
 
-def test_resume_prunes_programs_evicted_before_save(tmp_path) -> None:
+def test_resume_prunes_programs_evicted_before_save(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     config = _config(population_size=2, archive_size=2, num_islands=1)
     policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=config)
     for individual_id in range(1, 6):
@@ -164,17 +164,17 @@ def test_resume_prunes_programs_evicted_before_save(tmp_path) -> None:
             objectives=None,
         )
 
-    active_ids = set(policy._database.programs)
+    active_ids = set(policy._database.programs)  # noqa: SLF001  # tracked: #288
     resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=config)
 
     assert len(active_ids) <= 2
-    assert set(resumed._database.programs) == active_ids
+    assert set(resumed._database.programs) == active_ids  # noqa: SLF001  # tracked: #288
     assert {
         path.stem for path in (_persisted_dir(tmp_path) / "programs").glob("*.json")
     } == active_ids
 
 
-def test_replaying_population_does_not_readmit_evicted_individuals(tmp_path) -> None:
+def test_replaying_population_does_not_readmit_evicted_individuals(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     config = _config(
         population_size=2,
         archive_size=2,
@@ -194,8 +194,8 @@ def test_replaying_population_does_not_readmit_evicted_individuals(tmp_path) -> 
             target_island=0,
             objectives=None,
         )
-    expected_programs = set(policy._database.programs)
-    expected_generations = list(policy._database.island_generations)
+    expected_programs = set(policy._database.programs)  # noqa: SLF001  # tracked: #288
+    expected_generations = list(policy._database.island_generations)  # noqa: SLF001  # tracked: #288
 
     resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=None)
     for individual in individuals:
@@ -207,11 +207,11 @@ def test_replaying_population_does_not_readmit_evicted_individuals(tmp_path) -> 
             objectives=None,
         )
 
-    assert set(resumed._database.programs) == expected_programs
-    assert resumed._database.island_generations == expected_generations
+    assert set(resumed._database.programs) == expected_programs  # noqa: SLF001  # tracked: #288
+    assert resumed._database.island_generations == expected_generations  # noqa: SLF001  # tracked: #288
 
 
-def test_resume_rejects_changed_database_topology(tmp_path) -> None:
+def test_resume_rejects_changed_database_topology(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=_config(num_islands=2))
     policy.record(
         _individual(1),
@@ -225,7 +225,7 @@ def test_resume_rejects_changed_database_topology(tmp_path) -> None:
         OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=_config(num_islands=3))
 
 
-def test_resume_rejects_changed_fitness_objective(tmp_path) -> None:
+def test_resume_rejects_changed_fitness_objective(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     objectives = [Objective("latency_ms", "min")]
     policy = OpenEvolveSearchPolicy(
         state_dir=tmp_path,
@@ -250,7 +250,7 @@ def test_resume_rejects_changed_fitness_objective(tmp_path) -> None:
         )
 
 
-def test_finish_generation_keeps_iteration_monotonic(tmp_path) -> None:
+def test_finish_generation_keeps_iteration_monotonic(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=_config())
     policy.record(
         _individual(20),
@@ -262,13 +262,13 @@ def test_finish_generation_keeps_iteration_monotonic(tmp_path) -> None:
 
     policy.finish_generation(1)
 
-    assert policy._database.last_iteration == 20
+    assert policy._database.last_iteration == 20  # noqa: SLF001  # tracked: #288
     assert (
         json.loads((_persisted_dir(tmp_path) / "metadata.json").read_text())["last_iteration"] == 20
     )
 
 
-def test_zero_migration_rate_disables_upstream_minimum_migrant(tmp_path) -> None:
+def test_zero_migration_rate_disables_upstream_minimum_migrant(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     config = _config(migration_rate=0.0)
     policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=4, config=config)
     policy.record(
@@ -287,11 +287,12 @@ def test_zero_migration_rate_disables_upstream_minimum_migrant(tmp_path) -> None
     )
 
     assert not any(
-        program.metadata.get("migrant") for program in policy._database.programs.values()
+        program.metadata.get("migrant")
+        for program in policy._database.programs.values()  # noqa: SLF001  # tracked: #288
     )
 
 
-def test_empty_island_copy_resolves_through_vibesys_ancestry(tmp_path) -> None:
+def test_empty_island_copy_resolves_through_vibesys_ancestry(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     config = _config(migration_interval=50, migration_rate=0.0)
     seed = _individual(1)
     population = Population([seed])
@@ -303,13 +304,13 @@ def test_empty_island_copy_resolves_through_vibesys_ancestry(tmp_path) -> None:
         target_island=0,
         objectives=None,
     )
-    policy._database.set_current_island(1)
-    policy._database.config.exploration_ratio = 1.0
-    policy._database.config.exploitation_ratio = 0.0
+    policy._database.set_current_island(1)  # noqa: SLF001  # tracked: #288
+    policy._database.config.exploration_ratio = 1.0  # noqa: SLF001  # tracked: #288
+    policy._database.config.exploitation_ratio = 0.0  # noqa: SLF001  # tracked: #288
 
     selection = policy.select(
         population,
-        rng=random.Random(1),
+        rng=random.Random(1),  # noqa: S311  # tracked: #288
         k_top_inspirations=0,
         k_random_inspirations=0,
         selection_temperature=0.5,
@@ -320,11 +321,11 @@ def test_empty_island_copy_resolves_through_vibesys_ancestry(tmp_path) -> None:
     assert selection is not None
     assert selection.parent.id == seed.id
     assert selection.target_island == 1
-    copy = policy._database.programs[selection.policy_parent_id]
+    copy = policy._database.programs[selection.policy_parent_id]  # noqa: SLF001  # tracked: #288
     assert copy.metadata["vibesys_individual_id"] == seed.id
 
 
-def test_empty_island_copy_has_same_identity_after_resume(tmp_path) -> None:
+def test_empty_island_copy_has_same_identity_after_resume(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     config = _config(migration_interval=50, migration_rate=0.0)
     seed = _individual(1)
     population = Population([seed])
@@ -332,12 +333,12 @@ def test_empty_island_copy_has_same_identity_after_resume(tmp_path) -> None:
     policy.record(seed, code="seed", policy_parent_id=None, target_island=0, objectives=None)
     resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=999, config=None)
     for candidate in (policy, resumed):
-        candidate._database.set_current_island(1)
-        candidate._database.config.exploration_ratio = 1.0
-        candidate._database.config.exploitation_ratio = 0.0
+        candidate._database.set_current_island(1)  # noqa: SLF001  # tracked: #288
+        candidate._database.config.exploration_ratio = 1.0  # noqa: SLF001  # tracked: #288
+        candidate._database.config.exploitation_ratio = 0.0  # noqa: SLF001  # tracked: #288
 
     selection_args = {
-        "rng": random.Random(1),
+        "rng": random.Random(1),  # noqa: S311  # tracked: #288
         "k_top_inspirations": 0,
         "k_random_inspirations": 0,
         "selection_temperature": 0.5,
@@ -347,11 +348,11 @@ def test_empty_island_copy_has_same_identity_after_resume(tmp_path) -> None:
     uninterrupted_selection = policy.select(population, **selection_args)
     resumed_selection = resumed.select(population, **selection_args)
 
-    assert uninterrupted_selection is not None and resumed_selection is not None
+    assert uninterrupted_selection is not None and resumed_selection is not None  # noqa: PT018  # tracked: #288
     assert resumed_selection.policy_parent_id == uninterrupted_selection.policy_parent_id
 
 
-def test_migration_has_same_program_identity_after_resume(tmp_path) -> None:
+def test_migration_has_same_program_identity_after_resume(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     initial_dir = tmp_path / "initial"
     config = _config(num_islands=2, migration_interval=1, migration_rate=1.0)
     seed = _individual(1)
@@ -380,13 +381,14 @@ def test_migration_has_same_program_identity_after_resume(tmp_path) -> None:
         objectives=None,
     )
 
-    assert set(uninterrupted._database.programs) == set(resumed._database.programs)
+    assert set(uninterrupted._database.programs) == set(resumed._database.programs)  # noqa: SLF001  # tracked: #288
     assert {
-        program.id: program.timestamp for program in uninterrupted._database.programs.values()
-    } == {program.id: program.timestamp for program in resumed._database.programs.values()}
+        program.id: program.timestamp
+        for program in uninterrupted._database.programs.values()  # noqa: SLF001  # tracked: #288
+    } == {program.id: program.timestamp for program in resumed._database.programs.values()}  # noqa: SLF001  # tracked: #288
 
 
-def test_resume_continues_upstream_random_stream_without_touching_global_rng(tmp_path) -> None:
+def test_resume_continues_upstream_random_stream_without_touching_global_rng(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     config = _config(num_islands=1, migration_rate=0.0)
     population = Population([_individual(individual_id) for individual_id in range(1, 6)])
     policy = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=19, config=config)
@@ -401,7 +403,7 @@ def test_resume_continues_upstream_random_stream_without_touching_global_rng(tmp
 
     global_state = random.getstate()
     selection_args = {
-        "rng": random.Random(1),
+        "rng": random.Random(1),  # noqa: S311  # tracked: #288
         "k_top_inspirations": 0,
         "k_random_inspirations": 0,
         "selection_temperature": 0.5,
@@ -410,23 +412,23 @@ def test_resume_continues_upstream_random_stream_without_touching_global_rng(tmp
     }
     policy.select(population, **selection_args)
     resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=19, config=None)
-    program_ids = sorted(policy._database.programs)
-    policy._database.config.exploration_ratio = 1.0
-    resumed._database.config.exploration_ratio = 1.0
-    policy._database.islands[0] = _IterationOrderSet(program_ids, program_ids)
-    resumed._database.islands[0] = _IterationOrderSet(
+    program_ids = sorted(policy._database.programs)  # noqa: SLF001  # tracked: #288
+    policy._database.config.exploration_ratio = 1.0  # noqa: SLF001  # tracked: #288
+    resumed._database.config.exploration_ratio = 1.0  # noqa: SLF001  # tracked: #288
+    policy._database.islands[0] = _IterationOrderSet(program_ids, program_ids)  # noqa: SLF001  # tracked: #288
+    resumed._database.islands[0] = _IterationOrderSet(  # noqa: SLF001  # tracked: #288
         program_ids,
         program_ids[1:] + program_ids[:1],
     )
     uninterrupted_next = policy.select(population, **selection_args)
     resumed_next = resumed.select(population, **selection_args)
 
-    assert uninterrupted_next is not None and resumed_next is not None
+    assert uninterrupted_next is not None and resumed_next is not None  # noqa: PT018  # tracked: #288
     assert resumed_next.policy_parent_id == uninterrupted_next.policy_parent_id
     assert random.getstate() == global_state
 
 
-def test_selection_uses_lightweight_checkpoint_without_rewriting_programs(tmp_path) -> None:
+def test_selection_uses_lightweight_checkpoint_without_rewriting_programs(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     config = _config(num_islands=1, migration_rate=0.0)
     seed = _individual(1)
     population = Population([seed])
@@ -442,7 +444,7 @@ def test_selection_uses_lightweight_checkpoint_without_rewriting_programs(tmp_pa
 
     selection = policy.select(
         population,
-        rng=random.Random(1),
+        rng=random.Random(1),  # noqa: S311  # tracked: #288
         k_top_inspirations=0,
         k_random_inspirations=0,
         selection_temperature=0.5,
@@ -455,7 +457,7 @@ def test_selection_uses_lightweight_checkpoint_without_rewriting_programs(tmp_pa
     assert (tmp_path / "selection.json").is_file()
 
 
-def test_primary_min_objective_is_signed_for_openevolve_fitness(tmp_path) -> None:
+def test_primary_min_objective_is_signed_for_openevolve_fitness(tmp_path) -> None:  # noqa: ANN001  # tracked: #288
     objectives = [Objective("latency_ms", "min")]
     individual = _individual(1, perf=20.0, metrics={"latency_ms": 20.0})
     policy = OpenEvolveSearchPolicy(
@@ -472,7 +474,7 @@ def test_primary_min_objective_is_signed_for_openevolve_fitness(tmp_path) -> Non
         objectives=objectives,
     )
 
-    assert policy._database.programs["vibesys-1"].metrics["combined_score"] == -20.0
+    assert policy._database.programs["vibesys-1"].metrics["combined_score"] == -20.0  # noqa: SLF001  # tracked: #288
 
 
 @pytest.mark.parametrize(
@@ -486,6 +488,6 @@ def test_primary_min_objective_is_signed_for_openevolve_fitness(tmp_path) -> Non
         {"migration_rate": 1.1},
     ],
 )
-def test_openevolve_config_rejects_invalid_values(kwargs) -> None:
-    with pytest.raises(ValueError):
+def test_openevolve_config_rejects_invalid_values(kwargs) -> None:  # noqa: ANN001  # tracked: #288
+    with pytest.raises(ValueError):  # noqa: PT011  # tracked: #288
         _config(**kwargs)

--- a/tests/loops/plain/test_issue_board_compat.py
+++ b/tests/loops/plain/test_issue_board_compat.py
@@ -18,7 +18,7 @@ from vs_issue_board import (
 from vs_issue_board import mcp as issue_board_mcp
 
 
-def test_issue_board_compat_exports_reusable_package_api():
+def test_issue_board_compat_exports_reusable_package_api():  # noqa: ANN201  # tracked: #288
     assert compat.Issue is Issue
     assert compat.IssueBoard is IssueBoard
     assert compat.IssueEvent is IssueEvent
@@ -26,7 +26,7 @@ def test_issue_board_compat_exports_reusable_package_api():
     assert compat.IssueType is IssueType
 
 
-def test_tool_impl_compat_exports_reusable_package_helpers():
+def test_tool_impl_compat_exports_reusable_package_helpers():  # noqa: ANN201  # tracked: #288
     assert tool_impl.CreateIssuePolicy is CreateIssuePolicy
     assert tool_impl.check_create_allowed is check_create_allowed
     assert tool_impl.create_issue_under_policy is create_issue_under_policy
@@ -35,7 +35,7 @@ def test_tool_impl_compat_exports_reusable_package_helpers():
     assert tool_impl.parse_type is parse_type
 
 
-def test_mcp_server_compat_exports_reusable_package_server():
+def test_mcp_server_compat_exports_reusable_package_server():  # noqa: ANN201  # tracked: #288
     assert mcp_server.build_parser is issue_board_mcp.build_parser
     assert mcp_server.build_server is issue_board_mcp.build_server
     assert mcp_server.main is issue_board_mcp.main

--- a/tests/loops/plain/test_plain_loop.py
+++ b/tests/loops/plain/test_plain_loop.py
@@ -81,11 +81,11 @@ def _make_issue_runner(responses: list, *, backend_name: str = "deepagents") -> 
     runner.backend_name = backend_name
     it = iter(responses)
 
-    def _invoke(*, kind, **kwargs):
+    def _invoke(*, kind, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288
         try:
             return next(it)
         except StopIteration as exc:
-            raise AssertionError(f"invoke called beyond scripted responses (kind={kind})") from exc
+            raise AssertionError(f"invoke called beyond scripted responses (kind={kind})") from exc  # noqa: TRY003  # tracked: #288
 
     runner.invoke.side_effect = _invoke
     return runner
@@ -104,7 +104,7 @@ def _store_path(exp_dir: Path) -> Path:
 
 
 @pytest.fixture
-def ref_file(tmp_path):
+def ref_file(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Create a temporary reference file for run_plain_loop tests."""
     f = tmp_path / "ref.py"
     f.write_text("def predict(x): return x * 2\n")
@@ -119,8 +119,12 @@ def ref_file(tmp_path):
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_bootstrap_creates_initial_feature_issue_on_first_run(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
+def test_bootstrap_creates_initial_feature_issue_on_first_run(  # noqa: ANN201  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     mock_build.return_value = "anthropic:claude-sonnet-4-6"
     mock_build_runner.return_value = _make_issue_runner(
@@ -158,8 +162,12 @@ def test_bootstrap_creates_initial_feature_issue_on_first_run(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_bootstrap_idempotent_on_resume(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
+def test_bootstrap_idempotent_on_resume(  # noqa: ANN201  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """A resumed run with bootstrap_done=True must not re-create the bootstrap issue."""
     mock_build.return_value = "anthropic:claude-sonnet-4-6"
@@ -220,7 +228,7 @@ def test_bootstrap_idempotent_on_resume(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_judge_pass_closes_issue(mock_build_runner, mock_backend, mock_build, ref_file, tmp_path):
+def test_judge_pass_closes_issue(mock_build_runner, mock_backend, mock_build, ref_file, tmp_path):  # noqa: ANN001, ANN201, ARG001  # tracked: #288
     mock_build.return_value = "anthropic:claude-sonnet-4-6"
     mock_build_runner.return_value = _make_issue_runner(
         [
@@ -250,8 +258,12 @@ def test_judge_pass_closes_issue(mock_build_runner, mock_backend, mock_build, re
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_judge_fail_increments_attempts_and_keeps_open(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
+def test_judge_fail_increments_attempts_and_keeps_open(  # noqa: ANN201  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """A FAIL verdict reopens the issue; the next drain pass tries again."""
     mock_build.return_value = "anthropic:claude-sonnet-4-6"
@@ -289,8 +301,12 @@ def test_judge_fail_increments_attempts_and_keeps_open(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_issue_blocks_after_max_attempts_exhausted(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
+def test_issue_blocks_after_max_attempts_exhausted(  # noqa: ANN201  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """With max_attempts_per_issue=2, a fail/fail sequence should mark the issue BLOCKED."""
     mock_build.return_value = "anthropic:claude-sonnet-4-6"
@@ -362,8 +378,13 @@ _EXPECTED_TRACKER_TOOL_NAMES = {
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_judge_invoke_receives_tracker_kwargs(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path, backend_name
+def test_judge_invoke_receives_tracker_kwargs(  # noqa: ANN201, PLR0913  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
+    backend_name,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """The judge phase must receive issue-tracker access scoped to
     creator='judge', cap=1, allowed_types={BUG}.
@@ -402,7 +423,7 @@ def test_judge_invoke_receives_tracker_kwargs(
     if backend_name == "cli":
         assert kwargs.get("tools") is None
         specs = kwargs.get("mcp_servers")
-        assert specs is not None and len(specs) == 1
+        assert specs is not None and len(specs) == 1  # noqa: PT018  # tracked: #288
         spec = specs[0]
         assert spec.name == "vibesys-issues"
         assert spec.command == "python"
@@ -422,8 +443,13 @@ def test_judge_invoke_receives_tracker_kwargs(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_perf_eval_invoke_receives_tracker_kwargs(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path, backend_name
+def test_perf_eval_invoke_receives_tracker_kwargs(  # noqa: ANN201, PLR0913  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
+    backend_name,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """The perf_eval phase must receive issue-tracker access scoped to
     creator='perf_eval', cap=max_issues_per_perf_eval, and the
@@ -461,7 +487,7 @@ def test_perf_eval_invoke_receives_tracker_kwargs(
     if backend_name == "cli":
         assert kwargs.get("tools") is None
         specs = kwargs.get("mcp_servers")
-        assert specs is not None and len(specs) == 1
+        assert specs is not None and len(specs) == 1  # noqa: PT018  # tracked: #288
         spec = specs[0]
         parsed = _spec_args_to_dict(spec.args)
         assert parsed["creator"] == "perf_eval"
@@ -479,8 +505,12 @@ def test_perf_eval_invoke_receives_tracker_kwargs(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_judge_phase_calls_store_reload_after_invoke(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
+def test_judge_phase_calls_store_reload_after_invoke(  # noqa: ANN201  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """After the judge invoke returns, the loop must reload the store so it
     can see any issues the MCP server wrote during the phase."""
@@ -498,11 +528,11 @@ def test_judge_phase_calls_store_reload_after_invoke(
 
     original_reload = IssueBoard.reload
 
-    def tracking_reload(self):
+    def tracking_reload(self):  # noqa: ANN001, ANN202  # tracked: #288
         reload_call_order.append("reload")
         return original_reload(self)
 
-    def tracking_invoke(*, kind, **kwargs):
+    def tracking_invoke(*, kind, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288
         invoke_call_order.append(kind)
         if kind == "implementer":
             return _make_impl_resp(1)
@@ -510,7 +540,7 @@ def test_judge_phase_calls_store_reload_after_invoke(
             return _make_judge_resp(1, verdict="pass")
         if kind == "perf_eval":
             return _make_perf_resp(new_issue_ids=[])
-        raise AssertionError(f"unexpected kind: {kind}")
+        raise AssertionError(f"unexpected kind: {kind}")  # noqa: TRY003  # tracked: #288
 
     runner = MagicMock(spec=AgentRunner)
     runner.backend_name = "deepagents"
@@ -544,8 +574,13 @@ def test_judge_phase_calls_store_reload_after_invoke(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_implementer_invoke_has_no_tracker_kwargs(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path, backend_name
+def test_implementer_invoke_has_no_tracker_kwargs(  # noqa: ANN201, PLR0913  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
+    backend_name,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """The implementer phase has no issue tools (the issue is inlined in
     the prompt), so it must NOT receive ``mcp_servers`` or ``tools``.
@@ -604,8 +639,12 @@ def test_implementer_invoke_has_no_tracker_kwargs(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_perf_eval_runs_after_drain_complete(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
+def test_perf_eval_runs_after_drain_complete(  # noqa: ANN201  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """Within one outer iteration, the order of invoke kinds is impl -> judge -> perf_eval."""
     mock_build.return_value = "anthropic:claude-sonnet-4-6"
@@ -642,7 +681,7 @@ def test_perf_eval_runs_after_drain_complete(
     # Sanity: each phase still got a rendered (non-empty) system prompt.
     for call in runner.invoke.call_args_list:
         sys_prompt = call.kwargs.get("system_prompt")
-        assert isinstance(sys_prompt, str) and sys_prompt.strip()
+        assert isinstance(sys_prompt, str) and sys_prompt.strip()  # noqa: PT018  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
@@ -653,8 +692,12 @@ def test_perf_eval_runs_after_drain_complete(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_resume_with_bootstrap_done_skips_bootstrap_creation(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
+def test_resume_with_bootstrap_done_skips_bootstrap_creation(  # noqa: ANN201  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """Resuming with bootstrap_done=True must not add another bootstrap issue."""
     mock_build.return_value = "anthropic:claude-sonnet-4-6"
@@ -711,8 +754,12 @@ def test_resume_with_bootstrap_done_skips_bootstrap_creation(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_resume_retries_previously_blocked_issue(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
+def test_resume_retries_previously_blocked_issue(  # noqa: ANN201  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """A run that bailed out with all issues BLOCKED should retry those
     issues on resume. The blocked issue's attempts counter is reset so
@@ -787,8 +834,12 @@ def test_resume_retries_previously_blocked_issue(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_run_returns_true_when_perf_eval_files_no_issues_after_clean_drain(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
+def test_run_returns_true_when_perf_eval_files_no_issues_after_clean_drain(  # noqa: ANN201  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """Bootstrap -> pass -> perf_eval files nothing => run returns True and stops."""
     mock_build.return_value = "anthropic:claude-sonnet-4-6"
@@ -823,8 +874,12 @@ def test_run_returns_true_when_perf_eval_files_no_issues_after_clean_drain(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_state_json_written_with_bootstrap_done_after_run(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
+def test_state_json_written_with_bootstrap_done_after_run(  # noqa: ANN201  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """At the end of a successful run, state.json should reflect bootstrap_done=True."""
     mock_build.return_value = "anthropic:claude-sonnet-4-6"
@@ -864,8 +919,12 @@ def test_state_json_written_with_bootstrap_done_after_run(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_issue_loop_writes_per_issue_markdown_via_callback(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
+def test_issue_loop_writes_per_issue_markdown_via_callback(  # noqa: ANN201  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """End-to-end: drive a one-iteration drain cycle and assert that
     ``logs/issues/INDEX.md`` plus a per-issue MD file are written by the
@@ -926,8 +985,12 @@ def test_issue_loop_writes_per_issue_markdown_via_callback(
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
 @patch("vibesys.context.build_agent_runner")
-def test_implementer_retry_user_prompt_includes_prior_judge_feedback(
-    mock_build_runner, mock_backend, mock_build, ref_file, tmp_path
+def test_implementer_retry_user_prompt_includes_prior_judge_feedback(  # noqa: ANN201  # tracked: #288
+    mock_build_runner,  # noqa: ANN001  # tracked: #288
+    mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
+    mock_build,  # noqa: ANN001  # tracked: #288
+    ref_file,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001, ARG001, RUF100  # tracked: #288
 ):
     """When the judge fails an issue and the drain loop retries, the
     second implementer's *user* prompt must include the prior judge

--- a/tests/loops/plain/test_plain_loop.py
+++ b/tests/loops/plain/test_plain_loop.py
@@ -103,7 +103,7 @@ def _store_path(exp_dir: Path) -> Path:
     return exp_dir / "workspace" / "issues.json"
 
 
-@pytest.fixture()
+@pytest.fixture
 def ref_file(tmp_path):
     """Create a temporary reference file for run_plain_loop tests."""
     f = tmp_path / "ref.py"

--- a/tests/loops/plain/test_plain_loop_cli.py
+++ b/tests/loops/plain/test_plain_loop_cli.py
@@ -104,119 +104,119 @@ class TestMain:
                 assert exc_info.value.code == 1
 
     def test_main_passes_round_args_to_run_loop(self):
-        with patch(
-            "sys.argv",
-            [
-                *self._BASE_ARGV,
-                "--max-rounds",
-                "7",
-                "--max-attempts-per-issue",
-                "4",
-                "--max-issues-per-perf-eval",
-                "2",
-            ],
+        with (
+            patch(
+                "sys.argv",
+                [
+                    *self._BASE_ARGV,
+                    "--max-rounds",
+                    "7",
+                    "--max-attempts-per-issue",
+                    "4",
+                    "--max-issues-per-perf-eval",
+                    "2",
+                ],
+            ),
+            self._patch_config(),
+            patch(
+                "vibesys.loops.plain.loop.run_plain_loop",
+                return_value=True,
+            ) as mock_run,
         ):
-            with (
-                self._patch_config(),
-                patch(
-                    "vibesys.loops.plain.loop.run_plain_loop",
-                    return_value=True,
-                ) as mock_run,
-            ):
-                main()
-                kwargs = mock_run.call_args.kwargs
-                assert kwargs["max_rounds"] == 7
-                assert kwargs["max_attempts_per_issue"] == 4
-                assert kwargs["max_issues_per_perf_eval"] == 2
+            main()
+            kwargs = mock_run.call_args.kwargs
+            assert kwargs["max_rounds"] == 7
+            assert kwargs["max_attempts_per_issue"] == 4
+            assert kwargs["max_issues_per_perf_eval"] == 2
 
     def test_main_start_round_overrides_loaded_state(self, tmp_path):
-        with patch(
-            "sys.argv",
-            [
-                *self._BASE_ARGV,
-                "--resume",
-                "fake-run-dir",
-                "--start-round",
-                "3",
-            ],
+        with (
+            patch(
+                "sys.argv",
+                [
+                    *self._BASE_ARGV,
+                    "--resume",
+                    "fake-run-dir",
+                    "--start-round",
+                    "3",
+                ],
+            ),
+            self._patch_config(),
+            patch(
+                "vibesys.main._resolve_run_dir",
+                return_value="fake-run-dir",
+            ),
+            patch(
+                "vibesys.loops.plain.loop.run_plain_loop",
+                return_value=True,
+            ) as mock_run,
         ):
-            with (
-                self._patch_config(),
-                patch(
-                    "vibesys.main._resolve_run_dir",
-                    return_value="fake-run-dir",
-                ),
-                patch(
-                    "vibesys.loops.plain.loop.run_plain_loop",
-                    return_value=True,
-                ) as mock_run,
-            ):
-                main()
-                kwargs = mock_run.call_args.kwargs
-                assert kwargs["existing"] is True
-                state = kwargs["resume_state"]
-                assert isinstance(state, PlainLoopState)
-                assert state.round_idx == 2  # 0-indexed
-                assert state.bootstrap_done is True
+            main()
+            kwargs = mock_run.call_args.kwargs
+            assert kwargs["existing"] is True
+            state = kwargs["resume_state"]
+            assert isinstance(state, PlainLoopState)
+            assert state.round_idx == 2  # 0-indexed
+            assert state.bootstrap_done is True
 
     def test_main_forwards_agent_backend_and_cli_provider(self):
-        with patch(
-            "sys.argv",
-            [
-                *self._BASE_ARGV,
-                "--agent-backend",
-                "cli",
-                "--cli-provider",
-                "claude",
-            ],
+        with (
+            patch(
+                "sys.argv",
+                [
+                    *self._BASE_ARGV,
+                    "--agent-backend",
+                    "cli",
+                    "--cli-provider",
+                    "claude",
+                ],
+            ),
+            self._patch_config(),
+            patch(
+                "vibesys.loops.plain.loop.run_plain_loop",
+                return_value=True,
+            ) as mock_run,
         ):
-            with (
-                self._patch_config(),
-                patch(
-                    "vibesys.loops.plain.loop.run_plain_loop",
-                    return_value=True,
-                ) as mock_run,
-            ):
-                main()
-                kwargs = mock_run.call_args.kwargs
-                assert kwargs["agent_backend"] == "cli"
-                assert kwargs["cli_provider"] == "claude"
+            main()
+            kwargs = mock_run.call_args.kwargs
+            assert kwargs["agent_backend"] == "cli"
+            assert kwargs["cli_provider"] == "claude"
 
     def test_main_defaults_agent_backend_and_cli_provider_to_none(self):
-        with patch("sys.argv", list(self._BASE_ARGV)):
-            with (
-                self._patch_config(),
-                patch(
-                    "vibesys.loops.plain.loop.run_plain_loop",
-                    return_value=True,
-                ) as mock_run,
-            ):
-                main()
-                kwargs = mock_run.call_args.kwargs
-                assert kwargs["agent_backend"] is None
-                assert kwargs["cli_provider"] is None
+        with (
+            patch("sys.argv", list(self._BASE_ARGV)),
+            self._patch_config(),
+            patch(
+                "vibesys.loops.plain.loop.run_plain_loop",
+                return_value=True,
+            ) as mock_run,
+        ):
+            main()
+            kwargs = mock_run.call_args.kwargs
+            assert kwargs["agent_backend"] is None
+            assert kwargs["cli_provider"] is None
 
     @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
     def test_main_accepts_all_cli_providers(self, provider):
         """All four CLI providers must reach run_plain_loop without raising."""
-        with patch(
-            "sys.argv",
-            [
-                *self._BASE_ARGV,
-                "--agent-backend",
-                "cli",
-                "--cli-provider",
-                provider,
-            ],
+        with (
+            patch(
+                "sys.argv",
+                [
+                    *self._BASE_ARGV,
+                    "--agent-backend",
+                    "cli",
+                    "--cli-provider",
+                    provider,
+                ],
+            ),
+            self._patch_config(),
+            patch(
+                "vibesys.loops.plain.loop.run_plain_loop",
+                return_value=True,
+            ) as mock_run,
         ):
-            with (
-                self._patch_config(),
-                patch(
-                    "vibesys.loops.plain.loop.run_plain_loop",
-                    return_value=True,
-                ) as mock_run,
-            ):
-                main()
-                kwargs = mock_run.call_args.kwargs
-                assert kwargs["agent_backend"] == "cli"
-                assert kwargs["cli_provider"] == provider
+            main()
+            kwargs = mock_run.call_args.kwargs
+            assert kwargs["agent_backend"] == "cli"
+            assert kwargs["cli_provider"] == provider

--- a/tests/loops/plain/test_plain_loop_cli.py
+++ b/tests/loops/plain/test_plain_loop_cli.py
@@ -15,37 +15,37 @@ TARGET_ARGS = [
 
 
 class TestBuildParser:
-    def test_default_max_rounds(self):
+    def test_default_max_rounds(self):  # noqa: ANN201  # tracked: #288
         parser = build_parser()
         args = parser.parse_args([])
         assert args.max_rounds == 5
 
-    def test_default_max_attempts_per_issue(self):
+    def test_default_max_attempts_per_issue(self):  # noqa: ANN201  # tracked: #288
         parser = build_parser()
         args = parser.parse_args([])
         assert args.max_attempts_per_issue == 3
 
-    def test_default_max_issues_per_perf_eval(self):
+    def test_default_max_issues_per_perf_eval(self):  # noqa: ANN201  # tracked: #288
         parser = build_parser()
         args = parser.parse_args([])
         assert args.max_issues_per_perf_eval == 3
 
-    def test_default_resume_is_none(self):
+    def test_default_resume_is_none(self):  # noqa: ANN201  # tracked: #288
         parser = build_parser()
         args = parser.parse_args([])
         assert args.resume is None
 
-    def test_resume_without_value_defaults_to_latest(self):
+    def test_resume_without_value_defaults_to_latest(self):  # noqa: ANN201  # tracked: #288
         parser = build_parser()
         args = parser.parse_args(["--resume"])
         assert args.resume == "latest"
 
-    def test_resume_with_explicit_dir(self):
+    def test_resume_with_explicit_dir(self):  # noqa: ANN201  # tracked: #288
         parser = build_parser()
         args = parser.parse_args(["--resume", "20260408-090000-test"])
         assert args.resume == "20260408-090000-test"
 
-    def test_overrides_for_rounds(self):
+    def test_overrides_for_rounds(self):  # noqa: ANN201  # tracked: #288
         parser = build_parser()
         args = parser.parse_args(
             [
@@ -61,7 +61,7 @@ class TestBuildParser:
         assert args.max_attempts_per_issue == 5
         assert args.max_issues_per_perf_eval == 2
 
-    def test_common_args_present(self):
+    def test_common_args_present(self):  # noqa: ANN201  # tracked: #288
         parser = build_parser()
         args = parser.parse_args(["--exp-name", "myexp"])
         assert args.exp_name == "myexp"
@@ -71,16 +71,16 @@ class TestBuildParser:
 
 
 class TestMain:
-    _BASE_ARGV = ["vibesys", "--outer-loop", "plain", "--local", *TARGET_ARGS]
+    _BASE_ARGV = ["vibesys", "--outer-loop", "plain", "--local", *TARGET_ARGS]  # noqa: RUF012  # tracked: #288
 
-    def _patch_run(self, return_value: bool):
+    def _patch_run(self, return_value: bool):  # noqa: ANN202, FBT001  # tracked: #288
         return patch(
             "vibesys.loops.plain.loop.run_plain_loop",
             return_value=return_value,
         )
 
-    def _patch_config(self):
-        from vibesys.constants import DEFAULT_COMPUTE_BACKEND
+    def _patch_config(self):  # noqa: ANN202  # tracked: #288
+        from vibesys.constants import DEFAULT_COMPUTE_BACKEND  # noqa: PLC0415  # tracked: #288
 
         return patch(
             "vibesys.main.load_config_and_skills",
@@ -91,19 +91,19 @@ class TestMain:
             ),
         )
 
-    def test_main_exits_zero_on_success(self):
-        with patch("sys.argv", list(self._BASE_ARGV)):
-            with self._patch_config(), self._patch_run(True):
+    def test_main_exits_zero_on_success(self):  # noqa: ANN201  # tracked: #288
+        with patch("sys.argv", list(self._BASE_ARGV)):  # noqa: SIM117  # tracked: #288
+            with self._patch_config(), self._patch_run(True):  # noqa: FBT003  # tracked: #288
                 main()
 
-    def test_main_exits_one_on_failure(self):
-        with patch("sys.argv", list(self._BASE_ARGV)):
-            with self._patch_config(), self._patch_run(False):
+    def test_main_exits_one_on_failure(self):  # noqa: ANN201  # tracked: #288
+        with patch("sys.argv", list(self._BASE_ARGV)):  # noqa: SIM117  # tracked: #288
+            with self._patch_config(), self._patch_run(False):  # noqa: FBT003  # tracked: #288
                 with pytest.raises(SystemExit) as exc_info:
                     main()
                 assert exc_info.value.code == 1
 
-    def test_main_passes_round_args_to_run_loop(self):
+    def test_main_passes_round_args_to_run_loop(self):  # noqa: ANN201  # tracked: #288
         with (
             patch(
                 "sys.argv",
@@ -129,7 +129,7 @@ class TestMain:
             assert kwargs["max_attempts_per_issue"] == 4
             assert kwargs["max_issues_per_perf_eval"] == 2
 
-    def test_main_start_round_overrides_loaded_state(self, tmp_path):
+    def test_main_start_round_overrides_loaded_state(self, tmp_path):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         with (
             patch(
                 "sys.argv",
@@ -159,7 +159,7 @@ class TestMain:
             assert state.round_idx == 2  # 0-indexed
             assert state.bootstrap_done is True
 
-    def test_main_forwards_agent_backend_and_cli_provider(self):
+    def test_main_forwards_agent_backend_and_cli_provider(self):  # noqa: ANN201  # tracked: #288
         with (
             patch(
                 "sys.argv",
@@ -182,7 +182,7 @@ class TestMain:
             assert kwargs["agent_backend"] == "cli"
             assert kwargs["cli_provider"] == "claude"
 
-    def test_main_defaults_agent_backend_and_cli_provider_to_none(self):
+    def test_main_defaults_agent_backend_and_cli_provider_to_none(self):  # noqa: ANN201  # tracked: #288
         with (
             patch("sys.argv", list(self._BASE_ARGV)),
             self._patch_config(),
@@ -197,7 +197,7 @@ class TestMain:
             assert kwargs["cli_provider"] is None
 
     @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
-    def test_main_accepts_all_cli_providers(self, provider):
+    def test_main_accepts_all_cli_providers(self, provider):  # noqa: ANN001, ANN201  # tracked: #288
         """All four CLI providers must reach run_plain_loop without raising."""
         with (
             patch(

--- a/tests/loops/plain/test_plain_loop_state.py
+++ b/tests/loops/plain/test_plain_loop_state.py
@@ -11,7 +11,7 @@ from vibesys.loops.plain.loop import (
 from vs_issue_board import IssueBoard, IssueStatus, IssueType
 
 
-def _make_store(tmp_path) -> IssueBoard:
+def _make_store(tmp_path) -> IssueBoard:  # noqa: ANN001  # tracked: #288
     return IssueBoard(tmp_path / "issues.json")
 
 
@@ -21,7 +21,7 @@ def _make_store(tmp_path) -> IssueBoard:
 
 
 class TestSaveLoadState:
-    def test_round_trip(self, tmp_path):
+    def test_round_trip(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         state = PlainLoopState(
             round_idx=2,
             phase="judge",
@@ -36,25 +36,25 @@ class TestSaveLoadState:
         assert loaded.current_issue_id == 5
         assert loaded.bootstrap_done is True
 
-    def test_load_missing(self, tmp_path):
+    def test_load_missing(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         assert load_state(tmp_path) is None
 
-    def test_load_corrupt_json(self, tmp_path):
+    def test_load_corrupt_json(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         (tmp_path / "state.json").write_text("not json", encoding="utf-8")
         assert load_state(tmp_path) is None
 
-    def test_load_wrong_version(self, tmp_path):
+    def test_load_wrong_version(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         (tmp_path / "state.json").write_text(
             json.dumps({"version": 999, "iteration": 0}), encoding="utf-8"
         )
         assert load_state(tmp_path) is None
 
-    def test_atomic_write_leaves_no_tmp(self, tmp_path):
+    def test_atomic_write_leaves_no_tmp(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         _save_state(tmp_path, PlainLoopState())
         assert not (tmp_path / "state.json.tmp").exists()
         assert (tmp_path / "state.json").exists()
 
-    def test_load_ignores_extra_fields(self, tmp_path):
+    def test_load_ignores_extra_fields(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         data = {
             "version": 1,
             "round_idx": 3,
@@ -76,14 +76,14 @@ class TestSaveLoadState:
 
 
 class TestDetermineResumePoint:
-    def test_none_state_starts_fresh(self, tmp_path):
+    def test_none_state_starts_fresh(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         i, phase, issue_id = _determine_resume_point(None, store)
         assert i == 0
         assert phase == "implementer"
         assert issue_id is None
 
-    def test_mid_implementer_re_runs_implementer(self, tmp_path):
+    def test_mid_implementer_re_runs_implementer(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         issue = store.create(
             type=IssueType.BUG,
@@ -101,7 +101,7 @@ class TestDetermineResumePoint:
         assert phase == "implementer"
         assert issue_id == issue.id
 
-    def test_mid_judge_re_runs_judge(self, tmp_path):
+    def test_mid_judge_re_runs_judge(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         issue = store.create(
             type=IssueType.BUG,
@@ -119,7 +119,7 @@ class TestDetermineResumePoint:
         assert phase == "judge"
         assert issue_id == issue.id
 
-    def test_resume_picks_drain_when_open_issues_remain(self, tmp_path):
+    def test_resume_picks_drain_when_open_issues_remain(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         store.create(type=IssueType.BUG, title="t", description="d", created_by="x", iteration=1)
         # Loop was past judge, no current_issue_id
@@ -131,7 +131,7 @@ class TestDetermineResumePoint:
         assert phase == "implementer"
         assert issue_id is None
 
-    def test_resume_goes_to_implementer_when_no_open_issues(self, tmp_path):
+    def test_resume_goes_to_implementer_when_no_open_issues(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         # When no open issues remain, _determine_resume_point returns
         # phase="implementer" — the drain loop in run_plain_loop will
         # immediately exit (next_open() is None) and fall through to
@@ -145,11 +145,11 @@ class TestDetermineResumePoint:
         state = PlainLoopState(
             round_idx=1, phase="implementer", current_issue_id=None, bootstrap_done=True
         )
-        i, phase, issue_id = _determine_resume_point(state, store)
+        i, phase, issue_id = _determine_resume_point(state, store)  # noqa: RUF059  # tracked: #288
         assert phase == "implementer"
         assert issue_id is None
 
-    def test_resume_after_perf_eval_with_no_open_issues(self, tmp_path):
+    def test_resume_after_perf_eval_with_no_open_issues(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """If we crashed during/after perf_eval with no open issues left,
         _determine_resume_point should return phase='implementer'. The
         drain loop will then immediately exit (next_open() is None) and
@@ -167,7 +167,7 @@ class TestDetermineResumePoint:
         assert phase == "implementer"
         assert issue_id is None
 
-    def test_resume_skips_stale_current_issue_id_if_already_closed(self, tmp_path):
+    def test_resume_skips_stale_current_issue_id_if_already_closed(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         # If state.current_issue_id points at an issue that the store says is
         # already CLOSED (race after a crash), we should NOT try to re-run
         # that phase. Instead, drain remaining open issues.
@@ -180,7 +180,7 @@ class TestDetermineResumePoint:
         state = PlainLoopState(
             round_idx=0, phase="judge", current_issue_id=closed.id, bootstrap_done=True
         )
-        i, phase, issue_id = _determine_resume_point(state, store)
+        i, phase, issue_id = _determine_resume_point(state, store)  # noqa: RUF059  # tracked: #288
         # Should NOT try to re-run judge on the closed issue
         assert not (phase == "judge" and issue_id == closed.id)
         assert phase == "implementer"

--- a/tests/loops/plain/test_plain_runner_ext.py
+++ b/tests/loops/plain/test_plain_runner_ext.py
@@ -30,11 +30,11 @@ def _mock_runner(backend_name: str) -> MagicMock:
     return runner
 
 
-def _make_store(tmp_path) -> IssueBoard:
+def _make_store(tmp_path) -> IssueBoard:  # noqa: ANN001  # tracked: #288
     return IssueBoard(tmp_path / "issues.json")
 
 
-def _tool_names(tools) -> set[str]:
+def _tool_names(tools) -> set[str]:  # noqa: ANN001  # tracked: #288
     return {t.name for t in tools}
 
 
@@ -44,7 +44,7 @@ def _tool_names(tools) -> set[str]:
 
 
 class TestDeepAgentsBackend:
-    def test_judge_receives_in_process_tools(self, tmp_path):
+    def test_judge_receives_in_process_tools(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
@@ -57,7 +57,7 @@ class TestDeepAgentsBackend:
         assert kwargs["mcp_servers"] is None
         assert _tool_names(kwargs["tools"]) == _EXPECTED_TOOL_NAMES
 
-    def test_perf_eval_receives_in_process_tools(self, tmp_path):
+    def test_perf_eval_receives_in_process_tools(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=4)
@@ -69,7 +69,7 @@ class TestDeepAgentsBackend:
         assert kwargs["mcp_servers"] is None
         assert _tool_names(kwargs["tools"]) == _EXPECTED_TOOL_NAMES
 
-    def test_perf_eval_cap_comes_from_constructor(self, tmp_path):
+    def test_perf_eval_cap_comes_from_constructor(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """The perf_eval cap reaches build_issue_tools verbatim — file 5
         issues and the 6th must be rejected with the cap-reached error."""
         store = _make_store(tmp_path)
@@ -87,7 +87,7 @@ class TestDeepAgentsBackend:
         sixth = create.invoke({"type": "perf", "title": "overflow", "description": "d"})
         assert "cap" in sixth.lower() or "limit" in sixth.lower()
 
-    def test_judge_create_issue_rejects_non_bug_types(self, tmp_path):
+    def test_judge_create_issue_rejects_non_bug_types(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Judge is bug-only — feature/perf must be rejected by policy."""
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
@@ -108,7 +108,7 @@ class TestDeepAgentsBackend:
 
 
 class TestCliBackend:
-    def test_judge_receives_mcp_server_spec(self, tmp_path):
+    def test_judge_receives_mcp_server_spec(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("cli")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
@@ -131,7 +131,7 @@ class TestCliBackend:
         i_at = spec.args.index("--allowed-types")
         assert spec.args[i_at + 1] == "bug"
 
-    def test_perf_eval_receives_mcp_server_spec_with_all_types(self, tmp_path):
+    def test_perf_eval_receives_mcp_server_spec_with_all_types(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("cli")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=4)
@@ -155,7 +155,7 @@ class TestCliBackend:
 
 
 class TestPassThrough:
-    def test_implementer_passes_through_under_deepagents(self, tmp_path):
+    def test_implementer_passes_through_under_deepagents(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
@@ -167,7 +167,7 @@ class TestPassThrough:
         assert kwargs["mcp_servers"] is None
         assert kwargs["tools"] is None
 
-    def test_implementer_passes_through_under_cli(self, tmp_path):
+    def test_implementer_passes_through_under_cli(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("cli")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
@@ -178,7 +178,7 @@ class TestPassThrough:
         assert kwargs["mcp_servers"] is None
         assert kwargs["tools"] is None
 
-    def test_iteration_kwarg_is_consumed_not_forwarded(self, tmp_path):
+    def test_iteration_kwarg_is_consumed_not_forwarded(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """The wrapper consumes ``iteration=`` and must not pass it to the
         inner runner — the AgentRunner Protocol has no such kwarg."""
         store = _make_store(tmp_path)
@@ -189,7 +189,7 @@ class TestPassThrough:
 
         assert "iteration" not in inner.invoke.call_args.kwargs
 
-    def test_extra_kwargs_are_forwarded(self, tmp_path):
+    def test_extra_kwargs_are_forwarded(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Caller-supplied kwargs (workspace, system_prompt, etc.) must
         reach the inner runner unchanged."""
         store = _make_store(tmp_path)
@@ -200,21 +200,21 @@ class TestPassThrough:
             response_cls=_Resp,
             kind="judge",
             iteration=1,
-            workspace="/tmp/ws",
+            workspace="/tmp/ws",  # noqa: S108  # tracked: #288
             system_prompt="sys",
             user_prompt="user",
             round_label="r",
         )
 
         kwargs = inner.invoke.call_args.kwargs
-        assert kwargs["workspace"] == "/tmp/ws"
+        assert kwargs["workspace"] == "/tmp/ws"  # noqa: S108  # tracked: #288
         assert kwargs["system_prompt"] == "sys"
         assert kwargs["user_prompt"] == "user"
         assert kwargs["round_label"] == "r"
 
 
 class TestValidation:
-    def test_judge_without_iteration_raises(self, tmp_path):
+    def test_judge_without_iteration_raises(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         wrapper = PlainLoopAgentRunner(
             _mock_runner("deepagents"),
@@ -224,7 +224,7 @@ class TestValidation:
         with pytest.raises(ValueError, match="iteration"):
             wrapper.invoke(response_cls=_Resp, kind="judge", round_label="r")
 
-    def test_perf_eval_without_iteration_raises(self, tmp_path):
+    def test_perf_eval_without_iteration_raises(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         wrapper = PlainLoopAgentRunner(
             _mock_runner("cli"),
@@ -236,7 +236,7 @@ class TestValidation:
 
 
 class TestBackendName:
-    def test_backend_name_proxies_inner(self, tmp_path):
+    def test_backend_name_proxies_inner(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
         wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)

--- a/tests/loops/test_profiler.py
+++ b/tests/loops/test_profiler.py
@@ -167,7 +167,7 @@ def test_run_profiler_agent_no_response():
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture()
+@pytest.fixture
 def nsys_db(tmp_path):
     """Create a minimal nsys-like SQLite database for testing."""
     db_path = tmp_path / "test.sqlite"

--- a/tests/loops/test_profiler.py
+++ b/tests/loops/test_profiler.py
@@ -24,7 +24,7 @@ from vibesys.schemas import (
 # ---------------------------------------------------------------------------
 
 
-def test_profiler_response_creation():
+def test_profiler_response_creation():  # noqa: ANN201  # tracked: #288
     resp = ProfilerResponse(
         analysis="GPU is 85% busy, attention kernels dominate.",
         bottlenecks="1. flash_fwd_kernel (45% GPU time)\n2. rmsnorm_kernel (8%, 60 launches)",
@@ -35,7 +35,7 @@ def test_profiler_response_creation():
     assert "FlashInfer" in resp.suggestions
 
 
-def test_profiler_response_from_dict():
+def test_profiler_response_from_dict():  # noqa: ANN201  # tracked: #288
     data = {
         "analysis": "CPU launch overhead exceeds GPU exec time.",
         "bottlenecks": "Launch-bound: CPU/GPU ratio 1.7x",
@@ -45,7 +45,7 @@ def test_profiler_response_from_dict():
     assert resp.analysis == data["analysis"]
 
 
-def test_profiler_response_serialization():
+def test_profiler_response_serialization():  # noqa: ANN201  # tracked: #288
     resp = ProfilerResponse(
         analysis="Analysis.",
         bottlenecks="Bottlenecks.",
@@ -62,7 +62,7 @@ def test_profiler_response_serialization():
 # ---------------------------------------------------------------------------
 
 
-def _profiler_json(**overrides):
+def _profiler_json(**overrides):  # noqa: ANN003, ANN202  # tracked: #288
     data = {
         "analysis": "Kernel analysis here.",
         "bottlenecks": "Top bottleneck: attention at 45%.",
@@ -72,32 +72,32 @@ def _profiler_json(**overrides):
     return json.dumps(data)
 
 
-def test_parse_profiler_response_raw_json():
+def test_parse_profiler_response_raw_json():  # noqa: ANN201  # tracked: #288
     text = _profiler_json()
     resp = _parse_profiler_response_text(text)
     assert resp is not None
     assert resp.analysis == "Kernel analysis here."
 
 
-def test_parse_profiler_response_fenced_json():
+def test_parse_profiler_response_fenced_json():  # noqa: ANN201  # tracked: #288
     text = f"```json\n{_profiler_json()}\n```"
     resp = _parse_profiler_response_text(text)
     assert resp is not None
     assert "attention" in resp.bottlenecks
 
 
-def test_parse_profiler_response_with_surrounding_text():
+def test_parse_profiler_response_with_surrounding_text():  # noqa: ANN201  # tracked: #288
     text = f"Here is the analysis:\n{_profiler_json()}\nDone."
     resp = _parse_profiler_response_text(text)
     assert resp is not None
 
 
-def test_parse_profiler_response_empty():
+def test_parse_profiler_response_empty():  # noqa: ANN201  # tracked: #288
     assert _parse_profiler_response_text("") is None
     assert _parse_profiler_response_text("no json here") is None
 
 
-def test_parse_profiler_response_invalid_json():
+def test_parse_profiler_response_invalid_json():  # noqa: ANN201  # tracked: #288
     assert _parse_profiler_response_text("{invalid json}") is None
 
 
@@ -106,7 +106,7 @@ def test_parse_profiler_response_invalid_json():
 # ---------------------------------------------------------------------------
 
 
-def test_run_profiler_agent_structured_response():
+def test_run_profiler_agent_structured_response():  # noqa: ANN201  # tracked: #288
     """Agent returns structured response via stream."""
     agent = MagicMock()
     resp_data = ProfilerResponse(
@@ -129,7 +129,7 @@ def test_run_profiler_agent_structured_response():
     assert result.bottlenecks == "Attention dominates."
 
 
-def test_run_profiler_agent_fallback_json_parsing():
+def test_run_profiler_agent_fallback_json_parsing():  # noqa: ANN201  # tracked: #288
     """Agent returns JSON text instead of structured response."""
     agent = MagicMock()
     json_text = _profiler_json(analysis="Fallback parsing.")
@@ -146,7 +146,7 @@ def test_run_profiler_agent_fallback_json_parsing():
     assert result.analysis == "Fallback parsing."
 
 
-def test_run_profiler_agent_no_response():
+def test_run_profiler_agent_no_response():  # noqa: ANN201  # tracked: #288
     """Agent returns no parseable response."""
     agent = MagicMock()
     agent.stream.return_value = iter(
@@ -168,7 +168,7 @@ def test_run_profiler_agent_no_response():
 
 
 @pytest.fixture
-def nsys_db(tmp_path):
+def nsys_db(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Create a minimal nsys-like SQLite database for testing."""
     db_path = tmp_path / "test.sqlite"
     conn = sqlite3.connect(str(db_path))
@@ -232,8 +232,11 @@ def nsys_db(tmp_path):
     return str(db_path)
 
 
-def test_analyze_kernels(nsys_db):
-    from resources.profilers.nsys.analyze_nsys import _build_string_map, analyze_kernels
+def test_analyze_kernels(nsys_db):  # noqa: ANN001, ANN201  # tracked: #288
+    from resources.profilers.nsys.analyze_nsys import (  # noqa: PLC0415  # tracked: #288
+        _build_string_map,
+        analyze_kernels,
+    )
 
     conn = sqlite3.connect(nsys_db)
     strings = _build_string_map(conn)
@@ -246,8 +249,11 @@ def test_analyze_kernels(nsys_db):
     assert "Total GPU kernel time" in result
 
 
-def test_analyze_cpu_overhead(nsys_db):
-    from resources.profilers.nsys.analyze_nsys import _build_string_map, analyze_cpu_overhead
+def test_analyze_cpu_overhead(nsys_db):  # noqa: ANN001, ANN201  # tracked: #288
+    from resources.profilers.nsys.analyze_nsys import (  # noqa: PLC0415  # tracked: #288
+        _build_string_map,
+        analyze_cpu_overhead,
+    )
 
     conn = sqlite3.connect(nsys_db)
     strings = _build_string_map(conn)
@@ -260,8 +266,11 @@ def test_analyze_cpu_overhead(nsys_db):
     assert "cudaDeviceSynchronize" in result or "1 calls" in result
 
 
-def test_analyze_gpu_idle_gaps(nsys_db):
-    from resources.profilers.nsys.analyze_nsys import _build_string_map, analyze_gpu_idle_gaps
+def test_analyze_gpu_idle_gaps(nsys_db):  # noqa: ANN001, ANN201  # tracked: #288
+    from resources.profilers.nsys.analyze_nsys import (  # noqa: PLC0415  # tracked: #288
+        _build_string_map,
+        analyze_gpu_idle_gaps,
+    )
 
     conn = sqlite3.connect(nsys_db)
     strings = _build_string_map(conn)
@@ -273,8 +282,10 @@ def test_analyze_gpu_idle_gaps(nsys_db):
     assert "idle gaps" in result.lower() or "Idle gaps" in result
 
 
-def test_analyze_memory_ops(nsys_db):
-    from resources.profilers.nsys.analyze_nsys import analyze_memory_ops
+def test_analyze_memory_ops(nsys_db):  # noqa: ANN001, ANN201  # tracked: #288
+    from resources.profilers.nsys.analyze_nsys import (  # noqa: PLC0415  # tracked: #288
+        analyze_memory_ops,
+    )
 
     conn = sqlite3.connect(nsys_db)
     result = analyze_memory_ops(conn)
@@ -283,8 +294,10 @@ def test_analyze_memory_ops(nsys_db):
     assert "HtoD" in result
 
 
-def test_short_kernel_name():
-    from resources.profilers.nsys.analyze_nsys import _short_kernel_name
+def test_short_kernel_name():  # noqa: ANN201  # tracked: #288
+    from resources.profilers.nsys.analyze_nsys import (  # noqa: PLC0415  # tracked: #288
+        _short_kernel_name,
+    )
 
     assert (
         _short_kernel_name("void at::native::vectorized_elementwise_kernel<4, float>")

--- a/tests/loops/test_profiler_mcp.py
+++ b/tests/loops/test_profiler_mcp.py
@@ -20,7 +20,7 @@ from vibesys.profilers import ProfilerKind
 
 # The servers live under resources/ (co-located with the analysis scripts) so
 # importing them by file path keeps the tests decoupled from sys.path state.
-def _load_module(name: str, path: Path):
+def _load_module(name: str, path: Path):  # noqa: ANN202  # tracked: #288
     spec = importlib.util.spec_from_file_location(name, str(path))
     module = importlib.util.module_from_spec(spec)
     # Inject the server's parent dir onto sys.path BEFORE exec so the
@@ -42,7 +42,7 @@ def _load_module(name: str, path: Path):
 _REPO = Path(__file__).resolve().parent.parent.parent
 
 
-def test_profiler_mcp_spec_maps_known_kinds_exactly():
+def test_profiler_mcp_spec_maps_known_kinds_exactly():  # noqa: ANN201  # tracked: #288
     assert mcp_spec(ProfilerKind.NONE) is None
 
     nsys = mcp_spec(ProfilerKind.NSYS)
@@ -66,13 +66,13 @@ def test_profiler_mcp_spec_maps_known_kinds_exactly():
     assert macos.args == ["macos_cpu_profiler/server.py"]
 
 
-def test_profiler_mcp_spec_rejects_unknown_kind():
+def test_profiler_mcp_spec_rejects_unknown_kind():  # noqa: ANN201  # tracked: #288
     with pytest.raises(TypeError, match="ProfilerKind"):
         mcp_spec("bogus")
 
 
 @pytest.fixture(scope="module")
-def nsys_server_mod():
+def nsys_server_mod():  # noqa: ANN201  # tracked: #288
     return _load_module(
         "_nsys_server",
         _REPO / "resources" / "profilers" / "nsys" / "server.py",
@@ -80,7 +80,7 @@ def nsys_server_mod():
 
 
 @pytest.fixture(scope="module")
-def torch_server_mod():
+def torch_server_mod():  # noqa: ANN201  # tracked: #288
     return _load_module(
         "_torch_server",
         _REPO / "resources" / "profilers" / "torch" / "server.py",
@@ -88,19 +88,19 @@ def torch_server_mod():
 
 
 @pytest.fixture(scope="module")
-def otel_server_mod():
+def otel_server_mod():  # noqa: ANN201  # tracked: #288
     return _load_module(
         "_otel_server",
         _REPO / "resources" / "profilers" / "otel" / "server.py",
     )
 
 
-async def _list_tool_names(server) -> set[str]:
+async def _list_tool_names(server) -> set[str]:  # noqa: ANN001  # tracked: #288
     tools = await server.list_tools()
     return {t.name for t in tools}
 
 
-async def _call_tool(server, name: str, **kwargs) -> str:
+async def _call_tool(server, name: str, **kwargs) -> str:  # noqa: ANN001, ANN003  # tracked: #288
     _, structured = await server.call_tool(name, kwargs)
     return structured["result"]
 
@@ -111,7 +111,7 @@ async def _call_tool(server, name: str, **kwargs) -> str:
 
 
 class TestNsysMcpServer:
-    def test_registers_expected_tools(self, nsys_server_mod):
+    def test_registers_expected_tools(self, nsys_server_mod):  # noqa: ANN001, ANN201  # tracked: #288
         server = nsys_server_mod.build_server()
         names = asyncio.run(_list_tool_names(server))
         assert names == {
@@ -127,7 +127,7 @@ class TestNsysMcpServer:
             "summary",
         }
 
-    def test_tables_tool_reports_empty_db(self, nsys_server_mod, tmp_path):
+    def test_tables_tool_reports_empty_db(self, nsys_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """Against an empty SQLite file, ``tables`` returns a no-output marker."""
         db = tmp_path / "empty.sqlite"
         sqlite3.connect(str(db)).close()
@@ -138,7 +138,7 @@ class TestNsysMcpServer:
         # coerces that to "(no output)".
         assert out == "(no output)"
 
-    def test_kernels_tool_reports_no_data(self, nsys_server_mod, tmp_path):
+    def test_kernels_tool_reports_no_data(self, nsys_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """A SQLite file without a CUPTI_ACTIVITY_KIND_KERNEL table returns a friendly message."""
         db = tmp_path / "nokernels.sqlite"
         sqlite3.connect(str(db)).close()
@@ -147,7 +147,7 @@ class TestNsysMcpServer:
         out = asyncio.run(_call_tool(server, "kernels", report=str(db)))
         assert "No kernel data" in out
 
-    def test_query_tool_runs_arbitrary_sql(self, nsys_server_mod, tmp_path):
+    def test_query_tool_runs_arbitrary_sql(self, nsys_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         db = tmp_path / "q.sqlite"
         conn = sqlite3.connect(str(db))
         conn.execute("CREATE TABLE t (x INTEGER, y TEXT)")
@@ -170,12 +170,12 @@ class TestNsysMcpServer:
 
 
 class TestOtelMcpServer:
-    def test_registers_expected_tools(self, otel_server_mod):
+    def test_registers_expected_tools(self, otel_server_mod):  # noqa: ANN001, ANN201  # tracked: #288
         server = otel_server_mod.build_server()
         names = asyncio.run(_list_tool_names(server))
         assert names == {"reports", "summary", "compare"}
 
-    def test_summary_and_compare_use_normalized_service_rows(self, otel_server_mod, tmp_path):
+    def test_summary_and_compare_use_normalized_service_rows(self, otel_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         before = tmp_path / "before.json"
         after = tmp_path / "after.json"
         before.write_text(json.dumps(_otel_report(20.0)))
@@ -202,7 +202,7 @@ class TestOtelMcpServer:
             before.as_posix(),
         ]
 
-    def test_accepts_report_produced_by_go_otelcapture(self, otel_server_mod):
+    def test_accepts_report_produced_by_go_otelcapture(self, otel_server_mod):  # noqa: ANN001, ANN201  # tracked: #288
         """Round-trip a report generated by the Go otelcapture binary.
 
         Pins the cross-language contract: the JSON the evaluator writes must
@@ -229,7 +229,7 @@ class TestOtelMcpServer:
         assert otel_server_mod.find_reports(str(fixture.parent)) == [fixture.as_posix()]
 
     @pytest.mark.parametrize("identity_field", ["workload_name", "workload_hash"])
-    def test_compare_rejects_incompatible_reports(self, otel_server_mod, tmp_path, identity_field):
+    def test_compare_rejects_incompatible_reports(self, otel_server_mod, tmp_path, identity_field):  # noqa: ANN001, ANN201  # tracked: #288
         before = tmp_path / "before.json"
         after = tmp_path / "after.json"
         before.write_text(json.dumps(_otel_report(20.0)))
@@ -240,7 +240,7 @@ class TestOtelMcpServer:
         with pytest.raises(ValueError, match="matching workload identity"):
             otel_server_mod.compare_reports(str(before), str(after))
 
-    def test_compare_allows_run_specific_measurement_timestamps(self, otel_server_mod, tmp_path):
+    def test_compare_allows_run_specific_measurement_timestamps(self, otel_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         before = tmp_path / "before.json"
         after = tmp_path / "after.json"
         before.write_text(json.dumps(_otel_report(20.0)))
@@ -254,7 +254,7 @@ class TestOtelMcpServer:
 
         assert comparison.service_p95_changes[0].delta_p95_ms == -8.0
 
-    def test_load_report_rejects_invalid_aggregate_error_count(self, otel_server_mod, tmp_path):
+    def test_load_report_rejects_invalid_aggregate_error_count(self, otel_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         report = _otel_report(20.0)
         report["span_count"] = 1
         report["error_count"] = 2
@@ -287,28 +287,28 @@ class TestOtelMcpServer:
             "non-finite-latency",
         ],
     )
-    def test_load_report_rejects_malformed_contract(self, otel_server_mod, tmp_path, mutate):
+    def test_load_report_rejects_malformed_contract(self, otel_server_mod, tmp_path, mutate):  # noqa: ANN001, ANN201  # tracked: #288
         report = _otel_report(20.0)
         mutate(report)
         path = tmp_path / "invalid.json"
         path.write_text(json.dumps(report))
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011  # tracked: #288
             otel_server_mod.load_report(str(path))
 
-    def test_summary_rejects_non_positive_top(self, otel_server_mod, tmp_path):
+    def test_summary_rejects_non_positive_top(self, otel_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "report.json"
         path.write_text(json.dumps(_otel_report(20.0)))
 
         with pytest.raises(ValueError, match="top must be positive"):
             otel_server_mod.summarize_report(str(path), top=0)
 
-    def test_compare_rejects_non_positive_top_before_reading_files(self, otel_server_mod):
+    def test_compare_rejects_non_positive_top_before_reading_files(self, otel_server_mod):  # noqa: ANN001, ANN201  # tracked: #288
         # top is validated before any file I/O, so unreadable paths do not matter.
         with pytest.raises(ValueError, match="top must be positive"):
             otel_server_mod.compare_reports("missing-before.json", "missing-after.json", top=0)
 
-    def test_find_reports_skips_hostile_json(self, otel_server_mod, tmp_path):
+    def test_find_reports_skips_hostile_json(self, otel_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         valid = tmp_path / "valid.json"
         valid.write_text(json.dumps(_otel_report(20.0)))
         # A candidate under evaluation controls workspace files; none of these
@@ -320,7 +320,7 @@ class TestOtelMcpServer:
 
         assert otel_server_mod.find_reports(str(tmp_path)) == [valid.as_posix()]
 
-    def test_compare_surfaces_rows_present_in_one_report(self, otel_server_mod, tmp_path):
+    def test_compare_surfaces_rows_present_in_one_report(self, otel_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         def service_row(name: str, p95: float) -> dict:
             return {
                 "name": name,
@@ -400,7 +400,7 @@ def _otel_report(p95: float) -> dict:
 
 
 class TestTorchMcpServer:
-    def test_registers_expected_tools(self, torch_server_mod):
+    def test_registers_expected_tools(self, torch_server_mod):  # noqa: ANN001, ANN201  # tracked: #288
         server = torch_server_mod.build_server()
         names = asyncio.run(_list_tool_names(server))
         assert names == {
@@ -412,7 +412,7 @@ class TestTorchMcpServer:
             "summary",
         }
 
-    def test_tables_tool_reports_prof_json_overview(self, torch_server_mod, tmp_path):
+    def test_tables_tool_reports_prof_json_overview(self, torch_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         prof = tmp_path / "prof.json"
         prof.write_text(
             json.dumps(
@@ -452,7 +452,7 @@ class TestTorchMcpServer:
         assert "kernel" in out
         assert "operator" in out
 
-    def test_kernels_tool_ranks_by_self_cuda(self, torch_server_mod, tmp_path):
+    def test_kernels_tool_ranks_by_self_cuda(self, torch_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         prof = tmp_path / "prof.json"
         prof.write_text(
             json.dumps(

--- a/tests/render/test_format.py
+++ b/tests/render/test_format.py
@@ -5,34 +5,34 @@ from vibesys.server.events import AgentStatusData
 
 
 class TestFormatTokenCount:
-    def test_zero(self):
+    def test_zero(self):  # noqa: ANN201  # tracked: #288
         assert format_token_count(0) == "0"
 
-    def test_under_thousand(self):
+    def test_under_thousand(self):  # noqa: ANN201  # tracked: #288
         assert format_token_count(523) == "523"
         assert format_token_count(999) == "999"
 
-    def test_thousands_boundary(self):
+    def test_thousands_boundary(self):  # noqa: ANN201  # tracked: #288
         assert format_token_count(1000) == "1k"
         assert format_token_count(20_100) == "20k"
         assert format_token_count(199_500) == "199k"
         assert format_token_count(999_999) == "999k"
 
-    def test_millions(self):
+    def test_millions(self):  # noqa: ANN201  # tracked: #288
         assert format_token_count(1_000_000) == "1.0M"
         assert format_token_count(1_200_000) == "1.2M"
         assert format_token_count(1_048_576) == "1.0M"
 
 
 class TestFormatStatusPrefix:
-    def test_none_status_is_empty(self):
+    def test_none_status_is_empty(self):  # noqa: ANN201  # tracked: #288
         assert format_status_prefix(None) == ""
 
-    def test_anonymous_status_is_empty(self):
+    def test_anonymous_status_is_empty(self):  # noqa: ANN201  # tracked: #288
         status = AgentStatusData(elapsed_seconds=3.2, input_tokens=100)
         assert format_status_prefix(status) == ""
 
-    def test_full_prefix(self):
+    def test_full_prefix(self):  # noqa: ANN201  # tracked: #288
         status = AgentStatusData(
             progress="Round 3/24",
             agent_label="Implementer",
@@ -42,10 +42,10 @@ class TestFormatStatusPrefix:
         )
         assert format_status_prefix(status) == "[Round 3/24 | Implementer | 12.3s | 20k/1.0M] "
 
-    def test_no_context_window_omits_max(self):
+    def test_no_context_window_omits_max(self):  # noqa: ANN201  # tracked: #288
         status = AgentStatusData(agent_label="X", elapsed_seconds=0.0, input_tokens=0)
         assert format_status_prefix(status) == "[X | 0.0s | 0] "
 
-    def test_progress_only(self):
+    def test_progress_only(self):  # noqa: ANN201  # tracked: #288
         status = AgentStatusData(progress="Round 1/2", elapsed_seconds=1.0, input_tokens=500)
         assert format_status_prefix(status) == "[Round 1/2 | 1.0s | 500] "

--- a/tests/render/test_headless.py
+++ b/tests/render/test_headless.py
@@ -17,7 +17,7 @@ from vibesys.server.events import (
 )
 
 
-def _render(*payloads: tuple[EventType, EventData], **kwargs) -> str:
+def _render(*payloads: tuple[EventType, EventData], **kwargs) -> str:  # noqa: ANN003  # tracked: #288
     out = StringIO()
     renderer = HeadlessRenderer(out=out, **kwargs)
     for event_type, data in payloads:
@@ -25,7 +25,7 @@ def _render(*payloads: tuple[EventType, EventData], **kwargs) -> str:
     return out.getvalue()
 
 
-def _chunk(content: str, channel: str = "assistant", status: AgentStatusData | None = None):
+def _chunk(content: str, channel: str = "assistant", status: AgentStatusData | None = None):  # noqa: ANN202  # tracked: #288
     return (
         EventType.AGENT_OUTPUT_CHUNK,
         AgentOutputChunkData(channel=channel, content=content, status=status),  # type: ignore[arg-type]
@@ -41,68 +41,68 @@ _STATUS = AgentStatusData(
 
 
 class TestAssistantStreaming:
-    def test_tokens_stream_without_newlines(self):
+    def test_tokens_stream_without_newlines(self):  # noqa: ANN201  # tracked: #288
         assert _render(_chunk("hel"), _chunk("lo")) == "hello"
 
-    def test_prefix_written_once_at_line_start(self):
+    def test_prefix_written_once_at_line_start(self):  # noqa: ANN201  # tracked: #288
         out = _render(_chunk("hel", status=_STATUS), _chunk("lo", status=_STATUS))
         assert out == "[Implementer | 12.3s | 20k/1.0M] hello"
 
-    def test_no_prefix_for_anonymous_status(self):
+    def test_no_prefix_for_anonymous_status(self):  # noqa: ANN201  # tracked: #288
         assert _render(_chunk("hi")) == "hi"
 
-    def test_line_broken_before_next_surface(self):
+    def test_line_broken_before_next_surface(self):  # noqa: ANN201  # tracked: #288
         out = _render(_chunk("partial"), _chunk("diag\n", channel="diagnostic"))
         assert out == "partial\ndiag\n"
 
 
 class TestAnalysisChannel:
-    def test_rendered_as_prefixed_line(self):
+    def test_rendered_as_prefixed_line(self):  # noqa: ANN201  # tracked: #288
         out = _render(_chunk("thinking hard", channel="analysis", status=_STATUS))
         assert out == "[Implementer | 12.3s | 20k/1.0M] thinking hard\n"
 
 
 class TestBlockChannels:
-    def test_diagnostic_rendered_verbatim(self):
+    def test_diagnostic_rendered_verbatim(self):  # noqa: ANN201  # tracked: #288
         out = _render(_chunk("=== ROUND START ===\n", channel="diagnostic"))
         assert out == "=== ROUND START ===\n"
 
-    def test_prompt_truncated_with_pointer_to_log(self):
+    def test_prompt_truncated_with_pointer_to_log(self):  # noqa: ANN201  # tracked: #288
         out = _render(_chunk("x" * 30 + "\n", channel="prompt"), max_text_len=20)
         assert out == "x" * 20 + "\n... [10 more chars, see log for full text]\n"
 
-    def test_short_prompt_not_truncated(self):
+    def test_short_prompt_not_truncated(self):  # noqa: ANN201  # tracked: #288
         out = _render(_chunk("short\n", channel="prompt"), max_text_len=20)
         assert out == "short\n"
 
 
 class TestToolEvents:
-    def test_tool_channel_chunks_are_ignored(self):
+    def test_tool_channel_chunks_are_ignored(self):  # noqa: ANN201  # tracked: #288
         # Tool traffic renders from the typed events; tool-channel chunks
         # (legacy event files only) must not double-render.
         assert _render(_chunk("→ shell({})\n", channel="tool")) == ""
 
-    def test_tool_call_line(self):
+    def test_tool_call_line(self):  # noqa: ANN201  # tracked: #288
         out = _render(
             (EventType.TOOL_CALL, ToolCallData(tool="shell", args={"cmd": "ls"}, status=_STATUS))
         )
         assert out == '\n[Implementer | 12.3s | 20k/1.0M] → shell(cmd="ls")\n'
 
-    def test_tool_call_args_truncated(self):
+    def test_tool_call_args_truncated(self):  # noqa: ANN201  # tracked: #288
         long = "x" * 200
         out = _render((EventType.TOOL_CALL, ToolCallData(tool="shell", args={"cmd": long})))
         assert long not in out
         assert "x" * 80 + "..." in out
 
-    def test_non_string_args_rendered_as_json(self):
+    def test_non_string_args_rendered_as_json(self):  # noqa: ANN201  # tracked: #288
         out = _render((EventType.TOOL_CALL, ToolCallData(tool="t", args={"n": 3})))
         assert "n=3" in out
 
-    def test_tool_result_indented(self):
+    def test_tool_result_indented(self):  # noqa: ANN201  # tracked: #288
         out = _render((EventType.TOOL_RESULT, ToolResultData(tool="shell", content="a\nb")))
         assert out == "  a\n  b\n"
 
-    def test_tool_result_truncated(self):
+    def test_tool_result_truncated(self):  # noqa: ANN201  # tracked: #288
         out = _render(
             (EventType.TOOL_RESULT, ToolResultData(tool="shell", content="a" * 30)),
             max_result_len=10,
@@ -111,39 +111,39 @@ class TestToolEvents:
 
 
 class TestTodoRendering:
-    def _todos(self):
+    def _todos(self):  # noqa: ANN202  # tracked: #288
         return [
             TodoItemData(content="Set up project", status="completed"),
             TodoItemData(content="Implement handlers", status="in_progress"),
             TodoItemData(content="Add tests", status="pending"),
         ]
 
-    def test_renders_box_with_items(self):
+    def test_renders_box_with_items(self):  # noqa: ANN201  # tracked: #288
         out = _render((EventType.TODO_UPDATE, TodoUpdateData(todos=self._todos())))
         assert "┌─ Todo" in out
         assert "Set up project" in out
         assert "Implement handlers" in out
         assert "Add tests" in out
 
-    def test_status_indicators(self):
+    def test_status_indicators(self):  # noqa: ANN201  # tracked: #288
         out = _render((EventType.TODO_UPDATE, TodoUpdateData(todos=self._todos())))
         assert "✓" in out  # completed
         assert "▶" in out  # in_progress
         assert "○" in out  # pending
 
-    def test_unknown_status_degrades(self):
+    def test_unknown_status_degrades(self):  # noqa: ANN201  # tracked: #288
         todos = [TodoItemData(content="odd", status="unknown-state")]
         out = _render((EventType.TODO_UPDATE, TodoUpdateData(todos=todos)))
         assert "? odd" in out
 
-    def test_plain_mode_has_no_ansi_colors(self):
+    def test_plain_mode_has_no_ansi_colors(self):  # noqa: ANN201  # tracked: #288
         out = _render((EventType.TODO_UPDATE, TodoUpdateData(todos=self._todos())), color=False)
         assert "\033[3" not in out  # no color codes
         assert "✓" in out
 
 
 class TestTodoDisplay:
-    def test_clears_previous_lines(self):
+    def test_clears_previous_lines(self):  # noqa: ANN201  # tracked: #288
         buf = StringIO()
         td = TodoDisplay(file=buf)
         td.update([TodoItemData(content="task one", status="pending")])
@@ -160,18 +160,18 @@ class TestTodoDisplay:
         assert "\033[" in second_output
         assert "A" in second_output
 
-    def test_empty_list_prints_nothing(self):
+    def test_empty_list_prints_nothing(self):  # noqa: ANN201  # tracked: #288
         buf = StringIO()
         TodoDisplay(file=buf).update([])
         assert buf.getvalue() == ""
 
 
 class TestIgnoredEvents:
-    def test_usage_update_produces_no_output(self):
+    def test_usage_update_produces_no_output(self):  # noqa: ANN201  # tracked: #288
         out = _render((EventType.USAGE_UPDATE, UsageUpdateData(input_tokens=5)))
         assert out == ""
 
-    def test_event_without_data_produces_no_output(self):
+    def test_event_without_data_produces_no_output(self):  # noqa: ANN201  # tracked: #288
         out = StringIO()
         renderer = HeadlessRenderer(out=out)
         renderer.handle(make_event(EventType.RUN_STARTED))

--- a/tests/render/test_sink.py
+++ b/tests/render/test_sink.py
@@ -26,7 +26,7 @@ def _collect(sink: OutputSink) -> tuple[list[RunEvent], object]:
 
 
 class TestSubscription:
-    def test_subscriber_receives_events(self):
+    def test_subscriber_receives_events(self):  # noqa: ANN201  # tracked: #288
         sink = OutputSink()
         seen, _ = _collect(sink)
         sink.agent_output("hello", channel="assistant")
@@ -37,7 +37,7 @@ class TestSubscription:
         assert data.content == "hello"
         assert data.channel == "assistant"
 
-    def test_unsubscribe_stops_delivery(self):
+    def test_unsubscribe_stops_delivery(self):  # noqa: ANN201  # tracked: #288
         sink = OutputSink()
         seen, unsubscribe = _collect(sink)
         sink.agent_output("one")
@@ -45,7 +45,7 @@ class TestSubscription:
         sink.agent_output("two")
         assert [e.data.content for e in seen if isinstance(e.data, AgentOutputChunkData)] == ["one"]
 
-    def test_empty_content_is_not_emitted(self):
+    def test_empty_content_is_not_emitted(self):  # noqa: ANN201  # tracked: #288
         sink = OutputSink()
         seen, _ = _collect(sink)
         sink.agent_output("")
@@ -54,7 +54,7 @@ class TestSubscription:
 
 
 class TestTypedEmitters:
-    def test_tool_call_event(self):
+    def test_tool_call_event(self):  # noqa: ANN201  # tracked: #288
         sink = OutputSink()
         seen, _ = _collect(sink)
         sink.tool_call("shell", {"cmd": "ls"}, call_id="call-1")
@@ -65,17 +65,17 @@ class TestTypedEmitters:
         assert data.call_id == "call-1"
         assert data.args == {"cmd": "ls"}
 
-    def test_tool_call_args_coerced_to_json_safe(self):
+    def test_tool_call_args_coerced_to_json_safe(self):  # noqa: ANN201  # tracked: #288
         sink = OutputSink()
         seen, _ = _collect(sink)
-        sink.tool_call("write", {"path": Path("/tmp/x")})
+        sink.tool_call("write", {"path": Path("/tmp/x")})  # noqa: S108  # tracked: #288
         data = seen[0].data
         assert isinstance(data, ToolCallData)
         # Non-JSON values are repr()'d so the event always serializes.
         assert isinstance(data.args["path"], str)
         seen[0].model_dump_json()
 
-    def test_tool_result_event(self):
+    def test_tool_result_event(self):  # noqa: ANN201  # tracked: #288
         sink = OutputSink()
         seen, _ = _collect(sink)
         sink.tool_result("shell", "output text", call_id="call-1", is_error=True)
@@ -86,7 +86,7 @@ class TestTypedEmitters:
         assert data.content == "output text"
         assert data.is_error is True
 
-    def test_todo_update_event(self):
+    def test_todo_update_event(self):  # noqa: ANN201  # tracked: #288
         sink = OutputSink()
         seen, _ = _collect(sink)
         sink.todo_update([TodoItemData(content="a", status="pending")])
@@ -94,7 +94,7 @@ class TestTypedEmitters:
         assert isinstance(data, TodoUpdateData)
         assert data.todos[0].content == "a"
 
-    def test_usage_update_event(self):
+    def test_usage_update_event(self):  # noqa: ANN201  # tracked: #288
         sink = OutputSink()
         seen, _ = _collect(sink)
         sink.usage_update(12_345, context_window=200_000, model="claude-sonnet-4-6")
@@ -106,7 +106,7 @@ class TestTypedEmitters:
 
 
 class TestSupervisorForwarding:
-    def test_events_forwarded_to_active_supervisor(self, tmp_path):
+    def test_events_forwarded_to_active_supervisor(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         supervisor = RunSupervisor()
         supervisor.attach(tmp_path / "logs")
         REGISTRY.activate(supervisor)
@@ -121,11 +121,11 @@ class TestSupervisorForwarding:
         assert EventType.AGENT_OUTPUT_CHUNK in types
         assert EventType.TOOL_CALL in types
 
-    def test_no_supervisor_no_error(self):
+    def test_no_supervisor_no_error(self):  # noqa: ANN201  # tracked: #288
         sink = OutputSink()
         sink.agent_output("standalone")  # must not raise without a supervisor
 
-    def test_logger_metadata_routes_subprocess_thread_events_to_chat(self, tmp_path):
+    def test_logger_metadata_routes_subprocess_thread_events_to_chat(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         supervisor = RunSupervisor()
         supervisor.attach(tmp_path / "logs")
         logger = AgentLogger(

--- a/tests/sandbox/test_modal_evaluator.py
+++ b/tests/sandbox/test_modal_evaluator.py
@@ -52,7 +52,7 @@ def test_extract_modal_app_identifier_handles_rich_line_wrapping() -> None:
     assert modal_evaluator.extract_modal_app_identifier(output) == "vibesys-long-candidate"
 
 
-def test_run_evaluator_deploys_waits_and_injects_url(monkeypatch) -> None:
+def test_run_evaluator_deploys_waits_and_injects_url(monkeypatch) -> None:  # noqa: ANN001  # tracked: #288
     deploy = SimpleNamespace(
         returncode=0,
         stdout="Web Function URL: https://workspace--candidate.modal.run\n",
@@ -98,8 +98,8 @@ def test_run_evaluator_deploys_waits_and_injects_url(monkeypatch) -> None:
 
 
 def test_run_evaluator_reuses_healthy_deployment_for_exact_revision(
-    monkeypatch,
-    tmp_path,
+    monkeypatch,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
 ) -> None:
     lease_path = tmp_path / "deployment.json"
     lease_path.write_text(
@@ -140,8 +140,8 @@ def test_run_evaluator_reuses_healthy_deployment_for_exact_revision(
 
 
 def test_run_evaluator_releases_reused_deployment_after_final_gate(
-    monkeypatch,
-    tmp_path,
+    monkeypatch,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
 ) -> None:
     lease_path = tmp_path / "deployment.json"
     lease_path.write_text(
@@ -180,8 +180,8 @@ def test_run_evaluator_releases_reused_deployment_after_final_gate(
 
 
 def test_run_evaluator_releases_new_deployment_after_final_gate(
-    monkeypatch,
-    tmp_path,
+    monkeypatch,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
 ) -> None:
     lease_path = tmp_path / "deployment.json"
     deploy = SimpleNamespace(
@@ -220,8 +220,8 @@ def test_run_evaluator_releases_new_deployment_after_final_gate(
 
 
 def test_run_evaluator_stops_mismatched_leased_app_before_redeploy(
-    monkeypatch,
-    tmp_path,
+    monkeypatch,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
 ) -> None:
     lease_path = tmp_path / "deployment.json"
     lease_path.write_text(
@@ -263,8 +263,8 @@ def test_run_evaluator_stops_mismatched_leased_app_before_redeploy(
 
 
 def test_run_evaluator_redeploys_and_replaces_mismatched_revision(
-    monkeypatch,
-    tmp_path,
+    monkeypatch,  # noqa: ANN001  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
 ) -> None:
     lease_path = tmp_path / "deployment.json"
     lease_path.write_text(
@@ -300,8 +300,8 @@ def test_run_evaluator_redeploys_and_replaces_mismatched_revision(
 
 
 def test_run_evaluator_prints_modal_logs_when_readiness_fails(
-    monkeypatch,
-    capsys,
+    monkeypatch,  # noqa: ANN001  # tracked: #288
+    capsys,  # noqa: ANN001  # tracked: #288
 ) -> None:
     deploy = SimpleNamespace(
         returncode=0,

--- a/tests/sandbox/test_run_environment.py
+++ b/tests/sandbox/test_run_environment.py
@@ -24,15 +24,15 @@ class FakeBackend:
         self.sandbox = MagicMock()
         self.calls = []
 
-    def make_sandbox(self, kind, **kwargs):
+    def make_sandbox(self, kind, **kwargs):  # noqa: ANN001, ANN003, ANN201  # tracked: #288
         self.calls.append((kind, kwargs))
         return self.sandbox
 
 
-def _request(tmp_path: Path, backend: FakeBackend, **overrides):
+def _request(tmp_path: Path, backend: FakeBackend, **overrides):  # noqa: ANN003, ANN202  # tracked: #288
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    values = dict(
+    values = dict(  # noqa: C408  # tracked: #288
         log_dir=tmp_path / "logs",
         workspace=workspace,
         ref_dir=None,
@@ -45,7 +45,7 @@ def _request(tmp_path: Path, backend: FakeBackend, **overrides):
     return RunEnvironmentRequest(**values)
 
 
-def test_cli_compatibility_flags_keep_options_scoped_to_selected_environment():
+def test_cli_compatibility_flags_keep_options_scoped_to_selected_environment():  # noqa: ANN201  # tracked: #288
     assert make_run_environment_spec().options == {}
     assert make_run_environment_spec(use_docker=True, docker_image="editor").options == {
         "image": "editor"
@@ -71,7 +71,7 @@ def _modal_runtime_document(tmp_path: Path) -> str:
     return (tmp_path / "logs" / "runtime-environment.md").read_text()
 
 
-def test_local_environment_opens_local_sandbox_with_host_paths(tmp_path):
+def test_local_environment_opens_local_sandbox_with_host_paths(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("local"))
 
@@ -92,7 +92,7 @@ def test_local_environment_opens_local_sandbox_with_host_paths(tmp_path):
     backend.sandbox.start.assert_not_called()
 
 
-def test_local_environment_materializes_effective_objective_outside_workspace(tmp_path):
+def test_local_environment_materializes_effective_objective_outside_workspace(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("local"))
     effective = "Optimize the service.\n\n## Operator constraints\n\n- BF16 only\n"
@@ -105,7 +105,7 @@ def test_local_environment_materializes_effective_objective_outside_workspace(tm
     assert not objective_path.is_relative_to(tmp_path / "workspace")
 
 
-def test_docker_environment_opens_one_started_sandbox_with_agent_paths(tmp_path):
+def test_docker_environment_opens_one_started_sandbox_with_agent_paths(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
 
@@ -131,7 +131,7 @@ def test_docker_environment_opens_one_started_sandbox_with_agent_paths(tmp_path)
     backend.sandbox.stop.assert_called_once()
 
 
-def test_docker_environment_mounts_effective_objective_read_only(tmp_path):
+def test_docker_environment_mounts_effective_objective_read_only(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
     effective = "Optimize.\n\n## Operator constraints\n\n- exact BF16\n"
@@ -149,7 +149,7 @@ def test_docker_environment_mounts_effective_objective_read_only(tmp_path):
     assert session.view.paths.objective == "/opt/vibesys-runtime/objective.md"
 
 
-def test_docker_environment_copies_cli_auth_from_readonly_staging(tmp_path, monkeypatch):
+def test_docker_environment_copies_cli_auth_from_readonly_staging(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
     auth_file = tmp_path / "synthetic-codex-home" / "auth.json"
@@ -170,7 +170,7 @@ def test_docker_environment_copies_cli_auth_from_readonly_staging(tmp_path, monk
     )
 
 
-def test_docker_environment_exposes_framework_git_history_read_only(tmp_path):
+def test_docker_environment_exposes_framework_git_history_read_only(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
     history = tmp_path / "experiment-history"
@@ -194,7 +194,7 @@ def test_docker_environment_exposes_framework_git_history_read_only(tmp_path):
     assert "hashes without recoverable source are insufficient" in session.view.prompt_notes
 
 
-def test_docker_environment_uses_environment_bind_mounts(tmp_path):
+def test_docker_environment_uses_environment_bind_mounts(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
     model_dir = tmp_path / "model"
@@ -204,7 +204,7 @@ def test_docker_environment_uses_environment_bind_mounts(tmp_path):
         _request(
             tmp_path,
             backend,
-            environment_bind_mounts=(EnvironmentBindMount(model_dir, "/model", True),),
+            environment_bind_mounts=(EnvironmentBindMount(model_dir, "/model", True),),  # noqa: FBT003  # tracked: #288
         )
     )
 
@@ -213,7 +213,7 @@ def test_docker_environment_uses_environment_bind_mounts(tmp_path):
     assert "/model" in kwargs["passthrough_paths"]
 
 
-def test_docker_environment_mounts_selected_profiler_support(tmp_path):
+def test_docker_environment_mounts_selected_profiler_support(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
     support = tmp_path / "custom-profiler"
@@ -233,7 +233,7 @@ def test_docker_environment_mounts_selected_profiler_support(tmp_path):
     assert session.view.paths.profiler_support == "fixture_profiler"
 
 
-def test_docker_environment_does_not_infer_model_mount_from_reference_dir(tmp_path):
+def test_docker_environment_does_not_infer_model_mount_from_reference_dir(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
     ref_dir = tmp_path / "reference"
@@ -245,7 +245,7 @@ def test_docker_environment_does_not_infer_model_mount_from_reference_dir(tmp_pa
     assert all(container_path != "/model" for _, container_path, _ in bind_mounts)
 
 
-def test_environment_session_context_manager_closes(tmp_path):
+def test_environment_session_context_manager_closes(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
 
@@ -258,7 +258,7 @@ def test_environment_session_context_manager_closes(tmp_path):
     backend.sandbox.stop.assert_called_once()
 
 
-def test_modal_environment_uses_local_docker_for_editing(tmp_path):
+def test_modal_environment_uses_local_docker_for_editing(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Post-refactor (April 2026): Modal mode runs the agent in a local
     Docker container; only GPU-bound work the implementer dispatches via
     `modal run` actually touches Modal."""
@@ -278,7 +278,7 @@ def test_modal_environment_uses_local_docker_for_editing(tmp_path):
     backend.sandbox.start.assert_called_once()
 
 
-def test_modal_environment_owns_candidate_runtime_naming(tmp_path):
+def test_modal_environment_owns_candidate_runtime_naming(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))
     session = env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="codex"))
@@ -293,7 +293,7 @@ def test_modal_environment_owns_candidate_runtime_naming(tmp_path):
     assert runtime.deployment_name in runtime.prompt_notes
 
 
-def test_modal_environment_wraps_service_evaluators_with_remote_dispatch(tmp_path):
+def test_modal_environment_wraps_service_evaluators_with_remote_dispatch(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))
 
@@ -323,7 +323,7 @@ def test_modal_environment_wraps_service_evaluators_with_remote_dispatch(tmp_pat
     )
 
 
-def test_modal_environment_installs_modal_sdk_in_docker(tmp_path):
+def test_modal_environment_installs_modal_sdk_in_docker(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """The local Docker container needs the Modal Python SDK installed so
     the implementer-authored `modal run` calls work."""
     backend = FakeBackend()
@@ -338,7 +338,7 @@ def test_modal_environment_installs_modal_sdk_in_docker(tmp_path):
     assert backend.calls[0][1]["extra_env"]["UV_CACHE_DIR"] == "/workspace/.cache/uv"
 
 
-def test_modal_environment_prompt_references_runtime_document(tmp_path):
+def test_modal_environment_prompt_references_runtime_document(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Prompts name the runtime manual instead of embedding it in every role."""
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))
@@ -386,7 +386,7 @@ def test_modal_environment_prompt_references_runtime_document(tmp_path):
         assert term.casefold() not in runtime.casefold()
 
 
-def test_modal_environment_mounts_effective_objective_read_only(tmp_path):
+def test_modal_environment_mounts_effective_objective_read_only(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))
     effective = "Optimize.\n\n## Operator constraints\n\n- no quantization\n"
@@ -411,7 +411,7 @@ def test_modal_environment_mounts_effective_objective_read_only(tmp_path):
     assert session.view.paths.objective == "/opt/vibesys-runtime/objective.md"
 
 
-def test_modal_environment_prompt_notes_require_remote_runtime_fingerprint(tmp_path):
+def test_modal_environment_prompt_notes_require_remote_runtime_fingerprint(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))
 
@@ -424,7 +424,7 @@ def test_modal_environment_prompt_notes_require_remote_runtime_fingerprint(tmp_p
     assert "same Modal image and hardware" in notes
 
 
-def test_modal_environment_requires_exact_default_h100_identity(tmp_path):
+def test_modal_environment_requires_exact_default_h100_identity(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))
 
@@ -437,7 +437,7 @@ def test_modal_environment_requires_exact_default_h100_identity(tmp_path):
     assert "fail closed" in notes
 
 
-def test_modal_environment_documents_history_and_exact_measurement_source(tmp_path):
+def test_modal_environment_documents_history_and_exact_measurement_source(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))
     history = tmp_path / "experiment-history"
@@ -465,7 +465,7 @@ def test_modal_environment_documents_history_and_exact_measurement_source(tmp_pa
     assert "Create this provenance artifact before launch" in notes
 
 
-def test_modal_environment_per_run_namespace_prefix_unique(tmp_path):
+def test_modal_environment_per_run_namespace_prefix_unique(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Two runs (different exp_dir names) must produce different Modal
     namespace prefixes so concurrent runs cannot collide on app names,
     web-endpoint labels, or auxiliary volumes."""
@@ -511,7 +511,7 @@ def test_modal_environment_per_run_namespace_prefix_unique(tmp_path):
     assert "vibesys-20260429-100100-runb" not in notes_a
 
 
-def test_modal_environment_runtime_notes_describe_profile_contract(tmp_path):
+def test_modal_environment_runtime_notes_describe_profile_contract(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """The runtime notes must spell out the modal_profile / profile_remote
     contract; without it the profiler agent has no Modal entrypoint to
     invoke and falls back to local synthetic-weight profiling."""
@@ -532,7 +532,7 @@ def test_modal_environment_runtime_notes_describe_profile_contract(tmp_path):
     assert "from torch.autograd import DeviceType" not in notes
 
 
-def test_modal_environment_prompt_notes_reuse_workspace_uv_cache(tmp_path):
+def test_modal_environment_prompt_notes_reuse_workspace_uv_cache(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))
 
@@ -546,7 +546,7 @@ def test_modal_environment_prompt_notes_reuse_workspace_uv_cache(tmp_path):
     assert "excluding `.venv` and `.cache`" in notes
 
 
-def test_modal_environment_with_deepagents_uses_docker_too(tmp_path):
+def test_modal_environment_with_deepagents_uses_docker_too(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """The deepagents path also runs locally in Docker now — Modal is a
     dispatch target, not a runtime for the agent."""
     backend = FakeBackend()
@@ -557,17 +557,17 @@ def test_modal_environment_with_deepagents_uses_docker_too(tmp_path):
     assert backend.calls[0][0] is SandboxKind.DOCKER
 
 
-def test_unknown_environment_name_raises():
+def test_unknown_environment_name_raises():  # noqa: ANN201  # tracked: #288
     with pytest.raises(ValueError, match="unknown run environment"):
         build_run_environment(RunEnvironmentSpec("wat"))
 
 
-def test_docker_remove_workspace_child_quotes_path(tmp_path, monkeypatch):
+def test_docker_remove_workspace_child_quotes_path(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("docker"))
     calls = []
 
-    def fake_run(cmd, **kwargs):
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288
         calls.append(cmd)
         result = MagicMock()
         result.returncode = 0
@@ -588,14 +588,14 @@ def test_docker_remove_workspace_child_quotes_path(tmp_path, monkeypatch):
     assert "'/workspace/semi;touch hacked'" in shell_command
 
 
-def test_modal_teardown_deployment_stops_app_via_cli(monkeypatch):
-    import sys as _sys
+def test_modal_teardown_deployment_stops_app_via_cli(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    import sys as _sys  # noqa: PLC0415  # tracked: #288
 
     env = build_run_environment(RunEnvironmentSpec("modal"))
     calls = []
     logs = []
 
-    def fake_run(cmd, **kwargs):
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288
         calls.append(cmd)
         result = MagicMock()
         result.returncode = 0
@@ -610,11 +610,11 @@ def test_modal_teardown_deployment_stops_app_via_cli(monkeypatch):
     assert any("stopped candidate app vibesys-run-g1c2" in line for line in logs)
 
 
-def test_modal_teardown_deployment_is_best_effort_on_nonzero(monkeypatch):
+def test_modal_teardown_deployment_is_best_effort_on_nonzero(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     env = build_run_environment(RunEnvironmentSpec("modal"))
     logs = []
 
-    def fake_run(cmd, **kwargs):
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288
         result = MagicMock()
         result.returncode = 1
         result.stderr = "boom"
@@ -627,11 +627,11 @@ def test_modal_teardown_deployment_is_best_effort_on_nonzero(monkeypatch):
     assert any("failed" in line for line in logs)
 
 
-def test_modal_teardown_deployment_is_best_effort_on_exception(monkeypatch):
+def test_modal_teardown_deployment_is_best_effort_on_exception(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     env = build_run_environment(RunEnvironmentSpec("modal"))
     logs = []
 
-    def fake_run(cmd, **kwargs):
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288
         raise TimeoutError("stuck")
 
     monkeypatch.setattr("vibesys.sandbox.run_environment.subprocess.run", fake_run)
@@ -641,11 +641,11 @@ def test_modal_teardown_deployment_is_best_effort_on_exception(monkeypatch):
 
 
 @pytest.mark.parametrize("name", ["local", "docker"])
-def test_non_modal_teardown_deployment_is_noop(name, monkeypatch):
+def test_non_modal_teardown_deployment_is_noop(name, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     env = build_run_environment(RunEnvironmentSpec(name))
 
-    def fail_run(*args, **kwargs):
-        raise AssertionError("subprocess.run should not be called for non-Modal envs")
+    def fail_run(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001  # tracked: #288
+        raise AssertionError("subprocess.run should not be called for non-Modal envs")  # noqa: TRY003  # tracked: #288
 
     monkeypatch.setattr("vibesys.sandbox.run_environment.subprocess.run", fail_run)
 
@@ -653,11 +653,11 @@ def test_non_modal_teardown_deployment_is_noop(name, monkeypatch):
     env.teardown_deployment("vibesys-run-g1c2", log=lambda _: None)
 
 
-def test_modal_environment_prompt_notes_cover_seeded_checkouts(tmp_path):
+def test_modal_environment_prompt_notes_cover_seeded_checkouts(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Seeded starting-point checkouts live only in the editor container, so
     the runtime notes must tell the agent to bake them into the Modal image;
     unseeded runs must not mention checkouts at all."""
-    from vibesys.input_manifest import WorkspaceSource
+    from vibesys.input_manifest import WorkspaceSource  # noqa: PLC0415  # tracked: #288
 
     backend = FakeBackend()
     env = build_run_environment(RunEnvironmentSpec("modal"))

--- a/tests/server/test_event_store.py
+++ b/tests/server/test_event_store.py
@@ -25,7 +25,7 @@ def _write_events(path: Path, events: list[RunEvent]) -> None:
 
 
 class TestEventStore:
-    def test_startup_replay_cursor_and_next_sequence(self, tmp_path):
+    def test_startup_replay_cursor_and_next_sequence(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "events.jsonl"
         _write_events(path, [_persisted_event(1, "one"), _persisted_event(2, "two")])
 
@@ -39,7 +39,7 @@ class TestEventStore:
         assert appended.run_id == "active-run"
         assert [event.sequence for event in store.read(after_sequence=1)] == [2, 3]
 
-    def test_legacy_out_of_order_sequences_keep_file_order_filtering(self, tmp_path):
+    def test_legacy_out_of_order_sequences_keep_file_order_filtering(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "events.jsonl"
         _write_events(
             path,
@@ -52,14 +52,14 @@ class TestEventStore:
         assert store.append(make_event(EventType.OUTPUT, "four")).sequence == 4
         assert [event.text for event in store.read(after_sequence=2)] == ["three", "four"]
 
-    def test_repeated_tail_reads_do_not_reparse_history(self, tmp_path, monkeypatch):
+    def test_repeated_tail_reads_do_not_reparse_history(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "events.jsonl"
         event_count = 1_000
         _write_events(path, [_persisted_event(index) for index in range(1, event_count + 1)])
         parse_count = 0
         parse = RunEvent.model_validate_json
 
-        def counting_parse(raw):
+        def counting_parse(raw):  # noqa: ANN001, ANN202  # tracked: #288
             nonlocal parse_count
             parse_count += 1
             return parse(raw)
@@ -74,7 +74,7 @@ class TestEventStore:
 
         assert parse_count == event_count
 
-    def test_ignores_only_a_malformed_final_record(self, tmp_path):
+    def test_ignores_only_a_malformed_final_record(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "events.jsonl"
         valid = _persisted_event(1, "complete").model_dump_json()
         path.write_text(valid + "\n" + '{"protocol_version":1')
@@ -84,7 +84,7 @@ class TestEventStore:
         assert [event.text for event in store.read()] == ["complete"]
 
     @pytest.mark.parametrize("tail", ['{"protocol_version":1', '{"protocol_version":1\n'])
-    def test_append_repairs_ignored_malformed_tail_before_writing(self, tmp_path, tail):
+    def test_append_repairs_ignored_malformed_tail_before_writing(self, tmp_path, tail):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "events.jsonl"
         valid = _persisted_event(1, "complete").model_dump_json()
         path.write_text(valid + "\n" + tail)
@@ -98,16 +98,16 @@ class TestEventStore:
             (2, "after repair"),
         ]
 
-    def test_rejects_a_malformed_record_before_the_tail(self, tmp_path):
+    def test_rejects_a_malformed_record_before_the_tail(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "events.jsonl"
         first = _persisted_event(1).model_dump_json()
         last = _persisted_event(2).model_dump_json()
         path.write_text(first + "\nnot-json\n" + last + "\n")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011  # tracked: #288
             EventStore(path, run_id="active-run")
 
-    def test_append_wakes_multiple_independent_readers(self, tmp_path):
+    def test_append_wakes_multiple_independent_readers(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = EventStore(tmp_path / "events.jsonl", run_id="active-run")
         ready = threading.Barrier(3)
 
@@ -125,7 +125,7 @@ class TestEventStore:
         assert all(batch[0] == appended for batch in batches)
         assert batches[0][0] is not batches[1][0]
 
-    def test_cached_events_are_isolated_from_reader_mutation(self, tmp_path):
+    def test_cached_events_are_isolated_from_reader_mutation(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = EventStore(tmp_path / "events.jsonl", run_id="active-run")
         appended = store.append(make_event(EventType.OUTPUT, "durable"))
 
@@ -135,22 +135,22 @@ class TestEventStore:
         assert appended.text == "durable"
         assert store.read()[0].text == "durable"
 
-    def test_append_does_not_publish_cache_state_when_file_close_fails(self, tmp_path, monkeypatch):
+    def test_append_does_not_publish_cache_state_when_file_close_fails(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
         path = tmp_path / "events.jsonl"
         store = EventStore(path, run_id="active-run")
         real_open = Path.open
 
         class FailingCloseStream:
-            def __enter__(self):
+            def __enter__(self):  # noqa: ANN204  # tracked: #288
                 return self
 
-            def write(self, _text):
+            def write(self, _text):  # noqa: ANN001, ANN202  # tracked: #288
                 return None
 
-            def __exit__(self, *_args):
-                raise OSError("close failed")
+            def __exit__(self, *_args):  # noqa: ANN002, ANN204  # tracked: #288
+                raise OSError("close failed")  # noqa: TRY003  # tracked: #288
 
-        def open_with_close_failure(target, mode="r", *args, **kwargs):
+        def open_with_close_failure(target, mode="r", *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202  # tracked: #288
             if target == path and mode == "a":
                 return FailingCloseStream()
             return real_open(target, mode, *args, **kwargs)

--- a/tests/server/test_events.py
+++ b/tests/server/test_events.py
@@ -24,7 +24,7 @@ def _round_trip(event: RunEvent) -> RunEvent:
 
 
 class TestNewEventDataRoundTrip:
-    def test_tool_call(self):
+    def test_tool_call(self):  # noqa: ANN201  # tracked: #288
         status = AgentStatusData(
             progress="Round 1/2",
             agent_label="Implementer",
@@ -42,7 +42,7 @@ class TestNewEventDataRoundTrip:
         assert restored.data.args == {"cmd": "ls", "count": 3}
         assert restored.data.status == status
 
-    def test_tool_result(self):
+    def test_tool_result(self):  # noqa: ANN201  # tracked: #288
         event = make_event(
             EventType.TOOL_RESULT,
             data=ToolResultData(tool="shell", content="out", is_error=True),
@@ -51,7 +51,7 @@ class TestNewEventDataRoundTrip:
         assert isinstance(restored.data, ToolResultData)
         assert restored.data.is_error is True
 
-    def test_todo_update(self):
+    def test_todo_update(self):  # noqa: ANN201  # tracked: #288
         event = make_event(
             EventType.TODO_UPDATE,
             data=TodoUpdateData(todos=[TodoItemData(content="a", status="pending")]),
@@ -60,7 +60,7 @@ class TestNewEventDataRoundTrip:
         assert isinstance(restored.data, TodoUpdateData)
         assert restored.data.todos == [TodoItemData(content="a", status="pending")]
 
-    def test_usage_update(self):
+    def test_usage_update(self):  # noqa: ANN201  # tracked: #288
         event = make_event(
             EventType.USAGE_UPDATE,
             data=UsageUpdateData(input_tokens=5_000, context_window=1_000_000, model="m"),
@@ -69,7 +69,7 @@ class TestNewEventDataRoundTrip:
         assert isinstance(restored.data, UsageUpdateData)
         assert restored.data.input_tokens == 5_000
 
-    def test_agent_output_chunk_status_is_optional_and_round_trips(self):
+    def test_agent_output_chunk_status_is_optional_and_round_trips(self):  # noqa: ANN201  # tracked: #288
         bare = make_event(
             EventType.AGENT_OUTPUT_CHUNK,
             data=AgentOutputChunkData(channel="assistant", content="hi"),
@@ -89,7 +89,7 @@ class TestNewEventDataRoundTrip:
 
 
 class TestBackwardCompatibility:
-    def test_chunk_without_status_field_still_parses(self):
+    def test_chunk_without_status_field_still_parses(self):  # noqa: ANN201  # tracked: #288
         """Events recorded by older backends omit the new optional fields."""
         raw = (
             '{"protocol_version": 1, "sequence": 3, "run_id": "r", '
@@ -100,23 +100,23 @@ class TestBackwardCompatibility:
         assert isinstance(event.data, AgentOutputChunkData)
         assert event.data.status is None
 
-    def test_unknown_data_kind_rejected(self):
+    def test_unknown_data_kind_rejected(self):  # noqa: ANN201  # tracked: #288
         raw = (
             '{"protocol_version": 1, "timestamp": "2026-01-01T00:00:00Z", '
             '"type": "output", "data": {"kind": "not_a_kind"}}'
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011  # tracked: #288
             RunEvent.model_validate_json(raw)
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
-def test_benchmark_result_rejects_non_finite_value(value):
+def test_benchmark_result_rejects_non_finite_value(value):  # noqa: ANN001, ANN201  # tracked: #288
     with pytest.raises(ValidationError, match="finite number"):
         BenchmarkResultData(metric="throughput", value=value, unit="req/s")
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
-def test_round_finished_rejects_non_finite_perf_metric(value):
+def test_round_finished_rejects_non_finite_perf_metric(value):  # noqa: ANN001, ANN201  # tracked: #288
     with pytest.raises(ValidationError, match="finite number"):
         RoundFinishedData(
             attempts=1,

--- a/tests/test_agent_cli_mcp.py
+++ b/tests/test_agent_cli_mcp.py
@@ -64,12 +64,12 @@ def _spec_with_env() -> MCPServerSpec:
 
 
 class TestClaudeMCP:
-    def _agent(self):
+    def _agent(self):  # noqa: ANN202  # tracked: #288
         # Avoid binary lookup by skipping the normal init: we only call
         # install/uninstall, which doesn't touch the binary.
         return ClaudeCodeCodingAgent.__new__(ClaudeCodeCodingAgent)
 
-    def test_install_writes_mcp_json(self, tmp_path: Path):
+    def test_install_writes_mcp_json(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec()])
 
@@ -82,7 +82,7 @@ class TestClaudeMCP:
         assert "trust" not in server
         assert "env" not in server
 
-    def test_install_includes_env_when_present(self, tmp_path: Path):
+    def test_install_includes_env_when_present(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec_with_env()])
 
@@ -90,7 +90,7 @@ class TestClaudeMCP:
         server = config["mcpServers"]["vibesys-issues"]
         assert server["env"] == {"MY_VAR": "my_value", "OTHER": "x"}
 
-    def test_install_merges_and_uninstall_restores_existing_config(self, tmp_path: Path):
+    def test_install_merges_and_uninstall_restores_existing_config(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         target = tmp_path / ".mcp.json"
         original = (
             b'{"permissions":{"allow":["Bash(*)"]},"mcpServers":{"existing":{"command":"user"}}}\n'
@@ -108,7 +108,7 @@ class TestClaudeMCP:
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
         assert target.read_bytes() == original
 
-    def test_uninstall_preserves_config_edits_made_during_invocation(self, tmp_path: Path):
+    def test_uninstall_preserves_config_edits_made_during_invocation(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         target = tmp_path / ".mcp.json"
         target.write_text('{"theme":"light","mcpServers":{"existing":{"command":"user"}}}')
         agent = self._agent()
@@ -128,7 +128,7 @@ class TestClaudeMCP:
             "mcpServers": {"existing": {"command": "user"}},
         }
 
-    def test_uninstall_preserves_an_in_run_edit_to_an_injected_server(self, tmp_path: Path):
+    def test_uninstall_preserves_an_in_run_edit_to_an_injected_server(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         target = tmp_path / ".mcp.json"
         target.write_text('{"mcpServers":{"vibesys-issues":{"command":"user"}}}')
         agent = self._agent()
@@ -144,16 +144,18 @@ class TestClaudeMCP:
             "command": "agent-edited"
         }
 
-    def test_install_replace_failure_leaves_original_config_intact(
-        self, tmp_path: Path, monkeypatch
+    def test_install_replace_failure_leaves_original_config_intact(  # noqa: ANN201  # tracked: #288
+        self,
+        tmp_path: Path,
+        monkeypatch,  # noqa: ANN001  # tracked: #288
     ):
         target = tmp_path / ".mcp.json"
         original = b'{"theme":"dark"}\n'
         target.write_bytes(original)
         agent = self._agent()
 
-        def fail_replace(source, destination):
-            raise OSError("disk full")
+        def fail_replace(source, destination):  # noqa: ANN001, ANN202, ARG001  # tracked: #288
+            raise OSError("disk full")  # noqa: TRY003  # tracked: #288
 
         monkeypatch.setattr("vibesys._agent_cli.base.os.replace", fail_replace)
         with pytest.raises(OSError, match="disk full"):
@@ -162,7 +164,7 @@ class TestClaudeMCP:
         assert target.read_bytes() == original
         assert target not in getattr(agent, "_mcp_config_backups", {})
 
-    def test_uninstall_removes_file(self, tmp_path: Path):
+    def test_uninstall_removes_file(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec()])
         assert (tmp_path / ".mcp.json").exists()
@@ -170,7 +172,7 @@ class TestClaudeMCP:
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
         assert not (tmp_path / ".mcp.json").exists()
 
-    def test_uninstall_is_idempotent(self, tmp_path: Path):
+    def test_uninstall_is_idempotent(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         # No file present yet → no error.
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
@@ -184,10 +186,10 @@ class TestClaudeMCP:
 
 
 class TestGeminiMCP:
-    def _agent(self):
+    def _agent(self):  # noqa: ANN202  # tracked: #288
         return GeminiCodingAgent.__new__(GeminiCodingAgent)
 
-    def test_install_writes_settings_json_with_trust(self, tmp_path: Path):
+    def test_install_writes_settings_json_with_trust(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec()])
 
@@ -201,13 +203,13 @@ class TestGeminiMCP:
         # trust:true skips Gemini's per-tool approval prompts.
         assert server["trust"] is True
 
-    def test_install_creates_gemini_dir_if_missing(self, tmp_path: Path):
+    def test_install_creates_gemini_dir_if_missing(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         assert not (tmp_path / ".gemini").exists()
         agent.install_mcp_servers(tmp_path, [_spec()])
         assert (tmp_path / ".gemini").is_dir()
 
-    def test_install_with_existing_gemini_dir(self, tmp_path: Path):
+    def test_install_with_existing_gemini_dir(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         # Mimic a workspace where Gemini already wrote tmp/ session data.
         (tmp_path / ".gemini" / "tmp").mkdir(parents=True)
         agent = self._agent()
@@ -215,26 +217,26 @@ class TestGeminiMCP:
         assert (tmp_path / ".gemini" / "settings.json").exists()
         assert (tmp_path / ".gemini" / "tmp").is_dir()  # untouched
 
-    def test_uninstall_removes_settings_but_keeps_dir(self, tmp_path: Path):
+    def test_uninstall_removes_settings_but_keeps_dir(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec()])
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
         assert not (tmp_path / ".gemini" / "settings.json").exists()
         assert (tmp_path / ".gemini").is_dir()
 
-    def test_uninstall_is_idempotent(self, tmp_path: Path):
+    def test_uninstall_is_idempotent(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
 
-    def test_install_includes_env_when_present(self, tmp_path: Path):
+    def test_install_includes_env_when_present(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec_with_env()])
         config = json.loads((tmp_path / ".gemini" / "settings.json").read_text())
         server = config["mcpServers"]["vibesys-issues"]
         assert server["env"] == {"MY_VAR": "my_value", "OTHER": "x"}
 
-    def test_install_merges_and_uninstall_restores_existing_config(self, tmp_path: Path):
+    def test_install_merges_and_uninstall_restores_existing_config(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         target = tmp_path / ".gemini" / "settings.json"
         target.parent.mkdir()
         original = b'{"theme":"dark","mcpServers":{"existing":{"command":"user"}}}\n'
@@ -258,10 +260,10 @@ class TestGeminiMCP:
 
 
 class TestOpencodeMCP:
-    def _agent(self):
+    def _agent(self):  # noqa: ANN202  # tracked: #288
         return OpencodeCodingAgent.__new__(OpencodeCodingAgent)
 
-    def test_install_writes_opencode_json(self, tmp_path: Path):
+    def test_install_writes_opencode_json(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec()])
 
@@ -279,7 +281,7 @@ class TestOpencodeMCP:
         # opencode uses a single combined command array.
         assert server["command"] == ["python", *_spec().args]
 
-    def test_install_uses_environment_key_for_env(self, tmp_path: Path):
+    def test_install_uses_environment_key_for_env(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec_with_env()])
         config = json.loads((tmp_path / "opencode.json").read_text())
@@ -288,7 +290,7 @@ class TestOpencodeMCP:
         assert server["environment"] == {"MY_VAR": "my_value", "OTHER": "x"}
         assert "env" not in server
 
-    def test_install_merges_and_uninstall_restores_existing_config(self, tmp_path: Path):
+    def test_install_merges_and_uninstall_restores_existing_config(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         target = tmp_path / "opencode.json"
         original = b'{"theme":"dark","mcp":{"existing":{"type":"local","command":["user"]}}}\n'
         target.write_bytes(original)
@@ -304,13 +306,13 @@ class TestOpencodeMCP:
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
         assert target.read_bytes() == original
 
-    def test_uninstall_removes_file(self, tmp_path: Path):
+    def test_uninstall_removes_file(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec()])
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
         assert not (tmp_path / "opencode.json").exists()
 
-    def test_uninstall_is_idempotent(self, tmp_path: Path):
+    def test_uninstall_is_idempotent(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
@@ -322,18 +324,18 @@ class TestOpencodeMCP:
 
 
 class TestCodexMCP:
-    def _agent(self):
+    def _agent(self):  # noqa: ANN202  # tracked: #288
         agent = CodexCodingAgent.__new__(CodexCodingAgent)
         agent.base_config_args = []
         agent.extra_config_args = []
         return agent
 
-    def test_install_writes_no_file_in_workspace(self, tmp_path: Path):
+    def test_install_writes_no_file_in_workspace(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec()])
         assert list(tmp_path.iterdir()) == []
 
-    def test_install_populates_extra_config_args(self, tmp_path: Path):
+    def test_install_populates_extra_config_args(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec()])
 
@@ -350,7 +352,7 @@ class TestCodexMCP:
         args_entries = [v for v in values if v.startswith("mcp_servers.vibesys_issues.args=")]
         assert len(args_entries) == 1
         args_value = args_entries[0].split("=", 1)[1]
-        assert args_value.startswith("[") and args_value.endswith("]")
+        assert args_value.startswith("[") and args_value.endswith("]")  # noqa: PT018  # tracked: #288
         assert '"-m"' in args_value
         assert '"vs_issue_board.mcp"' in args_value
         assert '"--creator"' in args_value
@@ -358,14 +360,14 @@ class TestCodexMCP:
         assert '"--cap"' in args_value
         assert '"1"' in args_value
 
-    def test_install_includes_env_overrides(self, tmp_path: Path):
+    def test_install_includes_env_overrides(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec_with_env()])
         joined = "\n".join(agent.extra_config_args)
         assert 'mcp_servers.vibesys_issues.env.MY_VAR="my_value"' in joined
         assert 'mcp_servers.vibesys_issues.env.OTHER="x"' in joined
 
-    def test_install_quotes_strings_with_special_characters(self, tmp_path: Path):
+    def test_install_quotes_strings_with_special_characters(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         spec = MCPServerSpec(
             name="weird",
@@ -379,30 +381,30 @@ class TestCodexMCP:
         assert '"back\\\\slash"' in joined
         assert '"quoted\\"value"' in joined
 
-    def test_uninstall_clears_extra_config_args(self, tmp_path: Path):
+    def test_uninstall_clears_extra_config_args(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.install_mcp_servers(tmp_path, [_spec()])
         assert agent.extra_config_args  # populated
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
         assert agent.extra_config_args == []
 
-    def test_uninstall_is_idempotent(self, tmp_path: Path):
+    def test_uninstall_is_idempotent(self, tmp_path: Path):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
         agent.uninstall_mcp_servers(tmp_path, [_spec()])
         assert agent.extra_config_args == []
 
-    def test_get_command_appends_extra_config_args(self):
+    def test_get_command_appends_extra_config_args(self):  # noqa: ANN201  # tracked: #288
         agent = self._agent()
         agent.binary_path = "/usr/local/bin/codex"
         agent.model = None
         # Without install: cmd is the bare exec line.
-        cmd = agent._get_command("hello")
+        cmd = agent._get_command("hello")  # noqa: SLF001  # tracked: #288
         assert "--config" not in cmd
 
         # After install: --config flags are appended.
-        agent.install_mcp_servers(Path("/tmp"), [_spec()])
-        cmd = agent._get_command("hello")
+        agent.install_mcp_servers(Path("/tmp"), [_spec()])  # noqa: S108  # tracked: #288
+        cmd = agent._get_command("hello")  # noqa: SLF001  # tracked: #288
         assert "--config" in cmd
         assert any(s.startswith("mcp_servers.vibesys_issues.command=") for s in cmd)
 
@@ -412,13 +414,13 @@ class TestCodexMCP:
 # ---------------------------------------------------------------------------
 
 
-def test_base_class_default_install_uninstall_are_noop(tmp_path: Path):
+def test_base_class_default_install_uninstall_are_noop(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     """A subclass that doesn't override should silently do nothing."""
 
-    from vibesys._agent_cli.base import CodingAgent
+    from vibesys._agent_cli.base import CodingAgent  # noqa: PLC0415  # tracked: #288
 
     class DummyAgent(CodingAgent):
-        def generate(self, prompt, cwd=None, timeout=None, silent=False):
+        def generate(self, prompt, cwd=None, timeout=None, silent=False):  # noqa: ANN001, ANN202, ARG002, FBT002  # tracked: #288
             return ""
 
     agent = DummyAgent()

--- a/tests/test_agent_progress.py
+++ b/tests/test_agent_progress.py
@@ -23,7 +23,7 @@ def _make_context(tmp_path):
         workspace=tmp_path,
         run_log_path=tmp_path / "run.log",
     )
-    ctx.gpu_env = lambda: {}
+    ctx.gpu_env = dict
     ctx.agent_runner = MagicMock()
     ctx.agent_runner.invoke.return_value = _judge_fallback()
     return ctx

--- a/tests/test_agent_progress.py
+++ b/tests/test_agent_progress.py
@@ -14,10 +14,10 @@ def _judge_fallback() -> JudgeResponse:
     )
 
 
-def _make_context(tmp_path):
+def _make_context(tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
     ctx = object.__new__(_RunContext)
-    ctx._progress_stack = []
-    ctx._paths = RunPaths(
+    ctx._progress_stack = []  # noqa: SLF001  # tracked: #288
+    ctx._paths = RunPaths(  # noqa: SLF001  # tracked: #288
         exp_dir=tmp_path,
         log_dir=tmp_path / "logs",
         workspace=tmp_path,
@@ -29,12 +29,12 @@ def _make_context(tmp_path):
     return ctx
 
 
-def test_progress_rendering_is_loop_owned():
+def test_progress_rendering_is_loop_owned():  # noqa: ANN201  # tracked: #288
     assert RoundProgress(3, 24).label() == "Round 3/24"
     assert CandidateProgress(2, 8, 1, 4).label() == "Round 2/8 Cand 1/4"
 
 
-def test_run_context_progress_scope_restores_previous(tmp_path):
+def test_run_context_progress_scope_restores_previous(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ctx = _make_context(tmp_path)
     outer = RoundProgress(1, 3)
     inner = CandidateProgress(2, 3, 1, 2)
@@ -48,7 +48,7 @@ def test_run_context_progress_scope_restores_previous(tmp_path):
     assert ctx.current_progress() is None
 
 
-def test_run_context_injects_current_progress(tmp_path):
+def test_run_context_injects_current_progress(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ctx = _make_context(tmp_path)
     progress = RoundProgress(2, 5)
 
@@ -65,7 +65,7 @@ def test_run_context_injects_current_progress(tmp_path):
     assert ctx.agent_runner.invoke.call_args.kwargs["progress"] is progress
 
 
-def test_run_context_explicit_progress_overrides_scope(tmp_path):
+def test_run_context_explicit_progress_overrides_scope(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ctx = _make_context(tmp_path)
     scoped = RoundProgress(2, 5)
     explicit = CandidateProgress(2, 5, 1, 3)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ from vibesys.tui import TuiTheme
 
 class TestLoadConfigValid:
     @patch.dict(os.environ, {}, clear=False)
-    def test_full_config(self, tmp_path):
+    def test_full_config(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         # Clear vertex env vars so they don't override toml values
         os.environ.pop("VERTEX_SERVICE_ACCOUNT_JSON", None)
         os.environ.pop("VERTEX_PROJECT", None)
@@ -45,7 +45,7 @@ region = "us-east5"
         assert config.providers.vertex_ai.project == "my-project"
         assert config.providers.vertex_ai.region == "us-east5"
 
-    def test_minimal_config(self, tmp_path):
+    def test_minimal_config(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
         config = load_config(cfg_file)
@@ -59,7 +59,7 @@ region = "us-east5"
         assert config.repository.owner is None
         assert config.repository.visibility == "private"
 
-    def test_outer_and_inner_agent_models_are_parsed(self, tmp_path):
+    def test_outer_and_inner_agent_models_are_parsed(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text(
             """\
@@ -92,23 +92,23 @@ reasoning_effort = "xhigh"
 
 
 class TestLoadConfigErrors:
-    def test_missing_model_name(self, tmp_path):
+    def test_missing_model_name(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("[model]\nprovider = 'vertex-ai'\n")
         with pytest.raises(ValueError, match="name"):
             load_config(cfg_file)
 
-    def test_missing_file(self):
+    def test_missing_file(self):  # noqa: ANN201  # tracked: #288
         with pytest.raises(FileNotFoundError):
             load_config(Path("/nonexistent/agent.toml"))
 
-    def test_invalid_toml(self, tmp_path):
+    def test_invalid_toml(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("not valid toml [[[")
         with pytest.raises(tomllib.TOMLDecodeError):
             load_config(cfg_file)
 
-    def test_unknown_provider(self, tmp_path):
+    def test_unknown_provider(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("""\
 [model]
@@ -118,7 +118,7 @@ provider = "bedrock"
         with pytest.raises(ValueError, match="bedrock"):
             load_config(cfg_file)
 
-    def test_unknown_feature_flag(self, tmp_path):
+    def test_unknown_feature_flag(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("""\
 [model]
@@ -132,7 +132,7 @@ new_loop = true
 
 
 class TestLoadConfigFeatureFlags:
-    def test_feature_flags_parsed_as_typed_overrides(self, tmp_path):
+    def test_feature_flags_parsed_as_typed_overrides(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("""\
 [model]
@@ -145,7 +145,7 @@ example_feature = true
 
         assert config.feature_flags == {FeatureFlag.EXAMPLE_FEATURE: True}
 
-    def test_omnigent_agent_backend_parsed_from_toml(self, tmp_path):
+    def test_omnigent_agent_backend_parsed_from_toml(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("""\
 [model]
@@ -158,7 +158,7 @@ omnigent_agent_backend = true
 
         assert config.feature_flags == {FeatureFlag.OMNIGENT_AGENT_BACKEND: True}
 
-    def test_omnigent_agent_backend_rejects_non_boolean(self, tmp_path):
+    def test_omnigent_agent_backend_rejects_non_boolean(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("""\
 [model]
@@ -174,25 +174,25 @@ omnigent_agent_backend = "yes"
 class TestLoadConfigStrict:
     """Unknown sections/keys are rejected (fail-fast), not silently dropped."""
 
-    def test_unknown_top_level_section_rejected(self, tmp_path):
+    def test_unknown_top_level_section_rejected(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n\n[bogus]\nx = 1\n')
         with pytest.raises(ValueError, match="bogus"):
             load_config(cfg_file)
 
-    def test_unknown_key_in_known_section_rejected(self, tmp_path):
+    def test_unknown_key_in_known_section_rejected(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n\n[agent]\ncli_modle = "x"\n')
         with pytest.raises(ValueError, match="cli_modle"):
             load_config(cfg_file)
 
-    def test_unknown_backend_rejected(self, tmp_path):
+    def test_unknown_backend_rejected(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n\n[backend]\nname = "tpu"\n')
         with pytest.raises(ValueError, match="tpu"):
             load_config(cfg_file)
 
-    def test_removed_cli_model_key_rejected(self, tmp_path):
+    def test_removed_cli_model_key_rejected(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         # [agent].cli_model was removed in favour of [model].name driving the
         # CLI tool directly; stale configs that still set it must error rather
         # than be silently ignored.
@@ -205,7 +205,7 @@ class TestLoadConfigStrict:
 
 
 class TestLoadConfigProviderDefault:
-    def test_missing_provider_defaults_to_none(self, tmp_path):
+    def test_missing_provider_defaults_to_none(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
         config = load_config(cfg_file)
@@ -213,7 +213,7 @@ class TestLoadConfigProviderDefault:
 
 
 class TestLoadConfigEnvVars:
-    def test_env_var_fallbacks(self, tmp_path):
+    def test_env_var_fallbacks(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("""\
 [model]
@@ -234,7 +234,7 @@ provider = "vertex-ai"
         assert vx.project == "env-project"
         assert vx.region == "us-central1"
 
-    def test_env_vars_override_toml(self, tmp_path):
+    def test_env_vars_override_toml(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("""\
 [model]
@@ -260,7 +260,7 @@ region = "us-east5"
 
 
 class TestLoadDotenvFile:
-    def test_load_dotenv_file_parses_values(self, tmp_path):
+    def test_load_dotenv_file_parses_values(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         env_file = tmp_path / ".env"
         env_file.write_text("""\
 # comment
@@ -276,14 +276,14 @@ EMPTY=
             assert os.environ["GOOGLE_API_KEY"] == "google-key"
             assert os.environ["EMPTY"] == ""
 
-    def test_load_dotenv_file_does_not_override_existing(self, tmp_path):
+    def test_load_dotenv_file_does_not_override_existing(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         env_file = tmp_path / ".env"
         env_file.write_text("OPENAI_API_KEY=from-file")
         with patch.dict("os.environ", {"OPENAI_API_KEY": "existing"}, clear=True):
             _load_dotenv_file(env_file)
             assert os.environ["OPENAI_API_KEY"] == "existing"
 
-    def test_load_dotenv_file_strips_inline_comments(self, tmp_path):
+    def test_load_dotenv_file_strips_inline_comments(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         # python-dotenv strips trailing inline comments on unquoted values, but
         # preserves a '#' inside quotes (the prior hand-rolled parser did neither).
         env_file = tmp_path / ".env"
@@ -293,14 +293,14 @@ EMPTY=
             assert os.environ["PLAIN"] == "value"
             assert os.environ["QUOTED"] == "val # hash"
 
-    def test_load_dotenv_file_missing_file_is_noop(self, tmp_path):
+    def test_load_dotenv_file_missing_file_is_noop(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         with patch.dict("os.environ", {}, clear=True):
             _load_dotenv_file(tmp_path / "does-not-exist.env")  # no error
 
 
 class TestLoadConfigThinking:
     @pytest.mark.parametrize("budget", [-1, 0, 2048])
-    def test_thinking_budget_parsed(self, tmp_path, budget):
+    def test_thinking_budget_parsed(self, tmp_path, budget):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text(f"""\
 [model]
@@ -313,7 +313,7 @@ budget = {budget}
         assert config.thinking.level is None
         assert config.thinking.budget == budget
 
-    def test_thinking_level_and_budget_are_rejected(self, tmp_path):
+    def test_thinking_level_and_budget_are_rejected(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("""\
 [model]
@@ -327,7 +327,7 @@ budget = 2048
         with pytest.raises(ValueError, match=r"thinking\.level.*thinking\.budget"):
             load_config(cfg_file)
 
-    def test_thinking_budget_below_dynamic_sentinel_is_rejected(self, tmp_path):
+    def test_thinking_budget_below_dynamic_sentinel_is_rejected(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text("""\
 [model]
@@ -342,7 +342,7 @@ budget = -2
 
 
 class TestLoadConfigAgentSection:
-    def test_agent_section_preserved(self, tmp_path):
+    def test_agent_section_preserved(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         # The [agent] table drives build_agent_runner (cli_timeout, backend,
         # cli_provider). load_config must carry it through; the previous
         # allowlist loader silently dropped it.
@@ -361,7 +361,7 @@ cli_timeout = 1800
         assert config.agent.backend == "cli"
         assert config.agent.cli_provider == "claude"
 
-    def test_agent_section_defaults_to_empty(self, tmp_path):
+    def test_agent_section_defaults_to_empty(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
         config = load_config(cfg_file)
@@ -370,7 +370,7 @@ cli_timeout = 1800
         assert config.agent.cli_timeout is None
 
     @pytest.mark.parametrize("cli_timeout", [0, -1])
-    def test_non_positive_cli_timeout_is_rejected(self, tmp_path, cli_timeout):
+    def test_non_positive_cli_timeout_is_rejected(self, tmp_path, cli_timeout):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text(f"""\
 [model]
@@ -385,7 +385,7 @@ cli_timeout = {cli_timeout}
 
 
 class TestLoadConfigRepositorySection:
-    def test_repository_defaults_are_typed(self, tmp_path):
+    def test_repository_defaults_are_typed(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text(
             """\
@@ -404,7 +404,7 @@ visibility = "internal"
         assert config.repository.visibility == "internal"
 
     @pytest.mark.parametrize("owner", ["owner/name", "spaces are bad", ""])
-    def test_invalid_repository_owner_is_rejected(self, tmp_path, owner):
+    def test_invalid_repository_owner_is_rejected(self, tmp_path, owner):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text(f'[model]\nname = "gpt-5.5"\n\n[repository]\nowner = "{owner}"\n')
 
@@ -413,7 +413,7 @@ visibility = "internal"
 
 
 class TestLoadConfigTui:
-    def test_theme_defaults_to_dark(self, tmp_path):
+    def test_theme_defaults_to_dark(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "gpt-5.5"\n')
 
@@ -422,7 +422,7 @@ class TestLoadConfigTui:
         assert config.tui.theme is TuiTheme.DARK
 
     @pytest.mark.parametrize("theme", [theme.value for theme in TuiTheme])
-    def test_every_registered_theme_is_selectable(self, tmp_path, theme):
+    def test_every_registered_theme_is_selectable(self, tmp_path, theme):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text(f'[model]\nname = "gpt-5.5"\n\n[tui]\ntheme = "{theme}"\n')
 
@@ -431,23 +431,23 @@ class TestLoadConfigTui:
         assert config.tui.theme == theme
 
     @pytest.mark.parametrize("theme", ["monokai", "Dark", "", "solarized"])
-    def test_unknown_theme_is_rejected(self, tmp_path, theme):
+    def test_unknown_theme_is_rejected(self, tmp_path, theme):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text(f'[model]\nname = "gpt-5.5"\n\n[tui]\ntheme = "{theme}"\n')
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011  # tracked: #288
             load_config(cfg_file)
 
-    def test_unknown_tui_key_is_rejected(self, tmp_path):
+    def test_unknown_tui_key_is_rejected(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "gpt-5.5"\n\n[tui]\nthme = "dark"\n')
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011  # tracked: #288
             load_config(cfg_file)
 
 
 class TestLoadConfigPerfEval:
-    def test_load_levels_preserved(self, tmp_path):
+    def test_load_levels_preserved(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         # [perf_eval].load_levels feeds the perf_eval prompt template; the
         # allowlist loader dropped this section entirely.
         cfg_file = tmp_path / "agent.toml"
@@ -471,7 +471,7 @@ max_tokens = 256
         assert [lvl.rate for lvl in levels] == [1, 8]
         assert levels[1].max_tokens == 256
 
-    def test_perf_eval_defaults_to_none(self, tmp_path):
+    def test_perf_eval_defaults_to_none(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
         config = load_config(cfg_file)
@@ -479,7 +479,7 @@ max_tokens = 256
 
     @pytest.mark.parametrize("field", ["rate", "duration", "max_tokens"])
     @pytest.mark.parametrize("value", [0, -1])
-    def test_non_positive_load_level_value_is_rejected(self, tmp_path, field, value):
+    def test_non_positive_load_level_value_is_rejected(self, tmp_path, field, value):  # noqa: ANN001, ANN201  # tracked: #288
         load_level = {"rate": 1, "duration": 20, "max_tokens": 128}
         load_level[field] = value
         cfg_file = tmp_path / "agent.toml"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -22,9 +22,9 @@ from vibesys.run import GitTracker, RunLogger, RunPaths, Workspace
 from vibesys.sandbox.run_environment import RunEnvironmentSpec
 
 
-def _minimal_copy_context(workspace):
+def _minimal_copy_context(workspace):  # noqa: ANN001, ANN202  # tracked: #288
     ctx = object.__new__(_RunContext)
-    ctx._paths = RunPaths(
+    ctx._paths = RunPaths(  # noqa: SLF001  # tracked: #288
         exp_dir=workspace.parent,
         log_dir=workspace.parent / "logs",
         workspace=workspace,
@@ -37,11 +37,11 @@ def _minimal_copy_context(workspace):
     ctx.lprint = MagicMock()
     ctx.git = GitTracker(workspace, log=ctx.lprint, excluded_dirs=ctx.EXCLUDED_WORKSPACE_DIRS)
     ctx.implementer_backend = SimpleNamespace()
-    ctx._experiment_repository = None
+    ctx._experiment_repository = None  # noqa: SLF001  # tracked: #288
     return ctx
 
 
-def test_setup_exp_dir_uses_unique_names_for_concurrent_default_runs(tmp_path):
+def test_setup_exp_dir_uses_unique_names_for_concurrent_default_runs(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     first = setup_exp_dir("test", project_root=tmp_path)
     second = setup_exp_dir("test", project_root=tmp_path)
 
@@ -52,11 +52,11 @@ def test_setup_exp_dir_uses_unique_names_for_concurrent_default_runs(tmp_path):
     assert (second / ".git").is_dir()
 
 
-def test_log_switch_retargets_stderr_tee_and_restores_on_close(tmp_path):
+def test_log_switch_retargets_stderr_tee_and_restores_on_close(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ctx = object.__new__(_RunContext)
     original_stderr = sys.stderr
     ctx.logger = RunLogger(tmp_path)
-    ctx._paths = RunPaths(
+    ctx._paths = RunPaths(  # noqa: SLF001  # tracked: #288
         exp_dir=tmp_path,
         log_dir=tmp_path,
         workspace=tmp_path / "workspace",
@@ -68,10 +68,10 @@ def test_log_switch_retargets_stderr_tee_and_restores_on_close(tmp_path):
     ctx.switch_log_file("round001")
 
     assert original_file.closed
-    assert ctx.agent_runner._run_log_file is ctx.run_log_file
+    assert ctx.agent_runner._run_log_file is ctx.run_log_file  # noqa: SLF001  # tracked: #288
     # The unconditional tee mirrors stderr into the *current* log file,
     # stripped of ANSI escapes, while writes still reach the real stderr.
-    print("\033[31mcolored diagnostic\033[0m", file=sys.stderr)
+    print("\033[31mcolored diagnostic\033[0m", file=sys.stderr)  # noqa: T201  # tracked: #288
     assert ctx.run_log_path.name.endswith("-round001.log")
 
     ctx.logger.close()
@@ -80,7 +80,7 @@ def test_log_switch_retargets_stderr_tee_and_restores_on_close(tmp_path):
     assert "\033[31m" not in ctx.run_log_path.read_text()
 
 
-def test_input_copy_respects_source_gitignore(tmp_path):
+def test_input_copy_respects_source_gitignore(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     source = tmp_path / "source"
     source.mkdir()
     (source / ".gitignore").write_text("/candidate.so\n/build/\n")
@@ -88,7 +88,7 @@ def test_input_copy_respects_source_gitignore(tmp_path):
     (source / "candidate.so").write_bytes(b"stale")
     (source / "build").mkdir()
     (source / "build" / "cache").write_text("stale")
-    subprocess.run(["git", "init", "-q"], cwd=source, check=True)
+    subprocess.run(["git", "init", "-q"], cwd=source, check=True)  # noqa: S607  # tracked: #288
 
     destination = tmp_path / "workspace"
     workspace = Workspace(
@@ -106,15 +106,15 @@ def test_input_copy_respects_source_gitignore(tmp_path):
     assert not (destination / "build").exists()
 
 
-def test_trusted_input_changes_compare_against_initial_commit(tmp_path):
+def test_trusted_input_changes_compare_against_initial_commit(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     workspace = tmp_path / "workspace"
     (workspace / "accuracy_checker").mkdir(parents=True)
     (workspace / "accuracy_checker" / "checker.py").write_text("print('ok')\n")
     (workspace / "main.py").write_text("VALUE = 1\n")
-    subprocess.run(["git", "init", "-q"], cwd=workspace, check=True)
-    subprocess.run(["git", "add", "."], cwd=workspace, check=True)
+    subprocess.run(["git", "init", "-q"], cwd=workspace, check=True)  # noqa: S607  # tracked: #288
+    subprocess.run(["git", "add", "."], cwd=workspace, check=True)  # noqa: S607  # tracked: #288
     subprocess.run(
-        [
+        [  # noqa: S607  # tracked: #288
             "git",
             "-c",
             "user.name=test",
@@ -136,49 +136,49 @@ def test_trusted_input_changes_compare_against_initial_commit(tmp_path):
     assert ctx.trusted_input_changes() == ["accuracy_checker/checker.py"]
 
 
-def test_workspace_snapshot_pushes_remote_experiment_checkpoint(tmp_path):
+def test_workspace_snapshot_pushes_remote_experiment_checkpoint(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "main.py").write_text("VALUE = 1\n")
     ctx = _minimal_copy_context(workspace)
     ctx.git.init(existing=False)
-    ctx._experiment_repository = MagicMock()
+    ctx._experiment_repository = MagicMock()  # noqa: SLF001  # tracked: #288
 
     (workspace / "main.py").write_text("VALUE = 2\n")
     ctx.snapshot_workspace("round-1-implementer")
 
-    ctx._experiment_repository.sync.assert_called_once_with()
+    ctx._experiment_repository.sync.assert_called_once_with()  # noqa: SLF001  # tracked: #288
 
 
-def test_directory_snapshot_pushes_remote_experiment_checkpoint(tmp_path):
+def test_directory_snapshot_pushes_remote_experiment_checkpoint(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "main.py").write_text("VALUE = 1\n")
     ctx = _minimal_copy_context(workspace)
     ctx.git_tracking = False
     ctx.workspace_files = MagicMock()
-    ctx._experiment_repository = MagicMock()
+    ctx._experiment_repository = MagicMock()  # noqa: SLF001  # tracked: #288
 
     ctx.snapshot_workspace("round-1-implementer")
 
     snapshot = ctx.log_dir / "snapshots" / "round-1-implementer"
     assert (snapshot / "main.py").read_text() == "VALUE = 1\n"
     ctx.workspace_files.replace_external_symlinks.assert_called_once_with(snapshot)
-    ctx._experiment_repository.sync.assert_called_once_with()
+    ctx._experiment_repository.sync.assert_called_once_with()  # noqa: SLF001  # tracked: #288
 
 
-def test_workspace_snapshot_retries_remote_failure_without_stopping_run(tmp_path):
+def test_workspace_snapshot_retries_remote_failure_without_stopping_run(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "main.py").write_text("VALUE = 1\n")
     ctx = _minimal_copy_context(workspace)
     ctx.git.init(existing=False)
-    ctx._experiment_repository = MagicMock()
-    ctx._experiment_repository.sync.side_effect = RuntimeError("network unavailable")
+    ctx._experiment_repository = MagicMock()  # noqa: SLF001  # tracked: #288
+    ctx._experiment_repository.sync.side_effect = RuntimeError("network unavailable")  # noqa: SLF001  # tracked: #288
 
     ctx.snapshot_workspace("round-1-implementer")
 
-    ctx._experiment_repository.sync.assert_called_once_with()
+    ctx._experiment_repository.sync.assert_called_once_with()  # noqa: SLF001  # tracked: #288
     ctx.lprint.assert_called_with(
         "[warn] experiment repository checkpoint push failed: network unavailable"
     )
@@ -188,27 +188,27 @@ class _FakeBackend:
     image = "fake-image"
     selected_device = None
 
-    def __init__(self, profiler_kind=None) -> None:
+    def __init__(self, profiler_kind=None) -> None:  # noqa: ANN001  # tracked: #288
         self.sandbox = MagicMock()
         if profiler_kind is not None:
             self.profiler_kind = profiler_kind
 
-    def make_sandbox(self, *_args, **_kwargs):
+    def make_sandbox(self, *_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202  # tracked: #288
         return self.sandbox
 
-    def make_monitor(self, _log_dir):
+    def make_monitor(self, _log_dir):  # noqa: ANN001, ANN202  # tracked: #288
         return None
 
 
 @pytest.fixture(autouse=True)
-def _native_profiler_preflight_ok(monkeypatch):
+def _native_profiler_preflight_ok(monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
     monkeypatch.setattr(
         "vibesys.context.preflight_profiler_kind",
-        lambda kind: ProfilerPreflightResult(kind, True),
+        lambda kind: ProfilerPreflightResult(kind, True),  # noqa: FBT003  # tracked: #288
     )
 
 
-def _write_ref(tmp_path):
+def _write_ref(tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
     ref_dir = tmp_path / "input"
     ref_dir.mkdir()
     ref = ref_dir / "reference.py"
@@ -216,7 +216,7 @@ def _write_ref(tmp_path):
     return ref
 
 
-def _write_support_dirs(project_root):
+def _write_support_dirs(project_root):  # noqa: ANN001, ANN202  # tracked: #288
     dirs = {
         ProfilerKind.NSYS: "nsys_profiler",
         ProfilerKind.OTEL: "otel_profiler",
@@ -240,8 +240,11 @@ def _write_support_dirs(project_root):
         (ProfilerKind.OTEL, "otel_profiler", DomainName.MICROSERVICES),
     ],
 )
-def test_run_context_defaults_profiler_support_paths(
-    tmp_path, profiler_kind, workspace_name, profiler_domain
+def test_run_context_defaults_profiler_support_paths(  # noqa: ANN201  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
+    profiler_kind,  # noqa: ANN001  # tracked: #288
+    workspace_name,  # noqa: ANN001  # tracked: #288
+    profiler_domain,  # noqa: ANN001  # tracked: #288
 ):
     project_root = tmp_path / "project"
     source_dir = project_root / "resources" / "profilers" / profiler_kind.value
@@ -271,7 +274,7 @@ def test_run_context_defaults_profiler_support_paths(
         assert (ctx.workspace / workspace_name / "server.py").is_file()
 
 
-def test_cli_context_skips_unused_langchain_model_construction(tmp_path):
+def test_cli_context_skips_unused_langchain_model_construction(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     ref = _write_ref(tmp_path)
 
@@ -304,7 +307,7 @@ def test_cli_context_skips_unused_langchain_model_construction(tmp_path):
     "selected",
     [ProfilerKind.NONE, *sorted(ACTIVE_PROFILER_KINDS, key=lambda kind: kind.value)],
 )
-def test_run_context_copies_only_selected_profiler_support(tmp_path, selected):
+def test_run_context_copies_only_selected_profiler_support(tmp_path, selected):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     _write_support_dirs(project_root)
     ref = _write_ref(tmp_path)
@@ -349,7 +352,7 @@ def test_run_context_copies_only_selected_profiler_support(tmp_path, selected):
         assert (ctx.workspace / "linux_cpu_profiler").exists() is expected[ProfilerKind.LINUX_CPU]
 
 
-def test_run_context_generic_auto_resolves_to_macos_profiler(tmp_path):
+def test_run_context_generic_auto_resolves_to_macos_profiler(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     support_paths = _write_support_dirs(project_root)
     ref = _write_ref(tmp_path)
@@ -382,7 +385,7 @@ def test_run_context_generic_auto_resolves_to_macos_profiler(tmp_path):
         assert not (ctx.workspace / "linux_cpu_profiler").exists()
 
 
-def test_run_context_generic_auto_resolves_to_linux_profiler(tmp_path):
+def test_run_context_generic_auto_resolves_to_linux_profiler(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     support_paths = _write_support_dirs(project_root)
     ref = _write_ref(tmp_path)
@@ -415,15 +418,15 @@ def test_run_context_generic_auto_resolves_to_linux_profiler(tmp_path):
         assert (ctx.workspace / "linux_cpu_profiler").exists()
 
 
-def test_run_context_fails_fast_when_resolved_profiler_is_unusable(tmp_path):
+def test_run_context_fails_fast_when_resolved_profiler_is_unusable(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     _write_support_dirs(project_root)
     ref = _write_ref(tmp_path)
 
-    def fail_preflight(kind):
+    def fail_preflight(kind):  # noqa: ANN001, ANN202  # tracked: #288
         return ProfilerPreflightResult(
             kind,
-            False,
+            False,  # noqa: FBT003  # tracked: #288
             ("perf_unavailable", "perf_event_paranoid_restrictive"),
             ("perf_path=missing", "perf_event_paranoid=3"),
         )
@@ -458,7 +461,7 @@ def test_run_context_fails_fast_when_resolved_profiler_is_unusable(tmp_path):
         key=lambda kind: kind.value,
     ),
 )
-def test_run_context_rejects_generic_explicit_active_profilers(tmp_path, profiler_kind):
+def test_run_context_rejects_generic_explicit_active_profilers(tmp_path, profiler_kind):  # noqa: ANN001, ANN201  # tracked: #288
     ref = _write_ref(tmp_path)
 
     with (
@@ -481,7 +484,7 @@ def test_run_context_rejects_generic_explicit_active_profilers(tmp_path, profile
         )
 
 
-def test_run_context_llm_auto_uses_backend_profiler_and_defaults_support_dir(tmp_path):
+def test_run_context_llm_auto_uses_backend_profiler_and_defaults_support_dir(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     support_paths = _write_support_dirs(project_root)
     ref = _write_ref(tmp_path)
@@ -510,7 +513,7 @@ def test_run_context_llm_auto_uses_backend_profiler_and_defaults_support_dir(tmp
         assert not (ctx.workspace / "neuron_profiler").exists()
 
 
-def test_run_context_noop_environment_hooks_do_not_require_model_artifacts(tmp_path):
+def test_run_context_noop_environment_hooks_do_not_require_model_artifacts(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     ref_dir = tmp_path / "queue" / "reference"
     ref_dir.mkdir(parents=True)
@@ -536,7 +539,7 @@ def test_run_context_noop_environment_hooks_do_not_require_model_artifacts(tmp_p
         assert not (ref_dir / "model").exists()
 
 
-def test_candidate_context_cleans_up_when_agent_runner_construction_fails(tmp_path):
+def test_candidate_context_cleans_up_when_agent_runner_construction_fails(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     workspace = tmp_path / "candidates" / f"{tmp_path.name}-g1c2" / "workspace"
     parent = SimpleNamespace(
         exp_dir=tmp_path,
@@ -585,13 +588,13 @@ def test_candidate_context_cleans_up_when_agent_runner_construction_fails(tmp_pa
     parent.git.remove_worktree.assert_called_once_with(workspace)
 
 
-def test_candidate_context_cleans_up_when_add_worktree_partially_fails(tmp_path):
+def test_candidate_context_cleans_up_when_add_worktree_partially_fails(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     workspace = tmp_path / "candidates" / f"{tmp_path.name}-g1c2" / "workspace"
     parent = SimpleNamespace(exp_dir=tmp_path, git=MagicMock())
 
-    def partially_add(path, _commit):
+    def partially_add(path, _commit):  # noqa: ANN001, ANN202  # tracked: #288
         path.mkdir(parents=True)
-        raise RuntimeError("git add failed")
+        raise RuntimeError("git add failed")  # noqa: TRY003  # tracked: #288
 
     parent.git.add_worktree.side_effect = partially_add
 
@@ -607,7 +610,7 @@ def test_candidate_context_cleans_up_when_add_worktree_partially_fails(tmp_path)
     parent.git.remove_worktree.assert_called_once_with(workspace)
 
 
-def test_run_context_cleans_up_when_agent_runner_construction_fails(tmp_path):
+def test_run_context_cleans_up_when_agent_runner_construction_fails(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     ref = _write_ref(tmp_path)
     hooks = MagicMock()
@@ -636,7 +639,7 @@ def test_run_context_cleans_up_when_agent_runner_construction_fails(tmp_path):
     hooks.teardown.assert_called_once()
 
 
-def test_run_context_tears_down_prepared_hooks_when_workspace_setup_fails(tmp_path):
+def test_run_context_tears_down_prepared_hooks_when_workspace_setup_fails(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     ref = _write_ref(tmp_path)
     hooks = MagicMock()
@@ -663,11 +666,11 @@ def test_run_context_tears_down_prepared_hooks_when_workspace_setup_fails(tmp_pa
     hooks.teardown.assert_called_once()
 
 
-def test_partial_construction_cleanup_does_not_replace_original_error():
+def test_partial_construction_cleanup_does_not_replace_original_error():  # noqa: ANN201  # tracked: #288
     stack = ExitStack()
 
     def fail_cleanup() -> None:
-        raise OSError("cleanup failed")
+        raise OSError("cleanup failed")  # noqa: TRY003  # tracked: #288
 
     stack.callback(fail_cleanup)
     construction_error = RuntimeError("construction failed")
@@ -679,7 +682,7 @@ def test_partial_construction_cleanup_does_not_replace_original_error():
     ]
 
 
-def test_run_context_materializes_input_project_path_dependencies(tmp_path):
+def test_run_context_materializes_input_project_path_dependencies(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     input_core = project_root / "examples" / "libs" / "queue-input-core"
     input_core.mkdir(parents=True)

--- a/tests/test_device_lease.py
+++ b/tests/test_device_lease.py
@@ -9,18 +9,18 @@ from unittest.mock import MagicMock
 from vibesys.run import DeviceLease
 
 
-def test_gpu_env_pins_selected_device(tmp_path):
+def test_gpu_env_pins_selected_device(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = SimpleNamespace(selected_device=SimpleNamespace(index=3))
     lease = DeviceLease(backend, log_dir=tmp_path)
     assert lease.gpu_env() == {"CUDA_VISIBLE_DEVICES": "3"}
 
 
-def test_gpu_env_empty_without_device(tmp_path):
+def test_gpu_env_empty_without_device(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     lease = DeviceLease(SimpleNamespace(), log_dir=tmp_path)
     assert lease.gpu_env() == {}
 
 
-def test_reselect_skipped_when_view_disallows_host_reselect(tmp_path):
+def test_reselect_skipped_when_view_disallows_host_reselect(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     backend = MagicMock()
     view = SimpleNamespace(host_device_reselect=False)
     lease = DeviceLease(backend, log_dir=tmp_path, run_environment_view=view)
@@ -28,7 +28,7 @@ def test_reselect_skipped_when_view_disallows_host_reselect(tmp_path):
     backend.reselect_device.assert_not_called()
 
 
-def test_close_stops_monitor_and_finalizes_gpu_json(tmp_path):
+def test_close_stops_monitor_and_finalizes_gpu_json(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     (tmp_path / "gpu.json").write_text(json.dumps({"name": "H100"}))
     (tmp_path / "gpu_contention.jsonl").write_text('{"is_contended": true}\n' * 2)
 
@@ -46,7 +46,7 @@ def test_close_stops_monitor_and_finalizes_gpu_json(tmp_path):
     assert "finished_at" in data
 
 
-def test_close_without_gpu_json_is_a_noop(tmp_path):
+def test_close_without_gpu_json_is_a_noop(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     lease = DeviceLease(MagicMock(), log_dir=tmp_path)
     lease.close()
     assert not (tmp_path / "gpu.json").exists()

--- a/tests/test_environment_hooks.py
+++ b/tests/test_environment_hooks.py
@@ -40,7 +40,7 @@ def _ctx(
     )
 
 
-def test_noop_environment_hooks_return_empty_patch(tmp_path):
+def test_noop_environment_hooks_return_empty_patch(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ref_dir = tmp_path / "reference"
     ref_dir.mkdir()
 
@@ -50,7 +50,7 @@ def test_noop_environment_hooks_return_empty_patch(tmp_path):
     assert patch.bind_mounts == ()
 
 
-def test_llm_serving_hooks_require_model_artifacts_for_reference_dir(tmp_path):
+def test_llm_serving_hooks_require_model_artifacts_for_reference_dir(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ref_dir = tmp_path / "reference"
     ref_dir.mkdir()
     (ref_dir / "reference.py").write_text("pass\n")
@@ -59,7 +59,7 @@ def test_llm_serving_hooks_require_model_artifacts_for_reference_dir(tmp_path):
         LLMServingEnvironmentHooks().prepare(_ctx(ref_dir, tmp_path))
 
 
-def test_llm_serving_hooks_return_model_mount_and_isolated_copy_excludes(tmp_path):
+def test_llm_serving_hooks_return_model_mount_and_isolated_copy_excludes(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ref_dir = tmp_path / "reference"
     model_dir = ref_dir / "model"
     model_dir.mkdir(parents=True)
@@ -70,10 +70,10 @@ def test_llm_serving_hooks_return_model_mount_and_isolated_copy_excludes(tmp_pat
     )
 
     assert patch.copy_excludes == frozenset({"model", "draft_model"})
-    assert patch.bind_mounts == (EnvironmentBindMount(model_dir, "/model", True),)
+    assert patch.bind_mounts == (EnvironmentBindMount(model_dir, "/model", True),)  # noqa: FBT003  # tracked: #288
 
 
-def test_llm_serving_hooks_keep_model_in_local_workspace_copy(tmp_path):
+def test_llm_serving_hooks_keep_model_in_local_workspace_copy(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ref_dir = tmp_path / "reference"
     (ref_dir / "model").mkdir(parents=True)
     (ref_dir / "reference.py").write_text("pass\n")

--- a/tests/test_experiment_repo.py
+++ b/tests/test_experiment_repo.py
@@ -3,25 +3,29 @@
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 from vibesys.run import ExperimentRepository, RepositoryVisibility
 from vs_github import GitHubCLI
 
 
 def _git(cwd: Path, *args: str) -> str:
-    return subprocess.run(
-        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    return subprocess.run(  # noqa: S603  # tracked: #288
+        ["git", *args],  # noqa: S607  # tracked: #288
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,  # noqa: RUF100, S607  # tracked: #288
     ).stdout.strip()
 
 
-def test_sync_commits_durable_state_and_pushes_to_origin(tmp_path):
+def test_sync_commits_durable_state_and_pushes_to_origin(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     remote = tmp_path / "remote.git"
-    subprocess.run(["git", "init", "--bare", "-q", remote], check=True)
+    subprocess.run(["git", "init", "--bare", "-q", remote], check=True)  # noqa: S603, S607  # tracked: #288
 
     experiment = tmp_path / "experiment"
     experiment.mkdir()
-    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)  # noqa: S607  # tracked: #288
     _git(experiment, "remote", "add", "origin", str(remote))
     (experiment / "workspace").mkdir()
     (experiment / "workspace" / "main.py").write_text("VALUE = 1\n")
@@ -42,10 +46,10 @@ def test_sync_commits_durable_state_and_pushes_to_origin(tmp_path):
     assert messages == ["[repo] pushed experiment state to origin"]
 
 
-def test_sync_without_origin_is_a_noop(tmp_path):
+def test_sync_without_origin_is_a_noop(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     experiment = tmp_path / "experiment"
     experiment.mkdir()
-    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)  # noqa: S607  # tracked: #288
     (experiment / "workspace").mkdir()
     (experiment / "workspace" / "main.py").write_text("VALUE = 1\n")
 
@@ -56,13 +60,13 @@ def test_sync_without_origin_is_a_noop(tmp_path):
     assert messages == []
 
 
-def test_create_remote_uses_configurable_slug_and_visibility(tmp_path, monkeypatch):
+def test_create_remote_uses_configurable_slug_and_visibility(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     experiment = tmp_path / "experiment"
     experiment.mkdir()
-    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)  # noqa: S607  # tracked: #288
     commands: list[list[str]] = []
 
-    def fake_run(command, **kwargs):
+    def fake_run(command, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288
         commands.append(command)
         return subprocess.CompletedProcess(
             command,

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -5,21 +5,21 @@ import pytest
 from vibesys.features import FEATURES, FeatureFlag, is_feature_enabled
 
 
-def test_vibesys_declares_example_feature():
+def test_vibesys_declares_example_feature():  # noqa: ANN201  # tracked: #288
     assert FeatureFlag.EXAMPLE_FEATURE in list(FeatureFlag)
     assert FeatureFlag.EXAMPLE_FEATURE.value == "example_feature"
     assert FEATURES.definitions[FeatureFlag.EXAMPLE_FEATURE].description
     assert FEATURES.definitions[FeatureFlag.EXAMPLE_FEATURE].default is False
 
 
-def test_vibesys_declares_omnigent_agent_backend():
+def test_vibesys_declares_omnigent_agent_backend():  # noqa: ANN201  # tracked: #288
     assert FeatureFlag.OMNIGENT_AGENT_BACKEND.value == "omnigent_agent_backend"
     assert FEATURES.definitions[FeatureFlag.OMNIGENT_AGENT_BACKEND].description
     # Opt-in by design: the evaluation retained agentshim as the default.
     assert FEATURES.definitions[FeatureFlag.OMNIGENT_AGENT_BACKEND].default is False
 
 
-def test_every_flag_has_a_definition_and_defaults_off():
+def test_every_flag_has_a_definition_and_defaults_off():  # noqa: ANN201  # tracked: #288
     """New flags must ship a definition, and none may default on."""
     for flag in FeatureFlag:
         definition = FEATURES.definitions[flag]
@@ -27,33 +27,33 @@ def test_every_flag_has_a_definition_and_defaults_off():
         assert definition.default is False
 
 
-def test_is_feature_enabled_uses_manifest_default():
+def test_is_feature_enabled_uses_manifest_default():  # noqa: ANN201  # tracked: #288
     assert is_feature_enabled(FeatureFlag.EXAMPLE_FEATURE) is False
 
 
 @pytest.mark.parametrize("enabled", [False, True])
-def test_is_feature_enabled_uses_config_object_override(enabled):
+def test_is_feature_enabled_uses_config_object_override(enabled):  # noqa: ANN001, ANN201  # tracked: #288
     config = SimpleNamespace(feature_flags={FeatureFlag.EXAMPLE_FEATURE: enabled})
 
     assert is_feature_enabled(FeatureFlag.EXAMPLE_FEATURE, config) is enabled
 
 
-def test_is_feature_enabled_treats_missing_config_overrides_as_empty():
+def test_is_feature_enabled_treats_missing_config_overrides_as_empty():  # noqa: ANN201  # tracked: #288
     config = SimpleNamespace(feature_flags=None)
 
     assert is_feature_enabled(FeatureFlag.EXAMPLE_FEATURE, config) is False
 
 
-def test_is_feature_enabled_accepts_mapping_config():
+def test_is_feature_enabled_accepts_mapping_config():  # noqa: ANN201  # tracked: #288
     config = {"feature_flags": {FeatureFlag.EXAMPLE_FEATURE: True}}
 
     assert is_feature_enabled(FeatureFlag.EXAMPLE_FEATURE, config) is True
 
 
-def test_is_feature_enabled_treats_missing_mapping_overrides_as_empty():
+def test_is_feature_enabled_treats_missing_mapping_overrides_as_empty():  # noqa: ANN201  # tracked: #288
     assert is_feature_enabled(FeatureFlag.EXAMPLE_FEATURE, {}) is False
 
 
-def test_is_feature_enabled_rejects_non_mapping_overrides():
-    with pytest.raises(ValueError, match="config.feature_flags must be a mapping"):
+def test_is_feature_enabled_rejects_non_mapping_overrides():  # noqa: ANN201  # tracked: #288
+    with pytest.raises(ValueError, match="config.feature_flags must be a mapping"):  # noqa: RUF043  # tracked: #288
         is_feature_enabled(FeatureFlag.EXAMPLE_FEATURE, SimpleNamespace(feature_flags=True))

--- a/tests/test_git_snapshot_resilience.py
+++ b/tests/test_git_snapshot_resilience.py
@@ -13,51 +13,51 @@ import pytest
 from vibesys.run import GitTracker
 
 
-def _git(ws, *args):
-    subprocess.run(["git", *args], cwd=ws, check=True, capture_output=True)
+def _git(ws, *args):  # noqa: ANN001, ANN002, ANN202  # tracked: #288
+    subprocess.run(["git", *args], cwd=ws, check=True, capture_output=True)  # noqa: S603, S607  # tracked: #288
 
 
-def _make_tracker(ws, excluded_dirs=()):
-    return GitTracker(ws, log=lambda *a, **k: None, excluded_dirs=excluded_dirs)
+def _make_tracker(ws, excluded_dirs=()):  # noqa: ANN001, ANN202  # tracked: #288
+    return GitTracker(ws, log=lambda *a, **k: None, excluded_dirs=excluded_dirs)  # noqa: ARG005  # tracked: #288
 
 
-def test_workspace_gitignore_excludes_compiled_artifacts(tmp_path):
+def test_workspace_gitignore_excludes_compiled_artifacts(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = _make_tracker(tmp_path, excluded_dirs={".git", "__pycache__", "_mounts", "target"})
-    gi = tracker._workspace_gitignore()
+    gi = tracker._workspace_gitignore()  # noqa: SLF001  # tracked: #288
     # accelerator artifacts an agent might drop into the workspace
     for pat in ("*.neff", "*.ntff", "neuron-compile-cache/"):
         assert pat in gi
     # still excludes the standard dirs
-    assert ".git" in gi and "_mounts" in gi and "target" in gi
+    assert ".git" in gi and "_mounts" in gi and "target" in gi  # noqa: PT018  # tracked: #288
 
 
-def test_unreadable_from_stderr_parses_git_output():
+def test_unreadable_from_stderr_parses_git_output():  # noqa: ANN201  # tracked: #288
     stderr = (
         'error: open("system_profile.json"): Permission denied\n'
         "error: unable to index file 'sub/ntrace.pb'\n"
         "fatal: adding files failed\n"
     )
-    assert GitTracker._unreadable_from_stderr(stderr) == [
+    assert GitTracker._unreadable_from_stderr(stderr) == [  # noqa: SLF001  # tracked: #288
         "system_profile.json",
         "sub/ntrace.pb",
     ]
 
 
-def test_collect_unreadable_finds_mode000_file(tmp_path):
+def test_collect_unreadable_finds_mode000_file(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ws = tmp_path / "ws"
     ws.mkdir()
     (ws / "ok.txt").write_text("hi")
     secret = ws / "secret.bin"
     secret.write_text("x")
-    os.chmod(secret, 0o000)
+    os.chmod(secret, 0o000)  # noqa: PTH101  # tracked: #288
     try:
         tracker = _make_tracker(ws)
-        assert tracker._collect_unreadable() == ["secret.bin"]
+        assert tracker._collect_unreadable() == ["secret.bin"]  # noqa: SLF001  # tracked: #288
     finally:
-        os.chmod(secret, 0o644)  # let pytest clean up
+        os.chmod(secret, 0o644)  # let pytest clean up  # noqa: PTH101  # tracked: #288
 
 
-def test_collect_unreadable_does_not_enter_ignored_runtime_trees(tmp_path, monkeypatch):
+def test_collect_unreadable_does_not_enter_ignored_runtime_trees(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     ws = tmp_path / "ws"
     ignored = ws / ".venv" / "lib"
     ignored.mkdir(parents=True)
@@ -69,38 +69,40 @@ def test_collect_unreadable_does_not_enter_ignored_runtime_trees(tmp_path, monke
     checked: list[str] = []
     real_access = os.access
 
-    def recording_access(path, mode):
+    def recording_access(path, mode):  # noqa: ANN001, ANN202  # tracked: #288
         checked.append(os.fspath(path))
         return real_access(path, mode)
 
     monkeypatch.setattr(os, "access", recording_access)
     tracker = _make_tracker(ws, excluded_dirs={".venv"})
 
-    assert tracker._collect_unreadable() == []
+    assert tracker._collect_unreadable() == []  # noqa: SLF001  # tracked: #288
     assert any(path.endswith("src/engine.py") for path in checked)
     assert all(".venv" not in path for path in checked)
 
 
 @pytest.mark.skipif(os.geteuid() == 0, reason="root can read mode-000 files")
-def test_git_add_all_excludes_unreadable_and_succeeds(tmp_path):
+def test_git_add_all_excludes_unreadable_and_succeeds(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ws = tmp_path / "ws"
     ws.mkdir()
     _git(ws, "init")
     (ws / "code.py").write_text("print('hi')\n")
     secret = ws / "system_profile.json"
     secret.write_text("{}")
-    os.chmod(secret, 0o600)  # owner-read, but pytest runs as the owner...
-    os.chmod(secret, 0o000)  # ...so make it truly unreadable
+    os.chmod(  # noqa: PTH101  # tracked: #288
+        secret, 0o600
+    )  # owner-read, but pytest runs as the owner...  # noqa: PTH101, RUF100  # tracked: #288
+    os.chmod(secret, 0o000)  # ...so make it truly unreadable  # noqa: PTH101  # tracked: #288
 
     tracker = _make_tracker(ws)
     info_exclude = ws / ".git" / "info" / "exclude"
     original_info_exclude = info_exclude.read_text()
-    os.chmod(info_exclude, 0o444)
+    os.chmod(info_exclude, 0o444)  # noqa: PTH101  # tracked: #288
     try:
         # Plain `git add -A` would exit 128 here; the resilient path must not.
-        tracker._add_all()
+        tracker._add_all()  # noqa: SLF001  # tracked: #288
         staged = subprocess.run(
-            ["git", "diff", "--cached", "--name-only"],
+            ["git", "diff", "--cached", "--name-only"],  # noqa: S607  # tracked: #288
             cwd=ws,
             capture_output=True,
             text=True,
@@ -110,16 +112,16 @@ def test_git_add_all_excludes_unreadable_and_succeeds(tmp_path):
         assert "system_profile.json" not in staged
         # The offender is recorded outside the worktree; framework snapshots
         # do not depend on a sandbox-owned `.git/info/exclude` being writable.
-        exclude = tracker._exclude_file.read_text()
+        exclude = tracker._exclude_file.read_text()  # noqa: SLF001  # tracked: #288
         assert "system_profile.json" in exclude
         assert info_exclude.read_text() == original_info_exclude
     finally:
-        os.chmod(info_exclude, 0o644)
-        os.chmod(secret, 0o644)
+        os.chmod(info_exclude, 0o644)  # noqa: PTH101  # tracked: #288
+        os.chmod(secret, 0o644)  # noqa: PTH101  # tracked: #288
 
 
 @pytest.mark.skipif(os.geteuid() == 0, reason="root can read mode-000 files")
-def test_git_add_all_excludes_unreadable_when_workspace_below_repo_root(tmp_path):
+def test_git_add_all_excludes_unreadable_when_workspace_below_repo_root(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Experiment layout: the repo root is the experiment dir, the tracked
     workspace lives below it. Exclusions must be rooted correctly while the
     framework keeps them outside the sandbox-owned repository metadata."""
@@ -132,13 +134,13 @@ def test_git_add_all_excludes_unreadable_when_workspace_below_repo_root(tmp_path
     model.mkdir()
     secret = model / "model.safetensors"
     secret.write_text("x")
-    os.chmod(secret, 0o000)
+    os.chmod(secret, 0o000)  # noqa: PTH101  # tracked: #288
 
     tracker = _make_tracker(ws)
     try:
-        tracker._add_all()
+        tracker._add_all()  # noqa: SLF001  # tracked: #288
         staged = subprocess.run(
-            ["git", "diff", "--cached", "--name-only"],
+            ["git", "diff", "--cached", "--name-only"],  # noqa: S607  # tracked: #288
             cwd=exp,
             capture_output=True,
             text=True,
@@ -147,7 +149,7 @@ def test_git_add_all_excludes_unreadable_when_workspace_below_repo_root(tmp_path
         assert "workspace/code.py" in staged
         assert "workspace/model/model.safetensors" not in staged
         # Recorded in framework-owned state, anchored to the repo toplevel.
-        exclude = tracker._exclude_file.read_text()
+        exclude = tracker._exclude_file.read_text()  # noqa: SLF001  # tracked: #288
         assert "/workspace/model/model.safetensors" in exclude
         assert (
             "/workspace/model/model.safetensors"
@@ -156,10 +158,10 @@ def test_git_add_all_excludes_unreadable_when_workspace_below_repo_root(tmp_path
         # No spurious git dir invented inside the workspace.
         assert not (ws / ".git").exists()
     finally:
-        os.chmod(secret, 0o644)
+        os.chmod(secret, 0o644)  # noqa: PTH101  # tracked: #288
 
 
-def test_agent_created_nested_repo_does_not_hijack_snapshots(tmp_path):
+def test_agent_created_nested_repo_does_not_hijack_snapshots(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """An agent running `git init`/`uv init` inside the workspace mid-run must
     not capture later snapshots (or fail them with dubious-ownership errors):
     the tracker stays pinned to the repository resolved at init time."""
@@ -177,15 +179,15 @@ def test_agent_created_nested_repo_does_not_hijack_snapshots(tmp_path):
     (ws / "code.py").write_text("v2\n")
     tracker.snapshot("round-1")
 
-    exp_log = subprocess.run(
-        ["git", "--git-dir", str(exp / ".git"), "log", "--oneline"],
+    exp_log = subprocess.run(  # noqa: S603  # tracked: #288
+        ["git", "--git-dir", str(exp / ".git"), "log", "--oneline"],  # noqa: S607  # tracked: #288
         capture_output=True,
         text=True,
         check=True,
     ).stdout
     assert "round-1" in exp_log
-    nested_log = subprocess.run(
-        ["git", "--git-dir", str(ws / ".git"), "log", "--oneline"],
+    nested_log = subprocess.run(  # noqa: PLW1510, S603  # tracked: #288
+        ["git", "--git-dir", str(ws / ".git"), "log", "--oneline"],  # noqa: S607  # tracked: #288
         capture_output=True,
         text=True,
     ).stdout

--- a/tests/test_git_tracker.py
+++ b/tests/test_git_tracker.py
@@ -11,24 +11,24 @@ from vibesys.run import GitTracker
 _EXCLUDED = {".git", "__pycache__", "target"}
 
 
-def _make_tracker(ws, logs=None):
+def _make_tracker(ws, logs=None):  # noqa: ANN001, ANN202  # tracked: #288
     log = logs.append if logs is not None else (lambda _msg: None)
     return GitTracker(ws, log=log, excluded_dirs=_EXCLUDED)
 
 
-def _git_stdout(ws, *args) -> str:
-    return subprocess.run(["git", *args], cwd=ws, check=True, capture_output=True, text=True).stdout
+def _git_stdout(ws, *args) -> str:  # noqa: ANN001, ANN002  # tracked: #288
+    return subprocess.run(["git", *args], cwd=ws, check=True, capture_output=True, text=True).stdout  # noqa: S603, S607  # tracked: #288
 
 
 @pytest.fixture
-def ws(tmp_path):
+def ws(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ws = tmp_path / "ws"
     ws.mkdir()
     (ws / "main.py").write_text("VALUE = 1\n")
     return ws
 
 
-def test_init_creates_repo_gitignore_and_initial_commit(ws):
+def test_init_creates_repo_gitignore_and_initial_commit(ws):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = _make_tracker(ws)
     tracker.init(existing=False)
 
@@ -41,7 +41,7 @@ def test_init_creates_repo_gitignore_and_initial_commit(ws):
     assert log.strip() == "initial: workspace setup"
 
 
-def test_init_appends_to_existing_gitignore(ws):
+def test_init_appends_to_existing_gitignore(ws):  # noqa: ANN001, ANN201  # tracked: #288
     (ws / ".gitignore").write_text("custom-entry")  # no trailing newline
     tracker = _make_tracker(ws)
     tracker.init(existing=False)
@@ -51,12 +51,12 @@ def test_init_appends_to_existing_gitignore(ws):
     assert "*.neff" in gitignore
 
 
-def test_init_uses_containing_experiment_repo_without_nesting(tmp_path):
+def test_init_uses_containing_experiment_repo_without_nesting(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     experiment = tmp_path / "experiment"
     workspace = experiment / "workspace"
     workspace.mkdir(parents=True)
     (workspace / "main.py").write_text("VALUE = 1\n")
-    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)  # noqa: S607  # tracked: #288
 
     tracker = _make_tracker(workspace)
     tracker.init(existing=False)
@@ -69,36 +69,36 @@ def test_init_uses_containing_experiment_repo_without_nesting(tmp_path):
     ]
 
 
-def test_snapshot_stays_bound_when_agent_creates_nested_repo(tmp_path):
+def test_snapshot_stays_bound_when_agent_creates_nested_repo(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     experiment = tmp_path / "experiment"
     workspace = experiment / "workspace"
     workspace.mkdir(parents=True)
     (workspace / "main.py").write_text("VALUE = 1\n")
-    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)  # noqa: S607  # tracked: #288
 
     tracker = _make_tracker(workspace)
     tracker.init(existing=False)
     initial_sha = tracker.current_sha()
-    assert tracker._exclude_pattern("secret.bin") == "/workspace/secret.bin"
-    assert tracker._exclude_pattern("workspace/secret.bin") == "/workspace/secret.bin"
+    assert tracker._exclude_pattern("secret.bin") == "/workspace/secret.bin"  # noqa: SLF001  # tracked: #288
+    assert tracker._exclude_pattern("workspace/secret.bin") == "/workspace/secret.bin"  # noqa: SLF001  # tracked: #288
 
     # Reproduce an isolated/root agent running plain `uv init`: a new `.git`
     # appears below the already-selected experiment repository.
-    subprocess.run(["git", "init", "-q"], cwd=workspace, check=True)
+    subprocess.run(["git", "init", "-q"], cwd=workspace, check=True)  # noqa: S607  # tracked: #288
     (workspace / "main.py").write_text("VALUE = 2\n")
     tracker.snapshot("round 1")
 
     assert tracker.current_sha() != initial_sha
     assert _git_stdout(experiment, "log", "-1", "--format=%s").strip() == "round 1"
-    nested_head = subprocess.run(
-        ["git", "rev-parse", "--verify", "HEAD"],
+    nested_head = subprocess.run(  # noqa: PLW1510  # tracked: #288
+        ["git", "rev-parse", "--verify", "HEAD"],  # noqa: S607  # tracked: #288
         cwd=workspace,
         capture_output=True,
     )
     assert nested_head.returncode != 0
 
 
-def test_init_existing_requires_repo(ws):
+def test_init_existing_requires_repo(ws):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = _make_tracker(ws)
     with pytest.raises(ValueError, match="no git repository"):
         tracker.init(existing=True)
@@ -109,7 +109,7 @@ def test_init_existing_requires_repo(ws):
     assert log.strip() == "initial: workspace setup"
 
 
-def test_snapshot_commits_changes_and_skips_clean_tree(ws):
+def test_snapshot_commits_changes_and_skips_clean_tree(ws):  # noqa: ANN001, ANN201  # tracked: #288
     logs: list[str] = []
     tracker = _make_tracker(ws, logs)
     tracker.init(existing=False)
@@ -123,7 +123,7 @@ def test_snapshot_commits_changes_and_skips_clean_tree(ws):
     assert any("no changes to commit for 'round 2'" in line for line in logs)
 
 
-def test_current_sha_matches_head_and_is_none_without_repo(ws):
+def test_current_sha_matches_head_and_is_none_without_repo(ws):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = _make_tracker(ws)
     assert tracker.current_sha() is None  # no repo yet
 
@@ -131,7 +131,7 @@ def test_current_sha_matches_head_and_is_none_without_repo(ws):
     assert tracker.current_sha() == _git_stdout(ws, "rev-parse", "HEAD").strip()
 
 
-def test_pending_changes_reports_tracked_and_untracked_paths(ws):
+def test_pending_changes_reports_tracked_and_untracked_paths(ws):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = _make_tracker(ws)
     tracker.init(existing=False)
 
@@ -141,11 +141,11 @@ def test_pending_changes_reports_tracked_and_untracked_paths(ws):
     assert tracker.pending_changes() == ["main.py", "new.txt"]
 
 
-def test_pending_changes_are_relative_to_nested_workspace(tmp_path):
+def test_pending_changes_are_relative_to_nested_workspace(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     experiment = tmp_path / "experiment"
     workspace = experiment / "workspace"
     workspace.mkdir(parents=True)
-    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=experiment, check=True)  # noqa: S607  # tracked: #288
     (workspace / "main.py").write_text("VALUE = 1\n")
     tracker = _make_tracker(workspace)
     tracker.init(existing=False)
@@ -156,7 +156,7 @@ def test_pending_changes_are_relative_to_nested_workspace(tmp_path):
     assert tracker.pending_changes() == ["main.py", "new.txt"]
 
 
-def test_checkout_tree_restores_snapshot_without_moving_head(ws):
+def test_checkout_tree_restores_snapshot_without_moving_head(ws):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = _make_tracker(ws)
     tracker.init(existing=False)
     first = tracker.current_sha()
@@ -173,7 +173,7 @@ def test_checkout_tree_restores_snapshot_without_moving_head(ws):
     assert tracker.current_sha() == second
 
 
-def test_checkout_tree_clean_removes_untracked_files(ws):
+def test_checkout_tree_clean_removes_untracked_files(ws):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = _make_tracker(ws)
     tracker.init(existing=False)
     first = tracker.current_sha()
@@ -183,7 +183,7 @@ def test_checkout_tree_clean_removes_untracked_files(ws):
     assert not (ws / "leftover.txt").exists()
 
 
-def test_checkout_tree_clean_keeps_ignored_runtime_assets(ws):
+def test_checkout_tree_clean_keeps_ignored_runtime_assets(ws):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = GitTracker(
         ws,
         log=lambda _msg: None,
@@ -207,7 +207,7 @@ def test_checkout_tree_clean_keeps_ignored_runtime_assets(ws):
     assert not (ws / "scratch.txt").exists()
 
 
-def test_checkout_tree_preserves_framework_memory_while_removing_later_code(ws):
+def test_checkout_tree_preserves_framework_memory_while_removing_later_code(ws):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = _make_tracker(ws)
     tracker.init(existing=False)
     first = tracker.current_sha()
@@ -231,7 +231,7 @@ def test_checkout_tree_preserves_framework_memory_while_removing_later_code(ws):
     assert tracker.current_sha() == second
 
 
-def test_checkout_tree_returns_false_and_logs_on_bad_sha(ws):
+def test_checkout_tree_returns_false_and_logs_on_bad_sha(ws):  # noqa: ANN001, ANN201  # tracked: #288
     logs: list[str] = []
     tracker = _make_tracker(ws, logs)
     tracker.init(existing=False)
@@ -240,7 +240,7 @@ def test_checkout_tree_returns_false_and_logs_on_bad_sha(ws):
     assert any("git tree restore 00000000 failed" in line for line in logs)
 
 
-def test_trusted_input_changes_reports_committed_and_pending_edits(ws):
+def test_trusted_input_changes_reports_committed_and_pending_edits(ws):  # noqa: ANN001, ANN201  # tracked: #288
     (ws / "accuracy_checker").mkdir()
     (ws / "accuracy_checker" / "checker.py").write_text("print('ok')\n")
     tracker = _make_tracker(ws)
@@ -260,7 +260,7 @@ def test_trusted_input_changes_reports_committed_and_pending_edits(ws):
     assert tracker.trusted_input_changes() == ["accuracy_checker/checker.py"]
 
 
-def test_resume_can_authorize_immutable_trusted_input_baseline(ws):
+def test_resume_can_authorize_immutable_trusted_input_baseline(ws):  # noqa: ANN001, ANN201  # tracked: #288
     (ws / "accuracy_checker").mkdir()
     checker = ws / "accuracy_checker" / "checker.py"
     checker.write_text("print('v1')\n")
@@ -282,7 +282,7 @@ def test_resume_can_authorize_immutable_trusted_input_baseline(ws):
     assert resumed.trusted_input_changes() == ["accuracy_checker/checker.py"]
 
 
-def test_resume_rejects_invalid_trusted_input_baseline(ws):
+def test_resume_rejects_invalid_trusted_input_baseline(ws):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = _make_tracker(ws)
     tracker.init(existing=False)
 
@@ -291,7 +291,7 @@ def test_resume_rejects_invalid_trusted_input_baseline(ws):
         resumed.init(existing=True, trusted_input_baseline="not-a-revision")
 
 
-def test_run_is_a_public_escape_hatch(ws):
+def test_run_is_a_public_escape_hatch(ws):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = _make_tracker(ws)
     tracker.init(existing=False)
 
@@ -299,7 +299,7 @@ def test_run_is_a_public_escape_hatch(ws):
     assert result.returncode == 0
 
 
-def test_add_worktree_materializes_commit_and_shares_object_store(ws, tmp_path):
+def test_add_worktree_materializes_commit_and_shares_object_store(ws, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     tracker = _make_tracker(ws)
     tracker.init(existing=False)
     base_sha = tracker.current_sha()
@@ -322,7 +322,7 @@ def test_add_worktree_materializes_commit_and_shares_object_store(ws, tmp_path):
     (wt / "main.py").write_text("VALUE = 7\n")
     wt_tracker.snapshot("child")
     child_sha = wt_tracker.current_sha()
-    assert child_sha is not None and child_sha != base_sha
+    assert child_sha is not None and child_sha != base_sha  # noqa: PT018  # tracked: #288
     # `git cat-file -e <sha>` in the MAIN repo succeeds → object is shared.
     assert tracker.run(["git", "cat-file", "-e", child_sha], check=False).returncode == 0
 
@@ -334,11 +334,11 @@ def test_add_worktree_materializes_commit_and_shares_object_store(ws, tmp_path):
     assert tracker.run(["git", "cat-file", "-e", child_sha], check=False).returncode == 0
 
 
-def test_remove_worktree_deletes_orphaned_directory(ws, tmp_path):
+def test_remove_worktree_deletes_orphaned_directory(ws, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """If `git worktree remove` leaves the directory behind (as observed when a
     file is still held open by a just-stopped editor container), the explicit
     recursive delete still clears it."""
-    import shutil
+    import shutil  # noqa: PLC0415  # tracked: #288
 
     tracker = _make_tracker(ws)
     tracker.init(existing=False)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,7 +4,7 @@ from vibesys.llm_client import _is_google_model
 
 
 @pytest.mark.parametrize(
-    "model_name, expected",
+    "model_name, expected",  # noqa: PT006  # tracked: #288
     [
         ("gemini-1.5-pro", True),
         ("gemma-2b", True),
@@ -14,5 +14,5 @@ from vibesys.llm_client import _is_google_model
         ("Gemini-1.5-pro", False),  # case-sensitive
     ],
 )
-def test_is_google_model(model_name, expected):
+def test_is_google_model(model_name, expected):  # noqa: ANN001, ANN201  # tracked: #288
     assert _is_google_model(model_name) is expected

--- a/tests/test_input_project.py
+++ b/tests/test_input_project.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import shutil
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 
 import pytest
 
@@ -16,7 +16,7 @@ def _copy_dir(src: Path, dst: Path) -> None:
     shutil.copytree(src, dst, dirs_exist_ok=True)
 
 
-def test_discover_input_project_finds_pyproject_next_to_reference(tmp_path):
+def test_discover_input_project_finds_pyproject_next_to_reference(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     input_dir = tmp_path / "queue-spsc"
     reference_dir = input_dir / "reference"
     reference_dir.mkdir(parents=True)
@@ -27,7 +27,7 @@ def test_discover_input_project_finds_pyproject_next_to_reference(tmp_path):
     assert discover_input_project(None) is None
 
 
-def test_materialize_input_project_copies_and_rewrites_explicit_lib_path_deps(tmp_path):
+def test_materialize_input_project_copies_and_rewrites_explicit_lib_path_deps(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     input_core = project_root / "examples" / "libs" / "queue-input-core"
     input_core.mkdir(parents=True)
@@ -68,7 +68,7 @@ def test_materialize_input_project_copies_and_rewrites_explicit_lib_path_deps(tm
     assert (input_dir / "pyproject.toml").read_text() == source_pyproject
 
 
-def test_materialize_input_project_copies_transitive_examples_lib_deps(tmp_path):
+def test_materialize_input_project_copies_transitive_examples_lib_deps(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     libs = project_root / "examples" / "libs"
     common = libs / "queue-common"
@@ -119,7 +119,7 @@ def test_materialize_input_project_copies_transitive_examples_lib_deps(tmp_path)
     )
 
 
-def test_materialize_input_project_rejects_path_deps_outside_examples_libs(tmp_path):
+def test_materialize_input_project_rejects_path_deps_outside_examples_libs(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     input_dir = project_root / "examples" / "data-structures" / "queue-spsc"
     input_dir.mkdir(parents=True)

--- a/tests/test_linux_cpu_profiler.py
+++ b/tests/test_linux_cpu_profiler.py
@@ -18,14 +18,14 @@ from vibesys.linux_cpu_profiler import (
 )
 
 
-def test_detect_capability_rejects_non_linux():
+def test_detect_capability_rejects_non_linux():  # noqa: ANN201  # tracked: #288
     capability = detect_capability(system="Darwin")
 
     assert capability.tool is LinuxProfilerTool.NONE
     assert capability.diagnostics == (DiagnosticCode.NOT_LINUX,)
 
 
-def test_detect_capability_reports_missing_perf():
+def test_detect_capability_reports_missing_perf():  # noqa: ANN201  # tracked: #288
     with patch("vibesys.linux_cpu_profiler._read_int", return_value=1):
         capability = detect_capability(system="Linux", which=lambda _name: None)
 
@@ -33,7 +33,7 @@ def test_detect_capability_reports_missing_perf():
     assert DiagnosticCode.PERF_UNAVAILABLE in capability.diagnostics
 
 
-def test_read_int_returns_none_for_missing_or_invalid_values(tmp_path: Path):
+def test_read_int_returns_none_for_missing_or_invalid_values(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     invalid = tmp_path / "not-an-int"
     invalid.write_text("restricted\n", encoding="utf-8")
 
@@ -41,10 +41,10 @@ def test_read_int_returns_none_for_missing_or_invalid_values(tmp_path: Path):
     assert _read_int(tmp_path / "missing") is None
 
 
-def test_detect_capability_reports_restrictions_and_stat_failure():
+def test_detect_capability_reports_restrictions_and_stat_failure():  # noqa: ANN201  # tracked: #288
     calls: list[list[str]] = []
 
-    def fake_run(command: list[str], **_kwargs):
+    def fake_run(command: list[str], **_kwargs):  # noqa: ANN003, ANN202  # tracked: #288
         calls.append(command)
         if command[1] == "--version":
             return subprocess.CompletedProcess(command, 0, "perf version 6.8\n", "")
@@ -67,9 +67,9 @@ def test_detect_capability_reports_restrictions_and_stat_failure():
     assert DiagnosticCode.PERF_STAT_UNAVAILABLE in capability.diagnostics
 
 
-def test_detect_capability_handles_perf_version_exception():
-    def fake_run(_command: list[str], **_kwargs):
-        raise OSError("cannot execute perf")
+def test_detect_capability_handles_perf_version_exception():  # noqa: ANN201  # tracked: #288
+    def fake_run(_command: list[str], **_kwargs):  # noqa: ANN003, ANN202  # tracked: #288
+        raise OSError("cannot execute perf")  # noqa: TRY003  # tracked: #288
 
     with patch("vibesys.linux_cpu_profiler._read_int", return_value=None):
         capability = detect_capability(
@@ -83,8 +83,8 @@ def test_detect_capability_handles_perf_version_exception():
     assert DiagnosticCode.PERF_UNAVAILABLE in capability.diagnostics
 
 
-def test_detect_capability_handles_perf_stat_exception():
-    def fake_run(command: list[str], **_kwargs):
+def test_detect_capability_handles_perf_stat_exception():  # noqa: ANN201  # tracked: #288
+    def fake_run(command: list[str], **_kwargs):  # noqa: ANN003, ANN202  # tracked: #288
         if command[1] == "--version":
             return subprocess.CompletedProcess(command, 0, "", "perf version 6.9\n")
         raise subprocess.TimeoutExpired(command, 10)
@@ -101,7 +101,7 @@ def test_detect_capability_handles_perf_stat_exception():
     assert DiagnosticCode.PERF_STAT_UNAVAILABLE in capability.diagnostics
 
 
-def test_perf_parsers_skip_malformed_rows_and_stop_at_limit(tmp_path: Path):
+def test_perf_parsers_skip_malformed_rows_and_stop_at_limit(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     stat_path = tmp_path / "perf-stat.csv"
     stat_path.write_text(
         "# ignored\ntoo-short\n# comment,,cycles\n10,,cycles\n",
@@ -119,7 +119,7 @@ def test_perf_parsers_skip_malformed_rows_and_stop_at_limit(tmp_path: Path):
     assert _extract_hot_symbols(report_text, limit=1) == ("55.00% bench libqueue.so [.] enqueue",)
 
 
-def test_collect_persists_perf_artifacts_and_summary(tmp_path: Path):
+def test_collect_persists_perf_artifacts_and_summary(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     capability = Capability(
         tool=LinuxProfilerTool.PERF,
         perf_path="/usr/bin/perf",
@@ -128,7 +128,7 @@ def test_collect_persists_perf_artifacts_and_summary(tmp_path: Path):
         kptr_restrict=0,
     )
 
-    def fake_run(command: list[str], *, timeout: int | None):
+    def fake_run(command: list[str], *, timeout: int | None):  # noqa: ANN202  # tracked: #288
         del timeout
         if command[1] == "stat":
             output = Path(command[command.index("-o") + 1])
@@ -168,7 +168,7 @@ def test_collect_persists_perf_artifacts_and_summary(tmp_path: Path):
     assert "dequeue" in persisted["hot_symbols"][1]
 
 
-def test_collect_reports_failed_stat_record_and_missing_counters(tmp_path: Path):
+def test_collect_reports_failed_stat_record_and_missing_counters(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     capability = Capability(
         tool=LinuxProfilerTool.PERF,
         perf_path="/usr/bin/perf",
@@ -177,7 +177,7 @@ def test_collect_reports_failed_stat_record_and_missing_counters(tmp_path: Path)
         kptr_restrict=None,
     )
 
-    def fake_run(command: list[str], *, timeout: int | None):
+    def fake_run(command: list[str], *, timeout: int | None):  # noqa: ANN202  # tracked: #288
         del timeout
         if command[1] == "stat":
             return subprocess.CompletedProcess(command, 255, "", "stat failed")
@@ -196,7 +196,7 @@ def test_collect_reports_failed_stat_record_and_missing_counters(tmp_path: Path)
     assert DiagnosticCode.COLLECTION_FAILED in result.diagnostics
 
 
-def test_collect_reports_failed_perf_report(tmp_path: Path):
+def test_collect_reports_failed_perf_report(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     capability = Capability(
         tool=LinuxProfilerTool.PERF,
         perf_path="/usr/bin/perf",
@@ -205,7 +205,7 @@ def test_collect_reports_failed_perf_report(tmp_path: Path):
         kptr_restrict=None,
     )
 
-    def fake_run(command: list[str], *, timeout: int | None):
+    def fake_run(command: list[str], *, timeout: int | None):  # noqa: ANN202  # tracked: #288
         del timeout
         if command[1] == "stat":
             Path(command[command.index("-o") + 1]).write_text("1,,cycles\n", encoding="utf-8")
@@ -226,7 +226,7 @@ def test_collect_reports_failed_perf_report(tmp_path: Path):
     assert DiagnosticCode.COLLECTION_FAILED in result.diagnostics
 
 
-def test_summarize_empty_directory_and_parse_command(tmp_path: Path):
+def test_summarize_empty_directory_and_parse_command(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     summary = summarize(tmp_path)
 
     assert summary["metadata"] is None
@@ -234,7 +234,7 @@ def test_summarize_empty_directory_and_parse_command(tmp_path: Path):
     assert parse_command("bench --scenario 'spsc queue'") == ["bench", "--scenario", "spsc queue"]
 
 
-def test_collect_degrades_when_perf_unavailable(tmp_path: Path):
+def test_collect_degrades_when_perf_unavailable(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     capability = Capability(
         tool=LinuxProfilerTool.NONE,
         perf_path=None,

--- a/tests/test_llama_3_8b_benchmark.py
+++ b/tests/test_llama_3_8b_benchmark.py
@@ -7,27 +7,27 @@ from pathlib import Path
 
 BENCHMARK_PATH = Path("examples/model-serving/Llama-3-8B/benchmark/benchmark.py")
 SPEC = importlib.util.spec_from_file_location("llama_3_8b_benchmark", BENCHMARK_PATH)
-assert SPEC is not None and SPEC.loader is not None
+assert SPEC is not None and SPEC.loader is not None  # noqa: PT018  # tracked: #288
 BENCHMARK = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = BENCHMARK
 SPEC.loader.exec_module(BENCHMARK)
 
 
-def test_closed_loop_connection_limit_matches_requested_concurrency():
+def test_closed_loop_connection_limit_matches_requested_concurrency():  # noqa: ANN201  # tracked: #288
     limits = BENCHMARK.http_limits_for(256)
 
     assert limits.max_connections == 256
     assert limits.max_keepalive_connections == 256
 
 
-def test_open_loop_connection_limit_does_not_cap_active_requests():
+def test_open_loop_connection_limit_does_not_cap_active_requests():  # noqa: ANN201  # tracked: #288
     limits = BENCHMARK.http_limits_for(None)
 
     assert limits.max_connections is None
     assert limits.max_keepalive_connections == 100
 
 
-def test_concurrency_stats_track_driver_and_response_streams_separately():
+def test_concurrency_stats_track_driver_and_response_streams_separately():  # noqa: ANN201  # tracked: #288
     stats = BENCHMARK.ConcurrencyStats()
 
     stats.request_started()
@@ -43,18 +43,18 @@ def test_concurrency_stats_track_driver_and_response_streams_separately():
     assert stats.active_streams == 0
 
 
-def test_warmup_is_bounded_and_returns_discardable_results(monkeypatch):
+def test_warmup_is_bounded_and_returns_discardable_results(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     active = 0
     max_active = 0
 
-    async def fake_send_request(
-        client,
-        url,
-        model,
-        prompt,
-        max_tokens,
-        temperature,
-        concurrency_stats=None,
+    async def fake_send_request(  # noqa: ANN202, PLR0913  # tracked: #288
+        client,  # noqa: ANN001, ARG001  # tracked: #288
+        url,  # noqa: ANN001, ARG001  # tracked: #288
+        model,  # noqa: ANN001, ARG001  # tracked: #288
+        prompt,  # noqa: ANN001, ARG001  # tracked: #288
+        max_tokens,  # noqa: ANN001, ARG001  # tracked: #288
+        temperature,  # noqa: ANN001, ARG001  # tracked: #288
+        concurrency_stats=None,  # noqa: ANN001  # tracked: #288
     ):
         nonlocal active, max_active
         assert concurrency_stats is None
@@ -79,7 +79,7 @@ def test_warmup_is_bounded_and_returns_discardable_results(monkeypatch):
             "http://127.0.0.1:8000/v1/completions",
             ["prompt"],
             args,
-            random.Random(42),
+            random.Random(42),  # noqa: S311  # tracked: #288
         )
     )
 
@@ -87,25 +87,25 @@ def test_warmup_is_bounded_and_returns_discardable_results(monkeypatch):
     assert max_active == 3
 
 
-def test_benchmark_reports_requested_and_observed_concurrency(monkeypatch):
+def test_benchmark_reports_requested_and_observed_concurrency(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     class FakeAsyncClient:
-        def __init__(self, *, limits):
+        def __init__(self, *, limits):  # noqa: ANN001, ANN204  # tracked: #288
             self.limits = limits
 
-        async def __aenter__(self):
+        async def __aenter__(self):  # noqa: ANN204  # tracked: #288
             return self
 
-        async def __aexit__(self, exc_type, exc, traceback):
+        async def __aexit__(self, exc_type, exc, traceback):  # noqa: ANN001, ANN204  # tracked: #288
             return None
 
-    async def fake_send_request(
-        client,
-        url,
-        model,
-        prompt,
-        max_tokens,
-        temperature,
-        concurrency_stats=None,
+    async def fake_send_request(  # noqa: ANN202, PLR0913  # tracked: #288
+        client,  # noqa: ANN001, ARG001  # tracked: #288
+        url,  # noqa: ANN001, ARG001  # tracked: #288
+        model,  # noqa: ANN001, ARG001  # tracked: #288
+        prompt,  # noqa: ANN001, ARG001  # tracked: #288
+        max_tokens,  # noqa: ANN001, ARG001  # tracked: #288
+        temperature,  # noqa: ANN001, ARG001  # tracked: #288
+        concurrency_stats=None,  # noqa: ANN001  # tracked: #288
     ):
         concurrency_stats.request_started()
         concurrency_stats.stream_opened()

--- a/tests/test_llama_mlx_8bit_bundle.py
+++ b/tests/test_llama_mlx_8bit_bundle.py
@@ -5,7 +5,7 @@ from pathlib import Path
 BUNDLE = Path("examples/model-serving/Llama-3.1-8B-Instruct-MLX-8bit")
 
 
-def test_llama_mlx_8bit_bundle_layout():
+def test_llama_mlx_8bit_bundle_layout():  # noqa: ANN201  # tracked: #288
     assert (BUNDLE / "README.md").is_file()
     assert (BUNDLE / "config.json").is_file()
     assert (BUNDLE / "requirements.txt").is_file()
@@ -16,7 +16,7 @@ def test_llama_mlx_8bit_bundle_layout():
     assert (BUNDLE / "benchmark" / "benchmark.py").is_file()
 
 
-def test_llama_mlx_8bit_metadata_points_to_target_model():
+def test_llama_mlx_8bit_metadata_points_to_target_model():  # noqa: ANN201  # tracked: #288
     meta = json.loads((BUNDLE / "reference" / "meta.json").read_text())
     assert meta["model_id"] == "mlx-community/Meta-Llama-3.1-8B-Instruct-8bit"
     assert meta["revision"] == "142d428004044c37c441272c91316251d9aecc58"
@@ -26,7 +26,7 @@ def test_llama_mlx_8bit_metadata_points_to_target_model():
     assert config["quantization"] == {"group_size": 64, "bits": 8}
 
 
-def test_llama_mlx_8bit_reference_defaults_to_local_model_dir():
+def test_llama_mlx_8bit_reference_defaults_to_local_model_dir():  # noqa: ANN201  # tracked: #288
     tree = ast.parse((BUNDLE / "reference" / "reference.py").read_text())
     assignments = [
         node
@@ -39,7 +39,7 @@ def test_llama_mlx_8bit_reference_defaults_to_local_model_dir():
     assert "model" in ast.unparse(assignments[0])
 
 
-def test_llama_mlx_8bit_checker_and_benchmark_support_url_flags():
+def test_llama_mlx_8bit_checker_and_benchmark_support_url_flags():  # noqa: ANN201  # tracked: #288
     checker_source = (BUNDLE / "accuracy_checker" / "checker.py").read_text()
     benchmark_source = (BUNDLE / "benchmark" / "benchmark.py").read_text()
 
@@ -60,7 +60,7 @@ def test_llama_mlx_8bit_checker_and_benchmark_support_url_flags():
     assert "--dataset-revision" in benchmark_source
 
 
-def test_llama_mlx_8bit_pins_jsonschemabench_dataset_revision():
+def test_llama_mlx_8bit_pins_jsonschemabench_dataset_revision():  # noqa: ANN201  # tracked: #288
     checker_source = (BUNDLE / "accuracy_checker" / "checker.py").read_text()
     benchmark_source = (BUNDLE / "benchmark" / "benchmark.py").read_text()
     assert "epfl-dlab/JSONSchemaBench" in checker_source

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -7,11 +7,11 @@ from vibesys.config import Config
 from vibesys.llm_client import build_model
 
 
-def _make_config(
-    name="claude-sonnet-4-6",
-    provider=None,
-    thinking=None,
-    providers=None,
+def _make_config(  # noqa: ANN202  # tracked: #288
+    name="claude-sonnet-4-6",  # noqa: ANN001  # tracked: #288
+    provider=None,  # noqa: ANN001  # tracked: #288
+    thinking=None,  # noqa: ANN001  # tracked: #288
+    providers=None,  # noqa: ANN001  # tracked: #288
 ):
     """Helper to build a validated :class:`Config` matching load_config output."""
     return Config.model_validate(
@@ -36,7 +36,7 @@ FAKE_CREDS_DICT = {
 
 
 @pytest.fixture
-def key_file(tmp_path):
+def key_file(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     kf = tmp_path / "key.json"
     kf.write_text(json.dumps(FAKE_CREDS_DICT))
     return kf
@@ -46,15 +46,15 @@ def key_file(tmp_path):
 
 
 class TestAutoDetectProvider:
-    def test_claude_model_returns_anthropic_string(self):
+    def test_claude_model_returns_anthropic_string(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("claude-sonnet-4-6")
         assert build_model(config) == "anthropic:claude-sonnet-4-6"
 
-    def test_gemini_model_returns_google_genai_string(self):
+    def test_gemini_model_returns_google_genai_string(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("gemini-2.5-pro")
         assert build_model(config) == "google_genai:gemini-2.5-pro"
 
-    def test_unknown_model_prefix_raises(self):
+    def test_unknown_model_prefix_raises(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("llama-3-70b")
         with pytest.raises(ValueError, match="Cannot auto-detect"):
             build_model(config)
@@ -64,11 +64,11 @@ class TestAutoDetectProvider:
 
 
 class TestAnthropicProvider:
-    def test_anthropic_claude_model(self):
+    def test_anthropic_claude_model(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("claude-sonnet-4-6", provider="anthropic")
         assert build_model(config) == "anthropic:claude-sonnet-4-6"
 
-    def test_anthropic_non_claude_model_raises(self):
+    def test_anthropic_non_claude_model_raises(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("gemini-2.5-pro", provider="anthropic")
         with pytest.raises(ValueError, match="not a Claude model"):
             build_model(config)
@@ -78,11 +78,11 @@ class TestAnthropicProvider:
 
 
 class TestGoogleGenaiProvider:
-    def test_google_genai_gemini_model(self):
+    def test_google_genai_gemini_model(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("gemini-2.5-pro", provider="google-genai")
         assert build_model(config) == "google_genai:gemini-2.5-pro"
 
-    def test_google_genai_non_google_model_raises(self):
+    def test_google_genai_non_google_model_raises(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("claude-sonnet-4-6", provider="google-genai")
         with pytest.raises(ValueError, match="not a Google model"):
             build_model(config)
@@ -92,7 +92,7 @@ class TestGoogleGenaiProvider:
 
 
 class TestUnknownProvider:
-    def test_unknown_provider_rejected_by_schema(self):
+    def test_unknown_provider_rejected_by_schema(self):  # noqa: ANN201  # tracked: #288
         # Provider validation now happens at the Config boundary (fail-fast),
         # not inside build_model.
         with pytest.raises(ValueError, match="bedrock"):
@@ -105,7 +105,7 @@ class TestUnknownProvider:
 class TestVertexAIProvider:
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     @patch("vibesys.llm_client._vertex_anthropic_model_class")
-    def test_vertex_claude_model(self, mock_model_class, mock_from_sa, key_file):
+    def test_vertex_claude_model(self, mock_model_class, mock_from_sa, key_file):  # noqa: ANN001, ANN201  # tracked: #288
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
         constructed_model = object()
@@ -132,7 +132,7 @@ class TestVertexAIProvider:
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     @patch("vibesys.llm_client._vertex_gemini_model_class")
-    def test_vertex_gemini_model(self, mock_model_class, mock_from_sa, key_file):
+    def test_vertex_gemini_model(self, mock_model_class, mock_from_sa, key_file):  # noqa: ANN001, ANN201  # tracked: #288
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
         mock_chat_cls = MagicMock()
@@ -154,7 +154,7 @@ class TestVertexAIProvider:
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     @patch("vibesys.llm_client._vertex_gemini_model_class")
-    def test_vertex_gemini_thinking_level(self, mock_model_class, mock_from_sa, key_file):
+    def test_vertex_gemini_thinking_level(self, mock_model_class, mock_from_sa, key_file):  # noqa: ANN001, ANN201  # tracked: #288
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
         mock_chat_cls = MagicMock()
@@ -177,7 +177,7 @@ class TestVertexAIProvider:
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     @patch("vibesys.llm_client._vertex_gemini_model_class")
-    def test_vertex_gemini_thinking_budget(self, mock_model_class, mock_from_sa, key_file):
+    def test_vertex_gemini_thinking_budget(self, mock_model_class, mock_from_sa, key_file):  # noqa: ANN001, ANN201  # tracked: #288
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
         mock_chat_cls = MagicMock()
@@ -200,7 +200,7 @@ class TestVertexAIProvider:
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     @patch("vibesys.llm_client._vertex_gemini_model_class")
-    def test_vertex_gemini_zero_thinking_budget(self, mock_model_class, mock_from_sa, key_file):
+    def test_vertex_gemini_zero_thinking_budget(self, mock_model_class, mock_from_sa, key_file):  # noqa: ANN001, ANN201  # tracked: #288
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
         mock_chat_cls = MagicMock()
@@ -216,7 +216,7 @@ class TestVertexAIProvider:
         assert call_kwargs["thinking_budget"] == 0
         assert call_kwargs["include_thoughts"] is True
 
-    def test_vertex_missing_json_key_raises(self):
+    def test_vertex_missing_json_key_raises(self):  # noqa: ANN201  # tracked: #288
         config = _make_config(
             "claude-sonnet-4-6",
             provider="vertex-ai",
@@ -233,7 +233,7 @@ class TestVertexAIProvider:
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     @patch("vibesys.llm_client._vertex_anthropic_model_class")
-    def test_vertex_project_overrides_json(self, mock_model_class, mock_from_sa, key_file):
+    def test_vertex_project_overrides_json(self, mock_model_class, mock_from_sa, key_file):  # noqa: ANN001, ANN201  # tracked: #288
         mock_creds = MagicMock()
         mock_from_sa.return_value = mock_creds
         mock_chat_cls = MagicMock()
@@ -262,15 +262,15 @@ class TestVertexAIProvider:
 
 
 class TestConfigToModel:
-    def test_full_pipeline_anthropic(self):
+    def test_full_pipeline_anthropic(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("claude-sonnet-4-6", provider="anthropic")
         assert build_model(config) == "anthropic:claude-sonnet-4-6"
 
-    def test_full_pipeline_google_genai(self):
+    def test_full_pipeline_google_genai(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("gemini-2.5-pro", provider="google-genai")
         assert build_model(config) == "google_genai:gemini-2.5-pro"
 
-    def test_full_pipeline_openai(self):
+    def test_full_pipeline_openai(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("gpt-4o", provider="openai")
         assert build_model(config) == "openai:gpt-4o"
 
@@ -279,36 +279,36 @@ class TestConfigToModel:
 
 
 class TestOpenAIProvider:
-    def test_openai_gpt_model(self):
+    def test_openai_gpt_model(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("gpt-4o", provider="openai")
         assert build_model(config) == "openai:gpt-4o"
 
-    def test_openai_o1_model(self):
+    def test_openai_o1_model(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("o1", provider="openai")
         assert build_model(config) == "openai:o1"
 
-    def test_openai_o3_model(self):
+    def test_openai_o3_model(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("o3-mini", provider="openai")
         assert build_model(config) == "openai:o3-mini"
 
-    def test_openai_o4_model(self):
+    def test_openai_o4_model(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("o4-mini", provider="openai")
         assert build_model(config) == "openai:o4-mini"
 
-    def test_openai_non_openai_model_raises(self):
+    def test_openai_non_openai_model_raises(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("claude-sonnet-4-6", provider="openai")
         with pytest.raises(ValueError, match="not an OpenAI model"):
             build_model(config)
 
-    def test_auto_detect_openai_gpt(self):
+    def test_auto_detect_openai_gpt(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("gpt-4o")
         assert build_model(config) == "openai:gpt-4o"
 
-    def test_auto_detect_openai_o1(self):
+    def test_auto_detect_openai_o1(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("o1")
         assert build_model(config) == "openai:o1"
 
-    def test_auto_detect_openai_o3(self):
+    def test_auto_detect_openai_o3(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("o3-mini")
         assert build_model(config) == "openai:o3-mini"
 
@@ -317,40 +317,40 @@ class TestOpenAIProvider:
 
 
 class TestThinkingNotSupported:
-    def test_anthropic_with_thinking_raises(self):
+    def test_anthropic_with_thinking_raises(self):  # noqa: ANN201  # tracked: #288
         config = _make_config(
             "claude-sonnet-4-6", provider="anthropic", thinking={"level": "medium"}
         )
-        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
+        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):  # noqa: RUF043  # tracked: #288
             build_model(config)
 
-    def test_openai_with_thinking_raises(self):
+    def test_openai_with_thinking_raises(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("gpt-4o", provider="openai", thinking={"budget": 0})
-        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
+        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):  # noqa: RUF043  # tracked: #288
             build_model(config)
 
-    def test_google_genai_with_thinking_raises(self):
+    def test_google_genai_with_thinking_raises(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("gemini-2.5-pro", provider="google-genai", thinking={"budget": 1024})
-        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
+        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):  # noqa: RUF043  # tracked: #288
             build_model(config)
 
-    def test_auto_detect_anthropic_with_thinking_raises(self):
+    def test_auto_detect_anthropic_with_thinking_raises(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("claude-sonnet-4-6", thinking={"level": "low"})
-        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
+        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):  # noqa: RUF043  # tracked: #288
             build_model(config)
 
-    def test_auto_detect_openai_with_thinking_raises(self):
+    def test_auto_detect_openai_with_thinking_raises(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("gpt-4o", thinking={"budget": 512})
-        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
+        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):  # noqa: RUF043  # tracked: #288
             build_model(config)
 
-    def test_auto_detect_google_genai_with_thinking_raises(self):
+    def test_auto_detect_google_genai_with_thinking_raises(self):  # noqa: ANN201  # tracked: #288
         config = _make_config("gemini-2.5-pro", thinking={"level": "medium"})
-        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
+        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):  # noqa: RUF043  # tracked: #288
             build_model(config)
 
     @patch("google.oauth2.service_account.Credentials.from_service_account_info")
-    def test_vertex_claude_with_thinking_raises(self, mock_from_sa, key_file):
+    def test_vertex_claude_with_thinking_raises(self, mock_from_sa, key_file):  # noqa: ANN001, ANN201  # tracked: #288
         mock_from_sa.return_value = MagicMock()
         config = _make_config(
             "claude-sonnet-4-6",
@@ -358,5 +358,5 @@ class TestThinkingNotSupported:
             thinking={"level": "medium"},
             providers={"vertex-ai": {"json": str(key_file), "project": None, "region": "us-east5"}},
         )
-        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):
+        with pytest.raises(ValueError, match="[Tt]hinking.*not supported"):  # noqa: RUF043  # tracked: #288
             build_model(config)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -35,7 +35,7 @@ FAKE_CREDS_DICT = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture
 def key_file(tmp_path):
     kf = tmp_path / "key.json"
     kf.write_text(json.dumps(FAKE_CREDS_DICT))

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -7,19 +7,19 @@ import sys
 from vibesys.run import RunLogger
 
 
-def test_tee_logger_owns_and_restores_stderr(tmp_path):
+def test_tee_logger_owns_and_restores_stderr(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     original = sys.stderr
     logger = RunLogger(tmp_path)
     try:
         assert sys.stderr is not original  # tee installed
-        print("diagnostic", file=sys.stderr)
+        print("diagnostic", file=sys.stderr)  # noqa: T201  # tracked: #288
     finally:
         logger.close()
     assert sys.stderr is original  # restored on close
     assert "diagnostic" in logger.path.read_text()
 
 
-def test_no_tee_logger_leaves_stderr_untouched(tmp_path):
+def test_no_tee_logger_leaves_stderr_untouched(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     original = sys.stderr
     logger = RunLogger(tmp_path, tee_stderr=False)
     try:
@@ -35,7 +35,7 @@ def test_no_tee_logger_leaves_stderr_untouched(tmp_path):
     assert "candidate line" in logger.path.read_text()
 
 
-def test_switch_closes_each_superseded_log_file(tmp_path):
+def test_switch_closes_each_superseded_log_file(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     logger = RunLogger(tmp_path, tee_stderr=False)
     first = logger.file
 
@@ -52,7 +52,7 @@ def test_switch_closes_each_superseded_log_file(tmp_path):
     logger.close()  # Cleanup remains idempotent.
 
 
-def test_stable_writer_follows_switch_after_old_file_is_closed(tmp_path):
+def test_stable_writer_follows_switch_after_old_file_is_closed(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     logger = RunLogger(tmp_path, tee_stderr=False)
     writer = logger.writer
     first = logger.file

--- a/tests/test_macos_cpu_profiler.py
+++ b/tests/test_macos_cpu_profiler.py
@@ -13,11 +13,11 @@ from vibesys.macos_cpu_profiler import (
 
 
 class Result:
-    def __init__(self, returncode=0, stdout="", stderr=""):
+    def __init__(self, returncode=0, stdout="", stderr=""):  # noqa: ANN001, ANN204  # tracked: #288
         self.returncode, self.stdout, self.stderr = returncode, stdout, stderr
 
 
-def test_command_line_tools_shim_falls_back_to_sample():
+def test_command_line_tools_shim_falls_back_to_sample():  # noqa: ANN201  # tracked: #288
     capability = detect_capability(
         system="Darwin",
         which=lambda name: "/usr/bin/sample" if name == "sample" else None,
@@ -27,8 +27,8 @@ def test_command_line_tools_shim_falls_back_to_sample():
     assert DiagnosticCode.COMMAND_LINE_TOOLS_ONLY in capability.diagnostics
 
 
-def test_missing_time_profiler_template_falls_back_to_sample():
-    def run(command, **_kwargs):
+def test_missing_time_profiler_template_falls_back_to_sample():  # noqa: ANN201  # tracked: #288
+    def run(command, **_kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
         if command[:2] == ["xcode-select", "-p"]:
             return Result(stdout="/Applications/Xcode.app/Contents/Developer\n")
         return Result(stdout="Activity Monitor\n")
@@ -38,8 +38,8 @@ def test_missing_time_profiler_template_falls_back_to_sample():
     assert DiagnosticCode.TIME_PROFILER_UNAVAILABLE in capability.diagnostics
 
 
-def test_functional_time_profiler_selects_instruments():
-    def run(command, **_kwargs):
+def test_functional_time_profiler_selects_instruments():  # noqa: ANN201  # tracked: #288
+    def run(command, **_kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
         if command[:2] == ["xcode-select", "-p"]:
             return Result(stdout="/Applications/Xcode.app/Contents/Developer\n")
         if command[-2:] == ["list", "templates"]:
@@ -51,9 +51,9 @@ def test_functional_time_profiler_selects_instruments():
     assert capability.tool_version == "xctrace version 26.0"
 
 
-def test_detection_reports_unavailable_tools_after_xcode_select_failure():
-    def fail(*_args, **_kwargs):
-        raise OSError("xcode-select unavailable")
+def test_detection_reports_unavailable_tools_after_xcode_select_failure():  # noqa: ANN201  # tracked: #288
+    def fail(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202  # tracked: #288
+        raise OSError("xcode-select unavailable")  # noqa: TRY003  # tracked: #288
 
     with patch("vibesys.macos_cpu_profiler.Path.is_file", return_value=False):
         capability = detect_capability(system="Darwin", which=lambda _name: None, run=fail)
@@ -64,12 +64,12 @@ def test_detection_reports_unavailable_tools_after_xcode_select_failure():
     )
 
 
-def test_descendants_returns_nested_processes_and_ignores_malformed_rows():
+def test_descendants_returns_nested_processes_and_ignores_malformed_rows():  # noqa: ANN201  # tracked: #288
     result = Result(stdout="10 1\n20 10\nmalformed\n30 20\n40 10\n10 30\n")
     assert _descendants(10, run=lambda *_args, **_kwargs: result) == [20, 40, 30]
 
 
-def test_collection_persists_reproduction_metadata(tmp_path: Path):
+def test_collection_persists_reproduction_metadata(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     result = collect(["./benchmark"], tmp_path, capability=detect_capability(system="Linux"))
     metadata = Path(result.metadata).read_text()
     assert result.status == "error"
@@ -77,7 +77,7 @@ def test_collection_persists_reproduction_metadata(tmp_path: Path):
     assert '"scored_benchmark": false' in metadata
 
 
-def test_instruments_collection_builds_bounded_launch_command(tmp_path: Path):
+def test_instruments_collection_builds_bounded_launch_command(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     capability = Capability(
         MacOSProfilerTool.XCTRACE,
         "/Applications/Xcode.app/Contents/Developer",
@@ -113,7 +113,7 @@ def test_instruments_collection_builds_bounded_launch_command(tmp_path: Path):
     assert run.call_args.kwargs["timeout"] == 37
 
 
-def test_collection_converts_profiler_launch_error_to_diagnostic(tmp_path: Path):
+def test_collection_converts_profiler_launch_error_to_diagnostic(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     capability = Capability(MacOSProfilerTool.XCTRACE, None, "/usr/bin/xctrace", None, None)
     with patch(
         "vibesys.macos_cpu_profiler.subprocess.run",
@@ -125,7 +125,7 @@ def test_collection_converts_profiler_launch_error_to_diagnostic(tmp_path: Path)
     assert "cannot execute" in Path(result.metadata).read_text()
 
 
-def test_permission_failure_and_child_target_are_structured(tmp_path: Path):
+def test_permission_failure_and_child_target_are_structured(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     capability = detect_capability(
         system="Darwin",
         which=lambda name: "/usr/bin/sample" if name == "sample" else None,
@@ -136,9 +136,9 @@ def test_permission_failure_and_child_target_are_structured(tmp_path: Path):
         (),
         {
             "pid": 123,
-            "terminate": lambda self: None,
-            "wait": lambda self, timeout: 0,
-            "kill": lambda self: None,
+            "terminate": lambda self: None,  # noqa: ARG005  # tracked: #288
+            "wait": lambda self, timeout: 0,  # noqa: ARG005  # tracked: #288
+            "kill": lambda self: None,  # noqa: ARG005  # tracked: #288
         },
     )()
     with (
@@ -155,15 +155,15 @@ def test_permission_failure_and_child_target_are_structured(tmp_path: Path):
     assert DiagnosticCode.ATTACH_DENIED in result.diagnostics
 
 
-def test_sample_kills_launcher_when_graceful_wait_times_out(tmp_path: Path):
+def test_sample_kills_launcher_when_graceful_wait_times_out(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     capability = Capability(MacOSProfilerTool.SAMPLE, None, None, "/usr/bin/sample", None)
     process = type(
         "Process",
         (),
         {
             "pid": 123,
-            "terminate": lambda self: None,
-            "wait": lambda self, timeout: (_ for _ in ()).throw(
+            "terminate": lambda self: None,  # noqa: ARG005  # tracked: #288
+            "wait": lambda self, timeout: (_ for _ in ()).throw(  # noqa: ARG005  # tracked: #288
                 __import__("subprocess").TimeoutExpired("benchmark", timeout)
             ),
             "kill": lambda self: setattr(self, "killed", True),
@@ -182,7 +182,7 @@ def test_sample_kills_launcher_when_graceful_wait_times_out(tmp_path: Path):
     assert process.killed
 
 
-def test_parse_command_preserves_quoted_arguments_without_shell_execution():
+def test_parse_command_preserves_quoted_arguments_without_shell_execution():  # noqa: ANN201  # tracked: #288
     assert parse_command('python bench.py --label "queue run"') == [
         "python",
         "bench.py",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,20 +35,20 @@ from vibesys.profilers import ProfilerKind
 from vs_github import GitHubCLI
 
 
-def _patch_loop_runner(loop_name: str, runner: Mock):
+def _patch_loop_runner(loop_name: str, runner: Mock):  # noqa: ANN202  # tracked: #288
     """Swap the dispatch entry's ``run`` function for *runner*.
 
     ``_LOOP_COMMANDS`` holds direct function references, so patching the
     module-level function name no longer affects dispatch — patch the
     command record instead.
     """
-    import dataclasses
+    import dataclasses  # noqa: PLC0415  # tracked: #288
 
-    import vibesys.main as cli
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
-    command = cli._LOOP_COMMANDS[loop_name]
+    command = cli._LOOP_COMMANDS[loop_name]  # noqa: SLF001  # tracked: #288
     patched = dataclasses.replace(command, run=runner)
-    return patch.dict(cli._LOOP_COMMANDS, {loop_name: patched})
+    return patch.dict(cli._LOOP_COMMANDS, {loop_name: patched})  # noqa: SLF001  # tracked: #288
 
 
 TARGET_ARGS = ["--input", "examples/model-serving/Llama-3-8B"]
@@ -94,25 +94,25 @@ def _write_resume_event(
 # ---------------------------------------------------------------------------
 
 
-def test_extract_flag_space_form():
+def test_extract_flag_space_form():  # noqa: ANN201  # tracked: #288
     val, rest = _extract_flag(["--outer-loop", "agent", "--input", "x"], "--outer-loop")
     assert val == "agent"
     assert rest == ["--input", "x"]
 
 
-def test_extract_flag_equals_form():
+def test_extract_flag_equals_form():  # noqa: ANN201  # tracked: #288
     val, rest = _extract_flag(["--input", "x", "--outer-loop=evolve"], "--outer-loop")
     assert val == "evolve"
     assert rest == ["--input", "x"]
 
 
-def test_extract_flag_missing_returns_none():
+def test_extract_flag_missing_returns_none():  # noqa: ANN201  # tracked: #288
     val, rest = _extract_flag(["--input", "x"], "--outer-loop")
     assert val is None
     assert rest == ["--input", "x"]
 
 
-def test_extract_flag_dangling_exits():
+def test_extract_flag_dangling_exits():  # noqa: ANN201  # tracked: #288
     with pytest.raises(ConfigurationError) as exc:
         _extract_flag(["--outer-loop"], "--outer-loop")
     assert exc.value.diagnostic.code == "invalid_arguments"
@@ -124,33 +124,33 @@ def test_extract_flag_dangling_exits():
 
 
 @pytest.mark.parametrize(
-    "argv,expected_kind,expected_rest",
+    "argv,expected_kind,expected_rest",  # noqa: PT006  # tracked: #288
     [
         (["--outer-loop", "agent", "--input", "x"], "agent", ["--input", "x"]),
         (["--outer-loop", "plain", "--exp-name", "e"], "plain", ["--exp-name", "e"]),
         (["--outer-loop", "evolve", "--seed", "1"], "evolve", ["--seed", "1"]),
     ],
 )
-def test_extract_loop_selection(argv: list[str], expected_kind: str, expected_rest: list[str]):
+def test_extract_loop_selection(argv: list[str], expected_kind: str, expected_rest: list[str]):  # noqa: ANN201  # tracked: #288
     kind, rest = _extract_loop_selection(argv)
     assert kind == expected_kind
     assert rest == expected_rest
 
 
-def test_extract_loop_selection_defaults_to_agent():
+def test_extract_loop_selection_defaults_to_agent():  # noqa: ANN201  # tracked: #288
     kind, rest = _extract_loop_selection(["--input", "x"])
     assert kind == "agent"
     assert rest == ["--input", "x"]
 
 
-def test_extract_loop_selection_unknown_outer_loop_exits():
+def test_extract_loop_selection_unknown_outer_loop_exits():  # noqa: ANN201  # tracked: #288
     with pytest.raises(ConfigurationError) as exc:
         _extract_loop_selection(["--outer-loop", "nope"])
     assert exc.value.diagnostic.stage == "argument_parsing"
 
 
-def test_target_input_defaults_to_none():
-    from vibesys.main import _build_agent_parser
+def test_target_input_defaults_to_none():  # noqa: ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     args = _build_agent_parser().parse_args([])
 
@@ -167,8 +167,8 @@ def test_target_input_defaults_to_none():
     "obsolete_flag",
     ["--profiler-support", "--nsys-profiler", "--torch-profiler", "--neuron-profiler"],
 )
-def test_profiler_support_override_flags_are_rejected(obsolete_flag):
-    from vibesys.main import _build_agent_parser
+def test_profiler_support_override_flags_are_rejected(obsolete_flag):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     with pytest.raises(ConfigurationError, match="unrecognized arguments"):
         _build_agent_parser().parse_args([obsolete_flag, "support"])
@@ -182,8 +182,8 @@ def test_profiler_support_override_flags_are_rejected(obsolete_flag):
         "_build_plain_parser",
     ],
 )
-def test_input_arg_is_available_on_all_loop_parsers(builder_name):
-    import vibesys.main as cli
+def test_input_arg_is_available_on_all_loop_parsers(builder_name):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     parser = getattr(cli, builder_name)()
     args = parser.parse_args(["--input", "examples/data-structures/queue-spsc"])
@@ -191,9 +191,9 @@ def test_input_arg_is_available_on_all_loop_parsers(builder_name):
     assert args.input == Path("examples/data-structures/queue-spsc")
 
 
-def test_remote_repository_options_are_user_configurable():
-    from vibesys.main import _build_agent_parser
-    from vibesys.run import RepositoryVisibility
+def test_remote_repository_options_are_user_configurable():  # noqa: ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
+    from vibesys.run import RepositoryVisibility  # noqa: PLC0415  # tracked: #288
 
     args = _build_agent_parser().parse_args(
         ["--repo", "my-lab/trial", "--repo-visibility", "internal"]
@@ -203,9 +203,9 @@ def test_remote_repository_options_are_user_configurable():
     assert args.repo_visibility is RepositoryVisibility.INTERNAL
 
 
-def test_short_repository_name_uses_configured_owner(tmp_path):
-    from vibesys.main import _build_agent_parser
-    from vibesys.run import RepositoryVisibility
+def test_short_repository_name_uses_configured_owner(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
+    from vibesys.run import RepositoryVisibility  # noqa: PLC0415  # tracked: #288
 
     config_path = tmp_path / "agent.toml"
     config_path.write_text(
@@ -228,12 +228,12 @@ visibility = "internal"
     assert args.repo_visibility is RepositoryVisibility.INTERNAL
 
 
-def test_fresh_runs_default_to_authenticated_github_account(tmp_path, monkeypatch):
-    import vibesys.main as cli
+def test_fresh_runs_default_to_authenticated_github_account(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    args = cli._build_agent_parser().parse_args(["--input", str(bundle), "--no-skills"])
-    cli._validate_target_inputs(args)
+    args = cli._build_agent_parser().parse_args(["--input", str(bundle), "--no-skills"])  # noqa: SLF001  # tracked: #288
+    cli._validate_target_inputs(args)  # noqa: SLF001  # tracked: #288
     config = cli.Config.model_validate({"model": {"name": "gpt-5.5"}})
     github = Mock()
     github.current_user.return_value = "octocat"
@@ -246,12 +246,12 @@ def test_fresh_runs_default_to_authenticated_github_account(tmp_path, monkeypatc
     github.current_user.assert_called_once_with()
 
 
-def test_repository_owner_override_does_not_query_gh(tmp_path, monkeypatch):
-    import vibesys.main as cli
+def test_repository_owner_override_does_not_query_gh(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    args = cli._build_agent_parser().parse_args(["--input", str(bundle), "--no-skills"])
-    cli._validate_target_inputs(args)
+    args = cli._build_agent_parser().parse_args(["--input", str(bundle), "--no-skills"])  # noqa: SLF001  # tracked: #288
+    cli._validate_target_inputs(args)  # noqa: SLF001  # tracked: #288
     config = cli.Config.model_validate(
         {"model": {"name": "gpt-5.5"}, "repository": {"owner": "my-org"}}
     )
@@ -264,12 +264,12 @@ def test_repository_owner_override_does_not_query_gh(tmp_path, monkeypatch):
     github.current_user.assert_not_called()
 
 
-def test_local_runs_keep_generated_name_and_skip_github(tmp_path, monkeypatch):
-    import vibesys.main as cli
+def test_local_runs_keep_generated_name_and_skip_github(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    args = cli._build_agent_parser().parse_args(["--input", str(bundle), "--local", "--no-skills"])
-    cli._validate_target_inputs(args)
+    args = cli._build_agent_parser().parse_args(["--input", str(bundle), "--local", "--no-skills"])  # noqa: SLF001  # tracked: #288
+    cli._validate_target_inputs(args)  # noqa: SLF001  # tracked: #288
     config = cli.Config.model_validate({"model": {"name": "gpt-5.5"}})
     github = Mock()
     monkeypatch.setattr(cli, "GitHubCLI", Mock(return_value=github))
@@ -281,8 +281,8 @@ def test_local_runs_keep_generated_name_and_skip_github(tmp_path, monkeypatch):
     github.current_user.assert_not_called()
 
 
-def test_missing_gh_credentials_report_repository_setup_error(monkeypatch):
-    import vibesys.main as cli
+def test_missing_gh_credentials_report_repository_setup_error(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     config = cli.Config.model_validate({"model": {"name": "gpt-5.5"}})
     github = Mock()
@@ -290,15 +290,15 @@ def test_missing_gh_credentials_report_repository_setup_error(monkeypatch):
     monkeypatch.setattr(cli, "GitHubCLI", Mock(return_value=github))
 
     with pytest.raises(ConfigurationError) as exc:
-        cli._resolve_repository_owner(config)
+        cli._resolve_repository_owner(config)  # noqa: SLF001  # tracked: #288
 
     assert exc.value.diagnostic.code == "repository_setup_failed"
     assert exc.value.diagnostic.stage == "repository_setup"
     assert "gh auth login" in exc.value.diagnostic.message
 
 
-def test_local_and_repo_are_mutually_exclusive(tmp_path):
-    from vibesys.main import _build_agent_parser
+def test_local_and_repo_are_mutually_exclusive(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     config_path = tmp_path / "agent.toml"
@@ -321,15 +321,15 @@ def test_local_and_repo_are_mutually_exclusive(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "builder_name,validator_name",
+    "builder_name,validator_name",  # noqa: PT006  # tracked: #288
     [
         ("_build_agent_parser", "_validate_agent"),
         ("_build_evolve_parser", "_validate_evolve"),
         ("_build_plain_parser", "_validate_plain"),
     ],
 )
-def test_profiler_none_is_valid_with_modal(builder_name, validator_name, tmp_path):
-    import vibesys.main as cli
+def test_profiler_none_is_valid_with_modal(builder_name, validator_name, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     parser = getattr(cli, builder_name)()
@@ -341,14 +341,14 @@ def test_profiler_none_is_valid_with_modal(builder_name, validator_name, tmp_pat
     assert args.input_bundle.root == bundle.resolve()
 
 
-def test_profiler_validation_uses_selected_environment_capabilities(tmp_path, monkeypatch):
-    import vibesys.main as cli
+def test_profiler_validation_uses_selected_environment_capabilities(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    args = cli._build_agent_parser().parse_args(["--profiler", "nsys", "--input", str(bundle)])
+    args = cli._build_agent_parser().parse_args(["--profiler", "nsys", "--input", str(bundle)])  # noqa: SLF001  # tracked: #288
     selected_specs = []
 
-    def fake_environment(spec):
+    def fake_environment(spec):  # noqa: ANN001, ANN202  # tracked: #288
         selected_specs.append(spec)
         return Mock(
             supported_profiler_kinds=frozenset(
@@ -359,28 +359,28 @@ def test_profiler_validation_uses_selected_environment_capabilities(tmp_path, mo
     monkeypatch.setattr(cli, "build_run_environment", fake_environment)
 
     with pytest.raises(ConfigurationError, match="run environment 'local'"):
-        cli._validate_agent(args)
+        cli._validate_agent(args)  # noqa: SLF001  # tracked: #288
     assert [spec.name for spec in selected_specs] == ["local"]
 
 
-def test_validate_evolve_rejects_nonpositive_bootstrap_attempts(tmp_path):
+def test_validate_evolve_rejects_nonpositive_bootstrap_attempts(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """--bootstrap-max-attempts must be >= 1; 0 is a configuration error."""
-    import vibesys.main as cli
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    parser = cli._build_evolve_parser()
+    parser = cli._build_evolve_parser()  # noqa: SLF001  # tracked: #288
     args = parser.parse_args(["--bootstrap-max-attempts", "0", "--input", str(bundle)])
     assert args.bootstrap_max_attempts == 0
     with pytest.raises(ConfigurationError):
-        cli._validate_evolve(args)
+        cli._validate_evolve(args)  # noqa: SLF001  # tracked: #288
 
 
-def test_keep_deployments_flag_and_modal_alias_default_off_and_parse(tmp_path):
+def test_keep_deployments_flag_and_modal_alias_default_off_and_parse(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """The generic flag and compatibility alias select the same behavior."""
-    import vibesys.main as cli
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    parser = cli._build_evolve_parser()
+    parser = cli._build_evolve_parser()  # noqa: SLF001  # tracked: #288
 
     assert parser.parse_args(["--input", str(bundle)]).keep_deployments is False
     assert (
@@ -389,21 +389,21 @@ def test_keep_deployments_flag_and_modal_alias_default_off_and_parse(tmp_path):
     assert parser.parse_args(["--keep-modal-apps", "--input", str(bundle)]).keep_deployments is True
 
 
-def test_evolve_modality_defaults_to_domain_resolution(tmp_path):
+def test_evolve_modality_defaults_to_domain_resolution(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """A non-serving domain must not inherit the text-generation modality."""
-    import vibesys.main as cli
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    parser = cli._build_evolve_parser()
+    parser = cli._build_evolve_parser()  # noqa: SLF001  # tracked: #288
 
     assert parser.parse_args(["--input", str(bundle)]).modality is None
 
 
-def test_evolve_search_policy_defaults_and_openevolve_overrides(tmp_path):
-    import vibesys.main as cli
+def test_evolve_search_policy_defaults_and_openevolve_overrides(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    parser = cli._build_evolve_parser()
+    parser = cli._build_evolve_parser()  # noqa: SLF001  # tracked: #288
 
     defaults = parser.parse_args(["--input", str(bundle)])
     assert defaults.search_policy is None
@@ -435,9 +435,9 @@ def test_evolve_search_policy_defaults_and_openevolve_overrides(tmp_path):
     assert configured.openevolve_migration_rate == 0.25
 
 
-def test_openevolve_partial_resume_options_merge_with_saved_config(tmp_path):
-    import vibesys.main as cli
-    from vibesys.loops.evolve.search_policy import (
+def test_openevolve_partial_resume_options_merge_with_saved_config(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.evolve.search_policy import (  # noqa: PLC0415  # tracked: #288
         OpenEvolveSearchConfig,
         OpenEvolveSearchPolicy,
     )
@@ -456,12 +456,12 @@ def test_openevolve_partial_resume_options_merge_with_saved_config(tmp_path):
         seed=1,
         config=saved,
     )
-    args = cli._build_evolve_parser().parse_args(
+    args = cli._build_evolve_parser().parse_args(  # noqa: SLF001  # tracked: #288
         ["--input", str(bundle), "--openevolve-migration-rate", "0.25"]
     )
 
     with patch.object(cli, "_resume_exp_dir", return_value=run_dir):
-        policy_name, resolved = cli._resolve_openevolve_options(
+        policy_name, resolved = cli._resolve_openevolve_options(  # noqa: SLF001  # tracked: #288
             args,
             existing=True,
             exp_name="run",
@@ -471,10 +471,12 @@ def test_openevolve_partial_resume_options_merge_with_saved_config(tmp_path):
     assert resolved == saved
 
 
-def test_openevolve_resume_restores_flag_defined_objectives(tmp_path):
-    import vibesys.main as cli
-    from vibesys.loops.evolve.population import Objective
-    from vibesys.loops.evolve.search_policy import OpenEvolveSearchPolicy
+def test_openevolve_resume_restores_flag_defined_objectives(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.evolve.population import Objective  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.evolve.search_policy import (  # noqa: PLC0415  # tracked: #288
+        OpenEvolveSearchPolicy,
+    )
 
     run_dir = tmp_path / "run"
     expected = [Objective("latency_ms", "min"), Objective("throughput", "max")]
@@ -486,7 +488,7 @@ def test_openevolve_resume_restores_flag_defined_objectives(tmp_path):
     )
 
     with patch.object(cli, "_resume_exp_dir", return_value=run_dir):
-        restored = cli._restore_openevolve_objectives(
+        restored = cli._restore_openevolve_objectives(  # noqa: SLF001  # tracked: #288
             [],
             existing=True,
             exp_name="run",
@@ -495,15 +497,15 @@ def test_openevolve_resume_restores_flag_defined_objectives(tmp_path):
     assert restored == expected
 
 
-def test_openevolve_override_selects_policy_on_new_run(tmp_path):
-    import vibesys.main as cli
+def test_openevolve_override_selects_policy_on_new_run(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    args = cli._build_evolve_parser().parse_args(
+    args = cli._build_evolve_parser().parse_args(  # noqa: SLF001  # tracked: #288
         ["--input", str(bundle), "--openevolve-num-islands", "3"]
     )
 
-    policy_name, resolved = cli._resolve_openevolve_options(
+    policy_name, resolved = cli._resolve_openevolve_options(  # noqa: SLF001  # tracked: #288
         args,
         existing=False,
         exp_name="new",
@@ -514,11 +516,11 @@ def test_openevolve_override_selects_policy_on_new_run(tmp_path):
     assert resolved.num_islands == 3
 
 
-def test_validate_evolve_rejects_openevolve_knob_with_vibesys_policy(tmp_path):
-    import vibesys.main as cli
+def test_validate_evolve_rejects_openevolve_knob_with_vibesys_policy(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    args = cli._build_evolve_parser().parse_args(
+    args = cli._build_evolve_parser().parse_args(  # noqa: SLF001  # tracked: #288
         [
             "--input",
             str(bundle),
@@ -530,11 +532,11 @@ def test_validate_evolve_rejects_openevolve_knob_with_vibesys_policy(tmp_path):
     )
 
     with pytest.raises(ConfigurationError):
-        cli._validate_evolve(args)
+        cli._validate_evolve(args)  # noqa: SLF001  # tracked: #288
 
 
 @pytest.mark.parametrize(
-    "flag,value",
+    "flag,value",  # noqa: PT006  # tracked: #288
     [
         ("--openevolve-population-size", "0"),
         ("--openevolve-archive-size", "0"),
@@ -544,24 +546,24 @@ def test_validate_evolve_rejects_openevolve_knob_with_vibesys_policy(tmp_path):
         ("--openevolve-migration-rate", "1.1"),
     ],
 )
-def test_validate_evolve_rejects_invalid_openevolve_config(tmp_path, flag, value):
-    import vibesys.main as cli
+def test_validate_evolve_rejects_invalid_openevolve_config(tmp_path, flag, value):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    args = cli._build_evolve_parser().parse_args(
+    args = cli._build_evolve_parser().parse_args(  # noqa: SLF001  # tracked: #288
         ["--input", str(bundle), "--search-policy", "openevolve", flag, value]
     )
 
     with pytest.raises(ConfigurationError):
-        cli._validate_evolve(args)
+        cli._validate_evolve(args)  # noqa: SLF001  # tracked: #288
 
 
-def test_max_parallelism_defaults_to_one_and_parses(tmp_path):
+def test_max_parallelism_defaults_to_one_and_parses(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """--max-parallelism is serial (1) by default and accepts an int override."""
-    import vibesys.main as cli
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    parser = cli._build_evolve_parser()
+    parser = cli._build_evolve_parser()  # noqa: SLF001  # tracked: #288
 
     assert parser.parse_args(["--input", str(bundle)]).max_parallelism == 1
     assert (
@@ -569,34 +571,34 @@ def test_max_parallelism_defaults_to_one_and_parses(tmp_path):
     )
 
 
-def test_validate_evolve_rejects_nonpositive_parallelism(tmp_path):
+def test_validate_evolve_rejects_nonpositive_parallelism(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """--max-parallelism < 1 is a configuration error."""
-    import vibesys.main as cli
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    parser = cli._build_evolve_parser()
+    parser = cli._build_evolve_parser()  # noqa: SLF001  # tracked: #288
     args = parser.parse_args(["--max-parallelism", "0", "--input", str(bundle)])
     with pytest.raises(ConfigurationError):
-        cli._validate_evolve(args)
+        cli._validate_evolve(args)  # noqa: SLF001  # tracked: #288
 
 
-def test_validate_evolve_defers_parallelism_support_to_environment(tmp_path):
+def test_validate_evolve_defers_parallelism_support_to_environment(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """CLI validation does not hard-code one parallel-capable provider."""
-    import vibesys.main as cli
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    parser = cli._build_evolve_parser()
+    parser = cli._build_evolve_parser()  # noqa: SLF001  # tracked: #288
 
     # The loop reads the selected environment capability and may downgrade to
     # serial; the CLI must not assume which providers support isolation.
     args = parser.parse_args(["--max-parallelism", "4", "--input", str(bundle)])
-    cli._validate_evolve(args)
+    cli._validate_evolve(args)  # noqa: SLF001  # tracked: #288
 
     # Modal remains one supported adapter, not a special loop policy.
     args = parser.parse_args(
         ["--max-parallelism", "4", "--modal", "--profiler", "torch", "--input", str(bundle)]
     )
-    cli._validate_evolve(args)
+    cli._validate_evolve(args)  # noqa: SLF001  # tracked: #288
 
 
 @pytest.mark.parametrize(
@@ -605,8 +607,8 @@ def test_validate_evolve_defers_parallelism_support_to_environment(tmp_path):
         ["--profiler", "bogus"],
     ],
 )
-def test_agent_parser_rejects_invalid_enum_args(argv):
-    from vibesys.main import _build_agent_parser
+def test_agent_parser_rejects_invalid_enum_args(argv):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     with pytest.raises(ConfigurationError) as exc:
         _build_agent_parser().parse_args(argv)
@@ -614,15 +616,15 @@ def test_agent_parser_rejects_invalid_enum_args(argv):
     assert exc.value.diagnostic.code == "invalid_arguments"
 
 
-def test_agent_parser_rejects_obsolete_target_flags():
-    from vibesys.main import _build_agent_parser
+def test_agent_parser_rejects_obsolete_target_flags():  # noqa: ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     with pytest.raises(ConfigurationError):
         _build_agent_parser().parse_args(["--ref", "examples/Llama-3-8B/reference"])
 
 
-def test_validate_target_inputs_loads_manifest(tmp_path):
-    from vibesys.main import _build_agent_parser
+def test_validate_target_inputs_loads_manifest(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     args = _build_agent_parser().parse_args(["--input", str(bundle)])
@@ -635,15 +637,15 @@ def test_validate_target_inputs_loads_manifest(tmp_path):
     assert args.input_bundle.benchmark_command_display == "uv run python benchmark/benchmark.py"
 
 
-def test_agent_parser_rejects_domain_override_flag():
-    from vibesys.main import _build_agent_parser
+def test_agent_parser_rejects_domain_override_flag():  # noqa: ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     with pytest.raises(ConfigurationError):
         _build_agent_parser().parse_args(["--domain", "llm-serving"])
 
 
-def test_validate_target_inputs_loads_trusted_benchmark_result_contract(tmp_path):
-    from vibesys.main import _build_agent_parser
+def test_validate_target_inputs_loads_trusted_benchmark_result_contract(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     manifest = bundle / "vibesys.input.toml"
@@ -660,8 +662,8 @@ def test_validate_target_inputs_loads_trusted_benchmark_result_contract(tmp_path
     assert args.input_bundle.benchmark_result.metric == "ops_per_sec"
 
 
-def test_validate_target_inputs_rejects_missing_input_dir(tmp_path):
-    from vibesys.main import _build_agent_parser
+def test_validate_target_inputs_rejects_missing_input_dir(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     missing = tmp_path / "missing"
     args = _build_agent_parser().parse_args(["--input", str(missing)])
@@ -672,8 +674,8 @@ def test_validate_target_inputs_rejects_missing_input_dir(tmp_path):
     assert "--input path does not exist" in exc.value.diagnostic.message
 
 
-def test_validate_target_inputs_reports_missing_manifest(tmp_path):
-    from vibesys.main import _build_agent_parser
+def test_validate_target_inputs_reports_missing_manifest(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     bundle = tmp_path / "incomplete"
     bundle.mkdir()
@@ -687,8 +689,8 @@ def test_validate_target_inputs_reports_missing_manifest(tmp_path):
     assert "vibesys.input.toml" in exc.value.diagnostic.message
 
 
-def test_validate_target_inputs_reports_missing_command(tmp_path):
-    from vibesys.main import _build_agent_parser
+def test_validate_target_inputs_reports_missing_command(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     tools = bundle / "tools"
@@ -717,8 +719,8 @@ command = ["./tools/bench"]
     assert "benchmark.command executable does not exist" in exc.value.diagnostic.message
 
 
-def test_validate_target_inputs_requires_input():
-    from vibesys.main import _build_agent_parser
+def test_validate_target_inputs_requires_input():  # noqa: ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     args = _build_agent_parser().parse_args([])
 
@@ -728,8 +730,8 @@ def test_validate_target_inputs_requires_input():
     assert "missing required target input: --input" in exc.value.diagnostic.message
 
 
-def test_trusted_input_baseline_requires_resume(tmp_path):
-    from vibesys.main import _build_agent_parser, _validate_agent
+def test_trusted_input_baseline_requires_resume(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser, _validate_agent  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     args = _build_agent_parser().parse_args(
@@ -742,8 +744,8 @@ def test_trusted_input_baseline_requires_resume(tmp_path):
     assert "--trusted-input-baseline requires --resume" in exc.value.diagnostic.message
 
 
-def test_validate_agent_rejects_nonpositive_judge_cadence(tmp_path):
-    from vibesys.main import _build_agent_parser, _validate_agent
+def test_validate_agent_rejects_nonpositive_judge_cadence(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser, _validate_agent  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     args = _build_agent_parser().parse_args(["--input", str(bundle), "--judge-every", "0"])
@@ -754,8 +756,8 @@ def test_validate_agent_rejects_nonpositive_judge_cadence(tmp_path):
     assert "--judge-every must be >= 1" in exc.value.diagnostic.message
 
 
-def test_validate_agent_rejects_nonpositive_official_evaluation_cadence(tmp_path):
-    from vibesys.main import _build_agent_parser, _validate_agent
+def test_validate_agent_rejects_nonpositive_official_evaluation_cadence(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser, _validate_agent  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     args = _build_agent_parser().parse_args(["--input", str(bundle), "--official-eval-every", "0"])
@@ -766,8 +768,8 @@ def test_validate_agent_rejects_nonpositive_official_evaluation_cadence(tmp_path
     assert "--official-eval-every must be >= 1" in exc.value.diagnostic.message
 
 
-def test_agent_operator_constraints_are_repeatable_and_do_not_mutate_objective():
-    from vibesys.main import _build_agent_parser
+def test_agent_operator_constraints_are_repeatable_and_do_not_mutate_objective():  # noqa: ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     args = _build_agent_parser().parse_args(
         ["--constraint", "No quantization.", "--constraint", "  One H100 only.  "]
@@ -780,7 +782,7 @@ def test_agent_operator_constraints_are_repeatable_and_do_not_mutate_objective()
     assert effective.endswith("## Operator constraints\n\n- No quantization.\n- One H100 only.\n")
 
 
-def test_stub_agent_smoke_defaults_supply_input_and_unique_exp_name():
+def test_stub_agent_smoke_defaults_supply_input_and_unique_exp_name():  # noqa: ANN201  # tracked: #288
     argv = _prepare_stub_agent_smoke_defaults(["--stub-agent", "--max-rounds", "1"])
 
     assert argv[:2] == ["--input", str(Path("examples/data-structures/queue-spsc").resolve())]
@@ -789,14 +791,14 @@ def test_stub_agent_smoke_defaults_supply_input_and_unique_exp_name():
     assert argv[-2:] == ["--max-rounds", "1"]
 
 
-def test_stub_agent_smoke_defaults_preserve_explicit_input():
+def test_stub_agent_smoke_defaults_preserve_explicit_input():  # noqa: ANN201  # tracked: #288
     argv = ["--stub-agent", "--input", "examples/kv-store"]
 
     assert _prepare_stub_agent_smoke_defaults(argv) == argv
 
 
-def test_stub_agent_can_run_without_agent_toml(tmp_path):
-    from vibesys.main import _build_agent_parser
+def test_stub_agent_can_run_without_agent_toml(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     args = _build_agent_parser().parse_args(
@@ -817,8 +819,8 @@ def test_stub_agent_can_run_without_agent_toml(tmp_path):
     assert skills is None
 
 
-def test_missing_config_reports_configuration_error(tmp_path):
-    from vibesys.main import _build_agent_parser
+def test_missing_config_reports_configuration_error(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     args = _build_agent_parser().parse_args(
@@ -842,8 +844,8 @@ def test_missing_config_reports_configuration_error(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_tui_defaults_uses_repository_config_and_generated_name(tmp_path, capsys):
-    import json
+def test_tui_defaults_uses_repository_config_and_generated_name(tmp_path, capsys):  # noqa: ANN001, ANN201  # tracked: #288
+    import json  # noqa: PLC0415  # tracked: #288
 
     config_path = tmp_path / "agent.toml"
     config_path.write_text(
@@ -878,7 +880,7 @@ visibility = "private"
     assert defaults["theme"] == "dark"
 
 
-def _write_theme_config(tmp_path, theme: str | None) -> Path:
+def _write_theme_config(tmp_path, theme: str | None) -> Path:  # noqa: ANN001  # tracked: #288
     config_path = tmp_path / "agent.toml"
     tui_section = f'\n[tui]\ntheme = "{theme}"\n' if theme is not None else ""
     # An explicit owner keeps the theme assertions off the `gh auth` fallback
@@ -889,8 +891,8 @@ def _write_theme_config(tmp_path, theme: str | None) -> Path:
     return config_path
 
 
-def test_tui_defaults_reports_the_configured_theme(tmp_path, capsys):
-    import json
+def test_tui_defaults_reports_the_configured_theme(tmp_path, capsys):  # noqa: ANN001, ANN201  # tracked: #288
+    import json  # noqa: PLC0415  # tracked: #288
 
     argv = [
         "vibesys",
@@ -905,8 +907,8 @@ def test_tui_defaults_reports_the_configured_theme(tmp_path, capsys):
     assert json.loads(capsys.readouterr().out)["theme"] == "catppuccin-latte"
 
 
-def test_tui_defaults_theme_flag_overrides_the_configured_theme(tmp_path, capsys):
-    import json
+def test_tui_defaults_theme_flag_overrides_the_configured_theme(tmp_path, capsys):  # noqa: ANN001, ANN201  # tracked: #288
+    import json  # noqa: PLC0415  # tracked: #288
 
     argv = [
         "vibesys",
@@ -923,7 +925,7 @@ def test_tui_defaults_theme_flag_overrides_the_configured_theme(tmp_path, capsys
     assert json.loads(capsys.readouterr().out)["theme"] == "high-contrast-dark"
 
 
-def test_tui_defaults_rejects_an_unknown_theme(tmp_path):
+def test_tui_defaults_rejects_an_unknown_theme(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     argv = [
         "vibesys",
         "tui-defaults",
@@ -939,7 +941,7 @@ def test_tui_defaults_rejects_an_unknown_theme(tmp_path):
     assert excinfo.value.code == 2
 
 
-def test_validate_command_defaults_to_current_input_bundle(monkeypatch, tmp_path, capsys):
+def test_validate_command_defaults_to_current_input_bundle(monkeypatch, tmp_path, capsys):  # noqa: ANN001, ANN201  # tracked: #288
     bundle = _write_input_bundle(tmp_path)
     monkeypatch.chdir(bundle)
     monkeypatch.setattr(sys, "argv", ["vibesys", "validate"])
@@ -953,7 +955,7 @@ def test_validate_command_defaults_to_current_input_bundle(monkeypatch, tmp_path
     assert "benchmark command: uv run python benchmark/benchmark.py" in output
 
 
-def test_validate_command_accepts_input_bundle_path(tmp_path, capsys):
+def test_validate_command_accepts_input_bundle_path(tmp_path, capsys):  # noqa: ANN001, ANN201  # tracked: #288
     bundle = _write_input_bundle(tmp_path)
     argv = ["vibesys", "validate", str(bundle)]
 
@@ -965,7 +967,7 @@ def test_validate_command_accepts_input_bundle_path(tmp_path, capsys):
     assert f"objective: {bundle / 'OBJECTIVE.md'}" in output
 
 
-def test_validate_command_rejects_run_input_flag(tmp_path, capsys):
+def test_validate_command_rejects_run_input_flag(tmp_path, capsys):  # noqa: ANN001, ANN201  # tracked: #288
     bundle = _write_input_bundle(tmp_path)
     argv = ["vibesys", "validate", "--input", str(bundle)]
 
@@ -976,7 +978,7 @@ def test_validate_command_rejects_run_input_flag(tmp_path, capsys):
     assert "unrecognized arguments" in capsys.readouterr().err
 
 
-def test_all_example_input_bundles_pass_validate(example_input_bundles: tuple[Path, ...], capsys):
+def test_all_example_input_bundles_pass_validate(example_input_bundles: tuple[Path, ...], capsys):  # noqa: ANN001, ANN201  # tracked: #288
     for input_bundle in example_input_bundles:
         argv = ["vibesys", "validate", str(input_bundle)]
         with patch.object(sys, "argv", argv):
@@ -986,7 +988,7 @@ def test_all_example_input_bundles_pass_validate(example_input_bundles: tuple[Pa
     assert output.count("VibeSys validation passed") == len(example_input_bundles)
 
 
-def test_validate_command_reports_invalid_harness_without_running_agent(tmp_path, capsys):
+def test_validate_command_reports_invalid_harness_without_running_agent(tmp_path, capsys):  # noqa: ANN001, ANN201  # tracked: #288
     bundle = _write_input_bundle(tmp_path)
     (bundle / "OBJECTIVE.md").unlink()
     argv = ["vibesys", "validate", str(bundle)]
@@ -1006,8 +1008,8 @@ def test_validate_command_reports_invalid_harness_without_running_agent(tmp_path
     assert "OBJECTIVE.md not found" in error
 
 
-def test_resume_without_input_infers_original_input(monkeypatch, tmp_path):
-    import vibesys.main as cli
+def test_resume_without_input_infers_original_input(monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     run_dir = tmp_path / "exp_env" / "20260716-180256-test"
@@ -1021,8 +1023,8 @@ def test_resume_without_input_infers_original_input(monkeypatch, tmp_path):
     assert invocation.args.input_bundle.root == bundle.resolve()
 
 
-def test_resume_accepts_exp_env_path_without_input(monkeypatch, tmp_path):
-    import vibesys.main as cli
+def test_resume_accepts_exp_env_path_without_input(monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     run_dir = tmp_path / "exp_env" / "20260716-180256-test"
@@ -1037,8 +1039,8 @@ def test_resume_accepts_exp_env_path_without_input(monkeypatch, tmp_path):
     assert invocation.args.input_bundle.root == bundle.resolve()
 
 
-def test_resume_accepts_external_local_clone_and_materialized_input(monkeypatch, tmp_path):
-    import vibesys.main as cli
+def test_resume_accepts_external_local_clone_and_materialized_input(monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     run_dir = tmp_path / "clone"
     workspace = _write_input_bundle(run_dir)
@@ -1063,13 +1065,13 @@ def test_resume_accepts_external_local_clone_and_materialized_input(monkeypatch,
     assert invocation.args.input_bundle.evaluator_path is None
 
 
-def test_resume_github_repo_clones_into_exp_env(monkeypatch, tmp_path):
-    import vibesys.main as cli
+def test_resume_github_repo_clones_into_exp_env(monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
     commands: list[list[str]] = []
 
-    def fake_run(command, **_kwargs):
+    def fake_run(command, **_kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
         commands.append(command)
         if command[:3] == ["gh", "repo", "clone"]:
             Path(command[-1]).mkdir(parents=True)
@@ -1084,14 +1086,14 @@ def test_resume_github_repo_clones_into_exp_env(monkeypatch, tmp_path):
     ]
 
 
-def test_resume_github_repo_reuses_matching_local_clone(monkeypatch, tmp_path):
-    import vibesys.main as cli
+def test_resume_github_repo_reuses_matching_local_clone(monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     destination = tmp_path / "exp_env" / "trial"
     destination.mkdir(parents=True)
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
 
-    def fake_run(command, **_kwargs):
+    def fake_run(command, **_kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
         assert command == ["git", "remote", "get-url", "origin"]
         return subprocess.CompletedProcess(
             command,
@@ -1110,12 +1112,12 @@ def test_resume_github_repo_reuses_matching_local_clone(monkeypatch, tmp_path):
     assert _resolve_run_dir("vibesys-playground/trial") == "trial"
 
 
-def test_resume_github_repo_explains_missing_authentication(monkeypatch, tmp_path):
-    import vibesys.main as cli
+def test_resume_github_repo_explains_missing_authentication(monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
 
-    def fake_run(command, **_kwargs):
+    def fake_run(command, **_kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
         return subprocess.CompletedProcess(command, 1, "", "not logged into any GitHub hosts")
 
     monkeypatch.setattr(cli, "GitHubCLI", lambda: GitHubCLI(_runner=fake_run))
@@ -1128,7 +1130,7 @@ def test_resume_github_repo_explains_missing_authentication(monkeypatch, tmp_pat
     assert "not logged into any GitHub hosts" in exc.value.diagnostic.message
 
 
-def test_resume_rejects_creating_a_second_repository(tmp_path):
+def test_resume_rejects_creating_a_second_repository(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     bundle = _write_input_bundle(tmp_path)
 
     with pytest.raises(ConfigurationError) as exc:
@@ -1148,8 +1150,8 @@ def test_resume_rejects_creating_a_second_repository(tmp_path):
     assert exc.value.diagnostic.code == "invalid_arguments"
 
 
-def test_resume_latest_without_input_uses_latest_run_metadata(monkeypatch, tmp_path):
-    import vibesys.main as cli
+def test_resume_latest_without_input_uses_latest_run_metadata(monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     older_bundle = _write_input_bundle(tmp_path / "older")
     latest_bundle = _write_input_bundle(tmp_path / "latest")
@@ -1165,8 +1167,8 @@ def test_resume_latest_without_input_uses_latest_run_metadata(monkeypatch, tmp_p
     assert invocation.args.input_bundle.root == latest_bundle.resolve()
 
 
-def test_resume_latest_reports_missing_exp_env(monkeypatch, tmp_path):
-    import vibesys.main as cli
+def test_resume_latest_reports_missing_exp_env(monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
 
@@ -1176,8 +1178,8 @@ def test_resume_latest_reports_missing_exp_env(monkeypatch, tmp_path):
     assert exc.value.diagnostic.code == "resume_not_found"
 
 
-def test_resume_latest_reports_empty_exp_env(monkeypatch, tmp_path):
-    import vibesys.main as cli
+def test_resume_latest_reports_empty_exp_env(monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     (tmp_path / "exp_env").mkdir()
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
@@ -1188,8 +1190,8 @@ def test_resume_latest_reports_empty_exp_env(monkeypatch, tmp_path):
     assert exc.value.diagnostic.code == "resume_not_found"
 
 
-def test_resume_without_input_reports_missing_metadata(monkeypatch, tmp_path):
-    import vibesys.main as cli
+def test_resume_without_input_reports_missing_metadata(monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     (tmp_path / "exp_env" / "20260716-180256-test" / "logs").mkdir(parents=True)
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
@@ -1201,7 +1203,7 @@ def test_resume_without_input_reports_missing_metadata(monkeypatch, tmp_path):
     assert exc.value.diagnostic.stage == "resume_resolution"
 
 
-def test_resume_input_ignores_blank_and_non_run_events(tmp_path):
+def test_resume_input_ignores_blank_and_non_run_events(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     bundle = _write_input_bundle(tmp_path)
     run_dir = tmp_path / "exp_env" / "run"
     logs = run_dir / "logs"
@@ -1215,7 +1217,7 @@ def test_resume_input_ignores_blank_and_non_run_events(tmp_path):
     assert _infer_resume_input(run_dir) == bundle
 
 
-def test_resume_input_reports_invalid_json(tmp_path):
+def test_resume_input_reports_invalid_json(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     run_dir = tmp_path / "exp_env" / "run"
     logs = run_dir / "logs"
     logs.mkdir(parents=True)
@@ -1234,8 +1236,8 @@ def test_resume_input_reports_invalid_json(tmp_path):
         {"type": "run_started", "data": {}},
     ],
 )
-def test_resume_input_reports_missing_input_in_run_started(tmp_path, event):
-    import json
+def test_resume_input_reports_missing_input_in_run_started(tmp_path, event):  # noqa: ANN001, ANN201  # tracked: #288
+    import json  # noqa: PLC0415  # tracked: #288
 
     run_dir = tmp_path / "exp_env" / "run"
     logs = run_dir / "logs"
@@ -1248,7 +1250,7 @@ def test_resume_input_reports_missing_input_in_run_started(tmp_path, event):
     assert exc.value.diagnostic.code == "resume_input_not_found"
 
 
-def test_resume_round_defaults_when_rounds_json_missing_or_invalid(tmp_path):
+def test_resume_round_defaults_when_rounds_json_missing_or_invalid(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     exp_dir = tmp_path / "run"
 
     assert _detect_resume_round(exp_dir) == 1
@@ -1260,7 +1262,7 @@ def test_resume_round_defaults_when_rounds_json_missing_or_invalid(tmp_path):
     assert _detect_resume_round(exp_dir) == 1
 
 
-def test_resume_round_counts_round_entries_and_prunes_later_rounds(tmp_path):
+def test_resume_round_counts_round_entries_and_prunes_later_rounds(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     rounds_json = tmp_path / "run" / "logs" / "rounds.json"
     rounds_json.parent.mkdir(parents=True)
     rounds_json.write_text('[{"round": 1}, {"round": 2}, {"round": 3}]')
@@ -1276,21 +1278,21 @@ def test_resume_round_counts_round_entries_and_prunes_later_rounds(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "spec,message",
+    "spec,message",  # noqa: PT006  # tracked: #288
     [
         ("latency", "must be 'name:max' or 'name:min'"),
         (":max", "metric name is empty"),
         ("latency:avg", "direction must be 'max' or 'min'"),
     ],
 )
-def test_parse_cli_objective_rejects_malformed_specs(spec, message):
-    with pytest.raises(Exception) as exc:
+def test_parse_cli_objective_rejects_malformed_specs(spec, message):  # noqa: ANN001, ANN201  # tracked: #288
+    with pytest.raises(Exception) as exc:  # noqa: PT011  # tracked: #288
         _parse_cli_objective(spec)
 
     assert message in str(exc.value)
 
 
-def test_load_objectives_toml_reports_malformed_entries(tmp_path):
+def test_load_objectives_toml_reports_malformed_entries(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     (tmp_path / "objectives.toml").write_text(
         """
 [[objective]]
@@ -1303,7 +1305,7 @@ direction = "avg"
         _load_objectives_toml(tmp_path)
 
 
-def test_load_pareto_relative_noise_toml_is_opt_in(tmp_path):
+def test_load_pareto_relative_noise_toml_is_opt_in(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     assert _load_pareto_relative_noise_toml(tmp_path) == 0.0
 
     (tmp_path / "objectives.toml").write_text("[pareto]\nrelative_noise = 0.03\n")
@@ -1312,19 +1314,19 @@ def test_load_pareto_relative_noise_toml_is_opt_in(tmp_path):
 
 
 @pytest.mark.parametrize("value", ["true", "-0.1", "1.0", '"noisy"'])
-def test_load_pareto_relative_noise_toml_rejects_invalid_values(tmp_path, value):
+def test_load_pareto_relative_noise_toml_rejects_invalid_values(tmp_path, value):  # noqa: ANN001, ANN201  # tracked: #288
     (tmp_path / "objectives.toml").write_text(f"[pareto]\nrelative_noise = {value}\n")
 
-    with pytest.raises(ValueError, match="pareto.relative_noise"):
+    with pytest.raises(ValueError, match="pareto.relative_noise"):  # noqa: RUF043  # tracked: #288
         _load_pareto_relative_noise_toml(tmp_path)
 
 
-def test_control_socket_from_argv_handles_empty_equals_and_space_form():
+def test_control_socket_from_argv_handles_empty_equals_and_space_form():  # noqa: ANN201  # tracked: #288
     assert _control_socket_from_argv(["--control-socket="]) is None
-    assert _control_socket_from_argv(["--control-socket", "/tmp/vs.sock"]) == Path("/tmp/vs.sock")
+    assert _control_socket_from_argv(["--control-socket", "/tmp/vs.sock"]) == Path("/tmp/vs.sock")  # noqa: S108  # tracked: #288
 
 
-def test_render_configuration_error_prints_usage(capsys):
+def test_render_configuration_error_prints_usage(capsys):  # noqa: ANN001, ANN201  # tracked: #288
     diagnostic = ConfigurationError(
         diagnostic=ConfigurationDiagnostic(
             code="invalid_arguments",
@@ -1347,7 +1349,7 @@ def test_render_configuration_error_prints_usage(capsys):
 
 
 @pytest.mark.parametrize("loop_name", ["agent", "evolve", "plain"])
-def test_main_routes_to_runner(loop_name: str):
+def test_main_routes_to_runner(loop_name: str):  # noqa: ANN201  # tracked: #288
     argv = ["vibesys", "--outer-loop", loop_name, "--exp-name", "x", *TARGET_ARGS]
     runner = Mock()
     with patch.object(sys, "argv", argv), _patch_loop_runner(loop_name, runner):
@@ -1358,7 +1360,7 @@ def test_main_routes_to_runner(loop_name: str):
         assert args.input_bundle.root.name == "Llama-3-8B"
 
 
-def test_main_tty_run_stays_in_python_cli():
+def test_main_tty_run_stays_in_python_cli():  # noqa: ANN201  # tracked: #288
     argv = [
         "vibesys",
         "--outer-loop",
@@ -1379,7 +1381,7 @@ def test_main_tty_run_stays_in_python_cli():
     runner.assert_called_once()
 
 
-def test_main_headless_skips_tui():
+def test_main_headless_skips_tui():  # noqa: ANN201  # tracked: #288
     argv = [
         "vibesys",
         "--outer-loop",

--- a/tests/test_profilers.py
+++ b/tests/test_profilers.py
@@ -28,7 +28,7 @@ _ENVIRONMENT_DEFAULTS = (
 _PROFILER_VALUES = frozenset(kind.value for kind in ProfilerKind)
 
 
-def test_profiler_definitions_derive_uniform_packaging_names():
+def test_profiler_definitions_derive_uniform_packaging_names():  # noqa: ANN201  # tracked: #288
     assert frozenset(PROFILER_DEFINITIONS) == ACTIVE_PROFILER_KINDS
     for kind, definition in PROFILER_DEFINITIONS.items():
         assert definition.support_name == f"{kind.value}_profiler"
@@ -37,7 +37,7 @@ def test_profiler_definitions_derive_uniform_packaging_names():
         assert definition.mcp_name == f"vibesys-{kind.value.replace('_', '-')}-profiler"
 
 
-def test_profiler_definition_needs_no_path_or_dispatch_declaration():
+def test_profiler_definition_needs_no_path_or_dispatch_declaration():  # noqa: ANN201  # tracked: #288
     definition = ProfilerDefinition(
         kind=ProfilerKind.NSYS,
         domains=frozenset({DomainName.GENERIC}),
@@ -47,7 +47,7 @@ def test_profiler_definition_needs_no_path_or_dispatch_declaration():
     assert definition.prompt_template == "profilers/nsys.j2"
 
 
-def _expected_resolved(
+def _expected_resolved(  # noqa: PLR0911  # tracked: #288
     requested: ProfilerKind,
     *,
     domain: DomainName,
@@ -84,13 +84,13 @@ def _expected_resolved(
 @pytest.mark.parametrize("requested", _REQUESTED)
 @pytest.mark.parametrize("backend_profiler_kind", _BACKEND_KINDS)
 @pytest.mark.parametrize("environment_default_profiler_kind", _ENVIRONMENT_DEFAULTS)
-def test_profiler_auto_resolution_exhaustive(
-    domain,
-    requested,
-    backend_profiler_kind,
-    environment_default_profiler_kind,
+def test_profiler_auto_resolution_exhaustive(  # noqa: ANN201  # tracked: #288
+    domain,  # noqa: ANN001  # tracked: #288
+    requested,  # noqa: ANN001  # tracked: #288
+    backend_profiler_kind,  # noqa: ANN001  # tracked: #288
+    environment_default_profiler_kind,  # noqa: ANN001  # tracked: #288
 ):
-    kwargs = dict(
+    kwargs = dict(  # noqa: C408  # tracked: #288
         domain=domain,
         backend_profiler_kind=backend_profiler_kind,
         environment_default_profiler_kind=environment_default_profiler_kind,
@@ -98,13 +98,13 @@ def test_profiler_auto_resolution_exhaustive(
     try:
         expected = _expected_resolved(requested, **kwargs)
     except ValueError:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011  # tracked: #288
             resolve_profiler_kind(requested, **kwargs)
     else:
         assert resolve_profiler_kind(requested, **kwargs) is expected
 
 
-def test_generic_auto_uses_none_when_host_has_no_native_cpu_profiler(monkeypatch):
+def test_generic_auto_uses_none_when_host_has_no_native_cpu_profiler(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     monkeypatch.setattr(platform, "system", lambda: "FreeBSD")
 
     assert (
@@ -118,7 +118,7 @@ def test_generic_auto_uses_none_when_host_has_no_native_cpu_profiler(monkeypatch
     )
 
 
-def test_generic_auto_respects_environment_profiler_capabilities(monkeypatch):
+def test_generic_auto_respects_environment_profiler_capabilities(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
     monkeypatch.setattr(platform, "system", lambda: "Linux")
 
     assert (
@@ -135,7 +135,7 @@ def test_generic_auto_respects_environment_profiler_capabilities(monkeypatch):
     )
 
 
-def test_explicit_profiler_respects_environment_capabilities():
+def test_explicit_profiler_respects_environment_capabilities():  # noqa: ANN201  # tracked: #288
     with pytest.raises(ValueError, match="selected run environment"):
         resolve_profiler_kind(
             ProfilerKind.NSYS,
@@ -148,7 +148,7 @@ def test_explicit_profiler_respects_environment_capabilities():
         )
 
 
-def test_auto_profiler_falls_back_by_environment_capability_not_provider_name():
+def test_auto_profiler_falls_back_by_environment_capability_not_provider_name():  # noqa: ANN201  # tracked: #288
     assert (
         resolve_profiler_kind(
             ProfilerKind.AUTO,
@@ -169,20 +169,20 @@ def test_auto_profiler_falls_back_by_environment_capability_not_provider_name():
     backend_profiler_kind=st.sampled_from(_BACKEND_KINDS),
     environment_default_profiler_kind=st.sampled_from(_ENVIRONMENT_DEFAULTS),
 )
-def test_profiler_resolution_invariants(
-    domain,
-    requested,
-    backend_profiler_kind,
-    environment_default_profiler_kind,
+def test_profiler_resolution_invariants(  # noqa: ANN201  # tracked: #288
+    domain,  # noqa: ANN001  # tracked: #288
+    requested,  # noqa: ANN001  # tracked: #288
+    backend_profiler_kind,  # noqa: ANN001  # tracked: #288
+    environment_default_profiler_kind,  # noqa: ANN001  # tracked: #288
 ):
-    kwargs = dict(
+    kwargs = dict(  # noqa: C408  # tracked: #288
         domain=domain,
         backend_profiler_kind=backend_profiler_kind,
         environment_default_profiler_kind=environment_default_profiler_kind,
     )
     allowed = allowed_profiler_kinds(domain)
     if requested is not ProfilerKind.AUTO and requested not in allowed:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011  # tracked: #288
             resolve_profiler_kind(requested, **kwargs)
         return
 
@@ -208,7 +208,7 @@ def test_profiler_resolution_invariants(
 
 
 @given(value=st.text(min_size=1, max_size=12).filter(lambda text: text not in _PROFILER_VALUES))
-def test_unknown_profiler_names_raise(value):
+def test_unknown_profiler_names_raise(value):  # noqa: ANN001, ANN201  # tracked: #288
     with pytest.raises(ValueError, match="Unknown"):
         coerce_profiler_kind(value)
 
@@ -218,7 +218,7 @@ def test_unknown_profiler_names_raise(value):
         lambda text: text not in _PROFILER_VALUES
     )
 )
-def test_resolver_rejects_unparsed_backend_profiler_metadata(backend_profiler_kind):
+def test_resolver_rejects_unparsed_backend_profiler_metadata(backend_profiler_kind):  # noqa: ANN001, ANN201  # tracked: #288
     with pytest.raises(TypeError, match="backend profiler"):
         resolve_profiler_kind(
             ProfilerKind.AUTO,
@@ -228,8 +228,12 @@ def test_resolver_rejects_unparsed_backend_profiler_metadata(backend_profiler_ki
         )
 
 
-def test_linux_cpu_preflight_fails_when_perf_is_unavailable(monkeypatch):
-    from vibesys.linux_cpu_profiler import Capability, DiagnosticCode, LinuxProfilerTool
+def test_linux_cpu_preflight_fails_when_perf_is_unavailable(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.linux_cpu_profiler import (  # noqa: PLC0415  # tracked: #288
+        Capability,
+        DiagnosticCode,
+        LinuxProfilerTool,
+    )
 
     monkeypatch.setattr(
         "vibesys.linux_cpu_profiler.detect_capability",
@@ -254,8 +258,12 @@ def test_linux_cpu_preflight_fails_when_perf_is_unavailable(monkeypatch):
     assert "perf_unavailable" in result.error_message()
 
 
-def test_linux_cpu_preflight_accepts_perf_with_nonblocking_symbol_restrictions(monkeypatch):
-    from vibesys.linux_cpu_profiler import Capability, DiagnosticCode, LinuxProfilerTool
+def test_linux_cpu_preflight_accepts_perf_with_nonblocking_symbol_restrictions(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.linux_cpu_profiler import (  # noqa: PLC0415  # tracked: #288
+        Capability,
+        DiagnosticCode,
+        LinuxProfilerTool,
+    )
 
     monkeypatch.setattr(
         "vibesys.linux_cpu_profiler.detect_capability",

--- a/tests/test_queue_abi_header.py
+++ b/tests/test_queue_abi_header.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 
-def test_queue_abi_header_supports_cpp_linkage(tmp_path):
+def test_queue_abi_header_supports_cpp_linkage(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     compiler = shutil.which("c++")
     if compiler is None:
         pytest.skip("a C++ compiler is required to check the queue ABI header")
@@ -19,7 +19,7 @@ def test_queue_abi_header_supports_cpp_linkage(tmp_path):
         '#include "vibesys_queue_abi.h"\n'
         'extern "C" uint32_t vsq_abi_version() { return VSQ_ABI_VERSION; }\n'
     )
-    subprocess.run(
+    subprocess.run(  # noqa: S603  # tracked: #288
         [
             compiler,
             "-std=c++17",

--- a/tests/test_queue_evaluator.py
+++ b/tests/test_queue_evaluator.py
@@ -5,7 +5,7 @@ import json
 import shutil
 import subprocess
 import tomllib
-from collections.abc import Iterator
+from collections.abc import Iterator  # noqa: TC003  # tracked: #288
 from pathlib import Path
 
 import pytest
@@ -24,7 +24,7 @@ LINEARIZABLE_ACCURACY_SETTINGS = {
 
 
 @pytest.fixture(scope="session")
-def compiled_queue_candidate(tmp_path_factory) -> Path:
+def compiled_queue_candidate(tmp_path_factory) -> Path:  # noqa: ANN001  # tracked: #288
     """Build the shared Rust starter once for materialized-input tests."""
     if shutil.which("cargo") is None:
         pytest.skip("Rust is required by the trusted queue evaluator")
@@ -33,7 +33,7 @@ def compiled_queue_candidate(tmp_path_factory) -> Path:
     starter = project_root / "examples" / "starters" / "queue-rs"
     build_dir = tmp_path_factory.mktemp("queue-rs-build") / "starter"
     shutil.copytree(starter, build_dir)
-    subprocess.run(["make"], cwd=build_dir, check=True)
+    subprocess.run(["make"], cwd=build_dir, check=True)  # noqa: S607  # tracked: #288
 
     candidate = build_dir / "queue-candidate.so"
     assert candidate.is_file()
@@ -41,7 +41,7 @@ def compiled_queue_candidate(tmp_path_factory) -> Path:
 
 
 @pytest.fixture(scope="session")
-def queue_native_runner(tmp_path_factory) -> Iterator[Path]:
+def queue_native_runner(tmp_path_factory) -> Iterator[Path]:  # noqa: ANN001  # tracked: #288
     """Build the trusted evaluator runner once and reuse it across subprocesses."""
     if shutil.which("cargo") is None:
         pytest.skip("Rust is required by the trusted queue evaluator")
@@ -49,8 +49,8 @@ def queue_native_runner(tmp_path_factory) -> Iterator[Path]:
     project_root = Path(__file__).parents[1]
     source = project_root / "examples" / "evaluators" / "queue" / "native_runner"
     target_dir = tmp_path_factory.mktemp("queue-native-runner") / "target"
-    subprocess.run(
-        [
+    subprocess.run(  # noqa: S603  # tracked: #288
+        [  # noqa: S607  # tracked: #288
             "cargo",
             "build",
             "--quiet",
@@ -89,7 +89,7 @@ def _materialize_linearizable_input(
     input_name: str,
     workspace: Path,
 ) -> Path:
-    from vibesys.input_manifest import load_input_bundle
+    from vibesys.input_manifest import load_input_bundle  # noqa: PLC0415  # tracked: #288
 
     input_dir = project_root / "examples" / "data-structures" / input_name
     bundle = load_input_bundle(input_dir, project_root=project_root)
@@ -104,7 +104,7 @@ def _materialize_linearizable_input(
     return input_dir
 
 
-def test_linearizable_queue_manifests_invoke_go_evaluator_directly():
+def test_linearizable_queue_manifests_invoke_go_evaluator_directly():  # noqa: ANN201  # tracked: #288
     root = Path(__file__).parents[1] / "examples" / "data-structures"
 
     for input_name, scenario in LINEARIZABLE_QUEUE_INPUTS.items():
@@ -157,8 +157,8 @@ def test_linearizable_queue_manifests_invoke_go_evaluator_directly():
     assert not any(old_core.glob("src/queue_input_core/*.py"))
 
 
-def test_linearizable_queue_inputs_use_shared_editable_rust_starter():
-    from vibesys.input_manifest import load_input_bundle
+def test_linearizable_queue_inputs_use_shared_editable_rust_starter():  # noqa: ANN201  # tracked: #288
+    from vibesys.input_manifest import load_input_bundle  # noqa: PLC0415  # tracked: #288
 
     project_root = Path(__file__).parents[1]
     root = project_root / "examples" / "data-structures"
@@ -183,7 +183,7 @@ def test_linearizable_queue_inputs_use_shared_editable_rust_starter():
 
 
 @pytest.mark.usefixtures("queue_native_runner")
-def test_spsc_rigtorp_baseline_builds_and_passes_accuracy(tmp_path):
+def test_spsc_rigtorp_baseline_builds_and_passes_accuracy(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     if shutil.which("go") is None or shutil.which("c++") is None:
         pytest.skip("Go and a C++ compiler are required by the SPSC baseline")
 
@@ -194,13 +194,13 @@ def test_spsc_rigtorp_baseline_builds_and_passes_accuracy(tmp_path):
     evaluator = project_root / "examples" / "evaluators" / "queue"
     abi_header = evaluator / "include" / "vibesys_queue_abi.h"
 
-    subprocess.run(
-        ["make", "clean", "all", f"ABI_HEADER={abi_header}"],
+    subprocess.run(  # noqa: S603  # tracked: #288
+        ["make", "clean", "all", f"ABI_HEADER={abi_header}"],  # noqa: S607  # tracked: #288
         cwd=baseline,
         check=True,
     )
-    completed = subprocess.run(
-        [
+    completed = subprocess.run(  # noqa: S603  # tracked: #288
+        [  # noqa: S607  # tracked: #288
             "go",
             "-C",
             str(evaluator),
@@ -227,7 +227,7 @@ def test_spsc_rigtorp_baseline_builds_and_passes_accuracy(tmp_path):
     assert "PASS - spsc linearizable" in completed.stdout
 
 
-def test_spsc_rigtorp_baseline_uses_pinned_upstream_header():
+def test_spsc_rigtorp_baseline_uses_pinned_upstream_header():  # noqa: ANN201  # tracked: #288
     project_root = Path(__file__).parents[1]
     baseline = project_root / "examples" / "baselines" / "queue-spsc-rigtorp"
     upstream_header = baseline / "include" / "rigtorp" / "SPSCQueue.h"
@@ -241,7 +241,7 @@ def test_spsc_rigtorp_baseline_uses_pinned_upstream_header():
 
 
 @pytest.mark.usefixtures("queue_native_runner")
-def test_mpmc_locked_ring_baseline_builds_and_passes_accuracy(tmp_path):
+def test_mpmc_locked_ring_baseline_builds_and_passes_accuracy(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     if shutil.which("go") is None or shutil.which("cc") is None:
         pytest.skip("Go and a C compiler are required by the MPMC baseline")
 
@@ -252,13 +252,13 @@ def test_mpmc_locked_ring_baseline_builds_and_passes_accuracy(tmp_path):
     evaluator = project_root / "examples" / "evaluators" / "queue"
     abi_header = evaluator / "include" / "vibesys_queue_abi.h"
 
-    subprocess.run(
-        ["make", "clean", "all", f"ABI_HEADER={abi_header}"],
+    subprocess.run(  # noqa: S603  # tracked: #288
+        ["make", "clean", "all", f"ABI_HEADER={abi_header}"],  # noqa: S607  # tracked: #288
         cwd=baseline,
         check=True,
     )
-    completed = subprocess.run(
-        [
+    completed = subprocess.run(  # noqa: S603  # tracked: #288
+        [  # noqa: S607  # tracked: #288
             "go",
             "-C",
             str(evaluator),
@@ -285,7 +285,7 @@ def test_mpmc_locked_ring_baseline_builds_and_passes_accuracy(tmp_path):
     assert "PASS - mpmc reservation-aware bounded FIFO" in completed.stdout
 
 
-def test_mpmc_locked_ring_baseline_has_atomic_publication_region():
+def test_mpmc_locked_ring_baseline_has_atomic_publication_region():  # noqa: ANN201  # tracked: #288
     project_root = Path(__file__).parents[1]
     baseline = project_root / "examples" / "baselines" / "queue-mpmc-locked-ring"
     adapter = (baseline / "locked_ring.c").read_text()
@@ -303,11 +303,11 @@ def test_mpmc_locked_ring_baseline_has_atomic_publication_region():
 
 @pytest.mark.parametrize(("input_name", "scenario"), LINEARIZABLE_QUEUE_INPUTS.items())
 @pytest.mark.usefixtures("queue_native_runner")
-def test_materialized_rust_starter_passes_accuracy(
-    tmp_path,
-    input_name,
-    scenario,
-    compiled_queue_candidate,
+def test_materialized_rust_starter_passes_accuracy(  # noqa: ANN201  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
+    input_name,  # noqa: ANN001  # tracked: #288
+    scenario,  # noqa: ANN001  # tracked: #288
+    compiled_queue_candidate,  # noqa: ANN001  # tracked: #288
 ):
     if shutil.which("go") is None or shutil.which("cargo") is None:
         pytest.skip("Go and Rust are required by the trusted queue evaluator")
@@ -331,7 +331,7 @@ def test_materialized_rust_starter_passes_accuracy(
         "--trials",
         "1",
     ]
-    completed = subprocess.run(
+    completed = subprocess.run(  # noqa: S603  # tracked: #288
         accuracy,
         cwd=workspace,
         check=True,
@@ -349,7 +349,7 @@ def test_materialized_rust_starter_passes_accuracy(
 
 
 @pytest.mark.usefixtures("queue_native_runner")
-def test_materialized_manifest_commands_run_go_evaluator_directly(tmp_path):
+def test_materialized_manifest_commands_run_go_evaluator_directly(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     if shutil.which("go") is None or shutil.which("cargo") is None:
         pytest.skip("Go and Rust are required by the trusted queue evaluator")
 
@@ -361,7 +361,7 @@ def test_materialized_manifest_commands_run_go_evaluator_directly(tmp_path):
         workspace,
     )
     assert (workspace / "_evaluator" / "queue" / "DESIGN.md").is_file()
-    subprocess.run(["make"], cwd=workspace, check=True)
+    subprocess.run(["make"], cwd=workspace, check=True)  # noqa: S607  # tracked: #288
     manifest = tomllib.loads((input_dir / "vibesys.input.toml").read_text())
 
     accuracy = [
@@ -373,7 +373,7 @@ def test_materialized_manifest_commands_run_go_evaluator_directly(tmp_path):
         "--trials",
         "1",
     ]
-    subprocess.run(accuracy, cwd=workspace, check=True)
+    subprocess.run(accuracy, cwd=workspace, check=True)  # noqa: S603  # tracked: #288
 
     output = workspace / "results.json"
     benchmark = [
@@ -387,7 +387,7 @@ def test_materialized_manifest_commands_run_go_evaluator_directly(tmp_path):
         "--output-json",
         str(output),
     ]
-    subprocess.run(benchmark, cwd=workspace, check=True)
+    subprocess.run(benchmark, cwd=workspace, check=True)  # noqa: S603  # tracked: #288
     results = json.loads(output.read_text())
     assert [result["scenario"] for result in results] == ["spsc"]
     assert all(result["repetitions"] == 3 for result in results)
@@ -395,9 +395,9 @@ def test_materialized_manifest_commands_run_go_evaluator_directly(tmp_path):
 
 
 @pytest.mark.usefixtures("queue_native_runner")
-def test_queue_evaluator_rejects_adversarial_histories():
+def test_queue_evaluator_rejects_adversarial_histories():  # noqa: ANN201  # tracked: #288
     if shutil.which("go") is None or shutil.which("cargo") is None:
         pytest.skip("Go and Rust are required by the trusted queue evaluator")
 
     evaluator = Path(__file__).parents[1] / "examples" / "evaluators" / "queue"
-    subprocess.run(["go", "test", "./..."], cwd=evaluator, check=True)
+    subprocess.run(["go", "test", "./..."], cwd=evaluator, check=True)  # noqa: S607  # tracked: #288

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from vibesys.repository import generate_experiment_name, repository_name_from_experiment
 
 
-def test_generate_experiment_name_uses_input_and_timestamp():
+def test_generate_experiment_name_uses_input_and_timestamp():  # noqa: ANN201  # tracked: #288
     assert (
         generate_experiment_name(
             Path("examples/data-structures/Queue MPSC"),
@@ -14,5 +14,5 @@ def test_generate_experiment_name_uses_input_and_timestamp():
     )
 
 
-def test_repository_name_sanitizes_an_explicit_experiment_name():
+def test_repository_name_sanitizes_an_explicit_experiment_name():  # noqa: ANN201  # tracked: #288
     assert repository_name_from_experiment("My queue trial #4") == "my-queue-trial-4"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -32,7 +32,7 @@ def _profiler_summary(
     )
 
 
-def test_skill_resource_selection_forbids_unknown_fields():
+def test_skill_resource_selection_forbids_unknown_fields():  # noqa: ANN201  # tracked: #288
     with pytest.raises(ValidationError, match="unexpected"):
         SkillResourceSelection(
             skill="portable",
@@ -43,7 +43,7 @@ def test_skill_resource_selection_forbids_unknown_fields():
 
 
 @pytest.mark.parametrize("field", ["skill", "purpose"])
-def test_skill_resource_selection_rejects_whitespace_required_fields(field):
+def test_skill_resource_selection_rejects_whitespace_required_fields(field):  # noqa: ANN001, ANN201  # tracked: #288
     values = {"skill": "portable", "purpose": "Useful for this task."}
     values[field] = "   "
 
@@ -51,8 +51,8 @@ def test_skill_resource_selection_rejects_whitespace_required_fields(field):
         SkillResourceSelection(**values)
 
 
-def test_agent_skill_selection_fields_are_zero_to_many_by_default():
-    plan = OrchestratorPlan(task="work", pass_criteria="passes", reasoning="reason")
+def test_agent_skill_selection_fields_are_zero_to_many_by_default():  # noqa: ANN201  # tracked: #288
+    plan = OrchestratorPlan(task="work", pass_criteria="passes", reasoning="reason")  # noqa: S106  # tracked: #288
     implementer = ImplementerResponse(summary="done", expected_behavior="works")
     judge = JudgeResponse(analysis="clean", feedback="", verdict=Verdict.PASS)
     single_agent = SingleAgentRoundResponse(
@@ -73,19 +73,19 @@ def test_agent_skill_selection_fields_are_zero_to_many_by_default():
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
-def test_profiler_summary_rejects_non_finite_perf_metric(value):
+def test_profiler_summary_rejects_non_finite_perf_metric(value):  # noqa: ANN001, ANN201  # tracked: #288
     with pytest.raises(ValidationError, match="finite number"):
         _profiler_summary(perf_metric=value)
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
-def test_profiler_summary_rejects_non_finite_multi_objective_metric(value):
+def test_profiler_summary_rejects_non_finite_multi_objective_metric(value):  # noqa: ANN001, ANN201  # tracked: #288
     with pytest.raises(ValidationError, match="finite number"):
         _profiler_summary(metrics={"throughput": value})
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
-def test_single_agent_response_rejects_non_finite_perf_metric(value):
+def test_single_agent_response_rejects_non_finite_perf_metric(value):  # noqa: ANN001, ANN201  # tracked: #288
     with pytest.raises(ValidationError, match="finite number"):
         SingleAgentRoundResponse(
             summary="summary",
@@ -102,7 +102,7 @@ def test_single_agent_response_rejects_non_finite_perf_metric(value):
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
-def test_performance_stats_reject_non_finite_values(value):
+def test_performance_stats_reject_non_finite_values(value):  # noqa: ANN001, ANN201  # tracked: #288
     with pytest.raises(ValidationError, match="finite number"):
         LatencyStats(
             mean_ms=value,

--- a/tests/test_skills_wiring.py
+++ b/tests/test_skills_wiring.py
@@ -74,7 +74,7 @@ def test_trainium_loads_nki_skills_from_sidecar_metadata(tmp_path):
     assert backend is ComputeBackend.TRAINIUM
     names = _skill_names(skills)
     assert "serving-systems" in names
-    assert NKI_SKILL_NAMES <= names
+    assert names >= NKI_SKILL_NAMES
 
 
 def test_cuda_filters_out_trainium_scoped_nki_skills(tmp_path):
@@ -257,7 +257,7 @@ def test_all_repository_skill_metadata_is_valid():
         for item in validate_skill_tree(PROJECT_ROOT / "resources" / "skills")
     }
     assert metadata["serving-systems"].domains == (DomainName.LLM_SERVING,)
-    assert NKI_SKILL_NAMES <= set(metadata)
+    assert set(metadata) >= NKI_SKILL_NAMES
 
 
 def test_all_nki_skills_inherit_trainium_scope_from_wrapper_sidecar():

--- a/tests/test_skills_wiring.py
+++ b/tests/test_skills_wiring.py
@@ -37,7 +37,7 @@ NKI_SKILL_NAMES = {
 }
 
 
-def _args(tmp_path, backend, *, no_skills=False, skills_dir=None):
+def _args(tmp_path, backend, *, no_skills=False, skills_dir=None):  # noqa: ANN001, ANN202  # tracked: #288
     cfg = tmp_path / "agent.toml"
     cfg.write_text('[model]\nname = "gpt-5.5"\n')
     if skills_dir is None:
@@ -67,7 +67,7 @@ def _write_sidecar(root: Path, content: str) -> Path:
     return path
 
 
-def test_trainium_loads_nki_skills_from_sidecar_metadata(tmp_path):
+def test_trainium_loads_nki_skills_from_sidecar_metadata(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     _, skills, backend = load_config_and_skills(
         _args(tmp_path, ComputeBackend.TRAINIUM), domain=DomainName.LLM_SERVING
     )
@@ -77,7 +77,7 @@ def test_trainium_loads_nki_skills_from_sidecar_metadata(tmp_path):
     assert names >= NKI_SKILL_NAMES
 
 
-def test_cuda_filters_out_trainium_scoped_nki_skills(tmp_path):
+def test_cuda_filters_out_trainium_scoped_nki_skills(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     _, skills, _ = load_config_and_skills(
         _args(tmp_path, ComputeBackend.CUDA), domain=DomainName.LLM_SERVING
     )
@@ -87,13 +87,13 @@ def test_cuda_filters_out_trainium_scoped_nki_skills(tmp_path):
 
 
 @pytest.mark.parametrize("domain", [DomainName.GENERIC, DomainName.MICROSERVICES])
-def test_non_serving_domains_filter_out_serving_systems(tmp_path, domain):
+def test_non_serving_domains_filter_out_serving_systems(tmp_path, domain):  # noqa: ANN001, ANN201  # tracked: #288
     _, skills, _ = load_config_and_skills(_args(tmp_path, ComputeBackend.CUDA), domain=domain)
 
     assert "serving-systems" not in _skill_names(skills)
 
 
-def test_no_skills_disables_even_compatible_skills(tmp_path):
+def test_no_skills_disables_even_compatible_skills(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     _, skills, _ = load_config_and_skills(
         _args(tmp_path, ComputeBackend.TRAINIUM, no_skills=True),
         domain=DomainName.LLM_SERVING,
@@ -101,7 +101,7 @@ def test_no_skills_disables_even_compatible_skills(tmp_path):
     assert skills is None
 
 
-def test_sidecar_rule_filters_descendant_skill_subtree_by_backend(tmp_path):
+def test_sidecar_rule_filters_descendant_skill_subtree_by_backend(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "skills"
     _write_skill(root, "portable")
     _write_skill(root / "vendor" / "skills", "trainium-only")
@@ -119,7 +119,7 @@ def test_sidecar_rule_filters_descendant_skill_subtree_by_backend(tmp_path):
     assert _skill_names(trainium) == {"portable", "trainium-only"}
 
 
-def test_sidecar_rule_filters_skill_by_domain(tmp_path):
+def test_sidecar_rule_filters_skill_by_domain(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "skills"
     _write_skill(root, "portable")
     _write_skill(root, "serving-only")
@@ -139,7 +139,7 @@ def test_sidecar_rule_filters_skill_by_domain(tmp_path):
     assert _skill_names(serving) == {"portable", "serving-only"}
 
 
-def test_more_specific_sidecar_rule_wins(tmp_path):
+def test_more_specific_sidecar_rule_wins(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "skills"
     _write_skill(root / "vendor" / "skills" / "common", "cuda-too")
     _write_sidecar(
@@ -160,7 +160,7 @@ def test_more_specific_sidecar_rule_wins(tmp_path):
     assert _skill_names(trainium) == {"cuda-too"}
 
 
-def test_conflicting_same_specificity_rules_fail(tmp_path):
+def test_conflicting_same_specificity_rules_fail(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "skills"
     skill_dir = _write_skill(root / "vendor" / "skills", "ambiguous")
     _write_sidecar(
@@ -168,7 +168,7 @@ def test_conflicting_same_specificity_rules_fail(tmp_path):
         '[[rule]]\npath = "skills"\nbackends = ["trainium"]\n',
     )
     rules = discover_sidecar_rules(root / "vendor")
-    duplicate_rules = rules + [
+    duplicate_rules = rules + [  # noqa: RUF005  # tracked: #288
         type(rules[0])(
             sidecar_path=rules[0].sidecar_path,
             raw_path=rules[0].raw_path,
@@ -177,13 +177,13 @@ def test_conflicting_same_specificity_rules_fail(tmp_path):
             domains=None,
         )
     ]
-    from vibesys.skills import effective_skill_metadata
+    from vibesys.skills import effective_skill_metadata  # noqa: PLC0415  # tracked: #288
 
     with pytest.raises(SkillMetadataError, match="conflicting VibeSys rules"):
         effective_skill_metadata(skill_dir, duplicate_rules)
 
 
-def test_duplicate_skill_dirs_are_deduped(tmp_path):
+def test_duplicate_skill_dirs_are_deduped(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "skills"
     skill_dir = _write_skill(root, "portable")
 
@@ -194,7 +194,7 @@ def test_duplicate_skill_dirs_are_deduped(tmp_path):
     assert [Path(s).name for s in skills] == ["portable"]
 
 
-def test_discovery_ignores_hidden_skill_directories(tmp_path):
+def test_discovery_ignores_hidden_skill_directories(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "skills"
     visible = _write_skill(root, "portable")
     hidden = root / ".claude" / "skills" / "foreign"
@@ -207,7 +207,7 @@ def test_discovery_ignores_hidden_skill_directories(tmp_path):
     ) == [str(visible)]
 
 
-def test_hidden_dir_check_treats_external_paths_as_visible(tmp_path):
+def test_hidden_dir_check_treats_external_paths_as_visible(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     assert not _is_in_hidden_dir(tmp_path / "other" / ".hidden" / "SKILL.md", tmp_path / "skills")
 
 
@@ -232,7 +232,7 @@ def test_hidden_dir_check_treats_external_paths_as_visible(tmp_path):
         ),
     ],
 )
-def test_invalid_sidecar_metadata_fails_with_sidecar_path(tmp_path, content, message):
+def test_invalid_sidecar_metadata_fails_with_sidecar_path(tmp_path, content, message):  # noqa: ANN001, ANN201  # tracked: #288
     sidecar = _write_sidecar(tmp_path, content)
 
     with pytest.raises(SkillMetadataError) as exc:
@@ -242,7 +242,7 @@ def test_invalid_sidecar_metadata_fails_with_sidecar_path(tmp_path, content, mes
     assert message in str(exc.value)
 
 
-def test_missing_skill_frontmatter_is_invalid(tmp_path):
+def test_missing_skill_frontmatter_is_invalid(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     skill_dir = tmp_path / "bad-skill"
     skill_dir.mkdir()
     skill_dir.joinpath("SKILL.md").write_text("# bad\n", encoding="utf-8")
@@ -251,7 +251,7 @@ def test_missing_skill_frontmatter_is_invalid(tmp_path):
         load_skill_frontmatter(skill_dir)
 
 
-def test_all_repository_skill_metadata_is_valid():
+def test_all_repository_skill_metadata_is_valid():  # noqa: ANN201  # tracked: #288
     metadata = {
         item.skill_dir.name: item
         for item in validate_skill_tree(PROJECT_ROOT / "resources" / "skills")
@@ -260,14 +260,14 @@ def test_all_repository_skill_metadata_is_valid():
     assert set(metadata) >= NKI_SKILL_NAMES
 
 
-def test_all_nki_skills_inherit_trainium_scope_from_wrapper_sidecar():
+def test_all_nki_skills_inherit_trainium_scope_from_wrapper_sidecar():  # noqa: ANN201  # tracked: #288
     metadata = {m.skill_dir.name: m for m in validate_skill_tree(NKI_WRAPPER_DIR)}
     assert set(metadata) == NKI_SKILL_NAMES
     assert all(m.backends == (ComputeBackend.TRAINIUM,) for m in metadata.values())
     assert all(m.domains is None for m in metadata.values())
 
 
-def test_discover_skill_dirs_accepts_single_skill_root(tmp_path):
+def test_discover_skill_dirs_accepts_single_skill_root(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     skill_dir = _write_skill(tmp_path, "portable")
 
     assert discover_skill_dirs(skill_dir) == [skill_dir]
@@ -276,7 +276,7 @@ def test_discover_skill_dirs_accepts_single_skill_root(tmp_path):
 # -- references/platforms/ layout ------------------------------------------
 
 
-def _write_platform(skill_dir: Path, backend: str, *, skeleton=PLATFORM_SKELETON) -> Path:
+def _write_platform(skill_dir: Path, backend: str, *, skeleton=PLATFORM_SKELETON) -> Path:  # noqa: ANN001  # tracked: #288
     platform_dir = skill_dir / "references" / "platforms" / backend
     platform_dir.mkdir(parents=True)
     for name in skeleton:
@@ -284,13 +284,13 @@ def _write_platform(skill_dir: Path, backend: str, *, skeleton=PLATFORM_SKELETON
     return platform_dir
 
 
-def test_skill_without_platforms_tree_still_validates(tmp_path):
+def test_skill_without_platforms_tree_still_validates(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     skill_dir = _write_skill(tmp_path, "portable")
 
     validate_platform_layout(skill_dir)  # no references/platforms/ — nothing to check
 
 
-def test_complete_platform_skeleton_validates(tmp_path):
+def test_complete_platform_skeleton_validates(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     skill_dir = _write_skill(tmp_path, "multi")
     _write_platform(skill_dir, "cuda")
     _write_platform(skill_dir, "trainium")
@@ -299,7 +299,7 @@ def test_complete_platform_skeleton_validates(tmp_path):
 
 
 @pytest.mark.parametrize("missing", PLATFORM_SKELETON)
-def test_platform_missing_a_skeleton_file_fails(tmp_path, missing):
+def test_platform_missing_a_skeleton_file_fails(tmp_path, missing):  # noqa: ANN001, ANN201  # tracked: #288
     skill_dir = _write_skill(tmp_path, "gappy")
     _write_platform(skill_dir, "metal", skeleton=[n for n in PLATFORM_SKELETON if n != missing])
 
@@ -307,7 +307,7 @@ def test_platform_missing_a_skeleton_file_fails(tmp_path, missing):
         validate_platform_layout(skill_dir)
 
 
-def test_platform_dir_must_be_a_known_compute_backend(tmp_path):
+def test_platform_dir_must_be_a_known_compute_backend(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     skill_dir = _write_skill(tmp_path, "typo")
     _write_platform(skill_dir, "nvidia")  # vendor name, not a ComputeBackend value
 
@@ -315,7 +315,7 @@ def test_platform_dir_must_be_a_known_compute_backend(tmp_path):
         validate_platform_layout(skill_dir)
 
 
-def test_validate_skill_tree_enforces_platform_layout(tmp_path):
+def test_validate_skill_tree_enforces_platform_layout(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     skill_dir = _write_skill(tmp_path, "gappy")
     _write_platform(skill_dir, "cuda", skeleton=["floor.md"])
 
@@ -323,7 +323,7 @@ def test_validate_skill_tree_enforces_platform_layout(tmp_path):
         validate_skill_tree(tmp_path)
 
 
-def test_serving_systems_platform_dirs_cover_every_compute_backend():
+def test_serving_systems_platform_dirs_cover_every_compute_backend():  # noqa: ANN201  # tracked: #288
     """Every backend a run can select must have its own guidance.
 
     Without this, selecting a backend silently falls back to reading another
@@ -350,7 +350,7 @@ def _portable_reference_files() -> list[Path]:
     return sorted(f for tier in PORTABLE_TIERS for f in (refs / tier).rglob("*.md"))
 
 
-def test_portable_references_never_link_into_a_platform_dir():
+def test_portable_references_never_link_into_a_platform_dir():  # noqa: ANN201  # tracked: #288
     """Materialization prunes every non-selected platform directory, so a
     markdown link from a portable file into ``platforms/<backend>/<file>``
     dangles on every other backend. Link the directory or name the library as
@@ -367,7 +367,7 @@ def test_portable_references_never_link_into_a_platform_dir():
     )
 
 
-def test_portable_references_have_no_links_to_removed_tiers():
+def test_portable_references_have_no_links_to_removed_tiers():  # noqa: ANN201  # tracked: #288
     """`backends/` and `hardware/` dissolved into `platforms/`; a leftover link
     to either is a dead path in every workspace, not just foreign ones."""
     stale = re.compile(r"\]\((?:\.{1,2}/)*(?:backends|hardware)/[^)]*\)")
@@ -395,7 +395,7 @@ def _strip_code_blocks(text: str) -> str:
     return "\n".join(out)
 
 
-def test_serving_systems_internal_links_resolve():
+def test_serving_systems_internal_links_resolve():  # noqa: ANN201  # tracked: #288
     """Every relative markdown link inside the skill points at a real file.
 
     ``CLAUDE.md`` is excluded: as the authoring guide it cites illustrative
@@ -419,7 +419,7 @@ def test_serving_systems_internal_links_resolve():
     assert not broken, "broken internal links:\n" + "\n".join(broken)
 
 
-def test_skill_selection_resolves_zero_to_many_resources_with_stable_deduplication(tmp_path):
+def test_skill_selection_resolves_zero_to_many_resources_with_stable_deduplication(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "skills"
     skill = _write_skill(root, "portable")
     references = skill / "references"
@@ -457,7 +457,7 @@ def test_skill_selection_resolves_zero_to_many_resources_with_stable_deduplicati
     assert resolve_skill_selections([], catalog) == ([], [])
 
 
-def test_skill_selection_omits_unknown_skills_and_unsafe_resources(tmp_path):
+def test_skill_selection_omits_unknown_skills_and_unsafe_resources(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "skills"
     skill = _write_skill(root, "portable")
     references = skill / "references"
@@ -501,7 +501,7 @@ def test_skill_selection_omits_unknown_skills_and_unsafe_resources(tmp_path):
     assert any("POSIX separators" in diagnostic for diagnostic in diagnostics)
 
 
-def test_skill_selection_rejects_symlink_escape(tmp_path):
+def test_skill_selection_rejects_symlink_escape(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "skills"
     skill = _write_skill(root, "portable")
     references = skill / "references"
@@ -527,7 +527,7 @@ def test_skill_selection_rejects_symlink_escape(tmp_path):
     assert "escapes the skill root" in diagnostics[0]
 
 
-def test_skill_catalog_matches_materialization_last_writer_wins(tmp_path):
+def test_skill_catalog_matches_materialization_last_writer_wins(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     first = _write_skill(tmp_path / "first", "portable")
     second = _write_skill(tmp_path / "second", "portable")
 
@@ -536,7 +536,7 @@ def test_skill_catalog_matches_materialization_last_writer_wins(tmp_path):
     assert catalog["portable"].source_dir == second.resolve()
 
 
-def test_skill_catalog_rejects_frontmatter_name_that_cannot_be_materialized(tmp_path):
+def test_skill_catalog_rejects_frontmatter_name_that_cannot_be_materialized(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     skill = _write_skill(tmp_path, "portable")
     skill.joinpath("SKILL.md").write_text(
         "---\nname: different\ndescription: mismatch\n---\n",

--- a/tests/test_todo_display.py
+++ b/tests/test_todo_display.py
@@ -12,9 +12,9 @@ from vibesys.server.events import TodoUpdateData
 # --- Thread ID for state persistence ---
 
 
-def test_run_agent_passes_thread_id():
+def test_run_agent_passes_thread_id():  # noqa: ANN201  # tracked: #288
     """run_agent must pass a thread_id in config so checkpointer can persist state."""
-    from vibesys.agent_runner import run_agent
+    from vibesys.agent_runner import run_agent  # noqa: PLC0415  # tracked: #288
 
     agent = MagicMock()
     agent.stream.return_value = iter(
@@ -30,10 +30,10 @@ def test_run_agent_passes_thread_id():
     assert "thread_id" in config["configurable"]
 
 
-def test_run_judge_agent_passes_thread_id():
+def test_run_judge_agent_passes_thread_id():  # noqa: ANN201  # tracked: #288
     """run_judge_agent must pass a thread_id in config so checkpointer can persist state."""
-    from vibesys.agent_runner import run_judge_agent
-    from vibesys.schemas import JudgeResponse, Verdict
+    from vibesys.agent_runner import run_judge_agent  # noqa: PLC0415  # tracked: #288
+    from vibesys.schemas import JudgeResponse, Verdict  # noqa: PLC0415  # tracked: #288
 
     agent = MagicMock()
     agent.stream.return_value = iter(
@@ -61,12 +61,12 @@ def test_run_judge_agent_passes_thread_id():
 # --- Todo extraction in run_agent ---
 
 
-def _capture_todo_updates():
+def _capture_todo_updates():  # noqa: ANN202  # tracked: #288
     """Patch the runner's todo publisher, recording each emitted snapshot."""
     updates: list[TodoUpdateData] = []
 
-    def record(todos):
-        from vibesys.agent_runner import TodoItemData
+    def record(todos):  # noqa: ANN001, ANN202  # tracked: #288
+        from vibesys.agent_runner import TodoItemData  # noqa: PLC0415  # tracked: #288
 
         updates.append(
             TodoUpdateData(
@@ -79,9 +79,9 @@ def _capture_todo_updates():
     return updates, patch("vibesys.agent_runner.publish_todos", side_effect=record)
 
 
-def test_run_agent_publishes_todos_from_tools_node():
+def test_run_agent_publishes_todos_from_tools_node():  # noqa: ANN201  # tracked: #288
     """run_agent picks up todos from the tools node (where write_todos Command lands)."""
-    from vibesys.agent_runner import run_agent
+    from vibesys.agent_runner import run_agent  # noqa: PLC0415  # tracked: #288
 
     agent = MagicMock()
     agent.stream.return_value = iter(
@@ -119,9 +119,9 @@ def test_run_agent_publishes_todos_from_tools_node():
     assert len(updates[1].todos) == 2
 
 
-def test_run_agent_publishes_todos_from_any_node():
+def test_run_agent_publishes_todos_from_any_node():  # noqa: ANN201  # tracked: #288
     """run_agent finds todos regardless of which node key they appear under."""
-    from vibesys.agent_runner import run_agent
+    from vibesys.agent_runner import run_agent  # noqa: PLC0415  # tracked: #288
 
     agent = MagicMock()
     agent.stream.return_value = iter(
@@ -142,10 +142,10 @@ def test_run_agent_publishes_todos_from_any_node():
     assert updates[0].todos[0].content == "Task A"
 
 
-def test_run_judge_agent_publishes_todos():
+def test_run_judge_agent_publishes_todos():  # noqa: ANN201  # tracked: #288
     """run_judge_agent picks up todos from the tools node."""
-    from vibesys.agent_runner import run_judge_agent
-    from vibesys.schemas import JudgeResponse, Verdict
+    from vibesys.agent_runner import run_judge_agent  # noqa: PLC0415  # tracked: #288
+    from vibesys.schemas import JudgeResponse, Verdict  # noqa: PLC0415  # tracked: #288
 
     agent = MagicMock()
     agent.stream.return_value = iter(
@@ -177,11 +177,11 @@ def test_run_judge_agent_publishes_todos():
     assert updates[0].todos[0].content == "Review code"
 
 
-def test_publish_todos_emits_structured_event():
+def test_publish_todos_emits_structured_event():  # noqa: ANN201  # tracked: #288
     """publish_todos converts raw stream dicts into a typed TODO_UPDATE event."""
-    from vibesys.agent_runner import publish_todos
-    from vibesys.render import output_sink
-    from vibesys.server.events import EventType, RunEvent
+    from vibesys.agent_runner import publish_todos  # noqa: PLC0415  # tracked: #288
+    from vibesys.render import output_sink  # noqa: PLC0415  # tracked: #288
+    from vibesys.server.events import EventType, RunEvent  # noqa: PLC0415  # tracked: #288
 
     seen: list[RunEvent] = []
     unsubscribe = output_sink().subscribe(seen.append)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -291,7 +291,7 @@ def test_run_context_chat_exposes_trajectory_without_inlining_it_in_prompt(tmp_p
         workspace=tmp_path / "workspace",
         run_log_path=tmp_path / "run.log",
     )
-    ctx.gpu_env = lambda: {}
+    ctx.gpu_env = dict
     ctx._progress_stack = []
     ctx._chat_lock = threading.Lock()
     ctx._chat_history = []
@@ -554,7 +554,7 @@ def test_run_context_records_invocation_boundary(tmp_path):
         workspace=tmp_path,
         run_log_path=tmp_path / "run.log",
     )
-    ctx.gpu_env = lambda: {}
+    ctx.gpu_env = dict
     ctx._progress_stack = []
 
     result = ctx.invoke(

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -35,11 +35,11 @@ from vibesys.server.service import SupervisionService
 from vibesys.server.transport import SupervisionSocketServer
 
 
-def _events(path):
+def _events(path):  # noqa: ANN001, ANN202  # tracked: #288
     return [json.loads(line) for line in path.read_text().splitlines()]
 
 
-def test_chat_is_audited_but_not_injected(tmp_path):
+def test_chat_is_audited_but_not_injected(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)
     supervisor.record(EventType.CHAT, "What is happening?", status="answered")
@@ -52,7 +52,7 @@ def test_chat_is_audited_but_not_injected(tmp_path):
     assert event_types.index("chat") < event_types.index("invocation_started")
 
 
-def test_pause_takes_effect_at_next_safe_point(tmp_path):
+def test_pause_takes_effect_at_next_safe_point(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)
     supervisor.pause_after_call()
@@ -69,7 +69,7 @@ def test_pause_takes_effect_at_next_safe_point(tmp_path):
     assert result == [None]
 
 
-def test_invocation_audit_contains_prompts_and_result(tmp_path):
+def test_invocation_audit_contains_prompts_and_result(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)
     supervisor.before_agent("implementer", "round 4", "Do work", "System rules")
@@ -84,7 +84,7 @@ def test_invocation_audit_contains_prompts_and_result(tmp_path):
     assert finished["data"]["result"] == {"summary": "done"}
 
 
-def test_inspector_answers_round_and_failure_queries(tmp_path):
+def test_inspector_answers_round_and_failure_queries(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     (tmp_path / "logs").mkdir()
     supervisor.attach(tmp_path / "logs")
@@ -96,7 +96,7 @@ def test_inspector_answers_round_and_failure_queries(tmp_path):
     assert "latency regressed" in inspector.answer("why did the judge fail?")
 
 
-def test_general_chat_is_distinct_from_status_query(tmp_path):
+def test_general_chat_is_distinct_from_status_query(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)
     supervisor.chat("hello there")
@@ -104,7 +104,7 @@ def test_general_chat_is_distinct_from_status_query(tmp_path):
     assert event_types == ["server_started", "chat"]
 
 
-def test_side_channel_chat_output_is_tagged_without_changing_active_agent(tmp_path):
+def test_side_channel_chat_output_is_tagged_without_changing_active_agent(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)
     supervisor.before_agent("implementer", "round-1", "work")
@@ -124,7 +124,7 @@ def test_side_channel_chat_output_is_tagged_without_changing_active_agent(tmp_pa
     assert agent_events[1].data.content == "experiment output"
 
 
-def test_bootstrap_events_migrate_to_run_audit_without_replacing_history(tmp_path):
+def test_bootstrap_events_migrate_to_run_audit_without_replacing_history(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     logs = tmp_path / "run" / "logs"
     historical = RunSupervisor()
     historical.attach(logs)
@@ -159,7 +159,7 @@ def test_bootstrap_events_migrate_to_run_audit_without_replacing_history(tmp_pat
     ]
 
 
-def test_history_query_reads_prior_and_current_session_events(tmp_path):
+def test_history_query_reads_prior_and_current_session_events(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     logs = tmp_path / "run" / "logs"
     historical = RunSupervisor()
     historical.attach(logs)
@@ -179,7 +179,7 @@ def test_history_query_reads_prior_and_current_session_events(tmp_path):
     assert {event.round_label for event in supervisor.read_events()} == {None, "round-2"}
 
 
-def test_performance_query_reads_rounds_json(tmp_path):
+def test_performance_query_reads_rounds_json(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     logs = tmp_path / "run" / "logs"
     logs.mkdir(parents=True)
     (logs / "rounds.json").write_text(
@@ -214,12 +214,12 @@ def test_performance_query_reads_rounds_json(tmp_path):
 
     response = SupervisionService(supervisor).execute(PerformanceQuery())
 
-    assert [round.round for round in response.performance] == [1, 3]
+    assert [round.round for round in response.performance] == [1, 3]  # noqa: A001  # tracked: #288
     assert response.performance[1].perf_metric == 2400.0
     assert response.performance[1].perf_unit == "total_ops_per_sec"
 
 
-def test_chat_reports_structured_failed_invocation(tmp_path):
+def test_chat_reports_structured_failed_invocation(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)
     supervisor.before_agent("implementer", "round 5", "prompt")
@@ -229,7 +229,7 @@ def test_chat_reports_structured_failed_invocation(tmp_path):
     assert "agent process exited" in answer
 
 
-def test_service_accepts_chat(tmp_path):
+def test_service_accepts_chat(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     (tmp_path / "logs").mkdir()
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path / "logs")
@@ -241,7 +241,7 @@ def test_service_accepts_chat(tmp_path):
     assert any(event["type"] == "status_query" for event in events)
 
 
-def test_service_routes_chat_to_configured_agent_handler(tmp_path):
+def test_service_routes_chat_to_configured_agent_handler(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)
     questions = []
@@ -256,7 +256,7 @@ def test_service_routes_chat_to_configured_agent_handler(tmp_path):
     assert _events(tmp_path / "run-events.jsonl")[-1]["type"] == "chat"
 
 
-def test_chat_explains_configuration_failure_without_a_run_context(tmp_path):
+def test_chat_explains_configuration_failure_without_a_run_context(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)
     supervisor.record(
@@ -277,7 +277,7 @@ def test_chat_explains_configuration_failure_without_a_run_context(tmp_path):
     assert "agent.toml was not found" in response.chat.answer
 
 
-def test_run_context_chat_exposes_trajectory_without_inlining_it_in_prompt(tmp_path):
+def test_run_context_chat_exposes_trajectory_without_inlining_it_in_prompt(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path / "logs")
     (tmp_path / "logs" / "progress.md").write_text("Round 2 improved throughput.")
@@ -285,16 +285,16 @@ def test_run_context_chat_exposes_trajectory_without_inlining_it_in_prompt(tmp_p
     ctx.supervisor = supervisor
     ctx.agent_runner = Mock()
     ctx.agent_runner.invoke_text.return_value = "It improved in round 2."
-    ctx._paths = RunPaths(
+    ctx._paths = RunPaths(  # noqa: SLF001  # tracked: #288
         exp_dir=tmp_path,
         log_dir=tmp_path / "logs",
         workspace=tmp_path / "workspace",
         run_log_path=tmp_path / "run.log",
     )
     ctx.gpu_env = dict
-    ctx._progress_stack = []
-    ctx._chat_lock = threading.Lock()
-    ctx._chat_history = []
+    ctx._progress_stack = []  # noqa: SLF001  # tracked: #288
+    ctx._chat_lock = threading.Lock()  # noqa: SLF001  # tracked: #288
+    ctx._chat_history = []  # noqa: SLF001  # tracked: #288
     ctx.logger = Mock()
     ctx.logger.file = Mock()
 
@@ -324,14 +324,14 @@ def test_run_context_chat_exposes_trajectory_without_inlining_it_in_prompt(tmp_p
     assert "It improved in round 2." not in continuation["user_prompt"]
     assert "_vibesys_chat/instructions.md" in continuation["system_prompt"]
     assert "Prefer targeted commands" not in continuation["system_prompt"]
-    assert ctx._load_chat_history() == [("what improved?", "It improved in round 2.")]
+    assert ctx._load_chat_history() == [("what improved?", "It improved in round 2.")]  # noqa: SLF001  # tracked: #288
 
 
-def test_socket_transport_supports_multiple_clients_and_event_replay(tmp_path):
+def test_socket_transport_supports_multiple_clients_and_event_replay(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path / "logs")
     service = SupervisionService(supervisor)
-    socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"
+    socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"  # noqa: S108  # tracked: #288
 
     with SupervisionSocketServer(socket_path, service):
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as first:
@@ -355,17 +355,17 @@ def test_socket_transport_supports_multiple_clients_and_event_replay(tmp_path):
     assert any(event["type"] == "server_started" for event in replay["events"])
 
 
-def test_socket_transport_returns_clear_chat_agent_errors(tmp_path):
+def test_socket_transport_returns_clear_chat_agent_errors(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path / "logs")
 
     def fail_chat(question: str) -> str:
-        raise RuntimeError(f"Chat agent failed while answering: {question}")
+        raise RuntimeError(f"Chat agent failed while answering: {question}")  # noqa: TRY003  # tracked: #288
 
     supervisor.set_chat_handler(fail_chat)
-    socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"
+    socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"  # noqa: S108  # tracked: #288
 
-    with SupervisionSocketServer(socket_path, SupervisionService(supervisor)):
+    with SupervisionSocketServer(socket_path, SupervisionService(supervisor)):  # noqa: SIM117  # tracked: #288
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
             client.connect(str(socket_path))
             stream = client.makefile("rwb")
@@ -377,13 +377,13 @@ def test_socket_transport_returns_clear_chat_agent_errors(tmp_path):
     assert response["error"] == "Chat agent failed while answering: what happened?"
 
 
-def test_socket_subscription_replays_then_streams_new_events(tmp_path):
+def test_socket_subscription_replays_then_streams_new_events(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path / "logs")
     service = SupervisionService(supervisor)
-    socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"
+    socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"  # noqa: S108  # tracked: #288
 
-    with SupervisionSocketServer(socket_path, service):
+    with SupervisionSocketServer(socket_path, service):  # noqa: SIM117  # tracked: #288
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
             client.settimeout(2)
             client.connect(str(socket_path))
@@ -402,11 +402,11 @@ def test_socket_subscription_replays_then_streams_new_events(tmp_path):
     assert streamed["event"]["type"] == "chat"
 
 
-def test_cli_parse_failure_is_streamed_after_client_attaches():
-    session_dir = Path("/tmp") / f"vs-test-{uuid.uuid4().hex}"
+def test_cli_parse_failure_is_streamed_after_client_attaches():  # noqa: ANN201  # tracked: #288
+    session_dir = Path("/tmp") / f"vs-test-{uuid.uuid4().hex}"  # noqa: S108  # tracked: #288
     session_dir.mkdir()
     socket_path = session_dir / "control.sock"
-    process = subprocess.Popen(
+    process = subprocess.Popen(  # noqa: S603  # tracked: #288
         [
             sys.executable,
             "-m",
@@ -470,8 +470,8 @@ def test_cli_parse_failure_is_streamed_after_client_attaches():
     assert stderr == ""
 
 
-def test_supervision_runtime_streams_configuration_failure_before_exiting():
-    session_dir = Path("/tmp") / f"vs-runtime-test-{uuid.uuid4().hex}"
+def test_supervision_runtime_streams_configuration_failure_before_exiting():  # noqa: ANN201  # tracked: #288
+    session_dir = Path("/tmp") / f"vs-runtime-test-{uuid.uuid4().hex}"  # noqa: S108  # tracked: #288
     socket_path = session_dir / "control.sock"
     received_events = []
     chat_responses = []
@@ -541,21 +541,21 @@ def test_supervision_runtime_streams_configuration_failure_before_exiting():
         shutil.rmtree(session_dir, ignore_errors=True)
 
 
-def test_run_context_records_invocation_boundary(tmp_path):
+def test_run_context_records_invocation_boundary(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)
     ctx = _RunContext.__new__(_RunContext)
     ctx.supervisor = supervisor
     ctx.agent_runner = Mock()
     ctx.agent_runner.invoke.return_value = {"summary": "measured"}
-    ctx._paths = RunPaths(
+    ctx._paths = RunPaths(  # noqa: SLF001  # tracked: #288
         exp_dir=tmp_path,
         log_dir=tmp_path / "logs",
         workspace=tmp_path,
         run_log_path=tmp_path / "run.log",
     )
     ctx.gpu_env = dict
-    ctx._progress_stack = []
+    ctx._progress_stack = []  # noqa: SLF001  # tracked: #288
 
     result = ctx.invoke(
         kind="implementer",
@@ -574,6 +574,6 @@ def test_run_context_records_invocation_boundary(tmp_path):
     assert started["data"]["user_prompt"] == "original"
 
 
-def test_committed_protocol_schema_matches_python_contract():
+def test_committed_protocol_schema_matches_python_contract():  # noqa: ANN201  # tracked: #288
     schema_path = Path("clients/tui/src/generated/protocol.schema.json")
     assert json.loads(schema_path.read_text()) == ProtocolDocument.model_json_schema()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -17,7 +17,7 @@ from vibesys.constants import ComputeBackend
 from vibesys.run import CopySpec, InputProjectSpec, Workspace
 
 
-def _make_workspace(root, *, isolated=False, excluded_dirs=None, compute_backend=None):
+def _make_workspace(root, *, isolated=False, excluded_dirs=None, compute_backend=None):  # noqa: ANN001, ANN202  # tracked: #288
     return Workspace(
         root,
         run_environment=SimpleNamespace(isolated=isolated),
@@ -29,7 +29,7 @@ def _make_workspace(root, *, isolated=False, excluded_dirs=None, compute_backend
     )
 
 
-def _write_platform_skill(root):
+def _write_platform_skill(root):  # noqa: ANN001, ANN202  # tracked: #288
     """A skill carrying one references/platforms/<backend>/ dir per backend."""
     skill = root / "serving-systems"
     (skill / "references" / "algorithms").mkdir(parents=True)
@@ -49,7 +49,7 @@ def _write_platform_skill(root):
 @pytest.mark.parametrize(
     "selected", [ComputeBackend.CUDA, ComputeBackend.TRAINIUM, ComputeBackend.METAL]
 )
-def test_skill_copy_into_workspace_root_prunes_foreign_platforms(tmp_path, selected):
+def test_skill_copy_into_workspace_root_prunes_foreign_platforms(tmp_path, selected):  # noqa: ANN001, ANN201  # tracked: #288
     """The workspace-root skill copy is what the implementer prompt points at.
 
     It must be pruned exactly like the per-CLI copies — otherwise the agent can
@@ -69,7 +69,7 @@ def test_skill_copy_into_workspace_root_prunes_foreign_platforms(tmp_path, selec
     assert (ws.root / skill.name / "references/models/cuda/note.md").is_file()
 
 
-def test_skill_copy_without_backend_keeps_every_platform(tmp_path):
+def test_skill_copy_without_backend_keeps_every_platform(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     skill = _write_platform_skill(tmp_path / "src")
     ws = _make_workspace(tmp_path / "ws", compute_backend=None)
     ws.create()
@@ -80,7 +80,7 @@ def test_skill_copy_without_backend_keeps_every_platform(tmp_path):
     assert {p.name for p in platforms.iterdir()} == {b.value for b in ComputeBackend}
 
 
-def test_non_skill_copies_never_prune_platforms(tmp_path):
+def test_non_skill_copies_never_prune_platforms(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """prune_platforms is opt-in; an input bundle that happens to contain a
     references/platforms tree is copied verbatim."""
     src = _write_platform_skill(tmp_path / "src")
@@ -93,7 +93,7 @@ def test_non_skill_copies_never_prune_platforms(tmp_path):
     assert {p.name for p in platforms.iterdir()} == {b.value for b in ComputeBackend}
 
 
-def test_every_skill_copy_step_is_marked_for_pruning(tmp_path):
+def test_every_skill_copy_step_is_marked_for_pruning(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Each of the three skill CopySpecs (root, per-CLI refresh, fresh setup)
     must set prune_platforms; a new one added without it silently leaks."""
     ws = _make_workspace(tmp_path / "ws")
@@ -120,7 +120,7 @@ def test_every_skill_copy_step_is_marked_for_pruning(tmp_path):
     ]
 
 
-def test_fresh_plan_with_seed_overlays_input_and_rejects_collisions(tmp_path):
+def test_fresh_plan_with_seed_overlays_input_and_rejects_collisions(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ws = _make_workspace(tmp_path / "ws")
     seed = tmp_path / "seed"
     input_dir = tmp_path / "input"
@@ -162,7 +162,7 @@ def test_fresh_plan_with_seed_overlays_input_and_rejects_collisions(tmp_path):
     )
 
 
-def test_fresh_plan_without_seed_does_not_reject_collisions(tmp_path):
+def test_fresh_plan_without_seed_does_not_reject_collisions(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ws = _make_workspace(tmp_path / "ws")
     input_dir = tmp_path / "input"
 
@@ -180,7 +180,7 @@ def test_fresh_plan_without_seed_does_not_reject_collisions(tmp_path):
     assert plan == (CopySpec(src=input_dir, dest=ws.root),)
 
 
-def test_resume_plan_only_refreshes_skills_and_missing_profiler(tmp_path):
+def test_resume_plan_only_refreshes_skills_and_missing_profiler(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "ws"
     skill = tmp_path / "skills" / "serving-systems"
     # Skill targets that exist in the interrupted workspace get refreshed —
@@ -210,7 +210,7 @@ def test_resume_plan_only_refreshes_skills_and_missing_profiler(tmp_path):
     )
 
 
-def test_resume_plan_skips_profiler_already_present(tmp_path):
+def test_resume_plan_skips_profiler_already_present(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "ws"
     (root / "nsys_profiler").mkdir(parents=True)
 
@@ -229,7 +229,7 @@ def test_resume_plan_skips_profiler_already_present(tmp_path):
     assert plan == ()
 
 
-def test_setup_rejects_preexisting_evaluator_dir(tmp_path):
+def test_setup_rejects_preexisting_evaluator_dir(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "ws"
     evaluator = tmp_path / "evaluator"
     evaluator.mkdir()
@@ -254,7 +254,7 @@ def test_setup_rejects_preexisting_evaluator_dir(tmp_path):
         ws.setup(evaluator_steps, existing=False)
 
 
-def test_setup_prunes_excluded_dirs_on_fresh_runs_only(tmp_path):
+def test_setup_prunes_excluded_dirs_on_fresh_runs_only(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     root = tmp_path / "ws"
     (root / "target").mkdir(parents=True)
     (root / "target" / "stale.o").write_text("stale")
@@ -267,12 +267,12 @@ def test_setup_prunes_excluded_dirs_on_fresh_runs_only(tmp_path):
     assert not (root / "target").exists()
 
 
-def test_copy_dir_replaces_external_symlinks_when_not_isolated(tmp_path):
+def test_copy_dir_replaces_external_symlinks_when_not_isolated(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     outside = tmp_path / "outside"
     outside.mkdir()
     src = tmp_path / "src"
     src.mkdir()
-    os.symlink(outside, src / "model")
+    os.symlink(outside, src / "model")  # noqa: PTH211  # tracked: #288
 
     dst = tmp_path / "ws"
     _make_workspace(dst, isolated=False).copy_dir(src, dst)
@@ -281,12 +281,12 @@ def test_copy_dir_replaces_external_symlinks_when_not_isolated(tmp_path):
     assert (dst / "model.symlink_target").read_text() == str(outside.resolve())
 
 
-def test_copy_dir_removes_external_symlinks_when_isolated(tmp_path):
+def test_copy_dir_removes_external_symlinks_when_isolated(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     outside = tmp_path / "outside"
     outside.mkdir()
     src = tmp_path / "src"
     src.mkdir()
-    os.symlink(outside, src / "model")
+    os.symlink(outside, src / "model")  # noqa: PTH211  # tracked: #288
     (src / "kept.py").write_text("pass\n")
 
     dst = tmp_path / "ws"

--- a/tests/test_workspace_seed.py
+++ b/tests/test_workspace_seed.py
@@ -449,42 +449,42 @@ def test_fresh_workspace_materializes_seed_and_preserves_it_in_initial_commit(tm
     (input_dir / "OBJECTIVE.md").write_text("Build a queue.\n")
     (input_dir / "checker.py").write_text("pass\n")
 
-    with _patched_context_dependencies(project_root):
-        with _make_context(
+    with (
+        _patched_context_dependencies(project_root),
+        _make_context(
             input_dir,
             seed,
             evaluator_path=evaluator,
             git_tracking=True,
-        ) as ctx:
-            assert ctx.workspace_seed_path == seed.resolve()
-            assert ctx.evaluator_path == evaluator.resolve()
-            assert ctx.hidden_evaluator_path is None
-            assert (ctx.workspace / "Cargo.toml").is_file()
-            assert (ctx.workspace / "src" / "lib.rs").is_file()
-            assert (ctx.workspace / "OBJECTIVE.md").is_file()
-            assert (ctx.workspace / "checker.py").is_file()
-            assert not (ctx.workspace / "target").exists()
-            assert not (ctx.workspace / "candidate.so").exists()
-            assert (ctx.workspace / "_evaluator" / "queue" / "checker.go").is_file()
-            assert not (ctx.workspace / "_evaluator" / "queue" / "target").exists()
-            assert "target/\n" in (ctx.workspace / ".gitignore").read_text()
+        ) as ctx,
+    ):
+        assert ctx.workspace_seed_path == seed.resolve()
+        assert ctx.evaluator_path == evaluator.resolve()
+        assert ctx.hidden_evaluator_path is None
+        assert (ctx.workspace / "Cargo.toml").is_file()
+        assert (ctx.workspace / "src" / "lib.rs").is_file()
+        assert (ctx.workspace / "OBJECTIVE.md").is_file()
+        assert (ctx.workspace / "checker.py").is_file()
+        assert not (ctx.workspace / "target").exists()
+        assert not (ctx.workspace / "candidate.so").exists()
+        assert (ctx.workspace / "_evaluator" / "queue" / "checker.go").is_file()
+        assert not (ctx.workspace / "_evaluator" / "queue" / "target").exists()
+        assert "target/\n" in (ctx.workspace / ".gitignore").read_text()
 
-            tracked = subprocess.run(
-                ["git", "ls-files"],
-                cwd=ctx.workspace,
-                check=True,
-                capture_output=True,
-                text=True,
-            ).stdout.splitlines()
-            assert "Cargo.toml" in tracked
-            assert "src/lib.rs" in tracked
-            assert "OBJECTIVE.md" in tracked
-            assert "_evaluator/queue/checker.go" in tracked
+        tracked = subprocess.run(
+            ["git", "ls-files"],
+            cwd=ctx.workspace,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        assert "Cargo.toml" in tracked
+        assert "src/lib.rs" in tracked
+        assert "OBJECTIVE.md" in tracked
+        assert "_evaluator/queue/checker.go" in tracked
 
-            (ctx.workspace / "_evaluator" / "queue" / "checker.go").write_text(
-                "package compromised\n"
-            )
-            assert ctx.trusted_input_changes() == ["_evaluator/queue/checker.go"]
+        (ctx.workspace / "_evaluator" / "queue" / "checker.go").write_text("package compromised\n")
+        assert ctx.trusted_input_changes() == ["_evaluator/queue/checker.go"]
 
 
 def test_hidden_evaluator_stays_out_of_workspace_and_agent_project_mount(tmp_path):
@@ -552,32 +552,34 @@ def test_fresh_workspace_materializes_git_source_and_strips_nested_git(tmp_path)
         dest="vllm",
     )
 
-    with _patched_context_dependencies(project_root):
-        with _make_context(
+    with (
+        _patched_context_dependencies(project_root),
+        _make_context(
             input_dir,
             seed,
             workspace_sources=(source,),
             git_tracking=True,
-        ) as ctx:
-            assert (ctx.workspace / "serve.py").is_file()
-            assert (ctx.workspace / "vllm" / "vllm" / "__init__.py").read_text() == (
-                "__version__ = 'test'\n"
-            )
-            assert not (ctx.workspace / "vllm" / ".git").exists()
+        ) as ctx,
+    ):
+        assert (ctx.workspace / "serve.py").is_file()
+        assert (ctx.workspace / "vllm" / "vllm" / "__init__.py").read_text() == (
+            "__version__ = 'test'\n"
+        )
+        assert not (ctx.workspace / "vllm" / ".git").exists()
 
-            metadata = (ctx.workspace / "_vibesys_sources.json").read_text()
-            assert str(source_repo) in metadata
-            assert commit in metadata
+        metadata = (ctx.workspace / "_vibesys_sources.json").read_text()
+        assert str(source_repo) in metadata
+        assert commit in metadata
 
-            tracked = subprocess.run(
-                ["git", "ls-files"],
-                cwd=ctx.workspace,
-                check=True,
-                capture_output=True,
-                text=True,
-            ).stdout.splitlines()
-            assert "vllm/vllm/__init__.py" in tracked
-            assert "vllm/.git" not in tracked
+        tracked = subprocess.run(
+            ["git", "ls-files"],
+            cwd=ctx.workspace,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        assert "vllm/vllm/__init__.py" in tracked
+        assert "vllm/.git" not in tracked
 
 
 def test_fresh_workspace_materializes_git_source_without_seed(tmp_path):
@@ -605,19 +607,21 @@ def test_fresh_workspace_materializes_git_source_without_seed(tmp_path):
         dest="vllm",
     )
 
-    with _patched_context_dependencies(project_root):
-        with _make_context(
+    with (
+        _patched_context_dependencies(project_root),
+        _make_context(
             input_dir,
             seed=None,
             workspace_sources=(source,),
             git_tracking=True,
-        ) as ctx:
-            assert (ctx.workspace / "OBJECTIVE.md").is_file()
-            assert (ctx.workspace / "vllm" / "vllm" / "__init__.py").read_text() == (
-                "__version__ = 'test'\n"
-            )
-            metadata = (ctx.workspace / "_vibesys_sources.json").read_text()
-            assert commit in metadata
+        ) as ctx,
+    ):
+        assert (ctx.workspace / "OBJECTIVE.md").is_file()
+        assert (ctx.workspace / "vllm" / "vllm" / "__init__.py").read_text() == (
+            "__version__ = 'test'\n"
+        )
+        metadata = (ctx.workspace / "_vibesys_sources.json").read_text()
+        assert commit in metadata
 
 
 def test_workspace_source_destination_collision_is_rejected(tmp_path):

--- a/tests/test_workspace_seed.py
+++ b/tests/test_workspace_seed.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import subprocess
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path  # noqa: TC003  # tracked: #288
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -28,10 +28,10 @@ class _FakeBackend:
     def __init__(self) -> None:
         self.sandbox = MagicMock()
 
-    def make_sandbox(self, *_args, **_kwargs):
+    def make_sandbox(self, *_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202  # tracked: #288
         return self.sandbox
 
-    def make_monitor(self, _log_dir):
+    def make_monitor(self, _log_dir):  # noqa: ANN001, ANN202  # tracked: #288
         return None
 
 
@@ -59,13 +59,13 @@ command = ["benchmark"]
 
 
 def _init_git_repo(path: Path) -> None:
-    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(["git", "init", "-q", str(path)], check=True)  # noqa: S603, S607  # tracked: #288
 
 
 def _commit_all(path: Path, message: str = "init") -> str:
-    subprocess.run(["git", "add", "."], cwd=path, check=True)
-    subprocess.run(
-        [
+    subprocess.run(["git", "add", "."], cwd=path, check=True)  # noqa: S607  # tracked: #288
+    subprocess.run(  # noqa: S603  # tracked: #288
+        [  # noqa: S607  # tracked: #288
             "git",
             "-c",
             "user.name=VibeSys Test",
@@ -79,7 +79,7 @@ def _commit_all(path: Path, message: str = "init") -> str:
         check=True,
     )
     return subprocess.run(
-        ["git", "rev-parse", "HEAD"],
+        ["git", "rev-parse", "HEAD"],  # noqa: S607  # tracked: #288
         cwd=path,
         check=True,
         capture_output=True,
@@ -88,7 +88,7 @@ def _commit_all(path: Path, message: str = "init") -> str:
 
 
 @contextmanager
-def _patched_context_dependencies(project_root: Path):
+def _patched_context_dependencies(project_root: Path):  # noqa: ANN202  # tracked: #288
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model", return_value="mock-model"),
@@ -98,7 +98,7 @@ def _patched_context_dependencies(project_root: Path):
         yield
 
 
-def _make_context(input_dir: Path, seed: Path | None = None, **kwargs) -> _RunContext:
+def _make_context(input_dir: Path, seed: Path | None = None, **kwargs) -> _RunContext:  # noqa: ANN003  # tracked: #288
     return create_run_context(
         config={"model": {"name": "claude-sonnet-4-6"}},
         exp_name=kwargs.pop("exp_name", "workspace-seed"),
@@ -115,7 +115,7 @@ def _make_context(input_dir: Path, seed: Path | None = None, **kwargs) -> _RunCo
     )
 
 
-def test_all_repo_example_input_bundles_are_valid(
+def test_all_repo_example_input_bundles_are_valid(  # noqa: ANN201  # tracked: #288
     repo_root: Path, example_input_bundles: tuple[Path, ...]
 ):
     for input_bundle in example_input_bundles:
@@ -123,7 +123,7 @@ def test_all_repo_example_input_bundles_are_valid(
         assert bundle.domain is bundle.manifest.agent.domain
 
 
-def test_manifest_without_workspace_seed_remains_valid(tmp_path):
+def test_manifest_without_workspace_seed_remains_valid(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     bundle = _write_bundle(project_root)
 
@@ -134,7 +134,7 @@ def test_manifest_without_workspace_seed_remains_valid(tmp_path):
     assert loaded.hidden_evaluator_path is None
 
 
-def test_manifest_resolves_seed_relative_to_bundle(tmp_path):
+def test_manifest_resolves_seed_relative_to_bundle(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     seed = project_root / "examples" / "starters" / "queue-rs"
     seed.mkdir(parents=True)
@@ -148,7 +148,7 @@ def test_manifest_resolves_seed_relative_to_bundle(tmp_path):
     assert loaded.workspace_seed_path == seed.resolve()
 
 
-def test_manifest_resolves_workspace_sources(tmp_path):
+def test_manifest_resolves_workspace_sources(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     seed = project_root / "examples" / "starters" / "queue"
     seed.mkdir(parents=True)
@@ -199,7 +199,7 @@ dest = "vllm"
         ),
     ],
 )
-def test_manifest_rejects_invalid_workspace_sources(tmp_path, source_block, error):
+def test_manifest_rejects_invalid_workspace_sources(tmp_path, source_block, error):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     bundle = _write_bundle(
         project_root,
@@ -215,7 +215,7 @@ def test_manifest_rejects_invalid_workspace_sources(tmp_path, source_block, erro
         load_input_bundle(bundle, project_root=project_root)
 
 
-def test_manifest_rejects_duplicate_workspace_source_destinations(tmp_path):
+def test_manifest_rejects_duplicate_workspace_source_destinations(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     bundle = _write_bundle(
         project_root,
@@ -240,7 +240,7 @@ dest = "src"
         load_input_bundle(bundle, project_root=project_root)
 
 
-def test_manifest_resolves_evaluator_relative_to_bundle(tmp_path):
+def test_manifest_resolves_evaluator_relative_to_bundle(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     evaluator = project_root / "examples" / "evaluators" / "queue"
     evaluator.mkdir(parents=True)
@@ -254,7 +254,7 @@ def test_manifest_resolves_evaluator_relative_to_bundle(tmp_path):
     assert loaded.evaluator_path == evaluator.resolve()
 
 
-def test_manifest_resolves_hidden_evaluator_relative_to_bundle(tmp_path):
+def test_manifest_resolves_hidden_evaluator_relative_to_bundle(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     evaluator = project_root / "examples" / "evaluators" / "tracelab-replay"
     evaluator.mkdir(parents=True)
@@ -271,12 +271,12 @@ def test_manifest_resolves_hidden_evaluator_relative_to_bundle(tmp_path):
 @pytest.mark.parametrize(
     ("seed_value", "error"),
     [
-        ("/tmp/candidate", "seed must be relative"),
+        ("/tmp/candidate", "seed must be relative"),  # noqa: S108  # tracked: #288
         ("../../../outside", "must resolve inside"),
         ("../../starters/missing", "path does not exist"),
     ],
 )
-def test_manifest_rejects_invalid_seed_paths(tmp_path, seed_value, error):
+def test_manifest_rejects_invalid_seed_paths(tmp_path, seed_value, error):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     bundle = _write_bundle(
         project_root,
@@ -287,7 +287,7 @@ def test_manifest_rejects_invalid_seed_paths(tmp_path, seed_value, error):
         load_input_bundle(bundle, project_root=project_root)
 
 
-def test_manifest_rejects_seed_file(tmp_path):
+def test_manifest_rejects_seed_file(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     seed = project_root / "examples" / "starters" / "not-a-directory"
     seed.parent.mkdir(parents=True)
@@ -301,7 +301,7 @@ def test_manifest_rejects_seed_file(tmp_path):
         load_input_bundle(bundle, project_root=project_root)
 
 
-def test_manifest_rejects_seed_symlink_that_escapes_starters(tmp_path):
+def test_manifest_rejects_seed_symlink_that_escapes_starters(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     outside = project_root / "outside"
     outside.mkdir(parents=True)
@@ -317,7 +317,7 @@ def test_manifest_rejects_seed_symlink_that_escapes_starters(tmp_path):
         load_input_bundle(bundle, project_root=project_root)
 
 
-def test_manifest_rejects_unknown_workspace_keys(tmp_path):
+def test_manifest_rejects_unknown_workspace_keys(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     seed = project_root / "examples" / "starters" / "queue"
     seed.mkdir(parents=True)
@@ -333,12 +333,12 @@ def test_manifest_rejects_unknown_workspace_keys(tmp_path):
 @pytest.mark.parametrize(
     ("source_value", "error"),
     [
-        ("/tmp/evaluator", "source must be relative"),
+        ("/tmp/evaluator", "source must be relative"),  # noqa: S108  # tracked: #288
         ("../../../outside", "must resolve inside"),
         ("../../evaluators/missing", "path does not exist"),
     ],
 )
-def test_manifest_rejects_invalid_evaluator_paths(tmp_path, source_value, error):
+def test_manifest_rejects_invalid_evaluator_paths(tmp_path, source_value, error):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     bundle = _write_bundle(
         project_root,
@@ -349,7 +349,7 @@ def test_manifest_rejects_invalid_evaluator_paths(tmp_path, source_value, error)
         load_input_bundle(bundle, project_root=project_root)
 
 
-def test_manifest_rejects_evaluator_file(tmp_path):
+def test_manifest_rejects_evaluator_file(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     evaluator = project_root / "examples" / "evaluators" / "not-a-directory"
     evaluator.parent.mkdir(parents=True)
@@ -363,7 +363,7 @@ def test_manifest_rejects_evaluator_file(tmp_path):
         load_input_bundle(bundle, project_root=project_root)
 
 
-def test_manifest_rejects_evaluator_symlink_that_escapes_evaluators(tmp_path):
+def test_manifest_rejects_evaluator_symlink_that_escapes_evaluators(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     outside = project_root / "outside"
     outside.mkdir(parents=True)
@@ -379,7 +379,7 @@ def test_manifest_rejects_evaluator_symlink_that_escapes_evaluators(tmp_path):
         load_input_bundle(bundle, project_root=project_root)
 
 
-def test_manifest_rejects_unknown_evaluator_keys(tmp_path):
+def test_manifest_rejects_unknown_evaluator_keys(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     evaluator = project_root / "examples" / "evaluators" / "queue"
     evaluator.mkdir(parents=True)
@@ -395,12 +395,12 @@ def test_manifest_rejects_unknown_evaluator_keys(tmp_path):
 @pytest.mark.parametrize(
     ("source_value", "error"),
     [
-        ("/tmp/evaluator", "source must be relative"),
+        ("/tmp/evaluator", "source must be relative"),  # noqa: S108  # tracked: #288
         ("../../../outside", "must resolve inside"),
         ("../../evaluators/missing", "path does not exist"),
     ],
 )
-def test_manifest_rejects_invalid_hidden_evaluator_paths(tmp_path, source_value, error):
+def test_manifest_rejects_invalid_hidden_evaluator_paths(tmp_path, source_value, error):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     bundle = _write_bundle(
         project_root,
@@ -411,7 +411,7 @@ def test_manifest_rejects_invalid_hidden_evaluator_paths(tmp_path, source_value,
         load_input_bundle(bundle, project_root=project_root)
 
 
-def test_manifest_rejects_unknown_hidden_evaluator_keys(tmp_path):
+def test_manifest_rejects_unknown_hidden_evaluator_keys(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     evaluator = project_root / "examples" / "evaluators" / "queue"
     evaluator.mkdir(parents=True)
@@ -424,7 +424,7 @@ def test_manifest_rejects_unknown_hidden_evaluator_keys(tmp_path):
         load_input_bundle(bundle, project_root=project_root)
 
 
-def test_fresh_workspace_materializes_seed_and_preserves_it_in_initial_commit(tmp_path):
+def test_fresh_workspace_materializes_seed_and_preserves_it_in_initial_commit(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     project_root.mkdir()
     _init_git_repo(project_root)
@@ -472,7 +472,7 @@ def test_fresh_workspace_materializes_seed_and_preserves_it_in_initial_commit(tm
         assert "target/\n" in (ctx.workspace / ".gitignore").read_text()
 
         tracked = subprocess.run(
-            ["git", "ls-files"],
+            ["git", "ls-files"],  # noqa: S607  # tracked: #288
             cwd=ctx.workspace,
             check=True,
             capture_output=True,
@@ -487,7 +487,7 @@ def test_fresh_workspace_materializes_seed_and_preserves_it_in_initial_commit(tm
         assert ctx.trusted_input_changes() == ["_evaluator/queue/checker.go"]
 
 
-def test_hidden_evaluator_stays_out_of_workspace_and_agent_project_mount(tmp_path):
+def test_hidden_evaluator_stays_out_of_workspace_and_agent_project_mount(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     _init_git_repo(project_root)
     bundle = _write_bundle(
@@ -524,7 +524,7 @@ def test_hidden_evaluator_stays_out_of_workspace_and_agent_project_mount(tmp_pat
             ).exists()
 
 
-def test_fresh_workspace_materializes_git_source_and_strips_nested_git(tmp_path):
+def test_fresh_workspace_materializes_git_source_and_strips_nested_git(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     project_root.mkdir()
     _init_git_repo(project_root)
@@ -572,7 +572,7 @@ def test_fresh_workspace_materializes_git_source_and_strips_nested_git(tmp_path)
         assert commit in metadata
 
         tracked = subprocess.run(
-            ["git", "ls-files"],
+            ["git", "ls-files"],  # noqa: S607  # tracked: #288
             cwd=ctx.workspace,
             check=True,
             capture_output=True,
@@ -582,7 +582,7 @@ def test_fresh_workspace_materializes_git_source_and_strips_nested_git(tmp_path)
         assert "vllm/.git" not in tracked
 
 
-def test_fresh_workspace_materializes_git_source_without_seed(tmp_path):
+def test_fresh_workspace_materializes_git_source_without_seed(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """Sources must survive the input-bundle copy when no seed is declared."""
     project_root = tmp_path / "project"
     project_root.mkdir()
@@ -624,7 +624,7 @@ def test_fresh_workspace_materializes_git_source_without_seed(tmp_path):
         assert commit in metadata
 
 
-def test_workspace_source_destination_collision_is_rejected(tmp_path):
+def test_workspace_source_destination_collision_is_rejected(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     source_repo = tmp_path / "source"
     source_repo.mkdir()
     _init_git_repo(source_repo)
@@ -669,7 +669,7 @@ def test_workspace_source_destination_collision_is_rejected(tmp_path):
         workspace_files.setup(plan, existing=False)
 
 
-def test_input_collision_is_rejected_before_overlay(tmp_path):
+def test_input_collision_is_rejected_before_overlay(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     seed = tmp_path / "seed"
     input_dir = tmp_path / "input"
     workspace = tmp_path / "workspace"
@@ -697,7 +697,7 @@ def test_input_collision_is_rejected_before_overlay(tmp_path):
     assert not (workspace / "input-only.txt").exists()
 
 
-def test_resume_does_not_refresh_workspace_from_seed(tmp_path):
+def test_resume_does_not_refresh_workspace_from_seed(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     project_root.mkdir()
     _init_git_repo(project_root)
@@ -754,7 +754,7 @@ def test_resume_does_not_refresh_workspace_from_seed(tmp_path):
         ("plain", "vibesys.loops.plain.loop.run_plain_loop"),
     ],
 )
-def test_cli_forwards_workspace_sources_to_every_outer_loop(tmp_path, outer_loop, runner_path):
+def test_cli_forwards_workspace_sources_to_every_outer_loop(tmp_path, outer_loop, runner_path):  # noqa: ANN001, ANN201  # tracked: #288
     project_root = tmp_path / "project"
     seed = project_root / "examples" / "starters" / "queue"
     seed.mkdir(parents=True)
@@ -801,7 +801,7 @@ def test_cli_forwards_workspace_sources_to_every_outer_loop(tmp_path, outer_loop
         assert runner.call_args.kwargs["domain"] is DomainName.GENERIC
 
 
-def test_workspace_source_with_nested_git_is_rejected_when_tracking(tmp_path):
+def test_workspace_source_with_nested_git_is_rejected_when_tracking(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """strip_git=false under git tracking would snapshot a bare gitlink."""
     project_root = tmp_path / "project"
     project_root.mkdir()
@@ -826,12 +826,12 @@ def test_workspace_source_with_nested_git_is_rejected_when_tracking(tmp_path):
         strip_git=False,
     )
 
-    with _patched_context_dependencies(project_root):
+    with _patched_context_dependencies(project_root):  # noqa: SIM117  # tracked: #288
         with pytest.raises(ConfigurationError, match="strip_git=false"):
             _make_context(input_dir, workspace_sources=(source,), git_tracking=True)
 
 
-def test_workspace_source_dest_colliding_with_excluded_dirs_is_rejected(tmp_path):
+def test_workspace_source_dest_colliding_with_excluded_dirs_is_rejected(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     """A dest under an excluded name would be invisible to copies and tracking."""
     source_repo = tmp_path / "source"
     source_repo.mkdir()

--- a/uv.lock
+++ b/uv.lock
@@ -4490,7 +4490,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.411" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "ruff", specifier = ">=0.6" },
+    { name = "ruff", specifier = "==0.15.12" },
     { name = "vibesys", extras = ["omnigent"] },
 ]
 test = [


### PR DESCRIPTION
Closes #295
Part of #293
Part of #288

## Problem

`[tool.ruff.lint]` only selects `E, F, I, UP, B, W`. That misses whole classes
of bugs and hazards ruff can catch cheaply: bandit-style security checks (`S`),
blanket-except and error-handling patterns (`BLE`, `TRY`), missing type
annotations (`ANN`), complexity (`C901`, `PL`), and pathlib/datetime/logging
footguns (`PTH`, `DTZ`, `LOG`, `G`). `docs/coding-best-practices.md` already
asks for typed contracts, explicit failure modes, and small well-scoped
functions; ruff can enforce a meaningful slice of that automatically instead of
relying on review alone.

`ruff>=0.6` is also an open-ended floating bound: a routine `uv lock` refresh
could pick up a newer ruff with new default-on rules or changed autofix
behavior and silently change what CI enforces.

## Solution

Three commits: config, safe autofixes, then a per-site suppression baseline.

### Config (commit 1)

Expanded `select` to the families below, added `mccabe.max-complexity = 10`,
`pydocstyle.convention = "google"`, and a `flake8-type-checking`
`runtime-evaluated-base-classes = ["pydantic.BaseModel"]` entry so `TC` does
not try to move Pydantic field types into `TYPE_CHECKING` blocks, which would
break them at runtime. Pinned `ruff==0.15.12` (the version already resolved in
`uv.lock`) and refreshed the lock.

**Newly enabled:** `SIM, RUF, C4, PIE, ISC, RSE, INT, FLY, PERF, FURB, RET, A,
DTZ, LOG, G, N, PTH, YTT, EXE, ASYNC, ERA, T10, T20, TID, ICN, INP, FBT, FIX,
TD, PGH, ANN, BLE, SLF, C901, PL, S, PT, ARG, TRY, TC, D`

**Deliberately not enabled:**

| Family | Reason |
|---|---|
| `COM`, `Q` | Formatter conflict: both fight `ruff format`'s own comma and quote handling. |
| `preview = true` | Preview instability: preview rules churn across releases, which would defeat the version pin. |
| `FA` | Pydantic runtime-annotation hazard, and `from __future__ import annotations` is moot at py312. |
| `EM`, `CPY`, `DOC` | High noise-to-signal here (raw exception message strings, copyright headers, docstring content duplicating `D`); worth revisiting deliberately, not adopting sight-unseen. |
| `DJ`, `AIR`, `PD`, `FAST`, `NPY`, `PYI` | Inapplicable frameworks: no Django, Airflow, pandas, FastAPI, NumPy, or `.pyi` stubs in this repo. |

### Scoping (commit 1)

`scripts/check_lint.sh` runs `ruff check .`, i.e. the whole repo, so the new
rules had to be scoped to code this repo actually owns:

- **`resources/skills/` → `extend-exclude`.** Vendored reference material:
  submodule checkouts of vllm/sglang/TensorRT-LLM plus copied reference docs.
  The existing `UP040`/`UP046`/`UP047` comment already documents this subtree
  as not owned by VibeSys.
- **`examples/` → `per-file-ignores` for the new families only.** It ships
  candidate reference implementations, benchmark harnesses, and vendored
  submodules (transformers, DeathStarBench, TensorRT-LLM, Show-o, train-ticket,
  TraceLab) rather than first-party framework code. The pre-existing
  `E, F, I, UP, B, W` baseline, which it already passes, stays enforced; only
  the newly added families are skipped.
- **`resources/profilers/` gets the full rule set, same as `src/`.** An earlier
  revision of this PR carved it out; that did not hold up on review.
  `docs/extending-profilers.md` documents
  `resources/profilers/<kind>/server.py` as the extension point contributors
  are expected to write, so it is first-party maintained code, not vendored or
  reference material. It also launches subprocesses inside sandboxes, which
  makes `BLE`, `S`, and `ANN` *more* valuable there than average, not less. It
  is only 15 Python files.

`tests/**` and `libs/*/tests/**` get the four standard pytest per-file-ignores:
`S101` (assert), `PLR2004` (magic values), `D` (docstrings), `INP001` (implicit
namespace package).

### Safe autofixes (commit 2)

`ruff check --fix .` (safe fixes only, no `--unsafe-fixes`) plus
`ruff format .`. 108 fixes, all mechanical: `SIM117` nested-`with` collapsing,
`RUF022` `__all__` sorting, `PERF102` redundant dict iterator, import sorting,
and formatter whitespace.

### Suppression baseline (commit 3)

6,412 violations remained. Every one got a per-site
`# noqa: <CODE>  # tracked: #288` comment. No rule went into the global
`ignore` list, and no `per-file-ignores` were added beyond commit 1's.
Generated with `ruff check --add-noqa`, iterated against
`ruff check --fix` / `ruff format` to a fixed point.

**Ratchet mechanism:** `RUF100` (unused-noqa) and `PGH003`/`PGH004` (blanket
`type: ignore` / bare `noqa`) are enabled. When someone fixes an underlying
violation, its now-unused suppression becomes a `RUF100` CI failure and must be
deleted. The baseline can only shrink, never silently persist past the code that
justified it. The `# tracked: #288` marker is used instead of `TODO`/`FIXME`
precisely because `FIX002`/`TD002`/`TD003` are now enabled and would flag the
baseline itself.

**One site shape differs, deliberately.** In `analyze_nsys.py`, nine section
dividers of the form `# Subcommand: export` are false-positive `ERA001` hits
(`Subcommand: export` parses as an annotated assignment). Appending
`# noqa: ERA001  # tracked: #288` to such a line changes the comment text
enough that `ERA001` stops matching, which makes the directive unused and trips
`RUF100` instead, so inline suppression is self-defeating. Those nine carry a
bare `# noqa: ERA001` with the `# tracked: #288` marker on the preceding line.
This deliberately avoids a per-file-ignore, which would *not* ratchet; `RUF100`
still guards these nine sites.

**Commit 3 is mechanical suppression with no behavior change.** No types were
weakened (no `Any` added to silence `ANN`), no code deleted, no logic
restructured.

## Verification

Baseline recorded against `origin/main` before any change, in a separate
worktree: **2948 passed, 1 skipped**.

### Correctness properties

- **AST equivalence.** Commit 3 was verified by comparing
  `ast.dump(ast.parse(...))` for all **338** tracked Python files against the
  pre-suppression commit: **0 mismatches**. This is what proves the added
  comments (and the line reflow they trigger, plus the hand-cleaned stray
  fragments) changed no logic.
- `uv run pytest` matches `origin/main` exactly: no regressions, no new skips.
- Suppressions live only in per-site `# noqa` comments; the global `ignore` list
  still contains exactly the four pre-existing documented entries.
- `RUF100`/`PGH003`/`PGH004` enabled, so stale suppressions fail CI.

### Testing

```
./scripts/check_format.sh   # All checks passed! (280 files already formatted)
./scripts/check_lint.sh     # All checks passed!
./scripts/check_types.sh    # 0 errors, 0 warnings, 0 informations
uv run pytest               # 2948 passed, 1 skipped  (matches origin/main)
```

Violations after safe autofixes, before suppression:

| Tree | Violations |
|---|---|
| `src` | 1,251 |
| `tests` | 3,998 |
| `libs` (4 packages, src + tests) | 835 |
| `resources/profilers` | 328 |
| `examples`, `resources/skills` | 0 (scoped out of new rules; prior baseline still enforced) |
| **Total** | **6,412** |

`ruff check .` reports zero violations after suppression.
