### PR TITLE
Fix clean installs and experiment storage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,30 +1,38 @@
 [submodule "3rd_party/transformers"]
 	path = 3rd_party/transformers
 	url = git@github.com:huggingface/transformers.git
+	update = none
 [submodule "skills/serving-systems/repos/vllm"]
 	path = resources/skills/serving-systems/repos/vllm
 	url = https://github.com/vllm-project/vllm.git
 	branch = main
 	shallow = true
+	update = none
 [submodule "skills/serving-systems/repos/sglang"]
 	path = resources/skills/serving-systems/repos/sglang
 	url = https://github.com/sgl-project/sglang.git
 	branch = main
 	shallow = true
+	update = none
 [submodule "skills/serving-systems/repos/TensorRT-LLM"]
 	path = resources/skills/serving-systems/repos/TensorRT-LLM
 	url = https://github.com/NVIDIA/TensorRT-LLM.git
 	branch = main
 	shallow = true
+	update = none
 [submodule "inputs/show-o2-1.5B-HQ/reference/Show-o"]
 	path = examples/model-serving/show-o2-1.5B-HQ/reference/Show-o
 	url = https://github.com/showlab/Show-o.git
+	update = none
 [submodule "examples/microservices/social-network-read-timeline/3rd_party/deathstarbench"]
 	path = examples/microservices/social-network-read-timeline/3rd_party/deathstarbench
 	url = https://github.com/delimitrou/DeathStarBench.git
+	update = none
 [submodule "3rd_party/train-ticket"]
 	path = 3rd_party/train-ticket
 	url = git@github.com:FudanSELab/train-ticket.git
+	update = none
 [submodule "examples/evaluators/tracelab-replay/tracelab"]
 	path = examples/evaluators/tracelab-replay/tracelab
 	url = https://github.com/uw-syfi/TraceLab.git
+	update = none

--- a/README.md
+++ b/README.md
@@ -113,14 +113,15 @@ The published wheel installs the **`vibesys`** command and bundles the native
 Bun and OpenTUI runtime for Linux x86-64, Linux ARM64, macOS Intel, or macOS
 Apple Silicon. It accepts the same run flags described in
 [`docs/cli-flags.md`](docs/cli-flags.md). No separate JavaScript runtime is
-needed for the installed tool:
+needed for the installed tool. Every run requires `--runs-dir PATH`; VibeSys
+stores experiment directories, synthesized inputs, and shared caches there.
 
 ```bash
 # Interactive TUI
-vibesys --input <bundle> --local --agent-backend cli --cli-provider codex
+vibesys --runs-dir ~/vibesys-runs --input <bundle> --local --agent-backend cli --cli-provider codex
 
 # Same run, headless (no TUI, no Bun)
-vibesys --headless --input <bundle> --local
+vibesys --headless --runs-dir ~/vibesys-runs --input <bundle> --local
 
 vibesys --help                    # full flag list
 ```
@@ -141,6 +142,7 @@ add `--local` to skip GitHub sync when `gh` is not installed.
 ```bash
 # Issue-tracker outer loop, Codex CLI, Docker on local CUDA, 4 rounds
 ./vs \
+  --runs-dir ~/vibesys-runs \
   --input examples/model-serving/moonshine-streaming \
   --exp-name my-experiment \
   --docker \
@@ -251,8 +253,8 @@ See [`docs/cli-flags.md`](docs/cli-flags.md#client-theme).
 The config is validated against a typed schema on load (`vibesys/config.py`): unknown sections or keys, unknown providers/backends, and missing required fields are rejected with an error rather than silently ignored.
 
 Fresh runs use GitHub-backed tracking by default. Pass `--local` for a local-only
-run under `exp_env/`; see [`docs/cli-flags.md`](docs/cli-flags.md) for repository
-and resume options.
+run in the collection selected by `--runs-dir`; see
+[`docs/cli-flags.md`](docs/cli-flags.md) for repository and resume options.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ accuracy and performance results.
 
 ## Installation
 
-1. Install Python 3.12+ and [uv](https://docs.astral.sh/uv/).
+1. Install Python 3.12+, Git, and [uv](https://docs.astral.sh/uv/).
 2. For the default GitHub-synced runs, install the [GitHub CLI](https://cli.github.com/)
    and sign in with `gh auth login`. You do not need `gh` when every run uses
    `--local`.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ To use the interactive TUI, install Node.js 20+, Bun, and pnpm 11 (or enable
 Corepack). Run `./vs --runs-dir "$PWD/exp_env"`; it installs the frontend
 dependencies and builds the TUI when needed. npm is not required.
 
+### Installing from GitHub source
+
+```bash
+python -m pip install "git+https://github.com/uw-syfi/vibesys.git"
+```
+
+Source installs skip the repository's optional submodules and do not build the
+bundled native TUI. They run VibeSys headless; pass `--headless` explicitly to
+suppress the fallback notice. Use a supported PyPI wheel for the one-command
+install with the bundled Bun and OpenTUI runtime.
+
 ### Installing from PyPI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ with the CLI; API credentials are loaded from `.env` automatically.
 `uv sync` first.
 
 To use the interactive TUI, install Node.js 20+, Bun, and pnpm 11 (or enable
-Corepack). Run `./vs`; it installs the frontend dependencies and builds the TUI
-when needed. npm is not required.
+Corepack). Run `./vs --runs-dir "$PWD/exp_env"`; it installs the frontend
+dependencies and builds the TUI when needed. npm is not required.
 
 ### Installing from PyPI
 

--- a/clients/tui/src/launcher.test.ts
+++ b/clients/tui/src/launcher.test.ts
@@ -94,7 +94,7 @@ process.exit(0);
     process.env['VIBESYS_TUI_ENTRYPOINT'] = frontend;
     process.env['VIBESYS_FAKE_BACKEND_TERM_FILE'] = backendTerminated;
 
-    await expect(launch(['--stub-agent'])).resolves.toBe(0);
+    await expect(launch(['--stub-agent', '--runs-dir', '/tmp/vibesys-test-runs'])).resolves.toBe(0);
     await access(backendTerminated);
   });
 
@@ -148,11 +148,11 @@ process.exit(0);
 
     delete process.env['VIBESYS_RELEASE_SMOKE_MARKER'];
     process.env['VIBESYS_FAKE_BACKEND_TERM_FILE'] = join(tempDir, 'normal-backend-terminated');
-    await expect(launch(['--stub-agent'])).resolves.toBe(2);
+    await expect(launch(['--stub-agent', '--runs-dir', '/tmp/vibesys-test-runs'])).resolves.toBe(2);
 
     process.env['VIBESYS_RELEASE_SMOKE_MARKER'] = smokeMarker;
     process.env['VIBESYS_FAKE_BACKEND_TERM_FILE'] = backendTerminated;
-    await expect(launch(['--stub-agent'])).resolves.toBe(0);
+    await expect(launch(['--stub-agent', '--runs-dir', '/tmp/vibesys-test-runs'])).resolves.toBe(0);
     expect(await readFile(smokeMarker, 'utf8')).toBe('started');
     expect(await readFile(backendTerminated, 'utf8')).toBe('terminated');
   });
@@ -186,6 +186,7 @@ import {createServer} from 'node:net';
 
 if (process.argv.includes('tui-defaults')) {
   console.log(JSON.stringify({
+    runs_dir: '/repo/exp_env',
     input_path: '/repo/examples/queue-spsc',
     experiment_name: 'queue-spsc-generated',
     repository_owner: 'vibesys-playground',
@@ -223,6 +224,8 @@ import {writeFileSync} from 'node:fs';
 const defaults = JSON.parse(process.env.VIBESYS_SETUP_DEFAULTS);
 writeFileSync(process.env.VIBESYS_FAKE_SETUP_THEME_FILE, process.env.VIBESYS_THEME ?? '');
 writeFileSync(process.env.VIBESYS_SETUP_RESULT, JSON.stringify({
+  kind: 'experiment',
+  runsDirectory: defaults.runs_dir,
   inputPath: defaults.input_path,
   experimentName: defaults.experiment_name,
   repositoryOwner: defaults.repository_owner,
@@ -253,6 +256,8 @@ process.exit(0);
 
     await expect(launch(['--input', 'examples/queue-spsc'])).resolves.toBe(0);
     const args = JSON.parse(await readFile(backendArgs, 'utf8')) as string[];
+    expect(args.filter(argument => argument === '--runs-dir')).toHaveLength(1);
+    expect(args[args.indexOf('--runs-dir') + 1]).toBe('/repo/exp_env');
     expect(args).toContain('vibesys-playground/queue-spsc-generated');
     expect(args).toContain('queue-spsc-generated');
     expect(await readFile(setupTheme, 'utf8')).toBe('solarized-dark');

--- a/clients/tui/src/launcher.test.ts
+++ b/clients/tui/src/launcher.test.ts
@@ -13,8 +13,10 @@ const savedSetupEntrypoint = process.env['VIBESYS_SETUP_ENTRYPOINT'];
 const savedTermFile = process.env['VIBESYS_FAKE_BACKEND_TERM_FILE'];
 const savedArgsFile = process.env['VIBESYS_FAKE_BACKEND_ARGS_FILE'];
 const savedReleaseSmokeMarker = process.env['VIBESYS_RELEASE_SMOKE_MARKER'];
+const originalCwd = process.cwd();
 
 afterEach(async () => {
+  process.chdir(originalCwd);
   if (savedPython === undefined) delete process.env['VIBESYS_PYTHON'];
   else process.env['VIBESYS_PYTHON'] = savedPython;
   if (savedRuntime === undefined) delete process.env['VIBESYS_TUI_RUNTIME'];
@@ -275,6 +277,68 @@ process.exit(0);
 
     await expect(launch(['--theme', 'monokai'])).resolves.toBe(2);
   });
+
+  it('returns the backend argument error for an explicitly empty runs directory', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'vibesys-launcher-'));
+    const frontendMarker = join(tempDir, 'frontend-started');
+    const failureMarker = join(tempDir, 'configuration-failure.json');
+    const frontend = await writeExecutable(
+      'unused-frontend.mjs',
+      `
+import {writeFileSync} from 'node:fs';
+import {createConnection} from 'node:net';
+writeFileSync(${JSON.stringify(frontendMarker)}, 'started');
+const socket = createConnection(process.env.VIBESYS_CONTROL_SOCKET);
+let buffer = '';
+socket.once('connect', () => socket.write(JSON.stringify({
+  protocol_version: 1,
+  request_id: 'launcher-empty-runs-dir',
+  timestamp: '1970-01-01T00:00:00Z',
+  type: 'subscribe',
+  after_sequence: 0,
+}) + '\\n'));
+socket.setEncoding('utf8');
+socket.on('data', chunk => {
+  buffer += chunk;
+  while (buffer.includes('\\n')) {
+    const newline = buffer.indexOf('\\n');
+    const message = JSON.parse(buffer.slice(0, newline));
+    buffer = buffer.slice(newline + 1);
+    const events = message.type === 'event' ? [message.event] :
+      message.type === 'event_batch' ? message.events : [];
+    const failure = events.find(event => event.type === 'configuration_failed');
+    if (failure) {
+      writeFileSync(${JSON.stringify(failureMarker)}, JSON.stringify(failure));
+      socket.end();
+      return;
+    }
+    if (events.some(event => event.type === 'run_finished' || event.type === 'run_failed')) {
+      socket.end();
+      return;
+    }
+  }
+});
+socket.once('close', () => process.exit(0));
+`,
+    );
+    const python = join(dirname(fileURLToPath(import.meta.url)), '../../../.venv/bin/python');
+    process.chdir(tempDir);
+    process.env['VIBESYS_PYTHON'] = python;
+    process.env['VIBESYS_TUI_RUNTIME'] = process.execPath;
+    process.env['VIBESYS_TUI_ENTRYPOINT'] = frontend;
+
+    await expect(
+      launch(['--stub-agent', '--local', '--max-rounds', '0', '--runs-dir=']),
+    ).resolves.toBe(2);
+    await access(frontendMarker);
+    const failure = JSON.parse(await readFile(failureMarker, 'utf8')) as {
+      data: {code: string; stage: string; message: string};
+    };
+    expect(failure.data.code).toBe('invalid_arguments');
+    expect(failure.data.stage).toBe('argument_parsing');
+    expect(failure.data.message).toContain('argument --runs-dir: must not be empty');
+    await expect(access(join(tempDir, 'exp_env'))).rejects.toThrow();
+  }, 15_000);
 });
 
 async function writeExecutable(name: string, source: string): Promise<string> {

--- a/clients/tui/src/launcher.ts
+++ b/clients/tui/src/launcher.ts
@@ -12,8 +12,9 @@ import {
   applySetupSelection,
   parseSetupDefaults,
   type SetupDefaults,
+  type SetupFields,
   type SetupSelection,
-  shouldOfferInteractiveSetup,
+  setupFieldsFor,
 } from './setup-model.js';
 import {DEFAULT_THEME_NAME, isThemeName, THEME_NAMES, type ThemeName} from './ui/theme.js';
 
@@ -134,11 +135,12 @@ async function prepareInteractiveArgs(
     return {exitCode: 2};
   }
 
-  if (!shouldOfferInteractiveSetup(argv)) {
+  const fields = setupFieldsFor(argv);
+  if (fields === undefined) {
     return {argv, theme: requestedTheme ?? (await themeFromBackend(backend, argv))};
   }
 
-  const defaultsResult = await resolveSetupDefaults(backend, argv);
+  const defaultsResult = await resolveSetupDefaults(backend, argv, fields);
   if (defaultsResult.exitCode !== 0) {
     console.error(defaultsResult.stderr || 'vs: could not resolve interactive setup defaults');
     return {exitCode: defaultsResult.exitCode};
@@ -152,8 +154,6 @@ async function prepareInteractiveArgs(
     return {exitCode: 1};
   }
   const theme = requestedTheme ?? defaults.theme;
-  if (defaults.repository_owner === null) return {argv, theme};
-
   const setupEntrypoint =
     process.env['VIBESYS_SETUP_ENTRYPOINT'] ?? join(dirname(frontendEntrypoint), 'setup.js');
   if (!(await fileExists(setupEntrypoint))) {
@@ -164,7 +164,14 @@ async function prepareInteractiveArgs(
   const setupDir = await mkdtemp(join(tmpdir(), 'vibesys-setup-'));
   const resultPath = join(setupDir, 'selection.json');
   try {
-    const exitCode = await runSetupFrontend(runtime, setupEntrypoint, defaults, resultPath, theme);
+    const exitCode = await runSetupFrontend(
+      runtime,
+      setupEntrypoint,
+      defaults,
+      fields,
+      resultPath,
+      theme,
+    );
     if (exitCode !== 0) return {exitCode};
     let selection: SetupSelection;
     try {
@@ -181,12 +188,15 @@ async function prepareInteractiveArgs(
 function resolveSetupDefaults(
   backend: BackendCommand,
   argv: string[],
+  fields?: SetupFields,
 ): Promise<{exitCode: number; stdout: string; stderr: string}> {
   const args = [...backend.args, 'tui-defaults'];
-  for (const option of ['--config', '--input', '--exp-name', '--theme']) {
+  for (const option of ['--config', '--input', '--runs-dir', '--exp-name', '--theme']) {
     const value = optionValue(argv, option);
     if (value !== undefined) args.push(option, value);
   }
+  if (argv.includes('--stub-agent')) args.push('--stub-agent');
+  if (fields?.experiment === false) args.push('--directory-only');
   return runCaptured(backend.command, args);
 }
 
@@ -203,6 +213,7 @@ function runSetupFrontend(
   runtime: string,
   entrypoint: string,
   defaults: SetupDefaults,
+  fields: SetupFields,
   resultPath: string,
   theme: ThemeName,
 ): Promise<number> {
@@ -211,6 +222,7 @@ function runSetupFrontend(
       env: {
         ...process.env,
         VIBESYS_SETUP_DEFAULTS: JSON.stringify(defaults),
+        VIBESYS_SETUP_FIELDS: JSON.stringify(fields),
         VIBESYS_SETUP_RESULT: resultPath,
         VIBESYS_THEME: theme,
       },

--- a/clients/tui/src/setup-form.test.ts
+++ b/clients/tui/src/setup-form.test.ts
@@ -1,10 +1,13 @@
 import {afterEach, describe, expect, it} from 'bun:test';
 import {createTestRenderer} from '@opentui/core/testing';
 import {createSetupForm} from './setup-form.js';
-import type {SetupDefaults} from './setup-model.js';
+import type {SetupDefaults, SetupFields} from './setup-model.js';
 import {resolveTheme} from './ui/theme.js';
 
 const THEME = resolveTheme('dark');
+const ALL_FIELDS: SetupFields = {experiment: true, runsDirectory: true};
+const DIRECTORY_ONLY: SetupFields = {experiment: false, runsDirectory: true};
+const EXPERIMENT_ONLY: SetupFields = {experiment: true, runsDirectory: false};
 
 const cleanup: Array<() => void> = [];
 
@@ -13,6 +16,7 @@ afterEach(() => {
 });
 
 const DEFAULTS: SetupDefaults = {
+  runs_dir: '/repo/exp_env',
   input_path: 'examples/x',
   experiment_name: 'x',
   repository_owner: '',
@@ -24,15 +28,80 @@ const DEFAULTS: SetupDefaults = {
 const OWNER_ERROR = 'Repository owner must be one GitHub user or organization name.';
 
 describe('interactive setup form', () => {
+  it('shows and returns the required runs directory', async () => {
+    const testRenderer = await createTestRenderer({width: 92, height: 24});
+    const form = createSetupForm(testRenderer.renderer, DEFAULTS, ALL_FIELDS, THEME);
+    cleanup.push(() => {
+      form.destroy();
+      testRenderer.renderer.destroy();
+    });
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('Runs directory'));
+    expect(frame).toContain('/repo/exp_env');
+    expect(frame).toContain('Visibility');
+    testRenderer.mockInput.pressEnter();
+    expect(form.selection).toMatchObject({kind: 'experiment', runsDirectory: '/repo/exp_env'});
+  });
+
+  it('renders one directory-only form for skip modes', async () => {
+    const testRenderer = await createTestRenderer({width: 92, height: 12});
+    const form = createSetupForm(testRenderer.renderer, DEFAULTS, DIRECTORY_ONLY, THEME);
+    cleanup.push(() => {
+      form.destroy();
+      testRenderer.renderer.destroy();
+    });
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('Runs directory'));
+    expect(frame).not.toContain('Input bundle');
+    testRenderer.mockInput.pressEnter();
+    expect(form.selection).toEqual({kind: 'runs-directory', runsDirectory: '/repo/exp_env'});
+  });
+
+  it('keeps an explicit runs directory out of the experiment form', async () => {
+    const testRenderer = await createTestRenderer({width: 92, height: 24});
+    const form = createSetupForm(testRenderer.renderer, DEFAULTS, EXPERIMENT_ONLY, THEME);
+    cleanup.push(() => {
+      form.destroy();
+      testRenderer.renderer.destroy();
+    });
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('Input bundle'));
+    expect(frame).not.toContain('Runs directory');
+    testRenderer.mockInput.pressEnter();
+    expect(form.selection).toMatchObject({kind: 'experiment', runsDirectory: '/repo/exp_env'});
+  });
+
+  it('blocks an empty directory selection', async () => {
+    const testRenderer = await createTestRenderer({width: 92, height: 12});
+    const form = createSetupForm(
+      testRenderer.renderer,
+      {...DEFAULTS, runs_dir: ''},
+      DIRECTORY_ONLY,
+      THEME,
+    );
+    cleanup.push(() => {
+      form.destroy();
+      testRenderer.renderer.destroy();
+    });
+
+    testRenderer.mockInput.pressEnter();
+    const frame = await testRenderer.waitForFrame(value =>
+      value.includes('Runs directory is required.'),
+    );
+    expect(frame).toContain('Runs directory is required.');
+    expect(form.selection).toBeUndefined();
+  });
+
   it('dismisses a stale validation error once the user edits the input', async () => {
     const testRenderer = await createTestRenderer({width: 92, height: 24});
-    const form = createSetupForm(testRenderer.renderer, DEFAULTS, THEME);
+    const form = createSetupForm(testRenderer.renderer, DEFAULTS, ALL_FIELDS, THEME);
     cleanup.push(() => {
       form.destroy();
       testRenderer.renderer.destroy();
     });
 
     // Move to the Repository owner field and submit an invalid value.
+    testRenderer.mockInput.pressKey('TAB');
     testRenderer.mockInput.pressKey('TAB');
     testRenderer.mockInput.pressKey('TAB');
     await testRenderer.mockInput.typeText('a/b');
@@ -51,12 +120,13 @@ describe('interactive setup form', () => {
 
   it('still blocks submission while the value is invalid', async () => {
     const testRenderer = await createTestRenderer({width: 92, height: 24});
-    const form = createSetupForm(testRenderer.renderer, DEFAULTS, THEME);
+    const form = createSetupForm(testRenderer.renderer, DEFAULTS, ALL_FIELDS, THEME);
     cleanup.push(() => {
       form.destroy();
       testRenderer.renderer.destroy();
     });
 
+    testRenderer.mockInput.pressKey('TAB');
     testRenderer.mockInput.pressKey('TAB');
     testRenderer.mockInput.pressKey('TAB');
     await testRenderer.mockInput.typeText('bad/owner');

--- a/clients/tui/src/setup-form.ts
+++ b/clients/tui/src/setup-form.ts
@@ -1,5 +1,5 @@
 import {BoxRenderable, type CliRenderer, InputRenderable, TextRenderable} from '@opentui/core';
-import type {SetupDefaults, SetupSelection} from './setup-model.js';
+import type {SetupDefaults, SetupFields, SetupSelection} from './setup-model.js';
 import {validateSetupSelection} from './setup-model.js';
 import type {Theme} from './ui/theme.js';
 
@@ -17,6 +17,7 @@ export interface SetupForm {
 export function createSetupForm(
   renderer: CliRenderer,
   defaults: SetupDefaults,
+  fields: SetupFields,
   theme: Theme,
 ): SetupForm {
   const root = new BoxRenderable(renderer, {
@@ -31,36 +32,54 @@ export function createSetupForm(
   });
   const title = new TextRenderable(renderer, {
     id: 'setup-title',
-    height: 2,
+    height: 1,
     fg: theme.accent,
-    content: 'VibeSys · New experiment',
+    content: fields.experiment ? 'VibeSys · New experiment' : 'VibeSys · Runs directory',
   });
   const instructions = new TextRenderable(renderer, {
     id: 'setup-instructions',
-    height: 2,
+    height: 1,
     fg: theme.textMuted,
-    content: 'Tab / Shift-Tab: move · Enter: launch · Esc: cancel · Clear owner for local-only',
+    content: fields.experiment
+      ? 'Tab / Shift-Tab: move · Enter: launch · Esc: cancel · Clear owner for local-only'
+      : 'Enter: launch · Esc: cancel',
   });
   const error = new TextRenderable(renderer, {
     id: 'setup-error',
-    height: 2,
+    height: 1,
     fg: theme.error,
     content: '',
   });
 
-  const entries = [
-    createField(renderer, 'Input bundle', defaults.input_path, 'examples/<input>', theme),
-    createField(renderer, 'Experiment name', defaults.experiment_name, 'experiment name', theme),
-    createField(
-      renderer,
+  type FieldName =
+    | 'runsDirectory'
+    | 'inputPath'
+    | 'experimentName'
+    | 'repositoryOwner'
+    | 'repositoryName'
+    | 'visibility';
+  const entries: Array<{box: BoxRenderable; input: InputRenderable}> = [];
+  const inputs: Partial<Record<FieldName, InputRenderable>> = {};
+  const addField = (name: FieldName, label: string, value: string, placeholder: string): void => {
+    const entry = createField(renderer, label, value, placeholder, theme);
+    entries.push(entry);
+    inputs[name] = entry.input;
+  };
+  if (fields.runsDirectory) {
+    addField('runsDirectory', 'Runs directory', defaults.runs_dir, 'runs directory');
+  }
+  if (fields.experiment) {
+    addField('inputPath', 'Input bundle', defaults.input_path, 'examples/<input>');
+    addField('experimentName', 'Experiment name', defaults.experiment_name, 'experiment name');
+    addField(
+      'repositoryOwner',
       'Repository owner',
       defaults.repository_owner ?? '',
       'local-only if empty',
-      theme,
-    ),
-    createField(renderer, 'Repository name', defaults.repository_name, 'repository name', theme),
-    createField(renderer, 'Visibility', defaults.visibility, 'private | public | internal', theme),
-  ];
+    );
+    addField('repositoryName', 'Repository name', defaults.repository_name, 'repository name');
+    addField('visibility', 'Visibility', defaults.visibility, 'private | public | internal');
+  }
   root.add(title);
   root.add(instructions);
   for (const entry of entries) root.add(entry.box);
@@ -71,13 +90,19 @@ export function createSetupForm(
   let focused = 0;
   entries[focused]?.input.focus();
 
-  const readSelection = (): SetupSelection => ({
-    inputPath: entries[0]?.input.value ?? '',
-    experimentName: entries[1]?.input.value ?? '',
-    repositoryOwner: entries[2]?.input.value ?? '',
-    repositoryName: entries[3]?.input.value ?? '',
-    visibility: entries[4]?.input.value ?? '',
-  });
+  const readSelection = (): SetupSelection => {
+    const runsDirectory = inputs.runsDirectory?.value ?? defaults.runs_dir;
+    if (!fields.experiment) return {kind: 'runs-directory', runsDirectory};
+    return {
+      kind: 'experiment',
+      runsDirectory,
+      inputPath: inputs.inputPath?.value ?? '',
+      experimentName: inputs.experimentName?.value ?? '',
+      repositoryOwner: inputs.repositoryOwner?.value ?? '',
+      repositoryName: inputs.repositoryName?.value ?? '',
+      visibility: inputs.visibility?.value ?? '',
+    };
+  };
   const moveFocus = (offset: number): void => {
     entries[focused]?.input.blur();
     focused = (focused + offset + entries.length) % entries.length;

--- a/clients/tui/src/setup-model.test.ts
+++ b/clients/tui/src/setup-model.test.ts
@@ -2,12 +2,14 @@ import {describe, expect, it} from 'bun:test';
 import {
   applySetupSelection,
   parseSetupDefaults,
-  shouldOfferInteractiveSetup,
+  setupFieldsFor,
   validateSetupSelection,
 } from './setup-model.js';
 
 describe('interactive setup model', () => {
   const selection = {
+    kind: 'experiment' as const,
+    runsDirectory: '/repo/exp_env',
     inputPath: '/repo/examples/queue-spsc',
     experimentName: 'queue-spsc-20260720-120000',
     repositoryOwner: 'vibesys-playground',
@@ -19,6 +21,7 @@ describe('interactive setup model', () => {
     expect(
       parseSetupDefaults(
         JSON.stringify({
+          runs_dir: selection.runsDirectory,
           input_path: selection.inputPath,
           experiment_name: selection.experimentName,
           repository_owner: selection.repositoryOwner,
@@ -28,16 +31,33 @@ describe('interactive setup model', () => {
         }),
       ),
     ).toMatchObject({
+      runs_dir: '/repo/exp_env',
       repository_owner: 'vibesys-playground',
       visibility: 'private',
       theme: 'solarized-dark',
     });
   });
 
+  it('rejects backend defaults without a runs directory', () => {
+    expect(() =>
+      parseSetupDefaults(
+        JSON.stringify({
+          input_path: selection.inputPath,
+          experiment_name: selection.experimentName,
+          repository_owner: selection.repositoryOwner,
+          repository_name: selection.repositoryName,
+          visibility: selection.visibility,
+          theme: 'dark',
+        }),
+      ),
+    ).toThrow(/invalid interactive setup defaults/);
+  });
+
   it('rejects backend defaults carrying an unknown theme', () => {
     expect(() =>
       parseSetupDefaults(
         JSON.stringify({
+          runs_dir: selection.runsDirectory,
           input_path: selection.inputPath,
           experiment_name: selection.experimentName,
           repository_owner: selection.repositoryOwner,
@@ -51,10 +71,15 @@ describe('interactive setup model', () => {
 
   it('replaces launch values with the confirmed form values', () => {
     expect(
-      applySetupSelection(['--input=old', '--exp-name', 'old-name', '--backend', 'cpu'], selection),
+      applySetupSelection(
+        ['--input=old', '--exp-name', 'old-name', '--runs-dir=old-runs', '--backend', 'cpu'],
+        selection,
+      ),
     ).toEqual([
       '--backend',
       'cpu',
+      '--runs-dir',
+      selection.runsDirectory,
       '--input',
       selection.inputPath,
       '--exp-name',
@@ -75,16 +100,37 @@ describe('interactive setup model', () => {
   });
 
   it('validates repository and required fields', () => {
+    expect(validateSetupSelection({...selection, runsDirectory: ''})).toContain('Runs directory');
     expect(validateSetupSelection({...selection, inputPath: ''})).toContain('Input bundle');
     expect(validateSetupSelection({...selection, repositoryOwner: 'bad/owner'})).toContain('owner');
     expect(validateSetupSelection({...selection, visibility: 'secret'})).toContain('Visibility');
   });
 
-  it('skips setup for resume, explicit repositories, and smoke runs', () => {
-    expect(shouldOfferInteractiveSetup(['--input', 'example'])).toBe(true);
-    expect(shouldOfferInteractiveSetup(['--resume'])).toBe(false);
-    expect(shouldOfferInteractiveSetup(['--repo=owner/name'])).toBe(false);
-    expect(shouldOfferInteractiveSetup(['--local'])).toBe(false);
-    expect(shouldOfferInteractiveSetup(['--stub-agent'])).toBe(false);
+  it('preserves skip-mode arguments while applying a directory-only selection', () => {
+    expect(
+      applySetupSelection(['--resume', 'saved-run', '--backend', 'cpu', '--runs-dir=old-runs'], {
+        kind: 'runs-directory',
+        runsDirectory: '/repo/new-runs',
+      }),
+    ).toEqual(['--resume', 'saved-run', '--backend', 'cpu', '--runs-dir', '/repo/new-runs']);
+  });
+
+  it('selects explicit fields for each interactive launch mode', () => {
+    expect(setupFieldsFor(['--input', 'example'])).toEqual({
+      experiment: true,
+      runsDirectory: true,
+    });
+    expect(setupFieldsFor(['--input', 'example', '--runs-dir=chosen'])).toEqual({
+      experiment: true,
+      runsDirectory: false,
+    });
+
+    for (const argv of [['--resume'], ['--local'], ['--repo=owner/name'], ['--stub-agent']]) {
+      expect(setupFieldsFor(argv)).toEqual({experiment: false, runsDirectory: true});
+      expect(setupFieldsFor([...argv, '--runs-dir', '/repo/runs'])).toBeUndefined();
+    }
+
+    expect(setupFieldsFor(['--headless'])).toBeUndefined();
+    expect(setupFieldsFor(['--headless', '--runs-dir', '/repo/runs'])).toBeUndefined();
   });
 });

--- a/clients/tui/src/setup-model.ts
+++ b/clients/tui/src/setup-model.ts
@@ -5,6 +5,7 @@ export const REPOSITORY_VISIBILITIES = ['private', 'public', 'internal'] as cons
 export type RepositoryVisibility = (typeof REPOSITORY_VISIBILITIES)[number];
 
 export interface SetupDefaults {
+  runs_dir: string;
   input_path: string;
   experiment_name: string;
   repository_owner: string | null;
@@ -13,7 +14,14 @@ export interface SetupDefaults {
   theme: ThemeName;
 }
 
-export interface SetupSelection {
+export interface SetupFields {
+  experiment: boolean;
+  runsDirectory: boolean;
+}
+
+export interface ExperimentSetupSelection {
+  kind: 'experiment';
+  runsDirectory: string;
   inputPath: string;
   experimentName: string;
   repositoryOwner: string;
@@ -21,11 +29,19 @@ export interface SetupSelection {
   visibility: string;
 }
 
+export interface RunsDirectorySetupSelection {
+  kind: 'runs-directory';
+  runsDirectory: string;
+}
+
+export type SetupSelection = ExperimentSetupSelection | RunsDirectorySetupSelection;
+
 const REPOSITORY_COMPONENT = /^[A-Za-z0-9_.-]+$/;
 
 export function parseSetupDefaults(text: string): SetupDefaults {
   const value = JSON.parse(text) as Partial<SetupDefaults>;
   if (
+    typeof value.runs_dir !== 'string' ||
     typeof value.input_path !== 'string' ||
     typeof value.experiment_name !== 'string' ||
     (value.repository_owner !== null && typeof value.repository_owner !== 'string') ||
@@ -39,6 +55,8 @@ export function parseSetupDefaults(text: string): SetupDefaults {
 }
 
 export function validateSetupSelection(selection: SetupSelection): string | undefined {
+  if (selection.runsDirectory.trim().length === 0) return 'Runs directory is required.';
+  if (selection.kind === 'runs-directory') return undefined;
   if (selection.inputPath.trim().length === 0) return 'Input bundle is required.';
   if (selection.experimentName.trim().length === 0) return 'Experiment name is required.';
 
@@ -57,13 +75,19 @@ export function validateSetupSelection(selection: SetupSelection): string | unde
 }
 
 export function applySetupSelection(argv: string[], selection: SetupSelection): string[] {
-  const result = withoutOptions(argv, [
-    '--input',
-    '--exp-name',
-    '--repo',
-    '--repo-visibility',
-    '--local',
-  ]);
+  const withoutRunsDirectory = withoutOptions(argv, ['--runs-dir']);
+  const result =
+    selection.kind === 'experiment'
+      ? withoutOptions(withoutRunsDirectory, [
+          '--input',
+          '--exp-name',
+          '--repo',
+          '--repo-visibility',
+          '--local',
+        ])
+      : withoutRunsDirectory;
+  result.push('--runs-dir', selection.runsDirectory.trim());
+  if (selection.kind === 'runs-directory') return result;
   result.push('--input', selection.inputPath.trim());
   result.push('--exp-name', selection.experimentName.trim());
 
@@ -77,17 +101,19 @@ export function applySetupSelection(argv: string[], selection: SetupSelection): 
   return result;
 }
 
-export function shouldOfferInteractiveSetup(argv: string[]): boolean {
-  return !argv.some(
-    argument =>
-      argument === '--resume' ||
-      argument.startsWith('--resume=') ||
-      argument === '--repo' ||
-      argument.startsWith('--repo=') ||
-      argument === '--local' ||
-      argument === '--stub-agent' ||
-      argument === '--headless',
+export function setupFieldsFor(argv: string[]): SetupFields | undefined {
+  if (hasOption(argv, '--headless')) return undefined;
+
+  const runsDirectory = !hasOption(argv, '--runs-dir');
+  const experiment = !['--resume', '--repo', '--local', '--stub-agent'].some(option =>
+    hasOption(argv, option),
   );
+  if (!experiment && !runsDirectory) return undefined;
+  return {experiment, runsDirectory};
+}
+
+function hasOption(argv: string[], option: string): boolean {
+  return argv.some(argument => argument === option || argument.startsWith(`${option}=`));
 }
 
 function withoutOptions(argv: string[], options: string[]): string[] {

--- a/clients/tui/src/setup.ts
+++ b/clients/tui/src/setup.ts
@@ -1,19 +1,23 @@
 import {writeFile} from 'node:fs/promises';
 import {CliRenderEvents, createCliRenderer} from '@opentui/core';
 import {createSetupForm} from './setup-form.js';
-import type {SetupDefaults} from './setup-model.js';
+import type {SetupDefaults, SetupFields} from './setup-model.js';
 import {resolveTheme} from './ui/theme.js';
 
 const rawDefaults = process.env['VIBESYS_SETUP_DEFAULTS'];
+const rawFields = process.env['VIBESYS_SETUP_FIELDS'];
 const resultPath = process.env['VIBESYS_SETUP_RESULT'];
-if (!rawDefaults || !resultPath) {
-  throw new Error('VIBESYS_SETUP_DEFAULTS and VIBESYS_SETUP_RESULT are required');
+if (!rawDefaults || !rawFields || !resultPath) {
+  throw new Error(
+    'VIBESYS_SETUP_DEFAULTS, VIBESYS_SETUP_FIELDS, and VIBESYS_SETUP_RESULT are required',
+  );
 }
 
 const defaults = JSON.parse(rawDefaults) as SetupDefaults;
+const fields = JSON.parse(rawFields) as SetupFields;
 const theme = resolveTheme(process.env['VIBESYS_THEME']);
 const renderer = await createCliRenderer({exitOnCtrlC: false});
-const form = createSetupForm(renderer, defaults, theme);
+const form = createSetupForm(renderer, defaults, fields, theme);
 renderer.start();
 
 await new Promise<void>(resolve => renderer.once(CliRenderEvents.DESTROY, resolve));

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -32,7 +32,8 @@ Several flags look independent, but they combine into one execution contract:
 | Modality | `--modality` | Per-task I/O contract, such as `text_generation` or `speech_to_text`. |
 | Skills | `--skills-dir`, `--extra-skills`, `--no-skills` | Override the preset skill roots, stack extra skills on top of the presets, or disable skill loading. |
 | Target inputs | `--input` | Target bundle directory with manifest-declared correctness and benchmark commands. |
-| Experiment repository | `--repo`, `--repo-visibility`, `--local`, `--resume` | Fresh runs use GitHub by default; `--local` keeps one under `exp_env/`, and `--resume` accepts local paths or GitHub repositories. |
+| Experiment collection | `--runs-dir PATH` | Required for every run. Owns run directories, synthesized inputs, and shared caches. |
+| Experiment repository | `--repo`, `--repo-visibility`, `--local`, `--resume` | Fresh runs use GitHub by default; `--local` keeps one in the selected collection, and `--resume` accepts local paths or GitHub repositories. |
 | Client theme | `--theme` | Presentation only. Which semantic theme the interactive client renders with. |
 
 Do not treat these as simple toggles. Some combinations imply a startup
@@ -116,10 +117,10 @@ Names default to `<input-name>-<UTC timestamp>`.
 
 For headless use, the generated repository name is used automatically. Pass
 `--repo NAME` to override the name, or `--repo OWNER/NAME` to override the owner
-explicitly. Pass `--local` to keep the experiment under `exp_env/` without a
-GitHub repository. Repositories use `[repository].visibility` unless
-`--repo-visibility` overrides it. Creation goes through the authenticated `gh`
-CLI.
+explicitly. Every run requires `--runs-dir PATH`. Pass `--local` to keep the
+experiment in that collection without a GitHub repository. Repositories use
+`[repository].visibility` unless `--repo-visibility` overrides it. Creation goes
+through the authenticated `gh` CLI.
 
 The experiment repository records the materialized workspace and durable state
 needed to continue the loop. Provider/agent `logs/*.log` files and directory
@@ -134,16 +135,17 @@ rather than force-pushing.
 GitHub `OWNER/NAME` pairs, and cloneable HTTPS/SSH URLs:
 
 ```bash
-./vs --resume 20260720-120000-example
-./vs --resume /work/experiments/example
-./vs --resume vibesys-playground/example
-./vs --resume https://github.com/my-org/example.git
+./vs --runs-dir /work/vibesys-runs --resume 20260720-120000-example
+./vs --runs-dir /work/vibesys-runs --resume /work/experiments/example
+./vs --runs-dir /work/vibesys-runs --resume vibesys-playground/example
+./vs --runs-dir /work/vibesys-runs --resume https://github.com/my-org/example.git
 ```
 
-Remote repositories are cloned under `exp_env/`. A local clone can live
-anywhere. Resumed repositories with an `origin` are synchronized again after
-the run. `--repo` only creates a repository for a fresh experiment and cannot
-be combined with `--resume`.
+Remote repositories are cloned into the selected collection. A local clone can
+live anywhere, but `--runs-dir` is still required for shared caches and any
+future runs. Resumed repositories with an `origin` are synchronized again after
+the run. `--repo` only creates a repository for a fresh experiment and cannot be
+combined with `--resume`.
 
 ## Repository Validation
 
@@ -299,7 +301,7 @@ per-status marker, and the running round is the only one with an elapsed-time
 suffix.
 
 ```bash
-./vs --input examples/model-serving/Llama-3-8B --theme solarized-light
+./vs --runs-dir /work/vibesys-runs --input examples/model-serving/Llama-3-8B --theme solarized-light
 ```
 
 ## Skills
@@ -317,12 +319,12 @@ skills, or a single `SKILL.md` file:
 
 ```bash
 # presets + your own skill directory and a single SKILL.md file
-./vs --input <bundle> \
+./vs --runs-dir /work/vibesys-runs --input <bundle> \
   --extra-skills ./my-skills \
   --extra-skills ./one-off-skill/SKILL.md
 
 # use ONLY your skills, ignoring the presets
-./vs --input <bundle> --skills-dir ./my-skills
+./vs --runs-dir /work/vibesys-runs --input <bundle> --skills-dir ./my-skills
 ```
 
 Before a run starts, VibeSys discovers each `SKILL.md` under the candidate
@@ -373,7 +375,7 @@ assumptions in a separate design document.
 For those bundles, pass the root once:
 
 ```bash
-./vs --input examples/<target> ...
+./vs --runs-dir /work/vibesys-runs --input examples/<target> ...
 ```
 
 The manifest declares the evaluator entrypoints and does not define a candidate
@@ -435,6 +437,7 @@ commit the authorized refresh before resuming and pass that immutable revision:
 
 ```bash
 ./vs --outer-loop agent \
+  --runs-dir /work/vibesys-runs \
   --resume /path/to/experiment \
   --trusted-input-baseline <refresh-commit>
 ```
@@ -448,10 +451,10 @@ workspace baseline, so ordinary resumes cannot silently bless agent tampering.
 
 For external usage where no `examples/` bundle is on disk, pass the bundle's
 contents as separate `--input-*` flags instead of `--input`. VibeSys synthesizes
-a bundle under `exp_env/_inputs/<exp-name>/` and then loads it through the same
-path as `--input`, so every loop, resume, and evaluator behaves identically. The
-two forms are mutually exclusive: combining `--input` with any `--input-*` flag
-is rejected.
+a bundle under `<runs-dir>/_inputs/<exp-name>/` and then loads it through the
+same path as `--input`, so every loop, resume, and evaluator behaves identically.
+The two forms are mutually exclusive: combining `--input` with any `--input-*`
+flag is rejected.
 
 Required flags:
 
@@ -482,6 +485,7 @@ use `--input` for those.
 
 ```bash
 ./vs \
+  --runs-dir /work/vibesys-runs \
   --input-objective-file ./OBJECTIVE.md \
   --input-domain llm-serving \
   --input-accuracy-command "python checker.py" \
@@ -498,6 +502,7 @@ Default agent loop on local CUDA-compatible host:
 
 ```bash
 ./vs \
+  --runs-dir /work/vibesys-runs \
   --outer-loop agent \
   --backend cuda \
   --interface inprocess \
@@ -507,25 +512,26 @@ Default agent loop on local CUDA-compatible host:
 Docker CUDA run:
 
 ```bash
-./vs --outer-loop agent --backend cuda --docker ...
+./vs --runs-dir /work/vibesys-runs --outer-loop agent --backend cuda --docker ...
 ```
 
 Modal GPU run:
 
 ```bash
-./vs --outer-loop agent --backend cuda --modal --profiler torch ...
+./vs --runs-dir /work/vibesys-runs --outer-loop agent --backend cuda --modal --profiler torch ...
 ```
 
 Trainium run:
 
 ```bash
-./vs --outer-loop agent --backend trainium --profiler auto ...
+./vs --runs-dir /work/vibesys-runs --outer-loop agent --backend trainium --profiler auto ...
 ```
 
 Over-the-wire service target:
 
 ```bash
 ./vs \
+  --runs-dir /work/vibesys-runs \
   --outer-loop agent \
   --interface service \
   --input examples/<target>
@@ -534,7 +540,7 @@ Over-the-wire service target:
 CPU-only target:
 
 ```bash
-./vs --outer-loop agent --backend cpu --interface service ...
+./vs --runs-dir /work/vibesys-runs --outer-loop agent --backend cpu --interface service ...
 ```
 
 CPU runs support local execution and Docker; use local execution unless you

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,6 +35,13 @@ The main framework boundaries are:
 
 ## Local development
 
+Repository submodules are opt-in. Initialize them only when your work needs the
+vendored sources, using `--checkout` to override their default update policy:
+
+```bash
+git submodule update --init --recursive --checkout
+```
+
 Run the Python checks from the repository root:
 
 ```bash

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -57,8 +57,9 @@ vibesys --headless validate /path/to/input
 ```
 
 Exercise the interactive TUI on each supported platform when promoting a
-release candidate. Coding-agent CLIs and provider credentials remain external
-user prerequisites and must be configured separately.
+release candidate. Git must be installed separately. Coding-agent CLIs and
+provider credentials remain external user prerequisites and must be configured
+separately.
 
 ## Recovery
 

--- a/examples/microservices/hotel-reservation/README.md
+++ b/examples/microservices/hotel-reservation/README.md
@@ -13,7 +13,7 @@ default branch is `master`; the pinned revision already matches the latest
 remote `master` at the time this scenario was added.
 
 ```bash
-git submodule update --init \
+git submodule update --init --checkout \
   examples/microservices/social-network-read-timeline/3rd_party/deathstarbench
 examples/microservices/hotel-reservation/scripts/materialize-reference.sh
 ```

--- a/examples/microservices/hotel-reservation/README.md
+++ b/examples/microservices/hotel-reservation/README.md
@@ -94,6 +94,7 @@ between runs to keep the raw capture small.
 ```bash
 ./vs --outer-loop agent \
   --input examples/microservices/hotel-reservation \
+  --runs-dir "$PWD/exp_env" \
   --exp-name hotel-reservation-opt \
   --backend cpu --interface service \
   --agent-backend cli --cli-provider codex \

--- a/examples/microservices/hotel-reservation/scripts/materialize-reference.sh
+++ b/examples/microservices/hotel-reservation/scripts/materialize-reference.sh
@@ -8,7 +8,7 @@ destination="${scenario_dir}/hotelReservation"
 
 if [[ ! -f "${source_dir}/docker-compose.yml" ]]; then
   echo "DeathStarBench is not initialized at ${source_dir}" >&2
-  echo "Run: git submodule update --init examples/microservices/social-network-read-timeline/3rd_party/deathstarbench" >&2
+  echo "Run: git submodule update --init --checkout examples/microservices/social-network-read-timeline/3rd_party/deathstarbench" >&2
   exit 1
 fi
 if [[ -e "${destination}" ]]; then

--- a/examples/microservices/social-network-read-timeline/README.md
+++ b/examples/microservices/social-network-read-timeline/README.md
@@ -51,9 +51,11 @@ Clone this repo, then explicitly initialize the submodule:
 DeathStarBench is tracked as a git submodule at `3rd_party/deathstarbench`. It must be initialised on first clone:
 
 ```bash
-git clone <your-fork-url>
-cd social-network-read-timeline
-git submodule update --init --recursive --checkout
+git clone <your-fork-url> vibesys
+cd vibesys
+git submodule update --init --checkout \
+  examples/microservices/social-network-read-timeline/3rd_party/deathstarbench
+cd examples/microservices/social-network-read-timeline
 ```
 
 To verify if the submodule is properly populated, run the following command: 

--- a/examples/microservices/social-network-read-timeline/README.md
+++ b/examples/microservices/social-network-read-timeline/README.md
@@ -46,19 +46,14 @@ The following 11 checks are used for this service.
 
 Below are instructions to build and run this system.
 
-Clone this repo with the submodule:
+Clone this repo, then explicitly initialize the submodule:
 
 DeathStarBench is tracked as a git submodule at `3rd_party/deathstarbench`. It must be initialised on first clone:
 
 ```bash
-git clone --recurse-submodules <your-fork-url>
+git clone <your-fork-url>
 cd social-network-read-timeline
-```
-
-If you already cloned without `--recurse-submodules`:
-
-```bash
-git submodule update --init --recursive
+git submodule update --init --recursive --checkout
 ```
 
 To verify if the submodule is properly populated, run the following command: 

--- a/examples/model-serving/qwen3-coder-tracelab-h100/README.md
+++ b/examples/model-serving/qwen3-coder-tracelab-h100/README.md
@@ -19,6 +19,7 @@ Start an optimization run with:
 ```bash
 ./vs \
   --input examples/model-serving/qwen3-coder-tracelab-h100 \
+  --runs-dir "$PWD/exp_env" \
   --exp-name qwen3-coder-tracelab-h100 \
   --modal \
   --modal-gpu H100 \

--- a/packaging/release-wheel.Dockerfile
+++ b/packaging/release-wheel.Dockerfile
@@ -6,6 +6,10 @@ COPY --from=uv /uv /usr/local/bin/uv
 COPY vibesys-*.whl /tmp/
 COPY verify_installed_release.py /verify_installed_release.py
 
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV HOME=/tmp/verify-home \
     INSTALL_HOME=/tmp/install-home \
     PATH=/tmp/vibesys-bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "langchain-google-vertexai>=3.2.2",
     "langchain-openai",
     "huggingface_hub",
-    "mcp>=1.0",
+    "mcp>=1.0,<2",
     "modal>=1.4.2",
     "pydantic>=2",
     "pyyaml>=6",

--- a/resources/skills/serving-systems/CLAUDE.md
+++ b/resources/skills/serving-systems/CLAUDE.md
@@ -210,8 +210,8 @@ The `repos/` directory is **excluded** from agent materialization (see `src/vibe
 ## Running the reference repos
 
 ```bash
-git submodule update --init resources/skills/serving-systems/repos       # initialize all
-git submodule update --init resources/skills/serving-systems/repos/vllm  # initialize one
+git submodule update --init --checkout resources/skills/serving-systems/repos       # initialize all
+git submodule update --init --checkout resources/skills/serving-systems/repos/vllm  # initialize one
 git -C resources/skills/serving-systems/repos/vllm pull origin main      # update one
 ```
 

--- a/resources/skills/serving-systems/README.md
+++ b/resources/skills/serving-systems/README.md
@@ -47,7 +47,7 @@ The reference engines (`repos/{vllm,sglang,TensorRT-LLM}/`) are tracked as
 git submodules — initialize with:
 
 ```bash
-git submodule update --init skills/serving-systems/repos
+git submodule update --init --checkout resources/skills/serving-systems/repos
 ```
 
 `update-repos.sh` is the upstream sparse-checkout helper, kept for parity

--- a/resources/skills/serving-systems/references/engines/sglang.md
+++ b/resources/skills/serving-systems/references/engines/sglang.md
@@ -19,7 +19,7 @@ git fetch --depth 1 origin 04b1caf75b3c6f043a979ddce21d43ed07c217a6
 git checkout -q FETCH_HEAD
 ```
 
-(From the vibesys repo root the equivalent is `git submodule update --init skills/serving-systems/repos/sglang`.)
+(From the vibesys repo root the equivalent is `git submodule update --init --checkout resources/skills/serving-systems/repos/sglang`.)
 
 ## Directory map
 

--- a/resources/skills/serving-systems/references/engines/trtllm.md
+++ b/resources/skills/serving-systems/references/engines/trtllm.md
@@ -18,7 +18,7 @@ git fetch --depth 1 origin 0d2bea7c3c99b734a8e09c4c767820e03136a15b
 git checkout -q FETCH_HEAD
 ```
 
-(From the vibesys repo root the equivalent is `git submodule update --init skills/serving-systems/repos/TensorRT-LLM`.)
+(From the vibesys repo root the equivalent is `git submodule update --init --checkout resources/skills/serving-systems/repos/TensorRT-LLM`.)
 
 ## Runtimes
 

--- a/resources/skills/serving-systems/references/engines/vllm.md
+++ b/resources/skills/serving-systems/references/engines/vllm.md
@@ -19,7 +19,7 @@ git fetch --depth 1 origin 0210024ae796446a121f96d2d31053668ac0fd85
 git checkout -q FETCH_HEAD
 ```
 
-(From the vibesys repo root the equivalent is `git submodule update --init skills/serving-systems/repos/vllm`.)
+(From the vibesys repo root the equivalent is `git submodule update --init --checkout resources/skills/serving-systems/repos/vllm`.)
 
 ## Directory map
 

--- a/scripts/verify_installed_release.py
+++ b/scripts/verify_installed_release.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import errno
 import importlib
 import importlib.metadata
-import json
 import os
 import pty
 import select
@@ -225,6 +224,57 @@ def _verify_tui() -> None:
         runtime_root=_RUNTIME_ROOT,
         timeout=60,
     )
+    run_headless_stub_smoke(
+        [executable],
+        env=environment,
+        runtime_root=_RUNTIME_ROOT,
+        timeout=60,
+    )
+
+
+def _write_stub_input(input_root: Path) -> None:
+    input_root.mkdir()
+    (input_root / "OBJECTIVE.md").write_text("Verify the installed release.\n")
+    (input_root / "vibesys.input.toml").write_text(
+        "version = 1\n"
+        "\n"
+        "[agent]\n"
+        'domain = "generic"\n'
+        "\n"
+        "[accuracy]\n"
+        'command = ["python", "-c", "raise SystemExit(0)"]\n'
+        "\n"
+        "[benchmark]\n"
+        'command = ["python", "-c", "raise SystemExit(0)"]\n'
+    )
+
+
+def _stub_smoke_command(
+    command_prefix: list[str],
+    *,
+    input_root: Path,
+    runs_root: Path,
+    headless: bool,
+) -> list[str]:
+    return [
+        *command_prefix,
+        *(["--headless"] if headless else []),
+        "--stub-agent",
+        "--input",
+        str(input_root),
+        "--exp-name",
+        "installed-release-smoke",
+        "--max-rounds",
+        "1",
+        "--local",
+        "--no-skills",
+        "--backend",
+        "cpu",
+        "--profiler",
+        "none",
+        "--runs-dir",
+        str(runs_root),
+    ]
 
 
 def run_interactive_tui_smoke(
@@ -235,60 +285,58 @@ def run_interactive_tui_smoke(
     timeout: int,
 ) -> None:
     """Run the installed interactive CLI through a PTY until controller startup."""
-    mutable_prefix_paths_before = _mutable_install_paths(Path(sys.prefix))
     with tempfile.TemporaryDirectory(prefix="vibesys-tui-smoke-", dir=runtime_root) as temporary:
         smoke_root = Path(temporary)
         input_root = smoke_root / "input"
-        input_root.mkdir()
-        (input_root / "OBJECTIVE.md").write_text("Verify installed interactive startup.\n")
-        python_literal = json.dumps(sys.executable)
-        (input_root / "vibesys.input.toml").write_text(
-            "version = 1\n"
-            "\n"
-            "[agent]\n"
-            'domain = "generic"\n'
-            "\n"
-            "[accuracy]\n"
-            f'command = [{python_literal}, "-c", "raise SystemExit(0)"]\n'
-            "\n"
-            "[benchmark]\n"
-            f'command = [{python_literal}, "-c", "raise SystemExit(0)"]\n'
-        )
+        _write_stub_input(input_root)
         marker = smoke_root / "controller-started"
         runs_root = smoke_root / "runs"
         smoke_environment = {**env, TUI_SMOKE_MARKER_ENV: str(marker)}
-        command = [
-            *command_prefix,
-            "--stub-agent",
-            "--input",
-            str(input_root),
-            "--exp-name",
-            "installed-release-smoke",
-            "--max-rounds",
-            "1",
-            "--local",
-            "--no-skills",
-            "--backend",
-            "cpu",
-            "--profiler",
-            "none",
-            "--runs-dir",
-            str(runs_root),
-        ]
+        command = _stub_smoke_command(
+            command_prefix,
+            input_root=input_root,
+            runs_root=runs_root,
+            headless=False,
+        )
         _run_in_pty(command, env=smoke_environment, timeout=timeout)
         if not marker.is_file() or marker.read_text() != TUI_SMOKE_MARKER_CONTENT:
             _fail("Interactive TUI did not write its control-protocol marker")
+
+
+def run_headless_stub_smoke(
+    command_prefix: list[str],
+    *,
+    env: dict[str, str],
+    runtime_root: Path,
+    timeout: int,
+) -> None:
+    """Run the installed headless stub loop to completion in an explicit collection."""
+    mutable_prefix_paths_before = _mutable_install_paths(Path(sys.prefix))
+    with tempfile.TemporaryDirectory(
+        prefix="vibesys-headless-smoke-", dir=runtime_root
+    ) as temporary:
+        smoke_root = Path(temporary)
+        input_root = smoke_root / "input"
+        _write_stub_input(input_root)
+        runs_root = smoke_root / "runs"
+        command = _stub_smoke_command(
+            command_prefix,
+            input_root=input_root,
+            runs_root=runs_root,
+            headless=True,
+        )
+        _run(command, env=env, timeout=timeout)
         runs = [
             path
-            for path in runs_root.iterdir()
+            for path in (runs_root.iterdir() if runs_root.is_dir() else ())
             if path.is_dir() and not path.name.startswith((".", "_"))
         ]
         if len(runs) != 1 or not runs[0].name.endswith("-installed-release-smoke"):
-            _fail(f"Interactive TUI did not create its run under {runs_root}: {runs}")
+            _fail(f"Headless smoke did not create exactly one run under {runs_root}: {runs}")
     added_prefix_paths = _mutable_install_paths(Path(sys.prefix)) - mutable_prefix_paths_before
     if added_prefix_paths:
         _fail(
-            "Interactive TUI created a mutable run tree or cache beneath the Python "
+            "Headless smoke created a mutable run tree or cache beneath the Python "
             f"installation prefix: {sorted(added_prefix_paths)}"
         )
 

--- a/scripts/verify_installed_release.py
+++ b/scripts/verify_installed_release.py
@@ -35,6 +35,7 @@ FRAMEWORK_PACKAGES = (
     "vs_loop_state",
     "vs_sandbox",
 )
+REQUIRED_SYSTEM_TOOLS = ("git",)
 SYSTEM_JAVASCRIPT_TOOLS = ("bun", "node", "npm", "pnpm")
 TUI_SMOKE_MARKER_ENV = "VIBESYS_RELEASE_SMOKE_MARKER"
 TUI_SMOKE_MARKER_CONTENT = "renderer initialized; control protocol exchanged\n"
@@ -84,6 +85,7 @@ def _verify_isolated_interpreter() -> None:
         _fail("User-site packages are not disabled")
     if os.environ.get("PYTHONPATH"):
         _fail("PYTHONPATH must be empty")
+    _verify_required_system_tools()
     for executable in SYSTEM_JAVASCRIPT_TOOLS:
         if shutil.which(executable) is not None:
             _fail(f"System JavaScript runtime is present on PATH: {executable}")
@@ -92,6 +94,12 @@ def _verify_isolated_interpreter() -> None:
         _fail(f"HOME must be an empty isolated directory: {home}")
     if Path.cwd().resolve() != _RUNTIME_ROOT:
         _fail(f"Installed verification must run from {_RUNTIME_ROOT}, not {Path.cwd().resolve()}")
+
+
+def _verify_required_system_tools() -> None:
+    for executable in REQUIRED_SYSTEM_TOOLS:
+        if shutil.which(executable) is None:
+            _fail(f"Required system executable is absent from PATH: {executable}")
 
 
 def _verify_framework_imports() -> None:

--- a/scripts/verify_installed_release.py
+++ b/scripts/verify_installed_release.py
@@ -113,11 +113,15 @@ def _verify_framework_imports() -> None:
 
 
 def verify_console_entry_point() -> None:
-    """Exercise the installed ``vibesys`` console script in headless mode."""
+    """Exercise the installed VibeSys console scripts."""
     executable = shutil.which("vibesys")
     if executable is None:
         _fail("Installed vibesys console script is absent from PATH")
     _run([executable, "--headless", "--help"], timeout=30)
+    issue_mcp = shutil.which("vibesys-issue-mcp")
+    if issue_mcp is None:
+        _fail("Installed vibesys-issue-mcp console script is absent from PATH")
+    _run([issue_mcp, "--help"], timeout=30)
 
 
 def _verify_resources() -> None:

--- a/scripts/verify_installed_release.py
+++ b/scripts/verify_installed_release.py
@@ -235,6 +235,7 @@ def run_interactive_tui_smoke(
     timeout: int,
 ) -> None:
     """Run the installed interactive CLI through a PTY until controller startup."""
+    mutable_prefix_paths_before = _mutable_install_paths(Path(sys.prefix))
     with tempfile.TemporaryDirectory(prefix="vibesys-tui-smoke-", dir=runtime_root) as temporary:
         smoke_root = Path(temporary)
         input_root = smoke_root / "input"
@@ -254,6 +255,7 @@ def run_interactive_tui_smoke(
             f'command = [{python_literal}, "-c", "raise SystemExit(0)"]\n'
         )
         marker = smoke_root / "controller-started"
+        runs_root = smoke_root / "runs"
         smoke_environment = {**env, TUI_SMOKE_MARKER_ENV: str(marker)}
         command = [
             *command_prefix,
@@ -270,10 +272,40 @@ def run_interactive_tui_smoke(
             "cpu",
             "--profiler",
             "none",
+            "--runs-dir",
+            str(runs_root),
         ]
         _run_in_pty(command, env=smoke_environment, timeout=timeout)
         if not marker.is_file() or marker.read_text() != TUI_SMOKE_MARKER_CONTENT:
             _fail("Interactive TUI did not write its control-protocol marker")
+        runs = [
+            path
+            for path in runs_root.iterdir()
+            if path.is_dir() and not path.name.startswith((".", "_"))
+        ]
+        if len(runs) != 1 or not runs[0].name.endswith("-installed-release-smoke"):
+            _fail(f"Interactive TUI did not create its run under {runs_root}: {runs}")
+    added_prefix_paths = _mutable_install_paths(Path(sys.prefix)) - mutable_prefix_paths_before
+    if added_prefix_paths:
+        _fail(
+            "Interactive TUI created a mutable run tree or cache beneath the Python "
+            f"installation prefix: {sorted(added_prefix_paths)}"
+        )
+
+
+def _mutable_install_paths(prefix: Path) -> set[Path]:
+    if not prefix.is_dir():
+        return set()
+    mutable_paths: set[Path] = set()
+    for path in prefix.rglob("*"):
+        parts = path.relative_to(prefix).parts
+        if (
+            "exp_env" in parts
+            or ".hf_cache" in parts
+            or any(parts[index : index + 2] == (".cache", "huggingface") for index in range(len(parts) - 1))
+        ):
+            mutable_paths.add(path.resolve())
+    return mutable_paths
 
 
 def _run_in_pty(command: list[str], *, env: dict[str, str], timeout: int) -> None:

--- a/scripts/verify_release_wheel.py
+++ b/scripts/verify_release_wheel.py
@@ -280,8 +280,11 @@ def _verify_metadata(
         raise ReleaseWheelError.invalid_requirement(exc) from exc
     for requirement in actual:
         parsed = Requirement(requirement)
-        if canonicalize_name(parsed.name) in _INTERNAL_DISTRIBUTIONS:
+        canonical_name = canonicalize_name(parsed.name)
+        if canonical_name in _INTERNAL_DISTRIBUTIONS:
             _fail(f"Wheel must not depend on internal distribution {parsed.name}")
+        if canonical_name == "mcp" and parsed.specifier.contains("2.0.0", prereleases=True):
+            _fail("Wheel MCP dependency must exclude MCP 2.0.0")
 
     expected_values = _project_requirements(project)
     expected = Counter(str(Requirement(value)) for value in expected_values)

--- a/src/vibesys/__init__.py
+++ b/src/vibesys/__init__.py
@@ -3,7 +3,7 @@
 This package's ``__init__.py`` is intentionally empty so that submodules
 with lightweight import footprints (notably ``vs_issue_board.mcp``,
 which the plain loop's .mcp.json sandwich spawns inside Docker containers
-that only have ``mcp>=1.0`` installed) don't drag in heavy optional
+that only have ``mcp>=1.0,<2`` installed) don't drag in heavy optional
 dependencies like ``langchain_core`` via package-level re-exports.
 
 Import what you need by full module path, e.g.::

--- a/src/vibesys/agents/cli_docker.py
+++ b/src/vibesys/agents/cli_docker.py
@@ -99,7 +99,7 @@ _COMMON_DOCKER_TOOLING_INSTALL = [
     _RUST_TOOLCHAIN_INSTALL,
     _apt_install("ripgrep", check_bin="rg"),
     _apt_install("python3 python3-pip"),
-    "python3 -m pip install --quiet 'mcp>=1.0'",
+    "python3 -m pip install --quiet 'mcp>=1.0,<2'",
 ]
 
 _DOCKER_INSTALL_COMMANDS: dict[str, list[str]] = {

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -45,6 +45,7 @@ from vibesys.profilers import (
     resolve_profiler_kind,
 )
 from vibesys.render import HeadlessRenderer, output_sink
+from vibesys.repository import validate_experiment_name
 from vibesys.resource_paths import profiler_support_dir
 from vibesys.run import (
     DeviceLease,
@@ -109,6 +110,7 @@ def setup_exp_dir(
     if existing:
         exp_dir = runs_dir / exp_name
     else:
+        validate_experiment_name(exp_name)
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")  # noqa: DTZ005  # tracked: #288
         exp_dir = runs_dir / f"{timestamp}-{uuid.uuid4().hex[:8]}-{exp_name}"
     if existing:

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -100,15 +100,17 @@ exchange, and investigate the refreshed trajectory evidence before making claims
 
 def setup_exp_dir(
     exp_name: str,
-    project_root: Path = PROJECT_ROOT,
-    existing: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
+    *,
+    runs_dir: Path,
+    existing: bool = False,
 ) -> Path:
-    """Create or validate exp_env/<timestamp>-<exp_name>/ directory with git init."""
+    """Create or validate a run directory in the selected collection."""
+    runs_dir = runs_dir.expanduser().resolve()
     if existing:
-        exp_dir = project_root / "exp_env" / exp_name
+        exp_dir = runs_dir / exp_name
     else:
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")  # noqa: DTZ005  # tracked: #288
-        exp_dir = project_root / "exp_env" / f"{timestamp}-{uuid.uuid4().hex[:8]}-{exp_name}"
+        exp_dir = runs_dir / f"{timestamp}-{uuid.uuid4().hex[:8]}-{exp_name}"
     if existing:
         if not exp_dir.is_dir():
             raise FileNotFoundError(f"Experiment directory not found: {exp_dir}")  # noqa: TRY003  # tracked: #288
@@ -238,19 +240,21 @@ def create_run_context(  # noqa: PLR0913  # tracked: #288
     input_path: str,
     accuracy_command: str,
     benchmark_command: str,
+    *,
+    runs_dir: Path,
     workspace_seed: Path | None = None,
     workspace_sources: tuple[WorkspaceSource, ...] = (),
     evaluator_path: Path | None = None,
     hidden_evaluator_path: Path | None = None,
     objective: str | None = None,
-    existing: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
+    existing: bool = False,
     trusted_input_baseline: str | None = None,
-    debug: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
+    debug: bool = False,
     profiler_kind: ProfilerKind = ProfilerKind.AUTO,
     profiler_domain: DomainName = DomainName.LLM_SERVING,
     skills_dirs: list[str] | None = None,
     run_environment: RunEnvironmentSpec | None = None,
-    git_tracking: bool = False,  # noqa: FBT001, FBT002  # tracked: #288
+    git_tracking: bool = False,
     agent_backend: str | None = None,
     cli_provider: str | None = None,
     backend: ComputeBackend = DEFAULT_COMPUTE_BACKEND,
@@ -275,6 +279,7 @@ def create_run_context(  # noqa: PLR0913  # tracked: #288
             input_path=input_path,
             accuracy_command=accuracy_command,
             benchmark_command=benchmark_command,
+            runs_dir=runs_dir,
             workspace_seed=workspace_seed,
             workspace_sources=workspace_sources,
             evaluator_path=evaluator_path,
@@ -321,6 +326,7 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
     input_path: str,
     accuracy_command: str,
     benchmark_command: str,
+    runs_dir: Path,
     workspace_seed: Path | None,
     workspace_sources: tuple[WorkspaceSource, ...],
     evaluator_path: Path | None,
@@ -366,7 +372,8 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
     run_environment_spec = run_environment or make_run_environment_spec()
     environment = build_run_environment(run_environment_spec)
 
-    exp_dir = setup_exp_dir(exp_name, PROJECT_ROOT, existing)
+    runs_dir = runs_dir.expanduser().resolve()
+    exp_dir = setup_exp_dir(exp_name, runs_dir=runs_dir, existing=existing)
 
     log_dir = exp_dir / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
@@ -525,6 +532,7 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
         workspace=workspace_files.root,
         run_environment=environment,
         project_root=PROJECT_ROOT,
+        model_cache_dir=runs_dir / ".cache" / "huggingface",
         log=logger.lprint,
     )
     environment_patch = hooks.prepare(environment_context)

--- a/src/vibesys/domains/environment.py
+++ b/src/vibesys/domains/environment.py
@@ -19,6 +19,7 @@ class EnvironmentContext:  # noqa: D101  # tracked: #288
     workspace: Path
     run_environment: RunEnvironmentCapabilities
     project_root: Path
+    model_cache_dir: Path
     log: Callable[[str], None]
 
 

--- a/src/vibesys/domains/llm_serving/hooks.py
+++ b/src/vibesys/domains/llm_serving/hooks.py
@@ -16,7 +16,7 @@ from vibesys.domains.environment import (
 def _ensure_model_weights(
     ref_dir: Path,
     *,
-    project_root: Path,
+    cache_dir: Path,
     log: Callable[[str], None],
 ) -> None:
     """Ensure model weights exist in ref_dir/model, downloading if needed."""
@@ -41,7 +41,6 @@ def _ensure_model_weights(
         raise ValueError(f"meta.json at {meta_path} missing required 'model_id' field")  # noqa: TRY003  # tracked: #288
 
     revision = meta.get("revision")
-    cache_dir = project_root / ".hf_cache"
     log(f"[model] Weights not found at {model_path}. Downloading {model_id} to {cache_dir}...")
     from huggingface_hub import snapshot_download  # noqa: PLC0415  # tracked: #288
 
@@ -61,7 +60,7 @@ class LLMServingEnvironmentHooks:  # noqa: D101  # tracked: #288
         model_path = ref_path / "model"
         meta_path = ref_path / "meta.json"
         if ctx.run_environment.materialize_local_model_weights or not meta_path.exists():
-            _ensure_model_weights(ref_path, project_root=ctx.project_root, log=ctx.log)
+            _ensure_model_weights(ref_path, cache_dir=ctx.model_cache_dir, log=ctx.log)
 
         bind_mounts: list[EnvironmentBindMount] = []
         if model_path.is_dir() or model_path.is_symlink():

--- a/src/vibesys/loops/__init__.py
+++ b/src/vibesys/loops/__init__.py
@@ -11,6 +11,6 @@ Each subpackage corresponds to one ``--outer-loop`` value:
 
 This package's ``__init__.py`` is intentionally empty so submodules with
 lightweight footprints (e.g. ``loops.plain.mcp_server``, spawned inside
-Docker containers that only have ``mcp>=1.0`` installed) don't drag in
+Docker containers that only have ``mcp>=1.0,<2`` installed) don't drag in
 heavy optional dependencies via package-level re-exports.
 """

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -2121,6 +2121,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     benchmark_command: str,
     objective: str,
     *,
+    runs_dir: Path,
     objectives: list[Objective] | None = None,
     pareto_relative_noise: float = _DEFAULT_PARETO_RELATIVE_NOISE,
     workspace_seed: Path | None = None,
@@ -2210,6 +2211,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     ctx = create_run_context(
         config=config,
         exp_name=exp_name,
+        runs_dir=runs_dir,
         input_path=input_path,
         accuracy_command=accuracy_command,
         benchmark_command=benchmark_command,

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -1230,6 +1230,7 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     benchmark_command: str,
     objective: str,
     *,
+    runs_dir: Path,
     workspace_seed: Path | None = None,
     workspace_sources: tuple[WorkspaceSource, ...] = (),
     evaluator_path: Path | None = None,
@@ -1288,6 +1289,7 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     ctx = create_run_context(
         config=config,
         exp_name=exp_name,
+        runs_dir=runs_dir,
         input_path=input_path,
         accuracy_command=accuracy_command,
         benchmark_command=benchmark_command,

--- a/src/vibesys/loops/plain/loop.py
+++ b/src/vibesys/loops/plain/loop.py
@@ -348,6 +348,7 @@ def run_plain_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     accuracy_command: str,
     benchmark_command: str,
     *,
+    runs_dir: Path,
     workspace_seed: Path | None = None,
     workspace_sources: tuple[WorkspaceSource, ...] = (),
     evaluator_path: Path | None = None,
@@ -383,6 +384,7 @@ def run_plain_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     with create_run_context(
         config=config,
         exp_name=exp_name,
+        runs_dir=runs_dir,
         input_path=input_path,
         accuracy_command=accuracy_command,
         benchmark_command=benchmark_command,

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -120,6 +120,12 @@ def _parse_profiler_kind(value: str) -> ProfilerKind:
         raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
+def _parse_runs_dir(value: str) -> Path:
+    if not value.strip():
+        raise argparse.ArgumentTypeError("must not be empty")  # noqa: TRY003  # tracked: #288
+    return Path(value)
+
+
 # ---------------------------------------------------------------------------
 # Loop selection from argv
 # ---------------------------------------------------------------------------
@@ -340,7 +346,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--runs-dir",
-        type=Path,
+        type=_parse_runs_dir,
         default=None,
         metavar="PATH",
         help="Directory that owns run directories, synthesized inputs, and shared caches.",
@@ -914,7 +920,7 @@ def _build_tui_defaults_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--config", type=Path, default=PROJECT_ROOT / "agent.toml")
     parser.add_argument("--input", type=Path, default=None)
-    parser.add_argument("--runs-dir", type=Path, default=None)
+    parser.add_argument("--runs-dir", type=_parse_runs_dir, default=None)
     parser.add_argument("--exp-name", default=None)
     parser.add_argument("--theme", type=TuiTheme, choices=list(TuiTheme), default=None)
     parser.add_argument("--stub-agent", action="store_true")

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -337,6 +337,13 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
             "vibesys.input.toml with accuracy and benchmark commands."
         ),
     )
+    parser.add_argument(
+        "--runs-dir",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Directory that owns run directories, synthesized inputs, and shared caches.",
+    )
     _add_standalone_input_args(parser)
     parser.add_argument(
         "--exp-name",
@@ -480,7 +487,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--local",
         action="store_true",
-        help="Keep this experiment local under exp_env; do not create or sync GitHub.",
+        help="Keep this experiment local under --runs-dir; do not create or sync GitHub.",
     )
     parser.add_argument(
         "--repo-visibility",
@@ -653,41 +660,65 @@ def _validate_run_environment_profiler(args: argparse.Namespace) -> None:
     )
 
 
-def _resolve_run_dir(run_dir_arg: str) -> str:  # noqa: PLR0911  # tracked: #288
+def _normalize_runs_dir(args: argparse.Namespace) -> None:
+    raw = getattr(args, "runs_dir", None)
+    if raw is None:
+        _configuration_error(
+            "--runs-dir PATH is required for run commands.",
+            code="missing_runs_dir",
+            stage="argument_parsing",
+        )
+    runs_dir = raw.expanduser().resolve()
+    prefix = Path(sys.prefix).resolve()
+    if runs_dir.is_relative_to(prefix):
+        _configuration_error(
+            f"--runs-dir cannot be inside the Python installation prefix {prefix}: {runs_dir}",
+            code="invalid_runs_dir",
+            stage="argument_parsing",
+        )
+    if runs_dir.exists() and not runs_dir.is_dir():
+        _configuration_error(
+            f"--runs-dir is not a directory: {runs_dir}",
+            code="invalid_runs_dir",
+            stage="argument_parsing",
+        )
+    args.runs_dir = runs_dir
+
+
+def _resolve_run_dir(run_dir_arg: str, runs_dir: Path) -> str:
     """Resolve a run directory name.
 
     If *run_dir_arg* is ``"latest"``, find the most recent experiment
-    directory in ``exp_env/``. Otherwise accept either a bare run directory
-    name or a path whose final parent is ``exp_env``.
+    directory in *runs_dir*. Otherwise accept either a bare run directory
+    name or an existing run directory path.
     """
     if run_dir_arg != "latest":
         run_dir_path = Path(run_dir_arg).expanduser()
-        if run_dir_path.parent.name == "exp_env":
-            project_relative = PROJECT_ROOT / run_dir_path
-            if project_relative.is_dir():
-                return run_dir_path.name
         if run_dir_path.is_dir():
             resolved = run_dir_path.resolve()
-            if resolved.parent == (PROJECT_ROOT / "exp_env").resolve():
+            if resolved.parent == runs_dir:
                 return resolved.name
             return str(resolved)
 
-        legacy_path = PROJECT_ROOT / "exp_env" / run_dir_arg
-        if legacy_path.is_dir():
+        collection_path = runs_dir / run_dir_arg
+        if collection_path.is_dir():
             return run_dir_arg
 
         if _is_remote_experiment(run_dir_arg):
-            return _clone_experiment(run_dir_arg)
+            return _clone_experiment(run_dir_arg, runs_dir)
         return run_dir_arg
-    exp_env = PROJECT_ROOT / "exp_env"
-    if not exp_env.is_dir():
+    if not runs_dir.is_dir():
         _configuration_error(
-            "exp_env/ directory does not exist.", code="resume_not_found", stage="resume_resolution"
+            f"Runs directory does not exist: {runs_dir}",
+            code="resume_not_found",
+            stage="resume_resolution",
         )
-    dirs = sorted([d.name for d in exp_env.iterdir() if d.is_dir()])
+    dirs = sorted(
+        d.name for d in runs_dir.iterdir() if d.is_dir() and not d.name.startswith((".", "_"))
+    )
     if not dirs:
         _configuration_error(
-            "No experiment directories found in exp_env/.",
+            f"No experiment directories found in {runs_dir}.",
             code="resume_not_found",
             stage="resume_resolution",
         )
@@ -700,8 +731,8 @@ def _is_remote_experiment(value: str) -> bool:
     )
 
 
-def _clone_experiment(remote: str) -> str:
-    """Clone a remote experiment into ``exp_env/`` and return its run key."""
+def _clone_experiment(remote: str, runs_dir: Path) -> str:
+    """Clone a remote experiment into *runs_dir* and return its run key."""
     repository_name = remote.rstrip("/").rsplit("/", 1)[-1]
     if ":" in repository_name:
         repository_name = repository_name.rsplit(":", 1)[-1]
@@ -713,7 +744,7 @@ def _clone_experiment(remote: str) -> str:
             stage="resume_resolution",
         )
 
-    destination = PROJECT_ROOT / "exp_env" / repository_name
+    destination = runs_dir / repository_name
     destination.parent.mkdir(parents=True, exist_ok=True)
     if destination.exists():
         if not destination.is_dir():
@@ -773,8 +804,8 @@ def _clone_experiment(remote: str) -> str:
     return destination.name
 
 
-def _resume_exp_dir(run_dir_name: str) -> Path:
-    return PROJECT_ROOT / "exp_env" / run_dir_name
+def _resume_exp_dir(run_dir_name: str, runs_dir: Path) -> Path:
+    return runs_dir / run_dir_name
 
 
 def _infer_resume_input(exp_dir: Path) -> Path:
@@ -830,15 +861,15 @@ def _resolve_resume_args(args: argparse.Namespace) -> None:
             stage="argument_parsing",
         )
 
-    run_dir_name = _resolve_run_dir(args.resume)
+    run_dir_name = _resolve_run_dir(args.resume, args.runs_dir)
     args.resume = run_dir_name
     if args.input is not None:
         return
 
-    exp_dir = _resume_exp_dir(run_dir_name)
+    exp_dir = _resume_exp_dir(run_dir_name, args.runs_dir)
     if not exp_dir.is_dir():
         _configuration_error(
-            f"Run directory does not exist: exp_env/{run_dir_name}",
+            f"Run directory does not exist: {exp_dir}",
             code="resume_not_found",
             stage="resume_resolution",
         )
@@ -1202,7 +1233,7 @@ def _synthesize_standalone_input(args: argparse.Namespace) -> Path:
 
     if args.exp_name is None:
         args.exp_name = generate_experiment_name(Path(str(args.input_domain)))
-    destination = PROJECT_ROOT / "exp_env" / "_inputs" / args.exp_name
+    destination = args.runs_dir / "_inputs" / args.exp_name
     try:
         return synthesize_input_bundle(spec, destination)
     except InputSynthesisError as exc:
@@ -1276,14 +1307,14 @@ def _run_agent(args: argparse.Namespace) -> None:
     start_round = args.start_round or 1
 
     if args.resume is not None:
-        run_dir_name = _resolve_run_dir(args.resume)
+        run_dir_name = _resolve_run_dir(args.resume, args.runs_dir)
         exp_name = run_dir_name
         existing = True
-        print(f"Resuming agent run: exp_env/{run_dir_name}/")  # noqa: T201  # tracked: #288
-        exp_dir = PROJECT_ROOT / "exp_env" / run_dir_name
+        exp_dir = _resume_exp_dir(run_dir_name, args.runs_dir)
+        print(f"Resuming agent run: {exp_dir}/")  # noqa: T201  # tracked: #288
         if not exp_dir.is_dir():
             _configuration_error(
-                f"Run directory does not exist: exp_env/{run_dir_name}",
+                f"Run directory does not exist: {exp_dir}",
                 code="resume_not_found",
                 stage="resume_resolution",
             )
@@ -1309,6 +1340,7 @@ def _run_agent(args: argparse.Namespace) -> None:
     success = run_agent_loop(
         config=config,
         exp_name=exp_name,
+        runs_dir=args.runs_dir,
         input_path=str(bundle.root),
         accuracy_command=bundle.accuracy_command_display,
         benchmark_command=bundle.benchmark_command_display,
@@ -1558,6 +1590,7 @@ def _resolve_openevolve_options(
     *,
     existing: bool,
     exp_name: str,
+    runs_dir: Path,
 ) -> tuple[str | None, OpenEvolveSearchConfig | None]:
     from vibesys.loops.evolve.search_policy import (  # noqa: PLC0415  # tracked: #288
         OpenEvolveSearchConfig,
@@ -1568,7 +1601,7 @@ def _resolve_openevolve_options(
     if existing:
         openevolve_defaults = (
             OpenEvolveSearchPolicy.persisted_config(
-                _resume_exp_dir(exp_name) / "logs" / "openevolve"
+                _resume_exp_dir(exp_name, runs_dir) / "logs" / "openevolve"
             )
             or openevolve_defaults
         )
@@ -1604,6 +1637,7 @@ def _restore_openevolve_objectives(
     *,
     existing: bool,
     exp_name: str,
+    runs_dir: Path,
 ) -> list[Objective]:
     if not existing or objectives:
         return objectives
@@ -1612,7 +1646,7 @@ def _restore_openevolve_objectives(
     )
 
     persisted = OpenEvolveSearchPolicy.persisted_objectives(
-        _resume_exp_dir(exp_name) / "logs" / "openevolve"
+        _resume_exp_dir(exp_name, runs_dir) / "logs" / "openevolve"
     )
     return objectives if persisted is None else persisted
 
@@ -1629,15 +1663,18 @@ def _run_evolve(args: argparse.Namespace) -> None:
     existing = False
     exp_name = args.exp_name
     if args.resume is not None:
-        run_dir_name = _resolve_run_dir(args.resume)
+        run_dir_name = _resolve_run_dir(args.resume, args.runs_dir)
         exp_name = run_dir_name
         existing = True
-        print(f"Resuming evolve run: exp_env/{run_dir_name}/")  # noqa: T201  # tracked: #288
+        print(  # noqa: T201  # tracked: #288
+            f"Resuming evolve run: {_resume_exp_dir(run_dir_name, args.runs_dir)}/"
+        )
 
     objectives = _restore_openevolve_objectives(
         objectives,
         existing=existing,
         exp_name=exp_name,
+        runs_dir=args.runs_dir,
     )
     if objectives:
         spec = ", ".join(f"{o.name}({o.direction})" for o in objectives)
@@ -1647,11 +1684,13 @@ def _run_evolve(args: argparse.Namespace) -> None:
         args,
         existing=existing,
         exp_name=exp_name,
+        runs_dir=args.runs_dir,
     )
 
     success = run_evolve_loop(
         config=config,
         exp_name=exp_name,
+        runs_dir=args.runs_dir,
         input_path=str(bundle.root),
         accuracy_command=bundle.accuracy_command_display,
         benchmark_command=bundle.benchmark_command_display,
@@ -1738,12 +1777,11 @@ def _run_plain(args: argparse.Namespace) -> None:
     resume_state: PlainLoopState | None = None
 
     if args.resume is not None:
-        run_dir_name = _resolve_run_dir(args.resume)
+        run_dir_name = _resolve_run_dir(args.resume, args.runs_dir)
         exp_name = run_dir_name
         existing = True
-        print(f"Resuming from: exp_env/{run_dir_name}/")  # noqa: T201  # tracked: #288
-
-        exp_dir = PROJECT_ROOT / "exp_env" / run_dir_name
+        exp_dir = _resume_exp_dir(run_dir_name, args.runs_dir)
+        print(f"Resuming from: {exp_dir}/")  # noqa: T201  # tracked: #288
         log_dir = exp_dir / "logs"
 
         if args.start_round is not None:
@@ -1773,6 +1811,7 @@ def _run_plain(args: argparse.Namespace) -> None:
     success = run_plain_loop(
         config=config,
         exp_name=exp_name,
+        runs_dir=args.runs_dir,
         input_path=str(bundle.root),
         accuracy_command=bundle.accuracy_command_display,
         benchmark_command=bundle.benchmark_command_display,
@@ -1830,6 +1869,7 @@ def parse_cli_invocation(argv: list[str]) -> CliInvocation:
     loop_kind, remaining = _extract_loop_selection(argv)
     command = _LOOP_COMMANDS[loop_kind]
     args = command.build_parser().parse_args(remaining)
+    _normalize_runs_dir(args)
     _resolve_resume_args(args)
     command.validate(args)
     return CliInvocation(loop_kind=loop_kind, args=args)

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -45,6 +45,7 @@ from vibesys.repository import (
     RepositoryVisibility,
     generate_experiment_name,
     repository_name_from_experiment,
+    validate_experiment_name,
 )
 from vibesys.resource_paths import default_skill_roots
 from vibesys.sandbox.run_environment import (
@@ -1241,6 +1242,16 @@ def _synthesize_standalone_input(args: argparse.Namespace) -> Path:
 
 
 def _validate_target_inputs(args: argparse.Namespace) -> None:
+    if args.resume is None and args.exp_name is not None:
+        try:
+            validate_experiment_name(args.exp_name)
+        except ValueError as exc:
+            _configuration_error(
+                str(exc),
+                code="invalid_exp_name",
+                stage="argument_parsing",
+            )
+
     input_arg = getattr(args, "input", None)
     standalone = _standalone_input_dests_set(args)
     synthesized = False

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -914,22 +914,30 @@ def _build_tui_defaults_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--config", type=Path, default=PROJECT_ROOT / "agent.toml")
     parser.add_argument("--input", type=Path, default=None)
+    parser.add_argument("--runs-dir", type=Path, default=None)
     parser.add_argument("--exp-name", default=None)
     parser.add_argument("--theme", type=TuiTheme, choices=list(TuiTheme), default=None)
+    parser.add_argument("--stub-agent", action="store_true")
+    parser.add_argument("--directory-only", action="store_true")
     return parser
 
 
 def _run_tui_defaults(argv: list[str]) -> None:
     args = _build_tui_defaults_parser().parse_args(argv)
-    try:
-        config = load_config(args.config)
-    except (ValueError, FileNotFoundError) as exc:
-        _configuration_error(str(exc), code="config_load_failed", stage="config_loading")
+    if args.stub_agent and not args.config.is_file():
+        config = Config.model_validate(tomllib.loads(_STUB_AGENT_DEFAULT_CONFIG_TEXT))
+    else:
+        try:
+            config = load_config(args.config)
+        except (ValueError, FileNotFoundError) as exc:
+            _configuration_error(str(exc), code="config_load_failed", stage="config_loading")
 
     input_path = args.input.expanduser().resolve() if args.input is not None else None
+    runs_dir = (args.runs_dir or Path.cwd() / "exp_env").expanduser().resolve()
     experiment_name = args.exp_name or generate_experiment_name(input_path)
-    repository_owner = _resolve_repository_owner(config)
+    repository_owner = None if args.directory_only else _resolve_repository_owner(config)
     defaults = InteractiveSetupDefaults(
+        runs_dir=str(runs_dir),
         input_path=str(input_path) if input_path is not None else "",
         experiment_name=experiment_name,
         repository_owner=repository_owner,

--- a/src/vibesys/repository.py
+++ b/src/vibesys/repository.py
@@ -51,6 +51,21 @@ def generate_experiment_name(
     return f"{base}-{timestamp}"
 
 
+def validate_experiment_name(experiment_name: str) -> str:
+    """Require a fresh experiment name to be one safe path component."""
+    if (
+        not experiment_name
+        or experiment_name in {".", ".."}
+        or "/" in experiment_name
+        or "\\" in experiment_name
+    ):
+        raise ValueError(  # noqa: TRY003  # tracked: #288
+            "--exp-name must be a non-empty single path component other than '.' or '..': "
+            f"{experiment_name!r}"
+        )
+    return experiment_name
+
+
 def repository_name_from_experiment(experiment_name: str) -> str:
     """Convert an experiment label into a valid GitHub repository component."""
     name = re.sub(r"[^A-Za-z0-9_.-]+", "-", experiment_name).strip("-._").lower()

--- a/src/vibesys/repository.py
+++ b/src/vibesys/repository.py
@@ -29,6 +29,7 @@ class InteractiveSetupDefaults(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    runs_dir: str
     input_path: str
     experiment_name: str
     repository_owner: str | None

--- a/tests/agents/test_cli_docker.py
+++ b/tests/agents/test_cli_docker.py
@@ -103,6 +103,13 @@ def test_codex_container_installs_luna_capable_cli_version():  # noqa: ANN201  #
 
 
 @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
+def test_editor_container_installs_only_mcp_v1(provider: str) -> None:
+    commands = cli_docker.docker_init_commands(provider)
+
+    assert "python3 -m pip install --quiet 'mcp>=1.0,<2'" in commands
+
+
+@pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
 def test_editor_container_installs_pinned_rust_toolchain(provider: str):  # noqa: ANN201  # tracked: #288
     commands = cli_docker.docker_init_commands(provider)
     rust_install = next(command for command in commands if "rustup-init.sh" in command)

--- a/tests/loops/agent/test_interface_modes.py
+++ b/tests/loops/agent/test_interface_modes.py
@@ -8,6 +8,8 @@ artifact requirements.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from vibesys.domains.base import DomainName, DomainRole
@@ -77,6 +79,7 @@ def test_loop_constants_and_rejects_unknown_interface():  # noqa: ANN201  # trac
             accuracy_command="accuracy-checker",
             benchmark_command="benchmark",
             objective="o",
+            runs_dir=Path("/tmp/vibesys-test-runs"),  # noqa: S108
             interface="native",
         )
 

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -239,6 +239,7 @@ def _invoke_orchestrate(tmp_path, ref_file, runner, **kwargs):  # noqa: ANN001, 
     defaults = dict(  # noqa: C408  # tracked: #288
         config={"model": {"name": "claude-sonnet-4-6"}},
         exp_name="test-orch",
+        runs_dir=tmp_path / "exp_env",
         input_path=str(Path(ref_file).parent),
         accuracy_command="uv run python accuracy_checker/checker.py",
         benchmark_command="uv run python benchmark/benchmark.py",

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -163,6 +163,7 @@ def _invoke_loop(tmp_path, ref_file, runner, **kwargs):  # noqa: ANN001, ANN003,
     defaults = dict(  # noqa: C408  # tracked: #288
         config={"model": {"name": "claude-sonnet-4-6"}},
         exp_name="test-evolve",
+        runs_dir=tmp_path / "exp_env",
         input_path=str(Path(ref_file).parent),
         accuracy_command="uv run python accuracy_checker/checker.py",
         benchmark_command="uv run python benchmark/benchmark.py",
@@ -762,6 +763,7 @@ def test_search_policy_initialization_failure_closes_context(tmp_path):  # noqa:
             "check",
             "benchmark",
             "objective",
+            runs_dir=tmp_path / "exp_env",
             domain=DomainName.GENERIC,
             search_policy="openevolve",
         )
@@ -1145,6 +1147,7 @@ def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test-parallel-subctx",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",

--- a/tests/loops/plain/test_plain_loop.py
+++ b/tests/loops/plain/test_plain_loop.py
@@ -139,6 +139,7 @@ def test_bootstrap_creates_initial_feature_issue_on_first_run(  # noqa: ANN201  
         result = run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -184,6 +185,7 @@ def test_bootstrap_idempotent_on_resume(  # noqa: ANN201  # tracked: #288
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -205,6 +207,7 @@ def test_bootstrap_idempotent_on_resume(  # noqa: ANN201  # tracked: #288
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name=exp_dir.name,
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -242,6 +245,7 @@ def test_judge_pass_closes_issue(mock_build_runner, mock_backend, mock_build, re
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -282,6 +286,7 @@ def test_judge_fail_increments_attempts_and_keeps_open(  # noqa: ANN201  # track
         result = run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -323,6 +328,7 @@ def test_issue_blocks_after_max_attempts_exhausted(  # noqa: ANN201  # tracked: 
         result = run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -409,6 +415,7 @@ def test_judge_invoke_receives_tracker_kwargs(  # noqa: ANN201, PLR0913  # track
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -473,6 +480,7 @@ def test_perf_eval_invoke_receives_tracker_kwargs(  # noqa: ANN201, PLR0913  # t
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -558,6 +566,7 @@ def test_judge_phase_calls_store_reload_after_invoke(  # noqa: ANN201  # tracked
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -604,6 +613,7 @@ def test_implementer_invoke_has_no_tracker_kwargs(  # noqa: ANN201, PLR0913  # t
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -661,6 +671,7 @@ def test_perf_eval_runs_after_drain_complete(  # noqa: ANN201  # tracked: #288
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -714,6 +725,7 @@ def test_resume_with_bootstrap_done_skips_bootstrap_creation(  # noqa: ANN201  #
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -733,6 +745,7 @@ def test_resume_with_bootstrap_done_skips_bootstrap_creation(  # noqa: ANN201  #
         result = run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name=exp_dir.name,
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -780,6 +793,7 @@ def test_resume_retries_previously_blocked_issue(  # noqa: ANN201  # tracked: #2
         result1 = run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -807,6 +821,7 @@ def test_resume_retries_previously_blocked_issue(  # noqa: ANN201  # tracked: #2
         result2 = run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name=exp_dir.name,
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -856,6 +871,7 @@ def test_run_returns_true_when_perf_eval_files_no_issues_after_clean_drain(  # n
         result = run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -895,6 +911,7 @@ def test_state_json_written_with_bootstrap_done_after_run(  # noqa: ANN201  # tr
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -943,6 +960,7 @@ def test_issue_loop_writes_per_issue_markdown_via_callback(  # noqa: ANN201  # t
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -1016,6 +1034,7 @@ def test_implementer_retry_user_prompt_includes_prior_judge_feedback(  # noqa: A
         run_plain_loop(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="test",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(Path(ref_file).parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",

--- a/tests/loops/plain/test_plain_loop_cli.py
+++ b/tests/loops/plain/test_plain_loop_cli.py
@@ -1,5 +1,6 @@
 """Tests for the issue outer-loop CLI parser and main()."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +12,8 @@ from vibesys.main import main
 TARGET_ARGS = [
     "--input",
     "examples/model-serving/Llama-3-8B",
+    "--runs-dir",
+    "/tmp/vibesys-test-runs",  # noqa: S108
 ]
 
 
@@ -128,6 +131,7 @@ class TestMain:
             assert kwargs["max_rounds"] == 7
             assert kwargs["max_attempts_per_issue"] == 4
             assert kwargs["max_issues_per_perf_eval"] == 2
+            assert kwargs["runs_dir"] == Path("/tmp/vibesys-test-runs")  # noqa: S108
 
     def test_main_start_round_overrides_loaded_state(self, tmp_path):  # noqa: ANN001, ANN201, ARG002  # tracked: #288
         with (

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -41,11 +41,15 @@ def _minimal_copy_context(workspace):  # noqa: ANN001, ANN202  # tracked: #288
     return ctx
 
 
-def test_setup_exp_dir_uses_unique_names_for_concurrent_default_runs(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
-    first = setup_exp_dir("test", project_root=tmp_path)
-    second = setup_exp_dir("test", project_root=tmp_path)
+def test_setup_exp_dir_uses_selected_collection_and_unique_names(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    runs_dir = tmp_path / "selected-runs"
+
+    first = setup_exp_dir("test", runs_dir=runs_dir)
+    second = setup_exp_dir("test", runs_dir=runs_dir)
 
     assert first != second
+    assert first.parent == runs_dir
+    assert second.parent == runs_dir
     assert first.name.endswith("-test")
     assert second.name.endswith("-test")
     assert (first / ".git").is_dir()
@@ -262,6 +266,7 @@ def test_run_context_defaults_profiler_support_paths(  # noqa: ANN201  # tracked
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name=f"{profiler_kind}-defaults",
+            runs_dir=project_root / "exp_env",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -292,6 +297,7 @@ def test_cli_context_skips_unused_langchain_model_construction(tmp_path):  # noq
                 "agent": {"backend": "cli", "cli_provider": "codex"},
             },
             exp_name="cli-reasoning",
+            runs_dir=project_root / "exp_env",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -329,6 +335,7 @@ def test_run_context_copies_only_selected_profiler_support(tmp_path, selected): 
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name=f"{selected.value}-support",
+            runs_dir=project_root / "exp_env",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -370,6 +377,7 @@ def test_run_context_generic_auto_resolves_to_macos_profiler(tmp_path):  # noqa:
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="generic-auto-none",
+            runs_dir=project_root / "exp_env",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -404,6 +412,7 @@ def test_run_context_generic_auto_resolves_to_linux_profiler(tmp_path):  # noqa:
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="generic-auto-linux",
+            runs_dir=project_root / "exp_env",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -449,6 +458,7 @@ def test_run_context_fails_fast_when_resolved_profiler_is_unusable(tmp_path):  #
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="generic-auto-linux-unusable",
+            runs_dir=project_root / "exp_env",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -479,6 +489,7 @@ def test_run_context_rejects_generic_explicit_active_profilers(tmp_path, profile
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name=f"generic-{profiler_kind.value}",
+            runs_dir=tmp_path / "exp_env",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -504,6 +515,7 @@ def test_run_context_llm_auto_uses_backend_profiler_and_defaults_support_dir(tmp
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="llm-auto-nsys",
+            runs_dir=project_root / "exp_env",
             input_path=str(ref.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -535,6 +547,7 @@ def test_run_context_noop_environment_hooks_do_not_require_model_artifacts(tmp_p
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="generic-reference-dir",
+            runs_dir=project_root / "exp_env",
             input_path=str(ref_dir.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -636,6 +649,7 @@ def test_run_context_cleans_up_when_agent_runner_construction_fails(tmp_path):  
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="failed-construction",
+            runs_dir=project_root / "exp_env",
             input_path=str(ref.parent),
             accuracy_command="check-accuracy",
             benchmark_command="run-benchmark",
@@ -665,6 +679,7 @@ def test_run_context_tears_down_prepared_hooks_when_workspace_setup_fails(tmp_pa
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="failed-workspace-setup",
+            runs_dir=project_root / "exp_env",
             input_path=str(ref.parent),
             accuracy_command="check-accuracy",
             benchmark_command="run-benchmark",
@@ -730,6 +745,7 @@ def test_run_context_materializes_input_project_path_dependencies(tmp_path):  # 
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="input-local-package",
+            runs_dir=project_root / "exp_env",
             input_path=str(ref_dir.parent),
             accuracy_command="uv run python accuracy_checker/checker.py",
             benchmark_command="uv run python benchmark/benchmark.py",
@@ -788,6 +804,7 @@ def test_run_context_materializes_sdk_deps_from_workspace_seed(tmp_path):  # noq
         create_run_context(
             config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
             exp_name="seed-sdk-dep",
+            runs_dir=project_root / "exp_env",
             input_path=str(input_dir),
             accuracy_command="echo ok",
             benchmark_command="uv run python benchmark/benchmark.py",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -56,6 +56,21 @@ def test_setup_exp_dir_uses_selected_collection_and_unique_names(tmp_path):  # n
     assert (second / ".git").is_dir()
 
 
+@pytest.mark.parametrize(
+    "unsafe_name",
+    ["/absolute", "nested/name", ".", ".."],
+)
+def test_setup_exp_dir_rejects_unsafe_fresh_name(tmp_path, unsafe_name):  # noqa: ANN001, ANN201  # tracked: #288
+    runs_dir = tmp_path / "selected-runs"
+    exp_name = str(tmp_path / "outside") if unsafe_name == "/absolute" else unsafe_name
+
+    with pytest.raises(ValueError, match="single path component"):
+        setup_exp_dir(exp_name, runs_dir=runs_dir)
+
+    assert not runs_dir.exists()
+    assert not (tmp_path / "outside").exists()
+
+
 def test_log_switch_retargets_stderr_tee_and_restores_on_close(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     ctx = object.__new__(_RunContext)
     original_stderr = sys.stderr

--- a/tests/test_distribution_packaging.py
+++ b/tests/test_distribution_packaging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import configparser
 import importlib.util
+import re
 import subprocess
 import tomllib
 import zipfile
@@ -47,6 +48,40 @@ def test_vcs_installs_do_not_initialize_repository_submodules() -> None:
         for section in submodule_sections
         if config.get(section, "update", fallback=None) != "none"
     ] == []
+
+
+def test_tracked_submodule_initialization_commands_override_the_opt_out() -> None:
+    """Adding an ineffective setup command must make the documentation contract fail."""
+    result = subprocess.run(
+        [  # noqa: S607
+            "git",
+            "ls-files",
+            "-z",
+            "--",
+            "*.md",
+            "*.sh",
+            ":(exclude)third_party/**",
+        ],
+        cwd=PROJECT_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    tracked_files = [Path(path) for path in result.stdout.split("\0") if path]
+
+    ineffective_commands = []
+    for relative_path in tracked_files:
+        for line_number, line in enumerate(
+            (PROJECT_ROOT / relative_path).read_text().splitlines(), start=1
+        ):
+            if (
+                re.search(r"\bgit\s+submodule\s+update\b", line)
+                and "--init" in line
+                and "--checkout" not in line
+            ):
+                ineffective_commands.append(f"{relative_path}:{line_number}")
+
+    assert ineffective_commands == []
 
 
 def _load_packaging_support() -> ModuleType:

--- a/tests/test_distribution_packaging.py
+++ b/tests/test_distribution_packaging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import configparser
 import importlib.util
 import subprocess
 import tomllib
@@ -30,6 +31,22 @@ INTERNAL_IMPORT_PACKAGES = {
     "vs_loop_state",
     "vs_sandbox",
 }
+
+
+def test_vcs_installs_do_not_initialize_repository_submodules() -> None:
+    """Removing the opt-out from one submodule must make source installs fail here."""
+    config = configparser.ConfigParser()
+    config.read(PROJECT_ROOT / ".gitmodules")
+
+    submodule_sections = [
+        section for section in config.sections() if section.startswith('submodule "')
+    ]
+    assert submodule_sections
+    assert [
+        section
+        for section in submodule_sections
+        if config.get(section, "update", fallback=None) != "none"
+    ] == []
 
 
 def _load_packaging_support() -> ModuleType:

--- a/tests/test_distribution_packaging.py
+++ b/tests/test_distribution_packaging.py
@@ -117,3 +117,4 @@ def test_built_distribution_caps_dependencies_without_current_intel_macos_wheels
 
     assert str(requirements["cbor2"].specifier) == "<6"
     assert str(requirements["cryptography"].specifier) == "<50"
+    assert str(requirements["mcp"].specifier) == "<2,>=1.0"

--- a/tests/test_distribution_packaging.py
+++ b/tests/test_distribution_packaging.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import configparser
 import importlib.util
 import re
+import shlex
 import subprocess
 import tomllib
 import zipfile
@@ -32,6 +33,21 @@ INTERNAL_IMPORT_PACKAGES = {
     "vs_loop_state",
     "vs_sandbox",
 }
+
+
+def test_headless_readme_examples_select_a_run_collection() -> None:
+    """Removing the explicit collection from a headless example must fail here."""
+    readmes = [
+        PROJECT_ROOT / "examples/microservices/hotel-reservation/README.md",
+        PROJECT_ROOT / "examples/model-serving/qwen3-coder-tracelab-h100/README.md",
+    ]
+
+    for readme in readmes:
+        blocks = re.findall(r"```bash\n(.*?)```", readme.read_text(), flags=re.DOTALL)
+        headless_block = next(block for block in blocks if "--headless" in block)
+        arguments = shlex.split(headless_block.replace("\\\n", " "))
+        runs_index = arguments.index("--runs-dir")
+        assert arguments[runs_index + 1] == "$PWD/exp_env", readme
 
 
 def test_vcs_installs_do_not_initialize_repository_submodules() -> None:

--- a/tests/test_environment_hooks.py
+++ b/tests/test_environment_hooks.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -36,6 +37,7 @@ def _ctx(
             materialize_local_model_weights=materialize_local_model_weights,
         ),
         project_root=tmp_path / "project",
+        model_cache_dir=tmp_path / "runs" / ".cache" / "huggingface",
         log=lambda _msg: None,
     )
 
@@ -88,3 +90,24 @@ def test_llm_serving_hooks_keep_model_in_local_workspace_copy(tmp_path):  # noqa
     )
 
     assert patch.copy_excludes == frozenset()
+
+
+def test_llm_serving_model_download_uses_shared_runs_cache(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    ref_dir = tmp_path / "reference"
+    ref_dir.mkdir()
+    (ref_dir / "meta.json").write_text('{"model_id": "org/model", "revision": "abc"}')
+    downloaded = tmp_path / "downloaded"
+    downloaded.mkdir()
+
+    with patch(
+        "huggingface_hub.snapshot_download",
+        return_value=str(downloaded),
+    ) as snapshot_download:
+        LLMServingEnvironmentHooks().prepare(_ctx(ref_dir, tmp_path))
+
+    snapshot_download.assert_called_once_with(
+        "org/model",
+        revision="abc",
+        cache_dir=str(tmp_path / "runs" / ".cache" / "huggingface"),
+    )
+    assert (ref_dir / "model").resolve() == downloaded

--- a/tests/test_input_synthesis.py
+++ b/tests/test_input_synthesis.py
@@ -150,13 +150,17 @@ def test_standalone_flags_synthesize_bundle(tmp_path, monkeypatch):  # noqa: ANN
             "--input-benchmark-command",
             "python benchmark.py",
             "--no-skills",
+            "--runs-dir",
+            str(tmp_path / "selected-runs"),
         ]
     )
+
+    args.runs_dir = args.runs_dir.resolve()
 
     cli._validate_target_inputs(args)  # noqa: SLF001  # tracked: #288
 
     assert args.exp_name.startswith("llm-serving-")
-    assert args.input == tmp_path / "exp_env" / "_inputs" / args.exp_name
+    assert args.input == tmp_path / "selected-runs" / "_inputs" / args.exp_name
     assert args.input_bundle.domain == DomainName.LLM_SERVING
     assert args.input_bundle.accuracy_command == ("python", "checker.py")
 
@@ -177,6 +181,8 @@ def test_objective_file_is_read(tmp_path, monkeypatch):  # noqa: ANN001, ANN201 
             "checker",
             "--input-benchmark-command",
             "bench",
+            "--runs-dir",
+            str(tmp_path / "runs"),
         ]
     )
 

--- a/tests/test_input_synthesis.py
+++ b/tests/test_input_synthesis.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -14,6 +15,9 @@ from vibesys.input_synthesis import (
     SynthesizedInputSpec,
     synthesize_input_bundle,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _BASE_SPEC = SynthesizedInputSpec(
     objective="Serve the model quickly.",
@@ -163,6 +167,47 @@ def test_standalone_flags_synthesize_bundle(tmp_path, monkeypatch):  # noqa: ANN
     assert args.input == tmp_path / "selected-runs" / "_inputs" / args.exp_name
     assert args.input_bundle.domain == DomainName.LLM_SERVING
     assert args.input_bundle.accuracy_command == ("python", "checker.py")
+
+
+@pytest.mark.parametrize(
+    "unsafe_name",
+    ["/absolute", "nested/name", ".", ".."],
+)
+def test_standalone_flags_reject_unsafe_fresh_experiment_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    unsafe_name: str,
+) -> None:
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    monkeypatch.setattr(cli.sys, "prefix", str(tmp_path / ".venv"))
+    runs_dir = tmp_path / "selected-runs"
+    exp_name = str(tmp_path / "outside") if unsafe_name == "/absolute" else unsafe_name
+
+    with pytest.raises(ConfigurationError) as exc:
+        cli.parse_cli_invocation(
+            [
+                "--outer-loop",
+                "agent",
+                "--runs-dir",
+                str(runs_dir),
+                "--exp-name",
+                exp_name,
+                "--input-objective",
+                "Serve fast.",
+                "--input-domain",
+                "llm-serving",
+                "--input-accuracy-command",
+                "python checker.py",
+                "--input-benchmark-command",
+                "python benchmark.py",
+                "--no-skills",
+            ]
+        )
+
+    assert exc.value.diagnostic.code == "invalid_exp_name"
+    assert not runs_dir.exists()
+    assert not (tmp_path / "outside").exists()
 
 
 def test_objective_file_is_read(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288

--- a/tests/test_installed_release_verifier.py
+++ b/tests/test_installed_release_verifier.py
@@ -59,7 +59,7 @@ def test_sdk_sync_uses_the_running_isolated_interpreter(tmp_path: Path) -> None:
     ]
 
 
-def test_tui_verification_runs_installed_cli_in_a_pty_through_controller_startup(
+def test_tui_verification_checks_controller_startup_and_completed_headless_run(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -79,6 +79,7 @@ def test_tui_verification_runs_installed_cli_in_a_pty_through_controller_startup
 import json
 import os
 import sys
+import tomllib
 from pathlib import Path
 
 arguments = sys.argv[1:]
@@ -86,18 +87,27 @@ input_index = arguments.index("--input")
 input_root = Path(arguments[input_index + 1])
 runs_index = arguments.index("--runs-dir")
 runs_root = Path(arguments[runs_index + 1])
-(runs_root / "20260811-120000-installed-release-smoke").mkdir(parents=True)
+headless = "--headless" in arguments
+if headless:
+    (runs_root / "20260811-120000-installed-release-smoke").mkdir(parents=True)
+else:
+    marker = Path(os.environ["VIBESYS_RELEASE_SMOKE_MARKER"])
+    marker.write_text("renderer initialized; control protocol exchanged\\n")
 normalized_arguments = list(arguments)
 normalized_arguments[input_index + 1] = "<temporary-input>"
 normalized_arguments[runs_index + 1] = "<temporary-runs>"
-Path(os.environ["VIBESYS_TEST_OBSERVED"]).write_text(json.dumps({
+manifest = tomllib.loads((input_root / "vibesys.input.toml").read_text())
+record = {
     "normalized_argv": normalized_arguments,
     "runs_share_smoke_root": runs_root.parent == input_root.parent,
     "input_files": sorted(path.name for path in input_root.iterdir()),
+    "manifest_commands": [manifest["accuracy"]["command"], manifest["benchmark"]["command"]],
     "ttys": [os.isatty(fd) for fd in (0, 1, 2)],
-}))
-marker = Path(os.environ["VIBESYS_RELEASE_SMOKE_MARKER"])
-marker.write_text("renderer initialized; control protocol exchanged\\n")
+}
+observed_path = Path(os.environ["VIBESYS_TEST_OBSERVED"])
+observed = json.loads(observed_path.read_text()) if observed_path.exists() else []
+observed.append(record)
+observed_path.write_text(json.dumps(observed))
 """.replace("__PYTHON__", sys.executable)
     )
     fake_cli.chmod(0o755)
@@ -112,28 +122,43 @@ marker.write_text("renderer initialized; control protocol exchanged\\n")
 
     verifier._verify_tui()  # noqa: SLF001
 
-    assert json.loads(observed.read_text()) == {
-        "normalized_argv": [
-            "--stub-agent",
-            "--input",
-            "<temporary-input>",
-            "--exp-name",
-            "installed-release-smoke",
-            "--max-rounds",
-            "1",
-            "--local",
-            "--no-skills",
-            "--backend",
-            "cpu",
-            "--profiler",
-            "none",
-            "--runs-dir",
-            "<temporary-runs>",
-        ],
-        "runs_share_smoke_root": True,
-        "input_files": ["OBJECTIVE.md", "vibesys.input.toml"],
-        "ttys": [True, True, True],
-    }
+    common_arguments = [
+        "--stub-agent",
+        "--input",
+        "<temporary-input>",
+        "--exp-name",
+        "installed-release-smoke",
+        "--max-rounds",
+        "1",
+        "--local",
+        "--no-skills",
+        "--backend",
+        "cpu",
+        "--profiler",
+        "none",
+        "--runs-dir",
+        "<temporary-runs>",
+    ]
+    valid_commands = [
+        ["python", "-c", "raise SystemExit(0)"],
+        ["python", "-c", "raise SystemExit(0)"],
+    ]
+    assert json.loads(observed.read_text()) == [
+        {
+            "normalized_argv": common_arguments,
+            "runs_share_smoke_root": True,
+            "input_files": ["OBJECTIVE.md", "vibesys.input.toml"],
+            "manifest_commands": valid_commands,
+            "ttys": [True, True, True],
+        },
+        {
+            "normalized_argv": ["--headless", *common_arguments],
+            "runs_share_smoke_root": True,
+            "input_files": ["OBJECTIVE.md", "vibesys.input.toml"],
+            "manifest_commands": valid_commands,
+            "ttys": [False, False, False],
+        },
+    ]
 
 
 def test_interactive_smoke_rejects_clean_exit_before_protocol_exchange(tmp_path: Path) -> None:
@@ -149,7 +174,7 @@ def test_interactive_smoke_rejects_clean_exit_before_protocol_exchange(tmp_path:
         )
 
 
-def test_interactive_smoke_rejects_mutable_run_tree_under_sys_prefix(
+def test_headless_smoke_rejects_mutable_run_tree_under_sys_prefix(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -166,16 +191,41 @@ prefix = Path(os.environ["VIBESYS_TEST_PREFIX"])
 arguments = os.sys.argv[1:]
 runs_root = Path(arguments[arguments.index("--runs-dir") + 1])
 (runs_root / "20260811-120000-installed-release-smoke").mkdir(parents=True)
-Path(os.environ["VIBESYS_RELEASE_SMOKE_MARKER"]).write_text(
-    "renderer initialized; control protocol exchanged\\n"
-)
 """
     )
     monkeypatch.setattr(verifier.sys, "prefix", str(prefix))
     environment = {**os.environ, "VIBESYS_TEST_PREFIX": str(prefix)}
 
     with pytest.raises(verifier.InstalledReleaseError, match="installation prefix"):
-        verifier.run_interactive_tui_smoke(
+        verifier.run_headless_stub_smoke(
+            [sys.executable, str(fake_cli)],
+            env=environment,
+            runtime_root=tmp_path,
+            timeout=5,
+        )
+
+
+@pytest.mark.parametrize("run_count", [0, 2])
+def test_headless_smoke_requires_exactly_one_run_in_selected_collection(
+    tmp_path: Path,
+    run_count: int,
+) -> None:
+    fake_cli = tmp_path / "fake_installed_cli.py"
+    fake_cli.write_text(
+        """\
+import os
+from pathlib import Path
+
+arguments = os.sys.argv[1:]
+runs_root = Path(arguments[arguments.index("--runs-dir") + 1])
+for index in range(int(os.environ["VIBESYS_TEST_RUN_COUNT"])):
+    (runs_root / f"20260811-12000{index}-installed-release-smoke").mkdir(parents=True)
+"""
+    )
+    environment = {**os.environ, "VIBESYS_TEST_RUN_COUNT": str(run_count)}
+
+    with pytest.raises(verifier.InstalledReleaseError, match="exactly one run"):
+        verifier.run_headless_stub_smoke(
             [sys.executable, str(fake_cli)],
             env=environment,
             runtime_root=tmp_path,

--- a/tests/test_installed_release_verifier.py
+++ b/tests/test_installed_release_verifier.py
@@ -22,20 +22,26 @@ def test_runtime_root_uses_the_resolved_filesystem_path(tmp_path: Path) -> None:
     assert verifier.resolved_runtime_root(apparent) == actual.resolve()
 
 
-def test_console_entry_point_runs_installed_command_with_headless_help(
+def test_console_entry_points_run_installed_commands_with_help(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    marker = tmp_path / "args"
-    executable = tmp_path / "vibesys"
-    executable.write_text('#!/bin/sh\nprintf "%s\\n" "$@" > "$VIBESYS_TEST_ARGS"\n')
-    executable.chmod(0o755)
+    vibesys_marker = tmp_path / "vibesys-args"
+    mcp_marker = tmp_path / "mcp-args"
+    vibesys = tmp_path / "vibesys"
+    vibesys.write_text('#!/bin/sh\nprintf "%s\\n" "$@" > "$VIBESYS_TEST_ARGS"\n')
+    vibesys.chmod(0o755)
+    issue_mcp = tmp_path / "vibesys-issue-mcp"
+    issue_mcp.write_text('#!/bin/sh\nprintf "%s\\n" "$@" > "$VIBESYS_MCP_TEST_ARGS"\n')
+    issue_mcp.chmod(0o755)
     monkeypatch.setenv("PATH", str(tmp_path))
-    monkeypatch.setenv("VIBESYS_TEST_ARGS", str(marker))
+    monkeypatch.setenv("VIBESYS_TEST_ARGS", str(vibesys_marker))
+    monkeypatch.setenv("VIBESYS_MCP_TEST_ARGS", str(mcp_marker))
 
     verifier.verify_console_entry_point()
 
-    assert marker.read_text().splitlines() == ["--headless", "--help"]
+    assert vibesys_marker.read_text().splitlines() == ["--headless", "--help"]
+    assert mcp_marker.read_text().splitlines() == ["--help"]
 
 
 def test_sdk_sync_uses_the_running_isolated_interpreter(tmp_path: Path) -> None:

--- a/tests/test_installed_release_verifier.py
+++ b/tests/test_installed_release_verifier.py
@@ -102,8 +102,9 @@ record = {
     "runs_share_smoke_root": runs_root.parent == input_root.parent,
     "input_files": sorted(path.name for path in input_root.iterdir()),
     "manifest_commands": [manifest["accuracy"]["command"], manifest["benchmark"]["command"]],
-    "ttys": [os.isatty(fd) for fd in (0, 1, 2)],
 }
+if not headless:
+    record["ttys"] = [os.isatty(fd) for fd in (0, 1, 2)]
 observed_path = Path(os.environ["VIBESYS_TEST_OBSERVED"])
 observed = json.loads(observed_path.read_text()) if observed_path.exists() else []
 observed.append(record)
@@ -156,7 +157,6 @@ observed_path.write_text(json.dumps(observed))
             "runs_share_smoke_root": True,
             "input_files": ["OBJECTIVE.md", "vibesys.input.toml"],
             "manifest_commands": valid_commands,
-            "ttys": [False, False, False],
         },
     ]
 

--- a/tests/test_installed_release_verifier.py
+++ b/tests/test_installed_release_verifier.py
@@ -59,6 +59,15 @@ def test_sdk_sync_uses_the_running_isolated_interpreter(tmp_path: Path) -> None:
     ]
 
 
+def test_required_system_tools_reject_missing_git(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(verifier.shutil, "which", lambda _executable: None)
+
+    with pytest.raises(verifier.InstalledReleaseError, match="git"):
+        verifier._verify_required_system_tools()  # noqa: SLF001
+
+
 def test_tui_verification_checks_controller_startup_and_completed_headless_run(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_installed_release_verifier.py
+++ b/tests/test_installed_release_verifier.py
@@ -84,12 +84,15 @@ from pathlib import Path
 arguments = sys.argv[1:]
 input_index = arguments.index("--input")
 input_root = Path(arguments[input_index + 1])
+runs_index = arguments.index("--runs-dir")
+runs_root = Path(arguments[runs_index + 1])
+(runs_root / "20260811-120000-installed-release-smoke").mkdir(parents=True)
+normalized_arguments = list(arguments)
+normalized_arguments[input_index + 1] = "<temporary-input>"
+normalized_arguments[runs_index + 1] = "<temporary-runs>"
 Path(os.environ["VIBESYS_TEST_OBSERVED"]).write_text(json.dumps({
-    "argv_without_input_path": [
-        *arguments[:input_index + 1],
-        "<temporary-input>",
-        *arguments[input_index + 2:],
-    ],
+    "normalized_argv": normalized_arguments,
+    "runs_share_smoke_root": runs_root.parent == input_root.parent,
     "input_files": sorted(path.name for path in input_root.iterdir()),
     "ttys": [os.isatty(fd) for fd in (0, 1, 2)],
 }))
@@ -110,7 +113,7 @@ marker.write_text("renderer initialized; control protocol exchanged\\n")
     verifier._verify_tui()  # noqa: SLF001
 
     assert json.loads(observed.read_text()) == {
-        "argv_without_input_path": [
+        "normalized_argv": [
             "--stub-agent",
             "--input",
             "<temporary-input>",
@@ -124,7 +127,10 @@ marker.write_text("renderer initialized; control protocol exchanged\\n")
             "cpu",
             "--profiler",
             "none",
+            "--runs-dir",
+            "<temporary-runs>",
         ],
+        "runs_share_smoke_root": True,
         "input_files": ["OBJECTIVE.md", "vibesys.input.toml"],
         "ttys": [True, True, True],
     }
@@ -138,6 +144,40 @@ def test_interactive_smoke_rejects_clean_exit_before_protocol_exchange(tmp_path:
         verifier.run_interactive_tui_smoke(
             [sys.executable, str(fake_cli)],
             env=os.environ.copy(),
+            runtime_root=tmp_path,
+            timeout=5,
+        )
+
+
+def test_interactive_smoke_rejects_mutable_run_tree_under_sys_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prefix = tmp_path / "isolated-prefix"
+    prefix.mkdir()
+    fake_cli = tmp_path / "fake_installed_cli.py"
+    fake_cli.write_text(
+        """\
+import os
+from pathlib import Path
+
+prefix = Path(os.environ["VIBESYS_TEST_PREFIX"])
+(prefix / "lib" / "exp_env" / "unexpected-run").mkdir(parents=True)
+arguments = os.sys.argv[1:]
+runs_root = Path(arguments[arguments.index("--runs-dir") + 1])
+(runs_root / "20260811-120000-installed-release-smoke").mkdir(parents=True)
+Path(os.environ["VIBESYS_RELEASE_SMOKE_MARKER"]).write_text(
+    "renderer initialized; control protocol exchanged\\n"
+)
+"""
+    )
+    monkeypatch.setattr(verifier.sys, "prefix", str(prefix))
+    environment = {**os.environ, "VIBESYS_TEST_PREFIX": str(prefix)}
+
+    with pytest.raises(verifier.InstalledReleaseError, match="installation prefix"):
+        verifier.run_interactive_tui_smoke(
+            [sys.executable, str(fake_cli)],
+            env=environment,
             runtime_root=tmp_path,
             timeout=5,
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,7 +51,8 @@ def _patch_loop_runner(loop_name: str, runner: Mock):  # noqa: ANN202  # tracked
     return patch.dict(cli._LOOP_COMMANDS, {loop_name: patched})  # noqa: SLF001  # tracked: #288
 
 
-TARGET_ARGS = ["--input", "examples/model-serving/Llama-3-8B"]
+TARGET_INPUT_ARGS = ["--input", "examples/model-serving/Llama-3-8B"]
+TARGET_ARGS = [*TARGET_INPUT_ARGS, "--runs-dir", "/tmp/vibesys-test-runs"]  # noqa: S108
 
 
 def _write_input_bundle(tmp_path: Path) -> Path:
@@ -164,6 +165,61 @@ def test_target_input_defaults_to_none():  # noqa: ANN201  # tracked: #288
     # Standalone-input flags default to None (they synthesize a bundle when set).
     assert args.input_domain is None
     assert args.input_objective is None
+
+
+def test_run_invocation_requires_runs_dir() -> None:
+    with pytest.raises(ConfigurationError) as exc:
+        parse_cli_invocation(["--outer-loop", "agent", *TARGET_INPUT_ARGS])
+
+    assert exc.value.diagnostic.code == "missing_runs_dir"
+    assert "--runs-dir PATH is required" in exc.value.diagnostic.message
+
+
+def test_runs_dir_is_normalized_to_an_absolute_collection_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = _write_input_bundle(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    invocation = parse_cli_invocation(
+        ["--outer-loop", "agent", "--runs-dir", "runs", "--input", str(bundle)]
+    )
+
+    assert invocation.args.runs_dir == (tmp_path / "runs").resolve()
+
+
+def test_runs_dir_rejects_python_installation_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    prefix = tmp_path / ".venv"
+    monkeypatch.setattr(cli.sys, "prefix", str(prefix))
+
+    with pytest.raises(ConfigurationError) as exc:
+        parse_cli_invocation(
+            ["--outer-loop", "agent", "--runs-dir", str(prefix / "runs"), *TARGET_INPUT_ARGS]
+        )
+
+    assert exc.value.diagnostic.code == "invalid_runs_dir"
+    assert "Python installation prefix" in exc.value.diagnostic.message
+
+
+def test_source_checkout_exp_env_outside_venv_prefix_is_valid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    monkeypatch.setattr(cli.sys, "prefix", str(tmp_path / ".venv"))
+
+    invocation = parse_cli_invocation(
+        ["--outer-loop", "agent", "--runs-dir", str(tmp_path / "exp_env"), *TARGET_INPUT_ARGS]
+    )
+
+    assert invocation.args.runs_dir == (tmp_path / "exp_env").resolve()
 
 
 @pytest.mark.parametrize(
@@ -468,6 +524,7 @@ def test_openevolve_partial_resume_options_merge_with_saved_config(tmp_path):  #
             args,
             existing=True,
             exp_name="run",
+            runs_dir=tmp_path,
         )
 
     assert policy_name == "openevolve"
@@ -495,6 +552,7 @@ def test_openevolve_resume_restores_flag_defined_objectives(tmp_path):  # noqa: 
             [],
             existing=True,
             exp_name="run",
+            runs_dir=tmp_path,
         )
 
     assert restored == expected
@@ -512,6 +570,7 @@ def test_openevolve_override_selects_policy_on_new_run(tmp_path):  # noqa: ANN00
         args,
         existing=False,
         exp_name="new",
+        runs_dir=tmp_path,
     )
 
     assert policy_name == "openevolve"
@@ -1023,7 +1082,16 @@ def test_resume_without_input_infers_original_input(monkeypatch, tmp_path):  # n
     _write_resume_event(run_dir, bundle)
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
 
-    invocation = parse_cli_invocation(["--outer-loop", "agent", "--resume", "20260716-180256-test"])
+    invocation = parse_cli_invocation(
+        [
+            "--outer-loop",
+            "agent",
+            "--runs-dir",
+            str(tmp_path / "exp_env"),
+            "--resume",
+            "20260716-180256-test",
+        ]
+    )
 
     assert invocation.args.resume == "20260716-180256-test"
     assert invocation.args.input == bundle
@@ -1039,7 +1107,14 @@ def test_resume_accepts_exp_env_path_without_input(monkeypatch, tmp_path):  # no
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
 
     invocation = parse_cli_invocation(
-        ["--outer-loop", "agent", "--resume", str(run_dir.relative_to(tmp_path))]
+        [
+            "--outer-loop",
+            "agent",
+            "--runs-dir",
+            str(tmp_path / "exp_env"),
+            "--resume",
+            str(run_dir),
+        ]
     )
 
     assert invocation.args.resume == "20260716-180256-test"
@@ -1064,7 +1139,16 @@ def test_resume_accepts_external_local_clone_and_materialized_input(monkeypatch,
     workspace.rename(experiment / "workspace")
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path / "project")
 
-    invocation = parse_cli_invocation(["--outer-loop", "agent", "--resume", str(experiment)])
+    invocation = parse_cli_invocation(
+        [
+            "--outer-loop",
+            "agent",
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "--resume",
+            str(experiment),
+        ]
+    )
 
     assert invocation.args.resume == str(experiment.resolve())
     assert invocation.args.input_bundle.root == (experiment / "workspace").resolve()
@@ -1086,7 +1170,7 @@ def test_resume_github_repo_clones_into_exp_env(monkeypatch, tmp_path):  # noqa:
 
     monkeypatch.setattr(cli, "GitHubCLI", lambda: GitHubCLI(_runner=fake_run))
 
-    assert _resolve_run_dir("vibesys-playground/trial") == "trial"
+    assert _resolve_run_dir("vibesys-playground/trial", tmp_path / "exp_env") == "trial"
     assert commands == [
         ["gh", "auth", "status", "--hostname", "github.com"],
         ["gh", "repo", "clone", "vibesys-playground/trial", str(tmp_path / "exp_env/trial")],
@@ -1116,7 +1200,7 @@ def test_resume_github_repo_reuses_matching_local_clone(monkeypatch, tmp_path): 
         lambda: pytest.fail("matching local clone should not invoke GitHub CLI"),
     )
 
-    assert _resolve_run_dir("vibesys-playground/trial") == "trial"
+    assert _resolve_run_dir("vibesys-playground/trial", tmp_path / "exp_env") == "trial"
 
 
 def test_resume_github_repo_explains_missing_authentication(monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
@@ -1130,7 +1214,7 @@ def test_resume_github_repo_explains_missing_authentication(monkeypatch, tmp_pat
     monkeypatch.setattr(cli, "GitHubCLI", lambda: GitHubCLI(_runner=fake_run))
 
     with pytest.raises(ConfigurationError) as exc:
-        _resolve_run_dir("vibesys-playground/trial")
+        _resolve_run_dir("vibesys-playground/trial", tmp_path / "exp_env")
 
     assert exc.value.diagnostic.code == "resume_clone_failed"
     assert "gh auth login --hostname github.com" in exc.value.diagnostic.message
@@ -1147,6 +1231,8 @@ def test_resume_rejects_creating_a_second_repository(tmp_path):  # noqa: ANN001,
                 "agent",
                 "--input",
                 str(bundle),
+                "--runs-dir",
+                str(tmp_path / "exp_env"),
                 "--resume",
                 "run",
                 "--repo",
@@ -1166,9 +1252,13 @@ def test_resume_latest_without_input_uses_latest_run_metadata(monkeypatch, tmp_p
     latest = tmp_path / "exp_env" / "20260716-180256-test"
     _write_resume_event(older, older_bundle)
     _write_resume_event(latest, latest_bundle)
+    (tmp_path / "exp_env" / "_inputs").mkdir()
+    (tmp_path / "exp_env" / ".cache").mkdir()
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
 
-    invocation = parse_cli_invocation(["--outer-loop", "agent", "--resume"])
+    invocation = parse_cli_invocation(
+        ["--outer-loop", "agent", "--runs-dir", str(tmp_path / "exp_env"), "--resume"]
+    )
 
     assert invocation.args.resume == "20260716-180256-test"
     assert invocation.args.input_bundle.root == latest_bundle.resolve()
@@ -1180,7 +1270,7 @@ def test_resume_latest_reports_missing_exp_env(monkeypatch, tmp_path):  # noqa: 
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
 
     with pytest.raises(ConfigurationError) as exc:
-        _resolve_run_dir("latest")
+        _resolve_run_dir("latest", tmp_path / "exp_env")
 
     assert exc.value.diagnostic.code == "resume_not_found"
 
@@ -1192,7 +1282,7 @@ def test_resume_latest_reports_empty_exp_env(monkeypatch, tmp_path):  # noqa: AN
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
 
     with pytest.raises(ConfigurationError) as exc:
-        _resolve_run_dir("latest")
+        _resolve_run_dir("latest", tmp_path / "exp_env")
 
     assert exc.value.diagnostic.code == "resume_not_found"
 
@@ -1204,7 +1294,16 @@ def test_resume_without_input_reports_missing_metadata(monkeypatch, tmp_path):  
     monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
 
     with pytest.raises(ConfigurationError) as exc:
-        parse_cli_invocation(["--outer-loop", "agent", "--resume", "20260716-180256-test"])
+        parse_cli_invocation(
+            [
+                "--outer-loop",
+                "agent",
+                "--runs-dir",
+                str(tmp_path / "exp_env"),
+                "--resume",
+                "20260716-180256-test",
+            ]
+        )
 
     assert exc.value.diagnostic.code == "resume_input_not_found"
     assert exc.value.diagnostic.stage == "resume_resolution"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -910,7 +910,11 @@ def test_missing_config_reports_configuration_error(tmp_path):  # noqa: ANN001, 
 # ---------------------------------------------------------------------------
 
 
-def test_tui_defaults_uses_repository_config_and_generated_name(tmp_path, capsys):  # noqa: ANN001, ANN201  # tracked: #288
+def test_tui_defaults_uses_repository_config_and_generated_name(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     import json  # noqa: PLC0415  # tracked: #288
 
     config_path = tmp_path / "agent.toml"
@@ -926,6 +930,7 @@ visibility = "private"
     )
     input_path = tmp_path / "Queue MPSC"
     input_path.mkdir()
+    monkeypatch.chdir(tmp_path)
     argv = [
         "vibesys",
         "tui-defaults",
@@ -944,6 +949,57 @@ visibility = "private"
     assert defaults["experiment_name"].startswith("queue-mpsc-")
     assert defaults["repository_name"] == defaults["experiment_name"]
     assert defaults["theme"] == "dark"
+    assert defaults["runs_dir"] == str((tmp_path / "exp_env").resolve())
+
+
+def test_tui_defaults_resolves_an_explicit_runs_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json  # noqa: PLC0415  # tracked: #288
+
+    monkeypatch.chdir(tmp_path)
+    argv = [
+        "vibesys",
+        "tui-defaults",
+        "--config",
+        str(_write_theme_config(tmp_path, None)),
+        "--runs-dir",
+        "selected-runs",
+    ]
+
+    with patch.object(sys, "argv", argv):
+        main()
+
+    assert json.loads(capsys.readouterr().out)["runs_dir"] == str(
+        (tmp_path / "selected-runs").resolve()
+    )
+
+
+def test_tui_defaults_supports_configless_stub_directory_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json  # noqa: PLC0415  # tracked: #288
+
+    monkeypatch.chdir(tmp_path)
+    argv = [
+        "vibesys",
+        "tui-defaults",
+        "--config",
+        str(tmp_path / "missing.toml"),
+        "--stub-agent",
+        "--directory-only",
+    ]
+
+    with patch.object(sys, "argv", argv):
+        main()
+
+    defaults = json.loads(capsys.readouterr().out)
+    assert defaults["runs_dir"] == str((tmp_path / "exp_env").resolve())
+    assert defaults["repository_owner"] is None
 
 
 def _write_theme_config(tmp_path, theme: str | None) -> Path:  # noqa: ANN001  # tracked: #288

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -175,6 +175,16 @@ def test_run_invocation_requires_runs_dir() -> None:
     assert "--runs-dir PATH is required" in exc.value.diagnostic.message
 
 
+@pytest.mark.parametrize("value", ["", " \t "])
+def test_run_parser_rejects_an_empty_runs_directory(value: str) -> None:
+    with pytest.raises(ConfigurationError) as exc:
+        parse_cli_invocation([f"--runs-dir={value}", *TARGET_INPUT_ARGS])
+
+    assert exc.value.diagnostic.code == "invalid_arguments"
+    assert exc.value.diagnostic.stage == "argument_parsing"
+    assert "--runs-dir" in exc.value.diagnostic.message
+
+
 def test_runs_dir_is_normalized_to_an_absolute_collection_path(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -975,6 +985,18 @@ def test_tui_defaults_resolves_an_explicit_runs_directory(
     assert json.loads(capsys.readouterr().out)["runs_dir"] == str(
         (tmp_path / "selected-runs").resolve()
     )
+
+
+@pytest.mark.parametrize("value", ["", " \t "])
+def test_tui_defaults_parser_rejects_an_empty_runs_directory(value: str) -> None:
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    with pytest.raises(ConfigurationError) as exc:
+        cli._build_tui_defaults_parser().parse_args([f"--runs-dir={value}"])  # noqa: SLF001  # tracked: #288
+
+    assert exc.value.diagnostic.code == "invalid_arguments"
+    assert exc.value.diagnostic.stage == "argument_parsing"
+    assert "--runs-dir" in exc.value.diagnostic.message
 
 
 def test_tui_defaults_supports_configless_stub_directory_selection(

--- a/tests/test_publish_workflow.py
+++ b/tests/test_publish_workflow.py
@@ -77,3 +77,10 @@ def test_docker_check_keeps_runtime_home_clean_during_installation() -> None:
     assert dockerfile.index('find "$INSTALL_HOME"') < dockerfile.index(
         'HOME="$INSTALL_HOME" uv tool install'
     )
+
+
+def test_docker_check_provides_the_git_runtime_prerequisite() -> None:
+    dockerfile = (REPO_ROOT / "packaging" / "release-wheel.Dockerfile").read_text()
+
+    assert "apt-get install --yes --no-install-recommends git" in dockerfile
+    assert "rm -rf /var/lib/apt/lists/*" in dockerfile

--- a/tests/test_release_wheel_verifier.py
+++ b/tests/test_release_wheel_verifier.py
@@ -397,6 +397,21 @@ def test_rejects_a_metadata_version_mismatch(release_fixture: tuple[Path, Path])
         _verify(source_root, wheel)
 
 
+def test_rejects_an_mcp_requirement_that_admits_version_2(
+    release_fixture: tuple[Path, Path],
+) -> None:
+    source_root, wheel = release_fixture
+    project = source_root / "pyproject.toml"
+    project.write_text(project.read_text().replace("example>=1", "mcp>=1.0"))
+    metadata = _wheel_files(source_root)[f"{DIST_INFO}/METADATA"].replace(
+        b"Requires-Dist: example>=1", b"Requires-Dist: mcp>=1.0"
+    )
+    _write_wheel(wheel, source_root, extra={f"{DIST_INFO}/METADATA": metadata})
+
+    with pytest.raises(verifier.ReleaseWheelError, match=r"MCP.*2\.0\.0"):
+        _verify(source_root, wheel)
+
+
 def test_rejects_a_source_digest_mismatch(release_fixture: tuple[Path, Path]) -> None:
     source_root, wheel = release_fixture
     archive_path = f"{PLATLIB}vibesys/__init__.py"

--- a/tests/test_workspace_seed.py
+++ b/tests/test_workspace_seed.py
@@ -102,6 +102,7 @@ def _make_context(input_dir: Path, seed: Path | None = None, **kwargs) -> _RunCo
     return create_run_context(
         config={"model": {"name": "claude-sonnet-4-6"}},  # pyright: ignore[reportArgumentType]  # tracked: #297
         exp_name=kwargs.pop("exp_name", "workspace-seed"),
+        runs_dir=input_dir.parents[2] / "exp_env",
         input_path=str(input_dir),
         accuracy_command="accuracy-checker",
         benchmark_command="benchmark",
@@ -797,7 +798,17 @@ def test_cli_forwards_workspace_sources_to_every_outer_loop(tmp_path, outer_loop
         'dest = "vllm"\n\n'
         '[evaluator]\nsource = "../../evaluators/queue"',
     )
-    argv = ["vibesys", "--outer-loop", outer_loop, "--local", "--input", str(bundle)]
+    runs_dir = tmp_path / "runs"
+    argv = [
+        "vibesys",
+        "--outer-loop",
+        outer_loop,
+        "--local",
+        "--input",
+        str(bundle),
+        "--runs-dir",
+        str(runs_dir),
+    ]
 
     with (
         patch("sys.argv", argv),
@@ -815,6 +826,7 @@ def test_cli_forwards_workspace_sources_to_every_outer_loop(tmp_path, outer_loop
         main()
 
     assert runner.call_args.kwargs["workspace_seed"] == seed.resolve()
+    assert runner.call_args.kwargs["runs_dir"] == runs_dir.resolve()
     assert runner.call_args.kwargs["workspace_sources"] == (
         WorkspaceSource(
             name="vllm",

--- a/uv.lock
+++ b/uv.lock
@@ -4622,7 +4622,7 @@ requires-dist = [
     { name = "langchain-google-vertexai", specifier = ">=3.2.2" },
     { name = "langchain-openai" },
     { name = "loguru", specifier = ">=0.7.2" },
-    { name = "mcp", specifier = ">=1.0" },
+    { name = "mcp", specifier = ">=1.0,<2" },
     { name = "modal", specifier = ">=1.4.2" },
     { name = "omnigent", marker = "extra == 'omnigent'", specifier = "==0.6.0" },
     { name = "openevolve", specifier = "==0.3.1" },


### PR DESCRIPTION
## Problem

Clean installs exposed three release blockers:

- the unconstrained MCP dependency could resolve MCP 2, which is incompatible with the FastMCP API VibeSys uses;
- installed runs could derive mutable experiment paths from the Python installation prefix;
- pip VCS installs initialized large optional repository submodules before building the wheel.

The installed-release smoke also proved only TUI startup, not a completed run in a user-selected collection.

## Solution

- Constrain MCP to `>=1.0,<2` everywhere it is installed, lock it, and enforce the bound in release checks.
- Require `--runs-dir PATH` for run commands. Store fresh runs, synthesized inputs, and the shared Hugging Face cache under that collection while keeping packaged resources and SDK sources immutable.
- Let the TUI suggest an absolute `<cwd>/exp_env`, collect a missing directory in the existing setup flow, and preserve explicit directory choices.
- Mark repository submodules `update = none` so pip VCS installs skip them. Document `--checkout` for contributor workflows that need them and distinguish headless GitHub source installs from native PyPI wheels.
- Split installed verification into a PTY-backed TUI startup check and a completed headless stub run that verifies run placement and installation-prefix cleanliness.

### Architecture

```mermaid
flowchart LR
    TUI["Interactive setup"] --> CLI["Python CLI"]
    Headless["Headless invocation"] --> CLI
    CLI --> Collection["Explicit runs directory"]
    Collection --> Runs["Experiment runs"]
    Collection --> Inputs["Synthesized inputs"]
    Collection --> Cache["Shared Hugging Face cache"]
    Wheel["Installed wheel"] --> Resources["Immutable resources and SDK"]
```

## Verification

Built and statically verified a native Linux x86-64 release wheel, then installed it into separate clean environments with both pip and `uv tool install`. Both installed verifiers passed, including the bundled TUI, MCP entry point, packaged resources, materialized SDK, and one completed stub round outside `sys.prefix`. A clean pip environment imported all 129 packaged modules.

A local pip VCS wheel build from a temporary bare origin skipped all seven live submodule gitlinks and produced the wheel without fetching their remotes.

### Correctness properties

- Resolved dependencies cannot select MCP 2.
- Every fresh run, resume, remote clone, synthesized input, and shared Hugging Face cache is rooted in the selected run collection.
- Fresh experiment names cannot escape or add nested paths beneath the collection.
- Run commands reject missing directories and directories inside `sys.prefix`; help and validation remain directory-independent.
- TUI setup emits exactly one canonical `--runs-dir PATH` and does not prompt for a directory when one was supplied.
- VCS installs skip optional submodules, while explicit contributor initialization still works with `--checkout`.
- Installed verification separately proves interactive startup and completed headless execution.

### Testing

- `uv run pytest` before the final parser/docs-only fix: 3,196 passed, 1 macOS-only skip.
- `uv run pytest -q tests/test_main.py tests/test_distribution_packaging.py` after the final fix: 121 passed.
- `bun 1.3.9 test --max-concurrency 1 src`: 170 passed.
- `./scripts/check_format.sh`: passed.
- `./scripts/check_lint.sh`: passed.
- `uv run pyright`: 0 errors.
- `pnpm run check`: passed.
- `bun 1.3.9 test --max-concurrency 1 src/launcher.test.ts` after the final fix: 7 passed.
- `scripts/build_release_wheel.py` and `scripts/verify_release_wheel.py` for `linux-x86_64`: passed.
- Clean pip install plus `scripts/verify_installed_release.py`: passed.
- Clean `uv tool install` plus `scripts/verify_installed_release.py`: passed.
- Clean installed import sweep: 129 modules imported.
- Local `pip wheel --no-deps git+file://...`: wheel produced, all seven live submodules skipped.
