### PR TITLE
Split docs site sidebar into user-facing docs and Contributing

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -81,8 +81,8 @@ const config: Config = {
           title: 'Docs',
           items: [
             {label: 'Running VibeSys', to: '/docs/running-vibesys'},
-            {label: 'Development', to: '/docs/development'},
             {label: 'CLI flags', to: '/docs/cli-flags'},
+            {label: 'Contributing', to: '/docs/development'},
           ],
         },
         {

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -7,14 +7,21 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   docsSidebar: [
     'running-vibesys',
-    'development',
     'cli-flags',
-    'coding-best-practices',
-    'extending-profilers',
-    'openevolve',
-    'publishing',
-    'skill-metadata',
-    'issue-authoring',
+    {
+      type: 'category',
+      label: 'Contributing',
+      link: {type: 'doc', id: 'development'},
+      items: [
+        'development',
+        'coding-best-practices',
+        'extending-profilers',
+        'skill-metadata',
+        'openevolve',
+        'issue-authoring',
+        'publishing',
+      ],
+    },
   ],
 };
 


### PR DESCRIPTION
## Problem

The public docs site (docs.vibing.systems, served from `docs/` via Docusaurus)
lists all 9 docs pages flat in one sidebar, with no distinction between docs a
VibeSys *user* needs and docs for people *contributing* to the framework. Only
`running-vibesys` and `cli-flags` are user-facing; the other seven
(`development`, `coding-best-practices`, `extending-profilers`,
`skill-metadata`, `openevolve`, `issue-authoring`, `publishing`) are
contributor or maintainer material — repo layout, coding conventions, CI
gates, release process, issue-filing conventions. The site footer's "Docs"
column made this worse by listing the contributor `development` page
alongside the two user pages as if it were equally primary.

## Solution

Nest the seven contributor/maintainer pages under a "Contributing" sidebar
category, keeping `running-vibesys` and `cli-flags` at the top level. No doc
content changed, only navigation structure in `website/sidebars.ts`. The
category links to `development.md` (already written as the contributor
entry point) so clicking "Contributing" itself is not a dead click.

Also updated the footer's "Docs" column in `website/docusaurus.config.ts` to
list the two user docs plus a link to the new Contributing category, instead
of surfacing `development` as a third peer link.

### Architecture

Purely a Docusaurus navigation change:

- `website/sidebars.ts`: `docsSidebar` array now has `running-vibesys`,
  `cli-flags`, and one `category` node (`Contributing`) wrapping the
  remaining seven doc IDs.
- `website/docusaurus.config.ts`: `footer.links[0].items` (the "Docs" column)
  swaps the `Development` entry for a `Contributing` entry pointing at the
  same `/docs/development` URL (now the category's landing doc).

The docs plugin still serves `docs/` directly (`path: '../docs'`), so no
files moved and doc IDs/URLs are unchanged; this is purely how they're
grouped in the sidebar and footer.

## Verification

Ran `npm ci && npm run build` in `website/`. Build succeeds. The only
warnings are pre-existing broken-link warnings for links from
`development.md`/`running-vibesys.md` to files outside the Docusaurus docs
root (e.g. `../.github/pull_request_template.md`, `../examples/`) — present
before this change and unrelated to the sidebar/footer edit.

### Correctness properties

- No doc content, doc IDs, or doc URLs changed — only sidebar grouping and
  footer links.
- The `Contributing` category remains fully expandable/navigable and still
  contains all seven contributor/maintainer pages.

### Testing

```
cd website && npm ci && npm run build
```
Result: `[SUCCESS] Generated static files in "build".`