### PR TITLE
Add --extra-skills and make skill sources file-aware

### DIFF
--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -17,7 +17,7 @@ Several flags look independent, but they combine into one execution contract:
 | Profiler | `--profiler` | Bottleneck evidence source: `nsys`, `torch`, `neuron`, `otel`, `macos_cpu`, `linux_cpu`, or `auto`. |
 | Domain | `[agent].domain` in `vibesys.input.toml` | Problem-space package used by the agent and evolve loops, such as `llm-serving`, `microservices`, or `generic`. |
 | Modality | `--modality` | Per-task I/O contract, such as `text_generation` or `speech_to_text`. |
-| Skills | `--skills-dir`, `--no-skills` | Candidate skill roots and the ablation switch that disables skill loading. |
+| Skills | `--skills-dir`, `--extra-skills`, `--no-skills` | Override the preset skill roots, stack extra skills on top of the presets, or disable skill loading. |
 | Target inputs | `--input` | Target bundle directory with manifest-declared correctness and benchmark commands. |
 | Experiment repository | `--repo`, `--repo-visibility`, `--local`, `--resume` | Fresh runs use GitHub by default; `--local` keeps one under `exp_env/`, and `--resume` accepts local paths or GitHub repositories. |
 | Client theme | `--theme` | Presentation only. Which semantic theme the interactive client renders with. |
@@ -289,9 +289,26 @@ suffix.
 
 ## Skills
 
-`--skills-dir` supplies skill candidate roots. Each value may point at one skill
-directory containing `SKILL.md`, or at a parent tree containing multiple skills.
-The default candidate root is `resources/skills/`.
+Skill sources come from two flags, both repeatable, and each value may point at
+one skill directory containing `SKILL.md`, a parent tree containing multiple
+skills, or a single `SKILL.md` file:
+
+- **`--skills-dir PATH`** *replaces* the built-in preset roots. When omitted, the
+  preset `resources/skills/` is the base.
+- **`--extra-skills PATH`** *stacks on top of* the presets (or on top of
+  `--skills-dir` when that is given). Use this to add your own skills while
+  keeping the presets such as the `llm-serving` serving-systems skills. A
+  same-named skill from `--extra-skills` overrides a preset one.
+
+```bash
+# presets + your own skill directory and a single SKILL.md file
+./vs --input <bundle> \
+  --extra-skills ./my-skills \
+  --extra-skills ./one-off-skill/SKILL.md
+
+# use ONLY your skills, ignoring the presets
+./vs --input <bundle> --skills-dir ./my-skills
+```
 
 Before a run starts, VibeSys discovers each `SKILL.md` under the candidate
 roots and validates its frontmatter. Optional `.vibesys.toml` sidecars can
@@ -311,9 +328,10 @@ Effective skill loading is the intersection of the declared constraints:
   backend is in that list;
 - skills matched by a sidecar rule with `domains` load only when the input
   bundle's `[agent].domain` is in that list;
-- `--skills-dir` adds candidate roots, but routing metadata still filters the
-  discovered skills;
-- `--no-skills` disables all skill loading, including scoped skills.
+- `--skills-dir` and `--extra-skills` add candidate roots, but routing metadata
+  still filters the discovered skills;
+- `--no-skills` disables all skill loading, including scoped skills, and
+  overrides both `--skills-dir` and `--extra-skills`.
 
 See [Skill Metadata](skill-metadata.md) for the VibeSys-specific metadata
 contract and validation rules.

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -228,15 +228,31 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--skills-dir",
-        default=list(DEFAULT_SKILL_ROOTS),
+        default=None,
         action="append",
         type=Path,
+        metavar="PATH",
         help=(
-            "Path to a skill source candidate root (can be repeated). Each "
-            "entry can be either a single skill directory (containing a "
-            "top-level `SKILL.md`) or a parent directory of multiple skill "
-            "directories. Skills with VibeSys routing metadata are loaded only "
-            "for matching domains and backends. Default: `resources/skills/`."
+            "Skill source that REPLACES the built-in preset roots (can be "
+            "repeated). Each entry is a skill directory (containing a top-level "
+            "`SKILL.md`), a parent directory of many skills, or a single "
+            "`SKILL.md` file. When omitted, the preset `resources/skills/` is "
+            "used. To keep the presets and add your own, use --extra-skills."
+        ),
+    )
+    parser.add_argument(
+        "--extra-skills",
+        default=None,
+        action="append",
+        type=Path,
+        metavar="PATH",
+        help=(
+            "Additional skill source stacked ON TOP of the preset roots (or on "
+            "top of --skills-dir when that is given). Repeat for multiple. Each "
+            "entry is a skill directory, a parent directory of many skills, or a "
+            "single `SKILL.md` file. Skills with VibeSys routing metadata still "
+            "load only for matching domains and backends; a same-named skill "
+            "from here overrides a preset one."
         ),
     )
     parser.add_argument(
@@ -246,7 +262,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
             "Disable skills entirely: no skill directories are copied into "
             "the workspace and no per-CLI skill-discovery paths are populated. "
             "Used for ablations measuring the skill library's contribution. "
-            "Overrides --skills-dir."
+            "Overrides --skills-dir and --extra-skills."
         ),
     )
     parser.add_argument(
@@ -417,12 +433,11 @@ def load_config_and_skills(
     if getattr(args, "no_skills", False):
         skills = None
     else:
-        raw_skills = (
-            args.skills_dir
-            if isinstance(args.skills_dir, list)
-            else ([args.skills_dir] if args.skills_dir else None)
-        )
-        skills = resolve_skill_source_dirs(raw_skills, backend=backend, domain=domain)
+        # --skills-dir overrides the presets; when omitted, the presets are the
+        # base. --extra-skills always stacks on top (presets or the override).
+        base = getattr(args, "skills_dir", None) or list(DEFAULT_SKILL_ROOTS)
+        extra = getattr(args, "extra_skills", None) or []
+        skills = resolve_skill_source_dirs([*base, *extra], backend=backend, domain=domain)
     return config, skills, backend
 
 

--- a/src/vibesys/skills.py
+++ b/src/vibesys/skills.py
@@ -300,15 +300,28 @@ def discover_sidecar_rules(root: Path) -> list[SkillRule]:
 
 
 def coerce_skill_root(raw: str | Path, *, project_root: Path = PROJECT_ROOT) -> Path:
-    """Resolve one configured skill root path."""
+    """Resolve one configured skill source to a directory.
+
+    A source may be a skill directory (containing ``SKILL.md``), a parent tree
+    of many skills, or a single ``SKILL.md`` file (resolved to its containing
+    skill directory).
+    """
     path = Path(raw).expanduser()
     if not path.is_absolute():
         path = project_root / path
     path = path.resolve()
     if not path.exists():
-        raise ValueError(f"--skills-dir path does not exist: {raw}")  # noqa: TRY003  # tracked: #288
+        raise ValueError(f"skill source path does not exist: {raw}")  # noqa: TRY003  # tracked: #288
+    if path.is_file():
+        if path.name != "SKILL.md":
+            raise ValueError(  # noqa: TRY003  # tracked: #288
+                f"skill source file must be a SKILL.md file: {raw}"
+            )
+        return path.parent
     if not path.is_dir():
-        raise ValueError(f"--skills-dir path is not a directory: {raw}")  # noqa: TRY003  # tracked: #288
+        raise ValueError(  # noqa: TRY003  # tracked: #288
+            f"skill source path is not a directory or SKILL.md file: {raw}"
+        )
     return path
 
 

--- a/tests/test_skills_wiring.py
+++ b/tests/test_skills_wiring.py
@@ -17,6 +17,7 @@ from vibesys.skills import (
     SkillMetadataError,
     _is_in_hidden_dir,
     build_skill_catalog,
+    coerce_skill_root,
     discover_sidecar_rules,
     discover_skill_dirs,
     load_sidecar_rules,
@@ -37,12 +38,28 @@ NKI_SKILL_NAMES = {
 }
 
 
-def _args(tmp_path, backend, *, no_skills=False, skills_dir=None):  # noqa: ANN001, ANN202  # tracked: #288
+def _args(  # noqa: ANN202, PLR0913  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
+    backend,  # noqa: ANN001  # tracked: #288
+    *,
+    no_skills=False,  # noqa: ANN001  # tracked: #288
+    skills_dir=None,  # noqa: ANN001  # tracked: #288
+    extra_skills=None,  # noqa: ANN001  # tracked: #288
+    default_presets=True,  # noqa: ANN001  # tracked: #288
+):
     cfg = tmp_path / "agent.toml"
     cfg.write_text('[model]\nname = "gpt-5.5"\n')
-    if skills_dir is None:
+    # By default emulate "presets only" by pointing --skills-dir at the repo
+    # presets; pass default_presets=False to exercise the omitted-flag path.
+    if skills_dir is None and default_presets:
         skills_dir = [Path("resources/skills")]
-    return SimpleNamespace(config=cfg, no_skills=no_skills, skills_dir=skills_dir, backend=backend)
+    return SimpleNamespace(
+        config=cfg,
+        no_skills=no_skills,
+        skills_dir=skills_dir,
+        extra_skills=extra_skills,
+        backend=backend,
+    )
 
 
 def _skill_names(skills: list[str] | None) -> set[str]:
@@ -101,6 +118,62 @@ def test_no_skills_disables_even_compatible_skills(tmp_path):  # noqa: ANN001, A
         domain=DomainName.LLM_SERVING,
     )
     assert skills is None
+
+
+def test_omitted_skills_dir_uses_presets(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    # With no --skills-dir the preset roots (resources/skills) are the base.
+    _, skills, _ = load_config_and_skills(
+        _args(tmp_path, ComputeBackend.CUDA, default_presets=False),  # pyright: ignore[reportArgumentType]  # tracked: #297
+        domain=DomainName.LLM_SERVING,
+    )
+    assert "serving-systems" in _skill_names(skills)
+
+
+def test_extra_skills_stack_on_presets(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    custom_root = tmp_path / "mine"
+    _write_skill(custom_root, "custom-skill")
+
+    _, skills, _ = load_config_and_skills(
+        _args(tmp_path, ComputeBackend.CUDA, extra_skills=[custom_root]),  # pyright: ignore[reportArgumentType]  # tracked: #297
+        domain=DomainName.LLM_SERVING,
+    )
+    names = _skill_names(skills)
+    assert "custom-skill" in names  # user skill loaded
+    assert "serving-systems" in names  # preset still present
+
+
+def test_skills_dir_replaces_presets(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    custom_root = tmp_path / "mine"
+    _write_skill(custom_root, "custom-skill")
+
+    _, skills, _ = load_config_and_skills(
+        _args(tmp_path, ComputeBackend.CUDA, skills_dir=[custom_root]),  # pyright: ignore[reportArgumentType]  # tracked: #297
+        domain=DomainName.LLM_SERVING,
+    )
+    names = _skill_names(skills)
+    assert names == {"custom-skill"}  # only the override, presets replaced
+
+
+def test_coerce_skill_root_accepts_skill_md_file(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    skill_dir = _write_skill(tmp_path, "portable")
+
+    assert coerce_skill_root(skill_dir / "SKILL.md") == skill_dir.resolve()
+
+    (tmp_path / "notes.md").write_text("x\n")
+    with pytest.raises(ValueError, match="must be a SKILL"):
+        coerce_skill_root(tmp_path / "notes.md")
+
+
+def test_resolve_accepts_single_skill_md_file(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    root = tmp_path / "mine"
+    skill_dir = _write_skill(root, "one")
+    _write_skill(root, "two")  # sibling that must NOT be pulled in
+
+    resolved = resolve_skill_source_dirs(
+        [skill_dir / "SKILL.md"], backend=ComputeBackend.CUDA, domain=DomainName.GENERIC
+    )
+
+    assert _skill_names(resolved) == {"one"}
 
 
 def test_sidecar_rule_filters_descendant_skill_subtree_by_backend(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288


### PR DESCRIPTION
## Problem

Users could not cleanly bring their own skills on top of the built-in presets.
`--skills-dir` existed, but its behavior was subtle and limited:

- Because it used argparse `action="append"` with a non-empty default, passing
  `--skills-dir X` *implicitly appended* to the preset root, giving
  `[resources/skills, X]` — but the help said "Default: resources/skills",
  implying it replaced. The intent (extend vs. override) was ambiguous.
- It only accepted **directories**; there was no way to point at a single
  `SKILL.md` file.
- There was no explicit, documented way to say "presets plus mine" vs. "only
  mine" short of the all-or-nothing `--no-skills`.

## Solution

Make skill sources first-class and composable:

- **`--extra-skills PATH`** (new, repeatable): stacks additional skill sources
  **on top of** the preset roots (or on top of `--skills-dir` when given). This
  is the "my skills + presets" path.
- **`--skills-dir PATH`** (repeatable): now explicitly **replaces** the preset
  roots (override). When omitted, `resources/skills/` is the base — same default
  outcome as before, without the implicit-append surprise.
- A skill source may now be a **skill directory**, a **parent tree** of skills,
  or a **single `SKILL.md` file** (resolved to its containing skill directory).
- `--no-skills` still disables everything and overrides both flags.

Routing metadata is unchanged: `.vibesys.toml` domain/backend sidecars still
filter which discovered skills load, and a same-named skill from `--extra-skills`
overrides a preset one (last-writer-wins, matching materialization).

### Architecture

The change is localized to the CLI-to-resolver boundary; the skill discovery /
metadata / materialization pipeline is untouched. `load_config_and_skills`
composes `base = --skills-dir or presets` then `base + --extra-skills` and hands
the combined list to the existing `resolve_skill_source_dirs`, which already
dedups by directory and applies routing metadata. File support is a small
addition to `coerce_skill_root` (a `SKILL.md` file resolves to its parent dir),
so the resolver's output stays "directories" and every downstream consumer is
unaffected.

## Verification

### Correctness properties

- Omitting `--skills-dir` loads the presets (`serving-systems` present for
  llm-serving/CUDA).
- `--extra-skills DIR` yields presets **and** the user skill.
- `--skills-dir DIR` yields **only** the override (presets replaced).
- A `SKILL.md` file resolves to exactly its own skill (a sibling skill in the
  same parent is not pulled in); a non-`SKILL.md` file is rejected.
- `--no-skills` still returns no skills.
- Domain/backend routing still filters discovered skills.

### Testing

```
uv run pytest tests/test_skills_wiring.py                        # 47 passed (adds 6 cases)
uv run pytest tests/test_skills_wiring.py tests/test_main.py tests/test_context.py  # 184 passed
./scripts/check_format.sh   # All checks passed
./scripts/check_lint.sh     # All checks passed
uv run pyright              # 0 errors
```

**CLI contract:** adds `--extra-skills`; changes `--skills-dir` from implicit
append-to-presets to explicit replace-presets (the omitted-flag default is
unchanged). No engine/protocol/manifest changes. `docs/cli-flags.md` updated.
