### PR TITLE
Add a microservice request-graph optimization skill

### DIFF
--- a/resources/skills/.vibesys.toml
+++ b/resources/skills/.vibesys.toml
@@ -1,3 +1,7 @@
 [[rule]]
 path = "serving-systems"
 domains = ["llm-serving"]
+
+[[rule]]
+path = "microservice-optimization"
+domains = ["microservices"]

--- a/resources/skills/microservice-optimization/SKILL.md
+++ b/resources/skills/microservice-optimization/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: microservice-optimization
+description: >-
+  Restructuring the request graph of a microservice application to cut
+  end-to-end latency. Activate on serialized cross-service calls,
+  critical-path contribution, sequential dependencies that could run in
+  parallel, work that could move off the request path, batching repeated calls
+  to one service, or collapsing a call edge by co-locating or merging two
+  services.
+---
+
+# microservice-optimization
+
+Two strategies for cutting end-to-end latency by changing the shape of the
+request graph, not by tuning parameters inside a fixed topology.
+
+| Strategy | Changes | Reach for it when |
+| --- | --- | --- |
+| 1. When work happens | Timing of calls relative to the request | The critical path is a chain of calls that need not be a chain |
+| 2. How many calls happen | Count of cross-service calls | The critical path is dominated by call count or per-call overhead |
+
+Tuning within the current topology (connection pools, gateway upstreams, cache
+usage, database indexes, worker counts, serialization) is covered by the
+orchestrator's standing task guidance and is not repeated here. Reach for this
+skill when the evidence points at the graph rather than at one service's
+configuration.
+
+## Establish the evidence first
+
+The two roles see different evidence. Neither should act on the other's.
+
+**Orchestrator.** You see the profiler's prose summary, not the trace graph.
+Select a strategy only when that summary names a specific bottleneck: a
+service, an operation, or an edge with critical-path contribution. A ranking of
+services by aggregate latency is not sufficient. Aggregate cost and
+critical-path contribution are different quantities, and the expensive service
+is frequently not the one holding the request open. When the summary names no
+edge, plan a profiling round rather than guessing one.
+
+**Implementer.** You can read the graph. Confirm the edge or the structure
+before editing:
+
+1. `trace_graphs()` to locate schema-v2 graphs.
+2. `critical_path(path=..., telemetry_path=...)` for wall-clock attribution.
+3. Read `nodes_by_contribution` for ranked contributors, and the representative
+   segments for the order in which calls actually occur.
+
+Overlapping sibling calls are not additive. Two calls each showing 10ms of
+inclusive latency may cost 10ms together, not 20ms, in which case
+parallelizing them gains nothing. Representative segments distinguish
+sequential work from overlapping work; flat span aggregates do not.
+
+Critical-path scope is `synchronous_request`. Async and linked relationships
+are excluded and counted in `async_relationships_excluded`. Work moved off the
+synchronous path leaves the critical path by construction, so a before/after
+critical-path comparison cannot by itself show that the work got cheaper.
+Confirm every claim against the benchmark's `primary_value`.
+
+## Strategy 1: change when work happens
+
+Two forms, in increasing risk.
+
+**Parallelize independent sequential calls.** Two calls issued one after the
+other, where the second does not consume the first's result, can be issued
+concurrently. Verify the independence in the code, not from the trace: the
+trace shows they are sequential, not that they must be.
+
+Preconditions: no data dependency, no ordering requirement the correctness
+contract relies on, and a downstream that tolerates the added concurrency.
+Check the second condition against the accuracy oracle's properties, not
+against the benchmark.
+
+**Move work off the request path.** Precompute it, do it at write time, or run
+it in the background. This removes the work from the measured path rather than
+making it faster.
+
+This form changes consistency semantics, and that is where it fails. The
+accuracy oracle independently checks read-your-write behavior, index
+invalidation, deletion, and isolation. Work deferred out of a write path can
+improve the benchmark and fail accuracy, which is a rejected round, not a
+tradeoff. State which property you are relying on staying true before making
+the change.
+
+## Strategy 2: change how many cross-service calls happen
+
+A ladder, cheapest and most reversible first. Take one step per round and
+measure. Each step subsumes the one before it, so a step that does not pay off
+is evidence against the steps above it.
+
+| Step | Change | Keeps |
+| --- | --- | --- |
+| 1. Batch | Coalesce repeated calls to one service into one call | Both services, the network hop, the process boundary |
+| 2. Co-locate | Schedule both services on one host so the call stops crossing the network | Both services, the RPC, the process boundary |
+| 3. Merge processes | The call becomes an in-process function call | Both codebases, separate storage |
+| 4. Merge storage | The two services share one datastore | Nothing of the boundary |
+
+Step 1 changes the callee's internal API and is usually the largest win per
+unit of risk when a call is issued in a loop or once per result row. Look for
+N+1 patterns in the representative segments before reaching for step 3.
+
+Step 2 is worth measuring on its own because it separates two causes that get
+conflated: network transit and serialization cost versus the process boundary
+itself. If co-location captures most of the gain, steps 3 and 4 are buying
+little.
+
+Steps 3 and 4 are hard to reverse. Step 4 in particular is what usually makes
+step 3 pay off, and also what makes the change difficult to unwind if a later
+round wants the boundary back.
+
+## What is fixed and what is not
+
+The externally visible API behavior and the correctness contract are fixed.
+Everything else is in scope: internal architecture, programming languages,
+service decomposition, storage systems, caches, RPC mechanisms, deployment
+topology, and internal APIs.
+
+This means step 3 and step 4 are legitimate optimizations, not contract
+violations. It also means the accuracy oracle, which exercises the external
+contract with randomized cases, is the check that matters. A restructuring that
+passes the benchmark and fails accuracy has not found anything.
+
+## Verification
+
+For any change from either strategy:
+
+- The benchmark's `primary_value` is the result. Critical-path contribution,
+  span latency, and trace graphs are diagnostic evidence for choosing the
+  change, never evidence that it worked.
+- Re-read the critical path after the change. A restructuring that moves the
+  bottleneck to a different edge is a partial result worth recording, and it
+  names the next round's target.
+- Compare graphs only across matching workload identity and window count. The
+  `critical_path` tool rejects mismatched pairs; do not work around it.
+- When a step in the strategy 2 ladder produces no measurable gain, record that
+  and stop climbing. The remaining steps cost more and are less reversible.


### PR DESCRIPTION
## Problem

Microservice optimization strategy today is always-loaded prompt text, and all
of it is parameter tuning inside a fixed service topology.
`src/vibesys/prompts/domains/microservices/orchestrator.md` lists seven task
shapes: connection pooling, gateway upstream tuning, cache usage, database
indexes, serialization, worker counts, and baseline establishment.

Strategies that change the shape of the request graph have nowhere to live, even
though #44's core rule explicitly permits them ("The implementation may replace
the internal architecture, programming languages, service decomposition, storage
systems, caches, RPC mechanisms, deployment topology, and internal APIs") and the
evidence needed to choose between them has been available since #318 wired
critical-path attribution through the OTel profiler MCP boundary.

`README.md` states the architecture rule that new optimization techniques are
added by writing a skill rather than by modifying the framework, and
`orchestrator_plan_prompt.j2` already asks the orchestrator to recommend
installed skill references. The `llm-serving` domain has `serving-systems`; the
`microservices` domain has no skill at all.

Part of #380. Parent area #44.

## Solution

One microservices-scoped skill, `resources/skills/microservice-optimization/`,
carrying two request-graph strategies:

1. **Change when work happens.** Parallelize independent sequential calls, or
   move work off the synchronous request path.
2. **Change how many cross-service calls happen.** A four-step ladder ordered by
   reversibility: batch, co-locate, merge processes, merge storage.

The split is deliberate: strategy 1 changes call *timing*, strategy 2 changes
call *count*. Batching sits in strategy 2 rather than strategy 1 because it
reduces edge count, which is the same axis as fusion.

The seven existing task shapes are untouched. They are a different altitude
(tuning within a topology) and the skill says so explicitly rather than
duplicating them.

### Architecture

The skill routes through the existing sidecar mechanism, not through new
framework code. One rule added to `resources/skills/.vibesys.toml`:

```toml
[[rule]]
path = "microservice-optimization"
domains = ["microservices"]
```

The load-bearing design point is that the two roles do not see the same
evidence, so the skill states requirements per role:

```mermaid
flowchart LR
    SB["servicebench trace"] -->|"trace-graph.json"| MCP["otel profiler MCP"]
    MCP -->|"trace_graphs()<br/>critical_path()"| PA["Profiler agent"]
    PA -->|"ProfilerSummary<br/>(prose)"| ORCH["Orchestrator<br/>selects strategy"]
    MCP -->|"trace_graphs()<br/>critical_path()"| IMPL["Implementer<br/>confirms the edge"]
    ORCH -->|"plan"| IMPL
```

The orchestrator only ever sees `ProfilerSummary` prose, so the skill tells it
to select a strategy only when the summary names a specific bottleneck, and to
plan a profiling round otherwise. The implementer can call the MCP tools, so the
skill tells it to confirm the edge against `nodes_by_contribution` and the
representative segments before editing.

Two evidence hazards are called out because both produce confident wrong work:

- Overlapping sibling calls are not additive, so parallelizing two calls that
  already overlap gains nothing. Flat span aggregates cannot show this;
  representative segments can.
- Critical-path scope is `synchronous_request`, so work moved off that path
  leaves the critical path by construction. A before/after critical-path
  comparison cannot on its own show a gain.

No guardrail text against collapsing the whole application into one process.
That is a deliberate decision: #44 permits it, and constraining it in a skill
would contradict the area's core rule. The ladder is ordered by reversibility so
the cheap step is the natural first move, but the ordering is guidance, not a
prohibition.

## Verification

### Correctness properties

- The skill loads only for `DomainName.MICROSERVICES`. Confirmed by resolving
  `SkillMetadata` through `validate_skill_tree`, which reports
  `domains=(DomainName.MICROSERVICES,)` for this directory.
- Frontmatter `name` matches the materialized directory name, which
  `src/vibesys/skills.py` requires so an orchestrator recommendation resolves
  identically across providers.
- The `description` triggers on request-graph evidence only. It does not mention
  cache, index, connection pool, or worker count, so it will not fire on the
  task shapes already in the always-loaded domain prompt.
- The skill states that benchmark `primary_value` is the result and that
  trace-derived evidence is diagnostic, matching the existing boundary in
  `profilers/otel.j2` and `domains/microservices/profiler.md`.
- No framework, evaluator, profiler, or prompt behavior changes. The only
  non-additive edit is one new rule in an existing sidecar.

### Testing

```
.venv/bin/python -m pytest tests/test_skills_wiring.py -q
47 passed

.venv/bin/python -m pytest tests/test_resources_packaging.py tests/test_workspace.py tests/test_schemas.py -q
42 passed
```

Routing checked directly:

```
.venv/bin/python -c "from pathlib import Path; from vibesys.skills import validate_skill_tree; [print(m) for m in validate_skill_tree(Path('resources/skills'))]"
SkillMetadata(skill_dir=.../microservice-optimization, backends=None, domains=(<DomainName.MICROSERVICES: 'microservices'>,), ...)
```

Not run: an end-to-end microservice campaign showing an agent invoking the skill
and the resulting round. That needs agent credentials and a full DeathStarBench
Hotel Reservation run; it is tracked as the last acceptance criterion on #380.
