### PR TITLE
Add delegation policy and skip CI for docs-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,19 @@ name: Tests
 on:
   push:
     branches: [main]
+    # Skip CI for pure-documentation changes. Only root-level Markdown and the
+    # docs/ tree are ignored; Markdown under resources/skills/ and test fixtures
+    # is consumed by prompt/skill snapshot tests, so it is deliberately not
+    # listed here. A change touching any non-doc file still runs the full
+    # matrix (paths-ignore skips only when every changed file matches).
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
 
 jobs:
   format:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,13 @@ Keep changes narrowly scoped to the requested behavior, preserve existing
 architecture boundaries, and run the smallest relevant checks before handing
 work back.
 
+# Delegation
+
+The main agent does orchestration: planning high-level effort, monitoring
+progress, and steering. Delegate detailed work (searching, reading, and
+editing across files) to subagents. Use cheaper models whenever the task
+allows, and run independent subagents in parallel.
+
 Before creating a GitHub issue, read
 [`docs/issue-authoring.md`](docs/issue-authoring.md) and the matching form under
 `.github/ISSUE_TEMPLATE/`. Search both the codebase and open and closed issues


### PR DESCRIPTION
## Problem

Two related gaps in agent/repo config:

1. `AGENTS.md` (surfaced to agents as `CLAUDE.md`) had no guidance on how the
   main agent should divide work, so it tends to do detailed searching, reading,
   and editing inline instead of orchestrating and delegating.
2. The `Tests` workflow had no path filter, so a docs-only PR (like the original
   `AGENTS.md` edit) ran the entire Python/TypeScript/Go/Rust matrix plus the
   sandbox jobs. All of that is irrelevant to a prose change.

## Solution

- Add a `Delegation` section to `AGENTS.md`: the main agent orchestrates (plans
  high-level effort, monitors, steers) and delegates detailed work to subagents,
  preferring cheaper models and parallel execution for independent work.
- Add `paths-ignore` (`*.md`, `docs/**`) to both the `push` and `pull_request`
  triggers in `.github/workflows/test.yml`.

Markdown under `resources/skills/` and test fixtures is deliberately **not**
ignored: prompt/skill snapshot tests (`tests/loops/**`, `tests/test_skills_wiring.py`)
consume it, so those changes must still run CI. `paths-ignore` skips a run only
when every changed file matches, so mixed doc+code PRs run the full matrix.

### Architecture

Config/docs only. `CLAUDE.md` is a symlink to `AGENTS.md`, so the delegation
guidance is visible under both names.

## Verification

- Confirmed `main` has no required status checks and no rulesets (`gh api
  .../branches/main/protection`, `.../rulesets`), so path-filtered (skipped)
  jobs cannot leave a required check stuck pending / block merges.
- Grepped `tests/` and `scripts/` to confirm root `AGENTS.md`/`CLAUDE.md` and
  `docs/**` are not consumed by any test or CI script.
- Validated `test.yml` parses (`yaml.safe_load`) with the expected filters on
  both triggers.

### Correctness properties

- No behavioral code changed; existing architecture boundaries untouched.
- CI coverage is preserved for every non-doc path, including skill/prompt/fixture
  Markdown, because those are excluded from `paths-ignore`.
- Mixed doc+code PRs still trigger the full workflow.

### Testing

- `uv run python -c "import yaml; ..."` → workflow YAML valid, `paths-ignore`
  present on `push` and `pull_request`.
- No unit tests apply (config/docs only).