### PR TITLE
Forward env-var CLI auth into the Docker editor and fail loudly without auth

### DIFF
--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -6,6 +6,7 @@ import atexit
 import json
 import logging
 import os
+import re
 import signal
 import subprocess
 import tempfile
@@ -28,6 +29,41 @@ if TYPE_CHECKING:
 
 # Global registry of live containers for cleanup on exit / SIGINT.
 _live_containers: dict[str, str] = {}  # container_id -> container_name
+
+# Environment variables whose *values* must never leave this process.
+# Credentials reach the container as ``-e NAME=VALUE`` arguments on
+# ``docker run``, and every sink that records a command or the env dict is
+# durable and readable: the command log lives beside the run's other logs, the
+# metadata file is written into the bind-mounted workspace the agent edits, and
+# startup errors are surfaced to the caller.  Endpoint variables such as
+# ``*_BASE_URL`` stay visible because they are diagnostics, not secrets.
+_SECRET_ENV_NAME_PATTERN = re.compile(
+    r"AUTH|TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|HEADERS",
+    re.IGNORECASE,
+)
+_REDACTED_VALUE = "<redacted>"
+
+
+def _is_secret_env_name(name: str) -> bool:
+    """Report whether *name* identifies a credential-bearing variable."""
+    return _SECRET_ENV_NAME_PATTERN.search(name) is not None
+
+
+def _redacted_command(cmd: list[str]) -> list[str]:
+    """Return *cmd* with the values of credential ``-e NAME=VALUE`` flags masked."""
+    redacted: list[str] = []
+    for index, argument in enumerate(cmd):
+        name, separator, _ = argument.partition("=")
+        if separator and index > 0 and cmd[index - 1] == "-e" and _is_secret_env_name(name):
+            redacted.append(f"{name}={_REDACTED_VALUE}")
+        else:
+            redacted.append(argument)
+    return redacted
+
+
+def _non_secret_env(env: dict[str, str]) -> dict[str, str]:
+    """Return *env* without credential entries, for the on-disk metadata file."""
+    return {name: value for name, value in env.items() if not _is_secret_env_name(name)}
 
 
 def _cleanup_containers() -> None:
@@ -205,7 +241,7 @@ class DockerSandbox(BaseSandbox):
     ) -> None:
         if self._logger is None:
             return
-        self._logger.info("CMD: %s", " ".join(cmd))
+        self._logger.info("CMD: %s", " ".join(_redacted_command(cmd)))
         if result is not None:
             self._logger.info("  exit_code=%d", result.returncode)
             if result.stdout and result.stdout.strip():
@@ -404,7 +440,7 @@ class DockerSandbox(BaseSandbox):
                 f"Failed to start Docker container (exit {result.returncode}):\n"
                 f"  stdout: {result.stdout.strip()}\n"
                 f"  stderr: {result.stderr.strip()}\n"
-                f"  cmd: {' '.join(cmd)}"
+                f"  cmd: {' '.join(_redacted_command(cmd))}"
             )
         self._container_id = result.stdout.strip()
         _live_containers[self._container_id] = self._container_name
@@ -430,7 +466,10 @@ class DockerSandbox(BaseSandbox):
             "entrypoint": self._entrypoint,
             "shm_size": self._shm_size,
             "bind_mounts": [[host, container, ro] for host, container, ro in self._bind_mounts],
-            "env": dict(self._env),
+            # Credentials are omitted rather than masked: the metadata file is
+            # written into the agent-visible workspace, and a masked value
+            # would rebuild a broken container that looks authenticated.
+            "env": _non_secret_env(self._env),
             "symlink_commands": [],
         }
         self._save_metadata()

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -1,5 +1,6 @@
 """Tests for DockerSandbox — all mock subprocess.run, no Docker required."""
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -915,6 +916,76 @@ class TestEnvVars:
         assert "-e" in cmd
         assert "MY_KEY=my_value" in cmd_str
         assert "OTHER=thing" in cmd_str
+
+    @patch("subprocess.run")
+    def test_credential_values_reach_the_container_but_not_the_log(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        log_path = tmp_path / "docker.log"
+        sandbox = DockerSandbox(
+            host_workspace=str(workspace),
+            image="pytorch:latest",
+            env={
+                "ANTHROPIC_AUTH_TOKEN": "sk-secret-token",
+                "ANTHROPIC_BASE_URL": "https://proxy.invalid/v1",
+                "PYTHONPATH": "/opt/vibesys",
+            },
+            log_path=log_path,
+        )
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc123\n", stderr=""
+        )
+
+        sandbox.start()
+
+        cmd_str = " ".join(mock_run.call_args_list[0][0][0])
+        assert "ANTHROPIC_AUTH_TOKEN=sk-secret-token" in cmd_str
+
+        log_text = log_path.read_text()
+        assert "sk-secret-token" not in log_text
+        assert "ANTHROPIC_AUTH_TOKEN=<redacted>" in log_text
+        # Endpoint selection is a diagnostic, not a credential.
+        assert "ANTHROPIC_BASE_URL=https://proxy.invalid/v1" in log_text
+        assert "PYTHONPATH=/opt/vibesys" in log_text
+
+    @patch("subprocess.run")
+    def test_credential_values_are_omitted_from_workspace_metadata(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        sandbox = DockerSandbox(
+            host_workspace=str(workspace),
+            image="pytorch:latest",
+            env={"ANTHROPIC_API_KEY": "sk-secret-key", "PYTHONPATH": "/opt/vibesys"},
+        )
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="abc123\n", stderr=""
+        )
+
+        sandbox.start()
+
+        metadata_text = (workspace / ".docker_metadata.json").read_text()
+        assert "sk-secret-key" not in metadata_text
+        assert json.loads(metadata_text)["env"] == {"PYTHONPATH": "/opt/vibesys"}
+
+    @patch("subprocess.run")
+    def test_start_failure_error_does_not_expose_credentials(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        sandbox = DockerSandbox(
+            host_workspace=str(tmp_path / "workspace"),
+            image="pytorch:latest",
+            env={"ANTHROPIC_AUTH_TOKEN": "sk-secret-token"},
+        )
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=125, stdout="", stderr="boom"
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            sandbox.start()
+
+        assert "sk-secret-token" not in str(excinfo.value)
+        assert "ANTHROPIC_AUTH_TOKEN=<redacted>" in str(excinfo.value)
 
 
 class TestDevicePassthrough:

--- a/src/vibesys/agents/cli_docker.py
+++ b/src/vibesys/agents/cli_docker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shlex
 from dataclasses import dataclass
 from pathlib import Path
@@ -220,6 +221,52 @@ DOCKER_AUTH_PATHS: dict[str, list[DockerAuthPath]] = {
         ),
     ],
 }
+
+
+# Host environment variables that carry provider authentication, forwarded
+# into the container alongside the staged files above.  A host may authenticate
+# a CLI entirely through the environment — an ``ANTHROPIC_AUTH_TOKEN`` plus
+# ``ANTHROPIC_BASE_URL`` pointing at a proxy or enterprise gateway is a
+# first-class Claude Code auth mechanism, and plain API keys are another — in
+# which case no provider state file exists to stage and the container CLI would
+# start unauthenticated.  Host sandboxes never hit this because they inherit
+# the host environment directly.
+#
+# Keep this registry to credential and endpoint variables.  Model-selection
+# variables such as ``ANTHROPIC_MODEL`` are deliberately excluded: VibeSys owns
+# per-role model selection, and forwarding a host export would let it silently
+# override the configured model inside the container.
+DOCKER_AUTH_ENV_VARS: dict[str, tuple[str, ...]] = {
+    "claude": (
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_CUSTOM_HEADERS",
+    ),
+    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    "codex": ("OPENAI_API_KEY", "OPENAI_BASE_URL"),
+    # OpenCode resolves credentials per *model* provider from the models.dev
+    # registry, so the variable names depend on whichever provider the user
+    # configured rather than on OpenCode itself; it documents no CLI-owned auth
+    # variable to enumerate here.  Its ``auth.json`` and config files are
+    # already staged through ``DOCKER_AUTH_PATHS``.
+    "opencode": (),
+}
+
+
+def auth_env_passthrough(provider: str) -> dict[str, str]:
+    """Return the host auth environment variables *provider* can actually use.
+
+    Unset and blank variables are dropped: an empty host export carries no
+    credential and must not shadow staged file authentication or make the
+    preflight check believe the container is authenticated.
+    """
+    values: dict[str, str] = {}
+    for name in DOCKER_AUTH_ENV_VARS.get(provider, ()):
+        value = os.environ.get(name)
+        if value and value.strip():
+            values[name] = value
+    return values
 
 
 def auth_bind_mounts(provider: str) -> list[tuple[str, str, bool]]:

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -1368,14 +1368,35 @@ def _cli_container_setup(
     if effective_agent != "cli" or not request.cli_provider:
         return [], {}
     from vibesys.agents.cli_docker import (  # noqa: PLC0415  # tracked: #288
+        DOCKER_AUTH_ENV_VARS,
+        DOCKER_AUTH_PATHS,
         DOCKER_PROVIDER_ENV,
         auth_copy_commands,
+        auth_env_passthrough,
         docker_init_commands,
     )
 
     provider = request.cli_provider
+    auth_commands = auth_copy_commands(provider)
+    auth_env = auth_env_passthrough(provider)
+    if not auth_commands and not auth_env:
+        checked_files = (
+            ", ".join(str(spec.host_path) for spec in DOCKER_AUTH_PATHS.get(provider, []))
+            or "<none registered>"
+        )
+        checked_env = ", ".join(DOCKER_AUTH_ENV_VARS.get(provider, ())) or "<none registered>"
+        raise ValueError(  # noqa: TRY003  # tracked: #288
+            f"no {provider!r} CLI authentication is available for the container: "
+            f"none of the host files exist ({checked_files}) and none of the "
+            f"environment variables are set ({checked_env}). Authenticate the "
+            f"{provider} CLI on this host, or export one of those variables, "
+            "before running in an isolated environment."
+        )
     env = dict(DOCKER_PROVIDER_ENV.get(provider, {}))
-    commands = [*auth_copy_commands(provider), *docker_init_commands(provider)]
+    # Container processes inherit only what ``docker run -e`` sets; the editor
+    # container has no other view of the host environment.
+    env.update(auth_env)
+    commands = [*auth_commands, *docker_init_commands(provider)]
     return commands, env
 
 

--- a/tests/agents/test_cli_docker.py
+++ b/tests/agents/test_cli_docker.py
@@ -93,6 +93,47 @@ def test_provider_auth_imports_exclude_bulk_runtime_roots():  # noqa: ANN201  # 
     )
 
 
+def test_provider_auth_env_registry_covers_credentials_not_model_selection():  # noqa: ANN201  # tracked: #288
+    assert cli_docker.DOCKER_AUTH_ENV_VARS == {
+        "claude": (
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_CUSTOM_HEADERS",
+        ),
+        "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        "codex": ("OPENAI_API_KEY", "OPENAI_BASE_URL"),
+        "opencode": (),
+    }
+    # VibeSys owns per-role model selection; a host export must not override it.
+    forwarded = {name for names in cli_docker.DOCKER_AUTH_ENV_VARS.values() for name in names}
+    assert forwarded.isdisjoint({"ANTHROPIC_MODEL", "OPENAI_MODEL", "GEMINI_MODEL"})
+    assert set(cli_docker.DOCKER_AUTH_ENV_VARS) == set(cli_docker.DOCKER_AUTH_PATHS)
+
+
+def test_auth_env_passthrough_forwards_only_variables_the_host_actually_set(  # noqa: ANN201  # tracked: #288
+    monkeypatch,  # noqa: ANN001  # tracked: #288
+):
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "token-value")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://proxy.invalid/v1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "   ")
+    monkeypatch.delenv("ANTHROPIC_CUSTOM_HEADERS", raising=False)
+    monkeypatch.setenv("ANTHROPIC_MODEL", "host-selected-model")
+
+    assert cli_docker.auth_env_passthrough("claude") == {
+        "ANTHROPIC_AUTH_TOKEN": "token-value",
+        "ANTHROPIC_BASE_URL": "https://proxy.invalid/v1",
+    }
+
+
+def test_auth_env_passthrough_is_empty_without_host_credentials(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    for name in cli_docker.DOCKER_AUTH_ENV_VARS["claude"]:
+        monkeypatch.delenv(name, raising=False)
+
+    assert cli_docker.auth_env_passthrough("claude") == {}
+    assert cli_docker.auth_env_passthrough("unregistered-provider") == {}
+
+
 def test_codex_container_installs_luna_capable_cli_version():  # noqa: ANN201  # tracked: #288
     commands = cli_docker.docker_init_commands("codex")
 

--- a/tests/sandbox/test_run_environment.py
+++ b/tests/sandbox/test_run_environment.py
@@ -52,6 +52,20 @@ def _request(tmp_path: Path, backend: FakeBackend, **overrides):  # noqa: ANN003
     return RunEnvironmentRequest(**values)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
 
+@pytest.fixture(autouse=True)
+def _synthetic_cli_auth(monkeypatch):  # pyright: ignore[reportUnusedFunction]  # noqa: ANN001, ANN202
+    """Pin a deterministic host auth source for container CLI setup.
+
+    ``_cli_container_setup`` fails loud when a provider has neither a staged
+    host file nor an auth environment variable, so these tests must not depend
+    on whichever CLI the developer running them happens to be logged into.
+    """
+    for names in cli_docker.DOCKER_AUTH_ENV_VARS.values():
+        for name in names:
+            monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "synthetic-openai-key")
+
+
 def test_cli_compatibility_flags_keep_options_scoped_to_selected_environment():  # noqa: ANN201  # tracked: #288
     assert make_run_environment_spec().options == {}
     assert make_run_environment_spec(use_docker=True, docker_image="editor").options == {
@@ -403,6 +417,48 @@ def test_docker_environment_copies_cli_auth_from_readonly_staging(tmp_path, monk
     assert kwargs["extra_init_commands"][0] == (
         "mkdir -p /root/.codex && cp -a /opt/vibesys-auth/0 /root/.codex/auth.json"
     )
+
+
+def test_docker_environment_forwards_host_cli_auth_environment(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    backend = FakeBackend()
+    env = build_run_environment(RunEnvironmentSpec("docker"))
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "proxy-token")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://proxy.invalid/v1")
+    monkeypatch.setenv("ANTHROPIC_MODEL", "host-selected-model")
+
+    env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="claude"))
+
+    container_env = backend.calls[0][1]["extra_env"]
+    assert container_env["ANTHROPIC_AUTH_TOKEN"] == "proxy-token"  # noqa: S105  # tracked: #288
+    assert container_env["ANTHROPIC_BASE_URL"] == "https://proxy.invalid/v1"
+    # VibeSys owns per-role model selection, so a host export must not reach
+    # the container and override it.
+    assert "ANTHROPIC_MODEL" not in container_env
+    assert container_env["IS_SANDBOX"] == "1"
+    assert container_env["PYTHONPATH"] == "/opt/vibesys"
+
+
+def test_docker_environment_rejects_a_cli_provider_without_any_auth_source(  # noqa: ANN201  # tracked: #288
+    tmp_path,  # noqa: ANN001  # tracked: #288
+    monkeypatch,  # noqa: ANN001  # tracked: #288
+):
+    backend = FakeBackend()
+    env = build_run_environment(RunEnvironmentSpec("docker"))
+    monkeypatch.setitem(
+        cli_docker.DOCKER_AUTH_PATHS,
+        "codex",
+        [DockerAuthPath(tmp_path / "absent-codex-home" / "auth.json", "/root/.codex/auth.json")],
+    )
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="no 'codex' CLI authentication") as excinfo:
+        env.open(_request(tmp_path, backend, agent_backend="cli", cli_provider="codex"))
+
+    message = str(excinfo.value)
+    assert str(tmp_path / "absent-codex-home" / "auth.json") in message
+    assert "OPENAI_API_KEY" in message
+    assert "OPENAI_BASE_URL" in message
+    assert backend.calls == []
 
 
 def test_docker_environment_exposes_framework_git_history_read_only(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288


### PR DESCRIPTION
## Problem

Fixes #353.

On hosts that authenticate the agent CLI via environment variables
(`ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, etc. — typical for CI, shared
machines, and enterprise gateways) rather than `~/.claude` credentials, the
Docker editor container received none of those variables. The in-container
`claude` invocation exited 1 with empty stderr, and the loop died at startup
with no hint that auth was the cause; diagnosing required manually exec-ing
into the editor container. Observed live in campaign #347: segment S3 died
immediately on resume with only "claude exited 1" as evidence.

## Solution

Forward the auth-relevant environment variables into the editor container,
redact their values from docker logs and sandbox metadata, and fail fast at
sandbox setup with an explicit error when no usable auth source is present
(env vars or mounted credentials).

Why this is thorough: it fixes both halves of the failure — the missing
passthrough (functional) and the empty diagnostic (operational). The
fail-fast check means a future auth regression surfaces at setup with a
named cause instead of as an opaque exit 1 at first agent invocation; the
redaction ensures the fix does not leak tokens into persisted logs/metadata,
which is verified by tests. Validated live: campaign segments S4-S5 ran the
editor container authenticated via env vars through round 10.

### Architecture

Ownership: `cli_docker` owns which vars are forwarded (`DOCKER_AUTH_ENV_VARS`,
`auth_env_passthrough`); `run_environment` (`_cli_container_setup`) merges the
passthrough env with the existing file-based auth commands and enforces the
fail-fast check when neither source is available; `docker_sandbox` owns
redaction at the logging boundary (docker.log, container-start failure
messages, `.docker_metadata.json`).

```
cli_docker.auth_env_passthrough(provider) ──┐
cli_docker.auth_copy_commands(provider) ────┼─▶ run_environment._cli_container_setup
                                             │      ├─ merges env, raises if both empty
                                             ▼
                                    docker_sandbox (container env + logs)
                                             │
                                             └─▶ redacts secret-shaped values in
                                                 docker.log / container-start errors /
                                                 .docker_metadata.json
```

This is a straight cherry-pick of commit `00aae96` from the campaign branch
`vs-meta-opt/llama70b-2xh100-vllm-20260813`. That commit was authored on top
of `292fe67` ("Record the runtime environment in run state and restore it on
resume"), which also touches `src/vibesys/sandbox/run_environment.py` and
`tests/sandbox/test_run_environment.py`. The cherry-pick onto current `main`
auto-merged cleanly in both files with no conflicts; I diffed the resulting
changes against the original commit's diff and confirmed they are identical
modulo line-number offsets, i.e. only this commit's auth-passthrough/fail-fast
change landed. `292fe67`'s environment-record changes are out of scope and
are not part of this PR.

## Verification

### Correctness properties

- Hosts using `~/.claude` credential mounts are unchanged: file-based auth
  copy commands still run when present, independent of env-var passthrough.
- Only auth/endpoint variables are forwarded (`DOCKER_AUTH_ENV_VARS`);
  model-selection variables such as `ANTHROPIC_MODEL` are excluded, since
  VibeSys owns per-role model selection.
- Secret values never appear in `docker.log`, container-start failure
  messages, or `.docker_metadata.json` — verified by redaction tests.
- Absence of all auth sources (no host file, no env var) fails at sandbox
  setup with a named cause, not mid-loop as an opaque `claude` exit code.

### Testing

Ran from the repo root:

- `./scripts/check_format.sh` — all checks passed, 348 files already
  formatted.
- `./scripts/check_lint.sh` — all checks passed.
- `./scripts/check_types.sh` — 0 errors, 0 warnings, 0 informations.
- `uv run pytest -q` — 4051 passed, 2 skipped, 1 failed (4054 collected,
  ~5m25s). The failure,
  `tests/sandbox/test_run_environment.py::test_environment_quotes_hotel_nested_shell_paths`,
  is pre-existing and unrelated to this change: it fails because the
  `examples/microservices/repositories/deathstarbench` git submodule is not
  checked out in this worktree (`git submodule status` shows a `-` prefix),
  so `Project.open(...)` can't find `.vibesys`. Confirmed the test file's
  diff for this commit only touches the fixture and two new test functions
  added far from this test (line ~230); this test predates the cherry-pick
  and is unaffected by it. All new tests introduced by this commit passed,
  including
  `tests/sandbox/test_run_environment.py::test_docker_environment_forwards_host_cli_auth_environment`
  and `test_docker_environment_rejects_a_cli_provider_without_any_auth_source`,
  the redaction tests in `libs/vs-sandbox/tests/test_docker_sandbox.py`, and
  the passthrough tests in `tests/agents/test_cli_docker.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
