### PR TITLE
VS Meta Opt: llama-70b-2xh100-vllm campaign (10 rounds)

### DIFF
--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -297,6 +297,27 @@ starts with an actionable error.
 `--docker-image` overrides the backend's default container image when Docker or
 Modal is active.
 
+The selected environment and its options (`--docker-image`, `--modal-gpu`,
+`--modal-model-volume`, `--modal-app`) are recorded in the run configuration.
+`--docker` and `--modal` are boolean flags, so an omitted flag cannot be told
+apart from an explicit "off": on resume the recorded environment is therefore
+authoritative. Omitting the runtime-environment flags restores it, and passing
+a flag that contradicts the recording is rejected like any other immutable
+configuration field. The candidate's Modal entrypoint is declared by the task,
+not recorded, so it follows the current input bundle.
+
+Run metadata written before run schema version 2 has no recorded environment.
+VibeSys refuses to load it rather than guess a local environment. Stamp the
+environment the run was launched with, once:
+
+```bash
+vibesys migrate-run-environment --project . --run <run-id> --run-environment modal
+```
+
+The command accepts the same `--docker-image`, `--modal-gpu`,
+`--modal-model-volume`, and `--modal-app` options as a run, with the same
+defaults, and is one-way.
+
 ## Profiler
 
 | Value | Intended use |

--- a/docs/running-vibesys.md
+++ b/docs/running-vibesys.md
@@ -140,7 +140,9 @@ vibesys --runs-dir /work/vibesys-runs --resume https://github.com/my-org/my-expe
 
 Omitted configuration flags and the selected task are restored from
 `.vibesys/state/runs/<run-id>/run.json`. The total round or generation limit
-may increase. Other recorded settings cannot change during a resume.
+may increase. Other recorded settings cannot change during a resume, including
+the runtime environment: a run launched with `--modal` resumes on Modal without
+repeating the flag.
 
 ## Supply an Input with CLI Flags
 

--- a/libs/vs-project/src/vs_project/__init__.py
+++ b/libs/vs-project/src/vs_project/__init__.py
@@ -17,6 +17,7 @@ from vs_project._layout import (
 )
 from vs_project._state import (
     PROJECT_SCHEMA_VERSION,
+    RUN_SCHEMA_VERSION,
     AgentRunConfiguration,
     EvolveRunConfiguration,
     GitObjectId,
@@ -28,7 +29,9 @@ from vs_project._state import (
     ProjectSandboxPaths,
     ProjectStateError,
     RunConfiguration,
+    RunEnvironmentRecord,
     RunManifest,
+    RunSchemaMigrationRequiredError,
     StateFile,
     StateModelNotFoundError,
     StateNamespace,
@@ -44,6 +47,7 @@ from vs_project.project import Project
 
 __all__ = [
     "PROJECT_SCHEMA_VERSION",
+    "RUN_SCHEMA_VERSION",
     "AgentRunConfiguration",
     "AmbiguousTaskError",
     "ConfigurationRoot",
@@ -65,7 +69,9 @@ __all__ = [
     "ProjectSandboxPaths",
     "ProjectStateError",
     "RunConfiguration",
+    "RunEnvironmentRecord",
     "RunManifest",
+    "RunSchemaMigrationRequiredError",
     "StateFile",
     "StateModelNotFoundError",
     "StateNamespace",

--- a/libs/vs-project/src/vs_project/_state.py
+++ b/libs/vs-project/src/vs_project/_state.py
@@ -38,6 +38,10 @@ if TYPE_CHECKING:
     from uuid import UUID
 
 PROJECT_SCHEMA_VERSION: Literal[1] = 1
+# Version 2 added the required run-environment recording to a run's
+# configuration. Older recordings cannot be interpreted safely, so they are
+# rejected at load time and must be migrated with an explicit environment.
+RUN_SCHEMA_VERSION: Literal[2] = 2
 _CONFIG_DIRECTORY_NAME = project_paths.CONFIGURATION_DIRECTORY_NAME
 _STATE_DIRECTORY_PARTS = project_paths.STATE_DIRECTORY_PARTS
 _STATE_DIRECTORY_PATH = project_paths.STATE_DIRECTORY_PATH
@@ -73,6 +77,20 @@ class ProjectStateError(ProjectError):
 
 class StateModelNotFoundError(ProjectStateError):
     """Raised when a required model is absent from a state namespace."""
+
+
+class RunSchemaMigrationRequiredError(ProjectStateError):
+    """Raised when a run manifest predates the current run schema version.
+
+    Callers own the operator-facing migration instructions; this package
+    reports only the offending path and the two schema versions.
+    """
+
+    def __init__(self, message: str, *, path: Path, run_id: str, recorded_version: int) -> None:
+        super().__init__(message)
+        self.path = path
+        self.run_id = run_id
+        self.recorded_version = recorded_version
 
 
 def is_project_state_path(relative_path: Path | str) -> bool:
@@ -673,19 +691,40 @@ class StateSlot[ModelT: BaseModel]:
 
 
 class _CommittedManifest(BaseModel):
-    """Strict base for versioned, portable metadata committed with source."""
+    """Strict base for versioned, portable metadata committed with source.
+
+    Each concrete manifest declares its own ``schema_version`` literal so the
+    project and run schemas can evolve independently.
+    """
 
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
-
-    schema_version: Literal[1]
 
 
 class ProjectManifest(_CommittedManifest):
     """Immutable identity and initial provenance of one project directory."""
 
+    schema_version: Literal[1]
     project_id: Identifier
     created_at: AwareDatetime
     initial_input_fingerprint: Sha256Digest
+
+
+class RunEnvironmentRecord(BaseModel):
+    """Runtime environment a run executes in, recorded for faithful resume.
+
+    ``name`` selects the environment; the remaining fields carry that
+    environment's operator-selected options and stay ``None`` when they do not
+    apply. Values a run derives from its own input (rather than from the
+    operator) are deliberately absent: they are re-derived on every launch.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    name: Literal["local", "docker", "modal"]
+    image: PortableText | None = None
+    gpu: PortableText | None = None
+    model_volume: PortableText | None = None
+    app: PortableText | None = None
 
 
 class _BaseRunConfiguration(BaseModel):
@@ -693,6 +732,7 @@ class _BaseRunConfiguration(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
+    run_environment: RunEnvironmentRecord
     model: PortableText | None = None
     agent_backend: PortableText
     cli_provider: PortableText | None = None
@@ -777,6 +817,7 @@ RunConfiguration = Annotated[
 class RunManifest(_CommittedManifest):
     """Immutable identity and starting provenance of one optimization run."""
 
+    schema_version: Literal[2]
     run_id: Identifier
     project_id: Identifier
     task_name: Identifier | None = None
@@ -991,7 +1032,7 @@ class ProjectState:
         project = self.load_project()
         created_at = _aware_now(now)
         return RunManifest(
-            schema_version=PROJECT_SCHEMA_VERSION,
+            schema_version=RUN_SCHEMA_VERSION,
             run_id=(
                 _validate_run_id(run_id)
                 if run_id is not None
@@ -1043,8 +1084,58 @@ class ProjectState:
         )
 
     def load_run(self, run_id: str) -> RunManifest:
-        """Load one run manifest."""
-        return _load_model(self._run_manifest_path(run_id), RunManifest)
+        """Load one run manifest, rejecting recordings from an older schema."""
+        path = self._run_manifest_path(run_id)
+        _require_current_run_schema(path, run_id)
+        return _load_model(path, RunManifest)
+
+    def migrate_run_environment(
+        self,
+        run_id: str,
+        run_environment: RunEnvironmentRecord,
+    ) -> RunManifest:
+        """Stamp an explicit run environment into a pre-version-2 run manifest.
+
+        Run schema version 1 never recorded the runtime environment, so the
+        operator supplies the environment the run actually used. The migration
+        is one-way and idempotent only in the sense that a manifest already at
+        the current version is rejected rather than rewritten.
+        """
+        self._validate_storage_roots()
+        path = self._run_manifest_path(run_id)
+        raw = _read_json_object(path)
+        recorded_version = raw.get("schema_version")
+        if recorded_version == RUN_SCHEMA_VERSION:
+            raise ProjectStateError(
+                f"Run metadata at {path} is already at run schema version {RUN_SCHEMA_VERSION}"
+            )
+        if recorded_version != 1:
+            raise ProjectStateError(
+                f"Run metadata at {path} records unsupported run schema version "
+                f"{recorded_version!r}; only version 1 can be migrated"
+            )
+        configuration = raw.get("configuration")
+        if not isinstance(configuration, dict):
+            raise ProjectStateError(f"Run metadata at {path} has no configuration object")
+        if "run_environment" in configuration:
+            raise ProjectStateError(
+                f"Run metadata at {path} already records a run environment; "
+                "its schema version is inconsistent with its contents"
+            )
+        migrated = {
+            **raw,
+            "schema_version": RUN_SCHEMA_VERSION,
+            "configuration": {
+                **configuration,
+                "run_environment": run_environment.model_dump(mode="json"),
+            },
+        }
+        try:
+            manifest = RunManifest.model_validate_json(json.dumps(migrated), strict=True)
+        except (TypeError, ValueError) as exc:
+            raise ProjectStateError(f"Could not migrate VibeSys metadata at {path}: {exc}") from exc
+        _atomic_write_model(path, manifest)
+        return manifest
 
     def run_manifest_snapshot(self, run_id: str) -> StateSnapshot:
         """Snapshot the current portable manifest for one run."""
@@ -1764,6 +1855,28 @@ def _read_json_object(path: Path) -> dict[str, object]:
     if not isinstance(raw, dict):
         raise ProjectStateError(f"Expected a JSON object in VibeSys metadata at {path}")
     return raw
+
+
+def _require_current_run_schema(path: Path, run_id: str) -> None:
+    """Reject a run manifest written before the current run schema version.
+
+    Only an outdated version is diagnosed here; every other defect is left to
+    the model validation that follows, which reports the offending field.
+    """
+    if not path.exists():
+        return
+    recorded_version = _read_json_object(path).get("schema_version")
+    if not isinstance(recorded_version, int) or recorded_version >= RUN_SCHEMA_VERSION:
+        return
+    raise RunSchemaMigrationRequiredError(
+        f"Run metadata at {path} uses run schema version {recorded_version}, but this "
+        f"VibeSys requires version {RUN_SCHEMA_VERSION}, which records the runtime "
+        "environment the run executes in. Migrate the run with the environment it "
+        "was launched with; VibeSys cannot infer it from an older recording.",
+        path=path,
+        run_id=run_id,
+        recorded_version=recorded_version,
+    )
 
 
 def _load_model[ModelT: BaseModel](path: Path, model_type: type[ModelT]) -> ModelT:

--- a/libs/vs-project/tests/test_store.py
+++ b/libs/vs-project/tests/test_store.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
 from vs_loop_state import RoundRecord, parse_round_record, serialize_round_record
 from vs_project import (
     PROJECT_SCHEMA_VERSION,
+    RUN_SCHEMA_VERSION,
     AgentRunConfiguration,
     EvolveRunConfiguration,
     PlainRunConfiguration,
@@ -22,7 +23,9 @@ from vs_project import (
     ProjectManifest,
     ProjectStateError,
     RunConfiguration,
+    RunEnvironmentRecord,
     RunManifest,
+    RunSchemaMigrationRequiredError,
     StateFile,
     StateModelNotFoundError,
     StateSnapshot,
@@ -47,6 +50,7 @@ def _configuration() -> AgentRunConfiguration:
     return AgentRunConfiguration(
         model="gpt-5",
         outer_loop="agent",
+        run_environment=RunEnvironmentRecord(name="local"),
         inner_loop="multi-agent",
         interface="inprocess",
         agent_backend="cli",
@@ -73,6 +77,7 @@ def _plain_configuration() -> PlainRunConfiguration:
     return PlainRunConfiguration(
         model="gpt-5",
         outer_loop="plain",
+        run_environment=RunEnvironmentRecord(name="local"),
         agent_backend="cli",
         cli_provider="codex",
         cli_timeout=1800,
@@ -88,6 +93,7 @@ def _evolve_configuration() -> EvolveRunConfiguration:
     return EvolveRunConfiguration(
         model="gpt-5",
         outer_loop="evolve",
+        run_environment=RunEnvironmentRecord(name="local"),
         agent_backend="cli",
         cli_provider="codex",
         cli_timeout=1800,
@@ -163,7 +169,7 @@ def test_manifests_are_strict_versioned_contracts() -> None:
     forbidden_value = ""
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         RunManifest(
-            schema_version=PROJECT_SCHEMA_VERSION,
+            schema_version=RUN_SCHEMA_VERSION,
             run_id="run-1",
             project_id="queue-abc",
             display_name="Queue",
@@ -641,6 +647,13 @@ def test_run_manifest_persists_complete_agent_loop_behavior(tmp_path: Path) -> N
         "outer_model": "gpt-5.6-sol",
         "outer_reasoning_effort": "xhigh",
         "profiler": "linux-cpu",
+        "run_environment": {
+            "app": None,
+            "gpu": None,
+            "image": None,
+            "model_volume": None,
+            "name": "local",
+        },
     }
 
 
@@ -1526,6 +1539,66 @@ def test_loaded_round_rejects_non_finite_metrics(tmp_path: Path) -> None:
 
     with pytest.raises(ProjectStateError, match=r"0001\.json.*finite numbers"):
         store.state.load_rounds(run.run_id)
+
+
+def _downgrade_run_schema(store: Project, run_id: str) -> Path:
+    """Rewrite one run manifest as a version 1 recording without an environment."""
+    path = store.state._run_manifest_path(run_id)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["schema_version"] = 1
+    del raw["configuration"]["run_environment"]
+    path.write_text(json.dumps(raw), encoding="utf-8")
+    return path
+
+
+def test_loading_a_pre_environment_run_requires_migration(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    run = _run(store)
+    _downgrade_run_schema(store, run.run_id)
+
+    with pytest.raises(RunSchemaMigrationRequiredError) as caught:
+        store.state.load_run(run.run_id)
+
+    assert caught.value.recorded_version == 1
+    assert caught.value.run_id == run.run_id
+    assert "run.json" in str(caught.value)
+    assert "runtime environment" in str(caught.value)
+
+
+def test_migrating_a_run_records_the_supplied_environment(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    run = _run(store)
+    _downgrade_run_schema(store, run.run_id)
+    environment = RunEnvironmentRecord(name="modal", gpu="H100!", app="vibesys")
+
+    migrated = store.state.migrate_run_environment(run.run_id, environment)
+
+    assert migrated.schema_version == RUN_SCHEMA_VERSION
+    assert migrated.configuration.run_environment == environment
+    assert store.state.load_run(run.run_id) == migrated
+    assert migrated.model_dump(exclude={"schema_version", "configuration"}) == run.model_dump(
+        exclude={"schema_version", "configuration"}
+    )
+
+
+def test_migrating_a_current_run_is_rejected(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    run = _run(store)
+
+    with pytest.raises(ProjectStateError, match="already at run schema version"):
+        store.state.migrate_run_environment(run.run_id, RunEnvironmentRecord(name="local"))
+
+
+def test_migrating_an_unknown_schema_version_is_rejected(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    run = _run(store)
+    path = store.state._run_manifest_path(run.run_id)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["schema_version"] = 99
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(ProjectStateError, match="unsupported run schema version"):
+        store.state.migrate_run_environment(run.run_id, RunEnvironmentRecord(name="local"))
 
 
 def test_corrupt_metadata_error_names_the_path(tmp_path: Path) -> None:

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -6,6 +6,7 @@ import atexit
 import json
 import logging
 import os
+import re
 import signal
 import subprocess
 import tempfile
@@ -28,6 +29,41 @@ if TYPE_CHECKING:
 
 # Global registry of live containers for cleanup on exit / SIGINT.
 _live_containers: dict[str, str] = {}  # container_id -> container_name
+
+# Environment variables whose *values* must never leave this process.
+# Credentials reach the container as ``-e NAME=VALUE`` arguments on
+# ``docker run``, and every sink that records a command or the env dict is
+# durable and readable: the command log lives beside the run's other logs, the
+# metadata file is written into the bind-mounted workspace the agent edits, and
+# startup errors are surfaced to the caller.  Endpoint variables such as
+# ``*_BASE_URL`` stay visible because they are diagnostics, not secrets.
+_SECRET_ENV_NAME_PATTERN = re.compile(
+    r"AUTH|TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|HEADERS",
+    re.IGNORECASE,
+)
+_REDACTED_VALUE = "<redacted>"
+
+
+def _is_secret_env_name(name: str) -> bool:
+    """Report whether *name* identifies a credential-bearing variable."""
+    return _SECRET_ENV_NAME_PATTERN.search(name) is not None
+
+
+def _redacted_command(cmd: list[str]) -> list[str]:
+    """Return *cmd* with the values of credential ``-e NAME=VALUE`` flags masked."""
+    redacted: list[str] = []
+    for index, argument in enumerate(cmd):
+        name, separator, _ = argument.partition("=")
+        if separator and index > 0 and cmd[index - 1] == "-e" and _is_secret_env_name(name):
+            redacted.append(f"{name}={_REDACTED_VALUE}")
+        else:
+            redacted.append(argument)
+    return redacted
+
+
+def _non_secret_env(env: dict[str, str]) -> dict[str, str]:
+    """Return *env* without credential entries, for the on-disk metadata file."""
+    return {name: value for name, value in env.items() if not _is_secret_env_name(name)}
 
 
 def _cleanup_containers() -> None:
@@ -205,7 +241,7 @@ class DockerSandbox(BaseSandbox):
     ) -> None:
         if self._logger is None:
             return
-        self._logger.info("CMD: %s", " ".join(cmd))
+        self._logger.info("CMD: %s", " ".join(_redacted_command(cmd)))
         if result is not None:
             self._logger.info("  exit_code=%d", result.returncode)
             if result.stdout and result.stdout.strip():
@@ -404,7 +440,7 @@ class DockerSandbox(BaseSandbox):
                 f"Failed to start Docker container (exit {result.returncode}):\n"
                 f"  stdout: {result.stdout.strip()}\n"
                 f"  stderr: {result.stderr.strip()}\n"
-                f"  cmd: {' '.join(cmd)}"
+                f"  cmd: {' '.join(_redacted_command(cmd))}"
             )
         self._container_id = result.stdout.strip()
         _live_containers[self._container_id] = self._container_name
@@ -430,7 +466,10 @@ class DockerSandbox(BaseSandbox):
             "entrypoint": self._entrypoint,
             "shm_size": self._shm_size,
             "bind_mounts": [[host, container, ro] for host, container, ro in self._bind_mounts],
-            "env": dict(self._env),
+            # Credentials are omitted rather than masked: the metadata file is
+            # written into the agent-visible workspace, and a masked value
+            # would rebuild a broken container that looks authenticated.
+            "env": _non_secret_env(self._env),
             "symlink_commands": [],
         }
         self._save_metadata()

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -1,5 +1,6 @@
 """Tests for DockerSandbox — all mock subprocess.run, no Docker required."""
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -915,6 +916,76 @@ class TestEnvVars:
         assert "-e" in cmd
         assert "MY_KEY=my_value" in cmd_str
         assert "OTHER=thing" in cmd_str
+
+    @patch("subprocess.run")
+    def test_credential_values_reach_the_container_but_not_the_log(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        log_path = tmp_path / "docker.log"
+        sandbox = DockerSandbox(
+            host_workspace=str(workspace),
+            image="pytorch:latest",
+            env={
+                "ANTHROPIC_AUTH_TOKEN": "sk-secret-token",
+                "ANTHROPIC_BASE_URL": "https://proxy.invalid/v1",
+                "PYTHONPATH": "/opt/vibesys",
+            },
+            log_path=log_path,
+        )
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc123\n", stderr=""
+        )
+
+        sandbox.start()
+
+        cmd_str = " ".join(mock_run.call_args_list[0][0][0])
+        assert "ANTHROPIC_AUTH_TOKEN=sk-secret-token" in cmd_str
+
+        log_text = log_path.read_text()
+        assert "sk-secret-token" not in log_text
+        assert "ANTHROPIC_AUTH_TOKEN=<redacted>" in log_text
+        # Endpoint selection is a diagnostic, not a credential.
+        assert "ANTHROPIC_BASE_URL=https://proxy.invalid/v1" in log_text
+        assert "PYTHONPATH=/opt/vibesys" in log_text
+
+    @patch("subprocess.run")
+    def test_credential_values_are_omitted_from_workspace_metadata(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        sandbox = DockerSandbox(
+            host_workspace=str(workspace),
+            image="pytorch:latest",
+            env={"ANTHROPIC_API_KEY": "sk-secret-key", "PYTHONPATH": "/opt/vibesys"},
+        )
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc123\n", stderr=""
+        )
+
+        sandbox.start()
+
+        metadata_text = (workspace / ".docker_metadata.json").read_text()
+        assert "sk-secret-key" not in metadata_text
+        assert json.loads(metadata_text)["env"] == {"PYTHONPATH": "/opt/vibesys"}
+
+    @patch("subprocess.run")
+    def test_start_failure_error_does_not_expose_credentials(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="pytorch:latest",
+            env={"ANTHROPIC_AUTH_TOKEN": "sk-secret-token"},
+        )
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=125, stdout="", stderr="boom"
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            sandbox.start()
+
+        assert "sk-secret-token" not in str(excinfo.value)
+        assert "ANTHROPIC_AUTH_TOKEN=<redacted>" in str(excinfo.value)
 
 
 class TestDevicePassthrough:

--- a/src/vibesys/_agent_cli/base.py
+++ b/src/vibesys/_agent_cli/base.py
@@ -87,6 +87,18 @@ class CodingAgent(ABC):
     subprocess working directory.
     """
 
+    native_output_schema_allows_arbitrary_keys = False
+    """Whether this provider's schema dialect accepts open-ended object maps.
+
+    The default is the strict subset (e.g. Codex's ``--output-schema``), which
+    requires every object to declare its properties and forbids undeclared keys,
+    so a Pydantic ``dict[str, T]`` field cannot be expressed natively. Providers
+    whose CLI accepts a schema-valued (or ``true``) ``additionalProperties``
+    (e.g. Claude Code's ``--json-schema``) set this ``True`` so mapping-bearing
+    response models keep the native structured-output path instead of falling
+    back to the prompt-level schema instruction.
+    """
+
     # Declared (not assigned) here: every concrete provider sets these in its
     # ``__init__``.  ``env`` is the subprocess environment the CLI is spawned
     # with; ``executor`` is the agentshim ``CommandExecutor`` (host, docker,

--- a/src/vibesys/_agent_cli/claude.py
+++ b/src/vibesys/_agent_cli/claude.py
@@ -66,6 +66,10 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
     # host and container execution paths, where the workspace is bind-mounted)
     # rather than the workspace-relative path Codex resolves against its cwd.
     native_output_schema_wants_absolute_path = True
+    # Unlike Codex's strict subset, ``--json-schema`` accepts open-ended object
+    # maps, so ``dict[str, T]`` fields (e.g. ``ImplementerResponse.metrics``)
+    # stay on the native path instead of degrading to the prompt hint.
+    native_output_schema_allows_arbitrary_keys = True
 
     def __init__(  # noqa: ANN204  # tracked: #288
         self,

--- a/src/vibesys/agents/__init__.py
+++ b/src/vibesys/agents/__init__.py
@@ -16,7 +16,7 @@ from vibesys.config import Config  # noqa: TC001  # tracked: #288
 from vibesys.constants import DEFAULT_AGENT_BACKEND, ComputeBackend
 from vibesys.features import FeatureFlag, is_feature_enabled
 
-from .base import AgentRunner
+from .base import AgentRunner, ResponseFallback
 from .progress import AgentProgress, CandidateProgress, RoundProgress
 
 # ``CliAgentRunner`` and ``DeepAgentsRunner`` are imported lazily to break a
@@ -39,6 +39,7 @@ __all__ = [
     "CandidateProgress",
     "CliAgentRunner",
     "DeepAgentsRunner",
+    "ResponseFallback",
     "RoundProgress",
     "build_agent_runner",
 ]

--- a/src/vibesys/agents/base.py
+++ b/src/vibesys/agents/base.py
@@ -17,8 +17,9 @@ session object; the default remains each runner's historical behavior.
 from __future__ import annotations
 
 from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from dataclasses import dataclass, field
 from pathlib import Path  # noqa: TC003  # tracked: #288
-from typing import Protocol, TypeVar
+from typing import Generic, Protocol, TypeVar
 
 from langchain_core.tools import BaseTool  # noqa: TC002  # tracked: #288
 from pydantic import BaseModel
@@ -27,6 +28,38 @@ from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #28
 from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 
 T = TypeVar("T", bound=BaseModel)
+
+
+@dataclass(slots=True)
+class ResponseFallback(Generic[T]):
+    """A ``fallback_factory`` that records whether the runner had to use it.
+
+    Every :meth:`AgentRunner.invoke` implementation calls ``fallback_factory``
+    exactly when the agent's output could not be parsed into ``response_cls``,
+    and returns the parsed response otherwise. Wrapping the factory turns that
+    framework-side event into a typed signal the caller can read after the
+    call, so a loop can tell a response it synthesized apart from one the agent
+    actually authored.
+
+    The signal deliberately lives here rather than on the response model: the
+    response schema is sent to the agent as its structured-output contract, and
+    a framework-only field would leak into it.
+
+    Instances are single-call scoped — construct one per ``invoke()``::
+
+        fallback = ResponseFallback(_missing_implementer_response)
+        response = ctx.invoke(..., fallback_factory=fallback)
+        if fallback.synthesized:
+            ...
+    """
+
+    build: Callable[[], T]
+    synthesized: bool = field(default=False, init=False)
+
+    def __call__(self) -> T:
+        """Build the fallback response and record that the runner needed it."""
+        self.synthesized = True
+        return self.build()
 
 
 class AgentRunner(Protocol):
@@ -72,7 +105,9 @@ class AgentRunner(Protocol):
             response_cls: Pydantic model class the agent should produce.
             fallback_factory: Constructs a default ``response_cls`` instance
                 used when the agent fails to produce a parseable response.
-                Implementations must call this rather than raise.
+                Implementations must call this rather than raise, and must
+                call it only for that reason — callers may wrap it in
+                :class:`ResponseFallback` to detect a synthesized response.
             round_label: Short label used in log headers (e.g. ``"judge #3"``).
             progress: Optional loop-owned progress state shown in the live
                 terminal prefix (e.g. ``RoundProgress(3, 24)``).

--- a/src/vibesys/agents/cli_common.py
+++ b/src/vibesys/agents/cli_common.py
@@ -73,17 +73,40 @@ _UNSUPPORTED_NATIVE_SCHEMA_KEYWORDS = frozenset(
 )
 
 
-def _validate_native_output_schema(schema: object) -> dict[str, object]:  # noqa: C901  # tracked: #288
-    """Normalize and validate the strict JSON Schema subset used by Codex.
+def _validate_native_output_schema(  # noqa: C901  # tracked: #288
+    schema: object,
+    *,
+    allow_arbitrary_keys: bool = False,
+) -> dict[str, object]:
+    """Normalize and validate the JSON Schema subset a provider accepts natively.
 
-    Native structured output requires every declared object property and
-    forbids undeclared keys. Pydantic omits defaulted properties from
-    ``required`` and represents arbitrary mappings with a schema-valued
-    ``additionalProperties``; the former is normalized here while the latter
-    falls back to the portable prompt contract.
+    The default (strict) profile is Codex's: every declared object property is
+    required and undeclared keys are forbidden. Pydantic omits defaulted
+    properties from ``required`` and represents arbitrary mappings with a
+    schema-valued ``additionalProperties``; the former is normalized here while
+    the latter is rejected so the caller can fall back to the portable prompt
+    contract.
+
+    *allow_arbitrary_keys* selects the permissive profile used by providers
+    whose CLI accepts open-ended object maps (see
+    :attr:`~vibesys._agent_cli.base.CodingAgent.native_output_schema_allows_arbitrary_keys`).
+    An existing ``additionalProperties`` is then preserved verbatim, and a
+    schema-valued one is still traversed so nested subschemas obey the same
+    rules. Objects that do not declare one are still closed with ``False``.
     """
     if not isinstance(schema, dict) or schema.get("type") != "object":
         raise ValueError("native output schema must have an object root")  # noqa: TRY003  # tracked: #288
+
+    def close_object(node: dict[str, object], location: str) -> None:
+        """Apply the profile's undeclared-key rule to one object node."""
+        additional = node.get("additionalProperties")
+        if additional in (None, False):
+            node["additionalProperties"] = False
+            return
+        if not allow_arbitrary_keys:
+            raise ValueError(f"native output schema uses arbitrary object keys at {location}")  # noqa: TRY003  # tracked: #288
+        # Preserved verbatim; a schema-valued map is traversed by the generic
+        # key walk below so nested subschemas obey the same rules.
 
     def visit(node: object, location: str) -> None:  # noqa: C901, PLR0912  # tracked: #288
         if isinstance(node, list):
@@ -106,16 +129,10 @@ def _validate_native_output_schema(schema: object) -> dict[str, object]:  # noqa
         if properties is not None:
             if not isinstance(properties, dict):
                 raise ValueError(f"native output schema {location}/properties must be an object")  # noqa: TRY003  # tracked: #288
-            additional = node.get("additionalProperties")
-            if additional not in (None, False):
-                raise ValueError(f"native output schema uses arbitrary object keys at {location}")  # noqa: TRY003  # tracked: #288
-            node["additionalProperties"] = False
+            close_object(node, location)
             node["required"] = list(properties)
         elif node.get("type") == "object":
-            additional = node.get("additionalProperties")
-            if additional not in (None, False):
-                raise ValueError(f"native output schema uses arbitrary object keys at {location}")  # noqa: TRY003  # tracked: #288
-            node["additionalProperties"] = False
+            close_object(node, location)
             node["required"] = []
         for key, value in node.items():
             if key in {"properties", "$defs", "definitions"}:
@@ -134,9 +151,22 @@ def _validate_native_output_schema(schema: object) -> dict[str, object]:  # noqa
     return schema
 
 
-def materialize_native_output_schema(workspace: Path, response_cls: type[BaseModel]) -> str:
-    """Atomically write a validated schema and return its relative CLI path."""
-    schema = _validate_native_output_schema(response_cls.model_json_schema())
+def materialize_native_output_schema(
+    workspace: Path,
+    response_cls: type[BaseModel],
+    *,
+    allow_arbitrary_keys: bool = False,
+) -> str:
+    """Atomically write a validated schema and return its relative CLI path.
+
+    *allow_arbitrary_keys* is the calling provider's
+    ``native_output_schema_allows_arbitrary_keys`` capability; it selects the
+    permissive validation profile for mapping-bearing response models.
+    """
+    schema = _validate_native_output_schema(
+        response_cls.model_json_schema(),
+        allow_arbitrary_keys=allow_arbitrary_keys,
+    )
     encoded = (json.dumps(schema, indent=2, sort_keys=True, allow_nan=False) + "\n").encode()
     digest = hashlib.sha256(encoded).hexdigest()[:16]
     relative = _NATIVE_SCHEMA_DIR / f"{response_cls.__name__}-{digest}.json"

--- a/src/vibesys/agents/cli_docker.py
+++ b/src/vibesys/agents/cli_docker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shlex
 from dataclasses import dataclass
 from pathlib import Path
@@ -220,6 +221,52 @@ DOCKER_AUTH_PATHS: dict[str, list[DockerAuthPath]] = {
         ),
     ],
 }
+
+
+# Host environment variables that carry provider authentication, forwarded
+# into the container alongside the staged files above.  A host may authenticate
+# a CLI entirely through the environment — an ``ANTHROPIC_AUTH_TOKEN`` plus
+# ``ANTHROPIC_BASE_URL`` pointing at a proxy or enterprise gateway is a
+# first-class Claude Code auth mechanism, and plain API keys are another — in
+# which case no provider state file exists to stage and the container CLI would
+# start unauthenticated.  Host sandboxes never hit this because they inherit
+# the host environment directly.
+#
+# Keep this registry to credential and endpoint variables.  Model-selection
+# variables such as ``ANTHROPIC_MODEL`` are deliberately excluded: VibeSys owns
+# per-role model selection, and forwarding a host export would let it silently
+# override the configured model inside the container.
+DOCKER_AUTH_ENV_VARS: dict[str, tuple[str, ...]] = {
+    "claude": (
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_CUSTOM_HEADERS",
+    ),
+    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    "codex": ("OPENAI_API_KEY", "OPENAI_BASE_URL"),
+    # OpenCode resolves credentials per *model* provider from the models.dev
+    # registry, so the variable names depend on whichever provider the user
+    # configured rather than on OpenCode itself; it documents no CLI-owned auth
+    # variable to enumerate here.  Its ``auth.json`` and config files are
+    # already staged through ``DOCKER_AUTH_PATHS``.
+    "opencode": (),
+}
+
+
+def auth_env_passthrough(provider: str) -> dict[str, str]:
+    """Return the host auth environment variables *provider* can actually use.
+
+    Unset and blank variables are dropped: an empty host export carries no
+    credential and must not shadow staged file authentication or make the
+    preflight check believe the container is authenticated.
+    """
+    values: dict[str, str] = {}
+    for name in DOCKER_AUTH_ENV_VARS.get(provider, ()):
+        value = os.environ.get(name)
+        if value and value.strip():
+            values[name] = value
+    return values
 
 
 def auth_bind_mounts(provider: str) -> list[tuple[str, str, bool]]:

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -186,7 +186,15 @@ class CliAgentRunner:
         )
         if native_schema_supported:
             try:
-                native_schema_path = materialize_native_output_schema(workspace, response_cls)
+                native_schema_path = materialize_native_output_schema(
+                    workspace,
+                    response_cls,
+                    allow_arbitrary_keys=getattr(
+                        self._provider_cls,
+                        "native_output_schema_allows_arbitrary_keys",
+                        False,
+                    ),
+                )
             except (OSError, TypeError, ValueError) as exc:
                 log_and_print(
                     f"[structured-output] native schema unavailable for "

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -1926,6 +1926,33 @@ def _run_framework_benchmark(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracke
     return feedback, None
 
 
+def _reconcile_model_requests(ctx: LoopContext) -> str | None:
+    """Stage any candidate-declared model weights before the framework gates.
+
+    The candidate may declare extra model weights it needs in
+    ``.vibesys/models.json`` (see ``vibesys.sandbox.model_requests``). This runs
+    once per gate invocation, before deploy; a malformed or disallowed manifest
+    is returned as gate feedback so the candidate can correct it rather than
+    crashing the run. Only meaningful for Modal runs (weights live in Modal
+    Volumes); a no-op otherwise.
+    """
+    if getattr(ctx.run_environment_view, "env_kind", "local") != "modal":
+        return None
+    from vibesys.sandbox.model_requests import (  # noqa: PLC0415  # tracked: #288
+        ModelRequestError,
+        reconcile_model_requests,
+    )
+
+    try:
+        volumes = reconcile_model_requests(ctx.workspace, log=ctx.lprint)
+    except ModelRequestError as exc:
+        ctx.lprint(f"[model-request] rejected: {exc}")
+        return f"Model-weight request could not be satisfied: {exc}"
+    if volumes:
+        ctx.lprint(f"[model-request] staged {len(volumes)} model volume(s): " + ", ".join(volumes))
+    return None
+
+
 def _run_framework_gates(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
@@ -1940,6 +1967,9 @@ def _run_framework_gates(  # noqa: PLR0913  # tracked: #288
 ) -> tuple[str | None, float | None, bool]:
     if ctx.agent_runner.backend_name == "stub":
         return None, None, False
+    resource_feedback = _reconcile_model_requests(ctx)
+    if resource_feedback is not None:
+        return resource_feedback, None, False
     if reuse_accuracy_pass:
         feedback = None
         issue_board.append_framework_accuracy_gate(

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any
 
+from vibesys.agents.base import ResponseFallback
 from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config, as_config
 from vibesys.constants import DEFAULT_AGENT_BACKEND, DEFAULT_COMPUTE_BACKEND, ComputeBackend
@@ -1018,6 +1019,21 @@ def _missing_implementer_response() -> ImplementerResponse:
     )
 
 
+@dataclass(frozen=True)
+class _ImplementerAttempt:
+    """One implementer turn plus who authored its response.
+
+    ``synthesized`` is True when the framework had to build the response with
+    :func:`_missing_implementer_response` because the turn's output did not
+    parse. Such a turn produced no reviewable evidence, so it must consume a
+    same-round retry rather than complete the round like a genuine
+    ``inconclusive`` result would.
+    """
+
+    response: ImplementerResponse
+    synthesized: bool
+
+
 def _validate_skill_selections(
     ctx: LoopContext,
     selections: list[SkillResourceSelection],
@@ -1086,7 +1102,7 @@ def _run_implementer(  # noqa: PLR0913  # tracked: #288
     official_evaluation_due: bool = False,
     official_evaluation_reason: str | None = None,
     prior_attempt_artifact_locations: tuple[str, ...] = (),
-) -> ImplementerResponse:
+) -> _ImplementerAttempt:
     plan.recommended_skills, resolved_skills = _validate_skill_selections(
         ctx, plan.recommended_skills
     )
@@ -1144,6 +1160,7 @@ def _run_implementer(  # noqa: PLR0913  # tracked: #288
         recommended_skills=resolved_skills,
         prior_attempt_artifact_locations=prior_attempt_artifact_locations,
     )
+    fallback = ResponseFallback(_missing_implementer_response)
     response = ctx.invoke(
         kind="implementer",
         system_prompt=system_prompt,
@@ -1154,7 +1171,7 @@ def _run_implementer(  # noqa: PLR0913  # tracked: #288
             else "Work persistently on the active hypothesis and return only the JSON object."
         ),
         response_cls=ImplementerResponse,
-        fallback_factory=_missing_implementer_response,
+        fallback_factory=fallback,
         round_label=f"round-{round_number}-retry-{retry}-implementer",
         reuse_session=True,
         session_key=f"hypothesis:{plan.hypothesis_id}",
@@ -1170,7 +1187,7 @@ def _run_implementer(  # noqa: PLR0913  # tracked: #288
     issue_board.write_implementer_artifact(progress_path, round_number, retry, response)
     issue_board.append_implementer(progress_path, round_number, retry, response)
     ctx.snapshot_workspace(f"round-{round_number}-retry-{retry}-implementer")
-    return response
+    return _ImplementerAttempt(response=response, synthesized=fallback.synthesized)
 
 
 def _run_judge(  # noqa: PLR0913  # tracked: #288
@@ -2364,7 +2381,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                             )
                         )
                         ctx.reselect_gpu()
-                        implementation = _run_implementer(
+                        attempt = _run_implementer(
                             ctx,
                             round_number=round_number,
                             retry=retry,
@@ -2392,6 +2409,26 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                             official_evaluation_reason=planned_official_reason,
                             prior_attempt_artifact_locations=prior_attempt_artifact_locations,
                         )
+                        implementation = attempt.response
+                        if attempt.synthesized:
+                            # The framework, not the implementer, wrote this
+                            # response because the turn's output did not parse.
+                            # It carries no reviewable evidence, so spend a
+                            # retry on a real turn instead of letting a parse
+                            # failure silently consume the whole round. When
+                            # retries are exhausted the round still commits the
+                            # fail-closed response, unreviewed, as before.
+                            ctx.lprint(
+                                f"[implementer] attempt {retry}/{max_retries_per_round} "
+                                "returned no parseable structured response; the framework "
+                                "synthesized a fail-closed one. "
+                                + (
+                                    "Retrying within the same round."
+                                    if retry < max_retries_per_round
+                                    else "Retries are exhausted; completing the round with it."
+                                )
+                            )
+                            continue
                         review_due = _review_due(
                             round_number=round_number,
                             max_rounds=max_rounds,

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -40,6 +40,7 @@ from vibesys.run import LoopContext, RepositoryVisibility, RunStateNamespace
 from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
+    run_environment_record,
 )
 from vibesys.schemas import (
     CandidateDisposition,
@@ -2082,6 +2083,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     normalized_config = as_config(config)
     project_configuration = AgentRunConfiguration(
         outer_loop="agent",
+        run_environment=run_environment_record(run_environment),
         inner_loop=inner_loop,
         interface=interface,
         model=normalized_config.model.name,

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -69,6 +69,7 @@ from vibesys.run import LoopContext, RepositoryVisibility, RunStateNamespace
 from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
+    run_environment_record,
 )
 from vibesys.schemas import JudgeResponse, MutatorResponse, ProfilerSummary, Verdict
 from vs_project import EvolveRunConfiguration
@@ -1329,6 +1330,7 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     selected_policy = SearchPolicyName(search_policy).value if search_policy is not None else None
     run_configuration = EvolveRunConfiguration(
         outer_loop="evolve",
+        run_environment=run_environment_record(run_environment),
         model=normalized_config.model.name,
         agent_backend=(agent_backend or normalized_config.agent.backend or DEFAULT_AGENT_BACKEND),
         cli_provider=cli_provider or normalized_config.agent.cli_provider or "codex",

--- a/src/vibesys/loops/plain/loop.py
+++ b/src/vibesys/loops/plain/loop.py
@@ -41,6 +41,7 @@ from vibesys.run import LoopContext, RepositoryVisibility, RunStateNamespace
 from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
+    run_environment_record,
 )
 from vibesys.schemas import (
     IssueImplementerResponse,
@@ -301,6 +302,7 @@ def run_plain_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     run_environment = run_environment or make_run_environment_spec()
     run_configuration = PlainRunConfiguration(
         outer_loop="plain",
+        run_environment=run_environment_record(run_environment),
         model=config.model.name,
         agent_backend=agent_backend or config.agent.backend or DEFAULT_AGENT_BACKEND,
         cli_provider=cli_provider or config.agent.cli_provider or "codex",

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -52,6 +52,7 @@ from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     build_run_environment,
     make_run_environment_spec,
+    run_environment_record,
 )
 from vibesys.skills import resolve_skill_source_dirs
 from vibesys.tui import KNOWN_TUI_THEMES, TuiTheme
@@ -63,6 +64,7 @@ from vs_project import (
     ProjectLayoutError,
     ProjectStateError,
     RunConfiguration,
+    RunSchemaMigrationRequiredError,
 )
 
 if TYPE_CHECKING:
@@ -111,6 +113,16 @@ _COMMON_RESUME_CLI_FIELDS: dict[str, str] = {
     "backend": "compute_backend",
     "profiler": "profiler",
     "modality": "modality",
+}
+
+# CLI destination -> ``RunEnvironmentRecord`` field for the runtime-environment
+# options. The environment kind itself comes from the ``--docker`` / ``--modal``
+# store-true flags and is handled separately.
+_RUN_ENVIRONMENT_OPTION_CLI_FIELDS: dict[str, str] = {
+    "docker_image": "image",
+    "modal_gpu": "gpu",
+    "modal_model_volume": "model_volume",
+    "modal_app": "app",
 }
 
 _AGENT_RESUME_CLI_FIELDS: dict[str, str] = {
@@ -473,7 +485,11 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--docker",
         action="store_true",
-        help="Run agent operations inside a Docker container.",
+        help=(
+            "Run agent operations inside a Docker container. On --resume the "
+            "recorded runtime environment is restored when no runtime-environment "
+            "flag is given, and a flag that contradicts the recording is rejected."
+        ),
     )
     parser.add_argument(
         "--docker-image",
@@ -491,7 +507,10 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
             "Use Modal for remote GPU dispatch. The agent (codex) still runs "
             "locally inside a Docker container for editing; GPU-bound code "
             "the implementer writes (decorated with `@app.cls` / `@app.function`) "
-            "is dispatched via `modal run`. Mutually exclusive with --docker."
+            "is dispatched via `modal run`. Mutually exclusive with --docker. "
+            "On --resume the recorded runtime environment is restored when no "
+            "runtime-environment flag is given, and a flag that contradicts the "
+            "recording is rejected."
         ),
     )
     parser.add_argument(
@@ -1201,6 +1220,42 @@ def _restore_resume_constraints(
     return requested != recorded.operator_constraints
 
 
+def _restore_resume_run_environment(
+    args: argparse.Namespace,
+    recorded: RunConfiguration,
+    explicit: frozenset[str],
+) -> list[str]:
+    """Restore the recorded runtime environment and reject contradictions.
+
+    ``--docker`` and ``--modal`` are store-true flags, so an omitted flag is
+    indistinguishable from ``--flag false``. The recorded environment therefore
+    wins whenever the resume invocation says nothing about it, and only an
+    explicitly passed flag that contradicts the recording is an error.
+    """
+    record = recorded.run_environment
+    changed: list[str] = []
+    if not hasattr(args, "docker") or not hasattr(args, "modal"):
+        return changed
+    if {"docker", "modal"} & explicit:
+        requested = "modal" if args.modal else "docker" if args.docker else "local"
+        if requested != record.name:
+            changed.append("run_environment")
+    else:
+        args.docker = record.name == "docker"
+        args.modal = record.name == "modal"
+
+    for destination, field in _RUN_ENVIRONMENT_OPTION_CLI_FIELDS.items():
+        if not hasattr(args, destination):
+            continue
+        expected = getattr(record, field)
+        if destination in explicit:
+            if getattr(args, destination) != expected:
+                changed.append(f"run_environment.{field}")
+        elif expected is not None:
+            setattr(args, destination, expected)
+    return changed
+
+
 def _normalized_resume_cli_value(destination: str, value: object) -> object:
     if destination == "backend" and value is not None:
         assert isinstance(value, ComputeBackend)  # noqa: S101  # argparse contract
@@ -1276,7 +1331,7 @@ def _restore_loop_resume_fields(
 ) -> tuple[dict[str, str], list[str]]:
     """Restore a loop's budget and return its immutable CLI field map."""
     fields = dict(_COMMON_RESUME_CLI_FIELDS)
-    changed: list[str] = []
+    changed: list[str] = _restore_resume_run_environment(args, recorded, explicit)
     if isinstance(recorded, AgentRunConfiguration):
         _restore_resume_budget(
             args,
@@ -1362,6 +1417,12 @@ def _resolve_resume_args(args: argparse.Namespace, *, loop_kind: str) -> None:
                 run_id = store.resolve_run().run_id
         _switch_project_resume_branch(project_root, run_id)
         run_manifest = store.load_run(run_id)
+    except RunSchemaMigrationRequiredError as exc:
+        _configuration_error(
+            f"{exc} Run: {_migrate_run_environment_command(project_root, exc.run_id)}",
+            code="project_run_schema_migration_required",
+            stage="resume_resolution",
+        )
     except ProjectStateError as exc:
         _configuration_error(
             f"Cannot resume project run: {exc}",
@@ -1406,6 +1467,111 @@ def _make_parser(prog: str, description: str) -> argparse.ArgumentParser:
     parser = _RunArgumentParser(prog=prog, description=description)
     _apply_common_args(parser)
     return parser
+
+
+# ---------------------------------------------------------------------------
+# Run metadata migration command
+# ---------------------------------------------------------------------------
+
+_MIGRATE_RUN_ENVIRONMENT_COMMAND = "migrate-run-environment"
+
+
+def _migrate_run_environment_command(project_root: Path, run_id: str) -> str:
+    """Render the operator command that migrates one run's recorded metadata."""
+    return shlex.join(
+        [
+            "vibesys",
+            _MIGRATE_RUN_ENVIRONMENT_COMMAND,
+            "--project",
+            str(project_root),
+            "--run",
+            run_id,
+            "--run-environment",
+            "local|docker|modal",
+        ]
+    )
+
+
+def _build_migrate_run_environment_parser() -> argparse.ArgumentParser:
+    parser = _RunArgumentParser(
+        prog=f"vibesys {_MIGRATE_RUN_ENVIRONMENT_COMMAND}",
+        description=(
+            "Record the runtime environment an existing run executes in. Run "
+            "metadata written before run schema version 2 never captured it, so "
+            "the operator supplies the environment the run was launched with. "
+            "The migration is one-way."
+        ),
+    )
+    parser.add_argument(
+        "--project",
+        type=Path,
+        default=None,
+        help="Project directory holding the run metadata. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--run",
+        default=None,
+        help="Run ID to migrate. Defaults to the project's current run.",
+    )
+    parser.add_argument(
+        "--run-environment",
+        choices=["local", "docker", "modal"],
+        required=True,
+        help="Runtime environment the run was launched with.",
+    )
+    # These mirror the run flags, defaults included, so a migrated recording is
+    # identical to what the same launch would have written today.
+    parser.add_argument("--docker-image", default=None, help="Recorded --docker-image value.")
+    parser.add_argument("--modal-gpu", default="H100!", help="Recorded --modal-gpu value.")
+    parser.add_argument(
+        "--modal-model-volume",
+        default=None,
+        help="Recorded --modal-model-volume value.",
+    )
+    parser.add_argument("--modal-app", default="vibesys", help="Recorded --modal-app value.")
+    return parser
+
+
+def _run_migrate_run_environment(argv: list[str]) -> None:
+    """Stamp an explicit runtime environment into one pre-version-2 run."""
+    args = _build_migrate_run_environment_parser().parse_args(argv)
+    project_root = (args.project or Path.cwd()).expanduser().resolve()
+    # Build the record through the same producer a fresh run uses so a migrated
+    # recording matches what the CLI would have written for those flags.
+    spec = make_run_environment_spec(
+        use_docker=args.run_environment == "docker",
+        use_modal=args.run_environment == "modal",
+        docker_image=args.docker_image,
+        modal_gpu=args.modal_gpu,
+        modal_model_volume=args.modal_model_volume,
+        modal_app=args.modal_app,
+    )
+    try:
+        store = Project.open(project_root).state
+        run_id = args.run or store.current_run_id()
+        if run_id is None:
+            _configuration_error(
+                f"No current run in {project_root}; pass --run RUN_ID",
+                code="migration_failed",
+                stage="run_migration",
+                exit_code=1,
+            )
+        manifest = store.migrate_run_environment(run_id, run_environment_record(spec))
+    except (ProjectLayoutError, ProjectStateError, ValueError) as exc:
+        _configuration_error(
+            f"Migration failed for VibeSys run in {project_root}: {exc}",
+            code="migration_failed",
+            stage="run_migration",
+            exit_code=1,
+        )
+
+    print(  # noqa: T201  # tracked: #288
+        f"Migrated run {manifest.run_id} to run schema version "
+        f"{manifest.schema_version}: run environment "
+        f"{manifest.configuration.run_environment.name}"
+    )
+    print(f"  metadata: {project_root}")  # noqa: T201  # tracked: #288
+    print("  commit the updated run metadata to keep the run branch clean.")  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
@@ -2303,6 +2469,9 @@ def _dispatch(argv: list[str]) -> None:
         return
     if argv and argv[0] == "validate":
         _run_validate(argv[1:])
+        return
+    if argv and argv[0] == _MIGRATE_RUN_ENVIRONMENT_COMMAND:
+        _run_migrate_run_environment(argv[1:])
         return
 
     invocation = parse_cli_invocation(argv)

--- a/src/vibesys/sandbox/modal_evaluator.py
+++ b/src/vibesys/sandbox/modal_evaluator.py
@@ -1,21 +1,36 @@
 """Run a trusted evaluator against a candidate deployed on Modal.
 
 The Modal run environment edits candidates in a local CPU-only container, so
-service-style evaluators cannot use their default localhost URL. This helper is
-mounted read-only by the runtime adapter. It deploys the current candidate,
-discovers the emitted web endpoint, waits for readiness, and appends ``--url``
-to the trusted evaluator command.
+service-style evaluators cannot reach the serving process at their default
+``http://localhost:8000``. This helper is mounted read-only by the runtime
+adapter. It deploys the current candidate, discovers the emitted web endpoint,
+waits for readiness, and then runs the trusted command *unmodified inside the
+serving container* (via ``modal container exec``) so the task's localhost
+measurement contract holds: metrics reflect the engine, not TLS, WAN, Modal
+ingress, or Modal's function-admission queue.
+
+The public endpoint is used only for deploy discovery, readiness, and periodic
+keep-warm probes during the in-container run (colocated traffic does not reset
+Modal's idle scaledown timer). Workspace-relative input files referenced by the
+command are staged into the container; absolute not-yet-existing paths in the
+command (for example a ``--output-json`` target) are relayed back to the caller
+after the run.
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
 import fcntl
+import io
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
+import tarfile
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -35,6 +50,14 @@ _DEPLOYMENT_LEASE_PATH = Path("/tmp/vibesys-modal-evaluator-deployment.json")  #
 _CANDIDATE_REVISION_ENV = "VIBESYS_CANDIDATE_REVISION"
 _RELEASE_DEPLOYMENT_ENV = "VIBESYS_RELEASE_MODAL_DEPLOYMENT"
 _MAX_DIAGNOSTIC_CHARS = 20_000
+_EXEC_RC_MARKER = "__VIBESYS_EXEC_RC__="
+_OUTPUT_FILE_MARKER = "__VIBESYS_OUTPUT_FILE__"
+_OUTPUT_END_MARKER = "__VIBESYS_OUTPUT_END__"
+# Linux caps a single argv string at 128 KiB; stay well under it per chunk.
+_B64_CHUNK_CHARS = 60_000
+_MAX_STAGE_ARCHIVE_BYTES = 8 * 1024 * 1024
+_CONTAINER_DISCOVERY_TIMEOUT_SECONDS = 90.0
+_KEEPWARM_INTERVAL_SECONDS = 30.0
 
 
 @dataclass(frozen=True)
@@ -236,6 +259,271 @@ def _deployment_path(workspace: str, entrypoint: str) -> Path:
     return candidate
 
 
+@dataclass(frozen=True)
+class _CommandTransferPlan:
+    """Files to stage into the serving container and outputs to relay back."""
+
+    stage_paths: tuple[str, ...]
+    output_paths: tuple[str, ...]
+
+
+def _plan_command_transfer(command: Sequence[str], workspace: str) -> _CommandTransferPlan:
+    """Classify command tokens into staged inputs and relayed outputs.
+
+    Workspace-relative tokens that resolve to files are staged with their
+    parent directory (scripts commonly import or read siblings); directory
+    tokens are staged whole. Absolute tokens that do not exist but whose
+    parent directory does are treated as output artifacts the command will
+    write, and are relayed back after the in-container run.
+    """
+    workspace_root = Path(workspace).resolve(strict=True)
+    staged: list[str] = []
+    outputs: list[str] = []
+    for token in command:
+        if not token or token.startswith("-"):
+            continue
+        if token.startswith("/"):
+            path = Path(token)
+            if not path.exists() and path.parent.is_dir() and token not in outputs:
+                outputs.append(token)
+            continue
+        candidate = workspace_root / token
+        try:
+            resolved = candidate.resolve(strict=True)
+            resolved.relative_to(workspace_root)
+        except (OSError, ValueError):
+            continue
+        if resolved.is_dir() or resolved.parent == workspace_root:
+            stage = resolved
+        else:
+            stage = resolved.parent
+        relative = stage.relative_to(workspace_root).as_posix()
+        if relative not in staged:
+            staged.append(relative)
+
+    def _covered(path: str) -> bool:
+        return any(other != path and path.startswith(f"{other}/") for other in staged)
+
+    kept = tuple(path for path in staged if not _covered(path))
+    return _CommandTransferPlan(stage_paths=kept, output_paths=tuple(outputs))
+
+
+def _build_stage_archive(workspace: str, stage_paths: Sequence[str]) -> bytes:
+    """Produce a gzipped tar of the staged paths, keyed by their relative paths."""
+    workspace_root = Path(workspace).resolve(strict=True)
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for relative in stage_paths:
+            archive.add(str(workspace_root / relative), arcname=relative)
+    payload = buffer.getvalue()
+    if len(payload) > _MAX_STAGE_ARCHIVE_BYTES:
+        raise ValueError(  # noqa: TRY003
+            f"evaluator inputs too large to stage into the serving container "
+            f"({len(payload)} bytes compressed, cap {_MAX_STAGE_ARCHIVE_BYTES})"
+        )
+    return payload
+
+
+def _find_app_container(
+    app_identifier: str,
+    *,
+    workspace: str,
+    base_url: str,
+    timeout_seconds: float = _CONTAINER_DISCOVERY_TIMEOUT_SECONDS,
+) -> str:
+    """Return the id of a running container for the deployed app.
+
+    Health probes double as warm-up: if the app scaled to zero between
+    readiness and discovery, probing the public endpoint starts a container.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    last_error = "no container listed"
+    while True:
+        try:
+            result = subprocess.run(  # tracked: #288
+                ["uv", "run", "modal", "container", "list", "--json"],  # noqa: S607  # tracked: #288
+                cwd=workspace,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=60,
+            )
+            entries = json.loads(result.stdout) if result.returncode == 0 else []
+        except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+            entries = []
+            last_error = f"{type(exc).__name__}: {exc}"
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("App Name") == app_identifier and entry.get("Container ID"):
+                return str(entry["Container ID"])
+        if time.monotonic() >= deadline:
+            raise TimeoutError(  # noqa: TRY003
+                f"no running container found for Modal app {app_identifier}: {last_error}"
+            )
+        _healthy_now(base_url)
+        time.sleep(5)
+
+
+def _bootstrap_script(command: Sequence[str], output_paths: Sequence[str]) -> str:
+    """Build the in-container POSIX shell bootstrap.
+
+    Receives the staged archive as base64 chunks in ``"$@"``, recreates the
+    workspace-relative layout in a temp directory, provides ``uv`` through a
+    ``python3 -m uv`` shim, runs the trusted command verbatim from that
+    directory (so its localhost defaults and relative paths hold), then emits
+    each existing output file and the command's exit code between sentinel
+    markers — ``modal container exec`` does not propagate exit codes.
+    """
+    quoted_command = " ".join(shlex.quote(token) for token in command)
+    relay_blocks = "\n".join(
+        f"if [ -f {shlex.quote(path)} ]; then\n"
+        f"  printf '\\n%s %s\\n' {shlex.quote(_OUTPUT_FILE_MARKER)} {shlex.quote(path)}\n"
+        f"  base64 {shlex.quote(path)}\n"
+        f"  printf '%s\\n' {shlex.quote(_OUTPUT_END_MARKER)}\n"
+        "fi"
+        for path in output_paths
+    )
+    return f"""set -u
+stage=$(mktemp -d /tmp/vibesys-eval-XXXXXX)
+printf '%s' "$@" | base64 -d | tar -xzf - -C "$stage"
+mkdir -p "$stage/.bin"
+printf '#!/bin/sh\\nexec python3 -m uv "$@"\\n' > "$stage/.bin/uv"
+chmod +x "$stage/.bin/uv"
+if ! python3 -m pip install --quiet --target "$stage/.pip" uv >&2; then
+  echo 'vibesys evaluator bootstrap failed: serving container lacks python3 -m pip' >&2
+  printf '\\n{_EXEC_RC_MARKER}%s\\n' 97
+  exit 0
+fi
+PATH="$stage/.bin:$PATH"; export PATH
+PYTHONPATH="$stage/.pip${{PYTHONPATH:+:$PYTHONPATH}}"; export PYTHONPATH
+UV_CACHE_DIR="$stage/.uv-cache"; export UV_CACHE_DIR
+cd "$stage"
+{quoted_command}
+rc=$?
+{relay_blocks}
+printf '\\n{_EXEC_RC_MARKER}%s\\n' "$rc"
+"""
+
+
+def _parse_exec_output(stdout: str) -> tuple[int | None, dict[str, bytes], str]:
+    """Split exec stdout into exit code, relayed output files, and passthrough."""
+    exit_code: int | None = None
+    files: dict[str, bytes] = {}
+    passthrough: list[str] = []
+    collecting: str | None = None
+    encoded: list[str] = []
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if collecting is not None:
+            if stripped == _OUTPUT_END_MARKER:
+                try:
+                    files[collecting] = base64.b64decode("".join(encoded))
+                except ValueError:
+                    files.pop(collecting, None)
+                collecting = None
+                encoded = []
+            else:
+                encoded.append(stripped)
+            continue
+        if stripped.startswith(f"{_OUTPUT_FILE_MARKER} "):
+            collecting = stripped[len(_OUTPUT_FILE_MARKER) + 1 :]
+            continue
+        if stripped.startswith(_EXEC_RC_MARKER):
+            suffix = stripped[len(_EXEC_RC_MARKER) :]
+            if suffix.isdigit():
+                exit_code = int(suffix)
+            continue
+        passthrough.append(line)
+    return exit_code, files, "\n".join(passthrough)
+
+
+class _DeploymentKeepWarm:
+    """Probe the public endpoint periodically while the colocated run executes.
+
+    Colocated traffic never crosses Modal ingress, so it does not reset the
+    app's idle scaledown timer; without these probes Modal may retire the
+    serving container mid-measurement.
+    """
+
+    def __init__(self, base_url: str) -> None:
+        self._base_url = base_url
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def __enter__(self) -> _DeploymentKeepWarm:
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._stop.set()
+        self._thread.join(timeout=10)
+
+    def _run(self) -> None:
+        while not self._stop.wait(_KEEPWARM_INTERVAL_SECONDS):
+            _healthy_now(self._base_url)
+
+
+def _execute_colocated(
+    command: Sequence[str],
+    *,
+    workspace: str,
+    app_identifier: str,
+    base_url: str,
+) -> int:
+    """Run the trusted command inside the app's serving container."""
+    plan = _plan_command_transfer(command, workspace)
+    archive = _build_stage_archive(workspace, plan.stage_paths)
+    encoded = base64.b64encode(archive).decode("ascii")
+    chunks = [
+        encoded[offset : offset + _B64_CHUNK_CHARS]
+        for offset in range(0, len(encoded), _B64_CHUNK_CHARS)
+    ] or [""]
+    container_id = _find_app_container(
+        app_identifier,
+        workspace=workspace,
+        base_url=base_url,
+    )
+    script = _bootstrap_script(command, plan.output_paths)
+    with _DeploymentKeepWarm(base_url):
+        result = subprocess.run(  # noqa: S603  # tracked: #288
+            [  # noqa: S607  # tracked: #288
+                "uv",
+                "run",
+                "modal",
+                "container",
+                "exec",
+                container_id,
+                "--",
+                "sh",
+                "-c",
+                script,
+                "vibesys-eval",
+                *chunks,
+            ],
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    exit_code, files, passthrough = _parse_exec_output(result.stdout)
+    if passthrough:
+        print(passthrough)  # noqa: T201  # tracked: #288
+    if result.stderr:
+        print(result.stderr, file=sys.stderr, end="")  # noqa: T201  # tracked: #288
+    for path, payload in files.items():
+        Path(path).write_bytes(payload)
+    if exit_code is None:
+        tail = result.stdout[-_MAX_DIAGNOSTIC_CHARS:]
+        print(  # noqa: T201  # tracked: #288
+            "Modal evaluator exec did not report an exit code "
+            f"(modal exit {result.returncode}); output tail:\n{tail}",
+            file=sys.stderr,
+        )
+        return result.returncode or 1
+    return exit_code
+
+
 def run_evaluator(
     command: Sequence[str],
     *,
@@ -243,7 +531,7 @@ def run_evaluator(
     entrypoint: str = "main.py",
     readiness_timeout_seconds: float = 90,
 ) -> int:
-    """Deploy the candidate and run ``command`` against its live URL."""
+    """Deploy the candidate and run ``command`` inside its serving container."""
     if not command:
         raise ValueError("missing evaluator command after '--'")  # noqa: TRY003  # tracked: #288
 
@@ -256,7 +544,7 @@ def run_evaluator(
         )
 
 
-def _run_evaluator_unlocked(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
+def _run_evaluator_unlocked(  # noqa: C901, PLR0911, PLR0912, PLR0915  # tracked: #288
     command: Sequence[str],
     *,
     workspace: str,
@@ -267,19 +555,26 @@ def _run_evaluator_unlocked(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
     if candidate_revision:
         lease = _read_deployment_lease()
         if lease is not None:
-            if lease.candidate_revision == candidate_revision and _healthy_now(lease.base_url):
+            if (
+                lease.candidate_revision == candidate_revision
+                and lease.app_identifier is not None
+                and _healthy_now(lease.base_url)
+            ):
                 print(  # noqa: T201  # tracked: #288
                     "Reusing healthy Modal deployment for candidate revision "
                     f"{candidate_revision}.",
                     file=sys.stderr,
                 )
                 try:
-                    result = subprocess.run(  # noqa: S603  # tracked: #288
-                        [*command, "--url", lease.base_url],
-                        cwd=workspace,
-                        check=False,
+                    return _execute_colocated(
+                        command,
+                        workspace=workspace,
+                        app_identifier=lease.app_identifier,
+                        base_url=lease.base_url,
                     )
-                    return result.returncode
+                except (TimeoutError, ValueError) as exc:
+                    print(f"Modal evaluator setup failed: {exc}", file=sys.stderr)  # noqa: T201
+                    return 1
                 finally:
                     if _release_requested():
                         _retire_deployment(lease, workspace=workspace)
@@ -307,18 +602,16 @@ def _run_evaluator_unlocked(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
     app_identifier: str | None = None
     try:
         base_url = extract_modal_web_url(deploy_output)
-        try:  # noqa: SIM105  # tracked: #288
-            app_identifier = extract_modal_app_identifier(deploy_output)
-        except ValueError:
-            pass
+        app_identifier = extract_modal_app_identifier(deploy_output)
         wait_for_health(base_url, timeout_seconds=readiness_timeout_seconds)
     except (TimeoutError, ValueError) as exc:
         print(f"Modal evaluator setup failed: {exc}", file=sys.stderr)  # noqa: T201  # tracked: #288
-        try:
-            app_identifier = extract_modal_app_identifier(deploy_output)
-        except ValueError:
-            pass
-        else:
+        if app_identifier is None:
+            try:  # noqa: SIM105  # tracked: #288
+                app_identifier = extract_modal_app_identifier(deploy_output)
+            except ValueError:
+                pass
+        if app_identifier is not None:
             print(  # noqa: T201  # tracked: #288
                 f"Recent Modal logs:\n{recent_modal_logs(app_identifier, workspace=workspace)}",
                 file=sys.stderr,
@@ -330,12 +623,15 @@ def _run_evaluator_unlocked(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
         _write_deployment_lease(candidate_revision, base_url, app_identifier)
 
     try:
-        result = subprocess.run(  # noqa: S603  # tracked: #288
-            [*command, "--url", base_url],
-            cwd=workspace,
-            check=False,
+        return _execute_colocated(
+            command,
+            workspace=workspace,
+            app_identifier=app_identifier,
+            base_url=base_url,
         )
-        return result.returncode
+    except (TimeoutError, ValueError) as exc:
+        print(f"Modal evaluator setup failed: {exc}", file=sys.stderr)  # noqa: T201  # tracked: #288
+        return 1
     finally:
         if _release_requested():
             lease = _read_deployment_lease()
@@ -345,7 +641,7 @@ def _run_evaluator_unlocked(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
                 and lease.candidate_revision == candidate_revision
             ):
                 _retire_deployment(lease, workspace=workspace)
-            elif app_identifier is not None:
+            else:
                 _stop_modal_app(app_identifier, workspace=workspace)
 
 

--- a/src/vibesys/sandbox/modal_evaluator.py
+++ b/src/vibesys/sandbox/modal_evaluator.py
@@ -348,15 +348,23 @@ def _find_app_container(
                 check=False,
                 timeout=60,
             )
-            entries = json.loads(result.stdout) if result.returncode == 0 else []
+            if result.returncode == 0:
+                entries = json.loads(result.stdout)
+            else:
+                entries = []
+                last_error = f"container list exited {result.returncode}: {result.stderr.strip()}"
         except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
             entries = []
             last_error = f"{type(exc).__name__}: {exc}"
         for entry in entries:
             if not isinstance(entry, dict):
                 continue
-            if entry.get("App Name") == app_identifier and entry.get("Container ID"):
-                return str(entry["Container ID"])
+            # Key style varies across modal client versions: 1.5.x emits
+            # snake_case ("app_name"), older clients title case ("App Name").
+            name = entry.get("app_name") or entry.get("App Name")
+            container_id = entry.get("container_id") or entry.get("Container ID")
+            if name == app_identifier and container_id:
+                return str(container_id)
         if time.monotonic() >= deadline:
             raise TimeoutError(  # noqa: TRY003
                 f"no running container found for Modal app {app_identifier}: {last_error}"

--- a/src/vibesys/sandbox/model_requests.py
+++ b/src/vibesys/sandbox/model_requests.py
@@ -1,0 +1,149 @@
+"""Candidate-declared model-weight requests.
+
+A candidate may declare additional model weights its implementation needs by
+writing a small manifest to ``.vibesys/models.json`` in its workspace root.
+Between rounds, before the framework deploys the candidate for its accuracy and
+benchmark gates, the framework reads this manifest and ensures each requested
+model is staged into a Modal Volume. Staging is idempotent: a volume that
+already carries the ready sentinel is a no-op, so reconciling every round (and
+again on resume) is cheap and safe.
+
+This is a general resource-request mechanism, deliberately narrow: the manifest
+expresses only *which model weights* the implementation needs. It cannot change
+the measurement envelope (GPU count, GPU type, benchmark configuration), which
+stays operator-owned. An operator may further restrict which repositories are
+permitted via the ``VIBESYS_MODEL_REQUEST_ALLOW`` environment variable (a
+comma-separated list of allowed HuggingFace repo-id prefixes); unset means no
+prefix restriction.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003  # tracked: #288
+
+MODEL_MANIFEST_RELPATH = ".vibesys/models.json"
+_ALLOW_ENV_VAR = "VIBESYS_MODEL_REQUEST_ALLOW"
+
+
+class ModelRequestError(ValueError):
+    """Raised when a model-request manifest is malformed or disallowed."""
+
+
+@dataclass(frozen=True)
+class ModelRequest:
+    """A single requested model: a HuggingFace repo id and optional revision."""
+
+    model_id: str
+    revision: str | None = None
+
+
+def read_model_requests(workspace: Path) -> list[ModelRequest]:
+    """Parse ``.vibesys/models.json`` under *workspace*.
+
+    Accepts either a bare JSON list of entries or an object with a ``"models"``
+    list. Each entry is ``{"id": "<repo-id>", "revision": "<optional>"}`` (the
+    key ``"model_id"`` is accepted as an alias for ``"id"``). Duplicate ids are
+    collapsed, keeping the first occurrence. A missing file yields ``[]``.
+
+    Raises:
+        ModelRequestError: on invalid JSON or an entry that is not a mapping
+            with a non-empty string id (and, if present, a string revision).
+    """
+    path = workspace / MODEL_MANIFEST_RELPATH
+    if not path.exists():
+        return []
+    try:
+        raw = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ModelRequestError(  # noqa: TRY003  # tracked: #288
+            f"{MODEL_MANIFEST_RELPATH} is not valid JSON: {exc}"
+        ) from exc
+
+    entries = raw.get("models") if isinstance(raw, dict) else raw
+    if not isinstance(entries, list):
+        raise ModelRequestError(  # noqa: TRY003  # tracked: #288
+            f"{MODEL_MANIFEST_RELPATH} must be a JSON list of model objects, "
+            'or an object with a "models" list'
+        )
+
+    requests: list[ModelRequest] = []
+    seen: set[str] = set()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ModelRequestError(  # noqa: TRY003  # tracked: #288
+                f"{MODEL_MANIFEST_RELPATH} entry {index} is not an object"
+            )
+        model_id = entry.get("id") or entry.get("model_id")
+        if not isinstance(model_id, str) or not model_id.strip():
+            raise ModelRequestError(  # noqa: TRY003  # tracked: #288
+                f"{MODEL_MANIFEST_RELPATH} entry {index} needs a non-empty "
+                'string "id" (the HuggingFace repo id)'
+            )
+        revision = entry.get("revision")
+        if revision is not None and not isinstance(revision, str):
+            raise ModelRequestError(  # noqa: TRY003  # tracked: #288
+                f'{MODEL_MANIFEST_RELPATH} entry {index} "revision" must be a string'
+            )
+        model_id = model_id.strip()
+        if model_id in seen:
+            continue
+        seen.add(model_id)
+        requests.append(ModelRequest(model_id=model_id, revision=revision))
+    return requests
+
+
+def _allow_prefixes() -> tuple[str, ...] | None:
+    """Return operator-configured allowed repo-id prefixes, or None if unset."""
+    raw = os.environ.get(_ALLOW_ENV_VAR, "").strip()
+    if not raw:
+        return None
+    return tuple(prefix.strip() for prefix in raw.split(",") if prefix.strip())
+
+
+def check_allowed(model_id: str, allow: tuple[str, ...] | None) -> bool:
+    """Return True if *model_id* is permitted by the *allow* prefix list.
+
+    ``allow=None`` means no prefix restriction (all model ids permitted).
+    """
+    if allow is None:
+        return True
+    return any(model_id.startswith(prefix) for prefix in allow)
+
+
+def reconcile_model_requests(
+    workspace: Path,
+    *,
+    log: Callable[[str], object] = print,
+) -> list[str]:
+    """Ensure every model declared under *workspace* is staged into a Volume.
+
+    Returns the list of provisioned Modal Volume names (empty when the manifest
+    is absent or empty). Idempotent: already-ready volumes are skipped by
+    :func:`vs_sandbox.ensure_model_volume`.
+
+    Raises:
+        ModelRequestError: if the manifest is malformed or requests a model that
+            the operator allowlist does not permit.
+    """
+    requests = read_model_requests(workspace)
+    if not requests:
+        return []
+
+    from vs_sandbox import ensure_model_volume  # noqa: PLC0415  # tracked: #288
+
+    allow = _allow_prefixes()
+    volumes: list[str] = []
+    for request in requests:
+        if not check_allowed(request.model_id, allow):
+            raise ModelRequestError(  # noqa: TRY003  # tracked: #288
+                f"model request {request.model_id!r} is not permitted by "
+                f"{_ALLOW_ENV_VAR}={os.environ.get(_ALLOW_ENV_VAR)!r}"
+            )
+        suffix = f"@{request.revision}" if request.revision else ""
+        log(f"[model-request] ensuring weights for {request.model_id}{suffix}")
+        volumes.append(ensure_model_volume(request.model_id, revision=request.revision, log=log))
+    return volumes

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -45,9 +45,11 @@ from vibesys.domains.environment import EnvironmentBindMount  # noqa: TC001  # t
 from vibesys.evaluators import PROJECT_ROOT_TOKEN, load_evaluator_package
 from vibesys.input_manifest import WorkspaceSource  # noqa: TC001  # tracked: #288
 from vibesys.profilers import ProfilerKind
+from vs_project import RunEnvironmentRecord
 from vs_sandbox import ProjectPathPolicy
 
 _SHELL_COMMAND_ARG_COUNT = 3
+_RECORDED_ENVIRONMENT_NAMES = frozenset({"local", "docker", "modal"})
 
 
 @dataclass(frozen=True)
@@ -653,6 +655,30 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
             ),
             deployment_name=candidate_name,
         )
+
+
+def run_environment_record(spec: RunEnvironmentSpec) -> RunEnvironmentRecord:
+    """Project a CLI-built spec onto the record persisted with the run.
+
+    Only operator-selected options are recorded, under the spec's own option
+    names. The candidate's Modal entrypoint is deliberately excluded: it is
+    declared by the input bundle and re-derived on every launch, so recording
+    it would make a legitimate task edit look like a resume mismatch.
+    """
+    if spec.name not in _RECORDED_ENVIRONMENT_NAMES:
+        raise ValueError(f"unknown run environment: {spec.name!r}")  # noqa: TRY003  # tracked: #288
+    return RunEnvironmentRecord(
+        name=spec.name,  # pyright: ignore[reportArgumentType]
+        image=_recorded_option(spec, "image"),
+        gpu=_recorded_option(spec, "gpu"),
+        model_volume=_recorded_option(spec, "model_volume"),
+        app=_recorded_option(spec, "app"),
+    )
+
+
+def _recorded_option(spec: RunEnvironmentSpec, key: str) -> str | None:
+    value = spec.options.get(key)
+    return str(value) if value else None
 
 
 def build_run_environment(spec: RunEnvironmentSpec) -> RunEnvironment:  # noqa: D103  # tracked: #288

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -1394,14 +1394,35 @@ def _cli_container_setup(
     if effective_agent != "cli" or not request.cli_provider:
         return [], {}
     from vibesys.agents.cli_docker import (  # noqa: PLC0415  # tracked: #288
+        DOCKER_AUTH_ENV_VARS,
+        DOCKER_AUTH_PATHS,
         DOCKER_PROVIDER_ENV,
         auth_copy_commands,
+        auth_env_passthrough,
         docker_init_commands,
     )
 
     provider = request.cli_provider
+    auth_commands = auth_copy_commands(provider)
+    auth_env = auth_env_passthrough(provider)
+    if not auth_commands and not auth_env:
+        checked_files = (
+            ", ".join(str(spec.host_path) for spec in DOCKER_AUTH_PATHS.get(provider, []))
+            or "<none registered>"
+        )
+        checked_env = ", ".join(DOCKER_AUTH_ENV_VARS.get(provider, ())) or "<none registered>"
+        raise ValueError(  # noqa: TRY003  # tracked: #288
+            f"no {provider!r} CLI authentication is available for the container: "
+            f"none of the host files exist ({checked_files}) and none of the "
+            f"environment variables are set ({checked_env}). Authenticate the "
+            f"{provider} CLI on this host, or export one of those variables, "
+            "before running in an isolated environment."
+        )
     env = dict(DOCKER_PROVIDER_ENV.get(provider, {}))
-    commands = [*auth_copy_commands(provider), *docker_init_commands(provider)]
+    # Container processes inherit only what ``docker run -e`` sets; the editor
+    # container has no other view of the host environment.
+    env.update(auth_env)
+    commands = [*auth_commands, *docker_init_commands(provider)]
     return commands, env
 
 

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -896,6 +896,16 @@ def _modal_runtime_notes(
         "Use `modal.Volume.from_name(<that-name>)` and mount it at "
         "whatever container path you prefer (no fixed convention is "
         "required).\n"
+        "  - If your implementation needs model weights beyond those the "
+        "task pre-stages, declare them in `.vibesys/models.json` in your "
+        'workspace root: a JSON list of `{"id": "<huggingface-repo-id>", '
+        '"revision": "<optional>"}` entries (or `{"models": [...]}`). Between '
+        "rounds, before measurement, the framework stages each requested "
+        "repository into its own `vibesys-model-<normalized-id>` Volume using "
+        "the exact naming rule above; mount them the same way. This request "
+        "covers model weights only and cannot change the GPU or benchmark "
+        "configuration. An operator allowlist may restrict which repositories "
+        "are permitted; a rejected request comes back as gate feedback.\n"
         f"  - **The `{reference_path}/` directory (meta.json, config.json, "
         "reference.py) exists ONLY in this local editor container — it is "
         "NOT present inside the deployed Modal container.** Reading "

--- a/tests/_agent_cli/test_claude.py
+++ b/tests/_agent_cli/test_claude.py
@@ -16,6 +16,17 @@ _SCHEMA = {
     "additionalProperties": False,
 }
 
+# Shape produced by a ``dict[str, float]`` field (e.g.
+# ``ImplementerResponse.metrics``): arbitrary keys with a constrained value type.
+_MAPPING_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "metrics": {"type": "object", "additionalProperties": {"type": "number"}},
+    },
+    "required": ["metrics"],
+    "additionalProperties": False,
+}
+
 
 class _MockCommandExecutor:
     """CommandExecutor that avoids real binary lookups."""
@@ -125,6 +136,35 @@ class TestClaudeNativeOutputSchema:
         # ``--json-schema`` is read inline at build time, so the schema file
         # path must be resolvable independent of the subprocess cwd.
         assert ClaudeCodeCodingAgent.native_output_schema_wants_absolute_path is True
+
+    def test_allows_arbitrary_object_keys(self):  # noqa: ANN202  # tracked: #288
+        # ``--json-schema`` accepts open-ended maps (verified against Claude
+        # Code 2.1.221), unlike Codex's strict ``--output-schema`` subset.
+        assert ClaudeCodeCodingAgent.native_output_schema_allows_arbitrary_keys is True
+
+    def test_mapping_schema_reaches_the_session_and_yields_structured_output(  # noqa: ANN202  # tracked: #288
+        self,
+        agent,  # noqa: ANN001  # tracked: #288
+        tmp_path,  # noqa: ANN001  # tracked: #288
+    ):
+        """A ``dict[str, float]`` field stays native: inlined, then captured back."""
+        schema_file = tmp_path / "schema.json"
+        schema_file.write_text(json.dumps(_MAPPING_SCHEMA), encoding="utf-8")
+        agent.set_output_schema_path(str(schema_file))
+        payload = {"metrics": {"latency_ms": 12.5, "throughput": 3.0}}
+        agent.executor = _ReplayExecutor(
+            [json.dumps({"type": "result", "result": "done", "structured_output": payload}) + "\n"]
+        )
+
+        cmd = agent._get_command("test prompt")  # noqa: SLF001  # tracked: #288
+        session = agent._create_session(cmd=cmd)  # noqa: SLF001  # tracked: #288
+        result = session.run("test prompt")
+
+        # The mapping survives into argv rather than being flattened away.
+        inline = json.loads(cmd[cmd.index("--json-schema") + 1])
+        assert inline == _MAPPING_SCHEMA
+        assert inline["properties"]["metrics"]["additionalProperties"] == {"type": "number"}
+        assert json.loads(result) == payload
 
     def test_command_omits_json_schema_when_unset(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
         cmd = agent._get_command("test prompt")  # noqa: SLF001  # tracked: #288

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -18,6 +18,7 @@ from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config
 from vibesys.constants import ComputeBackend
 from vibesys.schemas import (
+    ImplementerResponse,
     IssueJudgeResponse,
     JudgeResponse,
     Verdict,
@@ -28,6 +29,10 @@ from vs_sandbox import HostResource, ProjectPathPolicy
 def _agent_config(**agent) -> Config:  # noqa: ANN003  # tracked: #288
     """Minimal valid Config carrying just an ``[agent]`` section for runner tests."""
     return Config.model_validate({"model": {"name": "m"}, "agent": agent})
+
+
+def _implementer_fallback() -> ImplementerResponse:
+    return ImplementerResponse(summary="fallback", expected_behavior="fallback")
 
 
 def _judge_fallback() -> JudgeResponse:
@@ -1245,6 +1250,82 @@ class TestCliAgentRunner:
         assert Path(passed).is_file()
         assert Path(passed).parent == workspace / ".cache/vibesys/response-schemas"
         assert "Schema for JudgeResponse" not in agent.generate_calls[0]["prompt"]
+
+    def test_mapping_response_stays_native_on_a_permissive_provider(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        """``ImplementerResponse.metrics`` is a ``dict[str, float]``; Claude's
+        ``--json-schema`` accepts that, so the native path must be kept."""
+        captured: list = []
+        fake_cls = _make_fake_agent_class(
+            generate_returns='{"summary": "ok", "expected_behavior": "faster"}',
+            captured=captured,
+        )
+        fake_cls.supports_native_output_schema = True
+        fake_cls.native_output_schema_wants_absolute_path = True
+        fake_cls.native_output_schema_allows_arbitrary_keys = True
+        monkeypatch.setitem(
+            __import__(  # noqa: SLF001  # tracked: #288
+                "vibesys.agents.cli_runner",
+                fromlist=["_PROVIDER_CLASSES"],
+            )._PROVIDER_CLASSES,
+            "claude",
+            fake_cls,
+        )
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        runner = CliAgentRunner(provider="claude", model="m", run_log_file=None)
+
+        runner.invoke(
+            kind="implementer",
+            workspace=workspace,
+            system_prompt="THE-SYSTEM-PROMPT",
+            user_prompt="usr",
+            response_cls=ImplementerResponse,
+            fallback_factory=_implementer_fallback,
+            round_label="implementer #1",
+        )
+
+        agent = captured[0]
+        passed = agent.output_schema_paths[-1]
+        assert passed is not None
+        schema = json.loads(Path(passed).read_text())
+        assert schema["properties"]["metrics"]["additionalProperties"] == {"type": "number"}
+        assert "Schema for ImplementerResponse" not in agent.generate_calls[0]["prompt"]
+
+    def test_mapping_response_falls_back_on_a_strict_provider(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        """Codex's subset cannot express the mapping, so the prompt hint stays."""
+        captured: list = []
+        fake_cls = _make_fake_agent_class(
+            generate_returns='{"summary": "ok", "expected_behavior": "faster"}',
+            captured=captured,
+        )
+        fake_cls.supports_native_output_schema = True
+        monkeypatch.setitem(
+            __import__(  # noqa: SLF001  # tracked: #288
+                "vibesys.agents.cli_runner",
+                fromlist=["_PROVIDER_CLASSES"],
+            )._PROVIDER_CLASSES,
+            "codex",
+            fake_cls,
+        )
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        log = StringIO()
+        runner = CliAgentRunner(provider="codex", model="m", run_log_file=log)
+
+        runner.invoke(
+            kind="implementer",
+            workspace=workspace,
+            system_prompt="THE-SYSTEM-PROMPT",
+            user_prompt="usr",
+            response_cls=ImplementerResponse,
+            fallback_factory=_implementer_fallback,
+            round_label="implementer #1",
+        )
+
+        agent = captured[0]
+        assert agent.output_schema_paths == [None]
+        assert "Schema for ImplementerResponse" in agent.generate_calls[0]["prompt"]
+        assert "using prompt fallback" in log.getvalue()
 
     def test_cli_runner_chat_returns_plain_text_in_a_fresh_session_per_turn(  # noqa: ANN201  # tracked: #288
         self,

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibesys.agent_runner import log_json_and_print, log_prompt_markdown_and_print
-from vibesys.agents import build_agent_runner
+from vibesys.agents import ResponseFallback, build_agent_runner
 from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.cli_runner import CliAgentRunner
 from vibesys.agents.deepagents_runner import DeepAgentsRunner
@@ -827,6 +827,53 @@ class TestCliAgentRunner:
         assert "Failure" in stdout
         assert "# Failure" in stdout
         assert "**JSON**" in stdout
+
+    @pytest.mark.parametrize(
+        ("generate_returns", "expect_synthesized"),
+        [
+            ("not json at all", True),
+            ('{"analysis": "ok", "feedback": "", "verdict": "pass"}', False),
+        ],
+    )
+    def test_response_fallback_reports_who_authored_the_response(  # noqa: ANN201  # tracked: #288
+        self,
+        monkeypatch,  # noqa: ANN001  # tracked: #288
+        tmp_path,  # noqa: ANN001  # tracked: #288
+        generate_returns,  # noqa: ANN001  # tracked: #288
+        expect_synthesized,  # noqa: ANN001  # tracked: #288
+    ):
+        """Callers must be able to tell a synthesized response from a parsed one."""
+        captured: list = []
+        fake_cls = _make_fake_agent_class(
+            generate_returns=generate_returns,
+            captured=captured,
+        )
+        monkeypatch.setitem(
+            __import__(  # noqa: SLF001  # tracked: #288
+                "vibesys.agents.cli_runner",
+                fromlist=["_PROVIDER_CLASSES"],
+            )._PROVIDER_CLASSES,
+            "claude",
+            fake_cls,
+        )
+
+        runner = CliAgentRunner(provider="claude", model="m", run_log_file=None)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+
+        fallback = ResponseFallback(_judge_fallback)
+        result = runner.invoke(
+            kind="judge",
+            workspace=workspace,
+            system_prompt="sys",
+            user_prompt="usr",
+            response_cls=JudgeResponse,
+            fallback_factory=fallback,
+            round_label="judge #1",
+        )
+
+        assert fallback.synthesized is expect_synthesized
+        assert (result.analysis == "fallback") is expect_synthesized
 
     def test_cli_runner_passes_progress_to_logger(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []

--- a/tests/agents/test_cli_common.py
+++ b/tests/agents/test_cli_common.py
@@ -24,10 +24,27 @@ from vibesys.agents.cli_common import (
 )
 from vibesys.schemas import (
     ImplementerResponse,
+    IssuePerfEvalResponse,
     JudgeResponse,
     OrchestratorPlan,
+    PerfEvalResponse,
+    PerfMetrics,
     PreRoundDecision,
+    ProfilerSummary,
+    SingleAgentRoundResponse,
 )
+
+# Response models with at least one ``dict[str, T]`` field, which Pydantic
+# renders as a schema-valued (or ``true``) ``additionalProperties``. Providers
+# on the strict profile cannot express these natively; permissive ones can.
+MAPPING_RESPONSE_MODELS = [
+    ImplementerResponse,
+    SingleAgentRoundResponse,
+    ProfilerSummary,
+    PerfMetrics,
+    PerfEvalResponse,
+    IssuePerfEvalResponse,
+]
 
 
 def _skill(root: Path, name: str, body: str = "# skill\n") -> Path:
@@ -192,6 +209,35 @@ class TestBuildSchemaHint:
         assert "Do not wrap it in markdown fences" in build_schema_hint(JudgeResponse)
 
 
+def _assert_declared_objects_are_closed(node) -> None:  # noqa: ANN001  # tracked: #288
+    """Every object that declares properties requires all of them and is closed."""
+    if isinstance(node, list):
+        for value in node:
+            _assert_declared_objects_are_closed(value)
+    elif isinstance(node, dict):
+        if "$ref" in node:
+            assert set(node) == {"$ref"}
+        if "properties" in node:
+            assert set(node["required"]) == set(node["properties"])
+        for value in node.values():
+            _assert_declared_objects_are_closed(value)
+
+
+def _open_maps(node) -> list:  # noqa: ANN001  # tracked: #288
+    """Collect every ``additionalProperties`` value that permits extra keys."""
+    found = []
+    if isinstance(node, list):
+        for value in node:
+            found.extend(_open_maps(value))
+    elif isinstance(node, dict):
+        additional = node.get("additionalProperties")
+        if additional not in (None, False):
+            found.append(additional)
+        for value in node.values():
+            found.extend(_open_maps(value))
+    return found
+
+
 class TestMaterializeNativeOutputSchema:
     @pytest.mark.parametrize(
         "response_cls",
@@ -220,9 +266,56 @@ class TestMaterializeNativeOutputSchema:
         assert "default" not in target.read_text()
         assert not list(target.parent.glob(f".{target.name}.*"))
 
-    def test_schema_valued_mapping_falls_back_before_writing(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    @pytest.mark.parametrize("response_cls", MAPPING_RESPONSE_MODELS)
+    def test_strict_profile_rejects_mappings_before_writing(self, tmp_path, response_cls):  # noqa: ANN001, ANN201  # tracked: #288
+        """Providers on the Codex subset keep the prompt fallback for these."""
         with pytest.raises(ValueError, match="arbitrary object keys"):
-            materialize_native_output_schema(tmp_path, ImplementerResponse)
+            materialize_native_output_schema(tmp_path, response_cls)
+
+        assert not (tmp_path / ".cache/vibesys/response-schemas").exists()
+
+    @pytest.mark.parametrize("response_cls", MAPPING_RESPONSE_MODELS)
+    def test_permissive_profile_materializes_mappings(self, tmp_path, response_cls):  # noqa: ANN001, ANN201  # tracked: #288
+        relative = materialize_native_output_schema(
+            tmp_path, response_cls, allow_arbitrary_keys=True
+        )
+        target = tmp_path / relative
+        schema = json.loads(target.read_text())
+
+        assert relative.startswith(".cache/vibesys/response-schemas/")
+        _assert_declared_objects_are_closed(schema)
+        assert "default" not in target.read_text()
+        assert not list(target.parent.glob(f".{target.name}.*"))
+        # The mapping is preserved rather than rewritten to ``false``, so the
+        # CLI still constrains the value type of each arbitrary key.
+        assert _open_maps(schema), "expected the arbitrary-key mapping to survive"
+
+    @pytest.mark.parametrize("response_cls", [PreRoundDecision, OrchestratorPlan, JudgeResponse])
+    def test_permissive_profile_still_closes_declared_objects(self, tmp_path, response_cls):  # noqa: ANN001, ANN201  # tracked: #288
+        """Relaxing the mapping rule must not open up ordinary models."""
+        relative = materialize_native_output_schema(
+            tmp_path, response_cls, allow_arbitrary_keys=True
+        )
+        schema = json.loads((tmp_path / relative).read_text())
+
+        assert _open_maps(schema) == []
+
+    def test_permissive_profile_validates_inside_a_mapping(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        """The preserved mapping subschema is still walked for unsupported constructs."""
+
+        class MappedUnsupportedResponse(JudgeResponse):
+            @classmethod
+            def model_json_schema(cls, *args, **kwargs):  # noqa: ANN002, ANN003, ANN206, ARG003  # tracked: #288
+                return {
+                    "type": "object",
+                    "properties": {"metrics": {"type": "object"}},
+                    "additionalProperties": {"oneOf": [{"type": "string"}]},
+                }
+
+        with pytest.raises(ValueError, match="unsupported keyword 'oneOf'"):
+            materialize_native_output_schema(
+                tmp_path, MappedUnsupportedResponse, allow_arbitrary_keys=True
+            )
 
         assert not (tmp_path / ".cache/vibesys/response-schemas").exists()
 

--- a/tests/agents/test_cli_docker.py
+++ b/tests/agents/test_cli_docker.py
@@ -93,6 +93,47 @@ def test_provider_auth_imports_exclude_bulk_runtime_roots():  # noqa: ANN201  # 
     )
 
 
+def test_provider_auth_env_registry_covers_credentials_not_model_selection():  # noqa: ANN201  # tracked: #288
+    assert cli_docker.DOCKER_AUTH_ENV_VARS == {
+        "claude": (
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_CUSTOM_HEADERS",
+        ),
+        "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        "codex": ("OPENAI_API_KEY", "OPENAI_BASE_URL"),
+        "opencode": (),
+    }
+    # VibeSys owns per-role model selection; a host export must not override it.
+    forwarded = {name for names in cli_docker.DOCKER_AUTH_ENV_VARS.values() for name in names}
+    assert forwarded.isdisjoint({"ANTHROPIC_MODEL", "OPENAI_MODEL", "GEMINI_MODEL"})
+    assert set(cli_docker.DOCKER_AUTH_ENV_VARS) == set(cli_docker.DOCKER_AUTH_PATHS)
+
+
+def test_auth_env_passthrough_forwards_only_variables_the_host_actually_set(  # noqa: ANN201  # tracked: #288
+    monkeypatch,  # noqa: ANN001  # tracked: #288
+):
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "token-value")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://proxy.invalid/v1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "   ")
+    monkeypatch.delenv("ANTHROPIC_CUSTOM_HEADERS", raising=False)
+    monkeypatch.setenv("ANTHROPIC_MODEL", "host-selected-model")
+
+    assert cli_docker.auth_env_passthrough("claude") == {
+        "ANTHROPIC_AUTH_TOKEN": "token-value",
+        "ANTHROPIC_BASE_URL": "https://proxy.invalid/v1",
+    }
+
+
+def test_auth_env_passthrough_is_empty_without_host_credentials(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    for name in cli_docker.DOCKER_AUTH_ENV_VARS["claude"]:
+        monkeypatch.delenv(name, raising=False)
+
+    assert cli_docker.auth_env_passthrough("claude") == {}
+    assert cli_docker.auth_env_passthrough("unregistered-provider") == {}
+
+
 def test_codex_container_installs_luna_capable_cli_version():  # noqa: ANN201  # tracked: #288
     commands = cli_docker.docker_init_commands("codex")
 

--- a/tests/loops/agent/test_agent_state_store.py
+++ b/tests/loops/agent/test_agent_state_store.py
@@ -3,7 +3,12 @@
 from vibesys.loops.agent.model import ActiveHypothesis
 from vibesys.loops.agent.state import AgentStateStore
 from vibesys.schemas import OrchestratorPlan
-from vs_project import PlainRunConfiguration, Project, StateTransition
+from vs_project import (
+    PlainRunConfiguration,
+    Project,
+    RunEnvironmentRecord,
+    StateTransition,
+)
 
 
 def test_agent_state_store_round_trips_and_clears_active_state(tmp_path) -> None:  # noqa: ANN001
@@ -17,6 +22,7 @@ def test_agent_state_store_round_trips_and_clears_active_state(tmp_path) -> None
         trusted_input_baseline="a" * 40,
         configuration=PlainRunConfiguration(
             outer_loop="plain",
+            run_environment=RunEnvironmentRecord(name="local"),
             agent_backend="stub",
             compute_backend="cpu",
             max_rounds=1,

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -137,6 +137,7 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     implementer_skill_updates: list[list[SkillResourceSelection]] | None = None,
     implementer_validation_artifacts: list[str | None] | None = None,
     implementer_next_steps: list[str] | None = None,
+    implementer_parse_failures: list[bool] | None = None,
 ):
     """Build a MagicMock AgentRunner whose invoke() returns scripted responses.
 
@@ -144,6 +145,10 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     class. Defaults: when the plan queue is exhausted, the harness returns a
     permissive no-op plan and lets the loop's ``max_rounds`` bound the test.
     Judge verdicts default to pass; the profiler is not called.
+
+    ``implementer_parse_failures`` marks turns whose output does not parse.
+    Those return ``fallback_factory()`` — the contract every real runner obeys
+    for an unparseable response — instead of a scripted response.
     """
     pre_q = list(pre_decisions or [])
     plan_q = list(plans or [])
@@ -154,6 +159,7 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     impl_skill_q = list(implementer_skill_updates or [])
     impl_validation_q = list(implementer_validation_artifacts or [])
     impl_next_step_q = list(implementer_next_steps or [])
+    impl_parse_failure_q = list(implementer_parse_failures or [])
     counters = {"impl": 0, "judge": 0, "orch_pre": 0, "orch_plan": 0, "prof": 0}
 
     runner = MagicMock(spec=AgentRunner)
@@ -162,9 +168,13 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     def _invoke(*, kind, response_cls, fallback_factory, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001, PLR0911  # tracked: #288
         if kind == "orchestrator" and response_cls is PreRoundDecision:
             counters["orch_pre"] += 1
-            if pre_q:
-                return pre_q.pop(0)
-            return PreRoundDecision(need_profile=False, profile_focus="", reasoning="default skip")
+            return (
+                pre_q.pop(0)
+                if pre_q
+                else PreRoundDecision(
+                    need_profile=False, profile_focus="", reasoning="default skip"
+                )
+            )
         if kind == "orchestrator" and response_cls is OrchestratorPlan:
             counters["orch_plan"] += 1
             if plan_q:
@@ -176,6 +186,8 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
             )
         if kind == "implementer":
             counters["impl"] += 1
+            if impl_parse_failure_q and impl_parse_failure_q.pop(0):
+                return fallback_factory()
             outcome = outcome_q.pop(0) if outcome_q else HypothesisOutcome.NOMINATED
             perf_metric = impl_perf_q.pop(0) if impl_perf_q else None
             skill_updates = impl_skill_q.pop(0) if impl_skill_q else []
@@ -1829,6 +1841,91 @@ def test_loop_judge_retry_then_pass(tmp_path, ref_file):  # noqa: ANN001, ANN201
     assert "Same-round retry boundary" in retry_prompt
     assert "round-0001-attempt-01-implementer.json" in retry_prompt
     assert "remains consumed" in retry_prompt
+
+
+def test_unparseable_implementer_response_consumes_a_retry(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """A framework-synthesized response re-invokes the implementer in the same round.
+
+    Sparse-review cadence would otherwise defer the judge and let the round
+    complete on a fail-closed response that no agent authored, burning a round
+    without spending any of ``max_retries_per_round``.
+    """
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                task="Build server",
+                pass_criteria="tests pass",  # noqa: S106  # tracked: #288
+                reasoning="cold start",
+            ),
+        ],
+        implementer_parse_failures=[True],
+        implementer_outcomes=[HypothesisOutcome.NOMINATED],
+    )
+
+    result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1, max_retries_per_round=3)
+
+    assert result is True
+    assert runner.counters["impl"] == 2
+    assert runner.counters["judge"] == 1
+    implementer_labels = [
+        call.kwargs["round_label"]
+        for call in runner.invoke.call_args_list
+        if call.kwargs.get("response_cls") is ImplementerResponse
+    ]
+    assert implementer_labels == [
+        "round-1-retry-1-implementer",
+        "round-1-retry-2-implementer",
+    ]
+    rounds = _round_payloads(tmp_path)
+    assert len(rounds) == 1
+    assert rounds[0]["reviewed"] is True
+
+
+def test_unparseable_implementer_responses_commit_fail_closed_once_exhausted(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """Only genuine retry exhaustion may commit the synthesized response."""
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                task="Build server",
+                pass_criteria="tests pass",  # noqa: S106  # tracked: #288
+                reasoning="cold start",
+            ),
+        ],
+        implementer_parse_failures=[True, True],
+    )
+
+    result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1, max_retries_per_round=2)
+
+    assert result is True
+    assert runner.counters["impl"] == 2
+    assert runner.counters["judge"] == 0
+    rounds = _round_payloads(tmp_path)
+    assert len(rounds) == 1
+    assert rounds[0]["passed"] is False
+    assert rounds[0]["reviewed"] is False
+    assert rounds[0]["hypothesis_outcome"] == HypothesisOutcome.INCONCLUSIVE.value
+
+
+def test_agent_authored_inconclusive_completes_the_round(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """A parsed ``inconclusive`` turn is real evidence and keeps sparse review."""
+    runner = _make_orchestrate_runner(
+        implementer_outcomes=[HypothesisOutcome.INCONCLUSIVE] * 2,
+    )
+
+    result = _invoke_orchestrate(
+        tmp_path,
+        ref_file,
+        runner,
+        max_rounds=2,
+        judge_every=10,
+        max_retries_per_round=3,
+    )
+
+    assert result is True
+    assert runner.counters["impl"] == 2  # one attempt per round, no retries burned
+    assert runner.counters["judge"] == 1  # mandatory final-round review only
+    rounds = _round_payloads(tmp_path)
+    assert [round_data["reviewed"] for round_data in rounds] == [False, True]
 
 
 def test_loop_defers_judge_until_cadence_and_always_reviews_final_round(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -32,6 +32,7 @@ from vibesys.loops.evolve.population import Objective
 from vibesys.profilers import ProfilerKind, ProfilerPreflightResult
 from vibesys.prompts import PROMPTS_DIR
 from vibesys.run import GitTracker
+from vibesys.sandbox.run_environment import make_run_environment_spec
 from vibesys.schemas import (
     CandidateDisposition,
     HypothesisOutcome,
@@ -345,6 +346,11 @@ def test_project_configuration_captures_effective_agent_behavior(tmp_path: Path)
             memory_layout="directories",
             operator_constraints=("Preserve ordering",),
             domain=DomainName.GENERIC,
+            run_environment=make_run_environment_spec(
+                use_modal=True,
+                modal_gpu="A100-80GB",
+                modal_model_volume="weights",
+            ),
         )
 
     configuration = create_context.call_args.kwargs["project_configuration"]
@@ -370,6 +376,13 @@ def test_project_configuration_captures_effective_agent_behavior(tmp_path: Path)
         "inner_model": "gpt-inner",
         "inner_reasoning_effort": "medium",
         "operator_constraints": ("Preserve ordering",),
+        "run_environment": {
+            "name": "modal",
+            "image": None,
+            "gpu": "A100-80GB",
+            "model_volume": "weights",
+            "app": "vibesys",
+        },
     }
 
 

--- a/tests/loops/evolve/test_evolution_state_store.py
+++ b/tests/loops/evolve/test_evolution_state_store.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 from vibesys.loops.evolve.population import Individual, Population
 from vibesys.loops.evolve.state import EvolutionStateStore
 from vibesys.run import RunState, RunStateNamespace
-from vs_project import EvolveRunConfiguration, Project
+from vs_project import EvolveRunConfiguration, Project, RunEnvironmentRecord
 
 
 def _store(tmp_path) -> EvolutionStateStore:  # noqa: ANN001
@@ -19,6 +19,7 @@ def _store(tmp_path) -> EvolutionStateStore:  # noqa: ANN001
         trusted_input_baseline="a" * 40,
         configuration=EvolveRunConfiguration(
             outer_loop="evolve",
+            run_environment=RunEnvironmentRecord(name="local"),
             agent_backend="stub",
             compute_backend="cpu",
             max_generations=1,

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -54,7 +54,7 @@ from vibesys.profilers import ProfilerKind
 from vibesys.run import GitTracker, RunState, RunStateNamespace
 from vibesys.sandbox.run_environment import CandidateRuntime, RunEnvironmentSpec
 from vibesys.schemas import JudgeResponse, MutatorResponse, ProfilerSummary, Verdict
-from vs_project import EvolveRunConfiguration, Project
+from vs_project import EvolveRunConfiguration, Project, RunEnvironmentRecord
 
 _LLM_SERVING_DOMAIN = resolve_domain(DomainName.LLM_SERVING)
 
@@ -229,6 +229,7 @@ def _project_dir(tmp_path: Path) -> Path:
 def _evolution_configuration() -> EvolveRunConfiguration:
     return EvolveRunConfiguration(
         outer_loop="evolve",
+        run_environment=RunEnvironmentRecord(name="local"),
         agent_backend="stub",
         compute_backend="cpu",
         max_generations=1,
@@ -1286,6 +1287,7 @@ def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file
             environment_hooks=LLMServingEnvironmentHooks(),
             project_configuration=EvolveRunConfiguration(
                 outer_loop="evolve",
+                run_environment=RunEnvironmentRecord(name="local"),
                 agent_backend="deepagents",
                 compute_backend="cuda",
                 max_generations=1,

--- a/tests/loops/plain/test_plain_loop.py
+++ b/tests/loops/plain/test_plain_loop.py
@@ -28,7 +28,7 @@ from vibesys.schemas import (
     Verdict,
 )
 from vs_issue_board import IssueBoard, IssueStatus
-from vs_project import Project
+from vs_project import RUN_SCHEMA_VERSION, Project, RunEnvironmentRecord
 
 # ---------------------------------------------------------------------------
 # Helpers — factories and fixtures shared across tests
@@ -190,6 +190,9 @@ def test_bootstrap_creates_initial_feature_issue_on_first_run(  # noqa: ANN201  
 
     assert result is True
     exp_dir = _run_exp_dir(tmp_path)
+    manifest = Project.open(exp_dir).state.load_run(_run_id(exp_dir))
+    assert manifest.schema_version == RUN_SCHEMA_VERSION
+    assert manifest.configuration.run_environment == RunEnvironmentRecord(name="local")
     issues_path = _store_path(exp_dir)
     assert issues_path.is_file()
     data = json.loads(issues_path.read_text())

--- a/tests/loops/plain/test_plain_state_store.py
+++ b/tests/loops/plain/test_plain_state_store.py
@@ -6,7 +6,12 @@ import pytest
 
 from vibesys.loops.plain.state import PlainStateStore
 from vs_loop_state import PlainLoopCursor, PlainPerformanceRecord
-from vs_project import PlainRunConfiguration, Project, ProjectStateError
+from vs_project import (
+    PlainRunConfiguration,
+    Project,
+    ProjectStateError,
+    RunEnvironmentRecord,
+)
 
 
 def _store(tmp_path) -> PlainStateStore:  # noqa: ANN001
@@ -20,6 +25,7 @@ def _store(tmp_path) -> PlainStateStore:  # noqa: ANN001
         trusted_input_baseline="a" * 40,
         configuration=PlainRunConfiguration(
             outer_loop="plain",
+            run_environment=RunEnvironmentRecord(name="local"),
             agent_backend="stub",
             compute_backend="cpu",
             max_rounds=1,

--- a/tests/run/test_round_transaction.py
+++ b/tests/run/test_round_transaction.py
@@ -15,7 +15,12 @@ from vibesys.run import (
     RoundTransactionError,
 )
 from vs_loop_state import RoundRecord
-from vs_project import AgentRunConfiguration, Project, StateTransition
+from vs_project import (
+    AgentRunConfiguration,
+    Project,
+    RunEnvironmentRecord,
+    StateTransition,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -32,6 +37,7 @@ class _ActiveState(BaseModel):
 def _configuration() -> AgentRunConfiguration:
     return AgentRunConfiguration(
         outer_loop="agent",
+        run_environment=RunEnvironmentRecord(name="local"),
         inner_loop="multi-agent",
         interface="inprocess",
         agent_backend="cli",

--- a/tests/sandbox/test_modal_evaluator.py
+++ b/tests/sandbox/test_modal_evaluator.py
@@ -203,13 +203,13 @@ def test_build_stage_archive_rejects_oversized_inputs(
         modal_evaluator._build_stage_archive(str(workspace), ["blob.bin"])  # noqa: SLF001
 
 
-def test_find_app_container_matches_app_name(monkeypatch) -> None:  # noqa: ANN001
+def test_find_app_container_matches_snake_case_listing(monkeypatch) -> None:  # noqa: ANN001
     listing = SimpleNamespace(
         returncode=0,
         stdout=json.dumps(
             [
-                {"Container ID": "ta-other", "App Name": "other-app"},
-                {"Container ID": "ta-123", "App Name": "candidate-app"},
+                {"container_id": "ta-other", "app_name": "other-app"},
+                {"container_id": "ta-123", "app_name": "candidate-app"},
             ]
         ),
         stderr="",
@@ -225,6 +225,40 @@ def test_find_app_container_matches_app_name(monkeypatch) -> None:  # noqa: ANN0
 
     assert container == "ta-123"
     assert run.call_args_list[0].args[0][:5] == ["uv", "run", "modal", "container", "list"]
+
+
+def test_find_app_container_matches_title_case_listing(monkeypatch) -> None:  # noqa: ANN001
+    listing = SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps([{"Container ID": "ta-123", "App Name": "candidate-app"}]),
+        stderr="",
+    )
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", MagicMock(return_value=listing))
+
+    container = modal_evaluator._find_app_container(  # noqa: SLF001
+        "candidate-app",
+        workspace="/workspace",
+        base_url="https://workspace--candidate.modal.run",
+    )
+
+    assert container == "ta-123"
+
+
+def test_find_app_container_surfaces_cli_error(monkeypatch) -> None:  # noqa: ANN001
+    listing = SimpleNamespace(returncode=2, stdout="", stderr="token expired")
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", MagicMock(return_value=listing))
+    monkeypatch.setattr(modal_evaluator, "_healthy_now", MagicMock(return_value=True))
+    monkeypatch.setattr(modal_evaluator.time, "sleep", lambda _: None)
+    clock = iter([0.0, 0.0, 2.0])
+    monkeypatch.setattr(modal_evaluator.time, "monotonic", lambda: next(clock))
+
+    with pytest.raises(TimeoutError, match="container list exited 2: token expired"):
+        modal_evaluator._find_app_container(  # noqa: SLF001
+            "candidate-app",
+            workspace="/workspace",
+            base_url="https://workspace--candidate.modal.run",
+            timeout_seconds=1.5,
+        )
 
 
 def test_find_app_container_rewarms_then_times_out(monkeypatch) -> None:  # noqa: ANN001

--- a/tests/sandbox/test_modal_evaluator.py
+++ b/tests/sandbox/test_modal_evaluator.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import base64
+import io
 import json
+import tarfile
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, call
@@ -11,6 +14,11 @@ from vibesys.sandbox import modal_evaluator
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+_DEPLOY_STDOUT = (
+    "Web Function URL: https://workspace--candidate.modal.run\n"
+    "View Deployment: https://modal.com/apps/workspace/main/deployed/candidate-app\n"
+)
 
 
 @pytest.fixture(autouse=True)
@@ -122,17 +130,260 @@ def test_extract_modal_app_identifier_handles_rich_line_wrapping() -> None:
     assert modal_evaluator.extract_modal_app_identifier(output) == "vibesys-long-candidate"
 
 
-def test_run_evaluator_deploys_waits_and_injects_url(monkeypatch) -> None:  # noqa: ANN001  # tracked: #288
-    deploy = SimpleNamespace(
+def test_plan_command_transfer_classifies_inputs_and_outputs(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    task = workspace / ".vibesys" / "tasks" / "demo"
+    bench = task / "benchmark"
+    bench.mkdir(parents=True)
+    (task / "requirements.txt").write_text("httpx\n")
+    (bench / "benchmark.py").write_text("print('hi')\n")
+    (workspace / "main.py").write_text("app = object()\n")
+    outputs_parent = tmp_path / "outputs"
+    outputs_parent.mkdir()
+
+    plan = modal_evaluator._plan_command_transfer(  # noqa: SLF001
+        [
+            "uv",
+            "run",
+            "--no-project",
+            "--with-requirements",
+            ".vibesys/tasks/demo/requirements.txt",
+            "python",
+            ".vibesys/tasks/demo/benchmark/benchmark.py",
+            "main.py",
+            "--output-json",
+            str(outputs_parent / "result.json"),
+            str(tmp_path / "missing-dir" / "result.json"),
+        ],
+        str(workspace),
+    )
+
+    # benchmark/ is covered by the task directory staged for requirements.txt;
+    # root-level files stage themselves rather than the whole workspace.
+    assert plan.stage_paths == (".vibesys/tasks/demo", "main.py")
+    assert plan.output_paths == (str(outputs_parent / "result.json"),)
+
+
+def test_plan_command_transfer_ignores_escaping_symlinks(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret\n")
+    (workspace / "leak.txt").symlink_to(outside)
+
+    plan = modal_evaluator._plan_command_transfer(  # noqa: SLF001
+        ["python", "leak.txt"], str(workspace)
+    )
+
+    assert plan.stage_paths == ()
+
+
+def test_build_stage_archive_preserves_relative_layout(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    nested = workspace / "task" / "data"
+    nested.mkdir(parents=True)
+    (nested / "cases.json").write_text("[]")
+
+    payload = modal_evaluator._build_stage_archive(str(workspace), ["task"])  # noqa: SLF001
+
+    with tarfile.open(fileobj=io.BytesIO(payload), mode="r:gz") as archive:
+        assert "task/data/cases.json" in archive.getnames()
+
+
+def test_build_stage_archive_rejects_oversized_inputs(
+    tmp_path: Path,
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "blob.bin").write_bytes(b"x" * 4096)
+    monkeypatch.setattr(modal_evaluator, "_MAX_STAGE_ARCHIVE_BYTES", 16)
+
+    with pytest.raises(ValueError, match="too large"):
+        modal_evaluator._build_stage_archive(str(workspace), ["blob.bin"])  # noqa: SLF001
+
+
+def test_find_app_container_matches_app_name(monkeypatch) -> None:  # noqa: ANN001
+    listing = SimpleNamespace(
         returncode=0,
-        stdout="Web Function URL: https://workspace--candidate.modal.run\n",
+        stdout=json.dumps(
+            [
+                {"Container ID": "ta-other", "App Name": "other-app"},
+                {"Container ID": "ta-123", "App Name": "candidate-app"},
+            ]
+        ),
         stderr="",
     )
-    evaluator = SimpleNamespace(returncode=0)
-    run = MagicMock(side_effect=[deploy, evaluator])
+    run = MagicMock(return_value=listing)
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
+
+    container = modal_evaluator._find_app_container(  # noqa: SLF001
+        "candidate-app",
+        workspace="/workspace",
+        base_url="https://workspace--candidate.modal.run",
+    )
+
+    assert container == "ta-123"
+    assert run.call_args_list[0].args[0][:5] == ["uv", "run", "modal", "container", "list"]
+
+
+def test_find_app_container_rewarms_then_times_out(monkeypatch) -> None:  # noqa: ANN001
+    listing = SimpleNamespace(returncode=0, stdout="[]", stderr="")
+    run = MagicMock(return_value=listing)
+    warm = MagicMock(return_value=True)
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
+    monkeypatch.setattr(modal_evaluator, "_healthy_now", warm)
+    monkeypatch.setattr(modal_evaluator.time, "sleep", lambda _: None)
+    clock = iter([0.0, 0.0, 1.0, 2.0])
+    monkeypatch.setattr(modal_evaluator.time, "monotonic", lambda: next(clock))
+
+    with pytest.raises(TimeoutError, match="no running container"):
+        modal_evaluator._find_app_container(  # noqa: SLF001
+            "candidate-app",
+            workspace="/workspace",
+            base_url="https://workspace--candidate.modal.run",
+            timeout_seconds=1.5,
+        )
+    assert warm.call_count == 2
+
+
+def test_parse_exec_output_extracts_rc_files_and_passthrough() -> None:
+    encoded = base64.b64encode(b'{"metric": 1}').decode()
+    stdout = (
+        "benchmark progress line\n"
+        f"{modal_evaluator._OUTPUT_FILE_MARKER} /tmp/result.json\n"  # noqa: SLF001
+        f"{encoded}\n"
+        f"{modal_evaluator._OUTPUT_END_MARKER}\n"  # noqa: SLF001
+        f"{modal_evaluator._EXEC_RC_MARKER}0\n"  # noqa: SLF001
+    )
+
+    rc, files, passthrough = modal_evaluator._parse_exec_output(stdout)  # noqa: SLF001
+
+    assert rc == 0
+    assert files == {"/tmp/result.json": b'{"metric": 1}'}  # noqa: S108
+    assert passthrough == "benchmark progress line"
+
+
+def test_parse_exec_output_without_rc_marker_returns_none() -> None:
+    rc, files, passthrough = modal_evaluator._parse_exec_output("crashed early\n")  # noqa: SLF001
+
+    assert rc is None
+    assert files == {}
+    assert passthrough == "crashed early"
+
+
+def test_bootstrap_script_runs_command_verbatim_and_relays_outputs() -> None:
+    script = modal_evaluator._bootstrap_script(  # noqa: SLF001
+        ["uv", "run", "python", "bench.py"],
+        ["/tmp/result.json"],  # noqa: S108
+    )
+
+    assert "uv run python bench.py" in script
+    assert "/tmp/result.json" in script  # noqa: S108
+    assert modal_evaluator._EXEC_RC_MARKER in script  # noqa: SLF001
+    assert "--url" not in script
+
+
+def _colocated_exec_result(rc: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(
+        returncode=0,
+        stdout=f"{modal_evaluator._EXEC_RC_MARKER}{rc}\n",  # noqa: SLF001
+        stderr="",
+    )
+
+
+def test_execute_colocated_execs_in_container_and_returns_sentinel_rc(
+    monkeypatch,  # noqa: ANN001
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "checker.py").write_text("print('ok')\n")
+    run = MagicMock(return_value=_colocated_exec_result(rc=3))
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
+    monkeypatch.setattr(modal_evaluator, "_find_app_container", MagicMock(return_value="ta-123"))
+    keepwarm = MagicMock()
+    keepwarm.return_value.__enter__ = MagicMock()
+    keepwarm.return_value.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr(modal_evaluator, "_DeploymentKeepWarm", keepwarm)
+
+    result = modal_evaluator._execute_colocated(  # noqa: SLF001
+        ["python", "checker.py"],
+        workspace=str(workspace),
+        app_identifier="candidate-app",
+        base_url="https://workspace--candidate.modal.run",
+    )
+
+    assert result == 3
+    keepwarm.assert_called_once_with("https://workspace--candidate.modal.run")
+    exec_argv = run.call_args.args[0]
+    assert exec_argv[:6] == ["uv", "run", "modal", "container", "exec", "ta-123"]
+    assert exec_argv[6:9] == ["--", "sh", "-c"]
+    assert "python checker.py" in exec_argv[9]
+
+
+def test_execute_colocated_writes_relayed_output_files(
+    monkeypatch,  # noqa: ANN001
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    output_path = tmp_path / "result.json"
+    encoded = base64.b64encode(b'{"metric": 2}').decode()
+    exec_result = SimpleNamespace(
+        returncode=0,
+        stdout=(
+            f"{modal_evaluator._OUTPUT_FILE_MARKER} {output_path}\n"  # noqa: SLF001
+            f"{encoded}\n"
+            f"{modal_evaluator._OUTPUT_END_MARKER}\n"  # noqa: SLF001
+            f"{modal_evaluator._EXEC_RC_MARKER}0\n"  # noqa: SLF001
+        ),
+        stderr="",
+    )
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", MagicMock(return_value=exec_result))
+    monkeypatch.setattr(modal_evaluator, "_find_app_container", MagicMock(return_value="ta-123"))
+
+    result = modal_evaluator._execute_colocated(  # noqa: SLF001
+        ["python", "bench.py", "--output-json", str(output_path)],
+        workspace=str(workspace),
+        app_identifier="candidate-app",
+        base_url="https://workspace--candidate.modal.run",
+    )
+
+    assert result == 0
+    assert json.loads(output_path.read_text()) == {"metric": 2}
+
+
+def test_execute_colocated_reports_missing_rc_sentinel(
+    monkeypatch,  # noqa: ANN001
+    tmp_path: Path,
+    capsys,  # noqa: ANN001
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    exec_result = SimpleNamespace(returncode=0, stdout="killed mid-run\n", stderr="")
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", MagicMock(return_value=exec_result))
+    monkeypatch.setattr(modal_evaluator, "_find_app_container", MagicMock(return_value="ta-123"))
+
+    result = modal_evaluator._execute_colocated(  # noqa: SLF001
+        ["python", "bench.py"],
+        workspace=str(workspace),
+        app_identifier="candidate-app",
+        base_url="https://workspace--candidate.modal.run",
+    )
+
+    assert result == 1
+    assert "did not report an exit code" in capsys.readouterr().err
+
+
+def test_run_evaluator_deploys_waits_and_runs_colocated(monkeypatch) -> None:  # noqa: ANN001
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
+    run = MagicMock(return_value=deploy)
     wait = MagicMock()
+    colocated = MagicMock(return_value=0)
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
     monkeypatch.setattr(modal_evaluator, "wait_for_health", wait)
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", colocated)
 
     result = modal_evaluator.run_evaluator(
         ["uv", "run", "python", "checker.py"],
@@ -148,35 +399,47 @@ def test_run_evaluator_deploys_waits_and_injects_url(monkeypatch) -> None:  # no
             text=True,
             check=False,
         ),
-        call(
-            [
-                "uv",
-                "run",
-                "python",
-                "checker.py",
-                "--url",
-                "https://workspace--candidate.modal.run",
-            ],
-            cwd="/workspace",
-            check=False,
-        ),
     ]
     wait.assert_called_once_with(
         "https://workspace--candidate.modal.run",
         timeout_seconds=90,
     )
+    colocated.assert_called_once_with(
+        ["uv", "run", "python", "checker.py"],
+        workspace="/workspace",
+        app_identifier="candidate-app",
+        base_url="https://workspace--candidate.modal.run",
+    )
 
 
-def test_run_evaluator_deploys_custom_entrypoint(monkeypatch) -> None:  # noqa: ANN001
+def test_run_evaluator_requires_app_identifier(monkeypatch, capsys) -> None:  # noqa: ANN001
     deploy = SimpleNamespace(
         returncode=0,
         stdout="Web Function URL: https://workspace--candidate.modal.run\n",
         stderr="",
     )
-    evaluator = SimpleNamespace(returncode=0)
-    run = MagicMock(side_effect=[deploy, evaluator])
+    run = MagicMock(return_value=deploy)
+    colocated = MagicMock(return_value=0)
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
     monkeypatch.setattr(modal_evaluator, "wait_for_health", MagicMock())
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", colocated)
+
+    result = modal_evaluator.run_evaluator(
+        ["uv", "run", "python", "checker.py"],
+        workspace="/workspace",
+    )
+
+    assert result == 1
+    colocated.assert_not_called()
+    assert "did not print a deployment URL" in capsys.readouterr().err
+
+
+def test_run_evaluator_deploys_custom_entrypoint(monkeypatch) -> None:  # noqa: ANN001
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
+    run = MagicMock(return_value=deploy)
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
+    monkeypatch.setattr(modal_evaluator, "wait_for_health", MagicMock())
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", MagicMock(return_value=0))
 
     result = modal_evaluator.run_evaluator(
         ["checker"],
@@ -210,16 +473,17 @@ def test_run_evaluator_reuses_healthy_deployment_for_exact_revision(
             {
                 "candidate_revision": "abc123",
                 "base_url": "https://workspace--candidate.modal.run",
+                "app_identifier": "candidate-app",
             }
         )
     )
-    evaluator = SimpleNamespace(returncode=0)
-    run = MagicMock(return_value=evaluator)
     healthy = MagicMock(return_value=True)
+    colocated = MagicMock(return_value=0)
     monkeypatch.setenv("VIBESYS_CANDIDATE_REVISION", "abc123")
     monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
     monkeypatch.setattr(modal_evaluator, "_healthy_now", healthy)
-    monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", colocated)
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", MagicMock())
 
     result = modal_evaluator.run_evaluator(
         ["uv", "run", "python", "checker.py"],
@@ -228,18 +492,44 @@ def test_run_evaluator_reuses_healthy_deployment_for_exact_revision(
 
     assert result == 0
     healthy.assert_called_once_with("https://workspace--candidate.modal.run")
-    run.assert_called_once_with(
-        [
-            "uv",
-            "run",
-            "python",
-            "checker.py",
-            "--url",
-            "https://workspace--candidate.modal.run",
-        ],
-        cwd="/workspace",
-        check=False,
+    colocated.assert_called_once_with(
+        ["uv", "run", "python", "checker.py"],
+        workspace="/workspace",
+        app_identifier="candidate-app",
+        base_url="https://workspace--candidate.modal.run",
     )
+
+
+def test_run_evaluator_redeploys_when_lease_lacks_app_identifier(
+    monkeypatch,  # noqa: ANN001
+    tmp_path,  # noqa: ANN001
+) -> None:
+    lease_path = tmp_path / "deployment.json"
+    lease_path.write_text(
+        json.dumps(
+            {
+                "candidate_revision": "abc123",
+                "base_url": "https://workspace--candidate.modal.run",
+            }
+        )
+    )
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
+    run = MagicMock(return_value=deploy)
+    colocated = MagicMock(return_value=0)
+    monkeypatch.setenv("VIBESYS_CANDIDATE_REVISION", "abc123")
+    monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
+    monkeypatch.setattr(modal_evaluator, "wait_for_health", MagicMock())
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", colocated)
+
+    result = modal_evaluator.run_evaluator(
+        ["uv", "run", "python", "checker.py"],
+        workspace="/workspace",
+    )
+
+    assert result == 0
+    assert run.call_args_list[0].args[0][:4] == ["uv", "run", "modal", "deploy"]
+    colocated.assert_called_once()
 
 
 def test_run_evaluator_releases_reused_deployment_after_final_gate(
@@ -256,13 +546,13 @@ def test_run_evaluator_releases_reused_deployment_after_final_gate(
             }
         )
     )
-    evaluator = SimpleNamespace(returncode=0)
     stop = SimpleNamespace(returncode=0, stdout="", stderr="")
-    run = MagicMock(side_effect=[evaluator, stop])
+    run = MagicMock(return_value=stop)
     monkeypatch.setenv("VIBESYS_CANDIDATE_REVISION", "abc123")
     monkeypatch.setenv("VIBESYS_RELEASE_MODAL_DEPLOYMENT", "1")
     monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
     monkeypatch.setattr(modal_evaluator, "_healthy_now", MagicMock(return_value=True))
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", MagicMock(return_value=0))
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
 
     result = modal_evaluator.run_evaluator(
@@ -287,23 +577,15 @@ def test_run_evaluator_releases_new_deployment_after_final_gate(
     tmp_path,  # noqa: ANN001  # tracked: #288
 ) -> None:
     lease_path = tmp_path / "deployment.json"
-    deploy = SimpleNamespace(
-        returncode=0,
-        stdout=(
-            "Web Function URL: https://workspace--candidate.modal.run\n"
-            "View Deployment: "
-            "https://modal.com/apps/workspace/main/deployed/candidate-app\n"
-        ),
-        stderr="",
-    )
-    evaluator = SimpleNamespace(returncode=0)
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
     stop = SimpleNamespace(returncode=0, stdout="", stderr="")
-    run = MagicMock(side_effect=[deploy, evaluator, stop])
+    run = MagicMock(side_effect=[deploy, stop])
     monkeypatch.setenv("VIBESYS_CANDIDATE_REVISION", "abc123")
     monkeypatch.setenv("VIBESYS_RELEASE_MODAL_DEPLOYMENT", "1")
     monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
     monkeypatch.setattr(modal_evaluator, "wait_for_health", MagicMock())
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", MagicMock(return_value=0))
 
     result = modal_evaluator.run_evaluator(
         ["uv", "run", "python", "checker.py"],
@@ -337,17 +619,13 @@ def test_run_evaluator_stops_mismatched_leased_app_before_redeploy(
         )
     )
     stop = SimpleNamespace(returncode=0, stdout="", stderr="")
-    deploy = SimpleNamespace(
-        returncode=0,
-        stdout="Web Function URL: https://workspace--new.modal.run\n",
-        stderr="",
-    )
-    evaluator = SimpleNamespace(returncode=0)
-    run = MagicMock(side_effect=[stop, deploy, evaluator])
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
+    run = MagicMock(side_effect=[stop, deploy])
     monkeypatch.setenv("VIBESYS_CANDIDATE_REVISION", "new")
     monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
     monkeypatch.setattr(modal_evaluator, "wait_for_health", MagicMock())
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", MagicMock(return_value=0))
 
     result = modal_evaluator.run_evaluator(
         ["uv", "run", "python", "checker.py"],
@@ -378,17 +656,13 @@ def test_run_evaluator_redeploys_and_replaces_mismatched_revision(
             }
         )
     )
-    deploy = SimpleNamespace(
-        returncode=0,
-        stdout="Web Function URL: https://workspace--new.modal.run\n",
-        stderr="",
-    )
-    evaluator = SimpleNamespace(returncode=0)
-    run = MagicMock(side_effect=[deploy, evaluator])
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
+    run = MagicMock(return_value=deploy)
     monkeypatch.setenv("VIBESYS_CANDIDATE_REVISION", "new")
     monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
     monkeypatch.setattr(modal_evaluator, "wait_for_health", MagicMock())
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", MagicMock(return_value=0))
 
     result = modal_evaluator.run_evaluator(
         ["uv", "run", "python", "checker.py"],
@@ -398,7 +672,8 @@ def test_run_evaluator_redeploys_and_replaces_mismatched_revision(
     assert result == 0
     assert json.loads(lease_path.read_text()) == {
         "candidate_revision": "new",
-        "base_url": "https://workspace--new.modal.run",
+        "base_url": "https://workspace--candidate.modal.run",
+        "app_identifier": "candidate-app",
     }
 
 
@@ -406,15 +681,7 @@ def test_run_evaluator_prints_modal_logs_when_readiness_fails(
     monkeypatch,  # noqa: ANN001  # tracked: #288
     capsys,  # noqa: ANN001  # tracked: #288
 ) -> None:
-    deploy = SimpleNamespace(
-        returncode=0,
-        stdout=(
-            "Web Function URL: https://workspace--candidate.modal.run\n"
-            "View Deployment: "
-            "https://modal.com/apps/workspace/main/deployed/candidate-app\n"
-        ),
-        stderr="",
-    )
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
     run = MagicMock(return_value=deploy)
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
     monkeypatch.setattr(

--- a/tests/sandbox/test_model_requests.py
+++ b/tests/sandbox/test_model_requests.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vibesys.sandbox import model_requests
+from vibesys.sandbox.model_requests import (
+    MODEL_MANIFEST_RELPATH,
+    ModelRequest,
+    ModelRequestError,
+    check_allowed,
+    read_model_requests,
+    reconcile_model_requests,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_manifest(workspace: Path, payload: object) -> None:
+    path = workspace / MODEL_MANIFEST_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+
+
+# -- read_model_requests ----------------------------------------------------
+
+
+def test_missing_manifest_yields_empty(tmp_path: Path) -> None:
+    assert read_model_requests(tmp_path) == []
+
+
+def test_reads_bare_list(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, [{"id": "org/Foo-1.2-X", "revision": "abc"}])
+    assert read_model_requests(tmp_path) == [ModelRequest(model_id="org/Foo-1.2-X", revision="abc")]
+
+
+def test_reads_models_object_and_model_id_alias(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, {"models": [{"model_id": "org/bar"}]})
+    assert read_model_requests(tmp_path) == [ModelRequest(model_id="org/bar", revision=None)]
+
+
+def test_dedupes_keeping_first(tmp_path: Path) -> None:
+    _write_manifest(
+        tmp_path,
+        [
+            {"id": "org/dup", "revision": "first"},
+            {"id": "org/dup", "revision": "second"},
+            {"id": "org/other"},
+        ],
+    )
+    assert read_model_requests(tmp_path) == [
+        ModelRequest(model_id="org/dup", revision="first"),
+        ModelRequest(model_id="org/other", revision=None),
+    ]
+
+
+def test_strips_whitespace_from_id(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, [{"id": "  org/foo  "}])
+    assert read_model_requests(tmp_path) == [ModelRequest(model_id="org/foo", revision=None)]
+
+
+def test_invalid_json_raises(tmp_path: Path) -> None:
+    path = tmp_path / MODEL_MANIFEST_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json")
+    with pytest.raises(ModelRequestError, match="not valid JSON"):
+        read_model_requests(tmp_path)
+
+
+def test_non_list_raises(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, {"models": "org/foo"})
+    with pytest.raises(ModelRequestError, match="must be a JSON list"):
+        read_model_requests(tmp_path)
+
+
+def test_non_object_entry_raises(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, ["org/foo"])
+    with pytest.raises(ModelRequestError, match="entry 0 is not an object"):
+        read_model_requests(tmp_path)
+
+
+def test_missing_id_raises(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, [{"revision": "abc"}])
+    with pytest.raises(ModelRequestError, match="non-empty"):
+        read_model_requests(tmp_path)
+
+
+def test_non_string_revision_raises(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, [{"id": "org/foo", "revision": 3}])
+    with pytest.raises(ModelRequestError, match="revision"):
+        read_model_requests(tmp_path)
+
+
+# -- check_allowed ----------------------------------------------------------
+
+
+def test_allow_none_is_unrestricted() -> None:
+    assert check_allowed("anything/at-all", None) is True
+
+
+def test_allow_prefix_match_and_miss() -> None:
+    allow = ("org/", "trusted-org/")
+    assert check_allowed("org/foo", allow) is True
+    assert check_allowed("trusted-org/bar", allow) is True
+    assert check_allowed("other/baz", allow) is False
+
+
+def test_allow_prefixes_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VIBESYS_MODEL_REQUEST_ALLOW", " org/ , trusted/ ")
+    assert model_requests._allow_prefixes() == ("org/", "trusted/")  # noqa: SLF001
+
+
+def test_allow_prefixes_unset_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VIBESYS_MODEL_REQUEST_ALLOW", raising=False)
+    assert model_requests._allow_prefixes() is None  # noqa: SLF001
+
+
+# -- reconcile_model_requests ----------------------------------------------
+
+
+def test_reconcile_empty_does_not_touch_provisioner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    called = []
+
+    def _fail_if_called(*args: object, **_kwargs: object) -> str:
+        called.append(args)
+        return "vol"
+
+    monkeypatch.setattr("vs_sandbox.ensure_model_volume", _fail_if_called)
+    assert reconcile_model_requests(tmp_path) == []
+    assert called == []
+
+
+def test_reconcile_provisions_each_request(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_manifest(
+        tmp_path,
+        [{"id": "org/a", "revision": "r1"}, {"id": "org/b"}],
+    )
+    seen: list[tuple[str, str | None]] = []
+
+    def _fake_ensure(model_id: str, *, revision: str | None = None, **_kwargs: object) -> str:
+        seen.append((model_id, revision))
+        return f"vibesys-model-{model_id.replace('/', '-')}"
+
+    monkeypatch.setattr("vs_sandbox.ensure_model_volume", _fake_ensure)
+    volumes = reconcile_model_requests(tmp_path)
+    assert seen == [("org/a", "r1"), ("org/b", None)]
+    assert volumes == ["vibesys-model-org-a", "vibesys-model-org-b"]
+
+
+def test_reconcile_rejects_disallowed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_manifest(tmp_path, [{"id": "sketchy/model"}])
+    monkeypatch.setenv("VIBESYS_MODEL_REQUEST_ALLOW", "trusted/")
+
+    def _must_not_run(*_args: object, **_kwargs: object) -> str:
+        pytest.fail("provisioner must not run for disallowed request")
+
+    monkeypatch.setattr("vs_sandbox.ensure_model_volume", _must_not_run)
+    with pytest.raises(ModelRequestError, match="not permitted"):
+        reconcile_model_requests(tmp_path)

--- a/tests/sandbox/test_run_environment.py
+++ b/tests/sandbox/test_run_environment.py
@@ -18,8 +18,9 @@ from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     build_run_environment,
     make_run_environment_spec,
+    run_environment_record,
 )
-from vs_project import Project
+from vs_project import Project, RunEnvironmentRecord
 from vs_sandbox import ProjectPathPolicy
 
 
@@ -78,6 +79,33 @@ def test_cli_compatibility_flags_keep_options_scoped_to_selected_environment(): 
         modal_entrypoint="examples/deployment/service.py",
     )
     assert configured.options["entrypoint"] == "examples/deployment/service.py"
+
+
+def test_run_environment_record_captures_operator_selected_options():  # noqa: ANN201  # tracked: #288
+    assert run_environment_record(make_run_environment_spec()) == RunEnvironmentRecord(name="local")
+    assert run_environment_record(
+        make_run_environment_spec(use_docker=True, docker_image="editor")
+    ) == RunEnvironmentRecord(name="docker", image="editor")
+    assert run_environment_record(
+        make_run_environment_spec(
+            use_modal=True,
+            modal_gpu="accelerator",
+            modal_model_volume="weights",
+            modal_app="candidate",
+            # Declared by the input bundle, so it is re-derived rather than recorded.
+            modal_entrypoint="examples/deployment/service.py",
+        )
+    ) == RunEnvironmentRecord(
+        name="modal",
+        gpu="accelerator",
+        model_volume="weights",
+        app="candidate",
+    )
+
+
+def test_run_environment_record_rejects_an_unknown_environment():  # noqa: ANN201  # tracked: #288
+    with pytest.raises(ValueError, match="unknown run environment"):
+        run_environment_record(RunEnvironmentSpec("kubernetes"))
 
 
 def _modal_runtime_document(tmp_path: Path) -> str:

--- a/tests/sandbox/test_run_environment.py
+++ b/tests/sandbox/test_run_environment.py
@@ -53,6 +53,20 @@ def _request(tmp_path: Path, backend: FakeBackend, **overrides):  # noqa: ANN003
     return RunEnvironmentRequest(**values)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
 
+@pytest.fixture(autouse=True)
+def _synthetic_cli_auth(monkeypatch):  # pyright: ignore[reportUnusedFunction]  # noqa: ANN001, ANN202
+    """Pin a deterministic host auth source for container CLI setup.
+
+    ``_cli_container_setup`` fails loud when a provider has neither a staged
+    host file nor an auth environment variable, so these tests must not depend
+    on whichever CLI the developer running them happens to be logged into.
+    """
+    for names in cli_docker.DOCKER_AUTH_ENV_VARS.values():
+        for name in names:
+            monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "synthetic-openai-key")
+
+
 def test_cli_compatibility_flags_keep_options_scoped_to_selected_environment():  # noqa: ANN201  # tracked: #288
     assert make_run_environment_spec().options == {}
     assert make_run_environment_spec(use_docker=True, docker_image="editor").options == {
@@ -431,6 +445,48 @@ def test_docker_environment_copies_cli_auth_from_readonly_staging(tmp_path, monk
     assert kwargs["extra_init_commands"][0] == (
         "mkdir -p /root/.codex && cp -a /opt/vibesys-auth/0 /root/.codex/auth.json"
     )
+
+
+def test_docker_environment_forwards_host_cli_auth_environment(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    backend = FakeBackend()
+    env = build_run_environment(RunEnvironmentSpec("docker"))
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "proxy-token")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://proxy.invalid/v1")
+    monkeypatch.setenv("ANTHROPIC_MODEL", "host-selected-model")
+
+    env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="claude"))
+
+    container_env = backend.calls[0][1]["extra_env"]
+    assert container_env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"  # noqa: S105  # tracked: #288
+    assert container_env["ANTHROPIC_BASE_URL"] == "https://proxy.invalid/v1"
+    # VibeSys owns per-role model selection, so a host export must not reach
+    # the container and override it.
+    assert "ANTHROPIC_MODEL" not in container_env
+    assert container_env["IS_SANDBOX"] == "1"
+    assert container_env["PYTHONPATH"] == "/opt/vibesys"
+
+
+def test_docker_environment_rejects_a_cli_provider_without_any_auth_source(  # noqa: ANN201  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
+    monkeypatch,  # noqa: ANN001  # tracked: #288
+):
+    backend = FakeBackend()
+    env = build_run_environment(RunEnvironmentSpec("docker"))
+    monkeypatch.setitem(
+        cli_docker.DOCKER_AUTH_PATHS,
+        "codex",
+        [DockerAuthPath(tmp_path / "absent-codex-home" / "auth.json", "/root/.codex/auth.json")],
+    )
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="no 'codex' CLI authentication") as excinfo:
+        env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="codex"))
+
+    message = str(excinfo.value)
+    assert str(tmp_path / "absent-codex-home" / "auth.json") in message
+    assert "OPENAI_API_KEY" in message
+    assert "OPENAI_BASE_URL" in message
+    assert backend.calls == []
 
 
 def test_docker_environment_exposes_framework_git_history_read_only(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -17,7 +17,7 @@ from vibesys.profilers import ProfilerKind, ProfilerPreflightResult
 from vibesys.run import RunLogger, RunPaths, RunStateNamespace
 from vibesys.sandbox.run_environment import RunEnvironmentSpec
 from vs_loop_state import PlainLoopCursor
-from vs_project import AgentRunConfiguration, Project
+from vs_project import AgentRunConfiguration, Project, RunEnvironmentRecord
 
 
 class _FakeBackend:
@@ -60,6 +60,7 @@ def _context_dependencies(monkeypatch):  # pyright: ignore[reportUnusedFunction]
 def _configuration(max_rounds: int = 1) -> AgentRunConfiguration:
     return AgentRunConfiguration(
         outer_loop="agent",
+        run_environment=RunEnvironmentRecord(name="local"),
         inner_loop="multi-agent",
         interface="inprocess",
         model="gpt-test",

--- a/tests/test_git_tracker.py
+++ b/tests/test_git_tracker.py
@@ -10,7 +10,7 @@ import pytest
 
 from vibesys.run.git_tracker import GitTracker
 from vibesys.run.project_policy import trusted_project_input_paths
-from vs_project import PlainRunConfiguration, Project
+from vs_project import PlainRunConfiguration, Project, RunEnvironmentRecord
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -66,6 +66,7 @@ def _project(root: Path, tracker: GitTracker, run_id: str = "test-run") -> Proje
             trusted_input_baseline=tracker.trusted_input_baseline,
             configuration=PlainRunConfiguration(
                 outer_loop="plain",
+                run_environment=RunEnvironmentRecord(name="local"),
                 agent_backend="stub",
                 compute_backend="cpu",
                 max_rounds=2,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,6 +27,7 @@ from vibesys.main import (
     _parse_cli_objective,
     _prepare_experiment_repository,
     _render_configuration_error,
+    _run_migrate_run_environment,
     _validate_target_inputs,
     _with_operator_constraints,
     load_config_and_skills,
@@ -35,12 +36,15 @@ from vibesys.main import (
     run_environment_spec_from_args,
 )
 from vibesys.profilers import ProfilerKind
+from vibesys.sandbox.run_environment import run_environment_record
 from vs_project import (
+    RUN_SCHEMA_VERSION,
     AgentRunConfiguration,
     EvolveRunConfiguration,
     PlainRunConfiguration,
     Project,
     RunConfiguration,
+    RunEnvironmentRecord,
 )
 
 
@@ -124,6 +128,7 @@ def test_run_environment_spec_uses_task_modal_entrypoint(tmp_path: Path) -> None
 
 
 class _CommonConfiguration(TypedDict):
+    run_environment: RunEnvironmentRecord
     model: str
     agent_backend: str
     cli_provider: str
@@ -138,8 +143,20 @@ class _CommonConfiguration(TypedDict):
     inner_reasoning_effort: str
 
 
-def _common_configuration() -> _CommonConfiguration:
+_LOCAL_ENVIRONMENT = RunEnvironmentRecord(name="local")
+_MODAL_ENVIRONMENT = RunEnvironmentRecord(
+    name="modal",
+    gpu="A100-80GB",
+    model_volume="weights",
+    app="run-app",
+)
+
+
+def _common_configuration(
+    run_environment: RunEnvironmentRecord | None = None,
+) -> _CommonConfiguration:
     return {
+        "run_environment": run_environment or _LOCAL_ENVIRONMENT,
         "model": "gpt-recorded",
         "agent_backend": "cli",
         "cli_provider": "claude",
@@ -155,9 +172,13 @@ def _common_configuration() -> _CommonConfiguration:
     }
 
 
-def _agent_configuration(*, max_rounds: int = 7) -> AgentRunConfiguration:
+def _agent_configuration(
+    *,
+    max_rounds: int = 7,
+    run_environment: RunEnvironmentRecord | None = None,
+) -> AgentRunConfiguration:
     return AgentRunConfiguration(
-        **_common_configuration(),
+        **_common_configuration(run_environment),
         outer_loop="agent",
         inner_loop="single-agent",
         interface="service",
@@ -1318,6 +1339,168 @@ def test_resume_rejects_changes_to_immutable_configuration(
         parse_cli_invocation(["--resume", run_id, "--judge-every", "3"])
     assert exc.value.diagnostic.code == "project_resume_configuration_mismatch"
     assert "judge_every" in exc.value.diagnostic.message
+
+
+def _write_pre_migration_run(project: Path, run_id: str) -> None:
+    """Rewrite a run manifest as a schema version 1 recording."""
+    path = project / ".vibesys" / "state" / "runs" / run_id / "run.json"
+    raw = json.loads(path.read_text())
+    raw["schema_version"] = 1
+    del raw["configuration"]["run_environment"]
+    path.write_text(json.dumps(raw, indent=2, sort_keys=True))
+
+
+def _modal_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str]:
+    """Provision a project whose recorded run executes on Modal."""
+    project = _write_input_project(tmp_path)
+    run_id = "20260811-120000-11111111-agent"
+    _write_project_run(
+        project,
+        run_id,
+        configuration=_agent_configuration(run_environment=_MODAL_ENVIRONMENT),
+        created_at=datetime(2026, 8, 11, 12, tzinfo=UTC),
+    )
+    monkeypatch.chdir(project)
+    return project, run_id
+
+
+def test_fresh_run_records_the_selected_run_environment(tmp_path: Path) -> None:
+    project = _write_input_project(tmp_path)
+    args = argparse.Namespace(
+        input_bundle=load_input_bundle(project),
+        docker=False,
+        docker_image=None,
+        modal=True,
+        modal_gpu="A100-80GB",
+        modal_model_volume="weights",
+        modal_app="run-app",
+    )
+
+    record = run_environment_record(run_environment_spec_from_args(args))
+
+    assert record == _MODAL_ENVIRONMENT
+
+
+def test_resume_without_run_environment_flags_restores_the_recorded_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, run_id = _modal_run(tmp_path, monkeypatch)
+
+    args = parse_cli_invocation(["--resume", run_id]).args
+
+    assert args.modal is True
+    assert args.docker is False
+    assert args.modal_gpu == "A100-80GB"
+    assert args.modal_model_volume == "weights"
+    assert args.modal_app == "run-app"
+    assert run_environment_record(run_environment_spec_from_args(args)) == _MODAL_ENVIRONMENT
+
+
+def test_resume_with_matching_run_environment_flags_is_accepted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, run_id = _modal_run(tmp_path, monkeypatch)
+
+    args = parse_cli_invocation(
+        [
+            "--resume",
+            run_id,
+            "--modal",
+            "--modal-gpu",
+            "A100-80GB",
+            "--modal-model-volume",
+            "weights",
+            "--modal-app",
+            "run-app",
+        ]
+    ).args
+
+    assert run_environment_record(run_environment_spec_from_args(args)) == _MODAL_ENVIRONMENT
+
+
+@pytest.mark.parametrize(
+    ("flags", "field"),
+    [
+        (["--docker"], "run_environment"),
+        (["--modal", "--modal-gpu", "H100!"], "run_environment.gpu"),
+    ],
+)
+def test_resume_rejects_run_environment_flags_that_contradict_the_recording(
+    flags: list[str],
+    field: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, run_id = _modal_run(tmp_path, monkeypatch)
+
+    with pytest.raises(ConfigurationError) as exc:
+        parse_cli_invocation(["--resume", run_id, *flags])
+    assert exc.value.diagnostic.code == "project_resume_configuration_mismatch"
+    assert field in exc.value.diagnostic.message
+
+
+def test_resume_rejects_a_recording_without_a_run_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, run_id = _modal_run(tmp_path, monkeypatch)
+    _write_pre_migration_run(project, run_id)
+
+    with pytest.raises(ConfigurationError) as exc:
+        parse_cli_invocation(["--resume", run_id])
+
+    assert exc.value.diagnostic.code == "project_run_schema_migration_required"
+    assert "migrate-run-environment" in exc.value.diagnostic.message
+    assert run_id in exc.value.diagnostic.message
+
+
+def test_migrated_recording_resumes_with_the_supplied_run_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, run_id = _modal_run(tmp_path, monkeypatch)
+    _write_pre_migration_run(project, run_id)
+
+    _run_migrate_run_environment(
+        [
+            "--project",
+            str(project),
+            "--run",
+            run_id,
+            "--run-environment",
+            "modal",
+            "--modal-gpu",
+            "A100-80GB",
+            "--modal-model-volume",
+            "weights",
+            "--modal-app",
+            "run-app",
+        ]
+    )
+
+    args = parse_cli_invocation(["--resume", run_id]).args
+    assert args.modal is True
+    assert run_environment_record(run_environment_spec_from_args(args)) == _MODAL_ENVIRONMENT
+    recorded = Project.open(project).state.load_run(run_id)
+    assert recorded.schema_version == RUN_SCHEMA_VERSION
+    assert recorded.configuration.run_environment == _MODAL_ENVIRONMENT
+
+
+def test_migration_rejects_an_already_migrated_recording(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, run_id = _modal_run(tmp_path, monkeypatch)
+
+    with pytest.raises(ConfigurationError) as exc:
+        _run_migrate_run_environment(
+            ["--project", str(project), "--run", run_id, "--run-environment", "modal"]
+        )
+
+    assert exc.value.diagnostic.code == "migration_failed"
+    assert "already at run schema version" in exc.value.diagnostic.message
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -37,7 +37,7 @@ from vibesys.server.schema import ProtocolDocument
 from vibesys.server.service import SupervisionService
 from vibesys.server.transport import SupervisionSocketServer
 from vs_loop_state import RoundRecord
-from vs_project import AgentRunConfiguration, Project
+from vs_project import AgentRunConfiguration, Project, RunEnvironmentRecord
 
 
 def _events(path):  # noqa: ANN001, ANN202  # tracked: #288
@@ -57,6 +57,7 @@ def _project_run(project: Path) -> tuple[Project, str]:
         vibesys_version="0.2.0-test",
         configuration=AgentRunConfiguration(
             outer_loop="agent",
+            run_environment=RunEnvironmentRecord(name="local"),
             inner_loop="single-agent",
             interface="inprocess",
             agent_backend="stub",


### PR DESCRIPTION
## Problem

### Audit scope

- VS Meta Opt run: `llama70b-2xh100-vllm-20260813`
- VibeSys parent commit: `552f568b54a6ccdf015e3953c529e25ae15cd6f8` (main)
- Specified input paths and revisions: project `examples/model-serving/repositories/vllm` (submodule @ `8d8c11d`, detached), task `.vibesys/tasks/llama-70b-2xh100-vllm` (OBJECTIVE.md, vibesys.input.toml, objectives.toml, accuracy_checker/, benchmark/)
- Exact launch/resume command:
  ```
  cd /mnt/data/shli/vibesys/examples/model-serving/repositories/vllm
  uv run --project /mnt/data/shli/vibesys vibesys \
    --project . --task llama-70b-2xh100-vllm \
    --local --interface service --modal \
    --max-rounds 10 \
    --config /mnt/data/shli/vs-meta-opt/llama70b-20260813/agent.toml
  # resume: same cwd; uv run --project /mnt/data/shli/vibesys vibesys --resume <run-id> (same config)
  ```
- Campaign and round window: fresh campaign, rounds 1-10 (hard cap, user-specified)
- Objective and environment: maximize `aggregate_throughput`, minimize `p99_latency_ms` (Pareto) for vLLM serving `meta-llama/Llama-3.3-70B-Instruct` on 2x H100 80GB via Modal (`--modal`, backend default `cuda`); accuracy gates: sentinel echo, known-answer, greedy determinism. Model weights pre-seeded in Modal volume `vibesys-model-meta-llama-llama-3-3-70b-...`
- Prompt, skill, evaluator, and policy versions: all at VibeSys `552f568`; models: orchestrator (outer) = Claude Code `claude-fable-5`, implementer (inner) = `claude-sonnet-5`, judge/profiler (base) = `claude-opus-5`; `--judge-every 3`, `--official-eval-every 3` (defaults)
- Evidence index paths:
  - Portable state: `examples/model-serving/repositories/vllm/.vibesys/state/runs/<run-id>/` (run.json, agent/rounds/NNNN.json, runtime/effective-objective.md) on branch `vibesys-runs/<run-id>` in the submodule
  - Local state/logs: `examples/model-serving/repositories/vllm/.vibesys/state/local/runs/<run-id>/{logs,worktrees,agent}`
  - Launcher stdout/stderr: `/mnt/data/shli/vs-meta-opt/llama70b-20260813/vibesys.log`
- Missing instrumentation: none identified yet (to be filled as audits find gaps)

### Run control

- Maximum rounds: 10 (user directive)
- Maximum wall-clock time: 36 h from launch
- Maximum accelerator time or cost: ~40 H100-hours on Modal (monitor per round; audit if a single round exceeds ~4 GPU-hours)
- Maximum agent turns or inference budget: per-round CLI defaults (`--max-retries-per-round 3`); no extra cap
- Maximum meta-interventions: 4 committed VibeSys changes
- Terminal evaluation and cleanup reserve: final round's official eval + 1 h for evidence publication, Modal app teardown, worktree cleanup
- Final budgets: 10/10 rounds used (campaign complete 19:15 UTC, ~12.3h wall of 36h); 4/4 interventions used; GPU spend well under the 40 H100-hr cap (intermittent single 2xH100 container across rounds 8-10, including 3 cold starts in round 10 and the official eval)
- Last completed round and current phase: round 10 committed with official evaluation / terminal cleanup done
- Terminal state: all Modal apps stopped (framework stopped the round-10 app at 19:15 UTC post-eval), zero active containers, editor container removed, run branch final commit b673123

### Baseline effectiveness

| Category | Finding | Evidence | Baseline measure | Confidence |
| --- | --- | --- | --- | --- |
| Outcome effectiveness | 0/3 rounds produced metrics or frontier progress | rounds/0001-0002.json: passed=false, empty metrics | 0 evaluated candidates in 3 rounds | high |
| Learning effectiveness | Implementer work was real (main.py TP=2 candidate + 7 review blockers fixed) but ingestion failed every turn | round001-003 logs | 1 real implementation, 0 ingested | high |
| Operational efficiency | Rounds 2-3 were 110s no-op recovery turns consuming full rounds | usage.jsonl; round002/003 logs | 3 rounds burned, ~$13.3 LLM spend, 0 evidence | high |
| Coordination quality | Judge deferred by sparse-review policy on synthesized responses; retry budget never spent | round002 log tail; loop.py:2437 | max_retries_per_round unused | high |
| Evidence integrity | Intact: implementer honestly reported unassessed, no invented metrics; accuracy gates untouched | round logs | no reward-hacking signs | high |
| Search quality and generality | Not yet assessable (no evaluated round) | - | - | - |
| Other | Infra: first-run docker pull vs 120s start timeout; submodule .git pointer unresolvable in sandbox (git-history degraded) | vibesys.log; PR comment 1 | 2 launch failures | high |

### Limiting VibeSys mechanism

- Failure classification: framework defect (response ingestion), amplified by loop control flow
- Causal mechanism: (A) materialize_native_output_schema() applies Codex's strict schema subset to all providers; dict[str,T] fields (ImplementerResponse.metrics et al.) reject -> silent prompt fallback -> model hand-emits ~7.5KB JSON -> unescaped backslash/quote parse failures. (B) parse-failure fallback response indistinguishable from genuine inconclusive turn -> sparse-review defers judge -> round commits with no evidence; retries unspent.
- Confounders and alternatives: none material; reproduced deterministically offline (repro: feed round-log JSON into parse_typed_response_text; materialize schema for ImplementerResponse)

## Solution

### Meta-hypothesis

- Proposed VibeSys intervention: (1) e0364de provider-capability gate for native output schema strictness (Claude keeps native structured output for mapping-bearing schemas); (2) 8cb0c11 typed ResponseFallback signal so parse failures consume a same-round retry instead of committing an evidence-free round.
- Why it improves discovery rather than leaking an answer: both are procedural ingestion/control-flow fixes; no candidate knowledge, benchmark data, or evaluator behavior enters prompts.
- Expected meta-metric effects: implementer turns parse natively (no "[structured-output] ... prompt fallback" for ImplementerResponse); zero synthesized-response rounds; rounds produce judge reviews and official evaluations; round efficiency (evidence-bearing rounds / total) rises from 0/3.
- Possible regressions: schema dialect mismatch on claude CLI variants (mitigated: verified on 2.1.221 in this environment); retry-consumption could triple cost of a persistent extraction failure (bounded by max_retries_per_round=3).
- Success criteria: by round 6, >=1 round with real metrics ingested and no synthesized-response round commits.
- Reversion condition: if implementer turns still fail to parse in >=2 of rounds 4-6, revert e0364de and re-audit; if retry loop misbehaves (infinite or double-spend), revert 8cb0c11 immediately.
- Generality claim: applies to all CLI providers/schemas, not this task; strict providers keep prior behavior.

### Architecture

- Change surface and owner: TBD
- Candidate/system boundary: candidate = vLLM fork changes inside the campaign worktrees; system = VibeSys framework on this branch. No candidate code in framework commits.
- Framework, prompt, skill, adapter, and artifact responsibilities: TBD
- Project conventions followed: docs/coding-best-practices.md
- Existing abstractions reused or extended: TBD
- New abstraction or adjacent refactor and its justification: TBD
- Special-case or compatibility paths intentionally avoided: TBD

### Generated schema migration (if applicable)

- run.json schema v1 -> v2 (commit 292fe67): required `run_environment` record (name/image/gpu/model_volume/app) added to run configuration. One-way migration via `vibesys migrate-run-environment`; live campaign migrated once (snapshot: `run.json.pre-migration-snapshot`; migration committed on run branch, 9495cf0). Resume rejects v1 state with `RunSchemaMigrationRequiredError`. No parallel schema implementations retained.

### Intervention log

| Commit | Rationale | Scope | Validation status |
| --- | --- | --- | --- |
| e0364de | Codex-only schema strictness silently degraded Claude structured output; provider capability flag restores native path | _agent_cli/base,claude; agents/cli_common,cli_runner; tests (406 passed) | Validated in S2: zero prompt fallbacks rounds 4-6, native parses throughout |
| 8cb0c11 | Framework parse failure burned rounds; typed ResponseFallback signal spends retries instead | agents/base,__init__; loops/agent/loop.py; tests (556 passed) | Validated in S2: parse failures consumed in-round retries; no evidence-free round commits from synthesized responses |
| 292fe67 | Runtime environment (modal/docker/local) not persisted in run state; --resume silently degraded to local and ran gates on a GPU-less host (rounds 4-6 burned) | vs-project _state (schema v2 + migration), main.py resume restore + migrate subcommand, sandbox/run_environment.py record producer; tests | Validating (S4+): resume must restore modal env from recorded state |
| 00aae96 | Env-var CLI auth (ANTHROPIC_AUTH_TOKEN et al.) not forwarded into Docker editor container; in-container claude exited 1 with empty stderr | agents/cli_docker (auth env passthrough), sandbox/run_environment.py (merge + fail-fast), vs-sandbox docker_sandbox (secret redaction in logs/metadata) | Validating (S4+): editor container must authenticate; full suite 4101 passed |
| bf037ad | Defect #7: evaluator appended `--url https://<app>.modal.run`, measuring TLS/WAN/ingress/admission-queue instead of the task's localhost contract; official 35.34 tok/s was an admission-serialization artifact | sandbox/modal_evaluator.py rewritten to colocated execution: stage inputs into the serving container, run the trusted command unmodified via `modal container exec` (rc sentinel; exec does not propagate exit codes), relay output files, keep-warm thread against public /health; tests rewritten (4115 passed) | Validated post-campaign: colocated re-measurement of b673123 completed both gates in-container against 127.0.0.1:8000 |
| 215cc71 | Container discovery matched title-case `container list --json` keys; modal 1.5.x emits snake_case, so discovery timed out against a healthy deployment | modal_evaluator.py `_find_app_container` accepts both key styles and surfaces CLI stderr on failure; +3 tests | Validated post-campaign: discovery found the serving container on the re-measurement run |

Intervention budget: 4/4 in-campaign interventions used; bf037ad+215cc71 are a user-authorized post-campaign fix of defect #7 (validated by re-measurement, below). Defect #5 (ensure_model_volume proceeds silently without HF token, leaving an empty volume with exit 0) is documented for follow-up, not fixed in this campaign.

### Campaign segments

| Segment | VibeSys commit | Checkpoint and rounds | Input and command | Active meta-hypothesis | End reason and evidence |
| --- | --- | --- | --- | --- | --- |
| S1 | 552f568 (=5b6b120) | fresh -> round 3 (all failed, no evidence) | llama-70b-2xh100-vllm, command above | none (baseline observation) | paused 07:57 UTC after audit: 100% implementer parse failures; evidence: rounds/0001-0002.json, round001-003 logs, PR comments |
| S2 | 8cb0c11 | resume round 4 -> round 6 (rounds 4-5 committed without metrics) | same input, --resume 20260813-065726-... | fixes e0364de+8cb0c11 under validation | paused: fixes 1-2 validated, but rounds ran in silently-degraded local env (bug 3); gates could not pass without GPUs |
| S3 | 292fe67 | migrated run.json to schema v2; resume round 6 | same input + `migrate-run-environment` once | fix 292fe67 (env persistence) | died in startup: editor container claude auth failure (bug 4) |
| S4 | 00aae96 | resume round 6 (attempt 3 completed, judge pending) | same input, same resume command | fix 00aae96 (auth passthrough) | paused: model volume empty; meta-llama repo gated, two tokens 403; user approved mirror seed |
| S5 | 00aae96 | volume seeded from mirror 18:04 UTC (30 shards + sentinel verified); resumed round 8 -> 10 (rounds 6-7 had committed in S4) | same input, same resume command | validation only (no new interventions) | completed 19:15 UTC: max_rounds reached; round 10 passed with official eval (accuracy 3/3 PASS, aggregate_throughput=35.34) |

### Weights provenance

The Modal volume `vibesys-model-meta-llama-llama-3-3-70b-instruct` is seeded from `unsloth/Llama-3.3-70B-Instruct` (public, non-gated, full-bf16 rehost of `meta-llama/Llama-3.3-70B-Instruct`: 30 safetensors shards, ~141 GB, no quantization tags), because the official repo is gated and no authorized token was available. User-approved 2026-08-13. Caveat: official-result provenance is a mirror; the task's accuracy gates (sentinel echo, known-answer, greedy determinism) verify behavioral equivalence at serve time.

### Counterfactual trajectory reviews

| Round/window | Trigger | Independent review artifacts | Review cost | VibeSys proposal | Comparison | Attributed failure | System response |
| --- | --- | --- | --- | --- | --- | --- | --- |
| | | | | | | | |

### Leakage review

- [x] Prompts contain procedures and contracts, not candidate optimizations or benchmark answers. (Neither fix touches prompts beyond preserving the existing fallback hint.)
- [x] Reusable domain knowledge is isolated in versioned, selectively loaded skills. (No skill changes.)
- [x] Skill-set changes are recorded as capability changes rather than planning-policy gains. (N/A this window.)
- [x] Campaign-specific findings remain in artifacts referenced by path.

## Verification

### Effectiveness tracker

| Checkpoint | Campaign window | Meta-metrics | Comparison/control | Confounders | Interpretation |
| --- | --- | --- | --- | --- | --- |
| Baseline (S1, pre-intervention) | rounds 1-3 | 0/3 evidence-bearing rounds; 100% implementer parse failures; 0 judge reviews; retries unspent | n/a | fresh campaign | ingestion defects made every round evidence-free |
| Post fixes 1-2 (S2) | rounds 4-6 | 0 prompt fallbacks; retries consumed in-round; real judge reviews resumed | S1 | env silently degraded to local (bug 3) masked gate outcomes | fixes 1-2 validated; new defect class exposed |
| Post fixes 3-4 (S4-S5) | rounds 8-10 | 3/3 evidence-bearing rounds; 2 judge-passed rounds; round 10: accuracy 3/3 PASS + official benchmark PASS | S1-S2 | weights mirror substitution (user-approved); candidate-side nvcc blockers consumed rounds 8-9 | full pipeline (deploy, judge, official eval) functional end-to-end |
| Post fix 5 (bf037ad+215cc71, post-campaign) | re-measurement of final candidate b673123 | colocated eval: accuracy PASS (sentinel 6/6, known-answer 7/8, determinism 4/4); aggregate_throughput=274.99 tok/s, p99_latency=3779.8 ms, p99_TTFT=156.4 ms, p99_TPOT=28.55 ms, 72/72 requests | WAN-path official eval (35.34 tok/s) | none: same candidate revision, same volume, same benchmark config (c=8, 30 s) | 7.8x throughput delta confirms the WAN number was a Modal admission-queue artifact; engine runs at the ~28 ms/token bandwidth roofline with near-perfect batch-8 scaling |

### Terminal result

- Round 10 official evaluation (final_round): framework accuracy checker PASS (3/3 gates: sentinel echo, known-answer, greedy determinism), framework benchmark PASS with `aggregate_throughput = 35.337` (headline metric; recorded as `perf_metric` in rounds/0010.json). Judge verdict: pass, after byte-level provenance verification (main.py sha256 vs prelaunch archive), live production-path probes (streaming SSE contract, greedy determinism, stop/EOS semantics), and reward-hacking audit (workload, accounting, and gate sources untouched).
- Candidate delta over 10 rounds: Modal TP=2 deployment entrypoint (`main.py`) plus two startup repairs (`fuse_allreduce_rms=false` pass-config, `VLLM_USE_FLASHINFER_SAMPLER=0`) working around the serving image's missing CUDA toolkit; no vLLM source changes. First trusted frontier row established; no optimization iterations remained within the 10-round cap.
- Colocated re-measurement (post-campaign, fixed evaluator bf037ad+215cc71, same candidate b673123, same benchmark config): accuracy PASS; `aggregate_throughput = 274.99 tok/s`, `p99_latency_ms = 3779.8`, `p99_ttft_ms = 156.4`, `p99_tpot_ms = 28.55`, 72/72 requests, 0 errors. TPOT p50 28.53 ms equals the single-stream decode floor, i.e. batch-8 continuous batching added no per-token cost; throughput scaled 7.8x over the WAN-path official number. This confirms the 35.34 tok/s official row measured Modal's function-admission queue, not the engine. Full JSON: `/tmp/vibesys-rerun-benchmark.json` (copy in `/mnt/data/shli/vs-meta-opt/llama70b-20260813/`); log: `rerun.log`.
- Documented framework defects: #5 `ensure_model_volume` silently succeeds without an HF token, leaving an empty volume (exit 0) — open; #6 official-eval records only the headline metric into round state, losing the second Pareto axis (`p99_latency_ms`) — open; #7 the Modal evaluator rewrote the task's measurement topology (appended `--url https://<app>.modal.run`, adding TLS, WAN RTT, ingress, and the function-admission queue) — FIXED on this branch (bf037ad colocated execution + 215cc71 discovery key fix) and validated by the re-measurement above. Root-cause evidence for the artifact: engine logs showed `Running: 1, Waiting: 0` throughout with per-request execution 3.58 s while client-observed duration climbed linearly to 28.9 s.

### Correctness properties

- VibeSys system invariant: framework changes never encode candidate optimizations, benchmark answers, or evaluator behavior into prompts
- Evidence-integrity invariant: accuracy gates (sentinel echo, known-answer, greedy determinism) remain intact and unmodified by the campaign
- Generality or compatibility boundary: interventions must be justified for VibeSys generally, not only this task

### Testing

- Command or workflow: targeted pytest for touched modules + `vibesys validate` on the input; recorded per intervention
- Result: pending

### Disposition

- Current status: `Complete — recommend merge`
- Decision evidence: all interventions validated live (fixes 1-2 in S2: native parses, retries in-round; fixes 3-4 in S4-S5: modal env restored on resume, editor container authenticated, full round pipeline through official eval; fix 5 post-campaign: colocated evaluator produced a clean in-container measurement of the final candidate); full test suite 4115 passed; lint/format/pyright clean.
- Campaign outcome: 10/10 rounds, terminal official eval PASS (accuracy 3/3, aggregate_throughput=35.34 via the now-fixed WAN path; colocated re-measurement of the same candidate: 274.99 tok/s, p99 3779.8 ms). Rounds 1-7 were consumed by framework defects (now fixed) and environment blockers; rounds 8-10 by candidate bring-up. The optimizer never reached a perf-iteration phase, so search-quality effectiveness beyond bring-up remains unassessed in this campaign.
- Follow-up: file issues for defect #5 (silent tokenless volume seed) and #6 (official-eval persists only the headline metric, losing the second Pareto axis); consider a longer-round campaign now that #7 is fixed so official rows measure the engine (starting frontier ~275 tok/s at c=8, TPOT already at the bandwidth roofline, so gains must come from batching/scheduling headroom, KV/kernel efficiency, or latency-axis work).
- Weights provenance caveat: official result was served from the unsloth mirror of Llama-3.3-70B-Instruct (user-approved); accuracy gates verified behavioral equivalence at serve time.

