### PR TITLE
Experiment chat wired to coding agent in the TUI

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -22,12 +22,28 @@ available slash commands are:
 | --- | --- |
 | `/help` | Show commands and planned controls. |
 | `/chat` | Open a read-only chat about the run; `/chat <question>` asks immediately. |
+| | Slash commands work inside the chat too, and do the same thing as in the main input. |
 | `/pause` | Pause after the current agent call finishes. |
 | `/resume` | Resume a paused run. |
 | `/steer <message>` | Queue an instruction that is appended to the next agent invocation's prompt. |
 | `/history` | List rounds with agent-active elapsed time. |
 | `/perf` | Plot the recorded performance metric by round. |
 | `/theme` | List themes; `/theme <name>` switches immediately. |
+
+### Experiment chat
+
+The chat is answered by a coding agent scoped to the run, using the backend,
+provider, and model from `[agent]` in `agent.toml`, with conversation state
+carried across turns through `_vibesys_chat/conversation.jsonl` in the
+workspace. The agent handler exists only while the run context does, so a
+question asked during startup or after the run finishes has no agent to reach;
+the reply says so and falls back to a read-only keyword summary of the recorded
+events rather than presenting that summary as the answer.
+
+Text typed in the chat that starts with `/` is parsed as a slash command
+through the same path as the main input, so `/history` there does exactly what
+`/history` does anywhere else. Anything else is a question for the agent, and a
+question containing a slash mid-sentence is still a question.
 
 The footer shows keyboard navigation. `[` and `]` select rounds, Tab and
 Shift+Tab select agents, Page Up/Page Down scroll the transcript, Ctrl+T expands

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -325,6 +325,67 @@ describe('session controller', () => {
     expect(transport.requests).toEqual([]);
   });
 
+  it('runs a slash command typed in the chat through the main input path', async () => {
+    const transport = new FakeTransport();
+    const controller = new SocketSessionController(transport);
+    await controller.submit('/chat');
+    const before = transport.requests.length;
+
+    await controller.submitChat('/history');
+
+    // Handled as a command, not forwarded to the chat agent.
+    expect(transport.requests.slice(before)).toEqual([{type: 'query.history'}]);
+    expect(controller.state.overlay?.content).toContain('No rounds have started yet.');
+    expect(controller.state.chatConversation).toHaveLength(0);
+  });
+
+  it('agrees with the main input about what a command does', async () => {
+    const performance = [
+      {
+        round: 1,
+        perf_metric: 1200,
+        perf_unit: 'total_ops_per_sec',
+        passed: true,
+        profile_skipped: false,
+      },
+    ];
+    const viaChat = new SocketSessionController(new FakeTransport([], performance));
+    const viaInput = new SocketSessionController(new FakeTransport([], performance));
+
+    await viaChat.submitChat('/perf');
+    await viaInput.submit('/perf');
+
+    expect(viaChat.state.overlay?.content).toBe(viaInput.state.overlay?.content);
+  });
+
+  it('reports an unknown slash command in the chat instead of asking the agent', async () => {
+    const transport = new FakeTransport();
+    const controller = new SocketSessionController(transport);
+
+    await controller.submitChat('/nope');
+
+    expect(controller.state.overlay?.kind).toBe('error');
+    expect(controller.state.overlay?.content).toContain('Unknown command');
+    expect(transport.requests).toEqual([]);
+  });
+
+  it('still sends ordinary questions, including text containing a slash', async () => {
+    const transport = new FakeTransport([], [], {
+      question: 'what changed in a/b testing?',
+      answer: 'Nothing yet.',
+      effect: 'none',
+    });
+    const controller = new SocketSessionController(transport);
+
+    await controller.submitChat('what changed in a/b testing?');
+
+    expect(transport.requests.at(-1)).toEqual({
+      type: 'query.chat',
+      text: 'what changed in a/b testing?',
+    });
+    expect(controller.state.chatConversation.at(-1)?.content).toBe('Nothing yet.');
+  });
+
   it('reports an unknown theme as an error without switching', async () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -34,6 +34,7 @@ export interface SessionController {
   submit(value: string): Promise<void>;
   closeChat(): void;
   sendChat(value: string): Promise<void>;
+  submitChat(value: string): Promise<void>;
   live(): void;
   selectNextAgent(): void;
   selectPreviousAgent(): void;
@@ -132,6 +133,17 @@ export class SocketSessionController implements SessionController {
 
   closeChat(): void {
     this.#setState({...this.#state, chatOpen: false});
+  }
+
+  /**
+   * What the chat input submits. A slash command runs through exactly the same
+   * path as the main input, so the two surfaces cannot disagree about what a
+   * command does; anything else is a question for the chat agent.
+   */
+  submitChat(value: string): Promise<void> {
+    const text = value.trim();
+    if (!text.startsWith('/')) return this.sendChat(value);
+    return this.submit(text);
   }
 
   sendChat(value: string): Promise<void> {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -669,6 +669,12 @@ class FakeController implements SessionController {
     this.state = {...this.state, themeName};
     this.#notify();
   }
+  submitChat(value: string): Promise<void> {
+    const text = value.trim();
+    if (!text.startsWith('/')) return this.sendChat(value);
+    return this.submit(text);
+  }
+
   sendChat(value: string): Promise<void> {
     this.chatSubmissions.push(value);
     this.state = {

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -82,7 +82,7 @@ export class ChatOverlayView {
     this.output.add(this.#transcript);
     this.output.add(this.#inputBox);
     this.#hint = new TextRenderable(renderer, {
-      content: 'Enter to send · Esc to close',
+      content: 'Enter to send · /history and other commands work here · Esc to close',
       fg: theme.textSubtle,
       height: 1,
       width: '100%',
@@ -118,6 +118,6 @@ export class ChatOverlayView {
   readonly #submit = (value: string): void => {
     if (!value.trim()) return;
     this.#input.value = '';
-    void this.controller.sendChat(value);
+    void this.controller.submitChat(value);
   };
 }

--- a/src/vibesys/server/inspector.py
+++ b/src/vibesys/server/inspector.py
@@ -59,9 +59,12 @@ class RunInspector:
             number = int(current.group(1)) if current else self._latest_round_number()
             if number:
                 return self._status_answer(question, self.round_detail(max(1, number - 1)))
+        # Names only what this read-only matcher can actually answer. It must
+        # not advertise slash commands: this string is shown in the experiment
+        # chat, and the operator would have to leave it to run one.
         return (
-            f"{self.supervisor.status()}. Ask about a round, failure, judge, or benchmark; "
-            "use /history for the event timeline."
+            f"{self.supervisor.status()}. This summary matches on keywords, so it answers "
+            "questions about a round, a failure, the judge, or a benchmark."
         )
 
     def round_detail(self, number: int) -> str:  # noqa: D102  # tracked: #288

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -168,13 +168,30 @@ class RunSupervisor:
                 round_label=self._current_round,
             )
 
+    def chat_agent_available(self) -> bool:
+        """True when an agent-backed chat handler is installed for this run.
+
+        The handler exists only for the lifetime of the run context, so chat
+        asked during setup or after teardown has no agent to reach.
+        """
+        with self._condition:
+            return self._chat_handler is not None
+
     def chat(self, text: str) -> str:  # noqa: D102  # tracked: #288
         with self._condition:
             handler = self._chat_handler
         if handler is None:
             from vibesys.server.inspector import RunInspector  # noqa: PLC0415  # tracked: #288
 
-            answer = RunInspector(self).answer(text)
+            # No agent is reachable, so say that rather than answering as if
+            # this were the normal path. The keyword diagnostic is still worth
+            # showing, but it is supporting detail, not the answer.
+            answer = (
+                "The experiment chat agent is not available for this run"
+                f" ({self._chat_unavailable_reason()}), so this is a read-only"
+                " summary from the recorded events rather than an answer.\n\n"
+                + RunInspector(self).answer(text)
+            )
         else:
             answer = handler(text)
         self.record(
@@ -186,6 +203,13 @@ class RunSupervisor:
             data=ChatData(answer=answer),
         )
         return answer
+
+    def _chat_unavailable_reason(self) -> str:
+        with self._condition:
+            status = self._run_status
+        if status in {"completed", "failed"}:
+            return "the run has finished"
+        return "the run has not finished starting up"
 
     def set_chat_handler(self, handler: Callable[[str], str] | None) -> None:
         """Install the current experiment's agent-backed chat handler."""

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -318,6 +318,58 @@ def test_service_routes_chat_to_configured_agent_handler(tmp_path):  # noqa: ANN
     assert _events(tmp_path / "run-events.jsonl")[-1]["type"] == "chat"
 
 
+def test_chat_without_an_agent_says_so_instead_of_answering_as_if_normal(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    """The handler exists only while a run context does.
+
+    Asked during setup or after teardown there is no agent to reach, and the
+    keyword matcher must not be presented as the answer.
+    """
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    assert supervisor.chat_agent_available() is False
+
+    answer = supervisor.chat("what happened in this experiment?")
+
+    assert "chat agent is not available" in answer
+    assert "not finished starting up" in answer
+    # It must not send the operator to a command the chat cannot run.
+    assert "/history" not in answer
+
+
+def test_chat_without_an_agent_names_a_finished_run_as_the_reason(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.finish()
+
+    answer = supervisor.chat("what happened?")
+
+    assert "the run has finished" in answer
+
+
+def test_installing_an_agent_handler_takes_over_from_the_fallback(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    supervisor.set_chat_handler(lambda question: f"agent answered: {question}")
+    assert supervisor.chat_agent_available() is True
+    assert supervisor.chat("why did round 3 fail?") == "agent answered: why did round 3 fail?"
+
+    # Teardown removes it again, and the fallback says so rather than pretending.
+    supervisor.set_chat_handler(None)
+    assert supervisor.chat_agent_available() is False
+    assert "chat agent is not available" in supervisor.chat("and round 4?")
+
+
+def test_keyword_fallback_does_not_advertise_slash_commands(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    answer = RunInspector(supervisor).answer("tell me about the experiment")
+
+    assert "/history" not in answer
+    assert "keywords" in answer
+
+
 def test_chat_explains_configuration_failure_without_a_run_context(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)


### PR DESCRIPTION
## Problem

Fixes #282.

The issue reports that the experiment chat is not wired to a coding agent and that every message is answered by `RunInspector`'s keyword matcher. That is not the current state, and it is worth stating up front so the diff reads correctly: `_RunContext.chat` (`context.py:1105`) already calls `agent_runner.invoke_text(kind="chat", ...)`, and installs itself as the supervisor's chat handler at `context.py:997`. This was introduced in #193. 

`RunSupervisor.chat` (`supervisor.py:180`) dispatches to `self._chat_handler` and falls back to the keyword matcher when it is `None`. That handler exists only for the lifetime of the run context: installed in `_RunContext.__init__`, cleared in `close()` (`context.py:1291`). So two windows have no agent to reach:

- during startup, before the run context is built
- after the run finishes, which is exactly the "completed run with persisted logs" case in the issue's own verification steps

In both, the operator got a keyword answer presented as if it were the answer, ending in `use /history for the event timeline`. That instruction was not actionable where it was printed: slash commands were parsed only by the main input, and text typed in the chat overlay went straight to `sendChat`, so `/history` there was sent to the backend as an ordinary question and came back as the same fallback.

## Solution

Three changes, none of which touch the agent path that already works.

**The degraded path names itself.** New `RunSupervisor.chat_agent_available()`. When no handler is installed, the reply opens by saying the chat agent is not available and why, distinguishing a run that has not finished starting up from one that has finished. The keyword output is kept underneath as supporting detail, because it is still useful, but it is no longer passed off as the answer.

**The keyword matcher stopped advertising a command it cannot run.** `RunInspector.answer` now closes by naming what it can actually answer (a round, a failure, the judge, a benchmark) and saying it matches on keywords, with no slash command in the text. That string is shown inside the chat, so it must not send the operator somewhere the chat cannot go.

**Slash commands work in the chat.** `SocketSessionController.submitChat` sends anything not starting with `/` to the agent and routes the rest through `submit()`, the main input's own path. The two surfaces agree by construction rather than by a second parser, which is what "both surfaces agree" requires. A question with a slash mid-sentence is still a question.

### Architecture

```mermaid
flowchart TD
    IN[main input] --> PARSE[parseInput]
    CHATIN[chat input] --> SC[submitChat]
    SC -->|starts with /| PARSE
    SC -->|otherwise| Q[query.chat]
    Q --> SUP[RunSupervisor.chat]
    SUP --> H{_chat_handler installed?}
    H -->|yes, run context live| AGENT["_RunContext.chat<br/>agent_runner.invoke_text(kind=chat)"]
    H -->|no, starting up or finished| SAY[states the agent is unavailable<br/>+ read-only keyword summary]
    AGENT --> TRAJ[workspace/_vibesys_chat/trajectory<br/>refreshed from log_dir each turn]
```

Note on which agent this reaches, since it is not obvious from the call site: `build_agent_runner` constructs one runner per run from `[agent]` in `agent.toml`, so chat uses the same backend, provider, and model as the loop's other roles. `kind="chat"` is a label, not a selector. It picks the log prefix, is looked up in `role_models`, and at `cli_runner.py:331` excludes chat from agent-session reuse, which is why multi-turn continuity is carried by `_vibesys_chat/conversation.jsonl` rather than by a provider session.

## Verification

The thing to check is that the two no-agent windows now say what they are, and that a slash command means the same thing in both surfaces.

| Case | Before | After |
| --- | --- | --- |
| Question during startup | Keyword answer, presented as the answer | States the run has not finished starting up, then the summary |
| Question after the run finished | Keyword answer, presented as the answer | States the run has finished, then the summary |
| Question during the run | Agent answer | Unchanged |
| `/history` typed in the chat | Sent to the backend as a question | Runs the same command the main input runs |
| `/nope` typed in the chat | Sent to the backend as a question | Reported as an unknown command, no request sent |
| `what changed in a/b testing?` | Sent as a question | Still sent as a question |

### Correctness properties

- The keyword matcher is reached only when no chat handler is installed, and the reply says so rather than answering as if it were the normal path.
- No response the chat can produce advertises a slash command that the chat cannot execute.
- A slash command typed in the chat runs through the same function as the main input, so the two cannot diverge as commands are added.
- Text that is not a command, including text containing a slash, still reaches the chat agent unchanged.
- Installing a handler takes over from the fallback, and clearing it at teardown reverts to the fallback rather than erroring.
- Existing non-chat consumers of `RunInspector` are unchanged, and the inspector stays read-only.
- The agent path, its scoping, its multi-turn state, and its failure reporting are untouched.

### Testing

- `bun --bun vitest run` (in `clients/tui`) — 157 passed, 13 files. Adds 4 cases in `session-controller.test.ts`: a slash command typed in the chat taking the main-input path and sending no chat request, the chat and the main input producing identical results for `/history rounds`, an unknown command being reported instead of reaching the agent, and a slash mid-sentence still being a question.
- `uv run pytest tests/test_tui.py tests/server` — 51 passed. Adds 4 cases: the no-agent reply naming startup as the reason, the same naming a finished run, a handler taking over and teardown reverting, and the fallback carrying no slash commands.
- `npx tsc -p tsconfig.check.json` — passed. `npx biome check .` — passed, 42 files.
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright` — passed, 0 errors.