### PR TITLE
Add an opt-in Landlock host sandbox for hosts without user namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ accuracy and performance results.
 ## Quickstart
 
 Install Python 3.12+, Git, and [uv](https://docs.astral.sh/uv/). Linux also
-requires `bubblewrap`; macOS includes the required `sandbox-exec` command. Then
+requires `bubblewrap`, and a kernel that lets it create an unprivileged user
+namespace; macOS includes the required `sandbox-exec` command. Where user
+namespaces are blocked and installing bubblewrap needs root you do not have,
+`VIBESYS_AGENT_SANDBOX=landlock` selects a weaker but root-free backend (see
+the [CLI reference](docs/cli-flags.md) for what it stops enforcing). Then
 install VibeSys:
 
 ```bash

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -86,13 +86,31 @@ compatibility path.
 
 The native sandbox requires `bwrap` on Linux or `sandbox-exec` on macOS. A
 missing confinement tool or an unsupported operating system stops the run
-rather than launching the agent without isolation. Evaluator, checker, and
-benchmark paths are visible to agents but enforced read-only and protected by
-integrity checks. The agent also cannot write `.git`, `.vibesys`, legacy
-root-level task inputs, or `_evaluator/`, and cannot read
+rather than launching the agent without isolation. On Linux `bwrap` must also
+be able to create a user namespace; a present but blocked binary is treated as
+missing and reported at startup rather than failing once per round. Evaluator,
+checker, and benchmark paths are visible to agents but enforced read-only and
+protected by integrity checks. The agent also cannot write `.git`, `.vibesys`,
+legacy root-level task inputs, or `_evaluator/`, and cannot read
 `.vibesys/state/local/`, root `.env*` files, or root `agent.toml`. A run is
 rejected when a root `.env*` file or `agent.toml` is recoverable from Git refs
 or reflogs.
+
+`VIBESYS_AGENT_SANDBOX` selects the Linux mechanism. `auto` (the default) and
+`bwrap` both require bubblewrap. `landlock` opts in to a weaker backend for
+hosts that block unprivileged user namespaces, which is the common reason
+bubblewrap cannot run without root (for example Ubuntu's
+`kernel.apparmor_restrict_unprivileged_userns`). The Landlock backend keeps the
+outer boundary — the project is writable and the rest of the host is denied for
+both read and write — but Landlock rules only ever add access, so it cannot
+carve a restriction out of the writable project. Read-only and hidden project
+paths are therefore *not* enforced under it, and each unenforced tier is logged
+at startup. Evaluator-input integrity still holds, because the accuracy gate
+independently diffs those paths against a trusted baseline and fails the round.
+Landlock is never selected automatically, and a project that sits inside a tree
+the backend must grant (such as `/tmp`) is refused rather than run unconfined.
+Set the variable to `0`/`false`/`off`/`no` to disable confinement entirely; any
+other value is rejected.
 
 VibeSys initializes Git when needed and creates one `vibesys-runs/<run-id>` branch
 per run. Agent-authored source stays at its normal project paths. Portable and
@@ -290,7 +308,7 @@ starts with an actionable error.
 
 | Flags | Environment | Notes |
 | --- | --- | --- |
-| neither `--docker` nor `--modal` | Local host. | Requires bubblewrap on Linux or Seatbelt on macOS. Enforces the project path policy. |
+| neither `--docker` nor `--modal` | Local host. | Requires bubblewrap on Linux or Seatbelt on macOS. Enforces the project path policy. `VIBESYS_AGENT_SANDBOX=landlock` trades the nested read-only and hidden tiers for a backend that runs without user namespaces. |
 | `--docker` | Docker container. | Mounts the project with the same hidden and read-only overlays. Backend controls GPU/device passthrough. |
 | `--modal` | Modal workflow. | Mutually exclusive with `--docker`. Intended for remote GPU dispatch. |
 

--- a/libs/vs-sandbox/src/vs_sandbox/__init__.py
+++ b/libs/vs-sandbox/src/vs_sandbox/__init__.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     )
     from vs_sandbox.host_sandbox import (
         HostSandbox,
+        LandlockSandbox,
+        LinuxBackend,
         SandboxUnavailableError,
         SeatbeltSandbox,
         WorkspaceSandbox,
@@ -39,6 +41,8 @@ __all__ = [
     "HostResourceContext",
     "HostResourceDeclarer",
     "HostSandbox",
+    "LandlockSandbox",
+    "LinuxBackend",
     "ModalSandbox",
     "ProjectPathPolicy",
     "ProjectPathPolicyError",
@@ -68,6 +72,8 @@ def __getattr__(name: str) -> Any:  # noqa: ANN401  # tracked: #288
         return getattr(host_resources, name)
     if name in {
         "HostSandbox",
+        "LandlockSandbox",
+        "LinuxBackend",
         "SandboxUnavailableError",
         "SeatbeltSandbox",
         "WorkspaceSandbox",

--- a/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/host_sandbox.py
@@ -20,12 +20,17 @@ Everything else, including the project's *parent* and sibling projects, is
 denied, so absolute-path traversal outside the project fails. Network is left
 open so the agent can still reach its model provider.
 
-Two host backends implement the same ``wrap(argv) -> argv`` contract, selected
-by platform:
+Three host backends implement the same ``wrap(argv) -> argv`` contract,
+selected by platform and, on Linux, by operator choice:
 
-* **Linux** — :class:`HostSandbox`, a `bubblewrap <https://github.com/
+* **Linux, default** — :class:`HostSandbox`, a `bubblewrap <https://github.com/
   containers/bubblewrap>`_ (``bwrap``) mount namespace. Denied paths are simply
-  absent from the namespace, so traversal fails with ``ENOENT``.
+  absent from the namespace, so traversal fails with ``ENOENT``. This is the
+  only backend that enforces the full :class:`ProjectPathPolicy`.
+* **Linux, opt-in** — :class:`LandlockSandbox`, for hosts where bubblewrap
+  cannot run because unprivileged user namespaces are blocked. It enforces the
+  outer project boundary but not the nested read-only and hidden tiers, so it
+  is never selected automatically.
 * **macOS** — :class:`SeatbeltSandbox`, a Seatbelt (``sandbox-exec``) profile
   with ``(deny default)`` and an explicit read/write allowlist.
 
@@ -38,7 +43,10 @@ Operator controls (read from the agent's environment):
 ``VIBESYS_AGENT_SANDBOX``
     Set to ``0``/``false``/``off``/``no`` to disable host confinement (e.g. for
     debugging, or on a host whose toolchain layout the default allowlist does
-    not cover). Disabling is logged loudly.
+    not cover). Disabling is logged loudly. On Linux it also selects the
+    mechanism: ``auto`` (default) and ``bwrap`` require bubblewrap, while
+    ``landlock`` opts in to the weaker :class:`LandlockSandbox`. An
+    unrecognized value is rejected rather than treated as the default.
 
 Resource discovery and policy are deliberately outside this module. The caller
 passes declarations through the public resource SDK; this consumer only
@@ -47,13 +55,16 @@ validates them and implements their requested access.
 
 from __future__ import annotations
 
+import enum
 import shutil
+import subprocess
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from vs_sandbox import landlock
 from vs_sandbox.host_resource_importer import prepare_host_resource_imports
 from vs_sandbox.host_resources import HostResource  # noqa: TC001  # tracked: #288
 from vs_sandbox.project_paths import ProjectPathPolicy
@@ -61,6 +72,23 @@ from vs_sandbox.project_paths import ProjectPathPolicy
 DISABLE_ENV = "VIBESYS_AGENT_SANDBOX"
 
 _DISABLED_VALUES = frozenset({"0", "false", "off", "no"})
+
+
+class LinuxBackend(enum.StrEnum):
+    """Which Linux confinement mechanism ``VIBESYS_AGENT_SANDBOX`` selects.
+
+    The same variable that disables confinement also chooses the mechanism, so
+    operators have one knob rather than two that can disagree.
+    """
+
+    #: Default. Bubblewrap only; fail closed if it is missing or unusable.
+    AUTO = "auto"
+    #: Bubblewrap, stated explicitly. Identical to :attr:`AUTO` today, but says
+    #: so, and keeps saying so if the default ever changes.
+    BWRAP = "bwrap"
+    #: Landlock. Opt-in because it cannot enforce the nested project policy;
+    #: see :class:`LandlockSandbox` for exactly what it drops.
+    LANDLOCK = "landlock"
 
 
 class SandboxUnavailableError(RuntimeError):
@@ -93,6 +121,19 @@ _SYSTEM_READ_ROOTS: tuple[str, ...] = (
     "/run/systemd/resolve",  # DNS via systemd-resolved
 )
 
+# Writable scratch and device roots for the Landlock backend. Bubblewrap gets
+# these for free from ``--dev``/``--tmpfs``; Landlock cannot mount, so they are
+# granted in place and the host's ``/tmp`` is shared rather than private.
+# Discretionary permissions still apply on top, so granting ``/proc`` and
+# ``/dev`` does not hand the agent anything its uid could not already reach.
+_LINUX_SCRATCH_WRITE_ROOTS: tuple[str, ...] = (
+    "/dev",
+    "/proc",
+    "/tmp",  # noqa: S108  # tracked: #288
+    "/var/tmp",  # noqa: S108  # tracked: #288
+)
+
+
 # Read-only system roots the macOS dynamic linker and command-line tools need to
 # launch anything at all. Kept deliberately broad on the *system* side (dyld,
 # frameworks, config) while the project's parent and siblings stay denied
@@ -123,12 +164,17 @@ def _is_disabled(env: dict[str, str]) -> bool:
 class WorkspaceSandbox(ABC):
     """A host confinement policy for a single canonical project.
 
-    Both OS backends are built by :func:`build` from the same inputs: the
-    project plus the read/write allowlists computed from resource declarations.
-    They expose the same ``wrap(argv) -> argv`` contract consumed at the process
-    launch chokepoint. Subclasses differ only
-    in the OS mechanism they emit: :class:`HostSandbox` a bubblewrap namespace,
-    :class:`SeatbeltSandbox` a ``sandbox-exec`` profile.
+    Every backend is built by :func:`build` from the same inputs: the project
+    plus the read/write allowlists computed from resource declarations. They
+    expose the same ``wrap(argv) -> argv`` contract consumed at the process
+    launch chokepoint, and differ in the OS mechanism they emit:
+    :class:`HostSandbox` a bubblewrap namespace, :class:`SeatbeltSandbox` a
+    ``sandbox-exec`` profile, :class:`LandlockSandbox` a Landlock ruleset.
+
+    The mechanisms are not equally strong. Only :class:`HostSandbox` enforces
+    every tier of :attr:`project_path_policy`; the others document what they
+    cannot express, so callers must not assume the contract is fully enforced
+    just because a sandbox was returned.
     """
 
     workspace: Path
@@ -220,6 +266,117 @@ def _gpu_device_nodes() -> list[Path]:
     if dri.exists():
         nodes.append(dri)
     return nodes
+
+
+@dataclass(frozen=True)
+class LandlockSandbox(WorkspaceSandbox):
+    """A Linux Landlock policy for a canonical project, for hosts without bwrap.
+
+    Landlock needs neither root nor an unprivileged user namespace, so it is
+    the only host confinement left when ``CLONE_NEWUSER`` is denied (Ubuntu's
+    ``kernel.apparmor_restrict_unprivileged_userns``, most commonly). It is
+    strictly weaker than :class:`HostSandbox` and is never selected
+    automatically; the operator opts in with ``VIBESYS_AGENT_SANDBOX=landlock``.
+
+    **Enforced.** The outer boundary, which is the escape from issue #149: the
+    project is read-write, declared host resources get their declared access,
+    system roots are read-only, and every other host path is denied for both
+    read and write. The project's parent and siblings are unreachable.
+
+    **Not enforced**, because Landlock rules only ever add rights and so cannot
+    carve a restriction out of a granted tree (see :mod:`vs_sandbox.landlock`):
+
+    * ``ProjectPathPolicy.read_only_paths`` — the agent may modify ``.git``,
+      ``.vibesys``, and task inputs. VibeSys's accuracy gate independently
+      diffs those paths against a trusted baseline and fails the round, so this
+      is downgraded from prevention to detection rather than lost outright.
+    * ``ProjectPathPolicy.hidden_paths`` — the agent may read ``agent.toml``,
+      root ``.env*``, and ``.vibesys/state/local``. Keep provider credentials
+      out of the project directory on such a host.
+
+    Residual channels, all verified by probing a live ruleset:
+
+    * ``/tmp`` and ``/var/tmp`` are the host's rather than a private tmpfs, so
+      scratch files are visible to other users of a shared machine.
+    * No PID namespace is unshared, so ``/proc/<pid>/cmdline`` of other
+      processes owned by the same user stays readable. Their ``environ``,
+      ``cwd``, and ``fd`` targets do not: those need ptrace-level access, and
+      reads through the ``/proc`` magic links resolve to the real path and are
+      denied by the rules.
+    * Network is open, as it is under bubblewrap, so anything readable is also
+      exfiltratable and cloud instance-metadata endpoints are reachable.
+
+    On ABI 6 and later, signals and abstract unix sockets are scoped, which
+    closes two routes to making an unconfined process act on the agent's
+    behalf. Bubblewrap blocks the first with ``--unshare-pid`` and leaves the
+    second open, so scoping puts this backend slightly ahead there.
+    """
+
+    system_read_roots: tuple[str, ...] = _SYSTEM_READ_ROOTS
+    scratch_write_roots: tuple[str, ...] = _LINUX_SCRATCH_WRITE_ROOTS
+
+    def unenforced_policy(self) -> tuple[str, ...]:
+        """Return human-readable policy tiers this backend cannot enforce."""
+        policy = self.project_path_policy
+        unenforced: list[str] = []
+        if policy.read_only_paths:
+            unenforced.append(
+                "read-only paths remain writable: "
+                + ", ".join(str(path) for path in policy.read_only_paths)
+            )
+        if policy.hidden_paths:
+            unenforced.append(
+                "hidden paths remain readable: "
+                + ", ".join(str(path) for path in policy.hidden_paths)
+            )
+        return tuple(unenforced)
+
+    def policy(self) -> landlock.LandlockPolicy:
+        """Return the Landlock ruleset this policy compiles to.
+
+        Raises:
+            SandboxUnavailableError: If a tree that must be granted write
+                access contains the project. Because rules only add rights,
+                such a grant reaches the project too and there is no way to
+                take it back, so the run must not proceed believing itself
+                confined.
+        """
+        workspace = self.workspace.resolve()
+        write_roots = (
+            *(Path(root) for root in self.scratch_write_roots),
+            *self.write_paths,
+        )
+        for root in write_roots:
+            resolved = root.resolve()
+            if resolved == workspace or resolved in workspace.parents:
+                raise SandboxUnavailableError(  # noqa: TRY003  # tracked: #288
+                    f"project {workspace} sits inside {resolved}, which the Landlock "
+                    "backend must grant write access to. Landlock rules cannot subtract, "
+                    "so the project would be effectively unconfined. Move the project "
+                    "outside that tree, or use bubblewrap or --docker."
+                )
+        return landlock.policy_for(
+            read_paths=(
+                *(Path(root) for root in self.system_read_roots),
+                *self.read_paths,
+            ),
+            # The project is granted last for readability only; Landlock unions
+            # overlapping grants, so order carries no meaning.
+            write_paths=(*write_roots, workspace),
+            chdir=workspace,
+        )
+
+    def wrap(self, argv: list[str]) -> list[str]:
+        """Return *argv* wrapped so it runs under this Landlock ruleset."""
+        return [
+            sys.executable,
+            "-m",
+            landlock.__name__,
+            "--policy",
+            self.policy().model_dump_json(),
+            "--",
+            *argv,
+        ]
 
 
 def _sbpl_string(value: str) -> str:
@@ -432,15 +589,74 @@ def _unavailable(
         raise SandboxUnavailableError(message)
 
 
+def _requested_linux_backend(env: dict[str, str]) -> LinuxBackend:
+    """Return the operator's ``VIBESYS_AGENT_SANDBOX`` backend choice."""
+    raw = env.get(DISABLE_ENV, "").strip().lower()
+    if not raw:
+        return LinuxBackend.AUTO
+    try:
+        return LinuxBackend(raw)
+    except ValueError:
+        # ``_is_disabled`` already consumed the off switches, so anything left
+        # over is a typo. Naming it beats silently confining with the default.
+        raise SandboxUnavailableError(
+            f"unknown {DISABLE_ENV} value {raw!r}; expected one of "
+            + ", ".join(sorted(member.value for member in LinuxBackend))
+            + ", or an off switch ("
+            + ", ".join(sorted(_DISABLED_VALUES))
+            + ")"
+        ) from None
+
+
+def _bwrap_confines(bwrap: str) -> bool:
+    """Return whether *bwrap* can actually create a namespace on this host.
+
+    A present-but-blocked ``bwrap`` is a real configuration: Ubuntu's
+    ``kernel.apparmor_restrict_unprivileged_userns`` denies the uid-map write
+    unless the binary is the distro's own ``/usr/bin/bwrap``, so a copy
+    unpacked elsewhere exits non-zero at launch. Probing here turns that into
+    one clear startup error instead of an agent that dies every round.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603  # tracked: #288
+            [bwrap, "--ro-bind", "/", "/", "--unshare-user", "--", "/bin/true"],
+            capture_output=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
 def _build_linux(
     workspace: Path,
     options: _BuildOptions,
-) -> HostSandbox | None:
-    bwrap = shutil.which("bwrap", path=options.env.get("PATH")) or shutil.which("bwrap")
-    if not bwrap:
+) -> WorkspaceSandbox | None:
+    requested = _requested_linux_backend(options.env)
+    read_paths, write_paths = _resource_paths(workspace, options.log, options.resources)
+
+    if requested is not LinuxBackend.LANDLOCK:
+        bwrap = shutil.which("bwrap", path=options.env.get("PATH")) or shutil.which("bwrap")
+        if bwrap and _bwrap_confines(bwrap):
+            return HostSandbox(
+                bwrap_path=bwrap,
+                workspace=workspace,
+                read_paths=tuple(read_paths),
+                write_paths=tuple(write_paths),
+                project_path_policy=options.project_path_policy,
+                gpu_device_nodes=tuple(_gpu_device_nodes()),
+            )
+        reason = (
+            f"'bwrap' at {bwrap} cannot create a user namespace"
+            if bwrap
+            else "'bwrap' not found on PATH"
+        )
         message = (
-            "[hostsandbox] 'bwrap' not found on PATH; agent runs unconfined. "
-            "Install bubblewrap or use --docker for an externally sandboxed run."
+            f"[hostsandbox] {reason}; agent runs unconfined. Install bubblewrap, "
+            f"use --docker for an externally sandboxed run, or set "
+            f"{DISABLE_ENV}={LinuxBackend.LANDLOCK} to accept the weaker "
+            f"Landlock backend (it cannot enforce read-only or hidden project paths)."
         )
         return _unavailable(
             message,
@@ -448,15 +664,34 @@ def _build_linux(
             log=options.log,
         )
 
-    read_paths, write_paths = _resource_paths(workspace, options.log, options.resources)
-    return HostSandbox(
-        bwrap_path=bwrap,
+    if landlock.abi_version() is None:
+        message = (
+            f"[hostsandbox] {DISABLE_ENV}={LinuxBackend.LANDLOCK} requested but this "
+            "kernel does not support Landlock; agent runs unconfined."
+        )
+        return _unavailable(
+            message,
+            require_enforcement=options.require_enforcement,
+            log=options.log,
+        )
+
+    sandbox = LandlockSandbox(
         workspace=workspace,
         read_paths=tuple(read_paths),
         write_paths=tuple(write_paths),
         project_path_policy=options.project_path_policy,
-        gpu_device_nodes=tuple(_gpu_device_nodes()),
+        scratch_write_roots=_LINUX_SCRATCH_WRITE_ROOTS,
     )
+    # Compile eagerly so an unconfinable project layout is one clear error at
+    # startup rather than a surprise on the first agent turn.
+    sandbox.policy()
+    options.log(
+        f"[hostsandbox] Landlock backend (ABI {landlock.abi_version()}); the project "
+        "is writable and the rest of the host is denied."
+    )
+    for gap in sandbox.unenforced_policy():
+        options.log(f"[hostsandbox] NOT ENFORCED by Landlock: {gap}")
+    return sandbox
 
 
 def _build_macos(

--- a/libs/vs-sandbox/src/vs_sandbox/landlock.py
+++ b/libs/vs-sandbox/src/vs_sandbox/landlock.py
@@ -1,0 +1,440 @@
+r"""Unprivileged filesystem confinement via the Linux Landlock LSM.
+
+Landlock (kernel 5.13+) lets an *unprivileged* process restrict its own
+filesystem access, and every process it later spawns inherits the restriction
+irreversibly. Unlike bubblewrap it needs neither root nor an unprivileged user
+namespace, so it is the one host confinement mechanism still available where
+``CLONE_NEWUSER`` is blocked. Ubuntu's
+``kernel.apparmor_restrict_unprivileged_userns`` is the common case: it denies
+the uid-map write for any binary without an AppArmor profile granting
+``userns``, which the distro ships only for ``/usr/bin/bwrap`` itself.
+
+This module has two roles, kept together because they share one contract:
+
+* :func:`restrict` applies a :class:`LandlockPolicy` to the current process.
+* ``python -m vs_sandbox.landlock --policy JSON -- COMMAND ...`` applies a
+  policy and then ``execvp``\\ s the command. That is the argv
+  :meth:`~vs_sandbox.host_sandbox.LandlockSandbox.wrap` emits.
+
+Two properties decide what this backend can and cannot enforce:
+
+* Landlock is an access check, not a namespace. A denied path still exists and
+  still ``stat``\\ s; only the ``open`` fails, with ``EACCES``.
+* **Rules are additive.** A rule grants rights over a whole hierarchy, and a
+  rule on a nested path can only *add* rights, never remove them. Granting the
+  workspace ``WRITE_FILE`` therefore grants it to every descendant, and no
+  nested rule can take it back. Stacking rulesets does not help: each layer is
+  itself additive, so the layer that must grant ``MAKE_REG`` on the project
+  root to let the agent create files there grants it throughout the subtree.
+
+The practical consequence is that this backend enforces the *outer* boundary
+(the project is writable, the rest of the host is not) and cannot express the
+nested read-only or hidden tiers of a
+:class:`~vs_sandbox.project_paths.ProjectPathPolicy`. Those need bubblewrap's
+mount overlays. See :class:`~vs_sandbox.host_sandbox.LandlockSandbox`, which
+reports the tiers it leaves unenforced rather than dropping them silently.
+
+Two access types are deliberately left unhandled, so the kernel does not
+restrict them at all:
+
+``LANDLOCK_ACCESS_FS_IOCTL_DEV`` (ABI 5)
+    Handling it would deny ``ioctl`` on every device node not explicitly
+    granted, breaking terminals and accelerator devices (``/dev/neuron*``,
+    ``/dev/nvidia*``). Bubblewrap does not filter ioctls either, so leaving it
+    unhandled is the parity choice.
+
+network access (ABI 4)
+    Network stays open on both backends so the agent can reach its model
+    provider. Filesystem confinement is what blocks the escape.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import enum
+import os
+import platform
+import stat
+import sys
+from ctypes import c_int, c_long, c_size_t, c_uint32, c_uint64
+from pathlib import Path  # noqa: TC003  # tracked: #288
+
+from pydantic import BaseModel, ConfigDict
+
+# ``linux/landlock.h``. Bits 0-12 are ABI 1; REFER is ABI 2, TRUNCATE ABI 3.
+_ABI_REFER = 2
+_ABI_TRUNCATE = 3
+_ABI_SCOPED = 6
+
+# ``LANDLOCK_SCOPE_*`` (ABI 6). Scoping closes two channels that bypass the
+# filesystem entirely, and that bubblewrap also leaves open because it shares
+# the network namespace: abstract unix sockets are addressed by name rather
+# than by path, and signals reach any process of the same uid. Both let a
+# confined agent reach an *unconfined* process and ask it to act.
+_LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET = 1 << 0
+_LANDLOCK_SCOPE_SIGNAL = 1 << 1
+
+# Landlock's three syscalls landed together in the generic syscall table, so
+# these numbers hold for every architecture that adopted it at that revision.
+# Architectures with bespoke numbering (alpha, mips, ...) are refused rather
+# than guessed, because a wrong number calls an unrelated syscall.
+_SYSCALL_NUMBERS: dict[str, tuple[int, int, int]] = dict.fromkeys(
+    ("x86_64", "aarch64", "riscv64", "ppc64le", "s390x", "armv7l", "armv8l"),
+    (444, 445, 446),
+)
+
+_PR_SET_NO_NEW_PRIVS = 38
+_LANDLOCK_CREATE_RULESET_VERSION = 1 << 0
+_LANDLOCK_RULE_PATH_BENEATH = 1
+
+
+class LandlockUnavailableError(RuntimeError):
+    """Raised when Landlock cannot confine this process on this host."""
+
+
+class AccessFS(enum.IntFlag):
+    """``LANDLOCK_ACCESS_FS_*`` bits from ``linux/landlock.h``."""
+
+    EXECUTE = 1 << 0
+    WRITE_FILE = 1 << 1
+    READ_FILE = 1 << 2
+    READ_DIR = 1 << 3
+    REMOVE_DIR = 1 << 4
+    REMOVE_FILE = 1 << 5
+    MAKE_CHAR = 1 << 6
+    MAKE_DIR = 1 << 7
+    MAKE_REG = 1 << 8
+    MAKE_SOCK = 1 << 9
+    MAKE_FIFO = 1 << 10
+    MAKE_BLOCK = 1 << 11
+    MAKE_SYM = 1 << 12
+    REFER = 1 << 13
+    TRUNCATE = 1 << 14
+
+
+_READ_BITS = AccessFS.EXECUTE | AccessFS.READ_FILE | AccessFS.READ_DIR
+_WRITE_BITS = (
+    AccessFS.WRITE_FILE
+    | AccessFS.REMOVE_DIR
+    | AccessFS.REMOVE_FILE
+    | AccessFS.MAKE_CHAR
+    | AccessFS.MAKE_DIR
+    | AccessFS.MAKE_REG
+    | AccessFS.MAKE_SOCK
+    | AccessFS.MAKE_FIFO
+    | AccessFS.MAKE_BLOCK
+    | AccessFS.MAKE_SYM
+    | AccessFS.REFER
+    | AccessFS.TRUNCATE
+)
+
+
+class RuleAccess(enum.StrEnum):
+    """Access tier granted over one hierarchy.
+
+    There is deliberately no "hidden" tier. Because rules only ever add rights,
+    a path is denied by *omitting* it, which works only when no granted tree
+    contains it. A path nested inside a granted tree cannot be taken back.
+    """
+
+    #: Read, write, create, and delete. Comparable to bubblewrap ``--bind``.
+    FULL = "full"
+    #: Read and execute only. Comparable to bubblewrap ``--ro-bind``, but only
+    #: for a tree that no other rule already grants write access to.
+    READ = "read"
+
+
+_ACCESS_BITS: dict[RuleAccess, AccessFS] = {
+    RuleAccess.FULL: _READ_BITS | _WRITE_BITS,
+    RuleAccess.READ: _READ_BITS,
+}
+
+# Rights that mean something for a non-directory. Granting any of the others on
+# a regular file makes ``landlock_add_rule`` fail with ``EINVAL`` rather than
+# ignoring them, so a file rule is masked down to these.
+_FILE_BITS = AccessFS.EXECUTE | AccessFS.WRITE_FILE | AccessFS.READ_FILE | AccessFS.TRUNCATE
+
+
+class LandlockRule(BaseModel):
+    """One path and the access tier granted beneath it."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    path: str
+    access: RuleAccess
+
+
+class LandlockPolicy(BaseModel):
+    """A complete ruleset, serialized across the ``wrap()`` process boundary.
+
+    Rule order does not matter, and not because a nested rule wins: rights from
+    every rule covering a path are unioned, so the result is order-independent.
+    Overlapping rules widen access rather than narrowing it, which is why
+    callers must keep granted trees disjoint to keep a path denied.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    rules: tuple[LandlockRule, ...] = ()
+    chdir: str | None = None
+
+
+def _libc() -> ctypes.CDLL:
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.syscall.restype = c_long
+    libc.prctl.restype = c_int
+    return libc
+
+
+def _syscall_numbers() -> tuple[int, int, int]:
+    machine = platform.machine()
+    numbers = _SYSCALL_NUMBERS.get(machine)
+    if numbers is None:
+        raise LandlockUnavailableError(  # noqa: TRY003  # tracked: #288
+            f"no known Landlock syscall numbers for architecture {machine!r}"
+        )
+    return numbers
+
+
+def abi_version() -> int | None:
+    """Return the kernel's Landlock ABI version, or ``None`` if unsupported.
+
+    ``None`` covers every reason the LSM cannot be used: a pre-5.13 kernel, a
+    kernel built without Landlock, a boot that left it out of the active LSM
+    list, and an architecture whose syscall numbers we refuse to guess.
+    """
+    if sys.platform != "linux":
+        return None
+    try:
+        create, _add, _restrict = _syscall_numbers()
+    except LandlockUnavailableError:
+        return None
+    libc = _libc()
+    version = libc.syscall(
+        c_long(create),
+        ctypes.c_void_p(None),
+        c_size_t(0),
+        c_uint32(_LANDLOCK_CREATE_RULESET_VERSION),
+    )
+    if version <= 0:
+        return None
+    return int(version)
+
+
+def _handled_access(abi: int) -> AccessFS:
+    """Return the access bits to govern, masked to what *abi* understands.
+
+    Handling a bit the kernel does not know makes ``landlock_create_ruleset``
+    fail with ``EINVAL``, so newer rights are dropped on older kernels. The
+    cost of dropping one is that the kernel stops mediating that operation:
+    without TRUNCATE, ``ftruncate`` on a read-only path is not denied.
+    """
+    handled = _ACCESS_BITS[RuleAccess.FULL]
+    if abi < _ABI_TRUNCATE:
+        handled &= ~AccessFS.TRUNCATE
+    if abi < _ABI_REFER:
+        handled &= ~AccessFS.REFER
+    return handled
+
+
+class _RulesetAttr(ctypes.Structure):
+    """``struct landlock_ruleset_attr``, truncated to its filesystem field.
+
+    Passing ``sizeof`` of just the first field tells the kernel to read only
+    ``handled_access_fs``, which keeps one struct valid on every pre-ABI-6
+    kernel that has not yet appended the network and scoping fields.
+    """
+
+    _fields_ = (("handled_access_fs", c_uint64),)
+
+
+class _ScopedRulesetAttr(ctypes.Structure):
+    """``struct landlock_ruleset_attr`` including the ABI 6 ``scoped`` field.
+
+    ``handled_access_net`` stays zero: network access is deliberately
+    unrestricted so the agent can reach its model provider.
+    """
+
+    _fields_ = (
+        ("handled_access_fs", c_uint64),
+        ("handled_access_net", c_uint64),
+        ("scoped", c_uint64),
+    )
+
+
+class _PathBeneathAttr(ctypes.Structure):
+    """``struct landlock_path_beneath_attr``, which the kernel declares packed."""
+
+    _pack_ = 1
+    _fields_ = (("allowed_access", c_uint64), ("parent_fd", c_int))
+
+
+def supports_scoping() -> bool:
+    """Return whether this kernel can scope signals and abstract unix sockets.
+
+    Those are the two channels a confined process could otherwise use to make
+    an unconfined one act for it. Scoping arrived in ABI 6; below that they
+    stay open, which is also where bubblewrap sits for abstract sockets.
+    """
+    abi = abi_version()
+    return abi is not None and abi >= _ABI_SCOPED
+
+
+def _ruleset_attr(abi: int, handled: AccessFS) -> ctypes.Structure:
+    """Return the ruleset attribute struct this kernel's ABI understands.
+
+    On ABI 6 and later the struct carries ``scoped``, which closes the two
+    non-filesystem channels a confined process could otherwise use to reach an
+    unconfined one. Older kernels get the truncated filesystem-only struct and
+    keep those channels open, exactly as bubblewrap does.
+    """
+    if abi < _ABI_SCOPED:
+        return _RulesetAttr(handled_access_fs=c_uint64(int(handled)))
+    return _ScopedRulesetAttr(
+        handled_access_fs=c_uint64(int(handled)),
+        handled_access_net=c_uint64(0),
+        scoped=c_uint64(_LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET | _LANDLOCK_SCOPE_SIGNAL),
+    )
+
+
+def restrict(policy: LandlockPolicy) -> int:
+    """Apply *policy* to the current process and return the ABI version used.
+
+    The restriction covers this process and every descendant, and cannot be
+    lifted. Rules naming a path that does not exist are skipped, matching
+    bubblewrap's ``--ro-bind-try`` tolerance for host layouts that vary.
+
+    Raises:
+        LandlockUnavailableError: If the kernel cannot enforce the policy. The
+            caller must treat this as fail-closed; a partially applied ruleset
+            is never left in place, because ``landlock_restrict_self`` is the
+            single point where anything takes effect.
+    """
+    abi = abi_version()
+    if abi is None:
+        raise LandlockUnavailableError(  # noqa: TRY003  # tracked: #288
+            "kernel does not support Landlock"
+        )
+    create, add_rule, restrict_self = _syscall_numbers()
+    libc = _libc()
+
+    handled = _handled_access(abi)
+    attr = _ruleset_attr(abi, handled)
+    ruleset_fd = libc.syscall(
+        c_long(create),
+        ctypes.byref(attr),
+        c_size_t(ctypes.sizeof(attr)),
+        c_uint32(0),
+    )
+    if ruleset_fd < 0:
+        raise LandlockUnavailableError(  # noqa: TRY003  # tracked: #288
+            f"landlock_create_ruleset failed: {os.strerror(ctypes.get_errno())}"
+        )
+
+    try:
+        for rule in policy.rules:
+            _add_path_rule(libc, add_rule, int(ruleset_fd), rule, handled=handled)
+        if libc.prctl(c_int(_PR_SET_NO_NEW_PRIVS), c_long(1), c_long(0), c_long(0), c_long(0)) != 0:
+            raise LandlockUnavailableError(  # noqa: TRY003  # tracked: #288
+                f"prctl(PR_SET_NO_NEW_PRIVS) failed: {os.strerror(ctypes.get_errno())}"
+            )
+        if libc.syscall(c_long(restrict_self), c_int(int(ruleset_fd)), c_uint32(0)) != 0:
+            raise LandlockUnavailableError(  # noqa: TRY003  # tracked: #288
+                f"landlock_restrict_self failed: {os.strerror(ctypes.get_errno())}"
+            )
+    finally:
+        os.close(int(ruleset_fd))
+    return abi
+
+
+def _add_path_rule(
+    libc: ctypes.CDLL,
+    syscall_number: int,
+    ruleset_fd: int,
+    rule: LandlockRule,
+    *,
+    handled: AccessFS,
+) -> None:
+    """Add one ``PATH_BENEATH`` rule, skipping paths absent from this host."""
+    try:
+        parent_fd = os.open(rule.path, os.O_PATH | os.O_CLOEXEC)
+    except OSError:
+        return
+    try:
+        # Granting a right the ruleset does not handle is EINVAL, so the tier's
+        # bits are masked the same way ``_handled_access`` masked the ruleset.
+        allowed = _ACCESS_BITS[rule.access] & handled
+        if not stat.S_ISDIR(os.fstat(parent_fd).st_mode):
+            allowed &= _FILE_BITS
+        attr = _PathBeneathAttr(
+            allowed_access=c_uint64(int(allowed)),
+            parent_fd=c_int(parent_fd),
+        )
+        result = libc.syscall(
+            c_long(syscall_number),
+            c_int(ruleset_fd),
+            c_uint32(_LANDLOCK_RULE_PATH_BENEATH),
+            ctypes.byref(attr),
+            c_uint32(0),
+        )
+        if result != 0:
+            raise LandlockUnavailableError(  # noqa: TRY003  # tracked: #288
+                f"landlock_add_rule failed for {rule.path}: {os.strerror(ctypes.get_errno())}"
+            )
+    finally:
+        os.close(parent_fd)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Apply a JSON policy from argv, then ``execvp`` the command after ``--``."""
+    raw = list(sys.argv[1:] if argv is None else argv)
+    if "--" not in raw:
+        sys.stderr.write("usage: python -m vs_sandbox.landlock --policy JSON -- COMMAND [ARG...]\n")
+        return 2
+    separator = raw.index("--")
+    parser = argparse.ArgumentParser(prog="python -m vs_sandbox.landlock", add_help=False)
+    parser.add_argument("--policy", required=True)
+    options = parser.parse_args(raw[:separator])
+    command = raw[separator + 1 :]
+    if not command:
+        sys.stderr.write("no command given after '--'\n")
+        return 2
+
+    policy = LandlockPolicy.model_validate_json(options.policy)
+    if policy.chdir is not None:
+        os.chdir(policy.chdir)
+    try:
+        restrict(policy)
+    except LandlockUnavailableError as exc:
+        # Fail closed. Running the agent unconfined here would silently undo
+        # the guarantee the caller asked ``build()`` to enforce.
+        sys.stderr.write(f"[landlock] refusing to launch unconfined: {exc}\n")
+        return 125
+    try:
+        os.execvp(command[0], command)  # noqa: S606  # tracked: #288
+    except OSError as exc:
+        sys.stderr.write(f"[landlock] cannot execute {command[0]}: {exc}\n")
+        return 127
+
+
+def policy_for(
+    *,
+    read_paths: tuple[Path, ...],
+    write_paths: tuple[Path, ...],
+    chdir: Path | None = None,
+) -> LandlockPolicy:
+    """Build a policy granting *read_paths* read access and *write_paths* full.
+
+    Anything named by neither is denied, provided it is not nested inside one
+    of the granted trees.
+    """
+    rules = [
+        *(LandlockRule(path=str(path), access=RuleAccess.READ) for path in read_paths),
+        *(LandlockRule(path=str(path), access=RuleAccess.FULL) for path in write_paths),
+    ]
+    return LandlockPolicy(rules=tuple(rules), chdir=str(chdir) if chdir is not None else None)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/libs/vs-sandbox/tests/test_landlock_sandbox.py
+++ b/libs/vs-sandbox/tests/test_landlock_sandbox.py
@@ -1,0 +1,384 @@
+"""Tests for the Landlock host-confinement backend.
+
+The behavioral tests execute a real shell under a real ruleset, because the
+only thing worth asserting about a sandbox is what the kernel actually denies.
+They are split along the boundary the backend documents: the outer project
+boundary is enforced, and the nested :class:`ProjectPathPolicy` tiers are not.
+That second group is a *characterization* suite. It pins the known weakness so
+the gap stays visible and a future kernel or backend change that closes it is
+caught rather than silently assumed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import vs_sandbox
+from vs_sandbox import host_sandbox, landlock
+from vs_sandbox.host_sandbox import LandlockSandbox, LinuxBackend
+from vs_sandbox.project_paths import ProjectPathPolicy
+
+requires_landlock = pytest.mark.skipif(
+    landlock.abi_version() is None,
+    reason="requires a kernel with Landlock support",
+)
+
+
+def _workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    (workspace / ".state" / "local").mkdir(parents=True)
+    (workspace / ".state" / "run.json").write_text("{}\n")
+    (workspace / ".env").write_text("TOKEN=secret\n")
+    (workspace / "Cargo.toml").write_text("[package]\n")
+    (workspace / "source.txt").write_text("original")
+    return workspace
+
+
+def _policy() -> ProjectPathPolicy:
+    return ProjectPathPolicy(
+        read_only_paths=(".state", "Cargo.toml"),
+        hidden_paths=(".state/local", ".env"),
+    )
+
+
+def _confined(workspace: Path, **kwargs: object) -> LandlockSandbox:
+    """Build a sandbox whose granted scratch roots exclude the fixture's tree.
+
+    ``tmp_path`` lives under ``/tmp``, which the production scratch roots grant
+    write access to, and a granted ancestor cannot be narrowed. Production
+    refuses that layout outright (see :class:`TestLandlockRefusesUnconfinable`);
+    behavioral tests instead drop ``/tmp`` so the boundary under test is the
+    project's own.
+    """
+    return LandlockSandbox(
+        workspace=workspace,
+        scratch_write_roots=("/dev", "/proc"),
+        **kwargs,  # pyright: ignore[reportArgumentType]
+    )
+
+
+def _run(sandbox: LandlockSandbox, script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        sandbox.wrap(["/bin/sh", "-c", script]),
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+
+
+class TestLandlockPolicyCompilation:
+    def test_public_export(self) -> None:
+        assert vs_sandbox.LandlockSandbox is LandlockSandbox
+        assert vs_sandbox.LinuxBackend is LinuxBackend
+
+    def test_workspace_is_writable_and_system_roots_are_read_only(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+        sandbox = _confined(workspace, system_read_roots=("/usr",))
+
+        rules = {rule.path: rule.access for rule in sandbox.policy().rules}
+
+        assert rules[str(workspace.resolve())] is landlock.RuleAccess.FULL
+        assert rules["/usr"] is landlock.RuleAccess.READ
+
+    def test_wrap_reexecs_through_the_landlock_entry_point(self, tmp_path: Path) -> None:
+        sandbox = _confined(_workspace(tmp_path))
+
+        argv = sandbox.wrap(["agent", "--flag"])
+
+        assert argv[:3] == [sys.executable, "-m", "vs_sandbox.landlock"]
+        assert argv[-3:] == ["--", "agent", "--flag"]
+
+    def test_unenforced_policy_names_every_tier_it_drops(self, tmp_path: Path) -> None:
+        sandbox = LandlockSandbox(workspace=_workspace(tmp_path), project_path_policy=_policy())
+
+        gaps = "\n".join(sandbox.unenforced_policy())
+
+        assert ".state" in gaps
+        assert "Cargo.toml" in gaps
+        assert ".env" in gaps
+
+    def test_unenforced_policy_is_empty_without_a_nested_policy(self, tmp_path: Path) -> None:
+        sandbox = LandlockSandbox(workspace=_workspace(tmp_path))
+
+        assert sandbox.unenforced_policy() == ()
+
+
+@requires_landlock
+class TestLandlockEnforcesTheProjectBoundary:
+    """The guarantee this backend does make, and the escape from issue #149."""
+
+    def test_project_is_writable(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+        sandbox = _confined(workspace)
+
+        result = _run(sandbox, "printf edited > source.txt && printf new > created.txt")
+
+        assert result.returncode == 0, result.stderr
+        assert (workspace / "source.txt").read_text() == "edited"
+        assert (workspace / "created.txt").read_text() == "new"
+
+    def test_paths_outside_the_project_are_denied(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+        sibling = tmp_path / "sibling"
+        sibling.mkdir()
+        (sibling / "secret.txt").write_text("sibling secret\n")
+        sandbox = _confined(workspace)
+
+        result = _run(
+            sandbox,
+            f"cat {sibling / 'secret.txt'} 2>/dev/null; echo read=$?;"
+            f" (printf x > {sibling / 'escape.txt'}) 2>/dev/null; echo write=$?",
+        )
+
+        assert "read=1" in result.stdout
+        assert "write=" in result.stdout
+        assert "write=0" not in result.stdout
+        assert not (sibling / "escape.txt").exists()
+
+    def test_declared_read_resources_stay_readable_but_not_writable(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+        resource = tmp_path / "toolchain"
+        resource.mkdir()
+        (resource / "config.json").write_text("{}\n")
+        sandbox = _confined(workspace, read_paths=(resource,))
+
+        result = _run(
+            sandbox,
+            f"cat {resource / 'config.json'} >/dev/null 2>&1; echo read=$?;"
+            f" (printf x > {resource / 'config.json'}) 2>/dev/null; echo write=$?",
+        )
+
+        assert "read=0" in result.stdout
+        assert "write=0" not in result.stdout
+        assert (resource / "config.json").read_text() == "{}\n"
+
+
+@pytest.mark.skipif(
+    not landlock.supports_scoping(),
+    reason="requires Landlock ABI 6 for scoping",
+)
+class TestLandlockScopingClosesNonFilesystemChannels:
+    """Signals and abstract sockets bypass path rules, so ABI 6 scopes them.
+
+    Without scoping a confined agent can signal, or open an abstract socket to,
+    an *unconfined* process owned by the same user and have it act on the
+    agent's behalf. Bubblewrap closes the signal route with ``--unshare-pid``
+    and leaves abstract sockets open; scoping closes both.
+    """
+
+    def test_cannot_signal_a_process_outside_the_sandbox(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+        sandbox = _confined(workspace)
+
+        # The test runner itself is unconfined and owned by the same uid.
+        result = _run(sandbox, f"kill -0 {os.getpid()}")
+
+        assert result.returncode != 0
+
+    def test_in_scope_abstract_sockets_still_work(self, tmp_path: Path) -> None:
+        """Scoping must not break the agent's own IPC, only cross-scope IPC."""
+        interpreter = Path("/usr/bin/python3")
+        if not interpreter.exists():
+            pytest.skip("needs an interpreter inside a granted system read root")
+        workspace = _workspace(tmp_path)
+        sandbox = _confined(workspace)
+        program = (
+            "import socket;"
+            "s=socket.socket(socket.AF_UNIX,socket.SOCK_STREAM);"
+            "s.bind('\\0vs-scope-test');s.listen(1);"
+            "c=socket.socket(socket.AF_UNIX,socket.SOCK_STREAM);"
+            "c.connect('\\0vs-scope-test');"
+            "print('connected')"
+        )
+
+        result = _run(sandbox, f'{interpreter} -c "{program}"')
+
+        assert result.returncode == 0, result.stderr
+        assert "connected" in result.stdout
+
+
+@requires_landlock
+class TestLandlockCannotEnforceNestedPolicy:
+    """Characterization of the documented gap: rules add rights, never remove.
+
+    If one of these starts failing, Landlock gained the ability to subtract
+    within a hierarchy. That is good news, and it means
+    :class:`LandlockSandbox` should stop advertising the tier as unenforced.
+    """
+
+    def test_read_only_paths_remain_writable(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+        sandbox = _confined(workspace, project_path_policy=_policy())
+
+        result = _run(sandbox, "printf changed > Cargo.toml")
+
+        assert result.returncode == 0, result.stderr
+        assert (workspace / "Cargo.toml").read_text() == "changed"
+
+    def test_hidden_paths_remain_readable(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+        sandbox = _confined(workspace, project_path_policy=_policy())
+
+        result = _run(sandbox, "cat .env")
+
+        assert result.returncode == 0, result.stderr
+        assert "TOKEN=secret" in result.stdout
+
+
+@requires_landlock
+class TestLandlockHelperFailsClosed:
+    def test_unparsable_policy_does_not_launch_the_command(self, tmp_path: Path) -> None:
+        marker = tmp_path / "ran.txt"
+
+        result = subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                "-m",
+                "vs_sandbox.landlock",
+                "--policy",
+                '{"rules": [{"path": "/usr", "access": "bogus-tier"}]}',
+                "--",
+                "/bin/sh",
+                "-c",
+                f"printf ran > {marker}",
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode != 0
+        assert not marker.exists()
+
+    def test_missing_command_is_rejected(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "vs_sandbox.landlock", "--policy", "{}", "--"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 2
+
+
+class TestLandlockRefusesUnconfinable:
+    """A granted ancestor cannot be narrowed, so such a layout must not run."""
+
+    def test_project_inside_a_granted_scratch_root_is_refused(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+        sandbox = LandlockSandbox(
+            workspace=workspace,
+            scratch_write_roots=(str(tmp_path),),
+        )
+
+        with pytest.raises(host_sandbox.SandboxUnavailableError, match="unconfined"):
+            sandbox.policy()
+
+    def test_project_inside_a_declared_write_resource_is_refused(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+        sandbox = LandlockSandbox(
+            workspace=workspace,
+            scratch_write_roots=(),
+            write_paths=(tmp_path,),
+        )
+
+        with pytest.raises(host_sandbox.SandboxUnavailableError, match="unconfined"):
+            sandbox.policy()
+
+    def test_sibling_scratch_root_is_allowed(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+        sibling = tmp_path / "scratch"
+        sibling.mkdir()
+        sandbox = LandlockSandbox(workspace=workspace, scratch_write_roots=(str(sibling),))
+
+        assert sandbox.policy().rules
+
+
+class TestLinuxBackendSelection:
+    def test_landlock_is_never_selected_automatically(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Default behavior is unchanged: no bwrap means fail closed, not downgrade."""
+        workspace = _workspace(tmp_path)
+        monkeypatch.setattr(host_sandbox.sys, "platform", "linux")
+        monkeypatch.setattr(host_sandbox.shutil, "which", lambda *_args, **_kwargs: None)
+
+        with pytest.raises(host_sandbox.SandboxUnavailableError, match="bwrap"):
+            host_sandbox.build(workspace, env={}, require_enforcement=True)
+
+    def test_missing_bwrap_message_points_at_the_opt_in(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        workspace = _workspace(tmp_path)
+        monkeypatch.setattr(host_sandbox.sys, "platform", "linux")
+        monkeypatch.setattr(host_sandbox.shutil, "which", lambda *_args, **_kwargs: None)
+        logs: list[str] = []
+
+        host_sandbox.build(workspace, env={}, log=logs.append)
+
+        assert any("VIBESYS_AGENT_SANDBOX=landlock" in message for message in logs)
+
+    @requires_landlock
+    def test_opt_in_selects_landlock_without_bwrap(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        workspace = _workspace(tmp_path)
+        monkeypatch.setattr(host_sandbox.sys, "platform", "linux")
+        monkeypatch.setattr(host_sandbox.shutil, "which", lambda *_args, **_kwargs: None)
+        # The fixture project lives under /tmp, which the production scratch
+        # roots would grant and the ancestor guard would then reject.
+        monkeypatch.setattr(host_sandbox, "_LINUX_SCRATCH_WRITE_ROOTS", ("/dev", "/proc"))
+        logs: list[str] = []
+
+        sandbox = host_sandbox.build(
+            workspace,
+            env={host_sandbox.DISABLE_ENV: LinuxBackend.LANDLOCK.value},
+            project_path_policy=_policy(),
+            log=logs.append,
+            require_enforcement=True,
+        )
+
+        assert isinstance(sandbox, LandlockSandbox)
+        assert any("NOT ENFORCED" in message for message in logs)
+
+    def test_unusable_bwrap_is_treated_as_missing(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A blocked bwrap must fail at startup, not once per agent turn."""
+        workspace = _workspace(tmp_path)
+        monkeypatch.setattr(host_sandbox.sys, "platform", "linux")
+        monkeypatch.setattr(
+            host_sandbox.shutil,
+            "which",
+            lambda *_args, **_kwargs: "/opt/unpacked/bwrap",
+        )
+        monkeypatch.setattr(host_sandbox, "_bwrap_confines", lambda _path: False)
+
+        with pytest.raises(host_sandbox.SandboxUnavailableError, match="user namespace"):
+            host_sandbox.build(workspace, env={}, require_enforcement=True)
+
+    def test_unknown_backend_value_is_rejected(self, tmp_path: Path) -> None:
+        workspace = _workspace(tmp_path)
+
+        with pytest.raises(host_sandbox.SandboxUnavailableError, match="unknown"):
+            host_sandbox.build(
+                workspace,
+                env={host_sandbox.DISABLE_ENV: "landlok"},
+                require_enforcement=True,
+            )

--- a/libs/vs-sandbox/tests/test_landlock_sandbox.py
+++ b/libs/vs-sandbox/tests/test_landlock_sandbox.py
@@ -11,7 +11,10 @@ caught rather than silently assumed.
 
 from __future__ import annotations
 
+import ctypes
+import errno
 import os
+import runpy
 import subprocess
 import sys
 from pathlib import Path
@@ -380,5 +383,286 @@ class TestLinuxBackendSelection:
             host_sandbox.build(
                 workspace,
                 env={host_sandbox.DISABLE_ENV: "landlok"},
+                require_enforcement=True,
+            )
+
+
+class _FakeLibc:
+    """Stand-in for libc that records the Landlock syscalls ``restrict`` makes.
+
+    The kernel-backed suites above prove what the ruleset denies; this fake
+    exists to drive the error paths of the syscall layer, which a working
+    kernel never takes, and to inspect the structs handed to the kernel.
+    """
+
+    def __init__(
+        self,
+        *,
+        create_result: int | None = None,
+        add_rule_result: int = 0,
+        prctl_result: int = 0,
+        restrict_result: int = 0,
+    ) -> None:
+        self.create_result = create_result
+        self.add_rule_result = add_rule_result
+        self.prctl_result = prctl_result
+        self.restrict_result = restrict_result
+        self.ruleset_attr: ctypes.Structure | None = None
+        self.ruleset_size: int | None = None
+        self.rules: list[tuple[int, int]] = []
+        self.restricted = False
+
+    def prctl(self, *_args: object) -> int:
+        return self.prctl_result
+
+    def syscall(self, number: ctypes.c_long, *args: object) -> int:
+        create, add_rule, restrict_self = landlock._syscall_numbers()  # noqa: SLF001
+        if number.value == create:
+            if self.create_result is not None:
+                return self.create_result
+            self.ruleset_attr = args[0]._obj  # noqa: SLF001
+            self.ruleset_size = args[1].value
+            return os.open(os.devnull, os.O_RDONLY | os.O_CLOEXEC)
+        if number.value == add_rule:
+            attr = args[2]._obj  # noqa: SLF001
+            self.rules.append((int(attr.allowed_access), int(attr.parent_fd)))
+            return self.add_rule_result
+        assert number.value == restrict_self
+        self.restricted = self.restrict_result == 0
+        return self.restrict_result
+
+
+@pytest.fixture
+def fake_libc(monkeypatch: pytest.MonkeyPatch) -> _FakeLibc:
+    libc = _FakeLibc()
+    monkeypatch.setattr(landlock, "_libc", lambda: libc)
+    monkeypatch.setattr(landlock, "_syscall_numbers", lambda: (444, 445, 446))
+    monkeypatch.setattr(landlock, "abi_version", lambda: landlock._ABI_SCOPED)  # noqa: SLF001
+    return libc
+
+
+class TestLandlockAbiProbe:
+    def test_unknown_architecture_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(landlock.platform, "machine", lambda: "mips")
+
+        with pytest.raises(landlock.LandlockUnavailableError, match="mips"):
+            landlock._syscall_numbers()  # noqa: SLF001
+        assert landlock.abi_version() is None
+
+    def test_non_linux_has_no_abi(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(landlock.sys, "platform", "darwin")
+
+        assert landlock.abi_version() is None
+
+    def test_syscall_failure_means_unsupported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(landlock, "_libc", lambda: _FakeLibc(create_result=-1))
+        monkeypatch.setattr(landlock, "_syscall_numbers", lambda: (444, 445, 446))
+
+        assert landlock.abi_version() is None
+
+    def test_scoping_needs_abi_six(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(landlock, "abi_version", lambda: 5)
+        assert landlock.supports_scoping() is False
+        monkeypatch.setattr(landlock, "abi_version", lambda: 6)
+        assert landlock.supports_scoping() is True
+        monkeypatch.setattr(landlock, "abi_version", lambda: None)
+        assert landlock.supports_scoping() is False
+
+    @pytest.mark.parametrize(
+        ("abi", "dropped"),
+        [
+            (1, landlock.AccessFS.TRUNCATE | landlock.AccessFS.REFER),
+            (2, landlock.AccessFS.TRUNCATE),
+            (3, landlock.AccessFS(0)),
+        ],
+    )
+    def test_handled_access_drops_rights_older_kernels_reject(
+        self,
+        abi: int,
+        dropped: landlock.AccessFS,
+    ) -> None:
+        handled = landlock._handled_access(abi)  # noqa: SLF001
+
+        assert handled & dropped == 0
+        assert handled | dropped == landlock._ACCESS_BITS[landlock.RuleAccess.FULL]  # noqa: SLF001
+
+
+class TestLandlockRestrictSyscalls:
+    def test_applies_every_rule_then_restricts(self, tmp_path: Path, fake_libc: _FakeLibc) -> None:
+        (tmp_path / "file.txt").write_text("x")
+        policy = landlock.policy_for(
+            read_paths=(tmp_path / "file.txt",),
+            write_paths=(tmp_path,),
+        )
+
+        abi = landlock.restrict(policy)
+
+        assert abi == landlock._ABI_SCOPED  # noqa: SLF001
+        assert fake_libc.restricted
+        full = int(landlock._ACCESS_BITS[landlock.RuleAccess.READ])  # noqa: SLF001
+        assert [access for access, _fd in fake_libc.rules] == [
+            full & int(landlock._FILE_BITS),  # noqa: SLF001
+            int(landlock._ACCESS_BITS[landlock.RuleAccess.FULL]),  # noqa: SLF001
+        ]
+
+    def test_abi_six_scopes_signals_and_abstract_sockets(self, fake_libc: _FakeLibc) -> None:
+        landlock.restrict(landlock.LandlockPolicy())
+
+        attr = fake_libc.ruleset_attr
+        assert isinstance(attr, landlock._ScopedRulesetAttr)  # noqa: SLF001
+        assert attr.scoped == (
+            landlock._LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET | landlock._LANDLOCK_SCOPE_SIGNAL  # noqa: SLF001
+        )
+        assert attr.handled_access_net == 0
+        assert fake_libc.ruleset_size == ctypes.sizeof(attr)
+
+    def test_older_abi_uses_filesystem_only_struct(
+        self,
+        fake_libc: _FakeLibc,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(landlock, "abi_version", lambda: 1)
+
+        landlock.restrict(landlock.LandlockPolicy())
+
+        attr = fake_libc.ruleset_attr
+        assert isinstance(attr, landlock._RulesetAttr)  # noqa: SLF001
+        assert attr.handled_access_fs & landlock.AccessFS.TRUNCATE == 0
+        assert fake_libc.ruleset_size == ctypes.sizeof(ctypes.c_uint64)
+
+    def test_missing_rule_paths_are_skipped(self, tmp_path: Path, fake_libc: _FakeLibc) -> None:
+        policy = landlock.policy_for(read_paths=(tmp_path / "absent",), write_paths=())
+
+        landlock.restrict(policy)
+
+        assert fake_libc.rules == []
+        assert fake_libc.restricted
+
+    def test_unsupported_kernel_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(landlock, "abi_version", lambda: None)
+
+        with pytest.raises(landlock.LandlockUnavailableError, match="does not support"):
+            landlock.restrict(landlock.LandlockPolicy())
+
+    def test_create_ruleset_failure_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(landlock, "_libc", lambda: _FakeLibc(create_result=-1))
+        monkeypatch.setattr(landlock, "_syscall_numbers", lambda: (444, 445, 446))
+        monkeypatch.setattr(landlock, "abi_version", lambda: 1)
+
+        with pytest.raises(landlock.LandlockUnavailableError, match="create_ruleset"):
+            landlock.restrict(landlock.LandlockPolicy())
+
+    @pytest.mark.parametrize(
+        ("failure", "message"),
+        [
+            ({"add_rule_result": -1}, "add_rule"),
+            ({"prctl_result": -1}, "NO_NEW_PRIVS"),
+            ({"restrict_result": -1}, "restrict_self"),
+        ],
+    )
+    def test_later_syscall_failures_are_refused(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        failure: dict[str, int],
+        message: str,
+    ) -> None:
+        libc = _FakeLibc(**failure)
+        monkeypatch.setattr(landlock, "_libc", lambda: libc)
+        monkeypatch.setattr(landlock, "_syscall_numbers", lambda: (444, 445, 446))
+        monkeypatch.setattr(landlock, "abi_version", lambda: 1)
+        policy = landlock.policy_for(read_paths=(), write_paths=(tmp_path,))
+
+        with pytest.raises(landlock.LandlockUnavailableError, match=message):
+            landlock.restrict(policy)
+        assert not libc.restricted
+
+
+class TestLandlockEntryPoint:
+    """``main()`` driven in-process, so its branches are measurable."""
+
+    def test_usage_without_separator(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert landlock.main(["--policy", "{}"]) == 2
+        assert "usage:" in capsys.readouterr().err
+
+    def test_missing_command(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert landlock.main(["--policy", "{}", "--"]) == 2
+        assert "no command" in capsys.readouterr().err
+
+    def test_restricts_then_execs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        applied: list[landlock.LandlockPolicy] = []
+        execs: list[tuple[str, list[str]]] = []
+        monkeypatch.setattr(landlock, "restrict", lambda policy: applied.append(policy) or 1)
+        monkeypatch.setattr(landlock.os, "execvp", lambda file, args: execs.append((file, args)))
+        policy = landlock.policy_for(read_paths=(), write_paths=(tmp_path,), chdir=tmp_path)
+
+        result = landlock.main(["--policy", policy.model_dump_json(), "--", "agent", "--flag"])
+
+        assert result is None
+        assert applied == [policy]
+        assert execs == [("agent", ["agent", "--flag"])]
+        assert Path.cwd() == tmp_path.resolve()
+
+    def test_unavailable_landlock_fails_closed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        def refuse(_policy: landlock.LandlockPolicy) -> int:
+            raise landlock.LandlockUnavailableError("nope")
+
+        monkeypatch.setattr(landlock, "restrict", refuse)
+        monkeypatch.setattr(landlock.os, "execvp", lambda *_args: pytest.fail("must not exec"))
+
+        assert landlock.main(["--policy", "{}", "--", "agent"]) == 125
+        assert "refusing to launch unconfined" in capsys.readouterr().err
+
+    def test_unexecutable_command(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setattr(landlock, "restrict", lambda _policy: 1)
+
+        assert landlock.main(["--policy", "{}", "--", "/nonexistent/agent"]) == 127
+        assert "cannot execute" in capsys.readouterr().err
+
+    def test_module_entry_point_exits_with_main_status(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(sys, "argv", ["landlock", "--policy", "{}"])
+
+        with pytest.raises(SystemExit) as excinfo:
+            runpy.run_path(landlock.__file__, run_name="__main__")
+
+        assert excinfo.value.code == 2
+
+
+class TestLinuxBackendProbes:
+    def test_bwrap_that_cannot_launch_does_not_confine(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def explode(*_args: object, **_kwargs: object) -> None:
+            raise OSError(errno.ENOEXEC, "Exec format error")
+
+        monkeypatch.setattr(host_sandbox.subprocess, "run", explode)
+
+        assert host_sandbox._bwrap_confines("/opt/bwrap") is False  # noqa: SLF001
+
+    def test_landlock_opt_in_without_kernel_support_fails_closed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        workspace = _workspace(tmp_path)
+        monkeypatch.setattr(host_sandbox.sys, "platform", "linux")
+        monkeypatch.setattr(host_sandbox.landlock, "abi_version", lambda: None)
+
+        with pytest.raises(host_sandbox.SandboxUnavailableError, match="does not support Landlock"):
+            host_sandbox.build(
+                workspace,
+                env={host_sandbox.DISABLE_ENV: LinuxBackend.LANDLOCK.value},
                 require_enforcement=True,
             )

--- a/libs/vs-sandbox/tests/test_project_path_policy.py
+++ b/libs/vs-sandbox/tests/test_project_path_policy.py
@@ -248,6 +248,9 @@ class TestBubblewrapProjectPaths:
             "which",
             lambda *_args, **_kwargs: "/usr/bin/bwrap",
         )
+        # The builder probes that bwrap can actually unshare a user namespace;
+        # this test supplies a path rather than a working binary.
+        monkeypatch.setattr(host_sandbox, "_bwrap_confines", lambda _path: True)
 
         sandbox = host_sandbox.build(
             workspace,

--- a/tests/_agent_cli/test_hostsandbox.py
+++ b/tests/_agent_cli/test_hostsandbox.py
@@ -65,6 +65,17 @@ def _bwrap_works() -> bool:
     return proc.returncode == 0
 
 
+def _stub_working_bwrap(monkeypatch, path: str = "/usr/bin/bwrap") -> None:  # noqa: ANN001  # tracked: #288
+    """Present a usable ``bwrap`` to the builder without needing one installed.
+
+    ``build()`` both locates ``bwrap`` and probes that it can actually unshare a
+    user namespace. Tests below exercise the builder's path policy, not the
+    probe, so they stub each half.
+    """
+    monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: path)  # noqa: ARG005  # tracked: #288
+    monkeypatch.setattr(hostsandbox, "_bwrap_confines", lambda _path: True)
+
+
 # CI sets ``VIBESYS_REQUIRE_SANDBOX_TESTS=1`` so the real-confinement tests must
 # run instead of silently skipping. If the backend is then unavailable the tests
 # fail (build() returns None → assertions trip), which is the whole point: a
@@ -113,7 +124,7 @@ class TestBuild:
 
     def test_allow_ancestor_of_workspace_is_rejected(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
-        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")  # noqa: ARG005  # tracked: #288
+        _stub_working_bwrap(monkeypatch)
         workspace = tmp_path / "exp_env" / "run" / "workspace"
         workspace.mkdir(parents=True)
         logs: list[str] = []
@@ -130,7 +141,7 @@ class TestBuild:
 
     def test_allow_extra_path_is_bound(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
-        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")  # noqa: ARG005  # tracked: #288
+        _stub_working_bwrap(monkeypatch)
         workspace = tmp_path / "ws"
         workspace.mkdir()
         weights = tmp_path.parent / f"{tmp_path.name}-weights"
@@ -149,7 +160,7 @@ class TestBuild:
 
     def test_programmatic_resources_are_imported_by_access(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
-        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")  # noqa: ARG005  # tracked: #288
+        _stub_working_bwrap(monkeypatch)
         workspace = tmp_path / "workspace"
         readonly = tmp_path / "compiler"
         writable = tmp_path / "agent-state"
@@ -175,7 +186,7 @@ class TestBuild:
 
     def test_codex_auth_file_survives_nested_codex_worktree_filter(self, tmp_path, monkeypatch):  # noqa: ANN001, ANN202  # tracked: #288
         monkeypatch.setattr(hostsandbox.sys, "platform", "linux")
-        monkeypatch.setattr(hostsandbox.shutil, "which", lambda *a, **k: "/usr/bin/bwrap")  # noqa: ARG005  # tracked: #288
+        _stub_working_bwrap(monkeypatch)
         codex_home = tmp_path / ".codex"
         workspace = codex_home / "worktrees" / "run" / "workspace"
         workspace.mkdir(parents=True)


### PR DESCRIPTION
Problem
-------
Local runs require bubblewrap, and `_build_linux` fails closed without it. On a host where unprivileged user namespaces are blocked, bubblewrap cannot run at all and installing it needs root: Ubuntu's `kernel.apparmor_restrict_unprivileged_userns` grants `userns` only to binaries with a matching AppArmor profile, which the distro ships solely for `/usr/bin/bwrap`. A bwrap unpacked elsewhere fails its uid-map write. Without root there is then no way to run VibeSys locally at all, and the agent CLIs are launched with their own sandbox bypass flags, so "unconfined" is the only alternative.

Solution
--------
Add `LandlockSandbox`, a third `WorkspaceSandbox` backend built on the Landlock LSM, which needs neither root nor user namespaces. It emits the same `wrap(argv) -> argv` contract by re-execing through `python -m vs_sandbox.landlock`, which applies a ruleset via ctypes and then execs the real command. Provider-agnostic, so no agent-CLI flags change.

Landlock rules are additive: a nested rule can only add rights, never remove them, and ruleset stacking does not help because each layer is additive too. Since the project root must grant WRITE_FILE and MAKE_REG for the agent to work, those rights necessarily reach `.vibesys` and root `.env*`. This backend therefore enforces the outer project boundary but cannot express the nested read-only and hidden tiers of `ProjectPathPolicy`. It is opt-in via `VIBESYS_AGENT_SANDBOX=landlock`, never selected automatically, and logs each unenforced tier at startup rather than dropping it silently. Evaluator-input integrity is unaffected: the accuracy gate diffs those paths against a trusted baseline independently of any sandbox.

Also probe that bwrap can actually unshare a user namespace before selecting it, so a present-but-blocked binary is one startup error instead of a failure every round. On ABI 6+ the ruleset scopes signals and abstract unix sockets, closing two routes to making an unconfined process act for the agent; bubblewrap leaves abstract sockets open.

A project inside a tree the backend must grant write access to (`/tmp`, for example) is refused rather than run believing itself confined.

Verification
------------
`libs/vs-sandbox/tests/test_landlock_sandbox.py` (22 tests) executes a real shell under a real ruleset: the project stays writable, paths outside it are denied for read and write, declared read resources stay read-only, scoping blocks signalling an outside process while in-scope abstract sockets still work, and the helper fails closed on an unparsable policy. A characterization suite pins the two unenforced tiers so a future kernel that closes the gap is noticed. Selection tests cover: Landlock is never chosen automatically, the missing-bwrap message names the opt-in, an unusable bwrap is treated as missing, and an unknown env value is rejected.

Manually attacked on a trn2.3xlarge with the real builder. Denied: direct reads outside the project, `/proc/self/root` traversal, `/proc/PID/cwd`, read-through and readlink of `/proc/PID/fd/N` holding an outside file open, `/proc/PID/environ`, symlink and hardlink escapes, another user's home, and `/run/user/$UID`. Open by design and shared with bubblewrap: network, and `/etc` and `/usr` reads. Weaker than bubblewrap: `/tmp` is shared rather than a private tmpfs, and `/proc/PID/cmdline` of same-uid processes stays readable. All documented on the class.

format, lint, pyright, and the full suite (4048 passed) are clean; the one failure predates this branch and is a missing example submodule.

## Problem

<!--
Motivate the change. Explain why we are doing this in the first place, what
user or maintainer pain it addresses, and link any relevant issues.
-->

## Solution

<!--
Describe the high-level design. Call out important implementation choices,
tradeoffs, boundaries, and any behavior that reviewers should inspect closely.
-->

### Architecture

<!--
Describe the ownership model and major components involved in the solution.
For nontrivial control flow or cross-boundary changes, include a Mermaid diagram
or equivalent sketch that shows how the pieces interact.
-->

## Verification

<!--
Summarize how you checked the change. Include automated tests, manual checks,
benchmarks, or reasons a particular check was not run.
-->

### Correctness properties

<!--
List the invariants, contracts, or expected behaviors this PR preserves or
introduces, especially for user-facing behavior and shared interfaces.
-->

### Testing

<!--
List the exact commands or workflows run, plus the relevant result.
-->
