### PR TITLE
Gate native-output-schema strictness on a provider capability

### DIFF
--- a/src/vibesys/_agent_cli/base.py
+++ b/src/vibesys/_agent_cli/base.py
@@ -87,6 +87,18 @@ class CodingAgent(ABC):
     subprocess working directory.
     """
 
+    native_output_schema_allows_arbitrary_keys = False
+    """Whether this provider's schema dialect accepts open-ended object maps.
+
+    The default is the strict subset (e.g. Codex's ``--output-schema``), which
+    requires every object to declare its properties and forbids undeclared keys,
+    so a Pydantic ``dict[str, T]`` field cannot be expressed natively. Providers
+    whose CLI accepts a schema-valued (or ``true``) ``additionalProperties``
+    (e.g. Claude Code's ``--json-schema``) set this ``True`` so mapping-bearing
+    response models keep the native structured-output path instead of falling
+    back to the prompt-level schema instruction.
+    """
+
     # Declared (not assigned) here: every concrete provider sets these in its
     # ``__init__``.  ``env`` is the subprocess environment the CLI is spawned
     # with; ``executor`` is the agentshim ``CommandExecutor`` (host, docker,

--- a/src/vibesys/_agent_cli/claude.py
+++ b/src/vibesys/_agent_cli/claude.py
@@ -66,6 +66,10 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
     # host and container execution paths, where the workspace is bind-mounted)
     # rather than the workspace-relative path Codex resolves against its cwd.
     native_output_schema_wants_absolute_path = True
+    # Unlike Codex's strict subset, ``--json-schema`` accepts open-ended object
+    # maps, so ``dict[str, T]`` fields (e.g. ``ImplementerResponse.metrics``)
+    # stay on the native path instead of degrading to the prompt hint.
+    native_output_schema_allows_arbitrary_keys = True
 
     def __init__(  # noqa: ANN204  # tracked: #288
         self,

--- a/src/vibesys/agents/cli_common.py
+++ b/src/vibesys/agents/cli_common.py
@@ -73,17 +73,40 @@ _UNSUPPORTED_NATIVE_SCHEMA_KEYWORDS = frozenset(
 )
 
 
-def _validate_native_output_schema(schema: object) -> dict[str, object]:  # noqa: C901  # tracked: #288
-    """Normalize and validate the strict JSON Schema subset used by Codex.
+def _validate_native_output_schema(  # noqa: C901  # tracked: #288
+    schema: object,
+    *,
+    allow_arbitrary_keys: bool = False,
+) -> dict[str, object]:
+    """Normalize and validate the JSON Schema subset a provider accepts natively.
 
-    Native structured output requires every declared object property and
-    forbids undeclared keys. Pydantic omits defaulted properties from
-    ``required`` and represents arbitrary mappings with a schema-valued
-    ``additionalProperties``; the former is normalized here while the latter
-    falls back to the portable prompt contract.
+    The default (strict) profile is Codex's: every declared object property is
+    required and undeclared keys are forbidden. Pydantic omits defaulted
+    properties from ``required`` and represents arbitrary mappings with a
+    schema-valued ``additionalProperties``; the former is normalized here while
+    the latter is rejected so the caller can fall back to the portable prompt
+    contract.
+
+    *allow_arbitrary_keys* selects the permissive profile used by providers
+    whose CLI accepts open-ended object maps (see
+    :attr:`~vibesys._agent_cli.base.CodingAgent.native_output_schema_allows_arbitrary_keys`).
+    An existing ``additionalProperties`` is then preserved verbatim, and a
+    schema-valued one is still traversed so nested subschemas obey the same
+    rules. Objects that do not declare one are still closed with ``False``.
     """
     if not isinstance(schema, dict) or schema.get("type") != "object":
         raise ValueError("native output schema must have an object root")  # noqa: TRY003  # tracked: #288
+
+    def close_object(node: dict[str, object], location: str) -> None:
+        """Apply the profile's undeclared-key rule to one object node."""
+        additional = node.get("additionalProperties")
+        if additional in (None, False):
+            node["additionalProperties"] = False
+            return
+        if not allow_arbitrary_keys:
+            raise ValueError(f"native output schema uses arbitrary object keys at {location}")  # noqa: TRY003  # tracked: #288
+        # Preserved verbatim; a schema-valued map is traversed by the generic
+        # key walk below so nested subschemas obey the same rules.
 
     def visit(node: object, location: str) -> None:  # noqa: C901, PLR0912  # tracked: #288
         if isinstance(node, list):
@@ -106,16 +129,10 @@ def _validate_native_output_schema(schema: object) -> dict[str, object]:  # noqa
         if properties is not None:
             if not isinstance(properties, dict):
                 raise ValueError(f"native output schema {location}/properties must be an object")  # noqa: TRY003  # tracked: #288
-            additional = node.get("additionalProperties")
-            if additional not in (None, False):
-                raise ValueError(f"native output schema uses arbitrary object keys at {location}")  # noqa: TRY003  # tracked: #288
-            node["additionalProperties"] = False
+            close_object(node, location)
             node["required"] = list(properties)
         elif node.get("type") == "object":
-            additional = node.get("additionalProperties")
-            if additional not in (None, False):
-                raise ValueError(f"native output schema uses arbitrary object keys at {location}")  # noqa: TRY003  # tracked: #288
-            node["additionalProperties"] = False
+            close_object(node, location)
             node["required"] = []
         for key, value in node.items():
             if key in {"properties", "$defs", "definitions"}:
@@ -134,9 +151,22 @@ def _validate_native_output_schema(schema: object) -> dict[str, object]:  # noqa
     return schema
 
 
-def materialize_native_output_schema(workspace: Path, response_cls: type[BaseModel]) -> str:
-    """Atomically write a validated schema and return its relative CLI path."""
-    schema = _validate_native_output_schema(response_cls.model_json_schema())
+def materialize_native_output_schema(
+    workspace: Path,
+    response_cls: type[BaseModel],
+    *,
+    allow_arbitrary_keys: bool = False,
+) -> str:
+    """Atomically write a validated schema and return its relative CLI path.
+
+    *allow_arbitrary_keys* is the calling provider's
+    ``native_output_schema_allows_arbitrary_keys`` capability; it selects the
+    permissive validation profile for mapping-bearing response models.
+    """
+    schema = _validate_native_output_schema(
+        response_cls.model_json_schema(),
+        allow_arbitrary_keys=allow_arbitrary_keys,
+    )
     encoded = (json.dumps(schema, indent=2, sort_keys=True, allow_nan=False) + "\n").encode()
     digest = hashlib.sha256(encoded).hexdigest()[:16]
     relative = _NATIVE_SCHEMA_DIR / f"{response_cls.__name__}-{digest}.json"

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -186,7 +186,15 @@ class CliAgentRunner:
         )
         if native_schema_supported:
             try:
-                native_schema_path = materialize_native_output_schema(workspace, response_cls)
+                native_schema_path = materialize_native_output_schema(
+                    workspace,
+                    response_cls,
+                    allow_arbitrary_keys=getattr(
+                        self._provider_cls,
+                        "native_output_schema_allows_arbitrary_keys",
+                        False,
+                    ),
+                )
             except (OSError, TypeError, ValueError) as exc:
                 log_and_print(
                     f"[structured-output] native schema unavailable for "

--- a/tests/_agent_cli/test_claude.py
+++ b/tests/_agent_cli/test_claude.py
@@ -16,6 +16,17 @@ _SCHEMA = {
     "additionalProperties": False,
 }
 
+# Shape produced by a ``dict[str, float]`` field (e.g.
+# ``ImplementerResponse.metrics``): arbitrary keys with a constrained value type.
+_MAPPING_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "metrics": {"type": "object", "additionalProperties": {"type": "number"}},
+    },
+    "required": ["metrics"],
+    "additionalProperties": False,
+}
+
 
 class _MockCommandExecutor:
     """CommandExecutor that avoids real binary lookups."""
@@ -125,6 +136,35 @@ class TestClaudeNativeOutputSchema:
         # ``--json-schema`` is read inline at build time, so the schema file
         # path must be resolvable independent of the subprocess cwd.
         assert ClaudeCodeCodingAgent.native_output_schema_wants_absolute_path is True
+
+    def test_allows_arbitrary_object_keys(self):  # noqa: ANN202  # tracked: #288
+        # ``--json-schema`` accepts open-ended maps (verified against Claude
+        # Code 2.1.221), unlike Codex's strict ``--output-schema`` subset.
+        assert ClaudeCodeCodingAgent.native_output_schema_allows_arbitrary_keys is True
+
+    def test_mapping_schema_reaches_the_session_and_yields_structured_output(  # noqa: ANN202  # tracked: #288
+        self,
+        agent,  # noqa: ANN001  # tracked: #288
+        tmp_path,  # noqa: ANN001  # tracked: #288
+    ):
+        """A ``dict[str, float]`` field stays native: inlined, then captured back."""
+        schema_file = tmp_path / "schema.json"
+        schema_file.write_text(json.dumps(_MAPPING_SCHEMA), encoding="utf-8")
+        agent.set_output_schema_path(str(schema_file))
+        payload = {"metrics": {"latency_ms": 12.5, "throughput": 3.0}}
+        agent.executor = _ReplayExecutor(
+            [json.dumps({"type": "result", "result": "done", "structured_output": payload}) + "\n"]
+        )
+
+        cmd = agent._get_command("test prompt")  # noqa: SLF001  # tracked: #288
+        session = agent._create_session(cmd=cmd)  # noqa: SLF001  # tracked: #288
+        result = session.run("test prompt")
+
+        # The mapping survives into argv rather than being flattened away.
+        inline = json.loads(cmd[cmd.index("--json-schema") + 1])
+        assert inline == _MAPPING_SCHEMA
+        assert inline["properties"]["metrics"]["additionalProperties"] == {"type": "number"}
+        assert json.loads(result) == payload
 
     def test_command_omits_json_schema_when_unset(self, agent):  # noqa: ANN001, ANN202  # tracked: #288
         cmd = agent._get_command("test prompt")  # noqa: SLF001  # tracked: #288

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -18,6 +18,7 @@ from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config
 from vibesys.constants import ComputeBackend
 from vibesys.schemas import (
+    ImplementerResponse,
     IssueJudgeResponse,
     JudgeResponse,
     Verdict,
@@ -28,6 +29,10 @@ from vs_sandbox import HostResource, ProjectPathPolicy
 def _agent_config(**agent) -> Config:  # noqa: ANN003  # tracked: #288
     """Minimal valid Config carrying just an ``[agent]`` section for runner tests."""
     return Config.model_validate({"model": {"name": "m"}, "agent": agent})
+
+
+def _implementer_fallback() -> ImplementerResponse:
+    return ImplementerResponse(summary="fallback", expected_behavior="fallback")
 
 
 def _judge_fallback() -> JudgeResponse:
@@ -1245,6 +1250,82 @@ class TestCliAgentRunner:
         assert Path(passed).is_file()
         assert Path(passed).parent == workspace / ".cache/vibesys/response-schemas"
         assert "Schema for JudgeResponse" not in agent.generate_calls[0]["prompt"]
+
+    def test_mapping_response_stays_native_on_a_permissive_provider(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        """``ImplementerResponse.metrics`` is a ``dict[str, float]``; Claude's
+        ``--json-schema`` accepts that, so the native path must be kept."""
+        captured: list = []
+        fake_cls = _make_fake_agent_class(
+            generate_returns='{"summary": "ok", "expected_behavior": "faster"}',
+            captured=captured,
+        )
+        fake_cls.supports_native_output_schema = True
+        fake_cls.native_output_schema_wants_absolute_path = True
+        fake_cls.native_output_schema_allows_arbitrary_keys = True
+        monkeypatch.setitem(
+            __import__(  # noqa: SLF001  # tracked: #288
+                "vibesys.agents.cli_runner",
+                fromlist=["_PROVIDER_CLASSES"],
+            )._PROVIDER_CLASSES,
+            "claude",
+            fake_cls,
+        )
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        runner = CliAgentRunner(provider="claude", model="m", run_log_file=None)
+
+        runner.invoke(
+            kind="implementer",
+            workspace=workspace,
+            system_prompt="THE-SYSTEM-PROMPT",
+            user_prompt="usr",
+            response_cls=ImplementerResponse,
+            fallback_factory=_implementer_fallback,
+            round_label="implementer #1",
+        )
+
+        agent = captured[0]
+        passed = agent.output_schema_paths[-1]
+        assert passed is not None
+        schema = json.loads(Path(passed).read_text())
+        assert schema["properties"]["metrics"]["additionalProperties"] == {"type": "number"}
+        assert "Schema for ImplementerResponse" not in agent.generate_calls[0]["prompt"]
+
+    def test_mapping_response_falls_back_on_a_strict_provider(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        """Codex's subset cannot express the mapping, so the prompt hint stays."""
+        captured: list = []
+        fake_cls = _make_fake_agent_class(
+            generate_returns='{"summary": "ok", "expected_behavior": "faster"}',
+            captured=captured,
+        )
+        fake_cls.supports_native_output_schema = True
+        monkeypatch.setitem(
+            __import__(  # noqa: SLF001  # tracked: #288
+                "vibesys.agents.cli_runner",
+                fromlist=["_PROVIDER_CLASSES"],
+            )._PROVIDER_CLASSES,
+            "codex",
+            fake_cls,
+        )
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        log = StringIO()
+        runner = CliAgentRunner(provider="codex", model="m", run_log_file=log)
+
+        runner.invoke(
+            kind="implementer",
+            workspace=workspace,
+            system_prompt="THE-SYSTEM-PROMPT",
+            user_prompt="usr",
+            response_cls=ImplementerResponse,
+            fallback_factory=_implementer_fallback,
+            round_label="implementer #1",
+        )
+
+        agent = captured[0]
+        assert agent.output_schema_paths == [None]
+        assert "Schema for ImplementerResponse" in agent.generate_calls[0]["prompt"]
+        assert "using prompt fallback" in log.getvalue()
 
     def test_cli_runner_chat_returns_plain_text_in_a_fresh_session_per_turn(  # noqa: ANN201  # tracked: #288
         self,

--- a/tests/agents/test_cli_common.py
+++ b/tests/agents/test_cli_common.py
@@ -24,10 +24,27 @@ from vibesys.agents.cli_common import (
 )
 from vibesys.schemas import (
     ImplementerResponse,
+    IssuePerfEvalResponse,
     JudgeResponse,
     OrchestratorPlan,
+    PerfEvalResponse,
+    PerfMetrics,
     PreRoundDecision,
+    ProfilerSummary,
+    SingleAgentRoundResponse,
 )
+
+# Response models with at least one ``dict[str, T]`` field, which Pydantic
+# renders as a schema-valued (or ``true``) ``additionalProperties``. Providers
+# on the strict profile cannot express these natively; permissive ones can.
+MAPPING_RESPONSE_MODELS = [
+    ImplementerResponse,
+    SingleAgentRoundResponse,
+    ProfilerSummary,
+    PerfMetrics,
+    PerfEvalResponse,
+    IssuePerfEvalResponse,
+]
 
 
 def _skill(root: Path, name: str, body: str = "# skill\n") -> Path:
@@ -192,6 +209,35 @@ class TestBuildSchemaHint:
         assert "Do not wrap it in markdown fences" in build_schema_hint(JudgeResponse)
 
 
+def _assert_declared_objects_are_closed(node) -> None:  # noqa: ANN001  # tracked: #288
+    """Every object that declares properties requires all of them and is closed."""
+    if isinstance(node, list):
+        for value in node:
+            _assert_declared_objects_are_closed(value)
+    elif isinstance(node, dict):
+        if "$ref" in node:
+            assert set(node) == {"$ref"}
+        if "properties" in node:
+            assert set(node["required"]) == set(node["properties"])
+        for value in node.values():
+            _assert_declared_objects_are_closed(value)
+
+
+def _open_maps(node) -> list:  # noqa: ANN001  # tracked: #288
+    """Collect every ``additionalProperties`` value that permits extra keys."""
+    found = []
+    if isinstance(node, list):
+        for value in node:
+            found.extend(_open_maps(value))
+    elif isinstance(node, dict):
+        additional = node.get("additionalProperties")
+        if additional not in (None, False):
+            found.append(additional)
+        for value in node.values():
+            found.extend(_open_maps(value))
+    return found
+
+
 class TestMaterializeNativeOutputSchema:
     @pytest.mark.parametrize(
         "response_cls",
@@ -220,9 +266,56 @@ class TestMaterializeNativeOutputSchema:
         assert "default" not in target.read_text()
         assert not list(target.parent.glob(f".{target.name}.*"))
 
-    def test_schema_valued_mapping_falls_back_before_writing(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    @pytest.mark.parametrize("response_cls", MAPPING_RESPONSE_MODELS)
+    def test_strict_profile_rejects_mappings_before_writing(self, tmp_path, response_cls):  # noqa: ANN001, ANN201  # tracked: #288
+        """Providers on the Codex subset keep the prompt fallback for these."""
         with pytest.raises(ValueError, match="arbitrary object keys"):
-            materialize_native_output_schema(tmp_path, ImplementerResponse)
+            materialize_native_output_schema(tmp_path, response_cls)
+
+        assert not (tmp_path / ".cache/vibesys/response-schemas").exists()
+
+    @pytest.mark.parametrize("response_cls", MAPPING_RESPONSE_MODELS)
+    def test_permissive_profile_materializes_mappings(self, tmp_path, response_cls):  # noqa: ANN001, ANN201  # tracked: #288
+        relative = materialize_native_output_schema(
+            tmp_path, response_cls, allow_arbitrary_keys=True
+        )
+        target = tmp_path / relative
+        schema = json.loads(target.read_text())
+
+        assert relative.startswith(".cache/vibesys/response-schemas/")
+        _assert_declared_objects_are_closed(schema)
+        assert "default" not in target.read_text()
+        assert not list(target.parent.glob(f".{target.name}.*"))
+        # The mapping is preserved rather than rewritten to ``false``, so the
+        # CLI still constrains the value type of each arbitrary key.
+        assert _open_maps(schema), "expected the arbitrary-key mapping to survive"
+
+    @pytest.mark.parametrize("response_cls", [PreRoundDecision, OrchestratorPlan, JudgeResponse])
+    def test_permissive_profile_still_closes_declared_objects(self, tmp_path, response_cls):  # noqa: ANN001, ANN201  # tracked: #288
+        """Relaxing the mapping rule must not open up ordinary models."""
+        relative = materialize_native_output_schema(
+            tmp_path, response_cls, allow_arbitrary_keys=True
+        )
+        schema = json.loads((tmp_path / relative).read_text())
+
+        assert _open_maps(schema) == []
+
+    def test_permissive_profile_validates_inside_a_mapping(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        """The preserved mapping subschema is still walked for unsupported constructs."""
+
+        class MappedUnsupportedResponse(JudgeResponse):
+            @classmethod
+            def model_json_schema(cls, *args, **kwargs):  # noqa: ANN002, ANN003, ANN206, ARG003  # tracked: #288
+                return {
+                    "type": "object",
+                    "properties": {"metrics": {"type": "object"}},
+                    "additionalProperties": {"oneOf": [{"type": "string"}]},
+                }
+
+        with pytest.raises(ValueError, match="unsupported keyword 'oneOf'"):
+            materialize_native_output_schema(
+                tmp_path, MappedUnsupportedResponse, allow_arbitrary_keys=True
+            )
 
         assert not (tmp_path / ".cache/vibesys/response-schemas").exists()
 


### PR DESCRIPTION
## Problem

Fixes #350. With the `claude` CLI provider, `materialize_native_output_schema()`
applied the strict JSON Schema subset required by Codex's `--output-schema`
(every object must declare its properties; `additionalProperties` cannot be
schema-valued) to ALL providers, not just Codex. Any typed response containing
a mapping field (e.g. `ImplementerResponse.metrics: dict[str, float]`) failed
materialization for every provider, so the framework silently fell back to
prompt-embedded JSON: the model hand-emits a ~7.5 KB JSON object containing
code snippets, which routinely carries unescaped backslashes/quotes, so
`parse_typed_response_text` fails. Observed live in the meta-opt campaign
(#347): 100% implementer parse-failure rate in rounds 1-3, real sandbox work
was completed but never ingested. The failure is silent: the only trace is a
`[structured-output] ... prompt fallback` log line.

## Solution

Introduce a provider capability flag for native-output-schema strictness.
Codex keeps the strict subset (its contract); Claude Code (and any future
provider whose CLI accepts a schema-valued `additionalProperties`, verified on
Claude Code 2.1.221) keeps native structured output for mapping-bearing
schemas.

Why this is thorough: the root cause was one provider's constraint hardcoded
into a shared code path. Moving it behind a per-provider capability means new
providers declare their own constraint instead of inheriting Codex's, and the
strict-subset code path is byte-for-byte unchanged for Codex, so there is no
behavior change for existing users of that provider. Validated live: after
this fix, campaign rounds 4-10 had zero prompt fallbacks; every implementer
turn parsed natively.

### Architecture

- `CodingAgent.native_output_schema_allows_arbitrary_keys` (in
  `src/vibesys/_agent_cli/base.py`): new capability flag, defaults to `False`
  (the strict subset), declared alongside the provider's other schema
  capabilities (e.g. `native_output_schema_wants_absolute_path`).
- `ClaudeCodeCodingAgent` (in `src/vibesys/_agent_cli/claude.py`): overrides
  the flag to `True`, documenting that `--json-schema` accepts open-ended
  object maps.
- `materialize_native_output_schema()` (in `src/vibesys/agents/cli_common.py`):
  reads the flag off the provider instance and only strips/rejects
  schema-valued `additionalProperties` when the provider requires the strict
  subset; otherwise passes the schema through unchanged.
- `CliAgentRunner` (in `src/vibesys/agents/cli_runner.py`): threads the
  provider capability through to the materialization call.

No prompt changes; the fallback path (prompt-embedded JSON schema hint) is
unchanged and still exercised for providers that lack the capability.

```mermaid
flowchart LR
    A[CliAgentRunner] -->|provider instance| B[materialize_native_output_schema]
    B -->|allows_arbitrary_keys=False| C[Codex: strict subset / reject mapping fields]
    B -->|allows_arbitrary_keys=True| D[Claude Code: native schema incl. dict fields]
    C --> E[prompt-embedded JSON fallback]
```

## Verification

Ran the full local check suite plus the complete pytest run.

### Correctness properties

- Codex behavior is unchanged: `native_output_schema_allows_arbitrary_keys`
  defaults to `False`, so the strict-subset rejection and prompt fallback path
  Codex relies on is preserved exactly.
- The prompt-embedded fallback path still exists and is exercised only when a
  provider lacks native mapping support.
- No candidate- or task-specific knowledge was added to any prompt; this is a
  schema-materialization change only.

### Testing

- `./scripts/check_format.sh` — all checks passed (348 files already
  formatted).
- `./scripts/check_lint.sh` — all checks passed.
- `./scripts/check_types.sh` — 0 errors, 0 warnings, 0 informations.
- `uv run pytest -q` — 4062 passed, 2 skipped, 1 failed in 327.92s.
  The one failure, `tests/sandbox/test_run_environment.py::test_environment_quotes_hotel_nested_shell_paths`,
  reproduces identically on `origin/main` at `60b582f` without this change
  (`[Errno 116] Stale file handle` on the sandbox tmp filesystem during
  cleanup), confirming it is a pre-existing environmental flake unrelated to
  this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
