### PR TITLE
Deploy docs website to docs.vibing.systems via GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,63 @@
+name: Deploy docs website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - 'docs/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one deployment at a time; let an in-flight deploy finish rather than
+# cancel it, so the live site never lands on a half-deployed build.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install website dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Build website
+        working-directory: website
+        run: npm run build
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload build artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: website/build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -13,9 +13,10 @@ const config: Config = {
     v4: true, // Improve compatibility with the upcoming Docusaurus v4
   },
 
-  // Production URL. GitHub Pages for the uw-syfi/vibesys repo.
-  url: 'https://uw-syfi.github.io',
-  baseUrl: '/vibesys/',
+  // Production URL. GitHub Pages for the uw-syfi/vibesys repo, served under
+  // the custom subdomain docs.vibing.systems (see static/CNAME).
+  url: 'https://docs.vibing.systems',
+  baseUrl: '/',
 
   organizationName: 'uw-syfi',
   projectName: 'vibesys',

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+docs.vibing.systems


### PR DESCRIPTION
## Problem

The Docusaurus site added in #348 has no deploy path — GitHub Pages isn't
enabled on this repo, and the site is configured for
`uw-syfi.github.io/vibesys/`, a URL nobody has turned on. #348's description
called this out as a known follow-up.

The org already publishes `vibing.systems` via GitHub Pages from a different
repo (its `CNAME` points elsewhere, so that domain isn't available to this
repo directly — GitHub Pages serves one repo per custom domain, at the
domain root). `docs.vibing.systems` uses the same mechanism this repo can
own outright: one DNS `CNAME` record plus a `CNAME` file in the published
site.

## Solution

- Point `docusaurus.config.ts` at `https://docs.vibing.systems` with
  `baseUrl: '/'` (previously `https://uw-syfi.github.io` /
  `/vibesys/`).
- Add `website/static/CNAME` containing `docs.vibing.systems`, which
  Docusaurus copies into the build root; GitHub Pages reads it to serve the
  custom domain.
- Add `.github/workflows/deploy-docs.yml`: builds the site and publishes it
  via the official `actions/configure-pages` /
  `actions/upload-pages-artifact` / `actions/deploy-pages` flow, triggered on
  push to `main` for `website/**` or `docs/**`, plus `workflow_dispatch` for
  manual redeploys.

### Architecture

Two jobs (`build`, `deploy`) using GitHub's standard Pages-via-Actions
pattern (`environment: github-pages`, `permissions: pages: write, id-token:
write`). `concurrency: group: pages, cancel-in-progress: false` so an
in-flight deploy always finishes rather than getting cut over to a
half-published build.

This does **not** enable GitHub Pages on the repo or touch DNS — both are
external to this diff and are call-outs in Verification below.

## Verification

Rebuilt the site locally with the new config
(`cd website && npm ci && npm run build`): succeeds, routes resolve under
`/docs/...` with no `/vibesys/` prefix, and `build/CNAME` contains
`docs.vibing.systems`. Same pre-existing, disclosed broken-link warnings as
before (relative links in `docs/development.md` / `docs/running-vibesys.md`
that don't resolve inside the docs site); `onBrokenLinks: 'warn'` still
means these don't fail the build.

Validated `deploy-docs.yml`'s YAML with
`python -c "import yaml; yaml.safe_load(...)"`.

**Two manual steps remain outside this PR, both requiring repo/DNS admin
access I don't have:**

1. Add a DNS `CNAME` record: `docs.vibing.systems` → `uw-syfi.github.io`.
2. In the repo's Settings → Pages, set the source to "GitHub Actions" (this
   enables Pages for the first time on this repo). Once DNS has propagated,
   enable "Enforce HTTPS" for the custom domain.

Until both are done, this workflow will build and attempt to deploy but
Pages won't be live at the custom domain.

### Correctness properties

- `website/**` / `docs/**` changes on `main` build and deploy automatically;
  changes on PR branches do not (deploy only runs on `push` to `main`, not
  `pull_request`, so PRs never publish to the live site).
- The existing `Website` workflow (#363) still builds every PR before merge,
  so a broken build is caught pre-merge rather than surfacing only in this
  deploy workflow.

### Testing

- `cd website && npm ci && npm run build` — succeeds, `build/CNAME` present
  and correct.
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-docs.yml'))"`
  — parses.
