### PR TITLE
Fix missing run_environment in experiment-service tests

### DIFF
--- a/tests/server/test_experiments.py
+++ b/tests/server/test_experiments.py
@@ -13,7 +13,7 @@ from vibesys.server.experiments import UNIDENTIFIED, apply_baselines, build_expe
 from vibesys.server.protocol import ExperimentQuery
 from vibesys.server.service import SupervisionService
 from vs_loop_state import RoundRecord
-from vs_project import AgentRunConfiguration, PlainRunConfiguration, Project
+from vs_project import AgentRunConfiguration, PlainRunConfiguration, Project, RunEnvironmentRecord
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -200,6 +200,7 @@ def _agent_configuration() -> AgentRunConfiguration:
         judge_every=1,
         official_eval_every=1,
         memory_layout="files",
+        run_environment=RunEnvironmentRecord(name="local"),
     )
 
 
@@ -212,6 +213,7 @@ def _plain_configuration() -> PlainRunConfiguration:
         max_rounds=3,
         max_attempts_per_issue=1,
         max_issues_per_perf_eval=1,
+        run_environment=RunEnvironmentRecord(name="local"),
     )
 
 


### PR DESCRIPTION
## Problem

PR #356 added `run_environment` as a required field on `AgentRunConfiguration` and `PlainRunConfiguration` but missed updating two test helper functions in `tests/server/test_experiments.py`. This breaks both the test suite and type checking on main.

## Solution

Add `run_environment=RunEnvironmentRecord(name="local")` to `_agent_configuration()` and `_plain_configuration()`, matching the convention used by every other test file.

## Verification

`pytest tests/server/test_experiments.py` passes (11/11). The fix matches the pattern used in `test_tui.py`, `test_context.py`, `test_git_tracker.py`, and all loop state-store tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)