### PR TITLE
Populate objective row from official framework benchmark scalar

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -2896,6 +2896,15 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     candidate_retention_reason = (
                         active_hypothesis.gate_approved_candidate_retention_reason
                     )
+                # An official framework benchmark reports a single trusted
+                # scalar via perf_metric/perf_unit but leaves accepted_metrics
+                # empty (only implementer-reported evals populate it). Without a
+                # comparable objective row, _record_candidate_metrics falls back
+                # to the provisional candidate_metrics for frontier dominance.
+                # Promote the trusted scalar into the objective row so official
+                # framework measurements drive the frontier.
+                if not accepted_metrics and perf_metric is not None and perf_unit is not None:
+                    accepted_metrics = {perf_unit: perf_metric}
                 completed_record = RoundRecord(
                     round_number=round_number,
                     commit=commit,

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -2806,6 +2806,37 @@ def test_judge_audited_implementer_metrics_are_recorded(tmp_path, ref_file):  # 
     )
 
 
+def test_official_framework_benchmark_scalar_populates_round_metrics(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    from vibesys.input_manifest import BenchmarkResult  # noqa: PLC0415  # tracked: #288
+
+    # No implementer-reported perf: accepted_metrics stays empty, so the only
+    # objective row can come from the official framework benchmark's scalar.
+    runner = _make_orchestrate_runner()
+
+    with patch(
+        "vibesys.loops.agent.loop._run_framework_benchmark",
+        return_value=(None, 512.0),
+    ):
+        _invoke_orchestrate(
+            tmp_path,
+            ref_file,
+            runner,
+            max_rounds=1,
+            judge_every=10,
+            benchmark_result=BenchmarkResult(
+                json_argument="--output-json",
+                metric="tok/s",
+            ),
+        )
+
+    rounds = _round_payloads(tmp_path)
+    assert rounds[0]["perf_metric"] == 512.0
+    assert rounds[0]["perf_unit"] == "tok/s"
+    # The trusted framework scalar is promoted into the objective row even
+    # though the implementer reported no accepted_metrics.
+    assert rounds[0]["metrics"] == {"tok/s": 512.0}
+
+
 def test_loop_retries_when_framework_accuracy_gate_fails(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[OrchestratorPlan(task="Build", pass_criteria="tests", reasoning="start")],  # noqa: S106  # tracked: #288


### PR DESCRIPTION
## Problem

`_record_candidate_metrics` prefers `record.metrics` for official evaluations, but the framework colocated-benchmark path sets `perf_metric`/`perf_unit` and never populates `accepted_metrics`, so `record.metrics` stays `{}`. Official framework measurements then fall back to the provisional `candidate_metrics` for Pareto dominance.

This surfaced in a live campaign (`llama-70b-2xh100-vllm`, run `20260813-065726`). The official colocated evaluator measured decode throughput at 280.8 tok/s, but the frontier ranked the round on the provisional, serialized-ingress number (35.3 tok/s), so genuine colocated wins never drove the search. This is the frontier-metric issue that campaign exposed (the sibling fixes have already landed as #355–#359).

## Solution

Before building the `RoundRecord`, when `accepted_metrics` is empty and an official `perf_metric`/`perf_unit` is present, promote the trusted scalar into the objective row: `accepted_metrics = {perf_unit: perf_metric}`. This covers both single- and multi-agent inner loops (the multi-agent framework-benchmark branch also only sets `perf_metric`/`perf_unit`).

### Architecture

One guard in `run_agent_loop` immediately before `RoundRecord` construction. No schema, contract, or frontier-file-format change. The framework benchmark emits a single throughput scalar, so promoted official rows are throughput-only (p99 not comparable across official/provisional); dominance on the throughput axis is the intended behavior for official rows. Historical round records are not retroactively rewritten; `pareto-frontier.md` is regenerated from records each round.

## Verification

Ran the agent-loop orchestration suite and the repo format/lint gates on the cherry-picked branch (based on current `origin/main`).

### Correctness properties

- Fires only for official evals with a present `perf_metric`/`perf_unit` and empty `accepted_metrics`; implementer-reported evals (which populate `accepted_metrics`) are unaffected.
- No change to `candidate_metrics`, the provisional "awaiting review" display, or the frontier file format.
- Promoted official rows are throughput-only by construction (single-scalar benchmark result).

### Testing

- `.venv/bin/python -m pytest tests/loops/agent/test_orchestrate.py -q` → 112 passed
- `./scripts/check_format.sh` → All checks passed
- `./scripts/check_lint.sh` → All checks passed

AI assistance was used (see commit `Co-Authored-By` trailer).
