### PR TITLE
Wire /pause, /resume, and /steer TUI control commands

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -21,6 +21,10 @@ available slash commands are:
 | Command | Behavior |
 | --- | --- |
 | `/help` | Show commands and planned controls. |
+| `/chat` | Open a read-only chat about the run; `/chat <question>` asks immediately. |
+| `/pause` | Pause after the current agent call finishes. |
+| `/resume` | Resume a paused run. |
+| `/steer <message>` | Queue an instruction that is appended to the next agent invocation's prompt. |
 | `/history` | List rounds with agent-active elapsed time. |
 | `/perf` | Plot the recorded performance metric by round. |
 | `/theme` | List themes; `/theme <name>` switches immediately. |

--- a/clients/tui/src/commands.test.ts
+++ b/clients/tui/src/commands.test.ts
@@ -12,7 +12,19 @@ describe('parseInput', () => {
       localView: 'chat',
       chatMessage: 'what changed in the latest round?',
     });
-    expect(parseInput('/steer inspect the cache').error).toContain('Unknown command');
+  });
+
+  it('parses run-control commands', () => {
+    expect(parseInput('/pause')).toEqual({request: {type: 'command.pause'}});
+    expect(parseInput('/resume')).toEqual({request: {type: 'command.resume'}});
+    expect(parseInput('/steer prioritize the KV cache path')).toEqual({
+      request: {type: 'command.steer', text: 'prioritize the KV cache path'},
+    });
+  });
+
+  it('requires a message for /steer', () => {
+    expect(parseInput('/steer').error).toContain('Usage: /steer');
+    expect(parseInput('/steer   ').error).toContain('Usage: /steer');
   });
 
   it('sends ordinary text to the supervision chat endpoint', () => {
@@ -59,6 +71,9 @@ describe('slash-command input helpers', () => {
     expect(suggestSlashCommands('/').map(command => command.name)).toEqual([
       '/help',
       '/chat',
+      '/pause',
+      '/resume',
+      '/steer',
       '/history',
       '/perf',
       '/theme',

--- a/clients/tui/src/commands.ts
+++ b/clients/tui/src/commands.ts
@@ -18,6 +18,9 @@ export interface SlashCommand {
 export const SLASH_COMMANDS: readonly SlashCommand[] = [
   {name: '/help', description: 'Show this help'},
   {name: '/chat', description: 'Open experiment chat'},
+  {name: '/pause', description: 'Pause after the current agent call'},
+  {name: '/resume', description: 'Resume a paused run'},
+  {name: '/steer', description: 'Guide the next agent invocation: /steer <message>'},
   {name: '/history', description: 'List rounds and their elapsed time'},
   {name: '/perf', description: 'Plot performance by round'},
   {name: '/theme', description: 'List themes, or switch with /theme <name>'},
@@ -41,9 +44,6 @@ export const HELP_TEXT = [
   ...SLASH_COMMANDS.map(command => `  ${command.name.padEnd(18)} ${command.description}`),
   '',
   'Planned',
-  '  /pause             Pause at the next safe point',
-  '  /resume            Resume a paused run',
-  '  /steer <message>   Guide a future agent invocation',
   '  /round <number>    Inspect a completed round',
   '  /invocation <id>   Inspect an agent invocation',
 ].join('\n');
@@ -74,6 +74,14 @@ export function parseInput(text: string): ParsedInput {
       return {error: `Unknown theme: ${requested}. Available: ${THEME_NAMES.join(', ')}.`};
     }
     return {localView: 'theme', themeName: requested};
+  }
+  if (text === '/pause') return {request: {type: 'command.pause'}};
+  if (text === '/resume') return {request: {type: 'command.resume'}};
+  const steer = text.match(/^\/steer(?:\s+([\s\S]*))?$/);
+  if (steer) {
+    const message = steer[1]?.trim();
+    if (!message) return {error: 'Usage: /steer <message>'};
+    return {request: {type: 'command.steer', text: message}};
   }
   if (text === '/history') return {request: {type: 'query.history'}, responseView: 'history'};
   if (text === '/perf') return {request: {type: 'query.performance'}, responseView: 'perf'};

--- a/clients/tui/src/generated/protocol.generated.ts
+++ b/clients/tui/src/generated/protocol.generated.ts
@@ -3,6 +3,7 @@
 export type Request =
   | PauseCommand
   | ResumeCommand
+  | SteerCommand
   | SnapshotQuery
   | ChatQuery
   | HistoryQuery
@@ -21,51 +22,56 @@ export type Type1 = "command.resume";
 export type ProtocolVersion2 = 1;
 export type RequestId2 = string;
 export type Timestamp2 = string;
-export type Type2 = "query.snapshot";
+export type Type2 = "command.steer";
+export type Text = string;
 export type ProtocolVersion3 = 1;
 export type RequestId3 = string;
 export type Timestamp3 = string;
-export type Type3 = "query.chat";
-export type Text = string;
+export type Type3 = "query.snapshot";
 export type ProtocolVersion4 = 1;
 export type RequestId4 = string;
 export type Timestamp4 = string;
-export type Type4 = "query.history";
+export type Type4 = "query.chat";
+export type Text1 = string;
 export type ProtocolVersion5 = 1;
 export type RequestId5 = string;
 export type Timestamp5 = string;
-export type Type5 = "query.performance";
+export type Type5 = "query.history";
 export type ProtocolVersion6 = 1;
 export type RequestId6 = string;
 export type Timestamp6 = string;
-export type Type6 = "query.events";
-export type AfterSequence = number;
-export type TimeoutMs = number;
+export type Type6 = "query.performance";
 export type ProtocolVersion7 = 1;
 export type RequestId7 = string;
 export type Timestamp7 = string;
-export type Type7 = "subscribe";
-export type AfterSequence1 = number;
+export type Type7 = "query.events";
+export type AfterSequence = number;
+export type TimeoutMs = number;
 export type ProtocolVersion8 = 1;
 export type RequestId8 = string;
 export type Timestamp8 = string;
+export type Type8 = "subscribe";
+export type AfterSequence1 = number;
+export type ProtocolVersion9 = 1;
+export type RequestId9 = string;
+export type Timestamp9 = string;
 export type Ok = boolean;
 export type Error = string | null;
-export type Action = "pause" | "resume";
+export type Action = "pause" | "resume" | "steer";
 export type Status = "pending" | "consumed";
 export type Question = string;
 export type Answer = string;
 export type Effect = "none";
-export type ProtocolVersion9 = 1;
+export type ProtocolVersion10 = 1;
 export type RunId = string;
 export type Sequence = number;
 export type Status1 = string;
 export type AgentKind = string | null;
 export type RoundLabel = string | null;
-export type ProtocolVersion10 = 1;
+export type ProtocolVersion11 = 1;
 export type Sequence1 = number;
 export type RunId1 = string;
-export type Timestamp9 = string;
+export type Timestamp10 = string;
 export type EventType =
   | "server_started"
   | "server_ready"
@@ -91,7 +97,7 @@ export type EventType =
   | "tool_result"
   | "todo_update"
   | "usage_update";
-export type Text1 = string;
+export type Text2 = string;
 export type EventStatus = "active" | "answered" | "pending" | "consumed" | "completed" | "failed";
 export type RoundLabel1 = string | null;
 export type AgentKind1 = string | null;
@@ -197,15 +203,15 @@ export type Passed = boolean;
 export type ProfileSkipped = boolean;
 export type Performance = PerformanceRound[];
 export type ServerMessage = SubscribedMessage | EventMessage | EventBatchMessage | ProtocolErrorMessage;
-export type Type8 = "subscribed";
-export type RequestId9 = string;
+export type Type9 = "subscribed";
+export type RequestId10 = string;
 export type RunId2 = string;
 export type LatestSequence = number;
-export type Type9 = "event";
-export type Type10 = "event_batch";
+export type Type10 = "event";
+export type Type11 = "event_batch";
 export type Events1 = RunEvent[];
-export type Type11 = "protocol_error";
-export type RequestId10 = string | null;
+export type Type12 = "protocol_error";
+export type RequestId11 = string | null;
 export type Code1 = string;
 export type Message1 = string;
 
@@ -230,50 +236,57 @@ export interface ResumeCommand {
   timestamp?: Timestamp1;
   type?: Type1;
 }
-export interface SnapshotQuery {
+export interface SteerCommand {
   protocol_version?: ProtocolVersion2;
   request_id?: RequestId2;
   timestamp?: Timestamp2;
   type?: Type2;
+  text: Text;
 }
-export interface ChatQuery {
+export interface SnapshotQuery {
   protocol_version?: ProtocolVersion3;
   request_id?: RequestId3;
   timestamp?: Timestamp3;
   type?: Type3;
-  text: Text;
 }
-export interface HistoryQuery {
+export interface ChatQuery {
   protocol_version?: ProtocolVersion4;
   request_id?: RequestId4;
   timestamp?: Timestamp4;
   type?: Type4;
+  text: Text1;
 }
-export interface PerformanceQuery {
+export interface HistoryQuery {
   protocol_version?: ProtocolVersion5;
   request_id?: RequestId5;
   timestamp?: Timestamp5;
   type?: Type5;
 }
-export interface EventsQuery {
+export interface PerformanceQuery {
   protocol_version?: ProtocolVersion6;
   request_id?: RequestId6;
   timestamp?: Timestamp6;
   type?: Type6;
-  after_sequence?: AfterSequence;
-  timeout_ms?: TimeoutMs;
 }
-export interface SubscribeRequest {
+export interface EventsQuery {
   protocol_version?: ProtocolVersion7;
   request_id?: RequestId7;
   timestamp?: Timestamp7;
   type?: Type7;
+  after_sequence?: AfterSequence;
+  timeout_ms?: TimeoutMs;
+}
+export interface SubscribeRequest {
+  protocol_version?: ProtocolVersion8;
+  request_id?: RequestId8;
+  timestamp?: Timestamp8;
+  type?: Type8;
   after_sequence?: AfterSequence1;
 }
 export interface Response {
-  protocol_version?: ProtocolVersion8;
-  request_id: RequestId8;
-  timestamp?: Timestamp8;
+  protocol_version?: ProtocolVersion9;
+  request_id: RequestId9;
+  timestamp?: Timestamp9;
   ok?: Ok;
   error?: Error;
   ack?: CommandAck | null;
@@ -292,7 +305,7 @@ export interface ChatResult {
   effect?: Effect;
 }
 export interface RunSnapshot {
-  protocol_version?: ProtocolVersion9;
+  protocol_version?: ProtocolVersion10;
   run_id: RunId;
   sequence: Sequence;
   status: Status1;
@@ -303,12 +316,12 @@ export interface RunSnapshot {
  * One reproducible human, control, or invocation event.
  */
 export interface RunEvent {
-  protocol_version?: ProtocolVersion10;
+  protocol_version?: ProtocolVersion11;
   sequence?: Sequence1;
   run_id?: RunId1;
-  timestamp: Timestamp9;
+  timestamp: Timestamp10;
   type: EventType;
-  text?: Text1;
+  text?: Text2;
   status?: EventStatus | null;
   round_label?: RoundLabel1;
   agent_kind?: AgentKind1;
@@ -471,22 +484,22 @@ export interface PerformanceRound {
   profile_skipped?: ProfileSkipped;
 }
 export interface SubscribedMessage {
-  type?: Type8;
-  request_id: RequestId9;
+  type?: Type9;
+  request_id: RequestId10;
   run_id: RunId2;
   latest_sequence: LatestSequence;
 }
 export interface EventMessage {
-  type?: Type9;
+  type?: Type10;
   event: RunEvent;
 }
 export interface EventBatchMessage {
-  type?: Type10;
+  type?: Type11;
   events: Events1;
 }
 export interface ProtocolErrorMessage {
-  type?: Type11;
-  request_id?: RequestId10;
+  type?: Type12;
+  request_id?: RequestId11;
   code: Code1;
   message: Message1;
 }

--- a/clients/tui/src/generated/protocol.schema.json
+++ b/clients/tui/src/generated/protocol.schema.json
@@ -209,7 +209,8 @@
         "action": {
           "enum": [
             "pause",
-            "resume"
+            "resume",
+            "steer"
           ],
           "title": "Action",
           "type": "string"
@@ -1220,6 +1221,42 @@
       "title": "SnapshotQuery",
       "type": "object"
     },
+    "SteerCommand": {
+      "additionalProperties": false,
+      "properties": {
+        "protocol_version": {
+          "const": 1,
+          "default": 1,
+          "title": "Protocol Version",
+          "type": "integer"
+        },
+        "request_id": {
+          "title": "Request Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "format": "date-time",
+          "title": "Timestamp",
+          "type": "string"
+        },
+        "type": {
+          "const": "command.steer",
+          "default": "command.steer",
+          "title": "Type",
+          "type": "string"
+        },
+        "text": {
+          "minLength": 1,
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "SteerCommand",
+      "type": "object"
+    },
     "SubprocessOutputData": {
       "properties": {
         "kind": {
@@ -1497,6 +1534,7 @@
         "mapping": {
           "command.pause": "#/$defs/PauseCommand",
           "command.resume": "#/$defs/ResumeCommand",
+          "command.steer": "#/$defs/SteerCommand",
           "query.chat": "#/$defs/ChatQuery",
           "query.events": "#/$defs/EventsQuery",
           "query.history": "#/$defs/HistoryQuery",
@@ -1512,6 +1550,9 @@
         },
         {
           "$ref": "#/$defs/ResumeCommand"
+        },
+        {
+          "$ref": "#/$defs/SteerCommand"
         },
         {
           "$ref": "#/$defs/SnapshotQuery"

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -1069,7 +1069,9 @@ class _RunContext:
         """
         supervisor = getattr(self, "supervisor", None)
         if supervisor is not None:
-            supervisor.before_agent(kind, round_label, user_prompt, system_prompt)
+            # before_agent blocks while paused and returns the prompt with any
+            # queued operator steering appended, so the next invocation sees it.
+            user_prompt = supervisor.before_agent(kind, round_label, user_prompt, system_prompt)
         result: T | None = None
         error: BaseException | None = None
         try:

--- a/src/vibesys/server/protocol.py
+++ b/src/vibesys/server/protocol.py
@@ -32,6 +32,11 @@ class ResumeCommand(Request):  # noqa: D101  # tracked: #288
     type: Literal["command.resume"] = "command.resume"
 
 
+class SteerCommand(Request):  # noqa: D101  # tracked: #288
+    type: Literal["command.steer"] = "command.steer"
+    text: str = Field(min_length=1)
+
+
 class SnapshotQuery(Request):  # noqa: D101  # tracked: #288
     type: Literal["query.snapshot"] = "query.snapshot"
 
@@ -63,6 +68,7 @@ class SubscribeRequest(Request):  # noqa: D101  # tracked: #288
 ProtocolRequest = Annotated[
     PauseCommand
     | ResumeCommand
+    | SteerCommand
     | SnapshotQuery
     | ChatQuery
     | HistoryQuery
@@ -83,7 +89,7 @@ class RunSnapshot(ProtocolModel):  # noqa: D101  # tracked: #288
 
 
 class CommandAck(ProtocolModel):  # noqa: D101  # tracked: #288
-    action: Literal["pause", "resume"]
+    action: Literal["pause", "resume", "steer"]
     status: Literal["pending", "consumed"]
 
 

--- a/src/vibesys/server/service.py
+++ b/src/vibesys/server/service.py
@@ -20,6 +20,7 @@ from vibesys.server.protocol import (
     ResumeCommand,
     RunSnapshot,
     SnapshotQuery,
+    SteerCommand,
 )
 from vibesys.server.supervisor import RunSupervisor  # noqa: TC001  # tracked: #288
 
@@ -43,6 +44,12 @@ class SupervisionService:
             return Response(
                 request_id=request.request_id,
                 ack=CommandAck(action="resume", status="consumed"),
+            )
+        if isinstance(request, SteerCommand):
+            self.supervisor.steer(request.text)
+            return Response(
+                request_id=request.request_id,
+                ack=CommandAck(action="steer", status="pending"),
             )
         if isinstance(request, ChatQuery):
             sequence = self.supervisor.snapshot().sequence

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -37,6 +37,7 @@ class RunSupervisor:
         self._condition = threading.Condition()
         self._pause_after_call = False
         self._paused = False
+        self._pending_steer: list[str] = []
         self._active_invocation: str | None = None
         self._run_status = "starting"
         self._store: EventStore | None = None
@@ -225,15 +226,30 @@ class RunSupervisor:
             self._condition.notify_all()
         self.record(EventType.CONTROL, "/resume", status=EventStatus.CONSUMED)
 
+    def steer(self, text: str) -> None:
+        """Queue an operator instruction for the next agent invocation.
+
+        The message is drained and appended to the next agent's user prompt in
+        :meth:`before_agent`. It applies whether the run is live or paused (in
+        which case it takes effect when the run resumes).
+        """
+        with self._condition:
+            self._pending_steer.append(text)
+        self.record(EventType.CONTROL, f"/steer: {text}", status=EventStatus.PENDING)
+
     def before_agent(  # noqa: D102  # tracked: #288
         self, kind: str, round_label: str, user_prompt: str, system_prompt: str = ""
-    ) -> None:
+    ) -> str:
         with self._condition:
             while self._paused:
                 self._condition.wait()
+            steer_messages = self._pending_steer
+            self._pending_steer = []
             self._current_kind, self._current_round = kind, round_label
             invocation_id = uuid.uuid4().hex
             self._active_invocation = invocation_id
+
+        effective_prompt = _with_steering(user_prompt, steer_messages)
 
         phase = PhaseData(phase=kind, attempt=_attempt_from_label(round_label))
         self.record(
@@ -250,8 +266,18 @@ class RunSupervisor:
             agent_kind=kind,
             round_label=round_label,
             invocation_id=invocation_id,
-            data=InvocationStartedData(system_prompt=system_prompt, user_prompt=user_prompt),
+            data=InvocationStartedData(system_prompt=system_prompt, user_prompt=effective_prompt),
         )
+        if steer_messages:
+            self.record(
+                EventType.CONTROL,
+                "/steer",
+                status=EventStatus.CONSUMED,
+                agent_kind=kind,
+                round_label=round_label,
+                invocation_id=invocation_id,
+            )
+        return effective_prompt
 
     def after_agent(  # noqa: D102  # tracked: #288
         self,
@@ -320,3 +346,17 @@ class RunSupervisor:
 def _attempt_from_label(round_label: str) -> int | None:
     match = re.search(r"retry-(\d+)", round_label)
     return int(match.group(1)) if match else None
+
+
+def _with_steering(user_prompt: str, messages: list[str]) -> str:
+    """Append queued operator steering instructions to an agent's user prompt."""
+    if not messages:
+        return user_prompt
+    block = "\n".join(f"- {message}" for message in messages)
+    return (
+        f"{user_prompt.rstrip()}\n\n"
+        "## Operator steering (live)\n\n"
+        "The operator sent the following instruction(s) for this invocation. "
+        "Treat them as high-priority guidance for the work you do now:\n\n"
+        f"{block}\n"
+    )

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -25,8 +25,11 @@ from vibesys.server.protocol import (
     ChatQuery,
     EventsQuery,
     HistoryQuery,
+    PauseCommand,
     PerformanceQuery,
+    ResumeCommand,
     SnapshotQuery,
+    SteerCommand,
     SubscribeRequest,
 )
 from vibesys.server.runtime import run_server
@@ -66,7 +69,66 @@ def test_pause_takes_effect_at_next_safe_point(tmp_path):  # noqa: ANN001, ANN20
     assert waiter.is_alive()
     supervisor.resume()
     waiter.join(timeout=1)
-    assert result == [None]
+    # before_agent returns the effective prompt (unchanged without steering).
+    assert result == ["prompt"]
+
+
+def test_steer_injects_into_next_invocation(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.steer("focus on the KV cache")
+
+    effective = supervisor.before_agent("implementer", "round 1", "Do the work")
+
+    assert "Do the work" in effective
+    assert "focus on the KV cache" in effective
+    assert "Operator steering" in effective
+    started = next(e for e in supervisor.read_events() if e.type == "invocation_started")
+    assert started.data.user_prompt == effective  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    # Steering is one-shot: a later invocation without a new /steer is unchanged.
+    supervisor.after_agent("implementer", "round 1")
+    next_effective = supervisor.before_agent("judge", "round 1", "Review it")
+    assert next_effective == "Review it"
+
+
+def test_steer_while_paused_applies_on_resume(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.pause_after_call()
+    supervisor.after_agent("implementer", "round 1")
+
+    result: list[str] = []
+    waiter = threading.Thread(
+        target=lambda: result.append(supervisor.before_agent("judge", "round 1", "Review"))
+    )
+    waiter.start()
+    time.sleep(0.02)
+    assert waiter.is_alive()
+
+    supervisor.steer("check for reward hacking")
+    supervisor.resume()
+    waiter.join(timeout=1)
+
+    assert len(result) == 1
+    assert "Review" in result[0]
+    assert "check for reward hacking" in result[0]
+
+
+def test_service_control_commands_ack(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    service = SupervisionService(supervisor)
+
+    pause = service.execute(PauseCommand())
+    resume = service.execute(ResumeCommand())
+    steer = service.execute(SteerCommand(text="prioritize latency"))
+
+    assert (pause.ack.action, pause.ack.status) == ("pause", "pending")  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    assert (resume.ack.action, resume.ack.status) == ("resume", "consumed")  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    assert (steer.ack.action, steer.ack.status) == ("steer", "pending")  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    # The queued steer reaches the next agent invocation.
+    effective = supervisor.before_agent("implementer", "round 1", "Work")
+    assert "prioritize latency" in effective
 
 
 def test_invocation_audit_contains_prompts_and_result(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288


### PR DESCRIPTION
## Problem

The TUI's `/help` listed `/pause`, `/resume`, and `/steer <message>` under
"Planned", and none were usable. In practice the operator could only ask
read-only questions (`/chat`); there was no way to pause a run or to interject an
instruction that actually reaches the optimization agents. The backend supervisor
already implemented pause/resume (`pause_after_call`/`resume`, with
`before_agent` blocking while paused), but the TUI never sent the commands, and
there was no steer path at all.

This wires up all three control commands.

## Solution

**`/pause` and `/resume`** are TUI-only wiring: they send the existing
`command.pause` / `command.resume` protocol requests, which `SupervisionService`
already handles. The generic ack renderer displays `pause: pending` /
`resume: consumed`.

**`/steer <message>`** is new end to end:
- `SteerCommand { text }` added to the protocol (and regenerated schema/TS types).
- `SupervisionService` handles it → `RunSupervisor.steer(text)`, which queues the
  message under the existing condition lock and records a `CONTROL` event.
- `before_agent` drains queued steer messages and appends an "Operator steering
  (live)" section to the agent's user prompt, then returns the effective prompt;
  `_RunContext.invoke` passes that to the runner. Because draining happens right
  after the pause gate in `before_agent`, a steer sent while paused takes effect
  when the run resumes. Steering is **one-shot** per message (a later invocation
  without a new `/steer` is unchanged) — persistent guidance remains `--constraint`.

Design notes for reviewers:
- The single injection point is `_RunContext.invoke` → `before_agent`, which every
  optimization agent (implementer/judge/orchestrator/profiler/single-agent) flows
  through, so steering reaches whichever agent runs next.
- `before_agent`'s return type changed from `None` to `str` (the effective
  prompt). Its only non-test caller is `invoke`.
- The `INVOCATION_STARTED` audit records the steered prompt, and a `CONTROL`
  `/steer` (consumed) event is emitted when steering is applied.

### Architecture

```mermaid
sequenceDiagram
    participant TUI
    participant Service as SupervisionService
    participant Sup as RunSupervisor
    participant Loop as _RunContext.invoke
    TUI->>Service: command.steer {text}
    Service->>Sup: steer(text)  (queued)
    Service-->>TUI: ack steer: pending
    Loop->>Sup: before_agent(kind, round, prompt)
    Note over Sup: blocks while paused,<br/>then drains steer queue
    Sup-->>Loop: prompt + "Operator steering" section
    Loop->>Loop: agent_runner.invoke(effective_prompt)
```

## Verification

### Correctness properties

- `/pause` arms a pause that takes effect at the next `before_agent`; `/resume`
  releases it (unchanged backend behavior, now reachable from the TUI).
- A queued steer message is appended to the next invocation's user prompt and
  recorded in the invocation audit; it applies whether the run is live or paused.
- Steering is one-shot: subsequent invocations without a new `/steer` are unchanged.
- `/steer` with no message is rejected client-side (`Usage: /steer <message>`).
- Acks render as `<action>: <status>` for pause/resume/steer.
- Protocol stays backward-compatible: `SteerCommand` is additive;
  `CommandAck.action` gains `"steer"`.

### Testing

```
uv run pytest tests/test_tui.py                     # 24 passed (adds steer + service-ack tests)
uv run pytest tests/test_tui.py tests/loops/agent tests/render   # 321 passed (before_agent return-type change)
./scripts/check_format.sh                           # All checks passed
./scripts/check_lint.sh                             # All checks passed
uv run pyright                                       # 0 errors

# TUI (run under Node; Bun not required for these)
clients/tui: tsc -p tsconfig.check.json             # 0 errors
clients/tui: vitest run src/commands.test.ts        # 11 passed (adds control-command parsing tests)
```

**Contract notes:** protocol gains `command.steer` and a `"steer"` `CommandAck`
action; `clients/tui/src/generated/protocol.{schema.json,generated.ts}` were
regenerated from the Python models. TUI `/help` and `clients/tui/README.md`
updated (the three commands moved from "Planned" to available; `/round` and
`/invocation` remain planned). No engine CLI flags changed.
