### PR TITLE
Redesign homepage as an interactive use-case explorer

### DIFF
--- a/website/src/components/ArchitectureDiagram/index.tsx
+++ b/website/src/components/ArchitectureDiagram/index.tsx
@@ -1,4 +1,6 @@
 import {cloneElement, type ReactElement, type ReactNode} from 'react';
+import clsx from 'clsx';
+import {GENERIC_DIAGRAM, USE_CASES, type DiagramOutputLine} from '@site/src/data/useCases';
 import styles from './styles.module.css';
 
 /**
@@ -11,6 +13,13 @@ import styles from './styles.module.css';
  * two-line title/subtitle) rather than a shared oversized default, and
  * every region starts its first row at the same y so the three columns
  * read as one grid.
+ *
+ * The USER INPUT and BESPOKE SYSTEM regions are data-driven off the
+ * selected use case (see src/data/useCases.ts); the VibeSys region in
+ * between is drawn once and never changes, since the loop is the part
+ * that stays constant across targets. The use-case tabs live outside the
+ * SVG, in a real HTML button column to its left, so selection keeps
+ * native keyboard/focus behavior instead of hand-rolled SVG hit targets.
  */
 
 function Icon({
@@ -54,21 +63,31 @@ function LogoRow({
   y,
   size = 20,
   gap = 8,
+  highlight,
   children,
 }: {
   x: number;
   y: number;
   size?: number;
   gap?: number;
+  /** When set, dims every logo whose key doesn't match, to point at the
+   * hardware the active use case actually targets. */
+  highlight?: string;
   children: ReactElement<{size?: number}>[];
 }) {
   return (
     <g>
-      {children.map((child, i) => (
-        <g key={i} transform={`translate(${x + i * (size + gap)}, ${y})`}>
-          {cloneElement(child, {size})}
-        </g>
-      ))}
+      {children.map((child, i) => {
+        const dimmed = highlight != null && child.key !== highlight;
+        return (
+          <g
+            key={i}
+            transform={`translate(${x + i * (size + gap)}, ${y})`}
+            opacity={dimmed ? 0.25 : 1}>
+            {cloneElement(child, {size})}
+          </g>
+        );
+      })}
     </g>
   );
 }
@@ -112,7 +131,13 @@ function LeafCard({
    * e.g. the hardware backends or execution environments a card covers.
    * `y` is an absolute diagram coordinate, hand-placed like everything
    * else in this file. */
-  logoRow?: {y: number; size?: number; gap?: number; items: ReactElement<{size?: number}>[]};
+  logoRow?: {
+    y: number;
+    size?: number;
+    gap?: number;
+    highlight?: string;
+    items: ReactElement<{size?: number}>[];
+  };
 }) {
   const iconX = x + 13;
   const iconY = y + 11;
@@ -147,7 +172,7 @@ function LeafCard({
       <text className={styles.cardTitle}>{titleLines}</text>
       {subtitle && <text className={styles.cardSubtitle}>{subtitleLines}</text>}
       {logoRow && (
-        <LogoRow x={textX} y={logoRow.y} size={logoRow.size} gap={logoRow.gap}>
+        <LogoRow x={textX} y={logoRow.y} size={logoRow.size} gap={logoRow.gap} highlight={logoRow.highlight}>
           {logoRow.items}
         </LogoRow>
       )}
@@ -155,20 +180,118 @@ function LeafCard({
   );
 }
 
-export default function ArchitectureDiagram(): ReactNode {
+/** Renders the BESPOKE SYSTEM file tree from a use case's output lines.
+ * `dir`/`note` lines start a new visual group (extra leading space);
+ * `file` lines are dim; `file-new`/`file-modified` are bold so a changed
+ * or added file stands out against the rest of an otherwise-untouched tree.
+ * `startY` shifts down when a stat block occupies the top of the card. */
+function OutputTree({lines, startY}: {lines: DiagramOutputLine[]; startY: number}) {
+  return (
+    <text x={880} y={startY} className={styles.mono}>
+      {lines.map((line, i) => {
+        const step = i === 0 ? 0 : line.kind === 'dir' || line.kind === 'note' ? 27 : 19;
+        const bold = line.kind === 'dir' || line.kind === 'file-new' || line.kind === 'file-modified';
+        const dimClass =
+          line.kind === 'file' ? styles.monoDim : line.kind === 'note' ? styles.monoNote : undefined;
+        return (
+          <tspan key={i} x={880} dy={step} fontWeight={bold ? 600 : undefined} className={dimClass}>
+            {line.text}
+          </tspan>
+        );
+      })}
+    </text>
+  );
+}
+
+/** Performance-benefit callout at the top of the BESPOKE SYSTEM card: the
+ * metric, its context, and (for paper-backed cases) a link to the source.
+ * Only rendered when a use case is selected; the generic state has no
+ * result to show, so the file tree alone fills the card. */
+function StatBlock({
+  metric,
+  metricLabel,
+  link,
+}: {
+  metric: string;
+  metricLabel: string[];
+  link?: {label: string; href: string};
+}) {
+  const labelY = 118;
+  const linkY = labelY + metricLabel.length * 14 + 8;
+  return (
+    <g>
+      <rect x={864} y={62} width={264} height={104} rx={6} className={styles.card} />
+      <text x={880} y={96} className={styles.statMetric}>
+        {metric}
+      </text>
+      <text x={880} y={labelY} className={styles.statLabel}>
+        {metricLabel.map((line, i) => (
+          <tspan key={i} x={880} dy={i === 0 ? 0 : 14}>
+            {line}
+          </tspan>
+        ))}
+      </text>
+      {link && (
+        <a href={link.href} target="_blank" rel="noopener noreferrer">
+          <text x={880} y={linkY} className={styles.statLink}>
+            {link.label} →
+          </text>
+        </a>
+      )}
+    </g>
+  );
+}
+
+const DEFAULT_CAPTION =
+  'An outer loop searches over designs; an inner loop implements and validates each one.';
+
+export default function ArchitectureDiagram({
+  activeId,
+  onSelect,
+}: {
+  activeId: string | null;
+  onSelect: (id: string | null) => void;
+}): ReactNode {
+  const useCase = USE_CASES.find((candidate) => candidate.id === activeId) ?? null;
+  const diagram = useCase?.diagram ?? GENERIC_DIAGRAM;
+  const treeY = useCase ? 178 : 62;
+  const treeH = useCase ? 302 : 418;
+
   return (
     <figure className={styles.figure}>
-      <figcaption className={styles.caption}>
-        An outer loop plans the search over designs; an inner loop
-        implements and validates candidates; an independent judge checks
-        correctness before results are recorded.
-      </figcaption>
-      <svg
-        className={styles.diagram}
-        viewBox="0 0 1160 512"
-        role="img"
-        aria-label="Diagram: user input (model, hardware, workload) feeds VibeSys, where an outer loop plans the search and an inner loop of Implementer, Accuracy Judge, and Profiler implements, checks, and benchmarks each candidate, producing a bespoke system. On error, the Accuracy Judge sends the candidate back to the Implementer.">
-        <defs>
+      <figcaption className={styles.caption}>{useCase?.description ?? DEFAULT_CAPTION}</figcaption>
+      <div className={styles.diagramRow}>
+        <div className={styles.tabColumn} role="tablist" aria-label="Use case">
+          <span className={styles.tabColumnLabel}>USE CASES</span>
+          <div className={styles.tabList}>
+            {USE_CASES.map((candidate) => {
+              const active = candidate.id === activeId;
+              return (
+                <button
+                  key={candidate.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  className={clsx(styles.tab, active && styles.tabActive)}
+                  onClick={() => onSelect(active ? null : candidate.id)}>
+                  <span className={styles.tabText}>
+                    <span className={styles.tabTag}>{candidate.tag}</span>
+                    <span className={styles.tabHeadline}>{candidate.headline}</span>
+                  </span>
+                  <span className={styles.tabArrow} aria-hidden="true">
+                    →
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        <svg
+          className={styles.diagram}
+          viewBox="0 0 1160 512"
+          role="img"
+          aria-label="Diagram: user input (model, hardware, workload) feeds VibeSys, where an outer loop plans the search and an inner loop of Implementer, Accuracy Judge, and Profiler implements, checks, and benchmarks each candidate, producing a bespoke system. On error, the Accuracy Judge sends the candidate back to the Implementer.">
+          <defs>
           <marker
             id="arch-arrow"
             viewBox="0 0 10 10"
@@ -192,8 +315,8 @@ export default function ArchitectureDiagram(): ReactNode {
           y={62}
           w={184}
           h={108}
-          title={['Model']}
-          subtitle={['Weights, code']}
+          title={['Starting point']}
+          subtitle={diagram.startingPoint}
           icon={
             <>
               <circle cx={12} cy={5.5} r={2} />
@@ -209,7 +332,7 @@ export default function ArchitectureDiagram(): ReactNode {
           w={184}
           h={120}
           title={['Hardware']}
-          subtitle={['Device spec']}
+          subtitle={diagram.hardware}
           icon={
             <>
               <rect x={6} y={6} width={12} height={12} rx={1.5} />
@@ -220,6 +343,7 @@ export default function ArchitectureDiagram(): ReactNode {
             y: 298,
             size: 20,
             gap: 9,
+            highlight: diagram.hardwareVendor,
             items: [
               <Logo key="nvidia" title="NVIDIA" d={LOGO_PATHS.nvidia} />,
               <Logo key="amd" title="AMD" d={LOGO_PATHS.amd} />,
@@ -235,7 +359,7 @@ export default function ArchitectureDiagram(): ReactNode {
           w={184}
           h={108}
           title={['Workload']}
-          subtitle={['Benchmark metrics']}
+          subtitle={diagram.workload}
           icon={
             <>
               <rect x={4.5} y={13} width={3.4} height={7} fill="currentColor" stroke="none" />
@@ -428,57 +552,18 @@ export default function ArchitectureDiagram(): ReactNode {
         {/* arrow: VibeSys -> Bespoke System */}
         <line x1={824} y1={256} x2={844} y2={256} className={styles.arrow} markerEnd="url(#arch-arrow)" />
 
-        {/* ---- Region C: Bespoke System ---- */}
-        <rect x={848} y={16} width={296} height={480} rx={14} className={styles.regionOutline} />
-        <text x={864} y={44} className={styles.zoneLabel}>
-          BESPOKE SYSTEM
-        </text>
-        <rect x={864} y={62} width={264} height={418} rx={6} className={styles.card} />
-        <text x={880} y={90} className={styles.mono}>
-          <tspan x={880} dy={0} fontWeight={600}>
-            serving_system/
-          </tspan>
-          <tspan x={880} dy={19} className={styles.monoDim}>
-            {'├─ api_server.py'}
-          </tspan>
-          <tspan x={880} dy={19} className={styles.monoDim}>
-            {'├─ scheduler.py'}
-          </tspan>
-          <tspan x={880} dy={19} className={styles.monoDim}>
-            {'├─ router.py'}
-          </tspan>
-          <tspan x={880} dy={19} className={styles.monoDim}>
-            {'├─ cache.py'}
-          </tspan>
-          <tspan x={880} dy={19} className={styles.monoDim}>
-            {'├─ model.py'}
-          </tspan>
-          <tspan x={880} dy={19} className={styles.monoDim}>
-            {'└─ backend.py'}
-          </tspan>
-          <tspan x={880} dy={27} fontWeight={600}>
-            tests/
-          </tspan>
-          <tspan x={880} dy={19} className={styles.monoDim}>
-            {'├─ test_accuracy.py'}
-          </tspan>
-          <tspan x={880} dy={19} className={styles.monoDim}>
-            {'└─ test_router.py'}
-          </tspan>
-          <tspan x={880} dy={27} fontWeight={600}>
-            bench/
-          </tspan>
-          <tspan x={880} dy={19} className={styles.monoDim}>
-            {'├─ microbench.py'}
-          </tspan>
-          <tspan x={880} dy={19} className={styles.monoDim}>
-            {'├─ latency.csv'}
-          </tspan>
-          <tspan x={880} dy={19} className={styles.monoDim}>
-            {'└─ tpt.csv'}
-          </tspan>
-        </text>
-      </svg>
+          {/* ---- Region C: Bespoke System ---- */}
+          <rect x={848} y={16} width={296} height={480} rx={14} className={styles.regionOutline} />
+          <text x={864} y={44} className={styles.zoneLabel}>
+            BESPOKE SYSTEM
+          </text>
+          {useCase && (
+            <StatBlock metric={useCase.metric} metricLabel={useCase.metricLabel} link={useCase.link} />
+          )}
+          <rect x={864} y={treeY} width={264} height={treeH} rx={6} className={styles.card} />
+          <OutputTree lines={diagram.output} startY={treeY + 28} />
+        </svg>
+      </div>
     </figure>
   );
 }

--- a/website/src/components/ArchitectureDiagram/styles.module.css
+++ b/website/src/components/ArchitectureDiagram/styles.module.css
@@ -7,10 +7,170 @@
   margin: 0 auto 1.5rem;
 }
 
+.diagramRow {
+  display: flex;
+  align-items: stretch;
+  gap: 0.75rem;
+}
+
+/* Grid rows mirror the SVG's own y-coordinates as fractions of its 512-unit
+ * viewBox height (44 : 18 : 418 : 32 = label-row : gap : card-band : margin,
+ * matching USER INPUT's zone-label baseline at y=44, first card at y=62,
+ * and last card's bottom at y=480), so "USE CASES" lines up with "USER
+ * INPUT" and the tab list spans exactly the same band as the input cards,
+ * at any viewport width — fr units keep the ratio exact regardless of the
+ * stretched pixel height. */
+.tabColumn {
+  display: grid;
+  grid-template-rows: 44fr 18fr 418fr 32fr;
+  flex: 0 0 190px;
+  /* Without this, content can force the stretched column taller than the
+   * SVG at narrower viewports (the flex/grid min-height:auto gotcha). */
+  min-height: 0;
+}
+
+.tabColumnLabel {
+  grid-row: 1;
+  align-self: end;
+  min-height: 0;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  opacity: 0.55;
+}
+
+.tabList {
+  grid-row: 3;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.tab {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  padding: 0.45rem 0.7rem;
+  text-align: left;
+  font: inherit;
+  background: transparent;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-code-border-radius);
+  color: inherit;
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.tab:hover {
+  border-color: var(--ifm-color-primary);
+  background: var(--ifm-color-emphasis-100);
+}
+
+.tabActive {
+  background: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-background-color);
+}
+
+.tabActive:hover {
+  background: var(--ifm-color-primary);
+}
+
+.tabActive:hover .tabArrow {
+  opacity: 1;
+}
+
+.tabText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.tabTag {
+  display: block;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.6rem;
+  letter-spacing: 0.05em;
+  opacity: 0.6;
+  margin-bottom: 0.2rem;
+}
+
+.tabHeadline {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.tabArrow {
+  flex-shrink: 0;
+  opacity: 0.3;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+}
+
+.tab:hover .tabArrow {
+  opacity: 0.8;
+  transform: translateX(2px);
+}
+
+.tabActive .tabArrow {
+  opacity: 1;
+}
+
+/* Matches Infima's own breakpoint (the navbar and feature-card grid already
+ * reflow here). Side-by-side only holds up while the SVG is wide enough
+ * that its intrinsic height clears the tab column's content height — below
+ * this width the SVG would get stretched past its aspect ratio and letterbox
+ * internally, throwing off the fr-row alignment (verified against the SVG's
+ * actual rendered content via getScreenCTM, not just its CSS box). */
+@media (max-width: 996px) {
+  .diagramRow {
+    flex-direction: column;
+  }
+
+  .tabColumn {
+    /* Below the SVG instead of beside it, so height should track content
+     * (the fr-row proportions only matter when stacked side by side). */
+    flex: 0 0 auto;
+    width: 100%;
+  }
+}
+
 .diagram {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   height: auto;
   color: var(--ifm-font-color-base);
+}
+
+.statMetric {
+  font-family: var(--ifm-font-family-monospace);
+  font-weight: 700;
+  font-size: 22px;
+  fill: currentColor;
+}
+
+.statLabel {
+  font-family: var(--ifm-font-family-base);
+  font-size: 11px;
+  fill: currentColor;
+  opacity: 0.7;
+}
+
+.statLink {
+  font-family: var(--ifm-font-family-base);
+  font-size: 11px;
+  fill: currentColor;
+  text-decoration: underline;
 }
 
 .zoneLabel {
@@ -69,6 +229,14 @@
   font-size: 12.5px;
   fill: currentColor;
   opacity: 0.6;
+}
+
+.monoNote {
+  font-family: var(--ifm-font-family-monospace);
+  font-style: italic;
+  font-size: 12.5px;
+  fill: currentColor;
+  opacity: 0.5;
 }
 
 .regionOutline {

--- a/website/src/data/useCases.ts
+++ b/website/src/data/useCases.ts
@@ -1,0 +1,170 @@
+/**
+ * Single source of truth for the homepage's use-case tabs and the
+ * architecture diagram they drive. Selecting a use case swaps the
+ * diagram's USER INPUT values and BESPOKE SYSTEM output/metric; the loop
+ * machinery in between never changes, which is the point.
+ */
+
+export type DiagramOutputLineKind = 'dir' | 'file' | 'file-new' | 'file-modified' | 'note';
+
+export type DiagramOutputLine = {
+  text: string;
+  kind: DiagramOutputLineKind;
+};
+
+export type DiagramSpec = {
+  /** Hardware vendor logo to highlight in the Hardware card's logo row. */
+  hardwareVendor?: 'nvidia' | 'amd' | 'intel' | 'apple' | 'amazon';
+  startingPoint: string[];
+  hardware: string[];
+  workload: string[];
+  output: DiagramOutputLine[];
+};
+
+export type UseCase = {
+  id: string;
+  tag: string;
+  headline: string;
+  description: string;
+  metric: string;
+  /** Pre-wrapped lines (SVG text can't reflow on its own). */
+  metricLabel: string[];
+  link?: {label: string; href: string};
+  diagram: DiagramSpec;
+};
+
+export const GENERIC_DIAGRAM: DiagramSpec = {
+  startingPoint: ['Model, weights,', 'or a checkout'],
+  hardware: ['Device spec'],
+  workload: ['Benchmark metrics'],
+  output: [
+    {text: 'serving_system/', kind: 'dir'},
+    {text: '├─ api_server.py', kind: 'file'},
+    {text: '├─ scheduler.py', kind: 'file'},
+    {text: '├─ router.py', kind: 'file'},
+    {text: '├─ cache.py', kind: 'file'},
+    {text: '├─ model.py', kind: 'file'},
+    {text: '└─ backend.py', kind: 'file'},
+    {text: 'tests/', kind: 'dir'},
+    {text: '├─ test_accuracy.py', kind: 'file'},
+    {text: '└─ test_router.py', kind: 'file'},
+    {text: 'bench/', kind: 'dir'},
+    {text: '├─ microbench.py', kind: 'file'},
+    {text: '├─ latency.csv', kind: 'file'},
+    {text: '└─ tpt.csv', kind: 'file'},
+  ],
+};
+
+const PAPER_LINK = {label: 'Read the paper', href: 'https://arxiv.org/abs/2605.06068'};
+
+export const USE_CASES: UseCase[] = [
+  {
+    id: 'code-edit-spec-decode',
+    tag: 'FROM SCRATCH · WORKLOAD',
+    headline: 'Speculative decoding for code edits',
+    description:
+      'Generic servers ignore the predicted-output field. VibeSys treats it as a speculative-decoding draft.',
+    metric: '5.95×',
+    metricLabel: ['vs. vanilla autoregressive ·', '2× over vLLM spec-dec'],
+    link: PAPER_LINK,
+    diagram: {
+      hardwareVendor: 'nvidia',
+      startingPoint: ['Qwen3-32B', 'from scratch'],
+      hardware: ['1× H100'],
+      workload: ['CodeEditorBench,', 'predicted-outputs'],
+      output: [
+        {text: 'serving_system/', kind: 'dir'},
+        {text: '├─ api_server.py', kind: 'file'},
+        {text: '├─ scheduler.py', kind: 'file'},
+        {text: '├─ predicted_verifier.py', kind: 'file-new'},
+        {text: '├─ cache.py', kind: 'file'},
+        {text: '├─ model.py', kind: 'file'},
+        {text: '└─ backend.py', kind: 'file'},
+        {text: 'tests/', kind: 'dir'},
+        {text: '├─ test_accuracy.py', kind: 'file'},
+        {text: '└─ test_router.py', kind: 'file'},
+        {text: 'bench/', kind: 'dir'},
+        {text: '├─ microbench.py', kind: 'file'},
+        {text: '└─ latency.csv', kind: 'file'},
+      ],
+    },
+  },
+  {
+    id: 'show-o2-macbook',
+    tag: 'FROM SCRATCH · HARDWARE',
+    headline: 'Image generation on a laptop',
+    description:
+      'Show-o2 runs on no generic stack at all. VibeSys ports it to MLX, within 7% of the theoretical peak.',
+    metric: '6.27×',
+    metricLabel: ['vs. PyTorch-MPS baseline'],
+    link: PAPER_LINK,
+    diagram: {
+      hardwareVendor: 'apple',
+      startingPoint: ['Show-o2 1.5B-HQ', 'from scratch'],
+      hardware: ['MacBook (M3 Pro)'],
+      workload: ['432×432', 'text-to-image'],
+      output: [
+        {text: 'serving_system/', kind: 'dir'},
+        {text: '├─ api_server.py', kind: 'file'},
+        {text: '├─ diffusion_head.py', kind: 'file'},
+        {text: '├─ body.py', kind: 'file'},
+        {text: '├─ tokenizer.py', kind: 'file'},
+        {text: '└─ mlx_backend.py', kind: 'file'},
+        {text: 'tests/', kind: 'dir'},
+        {text: '├─ test_accuracy.py', kind: 'file'},
+        {text: '└─ test_image_shape.py', kind: 'file'},
+        {text: 'bench/', kind: 'dir'},
+        {text: '├─ microbench.py', kind: 'file'},
+        {text: '└─ latency.csv', kind: 'file'},
+      ],
+    },
+  },
+  {
+    id: 'vllm-spec-decode',
+    tag: 'STARTS FROM YOUR STACK',
+    headline: 'In-place vLLM optimization',
+    description: 'VibeSys inspects a running vLLM and adds speculative decoding, no rewrite needed.',
+    metric: '4.7×',
+    metricLabel: ['throughput over the', 'starting config'],
+    diagram: {
+      hardwareVendor: 'nvidia',
+      startingPoint: ['vLLM (pinned)', 'Llama-3.3-70B, bf16'],
+      hardware: ['2× H100'],
+      workload: ['Chat/completion'],
+      output: [
+        {text: 'vllm/  (existing)', kind: 'dir'},
+        {text: '~ engine/spec_decode.py', kind: 'file-modified'},
+        {text: '~ worker/model_runner.py', kind: 'file-modified'},
+        {text: '├─ api_server.py', kind: 'file'},
+        {text: '├─ worker/gpu_worker.py', kind: 'file'},
+        {text: '└─ ... (untouched)', kind: 'file'},
+        {text: 'tests/', kind: 'dir'},
+        {text: '└─ test_accuracy.py', kind: 'file'},
+        {text: 'bench/', kind: 'dir'},
+        {text: '└─ latency.csv', kind: 'file'},
+      ],
+    },
+  },
+  {
+    id: 'mpmc-queue',
+    tag: 'BEYOND SERVING',
+    headline: 'Concurrent queue optimization',
+    description: 'VibeSys cuts cross-thread cache-coherence traffic in a concurrent queue.',
+    metric: '2.77×',
+    metricLabel: ["vs. oneTBB's concurrent_queue"],
+    diagram: {
+      hardwareVendor: 'intel',
+      startingPoint: ['MPMC queue', 'naive Rust seed'],
+      hardware: ['Multi-core CPU'],
+      workload: ['Throughput +', 'FIFO correctness'],
+      output: [
+        {text: 'queue-rs/', kind: 'dir'},
+        {text: '├─ src/lib.rs', kind: 'file'},
+        {text: '└─ queue-candidate.so', kind: 'file'},
+        {text: 'benches/', kind: 'dir'},
+        {text: '└─ mpmc_bench.rs', kind: 'file'},
+        {text: 'same C ABI, any language', kind: 'note'},
+      ],
+    },
+  },
+];

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -37,5 +37,12 @@
 }
 
 .architecture {
-  padding: 2rem 0 4rem;
+  padding: 1.5rem 0 2.5rem;
+}
+
+.architectureNote {
+  max-width: 720px;
+  margin: 0 auto 1.25rem;
+  font-size: 0.9rem;
+  opacity: 0.75;
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import type {ReactNode} from 'react';
+import {useState, type ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -43,6 +43,7 @@ function HomepageHeader() {
 
 export default function Home(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
+  const [activeId, setActiveId] = useState<string | null>(null);
   return (
     <Layout
       title={siteConfig.title}
@@ -53,7 +54,10 @@ export default function Home(): ReactNode {
         <section className={styles.architecture}>
           <div className="container text--center">
             <Heading as="h2">Architecture</Heading>
-            <ArchitectureDiagram />
+            <p className={styles.architectureNote}>
+              Click a use case on the left to see its input, system, and result on the right.
+            </p>
+            <ArchitectureDiagram activeId={activeId} onSelect={setActiveId} />
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Problem

The docs homepage read as LLM-serving-specific, even though VibeSys is a
general framework for generating bespoke systems (serving, databases, data
structures, microservices, ...). The architecture diagram was static, and a
separate "Use Cases" card section duplicated space without showing how a
selection actually changes the system VibeSys produces.

## Solution

Fold 4 representative use cases directly into the architecture diagram as a
column of tabs at its left edge, so the reader's eye flows tab → input →
loop → output:

- **Speculative decoding for code edits** (from scratch, workload
  specialization) — 5.95x vs. vanilla autoregressive
- **Image generation on a laptop** (from scratch, hardware specialization,
  MLX on Apple Silicon) — 6.27x vs. PyTorch-MPS
- **In-place vLLM optimization** (modifies an existing system, not a
  from-scratch generation) — 4.7x throughput adding speculative decoding to
  a running vLLM, Llama-3.3-70B on 2xH100
- **Concurrent queue optimization** (generality beyond LLM serving) — 2.77x
  vs. oneTBB's `concurrent_queue`

Selecting a tab swaps the diagram's USER INPUT values and the BESPOKE SYSTEM
output/metric on the right; the VibeSys loop in the middle never changes,
which is the point — same mechanism, different target. The two paper-backed
use cases link to the arXiv paper; the vLLM and queue cases are not in the
paper (the "optimize an existing system in place" capability postdates it)
and are presented without a paper citation.

This fully replaces the old static "Use Cases" card row, which is why total
page height is *shorter* despite the added content — everything now fits
above the fold on a laptop screen.

### Architecture

- `src/data/useCases.ts` is the single source of truth: each use case's tab
  copy, diagram input/output data, and metric. `ArchitectureDiagram` reads
  from it directly rather than receiving props, so the tab list and diagram
  can never drift out of sync.
- The tab column is real HTML `<button role="tab">` elements outside the
  SVG (not SVG-native hit targets), for native keyboard/focus/ARIA
  behavior. `activeId` state lives in the page component and is passed down.
- The tab column's height is a CSS Grid with `fr` rows mirroring the SVG's
  internal y-coordinates, so "USE CASES" lines up with "USER INPUT" and the
  tab list spans exactly the same band as the input cards.

## Verification

### Correctness properties

- Tab column height must never force the SVG to stretch past its intrinsic
  aspect ratio: doing so lets the browser's default `preserveAspectRatio`
  letterbox the SVG's content inside its box, which desyncs the tab
  column's `fr`-row alignment from the diagram's actual rendered content
  (verified via `getScreenCTM()`, not just bounding-box comparison, since
  the box and the visible content can differ once letterboxed).
- Below 996px (Infima's own breakpoint, already used elsewhere on this
  page) the layout stacks vertically instead, since the alignment above
  only holds once the SVG is wide enough.

### Testing

- `npx tsc --noEmit` — clean.
- `npm run build` — clean production build, no stray emitted `.js`.
- Manual verification in a local `docusaurus serve` preview:
  - Alignment measured via `getScreenCTM()`-based coordinate mapping
    (actual rendered SVG content vs. the HTML tab column), confirmed exact
    (0px diff) at every width from 997px up to 1280px+.
  - Confirmed the 996px breakpoint transition stacks cleanly with no
    letterboxing on either side.
  - Confirmed click-to-select updates the diagram's input, output tree, and
    metric correctly for all 4 use cases.
  - Confirmed mobile (420px) layout renders correctly (tabs stack
    full-width above a scaled-down diagram).

🤖 Generated with [Claude Code](https://claude.com/claude-code)