### PR TITLE
Trainium local fixes

### DIFF
--- a/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
@@ -208,12 +208,18 @@ class HostSandbox(WorkspaceSandbox):
 
 
 def _gpu_device_nodes() -> list[Path]:
-    """NVIDIA character devices to pass through (``--dev`` hides them otherwise)."""
+    """Accelerator character devices to pass through.
+
+    ``--dev`` mounts a minimal devtmpfs that omits every accelerator node, so
+    anything the agent must reach to exercise its own code has to be bound back
+    explicitly. That covers NVIDIA GPUs, DRI render nodes, and AWS Neuron
+    devices for the Trainium backend's local (non-Docker) path.
+    """
     dev = Path("/dev")
     if not dev.exists():
         return []
     nodes: list[Path] = []
-    for pattern in ("nvidia*", "nvidia-uvm*", "nvidia-caps"):
+    for pattern in ("nvidia*", "nvidia-uvm*", "nvidia-caps", "neuron*"):
         nodes.extend(sorted(dev.glob(pattern)))
     # ``/dev/dri`` (render nodes) for non-NVIDIA / integrated GPUs.
     dri = dev / "dri"

--- a/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
@@ -91,6 +91,11 @@ _SYSTEM_READ_ROOTS: tuple[str, ...] = (
     "/etc",
     "/opt",
     "/run/systemd/resolve",  # DNS via systemd-resolved
+    # Accelerator runtimes discover devices through sysfs before they ever
+    # touch the device node: without it the AWS Neuron runtime aborts in
+    # ``nrt_init`` and ``neuron-ls`` exits fatal, and CUDA's device query
+    # fails the same way. Read-only, so it exposes topology, not control.
+    "/sys",
 )
 
 # Read-only system roots the macOS dynamic linker and command-line tools need to

--- a/libs/vs-sandbox/tests/test_device_nodes.py
+++ b/libs/vs-sandbox/tests/test_device_nodes.py
@@ -1,0 +1,36 @@
+"""Tests for accelerator device passthrough into the bubblewrap namespace."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vs_sandbox import host_sandbox
+
+
+def _host_devices(pattern: str) -> list[Path]:
+    dev = Path("/dev")
+    return sorted(dev.glob(pattern)) if dev.exists() else []
+
+
+class TestAcceleratorDeviceNodes:
+    """``--dev`` mounts a minimal devtmpfs, so accelerators need rebinding.
+
+    Without this the agent can edit code for an accelerator it cannot run,
+    which fails as a confusing driver error rather than a policy error.
+    """
+
+    @pytest.mark.parametrize("pattern", ["neuron*", "nvidia*"])
+    def test_host_accelerator_devices_are_passed_through(self, pattern: str) -> None:
+        devices = _host_devices(pattern)
+        if not devices:
+            pytest.skip(f"host has no /dev/{pattern} devices")
+
+        nodes = host_sandbox._gpu_device_nodes()  # noqa: SLF001
+
+        assert set(devices).issubset(set(nodes))
+
+    def test_returns_paths_that_exist(self) -> None:
+        nodes = host_sandbox._gpu_device_nodes()  # noqa: SLF001
+        assert all(node.exists() for node in nodes)

--- a/src/vibesys/backends/trainium/__init__.py
+++ b/src/vibesys/backends/trainium/__init__.py
@@ -135,11 +135,26 @@ class TrainiumBackend:
         env = self._build_env(extra_env)
 
         if kind is SandboxKind.LOCAL:
+            # ``_build_env`` names the *container* cache and temp paths, which
+            # only exist because the Docker branch bind-mounts them. A local run
+            # has no such mounts: /opt is root-owned and read-only inside the
+            # agent sandbox, so neuronx-cc would fail to write either one.
+            # Redirect both under the run's log directory, which is writable.
+            host_cache = self.log_dir / "neuron-compile-cache"
+            host_tmp = self.log_dir / "neuron-tmp"
+            host_cache.mkdir(parents=True, exist_ok=True)
+            host_tmp.mkdir(parents=True, exist_ok=True)
+            local_env = {
+                **env,
+                "NEURON_COMPILE_CACHE_URL": str(host_cache),
+                "TMPDIR": str(host_tmp),
+            }
+            local_env.update(extra_env)
             return LocalShellBackend(
                 root_dir=host_workspace,
                 virtual_mode=True,
                 inherit_env=True,
-                env=env,
+                env=local_env,
             )
 
         if kind is SandboxKind.DOCKER:


### PR DESCRIPTION
Three fixes that make `--backend trainium` work without `--docker`. None touch the Docker path: the first two edit the bubblewrap host sandbox, which container executors skip (`cli_runner.py`: "Container executors above are already externally sandboxed and deliberately skip this"), and the third changes only the `SandboxKind.LOCAL` branch of `TrainiumBackend.make_sandbox`.

- **Pass `/dev/neuron*` through the bubblewrap namespace.** `_gpu_device_nodes()` only globbed NVIDIA nodes and `/dev/dri`, so a local trainium run hid the accelerator from the agent. New `test_device_nodes.py` asserts every host `/dev/neuron*` / `/dev/nvidia*` node is in the passthrough set.
- **Mount `/sys` read-only in the agent sandbox.** Accelerator runtimes discover devices through sysfs before touching the device node; without it the Neuron runtime aborts in `nrt_init` and `neuron-ls` exits fatal (CUDA's device query fails the same way). Read-only, so it exposes topology, not a control surface.
- **Use host paths for the Neuron compile cache on local runs.** `make_sandbox` built the env before branching on sandbox kind, so a LOCAL run inherited `NEURON_COMPILE_CACHE_URL=/opt/neuron-compile-cache` and `TMPDIR=/opt/neuron-tmp`, which only exist because the Docker branch bind-mounts them. Point both under the run's log directory, mirroring the Docker branch's host-side dirs.

Verified on a trn2.3xlarge (1 device, 4 logical cores, 96 GB): `neuron-ls` previously exited fatal under the sandbox and now reports the device with exit 0. `ruff`, `pyright`, and `pytest libs/vs-sandbox tests/backends tests/_agent_cli` (308 passed) are clean.