### PR TITLE
Release VibeSys 0.1.1

### DIFF
--- a/clients/tui/package.json
+++ b/clients/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibesys/tui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "license": "MIT",
   "repository": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vibesys"
-version = "0.1.0"
+version = "0.1.1"
 description = "AI agent framework for generating bespoke systems from application, workload, and hardware requirements"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -4562,7 +4562,7 @@ wheels = [
 
 [[package]]
 name = "vibesys"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "agentshim" },


### PR DESCRIPTION
## Problem

The repository-native task support merged after VibeSys 0.1.0 was published. PyPI versions are immutable, so the merged functionality needs a new patch release before it can be distributed.

## Solution

Bump the Python distribution and TUI package versions from 0.1.0 to 0.1.1, and update the root package entry in `uv.lock`.

### Architecture

No architecture or runtime behavior changes. This PR changes only release identity metadata.

## Verification

The Python, TUI, and lock-file versions agree on 0.1.1.

### Correctness properties

- The Python distribution version is valid PEP 440.
- The TUI version is matching npm SemVer.
- The committed lock file matches the project version.
- The release remains unpublished until this commit is contained in `main` and GitHub release `v0.1.1` is published.

### Testing

- `uv lock --check`
- `uv run python scripts/check_release_version.py` (`0.1.1`)
- `git diff --check`
