### PR TITLE
Let round 1 decide whether to profile

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -741,6 +741,7 @@ def _run_pre_round_decision(  # noqa: PLR0913  # tracked: #288
     carry: _CarryOver,
     progress_path: Path,
     progress_location: str,
+    has_history: bool = True,
 ) -> PreRoundDecision:
     system_prompt = render_template(
         "orchestrator_pre_round_prompt.j2",
@@ -752,6 +753,7 @@ def _run_pre_round_decision(  # noqa: PLR0913  # tracked: #288
         progress_location=progress_location,
         profiler_kind=ctx.profiler_kind.value,
         profile_execution=ctx.run_environment_view.profile_execution,
+        has_history=has_history,
     )
     decision = _invoke_read_only_role(
         ctx,
@@ -2181,30 +2183,33 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                 pre_decision: PreRoundDecision | None = None
                 if active_hypothesis is None:
                     if inner_loop == "multi-agent":
-                        if not _is_fresh_cold_start(round_number, records):
-                            pre_decision = _run_pre_round_decision(
+                        # Round 1 used to skip this decision, which also skipped
+                        # the profiler nested under it: the round holding the
+                        # least evidence was the one round where nothing could
+                        # ask for measurement. It now decides like every other
+                        # round, told by ``has_history`` that it has no prior
+                        # entry to read and must establish runnability itself.
+                        pre_decision = _run_pre_round_decision(
+                            ctx,
+                            round_number=round_number,
+                            objective=objective,
+                            carry=carry,
+                            progress_path=progress_path,
+                            progress_location=progress_location,
+                            has_history=not _is_fresh_cold_start(round_number, records),
+                        )
+                        if pre_decision.need_profile and ctx.profiler_kind is not ProfilerKind.NONE:
+                            profiler_summary = _run_profiler(
                                 ctx,
                                 round_number=round_number,
-                                objective=objective,
-                                carry=carry,
+                                profile_focus=pre_decision.profile_focus
+                                or "general steady-state benchmark hotspots",
+                                modality=modality,
+                                interface=interface,
+                                domain_definition=domain_definition,
                                 progress_path=progress_path,
-                                progress_location=progress_location,
+                                objective=objective,
                             )
-                            if (
-                                pre_decision.need_profile
-                                and ctx.profiler_kind is not ProfilerKind.NONE
-                            ):
-                                profiler_summary = _run_profiler(
-                                    ctx,
-                                    round_number=round_number,
-                                    profile_focus=pre_decision.profile_focus
-                                    or "general steady-state benchmark hotspots",
-                                    modality=modality,
-                                    interface=interface,
-                                    domain_definition=domain_definition,
-                                    progress_path=progress_path,
-                                    objective=objective,
-                                )
                     elif last_single_agent_response is not None:
                         profiler_summary = _profiler_summary_from_single_agent(
                             last_single_agent_response

--- a/src/vibesys/prompts/loops/agent/orchestrator_pre_round_prompt.j2
+++ b/src/vibesys/prompts/loops/agent/orchestrator_pre_round_prompt.j2
@@ -2,11 +2,19 @@ You are the Orchestrator. Decide only whether new profiling is needed before
 the next design call. Do not edit code, restore checkpoints, run implementation
 tests, or launch other evaluations.
 
+{% if has_history|default(true) %}
 Read the objective at `{{ objective_location|default('OBJECTIVE.md') }}` and the
 latest relevant entry under `{{ progress_location|default('progress.md') }}`.
 Keep this routing decision bounded: normally inspect no more than one older
 named entry or one narrow skill reference, and only when it can change the
 yes/no answer. Do not inventory the campaign or roadmap.
+{% else %}
+Read the objective at `{{ objective_location|default('OBJECTIVE.md') }}`. This is
+round 1: `{{ progress_location|default('progress.md') }}` holds no result to
+read and no earlier profile to reuse. Decide from the objective and the
+candidate source, reading only enough to judge whether measurement would change
+the first plan.
+{% endif %}
 
 {% if profiler_kind|default('none') == 'none' %}
 Standalone profiling is disabled. Set `need_profile=false`; record any missing
@@ -31,6 +39,23 @@ determines the next step, when the current defect needs a local repair, or when
 the workspace contains terminal edits and planning must first select/restore a
 trusted checkpoint. This phase cannot apply rollback.
 
+{% if not has_history|default(true) %}
+Profiling measures a running system, and round 1 has no prior result saying one
+exists. A pinned seed checkout or a declared benchmark contract states intent,
+not the state of this workspace, so despite the restriction above you may run
+one cheap check to settle it; leave no long-lived process behind and never
+stand in for a benchmark run.
+
+If it does not build or run, no profile is possible however useful its evidence
+would be: set `need_profile=false` and record that the next round's work is to
+make it run. If it does run, decide on evidentiary value alone, weighing that
+round 1 holds no measurement at all, so a profile is the only way this
+campaign's first plan can target a measured bottleneck rather than a guessed
+one. If the check is inconclusive, prefer `need_profile=false`: a skipped
+profile costs one round of unmeasured planning, while profiling a candidate
+that does not run spends an expensive turn on a summary with no measurement
+behind it.
+{% endif %}
 {% if regression_info %}
 The latest progress entry records a regression or terminal-workspace notice;
 read it before deciding whether the current tree is meaningful to profile.

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -2810,10 +2810,11 @@ def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):  # 
     profiler_prompts: list[str] = []
     runner = _make_orchestrate_runner(
         pre_decisions=[
+            PreRoundDecision(need_profile=False, profile_focus="", reasoning="read the source"),
             PreRoundDecision(need_profile=True, profile_focus="kernels", reasoning="need data"),
         ],
         plans=[
-            # Round 1 cold-start plan (no pre-decision invoked on round 1).
+            # Round 1 plan: its own decision declined, so no profile precedes it.
             OrchestratorPlan(
                 task="Build server",
                 pass_criteria="ok",  # noqa: S106  # tracked: #288
@@ -2853,10 +2854,8 @@ def test_loop_orchestrator_requests_profile_before_plan(tmp_path, ref_file):  # 
 
     result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=2)
     assert result is True
-    # Round 1 cold-start: no pre → just plan.
-    # Round 2: pre → profiler → plan.
-    assert call_order[:1] == ["plan"]
-    assert "profiler" in call_order
+    # Round 1: pre declined → just plan. Round 2: pre → profiler → plan.
+    assert call_order == ["pre", "plan", "pre", "profiler", "plan"]
     plan_idx = [i for i, c in enumerate(call_order) if c == "plan"]
     prof_idx = call_order.index("profiler")
     # Profiler must come BEFORE the round-2 plan call.
@@ -2881,7 +2880,8 @@ def test_loop_skips_profiler_when_pre_round_decision_says_no(tmp_path, ref_file)
     result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=2)
 
     assert result is True
-    assert runner.counters["orch_pre"] == 1
+    # Both rounds decide, including round 1; neither asked for a profile.
+    assert runner.counters["orch_pre"] == 2
     assert runner.counters["prof"] == 0
 
 
@@ -2909,7 +2909,8 @@ def test_loop_skips_profiler_when_profiler_kind_is_none(tmp_path, ref_file):  # 
     )
 
     assert result is True
-    assert runner.counters["orch_pre"] == 1
+    # Both rounds decide, including round 1; neither asked for a profile.
+    assert runner.counters["orch_pre"] == 2
     assert runner.counters["prof"] == 0
 
 
@@ -2944,8 +2945,121 @@ def test_loop_generic_auto_profiler_resolves_to_macos_cpu(tmp_path, ref_file):  
         )
 
     assert result is True
-    assert runner.counters["orch_pre"] == 1
+    assert runner.counters["orch_pre"] == 2
     assert runner.counters["prof"] == 1
+
+
+def test_loop_asks_whether_to_profile_before_the_first_plan(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """Round 1 routes through the same decision as every other round.
+
+    It used to skip that decision outright, which also skipped the profiler
+    nested under it: the round holding the least evidence was the one round
+    where nothing could ask for measurement.
+    """
+    call_order: list[str] = []
+    plan_prompts: list[str] = []
+    pre_prompts: list[str] = []
+    runner = _make_orchestrate_runner(
+        pre_decisions=[
+            PreRoundDecision(need_profile=True, profile_focus="decode", reasoning="it runs"),
+        ],
+        plans=[
+            OrchestratorPlan(
+                task="Cut the measured hotspot",
+                pass_criteria="ok",  # noqa: S106  # tracked: #288
+                reasoning="the profile named it",
+            ),
+        ],
+        profiler_responses=[
+            ProfilerSummary(
+                analysis="decode is launch-bound",
+                bottlenecks="host-side sync",
+                suggestions="cuda graph",
+                perf_metric=5.0,
+                perf_unit="req/s",
+            ),
+        ],
+    )
+    real_invoke = runner.invoke.side_effect
+
+    def spy_invoke(*, kind, response_cls, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
+        if kind == "profiler":
+            call_order.append("profiler")
+        elif kind == "orchestrator" and response_cls is OrchestratorPlan:
+            call_order.append("plan")
+            plan_prompts.append(kwargs.get("system_prompt", ""))
+        elif kind == "orchestrator" and response_cls is PreRoundDecision:
+            call_order.append("pre")
+            pre_prompts.append(kwargs.get("system_prompt", ""))
+        return real_invoke(kind=kind, response_cls=response_cls, **kwargs)
+
+    runner.invoke.side_effect = spy_invoke
+
+    result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1)
+
+    assert result is True
+    # The decision precedes the profiler, which precedes the plan it informs.
+    assert call_order == ["pre", "profiler", "plan"]
+    # Round 1 is told it has no history and may establish runnability itself.
+    assert "This is\nround 1" in pre_prompts[0]
+    assert "one cheap check" in pre_prompts[0]
+    # The measurement reaches the planner rather than merely being collected.
+    # The plan prompt is path-only, so it names the evidence instead of
+    # embedding it; that section renders only when a summary was threaded in.
+    assert "The fresh profiler result is recorded" in plan_prompts[0]
+
+
+def test_loop_first_round_profiles_only_when_its_decision_asks(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """A round-1 decline costs no profiler turn.
+
+    A campaign that builds from scratch has nothing to profile yet. The
+    decision is what keeps that run from spending the turn, so a declined
+    round 1 must reach its plan with no profiler call at all.
+    """
+    runner = _make_orchestrate_runner(
+        pre_decisions=[
+            PreRoundDecision(
+                need_profile=False,
+                profile_focus="",
+                reasoning="nothing runs yet; round 1 must make it build",
+            ),
+        ],
+        plans=[
+            OrchestratorPlan(
+                task="Make the service build",
+                pass_criteria="compiles",  # noqa: S106  # tracked: #288
+                reasoning="no measurable system yet",
+            ),
+        ],
+    )
+
+    result = _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1)
+
+    assert result is True
+    assert runner.counters["orch_pre"] == 1
+    assert runner.counters["prof"] == 0
+
+
+def test_loop_records_the_first_round_decision_in_the_progress_artifact(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """Round 1's reasoning is auditable rather than an unrecorded skip."""
+    runner = _make_orchestrate_runner(
+        pre_decisions=[
+            PreRoundDecision(
+                need_profile=False,
+                profile_focus="",
+                reasoning="the candidate does not build yet",
+            ),
+        ],
+        plans=[
+            OrchestratorPlan(task="Make it build", pass_criteria="ok", reasoning="broken"),  # noqa: S106  # tracked: #288
+        ],
+    )
+
+    _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1)
+
+    progress = (_created_project(tmp_path) / "progress.md").read_text()
+    assert "## Round 1 — Orchestrator (pre-round)" in progress
+    assert "the candidate does not build yet" in progress
 
 
 def test_loop_runs_full_max_rounds_budget(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288

--- a/tests/loops/agent/test_prompt_snapshots.py
+++ b/tests/loops/agent/test_prompt_snapshots.py
@@ -610,3 +610,69 @@ def test_pre_round_prompt_byte_budgets():  # noqa: ANN201  # tracked: #288
 
     assert len(native.encode("utf-8")) <= 2_000
     assert len(fallback.encode("utf-8")) <= 4_000
+
+
+def test_pre_round_prompt_byte_budgets_on_a_cold_start():  # noqa: ANN201  # tracked: #288
+    """Round 1's extra guidance stays bounded too.
+
+    It renders once per campaign rather than once per round, so it earns a
+    larger ceiling than the steady-state text, not an exemption from one.
+    """
+    rendered = render_template(
+        "orchestrator_pre_round_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        objective_location="OBJECTIVE.md",
+        progress_location="progress/",
+        regression_info="recorded in progress",
+        exhaustion_info="recorded in progress",
+        profiler_kind="torch",
+        profile_execution="remote",
+        has_history=False,
+    )
+    native = rendered + "\n\nReturn only the JSON object."
+    fallback = native + build_schema_hint(PreRoundDecision)
+
+    assert len(native.encode("utf-8")) <= 2_900
+    assert len(fallback.encode("utf-8")) <= 4_900
+
+
+def test_pre_round_prompt_defaults_to_the_campaign_history_reading():  # noqa: ANN201  # tracked: #288
+    """Omitting ``has_history`` must not silently render round 1's text."""
+    rendered = render_template(
+        "orchestrator_pre_round_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        objective_location="OBJECTIVE.md",
+        progress_location="progress/",
+        profiler_kind="torch",
+        profile_execution="remote",
+    )
+
+    assert "latest relevant entry under `progress/`" in rendered
+    assert "This is\nround 1" not in rendered
+    assert "Profiling measures a running system" not in rendered
+    # The evaluation ban is relaxed only where the check is needed.
+    assert "you may run\none cheap check" not in rendered
+
+
+def test_pre_round_prompt_lets_a_cold_start_establish_that_it_runs():  # noqa: ANN201  # tracked: #288
+    """Round 1 has no prior result, so it is allowed one check of its own."""
+    rendered = render_template(
+        "orchestrator_pre_round_prompt.j2",
+        template_dir=_TEMPLATE_DIR,
+        objective_location="OBJECTIVE.md",
+        progress_location="progress/",
+        profiler_kind="torch",
+        profile_execution="remote",
+        has_history=False,
+    )
+
+    assert "This is\nround 1" in rendered
+    assert "latest relevant entry under" not in rendered
+    # The blanket ban still stands; the cold-start branch names its exception.
+    assert "or launch other evaluations." in rendered
+    assert "despite the restriction above you may run\none cheap check" in rendered
+    assert "never\nstand in for a benchmark run" in rendered
+    # A candidate that does not run must not be profiled, and the uncertain
+    # case defaults the same way rather than spending the turn.
+    assert "no profile is possible" in rendered
+    assert "If the check is inconclusive, prefer `need_profile=false`" in rendered


### PR DESCRIPTION
## Problem

Round 1 was the only round with a hardcoded answer to "should we profile before
planning". `_is_fresh_cold_start` skipped the pre-round decision, and the
profiler invocation was nested under that skip:

```python
if not _is_fresh_cold_start(round_number, records):
    pre_decision = _run_pre_round_decision(...)
    if pre_decision.need_profile and ctx.profiler_kind is not ProfilerKind.NONE:
        profiler_summary = _run_profiler(...)
```

Skipping the decision on a cold start had a reason: it reads the latest
`progress.md` entry, and there is none. But nesting the profiler under that skip
made round 1 the one round where nothing *could* request measurement, because
requesting it is the pre-round decision's job. The orchestrator picked the first
plan of every campaign from the objective text and a source read.

The obvious fix, profiling round 1 unconditionally, was tried in #361 and drew
the right objection: it is not always feasible to profile in round 1, because a
from-scratch campaign or a seed that does not build has nothing to measure.
Profiling a candidate that does not run is worse than not profiling.
`_run_profiler` catches errors, but the likelier outcome is a schema-valid
`ProfilerSummary` derived from reading source rather than measuring, which flows
into the plan as if it were evidence.

Related to #318; complements #360.

## Solution

Round 1 decides like every other round, and is told what it needs to decide well.

The control-flow change is the whole code diff: the `if not _is_fresh_cold_start`
guard is gone, and the round's answer comes from `PreRoundDecision` instead of a
round number. `_is_fresh_cold_start` survives as the source of a `has_history`
template flag rather than as a branch.

Everything else is prompt. The cold-start branch tells the decision three things
it could not otherwise know:

- `progress.md` holds no result to read and no earlier profile to reuse, so it
  should decide from the objective and the candidate source.
- Profiling presupposes a running system, and round 1 has no prior result
  confirming one. A pinned seed checkout or a declared benchmark contract states
  intent, not the state of this workspace, so neither settles it.
- It may run one cheap check to settle that itself. This is a narrow exception to
  the standing "do not launch other evaluations" rule, scoped to the cold-start
  branch and bounded: no long-lived processes, and never a stand-in for a
  benchmark run.

A failed or inconclusive check defaults to `need_profile=false`, with the reason
stated: a skipped profile costs one round of unmeasured planning, while profiling
a candidate that does not run spends an expensive turn on a summary with no
measurement behind it.

An earlier draft of this change had the framework run the declared `[benchmark]`
command itself and pass a typed verdict into the prompt. That is more
deterministic and more testable, but it is roughly 150 lines against a
capability the agent already has: `_invoke_read_only_role` is snapshot-and-
restore, not tool restriction, and its docstring says prompt boundaries "are not
an enforcement mechanism". The agent can already run commands; only the prompt
stopped it. This version relaxes that instead of adding a framework path beside
it. The tradeoff is real and worth reviewing: what is gained is a much smaller
diff, what is lost is a machine-checkable record of the verdict.

### Architecture

No new components. One call site moves out from under a guard it did not belong
to.

```mermaid
flowchart TD
  R{"fresh cold start?"} -->|"yes (was: skip everything)"| D
  R -->|no| D["_run_pre_round_decision(has_history=...)"]
  D --> N{"need_profile and profiler attached?"}
  N -->|yes| P["_run_profiler"]
  N -->|no| O
  P --> O["_run_orchestrator_plan(profiler_summary=...)"]
```

## Verification

### Correctness properties

- **Rounds 2+ are unchanged.** The rendered prompt for a round with history is
  byte-identical to `main`, verified by diffing rendered output across the
  change. The evaluation-ban exception lives inside the cold-start branch, so it
  does not reach any later round.
- **`has_history` defaults to `true`.** A caller that omits it renders the
  established text rather than silently getting round 1's, pinned by a test.
- **Non-profiling runs still never profile.** The `ctx.profiler_kind is not
  ProfilerKind.NONE` guard is untouched, and the prompt independently forces
  `need_profile=false` when profiling is disabled.
- **A declined round 1 costs no profiler turn.** This is the property that
  answers the #361 objection, and it is what makes a from-scratch campaign safe.
- **Round 1's reasoning is recorded.** `append_pre_round_decision` now writes a
  round-1 entry, so a skip is auditable instead of invisible.
- **The measurement reaches the planner.** Round 1's plan prompt renders its
  profiler section, which only happens when a summary was threaded in.
- **The round-1 branch stays bounded.** It renders once per campaign rather than
  once per round, so it gets a larger byte ceiling (2,900 native / 4,900
  fallback) rather than an exemption from one.

### Testing

```
uv run pytest tests/loops/agent -q --no-cov     268 passed
uv run pytest -q --no-cov                       4053 passed, 8 skipped, 1 failed
uv run ruff check                               All checks passed
uv run ruff format --check                      already formatted
```

The single full-suite failure is
`tests/test_tui.py::test_cli_parse_failure_is_streamed_after_client_attaches`.
It fails identically on a clean `main` and is unrelated.

End-to-end through the real CLI, same command on each branch
(`--stub-agent --profiler none --max-rounds 1`):

| | round 1 agent calls | progress.md first entry |
|---|---|---|
| `main` | `round-1-plan` | `## Round 1 — Orchestrator (plan)` |
| this branch | `round-1-pre` → `round-1-plan` | `## Round 1 — Orchestrator (pre-round)` |

**New tests.** `test_loop_asks_whether_to_profile_before_the_first_plan` pins the
round-1 call order to `["pre", "profiler", "plan"]`, asserts the round-1 prompt
carries the cold-start guidance, and asserts the profiler section renders in that
round's plan prompt.
`test_loop_first_round_profiles_only_when_its_decision_asks` covers the
from-scratch case. `test_loop_records_the_first_round_decision_in_the_progress_artifact`
pins the audit entry. Four prompt tests cover the `has_history` default, the
cold-start branch, and both byte budgets.

**Changed tests.** Four existing tests asserted `orch_pre == 1` across two rounds
and now assert `2`, which is the behavior change itself: round 1 asks.
`test_loop_orchestrator_requests_profile_before_plan` gained a second scripted
`PreRoundDecision` so round 1 declines and round 2 accepts, preserving its
original subject (the profiler precedes the plan it informs).

### Cost

One cheap read-only orchestrator turn on round 1 per multi-agent run, including
`--profiler none` runs where the answer is forced. Rounds 2+ already pay this on
non-profiling runs; skipping it whenever profiling is disabled would be a uniform
win but changes existing rounds, so it is out of scope here.

Round 1 may also spend one cheap command establishing whether the candidate runs.
That replaces a profiler turn in the case where it would have been wasted.

### Follow-up

Two things this deliberately does not address:

- The pre-round decision is the only agent call that receives no
  `render_domain_section`. `microservices/orchestrator.md` goes to the plan call
  and `microservices/profiler.md` to the profiler, both downstream, so the agent
  deciding whether to profile a microservices system only sees the string `otel`.
- Bootstrap rounds 2-4 of a from-scratch campaign have a weaker version of the
  same blindness. They at least have a progress entry recording the build
  failure, so the existing skip criteria can reach the right answer, but nothing
  states the precondition for them.
