### PR TITLE
Run Modal evaluators inside the serving container

### DIFF
--- a/src/vibesys/sandbox/modal_evaluator.py
+++ b/src/vibesys/sandbox/modal_evaluator.py
@@ -1,21 +1,36 @@
 """Run a trusted evaluator against a candidate deployed on Modal.
 
 The Modal run environment edits candidates in a local CPU-only container, so
-service-style evaluators cannot use their default localhost URL. This helper is
-mounted read-only by the runtime adapter. It deploys the current candidate,
-discovers the emitted web endpoint, waits for readiness, and appends ``--url``
-to the trusted evaluator command.
+service-style evaluators cannot reach the serving process at their default
+``http://localhost:8000``. This helper is mounted read-only by the runtime
+adapter. It deploys the current candidate, discovers the emitted web endpoint,
+waits for readiness, and then runs the trusted command *unmodified inside the
+serving container* (via ``modal container exec``) so the task's localhost
+measurement contract holds: metrics reflect the engine, not TLS, WAN, Modal
+ingress, or Modal's function-admission queue.
+
+The public endpoint is used only for deploy discovery, readiness, and periodic
+keep-warm probes during the in-container run (colocated traffic does not reset
+Modal's idle scaledown timer). Workspace-relative input files referenced by the
+command are staged into the container; absolute not-yet-existing paths in the
+command (for example a ``--output-json`` target) are relayed back to the caller
+after the run.
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
 import fcntl
+import io
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
+import tarfile
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -35,6 +50,14 @@ _DEPLOYMENT_LEASE_PATH = Path("/tmp/vibesys-modal-evaluator-deployment.json")  #
 _CANDIDATE_REVISION_ENV = "VIBESYS_CANDIDATE_REVISION"
 _RELEASE_DEPLOYMENT_ENV = "VIBESYS_RELEASE_MODAL_DEPLOYMENT"
 _MAX_DIAGNOSTIC_CHARS = 20_000
+_EXEC_RC_MARKER = "__VIBESYS_EXEC_RC__="
+_OUTPUT_FILE_MARKER = "__VIBESYS_OUTPUT_FILE__"
+_OUTPUT_END_MARKER = "__VIBESYS_OUTPUT_END__"
+# Linux caps a single argv string at 128 KiB; stay well under it per chunk.
+_B64_CHUNK_CHARS = 60_000
+_MAX_STAGE_ARCHIVE_BYTES = 8 * 1024 * 1024
+_CONTAINER_DISCOVERY_TIMEOUT_SECONDS = 90.0
+_KEEPWARM_INTERVAL_SECONDS = 30.0
 
 
 @dataclass(frozen=True)
@@ -236,6 +259,271 @@ def _deployment_path(workspace: str, entrypoint: str) -> Path:
     return candidate
 
 
+@dataclass(frozen=True)
+class _CommandTransferPlan:
+    """Files to stage into the serving container and outputs to relay back."""
+
+    stage_paths: tuple[str, ...]
+    output_paths: tuple[str, ...]
+
+
+def _plan_command_transfer(command: Sequence[str], workspace: str) -> _CommandTransferPlan:
+    """Classify command tokens into staged inputs and relayed outputs.
+
+    Workspace-relative tokens that resolve to files are staged with their
+    parent directory (scripts commonly import or read siblings); directory
+    tokens are staged whole. Absolute tokens that do not exist but whose
+    parent directory does are treated as output artifacts the command will
+    write, and are relayed back after the in-container run.
+    """
+    workspace_root = Path(workspace).resolve(strict=True)
+    staged: list[str] = []
+    outputs: list[str] = []
+    for token in command:
+        if not token or token.startswith("-"):
+            continue
+        if token.startswith("/"):
+            path = Path(token)
+            if not path.exists() and path.parent.is_dir() and token not in outputs:
+                outputs.append(token)
+            continue
+        candidate = workspace_root / token
+        try:
+            resolved = candidate.resolve(strict=True)
+            resolved.relative_to(workspace_root)
+        except (OSError, ValueError):
+            continue
+        if resolved.is_dir() or resolved.parent == workspace_root:
+            stage = resolved
+        else:
+            stage = resolved.parent
+        relative = stage.relative_to(workspace_root).as_posix()
+        if relative not in staged:
+            staged.append(relative)
+
+    def _covered(path: str) -> bool:
+        return any(other != path and path.startswith(f"{other}/") for other in staged)
+
+    kept = tuple(path for path in staged if not _covered(path))
+    return _CommandTransferPlan(stage_paths=kept, output_paths=tuple(outputs))
+
+
+def _build_stage_archive(workspace: str, stage_paths: Sequence[str]) -> bytes:
+    """Produce a gzipped tar of the staged paths, keyed by their relative paths."""
+    workspace_root = Path(workspace).resolve(strict=True)
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for relative in stage_paths:
+            archive.add(str(workspace_root / relative), arcname=relative)
+    payload = buffer.getvalue()
+    if len(payload) > _MAX_STAGE_ARCHIVE_BYTES:
+        raise ValueError(  # noqa: TRY003
+            f"evaluator inputs too large to stage into the serving container "
+            f"({len(payload)} bytes compressed, cap {_MAX_STAGE_ARCHIVE_BYTES})"
+        )
+    return payload
+
+
+def _find_app_container(
+    app_identifier: str,
+    *,
+    workspace: str,
+    base_url: str,
+    timeout_seconds: float = _CONTAINER_DISCOVERY_TIMEOUT_SECONDS,
+) -> str:
+    """Return the id of a running container for the deployed app.
+
+    Health probes double as warm-up: if the app scaled to zero between
+    readiness and discovery, probing the public endpoint starts a container.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    last_error = "no container listed"
+    while True:
+        try:
+            result = subprocess.run(  # tracked: #288
+                ["uv", "run", "modal", "container", "list", "--json"],  # noqa: S607  # tracked: #288
+                cwd=workspace,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=60,
+            )
+            entries = json.loads(result.stdout) if result.returncode == 0 else []
+        except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+            entries = []
+            last_error = f"{type(exc).__name__}: {exc}"
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("App Name") == app_identifier and entry.get("Container ID"):
+                return str(entry["Container ID"])
+        if time.monotonic() >= deadline:
+            raise TimeoutError(  # noqa: TRY003
+                f"no running container found for Modal app {app_identifier}: {last_error}"
+            )
+        _healthy_now(base_url)
+        time.sleep(5)
+
+
+def _bootstrap_script(command: Sequence[str], output_paths: Sequence[str]) -> str:
+    """Build the in-container POSIX shell bootstrap.
+
+    Receives the staged archive as base64 chunks in ``"$@"``, recreates the
+    workspace-relative layout in a temp directory, provides ``uv`` through a
+    ``python3 -m uv`` shim, runs the trusted command verbatim from that
+    directory (so its localhost defaults and relative paths hold), then emits
+    each existing output file and the command's exit code between sentinel
+    markers — ``modal container exec`` does not propagate exit codes.
+    """
+    quoted_command = " ".join(shlex.quote(token) for token in command)
+    relay_blocks = "\n".join(
+        f"if [ -f {shlex.quote(path)} ]; then\n"
+        f"  printf '\\n%s %s\\n' {shlex.quote(_OUTPUT_FILE_MARKER)} {shlex.quote(path)}\n"
+        f"  base64 {shlex.quote(path)}\n"
+        f"  printf '%s\\n' {shlex.quote(_OUTPUT_END_MARKER)}\n"
+        "fi"
+        for path in output_paths
+    )
+    return f"""set -u
+stage=$(mktemp -d /tmp/vibesys-eval-XXXXXX)
+printf '%s' "$@" | base64 -d | tar -xzf - -C "$stage"
+mkdir -p "$stage/.bin"
+printf '#!/bin/sh\\nexec python3 -m uv "$@"\\n' > "$stage/.bin/uv"
+chmod +x "$stage/.bin/uv"
+if ! python3 -m pip install --quiet --target "$stage/.pip" uv >&2; then
+  echo 'vibesys evaluator bootstrap failed: serving container lacks python3 -m pip' >&2
+  printf '\\n{_EXEC_RC_MARKER}%s\\n' 97
+  exit 0
+fi
+PATH="$stage/.bin:$PATH"; export PATH
+PYTHONPATH="$stage/.pip${{PYTHONPATH:+:$PYTHONPATH}}"; export PYTHONPATH
+UV_CACHE_DIR="$stage/.uv-cache"; export UV_CACHE_DIR
+cd "$stage"
+{quoted_command}
+rc=$?
+{relay_blocks}
+printf '\\n{_EXEC_RC_MARKER}%s\\n' "$rc"
+"""
+
+
+def _parse_exec_output(stdout: str) -> tuple[int | None, dict[str, bytes], str]:
+    """Split exec stdout into exit code, relayed output files, and passthrough."""
+    exit_code: int | None = None
+    files: dict[str, bytes] = {}
+    passthrough: list[str] = []
+    collecting: str | None = None
+    encoded: list[str] = []
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if collecting is not None:
+            if stripped == _OUTPUT_END_MARKER:
+                try:
+                    files[collecting] = base64.b64decode("".join(encoded))
+                except ValueError:
+                    files.pop(collecting, None)
+                collecting = None
+                encoded = []
+            else:
+                encoded.append(stripped)
+            continue
+        if stripped.startswith(f"{_OUTPUT_FILE_MARKER} "):
+            collecting = stripped[len(_OUTPUT_FILE_MARKER) + 1 :]
+            continue
+        if stripped.startswith(_EXEC_RC_MARKER):
+            suffix = stripped[len(_EXEC_RC_MARKER) :]
+            if suffix.isdigit():
+                exit_code = int(suffix)
+            continue
+        passthrough.append(line)
+    return exit_code, files, "\n".join(passthrough)
+
+
+class _DeploymentKeepWarm:
+    """Probe the public endpoint periodically while the colocated run executes.
+
+    Colocated traffic never crosses Modal ingress, so it does not reset the
+    app's idle scaledown timer; without these probes Modal may retire the
+    serving container mid-measurement.
+    """
+
+    def __init__(self, base_url: str) -> None:
+        self._base_url = base_url
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def __enter__(self) -> _DeploymentKeepWarm:
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._stop.set()
+        self._thread.join(timeout=10)
+
+    def _run(self) -> None:
+        while not self._stop.wait(_KEEPWARM_INTERVAL_SECONDS):
+            _healthy_now(self._base_url)
+
+
+def _execute_colocated(
+    command: Sequence[str],
+    *,
+    workspace: str,
+    app_identifier: str,
+    base_url: str,
+) -> int:
+    """Run the trusted command inside the app's serving container."""
+    plan = _plan_command_transfer(command, workspace)
+    archive = _build_stage_archive(workspace, plan.stage_paths)
+    encoded = base64.b64encode(archive).decode("ascii")
+    chunks = [
+        encoded[offset : offset + _B64_CHUNK_CHARS]
+        for offset in range(0, len(encoded), _B64_CHUNK_CHARS)
+    ] or [""]
+    container_id = _find_app_container(
+        app_identifier,
+        workspace=workspace,
+        base_url=base_url,
+    )
+    script = _bootstrap_script(command, plan.output_paths)
+    with _DeploymentKeepWarm(base_url):
+        result = subprocess.run(  # noqa: S603  # tracked: #288
+            [  # noqa: S607  # tracked: #288
+                "uv",
+                "run",
+                "modal",
+                "container",
+                "exec",
+                container_id,
+                "--",
+                "sh",
+                "-c",
+                script,
+                "vibesys-eval",
+                *chunks,
+            ],
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    exit_code, files, passthrough = _parse_exec_output(result.stdout)
+    if passthrough:
+        print(passthrough)  # noqa: T201  # tracked: #288
+    if result.stderr:
+        print(result.stderr, file=sys.stderr, end="")  # noqa: T201  # tracked: #288
+    for path, payload in files.items():
+        Path(path).write_bytes(payload)
+    if exit_code is None:
+        tail = result.stdout[-_MAX_DIAGNOSTIC_CHARS:]
+        print(  # noqa: T201  # tracked: #288
+            "Modal evaluator exec did not report an exit code "
+            f"(modal exit {result.returncode}); output tail:\n{tail}",
+            file=sys.stderr,
+        )
+        return result.returncode or 1
+    return exit_code
+
+
 def run_evaluator(
     command: Sequence[str],
     *,
@@ -243,7 +531,7 @@ def run_evaluator(
     entrypoint: str = "main.py",
     readiness_timeout_seconds: float = 90,
 ) -> int:
-    """Deploy the candidate and run ``command`` against its live URL."""
+    """Deploy the candidate and run ``command`` inside its serving container."""
     if not command:
         raise ValueError("missing evaluator command after '--'")  # noqa: TRY003  # tracked: #288
 
@@ -256,7 +544,7 @@ def run_evaluator(
         )
 
 
-def _run_evaluator_unlocked(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
+def _run_evaluator_unlocked(  # noqa: C901, PLR0911, PLR0912, PLR0915  # tracked: #288
     command: Sequence[str],
     *,
     workspace: str,
@@ -267,19 +555,26 @@ def _run_evaluator_unlocked(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
     if candidate_revision:
         lease = _read_deployment_lease()
         if lease is not None:
-            if lease.candidate_revision == candidate_revision and _healthy_now(lease.base_url):
+            if (
+                lease.candidate_revision == candidate_revision
+                and lease.app_identifier is not None
+                and _healthy_now(lease.base_url)
+            ):
                 print(  # noqa: T201  # tracked: #288
                     "Reusing healthy Modal deployment for candidate revision "
                     f"{candidate_revision}.",
                     file=sys.stderr,
                 )
                 try:
-                    result = subprocess.run(  # noqa: S603  # tracked: #288
-                        [*command, "--url", lease.base_url],
-                        cwd=workspace,
-                        check=False,
+                    return _execute_colocated(
+                        command,
+                        workspace=workspace,
+                        app_identifier=lease.app_identifier,
+                        base_url=lease.base_url,
                     )
-                    return result.returncode
+                except (TimeoutError, ValueError) as exc:
+                    print(f"Modal evaluator setup failed: {exc}", file=sys.stderr)  # noqa: T201
+                    return 1
                 finally:
                     if _release_requested():
                         _retire_deployment(lease, workspace=workspace)
@@ -307,18 +602,16 @@ def _run_evaluator_unlocked(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
     app_identifier: str | None = None
     try:
         base_url = extract_modal_web_url(deploy_output)
-        try:  # noqa: SIM105  # tracked: #288
-            app_identifier = extract_modal_app_identifier(deploy_output)
-        except ValueError:
-            pass
+        app_identifier = extract_modal_app_identifier(deploy_output)
         wait_for_health(base_url, timeout_seconds=readiness_timeout_seconds)
     except (TimeoutError, ValueError) as exc:
         print(f"Modal evaluator setup failed: {exc}", file=sys.stderr)  # noqa: T201  # tracked: #288
-        try:
-            app_identifier = extract_modal_app_identifier(deploy_output)
-        except ValueError:
-            pass
-        else:
+        if app_identifier is None:
+            try:  # noqa: SIM105  # tracked: #288
+                app_identifier = extract_modal_app_identifier(deploy_output)
+            except ValueError:
+                pass
+        if app_identifier is not None:
             print(  # noqa: T201  # tracked: #288
                 f"Recent Modal logs:\n{recent_modal_logs(app_identifier, workspace=workspace)}",
                 file=sys.stderr,
@@ -330,12 +623,15 @@ def _run_evaluator_unlocked(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
         _write_deployment_lease(candidate_revision, base_url, app_identifier)
 
     try:
-        result = subprocess.run(  # noqa: S603  # tracked: #288
-            [*command, "--url", base_url],
-            cwd=workspace,
-            check=False,
+        return _execute_colocated(
+            command,
+            workspace=workspace,
+            app_identifier=app_identifier,
+            base_url=base_url,
         )
-        return result.returncode
+    except (TimeoutError, ValueError) as exc:
+        print(f"Modal evaluator setup failed: {exc}", file=sys.stderr)  # noqa: T201  # tracked: #288
+        return 1
     finally:
         if _release_requested():
             lease = _read_deployment_lease()
@@ -345,7 +641,7 @@ def _run_evaluator_unlocked(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
                 and lease.candidate_revision == candidate_revision
             ):
                 _retire_deployment(lease, workspace=workspace)
-            elif app_identifier is not None:
+            else:
                 _stop_modal_app(app_identifier, workspace=workspace)
 
 

--- a/src/vibesys/sandbox/modal_evaluator.py
+++ b/src/vibesys/sandbox/modal_evaluator.py
@@ -348,15 +348,23 @@ def _find_app_container(
                 check=False,
                 timeout=60,
             )
-            entries = json.loads(result.stdout) if result.returncode == 0 else []
+            if result.returncode == 0:
+                entries = json.loads(result.stdout)
+            else:
+                entries = []
+                last_error = f"container list exited {result.returncode}: {result.stderr.strip()}"
         except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
             entries = []
             last_error = f"{type(exc).__name__}: {exc}"
         for entry in entries:
             if not isinstance(entry, dict):
                 continue
-            if entry.get("App Name") == app_identifier and entry.get("Container ID"):
-                return str(entry["Container ID"])
+            # Key style varies across modal client versions: 1.5.x emits
+            # snake_case ("app_name"), older clients title case ("App Name").
+            name = entry.get("app_name") or entry.get("App Name")
+            container_id = entry.get("container_id") or entry.get("Container ID")
+            if name == app_identifier and container_id:
+                return str(container_id)
         if time.monotonic() >= deadline:
             raise TimeoutError(  # noqa: TRY003
                 f"no running container found for Modal app {app_identifier}: {last_error}"

--- a/tests/sandbox/test_modal_evaluator.py
+++ b/tests/sandbox/test_modal_evaluator.py
@@ -203,13 +203,13 @@ def test_build_stage_archive_rejects_oversized_inputs(
         modal_evaluator._build_stage_archive(str(workspace), ["blob.bin"])  # noqa: SLF001
 
 
-def test_find_app_container_matches_app_name(monkeypatch) -> None:  # noqa: ANN001
+def test_find_app_container_matches_snake_case_listing(monkeypatch) -> None:  # noqa: ANN001
     listing = SimpleNamespace(
         returncode=0,
         stdout=json.dumps(
             [
-                {"Container ID": "ta-other", "App Name": "other-app"},
-                {"Container ID": "ta-123", "App Name": "candidate-app"},
+                {"container_id": "ta-other", "app_name": "other-app"},
+                {"container_id": "ta-123", "app_name": "candidate-app"},
             ]
         ),
         stderr="",
@@ -225,6 +225,40 @@ def test_find_app_container_matches_app_name(monkeypatch) -> None:  # noqa: ANN0
 
     assert container == "ta-123"
     assert run.call_args_list[0].args[0][:5] == ["uv", "run", "modal", "container", "list"]
+
+
+def test_find_app_container_matches_title_case_listing(monkeypatch) -> None:  # noqa: ANN001
+    listing = SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps([{"Container ID": "ta-123", "App Name": "candidate-app"}]),
+        stderr="",
+    )
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", MagicMock(return_value=listing))
+
+    container = modal_evaluator._find_app_container(  # noqa: SLF001
+        "candidate-app",
+        workspace="/workspace",
+        base_url="https://workspace--candidate.modal.run",
+    )
+
+    assert container == "ta-123"
+
+
+def test_find_app_container_surfaces_cli_error(monkeypatch) -> None:  # noqa: ANN001
+    listing = SimpleNamespace(returncode=2, stdout="", stderr="token expired")
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", MagicMock(return_value=listing))
+    monkeypatch.setattr(modal_evaluator, "_healthy_now", MagicMock(return_value=True))
+    monkeypatch.setattr(modal_evaluator.time, "sleep", lambda _: None)
+    clock = iter([0.0, 0.0, 2.0])
+    monkeypatch.setattr(modal_evaluator.time, "monotonic", lambda: next(clock))
+
+    with pytest.raises(TimeoutError, match="container list exited 2: token expired"):
+        modal_evaluator._find_app_container(  # noqa: SLF001
+            "candidate-app",
+            workspace="/workspace",
+            base_url="https://workspace--candidate.modal.run",
+            timeout_seconds=1.5,
+        )
 
 
 def test_find_app_container_rewarms_then_times_out(monkeypatch) -> None:  # noqa: ANN001

--- a/tests/sandbox/test_modal_evaluator.py
+++ b/tests/sandbox/test_modal_evaluator.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import base64
+import io
 import json
+import tarfile
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, call
@@ -11,6 +14,11 @@ from vibesys.sandbox import modal_evaluator
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+_DEPLOY_STDOUT = (
+    "Web Function URL: https://workspace--candidate.modal.run\n"
+    "View Deployment: https://modal.com/apps/workspace/main/deployed/candidate-app\n"
+)
 
 
 @pytest.fixture(autouse=True)
@@ -122,17 +130,260 @@ def test_extract_modal_app_identifier_handles_rich_line_wrapping() -> None:
     assert modal_evaluator.extract_modal_app_identifier(output) == "vibesys-long-candidate"
 
 
-def test_run_evaluator_deploys_waits_and_injects_url(monkeypatch) -> None:  # noqa: ANN001  # tracked: #288
-    deploy = SimpleNamespace(
+def test_plan_command_transfer_classifies_inputs_and_outputs(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    task = workspace / ".vibesys" / "tasks" / "demo"
+    bench = task / "benchmark"
+    bench.mkdir(parents=True)
+    (task / "requirements.txt").write_text("httpx\n")
+    (bench / "benchmark.py").write_text("print('hi')\n")
+    (workspace / "main.py").write_text("app = object()\n")
+    outputs_parent = tmp_path / "outputs"
+    outputs_parent.mkdir()
+
+    plan = modal_evaluator._plan_command_transfer(  # noqa: SLF001
+        [
+            "uv",
+            "run",
+            "--no-project",
+            "--with-requirements",
+            ".vibesys/tasks/demo/requirements.txt",
+            "python",
+            ".vibesys/tasks/demo/benchmark/benchmark.py",
+            "main.py",
+            "--output-json",
+            str(outputs_parent / "result.json"),
+            str(tmp_path / "missing-dir" / "result.json"),
+        ],
+        str(workspace),
+    )
+
+    # benchmark/ is covered by the task directory staged for requirements.txt;
+    # root-level files stage themselves rather than the whole workspace.
+    assert plan.stage_paths == (".vibesys/tasks/demo", "main.py")
+    assert plan.output_paths == (str(outputs_parent / "result.json"),)
+
+
+def test_plan_command_transfer_ignores_escaping_symlinks(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret\n")
+    (workspace / "leak.txt").symlink_to(outside)
+
+    plan = modal_evaluator._plan_command_transfer(  # noqa: SLF001
+        ["python", "leak.txt"], str(workspace)
+    )
+
+    assert plan.stage_paths == ()
+
+
+def test_build_stage_archive_preserves_relative_layout(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    nested = workspace / "task" / "data"
+    nested.mkdir(parents=True)
+    (nested / "cases.json").write_text("[]")
+
+    payload = modal_evaluator._build_stage_archive(str(workspace), ["task"])  # noqa: SLF001
+
+    with tarfile.open(fileobj=io.BytesIO(payload), mode="r:gz") as archive:
+        assert "task/data/cases.json" in archive.getnames()
+
+
+def test_build_stage_archive_rejects_oversized_inputs(
+    tmp_path: Path,
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "blob.bin").write_bytes(b"x" * 4096)
+    monkeypatch.setattr(modal_evaluator, "_MAX_STAGE_ARCHIVE_BYTES", 16)
+
+    with pytest.raises(ValueError, match="too large"):
+        modal_evaluator._build_stage_archive(str(workspace), ["blob.bin"])  # noqa: SLF001
+
+
+def test_find_app_container_matches_app_name(monkeypatch) -> None:  # noqa: ANN001
+    listing = SimpleNamespace(
         returncode=0,
-        stdout="Web Function URL: https://workspace--candidate.modal.run\n",
+        stdout=json.dumps(
+            [
+                {"Container ID": "ta-other", "App Name": "other-app"},
+                {"Container ID": "ta-123", "App Name": "candidate-app"},
+            ]
+        ),
         stderr="",
     )
-    evaluator = SimpleNamespace(returncode=0)
-    run = MagicMock(side_effect=[deploy, evaluator])
+    run = MagicMock(return_value=listing)
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
+
+    container = modal_evaluator._find_app_container(  # noqa: SLF001
+        "candidate-app",
+        workspace="/workspace",
+        base_url="https://workspace--candidate.modal.run",
+    )
+
+    assert container == "ta-123"
+    assert run.call_args_list[0].args[0][:5] == ["uv", "run", "modal", "container", "list"]
+
+
+def test_find_app_container_rewarms_then_times_out(monkeypatch) -> None:  # noqa: ANN001
+    listing = SimpleNamespace(returncode=0, stdout="[]", stderr="")
+    run = MagicMock(return_value=listing)
+    warm = MagicMock(return_value=True)
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
+    monkeypatch.setattr(modal_evaluator, "_healthy_now", warm)
+    monkeypatch.setattr(modal_evaluator.time, "sleep", lambda _: None)
+    clock = iter([0.0, 0.0, 1.0, 2.0])
+    monkeypatch.setattr(modal_evaluator.time, "monotonic", lambda: next(clock))
+
+    with pytest.raises(TimeoutError, match="no running container"):
+        modal_evaluator._find_app_container(  # noqa: SLF001
+            "candidate-app",
+            workspace="/workspace",
+            base_url="https://workspace--candidate.modal.run",
+            timeout_seconds=1.5,
+        )
+    assert warm.call_count == 2
+
+
+def test_parse_exec_output_extracts_rc_files_and_passthrough() -> None:
+    encoded = base64.b64encode(b'{"metric": 1}').decode()
+    stdout = (
+        "benchmark progress line\n"
+        f"{modal_evaluator._OUTPUT_FILE_MARKER} /tmp/result.json\n"  # noqa: SLF001
+        f"{encoded}\n"
+        f"{modal_evaluator._OUTPUT_END_MARKER}\n"  # noqa: SLF001
+        f"{modal_evaluator._EXEC_RC_MARKER}0\n"  # noqa: SLF001
+    )
+
+    rc, files, passthrough = modal_evaluator._parse_exec_output(stdout)  # noqa: SLF001
+
+    assert rc == 0
+    assert files == {"/tmp/result.json": b'{"metric": 1}'}  # noqa: S108
+    assert passthrough == "benchmark progress line"
+
+
+def test_parse_exec_output_without_rc_marker_returns_none() -> None:
+    rc, files, passthrough = modal_evaluator._parse_exec_output("crashed early\n")  # noqa: SLF001
+
+    assert rc is None
+    assert files == {}
+    assert passthrough == "crashed early"
+
+
+def test_bootstrap_script_runs_command_verbatim_and_relays_outputs() -> None:
+    script = modal_evaluator._bootstrap_script(  # noqa: SLF001
+        ["uv", "run", "python", "bench.py"],
+        ["/tmp/result.json"],  # noqa: S108
+    )
+
+    assert "uv run python bench.py" in script
+    assert "/tmp/result.json" in script  # noqa: S108
+    assert modal_evaluator._EXEC_RC_MARKER in script  # noqa: SLF001
+    assert "--url" not in script
+
+
+def _colocated_exec_result(rc: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(
+        returncode=0,
+        stdout=f"{modal_evaluator._EXEC_RC_MARKER}{rc}\n",  # noqa: SLF001
+        stderr="",
+    )
+
+
+def test_execute_colocated_execs_in_container_and_returns_sentinel_rc(
+    monkeypatch,  # noqa: ANN001
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "checker.py").write_text("print('ok')\n")
+    run = MagicMock(return_value=_colocated_exec_result(rc=3))
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
+    monkeypatch.setattr(modal_evaluator, "_find_app_container", MagicMock(return_value="ta-123"))
+    keepwarm = MagicMock()
+    keepwarm.return_value.__enter__ = MagicMock()
+    keepwarm.return_value.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr(modal_evaluator, "_DeploymentKeepWarm", keepwarm)
+
+    result = modal_evaluator._execute_colocated(  # noqa: SLF001
+        ["python", "checker.py"],
+        workspace=str(workspace),
+        app_identifier="candidate-app",
+        base_url="https://workspace--candidate.modal.run",
+    )
+
+    assert result == 3
+    keepwarm.assert_called_once_with("https://workspace--candidate.modal.run")
+    exec_argv = run.call_args.args[0]
+    assert exec_argv[:6] == ["uv", "run", "modal", "container", "exec", "ta-123"]
+    assert exec_argv[6:9] == ["--", "sh", "-c"]
+    assert "python checker.py" in exec_argv[9]
+
+
+def test_execute_colocated_writes_relayed_output_files(
+    monkeypatch,  # noqa: ANN001
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    output_path = tmp_path / "result.json"
+    encoded = base64.b64encode(b'{"metric": 2}').decode()
+    exec_result = SimpleNamespace(
+        returncode=0,
+        stdout=(
+            f"{modal_evaluator._OUTPUT_FILE_MARKER} {output_path}\n"  # noqa: SLF001
+            f"{encoded}\n"
+            f"{modal_evaluator._OUTPUT_END_MARKER}\n"  # noqa: SLF001
+            f"{modal_evaluator._EXEC_RC_MARKER}0\n"  # noqa: SLF001
+        ),
+        stderr="",
+    )
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", MagicMock(return_value=exec_result))
+    monkeypatch.setattr(modal_evaluator, "_find_app_container", MagicMock(return_value="ta-123"))
+
+    result = modal_evaluator._execute_colocated(  # noqa: SLF001
+        ["python", "bench.py", "--output-json", str(output_path)],
+        workspace=str(workspace),
+        app_identifier="candidate-app",
+        base_url="https://workspace--candidate.modal.run",
+    )
+
+    assert result == 0
+    assert json.loads(output_path.read_text()) == {"metric": 2}
+
+
+def test_execute_colocated_reports_missing_rc_sentinel(
+    monkeypatch,  # noqa: ANN001
+    tmp_path: Path,
+    capsys,  # noqa: ANN001
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    exec_result = SimpleNamespace(returncode=0, stdout="killed mid-run\n", stderr="")
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", MagicMock(return_value=exec_result))
+    monkeypatch.setattr(modal_evaluator, "_find_app_container", MagicMock(return_value="ta-123"))
+
+    result = modal_evaluator._execute_colocated(  # noqa: SLF001
+        ["python", "bench.py"],
+        workspace=str(workspace),
+        app_identifier="candidate-app",
+        base_url="https://workspace--candidate.modal.run",
+    )
+
+    assert result == 1
+    assert "did not report an exit code" in capsys.readouterr().err
+
+
+def test_run_evaluator_deploys_waits_and_runs_colocated(monkeypatch) -> None:  # noqa: ANN001
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
+    run = MagicMock(return_value=deploy)
     wait = MagicMock()
+    colocated = MagicMock(return_value=0)
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
     monkeypatch.setattr(modal_evaluator, "wait_for_health", wait)
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", colocated)
 
     result = modal_evaluator.run_evaluator(
         ["uv", "run", "python", "checker.py"],
@@ -148,35 +399,47 @@ def test_run_evaluator_deploys_waits_and_injects_url(monkeypatch) -> None:  # no
             text=True,
             check=False,
         ),
-        call(
-            [
-                "uv",
-                "run",
-                "python",
-                "checker.py",
-                "--url",
-                "https://workspace--candidate.modal.run",
-            ],
-            cwd="/workspace",
-            check=False,
-        ),
     ]
     wait.assert_called_once_with(
         "https://workspace--candidate.modal.run",
         timeout_seconds=90,
     )
+    colocated.assert_called_once_with(
+        ["uv", "run", "python", "checker.py"],
+        workspace="/workspace",
+        app_identifier="candidate-app",
+        base_url="https://workspace--candidate.modal.run",
+    )
 
 
-def test_run_evaluator_deploys_custom_entrypoint(monkeypatch) -> None:  # noqa: ANN001
+def test_run_evaluator_requires_app_identifier(monkeypatch, capsys) -> None:  # noqa: ANN001
     deploy = SimpleNamespace(
         returncode=0,
         stdout="Web Function URL: https://workspace--candidate.modal.run\n",
         stderr="",
     )
-    evaluator = SimpleNamespace(returncode=0)
-    run = MagicMock(side_effect=[deploy, evaluator])
+    run = MagicMock(return_value=deploy)
+    colocated = MagicMock(return_value=0)
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
     monkeypatch.setattr(modal_evaluator, "wait_for_health", MagicMock())
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", colocated)
+
+    result = modal_evaluator.run_evaluator(
+        ["uv", "run", "python", "checker.py"],
+        workspace="/workspace",
+    )
+
+    assert result == 1
+    colocated.assert_not_called()
+    assert "did not print a deployment URL" in capsys.readouterr().err
+
+
+def test_run_evaluator_deploys_custom_entrypoint(monkeypatch) -> None:  # noqa: ANN001
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
+    run = MagicMock(return_value=deploy)
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
+    monkeypatch.setattr(modal_evaluator, "wait_for_health", MagicMock())
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", MagicMock(return_value=0))
 
     result = modal_evaluator.run_evaluator(
         ["checker"],
@@ -210,16 +473,17 @@ def test_run_evaluator_reuses_healthy_deployment_for_exact_revision(
             {
                 "candidate_revision": "abc123",
                 "base_url": "https://workspace--candidate.modal.run",
+                "app_identifier": "candidate-app",
             }
         )
     )
-    evaluator = SimpleNamespace(returncode=0)
-    run = MagicMock(return_value=evaluator)
     healthy = MagicMock(return_value=True)
+    colocated = MagicMock(return_value=0)
     monkeypatch.setenv("VIBESYS_CANDIDATE_REVISION", "abc123")
     monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
     monkeypatch.setattr(modal_evaluator, "_healthy_now", healthy)
-    monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", colocated)
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", MagicMock())
 
     result = modal_evaluator.run_evaluator(
         ["uv", "run", "python", "checker.py"],
@@ -228,18 +492,44 @@ def test_run_evaluator_reuses_healthy_deployment_for_exact_revision(
 
     assert result == 0
     healthy.assert_called_once_with("https://workspace--candidate.modal.run")
-    run.assert_called_once_with(
-        [
-            "uv",
-            "run",
-            "python",
-            "checker.py",
-            "--url",
-            "https://workspace--candidate.modal.run",
-        ],
-        cwd="/workspace",
-        check=False,
+    colocated.assert_called_once_with(
+        ["uv", "run", "python", "checker.py"],
+        workspace="/workspace",
+        app_identifier="candidate-app",
+        base_url="https://workspace--candidate.modal.run",
     )
+
+
+def test_run_evaluator_redeploys_when_lease_lacks_app_identifier(
+    monkeypatch,  # noqa: ANN001
+    tmp_path,  # noqa: ANN001
+) -> None:
+    lease_path = tmp_path / "deployment.json"
+    lease_path.write_text(
+        json.dumps(
+            {
+                "candidate_revision": "abc123",
+                "base_url": "https://workspace--candidate.modal.run",
+            }
+        )
+    )
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
+    run = MagicMock(return_value=deploy)
+    colocated = MagicMock(return_value=0)
+    monkeypatch.setenv("VIBESYS_CANDIDATE_REVISION", "abc123")
+    monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
+    monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
+    monkeypatch.setattr(modal_evaluator, "wait_for_health", MagicMock())
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", colocated)
+
+    result = modal_evaluator.run_evaluator(
+        ["uv", "run", "python", "checker.py"],
+        workspace="/workspace",
+    )
+
+    assert result == 0
+    assert run.call_args_list[0].args[0][:4] == ["uv", "run", "modal", "deploy"]
+    colocated.assert_called_once()
 
 
 def test_run_evaluator_releases_reused_deployment_after_final_gate(
@@ -256,13 +546,13 @@ def test_run_evaluator_releases_reused_deployment_after_final_gate(
             }
         )
     )
-    evaluator = SimpleNamespace(returncode=0)
     stop = SimpleNamespace(returncode=0, stdout="", stderr="")
-    run = MagicMock(side_effect=[evaluator, stop])
+    run = MagicMock(return_value=stop)
     monkeypatch.setenv("VIBESYS_CANDIDATE_REVISION", "abc123")
     monkeypatch.setenv("VIBESYS_RELEASE_MODAL_DEPLOYMENT", "1")
     monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
     monkeypatch.setattr(modal_evaluator, "_healthy_now", MagicMock(return_value=True))
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", MagicMock(return_value=0))
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
 
     result = modal_evaluator.run_evaluator(
@@ -287,23 +577,15 @@ def test_run_evaluator_releases_new_deployment_after_final_gate(
     tmp_path,  # noqa: ANN001  # tracked: #288
 ) -> None:
     lease_path = tmp_path / "deployment.json"
-    deploy = SimpleNamespace(
-        returncode=0,
-        stdout=(
-            "Web Function URL: https://workspace--candidate.modal.run\n"
-            "View Deployment: "
-            "https://modal.com/apps/workspace/main/deployed/candidate-app\n"
-        ),
-        stderr="",
-    )
-    evaluator = SimpleNamespace(returncode=0)
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
     stop = SimpleNamespace(returncode=0, stdout="", stderr="")
-    run = MagicMock(side_effect=[deploy, evaluator, stop])
+    run = MagicMock(side_effect=[deploy, stop])
     monkeypatch.setenv("VIBESYS_CANDIDATE_REVISION", "abc123")
     monkeypatch.setenv("VIBESYS_RELEASE_MODAL_DEPLOYMENT", "1")
     monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
     monkeypatch.setattr(modal_evaluator, "wait_for_health", MagicMock())
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", MagicMock(return_value=0))
 
     result = modal_evaluator.run_evaluator(
         ["uv", "run", "python", "checker.py"],
@@ -337,17 +619,13 @@ def test_run_evaluator_stops_mismatched_leased_app_before_redeploy(
         )
     )
     stop = SimpleNamespace(returncode=0, stdout="", stderr="")
-    deploy = SimpleNamespace(
-        returncode=0,
-        stdout="Web Function URL: https://workspace--new.modal.run\n",
-        stderr="",
-    )
-    evaluator = SimpleNamespace(returncode=0)
-    run = MagicMock(side_effect=[stop, deploy, evaluator])
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
+    run = MagicMock(side_effect=[stop, deploy])
     monkeypatch.setenv("VIBESYS_CANDIDATE_REVISION", "new")
     monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
     monkeypatch.setattr(modal_evaluator, "wait_for_health", MagicMock())
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", MagicMock(return_value=0))
 
     result = modal_evaluator.run_evaluator(
         ["uv", "run", "python", "checker.py"],
@@ -378,17 +656,13 @@ def test_run_evaluator_redeploys_and_replaces_mismatched_revision(
             }
         )
     )
-    deploy = SimpleNamespace(
-        returncode=0,
-        stdout="Web Function URL: https://workspace--new.modal.run\n",
-        stderr="",
-    )
-    evaluator = SimpleNamespace(returncode=0)
-    run = MagicMock(side_effect=[deploy, evaluator])
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
+    run = MagicMock(return_value=deploy)
     monkeypatch.setenv("VIBESYS_CANDIDATE_REVISION", "new")
     monkeypatch.setattr(modal_evaluator, "_DEPLOYMENT_LEASE_PATH", lease_path)
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
     monkeypatch.setattr(modal_evaluator, "wait_for_health", MagicMock())
+    monkeypatch.setattr(modal_evaluator, "_execute_colocated", MagicMock(return_value=0))
 
     result = modal_evaluator.run_evaluator(
         ["uv", "run", "python", "checker.py"],
@@ -398,7 +672,8 @@ def test_run_evaluator_redeploys_and_replaces_mismatched_revision(
     assert result == 0
     assert json.loads(lease_path.read_text()) == {
         "candidate_revision": "new",
-        "base_url": "https://workspace--new.modal.run",
+        "base_url": "https://workspace--candidate.modal.run",
+        "app_identifier": "candidate-app",
     }
 
 
@@ -406,15 +681,7 @@ def test_run_evaluator_prints_modal_logs_when_readiness_fails(
     monkeypatch,  # noqa: ANN001  # tracked: #288
     capsys,  # noqa: ANN001  # tracked: #288
 ) -> None:
-    deploy = SimpleNamespace(
-        returncode=0,
-        stdout=(
-            "Web Function URL: https://workspace--candidate.modal.run\n"
-            "View Deployment: "
-            "https://modal.com/apps/workspace/main/deployed/candidate-app\n"
-        ),
-        stderr="",
-    )
+    deploy = SimpleNamespace(returncode=0, stdout=_DEPLOY_STDOUT, stderr="")
     run = MagicMock(return_value=deploy)
     monkeypatch.setattr(modal_evaluator.subprocess, "run", run)
     monkeypatch.setattr(


### PR DESCRIPTION
## Problem

Fixes #354.

Task benchmark/accuracy commands declare a localhost measurement contract: clients
default to `http://localhost:8000`, colocated with the server. The Modal evaluator
broke it. After deploying the candidate it appended `--url
https://<app>.modal.run` and ran the client on the CPU editor container, so every
official metric included TLS, WAN RTT, Modal ingress, and Modal's function-admission
queue. The queue dominates: a `@modal.web_server` without `@modal.concurrent` admits
one request at a time, so a concurrency-8 closed-loop benchmark serializes before it
ever reaches the engine.

Live evidence from campaign #347's terminal eval (Llama-3.3-70B TP=2, 2x H100):
the official row reported 35.34 tok/s while engine logs showed `Running: 1 reqs,
Waiting: 0`, constant 3.58 s execution per request, and client durations climbing
linearly to 28.9 s. A colocated re-measurement of the same candidate produced
274.99 tok/s (p99 TPOT 28.55 ms, at the hardware's bandwidth roofline): the official
metric was ~7.8x below engine capability, silently. This corrupts the optimizer's
reward signal and rewards candidates that game transport instead of improving the
engine.

## Solution

Run the trusted command UNMODIFIED inside the serving container via `modal
container exec`, preserving the localhost contract. Sub-problems solved (each is
load-bearing and unit-tested):

- **Input staging**: workspace-relative files referenced by the command are packed
  into an in-memory tar.gz (8 MiB cap) and shipped as base64 argv chunks. One
  base64 encoding is split into chunks; separately padded chunks cannot be
  concatenated, so the whole payload is encoded first and only then sliced.
- **Execution environment**: the serving image lacks `uv`, so a POSIX-sh bootstrap
  unpacks the staged archive, pip-installs `uv` into a private `--target` dir,
  shims `uv` as `python3 -m uv`, and runs the command verbatim from the staged
  directory so its localhost defaults and relative paths hold.
- **Exit codes**: `modal container exec` does not propagate them (verified
  empirically: `exit 7` returns rc 0), so the bootstrap emits a
  `__VIBESYS_EXEC_RC__=<n>` sentinel that is parsed back from stdout; a missing
  sentinel is treated as a failure with diagnostics.
- **Output relay**: absolute, not-yet-existing paths in the command (e.g.
  `--output-json /tmp/x.json`) are detected, base64-relayed back between markers,
  and written locally, so the agent loop's existing benchmark-JSON plumbing works
  unchanged.
- **Keep-warm**: colocated traffic does not reset Modal's idle scaledown timer, so
  a daemon thread probes the public `/health` every 30 s during execution.

The public endpoint's only remaining roles are deploy discovery, readiness, and
keep-warm. The `--url` injection is deleted entirely; there is no code path left
that can rewrite measurement topology.

The follow-up commit (215cc71) fixes a bug found during live validation of the
first: container discovery parsed `modal container list --json` with title-case
keys, but modal 1.5.x emits snake_case (`app_name`, `container_id`), so discovery
timed out against a healthy deployment. Discovery now accepts both key dialects
and surfaces the CLI's stderr on failure instead of a generic message.

### Architecture

Ownership stayed inside `modal_evaluator.py` because both external contracts were
preserved: the adapter (`run_environment.py`) still invokes the evaluator as an
opaque command prefix, and the loop still reads the same stdout/exit-code/output
files.

```mermaid
sequenceDiagram
    participant Editor as Editor container (CPU)
    participant Modal as Modal control plane
    participant Serving as Serving container (GPU)

    Editor->>Modal: deploy candidate app
    Modal-->>Editor: public https://<app>.modal.run
    Editor->>Modal: poll /health (readiness)
    Modal->>Serving: route health probe
    Serving-->>Editor: 200 OK (via Modal)

    Editor->>Editor: stage inputs (tar.gz, base64 chunks)
    Editor->>Modal: modal container exec (bootstrap + staged argv)
    Modal->>Serving: run bootstrap
    Serving->>Serving: unpack stage, install uv, run trusted command
    Serving->>Serving: client -> 127.0.0.1:8000 (localhost contract preserved)
    Serving-->>Editor: stdout with __VIBESYS_EXEC_RC__ + relayed output files

    par keep-warm (background)
        Editor->>Modal: GET /health every 30s
        Modal->>Serving: probe
    end
```

## Verification

31 unit tests covering transfer planning, archive building, bootstrap generation,
sentinel/output parsing, container discovery (both key dialects, CLI-error
surfacing, rewarm-then-timeout), colocated execution, and all deploy/reuse/release
lifecycle paths.

Live end-to-end validation: full colocated rerun of campaign #347's final
candidate. Accuracy gates passed in-container (sentinel 6/6, known-answer 7/8,
determinism 4/4) and the benchmark relayed complete JSON (274.99 tok/s, p99
latency 3779.8 ms, 72/72 requests, 0 errors), with the deployment auto-released
afterward.

Note honestly: the exec/exit-code and key-casing behaviors are external-contract
assumptions verified against modal client 1.5.4; unit tests pin our handling but
cannot detect future modal CLI contract drift.

### Correctness properties

- The trusted command runs byte-identical to its task-config form (no `--url`
  injection, no argument rewriting).
- Official metrics can no longer include WAN/ingress/admission-queue components:
  the client always talks to `127.0.0.1:8000`.
- Exit codes and output files round-trip exactly between the serving container and
  the editor container.
- Lease/release lifecycle semantics (deploy, reuse, release) are unchanged.
- No candidate knowledge is added to prompts.

### Testing

```
./scripts/check_format.sh          # All checks passed! 348 files already formatted
./scripts/check_lint.sh            # All checks passed!
./scripts/check_types.sh           # 0 errors, 0 warnings, 0 informations
uv run pytest tests/sandbox/test_modal_evaluator.py -q
  # 34 passed in 4.77s
uv run pytest -q
  # 1 failed, 4059 passed, 2 skipped, 1 warning in 328.23s
  # The 1 failure (test_environment_quotes_hotel_nested_shell_paths) is
  # pre-existing and unrelated: it fails because the DeathStarBench example
  # repository isn't initialized in this worktree (same root cause as the
  # pre-existing skip in tests/test_microservice_inputs.py). Confirmed the
  # example's .vibesys directory is absent independent of this branch's diff;
  # this PR touches only src/vibesys/sandbox/modal_evaluator.py and
  # tests/sandbox/test_modal_evaluator.py.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
