### PR TITLE
Extract _resolve_round_outcome from run_agent_loop (#290)

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -755,6 +755,29 @@ class _CarryOver:
     regression_info: str | None = None
     exhaustion_info: str | None = None
 
+@dataclass
+class _RoundOutcome:
+    """Resolved per-round metrics, outcome labels, and candidate evidence.
+
+    Computed once after the retry loop exits so that ``run_agent_loop``
+    can hand a single typed value to round-record persistence rather than
+    unpacking a dozen local variables inline.
+    """
+
+    perf_metric: float | None
+    perf_unit: str | None
+    profile_skipped: bool
+    accepted_metrics: dict[str, float]
+    accepted_evaluation_artifact: str | None
+    hypothesis_outcome: str | None
+    reviewed: bool
+    candidate_disposition: str
+    candidate_metrics: dict[str, float]
+    candidate_evaluation_artifact: str | None
+    candidate_operating_point: str
+    candidate_retention_reason: str
+    last_single_agent_response: SingleAgentRoundResponse | None
+
 
 def _review_due(
     *,
@@ -1005,6 +1028,192 @@ def _is_fresh_cold_start(round_number: int, records: list[_RoundRecord]) -> bool
     """True for round 1 of a fresh run (no prior rounds recorded)."""
     return round_number == 1 and not records
 
+
+def _resolve_round_outcome(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
+    *,
+    inner_loop: str,
+    passed: bool,
+    final_attempt_reviewed: bool,
+    completed_official_evaluation_reason: str | None,
+    framework_perf_metric: float | None,
+    benchmark_result: BenchmarkResult | None,
+    implementation: ImplementerResponse | None,
+    single_agent_response: SingleAgentRoundResponse | None,
+    active_hypothesis: _ActiveHypothesis,
+) -> _RoundOutcome:
+    """Resolve per-round metrics, outcome labels, and candidate evidence.
+
+    Called once after the retry loop exits.  All reads of
+    ``active_hypothesis`` are read-only here; the caller owns any
+    subsequent mutations.
+    """
+    reviewed = final_attempt_reviewed if inner_loop == "multi-agent" else True
+
+    # --- perf metric and profile-skipped flag ---
+    last_single_agent_response: SingleAgentRoundResponse | None = None
+    if inner_loop == "single-agent":
+        if (
+            single_agent_response is not None
+            and framework_perf_metric is not None
+            and completed_official_evaluation_reason is not None
+        ):
+            single_agent_response.perf_metric = framework_perf_metric
+            single_agent_response.perf_unit = (
+                benchmark_result.metric if benchmark_result else None
+            )
+        profile_skipped = single_agent_response is None or (
+            single_agent_response.perf_metric is None
+        )
+        perf_metric = (
+            single_agent_response.perf_metric
+            if (
+                single_agent_response
+                and passed
+                and completed_official_evaluation_reason is not None
+            )
+            else None
+        )
+        perf_unit = (
+            single_agent_response.perf_unit
+            if (
+                single_agent_response
+                and passed
+                and completed_official_evaluation_reason is not None
+            )
+            else None
+        )
+        accepted_metrics: dict[str, float] = {}
+        accepted_evaluation_artifact: str | None = None
+        if single_agent_response is not None:
+            last_single_agent_response = single_agent_response
+    else:
+        implementation_metric = (
+            implementation.perf_metric
+            if (
+                implementation is not None
+                and passed
+                and completed_official_evaluation_reason is not None
+            )
+            else None
+        )
+        if (
+            implementation_metric is None
+            and passed
+            and implementation is not None
+            and implementation.hypothesis_outcome
+            in {HypothesisOutcome.SUPPORTED, HypothesisOutcome.NOMINATED}
+            and active_hypothesis.gate_revalidation_pending
+            and completed_official_evaluation_reason is not None
+        ):
+            implementation_metric = active_hypothesis.gate_approved_perf_metric
+        profile_skipped = (
+            framework_perf_metric is None and implementation_metric is None
+        )
+        if (
+            framework_perf_metric is not None
+            and passed
+            and completed_official_evaluation_reason is not None
+        ):
+            perf_metric = framework_perf_metric
+            perf_unit = benchmark_result.metric if benchmark_result else None
+            accepted_metrics = {}
+            accepted_evaluation_artifact = None
+        elif implementation_metric is not None:
+            perf_metric = implementation_metric
+            if implementation is not None and implementation.perf_metric is not None:
+                perf_unit = implementation.perf_unit
+                accepted_metrics = dict(implementation.metrics)
+                accepted_evaluation_artifact = implementation.evaluation_artifact
+            else:
+                perf_unit = active_hypothesis.gate_approved_perf_unit
+                accepted_metrics = dict(active_hypothesis.gate_approved_metrics)
+                accepted_evaluation_artifact = (
+                    active_hypothesis.gate_approved_evaluation_artifact
+                )
+        else:
+            # Profiles and directional probes inform the designer,
+            # but only an official checkpoint may update the
+            # verified headline trajectory in rounds.json.
+            perf_metric = None
+            perf_unit = None
+            accepted_metrics = {}
+            accepted_evaluation_artifact = None
+
+    # --- hypothesis outcome label ---
+    if passed and inner_loop == "multi-agent" and implementation is not None:
+        hypothesis_outcome: str | None = (
+            "proven"
+            if implementation.hypothesis_outcome
+            in {HypothesisOutcome.SUPPORTED, HypothesisOutcome.NOMINATED}
+            else implementation.hypothesis_outcome.value
+        )
+    elif passed:
+        hypothesis_outcome = "proven"
+    elif reviewed:
+        hypothesis_outcome = "rejected"
+    elif implementation is not None:
+        hypothesis_outcome = implementation.hypothesis_outcome.value
+    else:
+        hypothesis_outcome = None
+
+    # --- candidate evidence ---
+    if implementation is not None:
+        candidate_disposition = implementation.candidate_disposition.value
+        candidate_metrics = dict(implementation.candidate_metrics)
+        candidate_evaluation_artifact = implementation.candidate_evaluation_artifact
+        candidate_operating_point = implementation.candidate_operating_point
+        candidate_retention_reason = implementation.candidate_retention_reason
+    elif single_agent_response is not None:
+        candidate_disposition = single_agent_response.candidate_disposition.value
+        candidate_metrics = dict(single_agent_response.candidate_metrics)
+        candidate_evaluation_artifact = (
+            single_agent_response.candidate_evaluation_artifact
+        )
+        candidate_operating_point = single_agent_response.candidate_operating_point
+        candidate_retention_reason = single_agent_response.candidate_retention_reason
+    else:
+        candidate_disposition = CandidateDisposition.UNASSESSED.value
+        candidate_metrics = {}
+        candidate_evaluation_artifact = None
+        candidate_operating_point = ""
+        candidate_retention_reason = ""
+
+    # A framework-gate retry may correctly return no fresh candidate
+    # row. Preserve the judge-approved provisional evidence for the
+    # unchanged checkpoint just as canonical evidence is preserved.
+    if (
+        candidate_disposition == CandidateDisposition.UNASSESSED.value
+        and active_hypothesis.gate_revalidation_pending
+        and active_hypothesis.gate_approved_candidate_disposition
+        == CandidateDisposition.PARETO_FRONTIER.value
+    ):
+        candidate_disposition = active_hypothesis.gate_approved_candidate_disposition
+        candidate_metrics = dict(active_hypothesis.gate_approved_candidate_metrics)
+        candidate_evaluation_artifact = (
+            active_hypothesis.gate_approved_candidate_evaluation_artifact
+        )
+        candidate_operating_point = (
+            active_hypothesis.gate_approved_candidate_operating_point
+        )
+        candidate_retention_reason = (
+            active_hypothesis.gate_approved_candidate_retention_reason
+        )
+
+    return _RoundOutcome(
+        perf_metric=perf_metric,
+        perf_unit=perf_unit,
+        profile_skipped=profile_skipped,
+        accepted_metrics=accepted_metrics,
+        accepted_evaluation_artifact=accepted_evaluation_artifact,
+        hypothesis_outcome=hypothesis_outcome,
+        reviewed=reviewed,
+        candidate_disposition=candidate_disposition,
+        candidate_metrics=candidate_metrics,
+        candidate_evaluation_artifact=candidate_evaluation_artifact,
+        candidate_operating_point=candidate_operating_point,
+        candidate_retention_reason=candidate_retention_reason,
+        last_single_agent_response=last_single_agent_response,
+    )
 
 def _run_pre_round_decision(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
@@ -2940,162 +3149,35 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         active_hypothesis.feedback = feedback
                         _save_active_hypothesis(active_hypothesis_path, active_hypothesis)
 
+
                 # --- Record round result & update carry-over ---
                 commit = ctx.git.current_sha() if ctx.git_tracking else None
-                # `profile_skipped` is True when no fresh profile ran this round
-                # (cold-start or the orchestrator/framework decided to skip).
-                # The plateau detector ignores skipped-profile rounds so cached
-                # / inherited perf numbers don't masquerade as fresh measurements.
-                #
-                # For single-agent inner loop, `profiler_summary` carries the
-                # PREVIOUS round's profile (fed forward to the orchestrator),
-                # so this round's perf comes from `single_agent_response` instead.
-                if inner_loop == "single-agent":
-                    if (
-                        single_agent_response is not None
-                        and framework_perf_metric is not None
-                        and completed_official_evaluation_reason is not None
-                    ):
-                        single_agent_response.perf_metric = framework_perf_metric
-                        single_agent_response.perf_unit = (
-                            benchmark_result.metric if benchmark_result else None
-                        )
-                    profile_skipped = single_agent_response is None or (
-                        single_agent_response.perf_metric is None
-                    )
-                    perf_metric = (
-                        single_agent_response.perf_metric
-                        if (
-                            single_agent_response
-                            and passed
-                            and completed_official_evaluation_reason is not None
-                        )
-                        else None
-                    )
-                    perf_unit = (
-                        single_agent_response.perf_unit
-                        if (
-                            single_agent_response
-                            and passed
-                            and completed_official_evaluation_reason is not None
-                        )
-                        else None
-                    )
-                    # Remember the latest profile for the orchestrator's next plan
-                    # and carry forward the implicit profile focus.
-                    if single_agent_response is not None:
-                        last_single_agent_response = single_agent_response
-                else:
-                    implementation_metric = (
-                        implementation.perf_metric
-                        if (
-                            implementation is not None
-                            and passed
-                            and completed_official_evaluation_reason is not None
-                        )
-                        else None
-                    )
-                    if (
-                        implementation_metric is None
-                        and passed
-                        and implementation is not None
-                        and implementation.hypothesis_outcome
-                        in {HypothesisOutcome.SUPPORTED, HypothesisOutcome.NOMINATED}
-                        and active_hypothesis.gate_revalidation_pending
-                        and completed_official_evaluation_reason is not None
-                    ):
-                        implementation_metric = active_hypothesis.gate_approved_perf_metric
-                    profile_skipped = (
-                        framework_perf_metric is None and implementation_metric is None
-                    )
-                    if (
-                        framework_perf_metric is not None
-                        and passed
-                        and completed_official_evaluation_reason is not None
-                    ):
-                        perf_metric = framework_perf_metric
-                        perf_unit = benchmark_result.metric if benchmark_result else None
-                    elif implementation_metric is not None:
-                        perf_metric = implementation_metric
-                        if implementation is not None and implementation.perf_metric is not None:
-                            perf_unit = implementation.perf_unit
-                            accepted_metrics = dict(implementation.metrics)
-                            accepted_evaluation_artifact = implementation.evaluation_artifact
-                        else:
-                            perf_unit = active_hypothesis.gate_approved_perf_unit
-                            accepted_metrics = dict(active_hypothesis.gate_approved_metrics)
-                            accepted_evaluation_artifact = (
-                                active_hypothesis.gate_approved_evaluation_artifact
-                            )
-                    else:
-                        # Profiles and directional probes inform the designer,
-                        # but only an official checkpoint may update the
-                        # verified headline trajectory in rounds.json.
-                        perf_metric = None
-                        perf_unit = None
-                # A prior retry may have been reviewed before the implementer
-                # returned a different terminal result.  Record and transition
-                # from the final attempt, not from any earlier audit in the
-                # round; otherwise an unreviewed ``disproven`` retry is
-                # mislabeled rejected and the dead hypothesis stays active.
-                reviewed = final_attempt_reviewed if inner_loop == "multi-agent" else True
-                if passed and inner_loop == "multi-agent" and implementation is not None:
-                    hypothesis_outcome = (
-                        "proven"
-                        if implementation.hypothesis_outcome
-                        in {HypothesisOutcome.SUPPORTED, HypothesisOutcome.NOMINATED}
-                        else implementation.hypothesis_outcome.value
-                    )
-                elif passed:
-                    hypothesis_outcome = "proven"
-                elif reviewed:
-                    hypothesis_outcome = "rejected"
-                elif implementation is not None:
-                    hypothesis_outcome = implementation.hypothesis_outcome.value
-                else:
-                    hypothesis_outcome = None
+                outcome = _resolve_round_outcome(
+                    inner_loop=inner_loop,
+                    passed=passed,
+                    final_attempt_reviewed=final_attempt_reviewed,
+                    completed_official_evaluation_reason=completed_official_evaluation_reason,
+                    framework_perf_metric=framework_perf_metric,
+                    benchmark_result=benchmark_result,
+                    implementation=implementation,
+                    single_agent_response=single_agent_response,
+                    active_hypothesis=active_hypothesis,
+                )
+                perf_metric = outcome.perf_metric
+                perf_unit = outcome.perf_unit
+                profile_skipped = outcome.profile_skipped
+                accepted_metrics = outcome.accepted_metrics
+                accepted_evaluation_artifact = outcome.accepted_evaluation_artifact
+                hypothesis_outcome = outcome.hypothesis_outcome
+                reviewed = outcome.reviewed
+                candidate_disposition = outcome.candidate_disposition
+                candidate_metrics = outcome.candidate_metrics
+                candidate_evaluation_artifact = outcome.candidate_evaluation_artifact
+                candidate_operating_point = outcome.candidate_operating_point
+                candidate_retention_reason = outcome.candidate_retention_reason
+                if outcome.last_single_agent_response is not None:
+                    last_single_agent_response = outcome.last_single_agent_response
 
-                if implementation is not None:
-                    candidate_disposition = implementation.candidate_disposition.value
-                    candidate_metrics = dict(implementation.candidate_metrics)
-                    candidate_evaluation_artifact = implementation.candidate_evaluation_artifact
-                    candidate_operating_point = implementation.candidate_operating_point
-                    candidate_retention_reason = implementation.candidate_retention_reason
-                elif single_agent_response is not None:
-                    candidate_disposition = single_agent_response.candidate_disposition.value
-                    candidate_metrics = dict(single_agent_response.candidate_metrics)
-                    candidate_evaluation_artifact = (
-                        single_agent_response.candidate_evaluation_artifact
-                    )
-                    candidate_operating_point = single_agent_response.candidate_operating_point
-                    candidate_retention_reason = single_agent_response.candidate_retention_reason
-                else:
-                    candidate_disposition = CandidateDisposition.UNASSESSED.value
-                    candidate_metrics = {}
-                    candidate_evaluation_artifact = None
-                    candidate_operating_point = ""
-                    candidate_retention_reason = ""
-
-                # A framework-gate retry may correctly return no fresh candidate
-                # row. Preserve the judge-approved provisional evidence for the
-                # unchanged checkpoint just as canonical evidence is preserved.
-                if (
-                    candidate_disposition == CandidateDisposition.UNASSESSED.value
-                    and active_hypothesis.gate_revalidation_pending
-                    and active_hypothesis.gate_approved_candidate_disposition
-                    == CandidateDisposition.PARETO_FRONTIER.value
-                ):
-                    candidate_disposition = active_hypothesis.gate_approved_candidate_disposition
-                    candidate_metrics = dict(active_hypothesis.gate_approved_candidate_metrics)
-                    candidate_evaluation_artifact = (
-                        active_hypothesis.gate_approved_candidate_evaluation_artifact
-                    )
-                    candidate_operating_point = (
-                        active_hypothesis.gate_approved_candidate_operating_point
-                    )
-                    candidate_retention_reason = (
-                        active_hypothesis.gate_approved_candidate_retention_reason
-                    )
                 records.append(
                     _RoundRecord(
                         round_number=round_number,

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -755,6 +755,7 @@ class _CarryOver:
     regression_info: str | None = None
     exhaustion_info: str | None = None
 
+
 @dataclass
 class _RoundOutcome:
     """Resolved per-round metrics, outcome labels, and candidate evidence.
@@ -1058,9 +1059,7 @@ def _resolve_round_outcome(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked:
             and completed_official_evaluation_reason is not None
         ):
             single_agent_response.perf_metric = framework_perf_metric
-            single_agent_response.perf_unit = (
-                benchmark_result.metric if benchmark_result else None
-            )
+            single_agent_response.perf_unit = benchmark_result.metric if benchmark_result else None
         profile_skipped = single_agent_response is None or (
             single_agent_response.perf_metric is None
         )
@@ -1106,9 +1105,7 @@ def _resolve_round_outcome(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked:
             and completed_official_evaluation_reason is not None
         ):
             implementation_metric = active_hypothesis.gate_approved_perf_metric
-        profile_skipped = (
-            framework_perf_metric is None and implementation_metric is None
-        )
+        profile_skipped = framework_perf_metric is None and implementation_metric is None
         if (
             framework_perf_metric is not None
             and passed
@@ -1127,9 +1124,7 @@ def _resolve_round_outcome(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked:
             else:
                 perf_unit = active_hypothesis.gate_approved_perf_unit
                 accepted_metrics = dict(active_hypothesis.gate_approved_metrics)
-                accepted_evaluation_artifact = (
-                    active_hypothesis.gate_approved_evaluation_artifact
-                )
+                accepted_evaluation_artifact = active_hypothesis.gate_approved_evaluation_artifact
         else:
             # Profiles and directional probes inform the designer,
             # but only an official checkpoint may update the
@@ -1166,9 +1161,7 @@ def _resolve_round_outcome(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked:
     elif single_agent_response is not None:
         candidate_disposition = single_agent_response.candidate_disposition.value
         candidate_metrics = dict(single_agent_response.candidate_metrics)
-        candidate_evaluation_artifact = (
-            single_agent_response.candidate_evaluation_artifact
-        )
+        candidate_evaluation_artifact = single_agent_response.candidate_evaluation_artifact
         candidate_operating_point = single_agent_response.candidate_operating_point
         candidate_retention_reason = single_agent_response.candidate_retention_reason
     else:
@@ -1192,12 +1185,8 @@ def _resolve_round_outcome(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked:
         candidate_evaluation_artifact = (
             active_hypothesis.gate_approved_candidate_evaluation_artifact
         )
-        candidate_operating_point = (
-            active_hypothesis.gate_approved_candidate_operating_point
-        )
-        candidate_retention_reason = (
-            active_hypothesis.gate_approved_candidate_retention_reason
-        )
+        candidate_operating_point = active_hypothesis.gate_approved_candidate_operating_point
+        candidate_retention_reason = active_hypothesis.gate_approved_candidate_retention_reason
 
     return _RoundOutcome(
         perf_metric=perf_metric,
@@ -1214,6 +1203,7 @@ def _resolve_round_outcome(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked:
         candidate_retention_reason=candidate_retention_reason,
         last_single_agent_response=last_single_agent_response,
     )
+
 
 def _run_pre_round_decision(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
@@ -3148,7 +3138,6 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         feedback = single_agent_response.feedback
                         active_hypothesis.feedback = feedback
                         _save_active_hypothesis(active_hypothesis_path, active_hypothesis)
-
 
                 # --- Record round result & update carry-over ---
                 commit = ctx.git.current_sha() if ctx.git_tracking else None

--- a/tests/loops/agent/test_resolve_round_outcome.py
+++ b/tests/loops/agent/test_resolve_round_outcome.py
@@ -1,3 +1,4 @@
+# ruff: noqa: ANN001, ANN201, PLR0913, S106
 """Unit tests for _resolve_round_outcome (issue #290)."""
 
 from vibesys.loops.agent.loop import (
@@ -15,9 +16,7 @@ from vibesys.schemas import (
 
 
 def _plan() -> OrchestratorPlan:
-    return OrchestratorPlan(
-        task="t", pass_criteria="p", hypothesis_id="h-1", reasoning="r"
-    )
+    return OrchestratorPlan(task="t", pass_criteria="p", hypothesis_id="h-1", reasoning="r")
 
 
 def _hypothesis() -> _ActiveHypothesis:

--- a/tests/loops/agent/test_resolve_round_outcome.py
+++ b/tests/loops/agent/test_resolve_round_outcome.py
@@ -1,0 +1,361 @@
+"""Unit tests for _resolve_round_outcome (issue #290)."""
+
+from vibesys.loops.agent.loop import (
+    _ActiveHypothesis,
+    _resolve_round_outcome,
+)
+from vibesys.schemas import (
+    CandidateDisposition,
+    HypothesisOutcome,
+    ImplementerResponse,
+    OrchestratorPlan,
+    SingleAgentRoundResponse,
+    Verdict,
+)
+
+
+def _plan() -> OrchestratorPlan:
+    return OrchestratorPlan(
+        task="t", pass_criteria="p", hypothesis_id="h-1", reasoning="r"
+    )
+
+
+def _hypothesis() -> _ActiveHypothesis:
+    return _ActiveHypothesis(plan=_plan(), started_round=1)
+
+
+def _implementer(
+    *,
+    outcome=HypothesisOutcome.SUPPORTED,
+    perf_metric=None,
+    perf_unit=None,
+    metrics=None,
+    evaluation_artifact=None,
+    candidate_disposition=CandidateDisposition.UNASSESSED,
+    candidate_metrics=None,
+    candidate_evaluation_artifact=None,
+    candidate_operating_point="",
+    candidate_retention_reason="",
+) -> ImplementerResponse:
+    return ImplementerResponse(
+        summary="s",
+        expected_behavior="b",
+        hypothesis_outcome=outcome,
+        evidence="e",
+        next_step="",
+        perf_metric=perf_metric,
+        perf_unit=perf_unit,
+        metrics=metrics or {},
+        evaluation_artifact=evaluation_artifact,
+        candidate_disposition=candidate_disposition,
+        candidate_metrics=candidate_metrics or {},
+        candidate_evaluation_artifact=candidate_evaluation_artifact,
+        candidate_operating_point=candidate_operating_point,
+        candidate_retention_reason=candidate_retention_reason,
+    )
+
+
+def _single_agent(
+    *,
+    verdict=Verdict.PASS,
+    perf_metric=None,
+    perf_unit=None,
+    candidate_disposition=CandidateDisposition.UNASSESSED,
+    candidate_metrics=None,
+) -> SingleAgentRoundResponse:
+    return SingleAgentRoundResponse(
+        summary="s",
+        expected_behavior="b",
+        self_review="r",
+        feedback="",
+        verdict=verdict,
+        bottlenecks="",
+        suggestions="",
+        profile_analysis="",
+        perf_metric=perf_metric,
+        perf_unit=perf_unit,
+        candidate_disposition=candidate_disposition,
+        candidate_metrics=candidate_metrics or {},
+    )
+
+
+def test_single_agent_pass_with_official_metric():
+    response = _single_agent()
+    outcome = _resolve_round_outcome(
+        inner_loop="single-agent",
+        passed=True,
+        final_attempt_reviewed=True,
+        completed_official_evaluation_reason="cadence",
+        framework_perf_metric=12.5,
+        benchmark_result=None,
+        implementation=None,
+        single_agent_response=response,
+        active_hypothesis=_hypothesis(),
+    )
+    assert outcome.perf_metric == 12.5
+    assert outcome.profile_skipped is False
+    assert outcome.hypothesis_outcome == "proven"
+    assert outcome.reviewed is True
+    assert outcome.last_single_agent_response is response
+
+
+def test_single_agent_no_response_profile_skipped():
+    outcome = _resolve_round_outcome(
+        inner_loop="single-agent",
+        passed=False,
+        final_attempt_reviewed=False,
+        completed_official_evaluation_reason=None,
+        framework_perf_metric=None,
+        benchmark_result=None,
+        implementation=None,
+        single_agent_response=None,
+        active_hypothesis=_hypothesis(),
+    )
+    assert outcome.profile_skipped is True
+    assert outcome.perf_metric is None
+    assert outcome.last_single_agent_response is None
+    assert outcome.hypothesis_outcome == "rejected"
+
+
+def test_single_agent_not_passed_but_reviewed_is_rejected():
+    response = _single_agent(verdict=Verdict.FAIL)
+    outcome = _resolve_round_outcome(
+        inner_loop="single-agent",
+        passed=False,
+        final_attempt_reviewed=True,
+        completed_official_evaluation_reason=None,
+        framework_perf_metric=None,
+        benchmark_result=None,
+        implementation=None,
+        single_agent_response=response,
+        active_hypothesis=_hypothesis(),
+    )
+    assert outcome.hypothesis_outcome == "rejected"
+    assert outcome.reviewed is True
+
+
+def test_multi_agent_framework_perf_metric_wins():
+    implementation = _implementer(perf_metric=1.0, perf_unit="tok/s")
+    outcome = _resolve_round_outcome(
+        inner_loop="multi-agent",
+        passed=True,
+        final_attempt_reviewed=True,
+        completed_official_evaluation_reason="cadence",
+        framework_perf_metric=99.0,
+        benchmark_result=None,
+        implementation=implementation,
+        single_agent_response=None,
+        active_hypothesis=_hypothesis(),
+    )
+    assert outcome.perf_metric == 99.0
+    assert outcome.accepted_metrics == {}
+    assert outcome.accepted_evaluation_artifact is None
+
+
+def test_multi_agent_implementation_metric_used_when_no_framework_metric():
+    implementation = _implementer(
+        perf_metric=5.0,
+        perf_unit="ms",
+        metrics={"latency_ms": 5.0},
+        evaluation_artifact="artifact.json",
+    )
+    outcome = _resolve_round_outcome(
+        inner_loop="multi-agent",
+        passed=True,
+        final_attempt_reviewed=True,
+        completed_official_evaluation_reason="cadence",
+        framework_perf_metric=None,
+        benchmark_result=None,
+        implementation=implementation,
+        single_agent_response=None,
+        active_hypothesis=_hypothesis(),
+    )
+    assert outcome.perf_metric == 5.0
+    assert outcome.perf_unit == "ms"
+    assert outcome.accepted_metrics == {"latency_ms": 5.0}
+    assert outcome.accepted_evaluation_artifact == "artifact.json"
+    assert outcome.profile_skipped is False
+
+
+def test_multi_agent_gate_revalidation_perf_fallback():
+    hyp = _hypothesis()
+    hyp.gate_revalidation_pending = True
+    hyp.gate_approved_perf_metric = 4.0
+    hyp.gate_approved_perf_unit = "ms"
+    hyp.gate_approved_metrics = {"latency_ms": 4.0}
+    hyp.gate_approved_evaluation_artifact = "prior.json"
+    implementation = _implementer(outcome=HypothesisOutcome.SUPPORTED, perf_metric=None)
+    outcome = _resolve_round_outcome(
+        inner_loop="multi-agent",
+        passed=True,
+        final_attempt_reviewed=True,
+        completed_official_evaluation_reason="cadence",
+        framework_perf_metric=None,
+        benchmark_result=None,
+        implementation=implementation,
+        single_agent_response=None,
+        active_hypothesis=hyp,
+    )
+    assert outcome.perf_metric == 4.0
+    assert outcome.perf_unit == "ms"
+    assert outcome.accepted_metrics == {"latency_ms": 4.0}
+    assert outcome.accepted_evaluation_artifact == "prior.json"
+
+
+def test_multi_agent_no_metric_at_all():
+    implementation = _implementer(perf_metric=None)
+    outcome = _resolve_round_outcome(
+        inner_loop="multi-agent",
+        passed=False,
+        final_attempt_reviewed=True,
+        completed_official_evaluation_reason=None,
+        framework_perf_metric=None,
+        benchmark_result=None,
+        implementation=implementation,
+        single_agent_response=None,
+        active_hypothesis=_hypothesis(),
+    )
+    assert outcome.perf_metric is None
+    assert outcome.perf_unit is None
+    assert outcome.profile_skipped is True
+    assert outcome.accepted_metrics == {}
+    assert outcome.accepted_evaluation_artifact is None
+
+
+def test_multi_agent_passed_nominated_labeled_proven():
+    implementation = _implementer(outcome=HypothesisOutcome.NOMINATED)
+    outcome = _resolve_round_outcome(
+        inner_loop="multi-agent",
+        passed=True,
+        final_attempt_reviewed=True,
+        completed_official_evaluation_reason="cadence",
+        framework_perf_metric=None,
+        benchmark_result=None,
+        implementation=implementation,
+        single_agent_response=None,
+        active_hypothesis=_hypothesis(),
+    )
+    assert outcome.hypothesis_outcome == "proven"
+
+
+def test_multi_agent_not_reviewed_uses_implementation_label():
+    implementation = _implementer(outcome=HypothesisOutcome.CONTINUE)
+    outcome = _resolve_round_outcome(
+        inner_loop="multi-agent",
+        passed=False,
+        final_attempt_reviewed=False,
+        completed_official_evaluation_reason=None,
+        framework_perf_metric=None,
+        benchmark_result=None,
+        implementation=implementation,
+        single_agent_response=None,
+        active_hypothesis=_hypothesis(),
+    )
+    assert outcome.hypothesis_outcome == HypothesisOutcome.CONTINUE.value
+    assert outcome.reviewed is False
+
+
+def test_no_implementation_and_not_passed_gives_none_label():
+    outcome = _resolve_round_outcome(
+        inner_loop="multi-agent",
+        passed=False,
+        final_attempt_reviewed=False,
+        completed_official_evaluation_reason=None,
+        framework_perf_metric=None,
+        benchmark_result=None,
+        implementation=None,
+        single_agent_response=None,
+        active_hypothesis=_hypothesis(),
+    )
+    assert outcome.hypothesis_outcome is None
+
+
+def test_candidate_evidence_from_implementation():
+    implementation = _implementer(
+        candidate_disposition=CandidateDisposition.PARETO_FRONTIER,
+        candidate_metrics={"latency_ms": 3.0},
+        candidate_evaluation_artifact="c.json",
+        candidate_operating_point="op",
+        candidate_retention_reason="reason",
+    )
+    outcome = _resolve_round_outcome(
+        inner_loop="multi-agent",
+        passed=True,
+        final_attempt_reviewed=True,
+        completed_official_evaluation_reason="cadence",
+        framework_perf_metric=None,
+        benchmark_result=None,
+        implementation=implementation,
+        single_agent_response=None,
+        active_hypothesis=_hypothesis(),
+    )
+    assert outcome.candidate_disposition == CandidateDisposition.PARETO_FRONTIER.value
+    assert outcome.candidate_metrics == {"latency_ms": 3.0}
+    assert outcome.candidate_evaluation_artifact == "c.json"
+    assert outcome.candidate_operating_point == "op"
+    assert outcome.candidate_retention_reason == "reason"
+
+
+def test_candidate_evidence_from_single_agent_response():
+    response = _single_agent(
+        candidate_disposition=CandidateDisposition.PARETO_FRONTIER,
+        candidate_metrics={"tok_s": 10.0},
+    )
+    outcome = _resolve_round_outcome(
+        inner_loop="single-agent",
+        passed=True,
+        final_attempt_reviewed=True,
+        completed_official_evaluation_reason="cadence",
+        framework_perf_metric=None,
+        benchmark_result=None,
+        implementation=None,
+        single_agent_response=response,
+        active_hypothesis=_hypothesis(),
+    )
+    assert outcome.candidate_disposition == CandidateDisposition.PARETO_FRONTIER.value
+    assert outcome.candidate_metrics == {"tok_s": 10.0}
+
+
+def test_candidate_evidence_defaults_when_nothing_present():
+    outcome = _resolve_round_outcome(
+        inner_loop="multi-agent",
+        passed=False,
+        final_attempt_reviewed=False,
+        completed_official_evaluation_reason=None,
+        framework_perf_metric=None,
+        benchmark_result=None,
+        implementation=None,
+        single_agent_response=None,
+        active_hypothesis=_hypothesis(),
+    )
+    assert outcome.candidate_disposition == CandidateDisposition.UNASSESSED.value
+    assert outcome.candidate_metrics == {}
+    assert outcome.candidate_evaluation_artifact is None
+    assert outcome.candidate_operating_point == ""
+    assert outcome.candidate_retention_reason == ""
+
+
+def test_candidate_evidence_falls_back_to_gate_approved_frontier():
+    hyp = _hypothesis()
+    hyp.gate_revalidation_pending = True
+    hyp.gate_approved_candidate_disposition = CandidateDisposition.PARETO_FRONTIER.value
+    hyp.gate_approved_candidate_metrics = {"latency_ms": 2.0}
+    hyp.gate_approved_candidate_evaluation_artifact = "gate.json"
+    hyp.gate_approved_candidate_operating_point = "gate-op"
+    hyp.gate_approved_candidate_retention_reason = "gate-reason"
+    outcome = _resolve_round_outcome(
+        inner_loop="multi-agent",
+        passed=False,
+        final_attempt_reviewed=True,
+        completed_official_evaluation_reason=None,
+        framework_perf_metric=None,
+        benchmark_result=None,
+        implementation=None,
+        single_agent_response=None,
+        active_hypothesis=hyp,
+    )
+    assert outcome.candidate_disposition == CandidateDisposition.PARETO_FRONTIER.value
+    assert outcome.candidate_metrics == {"latency_ms": 2.0}
+    assert outcome.candidate_evaluation_artifact == "gate.json"
+    assert outcome.candidate_operating_point == "gate-op"
+    assert outcome.candidate_retention_reason == "gate-reason"


### PR DESCRIPTION
## Problem

<!--
Motivate the change. Explain why we are doing this in the first place, what
user or maintainer pain it addresses, and link any relevant issues.
-->

`run_agent_loop`'s post-retry-loop bookkeeping resolved per-round metrics,
hypothesis outcome labels, and candidate evidence inline as a single ~160-line
block, mixing single-agent and multi-agent branches, gate-revalidation
fallbacks, and candidate-disposition inheritance all in one place inside an
already very large function. This made the round-result logic hard to read,
test in isolation, or reason about independently from the rest of the loop.

Closes #290.

## Solution

Extract the block into a dedicated `_RoundOutcome` dataclass and a pure
`_resolve_round_outcome()` function:

- `_RoundOutcome` holds the resolved values previously assigned to a dozen
  loose locals (`perf_metric`, `perf_unit`, `profile_skipped`,
  `accepted_metrics`, `hypothesis_outcome`, `candidate_disposition`, etc.).
- `_resolve_round_outcome()` takes the retry-loop's terminal state
  (`inner_loop`, `passed`, `implementation`, `single_agent_response`,
  `active_hypothesis`, etc.) and returns a single `_RoundOutcome`. It is a
  read-only function — it does not mutate `active_hypothesis`; the caller
  still owns any subsequent state transitions.
- `run_agent_loop` now calls `_resolve_round_outcome(...)` once after the
  retry loop exits and unpacks the result into the same local variable names
  used by the downstream `_RoundRecord(...)` construction, so the persisted
  round-record shape and behavior are unchanged.

No behavioral change is intended — this is a pure extraction. Existing
single-agent vs multi-agent branching, gate-revalidation candidate/perf-metric
fallback, and Pareto-frontier candidate inheritance are preserved exactly as
before.

## Testing

- `python -m py_compile src/vibesys/loops/agent/loop.py`
- `uv run ruff check src/vibesys/loops/agent/loop.py` — all checks passed
- `uv run pytest tests/loops/agent/ -x` — 258 passed (run under WSL/Linux,
  since `tests/conftest.py` imports `socketserver.ThreadingUnixStreamServer`,
  which isn't available on native Windows Python)