### PR TITLE
Spend a retry, not a round, on synthesized implementer responses

### DIFF
--- a/src/vibesys/agents/__init__.py
+++ b/src/vibesys/agents/__init__.py
@@ -16,7 +16,7 @@ from vibesys.config import Config  # noqa: TC001  # tracked: #288
 from vibesys.constants import DEFAULT_AGENT_BACKEND, ComputeBackend
 from vibesys.features import FeatureFlag, is_feature_enabled
 
-from .base import AgentRunner
+from .base import AgentRunner, ResponseFallback
 from .progress import AgentProgress, CandidateProgress, RoundProgress
 
 # ``CliAgentRunner`` and ``DeepAgentsRunner`` are imported lazily to break a
@@ -39,6 +39,7 @@ __all__ = [
     "CandidateProgress",
     "CliAgentRunner",
     "DeepAgentsRunner",
+    "ResponseFallback",
     "RoundProgress",
     "build_agent_runner",
 ]

--- a/src/vibesys/agents/base.py
+++ b/src/vibesys/agents/base.py
@@ -17,8 +17,9 @@ session object; the default remains each runner's historical behavior.
 from __future__ import annotations
 
 from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from dataclasses import dataclass, field
 from pathlib import Path  # noqa: TC003  # tracked: #288
-from typing import Protocol, TypeVar
+from typing import Generic, Protocol, TypeVar
 
 from langchain_core.tools import BaseTool  # noqa: TC002  # tracked: #288
 from pydantic import BaseModel
@@ -27,6 +28,38 @@ from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #28
 from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 
 T = TypeVar("T", bound=BaseModel)
+
+
+@dataclass(slots=True)
+class ResponseFallback(Generic[T]):
+    """A ``fallback_factory`` that records whether the runner had to use it.
+
+    Every :meth:`AgentRunner.invoke` implementation calls ``fallback_factory``
+    exactly when the agent's output could not be parsed into ``response_cls``,
+    and returns the parsed response otherwise. Wrapping the factory turns that
+    framework-side event into a typed signal the caller can read after the
+    call, so a loop can tell a response it synthesized apart from one the agent
+    actually authored.
+
+    The signal deliberately lives here rather than on the response model: the
+    response schema is sent to the agent as its structured-output contract, and
+    a framework-only field would leak into it.
+
+    Instances are single-call scoped — construct one per ``invoke()``::
+
+        fallback = ResponseFallback(_missing_implementer_response)
+        response = ctx.invoke(..., fallback_factory=fallback)
+        if fallback.synthesized:
+            ...
+    """
+
+    build: Callable[[], T]
+    synthesized: bool = field(default=False, init=False)
+
+    def __call__(self) -> T:
+        """Build the fallback response and record that the runner needed it."""
+        self.synthesized = True
+        return self.build()
 
 
 class AgentRunner(Protocol):
@@ -72,7 +105,9 @@ class AgentRunner(Protocol):
             response_cls: Pydantic model class the agent should produce.
             fallback_factory: Constructs a default ``response_cls`` instance
                 used when the agent fails to produce a parseable response.
-                Implementations must call this rather than raise.
+                Implementations must call this rather than raise, and must
+                call it only for that reason — callers may wrap it in
+                :class:`ResponseFallback` to detect a synthesized response.
             round_label: Short label used in log headers (e.g. ``"judge #3"``).
             progress: Optional loop-owned progress state shown in the live
                 terminal prefix (e.g. ``RoundProgress(3, 24)``).

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any
 
+from vibesys.agents.base import ResponseFallback
 from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config, as_config
 from vibesys.constants import DEFAULT_AGENT_BACKEND, DEFAULT_COMPUTE_BACKEND, ComputeBackend
@@ -1018,6 +1019,21 @@ def _missing_implementer_response() -> ImplementerResponse:
     )
 
 
+@dataclass(frozen=True)
+class _ImplementerAttempt:
+    """One implementer turn plus who authored its response.
+
+    ``synthesized`` is True when the framework had to build the response with
+    :func:`_missing_implementer_response` because the turn's output did not
+    parse. Such a turn produced no reviewable evidence, so it must consume a
+    same-round retry rather than complete the round like a genuine
+    ``inconclusive`` result would.
+    """
+
+    response: ImplementerResponse
+    synthesized: bool
+
+
 def _validate_skill_selections(
     ctx: LoopContext,
     selections: list[SkillResourceSelection],
@@ -1086,7 +1102,7 @@ def _run_implementer(  # noqa: PLR0913  # tracked: #288
     official_evaluation_due: bool = False,
     official_evaluation_reason: str | None = None,
     prior_attempt_artifact_locations: tuple[str, ...] = (),
-) -> ImplementerResponse:
+) -> _ImplementerAttempt:
     plan.recommended_skills, resolved_skills = _validate_skill_selections(
         ctx, plan.recommended_skills
     )
@@ -1144,6 +1160,7 @@ def _run_implementer(  # noqa: PLR0913  # tracked: #288
         recommended_skills=resolved_skills,
         prior_attempt_artifact_locations=prior_attempt_artifact_locations,
     )
+    fallback = ResponseFallback(_missing_implementer_response)
     response = ctx.invoke(
         kind="implementer",
         system_prompt=system_prompt,
@@ -1154,7 +1171,7 @@ def _run_implementer(  # noqa: PLR0913  # tracked: #288
             else "Work persistently on the active hypothesis and return only the JSON object."
         ),
         response_cls=ImplementerResponse,
-        fallback_factory=_missing_implementer_response,
+        fallback_factory=fallback,
         round_label=f"round-{round_number}-retry-{retry}-implementer",
         reuse_session=True,
         session_key=f"hypothesis:{plan.hypothesis_id}",
@@ -1170,7 +1187,7 @@ def _run_implementer(  # noqa: PLR0913  # tracked: #288
     issue_board.write_implementer_artifact(progress_path, round_number, retry, response)
     issue_board.append_implementer(progress_path, round_number, retry, response)
     ctx.snapshot_workspace(f"round-{round_number}-retry-{retry}-implementer")
-    return response
+    return _ImplementerAttempt(response=response, synthesized=fallback.synthesized)
 
 
 def _run_judge(  # noqa: PLR0913  # tracked: #288
@@ -2364,7 +2381,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                             )
                         )
                         ctx.reselect_gpu()
-                        implementation = _run_implementer(
+                        attempt = _run_implementer(
                             ctx,
                             round_number=round_number,
                             retry=retry,
@@ -2392,6 +2409,26 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                             official_evaluation_reason=planned_official_reason,
                             prior_attempt_artifact_locations=prior_attempt_artifact_locations,
                         )
+                        implementation = attempt.response
+                        if attempt.synthesized:
+                            # The framework, not the implementer, wrote this
+                            # response because the turn's output did not parse.
+                            # It carries no reviewable evidence, so spend a
+                            # retry on a real turn instead of letting a parse
+                            # failure silently consume the whole round. When
+                            # retries are exhausted the round still commits the
+                            # fail-closed response, unreviewed, as before.
+                            ctx.lprint(
+                                f"[implementer] attempt {retry}/{max_retries_per_round} "
+                                "returned no parseable structured response; the framework "
+                                "synthesized a fail-closed one. "
+                                + (
+                                    "Retrying within the same round."
+                                    if retry < max_retries_per_round
+                                    else "Retries are exhausted; completing the round with it."
+                                )
+                            )
+                            continue
                         review_due = _review_due(
                             round_number=round_number,
                             max_rounds=max_rounds,

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibesys.agent_runner import log_json_and_print, log_prompt_markdown_and_print
-from vibesys.agents import build_agent_runner
+from vibesys.agents import ResponseFallback, build_agent_runner
 from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.cli_runner import CliAgentRunner
 from vibesys.agents.deepagents_runner import DeepAgentsRunner
@@ -822,6 +822,53 @@ class TestCliAgentRunner:
         assert "Failure" in stdout
         assert "# Failure" in stdout
         assert "**JSON**" in stdout
+
+    @pytest.mark.parametrize(
+        ("generate_returns", "expect_synthesized"),
+        [
+            ("not json at all", True),
+            ('{"analysis": "ok", "feedback": "", "verdict": "pass"}', False),
+        ],
+    )
+    def test_response_fallback_reports_who_authored_the_response(  # noqa: ANN201  # tracked: #288
+        self,
+        monkeypatch,  # noqa: ANN001  # tracked: #288
+        tmp_path,  # noqa: ANN001  # tracked: #288
+        generate_returns,  # noqa: ANN001  # tracked: #288
+        expect_synthesized,  # noqa: ANN001  # tracked: #288
+    ):
+        """Callers must be able to tell a synthesized response from a parsed one."""
+        captured: list = []
+        fake_cls = _make_fake_agent_class(
+            generate_returns=generate_returns,
+            captured=captured,
+        )
+        monkeypatch.setitem(
+            __import__(  # noqa: SLF001  # tracked: #288
+                "vibesys.agents.cli_runner",
+                fromlist=["_PROVIDER_CLASSES"],
+            )._PROVIDER_CLASSES,
+            "claude",
+            fake_cls,
+        )
+
+        runner = CliAgentRunner(provider="claude", model="m", run_log_file=None)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+
+        fallback = ResponseFallback(_judge_fallback)
+        result = runner.invoke(
+            kind="judge",
+            workspace=workspace,
+            system_prompt="sys",
+            user_prompt="usr",
+            response_cls=JudgeResponse,
+            fallback_factory=fallback,
+            round_label="judge #1",
+        )
+
+        assert fallback.synthesized is expect_synthesized
+        assert (result.analysis == "fallback") is expect_synthesized
 
     def test_cli_runner_passes_progress_to_logger(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         captured: list = []

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -137,6 +137,7 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     implementer_skill_updates: list[list[SkillResourceSelection]] | None = None,
     implementer_validation_artifacts: list[str | None] | None = None,
     implementer_next_steps: list[str] | None = None,
+    implementer_parse_failures: list[bool] | None = None,
 ):
     """Build a MagicMock AgentRunner whose invoke() returns scripted responses.
 
@@ -144,6 +145,10 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     class. Defaults: when the plan queue is exhausted, the harness returns a
     permissive no-op plan and lets the loop's ``max_rounds`` bound the test.
     Judge verdicts default to pass; the profiler is not called.
+
+    ``implementer_parse_failures`` marks turns whose output does not parse.
+    Those return ``fallback_factory()`` — the contract every real runner obeys
+    for an unparseable response — instead of a scripted response.
     """
     pre_q = list(pre_decisions or [])
     plan_q = list(plans or [])
@@ -154,6 +159,7 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     impl_skill_q = list(implementer_skill_updates or [])
     impl_validation_q = list(implementer_validation_artifacts or [])
     impl_next_step_q = list(implementer_next_steps or [])
+    impl_parse_failure_q = list(implementer_parse_failures or [])
     counters = {"impl": 0, "judge": 0, "orch_pre": 0, "orch_plan": 0, "prof": 0}
 
     runner = MagicMock(spec=AgentRunner)
@@ -162,9 +168,13 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     def _invoke(*, kind, response_cls, fallback_factory, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001, PLR0911  # tracked: #288
         if kind == "orchestrator" and response_cls is PreRoundDecision:
             counters["orch_pre"] += 1
-            if pre_q:
-                return pre_q.pop(0)
-            return PreRoundDecision(need_profile=False, profile_focus="", reasoning="default skip")
+            return (
+                pre_q.pop(0)
+                if pre_q
+                else PreRoundDecision(
+                    need_profile=False, profile_focus="", reasoning="default skip"
+                )
+            )
         if kind == "orchestrator" and response_cls is OrchestratorPlan:
             counters["orch_plan"] += 1
             if plan_q:
@@ -176,6 +186,8 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
             )
         if kind == "implementer":
             counters["impl"] += 1
+            if impl_parse_failure_q and impl_parse_failure_q.pop(0):
+                return fallback_factory()
             outcome = outcome_q.pop(0) if outcome_q else HypothesisOutcome.NOMINATED
             perf_metric = impl_perf_q.pop(0) if impl_perf_q else None
             skill_updates = impl_skill_q.pop(0) if impl_skill_q else []
@@ -1829,6 +1841,91 @@ def test_loop_judge_retry_then_pass(tmp_path, ref_file):  # noqa: ANN001, ANN201
     assert "Same-round retry boundary" in retry_prompt
     assert "round-0001-attempt-01-implementer.json" in retry_prompt
     assert "remains consumed" in retry_prompt
+
+
+def test_unparseable_implementer_response_consumes_a_retry(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """A framework-synthesized response re-invokes the implementer in the same round.
+
+    Sparse-review cadence would otherwise defer the judge and let the round
+    complete on a fail-closed response that no agent authored, burning a round
+    without spending any of ``max_retries_per_round``.
+    """
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                task="Build server",
+                pass_criteria="tests pass",  # noqa: S106  # tracked: #288
+                reasoning="cold start",
+            ),
+        ],
+        implementer_parse_failures=[True],
+        implementer_outcomes=[HypothesisOutcome.NOMINATED],
+    )
+
+    result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1, max_retries_per_round=3)
+
+    assert result is True
+    assert runner.counters["impl"] == 2
+    assert runner.counters["judge"] == 1
+    implementer_labels = [
+        call.kwargs["round_label"]
+        for call in runner.invoke.call_args_list
+        if call.kwargs.get("response_cls") is ImplementerResponse
+    ]
+    assert implementer_labels == [
+        "round-1-retry-1-implementer",
+        "round-1-retry-2-implementer",
+    ]
+    rounds = _round_payloads(tmp_path)
+    assert len(rounds) == 1
+    assert rounds[0]["reviewed"] is True
+
+
+def test_unparseable_implementer_responses_commit_fail_closed_once_exhausted(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """Only genuine retry exhaustion may commit the synthesized response."""
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                task="Build server",
+                pass_criteria="tests pass",  # noqa: S106  # tracked: #288
+                reasoning="cold start",
+            ),
+        ],
+        implementer_parse_failures=[True, True],
+    )
+
+    result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1, max_retries_per_round=2)
+
+    assert result is True
+    assert runner.counters["impl"] == 2
+    assert runner.counters["judge"] == 0
+    rounds = _round_payloads(tmp_path)
+    assert len(rounds) == 1
+    assert rounds[0]["passed"] is False
+    assert rounds[0]["reviewed"] is False
+    assert rounds[0]["hypothesis_outcome"] == HypothesisOutcome.INCONCLUSIVE.value
+
+
+def test_agent_authored_inconclusive_completes_the_round(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """A parsed ``inconclusive`` turn is real evidence and keeps sparse review."""
+    runner = _make_orchestrate_runner(
+        implementer_outcomes=[HypothesisOutcome.INCONCLUSIVE] * 2,
+    )
+
+    result = _invoke_orchestrate(
+        tmp_path,
+        ref_file,
+        runner,
+        max_rounds=2,
+        judge_every=10,
+        max_retries_per_round=3,
+    )
+
+    assert result is True
+    assert runner.counters["impl"] == 2  # one attempt per round, no retries burned
+    assert runner.counters["judge"] == 1  # mandatory final-round review only
+    rounds = _round_payloads(tmp_path)
+    assert [round_data["reviewed"] for round_data in rounds] == [False, True]
 
 
 def test_loop_defers_judge_until_cadence_and_always_reviews_final_round(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288


### PR DESCRIPTION
## Problem

Fixes #351. When an implementer response fails to parse, the loop synthesized a
fallback response object indistinguishable from a genuinely inconclusive turn.
The sparse-review policy then deferred the judge (nothing to review), and the
round committed with no metrics, no review, and the `max_retries_per_round`
budget (3) untouched — retries only fired on typed failures the loop
recognized. Combined with any systematic extraction failure (like #350), every
round silently became a ~110-second no-op that still consumed a full round of
campaign budget. Observed live in campaign #347: rounds 2-3 burned exactly
this way (~$13 LLM spend, zero evidence, retries unspent).

## Solution

Introduce a typed `ResponseFallback` signal so a framework-side extraction
failure is structurally distinct from a real agent response. The loop treats
it as a retryable in-round failure: it spends a same-round retry instead of
committing the round.

Why this is thorough: the root cause was a type-level ambiguity (synthesized
response ≅ real response), and the fix removes the ambiguity at the type
level rather than adding heuristics downstream — no consumer can confuse the
two again, and the retry budget now bounds the cost of persistent extraction
failures (max 3x per round) instead of silently losing rounds. Validated
live: after this fix, parse failures consumed in-round retries and no
evidence-free rounds were committed from synthesized responses (campaign
segments S2-S5).

### Architecture

Ownership: the signal type (`ResponseFallback`) is defined in
`src/vibesys/agents/base.py`, raised at response ingestion inside
`AgentRunner.invoke()` implementations (via the existing `fallback_factory`
hook), and consumed by the round loop's retry control flow in
`src/vibesys/loops/agent/loop.py`. `_run_implementer` now returns an
`_ImplementerAttempt(response, synthesized)` pair instead of a bare
`ImplementerResponse`, so the round loop can branch on `synthesized` and
`continue` to spend a retry instead of proceeding to review/commit.
Orchestrator, judge, profiler, and persisted-state behavior are unchanged.

**Adaptation note:** this commit was authored on the campaign branch on top
of e0364de ("Gate native-output-schema strictness on a provider
capability"), a separate, unrelated fix for #350. The two commits touch
different files except for one shared test file
(`tests/agents/test_agent_runners.py`), where they add independent test
cases. The cherry-pick onto `main` applied cleanly via `git cherry-pick`
with no conflicts, and this commit's logic (the `ResponseFallback` type and
the retry-not-round control flow) does not depend on any symbol or behavior
introduced by e0364de — verified by diffing the touched files and confirming
`fallback_factory` was a pre-existing `AgentRunner.invoke()` parameter, not
new. No adaptation was needed; this PR imports only 8cb0c11.

## Verification

Ran the full local check suite from a clean cherry-pick onto `main`
(60b582f), no manual edits required.

### Correctness properties

- Genuine inconclusive turns (a real, parseable `ImplementerResponse` with
  `hypothesis_outcome=inconclusive`) are unaffected: `synthesized` is only
  `True` when the runner had to call the fallback factory because parsing
  failed.
- Retry budget semantics are unchanged for other failure kinds (e.g. typed
  exceptions still consume retries the same way as before).
- Bounded by `max_retries_per_round`: once retries are exhausted, the round
  still commits the fail-closed response, unreviewed, exactly as before this
  change — this PR does not change worst-case behavior, only spends the
  existing retry budget before falling back to it.

### Testing

- `./scripts/check_format.sh` — All checks passed! (348 files already
  formatted)
- `./scripts/check_lint.sh` — All checks passed!
- `./scripts/check_types.sh` — 0 errors, 0 warnings, 0 informations
- `uv run pytest -q` — 4048 passed, 1 failed, 2 skipped in 331.10s. The one
  failure, `tests/sandbox/test_run_environment.py::test_environment_quotes_hotel_nested_shell_paths`,
  is unrelated to this change (DeathStarBench hotel-reservation command
  quoting in the local sandbox environment) and reproduces identically on
  pristine `main` (60b582f) before this cherry-pick, confirmed by running it
  in a separate throwaway worktree at that commit. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
