### PR TITLE
Let round 1 decide whether to profile, and measure what it decides from

### DIFF
--- a/src/vibesys/loops/agent/issue_board.py
+++ b/src/vibesys/loops/agent/issue_board.py
@@ -402,6 +402,26 @@ def append_pre_round_decision(  # noqa: D103  # tracked: #288
     _append(progress_path, block, round_number)
 
 
+def append_cold_start_baseline(  # noqa: D103, PLR0913  # tracked: #288
+    progress_path: Path,
+    round_number: int,
+    *,
+    runnable: bool,
+    metric_name: str,
+    metric_value: float | None,
+    detail: str,
+) -> None:
+    verdict = "runnable" if runnable else "not runnable"
+    metric_line = f"- **{metric_name}**: {metric_value}\n" if metric_value is not None else ""
+    block = (
+        f"## Round {round_number} — Cold-start baseline\n"
+        f"- **verdict**: {verdict}\n"
+        f"{metric_line}\n"
+        f"### Detail\n{detail or '(no detail)'}\n"
+    )
+    _append(progress_path, block, round_number)
+
+
 def append_profiler_summary(  # noqa: D103  # tracked: #288
     progress_path: Path, round_number: int, summary: ProfilerSummary
 ) -> None:
@@ -633,11 +653,13 @@ def append_framework_benchmark(  # noqa: D103, PLR0913  # tracked: #288
     metric_name: str,
     metric_value: float | None,
     output: str,
+    attempt_label: str | None = None,
 ) -> None:
     verdict = "pass" if passed else "fail"
     metric_line = f"- **{metric_name}**: {metric_value}\n" if metric_value is not None else ""
+    attempt = attempt_label or f"attempt {retry}"
     block = (
-        f"## Round {round_number} — Framework benchmark (attempt {retry})\n"
+        f"## Round {round_number} — Framework benchmark ({attempt})\n"
         f"- **verdict**: {verdict}\n"
         f"- **command**: `{command}`\n"
         f"{metric_line}\n"

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -733,6 +733,92 @@ def _is_fresh_cold_start(round_number: int, records: list[RoundRecord]) -> bool:
     return round_number == 1 and not records
 
 
+# The focus a round asks for when nothing more specific has been established:
+# a cold start has no hypothesis to narrow it, and a pre-round decision may
+# request a profile without naming one.
+DEFAULT_PROFILE_FOCUS = "general steady-state benchmark hotspots"
+
+# Labels the cold-start probe's benchmark entry in the progress artifact. It
+# precedes any implementation, so numbering it as a judge retry would misread.
+_COLD_START_BASELINE_LABEL = "cold-start baseline"
+
+
+@dataclass(frozen=True)
+class ColdStartBaseline:
+    """Whether round 1's workspace runs, measured rather than inferred.
+
+    Rounds 2+ learn this from the previous round's record. Round 1 has none,
+    so the pre-round decision would otherwise guess at whether the candidate
+    can be profiled at all.
+    """
+
+    runnable: bool
+    metric_name: str
+    metric_value: float | None
+    detail: str
+
+
+def _run_cold_start_baseline(
+    ctx: LoopContext,
+    *,
+    benchmark_result: BenchmarkResult | None,
+    round_number: int,
+    progress_path: Path,
+    timeout_seconds: int | None,
+) -> ColdStartBaseline | None:
+    """Run the declared benchmark once, before round 1's first decision.
+
+    The benchmark command is the same one every later round is graded by, so
+    its exit code is ground truth about whether the candidate builds and runs.
+    Every other available signal (a pinned seed checkout, a declared result
+    contract, the objective text) describes intent rather than the state of
+    this workspace in this environment.
+
+    Returns ``None`` when no baseline can be established, which is not the
+    same as a failed one: the caller must not read absence as "does not run".
+    """
+    if ctx.agent_runner.backend_name == "stub":
+        return None
+    if benchmark_result is None or not ctx.judge_benchmark_command:
+        return None
+
+    ctx.lprint("[cold-start-baseline] establishing whether the candidate runs")
+    feedback, metric_value = _run_framework_benchmark(
+        ctx,
+        result_spec=benchmark_result,
+        round_number=round_number,
+        retry=0,
+        progress_path=progress_path,
+        timeout_seconds=timeout_seconds,
+        attempt_label=_COLD_START_BASELINE_LABEL,
+    )
+    runnable = feedback is None
+    detail = (
+        f"The declared benchmark completed and reported {benchmark_result.metric}={metric_value}."
+        if runnable
+        else (feedback or "").strip()[-2000:]
+    )
+    baseline = ColdStartBaseline(
+        runnable=runnable,
+        metric_name=benchmark_result.metric,
+        metric_value=metric_value,
+        detail=detail,
+    )
+    issue_board.append_cold_start_baseline(
+        progress_path,
+        round_number,
+        runnable=baseline.runnable,
+        metric_name=baseline.metric_name,
+        metric_value=baseline.metric_value,
+        detail=baseline.detail,
+    )
+    ctx.lprint(
+        f"[cold-start-baseline] {'runnable' if runnable else 'not runnable'}"
+        f"{f': {benchmark_result.metric}={metric_value}' if runnable else ''}"
+    )
+    return baseline
+
+
 def _run_pre_round_decision(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
@@ -741,6 +827,8 @@ def _run_pre_round_decision(  # noqa: PLR0913  # tracked: #288
     carry: _CarryOver,
     progress_path: Path,
     progress_location: str,
+    has_history: bool = True,
+    cold_start_baseline: ColdStartBaseline | None = None,
 ) -> PreRoundDecision:
     system_prompt = render_template(
         "orchestrator_pre_round_prompt.j2",
@@ -752,6 +840,13 @@ def _run_pre_round_decision(  # noqa: PLR0913  # tracked: #288
         progress_location=progress_location,
         profiler_kind=ctx.profiler_kind.value,
         profile_execution=ctx.run_environment_view.profile_execution,
+        has_history=has_history,
+        baseline_runnable=(None if cold_start_baseline is None else cold_start_baseline.runnable),
+        baseline_metric=(
+            None
+            if cold_start_baseline is None or cold_start_baseline.metric_value is None
+            else f"{cold_start_baseline.metric_name}={cold_start_baseline.metric_value}"
+        ),
     )
     decision = _invoke_read_only_role(
         ctx,
@@ -1791,6 +1886,7 @@ def _run_framework_benchmark(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracke
     progress_path: Path,
     timeout_seconds: int | None = None,
     candidate_revision: str | None = None,
+    attempt_label: str | None = None,
 ) -> tuple[str | None, float | None]:
     """Run and parse an opt-in trusted benchmark result contract."""
     if result_spec is None:
@@ -1886,6 +1982,7 @@ def _run_framework_benchmark(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracke
         metric_name=result_spec.metric,
         metric_value=metric_value,
         output=output[-8000:],
+        attempt_label=attempt_label,
     )
     ctx.snapshot_workspace(f"round-{round_number}-retry-{retry}-framework-benchmark")
     if passed:
@@ -2181,30 +2278,44 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                 pre_decision: PreRoundDecision | None = None
                 if active_hypothesis is None:
                     if inner_loop == "multi-agent":
-                        if not _is_fresh_cold_start(round_number, records):
-                            pre_decision = _run_pre_round_decision(
+                        # Round 1 used to skip this decision outright, which
+                        # also skipped the profiler nested under it: the round
+                        # holding the least evidence was the one round where
+                        # nothing could ask for measurement. It now decides
+                        # like every other round. What it lacks is a prior
+                        # record telling it whether the candidate runs, so a
+                        # cold start measures that first instead of guessing.
+                        cold_start = _is_fresh_cold_start(round_number, records)
+                        cold_start_baseline: ColdStartBaseline | None = None
+                        if cold_start and ctx.profiler_kind is not ProfilerKind.NONE:
+                            cold_start_baseline = _run_cold_start_baseline(
+                                ctx,
+                                benchmark_result=benchmark_result,
+                                round_number=round_number,
+                                progress_path=progress_path,
+                                timeout_seconds=benchmark_timeout_seconds,
+                            )
+                        pre_decision = _run_pre_round_decision(
+                            ctx,
+                            round_number=round_number,
+                            objective=objective,
+                            carry=carry,
+                            progress_path=progress_path,
+                            progress_location=progress_location,
+                            has_history=not cold_start,
+                            cold_start_baseline=cold_start_baseline,
+                        )
+                        if pre_decision.need_profile and ctx.profiler_kind is not ProfilerKind.NONE:
+                            profiler_summary = _run_profiler(
                                 ctx,
                                 round_number=round_number,
-                                objective=objective,
-                                carry=carry,
+                                profile_focus=pre_decision.profile_focus or DEFAULT_PROFILE_FOCUS,
+                                modality=modality,
+                                interface=interface,
+                                domain_definition=domain_definition,
                                 progress_path=progress_path,
-                                progress_location=progress_location,
+                                objective=objective,
                             )
-                            if (
-                                pre_decision.need_profile
-                                and ctx.profiler_kind is not ProfilerKind.NONE
-                            ):
-                                profiler_summary = _run_profiler(
-                                    ctx,
-                                    round_number=round_number,
-                                    profile_focus=pre_decision.profile_focus
-                                    or "general steady-state benchmark hotspots",
-                                    modality=modality,
-                                    interface=interface,
-                                    domain_definition=domain_definition,
-                                    progress_path=progress_path,
-                                    objective=objective,
-                                )
                     elif last_single_agent_response is not None:
                         profiler_summary = _profiler_summary_from_single_agent(
                             last_single_agent_response

--- a/src/vibesys/prompts/loops/agent/orchestrator_pre_round_prompt.j2
+++ b/src/vibesys/prompts/loops/agent/orchestrator_pre_round_prompt.j2
@@ -2,11 +2,19 @@ You are the Orchestrator. Decide only whether new profiling is needed before
 the next design call. Do not edit code, restore checkpoints, run implementation
 tests, or launch other evaluations.
 
+{% if has_history|default(true) %}
 Read the objective at `{{ objective_location|default('OBJECTIVE.md') }}` and the
 latest relevant entry under `{{ progress_location|default('progress.md') }}`.
 Keep this routing decision bounded: normally inspect no more than one older
 named entry or one narrow skill reference, and only when it can change the
 yes/no answer. Do not inventory the campaign or roadmap.
+{% else %}
+Read the objective at `{{ objective_location|default('OBJECTIVE.md') }}`. This is
+round 1: no round has run, so `{{ progress_location|default('progress.md') }}`
+holds no campaign history to consult. Decide from the objective and the
+candidate source. Keep this routing decision bounded: read enough source to
+judge whether measurement would change the first plan, and stop there.
+{% endif %}
 
 {% if profiler_kind|default('none') == 'none' %}
 Standalone profiling is disabled. Set `need_profile=false`; record any missing
@@ -31,6 +39,33 @@ determines the next step, when the current defect needs a local repair, or when
 the workspace contains terminal edits and planning must first select/restore a
 trusted checkpoint. This phase cannot apply rollback.
 
+{% if not has_history|default(true) %}
+Profiling measures a running system, so establish that one exists before
+weighing whether its evidence would help. A later round reads that from the
+previous round's result; round 1 has no such record.
+{% if baseline_runnable is sameas true %}
+The framework ran the declared benchmark against this workspace before asking
+you, and it completed.{% if baseline_metric %} It reported `{{ baseline_metric }}`.{% endif %}
+The candidate builds and runs, so profiling is possible. Decide on evidentiary
+value alone: round 1 has no prior measurement, so a profile is the only way
+this campaign's first plan can target a measured bottleneck rather than a
+guessed one.
+{% elif baseline_runnable is sameas false %}
+The framework ran the declared benchmark against this workspace before asking
+you and it did not complete; the cold-start baseline entry under
+`{{ progress_location|default('progress.md') }}` records the failure. Nothing
+runs yet, so no profile is possible regardless of how useful its evidence would
+be. Set `need_profile=false` and record that the next round's work is to make
+the candidate build and run.
+{% else %}
+No baseline was established, so whether this candidate runs is unverified. That
+is not evidence that it fails. Judge it from the source, and prefer
+`need_profile=false` when you cannot establish that the system runs: a skipped
+profile costs one round of unmeasured planning, while profiling a candidate
+that does not run spends an expensive turn and risks a summary with no
+measurement behind it.
+{% endif %}
+{% endif %}
 {% if regression_info %}
 The latest progress entry records a regression or terminal-workspace notice;
 read it before deciding whether the current tree is meaningful to profile.

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -2810,10 +2810,11 @@ def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):  # 
     profiler_prompts: list[str] = []
     runner = _make_orchestrate_runner(
         pre_decisions=[
+            PreRoundDecision(need_profile=False, profile_focus="", reasoning="read the source"),
             PreRoundDecision(need_profile=True, profile_focus="kernels", reasoning="need data"),
         ],
         plans=[
-            # Round 1 cold-start plan (no pre-decision invoked on round 1).
+            # Round 1 plan: its pre-decision declined, so no profile precedes it.
             OrchestratorPlan(
                 task="Build server",
                 pass_criteria="ok",  # noqa: S106  # tracked: #288
@@ -2853,10 +2854,8 @@ def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):  # 
 
     result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=2)
     assert result is True
-    # Round 1 cold-start: no pre → just plan.
-    # Round 2: pre → profiler → plan.
-    assert call_order[:1] == ["plan"]
-    assert "profiler" in call_order
+    # Round 1: pre declined → just plan. Round 2: pre → profiler → plan.
+    assert call_order == ["pre", "plan", "pre", "profiler", "plan"]
     plan_idx = [i for i, c in enumerate(call_order) if c == "plan"]
     prof_idx = call_order.index("profiler")
     # Profiler must come BEFORE the round-2 plan call.
@@ -2881,7 +2880,8 @@ def test_loop_skips_profiler_when_pre_round_decision_says_no(tmp_path, ref_file)
     result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=2)
 
     assert result is True
-    assert runner.counters["orch_pre"] == 1
+    # Both rounds decide, including round 1; neither asked for a profile.
+    assert runner.counters["orch_pre"] == 2
     assert runner.counters["prof"] == 0
 
 
@@ -2909,7 +2909,7 @@ def test_loop_skips_profiler_when_profiler_kind_is_none(tmp_path, ref_file):  # 
     )
 
     assert result is True
-    assert runner.counters["orch_pre"] == 1
+    assert runner.counters["orch_pre"] == 2
     assert runner.counters["prof"] == 0
 
 
@@ -2944,8 +2944,305 @@ def test_loop_generic_auto_profiler_resolves_to_macos_cpu(tmp_path, ref_file):  
         )
 
     assert result is True
-    assert runner.counters["orch_pre"] == 1
+    assert runner.counters["orch_pre"] == 2
     assert runner.counters["prof"] == 1
+
+
+def test_loop_asks_whether_to_profile_before_the_first_plan(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """Round 1 routes through the same pre-round decision as every other round.
+
+    It used to skip that decision outright, which also skipped the profiler
+    nested under it: the round holding the least evidence was the one round
+    where nothing could ask for measurement.
+    """
+    call_order: list[str] = []
+    plan_prompts: list[str] = []
+    runner = _make_orchestrate_runner(
+        pre_decisions=[
+            PreRoundDecision(need_profile=True, profile_focus="decode", reasoning="no evidence"),
+        ],
+        plans=[
+            OrchestratorPlan(
+                task="Cut the measured hotspot",
+                pass_criteria="ok",  # noqa: S106  # tracked: #288
+                reasoning="the baseline profile named it",
+            ),
+        ],
+        profiler_responses=[
+            ProfilerSummary(
+                analysis="decode is launch-bound",
+                bottlenecks="host-side sync",
+                suggestions="cuda graph",
+                perf_metric=5.0,
+                perf_unit="req/s",
+            ),
+        ],
+    )
+    real_invoke = runner.invoke.side_effect
+
+    def spy_invoke(*, kind, response_cls, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
+        if kind == "profiler":
+            call_order.append("profiler")
+        elif kind == "orchestrator" and response_cls is OrchestratorPlan:
+            call_order.append("plan")
+            plan_prompts.append(kwargs.get("system_prompt", ""))
+        elif kind == "orchestrator" and response_cls is PreRoundDecision:
+            call_order.append("pre")
+        return real_invoke(kind=kind, response_cls=response_cls, **kwargs)
+
+    runner.invoke.side_effect = spy_invoke
+
+    result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1)
+
+    assert result is True
+    # The decision precedes the profiler, which precedes the plan it informs.
+    assert call_order == ["pre", "profiler", "plan"]
+    # The measurement reaches the planner rather than merely being collected.
+    # The plan prompt is path-only, so it names the evidence instead of
+    # embedding it; that section renders only when a summary was threaded in.
+    assert "The fresh profiler result is recorded" in plan_prompts[0]
+
+
+def test_loop_first_round_profiles_only_when_its_decision_asks(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """A round-1 decline costs no profiler turn.
+
+    A campaign that builds from scratch has nothing to profile yet. The
+    decision is what keeps that run from spending the turn, so a declined
+    round 1 must reach its plan with no profiler call at all.
+    """
+    runner = _make_orchestrate_runner(
+        pre_decisions=[
+            PreRoundDecision(
+                need_profile=False,
+                profile_focus="",
+                reasoning="nothing runs yet; round 1 must make it build",
+            ),
+        ],
+        plans=[
+            OrchestratorPlan(
+                task="Make the service build",
+                pass_criteria="compiles",  # noqa: S106  # tracked: #288
+                reasoning="no measurable system yet",
+            ),
+        ],
+    )
+
+    result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1)
+
+    assert result is True
+    assert runner.counters["orch_pre"] == 1
+    assert runner.counters["prof"] == 0
+
+
+def test_cold_start_baseline_reports_a_runnable_candidate(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.input_manifest import BenchmarkResult  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.agent.loop import _run_cold_start_baseline  # noqa: PLC0415  # tracked: #288
+
+    ctx = MagicMock()
+    ctx.agent_runner.backend_name = "deepagents"
+    ctx.judge_benchmark_command = "trusted-benchmark"
+    progress = tmp_path / "progress.md"
+
+    with patch(
+        "vibesys.loops.agent.loop._run_framework_benchmark",
+        return_value=(None, 41.5),
+    ) as benchmark:
+        baseline = _run_cold_start_baseline(
+            ctx,
+            benchmark_result=BenchmarkResult(json_argument="--json", metric="primary_value"),
+            round_number=1,
+            progress_path=progress,
+            timeout_seconds=300,
+        )
+
+    assert baseline is not None
+    assert baseline.runnable is True
+    assert baseline.metric_value == 41.5
+    assert baseline.metric_name == "primary_value"
+    # The probe is labelled, not numbered as a judge retry: it precedes any
+    # implementation, so "attempt 0" would misread the progress artifact.
+    assert benchmark.call_args.kwargs["attempt_label"] == "cold-start baseline"
+    assert "Cold-start baseline" in progress.read_text()
+    assert "runnable" in progress.read_text()
+
+
+def test_cold_start_baseline_reports_a_candidate_that_does_not_run(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.input_manifest import BenchmarkResult  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.agent.loop import _run_cold_start_baseline  # noqa: PLC0415  # tracked: #288
+
+    ctx = MagicMock()
+    ctx.agent_runner.backend_name = "deepagents"
+    ctx.judge_benchmark_command = "trusted-benchmark"
+    progress = tmp_path / "progress.md"
+
+    with patch(
+        "vibesys.loops.agent.loop._run_framework_benchmark",
+        return_value=("Framework benchmark failed.\ngo: cannot find module", None),
+    ):
+        baseline = _run_cold_start_baseline(
+            ctx,
+            benchmark_result=BenchmarkResult(json_argument="--json", metric="primary_value"),
+            round_number=1,
+            progress_path=progress,
+            timeout_seconds=300,
+        )
+
+    assert baseline is not None
+    assert baseline.runnable is False
+    assert baseline.metric_value is None
+    assert "cannot find module" in baseline.detail
+    assert "not runnable" in progress.read_text()
+
+
+def test_cold_start_baseline_absent_is_not_evidence_that_nothing_runs(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    """No declared result contract yields no baseline, not a failed one."""
+    from vibesys.loops.agent.loop import _run_cold_start_baseline  # noqa: PLC0415  # tracked: #288
+
+    ctx = MagicMock()
+    ctx.agent_runner.backend_name = "deepagents"
+    ctx.judge_benchmark_command = "trusted-benchmark"
+
+    assert (
+        _run_cold_start_baseline(
+            ctx,
+            benchmark_result=None,
+            round_number=1,
+            progress_path=tmp_path / "progress.md",
+            timeout_seconds=300,
+        )
+        is None
+    )
+
+
+def test_cold_start_baseline_reaches_the_first_pre_round_decision(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """The measured verdict is what the round-1 decision reasons from.
+
+    Rounds 2+ read whether the candidate runs from the previous round's
+    record. Round 1 has none, so the benchmark's exit code stands in for it.
+    """
+    from vibesys.input_manifest import BenchmarkResult  # noqa: PLC0415  # tracked: #288
+
+    pre_prompts: list[str] = []
+    runner = _make_orchestrate_runner(
+        pre_decisions=[
+            PreRoundDecision(need_profile=True, profile_focus="decode", reasoning="it runs"),
+        ],
+        plans=[
+            OrchestratorPlan(task="Optimize", pass_criteria="ok", reasoning="measured"),  # noqa: S106  # tracked: #288
+        ],
+        profiler_responses=[
+            ProfilerSummary(
+                analysis="decode is launch-bound",
+                bottlenecks="sync",
+                suggestions="graph",
+                perf_metric=5.0,
+                perf_unit="req/s",
+            ),
+        ],
+    )
+    real_invoke = runner.invoke.side_effect
+
+    def spy_invoke(*, kind, response_cls, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
+        if kind == "orchestrator" and response_cls is PreRoundDecision:
+            pre_prompts.append(kwargs.get("system_prompt", ""))
+        return real_invoke(kind=kind, response_cls=response_cls, **kwargs)
+
+    runner.invoke.side_effect = spy_invoke
+
+    with patch(
+        "vibesys.loops.agent.loop._run_framework_benchmark",
+        return_value=(None, 41.5),
+    ) as benchmark:
+        result = _invoke_orchestrate(
+            tmp_path,
+            ref_file,
+            runner,
+            max_rounds=1,
+            benchmark_result=BenchmarkResult(json_argument="--json", metric="primary_value"),
+        )
+
+    assert result is True
+    assert benchmark.call_args_list[0].kwargs["attempt_label"] == "cold-start baseline"
+    assert "primary_value=41.5" in pre_prompts[0]
+    assert "The candidate builds and runs, so profiling is possible" in pre_prompts[0]
+    # Round 1 has no campaign history, and the prompt must not claim otherwise.
+    assert "latest relevant entry under" not in pre_prompts[0]
+    assert "This is\nround 1" in pre_prompts[0]
+
+
+def test_cold_start_baseline_reports_a_broken_candidate_to_the_decision(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """A candidate that does not build tells round 1 to skip profiling."""
+    from vibesys.input_manifest import BenchmarkResult  # noqa: PLC0415  # tracked: #288
+
+    pre_prompts: list[str] = []
+    runner = _make_orchestrate_runner(
+        pre_decisions=[
+            PreRoundDecision(need_profile=False, profile_focus="", reasoning="nothing runs"),
+        ],
+        plans=[
+            OrchestratorPlan(task="Make it build", pass_criteria="ok", reasoning="broken"),  # noqa: S106  # tracked: #288
+        ],
+    )
+    real_invoke = runner.invoke.side_effect
+
+    def spy_invoke(*, kind, response_cls, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
+        if kind == "orchestrator" and response_cls is PreRoundDecision:
+            pre_prompts.append(kwargs.get("system_prompt", ""))
+        return real_invoke(kind=kind, response_cls=response_cls, **kwargs)
+
+    runner.invoke.side_effect = spy_invoke
+
+    with patch(
+        "vibesys.loops.agent.loop._run_framework_benchmark",
+        return_value=("Framework benchmark failed.\ngo: cannot find module", None),
+    ):
+        result = _invoke_orchestrate(
+            tmp_path,
+            ref_file,
+            runner,
+            max_rounds=1,
+            benchmark_result=BenchmarkResult(json_argument="--json", metric="primary_value"),
+        )
+
+    assert result is True
+    assert "it did not complete" in pre_prompts[0]
+    assert "Set `need_profile=false`" in pre_prompts[0]
+    assert runner.counters["prof"] == 0
+
+
+def test_cold_start_baseline_runs_once_and_only_on_the_first_round(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """Later rounds read runnability from their predecessor, not a re-probe."""
+    from vibesys.input_manifest import BenchmarkResult  # noqa: PLC0415  # tracked: #288
+
+    runner = _make_orchestrate_runner(
+        pre_decisions=[
+            PreRoundDecision(need_profile=False, profile_focus="", reasoning="one"),
+            PreRoundDecision(need_profile=False, profile_focus="", reasoning="two"),
+        ],
+        plans=[
+            OrchestratorPlan(task="One", pass_criteria="ok", reasoning="r1"),  # noqa: S106  # tracked: #288
+            OrchestratorPlan(task="Two", pass_criteria="ok", reasoning="r2"),  # noqa: S106  # tracked: #288
+        ],
+    )
+
+    with patch(
+        "vibesys.loops.agent.loop._run_framework_benchmark",
+        return_value=(None, 41.5),
+    ) as benchmark:
+        result = _invoke_orchestrate(
+            tmp_path,
+            ref_file,
+            runner,
+            max_rounds=2,
+            benchmark_result=BenchmarkResult(json_argument="--json", metric="primary_value"),
+        )
+
+    assert result is True
+    baseline_calls = [
+        call for call in benchmark.call_args_list if call.kwargs.get("attempt_label") is not None
+    ]
+    assert len(baseline_calls) == 1
+    assert baseline_calls[0].kwargs["round_number"] == 1
 
 
 def test_loop_runs_full_max_rounds_budget(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288

--- a/tests/loops/agent/test_prompt_snapshots.py
+++ b/tests/loops/agent/test_prompt_snapshots.py
@@ -511,6 +511,66 @@ def test_pre_round_prompt_disables_none_profiler_without_fake_capture_path():  #
     assert "`remote` capture path" not in rendered
 
 
+def _pre_round(**overrides: object) -> str:
+    context: dict[str, object] = {
+        "objective_location": "OBJECTIVE.md",
+        "progress_location": "progress.md",
+        "profiler_kind": "otel",
+        "profile_execution": "local",
+    }
+    context.update(overrides)
+    return render_template(
+        "orchestrator_pre_round_prompt.j2", template_dir=_TEMPLATE_DIR, **context
+    )
+
+
+def test_pre_round_prompt_defaults_to_the_campaign_history_reading():  # noqa: ANN201  # tracked: #288
+    """Omitting ``has_history`` must not silently render round 1's text."""
+    rendered = _pre_round()
+
+    assert "latest relevant entry under `progress.md`" in rendered
+    assert "This is\nround 1" not in rendered
+    assert "Profiling measures a running system" not in rendered
+
+
+def test_pre_round_prompt_does_not_send_round_one_after_absent_history():  # noqa: ANN201  # tracked: #288
+    rendered = _pre_round(has_history=False)
+
+    assert "This is\nround 1" in rendered
+    assert "latest relevant entry under" not in rendered
+    assert "Profiling measures a running system" in rendered
+
+
+def test_pre_round_prompt_reports_a_runnable_cold_start_baseline():  # noqa: ANN201  # tracked: #288
+    rendered = _pre_round(
+        has_history=False,
+        baseline_runnable=True,
+        baseline_metric="primary_value=41.5",
+    )
+
+    assert "It reported `primary_value=41.5`." in rendered
+    assert "The candidate builds and runs, so profiling is possible" in rendered
+    assert "Set `need_profile=false`" not in rendered
+
+
+def test_pre_round_prompt_forbids_profiling_a_cold_start_that_does_not_run():  # noqa: ANN201  # tracked: #288
+    rendered = _pre_round(has_history=False, baseline_runnable=False)
+
+    assert "it did not complete" in rendered
+    assert "Set `need_profile=false`" in rendered
+    assert "builds and runs" not in rendered
+
+
+def test_pre_round_prompt_treats_an_absent_baseline_as_unverified():  # noqa: ANN201  # tracked: #288
+    """No baseline is not evidence of failure, but it does not license a profile."""
+    rendered = _pre_round(has_history=False)
+
+    assert "unverified" in rendered
+    assert "is not evidence that it fails" in rendered
+    assert "prefer\n`need_profile=false`" in rendered
+    assert "it did not complete" not in rendered
+
+
 def test_official_evaluation_due_changes_agent_measurement_contract():  # noqa: ANN201  # tracked: #288
     context = _CONTEXTS["full"] | {
         "official_evaluation_due": True,


### PR DESCRIPTION
## Problem

Round 1 was the only round with a hardcoded answer to "should we profile before
planning". `_is_fresh_cold_start` skipped the pre-round decision, and the
profiler invocation was nested under that skip:

```python
if not _is_fresh_cold_start(round_number, records):
    pre_decision = _run_pre_round_decision(...)
    if pre_decision.need_profile and ctx.profiler_kind is not ProfilerKind.NONE:
        profiler_summary = _run_profiler(...)
```

Skipping the decision on a cold start had a reason: it reads the latest
`progress.md` entry, and there is none. But nesting the profiler under that skip
made round 1 the one round where nothing *could* request measurement, because
requesting it is the pre-round decision's job. The orchestrator picked the first
plan of every campaign from the objective text and a source read.

This replaces #361, which fixed the same gap by profiling round 1
unconditionally. That drew the right objection: it may not be feasible to
profile in round 1, because a from-scratch campaign or a seed that does not
build has nothing to measure. Profiling a candidate that does not run is worse
than not profiling. `_run_profiler` catches errors, but the likelier outcome is
a schema-valid `ProfilerSummary` derived from reading source rather than
measuring, which flows into the plan as if it were evidence.

Related to #318; complements #360.

## Solution

Two changes, one behavioral and one that makes it decidable.

**Round 1 decides like every other round.** The cold-start branch is gone. The
pre-round decision runs unconditionally, and `_is_fresh_cold_start` survives
only as the source of a `has_history` template flag. A seeded, working repo can
now answer yes on round 1; a from-scratch campaign can answer no. Same mechanism
either way, and the reasoning is recorded in `progress.md` rather than being a
structural hole.

**A cold start measures whether it can be profiled.** Rounds 2+ infer
runnability from the previous round's record. Round 1 has none, so it would be
guessing. `_run_cold_start_baseline` runs the declared `[benchmark]` command once
before the first decision. Its exit code is ground truth: the candidate builds
and runs, or it does not.

Every other candidate signal was considered and rejected as inference rather
than observation. `[benchmark.result]` is a parsing schema (`json_argument`,
`metric`), not a measured value. `trusted_input_baseline` is a git revision.
`[[workspace.sources]]` appears in 2 of 22 example manifests, and its absence
does not imply from-scratch since most examples ship source in the example
directory. All 22 declare `[benchmark]`.

The verdict reaches the decision through three prompt branches: measured
runnable, measured broken, and no baseline established. The third is
deliberately not treated as failure; it states the asymmetry (a skipped profile
costs one round of unmeasured planning, a profile of a broken candidate spends
an expensive turn and risks a fabricated summary) and prefers `need_profile=false`.

### Architecture

No new components. One call site moves out from under a guard it did not belong
to, and one probe is added ahead of it.

```mermaid
flowchart TD
  R{"fresh cold start?"}
  R -->|"yes (was: skip everything)"| B["_run_cold_start_baseline"]
  B --> D
  R -->|no| D["_run_pre_round_decision"]
  D --> N{"need_profile and profiler attached?"}
  N -->|yes| P["_run_profiler"]
  N -->|no| O
  P --> O["_run_orchestrator_plan(profiler_summary=...)"]
```

The baseline probe reuses `_run_framework_benchmark` rather than duplicating its
JSON extraction. That function gained one optional `attempt_label` parameter so
the probe's progress entry reads "cold-start baseline" instead of "attempt 0";
it precedes any implementation, so numbering it as a judge retry would misread.

## Verification

### Correctness properties

- **Rounds 2+ are unchanged.** The rendered prompt for a round with history is
  byte-identical to `main`; verified by diffing the rendered output across the
  change. `has_history` defaults to `true`, so any caller omitting it keeps the
  established text.
- **Non-profiling runs do not pay for the probe.** The baseline is gated on
  `ctx.profiler_kind is not ProfilerKind.NONE`. `prof == 0` still holds for
  `--profiler none`.
- **The probe runs once, on round 1 only.** Guarded by `_is_fresh_cold_start`,
  which requires an empty round-record list, so resumed runs do not re-probe.
- **Absence of a baseline is not treated as failure.** `_run_cold_start_baseline`
  returns `None` when no result contract is declared, and the prompt's third
  branch says so explicitly rather than asserting the candidate is broken.
- **A broken candidate does not get profiled.** The measured-broken branch
  instructs `need_profile=false` and names the next round's work.
- **The measurement reaches the planner.** Round 1's plan prompt renders its
  profiler section, which only happens when a summary was threaded in.

### Testing

```
uv run pytest tests/loops/agent -q --no-cov     275 passed
uv run pytest -q --no-cov                       4060 passed, 8 skipped, 1 failed
uv run ruff check                               All checks passed
uv run ruff format --check                      372 files already formatted
```

The single full-suite failure is
`tests/test_tui.py::test_cli_parse_failure_is_streamed_after_client_attaches`.
It fails identically on a clean `main` (verified by stashing this branch and
re-running it), and is unrelated to this change.

**New tests.** `test_loop_asks_whether_to_profile_before_the_first_plan` pins the
round-1 call order to `["pre", "profiler", "plan"]` on a one-round run and
asserts the profiler section renders in that round's plan prompt, which is the
direct evidence that round-1 profiling now works end to end.
`test_loop_first_round_profiles_only_when_its_decision_asks` covers the
from-scratch case: a declined round 1 costs no profiler turn.
`test_cold_start_baseline_reaches_the_first_pre_round_decision` and
`test_cold_start_baseline_reports_a_broken_candidate_to_the_decision` assert the
measured verdict reaches the round-1 prompt in both directions. Three unit tests
cover `_run_cold_start_baseline` (runnable, broken, no contract), one asserts the
probe fires once and only on round 1, and five prompt-render tests pin each
branch including the `has_history` default.

**Changed tests.** Four existing tests asserted `orch_pre == 1` across two rounds
and now assert `2`, which is the behavior change itself: round 1 asks.
`test_loop_orchestrator_requests_profile_before_plan` gained a second scripted
`PreRoundDecision` so round 1 declines and round 2 accepts, preserving its
original subject (the profiler precedes the plan it informs) rather than
retargeting it.

### Cost

One cheap read-only orchestrator turn on round 1 for every multi-agent run,
including `--profiler none` runs, where the decision is forced to `false` by the
prompt. Rounds 2+ already pay this on non-profiling runs; skipping it whenever
profiling is disabled would be a uniform win but changes existing rounds, so it
is left out of this PR.

For runs with a profiler attached and a declared result contract, one benchmark
execution on round 1. That is the same command the campaign runs every round.

### Follow-up

The pre-round decision is the only agent call that receives no
`render_domain_section`. `microservices/orchestrator.md` goes to the plan call
and `microservices/profiler.md` goes to the profiler, both downstream, so the
agent deciding whether to profile a microservices system only sees the string
`otel`. Worth addressing separately.
