### PR TITLE
Make the VibeSys loop able to consume OTel critical-path evidence

### DIFF
--- a/resources/profilers/otel/server.py
+++ b/resources/profilers/otel/server.py
@@ -448,6 +448,64 @@ class CriticalPathEvidence(BaseModel):
     omitted_root_count: int
 
 
+class TraceNodeEvidence(BaseModel):
+    """One call-graph node with its inclusive and exclusive latency split."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    node_id: str
+    path: str
+    service: str
+    operation: str
+    kind: str
+    depth: int
+    inclusive_latency_ms: LatencyDistribution
+    exclusive_latency_ms: LatencyDistribution
+
+
+class BoundedRepresentativeTrace(BaseModel):
+    """Bounded representative waterfall returned to the profiler agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    trace_id: str
+    duration_ms: float
+    spans: list[WaterfallSpan]
+    omitted_span_count: int
+
+
+class TraceBreakdownRootEvidence(BaseModel):
+    """Bounded call-graph and waterfall evidence for one root operation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    service: str
+    operation: str
+    trace_count: int
+    error_count: int
+    latency_ms: LatencyDistribution
+    nodes: list[TraceNodeEvidence]
+    omitted_node_count: int
+    edges: list[TraceGraphEdge]
+    omitted_edge_count: int
+    representative_trace: BoundedRepresentativeTrace
+
+
+class TraceBreakdown(BaseModel):
+    """Bounded schema-v2 structure returned by the ``trace_breakdown`` tool."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    collected_at: str
+    workload_name: str
+    workload_hash: str
+    measurement_windows: list[MeasurementWindow]
+    quality: TraceQuality
+    roots: list[TraceBreakdownRootEvidence]
+    omitted_root_count: int
+
+
 def load_report(path: str) -> TelemetryReport:  # noqa: D103  # tracked: #288
     return TelemetryReport.model_validate_json(Path(path).read_text(encoding="utf-8"))
 
@@ -494,18 +552,7 @@ def summarize_critical_path(
 ) -> CriticalPathEvidence:
     """Return bounded critical-path evidence from a schema-v2 trace graph."""
     _validate_top(top)
-    graph = load_trace_graph(path)
-    telemetry = load_report(telemetry_path)
-    if (
-        graph.workload_name,
-        graph.workload_hash,
-        graph.measurement_windows,
-    ) != (
-        telemetry.workload_name,
-        telemetry.workload_hash,
-        telemetry.measurement_windows,
-    ):
-        raise ValueError(_GRAPH_REPORT_MISMATCH)
+    graph = _bound_graph_to_report(path, telemetry_path)
     roots = []
     for root in graph.roots[:top]:
         critical = root.critical_path
@@ -541,6 +588,93 @@ def summarize_critical_path(
         roots=roots,
         omitted_root_count=max(len(graph.roots) - top, 0),
     )
+
+
+def summarize_trace_breakdown(path: str, telemetry_path: str, *, top: int = 10) -> TraceBreakdown:
+    """Return the bounded call graph and representative waterfall of a trace graph.
+
+    ``critical_path`` answers "where does wall clock go"; this answers "what
+    calls what, and how do the calls overlap in one request". Both bind the
+    graph to the normalized report so a stale or foreign artifact fails closed.
+    """
+    _validate_top(top)
+    graph = _bound_graph_to_report(path, telemetry_path)
+    roots = []
+    for root in graph.roots[:top]:
+        # Rank by inclusive p95 so truncation drops cheap leaves, then report
+        # the survivors parent-first so the retained nodes still read as a tree.
+        ranked = sorted(root.nodes, key=lambda node: node.inclusive_latency_ms.p95_ms, reverse=True)
+        kept = {node.id for node in ranked[:top]}
+        nodes = sorted(
+            (node for node in root.nodes if node.id in kept),
+            key=lambda node: (_node_depth(node.path), -node.inclusive_latency_ms.p95_ms),
+        )
+        edges = [edge for edge in root.edges if edge.from_node in kept and edge.to in kept]
+        spans = sorted(root.representative_trace.spans, key=lambda span: -span.duration_ms)[:top]
+        roots.append(
+            TraceBreakdownRootEvidence(
+                service=root.service,
+                operation=root.operation,
+                trace_count=root.trace_count,
+                error_count=root.error_count,
+                latency_ms=root.latency_ms,
+                nodes=[
+                    TraceNodeEvidence(
+                        node_id=node.id,
+                        path=node.path,
+                        service=node.service,
+                        operation=node.operation,
+                        kind=node.kind,
+                        depth=_node_depth(node.path),
+                        inclusive_latency_ms=node.inclusive_latency_ms,
+                        exclusive_latency_ms=node.exclusive_latency_ms,
+                    )
+                    for node in nodes
+                ],
+                omitted_node_count=max(len(root.nodes) - len(nodes), 0),
+                edges=edges,
+                omitted_edge_count=max(len(root.edges) - len(edges), 0),
+                representative_trace=BoundedRepresentativeTrace(
+                    trace_id=root.representative_trace.trace_id,
+                    duration_ms=root.representative_trace.duration_ms,
+                    # Longest spans survive truncation; time order is restored so
+                    # the agent reads an ordered waterfall, not a ranking.
+                    spans=sorted(spans, key=lambda span: (span.offset_ms, -span.duration_ms)),
+                    omitted_span_count=max(len(root.representative_trace.spans) - len(spans), 0),
+                ),
+            )
+        )
+    return TraceBreakdown(
+        source=graph.source,
+        collected_at=graph.collected_at,
+        workload_name=graph.workload_name,
+        workload_hash=graph.workload_hash,
+        measurement_windows=graph.measurement_windows,
+        quality=graph.quality,
+        roots=roots,
+        omitted_root_count=max(len(graph.roots) - top, 0),
+    )
+
+
+def _bound_graph_to_report(path: str, telemetry_path: str) -> TraceGraphReport:
+    """Load a graph only when it shares one workload identity and windows."""
+    graph = load_trace_graph(path)
+    telemetry = load_report(telemetry_path)
+    if (
+        graph.workload_name,
+        graph.workload_hash,
+        graph.measurement_windows,
+    ) != (
+        telemetry.workload_name,
+        telemetry.workload_hash,
+        telemetry.measurement_windows,
+    ):
+        raise ValueError(_GRAPH_REPORT_MISMATCH)
+    return graph
+
+
+def _node_depth(path: str) -> int:
+    return path.count(" > ")
 
 
 def _report_identity(report: TelemetryReport) -> tuple:
@@ -669,6 +803,11 @@ def build_server() -> FastMCP:  # noqa: D103  # tracked: #288
     def critical_path(path: str, telemetry_path: str, top: int = 10) -> CriticalPathEvidence:
         """Return a graph's critical path after binding it to normalized telemetry."""
         return summarize_critical_path(path, telemetry_path, top=top)
+
+    @mcp.tool()
+    def trace_breakdown(path: str, telemetry_path: str, top: int = 10) -> TraceBreakdown:
+        """Return a graph's call structure and representative request waterfall."""
+        return summarize_trace_breakdown(path, telemetry_path, top=top)
 
     return mcp
 

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from collections.abc import Callable, Iterable  # noqa: TC003  # tracked: #288
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol, TextIO, TypeVar, cast
@@ -82,6 +84,32 @@ _PROVIDER_CLASSES: dict[str, _ProviderFactory] = {
 _MAX_CODEX_SESSION_TURNS = 2
 _MAX_CODEX_SESSION_INPUT_TOKENS = 10_000_000
 _MAX_CODEX_SESSION_DURATION_MS = 600_000
+
+_PYTHON_MCP_COMMANDS = frozenset({"python", "python3"})
+
+
+def _resolve_mcp_interpreter(
+    servers: list[MCPServerSpec], *, in_container: bool
+) -> list[MCPServerSpec]:
+    """Pin ``python`` MCP servers to the interpreter running VibeSys.
+
+    A host agent inherits an interactive login shell's environment, not the
+    launcher's, so a bare ``python`` resolves against the user's PATH and may
+    be missing or lack ``mcp``/``pydantic``. The CLI then fails to spawn the
+    stdio server and the agent silently loses its tools (profiler analysis,
+    issue board). The interpreter running VibeSys always has those
+    dependencies, and the host sandbox already imports ``sys.prefix`` and
+    ``sys.base_prefix`` read-only. Container executors keep ``python``: the
+    image provides its own and a host interpreter path does not exist there.
+    """
+    if in_container:
+        return servers
+    return [
+        replace(server, command=sys.executable)
+        if server.command in _PYTHON_MCP_COMMANDS
+        else server
+        for server in servers
+    ]
 
 
 def _is_missing_codex_rollout(exc: RuntimeError) -> bool:
@@ -424,6 +452,7 @@ class CliAgentRunner:
         #    for claude/gemini/opencode, runtime --config flags for codex).
         #    Wrapped in try/finally so a crash in generate() still cleans up.
         if mcp_servers:
+            mcp_servers = _resolve_mcp_interpreter(mcp_servers, in_container=_in_container)
             agent.install_mcp_servers(workspace, mcp_servers)
 
         log_and_print(

--- a/src/vibesys/agents/host_resource_declarations.py
+++ b/src/vibesys/agents/host_resource_declarations.py
@@ -44,9 +44,34 @@ def _resources(
     return tuple(HostResource(path, access, purpose) for path in paths)
 
 
+def _interpreter_alias_roots() -> set[Path]:
+    """Symlinked directories the interpreter is reached through.
+
+    A virtualenv's ``bin/python`` often reaches its base install through an
+    alias directory (uv keeps ``cpython-3.14`` pointing at ``cpython-3.14.7``).
+    ``sys.base_prefix`` is already symlink-resolved, so importing it alone
+    leaves the alias dangling inside the sandbox and every ``sys.executable``
+    exec fails with ENOENT: the agent then loses its stdio MCP servers.
+    Importing the alias directory itself binds the real install under the name
+    the interpreter actually walks.
+    """
+    roots: set[Path] = set()
+    current = Path(sys.executable)
+    seen: set[Path] = set()
+    while current.is_symlink() and current not in seen:
+        seen.add(current)
+        target = current.readlink()
+        current = target if target.is_absolute() else current.parent / target
+        roots.update(parent for parent in current.parents if parent.is_symlink())
+    return roots
+
+
 def _python_runtime(ctx: HostResourceContext) -> Iterable[HostResource]:
     del ctx
-    return _resources((Path(sys.base_prefix), Path(sys.prefix)), purpose="Python runtime")
+    return _resources(
+        (Path(sys.base_prefix), Path(sys.prefix), *sorted(_interpreter_alias_roots())),
+        purpose="Python runtime",
+    )
 
 
 def _path_toolchain(ctx: HostResourceContext) -> Iterable[HostResource]:

--- a/src/vibesys/prompts/loops/agent/profilers/otel.j2
+++ b/src/vibesys/prompts/loops/agent/profilers/otel.j2
@@ -38,23 +38,39 @@ Benchmark command: {{ benchmark_command }}
 1. Run the trusted benchmark command as configured by the input bundle. A
    critical-path run uses `servicebench trace` and produces both a normalized
    telemetry report and a versioned trace graph for the same measurement
-   windows.
-2. Call the `{{ profiler_mcp_name }}` MCP tools to read the evidence: `reports()`
-   to locate normalized reports, then `summary(path=...)`. Call
-   `trace_graphs()` to locate schema-v2 graphs, then
-   `critical_path(path=..., telemetry_path=...)` for bounded wall-clock
-   attribution. The tool rejects a graph unless its workload identity and
-   exact measurement windows match the normalized report.
+   windows. The command's `--telemetry-output` and `--trace-graph-json`
+   arguments name those two artifact paths: read them from the benchmark
+   command above and pass them to the tools directly. Artifacts a previous
+   round wrote outside this workspace (for example under `/tmp`) are not
+   visible to this turn, so produce them in this turn or use evidence retained
+   under the round artifact directory.
+2. Call the `{{ profiler_mcp_name }}` MCP tools to read the evidence:
+   `summary(path=...)` for ranked service, span, and datastore latency;
+   `trace_breakdown(path=..., telemetry_path=...)` for the call graph with
+   inclusive/exclusive latency per node and the representative request
+   waterfall; `critical_path(path=..., telemetry_path=...)` for bounded
+   wall-clock attribution. Use `reports()` and `trace_graphs()` only to
+   discover artifacts whose paths you do not already know; pass
+   `root=<artifact directory>` when they are not below the workspace. Both
+   graph tools reject a graph unless its workload identity and exact
+   measurement windows match the normalized report.
 3. Rank bottlenecks using concrete service, span, and datastore p50/p95/p99
-   values, error counts, and critical-path contribution. Use graph paths and
-   representative segments to distinguish sequential work from overlapping
-   calls; do not add overlapping sibling durations.
+   values, error counts, and critical-path contribution. Use graph paths,
+   the inclusive/exclusive split, and representative segments to distinguish
+   sequential work from overlapping calls:
+   do not add overlapping sibling durations. A node with high inclusive but low
+   exclusive latency is waiting on a callee, so name the callee as the
+   bottleneck.
 4. Use `compare()` when both baseline and candidate reports exist. Read each
    run's critical path separately and compare only graphs with matching
    workload identity and window count. Treat large
    span-count changes as a possible coverage or sampling change.
 5. Report the benchmark's declared `primary_value` as `perf_metric`; internal
    span latency is diagnostic evidence, not the scored result.
+6. In `analysis`, show the request breakdown you actually measured: the
+   representative waterfall as ordered `offset_ms +duration_ms service:operation`
+   lines, and the critical-path contributors with their share of root latency.
+   Report `omitted_*` counts when the bounded views truncate evidence.
 
 The critical path has scope `synchronous_request`. Report
 `async_relationships_excluded` and trace eligibility when they limit coverage.

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -1778,9 +1779,36 @@ class TestCliAgentRunner:
         # Strict ordering: install before generate before uninstall.
         assert agent.event_log == ["install", "generate", "uninstall"]
         assert agent.install_calls[0]["workspace"] == workspace
-        assert agent.install_calls[0]["servers"] == [spec]
+        # A host run pins the interpreter; install and uninstall see one spec.
+        installed = agent.install_calls[0]["servers"]
+        assert [server.name for server in installed] == [spec.name]
+        assert installed[0].command == sys.executable
         assert agent.uninstall_calls[0]["workspace"] == workspace
-        assert agent.uninstall_calls[0]["servers"] == [spec]
+        assert agent.uninstall_calls[0]["servers"] == installed
+
+    def test_mcp_interpreter_resolution_is_host_only_and_python_only(self):  # noqa: ANN201  # tracked: #288
+        """Host runs pin ``python``; containers and other commands are untouched."""
+        from vibesys._agent_cli.base import MCPServerSpec  # noqa: PLC0415  # tracked: #288
+        from vibesys.agents.cli_runner import _resolve_mcp_interpreter  # noqa: PLC0415
+
+        servers = [
+            MCPServerSpec(name="issues", command="python", args=["-m", "x"]),
+            MCPServerSpec(name="profiler", command="python3", args=["p/server.py"]),
+            MCPServerSpec(name="other", command="node", args=["server.js"]),
+        ]
+
+        host = _resolve_mcp_interpreter(servers, in_container=False)
+        container = _resolve_mcp_interpreter(servers, in_container=True)
+
+        assert [server.command for server in host] == [
+            sys.executable,
+            sys.executable,
+            "node",
+        ]
+        # Args and names survive the rewrite, and the container image keeps
+        # resolving ``python`` itself.
+        assert [server.args for server in host] == [server.args for server in servers]
+        assert container == servers
 
     def test_cli_runner_uninstalls_even_when_generate_raises(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """uninstall_mcp_servers must run in finally so a crashing generate

--- a/tests/agents/test_host_resource_declarations.py
+++ b/tests/agents/test_host_resource_declarations.py
@@ -30,6 +30,37 @@ class TestInstallRoot:
         )
 
 
+class TestInterpreterAliasRoots:
+    """A venv reached through an alias directory must import that alias."""
+
+    def test_alias_directory_between_venv_and_install_is_declared(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        install = tmp_path / "cpython-3.14.7"
+        (install / "bin").mkdir(parents=True)
+        real = install / "bin" / "python3.14"
+        real.write_text("#!/bin/false\n")
+        alias = tmp_path / "cpython-3.14"
+        alias.symlink_to(install)
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").symlink_to(alias / "bin" / "python3.14")
+        (venv_bin / "python3").symlink_to("python")
+        monkeypatch.setattr(host_resource_declarations.sys, "executable", str(venv_bin / "python3"))
+
+        roots = host_resource_declarations._interpreter_alias_roots()  # noqa: SLF001  # tracked: #288
+
+        # The alias, not the resolved install: sys.base_prefix already covers
+        # the resolved path, and only the alias name dangles in the sandbox.
+        assert roots == {alias}
+
+    def test_no_alias_declares_nothing_extra(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        real = tmp_path / "usr" / "bin" / "python3.14"
+        real.parent.mkdir(parents=True)
+        real.write_text("#!/bin/false\n")
+        monkeypatch.setattr(host_resource_declarations.sys, "executable", str(real))
+
+        assert host_resource_declarations._interpreter_alias_roots() == set()  # noqa: SLF001  # tracked: #288
+
+
 def test_defaults_declare_path_rust_and_shell_resources(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     home = tmp_path / "home"
     tool_bin = home / "tools" / "bin"

--- a/tests/loops/agent/test_prompt_domain_leakage.py
+++ b/tests/loops/agent/test_prompt_domain_leakage.py
@@ -290,6 +290,9 @@ def test_microservice_otel_profiler_uses_critical_path_as_diagnostic_evidence():
 
     assert "trace_graphs()" in rendered
     assert "critical_path(path=..., telemetry_path=...)" in rendered
+    assert "trace_breakdown(path=..., telemetry_path=...)" in rendered
+    assert "representative waterfall" in rendered
+    assert "--trace-graph-json" in rendered
     assert "async_relationships_excluded" in rendered
     assert "do not add overlapping sibling durations" in rendered
     assert "primary_value" in rendered

--- a/tests/loops/test_profiler_mcp.py
+++ b/tests/loops/test_profiler_mcp.py
@@ -187,7 +187,14 @@ class TestOtelMcpServer:
     def test_registers_expected_tools(self, otel_server_mod):  # noqa: ANN001, ANN201  # tracked: #288
         server = otel_server_mod.build_server()
         names = asyncio.run(_list_tool_names(server))
-        assert names == {"reports", "summary", "compare", "trace_graphs", "critical_path"}
+        assert names == {
+            "reports",
+            "summary",
+            "compare",
+            "trace_graphs",
+            "critical_path",
+            "trace_breakdown",
+        }
 
     def test_discovers_and_summarizes_critical_path(self, otel_server_mod, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         report_path = tmp_path / "telemetry.json"
@@ -230,6 +237,91 @@ class TestOtelMcpServer:
 
         assert result["workload_name"] == "hotel"
         assert result["roots"][0]["nodes_by_contribution"][0]["service"] == "search"
+
+    def test_trace_breakdown_returns_call_graph_and_waterfall(
+        self, otel_server_mod: ModuleType, tmp_path: Path
+    ) -> None:
+        graph_path = tmp_path / "trace-graph.json"
+        report_path = tmp_path / "telemetry.json"
+        graph_path.write_text(json.dumps(_trace_graph()))
+        report_path.write_text(json.dumps(_otel_report(20.0)))
+
+        breakdown = otel_server_mod.summarize_trace_breakdown(
+            str(graph_path), str(report_path), top=10
+        )
+
+        root = breakdown.roots[0]
+        assert [(node.node_id, node.depth) for node in root.nodes] == [
+            ("node-001", 0),
+            ("node-002", 1),
+        ]
+        assert root.nodes[0].inclusive_latency_ms.mean_ms == 20.0
+        assert root.nodes[0].exclusive_latency_ms.mean_ms == 5.0
+        assert (root.omitted_node_count, root.omitted_edge_count) == (0, 0)
+        assert [edge.from_node for edge in root.edges] == ["node-001"]
+        waterfall = root.representative_trace
+        assert [(span.offset_ms, span.duration_ms) for span in waterfall.spans] == [
+            (0.0, 20.0),
+            (5.0, 15.0),
+        ]
+        assert waterfall.omitted_span_count == 0
+
+    def test_trace_breakdown_bounds_output_and_keeps_the_costly_nodes(
+        self, otel_server_mod: ModuleType, tmp_path: Path
+    ) -> None:
+        graph_path = tmp_path / "trace-graph.json"
+        report_path = tmp_path / "telemetry.json"
+        graph_path.write_text(json.dumps(_trace_graph()))
+        report_path.write_text(json.dumps(_otel_report(20.0)))
+
+        breakdown = otel_server_mod.summarize_trace_breakdown(
+            str(graph_path), str(report_path), top=1
+        )
+
+        root = breakdown.roots[0]
+        # Ranking is by inclusive p95, so the cheap leaf is what gets dropped,
+        # and an edge to a dropped node cannot dangle.
+        assert [node.node_id for node in root.nodes] == ["node-001"]
+        assert (root.omitted_node_count, root.omitted_edge_count) == (1, 1)
+        assert root.edges == []
+        assert [span.duration_ms for span in root.representative_trace.spans] == [20.0]
+        assert root.representative_trace.omitted_span_count == 1
+
+    def test_trace_breakdown_tool_rejects_a_graph_from_another_workload(
+        self, otel_server_mod: ModuleType, tmp_path: Path
+    ) -> None:
+        graph_path = tmp_path / "trace-graph.json"
+        report_path = tmp_path / "telemetry.json"
+        graph = _trace_graph()
+        graph["workload_hash"] = "def456"
+        graph_path.write_text(json.dumps(graph))
+        report_path.write_text(json.dumps(_otel_report(20.0)))
+
+        with pytest.raises(ValueError, match="matching workload identity and windows"):
+            otel_server_mod.summarize_trace_breakdown(str(graph_path), str(report_path))
+
+    def test_trace_breakdown_tool_returns_structured_summary(
+        self, otel_server_mod: ModuleType, tmp_path: Path
+    ) -> None:
+        graph_path = tmp_path / "trace-graph.json"
+        report_path = tmp_path / "telemetry.json"
+        graph_path.write_text(json.dumps(_trace_graph()))
+        report_path.write_text(json.dumps(_otel_report(20.0)))
+
+        server = otel_server_mod.build_server()
+        result = asyncio.run(
+            _call_structured_tool(
+                server,
+                "trace_breakdown",
+                path=str(graph_path),
+                telemetry_path=str(report_path),
+                top=10,
+            )
+        )
+
+        assert result["workload_name"] == "hotel"
+        assert result["roots"][0]["representative_trace"]["trace_id"] == "trace-a"
+        assert result["roots"][0]["nodes"][1]["service"] == "search"
 
     def test_critical_path_rejects_graph_from_another_measurement_window(
         self, otel_server_mod: ModuleType, tmp_path: Path


### PR DESCRIPTION
## Problem

Follow-up to #339, advancing #318.

#339 landed the producer side: `servicebench trace` emits a versioned trace
graph with critical-path evidence, and the otel profiler MCP server exposes
bounded views of it. What it did not do is make that evidence reachable from a
profiler turn. On a Linux host the loop could not consume any of it, and the
failure was silent: the profiler agent ran, found no tools, and fell back to
reasoning from the scalar benchmark number alone.

Three defects, all in the seam between the loop and the evidence.

1. **The profiler MCP server never started.** `mcp_spec` in
   `loops/profiler.py` emits `MCPServerSpec(command="python", ...)`. The CLI
   agent resolves its environment through `bash -i -c env`, so `python` binds
   to whatever the login shell's PATH provides, not the interpreter running
   VibeSys. The server exited with `ModuleNotFoundError: No module named
   'mcp'`, and the agent lost every profiler tool with no error surfaced to
   the loop.

2. **Pinning the interpreter was not sufficient under bubblewrap.** A uv
   virtualenv reaches its base install through an alias directory
   (`cpython-3.14` -> `cpython-3.14.7`), while `sys.base_prefix` is already
   symlink-resolved. Importing only the resolved prefix leaves the alias
   dangling inside the sandbox, so every `sys.executable` exec failed with
   ENOENT.

3. **The bounded tools exposed rankings but no structure.** `critical_path`
   returns ordered contributors; nothing let the agent see call topology or
   per-request timing. Issue #318 asks for an agent that can cite *which*
   services and operations control end-to-end latency, which needs the shape
   of the request, not just a leaderboard.

## Solution

1. `_resolve_mcp_interpreter` in `agents/cli_runner.py` rewrites `python` and
   `python3` MCP server commands to `sys.executable` on host runs. Container
   executors are left untouched: their `python` is the correct one inside the
   image, and the host interpreter path does not exist there.

2. `_interpreter_alias_roots` in `agents/host_resource_declarations.py` walks
   the symlink chain from `sys.executable` and declares any symlinked ancestor
   directories as host resources. This binds the real install under the name
   the interpreter actually walks. Only directories are declared; binding the
   individual hop files makes bwrap fail to create the mount point.

3. A new `trace_breakdown(path, telemetry_path, top)` MCP tool returns a
   depth-ordered call graph (inclusive and exclusive latency per node, edges
   restricted to retained nodes) plus the representative trace's waterfall,
   with explicit omitted-node and omitted-span counts so truncation is never
   silent. It reuses the same workload-identity binding as `summary`,
   `compare`, and `critical_path`: a graph is only reported when it shares
   workload name, hash, and measurement windows with the telemetry report.

4. The otel profiler prompt now names `trace_breakdown` alongside the other
   evidence tools, demotes `reports()`/`trace_graphs()` to discovery, states
   that artifacts written outside the workspace (for example under `/tmp`) are
   not visible to a later turn, explains that high inclusive with low exclusive
   latency means waiting on a callee, and requires the analysis to include the
   representative waterfall as ordered `offset_ms +duration_ms
   service:operation` lines.

### Architecture

No ownership changes. The producer boundary (Go, `servicebench`) and the
consumer boundary (Python, profiler MCP server) are unchanged; this repairs
the process-launch path between the loop and the server, and adds one tool
behind the existing artifact-validation helper.

```mermaid
flowchart LR
  subgraph go["servicebench (Go)"]
    T["trace mode"] --> A["telemetry.json + trace-graph.json"]
  end
  subgraph loop["VibeSys loop"]
    P["profiler round"] --> C["cli_runner"]
    C -->|"MCPServerSpec(command=python)"| R{"_resolve_mcp_interpreter"}
    R -->|"host: sys.executable"| M["otel profiler MCP server"]
    R -->|"container: unchanged"| M
  end
  subgraph sandbox["agent host sandbox"]
    H["_interpreter_alias_roots"] -.->|"binds alias dirs"| M
  end
  A --> M
  M -->|"summary / trace_breakdown / critical_path"| G["profiler agent"]
  G --> S["ProfilerSummary"]
```

## Verification

### Correctness properties

- A graph is summarized only when it shares workload name, hash, and
  measurement windows with the telemetry report. `trace_breakdown` goes
  through the same `_bound_graph_to_report` helper as the existing tools, so a
  graph from another workload is rejected rather than silently mixed.
- Bounding is disclosed, not hidden. Roots, nodes, and waterfall spans are each
  capped at `top`, and every truncation is accompanied by an
  `omitted_*_count`, so an agent cannot mistake a truncated view for a complete
  one.
- Node retention is by p95 inclusive latency, but presentation is by depth,
  so the returned graph reads as a call structure rather than a ranking. Edges
  are filtered to retained nodes, so no edge references a node that was
  dropped.
- Interpreter pinning is host-only and Python-only. Non-Python MCP commands
  and all container executors keep their declared command verbatim.
- Alias declaration adds directories only, and only those that are actually
  symlinks. An interpreter with no alias in its chain declares nothing extra,
  so the sandbox is not widened on ordinary installs.

### Testing

Automated:

```
uv run pytest -q --no-cov
  4054 passed, 8 skipped, 1 failed in 4:29
```

The single failure is `tests/test_tui.py::test_cli_parse_failure_is_streamed_after_client_attaches`,
which is pre-existing and unrelated: it fails identically on a clean `main`
with these changes stashed.

```
uv run ruff check .        All checks passed
uv run ruff format --check All formatted
```

New tests: `trace_breakdown` returns a call graph and waterfall, bounds its
output while keeping the costly nodes, rejects a graph from another workload,
and returns a structured summary; the profiler tool set assertion now includes
it; interpreter resolution is host-only and Python-only; the runner sandwich
test asserts the installed spec carries the pinned interpreter; alias-root
declaration is covered with and without an alias present. Prompt leakage tests
assert the new tool signature, `representative waterfall`, and
`--trace-graph-json`.

Manual, end to end:

A microservices `evolve` run under a real bubblewrap sandbox reached the
profiler round, the MCP server started, and the agent called `summary`,
`trace_breakdown`, and `critical_path`, then produced a `ProfilerSummary`
citing specific critical-path evidence. Abbreviated from the run log:

```
=== Profiler ROUND START ===
→ mcp__vibesys-otel-profiler__summary(path=".../telemetry.json", top=15)
→ mcp__vibesys-otel-profiler__trace_breakdown(path=".../trace-graph.json",
    telemetry_path=".../telemetry.json", top=15)
→ mcp__vibesys-otel-profiler__critical_path(path=".../trace-graph.json",
    telemetry_path=".../telemetry.json", top=15)
```

From the resulting analysis:

```
Representative waterfall for trace-00062 (total 82.52ms):
  0.00 +82.52 frontend:GET /hotels;  0.63 +71.58 search:Nearby;
  1.19  +8.91 geo:Nearby;            1.41  +7.15 geo:mongo.find;
 10.77 +59.79 rate:GetRates;        11.02  +0.61 rate:memcached.get;
 11.73 +57.18 rate:mongo.find;      72.97  +8.55 profile:GetProfiles;
 ...
This single trace shows rate:mongo.find alone consuming 57.18ms of the
82.52ms root (69%). Aggregated critical-path contribution ranks
rate:mongo.find first: mean 38.89ms per occurrence, firing on 115/240
traces (47.9%), i.e. a memcached miss in the rate service.
```

The agent also disclosed coverage limits without prompting
(`async_relationships_excluded=480`, `unmatched_client_spans=880`) and
declined to convert contribution into a speedup ceiling, citing the absence of
an uninstrumented control. That is the behavior #318 asks for in its final two
acceptance criteria.

Not covered: this end-to-end run replayed a recorded OTLP capture through the
real `cmd/otelcapture` pipeline rather than driving a live Docker cluster, so
the Go producer, MCP tools, prompt, and agent reasoning are all exercised but
cluster spin-up is not. Two environment issues blocked a live run and are
worth separate follow-ups:

- The hotel-reservation task in the DeathStarBench submodule writes
  `--telemetry-output` and `--trace-graph-json` under `/tmp`, which the agent
  sandbox masks with a private tmpfs. The artifacts survive the turn that
  writes them but are invisible to later turns and to `reports()` discovery.
- The agent sandbox binds no Docker socket. `VIBESYS_AGENT_SANDBOX_ALLOW`
  does work for this (a read-only bind of a unix socket still permits
  `connect()`, verified directly), but it is documented nowhere, so the
  microservices domain fails under the default sandbox with an error that
  looks like a Docker problem rather than a sandbox policy one.

### Issue progress

Advances #318 rather than closing it. Lands the two integration criteria
("VibeSys discovers the versioned JSON artifact through the existing profiler
boundary and includes a bounded summary" and "an end-to-end microservice
evaluation demonstrates an agent citing specific critical-path evidence"),
with the caveat above that the end-to-end run used a recorded capture.

