### PR TITLE
Add structured runtime diagnostics across the supervision protocol

### DIFF
--- a/clients/tui/src/client.test.ts
+++ b/clients/tui/src/client.test.ts
@@ -3,7 +3,7 @@ import {randomUUID} from 'node:crypto';
 import {unlink} from 'node:fs/promises';
 import {createServer, type Server, type Socket} from 'node:net';
 import {join} from 'node:path';
-import {SupervisionClient, type SupervisionClientOptions} from './client.js';
+import {SupervisionClient, type SupervisionClientOptions, SupervisionError} from './client.js';
 
 let socketPath: string | undefined;
 
@@ -67,12 +67,31 @@ describe('SupervisionClient', () => {
               timestamp: new Date().toISOString(),
               ok: false,
               error: 'invalid request',
+              diagnostic: {
+                id: 'request-1',
+                code: 'future_backend_code',
+                summary: 'The request could not be completed.',
+                detail: 'The backend rejected the command.',
+                hint: 'Retry after checking the run state.',
+                scope: 'request',
+                severity: 'error',
+                retryability: 'manual',
+              },
               events: [],
             })}\n`,
           );
         }),
       async client => {
-        await expect(client.request({type: 'query.snapshot'})).rejects.toThrow('invalid request');
+        const rejected = client.request({type: 'query.snapshot'});
+        await expect(rejected).rejects.toBeInstanceOf(SupervisionError);
+        await expect(rejected).rejects.toMatchObject({
+          name: 'SupervisionError',
+          message: 'invalid request',
+          diagnostic: {
+            id: 'request-1',
+            summary: 'The request could not be completed.',
+          },
+        });
       },
     );
   });
@@ -184,6 +203,49 @@ describe('SupervisionClient', () => {
         );
         await new Promise(resolve => setTimeout(resolve, 20));
         expect(disconnects).toHaveLength(1);
+      },
+    );
+  });
+
+  it('keeps a structured protocol error when the stream closes afterward', async () => {
+    await withServer(
+      socket =>
+        respondToLines(socket, request => {
+          if (request['type'] !== 'subscribe') return;
+          socket.write(
+            `${JSON.stringify({
+              type: 'subscribed',
+              request_id: request['request_id'],
+              run_id: 'run-1',
+              latest_sequence: 0,
+            })}\n${JSON.stringify({
+              type: 'protocol_error',
+              code: 'stream_failed',
+              message: 'Event stream failed',
+              diagnostic: {
+                id: 'stream-1',
+                code: 'stream_failed',
+                summary: 'Event stream failed',
+                detail: 'RuntimeError: event store is unavailable',
+                scope: 'protocol',
+                severity: 'error',
+              },
+            })}\n`,
+            () => socket.destroy(),
+          );
+        }),
+      async client => {
+        const messages: string[] = [];
+        const disconnects: Error[] = [];
+        await client.subscribe(
+          0,
+          message => messages.push(String(message.type)),
+          error => disconnects.push(error),
+        );
+        await new Promise(resolve => setTimeout(resolve, 20));
+
+        expect(messages).toEqual(['subscribed', 'protocol_error']);
+        expect(disconnects).toEqual([]);
       },
     );
   });

--- a/clients/tui/src/client.ts
+++ b/clients/tui/src/client.ts
@@ -1,6 +1,12 @@
 import {randomUUID} from 'node:crypto';
 import {createConnection, type Socket} from 'node:net';
-import type {ProtocolRequest, ProtocolResponse, RequestInput, ServerMessage} from './protocol.js';
+import type {
+  Diagnostic,
+  ProtocolRequest,
+  ProtocolResponse,
+  RequestInput,
+  ServerMessage,
+} from './protocol.js';
 
 export interface EventSubscription {
   close(): Promise<void>;
@@ -13,6 +19,17 @@ export interface SupervisionClientOptions {
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/** A failed supervision response, including its optional structured diagnostic. */
+export class SupervisionError extends Error {
+  constructor(
+    message: string,
+    readonly diagnostic: Diagnostic | null = null,
+  ) {
+    super(message);
+    this.name = 'SupervisionError';
+  }
+}
 
 export class SupervisionClient {
   readonly #socket: Socket;
@@ -98,6 +115,7 @@ export class SupervisionClient {
       let subscribed = false;
       let closing = false;
       let disconnected = false;
+      let protocolErrorReceived = false;
       const handshakeTimeout = setTimeout(() => {
         disconnect(
           new Error(`Supervision subscription timed out after ${this.#connectTimeoutMs}ms`),
@@ -108,6 +126,7 @@ export class SupervisionClient {
         if (disconnected || closing) return;
         disconnected = true;
         clearTimeout(handshakeTimeout);
+        if (subscribed && protocolErrorReceived) return;
         if (subscribed) onDisconnect(error);
         else reject(error);
       };
@@ -145,6 +164,7 @@ export class SupervisionClient {
             socket.destroy();
             return;
           }
+          if (message.type === 'protocol_error') protocolErrorReceived = true;
           if (!subscribed && message.type === 'subscribed') {
             subscribed = true;
             clearTimeout(handshakeTimeout);
@@ -199,7 +219,13 @@ export class SupervisionClient {
       this.#pending.delete(response.request_id);
       clearTimeout(pending.timeout);
       if (response.ok) pending.resolve(response);
-      else pending.reject(new Error(response.error ?? 'Unknown supervision error'));
+      else
+        pending.reject(
+          new SupervisionError(
+            response.error ?? 'Unknown supervision error',
+            response.diagnostic ?? null,
+          ),
+        );
     }
   }
 

--- a/clients/tui/src/generated/protocol.generated.ts
+++ b/clients/tui/src/generated/protocol.generated.ts
@@ -62,6 +62,25 @@ export type RequestId10 = string;
 export type Timestamp10 = string;
 export type Ok = boolean;
 export type Error = string | null;
+export type Id = string;
+export type Code = string;
+export type Summary = string;
+export type Detail = string | null;
+export type Hint = string | null;
+/**
+ * Boundary at which a diagnostic was raised.
+ */
+export type DiagnosticScope = "configuration" | "invocation" | "phase" | "run" | "request" | "protocol" | "transport";
+/**
+ * Operator-visible seriousness of a diagnostic.
+ */
+export type DiagnosticSeverity = "warning" | "error" | "fatal";
+/**
+ * Whether retrying the failed operation is expected to help.
+ */
+export type DiagnosticRetryability = "automatic" | "manual" | "never" | "unknown";
+export type CauseId = string | null;
+export type DebugRef = string | null;
 export type Action = "pause" | "resume" | "steer";
 export type Status = "pending" | "consumed";
 export type Question = string;
@@ -150,7 +169,7 @@ export type Kind6 = "run_interrupted";
 export type Reason = string;
 export type Signal = string | null;
 export type Kind7 = "configuration_failed";
-export type Code = string;
+export type Code1 = string;
 export type Stage = string;
 export type Message = string;
 export type Usage = string | null;
@@ -241,7 +260,7 @@ export type Type12 = "event_batch";
 export type Events1 = RunEvent[];
 export type Type13 = "protocol_error";
 export type RequestId12 = string | null;
-export type Code1 = string;
+export type Code2 = string;
 export type Message1 = string;
 
 export interface ProtocolDocument {
@@ -327,12 +346,28 @@ export interface Response {
   timestamp?: Timestamp10;
   ok?: Ok;
   error?: Error;
+  diagnostic?: Diagnostic | null;
   ack?: CommandAck | null;
   chat?: ChatResult | null;
   snapshot?: RunSnapshot | null;
   events?: Events;
   performance?: Performance;
   experiments?: Experiments;
+}
+/**
+ * Structured, provider-neutral description of an operator diagnostic.
+ */
+export interface Diagnostic {
+  id?: Id;
+  code: Code;
+  summary: Summary;
+  detail?: Detail;
+  hint?: Hint;
+  scope: DiagnosticScope;
+  severity?: DiagnosticSeverity;
+  retryability?: DiagnosticRetryability;
+  cause_id?: CauseId;
+  debug_ref?: DebugRef;
 }
 export interface CommandAck {
   action: Action;
@@ -361,6 +396,7 @@ export interface RunEvent {
   timestamp: Timestamp11;
   type: EventType;
   text?: Text2;
+  diagnostic?: Diagnostic | null;
   status?: EventStatus | null;
   round_label?: RoundLabel1;
   agent_kind?: AgentKind1;
@@ -414,7 +450,7 @@ export interface RunInterruptedData {
 }
 export interface ConfigurationFailedData {
   kind?: Kind7;
-  code: Code;
+  code: Code1;
   stage: Stage;
   message: Message;
   usage?: Usage;
@@ -577,6 +613,7 @@ export interface EventBatchMessage {
 export interface ProtocolErrorMessage {
   type?: Type13;
   request_id?: RequestId12;
-  code: Code1;
+  code: Code2;
   message: Message1;
+  diagnostic?: Diagnostic | null;
 }

--- a/clients/tui/src/generated/protocol.schema.json
+++ b/clients/tui/src/generated/protocol.schema.json
@@ -277,6 +277,125 @@
       "title": "ConfigurationFailedData",
       "type": "object"
     },
+    "Diagnostic": {
+      "additionalProperties": false,
+      "description": "Structured, provider-neutral description of an operator diagnostic.",
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "code": {
+          "title": "Code",
+          "type": "string"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        },
+        "detail": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Detail"
+        },
+        "hint": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hint"
+        },
+        "scope": {
+          "$ref": "#/$defs/DiagnosticScope"
+        },
+        "severity": {
+          "$ref": "#/$defs/DiagnosticSeverity",
+          "default": "error"
+        },
+        "retryability": {
+          "$ref": "#/$defs/DiagnosticRetryability",
+          "default": "unknown"
+        },
+        "cause_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cause Id"
+        },
+        "debug_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Debug Ref"
+        }
+      },
+      "required": [
+        "code",
+        "summary",
+        "scope"
+      ],
+      "title": "Diagnostic",
+      "type": "object"
+    },
+    "DiagnosticRetryability": {
+      "description": "Whether retrying the failed operation is expected to help.",
+      "enum": [
+        "automatic",
+        "manual",
+        "never",
+        "unknown"
+      ],
+      "title": "DiagnosticRetryability",
+      "type": "string"
+    },
+    "DiagnosticScope": {
+      "description": "Boundary at which a diagnostic was raised.",
+      "enum": [
+        "configuration",
+        "invocation",
+        "phase",
+        "run",
+        "request",
+        "protocol",
+        "transport"
+      ],
+      "title": "DiagnosticScope",
+      "type": "string"
+    },
+    "DiagnosticSeverity": {
+      "description": "Operator-visible seriousness of a diagnostic.",
+      "enum": [
+        "warning",
+        "error",
+        "fatal"
+      ],
+      "title": "DiagnosticSeverity",
+      "type": "string"
+    },
     "EventBatchMessage": {
       "additionalProperties": false,
       "properties": {
@@ -957,6 +1076,17 @@
         "message": {
           "title": "Message",
           "type": "string"
+        },
+        "diagnostic": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Diagnostic"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
@@ -1000,6 +1130,17 @@
           ],
           "default": null,
           "title": "Error"
+        },
+        "diagnostic": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Diagnostic"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "ack": {
           "anyOf": [
@@ -1176,6 +1317,17 @@
           "default": "",
           "title": "Text",
           "type": "string"
+        },
+        "diagnostic": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Diagnostic"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "status": {
           "anyOf": [

--- a/clients/tui/src/protocol.ts
+++ b/clients/tui/src/protocol.ts
@@ -5,6 +5,7 @@ export type ProtocolResponse = ProtocolDocument['response'];
 export type RunEvent = ProtocolDocument['event'];
 export type RunSnapshot = ProtocolDocument['snapshot'];
 export type ServerMessage = ProtocolDocument['server_message'];
+export type Diagnostic = NonNullable<ProtocolResponse['diagnostic']>;
 export type HypothesisEntry = NonNullable<ProtocolResponse['experiments']>[number];
 export type HypothesisRound = NonNullable<HypothesisEntry['rounds']>[number];
 

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'bun:test';
-import type {EventSubscription} from './client.js';
+import {type EventSubscription, SupervisionError} from './client.js';
 import type {ProtocolResponse, RequestInput, RunEvent, ServerMessage} from './protocol.js';
 import {SocketSessionController, type SupervisionTransport} from './session-controller.js';
 import {chatPaneVisible, experimentLogVisible} from './session-model.js';
@@ -58,6 +58,59 @@ describe('session controller', () => {
     expect(controller.state.status).toBe('completed');
     expect(controller.state.overlay).toBeNull();
     expect(controller.state.errorBanner).toBeNull();
+  });
+
+  it('prefers structured response and protocol diagnostics over legacy messages', async () => {
+    const diagnostic = {
+      id: 'request-1',
+      code: 'unknown_future_code',
+      summary: 'The requested operation was rejected.',
+      detail: 'PermissionError: missing capability.',
+      hint: 'Request the required capability.',
+      scope: 'request' as const,
+      severity: 'error' as const,
+      retryability: 'manual' as const,
+    };
+    const transport = new FakeTransport(
+      [],
+      [],
+      undefined,
+      new SupervisionError('legacy request message', diagnostic),
+    );
+    const controller = new SocketSessionController(transport);
+
+    await controller.submit('/resume');
+
+    expect(controller.state.errorBanner).toMatchObject({
+      message: diagnostic.summary,
+      detail: diagnostic.detail,
+      hint: diagnostic.hint,
+      diagnosticId: diagnostic.id,
+      scope: 'request',
+    });
+
+    const protocolTransport = new FakeTransport();
+    const protocolController = new SocketSessionController(protocolTransport);
+    await protocolController.start();
+    protocolTransport.emit({
+      type: 'protocol_error',
+      code: 'unknown_protocol_code',
+      message: 'legacy protocol message',
+      diagnostic: {...diagnostic, id: 'protocol-1', scope: 'protocol', severity: 'warning'},
+    });
+
+    expect(protocolController.state.errorBanner).toMatchObject({
+      message: diagnostic.summary,
+      diagnosticId: 'protocol-1',
+      scope: 'protocol',
+      severity: 'recoverable',
+    });
+    protocolTransport.disconnect(new Error('Supervision event stream disconnected'));
+    expect(protocolController.state.errorBanner).toMatchObject({
+      message: diagnostic.summary,
+      diagnosticId: 'protocol-1',
+      scope: 'protocol',
+    });
   });
 
   it('renders a performance curve from the perf command', async () => {
@@ -329,7 +382,7 @@ describe('session controller', () => {
       kind: 'result',
       label: 'Chat failed',
       tone: 'failure',
-      content: 'Error: Codex exited with code 1',
+      content: 'Codex exited with code 1',
     });
   });
 

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -1,4 +1,4 @@
-import type {EventSubscription} from './client.js';
+import {type EventSubscription, SupervisionError} from './client.js';
 import {helpText, parseInput} from './commands.js';
 import {renderPerformanceCurve} from './performance-chart.js';
 import type {ProtocolResponse, RequestInput, RunEvent, ServerMessage} from './protocol.js';
@@ -115,6 +115,7 @@ export class SocketSessionController implements SessionController {
   /** Single-flight guard: phase events arrive faster than the fetch settles. */
   #experimentFetch: Promise<void> | null = null;
   #paneFetch: Promise<void> | null = null;
+  #streamProtocolError = false;
 
   constructor(
     private readonly client: SupervisionTransport,
@@ -132,7 +133,7 @@ export class SocketSessionController implements SessionController {
       const response = await this.client.request({type: 'query.snapshot'});
       if (response.snapshot) this.#setState(applySnapshot(this.#state, response.snapshot));
     } catch (error) {
-      this.#setState(reportError(this.#state, String(error), {scope: 'request'}));
+      this.#setState(reportCaughtError(this.#state, error, 'request'));
     }
     // The log is the landing view, so it is populated before the first frame
     // rather than on demand.
@@ -145,13 +146,13 @@ export class SocketSessionController implements SessionController {
           // A terminal event already carries the actual outcome. The socket
           // closing afterward is lifecycle cleanup, not a second failure that
           // should replace the useful diagnostic in the banner.
-          if (!this.#state.terminal) {
-            this.#setState(reportError(this.#state, String(error), {scope: 'transport'}));
+          if (!this.#state.terminal && !this.#streamProtocolError) {
+            this.#setState(reportCaughtError(this.#state, error, 'transport'));
           }
         },
       );
     } catch (error) {
-      this.#setState(reportError(this.#state, String(error), {scope: 'transport'}));
+      this.#setState(reportCaughtError(this.#state, error, 'transport'));
     }
   }
 
@@ -339,9 +340,8 @@ export class SocketSessionController implements SessionController {
       const content = renderPerformanceCurve(response.performance ?? [], response.events ?? []);
       this.#setState(setPaneContent(this.#state, view, content));
     } catch (error) {
-      this.#setState(
-        reportError(failPane(this.#state, view, String(error)), String(error), {scope: 'request'}),
-      );
+      const message = errorMessage(error);
+      this.#setState(reportCaughtError(failPane(this.#state, view, message), error, 'request'));
     }
   }
 
@@ -387,9 +387,8 @@ export class SocketSessionController implements SessionController {
       const response = await this.client.request({type: 'query.experiments'});
       this.#setState(setExperiments(this.#state, response.experiments ?? []));
     } catch (error) {
-      this.#setState(
-        reportError(failExperiments(this.#state, String(error)), String(error), {scope: 'request'}),
-      );
+      const message = errorMessage(error);
+      this.#setState(reportCaughtError(failExperiments(this.#state, message), error, 'request'));
     }
   }
 
@@ -469,14 +468,15 @@ export class SocketSessionController implements SessionController {
       }
       this.#setState(state);
     } catch (error) {
+      const message = errorMessage(error);
       this.#setState({
-        ...reportError(this.#state, String(error), {scope: 'request'}),
+        ...reportCaughtError(this.#state, error, 'request'),
         chatConversation: appendChatEntry(this.#state.chatConversation, {
           id: `chat-error-${++this.#chatMessageId}`,
           kind: 'result',
           label: 'Chat failed',
           tone: 'failure',
-          content: String(error),
+          content: message,
         }),
       });
     }
@@ -526,7 +526,7 @@ export class SocketSessionController implements SessionController {
       const rendered = renderResponse(parsed.request, response, parsed.responseView);
       if (rendered !== null) this.#setState(showDetail(this.#state, rendered));
     } catch (error) {
-      this.#setState(reportError(this.#state, String(error), {scope: 'request'}));
+      this.#setState(reportCaughtError(this.#state, error, 'request'));
     }
   }
 
@@ -544,7 +544,13 @@ export class SocketSessionController implements SessionController {
       this.#refreshPaneFor(message.events);
     }
     if (message.type === 'protocol_error') {
-      this.#setState(reportError(this.#state, message.message, {scope: 'protocol'}));
+      this.#streamProtocolError = true;
+      this.#setState(
+        reportError(this.#state, message.message, {
+          scope: 'protocol',
+          diagnostic: message.diagnostic ?? null,
+        }),
+      );
     }
   }
 
@@ -570,6 +576,21 @@ export class SocketSessionController implements SessionController {
     this.#state = normalizeFocus(state);
     for (const listener of this.#listeners) listener(this.#state);
   }
+}
+
+function reportCaughtError(
+  state: SessionState,
+  error: unknown,
+  scope: 'request' | 'transport',
+): SessionState {
+  return reportError(state, errorMessage(error), {
+    scope,
+    diagnostic: error instanceof SupervisionError ? error.diagnostic : null,
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function appendChatEntry(

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -146,6 +146,50 @@ describe('session event model', () => {
     });
   });
 
+  it('prefers structured diagnostics and deduplicates their ids across terminal events', () => {
+    let state = applyEvent(initialSessionState(), {
+      ...event(1, 'invocation_finished', {
+        kind: 'invocation_finished',
+        error: 'legacy invocation error',
+      }),
+      text: 'legacy invocation text',
+      diagnostic: {
+        id: 'failure-1',
+        code: 'unrecognized_future_code',
+        summary: 'The worker could not start.',
+        detail: 'PermissionError: sandbox rejected the worker.',
+        hint: 'Check the sandbox permissions.',
+        scope: 'invocation',
+        severity: 'error',
+        retryability: 'manual',
+      },
+    });
+    state = applyEvent(state, {
+      ...event(2, 'run_failed'),
+      text: 'legacy terminal text',
+      diagnostic: {
+        id: 'failure-1',
+        code: 'unrecognized_future_code',
+        summary: 'The worker could not start.',
+        detail: 'PermissionError: sandbox rejected the worker.\nExit code: 1',
+        hint: 'Check the sandbox permissions.',
+        scope: 'invocation',
+        severity: 'fatal',
+        retryability: 'manual',
+      },
+    });
+
+    expect(state.errorBanner).toMatchObject({
+      title: 'Invocation failed',
+      message: 'The worker could not start.',
+      detail: 'PermissionError: sandbox rejected the worker.\nExit code: 1',
+      hint: 'Check the sandbox permissions.',
+      diagnosticId: 'failure-1',
+      severity: 'fatal',
+      count: 2,
+    });
+  });
+
   it('keeps the more detailed terminal message when a failure is deduplicated', () => {
     let state = applyEvent(initialSessionState(), {
       ...event(1, 'invocation_finished', {
@@ -185,18 +229,27 @@ describe('session event model', () => {
   });
 
   it('shows structured interruption details when no event text is present', () => {
-    const state = applyEvent(
-      initialSessionState(),
-      event(1, 'run_interrupted', {
+    const state = applyEvent(initialSessionState(), {
+      ...event(1, 'run_interrupted', {
         kind: 'run_interrupted',
         reason: 'launcher_terminated',
         signal: 'SIGTERM',
       }),
-    );
+      diagnostic: {
+        id: 'interrupted-1',
+        code: 'interrupted',
+        summary: 'Run interrupted',
+        detail: 'RuntimeError: launcher_terminated (SIGTERM)',
+        scope: 'run',
+        severity: 'fatal',
+        retryability: 'never',
+      },
+    });
 
     expect(state.errorBanner).toMatchObject({
       title: 'Run interrupted',
-      message: 'launcher_terminated (SIGTERM)',
+      message: 'Run interrupted',
+      detail: 'RuntimeError: launcher_terminated (SIGTERM)',
       severity: 'fatal',
     });
   });

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -1,4 +1,4 @@
-import type {HypothesisEntry, RunEvent, RunSnapshot} from './protocol.js';
+import type {Diagnostic, HypothesisEntry, RunEvent, RunSnapshot} from './protocol.js';
 import {
   type AgentPhase,
   applyRunMapEvent,
@@ -68,6 +68,7 @@ export type ErrorSeverity = 'recoverable' | 'fatal';
 export type ErrorScope =
   | 'configuration'
   | 'invocation'
+  | 'phase'
   | 'run'
   | 'protocol'
   | 'request'
@@ -76,7 +77,11 @@ export type ErrorScope =
 
 export interface ErrorBannerState {
   title: string;
+  /** Human-facing summary, shown before structured detail and hint. */
   message: string;
+  detail: string | null;
+  hint: string | null;
+  diagnosticId: string | null;
   severity: ErrorSeverity;
   scope: ErrorScope;
   agentKind: string | null;
@@ -839,6 +844,7 @@ export interface ErrorReport {
   scope: ErrorScope;
   severity?: ErrorSeverity;
   title?: string;
+  diagnostic?: Diagnostic | null;
   agentKind?: string | null;
   roundLabel?: string | null;
   invocationId?: string | null;
@@ -854,12 +860,17 @@ export function reportError(
   message: string,
   report: ErrorReport,
 ): SessionState {
-  const severity = report.severity ?? 'recoverable';
+  const diagnostic = report.diagnostic ?? null;
+  const scope = diagnostic?.scope ?? report.scope;
+  const severity = diagnosticSeverity(diagnostic?.severity) ?? report.severity ?? 'recoverable';
   const banner: ErrorBannerState = {
-    title: report.title ?? errorTitle(report.scope),
-    message: message || 'An unknown error occurred.',
+    title: report.title ?? errorTitle(scope),
+    message: diagnostic?.summary || message || 'An unknown error occurred.',
+    detail: diagnostic?.detail ?? null,
+    hint: diagnostic?.hint ?? null,
+    diagnosticId: diagnostic?.id ?? null,
     severity,
-    scope: report.scope,
+    scope,
     agentKind: report.agentKind ?? null,
     roundLabel: report.roundLabel ?? null,
     invocationId: report.invocationId ?? null,
@@ -875,9 +886,12 @@ export function reportError(
     errorBanner: {
       ...existing,
       message: moreInformativeMessage(existing.message, banner.message),
+      detail: moreInformativeMessage(existing.detail ?? '', banner.detail ?? '') || null,
+      hint: moreInformativeMessage(existing.hint ?? '', banner.hint ?? '') || null,
       severity: promoted,
       title: promoted === 'fatal' ? banner.title : existing.title,
       scope: promoted === 'fatal' ? banner.scope : existing.scope,
+      diagnosticId: existing.diagnosticId ?? banner.diagnosticId,
       agentKind: existing.agentKind ?? banner.agentKind,
       roundLabel: existing.roundLabel ?? banner.roundLabel,
       invocationId: existing.invocationId ?? banner.invocationId,
@@ -888,6 +902,16 @@ export function reportError(
 
 function applyFailureEvent(state: SessionState, event: RunEvent): SessionState {
   const data = event.data;
+  if (event.diagnostic !== null && event.diagnostic !== undefined) {
+    return reportError(state, event.text ?? '', {
+      scope: 'protocol',
+      diagnostic: event.diagnostic,
+      ...(event.type === 'run_interrupted' ? {title: 'Run interrupted'} : {}),
+      agentKind: event.agent_kind ?? null,
+      roundLabel: event.round_label ?? null,
+      invocationId: event.invocation_id ?? null,
+    });
+  }
   if (data?.kind === 'configuration_failed') {
     return reportError(state, formatConfigurationFailure(event), {
       scope: 'configuration',
@@ -934,6 +958,7 @@ function moreInformativeMessage(current: string, later: string): string {
 }
 
 function equivalentError(left: ErrorBannerState, right: ErrorBannerState): boolean {
+  if (left.diagnosticId !== null && left.diagnosticId === right.diagnosticId) return true;
   if (left.invocationId !== null && left.invocationId === right.invocationId) return true;
   const leftMessage = left.message.trim();
   const rightMessage = right.message.trim();
@@ -950,6 +975,7 @@ function errorTitle(scope: ErrorScope): string {
   const titles: Record<ErrorScope, string> = {
     configuration: 'Configuration failed',
     invocation: 'Invocation failed',
+    phase: 'Phase failed',
     run: 'Run failed',
     protocol: 'Protocol error',
     request: 'Request failed',
@@ -957,6 +983,13 @@ function errorTitle(scope: ErrorScope): string {
     input: 'Input error',
   };
   return titles[scope];
+}
+
+function diagnosticSeverity(
+  severity: Diagnostic['severity'] | undefined,
+): ErrorSeverity | undefined {
+  if (severity === undefined) return undefined;
+  return severity === 'fatal' ? 'fatal' : 'recoverable';
 }
 
 function formatConfigurationFailure(event: RunEvent): string {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -95,6 +95,9 @@ describe('OpenTUI presentation', () => {
       errorBanner: {
         title: 'Run failed',
         message: 'RuntimeError: app-server initialization was denied\nOperation not permitted',
+        detail: 'The run server exited before accepting a client.',
+        hint: 'Check the startup log and retry.',
+        diagnosticId: 'diagnostic-1',
         severity: 'fatal',
         scope: 'run',
         agentKind: 'orchestrator',
@@ -109,6 +112,8 @@ describe('OpenTUI presentation', () => {
     );
     expect(frame).toContain('Run failed · orchestrator · round-1-pre');
     expect(frame).toContain('Operation not permitted');
+    expect(frame).toContain('Detail: The run server exited before accepting a client.');
+    expect(frame).toContain('Hint: Check the startup log and retry.');
     expect(frame).toContain('Experiments');
 
     expect(frame).toContain('Ctrl+PgUp/PgDn: scroll');

--- a/clients/tui/src/ui/error-banner.ts
+++ b/clients/tui/src/ui/error-banner.ts
@@ -92,6 +92,26 @@ export class ErrorBannerView {
         wrapMode: 'word',
       }),
     );
+    if (banner.detail !== null) {
+      this.#scroll.add(
+        new TextRenderable(this.renderer, {
+          content: `Detail: ${banner.detail}`,
+          fg: this.#theme.textPrimary,
+          width: '100%',
+          wrapMode: 'word',
+        }),
+      );
+    }
+    if (banner.hint !== null) {
+      this.#scroll.add(
+        new TextRenderable(this.renderer, {
+          content: `Hint: ${banner.hint}`,
+          fg: this.#theme.warning,
+          width: '100%',
+          wrapMode: 'word',
+        }),
+      );
+    }
     this.output.add(
       new TextRenderable(this.renderer, {
         content: 'Ctrl+PgUp/PgDn: scroll',

--- a/src/vibesys/server/diagnostics.py
+++ b/src/vibesys/server/diagnostics.py
@@ -1,0 +1,185 @@
+"""Presentation-neutral diagnostics shared by supervision protocol models."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class DiagnosticScope(StrEnum):
+    """Boundary at which a diagnostic was raised."""
+
+    CONFIGURATION = "configuration"
+    INVOCATION = "invocation"
+    PHASE = "phase"
+    RUN = "run"
+    REQUEST = "request"
+    PROTOCOL = "protocol"
+    TRANSPORT = "transport"
+
+
+class DiagnosticSeverity(StrEnum):
+    """Operator-visible seriousness of a diagnostic."""
+
+    WARNING = "warning"
+    ERROR = "error"
+    FATAL = "fatal"
+
+
+class DiagnosticRetryability(StrEnum):
+    """Whether retrying the failed operation is expected to help."""
+
+    AUTOMATIC = "automatic"
+    MANUAL = "manual"
+    NEVER = "never"
+    UNKNOWN = "unknown"
+
+
+class Diagnostic(BaseModel):
+    """Structured, provider-neutral description of an operator diagnostic."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    code: str
+    summary: str
+    detail: str | None = None
+    hint: str | None = None
+    scope: DiagnosticScope
+    severity: DiagnosticSeverity = DiagnosticSeverity.ERROR
+    retryability: DiagnosticRetryability = DiagnosticRetryability.UNKNOWN
+    cause_id: str | None = None
+    debug_ref: str | None = None
+
+    @field_validator("summary", "detail", "hint", mode="before")
+    @classmethod
+    def _redact_text(cls, value: object) -> object:
+        if isinstance(value, str):
+            return redact_diagnostic_text(value)
+        return value
+
+
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?i)(\b(?:[A-Z][A-Z0-9_]*(?:TOKEN|PASSWORD|SECRET|KEY)|"
+    r"api[_-]?key|auth[_-]?token|password|secret|token)\b\s*[:=]\s*)"
+    r"([^\s,;]+)"
+)
+_BEARER_TOKEN = re.compile(r"(?i)(\bbearer\s+)[^\s,;]+")
+
+
+def redact_diagnostic_text(text: str) -> str:
+    """Redact common credential assignments before they cross the UI boundary."""
+    text = _SECRET_ASSIGNMENT.sub(r"\1[REDACTED]", text)
+    return _BEARER_TOKEN.sub(r"\1[REDACTED]", text)
+
+
+def exception_detail(error: BaseException) -> str:
+    """Return sanitized technical detail while retaining exception identity."""
+    return " <- ".join(_exception_fragment(item) for item in _exception_chain(error))
+
+
+def exception_summary(error: BaseException, operation: str = "Operation") -> str:
+    """Map common exceptions to concise, high-level user-facing summaries."""
+    error = _classified_exception(error)
+    for exception_type, summary in (
+        (PermissionError, f"{operation} was denied"),
+        (FileNotFoundError, f"{operation} could not find a required file"),
+        (TimeoutError, f"{operation} timed out"),
+        (ValueError, f"{operation} received invalid input"),
+    ):
+        if isinstance(error, exception_type):
+            return summary
+    return f"{operation} failed"
+
+
+def exception_to_diagnostic(  # noqa: PLR0913  # independent contract dimensions
+    error: BaseException,
+    *,
+    scope: DiagnosticScope
+    | Literal[
+        "configuration",
+        "invocation",
+        "phase",
+        "run",
+        "request",
+        "protocol",
+        "transport",
+    ],
+    operation: str = "Operation",
+    summary: str | None = None,
+    code: str | None = None,
+    hint: str | None = None,
+    severity: DiagnosticSeverity = DiagnosticSeverity.ERROR,
+    retryability: DiagnosticRetryability = DiagnosticRetryability.UNKNOWN,
+    cause_id: str | None = None,
+    debug_ref: str | None = None,
+) -> Diagnostic:
+    """Map an exception to the canonical diagnostic contract."""
+    return Diagnostic(
+        code=code or _default_code(error),
+        summary=summary or exception_summary(error, operation),
+        detail=exception_detail(error),
+        hint=hint,
+        scope=DiagnosticScope(scope),
+        severity=severity,
+        retryability=retryability,
+        cause_id=cause_id,
+        debug_ref=debug_ref,
+    )
+
+
+def _default_code(error: BaseException) -> str:
+    """Provide a deterministic fallback code without exposing exception text."""
+    error = _classified_exception(error)
+    for exception_type, code in (
+        (PermissionError, "permission_denied"),
+        (FileNotFoundError, "not_found"),
+        (TimeoutError, "timeout"),
+        (ValueError, "invalid_value"),
+    ):
+        if isinstance(error, exception_type):
+            return code
+    return "operation_failed"
+
+
+_KNOWN_EXCEPTIONS = (PermissionError, FileNotFoundError, TimeoutError, ValueError)
+_MAX_EXCEPTION_CHAIN = 8
+
+
+def _exception_chain(error: BaseException) -> list[BaseException]:
+    """Follow explicit causes, then unsuppressed contexts, without looping."""
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and len(chain) < _MAX_EXCEPTION_CHAIN:
+        marker = id(current)
+        if marker in seen:
+            break
+        seen.add(marker)
+        chain.append(current)
+        cause = current.__cause__
+        if cause is not None:
+            current = cause
+        elif not current.__suppress_context__:
+            current = current.__context__
+        else:
+            current = None
+    return chain
+
+
+def _classified_exception(error: BaseException) -> BaseException:
+    """Prefer the first known underlying error when wrappers obscure it."""
+    chain = _exception_chain(error)
+    for item in chain:
+        if isinstance(item, _KNOWN_EXCEPTIONS):
+            return item
+    return error
+
+
+def _exception_fragment(error: BaseException) -> str:
+    text = redact_diagnostic_text(str(error).strip())
+    return f"{type(error).__name__}: {text}" if text else type(error).__name__

--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -12,6 +12,8 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, ValidationError
 
+from vibesys.server.diagnostics import Diagnostic
+
 
 class EventType(StrEnum):  # noqa: D101  # tracked: #288
     SERVER_STARTED = "server_started"
@@ -235,6 +237,7 @@ class RunEvent(BaseModel):
     timestamp: datetime
     type: EventType
     text: str = ""
+    diagnostic: Diagnostic | None = None
     status: EventStatus | None = None
     round_label: str | None = None
     agent_kind: str | None = None

--- a/src/vibesys/server/protocol.py
+++ b/src/vibesys/server/protocol.py
@@ -8,6 +8,7 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, FiniteFloat
 
+from vibesys.server.diagnostics import Diagnostic
 from vibesys.server.events import RunEvent
 
 PROTOCOL_VERSION = 1
@@ -169,6 +170,7 @@ class Response(ProtocolModel):  # noqa: D101  # tracked: #288
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
     ok: bool = True
     error: str | None = None
+    diagnostic: Diagnostic | None = None
     ack: CommandAck | None = None
     chat: ChatResult | None = None
     snapshot: RunSnapshot | None = None
@@ -199,6 +201,7 @@ class ProtocolErrorMessage(ProtocolModel):  # noqa: D101  # tracked: #288
     request_id: str | None = None
     code: str
     message: str
+    diagnostic: Diagnostic | None = None
 
 
 ServerMessage = Annotated[

--- a/src/vibesys/server/protocol.py
+++ b/src/vibesys/server/protocol.py
@@ -8,7 +8,7 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, FiniteFloat
 
-from vibesys.server.diagnostics import Diagnostic
+from vibesys.server.diagnostics import Diagnostic, DiagnosticScope, exception_to_diagnostic
 from vibesys.server.events import RunEvent
 
 PROTOCOL_VERSION = 1
@@ -178,6 +178,20 @@ class Response(ProtocolModel):  # noqa: D101  # tracked: #288
     performance: list[PerformanceRound] = Field(default_factory=list)
     experiments: list[HypothesisEntry] = Field(default_factory=list)
 
+    @classmethod
+    def from_exception(
+        cls,
+        request_id: str,
+        error: BaseException,
+        *,
+        operation: str = "Request",
+        scope: DiagnosticScope = DiagnosticScope.REQUEST,
+        code: str | None = None,
+    ) -> Response:
+        """Build a failed response with consistent legacy and typed errors."""
+        diagnostic = exception_to_diagnostic(error, scope=scope, operation=operation, code=code)
+        return cls(request_id=request_id, ok=False, error=diagnostic.summary, diagnostic=diagnostic)
+
 
 class SubscribedMessage(ProtocolModel):  # noqa: D101  # tracked: #288
     type: Literal["subscribed"] = "subscribed"
@@ -202,6 +216,25 @@ class ProtocolErrorMessage(ProtocolModel):  # noqa: D101  # tracked: #288
     code: str
     message: str
     diagnostic: Diagnostic | None = None
+
+    @classmethod
+    def from_exception(
+        cls,
+        error: BaseException,
+        *,
+        request_id: str | None = None,
+        operation: str = "Protocol operation",
+        scope: DiagnosticScope = DiagnosticScope.PROTOCOL,
+        code: str | None = None,
+    ) -> ProtocolErrorMessage:
+        """Build a protocol error with consistent legacy and typed errors."""
+        diagnostic = exception_to_diagnostic(error, scope=scope, operation=operation, code=code)
+        return cls(
+            request_id=request_id,
+            code=diagnostic.code,
+            message=diagnostic.summary,
+            diagnostic=diagnostic,
+        )
 
 
 ServerMessage = Annotated[

--- a/src/vibesys/server/runtime.py
+++ b/src/vibesys/server/runtime.py
@@ -8,6 +8,13 @@ from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any
 
 from vibesys.errors import ConfigurationError
+from vibesys.server.diagnostics import (
+    Diagnostic,
+    DiagnosticRetryability,
+    DiagnosticScope,
+    DiagnosticSeverity,
+    exception_to_diagnostic,
+)
 from vibesys.server.events import (
     ConfigurationFailedData,
     EventStatus,
@@ -50,28 +57,54 @@ def run_server(
             try:
                 value = run()
             except KeyboardInterrupt:
+                launcher_error = RuntimeError("launcher_terminated (SIGTERM)")
+                event_diagnostic = exception_to_diagnostic(
+                    launcher_error,
+                    scope=DiagnosticScope.RUN,
+                    operation="Run",
+                    summary="Run interrupted",
+                    code="interrupted",
+                    severity=DiagnosticSeverity.FATAL,
+                    retryability=DiagnosticRetryability.NEVER,
+                )
                 supervisor.record(
                     EventType.RUN_INTERRUPTED,
                     status=EventStatus.FAILED,
                     data=RunInterruptedData(reason="launcher_terminated", signal="SIGTERM"),
+                    diagnostic=event_diagnostic,
                 )
-                supervisor.finish(RuntimeError("Run interrupted by launcher"))
+                supervisor.finish(launcher_error, diagnostic=event_diagnostic)
                 raise
             except ConfigurationError as exc:
-                diagnostic = exc.diagnostic
+                configuration_diagnostic = exc.diagnostic
+                event_diagnostic = Diagnostic(
+                    code=configuration_diagnostic.code,
+                    summary=configuration_diagnostic.message,
+                    detail=(
+                        f"Stage: {configuration_diagnostic.stage}\n"
+                        f"Exit code: {configuration_diagnostic.exit_code}"
+                    ),
+                    hint=configuration_diagnostic.usage,
+                    scope=DiagnosticScope.CONFIGURATION,
+                    severity=DiagnosticSeverity.FATAL,
+                    retryability=DiagnosticRetryability.NEVER,
+                )
+                configuration_message = event_diagnostic.summary
+                configuration_usage = event_diagnostic.hint
                 supervisor.record(
                     EventType.CONFIGURATION_FAILED,
-                    diagnostic.message,
+                    configuration_message,
                     status=EventStatus.FAILED,
                     data=ConfigurationFailedData(
-                        code=diagnostic.code,
-                        stage=diagnostic.stage,
-                        message=diagnostic.message,
-                        usage=diagnostic.usage,
-                        exit_code=diagnostic.exit_code,
+                        code=configuration_diagnostic.code,
+                        stage=configuration_diagnostic.stage,
+                        message=configuration_message,
+                        usage=configuration_usage,
+                        exit_code=configuration_diagnostic.exit_code,
                     ),
+                    diagnostic=event_diagnostic,
                 )
-                supervisor.finish(exc, record_event=False)
+                supervisor.finish(exc, record_event=False, diagnostic=event_diagnostic)
                 server.wait_for_subscriber_disconnect()
                 raise
             except BaseException as exc:

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Generator  # noqa: TC003  # tracked: #288
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003  # tracked: #288
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from vibesys.server.diagnostics import (
     Diagnostic,
@@ -39,6 +39,16 @@ from vibesys.server.events import (
 from vibesys.server.protocol import RunSnapshot
 
 _MAX_EXCEPTION_CHAIN = 8
+_DIAGNOSTIC_FAILURE_EVENTS = frozenset(
+    {
+        EventType.CONFIGURATION_FAILED,
+        EventType.INVOCATION_FINISHED,
+        EventType.PHASE_FINISHED,
+        EventType.RUN_FAILED,
+        EventType.RUN_INTERRUPTED,
+    }
+)
+_NONTERMINAL_FAILURE_EVENTS = frozenset({EventType.INVOCATION_FINISHED, EventType.PHASE_FINISHED})
 
 if TYPE_CHECKING:
     from vs_project import Project, StateSnapshot
@@ -189,7 +199,13 @@ class RunSupervisor:
         *,
         data: EventData | None = None,
         **fields: Any,  # noqa: ANN401  # tracked: #288
-    ) -> RunEvent | None:
+    ) -> RunEvent:
+        if (
+            event_type in _DIAGNOSTIC_FAILURE_EVENTS
+            and fields.get("status") in {EventStatus.FAILED, EventStatus.FAILED.value}
+            and fields.get("diagnostic") is None
+        ):
+            raise ValueError(f"Failed {event_type.value} events must include a diagnostic")  # noqa: TRY003  # contract violation, not a user-facing error
         event = make_event(event_type, text, data=data, **fields)
         with self._condition:
             store = self._store
@@ -201,6 +217,104 @@ class RunSupervisor:
         if audit_store is not None:
             audit_store.append(event)
         return recorded
+
+    def record_failure(  # noqa: PLR0913  # failure event fields belong at this boundary
+        self,
+        event_type: EventType,
+        error: BaseException,
+        *,
+        scope: DiagnosticScope,
+        operation: str,
+        data: EventData | Callable[[Diagnostic], EventData] | None = None,
+        text: str | None = None,
+        severity: DiagnosticSeverity = DiagnosticSeverity.ERROR,
+        diagnostic: Diagnostic | None = None,
+        **fields: Any,  # noqa: ANN401  # tracked: #288
+    ) -> RunEvent:
+        """Record a failed operational event with its canonical diagnostic.
+
+        This API handles nonterminal invocation and phase boundaries. Pass an
+        existing diagnostic when related events must share an identity.
+        Terminal failures remain owned by ``finish`` and ``run_server``.
+        """
+        if event_type not in _NONTERMINAL_FAILURE_EVENTS:
+            raise ValueError(f"Cannot record {event_type.value} without owning run termination")  # noqa: TRY003  # contract violation, not a user-facing error
+        return self._record_failure_event(
+            event_type,
+            error,
+            scope=scope,
+            operation=operation,
+            data=data,
+            text=text,
+            severity=severity,
+            diagnostic=diagnostic,
+            **fields,
+        )
+
+    def _record_failure_event(  # noqa: PLR0913  # failure event fields belong at this boundary
+        self,
+        event_type: EventType,
+        error: BaseException,
+        *,
+        scope: DiagnosticScope,
+        operation: str,
+        data: EventData | Callable[[Diagnostic], EventData] | None = None,
+        text: str | None = None,
+        severity: DiagnosticSeverity = DiagnosticSeverity.ERROR,
+        diagnostic: Diagnostic | None = None,
+        **fields: Any,  # noqa: ANN401  # tracked: #288
+    ) -> RunEvent:
+        """Record an operational failure after its lifecycle owner is known."""
+        if event_type not in _DIAGNOSTIC_FAILURE_EVENTS:
+            raise ValueError(f"{event_type.value} is not an operational failure event")  # noqa: TRY003  # contract violation, not a user-facing error
+        diagnostic = diagnostic or self._diagnostic_for(error, scope, operation=operation)
+        if diagnostic.severity is not severity:
+            diagnostic = diagnostic.model_copy(update={"severity": severity})
+        event_data = data(diagnostic) if callable(data) else data
+        return self.record(
+            event_type,
+            diagnostic.summary if text is None else text,
+            status=EventStatus.FAILED,
+            data=event_data,
+            diagnostic=diagnostic,
+            **fields,
+        )
+
+    @contextmanager
+    def capture_failure(  # noqa: PLR0913  # failure event fields belong at this boundary
+        self,
+        *,
+        event_type: EventType,
+        scope: DiagnosticScope,
+        operation: str,
+        data: EventData | Callable[[Diagnostic], EventData] | None = None,
+        text: str | None = None,
+        severity: DiagnosticSeverity = DiagnosticSeverity.ERROR,
+        **fields: Any,  # noqa: ANN401  # tracked: #288
+    ) -> Generator[None]:
+        """Capture one independent background operation's failure.
+
+        Use only for new entry points without an existing failure boundary.
+        Do not wrap LoopContext agent calls or ``run_server``: ``after_agent``
+        and ``finish`` already record those failures. This helper records one
+        failure and re-raises it, but never finishes the run.
+        """
+        if event_type not in _NONTERMINAL_FAILURE_EVENTS:
+            raise ValueError(f"Cannot capture {event_type.value} without owning run termination")  # noqa: TRY003  # contract violation, not a user-facing error
+        try:
+            yield
+        except BaseException as error:
+            self.record_failure(
+                event_type,
+                error,
+                scope=scope,
+                operation=operation,
+                data=data,
+                text=text,
+                severity=severity,
+                **fields,
+            )
+            raise
 
     def read_events(self, after_sequence: int = 0) -> list[RunEvent]:  # noqa: D102  # tracked: #288
         store = self._store
@@ -377,31 +491,49 @@ class RunSupervisor:
                 self._pause_after_call = False
                 self._paused = True
 
-        diagnostic = (
-            self._diagnostic_for(error, DiagnosticScope.INVOCATION, operation="Agent invocation")
-            if error
-            else None
-        )
-        self.record(
-            EventType.INVOCATION_FINISHED,
-            status=EventStatus.FAILED if error else EventStatus.COMPLETED,
-            agent_kind=kind,
-            round_label=round_label,
-            invocation_id=invocation_id,
-            data=InvocationFinishedData(
-                result=json_value(result), error=diagnostic.summary if diagnostic else None
-            ),
-            diagnostic=diagnostic,
-        )
-        self.record(
-            EventType.PHASE_FINISHED,
-            status=EventStatus.FAILED if error else EventStatus.COMPLETED,
-            agent_kind=kind,
-            round_label=round_label,
-            invocation_id=invocation_id,
-            data=PhaseData(phase=kind, attempt=_attempt_from_label(round_label)),
-            diagnostic=diagnostic,
-        )
+        phase = PhaseData(phase=kind, attempt=_attempt_from_label(round_label))
+        if error is not None:
+            invocation_event = self.record_failure(
+                EventType.INVOCATION_FINISHED,
+                error,
+                scope=DiagnosticScope.INVOCATION,
+                operation="Agent invocation",
+                data=lambda diagnostic: InvocationFinishedData(
+                    result=json_value(result), error=diagnostic.summary
+                ),
+                agent_kind=kind,
+                round_label=round_label,
+                invocation_id=invocation_id,
+            )
+            invocation_diagnostic = cast("Diagnostic", invocation_event.diagnostic)
+            self.record_failure(
+                EventType.PHASE_FINISHED,
+                error,
+                scope=DiagnosticScope.INVOCATION,
+                operation="Agent invocation",
+                data=phase,
+                diagnostic=invocation_diagnostic,
+                agent_kind=kind,
+                round_label=round_label,
+                invocation_id=invocation_id,
+            )
+        else:
+            self.record(
+                EventType.INVOCATION_FINISHED,
+                status=EventStatus.COMPLETED,
+                data=InvocationFinishedData(result=json_value(result)),
+                agent_kind=kind,
+                round_label=round_label,
+                invocation_id=invocation_id,
+            )
+            self.record(
+                EventType.PHASE_FINISHED,
+                status=EventStatus.COMPLETED,
+                data=phase,
+                agent_kind=kind,
+                round_label=round_label,
+                invocation_id=invocation_id,
+            )
         if should_pause:
             self.record(
                 EventType.CONTROL,
@@ -426,9 +558,13 @@ class RunSupervisor:
         record_event: bool = True,
         diagnostic: Diagnostic | None = None,
     ) -> None:
-        event_diagnostic = diagnostic or (
-            self._diagnostic_for(error, DiagnosticScope.RUN, operation="Run") if error else None
-        )
+        with self._condition:
+            if self._run_status in {"completed", "failed"}:
+                return
+            self._run_status = "failed" if error else "completed"
+            self._condition.notify_all()
+
+        event_diagnostic = diagnostic
         if error is not None and event_diagnostic is not None:
             # A terminal run failure is fatal, but it may originate at an
             # earlier boundary. Preserve that origin and stable identity so
@@ -436,18 +572,27 @@ class RunSupervisor:
             event_diagnostic = event_diagnostic.model_copy(
                 update={"severity": DiagnosticSeverity.FATAL}
             )
-        with self._condition:
-            self._run_status = "failed" if error else "completed"
-            self._condition.notify_all()
-            self._error_diagnostics.clear()
-        if not record_event:
-            return
-        self.record(
-            EventType.RUN_FAILED if error else EventType.RUN_FINISHED,
-            event_diagnostic.summary if event_diagnostic else "",
-            status=EventStatus.FAILED if error else EventStatus.COMPLETED,
-            diagnostic=event_diagnostic,
-        )
+        try:
+            if not record_event:
+                return
+            if error is not None and event_diagnostic is None:
+                self._record_failure_event(
+                    EventType.RUN_FAILED,
+                    error,
+                    scope=DiagnosticScope.RUN,
+                    operation="Run",
+                    severity=DiagnosticSeverity.FATAL,
+                )
+                return
+            self.record(
+                EventType.RUN_FAILED if error else EventType.RUN_FINISHED,
+                event_diagnostic.summary if event_diagnostic else "",
+                status=EventStatus.FAILED if error else EventStatus.COMPLETED,
+                diagnostic=event_diagnostic,
+            )
+        finally:
+            with self._condition:
+                self._error_diagnostics.clear()
 
     def _diagnostic_for(
         self, error: BaseException, scope: DiagnosticScope, *, operation: str

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -11,6 +11,14 @@ from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import TYPE_CHECKING, Any
 
+from vibesys.server.diagnostics import (
+    Diagnostic,
+    DiagnosticRetryability,
+    DiagnosticScope,
+    DiagnosticSeverity,
+    exception_detail,
+    exception_to_diagnostic,
+)
 from vibesys.server.events import (
     AgentOutputChannel,
     AgentOutputChunkData,
@@ -29,6 +37,8 @@ from vibesys.server.events import (
     make_event,
 )
 from vibesys.server.protocol import RunSnapshot
+
+_MAX_EXCEPTION_CHAIN = 8
 
 if TYPE_CHECKING:
     from vs_project import Project, StateSnapshot
@@ -68,6 +78,10 @@ class RunSupervisor:
         self._current_round: str | None = None
         self._chat_handler: Callable[[str], str] | None = None
         self._presentation_local = threading.local()
+        # An invocation and its terminal run failure often carry the same
+        # exception. Keep one diagnostic object so both events identify the
+        # same operator-visible failure without reformatting it at each layer.
+        self._error_diagnostics: dict[int, tuple[BaseException, Diagnostic]] = {}
 
     @property
     def current_round(self) -> str | None:  # noqa: D102  # tracked: #288
@@ -363,6 +377,11 @@ class RunSupervisor:
                 self._pause_after_call = False
                 self._paused = True
 
+        diagnostic = (
+            self._diagnostic_for(error, DiagnosticScope.INVOCATION, operation="Agent invocation")
+            if error
+            else None
+        )
         self.record(
             EventType.INVOCATION_FINISHED,
             status=EventStatus.FAILED if error else EventStatus.COMPLETED,
@@ -370,8 +389,9 @@ class RunSupervisor:
             round_label=round_label,
             invocation_id=invocation_id,
             data=InvocationFinishedData(
-                result=json_value(result), error=repr(error) if error else None
+                result=json_value(result), error=diagnostic.summary if diagnostic else None
             ),
+            diagnostic=diagnostic,
         )
         self.record(
             EventType.PHASE_FINISHED,
@@ -380,6 +400,7 @@ class RunSupervisor:
             round_label=round_label,
             invocation_id=invocation_id,
             data=PhaseData(phase=kind, attempt=_attempt_from_label(round_label)),
+            diagnostic=diagnostic,
         )
         if should_pause:
             self.record(
@@ -398,22 +419,86 @@ class RunSupervisor:
             round_label = self._current_round or "no round yet"
         return f"{state} · {kind} · {round_label}"
 
-    def finish(self, error: BaseException | None = None, *, record_event: bool = True) -> None:  # noqa: D102  # tracked: #288
+    def finish(  # noqa: D102  # tracked: #288
+        self,
+        error: BaseException | None = None,
+        *,
+        record_event: bool = True,
+        diagnostic: Diagnostic | None = None,
+    ) -> None:
+        event_diagnostic = diagnostic or (
+            self._diagnostic_for(error, DiagnosticScope.RUN, operation="Run") if error else None
+        )
+        if error is not None and event_diagnostic is not None:
+            # A terminal run failure is fatal, but it may originate at an
+            # earlier boundary. Preserve that origin and stable identity so
+            # consumers can coalesce the invocation, phase, and run events.
+            event_diagnostic = event_diagnostic.model_copy(
+                update={"severity": DiagnosticSeverity.FATAL}
+            )
         with self._condition:
             self._run_status = "failed" if error else "completed"
             self._condition.notify_all()
+            self._error_diagnostics.clear()
         if not record_event:
             return
         self.record(
             EventType.RUN_FAILED if error else EventType.RUN_FINISHED,
-            repr(error) if error else "",
+            event_diagnostic.summary if event_diagnostic else "",
             status=EventStatus.FAILED if error else EventStatus.COMPLETED,
+            diagnostic=event_diagnostic,
         )
+
+    def _diagnostic_for(
+        self, error: BaseException, scope: DiagnosticScope, *, operation: str
+    ) -> Diagnostic:
+        """Return the canonical diagnostic for one exception instance."""
+        key = id(error)
+        with self._condition:
+            for item in _exception_chain(error):
+                cached = self._error_diagnostics.get(id(item))
+                if cached is None or cached[0] is not item:
+                    continue
+                if item is error:
+                    return cached[1]
+                diagnostic = cached[1].model_copy(update={"detail": exception_detail(error)})
+                self._error_diagnostics[key] = (error, diagnostic)
+                return diagnostic
+        diagnostic = exception_to_diagnostic(
+            error,
+            scope=scope,
+            operation=operation,
+            severity=DiagnosticSeverity.ERROR,
+            retryability=DiagnosticRetryability.UNKNOWN,
+        )
+        with self._condition:
+            self._error_diagnostics[key] = (error, diagnostic)
+        return diagnostic
 
 
 def _attempt_from_label(round_label: str) -> int | None:
     match = re.search(r"retry-(\d+)", round_label)
     return int(match.group(1)) if match else None
+
+
+def _exception_chain(error: BaseException) -> list[BaseException]:
+    """Follow causes and contexts without depending on diagnostic internals."""
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and len(chain) < _MAX_EXCEPTION_CHAIN:
+        marker = id(current)
+        if marker in seen:
+            break
+        seen.add(marker)
+        chain.append(current)
+        if current.__cause__ is not None:
+            current = current.__cause__
+        elif not current.__suppress_context__:
+            current = current.__context__
+        else:
+            current = None
+    return chain
 
 
 def _with_steering(user_prompt: str, messages: list[str]) -> str:

--- a/src/vibesys/server/transport.py
+++ b/src/vibesys/server/transport.py
@@ -8,13 +8,16 @@ import socket
 import socketserver
 import threading
 import time
+from contextlib import suppress
 from pathlib import Path  # noqa: TC003  # tracked: #288
 
 from pydantic import BaseModel, TypeAdapter
 
+from vibesys.server.diagnostics import DiagnosticScope, exception_to_diagnostic
 from vibesys.server.protocol import (
     EventBatchMessage,
     EventMessage,
+    ProtocolErrorMessage,
     ProtocolRequest,
     Response,
     SubscribedMessage,
@@ -40,15 +43,23 @@ class _RequestHandler(socketserver.StreamRequestHandler):
                         self._stream(request)
                     except (BrokenPipeError, ConnectionResetError):
                         pass
+                    except Exception as exc:  # noqa: BLE001  # tracked: #288
+                        self._write_stream_error(request.request_id, exc)
                     finally:
                         self.server.client_disconnected.set()  # type: ignore[attr-defined]
                     return
                 response = service.execute(request)
             except Exception as exc:  # noqa: BLE001  # tracked: #288
+                diagnostic = exception_to_diagnostic(
+                    exc,
+                    scope=DiagnosticScope.REQUEST,
+                    operation="Request",
+                )
                 response = Response(
                     request_id=request_id,
                     ok=False,
-                    error=str(exc),
+                    error=diagnostic.summary,
+                    diagnostic=diagnostic,
                 )
             self.wfile.write(response.model_dump_json().encode() + b"\n")
             self.wfile.flush()
@@ -78,6 +89,24 @@ class _RequestHandler(socketserver.StreamRequestHandler):
             for event in events:
                 self._write_message(EventMessage(event=event))
                 cursor = event.sequence
+
+    def _write_stream_error(self, request_id: str, error: Exception) -> None:
+        """Report a replay or stream failure without hiding a live connection."""
+        diagnostic = exception_to_diagnostic(
+            error,
+            scope=DiagnosticScope.PROTOCOL,
+            operation="Event stream",
+            code="stream_failed",
+        )
+        with suppress(BrokenPipeError, ConnectionResetError):
+            self._write_message(
+                ProtocolErrorMessage(
+                    request_id=request_id,
+                    code=diagnostic.code,
+                    message=diagnostic.summary,
+                    diagnostic=diagnostic,
+                )
+            )
 
     def _client_disconnected(self) -> bool:
         try:

--- a/src/vibesys/server/transport.py
+++ b/src/vibesys/server/transport.py
@@ -13,7 +13,6 @@ from pathlib import Path  # noqa: TC003  # tracked: #288
 
 from pydantic import BaseModel, TypeAdapter
 
-from vibesys.server.diagnostics import DiagnosticScope, exception_to_diagnostic
 from vibesys.server.protocol import (
     EventBatchMessage,
     EventMessage,
@@ -50,16 +49,10 @@ class _RequestHandler(socketserver.StreamRequestHandler):
                     return
                 response = service.execute(request)
             except Exception as exc:  # noqa: BLE001  # tracked: #288
-                diagnostic = exception_to_diagnostic(
+                response = Response.from_exception(
+                    request_id,
                     exc,
-                    scope=DiagnosticScope.REQUEST,
                     operation="Request",
-                )
-                response = Response(
-                    request_id=request_id,
-                    ok=False,
-                    error=diagnostic.summary,
-                    diagnostic=diagnostic,
                 )
             self.wfile.write(response.model_dump_json().encode() + b"\n")
             self.wfile.flush()
@@ -92,21 +85,14 @@ class _RequestHandler(socketserver.StreamRequestHandler):
 
     def _write_stream_error(self, request_id: str, error: Exception) -> None:
         """Report a replay or stream failure without hiding a live connection."""
-        diagnostic = exception_to_diagnostic(
+        protocol_error = ProtocolErrorMessage.from_exception(
             error,
-            scope=DiagnosticScope.PROTOCOL,
             operation="Event stream",
             code="stream_failed",
+            request_id=request_id,
         )
         with suppress(BrokenPipeError, ConnectionResetError):
-            self._write_message(
-                ProtocolErrorMessage(
-                    request_id=request_id,
-                    code=diagnostic.code,
-                    message=diagnostic.summary,
-                    diagnostic=diagnostic,
-                )
-            )
+            self._write_message(protocol_error)
 
     def _client_disconnected(self) -> bool:
         try:

--- a/tests/server/test_diagnostics.py
+++ b/tests/server/test_diagnostics.py
@@ -1,0 +1,132 @@
+"""Tests for the shared supervision diagnostic contract."""
+
+from vibesys.server.diagnostics import (
+    Diagnostic,
+    DiagnosticRetryability,
+    DiagnosticScope,
+    DiagnosticSeverity,
+    exception_detail,
+    exception_to_diagnostic,
+    redact_diagnostic_text,
+)
+from vibesys.server.events import EventType, RunEvent, make_event
+from vibesys.server.protocol import ProtocolErrorMessage, Response
+
+
+def test_diagnostic_round_trips_on_protocol_and_event_models() -> None:
+    diagnostic = Diagnostic(
+        code="permission_denied",
+        summary="The operation was denied",
+        detail="PermissionError: sandbox rejected the operation",
+        scope=DiagnosticScope.INVOCATION,
+        severity=DiagnosticSeverity.FATAL,
+        retryability=DiagnosticRetryability.NEVER,
+        hint="Check the sandbox permissions.",
+        debug_ref="run-events.jsonl:12",
+    )
+
+    response = Response(
+        request_id="request", ok=False, error=diagnostic.summary, diagnostic=diagnostic
+    )
+    restored_response = Response.model_validate_json(response.model_dump_json())
+    assert restored_response.diagnostic == diagnostic
+
+    protocol_error = ProtocolErrorMessage(
+        code="request_failed", message=diagnostic.summary, diagnostic=diagnostic
+    )
+    assert (
+        ProtocolErrorMessage.model_validate_json(protocol_error.model_dump_json()).diagnostic
+        == diagnostic
+    )
+
+    event = make_event(EventType.RUN_FAILED, diagnostic.summary, diagnostic=diagnostic)
+    restored_event = RunEvent.model_validate_json(event.model_dump_json())
+    assert restored_event.diagnostic == diagnostic
+
+
+def test_legacy_payloads_without_diagnostic_still_parse() -> None:
+    response = Response.model_validate_json('{"request_id":"request","ok":false,"error":"failed"}')
+    assert response.diagnostic is None
+    event = RunEvent.model_validate_json(
+        '{"protocol_version":1,"timestamp":"2026-01-01T00:00:00Z","type":"run_failed","text":"failed"}'
+    )
+    assert event.diagnostic is None
+
+
+def test_exception_conversion_maps_type_and_redacts_credentials() -> None:
+    diagnostic = exception_to_diagnostic(
+        PermissionError("token=abc123 Bearer secret-value"),
+        scope=DiagnosticScope.TRANSPORT,
+        operation="Codex startup",
+        retryability=DiagnosticRetryability.MANUAL,
+    )
+    assert diagnostic.code == "permission_denied"
+    assert diagnostic.summary == "Codex startup was denied"
+    assert diagnostic.detail == "PermissionError: token=[REDACTED] Bearer [REDACTED]"
+    assert diagnostic.summary != diagnostic.detail
+    assert diagnostic.scope is DiagnosticScope.TRANSPORT
+    assert diagnostic.severity is DiagnosticSeverity.ERROR
+    assert diagnostic.retryability is DiagnosticRetryability.MANUAL
+
+
+def test_exception_conversion_classifies_wrapped_known_exception_and_keeps_chain() -> None:
+    cause = PermissionError("OPENAI_API_KEY=secret")
+    wrapped = RuntimeError("agent startup failed")
+    wrapped.__cause__ = cause
+
+    diagnostic = exception_to_diagnostic(
+        wrapped, scope=DiagnosticScope.INVOCATION, operation="Agent startup"
+    )
+    assert diagnostic.code == "permission_denied"
+    assert diagnostic.summary == "Agent startup was denied"
+    assert diagnostic.detail == (
+        "RuntimeError: agent startup failed <- PermissionError: OPENAI_API_KEY=[REDACTED]"
+    )
+
+
+def test_exception_conversion_uses_unsuppressed_context_and_bounds_cycles() -> None:
+    outer = RuntimeError("outer")
+    inner = TimeoutError("inner")
+    outer.__context__ = inner
+    inner.__context__ = outer
+    diagnostic = exception_to_diagnostic(outer, scope=DiagnosticScope.RUN, operation="Run")
+    assert diagnostic.code == "timeout"
+    assert diagnostic.detail == "RuntimeError: outer <- TimeoutError: inner"
+
+
+def test_exception_conversion_maps_known_exception_subclasses() -> None:
+    class SandboxPermissionError(PermissionError):
+        pass
+
+    diagnostic = exception_to_diagnostic(
+        SandboxPermissionError("denied"),
+        scope=DiagnosticScope.INVOCATION,
+        operation="Sandbox setup",
+    )
+    assert diagnostic.code == "permission_denied"
+    assert diagnostic.summary == "Sandbox setup was denied"
+
+
+def test_diagnostic_redacts_explicit_text_on_construction_and_round_trip() -> None:
+    diagnostic = Diagnostic(
+        code="provider_failed",
+        summary="OPENAI_API_KEY=summary-secret",
+        detail="AWS_SECRET_ACCESS_KEY=detail-secret",
+        hint="Use FOO_TOKEN=hint-secret",
+        scope=DiagnosticScope.REQUEST,
+    )
+    assert diagnostic.summary == "OPENAI_API_KEY=[REDACTED]"
+    assert diagnostic.detail == "AWS_SECRET_ACCESS_KEY=[REDACTED]"
+    assert diagnostic.hint == "Use FOO_TOKEN=[REDACTED]"
+
+    restored = Diagnostic.model_validate_json(diagnostic.model_dump_json())
+    assert restored == diagnostic
+
+
+def test_empty_exception_uses_exception_type_as_user_message() -> None:
+    assert exception_detail(RuntimeError()) == "RuntimeError"
+    assert (
+        exception_to_diagnostic(TimeoutError(), scope=DiagnosticScope.RUN, operation="Run").summary
+        == "Run timed out"
+    )
+    assert redact_diagnostic_text("password: hidden") == "password: [REDACTED]"

--- a/tests/server/test_diagnostics.py
+++ b/tests/server/test_diagnostics.py
@@ -123,6 +123,24 @@ def test_diagnostic_redacts_explicit_text_on_construction_and_round_trip() -> No
     assert restored == diagnostic
 
 
+def test_failure_factories_keep_legacy_fields_consistent_and_sanitized() -> None:
+    error = PermissionError("OPENAI_API_KEY=secret")
+    response = Response.from_exception("request", error, operation="Codex startup")
+    assert response.ok is False
+    assert response.diagnostic is not None
+    assert response.error == response.diagnostic.summary
+    assert response.error == "Codex startup was denied"
+    assert response.diagnostic.detail == "PermissionError: OPENAI_API_KEY=[REDACTED]"
+
+    protocol_error = ProtocolErrorMessage.from_exception(
+        error, request_id="request", operation="Event stream", code="stream_failed"
+    )
+    assert protocol_error.diagnostic is not None
+    assert protocol_error.code == protocol_error.diagnostic.code == "stream_failed"
+    assert protocol_error.message == protocol_error.diagnostic.summary
+    assert "secret" not in protocol_error.model_dump_json()
+
+
 def test_empty_exception_uses_exception_type_as_user_message() -> None:
     assert exception_detail(RuntimeError()) == "RuntimeError"
     assert (

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -20,6 +20,11 @@ from vibesys.server import (
     RunInspector,
     RunSupervisor,
 )
+from vibesys.server.diagnostics import (
+    DiagnosticRetryability,
+    DiagnosticScope,
+    DiagnosticSeverity,
+)
 from vibesys.server.events import ConfigurationFailedData
 from vibesys.server.protocol import (
     ChatQuery,
@@ -389,6 +394,77 @@ def test_chat_reports_structured_failed_invocation(tmp_path):  # noqa: ANN001, A
     assert "agent process exited" in answer
 
 
+def test_failure_events_share_and_promote_a_human_facing_diagnostic(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    error = RuntimeError("token=super-secret agent process exited")
+    supervisor.before_agent("implementer", "round 5", "prompt")
+    supervisor.after_agent("implementer", "round 5", error=error)
+    supervisor.finish(error)
+
+    invocation, phase, terminal = [
+        event
+        for event in supervisor.read_events()
+        if event.type
+        in {
+            EventType.INVOCATION_FINISHED,
+            EventType.PHASE_FINISHED,
+            EventType.RUN_FAILED,
+        }
+    ]
+    assert invocation.diagnostic is not None
+    assert phase.diagnostic == invocation.diagnostic
+    assert terminal.diagnostic is not None
+    assert terminal.diagnostic.id == invocation.diagnostic.id
+    assert terminal.diagnostic.scope is DiagnosticScope.INVOCATION
+    assert terminal.diagnostic.summary == invocation.diagnostic.summary
+    assert terminal.diagnostic.detail == invocation.diagnostic.detail
+    assert invocation.diagnostic.severity is DiagnosticSeverity.ERROR
+    assert terminal.diagnostic.severity is DiagnosticSeverity.FATAL
+    assert terminal.diagnostic.retryability is DiagnosticRetryability.UNKNOWN
+    assert invocation.data.error == "Agent invocation failed"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    assert terminal.text == "Agent invocation failed"
+    assert terminal.diagnostic.detail == "RuntimeError: token=[REDACTED] agent process exited"
+    assert "RuntimeError(" not in terminal.text
+
+
+def test_generic_run_failure_is_fatal_with_unknown_retryability(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.finish(RuntimeError("worker failed"))
+
+    terminal = next(
+        event for event in supervisor.read_events() if event.type is EventType.RUN_FAILED
+    )
+    assert terminal.diagnostic is not None
+    assert terminal.diagnostic.scope is DiagnosticScope.RUN
+    assert terminal.diagnostic.severity is DiagnosticSeverity.FATAL
+    assert terminal.diagnostic.retryability is DiagnosticRetryability.UNKNOWN
+
+
+def test_terminal_wrapper_reuses_an_invocation_diagnostic(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    cause = RuntimeError("token=super-secret agent process exited")
+    supervisor.before_agent("implementer", "round 5", "prompt")
+    supervisor.after_agent("implementer", "round 5", error=cause)
+    wrapper = RuntimeError("run cleanup failed")
+    wrapper.__cause__ = cause
+    supervisor.finish(wrapper)
+
+    invocation, terminal = [
+        event
+        for event in supervisor.read_events()
+        if event.type in {EventType.INVOCATION_FINISHED, EventType.RUN_FAILED}
+    ]
+    assert invocation.diagnostic is not None
+    assert terminal.diagnostic is not None
+    assert terminal.diagnostic.id == invocation.diagnostic.id
+    assert terminal.diagnostic.detail == (
+        "RuntimeError: run cleanup failed <- RuntimeError: token=[REDACTED] agent process exited"
+    )
+
+
 def test_service_accepts_chat(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     (tmp_path / "logs").mkdir()
     supervisor = RunSupervisor()
@@ -585,7 +661,9 @@ def test_socket_transport_returns_clear_chat_agent_errors(tmp_path):  # noqa: AN
     supervisor.attach(tmp_path / "logs")
 
     def fail_chat(question: str) -> str:
-        raise RuntimeError(f"Chat agent failed while answering: {question}")  # noqa: TRY003  # tracked: #288
+        raise RuntimeError(  # noqa: TRY003  # tracked: #288
+            f"token=super-secret Chat agent failed while answering: {question}"
+        )
 
     supervisor.set_chat_handler(fail_chat)
     socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"  # noqa: S108  # tracked: #288
@@ -599,7 +677,13 @@ def test_socket_transport_returns_clear_chat_agent_errors(tmp_path):  # noqa: AN
             response = json.loads(stream.readline())
 
     assert response["ok"] is False
-    assert response["error"] == "Chat agent failed while answering: what happened?"
+    assert response["error"] == "Request failed"
+    assert "super-secret" not in response["error"]
+    assert response["diagnostic"]["scope"] == "request"
+    assert response["diagnostic"]["summary"] == "Request failed"
+    assert response["diagnostic"]["detail"] == (
+        "RuntimeError: token=[REDACTED] Chat agent failed while answering: what happened?"
+    )
 
 
 def test_socket_subscription_replays_then_streams_new_events(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
@@ -625,6 +709,48 @@ def test_socket_subscription_replays_then_streams_new_events(tmp_path):  # noqa:
     assert replay["type"] == "event_batch"
     assert streamed["type"] == "event"
     assert streamed["event"]["type"] == "chat"
+
+
+def test_socket_subscription_reports_structured_stream_failures(tmp_path, monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path / "logs")
+    service = SupervisionService(supervisor)
+    socket_path = Path("/tmp") / f"vibesys-test-{uuid.uuid4().hex}.sock"  # noqa: S108  # tracked: #288
+
+    def fail_replay(after_sequence: int):  # noqa: ANN202  # tracked: #288
+        del after_sequence
+        raise RuntimeError("event store is unavailable")  # noqa: TRY003  # tracked: #288
+
+    monkeypatch.setattr(service, "events", fail_replay)
+    with SupervisionSocketServer(socket_path, service):  # noqa: SIM117  # tracked: #288
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(2)
+            client.connect(str(socket_path))
+            stream = client.makefile("rwb")
+            stream.write(SubscribeRequest(after_sequence=0).model_dump_json().encode() + b"\n")
+            stream.flush()
+            subscribed = json.loads(stream.readline())
+            failure = json.loads(stream.readline())
+
+    assert subscribed["type"] == "subscribed"
+    assert failure == {
+        "type": "protocol_error",
+        "request_id": subscribed["request_id"],
+        "code": "stream_failed",
+        "message": "Event stream failed",
+        "diagnostic": {
+            "id": failure["diagnostic"]["id"],
+            "code": "stream_failed",
+            "summary": "Event stream failed",
+            "detail": "RuntimeError: event store is unavailable",
+            "hint": None,
+            "scope": "protocol",
+            "severity": "error",
+            "retryability": "unknown",
+            "cause_id": None,
+            "debug_ref": None,
+        },
+    }
 
 
 def test_cli_parse_failure_is_streamed_after_client_attaches():  # noqa: ANN201  # tracked: #288
@@ -696,7 +822,7 @@ def test_cli_parse_failure_is_streamed_after_client_attaches():  # noqa: ANN201 
     assert stderr == ""
 
 
-def test_supervision_runtime_streams_configuration_failure_before_exiting():  # noqa: ANN201  # tracked: #288
+def test_supervision_runtime_streams_configuration_failure_before_exiting():  # noqa: ANN201, PLR0915  # tracked: #288
     session_dir = Path("/tmp") / f"vs-runtime-test-{uuid.uuid4().hex}"  # noqa: S108  # tracked: #288
     socket_path = session_dir / "control.sock"
     received_events = []
@@ -738,8 +864,8 @@ def test_supervision_runtime_streams_configuration_failure_before_exiting():  # 
         ConfigurationDiagnostic(
             code="invalid_arguments",
             stage="argument_parsing",
-            message="unknown option --bad",
-            usage="usage: vibesys ...",
+            message="unknown token=super-secret option --bad",
+            usage="usage: vibesys --token=super-secret",
         )
     )
     try:
@@ -755,13 +881,21 @@ def test_supervision_runtime_streams_configuration_failure_before_exiting():  # 
             "kind": "configuration_failed",
             "code": "invalid_arguments",
             "stage": "argument_parsing",
-            "message": "unknown option --bad",
-            "usage": "usage: vibesys ...",
+            "message": "unknown token=[REDACTED] option --bad",
+            "usage": "usage: vibesys --token=[REDACTED]",
             "exit_code": 2,
         }
+        assert configuration_event["text"] == "unknown token=[REDACTED] option --bad"
+        assert (
+            configuration_event["diagnostic"]["summary"] == "unknown token=[REDACTED] option --bad"
+        )
+        assert configuration_event["diagnostic"]["detail"] == (
+            "Stage: argument_parsing\nExit code: 2"
+        )
+        assert configuration_event["diagnostic"]["hint"] == "usage: vibesys --token=[REDACTED]"
         assert not any(event["type"] == "run_failed" for event in received_events)
         assert chat_responses[0]["ok"] is True
-        assert "unknown option --bad" in chat_responses[0]["chat"]["answer"]
+        assert "unknown token=[REDACTED] option --bad" in chat_responses[0]["chat"]["answer"]
     finally:
         subscriber.join(timeout=5)
         shutil.rmtree(session_dir, ignore_errors=True)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -24,8 +24,15 @@ from vibesys.server.diagnostics import (
     DiagnosticRetryability,
     DiagnosticScope,
     DiagnosticSeverity,
+    exception_to_diagnostic,
 )
-from vibesys.server.events import ConfigurationFailedData
+from vibesys.server.events import (
+    ConfigurationFailedData,
+    EventStatus,
+    JudgeResultData,
+    PhaseData,
+    RoundFinishedData,
+)
 from vibesys.server.protocol import (
     ChatQuery,
     EventsQuery,
@@ -440,6 +447,136 @@ def test_generic_run_failure_is_fatal_with_unknown_retryability(tmp_path):  # no
     assert terminal.diagnostic.scope is DiagnosticScope.RUN
     assert terminal.diagnostic.severity is DiagnosticSeverity.FATAL
     assert terminal.diagnostic.retryability is DiagnosticRetryability.UNKNOWN
+    assert sum(event.type is EventType.RUN_FAILED for event in supervisor.read_events()) == 1
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        EventType.CONFIGURATION_FAILED,
+        EventType.INVOCATION_FINISHED,
+        EventType.PHASE_FINISHED,
+        EventType.RUN_FAILED,
+        EventType.RUN_INTERRUPTED,
+    ],
+)
+def test_operational_failure_events_require_diagnostics(tmp_path, event_type):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    for status in (EventStatus.FAILED, "failed"):
+        with pytest.raises(ValueError, match="must include a diagnostic"):
+            supervisor.record(event_type, status=status)
+
+
+def test_semantic_failure_events_remain_valid_without_diagnostics(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    judge = supervisor.record(
+        EventType.JUDGE_RESULT,
+        status=EventStatus.FAILED,
+        data=JudgeResultData(verdict="fail", feedback="incorrect", attempt=1),
+    )
+    round_finished = supervisor.record(
+        EventType.ROUND_FINISHED,
+        status=EventStatus.FAILED,
+        data=RoundFinishedData(attempts=1, judge_verdict="fail"),
+    )
+
+    assert judge is not None
+    assert judge.diagnostic is None
+    assert round_finished is not None
+    assert round_finished.diagnostic is None
+
+
+def test_capture_failure_emits_nothing_on_success(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    before = supervisor.read_events()
+
+    with supervisor.capture_failure(
+        event_type=EventType.PHASE_FINISHED,
+        scope=DiagnosticScope.PHASE,
+        operation="Background maintenance",
+    ):
+        pass
+
+    assert supervisor.read_events() == before
+    assert supervisor.snapshot().status == "running"
+
+
+def test_failure_helpers_reject_non_operational_and_terminal_events(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    before = supervisor.read_events()
+
+    with pytest.raises(ValueError, match="without owning run termination"):
+        supervisor.record_failure(
+            EventType.JUDGE_RESULT,
+            RuntimeError("incorrect result"),
+            scope=DiagnosticScope.PHASE,
+            operation="Judge",
+        )
+    error = RuntimeError("worker failed")
+    for event_type in (EventType.CONFIGURATION_FAILED, EventType.RUN_FAILED):
+        with (
+            pytest.raises(ValueError, match="without owning run termination"),
+            supervisor.capture_failure(
+                event_type=event_type,
+                scope=DiagnosticScope.RUN,
+                operation="Background maintenance",
+            ),
+        ):
+            raise error
+
+    assert supervisor.read_events() == before
+
+
+def test_finish_is_idempotent(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    supervisor.finish(RuntimeError("first failure"))
+    supervisor.finish(RuntimeError("second failure"))
+
+    terminal = [event for event in supervisor.read_events() if event.type is EventType.RUN_FAILED]
+    assert len(terminal) == 1
+    assert terminal[0].diagnostic is not None
+    assert terminal[0].diagnostic.detail == "RuntimeError: first failure"
+
+
+def test_capture_failure_records_once_and_reraises_without_finishing(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    error = KeyboardInterrupt("background worker stopped")
+    before = supervisor.read_events()
+
+    with (
+        pytest.raises(KeyboardInterrupt) as raised,
+        supervisor.capture_failure(
+            event_type=EventType.PHASE_FINISHED,
+            scope=DiagnosticScope.PHASE,
+            operation="Background maintenance",
+            data=PhaseData(phase="maintenance", attempt=1),
+            agent_kind="maintenance",
+            round_label="round 1",
+        ),
+    ):
+        raise error
+
+    assert raised.value is error
+    events = supervisor.read_events()
+    assert len(events) == len(before) + 1
+    captured = events[-1]
+    assert captured.type is EventType.PHASE_FINISHED
+    assert captured.status is EventStatus.FAILED
+    assert captured.data == PhaseData(phase="maintenance", attempt=1)
+    assert captured.agent_kind == "maintenance"
+    assert captured.diagnostic is not None
+    assert captured.diagnostic.summary == "Background maintenance failed"
+    assert supervisor.snapshot().status == "running"
+    assert not any(event.type is EventType.RUN_FAILED for event in events)
 
 
 def test_terminal_wrapper_reuses_an_invocation_diagnostic(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
@@ -547,6 +684,7 @@ def test_keyword_fallback_does_not_advertise_slash_commands(tmp_path):  # noqa: 
 def test_chat_explains_configuration_failure_without_a_run_context(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)
+    error = RuntimeError("agent.toml was not found")
     supervisor.record(
         EventType.CONFIGURATION_FAILED,
         status="failed",
@@ -556,6 +694,11 @@ def test_chat_explains_configuration_failure_without_a_run_context(tmp_path):  #
             message="agent.toml was not found",
             usage=None,
             exit_code=2,
+        ),
+        diagnostic=exception_to_diagnostic(
+            error,
+            scope=DiagnosticScope.CONFIGURATION,
+            operation="Configuration",
         ),
     )
 


### PR DESCRIPTION
## Problem

Python exceptions can originate anywhere in the run, request, provider, or transport stack. The supervision protocol reduced many failures to Python repr or plain strings, which forced presentation clients to infer meaning from implementation-specific text. Users saw diagnostics such as `RuntimeError(...)` instead of a concise explanation with safe technical detail.

The persistent TUI error surface is already merged. This PR defines the structured backend-to-frontend diagnostic contract and makes conversion reliable at exception boundaries.

## Solution

Introduce one provider-neutral `Diagnostic` model with stable identity, machine-readable code, user-facing summary, sanitized detail, optional hint, scope, severity, retryability, causal linkage, and debug reference.

A centralized exception converter classifies common exception families using operation context, follows explicit causes and unsuppressed contexts, bounds traversal, and redacts credential-shaped values. Diagnostic field validation applies redaction even when callers construct or deserialize diagnostics directly.

Request and protocol producers use `Response.from_exception()` and `ProtocolErrorMessage.from_exception()`, so ordinary handlers do not call the converter directly. The supervisor exposes `record_failure()` and `capture_failure()` for nonterminal invocation and phase boundaries. Failed operational events are rejected if they lack diagnostics, while semantic judge and round failures remain valid without them.

Terminal ownership stays explicit: `finish()` and `run_server()` own run, interruption, and configuration termination. Background capture APIs reject terminal event types, and `finish()` is idempotent. Related invocation, phase, and terminal reports reuse one diagnostic ID.

The generated TypeScript bindings expose the same contract. The TUI client preserves structured response errors, the reducer prefers diagnostics while retaining legacy fallbacks, and the banner renders summary, detail, and hint without parsing Python exception strings.

### Architecture

Python exception
  -> semantic boundary API
  -> centralized conversion and redaction
  -> `Diagnostic` on `Response`, `ProtocolErrorMessage`, or `RunEvent`
  -> generated TypeScript contract
  -> TUI client and session reducer
  -> persistent error banner

Unexpected stream failures are reported as protocol diagnostics, and the following socket close does not replace the useful diagnostic with a generic disconnect.

## Verification

Repository formatting and lint checks pass. Focused Python contract, event, supervisor, runtime, transport, and TUI tests pass. Generated bindings were regenerated from the Python schema. TUI type checking and production build pass.

The complete TUI suite has one unrelated existing macOS path assertion failure where the test expects `/var` and receives `/private/var`. Full-repository Pyright also retains an unrelated existing `os.O_PATH` error in `libs/vs-sandbox`; Pyright over all changed Python files passes.

### Correctness properties

- Summary is concise and user-facing; detail is sanitized technical context.
- Diagnostic summary, detail, and hint are redacted on construction and deserialization.
- Wrapped exceptions preserve a bounded, cycle-safe cause chain.
- Request and protocol exception factories keep typed and legacy fields consistent.
- Failed operational events cannot be emitted without a diagnostic.
- Semantic judge and round failures do not require exception diagnostics.
- Background capture can emit only nonterminal invocation or phase failures, records once, and re-raises the original exception.
- Terminal failure ownership remains explicit and `finish()` emits at most one terminal event.
- One underlying invocation failure keeps one diagnostic ID through phase and terminal events.
- Structured protocol errors survive the subsequent stream close.
- New protocol fields are optional under protocol v1; old persisted events remain readable and new clients retain legacy fallbacks.

### Testing

- `./scripts/check_format.sh`: passed
- `./scripts/check_lint.sh`: passed
- `uv run pyright` on all changed Python files: 0 errors
- `uv run pytest tests/server/test_diagnostics.py tests/server/test_events.py tests/test_tui.py -q`: 68 passed
- `uv run pytest tests/server -q`: 42 passed before the boundary-only follow-up
- `pnpm --dir clients/tui generate:protocol`: generated artifacts current
- `pnpm --dir clients/tui check`: passed
- `pnpm --dir clients/tui build`: passed
- `pnpm --dir clients/tui exec bun test --max-concurrency 1 src`: 328 passed, 1 unrelated launcher path assertion failed
