### PR TITLE
Add CI check that builds the Docusaurus website

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,17 @@ name: Build and publish release wheels
 on:
   pull_request:
     branches: [main]
+    # Skip the wheel-build matrix (two paid macOS runners plus a Docker
+    # clean-room verification pass) for changes that can't affect native
+    # packaging: pure documentation and the Docusaurus site. Ignored by exact
+    # filename, not `.github/workflows/**`, so edits to this workflow still
+    # run the full matrix. `release` events don't support path filters and
+    # are unaffected.
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - 'website/**'
+      - '.github/workflows/website.yml'
   release:
     types: [published]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,19 +3,27 @@ name: Tests
 on:
   push:
     branches: [main]
-    # Skip CI for pure-documentation changes. Only root-level Markdown and the
-    # docs/ tree are ignored; Markdown under resources/skills/ and test fixtures
-    # is consumed by prompt/skill snapshot tests, so it is deliberately not
-    # listed here. A change touching any non-doc file still runs the full
-    # matrix (paths-ignore skips only when every changed file matches).
+    # Skip CI for changes that can't affect backend correctness:
+    # pure-documentation changes and the Docusaurus site (checked separately
+    # by website.yml). Root-level Markdown, docs/, website/, and the website
+    # workflow itself are ignored by exact name, not `.github/workflows/**`,
+    # so edits to this workflow (or publish.yml) still run the full matrix.
+    # Markdown under resources/skills/ and test fixtures is consumed by
+    # prompt/skill snapshot tests, so it is deliberately not listed here. A
+    # change touching any non-ignored file still runs the full matrix
+    # (paths-ignore skips only when every changed file matches).
     paths-ignore:
       - '*.md'
       - 'docs/**'
+      - 'website/**'
+      - '.github/workflows/website.yml'
   pull_request:
     branches: [main]
     paths-ignore:
       - '*.md'
       - 'docs/**'
+      - 'website/**'
+      - '.github/workflows/website.yml'
 
 jobs:
   format:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,46 @@
+name: Website
+
+# Runs independently of the main Tests workflow, which ignores docs/** and
+# *.md changes to avoid running the full backend matrix on doc-only edits.
+# The Docusaurus docs plugin renders docs/ directly (no copy step) and
+# sidebars.ts hardcodes doc ids against those filenames, so a docs/ change
+# can break the site build without touching website/ at all.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - 'docs/**'
+      - '.github/workflows/website.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - 'docs/**'
+      - '.github/workflows/website.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install website dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Check TypeScript
+        working-directory: website
+        run: npm run typecheck
+
+      - name: Build website
+        working-directory: website
+        run: npm run build


### PR DESCRIPTION
## Problem

The Docusaurus site added in #348 (`website/`) isn't checked by any CI
workflow, and conversely, docs/website-only changes weren't excluded from
workflows that can't be affected by them:

- `test.yml`'s `paths-ignore` only covered `*.md` and `docs/**`, so nothing
  checks that the site actually builds, and `website/**` changes still
  triggered the full Python/Go/Rust/TUI matrix for no reason. The docs
  plugin renders `docs/` directly with no copy step, and `sidebars.ts`
  hardcodes doc ids against those filenames, so a doc rename/delete or a bad
  relative link can break the site build without anyone noticing until a
  manual local build.
- `publish.yml` had no path filter at all, so every PR — including a
  docs/website-only one — ran the full native wheel matrix: two paid macOS
  runners plus a Docker clean-room verification pass. Nothing under `docs/**`
  or `website/**` can affect native wheel packaging.

## Solution

- Add a standalone `Website` workflow
  ([.github/workflows/website.yml](../../.github/workflows/website.yml)) that
  installs the site's npm dependencies, typechecks, and runs
  `docusaurus build`. It's a separate workflow file (not a job in `test.yml`)
  so it can trigger on exactly the paths `test.yml` deliberately excludes,
  without touching that workflow's doc-skip behavior.
- Extend `test.yml`'s `paths-ignore` with `website/**` and
  `.github/workflows/website.yml`.
- Add the same `paths-ignore` (`*.md`, `docs/**`, `website/**`,
  `.github/workflows/website.yml`) to `publish.yml`'s `pull_request` trigger.

All three ignore lists use exact filenames, not `.github/workflows/**`, so
edits to `test.yml` or `publish.yml` themselves still run their own full
matrix — a broad glob would let a broken CI-config change go unvalidated by
the very workflow meant to catch it.

### Architecture

`website.yml`: single `build` job, triggered on push/PR to `main` when
`website/**`, `docs/**`, or the workflow file itself changes. No deploy step
— that's the separate follow-up already called out in #348's description
(GitHub Pages isn't enabled on the repo yet).

`test.yml` / `publish.yml`: no job changes, only the `paths-ignore` lists
gained entries plus updated comments explaining the exact-filename choice.
`publish.yml`'s `release` trigger is untouched — GitHub Actions doesn't
support path filters on `release` events, and this repo's `release` jobs are
already gated to only fire on real releases, not PRs.

## Verification

This PR targets `keisuke/docs-website` (#348) rather than `main`, since
`website/` doesn't exist on `main` until that merges. GitHub will retarget
this PR to `main` automatically once #348 merges and its branch is deleted.

Checked this repo's branch protection and rulesets before touching
`publish.yml`: `gh api repos/uw-syfi/vibesys/branches/main/protection` shows
no `required_status_checks`, and `.../rulesets` is empty, so there's no
required-check gate that could get stuck waiting on a status that now never
posts for a docs/website-only PR.

### Correctness properties

- CI fails if `npm run typecheck` or `npm run build` fails for `website/`.
- A change touching only `website/**`, `docs/**`, or
  `.github/workflows/website.yml` runs `Website` but not the `Tests` backend
  matrix or `publish.yml`'s wheel-build matrix.
- A change touching `test.yml` or `publish.yml` themselves still runs the
  full matrix of the workflow being edited (not exempted by the new
  `paths-ignore` entries).
- `publish.yml`'s `release` trigger and its actual PyPI publish step
  (`if: github.event_name == 'release'`) are unaffected by this change.

### Testing

Ran the exact steps the `Website` workflow runs, locally, against this
branch:

- `cd website && npm ci` — succeeds.
- `npm run typecheck` — succeeds, no errors.
- `npm run build` — `[SUCCESS] Generated static files in "build"`. Only
  warnings are the pre-existing, disclosed broken relative links in
  `docs/development.md` and `docs/running-vibesys.md` (`onBrokenLinks: 'warn'`
  in `docusaurus.config.ts` means these don't fail the build).
- Validated `test.yml` and `publish.yml` YAML with
  `python -c "import yaml; yaml.safe_load(...)"`.
- `gh pr checks 363` before these changes showed the full `Tests` matrix and
  `Build and publish release wheels` (incl. both macOS runners) firing on a
  workflow-file-only diff; confirmed both are excluded by the new
  `paths-ignore` entries while `Website` still runs.
