### PR TITLE
Add experiment-chat as a permanent pane with the hypothesis log for the TUI

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -24,7 +24,7 @@ available slash commands are:
 | Command | Behavior |
 | --- | --- |
 | `/help` | Show commands and planned controls. |
-| `/chat` | Open a read-only chat about the run; `/chat <question>` asks immediately. |
+| `/chat` | Put the pane keys on the docked chat, or open it as a modal where it cannot dock; `/chat <question>` asks immediately. |
 | | Slash commands work inside the chat too, and do the same thing as in the main input. |
 | `/pause` | Pause after the current agent call finishes. |
 | `/resume` | Resume a paused run. |
@@ -80,18 +80,57 @@ reshuffle. Records written before hypothesis tracking render as
 `(Unidentified)` rather than being dropped. Columns drop widest first as the
 terminal narrows; hypothesis, rounds, and outcome always survive.
 
+The chat is docked beside the table as a permanent column of this view, so a
+question about the run never covers what the run has done. It has its own input
+at the foot of its column, under the instruction `Ask about this run`,
+and the client's command input sits beside it, starting at the boundary between
+the two columns so each box is under the surface it writes to. The command
+list rises out of the command input rather than across the chat.
+
+The cursor starts in the command input, and `Ctrl+W` moves both it and the pane
+keys to the chat and back; the chat's instruction line says so (`Ctrl+W to type
+here`) until it holds them, and the focused input carries the focus border, so
+where a keystroke lands is never a guess. A question typed into either box
+reaches the same agent and is answered in the same column. Page Up and Page Down scroll the focused pane, and
+Escape hands the keys back to the table. Arrows, Enter, and the rest of the
+table's keys are unaffected by the dock. A slash command typed into the chat
+input runs through the same path as anywhere else, and ordinary text typed into
+the command input is still a question for the agent: the two boxes are a
+division of attention, not of capability.
+
+`/chat` leaves the command surface on this view, since the chat is already
+beside the table: it is absent from `/help` and from the completions, though it
+is still accepted and still focuses the pane. Inside a hypothesis, where the
+chat is a dialog again, the command comes back and opens it over the
+trajectory. It is one conversation throughout, so a question asked from the
+pop-up is in the column when the operator steps back out.
+
+The chat asks for the columns left over once the table has enough for its
+claim, so a wide terminal loses no table column to it; where there is no such
+surplus it still takes its readable minimum and the table drops columns as it
+does on any narrow terminal. Below about 92 columns two columns would both be
+unreadable, so the table keeps the row alone and the chat opens over it as a
+modal. Opening a visualization narrows the chat before it narrows the table,
+and where all three will not fit the chat is the one that steps aside.
+
+Whichever way the chat is on screen, it never replaces the view it was asked
+from: the modal floats over the table rather than swapping in the per-round
+transcript behind it.
+
 ### Split panes
 
 Visualization commands render beside the current view rather than over it.
 `/perf` puts its output in a right pane and leaves the transcript, the chat,
-or the experiment log in the left one, both live at the same time. A second
-visualization command replaces the pane's contents rather than stacking
-another surface on top.
+or the experiment log in the left one, both live at the same time. On the
+experiment log that makes three columns, chat, table, and visualization, each
+live. A second visualization command replaces the pane's contents rather than
+stacking another surface on top.
 
-`Ctrl+W` moves focus between the panes; the focused one carries the theme's
-focus border and says so in its title. Page Up and Page Down scroll whichever
-pane has focus, and Escape on the right pane closes it and restores the
-full-width view. Chat and transcript state survive the pane closing.
+`Ctrl+W` moves focus one column to the right and wraps, through whichever
+columns are actually on screen; the focused one carries the theme's focus
+border and says so in its title. Page Up and Page Down scroll whichever pane
+has focus, and Escape on the right pane closes it and restores the full-width
+view. Chat and transcript state survive the pane closing.
 
 Pane widths are computed from the terminal, so a wide terminal gives the
 visualization real room while the left pane keeps a readable floor. Below 100
@@ -115,6 +154,12 @@ Text typed in the chat that starts with `/` is parsed as a slash command
 through the same path as the main input, so `/perf` there does exactly what
 `/perf` does anywhere else. Anything else is a question for the agent, and a
 question containing a slash mid-sentence is still a question.
+
+Where the chat is docked it answers in its column, under its own input; where
+it is not, inside a hypothesis or in a terminal too narrow to dock, it opens
+over the view as before, carrying the same input at the foot of the modal. It
+is one conversation either way: the transcript survives docking, undocking, and
+the pane closing.
 
 Inside a hypothesis the footer shows keyboard navigation. `[` and `]` select rounds, Tab and
 Shift+Tab select agents, Page Up/Page Down scroll the transcript, Ctrl+T expands

--- a/clients/tui/src/commands.test.ts
+++ b/clients/tui/src/commands.test.ts
@@ -1,5 +1,11 @@
 import {describe, expect, it} from 'bun:test';
-import {parseInput, slashCommandRange, suggestSlashCommands} from './commands.js';
+import {
+  availableCommands,
+  helpText,
+  parseInput,
+  slashCommandRange,
+  suggestSlashCommands,
+} from './commands.js';
 
 describe('parseInput', () => {
   it('accepts the intentionally small slash-command surface', () => {
@@ -82,6 +88,28 @@ describe('parseInput', () => {
     expect(parsed.error).toContain('Unknown theme: monokai');
     expect(parsed.error).toContain('catppuccin-mocha');
     expect(parsed.localView).toBeUndefined();
+  });
+});
+
+describe('command surface by view', () => {
+  it('drops /chat where the chat is already a pane of the view', () => {
+    const docked = availableCommands({chatDocked: true}).map(command => command.name);
+
+    expect(docked).not.toContain('/chat');
+    expect(docked).toContain('/perf');
+    expect(helpText({chatDocked: true})).not.toContain('/chat');
+    expect(suggestSlashCommands('/c', {chatDocked: true})).toEqual([]);
+  });
+
+  it('offers /chat everywhere the chat is not already on screen', () => {
+    expect(availableCommands().map(command => command.name)).toContain('/chat');
+    expect(helpText()).toContain('/chat');
+    expect(suggestSlashCommands('/c').map(command => command.name)).toEqual(['/chat']);
+  });
+
+  it('still accepts /chat when it is not offered, since the chat is the point', () => {
+    // Hidden from the list, not removed from the client.
+    expect(parseInput('/chat')).toEqual({localView: 'chat'});
   });
 });
 

--- a/clients/tui/src/commands.ts
+++ b/clients/tui/src/commands.ts
@@ -38,18 +38,40 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
   {name: '/theme', description: 'List themes, or switch with /theme <name>'},
 ];
 
-export const HELP_TEXT = [
-  'Available',
-  ...SLASH_COMMANDS.map(command => `  ${command.name.padEnd(18)} ${command.description}`),
-  '',
-  'Planned',
-  '  /round <number>    Inspect a completed round',
-  '  /invocation <id>   Inspect an agent invocation',
-].join('\n');
+/**
+ * Where the chat is a pane of the current view there is nothing for `/chat` to
+ * open, so it leaves the command surface rather than sitting in it as a command
+ * that does nothing new. It is still accepted, and still opens the chat
+ * anywhere the chat is not already on screen.
+ */
+export interface CommandContext {
+  chatDocked?: boolean;
+}
 
-export function suggestSlashCommands(text: string): readonly SlashCommand[] {
+export function availableCommands(context: CommandContext = {}): readonly SlashCommand[] {
+  if (!context.chatDocked) return SLASH_COMMANDS;
+  return SLASH_COMMANDS.filter(command => command.name !== '/chat');
+}
+
+export function helpText(context: CommandContext = {}): string {
+  return [
+    'Available',
+    ...availableCommands(context).map(
+      command => `  ${command.name.padEnd(18)} ${command.description}`,
+    ),
+    '',
+    'Planned',
+    '  /round <number>    Inspect a completed round',
+    '  /invocation <id>   Inspect an agent invocation',
+  ].join('\n');
+}
+
+export function suggestSlashCommands(
+  text: string,
+  context: CommandContext = {},
+): readonly SlashCommand[] {
   if (!text.startsWith('/') || /\s/.test(text)) return [];
-  return SLASH_COMMANDS.filter(command => command.name.startsWith(text));
+  return availableCommands(context).filter(command => command.name.startsWith(text));
 }
 
 export function slashCommandRange(text: string): {start: number; end: number} | null {

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from 'bun:test';
 import type {EventSubscription} from './client.js';
 import type {ProtocolResponse, RequestInput, RunEvent, ServerMessage} from './protocol.js';
 import {SocketSessionController, type SupervisionTransport} from './session-controller.js';
+import {chatPaneVisible, experimentLogVisible} from './session-model.js';
 
 describe('session controller', () => {
   it('shows local help without sending a backend command', async () => {
@@ -16,14 +17,17 @@ describe('session controller', () => {
     expect(transport.requests).toEqual([]);
   });
 
-  it('sends ordinary text to the multi-turn chat panel', async () => {
+  it('sends ordinary text to the chat docked beside the log', async () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
 
     await controller.submit('what is happening?');
 
     expect(transport.requests).toEqual([{type: 'query.chat', text: 'what is happening?'}]);
-    expect(controller.state.chatOpen).toBe(true);
+    // The pane is part of the landing view, so nothing opens over the table.
+    expect(controller.state.chatOpen).toBe(false);
+    expect(chatPaneVisible(controller.state)).toBe(true);
+    expect(experimentLogVisible(controller.state)).toBe(true);
     expect(controller.state.chatConversation).toMatchObject([
       {kind: 'user', label: 'You', content: 'what is happening?'},
       {kind: 'assistant', label: 'Answer', content: 'The implementer is running.'},
@@ -119,7 +123,10 @@ describe('session controller', () => {
 
     await controller.submit('/chat');
 
-    expect(controller.state.chatOpen).toBe(true);
+    // Already on screen: /chat puts the pane keys on it instead of opening a
+    // modal over the log.
+    expect(controller.state.chatOpen).toBe(false);
+    expect(controller.state.layout.focus).toBe('chat');
     expect(transport.requests).toEqual([]);
 
     await controller.sendChat('what changed?');
@@ -138,6 +145,99 @@ describe('session controller', () => {
     expect(controller.state.chatConversation).toHaveLength(4);
   });
 
+  it('opens the chat as a modal where it cannot dock', async () => {
+    const transport = new FakeTransport();
+    const controller = new SocketSessionController(transport);
+    // A terminal too narrow for two columns, reported by the renderer.
+    controller.setChatDockFits(false);
+
+    await controller.submit('what is happening?');
+
+    expect(controller.state.chatOpen).toBe(true);
+    expect(chatPaneVisible(controller.state)).toBe(false);
+    expect(controller.state.chatConversation.at(-1)?.content).toBe('The implementer is running.');
+  });
+
+  it('keeps the log as the view when the chat opens over it', async () => {
+    const transport = new FakeTransport();
+    transport.experiments = [entry('H-01', 1, 1, {resolved_outcome: 'proven'})];
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+    // Too narrow to dock, so the question opens the modal.
+    controller.setChatDockFits(false);
+
+    await controller.sendChat('what is happening?');
+
+    expect(controller.state.chatOpen).toBe(true);
+    // The modal floats over the table. It must not put the operator into the
+    // per-round transcript they never asked for.
+    expect(experimentLogVisible(controller.state)).toBe(true);
+    expect(controller.state.hypothesisScope).toBeNull();
+    expect(controller.state.experimentLog?.entries).toHaveLength(1);
+  });
+
+  it('offers /chat in help only where the chat is not already on screen', async () => {
+    const transport = new FakeTransport();
+    transport.experiments = [
+      entry('H-01', 1, 1, {rounds: [{round: 1, passed: true, reviewed: true}]}),
+    ];
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+
+    await controller.submit('/help');
+    expect(controller.state.overlay?.content).not.toContain('/chat');
+
+    // Inside a hypothesis the chat is a dialog again, so the command returns.
+    controller.enterExperimentDrilldown();
+    await controller.submit('/help');
+    expect(controller.state.overlay?.content).toContain('/chat');
+  });
+
+  it('carries the modal conversation back into the docked pane', async () => {
+    const transport = new FakeTransport();
+    transport.experiments = [
+      entry('H-01', 1, 1, {rounds: [{round: 1, passed: true, reviewed: true}]}),
+    ];
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+    controller.enterExperimentDrilldown();
+
+    // Asked from the trajectory view, where the chat is a pop-up.
+    await controller.submit('/chat why did r1 fail?');
+    expect(controller.state.chatOpen).toBe(true);
+
+    controller.live();
+
+    // Back on the landing view the same conversation is in the column, both
+    // the question and what came back.
+    expect(chatPaneVisible(controller.state)).toBe(true);
+    expect(controller.state.chatConversation.map(entry => entry.content)).toEqual([
+      'why did r1 fail?',
+      'The implementer is running.',
+    ]);
+  });
+
+  it('opens the chat as a modal inside a hypothesis', async () => {
+    const transport = new FakeTransport();
+    transport.experiments = [
+      entry('H-01', 1, 1, {rounds: [{round: 1, passed: true, reviewed: true}]}),
+    ];
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+    controller.enterExperimentDrilldown();
+
+    await controller.sendChat('why did r1 fail?');
+
+    // The row belongs to the transcript here, so the chat is the dialog it was.
+    expect(controller.state.chatOpen).toBe(true);
+
+    // Back on the landing view it docks again, transcript intact.
+    controller.live();
+    expect(controller.state.chatOpen).toBe(false);
+    expect(chatPaneVisible(controller.state)).toBe(true);
+    expect(controller.state.chatConversation.at(0)?.content).toBe('why did r1 fail?');
+  });
+
   it('opens chat and sends an initial message from the command line', async () => {
     const transport = new FakeTransport([], [], {
       question: 'why?',
@@ -148,7 +248,8 @@ describe('session controller', () => {
 
     await controller.submit('/chat why?');
 
-    expect(controller.state.chatOpen).toBe(true);
+    expect(controller.state.chatOpen).toBe(false);
+    expect(controller.state.layout.focus).toBe('chat');
     expect(transport.requests).toEqual([{type: 'query.chat', text: 'why?'}]);
   });
 
@@ -591,11 +692,29 @@ describe('session controller', () => {
     controller.closePane();
 
     expect(controller.state.layout.right).toBeNull();
-    expect(controller.state.chatOpen).toBe(true);
+    expect(chatPaneVisible(controller.state)).toBe(true);
     expect(controller.state.chatConversation.map(entry => entry.content)).toEqual([
       'why?',
       'Round 2 regressed.',
     ]);
+  });
+
+  it('keeps the docked chat beside the log while a visualization is open', async () => {
+    const transport = new FakeTransport(
+      [],
+      [{round: 1, perf_metric: 1200, perf_unit: 'ops', passed: true, profile_skipped: false}],
+    );
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+
+    await controller.submit('/perf');
+    await controller.sendChat('what changed in r1?');
+
+    // Three columns: chat, log, pane. None of them replaced another.
+    expect(controller.state.layout.right?.view).toBe('perf');
+    expect(chatPaneVisible(controller.state)).toBe(true);
+    expect(experimentLogVisible(controller.state)).toBe(true);
+    expect(controller.state.chatConversation.at(0)?.content).toBe('what changed in r1?');
   });
 
   it('sends chat messages while the pane stays put', async () => {

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -1,24 +1,30 @@
 import type {EventSubscription} from './client.js';
-import {HELP_TEXT, parseInput} from './commands.js';
+import {helpText, parseInput} from './commands.js';
 import {renderPerformanceCurve} from './performance-chart.js';
 import type {ProtocolResponse, RequestInput, RunEvent, ServerMessage} from './protocol.js';
 import {
   applyEvent,
   applySnapshot,
   type ConversationEntry,
+  chatDocked,
+  chatPaneVisible,
   closePane,
   closeThemePicker,
+  cyclePaneFocus,
   enterExperimentDrilldown,
   enterExperimentRound,
   failExperiments,
   failPane,
+  focusPane,
   initialSessionState,
   leaveExperimentDrilldown,
   moveExperimentSelection,
   moveThemeSelection,
+  openChat,
   openExperimentLog,
   openPane,
   openThemePicker,
+  type PaneFocus,
   type PaneView,
   type SessionState,
   selectNextAgent,
@@ -26,12 +32,12 @@ import {
   selectPreviousAgent,
   selectPreviousRound,
   selectRound,
+  setChatDockFits,
   setExperiments,
   setPaneContent,
   setTheme,
   showDetail,
   showLive,
-  togglePaneFocus,
   toggleTodos,
 } from './session-model.js';
 import {DEFAULT_THEME_NAME, type ThemeName} from './ui/theme.js';
@@ -56,7 +62,9 @@ export interface SessionController {
   openRound(roundNumber?: number): void;
   openPane(view: PaneView): Promise<void>;
   closePane(): void;
-  togglePaneFocus(): void;
+  cyclePaneFocus(): void;
+  focusPane(focus: PaneFocus): void;
+  setChatDockFits(fits: boolean): void;
   moveExperimentSelection(delta: number): void;
   enterExperimentDrilldown(): void;
   leaveExperimentDrilldown(): void;
@@ -219,8 +227,21 @@ export class SocketSessionController implements SessionController {
     this.#setState(closePane(this.#state));
   }
 
-  togglePaneFocus(): void {
-    this.#setState(togglePaneFocus(this.#state));
+  cyclePaneFocus(): void {
+    this.#setState(cyclePaneFocus(this.#state));
+  }
+
+  focusPane(focus: PaneFocus): void {
+    this.#setState(focusPane(this.#state, focus));
+  }
+
+  /**
+   * Reported by the renderer, which is the only part that knows how many
+   * columns there are. It decides whether a question opens the modal or lands
+   * in the pane beside the log.
+   */
+  setChatDockFits(fits: boolean): void {
+    this.#setState(setChatDockFits(this.#state, fits));
   }
 
   /**
@@ -311,7 +332,9 @@ export class SocketSessionController implements SessionController {
     this.#chatQueue.push({id, text});
     this.#setState({
       ...this.#state,
-      chatOpen: true,
+      // Docked, the answer lands in the pane the operator is already looking
+      // at, so nothing has to open over the log to show it.
+      ...(chatDocked(this.#state) ? {} : {chatOpen: true}),
       chatConversation: appendChatEntry(this.#state.chatConversation, {
         id,
         kind: 'user',
@@ -383,10 +406,12 @@ export class SocketSessionController implements SessionController {
     const parsed = parseInput(value.trim());
     if (parsed.error) return this.#setState(showDetail(this.#state, parsed.error, 'error'));
     if (parsed.localView === 'help') {
-      return this.#setState(showDetail(this.#state, HELP_TEXT, 'help'));
+      return this.#setState(
+        showDetail(this.#state, helpText({chatDocked: chatPaneVisible(this.#state)}), 'help'),
+      );
     }
     if (parsed.localView === 'chat') {
-      this.#setState({...this.#state, overlay: null, chatOpen: true});
+      this.#setState(openChat(this.#state));
       if (parsed.chatMessage) await this.sendChat(parsed.chatMessage);
       return;
     }

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -2,20 +2,27 @@ import {describe, expect, it} from 'bun:test';
 import type {RunEvent} from './protocol.js';
 import {
   applyEvent,
+  chatDocked,
+  chatPaneVisible,
   closePane,
   closeThemePicker,
+  cyclePaneFocus,
+  enterExperimentDrilldown,
   failPane,
+  focusPane,
   initialSessionState,
   moveThemeSelection,
+  openChat,
   openPane,
   openThemePicker,
   selectNextAgent,
   selectNextRound,
   selectRound,
+  setChatDockFits,
+  setExperiments,
   setPaneContent,
   setTheme,
   statusText,
-  togglePaneFocus,
   toggleTodos,
   visibleConversation,
   visiblePhases,
@@ -604,6 +611,56 @@ describe('session event model', () => {
   });
 });
 
+describe('docked experiment chat', () => {
+  const entry = {
+    hypothesis_id: 'H-01',
+    identified: true,
+    first_round: 1,
+    last_round: 1,
+    rounds: [{round: 1, passed: true, reviewed: true}],
+    kept: false,
+    active: false,
+  };
+
+  it('docks beside the log and nowhere else', () => {
+    const landing = setExperiments(initialSessionState(), [entry]);
+    expect(chatDocked(landing)).toBe(true);
+    expect(chatPaneVisible(landing)).toBe(true);
+
+    // Inside a hypothesis the row belongs to the transcript.
+    const scoped = enterExperimentDrilldown(landing);
+    expect(scoped.hypothesisScope).not.toBeNull();
+    expect(chatDocked(scoped)).toBe(false);
+  });
+
+  it('stops docking in a terminal too narrow for two columns', () => {
+    const narrow = setChatDockFits(initialSessionState(), false);
+
+    expect(chatDocked(narrow)).toBe(false);
+    expect(chatPaneVisible(narrow)).toBe(false);
+  });
+
+  it('gives the pane the keys instead of opening a modal over the table', () => {
+    const opened = openChat(initialSessionState());
+
+    expect(opened.chatOpen).toBe(false);
+    expect(opened.layout.focus).toBe('chat');
+  });
+
+  it('still opens the modal where the chat cannot dock', () => {
+    const narrow = setChatDockFits(initialSessionState(), false);
+
+    expect(openChat(narrow).chatOpen).toBe(true);
+  });
+
+  it('yields to the modal while one is open', () => {
+    const modal = {...initialSessionState(), chatOpen: true};
+
+    expect(chatDocked(modal)).toBe(true);
+    expect(chatPaneVisible(modal)).toBe(false);
+  });
+});
+
 describe('right pane layout', () => {
   it('starts single-pane with focus on the transcript', () => {
     const state = initialSessionState();
@@ -641,21 +698,48 @@ describe('right pane layout', () => {
     expect(failed.layout.right?.pending).toBe(false);
   });
 
-  it('moves focus between panes and returns it on close', () => {
+  it('cycles focus left to right through the columns on screen', () => {
+    // The landing view carries the docked chat, so opening a visualization
+    // makes three columns: chat, log, pane.
     const open = openPane(initialSessionState(), 'perf');
-    expect(togglePaneFocus(open).layout.focus).toBe('left');
-    expect(togglePaneFocus(togglePaneFocus(open)).layout.focus).toBe('right');
+    expect(open.layout.focus).toBe('right');
+    const first = cyclePaneFocus(open);
+    expect(first.layout.focus).toBe('chat');
+    expect(cyclePaneFocus(first).layout.focus).toBe('left');
+    expect(cyclePaneFocus(cyclePaneFocus(first)).layout.focus).toBe('right');
 
     const closed = closePane(open);
     expect(closed.layout.right).toBeNull();
     expect(closed.layout.focus).toBe('left');
   });
 
-  it('does nothing to focus while single-pane', () => {
-    const single = initialSessionState();
+  it('cycles between the chat and the log while no visualization is open', () => {
+    const docked = initialSessionState();
 
-    expect(togglePaneFocus(single)).toBe(single);
+    expect(cyclePaneFocus(docked).layout.focus).toBe('chat');
+    expect(cyclePaneFocus(cyclePaneFocus(docked)).layout.focus).toBe('left');
+  });
+
+  it('does nothing to focus when only one column is on screen', () => {
+    // Too narrow for the dock and no visualization: the log has the row.
+    const single = setChatDockFits(initialSessionState(), false);
+
+    expect(cyclePaneFocus(single)).toBe(single);
     expect(closePane(single)).toBe(single);
+  });
+
+  it('refuses focus for a column that is not on screen', () => {
+    const narrow = setChatDockFits(initialSessionState(), false);
+
+    expect(focusPane(narrow, 'chat')).toBe(narrow);
+    expect(focusPane(initialSessionState(), 'right').layout.focus).toBe('left');
+    expect(focusPane(initialSessionState(), 'chat').layout.focus).toBe('chat');
+  });
+
+  it('hands the keys back to the log when the dock stops fitting', () => {
+    const focused = focusPane(initialSessionState(), 'chat');
+
+    expect(setChatDockFits(focused, false).layout.focus).toBe('left');
   });
 
   it('leaves the chat transcript untouched when the pane closes', () => {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -33,6 +33,13 @@ export interface SessionState {
   experimentLog: ExperimentLogState | null;
   hypothesisScope: HypothesisScope | null;
   layout: LayoutState;
+  /**
+   * Whether the terminal is wide enough to carry the docked chat beside the
+   * log. Measured by the renderer and reported in, because where a question's
+   * answer is displayed has to agree with what is actually on screen: too
+   * narrow to dock and the chat is the modal it has always been.
+   */
+  chatDockFits: boolean;
   /** Non-null while the theme list is open as a keyboard selection. */
   themePicker: ThemePicker | null;
   /**
@@ -97,10 +104,17 @@ export interface RightPane {
   error: string | null;
 }
 
+/**
+ * Which column the pane keys act on. ``left`` is whatever holds the middle of
+ * the row, the experiment log or the transcript; ``chat`` and ``right`` are the
+ * panes beside it.
+ */
+export type PaneFocus = 'chat' | 'left' | 'right';
+
 export interface LayoutState {
-  /** null means single-pane: the transcript has the full width. */
+  /** null means no visualization pane: the left side has the rest of the row. */
   right: RightPane | null;
-  focus: 'left' | 'right';
+  focus: PaneFocus;
 }
 
 export interface ThemePicker {
@@ -172,6 +186,9 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
     experimentLog: {entries: [], selectedId: null, pending: true, error: null},
     hypothesisScope: null,
     layout: {right: null, focus: 'left'},
+    // Docked until the renderer measures otherwise, so the landing view carries
+    // the chat from the first frame rather than after a resize.
+    chatDockFits: true,
     themePicker: null,
     typedToolEvents: false,
   };
@@ -188,9 +205,57 @@ export function entryKey(entry: HypothesisEntry, index: number): string {
     : entry.hypothesis_id || `#${index}`;
 }
 
-/** True when the table itself is on screen rather than a hypothesis trajectory. */
+/**
+ * True when the table itself is on screen rather than a hypothesis trajectory.
+ * The chat does not enter into it: docked it is part of this view, and as a
+ * modal it floats over it, so asking a question never swaps the table for the
+ * per-round transcript underneath.
+ */
 export function experimentLogVisible(state: SessionState): boolean {
-  return state.experimentLog !== null && state.hypothesisScope === null && !state.chatOpen;
+  return state.experimentLog !== null && state.hypothesisScope === null;
+}
+
+/**
+ * The chat is docked on the landing view: it is part of that view rather than a
+ * dialog over it, so a question never hides the table it is about. Inside a
+ * hypothesis, and in a terminal too narrow for two columns, it stays the modal
+ * it was.
+ */
+export function chatDocked(state: SessionState): boolean {
+  return state.chatDockFits && state.experimentLog !== null && state.hypothesisScope === null;
+}
+
+/** True when the docked chat is the thing on screen rather than the modal. */
+export function chatPaneVisible(state: SessionState): boolean {
+  return chatDocked(state) && !state.chatOpen;
+}
+
+export function chatPaneFocused(state: SessionState): boolean {
+  return chatPaneVisible(state) && state.layout.focus === 'chat';
+}
+
+export function rightPaneFocused(state: SessionState): boolean {
+  return state.layout.right !== null && state.layout.focus === 'right';
+}
+
+export function setChatDockFits(state: SessionState, fits: boolean): SessionState {
+  if (state.chatDockFits === fits) return state;
+  const layout =
+    fits || state.layout.focus !== 'chat'
+      ? state.layout
+      : {...state.layout, focus: 'left' as const};
+  return {...state, chatDockFits: fits, layout};
+}
+
+/**
+ * What ``/chat`` does. Docked, the chat is already on screen, so opening it
+ * means putting the pane keys on it rather than covering the table.
+ */
+export function openChat(state: SessionState): SessionState {
+  if (chatDocked(state)) {
+    return {...state, overlay: null, layout: {...state.layout, focus: 'chat'}};
+  }
+  return {...state, overlay: null, chatOpen: true};
 }
 
 export function openExperimentLog(state: SessionState): SessionState {
@@ -373,12 +438,30 @@ export function closePane(state: SessionState): SessionState {
   return {...state, layout: {right: null, focus: 'left'}};
 }
 
-export function togglePaneFocus(state: SessionState): SessionState {
-  if (state.layout.right === null) return state;
-  return {
-    ...state,
-    layout: {...state.layout, focus: state.layout.focus === 'left' ? 'right' : 'left'},
-  };
+/**
+ * Moves the pane keys one column to the right, wrapping. Only the columns
+ * actually on screen take part, so the operator never lands on a pane they
+ * cannot see.
+ */
+export function cyclePaneFocus(state: SessionState): SessionState {
+  const order = visiblePaneOrder(state);
+  if (order.length < 2) return state;
+  const next = order[(order.indexOf(state.layout.focus) + 1) % order.length] ?? 'left';
+  return {...state, layout: {...state.layout, focus: next}};
+}
+
+export function focusPane(state: SessionState, focus: PaneFocus): SessionState {
+  if (state.layout.focus === focus) return state;
+  if (!visiblePaneOrder(state).includes(focus)) return state;
+  return {...state, layout: {...state.layout, focus}};
+}
+
+function visiblePaneOrder(state: SessionState): PaneFocus[] {
+  return [
+    ...(chatPaneVisible(state) ? (['chat'] as const) : []),
+    'left' as const,
+    ...(state.layout.right !== null ? (['right'] as const) : []),
+  ];
 }
 
 export function setTheme(state: SessionState, themeName: ThemeName): SessionState {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -6,20 +6,23 @@ import type {SessionController} from '../session-controller.js';
 import {
   closePane,
   closeThemePicker,
+  cyclePaneFocus,
   enterExperimentDrilldown,
   enterExperimentRound,
+  focusPane,
   initialSessionState,
   leaveExperimentDrilldown,
   moveExperimentSelection,
   moveThemeSelection,
   openExperimentLog,
   openPane,
+  type PaneFocus,
   type PaneView,
   type SessionState,
+  setChatDockFits,
   setExperiments,
   setPaneContent,
   setTheme,
-  togglePaneFocus,
 } from '../session-model.js';
 import {createOpenTuiApp, type OpenTuiApp} from './app.js';
 import {resolveTheme, type ThemeName} from './theme.js';
@@ -1053,6 +1056,224 @@ describe('theming', () => {
     expect(controller.state.experimentLog?.selectedId).toBe('H-001');
   });
 
+  it('lands with the chat docked beside the hypothesis table', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    const landing = await frameAfter(testRenderer);
+
+    // Both columns at once, and the table keeps the claim it came to show.
+    expect(landing).toContain('Experiment chat');
+    expect(landing).toContain('Experiments');
+    expect(landing).toContain('Implementation Details');
+    expect(landing).toContain('Batch the prefill step');
+
+    // Each column has its own input, under the surface it writes to, and the
+    // command box starts where the chat column ends rather than running under
+    // it.
+    // The cursor starts in the command box, and the chat says how to reach it.
+    expect(landing).toContain('Ctrl+W to type here');
+    const lines = landing.split('\n');
+    const paneTop = lines.find(line => line.includes('╭─ Experiment chat')) ?? '';
+    const inputTop = lines.find(line => line.includes('╭─ Chat ')) ?? '';
+    expect(inputTop).toContain('╭─ Ask or command');
+    expect(inputTop.indexOf('╭─ Ask or command')).toBe(paneTop.indexOf('╭─ Experiments'));
+  });
+
+  it('routes typing to whichever input Ctrl+W points at', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
+    await testRenderer.mockInput.typeText('why is r41 slow?');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.chatSubmissions.length === 1);
+
+    // The chat's own box took it, not the command input.
+    expect(controller.chatSubmissions).toEqual(['why is r41 slow?']);
+    expect(controller.submissions).toEqual([]);
+
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
+    await testRenderer.mockInput.typeText('/perf');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.submissions.length === 1);
+
+    expect(controller.submissions).toEqual(['/perf']);
+    expect(controller.chatSubmissions).toHaveLength(1);
+  });
+
+  it('raises the command list out of the command input, clear of the chat', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    await testRenderer.mockInput.typeText('/pe');
+    const frame = await testRenderer.waitForFrame(value => value.includes('[Tab]'));
+
+    const lines = frame.split('\n');
+    const suggestion = lines.find(line => line.includes('/perf')) ?? '';
+    const commandInput = lines.find(line => line.includes('╭─ Ask or command')) ?? '';
+    // The list belongs to the box it completes, so it starts where that box
+    // starts rather than running back across the chat column.
+    expect(suggestion.indexOf('│')).toBe(commandInput.indexOf('╭─ Ask or command'));
+  });
+
+  it('drops /chat from the command surface while the chat is already docked', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    await testRenderer.mockInput.typeText('/c');
+    const frame = await frameAfter(testRenderer);
+
+    // Nothing to open: the chat is the column beside the table.
+    expect(frame).not.toContain('/chat');
+  });
+
+  it('says when the docked chat is waiting on the agent', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    controller.publish({...controller.state, chatPending: true});
+
+    expect(await frameAfter(testRenderer)).toContain('Awaiting the agent');
+  });
+
+  it('answers in the docked chat without covering the table', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    await testRenderer.mockInput.typeText('why is r41 slow?');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.submissions.length === 1);
+    controller.publish({
+      ...controller.state,
+      chatConversation: [
+        {id: 'q', kind: 'user', label: 'You', content: 'why is r41 slow?'},
+        {id: 'a', kind: 'assistant', label: 'Answer', content: 'Prefill dominates.'},
+      ],
+    });
+
+    const answered = await frameAfter(testRenderer);
+
+    expect(answered).toContain('Prefill dominates.');
+    expect(answered).toContain('H-07');
+    expect(answered).toContain('Implementation Details');
+  });
+
+  it('keeps the chat, the table, and the visualization on screen together', async () => {
+    const testRenderer = await createTestRenderer({width: 200, height: 20});
+    const controller = logController();
+    controller.paneContent = 'Performance · tok_s\n    1135 ┤   ●\nbest r7 1135 tok_s';
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    controller.publish({
+      ...controller.state,
+      chatConversation: [{id: 'a', kind: 'assistant', label: 'Answer', content: 'Prefill.'}],
+    });
+
+    await controller.openPane('perf');
+    const frame = await frameAfter(testRenderer);
+
+    // Three columns: chat, table, visualization. None replaced another.
+    expect(frame).toContain('Experiment chat');
+    expect(frame).toContain('H-07');
+    expect(frame).toContain('best r7 1135 tok_s');
+    expect(frame).toContain('Ctrl+W: switch pane');
+  });
+
+  it('gives the row to the table alone when the chat cannot fit beside it', async () => {
+    const testRenderer = await createTestRenderer({width: 84, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    const landing = await frameAfter(testRenderer);
+
+    // Two columns would both be unreadable here, so the table keeps the row.
+    expect(landing).not.toContain('Experiment chat');
+    expect(landing).toContain('H-07');
+    expect(controller.state.chatDockFits).toBe(false);
+  });
+
+  it('keeps the table behind the chat modal instead of the round transcript', async () => {
+    const testRenderer = await createTestRenderer({width: 84, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    // What a question does where the chat cannot dock.
+    controller.publish({...controller.state, chatOpen: true});
+
+    const frame = await frameAfter(testRenderer);
+
+    expect(frame).toContain('Experiment chat');
+    expect(frame).toContain('H-07');
+    // The per-round chrome belongs to a hypothesis the operator never opened.
+    expect(frame).not.toContain('─ Rounds ─');
+    expect(frame).not.toContain('─ Agents ─');
+  });
+
+  it('moves the pane keys onto the docked chat and back with Ctrl+W', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    const focused = await frameAfter(testRenderer);
+    expect(focused).toContain('▸ Experiment chat');
+    expect(focused).toContain('Ask about this run');
+    expect(controller.state.layout.focus).toBe('chat');
+
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.focus).toBe('left');
+  });
+
+  it('leaves the table its own keys while the chat is docked', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    controller.experiments = [
+      logEntry('H-07', 41, 41, {claim: 'batch the prefill step', resolved_outcome: 'proven'}),
+      logEntry('H-08', 42, 42, {claim: 'bigger KV cache block', resolved_outcome: 'disproven'}),
+    ];
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    // Arrows still belong to the table, docked chat or not.
+    testRenderer.mockInput.pressKey('ARROW_DOWN');
+    await frameAfter(testRenderer);
+    expect(controller.state.experimentLog?.selectedId).toBe('H-08');
+  });
+
   it('renders the transcript and the visualization side by side', async () => {
     const testRenderer = await createTestRenderer({width: 140, height: 20});
     const controller = splitController();
@@ -1163,7 +1384,7 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'Performance · focused')?.fg).toBe(theme.borderFocus);
     expect(spanColors(testRenderer, 'best r7 1135 tok_s')?.fg).toBe(theme.textPrimary);
 
-    controller.togglePaneFocus();
+    controller.cyclePaneFocus();
     await frameAfter(testRenderer);
 
     // Focus moved to the transcript, so the pane border drops back to the
@@ -1234,6 +1455,25 @@ async function frameAfter(testRenderer: TestRendererSetup): Promise<string> {
 async function frameAfterEscape(testRenderer: TestRendererSetup): Promise<string> {
   await new Promise(resolve => setTimeout(resolve, 40));
   return frameAfter(testRenderer);
+}
+
+/** A client on the landing view, with one hypothesis to show. */
+function logController(): FakeController {
+  const controller = new FakeController({
+    ...initialSessionState(),
+    status: 'running',
+    rounds: [{number: 41, status: 'completed'}],
+  });
+  controller.publish({...controller.state, experimentLog: initialSessionState().experimentLog});
+  controller.experiments = [
+    logEntry('H-07', 41, 41, {
+      claim: 'batch the prefill step',
+      resolved_outcome: 'proven',
+      judge_verdict: 'pass',
+      rounds: [{round: 41, passed: true, reviewed: true}],
+    }),
+  ];
+  return controller;
 }
 
 function splitController(): FakeController {
@@ -1451,8 +1691,14 @@ class FakeController implements SessionController {
   closePane(): void {
     this.publish(closePane(this.state));
   }
-  togglePaneFocus(): void {
-    this.publish(togglePaneFocus(this.state));
+  cyclePaneFocus(): void {
+    this.publish(cyclePaneFocus(this.state));
+  }
+  focusPane(focus: PaneFocus): void {
+    this.publish(focusPane(this.state, focus));
+  }
+  setChatDockFits(fits: boolean): void {
+    this.publish(setChatDockFits(this.state, fits));
   }
 
   /** Content the fake server returns for whichever visualization is opened. */

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -3,9 +3,10 @@ import type {SessionController} from '../session-controller.js';
 import {experimentLogVisible, type SessionState, statusText} from '../session-model.js';
 import {AgentMapView} from './agent-map.js';
 import {ChatOverlayView} from './chat-overlay.js';
+import {ChatPaneView, chatDockFits, chatPaneWidth} from './chat-pane.js';
 import {ConversationView} from './conversation.js';
 import {ExperimentLogView} from './experiment-log.js';
-import {createInputPanel} from './input.js';
+import {createChatInputPanel, createInputPanel} from './input.js';
 import {bindKeybindings} from './keybindings.js';
 import {OverlayView} from './overlay.js';
 import {RightPaneView, rightPaneWidth, splitFits} from './right-pane.js';
@@ -19,12 +20,26 @@ export interface OpenTuiApp {
   destroy(): void;
 }
 
+/** Which of the client's inputs currently holds the cursor. */
+type FocusTarget = 'command' | 'chat' | 'modal';
+
 const KEY_HELP =
   '[/]: round · Tab: agent · PgUp/PgDn · Ctrl+T: todos · Ctrl+P: prompt · Ctrl+L: live';
 const SCOPED_KEY_HELP =
   '[/]: round · Tab: agent · PgUp/PgDn · Ctrl+T: todos · Ctrl+P: prompt · Esc: experiments';
 const LOG_KEY_HELP =
   '↑↓ or scroll: select · Enter or /open-round: open its rounds · /open-round --N';
+const LOG_CHAT_KEY_HELP =
+  '↑↓: select · Enter: open its rounds · Ctrl+W: chat and back · /open-round --N';
+/**
+ * Shown above the docked chat's own input. Short enough to leave a gap before
+ * the key hints beside it even in the narrowest column that docks, and it says
+ * how to reach the box while the cursor is in the command input, because two
+ * boxes on screen must never leave that a guess.
+ */
+const CHAT_INPUT_HINT = 'Ask about this run';
+const CHAT_INPUT_PENDING_HINT = 'Awaiting the agent';
+const CHAT_INPUT_BLURRED_HINT = 'Ctrl+W to type here';
 const SPLIT_KEY_HELP =
   'Ctrl+W: switch pane · PgUp/PgDn: scroll focused pane · Esc on the pane: close it';
 
@@ -78,22 +93,69 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   const themePicker = new ThemePickerView(renderer, theme);
   const conversation = new ConversationView(renderer, controller, markdownStyle, theme);
   const chat = new ChatOverlayView(renderer, controller, markdownStyle, theme);
+  const chatPane = new ChatPaneView(renderer, controller, markdownStyle, theme);
   const input = createInputPanel(renderer, value => void controller.submit(value), theme);
+  const chatInput = createChatInputPanel(
+    renderer,
+    value => void controller.submitChat(value),
+    theme,
+  );
+  // The two inputs share a row and split it on the same boundary as the panes
+  // above them, so each box sits under the surface it writes to.
+  const bottom = new BoxRenderable(renderer, {
+    id: 'bottom',
+    width: '100%',
+    flexShrink: 0,
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+  });
+  const chatInputColumn = new BoxRenderable(renderer, {
+    id: 'chat-input-column',
+    flexDirection: 'column',
+    flexShrink: 0,
+    flexGrow: 0,
+    visible: false,
+  });
+  const chatInputHint = new TextRenderable(renderer, {
+    id: 'chat-input-hint',
+    height: 1,
+    width: '100%',
+    wrapMode: 'none',
+    truncate: true,
+    fg: theme.textSubtle,
+    content: CHAT_INPUT_HINT,
+  });
+  const commandColumn = new BoxRenderable(renderer, {
+    id: 'command-column',
+    flexGrow: 1,
+    flexShrink: 0,
+    flexDirection: 'column',
+  });
 
   viewport.add(conversation.output);
   main.add(agentMap.output);
+  // The chat is the leftmost column of the landing view, so it is added before
+  // the surfaces it sits beside.
+  main.add(chatPane.output);
   main.add(viewport);
   // The log lives in the main pane rather than floating over it: it is the
   // landing view, not a dialog.
   main.add(experimentLog.output);
   main.add(rightPane.output);
+  chatInputColumn.add(chatInputHint);
+  chatInputColumn.add(chatInput.box);
+  commandColumn.add(help);
+  // Absolute inside the command column rather than the root, so the list rises
+  // out of the input it belongs to instead of across the chat beside it.
+  commandColumn.add(input.suggestions);
+  commandColumn.add(input.box);
+  bottom.add(chatInputColumn);
+  bottom.add(commandColumn);
   root.add(header);
   root.add(roundStrip.output);
   root.add(main);
   root.add(todoStrip.output);
-  root.add(help);
-  root.add(input.suggestions);
-  root.add(input.box);
+  root.add(bottom);
   root.add(overlay.output);
   root.add(themePicker.output);
   root.add(chat.output);
@@ -118,11 +180,14 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     themePicker.applyTheme(theme);
     conversation.applyTheme(theme, markdownStyle);
     chat.applyTheme(theme, markdownStyle);
+    chatPane.applyTheme(theme, markdownStyle);
+    chatInput.applyTheme(theme);
+    chatInputHint.fg = theme.textSubtle;
     input.applyTheme(theme);
     return () => previousMarkdownStyle.destroy();
   };
 
-  let chatWasOpen = false;
+  let focusTarget: FocusTarget = 'command';
   let lastState: SessionState = controller.state;
   const render = (state: SessionState): void => {
     lastState = state;
@@ -137,9 +202,16 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     const paneFallback = splitOpen && !showSplit ? state.layout.right : null;
     // Whatever holds the left side, log or transcript, shares the row with the
     // pane rather than being replaced by it.
-    const leftWidth = showSplit
-      ? renderer.terminalWidth - rightPaneWidth(renderer.terminalWidth)
-      : renderer.terminalWidth;
+    const rightWidth = showSplit ? rightPaneWidth(renderer.terminalWidth) : 0;
+    const leftWidth = renderer.terminalWidth - rightWidth;
+    // Measured here because this is the only place that knows the width, and
+    // reported to the controller so a question goes where the operator can see
+    // it. The layout below uses the measurement directly rather than waiting
+    // for the state to come back, so a resize never draws a stale row.
+    const dockFits = chatDockFits(renderer.terminalWidth, rightWidth);
+    if (state.chatDockFits !== dockFits) controller.setChatDockFits(dockFits);
+    const showChatPane = showLog && dockFits && !state.chatOpen;
+    const chatWidth = showChatPane ? chatPaneWidth(renderer.terminalWidth, rightWidth) : 0;
     const dialogOpen = state.chatOpen || state.overlay !== null || state.themePicker !== null;
     const returnHint = dialogOpen ? ' · Esc: close dialog' : '';
     const selection = state.selectedAgentKind ? ` · selected ${state.selectedAgentKind}` : '';
@@ -152,7 +224,9 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     help.content = showSplit
       ? SPLIT_KEY_HELP
       : showLog
-        ? LOG_KEY_HELP
+        ? showChatPane
+          ? LOG_CHAT_KEY_HELP
+          : LOG_KEY_HELP
         : state.hypothesisScope === null
           ? KEY_HELP
           : SCOPED_KEY_HELP;
@@ -188,7 +262,22 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     } else {
       chat.setPaneBounds(null);
     }
-    experimentLog.setAvailableWidth(showSplit ? leftWidth : null);
+    chatPane.render(state, showChatPane, chatWidth);
+    // The chat's input tracks the pane above it, so the boundary between the
+    // two boxes is the boundary between the two surfaces they write to.
+    chatInputColumn.visible = showChatPane;
+    chatInputColumn.width = chatWidth;
+    const chatInputFocused = showChatPane && state.layout.focus === 'chat';
+    chatInputHint.content = state.chatPending
+      ? CHAT_INPUT_PENDING_HINT
+      : chatInputFocused
+        ? CHAT_INPUT_HINT
+        : CHAT_INPUT_BLURRED_HINT;
+    chatInput.setFocused(chatInputFocused);
+    // The command list completes the box it belongs to, and on this view that
+    // box cannot open a chat that is already beside it.
+    input.setCommandContext({chatDocked: showChatPane});
+    experimentLog.setAvailableWidth(showSplit || showChatPane ? leftWidth - chatWidth : null);
     experimentLog.render(state);
     rightPane.render(state, showSplit);
     overlay.render(
@@ -198,14 +287,23 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     );
     themePicker.render(state);
     chat.render(state);
-    if (state.chatOpen && !chatWasOpen) chat.focus();
-    if (!state.chatOpen && chatWasOpen) input.focus();
-    chatWasOpen = state.chatOpen;
+    // One cursor, three places it can be. The modal owns it while it is open;
+    // otherwise it belongs to whichever input the pane focus points at.
+    const target: FocusTarget = state.chatOpen ? 'modal' : chatInputFocused ? 'chat' : 'command';
+    if (target !== focusTarget) {
+      focusTarget = target;
+      if (target === 'modal') chat.focus();
+      else if (target === 'chat') chatInput.focus();
+      else input.focus();
+    }
     releasePreviousStyle?.();
   };
   const unbindKeys = bindKeybindings(renderer, controller, viewport, {
     completeInput: () => input.completeSuggestion(),
-    inputIsEmpty: () => input.isEmpty(),
+    // Enter belongs to a pane only when nothing is typed anywhere. Asking which
+    // box has the cursor is not enough: a question waiting in the other box is
+    // still a question, and Enter must never discard it to open a hypothesis.
+    inputIsEmpty: () => input.isEmpty() && chatInput.isEmpty(),
     closeChat: () => controller.closeChat(),
     toggleLatestPrompt: () => conversation.toggleLatestPrompt(),
     selectNextAgent: () => controller.selectNextAgent(),
@@ -214,6 +312,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     selectPreviousRound: () => controller.selectPreviousRound(),
     toggleTodos: () => controller.toggleTodos(),
     scrollRightPane: delta => rightPane.scrollBy(delta),
+    scrollChatPane: delta => chatPane.scrollBy(delta),
   });
   // Pane widths come from the terminal, so a resize has to redraw even though
   // no state changed.
@@ -227,6 +326,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
       unsubscribe();
       unbindKeys();
       input.destroy();
+      chatInput.destroy();
       chat.destroy();
       roundStrip.destroy();
       agentMap.destroy();

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -101,7 +101,7 @@ export class ChatOverlayView {
     this.output.add(this.#transcript);
     this.output.add(this.#inputBox);
     this.#hint = new TextRenderable(renderer, {
-      content: 'Enter to send · /history and other commands work here · Esc to close',
+      content: 'Enter to send · /perf and other commands work here · Esc to close',
       fg: theme.textSubtle,
       height: 1,
       width: '100%',

--- a/clients/tui/src/ui/chat-pane.test.ts
+++ b/clients/tui/src/ui/chat-pane.test.ts
@@ -1,0 +1,54 @@
+import {describe, expect, it} from 'bun:test';
+import {chatDockFits, chatPaneWidth, MIN_DOCK_WIDTH} from './chat-pane.js';
+import {LOG_CLAIM_PANEL_WIDTH, LOG_COMPACT_PANEL_WIDTH} from './experiment-log.js';
+
+describe('chat dock thresholds', () => {
+  it('docks wherever the table is still usable beside it', () => {
+    expect(chatDockFits(MIN_DOCK_WIDTH)).toBe(true);
+    expect(chatDockFits(MIN_DOCK_WIDTH - 1)).toBe(false);
+    // Small enough that two columns would both be unreadable.
+    expect(chatDockFits(80)).toBe(false);
+    expect(chatDockFits(120)).toBe(true);
+  });
+
+  it('docks beside a visualization only when all three columns fit', () => {
+    expect(chatDockFits(200, 84)).toBe(true);
+    // The visualization has taken the room the chat would need.
+    expect(chatDockFits(140, 63)).toBe(false);
+  });
+});
+
+describe('chat dock sizing', () => {
+  it('takes the columns left over once the table has its claim', () => {
+    // No surplus: the chat takes its minimum and the table keeps the rest.
+    expect(chatPaneWidth(MIN_DOCK_WIDTH)).toBe(25);
+    expect(chatPaneWidth(200)).toBeGreaterThan(chatPaneWidth(140));
+  });
+
+  it('stops widening once the chat is comfortable', () => {
+    expect(chatPaneWidth(400)).toBe(chatPaneWidth(300));
+  });
+
+  it('costs the table no column once there are spare ones', () => {
+    for (let width = LOG_CLAIM_PANEL_WIDTH + 25; width <= 400; width += 1) {
+      const log = width - chatPaneWidth(width);
+      expect(log, `log at ${width}`).toBeGreaterThanOrEqual(LOG_CLAIM_PANEL_WIDTH);
+    }
+  });
+
+  it('never takes the table below its compact set', () => {
+    for (let width = MIN_DOCK_WIDTH; width <= 400; width += 1) {
+      const log = width - chatPaneWidth(width);
+      expect(log, `log at ${width}`).toBeGreaterThanOrEqual(LOG_COMPACT_PANEL_WIDTH);
+    }
+    const right = 84;
+    for (let width = 200; width <= 400; width += 1) {
+      const log = width - right - chatPaneWidth(width, right);
+      expect(log, `log at ${width} beside a pane`).toBeGreaterThanOrEqual(LOG_COMPACT_PANEL_WIDTH);
+    }
+  });
+
+  it('narrows itself rather than the table when a visualization opens', () => {
+    expect(chatPaneWidth(200, 84)).toBeLessThan(chatPaneWidth(200));
+  });
+});

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -1,0 +1,127 @@
+import {
+  BoxRenderable,
+  type CliRenderer,
+  ScrollBoxRenderable,
+  type SyntaxStyle,
+} from '@opentui/core';
+import type {SessionController} from '../session-controller.js';
+import {chatPaneFocused, type SessionState} from '../session-model.js';
+import {ConversationView} from './conversation.js';
+import {LOG_CLAIM_PANEL_WIDTH, LOG_COMPACT_PANEL_WIDTH} from './experiment-log.js';
+import type {Theme} from './theme.js';
+
+/**
+ * Columns the chat needs before a question and its answer read as prose rather
+ * than as a column of fragments.
+ */
+const CHAT_PANE_MIN = 25;
+const CHAT_PANE_MAX = 52;
+
+/**
+ * The chat is part of the landing view, so it docks wherever the table is still
+ * usable beside it rather than only where the table keeps every column. Below
+ * that the table has the row to itself and the chat opens over it as a modal,
+ * which is the one case where two columns would both be unreadable.
+ */
+export const MIN_DOCK_WIDTH = LOG_COMPACT_PANEL_WIDTH + CHAT_PANE_MIN;
+
+/** True when the terminal can carry the chat beside a usable table. */
+export function chatDockFits(terminalWidth: number, rightPaneWidth = 0): boolean {
+  return terminalWidth - rightPaneWidth - CHAT_PANE_MIN >= LOG_COMPACT_PANEL_WIDTH;
+}
+
+/**
+ * Width in columns for the docked chat. It asks for the columns left over once
+ * the table has enough for its claim, so a wide terminal loses no table column
+ * to the chat; where there is no such surplus it still takes its readable
+ * minimum, and it never takes the table below its compact set.
+ */
+export function chatPaneWidth(terminalWidth: number, rightPaneWidth = 0): number {
+  const available = terminalWidth - rightPaneWidth;
+  const surplus = available - LOG_CLAIM_PANEL_WIDTH;
+  const wanted = Math.max(CHAT_PANE_MIN, Math.min(CHAT_PANE_MAX, surplus));
+  return Math.min(wanted, available - LOG_COMPACT_PANEL_WIDTH);
+}
+
+/**
+ * The experiment chat as a column of the landing view rather than a dialog over
+ * it. It has no input of its own: the client already has one, and plain text
+ * typed there is a question for the agent, so a second box would only split the
+ * operator's attention.
+ */
+export class ChatPaneView {
+  readonly output: BoxRenderable;
+  readonly #scroll: ScrollBoxRenderable;
+  readonly #conversation: ConversationView;
+  #theme: Theme;
+  #renderedState: SessionState | null = null;
+
+  constructor(
+    renderer: CliRenderer,
+    controller: SessionController,
+    markdownStyle: SyntaxStyle,
+    theme: Theme,
+  ) {
+    this.#theme = theme;
+    this.output = new BoxRenderable(renderer, {
+      id: 'chat-pane',
+      height: '100%',
+      flexShrink: 0,
+      flexDirection: 'column',
+      paddingLeft: 1,
+      paddingRight: 1,
+      border: true,
+      borderStyle: 'rounded',
+      borderColor: theme.border,
+      title: ' Experiment chat ',
+      visible: false,
+    });
+    this.#scroll = new ScrollBoxRenderable(renderer, {
+      id: 'chat-pane-scroll',
+      width: '100%',
+      flexGrow: 1,
+      stickyScroll: true,
+      stickyStart: 'bottom',
+      viewportCulling: true,
+      verticalScrollbarOptions: {showArrows: false},
+    });
+    this.#conversation = new ConversationView(renderer, controller, markdownStyle, theme, {
+      selectConversation: state => state.chatConversation,
+      emptyContent: 'Ask about this run: progress, a failure, or what a hypothesis changed.',
+      renderMarkdown: false,
+    });
+    this.#scroll.add(this.#conversation.output);
+    this.output.add(this.#scroll);
+  }
+
+  applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {
+    this.#theme = theme;
+    this.output.borderColor = theme.border;
+    this.#conversation.applyTheme(theme, markdownStyle);
+    this.#renderedState = null;
+  }
+
+  /** Scrolled by Page Up/Page Down while this pane holds focus. */
+  scrollBy(delta: number): void {
+    this.#scroll.scrollBy(delta, 'viewport');
+  }
+
+  render(state: SessionState, visible: boolean, width: number): void {
+    this.output.visible = visible;
+    if (!visible) {
+      this.#renderedState = null;
+      return;
+    }
+    this.output.width = width;
+    const focused = chatPaneFocused(state);
+    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
+    // The column can be as narrow as its minimum, where a spelled-out "focused"
+    // costs the title itself: a box with no title reads as nothing at all. The
+    // marker is the one the table already uses for the row that has the keys.
+    this.output.title = focused ? ' ▸ Experiment chat ' : ' Experiment chat ';
+    if (state === this.#renderedState) return;
+    this.#renderedState = state;
+    this.#conversation.render(state);
+    this.#scroll.scrollTo(this.#scroll.scrollHeight);
+  }
+}

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -23,6 +23,15 @@ const CLAIM_MIN_WIDTH = 90;
 const MEASURED_MIN_WIDTH = 62;
 const KEPT_MIN_WIDTH = 104;
 
+/**
+ * Panel width at which the table still shows the claim, which is the row's
+ * identity in words. Anything that takes columns from the table reads this
+ * rather than restating the threshold.
+ */
+export const LOG_CLAIM_PANEL_WIDTH = CLAIM_MIN_WIDTH + PANEL_CHROME_COLUMNS;
+/** Panel width that still carries the measured and verdict columns. */
+export const LOG_COMPACT_PANEL_WIDTH = MEASURED_MIN_WIDTH + PANEL_CHROME_COLUMNS;
+
 interface Columns {
   claim: boolean;
   measured: boolean;

--- a/clients/tui/src/ui/input.ts
+++ b/clients/tui/src/ui/input.ts
@@ -6,12 +6,19 @@ import {
   SyntaxStyle,
   TextRenderable,
 } from '@opentui/core';
-import {type SlashCommand, slashCommandRange, suggestSlashCommands} from '../commands.js';
+import {
+  type CommandContext,
+  type SlashCommand,
+  slashCommandRange,
+  suggestSlashCommands,
+} from '../commands.js';
 import type {Theme} from './theme.js';
 
 export interface InputPanel {
   box: BoxRenderable;
   suggestions: BoxRenderable;
+  /** Narrows the completions to the commands the current view offers. */
+  setCommandContext(context: CommandContext): void;
   completeSuggestion(): boolean;
   /** True when nothing is typed, so Enter belongs to whatever pane is behind. */
   isEmpty(): boolean;
@@ -22,6 +29,75 @@ export interface InputPanel {
 
 function commandSyntaxStyle(theme: Theme): SyntaxStyle {
   return SyntaxStyle.fromStyles({'slash-command': {fg: theme.accent, bold: true}});
+}
+
+/**
+ * The docked chat's own input. It carries no command suggestions: the command
+ * list belongs to the client's input, and this box is for questions about the
+ * experiment on screen. A slash command typed here still runs, through the same
+ * path as anywhere else.
+ */
+export interface ChatInputPanel {
+  box: BoxRenderable;
+  isEmpty(): boolean;
+  focus(): void;
+  setFocused(focused: boolean): void;
+  applyTheme(theme: Theme): void;
+  destroy(): void;
+}
+
+export function createChatInputPanel(
+  renderer: CliRenderer,
+  onSubmit: (value: string) => void,
+  theme: Theme,
+): ChatInputPanel {
+  const box = new BoxRenderable(renderer, {
+    // The modal chat owns 'chat-input-box'; this is the docked one.
+    id: 'chat-dock-input-box',
+    height: 3,
+    width: '100%',
+    border: true,
+    borderStyle: 'rounded',
+    borderColor: theme.border,
+    title: ' Chat ',
+    paddingLeft: 1,
+    paddingRight: 1,
+  });
+  const input = new InputRenderable(renderer, {
+    id: 'chat-dock-input',
+    width: '100%',
+    placeholder: 'Type a question',
+    textColor: theme.textStrong,
+    focusedTextColor: theme.textStrong,
+  });
+  const submit = (value: string): void => {
+    input.value = '';
+    onSubmit(value);
+  };
+  input.on(InputRenderableEvents.ENTER, submit);
+  box.add(input);
+  let focused = false;
+  let current = theme;
+  return {
+    box,
+    isEmpty: () => input.value.trim() === '',
+    focus: () => input.focus(),
+    // Which box the keystrokes land in is the one thing two inputs must never
+    // leave ambiguous, so the focused one carries the focus border.
+    setFocused(next: boolean): void {
+      focused = next;
+      box.borderColor = next ? current.borderFocus : current.border;
+    },
+    applyTheme(next: Theme): void {
+      current = next;
+      box.borderColor = focused ? next.borderFocus : next.border;
+      input.textColor = next.textStrong;
+      input.focusedTextColor = next.textStrong;
+    },
+    destroy(): void {
+      input.off(InputRenderableEvents.ENTER, submit);
+    },
+  };
 }
 
 export function createInputPanel(
@@ -77,6 +153,7 @@ export function createInputPanel(
   });
   suggestions.add(suggestionList);
   let matches: readonly SlashCommand[] = [];
+  let context: CommandContext = {};
 
   const updateDecorations = (value: string): void => {
     input.clearAllHighlights();
@@ -85,7 +162,7 @@ export function createInputPanel(
       input.addHighlightByCharRange({...range, styleId: commandStyleId});
     }
 
-    matches = suggestSlashCommands(value);
+    matches = suggestSlashCommands(value, context);
     const visible = matches.length > 0;
     suggestions.visible = visible;
     suggestions.height = matches.length + 2;
@@ -109,6 +186,11 @@ export function createInputPanel(
   return {
     box,
     suggestions,
+    setCommandContext(next: CommandContext): void {
+      if (next.chatDocked === context.chatDocked) return;
+      context = next;
+      updateDecorations(input.value);
+    },
     completeSuggestion(): boolean {
       const suggestion = matches[0];
       if (suggestion === undefined || suggestion.name === input.value) return false;

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -1,6 +1,6 @@
 import type {CliRenderer, KeyEvent, ScrollBoxRenderable} from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
-import {experimentLogVisible} from '../session-model.js';
+import {chatPaneFocused, chatPaneVisible, experimentLogVisible} from '../session-model.js';
 
 export interface KeybindingActions {
   completeInput(): boolean;
@@ -13,6 +13,7 @@ export interface KeybindingActions {
   selectPreviousRound(): void;
   toggleTodos(): void;
   scrollRightPane(delta: number): void;
+  scrollChatPane(delta: number): void;
 }
 
 export function bindKeybindings(
@@ -27,11 +28,15 @@ export function bindKeybindings(
       renderer.destroy();
       return;
     }
-    // Pane switching works from anywhere the split is open, including with the
-    // chat focused, so the operator never has to close the chat to look at the
-    // visualization beside it.
-    if (key.ctrl && key.name === 'w' && controller.state.layout.right !== null) {
-      controller.togglePaneFocus();
+    // Pane switching works from anywhere a second column is on screen, which
+    // on the landing view includes the docked chat, so the operator never has
+    // to leave the table to scroll back through an answer.
+    if (
+      key.ctrl &&
+      key.name === 'w' &&
+      (controller.state.layout.right !== null || chatPaneVisible(controller.state))
+    ) {
+      controller.cyclePaneFocus();
       key.preventDefault();
       return;
     }
@@ -44,6 +49,19 @@ export function bindKeybindings(
     ) {
       if (key.name === 'escape') controller.closePane();
       else actions.scrollRightPane(key.name === 'pageup' ? -1 : 1);
+      key.preventDefault();
+      return;
+    }
+    // The docked chat takes the scroll keys while it holds focus, so Page Up
+    // reads the conversation back instead of moving the table's selection.
+    // Escape hands the keys back to the table rather than closing anything:
+    // the pane is part of the view, not a dialog over it.
+    if (
+      chatPaneFocused(controller.state) &&
+      (key.name === 'pageup' || key.name === 'pagedown' || key.name === 'escape')
+    ) {
+      if (key.name === 'escape') controller.focusPane('left');
+      else actions.scrollChatPane(key.name === 'pageup' ? -1 : 1);
       key.preventDefault();
       return;
     }


### PR DESCRIPTION
## Problem

The client opens on the experiment log, and the chat is wired to a coding agent scoped to the run (#330), but the two cannot be on screen at once. `chatOpen` makes `experimentLogVisible` false, so `/chat`, `/chat <question>`, and any plain text typed into the input all replace the table with a modal. The operator asks "what changed in r41?" and the rows the question is about disappear behind the answer.

That is backwards for the questions this chat is for. "Summarize the last three rounds", "why was H-08 rejected", "what is the implementer doing now" are all questions about what the table is showing. Answering them should not cost the operator the thing they were reading, and closing the answer to look at the table again should not be part of the loop.

#328 gave the client a real layout: visualization output renders in a right pane beside the view instead of over it, and the chat, while open, is confined to the left pane rather than floating across the middle. The layout is there. The chat is still a dialog.

Worse, opening it costs the operator the view they asked from. `experimentLogVisible` required `!chatOpen`, so the moment a question opened the chat the landing view was replaced by the per-round transcript: the rounds strip, the agent strip, and unfiltered log output, none of which the operator asked for, behind a modal answering a question about the table that just disappeared.

## Solution

Demo:


https://github.com/user-attachments/assets/d9ceffed-654d-4804-8837-94277d63c30e



**The chat becomes a column of the landing view rather than a dialog over it.** `chatDocked(state)` is true when the experiment log is the view and the terminal can carry the column. Docked, plain text and `/chat <question>` no longer set `chatOpen` at all: the question and its answer land in the pane and the table stays exactly where it was. Bare `/chat` puts the pane keys on the chat instead of opening a modal over the view it is already part of. Inside a hypothesis, and in a terminal too narrow to dock, the chat is the modal it has always been, so nothing loses a surface it used to have.

**Each column gets the input that writes to it.** The chat has its own box at the foot of its column and the client's command input starts at the boundary between the two columns rather than running the width of the screen under both. The command list rises out of the command input rather than across the chat, because it completes that box and not the other one. `Ctrl+W` moves the cursor along with the pane keys, and the focused box carries the focus border. The chat's instruction line carries the state it needs to: `Ctrl+W to type here` while the cursor is elsewhere, `Ask about this run` when it holds it, and `Awaiting the agent` while a question is in flight. A question typed into either box reaches the same agent and is answered in the same column, so the split is a division of attention rather than of capability.

**`/chat` leaves the command surface where the chat is already a pane.** On the landing view it is absent from `/help` and from the completions: there is nothing for it to open. It is still accepted, and still focuses the pane, because hiding a command is not the same as removing it. Inside a hypothesis the chat is a dialog again, the command comes back, and it opens over the trajectory. The conversation is one conversation throughout, so a question asked from the pop-up is in the column when the operator steps back out.

**Focus becomes three regions instead of two.** `PaneFocus` is `'chat' | 'left' | 'right'`, and `Ctrl+W` cycles one column to the right through whichever columns are actually on screen, wrapping. Page Up and Page Down scroll the focused pane; Escape on the chat hands the keys back to the table, while Escape on the right pane still closes it. The table keeps its own keys throughout: arrows move the selection and Enter opens a hypothesis whether the chat is docked or not. `togglePaneFocus` is renamed `cyclePaneFocus` because with three regions "toggle" is no longer what it does, and `focusPane` is added for the one case that names its destination.

**The chat never replaces the view it was asked from.** `experimentLogVisible` no longer consults `chatOpen`. Docked, the chat is part of the landing view; as a modal it floats over it. Either way the table stays behind it, and a question can no longer drop the operator into a hypothesis they never opened.

**The widths are derived from what the table needs, not guessed.** `experiment-log.ts` now exports the panel widths at which it keeps its claim column and its compact column set, and `chat-pane.ts` sizes the dock from those. The chat asks for the columns left over once the table has its claim, so nothing is taken from a wide table; where there is no surplus it takes its readable minimum of 25 and the table drops columns as it would on any narrow terminal:

| Terminal | Landing view | Why |
| --- | --- | --- |
| < 92 columns | table only, chat as a modal over it | Two columns would both be unreadable |
| 92 to 119 columns | chat + table | The chat takes 25; the table drops columns as it narrows |
| ≥ 120 columns | chat + table, table whole | The surplus over the table's claim width is the chat's, up to 52 |
| ≥ ~180 columns with `/perf` | chat + table + chart | All three keep a readable floor |
| `/perf` on a narrower terminal | table + chart | The chat steps aside; `/chat` still opens it |
| < 100 columns with `/perf` | table, chart as a modal | Unchanged from #328 |

Opening a visualization therefore narrows the chat before it narrows the table, and where all three will not fit the chat is the one that yields, because the chart was asked for explicitly and the table is the view.

**The measurement is reported in rather than guessed at.** Only the renderer knows how many columns there are, so `app.ts` measures and calls `controller.setChatDockFits(fits)`. Where a question's answer is displayed has to agree with what is on screen: if the chat cannot dock, a typed question must open the modal rather than writing the answer into a column that is not being drawn. The layout in that same render pass uses the measurement directly rather than waiting for the state to come back, so a resize never draws a stale row.

Two columns at 140, each with its own input:

```
╭─ Experiment chat ─────────────────────────╮╭─ Experiments ───────────────────────────────────────────────────────────────────────────────╮
│  Ask about this run: progress, a          ││  Hypothesis     Rounds   Implementation Details          Measured    Verdict  Outcome       │
│  failure, or what a hypothesis changed.   ││  H-07           41       Batch the prefill step          —           Pass     Proven        │
│                                           ││                                                                                             │
│                                           ││ 1/1 · ↑↓ or scroll: select · Enter or /open-round: open its rounds                          │
╰───────────────────────────────────────────╯╰─────────────────────────────────────────────────────────────────────────────────────────────╯
Ctrl+W to type here                          ↑↓: select · Enter: open its rounds · Ctrl+W: chat and back · /open-round --N
╭─ Chat ────────────────────────────────────╮╭─ Ask or command ────────────────────────────────────────────────────────────────────────────╮
│ Type a question                           ││ Type a question or /help                                                                    │
╰───────────────────────────────────────────╯╰─────────────────────────────────────────────────────────────────────────────────────────────╯
```

Three at 200, after `/perf`. The command input still starts on the same boundary, now spanning the table and the chart:

```
╭─ Experiment chat ─────╮╭─ Experiments ───────────────────────────────────────────────────────────────────────────╮╭─ Performance · focused ──────────────────────────────────────────────────────────╮
│                       ││  Hypothesis     Rounds   Measured    Verdict  Outcome                                   ││ Performance · tok_s                                                              │
│  ╭─────────────────╮  ││  H-07           41       —           Pass     Proven                                    ││     1135 ┤   ●                                                                   │
│  │ Answer          │  ││                                                                                         ││ best r7 1135 tok_s                                                               │
│  │ Prefill.        │  ││                                                                                         ││                                                                                  │
│  ╰─────────────────╯  ││                                                                                         ││                                                                                  │
│                       ││                                                                                         ││                                                                                  │
│                       ││ 1/1 · ↑↓ or scroll: select · Enter or /open-round: open its rounds                      ││                                                                                  │
╰───────────────────────╯╰─────────────────────────────────────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────────────────────────────╯
Ctrl+W to type here      Ctrl+W: switch pane · PgUp/PgDn: scroll focused pane · Esc on the pane: close it
╭─ Chat ────────────────╮╭─ Ask or command ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Type a question       ││ Type a question or /help                                                                                                                                                    │
╰───────────────────────╯╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

### Architecture

```mermaid
flowchart TD
    INPUT["client input"] --> PARSE[parseInput]
    PARSE -->|plain text| SEND["sendChat"]
    PARSE -->|/chat| OPEN["openChat"]
    PARSE -->|/perf · /history rounds| PANE["openPane"]
    DOCKED{"chatDocked(state)<br/>log is the view · terminal fits"}
    SEND --> DOCKED
    OPEN --> DOCKED
    DOCKED -->|yes| COL["answer lands in the chat column<br/>chatOpen stays false"]
    DOCKED -->|no| MODAL["chat opens over the view<br/>as before"]
    RENDER["app.ts render"] -->|measures terminal| FITS["controller.setChatDockFits"]
    FITS --> DOCKED
    COL --> ROW["main row: chat · log · right pane"]
    PANE --> ROW
    CTRLW["Ctrl+W"] --> CYCLE["cyclePaneFocus over the columns on screen"]
    CYCLE --> ROW
```

The chat transcript itself is untouched: one `chatConversation`, one agent, one queue. Docking changes where it is drawn and whether a modal opens, not what a question does or what comes back.

### Correctness properties

- On the landing view with room to dock, a typed question leaves `chatOpen` false, keeps `experimentLogVisible` true, and puts both the question and the answer in the chat column.
- Where the chat cannot dock, in a terminal too narrow or inside a hypothesis, a question opens the modal, so an answer is never written to a column that is not on screen.
- Asking from the landing view never changes the view. With the chat docked the table does not move; with the chat modal the table stays behind it, and the rounds strip, agent strip, and per-round transcript stay out of a view the operator did not open.
- Bare `/chat` while docked focuses the pane and opens nothing; `/chat <question>` sends the question and still opens nothing.
- The two inputs never overlap: the command input starts at exactly the column where the chat pane ends, and the command list is confined to the column it completes.
- Exactly one input holds the cursor. `Ctrl+W` moves it with the pane focus, the modal takes it back while it is open, and Enter goes to whichever box is focused rather than always to the command input.
- Text typed into the chat input reaches the agent through `submitChat`, so a slash command typed there still runs as a command.
- Enter opens the selected hypothesis only when both boxes are empty, so a question waiting in either one is never discarded by a keystroke meant to send it.
- `/chat` is absent from `/help` and from the completions on the landing view, present in both inside a hypothesis, and accepted either way.
- The transcript is continuous across surfaces: a question asked from the pop-up inside a hypothesis, question and answer both, is in the docked column after `Ctrl+L` returns to the table.
- The chat transcript is one conversation across all of it: docking, undocking, opening and closing a visualization, and stepping in and out of a hypothesis leave it intact.
- Docking never costs the table its claim column. For every terminal width at or above the dock threshold, the table keeps at least the width it needs for the claim; with a visualization open it keeps at least its compact column set.
- The chat column is never narrower than 28 columns or wider than 52, and it yields columns to a visualization before the table does.
- The table keeps its own keys while docked: arrows move the selection, Enter opens the selected hypothesis, and Page Up and Page Down move the selection unless the chat holds focus.
- `Ctrl+W` only ever lands on a column that is drawn, and focus falls back to the table when the dock stops fitting.
- Escape on the chat returns the keys to the table without closing anything; Escape on the right pane still closes the pane.
- `/help`, `/theme`, and errors are still modal, and the visualization pane's own fallback below 100 columns is unchanged.
- No protocol change: no request, response field, or event was added, removed, or reinterpreted, and the Python side is untouched.

### Testing

- `bun test --max-concurrency 1 src` in `clients/tui`: 269 pass, 1 fail, 270 tests across 15 files. The failure is in `launcher.test.ts`, fails identically on unmodified `origin/main` in a second worktree, and is environment-dependent: it shells out to the launcher.
- `pnpm --dir clients/tui check` (`tsc -p tsconfig.check.json`): clean.
- `pnpm --dir clients/tui build`: clean.
- `pnpm check:ts` (`biome check .`): clean across all 44 files.
- `uv run pytest tests/test_tui.py`: 32 passed. No Python file changed; this is the regression check for the protocol the client talks to.

New and changed tests:

| File | Test | Covers |
| --- | --- | --- |
| `ui/chat-pane.test.ts` | `docks only once the table can keep its claim column` | The dock threshold, including that 120 columns still belongs to the table alone |
| `ui/chat-pane.test.ts` | `docks beside a visualization out of the compact table width` | Three columns fit at 200; at 140 with a chart they do not |
| `ui/chat-pane.test.ts` | `never takes the table below the width it needs` | Every width from the threshold to 400, with and without a chart |
| `ui/chat-pane.test.ts` | `narrows itself rather than the table when a visualization opens` | Which surface yields columns first |
| `session-model.test.ts` | `docks beside the log and nowhere else` | Docked on the landing view, not inside a hypothesis |
| `session-model.test.ts` | `gives the pane the keys instead of opening a modal over the table` | `/chat` while docked |
| `session-model.test.ts` | `still opens the modal where the chat cannot dock` | The narrow-terminal fallback |
| `session-model.test.ts` | `cycles focus left to right through the columns on screen` | Three-region `Ctrl+W`, and focus after the pane closes |
| `session-model.test.ts` | `refuses focus for a column that is not on screen` | `focusPane` on a hidden column |
| `session-model.test.ts` | `hands the keys back to the log when the dock stops fitting` | Resize while the chat holds focus |
| `session-controller.test.ts` | `sends ordinary text to the chat docked beside the log` | The table survives a question |
| `session-controller.test.ts` | `opens the chat as a modal where it cannot dock` | Narrow terminal, reported by the renderer |
| `session-controller.test.ts` | `keeps the log as the view when the chat opens over it` | The regression: a question must not swap in the per-round transcript |
| `ui/app.test.ts` | `keeps the table behind the chat modal instead of the round transcript` | The same, in a rendered frame at 84 columns |
| `session-controller.test.ts` | `opens the chat as a modal inside a hypothesis`| Modal there, docked again after `Ctrl+L`, transcript intact |
| `session-controller.test.ts` | `keeps the docked chat beside the log while a visualization is open` | `/perf` plus a question, all three live |
| `ui/app.test.ts` | `lands with the chat docked beside the hypothesis table` | The rendered landing frame, claim column intact, and the command input starting exactly where the chat column ends |
| `ui/app.test.ts` | `routes typing to whichever input Ctrl+W points at` | A question typed after `Ctrl+W` reaches `submitChat`; a command typed after `Ctrl+W` back reaches `submit` |
| `ui/app.test.ts` | `raises the command list out of the command input, clear of the chat` | Suggestion box aligned to the command column |
| `ui/app.test.ts` | `says when the docked chat is waiting on the agent` | The instruction line as the pending indicator |
| `ui/app.test.ts` | `drops /chat from the command surface while the chat is already docked` | Typing `/c` on the landing view completes nothing |
| `commands.test.ts` | `drops /chat where the chat is already a pane of the view` | The list, the help text, and the completions |
| `commands.test.ts` | `still accepts /chat when it is not offered, since the chat is the point` | Hidden, not removed |
| `session-controller.test.ts` | `offers /chat in help only where the chat is not already on screen` | `/help` on the landing view and inside a hypothesis |
| `session-controller.test.ts` | `carries the modal conversation back into the docked pane` | Ask from the pop-up, step back out, find it in the column |
| `ui/app.test.ts` | `answers in the docked chat without covering the table` | A typed question and its answer beside the rows |
| `ui/app.test.ts` | `keeps the chat, the table, and the visualization on screen together` | The three-column frame |
| `ui/app.test.ts` | `gives the row to the table alone when the chat cannot fit beside it` | The narrow frame, and that the measurement reached the model |
| `ui/app.test.ts` | `moves the pane keys onto the docked chat and back with Ctrl+W` | Focus border and title in the frame |
| `ui/app.test.ts` | `leaves the table its own keys while the chat is docked` | Arrow keys still move the selection |