### PR TITLE
Pass reasoning effort to Claude Code, not only Codex

### DIFF
--- a/src/vibesys/_agent_cli/claude.py
+++ b/src/vibesys/_agent_cli/claude.py
@@ -144,6 +144,20 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
         if self.output_schema_json is not None:
             cmd.extend(["--json-schema", self.output_schema_json])
 
+    def set_reasoning_effort(self, effort: str) -> None:
+        """Apply a per-agent effort level to fresh and resumed turns.
+
+        Claude Code takes this as a session flag rather than a config override,
+        which is why it is stored and re-emitted per command instead of being
+        appended to a persistent argument list the way Codex does it.
+        """
+        self.reasoning_effort = effort
+
+    def _append_reasoning_effort(self, cmd: list[str]) -> None:
+        effort = getattr(self, "reasoning_effort", None)
+        if effort:
+            cmd.extend(["--effort", effort])
+
     def _get_command(self, prompt: str) -> list[str]:  # noqa: ARG002  # tracked: #288
         cmd = [
             self.binary_path,
@@ -155,6 +169,7 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
         ]
         if self.model:
             cmd.extend(["--model", self.model])
+        self._append_reasoning_effort(cmd)
         self._append_output_schema(cmd)
         return cmd
 
@@ -171,6 +186,7 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
         ]
         if self.model:
             cmd.extend(["--model", self.model])
+        self._append_reasoning_effort(cmd)
         self._append_output_schema(cmd)
         return cmd
 

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -70,6 +70,10 @@ class _ProviderFactory(Protocol):
     ) -> CodingAgent: ...
 
 
+# Providers whose CLI accepts a reasoning-effort level. Others silently
+# ignore the setting rather than failing, so the gate is explicit.
+_REASONING_EFFORT_PROVIDERS = frozenset({"codex", "claude"})
+
 _PROVIDER_CLASSES: dict[str, _ProviderFactory] = {
     "claude": ClaudeCodeCodingAgent,
     "gemini": GeminiCodingAgent,
@@ -344,7 +348,7 @@ class CliAgentRunner:
             kind, self._default_reasoning_effort
         )
         selected_reasoning_effort = (
-            configured_reasoning_effort if self._provider == "codex" else None
+            configured_reasoning_effort if self._provider in _REASONING_EFFORT_PROVIDERS else None
         )
         materialize_skills(
             workspace,
@@ -572,9 +576,17 @@ class CliAgentRunner:
         return text
 
     def _configure_reasoning_effort(self, agent: CodingAgent, reasoning_effort: str | None) -> None:
-        """Apply provider-specific reasoning controls to a newly built CLI agent."""
-        if self._provider == "codex" and reasoning_effort is not None:
-            cast("CodexCodingAgent", agent).set_reasoning_effort(reasoning_effort)
+        """Apply provider-specific reasoning controls to a newly built CLI agent.
+
+        Codex takes the level as a ``--config`` override and Claude Code as a
+        ``--effort`` session flag, but both expose the same
+        ``set_reasoning_effort`` hook, so the caller does not branch on which.
+        """
+        if reasoning_effort is None or self._provider not in _REASONING_EFFORT_PROVIDERS:
+            return
+        cast("CodexCodingAgent | ClaudeCodeCodingAgent", agent).set_reasoning_effort(
+            reasoning_effort
+        )
 
     def _write_usage_record(
         self,


### PR DESCRIPTION
`cli_runner.py` gated reasoning effort on `provider == "codex"`, so `[thinking].level` and `[agent].*.reasoning_effort` were silently dropped for every other CLI. The Claude Code adapter also never emitted an effort flag even though the CLI accepts `--effort`. Configuring `level = "high"` with `cli_provider = "claude"` therefore ran at the default effort with no warning.

Give `ClaudeCodeCodingAgent` the same `set_reasoning_effort` hook Codex has, emitting `--effort` on both fresh and resumed turns, and replace the codex-only check with an explicit `_REASONING_EFFORT_PROVIDERS` set. Codex takes the level as a `--config` override and Claude as a session flag, but both now expose the same hook so the caller does not branch on which.

Verified `--effort high` reaches the constructed argv. `ruff`, `pyright`, and `pytest tests/agents tests/_agent_cli` (405 passed) are clean.