### PR TITLE
Report the microservice benchmark metric through the evaluator SDK

### DIFF
--- a/examples/microservices/train-ticket/OBJECTIVE.md
+++ b/examples/microservices/train-ticket/OBJECTIVE.md
@@ -1,9 +1,10 @@
 Optimize a Train Ticket v0.2.0-compatible deployment for stateful API
 throughput while preserving externally observable behavior.
 
-Headline metric: successful `operations_per_second` from the shared evaluator
-result (`primary_value`, maximize). An operation may contain multiple dependent
-HTTP requests; update/read and create/read/delete sequences are counted once.
+Headline metric: successful `operations_per_second`, maximize. The workload
+declares it, and the evaluator reports it under that name on its result stream.
+An operation may contain multiple dependent HTTP requests; update/read and
+create/read/delete sequences are counted once.
 
 The candidate may use any implementation language, process topology, database,
 persistence format, or caching strategy. It must preserve the public HTTP

--- a/examples/microservices/train-ticket/README.md
+++ b/examples/microservices/train-ticket/README.md
@@ -170,5 +170,6 @@ go -C resources/evaluators/microservice run ./cmd/servicebench \
 
 The checker requires the exact v0.2.0 seed catalog and does not silently accept
 empty or structurally different startup data. The committed benchmark workload
-runs three independent repetitions and uses their median as `primary_value` so
-normal host variance does not steer optimization from a single trial.
+runs three independent repetitions and reports their median as
+`operations_per_second` so normal host variance does not steer optimization from
+a single trial.

--- a/examples/microservices/train-ticket/vibesys.input.toml
+++ b/examples/microservices/train-ticket/vibesys.input.toml
@@ -25,7 +25,4 @@ command = [
 	"--fixture-seed", "random",
 ]
 timeout_seconds = 300
-
-[benchmark.result]
-json_argument = "--output-json"
-metric = "primary_value"
+result_protocol = 1

--- a/resources/evaluators/microservice/DESIGN.md
+++ b/resources/evaluators/microservice/DESIGN.md
@@ -240,3 +240,18 @@ include every failed attempt. `primary_value` is omitted unless every trial:
 Individual trials are the independent aggregation units. The summary reports
 their median, MAD, IQR, and a deterministic bootstrap interval when at least two
 valid trials are available.
+
+### Reporting the measurement
+
+`--vs-output` names the evaluator record stream specified by
+`sdk/vs-evaluator/PROTOCOL.md`. The stream declares the workload's own
+objective: its `metric` name, `unit`, and direction, read from the loaded
+workload rather than fixed by the command. The framework therefore sees the
+metric the task declared, and a task objective can name it directly instead of
+scraping a generically named summary field.
+
+The stream carries one metric because the summary carries one optimization
+score. A run without a `primary_value`, and any failure the command reaches
+before producing one, closes the stream with an error record naming the reason,
+so a failed benchmark reaches the framework as a reported failure rather than
+only as an exit status. The summary JSON stays diagnostic evidence.

--- a/resources/evaluators/microservice/README.md
+++ b/resources/evaluators/microservice/README.md
@@ -157,8 +157,9 @@ bytes remain visible separately. A trial is invalid when it:
 - violates a success-rate, error-rate, or per-operation coverage constraint; or
 - fails during reset, setup, execution, or interruption.
 
-An invalid run omits `primary_value`, preventing the optimization loop from
-treating a fast-but-incorrect or client-limited result as an improvement.
+An invalid run omits `primary_value` and reports the failure rather than a
+number, preventing the optimization loop from treating a fast-but-incorrect or
+client-limited result as an improvement.
 
 The summary aggregates trial-level primary values rather than pooling every
 operation across trials. It reports median, median absolute deviation (MAD), and
@@ -230,6 +231,31 @@ go -C resources/evaluators/microservice run ./cmd/servicebench \
   --output-json /tmp/result.json \
   --output-raw /tmp/requests.ndjson
 ```
+
+### Benchmark output
+
+Benchmark mode writes two independent outputs, and both flags are optional.
+
+`--vs-output` names the VibeSys evaluator record stream, the framework-facing
+result channel specified by `sdk/vs-evaluator/PROTOCOL.md`. The command declares
+one metric: the workload's own `objective`, under its declared `metric` name,
+`unit`, and direction (`maximize` becomes `max`, `minimize` becomes `min`). The
+Train Ticket workload therefore reports `operations_per_second` in
+`operations/s` with direction `max`. The hello record is written once the
+resolved workload is valid and before any traffic runs, so a crashed or
+timed-out run still leaves a stream that names its metric. The stream then
+closes with either a result record carrying `primary_value` or an error record
+naming why no value exists.
+
+`--output-json` keeps the versioned summary: per-trial distributions, generator
+health, constraint reasons, and optional telemetry. It is diagnostic output, not
+the metric channel.
+
+Omitting `--vs-output` reports nothing to the framework and leaves the printed
+summary, the detailed report, and the exit status unchanged. Standalone and
+baseline invocations use that form. The flag is benchmark-only: accuracy mode
+still communicates through its exit status, and `--validate-only` runs no
+measurement, so both reject it.
 
 Validate a workload and its registered extensions without running traffic:
 

--- a/resources/evaluators/microservice/cmd/servicebench/README.md
+++ b/resources/evaluators/microservice/cmd/servicebench/README.md
@@ -12,7 +12,9 @@ The command is responsible for:
 - validating command-line overrides and registered extensions;
 - hashing the fully resolved workload;
 - signal-aware execution;
-- atomically writing the summary JSON and optionally writing raw NDJSON; and
+- atomically writing the summary JSON and optionally writing raw NDJSON;
+- reporting the workload's objective metric on the evaluator record stream when
+  `--vs-output` names one; and
 - returning a nonzero status for invalid benchmark results.
 
 `--mode benchmark` is the default. `--mode accuracy` uses the same resolved

--- a/resources/evaluators/microservice/cmd/servicebench/main.go
+++ b/resources/evaluators/microservice/cmd/servicebench/main.go
@@ -19,6 +19,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/uw-syfi/vibesys/sdk/vs-evaluator/vseval"
+
 	"vibesys/microservice-evaluator/accuracy"
 	accuracyhotel "vibesys/microservice-evaluator/accuracyapps/hotel"
 	accuracytrainticket "vibesys/microservice-evaluator/accuracyapps/trainticket"
@@ -45,6 +47,8 @@ type modeFlagConfig struct {
 	trace              bool
 	explicit           map[string]bool
 	outputRaw          string
+	streamOutput       string
+	validateOnly       bool
 	casesMin           int
 	casesMax           int
 	startupTimeout     float64
@@ -156,11 +160,17 @@ func run() (resultErr error) {
 	flag.IntVar(&traceMaxRoots, "trace-max-roots", 10, "maximum root groups in rendered trace output")
 	flag.IntVar(&traceMaxNodes, "trace-max-nodes", 30, "maximum nodes per root in rendered trace output")
 	flag.IntVar(&traceTimelineWidth, "trace-timeline-width", 48, "representative waterfall width")
+	// The SDK owns the name and usage of the result-stream flag. Registering it
+	// here rather than through vseval.Schema.Start keeps flag parsing in one
+	// place: the stream's metric comes from the workload, which is not loaded
+	// yet.
+	streamOutput := vseval.RegisterFlags(flag.CommandLine)
 	flag.Parse()
 	explicitFlags := make(map[string]bool)
 	flag.Visit(func(used *flag.Flag) { explicitFlags[used.Name] = true })
 	if err := validateModeFlags(modeFlagConfig{
 		mode: mode, trace: traceMode, explicit: explicitFlags, outputRaw: outputRaw,
+		streamOutput: *streamOutput, validateOnly: validateOnly,
 		casesMin: casesMin, casesMax: casesMax, startupTimeout: startupTimeout,
 		runCommandJSON: runCommandJSON, stopCommandJSON: stopCommandJSON,
 		cleanupCommandJSON: cleanupCommandJSON,
@@ -225,6 +235,16 @@ func run() (resultErr error) {
 	if err := config.Validate(workload); err != nil {
 		return fmt.Errorf("invalid command-line override: %w", err)
 	}
+	// The stream declares the workload's own objective metric, so it opens as
+	// soon as the resolved workload is valid and before anything is measured.
+	// Close runs last; finish reports whatever the command returns, including
+	// a managed-candidate cleanup failure, as the stream's error record.
+	stream, err := startBenchmarkStream(workload.Objective, *streamOutput)
+	if err != nil {
+		return err
+	}
+	defer stream.Close()
+	defer func() { resultErr = stream.finish(resultErr) }()
 	canonical, err := config.CanonicalJSON(workload)
 	if err != nil {
 		return fmt.Errorf("serialize resolved workload: %w", err)
@@ -427,10 +447,7 @@ func run() (resultErr error) {
 	} else {
 		fmt.Println(string(encoded))
 	}
-	if !runResult.Summary.Valid {
-		return errors.New("benchmark result is invalid; inspect constraints and trial invalid_reasons")
-	}
-	return nil
+	return stream.emit(runResult.Summary)
 }
 
 // shouldCollectTelemetry reports whether servicebench invokes the telemetry
@@ -477,11 +494,18 @@ func validateModeFlags(config modeFlagConfig) error {
 		config.explicit["trace-max-roots"] || config.explicit["trace-max-nodes"] || config.explicit["trace-timeline-width"] {
 		return errors.New("trace graph flags require the servicebench trace subcommand")
 	}
+	if config.streamOutput != "" && config.validateOnly {
+		return fmt.Errorf(
+			"--%s reports a measurement, so it cannot be combined with --validate-only",
+			vseval.OutputFlag,
+		)
+	}
 	accuracyOnly := []string{"cases-min", "cases-max", "state-dir", "state-env"}
 	benchmarkOnly := []string{
 		"output-raw", "skip-prepare", "fixture-seed", "rate", "duration", "warmup", "concurrency", "repetitions",
 		"telemetry-command-json", "telemetry-output", "telemetry-timeout",
 		"trace-graph-json", "trace-graph-text", "trace-max-roots", "trace-max-nodes", "trace-timeline-width",
+		vseval.OutputFlag,
 	}
 	if config.mode == "benchmark" {
 		for _, name := range accuracyOnly {

--- a/resources/evaluators/microservice/cmd/servicebench/main_test.go
+++ b/resources/evaluators/microservice/cmd/servicebench/main_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/uw-syfi/vibesys/sdk/vs-evaluator/vseval"
+)
 
 func TestParseCommandJSONRejectsMalformedAndEmptyArguments(t *testing.T) {
 	for _, raw := range []string{
@@ -161,6 +165,21 @@ func TestValidateModeFlagsRejectsIgnoredOrMalformedCombinations(t *testing.T) {
 			},
 		},
 		{
+			name: "accuracy result stream",
+			config: modeFlagConfig{
+				mode: "accuracy", explicit: map[string]bool{vseval.OutputFlag: true},
+				streamOutput: "stream.jsonl",
+				casesMin:     2, casesMax: 5, startupTimeout: 15, stateEnv: "VIBESYS_STATE_DIR",
+			},
+		},
+		{
+			name: "result stream without a measurement",
+			config: modeFlagConfig{
+				mode: "benchmark", explicit: map[string]bool{vseval.OutputFlag: true},
+				streamOutput: "stream.jsonl", validateOnly: true, startupTimeout: 15,
+			},
+		},
+		{
 			name: "telemetry timeout without command",
 			config: modeFlagConfig{
 				mode: "benchmark", startupTimeout: 15,
@@ -181,6 +200,11 @@ func TestValidateModeFlagsRejectsIgnoredOrMalformedCombinations(t *testing.T) {
 	}
 	if err := validateModeFlags(validBenchmark); err != nil {
 		t.Fatalf("valid benchmark flags: %v", err)
+	}
+	validBenchmark.streamOutput = "stream.jsonl"
+	validBenchmark.explicit = map[string]bool{vseval.OutputFlag: true}
+	if err := validateModeFlags(validBenchmark); err != nil {
+		t.Fatalf("valid benchmark result stream: %v", err)
 	}
 	validBenchmark.telemetryCommand = `["./collector"]`
 	validBenchmark.telemetryOutput = "telemetry.json"

--- a/resources/evaluators/microservice/cmd/servicebench/result_stream.go
+++ b/resources/evaluators/microservice/cmd/servicebench/result_stream.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/uw-syfi/vibesys/sdk/vs-evaluator/vseval"
+
+	"vibesys/microservice-evaluator/api"
+	"vibesys/microservice-evaluator/engine"
+)
+
+// benchmarkStream is the framework-facing output of benchmark mode: the
+// VibeSys evaluator record stream described by sdk/vs-evaluator/PROTOCOL.md.
+// It declares the workload's own objective metric and carries either the
+// summary's primary value or the reason no value exists.
+//
+// The stream reports one metric because the summary has one optimization
+// score. Everything else the summary holds (per-trial distributions, generator
+// health, telemetry) stays in the --output-json report, which is diagnostics
+// rather than a measurement contract.
+//
+// Without --vs-output the SDK run discards every record, so standalone
+// invocations that only want the printed summary and the --output-json report
+// behave exactly as before.
+type benchmarkStream struct {
+	run     *vseval.Run
+	metric  vseval.Metric
+	emitted bool
+}
+
+// startBenchmarkStream declares the workload's objective metric and writes the
+// hello record to outputPath, or to nothing when outputPath is empty.
+//
+// The declared name, unit, and direction are the workload's own: an objective
+// with metric "operations_per_second" reaches the framework under that name
+// rather than under a generic result field. The metric therefore cannot be
+// declared before the workload is loaded, which is why the hello record lands
+// after configuration rather than at flag-parse time. It still lands before
+// any measurement runs, so a crashed or timed-out benchmark leaves a stream
+// that names its metric.
+func startBenchmarkStream(objective api.Objective, outputPath string) (*benchmarkStream, error) {
+	direction, err := streamDirection(objective.Direction)
+	if err != nil {
+		return nil, err
+	}
+	schema := vseval.NewSchema()
+	metric := schema.Number(
+		objective.Metric,
+		vseval.Unit(objective.Unit),
+		vseval.Direction(direction),
+	)
+	run, err := schema.StartWith(outputPath)
+	if err != nil {
+		return nil, err
+	}
+	return &benchmarkStream{run: run, metric: metric}, nil
+}
+
+// streamDirection maps a workload objective direction onto the protocol's
+// advisory better-direction. config.Validate already rejects anything else;
+// this fails closed rather than declaring a metric with no direction.
+func streamDirection(direction string) (vseval.Dir, error) {
+	switch direction {
+	case "maximize":
+		return vseval.Max, nil
+	case "minimize":
+		return vseval.Min, nil
+	default:
+		return "", fmt.Errorf("objective.direction must be minimize or maximize, got %q", direction)
+	}
+}
+
+// emit writes the summary's primary value as the stream's result record.
+//
+// A run the engine rejected, or one that produced no primary value, is a
+// failure rather than a measurement: emit returns the reason and leaves the
+// error record to finish, so the command's exit status and stderr keep the
+// wording they had before the stream existed.
+func (s *benchmarkStream) emit(summary engine.Summary) error {
+	if !summary.Valid {
+		return errors.New("benchmark result is invalid; inspect constraints and trial invalid_reasons")
+	}
+	if summary.PrimaryValue == nil {
+		return fmt.Errorf("benchmark produced no %s value", summary.PrimaryMetric.Metric)
+	}
+	s.run.Set(s.metric, *summary.PrimaryValue)
+	if err := s.run.Emit(); err != nil {
+		return err
+	}
+	s.emitted = true
+	return nil
+}
+
+// finish reports cause as the stream's error record and returns it unchanged.
+// Deferring it covers every failure the command can return once the stream is
+// open, including the ones managed-candidate cleanup adds on the way out,
+// without each return site having to know about the stream.
+//
+// A command that returns nothing and reported nothing leaves a stream holding
+// only its hello record, which a reader reports as a missing outcome. That is
+// the honest report: no measurement was made.
+func (s *benchmarkStream) finish(cause error) error {
+	if cause == nil || s.emitted {
+		return cause
+	}
+	if err := s.run.EmitError(cause); err != nil {
+		return fmt.Errorf("%w (reporting the failure also failed: %v)", cause, err)
+	}
+	s.emitted = true
+	return cause
+}
+
+// Close releases the output file. It is the only close in the command: the SDK
+// leaves it to whoever started the run.
+func (s *benchmarkStream) Close() error {
+	return s.run.Close()
+}

--- a/resources/evaluators/microservice/cmd/servicebench/result_stream_test.go
+++ b/resources/evaluators/microservice/cmd/servicebench/result_stream_test.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"vibesys/microservice-evaluator/api"
+	"vibesys/microservice-evaluator/engine"
+)
+
+// trainTicketObjective is the objective the committed Train Ticket workload
+// declares. Its name and its metric differ on purpose: the stream declares the
+// metric, which is the quantity the summary measures.
+func trainTicketObjective() api.Objective {
+	return api.Objective{
+		Name:      "logical_operations_per_second",
+		Metric:    "operations_per_second",
+		Direction: "maximize",
+		Unit:      "operations/s",
+	}
+}
+
+func measuredSummary(objective api.Objective, value float64) engine.Summary {
+	return engine.Summary{
+		SchemaVersion: engine.ResultSchemaVersion,
+		WorkloadName:  "train-ticket",
+		PrimaryValue:  &value,
+		PrimaryMetric: objective,
+		Valid:         true,
+		Aggregate:     engine.Aggregate{Trials: 3, Median: &value},
+	}
+}
+
+func readStreamRecords(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	records := make([]map[string]any, 0, 2)
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("record %q: %v", line, err)
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+// summaryPrimaryValue reads primary_value out of the summary exactly as the
+// --output-json report serializes it, so the stream can be compared against
+// the number the diagnostic report publishes rather than against the Go field.
+func summaryPrimaryValue(t *testing.T, summary engine.Summary) any {
+	t.Helper()
+	encoded, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(encoded, &report); err != nil {
+		t.Fatal(err)
+	}
+	return report["primary_value"]
+}
+
+func TestBenchmarkStreamDeclaresWorkloadObjective(t *testing.T) {
+	objective := trainTicketObjective()
+	streamPath := filepath.Join(t.TempDir(), "stream.jsonl")
+
+	stream, err := startBenchmarkStream(objective, streamPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+
+	summary := measuredSummary(objective, 412.5)
+	if err := stream.emit(summary); err != nil {
+		t.Fatal(err)
+	}
+
+	records := readStreamRecords(t, streamPath)
+	if len(records) != 2 {
+		t.Fatalf("stream records = %v, want hello and result", records)
+	}
+	hello := records[0]
+	if hello["kind"] != "hello" || hello["protocol"] != float64(1) {
+		t.Fatalf("hello record = %v", hello)
+	}
+	metrics, ok := hello["metrics"].(map[string]any)
+	if !ok || len(metrics) != 1 {
+		t.Fatalf("hello metrics = %v, want exactly the workload objective metric", hello["metrics"])
+	}
+	spec, ok := metrics[objective.Metric].(map[string]any)
+	if !ok {
+		t.Fatalf("hello metrics = %v, want %q", metrics, objective.Metric)
+	}
+	if spec["unit"] != objective.Unit || spec["direction"] != "max" {
+		t.Fatalf("%s spec = %v", objective.Metric, spec)
+	}
+
+	result := records[1]
+	if result["kind"] != "result" || result["label"] != "" {
+		t.Fatalf("result record = %v", result)
+	}
+	values, ok := result["values"].(map[string]any)
+	if !ok || len(values) != 1 {
+		t.Fatalf("result values = %v, want exactly %q", result["values"], objective.Metric)
+	}
+	if values[objective.Metric] != summaryPrimaryValue(t, summary) {
+		t.Fatalf(
+			"streamed %s = %v, summary primary_value = %v",
+			objective.Metric,
+			values[objective.Metric],
+			summaryPrimaryValue(t, summary),
+		)
+	}
+}
+
+func TestBenchmarkStreamDeclaresMinimizedObjective(t *testing.T) {
+	objective := api.Objective{
+		Name:      "read_latency_p50",
+		Metric:    "latency_ms.p50",
+		Direction: "minimize",
+		Unit:      "ms",
+	}
+	streamPath := filepath.Join(t.TempDir(), "stream.jsonl")
+
+	stream, err := startBenchmarkStream(objective, streamPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	if err := stream.emit(measuredSummary(objective, 12.5)); err != nil {
+		t.Fatal(err)
+	}
+
+	records := readStreamRecords(t, streamPath)
+	metrics, ok := records[0]["metrics"].(map[string]any)
+	if !ok {
+		t.Fatalf("hello record = %v", records[0])
+	}
+	spec, ok := metrics[objective.Metric].(map[string]any)
+	if !ok {
+		t.Fatalf("hello metrics = %v, want %q", metrics, objective.Metric)
+	}
+	if spec["unit"] != "ms" || spec["direction"] != "min" {
+		t.Fatalf("%s spec = %v", objective.Metric, spec)
+	}
+}
+
+func TestStartBenchmarkStreamRejectsUnknownDirection(t *testing.T) {
+	objective := trainTicketObjective()
+	objective.Direction = "sideways"
+	streamPath := filepath.Join(t.TempDir(), "stream.jsonl")
+
+	if _, err := startBenchmarkStream(objective, streamPath); err == nil {
+		t.Fatal("accepted an objective direction the protocol cannot declare")
+	}
+	if _, err := os.Stat(streamPath); err == nil {
+		t.Fatal("rejected objective still opened a stream")
+	}
+}
+
+func TestBenchmarkStreamReportsInvalidResultAsErrorRecord(t *testing.T) {
+	objective := trainTicketObjective()
+	streamPath := filepath.Join(t.TempDir(), "stream.jsonl")
+
+	stream, err := startBenchmarkStream(objective, streamPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+
+	summary := measuredSummary(objective, 412.5)
+	summary.Valid = false
+	summary.PrimaryValue = nil
+	summary.Constraints = engine.ConstraintResult{
+		Passed:  false,
+		Reasons: []string{"trial 0: error rate 0.02 exceeds 0.00"},
+	}
+	emitErr := stream.emit(summary)
+	if emitErr == nil {
+		t.Fatal("invalid summary was reported as a measurement")
+	}
+	// The command reports the failure the way it always has; the stream picks
+	// the same reason up from the returned error.
+	if got := stream.finish(emitErr); !errors.Is(got, emitErr) {
+		t.Fatalf("finish(%v) = %v, want the cause unchanged", emitErr, got)
+	}
+
+	records := readStreamRecords(t, streamPath)
+	if len(records) != 2 {
+		t.Fatalf("stream records = %v, want hello and error", records)
+	}
+	if records[0]["kind"] != "hello" {
+		t.Fatalf("first record = %v, want hello", records[0])
+	}
+	if records[1]["kind"] != "error" || records[1]["message"] != emitErr.Error() {
+		t.Fatalf("second record = %v, want the error %q", records[1], emitErr)
+	}
+}
+
+func TestBenchmarkStreamReportsAbsentPrimaryValueAsErrorRecord(t *testing.T) {
+	objective := trainTicketObjective()
+	streamPath := filepath.Join(t.TempDir(), "stream.jsonl")
+
+	stream, err := startBenchmarkStream(objective, streamPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+
+	// A summary the engine accepted but that carries no aggregate value has no
+	// row to report, and a Go zero must not pass for a measurement.
+	summary := measuredSummary(objective, 0)
+	summary.PrimaryValue = nil
+	summary.Aggregate = engine.Aggregate{Trials: 3}
+	emitErr := stream.emit(summary)
+	if emitErr == nil {
+		t.Fatal("summary without a primary value was reported as a measurement")
+	}
+	if !strings.Contains(emitErr.Error(), objective.Metric) {
+		t.Fatalf("error = %v, want it to name %q", emitErr, objective.Metric)
+	}
+	if got := stream.finish(emitErr); !errors.Is(got, emitErr) {
+		t.Fatalf("finish(%v) = %v, want the cause unchanged", emitErr, got)
+	}
+
+	records := readStreamRecords(t, streamPath)
+	if len(records) != 2 || records[1]["kind"] != "error" {
+		t.Fatalf("stream records = %v, want hello and error", records)
+	}
+	if records[1]["message"] != emitErr.Error() {
+		t.Fatalf("error record message = %v, want %q", records[1]["message"], emitErr)
+	}
+}
+
+// TestBenchmarkStreamFinishReportsCommandFailure covers the failures that
+// never reach emit: a candidate that does not start, a telemetry collector
+// fault, a cleanup error on the way out. The deferred finish turns each into
+// the stream's error record.
+func TestBenchmarkStreamFinishReportsCommandFailure(t *testing.T) {
+	streamPath := filepath.Join(t.TempDir(), "stream.jsonl")
+
+	stream, err := startBenchmarkStream(trainTicketObjective(), streamPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+
+	cause := errors.New("prepare managed candidate: readiness probe timed out")
+	if got := stream.finish(cause); !errors.Is(got, cause) {
+		t.Fatalf("finish(%v) = %v, want the cause unchanged", cause, got)
+	}
+	// A second failure on the way out must not append a second outcome record.
+	if got := stream.finish(errors.New("close managed candidate: exit status 1")); got == nil {
+		t.Fatal("finish swallowed a later failure")
+	}
+
+	records := readStreamRecords(t, streamPath)
+	if len(records) != 2 {
+		t.Fatalf("stream records = %v, want hello and error", records)
+	}
+	if records[1]["kind"] != "error" || records[1]["message"] != cause.Error() {
+		t.Fatalf("error record = %v, want %q", records[1], cause)
+	}
+}
+
+// TestBenchmarkStreamAfterEmitKeepsTheResult guards the ordering of the
+// deferred finish against the deferred managed-candidate cleanup: a cleanup
+// failure after a measured row must not overwrite the row with an error.
+func TestBenchmarkStreamAfterEmitKeepsTheResult(t *testing.T) {
+	objective := trainTicketObjective()
+	streamPath := filepath.Join(t.TempDir(), "stream.jsonl")
+
+	stream, err := startBenchmarkStream(objective, streamPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	if err := stream.emit(measuredSummary(objective, 412.5)); err != nil {
+		t.Fatal(err)
+	}
+
+	cause := errors.New("close managed candidate: exit status 1")
+	if got := stream.finish(cause); !errors.Is(got, cause) {
+		t.Fatalf("finish(%v) = %v, want the cause unchanged", cause, got)
+	}
+	records := readStreamRecords(t, streamPath)
+	if len(records) != 2 || records[1]["kind"] != "result" {
+		t.Fatalf("stream records = %v, want hello and result", records)
+	}
+}
+
+func TestBenchmarkWithoutStreamFlagWritesNothing(t *testing.T) {
+	objective := trainTicketObjective()
+	outputs := t.TempDir()
+
+	stream, err := startBenchmarkStream(objective, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	if stream.run.Reporting() {
+		t.Fatal("omitting the output path still reports a stream")
+	}
+	if err := stream.emit(measuredSummary(objective, 412.5)); err != nil {
+		t.Fatal(err)
+	}
+	cause := errors.New("benchmark result is invalid")
+	if got := stream.finish(cause); !errors.Is(got, cause) {
+		t.Fatalf("finish(%v) = %v, want the cause unchanged", cause, got)
+	}
+
+	entries, err := os.ReadDir(outputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("omitting the output path wrote files: %v", entries)
+	}
+}

--- a/resources/evaluators/microservice/go.mod
+++ b/resources/evaluators/microservice/go.mod
@@ -5,3 +5,5 @@ go 1.21
 require github.com/BurntSushi/toml v1.4.0
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require github.com/uw-syfi/vibesys/sdk/vs-evaluator/vseval v0.1.0

--- a/resources/evaluators/microservice/go.sum
+++ b/resources/evaluators/microservice/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/uw-syfi/vibesys/sdk/vs-evaluator/vseval v0.1.0 h1:OGFZWt+0+/BLiydMSm+E9lm2Fo5mURBwY2rDhHT4CEg=
+github.com/uw-syfi/vibesys/sdk/vs-evaluator/vseval v0.1.0/go.mod h1:F1FaSrDktADJ2IlwTmBeWmCeQwS7DST8rrwHHr0qXII=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/tests/test_microservice_inputs.py
+++ b/tests/test_microservice_inputs.py
@@ -41,9 +41,10 @@ def test_legacy_microservice_scenario_uses_source_evaluator() -> None:
         "run",
         "./cmd/servicebench",
     )
-    assert bundle.benchmark_result is not None
-    assert bundle.benchmark_result.json_argument == "--output-json"
-    assert bundle.benchmark_result.metric == "primary_value"
+    # The benchmark reports the workload's own objective metric on the
+    # evaluator result stream, so it declares no scraped result field.
+    assert bundle.benchmark_result is None
+    assert bundle.benchmark_result_protocol == 1
     assert ("--seed", "random") in _adjacent_pairs(bundle.benchmark_command)
     assert ("--fixture-seed", "random") in _adjacent_pairs(bundle.benchmark_command)
 


### PR DESCRIPTION
## Problem

Part of #377, following #383 and #386. `resources/evaluators/microservice` was
the last Go evaluator still on the scraping contract, and it is the clearest
illustration of what that contract costs.

The manifest told the framework to read a field called `primary_value`:

```toml
[benchmark.result]
json_argument = "--output-json"
metric = "primary_value"
```

That name says nothing about what was measured. Meanwhile the workload had
declared the real thing all along (`benchmark/workload.toml:169`):

```toml
[objective]
name = "logical_operations_per_second"
metric = "operations_per_second"
direction = "maximize"
unit = "operations/s"
```

and the evaluator emitted that metadata beside the value in `primary_metric`.
The contract discarded all of it and reported a generically named scalar, which
`OBJECTIVE.md` then had to document as a deliberate rename.

## Solution

Declare the metric to the SDK from the loaded workload, and delete the
indirection. The framework now sees a metric named `operations_per_second`, so
an objective can name it directly and the rename documentation goes away.

Nothing is hardcoded. Name, direction, and unit are read from the resolved
workload at run time, so a workload declaring a latency metric declares `min`
instead. A test covers that.

Two details worth review:

**When the stream opens.** Unlike the queue evaluator, whose metric is a
constant known at flag-parse time, this evaluator's metric identity comes from
the workload. The stream therefore opens once the resolved workload validates,
and a deferred reporter converts any later failure into an error record without
touching the command's fifteen return sites. The consequence is that failures
*before* the workload parses produce no stream, so the framework sees a failed
command rather than a structured reason.

**`--validate-only` rejects `--vs-output`.** It measures nothing and would
otherwise leave a hello-only stream behind a zero exit.

Accuracy mode is untouched and still communicates by exit code. `--output-json`
is unchanged and remains diagnostics; both outputs are produced in one run.

## Verification

### Correctness properties

- The declared metric name, direction, and unit are exactly the workload's, so
  the evaluator cannot report an axis the task did not define.
- The streamed value equals the summary's `primary_value` for the same run.
- A failed run, or one whose `PrimaryValue` is absent, produces an error record
  whose message equals the error the command returns; the exit status and
  stderr are unchanged from today.
- Omitting `--vs-output` leaves behavior exactly as it is now, including every
  documented standalone invocation.
- The evaluator resolves its SDK identically from the repo and from a copy at
  `_evaluator/<name>`.

### Testing

Real run against a local HTTP stub, exit 0:

```
{"kind":"hello","protocol":1,"metrics":{"operations_per_second":{"unit":"operations/s","direction":"max"}}}
{"kind":"result","label":"","values":{"operations_per_second":50.890134404346206}}
```

matching the summary's `primary_value` of `50.890134404346206`. Round-tripped
through `libs/vs-evaluator-protocol`: the reader accepted the row and
`check_objectives(hello, {"operations_per_second"})` passed. With the stub
killed, the same command exits 1 and emits an `error` record the reader surfaces
as the failure reason.

```
cd resources/evaluators/microservice && gofmt -l . && go vet ./... && go test ./...   passed
uv run pytest -q --no-cov tests/test_microservice_inputs.py tests/test_input_sources.py   31 passed, 1 skipped
./scripts/check_format.sh / check_lint.sh / check_doc_links.py                       passed
```

The skip is `test_microservice_inputs.py`, which needs the DeathStarBench
submodule; it is uninitialized in this worktree, so its two changed assertions
were verified directly through `load_input_bundle` (`benchmark_result is None`,
`benchmark_result_protocol == 1`).

Copied outside the repo with an empty `GOMODCACHE`, resolving purely from the
proxy:

```
go: downloading github.com/uw-syfi/vibesys/sdk/vs-evaluator/vseval v0.1.0
build exit=0
ok  vibesys/microservice-evaluator/cmd/servicebench
```

## SDK feedback this port produced

Worth folding into a later SDK version rather than blocking here:

- `StartFlagSet` implicitly assumes a schema known at flag-parse time. An
  evaluator whose metric identity comes from config cannot use it, and there is
  no seam to open the stream before the schema is known, which is why early
  failures here produce no stream.
- Exact key-set equality plus declare-before-measure means only metrics that
  are *always* produced can be declared. This summary carries latency
  distributions and error categories that would be useful axes but can be
  empty, so they stay in `--output-json`.
- There is no exported way to ask a `Run` whether the outcome was already
  written, so a deferred reporter tracks that itself.
- Workloads spell directions `maximize`/`minimize` while the SDK takes
  `Max`/`Min`, so every evaluator writes the same small mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
