### PR TITLE
Extract round-state persistence into a typed vs-loop-state library

### DIFF
--- a/libs/vs-loop-state/pyproject.toml
+++ b/libs/vs-loop-state/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vs-loop-state"
+version = "0.1.0"
+description = "Typed, atomic on-disk round state for VibeSys loop drivers"
+requires-python = ">=3.12"
+dependencies = [
+    "pydantic>=2",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["vs_loop_state*"]
+
+[tool.setuptools.package-data]
+vs_loop_state = ["py.typed"]

--- a/libs/vs-loop-state/src/vs_loop_state/__init__.py
+++ b/libs/vs-loop-state/src/vs_loop_state/__init__.py
@@ -1,0 +1,14 @@
+"""Public API of the ``vs_loop_state`` library.
+
+``RoundRecord`` and ``RoundHistory`` are the deliberate surface consumers
+depend on. Everything else (JSON encoding, atomic writes, per-field legacy
+migrations) is an implementation detail of ``vs_loop_state.agent`` and
+``vs_loop_state.core``.
+"""
+
+from vs_loop_state.agent import RoundHistory, RoundRecord
+
+__all__ = [
+    "RoundHistory",
+    "RoundRecord",
+]

--- a/libs/vs-loop-state/src/vs_loop_state/agent.py
+++ b/libs/vs-loop-state/src/vs_loop_state/agent.py
@@ -1,0 +1,171 @@
+"""Round-record state for the agent loop: typed model, history, rollback resolution.
+
+``hypothesis_outcome`` and ``candidate_disposition`` are plain strings rather
+than enums: this library intentionally does not depend on ``vibesys``, which
+owns the actual ``HypothesisOutcome``/``CandidateDisposition`` vocabularies.
+Callers validate those values against their own enums and pass in the
+classification (e.g. which outcome strings count as a failure) rather than
+this module hard-coding it.
+
+``RoundRecord`` is a ``pydantic.dataclasses.dataclass`` rather than a
+``BaseModel``: callers construct it positionally/by-keyword exactly like a
+plain dataclass (matching how the framework's own tests build fixtures),
+while still getting field validation and ``extra="forbid"`` on load. On disk,
+``round_number`` is persisted under the key ``"round"``; that rename is
+handled at the JSON boundary rather than via a pydantic field alias, since an
+aliased first field without a plain default conflicts with dataclass
+field-ordering rules (a later required field would "follow a default
+argument").
+
+``RoundHistory`` is the public entry point for reading, mutating, and
+persisting a run's round history. How it's stored (JSON, atomic writes) is
+deliberately not part of its API.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Container
+from pathlib import Path
+from typing import Any
+
+from pydantic import ConfigDict, Field, TypeAdapter
+from pydantic.dataclasses import dataclass
+
+from vs_loop_state.core import atomic_write_json, read_json
+
+
+@dataclass(config=ConfigDict(extra="forbid"))
+class RoundRecord:
+    """One completed round of the agent loop."""
+
+    round_number: int
+    commit: str | None
+    perf_metric: float | None
+    perf_unit: str | None
+    passed: bool
+    # True when the orchestrator chose to skip profiling this round; the
+    # perf_metric (if any) was reused / inherited from a prior measurement
+    # rather than freshly measured this round. Plateau detection ignores
+    # these so a chain of skipped-profile rounds doesn't masquerade as a
+    # real plateau.
+    profile_skipped: bool = False
+    # False means the implementer was still investigating and sparse-review
+    # policy intentionally deferred both the independent judge and official
+    # framework gates. Such a round is provisional, not a failed attempt.
+    reviewed: bool = True
+    hypothesis_id: str | None = None
+    hypothesis_outcome: str | None = None
+    hypothesis_parent_round: int | None = None
+    # Exact tree from which this hypothesis started. This can be newer than
+    # the historical end-of-round checkpoint when an operator or framework
+    # repair lands between rounds.
+    hypothesis_parent_commit: str | None = None
+    metrics: dict[str, float] = Field(default_factory=dict)
+    evaluation_artifact: str | None = None
+    # Only framework-owned gates can set this. A judge-approved hypothesis may
+    # be a useful provisional working checkpoint without becoming the latest
+    # officially verified checkpoint.
+    official_evaluation: bool = False
+    official_evaluation_reason: str | None = None
+    # Candidate evidence is deliberately separate from official tracking. It
+    # may describe one directly comparable representative point rather than a
+    # full canonical evaluation and therefore never updates ``perf_metric`` or
+    # plateau detection by itself.
+    #
+    # Mirrors ``vibesys.schemas.CandidateDisposition.UNASSESSED.value``; kept
+    # as a plain string default rather than importing the enum (see module
+    # docstring).
+    candidate_disposition: str = "unassessed"
+    candidate_metrics: dict[str, float] = Field(default_factory=dict)
+    candidate_evaluation_artifact: str | None = None
+    candidate_operating_point: str = ""
+    candidate_retention_reason: str = ""
+
+
+_ROUND_RECORD_ADAPTER: TypeAdapter[RoundRecord] = TypeAdapter(RoundRecord)
+
+
+def _round_record_to_json(record: RoundRecord) -> dict[str, Any]:
+    dumped = _ROUND_RECORD_ADAPTER.dump_python(record, mode="json")
+    round_number = dumped.pop("round_number")
+    return {"round": round_number, **dumped}
+
+
+def _parse_round_record(data: dict[str, Any]) -> RoundRecord:
+    """Parse one raw JSON object (e.g. one entry of a persisted history) into a `RoundRecord`."""
+    if "round_number" not in data and "round" in data:
+        data = dict(data)
+        data["round_number"] = data.pop("round")
+    if "official_evaluation" not in data:
+        # Runs written before sparse official evaluation executed global
+        # gates for every proven candidate. Preserve that history when
+        # resuming rather than relabeling old checkpoints provisional.
+        data = dict(data)
+        data["official_evaluation"] = (
+            bool(data.get("passed", False)) and data.get("hypothesis_outcome") == "proven"
+        )
+    return _ROUND_RECORD_ADAPTER.validate_python(data)
+
+
+class RoundHistory:
+    """The round-by-round history of an agent-loop run.
+
+    Wraps the list of `RoundRecord`\\ s produced by a run together with where
+    (if anywhere) it's persisted. Construct with ``records=`` for a purely
+    in-memory history (e.g. in tests); use `RoundHistory.load` to read one
+    back from wherever it was previously saved.
+    """
+
+    def __init__(self, path: Path | None = None, records: list[RoundRecord] | None = None) -> None:
+        self.path = path
+        self.records: list[RoundRecord] = records if records is not None else []
+
+    @classmethod
+    def load(cls, path: Path) -> RoundHistory:
+        """Load the round history from *path*, or start empty if it doesn't exist yet."""
+        data = read_json(path)
+        records = [] if data is None else [_parse_round_record(entry) for entry in data]
+        return cls(path, records)
+
+    def save(self) -> None:
+        """Persist the current history, atomically, to the path it was loaded/created with."""
+        if self.path is None:
+            raise ValueError("RoundHistory has no path to save to")
+        atomic_write_json(self.path, [_round_record_to_json(record) for record in self.records])
+
+    def append(self, record: RoundRecord) -> None:
+        self.records.append(record)
+
+    def resolve_rollback_commit(
+        self,
+        target: RoundRecord,
+        failed_outcomes: Container[str],
+    ) -> tuple[str | None, int | None]:
+        """Resolve a requested parent round to the actual failed-child base tree.
+
+        A round record names the historical tree at the end of that round. An
+        immediately following hypothesis can start from a newer tree after a
+        validated operator or framework repair. If that child later fails,
+        restore its recorded pre-hypothesis tree instead of erasing those
+        independent repairs along with the failed implementation.
+
+        *failed_outcomes* names which ``hypothesis_outcome`` values count as
+        a failed hypothesis; the caller derives this from its own outcome
+        enum.
+
+        The second return value identifies the failed child whose base was
+        chosen; ``None`` means the historical target commit is used
+        unchanged.
+        """
+        if not self.records:
+            return target.commit, None
+        latest = self.records[-1]
+        if (
+            latest.round_number > target.round_number
+            and latest.hypothesis_parent_round == target.round_number
+            and latest.hypothesis_parent_commit is not None
+            and latest.hypothesis_outcome is not None
+            and latest.hypothesis_outcome in failed_outcomes
+        ):
+            return latest.hypothesis_parent_commit, latest.round_number
+        return target.commit, None

--- a/libs/vs-loop-state/src/vs_loop_state/agent.py
+++ b/libs/vs-loop-state/src/vs_loop_state/agent.py
@@ -24,14 +24,16 @@ deliberately not part of its API.
 
 from __future__ import annotations
 
-from collections.abc import Container
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import ConfigDict, Field, TypeAdapter
 from pydantic.dataclasses import dataclass
 
 from vs_loop_state.core import atomic_write_json, read_json
+
+if TYPE_CHECKING:
+    from collections.abc import Container
+    from pathlib import Path
 
 
 @dataclass(config=ConfigDict(extra="forbid"))
@@ -110,13 +112,14 @@ def _parse_round_record(data: dict[str, Any]) -> RoundRecord:
 class RoundHistory:
     """The round-by-round history of an agent-loop run.
 
-    Wraps the list of `RoundRecord`\\ s produced by a run together with where
+    Wraps the list of round records produced by a run together with where
     (if anywhere) it's persisted. Construct with ``records=`` for a purely
     in-memory history (e.g. in tests); use `RoundHistory.load` to read one
     back from wherever it was previously saved.
     """
 
     def __init__(self, path: Path | None = None, records: list[RoundRecord] | None = None) -> None:
+        """Wrap *records* (empty by default) together with the *path* to persist to."""
         self.path = path
         self.records: list[RoundRecord] = records if records is not None else []
 
@@ -130,10 +133,11 @@ class RoundHistory:
     def save(self) -> None:
         """Persist the current history, atomically, to the path it was loaded/created with."""
         if self.path is None:
-            raise ValueError("RoundHistory has no path to save to")
+            raise ValueError("RoundHistory has no path to save to")  # noqa: TRY003  # tracked: #288
         atomic_write_json(self.path, [_round_record_to_json(record) for record in self.records])
 
     def append(self, record: RoundRecord) -> None:
+        """Add *record* to the end of the history."""
         self.records.append(record)
 
     def resolve_rollback_commit(

--- a/libs/vs-loop-state/src/vs_loop_state/core.py
+++ b/libs/vs-loop-state/src/vs_loop_state/core.py
@@ -7,11 +7,13 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
-def atomic_write_json(path: Path, payload: Any) -> None:
+def atomic_write_json(path: Path, payload: Any) -> None:  # noqa: ANN401  # tracked: #288
     """Write *payload* to *path* as indented JSON, atomically.
 
     Writes to a sibling ``.tmp`` file first and ``os.replace``s it onto the
@@ -20,10 +22,10 @@ def atomic_write_json(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    os.replace(tmp, path)
+    os.replace(tmp, path)  # noqa: PTH105  # tracked: #288
 
 
-def read_json(path: Path) -> Any | None:
+def read_json(path: Path) -> Any | None:  # noqa: ANN401  # tracked: #288
     """Return the parsed JSON at *path*, or ``None`` if it doesn't exist."""
     if not path.exists():
         return None

--- a/libs/vs-loop-state/src/vs_loop_state/core.py
+++ b/libs/vs-loop-state/src/vs_loop_state/core.py
@@ -1,0 +1,30 @@
+"""Atomic JSON file persistence primitives shared by loop-state stores.
+
+Framework-neutral: no knowledge of any particular loop's schema lives here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+def atomic_write_json(path: Path, payload: Any) -> None:
+    """Write *payload* to *path* as indented JSON, atomically.
+
+    Writes to a sibling ``.tmp`` file first and ``os.replace``s it onto the
+    target, so a process killed mid-write cannot leave a truncated file.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def read_json(path: Path) -> Any | None:
+    """Return the parsed JSON at *path*, or ``None`` if it doesn't exist."""
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/libs/vs-loop-state/tests/test_vs_loop_state_agent.py
+++ b/libs/vs-loop-state/tests/test_vs_loop_state_agent.py
@@ -1,6 +1,7 @@
 """Tests for RoundRecord validation and RoundHistory persistence/rollback resolution."""
 
 import json
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -12,7 +13,7 @@ from vs_loop_state.agent import RoundHistory, RoundRecord
 # ---------------------------------------------------------------------------
 
 
-def test_persisted_round_uses_the_round_key_not_round_number(tmp_path):
+def test_persisted_round_uses_the_round_key_not_round_number(tmp_path: Path) -> None:
     path = tmp_path / "rounds.json"
     history = RoundHistory(path)
     history.append(
@@ -26,7 +27,7 @@ def test_persisted_round_uses_the_round_key_not_round_number(tmp_path):
     assert "round_number" not in raw[0]
 
 
-def test_load_rejects_unknown_fields(tmp_path):
+def test_load_rejects_unknown_fields(tmp_path: Path) -> None:
     path = tmp_path / "rounds.json"
     path.write_text(
         json.dumps(
@@ -47,7 +48,9 @@ def test_load_rejects_unknown_fields(tmp_path):
         RoundHistory.load(path)
 
 
-def test_legacy_record_without_official_evaluation_infers_from_proven_outcome(tmp_path):
+def test_legacy_record_without_official_evaluation_infers_from_proven_outcome(
+    tmp_path: Path,
+) -> None:
     path = tmp_path / "rounds.json"
     path.write_text(
         json.dumps(
@@ -78,7 +81,7 @@ def test_legacy_record_without_official_evaluation_infers_from_proven_outcome(tm
     assert history.records[1].official_evaluation is False
 
 
-def test_explicit_official_evaluation_is_not_overridden(tmp_path):
+def test_explicit_official_evaluation_is_not_overridden(tmp_path: Path) -> None:
     path = tmp_path / "rounds.json"
     path.write_text(
         json.dumps(
@@ -106,11 +109,11 @@ def test_explicit_official_evaluation_is_not_overridden(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_load_missing_file_starts_empty(tmp_path):
+def test_load_missing_file_starts_empty(tmp_path: Path) -> None:
     assert RoundHistory.load(tmp_path / "rounds.json").records == []
 
 
-def test_save_and_load_round_trips(tmp_path):
+def test_save_and_load_round_trips(tmp_path: Path) -> None:
     path = tmp_path / "rounds.json"
     history = RoundHistory(path)
     history.append(
@@ -128,10 +131,10 @@ def test_save_and_load_round_trips(tmp_path):
     assert reloaded.records == history.records
 
 
-def test_save_without_a_path_raises():
+def test_save_without_a_path_raises() -> None:
     history = RoundHistory(records=[])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="no path to save to"):
         history.save()
 
 
@@ -140,7 +143,7 @@ def test_save_without_a_path_raises():
 # ---------------------------------------------------------------------------
 
 
-def test_rollback_with_no_history_returns_target_commit_unchanged():
+def test_rollback_with_no_history_returns_target_commit_unchanged() -> None:
     target = RoundRecord(
         round_number=5, commit="a" * 40, perf_metric=None, perf_unit=None, passed=True
     )
@@ -152,7 +155,7 @@ def test_rollback_with_no_history_returns_target_commit_unchanged():
     assert child_round is None
 
 
-def test_failed_child_rollback_preserves_its_exact_parent_commit():
+def test_failed_child_rollback_preserves_its_exact_parent_commit() -> None:
     historical_parent = RoundRecord(
         round_number=20, commit="a" * 40, perf_metric=1400.0, perf_unit="tok/s", passed=True
     )
@@ -174,7 +177,7 @@ def test_failed_child_rollback_preserves_its_exact_parent_commit():
     assert child_round == 21
 
 
-def test_implementation_failed_child_rollback_preserves_its_exact_parent_commit():
+def test_implementation_failed_child_rollback_preserves_its_exact_parent_commit() -> None:
     historical_parent = RoundRecord(
         round_number=20, commit="a" * 40, perf_metric=1400.0, perf_unit="tok/s", passed=True
     )
@@ -198,7 +201,7 @@ def test_implementation_failed_child_rollback_preserves_its_exact_parent_commit(
     assert child_round == 21
 
 
-def test_rollback_ignores_outcomes_outside_the_caller_supplied_failure_set():
+def test_rollback_ignores_outcomes_outside_the_caller_supplied_failure_set() -> None:
     historical_parent = RoundRecord(
         round_number=20, commit="a" * 40, perf_metric=1400.0, perf_unit="tok/s", passed=True
     )
@@ -222,7 +225,7 @@ def test_rollback_ignores_outcomes_outside_the_caller_supplied_failure_set():
     assert child_round is None
 
 
-def test_distant_rollback_uses_requested_historical_commit():
+def test_distant_rollback_uses_requested_historical_commit() -> None:
     historical_parent = RoundRecord(
         round_number=5, commit="a" * 40, perf_metric=None, perf_unit=None, passed=True
     )

--- a/libs/vs-loop-state/tests/test_vs_loop_state_agent.py
+++ b/libs/vs-loop-state/tests/test_vs_loop_state_agent.py
@@ -1,0 +1,244 @@
+"""Tests for RoundRecord validation and RoundHistory persistence/rollback resolution."""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from vs_loop_state.agent import RoundHistory, RoundRecord
+
+# ---------------------------------------------------------------------------
+# On-disk shape
+# ---------------------------------------------------------------------------
+
+
+def test_persisted_round_uses_the_round_key_not_round_number(tmp_path):
+    path = tmp_path / "rounds.json"
+    history = RoundHistory(path)
+    history.append(
+        RoundRecord(round_number=3, commit="a" * 40, perf_metric=None, perf_unit=None, passed=True)
+    )
+
+    history.save()
+
+    raw = json.loads(path.read_text())
+    assert raw[0]["round"] == 3
+    assert "round_number" not in raw[0]
+
+
+def test_load_rejects_unknown_fields(tmp_path):
+    path = tmp_path / "rounds.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "round": 1,
+                    "commit": None,
+                    "perf_metric": None,
+                    "perf_unit": None,
+                    "passed": False,
+                    "made_up_field": "surprise",
+                }
+            ]
+        )
+    )
+
+    with pytest.raises(ValidationError):
+        RoundHistory.load(path)
+
+
+def test_legacy_record_without_official_evaluation_infers_from_proven_outcome(tmp_path):
+    path = tmp_path / "rounds.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "round": 1,
+                    "commit": "a" * 40,
+                    "perf_metric": 10.0,
+                    "perf_unit": "tok/s",
+                    "passed": True,
+                    "hypothesis_outcome": "proven",
+                },
+                {
+                    "round": 2,
+                    "commit": "b" * 40,
+                    "perf_metric": None,
+                    "perf_unit": None,
+                    "passed": False,
+                    "hypothesis_outcome": "disproven",
+                },
+            ]
+        )
+    )
+
+    history = RoundHistory.load(path)
+
+    assert history.records[0].official_evaluation is True
+    assert history.records[1].official_evaluation is False
+
+
+def test_explicit_official_evaluation_is_not_overridden(tmp_path):
+    path = tmp_path / "rounds.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "round": 1,
+                    "commit": "a" * 40,
+                    "perf_metric": None,
+                    "perf_unit": None,
+                    "passed": True,
+                    "hypothesis_outcome": "proven",
+                    "official_evaluation": False,
+                }
+            ]
+        )
+    )
+
+    history = RoundHistory.load(path)
+
+    assert history.records[0].official_evaluation is False
+
+
+# ---------------------------------------------------------------------------
+# RoundHistory persistence
+# ---------------------------------------------------------------------------
+
+
+def test_load_missing_file_starts_empty(tmp_path):
+    assert RoundHistory.load(tmp_path / "rounds.json").records == []
+
+
+def test_save_and_load_round_trips(tmp_path):
+    path = tmp_path / "rounds.json"
+    history = RoundHistory(path)
+    history.append(
+        RoundRecord(
+            round_number=1, commit="a" * 40, perf_metric=1.0, perf_unit="tok/s", passed=True
+        )
+    )
+    history.append(
+        RoundRecord(round_number=2, commit="b" * 40, perf_metric=None, perf_unit=None, passed=False)
+    )
+
+    history.save()
+    reloaded = RoundHistory.load(path)
+
+    assert reloaded.records == history.records
+
+
+def test_save_without_a_path_raises():
+    history = RoundHistory(records=[])
+
+    with pytest.raises(ValueError):
+        history.save()
+
+
+# ---------------------------------------------------------------------------
+# Rollback resolution
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_with_no_history_returns_target_commit_unchanged():
+    target = RoundRecord(
+        round_number=5, commit="a" * 40, perf_metric=None, perf_unit=None, passed=True
+    )
+    history = RoundHistory(records=[])
+
+    commit, child_round = history.resolve_rollback_commit(target, {"disproven"})
+
+    assert commit == "a" * 40
+    assert child_round is None
+
+
+def test_failed_child_rollback_preserves_its_exact_parent_commit():
+    historical_parent = RoundRecord(
+        round_number=20, commit="a" * 40, perf_metric=1400.0, perf_unit="tok/s", passed=True
+    )
+    failed_child = RoundRecord(
+        round_number=21,
+        commit="c" * 40,
+        perf_metric=None,
+        perf_unit=None,
+        passed=True,
+        hypothesis_outcome="disproven",
+        hypothesis_parent_round=20,
+        hypothesis_parent_commit="b" * 40,
+    )
+    history = RoundHistory(records=[historical_parent, failed_child])
+
+    commit, child_round = history.resolve_rollback_commit(historical_parent, {"disproven"})
+
+    assert commit == "b" * 40
+    assert child_round == 21
+
+
+def test_implementation_failed_child_rollback_preserves_its_exact_parent_commit():
+    historical_parent = RoundRecord(
+        round_number=20, commit="a" * 40, perf_metric=1400.0, perf_unit="tok/s", passed=True
+    )
+    failed_child = RoundRecord(
+        round_number=21,
+        commit="c" * 40,
+        perf_metric=None,
+        perf_unit=None,
+        passed=True,
+        hypothesis_outcome="implementation_failed",
+        hypothesis_parent_round=20,
+        hypothesis_parent_commit="b" * 40,
+    )
+    history = RoundHistory(records=[historical_parent, failed_child])
+
+    commit, child_round = history.resolve_rollback_commit(
+        historical_parent, {"implementation_failed"}
+    )
+
+    assert commit == "b" * 40
+    assert child_round == 21
+
+
+def test_rollback_ignores_outcomes_outside_the_caller_supplied_failure_set():
+    historical_parent = RoundRecord(
+        round_number=20, commit="a" * 40, perf_metric=1400.0, perf_unit="tok/s", passed=True
+    )
+    continuing_child = RoundRecord(
+        round_number=21,
+        commit="c" * 40,
+        perf_metric=None,
+        perf_unit=None,
+        passed=True,
+        hypothesis_outcome="continue",
+        hypothesis_parent_round=20,
+        hypothesis_parent_commit="b" * 40,
+    )
+    history = RoundHistory(records=[historical_parent, continuing_child])
+
+    commit, child_round = history.resolve_rollback_commit(
+        historical_parent, {"disproven", "implementation_failed"}
+    )
+
+    assert commit == "a" * 40
+    assert child_round is None
+
+
+def test_distant_rollback_uses_requested_historical_commit():
+    historical_parent = RoundRecord(
+        round_number=5, commit="a" * 40, perf_metric=None, perf_unit=None, passed=True
+    )
+    failed_child = RoundRecord(
+        round_number=21,
+        commit="c" * 40,
+        perf_metric=None,
+        perf_unit=None,
+        passed=True,
+        hypothesis_outcome="disproven",
+        hypothesis_parent_round=20,
+        hypothesis_parent_commit="b" * 40,
+    )
+    history = RoundHistory(records=[historical_parent, failed_child])
+
+    commit, child_round = history.resolve_rollback_commit(historical_parent, {"disproven"})
+
+    assert commit == "a" * 40
+    assert child_round is None

--- a/libs/vs-loop-state/tests/test_vs_loop_state_core.py
+++ b/libs/vs-loop-state/tests/test_vs_loop_state_core.py
@@ -1,34 +1,36 @@
 """Tests for the generic atomic JSON persistence primitives."""
 
+from pathlib import Path
+
 from vs_loop_state.core import atomic_write_json, read_json
 
 
-def test_read_json_missing_path_returns_none(tmp_path):
+def test_read_json_missing_path_returns_none(tmp_path: Path) -> None:
     assert read_json(tmp_path / "missing.json") is None
 
 
-def test_atomic_write_json_round_trips(tmp_path):
+def test_atomic_write_json_round_trips(tmp_path: Path) -> None:
     path = tmp_path / "state.json"
     atomic_write_json(path, {"a": 1, "b": [1, 2, 3]})
 
     assert read_json(path) == {"a": 1, "b": [1, 2, 3]}
 
 
-def test_atomic_write_json_creates_parent_directories(tmp_path):
+def test_atomic_write_json_creates_parent_directories(tmp_path: Path) -> None:
     path = tmp_path / "nested" / "dir" / "state.json"
     atomic_write_json(path, {"a": 1})
 
     assert read_json(path) == {"a": 1}
 
 
-def test_atomic_write_json_does_not_leave_tmp_file_behind(tmp_path):
+def test_atomic_write_json_does_not_leave_tmp_file_behind(tmp_path: Path) -> None:
     path = tmp_path / "state.json"
     atomic_write_json(path, {"a": 1})
 
     assert not (tmp_path / "state.json.tmp").exists()
 
 
-def test_atomic_write_json_overwrites_existing_file(tmp_path):
+def test_atomic_write_json_overwrites_existing_file(tmp_path: Path) -> None:
     path = tmp_path / "state.json"
     atomic_write_json(path, {"a": 1})
     atomic_write_json(path, {"a": 2})

--- a/libs/vs-loop-state/tests/test_vs_loop_state_core.py
+++ b/libs/vs-loop-state/tests/test_vs_loop_state_core.py
@@ -1,0 +1,36 @@
+"""Tests for the generic atomic JSON persistence primitives."""
+
+from vs_loop_state.core import atomic_write_json, read_json
+
+
+def test_read_json_missing_path_returns_none(tmp_path):
+    assert read_json(tmp_path / "missing.json") is None
+
+
+def test_atomic_write_json_round_trips(tmp_path):
+    path = tmp_path / "state.json"
+    atomic_write_json(path, {"a": 1, "b": [1, 2, 3]})
+
+    assert read_json(path) == {"a": 1, "b": [1, 2, 3]}
+
+
+def test_atomic_write_json_creates_parent_directories(tmp_path):
+    path = tmp_path / "nested" / "dir" / "state.json"
+    atomic_write_json(path, {"a": 1})
+
+    assert read_json(path) == {"a": 1}
+
+
+def test_atomic_write_json_does_not_leave_tmp_file_behind(tmp_path):
+    path = tmp_path / "state.json"
+    atomic_write_json(path, {"a": 1})
+
+    assert not (tmp_path / "state.json.tmp").exists()
+
+
+def test_atomic_write_json_overwrites_existing_file(tmp_path):
+    path = tmp_path / "state.json"
+    atomic_write_json(path, {"a": 1})
+    atomic_write_json(path, {"a": 2})
+
+    assert read_json(path) == {"a": 2}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "vs-feature-flags",
     "vs-github",
     "vs-issue-board",
+    "vs-loop-state",
     "vs-sandbox",
     "openevolve==0.3.1",
 ]
@@ -68,7 +69,7 @@ test = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests", "libs/vs-feature-flags/tests", "libs/vs-github/tests", "libs/vs-issue-board/tests", "libs/vs-sandbox/tests"]
+testpaths = ["tests", "libs/vs-feature-flags/tests", "libs/vs-github/tests", "libs/vs-issue-board/tests", "libs/vs-loop-state/tests", "libs/vs-sandbox/tests"]
 # Bare `--cov` measures the packages listed in `[tool.coverage.run] source`
 # below, so `uv run pytest` reports coverage locally without needing the full
 # flag string CI uses. CI layers on `--cov-report=xml`, `--cov-report=json`,
@@ -79,7 +80,7 @@ pythonpath = ["."]
 
 [tool.coverage.run]
 branch = true
-source = ["vibesys", "vs_feature_flags", "vs_github", "vs_issue_board", "vs_sandbox"]
+source = ["vibesys", "vs_feature_flags", "vs_github", "vs_issue_board", "vs_loop_state", "vs_sandbox"]
 relative_files = true
 omit = [
     # `python -m vibesys` launcher stub: one import and a guarded call into
@@ -123,7 +124,7 @@ allowlist = [
 [tool.ruff]
 line-length = 100
 target-version = "py312"
-src = ["src", "tests", "libs/vs-feature-flags/src", "libs/vs-feature-flags/tests", "libs/vs-github/src", "libs/vs-github/tests", "libs/vs-issue-board/src", "libs/vs-issue-board/tests", "libs/vs-sandbox/src", "libs/vs-sandbox/tests"]
+src = ["src", "tests", "libs/vs-feature-flags/src", "libs/vs-feature-flags/tests", "libs/vs-github/src", "libs/vs-github/tests", "libs/vs-issue-board/src", "libs/vs-issue-board/tests", "libs/vs-loop-state/src", "libs/vs-loop-state/tests", "libs/vs-sandbox/src", "libs/vs-sandbox/tests"]
 # resources/skills/ vendors reference code (submodule checkouts and copied
 # reference material) that VibeSys does not own and does not hold to repo
 # lint standards; see the UP040/UP046/UP047 note below.
@@ -195,7 +196,7 @@ reportUnknownArgumentType = "none"
 # `libs/*/src` too, not just the test paths whose baseline relies on it.
 reportUnnecessaryTypeIgnoreComment = "error"
 pythonVersion = "3.12"
-include = ["src", "tests", "libs/vs-feature-flags/src", "libs/vs-feature-flags/tests", "libs/vs-github/src", "libs/vs-github/tests", "libs/vs-issue-board/src", "libs/vs-issue-board/tests", "libs/vs-sandbox/src", "libs/vs-sandbox/tests"]
+include = ["src", "tests", "libs/vs-feature-flags/src", "libs/vs-feature-flags/tests", "libs/vs-github/src", "libs/vs-github/tests", "libs/vs-issue-board/src", "libs/vs-issue-board/tests", "libs/vs-loop-state/src", "libs/vs-loop-state/tests", "libs/vs-sandbox/src", "libs/vs-sandbox/tests"]
 # `tests` and `libs/*/tests` are included above so the strict checker actually
 # sees them (previously they were unchecked entirely). Running them at full
 # strict produced thousands of errors, almost all from patterns strict mode was
@@ -234,12 +235,14 @@ executionEnvironments = [
     { root = "libs/vs-feature-flags/src" },
     { root = "libs/vs-github/src" },
     { root = "libs/vs-issue-board/src" },
+    { root = "libs/vs-loop-state/src" },
     { root = "libs/vs-sandbox/src" },
     { root = "src" },
     { root = "tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none" },
     { root = "libs/vs-feature-flags/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none" },
     { root = "libs/vs-github/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none" },
     { root = "libs/vs-issue-board/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none" },
+    { root = "libs/vs-loop-state/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none" },
     { root = "libs/vs-sandbox/tests", reportMissingParameterType = "none", reportUnknownParameterType = "none", reportUnknownLambdaType = "none", reportMissingTypeArgument = "none", reportPrivateUsage = "none", reportPrivateImportUsage = "none", reportAttributeAccessIssue = "none", reportFunctionMemberAccess = "none" },
 ]
 
@@ -254,4 +257,5 @@ members = ["libs/*"]
 vs-feature-flags = { workspace = true }
 vs-github = { workspace = true }
 vs-issue-board = { workspace = true }
+vs-loop-state = { workspace = true }
 vs-sandbox = { workspace = true }

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -66,6 +66,7 @@ from vibesys.skills import (
     build_skill_catalog,
     resolve_skill_selections,
 )
+from vs_loop_state.agent import RoundHistory, RoundRecord
 
 # Candidate process boundaries selected by ``--interface``. Language, tooling,
 # and artifact requirements belong to the selected domain and input bundle.
@@ -78,109 +79,14 @@ _TEMPLATE_DIR = PROMPTS_DIR / "loops" / "agent"
 
 
 # ---------------------------------------------------------------------------
-# Rounds state (persisted to log_dir/rounds.json)
+# Active hypothesis state (persisted to log_dir/active_hypothesis.json)
+#
+# ``RoundRecord`` (persisted to log_dir/rounds.json) and its load/save/
+# rollback-resolution helpers live in the vs-loop-state library
+# (vs_loop_state.agent) — see its module docstring. ``_ActiveHypothesis``
+# stays here: it embeds ``OrchestratorPlan`` from ``vibesys.schemas``, which
+# that dependency-free library cannot import.
 # ---------------------------------------------------------------------------
-
-
-@dataclass
-class _RoundRecord:
-    round_number: int
-    commit: str | None
-    perf_metric: float | None
-    perf_unit: str | None
-    passed: bool
-    # True when the orchestrator chose to skip profiling this round; the
-    # perf_metric (if any) was reused / inherited from a prior measurement
-    # rather than freshly measured this round.  Plateau detection ignores
-    # these so a chain of skipped-profile rounds doesn't masquerade as a
-    # real plateau.
-    profile_skipped: bool = False
-    # False means the implementer was still investigating and sparse-review
-    # policy intentionally deferred both the independent judge and official
-    # framework gates. Such a round is provisional, not a failed attempt.
-    reviewed: bool = True
-    hypothesis_id: str | None = None
-    hypothesis_outcome: str | None = None
-    hypothesis_parent_round: int | None = None
-    # Exact tree from which this hypothesis started. This can be newer than
-    # the historical end-of-round checkpoint when an operator or framework
-    # repair lands between rounds.
-    hypothesis_parent_commit: str | None = None
-    metrics: dict[str, float] = field(default_factory=dict)
-    evaluation_artifact: str | None = None
-    # Only framework-owned gates can set this. A judge-approved hypothesis may
-    # be a useful provisional working checkpoint without becoming the latest
-    # officially verified checkpoint.
-    official_evaluation: bool = False
-    official_evaluation_reason: str | None = None
-    # Candidate evidence is deliberately separate from official tracking.
-    # It may describe one directly comparable representative point rather
-    # than a full canonical evaluation and therefore never updates
-    # ``perf_metric`` or plateau detection by itself.
-    candidate_disposition: str = CandidateDisposition.UNASSESSED.value
-    candidate_metrics: dict[str, float] = field(default_factory=dict)
-    candidate_evaluation_artifact: str | None = None
-    candidate_operating_point: str = ""
-    candidate_retention_reason: str = ""
-
-    def to_json(self) -> dict[str, Any]:
-        return {
-            "round": self.round_number,
-            "commit": self.commit,
-            "perf_metric": self.perf_metric,
-            "perf_unit": self.perf_unit,
-            "passed": self.passed,
-            "profile_skipped": self.profile_skipped,
-            "reviewed": self.reviewed,
-            "hypothesis_id": self.hypothesis_id,
-            "hypothesis_outcome": self.hypothesis_outcome,
-            "hypothesis_parent_round": self.hypothesis_parent_round,
-            "hypothesis_parent_commit": self.hypothesis_parent_commit,
-            "metrics": self.metrics,
-            "evaluation_artifact": self.evaluation_artifact,
-            "official_evaluation": self.official_evaluation,
-            "official_evaluation_reason": self.official_evaluation_reason,
-            "candidate_disposition": self.candidate_disposition,
-            "candidate_metrics": self.candidate_metrics,
-            "candidate_evaluation_artifact": self.candidate_evaluation_artifact,
-            "candidate_operating_point": self.candidate_operating_point,
-            "candidate_retention_reason": self.candidate_retention_reason,
-        }
-
-    @classmethod
-    def from_json(cls, data: dict[str, Any]) -> _RoundRecord:
-        return cls(
-            round_number=int(data["round"]),
-            commit=data.get("commit"),
-            perf_metric=data.get("perf_metric"),
-            perf_unit=data.get("perf_unit"),
-            passed=bool(data.get("passed", False)),
-            profile_skipped=bool(data.get("profile_skipped", False)),
-            reviewed=bool(data.get("reviewed", True)),
-            hypothesis_id=data.get("hypothesis_id"),
-            hypothesis_outcome=data.get("hypothesis_outcome"),
-            hypothesis_parent_round=data.get("hypothesis_parent_round"),
-            hypothesis_parent_commit=data.get("hypothesis_parent_commit"),
-            metrics=data.get("metrics", {}),
-            evaluation_artifact=data.get("evaluation_artifact"),
-            # Runs written before sparse official evaluation executed global
-            # gates for every proven candidate. Preserve that history when
-            # resuming rather than relabeling old checkpoints provisional.
-            official_evaluation=bool(
-                data.get(
-                    "official_evaluation",
-                    data.get("passed", False) and data.get("hypothesis_outcome") == "proven",
-                )
-            ),
-            official_evaluation_reason=data.get("official_evaluation_reason"),
-            candidate_disposition=data.get(
-                "candidate_disposition", CandidateDisposition.UNASSESSED.value
-            ),
-            candidate_metrics=data.get("candidate_metrics", {}),
-            candidate_evaluation_artifact=data.get("candidate_evaluation_artifact"),
-            candidate_operating_point=data.get("candidate_operating_point", ""),
-            candidate_retention_reason=data.get("candidate_retention_reason", ""),
-        )
 
 
 @dataclass
@@ -299,18 +205,6 @@ class _ActiveHypothesis:
         )
 
 
-def _load_rounds_state(path: Path) -> list[_RoundRecord]:
-    if not path.exists():
-        return []
-    data = json.loads(path.read_text())
-    return [_RoundRecord.from_json(d) for d in data]
-
-
-def _save_rounds_state(path: Path, records: list[_RoundRecord]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps([r.to_json() for r in records], indent=2))
-
-
 def _load_active_hypothesis(path: Path) -> _ActiveHypothesis | None:
     if not path.exists():
         return None
@@ -328,7 +222,7 @@ def _save_active_hypothesis(path: Path, state: _ActiveHypothesis | None) -> None
 
 def _backfill_revert_commit(
     state: _ActiveHypothesis | None,
-    records: list[_RoundRecord],
+    records: list[RoundRecord],
 ) -> bool:
     """Recover rollback provenance for state written before it was persisted.
 
@@ -411,36 +305,8 @@ def _implementation_keeps_hypothesis_active(
     )
 
 
-def _resolve_rollback_commit(
-    target: _RoundRecord,
-    records: list[_RoundRecord],
-) -> tuple[str | None, int | None]:
-    """Resolve a requested parent round to the actual failed-child base tree.
-
-    A round record names the historical tree at the end of that round. An
-    immediately following hypothesis can start from a newer tree after a
-    validated operator or framework repair. If that child later fails, restore
-    its recorded pre-hypothesis tree instead of erasing those independent
-    repairs along with the failed implementation.
-
-    The second return value identifies the failed child whose base was chosen;
-    ``None`` means the historical target commit is used unchanged.
-    """
-    if not records:
-        return target.commit, None
-    latest = records[-1]
-    if (
-        latest.round_number > target.round_number
-        and latest.hypothesis_parent_round == target.round_number
-        and latest.hypothesis_parent_commit is not None
-        and latest.hypothesis_outcome in _FAILED_HYPOTHESIS_OUTCOMES
-    ):
-        return latest.hypothesis_parent_commit, latest.round_number
-    return target.commit, None
-
-
-def _best_round(records: list[_RoundRecord]) -> _RoundRecord | None:
-    best: _RoundRecord | None = None
+def _best_round(records: list[RoundRecord]) -> RoundRecord | None:
+    best: RoundRecord | None = None
     best_metric = float("-inf")
     for r in records:
         if not r.official_evaluation:
@@ -462,7 +328,7 @@ def _best_round(records: list[_RoundRecord]) -> _RoundRecord | None:
 _DEFAULT_PARETO_RELATIVE_NOISE = 0.0
 
 
-def _record_candidate_metrics(record: _RoundRecord) -> dict[str, float]:
+def _record_candidate_metrics(record: RoundRecord) -> dict[str, float]:
     """Return the comparable objective row associated with *record*.
 
     Official metrics remain authoritative when present. Candidate metrics are
@@ -511,13 +377,13 @@ def _noise_aware_dominates(
 
 
 def _trusted_candidate_records(
-    records: list[_RoundRecord], objectives: list[Objective]
-) -> list[_RoundRecord]:
+    records: list[RoundRecord], objectives: list[Objective]
+) -> list[RoundRecord]:
     """Return reviewed checkpoints with complete comparable objective rows."""
     objective_names = {objective.name for objective in objectives}
     if not objective_names:
         return []
-    trusted: list[_RoundRecord] = []
+    trusted: list[RoundRecord] = []
     for record in records:
         metrics = _record_candidate_metrics(record)
         if not objective_names.issubset(metrics):
@@ -534,11 +400,11 @@ def _trusted_candidate_records(
 
 
 def _pareto_frontier_records(
-    records: list[_RoundRecord],
+    records: list[RoundRecord],
     objectives: list[Objective],
     *,
     relative_noise: float = _DEFAULT_PARETO_RELATIVE_NOISE,
-) -> list[_RoundRecord]:
+) -> list[RoundRecord]:
     """Compute the noise-aware frontier over independently reviewed points."""
     candidates = _trusted_candidate_records(records, objectives)
     return [
@@ -559,11 +425,11 @@ def _pareto_frontier_records(
 
 def _pareto_archive_dominators(
     candidate_metrics: dict[str, float],
-    records: list[_RoundRecord],
+    records: list[RoundRecord],
     objectives: list[Objective],
     *,
     relative_noise: float = _DEFAULT_PARETO_RELATIVE_NOISE,
-) -> list[_RoundRecord]:
+) -> list[RoundRecord]:
     """Return trusted archive points that dominate a proposed candidate row."""
     objective_names = {objective.name for objective in objectives}
     if not objective_names or not objective_names.issubset(candidate_metrics):
@@ -589,7 +455,7 @@ def _format_metric_row(metrics: dict[str, float], objectives: list[Objective]) -
 
 
 def _pareto_archive_summary(
-    records: list[_RoundRecord],
+    records: list[RoundRecord],
     objectives: list[Objective],
     *,
     relative_noise: float = _DEFAULT_PARETO_RELATIVE_NOISE,
@@ -658,7 +524,7 @@ def _pareto_archive_conflict(
     *,
     candidate_disposition: CandidateDisposition,
     candidate_metrics: dict[str, float],
-    records: list[_RoundRecord],
+    records: list[RoundRecord],
     objectives: list[Objective],
 ) -> str | None:
     """Explain why a claimed frontier row is dominated by the live archive."""
@@ -691,7 +557,7 @@ _PLATEAU_MIN_STREAK = 3
 
 
 def _detect_plateau(
-    records: list[_RoundRecord],
+    records: list[RoundRecord],
     *,
     threshold_pct: float = _PLATEAU_THRESHOLD_PCT,
     min_streak: int = _PLATEAU_MIN_STREAK,
@@ -785,7 +651,7 @@ def _review_due(
 
 def _candidate_evidence_is_fresh(
     implementation: ImplementerResponse,
-    records: list[_RoundRecord],
+    records: list[RoundRecord],
 ) -> bool:
     """Return whether an implementer reported a previously unseen objective row."""
     if not implementation.candidate_metrics:
@@ -802,7 +668,7 @@ def _candidate_evidence_is_fresh(
     )
 
 
-def _provisional_candidates_since_official(records: list[_RoundRecord]) -> int:
+def _provisional_candidates_since_official(records: list[RoundRecord]) -> int:
     """Count accepted candidate checkpoints after the latest official one."""
     count = 0
     for record in reversed(records):
@@ -822,7 +688,7 @@ def _provisional_candidates_since_official(records: list[_RoundRecord]) -> int:
 
 def _official_evaluation_reason(  # noqa: PLR0913  # tracked: #288
     *,
-    records: list[_RoundRecord],
+    records: list[RoundRecord],
     round_number: int,
     max_rounds: int,
     official_eval_every: int,
@@ -848,7 +714,7 @@ def _official_evaluation_reason(  # noqa: PLR0913  # tracked: #288
     return None
 
 
-def _terminal_workspace_notice(records: list[_RoundRecord]) -> str | None:
+def _terminal_workspace_notice(records: list[RoundRecord]) -> str | None:
     """Describe a terminal hypothesis whose edits remain in the workspace."""
     if not records:
         return None
@@ -1001,7 +867,7 @@ def _invoke_read_only_role(
             )
 
 
-def _is_fresh_cold_start(round_number: int, records: list[_RoundRecord]) -> bool:
+def _is_fresh_cold_start(round_number: int, records: list[RoundRecord]) -> bool:
     """True for round 1 of a fresh run (no prior rounds recorded)."""
     return round_number == 1 and not records
 
@@ -1618,7 +1484,7 @@ def _run_single_agent_round(  # noqa: PLR0913  # tracked: #288
     official_evaluation_due: bool = False,
     official_evaluation_reason: str | None = None,
     framework_benchmark_enabled: bool = False,
-    pareto_records: list[_RoundRecord] | None = None,
+    pareto_records: list[RoundRecord] | None = None,
     objectives: list[Objective] | None = None,
 ) -> SingleAgentRoundResponse:
     """Invoke one agent that plays implementer + judge + profiler.
@@ -2381,7 +2247,8 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     pareto_archive_location = issue_board.display_path(pareto_archive_path, ctx.workspace)
 
     rounds_state_path = ctx.log_dir / "rounds.json"
-    records = _load_rounds_state(rounds_state_path)
+    round_history = RoundHistory.load(rounds_state_path)
+    records = round_history.records
     active_hypothesis_path = ctx.log_dir / "active_hypothesis.json"
     active_hypothesis = _load_active_hypothesis(active_hypothesis_path)
     if _backfill_revert_commit(active_hypothesis, records):
@@ -2520,8 +2387,8 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         None,
                     )
                     if target and target.commit:
-                        rollback_commit, failed_child_round = _resolve_rollback_commit(
-                            target, records
+                        rollback_commit, failed_child_round = round_history.resolve_rollback_commit(
+                            target, _FAILED_HYPOTHESIS_OUTCOMES
                         )
                         assert rollback_commit is not None  # noqa: S101  # tracked: #288
                         # Restore the tree without moving HEAD so subsequent
@@ -3097,7 +2964,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         active_hypothesis.gate_approved_candidate_retention_reason
                     )
                 records.append(
-                    _RoundRecord(
+                    RoundRecord(
                         round_number=round_number,
                         commit=commit,
                         perf_metric=perf_metric,
@@ -3132,7 +2999,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         candidate_retention_reason=candidate_retention_reason,
                     )
                 )
-                _save_rounds_state(rounds_state_path, records)
+                round_history.save()
                 if ctx.supervisor is not None:
                     ctx.supervisor.record(
                         EventType.ROUND_FINISHED,

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -23,9 +23,7 @@ from vibesys.loops.agent.loop import (
     _pareto_archive_summary,
     _pareto_frontier_records,
     _provisional_candidates_since_official,
-    _resolve_rollback_commit,
     _review_due,
-    _RoundRecord,
     _run_framework_validation_gate,
     _terminal_workspace_notice,
     run_agent_loop,
@@ -47,6 +45,7 @@ from vibesys.schemas import (
     ValidationRecipeArtifact,
     Verdict,
 )
+from vs_loop_state.agent import RoundRecord
 
 # ---------------------------------------------------------------------------
 # Fixtures & helpers
@@ -75,7 +74,7 @@ def test_legacy_active_hypothesis_backfills_framework_revert_commit():  # noqa: 
         revert_applied=True,
     )
     records = [
-        _RoundRecord(
+        RoundRecord(
             round_number=28,
             commit="a" * 40,
             perf_metric=None,
@@ -89,85 +88,11 @@ def test_legacy_active_hypothesis_backfills_framework_revert_commit():  # noqa: 
     assert _backfill_revert_commit(state, records) is False
 
 
-def test_failed_child_rollback_preserves_its_exact_parent_commit():  # noqa: ANN201  # tracked: #288
-    historical_parent = _RoundRecord(
-        round_number=20,
-        commit="a" * 40,
-        perf_metric=1400.0,
-        perf_unit="tok/s",
-        passed=True,
-    )
-    failed_child = _RoundRecord(
-        round_number=21,
-        commit="c" * 40,
-        perf_metric=None,
-        perf_unit=None,
-        passed=True,
-        hypothesis_outcome="disproven",
-        hypothesis_parent_round=20,
-        hypothesis_parent_commit="b" * 40,
-    )
-
-    commit, child_round = _resolve_rollback_commit(
-        historical_parent, [historical_parent, failed_child]
-    )
-
-    assert commit == "b" * 40
-    assert child_round == 21
-
-
-def test_implementation_failed_child_rollback_preserves_its_exact_parent_commit():  # noqa: ANN201  # tracked: #288
-    historical_parent = _RoundRecord(
-        round_number=20,
-        commit="a" * 40,
-        perf_metric=1400.0,
-        perf_unit="tok/s",
-        passed=True,
-    )
-    failed_child = _RoundRecord(
-        round_number=21,
-        commit="c" * 40,
-        perf_metric=None,
-        perf_unit=None,
-        passed=True,
-        hypothesis_outcome=HypothesisOutcome.IMPLEMENTATION_FAILED.value,
-        hypothesis_parent_round=20,
-        hypothesis_parent_commit="b" * 40,
-    )
-
-    commit, child_round = _resolve_rollback_commit(
-        historical_parent, [historical_parent, failed_child]
-    )
-
-    assert commit == "b" * 40
-    assert child_round == 21
-
-
-def test_distant_rollback_uses_requested_historical_commit():  # noqa: ANN201  # tracked: #288
-    historical_parent = _RoundRecord(
-        round_number=5,
-        commit="a" * 40,
-        perf_metric=None,
-        perf_unit=None,
-        passed=True,
-    )
-    failed_child = _RoundRecord(
-        round_number=21,
-        commit="c" * 40,
-        perf_metric=None,
-        perf_unit=None,
-        passed=True,
-        hypothesis_outcome="disproven",
-        hypothesis_parent_round=20,
-        hypothesis_parent_commit="b" * 40,
-    )
-
-    commit, child_round = _resolve_rollback_commit(
-        historical_parent, [historical_parent, failed_child]
-    )
-
-    assert commit == "a" * 40
-    assert child_round is None
+# RoundRecord's persistence and rollback resolution (RoundHistory) now live
+# in libs/vs-loop-state; see its own tests
+# (libs/vs-loop-state/tests/test_vs_loop_state_agent.py) for that coverage,
+# including the failed-child, implementation-failed, and distant-rollback
+# cases previously duplicated here.
 
 
 @pytest.fixture
@@ -546,10 +471,10 @@ def test_orchestrator_plan_revert_round_optional():  # noqa: ANN201  # tracked: 
 
 def test_official_evaluation_cadence_counts_candidate_checkpoints_not_rounds():  # noqa: ANN201  # tracked: #288
     records = [
-        _RoundRecord(1, "a", None, None, False, reviewed=False, hypothesis_outcome="continue"),  # noqa: FBT003  # tracked: #288
-        _RoundRecord(2, "b", None, None, True, reviewed=True, hypothesis_outcome="proven"),  # noqa: FBT003  # tracked: #288
-        _RoundRecord(3, "c", None, None, False, reviewed=True, hypothesis_outcome="rejected"),  # noqa: FBT003  # tracked: #288
-        _RoundRecord(4, "d", None, None, True, reviewed=True, hypothesis_outcome="proven"),  # noqa: FBT003  # tracked: #288
+        RoundRecord(1, "a", None, None, False, reviewed=False, hypothesis_outcome="continue"),  # noqa: FBT003  # tracked: #288
+        RoundRecord(2, "b", None, None, True, reviewed=True, hypothesis_outcome="proven"),  # noqa: FBT003  # tracked: #288
+        RoundRecord(3, "c", None, None, False, reviewed=True, hypothesis_outcome="rejected"),  # noqa: FBT003  # tracked: #288
+        RoundRecord(4, "d", None, None, True, reviewed=True, hypothesis_outcome="proven"),  # noqa: FBT003  # tracked: #288
     ]
 
     assert _provisional_candidates_since_official(records) == 2
@@ -588,7 +513,7 @@ def test_measured_candidate_forces_review_even_when_disposition_is_downgraded():
 
 def test_reused_candidate_evidence_does_not_bypass_sparse_review():  # noqa: ANN201  # tracked: #288
     metrics = {"throughput": 6205.0, "latency": 10660.0}
-    record = _RoundRecord(
+    record = RoundRecord(
         round_number=75,
         commit="a" * 40,
         perf_metric=None,
@@ -620,7 +545,7 @@ def test_reused_candidate_evidence_does_not_bypass_sparse_review():  # noqa: ANN
 
 
 def test_changed_candidate_row_is_fresh_even_when_artifact_name_is_reused():  # noqa: ANN201  # tracked: #288
-    record = _RoundRecord(
+    record = RoundRecord(
         round_number=4,
         commit="a" * 40,
         perf_metric=None,
@@ -643,7 +568,7 @@ def test_changed_candidate_row_is_fresh_even_when_artifact_name_is_reused():  # 
 
 def test_official_evaluation_cadence_counts_reviewed_frontier_tradeoff():  # noqa: ANN201  # tracked: #288
     records = [
-        _RoundRecord(
+        RoundRecord(
             2,
             "b",
             None,
@@ -679,8 +604,8 @@ def test_noise_aware_dominance_preserves_sub_noise_alternatives():  # noqa: ANN2
 def test_pareto_frontier_keeps_throughput_latency_tradeoff_and_drops_dominated_point():  # noqa: ANN201  # tracked: #288
     objectives = [Objective("throughput", "max"), Objective("latency", "min")]
 
-    def candidate(round_number: int, throughput: float, latency: float) -> _RoundRecord:
-        return _RoundRecord(
+    def candidate(round_number: int, throughput: float, latency: float) -> RoundRecord:
+        return RoundRecord(
             round_number,
             str(round_number) * 40,
             None,
@@ -706,7 +631,7 @@ def test_live_archive_rejects_stale_frontier_claim_for_dominated_candidate():  #
     from vibesys.loops.agent.loop import _pareto_archive_conflict  # noqa: PLC0415  # tracked: #288
 
     objectives = [Objective("throughput", "max"), Objective("latency", "min")]
-    trusted = _RoundRecord(
+    trusted = RoundRecord(
         61,
         "a" * 40,
         None,
@@ -733,7 +658,7 @@ def test_live_archive_preserves_real_throughput_latency_tradeoff():  # noqa: ANN
     from vibesys.loops.agent.loop import _pareto_archive_conflict  # noqa: PLC0415  # tracked: #288
 
     objectives = [Objective("throughput", "max"), Objective("latency", "min")]
-    trusted = _RoundRecord(
+    trusted = RoundRecord(
         6,
         "a" * 40,
         None,
@@ -757,7 +682,7 @@ def test_live_archive_preserves_real_throughput_latency_tradeoff():  # noqa: ANN
 
 def test_pareto_archive_distinguishes_trusted_and_pending_candidates():  # noqa: ANN201  # tracked: #288
     objectives = [Objective("throughput", "max"), Objective("latency", "min")]
-    trusted = _RoundRecord(
+    trusted = RoundRecord(
         49,
         "a" * 40,
         None,
@@ -769,7 +694,7 @@ def test_pareto_archive_distinguishes_trusted_and_pending_candidates():  # noqa:
         candidate_evaluation_artifact="h31.json",
         candidate_operating_point="concurrency=128",
     )
-    pending = _RoundRecord(
+    pending = RoundRecord(
         51,
         "b" * 40,
         None,
@@ -793,7 +718,7 @@ def test_pareto_archive_distinguishes_trusted_and_pending_candidates():  # noqa:
 
 def test_official_evaluation_cadence_resets_at_verified_checkpoint():  # noqa: ANN201  # tracked: #288
     records = [
-        _RoundRecord(
+        RoundRecord(
             1,
             "a",
             10.0,
@@ -804,7 +729,7 @@ def test_official_evaluation_cadence_resets_at_verified_checkpoint():  # noqa: A
             official_evaluation=True,
             official_evaluation_reason="orchestrator_request",
         ),
-        _RoundRecord(2, "b", None, None, True, reviewed=True, hypothesis_outcome="proven"),  # noqa: FBT003  # tracked: #288
+        RoundRecord(2, "b", None, None, True, reviewed=True, hypothesis_outcome="proven"),  # noqa: FBT003  # tracked: #288
     ]
 
     assert _provisional_candidates_since_official(records) == 1
@@ -823,8 +748,8 @@ def test_official_evaluation_cadence_resets_at_verified_checkpoint():  # noqa: A
 
 def test_terminal_workspace_notice_points_designer_to_hypothesis_parent():  # noqa: ANN201  # tracked: #288
     records = [
-        _RoundRecord(28, "a" * 40, None, None, False),  # noqa: FBT003  # tracked: #288
-        _RoundRecord(
+        RoundRecord(28, "a" * 40, None, None, False),  # noqa: FBT003  # tracked: #288
+        RoundRecord(
             29,
             "b" * 40,
             None,
@@ -834,7 +759,7 @@ def test_terminal_workspace_notice_points_designer_to_hypothesis_parent():  # no
             hypothesis_id="bad-scheduler",
             hypothesis_outcome="rejected",
         ),
-        _RoundRecord(
+        RoundRecord(
             30,
             "c" * 40,
             None,
@@ -856,7 +781,7 @@ def test_terminal_workspace_notice_points_designer_to_hypothesis_parent():  # no
 
 
 def test_terminal_workspace_notice_preserves_pareto_tradeoff_commit():  # noqa: ANN201  # tracked: #288
-    record = _RoundRecord(
+    record = RoundRecord(
         51,
         "b" * 40,
         None,
@@ -879,8 +804,8 @@ def test_terminal_workspace_notice_preserves_pareto_tradeoff_commit():  # noqa: 
 
 def test_terminal_workspace_notice_preserves_credible_continuation_checkpoint():  # noqa: ANN201  # tracked: #288
     records = [
-        _RoundRecord(28, "a" * 40, None, None, False),  # noqa: FBT003  # tracked: #288
-        _RoundRecord(
+        RoundRecord(28, "a" * 40, None, None, False),  # noqa: FBT003  # tracked: #288
+        RoundRecord(
             34,
             "b" * 40,
             None,
@@ -891,7 +816,7 @@ def test_terminal_workspace_notice_preserves_credible_continuation_checkpoint():
             hypothesis_outcome="continue",
             hypothesis_parent_round=28,
         ),
-        _RoundRecord(
+        RoundRecord(
             35,
             "c" * 40,
             None,
@@ -902,7 +827,7 @@ def test_terminal_workspace_notice_preserves_credible_continuation_checkpoint():
             hypothesis_outcome="continue",
             hypothesis_parent_round=28,
         ),
-        _RoundRecord(
+        RoundRecord(
             36,
             "d" * 40,
             None,
@@ -926,8 +851,8 @@ def test_terminal_workspace_notice_preserves_credible_continuation_checkpoint():
 
 def test_terminal_workspace_notice_keeps_original_parent_after_same_id_reproposal():  # noqa: ANN201  # tracked: #288
     records = [
-        _RoundRecord(60, "a" * 40, None, None, True),  # noqa: FBT003  # tracked: #288
-        _RoundRecord(
+        RoundRecord(60, "a" * 40, None, None, True),  # noqa: FBT003  # tracked: #288
+        RoundRecord(
             61,
             "b" * 40,
             None,
@@ -938,7 +863,7 @@ def test_terminal_workspace_notice_keeps_original_parent_after_same_id_reproposa
             hypothesis_outcome="implementation_failed",
             hypothesis_parent_round=60,
         ),
-        _RoundRecord(
+        RoundRecord(
             62,
             "c" * 40,
             None,
@@ -949,7 +874,7 @@ def test_terminal_workspace_notice_keeps_original_parent_after_same_id_reproposa
             hypothesis_outcome="blocked",
             hypothesis_parent_round=60,
         ),
-        _RoundRecord(
+        RoundRecord(
             63,
             "d" * 40,
             None,
@@ -3100,10 +3025,8 @@ def test_pareto_archive_is_materialized_beside_progress(tmp_path, progress_name,
 
 
 def _record(round_number: int, perf: float | None, unit: str = "tok/s"):  # noqa: ANN202  # tracked: #288
-    """Build a _RoundRecord shorthand for plateau tests."""
-    from vibesys.loops.agent.loop import _RoundRecord  # noqa: PLC0415  # tracked: #288
-
-    return _RoundRecord(
+    """Build a RoundRecord shorthand for plateau tests."""
+    return RoundRecord(
         round_number=round_number,
         commit=f"sha{round_number:03d}",
         perf_metric=perf,

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,7 @@ members = [
     "vs-feature-flags",
     "vs-github",
     "vs-issue-board",
+    "vs-loop-state",
     "vs-sandbox",
 ]
 
@@ -4434,6 +4435,7 @@ dependencies = [
     { name = "vs-feature-flags" },
     { name = "vs-github" },
     { name = "vs-issue-board" },
+    { name = "vs-loop-state" },
     { name = "vs-sandbox" },
 ]
 
@@ -4477,6 +4479,7 @@ requires-dist = [
     { name = "vs-feature-flags", editable = "libs/vs-feature-flags" },
     { name = "vs-github", editable = "libs/vs-github" },
     { name = "vs-issue-board", editable = "libs/vs-issue-board" },
+    { name = "vs-loop-state", editable = "libs/vs-loop-state" },
     { name = "vs-sandbox", editable = "libs/vs-sandbox" },
 ]
 provides-extras = ["omnigent"]
@@ -4523,6 +4526,17 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.0" },
     { name = "pydantic", specifier = ">=2" },
 ]
+
+[[package]]
+name = "vs-loop-state"
+version = "0.1.0"
+source = { editable = "libs/vs-loop-state" }
+dependencies = [
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pydantic", specifier = ">=2" }]
 
 [[package]]
 name = "vs-sandbox"


### PR DESCRIPTION
## Problem

`_RoundRecord` (`src/vibesys/loops/agent/loop.py`) was a hand-rolled dataclass with three parallel sources of truth for its shape: the field list, a manually written `to_json()` key dict, and a manually written `from_json()` reconstruction. That's exactly the class of bug #291 patched around (`_FAILED_HYPOTHESIS_OUTCOMES` drifting from the `HypothesisOutcome` enum it was meant to mirror, fixed in #300) — nothing enforces these representations stay in sync.

Separately, persistence used `path.write_text(...)` to truncate-and-rewrite `rounds.json` in place on every round. A process killed mid-write (OOM-kill, SIGKILL, crash) can leave that file truncated or corrupted, with no atomicity and no validation on load (`from_json` uses permissive `.get()` defaults for everything, including unrecognized values).

This came out of a design discussion on the parent issue (#290, "Decompose run_agent_loop into round-scoped units") about what a more fundamental fix looks like versus another one-off patch.

## Solution

New package `libs/vs-loop-state` (`vs_loop_state.agent`), following the existing `libs/vs-*` leaf-package convention (own `pyproject.toml`, `src/` layout, own tests — same shape as `vs-issue-board`, which already does atomic JSON-file persistence for a different domain).

**Public API is deliberately small: `RoundRecord` and `RoundHistory`.** An earlier draft of this PR exposed `load_round_records`/`save_round_records`/`validate_round_record`/`resolve_rollback_commit` as free functions taking a path — that leaked the JSON-file implementation into the public surface. It's now:

```python
history = RoundHistory.load(path)      # or RoundHistory(records=[...]) for a purely in-memory one
history.records                        # list[RoundRecord]
history.append(record)
history.save()                         # atomic write; raises if constructed without a path
history.resolve_rollback_commit(target, failed_outcomes)
```
`atomic_write_json`/`read_json` (`core.py`) and the `round`↔`round_number` on-disk key rename are internal to `agent.py`/`core.py` now, not part of the package's `__init__.py` surface.

- **`RoundRecord`** is a `pydantic.dataclasses.dataclass` rather than a `BaseModel`. It keeps the exact same positional/keyword `__init__` signature as before (verified: existing test fixtures across `test_orchestrate.py` construct it positionally in ~40 places and needed no changes beyond the import), but now gets field validation and `extra="forbid"` on load — a corrupted or unexpectedly-shaped `rounds.json` entry now fails loudly instead of silently reconstructing with wrong defaults.
- **`RoundHistory.resolve_rollback_commit`** takes the failed-outcome set as an explicit parameter instead of hard-coding `HypothesisOutcome` vocabulary. The library has zero dependency on `vibesys` — matching every other `libs/vs-*` package — so it can't know about `HypothesisOutcome` directly. `agent/loop.py` keeps `_FAILED_HYPOTHESIS_OUTCOMES` (from #300) as the single owner of that classification and passes it in.
- The on-disk shape (JSON keys, key order) is unchanged for equivalent record content — verified directly and via a round-trip test.

### What deliberately stayed in `loop.py`

- **`_ActiveHypothesis`**: it embeds `OrchestratorPlan` from `vibesys.schemas`. Moving it would require either pulling `OrchestratorPlan` into the dependency-free library too (bigger, riskier scope) or making the field untyped — neither is a clean win for this PR.
- **`_best_round`, `_terminal_workspace_notice`, pareto-frontier functions (`_pareto_frontier_records` etc.)**: these are presentation/objective-comparison logic entangled with `Objective` from the evolve loop, not state persistence. Extracting them is a separate, larger decision and isn't needed to fix the identified persistence/typing problem.

This is scoped narrower than the full "decompose run_agent_loop" ask in #290 — it's the state-persistence and rollback-resolution slice of that issue's four named extraction units, done as a standalone, independently reviewable step, per #290's own guidance to stage this as multiple small PRs rather than one large rewrite.

### Architecture

```
libs/vs-loop-state/
  src/vs_loop_state/
    core.py    atomic_write_json / read_json — generic, no schema knowledge (internal)
    agent.py   RoundRecord, RoundHistory
    __init__.py  exports only RoundRecord, RoundHistory
  tests/
    test_vs_loop_state_core.py
    test_vs_loop_state_agent.py
```

`agent/loop.py`'s migration is a 4-line change, not a rewrite of the surrounding function: load once (`round_history = RoundHistory.load(rounds_state_path)`), bind `records = round_history.records` (the same list object — the ~20 other pure functions in `loop.py` keep reading `records` as a plain `list[RoundRecord]`, untouched, since `records.append(...)` already mutates `round_history.records` too), one `round_history.save()` call, one `round_history.resolve_rollback_commit(...)` call.

This branch is rebased onto `main` after #300 and #307 (the stricter ruff/pyright baseline) both landed; a second commit brings the new package into conformance with #307's expanded rule set (real type annotations on test functions, docstrings, `TYPE_CHECKING`-gated imports, and the same `# noqa: <RULE>  # tracked: #288` ratchet pattern the rest of the codebase already uses for the same categories: `os.replace` for atomic writes, `Any` for generic JSON payloads).

## Verification

### Correctness properties

- `rounds.json`'s on-disk shape (keys, key order, values) is unchanged for equivalent record content.
- `resolve_rollback_commit`'s behavior is unchanged: same four-condition gate, same two return values; only the failure-set source moved from a module constant to a parameter, and the call moved from a free function to a `RoundHistory` method.
- Loading rejects unrecognized fields (`extra="forbid"`) where the old code silently ignored them — called out explicitly as the one deliberate, minor behavior change (see `libs/vs-loop-state/src/vs_loop_state/agent.py` module docstring and `test_load_rejects_unknown_fields`). Since the old `to_json()`/new on-disk writer always fully re-serialize the declared field set (never incrementally patch), a `rounds.json` written by any version of this code cannot accumulate stale extra keys — this only matters for hand-edited or otherwise foreign files.
- Legacy records missing `official_evaluation` still infer it from `passed`/`hypothesis_outcome == "proven"`, matching the old `from_json` fallback (`test_legacy_record_without_official_evaluation_infers_from_proven_outcome`).
- `_ActiveHypothesis`, `_backfill_revert_commit`, and every other function in `loop.py` besides the ones listed above are untouched except for the `_RoundRecord` → `RoundRecord` type rename.

### Testing

- `uv run pytest libs/vs-loop-state/tests` — 17 passed, 99–100% coverage on the new package
- `uv run pytest tests/loops/agent/` — 272 passed
- `uv run pytest` (full repo) — 2963 passed, 1 pre-existing skip (macOS-only sandbox test)
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run pyright` (full repo) — 0 errors, 0 warnings