### PR TITLE
Retheme docs site: monochrome palette, IBM Plex, unified Prism

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -29,6 +29,13 @@ const config: Config = {
     locales: ['en'],
   },
 
+  stylesheets: [
+    {
+      href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap',
+      type: 'text/css',
+    },
+  ],
+
   presets: [
     [
       'classic',
@@ -55,6 +62,11 @@ const config: Config = {
     },
     navbar: {
       title: 'VibeSys',
+      logo: {
+        alt: 'VibeSys',
+        src: 'img/logo.svg',
+        srcDark: 'img/logo-dark.svg',
+      },
       items: [
         {
           type: 'docSidebar',
@@ -106,8 +118,8 @@ const config: Config = {
       copyright: `Copyright © ${new Date().getFullYear()} University of Washington SyFI Lab. Built with Docusaurus.`,
     },
     prism: {
-      theme: prismThemes.github,
-      darkTheme: prismThemes.dracula,
+      theme: prismThemes.vsLight,
+      darkTheme: prismThemes.vsDark,
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/website/src/components/ArchitectureDiagram/index.tsx
+++ b/website/src/components/ArchitectureDiagram/index.tsx
@@ -1,0 +1,398 @@
+import type {ReactNode} from 'react';
+import styles from './styles.module.css';
+
+/**
+ * Native SVG redraw of the architecture figure (previously a static PNG).
+ * Layout is grid-aligned by hand: three top-level regions share the same
+ * y=16..496 band, connected by plain arrows; the two loop zones inside
+ * VibeSys are dashed outlines (vs. solid-filled leaf cards) so nesting
+ * reads without relying on hue, consistent with the site's monochrome
+ * palette. Card heights track their actual content (single-line vs.
+ * two-line title/subtitle) rather than a shared oversized default, and
+ * every region starts its first row at the same y so the three columns
+ * read as one grid.
+ */
+
+function Icon({
+  x,
+  y,
+  size = 22,
+  children,
+}: {
+  x: number;
+  y: number;
+  size?: number;
+  children: ReactNode;
+}) {
+  return (
+    <svg
+      x={x}
+      y={y}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      className={styles.icon}>
+      {children}
+    </svg>
+  );
+}
+
+function LeafCard({
+  x,
+  y,
+  w,
+  h,
+  icon,
+  title,
+  subtitle,
+}: {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  icon: ReactNode;
+  title: string[];
+  subtitle?: string[];
+}) {
+  const iconX = x + 13;
+  const iconY = y + 11;
+  const textX = x + 13;
+  let ty = iconY + 22 + 19;
+  const titleLines = title.map((line, i) => {
+    const el = (
+      <tspan key={i} x={textX} y={ty}>
+        {line}
+      </tspan>
+    );
+    ty += 18;
+    return el;
+  });
+  ty += 3;
+  const subtitleLines = (subtitle ?? []).map((line, i) => {
+    const el = (
+      <tspan key={i} x={textX} y={ty}>
+        {line}
+      </tspan>
+    );
+    ty += 16;
+    return el;
+  });
+
+  return (
+    <g>
+      <rect x={x} y={y} width={w} height={h} rx={6} className={styles.card} />
+      <Icon x={iconX} y={iconY}>
+        {icon}
+      </Icon>
+      <text className={styles.cardTitle}>{titleLines}</text>
+      {subtitle && <text className={styles.cardSubtitle}>{subtitleLines}</text>}
+    </g>
+  );
+}
+
+export default function ArchitectureDiagram(): ReactNode {
+  return (
+    <figure className={styles.figure}>
+      <figcaption className={styles.caption}>
+        An outer loop plans the search over designs; an inner loop
+        implements and validates candidates; an independent judge checks
+        correctness before results are recorded.
+      </figcaption>
+      <svg
+        className={styles.diagram}
+        viewBox="0 0 1160 520"
+        role="img"
+        aria-label="Diagram: user input (model, hardware, workload) feeds VibeSys, where an outer loop plans the search and an inner loop of Implementer, Accuracy Judge, and Profiler implements, checks, and benchmarks each candidate, producing a bespoke system. On error, the Accuracy Judge sends the candidate back to the Implementer.">
+        <defs>
+          <marker
+            id="arch-arrow"
+            viewBox="0 0 10 10"
+            refX="8"
+            refY="5"
+            markerWidth="7"
+            markerHeight="7"
+            orient="auto-start-reverse">
+            <path d="M0 0L10 5L0 10z" className={styles.arrowHead} />
+          </marker>
+        </defs>
+
+        {/* ---- Region A: User Input ---- */}
+        <rect x={16} y={16} width={216} height={480} rx={14} className={styles.regionOutline} />
+        <text x={32} y={44} className={styles.zoneLabel}>
+          USER INPUT
+        </text>
+
+        <LeafCard
+          x={32}
+          y={62}
+          w={184}
+          h={108}
+          title={['Model']}
+          subtitle={['weights, code']}
+          icon={
+            <>
+              <circle cx={12} cy={5.5} r={2} />
+              <circle cx={5.5} cy={18} r={2} />
+              <circle cx={18.5} cy={18} r={2} />
+              <path d="M10.8 7.3L7 15.5M13.2 7.3l3.8 8.2" />
+            </>
+          }
+        />
+        <LeafCard
+          x={32}
+          y={217}
+          w={184}
+          h={108}
+          title={['Hardware']}
+          subtitle={['H100, M4 Pro, …']}
+          icon={
+            <>
+              <rect x={6} y={6} width={12} height={12} rx={1.5} />
+              <path d="M9 3v3M15 3v3M9 18v3M15 18v3M3 9h3M3 15h3M18 9h3M18 15h3" />
+            </>
+          }
+        />
+        <LeafCard
+          x={32}
+          y={372}
+          w={184}
+          h={108}
+          title={['Workload']}
+          subtitle={['benchmark metrics']}
+          icon={
+            <>
+              <rect x={4.5} y={13} width={3.4} height={7} fill="currentColor" stroke="none" />
+              <rect x={10.3} y={9} width={3.4} height={11} fill="currentColor" stroke="none" />
+              <rect x={16.1} y={4} width={3.4} height={16} fill="currentColor" stroke="none" />
+            </>
+          }
+        />
+
+        {/* arrow: User Input -> VibeSys */}
+        <line x1={236} y1={256} x2={256} y2={256} className={styles.arrow} markerEnd="url(#arch-arrow)" />
+
+        {/* ---- Region B: VibeSys ---- */}
+        <rect x={260} y={16} width={560} height={480} rx={14} className={styles.regionOutline} />
+        <text x={280} y={52} className={styles.title}>
+          VibeSys
+        </text>
+
+        {/* Outer Loop zone */}
+        <rect x={276} y={70} width={528} height={154} rx={10} className={styles.zoneOutline} />
+        <text x={288} y={88} className={styles.zoneLabel}>
+          OUTER LOOP
+        </text>
+        <LeafCard
+          x={292}
+          y={100}
+          w={248}
+          h={112}
+          title={['Search Policy']}
+          subtitle={['design decisions', 'branch / backtrack']}
+          icon={
+            <>
+              <circle cx={6} cy={6} r={2} />
+              <circle cx={6} cy={18} r={2} />
+              <circle cx={18} cy={6} r={2} />
+              <path d="M6 8v8M8 6h8a2 2 0 0 1-2 2h-2a4 4 0 0 0-4 4" />
+            </>
+          }
+        />
+        <LeafCard
+          x={556}
+          y={100}
+          w={232}
+          h={112}
+          title={['Search State']}
+          subtitle={['git state', 'feedback history']}
+          icon={
+            <>
+              <ellipse cx={12} cy={6} rx={7} ry={3} />
+              <path d="M5 6v12a7 3 0 0 0 14 0V6" />
+              <path d="M5 12a7 3 0 0 0 14 0" />
+            </>
+          }
+        />
+        <line
+          x1={554}
+          y1={156}
+          x2={542}
+          y2={156}
+          className={styles.arrowMuted}
+          markerEnd="url(#arch-arrow)"
+        />
+
+        {/* Base Commit + Task / Commit + Feedback connectors */}
+        <text x={400} y={242} textAnchor="middle" className={styles.flowLabel}>
+          Base Commit + Task
+        </text>
+        <line x1={400} y1={246} x2={400} y2={259} className={styles.arrow} markerEnd="url(#arch-arrow)" />
+        <text x={680} y={242} textAnchor="middle" className={styles.flowLabel}>
+          Commit + Feedback
+        </text>
+        <line x1={680} y1={259} x2={680} y2={246} className={styles.arrow} markerEnd="url(#arch-arrow)" />
+
+        {/* Inner Loop zone */}
+        <rect x={276} y={264} width={528} height={122} rx={10} className={styles.zoneOutline} />
+        <text x={288} y={282} className={styles.zoneLabel}>
+          INNER LOOP
+        </text>
+
+        {/* Error: Accuracy Judge sends the candidate back to the Implementer */}
+        <path
+          d="M540 298 C 500 284, 407 284, 367 298"
+          className={styles.arrowDashed}
+          markerEnd="url(#arch-arrow)"
+        />
+        <text x={454} y={280} textAnchor="middle" className={styles.errorLabel}>
+          Error
+        </text>
+
+        <LeafCard
+          x={292}
+          y={298}
+          w={150}
+          h={76}
+          title={['Implementer']}
+          icon={<path d="M8 6L3 12l5 6M16 6l5 6-5 6" />}
+        />
+        <LeafCard
+          x={458}
+          y={298}
+          w={165}
+          h={76}
+          title={['Accuracy Judge']}
+          icon={
+            <>
+              <circle cx={12} cy={12} r={8} />
+              <path d="M8.5 12.5l2.5 2.5 5-5" />
+            </>
+          }
+        />
+        <LeafCard
+          x={639}
+          y={298}
+          w={150}
+          h={76}
+          title={['Profiler']}
+          icon={
+            <>
+              <path d="M4 16a8 8 0 0 1 16 0" />
+              <path d="M12 16l4-5" />
+              <circle cx={12} cy={16} r={1.3} fill="currentColor" stroke="none" />
+            </>
+          }
+        />
+        <line x1={442} y1={336} x2={458} y2={336} className={styles.arrowMuted} markerEnd="url(#arch-arrow)" />
+        <line x1={623} y1={336} x2={639} y2={336} className={styles.arrowMuted} markerEnd="url(#arch-arrow)" />
+
+        <LeafCard
+          x={292}
+          y={404}
+          w={248}
+          h={76}
+          title={['Skills Library']}
+          icon={
+            <>
+              <path d="M6 3h9l4 4v14H6z" />
+              <path d="M9 11h6M9 14h6M9 17h4" />
+            </>
+          }
+        />
+        <LeafCard
+          x={556}
+          y={404}
+          w={232}
+          h={76}
+          title={['Execution Env.']}
+          icon={
+            <>
+              <rect x={3} y={4} width={18} height={16} rx={1} />
+              <path d="M7 9l3 3-3 3M13 15h4" />
+            </>
+          }
+        />
+        <line
+          x1={367}
+          y1={404}
+          x2={367}
+          y2={374}
+          className={styles.arrowMuted}
+          markerEnd="url(#arch-arrow)"
+        />
+        <line
+          x1={590}
+          y1={404}
+          x2={590}
+          y2={374}
+          className={styles.arrowMuted}
+          markerStart="url(#arch-arrow)"
+          markerEnd="url(#arch-arrow)"
+        />
+        <line
+          x1={740}
+          y1={404}
+          x2={740}
+          y2={374}
+          className={styles.arrowMuted}
+          markerStart="url(#arch-arrow)"
+          markerEnd="url(#arch-arrow)"
+        />
+
+        {/* arrow: VibeSys -> Bespoke System */}
+        <line x1={824} y1={256} x2={844} y2={256} className={styles.arrow} markerEnd="url(#arch-arrow)" />
+
+        {/* ---- Region C: Bespoke System ---- */}
+        <rect x={848} y={16} width={296} height={480} rx={14} className={styles.regionOutline} />
+        <text x={864} y={44} className={styles.zoneLabel}>
+          BESPOKE SYSTEM
+        </text>
+        <rect x={864} y={62} width={264} height={418} rx={6} className={styles.card} />
+        <text x={880} y={90} className={styles.mono}>
+          <tspan x={880} dy={0} fontWeight={600}>
+            serving_system/
+          </tspan>
+          <tspan x={880} dy={19} className={styles.monoDim}>
+            {'├─ api_server.py'}
+          </tspan>
+          <tspan x={880} dy={19} className={styles.monoDim}>
+            {'├─ scheduler.py'}
+          </tspan>
+          <tspan x={880} dy={19} className={styles.monoDim}>
+            {'├─ router.py'}
+          </tspan>
+          <tspan x={880} dy={19} className={styles.monoDim}>
+            {'├─ cache.py'}
+          </tspan>
+          <tspan x={880} dy={19} className={styles.monoDim}>
+            {'├─ model.py'}
+          </tspan>
+          <tspan x={880} dy={19} className={styles.monoDim}>
+            {'└─ backend.py'}
+          </tspan>
+          <tspan x={880} dy={27} fontWeight={600}>
+            tests/
+          </tspan>
+          <tspan x={880} dy={19} className={styles.monoDim}>
+            {'├─ test_accuracy.py'}
+          </tspan>
+          <tspan x={880} dy={19} className={styles.monoDim}>
+            {'└─ test_router.py'}
+          </tspan>
+          <tspan x={880} dy={27} fontWeight={600}>
+            bench/
+          </tspan>
+          <tspan x={880} dy={19} className={styles.monoDim}>
+            {'├─ microbench.py'}
+          </tspan>
+          <tspan x={880} dy={19} className={styles.monoDim}>
+            {'├─ latency.csv'}
+          </tspan>
+          <tspan x={880} dy={19} className={styles.monoDim}>
+            {'└─ tpt.csv'}
+          </tspan>
+        </text>
+      </svg>
+    </figure>
+  );
+}

--- a/website/src/components/ArchitectureDiagram/styles.module.css
+++ b/website/src/components/ArchitectureDiagram/styles.module.css
@@ -1,0 +1,130 @@
+.figure {
+  margin: 0;
+}
+
+.caption {
+  max-width: 720px;
+  margin: 0 auto 1.5rem;
+}
+
+.diagram {
+  width: 100%;
+  height: auto;
+  color: var(--ifm-font-color-base);
+}
+
+.zoneLabel {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 12.5px;
+  letter-spacing: 0.06em;
+  fill: currentColor;
+  opacity: 0.6;
+}
+
+.title {
+  font-family: var(--ifm-font-family-base);
+  font-weight: 700;
+  font-size: 23px;
+  fill: currentColor;
+}
+
+.cardTitle {
+  font-family: var(--ifm-font-family-base);
+  font-weight: 600;
+  font-size: 15px;
+  fill: currentColor;
+}
+
+.cardSubtitle {
+  font-family: var(--ifm-font-family-base);
+  font-size: 12.5px;
+  fill: currentColor;
+  opacity: 0.6;
+}
+
+.flowLabel {
+  font-family: var(--ifm-font-family-base);
+  font-weight: 600;
+  font-size: 12.5px;
+  fill: currentColor;
+  opacity: 0.85;
+}
+
+.errorLabel {
+  font-family: var(--ifm-font-family-base);
+  font-style: italic;
+  font-size: 12px;
+  fill: currentColor;
+  opacity: 0.55;
+}
+
+.mono {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 12.5px;
+  fill: currentColor;
+}
+
+.monoDim {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 12.5px;
+  fill: currentColor;
+  opacity: 0.6;
+}
+
+.regionOutline {
+  fill: none;
+  stroke: currentColor;
+  stroke-opacity: 0.32;
+  stroke-width: 1.4;
+}
+
+.zoneOutline {
+  fill: none;
+  stroke: currentColor;
+  stroke-opacity: 0.32;
+  stroke-width: 1.1;
+  stroke-dasharray: 3 3;
+}
+
+.card {
+  fill: currentColor;
+  fill-opacity: 0.04;
+  stroke: currentColor;
+  stroke-opacity: 0.55;
+  stroke-width: 1.1;
+}
+
+.arrow {
+  fill: none;
+  stroke: currentColor;
+  stroke-opacity: 0.75;
+  stroke-width: 1.4;
+}
+
+.arrowMuted {
+  fill: none;
+  stroke: currentColor;
+  stroke-opacity: 0.4;
+  stroke-width: 1.1;
+}
+
+.arrowDashed {
+  fill: none;
+  stroke: currentColor;
+  stroke-opacity: 0.5;
+  stroke-width: 1.1;
+  stroke-dasharray: 3 3;
+}
+
+.icon {
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.arrowHead {
+  fill: currentColor;
+  fill-opacity: 0.75;
+}

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -20,9 +20,8 @@ const FeatureList: FeatureItem[] = [
     ),
     description: (
       <>
-        Each target defines its own implementation contract, correctness checks,
-        and performance benchmark, so VibeSys works across domains instead of
-        assuming one runtime, language, or deployment shape.
+        Each target gets its own contract, checks, and benchmark, not a
+        fixed runtime, language, or deployment shape
       </>
     ),
   },
@@ -36,14 +35,13 @@ const FeatureList: FeatureItem[] = [
     ),
     description: (
       <>
-        An outer loop plans the search over designs; an inner loop implements and
-        validates candidates. An independent judge checks correctness and
-        reward-hacking risk before results are recorded.
+        An outer loop searches over designs while an inner loop implements,
+        validates, and judges each candidate
       </>
     ),
   },
   {
-    title: 'Extend with skills, not forks',
+    title: 'Extend with skills',
     icon: (
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
         <rect x="4" y="4" width="7" height="7" rx="1" />
@@ -54,9 +52,8 @@ const FeatureList: FeatureItem[] = [
     ),
     description: (
       <>
-        New model families, hardware platforms, and optimizations are added by
-        writing an Agent Skill distilled from real serving engines and research,
-        not by modifying the framework.
+        New model families, hardware, and optimizations arrive as Agent
+        Skills, not framework changes
       </>
     ),
   },

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -5,14 +5,19 @@ import styles from './styles.module.css';
 
 type FeatureItem = {
   title: string;
-  icon: string;
+  icon: ReactNode;
   description: ReactNode;
 };
 
 const FeatureList: FeatureItem[] = [
   {
     title: 'Bespoke by target',
-    icon: '🎯',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <circle cx="12" cy="12" r="7" />
+        <circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none" />
+      </svg>
+    ),
     description: (
       <>
         Each target defines its own implementation contract, correctness checks,
@@ -23,7 +28,12 @@ const FeatureList: FeatureItem[] = [
   },
   {
     title: 'Multi-agent optimization loop',
-    icon: '🔁',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <path d="M4 12a8 8 0 0 1 14-5M20 12a8 8 0 0 1-14 5" />
+        <path d="M18 4v3h-3M6 20v-3h3" />
+      </svg>
+    ),
     description: (
       <>
         An outer loop plans the search over designs; an inner loop implements and
@@ -34,7 +44,14 @@ const FeatureList: FeatureItem[] = [
   },
   {
     title: 'Extend with skills, not forks',
-    icon: '🧩',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <rect x="4" y="4" width="7" height="7" rx="1" />
+        <rect x="13" y="4" width="7" height="7" rx="1" />
+        <rect x="4" y="13" width="7" height="7" rx="1" />
+        <rect x="13" y="13" width="7" height="7" rx="1" />
+      </svg>
+    ),
     description: (
       <>
         New model families, hardware platforms, and optimizations are added by
@@ -49,7 +66,7 @@ function Feature({title, icon, description}: FeatureItem) {
   return (
     <div className={clsx('col col--4')}>
       <div className="text--center">
-        <span className={styles.featureIcon} role="img" aria-hidden="true">
+        <span className={styles.featureIcon} aria-hidden="true">
           {icon}
         </span>
       </div>

--- a/website/src/components/HomepageFeatures/styles.module.css
+++ b/website/src/components/HomepageFeatures/styles.module.css
@@ -6,8 +6,12 @@
 }
 
 .featureIcon {
-  font-size: 3.5rem;
-  line-height: 1;
   display: inline-block;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
+  color: var(--ifm-color-primary);
+}
+
+.featureIcon svg {
+  width: 32px;
+  height: 32px;
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -4,27 +4,49 @@
  * work well for content-centric websites.
  */
 
-/* You can override the default Infima variables here. */
+/*
+ * Raw Terminal: monochrome, standard corners, no CLI prompt line.
+ * The "accent" is ink itself, not a hue, so links rely on underline
+ * (see .markdown a below) rather than color to read as links.
+ */
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
+  --ifm-color-primary: #17171a;
+  --ifm-color-primary-dark: #101012;
+  --ifm-color-primary-darker: #0c0c0e;
+  --ifm-color-primary-darkest: #000000;
+  --ifm-color-primary-light: #2c2c30;
+  --ifm-color-primary-lighter: #3a3a3f;
+  --ifm-color-primary-lightest: #63656b;
+  --ifm-background-color: #ffffff;
+  --ifm-background-surface-color: #fbfbfa;
+  --ifm-color-emphasis-300: #d9d8d3;
+  --ifm-font-family-base: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, sans-serif;
+  --ifm-font-family-monospace: 'IBM Plex Mono', ui-monospace, SFMono-Regular,
+    Menlo, Monaco, Consolas, monospace;
   --ifm-code-font-size: 95%;
+  --ifm-button-border-radius: 5px;
+  --ifm-code-border-radius: 5px;
+  --ifm-alert-border-radius: 5px;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
-/* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
+  --ifm-color-primary: #ececeb;
+  --ifm-color-primary-dark: #d8d8d6;
+  --ifm-color-primary-darker: #cacac8;
+  --ifm-color-primary-darkest: #9a9a9c;
+  --ifm-color-primary-light: #f2f2f1;
+  --ifm-color-primary-lighter: #f6f6f5;
+  --ifm-color-primary-lightest: #ffffff;
+  --ifm-background-color: #0e0e10;
+  --ifm-background-surface-color: #16161a;
+  --ifm-color-emphasis-300: #333338;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+}
+
+/* Links carry no color accent in monochrome, so underline them instead. */
+.markdown a {
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
 }

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -10,6 +10,11 @@
   overflow: hidden;
 }
 
+.promptMark {
+  font-family: var(--ifm-font-family-monospace);
+  margin-right: 0.15em;
+}
+
 @media screen and (max-width: 996px) {
   .heroBanner {
     padding: 2rem;

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -39,13 +39,3 @@
 .architecture {
   padding: 2rem 0 4rem;
 }
-
-.architectureCaption {
-  max-width: 720px;
-  margin: 0 auto 1.5rem;
-}
-
-.architectureImg {
-  max-width: 100%;
-  height: auto;
-}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -12,9 +12,10 @@ import styles from './index.module.css';
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
+    <header className={clsx('hero', styles.heroBanner)}>
       <div className="container">
         <Heading as="h1" className="hero__title">
+          <span className={styles.promptMark}>&gt;</span>
           {siteConfig.title}
         </Heading>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
@@ -25,12 +26,12 @@ function HomepageHeader() {
         </p>
         <div className={styles.buttons}>
           <Link
-            className="button button--secondary button--lg"
+            className="button button--primary button--lg"
             to="/docs/running-vibesys">
             Read the docs
           </Link>
           <Link
-            className="button button--outline button--secondary button--lg"
+            className="button button--outline button--primary button--lg"
             href="https://arxiv.org/abs/2605.06068">
             Paper (arXiv)
           </Link>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -2,9 +2,9 @@ import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
+import ArchitectureDiagram from '@site/src/components/ArchitectureDiagram';
 import Heading from '@theme/Heading';
 
 import styles from './index.module.css';
@@ -53,16 +53,7 @@ export default function Home(): ReactNode {
         <section className={styles.architecture}>
           <div className="container text--center">
             <Heading as="h2">Architecture</Heading>
-            <p className={styles.architectureCaption}>
-              An outer loop plans the search over designs; an inner loop
-              implements and validates candidates; an independent judge checks
-              correctness before results are recorded.
-            </p>
-            <img
-              src={useBaseUrl('/img/architecture.png')}
-              alt="VibeSys architecture: an outer loop dispatches per-round tasks to an inner loop of Implementer, Accuracy Judge, and Performance Evaluator agents"
-              className={styles.architectureImg}
-            />
+            <ArchitectureDiagram />
           </div>
         </section>
       </main>

--- a/website/static/img/logo-dark.svg
+++ b/website/static/img/logo-dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#ececeb" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="4" width="18" height="16" rx="1"/>
+  <path d="M7 9l3 3-3 3M13 15h4"/>
+</svg>

--- a/website/static/img/logo.svg
+++ b/website/static/img/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#17171a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="4" width="18" height="16" rx="1"/>
+  <path d="M7 9l3 3-3 3M13 15h4"/>
+</svg>


### PR DESCRIPTION
## Problem

The docs site was still running the literal `create-docusaurus` scaffold
defaults: the tutorial green/teal palette (`#2e8555`/`#25c2a0`), a mismatched
`github`/`dracula` Prism pair, emoji feature icons, a text-only navbar, and a
static architecture PNG that didn't match anything else on the page. Nothing
had been themed since the site was added — it read as generic and unfinished
for a project with its own identity.

## Solution

Landed a monochrome "Raw Terminal" direction, arrived at through a few rounds
of visual exploration (mockups compared side-by-side against the current
site) before touching real code:

- Ink-based Infima primary ramp instead of a hue (`#17171a` light /
  `#ececeb` dark) — the "accent" is ink itself, not a color.
- IBM Plex Sans (UI) + IBM Plex Mono (code and the one prompt-mark flourish),
  loaded via a Google Fonts stylesheet link.
- Unified `vsLight`/`vsDark` Prism theme pair, replacing the unrelated
  `github`/`dracula` combination.
- A new terminal-window SVG navbar mark (separate light/dark variants),
  replacing the text-only logo.
- SVG feature icons (target / loop / grid) replacing the three emoji, which
  render inconsistently across OS/browser; feature-card copy tightened to
  one sentence each.
- Standard 5px corner radius on buttons/code/alerts, neutral grey borders.
- Prose links are underlined (`.markdown a`), since there's no hue left to
  distinguish them by color.
- Dropped `hero--primary` from the homepage header — with primary now equal
  to ink, that class would paint a solid black/white band. The hero is flat
  instead, with a small monospace `>` before the title as the only terminal
  touch (explicitly no persistent CLI-prompt-line UI).
- Redrew the homepage architecture figure as hand-authored inline SVG
  instead of a static PNG: `currentColor`-themed so it flips with light/dark
  like everything else, solid-outline regions with dashed-outline loop zones
  (vs. filled leaf cards) to show nesting without relying on hue, and the
  same stroke-icon language as the navbar mark and feature cards. Card sizes
  track their actual content instead of a shared oversized default, and the
  three columns share start/end coordinates so they read as one grid.

Also pinned `--ifm-background-color` explicitly for light mode instead of
relying on Infima's `transparent` default (which only works because a real
browser's canvas is white) — latent, harmless, but worth making explicit
while touching these tokens.

### Architecture

Theming-only change confined to `website/`: Infima CSS custom properties
(`custom.css`), site config (`docusaurus.config.ts`, for the navbar logo,
Prism theme, and font stylesheet), three React components
(`HomepageFeatures`, the new `ArchitectureDiagram`, and homepage `index.tsx`)
swapped from emoji/raster-image/text to SVG, and two new static SVG assets.
No backend, CLI, or agent-facing contract is touched, so no diagram is
included here beyond the one that's now part of the site itself.

## Verification

Ran the same checks CI runs (`.github/workflows/website.yml`):
`npm run typecheck` and `npm run build`, both from `website/`. Also manually
exercised the dev server in both light and dark mode across several rounds —
homepage hero, feature cards, navbar logo, the architecture diagram (font
sizing, box/gap balance, column alignment, and the Accuracy Judge → error →
Implementer arrow direction), and a docs page (code blocks, sidebar, prose
links) — verified via browser screenshots and direct computed-style /
DOM inspection (background/ink/accent values, link `text-decoration`, arrow
path coordinates).

### Correctness properties

- Website-only change; no backend/CLI/agent contract is affected.
- `onBrokenLinks`/`onBrokenMarkdownLinks` remain `warn` (unchanged), so the
  pre-existing relative-link warnings from `docs/development.md` and
  `docs/running-vibesys.md` don't fail the build, same as before this PR.
- Both `data-theme="light"` and `data-theme="dark"` render with explicit,
  opaque backgrounds and legible ink-on-background contrast.
- Prose links remain visually distinguishable without relying on hue.
- The architecture diagram's SVG text content matches the original figure's
  information (inputs, outer/inner loop, agents, generated file tree),
  renamed per request (`Implementer`/`Accuracy Judge`/`Profiler`, `VibeSys`,
  `Bespoke System`) with no information dropped.

### Testing

- `cd website && npm run typecheck` → pass, no errors.
- `cd website && npm run build` → pass; only the pre-existing broken-link
  warnings (unrelated relative links to files outside `docs/`), unchanged
  from before this change.
- Manual: `npm run start`, checked `/` and `/docs/running-vibesys` in both
  themes across each iteration (navbar logo, hero, feature icons, code
  blocks, sidebar, link underline, architecture diagram layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
