### PR TITLE
Add standalone --input-* flags to synthesize an input bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ agent domain, correctness command, benchmark command, optional starter
 workspace, optional trusted evaluator source, and optional benchmark result
 metric.
 
+For external usage without a bundle on disk, supply the same pieces as separate
+`--input-objective`/`--input-objective-file`, `--input-domain`,
+`--input-accuracy-command`, and `--input-benchmark-command` flags (plus optional
+`--input-reference`, `--input-evaluator-dir`, and others). VibeSys synthesizes a
+bundle and runs it identically. See
+[`docs/cli-flags.md`](docs/cli-flags.md#providing-inputs-without-a-bundle---input-)
+for the full flag list.
+
 `OBJECTIVE.md` is read at the start of every run and must live next to the
 `reference/` directory (sibling, not inside). See `examples/model-serving/Llama-3-8B/`, `examples/model-serving/moonshine-streaming/`, `examples/model-serving/qwen3-32b-code-edit/`, `examples/model-serving/olmo-hybrid-prefix-caching/`, `examples/model-serving/Llama-3.1-8B-Instruct-MLX-8bit/`, `examples/model-serving/show-o2-1.5B-HQ-h100/`, and `examples/model-serving/show-o2-1.5B-HQ-macbook/` for the paper scenarios.
 

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -238,7 +238,9 @@ context for the agent and evolve loops. Registered domains include:
 | `microservices` | Microservice workload guidance, lifecycle rules, and service-level evaluation context. |
 | `generic` | No extra domain guidance. Useful for custom/non-LLM targets. |
 
-Each input bundle must declare `[agent].domain`; there is no CLI override. New
+Each input bundle must declare `[agent].domain`; there is no CLI override for a
+bundle passed with `--input`. When synthesizing a bundle from `--input-*` flags
+instead, `--input-domain` sets `[agent].domain` for the generated manifest. New
 domains are added in source by registering a domain package with optional
 environment setup/teardown hooks.
 
@@ -410,6 +412,54 @@ The revision must be an ancestor of the current experiment `HEAD`. The guard
 continues to reject pending trusted-input edits and every trusted-input change
 committed after that baseline. Omitting the flag retains the original initial
 workspace baseline, so ordinary resumes cannot silently bless agent tampering.
+
+### Providing inputs without a bundle (`--input-*`)
+
+For external usage where no `examples/` bundle is on disk, pass the bundle's
+contents as separate `--input-*` flags instead of `--input`. VibeSys synthesizes
+a bundle under `exp_env/_inputs/<exp-name>/` and then loads it through the same
+path as `--input`, so every loop, resume, and evaluator behaves identically. The
+two forms are mutually exclusive: combining `--input` with any `--input-*` flag
+is rejected.
+
+Required flags:
+
+| Flag | Maps to |
+| --- | --- |
+| `--input-objective TEXT` or `--input-objective-file PATH` | `OBJECTIVE.md` |
+| `--input-domain {llm-serving,generic,microservices}` | `[agent].domain` |
+| `--input-accuracy-command CMD` | `[accuracy].command` (shell-quoted argv) |
+| `--input-benchmark-command CMD` | `[benchmark].command` (shell-quoted argv) |
+
+Optional flags:
+
+| Flag | Maps to |
+| --- | --- |
+| `--input-accuracy-timeout SECONDS` / `--input-benchmark-timeout SECONDS` | command `timeout_seconds` |
+| `--input-benchmark-metric NAME` + `--input-benchmark-result-arg OPT` | `[benchmark.result]` (both required together) |
+| `--input-reference DIR` | copied to `reference/` |
+| `--input-evaluator-dir DIR` | contents copied into the bundle root (evaluator scripts the commands invoke) |
+| `--input-workspace-seed DIR` | `[workspace].seed` (staged inside the bundle) |
+| `--input-evaluator-source DIR` | `[evaluator].source` (staged inside the bundle) |
+| `--input-hidden-evaluator-source DIR` | `[hidden_evaluator].source` (staged inside the bundle) |
+
+Unlike bundle-declared `workspace.seed` and `evaluator.source`, which must
+resolve inside `examples/starters/` and `examples/evaluators/`, the synthesized
+bundle stages these directories inside itself, so any local directory is
+accepted. Git-pinned `[[workspace.sources]]` entries are not exposed as flags;
+use `--input` for those.
+
+```bash
+./vs \
+  --input-objective-file ./OBJECTIVE.md \
+  --input-domain llm-serving \
+  --input-accuracy-command "python checker.py" \
+  --input-benchmark-command "python benchmark.py --result-json out.json" \
+  --input-benchmark-metric requests_per_second \
+  --input-benchmark-result-arg --result-json \
+  --input-evaluator-dir ./evaluator \
+  --local
+```
 
 ## Common Commands
 

--- a/src/vibesys/input_manifest.py
+++ b/src/vibesys/input_manifest.py
@@ -258,17 +258,32 @@ class InputBundle(BaseModel):
         return self.manifest.workspace.sources
 
 
+def _within(child: Path, parent: Path) -> bool:
+    """Return whether ``child`` resolves inside ``parent`` (or equals it)."""
+    try:
+        child.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
 def load_input_bundle(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
     path: Path,
     *,
     project_root: Path | None = None,
     allow_materialized_sources: bool = False,
+    allow_bundle_local_sources: bool = False,
 ) -> InputBundle:
     """Load and validate a command-based input bundle.
 
     ``allow_materialized_sources`` is used only when resuming an experiment
     from its copied workspace. Starter and evaluator sources may have lived
     outside the original bundle and are no longer needed once materialized.
+
+    ``allow_bundle_local_sources`` additionally permits workspace seed and
+    evaluator sources to resolve inside the bundle root itself, not only under
+    the repository ``examples/`` trees. It is used for bundles synthesized from
+    standalone CLI flags, which stage their trusted sources inside the bundle.
     """
     project_root = (project_root or PROJECT_ROOT).resolve()
     root = path.expanduser().resolve()
@@ -324,13 +339,14 @@ def load_input_bundle(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
         and not allow_materialized_sources
     ):
         starters_root = (project_root / "examples" / "starters").resolve()
+        allowed_seed_roots = (
+            (root, starters_root) if allow_bundle_local_sources else (starters_root,)
+        )
         workspace_seed_path = (root / manifest.workspace.seed).resolve()
-        try:
-            workspace_seed_path.relative_to(starters_root)
-        except ValueError as exc:
+        if not any(_within(workspace_seed_path, allowed) for allowed in allowed_seed_roots):
             raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"workspace.seed must resolve inside {starters_root}: {manifest.workspace.seed}"
-            ) from exc
+            )
         if not workspace_seed_path.exists():
             raise FileNotFoundError(f"workspace.seed path does not exist: {workspace_seed_path}")  # noqa: TRY003  # tracked: #288
         if not workspace_seed_path.is_dir():
@@ -339,14 +355,15 @@ def load_input_bundle(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
     evaluator_path = None
     if manifest.evaluator is not None and not allow_materialized_sources:
         evaluators_root = (project_root / "examples" / "evaluators").resolve()
+        allowed_eval_roots = (
+            (root, evaluators_root) if allow_bundle_local_sources else (evaluators_root,)
+        )
         evaluator_path = (root / manifest.evaluator.source).resolve()
-        try:
-            evaluator_path.relative_to(evaluators_root)
-        except ValueError as exc:
+        if not any(_within(evaluator_path, allowed) for allowed in allowed_eval_roots):
             raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"evaluator.source must resolve inside {evaluators_root}: "
                 f"{manifest.evaluator.source}"
-            ) from exc
+            )
         if not evaluator_path.exists():
             raise FileNotFoundError(f"evaluator.source path does not exist: {evaluator_path}")  # noqa: TRY003  # tracked: #288
         if not evaluator_path.is_dir():
@@ -355,14 +372,15 @@ def load_input_bundle(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
     hidden_evaluator_path = None
     if manifest.hidden_evaluator is not None and not allow_materialized_sources:
         evaluators_root = (project_root / "examples" / "evaluators").resolve()
+        allowed_hidden_roots = (
+            (root, evaluators_root) if allow_bundle_local_sources else (evaluators_root,)
+        )
         hidden_evaluator_path = (root / manifest.hidden_evaluator.source).resolve()
-        try:
-            hidden_evaluator_path.relative_to(evaluators_root)
-        except ValueError as exc:
+        if not any(_within(hidden_evaluator_path, allowed) for allowed in allowed_hidden_roots):
             raise ValueError(  # noqa: TRY003  # tracked: #288
                 f"hidden_evaluator.source must resolve inside {evaluators_root}: "
                 f"{manifest.hidden_evaluator.source}"
-            ) from exc
+            )
         if not hidden_evaluator_path.exists():
             raise FileNotFoundError(  # noqa: TRY003  # tracked: #288
                 f"hidden_evaluator.source path does not exist: {hidden_evaluator_path}"

--- a/src/vibesys/input_synthesis.py
+++ b/src/vibesys/input_synthesis.py
@@ -1,0 +1,262 @@
+"""Synthesize an input bundle from standalone CLI flags.
+
+External users who install VibeSys as a package do not have the repository
+``examples/`` bundles on disk. Rather than require them to hand-assemble the
+``OBJECTIVE.md`` + ``vibesys.input.toml`` bundle shape, they can pass the same
+information as separate flags (objective, domain, evaluator commands, optional
+reference/evaluator directories). This module materializes those flags into a
+conventional bundle directory that :func:`vibesys.input_manifest.load_input_bundle`
+then loads unchanged, so every downstream consumer keeps seeing a real
+``InputBundle`` rooted at a real directory.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003  # tracked: #288
+
+from pydantic import ValidationError
+
+from vibesys.domains.base import DomainName  # noqa: TC001  # tracked: #288
+from vibesys.input_manifest import MANIFEST_NAME, InputManifest
+
+#: Bundle-relative directory names used to stage trusted sources supplied by
+#: standalone flags. They live inside the synthesized bundle so the bundle is
+#: self-contained; ``load_input_bundle(..., allow_bundle_local_sources=True)``
+#: permits sources that resolve here.
+SEED_DIRNAME = "_seed"
+EVALUATOR_SRC_DIRNAME = "_evaluator_src"
+HIDDEN_EVALUATOR_SRC_DIRNAME = "_hidden_evaluator_src"
+
+#: Top-level entries the synthesizer owns. An ``--evaluator-dir`` whose contents
+#: are copied into the bundle root must not collide with any of these.
+_RESERVED_ROOT_ENTRIES = frozenset(
+    {
+        "OBJECTIVE.md",
+        MANIFEST_NAME,
+        "reference",
+        SEED_DIRNAME,
+        EVALUATOR_SRC_DIRNAME,
+        HIDDEN_EVALUATOR_SRC_DIRNAME,
+    }
+)
+
+
+class InputSynthesisError(ValueError):
+    """Raised when standalone input flags cannot be synthesized into a bundle."""
+
+
+@dataclass(frozen=True)
+class SynthesizedInputSpec:
+    """Resolved standalone-input flags describing a bundle to synthesize.
+
+    Directory fields are absolute source paths on the operator's machine; their
+    contents are copied into the synthesized bundle so it is self-contained.
+    """
+
+    objective: str
+    domain: DomainName
+    accuracy_command: tuple[str, ...]
+    benchmark_command: tuple[str, ...]
+    accuracy_timeout_seconds: int | None = None
+    benchmark_timeout_seconds: int | None = None
+    benchmark_metric: str | None = None
+    benchmark_result_arg: str | None = None
+    reference_dir: Path | None = None
+    evaluator_dir: Path | None = None
+    workspace_seed_dir: Path | None = None
+    evaluator_source_dir: Path | None = None
+    hidden_evaluator_source_dir: Path | None = None
+
+
+def _toml_string(value: str) -> str:
+    """Render ``value`` as a TOML basic string with the escapes TOML requires."""
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    return f'"{escaped}"'
+
+
+def _toml_string_array(values: tuple[str, ...]) -> str:
+    return "[" + ", ".join(_toml_string(value) for value in values) + "]"
+
+
+def _require_source_dir(path: Path, label: str) -> Path:
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        raise InputSynthesisError(f"{label} path does not exist: {path}")  # noqa: TRY003
+    if not resolved.is_dir():
+        raise InputSynthesisError(f"{label} path is not a directory: {path}")  # noqa: TRY003
+    return resolved
+
+
+def _build_manifest_dict(spec: SynthesizedInputSpec) -> dict[str, object]:
+    """Assemble the manifest payload, mirroring the emitted TOML structure."""
+    accuracy: dict[str, object] = {"command": list(spec.accuracy_command)}
+    if spec.accuracy_timeout_seconds is not None:
+        accuracy["timeout_seconds"] = spec.accuracy_timeout_seconds
+
+    benchmark: dict[str, object] = {"command": list(spec.benchmark_command)}
+    if spec.benchmark_timeout_seconds is not None:
+        benchmark["timeout_seconds"] = spec.benchmark_timeout_seconds
+    if spec.benchmark_metric is not None or spec.benchmark_result_arg is not None:
+        if spec.benchmark_metric is None or spec.benchmark_result_arg is None:
+            raise InputSynthesisError(  # noqa: TRY003
+                "benchmark result requires both --input-benchmark-metric and "
+                "--input-benchmark-result-arg."
+            )
+        benchmark["result"] = {
+            "json_argument": spec.benchmark_result_arg,
+            "metric": spec.benchmark_metric,
+        }
+
+    manifest: dict[str, object] = {
+        "version": 1,
+        "agent": {"domain": str(spec.domain)},
+        "accuracy": accuracy,
+        "benchmark": benchmark,
+    }
+    if spec.workspace_seed_dir is not None:
+        manifest["workspace"] = {"seed": SEED_DIRNAME}
+    if spec.evaluator_source_dir is not None:
+        manifest["evaluator"] = {"source": EVALUATOR_SRC_DIRNAME}
+    if spec.hidden_evaluator_source_dir is not None:
+        manifest["hidden_evaluator"] = {"source": HIDDEN_EVALUATOR_SRC_DIRNAME}
+    return manifest
+
+
+def _render_manifest_toml(spec: SynthesizedInputSpec) -> str:
+    """Render the fixed manifest shape for ``spec`` as TOML text.
+
+    This is a purpose-built emitter for exactly the tables the synthesizer
+    generates, not a general TOML writer. The output round-trips through
+    :func:`vibesys.input_manifest.load_input_bundle`, which re-validates it. The
+    same shape is validated eagerly via :func:`_build_manifest_dict`.
+    """
+    lines: list[str] = [
+        "version = 1",
+        "",
+        "[agent]",
+        f"domain = {_toml_string(str(spec.domain))}",
+        "",
+        "[accuracy]",
+        f"command = {_toml_string_array(spec.accuracy_command)}",
+    ]
+    if spec.accuracy_timeout_seconds is not None:
+        lines.append(f"timeout_seconds = {spec.accuracy_timeout_seconds}")
+    lines.append("")
+
+    lines.append("[benchmark]")
+    lines.append(f"command = {_toml_string_array(spec.benchmark_command)}")
+    if spec.benchmark_timeout_seconds is not None:
+        lines.append(f"timeout_seconds = {spec.benchmark_timeout_seconds}")
+    lines.append("")
+    if spec.benchmark_metric is not None and spec.benchmark_result_arg is not None:
+        lines.append("[benchmark.result]")
+        lines.append(f"json_argument = {_toml_string(spec.benchmark_result_arg)}")
+        lines.append(f"metric = {_toml_string(spec.benchmark_metric)}")
+        lines.append("")
+
+    for present, table, key, value in (
+        (spec.workspace_seed_dir is not None, "workspace", "seed", SEED_DIRNAME),
+        (spec.evaluator_source_dir is not None, "evaluator", "source", EVALUATOR_SRC_DIRNAME),
+        (
+            spec.hidden_evaluator_source_dir is not None,
+            "hidden_evaluator",
+            "source",
+            HIDDEN_EVALUATOR_SRC_DIRNAME,
+        ),
+    ):
+        if present:
+            lines.append(f"[{table}]")
+            lines.append(f"{key} = {_toml_string(value)}")
+            lines.append("")
+
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def _copy_tree_into(source: Path, destination: Path) -> None:
+    shutil.copytree(source, destination, symlinks=True)
+
+
+def _copy_evaluator_dir_contents(evaluator_dir: Path, bundle_root: Path) -> None:
+    """Copy each top-level entry of ``evaluator_dir`` into the bundle root."""
+    for child in sorted(evaluator_dir.iterdir()):
+        if child.name in _RESERVED_ROOT_ENTRIES:
+            raise InputSynthesisError(  # noqa: TRY003
+                f"--input-evaluator-dir entry collides with a reserved bundle name: {child.name}"
+            )
+        target = bundle_root / child.name
+        if child.is_dir():
+            _copy_tree_into(child, target)
+        else:
+            shutil.copy2(child, target)
+
+
+def synthesize_input_bundle(spec: SynthesizedInputSpec, destination: Path) -> Path:
+    """Materialize ``spec`` into a bundle directory at ``destination``.
+
+    Returns the created bundle root. The caller loads it with
+    ``load_input_bundle(root, allow_bundle_local_sources=True)``.
+    """
+    manifest = _build_manifest_dict(spec)
+    try:
+        InputManifest.model_validate(manifest)
+    except ValidationError as exc:  # pragma: no cover - defensive, flags validated upstream
+        raise InputSynthesisError(f"Invalid synthesized manifest: {exc}") from exc  # noqa: TRY003
+
+    reference_dir = (
+        _require_source_dir(spec.reference_dir, "--input-reference")
+        if spec.reference_dir is not None
+        else None
+    )
+    evaluator_dir = (
+        _require_source_dir(spec.evaluator_dir, "--input-evaluator-dir")
+        if spec.evaluator_dir is not None
+        else None
+    )
+    seed_dir = (
+        _require_source_dir(spec.workspace_seed_dir, "--input-workspace-seed")
+        if spec.workspace_seed_dir is not None
+        else None
+    )
+    evaluator_source_dir = (
+        _require_source_dir(spec.evaluator_source_dir, "--input-evaluator-source")
+        if spec.evaluator_source_dir is not None
+        else None
+    )
+    hidden_evaluator_source_dir = (
+        _require_source_dir(spec.hidden_evaluator_source_dir, "--input-hidden-evaluator-source")
+        if spec.hidden_evaluator_source_dir is not None
+        else None
+    )
+
+    root = destination.expanduser().resolve()
+    if root.exists():
+        raise InputSynthesisError(f"synthesized bundle directory already exists: {root}")  # noqa: TRY003
+    root.mkdir(parents=True)
+
+    # Evaluator-dir contents go in first so a later reserved-name write always
+    # wins and a collision is reported rather than silently overwritten.
+    if evaluator_dir is not None:
+        _copy_evaluator_dir_contents(evaluator_dir, root)
+
+    objective_text = spec.objective if spec.objective.endswith("\n") else spec.objective + "\n"
+    (root / "OBJECTIVE.md").write_text(objective_text)
+    (root / MANIFEST_NAME).write_text(_render_manifest_toml(spec))
+
+    if reference_dir is not None:
+        _copy_tree_into(reference_dir, root / "reference")
+    if seed_dir is not None:
+        _copy_tree_into(seed_dir, root / SEED_DIRNAME)
+    if evaluator_source_dir is not None:
+        _copy_tree_into(evaluator_source_dir, root / EVALUATOR_SRC_DIRNAME)
+    if hidden_evaluator_source_dir is not None:
+        _copy_tree_into(hidden_evaluator_source_dir, root / HIDDEN_EVALUATOR_SRC_DIRNAME)
+
+    return root

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -20,6 +20,7 @@ import argparse
 import json
 import math
 import os
+import shlex
 import subprocess
 import sys
 import tomllib
@@ -34,7 +35,7 @@ from vibesys.constants import (
     PROJECT_ROOT,
     ComputeBackend,
 )
-from vibesys.domains.base import DomainName  # noqa: TC001  # tracked: #288
+from vibesys.domains.base import DomainName
 from vibesys.errors import ConfigurationDiagnostic, ConfigurationError
 from vibesys.input_manifest import InputBundle, load_input_bundle
 from vibesys.profilers import CLI_PROFILER_CHOICES, ProfilerKind, coerce_profiler_kind
@@ -184,6 +185,146 @@ def _fail(msg: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+#: Standalone-input flag dests that together synthesize a bundle when ``--input``
+#: is omitted. Kept in one place so conflict/requirement checks stay in sync.
+#: Every flag is spelled ``--input-<name>``; argparse maps it to ``input_<name>``.
+_STANDALONE_INPUT_DESTS = (
+    "input_objective",
+    "input_objective_file",
+    "input_domain",
+    "input_accuracy_command",
+    "input_benchmark_command",
+    "input_accuracy_timeout",
+    "input_benchmark_timeout",
+    "input_benchmark_metric",
+    "input_benchmark_result_arg",
+    "input_reference",
+    "input_evaluator_dir",
+    "input_workspace_seed",
+    "input_evaluator_source",
+    "input_hidden_evaluator_source",
+)
+
+
+def _add_standalone_input_args(parser: argparse.ArgumentParser) -> None:
+    """Add flags that synthesize an input bundle without a prebuilt ``--input``.
+
+    These let external users (e.g. a ``pip install``ed VibeSys with no
+    repository ``examples/`` on disk) pass the objective, domain, and evaluator
+    commands directly. When any are set and ``--input`` is omitted, the flags
+    are materialized into a bundle before the normal input-loading path runs.
+
+    All flags share the ``--input-`` prefix so they read as the pieces of
+    ``--input`` provided separately, and so none abbreviate to a retired flag
+    (e.g. ``--ref``, ``--domain``) that the CLI still rejects.
+    """
+    group = parser.add_argument_group(
+        "standalone input",
+        "Provide an input bundle's contents directly instead of --input. "
+        "Requires --input-objective/--input-objective-file, --input-domain, "
+        "--input-accuracy-command, and --input-benchmark-command; the rest are optional.",
+    )
+    group.add_argument(
+        "--input-objective",
+        default=None,
+        metavar="TEXT",
+        help="Objective text (becomes OBJECTIVE.md). Mutually exclusive with --input-objective-file.",
+    )
+    group.add_argument(
+        "--input-objective-file",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Path to a file whose contents become OBJECTIVE.md.",
+    )
+    group.add_argument(
+        "--input-domain",
+        type=DomainName,
+        choices=list(DomainName),
+        default=None,
+        help="Target domain for the synthesized bundle's [agent].domain.",
+    )
+    group.add_argument(
+        "--input-accuracy-command",
+        default=None,
+        metavar="CMD",
+        help="Accuracy evaluator command, shell-quoted (e.g. 'python checker.py').",
+    )
+    group.add_argument(
+        "--input-benchmark-command",
+        default=None,
+        metavar="CMD",
+        help="Benchmark command, shell-quoted (e.g. 'python benchmark.py').",
+    )
+    group.add_argument(
+        "--input-accuracy-timeout",
+        type=int,
+        default=None,
+        metavar="SECONDS",
+        help="Optional timeout for the accuracy command.",
+    )
+    group.add_argument(
+        "--input-benchmark-timeout",
+        type=int,
+        default=None,
+        metavar="SECONDS",
+        help="Optional timeout for the benchmark command.",
+    )
+    group.add_argument(
+        "--input-benchmark-metric",
+        default=None,
+        metavar="NAME",
+        help=(
+            "JSON field the benchmark emits as its scalar result "
+            "(with --input-benchmark-result-arg)."
+        ),
+    )
+    group.add_argument(
+        "--input-benchmark-result-arg",
+        default=None,
+        metavar="OPT",
+        help=(
+            "Option-style argv element the benchmark accepts for its JSON result path "
+            "(e.g. --result-json); pairs with --input-benchmark-metric."
+        ),
+    )
+    group.add_argument(
+        "--input-reference",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Directory copied into the bundle as reference/.",
+    )
+    group.add_argument(
+        "--input-evaluator-dir",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Directory whose contents are copied into the bundle root (evaluator scripts, etc.).",
+    )
+    group.add_argument(
+        "--input-workspace-seed",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Directory copied in as the candidate workspace seed (manifest [workspace].seed).",
+    )
+    group.add_argument(
+        "--input-evaluator-source",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Trusted evaluator source directory (manifest [evaluator].source).",
+    )
+    group.add_argument(
+        "--input-hidden-evaluator-source",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Hidden evaluator source directory (manifest [hidden_evaluator].source).",
+    )
+
+
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
     """Add CLI arguments shared across every outer-loop parser."""
     parser.add_argument(
@@ -195,6 +336,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
             "vibesys.input.toml with accuracy and benchmark commands."
         ),
     )
+    _add_standalone_input_args(parser)
     parser.add_argument(
         "--exp-name",
         required=False,
@@ -945,19 +1087,144 @@ def _build_agent_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _validate_target_inputs(args: argparse.Namespace) -> None:
-    input_arg = getattr(args, "input", None)
-    if input_arg is None:
+def _standalone_input_dests_set(args: argparse.Namespace) -> list[str]:
+    """Return the standalone-input flag dests that were provided (non-default)."""
+    return [dest for dest in _STANDALONE_INPUT_DESTS if getattr(args, dest, None) is not None]
+
+
+def _resolve_standalone_objective(args: argparse.Namespace) -> str:
+    if args.input_objective is not None and args.input_objective_file is not None:
         _configuration_error(
-            "Error: missing required target input: --input. "
-            "Pass a bundle containing OBJECTIVE.md and vibesys.input.toml.",
+            "Error: pass only one of --input-objective or --input-objective-file.",
+            code="invalid_arguments",
+            stage="argument_parsing",
+        )
+    if args.input_objective is not None:
+        return args.input_objective
+    if args.input_objective_file is None:
+        _configuration_error(
+            "Error: --input-objective or --input-objective-file is required.",
             code="missing_input",
             stage="input_loading",
         )
+    objective_file = args.input_objective_file.expanduser()
+    if not objective_file.is_file():
+        _configuration_error(
+            f"Error: --input-objective-file not found: {args.input_objective_file}",
+            code="invalid_input",
+            stage="input_loading",
+        )
+    return objective_file.read_text()
+
+
+def _parse_command_flag(raw: str, flag: str) -> tuple[str, ...]:
+    try:
+        parts = tuple(shlex.split(raw))
+    except ValueError as exc:
+        _configuration_error(
+            f"Error: could not parse {flag}: {exc}",
+            code="invalid_arguments",
+            stage="argument_parsing",
+        )
+    if not parts:
+        _configuration_error(
+            f"Error: {flag} must contain at least one argument.",
+            code="invalid_arguments",
+            stage="argument_parsing",
+        )
+    return parts
+
+
+def _synthesize_standalone_input(args: argparse.Namespace) -> Path:
+    """Materialize standalone-input flags into a bundle and return its path."""
+    from vibesys.input_synthesis import (  # noqa: PLC0415  # tracked: #288
+        InputSynthesisError,
+        SynthesizedInputSpec,
+        synthesize_input_bundle,
+    )
+
+    missing = [
+        flag
+        for flag, present in (
+            (
+                "--input-objective/--input-objective-file",
+                args.input_objective is not None or args.input_objective_file is not None,
+            ),
+            ("--input-domain", args.input_domain is not None),
+            ("--input-accuracy-command", args.input_accuracy_command is not None),
+            ("--input-benchmark-command", args.input_benchmark_command is not None),
+        )
+        if not present
+    ]
+    if missing:
+        _configuration_error(
+            "Error: standalone input requires " + ", ".join(missing) + ".",
+            code="missing_input",
+            stage="input_loading",
+        )
+
+    objective = _resolve_standalone_objective(args)
+    spec = SynthesizedInputSpec(
+        objective=objective,
+        domain=args.input_domain,
+        accuracy_command=_parse_command_flag(
+            args.input_accuracy_command, "--input-accuracy-command"
+        ),
+        benchmark_command=_parse_command_flag(
+            args.input_benchmark_command, "--input-benchmark-command"
+        ),
+        accuracy_timeout_seconds=args.input_accuracy_timeout,
+        benchmark_timeout_seconds=args.input_benchmark_timeout,
+        benchmark_metric=args.input_benchmark_metric,
+        benchmark_result_arg=args.input_benchmark_result_arg,
+        reference_dir=args.input_reference,
+        evaluator_dir=args.input_evaluator_dir,
+        workspace_seed_dir=args.input_workspace_seed,
+        evaluator_source_dir=args.input_evaluator_source,
+        hidden_evaluator_source_dir=args.input_hidden_evaluator_source,
+    )
+
+    if args.exp_name is None:
+        args.exp_name = generate_experiment_name(Path(str(args.input_domain)))
+    destination = PROJECT_ROOT / "exp_env" / "_inputs" / args.exp_name
+    try:
+        return synthesize_input_bundle(spec, destination)
+    except InputSynthesisError as exc:
+        _configuration_error(str(exc), code="invalid_input", stage="input_loading")
+
+
+def _validate_target_inputs(args: argparse.Namespace) -> None:
+    input_arg = getattr(args, "input", None)
+    standalone = _standalone_input_dests_set(args)
+    synthesized = False
+
+    if input_arg is not None and standalone:
+        _configuration_error(
+            "Error: --input cannot be combined with standalone input flags "
+            f"({', '.join('--' + dest.replace('_', '-') for dest in standalone)}).",
+            code="invalid_arguments",
+            stage="argument_parsing",
+        )
+
+    if input_arg is None:
+        if not standalone:
+            _configuration_error(
+                "Error: missing required target input. Pass --input with a bundle "
+                "containing OBJECTIVE.md and vibesys.input.toml, or provide "
+                "--input-objective/--input-objective-file, --input-domain, "
+                "--input-accuracy-command, and --input-benchmark-command to synthesize one.",
+                code="missing_input",
+                stage="input_loading",
+            )
+        input_arg = _synthesize_standalone_input(args)
+        args.input = input_arg
+        synthesized = True
+
     try:
         args.input_bundle = load_input_bundle(
             input_arg,
             allow_materialized_sources=getattr(args, "resume", None) is not None,
+            allow_bundle_local_sources=synthesized,
         )
     except (FileNotFoundError, ValueError) as exc:
         _configuration_error(str(exc), code="invalid_input", stage="input_loading")

--- a/tests/test_input_synthesis.py
+++ b/tests/test_input_synthesis.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 
 from vibesys.domains.base import DomainName
@@ -13,16 +15,16 @@ from vibesys.input_synthesis import (
     synthesize_input_bundle,
 )
 
+_BASE_SPEC = SynthesizedInputSpec(
+    objective="Serve the model quickly.",
+    domain=DomainName.LLM_SERVING,
+    accuracy_command=("python", "checker.py"),
+    benchmark_command=("python", "benchmark.py"),
+)
 
-def _minimal_spec(**overrides) -> SynthesizedInputSpec:  # noqa: ANN003  # tracked: #288
-    base = {
-        "objective": "Serve the model quickly.",
-        "domain": DomainName.LLM_SERVING,
-        "accuracy_command": ("python", "checker.py"),
-        "benchmark_command": ("python", "benchmark.py"),
-    }
-    base.update(overrides)
-    return SynthesizedInputSpec(**base)
+
+def _minimal_spec(**overrides: object) -> SynthesizedInputSpec:
+    return dataclasses.replace(_BASE_SPEC, **overrides)
 
 
 def test_synthesize_minimal_bundle_round_trips(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
@@ -65,6 +67,7 @@ def test_synthesize_populates_optional_fields(tmp_path):  # noqa: ANN001, ANN201
     assert bundle.benchmark_result.metric == "latency_ms"
     assert bundle.benchmark_result.json_argument == "--result-json"
     assert bundle.reference_path == (root / "reference").resolve()
+    assert bundle.reference_path is not None
     assert (bundle.reference_path / "golden.txt").read_text() == "42\n"
     assert bundle.workspace_seed_path == (root / "_seed").resolve()
 

--- a/tests/test_input_synthesis.py
+++ b/tests/test_input_synthesis.py
@@ -1,0 +1,235 @@
+"""Tests for synthesizing input bundles from standalone CLI flags."""
+
+from __future__ import annotations
+
+import pytest
+
+from vibesys.domains.base import DomainName
+from vibesys.errors import ConfigurationError
+from vibesys.input_manifest import load_input_bundle
+from vibesys.input_synthesis import (
+    InputSynthesisError,
+    SynthesizedInputSpec,
+    synthesize_input_bundle,
+)
+
+
+def _minimal_spec(**overrides) -> SynthesizedInputSpec:  # noqa: ANN003  # tracked: #288
+    base = {
+        "objective": "Serve the model quickly.",
+        "domain": DomainName.LLM_SERVING,
+        "accuracy_command": ("python", "checker.py"),
+        "benchmark_command": ("python", "benchmark.py"),
+    }
+    base.update(overrides)
+    return SynthesizedInputSpec(**base)
+
+
+def test_synthesize_minimal_bundle_round_trips(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    root = synthesize_input_bundle(_minimal_spec(), tmp_path / "bundle")
+
+    bundle = load_input_bundle(root, allow_bundle_local_sources=True)
+
+    assert bundle.domain == DomainName.LLM_SERVING
+    assert bundle.objective == "Serve the model quickly.\n"
+    assert bundle.accuracy_command == ("python", "checker.py")
+    assert bundle.benchmark_command == ("python", "benchmark.py")
+    assert bundle.reference_path is None
+    assert bundle.workspace_seed_path is None
+    assert bundle.benchmark_result is None
+
+
+def test_synthesize_populates_optional_fields(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    reference = tmp_path / "ref"
+    reference.mkdir()
+    (reference / "golden.txt").write_text("42\n")
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "main.py").write_text("# candidate\n")
+
+    spec = _minimal_spec(
+        accuracy_timeout_seconds=120,
+        benchmark_timeout_seconds=300,
+        benchmark_metric="latency_ms",
+        benchmark_result_arg="--result-json",
+        reference_dir=reference,
+        workspace_seed_dir=seed,
+    )
+    root = synthesize_input_bundle(spec, tmp_path / "bundle")
+
+    bundle = load_input_bundle(root, allow_bundle_local_sources=True)
+
+    assert bundle.manifest.accuracy.timeout_seconds == 120
+    assert bundle.manifest.benchmark.timeout_seconds == 300
+    assert bundle.benchmark_result is not None
+    assert bundle.benchmark_result.metric == "latency_ms"
+    assert bundle.benchmark_result.json_argument == "--result-json"
+    assert bundle.reference_path == (root / "reference").resolve()
+    assert (bundle.reference_path / "golden.txt").read_text() == "42\n"
+    assert bundle.workspace_seed_path == (root / "_seed").resolve()
+
+
+def test_synthesize_copies_evaluator_dir_contents_into_root(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    evaluator = tmp_path / "eval"
+    (evaluator / "pkg").mkdir(parents=True)
+    (evaluator / "checker.py").write_text("print('ok')\n")
+    (evaluator / "pkg" / "helper.py").write_text("X = 1\n")
+
+    root = synthesize_input_bundle(_minimal_spec(evaluator_dir=evaluator), tmp_path / "bundle")
+
+    assert (root / "checker.py").read_text() == "print('ok')\n"
+    assert (root / "pkg" / "helper.py").read_text() == "X = 1\n"
+    # The manifest and objective the synthesizer owns are still intact.
+    load_input_bundle(root, allow_bundle_local_sources=True)
+
+
+def test_synthesize_rejects_evaluator_dir_reserved_name_collision(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    evaluator = tmp_path / "eval"
+    (evaluator / "reference").mkdir(parents=True)
+
+    with pytest.raises(InputSynthesisError, match="reserved bundle name"):
+        synthesize_input_bundle(_minimal_spec(evaluator_dir=evaluator), tmp_path / "bundle")
+
+
+def test_synthesize_requires_both_benchmark_result_fields(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    with pytest.raises(InputSynthesisError, match="both --input-benchmark-metric"):
+        synthesize_input_bundle(_minimal_spec(benchmark_metric="latency_ms"), tmp_path / "bundle")
+
+
+def test_synthesize_refuses_existing_destination(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    dest = tmp_path / "bundle"
+    dest.mkdir()
+
+    with pytest.raises(InputSynthesisError, match="already exists"):
+        synthesize_input_bundle(_minimal_spec(), dest)
+
+
+def test_synthesize_rejects_missing_source_dir(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    with pytest.raises(InputSynthesisError, match="--input-reference path does not exist"):
+        synthesize_input_bundle(_minimal_spec(reference_dir=tmp_path / "nope"), tmp_path / "bundle")
+
+
+def test_synthesize_escapes_special_characters_in_commands(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    spec = _minimal_spec(
+        objective='Handle "quotes" and\nnewlines.',
+        accuracy_command=("python", "-c", 'print("hi")'),
+    )
+    root = synthesize_input_bundle(spec, tmp_path / "bundle")
+
+    bundle = load_input_bundle(root, allow_bundle_local_sources=True)
+    assert bundle.accuracy_command == ("python", "-c", 'print("hi")')
+    assert bundle.objective == 'Handle "quotes" and\nnewlines.\n'
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def _agent_args(argv: list[str]):  # noqa: ANN202  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    return cli._build_agent_parser().parse_args(argv)  # noqa: SLF001  # tracked: #288
+
+
+def test_standalone_flags_synthesize_bundle(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    args = _agent_args(
+        [
+            "--input-objective",
+            "Serve fast.",
+            "--input-domain",
+            "llm-serving",
+            "--input-accuracy-command",
+            "python checker.py",
+            "--input-benchmark-command",
+            "python benchmark.py",
+            "--no-skills",
+        ]
+    )
+
+    cli._validate_target_inputs(args)  # noqa: SLF001  # tracked: #288
+
+    assert args.exp_name.startswith("llm-serving-")
+    assert args.input == tmp_path / "exp_env" / "_inputs" / args.exp_name
+    assert args.input_bundle.domain == DomainName.LLM_SERVING
+    assert args.input_bundle.accuracy_command == ("python", "checker.py")
+
+
+def test_objective_file_is_read(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    objective_file = tmp_path / "OBJ.md"
+    objective_file.write_text("From a file.\n")
+    args = _agent_args(
+        [
+            "--input-objective-file",
+            str(objective_file),
+            "--input-domain",
+            "generic",
+            "--input-accuracy-command",
+            "checker",
+            "--input-benchmark-command",
+            "bench",
+        ]
+    )
+
+    cli._validate_target_inputs(args)  # noqa: SLF001  # tracked: #288
+
+    assert args.input_bundle.objective == "From a file.\n"
+
+
+def test_input_conflicts_with_standalone_flags(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    args = _agent_args(["--input", str(tmp_path), "--input-domain", "generic"])
+
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    with pytest.raises(ConfigurationError, match="cannot be combined"):
+        cli._validate_target_inputs(args)  # noqa: SLF001  # tracked: #288
+
+
+def test_missing_input_and_standalone_flags_errors():  # noqa: ANN201  # tracked: #288
+    args = _agent_args([])
+
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    with pytest.raises(ConfigurationError, match="missing required target input"):
+        cli._validate_target_inputs(args)  # noqa: SLF001  # tracked: #288
+
+
+def test_incomplete_standalone_flags_error():  # noqa: ANN201  # tracked: #288
+    # Objective + domain but no evaluator commands.
+    args = _agent_args(["--input-objective", "x", "--input-domain", "generic"])
+
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    with pytest.raises(ConfigurationError, match="standalone input requires"):
+        cli._validate_target_inputs(args)  # noqa: SLF001  # tracked: #288
+
+
+def test_both_objective_forms_rejected(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    objective_file = tmp_path / "OBJ.md"
+    objective_file.write_text("file\n")
+    args = _agent_args(
+        [
+            "--input-objective",
+            "inline",
+            "--input-objective-file",
+            str(objective_file),
+            "--input-domain",
+            "generic",
+            "--input-accuracy-command",
+            "checker",
+            "--input-benchmark-command",
+            "bench",
+        ]
+    )
+
+    with pytest.raises(ConfigurationError, match="only one of --input-objective"):
+        cli._validate_target_inputs(args)  # noqa: SLF001  # tracked: #288

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -161,6 +161,9 @@ def test_target_input_defaults_to_none():  # noqa: ANN201  # tracked: #288
     assert args.profiler is ProfilerKind.AUTO
     assert not hasattr(args, "profiler_support")
     assert not hasattr(args, "domain")
+    # Standalone-input flags default to None (they synthesize a bundle when set).
+    assert args.input_domain is None
+    assert args.input_objective is None
 
 
 @pytest.mark.parametrize(
@@ -727,7 +730,11 @@ def test_validate_target_inputs_requires_input():  # noqa: ANN201  # tracked: #2
     with pytest.raises(ConfigurationError) as exc:
         _validate_target_inputs(args)
 
-    assert "missing required target input: --input" in exc.value.diagnostic.message
+    message = exc.value.diagnostic.message
+    assert "missing required target input" in message
+    # The error points at both ways to supply a target.
+    assert "--input" in message
+    assert "--input-objective" in message
 
 
 def test_trusted_input_baseline_requires_resume(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288

--- a/tests/test_workspace_seed.py
+++ b/tests/test_workspace_seed.py
@@ -268,6 +268,33 @@ def test_manifest_resolves_hidden_evaluator_relative_to_bundle(tmp_path):  # noq
     assert loaded.hidden_evaluator_path == evaluator.resolve()
 
 
+def test_bundle_local_seed_rejected_without_flag_but_allowed_with_it(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    project_root = tmp_path / "project"
+    bundle = _write_bundle(project_root, '[workspace]\nseed = "_seed"')
+    (bundle / "_seed").mkdir()
+
+    # A seed inside the bundle escapes examples/starters under the default policy.
+    with pytest.raises(ValueError, match="must resolve inside"):
+        load_input_bundle(bundle, project_root=project_root)
+
+    loaded = load_input_bundle(bundle, project_root=project_root, allow_bundle_local_sources=True)
+    assert loaded.workspace_seed_path == (bundle / "_seed").resolve()
+
+
+def test_bundle_local_evaluator_sources_allowed_with_flag(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    project_root = tmp_path / "project"
+    bundle = _write_bundle(
+        project_root,
+        '[evaluator]\nsource = "_evaluator_src"\n\n[hidden_evaluator]\nsource = "_hidden_evaluator_src"',
+    )
+    (bundle / "_evaluator_src").mkdir()
+    (bundle / "_hidden_evaluator_src").mkdir()
+
+    loaded = load_input_bundle(bundle, project_root=project_root, allow_bundle_local_sources=True)
+    assert loaded.evaluator_path == (bundle / "_evaluator_src").resolve()
+    assert loaded.hidden_evaluator_path == (bundle / "_hidden_evaluator_src").resolve()
+
+
 @pytest.mark.parametrize(
     ("seed_value", "error"),
     [


### PR DESCRIPTION
## Problem

Running a target today requires a prebuilt bundle directory passed with
`--input` (an `OBJECTIVE.md` + `vibesys.input.toml` plus evaluator scripts).
That is fine inside the repo, where `examples/` bundles exist on disk, but it is
awkward for external/programmatic callers who have the pieces in hand (an
objective, a domain, an accuracy command, a benchmark command) and no assembled
bundle. They had to hand-write the manifest and lay out the conventional files
before VibeSys would accept the target.

This adds a first-class way to pass those pieces as separate flags, while
leaving `--input` completely unchanged.

## Solution

New `--input-*` flags let a caller describe a target directly. When any are set
and `--input` is omitted, VibeSys synthesizes a conventional bundle under
`exp_env/_inputs/<exp-name>/` and then loads it through the **existing**
`load_input_bundle` path. Because downstream code still receives a real
`InputBundle` rooted at a real directory, every loop, resume, git snapshot, and
evaluator behaves identically to a hand-authored `--input` bundle.

Required flags: `--input-objective`/`--input-objective-file`, `--input-domain`,
`--input-accuracy-command`, `--input-benchmark-command`. Optional:
`--input-reference`, `--input-evaluator-dir` (scripts copied into the bundle
root), `--input-benchmark-metric`/`--input-benchmark-result-arg`, timeouts, and
`--input-workspace-seed` / `--input-evaluator-source` /
`--input-hidden-evaluator-source`.

Reviewers should look at:
- The `--input-` prefix on every flag. Bare `--objective`/`--domain`/`--reference`
  were unusable: `--objective` collides with the evolve loop's existing
  multi-objective flag, and `--domain`/`--reference` would re-enable the retired
  `--domain`/`--ref` flags via argparse prefix-abbreviation (which guard tests
  reject). The uniform prefix avoids all three and reads as "the pieces of
  `--input`".
- The synthesized-bundle location. The real run dir is
  `exp_env/<timestamp>-<uuid>-<name>/`, created later with `exist_ok=False`, so
  the bundle cannot live there at validation time. It is written to a stable
  `exp_env/_inputs/<exp-name>/` (gitignored), referenced by absolute path, and
  survives the run and resume.
- `allow_bundle_local_sources` in `load_input_bundle`: synthesized bundles stage
  their seed/evaluator sources inside themselves, so those sources are permitted
  to resolve inside the bundle root. The default (used by `--input`) still
  restricts them to `examples/starters` and `examples/evaluators`.

### Architecture

`input_synthesis.py` owns flag-to-bundle materialization and a small
purpose-built TOML writer; `main.py` owns CLI wiring; `input_manifest.py`
loads/validates bundles as before.

```mermaid
flowchart LR
    A["--input-* flags"] --> B["_validate_target_inputs (main.py)"]
    C["--input DIR"] --> B
    B -->|standalone flags| D["synthesize_input_bundle\n(input_synthesis.py)"]
    D --> E["exp_env/_inputs/<exp>/\nOBJECTIVE.md + vibesys.input.toml"]
    E --> F["load_input_bundle\n(allow_bundle_local_sources=True)"]
    C --> F
    F --> G["InputBundle -> loops / resume / evaluators"]
```

## Verification

### Correctness properties

- `--input` and `--input-*` are mutually exclusive; combining them errors.
- Synthesis requires objective (one of two forms), domain, and both evaluator
  commands; missing ones produce a named error.
- The emitted `vibesys.input.toml` round-trips through `load_input_bundle`
  (validated), including special characters in objective and command argv.
- `--input` behavior is unchanged; the default source-location trust boundary
  (`examples/starters`, `examples/evaluators`) is preserved when
  `allow_bundle_local_sources` is false.
- `--input-benchmark-metric` and `--input-benchmark-result-arg` must be supplied
  together.
- Retired flags `--ref` and `--domain` remain rejected (no abbreviation
  collision introduced).

### Testing

```
uv run pytest tests/test_input_synthesis.py tests/test_workspace_seed.py tests/test_main.py
# 158 passed

./scripts/check_format.sh   # All checks passed
./scripts/check_lint.sh     # All checks passed
uv run pyright src/vibesys/input_synthesis.py src/vibesys/input_manifest.py src/vibesys/main.py
# 0 errors
```

New tests: `tests/test_input_synthesis.py` (synthesis + round-trip, evaluator-dir
copying and reserved-name collisions, benchmark-result pairing, CLI wiring,
conflict/missing/incomplete errors) and added cases in `tests/test_workspace_seed.py`
for the relaxed source-location constraint.

**CLI contract note:** adds the `--input-*` flag family to the agent, evolve, and
plain parsers; no existing flag changed. Manifest/bundle shape is unchanged.
Prompt snapshots not applicable.
