### PR TITLE
Add agent graph representation feature for the agent strip and update round strips

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -24,7 +24,7 @@ available slash commands are:
 | Command | Behavior |
 | --- | --- |
 | `/help` | Show commands and planned controls. |
-| `/chat` | Open a read-only chat about the run; `/chat <question>` asks immediately. |
+| `/chat` | Put the pane keys on the docked chat, or open it as a modal where it cannot dock; `/chat <question>` asks immediately. |
 | | Slash commands work inside the chat too, and do the same thing as in the main input. |
 | `/pause` | Pause after the current agent call finishes. |
 | `/resume` | Resume a paused run. |
@@ -80,18 +80,57 @@ reshuffle. Records written before hypothesis tracking render as
 `(Unidentified)` rather than being dropped. Columns drop widest first as the
 terminal narrows; hypothesis, rounds, and outcome always survive.
 
+The chat is docked beside the table as a permanent column of this view, so a
+question about the run never covers what the run has done. It has its own input
+at the foot of its column, under the instruction `Ask about this run`,
+and the client's command input sits beside it, starting at the boundary between
+the two columns so each box is under the surface it writes to. The command
+list rises out of the command input rather than across the chat.
+
+The cursor starts in the command input, and `Ctrl+W` moves both it and the pane
+keys to the chat and back; the chat's instruction line says so (`Ctrl+W to type
+here`) until it holds them, and the focused input carries the focus border, so
+where a keystroke lands is never a guess. A question typed into either box
+reaches the same agent and is answered in the same column. Page Up and Page Down scroll the focused pane, and
+Escape hands the keys back to the table. Arrows, Enter, and the rest of the
+table's keys are unaffected by the dock. A slash command typed into the chat
+input runs through the same path as anywhere else, and ordinary text typed into
+the command input is still a question for the agent: the two boxes are a
+division of attention, not of capability.
+
+`/chat` leaves the command surface on this view, since the chat is already
+beside the table: it is absent from `/help` and from the completions, though it
+is still accepted and still focuses the pane. Inside a hypothesis, where the
+chat is a dialog again, the command comes back and opens it over the
+trajectory. It is one conversation throughout, so a question asked from the
+pop-up is in the column when the operator steps back out.
+
+The chat asks for the columns left over once the table has enough for its
+claim, so a wide terminal loses no table column to it; where there is no such
+surplus it still takes its readable minimum and the table drops columns as it
+does on any narrow terminal. Below about 92 columns two columns would both be
+unreadable, so the table keeps the row alone and the chat opens over it as a
+modal. Opening a visualization narrows the chat before it narrows the table,
+and where all three will not fit the chat is the one that steps aside.
+
+Whichever way the chat is on screen, it never replaces the view it was asked
+from: the modal floats over the table rather than swapping in the per-round
+transcript behind it.
+
 ### Split panes
 
 Visualization commands render beside the current view rather than over it.
 `/perf` puts its output in a right pane and leaves the transcript, the chat,
-or the experiment log in the left one, both live at the same time. A second
-visualization command replaces the pane's contents rather than stacking
-another surface on top.
+or the experiment log in the left one, both live at the same time. On the
+experiment log that makes three columns, chat, table, and visualization, each
+live. A second visualization command replaces the pane's contents rather than
+stacking another surface on top.
 
-`Ctrl+W` moves focus between the panes; the focused one carries the theme's
-focus border and says so in its title. Page Up and Page Down scroll whichever
-pane has focus, and Escape on the right pane closes it and restores the
-full-width view. Chat and transcript state survive the pane closing.
+`Ctrl+W` moves focus one column to the right and wraps, through whichever
+columns are actually on screen; the focused one carries the theme's focus
+border and says so in its title. Page Up and Page Down scroll whichever pane
+has focus, and Escape on the right pane closes it and restores the full-width
+view. Chat and transcript state survive the pane closing.
 
 Pane widths are computed from the terminal, so a wide terminal gives the
 visualization real room while the left pane keeps a readable floor. Below 100
@@ -115,6 +154,12 @@ Text typed in the chat that starts with `/` is parsed as a slash command
 through the same path as the main input, so `/perf` there does exactly what
 `/perf` does anywhere else. Anything else is a question for the agent, and a
 question containing a slash mid-sentence is still a question.
+
+Where the chat is docked it answers in its column, under its own input; where
+it is not, inside a hypothesis or in a terminal too narrow to dock, it opens
+over the view as before, carrying the same input at the foot of the modal. It
+is one conversation either way: the transcript survives docking, undocking, and
+the pane closing.
 
 Inside a hypothesis the footer shows keyboard navigation. `[` and `]` select rounds, Tab and
 Shift+Tab select agents, Page Up/Page Down scroll the transcript, Ctrl+T expands

--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -161,11 +161,24 @@ over the view as before, carrying the same input at the foot of the modal. It
 is one conversation either way: the transcript survives docking, undocking, and
 the pane closing.
 
-Inside a hypothesis the footer shows keyboard navigation. `[` and `]` select rounds, Tab and
-Shift+Tab select agents, Page Up/Page Down scroll the transcript, Ctrl+T expands
-todos, Ctrl+P expands the latest prompt in the current selection, Ctrl+L and
-Escape return to the experiment log, and Ctrl+C exits. Commands listed under "Planned" in `/help`
-are not accepted yet.
+Inside a hypothesis the footer shows keyboard navigation. `[` and `]` select
+rounds, Tab and Shift+Tab select agents, the arrow keys move a cursor through
+the transcript's entries, Page Up/Page Down scroll it, and F2 (or Ctrl+T)
+expands the todo box, which then takes the arrow keys until Escape closes it.
+F3 (or Ctrl+P) expands the latest prompt in the current selection. Function keys
+are offered alongside the Control chords because a terminal is free to keep a
+Control chord for itself, and on macOS several do.
+
+Escape unwinds the round view one step at a time: the entry cursor, then the
+agent filter, then the hypothesis. Ctrl+L returns to the experiment log from
+anywhere, and Ctrl+C exits. Rounds and agents can also be clicked: a round chip
+selects its round, an agent node filters the transcript to that agent, and
+clicking the selected node clears the filter. Commands listed under "Planned" in
+`/help` are not accepted yet.
+
+The rounds strip covers the whole run, including rounds it has not reached yet,
+and windows onto the part that fits. The selected round is always in view, and
+`‹ n` and `n ›` say how many rounds sit past each edge.
 
 The launcher retains terminal results until the operator exits. If the backend
 fails to start, its log tail is printed before the temporary session directory

--- a/clients/tui/src/commands.test.ts
+++ b/clients/tui/src/commands.test.ts
@@ -1,5 +1,11 @@
 import {describe, expect, it} from 'bun:test';
-import {parseInput, slashCommandRange, suggestSlashCommands} from './commands.js';
+import {
+  availableCommands,
+  helpText,
+  parseInput,
+  slashCommandRange,
+  suggestSlashCommands,
+} from './commands.js';
 
 describe('parseInput', () => {
   it('accepts the intentionally small slash-command surface', () => {
@@ -82,6 +88,28 @@ describe('parseInput', () => {
     expect(parsed.error).toContain('Unknown theme: monokai');
     expect(parsed.error).toContain('catppuccin-mocha');
     expect(parsed.localView).toBeUndefined();
+  });
+});
+
+describe('command surface by view', () => {
+  it('drops /chat where the chat is already a pane of the view', () => {
+    const docked = availableCommands({chatDocked: true}).map(command => command.name);
+
+    expect(docked).not.toContain('/chat');
+    expect(docked).toContain('/perf');
+    expect(helpText({chatDocked: true})).not.toContain('/chat');
+    expect(suggestSlashCommands('/c', {chatDocked: true})).toEqual([]);
+  });
+
+  it('offers /chat everywhere the chat is not already on screen', () => {
+    expect(availableCommands().map(command => command.name)).toContain('/chat');
+    expect(helpText()).toContain('/chat');
+    expect(suggestSlashCommands('/c').map(command => command.name)).toEqual(['/chat']);
+  });
+
+  it('still accepts /chat when it is not offered, since the chat is the point', () => {
+    // Hidden from the list, not removed from the client.
+    expect(parseInput('/chat')).toEqual({localView: 'chat'});
   });
 });
 

--- a/clients/tui/src/commands.test.ts
+++ b/clients/tui/src/commands.test.ts
@@ -107,6 +107,13 @@ describe('command surface by view', () => {
     expect(suggestSlashCommands('/c').map(command => command.name)).toEqual(['/chat']);
   });
 
+  it('reaches the todo and prompt toggles by name', () => {
+    // macOS keeps the function keys for itself and a terminal may keep a
+    // Control chord, so both toggles have to be reachable without either.
+    expect(parseInput('/todos')).toEqual({toggle: 'todos'});
+    expect(parseInput('/prompt')).toEqual({toggle: 'prompt'});
+  });
+
   it('still accepts /chat when it is not offered, since the chat is the point', () => {
     // Hidden from the list, not removed from the client.
     expect(parseInput('/chat')).toEqual({localView: 'chat'});
@@ -123,6 +130,8 @@ describe('slash-command input helpers', () => {
       '/steer',
       '/open-round',
       '/perf',
+      '/todos',
+      '/prompt',
       '/theme',
     ]);
     expect(suggestSlashCommands('/h').map(command => command.name)).toEqual(['/help']);

--- a/clients/tui/src/commands.ts
+++ b/clients/tui/src/commands.ts
@@ -38,18 +38,40 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
   {name: '/theme', description: 'List themes, or switch with /theme <name>'},
 ];
 
-export const HELP_TEXT = [
-  'Available',
-  ...SLASH_COMMANDS.map(command => `  ${command.name.padEnd(18)} ${command.description}`),
-  '',
-  'Planned',
-  '  /round <number>    Inspect a completed round',
-  '  /invocation <id>   Inspect an agent invocation',
-].join('\n');
+/**
+ * Where the chat is a pane of the current view there is nothing for `/chat` to
+ * open, so it leaves the command surface rather than sitting in it as a command
+ * that does nothing new. It is still accepted, and still opens the chat
+ * anywhere the chat is not already on screen.
+ */
+export interface CommandContext {
+  chatDocked?: boolean;
+}
 
-export function suggestSlashCommands(text: string): readonly SlashCommand[] {
+export function availableCommands(context: CommandContext = {}): readonly SlashCommand[] {
+  if (!context.chatDocked) return SLASH_COMMANDS;
+  return SLASH_COMMANDS.filter(command => command.name !== '/chat');
+}
+
+export function helpText(context: CommandContext = {}): string {
+  return [
+    'Available',
+    ...availableCommands(context).map(
+      command => `  ${command.name.padEnd(18)} ${command.description}`,
+    ),
+    '',
+    'Planned',
+    '  /round <number>    Inspect a completed round',
+    '  /invocation <id>   Inspect an agent invocation',
+  ].join('\n');
+}
+
+export function suggestSlashCommands(
+  text: string,
+  context: CommandContext = {},
+): readonly SlashCommand[] {
   if (!text.startsWith('/') || /\s/.test(text)) return [];
-  return SLASH_COMMANDS.filter(command => command.name.startsWith(text));
+  return availableCommands(context).filter(command => command.name.startsWith(text));
 }
 
 export function slashCommandRange(text: string): {start: number; end: number} | null {

--- a/clients/tui/src/commands.ts
+++ b/clients/tui/src/commands.ts
@@ -4,6 +4,12 @@ import {isThemeName, THEME_NAMES, type ThemeName} from './ui/theme.js';
 
 export type ParsedInput = {
   localView?: 'chat' | 'help' | 'theme';
+  /**
+   * Surfaces that also have a key. macOS reserves the function keys for system
+   * controls and a terminal may keep a Control chord for itself, so every
+   * toggle is reachable by name as well.
+   */
+  toggle?: 'todos' | 'prompt';
   chatMessage?: string;
   themeName?: ThemeName;
   request?: RequestInput;
@@ -35,6 +41,8 @@ export const SLASH_COMMANDS: readonly SlashCommand[] = [
     description: 'Open the selected hypothesis, or /open-round --N for round N',
   },
   {name: '/perf', description: 'Plot performance by round in the right pane'},
+  {name: '/todos', description: "Expand or collapse the visible agent's todo list"},
+  {name: '/prompt', description: 'Expand or collapse the latest prompt in view'},
   {name: '/theme', description: 'List themes, or switch with /theme <name>'},
 ];
 
@@ -116,6 +124,8 @@ export function parseInput(text: string): ParsedInput {
     }
     return {openRound: {round: Number(match[1])}};
   }
+  if (text === '/todos') return {toggle: 'todos'};
+  if (text === '/prompt') return {toggle: 'prompt'};
   if (text === '/perf') {
     return {request: {type: 'query.performance'}, responseView: 'perf', paneView: 'perf'};
   }

--- a/clients/tui/src/run-map.ts
+++ b/clients/tui/src/run-map.ts
@@ -8,7 +8,11 @@ import {
 } from './round-timing.js';
 
 export type AgentPhaseStatus = 'pending' | 'active' | 'completed' | 'failed';
-export type RoundStatus = 'active' | 'completed' | 'failed';
+/**
+ * ``planned`` is not an observed state: it stands for a round the run intends to
+ * reach, so the strip can show the whole run rather than only what has happened.
+ */
+export type RoundStatus = 'active' | 'completed' | 'failed' | 'planned';
 
 export interface RoundSummary extends RoundTimingState {
   number: number;

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from 'bun:test';
 import type {EventSubscription} from './client.js';
 import type {ProtocolResponse, RequestInput, RunEvent, ServerMessage} from './protocol.js';
 import {SocketSessionController, type SupervisionTransport} from './session-controller.js';
+import {chatPaneVisible, experimentLogVisible} from './session-model.js';
 
 describe('session controller', () => {
   it('shows local help without sending a backend command', async () => {
@@ -16,14 +17,17 @@ describe('session controller', () => {
     expect(transport.requests).toEqual([]);
   });
 
-  it('sends ordinary text to the multi-turn chat panel', async () => {
+  it('sends ordinary text to the chat docked beside the log', async () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
 
     await controller.submit('what is happening?');
 
     expect(transport.requests).toEqual([{type: 'query.chat', text: 'what is happening?'}]);
-    expect(controller.state.chatOpen).toBe(true);
+    // The pane is part of the landing view, so nothing opens over the table.
+    expect(controller.state.chatOpen).toBe(false);
+    expect(chatPaneVisible(controller.state)).toBe(true);
+    expect(experimentLogVisible(controller.state)).toBe(true);
     expect(controller.state.chatConversation).toMatchObject([
       {kind: 'user', label: 'You', content: 'what is happening?'},
       {kind: 'assistant', label: 'Answer', content: 'The implementer is running.'},
@@ -119,7 +123,10 @@ describe('session controller', () => {
 
     await controller.submit('/chat');
 
-    expect(controller.state.chatOpen).toBe(true);
+    // Already on screen: /chat puts the pane keys on it instead of opening a
+    // modal over the log.
+    expect(controller.state.chatOpen).toBe(false);
+    expect(controller.state.layout.focus).toBe('chat');
     expect(transport.requests).toEqual([]);
 
     await controller.sendChat('what changed?');
@@ -138,6 +145,99 @@ describe('session controller', () => {
     expect(controller.state.chatConversation).toHaveLength(4);
   });
 
+  it('opens the chat as a modal where it cannot dock', async () => {
+    const transport = new FakeTransport();
+    const controller = new SocketSessionController(transport);
+    // A terminal too narrow for two columns, reported by the renderer.
+    controller.setChatDockFits(false);
+
+    await controller.submit('what is happening?');
+
+    expect(controller.state.chatOpen).toBe(true);
+    expect(chatPaneVisible(controller.state)).toBe(false);
+    expect(controller.state.chatConversation.at(-1)?.content).toBe('The implementer is running.');
+  });
+
+  it('keeps the log as the view when the chat opens over it', async () => {
+    const transport = new FakeTransport();
+    transport.experiments = [entry('H-01', 1, 1, {resolved_outcome: 'proven'})];
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+    // Too narrow to dock, so the question opens the modal.
+    controller.setChatDockFits(false);
+
+    await controller.sendChat('what is happening?');
+
+    expect(controller.state.chatOpen).toBe(true);
+    // The modal floats over the table. It must not put the operator into the
+    // per-round transcript they never asked for.
+    expect(experimentLogVisible(controller.state)).toBe(true);
+    expect(controller.state.hypothesisScope).toBeNull();
+    expect(controller.state.experimentLog?.entries).toHaveLength(1);
+  });
+
+  it('offers /chat in help only where the chat is not already on screen', async () => {
+    const transport = new FakeTransport();
+    transport.experiments = [
+      entry('H-01', 1, 1, {rounds: [{round: 1, passed: true, reviewed: true}]}),
+    ];
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+
+    await controller.submit('/help');
+    expect(controller.state.overlay?.content).not.toContain('/chat');
+
+    // Inside a hypothesis the chat is a dialog again, so the command returns.
+    controller.enterExperimentDrilldown();
+    await controller.submit('/help');
+    expect(controller.state.overlay?.content).toContain('/chat');
+  });
+
+  it('carries the modal conversation back into the docked pane', async () => {
+    const transport = new FakeTransport();
+    transport.experiments = [
+      entry('H-01', 1, 1, {rounds: [{round: 1, passed: true, reviewed: true}]}),
+    ];
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+    controller.enterExperimentDrilldown();
+
+    // Asked from the trajectory view, where the chat is a pop-up.
+    await controller.submit('/chat why did r1 fail?');
+    expect(controller.state.chatOpen).toBe(true);
+
+    controller.live();
+
+    // Back on the landing view the same conversation is in the column, both
+    // the question and what came back.
+    expect(chatPaneVisible(controller.state)).toBe(true);
+    expect(controller.state.chatConversation.map(entry => entry.content)).toEqual([
+      'why did r1 fail?',
+      'The implementer is running.',
+    ]);
+  });
+
+  it('opens the chat as a modal inside a hypothesis', async () => {
+    const transport = new FakeTransport();
+    transport.experiments = [
+      entry('H-01', 1, 1, {rounds: [{round: 1, passed: true, reviewed: true}]}),
+    ];
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+    controller.enterExperimentDrilldown();
+
+    await controller.sendChat('why did r1 fail?');
+
+    // The row belongs to the transcript here, so the chat is the dialog it was.
+    expect(controller.state.chatOpen).toBe(true);
+
+    // Back on the landing view it docks again, transcript intact.
+    controller.live();
+    expect(controller.state.chatOpen).toBe(false);
+    expect(chatPaneVisible(controller.state)).toBe(true);
+    expect(controller.state.chatConversation.at(0)?.content).toBe('why did r1 fail?');
+  });
+
   it('opens chat and sends an initial message from the command line', async () => {
     const transport = new FakeTransport([], [], {
       question: 'why?',
@@ -148,7 +248,8 @@ describe('session controller', () => {
 
     await controller.submit('/chat why?');
 
-    expect(controller.state.chatOpen).toBe(true);
+    expect(controller.state.chatOpen).toBe(false);
+    expect(controller.state.layout.focus).toBe('chat');
     expect(transport.requests).toEqual([{type: 'query.chat', text: 'why?'}]);
   });
 
@@ -591,11 +692,29 @@ describe('session controller', () => {
     controller.closePane();
 
     expect(controller.state.layout.right).toBeNull();
-    expect(controller.state.chatOpen).toBe(true);
+    expect(chatPaneVisible(controller.state)).toBe(true);
     expect(controller.state.chatConversation.map(entry => entry.content)).toEqual([
       'why?',
       'Round 2 regressed.',
     ]);
+  });
+
+  it('keeps the docked chat beside the log while a visualization is open', async () => {
+    const transport = new FakeTransport(
+      [],
+      [{round: 1, perf_metric: 1200, perf_unit: 'ops', passed: true, profile_skipped: false}],
+    );
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+
+    await controller.submit('/perf');
+    await controller.sendChat('what changed in r1?');
+
+    // Three columns: chat, log, pane. None of them replaced another.
+    expect(controller.state.layout.right?.view).toBe('perf');
+    expect(chatPaneVisible(controller.state)).toBe(true);
+    expect(experimentLogVisible(controller.state)).toBe(true);
+    expect(controller.state.chatConversation.at(0)?.content).toBe('what changed in r1?');
   });
 
   it('sends chat messages while the pane stays put', async () => {

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -132,17 +132,17 @@ describe('session controller', () => {
     await controller.sendChat('what changed?');
 
     expect(transport.requests).toEqual([{type: 'query.chat', text: 'what changed?'}]);
+    // The exchange, and only the exchange: the chat agent's own narration and
+    // tool turns belong in the transcript, not on top of the answer.
     expect(controller.state.chatConversation.map(entry => entry.kind)).toEqual([
       'user',
-      'analysis',
-      'tool',
       'assistant',
     ]);
     expect(controller.state.chatConversation.at(-1)?.content).toBe('Round 2 improved throughput.');
 
     controller.closeChat();
     expect(controller.state.chatOpen).toBe(false);
-    expect(controller.state.chatConversation).toHaveLength(4);
+    expect(controller.state.chatConversation).toHaveLength(2);
   });
 
   it('opens the chat as a modal where it cannot dock', async () => {
@@ -588,7 +588,9 @@ describe('session controller', () => {
     await controller.submit('/open-round');
 
     expect(controller.state.hypothesisScope).toMatchObject({id: 'H-02', rounds: [2, 3]});
-    expect(controller.state.selectedRound).toBeNull();
+    // Lands on the hypothesis's latest round: the round view is built around
+    // one round, and `[` walks back through the earlier ones.
+    expect(controller.state.selectedRound).toBe(3);
   });
 
   it('opens the hypothesis owning a round with /open-round --N', async () => {

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -1,24 +1,30 @@
 import type {EventSubscription} from './client.js';
-import {HELP_TEXT, parseInput} from './commands.js';
+import {helpText, parseInput} from './commands.js';
 import {renderPerformanceCurve} from './performance-chart.js';
 import type {ProtocolResponse, RequestInput, RunEvent, ServerMessage} from './protocol.js';
 import {
   applyEvent,
   applySnapshot,
   type ConversationEntry,
+  chatDocked,
+  chatPaneVisible,
   closePane,
   closeThemePicker,
+  cyclePaneFocus,
   enterExperimentDrilldown,
   enterExperimentRound,
   failExperiments,
   failPane,
+  focusPane,
   initialSessionState,
   leaveExperimentDrilldown,
   moveExperimentSelection,
   moveThemeSelection,
+  openChat,
   openExperimentLog,
   openPane,
   openThemePicker,
+  type PaneFocus,
   type PaneView,
   type SessionState,
   selectNextAgent,
@@ -26,12 +32,12 @@ import {
   selectPreviousAgent,
   selectPreviousRound,
   selectRound,
+  setChatDockFits,
   setExperiments,
   setPaneContent,
   setTheme,
   showDetail,
   showLive,
-  togglePaneFocus,
   toggleTodos,
 } from './session-model.js';
 import {DEFAULT_THEME_NAME, type ThemeName} from './ui/theme.js';
@@ -56,7 +62,9 @@ export interface SessionController {
   openRound(roundNumber?: number): void;
   openPane(view: PaneView): Promise<void>;
   closePane(): void;
-  togglePaneFocus(): void;
+  cyclePaneFocus(): void;
+  focusPane(focus: PaneFocus): void;
+  setChatDockFits(fits: boolean): void;
   moveExperimentSelection(delta: number): void;
   enterExperimentDrilldown(): void;
   leaveExperimentDrilldown(): void;
@@ -219,8 +227,21 @@ export class SocketSessionController implements SessionController {
     this.#setState(closePane(this.#state));
   }
 
-  togglePaneFocus(): void {
-    this.#setState(togglePaneFocus(this.#state));
+  cyclePaneFocus(): void {
+    this.#setState(cyclePaneFocus(this.#state));
+  }
+
+  focusPane(focus: PaneFocus): void {
+    this.#setState(focusPane(this.#state, focus));
+  }
+
+  /**
+   * Reported by the renderer, which is the only part that knows how many
+   * columns there are. It decides whether a question opens the modal or lands
+   * in the pane beside the log.
+   */
+  setChatDockFits(fits: boolean): void {
+    this.#setState(setChatDockFits(this.#state, fits));
   }
 
   /**
@@ -311,7 +332,9 @@ export class SocketSessionController implements SessionController {
     this.#chatQueue.push({id, text});
     this.#setState({
       ...this.#state,
-      chatOpen: true,
+      // Docked, the answer lands in the pane the operator is already looking
+      // at, so nothing has to open over the log to show it.
+      ...(chatDocked(this.#state) ? {} : {chatOpen: true}),
       chatConversation: appendChatEntry(this.#state.chatConversation, {
         id,
         kind: 'user',
@@ -383,10 +406,12 @@ export class SocketSessionController implements SessionController {
     const parsed = parseInput(value.trim());
     if (parsed.error) return this.#setState(showDetail(this.#state, parsed.error, 'error'));
     if (parsed.localView === 'help') {
-      return this.#setState(showDetail(this.#state, HELP_TEXT, 'help'));
+      return this.#setState(
+        showDetail(this.#state, helpText({chatDocked: chatPaneVisible(this.#state)}), 'help'),
+      );
     }
     if (parsed.localView === 'chat') {
-      this.#setState({...this.#state, overlay: null, chatOpen: true});
+      this.#setState(openChat(this.#state));
       if (parsed.chatMessage) await this.sendChat(parsed.chatMessage);
       return;
     }

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -8,6 +8,9 @@ import {
   type ConversationEntry,
   chatDocked,
   chatPaneVisible,
+  clearAgentSelection,
+  clearEntrySelection,
+  closeOverlays,
   closePane,
   closeThemePicker,
   cyclePaneFocus,
@@ -16,19 +19,25 @@ import {
   failExperiments,
   failPane,
   focusPane,
+  focusRound,
   initialSessionState,
   leaveExperimentDrilldown,
   moveExperimentSelection,
   moveThemeSelection,
+  normalizeFocus,
   openChat,
   openExperimentLog,
   openPane,
   openThemePicker,
   type PaneFocus,
   type PaneView,
+  type RoundFocus,
   type SessionState,
+  selectAgent,
   selectNextAgent,
+  selectNextEntry,
   selectNextRound,
+  selectNextTodo,
   selectPreviousAgent,
   selectPreviousRound,
   selectRound,
@@ -56,12 +65,22 @@ export interface SessionController {
   selectNextRound(): void;
   selectPreviousRound(): void;
   selectRound(roundNumber: number): void;
+  selectAgent(kind: string): void;
+  selectNextEntry(delta: number, id?: string): void;
+  clearEntrySelection(): void;
+  clearAgentSelection(): void;
+  focusRound(focus: RoundFocus): void;
+  selectNextTodo(delta: number): void;
   toggleTodos(): void;
+  /** Expands the latest prompt in view; the view owns what "latest" means. */
+  togglePrompt(): void;
+  onTogglePrompt(handler: () => void): void;
   setTheme(themeName: ThemeName): void;
   openExperimentLog(): Promise<void>;
   openRound(roundNumber?: number): void;
   openPane(view: PaneView): Promise<void>;
   closePane(): void;
+  closeOverlays(): void;
   cyclePaneFocus(): void;
   focusPane(focus: PaneFocus): void;
   setChatDockFits(fits: boolean): void;
@@ -138,6 +157,30 @@ export class SocketSessionController implements SessionController {
     this.#setState(showLive(this.#state));
   }
 
+  selectAgent(kind: string): void {
+    this.#setState(selectAgent(this.#state, kind));
+  }
+
+  selectNextEntry(delta: number, id?: string): void {
+    this.#setState(selectNextEntry(this.#state, delta, id));
+  }
+
+  clearEntrySelection(): void {
+    this.#setState(clearEntrySelection(this.#state));
+  }
+
+  clearAgentSelection(): void {
+    this.#setState(clearAgentSelection(this.#state));
+  }
+
+  focusRound(focus: RoundFocus): void {
+    this.#setState(focusRound(this.#state, focus));
+  }
+
+  selectNextTodo(delta: number): void {
+    this.#setState(selectNextTodo(this.#state, delta));
+  }
+
   selectNextAgent(): void {
     this.#setState(selectNextAgent(this.#state));
   }
@@ -156,6 +199,21 @@ export class SocketSessionController implements SessionController {
 
   selectRound(roundNumber: number): void {
     this.#setState(selectRound(this.#state, roundNumber));
+  }
+
+  #promptToggle: (() => void) | null = null;
+
+  /**
+   * The prompt lives in the transcript, so the view performs the toggle; the
+   * controller only routes the request, which is what lets a slash command and
+   * a key do the same thing.
+   */
+  onTogglePrompt(handler: () => void): void {
+    this.#promptToggle = handler;
+  }
+
+  togglePrompt(): void {
+    this.#promptToggle?.();
   }
 
   toggleTodos(): void {
@@ -225,6 +283,10 @@ export class SocketSessionController implements SessionController {
 
   closePane(): void {
     this.#setState(closePane(this.#state));
+  }
+
+  closeOverlays(): void {
+    this.#setState(closeOverlays(this.#state));
   }
 
   cyclePaneFocus(): void {
@@ -415,6 +477,14 @@ export class SocketSessionController implements SessionController {
       if (parsed.chatMessage) await this.sendChat(parsed.chatMessage);
       return;
     }
+    if (parsed.toggle === 'todos') {
+      this.toggleTodos();
+      return;
+    }
+    if (parsed.toggle === 'prompt') {
+      this.togglePrompt();
+      return;
+    }
     if (parsed.openRound) {
       this.openRound(parsed.openRound.round);
       return;
@@ -475,8 +545,11 @@ export class SocketSessionController implements SessionController {
   }
 
   #setState(state: SessionState): void {
-    this.#state = state;
-    for (const listener of this.#listeners) listener(state);
+    // Every state change goes through here, which makes it the one place that
+    // can guarantee focus still names a column that exists. A pane that closes
+    // while it holds the keys would otherwise swallow every keystroke.
+    this.#state = normalizeFocus(state);
+    for (const listener of this.#listeners) listener(this.#state);
   }
 }
 

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -2,20 +2,27 @@ import {describe, expect, it} from 'bun:test';
 import type {RunEvent} from './protocol.js';
 import {
   applyEvent,
+  chatDocked,
+  chatPaneVisible,
   closePane,
   closeThemePicker,
+  cyclePaneFocus,
+  enterExperimentDrilldown,
   failPane,
+  focusPane,
   initialSessionState,
   moveThemeSelection,
+  openChat,
   openPane,
   openThemePicker,
   selectNextAgent,
   selectNextRound,
   selectRound,
+  setChatDockFits,
+  setExperiments,
   setPaneContent,
   setTheme,
   statusText,
-  togglePaneFocus,
   toggleTodos,
   visibleConversation,
   visiblePhases,
@@ -604,6 +611,56 @@ describe('session event model', () => {
   });
 });
 
+describe('docked experiment chat', () => {
+  const entry = {
+    hypothesis_id: 'H-01',
+    identified: true,
+    first_round: 1,
+    last_round: 1,
+    rounds: [{round: 1, passed: true, reviewed: true}],
+    kept: false,
+    active: false,
+  };
+
+  it('docks beside the log and nowhere else', () => {
+    const landing = setExperiments(initialSessionState(), [entry]);
+    expect(chatDocked(landing)).toBe(true);
+    expect(chatPaneVisible(landing)).toBe(true);
+
+    // Inside a hypothesis the row belongs to the transcript.
+    const scoped = enterExperimentDrilldown(landing);
+    expect(scoped.hypothesisScope).not.toBeNull();
+    expect(chatDocked(scoped)).toBe(false);
+  });
+
+  it('stops docking in a terminal too narrow for two columns', () => {
+    const narrow = setChatDockFits(initialSessionState(), false);
+
+    expect(chatDocked(narrow)).toBe(false);
+    expect(chatPaneVisible(narrow)).toBe(false);
+  });
+
+  it('gives the pane the keys instead of opening a modal over the table', () => {
+    const opened = openChat(initialSessionState());
+
+    expect(opened.chatOpen).toBe(false);
+    expect(opened.layout.focus).toBe('chat');
+  });
+
+  it('still opens the modal where the chat cannot dock', () => {
+    const narrow = setChatDockFits(initialSessionState(), false);
+
+    expect(openChat(narrow).chatOpen).toBe(true);
+  });
+
+  it('yields to the modal while one is open', () => {
+    const modal = {...initialSessionState(), chatOpen: true};
+
+    expect(chatDocked(modal)).toBe(true);
+    expect(chatPaneVisible(modal)).toBe(false);
+  });
+});
+
 describe('right pane layout', () => {
   it('starts single-pane with focus on the transcript', () => {
     const state = initialSessionState();
@@ -641,21 +698,48 @@ describe('right pane layout', () => {
     expect(failed.layout.right?.pending).toBe(false);
   });
 
-  it('moves focus between panes and returns it on close', () => {
+  it('cycles focus left to right through the columns on screen', () => {
+    // The landing view carries the docked chat, so opening a visualization
+    // makes three columns: chat, log, pane.
     const open = openPane(initialSessionState(), 'perf');
-    expect(togglePaneFocus(open).layout.focus).toBe('left');
-    expect(togglePaneFocus(togglePaneFocus(open)).layout.focus).toBe('right');
+    expect(open.layout.focus).toBe('right');
+    const first = cyclePaneFocus(open);
+    expect(first.layout.focus).toBe('chat');
+    expect(cyclePaneFocus(first).layout.focus).toBe('left');
+    expect(cyclePaneFocus(cyclePaneFocus(first)).layout.focus).toBe('right');
 
     const closed = closePane(open);
     expect(closed.layout.right).toBeNull();
     expect(closed.layout.focus).toBe('left');
   });
 
-  it('does nothing to focus while single-pane', () => {
-    const single = initialSessionState();
+  it('cycles between the chat and the log while no visualization is open', () => {
+    const docked = initialSessionState();
 
-    expect(togglePaneFocus(single)).toBe(single);
+    expect(cyclePaneFocus(docked).layout.focus).toBe('chat');
+    expect(cyclePaneFocus(cyclePaneFocus(docked)).layout.focus).toBe('left');
+  });
+
+  it('does nothing to focus when only one column is on screen', () => {
+    // Too narrow for the dock and no visualization: the log has the row.
+    const single = setChatDockFits(initialSessionState(), false);
+
+    expect(cyclePaneFocus(single)).toBe(single);
     expect(closePane(single)).toBe(single);
+  });
+
+  it('refuses focus for a column that is not on screen', () => {
+    const narrow = setChatDockFits(initialSessionState(), false);
+
+    expect(focusPane(narrow, 'chat')).toBe(narrow);
+    expect(focusPane(initialSessionState(), 'right').layout.focus).toBe('left');
+    expect(focusPane(initialSessionState(), 'chat').layout.focus).toBe('chat');
+  });
+
+  it('hands the keys back to the log when the dock stops fitting', () => {
+    const focused = focusPane(initialSessionState(), 'chat');
+
+    expect(setChatDockFits(focused, false).layout.focus).toBe('left');
   });
 
   it('leaves the chat transcript untouched when the pane closes', () => {

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -1,5 +1,6 @@
-import {describe, expect, it} from 'bun:test';
+import {describe, expect, it, test} from 'bun:test';
 import type {RunEvent} from './protocol.js';
+import type {SessionState} from './session-model.js';
 import {
   applyEvent,
   chatDocked,
@@ -8,9 +9,11 @@ import {
   closeThemePicker,
   cyclePaneFocus,
   enterExperimentDrilldown,
+  enterExperimentRound,
   failPane,
   focusPane,
   initialSessionState,
+  leaveExperimentDrilldown,
   moveThemeSelection,
   openChat,
   openPane,
@@ -22,6 +25,7 @@ import {
   setExperiments,
   setPaneContent,
   setTheme,
+  showDetail,
   statusText,
   toggleTodos,
   visibleConversation,
@@ -148,15 +152,8 @@ describe('session event model', () => {
 
     expect(state.conversation).toEqual([]);
     expect(state.agentKind).toBeNull();
-    expect(state.chatConversation.map(entry => entry.kind)).toEqual([
-      'analysis',
-      'tool',
-      'assistant',
-    ]);
-    expect(state.chatConversation[1]).toMatchObject({
-      toolCall: '→ read_file(path="progress.md")\n',
-      toolResponse: 'Round 2 improved throughput.',
-    });
+    // Routed to the chat, and filtered there to the answer itself.
+    expect(state.chatConversation.map(entry => entry.kind)).toEqual(['assistant']);
     expect(state.chatConversation.at(-1)?.content).toBe('Round 2 improved throughput.');
   });
 
@@ -824,5 +821,86 @@ describe('theme picker', () => {
     expect(setTheme(opened, 'light').themeName).toBe('light');
     // Re-applying the active theme is still an answer to the picker.
     expect(setTheme(opened, 'dark').themePicker).toBeNull();
+  });
+});
+
+describe('re-entering a round after leaving it', () => {
+  const hypothesis = {
+    hypothesis_id: 'H1',
+    first_round: 1,
+    last_round: 2,
+    rounds: [{round: 1}, {round: 2}],
+  } as never;
+
+  function scoped() {
+    const base: SessionState = {
+      ...initialSessionState(),
+      rounds: [
+        {number: 1, status: 'completed'},
+        {number: 2, status: 'active'},
+      ],
+      phases: [
+        {
+          kind: 'implementer',
+          status: 'completed',
+          roundNumber: 1,
+          roundLabel: 'round-1-implementer',
+        },
+        {kind: 'judge', status: 'completed', roundNumber: 1, roundLabel: 'round-1-judge'},
+      ],
+      conversation: [
+        {id: 'a', kind: 'assistant', label: 'implementer', content: 'patched', roundNumber: 1},
+      ],
+    };
+    return setExperiments(base, [hypothesis]);
+  }
+
+  test('shows the round again after leaving and coming back through an error', () => {
+    const withLog = scoped();
+    const first = enterExperimentRound(withLog, 1);
+    expect(first).not.toBeNull();
+    expect(visiblePhases(first as SessionState)).toHaveLength(2);
+    expect(visibleConversation(first as SessionState)).toHaveLength(1);
+
+    const left = leaveExperimentDrilldown(first as SessionState);
+    const errored = showDetail(left, 'Unknown command: /nope. Use /help.');
+    const again = enterExperimentRound(errored, 1);
+    expect(again).not.toBeNull();
+    expect(visiblePhases(again as SessionState)).toHaveLength(2);
+    expect(visibleConversation(again as SessionState)).toHaveLength(1);
+  });
+});
+
+describe('a long run', () => {
+  test('keeps an earlier round openable after thousands of entries', () => {
+    let state: SessionState = initialSessionState();
+    // Two hundred rounds of chatter: far past any per-entry cap.
+    for (let round = 1; round <= 200; round += 1) {
+      for (let turn = 0; turn < 30; turn += 1) {
+        state = applyEvent(state, {
+          sequence: round * 100 + turn,
+          timestamp: '2026-01-01T00:00:00Z',
+          type: 'agent_output_chunk',
+          agent_kind: 'implementer',
+          round_label: `round-${round}-implementer`,
+          invocation_id: `impl-${round}-${turn}`,
+          data: {
+            kind: 'agent_output_chunk',
+            channel: 'assistant',
+            content: `round ${round} turn ${turn}`,
+          },
+        } as RunEvent);
+      }
+    }
+
+    // The round the operator opens still has its turns, whole.
+    const late = {...state, selectedRound: 200};
+    expect(visibleConversation(late).length).toBeGreaterThan(0);
+
+    // And a round from early in the run is either fully there or fully gone,
+    // never a fragment that reads as a round which barely ran.
+    const early = {...state, selectedRound: 150};
+    const entries = visibleConversation(early);
+    expect(entries.length === 0 || entries.length >= 30).toBe(true);
   });
 });

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -33,6 +33,13 @@ export interface SessionState {
   experimentLog: ExperimentLogState | null;
   hypothesisScope: HypothesisScope | null;
   layout: LayoutState;
+  /**
+   * Whether the terminal is wide enough to carry the docked chat beside the
+   * log. Measured by the renderer and reported in, because where a question's
+   * answer is displayed has to agree with what is actually on screen: too
+   * narrow to dock and the chat is the modal it has always been.
+   */
+  chatDockFits: boolean;
   /** Non-null while the theme list is open as a keyboard selection. */
   themePicker: ThemePicker | null;
   /**
@@ -97,10 +104,17 @@ export interface RightPane {
   error: string | null;
 }
 
+/**
+ * Which column the pane keys act on. ``left`` is whatever holds the middle of
+ * the row, the experiment log or the transcript; ``chat`` and ``right`` are the
+ * panes beside it.
+ */
+export type PaneFocus = 'chat' | 'left' | 'right';
+
 export interface LayoutState {
-  /** null means single-pane: the transcript has the full width. */
+  /** null means no visualization pane: the left side has the rest of the row. */
   right: RightPane | null;
-  focus: 'left' | 'right';
+  focus: PaneFocus;
 }
 
 export interface ThemePicker {
@@ -172,6 +186,9 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
     experimentLog: {entries: [], selectedId: null, pending: true, error: null},
     hypothesisScope: null,
     layout: {right: null, focus: 'left'},
+    // Docked until the renderer measures otherwise, so the landing view carries
+    // the chat from the first frame rather than after a resize.
+    chatDockFits: true,
     themePicker: null,
     typedToolEvents: false,
   };
@@ -188,9 +205,57 @@ export function entryKey(entry: HypothesisEntry, index: number): string {
     : entry.hypothesis_id || `#${index}`;
 }
 
-/** True when the table itself is on screen rather than a hypothesis trajectory. */
+/**
+ * True when the table itself is on screen rather than a hypothesis trajectory.
+ * The chat does not enter into it: docked it is part of this view, and as a
+ * modal it floats over it, so asking a question never swaps the table for the
+ * per-round transcript underneath.
+ */
 export function experimentLogVisible(state: SessionState): boolean {
-  return state.experimentLog !== null && state.hypothesisScope === null && !state.chatOpen;
+  return state.experimentLog !== null && state.hypothesisScope === null;
+}
+
+/**
+ * The chat is docked on the landing view: it is part of that view rather than a
+ * dialog over it, so a question never hides the table it is about. Inside a
+ * hypothesis, and in a terminal too narrow for two columns, it stays the modal
+ * it was.
+ */
+export function chatDocked(state: SessionState): boolean {
+  return state.chatDockFits && state.experimentLog !== null && state.hypothesisScope === null;
+}
+
+/** True when the docked chat is the thing on screen rather than the modal. */
+export function chatPaneVisible(state: SessionState): boolean {
+  return chatDocked(state) && !state.chatOpen;
+}
+
+export function chatPaneFocused(state: SessionState): boolean {
+  return chatPaneVisible(state) && state.layout.focus === 'chat';
+}
+
+export function rightPaneFocused(state: SessionState): boolean {
+  return state.layout.right !== null && state.layout.focus === 'right';
+}
+
+export function setChatDockFits(state: SessionState, fits: boolean): SessionState {
+  if (state.chatDockFits === fits) return state;
+  const layout =
+    fits || state.layout.focus !== 'chat'
+      ? state.layout
+      : {...state.layout, focus: 'left' as const};
+  return {...state, chatDockFits: fits, layout};
+}
+
+/**
+ * What ``/chat`` does. Docked, the chat is already on screen, so opening it
+ * means putting the pane keys on it rather than covering the table.
+ */
+export function openChat(state: SessionState): SessionState {
+  if (chatDocked(state)) {
+    return {...state, overlay: null, layout: {...state.layout, focus: 'chat'}};
+  }
+  return {...state, overlay: null, chatOpen: true};
 }
 
 export function openExperimentLog(state: SessionState): SessionState {
@@ -373,12 +438,30 @@ export function closePane(state: SessionState): SessionState {
   return {...state, layout: {right: null, focus: 'left'}};
 }
 
-export function togglePaneFocus(state: SessionState): SessionState {
-  if (state.layout.right === null) return state;
-  return {
-    ...state,
-    layout: {...state.layout, focus: state.layout.focus === 'left' ? 'right' : 'left'},
-  };
+/**
+ * Moves the pane keys one column to the right, wrapping. Only the columns
+ * actually on screen take part, so the operator never lands on a pane they
+ * cannot see.
+ */
+export function cyclePaneFocus(state: SessionState): SessionState {
+  const order = visiblePaneOrder(state);
+  if (order.length < 2) return state;
+  const next = order[(order.indexOf(state.layout.focus) + 1) % order.length] ?? 'left';
+  return {...state, layout: {...state.layout, focus: next}};
+}
+
+export function focusPane(state: SessionState, focus: PaneFocus): SessionState {
+  if (state.layout.focus === focus) return state;
+  if (!visiblePaneOrder(state).includes(focus)) return state;
+  return {...state, layout: {...state.layout, focus}};
+}
+
+function visiblePaneOrder(state: SessionState): PaneFocus[] {
+  return [
+    ...(chatPaneVisible(state) ? (['chat'] as const) : []),
+    'left' as const,
+    ...(state.layout.right !== null ? (['right'] as const) : []),
+  ];
 }
 
 export function setTheme(state: SessionState, themeName: ThemeName): SessionState {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -16,9 +16,21 @@ export interface SessionState {
   roundLabel: string | null;
   outerLoop: string | null;
   rounds: RoundSummary[];
+  /** Rounds the run intends to reach, from ``run_started``; null until it arrives. */
+  maxRounds: number | null;
   phases: AgentPhase[];
   selectedRound: number | null;
   selectedAgentKind: string | null;
+  /** Transcript entry the arrow keys are on, so a trace is readable without a mouse. */
+  selectedEntryId: string | null;
+  /** Todo row the arrow keys are on while the todo box holds focus. */
+  selectedTodoIndex: number | null;
+  /**
+   * Which half of the round view the arrow keys act on. The round view is two
+   * panes side by side, and both are navigable, so the keys have to belong to
+   * one of them at a time.
+   */
+  roundFocus: RoundFocus;
   conversation: ConversationEntry[];
   overlay: OverlayPanel | null;
   chatOpen: boolean;
@@ -49,6 +61,9 @@ export interface SessionState {
    */
   typedToolEvents: boolean;
 }
+
+/** The agent graph on the left, or the transcript on the right. */
+export type RoundFocus = 'agents' | 'transcript';
 
 export interface TodoItem {
   content: string;
@@ -167,9 +182,13 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
     roundLabel: null,
     outerLoop: null,
     rounds: [],
+    maxRounds: null,
     phases: [],
     selectedRound: null,
     selectedAgentKind: null,
+    selectedEntryId: null,
+    selectedTodoIndex: null,
+    roundFocus: 'transcript',
     conversation: [],
     overlay: null,
     chatOpen: false,
@@ -297,8 +316,13 @@ export function moveExperimentSelection(state: SessionState, delta: number): Ses
   const log = state.experimentLog;
   if (log === null || state.hypothesisScope !== null || log.entries.length === 0) return state;
   const keys = log.entries.map(entryKey);
-  const current = log.selectedId === null ? 0 : keys.indexOf(log.selectedId);
-  const index = Math.min(keys.length - 1, Math.max(0, (current === -1 ? 0 : current) + delta));
+  const current = log.selectedId === null ? -1 : keys.indexOf(log.selectedId);
+  // With nothing selected the first key lands on the first row rather than
+  // stepping past it: the table has a selection the moment it is used.
+  if (current === -1) {
+    return {...state, experimentLog: {...log, selectedId: keys[0] ?? null}};
+  }
+  const index = Math.min(keys.length - 1, Math.max(0, current + delta));
   return {...state, experimentLog: {...log, selectedId: keys[index] ?? null}};
 }
 
@@ -314,9 +338,19 @@ export function enterExperimentDrilldown(state: SessionState): SessionState {
   return {
     ...state,
     overlay: null,
+    // A visualization opened from the log belongs to the log. Carrying it into
+    // the round view would leave the operator reading one view's answer beside
+    // another view's transcript.
+    layout: {right: null, focus: 'left'},
     hypothesisScope: {id: entry.hypothesis_id, label: hypothesisLabel(entry), rounds},
-    selectedRound: null,
+    // Land on the hypothesis's latest round rather than on "no round". The
+    // round view is built around one round: the strip marks it, the agent graph
+    // draws its phases, the transcript carries its turns. Leaving the round
+    // unset drew an empty strip and an empty graph, and `[` walks back through
+    // the earlier rounds from here anyway.
+    selectedRound: rounds.at(-1) ?? null,
     selectedAgentKind: null,
+    selectedEntryId: null,
   };
 }
 
@@ -343,6 +377,7 @@ export function enterExperimentRound(
     ...state,
     overlay: null,
     chatOpen: false,
+    layout: {right: null, focus: 'left'},
     hypothesisScope: {
       id: entry.hypothesis_id,
       label: hypothesisLabel(entry),
@@ -350,6 +385,7 @@ export function enterExperimentRound(
     },
     selectedRound: roundNumber,
     selectedAgentKind: null,
+    selectedEntryId: null,
     experimentLog:
       state.experimentLog === null
         ? null
@@ -448,6 +484,29 @@ export function cyclePaneFocus(state: SessionState): SessionState {
   if (order.length < 2) return state;
   const next = order[(order.indexOf(state.layout.focus) + 1) % order.length] ?? 'left';
   return {...state, layout: {...state.layout, focus: next}};
+}
+
+/**
+ * Focus has to name a column that is actually on screen. A pane can close, or a
+ * view can change, while the keys still point at it, and every keystroke then
+ * goes to a surface that is not there: the client looks frozen. Called on every
+ * state change, so focus can never be left pointing at nothing.
+ */
+export function normalizeFocus(state: SessionState): SessionState {
+  const order = visiblePaneOrder(state);
+  if (order.includes(state.layout.focus)) return state;
+  return {...state, layout: {...state.layout, focus: 'left'}};
+}
+
+/** Escape from a round view: close whatever is layered over it, all of it. */
+export function closeOverlays(state: SessionState): SessionState {
+  if (state.layout.right === null && !state.chatOpen && state.overlay === null) return state;
+  return {
+    ...state,
+    overlay: null,
+    chatOpen: false,
+    layout: {right: null, focus: 'left'},
+  };
 }
 
 export function focusPane(state: SessionState, focus: PaneFocus): SessionState {
@@ -560,6 +619,7 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
 
   if (event.type === 'run_started') {
     next.status = 'running';
+    if (event.data?.kind === 'run_started') next.maxRounds = event.data.max_rounds;
   }
   if (event.type === 'configuration_failed') {
     next.status = 'failed';
@@ -576,6 +636,13 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
   return next;
 }
 
+/**
+ * The chat shows the exchange: what was asked, and what came back. The chat
+ * agent's narration, tool turns, and phase markers are run plumbing; they
+ * belong in the transcript, and here they only bury the answer.
+ */
+const CHAT_KINDS: ReadonlySet<ConversationEntry['kind']> = new Set(['user', 'assistant', 'result']);
+
 function applyChatEvent(state: SessionState, event: RunEvent): SessionState {
   const next = {...state};
   const data = event.data;
@@ -586,6 +653,10 @@ function applyChatEvent(state: SessionState, event: RunEvent): SessionState {
     data?.kind === 'agent_output_chunk' && data.channel === 'tool' && next.chatTypedToolEvents;
   if (suppressed) return next;
   const entry = eventToConversationEntry(event);
+  // The chat is a question and its answer. The chat agent's own diagnostics and
+  // phase markers are run plumbing: they belong in the transcript, and in the
+  // chat they only bury the answer the operator asked for.
+  if (entry !== null && !CHAT_KINDS.has(entry.kind)) return next;
   if (entry !== null) {
     next.chatConversation = appendConversation(next.chatConversation, entry);
   }
@@ -598,7 +669,7 @@ export function selectNextAgent(state: SessionState): SessionState {
   const current = state.selectedAgentKind;
   const index = current === null ? -1 : phases.findIndex(phase => phase.kind === current);
   const next = phases[(index + 1 + phases.length) % phases.length];
-  return {...state, selectedAgentKind: next?.kind ?? null, overlay: null};
+  return {...state, selectedAgentKind: next?.kind ?? null, roundFocus: 'agents', overlay: null};
 }
 
 export function selectPreviousAgent(state: SessionState): SessionState {
@@ -607,20 +678,31 @@ export function selectPreviousAgent(state: SessionState): SessionState {
   const current = state.selectedAgentKind;
   const index = current === null ? 0 : phases.findIndex(phase => phase.kind === current);
   const previous = phases[(index - 1 + phases.length) % phases.length];
-  return {...state, selectedAgentKind: previous?.kind ?? null, overlay: null};
+  return {
+    ...state,
+    selectedAgentKind: previous?.kind ?? null,
+    roundFocus: 'agents',
+    overlay: null,
+  };
 }
 
 export function selectNextRound(state: SessionState): SessionState {
-  const rounds = scopedRounds(state);
+  const rounds = stripRounds(state);
   if (rounds.length === 0) return state;
   const visible = visibleRoundNumber(state);
   const index = visible === null ? -1 : rounds.findIndex(round => round.number === visible);
   const next = rounds[(index + 1 + rounds.length) % rounds.length];
-  return {...state, selectedRound: next?.number ?? null, selectedAgentKind: null, overlay: null};
+  return {
+    ...state,
+    selectedRound: next?.number ?? null,
+    selectedAgentKind: null,
+    selectedEntryId: null,
+    overlay: null,
+  };
 }
 
 export function selectPreviousRound(state: SessionState): SessionState {
-  const rounds = scopedRounds(state);
+  const rounds = stripRounds(state);
   if (rounds.length === 0) return state;
   const visible = visibleRoundNumber(state);
   const index = visible === null ? 0 : rounds.findIndex(round => round.number === visible);
@@ -629,17 +711,102 @@ export function selectPreviousRound(state: SessionState): SessionState {
     ...state,
     selectedRound: previous?.number ?? null,
     selectedAgentKind: null,
+    selectedEntryId: null,
     overlay: null,
   };
 }
 
 export function selectRound(state: SessionState, roundNumber: number): SessionState {
-  if (!scopedRounds(state).some(round => round.number === roundNumber)) return state;
-  return {...state, selectedRound: roundNumber, selectedAgentKind: null, overlay: null};
+  if (!stripRounds(state).some(round => round.number === roundNumber)) return state;
+  return {
+    ...state,
+    selectedRound: roundNumber,
+    selectedAgentKind: null,
+    selectedEntryId: null,
+    overlay: null,
+  };
 }
 
 export function clearAgentSelection(state: SessionState): SessionState {
-  return {...state, selectedAgentKind: null, overlay: null};
+  return {
+    ...state,
+    selectedAgentKind: null,
+    selectedEntryId: null,
+    roundFocus: 'transcript',
+    overlay: null,
+  };
+}
+
+/**
+ * Picks one agent out of the round, or clears the pick when it is already the
+ * selected one, so clicking a node twice behaves the way a toggle should. The
+ * transcript follows the selection, so the entry cursor starts over with it.
+ */
+export function selectAgent(state: SessionState, kind: string): SessionState {
+  const selected = state.selectedAgentKind === kind ? null : kind;
+  return {
+    ...state,
+    selectedAgentKind: selected,
+    selectedEntryId: null,
+    roundFocus: 'agents',
+    overlay: null,
+  };
+}
+
+/**
+ * Moves the transcript cursor. The cursor is an entry id rather than an index
+ * because the visible list changes underneath it as the run streams: an id
+ * still points at the same turn after new output arrives.
+ */
+export function selectNextEntry(state: SessionState, delta: number, id?: string): SessionState {
+  const entries = visibleConversation(state);
+  if (entries.length === 0) return state;
+  // A click names the entry outright; the keys step from wherever the cursor is.
+  if (id !== undefined) {
+    if (!entries.some(entry => entry.id === id)) return state;
+    return {...state, selectedEntryId: state.selectedEntryId === id ? null : id};
+  }
+  const current =
+    state.selectedEntryId === null
+      ? -1
+      : entries.findIndex(entry => entry.id === state.selectedEntryId);
+  // No cursor yet: step in from the end the operator is moving away from.
+  const start = current === -1 ? (delta > 0 ? -1 : entries.length) : current;
+  const index = Math.min(entries.length - 1, Math.max(0, start + delta));
+  return {...state, selectedEntryId: entries[index]?.id ?? null};
+}
+
+/**
+ * Moves the round view's keys one pane over, in the direction the arrow points.
+ * The agent graph is the left pane and the transcript the right one, so this is
+ * the spatial move; at either edge it stays put rather than wrapping, because
+ * wrapping across the width of the screen is disorienting.
+ */
+export function focusRound(state: SessionState, focus: RoundFocus): SessionState {
+  if (state.roundFocus === focus) return state;
+  // Arriving at the graph with nothing picked out puts the cursor on the agent
+  // whose turns are on screen, so Tab starts from where the operator is looking.
+  if (focus === 'agents' && state.selectedAgentKind === null) {
+    const phases = visiblePhases(state);
+    const active = phases.find(phase => phase.status === 'active') ?? phases[0];
+    return {...state, roundFocus: focus, selectedAgentKind: active?.kind ?? null};
+  }
+  return {...state, roundFocus: focus};
+}
+
+export function clearEntrySelection(state: SessionState): SessionState {
+  if (state.selectedEntryId === null) return state;
+  return {...state, selectedEntryId: null};
+}
+
+/** Moves the todo cursor within the visible phase's list. */
+export function selectNextTodo(state: SessionState, delta: number): SessionState {
+  const todos = visibleTodos(state);
+  if (todos.length === 0) return state;
+  const current = state.selectedTodoIndex;
+  const start = current === null ? (delta > 0 ? -1 : todos.length) : current;
+  const index = Math.min(todos.length - 1, Math.max(0, start + delta));
+  return {...state, selectedTodoIndex: index};
 }
 
 function formatConfigurationFailure(event: RunEvent): string {
@@ -850,7 +1017,26 @@ function appendConversation(
   ) {
     return [...previous.slice(0, -1), {...last, content: last.content + incoming.content}];
   }
-  return [...previous, incoming].slice(-1_000);
+  return capConversation([...previous, incoming]);
+}
+
+/**
+ * A run can outlive any fixed number of entries, but a round the operator can
+ * still open must keep all of its turns: a half-evicted round reads as a round
+ * that never ran. So the cap is generous, and when it is reached the oldest
+ * round goes as a whole rather than the oldest few lines.
+ */
+const MAX_CONVERSATION_ENTRIES = 20_000;
+
+function capConversation(entries: ConversationEntry[]): ConversationEntry[] {
+  if (entries.length <= MAX_CONVERSATION_ENTRIES) return entries;
+  const oldestRound = entries.find(entry => entry.roundNumber !== undefined)?.roundNumber;
+  if (oldestRound === undefined) return entries.slice(-MAX_CONVERSATION_ENTRIES);
+  const kept = entries.filter(
+    entry => entry.roundNumber === undefined || entry.roundNumber > oldestRound,
+  );
+  // Nothing to drop by round (one huge round): fall back to trimming the front.
+  return kept.length === entries.length ? entries.slice(-MAX_CONVERSATION_ENTRIES) : kept;
 }
 
 function findToolCall(previous: ConversationEntry[], result: ConversationEntry): number {
@@ -933,17 +1119,6 @@ function formatTokenCount(count: number): string {
 }
 
 export function visibleConversation(state: SessionState): ConversationEntry[] {
-  const scope = state.hypothesisScope;
-  // Inside a hypothesis with no round picked out, show the whole trajectory of
-  // that hypothesis rather than only its latest round.
-  if (scope !== null && state.selectedRound === null) {
-    return state.conversation.filter(entry => {
-      if (entry.roundNumber === undefined || !scope.rounds.includes(entry.roundNumber)) {
-        return false;
-      }
-      return state.selectedAgentKind === null || entry.agentKind === state.selectedAgentKind;
-    });
-  }
   const roundNumber = visibleRoundNumber(state);
   return state.conversation.filter(entry => {
     if (roundNumber !== null && entry.roundNumber !== roundNumber) return false;
@@ -996,15 +1171,43 @@ export function visibleTodos(state: SessionState): TodoItem[] {
 }
 
 export function visibleRoundNumber(state: SessionState): number | null {
-  if (state.hypothesisScope !== null && state.selectedRound === null) return null;
-  return visibleRunMapRoundNumber(scopedRounds(state), state.selectedRound);
+  const scope = state.hypothesisScope;
+  if (scope !== null && state.selectedRound === null) {
+    // Opening a hypothesis lands on one of its rounds rather than on nothing.
+    // Leaving the round unset used to mean "the whole trajectory", which drew an
+    // empty agent strip and an empty transcript for any run whose events are not
+    // all round-stamped: a blank view where a round was asked for.
+    const rounds = state.rounds.filter(round => scope.rounds.includes(round.number));
+    const active = [...rounds].reverse().find(round => round.status === 'active');
+    return active?.number ?? rounds.at(-1)?.number ?? scope.rounds.at(-1) ?? null;
+  }
+  return visibleRunMapRoundNumber(stripRounds(state), state.selectedRound);
 }
 
-/** The rounds the strip and round navigation operate on for the current view. */
+/** The rounds owned by the hypothesis on screen, or every round outside one. */
 export function scopedRounds(state: SessionState): RoundSummary[] {
   const scope = state.hypothesisScope;
   if (scope === null) return state.rounds;
   return state.rounds.filter(round => scope.rounds.includes(round.number));
+}
+
+/**
+ * What the strip shows and what round navigation moves through: every round of
+ * the run, including ones it has not reached yet. A run announces how many
+ * rounds it intends to take, so the strip can show the shape of the whole run
+ * from the first round rather than growing one chip at a time. Rounds beyond
+ * what has happened carry ``planned`` and open an empty view, which is the
+ * honest thing to show for a round that has not run.
+ */
+export function stripRounds(state: SessionState): RoundSummary[] {
+  const highest = Math.max(state.maxRounds ?? 0, ...state.rounds.map(round => round.number), 0);
+  if (highest === 0) return state.rounds;
+  const known = new Map(state.rounds.map(round => [round.number, round]));
+  const rounds: RoundSummary[] = [];
+  for (let number = 1; number <= highest; number += 1) {
+    rounds.push(known.get(number) ?? {number, status: 'planned'});
+  }
+  return rounds;
 }
 
 const MAX_TOOL_ARG_LEN = 80;

--- a/clients/tui/src/ui/agent-graph.test.ts
+++ b/clients/tui/src/ui/agent-graph.test.ts
@@ -1,0 +1,170 @@
+import {describe, expect, test} from 'bun:test';
+import type {AgentPhase} from '../run-map.js';
+import {graphPaneBounds, layoutAgentGraph, NODE_HEIGHT, stageKinds} from './agent-graph.js';
+
+function phase(kind: string, status: AgentPhase['status'], roundNumber = 1): AgentPhase {
+  return {kind, status, roundNumber, roundLabel: `round-${roundNumber}-${kind}`};
+}
+
+const CHAIN = [
+  phase('orchestrator', 'completed'),
+  phase('implementer', 'active'),
+  phase('judge', 'pending'),
+];
+
+describe('stageKinds', () => {
+  test('keeps the order the round first mentions each kind', () => {
+    expect(stageKinds(CHAIN)).toEqual(['orchestrator', 'implementer', 'judge']);
+  });
+
+  test('collapses repeats of a kind into one stage', () => {
+    const parallel = [phase('implementer', 'active'), phase('implementer', 'completed')];
+    expect(stageKinds(parallel)).toEqual(['implementer']);
+  });
+});
+
+describe('layoutAgentGraph', () => {
+  test('places one column per stage, left to right', () => {
+    const graph = layoutAgentGraph(CHAIN, graphPaneBounds(3).max - 4);
+    const xs = graph.nodes.map(node => node.x);
+    expect(xs).toEqual([...xs].sort((a, b) => a - b));
+    expect(new Set(xs).size).toBe(3);
+    expect(graph.nodes.every(node => node.y === 0)).toBe(true);
+  });
+
+  test('stacks several agents of one kind inside their column', () => {
+    const parallel = [
+      phase('orchestrator', 'completed'),
+      phase('implementer', 'active'),
+      phase('implementer', 'active'),
+    ];
+    const graph = layoutAgentGraph(parallel, graphPaneBounds(2).max - 4);
+    const implementers = graph.nodes.filter(node => node.phase.kind === 'implementer');
+    expect(implementers).toHaveLength(2);
+    expect(implementers[0]?.x).toBe(implementers[1]?.x as number);
+    expect((implementers[1]?.y as number) - (implementers[0]?.y as number)).toBeGreaterThanOrEqual(
+      NODE_HEIGHT,
+    );
+  });
+
+  test('centres a shorter stage against the tallest one', () => {
+    const parallel = [
+      phase('orchestrator', 'completed'),
+      phase('implementer', 'active'),
+      phase('implementer', 'active'),
+    ];
+    const graph = layoutAgentGraph(parallel, graphPaneBounds(2).max - 4);
+    const orchestrator = graph.nodes.find(node => node.phase.kind === 'orchestrator');
+    expect(orchestrator?.y).toBeGreaterThan(0);
+  });
+
+  test('draws an arrow into every target and keeps edges inside the gutter', () => {
+    const graph = layoutAgentGraph(CHAIN, graphPaneBounds(3).max - 4);
+    const arrows = graph.cells.filter(cell => cell.glyph === '▶');
+    expect(arrows).toHaveLength(2);
+    const nodeWidth = graph.nodes[0]?.width as number;
+    for (const cell of graph.cells) {
+      const column = cell.x % (nodeWidth + 5);
+      expect(column).toBeGreaterThanOrEqual(nodeWidth);
+    }
+  });
+
+  test('tones an edge by the phases it connects', () => {
+    const graph = layoutAgentGraph(
+      [...CHAIN, phase('profiler', 'pending')],
+      graphPaneBounds(4).max - 4,
+    );
+    // The frontier glows: an edge is live while either end is running. Two
+    // stages that have not run yet stay idle.
+    expect(graph.cells.some(cell => cell.tone === 'live')).toBe(true);
+    expect(graph.cells.some(cell => cell.tone === 'idle')).toBe(true);
+  });
+
+  test('a finished handover between finished stages reads as done', () => {
+    const done = [phase('implementer', 'completed'), phase('judge', 'completed')];
+    const graph = layoutAgentGraph(done, graphPaneBounds(2).max - 4);
+    expect(graph.cells.every(cell => cell.tone === 'done')).toBe(true);
+  });
+
+  test('a failed phase colors the edge leaving it', () => {
+    const failed = [phase('implementer', 'failed'), phase('judge', 'pending')];
+    const graph = layoutAgentGraph(failed, graphPaneBounds(2).max - 4);
+    expect(graph.cells.every(cell => cell.tone === 'failed')).toBe(true);
+  });
+
+  test('gives overlapping fan-outs their own lanes', () => {
+    const fan = [
+      phase('orchestrator', 'completed'),
+      phase('implementer', 'active'),
+      phase('implementer', 'active'),
+      phase('implementer', 'active'),
+    ];
+    const graph = layoutAgentGraph(fan, graphPaneBounds(2).max - 4);
+    // Every implementer must be reachable: one arrow head each.
+    expect(graph.cells.filter(cell => cell.glyph === '▶')).toHaveLength(3);
+  });
+
+  test('narrow panes shrink the node, never below the readable floor', () => {
+    const wide = layoutAgentGraph(CHAIN, graphPaneBounds(3).max - 4);
+    const narrow = layoutAgentGraph(CHAIN, graphPaneBounds(3).min - 4);
+    expect(narrow.nodes[0]?.width).toBeLessThan(wide.nodes[0]?.width as number);
+    expect(narrow.nodes[0]?.width).toBeGreaterThanOrEqual(14);
+  });
+
+  test('handles an empty round without throwing', () => {
+    const graph = layoutAgentGraph([], 60);
+    expect(graph.nodes).toEqual([]);
+    expect(graph.cells).toEqual([]);
+    expect(graph.width).toBe(0);
+  });
+});
+
+describe('graphPaneBounds', () => {
+  test('grows with the number of stages', () => {
+    expect(graphPaneBounds(4).min).toBeGreaterThan(graphPaneBounds(3).min);
+    expect(graphPaneBounds(4).max).toBeGreaterThan(graphPaneBounds(4).min);
+  });
+});
+
+describe('a round with many agents', () => {
+  const many: AgentPhase[] = [
+    phase('orchestrator', 'completed'),
+    ...Array.from({length: 4}, () => phase('implementer', 'active')),
+    ...Array.from({length: 3}, () => phase('judge', 'pending')),
+    ...Array.from({length: 2}, () => phase('profiler', 'pending')),
+  ];
+
+  test('gives every agent its own node and every fed agent an arrow', () => {
+    const graph = layoutAgentGraph(many, graphPaneBounds(4).max - 4);
+    expect(graph.nodes).toHaveLength(10);
+    // One arrow head per node that is fed, not one per edge: several sources
+    // converging on a judge share the head they point at.
+    expect(graph.cells.filter(cell => cell.glyph === '▶')).toHaveLength(4 + 3 + 2);
+  });
+
+  test('never stacks two nodes on the same cell', () => {
+    const graph = layoutAgentGraph(many, graphPaneBounds(4).max - 4);
+    const seen = new Set<string>();
+    for (const node of graph.nodes) {
+      for (let row = node.y; row < node.y + NODE_HEIGHT; row += 1) {
+        const key = `${node.x},${row}`;
+        expect(seen.has(key)).toBe(false);
+        seen.add(key);
+      }
+    }
+  });
+
+  test('keeps edge cells out of the columns the nodes occupy', () => {
+    const graph = layoutAgentGraph(many, graphPaneBounds(4).max - 4);
+    const width = graph.nodes[0]?.width as number;
+    for (const cell of graph.cells) {
+      expect(cell.x % (width + 5)).toBeGreaterThanOrEqual(width);
+    }
+  });
+
+  test('resolves crossing edges into junctions rather than overwriting', () => {
+    const graph = layoutAgentGraph(many, graphPaneBounds(4).max - 4);
+    const junctions = graph.cells.filter(cell => '┼├┤┬┴'.includes(cell.glyph));
+    expect(junctions.length).toBeGreaterThan(0);
+  });
+});

--- a/clients/tui/src/ui/agent-graph.ts
+++ b/clients/tui/src/ui/agent-graph.ts
@@ -1,0 +1,291 @@
+import type {AgentPhase} from '../run-map.js';
+
+/**
+ * Layout for the agent graph drawn in the Agents pane.
+ *
+ * The pane shows one column per agent kind, left to right in the order the
+ * loop runs them, with the agents of a kind stacked inside their column. Today
+ * a round has one phase per kind, so the graph is a chain; the layout is
+ * written for several agents per kind because that is where the loop is going,
+ * and a stage that grows only adds rows to its column.
+ *
+ * This module is pure geometry: it turns phases plus an available width into
+ * cell coordinates. The renderer owns colors and renderables.
+ */
+
+/** Border plus one content row for the kind and one for the status. */
+export const NODE_HEIGHT = 4;
+/** Blank row between stacked agents in the same column. */
+const ROW_GAP = 2;
+/**
+ * Columns between one node's right edge and the next node's left edge. Three
+ * of them are lanes for vertical runs, one is the arrow head, and one keeps the
+ * arrow off the border.
+ */
+const GUTTER = 5;
+/** Narrower than this and a kind is unreadable even truncated. */
+const NODE_WIDTH_MIN = 14;
+/** Wider adds padding, not information. */
+const NODE_WIDTH_MAX = 18;
+
+export interface GraphNode {
+  phase: AgentPhase;
+  /** Cell of the node's top-left corner, relative to the graph area. */
+  x: number;
+  y: number;
+  width: number;
+}
+
+/** How an edge cell should be colored, decided from the phases it connects. */
+export type EdgeTone = 'idle' | 'done' | 'live' | 'failed';
+
+export interface GraphCell {
+  x: number;
+  y: number;
+  glyph: string;
+  tone: EdgeTone;
+}
+
+export interface AgentGraph {
+  nodes: GraphNode[];
+  cells: GraphCell[];
+  width: number;
+  height: number;
+}
+
+/** Border on both sides plus one column of padding on both sides. */
+const PANE_CHROME = 4;
+
+/**
+ * Pane widths that can draw `stageCount` stages: `min` is the narrowest the
+ * graph stays readable at, `max` the point past which extra columns add
+ * padding rather than information. Callers compare `min` against the room they
+ * have before choosing the graph over the stacked list.
+ */
+export function graphPaneBounds(stageCount: number): {min: number; max: number} {
+  const stages = Math.max(1, stageCount);
+  const gutters = (stages - 1) * GUTTER;
+  return {
+    min: stages * NODE_WIDTH_MIN + gutters + PANE_CHROME,
+    max: stages * NODE_WIDTH_MAX + gutters + PANE_CHROME,
+  };
+}
+
+/** Agent kinds in the order the round first mentions them. */
+export function stageKinds(phases: AgentPhase[]): string[] {
+  const kinds: string[] = [];
+  for (const phase of phases) if (!kinds.includes(phase.kind)) kinds.push(phase.kind);
+  return kinds;
+}
+
+export function layoutAgentGraph(phases: AgentPhase[], availableWidth: number): AgentGraph {
+  const kinds = stageKinds(phases);
+  const columns = kinds.map(kind => phases.filter(phase => phase.kind === kind));
+  const nodeWidth = fitNodeWidth(kinds.length, availableWidth);
+  const pitch = nodeWidth + GUTTER;
+  const tallest = Math.max(...columns.map(column => columnHeight(column.length)), 0);
+
+  const nodes: GraphNode[] = [];
+  for (const [index, column] of columns.entries()) {
+    // Shorter stages centre against the tallest one, which is what a layered
+    // graph looks like and keeps the edges near horizontal.
+    const top = Math.floor((tallest - columnHeight(column.length)) / 2);
+    for (const [row, phase] of column.entries()) {
+      nodes.push({
+        phase,
+        x: index * pitch,
+        y: top + row * (NODE_HEIGHT + ROW_GAP),
+        width: nodeWidth,
+      });
+    }
+  }
+
+  const cells = routeEdges(columns, nodes, nodeWidth, pitch);
+  const width = kinds.length === 0 ? 0 : (kinds.length - 1) * pitch + nodeWidth;
+  return {nodes, cells, width, height: tallest};
+}
+
+function columnHeight(count: number): number {
+  return count === 0 ? 0 : count * NODE_HEIGHT + (count - 1) * ROW_GAP;
+}
+
+function fitNodeWidth(stageCount: number, availableWidth: number): number {
+  if (stageCount <= 0) return NODE_WIDTH_MIN;
+  const room = availableWidth - (stageCount - 1) * GUTTER;
+  const fitted = Math.floor(room / stageCount);
+  return Math.max(NODE_WIDTH_MIN, Math.min(NODE_WIDTH_MAX, fitted));
+}
+
+const UP = 1;
+const RIGHT = 2;
+const DOWN = 4;
+const LEFT = 8;
+
+/**
+ * Box-drawing glyph for a cell, keyed by the directions that leave it. Edges
+ * that cross or merge resolve to a junction instead of one overwriting the
+ * other.
+ */
+const JUNCTION: Record<number, string> = {
+  [UP]: '│',
+  [DOWN]: '│',
+  [LEFT]: '─',
+  [RIGHT]: '─',
+  [UP | DOWN]: '│',
+  [LEFT | RIGHT]: '─',
+  [UP | RIGHT]: '└',
+  [UP | LEFT]: '┘',
+  [DOWN | RIGHT]: '┌',
+  [DOWN | LEFT]: '┐',
+  [UP | DOWN | RIGHT]: '├',
+  [UP | DOWN | LEFT]: '┤',
+  [UP | LEFT | RIGHT]: '┴',
+  [DOWN | LEFT | RIGHT]: '┬',
+  [UP | DOWN | LEFT | RIGHT]: '┼',
+};
+
+const TONE_RANK: Record<EdgeTone, number> = {idle: 0, done: 1, live: 2, failed: 3};
+
+function routeEdges(
+  columns: AgentPhase[][],
+  nodes: GraphNode[],
+  nodeWidth: number,
+  pitch: number,
+): GraphCell[] {
+  const cellAt = new Map<string, {mask: number; tone: EdgeTone; glyph: string}>();
+  const nodeOf = (phase: AgentPhase): GraphNode =>
+    nodes[nodes.findIndex(node => node.phase === phase)] as GraphNode;
+
+  for (const [index, column] of columns.entries()) {
+    const next = columns[index + 1];
+    if (next === undefined) continue;
+    const x1 = index * pitch + nodeWidth;
+    const x2 = x1 + GUTTER - 1;
+    const lanes = laneOrder(x1 + 1, x2 - 1);
+    const taken: Array<Array<[number, number]>> = lanes.map(() => []);
+
+    for (const source of column) {
+      const from = nodeOf(source);
+      const sourceY = from.y + 1;
+      const targetYs = next.map(target => nodeOf(target).y + 1);
+      const lane = claimLane(
+        lanes,
+        taken,
+        Math.min(sourceY, ...targetYs),
+        Math.max(sourceY, ...targetYs),
+      );
+      for (const target of next) {
+        const to = nodeOf(target);
+        const targetY = to.y + 1;
+        const tone = edgeTone(source, target);
+        const points: Array<[number, number]> =
+          sourceY === targetY
+            ? [
+                [x1, sourceY],
+                [x2, targetY],
+              ]
+            : [
+                [x1, sourceY],
+                [lane, sourceY],
+                [lane, targetY],
+                [x2, targetY],
+              ];
+        paint(cellAt, points, tone);
+        // The arrow head replaces the junction glyph: it is the one cell that
+        // has to say which way the handover went.
+        cellAt.set(`${x2},${targetY}`, {mask: 0, tone, glyph: '▶'});
+      }
+    }
+  }
+
+  return [...cellAt.entries()].map(([key, value]) => {
+    const [x, y] = key.split(',').map(Number);
+    return {x: x as number, y: y as number, glyph: value.glyph, tone: value.tone};
+  });
+}
+
+/** Centre lane first, so a single chain draws a straight line. */
+function laneOrder(low: number, high: number): number[] {
+  const lanes: number[] = [];
+  for (let lane = low; lane <= high; lane += 1) lanes.push(lane);
+  const middle = Math.floor((low + high) / 2);
+  return lanes.sort((a, b) => Math.abs(a - middle) - Math.abs(b - middle) || a - b);
+}
+
+/**
+ * Edges leaving one node share a lane. Edges from different nodes take
+ * different lanes when their row ranges overlap, so two unrelated handovers
+ * never merge into a line that reads as a connection.
+ */
+function claimLane(
+  lanes: number[],
+  taken: Array<Array<[number, number]>>,
+  low: number,
+  high: number,
+): number {
+  for (const [index, lane] of lanes.entries()) {
+    const rows = taken[index];
+    if (rows === undefined) continue;
+    if (rows.every(([from, to]) => high < from || low > to)) {
+      rows.push([low, high]);
+      return lane;
+    }
+  }
+  return lanes[0] ?? low;
+}
+
+function paint(
+  cellAt: Map<string, {mask: number; tone: EdgeTone; glyph: string}>,
+  points: Array<[number, number]>,
+  tone: EdgeTone,
+): void {
+  const cells = expand(points);
+  for (const [index, cell] of cells.entries()) {
+    let mask = 0;
+    const previous = cells[index - 1];
+    const next = cells[index + 1];
+    if (previous) mask |= direction(previous[0] - cell[0], previous[1] - cell[1]);
+    if (next) mask |= direction(next[0] - cell[0], next[1] - cell[1]);
+    const key = `${cell[0]},${cell[1]}`;
+    const existing = cellAt.get(key);
+    const merged = (existing?.mask ?? 0) | mask;
+    const winner =
+      existing === undefined || TONE_RANK[tone] >= TONE_RANK[existing.tone] ? tone : existing.tone;
+    cellAt.set(key, {mask: merged, tone: winner, glyph: JUNCTION[merged] ?? '┼'});
+  }
+}
+
+function expand(points: Array<[number, number]>): Array<[number, number]> {
+  const cells: Array<[number, number]> = [];
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const from = points[index] as [number, number];
+    const to = points[index + 1] as [number, number];
+    const stepX = Math.sign(to[0] - from[0]);
+    const stepY = Math.sign(to[1] - from[1]);
+    let [x, y] = from;
+    while (x !== to[0] || y !== to[1]) {
+      cells.push([x, y]);
+      x += stepX;
+      y += stepY;
+    }
+  }
+  const last = points.at(-1);
+  if (last) cells.push(last);
+  return cells;
+}
+
+function direction(deltaX: number, deltaY: number): number {
+  if (deltaX > 0) return RIGHT;
+  if (deltaX < 0) return LEFT;
+  if (deltaY > 0) return DOWN;
+  return UP;
+}
+
+function edgeTone(source: AgentPhase, target: AgentPhase): EdgeTone {
+  if (source.status === 'failed') return 'failed';
+  if (source.status === 'active' || (source.status === 'completed' && target.status === 'active')) {
+    return 'live';
+  }
+  if (source.status === 'completed' && target.status !== 'pending') return 'done';
+  return 'idle';
+}

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -2,8 +2,17 @@ import {BoxRenderable, type CliRenderer, TextRenderable} from '@opentui/core';
 import {hasActiveAgentTiming} from '../round-timing.js';
 import type {AgentPhase, RoundSummary} from '../run-map.js';
 import {roundAgentElapsedMs} from '../run-map.js';
+import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
-import {scopedRounds, visiblePhases, visibleRoundNumber} from '../session-model.js';
+import {scopedRounds, stripRounds, visiblePhases, visibleRoundNumber} from '../session-model.js';
+import {
+  type AgentGraph,
+  type EdgeTone,
+  graphPaneBounds,
+  layoutAgentGraph,
+  NODE_HEIGHT,
+  stageKinds,
+} from './agent-graph.js';
 import {elapsedLabel} from './previews.js';
 import type {Theme} from './theme.js';
 
@@ -14,6 +23,13 @@ const STATUS_MARKER: Record<AgentPhase['status'], string> = {
   failed: '×',
 };
 
+/** Width the stacked fallback uses, and the width this pane had before. */
+const STACKED_WIDTH = 30;
+/** Columns the transcript needs to stay worth reading beside the graph. */
+const TRANSCRIPT_MIN = 42;
+/** Share of the terminal the graph takes when there is room for it. */
+const GRAPH_SHARE = 0.55;
+
 function statusColor(theme: Theme, status: AgentPhase['status']): string {
   if (status === 'active') return theme.success;
   if (status === 'completed') return theme.info;
@@ -21,22 +37,49 @@ function statusColor(theme: Theme, status: AgentPhase['status']): string {
   return theme.textSubtle;
 }
 
+function edgeColor(theme: Theme, tone: EdgeTone): string {
+  if (tone === 'failed') return theme.error;
+  if (tone === 'live') return theme.accent;
+  if (tone === 'done') return theme.info;
+  return theme.borderStrong;
+}
+
+/**
+ * Width for the Agents pane, or null when the terminal cannot carry the graph
+ * beside a readable transcript. Derived from the terminal rather than fixed, so
+ * a wide terminal gives the graph room while the transcript keeps its floor.
+ */
+export function agentPaneWidth(terminalWidth: number, stageCount: number): number | null {
+  const bounds = graphPaneBounds(stageCount);
+  // Never narrower than the pane used to be: a one-stage round needs less room
+  // than the heading above it, and a wrapped heading reads worse than slack.
+  const floor = Math.max(bounds.min, STACKED_WIDTH);
+  const ceiling = Math.max(bounds.max, STACKED_WIDTH);
+  const room = terminalWidth - TRANSCRIPT_MIN;
+  if (room < floor) return null;
+  const share = Math.round(terminalWidth * GRAPH_SHARE);
+  return Math.min(ceiling, room, Math.max(floor, share));
+}
+
 export class AgentMapView {
   readonly output: BoxRenderable;
   #theme: Theme;
   #renderedState: SessionState | null = null;
+  #renderedWidth = 0;
   #elapsedTimer: ReturnType<typeof setInterval> | null = null;
   #runningRound: {round: RoundSummary; text: TextRenderable} | null = null;
 
   constructor(
     private readonly renderer: CliRenderer,
+    private readonly controller: SessionController,
     theme: Theme,
   ) {
     this.#theme = theme;
     this.output = new BoxRenderable(renderer, {
       id: 'agent-map',
-      width: 30,
+      width: STACKED_WIDTH,
       height: '100%',
+      flexShrink: 0,
       flexDirection: 'column',
       paddingLeft: 1,
       paddingRight: 1,
@@ -54,14 +97,37 @@ export class AgentMapView {
   }
 
   render(state: SessionState): void {
-    if (state === this.#renderedState) return;
-    this.#renderedState = state;
-    this.#clear();
     const phases = visiblePhases(state);
+    // The pane's width follows the terminal, so a resize has to redraw even
+    // when the state is unchanged.
+    const width = agentPaneWidth(this.renderer.terminalWidth, stageKinds(phases).length);
+    const paneWidth = width ?? STACKED_WIDTH;
+    if (state === this.#renderedState && paneWidth === this.#renderedWidth) return;
+    // Selection and focus are drawn into the nodes, so a change to either is a
+    // reason to redraw even when the phases are identical.
+    this.#renderedState = state;
+    this.#renderedWidth = paneWidth;
+    this.output.width = paneWidth;
+    // The pane that owns the arrow keys says so, the way every other focusable
+    // surface in the client does.
+    this.output.borderColor =
+      state.roundFocus === 'agents' ? this.#theme.borderFocus : this.#theme.border;
+    this.output.title = state.roundFocus === 'agents' ? ' ▸ Agents ' : ' Agents ';
+    this.#clear();
     if (phases.length === 0) {
+      // A round the run has not reached has no agents, and never will until it
+      // runs. "Waiting" would suggest something is on its way.
+      const roundNumber = visibleRoundNumber(state);
+      const round =
+        roundNumber === null
+          ? null
+          : (stripRounds(state).find(item => item.number === roundNumber) ?? null);
       this.output.add(
         new TextRenderable(this.renderer, {
-          content: 'Waiting for phases…',
+          content:
+            round?.status === 'planned'
+              ? `Round ${roundNumber} has not run yet.`
+              : 'Waiting for phases…',
           fg: this.#theme.textSubtle,
           width: '100%',
         }),
@@ -74,17 +140,136 @@ export class AgentMapView {
       roundNumber === null
         ? null
         : (scopedRounds(state).find(item => item.number === roundNumber) ?? null);
-    const heading = new TextRenderable(this.renderer, {
-      content: headingLabel(roundNumber, round),
-      fg: this.#theme.textPrimary,
+    const headingRow = new BoxRenderable(this.renderer, {
+      id: 'agent-map-heading',
       width: '100%',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
     });
-    this.output.add(heading);
+    const headingText = headingLabel(roundNumber, round);
+    const heading = new TextRenderable(this.renderer, {
+      content: headingText,
+      fg: this.#theme.textPrimary,
+    });
+    headingRow.add(heading);
+    // What the round is made of, in one line. With one agent per stage it reads
+    // as a summary; with a dozen it is the only way to see the round's shape
+    // without counting nodes. It is the first thing to give up room, because a
+    // wrapped heading costs a row of graph and says less.
+    const summary = phaseSummary(phases);
+    if (headingText.length + summary.length + 2 <= paneWidth - 4) {
+      headingRow.add(
+        new TextRenderable(this.renderer, {
+          content: summary,
+          fg: this.#theme.textMuted,
+        }),
+      );
+    }
+    this.output.add(headingRow);
     // Elapsed time only advances while an agent is running, so the heading
     // ticks for exactly as long as one is.
     if (round !== null && hasActiveAgentTiming(round)) this.#runningRound = {round, text: heading};
+    if (width === null) this.#renderStacked(phases, state.selectedAgentKind);
+    else this.#renderGraph(phases, state.selectedAgentKind, width);
+    this.#syncElapsedTimer();
+  }
+
+  destroy(): void {
+    this.#stopElapsedTimer();
+  }
+
+  /**
+   * Stages left to right with the agents of a stage stacked inside their
+   * column, laid out by `agent-graph.ts` and positioned absolutely: a graph has
+   * no row-and-column structure for flex to follow.
+   */
+  #renderGraph(phases: AgentPhase[], selectedKind: string | null, paneWidth: number): void {
+    const graph = layoutAgentGraph(phases, paneWidth - 4);
+    // The graph sits in the middle of the pane rather than hugging the heading:
+    // a chain is a few rows tall and a pane is not. `area` centres, `canvas`
+    // gives the absolutely positioned cells their origin.
+    const area = new BoxRenderable(this.renderer, {
+      id: 'agent-graph',
+      width: '100%',
+      flexGrow: 1,
+      flexShrink: 1,
+      flexDirection: 'column',
+      justifyContent: 'center',
+    });
+    const canvas = new BoxRenderable(this.renderer, {
+      id: 'agent-graph-canvas',
+      width: '100%',
+      height: graph.height,
+      flexShrink: 0,
+    });
+    this.output.add(area);
+    area.add(canvas);
+    for (const run of edgeRuns(graph)) {
+      canvas.add(
+        new TextRenderable(this.renderer, {
+          content: run.glyphs,
+          fg: edgeColor(this.#theme, run.tone),
+          position: 'absolute',
+          left: run.x,
+          top: run.y,
+        }),
+      );
+    }
+    for (const node of graph.nodes) {
+      canvas.add(this.#renderNode(node.phase, node.phase.kind === selectedKind, node));
+    }
+  }
+
+  #renderNode(
+    phase: AgentPhase,
+    selected: boolean,
+    node: {x: number; y: number; width: number},
+  ): BoxRenderable {
+    const color = statusColor(this.#theme, phase.status);
+    const box = new BoxRenderable(this.renderer, {
+      id: `agent-${phase.kind}-${node.y}`,
+      position: 'absolute',
+      left: node.x,
+      top: node.y,
+      width: node.width,
+      height: NODE_HEIGHT,
+      flexDirection: 'column',
+      // No horizontal padding: two columns of it is the difference between
+      // "implementer" and "implement…" at the widths a four-stage round leaves.
+      border: true,
+      borderStyle: 'rounded',
+      borderColor: selected
+        ? this.#theme.borderFocus
+        : phase.status === 'pending'
+          ? this.#theme.borderStrong
+          : color,
+      ...(selected ? {backgroundColor: this.#theme.selectedSurface} : {}),
+      // Clicking a node filters the transcript to it, and clicking the selected
+      // one clears the filter: the same toggle Tab and Esc give the keyboard.
+      onMouseUp: () => this.controller.selectAgent(phase.kind),
+    });
+    const inner = node.width - 2;
+    box.add(
+      new TextRenderable(this.renderer, {
+        content: truncate(`${STATUS_MARKER[phase.status]} ${phase.kind}`, inner),
+        fg: selected ? this.#theme.textStrong : color,
+        width: '100%',
+      }),
+    );
+    box.add(
+      new TextRenderable(this.renderer, {
+        content: truncate(phase.status, inner),
+        fg: color,
+        width: '100%',
+      }),
+    );
+    return box;
+  }
+
+  /** The pane before the graph: used when the terminal is too narrow for it. */
+  #renderStacked(phases: AgentPhase[], selectedKind: string | null): void {
     for (const [index, phase] of phases.entries()) {
-      this.output.add(this.#renderPhase(phase, state.selectedAgentKind === phase.kind));
+      this.output.add(this.#renderStackedPhase(phase, selectedKind === phase.kind));
       if (index < phases.length - 1) {
         this.output.add(
           new TextRenderable(this.renderer, {
@@ -95,38 +280,9 @@ export class AgentMapView {
         );
       }
     }
-    this.#syncElapsedTimer();
   }
 
-  destroy(): void {
-    this.#stopElapsedTimer();
-  }
-
-  #syncElapsedTimer(): void {
-    if (this.#runningRound === null || this.#elapsedTimer !== null) return;
-    this.#elapsedTimer = setInterval(() => {
-      if (this.#runningRound === null) return;
-      const {round, text} = this.#runningRound;
-      text.content = headingLabel(round.number, round);
-    }, 1000);
-  }
-
-  #stopElapsedTimer(): void {
-    if (this.#elapsedTimer === null) return;
-    clearInterval(this.#elapsedTimer);
-    this.#elapsedTimer = null;
-  }
-
-  #clear(): void {
-    this.#runningRound = null;
-    this.#stopElapsedTimer();
-    for (const child of [...this.output.getChildren()]) {
-      this.output.remove(child);
-      child.destroyRecursively();
-    }
-  }
-
-  #renderPhase(phase: AgentPhase, selected: boolean): BoxRenderable {
+  #renderStackedPhase(phase: AgentPhase, selected: boolean): BoxRenderable {
     const row = new BoxRenderable(this.renderer, {
       id: `agent-${phase.kind}`,
       width: '100%',
@@ -134,9 +290,15 @@ export class AgentMapView {
       marginTop: 1,
       paddingLeft: 1,
       paddingRight: 1,
-      border: selected,
-      borderStyle: 'rounded',
-      borderColor: selected ? this.#theme.borderFocus : this.#theme.border,
+      // Passing borderStyle without border draws a frame that the layout does
+      // not reserve rows for, and the phase's lines then overlap it.
+      ...(selected
+        ? {
+            border: true,
+            borderStyle: 'rounded' as const,
+            borderColor: this.#theme.borderFocus,
+          }
+        : {}),
       ...(selected ? {backgroundColor: this.#theme.selectedSurface} : {}),
     });
     const color = statusColor(this.#theme, phase.status);
@@ -165,6 +327,75 @@ export class AgentMapView {
     }
     return row;
   }
+
+  #syncElapsedTimer(): void {
+    if (this.#runningRound === null || this.#elapsedTimer !== null) return;
+    this.#elapsedTimer = setInterval(() => {
+      if (this.#runningRound === null) return;
+      const {round, text} = this.#runningRound;
+      text.content = headingLabel(round.number, round);
+    }, 1000);
+  }
+
+  #stopElapsedTimer(): void {
+    if (this.#elapsedTimer === null) return;
+    clearInterval(this.#elapsedTimer);
+    this.#elapsedTimer = null;
+  }
+
+  #clear(): void {
+    this.#runningRound = null;
+    this.#stopElapsedTimer();
+    for (const child of [...this.output.getChildren()]) {
+      this.output.remove(child);
+      child.destroyRecursively();
+    }
+  }
+}
+
+/**
+ * Edge cells grouped into horizontal runs of one tone, so a straight edge is
+ * one renderable rather than one per cell.
+ */
+export function edgeRuns(
+  graph: AgentGraph,
+): Array<{x: number; y: number; glyphs: string; tone: EdgeTone}> {
+  const sorted = [...graph.cells].sort((a, b) => a.y - b.y || a.x - b.x);
+  const runs: Array<{x: number; y: number; glyphs: string; tone: EdgeTone}> = [];
+  for (const cell of sorted) {
+    const open = runs.at(-1);
+    if (
+      open !== undefined &&
+      open.y === cell.y &&
+      open.tone === cell.tone &&
+      open.x + open.glyphs.length === cell.x
+    ) {
+      open.glyphs += cell.glyph;
+      continue;
+    }
+    runs.push({x: cell.x, y: cell.y, glyphs: cell.glyph, tone: cell.tone});
+  }
+  return runs;
+}
+
+/** `4 agents · 1 active · 2 done`, with failures and skips only when they exist. */
+export function phaseSummary(phases: AgentPhase[]): string {
+  const count = (status: AgentPhase['status']): number =>
+    phases.filter(phase => phase.status === status).length;
+  const parts = [
+    `${phases.length} ${phases.length === 1 ? 'agent' : 'agents'}`,
+    `${count('active')} active`,
+    `${count('completed')} done`,
+  ];
+  if (count('failed') > 0) parts.push(`${count('failed')} failed`);
+  const pending = count('pending');
+  if (pending > 0) parts.push(`${pending} waiting`);
+  return parts.join(' · ');
+}
+
+function truncate(text: string, width: number): string {
+  const room = Math.max(1, width);
+  return text.length <= room ? text : `${text.slice(0, room - 1)}…`;
 }
 
 /**

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -6,20 +6,23 @@ import type {SessionController} from '../session-controller.js';
 import {
   closePane,
   closeThemePicker,
+  cyclePaneFocus,
   enterExperimentDrilldown,
   enterExperimentRound,
+  focusPane,
   initialSessionState,
   leaveExperimentDrilldown,
   moveExperimentSelection,
   moveThemeSelection,
   openExperimentLog,
   openPane,
+  type PaneFocus,
   type PaneView,
   type SessionState,
+  setChatDockFits,
   setExperiments,
   setPaneContent,
   setTheme,
-  togglePaneFocus,
 } from '../session-model.js';
 import {createOpenTuiApp, type OpenTuiApp} from './app.js';
 import {resolveTheme, type ThemeName} from './theme.js';
@@ -1053,6 +1056,224 @@ describe('theming', () => {
     expect(controller.state.experimentLog?.selectedId).toBe('H-001');
   });
 
+  it('lands with the chat docked beside the hypothesis table', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    const landing = await frameAfter(testRenderer);
+
+    // Both columns at once, and the table keeps the claim it came to show.
+    expect(landing).toContain('Experiment chat');
+    expect(landing).toContain('Experiments');
+    expect(landing).toContain('Implementation Details');
+    expect(landing).toContain('Batch the prefill step');
+
+    // Each column has its own input, under the surface it writes to, and the
+    // command box starts where the chat column ends rather than running under
+    // it.
+    // The cursor starts in the command box, and the chat says how to reach it.
+    expect(landing).toContain('Ctrl+W to type here');
+    const lines = landing.split('\n');
+    const paneTop = lines.find(line => line.includes('╭─ Experiment chat')) ?? '';
+    const inputTop = lines.find(line => line.includes('╭─ Chat ')) ?? '';
+    expect(inputTop).toContain('╭─ Ask or command');
+    expect(inputTop.indexOf('╭─ Ask or command')).toBe(paneTop.indexOf('╭─ Experiments'));
+  });
+
+  it('routes typing to whichever input Ctrl+W points at', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
+    await testRenderer.mockInput.typeText('why is r41 slow?');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.chatSubmissions.length === 1);
+
+    // The chat's own box took it, not the command input.
+    expect(controller.chatSubmissions).toEqual(['why is r41 slow?']);
+    expect(controller.submissions).toEqual([]);
+
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
+    await testRenderer.mockInput.typeText('/perf');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.submissions.length === 1);
+
+    expect(controller.submissions).toEqual(['/perf']);
+    expect(controller.chatSubmissions).toHaveLength(1);
+  });
+
+  it('raises the command list out of the command input, clear of the chat', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    await testRenderer.mockInput.typeText('/pe');
+    const frame = await testRenderer.waitForFrame(value => value.includes('[Tab]'));
+
+    const lines = frame.split('\n');
+    const suggestion = lines.find(line => line.includes('/perf')) ?? '';
+    const commandInput = lines.find(line => line.includes('╭─ Ask or command')) ?? '';
+    // The list belongs to the box it completes, so it starts where that box
+    // starts rather than running back across the chat column.
+    expect(suggestion.indexOf('│')).toBe(commandInput.indexOf('╭─ Ask or command'));
+  });
+
+  it('drops /chat from the command surface while the chat is already docked', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    await testRenderer.mockInput.typeText('/c');
+    const frame = await frameAfter(testRenderer);
+
+    // Nothing to open: the chat is the column beside the table.
+    expect(frame).not.toContain('/chat');
+  });
+
+  it('says when the docked chat is waiting on the agent', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    controller.publish({...controller.state, chatPending: true});
+
+    expect(await frameAfter(testRenderer)).toContain('Awaiting the agent');
+  });
+
+  it('answers in the docked chat without covering the table', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    await testRenderer.mockInput.typeText('why is r41 slow?');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.submissions.length === 1);
+    controller.publish({
+      ...controller.state,
+      chatConversation: [
+        {id: 'q', kind: 'user', label: 'You', content: 'why is r41 slow?'},
+        {id: 'a', kind: 'assistant', label: 'Answer', content: 'Prefill dominates.'},
+      ],
+    });
+
+    const answered = await frameAfter(testRenderer);
+
+    expect(answered).toContain('Prefill dominates.');
+    expect(answered).toContain('H-07');
+    expect(answered).toContain('Implementation Details');
+  });
+
+  it('keeps the chat, the table, and the visualization on screen together', async () => {
+    const testRenderer = await createTestRenderer({width: 200, height: 20});
+    const controller = logController();
+    controller.paneContent = 'Performance · tok_s\n    1135 ┤   ●\nbest r7 1135 tok_s';
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    controller.publish({
+      ...controller.state,
+      chatConversation: [{id: 'a', kind: 'assistant', label: 'Answer', content: 'Prefill.'}],
+    });
+
+    await controller.openPane('perf');
+    const frame = await frameAfter(testRenderer);
+
+    // Three columns: chat, table, visualization. None replaced another.
+    expect(frame).toContain('Experiment chat');
+    expect(frame).toContain('H-07');
+    expect(frame).toContain('best r7 1135 tok_s');
+    expect(frame).toContain('Ctrl+W: switch pane');
+  });
+
+  it('gives the row to the table alone when the chat cannot fit beside it', async () => {
+    const testRenderer = await createTestRenderer({width: 84, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    const landing = await frameAfter(testRenderer);
+
+    // Two columns would both be unreadable here, so the table keeps the row.
+    expect(landing).not.toContain('Experiment chat');
+    expect(landing).toContain('H-07');
+    expect(controller.state.chatDockFits).toBe(false);
+  });
+
+  it('keeps the table behind the chat modal instead of the round transcript', async () => {
+    const testRenderer = await createTestRenderer({width: 84, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    // What a question does where the chat cannot dock.
+    controller.publish({...controller.state, chatOpen: true});
+
+    const frame = await frameAfter(testRenderer);
+
+    expect(frame).toContain('Experiment chat');
+    expect(frame).toContain('H-07');
+    // The per-round chrome belongs to a hypothesis the operator never opened.
+    expect(frame).not.toContain('─ Rounds ─');
+    expect(frame).not.toContain('─ Agents ─');
+  });
+
+  it('moves the pane keys onto the docked chat and back with Ctrl+W', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    const focused = await frameAfter(testRenderer);
+    expect(focused).toContain('▸ Experiment chat');
+    expect(focused).toContain('Ask about this run');
+    expect(controller.state.layout.focus).toBe('chat');
+
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.focus).toBe('left');
+  });
+
+  it('leaves the table its own keys while the chat is docked', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    controller.experiments = [
+      logEntry('H-07', 41, 41, {claim: 'batch the prefill step', resolved_outcome: 'proven'}),
+      logEntry('H-08', 42, 42, {claim: 'bigger KV cache block', resolved_outcome: 'disproven'}),
+    ];
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    // Arrows still belong to the table, docked chat or not.
+    testRenderer.mockInput.pressKey('ARROW_DOWN');
+    await frameAfter(testRenderer);
+    expect(controller.state.experimentLog?.selectedId).toBe('H-08');
+  });
+
   it('renders the transcript and the visualization side by side', async () => {
     const testRenderer = await createTestRenderer({width: 140, height: 20});
     const controller = splitController();
@@ -1163,7 +1384,7 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'Performance · focused')?.fg).toBe(theme.borderFocus);
     expect(spanColors(testRenderer, 'best r7 1135 tok_s')?.fg).toBe(theme.textPrimary);
 
-    controller.togglePaneFocus();
+    controller.cyclePaneFocus();
     await frameAfter(testRenderer);
 
     // Focus moved to the transcript, so the pane border drops back to the
@@ -1234,6 +1455,25 @@ async function frameAfter(testRenderer: TestRendererSetup): Promise<string> {
 async function frameAfterEscape(testRenderer: TestRendererSetup): Promise<string> {
   await new Promise(resolve => setTimeout(resolve, 40));
   return frameAfter(testRenderer);
+}
+
+/** A client on the landing view, with one hypothesis to show. */
+function logController(): FakeController {
+  const controller = new FakeController({
+    ...initialSessionState(),
+    status: 'running',
+    rounds: [{number: 41, status: 'completed'}],
+  });
+  controller.publish({...controller.state, experimentLog: initialSessionState().experimentLog});
+  controller.experiments = [
+    logEntry('H-07', 41, 41, {
+      claim: 'batch the prefill step',
+      resolved_outcome: 'proven',
+      judge_verdict: 'pass',
+      rounds: [{round: 41, passed: true, reviewed: true}],
+    }),
+  ];
+  return controller;
 }
 
 function splitController(): FakeController {
@@ -1451,8 +1691,14 @@ class FakeController implements SessionController {
   closePane(): void {
     this.publish(closePane(this.state));
   }
-  togglePaneFocus(): void {
-    this.publish(togglePaneFocus(this.state));
+  cyclePaneFocus(): void {
+    this.publish(cyclePaneFocus(this.state));
+  }
+  focusPane(focus: PaneFocus): void {
+    this.publish(focusPane(this.state, focus));
+  }
+  setChatDockFits(fits: boolean): void {
+    this.publish(setChatDockFits(this.state, fits));
   }
 
   /** Content the fake server returns for whichever visualization is opened. */

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -4,21 +4,32 @@ import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing'
 import type {HypothesisEntry} from '../protocol.js';
 import type {SessionController} from '../session-controller.js';
 import {
+  clearAgentSelection,
+  clearEntrySelection,
+  closeOverlays,
   closePane,
   closeThemePicker,
   cyclePaneFocus,
   enterExperimentDrilldown,
   enterExperimentRound,
   focusPane,
+  focusRound,
   initialSessionState,
   leaveExperimentDrilldown,
   moveExperimentSelection,
   moveThemeSelection,
+  normalizeFocus,
   openExperimentLog,
   openPane,
   type PaneFocus,
   type PaneView,
+  type RoundFocus,
   type SessionState,
+  selectAgent,
+  selectNextEntry,
+  selectNextRound,
+  selectNextTodo,
+  selectPreviousRound,
   setChatDockFits,
   setExperiments,
   setPaneContent,
@@ -127,6 +138,445 @@ describe('OpenTUI presentation', () => {
     const frame = await testRenderer.waitForFrame(value => value.includes('Round 2 flow'));
 
     expect(frame).toMatch(/Round 2 flow · 1m \d+s/);
+  });
+
+  it('draws the round as a left-to-right graph when the terminal has room', async () => {
+    const testRenderer = await createTestRenderer({width: 150, height: 24});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      rounds: [{number: 1, status: 'active'}],
+      phases: [
+        {kind: 'orchestrator', status: 'completed', roundNumber: 1, roundLabel: 'round-1-plan'},
+        {kind: 'implementer', status: 'active', roundNumber: 1, roundLabel: 'round-1-implementer'},
+        {kind: 'judge', status: 'pending', roundNumber: 1, roundLabel: 'round-1-judge'},
+      ],
+      conversation: [{id: 'live', kind: 'assistant', label: 'Agent', content: 'live output'}],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('orchestrator'));
+
+    // Stages share a row and are joined by edges, rather than stacked with ↓.
+    const stageRow = frame
+      .split('\n')
+      .find(line => line.includes('orchestrator') && line.includes('implementer'));
+    expect(stageRow).toBeDefined();
+    expect(stageRow).toContain('judge');
+    expect(frame).toContain('▶');
+    // The stacked strip's connector, not the arrow glyphs in the key help.
+    expect(frame).not.toContain('        ↓');
+  });
+
+  it('walks the transcript with the arrow keys and filters it to a clicked agent', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 26});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      rounds: [{number: 1, status: 'active'}],
+      phases: [
+        {kind: 'implementer', status: 'completed', roundNumber: 1, roundLabel: 'round-1-impl'},
+        {kind: 'judge', status: 'active', roundNumber: 1, roundLabel: 'round-1-judge'},
+      ],
+      selectedRound: 1,
+      conversation: [
+        {
+          id: 'e1',
+          kind: 'assistant',
+          label: 'implementer · round-1',
+          content: 'edited the kernel',
+          agentKind: 'implementer',
+          roundNumber: 1,
+        },
+        {
+          id: 'e2',
+          kind: 'assistant',
+          label: 'judge · round-1',
+          content: 'checking the diff',
+          agentKind: 'judge',
+          roundNumber: 1,
+        },
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    // A phase is running, so the newest entry is marked as still working.
+    const live = await testRenderer.waitForFrame(value => value.includes('checking the diff'));
+    expect(live).toContain('Working');
+
+    // Arrows put a cursor on an entry without touching the input.
+    testRenderer.mockInput.pressKey('ARROW_UP');
+    const cursored = await frameAfter(testRenderer);
+    expect(controller.state.selectedEntryId).not.toBeNull();
+    expect(cursored).toContain('▸');
+
+    // Selecting an agent filters the transcript to that agent's turns.
+    controller.selectAgent('implementer');
+    const filtered = await frameAfter(testRenderer);
+    expect(filtered).toContain('edited the kernel');
+    expect(filtered).not.toContain('checking the diff');
+  });
+
+  it('shows the whole run in the strip and keeps early rounds reachable', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 20});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      // A run that announced 100 rounds and has reached 12 of them.
+      maxRounds: 100,
+      rounds: Array.from({length: 12}, (_, index) => ({
+        number: index + 1,
+        status: index === 11 ? ('active' as const) : ('completed' as const),
+      })),
+      phases: [{kind: 'judge', status: 'active', roundNumber: 12, roundLabel: 'round-12-judge'}],
+      conversation: [{id: 'live', kind: 'assistant', label: 'Agent', content: 'out'}],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('r12'));
+    // Rounds the run has not reached are still part of the strip, and the strip
+    // says how many it could not fit.
+    expect(frame).toMatch(/r1[34]/);
+    expect(frame).toMatch(/\d+ ›/);
+
+    // `[` walks back to the first round, and the strip follows the selection
+    // rather than leaving it hidden past the edge.
+    let early = frame;
+    for (let step = 0; step < 11; step += 1) {
+      testRenderer.mockInput.pressKey('[');
+      early = await frameAfter(testRenderer);
+    }
+    expect(controller.state.selectedRound).toBe(1);
+    expect(early).toContain('[ r1 ]');
+  });
+
+  it('filters the transcript to an agent node that is clicked', async () => {
+    const testRenderer = await createTestRenderer({width: 150, height: 24});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      rounds: [{number: 1, status: 'active'}],
+      selectedRound: 1,
+      phases: [
+        {kind: 'implementer', status: 'completed', roundNumber: 1, roundLabel: 'round-1-impl'},
+        {kind: 'judge', status: 'active', roundNumber: 1, roundLabel: 'round-1-judge'},
+      ],
+      conversation: [
+        {
+          id: 'e1',
+          kind: 'assistant',
+          label: 'implementer',
+          content: 'edited the kernel',
+          agentKind: 'implementer',
+          roundNumber: 1,
+        },
+        {
+          id: 'e2',
+          kind: 'assistant',
+          label: 'judge',
+          content: 'checking the diff',
+          agentKind: 'judge',
+          roundNumber: 1,
+        },
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    const frame = await testRenderer.waitForFrame(value => value.includes('implementer'));
+
+    // Click the node's own label, which is what a pointer lands on.
+    const lines = frame.split('\n');
+    const row = lines.findIndex(line => line.includes('✓ implementer'));
+    const column = (lines[row]?.indexOf('implementer') ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
+    const filtered = await frameAfter(testRenderer);
+
+    expect(controller.state.selectedAgentKind).toBe('implementer');
+    expect(filtered).not.toContain('checking the diff');
+  });
+
+  it('moves the round view keys between the graph and the transcript', async () => {
+    const testRenderer = await createTestRenderer({width: 150, height: 26});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      rounds: [{number: 1, status: 'active'}],
+      selectedRound: 1,
+      phases: [
+        {kind: 'implementer', status: 'completed', roundNumber: 1, roundLabel: 'round-1-impl'},
+        {kind: 'judge', status: 'active', roundNumber: 1, roundLabel: 'round-1-judge'},
+      ],
+      conversation: [
+        {
+          id: 'e1',
+          kind: 'assistant',
+          label: 'implementer',
+          content: 'edited the kernel',
+          agentKind: 'implementer',
+          roundNumber: 1,
+        },
+        {
+          id: 'e2',
+          kind: 'assistant',
+          label: 'implementer',
+          content: 'guarded the tail tile',
+          agentKind: 'implementer',
+          roundNumber: 1,
+        },
+        {
+          id: 'e3',
+          kind: 'assistant',
+          label: 'judge',
+          content: 'checking the diff',
+          agentKind: 'judge',
+          roundNumber: 1,
+        },
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('implementer'));
+
+    // Left reaches the graph, and the pane says it holds the keys.
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    const onAgents = await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('agents');
+    expect(onAgents).toContain('▸ Agents');
+
+    // There, up and down walk the agents rather than the transcript.
+    testRenderer.mockInput.pressKey('ARROW_DOWN');
+    await frameAfter(testRenderer);
+    const firstAgent = controller.state.selectedAgentKind;
+    expect(firstAgent).not.toBeNull();
+    expect(controller.state.selectedEntryId).toBeNull();
+
+    // Right hands them to the transcript, where they walk its entries instead.
+    testRenderer.mockInput.pressKey('ARROW_RIGHT');
+    await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('transcript');
+    testRenderer.mockInput.pressKey('ARROW_UP');
+    await frameAfter(testRenderer);
+    expect(controller.state.selectedEntryId).not.toBeNull();
+    // The agent picked on the left is still the filter: moving the keys is not
+    // the same as giving up the selection.
+    expect(controller.state.selectedAgentKind).toBe(firstAgent);
+
+    // And Tab still works after coming back, from where the operator left off.
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    testRenderer.mockInput.pressKey('TAB');
+    await frameAfter(testRenderer);
+    expect(controller.state.selectedAgentKind).not.toBe(firstAgent);
+  });
+
+  it('marks the chat input as focused when it is clicked', async () => {
+    const testRenderer = await createTestRenderer({width: 150, height: 22});
+    const controller = new FakeController({...initialSessionState(), chatDockFits: true});
+    controller.experiments = [
+      logEntry('H-01', 1, 1, {
+        claim: 'fuse the epilogue',
+        rounds: [{round: 1, passed: true, reviewed: true}],
+      }),
+    ];
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    const docked = await testRenderer.waitForFrame(value => value.includes('Type a question'));
+    // The hint says the keys are elsewhere, which is the state being reported.
+    expect(docked).toContain('Ctrl+W to type here');
+
+    // Click the box the operator types into, not the conversation above it.
+    const lines = docked.split('\n');
+    const row = lines.findIndex(line => line.includes('Type a question'));
+    const column = (lines[row]?.indexOf('Type a question') ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
+    const focused = await frameAfter(testRenderer);
+
+    expect(controller.state.layout.focus).toBe('chat');
+    // And the box says so: clicking must move the border, not only the cursor.
+    expect(focused).not.toContain('Ctrl+W to type here');
+    expect(spanColors(testRenderer, 'Chat')?.fg).toBe(resolveTheme('dark').borderFocus);
+  });
+
+  it('gives the chat the keys when it is clicked, not only on Ctrl+W', async () => {
+    const testRenderer = await createTestRenderer({width: 150, height: 22});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      chatDockFits: true,
+      chatConversation: [
+        {id: 'a1', kind: 'assistant', label: 'Answer', content: 'the epilogue was fused'},
+      ],
+    });
+    controller.experiments = [
+      logEntry('H-01', 1, 1, {
+        claim: 'fuse the epilogue',
+        rounds: [{round: 1, passed: true, reviewed: true}],
+      }),
+    ];
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    const docked = await testRenderer.waitForFrame(value => value.includes('Experiment chat'));
+    expect(controller.state.layout.focus).toBe('left');
+
+    // Click inside the chat's body, which is where a pointer actually lands.
+    const row = docked.split('\n').findIndex(line => line.includes('the epilogue was fused'));
+    const column = docked.split('\n')[row]?.indexOf('the epilogue') ?? 0;
+    await testRenderer.mockMouse.click(column, row);
+    await frameAfter(testRenderer);
+
+    expect(controller.state.layout.focus).toBe('chat');
+  });
+
+  it('says so when a round has not run instead of looking broken', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 20});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      maxRounds: 20,
+      rounds: [{number: 1, status: 'completed'}],
+      phases: [{kind: 'judge', status: 'completed', roundNumber: 1, roundLabel: 'round-1-judge'}],
+      selectedRound: 9,
+      conversation: [
+        {id: 'e1', kind: 'assistant', label: 'judge', content: 'done', roundNumber: 1},
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('has not run yet'));
+    expect(frame).toContain('Round 9 has not run yet.');
+    // The strip still shows it as a round of this run, marked as the one open.
+    expect(frame).toContain('[ r9 ]');
+  });
+
+  it('closes a visualization and the chat together on one Escape', async () => {
+    const testRenderer = await createTestRenderer({width: 130, height: 22});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      rounds: [{number: 1, status: 'active'}],
+      phases: [{kind: 'judge', status: 'active', roundNumber: 1, roundLabel: 'round-1-judge'}],
+      hypothesisScope: {id: 'H-01', label: 'H-01 · r1', rounds: [1]},
+      selectedRound: 1,
+      conversation: [
+        {id: 'e1', kind: 'assistant', label: 'judge', content: 'weighing it', roundNumber: 1},
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openPane('perf');
+    controller.publish({...controller.state, chatOpen: true});
+    await frameAfter(testRenderer);
+
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await frameAfterEscape(testRenderer);
+
+    // Back on the round in one press, not part way with the chat still over it.
+    expect(controller.state.chatOpen).toBe(false);
+    expect(controller.state.layout.right).toBeNull();
+    expect(controller.state.hypothesisScope).not.toBeNull();
+  });
+
+  it('hands the keys back when the pane holding them closes', async () => {
+    const testRenderer = await createTestRenderer({width: 130, height: 22});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      rounds: [{number: 1, status: 'active'}],
+      phases: [{kind: 'judge', status: 'active', roundNumber: 1, roundLabel: 'round-1-judge'}],
+      selectedRound: 1,
+      conversation: [
+        {id: 'e1', kind: 'assistant', label: 'judge', content: 'weighing it', roundNumber: 1},
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openPane('perf');
+    controller.focusPane('right');
+    await frameAfter(testRenderer);
+    controller.closePane();
+    await frameAfter(testRenderer);
+
+    // Focus cannot be left pointing at a pane that is gone, or every key after
+    // it goes nowhere and the client looks frozen.
+    expect(controller.state.layout.focus).toBe('left');
+    testRenderer.mockInput.pressKey(']');
+    await frameAfter(testRenderer);
+    expect(controller.state.selectedRound).toBe(1);
+  });
+
+  it('keeps the chat in one conversation across the log and a round', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 22});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      chatConversation: [
+        {id: 'q1', kind: 'user', label: 'You', content: 'what changed?'},
+        {id: 'a1', kind: 'assistant', label: 'Answer', content: 'the epilogue was fused'},
+      ],
+      rounds: [{number: 1, status: 'active'}],
+      phases: [{kind: 'judge', status: 'active', roundNumber: 1, roundLabel: 'round-1-judge'}],
+      chatOpen: true,
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    // The same exchange is on screen inside a round, not only on the log.
+    const frame = await testRenderer.waitForFrame(value =>
+      value.includes('the epilogue was fused'),
+    );
+    expect(frame).toContain('what changed?');
+  });
+
+  it('draws a round with many agents per stage without overlap', async () => {
+    const testRenderer = await createTestRenderer({width: 150, height: 34});
+    const phase = (kind: string, status: 'completed' | 'active' | 'pending', index: number) => ({
+      kind,
+      status,
+      roundNumber: 1,
+      roundLabel: `round-1-${kind}`,
+      invocationId: `${kind}-${index}`,
+    });
+    const controller = new FakeController({
+      ...initialSessionState(),
+      rounds: [{number: 1, status: 'active'}],
+      phases: [
+        phase('orchestrator', 'completed', 0),
+        phase('implementer', 'completed', 1),
+        phase('implementer', 'active', 2),
+        phase('implementer', 'active', 3),
+        phase('judge', 'pending', 4),
+        phase('judge', 'pending', 5),
+        phase('profiler', 'pending', 6),
+      ],
+      conversation: [{id: 'live', kind: 'assistant', label: 'Agent', content: 'out'}],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('orchestrator'));
+
+    expect(frame).toContain('7 agents');
+    expect(frame).toContain('2 active');
+    // Every stage is drawn, and the fan-out rows do not collapse onto each other.
+    const nodeRows = frame.split('\n').filter(line => line.includes('implementer'));
+    expect(nodeRows.length).toBeGreaterThanOrEqual(3);
+    expect(frame).toContain('▶');
+  });
+
+  it('falls back to the stacked strip when the terminal is too narrow for a graph', async () => {
+    const testRenderer = await createTestRenderer({width: 80, height: 30});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      rounds: [{number: 1, status: 'active'}],
+      phases: [
+        {kind: 'orchestrator', status: 'completed', roundNumber: 1, roundLabel: 'round-1-plan'},
+        {kind: 'implementer', status: 'active', roundNumber: 1, roundLabel: 'round-1-implementer'},
+        {kind: 'judge', status: 'pending', roundNumber: 1, roundLabel: 'round-1-judge'},
+      ],
+      conversation: [{id: 'live', kind: 'assistant', label: 'Agent', content: 'live output'}],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('orchestrator'));
+
+    expect(frame).toContain('        ↓');
+    expect(frame).not.toContain('▶');
   });
 
   it('holds the agent-active elapsed time of a finished round', async () => {
@@ -617,8 +1067,9 @@ describe('theming', () => {
     expect(spanColors(testRenderer, 'VibeSys')?.fg).toBe('#22d3ee');
     const body = spanColors(testRenderer, 'themed body text');
     expect(body?.fg).toBe('#e2e8f0');
-    expect(body?.bg).toBe('#0f1b24');
-    expect(spanColors(testRenderer, 'implementer')?.fg).toBe('#67e8f9');
+    // Assistant cards derive their fill from the canvas and the role accent.
+    expect(body?.bg).toBe('#0e283d');
+    expect(spanColors(testRenderer, 'implementer')?.fg).toBe('#5cb6cc');
   });
 
   it('repaints live when the selected theme changes', async () => {
@@ -904,14 +1355,17 @@ describe('theming', () => {
     testRenderer.mockInput.pressEnter();
     const trajectory = await frameAfter(testRenderer);
 
-    // Every round of that hypothesis, and only those rounds.
-    expect(trajectory).toContain('grew the block');
+    // Opening a hypothesis lands on its latest round, and the earlier ones are
+    // one `[` away.
+    expect(trajectory).toContain('r43');
     expect(trajectory).toContain('regression found');
     expect(trajectory).not.toContain('unrelated round 41');
     expect(trajectory).toContain('H-08 · r42-43');
     expect(trajectory).toContain('r42');
     expect(trajectory).toContain('r43');
-    expect(trajectory).not.toContain('r41');
+    // The strip covers the whole run, so rounds outside this hypothesis are
+    // reachable from it; the transcript still shows only the selected round.
+    expect(trajectory).toContain('r41');
     expect(controller.state.hypothesisScope).toMatchObject({id: 'H-08', rounds: [42, 43]});
 
     testRenderer.mockInput.pressKey('ESCAPE');
@@ -1554,7 +2008,9 @@ class FakeController implements SessionController {
   state: SessionState;
 
   publish(state: SessionState): void {
-    this.state = state;
+    // The real controller normalizes focus on every state change; the fake has
+    // to as well, or tests pass on a focus the client could never be in.
+    this.state = normalizeFocus(state);
     for (const listener of this.#listeners) listener(this.state);
   }
 
@@ -1653,18 +2109,39 @@ class FakeController implements SessionController {
     this.selectNextAgent();
   }
   selectNextRound(): void {
-    const index = this.state.rounds.findIndex(round => round.number === this.state.selectedRound);
-    const next =
-      this.state.rounds[(index + 1 + this.state.rounds.length) % this.state.rounds.length];
-    this.state = {...this.state, selectedRound: next?.number ?? null, selectedAgentKind: null};
-    for (const listener of this.#listeners) listener(this.state);
+    this.publish(selectNextRound(this.state));
   }
   selectPreviousRound(): void {
-    this.selectNextRound();
+    this.publish(selectPreviousRound(this.state));
+  }
+  selectAgent(kind: string): void {
+    this.publish(selectAgent(this.state, kind));
+  }
+  selectNextEntry(delta: number, id?: string): void {
+    this.publish(selectNextEntry(this.state, delta, id));
+  }
+  clearEntrySelection(): void {
+    this.publish(clearEntrySelection(this.state));
+  }
+  clearAgentSelection(): void {
+    this.publish(clearAgentSelection(this.state));
+  }
+  focusRound(focus: RoundFocus): void {
+    this.publish(focusRound(this.state, focus));
+  }
+  selectNextTodo(delta: number): void {
+    this.publish(selectNextTodo(this.state, delta));
   }
   selectRound(roundNumber: number): void {
     this.state = {...this.state, selectedRound: roundNumber, selectedAgentKind: null};
     for (const listener of this.#listeners) listener(this.state);
+  }
+  #promptToggle: (() => void) | null = null;
+  onTogglePrompt(handler: () => void): void {
+    this.#promptToggle = handler;
+  }
+  togglePrompt(): void {
+    this.#promptToggle?.();
   }
   toggleTodos(): void {
     this.state = {...this.state, todosExpanded: !this.state.todosExpanded};
@@ -1690,6 +2167,9 @@ class FakeController implements SessionController {
   }
   closePane(): void {
     this.publish(closePane(this.state));
+  }
+  closeOverlays(): void {
+    this.publish(closeOverlays(this.state));
   }
   cyclePaneFocus(): void {
     this.publish(cyclePaneFocus(this.state));

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -3,9 +3,10 @@ import type {SessionController} from '../session-controller.js';
 import {experimentLogVisible, type SessionState, statusText} from '../session-model.js';
 import {AgentMapView} from './agent-map.js';
 import {ChatOverlayView} from './chat-overlay.js';
+import {ChatPaneView, chatDockFits, chatPaneWidth} from './chat-pane.js';
 import {ConversationView} from './conversation.js';
 import {ExperimentLogView} from './experiment-log.js';
-import {createInputPanel} from './input.js';
+import {createChatInputPanel, createInputPanel} from './input.js';
 import {bindKeybindings} from './keybindings.js';
 import {OverlayView} from './overlay.js';
 import {RightPaneView, rightPaneWidth, splitFits} from './right-pane.js';
@@ -19,12 +20,26 @@ export interface OpenTuiApp {
   destroy(): void;
 }
 
+/** Which of the client's inputs currently holds the cursor. */
+type FocusTarget = 'command' | 'chat' | 'modal';
+
 const KEY_HELP =
   '[/]: round · Tab: agent · PgUp/PgDn · Ctrl+T: todos · Ctrl+P: prompt · Ctrl+L: live';
 const SCOPED_KEY_HELP =
   '[/]: round · Tab: agent · PgUp/PgDn · Ctrl+T: todos · Ctrl+P: prompt · Esc: experiments';
 const LOG_KEY_HELP =
   '↑↓ or scroll: select · Enter or /open-round: open its rounds · /open-round --N';
+const LOG_CHAT_KEY_HELP =
+  '↑↓: select · Enter: open its rounds · Ctrl+W: chat and back · /open-round --N';
+/**
+ * Shown above the docked chat's own input. Short enough to leave a gap before
+ * the key hints beside it even in the narrowest column that docks, and it says
+ * how to reach the box while the cursor is in the command input, because two
+ * boxes on screen must never leave that a guess.
+ */
+const CHAT_INPUT_HINT = 'Ask about this run';
+const CHAT_INPUT_PENDING_HINT = 'Awaiting the agent';
+const CHAT_INPUT_BLURRED_HINT = 'Ctrl+W to type here';
 const SPLIT_KEY_HELP =
   'Ctrl+W: switch pane · PgUp/PgDn: scroll focused pane · Esc on the pane: close it';
 
@@ -78,22 +93,69 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   const themePicker = new ThemePickerView(renderer, theme);
   const conversation = new ConversationView(renderer, controller, markdownStyle, theme);
   const chat = new ChatOverlayView(renderer, controller, markdownStyle, theme);
+  const chatPane = new ChatPaneView(renderer, controller, markdownStyle, theme);
   const input = createInputPanel(renderer, value => void controller.submit(value), theme);
+  const chatInput = createChatInputPanel(
+    renderer,
+    value => void controller.submitChat(value),
+    theme,
+  );
+  // The two inputs share a row and split it on the same boundary as the panes
+  // above them, so each box sits under the surface it writes to.
+  const bottom = new BoxRenderable(renderer, {
+    id: 'bottom',
+    width: '100%',
+    flexShrink: 0,
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+  });
+  const chatInputColumn = new BoxRenderable(renderer, {
+    id: 'chat-input-column',
+    flexDirection: 'column',
+    flexShrink: 0,
+    flexGrow: 0,
+    visible: false,
+  });
+  const chatInputHint = new TextRenderable(renderer, {
+    id: 'chat-input-hint',
+    height: 1,
+    width: '100%',
+    wrapMode: 'none',
+    truncate: true,
+    fg: theme.textSubtle,
+    content: CHAT_INPUT_HINT,
+  });
+  const commandColumn = new BoxRenderable(renderer, {
+    id: 'command-column',
+    flexGrow: 1,
+    flexShrink: 0,
+    flexDirection: 'column',
+  });
 
   viewport.add(conversation.output);
   main.add(agentMap.output);
+  // The chat is the leftmost column of the landing view, so it is added before
+  // the surfaces it sits beside.
+  main.add(chatPane.output);
   main.add(viewport);
   // The log lives in the main pane rather than floating over it: it is the
   // landing view, not a dialog.
   main.add(experimentLog.output);
   main.add(rightPane.output);
+  chatInputColumn.add(chatInputHint);
+  chatInputColumn.add(chatInput.box);
+  commandColumn.add(help);
+  // Absolute inside the command column rather than the root, so the list rises
+  // out of the input it belongs to instead of across the chat beside it.
+  commandColumn.add(input.suggestions);
+  commandColumn.add(input.box);
+  bottom.add(chatInputColumn);
+  bottom.add(commandColumn);
   root.add(header);
   root.add(roundStrip.output);
   root.add(main);
   root.add(todoStrip.output);
-  root.add(help);
-  root.add(input.suggestions);
-  root.add(input.box);
+  root.add(bottom);
   root.add(overlay.output);
   root.add(themePicker.output);
   root.add(chat.output);
@@ -118,11 +180,14 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     themePicker.applyTheme(theme);
     conversation.applyTheme(theme, markdownStyle);
     chat.applyTheme(theme, markdownStyle);
+    chatPane.applyTheme(theme, markdownStyle);
+    chatInput.applyTheme(theme);
+    chatInputHint.fg = theme.textSubtle;
     input.applyTheme(theme);
     return () => previousMarkdownStyle.destroy();
   };
 
-  let chatWasOpen = false;
+  let focusTarget: FocusTarget = 'command';
   let lastState: SessionState = controller.state;
   const render = (state: SessionState): void => {
     lastState = state;
@@ -137,9 +202,16 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     const paneFallback = splitOpen && !showSplit ? state.layout.right : null;
     // Whatever holds the left side, log or transcript, shares the row with the
     // pane rather than being replaced by it.
-    const leftWidth = showSplit
-      ? renderer.terminalWidth - rightPaneWidth(renderer.terminalWidth)
-      : renderer.terminalWidth;
+    const rightWidth = showSplit ? rightPaneWidth(renderer.terminalWidth) : 0;
+    const leftWidth = renderer.terminalWidth - rightWidth;
+    // Measured here because this is the only place that knows the width, and
+    // reported to the controller so a question goes where the operator can see
+    // it. The layout below uses the measurement directly rather than waiting
+    // for the state to come back, so a resize never draws a stale row.
+    const dockFits = chatDockFits(renderer.terminalWidth, rightWidth);
+    if (state.chatDockFits !== dockFits) controller.setChatDockFits(dockFits);
+    const showChatPane = showLog && dockFits && !state.chatOpen;
+    const chatWidth = showChatPane ? chatPaneWidth(renderer.terminalWidth, rightWidth) : 0;
     const dialogOpen = state.chatOpen || state.overlay !== null || state.themePicker !== null;
     const returnHint = dialogOpen ? ' · Esc: close dialog' : '';
     const selection = state.selectedAgentKind ? ` · selected ${state.selectedAgentKind}` : '';
@@ -152,7 +224,9 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     help.content = showSplit
       ? SPLIT_KEY_HELP
       : showLog
-        ? LOG_KEY_HELP
+        ? showChatPane
+          ? LOG_CHAT_KEY_HELP
+          : LOG_KEY_HELP
         : state.hypothesisScope === null
           ? KEY_HELP
           : SCOPED_KEY_HELP;
@@ -188,7 +262,22 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     } else {
       chat.setPaneBounds(null);
     }
-    experimentLog.setAvailableWidth(showSplit ? leftWidth : null);
+    chatPane.render(state, showChatPane, chatWidth);
+    // The chat's input tracks the pane above it, so the boundary between the
+    // two boxes is the boundary between the two surfaces they write to.
+    chatInputColumn.visible = showChatPane;
+    chatInputColumn.width = chatWidth;
+    const chatInputFocused = showChatPane && state.layout.focus === 'chat';
+    chatInputHint.content = state.chatPending
+      ? CHAT_INPUT_PENDING_HINT
+      : chatInputFocused
+        ? CHAT_INPUT_HINT
+        : CHAT_INPUT_BLURRED_HINT;
+    chatInput.setFocused(chatInputFocused);
+    // The command list completes the box it belongs to, and on this view that
+    // box cannot open a chat that is already beside it.
+    input.setCommandContext({chatDocked: showChatPane});
+    experimentLog.setAvailableWidth(showSplit || showChatPane ? leftWidth - chatWidth : null);
     experimentLog.render(state);
     rightPane.render(state, showSplit);
     overlay.render(
@@ -198,14 +287,23 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     );
     themePicker.render(state);
     chat.render(state);
-    if (state.chatOpen && !chatWasOpen) chat.focus();
-    if (!state.chatOpen && chatWasOpen) input.focus();
-    chatWasOpen = state.chatOpen;
+    // One cursor, three places it can be. The modal owns it while it is open;
+    // otherwise it belongs to whichever input the pane focus points at.
+    const target: FocusTarget = state.chatOpen ? 'modal' : chatInputFocused ? 'chat' : 'command';
+    if (target !== focusTarget) {
+      focusTarget = target;
+      if (target === 'modal') chat.focus();
+      else if (target === 'chat') chatInput.focus();
+      else input.focus();
+    }
     releasePreviousStyle?.();
   };
   const unbindKeys = bindKeybindings(renderer, controller, viewport, {
     completeInput: () => input.completeSuggestion(),
-    inputIsEmpty: () => input.isEmpty(),
+    // Enter belongs to a pane only when nothing is typed anywhere. Asking which
+    // box has the cursor is not enough: a question waiting in the other box is
+    // still a question, and Enter must never discard it to open a hypothesis.
+    inputIsEmpty: () => input.isEmpty() && chatInput.isEmpty(),
     closeChat: () => controller.closeChat(),
     toggleLatestPrompt: () => conversation.toggleLatestPrompt(),
     selectNextAgent: () => controller.selectNextAgent(),
@@ -214,6 +312,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     selectPreviousRound: () => controller.selectPreviousRound(),
     toggleTodos: () => controller.toggleTodos(),
     scrollRightPane: delta => rightPane.scrollBy(delta),
+    scrollChatPane: delta => chatPane.scrollBy(delta),
   });
   // Pane widths come from the terminal, so a resize has to redraw even though
   // no state changed.
@@ -227,6 +326,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
       unsubscribe();
       unbindKeys();
       input.destroy();
+      chatInput.destroy();
       chat.destroy();
       roundStrip.destroy();
       agentMap.destroy();

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -1,6 +1,12 @@
 import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
-import {experimentLogVisible, type SessionState, statusText} from '../session-model.js';
+import {
+  experimentLogVisible,
+  type SessionState,
+  statusText,
+  stripRounds,
+  visibleRoundNumber,
+} from '../session-model.js';
 import {AgentMapView} from './agent-map.js';
 import {ChatOverlayView} from './chat-overlay.js';
 import {ChatPaneView, chatDockFits, chatPaneWidth} from './chat-pane.js';
@@ -14,7 +20,7 @@ import {RoundStripView} from './round-strip.js';
 import {createMarkdownStyle} from './styles.js';
 import {resolveTheme, type ThemeName} from './theme.js';
 import {ThemePickerView} from './theme-picker.js';
-import {TodoStripView} from './todo-strip.js';
+import {TodoStripView, todoStripWidth} from './todo-strip.js';
 
 export interface OpenTuiApp {
   destroy(): void;
@@ -23,10 +29,8 @@ export interface OpenTuiApp {
 /** Which of the client's inputs currently holds the cursor. */
 type FocusTarget = 'command' | 'chat' | 'modal';
 
-const KEY_HELP =
-  '[/]: round · Tab: agent · PgUp/PgDn · Ctrl+T: todos · Ctrl+P: prompt · Ctrl+L: live';
-const SCOPED_KEY_HELP =
-  '[/]: round · Tab: agent · PgUp/PgDn · Ctrl+T: todos · Ctrl+P: prompt · Esc: experiments';
+const KEY_HELP = '[/]: round · ←→: pane · ↑↓/Tab: within it · /todos · /prompt · Ctrl+L: live';
+const SCOPED_KEY_HELP = '[/]: round · ←→: pane · ↑↓/Tab: within it · /todos · /prompt · Esc: back';
 const LOG_KEY_HELP =
   '↑↓ or scroll: select · Enter or /open-round: open its rounds · /open-round --N';
 const LOG_CHAT_KEY_HELP =
@@ -42,6 +46,18 @@ const CHAT_INPUT_PENDING_HINT = 'Awaiting the agent';
 const CHAT_INPUT_BLURRED_HINT = 'Ctrl+W to type here';
 const SPLIT_KEY_HELP =
   'Ctrl+W: switch pane · PgUp/PgDn: scroll focused pane · Esc on the pane: close it';
+
+/**
+ * A round the run has not reached has no turns and never will until it runs.
+ * Saying so beats "waiting for run events", which reads as something broken.
+ */
+function emptyTranscriptMessage(state: SessionState): string {
+  const roundNumber = visibleRoundNumber(state);
+  if (roundNumber === null) return 'Waiting for run events…';
+  const round = stripRounds(state).find(item => item.number === roundNumber);
+  if (round?.status === 'planned') return `Round ${roundNumber} has not run yet.`;
+  return 'Waiting for run events…';
+}
 
 export function createOpenTuiApp(renderer: CliRenderer, controller: SessionController): OpenTuiApp {
   let themeName: ThemeName = controller.state.themeName;
@@ -86,19 +102,29 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   let markdownStyle = createMarkdownStyle(theme);
   const roundStrip = new RoundStripView(renderer, controller, theme);
   const todoStrip = new TodoStripView(renderer, controller, theme);
-  const agentMap = new AgentMapView(renderer, theme);
+  const agentMap = new AgentMapView(renderer, controller, theme);
   const overlay = new OverlayView(renderer, theme);
   const experimentLog = new ExperimentLogView(renderer, controller, theme);
   const rightPane = new RightPaneView(renderer, theme);
   const themePicker = new ThemePickerView(renderer, theme);
-  const conversation = new ConversationView(renderer, controller, markdownStyle, theme);
+  const conversation = new ConversationView(renderer, controller, markdownStyle, theme, {
+    showsSelection: true,
+  });
   const chat = new ChatOverlayView(renderer, controller, markdownStyle, theme);
   const chatPane = new ChatPaneView(renderer, controller, markdownStyle, theme);
-  const input = createInputPanel(renderer, value => void controller.submit(value), theme);
+  // Clicking either box moves the pane focus to it, so the border, the hint,
+  // and the cursor never disagree about which surface is taking keystrokes.
+  const input = createInputPanel(
+    renderer,
+    value => void controller.submit(value),
+    theme,
+    () => controller.focusPane('left'),
+  );
   const chatInput = createChatInputPanel(
     renderer,
     value => void controller.submitChat(value),
     theme,
+    () => controller.focusPane('chat'),
   );
   // The two inputs share a row and split it on the same boundary as the panes
   // above them, so each box sits under the surface it writes to.
@@ -132,6 +158,9 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     flexDirection: 'column',
   });
 
+  // A slash command and a key toggle the same prompt: the controller routes the
+  // request, the transcript decides which prompt it applies to.
+  controller.onTogglePrompt(() => conversation.toggleLatestPrompt());
   viewport.add(conversation.output);
   main.add(agentMap.output);
   // The chat is the leftmost column of the landing view, so it is added before
@@ -238,15 +267,27 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     todoStrip.output.visible = !showLog;
     if (!showLog) {
       roundStrip.render(state);
-      todoStrip.render(state);
       agentMap.render(state);
+      // The todo box sits under the agent pane and stops where it stops: the
+      // todos belong to an agent, so running them under the transcript would
+      // attach them to the wrong thing.
+      conversation.setEmptyContent(emptyTranscriptMessage(state));
+      const agentWidth = agentMap.output.width;
+      todoStrip.render(
+        state,
+        typeof agentWidth === 'number' ? todoStripWidth(agentWidth, renderer.terminalWidth) : null,
+      );
       conversation.render(state);
     }
     // The agent map is the first thing to give up room: it is a summary the
     // visualization largely supersedes while the split is open.
     agentMap.output.visible = !showLog && !showSplit;
-    viewport.borderColor =
-      showSplit && state.layout.focus === 'left' ? theme.borderFocus : theme.border;
+    // Inside a round the transcript is one of two navigable panes, so it carries
+    // the focus border whenever the round view's keys are on it.
+    const transcriptFocused = showLog
+      ? showSplit && state.layout.focus === 'left'
+      : state.roundFocus === 'transcript';
+    viewport.borderColor = transcriptFocused ? theme.borderFocus : theme.border;
     // Match the chat to the left pane's rectangle so it sits beside the
     // visualization instead of over it. Bounds come from the siblings that
     // actually occupy those rows, so a taller todo strip still fits.
@@ -306,6 +347,10 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     inputIsEmpty: () => input.isEmpty() && chatInput.isEmpty(),
     closeChat: () => controller.closeChat(),
     toggleLatestPrompt: () => conversation.toggleLatestPrompt(),
+    revealSelectedEntry: () => {
+      const card = conversation.selectedCard();
+      if (card !== null) viewport.scrollChildIntoView(card.id);
+    },
     selectNextAgent: () => controller.selectNextAgent(),
     selectPreviousAgent: () => controller.selectPreviousAgent(),
     selectNextRound: () => controller.selectNextRound(),
@@ -328,6 +373,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
       input.destroy();
       chatInput.destroy();
       chat.destroy();
+      conversation.destroy();
       roundStrip.destroy();
       agentMap.destroy();
       root.destroyRecursively();

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -101,7 +101,7 @@ export class ChatOverlayView {
     this.output.add(this.#transcript);
     this.output.add(this.#inputBox);
     this.#hint = new TextRenderable(renderer, {
-      content: 'Enter to send · /history and other commands work here · Esc to close',
+      content: 'Enter to send · /perf and other commands work here · Esc to close',
       fg: theme.textSubtle,
       height: 1,
       width: '100%',

--- a/clients/tui/src/ui/chat-pane.test.ts
+++ b/clients/tui/src/ui/chat-pane.test.ts
@@ -1,0 +1,54 @@
+import {describe, expect, it} from 'bun:test';
+import {chatDockFits, chatPaneWidth, MIN_DOCK_WIDTH} from './chat-pane.js';
+import {LOG_CLAIM_PANEL_WIDTH, LOG_COMPACT_PANEL_WIDTH} from './experiment-log.js';
+
+describe('chat dock thresholds', () => {
+  it('docks wherever the table is still usable beside it', () => {
+    expect(chatDockFits(MIN_DOCK_WIDTH)).toBe(true);
+    expect(chatDockFits(MIN_DOCK_WIDTH - 1)).toBe(false);
+    // Small enough that two columns would both be unreadable.
+    expect(chatDockFits(80)).toBe(false);
+    expect(chatDockFits(120)).toBe(true);
+  });
+
+  it('docks beside a visualization only when all three columns fit', () => {
+    expect(chatDockFits(200, 84)).toBe(true);
+    // The visualization has taken the room the chat would need.
+    expect(chatDockFits(140, 63)).toBe(false);
+  });
+});
+
+describe('chat dock sizing', () => {
+  it('takes the columns left over once the table has its claim', () => {
+    // No surplus: the chat takes its minimum and the table keeps the rest.
+    expect(chatPaneWidth(MIN_DOCK_WIDTH)).toBe(25);
+    expect(chatPaneWidth(200)).toBeGreaterThan(chatPaneWidth(140));
+  });
+
+  it('stops widening once the chat is comfortable', () => {
+    expect(chatPaneWidth(400)).toBe(chatPaneWidth(300));
+  });
+
+  it('costs the table no column once there are spare ones', () => {
+    for (let width = LOG_CLAIM_PANEL_WIDTH + 25; width <= 400; width += 1) {
+      const log = width - chatPaneWidth(width);
+      expect(log, `log at ${width}`).toBeGreaterThanOrEqual(LOG_CLAIM_PANEL_WIDTH);
+    }
+  });
+
+  it('never takes the table below its compact set', () => {
+    for (let width = MIN_DOCK_WIDTH; width <= 400; width += 1) {
+      const log = width - chatPaneWidth(width);
+      expect(log, `log at ${width}`).toBeGreaterThanOrEqual(LOG_COMPACT_PANEL_WIDTH);
+    }
+    const right = 84;
+    for (let width = 200; width <= 400; width += 1) {
+      const log = width - right - chatPaneWidth(width, right);
+      expect(log, `log at ${width} beside a pane`).toBeGreaterThanOrEqual(LOG_COMPACT_PANEL_WIDTH);
+    }
+  });
+
+  it('narrows itself rather than the table when a visualization opens', () => {
+    expect(chatPaneWidth(200, 84)).toBeLessThan(chatPaneWidth(200));
+  });
+});

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -1,0 +1,127 @@
+import {
+  BoxRenderable,
+  type CliRenderer,
+  ScrollBoxRenderable,
+  type SyntaxStyle,
+} from '@opentui/core';
+import type {SessionController} from '../session-controller.js';
+import {chatPaneFocused, type SessionState} from '../session-model.js';
+import {ConversationView} from './conversation.js';
+import {LOG_CLAIM_PANEL_WIDTH, LOG_COMPACT_PANEL_WIDTH} from './experiment-log.js';
+import type {Theme} from './theme.js';
+
+/**
+ * Columns the chat needs before a question and its answer read as prose rather
+ * than as a column of fragments.
+ */
+const CHAT_PANE_MIN = 25;
+const CHAT_PANE_MAX = 52;
+
+/**
+ * The chat is part of the landing view, so it docks wherever the table is still
+ * usable beside it rather than only where the table keeps every column. Below
+ * that the table has the row to itself and the chat opens over it as a modal,
+ * which is the one case where two columns would both be unreadable.
+ */
+export const MIN_DOCK_WIDTH = LOG_COMPACT_PANEL_WIDTH + CHAT_PANE_MIN;
+
+/** True when the terminal can carry the chat beside a usable table. */
+export function chatDockFits(terminalWidth: number, rightPaneWidth = 0): boolean {
+  return terminalWidth - rightPaneWidth - CHAT_PANE_MIN >= LOG_COMPACT_PANEL_WIDTH;
+}
+
+/**
+ * Width in columns for the docked chat. It asks for the columns left over once
+ * the table has enough for its claim, so a wide terminal loses no table column
+ * to the chat; where there is no such surplus it still takes its readable
+ * minimum, and it never takes the table below its compact set.
+ */
+export function chatPaneWidth(terminalWidth: number, rightPaneWidth = 0): number {
+  const available = terminalWidth - rightPaneWidth;
+  const surplus = available - LOG_CLAIM_PANEL_WIDTH;
+  const wanted = Math.max(CHAT_PANE_MIN, Math.min(CHAT_PANE_MAX, surplus));
+  return Math.min(wanted, available - LOG_COMPACT_PANEL_WIDTH);
+}
+
+/**
+ * The experiment chat as a column of the landing view rather than a dialog over
+ * it. It has no input of its own: the client already has one, and plain text
+ * typed there is a question for the agent, so a second box would only split the
+ * operator's attention.
+ */
+export class ChatPaneView {
+  readonly output: BoxRenderable;
+  readonly #scroll: ScrollBoxRenderable;
+  readonly #conversation: ConversationView;
+  #theme: Theme;
+  #renderedState: SessionState | null = null;
+
+  constructor(
+    renderer: CliRenderer,
+    controller: SessionController,
+    markdownStyle: SyntaxStyle,
+    theme: Theme,
+  ) {
+    this.#theme = theme;
+    this.output = new BoxRenderable(renderer, {
+      id: 'chat-pane',
+      height: '100%',
+      flexShrink: 0,
+      flexDirection: 'column',
+      paddingLeft: 1,
+      paddingRight: 1,
+      border: true,
+      borderStyle: 'rounded',
+      borderColor: theme.border,
+      title: ' Experiment chat ',
+      visible: false,
+    });
+    this.#scroll = new ScrollBoxRenderable(renderer, {
+      id: 'chat-pane-scroll',
+      width: '100%',
+      flexGrow: 1,
+      stickyScroll: true,
+      stickyStart: 'bottom',
+      viewportCulling: true,
+      verticalScrollbarOptions: {showArrows: false},
+    });
+    this.#conversation = new ConversationView(renderer, controller, markdownStyle, theme, {
+      selectConversation: state => state.chatConversation,
+      emptyContent: 'Ask about this run: progress, a failure, or what a hypothesis changed.',
+      renderMarkdown: false,
+    });
+    this.#scroll.add(this.#conversation.output);
+    this.output.add(this.#scroll);
+  }
+
+  applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {
+    this.#theme = theme;
+    this.output.borderColor = theme.border;
+    this.#conversation.applyTheme(theme, markdownStyle);
+    this.#renderedState = null;
+  }
+
+  /** Scrolled by Page Up/Page Down while this pane holds focus. */
+  scrollBy(delta: number): void {
+    this.#scroll.scrollBy(delta, 'viewport');
+  }
+
+  render(state: SessionState, visible: boolean, width: number): void {
+    this.output.visible = visible;
+    if (!visible) {
+      this.#renderedState = null;
+      return;
+    }
+    this.output.width = width;
+    const focused = chatPaneFocused(state);
+    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
+    // The column can be as narrow as its minimum, where a spelled-out "focused"
+    // costs the title itself: a box with no title reads as nothing at all. The
+    // marker is the one the table already uses for the row that has the keys.
+    this.output.title = focused ? ' ▸ Experiment chat ' : ' Experiment chat ';
+    if (state === this.#renderedState) return;
+    this.#renderedState = state;
+    this.#conversation.render(state);
+    this.#scroll.scrollTo(this.#scroll.scrollHeight);
+  }
+}

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -72,9 +72,13 @@ export class ChatPaneView {
       paddingRight: 1,
       border: true,
       borderStyle: 'rounded',
-      borderColor: theme.border,
+      borderColor: theme.info,
       title: ' Experiment chat ',
       visible: false,
+      // Clicking into the chat gives it the keys, the same thing Ctrl+W does.
+      // Without this the pane took the click but the focus border stayed on the
+      // table, so the operator could not tell where their keys were going.
+      onMouseUp: () => controller.focusPane('chat'),
     });
     this.#scroll = new ScrollBoxRenderable(renderer, {
       id: 'chat-pane-scroll',
@@ -84,6 +88,10 @@ export class ChatPaneView {
       stickyStart: 'bottom',
       viewportCulling: true,
       verticalScrollbarOptions: {showArrows: false},
+      // The pointer lands on whatever is innermost, so the outer box's handler
+      // never fires for a click on the conversation itself. Both surfaces ask
+      // for focus, and the border then agrees with where the keys go.
+      onMouseUp: () => controller.focusPane('chat'),
     });
     this.#conversation = new ConversationView(renderer, controller, markdownStyle, theme, {
       selectConversation: state => state.chatConversation,
@@ -96,7 +104,7 @@ export class ChatPaneView {
 
   applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {
     this.#theme = theme;
-    this.output.borderColor = theme.border;
+    this.output.borderColor = theme.info;
     this.#conversation.applyTheme(theme, markdownStyle);
     this.#renderedState = null;
   }
@@ -114,7 +122,10 @@ export class ChatPaneView {
     }
     this.output.width = width;
     const focused = chatPaneFocused(state);
-    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
+    // The chat keeps a colour of its own at rest, the way the command input
+    // keeps green: which box a keystroke lands in should be readable without
+    // moving focus around to find out.
+    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.info;
     // The column can be as narrow as its minimum, where a spelled-out "focused"
     // costs the title itself: a box with no title reads as nothing at all. The
     // marker is the one the table already uses for the row that has the keys.

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -7,7 +7,7 @@ import {
 } from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
 import type {ConversationEntry, SessionState} from '../session-model.js';
-import {visibleConversation} from '../session-model.js';
+import {visibleConversation, visiblePhases} from '../session-model.js';
 import {promptPreview, toolOutputPreview} from './previews.js';
 import {entryPalette} from './styles.js';
 import type {Theme} from './theme.js';
@@ -16,7 +16,12 @@ export interface ConversationViewOptions {
   selectConversation?: (state: SessionState) => ConversationEntry[];
   emptyContent?: string;
   renderMarkdown?: boolean;
+  /** Whether this view draws the entry cursor and the working marker. */
+  showsSelection?: boolean;
 }
+
+/** Braille dots: one cell wide in every terminal, unlike a spinner of glyphs. */
+const WORKING_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
 export class ConversationView {
   readonly output: BoxRenderable;
@@ -24,10 +29,18 @@ export class ConversationView {
   #markdownStyle: SyntaxStyle;
   readonly #expandedPrompts = new Set<string>();
   readonly #selectConversation: (state: SessionState) => ConversationEntry[];
-  readonly #emptyContent: string;
+  #emptyContent: string;
   readonly #renderMarkdown: boolean;
+  readonly #showsSelection: boolean;
   #renderedConversation: ConversationEntry[] = [];
   #renderedCards: BoxRenderable[] = [];
+  #renderedSelection: string | null = null;
+  #renderedPending = false;
+  #selectedId: string | null = null;
+  /** True while the run is still producing output for the last entry. */
+  #pending = false;
+  #workingFrame = 0;
+  #workingTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -41,6 +54,7 @@ export class ConversationView {
     this.#selectConversation = options.selectConversation ?? visibleConversation;
     this.#emptyContent = options.emptyContent ?? 'Waiting for run events…';
     this.#renderMarkdown = options.renderMarkdown ?? true;
+    this.#showsSelection = options.showsSelection ?? false;
     this.output = new BoxRenderable(renderer, {
       id: 'output',
       width: '100%',
@@ -51,7 +65,85 @@ export class ConversationView {
   }
 
   render(state: SessionState): void {
+    const selection = this.#selectionFor(state);
+    const pending = this.#pendingFor(state);
+    if (selection !== this.#renderedSelection || pending !== this.#renderedPending) {
+      // The cursor and the working marker are drawn into the cards, so a change
+      // to either has to redraw them even when the entries are identical.
+      this.#renderedConversation = [];
+      this.#renderedSelection = selection;
+      this.#renderedPending = pending;
+    }
+    this.#selectedId = selection;
+    this.#pending = pending;
     this.#renderConversation(this.#selectConversation(state));
+    this.#syncWorkingTimer();
+  }
+
+  /** The transcript owns the entry cursor; the chat panes never show one. */
+  #selectionFor(state: SessionState): string | null {
+    return this.#showsSelection ? state.selectedEntryId : null;
+  }
+
+  /**
+   * An agent that has started and not finished is still working, so its last
+   * entry carries a marker. Read from the phases rather than from the text, so
+   * it clears the moment the phase does.
+   */
+  #pendingFor(state: SessionState): boolean {
+    // Only the round transcript carries it: in the chat the marker sat on the
+    // answer, where an agent's phase says nothing about the reply.
+    if (!this.#showsSelection) return false;
+    return visiblePhases(state).some(phase => phase.status === 'active');
+  }
+
+  /**
+   * What an empty transcript says. A round with no turns because it has not run
+   * is a different thing from a round whose turns have not arrived, and the
+   * operator should not have to guess which one they are looking at.
+   */
+  setEmptyContent(content: string): void {
+    if (content === this.#emptyContent) return;
+    this.#emptyContent = content;
+    this.#renderedConversation = [];
+  }
+
+  /** Scrolls the selected card into view; the viewport owns the scrolling. */
+  selectedCard(): BoxRenderable | null {
+    if (this.#selectedId === null) return null;
+    const index = this.#renderedConversation.findIndex(entry => entry.id === this.#selectedId);
+    return index === -1 ? null : (this.#renderedCards[index] ?? null);
+  }
+
+  /**
+   * The marker animates on its own clock: nothing else about the transcript
+   * changes between frames, so redrawing the whole view would be waste.
+   */
+  #syncWorkingTimer(): void {
+    if (!this.#pending) {
+      this.#stopWorkingTimer();
+      return;
+    }
+    if (this.#workingTimer !== null) return;
+    this.#workingTimer = setInterval(() => {
+      this.#workingFrame = (this.#workingFrame + 1) % WORKING_FRAMES.length;
+      const card = this.#renderedCards.at(-1);
+      const heading = card?.getChildren()[0];
+      const marker = heading?.getChildren()[1];
+      if (marker instanceof TextRenderable) {
+        marker.content = ` ${WORKING_FRAMES[this.#workingFrame]} Working `;
+      }
+    }, 120);
+  }
+
+  #stopWorkingTimer(): void {
+    if (this.#workingTimer === null) return;
+    clearInterval(this.#workingTimer);
+    this.#workingTimer = null;
+  }
+
+  destroy(): void {
+    this.#stopWorkingTimer();
   }
 
   applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {
@@ -84,7 +176,7 @@ export class ConversationView {
       return;
     if (isEntryPrefix(this.#renderedConversation, entries)) {
       for (const entry of entries.slice(this.#renderedConversation.length)) {
-        const card = this.#renderEntry(entry);
+        const card = this.#renderEntry(entry, entry === entries.at(-1));
         this.output.add(card);
         this.#renderedCards.push(card);
       }
@@ -98,7 +190,7 @@ export class ConversationView {
       if (previousCard !== undefined && entry !== undefined) {
         this.output.remove(previousCard);
         previousCard.destroyRecursively();
-        const card = this.#renderEntry(entry);
+        const card = this.#renderEntry(entry, changedIndex === entries.length - 1);
         this.output.add(card, changedIndex);
         this.#renderedCards[changedIndex] = card;
         this.#renderedConversation = entries;
@@ -116,7 +208,7 @@ export class ConversationView {
       return;
     }
     for (const entry of entries) {
-      const card = this.#renderEntry(entry);
+      const card = this.#renderEntry(entry, entry === entries.at(-1));
       this.output.add(card);
       this.#renderedCards.push(card);
     }
@@ -129,8 +221,9 @@ export class ConversationView {
     this.#renderConversation(this.#selectConversation(this.controller.state));
   }
 
-  #renderEntry(entry: ConversationEntry): BoxRenderable {
+  #renderEntry(entry: ConversationEntry, isLast = false): BoxRenderable {
     const palette = entryPalette(entry, this.#theme);
+    const selected = this.#selectedId === entry.id;
     const card = new BoxRenderable(this.renderer, {
       id: `event-${entry.id}`,
       width: '100%',
@@ -140,17 +233,48 @@ export class ConversationView {
       paddingRight: 1,
       border: entry.kind !== 'status',
       borderStyle: 'rounded',
-      borderColor: palette.border,
+      // The cursor is the card's border, not a fill: a filled card reads as
+      // selected text, and the transcript already uses fills for roles.
+      borderColor: selected ? this.#theme.borderFocus : palette.border,
       backgroundColor: palette.background,
-      ...(entry.kind === 'prompt' ? {onMouseUp: () => this.#togglePrompt(entry.id)} : {}),
+      ...(this.#showsSelection
+        ? {
+            onMouseUp: () =>
+              entry.kind === 'prompt'
+                ? this.#togglePrompt(entry.id)
+                : this.controller.selectNextEntry(0, entry.id),
+          }
+        : entry.kind === 'prompt'
+          ? {onMouseUp: () => this.#togglePrompt(entry.id)}
+          : {}),
     });
-    card.add(
+    const heading = new BoxRenderable(this.renderer, {
+      id: `event-${entry.id}-heading`,
+      width: '100%',
+      height: 1,
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+    });
+    heading.add(
       new TextRenderable(this.renderer, {
-        content: entry.label ?? entry.kind,
-        fg: palette.label,
+        content: `${selected ? '▸ ' : ''}${entry.label ?? entry.kind}`,
+        fg: selected ? this.#theme.textStrong : palette.label,
         height: 1,
       }),
     );
+    // The last entry of an agent that is still running gets a marker, so a
+    // transcript that has paused mid-turn is told apart from one that is done.
+    if (isLast && this.#pending) {
+      heading.add(
+        new TextRenderable(this.renderer, {
+          content: ` ${WORKING_FRAMES[this.#workingFrame]} Working `,
+          fg: this.#theme.canvas,
+          bg: this.#theme.success,
+          height: 1,
+        }),
+      );
+    }
+    card.add(heading);
     if (
       this.#renderMarkdown &&
       (entry.kind === 'assistant' || entry.kind === 'prompt' || entry.kind === 'user')

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -23,6 +23,15 @@ const CLAIM_MIN_WIDTH = 90;
 const MEASURED_MIN_WIDTH = 62;
 const KEPT_MIN_WIDTH = 104;
 
+/**
+ * Panel width at which the table still shows the claim, which is the row's
+ * identity in words. Anything that takes columns from the table reads this
+ * rather than restating the threshold.
+ */
+export const LOG_CLAIM_PANEL_WIDTH = CLAIM_MIN_WIDTH + PANEL_CHROME_COLUMNS;
+/** Panel width that still carries the measured and verdict columns. */
+export const LOG_COMPACT_PANEL_WIDTH = MEASURED_MIN_WIDTH + PANEL_CHROME_COLUMNS;
+
 interface Columns {
   claim: boolean;
   measured: boolean;

--- a/clients/tui/src/ui/input.ts
+++ b/clients/tui/src/ui/input.ts
@@ -6,12 +6,19 @@ import {
   SyntaxStyle,
   TextRenderable,
 } from '@opentui/core';
-import {type SlashCommand, slashCommandRange, suggestSlashCommands} from '../commands.js';
+import {
+  type CommandContext,
+  type SlashCommand,
+  slashCommandRange,
+  suggestSlashCommands,
+} from '../commands.js';
 import type {Theme} from './theme.js';
 
 export interface InputPanel {
   box: BoxRenderable;
   suggestions: BoxRenderable;
+  /** Narrows the completions to the commands the current view offers. */
+  setCommandContext(context: CommandContext): void;
   completeSuggestion(): boolean;
   /** True when nothing is typed, so Enter belongs to whatever pane is behind. */
   isEmpty(): boolean;
@@ -22,6 +29,75 @@ export interface InputPanel {
 
 function commandSyntaxStyle(theme: Theme): SyntaxStyle {
   return SyntaxStyle.fromStyles({'slash-command': {fg: theme.accent, bold: true}});
+}
+
+/**
+ * The docked chat's own input. It carries no command suggestions: the command
+ * list belongs to the client's input, and this box is for questions about the
+ * experiment on screen. A slash command typed here still runs, through the same
+ * path as anywhere else.
+ */
+export interface ChatInputPanel {
+  box: BoxRenderable;
+  isEmpty(): boolean;
+  focus(): void;
+  setFocused(focused: boolean): void;
+  applyTheme(theme: Theme): void;
+  destroy(): void;
+}
+
+export function createChatInputPanel(
+  renderer: CliRenderer,
+  onSubmit: (value: string) => void,
+  theme: Theme,
+): ChatInputPanel {
+  const box = new BoxRenderable(renderer, {
+    // The modal chat owns 'chat-input-box'; this is the docked one.
+    id: 'chat-dock-input-box',
+    height: 3,
+    width: '100%',
+    border: true,
+    borderStyle: 'rounded',
+    borderColor: theme.border,
+    title: ' Chat ',
+    paddingLeft: 1,
+    paddingRight: 1,
+  });
+  const input = new InputRenderable(renderer, {
+    id: 'chat-dock-input',
+    width: '100%',
+    placeholder: 'Type a question',
+    textColor: theme.textStrong,
+    focusedTextColor: theme.textStrong,
+  });
+  const submit = (value: string): void => {
+    input.value = '';
+    onSubmit(value);
+  };
+  input.on(InputRenderableEvents.ENTER, submit);
+  box.add(input);
+  let focused = false;
+  let current = theme;
+  return {
+    box,
+    isEmpty: () => input.value.trim() === '',
+    focus: () => input.focus(),
+    // Which box the keystrokes land in is the one thing two inputs must never
+    // leave ambiguous, so the focused one carries the focus border.
+    setFocused(next: boolean): void {
+      focused = next;
+      box.borderColor = next ? current.borderFocus : current.border;
+    },
+    applyTheme(next: Theme): void {
+      current = next;
+      box.borderColor = focused ? next.borderFocus : next.border;
+      input.textColor = next.textStrong;
+      input.focusedTextColor = next.textStrong;
+    },
+    destroy(): void {
+      input.off(InputRenderableEvents.ENTER, submit);
+    },
+  };
 }
 
 export function createInputPanel(
@@ -77,6 +153,7 @@ export function createInputPanel(
   });
   suggestions.add(suggestionList);
   let matches: readonly SlashCommand[] = [];
+  let context: CommandContext = {};
 
   const updateDecorations = (value: string): void => {
     input.clearAllHighlights();
@@ -85,7 +162,7 @@ export function createInputPanel(
       input.addHighlightByCharRange({...range, styleId: commandStyleId});
     }
 
-    matches = suggestSlashCommands(value);
+    matches = suggestSlashCommands(value, context);
     const visible = matches.length > 0;
     suggestions.visible = visible;
     suggestions.height = matches.length + 2;
@@ -109,6 +186,11 @@ export function createInputPanel(
   return {
     box,
     suggestions,
+    setCommandContext(next: CommandContext): void {
+      if (next.chatDocked === context.chatDocked) return;
+      context = next;
+      updateDecorations(input.value);
+    },
     completeSuggestion(): boolean {
       const suggestion = matches[0];
       if (suggestion === undefined || suggestion.name === input.value) return false;

--- a/clients/tui/src/ui/input.ts
+++ b/clients/tui/src/ui/input.ts
@@ -50,6 +50,14 @@ export function createChatInputPanel(
   renderer: CliRenderer,
   onSubmit: (value: string) => void,
   theme: Theme,
+  /**
+   * Called when the box is clicked. Clicking an input hands it the cursor at
+   * the renderer level, and that is invisible on its own: without telling the
+   * model, the pane focus stays where it was, the border and the hint keep
+   * pointing at the other box, and the operator types into a box that looks
+   * inert.
+   */
+  onFocusRequest: () => void = () => {},
 ): ChatInputPanel {
   const box = new BoxRenderable(renderer, {
     // The modal chat owns 'chat-input-box'; this is the docked one.
@@ -62,6 +70,7 @@ export function createChatInputPanel(
     title: ' Chat ',
     paddingLeft: 1,
     paddingRight: 1,
+    onMouseUp: onFocusRequest,
   });
   const input = new InputRenderable(renderer, {
     id: 'chat-dock-input',
@@ -69,6 +78,7 @@ export function createChatInputPanel(
     placeholder: 'Type a question',
     textColor: theme.textStrong,
     focusedTextColor: theme.textStrong,
+    onMouseUp: onFocusRequest,
   });
   const submit = (value: string): void => {
     input.value = '';
@@ -104,6 +114,8 @@ export function createInputPanel(
   renderer: CliRenderer,
   onSubmit: (value: string) => void,
   theme: Theme,
+  /** Called when the box is clicked, so the pane focus follows the cursor. */
+  onFocusRequest: () => void = () => {},
 ): InputPanel {
   const box = new BoxRenderable(renderer, {
     id: 'input-box',
@@ -115,6 +127,7 @@ export function createInputPanel(
     title: ' Ask or command ',
     paddingLeft: 1,
     paddingRight: 1,
+    onMouseUp: onFocusRequest,
   });
   let syntaxStyle = commandSyntaxStyle(theme);
   let commandStyleId = syntaxStyle.getStyleId('slash-command');
@@ -125,6 +138,7 @@ export function createInputPanel(
     textColor: theme.textStrong,
     focusedTextColor: theme.textStrong,
     syntaxStyle,
+    onMouseUp: onFocusRequest,
   });
   const suggestions = new BoxRenderable(renderer, {
     id: 'input-suggestions',

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -1,6 +1,6 @@
 import type {CliRenderer, KeyEvent, ScrollBoxRenderable} from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
-import {experimentLogVisible} from '../session-model.js';
+import {chatPaneFocused, chatPaneVisible, experimentLogVisible} from '../session-model.js';
 
 export interface KeybindingActions {
   completeInput(): boolean;
@@ -13,6 +13,7 @@ export interface KeybindingActions {
   selectPreviousRound(): void;
   toggleTodos(): void;
   scrollRightPane(delta: number): void;
+  scrollChatPane(delta: number): void;
 }
 
 export function bindKeybindings(
@@ -27,11 +28,15 @@ export function bindKeybindings(
       renderer.destroy();
       return;
     }
-    // Pane switching works from anywhere the split is open, including with the
-    // chat focused, so the operator never has to close the chat to look at the
-    // visualization beside it.
-    if (key.ctrl && key.name === 'w' && controller.state.layout.right !== null) {
-      controller.togglePaneFocus();
+    // Pane switching works from anywhere a second column is on screen, which
+    // on the landing view includes the docked chat, so the operator never has
+    // to leave the table to scroll back through an answer.
+    if (
+      key.ctrl &&
+      key.name === 'w' &&
+      (controller.state.layout.right !== null || chatPaneVisible(controller.state))
+    ) {
+      controller.cyclePaneFocus();
       key.preventDefault();
       return;
     }
@@ -44,6 +49,19 @@ export function bindKeybindings(
     ) {
       if (key.name === 'escape') controller.closePane();
       else actions.scrollRightPane(key.name === 'pageup' ? -1 : 1);
+      key.preventDefault();
+      return;
+    }
+    // The docked chat takes the scroll keys while it holds focus, so Page Up
+    // reads the conversation back instead of moving the table's selection.
+    // Escape hands the keys back to the table rather than closing anything:
+    // the pane is part of the view, not a dialog over it.
+    if (
+      chatPaneFocused(controller.state) &&
+      (key.name === 'pageup' || key.name === 'pagedown' || key.name === 'escape')
+    ) {
+      if (key.name === 'escape') controller.focusPane('left');
+      else actions.scrollChatPane(key.name === 'pageup' ? -1 : 1);
       key.preventDefault();
       return;
     }

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -7,6 +7,8 @@ export interface KeybindingActions {
   inputIsEmpty(): boolean;
   closeChat(): void;
   toggleLatestPrompt(): void;
+  /** Brings the entry the cursor moved to into view. */
+  revealSelectedEntry(): void;
   selectNextAgent(): void;
   selectPreviousAgent(): void;
   selectNextRound(): void;
@@ -47,7 +49,10 @@ export function bindKeybindings(
       controller.state.layout.right !== null &&
       (key.name === 'pageup' || key.name === 'pagedown' || key.name === 'escape')
     ) {
-      if (key.name === 'escape') controller.closePane();
+      // Escape leaves the view the operator was in, not one layer of it: a
+      // visualization and a chat opened over a round both go at once, rather
+      // than the chat being left behind as a pop-up over the round.
+      if (key.name === 'escape') controller.closeOverlays();
       else actions.scrollRightPane(key.name === 'pageup' ? -1 : 1);
       key.preventDefault();
       return;
@@ -83,7 +88,10 @@ export function bindKeybindings(
     }
     if (controller.state.chatOpen) {
       if (key.name === 'escape') {
-        actions.closeChat();
+        // The chat may be sitting over a round that also has a pane open.
+        // One Escape puts the operator back on the round, not part way.
+        if (controller.state.layout.right !== null) controller.closeOverlays();
+        else actions.closeChat();
         key.preventDefault();
       }
       return;
@@ -103,6 +111,8 @@ export function bindKeybindings(
     // the log rather than the log swallowing the keystroke.
     if (experimentLogVisible(controller.state)) {
       // Escape has nowhere to go from the root view: the log is the root.
+      // Arrows move the table's selection from the moment the log is on screen:
+      // the table is the view, so it should not need to be clicked into first.
       if (key.name === 'up') controller.moveExperimentSelection(-1);
       else if (key.name === 'down') controller.moveExperimentSelection(1);
       else if (key.name === 'pageup') controller.moveExperimentSelection(-10);
@@ -117,20 +127,63 @@ export function bindKeybindings(
       key.preventDefault();
       return;
     }
-    // Inside a hypothesis, Escape steps back out to the table rather than
-    // dropping the operator into unfiltered live output.
+    // Escape unwinds the round view one step at a time: the entry cursor, then
+    // the agent filter, then the hypothesis itself. Leaving outright would throw
+    // away a selection the operator may have spent a while arriving at.
     if (key.name === 'escape' && controller.state.hypothesisScope !== null) {
-      controller.leaveExperimentDrilldown();
+      if (controller.state.selectedEntryId !== null) controller.clearEntrySelection();
+      else if (controller.state.selectedAgentKind !== null) controller.clearAgentSelection();
+      else controller.leaveExperimentDrilldown();
       key.preventDefault();
       return;
     }
-    if (key.ctrl && key.name === 'p') {
+    // F2 and F3 alongside Ctrl+T and Ctrl+P: a terminal is free to keep a
+    // Control chord for itself, and on macOS several do, but function keys
+    // reach the application everywhere.
+    if ((key.ctrl && key.name === 'p') || key.name === 'f3') {
       actions.toggleLatestPrompt();
       key.preventDefault();
       return;
     }
-    if (key.ctrl && key.name === 't') {
+    if ((key.ctrl && key.name === 't') || key.name === 'f2') {
       actions.toggleTodos();
+      key.preventDefault();
+      return;
+    }
+    // While the todo box is open it owns the arrows, and it is drawn focused so
+    // the operator can see where the keys are going. Escape closes it and hands
+    // them straight back to the transcript. Every other key falls through: a
+    // surface that claims keys it does not act on reads as a frozen client.
+    if (controller.state.todosExpanded) {
+      if (key.name === 'up' || key.name === 'down') {
+        controller.selectNextTodo(key.name === 'down' ? 1 : -1);
+        key.preventDefault();
+        return;
+      }
+      if (key.name === 'escape') {
+        controller.toggleTodos();
+        key.preventDefault();
+        return;
+      }
+    }
+    // Left and right move between the round view's two panes. The agent graph
+    // is on the left and the transcript on the right, so the arrow points at
+    // the pane it moves to, and each pane then owns the up and down keys.
+    if (key.name === 'left' || key.name === 'right') {
+      controller.focusRound(key.name === 'left' ? 'agents' : 'transcript');
+      key.preventDefault();
+      return;
+    }
+    // Up and down belong to whichever pane holds the round view's keys: agents
+    // within a stage on the left, entries on the right.
+    if (key.name === 'up' || key.name === 'down') {
+      if (controller.state.roundFocus === 'agents') {
+        if (key.name === 'down') controller.selectNextAgent();
+        else controller.selectPreviousAgent();
+      } else {
+        controller.selectNextEntry(key.name === 'down' ? 1 : -1);
+        actions.revealSelectedEntry();
+      }
       key.preventDefault();
       return;
     }

--- a/clients/tui/src/ui/round-strip.test.ts
+++ b/clients/tui/src/ui/round-strip.test.ts
@@ -1,0 +1,81 @@
+import {describe, expect, test} from 'bun:test';
+import type {RoundSummary} from '../run-map.js';
+import {stripWindow} from './round-strip.js';
+
+function rounds(count: number): RoundSummary[] {
+  return Array.from({length: count}, (_, index) => ({
+    number: index + 1,
+    status: 'completed' as const,
+  }));
+}
+
+/** ` r7 ` and friends: the width the strip actually asks for. */
+const width = (round: RoundSummary): number => `  r${round.number}  `.length;
+
+describe('stripWindow', () => {
+  test('shows every round when they all fit', () => {
+    const view = stripWindow(rounds(5), 1, 200, width);
+    expect(view.rounds).toHaveLength(5);
+    expect(view.hiddenBefore).toBe(0);
+    expect(view.hiddenAfter).toBe(0);
+  });
+
+  test('keeps the selected round visible however far into the run it is', () => {
+    for (const selected of [1, 2, 37, 99, 100]) {
+      const view = stripWindow(rounds(100), selected, 60, width);
+      expect(view.rounds.some(round => round.number === selected)).toBe(true);
+    }
+  });
+
+  test('reports what it had to hide on each side', () => {
+    const view = stripWindow(rounds(100), 50, 60, width);
+    expect(view.hiddenBefore).toBeGreaterThan(0);
+    expect(view.hiddenAfter).toBeGreaterThan(0);
+    expect(view.hiddenBefore + view.rounds.length + view.hiddenAfter).toBe(100);
+  });
+
+  test('never exceeds the width it was given', () => {
+    for (const selected of [1, 8, 44, 100]) {
+      const view = stripWindow(rounds(100), selected, 60, width);
+      const used = view.rounds.reduce((total, round) => total + width(round), 0);
+      expect(used).toBeLessThanOrEqual(60);
+    }
+  });
+
+  test('fills the strip when the selection sits at either end', () => {
+    const atStart = stripWindow(rounds(100), 1, 60, width);
+    const atEnd = stripWindow(rounds(100), 100, 60, width);
+    expect(atStart.rounds.length).toBeGreaterThan(3);
+    expect(atEnd.rounds.length).toBeGreaterThan(3);
+    expect(atStart.hiddenBefore).toBe(0);
+    expect(atEnd.hiddenAfter).toBe(0);
+  });
+
+  test('slides by one as the selection steps, so the run scrolls rather than pages', () => {
+    const all = rounds(100);
+    let previous = stripWindow(all, 20, 60, width);
+    for (let selected = 21; selected < 30; selected += 1) {
+      const next = stripWindow(all, selected, 60, width);
+      expect(next.rounds.some(round => round.number === selected)).toBe(true);
+      // The window moves at most one round per step: no jumping.
+      expect(Math.abs(next.hiddenBefore - previous.hiddenBefore)).toBeLessThanOrEqual(1);
+      previous = next;
+    }
+  });
+
+  test('keeps round order stable', () => {
+    const view = stripWindow(rounds(100), 50, 60, width);
+    const numbers = view.rounds.map(round => round.number);
+    expect(numbers).toEqual([...numbers].sort((a, b) => a - b));
+  });
+
+  test('handles an empty run and a one-round run', () => {
+    expect(stripWindow([], null, 60, width).rounds).toEqual([]);
+    expect(stripWindow(rounds(1), 1, 60, width).rounds).toHaveLength(1);
+  });
+
+  test('still shows the selection in a very narrow strip', () => {
+    const view = stripWindow(rounds(100), 60, 12, width);
+    expect(view.rounds.some(round => round.number === 60)).toBe(true);
+  });
+});

--- a/clients/tui/src/ui/round-strip.ts
+++ b/clients/tui/src/ui/round-strip.ts
@@ -3,20 +3,84 @@ import {hasActiveAgentTiming} from '../round-timing.js';
 import {type RoundSummary, roundAgentElapsedMs} from '../run-map.js';
 import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
-import {scopedRounds, visibleRoundNumber} from '../session-model.js';
+import {stripRounds, visibleRoundNumber} from '../session-model.js';
 import {elapsedLabel} from './previews.js';
 import type {Theme} from './theme.js';
+
+/** Border on both sides plus a column of padding on both sides. */
+const STRIP_CHROME = 4;
+/** Width of a `‹ 12 more` marker, so the window leaves room for one per side. */
+const MARKER_WIDTH = 10;
+
+interface StripWindow {
+  rounds: RoundSummary[];
+  hiddenBefore: number;
+  hiddenAfter: number;
+}
+
+/**
+ * The rounds that fit, always including the selected one.
+ *
+ * A run is normally longer than the strip is wide, so the strip is a window
+ * onto it rather than the whole list. The window follows the selection instead
+ * of pinning to either end: moving off the visible set slides it by one, which
+ * is what makes holding `[` feel like the run scrolling past rather than
+ * jumping a page at a time.
+ */
+export function stripWindow(
+  rounds: RoundSummary[],
+  selected: number | null,
+  availableWidth: number,
+  labelWidth: (round: RoundSummary) => number,
+): StripWindow {
+  if (rounds.length === 0) return {rounds: [], hiddenBefore: 0, hiddenAfter: 0};
+  const index = Math.max(
+    0,
+    rounds.findIndex(round => round.number === selected),
+  );
+  let first = index;
+  let last = index;
+  let used = labelWidth(rounds[index] as RoundSummary);
+  // Grow outward from the selection, preferring the side that still has rounds,
+  // so a selection near either end still fills the strip.
+  for (;;) {
+    const before = first > 0 ? labelWidth(rounds[first - 1] as RoundSummary) : null;
+    const after = last < rounds.length - 1 ? labelWidth(rounds[last + 1] as RoundSummary) : null;
+    if (before === null && after === null) break;
+    const reserve =
+      (first - 1 > 0 || (before === null && first > 0) ? MARKER_WIDTH : 0) +
+      (last + 1 < rounds.length - 1 ? MARKER_WIDTH : 0);
+    // Take from whichever side is closer to the selection, so the window stays
+    // centred on it as it moves.
+    const takeAfter =
+      after !== null && (before === null || last - index <= index - first) ? after : null;
+    const width = takeAfter ?? before;
+    if (width === null) break;
+    if (used + width + reserve > availableWidth) break;
+    used += width;
+    if (takeAfter !== null) last += 1;
+    else first -= 1;
+  }
+  return {
+    rounds: rounds.slice(first, last + 1),
+    hiddenBefore: first,
+    hiddenAfter: rounds.length - 1 - last,
+  };
+}
 
 export class RoundStripView {
   readonly output: BoxRenderable;
   #theme: Theme;
   #renderedState: SessionState | null = null;
+  #renderedWidth = 0;
   #elapsedTimer: ReturnType<typeof setInterval> | null = null;
   #runningRound: {
     round: RoundSummary;
     selected: number | null;
     text: TextRenderable;
   } | null = null;
+  /** The chips currently on screen, by round number, for in-place repaints. */
+  readonly #chips = new Map<number, TextRenderable>();
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -44,12 +108,19 @@ export class RoundStripView {
   }
 
   render(state: SessionState): void {
-    if (state === this.#renderedState) return;
+    const width = this.renderer.terminalWidth;
+    if (state === this.#renderedState && width === this.#renderedWidth) return;
     this.#renderedState = state;
+    this.#renderedWidth = width;
+    // Stepping through rounds changes which chip is marked far more often than
+    // it changes which chips are on screen. Repainting the ones already there
+    // keeps navigation smooth; the strip is only rebuilt when the window itself
+    // moves.
+    if (this.#repaint(state)) return;
     this.#clear();
-    // Inside a hypothesis the strip covers that hypothesis's rounds only, so
-    // round navigation stays within the trajectory the operator opened.
-    const rounds = scopedRounds(state);
+    // Every round of the run, including ones it has not reached: the strip
+    // shows the shape of the whole run, not only what has happened so far.
+    const rounds = stripRounds(state);
     if (rounds.length === 0) {
       this.output.add(
         new TextRenderable(this.renderer, {
@@ -67,8 +138,22 @@ export class RoundStripView {
     });
     const selected = visibleRoundNumber(state);
     const runningRound = latestActiveRoundNumber(rounds);
-    for (const round of rounds.slice(-8)) {
+    const view = stripWindow(
+      rounds,
+      selected,
+      width - STRIP_CHROME,
+      round => this.#roundLabel(round, selected).length,
+    );
+    // The markers are the strip saying the run continues past its edge, and
+    // they move the selection so the hidden rounds are reachable by mouse too.
+    if (view.hiddenBefore > 0) {
+      row.add(this.#marker(`‹ ${view.hiddenBefore} `, -1));
+    }
+    for (const round of view.rounds) {
       row.add(this.#renderRound(round, {selected, runningRound}));
+    }
+    if (view.hiddenAfter > 0) {
+      row.add(this.#marker(` ${view.hiddenAfter} ›`, 1));
     }
     this.output.add(row);
     this.#syncElapsedTimer();
@@ -78,8 +163,56 @@ export class RoundStripView {
     this.#stopElapsedTimer();
   }
 
+  /**
+   * Repaints the chips in place when the window is unchanged. Returns false
+   * when the strip has to be rebuilt, which is when the window slid, the run
+   * grew, or nothing has been drawn yet.
+   */
+  #repaint(state: SessionState): boolean {
+    if (this.#chips.size === 0) return false;
+    const rounds = stripRounds(state);
+    const selected = visibleRoundNumber(state);
+    const runningRound = latestActiveRoundNumber(rounds);
+    const view = stripWindow(
+      rounds,
+      selected,
+      this.renderer.terminalWidth - STRIP_CHROME,
+      round => this.#roundLabel(round, selected).length,
+    );
+    if (view.rounds.length !== this.#chips.size) return false;
+    if (!view.rounds.every(round => this.#chips.has(round.number))) return false;
+    this.#runningRound = null;
+    for (const round of view.rounds) {
+      const chip = this.#chips.get(round.number);
+      if (chip === undefined) return false;
+      const isSelected = round.number === selected;
+      const isRunning = round.number === runningRound;
+      const colors = this.#roundColors(round, isSelected, isRunning);
+      chip.content = this.#roundLabel(round, selected);
+      chip.fg = colors.fg;
+      chip.bg = colors.bg ?? this.#theme.canvas;
+      if (isRunning && hasActiveAgentTiming(round)) {
+        this.#runningRound = {round, selected, text: chip};
+      }
+    }
+    this.#syncElapsedTimer();
+    return true;
+  }
+
+  #marker(content: string, direction: number): TextRenderable {
+    return new TextRenderable(this.renderer, {
+      content,
+      fg: this.#theme.textSubtle,
+      onMouseUp: () => {
+        if (direction < 0) this.controller.selectPreviousRound();
+        else this.controller.selectNextRound();
+      },
+    });
+  }
+
   #clear(): void {
     this.#runningRound = null;
+    this.#chips.clear();
     this.#stopElapsedTimer();
     for (const child of [...this.output.getChildren()]) {
       this.output.remove(child);
@@ -96,12 +229,32 @@ export class RoundStripView {
     const isRunning = round.number === runningRound;
     const text = new TextRenderable(this.renderer, {
       content: this.#roundLabel(round, selected),
-      fg: isRunning ? this.#theme.success : this.#theme.textPrimary,
-      ...(isSelected ? {bg: this.#theme.selectedSurface} : {}),
+      ...this.#roundColors(round, isSelected, isRunning),
       onMouseUp: () => this.controller.selectRound(round.number),
     });
     if (isRunning && hasActiveAgentTiming(round)) this.#runningRound = {round, selected, text};
+    this.#chips.set(round.number, text);
     return text;
+  }
+
+  /**
+   * The round being viewed is marked twice over: the brackets say which one it
+   * is, and the theme's accent on its selected surface makes it findable at a
+   * glance in a strip of twenty. Colour alone would fail the operator whose
+   * terminal drops it, brackets alone are easy to lose in a long strip.
+   */
+  #roundColors(
+    round: RoundSummary,
+    isSelected: boolean,
+    isRunning: boolean,
+  ): {fg: string; bg?: string; attributes?: number} {
+    if (isSelected) {
+      return {fg: this.#theme.accent, bg: this.#theme.selectedSurface};
+    }
+    if (isRunning) return {fg: this.#theme.success};
+    if (round.status === 'planned') return {fg: this.#theme.textSubtle};
+    if (round.status === 'failed') return {fg: this.#theme.error};
+    return {fg: this.#theme.textPrimary};
   }
 
   #roundLabel(round: RoundSummary, selected: number | null): string {

--- a/clients/tui/src/ui/styles.ts
+++ b/clients/tui/src/ui/styles.ts
@@ -23,10 +23,11 @@ export function conversationRole(entry: ConversationEntry): ConversationRole {
   if (entry.kind === 'assistant') return 'assistant';
   if (entry.kind === 'user') return 'user';
   if (entry.kind === 'prompt') return 'prompt';
-  if (entry.kind === 'analysis') return 'analysis';
-  if (entry.kind === 'tool' || entry.kind === 'diagnostic' || entry.kind === 'subprocess') {
-    return 'tool';
-  }
+  // An agent narrating its own work is analysis whichever channel carried it:
+  // the diagnostic channel is where most backends put that narration, and
+  // slate-on-slate buried it. Tool turns keep the neutral surface.
+  if (entry.kind === 'analysis' || entry.kind === 'diagnostic') return 'analysis';
+  if (entry.kind === 'tool' || entry.kind === 'subprocess') return 'tool';
   return 'neutral';
 }
 

--- a/clients/tui/src/ui/theme.test.ts
+++ b/clients/tui/src/ui/theme.test.ts
@@ -52,7 +52,9 @@ describe('theme selection', () => {
     expect(dark.success).toBe('#22c55e');
     expect(dark.info).toBe('#38bdf8');
     expect(dark.textPrimary).toBe('#e2e8f0');
-    expect(dark.conversation.analysis.label).toBe('#a78bfa');
+    // Analysis keeps its violet; the exact shade is derived from the accent and
+    // the card fill rather than hand-set per theme.
+    expect(dark.conversation.analysis.label).toBe('#b193f8');
   });
 
   it('keeps the dark baseline pinned to the pre-theme appearance', () => {
@@ -62,14 +64,30 @@ describe('theme selection', () => {
     expect(dark.border).toBe('#475569');
     expect(dark.conversation.assistant).toEqual({
       border: '#0891b2',
-      background: '#0f1b24',
-      label: '#67e8f9',
+      background: '#0e283d',
+      label: '#5cb6cc',
       content: '#e2e8f0',
     });
-    expect(dark.conversation.failure.label).toBe('#f87171');
-    expect(dark.toolCall).toEqual({foreground: '#dbeafe', background: '#1e3a8a'});
+    expect(dark.conversation.failure.label).toBe('#f28484');
+    // A tool call is told apart by its text colour, not by a filled band: a
+    // block of background behind text reads as a selection.
+    expect(dark.toolCall.background).toBe(dark.conversation.tool.background);
+    expect(dark.toolResult.background).toBe(dark.conversation.tool.background);
+    expect(dark.toolCall.foreground).not.toBe(dark.toolResult.foreground);
     expect(dark.markdown.code).toBe('#a5f3fc');
     expect(dark.markdown.codeBackground).toBe('#1e293b');
+  });
+});
+
+describe('selection', () => {
+  it.each(
+    listThemes().map(theme => [theme.name, theme] as const),
+  )('%s paints a selection the operator can see', (_name, theme: Theme) => {
+    // A selected row, chip, or node is drawn on this surface. Equal to the
+    // canvas it marks nothing, which is how the dark theme lost its round
+    // marker to everything but the brackets.
+    expect(theme.selectedSurface).not.toBe(theme.canvas);
+    expect(contrastRatio(theme.textStrong, theme.selectedSurface)).toBeGreaterThanOrEqual(4.5);
   });
 });
 

--- a/clients/tui/src/ui/theme.ts
+++ b/clients/tui/src/ui/theme.ts
@@ -197,31 +197,25 @@ interface ThemeSpec {
   };
 }
 
-const TOOL_BAND_TINT: Record<Appearance, number> = {dark: 0.55, light: 0.22};
-
 const SUBTLE_TEXT_MIN_CONTRAST = 3;
 
-function readableBandBackground(
-  base: string,
-  accent: string,
-  tint: number,
-  foreground: string,
-  minRatio: number,
-): string {
-  for (let step = 0; step <= CONTRAST_STEPS; step += 1) {
-    const background = mix(base, accent, (tint * (CONTRAST_STEPS - step)) / CONTRAST_STEPS);
-    if (contrastRatio(foreground, background) >= minRatio) return background;
-  }
-  return base;
-}
+/**
+ * How far a card's label is pulled toward the theme's strongest text before the
+ * contrast floor is applied. The raw role accent reads as a border but is too
+ * close to the card fill to head it: lifting it keeps the role's hue while
+ * giving the label the presence a heading needs, in light themes as in dark.
+ */
+const LABEL_LIFT = 0.35;
 
 function buildConversationRole(spec: ThemeSpec, role: ConversationRole): ConversationRoleColors {
   const accent = spec.roleAccents[role];
+  // A low tint off the canvas: enough to group a card's lines together, not so
+  // much that a screen of cards becomes a field of blocks.
   const background = mix(spec.canvas, accent, spec.cardTint);
   const derived: ConversationRoleColors = {
     border: accent,
     background,
-    label: ensureContrast(accent, background, spec.minContrast),
+    label: ensureContrast(mix(accent, spec.textStrong, LABEL_LIFT), background, spec.minContrast),
     content: ensureContrast(spec.textPrimary, background, spec.minContrast),
   };
   return {...derived, ...spec.overrides?.conversation?.[role]};
@@ -231,18 +225,11 @@ function buildToolBands(
   spec: ThemeSpec,
   conversation: Record<ConversationRole, ConversationRoleColors>,
 ): {toolCall: BandColors; toolResult: BandColors} {
-  const callBackground = readableBandBackground(
-    spec.canvas,
-    spec.roleAccents.user,
-    TOOL_BAND_TINT[spec.appearance],
-    spec.textStrong,
-    spec.minContrast,
-  );
   const tool = conversation.tool;
   return {
     toolCall: {
-      background: callBackground,
-      foreground: ensureContrast(spec.textStrong, callBackground, spec.minContrast),
+      background: tool.background,
+      foreground: ensureContrast(spec.roleAccents.user, tool.background, spec.minContrast),
       ...spec.overrides?.toolCall,
     },
     toolResult: {
@@ -308,7 +295,9 @@ const DARK: ThemeSpec = {
   canvas: '#0f172a',
   surface: '#1e293b',
   elevatedSurface: '#020617',
-  selectedSurface: '#0f172a',
+  // Distinct from the canvas: a selection painted in the canvas colour is not a
+  // selection. Every other theme already differs here.
+  selectedSurface: '#1e293b',
   textPrimary: '#e2e8f0',
   textMuted: '#94a3b8',
   textSubtle: '#64748b',
@@ -327,25 +316,13 @@ const DARK: ThemeSpec = {
     assistant: '#0891b2',
     user: '#2563eb',
     prompt: '#3b82f6',
-    analysis: '#475569',
-    tool: '#3f3f46',
-    neutral: '#475569',
+    analysis: '#8b5cf6',
+    tool: '#64748b',
+    neutral: '#94a3b8',
     success: '#22c55e',
     failure: '#ef4444',
   },
   overrides: {
-    conversation: {
-      assistant: {background: '#0f1b24', label: '#67e8f9', content: '#e2e8f0'},
-      user: {background: '#102548', label: '#7dd3fc', content: '#e0f2fe'},
-      prompt: {background: '#102548', label: '#93c5fd', content: '#dbeafe'},
-      analysis: {background: '#171923', label: '#a78bfa', content: '#94a3b8'},
-      tool: {background: '#18181b', label: '#a1a1aa', content: '#a1a1aa'},
-      neutral: {background: '#111827', label: '#94a3b8', content: '#cbd5e1'},
-      success: {background: '#102018', label: '#4ade80', content: '#bbf7d0'},
-      failure: {background: '#1f1215', label: '#f87171', content: '#fecaca'},
-    },
-    toolCall: {foreground: '#dbeafe', background: '#1e3a8a'},
-    toolResult: {foreground: '#a1a1aa', background: '#18181b'},
     markdown: {
       default: '#e2e8f0',
       heading: '#67e8f9',

--- a/clients/tui/src/ui/todo-strip.ts
+++ b/clients/tui/src/ui/todo-strip.ts
@@ -16,6 +16,19 @@ const UNKNOWN_MARKER = '?';
 
 const MAX_EXPANDED_ITEMS = 10;
 
+/** Below this a todo line is all ellipsis, which is worse than crossing a pane edge. */
+const TODO_MIN_WIDTH = 48;
+
+/**
+ * The todo box follows the agent pane it belongs under, so it stops at the
+ * boundary with the transcript rather than running the width of the screen.
+ * A very narrow agent pane is the one exception: a strip too thin to read says
+ * nothing at all, so it keeps a readable floor.
+ */
+export function todoStripWidth(agentPaneWidth: number, terminalWidth: number): number {
+  return Math.min(terminalWidth, Math.max(agentPaneWidth, TODO_MIN_WIDTH));
+}
+
 export function todoMarker(status: string): string {
   return STATUS_MARKER[status] ?? UNKNOWN_MARKER;
 }
@@ -61,6 +74,8 @@ export class TodoStripView {
   #theme: Theme;
   #renderedTodos: TodoItem[] | null = null;
   #renderedExpanded = false;
+  #renderedSelection: number | null = null;
+  #renderedWidth: number | null = null;
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -71,13 +86,11 @@ export class TodoStripView {
     this.output = new BoxRenderable(renderer, {
       id: 'todo-strip',
       width: '100%',
+      flexShrink: 0,
       height: 1,
       flexDirection: 'column',
       paddingLeft: 1,
       paddingRight: 1,
-      borderStyle: 'rounded',
-      borderColor: theme.borderStrong,
-      border: false,
       visible: false,
       onMouseUp: () => controller.toggleTodos(),
     });
@@ -85,11 +98,10 @@ export class TodoStripView {
 
   applyTheme(theme: Theme): void {
     this.#theme = theme;
-    this.output.borderColor = theme.borderStrong;
     this.#renderedTodos = null;
   }
 
-  render(state: SessionState): void {
+  render(state: SessionState, width: number | null = null): void {
     const todos = visibleTodos(state);
     if (todos.length === 0) {
       this.output.visible = false;
@@ -97,16 +109,27 @@ export class TodoStripView {
       return;
     }
     this.output.visible = true;
-    if (todos === this.#renderedTodos && state.todosExpanded === this.#renderedExpanded) return;
+    // The todos belong to the agent whose transcript is on the left, so the box
+    // stops where that pane stops rather than running under the right pane.
+    this.output.width = width ?? '100%';
+    if (
+      todos === this.#renderedTodos &&
+      state.todosExpanded === this.#renderedExpanded &&
+      state.selectedTodoIndex === this.#renderedSelection &&
+      width === this.#renderedWidth
+    ) {
+      return;
+    }
     this.#renderedTodos = todos;
     this.#renderedExpanded = state.todosExpanded;
+    this.#renderedSelection = state.selectedTodoIndex;
+    this.#renderedWidth = width;
     this.#clear();
-    if (state.todosExpanded) this.#renderExpanded(todos);
+    if (state.todosExpanded) this.#renderExpanded(todos, state.selectedTodoIndex);
     else this.#renderCollapsed(todos);
   }
 
   #renderCollapsed(todos: TodoItem[]): void {
-    this.output.border = false;
     this.output.height = 1;
     this.output.add(
       new TextRenderable(this.renderer, {
@@ -118,24 +141,43 @@ export class TodoStripView {
     );
   }
 
-  #renderExpanded(todos: TodoItem[]): void {
+  #renderExpanded(todos: TodoItem[], selected: number | null): void {
     const shown = todos.slice(0, MAX_EXPANDED_ITEMS);
     const hidden = todos.length - shown.length;
-    this.output.border = true;
-    this.output.title = ` ${todoTitle(todos)} `;
-    this.output.height = shown.length + (hidden > 0 ? 1 : 0) + 2;
-    for (const todo of shown) {
-      this.output.add(
+    const height = shown.length + (hidden > 0 ? 1 : 0) + 2;
+    this.output.height = height;
+    // The border belongs to a box that only exists while the list is open.
+    // Toggling a border on a live box leaves a frame the layout has no rows
+    // for, and the list then draws over it.
+    const list = new BoxRenderable(this.renderer, {
+      id: 'todo-list',
+      width: '100%',
+      height,
+      flexDirection: 'column',
+      paddingLeft: 1,
+      paddingRight: 1,
+      border: true,
+      borderStyle: 'rounded',
+      // The open list owns the arrow keys, so it carries the focus border: the
+      // operator can see where the keys are going without being told.
+      borderColor: this.#theme.borderFocus,
+      title: ` ${todoTitle(todos)} `,
+    });
+    this.output.add(list);
+    for (const [index, todo] of shown.entries()) {
+      const isSelected = index === selected;
+      list.add(
         new TextRenderable(this.renderer, {
-          content: todoItemLine(todo, this.#contentWidth()),
-          fg: todoColor(todo.status, this.#theme),
+          content: `${isSelected ? '▸' : ' '}${todoItemLine(todo, this.#contentWidth() - 1)}`,
+          fg: isSelected ? this.#theme.textStrong : todoColor(todo.status, this.#theme),
+          ...(isSelected ? {bg: this.#theme.selectedSurface} : {}),
           height: 1,
           width: '100%',
         }),
       );
     }
     if (hidden > 0) {
-      this.output.add(
+      list.add(
         new TextRenderable(this.renderer, {
           content: `… +${hidden} more`,
           fg: this.#theme.textSubtle,
@@ -147,7 +189,7 @@ export class TodoStripView {
   }
 
   #contentWidth(): number {
-    return this.renderer.terminalWidth - 6;
+    return (this.#renderedWidth ?? this.renderer.terminalWidth) - 6;
   }
 
   #clear(): void {


### PR DESCRIPTION
## Problem

The round view is where an operator goes to understand what a round actually did, and every surface in it is currently read-only. `/open-round --N` and Enter open it, and from there almost nothing can be reached with a key or a click.

**The rounds strip loses the run.** `round-strip.ts` renders `rounds.slice(-8)`. Once a run passes eight rounds the earliest ones drop off the strip and cannot be reached from it: there is no scrolling, no paging, no arrows, and no sign that anything is missing. `[` and `]` still move the selection, so the operator can navigate to a round that the strip then refuses to show, selection marker and all. The strip also shows only rounds that have already happened, so a run announced as `--max-rounds 100` looks like a run of however many rounds have finished so far, growing one chip at a time.

**The agent strip is a list of blocks in a 30-column column.** It stacks the round's phases vertically with `↓` between them. That reads as a sequence because today it is one: one orchestrator, then one implementer, then one judge. The evolve loop already evaluates candidates concurrently through a `ThreadPoolExecutor`, and a vertical list has nowhere to put a second implementer. Nothing in the pane says how many agents a round has, how many are still running, or how many failed.

**The transcript can only be scrolled.** There is no way to step through a round's turns, no way to say "show me only what the judge did", and no indication of which agent is still working. Selecting an agent exists behind Tab, but nothing can be clicked, and a mouse-driven operator has no path to it. The round view is two navigable panes side by side with no way to move between them: an operator working in the agent strip has to reach for the mouse to read the trace of the agent they just selected.

**Clicking an input box does not move the focus that the client displays.** The docked chat has its own input beneath it, and neither it nor the command input carries a mouse handler. Clicking one hands it the cursor at the renderer level, so typing goes where the operator expects, but `layout.focus` never moves: the border stays on the other box and the hint keeps reading `Ctrl+W to type here`. Every visible signal reports the box as inert while it is in fact taking keystrokes.

**Several things are simply broken.** A long run silently discards its own history: `appendConversation` capped the transcript at 1000 entries, so on any run past roughly thirty rounds, opening an earlier round showed `Waiting for run events…` for a round that had certainly run. Opening a hypothesis with Enter left `selectedRound` null, which made `visibleRoundNumber` return null, which made `visiblePhases` match nothing: an empty agent strip in a view whose entire purpose is one round. In the dark theme `selectedSurface` was `#0f172a`, identical to `canvas`, so every selection highlight in the client painted the background colour onto the background. `Ctrl+T` and `Ctrl+P` are the only way to reach the todo list and the prompt, and neither reliably arrives on macOS, where the function keys are system controls and a terminal is free to keep a Control chord for itself.

## Solution

Closes #255, #256, #259, #284, #396.

Demonstration:



https://github.com/user-attachments/assets/80cb59fd-660a-4fdd-832f-8ebc6af83e87


**The strip covers the whole run and windows onto it.** `max_rounds` already travels in `run_started`; the client kept discarding it. It now lands in `SessionState`, and `stripRounds(state)` returns every round from 1 to the higher of the announced maximum and the highest round seen, filling gaps with a `planned` round. `stripWindow()` picks the rounds that fit around the selection and reports what it hid on each side, which the strip draws as `‹ 4` and `82 ›` markers that are themselves clickable. The window grows outward from the selected round and prefers whichever side is nearer it, so stepping moves the window by one round rather than paging: the run scrolls past rather than jumping. The selected round is in the window by construction.

```
╭─ Rounds ──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ ‹ 2   r3    r4    r5    r6    r7    r8  [ r9 ]  r10    r11    r12    r13    r14    r15    r16   4 ›                    │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
        rounds that ran        the round on screen: brackets and the theme's accent        planned: dim        4 hidden
```


**The agent strip becomes a layered graph.** `agent-graph.ts` is pure geometry: it turns a round's phases and an available width into node rectangles and edge cells, with no renderable and no theme in it. One column per agent kind in the order the round first mentions them, the agents of a kind stacked inside their column, shorter stages centred against the tallest. Edges leaving one node share a lane; edges from different nodes take separate lanes when their row ranges overlap, so two unrelated handovers never merge into a line that reads as a connection. Crossings resolve through a four-bit mask into `┼ ├ ┤ ┬ ┴` rather than one edge overwriting another.

```
╭─ Agents ────────────────────────────────────────────────────────────────────────╮
│ Round 1 flow                           7 agents · 2 active · 2 done · 3 waiting │
│                      ╭──────────────╮                                           │
│                   ┌─▶│✓ implementer │──┐                                        │
│                   │  │completed     │  │                                        │
│                   │  ╰──────────────╯  │  ╭──────────────╮                      │
│                   │                   ┌┼┬▶│○ judge       │──┐                   │
│                   │                   │││ │pending       │  │                   │
│ ╭──────────────╮  │  ╭──────────────╮ │││ ╰──────────────╯  │  ╭──────────────╮ │
│ │✓ orchestrator│──┼─▶│● implementer │─┤││                  ┌┴─▶│○ profiler    │ │
│ │completed     │  │  │active        │ │││                  │   │pending       │ │
│ ╰──────────────╯  │  ╰──────────────╯ │││ ╭──────────────╮ │   ╰──────────────╯ │
│                   │                   └┴┼▶│○ judge       │─┘                    │
│                   │                     │ │pending       │                      │
│                   │  ╭──────────────╮   │ ╰──────────────╯                      │
│                   └─▶│● implementer │───┘                                       │
│                      │active        │                                           │
│                      ╰──────────────╯                                           │
╰─────────────────────────────────────────────────────────────────────────────────╯
```

Currently, since it's one agent per run, the graph is a straight horizontal chain. The pane's width is derived from the terminal rather than fixed, and when the terminal cannot carry the graph beside a readable transcript the pane falls back to the vertical strip it has always been, so narrow terminals are unaffected. The round flow label and its elapsed time stay on the pane's first inner row, where `agent-map.ts` has always written them, now with a count of what the round is made of beside them.

**Every surface takes a key and a click.** Each one owns its own keys, so there is no mode to keep track of:

| Keys | Surface |
| --- | --- |
| `[` `]` | previous / next round, across the whole run |
| `←` `→` | move the round view's keys between the agent graph and the transcript |
| `↑` `↓` | act on whichever of those two panes holds the keys |
| `Tab` `Shift+Tab` | previous / next agent, and pulls the keys to the graph |
| `Ctrl+W` | move the pane keys between columns of the landing view |
| `Esc` | unwind: entry cursor, then agent filter, then the hypothesis |

The round view holds `roundFocus`, which is `agents` or `transcript`, and the pane that has it draws the focus border and marks its title. Arriving at the graph with no agent picked out puts the cursor on the agent whose turns are on screen, so `Tab` starts from where the operator is looking. Moving the keys to the transcript keeps the agent filter: moving focus is not the same as giving up a selection.

Round chips and agent nodes are clickable, and clicking the selected node clears the filter, which is the same toggle `Tab` and `Esc` give the keyboard. Selecting an agent filters the transcript to that agent, which is what `selectedAgentKind` already meant; it simply had no way in besides `Tab`.

**Toggles are reachable by name.** `/todos` and `/prompt` join the command list. `Ctrl+T`, `Ctrl+P`, `F2`, and `F3` stay bound for terminals that deliver them, but neither the function keys nor the Control chords can be relied on: macOS takes `F2` and `F3` for screen brightness before a terminal ever sees them. The prompt toggle routes through a handler the transcript registers, because only the view knows which prompt is the latest one.

**The todo list becomes a box under the agent pane.** It stops at the boundary with the transcript rather than running the width of the screen, because the todos belong to an agent and the agent pane is where that agent is. Open, it carries the focus border and takes the arrow keys until `Esc` closes it; each row is coloured by its status, and the row under the cursor is marked.

**The transcript says what is happening.** The newest entry of a round with a running phase carries a `⠋ Working` marker that animates on its own timer, so nothing else in the view redraws for it. It appears only in the round transcript: in the chat it sat on the answer, where a run's phases say nothing about the reply.

**A click on an input box moves the focus, not just the cursor.** Both inputs take an `onFocusRequest` callback, fired from `onMouseUp` on the box and on the input inside it, because the pointer lands on whichever renderable is innermost. Clicking the chat's input focuses the chat column; clicking the command input focuses the view. The border, the hint, and the cursor are then three views of one fact rather than three independent guesses at it.

**Cards are derived per theme instead of hand-set.** The dark theme carried a table of literal card colours, which is why its tool cards were near-black (`#18181b`) and its tool calls sat on a filled `#1e3a8a` band that reads as selected text. Cards now derive from the theme's own canvas and role accent, so every theme gets the same treatment, and a tool call is told apart by its text colour rather than by a block of background. An agent narrating its own work is `analysis` whichever channel carried it, which puts the violet back on the diagnostic output that most backends actually emit.

### Architecture

```mermaid
flowchart TD
    EV["run events"] --> MODEL["session-model · run-map"]
    MODEL --> MR["maxRounds from run_started"]
    MR --> SR["stripRounds(): 1..max, gaps planned"]
    SR --> WIN["stripWindow(): what fits around the selection"]
    WIN --> STRIP["round-strip: chips, ‹ n and n › markers"]
    MODEL --> PH["visiblePhases(round)"]
    PH --> GEO["agent-graph: pure layout<br/>columns · lanes · junction mask"]
    GEO --> MAP["agent-map: renderables, theme, clicks"]
    MODEL --> CONV["visibleConversation(round, agent)"]
    CONV --> TR["conversation: cards, cursor, working marker"]
    KEYS["keybindings"] --> CTRL["controller actions"]
    CLICK["onMouseUp on chips and nodes"] --> CTRL
    CTRL --> SET["#setState → normalizeFocus"]
    SET --> MODEL
```

`agent-graph.ts` owns geometry and knows nothing about renderables or colours; `agent-map.ts` owns renderables and colours and computes no geometry. That split is what makes the fan-out layouts testable without a renderer, and it is why the ten-agent cases below are unit tests rather than frame comparisons.

`normalizeFocus()` runs inside the controller's `#setState`, which is the one place every state change passes through. Focus can otherwise outlive the column it names, and every keystroke then goes to a surface that is not on screen.

### Correctness properties

- Every round of a run is reachable from the strip, at any round count and any terminal width, and the selected round is always in the window with its marker.
- The strip reports what it hid on each side, and those markers move the selection, so hidden rounds are reachable by mouse as well as by key.
- The window moves by at most one round per step, so navigation scrolls rather than pages.
- Round order in the strip is stable as rounds are added.
- A round the run has not reached renders as `planned`, opens to `Round N has not run yet.` in both panes, and is never mistaken for a round whose events failed to arrive.
- Opening a hypothesis lands on one of its rounds, so the strip, the graph, and the transcript always agree about which round is on screen.
- A round the operator can open keeps all of its turns: the transcript cap evicts the oldest round whole rather than the oldest few lines, so no round is ever a fragment.
- Every agent of a round gets its own node; no two nodes occupy the same cell at any fan-out width.
- Edge cells never fall inside the columns the nodes occupy, and crossing edges resolve to junction glyphs rather than overwriting one another.
- Edges from one node share a lane; edges from different nodes take different lanes whenever their row ranges overlap.
- With one agent per stage the graph is a chain, and where the terminal cannot carry the graph the pane falls back to the previous vertical strip.
- Selecting an agent filters the transcript to that agent; clearing the selection restores the round's full transcript; clicking the selected node clears it.
- The entry cursor names an entry rather than an index, so it still points at the same turn after new output arrives.
- The working marker appears only in the round transcript, only while a phase of the visible round is active.
- Focus always names a column that is on screen: a pane that closes while holding the keys hands them back rather than swallowing them.
- No surface claims a key it does not act on, so no combination of open todo box, open pane, and open chat can leave the client unresponsive.
- One `Esc` in a round view returns to the round, closing a visualization and the chat together rather than leaving either behind.
- The chat is one conversation across the log, a hypothesis, and a round, and it contains the exchange only: the chat agent's diagnostics, tool turns, and phase markers stay in the transcript.
- A click anywhere in the chat, its conversation or its input, gives it the keys, so the border, the hint, and the cursor always agree about which box is taking keystrokes. The same holds in the other direction for the command input.
- The round view's keys always belong to one of its two panes, that pane says so, and `←` and `→` move them in the direction the arrow points.
- Moving the keys between panes preserves the agent filter and the entry cursor; only the operator clearing them clears them.
- Every theme's selected surface differs from its canvas, and every card label and body clears its contrast floor on its own fill.
- No protocol change: no request, response field, or event was added, removed, or reinterpreted. `max_rounds` was already published and was being discarded.

### Testing

- `bun test --max-concurrency 1 src` in `clients/tui`: 319 pass, 1 fail, 320 tests across 17 files. The failure is `launcher.test.ts`, which compares a temporary directory path and receives `/private/var/...` where it expects `/var/...`. It is macOS symlink resolution, it fails identically without this change, and `launcher.ts` is untouched here.
- `pnpm --dir clients/tui check` (`tsc -p tsconfig.check.json`): clean.
- `pnpm --dir clients/tui build`: clean.
- `biome check clients/tui/src`: clean across 46 files.
- `uv run pytest tests/test_tui.py`: 32 passed. No Python file changed; this is the regression check for the protocol the client talks to.
- Both fixes for reported bugs were checked against their own tests with the fix removed: the chat-input click test and the pane-navigation test each fail without the change and pass with it, so neither is passing for an unrelated reason.
- Manually, against `--stub-agent --local --max-rounds 40`: the strip at 40 rounds, `[` back to round 1, opening a round that has not run, `Tab` and clicks through nodes, arrows through traces, `/todos`, `/perf` and `/chat` closed by one `Esc`, a question asked from both the log and a round, and clicking each input box in turn to watch the border follow.