### PR TITLE
Complete database domain role prompts

### DIFF
--- a/src/vibesys/prompts/domains/database/README.md
+++ b/src/vibesys/prompts/domains/database/README.md
@@ -22,6 +22,10 @@ Present:
   micro-optimization.
 - `judge.md` — what to check: output-equivalence, behavioral-consistency, the
   in-place / no-rearchitecture discipline, and reward-hack guards.
+- `orchestrator.md` — how the planner should pick round-sized micro-optimization
+  tasks and write pass criteria in cost-metric + output-equivalence terms.
+- `profiler.md` — how to capture a profile of the engine on the scored workload
+  to locate the hot path without displacing the benchmark's headline metric.
 
 The behavioral-consistency gates (determinism, crash/restart recovery,
 race-freedom) are named generically here; their concrete checker wiring is added

--- a/src/vibesys/prompts/domains/database/orchestrator.md
+++ b/src/vibesys/prompts/domains/database/orchestrator.md
@@ -1,0 +1,40 @@
+## In-place optimization planning guidance
+
+Choose round-sized tasks that shave measured cost from the engine while keeping
+its results and guarantees **identical** to the pristine round-0 source. Every
+task is an in-place micro-optimization of the engine's own code — never a
+rewrite, an operator reimplementation, an algorithm or complexity-class swap, a
+change to the execution or concurrency model, or a new heavyweight dependency.
+Those are architectural changes and are out of scope by construction.
+
+Good task shapes include:
+
+- Establish a baseline first: run the accuracy checker and the benchmark on the
+  vanilla source, then profile to locate the dominant hot function, allocation
+  site, or loop on the measured workload.
+- Remove hot-path heap allocation; reuse buffers; right-size vectors and
+  small-buffer optimizations on the identified hot path.
+- Tighten one existing merge, sort, scan, join, aggregation, or consolidation
+  loop; cut redundant clones and copies.
+- Improve data layout and locality (field ordering, alignment, SoA/AoS,
+  power-of-two indexing) of existing structures — layout is fair game, the data
+  *model* is not.
+- Inline a hot function, add cold/hot annotations, or take a branchless path.
+- Tune build and codegen flags (optimization level, LTO, codegen units, target
+  CPU) that do not alter results.
+
+Write pass criteria in terms of the objective's headline cost metric **and**
+correctness: a round passes only when it is faster at output-equivalence with
+the pristine reference on every workload the checker exercises and preserves the
+engine's behavioral guarantees (determinism across configuration, crash/restart
+recovery, race-freedom). A cost win that changes a single result or weakens a
+guarantee is a failure, not a win.
+
+Prefer one micro-optimization per round so a regression is attributable to a
+single change, and so the diff against the pristine reference stays a short list
+of named, defensible edits. The honest expectation for an accepted round is a
+**modest percentage, not a multiple**.
+
+If the engine's build, run, checker, or benchmark contract is uncertain, first
+ask the implementer to document and validate those commands against the vanilla
+source before attempting any optimization.

--- a/src/vibesys/prompts/domains/database/profiler.md
+++ b/src/vibesys/prompts/domains/database/profiler.md
@@ -1,0 +1,33 @@
+## Engine profile capture
+
+Profile the **same workload the benchmark scores**, at steady state after
+warmup, in the **exact configuration the metric uses** (for example the same
+worker/parallelism count and input sizes) so the profile attributes cost on the
+scored path rather than a different one. Start from the objective and manifest to
+identify the engine binary, the fixed workload arguments, and the headline cost
+metric.
+
+Useful evidence includes:
+
+- Benchmark output with the headline cost metric (for example CPU-seconds or
+  wall time) alongside any latency, throughput, or resource fields it reports.
+- A CPU profile or flamegraph attributing self and inclusive time to functions
+  on the hot path — captured with whatever profiler fits the engine's language
+  and build (for example `perf`, `samply`, `cargo-flamegraph`, or `py-spy`).
+- An allocation profile showing heap allocations, retained bytes, and copy
+  volume on the hot path, when allocation is a suspected cost.
+- Hardware counters where available: cache misses, branch mispredictions, and
+  instructions-per-cycle for the hottest functions.
+- A phase breakdown that separates build/compile time from run time, so a
+  build-flag change is never mistaken for a run-time win.
+
+Rank bottlenecks by self time, then compare the **same function across the
+candidate and the pristine reference** to confirm a micro-optimization actually
+moved the hot spot instead of shifting cost elsewhere or regressing another
+path. Capture after warmup and discard the first iterations.
+
+Keep the benchmark's headline cost metric as the authoritative score: a profile
+is evidence for **where** to optimize, not the score itself. Reject a profile
+that does not match the scored workload identity and configuration, and remember
+that output-equivalence and the behavioral-consistency gates still gate any
+change the profile motivates.

--- a/tests/loops/agent/test_domain_packs.py
+++ b/tests/loops/agent/test_domain_packs.py
@@ -379,6 +379,26 @@ def test_generic_orchestrator_has_no_llm_serving_method():  # noqa: ANN201  # tr
     assert "## Task granularity" in out  # base skeleton intact
 
 
+def test_database_provides_in_place_orchestrator_method():  # noqa: ANN201  # tracked: #288
+    section = render_domain_section(
+        resolve_domain(DomainName.DATABASE),
+        DomainRole.ORCHESTRATOR,
+        modality="dataflow",
+        workspace_sources=(),
+    )
+    assert "In-place optimization planning guidance" in section
+    # round-sized, one-change-per-round, correctness-gated micro-opt framing
+    assert "micro-optimization" in section.lower()
+    assert "one micro-optimization per round" in section.lower()
+    assert "output-equivalence" in section.lower()
+
+
+def test_database_method_is_injected_into_plan():  # noqa: ANN201  # tracked: #288
+    out = _render_orchestrator(DomainName.DATABASE)
+    assert "In-place optimization planning guidance" in out
+    assert "## Task granularity" in out  # base skeleton intact
+
+
 def test_llm_serving_profiler_branches_on_remote_execution_not_provider():  # noqa: ANN201  # tracked: #288
     domain = resolve_domain(DomainName.LLM_SERVING)
 
@@ -391,6 +411,19 @@ def test_llm_serving_profiler_branches_on_remote_execution_not_provider():  # no
     assert "bounded controller/profile command" in remote
     assert "Modal" not in local
     assert "Modal" not in remote
+
+
+def test_render_database_profiler_has_content():  # noqa: ANN201  # tracked: #288
+    section = render_domain_section(
+        resolve_domain(DomainName.DATABASE),
+        DomainRole.PROFILER,
+        profile_execution="local",
+    )
+    assert "Engine profile capture" in section
+    # locate the hot path without displacing the scored metric
+    assert "flamegraph" in section.lower()
+    assert "headline cost metric" in section.lower()
+    assert "output-equivalence" in section.lower()
 
 
 def test_torch_profiler_remote_capture_is_provider_neutral():  # noqa: ANN201  # tracked: #288


### PR DESCRIPTION
## What

Adds the `orchestrator.md` and `profiler.md` role files to the `database` domain so it matches `microservices` and `llm-serving` domains. Before this, the database domain shipped only `implementer.md` + `judge.md`, so the planner and profiler fell back to the neutral skeleton with no database-specific guidance.

Follow-up to #368 (which added the domain skeleton).
## Changes

- **`prompts/domains/database/orchestrator.md`** — planner strategy: pick round-sized in-place micro-optimization tasks (baseline → profile → one change per round), with pass criteria written in headline-cost-metric **and** output-equivalence + behavioral-consistency terms; explicit no-rearchitecture scope.
- **`prompts/domains/database/profiler.md`** — capture recipe: profile the *scored* workload at steady state in the metric's exact configuration, gather CPU/flamegraph + allocation + counter evidence, compare the same function candidate-vs-pristine, and keep the benchmark's headline metric authoritative.
- **`prompts/domains/database/README.md`** — "Present:" list now includes the two new role files.
- **`tests/loops/agent/test_domain_packs.py`** — adds `test_database_provides_in_place_orchestrator_method`, `test_database_method_is_injected_into_plan` (end-to-end injection into the planner prompt), and `test_render_database_profiler_has_content`, matching the existing llm-serving orchestrator/profiler test style.

All five renderable roles are now supplied for `database`; `single_agent` still auto-derives from implementer + judge (matching `microservices`).

## Verification

- `uv run pytest tests/loops/agent/test_domain_packs.py` — 31 passed
- `./scripts/check_format.sh` — clean (383 files)
- `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)