### PR TITLE
Let candidates request extra model weights via a workspace manifest

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -1926,6 +1926,33 @@ def _run_framework_benchmark(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracke
     return feedback, None
 
 
+def _reconcile_model_requests(ctx: LoopContext) -> str | None:
+    """Stage any candidate-declared model weights before the framework gates.
+
+    The candidate may declare extra model weights it needs in
+    ``.vibesys/models.json`` (see ``vibesys.sandbox.model_requests``). This runs
+    once per gate invocation, before deploy; a malformed or disallowed manifest
+    is returned as gate feedback so the candidate can correct it rather than
+    crashing the run. Only meaningful for Modal runs (weights live in Modal
+    Volumes); a no-op otherwise.
+    """
+    if getattr(ctx.run_environment_view, "env_kind", "local") != "modal":
+        return None
+    from vibesys.sandbox.model_requests import (  # noqa: PLC0415  # tracked: #288
+        ModelRequestError,
+        reconcile_model_requests,
+    )
+
+    try:
+        volumes = reconcile_model_requests(ctx.workspace, log=ctx.lprint)
+    except ModelRequestError as exc:
+        ctx.lprint(f"[model-request] rejected: {exc}")
+        return f"Model-weight request could not be satisfied: {exc}"
+    if volumes:
+        ctx.lprint(f"[model-request] staged {len(volumes)} model volume(s): " + ", ".join(volumes))
+    return None
+
+
 def _run_framework_gates(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
@@ -1940,6 +1967,9 @@ def _run_framework_gates(  # noqa: PLR0913  # tracked: #288
 ) -> tuple[str | None, float | None, bool]:
     if ctx.agent_runner.backend_name == "stub":
         return None, None, False
+    resource_feedback = _reconcile_model_requests(ctx)
+    if resource_feedback is not None:
+        return resource_feedback, None, False
     if reuse_accuracy_pass:
         feedback = None
         issue_board.append_framework_accuracy_gate(

--- a/src/vibesys/sandbox/model_requests.py
+++ b/src/vibesys/sandbox/model_requests.py
@@ -1,0 +1,149 @@
+"""Candidate-declared model-weight requests.
+
+A candidate may declare additional model weights its implementation needs by
+writing a small manifest to ``.vibesys/models.json`` in its workspace root.
+Between rounds, before the framework deploys the candidate for its accuracy and
+benchmark gates, the framework reads this manifest and ensures each requested
+model is staged into a Modal Volume. Staging is idempotent: a volume that
+already carries the ready sentinel is a no-op, so reconciling every round (and
+again on resume) is cheap and safe.
+
+This is a general resource-request mechanism, deliberately narrow: the manifest
+expresses only *which model weights* the implementation needs. It cannot change
+the measurement envelope (GPU count, GPU type, benchmark configuration), which
+stays operator-owned. An operator may further restrict which repositories are
+permitted via the ``VIBESYS_MODEL_REQUEST_ALLOW`` environment variable (a
+comma-separated list of allowed HuggingFace repo-id prefixes); unset means no
+prefix restriction.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003  # tracked: #288
+
+MODEL_MANIFEST_RELPATH = ".vibesys/models.json"
+_ALLOW_ENV_VAR = "VIBESYS_MODEL_REQUEST_ALLOW"
+
+
+class ModelRequestError(ValueError):
+    """Raised when a model-request manifest is malformed or disallowed."""
+
+
+@dataclass(frozen=True)
+class ModelRequest:
+    """A single requested model: a HuggingFace repo id and optional revision."""
+
+    model_id: str
+    revision: str | None = None
+
+
+def read_model_requests(workspace: Path) -> list[ModelRequest]:
+    """Parse ``.vibesys/models.json`` under *workspace*.
+
+    Accepts either a bare JSON list of entries or an object with a ``"models"``
+    list. Each entry is ``{"id": "<repo-id>", "revision": "<optional>"}`` (the
+    key ``"model_id"`` is accepted as an alias for ``"id"``). Duplicate ids are
+    collapsed, keeping the first occurrence. A missing file yields ``[]``.
+
+    Raises:
+        ModelRequestError: on invalid JSON or an entry that is not a mapping
+            with a non-empty string id (and, if present, a string revision).
+    """
+    path = workspace / MODEL_MANIFEST_RELPATH
+    if not path.exists():
+        return []
+    try:
+        raw = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ModelRequestError(  # noqa: TRY003  # tracked: #288
+            f"{MODEL_MANIFEST_RELPATH} is not valid JSON: {exc}"
+        ) from exc
+
+    entries = raw.get("models") if isinstance(raw, dict) else raw
+    if not isinstance(entries, list):
+        raise ModelRequestError(  # noqa: TRY003  # tracked: #288
+            f"{MODEL_MANIFEST_RELPATH} must be a JSON list of model objects, "
+            'or an object with a "models" list'
+        )
+
+    requests: list[ModelRequest] = []
+    seen: set[str] = set()
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ModelRequestError(  # noqa: TRY003  # tracked: #288
+                f"{MODEL_MANIFEST_RELPATH} entry {index} is not an object"
+            )
+        model_id = entry.get("id") or entry.get("model_id")
+        if not isinstance(model_id, str) or not model_id.strip():
+            raise ModelRequestError(  # noqa: TRY003  # tracked: #288
+                f"{MODEL_MANIFEST_RELPATH} entry {index} needs a non-empty "
+                'string "id" (the HuggingFace repo id)'
+            )
+        revision = entry.get("revision")
+        if revision is not None and not isinstance(revision, str):
+            raise ModelRequestError(  # noqa: TRY003  # tracked: #288
+                f'{MODEL_MANIFEST_RELPATH} entry {index} "revision" must be a string'
+            )
+        model_id = model_id.strip()
+        if model_id in seen:
+            continue
+        seen.add(model_id)
+        requests.append(ModelRequest(model_id=model_id, revision=revision))
+    return requests
+
+
+def _allow_prefixes() -> tuple[str, ...] | None:
+    """Return operator-configured allowed repo-id prefixes, or None if unset."""
+    raw = os.environ.get(_ALLOW_ENV_VAR, "").strip()
+    if not raw:
+        return None
+    return tuple(prefix.strip() for prefix in raw.split(",") if prefix.strip())
+
+
+def check_allowed(model_id: str, allow: tuple[str, ...] | None) -> bool:
+    """Return True if *model_id* is permitted by the *allow* prefix list.
+
+    ``allow=None`` means no prefix restriction (all model ids permitted).
+    """
+    if allow is None:
+        return True
+    return any(model_id.startswith(prefix) for prefix in allow)
+
+
+def reconcile_model_requests(
+    workspace: Path,
+    *,
+    log: Callable[[str], object] = print,
+) -> list[str]:
+    """Ensure every model declared under *workspace* is staged into a Volume.
+
+    Returns the list of provisioned Modal Volume names (empty when the manifest
+    is absent or empty). Idempotent: already-ready volumes are skipped by
+    :func:`vs_sandbox.ensure_model_volume`.
+
+    Raises:
+        ModelRequestError: if the manifest is malformed or requests a model that
+            the operator allowlist does not permit.
+    """
+    requests = read_model_requests(workspace)
+    if not requests:
+        return []
+
+    from vs_sandbox import ensure_model_volume  # noqa: PLC0415  # tracked: #288
+
+    allow = _allow_prefixes()
+    volumes: list[str] = []
+    for request in requests:
+        if not check_allowed(request.model_id, allow):
+            raise ModelRequestError(  # noqa: TRY003  # tracked: #288
+                f"model request {request.model_id!r} is not permitted by "
+                f"{_ALLOW_ENV_VAR}={os.environ.get(_ALLOW_ENV_VAR)!r}"
+            )
+        suffix = f"@{request.revision}" if request.revision else ""
+        log(f"[model-request] ensuring weights for {request.model_id}{suffix}")
+        volumes.append(ensure_model_volume(request.model_id, revision=request.revision, log=log))
+    return volumes

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -898,6 +898,16 @@ def _modal_runtime_notes(
         "Use `modal.Volume.from_name(<that-name>)` and mount it at "
         "whatever container path you prefer (no fixed convention is "
         "required).\n"
+        "  - If your implementation needs model weights beyond those the "
+        "task pre-stages, declare them in `.vibesys/models.json` in your "
+        'workspace root: a JSON list of `{"id": "<huggingface-repo-id>", '
+        '"revision": "<optional>"}` entries (or `{"models": [...]}`). Between '
+        "rounds, before measurement, the framework stages each requested "
+        "repository into its own `vibesys-model-<normalized-id>` Volume using "
+        "the exact naming rule above; mount them the same way. This request "
+        "covers model weights only and cannot change the GPU or benchmark "
+        "configuration. An operator allowlist may restrict which repositories "
+        "are permitted; a rejected request comes back as gate feedback.\n"
         f"  - **The `{reference_path}/` directory (meta.json, config.json, "
         "reference.py) exists ONLY in this local editor container — it is "
         "NOT present inside the deployed Modal container.** Reading "

--- a/tests/sandbox/test_model_requests.py
+++ b/tests/sandbox/test_model_requests.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vibesys.sandbox import model_requests
+from vibesys.sandbox.model_requests import (
+    MODEL_MANIFEST_RELPATH,
+    ModelRequest,
+    ModelRequestError,
+    check_allowed,
+    read_model_requests,
+    reconcile_model_requests,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_manifest(workspace: Path, payload: object) -> None:
+    path = workspace / MODEL_MANIFEST_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+
+
+# -- read_model_requests ----------------------------------------------------
+
+
+def test_missing_manifest_yields_empty(tmp_path: Path) -> None:
+    assert read_model_requests(tmp_path) == []
+
+
+def test_reads_bare_list(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, [{"id": "org/Foo-1.2-X", "revision": "abc"}])
+    assert read_model_requests(tmp_path) == [ModelRequest(model_id="org/Foo-1.2-X", revision="abc")]
+
+
+def test_reads_models_object_and_model_id_alias(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, {"models": [{"model_id": "org/bar"}]})
+    assert read_model_requests(tmp_path) == [ModelRequest(model_id="org/bar", revision=None)]
+
+
+def test_dedupes_keeping_first(tmp_path: Path) -> None:
+    _write_manifest(
+        tmp_path,
+        [
+            {"id": "org/dup", "revision": "first"},
+            {"id": "org/dup", "revision": "second"},
+            {"id": "org/other"},
+        ],
+    )
+    assert read_model_requests(tmp_path) == [
+        ModelRequest(model_id="org/dup", revision="first"),
+        ModelRequest(model_id="org/other", revision=None),
+    ]
+
+
+def test_strips_whitespace_from_id(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, [{"id": "  org/foo  "}])
+    assert read_model_requests(tmp_path) == [ModelRequest(model_id="org/foo", revision=None)]
+
+
+def test_invalid_json_raises(tmp_path: Path) -> None:
+    path = tmp_path / MODEL_MANIFEST_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json")
+    with pytest.raises(ModelRequestError, match="not valid JSON"):
+        read_model_requests(tmp_path)
+
+
+def test_non_list_raises(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, {"models": "org/foo"})
+    with pytest.raises(ModelRequestError, match="must be a JSON list"):
+        read_model_requests(tmp_path)
+
+
+def test_non_object_entry_raises(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, ["org/foo"])
+    with pytest.raises(ModelRequestError, match="entry 0 is not an object"):
+        read_model_requests(tmp_path)
+
+
+def test_missing_id_raises(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, [{"revision": "abc"}])
+    with pytest.raises(ModelRequestError, match="non-empty"):
+        read_model_requests(tmp_path)
+
+
+def test_non_string_revision_raises(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, [{"id": "org/foo", "revision": 3}])
+    with pytest.raises(ModelRequestError, match="revision"):
+        read_model_requests(tmp_path)
+
+
+# -- check_allowed ----------------------------------------------------------
+
+
+def test_allow_none_is_unrestricted() -> None:
+    assert check_allowed("anything/at-all", None) is True
+
+
+def test_allow_prefix_match_and_miss() -> None:
+    allow = ("org/", "trusted-org/")
+    assert check_allowed("org/foo", allow) is True
+    assert check_allowed("trusted-org/bar", allow) is True
+    assert check_allowed("other/baz", allow) is False
+
+
+def test_allow_prefixes_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VIBESYS_MODEL_REQUEST_ALLOW", " org/ , trusted/ ")
+    assert model_requests._allow_prefixes() == ("org/", "trusted/")  # noqa: SLF001
+
+
+def test_allow_prefixes_unset_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VIBESYS_MODEL_REQUEST_ALLOW", raising=False)
+    assert model_requests._allow_prefixes() is None  # noqa: SLF001
+
+
+# -- reconcile_model_requests ----------------------------------------------
+
+
+def test_reconcile_empty_does_not_touch_provisioner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    called = []
+
+    def _fail_if_called(*args: object, **_kwargs: object) -> str:
+        called.append(args)
+        return "vol"
+
+    monkeypatch.setattr("vs_sandbox.ensure_model_volume", _fail_if_called)
+    assert reconcile_model_requests(tmp_path) == []
+    assert called == []
+
+
+def test_reconcile_provisions_each_request(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_manifest(
+        tmp_path,
+        [{"id": "org/a", "revision": "r1"}, {"id": "org/b"}],
+    )
+    seen: list[tuple[str, str | None]] = []
+
+    def _fake_ensure(model_id: str, *, revision: str | None = None, **_kwargs: object) -> str:
+        seen.append((model_id, revision))
+        return f"vibesys-model-{model_id.replace('/', '-')}"
+
+    monkeypatch.setattr("vs_sandbox.ensure_model_volume", _fake_ensure)
+    volumes = reconcile_model_requests(tmp_path)
+    assert seen == [("org/a", "r1"), ("org/b", None)]
+    assert volumes == ["vibesys-model-org-a", "vibesys-model-org-b"]
+
+
+def test_reconcile_rejects_disallowed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_manifest(tmp_path, [{"id": "sketchy/model"}])
+    monkeypatch.setenv("VIBESYS_MODEL_REQUEST_ALLOW", "trusted/")
+
+    def _must_not_run(*_args: object, **_kwargs: object) -> str:
+        pytest.fail("provisioner must not run for disallowed request")
+
+    monkeypatch.setattr("vs_sandbox.ensure_model_volume", _must_not_run)
+    with pytest.raises(ModelRequestError, match="not permitted"):
+        reconcile_model_requests(tmp_path)


### PR DESCRIPTION
## Problem

A serving candidate can only use model weights the task pre-stages, via the task-owned `reference/meta.json` / `draft_meta.json` convention read once at `RunEnvironment.open()`. A candidate that needs weights beyond what the task ships has no way to ask for them. Tasks with no `reference/` directory (e.g. `llama-70b-2xh100-vllm`) skip framework staging entirely and rely on out-of-band manual seeding — the candidate cannot introduce any new weights its implementation might need.

## Solution

A general, candidate-editable resource-request mechanism, scoped to model weights. The candidate declares needed weights in `.vibesys/models.json` in its workspace root:

```json
[{"id": "org/Some-Model", "revision": "optional-sha"}]
```

(a bare list, or `{"models": [...]}`; `model_id` is accepted as an alias for `id`).

Before each framework-gate deploy, the loop reconciles the manifest: it stages every requested repository into its `vibesys-model-<normalized-id>` Modal Volume via the existing `ensure_model_volume`. Staging is idempotent (sentinel-gated), so reconciling every round and again on resume is a no-op once a volume is ready. The manifest rides the workspace snapshot, so resume-safety needs no run-state schema change.

The request is deliberately narrow: it expresses only *which weights* to stage and cannot alter the measurement envelope (GPU count/type, benchmark configuration), which stays operator-owned. Operators may restrict permitted repositories with `VIBESYS_MODEL_REQUEST_ALLOW` (comma-separated repo-id prefixes; unset = unrestricted). Malformed or disallowed manifests return as gate feedback so the candidate corrects them rather than crashing the run.

### Architecture

- `src/vibesys/sandbox/model_requests.py` (new): manifest parsing (`read_model_requests`), operator allowlist (`check_allowed` / `VIBESYS_MODEL_REQUEST_ALLOW`), and `reconcile_model_requests` which calls `vs_sandbox.ensure_model_volume` per request. Pure and independently testable; the heavy `vs_sandbox`/Modal import is deferred to call time.
- `src/vibesys/loops/agent/loop.py`: `_reconcile_model_requests(ctx)` runs at the top of `_run_framework_gates` (the single deploy path shared by the multi-agent and single-agent branches), before accuracy/benchmark. It is a no-op unless `run_environment_view.env_kind == "modal"`; a `ModelRequestError` is surfaced as gate feedback.
- `src/vibesys/sandbox/run_environment.py`: appends a technique-neutral paragraph to the existing model-weights note in `_modal_runtime_notes`, telling the candidate it may declare extra weights and how the volume name is derived. No task-specific or optimization-specific language, consistent with that function's task-agnostic contract.

Ownership boundary: the candidate owns *what weights it needs* (inner loop); the operator owns *what is permitted* and the fixed measurement envelope. This slice intentionally defers a persisted provisioned-models audit record — the volume ready-sentinel already makes reconcile idempotent and resume-safe, so no `RunEnvironmentRecord` schema bump is required.

## Verification

### Correctness properties

- Absent manifest → empty request list; provisioner is never invoked.
- Reconcile is idempotent and resume-safe: repeated calls hit the volume ready-sentinel and no-op.
- A request can only stage model weights; it cannot change GPU count/type or benchmark configuration.
- A disallowed or malformed request never invokes the provisioner and is reported as gate feedback, not an uncaught crash.
- Duplicate ids collapse (first wins); ids are whitespace-trimmed.
- Off-Modal runs are unaffected (hook is a no-op).

### Testing

- `uv run --no-sync pytest tests/sandbox/test_model_requests.py -q` → 17 passed (100% coverage of `model_requests.py`).
- `uv run --no-sync pytest tests/loops/agent/test_orchestrate.py -k "gate or framework" -q` → 21 passed (existing framework-gate behavior unchanged).
- `uv run --no-sync ruff check` on all four changed files → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)