### PR TITLE
Record the runtime environment in run state and restore it on resume

### DIFF
--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -297,6 +297,27 @@ starts with an actionable error.
 `--docker-image` overrides the backend's default container image when Docker or
 Modal is active.
 
+The selected environment and its options (`--docker-image`, `--modal-gpu`,
+`--modal-model-volume`, `--modal-app`) are recorded in the run configuration.
+`--docker` and `--modal` are boolean flags, so an omitted flag cannot be told
+apart from an explicit "off": on resume the recorded environment is therefore
+authoritative. Omitting the runtime-environment flags restores it, and passing
+a flag that contradicts the recording is rejected like any other immutable
+configuration field. The candidate's Modal entrypoint is declared by the task,
+not recorded, so it follows the current input bundle.
+
+Run metadata written before run schema version 2 has no recorded environment.
+VibeSys refuses to load it rather than guess a local environment. Stamp the
+environment the run was launched with, once:
+
+```bash
+vibesys migrate-run-environment --project . --run <run-id> --run-environment modal
+```
+
+The command accepts the same `--docker-image`, `--modal-gpu`,
+`--modal-model-volume`, and `--modal-app` options as a run, with the same
+defaults, and is one-way.
+
 ## Profiler
 
 | Value | Intended use |

--- a/docs/running-vibesys.md
+++ b/docs/running-vibesys.md
@@ -140,7 +140,9 @@ vibesys --runs-dir /work/vibesys-runs --resume https://github.com/my-org/my-expe
 
 Omitted configuration flags and the selected task are restored from
 `.vibesys/state/runs/<run-id>/run.json`. The total round or generation limit
-may increase. Other recorded settings cannot change during a resume.
+may increase. Other recorded settings cannot change during a resume, including
+the runtime environment: a run launched with `--modal` resumes on Modal without
+repeating the flag.
 
 ## Supply an Input with CLI Flags
 

--- a/libs/vs-project/src/vs_project/__init__.py
+++ b/libs/vs-project/src/vs_project/__init__.py
@@ -17,6 +17,7 @@ from vs_project._layout import (
 )
 from vs_project._state import (
     PROJECT_SCHEMA_VERSION,
+    RUN_SCHEMA_VERSION,
     AgentRunConfiguration,
     EvolveRunConfiguration,
     GitObjectId,
@@ -28,7 +29,9 @@ from vs_project._state import (
     ProjectSandboxPaths,
     ProjectStateError,
     RunConfiguration,
+    RunEnvironmentRecord,
     RunManifest,
+    RunSchemaMigrationRequiredError,
     StateFile,
     StateModelNotFoundError,
     StateNamespace,
@@ -44,6 +47,7 @@ from vs_project.project import Project
 
 __all__ = [
     "PROJECT_SCHEMA_VERSION",
+    "RUN_SCHEMA_VERSION",
     "AgentRunConfiguration",
     "AmbiguousTaskError",
     "ConfigurationRoot",
@@ -65,7 +69,9 @@ __all__ = [
     "ProjectSandboxPaths",
     "ProjectStateError",
     "RunConfiguration",
+    "RunEnvironmentRecord",
     "RunManifest",
+    "RunSchemaMigrationRequiredError",
     "StateFile",
     "StateModelNotFoundError",
     "StateNamespace",

--- a/libs/vs-project/src/vs_project/_state.py
+++ b/libs/vs-project/src/vs_project/_state.py
@@ -38,6 +38,10 @@ if TYPE_CHECKING:
     from uuid import UUID
 
 PROJECT_SCHEMA_VERSION: Literal[1] = 1
+# Version 2 added the required run-environment recording to a run's
+# configuration. Older recordings cannot be interpreted safely, so they are
+# rejected at load time and must be migrated with an explicit environment.
+RUN_SCHEMA_VERSION: Literal[2] = 2
 _CONFIG_DIRECTORY_NAME = project_paths.CONFIGURATION_DIRECTORY_NAME
 _STATE_DIRECTORY_PARTS = project_paths.STATE_DIRECTORY_PARTS
 _STATE_DIRECTORY_PATH = project_paths.STATE_DIRECTORY_PATH
@@ -73,6 +77,20 @@ class ProjectStateError(ProjectError):
 
 class StateModelNotFoundError(ProjectStateError):
     """Raised when a required model is absent from a state namespace."""
+
+
+class RunSchemaMigrationRequiredError(ProjectStateError):
+    """Raised when a run manifest predates the current run schema version.
+
+    Callers own the operator-facing migration instructions; this package
+    reports only the offending path and the two schema versions.
+    """
+
+    def __init__(self, message: str, *, path: Path, run_id: str, recorded_version: int) -> None:
+        super().__init__(message)
+        self.path = path
+        self.run_id = run_id
+        self.recorded_version = recorded_version
 
 
 def is_project_state_path(relative_path: Path | str) -> bool:
@@ -673,19 +691,40 @@ class StateSlot[ModelT: BaseModel]:
 
 
 class _CommittedManifest(BaseModel):
-    """Strict base for versioned, portable metadata committed with source."""
+    """Strict base for versioned, portable metadata committed with source.
+
+    Each concrete manifest declares its own ``schema_version`` literal so the
+    project and run schemas can evolve independently.
+    """
 
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
-
-    schema_version: Literal[1]
 
 
 class ProjectManifest(_CommittedManifest):
     """Immutable identity and initial provenance of one project directory."""
 
+    schema_version: Literal[1]
     project_id: Identifier
     created_at: AwareDatetime
     initial_input_fingerprint: Sha256Digest
+
+
+class RunEnvironmentRecord(BaseModel):
+    """Runtime environment a run executes in, recorded for faithful resume.
+
+    ``name`` selects the environment; the remaining fields carry that
+    environment's operator-selected options and stay ``None`` when they do not
+    apply. Values a run derives from its own input (rather than from the
+    operator) are deliberately absent: they are re-derived on every launch.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    name: Literal["local", "docker", "modal"]
+    image: PortableText | None = None
+    gpu: PortableText | None = None
+    model_volume: PortableText | None = None
+    app: PortableText | None = None
 
 
 class _BaseRunConfiguration(BaseModel):
@@ -693,6 +732,7 @@ class _BaseRunConfiguration(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
+    run_environment: RunEnvironmentRecord
     model: PortableText | None = None
     agent_backend: PortableText
     cli_provider: PortableText | None = None
@@ -777,6 +817,7 @@ RunConfiguration = Annotated[
 class RunManifest(_CommittedManifest):
     """Immutable identity and starting provenance of one optimization run."""
 
+    schema_version: Literal[2]
     run_id: Identifier
     project_id: Identifier
     task_name: Identifier | None = None
@@ -991,7 +1032,7 @@ class ProjectState:
         project = self.load_project()
         created_at = _aware_now(now)
         return RunManifest(
-            schema_version=PROJECT_SCHEMA_VERSION,
+            schema_version=RUN_SCHEMA_VERSION,
             run_id=(
                 _validate_run_id(run_id)
                 if run_id is not None
@@ -1043,8 +1084,58 @@ class ProjectState:
         )
 
     def load_run(self, run_id: str) -> RunManifest:
-        """Load one run manifest."""
-        return _load_model(self._run_manifest_path(run_id), RunManifest)
+        """Load one run manifest, rejecting recordings from an older schema."""
+        path = self._run_manifest_path(run_id)
+        _require_current_run_schema(path, run_id)
+        return _load_model(path, RunManifest)
+
+    def migrate_run_environment(
+        self,
+        run_id: str,
+        run_environment: RunEnvironmentRecord,
+    ) -> RunManifest:
+        """Stamp an explicit run environment into a pre-version-2 run manifest.
+
+        Run schema version 1 never recorded the runtime environment, so the
+        operator supplies the environment the run actually used. The migration
+        is one-way and idempotent only in the sense that a manifest already at
+        the current version is rejected rather than rewritten.
+        """
+        self._validate_storage_roots()
+        path = self._run_manifest_path(run_id)
+        raw = _read_json_object(path)
+        recorded_version = raw.get("schema_version")
+        if recorded_version == RUN_SCHEMA_VERSION:
+            raise ProjectStateError(
+                f"Run metadata at {path} is already at run schema version {RUN_SCHEMA_VERSION}"
+            )
+        if recorded_version != 1:
+            raise ProjectStateError(
+                f"Run metadata at {path} records unsupported run schema version "
+                f"{recorded_version!r}; only version 1 can be migrated"
+            )
+        configuration = raw.get("configuration")
+        if not isinstance(configuration, dict):
+            raise ProjectStateError(f"Run metadata at {path} has no configuration object")
+        if "run_environment" in configuration:
+            raise ProjectStateError(
+                f"Run metadata at {path} already records a run environment; "
+                "its schema version is inconsistent with its contents"
+            )
+        migrated = {
+            **raw,
+            "schema_version": RUN_SCHEMA_VERSION,
+            "configuration": {
+                **configuration,
+                "run_environment": run_environment.model_dump(mode="json"),
+            },
+        }
+        try:
+            manifest = RunManifest.model_validate_json(json.dumps(migrated), strict=True)
+        except (TypeError, ValueError) as exc:
+            raise ProjectStateError(f"Could not migrate VibeSys metadata at {path}: {exc}") from exc
+        _atomic_write_model(path, manifest)
+        return manifest
 
     def run_manifest_snapshot(self, run_id: str) -> StateSnapshot:
         """Snapshot the current portable manifest for one run."""
@@ -1764,6 +1855,28 @@ def _read_json_object(path: Path) -> dict[str, object]:
     if not isinstance(raw, dict):
         raise ProjectStateError(f"Expected a JSON object in VibeSys metadata at {path}")
     return raw
+
+
+def _require_current_run_schema(path: Path, run_id: str) -> None:
+    """Reject a run manifest written before the current run schema version.
+
+    Only an outdated version is diagnosed here; every other defect is left to
+    the model validation that follows, which reports the offending field.
+    """
+    if not path.exists():
+        return
+    recorded_version = _read_json_object(path).get("schema_version")
+    if not isinstance(recorded_version, int) or recorded_version >= RUN_SCHEMA_VERSION:
+        return
+    raise RunSchemaMigrationRequiredError(
+        f"Run metadata at {path} uses run schema version {recorded_version}, but this "
+        f"VibeSys requires version {RUN_SCHEMA_VERSION}, which records the runtime "
+        "environment the run executes in. Migrate the run with the environment it "
+        "was launched with; VibeSys cannot infer it from an older recording.",
+        path=path,
+        run_id=run_id,
+        recorded_version=recorded_version,
+    )
 
 
 def _load_model[ModelT: BaseModel](path: Path, model_type: type[ModelT]) -> ModelT:

--- a/libs/vs-project/tests/test_store.py
+++ b/libs/vs-project/tests/test_store.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
 from vs_loop_state import RoundRecord, parse_round_record, serialize_round_record
 from vs_project import (
     PROJECT_SCHEMA_VERSION,
+    RUN_SCHEMA_VERSION,
     AgentRunConfiguration,
     EvolveRunConfiguration,
     PlainRunConfiguration,
@@ -22,7 +23,9 @@ from vs_project import (
     ProjectManifest,
     ProjectStateError,
     RunConfiguration,
+    RunEnvironmentRecord,
     RunManifest,
+    RunSchemaMigrationRequiredError,
     StateFile,
     StateModelNotFoundError,
     StateSnapshot,
@@ -47,6 +50,7 @@ def _configuration() -> AgentRunConfiguration:
     return AgentRunConfiguration(
         model="gpt-5",
         outer_loop="agent",
+        run_environment=RunEnvironmentRecord(name="local"),
         inner_loop="multi-agent",
         interface="inprocess",
         agent_backend="cli",
@@ -73,6 +77,7 @@ def _plain_configuration() -> PlainRunConfiguration:
     return PlainRunConfiguration(
         model="gpt-5",
         outer_loop="plain",
+        run_environment=RunEnvironmentRecord(name="local"),
         agent_backend="cli",
         cli_provider="codex",
         cli_timeout=1800,
@@ -88,6 +93,7 @@ def _evolve_configuration() -> EvolveRunConfiguration:
     return EvolveRunConfiguration(
         model="gpt-5",
         outer_loop="evolve",
+        run_environment=RunEnvironmentRecord(name="local"),
         agent_backend="cli",
         cli_provider="codex",
         cli_timeout=1800,
@@ -163,7 +169,7 @@ def test_manifests_are_strict_versioned_contracts() -> None:
     forbidden_value = ""
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         RunManifest(
-            schema_version=PROJECT_SCHEMA_VERSION,
+            schema_version=RUN_SCHEMA_VERSION,
             run_id="run-1",
             project_id="queue-abc",
             display_name="Queue",
@@ -641,6 +647,13 @@ def test_run_manifest_persists_complete_agent_loop_behavior(tmp_path: Path) -> N
         "outer_model": "gpt-5.6-sol",
         "outer_reasoning_effort": "xhigh",
         "profiler": "linux-cpu",
+        "run_environment": {
+            "app": None,
+            "gpu": None,
+            "image": None,
+            "model_volume": None,
+            "name": "local",
+        },
     }
 
 
@@ -1526,6 +1539,66 @@ def test_loaded_round_rejects_non_finite_metrics(tmp_path: Path) -> None:
 
     with pytest.raises(ProjectStateError, match=r"0001\.json.*finite numbers"):
         store.state.load_rounds(run.run_id)
+
+
+def _downgrade_run_schema(store: Project, run_id: str) -> Path:
+    """Rewrite one run manifest as a version 1 recording without an environment."""
+    path = store.state._run_manifest_path(run_id)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["schema_version"] = 1
+    del raw["configuration"]["run_environment"]
+    path.write_text(json.dumps(raw), encoding="utf-8")
+    return path
+
+
+def test_loading_a_pre_environment_run_requires_migration(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    run = _run(store)
+    _downgrade_run_schema(store, run.run_id)
+
+    with pytest.raises(RunSchemaMigrationRequiredError) as caught:
+        store.state.load_run(run.run_id)
+
+    assert caught.value.recorded_version == 1
+    assert caught.value.run_id == run.run_id
+    assert "run.json" in str(caught.value)
+    assert "runtime environment" in str(caught.value)
+
+
+def test_migrating_a_run_records_the_supplied_environment(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    run = _run(store)
+    _downgrade_run_schema(store, run.run_id)
+    environment = RunEnvironmentRecord(name="modal", gpu="H100!", app="vibesys")
+
+    migrated = store.state.migrate_run_environment(run.run_id, environment)
+
+    assert migrated.schema_version == RUN_SCHEMA_VERSION
+    assert migrated.configuration.run_environment == environment
+    assert store.state.load_run(run.run_id) == migrated
+    assert migrated.model_dump(exclude={"schema_version", "configuration"}) == run.model_dump(
+        exclude={"schema_version", "configuration"}
+    )
+
+
+def test_migrating_a_current_run_is_rejected(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    run = _run(store)
+
+    with pytest.raises(ProjectStateError, match="already at run schema version"):
+        store.state.migrate_run_environment(run.run_id, RunEnvironmentRecord(name="local"))
+
+
+def test_migrating_an_unknown_schema_version_is_rejected(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    run = _run(store)
+    path = store.state._run_manifest_path(run.run_id)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["schema_version"] = 99
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(ProjectStateError, match="unsupported run schema version"):
+        store.state.migrate_run_environment(run.run_id, RunEnvironmentRecord(name="local"))
 
 
 def test_corrupt_metadata_error_names_the_path(tmp_path: Path) -> None:

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -39,6 +39,7 @@ from vibesys.run import LoopContext, RepositoryVisibility, RunStateNamespace
 from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
+    run_environment_record,
 )
 from vibesys.schemas import (
     CandidateDisposition,
@@ -2065,6 +2066,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     normalized_config = as_config(config)
     project_configuration = AgentRunConfiguration(
         outer_loop="agent",
+        run_environment=run_environment_record(run_environment),
         inner_loop=inner_loop,
         interface=interface,
         model=normalized_config.model.name,

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -69,6 +69,7 @@ from vibesys.run import LoopContext, RepositoryVisibility, RunStateNamespace
 from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
+    run_environment_record,
 )
 from vibesys.schemas import JudgeResponse, MutatorResponse, ProfilerSummary, Verdict
 from vs_project import EvolveRunConfiguration
@@ -1329,6 +1330,7 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     selected_policy = SearchPolicyName(search_policy).value if search_policy is not None else None
     run_configuration = EvolveRunConfiguration(
         outer_loop="evolve",
+        run_environment=run_environment_record(run_environment),
         model=normalized_config.model.name,
         agent_backend=(agent_backend or normalized_config.agent.backend or DEFAULT_AGENT_BACKEND),
         cli_provider=cli_provider or normalized_config.agent.cli_provider or "codex",

--- a/src/vibesys/loops/plain/loop.py
+++ b/src/vibesys/loops/plain/loop.py
@@ -41,6 +41,7 @@ from vibesys.run import LoopContext, RepositoryVisibility, RunStateNamespace
 from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     make_run_environment_spec,
+    run_environment_record,
 )
 from vibesys.schemas import (
     IssueImplementerResponse,
@@ -301,6 +302,7 @@ def run_plain_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     run_environment = run_environment or make_run_environment_spec()
     run_configuration = PlainRunConfiguration(
         outer_loop="plain",
+        run_environment=run_environment_record(run_environment),
         model=config.model.name,
         agent_backend=agent_backend or config.agent.backend or DEFAULT_AGENT_BACKEND,
         cli_provider=cli_provider or config.agent.cli_provider or "codex",

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -52,6 +52,7 @@ from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     build_run_environment,
     make_run_environment_spec,
+    run_environment_record,
 )
 from vibesys.skills import resolve_skill_source_dirs
 from vibesys.tui import KNOWN_TUI_THEMES, TuiTheme
@@ -63,6 +64,7 @@ from vs_project import (
     ProjectLayoutError,
     ProjectStateError,
     RunConfiguration,
+    RunSchemaMigrationRequiredError,
 )
 
 if TYPE_CHECKING:
@@ -111,6 +113,16 @@ _COMMON_RESUME_CLI_FIELDS: dict[str, str] = {
     "backend": "compute_backend",
     "profiler": "profiler",
     "modality": "modality",
+}
+
+# CLI destination -> ``RunEnvironmentRecord`` field for the runtime-environment
+# options. The environment kind itself comes from the ``--docker`` / ``--modal``
+# store-true flags and is handled separately.
+_RUN_ENVIRONMENT_OPTION_CLI_FIELDS: dict[str, str] = {
+    "docker_image": "image",
+    "modal_gpu": "gpu",
+    "modal_model_volume": "model_volume",
+    "modal_app": "app",
 }
 
 _AGENT_RESUME_CLI_FIELDS: dict[str, str] = {
@@ -473,7 +485,11 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--docker",
         action="store_true",
-        help="Run agent operations inside a Docker container.",
+        help=(
+            "Run agent operations inside a Docker container. On --resume the "
+            "recorded runtime environment is restored when no runtime-environment "
+            "flag is given, and a flag that contradicts the recording is rejected."
+        ),
     )
     parser.add_argument(
         "--docker-image",
@@ -491,7 +507,10 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
             "Use Modal for remote GPU dispatch. The agent (codex) still runs "
             "locally inside a Docker container for editing; GPU-bound code "
             "the implementer writes (decorated with `@app.cls` / `@app.function`) "
-            "is dispatched via `modal run`. Mutually exclusive with --docker."
+            "is dispatched via `modal run`. Mutually exclusive with --docker. "
+            "On --resume the recorded runtime environment is restored when no "
+            "runtime-environment flag is given, and a flag that contradicts the "
+            "recording is rejected."
         ),
     )
     parser.add_argument(
@@ -1201,6 +1220,42 @@ def _restore_resume_constraints(
     return requested != recorded.operator_constraints
 
 
+def _restore_resume_run_environment(
+    args: argparse.Namespace,
+    recorded: RunConfiguration,
+    explicit: frozenset[str],
+) -> list[str]:
+    """Restore the recorded runtime environment and reject contradictions.
+
+    ``--docker`` and ``--modal`` are store-true flags, so an omitted flag is
+    indistinguishable from ``--flag false``. The recorded environment therefore
+    wins whenever the resume invocation says nothing about it, and only an
+    explicitly passed flag that contradicts the recording is an error.
+    """
+    record = recorded.run_environment
+    changed: list[str] = []
+    if not hasattr(args, "docker") or not hasattr(args, "modal"):
+        return changed
+    if {"docker", "modal"} & explicit:
+        requested = "modal" if args.modal else "docker" if args.docker else "local"
+        if requested != record.name:
+            changed.append("run_environment")
+    else:
+        args.docker = record.name == "docker"
+        args.modal = record.name == "modal"
+
+    for destination, field in _RUN_ENVIRONMENT_OPTION_CLI_FIELDS.items():
+        if not hasattr(args, destination):
+            continue
+        expected = getattr(record, field)
+        if destination in explicit:
+            if getattr(args, destination) != expected:
+                changed.append(f"run_environment.{field}")
+        elif expected is not None:
+            setattr(args, destination, expected)
+    return changed
+
+
 def _normalized_resume_cli_value(destination: str, value: object) -> object:
     if destination == "backend" and value is not None:
         assert isinstance(value, ComputeBackend)  # noqa: S101  # argparse contract
@@ -1276,7 +1331,7 @@ def _restore_loop_resume_fields(
 ) -> tuple[dict[str, str], list[str]]:
     """Restore a loop's budget and return its immutable CLI field map."""
     fields = dict(_COMMON_RESUME_CLI_FIELDS)
-    changed: list[str] = []
+    changed: list[str] = _restore_resume_run_environment(args, recorded, explicit)
     if isinstance(recorded, AgentRunConfiguration):
         _restore_resume_budget(
             args,
@@ -1362,6 +1417,12 @@ def _resolve_resume_args(args: argparse.Namespace, *, loop_kind: str) -> None:
                 run_id = store.resolve_run().run_id
         _switch_project_resume_branch(project_root, run_id)
         run_manifest = store.load_run(run_id)
+    except RunSchemaMigrationRequiredError as exc:
+        _configuration_error(
+            f"{exc} Run: {_migrate_run_environment_command(project_root, exc.run_id)}",
+            code="project_run_schema_migration_required",
+            stage="resume_resolution",
+        )
     except ProjectStateError as exc:
         _configuration_error(
             f"Cannot resume project run: {exc}",
@@ -1406,6 +1467,111 @@ def _make_parser(prog: str, description: str) -> argparse.ArgumentParser:
     parser = _RunArgumentParser(prog=prog, description=description)
     _apply_common_args(parser)
     return parser
+
+
+# ---------------------------------------------------------------------------
+# Run metadata migration command
+# ---------------------------------------------------------------------------
+
+_MIGRATE_RUN_ENVIRONMENT_COMMAND = "migrate-run-environment"
+
+
+def _migrate_run_environment_command(project_root: Path, run_id: str) -> str:
+    """Render the operator command that migrates one run's recorded metadata."""
+    return shlex.join(
+        [
+            "vibesys",
+            _MIGRATE_RUN_ENVIRONMENT_COMMAND,
+            "--project",
+            str(project_root),
+            "--run",
+            run_id,
+            "--run-environment",
+            "local|docker|modal",
+        ]
+    )
+
+
+def _build_migrate_run_environment_parser() -> argparse.ArgumentParser:
+    parser = _RunArgumentParser(
+        prog=f"vibesys {_MIGRATE_RUN_ENVIRONMENT_COMMAND}",
+        description=(
+            "Record the runtime environment an existing run executes in. Run "
+            "metadata written before run schema version 2 never captured it, so "
+            "the operator supplies the environment the run was launched with. "
+            "The migration is one-way."
+        ),
+    )
+    parser.add_argument(
+        "--project",
+        type=Path,
+        default=None,
+        help="Project directory holding the run metadata. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--run",
+        default=None,
+        help="Run ID to migrate. Defaults to the project's current run.",
+    )
+    parser.add_argument(
+        "--run-environment",
+        choices=["local", "docker", "modal"],
+        required=True,
+        help="Runtime environment the run was launched with.",
+    )
+    # These mirror the run flags, defaults included, so a migrated recording is
+    # identical to what the same launch would have written today.
+    parser.add_argument("--docker-image", default=None, help="Recorded --docker-image value.")
+    parser.add_argument("--modal-gpu", default="H100!", help="Recorded --modal-gpu value.")
+    parser.add_argument(
+        "--modal-model-volume",
+        default=None,
+        help="Recorded --modal-model-volume value.",
+    )
+    parser.add_argument("--modal-app", default="vibesys", help="Recorded --modal-app value.")
+    return parser
+
+
+def _run_migrate_run_environment(argv: list[str]) -> None:
+    """Stamp an explicit runtime environment into one pre-version-2 run."""
+    args = _build_migrate_run_environment_parser().parse_args(argv)
+    project_root = (args.project or Path.cwd()).expanduser().resolve()
+    # Build the record through the same producer a fresh run uses so a migrated
+    # recording matches what the CLI would have written for those flags.
+    spec = make_run_environment_spec(
+        use_docker=args.run_environment == "docker",
+        use_modal=args.run_environment == "modal",
+        docker_image=args.docker_image,
+        modal_gpu=args.modal_gpu,
+        modal_model_volume=args.modal_model_volume,
+        modal_app=args.modal_app,
+    )
+    try:
+        store = Project.open(project_root).state
+        run_id = args.run or store.current_run_id()
+        if run_id is None:
+            _configuration_error(
+                f"No current run in {project_root}; pass --run RUN_ID",
+                code="migration_failed",
+                stage="run_migration",
+                exit_code=1,
+            )
+        manifest = store.migrate_run_environment(run_id, run_environment_record(spec))
+    except (ProjectLayoutError, ProjectStateError, ValueError) as exc:
+        _configuration_error(
+            f"Migration failed for VibeSys run in {project_root}: {exc}",
+            code="migration_failed",
+            stage="run_migration",
+            exit_code=1,
+        )
+
+    print(  # noqa: T201  # tracked: #288
+        f"Migrated run {manifest.run_id} to run schema version "
+        f"{manifest.schema_version}: run environment "
+        f"{manifest.configuration.run_environment.name}"
+    )
+    print(f"  metadata: {project_root}")  # noqa: T201  # tracked: #288
+    print("  commit the updated run metadata to keep the run branch clean.")  # noqa: T201  # tracked: #288
 
 
 # ---------------------------------------------------------------------------
@@ -2303,6 +2469,9 @@ def _dispatch(argv: list[str]) -> None:
         return
     if argv and argv[0] == "validate":
         _run_validate(argv[1:])
+        return
+    if argv and argv[0] == _MIGRATE_RUN_ENVIRONMENT_COMMAND:
+        _run_migrate_run_environment(argv[1:])
         return
 
     invocation = parse_cli_invocation(argv)

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -45,9 +45,11 @@ from vibesys.domains.environment import EnvironmentBindMount  # noqa: TC001  # t
 from vibesys.evaluators import PROJECT_ROOT_TOKEN, load_evaluator_package
 from vibesys.input_manifest import WorkspaceSource  # noqa: TC001  # tracked: #288
 from vibesys.profilers import ProfilerKind
+from vs_project import RunEnvironmentRecord
 from vs_sandbox import ProjectPathPolicy
 
 _SHELL_COMMAND_ARG_COUNT = 3
+_RECORDED_ENVIRONMENT_NAMES = frozenset({"local", "docker", "modal"})
 
 
 @dataclass(frozen=True)
@@ -653,6 +655,30 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
             ),
             deployment_name=candidate_name,
         )
+
+
+def run_environment_record(spec: RunEnvironmentSpec) -> RunEnvironmentRecord:
+    """Project a CLI-built spec onto the record persisted with the run.
+
+    Only operator-selected options are recorded, under the spec's own option
+    names. The candidate's Modal entrypoint is deliberately excluded: it is
+    declared by the input bundle and re-derived on every launch, so recording
+    it would make a legitimate task edit look like a resume mismatch.
+    """
+    if spec.name not in _RECORDED_ENVIRONMENT_NAMES:
+        raise ValueError(f"unknown run environment: {spec.name!r}")  # noqa: TRY003  # tracked: #288
+    return RunEnvironmentRecord(
+        name=spec.name,  # pyright: ignore[reportArgumentType]
+        image=_recorded_option(spec, "image"),
+        gpu=_recorded_option(spec, "gpu"),
+        model_volume=_recorded_option(spec, "model_volume"),
+        app=_recorded_option(spec, "app"),
+    )
+
+
+def _recorded_option(spec: RunEnvironmentSpec, key: str) -> str | None:
+    value = spec.options.get(key)
+    return str(value) if value else None
 
 
 def build_run_environment(spec: RunEnvironmentSpec) -> RunEnvironment:  # noqa: D103  # tracked: #288

--- a/tests/loops/agent/test_agent_state_store.py
+++ b/tests/loops/agent/test_agent_state_store.py
@@ -3,7 +3,12 @@
 from vibesys.loops.agent.model import ActiveHypothesis
 from vibesys.loops.agent.state import AgentStateStore
 from vibesys.schemas import OrchestratorPlan
-from vs_project import PlainRunConfiguration, Project, StateTransition
+from vs_project import (
+    PlainRunConfiguration,
+    Project,
+    RunEnvironmentRecord,
+    StateTransition,
+)
 
 
 def test_agent_state_store_round_trips_and_clears_active_state(tmp_path) -> None:  # noqa: ANN001
@@ -17,6 +22,7 @@ def test_agent_state_store_round_trips_and_clears_active_state(tmp_path) -> None
         trusted_input_baseline="a" * 40,
         configuration=PlainRunConfiguration(
             outer_loop="plain",
+            run_environment=RunEnvironmentRecord(name="local"),
             agent_backend="stub",
             compute_backend="cpu",
             max_rounds=1,

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -32,6 +32,7 @@ from vibesys.loops.evolve.population import Objective
 from vibesys.profilers import ProfilerKind, ProfilerPreflightResult
 from vibesys.prompts import PROMPTS_DIR
 from vibesys.run import GitTracker
+from vibesys.sandbox.run_environment import make_run_environment_spec
 from vibesys.schemas import (
     CandidateDisposition,
     HypothesisOutcome,
@@ -333,6 +334,11 @@ def test_project_configuration_captures_effective_agent_behavior(tmp_path: Path)
             memory_layout="directories",
             operator_constraints=("Preserve ordering",),
             domain=DomainName.GENERIC,
+            run_environment=make_run_environment_spec(
+                use_modal=True,
+                modal_gpu="A100-80GB",
+                modal_model_volume="weights",
+            ),
         )
 
     configuration = create_context.call_args.kwargs["project_configuration"]
@@ -358,6 +364,13 @@ def test_project_configuration_captures_effective_agent_behavior(tmp_path: Path)
         "inner_model": "gpt-inner",
         "inner_reasoning_effort": "medium",
         "operator_constraints": ("Preserve ordering",),
+        "run_environment": {
+            "name": "modal",
+            "image": None,
+            "gpu": "A100-80GB",
+            "model_volume": "weights",
+            "app": "vibesys",
+        },
     }
 
 

--- a/tests/loops/evolve/test_evolution_state_store.py
+++ b/tests/loops/evolve/test_evolution_state_store.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 from vibesys.loops.evolve.population import Individual, Population
 from vibesys.loops.evolve.state import EvolutionStateStore
 from vibesys.run import RunState, RunStateNamespace
-from vs_project import EvolveRunConfiguration, Project
+from vs_project import EvolveRunConfiguration, Project, RunEnvironmentRecord
 
 
 def _store(tmp_path) -> EvolutionStateStore:  # noqa: ANN001
@@ -19,6 +19,7 @@ def _store(tmp_path) -> EvolutionStateStore:  # noqa: ANN001
         trusted_input_baseline="a" * 40,
         configuration=EvolveRunConfiguration(
             outer_loop="evolve",
+            run_environment=RunEnvironmentRecord(name="local"),
             agent_backend="stub",
             compute_backend="cpu",
             max_generations=1,

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -54,7 +54,7 @@ from vibesys.profilers import ProfilerKind
 from vibesys.run import GitTracker, RunState, RunStateNamespace
 from vibesys.sandbox.run_environment import CandidateRuntime, RunEnvironmentSpec
 from vibesys.schemas import JudgeResponse, MutatorResponse, ProfilerSummary, Verdict
-from vs_project import EvolveRunConfiguration, Project
+from vs_project import EvolveRunConfiguration, Project, RunEnvironmentRecord
 
 _LLM_SERVING_DOMAIN = resolve_domain(DomainName.LLM_SERVING)
 
@@ -229,6 +229,7 @@ def _project_dir(tmp_path: Path) -> Path:
 def _evolution_configuration() -> EvolveRunConfiguration:
     return EvolveRunConfiguration(
         outer_loop="evolve",
+        run_environment=RunEnvironmentRecord(name="local"),
         agent_backend="stub",
         compute_backend="cpu",
         max_generations=1,
@@ -1286,6 +1287,7 @@ def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file
             environment_hooks=LLMServingEnvironmentHooks(),
             project_configuration=EvolveRunConfiguration(
                 outer_loop="evolve",
+                run_environment=RunEnvironmentRecord(name="local"),
                 agent_backend="deepagents",
                 compute_backend="cuda",
                 max_generations=1,

--- a/tests/loops/plain/test_plain_loop.py
+++ b/tests/loops/plain/test_plain_loop.py
@@ -28,7 +28,7 @@ from vibesys.schemas import (
     Verdict,
 )
 from vs_issue_board import IssueBoard, IssueStatus
-from vs_project import Project
+from vs_project import RUN_SCHEMA_VERSION, Project, RunEnvironmentRecord
 
 # ---------------------------------------------------------------------------
 # Helpers — factories and fixtures shared across tests
@@ -190,6 +190,9 @@ def test_bootstrap_creates_initial_feature_issue_on_first_run(  # noqa: ANN201  
 
     assert result is True
     exp_dir = _run_exp_dir(tmp_path)
+    manifest = Project.open(exp_dir).state.load_run(_run_id(exp_dir))
+    assert manifest.schema_version == RUN_SCHEMA_VERSION
+    assert manifest.configuration.run_environment == RunEnvironmentRecord(name="local")
     issues_path = _store_path(exp_dir)
     assert issues_path.is_file()
     data = json.loads(issues_path.read_text())

--- a/tests/loops/plain/test_plain_state_store.py
+++ b/tests/loops/plain/test_plain_state_store.py
@@ -6,7 +6,12 @@ import pytest
 
 from vibesys.loops.plain.state import PlainStateStore
 from vs_loop_state import PlainLoopCursor, PlainPerformanceRecord
-from vs_project import PlainRunConfiguration, Project, ProjectStateError
+from vs_project import (
+    PlainRunConfiguration,
+    Project,
+    ProjectStateError,
+    RunEnvironmentRecord,
+)
 
 
 def _store(tmp_path) -> PlainStateStore:  # noqa: ANN001
@@ -20,6 +25,7 @@ def _store(tmp_path) -> PlainStateStore:  # noqa: ANN001
         trusted_input_baseline="a" * 40,
         configuration=PlainRunConfiguration(
             outer_loop="plain",
+            run_environment=RunEnvironmentRecord(name="local"),
             agent_backend="stub",
             compute_backend="cpu",
             max_rounds=1,

--- a/tests/run/test_round_transaction.py
+++ b/tests/run/test_round_transaction.py
@@ -15,7 +15,12 @@ from vibesys.run import (
     RoundTransactionError,
 )
 from vs_loop_state import RoundRecord
-from vs_project import AgentRunConfiguration, Project, StateTransition
+from vs_project import (
+    AgentRunConfiguration,
+    Project,
+    RunEnvironmentRecord,
+    StateTransition,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -32,6 +37,7 @@ class _ActiveState(BaseModel):
 def _configuration() -> AgentRunConfiguration:
     return AgentRunConfiguration(
         outer_loop="agent",
+        run_environment=RunEnvironmentRecord(name="local"),
         inner_loop="multi-agent",
         interface="inprocess",
         agent_backend="cli",

--- a/tests/sandbox/test_run_environment.py
+++ b/tests/sandbox/test_run_environment.py
@@ -18,8 +18,9 @@ from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
     build_run_environment,
     make_run_environment_spec,
+    run_environment_record,
 )
-from vs_project import Project
+from vs_project import Project, RunEnvironmentRecord
 from vs_sandbox import ProjectPathPolicy
 
 
@@ -78,6 +79,33 @@ def test_cli_compatibility_flags_keep_options_scoped_to_selected_environment(): 
         modal_entrypoint="examples/deployment/service.py",
     )
     assert configured.options["entrypoint"] == "examples/deployment/service.py"
+
+
+def test_run_environment_record_captures_operator_selected_options():  # noqa: ANN201  # tracked: #288
+    assert run_environment_record(make_run_environment_spec()) == RunEnvironmentRecord(name="local")
+    assert run_environment_record(
+        make_run_environment_spec(use_docker=True, docker_image="editor")
+    ) == RunEnvironmentRecord(name="docker", image="editor")
+    assert run_environment_record(
+        make_run_environment_spec(
+            use_modal=True,
+            modal_gpu="accelerator",
+            modal_model_volume="weights",
+            modal_app="candidate",
+            # Declared by the input bundle, so it is re-derived rather than recorded.
+            modal_entrypoint="examples/deployment/service.py",
+        )
+    ) == RunEnvironmentRecord(
+        name="modal",
+        gpu="accelerator",
+        model_volume="weights",
+        app="candidate",
+    )
+
+
+def test_run_environment_record_rejects_an_unknown_environment():  # noqa: ANN201  # tracked: #288
+    with pytest.raises(ValueError, match="unknown run environment"):
+        run_environment_record(RunEnvironmentSpec("kubernetes"))
 
 
 def _modal_runtime_document(tmp_path: Path) -> str:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -17,7 +17,7 @@ from vibesys.profilers import ProfilerKind, ProfilerPreflightResult
 from vibesys.run import RunLogger, RunPaths, RunStateNamespace
 from vibesys.sandbox.run_environment import RunEnvironmentSpec
 from vs_loop_state import PlainLoopCursor
-from vs_project import AgentRunConfiguration, Project
+from vs_project import AgentRunConfiguration, Project, RunEnvironmentRecord
 
 
 class _FakeBackend:
@@ -60,6 +60,7 @@ def _context_dependencies(monkeypatch):  # pyright: ignore[reportUnusedFunction]
 def _configuration(max_rounds: int = 1) -> AgentRunConfiguration:
     return AgentRunConfiguration(
         outer_loop="agent",
+        run_environment=RunEnvironmentRecord(name="local"),
         inner_loop="multi-agent",
         interface="inprocess",
         model="gpt-test",

--- a/tests/test_git_tracker.py
+++ b/tests/test_git_tracker.py
@@ -10,7 +10,7 @@ import pytest
 
 from vibesys.run.git_tracker import GitTracker
 from vibesys.run.project_policy import trusted_project_input_paths
-from vs_project import PlainRunConfiguration, Project
+from vs_project import PlainRunConfiguration, Project, RunEnvironmentRecord
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -66,6 +66,7 @@ def _project(root: Path, tracker: GitTracker, run_id: str = "test-run") -> Proje
             trusted_input_baseline=tracker.trusted_input_baseline,
             configuration=PlainRunConfiguration(
                 outer_loop="plain",
+                run_environment=RunEnvironmentRecord(name="local"),
                 agent_backend="stub",
                 compute_backend="cpu",
                 max_rounds=2,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,6 +27,7 @@ from vibesys.main import (
     _parse_cli_objective,
     _prepare_experiment_repository,
     _render_configuration_error,
+    _run_migrate_run_environment,
     _validate_target_inputs,
     _with_operator_constraints,
     load_config_and_skills,
@@ -35,12 +36,15 @@ from vibesys.main import (
     run_environment_spec_from_args,
 )
 from vibesys.profilers import ProfilerKind
+from vibesys.sandbox.run_environment import run_environment_record
 from vs_project import (
+    RUN_SCHEMA_VERSION,
     AgentRunConfiguration,
     EvolveRunConfiguration,
     PlainRunConfiguration,
     Project,
     RunConfiguration,
+    RunEnvironmentRecord,
 )
 
 
@@ -124,6 +128,7 @@ def test_run_environment_spec_uses_task_modal_entrypoint(tmp_path: Path) -> None
 
 
 class _CommonConfiguration(TypedDict):
+    run_environment: RunEnvironmentRecord
     model: str
     agent_backend: str
     cli_provider: str
@@ -138,8 +143,20 @@ class _CommonConfiguration(TypedDict):
     inner_reasoning_effort: str
 
 
-def _common_configuration() -> _CommonConfiguration:
+_LOCAL_ENVIRONMENT = RunEnvironmentRecord(name="local")
+_MODAL_ENVIRONMENT = RunEnvironmentRecord(
+    name="modal",
+    gpu="A100-80GB",
+    model_volume="weights",
+    app="run-app",
+)
+
+
+def _common_configuration(
+    run_environment: RunEnvironmentRecord | None = None,
+) -> _CommonConfiguration:
     return {
+        "run_environment": run_environment or _LOCAL_ENVIRONMENT,
         "model": "gpt-recorded",
         "agent_backend": "cli",
         "cli_provider": "claude",
@@ -155,9 +172,13 @@ def _common_configuration() -> _CommonConfiguration:
     }
 
 
-def _agent_configuration(*, max_rounds: int = 7) -> AgentRunConfiguration:
+def _agent_configuration(
+    *,
+    max_rounds: int = 7,
+    run_environment: RunEnvironmentRecord | None = None,
+) -> AgentRunConfiguration:
     return AgentRunConfiguration(
-        **_common_configuration(),
+        **_common_configuration(run_environment),
         outer_loop="agent",
         inner_loop="single-agent",
         interface="service",
@@ -1318,6 +1339,168 @@ def test_resume_rejects_changes_to_immutable_configuration(
         parse_cli_invocation(["--resume", run_id, "--judge-every", "3"])
     assert exc.value.diagnostic.code == "project_resume_configuration_mismatch"
     assert "judge_every" in exc.value.diagnostic.message
+
+
+def _write_pre_migration_run(project: Path, run_id: str) -> None:
+    """Rewrite a run manifest as a schema version 1 recording."""
+    path = project / ".vibesys" / "state" / "runs" / run_id / "run.json"
+    raw = json.loads(path.read_text())
+    raw["schema_version"] = 1
+    del raw["configuration"]["run_environment"]
+    path.write_text(json.dumps(raw, indent=2, sort_keys=True))
+
+
+def _modal_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str]:
+    """Provision a project whose recorded run executes on Modal."""
+    project = _write_input_project(tmp_path)
+    run_id = "20260811-120000-11111111-agent"
+    _write_project_run(
+        project,
+        run_id,
+        configuration=_agent_configuration(run_environment=_MODAL_ENVIRONMENT),
+        created_at=datetime(2026, 8, 11, 12, tzinfo=UTC),
+    )
+    monkeypatch.chdir(project)
+    return project, run_id
+
+
+def test_fresh_run_records_the_selected_run_environment(tmp_path: Path) -> None:
+    project = _write_input_project(tmp_path)
+    args = argparse.Namespace(
+        input_bundle=load_input_bundle(project),
+        docker=False,
+        docker_image=None,
+        modal=True,
+        modal_gpu="A100-80GB",
+        modal_model_volume="weights",
+        modal_app="run-app",
+    )
+
+    record = run_environment_record(run_environment_spec_from_args(args))
+
+    assert record == _MODAL_ENVIRONMENT
+
+
+def test_resume_without_run_environment_flags_restores_the_recorded_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, run_id = _modal_run(tmp_path, monkeypatch)
+
+    args = parse_cli_invocation(["--resume", run_id]).args
+
+    assert args.modal is True
+    assert args.docker is False
+    assert args.modal_gpu == "A100-80GB"
+    assert args.modal_model_volume == "weights"
+    assert args.modal_app == "run-app"
+    assert run_environment_record(run_environment_spec_from_args(args)) == _MODAL_ENVIRONMENT
+
+
+def test_resume_with_matching_run_environment_flags_is_accepted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, run_id = _modal_run(tmp_path, monkeypatch)
+
+    args = parse_cli_invocation(
+        [
+            "--resume",
+            run_id,
+            "--modal",
+            "--modal-gpu",
+            "A100-80GB",
+            "--modal-model-volume",
+            "weights",
+            "--modal-app",
+            "run-app",
+        ]
+    ).args
+
+    assert run_environment_record(run_environment_spec_from_args(args)) == _MODAL_ENVIRONMENT
+
+
+@pytest.mark.parametrize(
+    ("flags", "field"),
+    [
+        (["--docker"], "run_environment"),
+        (["--modal", "--modal-gpu", "H100!"], "run_environment.gpu"),
+    ],
+)
+def test_resume_rejects_run_environment_flags_that_contradict_the_recording(
+    flags: list[str],
+    field: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, run_id = _modal_run(tmp_path, monkeypatch)
+
+    with pytest.raises(ConfigurationError) as exc:
+        parse_cli_invocation(["--resume", run_id, *flags])
+    assert exc.value.diagnostic.code == "project_resume_configuration_mismatch"
+    assert field in exc.value.diagnostic.message
+
+
+def test_resume_rejects_a_recording_without_a_run_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, run_id = _modal_run(tmp_path, monkeypatch)
+    _write_pre_migration_run(project, run_id)
+
+    with pytest.raises(ConfigurationError) as exc:
+        parse_cli_invocation(["--resume", run_id])
+
+    assert exc.value.diagnostic.code == "project_run_schema_migration_required"
+    assert "migrate-run-environment" in exc.value.diagnostic.message
+    assert run_id in exc.value.diagnostic.message
+
+
+def test_migrated_recording_resumes_with_the_supplied_run_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, run_id = _modal_run(tmp_path, monkeypatch)
+    _write_pre_migration_run(project, run_id)
+
+    _run_migrate_run_environment(
+        [
+            "--project",
+            str(project),
+            "--run",
+            run_id,
+            "--run-environment",
+            "modal",
+            "--modal-gpu",
+            "A100-80GB",
+            "--modal-model-volume",
+            "weights",
+            "--modal-app",
+            "run-app",
+        ]
+    )
+
+    args = parse_cli_invocation(["--resume", run_id]).args
+    assert args.modal is True
+    assert run_environment_record(run_environment_spec_from_args(args)) == _MODAL_ENVIRONMENT
+    recorded = Project.open(project).state.load_run(run_id)
+    assert recorded.schema_version == RUN_SCHEMA_VERSION
+    assert recorded.configuration.run_environment == _MODAL_ENVIRONMENT
+
+
+def test_migration_rejects_an_already_migrated_recording(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, run_id = _modal_run(tmp_path, monkeypatch)
+
+    with pytest.raises(ConfigurationError) as exc:
+        _run_migrate_run_environment(
+            ["--project", str(project), "--run", run_id, "--run-environment", "modal"]
+        )
+
+    assert exc.value.diagnostic.code == "migration_failed"
+    assert "already at run schema version" in exc.value.diagnostic.message
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -37,7 +37,7 @@ from vibesys.server.schema import ProtocolDocument
 from vibesys.server.service import SupervisionService
 from vibesys.server.transport import SupervisionSocketServer
 from vs_loop_state import RoundRecord
-from vs_project import AgentRunConfiguration, Project
+from vs_project import AgentRunConfiguration, Project, RunEnvironmentRecord
 
 
 def _events(path):  # noqa: ANN001, ANN202  # tracked: #288
@@ -57,6 +57,7 @@ def _project_run(project: Path) -> tuple[Project, str]:
         vibesys_version="0.2.0-test",
         configuration=AgentRunConfiguration(
             outer_loop="agent",
+            run_environment=RunEnvironmentRecord(name="local"),
             inner_loop="single-agent",
             interface="inprocess",
             agent_backend="stub",


### PR DESCRIPTION
## Problem

Fixes #352.

`run.json` (schema v1) never recorded which runtime environment (modal /
docker / local) a campaign was launched with. On `vibesys --resume`, the
environment was reconstructed from defaults, so a campaign launched with
`--modal` silently resumed as LOCAL: accuracy gates and benchmarks executed
on the (GPU-less) host instead of deploying to Modal, gates failed for
environment reasons, and the loop attributed those failures to the
candidate. Nothing failed loudly, the only tell was the absence of
`modal deploy` output in round logs.

Observed live in campaign #347: rounds 4-6 were burned this way after a
routine pause/resume.

## Solution

Make the runtime environment part of persisted run state. Schema v2 records
a `run_environment` block (name/image/gpu/model_volume/app); resume restores
it exactly; v1 state is rejected with `RunSchemaMigrationRequiredError` and a
one-way `vibesys migrate-run-environment` command migrates existing runs
(snapshot kept alongside).

Why this is thorough: the root cause was launch-time configuration living
only in process arguments. The fix moves it into the canonical state schema
with a versioned migration, so resume can never again reinterpret a campaign
under different defaults, and old state fails loudly instead of degrading.
No parallel schema implementations are retained, v2 is the only runtime
representation.

Validated live: campaign segments S3-S5 resumed with the Modal environment
correctly restored through two more process restarts.

### Architecture

Ownership: schema + migration live in the `vs-project` `_state` library;
`sandbox/run_environment.py` produces the `RunEnvironmentRecord` at launch;
`main.py`'s resume path consumes it and refuses v1 state.

```mermaid
flowchart LR
    A[Launch: --modal/--docker/local flags] --> B[run_environment.py:\nbuild RunEnvironmentRecord]
    B --> C[vs_project._state:\nwrite run.json schema v2]
    C -->|resume| D{schema version?}
    D -->|v2| E[Restore RunEnvironmentRecord exactly]
    D -->|v1| F[Raise RunSchemaMigrationRequiredError]
    F --> G[vibesys migrate-run-environment\n(one-way, snapshot kept)]
    G --> C
    E --> H[Loop resumes against\nrecorded environment]
```

## Verification

Cherry-picked `292fe67` from the meta-opt campaign branch
`vs-meta-opt/llama70b-2xh100-vllm-20260813` onto a clean branch off
`origin/main` (`60b582f`). The cherry-pick applied without conflicts; the
commit's two campaign-branch parents (`e0364de`, gating native-output-schema
strictness, and `8cb0c11`, retry accounting for synthesized responses) touch
unrelated subsystems with no file overlap, so no adaptation was needed to
make this change stand alone on `main`.

### Correctness properties

- Fresh runs are unaffected: launch always records the operator-selected
  environment into schema v2 `run_environment`.
- Resume is exact-restore-or-loud-failure: a v2 recording is restored
  verbatim; a contradicting `--modal`/`--docker` flag at resume is rejected
  through the existing resume-mismatch machinery instead of silently
  overriding the record.
- Migration is one-way: `vibesys migrate-run-environment` upgrades v1 state
  to v2 and keeps a pre-migration snapshot; there is no downgrade path.
- v1 state can never be silently reinterpreted: loading it raises
  `RunSchemaMigrationRequiredError` with instructions to migrate, rather than
  defaulting to local.

### Testing

- `./scripts/check_format.sh` — all checks passed, 348 files already formatted.
- `./scripts/check_lint.sh` — all checks passed.
- `./scripts/check_types.sh` — 0 errors, 0 warnings, 0 informations.
- `uv run pytest -q` — 4057 passed, 2 skipped, 1 failed in 329.63s.
  The one failure, `tests/sandbox/test_run_environment.py::test_environment_quotes_hotel_nested_shell_paths`,
  is a pre-existing environment gap unrelated to this change: it requires the
  DeathStarBench example repository checked out under
  `examples/microservices/repositories/deathstarbench/`, which is empty in
  this worktree (a sibling test in `tests/test_microservice_inputs.py` is
  explicitly skipped for the same reason). Verified the identical failure
  reproduces on an unmodified `origin/main` checkout, confirming it predates
  and is independent of this cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
