### PR TITLE
Fix local OTel profiling for microservice tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ requires `bubblewrap`, and a kernel that lets it create an unprivileged user
 namespace; macOS includes the required `sandbox-exec` command. Where user
 namespaces are blocked and installing bubblewrap needs root you do not have,
 `VIBESYS_AGENT_SANDBOX=landlock` selects a weaker but root-free backend (see
-the [CLI reference](docs/cli-flags.md) for what it stops enforcing). Then
-install VibeSys:
+the [CLI reference](docs/cli-flags.md) for what it stops enforcing). Tasks whose
+candidate is a container topology, such as the `microservices` examples, also
+need Docker Engine reachable without `sudo` (add your user to the `docker`
+group) and a Go toolchain on `PATH`. Then install VibeSys:
 
 ```bash
 uv tool install vibesys

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -96,6 +96,16 @@ legacy root-level task inputs, or `_evaluator/`, and cannot read
 rejected when a root `.env*` file or `agent.toml` is recoverable from Git refs
 or reflogs.
 
+Local runs in the `microservices` domain import two extra host resources,
+because a microservice candidate is a container topology rather than a process
+the agent can start on its own: the Docker control socket, and the task scratch
+directory `/tmp/vibesys-<task>`. The scratch directory is shared with the host
+rather than masked by the sandbox's private `/tmp`, because Docker resolves a
+bind-mount source in the daemon's namespace, so a capture directory only works
+when the path names the same directory inside and outside confinement. Access
+to the Docker socket is equivalent to root on the host, so it is granted only
+for this domain; use `--docker` to confine the workload to a container instead.
+
 `VIBESYS_AGENT_SANDBOX` selects the Linux mechanism. `auto` (the default) and
 `bwrap` both require bubblewrap. `landlock` opts in to a weaker backend for
 hosts that block unprivileged user namespaces, which is the common reason
@@ -344,7 +354,7 @@ defaults, and is one-way.
 | `nsys` | NVIDIA Nsight Systems. Requires a CUDA/NVIDIA profiling environment. |
 | `torch` | PyTorch profiler. Used for in-process Python profiling and Modal GPU dispatch. |
 | `neuron` | AWS Neuron profiler for Trainium. |
-| `otel` | OpenTelemetry service, span, and datastore latency for microservice benchmarks. Opt-in only (`auto` never selects it) and needs an input bundle that provisions instrumentation and a collector. |
+| `otel` | OpenTelemetry service, span, datastore, and critical-path latency for microservice benchmarks. Needs an input bundle that provisions instrumentation and a collector; `auto` selects it when the bundle's benchmark command declares both `--telemetry-output` and `--trace-graph-json`, and resolves to `none` otherwise. |
 | `macos_cpu` | Instruments Time Profiler with a supported `/usr/bin/sample` fallback. |
 | `linux_cpu` | Linux `perf` profiler for native and mixed-language CPU workloads. |
 

--- a/docs/running-vibesys.md
+++ b/docs/running-vibesys.md
@@ -87,6 +87,31 @@ entrypoint = "vibesys-queue"
 args = ["benchmark", "--workspace", "${PROJECT_ROOT}", "--scenario", "spsc"]
 ```
 
+## Container Topologies
+
+A `microservices` candidate is not a process the agent starts on its own: it is
+a Docker Compose topology the agent must build, start, and trace. Such a task
+needs Docker Engine reachable without `sudo` and, when its benchmark shells out
+to Go helpers, a Go toolchain on `PATH`.
+
+A local run in this domain therefore imports two host resources the default
+confinement withholds: the Docker control socket, and the task scratch
+directory `/tmp/vibesys-<task>`. The scratch directory is shared with the host
+rather than masked by the sandbox's private `/tmp`, because Docker resolves a
+bind-mount source in the daemon's namespace, not the agent's, so a capture
+directory only resolves when the path names the same directory inside and
+outside confinement. Sharing it also makes the benchmark's telemetry artifacts
+durable and readable by the profiler in later rounds. Reaching the Docker
+socket is equivalent to root on the host, so this widening is scoped to this
+domain; use `--docker` to confine the workload to a container instead.
+
+A benchmark command that names both `--telemetry-output` and
+`--trace-graph-json` declares that the task provisions instrumentation and a
+collector. `--profiler auto` selects the OpenTelemetry profiler for such a task,
+which gives the loop service, span, datastore, critical-path, and trace
+breakdown evidence. Tasks without those flags stay on `none`, since OTel
+profiling has nothing to read.
+
 ## Legacy Input Bundles
 
 Root-level `OBJECTIVE.md` plus `vibesys.input.toml`, `[workspace]`,

--- a/src/vibesys/agents/host_resource_declarations.py
+++ b/src/vibesys/agents/host_resource_declarations.py
@@ -170,6 +170,44 @@ def _provider_state(ctx: HostResourceContext) -> Iterable[HostResource]:
     )
 
 
+#: Conventional host scratch root for a repository-native task. Container
+#: workloads bind-mount capture directories from here, and Docker resolves a
+#: bind source in the daemon's namespace rather than the agent's, so the path
+#: only works when it names the same directory inside and outside confinement.
+TASK_SCRATCH_ROOT = Path("/tmp")  # noqa: S108  # tracked: #288
+
+
+def task_scratch_dir(task_name: str) -> Path:
+    """Return the host scratch directory shared with a task's containers."""
+    return TASK_SCRATCH_ROOT / f"vibesys-{task_name}"
+
+
+def container_runtime_resources(env: Mapping[str, str] | None = None) -> tuple[HostResource, ...]:
+    """Declare the Docker control socket for tasks that orchestrate containers.
+
+    A microservice benchmark *is* a container topology: without the socket the
+    agent cannot build, start, or profile the system it is optimizing, and the
+    round-one routing check concludes the candidate does not run. The default
+    Linux confinement exposes no ``/var/run``, so the socket has to be imported
+    deliberately.
+
+    This is a real widening. Access to the daemon is equivalent to root on the
+    host, so it is declared only for the domain that needs it rather than for
+    every local agent. Run with ``--docker`` when the workload should be
+    confined to a container instead.
+    """
+    env = env if env is not None else os.environ
+    paths = [Path("/var/run/docker.sock")]  # tracked: #288
+    host = env.get("DOCKER_HOST", "")
+    if host.startswith("unix://"):
+        paths.append(Path(host.removeprefix("unix://")))
+    return _resources(
+        paths,
+        access=HostResourceAccess.READ_WRITE,
+        purpose="Docker control socket",
+    )
+
+
 def _operator_allowlist(ctx: HostResourceContext) -> Iterable[HostResource]:
     raw = ctx.env.get(ALLOW_ENV, "")
     paths = (Path(path).expanduser() for path in raw.split(os.pathsep) if path.strip())

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -892,6 +892,7 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
         state=RunState(project, git, run_id),
         run_id=run_id,
         round_transaction_coordinator=round_transaction_coordinator,
+        agent_host_resources=agent_host_resources,
     )
     construction_complete = True
     return result
@@ -1057,6 +1058,10 @@ def _assemble_candidate_context(  # noqa: PLR0913  # tracked: #288
         log_dir=log_dir,
         project_path_policy=project_path_policy,
         require_host_sandbox=not session.view.cli_sandboxed,
+        # A candidate runs the same domain as its parent, so it needs the same
+        # container access; recomputing is impossible here because a candidate
+        # context carries neither the profiler domain nor the task name.
+        host_resources=parent.agent_host_resources,
     )
 
     paths = RunPaths(
@@ -1103,6 +1108,7 @@ def _assemble_candidate_context(  # noqa: PLR0913  # tracked: #288
         project=parent.project,
         state=parent.state,
         run_id=parent.run_id,
+        agent_host_resources=parent.agent_host_resources,
     )
 
 
@@ -1161,8 +1167,13 @@ class _RunContext:
         state: RunState,
         run_id: str,
         round_transaction_coordinator: RoundTransactionCoordinator | None = None,
+        agent_host_resources: tuple[HostResource, ...] = (),
     ):
         self.backend = backend
+        # Retained so a candidate sub-context can hand its own agent runner the
+        # same declarations the parent computed, rather than recomputing them
+        # from state a candidate context does not carry.
+        self.agent_host_resources = agent_host_resources
         self.run_environment = run_environment
         self.supervisor = supervisor
         self.logger = logger

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -17,6 +17,10 @@ from pydantic import BaseModel
 from vibesys import backends
 from vibesys.agents import build_agent_runner
 from vibesys.agents.base import AgentRunner
+from vibesys.agents.host_resource_declarations import (
+    container_runtime_resources,
+    task_scratch_dir,
+)
 from vibesys.agents.progress import AgentProgress
 from vibesys.backends.base import ComputeBackendImpl, ContentionMonitor
 from vibesys.config import Config, as_config
@@ -83,6 +87,7 @@ from vs_project import (
     StateTransition,
     generate_run_id,
 )
+from vs_sandbox import HostResource, HostResourceAccess
 
 if TYPE_CHECKING:
     from vibesys.server.supervisor import RunSupervisor
@@ -791,6 +796,28 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
     teardown_stack.callback(device.close)
     device.start_monitor()
 
+    # A microservice candidate is a container topology, so the local agent
+    # needs the Docker socket and a scratch directory that names the same
+    # path inside and outside confinement for container bind mounts to
+    # resolve. Other domains keep the narrower default resource set.
+    agent_host_resources: tuple[HostResource, ...] = ()
+    if profiler_domain is DomainName.MICROSERVICES:
+        scratch_resources: tuple[HostResource, ...] = ()
+        if task_name is not None:
+            scratch = task_scratch_dir(task_name)
+            scratch.mkdir(parents=True, exist_ok=True)
+            scratch_resources = (
+                HostResource(
+                    scratch,
+                    HostResourceAccess.READ_WRITE,
+                    "task container scratch",
+                ),
+            )
+        # Container backends run the agent inside their own image and own
+        # resource exposure themselves, so the declarations are host-only.
+        if not session.view.cli_sandboxed:
+            agent_host_resources = (*container_runtime_resources(), *scratch_resources)
+
     # Build the backend-agnostic agent runner. Loops invoke this instead
     # of calling create_deep_agent / vibesys._agent_cli directly. The cli
     # backend is rejected if --docker is set; build_agent_runner raises
@@ -825,6 +852,7 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
         log_dir=log_dir,
         project_path_policy=project_path_policy,
         require_host_sandbox=not session.view.cli_sandboxed,
+        host_resources=agent_host_resources,
     )
 
     result = _RunContext(

--- a/src/vibesys/input_manifest.py
+++ b/src/vibesys/input_manifest.py
@@ -449,6 +449,20 @@ class InputBundle(BaseModel):
         return self.manifest.benchmark.result_protocol
 
     @property
+    def provisions_trace_telemetry(self) -> bool:
+        """Whether the benchmark command captures a distributed trace graph.
+
+        OTel profiling is only meaningful when the task itself provisions
+        instrumentation and a collector and emits the two artifacts the
+        profiler reads. A benchmark that names both ``--telemetry-output`` and
+        ``--trace-graph-json`` is making exactly that declaration, so this is
+        the capability signal ``auto`` profiler resolution keys off rather than
+        a separate hand-maintained flag that could drift from the command.
+        """
+        arguments = set(self.resolved_benchmark_command)
+        return {"--telemetry-output", "--trace-graph-json"} <= arguments
+
+    @property
     def modal_entrypoint(self) -> str | None:
         """Return the task's project-relative Modal deployment file, if declared."""
         environment = self.manifest.environment

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -1926,6 +1926,8 @@ def _validate_target_inputs(args: argparse.Namespace) -> None:
     except (FileNotFoundError, ProjectLayoutError, ValueError) as exc:
         _configuration_error(str(exc), code="invalid_input", stage="input_loading")
 
+    _apply_bundle_profiler_default(args)
+
     if args.resume is None and args.runs_dir is None:
         workspace = args.input_bundle.manifest.workspace
         if workspace is not None and workspace.sources:
@@ -1935,6 +1937,26 @@ def _validate_target_inputs(args: argparse.Namespace) -> None:
                 code="direct_project_materialization_unsupported",
                 stage="input_validation",
             )
+
+
+def _apply_bundle_profiler_default(args: argparse.Namespace) -> None:
+    """Upgrade ``--profiler auto`` to OTel when the task provisions tracing.
+
+    ``resolve_profiler_kind`` keeps bare microservice ``auto`` on ``none``
+    because OTel needs instrumentation and a collector that only the task can
+    provide. A benchmark command that emits a normalized telemetry report and a
+    trace graph has provided exactly that, so honoring it here is what makes an
+    instrumented task profile out of the box. An explicit ``--profiler`` always
+    wins: this only ever replaces ``auto``.
+    """
+    bundle = getattr(args, "input_bundle", None)
+    if bundle is None or getattr(args, "profiler", None) is not ProfilerKind.AUTO:
+        return
+    if bundle.domain is not DomainName.MICROSERVICES:
+        return
+    if not bundle.provisions_trace_telemetry:
+        return
+    args.profiler = ProfilerKind.OTEL
 
 
 def _resolve_implicit_input(args: argparse.Namespace, standalone: list[str]) -> Path:

--- a/src/vibesys/prompts/loops/agent/profilers/otel.j2
+++ b/src/vibesys/prompts/loops/agent/profilers/otel.j2
@@ -42,10 +42,10 @@ Benchmark command: {{ benchmark_command }}
    telemetry report and a versioned trace graph for the same measurement
    windows. The command's `--telemetry-output` and `--trace-graph-json`
    arguments name those two artifact paths: read them from the benchmark
-   command above and pass them to the tools directly. Artifacts a previous
-   round wrote outside this workspace (for example under `/tmp`) are not
-   visible to this turn, so produce them in this turn or use evidence retained
-   under the round artifact directory.
+   command above and pass them to the tools directly. Those paths stay
+   readable across rounds, so check whether the current round's benchmark
+   already wrote them before spending a turn on another capture. Re-run only
+   when they are missing, or when they predate the edit you are attributing.
 2. Call the `{{ profiler_mcp_name }}` MCP tools to read the evidence:
    `summary(path=...)` for ranked service, span, and datastore latency;
    `trace_breakdown(path=..., telemetry_path=...)` for the call graph with

--- a/tests/agents/test_host_resource_declarations.py
+++ b/tests/agents/test_host_resource_declarations.py
@@ -106,3 +106,46 @@ def test_provider_state_is_scoped_to_selected_agent(tmp_path, provider, expected
 
     assert expected in writable
     assert forbidden not in writable
+
+
+class TestContainerRuntimeResources:
+    """Microservice candidates are container topologies the agent must drive."""
+
+    def test_docker_socket_is_declared_writable(self):  # noqa: ANN201  # tracked: #288
+        declarations = host_resource_declarations.container_runtime_resources({})
+
+        writable = {
+            resource.path
+            for resource in declarations
+            if resource.access is HostResourceAccess.READ_WRITE
+        }
+        assert Path("/var/run/docker.sock") in writable
+
+    def test_custom_unix_docker_host_is_declared(self):  # noqa: ANN201  # tracked: #288
+        declarations = host_resource_declarations.container_runtime_resources(
+            {"DOCKER_HOST": "unix:///run/user/1000/docker.sock"}
+        )
+
+        paths = {resource.path for resource in declarations}
+        assert Path("/run/user/1000/docker.sock") in paths
+
+    def test_tcp_docker_host_declares_no_extra_path(self):  # noqa: ANN201  # tracked: #288
+        declarations = host_resource_declarations.container_runtime_resources(
+            {"DOCKER_HOST": "tcp://127.0.0.1:2375"}
+        )
+
+        assert {resource.path for resource in declarations} == {Path("/var/run/docker.sock")}
+
+
+class TestTaskScratchDir:
+    """Container bind sources resolve in the daemon's namespace, not the agent's.
+
+    The scratch path therefore has to name the same directory inside and
+    outside confinement, so it is a fixed host path rather than anything
+    derived from the sandbox's private ``/tmp``.
+    """
+
+    def test_scratch_dir_follows_the_task_naming_convention(self):  # noqa: ANN201  # tracked: #288
+        assert host_resource_declarations.task_scratch_dir("hotel-reservation") == Path(
+            "/tmp/vibesys-hotel-reservation"  # noqa: S108  # tracked: #288
+        )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1573,3 +1573,96 @@ def test_main_routes_to_the_selected_loop(
 
     runner.assert_called_once()
     assert runner.call_args.args[0].input_bundle.root == project.resolve()
+
+
+def _write_microservice_project(parent: Path, *, traced: bool, name: str = "hotel") -> Path:
+    """Write a microservice bundle that does or does not capture a trace graph."""
+    project = parent / name
+    (project / "src").mkdir(parents=True)
+    (project / "OBJECTIVE.md").write_text("Make the request path faster.\n")
+    telemetry = (
+        ', "--telemetry-output", "/tmp/otel/telemetry.json"'
+        ', "--trace-graph-json", "/tmp/otel/trace-graph.json"'
+        if traced
+        else ""
+    )
+    (project / "vibesys.input.toml").write_text(
+        f"""\
+version = 1
+
+[agent]
+domain = "microservices"
+
+[accuracy]
+command = ["python", "-c", "print('ok')"]
+
+[benchmark]
+command = ["servicebench", "trace", "--candidate-dir", "svc"{telemetry}]
+
+[benchmark.result]
+json_argument = "--output-json"
+metric = "primary_value"
+"""
+    )
+    return project
+
+
+def test_instrumented_microservice_task_profiles_with_otel_by_default(tmp_path: Path) -> None:
+    """A task that provisions tracing is why ``auto`` can safely mean OTel.
+
+    Without this the default run resolves to ``none`` for microservices, the
+    profiler role never executes, and no critical-path evidence is produced.
+    """
+    import vibesys.main as cli  # noqa: PLC0415
+
+    project = _write_microservice_project(tmp_path, traced=True)
+    args = cli._build_agent_parser().parse_args(["--input", str(project)])  # noqa: SLF001
+    args.input_bundle = load_input_bundle(project)
+
+    assert args.profiler is ProfilerKind.AUTO
+    cli._apply_bundle_profiler_default(args)  # noqa: SLF001
+
+    assert args.profiler is ProfilerKind.OTEL
+
+
+def test_uninstrumented_microservice_task_keeps_auto(tmp_path: Path) -> None:
+    """Without a collector there is nothing for the OTel profiler to read."""
+    import vibesys.main as cli  # noqa: PLC0415
+
+    project = _write_microservice_project(tmp_path, traced=False)
+    args = cli._build_agent_parser().parse_args(["--input", str(project)])  # noqa: SLF001
+    args.input_bundle = load_input_bundle(project)
+
+    cli._apply_bundle_profiler_default(args)  # noqa: SLF001
+
+    assert args.profiler is ProfilerKind.AUTO
+
+
+def test_explicit_profiler_flag_overrides_the_task_default(tmp_path: Path) -> None:
+    """The bundle only supplies a default; the operator stays in control."""
+    import vibesys.main as cli  # noqa: PLC0415
+
+    project = _write_microservice_project(tmp_path, traced=True)
+    args = cli._build_agent_parser().parse_args(  # noqa: SLF001
+        ["--input", str(project), "--profiler", "none"]
+    )
+    args.input_bundle = load_input_bundle(project)
+
+    cli._apply_bundle_profiler_default(args)  # noqa: SLF001
+
+    assert args.profiler is ProfilerKind.NONE
+
+
+def test_non_microservice_task_is_unaffected_by_trace_arguments(tmp_path: Path) -> None:
+    """OTel is microservices-only; a generic bundle must not be upgraded."""
+    import vibesys.main as cli  # noqa: PLC0415
+
+    project = _write_microservice_project(tmp_path, traced=True, name="generic-task")
+    manifest = project / "vibesys.input.toml"
+    manifest.write_text(manifest.read_text().replace('"microservices"', '"generic"'))
+    args = cli._build_agent_parser().parse_args(["--input", str(project)])  # noqa: SLF001
+    args.input_bundle = load_input_bundle(project)
+
+    cli._apply_bundle_profiler_default(args)  # noqa: SLF001
+
+    assert args.profiler is ProfilerKind.AUTO


### PR DESCRIPTION
## Problem

`--profiler otel` did not work on a local Linux run of a `microservices` task.
A user cloning the repo and running the `hotel-reservation` example got a loop
that planned from source reading alone, with no trace evidence, and no error
explaining why.

Three separate defects produced that outcome:

1. **`auto` resolved to `none`.** The microservices domain defaults `auto` to
   `NONE`, so a task whose benchmark already provisions a collector and
   instrumentation still ran unprofiled unless the user knew to pass
   `--profiler otel` explicitly. Nothing in the CLI surfaced that the task was
   capable of more.
2. **The Profiler could not reach the workload.** A microservices candidate is
   a Docker Compose topology, not a process the agent starts itself. Under the
   default bubblewrap confinement the agent has no Docker socket, and the
   sandbox's private `/tmp` masks the capture directory the benchmark writes
   to. Docker resolves bind-mount sources in the daemon's namespace rather than
   the agent's, so a capture path that does not name the same directory inside
   and outside confinement silently resolves to the wrong place.
3. **The Profiler could not run the benchmark.** The packaged benchmark command
   names `${PACKAGE_ROOT}`, and the Profiler is instructed to run it when no
   capture exists yet. That package lives outside the workspace and was not
   imported, so on a cold start the command died on a missing directory and the
   role returned no evidence at all.

The result was that the OTel path only appeared to work when a capture had been
left behind by some earlier out-of-band run.

## Solution

Fix each defect at its own boundary; no new profiler machinery.

- **Capability-based default.** `InputBundle.provisions_trace_telemetry` reports
  whether a resolved benchmark command names both `--telemetry-output` and
  `--trace-graph-json`. At the CLI boundary, `_apply_bundle_profiler_default`
  upgrades `ProfilerKind.AUTO` to `OTEL` for a microservices bundle with that
  capability. An explicit `--profiler` always wins; tasks without those flags
  stay on `none`, since OTel profiling would have nothing to read.
- **Scoped host-resource widening.** `container_runtime_resources()` and
  `task_scratch_dir()` declare the Docker control socket and
  `/tmp/vibesys-<task>`, bound back through the tmpfs mask at an identical path
  so bind-mount sources resolve identically in both namespaces. This is gated on
  the microservices domain and on host runs only: container backends run the
  agent inside their own image and own resource exposure themselves.
- **Evaluator package import.** The evaluator package root is imported
  read-only so a packaged benchmark command resolves. Read-only because the
  evaluator is trusted, integrity-checked input that no role may edit.
- **Prompt correction.** `otel.j2` carried a stale caveat claiming `/tmp`
  artifacts are invisible to the agent. That is no longer true, and it steered
  the Profiler away from reusing valid captures. Replaced with guidance to reuse
  an existing artifact unless it is missing or older than the edit being
  attributed.

Reviewers should look closely at the gating in `context.py`: reaching the Docker
socket is root-equivalent on the host, so the widening must not leak outside the
microservices domain or into container-backed runs.

### Architecture

`_assemble_run_context` computes the declarations once and hands them to
`build_agent_client`. `_RunContext` retains them so `_assemble_candidate_context`
(the `--loop evolve` path) can give a candidate the same access: a candidate
runs its parent's domain, but its context carries neither the profiler domain
nor the task name, so recomputing there is impossible.

```mermaid
flowchart TD
    A[main: bundle load] -->|provisions_trace_telemetry| B[AUTO becomes OTEL]
    B --> C[_assemble_run_context]
    C -->|domain is MICROSERVICES and not cli_sandboxed| D[agent_host_resources]
    D -->|docker.sock RW, scratch RW, evaluator pkg RO| E[build_agent_client]
    C -->|retained on _RunContext| F[_assemble_candidate_context]
    F -->|parent.agent_host_resources| G[build_agent_client for candidate]
    E --> H[Profiler role]
    H -->|servicebench trace| I[scratch otel dir]
    I --> J[OTel MCP: summary, critical_path, trace_graphs]
```

## Verification

Verified by an end-to-end agentic run from a genuinely cold state, not by code
inspection alone: submodule reset to baseline, `/tmp/vibesys-<task>` removed, no
containers running, no pre-staged capture.

The run reached `need_profile=true`, instantiated the Profiler, found no
telemetry, ran `servicebench trace` itself, captured 265,744 spans across 23,498
traces over 3x30s windows, and called the OTel MCP tools. The resulting plan
cited measured values (`/hotels` p95 26.12ms, profile fetch ~5ms sitting
sequentially after an independent call) rather than source reading. The accepted
change parallelized `profile.GetProfiles` with `reservation.CheckAvailability`
in the frontend; the framework accuracy gate passed and the benchmark reported
2848.17 ops/s. A second profile confirmed activation: `/hotels` p50 16.66ms to
14.87ms, p95 26.12ms to 23.70ms, with the profile span's mean critical-path
contribution dropping 1.33ms to 0.59ms.

Known gap: that run stopped after one completed round on a pre-existing
structured-output retry defect unrelated to this change (the orchestrator emits
its plan wrapped in an envelope key, fails schema validation, and exhausts
retries fatally). Filing separately.

### Correctness properties

- An explicit `--profiler` is never overridden by the capability default.
- Only a microservices bundle naming both `--telemetry-output` and
  `--trace-graph-json` upgrades `AUTO`; every other task keeps its current
  resolution.
- Host-resource widening is inert outside the microservices domain and inert
  when `cli_sandboxed` is set, so container-backed runs are unchanged.
- The evaluator package is imported read-only; no role can edit trusted,
  integrity-checked evaluator input.
- The scratch directory names the same absolute path inside and outside
  confinement, which is what makes a Docker bind-mount source resolve correctly.
- A candidate context receives exactly its parent's declarations, so `--loop
  evolve` and `--loop agent` expose the same surface.

### Testing

```
./scripts/check_format.sh          # All checks passed
./scripts/check_lint.sh            # All checks passed
uv run pytest                      # 4961 passed, 12 skipped, 3 failed
```

The 3 failures (`tests/test_launch_imports.py` x2,
`tests/test_tui.py::test_cli_parse_failure_is_streamed_after_client_attaches`)
reproduce identically on `origin/main` in a clean worktree and are unrelated to
this branch.

`ruff format --check` also flags `src/vibesys/agents/drivers/__init__.py`, which
is likewise pre-existing on `origin/main` and untouched here; left alone to keep
this PR scoped.
