### PR TITLE
Add ServiceBench Trace Graph CLI

### DIFF
--- a/examples/evaluators/microservice/DESIGN.md
+++ b/examples/evaluators/microservice/DESIGN.md
@@ -179,6 +179,13 @@ fails closed on command errors, malformed reports, or zero in-window spans.
 Applications own their instrumentation and export pipeline; the evaluator owns
 measurement correlation, normalization, validation, and artifact attachment.
 
+The optional `servicebench trace` command adds a separate trace-graph
+artifact without changing the benchmark summary schema. It reconstructs only
+complete workload-window traces, groups repeated service-call paths, and emits
+a bounded visual rendering. It does not infer a critical path; that analysis
+requires an independently reviewed contract for synchronous, parallel, and
+asynchronous causality.
+
 Closed-loop workloads use the same engine, drivers, observations, and semantic
 validation, but each worker schedules its next logical operation after the
 previous one completes. They are appropriate for saturation-throughput

--- a/examples/evaluators/microservice/cmd/otelcapture/main.go
+++ b/examples/evaluators/microservice/cmd/otelcapture/main.go
@@ -35,17 +35,30 @@ func run() error {
 	var inputs stringList
 	var requestPath string
 	var outputPath string
+	var traceGraphPath string
+	var traceTextPath string
 	var top int
+	var maxRoots int
+	var maxNodes int
+	var timelineWidth int
 	var settleSeconds float64
 	flag.Var(&inputs, "input-json", "OTLP JSON or NDJSON input path (repeatable)")
 	flag.StringVar(&requestPath, "request-json", "", "servicebench telemetry request path")
 	flag.StringVar(&outputPath, "output-json", "", "normalized telemetry report path")
+	flag.StringVar(&traceGraphPath, "trace-graph-json", "", "optional versioned trace graph path")
+	flag.StringVar(&traceTextPath, "trace-graph-text", "", "optional rendered trace graph path")
 	flag.IntVar(&top, "top", 20, "maximum rows per latency category")
+	flag.IntVar(&maxRoots, "trace-max-roots", 10, "maximum root groups in rendered trace text")
+	flag.IntVar(&maxNodes, "trace-max-nodes", 30, "maximum nodes per root in rendered trace text")
+	flag.IntVar(&timelineWidth, "trace-timeline-width", 48, "representative waterfall width")
 	flag.Float64Var(&settleSeconds, "settle-seconds", 0,
 		"delay before reading inputs so exporter buffers flush")
 	flag.Parse()
 	if requestPath == "" || outputPath == "" {
 		return fmt.Errorf("--request-json and --output-json are required")
+	}
+	if traceTextPath != "" && traceGraphPath == "" {
+		return fmt.Errorf("--trace-graph-text requires --trace-graph-json")
 	}
 	if settleSeconds < 0 {
 		return fmt.Errorf("--settle-seconds must not be negative")
@@ -69,6 +82,42 @@ func run() error {
 	}
 	if err := fsutil.WriteFileAtomic(outputPath, append(encoded, '\n'), 0o644); err != nil {
 		return fmt.Errorf("write report: %w", err)
+	}
+	if traceGraphPath != "" {
+		if err := writeTraceGraphArtifacts(request, inputs, traceGraphPath, traceTextPath, telemetry.TraceRenderOptions{MaxRoots: maxRoots, MaxNodesPerRoot: maxNodes, TimelineWidth: timelineWidth}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeTraceGraphArtifacts(
+	request telemetry.CollectionRequest,
+	inputs []string,
+	graphPath string,
+	textPath string,
+	options telemetry.TraceRenderOptions,
+) error {
+	graph, err := telemetry.BuildTraceGraph(request, inputs)
+	if err != nil {
+		return err
+	}
+	encoded, err := json.MarshalIndent(graph, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode trace graph: %w", err)
+	}
+	if err := fsutil.WriteFileAtomic(graphPath, append(encoded, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write trace graph: %w", err)
+	}
+	if textPath == "" {
+		return nil
+	}
+	rendered, err := telemetry.RenderTraceGraph(graph, options)
+	if err != nil {
+		return err
+	}
+	if err := fsutil.WriteFileAtomic(textPath, []byte(rendered), 0o644); err != nil {
+		return fmt.Errorf("write rendered trace graph: %w", err)
 	}
 	return nil
 }

--- a/examples/evaluators/microservice/cmd/otelcapture/main_test.go
+++ b/examples/evaluators/microservice/cmd/otelcapture/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"vibesys/microservice-evaluator/telemetry"
+)
+
+func TestWriteTraceGraphArtifactsWritesJSONAndText(t *testing.T) {
+	start := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	input := filepath.Join(t.TempDir(), "spans.json")
+	data := `{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"frontend"}}]},"scopeSpans":[{"spans":[{"traceId":"trace-a","spanId":"root","name":"GET /","kind":"SPAN_KIND_SERVER","startTimeUnixNano":"` +
+		formatNano(start.Add(100*time.Millisecond).UnixNano()) + `","endTimeUnixNano":"` + formatNano(start.Add(120*time.Millisecond).UnixNano()) + `","status":{"code":"STATUS_CODE_OK"}}]}]}]}`
+	if err := os.WriteFile(input, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	request := telemetry.CollectionRequest{SchemaVersion: telemetry.RequestSchemaVersion, WorkloadName: "test", WorkloadHash: "abc", Windows: []telemetry.MeasurementWindow{{Start: start, End: start.Add(time.Second)}}}
+	graphPath := filepath.Join(t.TempDir(), "graph.json")
+	textPath := filepath.Join(t.TempDir(), "graph.txt")
+
+	if err := writeTraceGraphArtifacts(request, []string{input}, graphPath, textPath, telemetry.TraceRenderOptions{MaxRoots: 5, MaxNodesPerRoot: 10, TimelineWidth: 40}); err != nil {
+		t.Fatal(err)
+	}
+	graph, err := os.ReadFile(graphPath)
+	if err != nil || !strings.Contains(string(graph), `"schema_version": 1`) {
+		t.Fatalf("graph JSON = %q, %v", graph, err)
+	}
+	rendered, err := os.ReadFile(textPath)
+	if err != nil || !strings.Contains(string(rendered), "REPRESENTATIVE WATERFALL") {
+		t.Fatalf("graph text = %q, %v", rendered, err)
+	}
+}
+
+func formatNano(value int64) string { return strconv.FormatInt(value, 10) }

--- a/examples/evaluators/microservice/cmd/servicebench/README.md
+++ b/examples/evaluators/microservice/cmd/servicebench/README.md
@@ -24,3 +24,27 @@ the command fails closed when a dedicated PID namespace cannot be created.
 
 It should contain orchestration only. Protocol behavior belongs in `drivers/`,
 application behavior in `apps/`, and measurement behavior in `engine/`.
+
+## Trace Graph
+
+`servicebench trace` runs the normal managed benchmark path, then asks the
+configured telemetry collector for a separate, versioned trace graph. It emits
+a bounded box-and-arrow call graph and waterfall on stdout for human inspection
+while preserving the full machine-readable graph on disk:
+
+```bash
+servicebench trace \
+  --workload benchmark/workload.toml \
+  --run-command-json '["./benchmark/run.sh"]' \
+  --telemetry-command-json '["otelcapture","--input-json","metrics/otlp.ndjson"]' \
+  --telemetry-output metrics/telemetry.json \
+  --trace-graph-json metrics/trace-graph.json \
+  --trace-graph-text metrics/trace-graph.txt \
+  --output-json metrics/benchmark.json
+```
+
+The graph includes only complete traces observed in benchmark measurement
+windows. `--trace-max-roots`, `--trace-max-nodes`, and
+`--trace-timeline-width` bound the text view; the JSON remains complete. The
+text reports every omission explicitly. This command does not calculate a
+critical path and is not wired into the VibeSys optimization loop in this PR.

--- a/examples/evaluators/microservice/cmd/servicebench/main.go
+++ b/examples/evaluators/microservice/cmd/servicebench/main.go
@@ -42,6 +42,7 @@ type targetOverrides map[string]string
 
 type modeFlagConfig struct {
 	mode               string
+	trace              bool
 	explicit           map[string]bool
 	outputRaw          string
 	casesMin           int
@@ -55,6 +56,11 @@ type modeFlagConfig struct {
 	telemetryCommand   string
 	telemetryOutput    string
 	telemetryTimeout   float64
+	traceGraphOutput   string
+	traceTextOutput    string
+	traceMaxRoots      int
+	traceMaxNodes      int
+	traceTimelineWidth int
 }
 
 func (o *targetOverrides) String() string {
@@ -78,6 +84,11 @@ func main() {
 }
 
 func run() (resultErr error) {
+	traceMode, commandArgs, err := parseServicebenchCommand(os.Args[1:])
+	if err != nil {
+		return err
+	}
+	os.Args = append([]string{os.Args[0]}, commandArgs...)
 	var mode string
 	var workloadPath string
 	var profile string
@@ -106,6 +117,11 @@ func run() (resultErr error) {
 	var telemetryCommandJSON string
 	var telemetryOutput string
 	var telemetryTimeout float64
+	var traceGraphOutput string
+	var traceTextOutput string
+	var traceMaxRoots int
+	var traceMaxNodes int
+	var traceTimelineWidth int
 
 	flag.StringVar(&mode, "mode", "benchmark", "execution mode: benchmark or accuracy")
 	flag.StringVar(&workloadPath, "workload", "", "path to the workload TOML file")
@@ -135,17 +151,25 @@ func run() (resultErr error) {
 	flag.StringVar(&telemetryCommandJSON, "telemetry-command-json", "", "trusted telemetry collector command as a JSON string array")
 	flag.StringVar(&telemetryOutput, "telemetry-output", "", "normalized telemetry report path")
 	flag.Float64Var(&telemetryTimeout, "telemetry-timeout", 30, "telemetry collector timeout in seconds")
+	flag.StringVar(&traceGraphOutput, "trace-graph-json", "", "versioned trace graph output path")
+	flag.StringVar(&traceTextOutput, "trace-graph-text", "", "optional rendered trace graph output path")
+	flag.IntVar(&traceMaxRoots, "trace-max-roots", 10, "maximum root groups in rendered trace output")
+	flag.IntVar(&traceMaxNodes, "trace-max-nodes", 30, "maximum nodes per root in rendered trace output")
+	flag.IntVar(&traceTimelineWidth, "trace-timeline-width", 48, "representative waterfall width")
 	flag.Parse()
 	explicitFlags := make(map[string]bool)
 	flag.Visit(func(used *flag.Flag) { explicitFlags[used.Name] = true })
 	if err := validateModeFlags(modeFlagConfig{
-		mode: mode, explicit: explicitFlags, outputRaw: outputRaw,
+		mode: mode, trace: traceMode, explicit: explicitFlags, outputRaw: outputRaw,
 		casesMin: casesMin, casesMax: casesMax, startupTimeout: startupTimeout,
 		runCommandJSON: runCommandJSON, stopCommandJSON: stopCommandJSON,
 		cleanupCommandJSON: cleanupCommandJSON,
 		stateDir:           stateDir, stateEnv: stateEnv,
 		telemetryCommand: telemetryCommandJSON, telemetryOutput: telemetryOutput,
 		telemetryTimeout: telemetryTimeout,
+		traceGraphOutput: traceGraphOutput, traceTextOutput: traceTextOutput,
+		traceMaxRoots: traceMaxRoots, traceMaxNodes: traceMaxNodes,
+		traceTimelineWidth: traceTimelineWidth,
 	}); err != nil {
 		return err
 	}
@@ -336,6 +360,7 @@ func run() (resultErr error) {
 	if err != nil {
 		return err
 	}
+	var renderedTrace string
 	if shouldCollectTelemetry(telemetryCommandJSON, runResult.Summary.Valid) {
 		command, parseErr := parseCommandJSON(
 			telemetryCommandJSON,
@@ -349,20 +374,39 @@ func run() (resultErr error) {
 			windows = append(windows, trial.MeasurementWindow)
 		}
 		collector := telemetry.CommandCollector{
-			Command:    command,
-			OutputPath: telemetryOutput,
-			Timeout:    time.Duration(telemetryTimeout * float64(time.Second)),
+			Command:        command,
+			OutputPath:     telemetryOutput,
+			TraceGraphPath: traceGraphOutput,
+			Timeout:        time.Duration(telemetryTimeout * float64(time.Second)),
 		}
-		report, collectErr := collector.Collect(ctx, telemetry.CollectionRequest{
+		request := telemetry.CollectionRequest{
 			SchemaVersion: telemetry.RequestSchemaVersion,
 			WorkloadName:  workload.Name,
 			WorkloadHash:  hex.EncodeToString(hash[:]),
 			Windows:       windows,
-		})
-		if collectErr != nil {
-			return fmt.Errorf("collect benchmark telemetry: %w", collectErr)
 		}
-		runResult.Summary.Telemetry = &report
+		if traceMode {
+			artifacts, collectErr := collector.CollectTrace(ctx, request)
+			if collectErr != nil {
+				return fmt.Errorf("collect benchmark trace graph: %w", collectErr)
+			}
+			runResult.Summary.Telemetry = &artifacts.Report
+			renderedTrace, err = telemetry.RenderTraceGraph(artifacts.TraceGraph, telemetry.TraceRenderOptions{MaxRoots: traceMaxRoots, MaxNodesPerRoot: traceMaxNodes, TimelineWidth: traceTimelineWidth})
+			if err != nil {
+				return fmt.Errorf("render benchmark trace graph: %w", err)
+			}
+			if traceTextOutput != "" {
+				if err := fsutil.WriteFileAtomic(traceTextOutput, []byte(renderedTrace), 0o644); err != nil {
+					return fmt.Errorf("write rendered trace graph: %w", err)
+				}
+			}
+		} else {
+			report, collectErr := collector.Collect(ctx, request)
+			if collectErr != nil {
+				return fmt.Errorf("collect benchmark telemetry: %w", collectErr)
+			}
+			runResult.Summary.Telemetry = &report
+		}
 	}
 	if outputRaw != "" {
 		if err := writeNDJSON(outputRaw, runResult.Observations); err != nil {
@@ -378,7 +422,11 @@ func run() (resultErr error) {
 			return err
 		}
 	}
-	fmt.Println(string(encoded))
+	if traceMode {
+		fmt.Print(renderedTrace)
+	} else {
+		fmt.Println(string(encoded))
+	}
 	if !runResult.Summary.Valid {
 		return errors.New("benchmark result is invalid; inspect constraints and trial invalid_reasons")
 	}
@@ -395,6 +443,16 @@ func shouldCollectTelemetry(command string, valid bool) bool {
 	return command != "" && valid
 }
 
+func parseServicebenchCommand(args []string) (bool, []string, error) {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return false, args, nil
+	}
+	if args[0] != "trace" {
+		return false, nil, fmt.Errorf("unknown subcommand %q", args[0])
+	}
+	return true, args[1:], nil
+}
+
 func validateModeFlags(config modeFlagConfig) error {
 	if config.mode != "benchmark" && config.mode != "accuracy" {
 		return fmt.Errorf("--mode must be benchmark or accuracy, got %q", config.mode)
@@ -402,10 +460,28 @@ func validateModeFlags(config modeFlagConfig) error {
 	if config.startupTimeout <= 0 {
 		return fmt.Errorf("--startup-timeout must be positive")
 	}
+	if config.trace {
+		if config.mode != "benchmark" {
+			return errors.New("servicebench trace only supports benchmark mode")
+		}
+		if config.telemetryCommand == "" || config.telemetryOutput == "" {
+			return errors.New("servicebench trace requires --telemetry-command-json and --telemetry-output")
+		}
+		if config.traceGraphOutput == "" {
+			return errors.New("servicebench trace requires --trace-graph-json")
+		}
+		if config.traceMaxRoots <= 0 || config.traceMaxNodes <= 0 || config.traceTimelineWidth < 10 {
+			return errors.New("trace render limits must be positive and --trace-timeline-width must be at least 10")
+		}
+	} else if config.traceGraphOutput != "" || config.traceTextOutput != "" ||
+		config.explicit["trace-max-roots"] || config.explicit["trace-max-nodes"] || config.explicit["trace-timeline-width"] {
+		return errors.New("trace graph flags require the servicebench trace subcommand")
+	}
 	accuracyOnly := []string{"cases-min", "cases-max", "state-dir", "state-env"}
 	benchmarkOnly := []string{
 		"output-raw", "skip-prepare", "fixture-seed", "rate", "duration", "warmup", "concurrency", "repetitions",
 		"telemetry-command-json", "telemetry-output", "telemetry-timeout",
+		"trace-graph-json", "trace-graph-text", "trace-max-roots", "trace-max-nodes", "trace-timeline-width",
 	}
 	if config.mode == "benchmark" {
 		for _, name := range accuracyOnly {

--- a/examples/evaluators/microservice/cmd/servicebench/main_test.go
+++ b/examples/evaluators/microservice/cmd/servicebench/main_test.go
@@ -211,3 +211,38 @@ func TestShouldCollectTelemetry(t *testing.T) {
 		})
 	}
 }
+
+func TestParseServicebenchCommandRecognizesTraceSubcommand(t *testing.T) {
+	trace, args, err := parseServicebenchCommand([]string{"trace", "--workload", "workload.toml"})
+	if err != nil || !trace || len(args) != 2 || args[0] != "--workload" {
+		t.Fatalf("trace=%v args=%v err=%v", trace, args, err)
+	}
+	trace, args, err = parseServicebenchCommand([]string{"--workload", "workload.toml"})
+	if err != nil || trace || len(args) != 2 {
+		t.Fatalf("legacy trace=%v args=%v err=%v", trace, args, err)
+	}
+	if _, _, err := parseServicebenchCommand([]string{"unknown"}); err == nil {
+		t.Fatal("accepted an unknown subcommand")
+	}
+}
+
+func TestValidateModeFlagsRequiresTraceArtifacts(t *testing.T) {
+	base := modeFlagConfig{
+		mode: "benchmark", trace: true, startupTimeout: 15,
+		telemetryCommand: `["./collector"]`, telemetryOutput: "telemetry.json", telemetryTimeout: 30,
+		traceGraphOutput: "trace.json", traceMaxRoots: 10, traceMaxNodes: 30, traceTimelineWidth: 48,
+	}
+	if err := validateModeFlags(base); err != nil {
+		t.Fatalf("valid trace flags: %v", err)
+	}
+	missing := base
+	missing.traceGraphOutput = ""
+	if err := validateModeFlags(missing); err == nil {
+		t.Fatal("trace mode accepted no graph output")
+	}
+	accuracy := base
+	accuracy.mode = "accuracy"
+	if err := validateModeFlags(accuracy); err == nil {
+		t.Fatal("trace mode accepted accuracy execution")
+	}
+}

--- a/examples/evaluators/microservice/telemetry/README.md
+++ b/examples/evaluators/microservice/telemetry/README.md
@@ -28,6 +28,39 @@ service identity from `service.name`, and recognizes datastore spans through
 `db.*` semantic attributes. This keeps application and protocol knowledge out
 of the evaluator.
 
+## Trace graph artifact
+
+When a collector receives `--trace-graph-json`, `cmd/otelcapture` also
+reconstructs workload-observed traces into trace graph schema version 1. The
+artifact groups traces by root service and semantic operation, then records:
+
+- path-aware service/operation nodes and synchronous, asynchronous, and linked
+  edges;
+- count, errors, mean, p50, p95, p99, and maximum inclusive and exclusive
+  duration for every node;
+- captured, eligible, and excluded trace counts, including exclusion reasons
+  and per-trial evidence;
+- unambiguous client/server pair collapsing with unmatched-span counters; and
+- one deterministic representative successful trace nearest the root p95 for
+  a waterfall view.
+
+Operation identity uses safe OTel semantic attributes such as `http.route`,
+`rpc.service`, `rpc.method`, `db.system.name`, and `db.operation.name`, then
+falls back to the span name. Arbitrary attributes, request bodies, raw query
+strings, and credentials are not copied into the artifact.
+
+Exclusive duration means a span's wall-clock interval minus the union of its
+direct-child intervals. It is useful attribution evidence, but it is not CPU
+time. Traces with missing parents, duplicate IDs, multiple roots, cycles,
+window crossings, or inconsistent parent/child clocks are excluded rather
+than partially graphed. A graph request fails when no eligible trace remains.
+
+`--trace-graph-text` optionally writes the deterministic human view: boxes and
+arrows show call structure, and a separate timeline shows span overlap.
+Rendering limits affect only this text view and report explicit omitted counts.
+The versioned JSON is the machine contract. Critical-path analysis and
+automatic VibeSys-loop consumption are intentionally deferred.
+
 ## Instrumentation boundary
 
 The application must export spans with synchronized timestamps and meaningful

--- a/examples/evaluators/microservice/telemetry/command.go
+++ b/examples/evaluators/microservice/telemetry/command.go
@@ -17,18 +17,74 @@ const defaultWaitDelay = 10 * time.Second
 
 // CommandCollector invokes a trusted collector command using the normalized contract.
 type CommandCollector struct {
-	Command    []string
-	OutputPath string
-	Timeout    time.Duration
+	Command        []string
+	OutputPath     string
+	TraceGraphPath string
+	Timeout        time.Duration
 	// WaitDelay bounds the wait for the collector's output pipe to close after
 	// the process exits or is killed. Zero uses defaultWaitDelay.
 	WaitDelay time.Duration
+}
+
+type CollectionArtifacts struct {
+	Report     Report
+	TraceGraph TraceGraphReport
 }
 
 // Collect writes a request, invokes the collector, and validates its report.
 func (collector CommandCollector) Collect(
 	ctx context.Context,
 	request CollectionRequest,
+) (Report, error) {
+	return collector.collectReport(ctx, request, nil)
+}
+
+// CollectTrace invokes a collector that produces both normalized telemetry artifacts.
+func (collector CommandCollector) CollectTrace(
+	ctx context.Context,
+	request CollectionRequest,
+) (CollectionArtifacts, error) {
+	if collector.TraceGraphPath == "" {
+		return CollectionArtifacts{}, fmt.Errorf("trace graph output path must not be empty")
+	}
+	graphPath, err := filepath.Abs(collector.TraceGraphPath)
+	if err != nil {
+		return CollectionArtifacts{}, fmt.Errorf("resolve trace graph output path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(graphPath), 0o755); err != nil {
+		return CollectionArtifacts{}, fmt.Errorf("create trace graph output directory: %w", err)
+	}
+	if err := os.Remove(graphPath); err != nil && !os.IsNotExist(err) {
+		return CollectionArtifacts{}, fmt.Errorf("remove stale trace graph: %w", err)
+	}
+	report, err := collector.collectReport(ctx, request, []string{"--trace-graph-json", graphPath})
+	if err != nil {
+		return CollectionArtifacts{}, err
+	}
+	data, err := os.ReadFile(graphPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return CollectionArtifacts{}, fmt.Errorf("telemetry collector did not write a trace graph to %s", graphPath)
+		}
+		return CollectionArtifacts{}, fmt.Errorf("read trace graph: %w", err)
+	}
+	var graph TraceGraphReport
+	if err := json.Unmarshal(data, &graph); err != nil {
+		return CollectionArtifacts{}, fmt.Errorf("decode trace graph: %w", err)
+	}
+	if err := ValidateTraceGraph(graph); err != nil {
+		return CollectionArtifacts{}, err
+	}
+	if err := validateTraceGraphRequest(graph, request); err != nil {
+		return CollectionArtifacts{}, err
+	}
+	return CollectionArtifacts{Report: report, TraceGraph: graph}, nil
+}
+
+func (collector CommandCollector) collectReport(
+	ctx context.Context,
+	request CollectionRequest,
+	extraArguments []string,
 ) (Report, error) {
 	if err := ValidateRequest(request); err != nil {
 		return Report{}, err
@@ -73,6 +129,7 @@ func (collector CommandCollector) Collect(
 	}
 	arguments := append([]string(nil), collector.Command[1:]...)
 	arguments = append(arguments, "--request-json", requestPath, "--output-json", outputPath)
+	arguments = append(arguments, extraArguments...)
 	command := exec.CommandContext(commandContext, collector.Command[0], arguments...)
 	// CombinedOutput waits for the collector's output pipe to close, which a
 	// killed collector's surviving child processes can otherwise hold open long
@@ -119,6 +176,22 @@ func (collector CommandCollector) Collect(
 		return Report{}, err
 	}
 	return report, nil
+}
+
+func validateTraceGraphRequest(graph TraceGraphReport, request CollectionRequest) error {
+	if graph.WorkloadName != request.WorkloadName || graph.WorkloadHash != request.WorkloadHash {
+		return fmt.Errorf("trace graph workload identity does not match request")
+	}
+	if len(graph.Windows) != len(request.Windows) {
+		return fmt.Errorf("trace graph measurement windows do not match request")
+	}
+	for index := range request.Windows {
+		if !graph.Windows[index].Start.Equal(request.Windows[index].Start) ||
+			!graph.Windows[index].End.Equal(request.Windows[index].End) {
+			return fmt.Errorf("trace graph measurement windows do not match request")
+		}
+	}
+	return nil
 }
 
 func validateReportRequest(report Report, request CollectionRequest) error {

--- a/examples/evaluators/microservice/telemetry/command_test.go
+++ b/examples/evaluators/microservice/telemetry/command_test.go
@@ -62,6 +62,50 @@ EOF
 	}
 }
 
+func TestCommandCollectorCollectTracePassesAndValidatesGraphArtifact(t *testing.T) {
+	directory := t.TempDir()
+	script := filepath.Join(directory, "collector.sh")
+	scriptBody := `#!/bin/sh
+set -eu
+report=""
+graph=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --request-json) request="$2"; shift 2 ;;
+    --output-json) report="$2"; shift 2 ;;
+    --trace-graph-json) graph="$2"; shift 2 ;;
+    *) exit 9 ;;
+  esac
+done
+test -s "$request"
+cat >"$report" <<'EOF'
+{"schema_version":1,"source":"test","collected_at":"2026-07-22T12:00:00Z","workload_name":"test","workload_hash":"abc","measurement_windows":[{"start":"2026-07-22T12:00:00Z","end":"2026-07-22T12:00:01Z"}],"span_count":1,"error_count":0,"services_by_p95":[{"name":"frontend","count":1,"error_count":0,"mean_ms":2,"p50_ms":2,"p95_ms":2,"p99_ms":2,"max_ms":2}],"spans_by_p95":[{"name":"frontend:GET /","count":1,"error_count":0,"mean_ms":2,"p50_ms":2,"p95_ms":2,"p99_ms":2,"max_ms":2}]}
+EOF
+cat >"$graph" <<'EOF'
+{"schema_version":1,"source":"test","collected_at":"2026-07-22T12:00:00Z","workload_name":"test","workload_hash":"abc","measurement_windows":[{"start":"2026-07-22T12:00:00Z","end":"2026-07-22T12:00:01Z"}],"quality":{"captured_traces":1,"eligible_traces":1,"excluded_traces":0,"matched_client_server_pairs":0,"unmatched_client_spans":0,"unmatched_server_spans":0,"async_relationships":0},"trials":[{"trial":1,"captured_traces":1,"eligible_traces":1,"excluded_traces":0}],"roots":[{"service":"frontend","operation":"GET /","trace_count":1,"error_count":0,"latency_ms":{"count":1,"error_count":0,"mean_ms":2,"p50_ms":2,"p95_ms":2,"p99_ms":2,"max_ms":2},"nodes":[{"id":"node-001","path":"frontend:GET /","service":"frontend","operation":"GET /","kind":"server","inclusive_latency_ms":{"count":1,"error_count":0,"mean_ms":2,"p50_ms":2,"p95_ms":2,"p99_ms":2,"max_ms":2},"exclusive_latency_ms":{"count":1,"error_count":0,"mean_ms":2,"p50_ms":2,"p95_ms":2,"p99_ms":2,"max_ms":2}}],"edges":[],"representative_trace":{"trace_id":"trace-a","duration_ms":2,"spans":[{"node_id":"node-001","service":"frontend","operation":"GET /","offset_ms":0,"duration_ms":2}]}}]}
+EOF
+`
+	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	start := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	artifacts, err := (CommandCollector{
+		Command:        []string{script},
+		OutputPath:     filepath.Join(directory, "report.json"),
+		TraceGraphPath: filepath.Join(directory, "graph.json"),
+		Timeout:        time.Second,
+	}).CollectTrace(context.Background(), CollectionRequest{
+		SchemaVersion: RequestSchemaVersion, WorkloadName: "test", WorkloadHash: "abc",
+		Windows: []MeasurementWindow{{Start: start, End: start.Add(time.Second)}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifacts.Report.SpanCount != 1 || artifacts.TraceGraph.Quality.EligibleTraces != 1 {
+		t.Fatalf("artifacts = %+v", artifacts)
+	}
+}
+
 func TestCommandCollectorRejectsEmptyReport(t *testing.T) {
 	directory := t.TempDir()
 	script := filepath.Join(directory, "collector.sh")

--- a/examples/evaluators/microservice/telemetry/trace_graph.go
+++ b/examples/evaluators/microservice/telemetry/trace_graph.go
@@ -1,0 +1,646 @@
+package telemetry
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const TraceGraphSchemaVersion = 1
+
+type LatencyDistribution struct {
+	Count      int     `json:"count"`
+	ErrorCount int     `json:"error_count"`
+	MeanMS     float64 `json:"mean_ms"`
+	P50MS      float64 `json:"p50_ms"`
+	P95MS      float64 `json:"p95_ms"`
+	P99MS      float64 `json:"p99_ms"`
+	MaxMS      float64 `json:"max_ms"`
+}
+
+type TraceQuality struct {
+	CapturedTraces           int            `json:"captured_traces"`
+	EligibleTraces           int            `json:"eligible_traces"`
+	ExcludedTraces           int            `json:"excluded_traces"`
+	ExclusionReasons         map[string]int `json:"exclusion_reasons,omitempty"`
+	MatchedClientServerPairs int            `json:"matched_client_server_pairs"`
+	UnmatchedClientSpans     int            `json:"unmatched_client_spans"`
+	UnmatchedServerSpans     int            `json:"unmatched_server_spans"`
+	AsyncRelationships       int            `json:"async_relationships"`
+}
+
+type TraceTrialQuality struct {
+	Trial          int `json:"trial"`
+	CapturedTraces int `json:"captured_traces"`
+	EligibleTraces int `json:"eligible_traces"`
+	ExcludedTraces int `json:"excluded_traces"`
+}
+
+type TraceGraphNode struct {
+	ID        string              `json:"id"`
+	Path      string              `json:"path"`
+	Service   string              `json:"service"`
+	Operation string              `json:"operation"`
+	Kind      string              `json:"kind"`
+	Inclusive LatencyDistribution `json:"inclusive_latency_ms"`
+	Exclusive LatencyDistribution `json:"exclusive_latency_ms"`
+}
+
+type TraceGraphEdge struct {
+	From         string `json:"from"`
+	To           string `json:"to"`
+	Relationship string `json:"relationship"`
+	Count        int    `json:"count"`
+}
+
+type WaterfallSpan struct {
+	NodeID     string  `json:"node_id"`
+	Service    string  `json:"service"`
+	Operation  string  `json:"operation"`
+	OffsetMS   float64 `json:"offset_ms"`
+	DurationMS float64 `json:"duration_ms"`
+}
+
+type RepresentativeTrace struct {
+	TraceID    string          `json:"trace_id"`
+	DurationMS float64         `json:"duration_ms"`
+	Spans      []WaterfallSpan `json:"spans"`
+}
+
+type TraceRootGraph struct {
+	Service        string              `json:"service"`
+	Operation      string              `json:"operation"`
+	TraceCount     int                 `json:"trace_count"`
+	ErrorCount     int                 `json:"error_count"`
+	Latency        LatencyDistribution `json:"latency_ms"`
+	Nodes          []TraceGraphNode    `json:"nodes"`
+	Edges          []TraceGraphEdge    `json:"edges"`
+	Representative RepresentativeTrace `json:"representative_trace"`
+}
+
+type TraceGraphReport struct {
+	SchemaVersion int                 `json:"schema_version"`
+	Source        string              `json:"source"`
+	CollectedAt   time.Time           `json:"collected_at"`
+	WorkloadName  string              `json:"workload_name"`
+	WorkloadHash  string              `json:"workload_hash"`
+	Windows       []MeasurementWindow `json:"measurement_windows"`
+	Quality       TraceQuality        `json:"quality"`
+	Trials        []TraceTrialQuality `json:"trials"`
+	Roots         []TraceRootGraph    `json:"roots"`
+}
+
+func ValidateTraceGraph(report TraceGraphReport) error {
+	if report.SchemaVersion != TraceGraphSchemaVersion {
+		return fmt.Errorf("trace graph schema_version must be %d", TraceGraphSchemaVersion)
+	}
+	if report.Source == "" || report.CollectedAt.IsZero() {
+		return fmt.Errorf("trace graph source and collected_at must not be empty")
+	}
+	if err := validateIdentityAndWindows(report.WorkloadName, report.WorkloadHash, report.Windows); err != nil {
+		return fmt.Errorf("trace graph: %w", err)
+	}
+	if report.Quality.CapturedTraces <= 0 || report.Quality.EligibleTraces <= 0 || report.Quality.ExcludedTraces < 0 || report.Quality.EligibleTraces+report.Quality.ExcludedTraces != report.Quality.CapturedTraces {
+		return fmt.Errorf("trace graph has invalid trace quality counts")
+	}
+	if len(report.Trials) != len(report.Windows) || len(report.Roots) == 0 {
+		return fmt.Errorf("trace graph requires per-trial quality and root graphs")
+	}
+	return nil
+}
+
+type graphSpan struct {
+	traceID, spanID, parentID string
+	service, operation, kind  string
+	start, end                int64
+	failed                    bool
+	links                     []graphSpanLink
+}
+
+type graphSpanLink struct{ traceID, spanID string }
+
+type graphSample struct {
+	inclusive float64
+	exclusive float64
+	failed    bool
+}
+
+type graphNodeAggregate struct {
+	path, service, operation, kind string
+	samples                        []graphSample
+}
+
+type graphRootAggregate struct {
+	service, operation string
+	traces             []eligibleTrace
+	nodes              map[string]*graphNodeAggregate
+	edges              map[string]int
+}
+
+type eligibleTrace struct {
+	id     string
+	root   *graphSpan
+	spans  []*graphSpan
+	paths  map[string]string
+	paired map[string]bool
+	window int
+}
+
+// BuildTraceGraph reconstructs complete workload-window traces into a stable graph.
+func BuildTraceGraph(request CollectionRequest, paths []string) (TraceGraphReport, error) {
+	if err := ValidateRequest(request); err != nil {
+		return TraceGraphReport{}, err
+	}
+	if len(paths) == 0 {
+		return TraceGraphReport{}, fmt.Errorf("at least one OTLP JSON input is required")
+	}
+	byTrace := make(map[string][]*graphSpan)
+	for _, path := range paths {
+		documents, err := readJSONDocuments(path)
+		if err != nil {
+			return TraceGraphReport{}, err
+		}
+		for _, document := range documents {
+			visitResourceSpans(document, func(service string, raw map[string]any) {
+				span, ok := parseGraphSpan(service, raw)
+				if ok && overlapsMeasurementWindows(span.start, span.end, request.Windows) {
+					byTrace[span.traceID] = append(byTrace[span.traceID], span)
+				}
+			})
+		}
+	}
+	report := TraceGraphReport{
+		SchemaVersion: TraceGraphSchemaVersion,
+		Source:        "otlp-json",
+		CollectedAt:   time.Now().UTC(),
+		WorkloadName:  request.WorkloadName,
+		WorkloadHash:  request.WorkloadHash,
+		Windows:       append([]MeasurementWindow(nil), request.Windows...),
+		Quality:       TraceQuality{CapturedTraces: len(byTrace), ExclusionReasons: map[string]int{}},
+		Trials:        make([]TraceTrialQuality, len(request.Windows)),
+	}
+	for index := range report.Trials {
+		report.Trials[index].Trial = index + 1
+	}
+	aggregates := make(map[string]*graphRootAggregate)
+	traceIDs := sortedTraceIDs(byTrace)
+	for _, traceID := range traceIDs {
+		trace, reason := qualifyTrace(traceID, byTrace[traceID], request.Windows)
+		trial := trace.window
+		if trial < 0 {
+			trial = firstOverlappingWindow(byTrace[traceID], request.Windows)
+		}
+		if trial >= 0 {
+			report.Trials[trial].CapturedTraces++
+		}
+		if reason != "" {
+			report.Quality.ExcludedTraces++
+			report.Quality.ExclusionReasons[reason]++
+			if trial >= 0 {
+				report.Trials[trial].ExcludedTraces++
+			}
+			continue
+		}
+		report.Quality.EligibleTraces++
+		report.Trials[trace.window].EligibleTraces++
+		accountPairing(&report.Quality, trace)
+		key := trace.root.service + "\x00" + trace.root.operation
+		aggregate := aggregates[key]
+		if aggregate == nil {
+			aggregate = &graphRootAggregate{service: trace.root.service, operation: trace.root.operation, nodes: map[string]*graphNodeAggregate{}, edges: map[string]int{}}
+			aggregates[key] = aggregate
+		}
+		aggregate.addTrace(trace, &report.Quality)
+	}
+	if report.Quality.EligibleTraces == 0 {
+		return TraceGraphReport{}, fmt.Errorf("trace graph contains no eligible traces")
+	}
+	report.Roots = materializeRoots(aggregates)
+	if err := ValidateTraceGraph(report); err != nil {
+		return TraceGraphReport{}, err
+	}
+	return report, nil
+}
+
+func parseGraphSpan(service string, raw map[string]any) (*graphSpan, bool) {
+	start, end, ok := spanTimes(raw)
+	traceID, spanID := stringValue(raw["traceId"]), stringValue(raw["spanId"])
+	if !ok || traceID == "" || spanID == "" {
+		return nil, false
+	}
+	attributes := otlpAttributes(asSlice(raw["attributes"]))
+	if service == "" {
+		service = "unknown"
+	}
+	span := &graphSpan{
+		traceID: traceID, spanID: spanID, parentID: stringValue(raw["parentSpanId"]),
+		service: service, operation: semanticOperation(stringValue(raw["name"]), attributes),
+		kind: normalizeSpanKind(stringValue(raw["kind"])), start: start, end: end,
+		failed: spanFailed(raw, attributes),
+	}
+	for _, rawLink := range asSlice(raw["links"]) {
+		link, ok := rawLink.(map[string]any)
+		if !ok {
+			continue
+		}
+		span.links = append(span.links, graphSpanLink{traceID: stringValue(link["traceId"]), spanID: stringValue(link["spanId"])})
+	}
+	return span, true
+}
+
+func semanticOperation(name string, attributes map[string]any) string {
+	if route := stringValue(attributes["http.route"]); route != "" {
+		if method := stringValue(attributes["http.request.method"]); method != "" {
+			return method + " " + route
+		}
+		return route
+	}
+	if service, method := stringValue(attributes["rpc.service"]), stringValue(attributes["rpc.method"]); service != "" && method != "" {
+		return service + "/" + method
+	}
+	if system := firstString(attributes, "db.system.name", "db.system"); system != "" {
+		if operation := stringValue(attributes["db.operation.name"]); operation != "" {
+			return system + ":" + operation
+		}
+	}
+	if name == "" {
+		return "unknown"
+	}
+	return stripQueryString(name)
+}
+
+func stripQueryString(value string) string {
+	query := strings.IndexByte(value, '?')
+	if query < 0 {
+		return value
+	}
+	suffix := strings.IndexAny(value[query:], " \t")
+	if suffix < 0 {
+		return value[:query]
+	}
+	return value[:query] + value[query+suffix:]
+}
+
+func firstString(attributes map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value := stringValue(attributes[key]); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func normalizeSpanKind(kind string) string {
+	kind = strings.TrimPrefix(strings.ToLower(kind), "span_kind_")
+	if kind == "" || kind == "0" || kind == "unspecified" {
+		return "internal"
+	}
+	return kind
+}
+
+func qualifyTrace(id string, spans []*graphSpan, windows []MeasurementWindow) (eligibleTrace, string) {
+	trace := eligibleTrace{id: id, spans: spans, paths: map[string]string{}, paired: map[string]bool{}, window: -1}
+	byID := make(map[string]*graphSpan, len(spans))
+	for _, span := range spans {
+		if _, exists := byID[span.spanID]; exists {
+			return trace, "duplicate_span_id"
+		}
+		byID[span.spanID] = span
+		if span.parentID == "" {
+			if trace.root != nil {
+				return trace, "multiple_roots"
+			}
+			trace.root = span
+		}
+	}
+	if trace.root == nil {
+		return trace, "missing_parent"
+	}
+	for index, window := range windows {
+		if inMeasurementWindows(trace.root.start, trace.root.end, []MeasurementWindow{window}) {
+			trace.window = index
+			break
+		}
+	}
+	if trace.window < 0 {
+		return trace, "outside_measurement_window"
+	}
+	window := windows[trace.window]
+	for _, span := range spans {
+		if !inMeasurementWindows(span.start, span.end, []MeasurementWindow{window}) {
+			return trace, "outside_measurement_window"
+		}
+		if span.parentID == "" {
+			continue
+		}
+		parent := byID[span.parentID]
+		if parent == nil {
+			return trace, "missing_parent"
+		}
+		if span.start < parent.start || span.end > parent.end {
+			return trace, "clock_inconsistency"
+		}
+	}
+	children := childrenByParent(spans)
+	for _, span := range spans {
+		if span.kind == "client" {
+			matches := 0
+			for _, child := range children[span.spanID] {
+				if child.kind == "server" && child.service != span.service {
+					matches++
+				}
+			}
+			if matches == 1 {
+				trace.paired[span.spanID] = true
+			}
+		}
+	}
+	if !tracePaths(&trace, byID) {
+		return trace, "cycle"
+	}
+	return trace, ""
+}
+
+func tracePaths(trace *eligibleTrace, byID map[string]*graphSpan) bool {
+	visiting := map[string]bool{}
+	var resolve func(*graphSpan) (string, bool)
+	resolve = func(span *graphSpan) (string, bool) {
+		if path, ok := trace.paths[span.spanID]; ok {
+			return path, true
+		}
+		if visiting[span.spanID] {
+			return "", false
+		}
+		visiting[span.spanID] = true
+		segment := span.service + ":" + span.operation
+		if span.parentID == "" {
+			trace.paths[span.spanID] = segment
+		} else {
+			parent := byID[span.parentID]
+			for parent != nil && trace.paired[parent.spanID] {
+				parent = byID[parent.parentID]
+			}
+			if parent == nil {
+				return "", false
+			}
+			parentPath, ok := resolve(parent)
+			if !ok {
+				return "", false
+			}
+			trace.paths[span.spanID] = parentPath + " > " + segment
+		}
+		visiting[span.spanID] = false
+		return trace.paths[span.spanID], true
+	}
+	for _, span := range trace.spans {
+		if _, ok := resolve(span); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (aggregate *graphRootAggregate) addTrace(trace eligibleTrace, quality *TraceQuality) {
+	aggregate.traces = append(aggregate.traces, trace)
+	children := childrenByParent(trace.spans)
+	visibleByPath := make(map[string]*graphSpan)
+	for _, span := range trace.spans {
+		if trace.paired[span.spanID] {
+			continue
+		}
+		path := trace.paths[span.spanID]
+		node := aggregate.nodes[path]
+		if node == nil {
+			node = &graphNodeAggregate{path: path, service: span.service, operation: span.operation, kind: span.kind}
+			aggregate.nodes[path] = node
+		}
+		node.samples = append(node.samples, graphSample{
+			inclusive: durationMS(span.start, span.end),
+			exclusive: exclusiveDurationMS(span, children[span.spanID]),
+			failed:    span.failed,
+		})
+		visibleByPath[path] = span
+		if span.kind == "client" {
+			quality.UnmatchedClientSpans++
+		}
+		if span.kind == "server" && span.parentID != "" {
+			parent := findSpan(trace.spans, span.parentID)
+			if parent == nil || !trace.paired[parent.spanID] {
+				quality.UnmatchedServerSpans++
+			}
+		}
+	}
+	for path, span := range visibleByPath {
+		if span.parentID == "" {
+			continue
+		}
+		parent := findSpan(trace.spans, span.parentID)
+		for parent != nil && trace.paired[parent.spanID] {
+			parent = findSpan(trace.spans, parent.parentID)
+		}
+		if parent == nil {
+			continue
+		}
+		relationship := "sync"
+		if parent.kind == "producer" || span.kind == "consumer" {
+			relationship = "async"
+			quality.AsyncRelationships++
+		}
+		aggregate.edges[trace.paths[parent.spanID]+"\x00"+path+"\x00"+relationship]++
+		for _, link := range span.links {
+			if link.traceID != trace.id {
+				continue
+			}
+			linked := findSpan(trace.spans, link.spanID)
+			if linked == nil || trace.paired[linked.spanID] {
+				continue
+			}
+			aggregate.edges[trace.paths[linked.spanID]+"\x00"+path+"\x00link"]++
+			quality.AsyncRelationships++
+		}
+	}
+}
+
+func accountPairing(quality *TraceQuality, trace eligibleTrace) {
+	quality.MatchedClientServerPairs += len(trace.paired)
+}
+
+func materializeRoots(aggregates map[string]*graphRootAggregate) []TraceRootGraph {
+	keys := make([]string, 0, len(aggregates))
+	for key := range aggregates {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	roots := make([]TraceRootGraph, 0, len(keys))
+	for _, key := range keys {
+		aggregate := aggregates[key]
+		paths := make([]string, 0, len(aggregate.nodes))
+		for path := range aggregate.nodes {
+			paths = append(paths, path)
+		}
+		sort.Strings(paths)
+		ids := make(map[string]string, len(paths))
+		nodes := make([]TraceGraphNode, 0, len(paths))
+		for index, path := range paths {
+			ids[path] = fmt.Sprintf("node-%03d", index+1)
+			node := aggregate.nodes[path]
+			inclusive, exclusive := make([]spanSample, 0, len(node.samples)), make([]spanSample, 0, len(node.samples))
+			for _, sample := range node.samples {
+				inclusive = append(inclusive, spanSample{durationMS: sample.inclusive, failed: sample.failed})
+				exclusive = append(exclusive, spanSample{durationMS: sample.exclusive, failed: sample.failed})
+			}
+			nodes = append(nodes, TraceGraphNode{ID: ids[path], Path: path, Service: node.service, Operation: node.operation, Kind: node.kind, Inclusive: distribution(inclusive), Exclusive: distribution(exclusive)})
+		}
+		edgeKeys := make([]string, 0, len(aggregate.edges))
+		for edge := range aggregate.edges {
+			edgeKeys = append(edgeKeys, edge)
+		}
+		sort.Strings(edgeKeys)
+		edges := make([]TraceGraphEdge, 0, len(edgeKeys))
+		for _, edgeKey := range edgeKeys {
+			parts := strings.Split(edgeKey, "\x00")
+			edges = append(edges, TraceGraphEdge{From: ids[parts[0]], To: ids[parts[1]], Relationship: parts[2], Count: aggregate.edges[edgeKey]})
+		}
+		rootSamples := make([]spanSample, 0, len(aggregate.traces))
+		errorCount := 0
+		for _, trace := range aggregate.traces {
+			rootSamples = append(rootSamples, spanSample{durationMS: durationMS(trace.root.start, trace.root.end), failed: trace.root.failed})
+			if trace.root.failed {
+				errorCount++
+			}
+		}
+		root := TraceRootGraph{Service: aggregate.service, Operation: aggregate.operation, TraceCount: len(aggregate.traces), ErrorCount: errorCount, Latency: distribution(rootSamples), Nodes: nodes, Edges: edges}
+		root.Representative = representativeTrace(aggregate.traces, ids, root.Latency.P95MS)
+		roots = append(roots, root)
+	}
+	return roots
+}
+
+func representativeTrace(traces []eligibleTrace, ids map[string]string, target float64) RepresentativeTrace {
+	var candidates []eligibleTrace
+	for _, trace := range traces {
+		if !trace.root.failed {
+			candidates = append(candidates, trace)
+		}
+	}
+	if len(candidates) == 0 {
+		candidates = traces
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		di := abs(durationMS(candidates[i].root.start, candidates[i].root.end) - target)
+		dj := abs(durationMS(candidates[j].root.start, candidates[j].root.end) - target)
+		if di == dj {
+			return candidates[i].id < candidates[j].id
+		}
+		return di < dj
+	})
+	selected := candidates[0]
+	result := RepresentativeTrace{TraceID: selected.id, DurationMS: durationMS(selected.root.start, selected.root.end)}
+	for _, span := range selected.spans {
+		if selected.paired[span.spanID] {
+			continue
+		}
+		result.Spans = append(result.Spans, WaterfallSpan{NodeID: ids[selected.paths[span.spanID]], Service: span.service, Operation: span.operation, OffsetMS: durationMS(selected.root.start, span.start), DurationMS: durationMS(span.start, span.end)})
+	}
+	sort.Slice(result.Spans, func(i, j int) bool {
+		if result.Spans[i].OffsetMS == result.Spans[j].OffsetMS {
+			return result.Spans[i].NodeID < result.Spans[j].NodeID
+		}
+		return result.Spans[i].OffsetMS < result.Spans[j].OffsetMS
+	})
+	return result
+}
+
+func distribution(samples []spanSample) LatencyDistribution {
+	values := make([]float64, 0, len(samples))
+	errors := 0
+	for _, sample := range samples {
+		values = append(values, sample.durationMS)
+		if sample.failed {
+			errors++
+		}
+	}
+	sort.Float64s(values)
+	mean := 0.0
+	for _, value := range values {
+		mean += value
+	}
+	mean /= float64(len(values))
+	return LatencyDistribution{Count: len(values), ErrorCount: errors, MeanMS: mean, P50MS: percentile(values, 50), P95MS: percentile(values, 95), P99MS: percentile(values, 99), MaxMS: values[len(values)-1]}
+}
+
+func exclusiveDurationMS(parent *graphSpan, children []*graphSpan) float64 {
+	intervals := make([][2]int64, 0, len(children))
+	for _, child := range children {
+		intervals = append(intervals, [2]int64{child.start, child.end})
+	}
+	sort.Slice(intervals, func(i, j int) bool { return intervals[i][0] < intervals[j][0] })
+	covered := int64(0)
+	for index := 0; index < len(intervals); {
+		start, end := intervals[index][0], intervals[index][1]
+		index++
+		for index < len(intervals) && intervals[index][0] <= end {
+			if intervals[index][1] > end {
+				end = intervals[index][1]
+			}
+			index++
+		}
+		covered += end - start
+	}
+	return float64(parent.end-parent.start-covered) / 1e6
+}
+
+func childrenByParent(spans []*graphSpan) map[string][]*graphSpan {
+	children := make(map[string][]*graphSpan)
+	for _, span := range spans {
+		children[span.parentID] = append(children[span.parentID], span)
+	}
+	return children
+}
+
+func overlapsMeasurementWindows(start, end int64, windows []MeasurementWindow) bool {
+	for _, window := range windows {
+		if time.Unix(0, end).After(window.Start) && time.Unix(0, start).Before(window.End) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstOverlappingWindow(spans []*graphSpan, windows []MeasurementWindow) int {
+	for index, window := range windows {
+		for _, span := range spans {
+			if overlapsMeasurementWindows(span.start, span.end, []MeasurementWindow{window}) {
+				return index
+			}
+		}
+	}
+	return -1
+}
+
+func sortedTraceIDs(traces map[string][]*graphSpan) []string {
+	ids := make([]string, 0, len(traces))
+	for id := range traces {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func findSpan(spans []*graphSpan, id string) *graphSpan {
+	for _, span := range spans {
+		if span.spanID == id {
+			return span
+		}
+	}
+	return nil
+}
+
+func durationMS(start, end int64) float64 { return float64(end-start) / 1e6 }
+func abs(value float64) float64 {
+	if value < 0 {
+		return -value
+	}
+	return value
+}

--- a/examples/evaluators/microservice/telemetry/trace_graph_test.go
+++ b/examples/evaluators/microservice/telemetry/trace_graph_test.go
@@ -1,0 +1,193 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildTraceGraphAggregatesPathsAndExclusiveLatency(t *testing.T) {
+	start := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	request := traceGraphRequest(start, 2*time.Second)
+	root := rawGraphSpan("trace-a", "root", "", "GET /hotels", "SPAN_KIND_SERVER", start.Add(100*time.Millisecond), 100*time.Millisecond)
+	root["attributes"] = []any{attribute("http.request.method", "GET"), attribute("http.route", "/hotels")}
+	searchClient := rawGraphSpan("trace-a", "search-client", "root", "grpc.search", "SPAN_KIND_CLIENT", start.Add(110*time.Millisecond), 60*time.Millisecond)
+	searchServer := rawGraphSpan("trace-a", "search-server", "search-client", "Search", "SPAN_KIND_SERVER", start.Add(112*time.Millisecond), 55*time.Millisecond)
+	searchServer["attributes"] = []any{attribute("rpc.service", "search.SearchService"), attribute("rpc.method", "Nearby")}
+	db := rawGraphSpan("trace-a", "db", "search-server", "mongo.find", "SPAN_KIND_CLIENT", start.Add(120*time.Millisecond), 20*time.Millisecond)
+	db["attributes"] = []any{attribute("db.system.name", "mongodb"), attribute("db.operation.name", "find")}
+	path := writeTraceDocument(t, map[string][]map[string]any{
+		"frontend": {root, searchClient},
+		"search":   {searchServer, db},
+	})
+
+	report, err := BuildTraceGraph(request, []string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.SchemaVersion != TraceGraphSchemaVersion || report.Quality.EligibleTraces != 1 {
+		t.Fatalf("report metadata = %+v", report)
+	}
+	if report.Quality.MatchedClientServerPairs != 1 || report.Quality.UnmatchedClientSpans != 1 {
+		t.Fatalf("pair quality = %+v", report.Quality)
+	}
+	if len(report.Roots) != 1 || report.Roots[0].Operation != "GET /hotels" {
+		t.Fatalf("roots = %+v", report.Roots)
+	}
+	rootNode := findGraphNode(t, report.Roots[0], "frontend", "GET /hotels")
+	searchNode := findGraphNode(t, report.Roots[0], "search", "search.SearchService/Nearby")
+	dbNode := findGraphNode(t, report.Roots[0], "search", "mongodb:find")
+	if rootNode.Exclusive.MeanMS != 40 || searchNode.Exclusive.MeanMS != 35 || dbNode.Exclusive.MeanMS != 20 {
+		t.Fatalf("exclusive means root=%v search=%v db=%v", rootNode.Exclusive.MeanMS, searchNode.Exclusive.MeanMS, dbNode.Exclusive.MeanMS)
+	}
+	if searchNode.Path == rootNode.Path || !strings.Contains(dbNode.Path, searchNode.Path) {
+		t.Fatalf("paths root=%q search=%q db=%q", rootNode.Path, searchNode.Path, dbNode.Path)
+	}
+	if report.Roots[0].Representative.TraceID != "trace-a" || len(report.Roots[0].Representative.Spans) != 3 {
+		t.Fatalf("representative = %+v", report.Roots[0].Representative)
+	}
+}
+
+func TestBuildTraceGraphUnionsOverlappingChildren(t *testing.T) {
+	start := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	request := traceGraphRequest(start, time.Second)
+	path := writeTraceDocument(t, map[string][]map[string]any{
+		"frontend": {
+			rawGraphSpan("trace-a", "root", "", "root", "SPAN_KIND_SERVER", start.Add(100*time.Millisecond), 100*time.Millisecond),
+			rawGraphSpan("trace-a", "a", "root", "a", "SPAN_KIND_INTERNAL", start.Add(110*time.Millisecond), 40*time.Millisecond),
+			rawGraphSpan("trace-a", "b", "root", "b", "SPAN_KIND_INTERNAL", start.Add(130*time.Millisecond), 40*time.Millisecond),
+		},
+	})
+
+	report, err := BuildTraceGraph(request, []string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := findGraphNode(t, report.Roots[0], "frontend", "root")
+	if root.Exclusive.MeanMS != 40 {
+		t.Fatalf("exclusive mean = %v, want 40", root.Exclusive.MeanMS)
+	}
+}
+
+func TestBuildTraceGraphAccountsForExcludedTraces(t *testing.T) {
+	start := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	request := traceGraphRequest(start, time.Second)
+	path := writeTraceDocument(t, map[string][]map[string]any{
+		"frontend": {
+			rawGraphSpan("good", "root-good", "", "good", "SPAN_KIND_SERVER", start.Add(100*time.Millisecond), 50*time.Millisecond),
+			rawGraphSpan("orphan", "child", "missing", "orphan", "SPAN_KIND_INTERNAL", start.Add(200*time.Millisecond), 20*time.Millisecond),
+			rawGraphSpan("crossing", "root-cross", "", "crossing", "SPAN_KIND_SERVER", start.Add(990*time.Millisecond), 20*time.Millisecond),
+		},
+	})
+
+	report, err := BuildTraceGraph(request, []string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Quality.CapturedTraces != 3 || report.Quality.EligibleTraces != 1 || report.Quality.ExcludedTraces != 2 {
+		t.Fatalf("quality = %+v", report.Quality)
+	}
+	if report.Quality.ExclusionReasons["missing_parent"] != 1 || report.Quality.ExclusionReasons["outside_measurement_window"] != 1 {
+		t.Fatalf("exclusions = %+v", report.Quality.ExclusionReasons)
+	}
+	if len(report.Trials) != 1 || report.Trials[0].EligibleTraces != 1 {
+		t.Fatalf("trials = %+v", report.Trials)
+	}
+}
+
+func TestBuildTraceGraphRejectsNoEligibleTraces(t *testing.T) {
+	start := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	path := writeTraceDocument(t, map[string][]map[string]any{
+		"frontend": {rawGraphSpan("orphan", "child", "missing", "orphan", "SPAN_KIND_INTERNAL", start.Add(100*time.Millisecond), 20*time.Millisecond)},
+	})
+	_, err := BuildTraceGraph(traceGraphRequest(start, time.Second), []string{path})
+	if err == nil || !strings.Contains(err.Error(), "no eligible traces") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestBuildTraceGraphPreservesLinkedAsyncRelationships(t *testing.T) {
+	start := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	producer := rawGraphSpan("trace-a", "producer", "root", "publish", "SPAN_KIND_PRODUCER", start.Add(110*time.Millisecond), 10*time.Millisecond)
+	consumer := rawGraphSpan("trace-a", "consumer", "root", "consume", "SPAN_KIND_CONSUMER", start.Add(130*time.Millisecond), 20*time.Millisecond)
+	consumer["links"] = []any{map[string]any{"traceId": "trace-a", "spanId": "producer"}}
+	path := writeTraceDocument(t, map[string][]map[string]any{
+		"frontend": {rawGraphSpan("trace-a", "root", "", "request", "SPAN_KIND_SERVER", start.Add(100*time.Millisecond), 100*time.Millisecond)},
+		"queue":    {producer, consumer},
+	})
+
+	report, err := BuildTraceGraph(traceGraphRequest(start, time.Second), []string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Quality.AsyncRelationships < 1 {
+		t.Fatalf("quality = %+v", report.Quality)
+	}
+	foundLink := false
+	for _, edge := range report.Roots[0].Edges {
+		foundLink = foundLink || edge.Relationship == "link"
+	}
+	if !foundLink {
+		t.Fatalf("edges = %+v", report.Roots[0].Edges)
+	}
+}
+
+func TestSemanticOperationDoesNotRetainRawQueryStrings(t *testing.T) {
+	operation := semanticOperation("HTTP GET /hotels?api_key=secret", map[string]any{})
+	if operation != "HTTP GET /hotels" {
+		t.Fatalf("operation = %q", operation)
+	}
+}
+
+func traceGraphRequest(start time.Time, duration time.Duration) CollectionRequest {
+	return CollectionRequest{
+		SchemaVersion: RequestSchemaVersion,
+		WorkloadName:  "hotel",
+		WorkloadHash:  "abc123",
+		Windows:       []MeasurementWindow{{Start: start, End: start.Add(duration)}},
+	}
+}
+
+func rawGraphSpan(traceID, spanID, parentID, name, kind string, start time.Time, duration time.Duration) map[string]any {
+	return map[string]any{
+		"traceId": traceID, "spanId": spanID, "parentSpanId": parentID,
+		"name": name, "kind": kind,
+		"startTimeUnixNano": start.UnixNano(), "endTimeUnixNano": start.Add(duration).UnixNano(),
+		"status": map[string]any{"code": "STATUS_CODE_OK"},
+	}
+}
+
+func attribute(key, value string) map[string]any {
+	return map[string]any{"key": key, "value": map[string]any{"stringValue": value}}
+}
+
+func writeTraceDocument(t *testing.T, services map[string][]map[string]any) string {
+	t.Helper()
+	resources := make([]any, 0, len(services))
+	for service, spans := range services {
+		resources = append(resources, resourceSpans(service, spans))
+	}
+	data, err := json.Marshal(map[string]any{"resourceSpans": resources})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "traces.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func findGraphNode(t *testing.T, root TraceRootGraph, service, operation string) TraceGraphNode {
+	t.Helper()
+	for _, node := range root.Nodes {
+		if node.Service == service && node.Operation == operation {
+			return node
+		}
+	}
+	t.Fatalf("missing node %s:%s in %+v", service, operation, root.Nodes)
+	return TraceGraphNode{}
+}

--- a/examples/evaluators/microservice/telemetry/trace_render.go
+++ b/examples/evaluators/microservice/telemetry/trace_render.go
@@ -1,0 +1,290 @@
+package telemetry
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	minimumBoxInnerWidth = 45
+	callGraphGap         = 2
+	traceGroupBarWidth   = 150
+)
+
+type TraceRenderOptions struct {
+	MaxRoots        int
+	MaxNodesPerRoot int
+	TimelineWidth   int
+}
+
+type callTree struct {
+	node     TraceGraphNode
+	children []*callTree
+}
+
+type textBlock struct {
+	lines      []string
+	width      int
+	rootCenter int
+}
+
+// RenderTraceGraph produces deterministic, bounded text for human inspection.
+func RenderTraceGraph(report TraceGraphReport, options TraceRenderOptions) (string, error) {
+	if report.SchemaVersion != TraceGraphSchemaVersion {
+		return "", fmt.Errorf("trace graph schema_version must be %d", TraceGraphSchemaVersion)
+	}
+	if options.MaxRoots <= 0 || options.MaxNodesPerRoot <= 0 || options.TimelineWidth < 10 {
+		return "", fmt.Errorf("trace render limits must be positive and timeline width must be at least 10")
+	}
+	roots := append([]TraceRootGraph(nil), report.Roots...)
+	sort.Slice(roots, func(i, j int) bool {
+		if roots[i].Latency.P95MS == roots[j].Latency.P95MS {
+			return roots[i].Service+roots[i].Operation < roots[j].Service+roots[j].Operation
+		}
+		return roots[i].Latency.P95MS > roots[j].Latency.P95MS
+	})
+	var output strings.Builder
+	fmt.Fprintf(&output, "TRACE GRAPH v%d  workload=%s\n", report.SchemaVersion, report.WorkloadName)
+	fmt.Fprintf(&output, "quality: eligible=%d/%d excluded=%d\n", report.Quality.EligibleTraces, report.Quality.CapturedTraces, report.Quality.ExcludedTraces)
+	fmt.Fprintf(&output, "transport: paired=%d unmatched_client=%d unmatched_server=%d async=%d\n\n", report.Quality.MatchedClientServerPairs, report.Quality.UnmatchedClientSpans, report.Quality.UnmatchedServerSpans, report.Quality.AsyncRelationships)
+	rootLimit := minInt(len(roots), options.MaxRoots)
+	for rootIndex := 0; rootIndex < rootLimit; rootIndex++ {
+		if rootIndex > 0 {
+			output.WriteString(strings.Repeat("═", traceGroupBarWidth))
+			output.WriteString("\n\n")
+		}
+		renderRoot(&output, roots[rootIndex], options)
+	}
+	if omitted := len(roots) - rootLimit; omitted > 0 {
+		fmt.Fprintf(&output, "... %d %s omitted\n", omitted, plural(omitted, "root group", "root groups"))
+	}
+	output.WriteString("Legend: inclusive is wall time; exclusive subtracts the union of direct-child intervals.\n")
+	return output.String(), nil
+}
+
+func renderRoot(output *strings.Builder, root TraceRootGraph, options TraceRenderOptions) {
+	fmt.Fprintf(output, "ROOT  %s: %s  traces=%d errors=%d\n", root.Service, root.Operation, root.TraceCount, root.ErrorCount)
+	fmt.Fprintf(output, "latency mean=%.2fms p50=%.2fms p95=%.2fms p99=%.2fms max=%.2fms\n\n", root.Latency.MeanMS, root.Latency.P50MS, root.Latency.P95MS, root.Latency.P99MS, root.Latency.MaxMS)
+	output.WriteString("CALL GRAPH\n\n")
+	nodes := append([]TraceGraphNode(nil), root.Nodes...)
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Path < nodes[j].Path })
+	nodeLimit := minInt(len(nodes), options.MaxNodesPerRoot)
+	for _, tree := range buildCallTrees(nodes[:nodeLimit]) {
+		block := renderCallTree(tree)
+		for _, line := range block.lines {
+			output.WriteString(strings.TrimRight(line, " "))
+			output.WriteByte('\n')
+		}
+	}
+	if omitted := len(nodes) - nodeLimit; omitted > 0 {
+		fmt.Fprintf(output, "... %d %s omitted\n", omitted, plural(omitted, "node", "nodes"))
+	}
+	fmt.Fprintf(output, "\nREPRESENTATIVE WATERFALL  trace=%s  duration=%.2fms\n", root.Representative.TraceID, root.Representative.DurationMS)
+	renderWaterfall(output, root.Representative, options.TimelineWidth)
+	output.WriteByte('\n')
+}
+
+func buildCallTrees(nodes []TraceGraphNode) []*callTree {
+	byPath := make(map[string]*callTree, len(nodes))
+	for _, node := range nodes {
+		copy := node
+		byPath[node.Path] = &callTree{node: copy}
+	}
+	var roots []*callTree
+	for _, tree := range byPath {
+		parentPath := pathParent(tree.node.Path)
+		parent := byPath[parentPath]
+		if parent == nil {
+			roots = append(roots, tree)
+			continue
+		}
+		parent.children = append(parent.children, tree)
+	}
+	var sortTree func(*callTree)
+	sortTree = func(tree *callTree) {
+		sort.Slice(tree.children, func(i, j int) bool {
+			return tree.children[i].node.Service+tree.children[i].node.Operation <
+				tree.children[j].node.Service+tree.children[j].node.Operation
+		})
+		for _, child := range tree.children {
+			sortTree(child)
+		}
+	}
+	sort.Slice(roots, func(i, j int) bool { return roots[i].node.Path < roots[j].node.Path })
+	for _, root := range roots {
+		sortTree(root)
+	}
+	return roots
+}
+
+func pathParent(path string) string {
+	index := strings.LastIndex(path, " > ")
+	if index < 0 {
+		return ""
+	}
+	return path[:index]
+}
+
+func renderCallTree(tree *callTree) textBlock {
+	box := renderNodeBox(tree.node)
+	if len(tree.children) == 0 {
+		return textBlock{lines: box, width: runeWidth(box[0]), rootCenter: runeWidth(box[0]) / 2}
+	}
+	children := make([]textBlock, 0, len(tree.children))
+	childrenWidth := 0
+	for _, child := range tree.children {
+		block := renderCallTree(child)
+		children = append(children, block)
+		childrenWidth += block.width
+	}
+	childrenWidth += callGraphGap * (len(children) - 1)
+	boxWidth := runeWidth(box[0])
+	width := maxInt(boxWidth, childrenWidth)
+	rootCenter := width / 2
+	lines := indentLines(box, rootCenter-boxWidth/2, width)
+	childOffset := (width - childrenWidth) / 2
+	childCenters := make([]int, len(children))
+	offset := childOffset
+	for index, child := range children {
+		childCenters[index] = offset + child.rootCenter
+		offset += child.width + callGraphGap
+	}
+	lines = append(lines, connectorLines(width, rootCenter, childCenters)...)
+	maxHeight := 0
+	for _, child := range children {
+		maxHeight = maxInt(maxHeight, len(child.lines))
+	}
+	for row := 0; row < maxHeight; row++ {
+		canvas := blankCanvas(width)
+		offset = childOffset
+		for _, child := range children {
+			if row < len(child.lines) {
+				placeRunes(canvas, offset, child.lines[row])
+			}
+			offset += child.width + callGraphGap
+		}
+		lines = append(lines, string(canvas))
+	}
+	return textBlock{lines: lines, width: width, rootCenter: rootCenter}
+}
+
+func renderNodeBox(node TraceGraphNode) []string {
+	label := node.Service + ": " + node.Operation
+	metrics := fmt.Sprintf("inclusive: %.2f ms   exclusive: %.2f ms", node.Inclusive.MeanMS, node.Exclusive.MeanMS)
+	innerWidth := maxInt(minimumBoxInnerWidth, maxInt(runeWidth(label), runeWidth(metrics))+2)
+	contentWidth := innerWidth - 2
+	return []string{
+		"┌" + strings.Repeat("─", innerWidth) + "┐",
+		"│ " + padRight(label, contentWidth) + " │",
+		"│ " + padRight(metrics, contentWidth) + " │",
+		"└" + strings.Repeat("─", innerWidth) + "┘",
+	}
+}
+
+func connectorLines(width, rootCenter int, childCenters []int) []string {
+	if len(childCenters) == 1 {
+		calls := blankCanvas(width)
+		placeRunes(calls, rootCenter, "│ calls")
+		arrow := blankCanvas(width)
+		placeRunes(arrow, childCenters[0], "▼")
+		return []string{string(calls), string(arrow)}
+	}
+	vertical := blankCanvas(width)
+	placeRunes(vertical, rootCenter, "│")
+	branch := blankCanvas(width)
+	first, last := childCenters[0], childCenters[len(childCenters)-1]
+	for index := first + 1; index < last; index++ {
+		branch[index] = '─'
+	}
+	branch[first], branch[last], branch[rootCenter] = '┌', '┐', '┴'
+	calls := blankCanvas(width)
+	arrows := blankCanvas(width)
+	for _, center := range childCenters {
+		placeRunes(calls, center, "│ calls")
+		placeRunes(arrows, center, "▼")
+	}
+	return []string{string(vertical), string(branch), string(calls), string(arrows)}
+}
+
+func renderWaterfall(output *strings.Builder, trace RepresentativeTrace, width int) {
+	labelWidth := 0
+	for _, span := range trace.Spans {
+		labelWidth = maxInt(labelWidth, runeWidth(span.Service+" "+span.Operation))
+	}
+	fmt.Fprintf(output, "TIME →  0 ms%s%.2f ms\n\n", strings.Repeat(" ", maxInt(1, labelWidth+width-8)), trace.DurationMS)
+	for _, span := range trace.Spans {
+		label := span.Service + " " + span.Operation
+		fmt.Fprintf(output, "%-*s [%s] %.2f ms\n", labelWidth, label, timeline(span.OffsetMS, span.DurationMS, trace.DurationMS, width), span.DurationMS)
+	}
+}
+
+func timeline(offset, duration, total float64, width int) string {
+	if total <= 0 {
+		return strings.Repeat(" ", width)
+	}
+	start := int(offset / total * float64(width))
+	end := int((offset + duration) / total * float64(width))
+	if start < 0 {
+		start = 0
+	}
+	if end <= start {
+		end = start + 1
+	}
+	if end > width {
+		end = width
+	}
+	if start >= width {
+		start = width - 1
+	}
+	return strings.Repeat(" ", start) + strings.Repeat("=", end-start) + strings.Repeat(" ", width-end)
+}
+
+func indentLines(lines []string, offset, width int) []string {
+	result := make([]string, 0, len(lines))
+	for _, line := range lines {
+		canvas := blankCanvas(width)
+		placeRunes(canvas, offset, line)
+		result = append(result, string(canvas))
+	}
+	return result
+}
+
+func blankCanvas(width int) []rune { return []rune(strings.Repeat(" ", width)) }
+
+func placeRunes(canvas []rune, offset int, value string) {
+	for index, character := range []rune(value) {
+		position := offset + index
+		if position >= 0 && position < len(canvas) {
+			canvas[position] = character
+		}
+	}
+}
+
+func padRight(value string, width int) string {
+	return value + strings.Repeat(" ", maxInt(0, width-runeWidth(value)))
+}
+
+func runeWidth(value string) int { return utf8.RuneCountInString(value) }
+
+func minInt(left, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}
+
+func maxInt(left, right int) int {
+	if left > right {
+		return left
+	}
+	return right
+}
+
+func plural(count int, singular, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}

--- a/examples/evaluators/microservice/telemetry/trace_render_test.go
+++ b/examples/evaluators/microservice/telemetry/trace_render_test.go
@@ -1,0 +1,137 @@
+package telemetry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderTraceGraphShowsArchitectureMetricsAndWaterfall(t *testing.T) {
+	report := renderFixtureReport()
+
+	first, err := RenderTraceGraph(report, TraceRenderOptions{MaxRoots: 5, MaxNodesPerRoot: 5, TimelineWidth: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := RenderTraceGraph(report, TraceRenderOptions{MaxRoots: 5, MaxNodesPerRoot: 5, TimelineWidth: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatal("rendering is not deterministic")
+	}
+	for _, want := range []string{
+		"TRACE GRAPH v1", "eligible=3/4", "frontend: GET /hotels", "mean=100.00ms",
+		"CALL GRAPH", "┌", "┐", "└", "┘", "│ calls", "▼",
+		"search: Search/Nearby", "exclusive: 35.00 ms",
+		"REPRESENTATIVE WATERFALL", "TIME →", "[", "]", "trace-a",
+		"Legend: inclusive is wall time; exclusive subtracts the union of direct-child intervals.",
+	} {
+		if !strings.Contains(first, want) {
+			t.Fatalf("rendered graph missing %q:\n%s", want, first)
+		}
+	}
+}
+
+func TestRenderTraceGraphUsesBoxAndArrowLayout(t *testing.T) {
+	rendered, err := RenderTraceGraph(renderFixtureReport(), TraceRenderOptions{MaxRoots: 5, MaxNodesPerRoot: 5, TimelineWidth: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range []string{
+		"┌─────────────────────────────────────────────┐",
+		"│ frontend: GET /hotels                       │",
+		"│ inclusive: 100.00 ms   exclusive: 40.00 ms  │",
+		"└─────────────────────────────────────────────┘",
+		"                       │ calls",
+		"                       ▼",
+		"│ search: Search/Nearby                       │",
+	} {
+		if !strings.Contains(rendered, line) {
+			t.Fatalf("rendered graph missing exact line %q:\n%s", line, rendered)
+		}
+	}
+}
+
+func TestRenderTraceGraphReportsOmittedRootsAndNodes(t *testing.T) {
+	report := renderFixtureReport()
+	report.Roots = append(report.Roots, report.Roots[0])
+	report.Roots[0].Nodes = append(report.Roots[0].Nodes, report.Roots[0].Nodes[1])
+
+	rendered, err := RenderTraceGraph(report, TraceRenderOptions{MaxRoots: 1, MaxNodesPerRoot: 2, TimelineWidth: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(rendered, "1 node omitted") || !strings.Contains(rendered, "1 root group omitted") {
+		t.Fatalf("omission counts missing:\n%s", rendered)
+	}
+}
+
+func TestRenderTraceGraphSeparatesRootTraceGroups(t *testing.T) {
+	report := renderFixtureReport()
+	second := report.Roots[0]
+	second.Operation = "GET /user"
+	report.Roots = append(report.Roots, second)
+
+	rendered, err := RenderTraceGraph(report, TraceRenderOptions{MaxRoots: 5, MaxNodesPerRoot: 5, TimelineWidth: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	separator := strings.Repeat("═", 150)
+	if strings.Count(rendered, separator) != 1 {
+		t.Fatalf("trace groups do not have exactly one separator:\n%s", rendered)
+	}
+	first := strings.Index(rendered, "ROOT  frontend: GET /hotels")
+	bar := strings.Index(rendered, separator)
+	secondRoot := strings.Index(rendered, "ROOT  frontend: GET /user")
+	if first < 0 || bar < first || secondRoot < bar {
+		t.Fatalf("separator is not between trace groups:\n%s", rendered)
+	}
+}
+
+func TestRenderTraceGraphPlacesSiblingCallsSideBySide(t *testing.T) {
+	report := renderFixtureReport()
+	report.Roots[0].Nodes = append(report.Roots[0].Nodes, TraceGraphNode{
+		ID: "node-003", Path: "frontend:GET /hotels > rate:Rate/GetRates",
+		Service: "rate", Operation: "Rate/GetRates",
+		Inclusive: LatencyDistribution{Count: 3, MeanMS: 20},
+		Exclusive: LatencyDistribution{Count: 3, MeanMS: 5},
+	})
+
+	rendered, err := RenderTraceGraph(report, TraceRenderOptions{MaxRoots: 5, MaxNodesPerRoot: 5, TimelineWidth: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(rendered, "┴") || !strings.Contains(rendered, "rate: Rate/GetRates") {
+		t.Fatalf("branch layout missing:\n%s", rendered)
+	}
+	foundSiblingBoxes := false
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.Count(line, "┌") == 2 {
+			foundSiblingBoxes = true
+		}
+	}
+	if !foundSiblingBoxes {
+		t.Fatalf("sibling boxes were not placed side by side:\n%s", rendered)
+	}
+}
+
+func renderFixtureReport() TraceGraphReport {
+	distribution := LatencyDistribution{Count: 3, MeanMS: 100, P50MS: 90, P95MS: 120, P99MS: 124, MaxMS: 125}
+	return TraceGraphReport{
+		SchemaVersion: TraceGraphSchemaVersion,
+		WorkloadName:  "hotel",
+		WorkloadHash:  "abc",
+		Quality:       TraceQuality{CapturedTraces: 4, EligibleTraces: 3, ExcludedTraces: 1},
+		Roots: []TraceRootGraph{{
+			Service: "frontend", Operation: "GET /hotels", TraceCount: 3, Latency: distribution,
+			Nodes: []TraceGraphNode{
+				{ID: "node-001", Path: "frontend:GET /hotels", Service: "frontend", Operation: "GET /hotels", Inclusive: distribution, Exclusive: LatencyDistribution{Count: 3, MeanMS: 40}},
+				{ID: "node-002", Path: "frontend:GET /hotels > search:Search/Nearby", Service: "search", Operation: "Search/Nearby", Inclusive: LatencyDistribution{Count: 3, MeanMS: 55}, Exclusive: LatencyDistribution{Count: 3, MeanMS: 35}},
+			},
+			Representative: RepresentativeTrace{TraceID: "trace-a", DurationMS: 100, Spans: []WaterfallSpan{
+				{NodeID: "node-001", Service: "frontend", Operation: "GET /hotels", OffsetMS: 0, DurationMS: 100},
+				{NodeID: "node-002", Service: "search", Operation: "Search/Nearby", OffsetMS: 10, DurationMS: 55},
+			}},
+		}},
+	}
+}


### PR DESCRIPTION
## Problem

OpenTelemetry collection gives the microservice evaluator raw spans and aggregate telemetry, but it does not provide a compact representation of the workload-specific call structure and timing. A developer currently has to inspect raw OTLP data to understand which services participated in a request, how calls nested or overlapped, and where each operation spent time. As an extension of this, LLMs also need to spend more effort to figure out OTel data and what the critical path for the microservice is. This makes the optimization part of VibeSys less reliable, when it doesn't need to be this way.

This is the first part of #318. It adds the trace representation and CLI surface only. Critical-path analysis and VibeSys loop integration remain follow-up work.

## Solution

Add `servicebench trace`, which runs the normal managed benchmark path and then asks the configured telemetry collector to produce a versioned trace graph for the benchmark measurement windows.

The graph records complete root traces, stable service/operation nodes, parent-child edges, inclusive and exclusive latency distributions, trace quality, and representative timelines. `otelcapture` writes the complete JSON contract and can render a bounded text view. ServiceBench prints a readable box-and-arrow call graph and waterfall, and can persist the same text separately.

The JSON output is authoritative and unbounded. Human rendering limits affect only presentation and report every omission. This PR does not calculate a critical path or expose the graph to VibeSys agents.

### Architecture

```mermaid
flowchart LR
    A[servicebench trace] --> B[managed benchmark]
    B --> C[measurement windows]
    C --> D[telemetry command]
    D --> E[otelcapture]
    E --> F[OTLP span normalization]
    F --> G[versioned trace graph JSON]
    G --> H[bounded text renderer]
    H --> I[stdout and optional text artifact]
```

`servicebench` owns orchestration and CLI validation. The telemetry package owns the versioned graph contract, OTLP reconstruction, validation, and deterministic rendering. `otelcapture` remains the collector adapter that writes artifacts atomically.

## Verification

Focused race tests pass for every changed Go package. The complete microservice evaluator suite passes when the environment-dependent Bubblewrap test is allowed to skip. CLI validation passes against the Hotel Reservation workload.

Output JSON and text results were verified by hand, available after running the trace command.

### Correctness properties

- Only complete traces whose roots fall within benchmark measurement windows enter graph aggregates.
- The versioned JSON graph is complete; rendering limits never truncate the machine contract.
- Inclusive time includes descendants, while exclusive time subtracts the union of direct-child intervals to avoid double-counting overlap.
- Nodes and edges have deterministic identities and ordering for stable artifacts and tests.
- Missing parents, duplicate spans, invalid intervals, and excluded traces are counted in trace-quality metadata.
- `servicebench trace` requires trace output configuration, while existing benchmark and accuracy commands retain their current behavior.
- The CLI does not claim or infer a critical path.

### Testing

- `PATH=/tmp/codex-go1.24.6/bin:$PATH GOCACHE=/tmp/vibesys-go-build-cache VIBESYS_REQUIRE_MANAGED_CANDIDATE_TESTS=1 go test -race ./telemetry ./cmd/otelcapture ./cmd/servicebench` (pass)
- `PATH=/tmp/codex-go1.24.6/bin:$PATH GOCACHE=/tmp/vibesys-go-build-cache go test -race ./...` from `examples/evaluators/microservice` (pass)
- `go run ./cmd/servicebench trace ... --workload ../../microservices/hotel-reservation/benchmark/workload.toml --validate-only` (pass)
- `gofmt -d` over all changed Go files (clean)
- `git diff --check origin/main...HEAD` (clean)
- `./scripts/check_format.sh && ./scripts/check_lint.sh` (not runnable: Snap `uv` permission failure described above)

