### PR TITLE
Protocol 2: optional metrics and failures reported before declaring

### DIFF
--- a/libs/vs-evaluator-protocol/README.md
+++ b/libs/vs-evaluator-protocol/README.md
@@ -1,6 +1,6 @@
 # vs-evaluator-protocol
 
-Framework-side reader for the VibeSys evaluator result protocol, version 1. The
+Framework-side reader for the VibeSys evaluator result protocol, version 2. The
 protocol itself, its fixtures, and the evaluator-side SDKs live in
 `sdk/vs-evaluator/`; this library is the only implementation the framework uses
 to consume an evaluator's record stream.
@@ -9,13 +9,21 @@ The public API exported from `vs_evaluator_protocol` has three groups:
 
 - `Hello`, `Result`, `ErrorRecord`, `MetricSpec`, and the `Record` union define
   the records, with `PROTOCOL_VERSION` naming the version this reader
-  implements.
+  implements. `MetricSpec.required` (default `true`) says whether every
+  successful run must report the metric; an optional metric is still declared,
+  so it can never be reported under a name the reader has not seen.
 - `parse_records` turns stream text into typed records, one per non-blank line.
   `read_measurement` consumes records in order and returns one `Measurement`:
-  the declared metrics plus either the measured row or a failure message.
+  the declared metrics plus either the measured row or a failure message. An
+  `error` may replace the `hello` entirely, for an evaluator that fails before
+  its configuration tells it what it measures; such a `Measurement` has
+  `metrics is None`. A measured row always carries the declaration it was
+  validated against.
 - `check_objectives` verifies that a task's objectives are declared by the
-  evaluator. It is separate from `read_measurement` because objectives belong
-  to the task; the evaluator never learns which metrics are optimized.
+  evaluator *and* declared required. It is separate from `read_measurement`
+  because objectives belong to the task; the evaluator never learns which
+  metrics are optimized. A task cannot rank on an optional metric, since a
+  successful run may omit it and the frontier would silently lose the round.
 
 Every rejection raises `ProtocolError` carrying a `ReasonCode` from the shared
 contract and a message naming the offending record and key. Record models
@@ -23,6 +31,11 @@ reject unknown keys and type coercion; Pydantic failures are translated, never
 surfaced. `read_measurement` loops over records rather than indexing a
 fully-parsed stream, so a transport that delivers records incrementally can
 reuse it unchanged.
+
+The reader also accepts version 1 streams, reading them as declaring every
+metric required. That support is transitional: it exists only until the Go
+evaluators in this repository are rebuilt against an SDK that emits version 2,
+and the code carrying it is marked for deletion in `records.py`.
 
 The library does not read or write files, run evaluators, or score
 measurements.

--- a/libs/vs-evaluator-protocol/src/vs_evaluator_protocol/measurement.py
+++ b/libs/vs-evaluator-protocol/src/vs_evaluator_protocol/measurement.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from vs_evaluator_protocol.errors import ReasonCode, reject
 from vs_evaluator_protocol.records import (
     PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
     ErrorRecord,
     Hello,
     Result,
@@ -26,12 +27,17 @@ if TYPE_CHECKING:
 class Measurement:
     """One validated evaluator outcome.
 
-    `metrics` is the declaration from `hello`. Exactly one of `values` (the
-    measured row, keyed by declared metric name) and `failure` (why the
-    evaluator produced no row) is set.
+    Exactly one of `values` (the measured row, keyed by declared metric name)
+    and `failure` (why the evaluator produced no row) is set.
+
+    `metrics` is the declaration from `hello`, or `None` when the evaluator
+    failed before it declared anything: an `error` is the one record the
+    protocol lets arrive with no preceding `hello`, so a failed measurement
+    need not carry a declaration. A measured row always does, since the row
+    was validated against it.
     """
 
-    metrics: Mapping[str, MetricSpec]
+    metrics: Mapping[str, MetricSpec] | None
     values: Mapping[str, float] | None = None
     failure: str | None = None
 
@@ -39,6 +45,9 @@ class Measurement:
         """Reject an outcome that is neither exactly a row nor a failure."""
         if (self.values is None) == (self.failure is None):
             message = "a measurement carries either values or a failure message"
+            raise ValueError(message)
+        if self.values is not None and self.metrics is None:
+            message = "a measured row carries the metric declaration it was validated against"
             raise ValueError(message)
 
     @property
@@ -64,6 +73,13 @@ def read_measurement(records: Iterable[Record]) -> Measurement:
         if isinstance(record, Hello):
             hello = _read_hello(record, hello=hello, position=position)
         elif hello is None:
+            if isinstance(record, ErrorRecord) and position == 1:
+                # An error is the one record that may replace hello: an
+                # evaluator whose metric identity comes from configuration
+                # cannot declare anything until that configuration loads, and
+                # a failure before then must still reach the framework as a
+                # reason rather than as a missing file.
+                return Measurement(metrics=None, failure=record.message)
             # A hello may still arrive; whether this is HELLO_NOT_FIRST or
             # MISSING_HELLO is only decided once the stream is exhausted.
             continue
@@ -82,20 +98,38 @@ def read_measurement(records: Iterable[Record]) -> Measurement:
 def check_objectives(hello: Hello, objective_names: Set[str]) -> None:
     """Check that the evaluator declares every metric the task optimizes for.
 
+    An objective must be declared *and* declared required. An optional metric
+    may be absent from a successful run, so a task cannot rank on one: the
+    frontier would silently lose the round.
+
     Separate from `read_measurement` on purpose: objectives belong to the
     task, not to the evaluator, which never learns which metrics are
     optimized.
 
     Raises:
-        ProtocolError: when an objective is absent from `hello.metrics`.
+        ProtocolError: when an objective is absent from `hello.metrics` or is
+            declared there as optional.
     """
-    missing = sorted(name for name in objective_names if name not in hello.metrics)
-    if missing:
-        reject(
-            ReasonCode.MISSING_METRIC,
-            f"objectives {', '.join(repr(name) for name in missing)} are not declared by "
-            f"the evaluator; hello record declares {_names(hello.metrics)}",
+    undeclared = sorted(name for name in objective_names if name not in hello.metrics)
+    optional = sorted(
+        name
+        for name in objective_names
+        if name in hello.metrics and not hello.metrics[name].required
+    )
+    if not undeclared and not optional:
+        return
+    faults: list[str] = []
+    if undeclared:
+        faults.append(f"objectives {_names(undeclared)} are not declared by the evaluator")
+    if optional:
+        faults.append(
+            f"objectives {_names(optional)} are declared optional, so a successful run may "
+            "omit them and the task cannot rank on them"
         )
+    reject(
+        ReasonCode.MISSING_METRIC,
+        f"{'; '.join(faults)}; hello record declares {_names(hello.metrics)}",
+    )
 
 
 def _read_hello(record: Hello, *, hello: Hello | None, position: int) -> Hello:
@@ -104,7 +138,7 @@ def _read_hello(record: Hello, *, hello: Hello | None, position: int) -> Hello:
         reject(ReasonCode.DUPLICATE_HELLO, f"record {position} is a second hello record")
     if position != 1:
         reject(ReasonCode.HELLO_NOT_FIRST, f"record {position} is a hello but is not first")
-    if record.protocol != PROTOCOL_VERSION:
+    if record.protocol not in SUPPORTED_PROTOCOL_VERSIONS:
         reject(
             ReasonCode.UNSUPPORTED_PROTOCOL,
             f"hello record has key 'protocol' = {record.protocol}, "
@@ -129,18 +163,22 @@ def _read_values(
     values: Mapping[str, float] | None,
     position: int,
 ) -> Mapping[str, float]:
-    """Validate one measured row against the declared metrics."""
+    """Validate one measured row against the declared metrics.
+
+    Every reported name must be declared, and every metric declared required
+    must be reported. A declared optional metric may be absent.
+    """
     if values is not None:
         reject(
             ReasonCode.INVALID_RECORD,
             f"record {position} is a second result record, "
-            "but protocol 1 carries at most one operating point",
+            f"but protocol {PROTOCOL_VERSION} carries at most one operating point",
         )
     if record.label:
         reject(
             ReasonCode.UNSUPPORTED_LABEL,
             f"record {position} has key 'label' = {record.label!r}, "
-            "but protocol 1 accepts only the default label",
+            f"but protocol {PROTOCOL_VERSION} accepts only the default label",
         )
     unknown = sorted(name for name in record.values if name not in hello.metrics)
     if unknown:
@@ -149,11 +187,13 @@ def _read_values(
             f"record {position} has key 'values' with undeclared metrics "
             f"{_names(unknown)}; hello record declares {_names(hello.metrics)}",
         )
-    missing = sorted(name for name in hello.metrics if name not in record.values)
+    missing = sorted(
+        name for name, spec in hello.metrics.items() if spec.required and name not in record.values
+    )
     if missing:
         reject(
             ReasonCode.MISSING_METRIC,
-            f"record {position} has key 'values' missing declared metrics {_names(missing)}",
+            f"record {position} has key 'values' missing required metrics {_names(missing)}",
         )
     return {
         name: _read_value(value, name=name, position=position)

--- a/libs/vs-evaluator-protocol/src/vs_evaluator_protocol/records.py
+++ b/libs/vs-evaluator-protocol/src/vs_evaluator_protocol/records.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 import json
-from typing import Literal, NoReturn
+from typing import Literal, NoReturn, Self
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, ValidationError, model_validator
 
 from vs_evaluator_protocol.errors import ReasonCode, reject
 
-PROTOCOL_VERSION: int = 1
+PROTOCOL_VERSION: int = 2
+
+# TRANSITIONAL: the two Go evaluators in this repository still emit protocol 1,
+# so the reader keeps accepting it until they are rebuilt against an SDK that
+# emits protocol 2. Version 1 has no `required` key, so a version 1 stream is
+# read as declaring every metric required. Delete `LEGACY_PROTOCOL_VERSION`,
+# `SUPPORTED_PROTOCOL_VERSIONS`, and `Hello._require_every_legacy_metric` in
+# that follow-up; nothing else carries version 1 behavior.
+LEGACY_PROTOCOL_VERSION: int = 1
+SUPPORTED_PROTOCOL_VERSIONS: frozenset[int] = frozenset({LEGACY_PROTOCOL_VERSION, PROTOCOL_VERSION})
 
 
 class _StrictRecord(BaseModel):
@@ -19,14 +28,19 @@ class _StrictRecord(BaseModel):
 
 
 class MetricSpec(_StrictRecord):
-    """Advisory metadata for one declared metric.
+    """Declaration of one metric the evaluator produces.
 
-    Neither field selects objectives: `unit` is human-facing and `direction`
-    states the metric's intrinsic better-direction.
+    `unit` and `direction` are advisory and select nothing: `unit` is
+    human-facing and `direction` states the metric's intrinsic
+    better-direction. `required` is not advisory: it says whether every
+    successful run must report the metric. An optional metric is still
+    declared, so it can never be reported under a name the reader has not
+    seen, but it may be absent from a result row.
     """
 
     unit: str | None = None
     direction: Literal["max", "min"] | None = None
+    required: bool = True
 
 
 class Hello(_StrictRecord):
@@ -35,6 +49,22 @@ class Hello(_StrictRecord):
     kind: Literal["hello"] = "hello"
     protocol: int
     metrics: dict[str, MetricSpec]
+
+    @model_validator(mode="after")
+    def _require_every_legacy_metric(self) -> Self:
+        """Read a version 1 declaration as marking every metric required.
+
+        TRANSITIONAL, removed with the rest of version 1 support. Version 1
+        has no `required` key, so normalizing here keeps every consumer of a
+        `Hello`, `read_measurement` and `check_objectives` alike, from having
+        to branch on the protocol version.
+        """
+        if self.protocol == LEGACY_PROTOCOL_VERSION:
+            self.metrics = {
+                name: spec.model_copy(update={"required": True})
+                for name, spec in self.metrics.items()
+            }
+        return self
 
 
 class Result(_StrictRecord):

--- a/libs/vs-evaluator-protocol/tests/test_vs_evaluator_protocol_fixtures.py
+++ b/libs/vs-evaluator-protocol/tests/test_vs_evaluator_protocol_fixtures.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 from vs_evaluator_protocol import (
+    Hello,
     Measurement,
     ProtocolError,
     ReasonCode,
@@ -61,9 +62,18 @@ def test_valid_stream_reads_the_expected_outcome(stream: Path) -> None:
         assert not measurement.failed
         assert measurement.failure is None
         assert measurement.values == expected["values"]
-        assert set(measurement.metrics) == set(expected["values"])
+        assert measurement.metrics is not None
+        reported = set(expected["values"])
+        declared = set(measurement.metrics)
+        required = {name for name, spec in measurement.metrics.items() if spec.required}
+        assert reported <= declared
+        assert required <= reported
     else:
         assert measurement.failed
         assert measurement.values is None
         assert measurement.failure
-        assert measurement.metrics
+        # A failed stream carries the declaration only when it had one: an
+        # error may arrive with no preceding hello.
+        records = parse_records(stream.read_text(encoding="utf-8"))
+        declares = any(isinstance(record, Hello) for record in records)
+        assert (measurement.metrics is not None) == declares

--- a/libs/vs-evaluator-protocol/tests/test_vs_evaluator_protocol_reader.py
+++ b/libs/vs-evaluator-protocol/tests/test_vs_evaluator_protocol_reader.py
@@ -26,13 +26,16 @@ if TYPE_CHECKING:
     from vs_evaluator_protocol import Record
 
 HELLO_LINE = (
-    '{"kind":"hello","protocol":1,"metrics":{"throughput":{"unit":"ops/s","direction":"max"}}}'
+    '{"kind":"hello","protocol":2,"metrics":{"throughput":{"unit":"ops/s","direction":"max"}}}'
 )
 RESULT_LINE = '{"kind":"result","label":"","values":{"throughput":41250.3}}'
 
 
-def _hello(*names: str) -> Hello:
-    return Hello(protocol=PROTOCOL_VERSION, metrics=dict.fromkeys(names, MetricSpec()))
+def _hello(*names: str, optional: str | None = None) -> Hello:
+    metrics = dict.fromkeys(names, MetricSpec())
+    if optional is not None:
+        metrics[optional] = MetricSpec(required=False)
+    return Hello(protocol=PROTOCOL_VERSION, metrics=metrics)
 
 
 def test_parse_records_skips_blank_lines_and_keeps_order() -> None:
@@ -40,13 +43,13 @@ def test_parse_records_skips_blank_lines_and_keeps_order() -> None:
 
     assert [type(record) for record in records] == [Hello, Result]
     assert records[0] == Hello(
-        protocol=1,
+        protocol=2,
         metrics={"throughput": MetricSpec(unit="ops/s", direction="max")},
     )
 
 
 def test_parse_records_rejects_an_unknown_key_inside_a_metric_spec() -> None:
-    line = '{"kind":"hello","protocol":1,"metrics":{"throughput":{"scale":"log"}}}'
+    line = '{"kind":"hello","protocol":2,"metrics":{"throughput":{"scale":"log"}}}'
 
     with pytest.raises(ProtocolError) as rejection:
         parse_records(line)
@@ -66,14 +69,14 @@ def test_parse_records_rejects_a_line_that_is_not_a_json_object(line: str) -> No
 
 def test_parse_records_rejects_a_record_without_a_kind() -> None:
     with pytest.raises(ProtocolError) as rejection:
-        parse_records('{"protocol":1,"metrics":{}}')
+        parse_records('{"protocol":2,"metrics":{}}')
 
     assert rejection.value.code == ReasonCode.UNKNOWN_KIND
 
 
 def test_parse_records_rejects_a_coerced_field_type() -> None:
     with pytest.raises(ProtocolError) as rejection:
-        parse_records('{"kind":"hello","protocol":"1","metrics":{"throughput":{}}}')
+        parse_records('{"kind":"hello","protocol":"2","metrics":{"throughput":{}}}')
 
     assert rejection.value.code == ReasonCode.INVALID_RECORD
     assert "protocol" in str(rejection.value)
@@ -91,6 +94,7 @@ def test_read_measurement_consumes_a_lazy_record_stream() -> None:
 
     assert consumed == ["hello", "result"]
     assert measurement.values == {"throughput": 41250.3}
+    assert measurement.metrics is not None
     assert measurement.metrics["throughput"].direction == "max"
 
 
@@ -124,6 +128,81 @@ def test_read_measurement_rejects_a_second_result_record() -> None:
 
     assert rejection.value.code == ReasonCode.INVALID_RECORD
     assert "record 3" in str(rejection.value)
+
+
+def test_read_measurement_accepts_a_declared_optional_metric_when_reported() -> None:
+    records = [
+        _hello("throughput", optional="p99_latency_ms"),
+        Result(values={"throughput": 1.0, "p99_latency_ms": 812.0}),
+    ]
+
+    measurement = read_measurement(records)
+
+    assert measurement.values == {"throughput": 1.0, "p99_latency_ms": 812.0}
+
+
+def test_read_measurement_accepts_a_declared_optional_metric_when_absent() -> None:
+    hello = _hello("throughput", optional="p99_latency_ms")
+
+    measurement = read_measurement([hello, Result(values={"throughput": 1.0})])
+
+    assert measurement.values == {"throughput": 1.0}
+    assert measurement.metrics == hello.metrics
+
+
+def test_read_measurement_rejects_a_row_missing_a_required_metric() -> None:
+    records = [
+        _hello("throughput", optional="p99_latency_ms"),
+        Result(values={"p99_latency_ms": 812.0}),
+    ]
+
+    with pytest.raises(ProtocolError) as rejection:
+        read_measurement(records)
+
+    assert rejection.value.code == ReasonCode.MISSING_METRIC
+    message = str(rejection.value)
+    assert "'throughput'" in message
+    assert "p99_latency_ms" not in message
+
+
+def test_read_measurement_accepts_an_error_that_replaces_the_hello() -> None:
+    measurement = read_measurement([ErrorRecord(message="config failed to parse")])
+
+    assert measurement.failed
+    assert measurement.failure == "config failed to parse"
+    assert measurement.metrics is None
+    assert measurement.values is None
+
+
+def test_read_measurement_rejects_an_error_that_follows_a_record_without_a_hello() -> None:
+    records = [Result(values={"throughput": 1.0}), ErrorRecord(message="runner died")]
+
+    with pytest.raises(ProtocolError) as rejection:
+        read_measurement(records)
+
+    assert rejection.value.code == ReasonCode.MISSING_HELLO
+
+
+def test_read_measurement_reads_a_protocol_1_stream_as_all_metrics_required() -> None:
+    legacy_hello = (
+        '{"kind":"hello","protocol":1,"metrics":{"throughput":{"unit":"ops/s","direction":"max"}}}'
+    )
+
+    measurement = read_measurement(parse_records(f"{legacy_hello}\n{RESULT_LINE}"))
+
+    assert measurement.values == {"throughput": 41250.3}
+    assert measurement.metrics is not None
+    assert measurement.metrics["throughput"].required
+
+
+def test_read_measurement_rejects_a_protocol_1_row_missing_a_metric() -> None:
+    legacy_hello = '{"kind":"hello","protocol":1,"metrics":{"throughput":{},"latency_ms":{}}}'
+
+    with pytest.raises(ProtocolError) as rejection:
+        read_measurement(parse_records(f"{legacy_hello}\n{RESULT_LINE}"))
+
+    assert rejection.value.code == ReasonCode.MISSING_METRIC
+    assert "'latency_ms'" in str(rejection.value)
 
 
 def test_read_measurement_reports_every_undeclared_metric() -> None:
@@ -171,6 +250,11 @@ def test_measurement_rejects_an_outcome_that_is_both_or_neither() -> None:
         Measurement(metrics=metrics, values={"throughput": 1.0}, failure="runner died")
 
 
+def test_measurement_rejects_a_row_without_the_declaration_it_was_validated_against() -> None:
+    with pytest.raises(ValueError, match="carries the metric declaration"):
+        Measurement(metrics=None, values={"throughput": 1.0})
+
+
 def test_check_objectives_accepts_a_subset_of_the_declared_metrics() -> None:
     hello = _hello("throughput", "latency_ms")
 
@@ -189,3 +273,27 @@ def test_check_objectives_names_the_missing_objective_and_the_declared_metrics()
     assert "'goodput'" in message
     assert "'throughput'" in message
     assert "'latency_ms'" in message
+
+
+def test_check_objectives_rejects_an_objective_declared_optional() -> None:
+    hello = _hello("throughput", optional="p99_latency_ms")
+
+    with pytest.raises(ProtocolError) as rejection:
+        check_objectives(hello, {"p99_latency_ms"})
+
+    assert rejection.value.code == ReasonCode.MISSING_METRIC
+    message = str(rejection.value)
+    assert "'p99_latency_ms'" in message
+    assert "optional" in message
+    assert "not declared" not in message
+
+
+def test_check_objectives_separates_undeclared_objectives_from_optional_ones() -> None:
+    hello = _hello("throughput", optional="p99_latency_ms")
+
+    with pytest.raises(ProtocolError) as rejection:
+        check_objectives(hello, {"goodput", "p99_latency_ms", "throughput"})
+
+    message = str(rejection.value)
+    assert "objectives 'goodput' are not declared" in message
+    assert "objectives 'p99_latency_ms' are declared optional" in message

--- a/sdk/vs-evaluator/PROTOCOL.md
+++ b/sdk/vs-evaluator/PROTOCOL.md
@@ -1,6 +1,6 @@
 # VibeSys evaluator result protocol
 
-Version 1.
+Version 2.
 
 An evaluator reports its measurements to the VibeSys framework as a **record
 stream**: a sequence of JSON objects, one per line, written to the file named by
@@ -19,10 +19,11 @@ are rejected. Unknown keys inside a known record are rejected.
 
 ### `hello`
 
-Exactly one, and it must be the first record.
+Exactly one. It must be first, unless the stream is a single `error` (see
+below).
 
 ```json
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{"unit":"ops/s","direction":"max"}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{"unit":"ops/s","direction":"max"}}}
 ```
 
 - `protocol` (int, required): protocol version. Readers reject versions they do
@@ -31,13 +32,23 @@ Exactly one, and it must be the first record.
   produces. Each value is a spec object:
   - `unit` (string, optional): human-facing unit. Never parsed for meaning.
   - `direction` (`"max"` or `"min"`, optional): intrinsic better-direction of
-    the metric. Advisory metadata. It does not select objectives.
+    the metric. Advisory metadata. It does not select objectives. Only these two
+    spellings are valid on the wire. An SDK may accept `maximize`/`minimize` at
+    its own API boundary, since that is how task configs spell them, but must
+    write the short form.
+  - `required` (bool, optional, default `true`): whether every successful run
+    must report this metric. Producers omit the key when a metric is required,
+    since the corpus compares records semantically and an explicit `true` would
+    not match its counterpart. Mark a metric optional when the evaluator can only
+    sometimes produce it, for example a latency distribution that is empty when
+    no sample matched. An optional metric is still declared, so it can never be
+    reported under a name the reader has not seen.
 
 Metric names must be non-empty and contain no whitespace.
 
 ### `result`
 
-Zero or one per stream in protocol 1. A stream with no `result` and no `error`
+Zero or one per stream. A stream with no `result` and no `error`
 is invalid.
 
 ```json
@@ -45,14 +56,26 @@ is invalid.
 ```
 
 - `label` (string, optional, default `""`): names the operating point. Reserved
-  for future multi-point streams; protocol 1 readers accept only the default.
-- `values` (object, required): the measured row. Its key set must equal the
-  `metrics` key set from `hello` exactly: no missing names, no extra names.
-  Every value must be a finite JSON number. Booleans are not numbers.
+  for future multi-point streams; version 2 readers accept only the default.
+- `values` (object, required): the measured row. Every name in it must be
+  declared in `hello`, and every metric `hello` marked required must appear.
+  An optional metric may be absent. Every value must be a finite JSON number.
+  Booleans are not numbers.
 
 ### `error`
 
 Terminates the stream. Any `result` in the same stream is ignored.
+
+An `error` may appear without a preceding `hello`, and is the only record that
+may. An evaluator whose metric identity comes from configuration cannot declare
+anything until that configuration loads, and a failure before then still needs
+to reach the framework as a reason rather than as a missing file.
+
+Precisely: an `error` in the first position is accepted whether or not a `hello`
+ever arrives, and, as with any `error`, later records are not checked. A `hello`
+that arrives after any other record is still `HELLO_NOT_FIRST`, and a stream
+that reaches its end with neither a first-position `error` nor a `hello` is
+`MISSING_HELLO`.
 
 ```json
 {"kind":"error","message":"vLLM server did not become ready within 300s"}
@@ -72,22 +95,25 @@ Terminates the stream. Any `result` in the same stream is ignored.
 A conforming reader must reject a stream when any of these hold, and must name
 the offending record and key in its error:
 
-1. no `hello`, or `hello` is not first, or more than one `hello`
+1. no `hello`, or `hello` is not first, or more than one `hello`. A stream
+   whose only record is an `error` is the one exception
 2. `protocol` is not a version the reader implements
 3. `metrics` is empty, or a metric name is empty or contains whitespace
 4. neither `result` nor `error` is present
-5. `values` has a key not in `metrics`, or is missing a key in `metrics`
+5. `values` has a key not in `metrics`, or is missing a metric `metrics` marked
+   required
 6. a value is not a number, is a boolean, or is not finite
 7. `label` is not `""`
 8. a record has an unknown `kind`, or a known record has an unknown key
 9. a line is not a JSON object
-10. a second `result` appears. Protocol 1 carries one operating point, so a
+10. a second `result` appears. Protocol 2 carries one operating point, so a
     second row is a producer bug, not a value to silently overwrite.
 
 Rules 1 through 9 are per-record and can be applied as records arrive. Rule 1
 splits by position: a `hello` at any position after the first is
 `HELLO_NOT_FIRST`, reported immediately; the absence of a `hello` is
-`MISSING_HELLO`, and can only be reported once the stream ends. A reader may
+`MISSING_HELLO`, and can only be reported once the stream ends, since an
+`error`-only stream is valid and is not distinguishable until then. A reader may
 therefore not fail on the first offending record in that one case.
 
 An `error` record terminates the stream. Records after it are not checked.
@@ -113,16 +139,22 @@ Three of these need their boundaries stated:
 
 ## Objectives
 
-The framework applies one further check outside the protocol: every objective
-named by the task must appear in `hello.metrics`. That check is separate because
-objectives belong to the task, not to the evaluator. A failure reuses
-`MISSING_METRIC`, naming the objectives that are missing and listing the metrics
+The framework applies two further checks outside the protocol, because
+objectives belong to the task and the evaluator never learns them:
+
+1. Every objective named by the task must appear in `hello.metrics`.
+2. Every objective must be declared `required`. An optional metric may be
+   absent from a successful run, so a task cannot rank on one: the frontier
+   would silently lose the round, which is the failure this protocol exists to
+   prevent.
+
+Both reuse `MISSING_METRIC`, naming the offending objectives and listing what
 the evaluator declared.
 
-## Version 1 limits
+## Version 2 limits
 
 **One row per stream.** `label` exists so a later version can carry several
-operating points, but version 1 readers accept only `""`. This is deliberate:
+operating points, but version 2 readers accept only `""`. This is deliberate:
 the framework has no model for multi-operating-point measurements, so putting
 labelled rows on the wire would move the problem rather than solve it. An
 evaluator with a genuine multi-point mode should reject the combination of that

--- a/sdk/vs-evaluator/fixtures/expectations.json
+++ b/sdk/vs-evaluator/fixtures/expectations.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Reason code every conforming reader must report for each invalid stream. Codes are part of the protocol contract; error message wording is not.",
+  "comment": "Reason code every conforming reader must report for each invalid stream. Codes are part of the protocol contract; error message wording is not. `legacy-protocol-1` is transitional: it exists only until the Go evaluators are rebuilt against an SDK that emits protocol 2, and is removed with protocol 1 support.",
   "invalid": {
     "boolean-value": "NON_NUMERIC_VALUE",
     "duplicate-hello": "DUPLICATE_HELLO",
@@ -14,6 +14,7 @@
     "no-outcome": "NO_OUTCOME",
     "non-finite-value": "NON_FINITE_VALUE",
     "non-numeric-value": "NON_NUMERIC_VALUE",
+    "required-metric-missing": "MISSING_METRIC",
     "second-result": "INVALID_RECORD",
     "unknown-key": "UNKNOWN_KEY",
     "unknown-kind": "UNKNOWN_KIND",
@@ -31,11 +32,36 @@
     "error": {
       "outcome": "error"
     },
+    "error-first-ignores-later-records": {
+      "outcome": "error"
+    },
+    "error-without-hello": {
+      "outcome": "error"
+    },
+    "legacy-protocol-1": {
+      "outcome": "result",
+      "values": {
+        "total_ops_per_sec": 41250.3
+      }
+    },
     "negative-and-integer-values": {
       "outcome": "result",
       "values": {
         "drift_ratio": -0.25,
         "enqueued": 1048576.0
+      }
+    },
+    "optional-metric-absent": {
+      "outcome": "result",
+      "values": {
+        "operations_per_second": 50.9
+      }
+    },
+    "optional-metric-present": {
+      "outcome": "result",
+      "values": {
+        "operations_per_second": 50.9,
+        "p99_latency_ms": 812.0
       }
     },
     "single-metric": {

--- a/sdk/vs-evaluator/fixtures/invalid/boolean-value.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/boolean-value.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
 {"kind":"result","label":"","values":{"total_ops_per_sec":true}}

--- a/sdk/vs-evaluator/fixtures/invalid/duplicate-hello.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/duplicate-hello.jsonl
@@ -1,3 +1,3 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
 {"kind":"result","label":"","values":{"total_ops_per_sec":41250.3}}

--- a/sdk/vs-evaluator/fixtures/invalid/empty-error-message.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/empty-error-message.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
 {"kind":"error","message":""}

--- a/sdk/vs-evaluator/fixtures/invalid/empty-metrics.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/empty-metrics.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{}}
+{"kind":"hello","protocol":2,"metrics":{}}
 {"kind":"result","label":"","values":{}}

--- a/sdk/vs-evaluator/fixtures/invalid/hello-not-first.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/hello-not-first.jsonl
@@ -1,2 +1,2 @@
 {"kind":"result","label":"","values":{"total_ops_per_sec":41250.3}}
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}

--- a/sdk/vs-evaluator/fixtures/invalid/labeled-result.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/labeled-result.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
 {"kind":"result","label":"concurrency=64","values":{"total_ops_per_sec":41250.3}}

--- a/sdk/vs-evaluator/fixtures/invalid/malformed-line.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/malformed-line.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
 ["kind","result"]

--- a/sdk/vs-evaluator/fixtures/invalid/missing-kind.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/missing-kind.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
 {"values":{"total_ops_per_sec":41250.3}}

--- a/sdk/vs-evaluator/fixtures/invalid/missing-metric.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/missing-metric.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{},"p99_latency_ms":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{},"p99_latency_ms":{}}}
 {"kind":"result","label":"","values":{"total_ops_per_sec":41250.3}}

--- a/sdk/vs-evaluator/fixtures/invalid/no-outcome.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/no-outcome.jsonl
@@ -1,1 +1,1 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}

--- a/sdk/vs-evaluator/fixtures/invalid/non-finite-value.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/non-finite-value.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
 {"kind":"result","label":"","values":{"total_ops_per_sec":1e999}}

--- a/sdk/vs-evaluator/fixtures/invalid/non-numeric-value.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/non-numeric-value.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
 {"kind":"result","label":"","values":{"total_ops_per_sec":"41250.3"}}

--- a/sdk/vs-evaluator/fixtures/invalid/required-metric-missing.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/required-metric-missing.jsonl
@@ -1,0 +1,2 @@
+{"kind":"hello","protocol":2,"metrics":{"operations_per_second":{"unit":"operations/s"},"p99_latency_ms":{"unit":"ms","required":false}}}
+{"kind":"result","label":"","values":{"p99_latency_ms":812.0}}

--- a/sdk/vs-evaluator/fixtures/invalid/second-result.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/second-result.jsonl
@@ -1,3 +1,3 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
 {"kind":"result","label":"","values":{"total_ops_per_sec":41250.3}}
 {"kind":"result","label":"","values":{"total_ops_per_sec":41300.1}}

--- a/sdk/vs-evaluator/fixtures/invalid/unknown-key.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/unknown-key.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
 {"kind":"result","label":"","values":{"total_ops_per_sec":41250.3},"elapsed_s":12.5}

--- a/sdk/vs-evaluator/fixtures/invalid/unknown-kind.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/unknown-kind.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
 {"kind":"summary","values":{"total_ops_per_sec":41250.3}}

--- a/sdk/vs-evaluator/fixtures/invalid/unknown-metric.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/unknown-metric.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
 {"kind":"result","label":"","values":{"total_ops_per_sec":41250.3,"p99_latency_ms":8.2}}

--- a/sdk/vs-evaluator/fixtures/invalid/unsupported-protocol.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/unsupported-protocol.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{}}}
+{"kind":"hello","protocol":3,"metrics":{"total_ops_per_sec":{}}}
 {"kind":"result","label":"","values":{"total_ops_per_sec":41250.3}}

--- a/sdk/vs-evaluator/fixtures/invalid/whitespace-metric-name.jsonl
+++ b/sdk/vs-evaluator/fixtures/invalid/whitespace-metric-name.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total ops per sec":{}}}
+{"kind":"hello","protocol":2,"metrics":{"total ops per sec":{}}}
 {"kind":"result","label":"","values":{"total ops per sec":41250.3}}

--- a/sdk/vs-evaluator/fixtures/valid/bare-metric-spec.jsonl
+++ b/sdk/vs-evaluator/fixtures/valid/bare-metric-spec.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"primary_value":{}}}
+{"kind":"hello","protocol":2,"metrics":{"primary_value":{}}}
 {"kind":"result","label":"","values":{"primary_value":0.0}}

--- a/sdk/vs-evaluator/fixtures/valid/error-first-ignores-later-records.jsonl
+++ b/sdk/vs-evaluator/fixtures/valid/error-first-ignores-later-records.jsonl
@@ -1,0 +1,2 @@
+{"kind":"error","message":"candidate service never became reachable"}
+{"kind":"result","label":"","values":{"anything":1.0}}

--- a/sdk/vs-evaluator/fixtures/valid/error-without-hello.jsonl
+++ b/sdk/vs-evaluator/fixtures/valid/error-without-hello.jsonl
@@ -1,0 +1,1 @@
+{"kind":"error","message":"workload config failed to parse, so no metric identity exists yet"}

--- a/sdk/vs-evaluator/fixtures/valid/error.jsonl
+++ b/sdk/vs-evaluator/fixtures/valid/error.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{"unit":"ops/s"}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{"unit":"ops/s"}}}
 {"kind":"error","message":"queue runner exited before the workload completed"}

--- a/sdk/vs-evaluator/fixtures/valid/legacy-protocol-1.jsonl
+++ b/sdk/vs-evaluator/fixtures/valid/legacy-protocol-1.jsonl
@@ -1,0 +1,2 @@
+{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{"unit":"ops/s","direction":"max"}}}
+{"kind":"result","label":"","values":{"total_ops_per_sec":41250.3}}

--- a/sdk/vs-evaluator/fixtures/valid/negative-and-integer-values.jsonl
+++ b/sdk/vs-evaluator/fixtures/valid/negative-and-integer-values.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"drift_ratio":{},"enqueued":{"unit":"ops"}}}
+{"kind":"hello","protocol":2,"metrics":{"drift_ratio":{},"enqueued":{"unit":"ops"}}}
 {"kind":"result","label":"","values":{"drift_ratio":-0.25,"enqueued":1048576}}

--- a/sdk/vs-evaluator/fixtures/valid/optional-metric-absent.jsonl
+++ b/sdk/vs-evaluator/fixtures/valid/optional-metric-absent.jsonl
@@ -1,0 +1,2 @@
+{"kind":"hello","protocol":2,"metrics":{"operations_per_second":{"unit":"operations/s","direction":"max"},"p99_latency_ms":{"unit":"ms","direction":"min","required":false}}}
+{"kind":"result","label":"","values":{"operations_per_second":50.9}}

--- a/sdk/vs-evaluator/fixtures/valid/optional-metric-present.jsonl
+++ b/sdk/vs-evaluator/fixtures/valid/optional-metric-present.jsonl
@@ -1,0 +1,2 @@
+{"kind":"hello","protocol":2,"metrics":{"operations_per_second":{"unit":"operations/s","direction":"max"},"p99_latency_ms":{"unit":"ms","direction":"min","required":false}}}
+{"kind":"result","label":"","values":{"operations_per_second":50.9,"p99_latency_ms":812.0}}

--- a/sdk/vs-evaluator/fixtures/valid/single-metric.jsonl
+++ b/sdk/vs-evaluator/fixtures/valid/single-metric.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"total_ops_per_sec":{"unit":"ops/s","direction":"max"}}}
+{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{"unit":"ops/s","direction":"max"}}}
 {"kind":"result","label":"","values":{"total_ops_per_sec":41250.3}}

--- a/sdk/vs-evaluator/fixtures/valid/two-metrics.jsonl
+++ b/sdk/vs-evaluator/fixtures/valid/two-metrics.jsonl
@@ -1,2 +1,2 @@
-{"kind":"hello","protocol":1,"metrics":{"aggregate_throughput":{"unit":"tok/s","direction":"max"},"p99_latency_ms":{"unit":"ms","direction":"min"}}}
+{"kind":"hello","protocol":2,"metrics":{"aggregate_throughput":{"unit":"tok/s","direction":"max"},"p99_latency_ms":{"unit":"ms","direction":"min"}}}
 {"kind":"result","label":"","values":{"aggregate_throughput":1180.4,"p99_latency_ms":812.0}}

--- a/sdk/vs-evaluator/vseval/api_test.go
+++ b/sdk/vs-evaluator/vseval/api_test.go
@@ -16,16 +16,15 @@ import (
 	"github.com/uw-syfi/vibesys/sdk/vs-evaluator/vseval"
 )
 
-// TestHelloIsWrittenAtStart pins the crash-visibility property: the schema
+// TestHelloIsWrittenAtDeclare pins the crash-visibility property: the schema
 // reaches the file before any measurement runs, so a reader of a truncated
 // stream reports a missing outcome rather than a missing hello.
-func TestHelloIsWrittenAtStart(t *testing.T) {
+func TestHelloIsWrittenAtDeclare(t *testing.T) {
 	var buf bytes.Buffer
 	schema := vseval.NewSchema()
 	schema.Number("total_ops_per_sec", vseval.Unit("ops/s"), vseval.Direction(vseval.Max))
-	if _, err := schema.StartWriter(&buf); err != nil {
-		t.Fatalf("StartWriter: %v", err)
-	}
+	declare(t, schema, &buf)
+
 	records := parseStream(t, buf.Bytes())
 	if len(records) != 1 || records[0]["kind"] != "hello" {
 		t.Fatalf("want a single hello record, got %v", records)
@@ -33,25 +32,184 @@ func TestHelloIsWrittenAtStart(t *testing.T) {
 	if records[0]["protocol"] != float64(vseval.Protocol) {
 		t.Errorf("protocol = %v, want %d", records[0]["protocol"], vseval.Protocol)
 	}
+	if vseval.Protocol != 2 {
+		t.Errorf("Protocol = %d, want 2", vseval.Protocol)
+	}
 }
 
-func TestEmitRejectsUnsetMetric(t *testing.T) {
+// TestOpeningWritesNothing is the other half of the two-phase contract: an
+// open report has declared nothing, so it has put nothing on the wire.
+func TestOpeningWritesNothing(t *testing.T) {
+	var buf bytes.Buffer
+	report := vseval.OpenWriter(&buf)
+	if !report.Reporting() {
+		t.Error("Reporting is false for a report opened on a writer")
+	}
+	if report.OutcomeWritten() {
+		t.Error("OutcomeWritten is true before anything was written")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("opening wrote %q, want nothing", buf.String())
+	}
+}
+
+// TestFailureBeforeAnySchemaIsAValidStream covers the port that motivated the
+// split: an evaluator whose metric identity comes from a config file cannot
+// declare anything until that file loads, and a failure before then must still
+// reach the framework as a reason.
+func TestFailureBeforeAnySchemaIsAValidStream(t *testing.T) {
+	var buf bytes.Buffer
+	report := vseval.OpenWriter(&buf)
+	if err := report.EmitError(errors.New("workload config failed to parse")); err != nil {
+		t.Fatalf("EmitError: %v", err)
+	}
+	records := parseStream(t, buf.Bytes())
+	if len(records) != 1 {
+		t.Fatalf("stream = %v, want a single error record", records)
+	}
+	if records[0]["kind"] != "error" || records[0]["message"] != "workload config failed to parse" {
+		t.Errorf("record = %v", records[0])
+	}
+	if !report.OutcomeWritten() {
+		t.Error("OutcomeWritten is false after an error record")
+	}
+	if _, err := report.Declare(vseval.NewSchema()); err == nil {
+		t.Error("Declare succeeded after the stream already had an outcome")
+	}
+}
+
+// TestOutcomeWrittenTracksTheStream covers the query a deferred failure
+// reporter needs, so an evaluator does not have to track the outcome itself.
+func TestOutcomeWrittenTracksTheStream(t *testing.T) {
+	for name, finish := range map[string]func(*testing.T, *vseval.Run){
+		"result": func(t *testing.T, run *vseval.Run) { mustEmit(t, run) },
+		"error": func(t *testing.T, run *vseval.Run) {
+			if err := run.EmitError(errors.New("queue runner exited")); err != nil {
+				t.Fatalf("EmitError: %v", err)
+			}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			schema := vseval.NewSchema()
+			ops := schema.Number("total_ops_per_sec")
+			run := declare(t, schema, &buf)
+			run.Set(ops, 1)
+			if run.OutcomeWritten() {
+				t.Error("OutcomeWritten is true after the hello record alone")
+			}
+			finish(t, run)
+			if !run.OutcomeWritten() {
+				t.Error("OutcomeWritten is false after the outcome record")
+			}
+			// The deferred-reporter shape: asking is what keeps a late failure
+			// from writing a second outcome.
+			if err := run.EmitError(errors.New("late failure")); err == nil {
+				t.Error("EmitError succeeded after the stream already had an outcome")
+			}
+			if got := len(parseStream(t, buf.Bytes())); got != 2 {
+				t.Errorf("wrote %d records, want hello and one outcome", got)
+			}
+		})
+	}
+}
+
+// TestOptionalMetricMayBeAbsent covers the metric an evaluator can only
+// sometimes produce: declared either way, absent from the row when unset.
+func TestOptionalMetricMayBeAbsent(t *testing.T) {
+	var buf bytes.Buffer
+	schema := vseval.NewSchema()
+	ops := schema.Number("operations_per_second", vseval.Direction(vseval.Max))
+	schema.Number("p99_latency_ms", vseval.Unit("ms"), vseval.Optional())
+	run := declare(t, schema, &buf)
+	run.Set(ops, 50.9)
+	mustEmit(t, run)
+
+	records := parseStream(t, buf.Bytes())
+	metrics := records[0]["metrics"].(map[string]any)
+	spec := metrics["p99_latency_ms"].(map[string]any)
+	if spec["required"] != false {
+		t.Errorf("optional metric spec = %v, want required:false", spec)
+	}
+	if _, declared := metrics["operations_per_second"].(map[string]any)["required"]; declared {
+		t.Error("a required metric put a required key on the wire; the protocol default is true")
+	}
+	values := records[1]["values"].(map[string]any)
+	if _, present := values["p99_latency_ms"]; present {
+		t.Errorf("values = %v, want the unset optional metric left out", values)
+	}
+	if values["operations_per_second"] != 50.9 {
+		t.Errorf("values = %v", values)
+	}
+}
+
+func TestOptionalMetricMayBePresent(t *testing.T) {
+	var buf bytes.Buffer
+	schema := vseval.NewSchema()
+	ops := schema.Number("operations_per_second", vseval.Direction(vseval.Max))
+	p99 := schema.Number("p99_latency_ms", vseval.Unit("ms"), vseval.Optional())
+	run := declare(t, schema, &buf)
+	run.Set(ops, 50.9)
+	run.Set(p99, 812.0)
+	mustEmit(t, run)
+
+	values := parseStream(t, buf.Bytes())[1]["values"].(map[string]any)
+	if values["p99_latency_ms"] != 812.0 {
+		t.Errorf("values = %v, want the optional metric that was set", values)
+	}
+}
+
+// TestEmitRejectsUnsetRequiredMetric keeps the zero value from passing for a
+// measurement, which is the whole point of declaring metrics required.
+func TestEmitRejectsUnsetRequiredMetric(t *testing.T) {
 	var buf bytes.Buffer
 	schema := vseval.NewSchema()
 	ops := schema.Number("total_ops_per_sec")
 	schema.Number("p99_latency_ms")
-	run := start(t, schema, &buf)
+	run := declare(t, schema, &buf)
 	run.Set(ops, 1)
 
 	err := run.Emit()
 	if err == nil {
-		t.Fatal("Emit succeeded with an unset metric")
+		t.Fatal("Emit succeeded with an unset required metric")
 	}
 	if !strings.Contains(err.Error(), "p99_latency_ms") {
 		t.Errorf("error does not name the unset metric: %v", err)
 	}
 	if got := len(parseStream(t, buf.Bytes())); got != 1 {
 		t.Errorf("wrote %d records, want only the hello record", got)
+	}
+}
+
+func TestParseDir(t *testing.T) {
+	valid := map[string]vseval.Dir{
+		"max":        vseval.Max,
+		"maximize":   vseval.Max,
+		"MAXIMIZE":   vseval.Max,
+		"  max  ":    vseval.Max,
+		"min":        vseval.Min,
+		"minimize":   vseval.Min,
+		" Minimize ": vseval.Min,
+	}
+	for input, want := range valid {
+		got, err := vseval.ParseDir(input)
+		if err != nil {
+			t.Errorf("ParseDir(%q): %v", input, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("ParseDir(%q) = %q, want %q", input, got, want)
+		}
+	}
+	for _, input := range []string{"", "higher", "maximise", "max ops", "up"} {
+		got, err := vseval.ParseDir(input)
+		if err == nil {
+			t.Errorf("ParseDir(%q) = %q, want an error", input, got)
+			continue
+		}
+		if !strings.Contains(err.Error(), "maximize") {
+			t.Errorf("ParseDir(%q) error = %v, want it to list the accepted words", input, err)
+		}
 	}
 }
 
@@ -65,7 +223,7 @@ func TestEmitRejectsNonFiniteValues(t *testing.T) {
 			var buf bytes.Buffer
 			schema := vseval.NewSchema()
 			ops := schema.Number("total_ops_per_sec")
-			run := start(t, schema, &buf)
+			run := declare(t, schema, &buf)
 			run.Set(ops, value)
 
 			err := run.Emit()
@@ -86,7 +244,7 @@ func TestSetLastWriteWins(t *testing.T) {
 	var buf bytes.Buffer
 	schema := vseval.NewSchema()
 	ops := schema.Number("total_ops_per_sec")
-	run := start(t, schema, &buf)
+	run := declare(t, schema, &buf)
 	run.Set(ops, 1)
 	run.Set(ops, 2)
 	mustEmit(t, run)
@@ -98,26 +256,28 @@ func TestSetLastWriteWins(t *testing.T) {
 	}
 }
 
-func TestStartRejectsInvalidDeclarations(t *testing.T) {
+func TestDeclareRejectsInvalidSchema(t *testing.T) {
 	cases := map[string]struct {
 		declare func(*vseval.Schema)
 		want    string
 	}{
-		"duplicate":        {func(s *vseval.Schema) { s.Number("ops"); s.Number("ops") }, "declared twice"},
-		"empty name":       {func(s *vseval.Schema) { s.Number("") }, "must not be empty"},
-		"inner space":      {func(s *vseval.Schema) { s.Number("total ops") }, "whitespace"},
-		"tab":              {func(s *vseval.Schema) { s.Number("total\tops") }, "whitespace"},
-		"trailing newline": {func(s *vseval.Schema) { s.Number("ops\n") }, "whitespace"},
-		"no metrics":       {func(s *vseval.Schema) {}, "no metrics declared"},
+		"duplicate":         {func(s *vseval.Schema) { s.Number("ops"); s.Number("ops") }, "declared twice"},
+		"empty name":        {func(s *vseval.Schema) { s.Number("") }, "must not be empty"},
+		"inner space":       {func(s *vseval.Schema) { s.Number("total ops") }, "whitespace"},
+		"tab":               {func(s *vseval.Schema) { s.Number("total\tops") }, "whitespace"},
+		"trailing newline":  {func(s *vseval.Schema) { s.Number("ops\n") }, "whitespace"},
+		"no metrics":        {func(s *vseval.Schema) {}, "no metrics declared"},
+		"unknown direction": {func(s *vseval.Schema) { s.Number("ops", vseval.Direction("maximize")) }, "direction"},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			schema := vseval.NewSchema()
 			tc.declare(schema)
 			var buf bytes.Buffer
-			_, err := schema.StartWriter(&buf)
+			report := vseval.OpenWriter(&buf)
+			_, err := report.Declare(schema)
 			if err == nil {
-				t.Fatal("StartWriter succeeded on an invalid schema")
+				t.Fatal("Declare succeeded on an invalid schema")
 			}
 			if !strings.Contains(err.Error(), tc.want) {
 				t.Errorf("error = %v, want it to mention %q", err, tc.want)
@@ -125,7 +285,34 @@ func TestStartRejectsInvalidDeclarations(t *testing.T) {
 			if buf.Len() != 0 {
 				t.Errorf("wrote %q, want nothing", buf.String())
 			}
+			// A rejected schema leaves the stream without an outcome, so the
+			// caller can still say why the evaluator is stopping.
+			if err := report.EmitError(err); err != nil {
+				t.Fatalf("EmitError after a rejected Declare: %v", err)
+			}
+			if got := len(parseStream(t, buf.Bytes())); got != 1 {
+				t.Errorf("wrote %d records, want the error record alone", got)
+			}
 		})
+	}
+}
+
+// TestDeclareOnlyOnce guards the one-hello rule at the producer.
+func TestDeclareOnlyOnce(t *testing.T) {
+	var buf bytes.Buffer
+	report := vseval.OpenWriter(&buf)
+	first := vseval.NewSchema()
+	first.Number("total_ops_per_sec")
+	if _, err := report.Declare(first); err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	second := vseval.NewSchema()
+	second.Number("p99_latency_ms")
+	if _, err := report.Declare(second); err == nil {
+		t.Fatal("Declare succeeded twice on one report")
+	}
+	if got := len(parseStream(t, buf.Bytes())); got != 1 {
+		t.Errorf("wrote %d records, want one hello record", got)
 	}
 }
 
@@ -136,7 +323,7 @@ func TestSetRejectsForeignHandle(t *testing.T) {
 	var buf bytes.Buffer
 	schema := vseval.NewSchema()
 	mine := schema.Number("total_ops_per_sec")
-	run := start(t, schema, &buf)
+	run := declare(t, schema, &buf)
 	run.Set(foreign, 1)
 	run.Set(mine, 1)
 
@@ -149,7 +336,7 @@ func TestEmitErrorWritesErrorRecord(t *testing.T) {
 	var buf bytes.Buffer
 	schema := vseval.NewSchema()
 	schema.Number("total_ops_per_sec")
-	run := start(t, schema, &buf)
+	run := declare(t, schema, &buf)
 
 	if err := run.EmitError(errors.New("queue runner exited")); err != nil {
 		t.Fatalf("EmitError: %v", err)
@@ -179,14 +366,12 @@ func TestEmitErrorSubstitutesBlankMessage(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			var buf bytes.Buffer
-			schema := vseval.NewSchema()
-			schema.Number("total_ops_per_sec")
-			run := start(t, schema, &buf)
-			if err := run.EmitError(cause); err != nil {
+			report := vseval.OpenWriter(&buf)
+			if err := report.EmitError(cause); err != nil {
 				t.Fatalf("EmitError: %v", err)
 			}
 			records := parseStream(t, buf.Bytes())
-			message, _ := records[1]["message"].(string)
+			message, _ := records[0]["message"].(string)
 			if message != vseval.FailureFallbackMessage {
 				t.Errorf("error record message = %q, want %q", message, vseval.FailureFallbackMessage)
 			}
@@ -194,15 +379,20 @@ func TestEmitErrorSubstitutesBlankMessage(t *testing.T) {
 	}
 }
 
-func TestStartWithWritesFileTheCallerCloses(t *testing.T) {
+func TestOpenPathWritesFileTheCallerCloses(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "result.jsonl")
+	report, err := vseval.OpenPath(path)
+	if err != nil {
+		t.Fatalf("OpenPath: %v", err)
+	}
+	defer report.Close()
+
 	schema := vseval.NewSchema()
 	ops := schema.Number("total_ops_per_sec", vseval.Unit("ops/s"), vseval.Direction(vseval.Max))
-	run, err := schema.StartWith(path)
+	run, err := report.Declare(schema)
 	if err != nil {
-		t.Fatalf("StartWith: %v", err)
+		t.Fatalf("Declare: %v", err)
 	}
-	defer run.Close()
 
 	// The hello record must be readable before the run ends.
 	data, err := os.ReadFile(path)
@@ -215,7 +405,7 @@ func TestStartWithWritesFileTheCallerCloses(t *testing.T) {
 
 	run.Set(ops, 41250.3)
 	mustEmit(t, run)
-	if err := run.Close(); err != nil {
+	if err := report.Close(); err != nil {
 		t.Errorf("Close after Emit: %v", err)
 	}
 
@@ -229,23 +419,30 @@ func TestStartWithWritesFileTheCallerCloses(t *testing.T) {
 	}
 }
 
-// TestStartWithoutOutputPathDiscards pins the optional-reporting contract: an
+// TestOpenWithoutOutputPathDiscards pins the optional-reporting contract: an
 // evaluator invoked without -vs-output runs the same code and writes no file.
-func TestStartWithoutOutputPathDiscards(t *testing.T) {
+func TestOpenWithoutOutputPathDiscards(t *testing.T) {
 	dir := t.TempDir()
+	report, err := vseval.OpenPath("")
+	if err != nil {
+		t.Fatalf("OpenPath(\"\"): %v", err)
+	}
+	defer report.Close()
+	if report.Reporting() {
+		t.Error("Reporting is true for a report opened without an output path")
+	}
 	schema := vseval.NewSchema()
 	ops := schema.Number("total_ops_per_sec")
-	run, err := schema.StartWith("")
+	run, err := report.Declare(schema)
 	if err != nil {
-		t.Fatalf("StartWith(\"\"): %v", err)
+		t.Fatalf("Declare: %v", err)
 	}
-	defer run.Close()
 	if run.Reporting() {
-		t.Error("Reporting is true for a run started without an output path")
+		t.Error("Run.Reporting is true for a run that reports nowhere")
 	}
 	run.Set(ops, 1)
 	mustEmit(t, run)
-	if err := run.Close(); err != nil {
+	if err := report.Close(); err != nil {
 		t.Errorf("Close: %v", err)
 	}
 	entries, err := os.ReadDir(dir)
@@ -260,54 +457,60 @@ func TestStartWithoutOutputPathDiscards(t *testing.T) {
 // TestUnreportedRunStillValidates keeps the discarding run honest: a missing
 // measurement is a bug whether or not anyone asked for the report.
 func TestUnreportedRunStillValidates(t *testing.T) {
+	report, err := vseval.OpenPath("")
+	if err != nil {
+		t.Fatalf("OpenPath(\"\"): %v", err)
+	}
+	defer report.Close()
 	schema := vseval.NewSchema()
 	schema.Number("total_ops_per_sec")
-	run, err := schema.StartWith("")
+	run, err := report.Declare(schema)
 	if err != nil {
-		t.Fatalf("StartWith(\"\"): %v", err)
+		t.Fatalf("Declare: %v", err)
 	}
-	defer run.Close()
 	if err := run.Emit(); err == nil {
 		t.Fatal("Emit succeeded on an unreported run with an unset metric")
 	}
 }
 
 func TestReportingIsTrueForAnOpenedFile(t *testing.T) {
-	schema := vseval.NewSchema()
-	schema.Number("total_ops_per_sec")
-	run, err := schema.StartWith(filepath.Join(t.TempDir(), "result.jsonl"))
+	report, err := vseval.OpenPath(filepath.Join(t.TempDir(), "result.jsonl"))
 	if err != nil {
-		t.Fatalf("StartWith: %v", err)
+		t.Fatalf("OpenPath: %v", err)
 	}
-	defer run.Close()
-	if !run.Reporting() {
-		t.Error("Reporting is false for a run that opened an output file")
+	defer report.Close()
+	if !report.Reporting() {
+		t.Error("Reporting is false for a report that opened an output file")
 	}
 }
 
-// TestStartFlagSetRegistersAndParses covers the subcommand entry point: the
+// TestOpenFlagSetRegistersAndParses covers the subcommand entry point: the
 // caller owns the flag set, and the SDK adds its flag and parses the argv.
-func TestStartFlagSetRegistersAndParses(t *testing.T) {
+func TestOpenFlagSetRegistersAndParses(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "result.jsonl")
 	fs := flag.NewFlagSet("benchmark", flag.ContinueOnError)
 	duration := fs.Duration("duration", 0, "measured duration")
 
+	report, err := vseval.OpenFlagSet(fs, []string{"--duration", "20ms", "--" + vseval.OutputFlag, path})
+	if err != nil {
+		t.Fatalf("OpenFlagSet: %v", err)
+	}
+	defer report.Close()
+	if *duration != 20*time.Millisecond {
+		t.Errorf("duration = %v, want 20ms: OpenFlagSet did not parse the caller's flags", *duration)
+	}
+	if !report.Reporting() {
+		t.Error("Reporting is false for a report opened from a parsed -" + vseval.OutputFlag)
+	}
 	schema := vseval.NewSchema()
 	ops := schema.Number("total_ops_per_sec")
-	run, err := schema.StartFlagSet(fs, []string{"--duration", "20ms", "--" + vseval.OutputFlag, path})
+	run, err := report.Declare(schema)
 	if err != nil {
-		t.Fatalf("StartFlagSet: %v", err)
-	}
-	defer run.Close()
-	if *duration != 20*time.Millisecond {
-		t.Errorf("duration = %v, want 20ms: StartFlagSet did not parse the caller's flags", *duration)
-	}
-	if !run.Reporting() {
-		t.Error("Reporting is false for a run started from a parsed -" + vseval.OutputFlag)
+		t.Fatalf("Declare: %v", err)
 	}
 	run.Set(ops, 1)
 	mustEmit(t, run)
-	if err := run.Close(); err != nil {
+	if err := report.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 
@@ -320,25 +523,23 @@ func TestStartFlagSetRegistersAndParses(t *testing.T) {
 	}
 }
 
-// TestStartFlagSetWithoutOutputFlag is the standalone invocation of a
+// TestOpenFlagSetWithoutOutputFlag is the standalone invocation of a
 // subcommand: the flag is registered but never given a value.
-func TestStartFlagSetWithoutOutputFlag(t *testing.T) {
+func TestOpenFlagSetWithoutOutputFlag(t *testing.T) {
 	fs := flag.NewFlagSet("benchmark", flag.ContinueOnError)
-	schema := vseval.NewSchema()
-	schema.Number("total_ops_per_sec")
-	run, err := schema.StartFlagSet(fs, nil)
+	report, err := vseval.OpenFlagSet(fs, nil)
 	if err != nil {
-		t.Fatalf("StartFlagSet: %v", err)
+		t.Fatalf("OpenFlagSet: %v", err)
 	}
-	defer run.Close()
-	if run.Reporting() {
+	defer report.Close()
+	if report.Reporting() {
 		t.Error("Reporting is true without -" + vseval.OutputFlag)
 	}
 }
 
-// TestStartFlagSetAcceptsParsedFlagSet lets a caller that already parsed its
+// TestOpenFlagSetAcceptsParsedFlagSet lets a caller that already parsed its
 // own argv, to validate it before measuring, still reach the same entry point.
-func TestStartFlagSetAcceptsParsedFlagSet(t *testing.T) {
+func TestOpenFlagSetAcceptsParsedFlagSet(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "result.jsonl")
 	fs := flag.NewFlagSet("benchmark", flag.ContinueOnError)
 	vseval.RegisterFlags(fs)
@@ -346,48 +547,42 @@ func TestStartFlagSetAcceptsParsedFlagSet(t *testing.T) {
 		t.Fatalf("parse flags: %v", err)
 	}
 
-	schema := vseval.NewSchema()
-	schema.Number("total_ops_per_sec")
-	run, err := schema.StartFlagSet(fs, nil)
+	report, err := vseval.OpenFlagSet(fs, nil)
 	if err != nil {
-		t.Fatalf("StartFlagSet: %v", err)
+		t.Fatalf("OpenFlagSet: %v", err)
 	}
-	defer run.Close()
-	if !run.Reporting() {
-		t.Fatalf("StartFlagSet ignored the path already parsed into the flag set")
+	defer report.Close()
+	if !report.Reporting() {
+		t.Fatalf("OpenFlagSet ignored the path already parsed into the flag set")
 	}
 }
 
-func TestStartFlagSetReportsParseErrors(t *testing.T) {
+func TestOpenFlagSetReportsParseErrors(t *testing.T) {
 	fs := flag.NewFlagSet("benchmark", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	schema := vseval.NewSchema()
-	schema.Number("total_ops_per_sec")
-	if _, err := schema.StartFlagSet(fs, []string{"--nonexistent"}); err == nil {
-		t.Fatal("StartFlagSet succeeded on an unparseable argv")
+	if _, err := vseval.OpenFlagSet(fs, []string{"--nonexistent"}); err == nil {
+		t.Fatal("OpenFlagSet succeeded on an unparseable argv")
 	}
 }
 
-// TestStartFlagSetReportsLateRegistration mirrors [TestStartReportsLateRegistration]
+// TestOpenFlagSetReportsLateRegistration mirrors [TestOpenReportsLateRegistration]
 // for a caller-owned flag set: a flag set parsed before the SDK saw it cannot
 // carry the output path.
-func TestStartFlagSetReportsLateRegistration(t *testing.T) {
+func TestOpenFlagSetReportsLateRegistration(t *testing.T) {
 	fs := flag.NewFlagSet("benchmark", flag.ContinueOnError)
 	if err := fs.Parse(nil); err != nil {
 		t.Fatalf("parse flags: %v", err)
 	}
-	schema := vseval.NewSchema()
-	schema.Number("total_ops_per_sec")
-	_, err := schema.StartFlagSet(fs, nil)
+	_, err := vseval.OpenFlagSet(fs, nil)
 	if err == nil {
-		t.Fatal("StartFlagSet succeeded on a flag set parsed without the output flag")
+		t.Fatal("OpenFlagSet succeeded on a flag set parsed without the output flag")
 	}
 	if !strings.Contains(err.Error(), "RegisterFlags") {
 		t.Errorf("error = %v, want it to point at RegisterFlags", err)
 	}
 }
 
-func TestStartParsesOutputFlag(t *testing.T) {
+func TestOpenPathUsesTheParsedOutputFlag(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "result.jsonl")
 	fs := flag.NewFlagSet("evaluator", flag.ContinueOnError)
 	output := vseval.RegisterFlags(fs)
@@ -395,13 +590,17 @@ func TestStartParsesOutputFlag(t *testing.T) {
 		t.Fatalf("parse flags: %v", err)
 	}
 
+	report, err := vseval.OpenPath(*output)
+	if err != nil {
+		t.Fatalf("OpenPath: %v", err)
+	}
+	defer report.Close()
 	schema := vseval.NewSchema()
 	ops := schema.Number("total_ops_per_sec")
-	run, err := schema.StartWith(*output)
+	run, err := report.Declare(schema)
 	if err != nil {
-		t.Fatalf("StartWith: %v", err)
+		t.Fatalf("Declare: %v", err)
 	}
-	defer run.Close()
 	run.Set(ops, 1)
 	mustEmit(t, run)
 
@@ -420,9 +619,8 @@ func TestBareMetricSpecSerializesEmpty(t *testing.T) {
 	var buf bytes.Buffer
 	schema := vseval.NewSchema()
 	schema.Number("primary_value")
-	if _, err := schema.StartWriter(&buf); err != nil {
-		t.Fatalf("StartWriter: %v", err)
-	}
+	declare(t, schema, &buf)
+
 	var hello struct {
 		Metrics map[string]json.RawMessage `json:"metrics"`
 	}
@@ -435,40 +633,38 @@ func TestBareMetricSpecSerializesEmpty(t *testing.T) {
 	}
 }
 
-// TestStartReportsLateRegistration covers the guard that keeps Start from
+// TestOpenReportsLateRegistration covers the guard that keeps Open from
 // silently reading an unregistered flag. The test binary has already parsed
 // flag.CommandLine, which is the situation an evaluator with its own flags
 // lands in.
-func TestStartReportsLateRegistration(t *testing.T) {
+func TestOpenReportsLateRegistration(t *testing.T) {
 	if !flag.Parsed() {
 		t.Skip("flag.CommandLine is unparsed in this test binary")
 	}
 	if flag.CommandLine.Lookup(vseval.OutputFlag) != nil {
 		t.Skip("-" + vseval.OutputFlag + " is already registered on flag.CommandLine")
 	}
-	schema := vseval.NewSchema()
-	schema.Number("total_ops_per_sec")
-	_, err := schema.Start()
+	_, err := vseval.Open()
 	if err == nil {
-		t.Fatal("Start succeeded without a registered output flag")
+		t.Fatal("Open succeeded without a registered output flag")
 	}
 	if !strings.Contains(err.Error(), "RegisterFlags") {
-		t.Errorf("error = %v, want it to point at RegisterFlags or StartWith", err)
+		t.Errorf("error = %v, want it to point at RegisterFlags or OpenPath", err)
 	}
 }
 
-// TestSetRejectsMetricDeclaredAfterStart guards the handle bounds: a metric
+// TestSetRejectsMetricDeclaredAfterDeclare guards the handle bounds: a metric
 // declared after the hello record is written is not in the stream's schema.
-func TestSetRejectsMetricDeclaredAfterStart(t *testing.T) {
+func TestSetRejectsMetricDeclaredAfterDeclare(t *testing.T) {
 	var buf bytes.Buffer
 	schema := vseval.NewSchema()
 	ops := schema.Number("total_ops_per_sec")
-	run := start(t, schema, &buf)
+	run := declare(t, schema, &buf)
 	late := schema.Number("p99_latency_ms")
 
 	run.Set(ops, 1)
 	if err := run.Emit(); err == nil {
-		t.Fatal("Emit succeeded with a metric declared after the run started")
+		t.Fatal("Emit succeeded with a metric declared after the schema")
 	}
 
 	run.Set(late, 2)

--- a/sdk/vs-evaluator/vseval/close_internal_test.go
+++ b/sdk/vs-evaluator/vseval/close_internal_test.go
@@ -6,31 +6,35 @@ import (
 	"testing"
 )
 
-// TestEmitLeavesTheOutputOpen pins the ownership rule: the caller that started
-// the run closes it, so a deferred Close is the only close in the program and
-// Emit does not race ahead of it. The check reaches into the Run because the
-// difference is invisible from outside: Close is idempotent either way.
+// TestEmitLeavesTheOutputOpen pins the ownership rule: the caller that opened
+// the report closes it, so a deferred Close is the only close in the program
+// and Emit does not race ahead of it. The check reaches into the Report because
+// the difference is invisible from outside: Close is idempotent either way.
 func TestEmitLeavesTheOutputOpen(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "result.jsonl")
+	report, err := OpenPath(path)
+	if err != nil {
+		t.Fatalf("OpenPath: %v", err)
+	}
+	defer report.Close()
+
 	schema := NewSchema()
 	ops := schema.Number("total_ops_per_sec")
-	run, err := schema.StartWith(path)
+	run, err := report.Declare(schema)
 	if err != nil {
-		t.Fatalf("StartWith: %v", err)
+		t.Fatalf("Declare: %v", err)
 	}
-	defer run.Close()
-
 	run.Set(ops, 1)
 	if err := run.Emit(); err != nil {
 		t.Fatalf("Emit: %v", err)
 	}
-	if run.closer == nil {
+	if report.closer == nil {
 		t.Fatal("Emit closed the output; closing belongs to the caller's deferred Close")
 	}
-	if err := run.Close(); err != nil {
+	if err := report.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if err := run.Close(); err != nil {
+	if err := report.Close(); err != nil {
 		t.Fatalf("second Close: %v", err)
 	}
 	data, err := os.ReadFile(path)
@@ -43,21 +47,19 @@ func TestEmitLeavesTheOutputOpen(t *testing.T) {
 }
 
 // TestEmitErrorLeavesTheOutputOpen is the failure-path twin of
-// TestEmitLeavesTheOutputOpen.
+// TestEmitLeavesTheOutputOpen, on a report that never declared a schema.
 func TestEmitErrorLeavesTheOutputOpen(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "result.jsonl")
-	schema := NewSchema()
-	schema.Number("total_ops_per_sec")
-	run, err := schema.StartWith(path)
+	report, err := OpenPath(path)
 	if err != nil {
-		t.Fatalf("StartWith: %v", err)
+		t.Fatalf("OpenPath: %v", err)
 	}
-	defer run.Close()
+	defer report.Close()
 
-	if err := run.EmitError(nil); err != nil {
+	if err := report.EmitError(nil); err != nil {
 		t.Fatalf("EmitError: %v", err)
 	}
-	if run.closer == nil {
+	if report.closer == nil {
 		t.Fatal("EmitError closed the output; closing belongs to the caller's deferred Close")
 	}
 }

--- a/sdk/vs-evaluator/vseval/doc.go
+++ b/sdk/vs-evaluator/vseval/doc.go
@@ -1,0 +1,83 @@
+// Package vseval writes VibeSys evaluator result streams.
+//
+// An evaluator declares the metrics it produces, measures them, and reports a
+// single row of values. The report is a record stream: one JSON object per
+// line, written to the file named by the -vs-output flag. The wire format is
+// specified by sdk/vs-evaluator/PROTOCOL.md.
+//
+// Reporting has two phases, because the two are not always known at the same
+// time. Opening the stream needs only the output path, which comes from the
+// argv; declaring the schema needs the metric names, which an evaluator may
+// have to read from a workload config first. Opening early is what lets a
+// failure in between still reach the framework as a reason:
+//
+//	open -> declare -> set -> emit
+//	  |        |        |
+//	  +--------+--------+---> fail
+//
+// Most evaluators are multi-command programs whose subcommands parse their own
+// argv, so the typical entry point is [OpenFlagSet]:
+//
+//	func benchmark(args []string) error {
+//		fs := flag.NewFlagSet("benchmark", flag.ContinueOnError)
+//		workload := fs.String("workload", "", "path of the workload config")
+//
+//		// Registers -vs-output on fs, parses args, opens the output.
+//		report, err := vseval.OpenFlagSet(fs, args)
+//		if err != nil {
+//			return err
+//		}
+//		defer report.Close()
+//
+//		config, err := loadWorkload(*workload)
+//		if err != nil {
+//			// No schema exists yet. An error record on its own is a valid
+//			// stream, so the framework still learns why the run failed.
+//			return errors.Join(err, report.EmitError(err))
+//		}
+//
+//		direction, err := vseval.ParseDir(config.Direction) // "maximize"
+//		if err != nil {
+//			return errors.Join(err, report.EmitError(err))
+//		}
+//		schema := vseval.NewSchema()
+//		primary := schema.Number(config.Metric, vseval.Unit(config.Unit), vseval.Direction(direction))
+//		// Reported only when a request actually completed.
+//		p99 := schema.Number("p99_latency_ms", vseval.Unit("ms"), vseval.Direction(vseval.Min), vseval.Optional())
+//
+//		// Writes and flushes the hello record.
+//		run, err := report.Declare(schema)
+//		if err != nil {
+//			return errors.Join(err, report.EmitError(err))
+//		}
+//
+//		result, err := measure(config)
+//		if err != nil {
+//			// Report the failure on the stream and still return it, so the
+//			// process exits non-zero.
+//			return errors.Join(err, run.EmitError(err))
+//		}
+//		run.Set(primary, result.Throughput)
+//		if result.Completed > 0 {
+//			run.Set(p99, result.P99Millis)
+//		}
+//		return run.Emit()
+//	}
+//
+// The caller owns nothing it must remember except the deferred [Report.Close]:
+// [Run.Emit] and [Run.EmitError] write a record and flush it, and leave
+// closing to the deferred call.
+//
+// Reporting is optional. When -vs-output is absent the returned report
+// discards every record, so the same code path works for a standalone
+// invocation; [Report.Reporting] tells an evaluator whether a report was
+// actually requested.
+//
+// [Run.Set] takes a [Metric] handle rather than a name, so a metric that was
+// never declared is a compile error rather than a run-time surprise, and a
+// result can only be emitted through the [Run] that declaring returns.
+//
+// An evaluator with a single command and no flag set of its own can use
+// [Open], which does the same against flag.CommandLine. One that parses its
+// own flags can use [OpenPath] with the path it parsed.
+package vseval

--- a/sdk/vs-evaluator/vseval/fail_internal_test.go
+++ b/sdk/vs-evaluator/vseval/fail_internal_test.go
@@ -11,14 +11,16 @@ import (
 // stubbed because Fail ends the process in production use.
 func TestFailWritesErrorRecordAndExits(t *testing.T) {
 	var buf bytes.Buffer
+	report := OpenWriter(&buf)
+	codes := []int{}
+	report.exit = func(code int) { codes = append(codes, code) }
+
 	schema := NewSchema()
 	ops := schema.Number("total_ops_per_sec")
-	run, err := schema.StartWriter(&buf)
+	run, err := report.Declare(schema)
 	if err != nil {
-		t.Fatalf("StartWriter: %v", err)
+		t.Fatalf("Declare: %v", err)
 	}
-	codes := []int{}
-	run.exit = func(code int) { codes = append(codes, code) }
 	run.Set(ops, 1)
 
 	run.Fail(errors.New("vLLM server did not become ready within 300s"))
@@ -35,5 +37,27 @@ func TestFailWritesErrorRecordAndExits(t *testing.T) {
 	}
 	if strings.Contains(buf.String(), `"kind":"result"`) {
 		t.Error("a result record was written alongside the error record")
+	}
+}
+
+// TestFailBeforeDeclareWritesErrorAlone is the phase-one terminal path: a
+// failure with no schema yet still exits non-zero with a reason on the stream.
+func TestFailBeforeDeclareWritesErrorAlone(t *testing.T) {
+	var buf bytes.Buffer
+	report := OpenWriter(&buf)
+	codes := []int{}
+	report.exit = func(code int) { codes = append(codes, code) }
+
+	report.Fail(errors.New("workload config failed to parse"))
+
+	if len(codes) != 1 || codes[0] == 0 {
+		t.Errorf("exit codes = %v, want one non-zero code", codes)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 1 || !strings.Contains(lines[0], `"kind":"error"`) {
+		t.Fatalf("stream = %q, want the error record alone", buf.String())
+	}
+	if !report.OutcomeWritten() {
+		t.Error("OutcomeWritten is false after Fail")
 	}
 }

--- a/sdk/vs-evaluator/vseval/fixture_test.go
+++ b/sdk/vs-evaluator/vseval/fixture_test.go
@@ -17,6 +17,20 @@ const fixtureDir = "../fixtures/valid"
 // buildFixture writes the stream of one fixture through the public API.
 type buildFixture func(t *testing.T, w *bytes.Buffer)
 
+// unproducible names the fixtures this SDK is not expected to be able to
+// produce, with the reason. It is not a way to excuse a stream the SDK ought to
+// write: every other file in fixtures/valid must have a counterpart below.
+var unproducible = map[string]string{
+	// Transitional fixture kept until the Go evaluators are rebuilt against
+	// this SDK. It carries protocol 1; this SDK emits protocol 2 and has no
+	// way to ask for an older version, by design.
+	"legacy-protocol-1.jsonl": "protocol 1 stream, superseded by single-metric.jsonl",
+	// Pins a reader rule rather than a producer one: a first-position error is
+	// accepted and later records are not checked. This SDK refuses to write a
+	// second outcome record at all, so it cannot emit this stream by design.
+	"error-first-ignores-later-records.jsonl": "reader-only rule; the SDK writes at most one outcome record",
+}
+
 // fixtures maps every stream in fixtures/valid to the SDK calls that produce
 // it. PROTOCOL.md compares records semantically, so the assertions below parse
 // both sides rather than comparing bytes.
@@ -24,15 +38,25 @@ var fixtures = map[string]buildFixture{
 	"bare-metric-spec.jsonl": func(t *testing.T, w *bytes.Buffer) {
 		schema := vseval.NewSchema()
 		value := schema.Number("primary_value")
-		run := start(t, schema, w)
+		run := declare(t, schema, w)
 		run.Set(value, 0.0)
 		mustEmit(t, run)
 	},
 	"error.jsonl": func(t *testing.T, w *bytes.Buffer) {
 		schema := vseval.NewSchema()
 		schema.Number("total_ops_per_sec", vseval.Unit("ops/s"))
-		run := start(t, schema, w)
+		run := declare(t, schema, w)
 		if err := run.EmitError(errors.New("queue runner exited before the workload completed")); err != nil {
+			t.Fatalf("EmitError: %v", err)
+		}
+	},
+	"error-without-hello.jsonl": func(t *testing.T, w *bytes.Buffer) {
+		// The failure the two-phase shape exists for: the output is open, but
+		// the config that names the metrics never loaded, so there is no
+		// schema to declare.
+		report := vseval.OpenWriter(w)
+		cause := errors.New("workload config failed to parse, so no metric identity exists yet")
+		if err := report.EmitError(cause); err != nil {
 			t.Fatalf("EmitError: %v", err)
 		}
 	},
@@ -40,15 +64,32 @@ var fixtures = map[string]buildFixture{
 		schema := vseval.NewSchema()
 		drift := schema.Number("drift_ratio")
 		enqueued := schema.Number("enqueued", vseval.Unit("ops"))
-		run := start(t, schema, w)
+		run := declare(t, schema, w)
 		run.Set(drift, -0.25)
 		run.Set(enqueued, 1048576)
+		mustEmit(t, run)
+	},
+	"optional-metric-absent.jsonl": func(t *testing.T, w *bytes.Buffer) {
+		schema := vseval.NewSchema()
+		ops := schema.Number("operations_per_second", vseval.Unit("operations/s"), vseval.Direction(vseval.Max))
+		schema.Number("p99_latency_ms", vseval.Unit("ms"), vseval.Direction(vseval.Min), vseval.Optional())
+		run := declare(t, schema, w)
+		run.Set(ops, 50.9)
+		mustEmit(t, run)
+	},
+	"optional-metric-present.jsonl": func(t *testing.T, w *bytes.Buffer) {
+		schema := vseval.NewSchema()
+		ops := schema.Number("operations_per_second", vseval.Unit("operations/s"), vseval.Direction(vseval.Max))
+		p99 := schema.Number("p99_latency_ms", vseval.Unit("ms"), vseval.Direction(vseval.Min), vseval.Optional())
+		run := declare(t, schema, w)
+		run.Set(ops, 50.9)
+		run.Set(p99, 812.0)
 		mustEmit(t, run)
 	},
 	"single-metric.jsonl": func(t *testing.T, w *bytes.Buffer) {
 		schema := vseval.NewSchema()
 		ops := schema.Number("total_ops_per_sec", vseval.Unit("ops/s"), vseval.Direction(vseval.Max))
-		run := start(t, schema, w)
+		run := declare(t, schema, w)
 		run.Set(ops, 41250.3)
 		mustEmit(t, run)
 	},
@@ -56,7 +97,7 @@ var fixtures = map[string]buildFixture{
 		schema := vseval.NewSchema()
 		throughput := schema.Number("aggregate_throughput", vseval.Unit("tok/s"), vseval.Direction(vseval.Max))
 		p99 := schema.Number("p99_latency_ms", vseval.Unit("ms"), vseval.Direction(vseval.Min))
-		run := start(t, schema, w)
+		run := declare(t, schema, w)
 		run.Set(throughput, 1180.4)
 		run.Set(p99, 812.0)
 		mustEmit(t, run)
@@ -73,8 +114,12 @@ func TestValidFixturesRoundTrip(t *testing.T) {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".jsonl" {
 			continue
 		}
-		seen++
 		name := entry.Name()
+		if reason, skip := unproducible[name]; skip {
+			t.Logf("skipping %s: %s", name, reason)
+			continue
+		}
+		seen++
 		build, ok := fixtures[name]
 		if !ok {
 			t.Errorf("fixture %s has no SDK counterpart in this test", name)
@@ -91,16 +136,17 @@ func TestValidFixturesRoundTrip(t *testing.T) {
 		})
 	}
 	if seen != len(fixtures) {
-		t.Errorf("found %d fixture files but the test declares %d", seen, len(fixtures))
+		t.Errorf("found %d producible fixture files but the test declares %d", seen, len(fixtures))
 	}
 }
 
-// start begins a run against buf, failing the test if the schema is invalid.
-func start(t *testing.T, schema *vseval.Schema, buf *bytes.Buffer) *vseval.Run {
+// declare opens a report on buf and declares schema, failing the test if the
+// schema is invalid.
+func declare(t *testing.T, schema *vseval.Schema, buf *bytes.Buffer) *vseval.Run {
 	t.Helper()
-	run, err := schema.StartWriter(buf)
+	run, err := vseval.OpenWriter(buf).Declare(schema)
 	if err != nil {
-		t.Fatalf("StartWriter: %v", err)
+		t.Fatalf("Declare: %v", err)
 	}
 	return run
 }

--- a/sdk/vs-evaluator/vseval/record.go
+++ b/sdk/vs-evaluator/vseval/record.go
@@ -1,6 +1,6 @@
 package vseval
 
-// Record kinds defined by protocol 1.
+// Record kinds defined by the protocol.
 const (
 	kindHello  = "hello"
 	kindResult = "result"
@@ -8,29 +8,36 @@ const (
 )
 
 // helloRecord declares the metrics this evaluator produces. It is the first
-// record of every stream.
+// record of every stream that carries one.
 type helloRecord struct {
 	Kind     string                `json:"kind"`
 	Protocol int                   `json:"protocol"`
 	Metrics  map[string]metricSpec `json:"metrics"`
 }
 
-// metricSpec is the advisory metadata of one declared metric. Both fields are
-// optional, so a metric declared without options serializes as {}.
+// metricSpec is the declared metadata of one metric. Every field is optional,
+// so a metric declared without options serializes as {}. Required is a pointer
+// because its protocol default is true: only an optional metric puts the key
+// on the wire.
 type metricSpec struct {
 	Unit      string `json:"unit,omitempty"`
 	Direction Dir    `json:"direction,omitempty"`
+	Required  *bool  `json:"required,omitempty"`
 }
 
-// resultRecord carries the measured row. Its key set must equal the hello
-// metric key set exactly.
+// required reports whether every successful run must carry this metric.
+func (s metricSpec) required() bool { return s.Required == nil || *s.Required }
+
+// resultRecord carries the measured row. Its key set must hold every required
+// hello metric and nothing the hello record did not declare.
 type resultRecord struct {
 	Kind   string             `json:"kind"`
 	Label  string             `json:"label"`
 	Values map[string]float64 `json:"values"`
 }
 
-// errorRecord terminates the stream. Any result in the same stream is ignored.
+// errorRecord terminates the stream. Any result in the same stream is ignored,
+// and the record is valid with or without a preceding hello.
 type errorRecord struct {
 	Kind    string `json:"kind"`
 	Message string `json:"message"`

--- a/sdk/vs-evaluator/vseval/report.go
+++ b/sdk/vs-evaluator/vseval/report.go
@@ -1,0 +1,263 @@
+package vseval
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// Protocol is the record stream protocol version this package writes.
+const Protocol = 2
+
+// OutputFlag is the name of the flag naming the output file. Callers spell it
+// -vs-output or --vs-output; both forms are accepted by the flag package.
+const OutputFlag = "vs-output"
+
+const outputFlagUsage = "path of the VibeSys evaluator result stream to write (required)"
+
+// FailureFallbackMessage is the error record message written when a caller
+// fails a report without a usable one. The protocol requires a non-empty
+// message, so a nil or blank cause must not be allowed to produce an invalid
+// stream.
+const FailureFallbackMessage = "evaluator failed without a message"
+
+// Report is an open evaluator result stream whose schema is not declared yet.
+// It is the first of the two reporting phases: the output is open, so a
+// failure can be reported from here on, and [Report.Declare] turns it into a
+// [Run] once the metrics are known.
+//
+// Opening the output before the schema exists is what lets an evaluator whose
+// metric identity comes from configuration report a failure that happens while
+// loading that configuration. An error record with no preceding hello is a
+// valid stream; a missing file is not.
+//
+// A Report is not safe for concurrent use.
+type Report struct {
+	w         io.Writer
+	closer    io.Closer
+	reporting bool
+	declared  bool
+	outcome   bool
+	exit      func(int)
+}
+
+// Open parses the process flags if they are not parsed yet and opens the file
+// named by -vs-output. It is the entry point for an evaluator with a single
+// command; one with subcommands should use [OpenFlagSet] instead, and one that
+// parses its own flags should use [OpenPath].
+//
+// Open registers -vs-output on flag.CommandLine. Callers that parse
+// flag.CommandLine themselves must call [RegisterFlags] before their own
+// flag.Parse.
+func Open() (*Report, error) {
+	return OpenFlagSet(flag.CommandLine, os.Args[1:])
+}
+
+// OpenFlagSet opens a report against a flag set the caller owns. It is the
+// entry point for an evaluator that dispatches subcommands, where each
+// subcommand parses its own argv into its own [flag.FlagSet].
+//
+// OpenFlagSet registers -vs-output on fs unless it is registered already,
+// parses args into fs unless fs is parsed already, and then opens the parsed
+// path, as [OpenPath] does. A flag set the caller already parsed is used as it
+// stands and args is ignored.
+func OpenFlagSet(fs *flag.FlagSet, args []string) (*Report, error) {
+	f := fs.Lookup(OutputFlag)
+	if f == nil {
+		if fs.Parsed() {
+			return nil, fmt.Errorf(
+				"flags were parsed without -%s registered: call vseval.RegisterFlags on the flag set before parsing it, or use vseval.OpenPath",
+				OutputFlag,
+			)
+		}
+		RegisterFlags(fs)
+		f = fs.Lookup(OutputFlag)
+	}
+	if !fs.Parsed() {
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+	}
+	return OpenPath(f.Value.String())
+}
+
+// RegisterFlags registers -vs-output on fs and returns the pointer that
+// receives the parsed path. Use it when the evaluator owns its own flag set or
+// parses flag.CommandLine itself.
+func RegisterFlags(fs *flag.FlagSet) *string {
+	return fs.String(OutputFlag, "", outputFlagUsage)
+}
+
+// OpenPath creates or truncates path and returns the report that writes to it.
+// Use it when the caller already parsed the output path.
+//
+// An empty path means no report was requested. Reporting is optional so that
+// an evaluator run by hand behaves like one run by the framework: OpenPath
+// returns a report that discards every record instead of an error, no file is
+// created, and [Report.Reporting] reports false. An evaluator that must not be
+// run unreported should check [Report.Reporting] and say so itself.
+func OpenPath(path string) (*Report, error) {
+	if path == "" {
+		return newReport(io.Discard, nil, false), nil
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("open evaluator output %q: %w", path, err)
+	}
+	return newReport(file, file, true), nil
+}
+
+// OpenWriter returns a report that writes to w. The caller owns w:
+// [Report.Close] does not close it. It is the seam tests and embedders use to
+// capture a stream without touching the filesystem.
+func OpenWriter(w io.Writer) *Report {
+	return newReport(w, nil, true)
+}
+
+func newReport(w io.Writer, closer io.Closer, reporting bool) *Report {
+	return &Report{w: w, closer: closer, reporting: reporting, exit: os.Exit}
+}
+
+// Declare writes the hello record for s and returns the run that measures it.
+// It is the second reporting phase; call it as soon as the metric names, units,
+// and directions are known.
+//
+// The hello record is written and flushed before Declare returns, not at
+// [Run.Emit]. If the evaluator crashes mid-run the stream still carries the
+// schema, so a reader reports a missing outcome ("it started and died") rather
+// than a missing hello ("this producer does not speak the protocol").
+//
+// Declare fails, writing nothing, if the schema is empty or carries a
+// declaration error, and it can be called only once per report. A failed
+// Declare leaves the stream without an outcome, so the caller can still report
+// the failure with [Report.EmitError] or [Report.Fail].
+func (r *Report) Declare(s *Schema) (*Run, error) {
+	if r.outcome {
+		return nil, errOutcomeWritten
+	}
+	if r.declared {
+		return nil, errors.New("a schema was already declared: a stream carries exactly one hello record")
+	}
+	if err := s.check(); err != nil {
+		return nil, err
+	}
+	metrics := make(map[string]metricSpec, len(s.names))
+	for i, name := range s.names {
+		metrics[name] = s.specs[i]
+	}
+	if err := r.write(helloRecord{Kind: kindHello, Protocol: Protocol, Metrics: metrics}); err != nil {
+		return nil, err
+	}
+	r.declared = true
+	s.declared = true
+	return &Run{
+		report: r,
+		schema: s,
+		values: make([]float64, len(s.names)),
+		set:    make([]bool, len(s.names)),
+	}, nil
+}
+
+// Reporting reports whether this report writes a stream anyone will read. It is
+// false for one opened without an output path, which discards every record so
+// that measurement code needs no branch of its own.
+//
+// Branch on it only for behavior that the report itself constrains. Protocol 2
+// carries a single result row, for example, so an evaluator that can sweep
+// several operating points has to narrow the sweep to one when it reports, and
+// need not when it does not.
+func (r *Report) Reporting() bool { return r.reporting }
+
+// OutcomeWritten reports whether the stream already carries its outcome, that
+// is a result or an error record. A second outcome is rejected, so a deferred
+// failure reporter asks this instead of tracking it itself:
+//
+//	defer func() {
+//		if err != nil && !report.OutcomeWritten() {
+//			report.EmitError(err)
+//		}
+//	}()
+func (r *Report) OutcomeWritten() bool { return r.outcome }
+
+// EmitError writes an error record and flushes it; like [Run.Emit] it leaves
+// the close to the caller. Use it when the evaluator cannot produce a row. It
+// is valid before a schema is declared: an error record on its own is a
+// complete stream.
+//
+// A nil cause, or one with a blank message, is reported as
+// [FailureFallbackMessage] so the stream stays valid.
+func (r *Report) EmitError(cause error) error {
+	if r.outcome {
+		return errOutcomeWritten
+	}
+	message := ""
+	if cause != nil {
+		message = strings.TrimSpace(cause.Error())
+	}
+	if message == "" {
+		message = FailureFallbackMessage
+	}
+	if err := r.write(errorRecord{Kind: kindError, Message: message}); err != nil {
+		return err
+	}
+	r.outcome = true
+	return nil
+}
+
+// Fail writes an error record and terminates the process with a non-zero
+// status. It is the terminal form of [Report.EmitError] for evaluators whose
+// main function has nothing left to do; a failure to write the record is
+// reported on stderr, since no one is left to receive it.
+//
+// Fail calls os.Exit, so no deferred function runs, including a deferred
+// [Report.Close]. Use [Report.EmitError] instead wherever the caller has
+// deferred cleanup or an error to return, which is every path but the
+// outermost one.
+func (r *Report) Fail(cause error) {
+	if err := r.EmitError(cause); err != nil {
+		fmt.Fprintf(os.Stderr, "vseval: %v\n", err)
+	}
+	r.exit(1)
+}
+
+// Close releases the output file if this report opened one. Defer it right
+// after opening: it is the only thing that closes the output, and it is
+// idempotent, so a second call after an early one is harmless. A report opened
+// with [OpenWriter], or one that is not reporting, owns no file and Close is a
+// no-op.
+func (r *Report) Close() error {
+	if r.closer == nil {
+		return nil
+	}
+	closer := r.closer
+	r.closer = nil
+	return closer.Close()
+}
+
+var errOutcomeWritten = errors.New("the outcome record was already written")
+
+// flusher is implemented by buffered writers such as *bufio.Writer. Records
+// must reach the file as they are produced, not when the process exits.
+type flusher interface {
+	Flush() error
+}
+
+func (r *Report) write(record any) error {
+	line, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("encode %T: %w", record, err)
+	}
+	if _, err := r.w.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("write evaluator record: %w", err)
+	}
+	if f, ok := r.w.(flusher); ok {
+		if err := f.Flush(); err != nil {
+			return fmt.Errorf("flush evaluator record: %w", err)
+		}
+	}
+	return nil
+}

--- a/sdk/vs-evaluator/vseval/run.go
+++ b/sdk/vs-evaluator/vseval/run.go
@@ -1,46 +1,23 @@
 package vseval
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"math"
-	"os"
 	"strings"
 )
 
-// FailureFallbackMessage is the error record message written when a caller
-// fails a run without a usable one. The protocol requires a non-empty message,
-// so a nil or blank cause must not be allowed to produce an invalid stream.
-const FailureFallbackMessage = "evaluator failed without a message"
-
-// Run is a live evaluator report. Its hello record is already written; what
-// remains is to set every declared metric and call [Run.Emit], or to report a
-// failure with [Run.Fail].
+// Run is a declared evaluator report. Its hello record is already written;
+// what remains is to set the declared metrics and call [Run.Emit], or to
+// report a failure with [Run.EmitError] or [Run.Fail].
 //
 // A Run is not safe for concurrent use.
 type Run struct {
-	schema    *Schema
-	w         io.Writer
-	closer    io.Closer
-	reporting bool
-	values    []float64
-	set       []bool
-	err       error
-	done      bool
-	exit      func(int)
+	report *Report
+	schema *Schema
+	values []float64
+	set    []bool
+	err    error
 }
-
-// Reporting reports whether this run writes a stream anyone will read. It is
-// false for a run started without an output path, which discards every record
-// so that measurement code needs no branch of its own.
-//
-// Branch on it only for behavior that the report itself constrains. Protocol 1
-// carries a single result row, for example, so an evaluator that can sweep
-// several operating points has to narrow the sweep to one when it reports, and
-// need not when it does not.
-func (r *Run) Reporting() bool { return r.reporting }
 
 // Set records the measured value of a declared metric.
 //
@@ -54,7 +31,7 @@ func (r *Run) Set(m Metric, value float64) {
 		return
 	}
 	if m.index >= len(r.values) {
-		r.setErr(fmt.Errorf("metric %q was declared after the run started, so it is not in the hello record", m.name))
+		r.setErr(fmt.Errorf("metric %q was declared after the schema, so it is not in the hello record", m.name))
 		return
 	}
 	if math.IsNaN(value) {
@@ -70,17 +47,18 @@ func (r *Run) Set(m Metric, value float64) {
 }
 
 // Emit writes the result record and flushes it. It does not close the output:
-// the caller that started the run owns the close, normally as a deferred
-// [Run.Close].
+// the caller that opened the report owns the close, normally as a deferred
+// [Report.Close].
 //
-// It fails, writing nothing, if a declared metric was never set, or if any
-// [Run.Set] call was rejected. An unset metric is an error rather than a zero:
-// Go's zero value must not pass for a measurement. After a failed Emit no
-// outcome has been written, so the caller can still report the failure with
-// [Run.EmitError] or [Run.Fail].
+// It fails, writing nothing, if a required metric was never set, or if any
+// [Run.Set] call was rejected. An unset required metric is an error rather
+// than a zero: Go's zero value must not pass for a measurement. A metric
+// declared with [Optional] may be absent, and is then left out of the row.
+// After a failed Emit no outcome has been written, so the caller can still
+// report the failure with [Run.EmitError] or [Run.Fail].
 func (r *Run) Emit() error {
-	if r.done {
-		return errors.New("the outcome record was already written")
+	if r.report.outcome {
+		return errOutcomeWritten
 	}
 	if r.err != nil {
 		return r.err
@@ -91,101 +69,43 @@ func (r *Run) Emit() error {
 		return err
 	}
 	var missing []string
-	for i, ok := range r.set {
-		if !ok {
+	values := make(map[string]float64, len(r.values))
+	for i := range r.set {
+		switch {
+		case r.set[i]:
+			values[r.schema.names[i]] = r.values[i]
+		case r.schema.specs[i].required():
 			missing = append(missing, r.schema.names[i])
 		}
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("declared metrics were never set: %s", strings.Join(missing, ", "))
+		return fmt.Errorf("required metrics were never set: %s", strings.Join(missing, ", "))
 	}
-	values := make(map[string]float64, len(r.values))
-	for i, name := range r.schema.names {
-		values[name] = r.values[i]
-	}
-	rec := resultRecord{Kind: kindResult, Label: "", Values: values}
-	if err := r.write(rec); err != nil {
+	if err := r.report.write(resultRecord{Kind: kindResult, Label: "", Values: values}); err != nil {
 		return err
 	}
-	r.done = true
+	r.report.outcome = true
 	return nil
 }
 
-// EmitError writes an error record and flushes it; like [Run.Emit] it leaves
-// the close to the caller. Use it when the evaluator cannot produce a row. A
-// nil cause, or one with a blank message, is reported as
-// [FailureFallbackMessage] so the stream stays valid.
-func (r *Run) EmitError(cause error) error {
-	if r.done {
-		return errors.New("the outcome record was already written")
-	}
-	message := ""
-	if cause != nil {
-		message = strings.TrimSpace(cause.Error())
-	}
-	if message == "" {
-		message = FailureFallbackMessage
-	}
-	if err := r.write(errorRecord{Kind: kindError, Message: message}); err != nil {
-		return err
-	}
-	r.done = true
-	return nil
-}
+// EmitError writes an error record on this run's report. See
+// [Report.EmitError].
+func (r *Run) EmitError(cause error) error { return r.report.EmitError(cause) }
 
-// Fail writes an error record and terminates the process with a non-zero
-// status. It is the terminal form of [Run.EmitError] for evaluators whose
-// main function has nothing left to do; a failure to write the record is
-// reported on stderr, since no one is left to receive it.
-//
-// Fail calls os.Exit, so no deferred function runs, including a deferred
-// [Run.Close]. Use [Run.EmitError] instead wherever the caller has deferred
-// cleanup or an error to return, which is every path but the outermost one.
-func (r *Run) Fail(cause error) {
-	if err := r.EmitError(cause); err != nil {
-		fmt.Fprintf(os.Stderr, "vseval: %v\n", err)
-	}
-	r.exit(1)
-}
+// Fail writes an error record on this run's report and terminates the process.
+// See [Report.Fail].
+func (r *Run) Fail(cause error) { r.report.Fail(cause) }
 
-// Close releases the output file if this Run opened one. Defer it right after
-// the run starts: it is the only thing that closes the output, and it is
-// idempotent, so a second call after an early one is harmless. A Run started
-// with [Schema.StartWriter], or one that is not reporting, owns no file and
-// Close is a no-op.
-func (r *Run) Close() error {
-	if r.closer == nil {
-		return nil
-	}
-	closer := r.closer
-	r.closer = nil
-	return closer.Close()
-}
+// Reporting reports whether this run writes a stream anyone will read. See
+// [Report.Reporting].
+func (r *Run) Reporting() bool { return r.report.Reporting() }
+
+// OutcomeWritten reports whether the stream already carries its outcome. See
+// [Report.OutcomeWritten].
+func (r *Run) OutcomeWritten() bool { return r.report.OutcomeWritten() }
 
 func (r *Run) setErr(err error) {
 	if r.err == nil {
 		r.err = err
 	}
-}
-
-// flusher is implemented by buffered writers such as *bufio.Writer. Records
-// must reach the file as they are produced, not when the process exits.
-type flusher interface {
-	Flush() error
-}
-
-func (r *Run) write(record any) error {
-	line, err := json.Marshal(record)
-	if err != nil {
-		return fmt.Errorf("encode %T: %w", record, err)
-	}
-	if _, err := r.w.Write(append(line, '\n')); err != nil {
-		return fmt.Errorf("write evaluator record: %w", err)
-	}
-	if f, ok := r.w.(flusher); ok {
-		if err := f.Flush(); err != nil {
-			return fmt.Errorf("flush evaluator record: %w", err)
-		}
-	}
-	return nil
 }

--- a/sdk/vs-evaluator/vseval/schema.go
+++ b/sdk/vs-evaluator/vseval/schema.go
@@ -1,72 +1,11 @@
-// Package vseval writes VibeSys evaluator result streams.
-//
-// An evaluator declares the metrics it produces, measures them, and reports a
-// single row of values. The report is a record stream: one JSON object per
-// line, written to the file named by the -vs-output flag. The wire format is
-// specified by sdk/vs-evaluator/PROTOCOL.md.
-//
-// Most evaluators are multi-command programs whose subcommands parse their own
-// argv, so the typical entry point is [Schema.StartFlagSet]:
-//
-//	func benchmark(args []string) error {
-//		fs := flag.NewFlagSet("benchmark", flag.ContinueOnError)
-//		duration := fs.Duration("duration", 10*time.Second, "measured duration")
-//
-//		schema := vseval.NewSchema()
-//		ops := schema.Number("total_ops_per_sec", vseval.Unit("ops/s"), vseval.Direction(vseval.Max))
-//		p99 := schema.Number("p99_latency_ms", vseval.Unit("ms"), vseval.Direction(vseval.Min))
-//
-//		// Registers -vs-output on fs, parses args, writes the hello record.
-//		run, err := schema.StartFlagSet(fs, args)
-//		if err != nil {
-//			return err
-//		}
-//		defer run.Close()
-//
-//		result, err := measure(*duration)
-//		if err != nil {
-//			// Report the failure on the stream and still return it, so the
-//			// process exits non-zero.
-//			return errors.Join(err, run.EmitError(err))
-//		}
-//		run.Set(ops, result.OpsPerSec)
-//		run.Set(p99, result.P99Millis)
-//		return run.Emit()
-//	}
-//
-// The run owns nothing the caller must remember except the deferred
-// [Run.Close]: [Run.Emit] and [Run.EmitError] write a record and flush it, and
-// leave closing to the deferred call.
-//
-// Reporting is optional. When -vs-output is absent the returned run discards
-// every record, so the same code path works for a standalone invocation;
-// [Run.Reporting] tells an evaluator whether a report was actually requested.
-//
-// Set takes a [Metric] handle rather than a name, so a metric that was never
-// declared is a compile error rather than a run-time surprise.
-//
-// An evaluator with a single command and no flag set of its own can use
-// [Schema.Start], which does the same against flag.CommandLine.
 package vseval
 
 import (
 	"errors"
-	"flag"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 	"unicode"
 )
-
-// Protocol is the record stream protocol version this package writes.
-const Protocol = 1
-
-// OutputFlag is the name of the flag naming the output file. Callers spell it
-// -vs-output or --vs-output; both forms are accepted by the flag package.
-const OutputFlag = "vs-output"
-
-const outputFlagUsage = "path of the VibeSys evaluator result stream to write (required)"
 
 // Dir is the intrinsic better-direction of a metric. It is advisory metadata:
 // it does not select which metrics a task optimizes for.
@@ -80,8 +19,25 @@ const (
 	Min Dir = "min"
 )
 
+// ParseDir converts a configured direction word to a [Dir]. Both the wire
+// forms ("max", "min") and the long forms config files usually spell
+// ("maximize", "minimize") are accepted, ignoring surrounding space and case,
+// so an evaluator that reads its direction from a workload config does not
+// have to carry a mapping of its own.
+func ParseDir(s string) (Dir, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "max", "maximize":
+		return Max, nil
+	case "min", "minimize":
+		return Min, nil
+	default:
+		return "", fmt.Errorf("unknown metric direction %q: want max, maximize, min, or minimize", s)
+	}
+}
+
 // MetricOption is optional metadata attached to a declared metric. Construct
-// one with [Unit] or [Direction]; the zero MetricOption does nothing.
+// one with [Unit], [Direction], or [Optional]; the zero MetricOption does
+// nothing.
 type MetricOption struct {
 	apply func(*metricSpec)
 }
@@ -92,9 +48,24 @@ func Unit(unit string) MetricOption {
 	return MetricOption{apply: func(s *metricSpec) { s.Unit = unit }}
 }
 
-// Direction sets the intrinsic better-direction of a metric.
+// Direction sets the intrinsic better-direction of a metric. Use [ParseDir]
+// for a direction that comes from configuration.
 func Direction(d Dir) MetricOption {
 	return MetricOption{apply: func(s *metricSpec) { s.Direction = d }}
+}
+
+// Optional marks a metric the evaluator can only sometimes produce, such as a
+// latency percentile that has no samples when nothing completed. [Run.Emit]
+// accepts a stream in which an optional metric was never set, and rejects one
+// missing any other declared metric.
+//
+// The metric is still declared, so a reader never sees a value under a name it
+// was not told about. A task cannot rank on an optional metric: the framework
+// requires every objective to be declared required, since a missing value
+// would silently drop the round.
+func Optional() MetricOption {
+	optional := false
+	return MetricOption{apply: func(s *metricSpec) { s.Required = &optional }}
 }
 
 // Metric is an opaque handle to a metric declared on a [Schema]. Obtain one
@@ -109,15 +80,16 @@ type Metric struct {
 func (m Metric) Name() string { return m.name }
 
 // Schema is the set of metrics an evaluator produces. Declare every metric
-// before starting the run; the declaration becomes the hello record.
+// before declaring the schema on a report; the declaration becomes the hello
+// record.
 //
 // A Schema is not safe for concurrent use.
 type Schema struct {
-	names   []string
-	specs   []metricSpec
-	index   map[string]int
-	err     error
-	started bool
+	names    []string
+	specs    []metricSpec
+	index    map[string]int
+	err      error
+	declared bool
 }
 
 // NewSchema returns an empty Schema.
@@ -128,8 +100,8 @@ func NewSchema() *Schema {
 // Number declares a numeric metric and returns its handle.
 //
 // Declaration errors (an empty name, a name containing whitespace, a duplicate
-// name, or a declaration made after the run started) are recorded on the
-// Schema and reported by whichever Start method begins the run, or by
+// name, an unknown direction, or a declaration made after the hello record was
+// written) are recorded on the Schema and reported by [Report.Declare], or by
 // [Run.Emit], so that declarations stay assignable to a single variable. The
 // returned handle is still usable; it just never reaches a stream.
 func (s *Schema) Number(name string, opts ...MetricOption) Metric {
@@ -139,13 +111,16 @@ func (s *Schema) Number(name string, opts ...MetricOption) Metric {
 			opt.apply(&spec)
 		}
 	}
-	if s.started {
-		s.setErr(fmt.Errorf("metric %q was declared after the run started: the hello record is already written", name))
+	if s.declared {
+		s.setErr(fmt.Errorf("metric %q was declared after the schema: the hello record is already written", name))
 	}
 	if err := validateName(name); err != nil {
 		s.setErr(err)
 	} else if _, dup := s.index[name]; dup {
 		s.setErr(fmt.Errorf("metric %q declared twice", name))
+	}
+	if err := validateDirection(name, spec.Direction); err != nil {
+		s.setErr(err)
 	}
 	index := len(s.names)
 	s.names = append(s.names, name)
@@ -165,109 +140,7 @@ func (s *Schema) setErr(err error) {
 	}
 }
 
-func validateName(name string) error {
-	if name == "" {
-		return errors.New("metric name must not be empty")
-	}
-	if strings.ContainsFunc(name, unicode.IsSpace) {
-		return fmt.Errorf("metric name %q must not contain whitespace", name)
-	}
-	return nil
-}
-
-// Start parses the process flags if they are not parsed yet, opens the file
-// named by -vs-output, and writes the hello record. It is the entry point for
-// an evaluator with a single command; one with subcommands should use
-// [Schema.StartFlagSet] instead, and one that parses its own flags should use
-// [Schema.StartWith].
-//
-// Start registers -vs-output on flag.CommandLine. Callers that parse
-// flag.CommandLine themselves must call [RegisterFlags] before their own
-// flag.Parse.
-func (s *Schema) Start() (*Run, error) {
-	return s.StartFlagSet(flag.CommandLine, os.Args[1:])
-}
-
-// StartFlagSet starts a run against a flag set the caller owns. It is the
-// entry point for an evaluator that dispatches subcommands, where each
-// subcommand parses its own argv into its own [flag.FlagSet].
-//
-// StartFlagSet registers -vs-output on fs unless it is registered already,
-// parses args into fs unless fs is parsed already, and then starts the run
-// against the parsed path, as [Schema.StartWith] does. A flag set the caller
-// already parsed is used as it stands and args is ignored.
-//
-// The hello record is written and flushed before StartFlagSet returns, not at
-// [Run.Emit]. If the evaluator crashes mid-run the stream still carries the
-// schema, so a reader reports a missing outcome rather than a missing hello.
-func (s *Schema) StartFlagSet(fs *flag.FlagSet, args []string) (*Run, error) {
-	f := fs.Lookup(OutputFlag)
-	if f == nil {
-		if fs.Parsed() {
-			return nil, fmt.Errorf(
-				"flags were parsed without -%s registered: call vseval.RegisterFlags on the flag set before parsing it, or use Schema.StartWith",
-				OutputFlag,
-			)
-		}
-		RegisterFlags(fs)
-		f = fs.Lookup(OutputFlag)
-	}
-	if !fs.Parsed() {
-		if err := fs.Parse(args); err != nil {
-			return nil, err
-		}
-	}
-	return s.StartWith(f.Value.String())
-}
-
-// RegisterFlags registers -vs-output on fs and returns the pointer that
-// receives the parsed path. Use it when the evaluator owns its own flag set or
-// parses flag.CommandLine itself.
-func RegisterFlags(fs *flag.FlagSet) *string {
-	return fs.String(OutputFlag, "", outputFlagUsage)
-}
-
-// StartWith opens path (creating or truncating it), writes the hello record,
-// and returns the run. Use it when the caller already parsed the output path.
-//
-// An empty path means no report was requested. Reporting is optional so that
-// an evaluator run by hand behaves like one run by the framework: StartWith
-// returns a run that discards every record instead of an error, no file is
-// created, and [Run.Reporting] reports false. An evaluator that must not be
-// run unreported should check [Run.Reporting] and say so itself.
-//
-// The hello record is written and flushed before StartWith returns, not at
-// [Run.Emit]. If the evaluator crashes mid-run the stream still carries the
-// schema, so a reader reports a missing outcome rather than a missing hello.
-func (s *Schema) StartWith(path string) (*Run, error) {
-	if err := s.check(); err != nil {
-		return nil, err
-	}
-	if path == "" {
-		return s.start(io.Discard, nil, false)
-	}
-	file, err := os.Create(path)
-	if err != nil {
-		return nil, fmt.Errorf("open evaluator output %q: %w", path, err)
-	}
-	run, err := s.start(file, file, true)
-	if err != nil {
-		file.Close()
-		return nil, err
-	}
-	return run, nil
-}
-
-// StartWriter writes the hello record to w and returns the run. The caller
-// owns w: [Run.Close] does not close it. It is the seam tests and embedders
-// use to capture a stream without touching the filesystem.
-func (s *Schema) StartWriter(w io.Writer) (*Run, error) {
-	if err := s.check(); err != nil {
-		return nil, err
-	}
-	return s.start(w, nil, true)
-}
-
+// check reports whether the schema can become a hello record.
 func (s *Schema) check() error {
 	if s.err != nil {
 		return s.err
@@ -278,24 +151,21 @@ func (s *Schema) check() error {
 	return nil
 }
 
-func (s *Schema) start(w io.Writer, closer io.Closer, reporting bool) (*Run, error) {
-	metrics := make(map[string]metricSpec, len(s.names))
-	for i, name := range s.names {
-		metrics[name] = s.specs[i]
+func validateName(name string) error {
+	if name == "" {
+		return errors.New("metric name must not be empty")
 	}
-	run := &Run{
-		schema:    s,
-		w:         w,
-		closer:    closer,
-		reporting: reporting,
-		values:    make([]float64, len(s.names)),
-		set:       make([]bool, len(s.names)),
-		exit:      os.Exit,
+	if strings.ContainsFunc(name, unicode.IsSpace) {
+		return fmt.Errorf("metric name %q must not contain whitespace", name)
 	}
-	rec := helloRecord{Kind: kindHello, Protocol: Protocol, Metrics: metrics}
-	if err := run.write(rec); err != nil {
-		return nil, err
+	return nil
+}
+
+func validateDirection(name string, d Dir) error {
+	switch d {
+	case "", Max, Min:
+		return nil
+	default:
+		return fmt.Errorf("metric %q declared direction %q: want %q or %q", name, d, Max, Min)
 	}
-	s.started = true
-	return run, nil
 }


### PR DESCRIPTION
## Problem

Part of #377. Porting the two Go evaluators (#383, #387) pushed on the same
rule from two directions.

Version 1 said: list every metric before measuring, then report exactly that
list. That rule is why the protocol is worth having. Listing first means a
wrong metric name fails before an hour of GPU time is spent. Exact matching
means a benchmark cannot quietly skip a number it promised. It stays.

But it pinched in two places, both found by the microservice evaluator:

- Its metric name, unit, and direction come from a workload config file, so it
  has nothing to declare until that file loads. A failure before then reached
  the framework as a missing file rather than a reason.
- It also measures latency distributions that are empty when no sample matched.
  Since it could not promise them up front, it could not declare them at all,
  so they stayed in a diagnostics file the framework never reads.

Two smaller things every evaluator was reimplementing: tracking whether it had
already reported, and converting `maximize`/`minimize` (how task configs spell
directions) into the SDK's `Max`/`Min`.

## Solution

**A failure may be reported with no preceding `hello`.** It is the only record
that may. An evaluator can open its output at startup and always have somewhere
to put a reason.

**A metric may be declared optional.** The row rule becomes: every reported
name must be declared, and every metric declared required must be present. An
optional metric is still declared, so nothing can be reported under a name the
reader has not seen.

**Objectives must be declared required.** This closes the obvious hole in the
previous point, and it closes it where the objectives are actually known. A
task cannot rank on a metric that a successful run may omit, because the round
would silently drop off the frontier, which is the exact failure #377 is about.
The evaluator never learns the objectives, so only the framework can enforce
this.

The Go SDK becomes two-phase: `Open` the output, then `Declare` once the schema
is known. `Emit` exists only on the value `Declare` returns, so a result cannot
be written without a declaration, while a failure can be reported from process
start. The old one-shot `Start*` constructors are gone rather than kept as a
shorthand, so there is one path and no evaluator can re-acquire the reporting
gap.

## Verification

### Correctness properties

- A reported name that was never declared is still rejected. Optional changes
  when a metric may be absent, never whether it may be unknown.
- A missing required metric is still rejected.
- A result cannot be emitted without a declared schema; the type system
  enforces it rather than a runtime check.
- An objective that is declared but optional is rejected, with a message that
  says so, because the fix differs from "not declared at all".
- A first-position error is accepted whether or not a `hello` follows; a
  `hello` after any other record is still an error; a stream ending with
  neither is still an error.

### Testing

The fixture corpus is the specification, and both implementations run against
all of it: 10 valid and 20 invalid streams.

```
uv run pytest -q --no-cov libs/vs-evaluator-protocol/tests tests/loops/agent/test_orchestrate.py   181 passed
cd sdk/vs-evaluator/vseval && gofmt -l . && go vet ./... && go test -race ./...                    passed
./scripts/check_format.sh / check_lint.sh / check_doc_links.py                                     passed
```

Worth noting one failure the corpus caught during development. A fixture was
added that pins a reader-only rule, and the SDK's round-trip test failed
because that stream cannot be produced by design. The test refuses to skip a
fixture silently, so it has to be declared unproducible with a reason. That is
the corpus working as intended: neither side can drift from it quietly.

## Transitional, and deliberately so

The reader still accepts protocol 1. The two Go evaluators emit it until they
are rebuilt against v0.2.0 in the follow-up, and without this, merging would
leave main in a state where the test suite passes and real runs fail. It is
marked `TRANSITIONAL` in the reader, and the corpus carries exactly one
version 1 stream, so the follow-up deletes both without archaeology.

## Next

Tag `sdk/vs-evaluator/vseval/v0.2.0`, then a follow-up rebuilds the two Go
evaluators against it, uses the new options, and removes protocol 1 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
