### PR TITLE
Initialize vibe-database domain

### DIFF
--- a/src/vibesys/domains/base.py
+++ b/src/vibesys/domains/base.py
@@ -13,6 +13,7 @@ class DomainName(StrEnum):  # noqa: D101  # tracked: #288
     LLM_SERVING = "llm-serving"
     GENERIC = "generic"
     MICROSERVICES = "microservices"
+    DATABASE = "database"
 
 
 class DomainRole(StrEnum):  # noqa: D101  # tracked: #288

--- a/src/vibesys/domains/database/__init__.py
+++ b/src/vibesys/domains/database/__init__.py
@@ -1,0 +1,16 @@
+"""Database domain definition.
+
+Hosts in-place optimization of real database / dataflow engines.
+"""
+
+from __future__ import annotations
+
+from vibesys.domains.base import DomainDefinition, DomainName
+from vibesys.domains.environment import NoopEnvironmentHooks
+from vibesys.prompts import PROMPTS_DIR
+
+DEFINITION = DomainDefinition(
+    name=DomainName.DATABASE,
+    prompt_dir=PROMPTS_DIR / "domains" / "database",
+    environment_hooks=NoopEnvironmentHooks(),
+)

--- a/src/vibesys/domains/registry.py
+++ b/src/vibesys/domains/registry.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from vibesys.domains import generic, llm_serving, microservices
+from vibesys.domains import database, generic, llm_serving, microservices
 from vibesys.domains.base import DomainDefinition, DomainName
 
 DOMAINS: dict[DomainName, DomainDefinition] = {
     generic.DEFINITION.name: generic.DEFINITION,
     llm_serving.DEFINITION.name: llm_serving.DEFINITION,
     microservices.DEFINITION.name: microservices.DEFINITION,
+    database.DEFINITION.name: database.DEFINITION,
 }
 
 

--- a/src/vibesys/prompts/domains/database/README.md
+++ b/src/vibesys/prompts/domains/database/README.md
@@ -1,0 +1,28 @@
+# Database domain prompts
+
+Role files injected into the base prompts for `domain = "database"`. Each
+`<role>.md` renders through Jinja with the uniform domain context (`modality`,
+`interface`, `reference_path`, `accuracy_command`, `benchmark_command`,
+`runtime_notes`, `profile_execution`, `workspace_sources`) and lands at the
+`{{ domain_<role> }}` injection point of the matching base template. A missing
+role file injects nothing; `single_agent.md` is derived from `implementer.md` +
+`judge.md` when absent.
+
+This domain hosts **in-place superoptimization of a real database / dataflow
+engine**: the engine's own upstream source is vendored into the workspace and
+micro-optimized in place, and correctness is judged as **output-equivalence with
+a pristine copy of the same round-0 engine, run live** — not against a
+hand-written oracle. The engine-specific workload, accuracy checker, and
+benchmark live with each task under the target's `.vibesys/tasks/<task>/`; these
+role files stay engine-agnostic.
+
+Present:
+
+- `implementer.md` — what to read and what "done" means for an in-place engine
+  micro-optimization.
+- `judge.md` — what to check: output-equivalence, behavioral-consistency, the
+  in-place / no-rearchitecture discipline, and reward-hack guards.
+
+The behavioral-consistency gates (determinism, crash/restart recovery,
+race-freedom) are named generically here; their concrete checker wiring is added
+alongside the first task's evaluator.

--- a/src/vibesys/prompts/domains/database/implementer.md
+++ b/src/vibesys/prompts/domains/database/implementer.md
@@ -1,0 +1,47 @@
+You are optimizing a **database / dataflow engine** by micro-optimizing its own
+real, already-correct source **in place**. The engine is vendored into the
+workspace as its actual upstream source; a pristine copy of the same round-0
+engine is kept beside it as the correctness oracle. Your job is to make the
+engine's workload cost less at **identical results and identical guarantees** —
+never to redesign it.
+
+## Development priorities
+
+1. Read the objective, manifest, README, and any candidate contract files before
+   editing code or configuration. Locate the engine source you may edit and the
+   pristine reference you may not.
+2. **Optimize the engine in place.** Never delete a module and rewrite it, never
+   reimplement an operator, never swap the algorithm or its complexity class,
+   never change the execution or concurrency model, and never replace the engine
+   with — or shell out to — a different one. Those are architectural changes and
+   they fail even when faster and still correct.
+3. Correctness is **output-equivalence**: your build must produce byte-identical
+   results to the pristine reference on every workload the checker runs, not just
+   the benchmarked one. Preserve the guarantees the reference provides —
+   determinism across configuration, crash/restart recovery, and race-freedom —
+   because a cost win that weakens any of them is not a win.
+4. Run the accuracy checker before trusting benchmark numbers. A faster candidate
+   whose output or a behavioral guarantee regressed is a failure, not progress.
+5. Treat the checker, benchmark, reference, and workload as evaluator-owned. Do
+   not edit them, and do not narrow the accepted workload so only the benchmark's
+   exact inputs succeed.
+
+## Common optimization levers
+
+Prefer changes that shave cost from the measured workload without changing what
+the engine computes:
+
+- Remove hot-path heap allocation; reuse buffers; right-size vectors and
+  small-buffer optimizations.
+- Improve data layout and locality (field ordering, alignment, SoA/AoS,
+  power-of-two indexing) of existing structures — layout is fair game, the data
+  *model* is not.
+- Tighten existing merge, sort, scan, join, aggregation, and consolidation loops;
+  cut redundant clones and copies.
+- Inline hot functions, add cold/hot annotations, take branchless paths.
+- Tune build and codegen flags (optimization level, LTO, codegen units, target
+  CPU) that do not alter results.
+
+Avoid shortcuts that only satisfy the benchmark shape: hard-coded or memorized
+answers for the known workload, short-circuiting the computation, embedding
+another engine, or returning results the real computation would not produce.

--- a/src/vibesys/prompts/domains/database/judge.md
+++ b/src/vibesys/prompts/domains/database/judge.md
@@ -1,0 +1,58 @@
+You are reviewing a **database / dataflow engine optimization** — a
+micro-optimization of a real engine's own source, kept in place. A pass verdict
+means the candidate is faster at **exactly** the results and guarantees of the
+pristine round-0 engine.
+
+## Always-on correctness checks
+
+In addition to the orchestrator's criteria, a pass verdict requires:
+
+1. **Output-equivalence.** The candidate must produce byte-identical results to
+   the pristine reference engine, run **live** on every workload the checker
+   exercises — not only the benchmarked one. A single diverging result is a
+   correctness failure.
+2. **Behavioral consistency.** The guarantees the reference provides must survive
+   the optimization: determinism across configuration (e.g. worker/parallelism
+   count), crash/restart recovery (a killed-and-restarted run converges to the
+   clean result), and race-freedom. A cost win that weakens any of these is a
+   failure, not a win.
+{% if accuracy_command %}
+3. Run `{{ accuracy_command }}` with default flags unless the objective gives a
+   stricter command. If it exits non-zero, the round fails.
+{% endif %}
+{% if benchmark_command %}
+4. Run `{{ benchmark_command }}` only after correctness passes, and read the
+   objective's headline cost metric from it.
+{% endif %}
+
+## In-place discipline — no rearchitecture
+
+Every change must be an identifiable **micro-optimization** — allocation removal,
+buffer reuse, collection sizing, inlining, a tightened merge/sort/scan/join/
+aggregation loop, layout of existing structures, or build/codegen flags.
+**Automatic failure — even if faster and still byte-identical — for any
+architectural change:** a module deleted and rewritten, an operator
+reimplemented, the algorithm or its complexity class changed, the execution or
+concurrency model changed, or a heavyweight engine/runtime dependency pulled in.
+The engine must stay the same engine; you are approving shaved cycles, not a
+redesign.
+
+## Reward-hack and regression checks
+
+Reject changes that make the benchmark pass by weakening or short-circuiting the
+engine instead of optimizing it:
+
+- Hard-coded, prerecorded, or memorized outputs for the known workload.
+- Short-circuiting the computation, or embedding / shelling out to another engine.
+- Narrowing the accepted workload so only the benchmark's exact inputs succeed.
+- Editing the evaluator-owned checker, benchmark, reference, or workload files.
+
+## Performance judgment
+
+Judge performance against the objective's end-to-end headline cost metric at
+correctness parity — never an internal microbenchmark unless the objective makes
+that the metric. A round that is faster because it changed the model or the
+output is a failure, not a win. The honest expectation for an in-place
+micro-optimization is a **modest percentage, not a multiple**; a small or zero
+win that stays genuinely equivalent is acceptable, a large win that does not is
+not.

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -47,6 +47,7 @@ def test_registered_domains_present():  # noqa: ANN201  # tracked: #288
     assert "llm-serving" in names
     assert "generic" in names
     assert "microservices" in names
+    assert "database" in names
     assert "README" not in names  # the authoring guide is not a domain
 
 
@@ -66,6 +67,14 @@ def test_resolve_microservices_domain():  # noqa: ANN201  # tracked: #288
     assert d.prompt_dir.parent.name == "domains"
 
 
+def test_resolve_database_domain():  # noqa: ANN201  # tracked: #288
+    d = resolve_domain(DomainName.DATABASE)
+    assert d.name is DomainName.DATABASE
+    assert d.prompt_dir.is_dir()
+    assert d.prompt_dir.name == "database"
+    assert d.prompt_dir.parent.name == "domains"
+
+
 def test_resolve_path_is_not_supported(tmp_path: Path):  # noqa: ANN201  # tracked: #288
     f = tmp_path / "mine"
     f.mkdir()
@@ -78,12 +87,14 @@ def test_registered_domains_carry_environment_hooks():  # noqa: ANN201  # tracke
     assert isinstance(DOMAINS[DomainName.LLM_SERVING].environment_hooks, LLMServingEnvironmentHooks)
     assert isinstance(DOMAINS[DomainName.GENERIC].environment_hooks, NoopEnvironmentHooks)
     assert isinstance(DOMAINS[DomainName.MICROSERVICES].environment_hooks, NoopEnvironmentHooks)
+    assert isinstance(DOMAINS[DomainName.DATABASE].environment_hooks, NoopEnvironmentHooks)
 
 
 def test_domains_declare_torch_profiler_compatibility():  # noqa: ANN201  # tracked: #288
     assert DOMAINS[DomainName.LLM_SERVING].supports_torch_profiler
     assert not DOMAINS[DomainName.GENERIC].supports_torch_profiler
     assert not DOMAINS[DomainName.MICROSERVICES].supports_torch_profiler
+    assert not DOMAINS[DomainName.DATABASE].supports_torch_profiler
 
 
 def test_resolve_unknown_raises():  # noqa: ANN201  # tracked: #288
@@ -135,6 +146,36 @@ def test_render_microservices_has_content():  # noqa: ANN201  # tracked: #288
     assert "connection pools" in impl
     assert "./check" in judge
     assert "./bench" in judge
+
+
+def test_render_database_has_content():  # noqa: ANN201  # tracked: #288
+    d = resolve_domain(DomainName.DATABASE)
+    impl = render_domain_section(d, DomainRole.IMPLEMENTER, reference_path="/ref")
+    judge = render_domain_section(
+        d,
+        DomainRole.JUDGE,
+        accuracy_command="./check",
+        benchmark_command="./bench",
+    )
+    # in-place-superopt framing is present on both role files
+    assert "database / dataflow engine" in impl
+    assert "output-equivalence" in impl.lower()
+    assert "output-equivalence" in judge.lower()
+    assert "no rearchitecture" in judge.lower()
+    # judge.md branches on the framework-supplied command variables
+    assert "./check" in judge
+    assert "./bench" in judge
+
+
+def test_render_database_judge_omits_commands_when_absent():  # noqa: ANN201  # tracked: #288
+    # with no commands supplied, the gated command lines drop out cleanly
+    d = resolve_domain(DomainName.DATABASE)
+    judge = render_domain_section(
+        d, DomainRole.JUDGE, accuracy_command=None, benchmark_command=None
+    )
+    assert judge  # the always-on correctness prose still renders
+    assert "./check" not in judge
+    assert "./bench" not in judge
 
 
 def test_role_file_keeps_markdown_headings(tmp_path: Path):  # noqa: ANN201  # tracked: #288


### PR DESCRIPTION
## What

Adds a new `database` domain to vibesys — the container for hosting in-place optimization of real database / dataflow engines. This is the first, engine-agnostic slice of moving the vibe-database concept into vibesys as a sub-concept.

Follows the documented "add a domain" recipe (`src/vibesys/domains/README.md`): register a `DomainName`, export a `DEFINITION`, and add role prompts under `prompts/domains/database/`.

## Changes

- `domains/base.py` — add `DATABASE = "database"` to `DomainName` (so manifests can select `domain = "database"`; validated against the enum).
- `domains/database/__init__.py` — export `DEFINITION` (`NoopEnvironmentHooks`, no torch profiler).
- `domains/registry.py` — register `database.DEFINITION`.
- `prompts/domains/database/{README,implementer,judge}.md` — engine-agnostic in-place-optimization framing: output-equivalence vs a live pristine reference, behavioral-consistency, no-rearchitecture discipline, reward-hack guards. `judge.md` branches on `accuracy_command` / `benchmark_command`.
- `tests/loops/agent/test_domain_packs.py` — mirror the microservices coverage for `database` (resolve, hooks, torch flag, role rendering + command branching).

## Deliberately out of scope (later PRs)

No oracle/gate code, no `EnvironmentHooks`/engine vendoring, no `examples/database/**`, and no specific engine (differential-dataflow) — those hang off this skeleton in follow-up PRs.

## Verification

- `tests/loops/agent/test_domain_packs.py` — passes
- Broader sweep (imports, features, packaging, profilers parametrized over all `DomainName`, context) — 2369 passed
- `./scripts/check_format.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)