### PR TITLE
Resolve installed config from launch directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,11 @@ The wheel does not bundle external coding-agent CLIs or their credentials.
 Install the selected Codex, Claude Code, Gemini, or OpenCode CLI separately and
 complete its login flow. For API-backed agents, export the provider credentials
 (for example, `OPENAI_API_KEY`) or load them through your own configuration.
-Pass `--config /path/to/agent.toml` for an installed-only configuration, and
-add `--local` to skip GitHub sync when `gh` is not installed.
+The wheel does not include `agent.toml`. When `--config` is omitted, VibeSys
+loads exactly `./agent.toml` from the working directory where it was launched
+and reports an error if that file is absent. Pass
+`--config /path/to/agent.toml` to override that path. Add `--local` to skip
+GitHub sync when `gh` is not installed.
 
 ## Quickstart
 

--- a/clients/tui/src/launcher.test.ts
+++ b/clients/tui/src/launcher.test.ts
@@ -180,6 +180,8 @@ process.exit(
     tempDir = await mkdtemp(join(tmpdir(), 'vs-launcher-test-'));
     const backendTerminated = join(tempDir, 'backend-terminated');
     const backendArgs = join(tempDir, 'backend-args.json');
+    const defaultsCwd = join(tempDir, 'defaults-cwd');
+    const backendCwd = join(tempDir, 'backend-cwd');
     const backend = await writeExecutable(
       'setup-backend.mjs',
       `
@@ -187,6 +189,7 @@ import {writeFileSync} from 'node:fs';
 import {createServer} from 'node:net';
 
 if (process.argv.includes('tui-defaults')) {
+  writeFileSync(${JSON.stringify(defaultsCwd)}, process.cwd());
   console.log(JSON.stringify({
     runs_dir: '/repo/exp_env',
     input_path: '/repo/examples/queue-spsc',
@@ -198,6 +201,7 @@ if (process.argv.includes('tui-defaults')) {
   }));
   process.exit(0);
 }
+writeFileSync(${JSON.stringify(backendCwd)}, process.cwd());
 writeFileSync(process.env.VIBESYS_FAKE_BACKEND_ARGS_FILE, JSON.stringify(process.argv.slice(2)));
 const socketPath = process.argv[process.argv.indexOf('--control-socket') + 1];
 const server = createServer(socket => {
@@ -255,6 +259,7 @@ process.exit(0);
     const frontendTheme = join(tempDir, 'frontend-theme');
     process.env['VIBESYS_FAKE_SETUP_THEME_FILE'] = setupTheme;
     process.env['VIBESYS_FAKE_FRONTEND_THEME_FILE'] = frontendTheme;
+    process.chdir(tempDir);
 
     await expect(launch(['--input', 'examples/queue-spsc'])).resolves.toBe(0);
     const args = JSON.parse(await readFile(backendArgs, 'utf8')) as string[];
@@ -262,6 +267,8 @@ process.exit(0);
     expect(args[args.indexOf('--runs-dir') + 1]).toBe('/repo/exp_env');
     expect(args).toContain('vibesys-playground/queue-spsc-generated');
     expect(args).toContain('queue-spsc-generated');
+    expect(await readFile(defaultsCwd, 'utf8')).toBe(tempDir);
+    expect(await readFile(backendCwd, 'utf8')).toBe(tempDir);
     expect(await readFile(setupTheme, 'utf8')).toBe('solarized-dark');
     expect(await readFile(frontendTheme, 'utf8')).toBe('solarized-dark');
     await access(backendTerminated);

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -18,6 +18,17 @@ start it:
 Examples in this document use `uv run vibesys`; drop the `uv run` prefix when the
 `vibesys` command is installed (add `--headless` to skip the TUI).
 
+### Agent configuration
+
+`--config PATH` selects an explicit `agent.toml`. When the flag is omitted,
+VibeSys loads exactly `agent.toml` from the process launch working directory. It
+does not search parent directories, and a missing file is an error. The
+internal `--stub-agent` smoke mode is the only configless exception.
+
+`./vs` changes to the source checkout root before launching, so its implicit
+config is the checkout's `agent.toml`. The installed `vibesys` command preserves
+the caller's working directory.
+
 ## Mental Model
 
 Several flags look independent, but they combine into one execution contract:

--- a/libs/vs-issue-board/src/vs_issue_board/mcp.py
+++ b/libs/vs-issue-board/src/vs_issue_board/mcp.py
@@ -32,7 +32,7 @@ def _parse_allowed_types(value: str) -> frozenset[IssueType]:
 
 def build_parser() -> argparse.ArgumentParser:  # noqa: D103  # tracked: #288
     parser = argparse.ArgumentParser(
-        prog="vs-issue-board-mcp",
+        prog="vibesys-issue-mcp",
         description=(
             "Stdio MCP server exposing an IssueBoard as four "
             "tools: list_issues, get_issue, search_issues, create_issue."

--- a/libs/vs-issue-board/tests/test_mcp.py
+++ b/libs/vs-issue-board/tests/test_mcp.py
@@ -39,6 +39,13 @@ async def _call_tool(server, name: str, **kwargs) -> str:  # noqa: ANN001, ANN00
 
 
 class TestArgparse:
+    def test_help_uses_published_console_script_name(self, capsys):  # noqa: ANN001, ANN201
+        with pytest.raises(SystemExit) as exc_info:
+            build_parser().parse_args(["--help"])
+
+        assert exc_info.value.code == 0
+        assert capsys.readouterr().out.startswith("usage: vibesys-issue-mcp ")
+
     def test_defaults(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         args = _ns(tmp_path)
         assert args.store_path == tmp_path / "issues.json"

--- a/scripts/verify_installed_release.py
+++ b/scripts/verify_installed_release.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import errno
 import importlib
 import importlib.metadata
+import json
 import os
 import pty
 import select
@@ -69,12 +70,18 @@ class InstalledReleaseError(RuntimeError):
         """Build an error for a failed PTY-backed interactive check."""
         return cls(f"Installed interactive verification {reason}: {command}\n{output}")
 
+    @classmethod
+    def invalid_first_launch_defaults(cls) -> InstalledReleaseError:
+        """Build an error for malformed installed setup defaults."""
+        return cls("Installed first-launch defaults are not valid JSON")
+
 
 def verify_installed_release() -> None:
     """Exercise the installed framework, SDK, resources, and native TUI."""
     _verify_isolated_interpreter()
     _verify_framework_imports()
     verify_console_entry_point()
+    verify_first_launch_defaults()
     _verify_resources()
     _verify_materialized_sdk()
     _verify_tui()
@@ -129,6 +136,25 @@ def verify_console_entry_point() -> None:
     if issue_mcp is None:
         _fail("Installed vibesys-issue-mcp console script is absent from PATH")
     _run([issue_mcp, "--help"], timeout=30)
+
+
+def verify_first_launch_defaults() -> None:
+    """Require configless setup defaults to work without an authenticated GitHub CLI."""
+    output = _run_capture([sys.executable, "-m", "vibesys", "tui-defaults"], timeout=30)
+    try:
+        defaults = json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise InstalledReleaseError.invalid_first_launch_defaults() from exc
+    if not isinstance(defaults, dict):
+        _fail("Installed first-launch defaults must be a JSON object")
+    runs_dir = defaults.get("runs_dir")
+    expected_runs_dir = (_RUNTIME_ROOT / "exp_env").resolve()
+    if not isinstance(runs_dir, str) or Path(runs_dir).resolve() != expected_runs_dir:
+        _fail(f"Installed first-launch runs directory is invalid: {runs_dir!r}")
+    if defaults.get("input_path") != "":
+        _fail(f"Installed first-launch input path must be empty: {defaults.get('input_path')!r}")
+    if "repository_owner" not in defaults or defaults["repository_owner"] is not None:
+        _fail("Installed first launch unexpectedly requires an authenticated GitHub account")
 
 
 def _verify_resources() -> None:
@@ -358,7 +384,10 @@ def _mutable_install_paths(prefix: Path) -> set[Path]:
         if (
             "exp_env" in parts
             or ".hf_cache" in parts
-            or any(parts[index : index + 2] == (".cache", "huggingface") for index in range(len(parts) - 1))
+            or any(
+                parts[index : index + 2] == (".cache", "huggingface")
+                for index in range(len(parts) - 1)
+            )
         ):
             mutable_paths.add(path.resolve())
     return mutable_paths
@@ -468,6 +497,20 @@ def _run(
         )
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
         raise InstalledReleaseError.command_failed(command) from exc
+
+
+def _run_capture(command: list[str], *, timeout: int) -> str:
+    try:
+        result = subprocess.run(  # noqa: S603
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise InstalledReleaseError.command_failed(command) from exc
+    return result.stdout
 
 
 def _fail(message: str) -> Never:

--- a/scripts/verify_installed_release.py
+++ b/scripts/verify_installed_release.py
@@ -17,7 +17,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Never
+from typing import Never, cast
 
 from vibesys.cli import bundled_tui
 from vibesys.input_project import materialize_input_project
@@ -139,22 +139,63 @@ def verify_console_entry_point() -> None:
 
 
 def verify_first_launch_defaults() -> None:
-    """Require configless setup defaults to work without an authenticated GitHub CLI."""
-    output = _run_capture([sys.executable, "-m", "vibesys", "tui-defaults"], timeout=30)
+    """Require a user-owned launch-directory config and no bundled default config."""
+    distribution_files = importlib.metadata.distribution("vibesys").files or ()
+    if any(Path(str(path)).name == "agent.toml" for path in distribution_files):
+        _fail("Installed VibeSys distribution unexpectedly contains agent.toml")
+    executable = shutil.which("vibesys")
+    if executable is None:
+        _fail("Installed vibesys console script is absent from PATH")
+    config_path = _RUNTIME_ROOT / "agent.toml"
+    if config_path.exists():
+        _fail(f"Installed first launch unexpectedly contains a config file: {config_path}")
+    config_path.write_text(
+        """\
+[model]
+name = "gpt-5.4"
+
+[repository]
+visibility = "public"
+
+[tui]
+theme = "solarized-light"
+"""
+    )
     try:
-        defaults = json.loads(output)
-    except json.JSONDecodeError as exc:
-        raise InstalledReleaseError.invalid_first_launch_defaults() from exc
-    if not isinstance(defaults, dict):
-        _fail("Installed first-launch defaults must be a JSON object")
+        output = _run_capture(
+            [executable, "tui-defaults"],
+            timeout=30,
+        )
+    finally:
+        config_path.unlink()
+    defaults = _parse_first_launch_defaults(output, source="launch-directory")
     runs_dir = defaults.get("runs_dir")
     expected_runs_dir = (_RUNTIME_ROOT / "exp_env").resolve()
     if not isinstance(runs_dir, str) or Path(runs_dir).resolve() != expected_runs_dir:
         _fail(f"Installed first-launch runs directory is invalid: {runs_dir!r}")
     if defaults.get("input_path") != "":
         _fail(f"Installed first-launch input path must be empty: {defaults.get('input_path')!r}")
-    if "repository_owner" not in defaults or defaults["repository_owner"] is not None:
-        _fail("Installed first launch unexpectedly requires an authenticated GitHub account")
+    expected_defaults = {
+        "repository_owner": None,
+        "visibility": "public",
+        "theme": "solarized-light",
+    }
+    for key, expected in expected_defaults.items():
+        if defaults.get(key) != expected:
+            _fail(
+                f"Installed first launch ignored agent.toml from its working directory: "
+                f"{key}={defaults.get(key)!r}"
+            )
+
+
+def _parse_first_launch_defaults(output: str, *, source: str) -> dict[str, object]:
+    try:
+        defaults: object = json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise InstalledReleaseError.invalid_first_launch_defaults() from exc
+    if not isinstance(defaults, dict):
+        _fail(f"Installed {source} defaults must be a JSON object")
+    return cast("dict[str, object]", defaults)
 
 
 def _verify_resources() -> None:

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -74,7 +74,6 @@ _MODALITIES = (
 
 _STUB_AGENT_DEFAULT_INPUT = PROJECT_ROOT / "examples" / "data-structures" / "queue-spsc"
 _STUB_AGENT_DEFAULT_CONFIG_TEXT = '[model]\nname = "gpt-5.5"\n'
-_INSTALLED_DEFAULT_CONFIG_TEXT = '[model]\nname = "gpt-5.4"\n'
 
 
 class _RunArgumentParser(argparse.ArgumentParser):
@@ -364,8 +363,8 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         type=Path,
         default=None,
         help=(
-            "Path to agent TOML config file. When omitted, use the repository agent.toml "
-            "if present, otherwise use installed defaults."
+            "Path to agent TOML config file (default: agent.toml in the launch working "
+            "directory; a missing file is an error)."
         ),
     )
     parser.add_argument(
@@ -559,7 +558,7 @@ def load_config_and_skills(
 ) -> tuple[Config, list[str] | None, ComputeBackend]:
     """Load config, resolve the backend, and select compatible skills."""
     try:
-        config = _load_config_or_installed_default(
+        config = _load_config_or_stub_default(
             args.config,
             stub_agent=getattr(args, "stub_agent", False),
         )
@@ -626,20 +625,20 @@ def _suggest_repository_owner(config: Config) -> str | None:
         return None
 
 
-def _load_config_or_installed_default(
+def _load_config_or_stub_default(
     config_path: Path | None,
     *,
     stub_agent: bool,
 ) -> Config:
-    """Load an explicit config or use safe defaults when the implicit config is absent."""
+    """Load an explicit or launch-directory config, with a stub-only fallback."""
     if config_path is not None:
         return load_config(config_path)
-    selected_path = PROJECT_ROOT / "agent.toml"
+    selected_path = Path.cwd() / "agent.toml"
     if selected_path.is_file():
         return load_config(selected_path)
     if stub_agent:
         return Config.model_validate(tomllib.loads(_STUB_AGENT_DEFAULT_CONFIG_TEXT))
-    return Config.model_validate(tomllib.loads(_INSTALLED_DEFAULT_CONFIG_TEXT))
+    return load_config(selected_path)
 
 
 def _prepare_experiment_repository(args: argparse.Namespace, config: Config) -> None:
@@ -961,7 +960,7 @@ def _build_tui_defaults_parser() -> argparse.ArgumentParser:
 def _run_tui_defaults(argv: list[str]) -> None:
     args = _build_tui_defaults_parser().parse_args(argv)
     try:
-        config = _load_config_or_installed_default(args.config, stub_agent=args.stub_agent)
+        config = _load_config_or_stub_default(args.config, stub_agent=args.stub_agent)
     except (ValueError, FileNotFoundError) as exc:
         _configuration_error(str(exc), code="config_load_failed", stage="config_loading")
 
@@ -1138,7 +1137,10 @@ def _build_agent_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--stub-agent",
         action="store_true",
-        help="Use deterministic local agent responses for fast TUI smoke tests.",
+        help=(
+            "Use deterministic local agent responses for fast TUI smoke tests. This mode "
+            "may run without agent.toml."
+        ),
     )
     parser.add_argument("--start-round", type=int, default=None, metavar="N")
     parser.add_argument(

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -74,6 +74,7 @@ _MODALITIES = (
 
 _STUB_AGENT_DEFAULT_INPUT = PROJECT_ROOT / "examples" / "data-structures" / "queue-spsc"
 _STUB_AGENT_DEFAULT_CONFIG_TEXT = '[model]\nname = "gpt-5.5"\n'
+_INSTALLED_DEFAULT_CONFIG_TEXT = '[model]\nname = "gpt-5.4"\n'
 
 
 class _RunArgumentParser(argparse.ArgumentParser):
@@ -361,8 +362,11 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--config",
         type=Path,
-        default=PROJECT_ROOT / "agent.toml",
-        help="Path to agent TOML config file (default: agent.toml)",
+        default=None,
+        help=(
+            "Path to agent TOML config file. When omitted, use the repository agent.toml "
+            "if present, otherwise use installed defaults."
+        ),
     )
     parser.add_argument(
         "--profiler",
@@ -554,13 +558,13 @@ def load_config_and_skills(
     domain: DomainName,
 ) -> tuple[Config, list[str] | None, ComputeBackend]:
     """Load config, resolve the backend, and select compatible skills."""
-    if getattr(args, "stub_agent", False) and not Path(args.config).is_file():
-        config = Config.model_validate(tomllib.loads(_STUB_AGENT_DEFAULT_CONFIG_TEXT))
-    else:
-        try:
-            config = load_config(args.config)
-        except (ValueError, FileNotFoundError) as e:
-            _configuration_error(str(e), code="config_load_failed", stage="config_loading")
+    try:
+        config = _load_config_or_installed_default(
+            args.config,
+            stub_agent=getattr(args, "stub_agent", False),
+        )
+    except (ValueError, FileNotFoundError) as e:
+        _configuration_error(str(e), code="config_load_failed", stage="config_loading")
 
     repository = getattr(args, "repo", None)
     if getattr(args, "local", False) and repository is not None:
@@ -610,6 +614,32 @@ def _resolve_repository_owner(config: Config) -> str:
             code="repository_setup_failed",
             stage="repository_setup",
         )
+
+
+def _suggest_repository_owner(config: Config) -> str | None:
+    """Return a setup-form owner suggestion without requiring GitHub access."""
+    if config.repository.owner is not None:
+        return config.repository.owner
+    try:
+        return GitHubCLI().current_user()
+    except GitHubCLIError:
+        return None
+
+
+def _load_config_or_installed_default(
+    config_path: Path | None,
+    *,
+    stub_agent: bool,
+) -> Config:
+    """Load an explicit config or use safe defaults when the implicit config is absent."""
+    if config_path is not None:
+        return load_config(config_path)
+    selected_path = PROJECT_ROOT / "agent.toml"
+    if selected_path.is_file():
+        return load_config(selected_path)
+    if stub_agent:
+        return Config.model_validate(tomllib.loads(_STUB_AGENT_DEFAULT_CONFIG_TEXT))
+    return Config.model_validate(tomllib.loads(_INSTALLED_DEFAULT_CONFIG_TEXT))
 
 
 def _prepare_experiment_repository(args: argparse.Namespace, config: Config) -> None:
@@ -918,7 +948,7 @@ def _build_tui_defaults_parser() -> argparse.ArgumentParser:
         prog="vibesys tui-defaults",
         description="Resolve configuration defaults for the pre-launch TUI.",
     )
-    parser.add_argument("--config", type=Path, default=PROJECT_ROOT / "agent.toml")
+    parser.add_argument("--config", type=Path, default=None)
     parser.add_argument("--input", type=Path, default=None)
     parser.add_argument("--runs-dir", type=_parse_runs_dir, default=None)
     parser.add_argument("--exp-name", default=None)
@@ -930,18 +960,15 @@ def _build_tui_defaults_parser() -> argparse.ArgumentParser:
 
 def _run_tui_defaults(argv: list[str]) -> None:
     args = _build_tui_defaults_parser().parse_args(argv)
-    if args.stub_agent and not args.config.is_file():
-        config = Config.model_validate(tomllib.loads(_STUB_AGENT_DEFAULT_CONFIG_TEXT))
-    else:
-        try:
-            config = load_config(args.config)
-        except (ValueError, FileNotFoundError) as exc:
-            _configuration_error(str(exc), code="config_load_failed", stage="config_loading")
+    try:
+        config = _load_config_or_installed_default(args.config, stub_agent=args.stub_agent)
+    except (ValueError, FileNotFoundError) as exc:
+        _configuration_error(str(exc), code="config_load_failed", stage="config_loading")
 
     input_path = args.input.expanduser().resolve() if args.input is not None else None
     runs_dir = (args.runs_dir or Path.cwd() / "exp_env").expanduser().resolve()
     experiment_name = args.exp_name or generate_experiment_name(input_path)
-    repository_owner = None if args.directory_only else _resolve_repository_owner(config)
+    repository_owner = None if args.directory_only else _suggest_repository_owner(config)
     defaults = InteractiveSetupDefaults(
         runs_dir=str(runs_dir),
         input_path=str(input_path) if input_path is not None else "",

--- a/tests/test_distribution_packaging.py
+++ b/tests/test_distribution_packaging.py
@@ -172,6 +172,7 @@ def test_built_distribution_caps_dependencies_without_current_intel_macos_wheels
     )
     wheel = next(tmp_path.glob("vibesys-*.whl"))
     with zipfile.ZipFile(wheel) as archive:
+        assert not any(Path(name).name == "agent.toml" for name in archive.namelist())
         metadata_path = next(
             name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
         )

--- a/tests/test_installed_release_verifier.py
+++ b/tests/test_installed_release_verifier.py
@@ -44,14 +44,19 @@ def test_console_entry_points_run_installed_commands_with_help(
     assert mcp_marker.read_text().splitlines() == ["--help"]
 
 
-def test_first_launch_defaults_are_configless_and_local_capable(
+def test_first_launch_defaults_use_user_owned_launch_directory_configuration(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed: list[tuple[list[str], int]] = []
+    executable = tmp_path / "bin" / "vibesys"
 
     def run_capture(command: list[str], *, timeout: int) -> str:
         observed.append((command, timeout))
+        config_path = tmp_path / "agent.toml"
+        config_text = config_path.read_text()
+        assert 'visibility = "public"' in config_text
+        assert "owner" not in config_text
         return json.dumps(
             {
                 "runs_dir": str(tmp_path / "exp_env"),
@@ -59,17 +64,23 @@ def test_first_launch_defaults_are_configless_and_local_capable(
                 "experiment_name": "experiment-20260811-120000",
                 "repository_owner": None,
                 "repository_name": "experiment-20260811-120000",
-                "visibility": "private",
-                "theme": "dark",
+                "visibility": "public",
+                "theme": "solarized-light",
             }
         )
 
     monkeypatch.setattr(verifier, "_RUNTIME_ROOT", tmp_path)
     monkeypatch.setattr(verifier, "_run_capture", run_capture)
+    monkeypatch.setattr(
+        verifier.shutil,
+        "which",
+        lambda name: str(executable) if name == "vibesys" else None,
+    )
 
     verifier.verify_first_launch_defaults()
 
-    assert observed == [([sys.executable, "-m", "vibesys", "tui-defaults"], 30)]
+    assert observed == [([str(executable), "tui-defaults"], 30)]
+    assert not (tmp_path / "agent.toml").exists()
 
 
 def test_sdk_sync_uses_the_running_isolated_interpreter(tmp_path: Path) -> None:

--- a/tests/test_installed_release_verifier.py
+++ b/tests/test_installed_release_verifier.py
@@ -44,6 +44,34 @@ def test_console_entry_points_run_installed_commands_with_help(
     assert mcp_marker.read_text().splitlines() == ["--help"]
 
 
+def test_first_launch_defaults_are_configless_and_local_capable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[tuple[list[str], int]] = []
+
+    def run_capture(command: list[str], *, timeout: int) -> str:
+        observed.append((command, timeout))
+        return json.dumps(
+            {
+                "runs_dir": str(tmp_path / "exp_env"),
+                "input_path": "",
+                "experiment_name": "experiment-20260811-120000",
+                "repository_owner": None,
+                "repository_name": "experiment-20260811-120000",
+                "visibility": "private",
+                "theme": "dark",
+            }
+        )
+
+    monkeypatch.setattr(verifier, "_RUNTIME_ROOT", tmp_path)
+    monkeypatch.setattr(verifier, "_run_capture", run_capture)
+
+    verifier.verify_first_launch_defaults()
+
+    assert observed == [([sys.executable, "-m", "vibesys", "tui-defaults"], 30)]
+
+
 def test_sdk_sync_uses_the_running_isolated_interpreter(tmp_path: Path) -> None:
     command = verifier.build_sdk_sync_command(tmp_path / "workspace")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -873,17 +873,19 @@ def test_stub_agent_smoke_defaults_preserve_explicit_input():  # noqa: ANN201  #
     assert _prepare_stub_agent_smoke_defaults(argv) == argv
 
 
-def test_stub_agent_can_run_without_agent_toml(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
-    from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
+def test_stub_agent_can_run_without_agent_toml(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    args = _build_agent_parser().parse_args(
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    args = cli._build_agent_parser().parse_args(  # noqa: SLF001  # tracked: #288
         [
             "--stub-agent",
             "--input",
             str(bundle),
-            "--config",
-            str(tmp_path / "missing-agent.toml"),
             "--no-skills",
         ]
     )
@@ -895,12 +897,57 @@ def test_stub_agent_can_run_without_agent_toml(tmp_path):  # noqa: ANN001, ANN20
     assert skills is None
 
 
-def test_missing_config_reports_configuration_error(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+def test_omitted_config_uses_installed_defaults_when_repository_config_is_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    bundle = _write_input_bundle(tmp_path)
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    args = cli._build_agent_parser().parse_args(  # noqa: SLF001  # tracked: #288
+        ["--input", str(bundle), "--local", "--no-skills"]
+    )
+
+    config, skills, _ = load_config_and_skills(args, domain=DomainName.GENERIC)
+
+    assert args.config is None
+    assert config.model.name == "gpt-5.4"
+    assert config.agent.backend is None
+    assert config.agent.cli_provider is None
+    assert skills is None
+
+
+def test_omitted_config_loads_repository_config_when_present(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    bundle = _write_input_bundle(tmp_path)
+    (tmp_path / "agent.toml").write_text('[model]\nname = "repository-model"\n')
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    args = cli._build_agent_parser().parse_args(  # noqa: SLF001  # tracked: #288
+        ["--input", str(bundle), "--local", "--no-skills"]
+    )
+
+    config, _, _ = load_config_and_skills(args, domain=DomainName.GENERIC)
+
+    assert args.config is None
+    assert config.model.name == "repository-model"
+
+
+@pytest.mark.parametrize("stub_args", [[], ["--stub-agent"]])
+def test_missing_explicit_config_reports_configuration_error(
+    tmp_path: Path,
+    stub_args: list[str],
+) -> None:
     from vibesys.main import _build_agent_parser  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
     args = _build_agent_parser().parse_args(
         [
+            *stub_args,
             "--input",
             str(bundle),
             "--config",
@@ -962,6 +1009,51 @@ visibility = "private"
     assert defaults["runs_dir"] == str((tmp_path / "exp_env").resolve())
 
 
+def test_tui_defaults_supports_configless_first_launch_without_github(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json  # noqa: PLC0415  # tracked: #288
+
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    github = Mock()
+    github.current_user.side_effect = cli.GitHubCLIError("GitHub CLI is unavailable")
+    monkeypatch.setattr(cli, "GitHubCLI", Mock(return_value=github))
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    with patch.object(sys, "argv", ["vibesys", "tui-defaults"]):
+        main()
+
+    defaults = json.loads(capsys.readouterr().out)
+    assert defaults["runs_dir"] == str((tmp_path / "exp_env").resolve())
+    assert defaults["input_path"] == ""
+    assert defaults["experiment_name"].startswith("experiment-")
+    assert defaults["repository_owner"] is None
+    assert defaults["repository_name"] == defaults["experiment_name"]
+    assert defaults["visibility"] == "private"
+    assert defaults["theme"] == "dark"
+    github.current_user.assert_called_once_with()
+
+
+def test_tui_defaults_rejects_an_explicit_missing_config(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing = tmp_path / "missing-agent.toml"
+
+    with (
+        patch.object(sys, "argv", ["vibesys", "tui-defaults", "--config", str(missing)]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        main()
+
+    assert exc.value.code == 2
+    assert str(missing) in capsys.readouterr().err
+
+
 def test_tui_defaults_resolves_an_explicit_runs_directory(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1006,12 +1098,13 @@ def test_tui_defaults_supports_configless_stub_directory_selection(
 ) -> None:
     import json  # noqa: PLC0415  # tracked: #288
 
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
     argv = [
         "vibesys",
         "tui-defaults",
-        "--config",
-        str(tmp_path / "missing.toml"),
         "--stub-agent",
         "--directory-only",
     ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -880,7 +880,9 @@ def test_stub_agent_can_run_without_agent_toml(
     import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    launch_dir = tmp_path / "launch"
+    launch_dir.mkdir()
+    monkeypatch.chdir(launch_dir)
     args = cli._build_agent_parser().parse_args(  # noqa: SLF001  # tracked: #288
         [
             "--stub-agent",
@@ -897,36 +899,71 @@ def test_stub_agent_can_run_without_agent_toml(
     assert skills is None
 
 
-def test_omitted_config_uses_installed_defaults_when_repository_config_is_absent(
+def test_config_help_describes_launch_directory_discovery() -> None:
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    help_text = " ".join(
+        cli._build_agent_parser().format_help().split()  # noqa: SLF001  # tracked: #288
+    )
+
+    assert "agent.toml in the launch working directory" in help_text
+    assert "a missing file is an error" in help_text
+
+
+def test_omitted_config_reports_missing_launch_directory_config(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    monkeypatch.chdir(tmp_path)
     args = cli._build_agent_parser().parse_args(  # noqa: SLF001  # tracked: #288
         ["--input", str(bundle), "--local", "--no-skills"]
     )
 
-    config, skills, _ = load_config_and_skills(args, domain=DomainName.GENERIC)
+    with pytest.raises(ConfigurationError) as exc:
+        load_config_and_skills(args, domain=DomainName.GENERIC)
 
-    assert args.config is None
-    assert config.model.name == "gpt-5.4"
-    assert config.agent.backend is None
-    assert config.agent.cli_provider is None
-    assert skills is None
+    assert exc.value.diagnostic.code == "config_load_failed"
+    assert exc.value.diagnostic.stage == "config_loading"
+    assert str(tmp_path / "agent.toml") in exc.value.diagnostic.message
 
 
-def test_omitted_config_loads_repository_config_when_present(
+def test_omitted_config_does_not_search_parent_for_agent_toml(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
 
     bundle = _write_input_bundle(tmp_path)
-    (tmp_path / "agent.toml").write_text('[model]\nname = "repository-model"\n')
-    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "agent.toml").write_text('[model]\nname = "parent-model"\n')
+    launch_dir = tmp_path / "launch"
+    launch_dir.mkdir()
+    monkeypatch.chdir(launch_dir)
+    args = cli._build_agent_parser().parse_args(  # noqa: SLF001  # tracked: #288
+        ["--input", str(bundle), "--local", "--no-skills"]
+    )
+
+    with pytest.raises(ConfigurationError) as exc:
+        load_config_and_skills(args, domain=DomainName.GENERIC)
+
+    assert exc.value.diagnostic.code == "config_load_failed"
+    assert str(launch_dir / "agent.toml") in exc.value.diagnostic.message
+    assert "parent-model" not in exc.value.diagnostic.message
+
+
+def test_omitted_config_loads_launch_directory_config_when_present(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
+
+    bundle = _write_input_bundle(tmp_path)
+    launch_dir = tmp_path / "launch"
+    launch_dir.mkdir()
+    (launch_dir / "agent.toml").write_text('[model]\nname = "launch-model"\n')
+    monkeypatch.chdir(launch_dir)
     args = cli._build_agent_parser().parse_args(  # noqa: SLF001  # tracked: #288
         ["--input", str(bundle), "--local", "--no-skills"]
     )
@@ -934,7 +971,7 @@ def test_omitted_config_loads_repository_config_when_present(
     config, _, _ = load_config_and_skills(args, domain=DomainName.GENERIC)
 
     assert args.config is None
-    assert config.model.name == "repository-model"
+    assert config.model.name == "launch-model"
 
 
 @pytest.mark.parametrize("stub_args", [[], ["--stub-agent"]])
@@ -967,7 +1004,7 @@ def test_missing_explicit_config_reports_configuration_error(
 # ---------------------------------------------------------------------------
 
 
-def test_tui_defaults_uses_repository_config_and_generated_name(
+def test_tui_defaults_uses_launch_directory_config_and_generated_name(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -991,8 +1028,6 @@ visibility = "private"
     argv = [
         "vibesys",
         "tui-defaults",
-        "--config",
-        str(config_path),
         "--input",
         str(input_path),
     ]
@@ -1009,7 +1044,7 @@ visibility = "private"
     assert defaults["runs_dir"] == str((tmp_path / "exp_env").resolve())
 
 
-def test_tui_defaults_supports_configless_first_launch_without_github(
+def test_tui_defaults_supports_first_launch_without_github_authentication(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -1021,7 +1056,7 @@ def test_tui_defaults_supports_configless_first_launch_without_github(
     github = Mock()
     github.current_user.side_effect = cli.GitHubCLIError("GitHub CLI is unavailable")
     monkeypatch.setattr(cli, "GitHubCLI", Mock(return_value=github))
-    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
+    (tmp_path / "agent.toml").write_text('[model]\nname = "gpt-5.4"\n')
     monkeypatch.chdir(tmp_path)
 
     with patch.object(sys, "argv", ["vibesys", "tui-defaults"]):
@@ -1036,6 +1071,23 @@ def test_tui_defaults_supports_configless_first_launch_without_github(
     assert defaults["visibility"] == "private"
     assert defaults["theme"] == "dark"
     github.current_user.assert_called_once_with()
+
+
+def test_tui_defaults_reports_missing_launch_directory_config(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch.object(sys, "argv", ["vibesys", "tui-defaults"]),
+        pytest.raises(SystemExit) as exc,
+    ):
+        main()
+
+    assert exc.value.code == 2
+    assert str(tmp_path / "agent.toml") in capsys.readouterr().err
 
 
 def test_tui_defaults_rejects_an_explicit_missing_config(
@@ -1098,10 +1150,7 @@ def test_tui_defaults_supports_configless_stub_directory_selection(
 ) -> None:
     import json  # noqa: PLC0415  # tracked: #288
 
-    import vibesys.main as cli  # noqa: PLC0415  # tracked: #288
-
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(cli, "PROJECT_ROOT", tmp_path)
     argv = [
         "vibesys",
         "tui-defaults",


### PR DESCRIPTION
## Problem

The Linux wheel from the PR's `main`-equivalent build installed successfully in a clean environment, but implicit configuration lookup was tied to the installed runtime prefix. A new user launching `vibesys` from a directory containing their own `agent.toml` could therefore fail on a nonexistent prefix-level config. The wheel should not own or package an `agent.toml`; configuration belongs to the user's launch directory unless they pass `--config`.

The first-launch setup path also treated missing or unauthenticated `gh` as fatal even though the form supports a blank owner for local runs. The secondary installed entry point reported the old `vs-issue-board-mcp` name in `--help` instead of `vibesys-issue-mcp`.

## Solution

- Preserve whether `--config` was explicitly supplied. Explicit paths remain strict.
- When `--config` is omitted, resolve exactly `Path.cwd() / "agent.toml"`. Do not search parent directories or provide a normal built-in fallback. A missing file is an error.
- Keep the configless fallback only for the internal `--stub-agent` release smoke.
- Use the same resolution for TUI defaults and the subsequent backend process, and preserve the launch working directory through the installed launcher.
- Make GitHub owner discovery best-effort only for the setup-form suggestion. Actual remote-run owner resolution remains strict.
- Verify that release wheels contain no `agent.toml`, then create a user-owned config in the clean verifier's working directory and exercise the installed console.
- Report the published MCP console-script name in parser help.

### Architecture

```mermaid
flowchart LR
    Launch["Installed vibesys"] --> Cwd["Preserve launch cwd"]
    Cwd --> Defaults["TUI defaults"]
    Cwd --> Backend["Backend process"]
    Defaults --> Config{"--config supplied?"}
    Backend --> Config
    Config -->|yes| Explicit["Load explicit path strictly"]
    Config -->|no| Local["Load cwd/agent.toml strictly"]
    Local --> Owner["Best-effort owner suggestion"]
    Owner --> Form["Setup form, blank owner permits local mode"]
```

## Verification

The original wheel was installed under an empty home and isolated tool directories. Help, validation, and stub smoke worked, but normal implicit configuration resolved to a missing installed-prefix `agent.toml`; setup defaults also failed without `gh`, and MCP help displayed the wrong program name.

After the fix and a rebase onto the unified launcher now on `main`, a native Linux wheel was rebuilt with pinned Bun 1.3.9, structurally verified, audited, and installed in the Docker clean room. The installed verifier confirmed that the wheel has no `agent.toml`, wrote a user-owned config in the launch directory, read its nondefault values through `vibesys tui-defaults`, tolerated absent `gh` for the owner suggestion, and completed a one-round stub smoke.

### Correctness properties

- Release wheels contain no file named `agent.toml`.
- An explicit config path is loaded strictly.
- An omitted config resolves exactly to `./agent.toml` in the launch working directory, with no ancestor search.
- A missing implicit config is an error for normal runs. Only `--stub-agent` may run configless.
- TUI defaults and the backend observe the same launch working directory.
- Missing GitHub authentication only clears the setup owner suggestion. Remote execution still requires a resolvable owner.
- Console help names the installed `vibesys-issue-mcp` entry point.

### Testing

- `uv run pytest --no-cov tests/test_main.py tests/test_installed_release_verifier.py tests/test_distribution_packaging.py libs/vs-issue-board/tests/test_mcp.py tests/test_cli_launcher.py`: 184 passed.
- `pnpm --dir clients/tui exec bun test src/launcher.test.ts`: 7 passed.
- `pnpm check:ts && pnpm --dir clients/tui check`: passed.
- `./scripts/check_format.sh && ./scripts/check_lint.sh && ./scripts/check_types.sh`: passed, 0 type errors.
- `scripts/build_release_wheel.py`, `scripts/verify_release_wheel.py`, and `scripts/audit_release_wheel.py` for `linux-x86_64`: passed on the rebased tree.
- `./scripts/test_release_wheel.sh <rebased-wheel>`: installed release verification passed in Docker.
- Full repository `uv run pytest` was not run. The affected CLI, launcher, packaging, installed-verifier, native-wheel, and clean-container checks were run instead.
