### PR TITLE
Wire microservice critical paths into VibeSys

### DIFF
--- a/examples/microservices/hotel-reservation/README.md
+++ b/examples/microservices/hotel-reservation/README.md
@@ -69,7 +69,7 @@ injected one and add the telemetry flags:
 
 ```bash
 SCENARIO="$PWD/examples/microservices/hotel-reservation"
-go -C examples/evaluators/microservice run ./cmd/servicebench \
+go -C examples/evaluators/microservice run ./cmd/servicebench trace \
   --workload "$SCENARIO/benchmark/workload.toml" \
   --seed random \
   --fixture-seed random \
@@ -80,12 +80,14 @@ go -C examples/evaluators/microservice run ./cmd/servicebench \
   --startup-timeout 120 \
   --telemetry-command-json "[\"go\",\"run\",\"./cmd/otelcapture\",\"--input-json\",\"$SCENARIO/metrics/otel/traces.otlp.ndjson\",\"--settle-seconds\",\"5\"]" \
   --telemetry-output /tmp/hotel-telemetry.json \
+  --trace-graph-json /tmp/hotel-trace-graph.json \
   --telemetry-timeout 60 \
   --output-json /tmp/hotel-benchmark.json
 ```
 
 A successful run writes the normalized report to `/tmp/hotel-telemetry.json`
-and embeds it in the benchmark output. Remove
+and the schema-v2 critical-path graph to `/tmp/hotel-trace-graph.json`, and
+embeds normalized telemetry in the benchmark output. Remove
 `examples/microservices/hotel-reservation/metrics/otel/traces.otlp.ndjson`
 between runs to keep the raw capture small.
 
@@ -96,6 +98,7 @@ between runs to keep the raw capture small.
   --input examples/microservices/hotel-reservation \
   --exp-name hotel-reservation-opt \
   --backend cpu --interface service \
+  --profiler otel \
   --agent-backend cli --cli-provider codex \
   --max-rounds 10 --git-tracking --headless
 ```

--- a/examples/microservices/hotel-reservation/vibesys.input.toml
+++ b/examples/microservices/hotel-reservation/vibesys.input.toml
@@ -25,6 +25,7 @@ timeout_seconds = 300
 command = [
   "go", "-C", "_evaluator/microservice",
   "run", "./cmd/servicebench",
+  "trace",
   "--workload", "../../benchmark/workload.toml",
   "--seed", "random",
   "--fixture-seed", "random",
@@ -35,6 +36,7 @@ command = [
   "--startup-timeout", "120",
   "--telemetry-command-json", "[\"go\",\"run\",\"./cmd/otelcapture\",\"--input-json\",\"../../metrics/otel/traces.otlp.ndjson\",\"--settle-seconds\",\"5\"]",
   "--telemetry-output", "../../metrics/telemetry.json",
+  "--trace-graph-json", "../../metrics/trace-graph.json",
   "--telemetry-timeout", "60",
 ]
 timeout_seconds = 360

--- a/resources/profilers/otel/server.py
+++ b/resources/profilers/otel/server.py
@@ -9,6 +9,10 @@ from typing import Literal
 from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, model_validator
 
+_GRAPH_REPORT_MISMATCH = (
+    "trace graph and telemetry report must have matching workload identity and windows"
+)
+
 
 class LatencyRow(BaseModel):  # noqa: D101  # tracked: #288
     model_config = ConfigDict(extra="forbid")
@@ -46,6 +50,276 @@ class MeasurementWindow(BaseModel):  # noqa: D101  # tracked: #288
         end = _parse_timestamp(self.end, "end")
         if end < start:
             raise ValueError("measurement window end must not precede start")  # noqa: TRY003  # tracked: #288
+        return self
+
+
+class LatencyDistribution(BaseModel):
+    """Validated latency distribution used by schema-v2 trace graphs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    count: StrictInt = Field(gt=0)
+    error_count: StrictInt = Field(ge=0)
+    mean_ms: StrictFloat = Field(ge=0)
+    p50_ms: StrictFloat = Field(ge=0)
+    p95_ms: StrictFloat = Field(ge=0)
+    p99_ms: StrictFloat = Field(ge=0)
+    max_ms: StrictFloat = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_distribution(self) -> "LatencyDistribution":  # noqa: D102  # tracked: #288
+        if self.error_count > self.count:
+            raise ValueError("error_count must not exceed count")  # noqa: TRY003  # tracked: #288
+        values = (self.mean_ms, self.p50_ms, self.p95_ms, self.p99_ms, self.max_ms)
+        if not all(math.isfinite(value) for value in values):
+            raise ValueError("latency values must be finite")  # noqa: TRY003  # tracked: #288
+        if self.mean_ms > self.max_ms or not (
+            self.p50_ms <= self.p95_ms <= self.p99_ms <= self.max_ms
+        ):
+            raise ValueError("latency distribution is inconsistent")  # noqa: TRY003  # tracked: #288
+        return self
+
+
+class TraceQuality(BaseModel):
+    """Trace eligibility and correlation quality for a graph artifact."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    captured_traces: StrictInt = Field(gt=0)
+    eligible_traces: StrictInt = Field(gt=0)
+    excluded_traces: StrictInt = Field(ge=0)
+    exclusion_reasons: dict[str, StrictInt] = Field(default_factory=dict)
+    matched_client_server_pairs: StrictInt = Field(ge=0)
+    unmatched_client_spans: StrictInt = Field(ge=0)
+    unmatched_server_spans: StrictInt = Field(ge=0)
+    async_relationships: StrictInt = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_counts(self) -> "TraceQuality":  # noqa: D102  # tracked: #288
+        if self.eligible_traces + self.excluded_traces != self.captured_traces:
+            raise ValueError("eligible and excluded traces must equal captured traces")  # noqa: TRY003  # tracked: #288
+        if any(not reason or count < 0 for reason, count in self.exclusion_reasons.items()):
+            raise ValueError("exclusion reasons must have names and nonnegative counts")  # noqa: TRY003  # tracked: #288
+        return self
+
+
+class TraceTrialQuality(BaseModel):
+    """Trace eligibility counts for one benchmark trial."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    trial: StrictInt = Field(gt=0)
+    captured_traces: StrictInt = Field(ge=0)
+    eligible_traces: StrictInt = Field(ge=0)
+    excluded_traces: StrictInt = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_counts(self) -> "TraceTrialQuality":  # noqa: D102  # tracked: #288
+        if self.eligible_traces + self.excluded_traces != self.captured_traces:
+            raise ValueError("trial eligible and excluded traces must equal captured traces")  # noqa: TRY003  # tracked: #288
+        return self
+
+
+class TraceGraphNode(BaseModel):
+    """One stable service-operation path in a trace graph."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)
+    path: str = Field(min_length=1)
+    service: str = Field(min_length=1)
+    operation: str = Field(min_length=1)
+    kind: str = Field(min_length=1)
+    inclusive_latency_ms: LatencyDistribution
+    exclusive_latency_ms: LatencyDistribution
+
+
+class TraceGraphEdge(BaseModel):
+    """One observed relationship between graph nodes."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    from_node: str = Field(alias="from", min_length=1)
+    to: str = Field(min_length=1)
+    relationship: str = Field(min_length=1)
+    count: StrictInt = Field(gt=0)
+
+
+class WaterfallSpan(BaseModel):
+    """One span in the representative trace waterfall."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    node_id: str = Field(min_length=1)
+    service: str = Field(min_length=1)
+    operation: str = Field(min_length=1)
+    offset_ms: StrictFloat = Field(ge=0)
+    duration_ms: StrictFloat = Field(gt=0)
+
+
+class RepresentativeTrace(BaseModel):
+    """Representative complete trace selected by servicebench."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    trace_id: str = Field(min_length=1)
+    duration_ms: StrictFloat = Field(gt=0)
+    spans: list[WaterfallSpan] = Field(min_length=1)
+
+
+class CriticalPathNodeContribution(BaseModel):
+    """Wall-clock contribution attributed to one graph node."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    node_id: str = Field(min_length=1)
+    path: str = Field(min_length=1)
+    service: str = Field(min_length=1)
+    operation: str = Field(min_length=1)
+    contribution_ms: LatencyDistribution
+
+
+class CriticalPathSegment(BaseModel):
+    """Contiguous segment of a representative synchronous critical path."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    node_id: str = Field(min_length=1)
+    offset_ms: StrictFloat = Field(ge=0)
+    duration_ms: StrictFloat = Field(gt=0)
+
+
+class RepresentativeCriticalPath(BaseModel):
+    """Critical-path decomposition of the representative trace."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    trace_id: str = Field(min_length=1)
+    duration_ms: StrictFloat = Field(gt=0)
+    segments: list[CriticalPathSegment] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_segments(self) -> "RepresentativeCriticalPath":  # noqa: D102  # tracked: #288
+        cursor = 0.0
+        for segment in self.segments:
+            if not math.isclose(segment.offset_ms, cursor, abs_tol=1e-9):
+                raise ValueError("critical path segments must be contiguous")  # noqa: TRY003  # tracked: #288
+            cursor += segment.duration_ms
+        if not math.isclose(cursor, self.duration_ms, abs_tol=1e-9):
+            raise ValueError("critical path segments must cover the representative duration")  # noqa: TRY003  # tracked: #288
+        return self
+
+
+class CriticalPathSummary(BaseModel):
+    """Aggregate synchronous critical-path evidence for one root operation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    algorithm: Literal["wall_clock_active_leaf_v1"]
+    scope: Literal["synchronous_request"]
+    trace_count: StrictInt = Field(gt=0)
+    async_relationships_excluded: StrictInt = Field(ge=0)
+    duration_ms: LatencyDistribution
+    nodes_by_contribution: list[CriticalPathNodeContribution] = Field(min_length=1)
+    representative: RepresentativeCriticalPath
+
+
+class TraceRootGraph(BaseModel):
+    """Aggregated trace graph and critical path for one root operation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    service: str = Field(min_length=1)
+    operation: str = Field(min_length=1)
+    trace_count: StrictInt = Field(gt=0)
+    error_count: StrictInt = Field(ge=0)
+    latency_ms: LatencyDistribution
+    nodes: list[TraceGraphNode] = Field(min_length=1)
+    edges: list[TraceGraphEdge]
+    representative_trace: RepresentativeTrace
+    critical_path: CriticalPathSummary
+
+    @model_validator(mode="after")
+    def validate_graph(self) -> "TraceRootGraph":  # noqa: C901, D102  # tracked: #288
+        if self.error_count > self.trace_count or self.latency_ms.count != self.trace_count:
+            raise ValueError("root latency counts must match trace counts")  # noqa: TRY003  # tracked: #288
+        node_by_id = {node.id: node for node in self.nodes}
+        if len(node_by_id) != len(self.nodes):
+            raise ValueError("trace graph node IDs must be unique")  # noqa: TRY003  # tracked: #288
+        if any(
+            edge.from_node not in node_by_id or edge.to not in node_by_id for edge in self.edges
+        ):
+            raise ValueError("trace graph edges must reference known nodes")  # noqa: TRY003  # tracked: #288
+        for span in self.representative_trace.spans:
+            node = node_by_id.get(span.node_id)
+            if node is None or (span.service, span.operation) != (node.service, node.operation):
+                raise ValueError("representative spans must match graph nodes")  # noqa: TRY003  # tracked: #288
+        critical = self.critical_path
+        if (
+            critical.trace_count != self.trace_count
+            or critical.duration_ms.count != self.trace_count
+        ):
+            raise ValueError("critical path counts must match root trace counts")  # noqa: TRY003  # tracked: #288
+        if (critical.representative.trace_id, critical.representative.duration_ms) != (
+            self.representative_trace.trace_id,
+            self.representative_trace.duration_ms,
+        ):
+            raise ValueError("critical path must use the representative trace")  # noqa: TRY003  # tracked: #288
+        contributors = {node.node_id: node for node in critical.nodes_by_contribution}
+        if len(contributors) != len(critical.nodes_by_contribution):
+            raise ValueError("critical path contributors must be unique")  # noqa: TRY003  # tracked: #288
+        for contributor in critical.nodes_by_contribution:
+            node = node_by_id.get(contributor.node_id)
+            if node is None or (contributor.path, contributor.service, contributor.operation) != (
+                node.path,
+                node.service,
+                node.operation,
+            ):
+                raise ValueError("critical path contributors must match graph nodes")  # noqa: TRY003  # tracked: #288
+            if contributor.contribution_ms.count > self.trace_count:
+                raise ValueError("critical path contribution count exceeds trace count")  # noqa: TRY003  # tracked: #288
+        if any(segment.node_id not in contributors for segment in critical.representative.segments):
+            raise ValueError("critical path segments must reference contributors")  # noqa: TRY003  # tracked: #288
+        return self
+
+
+class TraceGraphReport(BaseModel):
+    """Strict schema-v2 trace graph emitted by servicebench."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[2]
+    source: str = Field(min_length=1)
+    collected_at: str
+    workload_name: str = Field(min_length=1)
+    workload_hash: str = Field(min_length=1)
+    measurement_windows: list[MeasurementWindow] = Field(min_length=1)
+    quality: TraceQuality
+    trials: list[TraceTrialQuality] = Field(min_length=1)
+    roots: list[TraceRootGraph] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_report(self) -> "TraceGraphReport":  # noqa: D102  # tracked: #288
+        _parse_timestamp(self.collected_at, "collected_at")
+        if len(self.trials) != len(self.measurement_windows):
+            raise ValueError("trace trials must match measurement windows")  # noqa: TRY003  # tracked: #288
+        if len({trial.trial for trial in self.trials}) != len(self.trials):
+            raise ValueError("trace trial numbers must be unique")  # noqa: TRY003  # tracked: #288
+        trial_totals = (
+            sum(trial.captured_traces for trial in self.trials),
+            sum(trial.eligible_traces for trial in self.trials),
+            sum(trial.excluded_traces for trial in self.trials),
+        )
+        quality_totals = (
+            self.quality.captured_traces,
+            self.quality.eligible_traces,
+            self.quality.excluded_traces,
+        )
+        if trial_totals != quality_totals:
+            raise ValueError("trace trial totals must match report quality")  # noqa: TRY003  # tracked: #288
+        roots = [(root.service, root.operation) for root in self.roots]
+        if len(roots) != len(set(roots)):
+            raise ValueError("trace roots must be unique")  # noqa: TRY003  # tracked: #288
         return self
 
 
@@ -129,6 +403,51 @@ class ReportComparison(BaseModel):
     datastore_p95_changes: list[RowChange]
 
 
+class BoundedRepresentativeCriticalPath(BaseModel):
+    """Bounded representative path returned to the profiler agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    trace_id: str
+    duration_ms: float
+    segments: list[CriticalPathSegment]
+    omitted_segment_count: int
+
+
+class CriticalPathRootEvidence(BaseModel):
+    """Bounded critical-path evidence for one root operation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    service: str
+    operation: str
+    trace_count: int
+    error_count: int
+    latency_ms: LatencyDistribution
+    algorithm: str
+    scope: str
+    async_relationships_excluded: int
+    duration_ms: LatencyDistribution
+    nodes_by_contribution: list[CriticalPathNodeContribution]
+    omitted_contributor_count: int
+    representative: BoundedRepresentativeCriticalPath
+
+
+class CriticalPathEvidence(BaseModel):
+    """Bounded schema-v2 evidence returned by the ``critical_path`` tool."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    collected_at: str
+    workload_name: str
+    workload_hash: str
+    measurement_windows: list[MeasurementWindow]
+    quality: TraceQuality
+    roots: list[CriticalPathRootEvidence]
+    omitted_root_count: int
+
+
 def load_report(path: str) -> TelemetryReport:  # noqa: D103  # tracked: #288
     return TelemetryReport.model_validate_json(Path(path).read_text(encoding="utf-8"))
 
@@ -162,6 +481,65 @@ def compare_reports(before_path: str, after_path: str, *, top: int = 10) -> Repo
         service_p95_changes=_compare_rows(before.services_by_p95, after.services_by_p95, top),
         span_p95_changes=_compare_rows(before.spans_by_p95, after.spans_by_p95, top),
         datastore_p95_changes=_compare_rows(before.datastores_by_p95, after.datastores_by_p95, top),
+    )
+
+
+def load_trace_graph(path: str) -> TraceGraphReport:
+    """Load and strictly validate one servicebench schema-v2 trace graph."""
+    return TraceGraphReport.model_validate_json(Path(path).read_text(encoding="utf-8"))
+
+
+def summarize_critical_path(
+    path: str, telemetry_path: str, *, top: int = 10
+) -> CriticalPathEvidence:
+    """Return bounded critical-path evidence from a schema-v2 trace graph."""
+    _validate_top(top)
+    graph = load_trace_graph(path)
+    telemetry = load_report(telemetry_path)
+    if (
+        graph.workload_name,
+        graph.workload_hash,
+        graph.measurement_windows,
+    ) != (
+        telemetry.workload_name,
+        telemetry.workload_hash,
+        telemetry.measurement_windows,
+    ):
+        raise ValueError(_GRAPH_REPORT_MISMATCH)
+    roots = []
+    for root in graph.roots[:top]:
+        critical = root.critical_path
+        representative = critical.representative
+        roots.append(
+            CriticalPathRootEvidence(
+                service=root.service,
+                operation=root.operation,
+                trace_count=root.trace_count,
+                error_count=root.error_count,
+                latency_ms=root.latency_ms,
+                algorithm=critical.algorithm,
+                scope=critical.scope,
+                async_relationships_excluded=critical.async_relationships_excluded,
+                duration_ms=critical.duration_ms,
+                nodes_by_contribution=critical.nodes_by_contribution[:top],
+                omitted_contributor_count=max(len(critical.nodes_by_contribution) - top, 0),
+                representative=BoundedRepresentativeCriticalPath(
+                    trace_id=representative.trace_id,
+                    duration_ms=representative.duration_ms,
+                    segments=representative.segments[:top],
+                    omitted_segment_count=max(len(representative.segments) - top, 0),
+                ),
+            )
+        )
+    return CriticalPathEvidence(
+        source=graph.source,
+        collected_at=graph.collected_at,
+        workload_name=graph.workload_name,
+        workload_hash=graph.workload_hash,
+        measurement_windows=graph.measurement_windows,
+        quality=graph.quality,
+        roots=roots,
+        omitted_root_count=max(len(graph.roots) - top, 0),
     )
 
 
@@ -237,26 +615,31 @@ def _change_magnitude(change: RowChange) -> float:
 
 
 def find_reports(root: str = ".") -> list[str]:  # noqa: D103  # tracked: #288
-    base = Path(root)
-    reports = []
-    for path in base.rglob("*.json"):
+    return _find_artifacts(root, schema_version=1, model=TelemetryReport)
+
+
+def find_trace_graphs(root: str = ".") -> list[str]:
+    """Find strictly valid servicebench schema-v2 trace graphs."""
+    return _find_artifacts(root, schema_version=2, model=TraceGraphReport)
+
+
+def _find_artifacts(root: str, *, schema_version: int, model: type[BaseModel]) -> list[str]:
+    artifacts = []
+    for path in Path(root).rglob("*.json"):
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, RecursionError, ValueError):
-            # Skip any file we cannot read or parse so one bad ``*.json`` under
-            # the workspace cannot abort the whole scan. ValueError covers
-            # non-JSON (JSONDecodeError), non-UTF-8 bytes (UnicodeDecodeError),
-            # and oversized integer literals; RecursionError covers deeply
-            # nested JSON. A candidate under evaluation controls workspace files,
-            # so report discovery must tolerate hostile input.
+            # A candidate controls workspace files. One unreadable, malformed,
+            # deeply nested, or oversized JSON artifact must not abort discovery.
             continue
-        if isinstance(payload, dict) and payload.get("schema_version") == 1:
-            try:
-                TelemetryReport.model_validate(payload)
-            except ValueError:
-                continue
-            reports.append(path.as_posix())
-    return sorted(reports)
+        if not isinstance(payload, dict) or payload.get("schema_version") != schema_version:
+            continue
+        try:
+            model.model_validate(payload)
+        except ValueError:
+            continue
+        artifacts.append(path.as_posix())
+    return sorted(artifacts)
 
 
 def build_server() -> FastMCP:  # noqa: D103  # tracked: #288
@@ -276,6 +659,16 @@ def build_server() -> FastMCP:  # noqa: D103  # tracked: #288
     def compare(before_path: str, after_path: str, top: int = 10) -> ReportComparison:
         """Compare p95 latency for services, spans, and datastores."""
         return compare_reports(before_path, after_path, top=top)
+
+    @mcp.tool()
+    def trace_graphs(root: str = ".") -> list[str]:
+        """Find versioned servicebench trace graphs below a workspace path."""
+        return find_trace_graphs(root)
+
+    @mcp.tool()
+    def critical_path(path: str, telemetry_path: str, top: int = 10) -> CriticalPathEvidence:
+        """Return a graph's critical path after binding it to normalized telemetry."""
+        return summarize_critical_path(path, telemetry_path, top=top)
 
     return mcp
 

--- a/src/vibesys/prompts/domains/microservices/profiler.md
+++ b/src/vibesys/prompts/domains/microservices/profiler.md
@@ -16,12 +16,17 @@ Useful evidence includes:
   pool saturation.
 - A servicebench `telemetry` report with in-window service, span, and datastore
   mean, p50, p95, p99, maximum, count, and error count.
+- A servicebench schema-v2 trace graph with workload-correlated synchronous
+  critical-path contribution and a representative path decomposition.
 
 When using a system profiler, capture a steady-state run after warmup. For
 Docker Compose deployments, record the service or container being profiled and
 the benchmark load level used. Do not treat a single internal span or local
 handler timing as the final metric unless the objective defines it that way.
 Use normalized OpenTelemetry rows to rank likely bottlenecks and compare the
-same span across candidates. Keep the benchmark's `primary_value` as the
-authoritative score, and reject telemetry that is empty or not correlated to
-the evaluator's measurement windows.
+same span across candidates. Critical-path contribution is wall-clock
+attribution: overlapping sibling calls are not additive, and linked or async
+relationships are excluded from the synchronous path. Report those exclusions
+as a coverage limit. Keep the benchmark's `primary_value` as the authoritative
+score, and reject telemetry or trace graphs that are empty or do not match the
+workload identity and evaluator measurement windows.

--- a/src/vibesys/prompts/loops/agent/profilers/otel.j2
+++ b/src/vibesys/prompts/loops/agent/profilers/otel.j2
@@ -35,17 +35,31 @@ Benchmark command: {{ benchmark_command }}
 
 ## Analysis workflow
 
-1. Run the trusted benchmark command as configured by the input bundle. It must
-   include servicebench telemetry collection flags and produce a normalized
-   telemetry JSON report.
+1. Run the trusted benchmark command as configured by the input bundle. A
+   critical-path run uses `servicebench trace` and produces both a normalized
+   telemetry report and a versioned trace graph for the same measurement
+   windows.
 2. Call the `{{ profiler_mcp_name }}` MCP tools to read the evidence: `reports()`
-   to locate normalized reports, then `summary(path=...)`.
+   to locate normalized reports, then `summary(path=...)`. Call
+   `trace_graphs()` to locate schema-v2 graphs, then
+   `critical_path(path=..., telemetry_path=...)` for bounded wall-clock
+   attribution. The tool rejects a graph unless its workload identity and
+   exact measurement windows match the normalized report.
 3. Rank bottlenecks using concrete service, span, and datastore p50/p95/p99
-   values and error counts.
-4. Use `compare()` when both baseline and candidate reports exist. Treat large
+   values, error counts, and critical-path contribution. Use graph paths and
+   representative segments to distinguish sequential work from overlapping
+   calls; do not add overlapping sibling durations.
+4. Use `compare()` when both baseline and candidate reports exist. Read each
+   run's critical path separately and compare only graphs with matching
+   workload identity and window count. Treat large
    span-count changes as a possible coverage or sampling change.
 5. Report the benchmark's declared `primary_value` as `perf_metric`; internal
    span latency is diagnostic evidence, not the scored result.
+
+The critical path has scope `synchronous_request`. Report
+`async_relationships_excluded` and trace eligibility when they limit coverage.
+If no valid graph exists, say critical-path evidence is unavailable. Never
+invent a path from flat span aggregates.
 
 {% include "profilers/_observer_effect.j2" %}
 

--- a/tests/loops/agent/test_prompt_domain_leakage.py
+++ b/tests/loops/agent/test_prompt_domain_leakage.py
@@ -272,3 +272,25 @@ def test_profiler_prompts_calibrate_observer_effects():  # noqa: ANN201  # track
         assert "observer_effect_fraction" in rendered
         assert "differ by more than 10%" in rendered
         assert "must not be converted into exclusive phase shares" in rendered
+
+
+def test_microservice_otel_profiler_uses_critical_path_as_diagnostic_evidence():  # noqa: ANN201  # tracked: #288
+    context = _NEUTRAL_CONTEXT
+    rendered = render_template(
+        "profilers/otel.j2",
+        template_dir=_TEMPLATE_DIR,
+        profile_focus="microservice latency",
+        benchmark_command=context["benchmark_command"],
+        domain_profiler=_domain_section(DomainName.MICROSERVICES, "profiler", context),
+        runtime_notes=context["runtime_notes"],
+        objective=context["objective"],
+        profiler_support_name="otel_profiler",
+        profiler_mcp_name="vibesys-otel-profiler",
+    )
+
+    assert "trace_graphs()" in rendered
+    assert "critical_path(path=..., telemetry_path=...)" in rendered
+    assert "async_relationships_excluded" in rendered
+    assert "do not add overlapping sibling durations" in rendered
+    assert "primary_value" in rendered
+    assert "diagnostic evidence, not the scored result" in rendered

--- a/tests/loops/test_profiler_mcp.py
+++ b/tests/loops/test_profiler_mcp.py
@@ -11,6 +11,7 @@ import json
 import sqlite3
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -105,6 +106,11 @@ async def _call_tool(server, name: str, **kwargs) -> str:  # noqa: ANN001, ANN00
     return structured["result"]
 
 
+async def _call_structured_tool(server, name: str, **kwargs) -> dict:  # noqa: ANN001, ANN003  # tracked: #288
+    _, structured = await server.call_tool(name, kwargs)
+    return structured
+
+
 # ---------------------------------------------------------------------------
 # nsys MCP server
 # ---------------------------------------------------------------------------
@@ -173,7 +179,87 @@ class TestOtelMcpServer:
     def test_registers_expected_tools(self, otel_server_mod):  # noqa: ANN001, ANN201  # tracked: #288
         server = otel_server_mod.build_server()
         names = asyncio.run(_list_tool_names(server))
-        assert names == {"reports", "summary", "compare"}
+        assert names == {"reports", "summary", "compare", "trace_graphs", "critical_path"}
+
+    def test_discovers_and_summarizes_critical_path(self, otel_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        report_path = tmp_path / "telemetry.json"
+        graph_path = tmp_path / "trace-graph.json"
+        report_path.write_text(json.dumps(_otel_report(20.0)))
+        graph_path.write_text(json.dumps(_trace_graph()))
+
+        summary = otel_server_mod.summarize_critical_path(str(graph_path), str(report_path), top=1)
+
+        assert otel_server_mod.find_reports(str(tmp_path)) == [report_path.as_posix()]
+        assert otel_server_mod.find_trace_graphs(str(tmp_path)) == [graph_path.as_posix()]
+        assert summary.workload_name == "hotel"
+        assert summary.quality.eligible_traces == 3
+        assert len(summary.roots) == 1
+        assert summary.omitted_root_count == 0
+        root = summary.roots[0]
+        assert root.algorithm == "wall_clock_active_leaf_v1"
+        assert root.scope == "synchronous_request"
+        assert root.nodes_by_contribution[0].operation == "Search/Nearby"
+        assert root.omitted_contributor_count == 1
+        assert root.representative.segments[0].node_id == "node-001"
+        assert root.representative.omitted_segment_count == 1
+
+    def test_critical_path_tool_returns_structured_summary(self, otel_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        graph_path = tmp_path / "trace-graph.json"
+        report_path = tmp_path / "telemetry.json"
+        graph_path.write_text(json.dumps(_trace_graph()))
+        report_path.write_text(json.dumps(_otel_report(20.0)))
+
+        server = otel_server_mod.build_server()
+        result = asyncio.run(
+            _call_structured_tool(
+                server,
+                "critical_path",
+                path=str(graph_path),
+                telemetry_path=str(report_path),
+                top=1,
+            )
+        )
+
+        assert result["workload_name"] == "hotel"
+        assert result["roots"][0]["nodes_by_contribution"][0]["service"] == "search"
+
+    def test_critical_path_rejects_graph_from_another_measurement_window(
+        self, otel_server_mod: ModuleType, tmp_path: Path
+    ) -> None:
+        graph_path = tmp_path / "trace-graph.json"
+        report_path = tmp_path / "telemetry.json"
+        graph = _trace_graph()
+        graph["measurement_windows"][0]["start"] = "2026-07-23T12:00:00Z"
+        graph["measurement_windows"][0]["end"] = "2026-07-23T12:00:01Z"
+        graph_path.write_text(json.dumps(graph))
+        report_path.write_text(json.dumps(_otel_report(20.0)))
+
+        with pytest.raises(ValueError, match="matching workload identity and windows"):
+            otel_server_mod.summarize_critical_path(str(graph_path), str(report_path))
+
+    def test_load_trace_graph_rejects_invalid_critical_path_geometry(
+        self, otel_server_mod: ModuleType, tmp_path: Path
+    ) -> None:
+        graph = _trace_graph()
+        graph["roots"][0]["critical_path"]["representative"]["segments"][1]["offset_ms"] = 0.0
+        graph_path = tmp_path / "invalid-trace-graph.json"
+        graph_path.write_text(json.dumps(graph))
+
+        with pytest.raises(ValueError, match="contiguous"):
+            otel_server_mod.load_trace_graph(str(graph_path))
+
+    def test_find_trace_graphs_skips_hostile_and_malformed_json(
+        self, otel_server_mod: ModuleType, tmp_path: Path
+    ) -> None:
+        valid = tmp_path / "valid-graph.json"
+        valid.write_text(json.dumps(_trace_graph()))
+        malformed = _trace_graph()
+        malformed["quality"]["eligible_traces"] = 99
+        (tmp_path / "malformed-graph.json").write_text(json.dumps(malformed))
+        (tmp_path / "binary.json").write_bytes(b"\xff\xfe\x00\x01 not valid utf-8")
+        (tmp_path / "nested.json").write_text("[" * 3000 + "]" * 3000)
+
+        assert otel_server_mod.find_trace_graphs(str(tmp_path)) == [valid.as_posix()]
 
     def test_summary_and_compare_use_normalized_service_rows(self, otel_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         before = tmp_path / "before.json"
@@ -391,6 +477,121 @@ def _otel_report(p95: float) -> dict:
         "services_by_p95": [row],
         "spans_by_p95": [span],
         "datastores_by_p95": [datastore],
+    }
+
+
+def _trace_graph() -> dict:
+    def distribution(mean: float, *, count: int = 3) -> dict:
+        return {
+            "count": count,
+            "error_count": 0,
+            "mean_ms": mean,
+            "p50_ms": mean,
+            "p95_ms": mean + 1.0,
+            "p99_ms": mean + 2.0,
+            "max_ms": mean + 3.0,
+        }
+
+    return {
+        "schema_version": 2,
+        "source": "otlp-json",
+        "collected_at": "2026-07-22T12:00:00Z",
+        "workload_name": "hotel",
+        "workload_hash": "abc123",
+        "measurement_windows": [{"start": "2026-07-22T12:00:00Z", "end": "2026-07-22T12:00:01Z"}],
+        "quality": {
+            "captured_traces": 3,
+            "eligible_traces": 3,
+            "excluded_traces": 0,
+            "matched_client_server_pairs": 3,
+            "unmatched_client_spans": 0,
+            "unmatched_server_spans": 0,
+            "async_relationships": 1,
+        },
+        "trials": [{"trial": 1, "captured_traces": 3, "eligible_traces": 3, "excluded_traces": 0}],
+        "roots": [
+            {
+                "service": "frontend",
+                "operation": "GET /hotels",
+                "trace_count": 3,
+                "error_count": 0,
+                "latency_ms": distribution(20.0),
+                "nodes": [
+                    {
+                        "id": "node-001",
+                        "path": "frontend:GET /hotels",
+                        "service": "frontend",
+                        "operation": "GET /hotels",
+                        "kind": "server",
+                        "inclusive_latency_ms": distribution(20.0),
+                        "exclusive_latency_ms": distribution(5.0),
+                    },
+                    {
+                        "id": "node-002",
+                        "path": "frontend:GET /hotels > search:Search/Nearby",
+                        "service": "search",
+                        "operation": "Search/Nearby",
+                        "kind": "server",
+                        "inclusive_latency_ms": distribution(15.0),
+                        "exclusive_latency_ms": distribution(15.0),
+                    },
+                ],
+                "edges": [
+                    {"from": "node-001", "to": "node-002", "relationship": "child", "count": 3}
+                ],
+                "representative_trace": {
+                    "trace_id": "trace-a",
+                    "duration_ms": 20.0,
+                    "spans": [
+                        {
+                            "node_id": "node-001",
+                            "service": "frontend",
+                            "operation": "GET /hotels",
+                            "offset_ms": 0.0,
+                            "duration_ms": 20.0,
+                        },
+                        {
+                            "node_id": "node-002",
+                            "service": "search",
+                            "operation": "Search/Nearby",
+                            "offset_ms": 5.0,
+                            "duration_ms": 15.0,
+                        },
+                    ],
+                },
+                "critical_path": {
+                    "algorithm": "wall_clock_active_leaf_v1",
+                    "scope": "synchronous_request",
+                    "trace_count": 3,
+                    "async_relationships_excluded": 1,
+                    "duration_ms": distribution(20.0),
+                    "nodes_by_contribution": [
+                        {
+                            "node_id": "node-002",
+                            "path": "frontend:GET /hotels > search:Search/Nearby",
+                            "service": "search",
+                            "operation": "Search/Nearby",
+                            "contribution_ms": distribution(15.0),
+                        },
+                        {
+                            "node_id": "node-001",
+                            "path": "frontend:GET /hotels",
+                            "service": "frontend",
+                            "operation": "GET /hotels",
+                            "contribution_ms": distribution(5.0),
+                        },
+                    ],
+                    "representative": {
+                        "trace_id": "trace-a",
+                        "duration_ms": 20.0,
+                        "segments": [
+                            {"node_id": "node-001", "offset_ms": 0.0, "duration_ms": 5.0},
+                            {"node_id": "node-002", "offset_ms": 5.0, "duration_ms": 15.0},
+                        ],
+                    },
+                },
+            }
+        ],
     }
 
 

--- a/tests/test_microservice_inputs.py
+++ b/tests/test_microservice_inputs.py
@@ -154,6 +154,16 @@ def test_hotel_accuracy_uses_shared_evaluator_with_random_cases() -> None:
         bundle.benchmark_command[1:],
         strict=False,
     )
+    assert ("./cmd/servicebench", "trace") in zip(
+        bundle.benchmark_command,
+        bundle.benchmark_command[1:],
+        strict=False,
+    )
+    assert ("--trace-graph-json", "../../metrics/trace-graph.json") in zip(
+        bundle.benchmark_command,
+        bundle.benchmark_command[1:],
+        strict=False,
+    )
     assert ("--telemetry-timeout", "60") in zip(
         bundle.benchmark_command,
         bundle.benchmark_command[1:],


### PR DESCRIPTION
## Problem

ServiceBench can reconstruct microservice trace graphs (#319), and the stacked PR #334 adds synchronous critical-path analysis. VibeSys still does not request those artifacts, expose them through its OpenTelemetry profiler, or instruct the profiling agent to use them. As a result, optimization rounds cannot use the evaluator's workload-correlated critical-path evidence to choose latency work.

This is the third part of #318. It wires critical-path evidence into VibeSys while preserving the benchmark's declared `primary_value` as the authoritative score.

## Solution

Run the Hotel Reservation benchmark through `servicebench trace` and retain its schema-v2 graph beside the normalized telemetry report. Extend the existing OTel MCP profiler with strict schema-v2 models, separate graph discovery, and a bounded `critical_path` tool.

The tool requires both the graph and normalized telemetry paths. It rejects evidence unless workload name, workload hash, and exact measurement windows match. Agent instructions use contributor distributions and representative segments diagnostically, report async exclusions and trace quality, avoid summing overlapping siblings, and never replace the benchmark score.

The documented optimization command now explicitly selects `--profiler otel`. Existing schema-v1 `reports`, `summary`, and `compare` behavior remains available.

### Architecture

```mermaid
flowchart LR
    A[Hotel benchmark command] --> B[servicebench trace]
    B --> C[schema-v1 telemetry report]
    B --> D[schema-v2 trace graph]
    C --> E[OTel MCP profiler]
    D --> E
    E --> F[identity and window binding]
    F --> G[bounded critical-path evidence]
    G --> H[VibeSys profiler agent]
    H --> I[diagnostic bottlenecks and suggestions]
    B --> J[authoritative primary_value]
```

ServiceBench remains responsible for collection and critical-path semantics. The existing VibeSys OTel MCP server owns artifact validation and bounded agent-facing summaries. Prompt templates own interpretation rules. No loop result schema or ranking logic changes.

## Verification

Focused MCP, prompt, and input-bundle tests pass. Scoped Ruff lint, import ordering, formatting, and `git diff --check` pass. The tests cover schema-v1/v2 separation, tool registration, strict graph validation, bounded output, hostile JSON discovery, exact report/graph binding, prompt guidance, and Hotel manifest wiring.

### Correctness properties

- Schema-v1 normalized reports and schema-v2 trace graphs remain distinct contracts.
- Graphs fail closed on unknown fields, malformed distributions, invalid references, duplicate identities, inconsistent counts, or noncontiguous critical segments.
- Critical-path evidence is accepted only when graph and normalized telemetry workload identity and exact measurement windows match.
- Agent-facing results are bounded and report omitted roots, contributors, and representative segments.
- Discovery tolerates unreadable, malformed, deeply nested, and oversized candidate-controlled JSON.
- Synchronous critical-path contribution is diagnostic; overlapping siblings are not summed and async exclusions are surfaced.
- The benchmark's declared `primary_value` remains the authoritative optimization metric.
- Existing schema-v1 OTel summary and comparison tools retain their behavior.

### Testing

- `.venv/bin/python -m pytest -q tests/loops/test_profiler_mcp.py tests/loops/agent/test_prompt_domain_leakage.py tests/test_microservice_inputs.py` (47 passed)
- `.venv/bin/ruff check resources/profilers/otel/server.py tests/loops/test_profiler_mcp.py tests/loops/agent/test_prompt_domain_leakage.py tests/test_microservice_inputs.py` (pass)
- `.venv/bin/ruff check --select I resources/profilers/otel/server.py tests/loops/test_profiler_mcp.py tests/loops/agent/test_prompt_domain_leakage.py tests/test_microservice_inputs.py` (pass)
- `.venv/bin/ruff format --check resources/profilers/otel/server.py tests/loops/test_profiler_mcp.py tests/loops/agent/test_prompt_domain_leakage.py tests/test_microservice_inputs.py` (pass)
- `git diff --check` (pass)
- `./scripts/check_format.sh`, `./scripts/check_lint.sh`, and `./scripts/check_types.sh` (not runnable: Snap `uv` permission failure)
- `go run ./cmd/servicebench trace ... --validate-only` (not runnable: `go` is unavailable)

Stacked on #334. Related to #318.
