### PR TITLE
Ship resources/ in the wheel so installed runs get profilers and skills

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,9 @@ include clients/tui/tsconfig.check.json
 include clients/tui/README.md
 prune clients/tui/dist
 prune clients/tui/node_modules
+# Include the resource trees so a source build can stage them into
+# vibesys/_resources. Vendored skill repo checkouts stay out of the sdist.
+graft resources/profilers
+graft resources/skills
+prune resources/skills/serving-systems/repos
+global-exclude __pycache__ *.pyc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ include = ["vibesys*"]
 [tool.setuptools.package-data]
 # ``_tui`` is produced at build time by setup.py's build_py step and injected
 # into the wheel's build tree; the glob keeps it as package data when present.
-vibesys = ["prompts/*.j2", "prompts/**/*.j2", "prompts/**/*.md", "domains/README.md", "_tui/**/*"]
+vibesys = ["prompts/*.j2", "prompts/**/*.j2", "prompts/**/*.md", "domains/README.md", "_tui/**/*", "_resources/**/*"]
 
 [dependency-groups]
 dev = [

--- a/resources_packaging.py
+++ b/resources_packaging.py
@@ -1,0 +1,55 @@
+"""Stage bundled framework resources for inclusion in the Python wheel.
+
+Profiler support packages (``resources/profilers``) and the preset skills
+library (``resources/skills``) are resolved from the repository checkout at
+run time. An installed wheel has no checkout, so the wheel build copies both
+trees into the ``vibesys._resources`` package directory; ``setup.py`` calls
+:func:`stage_resources` from the same custom ``build_py`` step that stages the
+TUI. ``vibesys.resource_paths`` resolves the checkout first and falls back to
+the staged copy.
+
+Vendored skill repository checkouts (``repos/`` inside a skill) are excluded:
+they are git submodules, are already excluded from workspace materialization,
+and would bloat the wheel by hundreds of megabytes.
+
+Like ``tui_packaging``, this module is imported inside an isolated build
+environment, so it depends only on the standard library.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path  # noqa: TC003  # tracked: #288
+
+#: Subtrees of ``resources/`` staged into the wheel.
+STAGED_TREES: tuple[str, ...] = ("profilers", "skills")
+
+#: Directory names never copied, at any depth.
+EXCLUDED_NAMES: frozenset[str] = frozenset({".git", "__pycache__", "repos"})
+
+
+def _ignore(_directory: str, names: list[str]) -> set[str]:
+    return {name for name in names if name in EXCLUDED_NAMES or name.endswith(".pyc")}
+
+
+def stage_resources(repo_root: Path, dest: Path) -> bool:
+    """Copy the staged resource trees into ``dest``; return whether staged.
+
+    Returns ``False`` without side effects when the checkout has no
+    ``resources/`` directory (e.g. a build from an incomplete source tree);
+    the wheel then installs without bundled resources and run time falls back
+    to requiring a checkout, exactly as before staging existed.
+    """
+    source_root = repo_root / "resources"
+    if not source_root.is_dir():
+        return False
+    if dest.exists():
+        shutil.rmtree(dest)
+    staged_any = False
+    for tree in STAGED_TREES:
+        source = source_root / tree
+        if not source.is_dir():
+            continue
+        shutil.copytree(source, dest / tree, ignore=_ignore)
+        staged_any = True
+    return staged_any

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,9 @@
 
 Project metadata lives in ``pyproject.toml``; this file exists only to hook a
 custom ``build_py`` step that compiles ``clients/tui`` and stages the result
-into ``vibesys/_tui`` so a single ``pip install`` ships a usable TUI. The step
+into ``vibesys/_tui`` so a single ``pip install`` ships a usable TUI, and
+stages ``resources/`` into ``vibesys/_resources`` so profiler support
+packages and preset skills work without a checkout. The step
 is best-effort — see ``tui_packaging.build_and_stage_tui`` — so installs without
 a JavaScript toolchain still succeed and run headless.
 """
@@ -18,6 +20,7 @@ from setuptools.command.build_py import build_py as _build_py
 _REPO_ROOT = Path(__file__).parent.resolve()
 sys.path.insert(0, str(_REPO_ROOT))
 
+from resources_packaging import stage_resources  # noqa: E402
 from tui_packaging import build_and_stage_tui  # noqa: E402
 
 
@@ -28,6 +31,7 @@ class build_py(_build_py):  # noqa: N801 - setuptools command classes are lowerc
         super().run()
         dest = Path(self.build_lib) / "vibesys" / "_tui"
         build_and_stage_tui(_REPO_ROOT, dest)
+        stage_resources(_REPO_ROOT, Path(self.build_lib) / "vibesys" / "_resources")
 
 
 setup(cmdclass={"build_py": build_py})

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -45,6 +45,7 @@ from vibesys.profilers import (
     resolve_profiler_kind,
 )
 from vibesys.render import HeadlessRenderer, output_sink
+from vibesys.resource_paths import profiler_support_dir
 from vibesys.run import (
     DeviceLease,
     ExperimentRepository,
@@ -477,8 +478,8 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
     if resolved_profiler_kind in ACTIVE_PROFILER_KINDS:
         definition = profiler_definition(resolved_profiler_kind)
         profiler_support_name = definition.support_name
-        default_support = PROJECT_ROOT / "resources" / "profilers" / definition.kind.value
-        if default_support.is_dir():
+        default_support = profiler_support_dir(definition.kind.value)
+        if default_support is not None:
             profiler_support_path = str(default_support)
 
     skill_source_paths = _coerce_skills_dirs(skills_dirs)

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -46,12 +46,13 @@ from vibesys.repository import (
     generate_experiment_name,
     repository_name_from_experiment,
 )
+from vibesys.resource_paths import default_skill_roots
 from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     build_run_environment,
     make_run_environment_spec,
 )
-from vibesys.skills import DEFAULT_SKILL_ROOTS, resolve_skill_source_dirs
+from vibesys.skills import resolve_skill_source_dirs
 from vibesys.tui import KNOWN_TUI_THEMES, TuiTheme
 from vs_github import GitHubCLI, GitHubCLIError
 
@@ -577,7 +578,7 @@ def load_config_and_skills(
     else:
         # --skills-dir overrides the presets; when omitted, the presets are the
         # base. --extra-skills always stacks on top (presets or the override).
-        base = getattr(args, "skills_dir", None) or list(DEFAULT_SKILL_ROOTS)
+        base = getattr(args, "skills_dir", None) or list(default_skill_roots())
         extra = getattr(args, "extra_skills", None) or []
         skills = resolve_skill_source_dirs([*base, *extra], backend=backend, domain=domain)
     return config, skills, backend

--- a/src/vibesys/resource_paths.py
+++ b/src/vibesys/resource_paths.py
@@ -1,0 +1,51 @@
+"""Locate framework resources in a repository checkout or an installed wheel.
+
+Profiler support packages and the preset skills library live under
+``resources/`` in a checkout. The wheel build stages the same trees into the
+``vibesys._resources`` package directory (see ``resources_packaging.py``), so
+an installed ``vibesys`` finds them without a checkout. The checkout always
+wins when both exist: a developer editing ``resources/`` must see their edits,
+not a stale staged copy.
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+from pathlib import Path
+
+from vibesys.constants import PROJECT_ROOT
+
+
+def packaged_resources_dir() -> Path | None:
+    """Return the wheel-staged ``vibesys/_resources`` directory, or ``None``."""
+    try:
+        base = Path(str(files("vibesys"))) / "_resources"
+    except (ModuleNotFoundError, TypeError):  # pragma: no cover - defensive
+        return None
+    return base if base.is_dir() else None
+
+
+def resources_root() -> Path | None:
+    """Return the active resources tree: checkout first, wheel staging second."""
+    checkout = PROJECT_ROOT / "resources"
+    if checkout.is_dir():
+        return checkout
+    return packaged_resources_dir()
+
+
+def profiler_support_dir(kind_value: str) -> Path | None:
+    """Return the support package directory for a profiler kind, or ``None``."""
+    root = resources_root()
+    if root is None:
+        return None
+    candidate = root / "profilers" / kind_value
+    return candidate if candidate.is_dir() else None
+
+
+def default_skill_roots() -> tuple[Path, ...]:
+    """Return the preset skill roots, empty when no resources tree is found."""
+    root = resources_root()
+    if root is None:
+        return ()
+    skills = root / "skills"
+    return (skills,) if skills.is_dir() else ()

--- a/src/vibesys/skills.py
+++ b/src/vibesys/skills.py
@@ -14,7 +14,6 @@ from vibesys.constants import PROJECT_ROOT, ComputeBackend
 from vibesys.domains.base import DomainName
 from vibesys.schemas import SkillResourceSelection  # noqa: TC001  # tracked: #288
 
-DEFAULT_SKILL_ROOTS: tuple[Path, ...] = (Path("resources/skills"),)
 SIDECAR_NAME = ".vibesys.toml"
 _FRONTMATTER_DELIMITER = "---"
 _MATERIALIZATION_EXCLUDED_NAMES = frozenset({".git", "repos", "__pycache__"})

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -255,6 +255,7 @@ def test_run_context_defaults_profiler_support_paths(  # noqa: ANN201  # tracked
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.resource_paths.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
@@ -280,6 +281,7 @@ def test_cli_context_skips_unused_langchain_model_construction(tmp_path):  # noq
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.resource_paths.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model") as build_model,
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
@@ -320,6 +322,7 @@ def test_run_context_copies_only_selected_profiler_support(tmp_path, selected): 
         domain = DomainName.LLM_SERVING
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.resource_paths.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
@@ -359,6 +362,7 @@ def test_run_context_generic_auto_resolves_to_macos_profiler(tmp_path):  # noqa:
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.resource_paths.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
@@ -392,6 +396,7 @@ def test_run_context_generic_auto_resolves_to_linux_profiler(tmp_path):  # noqa:
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.resource_paths.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
@@ -433,6 +438,7 @@ def test_run_context_fails_fast_when_resolved_profiler_is_unusable(tmp_path):  #
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.resource_paths.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
@@ -491,6 +497,7 @@ def test_run_context_llm_auto_uses_backend_profiler_and_defaults_support_dir(tmp
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.resource_paths.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend(ProfilerKind.NSYS)),
@@ -521,6 +528,7 @@ def test_run_context_noop_environment_hooks_do_not_require_model_artifacts(tmp_p
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.resource_paths.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
@@ -619,6 +627,7 @@ def test_run_context_cleans_up_when_agent_runner_construction_fails(tmp_path):  
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.resource_paths.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", side_effect=RuntimeError("boom")),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
@@ -647,6 +656,7 @@ def test_run_context_tears_down_prepared_hooks_when_workspace_setup_fails(tmp_pa
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.resource_paths.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
         patch("vibesys.context.Workspace.setup", side_effect=RuntimeError("setup failed")),
@@ -713,6 +723,7 @@ def test_run_context_materializes_input_project_path_dependencies(tmp_path):  # 
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.resource_paths.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),
@@ -770,6 +781,7 @@ def test_run_context_materializes_sdk_deps_from_workspace_seed(tmp_path):  # noq
 
     with (
         patch("vibesys.context.PROJECT_ROOT", project_root),
+        patch("vibesys.resource_paths.PROJECT_ROOT", project_root),
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.context.build_agent_runner", return_value=MagicMock()),
         patch("vibesys.context.backends.get", return_value=_FakeBackend()),

--- a/tests/test_resources_packaging.py
+++ b/tests/test_resources_packaging.py
@@ -1,0 +1,99 @@
+"""Tests for wheel-time resource staging and run-time resource resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003  # tracked: #288
+
+# `resources_packaging` is a repo-root, build-time module (imported by
+# setup.py). It is not part of the installed package, so pyright's project
+# roots cannot resolve it; pytest picks it up via `pythonpath = ["."]`.
+from resources_packaging import (  # pyright: ignore[reportMissingImports]
+    stage_resources,
+)
+
+from vibesys import resource_paths
+from vibesys.constants import PROJECT_ROOT
+
+
+def _make_fake_repo(root: Path) -> Path:
+    (root / "resources" / "profilers" / "nsys").mkdir(parents=True)
+    (root / "resources" / "profilers" / "nsys" / "server.py").write_text("# server")
+    (root / "resources" / "profilers" / "nsys" / "__pycache__").mkdir()
+    (root / "resources" / "profilers" / "nsys" / "__pycache__" / "server.pyc").write_text("x")
+    skill = root / "resources" / "skills" / "serving-systems"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: serving-systems\ndescription: d\n---\n")
+    (skill / ".vibesys.toml").write_text('[[rule]]\npath = "."\n')
+    (skill / "repos" / "vllm").mkdir(parents=True)
+    (skill / "repos" / "vllm" / "big.bin").write_text("vendored checkout")
+    return root
+
+
+def test_stage_resources_copies_trees_and_drops_vendored_checkouts(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    repo = _make_fake_repo(tmp_path / "repo")
+    dest = tmp_path / "build" / "vibesys" / "_resources"
+
+    assert stage_resources(repo, dest)
+    assert (dest / "profilers" / "nsys" / "server.py").is_file()
+    assert (dest / "skills" / "serving-systems" / "SKILL.md").is_file()
+    assert (dest / "skills" / "serving-systems" / ".vibesys.toml").is_file()
+    assert not (dest / "skills" / "serving-systems" / "repos").exists()
+    assert not (dest / "profilers" / "nsys" / "__pycache__").exists()
+
+
+def test_stage_resources_is_idempotent(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    repo = _make_fake_repo(tmp_path / "repo")
+    dest = tmp_path / "dest"
+
+    assert stage_resources(repo, dest)
+    assert stage_resources(repo, dest)
+    assert (dest / "profilers" / "nsys" / "server.py").is_file()
+
+
+def test_stage_resources_without_resources_dir_is_a_noop(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    dest = tmp_path / "dest"
+
+    assert not stage_resources(tmp_path / "empty-repo", dest)
+    assert not dest.exists()
+
+
+def test_resources_root_prefers_the_checkout():  # noqa: ANN201  # tracked: #288
+    assert resource_paths.resources_root() == PROJECT_ROOT / "resources"
+
+
+def test_profiler_support_dir_resolves_known_kind_and_rejects_unknown():  # noqa: ANN201  # tracked: #288
+    nsys = resource_paths.profiler_support_dir("nsys")
+    assert nsys is not None
+    assert (nsys / "server.py").is_file()
+    assert resource_paths.profiler_support_dir("no-such-profiler") is None
+
+
+def test_default_skill_roots_point_at_the_resources_tree():  # noqa: ANN201  # tracked: #288
+    roots = resource_paths.default_skill_roots()
+    assert roots == (PROJECT_ROOT / "resources" / "skills",)
+
+
+def test_resources_root_falls_back_to_the_staged_wheel_copy(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    fake_checkout = tmp_path / "no-checkout"
+    fake_package = tmp_path / "site-packages" / "vibesys"
+    staged = fake_package / "_resources"
+    (staged / "profilers" / "nsys").mkdir(parents=True)
+    (staged / "profilers" / "nsys" / "server.py").write_text("# server")
+    (staged / "skills").mkdir()
+
+    monkeypatch.setattr(resource_paths, "PROJECT_ROOT", fake_checkout)
+    monkeypatch.setattr(resource_paths, "files", lambda _package: fake_package)
+
+    assert resource_paths.resources_root() == staged
+    support = resource_paths.profiler_support_dir("nsys")
+    assert support == staged / "profilers" / "nsys"
+    assert resource_paths.default_skill_roots() == (staged / "skills",)
+
+
+def test_resources_root_is_none_without_checkout_or_staged_copy(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    monkeypatch.setattr(resource_paths, "PROJECT_ROOT", tmp_path / "nowhere")
+    monkeypatch.setattr(resource_paths, "files", lambda _package: tmp_path / "no-package")
+
+    assert resource_paths.resources_root() is None
+    assert resource_paths.profiler_support_dir("nsys") is None
+    assert resource_paths.default_skill_roots() == ()


### PR DESCRIPTION
## Problem

`pip install vibesys` delivers a working engine and (when built with a JavaScript toolchain) the TUI, but silently loses every bundled profiler support package and the preset skills library: `context.py` resolved profiler support from `PROJECT_ROOT / "resources" / "profilers"` and the default skill root was the checkout-relative `resources/skills`. Neither exists in an installed layout, so no-clone runs get no profiler MCP servers and no preset skills, with no diagnostic. Skills have an escape hatch (`--skills-dir` accepts absolute paths); profilers have none.

## Solution

Mirror the existing `_tui` staging pattern for `resources/`:

- `resources_packaging.py` (repo root, stdlib-only, like `tui_packaging.py`): copies `resources/profilers` and `resources/skills` into `vibesys/_resources`, excluding `.git`, `__pycache__`, `*.pyc`, and the vendored skill `repos/` submodule checkouts (already excluded from workspace materialization; they would bloat the wheel by hundreds of MB). A missing `resources/` tree is a clean no-op, matching the best-effort TUI stage.
- `setup.py` stages resources from the same custom `build_py` step; `pyproject.toml` adds the `_resources/**/*` package-data glob; `MANIFEST.in` grafts the resource trees into the sdist (minus `repos/`).
- New `src/vibesys/resource_paths.py`: `resources_root()` prefers the checkout (`PROJECT_ROOT/resources`) and falls back to the staged `vibesys/_resources` (via `importlib.resources`, same lookup the TUI launcher uses), so a developer editing `resources/` always sees their edits. `profiler_support_dir(kind)` and `default_skill_roots()` are the two consumers' entry points.
- `context.py` resolves profiler support through `profiler_support_dir()`; `main.py` applies skill defaults through `default_skill_roots()`. The checkout-relative `DEFAULT_SKILL_ROOTS` constant in `skills.py` had exactly one consumer (that default-application site) and is removed.

### Architecture

Shared interface (`resource_paths`) owns location policy; the wiring sites (`context.py`, `main.py`) consume it; the build-time stager is a repo-root module imported only by `setup.py`. No behavior change in a checkout: `resources_root()` returns the same paths as before.

## Verification

### Correctness properties

- Checkout behavior is unchanged: with `PROJECT_ROOT/resources` present, all resolved paths are identical to before.
- Installed behavior: profiler support and preset skills resolve from `vibesys/_resources`; when neither location exists, resolution returns `None`/`()` exactly where the old code produced a missing path (no fabricated defaults).
- The wheel never ships vendored skill `repos/` checkouts or `__pycache__`.

### Testing

- `uv run pytest tests/ -q` — 2792 passed; the only exclusions are the two pre-existing `tests/_agent_cli/test_hostsandbox.py` failures that fail identically on a clean `main` on this host (bubblewrap environment).
- New `tests/test_resources_packaging.py`: staging copies both trees, drops `repos/`/`__pycache__`, is idempotent, no-ops without `resources/`; `resource_paths` prefers the checkout, falls back to a staged copy, and returns `None`/empty when neither exists.
- `tests/test_context.py`: the 12 fixtures that relocate `PROJECT_ROOT` now also patch `vibesys.resource_paths.PROJECT_ROOT`, keeping the existing support-dir assertions meaningful.
- End-to-end: `uv build --wheel` stages 292 resource files (verified via zip listing: `profilers/nsys/server.py` and `skills/serving-systems/SKILL.md` present, no `repos/`, no `__pycache__`); unzipping the wheel and importing from that layout resolves `resources_root()`, `profiler_support_dir("nsys")`, and `default_skill_roots()` from `vibesys/_resources`.
- `./scripts/format.sh`, `./scripts/check_format.sh`, `./scripts/check_lint.sh` — clean; `uv run pyright src/vibesys/resource_paths.py src/vibesys/context.py src/vibesys/main.py src/vibesys/skills.py` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)