### PR TITLE
Fix docs-site dead links and make broken links fail the build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,12 @@ jobs:
       - name: Check Python lint
         run: ./scripts/check_lint.sh
 
+      # docs/ and root Markdown are covered by website.yml, which this
+      # workflow's paths-ignore hands off to. This pass catches the rest:
+      # Markdown under src/, resources/, clients/, and examples/.
+      - name: Check Markdown links
+        run: python3 scripts/check_doc_links.py
+
   typecheck:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -11,12 +11,16 @@ on:
     paths:
       - 'website/**'
       - 'docs/**'
+      - '*.md'
+      - 'scripts/check_doc_links.py'
       - '.github/workflows/website.yml'
   pull_request:
     branches: [main]
     paths:
       - 'website/**'
       - 'docs/**'
+      - '*.md'
+      - 'scripts/check_doc_links.py'
       - '.github/workflows/website.yml'
 
 jobs:
@@ -25,6 +29,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Stdlib-only, so it needs no uv/dependency setup in this Node-only job.
+      # Covers what the Docusaurus build cannot: absolute links back into this
+      # repository, and Markdown outside docs/ that the site never renders.
+      - name: Check Markdown links
+        run: python3 scripts/check_doc_links.py
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/docs/coding-best-practices.md
+++ b/docs/coding-best-practices.md
@@ -150,6 +150,20 @@ through business logic.
 - Do not add VibeSys routing metadata to skill frontmatter; use
   `.vibesys.toml` sidecars.
 
+## Documentation Links
+
+`docs/` is rendered twice: by GitHub, and by the Docusaurus site at
+docs.vibing.systems, which serves `docs/` as its entire content root. A
+relative link from `docs/` to anything outside `docs/` resolves on GitHub and
+404s on the site.
+
+- Inside `docs/`, link to sibling docs relatively (`cli-flags.md`); link to
+  anything else in the repository by absolute URL
+  (`https://github.com/uw-syfi/vibesys/blob/main/...`).
+- Elsewhere in the repository, relative links are fine.
+- `scripts/check_doc_links.py` enforces both rules, including `#anchor`
+  targets and whether an absolute repo URL still points at a file that exists.
+
 ## Tests And Checks
 
 Run the narrowest relevant test first, then broaden when the change crosses
@@ -159,6 +173,7 @@ module boundaries.
 ./scripts/format.sh
 ./scripts/check_format.sh
 ./scripts/check_lint.sh
+uv run python scripts/check_doc_links.py
 uv run pytest
 uv run pytest path/to/test.py
 uv run pytest -k keyword

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ bundles, and the TUI.
 
 - Read [`docs/coding-best-practices.md`](coding-best-practices.md).
 - Keep changes within the owning package and preserve the framework boundaries.
-- Use the repository [pull request template](../.github/pull_request_template.md)
+- Use the repository [pull request template](https://github.com/uw-syfi/vibesys/blob/main/.github/pull_request_template.md)
   when opening a PR.
 
 ## Repository layout
@@ -96,7 +96,7 @@ uv run pytest -k orchestrator
 ```
 
 The TypeScript client has its own workflow; see
-[`clients/tui/README.md`](../clients/tui/README.md). The short version is:
+[`clients/tui/README.md`](https://github.com/uw-syfi/vibesys/blob/main/clients/tui/README.md). The short version is:
 
 ```bash
 pnpm install --frozen-lockfile
@@ -114,16 +114,16 @@ When Python protocol models change, regenerate the files under
 
 Use the guide that matches the surface you are adding:
 
-- [Add or customize a domain](../src/vibesys/domains/README.md) for new
+- [Add or customize a domain](https://github.com/uw-syfi/vibesys/blob/main/src/vibesys/domains/README.md) for new
   problem-space prompts, hooks, and domain registration.
-- [Add or update Agent Skills](../resources/skills/README.md) and read the
+- [Add or update Agent Skills](https://github.com/uw-syfi/vibesys/blob/main/resources/skills/README.md) and read the
   [VibeSys skill metadata guide](skill-metadata.md) when routing skills by
   backend or domain.
 - [Extend profilers](extending-profilers.md) for profiler support packages,
   MCP tools, and profiler prompts.
 - [Update CLI flags and combinations](cli-flags.md) when changing the user
   facing command contract.
-- [Update feature flags](../src/vibesys/FEATURE_FLAGS.md) for opt-in
+- [Update feature flags](https://github.com/uw-syfi/vibesys/blob/main/src/vibesys/FEATURE_FLAGS.md) for opt-in
   experiments and optional framework behavior.
 
 The experimental Omnigent adapter is a developer-facing alternative to the

--- a/docs/running-vibesys.md
+++ b/docs/running-vibesys.md
@@ -178,4 +178,4 @@ maintained by people.
 Legacy root input bundles remain valid positional arguments without `--task`.
 
 See the [CLI reference](cli-flags.md) for every flag and
-[`examples/`](../examples/) for complete objectives and manifests.
+[`examples/`](https://github.com/uw-syfi/vibesys/tree/main/examples) for complete objectives and manifests.

--- a/scripts/check_doc_links.py
+++ b/scripts/check_doc_links.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Fail when a Markdown link points at something that does not exist.
+
+Two link classes break in ways nothing else in CI catches:
+
+1.  A relative link whose target was renamed or deleted. Nothing type-checks
+    Markdown, so the link rots silently until a reader clicks it.
+2.  A link inside `docs/` that escapes `docs/`. Those resolve on GitHub but
+    not on the docs website: the Docusaurus docs plugin serves `docs/` as its
+    whole content root, so `../src/...` resolves to a site URL that was never
+    built. Such links must use an absolute repository URL instead.
+
+Checked: relative links and absolute links back into this repository
+(`https://github.com/uw-syfi/vibesys/blob|tree/<ref>/<path>`), including their
+`#anchor` when the target is Markdown. Other external URLs are not fetched,
+so the check stays offline and deterministic.
+
+Usage:
+    uv run python scripts/check_doc_links.py [PATH ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+REPO_URL_PREFIXES = (
+    "https://github.com/uw-syfi/vibesys/blob/",
+    "https://github.com/uw-syfi/vibesys/tree/",
+)
+
+# Subtrees the docs website publishes as its own content root. A relative link
+# from inside one of these must stay inside it.
+PUBLISHED_ROOTS = ("docs",)
+
+# Vendored trees. Their links belong to the upstream project and are broken
+# there too (they point at pages of the original site that were not mirrored),
+# so enforcing them here would only pin us to upstream's bugs.
+EXCLUDED_PREFIXES = (
+    "third_party/",
+    "3rd_party/",
+    "node_modules/",
+    "resources/skills/neuron-agentic-development/",
+)
+
+MARKDOWN_SUFFIXES = (".md", ".mdx")
+
+# Inline `[text](target)` links plus `[id]: target` reference definitions.
+INLINE_LINK = re.compile(r"\[[^\]]*\]\(\s*<?([^)\s<>]+)>?(?:\s+[\"'][^\"']*[\"'])?\s*\)")
+REFERENCE_LINK = re.compile(r"^\s{0,3}\[[^\]]+\]:\s*<?(\S+)>?", re.MULTILINE)
+FENCE = re.compile(r"^\s*(```|~~~)")
+
+EXPLICIT_HEADING_ID = re.compile(r"\{#([^}]+)\}\s*$")
+HTML_ANCHOR = re.compile(r"""(?:id|name)=["']([^"']+)["']""")
+
+
+@dataclass(frozen=True)
+class Link:
+    """One Markdown link, located at ``source``:``line``."""
+
+    source: Path
+    line: int
+    target: str
+
+
+@dataclass(frozen=True)
+class Problem:
+    """A link that failed a check, with the reason it failed."""
+
+    link: Link
+    reason: str
+
+
+def iter_markdown_files(paths: list[Path], repo_root: Path) -> list[Path]:
+    """List tracked Markdown files under ``paths`` (whole repo when empty)."""
+    argv = ["git", "-C", str(repo_root), "ls-files", "-z"]
+    argv += [str(p) for p in paths] if paths else ["*.md", "*.mdx"]
+    out = run_git(argv)
+    files = []
+    for name in filter(None, out.split("\0")):
+        if not name.endswith(MARKDOWN_SUFFIXES):
+            continue
+        if name.startswith(EXCLUDED_PREFIXES):
+            continue
+        files.append(repo_root / name)
+    return sorted(files)
+
+
+def run_git(argv: list[str]) -> str:
+    """Run a git command and return its stdout.
+
+    Argv is built from repo-relative paths supplied on the command line, never
+    from file contents, so `git` off PATH is the same trust boundary as the
+    rest of `scripts/`.
+    """
+    result = subprocess.run(  # noqa: S603
+        argv, capture_output=True, text=True, check=True
+    )
+    return result.stdout
+
+
+def extract_links(path: Path) -> list[Link]:
+    """Collect every inline and reference link in ``path``, skipping code fences."""
+    links: list[Link] = []
+    in_fence = False
+    for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+        if FENCE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        text = re.sub(r"`[^`]*`", "", line)
+        links.extend(Link(path, lineno, m.group(1)) for m in INLINE_LINK.finditer(text))
+        links.extend(Link(path, lineno, m.group(1)) for m in REFERENCE_LINK.finditer(text))
+    return links
+
+
+def slugify(heading: str) -> str:
+    """Approximate the GitHub heading-anchor slug for ``heading``."""
+    text = heading.strip().lstrip("#").strip()
+    text = EXPLICIT_HEADING_ID.sub("", text).strip()
+    text = re.sub(r"[`*_~]", "", text)
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
+    text = re.sub(r"[^\w\s-]", "", text, flags=re.UNICODE)
+    return re.sub(r"\s+", "-", text.strip()).lower()
+
+
+def anchors_of(path: Path) -> set[str]:
+    """Every anchor a Markdown file exposes: heading slugs, `{#id}`, HTML ids.
+
+    Repeated headings get GitHub's `-1`, `-2`, ... disambiguating suffixes.
+    """
+    anchors: set[str] = set()
+    seen: dict[str, int] = {}
+    in_fence = False
+    for line in path.read_text().splitlines():
+        if FENCE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        anchors.update(HTML_ANCHOR.findall(line))
+        if not line.lstrip().startswith("#"):
+            continue
+        explicit = EXPLICIT_HEADING_ID.search(line)
+        if explicit:
+            anchors.add(explicit.group(1))
+        slug = slugify(line)
+        if not slug:
+            continue
+        count = seen.get(slug, 0)
+        seen[slug] = count + 1
+        anchors.add(slug if count == 0 else f"{slug}-{count}")
+    return anchors
+
+
+def published_root_of(rel_path: Path) -> str | None:
+    """Return the published subtree containing ``rel_path``, if any."""
+    top = rel_path.parts[0] if rel_path.parts else ""
+    return top if top in PUBLISHED_ROOTS else None
+
+
+def resolve(link: Link, repo_root: Path) -> tuple[Path, str] | None:
+    """Map ``link`` to a repo path and anchor, or None when it is not checkable."""
+    target = link.target
+    for prefix in REPO_URL_PREFIXES:
+        if target.startswith(prefix):
+            # Strip the git ref segment that follows blob/ or tree/.
+            _ref, _, path_part = target[len(prefix) :].partition("/")
+            split = urlsplit(path_part)
+            if not split.path:
+                return None
+            return repo_root / unquote(split.path), split.fragment
+    if "://" in target or target.startswith(("mailto:", "#", "/")):
+        return None
+    split = urlsplit(target)
+    if not split.path:
+        return None
+    return (link.source.parent / unquote(split.path)).resolve(), split.fragment
+
+
+def check(files: list[Path], repo_root: Path) -> list[Problem]:
+    """Report every link in ``files`` whose target or anchor does not exist."""
+    problems: list[Problem] = []
+    for path in files:
+        source_rel = path.relative_to(repo_root)
+        for link in extract_links(path):
+            resolved = resolve(link, repo_root)
+            if resolved is None:
+                continue
+            target, anchor = resolved
+            if not target.exists():
+                problems.append(Problem(link, "target does not exist"))
+                continue
+            root = published_root_of(source_rel)
+            is_relative_link = not link.target.startswith("https://")
+            if root is not None and is_relative_link:
+                try:
+                    target.relative_to(repo_root / root)
+                except ValueError:
+                    problems.append(
+                        Problem(
+                            link,
+                            f"relative link escapes the published `{root}/` tree "
+                            "(breaks on the docs website); use an absolute "
+                            "https://github.com/uw-syfi/vibesys/... URL",
+                        )
+                    )
+                    continue
+            if (
+                anchor
+                and target.suffix in MARKDOWN_SUFFIXES
+                and anchor.lower() not in anchors_of(target)
+            ):
+                problems.append(Problem(link, f"no `#{anchor}` anchor in target"))
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Check every selected Markdown file and print each broken link."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="Limit the check to these files or directories (default: whole repo).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(run_git(["git", "rev-parse", "--show-toplevel"]).strip())
+    files = iter_markdown_files(args.paths, repo_root)
+    problems = check(files, repo_root)
+    for problem in problems:
+        rel = problem.link.source.relative_to(repo_root)
+        print(f"{rel}:{problem.link.line}: {problem.link.target}: {problem.reason}")
+    if problems:
+        print(f"\n{len(problems)} broken Markdown link(s) in {len(files)} file(s).")
+        return 1
+    print(f"Checked {len(files)} Markdown file(s); no broken links.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_doc_links.py
+++ b/tests/test_doc_links.py
@@ -1,0 +1,131 @@
+"""Contracts for the Markdown link checker used by CI.
+
+The checker's whole value is catching links that the Docusaurus build cannot
+see, so these tests pin the cases it must report. A link checker that silently
+matches nothing still exits 0, which is indistinguishable from a clean repo,
+so every "is reported" case here is paired with the accepted counterpart.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.check_doc_links import (  # pyright: ignore[reportMissingImports]
+    anchors_of,
+    check,
+    extract_links,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _repo(root: Path, files: dict[str, str]) -> Path:
+    """Materialize a fake repository from a path -> contents mapping."""
+    for name, text in files.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+    return root
+
+
+def _reasons(root: Path, *names: str) -> list[str]:
+    problems = check([root / name for name in names], root)
+    return [problem.reason for problem in problems]
+
+
+def test_relative_link_to_missing_file_is_reported(tmp_path: Path) -> None:
+    root = _repo(tmp_path, {"docs/a.md": "# A\n\n[gone](./b.md)\n"})
+
+    assert _reasons(root, "docs/a.md") == ["target does not exist"]
+
+
+def test_relative_link_between_siblings_in_docs_is_accepted(tmp_path: Path) -> None:
+    root = _repo(tmp_path, {"docs/a.md": "# A\n\n[b](b.md)\n", "docs/b.md": "# B\n"})
+
+    assert _reasons(root, "docs/a.md") == []
+
+
+def test_relative_link_escaping_the_published_tree_is_reported(tmp_path: Path) -> None:
+    """The defect that shipped: valid on GitHub, 404 on the docs site."""
+    root = _repo(
+        tmp_path,
+        {"docs/a.md": "# A\n\n[flags](../src/FLAGS.md)\n", "src/FLAGS.md": "# Flags\n"},
+    )
+
+    (reason,) = _reasons(root, "docs/a.md")
+    assert "escapes the published `docs/` tree" in reason
+
+
+def test_relative_link_outside_docs_may_escape_its_own_directory(tmp_path: Path) -> None:
+    """Only `docs/` is published, so the rule must not apply repo-wide."""
+    root = _repo(
+        tmp_path,
+        {"src/a.md": "# A\n\n[flags](../other/FLAGS.md)\n", "other/FLAGS.md": "# Flags\n"},
+    )
+
+    assert _reasons(root, "src/a.md") == []
+
+
+def test_absolute_repo_url_to_missing_path_is_reported(tmp_path: Path) -> None:
+    body = "# A\n\n[x](https://github.com/uw-syfi/vibesys/blob/main/src/gone.py)\n"
+    root = _repo(tmp_path, {"docs/a.md": body})
+
+    assert _reasons(root, "docs/a.md") == ["target does not exist"]
+
+
+def test_absolute_repo_url_to_existing_path_is_accepted(tmp_path: Path) -> None:
+    body = "# A\n\n[x](https://github.com/uw-syfi/vibesys/blob/main/src/FLAGS.md)\n"
+    root = _repo(tmp_path, {"docs/a.md": body, "src/FLAGS.md": "# Flags\n"})
+
+    assert _reasons(root, "docs/a.md") == []
+
+
+def test_third_party_urls_are_not_treated_as_repo_paths(tmp_path: Path) -> None:
+    root = _repo(tmp_path, {"docs/a.md": "# A\n\n[uv](https://docs.astral.sh/uv/)\n"})
+
+    assert _reasons(root, "docs/a.md") == []
+
+
+def test_missing_anchor_is_reported(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        {"docs/a.md": "# A\n\n[b](b.md#nope)\n", "docs/b.md": "# B\n\n## Real Heading\n"},
+    )
+
+    assert _reasons(root, "docs/a.md") == ["no `#nope` anchor in target"]
+
+
+def test_existing_anchor_is_accepted(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        {
+            "docs/a.md": "# A\n\n[b](b.md#real-heading)\n",
+            "docs/b.md": "# B\n\n## Real Heading\n",
+        },
+    )
+
+    assert _reasons(root, "docs/a.md") == []
+
+
+def test_links_inside_code_fences_are_ignored(tmp_path: Path) -> None:
+    body = "# A\n\n```\n[not a link](./gone.md)\n```\n"
+    root = _repo(tmp_path, {"docs/a.md": body})
+
+    assert extract_links(root / "docs/a.md") == []
+    assert _reasons(root, "docs/a.md") == []
+
+
+def test_reference_style_definitions_are_checked(tmp_path: Path) -> None:
+    root = _repo(tmp_path, {"docs/a.md": "# A\n\nSee [ref].\n\n[ref]: ./gone.md\n"})
+
+    assert _reasons(root, "docs/a.md") == ["target does not exist"]
+
+
+def test_anchors_cover_explicit_ids_and_repeated_headings(tmp_path: Path) -> None:
+    body = "# T\n\n## Setup {#install}\n\n## Notes\n\n## Notes\n"
+    root = _repo(tmp_path, {"docs/a.md": body})
+
+    anchors = anchors_of(root / "docs/a.md")
+
+    assert {"install", "notes", "notes-1"} <= anchors

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -21,8 +21,18 @@ const config: Config = {
   organizationName: 'uw-syfi',
   projectName: 'vibesys',
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  // Fail the build instead of warning. `warn` let broken links ship: the CI
+  // website build stayed green while the deployed site served dead links
+  // (docs/ links that escape the docs plugin's content root resolve to site
+  // URLs that were never built).
+  onBrokenLinks: 'throw',
+  onBrokenAnchors: 'throw',
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
+  },
 
   i18n: {
     defaultLocale: 'en',


### PR DESCRIPTION
## Problem

Six links in `docs/` are dead on the deployed site. They are live 404s right now, for example every "Extend VibeSys" link on https://docs.vibing.systems/docs/development:

```
/src/vibesys/domains/README.md     -> 404
/src/vibesys/FEATURE_FLAGS.md      -> 404
/resources/skills/README.md        -> 404
/clients/tui/README.md             -> 404
/.github/pull_request_template.md  -> 404
/examples/                         -> 404
```

All six were written as repo-relative links (`../src/vibesys/FEATURE_FLAGS.md`). Every target exists, so they render correctly on GitHub. The docs plugin serves `docs/` as its entire content root, so on the website they resolve to site URLs that were never built.

The detection was never missing. The Docusaurus build has been reporting all six on every run. `onBrokenLinks` was set to `'warn'`, so the build exited 0, `website.yml` stayed green, and `deploy-docs.yml` shipped them. This is the root cause: a check that reports but cannot fail.

## Solution

Three layers, because no single one covers the whole surface.

**1. Fix the links.** Rewritten as absolute `https://github.com/uw-syfi/vibesys/...` URLs, which resolve in both renderers. Two of the six are not prose and have no site representation anyway: `pull_request_template.md` is a GitHub mechanism, and `examples/` is a directory listing Docusaurus cannot render.

**2. Make the build fail.** `onBrokenLinks`, `onBrokenAnchors`, and `markdown.hooks.onBrokenMarkdownLinks` set to `'throw'`. This also migrates off the top-level `onBrokenMarkdownLinks`, which is deprecated in v4 and was emitting a warning on every build.

**3. Cover what the build cannot see.** The site build only validates what it renders, so it is structurally blind to absolute links back into this repo and to all Markdown outside `docs/`. `scripts/check_doc_links.py` checks both, plus `#anchor` targets, plus the rule that broke here: a relative link inside `docs/` may not escape `docs/`.

Considered and rejected: publishing the out-of-tree files into the site instead. Symlinks into `docs/` fail (Docusaurus routes them, then SSG throws resolving metadata for a real path outside the content root). An MDX stub importing `@site/../src/...` does work, but the imported page gets no on-page table of contents, "Edit this page" points at the stub, and it breaks the invariant that everything the site renders lives in `docs/`. Two of the six files are also shipped artifacts (`pyproject.toml` ships `domains/README.md` as package data; `MANIFEST.in` ships the TUI README), so they cannot move regardless. Whether contributor references like `FEATURE_FLAGS.md` belong on the site is an information-architecture decision, separate from this bug.

### Architecture

CI coverage is split so every path hits exactly one gate. `test.yml` ignores `*.md`, `docs/**`, and `website/**`; `website.yml` triggers on precisely those. Adding the checker to both closes the gap in either direction: a doc-only PR is covered by `website.yml`, and a PR that deletes a file one of the new absolute URLs points to (touching only `src/`) is covered by `test.yml`.

```mermaid
flowchart TD
    A[PR] --> B{changed paths}
    B -->|docs/, website/, root *.md| C[website.yml]
    B -->|everything else| D[test.yml lint]
    C --> E[check_doc_links.py]
    C --> F[npm run build<br/>onBrokenLinks: throw]
    D --> E
    E --> G[merge to main]
    F --> G
    G --> H[deploy-docs.yml -> Pages]
```

Because `deploy-docs.yml` builds from `main` with a committed lockfile and pinned Docusaurus, the deployed site is a deterministic function of `main`. With `website.yml` also running on `push: [main]`, "main is static-clean and the deploy succeeded" is sufficient to guarantee the served site has no broken internal links, with no need to crawl production.

## Verification

Every claim below was checked by running it, including confirming each gate actually fails on planted bad input.

### Correctness properties

- A relative link inside `docs/` that escapes `docs/` is reported. This is the defect that shipped.
- A relative link outside `docs/` may escape its own directory. Only `docs/` is published, so the rule is not repo-wide.
- An absolute repo URL whose path no longer exists is reported, so renaming a target invalidates the links introduced here instead of silently 404ing later.
- A `#anchor` that no target heading produces is reported; explicit `{#id}` and GitHub's `-1` suffixes for repeated headings are honored.
- Links inside fenced code blocks are not links.
- Third-party URLs are never fetched, so the check is offline and deterministic and safe as a PR gate.
- Vendored trees are excluded. `resources/skills/neuron-agentic-development/` is a mirror of `aws-neuron/neuron-agentic-development` and accounts for 350 broken links that belong to upstream. Excluding it, first-party Markdown had exactly the six fixed here.

### Testing

```
uv run pytest tests/test_doc_links.py     12 passed
./scripts/check_format.sh                 pass (362 files)
./scripts/check_lint.sh                   pass
uv run pyright scripts/check_doc_links.py tests/test_doc_links.py
                                          0 errors
uv run python scripts/check_doc_links.py  282 files, no broken links
npm run typecheck (website)               pass
npm run build (website)                   success, no warnings
```

Negative tests, confirming each gate fails rather than passing vacuously:

- Planted `../src/vibesys/does-not-exist.md` in `docs/development.md`: build exits 1, checker exits 1.
- Planted a bad anchor and a stale absolute repo URL: both reported.
- Planted `to="/docs/no-such-page"` in `src/pages/index.tsx`: build fails, confirming `onBrokenLinks` covers React routes, not just Markdown.
- Planted a missing Markdown image: build fails (Docusaurus already throws on these by default).

Before/after on the rendered page, same section:

```
deployed:  /src/vibesys/FEATURE_FLAGS.md                                          -> 404
this PR:   https://github.com/uw-syfi/vibesys/blob/main/src/vibesys/FEATURE_FLAGS.md
```

Not covered, deliberately: external URL rot (arXiv, the SyFI blog) and Pages/DNS failure are not statically detectable. All external targets returned 200 when checked manually. A scheduled liveness check would cover these, but it has zero hits today and is not part of this PR.
