### PR TITLE
Bring tests/ under pyright with a ratcheted baseline

### DIFF
--- a/libs/vs-feature-flags/tests/test_core.py
+++ b/libs/vs-feature-flags/tests/test_core.py
@@ -70,4 +70,4 @@ def test_definitions_mapping_is_read_only():
     registry = _registry()
 
     with pytest.raises(TypeError):
-        registry.definitions[ExampleFlag.NEW_LOOP] = FeatureDefinition(description="Changed.")
+        registry.definitions[ExampleFlag.NEW_LOOP] = FeatureDefinition(description="Changed.")  # pyright: ignore[reportIndexIssue]  # tracked: #297

--- a/libs/vs-issue-board/tests/test_issue_board_core.py
+++ b/libs/vs-issue-board/tests/test_issue_board_core.py
@@ -322,10 +322,10 @@ class TestStateTransitions:
             issue.id, IssueStatus.IN_PROGRESS, actor="loop", iteration=1, note="claimed"
         )
         reloaded = store.get(issue.id)
-        assert reloaded.status == IssueStatus.IN_PROGRESS
-        assert len(reloaded.history) == 2
-        assert reloaded.history[-1].action == "open->in_progress"
-        assert reloaded.history[-1].note == "claimed"
+        assert reloaded.status == IssueStatus.IN_PROGRESS  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert len(reloaded.history) == 2  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert reloaded.history[-1].action == "open->in_progress"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert reloaded.history[-1].note == "claimed"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     def test_update_status_to_closed_records_closed_iter(self, tmp_path):
         store = _make_store(tmp_path)
@@ -333,8 +333,8 @@ class TestStateTransitions:
         store.update_status(issue.id, IssueStatus.IN_PROGRESS, actor="loop", iteration=2)
         store.update_status(issue.id, IssueStatus.CLOSED, actor="judge", iteration=2, note="passed")
         reloaded = store.get(issue.id)
-        assert reloaded.status == IssueStatus.CLOSED
-        assert reloaded.closed_iter == 2
+        assert reloaded.status == IssueStatus.CLOSED  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert reloaded.closed_iter == 2  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     def test_update_status_blocked_records_closed_iter(self, tmp_path):
         store = _make_store(tmp_path)
@@ -343,8 +343,8 @@ class TestStateTransitions:
             issue.id, IssueStatus.BLOCKED, actor="loop", iteration=3, note="exhausted retries"
         )
         reloaded = store.get(issue.id)
-        assert reloaded.status == IssueStatus.BLOCKED
-        assert reloaded.closed_iter == 3
+        assert reloaded.status == IssueStatus.BLOCKED  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert reloaded.closed_iter == 3  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     def test_increment_attempts_appends_event(self, tmp_path):
         store = _make_store(tmp_path)
@@ -353,8 +353,8 @@ class TestStateTransitions:
         store.increment_attempts(issue.id, actor="implementer", iteration=1, note="first try")
         store.increment_attempts(issue.id, actor="implementer", iteration=1, note="retry")
         reloaded = store.get(issue.id)
-        assert reloaded.attempts == 2
-        assert sum(1 for e in reloaded.history if e.action == "attempt") == 2
+        assert reloaded.attempts == 2  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert sum(1 for e in reloaded.history if e.action == "attempt") == 2  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     def test_update_unknown_id_raises(self, tmp_path):
         store = _make_store(tmp_path)
@@ -412,13 +412,13 @@ class TestNextOpen:
         feature = _create(store, type=IssueType.FEATURE, title="feature")
         bug = _create(store, type=IssueType.BUG, title="bug")
         first = store.next_open()
-        assert first.id == bug.id
+        assert first.id == bug.id  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
         store.update_status(bug.id, IssueStatus.CLOSED, actor="x", iteration=1)
         second = store.next_open()
-        assert second.id == feature.id
+        assert second.id == feature.id  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
         store.update_status(feature.id, IssueStatus.CLOSED, actor="x", iteration=1)
         third = store.next_open()
-        assert third.id == perf.id
+        assert third.id == perf.id  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     def test_next_open_fifo_within_type(self, tmp_path):
         store = _make_store(tmp_path)
@@ -428,11 +428,11 @@ class TestNextOpen:
         b = _create(store, type=IssueType.BUG, title="second bug")
         time.sleep(0.005)
         c = _create(store, type=IssueType.BUG, title="third bug")
-        assert store.next_open().id == a.id
+        assert store.next_open().id == a.id  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
         store.update_status(a.id, IssueStatus.CLOSED, actor="x", iteration=1)
-        assert store.next_open().id == b.id
+        assert store.next_open().id == b.id  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
         store.update_status(b.id, IssueStatus.CLOSED, actor="x", iteration=1)
-        assert store.next_open().id == c.id
+        assert store.next_open().id == c.id  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     def test_next_open_skips_in_progress(self, tmp_path):
         store = _make_store(tmp_path)
@@ -440,7 +440,7 @@ class TestNextOpen:
         b = _create(store, type=IssueType.BUG, title="open")
         store.update_status(a.id, IssueStatus.IN_PROGRESS, actor="loop", iteration=1)
         first = store.next_open()
-        assert first.id == b.id
+        assert first.id == b.id  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
 
 # ---------------------------------------------------------------------------
@@ -490,8 +490,8 @@ class TestEventPayload:
         )
         reloaded = store.get(issue.id)
         # create + update_status + increment_attempts = 3 events
-        assert len(reloaded.history) == 3
-        for evt in reloaded.history:
+        assert len(reloaded.history) == 3  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        for evt in reloaded.history:  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
             assert evt.payload is None
 
     def test_load_old_json_without_payload_key(self, tmp_path):
@@ -553,9 +553,9 @@ class TestReopenBlocked:
             note="exhausted",
         )
         before = store.get(a.id)
-        assert before.status == IssueStatus.BLOCKED
-        assert before.attempts == 2
-        assert before.closed_iter == 1
+        assert before.status == IssueStatus.BLOCKED  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert before.attempts == 2  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert before.closed_iter == 1  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
         reopened = store.reopen_blocked(
             actor="loop:resume",
@@ -565,10 +565,10 @@ class TestReopenBlocked:
         assert reopened == [a.id]
 
         after = store.get(a.id)
-        assert after.status == IssueStatus.OPEN
-        assert after.attempts == 0
-        assert after.closed_iter is None
-        last = after.history[-1]
+        assert after.status == IssueStatus.OPEN  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert after.attempts == 0  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert after.closed_iter is None  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        last = after.history[-1]  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
         assert last.action == "blocked->open"
         assert last.actor == "loop:resume"
         assert last.iteration == 2
@@ -594,9 +594,9 @@ class TestReopenBlocked:
 
         reopened = store.reopen_blocked(actor="loop:resume", iteration=2)
         assert reopened == [blocked.id]
-        assert store.get(blocked.id).status == IssueStatus.OPEN
-        assert store.get(open_issue.id).status == IssueStatus.OPEN
-        assert store.get(closed.id).status == IssueStatus.CLOSED
+        assert store.get(blocked.id).status == IssueStatus.OPEN  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert store.get(open_issue.id).status == IssueStatus.OPEN  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert store.get(closed.id).status == IssueStatus.CLOSED  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     def test_reopen_blocked_no_blocked_is_noop(self, tmp_path):
         store = _make_store(tmp_path)
@@ -616,10 +616,10 @@ class TestReopenBlocked:
 
         fresh = _make_store(tmp_path)
         reloaded = fresh.get(a.id)
-        assert reloaded.status == IssueStatus.OPEN
-        assert reloaded.attempts == 0
-        assert reloaded.closed_iter is None
-        assert reloaded.history[-1].action == "blocked->open"
+        assert reloaded.status == IssueStatus.OPEN  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert reloaded.attempts == 0  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert reloaded.closed_iter is None  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert reloaded.history[-1].action == "blocked->open"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     def test_reopen_blocked_picked_by_next_open(self, tmp_path):
         store = _make_store(tmp_path)

--- a/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
@@ -345,7 +345,7 @@ class ModalSandbox(BaseSandbox):
 
         # _workspace_volume is created by start() before _create_container().
         volumes: dict[str | os.PathLike[str], modal.Volume | modal.CloudBucketMount] = {
-            self._CONTAINER_ROOT: self._workspace_volume  # pyright: ignore[reportOptionalMemberAccess,reportAssignmentType]
+            self._CONTAINER_ROOT: self._workspace_volume  # pyright: ignore[reportAssignmentType]
         }
         if self._model_volume_name:
             model_vol = modal.Volume.from_name(self._model_volume_name).read_only()

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -324,7 +324,7 @@ class TestSetupFns:
         s = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
-            setup_fns=[fn],
+            setup_fns=[fn],  # pyright: ignore[reportArgumentType]  # tracked: #297
         )
         s.start()
         assert invocations == [s]
@@ -347,7 +347,7 @@ class TestSetupFns:
         s = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
-            setup_fns=[fn],
+            setup_fns=[fn],  # pyright: ignore[reportArgumentType]  # tracked: #297
         )
         s.start()
         s.start()
@@ -373,7 +373,7 @@ class TestSetupFns:
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="test-image",
-            setup_fns=[fail_setup],
+            setup_fns=[fail_setup],  # pyright: ignore[reportArgumentType]  # tracked: #297
         )
 
         try:
@@ -415,7 +415,7 @@ class TestSetupFns:
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="test-image",
-            setup_fns=[fail_setup],
+            setup_fns=[fail_setup],  # pyright: ignore[reportArgumentType]  # tracked: #297
         )
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ typeCheckingMode = "strict"
 reportUnknownMemberType = "none"
 reportUnknownVariableType = "none"
 reportUnknownArgumentType = "none"
+# Makes every `# pyright: ignore[...]` a ratchet rather than a permanent hole:
+# once the underlying error is fixed, the now-dead suppression becomes an error
+# itself and has to be removed. Set at the top level so it covers `src` and
+# `libs/*/src` too, not just the test paths whose baseline relies on it.
+reportUnnecessaryTypeIgnoreComment = "error"
 pythonVersion = "3.12"
 include = ["src", "tests", "libs/vs-feature-flags/src", "libs/vs-feature-flags/tests", "libs/vs-github/src", "libs/vs-github/tests", "libs/vs-issue-board/src", "libs/vs-issue-board/tests", "libs/vs-sandbox/src", "libs/vs-sandbox/tests"]
 # `tests` and `libs/*/tests` are included above so the strict checker actually
@@ -109,7 +114,7 @@ include = ["src", "tests", "libs/vs-feature-flags/src", "libs/vs-feature-flags/t
 # meant to police in test code rather than latent bugs. Per-execution-environment
 # `typeCheckingMode` is documented but not honored by pyright 1.1.411 (verified:
 # setting it to "off"/"standard" on a scoped environment below left the error
-# count unchanged), so the relaxation is spelled out rule by rule instead. Two
+# count unchanged), so the relaxation is spelled out explicitly instead. Two
 # tiers, both scoped to test paths only -- `src` and `libs/*/src` above stay at
 # unmodified strict:
 #   1. Declaration-completeness rules that pytest's own conventions make
@@ -123,27 +128,31 @@ include = ["src", "tests", "libs/vs-feature-flags/src", "libs/vs-feature-flags/t
 #      objects expose attributes (call_args, assert_called_once_with, ...)
 #      that their static type doesn't declare (reportAttributeAccessIssue,
 #      reportFunctionMemberAccess).
-#   2. A suppress-and-track baseline for the remaining, genuinely
-#      strict-mode-independent findings (reportArgumentType,
+#      These rules are categorically inapplicable to test code, so they are
+#      relaxed at the rule level for these paths.
+#   2. Everything else stays at the strict default here and is instead
+#      suppressed per site with `# pyright: ignore[<rule>]` carrying a
+#      `tracked: #297` marker. Those findings (reportArgumentType,
 #      reportOptionalMemberAccess, reportOperatorIssue, reportReturnType,
 #      reportCallIssue, reportOptionalOperand, reportIndexIssue,
-#      reportAbstractUsage: ~300 pre-existing instances spread across most
-#      test files). These can be real bugs, not just missing declarations,
-#      but fixing them file by file is a separate, larger effort than
-#      turning the checker on; see #293 for the same suppress-then-tighten
-#      approach applied to ruff. Tracked for follow-up burn-down rather than
-#      fixed here.
+#      reportAbstractUsage) can be real bugs rather than missing
+#      declarations, so they must not become invisible: a rule-level "none"
+#      would also silently accept every *future* violation in test code.
+#      Per-site ignores plus reportUnnecessaryTypeIgnoreComment above give a
+#      baseline that can only shrink, mirroring the `# noqa: CODE` + RUF100
+#      approach used for the ruff rule expansion under the same parent.
+#      Grep `tracked: #297` for the remaining burn-down list.
 executionEnvironments = [
     { root = "libs/vs-feature-flags/src" },
     { root = "libs/vs-github/src" },
     { root = "libs/vs-issue-board/src" },
     { root = "libs/vs-sandbox/src" },
     { root = "src" },
-    { root = "tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none", reportArgumentType = "none", reportOptionalMemberAccess = "none", reportOperatorIssue = "none", reportReturnType = "none", reportCallIssue = "none", reportOptionalOperand = "none", reportIndexIssue = "none", reportAbstractUsage = "none" },
-    { root = "libs/vs-feature-flags/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none", reportArgumentType = "none", reportOptionalMemberAccess = "none", reportOperatorIssue = "none", reportReturnType = "none", reportCallIssue = "none", reportOptionalOperand = "none", reportIndexIssue = "none", reportAbstractUsage = "none" },
-    { root = "libs/vs-github/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none", reportArgumentType = "none", reportOptionalMemberAccess = "none", reportOperatorIssue = "none", reportReturnType = "none", reportCallIssue = "none", reportOptionalOperand = "none", reportIndexIssue = "none", reportAbstractUsage = "none" },
-    { root = "libs/vs-issue-board/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none", reportArgumentType = "none", reportOptionalMemberAccess = "none", reportOperatorIssue = "none", reportReturnType = "none", reportCallIssue = "none", reportOptionalOperand = "none", reportIndexIssue = "none", reportAbstractUsage = "none" },
-    { root = "libs/vs-sandbox/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none", reportArgumentType = "none", reportOptionalMemberAccess = "none", reportOperatorIssue = "none", reportReturnType = "none", reportCallIssue = "none", reportOptionalOperand = "none", reportIndexIssue = "none", reportAbstractUsage = "none" },
+    { root = "tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none" },
+    { root = "libs/vs-feature-flags/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none" },
+    { root = "libs/vs-github/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none" },
+    { root = "libs/vs-issue-board/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none" },
+    { root = "libs/vs-sandbox/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none" },
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,13 +102,48 @@ reportUnknownMemberType = "none"
 reportUnknownVariableType = "none"
 reportUnknownArgumentType = "none"
 pythonVersion = "3.12"
-include = ["src", "libs/vs-feature-flags/src", "libs/vs-github/src", "libs/vs-issue-board/src", "libs/vs-sandbox/src"]
+include = ["src", "tests", "libs/vs-feature-flags/src", "libs/vs-feature-flags/tests", "libs/vs-github/src", "libs/vs-github/tests", "libs/vs-issue-board/src", "libs/vs-issue-board/tests", "libs/vs-sandbox/src", "libs/vs-sandbox/tests"]
+# `tests` and `libs/*/tests` are included above so the strict checker actually
+# sees them (previously they were unchecked entirely). Running them at full
+# strict produced ~4.4k errors, almost all from patterns strict mode was never
+# meant to police in test code rather than latent bugs. Per-execution-environment
+# `typeCheckingMode` is documented but not honored by pyright 1.1.411 (verified:
+# setting it to "off"/"standard" on a scoped environment below left the error
+# count unchanged), so the relaxation is spelled out rule by rule instead. Two
+# tiers, both scoped to test paths only -- `src` and `libs/*/src` above stay at
+# unmodified strict:
+#   1. Declaration-completeness rules that pytest's own conventions make
+#      unsatisfiable: fixture parameters (tmp_path, monkeypatch, custom
+#      fixtures) are injected by name and have no annotation to check
+#      (reportMissingParameterType, reportUnknownParameterType,
+#      reportUnknownLambdaType, reportMissingTypeArgument); tests
+#      intentionally reach into module-private state and monkeypatch a
+#      module's own imported names to assert on internals
+#      (reportPrivateUsage, reportPrivateImportUsage); and unittest.mock
+#      objects expose attributes (call_args, assert_called_once_with, ...)
+#      that their static type doesn't declare (reportAttributeAccessIssue,
+#      reportFunctionMemberAccess).
+#   2. A suppress-and-track baseline for the remaining, genuinely
+#      strict-mode-independent findings (reportArgumentType,
+#      reportOptionalMemberAccess, reportOperatorIssue, reportReturnType,
+#      reportCallIssue, reportOptionalOperand, reportIndexIssue,
+#      reportAbstractUsage: ~300 pre-existing instances spread across most
+#      test files). These can be real bugs, not just missing declarations,
+#      but fixing them file by file is a separate, larger effort than
+#      turning the checker on; see #293 for the same suppress-then-tighten
+#      approach applied to ruff. Tracked for follow-up burn-down rather than
+#      fixed here.
 executionEnvironments = [
     { root = "libs/vs-feature-flags/src" },
     { root = "libs/vs-github/src" },
     { root = "libs/vs-issue-board/src" },
     { root = "libs/vs-sandbox/src" },
     { root = "src" },
+    { root = "tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none", reportArgumentType = "none", reportOptionalMemberAccess = "none", reportOperatorIssue = "none", reportReturnType = "none", reportCallIssue = "none", reportOptionalOperand = "none", reportIndexIssue = "none", reportAbstractUsage = "none" },
+    { root = "libs/vs-feature-flags/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none", reportArgumentType = "none", reportOptionalMemberAccess = "none", reportOperatorIssue = "none", reportReturnType = "none", reportCallIssue = "none", reportOptionalOperand = "none", reportIndexIssue = "none", reportAbstractUsage = "none" },
+    { root = "libs/vs-github/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none", reportArgumentType = "none", reportOptionalMemberAccess = "none", reportOperatorIssue = "none", reportReturnType = "none", reportCallIssue = "none", reportOptionalOperand = "none", reportIndexIssue = "none", reportAbstractUsage = "none" },
+    { root = "libs/vs-issue-board/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none", reportArgumentType = "none", reportOptionalMemberAccess = "none", reportOperatorIssue = "none", reportReturnType = "none", reportCallIssue = "none", reportOptionalOperand = "none", reportIndexIssue = "none", reportAbstractUsage = "none" },
+    { root = "libs/vs-sandbox/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none", reportArgumentType = "none", reportOptionalMemberAccess = "none", reportOperatorIssue = "none", reportReturnType = "none", reportCallIssue = "none", reportOptionalOperand = "none", reportIndexIssue = "none", reportAbstractUsage = "none" },
 ]
 
 [tool.uv]

--- a/src/vibesys/loops/plain/loop.py
+++ b/src/vibesys/loops/plain/loop.py
@@ -429,7 +429,7 @@ def run_plain_loop(
         # so every successful save (including tool-created issues from
         # judge/perf_eval) re-renders the human-readable mirror.
         # Forward-declare `store` so the lambda's late binding resolves.
-        store: IssueBoard  # type: ignore[no-redef]
+        store: IssueBoard
         store = IssueBoard(
             store_path,
             on_change=lambda: render_all(issues_dir, store),

--- a/tests/_agent_cli/fixtures/agents.py
+++ b/tests/_agent_cli/fixtures/agents.py
@@ -41,7 +41,14 @@ class StubAgent(CodingAgent):
         self.calls: list[dict[str, Any]] = []
         self.generate_calls: list[dict[str, Any]] = []
 
-    def generate(self, prompt: str, cwd=None, timeout=300, silent=False, **kwargs) -> str:
+    def generate(
+        self,
+        prompt: str,
+        cwd: str | None = None,
+        timeout: int | None = 300,
+        silent: bool = False,
+        **kwargs: Any,
+    ) -> str:
         """Return a stub response and record the call.
 
         When the prompt looks like a health assessment request, returns a

--- a/tests/_agent_cli/test_cleanup.py
+++ b/tests/_agent_cli/test_cleanup.py
@@ -77,7 +77,7 @@ class DummyAgent(CLICodingAgent[CLIGenerationSession]):
             cmd=cmd,
             logger=self.logger,
             cwd=cwd,
-            timeout=timeout,
+            timeout=timeout,  # pyright: ignore[reportArgumentType]  # tracked: #297
             silent=silent,
             event_handler=self.event_handler,
             executor=self.executor,

--- a/tests/_agent_cli/test_docker_executor.py
+++ b/tests/_agent_cli/test_docker_executor.py
@@ -59,7 +59,7 @@ class _HungProcess(_FakeProcess):
     def wait(self, timeout: int | None = None) -> int:
         self.wait_timeout = timeout
         if self.returncode is None:
-            raise subprocess.TimeoutExpired(["docker", "exec"], timeout)
+            raise subprocess.TimeoutExpired(["docker", "exec"], timeout)  # pyright: ignore[reportArgumentType]  # tracked: #297
         return self.returncode
 
 
@@ -87,7 +87,7 @@ def test_docker_executor_runs_command_request_and_streams_to_sink(monkeypatch):
         CallbackCommandStreamSink(
             on_stdout=stdout.append,
             on_stderr=stderr.append,
-            on_started=started.append,
+            on_started=started.append,  # pyright: ignore[reportArgumentType]  # tracked: #297
         ),
     )
 

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -252,7 +252,7 @@ class TestSharedAbstraction:
 
     def test_base_is_abstract(self):
         with pytest.raises(TypeError):
-            hostsandbox.WorkspaceSandbox(workspace=Path("/x"))
+            hostsandbox.WorkspaceSandbox(workspace=Path("/x"))  # pyright: ignore[reportAbstractUsage]  # tracked: #297
 
     def test_backends_share_fields_and_wrap(self):
         host = hostsandbox.HostSandbox(
@@ -293,7 +293,7 @@ class TestMacosBuild:
         assert sb.workspace == workspace.resolve()
 
     def test_missing_sandbox_exec_returns_none(self, tmp_path, monkeypatch):
-        self._patch(monkeypatch, sandbox_exec=None)
+        self._patch(monkeypatch, sandbox_exec=None)  # pyright: ignore[reportArgumentType]  # tracked: #297
         logs: list[str] = []
         assert hostsandbox.build(tmp_path, env={}, log=logs.append) is None
         assert any("sandbox-exec" in m for m in logs)
@@ -429,7 +429,7 @@ class _StubAgent(CLICodingAgent[CLIGenerationSession]):
             cmd=cmd,
             logger=self.logger,
             cwd=cwd,
-            timeout=timeout,
+            timeout=timeout,  # pyright: ignore[reportArgumentType]  # tracked: #297
             silent=silent,
             event_handler=self.event_handler,
             executor=self.executor,

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -1238,7 +1238,7 @@ class TestCliAgentRunner:
                 self.model = model
                 self.event_handler = event_handler
                 self.env: dict[str, str] = {}
-                self.session_id = "stale-thread"
+                self.session_id: str | None = "stale-thread"
                 self.generate_calls: list[dict] = []
                 self._last_session = None
                 captured.append(self)

--- a/tests/agents/test_callbacks.py
+++ b/tests/agents/test_callbacks.py
@@ -46,7 +46,7 @@ class TestOnLlmNewToken:
 
     def test_none_token_no_output(self, capsys):
         logger = AgentLogger()
-        logger.on_llm_new_token(None)
+        logger.on_llm_new_token(None)  # pyright: ignore[reportArgumentType]  # tracked: #297
         assert logger._streaming is False
         assert capsys.readouterr().out == ""
 
@@ -409,7 +409,7 @@ class TestOnChatModelStart:
             "kwargs": {"model": "claude-sonnet-4-6"},
         }
         messages = [[self._make_system_message(), self._make_human_message()]]
-        logger.on_chat_model_start(serialized, messages)
+        logger.on_chat_model_start(serialized, messages)  # pyright: ignore[reportArgumentType]  # tracked: #297
         log_text = log.getvalue()
         assert "claude-sonnet-4-6" in log_text
 
@@ -422,7 +422,7 @@ class TestOnChatModelStart:
         }
         system_prompt = "You are an expert ML engineer."
         messages = [[self._make_system_message(system_prompt), self._make_human_message()]]
-        logger.on_chat_model_start(serialized, messages)
+        logger.on_chat_model_start(serialized, messages)  # pyright: ignore[reportArgumentType]  # tracked: #297
         log_text = log.getvalue()
         assert system_prompt in log_text
 
@@ -440,7 +440,7 @@ class TestOnChatModelStart:
                 self._make_human_message("follow up"),
             ]
         ]
-        logger.on_chat_model_start(serialized, messages)
+        logger.on_chat_model_start(serialized, messages)  # pyright: ignore[reportArgumentType]  # tracked: #297
         log_text = log.getvalue()
         assert "1 system" in log_text
         assert "2 human" in log_text
@@ -452,8 +452,8 @@ class TestOnChatModelStart:
         logger = AgentLogger(log_file=log)
         serialized = {"id": ["langchain"], "kwargs": {}}
         messages = [[self._make_human_message()]]
-        logger.on_chat_model_start(serialized, messages)
-        logger.on_chat_model_start(serialized, messages)
+        logger.on_chat_model_start(serialized, messages)  # pyright: ignore[reportArgumentType]  # tracked: #297
+        logger.on_chat_model_start(serialized, messages)  # pyright: ignore[reportArgumentType]  # tracked: #297
         log_text = log.getvalue()
         assert "LLM call #1" in log_text
         assert "LLM call #2" in log_text
@@ -470,7 +470,7 @@ class TestOnChatModelStart:
                 self._make_human_message("second question"),
             ]
         ]
-        logger.on_chat_model_start(serialized, messages)
+        logger.on_chat_model_start(serialized, messages)  # pyright: ignore[reportArgumentType]  # tracked: #297
         log_text = log.getvalue()
         assert "second question" in log_text
 
@@ -479,7 +479,7 @@ class TestOnChatModelStart:
         logger = AgentLogger()
         serialized = {"id": ["langchain"], "kwargs": {"model": "test-model"}}
         messages = [[self._make_human_message()]]
-        logger.on_chat_model_start(serialized, messages)
+        logger.on_chat_model_start(serialized, messages)  # pyright: ignore[reportArgumentType]  # tracked: #297
         stdout = capsys.readouterr().out
         assert "test-model" not in stdout
         assert "LLM call" not in stdout
@@ -490,14 +490,14 @@ class TestOnChatModelStart:
         serialized = {"id": ["langchain"], "kwargs": {}}
         system_prompt = "You are an expert ML engineer."
         messages = [[self._make_system_message(system_prompt), self._make_human_message()]]
-        logger.on_chat_model_start(serialized, messages)
+        logger.on_chat_model_start(serialized, messages)  # pyright: ignore[reportArgumentType]  # tracked: #297
         first_log = log.getvalue()
         assert system_prompt in first_log
 
         # Second call should NOT repeat system prompt
         log.truncate(0)
         log.seek(0)
-        logger.on_chat_model_start(serialized, messages)
+        logger.on_chat_model_start(serialized, messages)  # pyright: ignore[reportArgumentType]  # tracked: #297
         second_log = log.getvalue()
         assert system_prompt not in second_log
 

--- a/tests/agents/test_omnigent_backend.py
+++ b/tests/agents/test_omnigent_backend.py
@@ -68,7 +68,7 @@ def _build(config: Config, **overrides):
         "use_docker": False,
     }
     kwargs.update(overrides)
-    return build_agent_runner(config, **kwargs)
+    return build_agent_runner(config, **kwargs)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
 
 def _judge_fallback() -> JudgeResponse:
@@ -711,7 +711,7 @@ class TestTurnPathWithFakeExecutor:
         executor = _FakeExecutor(events)
         schemas = [{"name": "sys_os_read", "description": "d", "parameters": {}}]
         # Bypass _build_executor so no OS environment (and so no bwrap) is needed.
-        runner._build_executor = lambda _ws: (executor, schemas)  # type: ignore[method-assign]
+        runner._build_executor = lambda _ws: (executor, schemas)
         return runner, executor
 
     def test_invoke_parses_a_structured_response(self, tmp_path):
@@ -817,7 +817,7 @@ class TestTurnPathWithFakeExecutor:
 
         runner = OmnigentAgentRunner(provider="claude", model_name="m")
         executor = _EnvProbe([TurnComplete(response="ok")])
-        runner._build_executor = lambda _ws: (executor, [])  # type: ignore[method-assign]
+        runner._build_executor = lambda _ws: (executor, [])
         os.environ.pop("CUDA_VISIBLE_DEVICES", None)
 
         runner.invoke_text(
@@ -868,7 +868,7 @@ class TestTurnPathWithFakeExecutor:
                 raise RuntimeError("harness exploded")
 
         runner = OmnigentAgentRunner(provider="claude", model_name="m", log_dir=log_dir)
-        runner._build_executor = lambda _ws: (_Boom([]), [])  # type: ignore[method-assign]
+        runner._build_executor = lambda _ws: (_Boom([]), [])
 
         with pytest.raises(RuntimeError, match="harness exploded"):
             runner.invoke_text(
@@ -912,7 +912,7 @@ class TestTurnPathWithFakeExecutor:
             return _FakeExecutor([TurnComplete(response="ok")]), []
 
         runner = OmnigentAgentRunner(provider="claude", model_name="m")
-        runner._build_executor = _build  # type: ignore[method-assign]
+        runner._build_executor = _build
 
         for _ in range(2):
             runner.invoke_text(
@@ -947,7 +947,7 @@ class TestTurnPathWithFakeExecutor:
             return executor, []
 
         runner = OmnigentAgentRunner(provider="claude", model_name="m")
-        runner._build_executor = _build  # type: ignore[method-assign]
+        runner._build_executor = _build
 
         for _ in range(2):
             runner.invoke_text(
@@ -986,7 +986,7 @@ class TestTurnPathWithFakeExecutor:
                 closed.append(True)
 
         runner = OmnigentAgentRunner(provider="claude", model_name="m")
-        runner._build_executor = lambda _ws: (_Closable([TurnComplete(response="ok")]), [])  # type: ignore[method-assign]
+        runner._build_executor = lambda _ws: (_Closable([TurnComplete(response="ok")]), [])
         runner.invoke_text(
             kind="implementer",
             workspace=tmp_path,
@@ -1008,7 +1008,7 @@ class TestTurnPathWithFakeExecutor:
 
         log = StringIO()
         runner = OmnigentAgentRunner(provider="claude", model_name="m", run_log_file=log)
-        runner._build_executor = lambda _ws: (_BadClose([TurnComplete(response="ok")]), [])  # type: ignore[method-assign]
+        runner._build_executor = lambda _ws: (_BadClose([TurnComplete(response="ok")]), [])
         runner.invoke_text(
             kind="implementer",
             workspace=tmp_path,

--- a/tests/backends/test_cpu_backend.py
+++ b/tests/backends/test_cpu_backend.py
@@ -17,7 +17,7 @@ from vs_sandbox import DockerSandbox
 
 
 def _make_backend(tmp_path) -> LocalBackend:
-    return backends.get(ComputeBackend.CPU, log_dir=tmp_path / "logs")
+    return backends.get(ComputeBackend.CPU, log_dir=tmp_path / "logs")  # pyright: ignore[reportReturnType]  # tracked: #297
 
 
 class TestCpuRegistry:

--- a/tests/backends/test_cuda_backend.py
+++ b/tests/backends/test_cuda_backend.py
@@ -23,5 +23,5 @@ def test_cpu_only_control_plane_docker_skips_gpu_runtime(
     )
 
     pick_device.assert_not_called()
-    assert sandbox._gpus is None  # pyright: ignore[reportAttributeAccessIssue]
+    assert sandbox._gpus is None
     assert backend.selected_device is None

--- a/tests/backends/test_gpu_monitor.py
+++ b/tests/backends/test_gpu_monitor.py
@@ -251,7 +251,7 @@ class TestMonitorLifecycle:
         mon.start()
         time.sleep(0.15)
         mon.stop()
-        assert not mon._thread.is_alive()
+        assert not mon._thread.is_alive()  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     def test_stop_without_start(self):
         mon = GpuContentionMonitor(log_dir=Path("/tmp"), gpu_uuid=GPU_A)
@@ -333,7 +333,9 @@ class TestReselectGpu:
     def test_noop_when_no_gpus(self, mock_pick, tmp_path):
         ctx = self._make_ctx(tmp_path, selected_gpu=_gpu(0, GPU_A))
         ctx.reselect_gpu()
-        assert ctx.selected_gpu.index == 0  # unchanged
+        # unchanged
+        selected_index = ctx.selected_gpu.index  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert selected_index == 0
 
     @patch("vibesys.backends.cuda.pick_gpu")
     def test_noop_when_same_gpu(self, mock_pick, tmp_path):
@@ -405,7 +407,7 @@ class TestReselectGpu:
         ctx.implementer_backend.start.assert_called_once()
         ctx.judge_backend.start.assert_called_once()
         # Clean up
-        ctx.gpu_monitor.stop()
+        ctx.gpu_monitor.stop()  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     # Note: symlink replay on restart is now the sandbox class's
     # responsibility (it runs setup_fns at the end of start()).  That
@@ -426,4 +428,4 @@ class TestReselectGpu:
         assert ctx.selected_gpu is gpu1
         assert ctx.implementer_backend._env["CUDA_VISIBLE_DEVICES"] == "1"
         # Clean up
-        ctx.gpu_monitor.stop()
+        ctx.gpu_monitor.stop()  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297

--- a/tests/backends/test_metal_backend.py
+++ b/tests/backends/test_metal_backend.py
@@ -16,7 +16,7 @@ from vibesys.profilers import ProfilerKind
 
 
 def _make_backend(tmp_path) -> LocalBackend:
-    return backends.get(ComputeBackend.METAL, log_dir=tmp_path / "logs")
+    return backends.get(ComputeBackend.METAL, log_dir=tmp_path / "logs")  # pyright: ignore[reportReturnType]  # tracked: #297
 
 
 class TestMetalRegistry:

--- a/tests/backends/test_rocm_backend.py
+++ b/tests/backends/test_rocm_backend.py
@@ -21,7 +21,7 @@ def _make_backend(tmp_path, devices=("/dev/kfd", "/dev/dri/renderD128")) -> Rocm
     impl = backends.get(ComputeBackend.ROCM, log_dir=tmp_path / "logs")
     # Pin a deterministic device set so tests don't depend on host hardware.
     impl._devices = list(devices)
-    return impl
+    return impl  # pyright: ignore[reportReturnType]  # tracked: #297
 
 
 class TestRocmRegistry:

--- a/tests/backends/test_trainium_backend.py
+++ b/tests/backends/test_trainium_backend.py
@@ -19,7 +19,7 @@ def _make_backend(tmp_path, devices=("/dev/neuron0",)) -> TrainiumBackend:
     impl = backends.get(ComputeBackend.TRAINIUM, log_dir=tmp_path / "logs")
     # Pin a deterministic device set so tests don't depend on host hardware.
     impl._devices = list(devices)
-    return impl
+    return impl  # pyright: ignore[reportReturnType]  # tracked: #297
 
 
 class TestTrainiumRegistry:

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -71,7 +71,7 @@ def test_resolve_path_is_not_supported(tmp_path: Path):
     f.mkdir()
     (f / "implementer.md").write_text("hello\n")
     with pytest.raises(TypeError, match="DomainName"):
-        resolve_domain(str(f))
+        resolve_domain(str(f))  # pyright: ignore[reportArgumentType]  # tracked: #297
 
 
 def test_registered_domains_carry_environment_hooks():
@@ -88,7 +88,7 @@ def test_domains_declare_torch_profiler_compatibility():
 
 def test_resolve_unknown_raises():
     with pytest.raises(TypeError) as exc:
-        resolve_domain("does-not-exist-xyz")
+        resolve_domain("does-not-exist-xyz")  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert "DomainName" in str(exc.value)
 
 

--- a/tests/loops/agent/test_interface_modes.py
+++ b/tests/loops/agent/test_interface_modes.py
@@ -38,7 +38,7 @@ def test_cli_exposes_only_process_boundary_modes():
 
     parser = _build_agent_parser()
     action = next(action for action in parser._actions if action.dest == "interface")
-    assert set(action.choices) == {"inprocess", "service"}
+    assert set(action.choices) == {"inprocess", "service"}  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert action.default == "inprocess"
     assert all(action.dest != "language" for action in parser._actions)
 
@@ -71,7 +71,7 @@ def test_loop_constants_and_rejects_unknown_interface():
     assert _INTERFACES == ("inprocess", "service")
     with pytest.raises(ValueError, match="interface"):
         run_agent_loop(
-            config=None,
+            config=None,  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="e",
             input_path="/x",
             accuracy_command="accuracy-checker",
@@ -116,7 +116,7 @@ def test_standalone_profiler_rejects_unknown_kind():
     from vibesys.loops.agent.loop import _profiler_prompt_template
 
     with pytest.raises(TypeError, match="ProfilerKind"):
-        _profiler_prompt_template("bogus")
+        _profiler_prompt_template("bogus")  # pyright: ignore[reportArgumentType]  # tracked: #297
 
 
 def _render_implementer(interface: str, *, modality: str | None = None) -> str:

--- a/tests/loops/agent/test_issue_tools.py
+++ b/tests/loops/agent/test_issue_tools.py
@@ -168,8 +168,8 @@ class TestCreateIssue:
         )
         assert out == "created issue #1"
         assert store.get(1) is not None
-        assert store.get(1).created_by == "perf_eval"
-        assert store.get(1).created_iter == 1
+        assert store.get(1).created_by == "perf_eval"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert store.get(1).created_iter == 1  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     def test_create_issue_invalid_type_returns_error_string(self, tmp_path):
         store = _make_store(tmp_path)

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -307,7 +307,7 @@ def _invoke_orchestrate(tmp_path, ref_file, runner, **kwargs):
             return_value=None,
         ),
     ):
-        return run_agent_loop(**defaults)
+        return run_agent_loop(**defaults)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
 
 # ---------------------------------------------------------------------------
@@ -432,7 +432,7 @@ def test_read_only_role_preserves_allowed_roadmap_and_reverts_other_writes(tmp_p
     )
 
     result = _invoke_read_only_role(
-        ctx,
+        ctx,  # pyright: ignore[reportArgumentType]  # tracked: #297
         role="orchestrator",
         checkpoint_label="round-2-plan-input",
         allowed_workspace_paths=("roadmap/index.md",),
@@ -479,7 +479,7 @@ def test_read_only_role_preserves_allowed_directory_and_reverts_candidate_edits(
     )
 
     result = _invoke_read_only_role(
-        ctx,
+        ctx,  # pyright: ignore[reportArgumentType]  # tracked: #297
         role="profiler",
         checkpoint_label="round-2-profiler-input",
         allowed_workspace_paths=("progress/profiles/round-0002",),
@@ -1311,7 +1311,7 @@ def test_framework_local_validation_fails_and_restores_mutation(tmp_path):
         progress_path=progress,
     )
 
-    assert "mutated the workspace" in feedback
+    assert "mutated the workspace" in feedback  # pyright: ignore[reportOperatorIssue]  # tracked: #297
     ctx.git.checkout_tree.assert_called_once_with("b" * 40, clean=True)
     artifact = progress / "validation" / "round-0003-attempt-01.json"
     assert '"passed": false' in artifact.read_text()
@@ -1357,8 +1357,8 @@ def test_framework_accuracy_gate_rejects_checker_failure(tmp_path):
         progress_path=tmp_path / "progress.md",
     )
 
-    assert "Framework accuracy gate failed" in feedback
-    assert "bad history" in feedback
+    assert "Framework accuracy gate failed" in feedback  # pyright: ignore[reportOperatorIssue]  # tracked: #297
+    assert "bad history" in feedback  # pyright: ignore[reportOperatorIssue]  # tracked: #297
 
 
 def test_framework_accuracy_gate_uses_manifest_timeout(tmp_path):
@@ -1440,7 +1440,7 @@ def test_framework_accuracy_gate_rejects_evaluator_changes_without_execution(tmp
         progress_path=tmp_path / "progress.md",
     )
 
-    assert "Evaluator-owned files were modified" in feedback
+    assert "Evaluator-owned files were modified" in feedback  # pyright: ignore[reportOperatorIssue]  # tracked: #297
     ctx.judge_backend.execute.assert_not_called()
 
 
@@ -1459,7 +1459,7 @@ def test_framework_accuracy_gate_rejects_changes_during_execution(tmp_path):
         progress_path=tmp_path / "progress.md",
     )
 
-    assert "changed during accuracy execution" in feedback
+    assert "changed during accuracy execution" in feedback  # pyright: ignore[reportOperatorIssue]  # tracked: #297
 
 
 def test_framework_gates_reuse_accuracy_pass_after_later_gate_failure(tmp_path):
@@ -1605,7 +1605,7 @@ def test_framework_benchmark_rejects_ambiguous_metric(tmp_path):
     )
 
     assert metric is None
-    assert "expected exactly one 'ops' field" in feedback
+    assert "expected exactly one 'ops' field" in feedback  # pyright: ignore[reportOperatorIssue]  # tracked: #297
 
 
 # ---------------------------------------------------------------------------

--- a/tests/loops/agent/test_prompt_snapshots.py
+++ b/tests/loops/agent/test_prompt_snapshots.py
@@ -277,17 +277,17 @@ def test_multi_agent_prompts_use_paths_without_embedding_durable_content():
 
     for prompt in prompts.values():
         assert all(sentinel not in prompt for sentinel in forbidden)
-        assert context["objective_location"] in prompt
+        assert context["objective_location"] in prompt  # pyright: ignore[reportOperatorIssue]  # tracked: #297
     for role in ("implementer", "implementer_continuation", "judge", "single_agent"):
-        assert context["plan_artifact_location"] in prompts[role]
+        assert context["plan_artifact_location"] in prompts[role]  # pyright: ignore[reportOperatorIssue]  # tracked: #297
     for role in ("implementer", "implementer_continuation", "judge"):
-        assert context["validation_recipe_contract_location"] in prompts[role]
-    assert context["implementer_artifact_location"] in prompts["judge"]
-    assert context["progress_location"] in prompts["orchestrator"]
-    assert context["roadmap_location"] in prompts["orchestrator"]
-    assert context["pareto_archive_location"] in prompts["orchestrator"]
+        assert context["validation_recipe_contract_location"] in prompts[role]  # pyright: ignore[reportOperatorIssue]  # tracked: #297
+    assert context["implementer_artifact_location"] in prompts["judge"]  # pyright: ignore[reportOperatorIssue]  # tracked: #297
+    assert context["progress_location"] in prompts["orchestrator"]  # pyright: ignore[reportOperatorIssue]  # tracked: #297
+    assert context["roadmap_location"] in prompts["orchestrator"]  # pyright: ignore[reportOperatorIssue]  # tracked: #297
+    assert context["pareto_archive_location"] in prompts["orchestrator"]  # pyright: ignore[reportOperatorIssue]  # tracked: #297
     for role in ("implementer", "implementer_continuation", "judge", "single_agent"):
-        assert context["validation_location"] in prompts[role]
+        assert context["validation_location"] in prompts[role]  # pyright: ignore[reportOperatorIssue]  # tracked: #297
 
     assert "reproducible production selector" in prompts["implementer"]
     assert "production selector" in prompts["implementer_continuation"]
@@ -354,9 +354,9 @@ def test_implementer_continuation_is_delta_only_and_fresh_session_safe():
     context = _CONTEXTS["full"]
     rendered = _render_prompt(DomainName.LLM_SERVING, "implementer_continuation", context)
 
-    assert context["continuation_step"] in rendered
-    assert context["feedback"] in rendered
-    assert context["current_round_location"] in rendered
+    assert context["continuation_step"] in rendered  # pyright: ignore[reportOperatorIssue]  # tracked: #297
+    assert context["feedback"] in rendered  # pyright: ignore[reportOperatorIssue]  # tracked: #297
+    assert context["current_round_location"] in rendered  # pyright: ignore[reportOperatorIssue]  # tracked: #297
     assert "If renewed" in rendered
     assert "scan the campaign" in rendered
     assert "PLAN_TASK_CONTENT_MUST_NOT_BE_EMBEDDED" not in rendered
@@ -410,7 +410,7 @@ def test_implementer_retry_references_prior_evidence_and_cumulative_budget():
     assert prior_locations is not None
 
     assert "Same-round retry boundary" in rendered
-    assert prior_locations[0] in rendered
+    assert prior_locations[0] in rendered  # pyright: ignore[reportIndexIssue,reportOperatorIssue]  # tracked: #297
     assert "remains consumed" in rendered
 
 
@@ -418,7 +418,7 @@ def test_judge_references_framework_evidence_without_embedding_implementer_prose
     context = _CONTEXTS["full"] | {"retry": 2}
     rendered = _render_prompt(DomainName.LLM_SERVING, "judge", context)
 
-    assert context["implementer_artifact_location"] in rendered
+    assert context["implementer_artifact_location"] in rendered  # pyright: ignore[reportOperatorIssue]  # tracked: #297
     assert "IMPLEMENTER_PROSE_MUST_NOT_BE_EMBEDDED" not in rendered
     assert "Implementer fields/artifacts are untrusted claims/data" in rendered
     assert "re-check the changed source/evidence" in rendered.lower()
@@ -450,7 +450,7 @@ def test_orchestrator_routes_profile_and_failure_details_through_progress():
         official_eval_cadence_due=False,
     )
 
-    assert context["progress_location"] in rendered
+    assert context["progress_location"] in rendered  # pyright: ignore[reportOperatorIssue]  # tracked: #297
     assert all(sentinel not in rendered for sentinel in sentinels.values())
     assert "fresh profiler result is recorded in the current progress entry" in rendered
     assert "observer effect" in rendered

--- a/tests/loops/agent/test_prompt_snapshots.py
+++ b/tests/loops/agent/test_prompt_snapshots.py
@@ -406,8 +406,11 @@ def test_implementer_retry_references_prior_evidence_and_cumulative_budget():
     }
     rendered = _render_prompt(DomainName.LLM_SERVING, "implementer_continuation", context)
 
+    prior_locations = context["prior_attempt_artifact_locations"]
+    assert prior_locations is not None
+
     assert "Same-round retry boundary" in rendered
-    assert context["prior_attempt_artifact_locations"][0] in rendered
+    assert prior_locations[0] in rendered
     assert "remains consumed" in rendered
 
 

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -183,7 +183,7 @@ def _invoke_loop(tmp_path, ref_file, runner, **kwargs):
             accuracy_gate,
         ),
     ):
-        return run_evolve_loop(**defaults)
+        return run_evolve_loop(**defaults)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
 
 def _load_population(tmp_path) -> Population:
@@ -732,7 +732,7 @@ def test_candidate_code_is_multi_file_but_excludes_runtime_logs(tmp_path):
     commit = tracker.current_sha()
 
     assert commit is not None
-    code = _candidate_code(SimpleNamespace(git=tracker), commit)
+    code = _candidate_code(SimpleNamespace(git=tracker), commit)  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert "src/lib.rs" in code
     assert "src/ffi.rs" in code
     assert "logs/profile.txt" not in code
@@ -775,7 +775,7 @@ def test_programmatic_openevolve_config_infers_policy(tmp_path):
     config = OpenEvolveSearchConfig(num_islands=1)
 
     name, policy = _initialize_search_policy(
-        ctx,
+        ctx,  # pyright: ignore[reportArgumentType]  # tracked: #297
         Population(),
         requested=None,
         seed=1,
@@ -793,7 +793,7 @@ def test_programmatic_openevolve_config_rejects_vibesys_policy(tmp_path):
 
     with pytest.raises(ValueError, match="requires the OpenEvolve search policy"):
         _initialize_search_policy(
-            ctx,
+            ctx,  # pyright: ignore[reportArgumentType]  # tracked: #297
             Population(),
             requested="vibesys",
             seed=1,
@@ -869,7 +869,7 @@ def test_candidate_runtime_notes_delegates_deployment_naming_to_environment():
             )
         ),
     )
-    notes, app = _candidate_runtime_notes(ctx, generation=3, child_idx=2)
+    notes, app = _candidate_runtime_notes(ctx, generation=3, child_idx=2)  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert app == "candidate-3-2"
     assert notes == "provider-owned candidate instructions"
 
@@ -884,7 +884,7 @@ def test_candidate_runtime_notes_noop_without_named_deployment():
             )
         ),
     )
-    notes, app = _candidate_runtime_notes(ctx, generation=1, child_idx=1)
+    notes, app = _candidate_runtime_notes(ctx, generation=1, child_idx=1)  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert app is None
     assert notes == notes_in
 
@@ -900,7 +900,7 @@ def test_teardown_candidate_deployment_delegates_to_run_environment():
     run_env = MagicMock()
     ctx = SimpleNamespace(run_environment=run_env, lprint=lambda _: None)
 
-    _teardown_candidate_deployment(ctx, "vibesys-run-g1c2", keep=False)
+    _teardown_candidate_deployment(ctx, "vibesys-run-g1c2", keep=False)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
     run_env.teardown_deployment.assert_called_once_with("vibesys-run-g1c2", log=ctx.lprint)
 
@@ -910,9 +910,9 @@ def test_teardown_candidate_deployment_noop_when_kept_or_absent():
     ctx = SimpleNamespace(run_environment=run_env, lprint=lambda _: None)
 
     # Opt-out: keep the app for post-hoc inspection.
-    _teardown_candidate_deployment(ctx, "vibesys-run-g1c2", keep=True)
+    _teardown_candidate_deployment(ctx, "vibesys-run-g1c2", keep=True)  # pyright: ignore[reportArgumentType]  # tracked: #297
     # No per-candidate deployment (non-Modal env).
-    _teardown_candidate_deployment(ctx, None, keep=False)
+    _teardown_candidate_deployment(ctx, None, keep=False)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
     run_env.teardown_deployment.assert_not_called()
 
@@ -944,7 +944,7 @@ def test_plan_candidate_falls_back_to_latest_passer_then_none():
     empty = Population([])
     assert (
         _plan_candidate(
-            ctx,
+            ctx,  # pyright: ignore[reportArgumentType]  # tracked: #297
             empty,
             rng,
             k_top_inspirations=1,
@@ -959,7 +959,7 @@ def test_plan_candidate_falls_back_to_latest_passer_then_none():
     # A passer exists → returned as parent.
     pop = Population([_passing_seed()])
     plan = _plan_candidate(
-        ctx,
+        ctx,  # pyright: ignore[reportArgumentType]  # tracked: #297
         pop,
         rng,
         k_top_inspirations=1,
@@ -1007,8 +1007,8 @@ def test_run_generation_parallel_bounds_concurrency_and_records_all(tmp_path, mo
     monkeypatch.setattr(evolve_loop, "_evaluate_in_subcontext", fake_eval)
 
     _run_generation_parallel(
-        ctx,
-        config={"model": {"name": "m"}},
+        ctx,  # pyright: ignore[reportArgumentType]  # tracked: #297
+        config={"model": {"name": "m"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
         agent_backend=None,
         cli_provider=None,
         max_parallelism=2,
@@ -1066,8 +1066,8 @@ def test_run_generation_parallel_skips_parent_without_commit(tmp_path, monkeypat
     monkeypatch.setattr(evolve_loop, "_evaluate_in_subcontext", fake_eval)
 
     _run_generation_parallel(
-        ctx,
-        config={"model": {"name": "m"}},
+        ctx,  # pyright: ignore[reportArgumentType]  # tracked: #297
+        config={"model": {"name": "m"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
         agent_backend=None,
         cli_provider=None,
         max_parallelism=2,
@@ -1106,8 +1106,8 @@ def test_evaluate_in_subcontext_skips_parent_without_commit():
     parentless = Individual(id=3, generation=1, parent_id=1, commit=None, passed=True, summary="x")
 
     outcome = _evaluate_in_subcontext(
-        parent_ctx,
-        config={"model": {"name": "m"}},
+        parent_ctx,  # pyright: ignore[reportArgumentType]  # tracked: #297
+        config={"model": {"name": "m"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
         agent_backend=None,
         cli_provider=None,
         generation=2,
@@ -1143,7 +1143,7 @@ def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file
         patch("vibesys.context.PROJECT_ROOT", tmp_path),
         patch("vibesys.loops.evolve.loop._run_framework_accuracy_gate", return_value=None),
         create_run_context(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test-parallel-subctx",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -1169,7 +1169,7 @@ def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file
 
         outcome = _evaluate_in_subcontext(
             parent,
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             agent_backend=None,
             cli_provider=None,
             generation=1,

--- a/tests/loops/evolve/test_evolutionary_population.py
+++ b/tests/loops/evolve/test_evolutionary_population.py
@@ -99,7 +99,7 @@ def test_passed_filter_excludes_no_commit_and_failed():
 
 def test_best_picks_highest_perf_metric():
     pop = Population([_passed(1, 10.0), _passed(2, 12.0), _passed(3, 11.0)])
-    assert pop.best().id == 2
+    assert pop.best().id == 2  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
 
 def test_best_returns_none_with_no_passed_individuals():
@@ -109,7 +109,7 @@ def test_best_returns_none_with_no_passed_individuals():
 
 def test_best_breaks_ties_by_id():
     pop = Population([_passed(1, 10.0), _passed(2, 10.0)])
-    assert pop.best().id == 2
+    assert pop.best().id == 2  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
 
 # ---------------------------------------------------------------------------
@@ -128,14 +128,14 @@ def test_select_parent_only_failed_returns_none():
 
 def test_select_parent_single_passed_returns_it():
     pop = Population([_failed(1), _passed(2, 10.0)])
-    assert pop.select_parent(rng=random.Random(0)).id == 2
+    assert pop.select_parent(rng=random.Random(0)).id == 2  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
 
 def test_select_parent_low_temperature_concentrates_on_best():
     """A near-zero temperature should pick the best almost every time."""
     pop = Population([_passed(1, 1.0), _passed(2, 5.0), _passed(3, 10.0)])
     rng = random.Random(123)
-    counts = Counter(pop.select_parent(rng=rng, temperature=0.01).id for _ in range(200))
+    counts = Counter(pop.select_parent(rng=rng, temperature=0.01).id for _ in range(200))  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     # The best (id=3) should dominate.
     assert counts[3] > 180
 
@@ -144,7 +144,7 @@ def test_select_parent_high_temperature_spreads():
     """High temperature flattens the distribution toward uniform."""
     pop = Population([_passed(1, 1.0), _passed(2, 5.0), _passed(3, 10.0)])
     rng = random.Random(123)
-    counts = Counter(pop.select_parent(rng=rng, temperature=100.0).id for _ in range(600))
+    counts = Counter(pop.select_parent(rng=rng, temperature=100.0).id for _ in range(600))  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     # All three should be picked a meaningful number of times.
     assert all(counts[i] > 100 for i in (1, 2, 3))
 
@@ -152,7 +152,7 @@ def test_select_parent_high_temperature_spreads():
 def test_select_parent_uniform_when_all_perfs_equal():
     pop = Population([_passed(1, 7.0), _passed(2, 7.0), _passed(3, 7.0)])
     rng = random.Random(42)
-    counts = Counter(pop.select_parent(rng=rng).id for _ in range(300))
+    counts = Counter(pop.select_parent(rng=rng).id for _ in range(300))  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     assert all(counts[i] > 50 for i in (1, 2, 3))
 
 
@@ -220,9 +220,9 @@ def test_population_save_and_load_round_trip(tmp_path):
 
     loaded = Population.load(path)
     assert [i.id for i in loaded.all] == [1, 2, 3]
-    assert loaded.best().id == 3
+    assert loaded.best().id == 3  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     # Parent id shape preserved (None survives JSON round-trip).
-    assert loaded.get(1).parent_id is None
+    assert loaded.get(1).parent_id is None  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
 
 def test_population_load_missing_returns_empty(tmp_path):
@@ -359,7 +359,8 @@ def test_select_parent_pareto_mode_draws_from_frontier_with_full_bias():
     objs = [Objective("tput", "max"), Objective("lat", "min")]
     rng = random.Random(0)
     counts = Counter(
-        pop.select_parent(rng=rng, objectives=objs, frontier_bias=1.0).id for _ in range(200)
+        pop.select_parent(rng=rng, objectives=objs, frontier_bias=1.0).id  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        for _ in range(200)
     )
     assert counts[3] == 0  # never the dominated one
 
@@ -383,7 +384,7 @@ def test_select_parent_pareto_mode_falls_back_to_scalar_when_bias_zero():
             objectives=objs,
             frontier_bias=0.0,
             temperature=0.01,
-        ).id
+        ).id  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
         for _ in range(100)
     )
     assert counts[1] > 90

--- a/tests/loops/evolve/test_search_policy.py
+++ b/tests/loops/evolve/test_search_policy.py
@@ -58,7 +58,7 @@ def _config(**overrides: object) -> OpenEvolveSearchConfig:
         "migration_interval": 1,
         "migration_rate": 1.0,
     }
-    values.update(overrides)
+    values.update(overrides)  # pyright: ignore[reportArgumentType,reportCallIssue]  # tracked: #297
     return OpenEvolveSearchConfig(**values)  # type: ignore[arg-type]
 
 
@@ -147,7 +147,7 @@ def test_migrants_keep_vibesys_identity_and_state_resumes(tmp_path) -> None:
     assert selection is not None
     assert selection.parent.id in {seed.id, child.id}
     assert selection.target_island == 1
-    selected_program = resumed._database.programs[selection.policy_parent_id]
+    selected_program = resumed._database.programs[selection.policy_parent_id]  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert selected_program.metadata["vibesys_individual_id"] == selection.parent.id
     assert selected_program.metadata["migrant"] is True
 
@@ -320,7 +320,7 @@ def test_empty_island_copy_resolves_through_vibesys_ancestry(tmp_path) -> None:
     assert selection is not None
     assert selection.parent.id == seed.id
     assert selection.target_island == 1
-    copy = policy._database.programs[selection.policy_parent_id]
+    copy = policy._database.programs[selection.policy_parent_id]  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert copy.metadata["vibesys_individual_id"] == seed.id
 
 
@@ -344,8 +344,8 @@ def test_empty_island_copy_has_same_identity_after_resume(tmp_path) -> None:
         "objectives": None,
         "frontier_bias": 0.7,
     }
-    uninterrupted_selection = policy.select(population, **selection_args)
-    resumed_selection = resumed.select(population, **selection_args)
+    uninterrupted_selection = policy.select(population, **selection_args)  # pyright: ignore[reportArgumentType]  # tracked: #297
+    resumed_selection = resumed.select(population, **selection_args)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
     assert uninterrupted_selection is not None and resumed_selection is not None
     assert resumed_selection.policy_parent_id == uninterrupted_selection.policy_parent_id
@@ -408,7 +408,7 @@ def test_resume_continues_upstream_random_stream_without_touching_global_rng(tmp
         "objectives": None,
         "frontier_bias": 0.7,
     }
-    policy.select(population, **selection_args)
+    policy.select(population, **selection_args)  # pyright: ignore[reportArgumentType]  # tracked: #297
     resumed = OpenEvolveSearchPolicy(state_dir=tmp_path, seed=19, config=None)
     program_ids = sorted(policy._database.programs)
     policy._database.config.exploration_ratio = 1.0
@@ -418,8 +418,8 @@ def test_resume_continues_upstream_random_stream_without_touching_global_rng(tmp
         program_ids,
         program_ids[1:] + program_ids[:1],
     )
-    uninterrupted_next = policy.select(population, **selection_args)
-    resumed_next = resumed.select(population, **selection_args)
+    uninterrupted_next = policy.select(population, **selection_args)  # pyright: ignore[reportArgumentType]  # tracked: #297
+    resumed_next = resumed.select(population, **selection_args)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
     assert uninterrupted_next is not None and resumed_next is not None
     assert resumed_next.policy_parent_id == uninterrupted_next.policy_parent_id

--- a/tests/loops/plain/test_plain_loop.py
+++ b/tests/loops/plain/test_plain_loop.py
@@ -133,7 +133,7 @@ def test_bootstrap_creates_initial_feature_issue_on_first_run(
 
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         result = run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -174,7 +174,7 @@ def test_bootstrap_idempotent_on_resume(
     )
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -195,7 +195,7 @@ def test_bootstrap_idempotent_on_resume(
     )
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name=exp_dir.name,
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -232,7 +232,7 @@ def test_judge_pass_closes_issue(mock_build_runner, mock_backend, mock_build, re
 
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -268,7 +268,7 @@ def test_judge_fail_increments_attempts_and_keeps_open(
 
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         result = run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -305,7 +305,7 @@ def test_issue_blocks_after_max_attempts_exhausted(
 
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         result = run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -386,7 +386,7 @@ def test_judge_invoke_receives_tracker_kwargs(
 
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -445,7 +445,7 @@ def test_perf_eval_invoke_receives_tracker_kwargs(
 
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -526,7 +526,7 @@ def test_judge_phase_calls_store_reload_after_invoke(
         ),
     ):
         run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -567,7 +567,7 @@ def test_implementer_invoke_has_no_tracker_kwargs(
 
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -620,7 +620,7 @@ def test_perf_eval_runs_after_drain_complete(
 
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -669,7 +669,7 @@ def test_resume_with_bootstrap_done_skips_bootstrap_creation(
     )
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -688,7 +688,7 @@ def test_resume_with_bootstrap_done_skips_bootstrap_creation(
     mock_build_runner.return_value = runner2
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         result = run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name=exp_dir.name,
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -731,7 +731,7 @@ def test_resume_retries_previously_blocked_issue(
     )
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         result1 = run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -743,8 +743,8 @@ def test_resume_retries_previously_blocked_issue(
 
     exp_dir = _run_exp_dir(tmp_path)
     pre_resume = IssueBoard(_store_path(exp_dir)).get(1)
-    assert pre_resume.status == IssueStatus.BLOCKED
-    assert pre_resume.attempts == 2
+    assert pre_resume.status == IssueStatus.BLOCKED  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    assert pre_resume.attempts == 2  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     # Phase 2: resume. The blocked issue should be reopened with a fresh
     # attempt budget; this time the implementer/judge cycle passes.
@@ -758,7 +758,7 @@ def test_resume_retries_previously_blocked_issue(
     )
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         result2 = run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name=exp_dir.name,
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -771,11 +771,11 @@ def test_resume_retries_previously_blocked_issue(
     assert result2 is True
 
     post_resume = IssueBoard(_store_path(exp_dir)).get(1)
-    assert post_resume.status == IssueStatus.CLOSED
+    assert post_resume.status == IssueStatus.CLOSED  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     # Reopen reset attempts to 0; the successful retry counts as attempt 1.
-    assert post_resume.attempts == 1
+    assert post_resume.attempts == 1  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     # The blocked->open transition is recorded in history.
-    actions = [evt.action for evt in post_resume.history]
+    actions = [evt.action for evt in post_resume.history]  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     assert "blocked->open" in actions
 
 
@@ -803,7 +803,7 @@ def test_run_returns_true_when_perf_eval_files_no_issues_after_clean_drain(
 
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         result = run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -838,7 +838,7 @@ def test_state_json_written_with_bootstrap_done_after_run(
 
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -882,7 +882,7 @@ def test_issue_loop_writes_per_issue_markdown_via_callback(
 
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -951,7 +951,7 @@ def test_implementer_retry_user_prompt_includes_prior_judge_feedback(
 
     with patch("vibesys.context.PROJECT_ROOT", tmp_path):
         run_plain_loop(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",

--- a/tests/loops/plain/test_plain_loop_state.py
+++ b/tests/loops/plain/test_plain_loop_state.py
@@ -145,7 +145,7 @@ class TestDetermineResumePoint:
         state = PlainLoopState(
             round_idx=1, phase="implementer", current_issue_id=None, bootstrap_done=True
         )
-        i, phase, issue_id = _determine_resume_point(state, store)
+        _i, phase, issue_id = _determine_resume_point(state, store)
         assert phase == "implementer"
         assert issue_id is None
 
@@ -180,7 +180,7 @@ class TestDetermineResumePoint:
         state = PlainLoopState(
             round_idx=0, phase="judge", current_issue_id=closed.id, bootstrap_done=True
         )
-        i, phase, issue_id = _determine_resume_point(state, store)
+        _i, phase, issue_id = _determine_resume_point(state, store)
         # Should NOT try to re-run judge on the closed issue
         assert not (phase == "judge" and issue_id == closed.id)
         assert phase == "implementer"

--- a/tests/loops/test_profiler.py
+++ b/tests/loops/test_profiler.py
@@ -3,6 +3,14 @@
 The orchestrate loop's profiler-gating behavior is covered in
 ``tests/test_orchestrate.py``; this module keeps the lower-level
 ProfilerResponse / parser / nsys-toolkit tests.
+
+The ``resources.profilers.nsys.analyze_nsys`` imports below resolve at
+runtime because pytest's ``pythonpath = ["."]`` setting (pyproject.toml)
+puts the repo root on ``sys.path``. Pyright's per-directory execution
+environment for ``tests`` does not carry that same implicit root, so it
+cannot resolve them statically; each import is suppressed by name rather
+than widened via ``extraPaths`` (widening was tried and made pyright treat
+the first-party ``vibesys`` package as an external stub-only dependency).
 """
 
 import json
@@ -233,7 +241,10 @@ def nsys_db(tmp_path):
 
 
 def test_analyze_kernels(nsys_db):
-    from resources.profilers.nsys.analyze_nsys import _build_string_map, analyze_kernels
+    from resources.profilers.nsys.analyze_nsys import (  # pyright: ignore[reportMissingImports]
+        _build_string_map,
+        analyze_kernels,
+    )
 
     conn = sqlite3.connect(nsys_db)
     strings = _build_string_map(conn)
@@ -247,7 +258,10 @@ def test_analyze_kernels(nsys_db):
 
 
 def test_analyze_cpu_overhead(nsys_db):
-    from resources.profilers.nsys.analyze_nsys import _build_string_map, analyze_cpu_overhead
+    from resources.profilers.nsys.analyze_nsys import (  # pyright: ignore[reportMissingImports]
+        _build_string_map,
+        analyze_cpu_overhead,
+    )
 
     conn = sqlite3.connect(nsys_db)
     strings = _build_string_map(conn)
@@ -261,7 +275,10 @@ def test_analyze_cpu_overhead(nsys_db):
 
 
 def test_analyze_gpu_idle_gaps(nsys_db):
-    from resources.profilers.nsys.analyze_nsys import _build_string_map, analyze_gpu_idle_gaps
+    from resources.profilers.nsys.analyze_nsys import (  # pyright: ignore[reportMissingImports]
+        _build_string_map,
+        analyze_gpu_idle_gaps,
+    )
 
     conn = sqlite3.connect(nsys_db)
     strings = _build_string_map(conn)
@@ -274,7 +291,9 @@ def test_analyze_gpu_idle_gaps(nsys_db):
 
 
 def test_analyze_memory_ops(nsys_db):
-    from resources.profilers.nsys.analyze_nsys import analyze_memory_ops
+    from resources.profilers.nsys.analyze_nsys import (  # pyright: ignore[reportMissingImports]
+        analyze_memory_ops,
+    )
 
     conn = sqlite3.connect(nsys_db)
     result = analyze_memory_ops(conn)
@@ -284,7 +303,9 @@ def test_analyze_memory_ops(nsys_db):
 
 
 def test_short_kernel_name():
-    from resources.profilers.nsys.analyze_nsys import _short_kernel_name
+    from resources.profilers.nsys.analyze_nsys import (  # pyright: ignore[reportMissingImports]
+        _short_kernel_name,
+    )
 
     assert (
         _short_kernel_name("void at::native::vectorized_elementwise_kernel<4, float>")

--- a/tests/loops/test_profiler_mcp.py
+++ b/tests/loops/test_profiler_mcp.py
@@ -22,7 +22,7 @@ from vibesys.profilers import ProfilerKind
 # importing them by file path keeps the tests decoupled from sys.path state.
 def _load_module(name: str, path: Path):
     spec = importlib.util.spec_from_file_location(name, str(path))
-    module = importlib.util.module_from_spec(spec)
+    module = importlib.util.module_from_spec(spec)  # pyright: ignore[reportArgumentType]  # tracked: #297
     # Inject the server's parent dir onto sys.path BEFORE exec so the
     # server's ``import analyze_nsys`` / ``import analyze_torch_profile``
     # succeeds.
@@ -32,7 +32,7 @@ def _load_module(name: str, path: Path):
         sys.path.insert(0, parent)
         inserted = True
     try:
-        spec.loader.exec_module(module)
+        spec.loader.exec_module(module)  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     finally:
         if inserted:
             sys.path.remove(parent)
@@ -46,29 +46,29 @@ def test_profiler_mcp_spec_maps_known_kinds_exactly():
     assert mcp_spec(ProfilerKind.NONE) is None
 
     nsys = mcp_spec(ProfilerKind.NSYS)
-    assert nsys.name == "vibesys-nsys-profiler"
-    assert nsys.args == ["nsys_profiler/server.py"]
+    assert nsys.name == "vibesys-nsys-profiler"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    assert nsys.args == ["nsys_profiler/server.py"]  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     torch = mcp_spec(ProfilerKind.TORCH)
-    assert torch.name == "vibesys-torch-profiler"
-    assert torch.args == ["torch_profiler/server.py"]
+    assert torch.name == "vibesys-torch-profiler"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    assert torch.args == ["torch_profiler/server.py"]  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     neuron = mcp_spec(ProfilerKind.NEURON)
-    assert neuron.name == "vibesys-neuron-profiler"
-    assert neuron.args == ["neuron_profiler/server.py"]
+    assert neuron.name == "vibesys-neuron-profiler"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    assert neuron.args == ["neuron_profiler/server.py"]  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     otel = mcp_spec(ProfilerKind.OTEL)
-    assert otel.name == "vibesys-otel-profiler"
-    assert otel.args == ["otel_profiler/server.py"]
+    assert otel.name == "vibesys-otel-profiler"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    assert otel.args == ["otel_profiler/server.py"]  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     macos = mcp_spec(ProfilerKind.MACOS_CPU)
-    assert macos.name == "vibesys-macos-cpu-profiler"
-    assert macos.args == ["macos_cpu_profiler/server.py"]
+    assert macos.name == "vibesys-macos-cpu-profiler"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    assert macos.args == ["macos_cpu_profiler/server.py"]  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
 
 def test_profiler_mcp_spec_rejects_unknown_kind():
     with pytest.raises(TypeError, match="ProfilerKind"):
-        mcp_spec("bogus")
+        mcp_spec("bogus")  # pyright: ignore[reportArgumentType]  # tracked: #297
 
 
 @pytest.fixture(scope="module")

--- a/tests/render/test_sink.py
+++ b/tests/render/test_sink.py
@@ -41,7 +41,7 @@ class TestSubscription:
         sink = OutputSink()
         seen, unsubscribe = _collect(sink)
         sink.agent_output("one")
-        unsubscribe()
+        unsubscribe()  # pyright: ignore[reportCallIssue]  # tracked: #297
         sink.agent_output("two")
         assert [e.data.content for e in seen if isinstance(e.data, AgentOutputChunkData)] == ["one"]
 

--- a/tests/sandbox/test_run_environment.py
+++ b/tests/sandbox/test_run_environment.py
@@ -41,8 +41,8 @@ def _request(tmp_path: Path, backend: FakeBackend, **overrides):
         cli_provider=None,
     )
     values.update(overrides)
-    values["log_dir"].mkdir(exist_ok=True)
-    return RunEnvironmentRequest(**values)
+    values["log_dir"].mkdir(exist_ok=True)  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    return RunEnvironmentRequest(**values)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
 
 def test_cli_compatibility_flags_keep_options_scoped_to_selected_environment():
@@ -288,7 +288,7 @@ def test_modal_environment_owns_candidate_runtime_naming(tmp_path):
     assert runtime.deployment_name is not None
     assert runtime.deployment_name.endswith("-g12c7")
     assert len(runtime.deployment_name) <= 63
-    assert session.view.deployment_namespace in runtime.prompt_notes
+    assert session.view.deployment_namespace in runtime.prompt_notes  # pyright: ignore[reportOperatorIssue]  # tracked: #297
     assert "Candidate-specific namespace override" in runtime.prompt_notes
     assert runtime.deployment_name in runtime.prompt_notes
 
@@ -487,7 +487,7 @@ def test_modal_environment_per_run_namespace_prefix_unique(tmp_path):
         log_dir=log_a,
         workspace=ws_a,
         ref_dir=None,
-        backend=backend_a,
+        backend=backend_a,  # pyright: ignore[reportArgumentType]  # tracked: #297
         agent_backend="cli",
         cli_provider="codex",
     )
@@ -495,7 +495,7 @@ def test_modal_environment_per_run_namespace_prefix_unique(tmp_path):
         log_dir=log_b,
         workspace=ws_b,
         ref_dir=None,
-        backend=backend_b,
+        backend=backend_b,  # pyright: ignore[reportArgumentType]  # tracked: #297
         agent_backend="cli",
         cli_provider="codex",
     )
@@ -579,7 +579,7 @@ def test_docker_remove_workspace_child_quotes_path(tmp_path, monkeypatch):
     ok = env.remove_workspace_child(
         tmp_path,
         "semi;touch hacked",
-        backend=backend,
+        backend=backend,  # pyright: ignore[reportArgumentType]  # tracked: #297
     )
 
     assert ok is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,9 +41,9 @@ region = "us-east5"
         assert config.model.provider == "vertex-ai"
         assert config.thinking.level == "medium"
         assert config.thinking.budget is None
-        assert config.providers.vertex_ai.json_path == "~/keys/vertex.json"
-        assert config.providers.vertex_ai.project == "my-project"
-        assert config.providers.vertex_ai.region == "us-east5"
+        assert config.providers.vertex_ai.json_path == "~/keys/vertex.json"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert config.providers.vertex_ai.project == "my-project"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert config.providers.vertex_ai.region == "us-east5"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     def test_minimal_config(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
@@ -230,9 +230,9 @@ provider = "vertex-ai"
         with patch.dict("os.environ", env, clear=False):
             config = load_config(cfg_file)
         vx = config.providers.vertex_ai
-        assert vx.json_path == "/env/key.json"
-        assert vx.project == "env-project"
-        assert vx.region == "us-central1"
+        assert vx.json_path == "/env/key.json"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert vx.project == "env-project"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert vx.region == "us-central1"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
     def test_env_vars_override_toml(self, tmp_path):
         cfg_file = tmp_path / "agent.toml"
@@ -254,9 +254,9 @@ region = "us-east5"
         with patch.dict("os.environ", env, clear=False):
             config = load_config(cfg_file)
         vx = config.providers.vertex_ai
-        assert vx.json_path == "/env/key.json"
-        assert vx.project == "env-project"
-        assert vx.region == "us-central1"
+        assert vx.json_path == "/env/key.json"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert vx.project == "env-project"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        assert vx.region == "us-central1"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
 
 class TestLoadDotenvFile:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -93,7 +93,7 @@ def test_input_copy_respects_source_gitignore(tmp_path):
     destination = tmp_path / "workspace"
     workspace = Workspace(
         destination,
-        run_environment=SimpleNamespace(isolated=False),
+        run_environment=SimpleNamespace(isolated=False),  # pyright: ignore[reportArgumentType]  # tracked: #297
         backend=MagicMock(),
         log=MagicMock(),
         project_root=tmp_path,
@@ -256,7 +256,7 @@ def test_run_context_defaults_profiler_support_paths(
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
         create_run_context(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name=f"{profiler_kind}-defaults",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -281,7 +281,7 @@ def test_cli_context_skips_unused_langchain_model_construction(tmp_path):
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
         create_run_context(
-            config={
+            config={  # pyright: ignore[reportArgumentType]  # tracked: #297
                 "model": {"name": "gpt-5.6-sol"},
                 "thinking": {"level": "xhigh"},
                 "agent": {"backend": "cli", "cli_provider": "codex"},
@@ -321,7 +321,7 @@ def test_run_context_copies_only_selected_profiler_support(tmp_path, selected):
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
         create_run_context(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name=f"{selected.value}-support",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -361,7 +361,7 @@ def test_run_context_generic_auto_resolves_to_macos_profiler(tmp_path):
         patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
         patch("vibesys.profilers.platform.system", return_value="Darwin"),
         create_run_context(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="generic-auto-none",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -394,7 +394,7 @@ def test_run_context_generic_auto_resolves_to_linux_profiler(tmp_path):
         patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
         patch("vibesys.profilers.platform.system", return_value="Linux"),
         create_run_context(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="generic-auto-linux",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -438,7 +438,7 @@ def test_run_context_fails_fast_when_resolved_profiler_is_unusable(tmp_path):
         pytest.raises(ConfigurationError, match="Resolved profiler 'linux_cpu' is not usable"),
     ):
         create_run_context(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="generic-auto-linux-unusable",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -468,7 +468,7 @@ def test_run_context_rejects_generic_explicit_active_profilers(tmp_path, profile
         pytest.raises(ValueError, match="not supported for domain 'generic'"),
     ):
         create_run_context(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name=f"generic-{profiler_kind.value}",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -492,7 +492,7 @@ def test_run_context_llm_auto_uses_backend_profiler_and_defaults_support_dir(tmp
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
         create_run_context(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="llm-auto-nsys",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -522,7 +522,7 @@ def test_run_context_noop_environment_hooks_do_not_require_model_artifacts(tmp_p
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
         create_run_context(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="generic-reference-dir",
             input_path=str(ref_dir.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
@@ -574,8 +574,8 @@ def test_candidate_context_cleans_up_when_agent_runner_construction_fails(tmp_pa
         pytest.raises(SystemExit, match="boom"),
     ):
         create_candidate_context(
-            parent,
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            parent,  # pyright: ignore[reportArgumentType]  # tracked: #297
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             generation=1,
             child_idx=2,
             parent_commit="deadbeef",
@@ -597,8 +597,8 @@ def test_candidate_context_cleans_up_when_add_worktree_partially_fails(tmp_path)
 
     with pytest.raises(RuntimeError, match="git add failed"):
         create_candidate_context(
-            parent,
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            parent,  # pyright: ignore[reportArgumentType]  # tracked: #297
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             generation=1,
             child_idx=2,
             parent_commit="deadbeef",
@@ -622,7 +622,7 @@ def test_run_context_cleans_up_when_agent_runner_construction_fails(tmp_path):
         pytest.raises(RuntimeError, match="boom"),
     ):
         create_run_context(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="failed-construction",
             input_path=str(ref.parent),
             accuracy_command="check-accuracy",
@@ -650,7 +650,7 @@ def test_run_context_tears_down_prepared_hooks_when_workspace_setup_fails(tmp_pa
         pytest.raises(RuntimeError, match="setup failed"),
     ):
         create_run_context(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="failed-workspace-setup",
             input_path=str(ref.parent),
             accuracy_command="check-accuracy",
@@ -714,7 +714,7 @@ def test_run_context_materializes_input_project_path_dependencies(tmp_path):
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
         create_run_context(
-            config={"model": {"name": "claude-sonnet-4-6"}},
+            config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="input-local-package",
             input_path=str(ref_dir.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -201,7 +201,7 @@ class _FakeBackend:
 
 
 @pytest.fixture(autouse=True)
-def _native_profiler_preflight_ok(monkeypatch):
+def _native_profiler_preflight_ok(monkeypatch):  # pyright: ignore[reportUnusedFunction] -- autouse fixture, never referenced by name
     monkeypatch.setattr(
         "vibesys.context.preflight_profiler_kind",
         lambda kind: ProfilerPreflightResult(kind, True),

--- a/tests/test_device_lease.py
+++ b/tests/test_device_lease.py
@@ -11,19 +11,19 @@ from vibesys.run import DeviceLease
 
 def test_gpu_env_pins_selected_device(tmp_path):
     backend = SimpleNamespace(selected_device=SimpleNamespace(index=3))
-    lease = DeviceLease(backend, log_dir=tmp_path)
+    lease = DeviceLease(backend, log_dir=tmp_path)  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert lease.gpu_env() == {"CUDA_VISIBLE_DEVICES": "3"}
 
 
 def test_gpu_env_empty_without_device(tmp_path):
-    lease = DeviceLease(SimpleNamespace(), log_dir=tmp_path)
+    lease = DeviceLease(SimpleNamespace(), log_dir=tmp_path)  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert lease.gpu_env() == {}
 
 
 def test_reselect_skipped_when_view_disallows_host_reselect(tmp_path):
     backend = MagicMock()
     view = SimpleNamespace(host_device_reselect=False)
-    lease = DeviceLease(backend, log_dir=tmp_path, run_environment_view=view)
+    lease = DeviceLease(backend, log_dir=tmp_path, run_environment_view=view)  # pyright: ignore[reportArgumentType]  # tracked: #297
     lease.reselect()
     backend.reselect_device.assert_not_called()
 

--- a/tests/test_git_tracker.py
+++ b/tests/test_git_tracker.py
@@ -166,7 +166,7 @@ def test_checkout_tree_restores_snapshot_without_moving_head(ws):
     tracker.snapshot("round 1")
     second = tracker.current_sha()
 
-    assert tracker.checkout_tree(first) is True
+    assert tracker.checkout_tree(first) is True  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert (ws / "main.py").read_text() == "VALUE = 1\n"
     assert not (ws / "later.py").exists()
     # HEAD stays put so the next commit lands as a new child commit.
@@ -179,7 +179,7 @@ def test_checkout_tree_clean_removes_untracked_files(ws):
     first = tracker.current_sha()
 
     (ws / "leftover.txt").write_text("scratch\n")
-    assert tracker.checkout_tree(first, clean=True) is True
+    assert tracker.checkout_tree(first, clean=True) is True  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert not (ws / "leftover.txt").exists()
 
 
@@ -221,7 +221,7 @@ def test_checkout_tree_preserves_framework_memory_while_removing_later_code(ws):
     (progress / "round-0003.md").write_text("# Round 3 in progress\n")
 
     assert tracker.checkout_tree(
-        first,
+        first,  # pyright: ignore[reportArgumentType]  # tracked: #297
         clean=True,
         preserve_paths=("progress",),
     )

--- a/tests/test_llama_3_8b_benchmark.py
+++ b/tests/test_llama_3_8b_benchmark.py
@@ -107,11 +107,11 @@ def test_benchmark_reports_requested_and_observed_concurrency(monkeypatch):
         temperature,
         concurrency_stats=None,
     ):
-        concurrency_stats.request_started()
-        concurrency_stats.stream_opened()
+        concurrency_stats.request_started()  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        concurrency_stats.stream_opened()  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
         await asyncio.sleep(0)
-        concurrency_stats.stream_closed()
-        concurrency_stats.request_finished()
+        concurrency_stats.stream_closed()  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+        concurrency_stats.request_finished()  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
         return {
             "error": None,
             "output_tokens": 2,

--- a/tests/test_macos_cpu_profiler.py
+++ b/tests/test_macos_cpu_profiler.py
@@ -21,7 +21,7 @@ def test_command_line_tools_shim_falls_back_to_sample():
     capability = detect_capability(
         system="Darwin",
         which=lambda name: "/usr/bin/sample" if name == "sample" else None,
-        run=lambda *_args, **_kwargs: Result(stdout="/Library/Developer/CommandLineTools\n"),
+        run=lambda *_args, **_kwargs: Result(stdout="/Library/Developer/CommandLineTools\n"),  # pyright: ignore[reportArgumentType]  # tracked: #297
     )
     assert capability.tool is MacOSProfilerTool.SAMPLE
     assert DiagnosticCode.COMMAND_LINE_TOOLS_ONLY in capability.diagnostics
@@ -33,7 +33,7 @@ def test_missing_time_profiler_template_falls_back_to_sample():
             return Result(stdout="/Applications/Xcode.app/Contents/Developer\n")
         return Result(stdout="Activity Monitor\n")
 
-    capability = detect_capability(system="Darwin", which=lambda name: f"/usr/bin/{name}", run=run)
+    capability = detect_capability(system="Darwin", which=lambda name: f"/usr/bin/{name}", run=run)  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert capability.tool is MacOSProfilerTool.SAMPLE
     assert DiagnosticCode.TIME_PROFILER_UNAVAILABLE in capability.diagnostics
 
@@ -46,7 +46,7 @@ def test_functional_time_profiler_selects_instruments():
             return Result(stdout="Time Profiler\n")
         return Result(stdout="xctrace version 26.0\n")
 
-    capability = detect_capability(system="Darwin", which=lambda name: f"/usr/bin/{name}", run=run)
+    capability = detect_capability(system="Darwin", which=lambda name: f"/usr/bin/{name}", run=run)  # pyright: ignore[reportArgumentType]  # tracked: #297
     assert capability.tool is MacOSProfilerTool.XCTRACE
     assert capability.tool_version == "xctrace version 26.0"
 
@@ -66,7 +66,7 @@ def test_detection_reports_unavailable_tools_after_xcode_select_failure():
 
 def test_descendants_returns_nested_processes_and_ignores_malformed_rows():
     result = Result(stdout="10 1\n20 10\nmalformed\n30 20\n40 10\n10 30\n")
-    assert _descendants(10, run=lambda *_args, **_kwargs: result) == [20, 40, 30]
+    assert _descendants(10, run=lambda *_args, **_kwargs: result) == [20, 40, 30]  # pyright: ignore[reportArgumentType]  # tracked: #297
 
 
 def test_collection_persists_reproduction_metadata(tmp_path: Path):
@@ -129,7 +129,7 @@ def test_permission_failure_and_child_target_are_structured(tmp_path: Path):
     capability = detect_capability(
         system="Darwin",
         which=lambda name: "/usr/bin/sample" if name == "sample" else None,
-        run=lambda *_args, **_kwargs: Result(stdout="/Library/Developer/CommandLineTools\n"),
+        run=lambda *_args, **_kwargs: Result(stdout="/Library/Developer/CommandLineTools\n"),  # pyright: ignore[reportArgumentType]  # tracked: #297
     )
     process = type(
         "Process",

--- a/tests/test_profilers.py
+++ b/tests/test_profilers.py
@@ -77,7 +77,7 @@ def _expected_resolved(
     )
     if candidate not in allowed:
         raise ValueError
-    return candidate
+    return candidate  # pyright: ignore[reportReturnType]  # tracked: #297
 
 
 @pytest.mark.parametrize("domain", _DOMAINS)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -38,7 +38,7 @@ def test_skill_resource_selection_forbids_unknown_fields():
             skill="portable",
             resource_paths=[],
             purpose="Useful for this task.",
-            unexpected=True,
+            unexpected=True,  # pyright: ignore[reportCallIssue]  # tracked: #297
         )
 
 
@@ -48,7 +48,7 @@ def test_skill_resource_selection_rejects_whitespace_required_fields(field):
     values[field] = "   "
 
     with pytest.raises(ValidationError, match="non-whitespace"):
-        SkillResourceSelection(**values)
+        SkillResourceSelection(**values)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
 
 def test_agent_skill_selection_fields_are_zero_to_many_by_default():

--- a/tests/test_skills_wiring.py
+++ b/tests/test_skills_wiring.py
@@ -69,7 +69,8 @@ def _write_sidecar(root: Path, content: str) -> Path:
 
 def test_trainium_loads_nki_skills_from_sidecar_metadata(tmp_path):
     _, skills, backend = load_config_and_skills(
-        _args(tmp_path, ComputeBackend.TRAINIUM), domain=DomainName.LLM_SERVING
+        _args(tmp_path, ComputeBackend.TRAINIUM),  # pyright: ignore[reportArgumentType]  # tracked: #297
+        domain=DomainName.LLM_SERVING,
     )
     assert backend is ComputeBackend.TRAINIUM
     names = _skill_names(skills)
@@ -79,7 +80,8 @@ def test_trainium_loads_nki_skills_from_sidecar_metadata(tmp_path):
 
 def test_cuda_filters_out_trainium_scoped_nki_skills(tmp_path):
     _, skills, _ = load_config_and_skills(
-        _args(tmp_path, ComputeBackend.CUDA), domain=DomainName.LLM_SERVING
+        _args(tmp_path, ComputeBackend.CUDA),  # pyright: ignore[reportArgumentType]  # tracked: #297
+        domain=DomainName.LLM_SERVING,
     )
     names = _skill_names(skills)
     assert "serving-systems" in names
@@ -88,14 +90,14 @@ def test_cuda_filters_out_trainium_scoped_nki_skills(tmp_path):
 
 @pytest.mark.parametrize("domain", [DomainName.GENERIC, DomainName.MICROSERVICES])
 def test_non_serving_domains_filter_out_serving_systems(tmp_path, domain):
-    _, skills, _ = load_config_and_skills(_args(tmp_path, ComputeBackend.CUDA), domain=domain)
+    _, skills, _ = load_config_and_skills(_args(tmp_path, ComputeBackend.CUDA), domain=domain)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
     assert "serving-systems" not in _skill_names(skills)
 
 
 def test_no_skills_disables_even_compatible_skills(tmp_path):
     _, skills, _ = load_config_and_skills(
-        _args(tmp_path, ComputeBackend.TRAINIUM, no_skills=True),
+        _args(tmp_path, ComputeBackend.TRAINIUM, no_skills=True),  # pyright: ignore[reportArgumentType]  # tracked: #297
         domain=DomainName.LLM_SERVING,
     )
     assert skills is None

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -438,6 +438,7 @@ def test_cli_parse_failure_is_streamed_after_client_attaches():
             stream.write(SubscribeRequest(after_sequence=0).model_dump_json().encode() + b"\n")
             stream.flush()
             messages = []
+            events = []
             while True:
                 line = stream.readline()
                 if not line:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -47,7 +47,7 @@ def test_chat_is_audited_but_not_injected(tmp_path):
     started = next(
         event for event in supervisor.read_events() if event.type == "invocation_started"
     )
-    assert started.data.user_prompt == "original prompt"
+    assert started.data.user_prompt == "original prompt"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     event_types = [event["type"] for event in _events(tmp_path / "run-events.jsonl")]
     assert event_types.index("chat") < event_types.index("invocation_started")
 
@@ -88,7 +88,7 @@ def test_inspector_answers_round_and_failure_queries(tmp_path):
     supervisor = RunSupervisor()
     (tmp_path / "logs").mkdir()
     supervisor.attach(tmp_path / "logs")
-    (supervisor.log_dir / "progress.md").write_text(
+    (supervisor.log_dir / "progress.md").write_text(  # pyright: ignore[reportOptionalOperand]  # tracked: #297
         "## Round 1 — Judge\nPASS\n\n## Round 2 — Judge\nFAIL: latency regressed\n"
     )
     inspector = RunInspector(supervisor)
@@ -121,7 +121,7 @@ def test_side_channel_chat_output_is_tagged_without_changing_active_agent(tmp_pa
     assert [event.agent_kind for event in agent_events] == ["chat", "implementer"]
     assert agent_events[0].round_label == "experiment-chat"
     assert agent_events[0].invocation_id == "chat-1"
-    assert agent_events[1].data.content == "experiment output"
+    assert agent_events[1].data.content == "experiment output"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
 
 def test_bootstrap_events_migrate_to_run_audit_without_replacing_history(tmp_path):
@@ -235,7 +235,7 @@ def test_service_accepts_chat(tmp_path):
     supervisor.attach(tmp_path / "logs")
     service = SupervisionService(supervisor)
     chat = service.execute(ChatQuery(text="what is the current status?"))
-    assert chat.chat.question == "what is the current status?"
+    assert chat.chat.question == "what is the current status?"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     events = _events(tmp_path / "logs" / "run-events.jsonl")
     assert any(event["type"] == "chat" for event in events)
     assert any(event["type"] == "status_query" for event in events)
@@ -249,7 +249,7 @@ def test_service_routes_chat_to_configured_agent_handler(tmp_path):
 
     response = SupervisionService(supervisor).execute(ChatQuery(text="what changed?"))
 
-    assert response.chat.answer == "agent answer"
+    assert response.chat.answer == "agent answer"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     assert questions == ["what changed?"]
     assert response.events[-1].type is EventType.CHAT
     assert response.events[-1].agent_kind == "chat"
@@ -273,8 +273,8 @@ def test_chat_explains_configuration_failure_without_a_run_context(tmp_path):
 
     response = SupervisionService(supervisor).execute(ChatQuery(text="why did startup fail?"))
 
-    assert "config_loading" in response.chat.answer
-    assert "agent.toml was not found" in response.chat.answer
+    assert "config_loading" in response.chat.answer  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    assert "agent.toml was not found" in response.chat.answer  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
 
 
 def test_run_context_chat_exposes_trajectory_without_inlining_it_in_prompt(tmp_path):
@@ -562,8 +562,8 @@ def test_run_context_records_invocation_boundary(tmp_path):
         kind="implementer",
         system_prompt="system",
         user_prompt="original",
-        response_cls=dict,
-        fallback_factory=dict,
+        response_cls=dict,  # pyright: ignore[reportArgumentType]  # tracked: #297
+        fallback_factory=dict,  # pyright: ignore[reportArgumentType]  # tracked: #297
         round_label="round 6 attempt 2",
     )
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -20,7 +20,7 @@ from vibesys.run import CopySpec, InputProjectSpec, Workspace
 def _make_workspace(root, *, isolated=False, excluded_dirs=None, compute_backend=None):
     return Workspace(
         root,
-        run_environment=SimpleNamespace(isolated=isolated),
+        run_environment=SimpleNamespace(isolated=isolated),  # pyright: ignore[reportArgumentType]  # tracked: #297
         backend=MagicMock(),
         log=MagicMock(),
         project_root=root.parent,

--- a/tests/test_workspace_seed.py
+++ b/tests/test_workspace_seed.py
@@ -100,7 +100,7 @@ def _patched_context_dependencies(project_root: Path):
 
 def _make_context(input_dir: Path, seed: Path | None = None, **kwargs) -> _RunContext:
     return create_run_context(
-        config={"model": {"name": "claude-sonnet-4-6"}},
+        config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
         exp_name=kwargs.pop("exp_name", "workspace-seed"),
         input_path=str(input_dir),
         accuracy_command="accuracy-checker",


### PR DESCRIPTION
## Problem

Pyright runs in `strict` mode, but `[tool.pyright].include` only covered
`src` and `libs/*/src`. `tests/` and `libs/*/tests` (~28.6k lines, roughly
the same size as `src/`) were never type-checked at all — half the Python
in the repo was invisible to the strict checker.

That gap matters more than a test-only gap normally would, because test
code here builds typed fixtures (`MagicMock(spec=...)`, real
`MutatorResponse`/`JudgeResponse` objects, manifest and config models)
that encode assumptions about production contracts. When a contract
changes, untyped test code silently keeps compiling against the old
shape. The in-repo precedent for closing this is on the TypeScript side:
`clients/tui/tsconfig.check.json` sets `exclude: []` specifically so test
files are type-checked.

Closes #297. Part of #293 and #288.

## Solution

Added `tests` and `libs/*/tests` to `[tool.pyright].include`. Measuring
first: running the full tree at strict surfaced **4,445 errors**. ~77%
(3.4k) came from two rules alone (`reportMissingParameterType` /
`reportUnknownParameterType`), fired almost entirely on untyped pytest
fixture parameters (`tmp_path`, `monkeypatch`, custom fixtures).

#297 prefers a scoped `executionEnvironments` entry with a relaxed
`typeCheckingMode` over disabling rules. I verified whether pyright
1.1.411 honors `typeCheckingMode` set *inside* an `executionEnvironments`
entry: **it does not**. Setting it to `"standard"` and separately to
`"off"` on a `tests`-scoped environment left the error count unchanged
(4446 both times), versus a single rule-level override alone taking it to
1043. It is a top-level-only setting in this version, silently accepted
as a per-environment key. So the relaxation is spelled out explicitly
instead, in two tiers — both scoped to test paths only. `src` and
`libs/*/src` keep their existing environments and the unmodified strict
bar; the three pre-existing global relaxations
(`reportUnknownMemberType`/`Variable`/`ArgumentType`) and their
justifying comment are preserved verbatim.

**Tier 1 — rule-level, for rules categorically inapplicable to test
code.** Untyped fixture params and lambdas
(`reportMissingParameterType`, `reportUnknownParameterType`,
`reportUnknownLambdaType`), bare generics in ad hoc test data
(`reportMissingTypeArgument`), deliberate private-state/import access for
asserting on internals and monkeypatching (`reportPrivateUsage`,
`reportPrivateImportUsage`), and `unittest.mock`'s dynamic attribute
surface (`reportAttributeAccessIssue`, `reportFunctionMemberAccess`).
These have no annotation to check or are the documented way to write the
test, so a rule-level relaxation is the honest expression of that.

**Tier 2 — per-site suppressions with a ratchet, for everything else.**
The remaining 358 findings across 8 rules (`reportArgumentType`,
`reportOptionalMemberAccess`, `reportOperatorIssue`, `reportReturnType`,
`reportCallIssue`, `reportOptionalOperand`, `reportIndexIssue`,
`reportAbstractUsage`) can be real bugs rather than missing
declarations, so they must not become invisible. Setting them to `"none"`
would also silently accept every *future* violation of those 8 rules in
test code — no ratchet at all. Instead they stay at the strict default
and are suppressed at **233 individual sites** with
`# pyright: ignore[<rule>]  # tracked: #297`, backed by a new top-level:

```toml
reportUnnecessaryTypeIgnoreComment = "error"
```

That makes the baseline monotonically shrinking: once an underlying error
is fixed, its now-dead suppression becomes an error itself and must be
removed. This mirrors the `# noqa: CODE` + `RUF100` approach used for the
ruff rule expansion under the same parent. `grep 'tracked: #297'` yields
the burn-down list. Set at the top level, so it covers `src` and
`libs/*/src` too, not just the test paths whose baseline depends on it.

Every suppression names its specific rule; no bare `# type: ignore` was
added anywhere (relevant because a concurrent PR enables ruff's
`PGH003`).

**Dead suppressions removed (10).** Enabling
`reportUnnecessaryTypeIgnoreComment` flagged 10 pre-existing suppressions
as no longer doing anything, all removed:

- **2 in first-party source**, dead independently of this change (verified
  by running the ratchet against the original `main` include scope):
  `libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py` (dropped a stale
  `reportOptionalMemberAccess` from a two-rule ignore, kept the live
  `reportAssignmentType`) and `src/vibesys/loops/plain/loop.py` (a
  `# type: ignore[no-redef]` that suppressed nothing).
- **8 in `tests/`**, dead because those paths are newly checked and tier 1
  covers their rules: 7 × `# type: ignore[method-assign]` in
  `tests/agents/test_omnigent_backend.py`, 1 ×
  `# pyright: ignore[reportAttributeAccessIssue]` in
  `tests/backends/test_cuda_backend.py`.

**Genuine fixes rather than suppressions.** Small, single-instance issues
the new coverage surfaced were fixed properly:

- `tests/test_tui.py` — a genuinely possibly-unbound `events` variable.
- `tests/agents/test_agent_runners.py` — an always-true comparison from a
  too-narrow inferred literal type; annotated `str | None`.
- `tests/loops/plain/test_plain_loop_state.py` — two unused unpacked
  variables, renamed `_i`.
- `tests/_agent_cli/fixtures/agents.py` — a test double's `generate()`
  override was incompatible with `CodingAgent.generate`; widened the
  parameter types to match.
- `tests/loops/test_profiler.py` — 5 imports of a `resources/`
  runtime-only module that pytest's `pythonpath = ["."]` resolves at
  runtime but pyright cannot once `tests` has its own execution
  environment. I tried `extraPaths = ["."]` first; that made pyright
  treat the first-party `vibesys` package as an external stub-only
  dependency (`reportMissingTypeStubs`), so I reverted it and suppressed
  the 5 lines by name with an explanatory module docstring note.
- `tests/test_context.py` — one `autouse=True` fixture pyright cannot see
  is used, suppressed by name.

### Architecture

Config plus mechanical test annotations. No production code, runtime
behavior, or contract changed; the only non-test source edits are the two
dead-suppression removals. `[tool.pyright]` is the only `pyproject.toml`
section touched, per the coordination note that concurrent PRs are
modifying `[tool.ruff.lint]` and the coverage config in the same file.

## Verification

### Correctness properties

- `src` and `libs/*/src` remain at unmodified strict — no rule relaxed or
  added for those trees; the existing three-rule relaxation is
  byte-identical. Verified by appending a deliberate
  undeclared-attribute access to `src/vibesys/errors.py` and confirming
  pyright still flagged it, then reverting.
- `tests` and `libs/*/tests` are now type-checked at all (previously: not
  checked), at 0 errors.
- **The tier-2 baseline can only shrink.** Verified end-to-end in three
  directions, each producing exactly one error and then reverted:
  1. Removed a live suppression → the real error resurfaced
     (`reportOptionalMemberAccess`).
  2. Added a suppression on a clean line → rejected
     (`Unnecessary "# pyright: ignore" rule`).
  3. Properly fixed a suppressed site (narrowed the `Optional`) while
     leaving its ignore in place → the now-dead ignore was flagged.
  Direction 3 is the one that matters: fixing a finding forces removal of
  its suppression, so the count cannot silently stay flat.
- No blanket suppressions: every ignore added names its rule(s). No
  `# type: ignore` was added by this PR.

Residual, noted rather than changed: 12 pre-existing `# type: ignore[code]`
comments remain in `src` and `tests`. Pyright ignores the bracketed codes
and treats each as an all-rules suppression for its line, so they are
coarser than the new named ignores — but they are validated as still
necessary by the new setting, and ruff's `PGH003` accepts them since they
carry codes. Converting them to named `# pyright: ignore[...]` is a
mechanical follow-up, deliberately left out to keep this diff scoped.

### Testing

```
./scripts/check_format.sh   # All checks passed! (310 files already formatted)
./scripts/check_lint.sh     # All checks passed!
./scripts/check_types.sh    # 0 errors, 0 warnings, 0 informations
uv run pytest               # 2948 passed, 1 skipped
```

Error count: **4,445 → 0**, with 233 tracked per-site suppressions and 10
dead suppressions removed.

One process note for reviewers: `ruff format` reflowed 4 of the
mechanically-inserted comments off their error lines. The new
`reportUnnecessaryTypeIgnoreComment` setting caught all 4 immediately
(each showed up as a paired real-error + dead-ignore), and they were
repositioned by hand. That is the ratchet doing its job on its own
rollout.
