### PR TITLE
Surface runtime errors in a persistent TUI banner

### DIFF
--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -57,6 +57,7 @@ describe('session controller', () => {
 
     expect(controller.state.status).toBe('completed');
     expect(controller.state.overlay).toBeNull();
+    expect(controller.state.errorBanner).toBeNull();
   });
 
   it('renders a performance curve from the perf command', async () => {
@@ -417,14 +418,14 @@ describe('session controller', () => {
     const controller = new SocketSessionController(transport);
 
     await controller.submit('/history');
-    expect(controller.state.overlay?.kind).toBe('error');
-    expect(controller.state.overlay?.content).toContain('Unknown command: /history');
+    expect(controller.state.errorBanner?.scope).toBe('input');
+    expect(controller.state.errorBanner?.message).toContain('Unknown command: /history');
 
     await controller.submit('/history rounds');
-    expect(controller.state.overlay?.content).toContain('Unknown command: /history rounds');
+    expect(controller.state.errorBanner?.message).toContain('Unknown command: /history rounds');
 
     await controller.submit('/experiments');
-    expect(controller.state.overlay?.content).toContain('Unknown command: /experiments');
+    expect(controller.state.errorBanner?.message).toContain('Unknown command: /experiments');
 
     expect(transport.requests).toEqual([]);
   });
@@ -770,8 +771,8 @@ describe('session controller', () => {
 
     await controller.submitChat('/nope');
 
-    expect(controller.state.overlay?.kind).toBe('error');
-    expect(controller.state.overlay?.content).toContain('Unknown command');
+    expect(controller.state.errorBanner).toMatchObject({scope: 'input'});
+    expect(controller.state.errorBanner?.message).toContain('Unknown command');
     expect(transport.requests).toEqual([]);
   });
 
@@ -798,8 +799,8 @@ describe('session controller', () => {
 
     await controller.submit('/theme monokai');
 
-    expect(controller.state.overlay?.kind).toBe('error');
-    expect(controller.state.overlay?.content).toContain('Unknown theme: monokai');
+    expect(controller.state.errorBanner).toMatchObject({scope: 'input'});
+    expect(controller.state.errorBanner?.message).toContain('Unknown theme: monokai');
     expect(controller.state.themeName).toBe('dark');
     expect(transport.requests).toEqual([]);
   });

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -32,6 +32,7 @@ import {
   type PaneFocus,
   type PaneView,
   type RoundFocus,
+  reportError,
   type SessionState,
   selectAgent,
   selectNextAgent,
@@ -127,18 +128,31 @@ export class SocketSessionController implements SessionController {
   }
 
   async start(): Promise<void> {
-    const response = await this.client.request({type: 'query.snapshot'});
-    if (response.snapshot) this.#setState(applySnapshot(this.#state, response.snapshot));
+    try {
+      const response = await this.client.request({type: 'query.snapshot'});
+      if (response.snapshot) this.#setState(applySnapshot(this.#state, response.snapshot));
+    } catch (error) {
+      this.#setState(reportError(this.#state, String(error), {scope: 'request'}));
+    }
     // The log is the landing view, so it is populated before the first frame
     // rather than on demand.
     await this.#loadExperiments();
-    this.#eventSubscription = await this.client.subscribe(
-      0,
-      message => this.#onMessage(message),
-      error => {
-        if (!this.#state.terminal) this.#setState(showDetail(this.#state, String(error), 'error'));
-      },
-    );
+    try {
+      this.#eventSubscription = await this.client.subscribe(
+        0,
+        message => this.#onMessage(message),
+        error => {
+          // A terminal event already carries the actual outcome. The socket
+          // closing afterward is lifecycle cleanup, not a second failure that
+          // should replace the useful diagnostic in the banner.
+          if (!this.#state.terminal) {
+            this.#setState(reportError(this.#state, String(error), {scope: 'transport'}));
+          }
+        },
+      );
+    } catch (error) {
+      this.#setState(reportError(this.#state, String(error), {scope: 'transport'}));
+    }
   }
 
   async stop(): Promise<void> {
@@ -325,7 +339,9 @@ export class SocketSessionController implements SessionController {
       const content = renderPerformanceCurve(response.performance ?? [], response.events ?? []);
       this.#setState(setPaneContent(this.#state, view, content));
     } catch (error) {
-      this.#setState(failPane(this.#state, view, String(error)));
+      this.#setState(
+        reportError(failPane(this.#state, view, String(error)), String(error), {scope: 'request'}),
+      );
     }
   }
 
@@ -371,7 +387,9 @@ export class SocketSessionController implements SessionController {
       const response = await this.client.request({type: 'query.experiments'});
       this.#setState(setExperiments(this.#state, response.experiments ?? []));
     } catch (error) {
-      this.#setState(failExperiments(this.#state, String(error)));
+      this.#setState(
+        reportError(failExperiments(this.#state, String(error)), String(error), {scope: 'request'}),
+      );
     }
   }
 
@@ -452,7 +470,7 @@ export class SocketSessionController implements SessionController {
       this.#setState(state);
     } catch (error) {
       this.#setState({
-        ...this.#state,
+        ...reportError(this.#state, String(error), {scope: 'request'}),
         chatConversation: appendChatEntry(this.#state.chatConversation, {
           id: `chat-error-${++this.#chatMessageId}`,
           kind: 'result',
@@ -466,7 +484,8 @@ export class SocketSessionController implements SessionController {
 
   async submit(value: string): Promise<void> {
     const parsed = parseInput(value.trim());
-    if (parsed.error) return this.#setState(showDetail(this.#state, parsed.error, 'error'));
+    if (parsed.error)
+      return this.#setState(reportError(this.#state, parsed.error, {scope: 'input'}));
     if (parsed.localView === 'help') {
       return this.#setState(
         showDetail(this.#state, helpText({chatDocked: chatPaneVisible(this.#state)}), 'help'),
@@ -507,7 +526,7 @@ export class SocketSessionController implements SessionController {
       const rendered = renderResponse(parsed.request, response, parsed.responseView);
       if (rendered !== null) this.#setState(showDetail(this.#state, rendered));
     } catch (error) {
-      this.#setState(showDetail(this.#state, String(error), 'error'));
+      this.#setState(reportError(this.#state, String(error), {scope: 'request'}));
     }
   }
 
@@ -525,7 +544,7 @@ export class SocketSessionController implements SessionController {
       this.#refreshPaneFor(message.events);
     }
     if (message.type === 'protocol_error') {
-      this.#setState(showDetail(this.#state, message.message, 'error'));
+      this.#setState(reportError(this.#state, message.message, {scope: 'protocol'}));
     }
   }
 

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -109,9 +109,96 @@ describe('session event model', () => {
     expect(state.status).toBe('failed');
     expect(state.terminal).toBe(true);
     expect(state.overlay).toBeNull();
+    expect(state.errorBanner).toMatchObject({
+      title: 'Configuration failed',
+      severity: 'fatal',
+    });
+    expect(state.errorBanner?.message).toContain('This run has completed 30 rounds.');
     expect(state.conversation[0]?.content).toContain('This run has completed 30 rounds.');
     expect(state.conversation[0]?.content).toContain('resume_limit_exhausted');
     expect(state.conversation[0]?.tone).toBe('failure');
+  });
+
+  it('promotes an invocation failure to one terminal error banner', () => {
+    let state = applyEvent(initialSessionState(), {
+      ...event(1, 'invocation_finished', {
+        kind: 'invocation_finished',
+        error: 'RuntimeError: app-server initialization was denied',
+      }),
+      status: 'failed',
+      invocation_id: 'invocation-1',
+    });
+
+    expect(state.errorBanner).toMatchObject({
+      title: 'Invocation failed',
+      severity: 'recoverable',
+      invocationId: 'invocation-1',
+    });
+    state = applyEvent(state, {
+      ...event(2, 'run_failed'),
+      text: 'RuntimeError: app-server initialization was denied',
+    });
+
+    expect(state.errorBanner).toMatchObject({
+      title: 'Run failed',
+      severity: 'fatal',
+      count: 2,
+    });
+  });
+
+  it('keeps the more detailed terminal message when a failure is deduplicated', () => {
+    let state = applyEvent(initialSessionState(), {
+      ...event(1, 'invocation_finished', {
+        kind: 'invocation_finished',
+        error: 'RuntimeError: app-server initialization was denied',
+      }),
+      invocation_id: 'invocation-1',
+    });
+    const terminalMessage =
+      'RuntimeError: app-server initialization was denied\nOperation not permitted (os error 1)';
+    state = applyEvent(state, {...event(2, 'run_failed'), text: terminalMessage});
+
+    expect(state.errorBanner).toMatchObject({count: 2, message: terminalMessage});
+  });
+
+  it('uses an error-bearing invocation result even when the status is absent', () => {
+    const state = applyEvent(initialSessionState(), {
+      ...event(1, 'invocation_finished', {
+        kind: 'invocation_finished',
+        error: 'The agent process could not start.',
+      }),
+      status: null,
+    });
+
+    expect(state.errorBanner).toMatchObject({
+      title: 'Invocation failed',
+      message: 'The agent process could not start.',
+    });
+  });
+
+  it('uses the terminal event type for an empty failure message', () => {
+    const failed = applyEvent(initialSessionState(), event(1, 'run_failed'));
+    const interrupted = applyEvent(initialSessionState(), event(1, 'run_interrupted'));
+
+    expect(failed.errorBanner?.message).toBe('Run failed.');
+    expect(interrupted.errorBanner?.message).toBe('Run interrupted.');
+  });
+
+  it('shows structured interruption details when no event text is present', () => {
+    const state = applyEvent(
+      initialSessionState(),
+      event(1, 'run_interrupted', {
+        kind: 'run_interrupted',
+        reason: 'launcher_terminated',
+        signal: 'SIGTERM',
+      }),
+    );
+
+    expect(state.errorBanner).toMatchObject({
+      title: 'Run interrupted',
+      message: 'launcher_terminated (SIGTERM)',
+      severity: 'fatal',
+    });
   });
 
   it('routes chat agent trajectory events away from the experiment transcript', () => {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -60,6 +60,30 @@ export interface SessionState {
    * by older backends) are ignored so tool turns never render twice.
    */
   typedToolEvents: boolean;
+  /** Root-level error state, independent of the active transcript or log view. */
+  errorBanner: ErrorBannerState | null;
+}
+
+export type ErrorSeverity = 'recoverable' | 'fatal';
+export type ErrorScope =
+  | 'configuration'
+  | 'invocation'
+  | 'run'
+  | 'protocol'
+  | 'request'
+  | 'transport'
+  | 'input';
+
+export interface ErrorBannerState {
+  title: string;
+  message: string;
+  severity: ErrorSeverity;
+  scope: ErrorScope;
+  agentKind: string | null;
+  roundLabel: string | null;
+  invocationId: string | null;
+  /** Equivalent reports are folded into one banner. */
+  count: number;
 }
 
 /** The agent graph on the left, or the transcript on the right. */
@@ -210,6 +234,7 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
     chatDockFits: true,
     themePicker: null,
     typedToolEvents: false,
+    errorBanner: null,
   };
 }
 
@@ -570,7 +595,8 @@ export function applySnapshot(state: SessionState, snapshot: RunSnapshot): Sessi
 export function applyEvent(state: SessionState, event: RunEvent): SessionState {
   const sequence = event.sequence ?? 0;
   if (sequence > 0 && sequence <= state.sequence) return state;
-  const next = {...state, sequence: Math.max(state.sequence, sequence)};
+  let next = {...state, sequence: Math.max(state.sequence, sequence)};
+  next = applyFailureEvent(next, event);
   if (event.agent_kind === 'chat') return applyChatEvent(next, event);
   if (event.agent_kind) next.agentKind = event.agent_kind;
   if (event.round_label) next.roundLabel = event.round_label;
@@ -807,6 +833,130 @@ export function selectNextTodo(state: SessionState, delta: number): SessionState
   const start = current === null ? (delta > 0 ? -1 : todos.length) : current;
   const index = Math.min(todos.length - 1, Math.max(0, start + delta));
   return {...state, selectedTodoIndex: index};
+}
+
+export interface ErrorReport {
+  scope: ErrorScope;
+  severity?: ErrorSeverity;
+  title?: string;
+  agentKind?: string | null;
+  roundLabel?: string | null;
+  invocationId?: string | null;
+}
+
+/**
+ * Records an error independently of any particular view. A terminal event
+ * commonly repeats an invocation failure, so equivalent reports promote the
+ * current banner instead of burying its cause beneath a duplicate.
+ */
+export function reportError(
+  state: SessionState,
+  message: string,
+  report: ErrorReport,
+): SessionState {
+  const severity = report.severity ?? 'recoverable';
+  const banner: ErrorBannerState = {
+    title: report.title ?? errorTitle(report.scope),
+    message: message || 'An unknown error occurred.',
+    severity,
+    scope: report.scope,
+    agentKind: report.agentKind ?? null,
+    roundLabel: report.roundLabel ?? null,
+    invocationId: report.invocationId ?? null,
+    count: 1,
+  };
+  const existing = state.errorBanner;
+  if (existing === null || !equivalentError(existing, banner)) {
+    return {...state, errorBanner: banner};
+  }
+  const promoted = existing.severity === 'fatal' || severity === 'fatal' ? 'fatal' : 'recoverable';
+  return {
+    ...state,
+    errorBanner: {
+      ...existing,
+      message: moreInformativeMessage(existing.message, banner.message),
+      severity: promoted,
+      title: promoted === 'fatal' ? banner.title : existing.title,
+      scope: promoted === 'fatal' ? banner.scope : existing.scope,
+      agentKind: existing.agentKind ?? banner.agentKind,
+      roundLabel: existing.roundLabel ?? banner.roundLabel,
+      invocationId: existing.invocationId ?? banner.invocationId,
+      count: existing.count + 1,
+    },
+  };
+}
+
+function applyFailureEvent(state: SessionState, event: RunEvent): SessionState {
+  const data = event.data;
+  if (data?.kind === 'configuration_failed') {
+    return reportError(state, formatConfigurationFailure(event), {
+      scope: 'configuration',
+      severity: 'fatal',
+      title: 'Configuration failed',
+    });
+  }
+  if (
+    data?.kind === 'invocation_finished' &&
+    ((data.error !== null && data.error !== undefined) || event.status === 'failed')
+  ) {
+    return reportError(state, data.error || event.text || 'Agent invocation failed.', {
+      scope: 'invocation',
+      title: 'Invocation failed',
+      agentKind: event.agent_kind ?? null,
+      roundLabel: event.round_label ?? null,
+      invocationId: event.invocation_id ?? null,
+    });
+  }
+  if (event.type === 'run_failed' || event.type === 'run_interrupted') {
+    const interruption =
+      data?.kind === 'run_interrupted'
+        ? `${data.reason}${data.signal === null ? '' : ` (${data.signal})`}`
+        : '';
+    const fallback = event.type === 'run_failed' ? 'Run failed.' : 'Run interrupted.';
+    return reportError(state, event.text || interruption || fallback, {
+      scope: 'run',
+      severity: 'fatal',
+      title: event.type === 'run_interrupted' ? 'Run interrupted' : 'Run failed',
+      agentKind: event.agent_kind ?? null,
+      roundLabel: event.round_label ?? null,
+      invocationId: event.invocation_id ?? null,
+    });
+  }
+  return state;
+}
+
+/** Keep a terminal wrapper's extra context when it repeats an invocation error. */
+function moreInformativeMessage(current: string, later: string): string {
+  if (later.length >= current.length) return later;
+  const currentLines = current.split('\n').length;
+  const laterLines = later.split('\n').length;
+  return laterLines > currentLines ? later : current;
+}
+
+function equivalentError(left: ErrorBannerState, right: ErrorBannerState): boolean {
+  if (left.invocationId !== null && left.invocationId === right.invocationId) return true;
+  const leftMessage = left.message.trim();
+  const rightMessage = right.message.trim();
+  if (leftMessage === rightMessage) return true;
+  // Terminal wrappers often add only an exception prefix around an invocation
+  // error. Fold those together, but do not equate short generic diagnostics.
+  return (
+    Math.min(leftMessage.length, rightMessage.length) >= 24 &&
+    (leftMessage.includes(rightMessage) || rightMessage.includes(leftMessage))
+  );
+}
+
+function errorTitle(scope: ErrorScope): string {
+  const titles: Record<ErrorScope, string> = {
+    configuration: 'Configuration failed',
+    invocation: 'Invocation failed',
+    run: 'Run failed',
+    protocol: 'Protocol error',
+    request: 'Request failed',
+    transport: 'Connection lost',
+    input: 'Input error',
+  };
+  return titles[scope];
 }
 
 function formatConfigurationFailure(event: RunEvent): string {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -84,6 +84,36 @@ describe('OpenTUI presentation', () => {
     expect(frame).toContain('Type a question or /help');
   });
 
+  it('keeps a fatal error visible above the empty experiment log', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController(initialSessionState());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    controller.publish({
+      ...controller.state,
+      experimentLog: {entries: [], selectedId: null, pending: false, error: null},
+      errorBanner: {
+        title: 'Run failed',
+        message: 'RuntimeError: app-server initialization was denied\nOperation not permitted',
+        severity: 'fatal',
+        scope: 'run',
+        agentKind: 'orchestrator',
+        roundLabel: 'round-1-pre',
+        invocationId: null,
+        count: 1,
+      },
+    });
+
+    const frame = await testRenderer.waitForFrame(value =>
+      value.includes('app-server initialization was denied'),
+    );
+    expect(frame).toContain('Run failed · orchestrator · round-1-pre');
+    expect(frame).toContain('Operation not permitted');
+    expect(frame).toContain('Experiments');
+
+    expect(frame).toContain('Ctrl+PgUp/PgDn: scroll');
+  });
+
   it('renders quiet round labels without status text or symbols', async () => {
     const testRenderer = await createTestRenderer({width: 100, height: 18});
     const activeStartedAt = new Date(Date.now() - 65_000).toISOString();

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -11,6 +11,7 @@ import {AgentMapView} from './agent-map.js';
 import {ChatOverlayView} from './chat-overlay.js';
 import {ChatPaneView, chatDockFits, chatPaneWidth} from './chat-pane.js';
 import {ConversationView} from './conversation.js';
+import {ErrorBannerView} from './error-banner.js';
 import {ExperimentLogView} from './experiment-log.js';
 import {createChatInputPanel, createInputPanel} from './input.js';
 import {bindKeybindings} from './keybindings.js';
@@ -102,6 +103,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   let markdownStyle = createMarkdownStyle(theme);
   const roundStrip = new RoundStripView(renderer, controller, theme);
   const todoStrip = new TodoStripView(renderer, controller, theme);
+  const errorBanner = new ErrorBannerView(renderer, theme);
   const agentMap = new AgentMapView(renderer, controller, theme);
   const overlay = new OverlayView(renderer, theme);
   const experimentLog = new ExperimentLogView(renderer, controller, theme);
@@ -181,6 +183,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   bottom.add(chatInputColumn);
   bottom.add(commandColumn);
   root.add(header);
+  root.add(errorBanner.output);
   root.add(roundStrip.output);
   root.add(main);
   root.add(todoStrip.output);
@@ -202,6 +205,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     help.fg = theme.textSubtle;
     roundStrip.applyTheme(theme);
     todoStrip.applyTheme(theme);
+    errorBanner.applyTheme(theme);
     agentMap.applyTheme(theme);
     overlay.applyTheme(theme);
     experimentLog.applyTheme(theme);
@@ -248,6 +252,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     header.content = showLog
       ? `VibeSys · ${statusText(state)} · experiments`
       : `VibeSys · ${statusText(state)}${scope}${selection}${returnHint}`;
+    errorBanner.render(state);
     // The log carries its own key hints in its footer, so when it shares the
     // row with a pane the global line is the place for the pane's keys.
     help.content = showSplit
@@ -292,7 +297,8 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     // visualization instead of over it. Bounds come from the siblings that
     // actually occupy those rows, so a taller todo strip still fits.
     if (showSplit) {
-      const top = header.height + (showLog ? 0 : roundStrip.output.height);
+      const errorHeight = state.errorBanner === null ? 0 : errorBanner.output.height;
+      const top = header.height + errorHeight + (showLog ? 0 : roundStrip.output.height);
       const below = todoStrip.output.height + help.height + input.box.height;
       chat.setPaneBounds({
         left: 1,
@@ -358,6 +364,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     toggleTodos: () => controller.toggleTodos(),
     scrollRightPane: delta => rightPane.scrollBy(delta),
     scrollChatPane: delta => chatPane.scrollBy(delta),
+    scrollErrorBanner: delta => errorBanner.scrollBy(delta),
   });
   // Pane widths come from the terminal, so a resize has to redraw even though
   // no state changed.

--- a/clients/tui/src/ui/error-banner.ts
+++ b/clients/tui/src/ui/error-banner.ts
@@ -1,0 +1,119 @@
+import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
+import type {ErrorBannerState, SessionState} from '../session-model.js';
+import type {Theme} from './theme.js';
+
+/** Enough rows to read a useful diagnostic without pushing the run off screen. */
+const ERROR_HEIGHT = 10;
+
+function context(banner: ErrorBannerState): string {
+  return [banner.agentKind, banner.roundLabel]
+    .filter((item): item is string => item !== null)
+    .join(' · ');
+}
+
+/**
+ * A single, always-rooted, fixed-height error surface. It does not take input
+ * focus, while Ctrl+PgUp/Ctrl+PgDn scroll a long diagnostic.
+ */
+export class ErrorBannerView {
+  readonly output: BoxRenderable;
+  readonly #scroll: ScrollBoxRenderable;
+  #theme: Theme;
+  #rendered: ErrorBannerState | null = null;
+
+  constructor(
+    private readonly renderer: CliRenderer,
+    theme: Theme,
+  ) {
+    this.#theme = theme;
+    this.output = new BoxRenderable(renderer, {
+      id: 'error-banner',
+      width: '100%',
+      height: ERROR_HEIGHT,
+      flexShrink: 0,
+      flexDirection: 'column',
+      border: true,
+      borderStyle: 'rounded',
+      borderColor: theme.error,
+      paddingLeft: 1,
+      paddingRight: 1,
+      backgroundColor: theme.elevatedSurface,
+      visible: false,
+    });
+    this.#scroll = new ScrollBoxRenderable(renderer, {
+      id: 'error-banner-scroll',
+      width: '100%',
+      flexGrow: 1,
+      stickyScroll: false,
+      viewportCulling: true,
+      verticalScrollbarOptions: {showArrows: true},
+    });
+  }
+
+  applyTheme(theme: Theme): void {
+    this.#theme = theme;
+    this.output.backgroundColor = theme.elevatedSurface;
+    this.#rendered = null;
+  }
+
+  scrollBy(delta: number): void {
+    this.#scroll.scrollBy(delta, 'viewport');
+  }
+
+  render(state: SessionState): void {
+    const banner = state.errorBanner;
+    if (banner === null) {
+      this.output.visible = false;
+      this.#rendered = null;
+      return;
+    }
+    this.output.visible = true;
+    if (banner === this.#rendered) return;
+    this.#rendered = banner;
+    this.#clear();
+    this.output.borderColor = banner.severity === 'fatal' ? this.#theme.error : this.#theme.warning;
+    this.output.height = ERROR_HEIGHT;
+    this.#renderContent(banner);
+  }
+
+  #renderContent(banner: ErrorBannerState): void {
+    const where = context(banner);
+    const count = banner.count > 1 ? ` · ${banner.count} reports` : '';
+    this.output.title = ` × ${banner.title}${where ? ` · ${where}` : ''}${count} `;
+    this.output.add(this.#scroll);
+    this.#scroll.add(
+      new TextRenderable(this.renderer, {
+        content: banner.message,
+        fg:
+          banner.severity === 'fatal'
+            ? this.#theme.conversation.failure.content
+            : this.#theme.warning,
+        width: '100%',
+        wrapMode: 'word',
+      }),
+    );
+    this.output.add(
+      new TextRenderable(this.renderer, {
+        content: 'Ctrl+PgUp/PgDn: scroll',
+        fg: this.#theme.textSubtle,
+        width: '100%',
+        height: 1,
+        wrapMode: 'none',
+        truncate: true,
+      }),
+    );
+    this.#scroll.scrollTo(0);
+  }
+
+  #clear(): void {
+    this.output.title = '';
+    for (const child of [...this.output.getChildren()]) {
+      this.output.remove(child);
+      if (child !== this.#scroll) child.destroyRecursively();
+    }
+    for (const child of [...this.#scroll.getChildren()]) {
+      this.#scroll.remove(child);
+      child.destroyRecursively();
+    }
+  }
+}

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -16,6 +16,7 @@ export interface KeybindingActions {
   toggleTodos(): void;
   scrollRightPane(delta: number): void;
   scrollChatPane(delta: number): void;
+  scrollErrorBanner(delta: number): void;
 }
 
 export function bindKeybindings(
@@ -28,6 +29,15 @@ export function bindKeybindings(
     if (key.ctrl && key.name === 'c') {
       key.preventDefault();
       renderer.destroy();
+      return;
+    }
+    if (
+      controller.state.errorBanner !== null &&
+      key.ctrl &&
+      (key.name === 'pageup' || key.name === 'pagedown')
+    ) {
+      actions.scrollErrorBanner(key.name === 'pageup' ? -1 : 1);
+      key.preventDefault();
       return;
     }
     // Pane switching works from anywhere a second column is on screen, which


### PR DESCRIPTION
## Problem

Runtime, protocol, request, and configuration failures can arrive while the TUI is showing the experiment log or another non-transcript view. The existing UI routed several failures into view-specific overlays or contextual state, and it discarded detailed invocation failure events. Users could see that a run failed without seeing the underlying diagnostic.

## Solution

Add one persistent root-level error banner for provider-neutral error reports. The controller routes local, request, transport, and protocol failures into the same state. The event reducer extracts configuration, invocation, interruption, and run failures, deduplicates repeated invocation and terminal reports, promotes terminal severity, and retains the more informative diagnostic.

The banner is always visible at a fixed expanded height when an error exists. Long messages wrap and scroll with the mouse wheel or Ctrl+PageUp and Ctrl+PageDown. Normal PageUp and PageDown remain available to the focused transcript or pane.

### Architecture

```mermaid
flowchart LR
    Events[Backend events] --> Reducer[Session error reducer]
    Requests[Controller failures] --> Reducer
    Reducer --> State[SessionState errorBanner]
    State --> Banner[Root TUI error banner]
```

This changes only TUI presentation and client state. The backend protocol and Codex execution behavior are unchanged.

## Verification

Biome formatting, TypeScript checks, production build, focused error-state tests, and the complete TUI test suite were run. The full suite has one unrelated existing macOS path assertion failure where the test expects /var and receives /private/var.

### Correctness properties

- Errors remain visible regardless of the active TUI view.
- Terminal stream shutdown does not overwrite the actual terminal failure.
- Equivalent invocation and run reports produce one banner and retain the more informative message.
- Invocation errors are surfaced even when status is absent.
- Run interruption details preserve reason and signal.
- Error rendering is provider-neutral and does not change the backend protocol.
- Ordinary pane scrolling remains available while an error is visible.

### Testing

- pnpm exec biome check on all changed TUI files: passed
- pnpm --dir clients/tui check: passed
- pnpm --dir clients/tui build: passed
- pnpm --dir clients/tui exec bun test --max-concurrency 1 src: 325 passed, 1 unrelated launcher path assertion failed