### PR TITLE
Profile the cold start so the first plan is not chosen blind

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -733,6 +733,12 @@ def _is_fresh_cold_start(round_number: int, records: list[RoundRecord]) -> bool:
     return round_number == 1 and not records
 
 
+# The focus a round asks for when nothing more specific has been established:
+# a cold start has no hypothesis to narrow it, and a pre-round decision may
+# request a profile without naming one.
+DEFAULT_PROFILE_FOCUS = "general steady-state benchmark hotspots"
+
+
 def _run_pre_round_decision(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
@@ -2181,7 +2187,26 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                 pre_decision: PreRoundDecision | None = None
                 if active_hypothesis is None:
                     if inner_loop == "multi-agent":
-                        if not _is_fresh_cold_start(round_number, records):
+                        if _is_fresh_cold_start(round_number, records):
+                            # A cold start has no prior round to reason about,
+                            # so there is no pre-round decision to make. It is
+                            # also the round holding the least evidence, so an
+                            # attached profiler runs unconditionally: the first
+                            # plan is then chosen from measurement instead of
+                            # from the objective text alone. ``evolve`` profiles
+                            # its generation-0 seed for the same reason.
+                            if ctx.profiler_kind is not ProfilerKind.NONE:
+                                profiler_summary = _run_profiler(
+                                    ctx,
+                                    round_number=round_number,
+                                    profile_focus=DEFAULT_PROFILE_FOCUS,
+                                    modality=modality,
+                                    interface=interface,
+                                    domain_definition=domain_definition,
+                                    progress_path=progress_path,
+                                    objective=objective,
+                                )
+                        else:
                             pre_decision = _run_pre_round_decision(
                                 ctx,
                                 round_number=round_number,
@@ -2198,7 +2223,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                                     ctx,
                                     round_number=round_number,
                                     profile_focus=pre_decision.profile_focus
-                                    or "general steady-state benchmark hotspots",
+                                    or DEFAULT_PROFILE_FOCUS,
                                     modality=modality,
                                     interface=interface,
                                     domain_definition=domain_definition,

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -1800,7 +1800,8 @@ def test_implementer_skill_updates_survive_a_renewed_continuation_prompt(tmp_pat
     plan_path = calls[1].kwargs["workspace"] / "progress-artifacts" / "plans" / "round-0002.json"
     persisted = OrchestratorPlan.model_validate_json(plan_path.read_text())
     assert persisted.recommended_skills == [selection]
-    assert runner.counters["prof"] == 0
+    # Only the cold-start baseline profile; no pre-round decision asked for more.
+    assert runner.counters["prof"] == 1
 
 
 def test_loop_judge_retry_then_pass(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
@@ -2813,7 +2814,7 @@ def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):  # 
             PreRoundDecision(need_profile=True, profile_focus="kernels", reasoning="need data"),
         ],
         plans=[
-            # Round 1 cold-start plan (no pre-decision invoked on round 1).
+            # Round 1 cold-start plan (baseline profile, no pre-decision).
             OrchestratorPlan(
                 task="Build server",
                 pass_criteria="ok",  # noqa: S106  # tracked: #288
@@ -2853,18 +2854,19 @@ def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):  # 
 
     result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=2)
     assert result is True
-    # Round 1 cold-start: no pre → just plan.
+    # Round 1 cold-start: profiler (unconditional baseline) → plan, no pre.
     # Round 2: pre → profiler → plan.
-    assert call_order[:1] == ["plan"]
-    assert "profiler" in call_order
+    assert call_order == ["profiler", "plan", "pre", "profiler", "plan"]
     plan_idx = [i for i, c in enumerate(call_order) if c == "plan"]
-    prof_idx = call_order.index("profiler")
-    # Profiler must come BEFORE the round-2 plan call.
-    assert prof_idx < plan_idx[1]
-    assert "Recent campaign context" in profiler_prompts[0]
-    assert "The durable progress artifact is `progress.md`" in profiler_prompts[0]
-    assert "Round 1" not in profiler_prompts[0]
-    assert "Do not launch a duplicate expensive evaluation" in profiler_prompts[0]
+    prof_idx = [i for i, c in enumerate(call_order) if c == "profiler"]
+    # Each round's profiler must come BEFORE that round's plan call.
+    assert prof_idx[0] < plan_idx[0]
+    assert prof_idx[1] < plan_idx[1]
+    for prompt in profiler_prompts:
+        assert "Recent campaign context" in prompt
+        assert "The durable progress artifact is `progress.md`" in prompt
+        assert "Round 1" not in prompt
+        assert "Do not launch a duplicate expensive evaluation" in prompt
 
 
 def test_loop_skips_profiler_when_pre_round_decision_says_no(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
@@ -2882,7 +2884,58 @@ def test_loop_skips_profiler_when_pre_round_decision_says_no(tmp_path, ref_file)
 
     assert result is True
     assert runner.counters["orch_pre"] == 1
-    assert runner.counters["prof"] == 0
+    # The round-1 baseline still runs; round 2 declined, so it stops at one.
+    assert runner.counters["prof"] == 1
+
+
+def test_loop_profiles_the_cold_start_before_its_first_plan(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """Round 1 profiles unconditionally so the first plan is not chosen blind.
+
+    A fresh cold start has no prior round, so no pre-round decision runs and
+    nothing can request a profile. Without an unconditional baseline the first
+    optimization would be selected from the objective text alone.
+    """
+    call_order: list[str] = []
+    plan_prompts: list[str] = []
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                task="Cut the measured hotspot",
+                pass_criteria="ok",  # noqa: S106  # tracked: #288
+                reasoning="baseline profile named it",
+            ),
+        ],
+        profiler_responses=[
+            ProfilerSummary(
+                analysis="decode is launch-bound",
+                bottlenecks="host-side sync",
+                suggestions="cuda graph",
+                perf_metric=5.0,
+                perf_unit="req/s",
+            ),
+        ],
+    )
+    real_invoke = runner.invoke.side_effect
+
+    def spy_invoke(*, kind, response_cls, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
+        if kind == "profiler":
+            call_order.append("profiler")
+        elif kind == "orchestrator" and response_cls is OrchestratorPlan:
+            call_order.append("plan")
+            plan_prompts.append(kwargs.get("system_prompt", ""))
+        elif kind == "orchestrator" and response_cls is PreRoundDecision:
+            call_order.append("pre")
+        return real_invoke(kind=kind, response_cls=response_cls, **kwargs)
+
+    runner.invoke.side_effect = spy_invoke
+
+    result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1)
+
+    assert result is True
+    assert call_order == ["profiler", "plan"]
+    assert runner.counters["orch_pre"] == 0
+    # The baseline must reach the planner, not merely have been collected.
+    assert "The fresh profiler result is recorded" in plan_prompts[0]
 
 
 def test_loop_skips_profiler_when_profiler_kind_is_none(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
@@ -2945,7 +2998,8 @@ def test_loop_generic_auto_profiler_resolves_to_macos_cpu(tmp_path, ref_file):  
 
     assert result is True
     assert runner.counters["orch_pre"] == 1
-    assert runner.counters["prof"] == 1
+    # Round-1 baseline plus the round-2 profile the pre-round decision asked for.
+    assert runner.counters["prof"] == 2
 
 
 def test_loop_runs_full_max_rounds_budget(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288


### PR DESCRIPTION
## Problem

Round 1 of a fresh `agent` run never profiled, so the first optimization of
every campaign was chosen without measurement.

`_is_fresh_cold_start` gated two things at once:

```python
if not _is_fresh_cold_start(round_number, records):
    pre_decision = _run_pre_round_decision(...)
    if pre_decision.need_profile and ctx.profiler_kind is not ProfilerKind.NONE:
        profiler_summary = _run_profiler(...)
```

Skipping the pre-round decision on a cold start is correct: it reasons about
prior rounds, and there are none. But nesting the profiler inside that skip is
backwards. Round 1 holds the least evidence of any round, and it is the one
round where nothing *can* request a profile, because requesting one is the
pre-round decision's job. The orchestrator then picked its first plan from the
objective text and a source read alone.

For the microservices domain this is what made trace-graph and critical-path
evidence unavailable exactly when the first plan was chosen, even with
`--profiler otel` passed. Related to #318; complements #360, which fixed the
separate problem that a profiler round could not read that evidence at all.

## Solution

On a fresh cold start, run an attached profiler unconditionally with the
default focus, and skip only the pre-round decision.

```python
if _is_fresh_cold_start(round_number, records):
    if ctx.profiler_kind is not ProfilerKind.NONE:
        profiler_summary = _run_profiler(..., profile_focus=DEFAULT_PROFILE_FOCUS)
else:
    pre_decision = _run_pre_round_decision(...)
    ...
```

The summary reaches that round's orchestrator plan through the existing
`profiler_summary` parameter, so the first plan is chosen from measurement.
`evolve` already profiles its generation-0 seed for this reason; this brings
the `agent` loop in line with it.

The inline default focus string is now the module constant
`DEFAULT_PROFILE_FOCUS`, shared by the cold-start call and the existing
fallback for a pre-round decision that requests a profile without naming a
focus.

### Architecture

No new components and no new control flow. One existing call site moves out
from under a guard it did not belong to.

```mermaid
flowchart TD
  R{"fresh cold start?"}
  R -->|"yes (was: skip everything)"| P1["_run_profiler(DEFAULT_PROFILE_FOCUS)"]
  R -->|no| D["_run_pre_round_decision"]
  D --> N{"need_profile and profiler attached?"}
  N -->|yes| P2["_run_profiler(decision focus)"]
  N -->|no| O
  P1 --> O["_run_orchestrator_plan(profiler_summary=...)"]
  P2 --> O
```

## Verification

### Correctness properties

- Runs with no profiler are unchanged. The invocation stays gated on
  `ctx.profiler_kind is not ProfilerKind.NONE`, so the extra turn is only spent
  by runs that explicitly asked for profiling.
- The pre-round decision is still skipped on a cold start. `orch_pre` call
  counts are unchanged for every existing scenario.
- A cold start that cannot be profiled degrades rather than fails.
  `_run_profiler` already catches and returns `None` on error, and falls back
  to a structured "profiler produced no structured response" summary, so round
  1 behaves as it does today when profiling is not yet possible.
- Resumed runs do not re-profile. `_is_fresh_cold_start` requires an empty
  round-record list, so only a genuinely fresh run triggers the baseline.
- The baseline reaches the planner rather than merely being collected. The new
  test asserts the round-1 orchestrator prompt carries the profiler section.

### Testing

```
uv run pytest tests/loops/agent -q --no-cov     263 passed
uv run pytest -q --no-cov                       4048 passed, 8 skipped, 1 failed
uv run ruff check                               All checks passed
uv run ruff format --check                       already formatted
```

The single full-suite failure is
`tests/test_tui.py::test_cli_parse_failure_is_streamed_after_client_attaches`,
pre-existing and unrelated: it fails identically on a clean `main`.

New test: `test_loop_profiles_the_cold_start_before_its_first_plan` pins the
call order to `["profiler", "plan"]` on a one-round run, asserts no pre-round
decision was made, and asserts the profiler section appears in the plan prompt.

Four existing tests changed expected profiler call counts, which is the
behavior change itself rather than incidental churn:

| Test | Before | After |
|---|---|---|
| `test_loop_orchestrator_requests_profile_before_plan` | `["plan", ...]` | `["profiler", "plan", "pre", "profiler", "plan"]` |
| `test_loop_skips_profiler_when_pre_round_decision_says_no` | `prof == 0` | `prof == 1` (baseline only) |
| `test_loop_generic_auto_profiler_resolves_to_macos_cpu` | `prof == 1` | `prof == 2` |
| `test_implementer_skill_updates_survive_a_renewed_continuation_prompt` | `prof == 0` | `prof == 1` |

`test_loop_skips_profiler_when_profiler_kind_is_none` still asserts
`prof == 0`, unchanged, which is the guard that keeps non-profiling runs free
of the new turn.

### Cost

One extra profiler turn per fresh run that has a profiler attached. That is
the intended trade: the alternative is choosing the first change of a campaign
with no measurement at all.
