### PR TITLE
Refactor agent execution around runtime drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ name = "gpt-5.4"
 
 [agent]
 backend = "cli"
+# Optional. AgentShim is the default; Omnigent is an alternate runtime.
+driver = "agentshim"
 cli_provider = "codex"
 
 [backend]

--- a/docs/contributing/feature-flags.md
+++ b/docs/contributing/feature-flags.md
@@ -38,14 +38,21 @@ plumbing and tests. Remove it when the first real VibeSys feature flag exists.
 | Flag | Default | Effect |
 | --- | --- | --- |
 | `example_feature` | `false` | Sample flag; exercises the plumbing only. |
-| `omnigent_agent_backend` | `false` | Runs the `cli` agent backend through Omnigent's in-process executor instead of agentshim. |
+| `omnigent_agent_backend` | `false` | Compatibility alias for `[agent].driver = "omnigent"`. |
 
 ### `omnigent_agent_backend`
 
-Opt-in and unproven. The flag is off by default because the integration uses a
-fast-moving alpha dependency, supports only two providers, and has not proven
-equivalence with the default sandbox path. With the flag off, nothing under
-`vibesys/agents/omnigent/` is imported and the agentshim path is unchanged.
+New configuration should select the optional runtime directly:
+
+```toml
+[agent]
+backend = "cli"
+driver = "omnigent"
+```
+
+Omitting `driver` selects `agentshim`. The feature flag remains as a
+compatibility alias while existing experiments migrate. Setting the flag and
+explicitly selecting `agentshim` is rejected as conflicting configuration.
 
 Enabling it requires the optional extra. Contributors already have it —
 `uv sync --dev` pulls `vibesys[omnigent]` — but an end-user install needs:
@@ -59,19 +66,25 @@ uv sync --extra omnigent
 omnigent_agent_backend = true
 ```
 
-Constraints, each of which raises `OmnigentUnavailableError` naming the remedy
-rather than silently falling back to agentshim:
+The `AgentClient` presents one application interface over both drivers. It owns
+session reuse, skill setup, response parsing, logging, usage records, and
+lifecycle. A driver owns native executor setup, policy translation, turns,
+events, and cleanup. Unsupported requirements fail before a session starts.
+
+Current Omnigent constraints:
 
 - Only the `claude` and `codex` providers are supported. Omnigent 0.6.0 ships
   no Gemini harness, and its `opencode-native` executor is a bridge for
   Omnigent's own web UI (it takes no `cwd`/`model`), so neither can run a
   headless VibeSys turn.
 - `--docker` is rejected; this integration has no container-launcher support.
-- Per-invocation MCP server injection is rejected; Omnigent wires MCP through
-  its own agent spec, which this integration does not construct.
+- MCP server setup is rejected; the current Omnigent driver does not translate
+  VibeSys MCP specifications.
 - Extra host resource grants are rejected. The agentshim path declares these
   through `vs_sandbox`; this integration confines the agent to its workspace
   and nothing else, so it cannot honour them.
+- Nested read-only and hidden project paths are rejected. Omnigent currently
+  enforces the workspace boundary but cannot express those finer-grained rules.
 
 Sandboxing differs between the two backends. The agentshim path wraps the agent
 in a `vs_sandbox` host sandbox; the Omnigent path expresses the same intent in
@@ -89,8 +102,8 @@ which is the most upgrade-fragile line in the integration.
 
 Requires the platform sandbox backend — `bwrap` on Linux
 (`apt install bubblewrap`) or `sandbox-exec` on macOS. Omnigent resolves it when
-the agent's OS environment is created; if it is missing, the flag raises
-`OmnigentUnavailableError` naming the remedy rather than running the agent
+the agent's OS environment is created; if it is missing, the driver raises
+`OmnigentDriverError` naming the remedy rather than running the agent
 unconfined. GitHub's runners do not ship `bwrap`, so the tests that build a real
 OS environment skip there under the repo's existing
 `VIBESYS_REQUIRE_SANDBOX_TESTS` convention.

--- a/libs/vs-project/src/vs_project/_state.py
+++ b/libs/vs-project/src/vs_project/_state.py
@@ -735,6 +735,7 @@ class _BaseRunConfiguration(BaseModel):
     run_environment: RunEnvironmentRecord
     model: PortableText | None = None
     agent_backend: PortableText
+    agent_driver: PortableText | None = None
     cli_provider: PortableText | None = None
     cli_timeout: Annotated[int, Field(gt=0)] | None = None
     compute_backend: PortableText

--- a/libs/vs-project/tests/test_store.py
+++ b/libs/vs-project/tests/test_store.py
@@ -54,6 +54,7 @@ def _configuration() -> AgentRunConfiguration:
         inner_loop="multi-agent",
         interface="inprocess",
         agent_backend="cli",
+        agent_driver="agentshim",
         cli_provider="codex",
         cli_timeout=1800,
         compute_backend="cpu",
@@ -226,6 +227,7 @@ def test_run_configuration_allows_optional_behavior_overrides_to_be_absent() -> 
     raw = _configuration().model_dump()
     for field in (
         "model",
+        "agent_driver",
         "cli_provider",
         "cli_timeout",
         "profiler",
@@ -627,6 +629,7 @@ def test_run_manifest_persists_complete_agent_loop_behavior(tmp_path: Path) -> N
     assert raw["trusted_input_baseline"] == "a" * 40
     assert raw["configuration"] == {
         "agent_backend": "cli",
+        "agent_driver": "agentshim",
         "cli_provider": "codex",
         "cli_timeout": 1800,
         "compute_backend": "cpu",

--- a/src/vibesys/agents/__init__.py
+++ b/src/vibesys/agents/__init__.py
@@ -1,43 +1,29 @@
-"""Backend-agnostic agent runner package.
-
-The ``build_agent_runner`` function is added at the bottom once the concrete
-runner classes are imported, so the public API of this package is::
-
-    from vibesys.agents import AgentRunner, RoundProgress, build_agent_runner
-"""
+"""Application-level agent execution contracts and composition."""
 
 from __future__ import annotations
 
-from collections.abc import Iterable  # noqa: TC003  # tracked: #288
-from pathlib import Path  # noqa: TC003  # tracked: #288
-from typing import TYPE_CHECKING, Any, TextIO
-
-from vibesys.config import Config  # noqa: TC001  # tracked: #288
-from vibesys.constants import DEFAULT_AGENT_BACKEND, ComputeBackend
-from vibesys.features import FeatureFlag, is_feature_enabled
+from typing import TYPE_CHECKING, Any
 
 from .base import AgentRunner, ResponseFallback
 from .progress import AgentProgress, CandidateProgress, RoundProgress
 
-# ``CliAgentRunner`` and ``DeepAgentsRunner`` are imported lazily to break a
-# circular import: ``vibesys.agent_runner`` imports
-# ``vibesys.agents.callbacks`` (which triggers this ``__init__``), and both
-# concrete runners import back from ``vibesys.agent_runner``. Importing
-# them eagerly here turned the cycle into an ImportError on the first entry
-# point that hits ``agent_runner`` first (e.g. the ``vibesys`` script).
-# The ``TYPE_CHECKING`` imports let pyright resolve the lazily provided
-# names statically without triggering the runtime cycle.
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+    from typing import TextIO
+
+    from vibesys.config import Config
+    from vibesys.constants import ComputeBackend
     from vs_sandbox import HostResource, ProjectPathPolicy
 
-    from .cli_runner import CliAgentRunner
+    from .client import AgentClient
     from .deepagents_runner import DeepAgentsRunner
 
 __all__ = [
+    "AgentClient",
     "AgentProgress",
     "AgentRunner",
     "CandidateProgress",
-    "CliAgentRunner",
     "DeepAgentsRunner",
     "ResponseFallback",
     "RoundProgress",
@@ -45,19 +31,20 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str) -> Any:  # noqa: ANN401  # tracked: #288
-    if name == "CliAgentRunner":
-        from .cli_runner import CliAgentRunner  # noqa: PLC0415  # tracked: #288
+def __getattr__(name: str) -> Any:  # noqa: ANN401
+    """Keep implementations lazy so callback imports cannot form a cycle."""
+    if name == "AgentClient":
+        from .client import AgentClient  # noqa: PLC0415
 
-        return CliAgentRunner
+        return AgentClient
     if name == "DeepAgentsRunner":
-        from .deepagents_runner import DeepAgentsRunner  # noqa: PLC0415  # tracked: #288
+        from .deepagents_runner import DeepAgentsRunner  # noqa: PLC0415
 
         return DeepAgentsRunner
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # noqa: TRY003  # tracked: #288
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # noqa: TRY003
 
 
-def build_agent_runner(  # noqa: C901, D417, PLR0913  # tracked: #288
+def build_agent_runner(  # noqa: PLR0913
     config: Config,
     *,
     agent_backend: str | None,
@@ -66,7 +53,7 @@ def build_agent_runner(  # noqa: C901, D417, PLR0913  # tracked: #288
     skills: list[str],
     skill_source_dirs: list[Path],
     compute_backend: ComputeBackend | None = None,
-    model: Any,  # noqa: ANN401  # tracked: #288
+    model: Any,  # noqa: ANN401
     model_name: str,
     run_log_file: TextIO | None,
     use_docker: bool,
@@ -75,176 +62,23 @@ def build_agent_runner(  # noqa: C901, D417, PLR0913  # tracked: #288
     project_path_policy: ProjectPathPolicy | None = None,
     require_host_sandbox: bool = False,
 ) -> AgentRunner:
-    """Construct the right :class:`AgentRunner` for the requested backend.
+    """Build an agent service through the application composition module."""
+    from .factory import build_agent_runner as build  # noqa: PLC0415
 
-    Args:
-        config: Parsed :class:`~vibesys.config.Config`; the ``[agent]``
-            section drives backend/provider/model/timeout selection.
-        agent_backend: CLI override; if set, takes precedence over
-            ``config.agent.backend``. Falls back to
-            :data:`vibesys.constants.DEFAULT_AGENT_BACKEND` (``"cli"``).
-        cli_provider: CLI override for ``config.agent.cli_provider``.
-        backends: Mapping ``{"implementer": BaseSandbox, "judge": ..., "perf_eval": ...}``.
-            Required for the deepagents path; ignored for the cli path.
-        skills: Skill directory names already materialized in the workspace,
-            for the deepagents backend (passed through to ``create_deep_agent``).
-        skill_source_dirs: Absolute source paths of skill directories — the
-            cli runner copies these into the workspace's ``.claude/skills/``
-            on each invoke.
-        model: Result of :func:`vibesys.llm_client.build_model` — only
-            used by the deepagents path. The cli path uses ``model_name``.
-        model_name: Bare model id (e.g. ``"claude-sonnet-4-6"``) — used both
-            for the cli runner and for the deepagents ``AgentLogger`` prefix.
-        run_log_file: Open text-mode file handle for the loop's main log.
-        use_docker: Whether the loop is running with ``--docker``. The cli
-            runner refuses Docker mode (CLI tools have their own sandboxing).
-        log_dir: Optional directory where the cli runner appends per-invoke
-            usage/cost records (``<log_dir>/usage.jsonl``). Ignored by the
-            deepagents backend, which already shows live token counts in
-            its callback prefix and would need a separate cleanup for JSONL
-            persistence.
-        host_resources: Provider-independent host resource declarations for
-            local CLI agents. Ignored by container and non-CLI backends, whose
-            run-environment importers own resource exposure.
-
-    Raises:
-        SystemExit: If the requested backend is unknown, the cli backend was
-            combined with ``--docker``, or the cli backend was selected
-            without a provider.
-        OmnigentUnavailableError: If the ``omnigent_agent_backend`` feature
-            flag is enabled but the requested provider has no Omnigent
-            executor, or the flag was combined with ``--docker``. Never raised
-            with the flag off, which is the default.
-    """
-    agent_cfg = config.agent
-    backend = agent_backend or agent_cfg.backend or DEFAULT_AGENT_BACKEND
-
-    if require_host_sandbox and backend not in {"cli", "stub"}:
-        raise SystemExit(  # noqa: TRY003  # tracked: #288
-            "local project execution requires the CLI agent backend so VibeSys can "
-            "enforce nested read-only and hidden paths"
-        )
-
-    if backend == "deepagents":
-        if backends is None:
-            raise SystemExit(  # noqa: TRY003  # tracked: #288
-                "internal error: build_agent_runner called with backend='deepagents' "
-                "but no backends dict was provided"
-            )
-        from .deepagents_runner import DeepAgentsRunner  # noqa: PLC0415  # tracked: #288
-
-        return DeepAgentsRunner(
-            model=model,
-            backends=backends,
-            skills=skills,
-            model_name=model_name,
-            run_log_file=run_log_file,
-        )
-
-    if backend == "stub":
-        from .stub_runner import StubAgentRunner  # noqa: PLC0415  # tracked: #288
-
-        return StubAgentRunner()
-
-    if backend == "cli":
-        provider = cli_provider or agent_cfg.cli_provider or "codex"
-        timeout = agent_cfg.cli_timeout
-
-        if is_feature_enabled(FeatureFlag.OMNIGENT_AGENT_BACKEND, config):
-            if require_host_sandbox:
-                raise SystemExit(  # noqa: TRY003  # tracked: #288
-                    "local project execution does not yet support the Omnigent "
-                    "backend; disable feature_flags.omnigent_agent_backend"
-                )
-            # Opt-in alternative to agentshim. Validated and constructed here
-            # so an unsupported provider or a missing optional dependency
-            # fails before the loop starts. With the flag off (the default)
-            # this branch is never entered and nothing imports omnigent.
-            from .omnigent.runner import (  # noqa: PLC0415  # tracked: #288
-                OmnigentAgentRunner,
-                OmnigentUnavailableError,
-            )
-
-            if use_docker:
-                raise OmnigentUnavailableError(  # noqa: TRY003  # tracked: #288
-                    "feature flag 'omnigent_agent_backend' is not supported with "
-                    "--docker; this integration has no container-launcher "
-                    "support. Drop --docker or disable the flag."
-                )
-            extra_resources = tuple(host_resources)
-            if extra_resources:
-                # These are explicit operator grants that the agentshim path
-                # feeds to declare_agent_host_resources. Omnigent's sandbox
-                # takes its own path vocabulary and this integration does not
-                # translate them, so honouring the request is impossible and
-                # dropping it silently would weaken a security boundary the
-                # caller asked for.
-                raise OmnigentUnavailableError(  # noqa: TRY003  # tracked: #288
-                    "the Omnigent backend cannot honour the requested host "
-                    f"resource grants ({[str(r.path) for r in extra_resources]}); "
-                    "it confines the agent to the workspace only. Disable "
-                    "'omnigent_agent_backend' to use the agentshim backend, "
-                    "which declares these through vs_sandbox."
-                )
-            return OmnigentAgentRunner(
-                provider=provider,
-                model=model_name,
-                skills=skill_source_dirs,
-                model_name=model_name or provider,
-                timeout=timeout,
-                run_log_file=run_log_file,
-                log_dir=log_dir,
-            )
-
-        docker_sandboxes = None
-        if use_docker:
-            # The Docker CLI path reuses the DOCKER_PROVIDER_ENV registry for
-            # per-provider install + env requirements (node/npm, codex binary,
-            # PYTHONPATH, etc).
-            from .cli_docker import DOCKER_PROVIDER_ENV  # noqa: PLC0415  # tracked: #288
-
-            if provider not in DOCKER_PROVIDER_ENV:
-                raise SystemExit(  # noqa: TRY003  # tracked: #288
-                    f"--cli-provider {provider!r} is not yet supported with --docker; "
-                    f"supported: {sorted(DOCKER_PROVIDER_ENV)}"
-                )
-            docker_sandboxes = backends
-        # The CLI tool runs [model].name, same as the deepagents backend —
-        # it's the single source of truth for the model. model.name is a
-        # required field (and always validated by build_model), so it is
-        # always a non-empty string here.
-        from .cli_runner import CliAgentRunner  # noqa: PLC0415  # tracked: #288
-
-        return CliAgentRunner(
-            provider=provider,
-            model=model_name,
-            skills=skill_source_dirs,
-            compute_backend=compute_backend,
-            model_name=model_name or provider,
-            timeout=timeout,
-            run_log_file=run_log_file,
-            docker_sandboxes=docker_sandboxes,
-            host_resources=host_resources,
-            log_dir=log_dir,
-            default_reasoning_effort=config.thinking.level,
-            role_models={
-                role: configured
-                for role, configured in {
-                    "orchestrator": agent_cfg.outer.model,
-                    "implementer": agent_cfg.inner.model,
-                }.items()
-                if configured is not None
-            },
-            role_reasoning_efforts={
-                role: configured
-                for role, configured in {
-                    "orchestrator": agent_cfg.outer.reasoning_effort,
-                    "implementer": agent_cfg.inner.reasoning_effort,
-                }.items()
-                if configured is not None
-            },
-            project_path_policy=project_path_policy,
-            require_host_sandbox=require_host_sandbox,
-        )
-
-    raise SystemExit(f"unknown agent backend: {backend!r}")  # noqa: TRY003  # tracked: #288
+    return build(
+        config,
+        agent_backend=agent_backend,
+        cli_provider=cli_provider,
+        backends=backends,
+        skills=skills,
+        skill_source_dirs=skill_source_dirs,
+        compute_backend=compute_backend,
+        model=model,
+        model_name=model_name,
+        run_log_file=run_log_file,
+        use_docker=use_docker,
+        log_dir=log_dir,
+        host_resources=host_resources,
+        project_path_policy=project_path_policy,
+        require_host_sandbox=require_host_sandbox,
+    )

--- a/src/vibesys/agents/__init__.py
+++ b/src/vibesys/agents/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from .base import AgentRunner, ResponseFallback
+from .base import ResponseFallback
 from .progress import AgentProgress, CandidateProgress, RoundProgress
 
 if TYPE_CHECKING:
@@ -17,17 +17,16 @@ if TYPE_CHECKING:
     from vs_sandbox import HostResource, ProjectPathPolicy
 
     from .client import AgentClient
-    from .deepagents_runner import DeepAgentsRunner
+    from .deepagents_runner import DeepAgentsClient
 
 __all__ = [
     "AgentClient",
     "AgentProgress",
-    "AgentRunner",
     "CandidateProgress",
-    "DeepAgentsRunner",
+    "DeepAgentsClient",
     "ResponseFallback",
     "RoundProgress",
-    "build_agent_runner",
+    "build_agent_client",
 ]
 
 
@@ -37,14 +36,14 @@ def __getattr__(name: str) -> Any:  # noqa: ANN401
         from .client import AgentClient  # noqa: PLC0415
 
         return AgentClient
-    if name == "DeepAgentsRunner":
-        from .deepagents_runner import DeepAgentsRunner  # noqa: PLC0415
+    if name == "DeepAgentsClient":
+        from .deepagents_runner import DeepAgentsClient  # noqa: PLC0415
 
-        return DeepAgentsRunner
+        return DeepAgentsClient
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # noqa: TRY003
 
 
-def build_agent_runner(  # noqa: PLR0913
+def build_agent_client(  # noqa: PLR0913
     config: Config,
     *,
     agent_backend: str | None,
@@ -61,9 +60,9 @@ def build_agent_runner(  # noqa: PLR0913
     host_resources: Iterable[HostResource] = (),
     project_path_policy: ProjectPathPolicy | None = None,
     require_host_sandbox: bool = False,
-) -> AgentRunner:
+) -> AgentClient:
     """Build an agent service through the application composition module."""
-    from .factory import build_agent_runner as build  # noqa: PLC0415
+    from .factory import build_agent_client as build  # noqa: PLC0415
 
     return build(
         config,

--- a/src/vibesys/agents/base.py
+++ b/src/vibesys/agents/base.py
@@ -1,32 +1,12 @@
-"""Backend-agnostic agent runner protocol.
-
-Application runners live alongside this module:
-
-- :mod:`vibesys.agents.deepagents_runner` wraps the existing
-  ``deepagents`` + ``langchain`` stack used by every loop today.
-- :class:`vibesys.agents.client.AgentClient` presents this interface over a
-  stateful driver session. AgentShim and Omnigent are driver implementations.
-
-Loops call a single ``invoke()`` method per (iteration × phase). Callers can
-request a durable session by key without depending on a backend-specific
-session object; the default remains each runner's historical behavior.
-"""  # noqa: RUF002  # tracked: #288
+"""Shared application-level agent client helpers."""
 
 from __future__ import annotations
 
 from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass, field
-from pathlib import Path  # noqa: TC003  # tracked: #288
-from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
+from typing import Generic, TypeVar
 
 from pydantic import BaseModel
-
-from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #288
-from vibesys.agents.contracts import AgentCapabilities  # noqa: TC001
-from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
-
-if TYPE_CHECKING:
-    from langchain_core.tools import BaseTool  # annotation only; avoid eager agent-stack import
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -35,7 +15,7 @@ T = TypeVar("T", bound=BaseModel)
 class ResponseFallback(Generic[T]):
     """A ``fallback_factory`` that records whether the runner had to use it.
 
-    Every :meth:`AgentRunner.invoke` implementation calls ``fallback_factory``
+    Every :meth:`AgentClient.invoke` implementation calls ``fallback_factory``
     exactly when the agent's output could not be parsed into ``response_cls``,
     and returns the parsed response otherwise. Wrapping the factory turns that
     framework-side event into a typed signal the caller can read after the
@@ -61,106 +41,3 @@ class ResponseFallback(Generic[T]):
         """Build the fallback response and record that the runner needed it."""
         self.synthesized = True
         return self.build()
-
-
-class AgentRunner(Protocol):
-    """Backend-agnostic agent invoker. One instance per loop run."""
-
-    backend_name: str
-    """Diagnostic application backend identifier."""
-
-    @property
-    def capabilities(self) -> AgentCapabilities:
-        """Return factual tool and execution capabilities."""
-        ...
-
-    def invoke(  # noqa: D417, PLR0913  # tracked: #288
-        self,
-        *,
-        # static per-task config
-        kind: str,
-        workspace: Path,
-        system_prompt: str,
-        env: dict[str, str] | None = None,
-        # dynamic per-call config
-        user_prompt: str,
-        response_cls: type[T],
-        fallback_factory: Callable[[], T],
-        round_label: str,
-        invocation_id: str | None = None,
-        progress: AgentProgress | None = None,
-        mcp_servers: list[MCPServerSpec] | None = None,
-        tools: list[BaseTool] | None = None,
-        reuse_session: bool | None = None,
-        session_key: str | None = None,
-    ) -> T:
-        """Run an agent and return a structured response.
-
-        Args:
-            kind: One of ``"implementer"``, ``"judge"``, ``"perf_eval"``.
-                The deepagents runner uses this to pick the right
-                ``BaseSandbox`` from its backends dict; both backends use
-                it to derive the human-facing label.
-            workspace: Workspace root for this phase. The deepagents runner
-                ignores it (its sandbox already encapsulates a working
-                directory); the cli runner passes it through as ``cwd``
-                to the underlying CLI process.
-            system_prompt: Rendered Jinja2 system prompt (per phase).
-            env: Optional environment overrides (e.g. ``CUDA_VISIBLE_DEVICES``).
-            user_prompt: Rendered Jinja2 user prompt (per iteration).
-            response_cls: Pydantic model class the agent should produce.
-            fallback_factory: Constructs a default ``response_cls`` instance
-                used when the agent fails to produce a parseable response.
-                Implementations must call this rather than raise, and must
-                call it only for that reason — callers may wrap it in
-                :class:`ResponseFallback` to detect a synthesized response.
-            round_label: Short label used in log headers (e.g. ``"judge #3"``).
-            progress: Optional loop-owned progress state shown in the live
-                terminal prefix (e.g. ``RoundProgress(3, 24)``).
-            mcp_servers: Optional list of stdio MCP servers to install for
-                the duration of this call. The cli runner forwards these to
-                the underlying ``CodingAgent``'s
-                :meth:`~vibesys._agent_cli.base.CodingAgent.install_mcp_servers`
-                hook (then uninstalls in ``finally``); the deepagents runner
-                ignores this kwarg.
-            tools: Optional list of in-process LangChain tools to expose to
-                the agent for the duration of this call. The deepagents
-                runner forwards them to ``create_deep_agent(tools=...)``;
-                the cli runner ignores this kwarg (the cli path uses
-                ``mcp_servers`` for tool injection). Both kwargs are
-                transport-level injection points and contain no domain
-                knowledge — loops or wrappers populate them.
-            reuse_session: Override the runner's historical session reuse
-                policy. ``True`` continues the conversation identified by
-                ``session_key``; ``False`` starts a clean session.
-            session_key: Loop-owned stable identity for a reusable session.
-                Defaults to ``kind`` when reuse is enabled.
-
-        Returns:
-            An instance of ``response_cls``, either parsed from the agent's
-            output or produced by ``fallback_factory()``.
-        """
-        ...
-
-    def invoke_text(  # noqa: PLR0913  # tracked: #288
-        self,
-        *,
-        kind: str,
-        workspace: Path,
-        system_prompt: str,
-        env: dict[str, str] | None = None,
-        user_prompt: str,
-        round_label: str,
-        invocation_id: str | None = None,
-        progress: AgentProgress | None = None,
-        mcp_servers: list[MCPServerSpec] | None = None,
-        tools: list[BaseTool] | None = None,
-        reuse_session: bool | None = None,
-        session_key: str | None = None,
-    ) -> str:
-        """Run an agent and return its final message without a response schema."""
-        ...
-
-    def close(self) -> None:
-        """Release runner resources. Implementations must be idempotent."""
-        ...

--- a/src/vibesys/agents/base.py
+++ b/src/vibesys/agents/base.py
@@ -1,13 +1,11 @@
 """Backend-agnostic agent runner protocol.
 
-Two implementations live alongside this module:
+Application runners live alongside this module:
 
 - :mod:`vibesys.agents.deepagents_runner` wraps the existing
   ``deepagents`` + ``langchain`` stack used by every loop today.
-- :mod:`vibesys.agents.cli_runner` wraps an
-  ``agentshim``-backed ``vibesys._agent_cli`` compatibility layer, which drives
-  external coding-agent CLIs
-  (Claude Code, Gemini, Codex, Opencode).
+- :class:`vibesys.agents.client.AgentClient` presents this interface over a
+  stateful driver session. AgentShim and Omnigent are driver implementations.
 
 Loops call a single ``invoke()`` method per (iteration × phase). Callers can
 request a durable session by key without depending on a backend-specific
@@ -24,6 +22,7 @@ from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
 from pydantic import BaseModel
 
 from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #288
+from vibesys.agents.contracts import AgentCapabilities  # noqa: TC001
 from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 
 if TYPE_CHECKING:
@@ -68,7 +67,12 @@ class AgentRunner(Protocol):
     """Backend-agnostic agent invoker. One instance per loop run."""
 
     backend_name: str
-    """Diagnostic identifier — ``"deepagents"`` or ``"cli"``."""
+    """Diagnostic application backend identifier."""
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        """Return factual tool and execution capabilities."""
+        ...
 
     def invoke(  # noqa: D417, PLR0913  # tracked: #288
         self,
@@ -155,4 +159,8 @@ class AgentRunner(Protocol):
         session_key: str | None = None,
     ) -> str:
         """Run an agent and return its final message without a response schema."""
+        ...
+
+    def close(self) -> None:
+        """Release runner resources. Implementations must be idempotent."""
         ...

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -390,7 +390,7 @@ class AgentLogger(BaseCallbackHandler):
     #
     # The deepagents path drives ``AgentLogger`` via the langchain
     # ``BaseCallbackHandler`` hooks (``on_llm_new_token``, ``on_tool_end``, …).
-    # The cli runner in ``vibesys.agents.cli_runner`` receives events
+    # External-agent drivers receive events
     # from ``vibesys._agent_cli.AgentEventHandler`` directly on this object. Both
     # paths converge on the same private ``_emit_*`` helpers, so emitted events
     # and log text are identical regardless of which backend is in use.

--- a/src/vibesys/agents/cli_common.py
+++ b/src/vibesys/agents/cli_common.py
@@ -1,14 +1,7 @@
-"""Prompt and workspace helpers shared by the CLI-shaped agent backends.
+"""Prompt and workspace helpers shared by external-agent drivers.
 
-Both :mod:`vibesys.agents.cli_runner` (agentshim, the default) and
-:mod:`vibesys.agents.omnigent.runner` (opt-in) drive an external coding-agent
-CLI against a VibeSys workspace. The pieces that decide *what the agent sees* —
-which skill directories are materialized where, and how a structured-response
-request is phrased — belong to that shared shape rather than to either backend,
-so they live here and have exactly one definition.
-
-Backend-specific concerns (executors, sessions, event handling, Docker
-routing) stay in the individual runner modules.
+The application client owns skill materialization and response parsing. Drivers
+reuse the schema helpers when translating a turn to their native API.
 """
 
 from __future__ import annotations

--- a/src/vibesys/agents/cli_docker.py
+++ b/src/vibesys/agents/cli_docker.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 # Per-provider environment variables to set inside the container.  Used as
 # the canonical "supported with --docker" registry — providers absent from
-# this dict are rejected up front in ``build_agent_runner``.
+# this dict are rejected up front in ``build_agent_client``.
 #
 # Claude Code refuses ``--dangerously-skip-permissions`` when running as
 # root unless ``IS_SANDBOX=1`` is set, so we set it here.  We run everything

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -50,6 +50,7 @@ from vibesys.agents.cli_common import (
     materialize_native_output_schema,
     materialize_skills,
 )
+from vibesys.agents.contracts import AgentCapabilities
 from vibesys.agents.host_resource_declarations import declare_agent_host_resources
 from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 from vibesys.constants import ComputeBackend  # noqa: TC001  # tracked: #288
@@ -140,6 +141,14 @@ class CliAgentRunner:
     """:class:`AgentRunner` backed by ``vibesys._agent_cli`` CLI agents."""
 
     backend_name = "cli"
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        """Compatibility metadata for the superseded concrete runner."""
+        return AgentCapabilities(mcp_servers=True, timeouts=True)
+
+    def close(self) -> None:
+        """AgentShim launches one process per turn and retains no live process."""
 
     def __init__(  # noqa: ANN204, D107, PLR0913  # tracked: #288
         self,

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -1,4 +1,4 @@
-"""CLI implementation of :class:`AgentRunner`.
+"""Pre-driver CLI client retained for compatibility tests.
 
 Wraps the local ``vibesys._agent_cli`` compatibility layer, which is backed by
 the open-source ``agentshim`` package plus a few repo-specific extensions for
@@ -138,13 +138,13 @@ def _heavy_codex_turn_reason(agent: CodingAgent) -> str | None:
 
 
 class CliAgentRunner:
-    """:class:`AgentRunner` backed by ``vibesys._agent_cli`` CLI agents."""
+    """Direct client backed by ``vibesys._agent_cli`` CLI agents."""
 
     backend_name = "cli"
 
     @property
     def capabilities(self) -> AgentCapabilities:
-        """Compatibility metadata for the superseded concrete runner."""
+        """Return the direct client's supported features."""
         return AgentCapabilities(mcp_servers=True, timeouts=True)
 
     def close(self) -> None:

--- a/src/vibesys/agents/client.py
+++ b/src/vibesys/agents/client.py
@@ -1,0 +1,501 @@
+"""VibeSys agent service shared by all external-agent drivers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, TypeVar
+
+from pydantic import BaseModel
+
+from vibesys.agent_runner import (
+    log_and_print,
+    log_json_and_print,
+    log_markdown_and_print,
+    log_prompt_markdown_and_print,
+    parse_typed_response_text,
+)
+from vibesys.agents.callbacks import AgentLogger
+from vibesys.agents.cli_common import agent_label, materialize_skills
+from vibesys.agents.contracts import (
+    AgentCapabilities,
+    AgentDriver,
+    AgentEvent,
+    AgentEventKind,
+    AgentExecutionPolicy,
+    AgentObserver,
+    AgentSession,
+    AgentSessionSpec,
+    AgentTurnRequest,
+    AgentTurnResult,
+    AgentUsage,
+    MCPServerSpec,
+    SessionDisposition,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping
+    from pathlib import Path
+    from typing import TextIO
+
+    from langchain_core.tools import BaseTool
+
+    from vibesys._agent_cli.base import MCPServerSpec as LegacyMCPServerSpec
+    from vibesys.agents.progress import AgentProgress
+    from vibesys.constants import ComputeBackend
+    from vs_sandbox import HostResource, ProjectPathPolicy
+
+T = TypeVar("T", bound=BaseModel)
+
+
+@dataclass(slots=True)
+class _CachedSession:
+    spec: AgentSessionSpec
+    session: AgentSession
+
+
+class AgentDiagnosticLog:
+    """Mutable diagnostic destination shared by a client and its driver."""
+
+    def __init__(self, stream: TextIO | None) -> None:
+        """Create a log target backed by ``stream``."""
+        self.stream = stream
+
+    def __call__(self, message: str) -> None:
+        """Write one driver diagnostic to the current run log."""
+        log_and_print(message, self.stream)
+
+
+class _LoggerObserver:
+    """Translate neutral driver events into VibeSys's application logger."""
+
+    def __init__(self, logger: AgentLogger) -> None:
+        self._logger = logger
+
+    def on_event(self, event: AgentEvent) -> None:
+        """Render one normalized driver event."""
+        if event.kind is AgentEventKind.TEXT:
+            self._logger.log_text(event.text or "")
+        elif event.kind is AgentEventKind.THINKING:
+            self._logger.on_thinking(event.text or "")
+        elif event.kind is AgentEventKind.TOOL_CALL:
+            tool = str(event.payload.get("tool", "unknown"))
+            args = event.payload.get("args")
+            self._logger.on_tool_call(tool, args if isinstance(args, (dict, str)) else None)
+        elif event.kind is AgentEventKind.TOOL_RESULT:
+            exit_code = event.payload.get("exit_code")
+            duration = event.payload.get("duration")
+            self._logger.on_tool_result(
+                str(event.payload.get("tool", "unknown")),
+                stdout=str(event.payload.get("stdout", event.text or "")),
+                stderr=str(event.payload.get("stderr", "")),
+                exit_code=exit_code if isinstance(exit_code, int) else None,
+                duration=float(duration) if isinstance(duration, (int, float)) else None,
+            )
+        elif event.kind is AgentEventKind.USAGE and event.usage is not None:
+            self._logger.update_usage(_usage_dict(event.usage))
+
+
+def _usage_dict(usage: AgentUsage) -> dict[str, int | float | None]:
+    return {
+        "input_tokens": usage.input_tokens,
+        "cache_creation_input_tokens": usage.cache_creation_input_tokens,
+        "cache_read_input_tokens": usage.cache_read_input_tokens,
+        "output_tokens": usage.output_tokens,
+        "total_cost_usd": usage.total_cost_usd,
+        "duration_ms": usage.duration_ms,
+    }
+
+
+def _normalize_mcp_servers(
+    servers: Iterable[LegacyMCPServerSpec] | None,
+) -> tuple[MCPServerSpec, ...]:
+    if servers is None:
+        return ()
+    return tuple(
+        MCPServerSpec(
+            name=server.name,
+            command=server.command,
+            args=tuple(server.args),
+            env=tuple(sorted(server.env.items())),
+        )
+        for server in servers
+    )
+
+
+class AgentClient:
+    """Run agent turns and own the resulting configured sessions.
+
+    A non-``None`` session key resumes a conversation only while its immutable
+    session specification remains equal. Changing setup configuration closes
+    and replaces the old session. An unkeyed turn uses an ephemeral session.
+    """
+
+    backend_name = "cli"
+
+    def __init__(  # noqa: PLR0913
+        self,
+        driver: AgentDriver,
+        *,
+        provider: str | None = None,
+        skills: Iterable[Path] = (),
+        compute_backend: ComputeBackend | None = None,
+        model_name: str | None = None,
+        timeout: int | None = None,
+        run_log_file: TextIO | None = None,
+        log_dir: Path | None = None,
+        default_reasoning_effort: str | None = None,
+        role_models: Mapping[str, str] | None = None,
+        role_reasoning_efforts: Mapping[str, str] | None = None,
+        project_path_policy: ProjectPathPolicy | None = None,
+        host_resources: Iterable[HostResource] = (),
+        require_host_sandbox: bool = False,
+        containerized: bool = False,
+        driver_log: AgentDiagnosticLog | None = None,
+    ) -> None:
+        """Create a client that owns ``driver`` and every session it creates."""
+        self._driver = driver
+        self._provider = provider
+        self._skills = tuple(skills)
+        self._compute_backend = compute_backend
+        self._model_name = model_name
+        self._timeout = timeout
+        self._run_log_file = run_log_file
+        self._driver_log = driver_log
+        self._log_dir = log_dir
+        self._default_reasoning_effort = default_reasoning_effort
+        self._role_models = dict(role_models or {})
+        self._role_reasoning_efforts = dict(role_reasoning_efforts or {})
+        self._policy = AgentExecutionPolicy(
+            project_paths=project_path_policy,
+            host_resources=tuple(host_resources),
+            require_enforcement=require_host_sandbox,
+            containerized=containerized,
+        )
+        self._sessions: dict[str, _CachedSession] = {}
+        self._closed = False
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        """Return the selected driver's factual capabilities."""
+        return self._driver.capabilities
+
+    def set_log_file(self, stream: TextIO | None) -> None:
+        """Direct subsequent application logs to ``stream``."""
+        self._run_log_file = stream
+        if self._driver_log is not None:
+            self._driver_log.stream = stream
+
+    def invoke(  # noqa: PLR0913
+        self,
+        *,
+        kind: str,
+        workspace: Path,
+        system_prompt: str,
+        user_prompt: str,
+        response_cls: type[T],
+        fallback_factory: Callable[[], T],
+        round_label: str,
+        env: dict[str, str] | None = None,
+        invocation_id: str | None = None,
+        progress: AgentProgress | None = None,
+        mcp_servers: list[LegacyMCPServerSpec] | None = None,
+        tools: list[BaseTool] | None = None,
+        reuse_session: bool | None = None,
+        session_key: str | None = None,
+    ) -> T:
+        """Run one turn and parse its structured response."""
+        del tools  # In-process tools remain a deepagents-only compatibility path.
+        result = self._invoke_turn(
+            kind=kind,
+            workspace=workspace,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            output_schema=response_cls,
+            round_label=round_label,
+            env=env,
+            invocation_id=invocation_id,
+            progress=progress,
+            mcp_servers=mcp_servers,
+            reuse_session=reuse_session,
+            session_key=session_key,
+        )
+        label = agent_label(kind)
+        parsed = parse_typed_response_text(result.text, response_cls)
+        if parsed is None:
+            log_and_print(f"\n=== {label} ROUND OUTPUT (missing response) ===", self._run_log_file)
+            log_and_print(
+                f"No structured response received from {label.lower()}.",
+                self._run_log_file,
+            )
+            if result.text:
+                log_and_print(
+                    f"\n=== {label} ROUND OUTPUT (raw output) ===",
+                    self._run_log_file,
+                )
+                log_markdown_and_print(result.text, self._run_log_file)
+            return fallback_factory()
+        log_and_print(f"\n=== {label} ROUND OUTPUT ===", self._run_log_file)
+        log_json_and_print(parsed.model_dump_json(indent=2), self._run_log_file)
+        return parsed
+
+    def invoke_text(  # noqa: PLR0913
+        self,
+        *,
+        kind: str,
+        workspace: Path,
+        system_prompt: str,
+        user_prompt: str,
+        round_label: str,
+        env: dict[str, str] | None = None,
+        invocation_id: str | None = None,
+        progress: AgentProgress | None = None,
+        mcp_servers: list[LegacyMCPServerSpec] | None = None,
+        tools: list[BaseTool] | None = None,
+        reuse_session: bool | None = None,
+        session_key: str | None = None,
+    ) -> str:
+        """Run one conversational turn without a structured-output requirement."""
+        del tools
+        result = self._invoke_turn(
+            kind=kind,
+            workspace=workspace,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            output_schema=None,
+            round_label=round_label,
+            env=env,
+            invocation_id=invocation_id,
+            progress=progress,
+            mcp_servers=mcp_servers,
+            reuse_session=reuse_session,
+            session_key=session_key,
+        )
+        label = agent_label(kind)
+        if result.text:
+            log_and_print(f"\n=== {label} ROUND OUTPUT ===", self._run_log_file)
+            log_markdown_and_print(result.text, self._run_log_file)
+        else:
+            log_and_print(f"\n=== {label} ROUND OUTPUT (missing response) ===", self._run_log_file)
+            log_and_print(f"No response received from {label.lower()}.", self._run_log_file)
+        return result.text
+
+    def _invoke_turn(  # noqa: PLR0913
+        self,
+        *,
+        kind: str,
+        workspace: Path,
+        system_prompt: str,
+        user_prompt: str,
+        output_schema: type[BaseModel] | None,
+        round_label: str,
+        env: dict[str, str] | None,
+        invocation_id: str | None,
+        progress: AgentProgress | None,
+        mcp_servers: list[LegacyMCPServerSpec] | None,
+        reuse_session: bool | None,
+        session_key: str | None,
+    ) -> AgentTurnResult:
+        label = agent_label(kind)
+        model = self._role_models.get(kind, self._model_name)
+        reasoning_effort = self._role_reasoning_efforts.get(kind, self._default_reasoning_effort)
+        spec = AgentSessionSpec(
+            role=kind,
+            provider=self._provider or "codex",
+            workspace=workspace,
+            policy=self._policy,
+            model=model,
+            mcp_servers=_normalize_mcp_servers(mcp_servers),
+            skills=self._skills,
+            environment=tuple(sorted((env or {}).items())),
+            reasoning_effort=reasoning_effort,
+        )
+        turn = AgentTurnRequest(
+            message=user_prompt,
+            instructions=system_prompt,
+            output_schema=output_schema,
+            timeout=timedelta(seconds=self._timeout) if self._timeout is not None else None,
+            invocation_id=invocation_id,
+            label=round_label,
+        )
+        logger = AgentLogger(
+            log_file=self._run_log_file,
+            model_name=model,
+            agent_label=label,
+            progress=progress,
+            agent_kind=kind,
+            round_label=round_label,
+            invocation_id=invocation_id,
+        )
+        log_and_print(f"\n=== {label} ROUND START: {round_label} ===", self._run_log_file)
+        log_and_print(
+            f"driver: {type(self._driver).__name__}, provider: {spec.provider}, "
+            f"model: {model}, reasoning_effort: {reasoning_effort or 'provider_default'}, "
+            f"cwd: {workspace}",
+            self._run_log_file,
+        )
+        log_and_print("--- input ---", self._run_log_file)
+        log_prompt_markdown_and_print(f"{system_prompt}\n\n{user_prompt}", self._run_log_file)
+        reuse = kind != "chat" and (reuse_session if reuse_session is not None else True)
+        cache_key = session_key or kind
+        result: AgentTurnResult | None = None
+        try:
+            result = self.run(
+                session_spec=spec,
+                turn=turn,
+                session_key=cache_key if reuse else None,
+                observer=_LoggerObserver(logger),
+            )
+        except Exception as exc:
+            log_and_print(f"\n=== {label} ROUND ERROR: {round_label} ===", self._run_log_file)
+            log_and_print(f"{type(exc).__name__}: {exc}", self._run_log_file)
+            raise
+        finally:
+            # The result may not exist after a setup/turn failure. The empty
+            # record preserves one audit row per attempted invocation.
+            self._write_usage_record(
+                kind=kind,
+                round_label=round_label,
+                model=model,
+                reasoning_effort=reasoning_effort,
+                usage=result.usage if result is not None else AgentUsage(),
+            )
+        assert result is not None  # noqa: S101  # assigned or the exception propagated
+        return result
+
+    def _write_usage_record(
+        self,
+        *,
+        kind: str,
+        round_label: str,
+        model: str | None,
+        reasoning_effort: str | None,
+        usage: AgentUsage,
+    ) -> None:
+        if self._log_dir is None:
+            return
+        record = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "kind": kind,
+            "round_label": round_label,
+            "provider": self._provider,
+            "model": model,
+            "reasoning_effort": reasoning_effort,
+            **_usage_dict(usage),
+        }
+        target = self._log_dir / "usage.jsonl"
+        try:
+            with target.open("a", encoding="utf-8") as stream:
+                stream.write(json.dumps(record) + "\n")
+        except OSError as exc:
+            log_and_print(
+                f"[usage] failed to append {target}: {type(exc).__name__}: {exc}",
+                self._run_log_file,
+            )
+
+    def run(
+        self,
+        *,
+        session_spec: AgentSessionSpec,
+        turn: AgentTurnRequest,
+        session_key: str | None = None,
+        observer: AgentObserver | None = None,
+    ) -> AgentTurnResult:
+        """Run one raw turn, optionally retaining its session for reuse."""
+        self._ensure_open()
+        if session_key is None:
+            return self._run_ephemeral(session_spec, turn, observer)
+
+        cached = self._sessions.get(session_key)
+        if cached is None or cached.spec != session_spec:
+            if cached is not None:
+                self._evict(session_key)
+            cached = _CachedSession(
+                spec=session_spec,
+                session=self._create_session(session_spec),
+            )
+            self._sessions[session_key] = cached
+
+        try:
+            result = cached.session.run_turn(turn, observer)
+        except BaseException as error:
+            try:
+                self._evict(session_key)
+            except Exception as cleanup_error:  # noqa: BLE001  # preserve the turn failure
+                error.add_note(f"agent session cleanup also failed: {cleanup_error}")
+            raise
+
+        if result.disposition is SessionDisposition.RESET_REQUIRED:
+            self._evict(session_key)
+        return result
+
+    def close(self) -> None:
+        """Close all cached sessions and the driver exactly once."""
+        if self._closed:
+            return
+        self._closed = True
+        first_error: Exception | None = None
+        for key in tuple(self._sessions):
+            try:
+                self._evict(key)
+            except Exception as error:  # noqa: BLE001  # cleanup must continue
+                if first_error is None:
+                    first_error = error
+        try:
+            self._driver.close()
+        except Exception as error:  # noqa: BLE001  # preserve earlier cleanup failures
+            if first_error is None:
+                first_error = error
+        if first_error is not None:
+            raise first_error
+
+    def _run_ephemeral(
+        self,
+        session_spec: AgentSessionSpec,
+        turn: AgentTurnRequest,
+        observer: AgentObserver | None,
+    ) -> AgentTurnResult:
+        session = self._create_session(session_spec)
+        turn_error: BaseException | None = None
+        try:
+            return session.run_turn(turn, observer)
+        except BaseException as error:
+            turn_error = error
+            raise
+        finally:
+            try:
+                session.close()
+            except Exception as cleanup_error:
+                if turn_error is None:
+                    raise
+                turn_error.add_note(f"agent session cleanup also failed: {cleanup_error}")
+
+    def _evict(self, key: str) -> None:
+        cached = self._sessions.pop(key, None)
+        if cached is not None:
+            cached.session.close()
+
+    def _create_session(self, spec: AgentSessionSpec) -> AgentSession:
+        """Perform VibeSys-owned setup, then delegate runtime-specific setup."""
+        materialize_skills(
+            spec.workspace,
+            list(spec.skills),
+            compute_backend=self._compute_backend,
+            log_file=self._run_log_file,
+        )
+        return self._driver.create_session(spec)
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            msg = "agent client is closed"
+            raise RuntimeError(msg)
+
+    def __enter__(self) -> AgentClient:
+        """Return this open client as a context manager."""
+        self._ensure_open()
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        """Close the client when leaving its context."""
+        self.close()

--- a/src/vibesys/agents/contracts.py
+++ b/src/vibesys/agents/contracts.py
@@ -1,0 +1,172 @@
+"""Implementation-neutral contracts for stateful agent execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from datetime import timedelta
+    from pathlib import Path
+
+    from pydantic import BaseModel
+
+    from vs_sandbox import HostResource, ProjectPathPolicy
+
+
+class SessionDisposition(StrEnum):
+    """Whether a session remains safe to use after a turn."""
+
+    REUSABLE = "reusable"
+    RESET_REQUIRED = "reset_required"
+
+
+class AgentEventKind(StrEnum):
+    """Semantic categories streamed by every driver."""
+
+    TEXT = "text"
+    THINKING = "thinking"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    USAGE = "usage"
+
+
+@dataclass(frozen=True, slots=True)
+class AgentExecutionPolicy:
+    """Existing sandbox semantics that a driver must enforce for a session.
+
+    Drivers must reject policies they cannot fully enforce. The reusable
+    ``vs_sandbox`` library remains the authority for project-path and host-
+    resource semantics; this value only attaches them to agent setup.
+    """
+
+    project_paths: ProjectPathPolicy | None = None
+    host_resources: tuple[HostResource, ...] = ()
+    require_enforcement: bool = True
+    containerized: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class MCPServerSpec:
+    """Provider-independent description of a session-scoped stdio MCP server."""
+
+    name: str
+    command: str
+    args: tuple[str, ...] = ()
+    env: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class AgentCapabilities:
+    """Features a driver can provide without weakening requested semantics."""
+
+    mcp_servers: bool = False
+    in_process_tools: bool = False
+    nested_read_only_paths: bool = False
+    hidden_paths: bool = False
+    host_path_grants: bool = False
+    container_execution: bool = False
+    timeouts: bool = False
+    session_reuse: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class AgentUsage:
+    """Provider-independent token and cost accounting for one turn."""
+
+    input_tokens: int | None = None
+    cache_creation_input_tokens: int | None = None
+    cache_read_input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_cost_usd: float | None = None
+    duration_ms: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AgentEvent:
+    """One normalized event emitted while an agent turn is running."""
+
+    kind: AgentEventKind
+    text: str | None = None
+    payload: Mapping[str, object] = field(default_factory=dict)
+    usage: AgentUsage | None = None
+
+
+class AgentObserver(Protocol):
+    """Consumer of normalized streaming events from an agent driver."""
+
+    def on_event(self, event: AgentEvent) -> None:
+        """Observe one event in driver emission order."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSessionSpec:
+    """Immutable configuration installed once for a conversation."""
+
+    role: str
+    provider: str
+    workspace: Path
+    policy: AgentExecutionPolicy
+    model: str | None = None
+    mcp_servers: tuple[MCPServerSpec, ...] = ()
+    skills: tuple[Path, ...] = ()
+    environment: tuple[tuple[str, str], ...] = ()
+    reasoning_effort: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AgentTurnRequest:
+    """Context added to an existing conversation for one agent turn."""
+
+    message: str
+    instructions: str = ""
+    output_schema: type[BaseModel] | None = None
+    timeout: timedelta | None = None
+    invocation_id: str | None = None
+    label: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AgentTurnResult:
+    """Provider-independent result of one raw agent turn."""
+
+    text: str
+    usage: AgentUsage = field(default_factory=AgentUsage)
+    provider_session_id: str | None = None
+    disposition: SessionDisposition = SessionDisposition.REUSABLE
+
+
+class AgentSession(Protocol):
+    """A configured agent conversation owned by an :class:`AgentDriver`."""
+
+    def run_turn(
+        self,
+        request: AgentTurnRequest,
+        observer: AgentObserver | None = None,
+    ) -> AgentTurnResult:
+        """Add one turn to the conversation and return its raw result."""
+        ...
+
+    def close(self) -> None:
+        """Release session resources. Implementations must be idempotent."""
+        ...
+
+
+class AgentDriver(Protocol):
+    """Adapter that creates configured sessions using one execution system."""
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        """Return the features this driver can enforce."""
+        ...
+
+    def create_session(self, spec: AgentSessionSpec) -> AgentSession:
+        """Create a session or reject any unsupported part of ``spec``."""
+        ...
+
+    def close(self) -> None:
+        """Release driver resources. Implementations must be idempotent."""
+        ...

--- a/src/vibesys/agents/deepagents_runner.py
+++ b/src/vibesys/agents/deepagents_runner.py
@@ -1,4 +1,4 @@
-"""Deepagents implementation of :class:`AgentRunner`.
+"""Deepagents implementation of :class:`AgentClient`.
 
 Wraps ``deepagents.create_deep_agent`` and the existing
 ``vibesys.agent_runner.run_typed_agent`` plumbing — no behavior
@@ -26,6 +26,7 @@ from vibesys.agent_runner import (
     run_typed_agent,
 )
 from vibesys.agents.callbacks import AgentLogger
+from vibesys.agents.client import AgentClient
 from vibesys.agents.contracts import AgentCapabilities
 from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 
@@ -37,8 +38,8 @@ def _agent_label(kind: str) -> str:
     return kind.replace("_", " ").title()
 
 
-class DeepAgentsRunner:
-    """:class:`AgentRunner` backed by ``deepagents.create_deep_agent``."""
+class DeepAgentsClient(AgentClient):
+    """:class:`AgentClient` backed by ``deepagents.create_deep_agent``."""
 
     backend_name = "deepagents"
 
@@ -75,7 +76,7 @@ class DeepAgentsRunner:
         self._agents: dict[str, Any] = {}
         self._agent_signatures: dict[str, tuple[Any, ...]] = {}
         self._checkpointers: dict[str, MemorySaver] = {}
-        self._sessions: dict[str, tuple[MemorySaver, str]] = {}
+        self._deepagents_sessions: dict[str, tuple[MemorySaver, str]] = {}
 
     def _checkpointer(self, kind: str) -> MemorySaver:
         """Return the checkpointer shared by one kind's cached graphs."""
@@ -93,9 +94,9 @@ class DeepAgentsRunner:
         if not reuse_session or kind == "chat":
             return checkpointer, uuid.uuid4().hex
         key = f"{kind}:{session_key}" if session_key else kind
-        if key not in self._sessions:
-            self._sessions[key] = (checkpointer, uuid.uuid4().hex)
-        return self._sessions[key]
+        if key not in self._deepagents_sessions:
+            self._deepagents_sessions[key] = (checkpointer, uuid.uuid4().hex)
+        return self._deepagents_sessions[key]
 
     def _get_agent(
         self,

--- a/src/vibesys/agents/deepagents_runner.py
+++ b/src/vibesys/agents/deepagents_runner.py
@@ -26,6 +26,7 @@ from vibesys.agent_runner import (
     run_typed_agent,
 )
 from vibesys.agents.callbacks import AgentLogger
+from vibesys.agents.contracts import AgentCapabilities
 from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 
 T = TypeVar("T", bound=BaseModel)
@@ -40,6 +41,18 @@ class DeepAgentsRunner:
     """:class:`AgentRunner` backed by ``deepagents.create_deep_agent``."""
 
     backend_name = "deepagents"
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        """Deepagents exposes only its in-process LangChain tool transport."""
+        return AgentCapabilities(in_process_tools=True, session_reuse=False)
+
+    def close(self) -> None:
+        """Deepagents owns no resources beyond each invocation."""
+
+    def set_log_file(self, stream: TextIO | None) -> None:
+        """Direct subsequent logs to ``stream``."""
+        self._run_log_file = stream
 
     def __init__(  # noqa: ANN204, D107  # tracked: #288
         self,

--- a/src/vibesys/agents/drivers/__init__.py
+++ b/src/vibesys/agents/drivers/__init__.py
@@ -1,0 +1,2 @@
+"""Concrete implementations of the VibeSys agent-driver contract."""
+"""Runtime adapters implementing the driver-neutral agent session contract."""

--- a/src/vibesys/agents/drivers/agentshim.py
+++ b/src/vibesys/agents/drivers/agentshim.py
@@ -1,0 +1,477 @@
+"""AgentShim implementation of the stateful agent-driver contract."""
+
+from __future__ import annotations
+
+import os
+import sys
+import weakref
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from vibesys._agent_cli.base import CodingAgent
+from vibesys._agent_cli.base import MCPServerSpec as AgentShimMCPServerSpec
+from vibesys._agent_cli.claude import ClaudeCodeCodingAgent
+from vibesys._agent_cli.codex import CodexCodingAgent
+from vibesys._agent_cli.gemini import GeminiCodingAgent
+from vibesys._agent_cli.opencode import OpencodeCodingAgent
+from vibesys.agents.cli_common import build_schema_hint, materialize_native_output_schema
+from vibesys.agents.contracts import (
+    AgentCapabilities,
+    AgentEvent,
+    AgentEventKind,
+    AgentObserver,
+    AgentSession,
+    AgentSessionSpec,
+    AgentTurnRequest,
+    AgentTurnResult,
+    AgentUsage,
+    MCPServerSpec,
+)
+from vibesys.agents.docker_executor import DockerCommandExecutor
+from vibesys.agents.host_resource_declarations import declare_agent_host_resources
+from vs_sandbox import build_host_sandbox
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class _ProviderFactory(Protocol):
+    """Constructor signature shared by AgentShim provider classes."""
+
+    def __call__(
+        self,
+        model: str | None = None,
+        event_handler: Any | None = None,  # noqa: ANN401  # tracked: #288
+        *,
+        executor: Any | None = None,  # noqa: ANN401  # tracked: #288
+    ) -> CodingAgent: ...
+
+
+_PROVIDER_CLASSES: dict[str, _ProviderFactory] = {
+    "claude": ClaudeCodeCodingAgent,
+    "gemini": GeminiCodingAgent,
+    "codex": CodexCodingAgent,
+    "opencode": OpencodeCodingAgent,
+}
+
+_REASONING_EFFORT_PROVIDERS = frozenset({"codex", "claude"})
+_PYTHON_MCP_COMMANDS = frozenset({"python", "python3"})
+
+_MAX_CODEX_SESSION_TURNS = 2
+_MAX_CODEX_SESSION_INPUT_TOKENS = 10_000_000
+_MAX_CODEX_SESSION_DURATION_MS = 600_000
+
+
+def _ignore_log(_message: str) -> None:
+    """Discard a driver diagnostic when no log sink was configured."""
+
+
+def _is_missing_codex_rollout(exc: RuntimeError) -> bool:
+    message = str(exc)
+    return "thread/resume failed" in message and "no rollout found" in message
+
+
+def _heavy_codex_turn_reason(agent: CodingAgent) -> str | None:
+    session = getattr(agent, "_last_session", None)
+    usage = getattr(session, "final_usage", None) or {}
+    input_tokens = int(usage.get("input_tokens", 0) or 0)
+    duration_ms = int(getattr(session, "duration_ms", 0) or 0)
+    reasons: list[str] = []
+    if input_tokens >= _MAX_CODEX_SESSION_INPUT_TOKENS:
+        reasons.append(f"{input_tokens} input tokens")
+    if duration_ms >= _MAX_CODEX_SESSION_DURATION_MS:
+        reasons.append(f"{duration_ms} ms duration")
+    return " and ".join(reasons) or None
+
+
+def _usage_from_agent(agent: CodingAgent) -> AgentUsage:
+    session = getattr(agent, "_last_session", None)
+    raw = getattr(session, "final_usage", None) or {}
+    return AgentUsage(
+        input_tokens=raw.get("input_tokens"),
+        cache_creation_input_tokens=raw.get("cache_creation_input_tokens"),
+        cache_read_input_tokens=raw.get("cache_read_input_tokens"),
+        output_tokens=raw.get("output_tokens"),
+        total_cost_usd=getattr(session, "total_cost_usd", None),
+        duration_ms=getattr(session, "duration_ms", None),
+    )
+
+
+def _as_agentshim_mcp(spec: MCPServerSpec, *, in_container: bool) -> AgentShimMCPServerSpec:
+    command = spec.command
+    if not in_container and command in _PYTHON_MCP_COMMANDS:
+        command = sys.executable
+    return AgentShimMCPServerSpec(
+        name=spec.name,
+        command=command,
+        args=list(spec.args),
+        env=dict(spec.env),
+    )
+
+
+class _AgentShimEventHandler:
+    """Translate AgentShim callbacks into neutral driver events."""
+
+    def __init__(self) -> None:
+        self.observer: AgentObserver | None = None
+
+    def _emit(self, event: AgentEvent) -> None:
+        if self.observer is not None:
+            self.observer.on_event(event)
+
+    def on_thinking(self, text: str) -> None:
+        self._emit(AgentEvent(kind=AgentEventKind.THINKING, text=text))
+
+    def on_tool_call(self, tool: str, args: dict[str, Any] | str | None = None) -> None:
+        self._emit(
+            AgentEvent(
+                kind=AgentEventKind.TOOL_CALL,
+                payload={"tool": tool, "args": args if args is not None else {}},
+            )
+        )
+
+    def on_tool_result(
+        self,
+        tool: str,
+        stdout: str = "",
+        stderr: str = "",
+        exit_code: int | None = None,
+        duration: float | None = None,
+    ) -> None:
+        self._emit(
+            AgentEvent(
+                kind=AgentEventKind.TOOL_RESULT,
+                text=stdout or stderr,
+                payload={
+                    "tool": tool,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "exit_code": exit_code,
+                    "duration": duration,
+                },
+            )
+        )
+
+    def on_usage(self, usage: dict[str, Any]) -> None:
+        self._emit(
+            AgentEvent(
+                kind=AgentEventKind.USAGE,
+                usage=AgentUsage(
+                    input_tokens=usage.get("input_tokens"),
+                    cache_creation_input_tokens=usage.get("cache_creation_input_tokens"),
+                    cache_read_input_tokens=usage.get("cache_read_input_tokens"),
+                    output_tokens=usage.get("output_tokens"),
+                    total_cost_usd=usage.get("total_cost_usd"),
+                    duration_ms=usage.get("duration_ms"),
+                ),
+            )
+        )
+
+
+class AgentShimSession:
+    """One configured AgentShim conversation."""
+
+    def __init__(  # noqa: D107, PLR0913  # tracked: #288
+        self,
+        *,
+        agent: CodingAgent,
+        spec: AgentSessionSpec,
+        provider: str,
+        timeout: int | None,
+        event_handler: _AgentShimEventHandler,
+        docker_sandboxes: dict[str, Any] | None,
+        log: Callable[[str], None],
+    ) -> None:
+        self._agent = agent
+        self._spec = spec
+        self._provider = provider
+        self._timeout = timeout
+        self._event_handler = event_handler
+        self._docker_sandboxes = docker_sandboxes
+        self._log = log
+        self._turn_count = 0
+        self._closed = False
+
+    def run_turn(  # noqa: C901, D102, PLR0912  # tracked: #288
+        self,
+        request: AgentTurnRequest,
+        observer: AgentObserver | None = None,
+    ) -> AgentTurnResult:
+        if self._closed:
+            raise RuntimeError("agent session is closed")  # noqa: TRY003  # tracked: #288
+
+        self._event_handler.observer = observer
+        self._refresh_container()
+        prompt, schema_path = self._prepare_prompt(request)
+        self._set_output_schema(schema_path)
+        self._renew_codex_thread_if_needed()
+
+        in_container = self._docker_sandboxes is not None
+        mcp_servers = [
+            _as_agentshim_mcp(server, in_container=in_container)
+            for server in self._spec.mcp_servers
+        ]
+        if mcp_servers:
+            self._agent.install_mcp_servers(self._spec.workspace, mcp_servers)
+
+        timeout = self._timeout
+        if request.timeout is not None:
+            timeout = max(1, int(request.timeout.total_seconds()))
+        workspace_arg = None if in_container else str(self._spec.workspace)
+
+        turn_error: BaseException | None = None
+        try:
+            text = self._generate_with_stale_rollout_retry(
+                prompt,
+                cwd=workspace_arg,
+                timeout=timeout,
+            )
+            self._turn_count += 1
+        except BaseException as exc:
+            turn_error = exc
+            raise
+        finally:
+            cleanup_error: Exception | None = None
+            if mcp_servers:
+                try:
+                    self._agent.uninstall_mcp_servers(self._spec.workspace, mcp_servers)
+                except Exception as exc:  # noqa: BLE001  # tracked: #288
+                    cleanup_error = exc
+                    if turn_error is not None:
+                        self._log(
+                            "MCP config cleanup failed while preserving the original "
+                            f"agent error: {exc}"
+                        )
+            try:
+                self._repair_workspace_ownership()
+            except Exception as exc:  # noqa: BLE001  # tracked: #288
+                if cleanup_error is None:
+                    cleanup_error = exc
+                elif turn_error is not None:
+                    self._log(f"workspace ownership repair also failed: {exc}")
+                if turn_error is not None:
+                    self._log(
+                        "workspace ownership repair failed while preserving the original "
+                        f"agent error: {exc}"
+                    )
+            self._event_handler.observer = None
+            if turn_error is None and cleanup_error is not None:
+                raise cleanup_error
+
+        return AgentTurnResult(
+            text=text,
+            usage=_usage_from_agent(self._agent),
+            provider_session_id=getattr(self._agent, "session_id", None),
+        )
+
+    def close(self) -> None:
+        """Release this logical session. AgentShim processes are per-turn."""
+        self._closed = True
+        self._event_handler.observer = None
+
+    def _prepare_prompt(self, request: AgentTurnRequest) -> tuple[str, str | None]:
+        response_cls = request.output_schema
+        native_schema_path: str | None = None
+        if response_cls is not None and bool(
+            getattr(type(self._agent), "supports_native_output_schema", False)
+            and callable(getattr(self._agent, "set_output_schema_path", None))
+        ):
+            try:
+                native_schema_path = materialize_native_output_schema(
+                    self._spec.workspace,
+                    response_cls,
+                    allow_arbitrary_keys=getattr(
+                        type(self._agent),
+                        "native_output_schema_allows_arbitrary_keys",
+                        False,
+                    ),
+                )
+            except (OSError, TypeError, ValueError) as exc:
+                self._log(
+                    f"[structured-output] native schema unavailable for "
+                    f"{response_cls.__name__}; using prompt fallback: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+
+        schema_arg = native_schema_path
+        if native_schema_path is not None and getattr(
+            type(self._agent), "native_output_schema_wants_absolute_path", False
+        ):
+            schema_arg = str(self._spec.workspace / native_schema_path)
+        schema_hint = (
+            build_schema_hint(response_cls)
+            if response_cls is not None and native_schema_path is None
+            else ""
+        )
+        prompt = f"{request.instructions}\n\n{request.message}{schema_hint}"
+        return prompt, schema_arg
+
+    def _set_output_schema(self, path: str | None) -> None:
+        setter = getattr(self._agent, "set_output_schema_path", None)
+        if callable(setter):
+            setter(path)
+        elif path is not None:
+            raise RuntimeError(  # noqa: TRY003  # tracked: #288
+                f"{type(self._agent).__name__} advertised native output schemas "
+                "without implementing set_output_schema_path()"
+            )
+
+    def _renew_codex_thread_if_needed(self) -> None:
+        if self._provider != "codex":
+            return
+        reason = (
+            f"{_MAX_CODEX_SESSION_TURNS} successful turns"
+            if self._turn_count >= _MAX_CODEX_SESSION_TURNS
+            else _heavy_codex_turn_reason(self._agent)
+        )
+        if reason is None:
+            return
+        self._log(
+            f"renewing Codex thread after {reason}; durable workspace state remains authoritative."
+        )
+        cast("CodexCodingAgent", self._agent).session_id = None
+        self._turn_count = 0
+
+    def _generate_with_stale_rollout_retry(
+        self,
+        prompt: str,
+        *,
+        cwd: str | None,
+        timeout: int | None,
+    ) -> str:
+        try:
+            return self._agent.generate(prompt, cwd=cwd, timeout=timeout, silent=True)
+        except RuntimeError as exc:
+            if not (
+                self._provider == "codex"
+                and getattr(self._agent, "session_id", None)
+                and _is_missing_codex_rollout(exc)
+            ):
+                raise
+            self._log("Codex session is no longer available; retrying with a fresh thread.")
+            cast("CodexCodingAgent", self._agent).session_id = None
+            self._turn_count = 0
+            return self._agent.generate(prompt, cwd=cwd, timeout=timeout, silent=True)
+
+    def _refresh_container(self) -> None:
+        if self._docker_sandboxes is None:
+            return
+        executor = getattr(self._agent, "executor", None)
+        executor.container_id = self._docker_sandboxes[self._spec.role]._container_id  # pyright: ignore[reportOptionalMemberAccess]  # noqa: SLF001  # tracked: #288
+
+    def _repair_workspace_ownership(self) -> None:
+        if self._docker_sandboxes is None:
+            return
+        self._agent.executor.repair_workspace_ownership(uid=os.getuid(), gid=os.getgid())
+
+
+class AgentShimDriver:
+    """Create AgentShim sessions and translate VibeSys execution policy."""
+
+    def __init__(  # noqa: D107  # tracked: #288
+        self,
+        *,
+        provider: str,
+        timeout: int | None = None,
+        docker_sandboxes: dict[str, Any] | None = None,
+        log: Callable[[str], None] | None = None,
+    ) -> None:
+        if provider not in _PROVIDER_CLASSES:
+            raise ValueError(  # noqa: TRY003  # tracked: #288
+                f"unknown AgentShim provider {provider!r}; expected one of: "
+                f"{sorted(_PROVIDER_CLASSES)}"
+            )
+        self._provider = provider
+        self._provider_cls = _PROVIDER_CLASSES[provider]
+        self._timeout = timeout
+        self._docker_sandboxes = docker_sandboxes
+        self._log = log or _ignore_log
+        self._sessions: weakref.WeakSet[AgentShimSession] = weakref.WeakSet()
+        self._closed = False
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        """Describe the policy and lifecycle features this driver enforces."""
+        return AgentCapabilities(
+            mcp_servers=True,
+            nested_read_only_paths=True,
+            hidden_paths=True,
+            host_path_grants=self._docker_sandboxes is None,
+            container_execution=self._docker_sandboxes is not None,
+            timeouts=True,
+            session_reuse=True,
+        )
+
+    def create_session(self, spec: AgentSessionSpec) -> AgentSession:
+        """Create one configured AgentShim conversation."""
+        if self._closed:
+            raise RuntimeError("agent driver is closed")  # noqa: TRY003  # tracked: #288
+        if spec.provider != self._provider:
+            raise ValueError(  # noqa: TRY003  # tracked: #288
+                f"AgentShimDriver for {self._provider!r} cannot create a {spec.provider!r} session"
+            )
+        in_container = self._docker_sandboxes is not None
+        if spec.policy.containerized != in_container:
+            raise ValueError(  # noqa: TRY003  # tracked: #288
+                "agent session container policy does not match the configured "
+                "AgentShim execution mode"
+            )
+
+        event_handler = _AgentShimEventHandler()
+        if in_container:
+            assert self._docker_sandboxes is not None  # noqa: S101  # tracked: #288
+            sandbox = self._docker_sandboxes.get(spec.role)
+            if sandbox is None:
+                raise ValueError(  # noqa: TRY003  # tracked: #288
+                    f"no AgentShim Docker sandbox configured for role {spec.role!r}"
+                )
+            agent = self._provider_cls(
+                model=spec.model,
+                event_handler=event_handler,
+                executor=DockerCommandExecutor(sandbox._container_id),  # noqa: SLF001  # tracked: #288
+            )
+        else:
+            agent = self._provider_cls(model=spec.model, event_handler=event_handler)
+        if spec.environment:
+            agent.env = {**agent.env, **dict(spec.environment)}
+
+        if not in_container:
+            resources = declare_agent_host_resources(
+                agent.env,
+                binary_path=getattr(agent, "binary_path", None),
+                provider=self._provider,
+                additional=spec.policy.host_resources,
+            )
+            agent.sandbox = build_host_sandbox(
+                spec.workspace,
+                env=agent.env,
+                resources=resources,
+                log=self._log,
+                project_path_policy=spec.policy.project_paths,
+                require_enforcement=spec.policy.require_enforcement,
+            )
+
+        if spec.reasoning_effort is not None and self._provider in _REASONING_EFFORT_PROVIDERS:
+            cast("CodexCodingAgent | ClaudeCodeCodingAgent", agent).set_reasoning_effort(
+                spec.reasoning_effort
+            )
+
+        session = AgentShimSession(
+            agent=agent,
+            spec=spec,
+            provider=self._provider,
+            timeout=self._timeout,
+            event_handler=event_handler,
+            docker_sandboxes=self._docker_sandboxes,
+            log=self._log,
+        )
+        self._sessions.add(session)
+        return session
+
+    def close(self) -> None:
+        """Close every session created by this driver, idempotently."""
+        if self._closed:
+            return
+        self._closed = True
+        for session in self._sessions:
+            session.close()
+        self._sessions.clear()

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -1,0 +1,434 @@
+"""Omnigent implementation of the stateful agent-driver contract."""
+
+# ruff: noqa: TRY003
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import sys
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+from vibesys.agents.cli_common import build_schema_hint
+from vibesys.agents.contracts import (
+    AgentCapabilities,
+    AgentEvent,
+    AgentEventKind,
+    AgentObserver,
+    AgentSessionSpec,
+    AgentTurnRequest,
+    AgentTurnResult,
+    AgentUsage,
+)
+from vibesys.agents.omnigent.providers import (
+    OMNIGENT_PROVIDER_EXECUTORS,
+    OmnigentExecutorSpec,
+    supported_providers,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+    from pathlib import Path
+
+_TOOL_EXECUTOR_ATTR = "_tool_executor"
+"""Private Omnigent 0.6.0 tool-dispatch seam, guarded before assignment."""
+
+
+class OmnigentDriverError(RuntimeError):
+    """An Omnigent driver requirement could not be satisfied safely."""
+
+
+def _resolve_executor_spec(provider: str) -> OmnigentExecutorSpec:
+    spec = OMNIGENT_PROVIDER_EXECUTORS.get(provider)
+    if spec is None:
+        raise OmnigentDriverError(
+            f"Omnigent does not support agent provider {provider!r}; "
+            f"supported providers: {supported_providers()}"
+        )
+    return spec
+
+
+def _missing_omnigent(what: str, exc: ImportError) -> OmnigentDriverError:
+    return OmnigentDriverError(
+        f"{what} is not importable ({type(exc).__name__}: {exc}). "
+        "Install the Omnigent optional dependency with `uv sync --extra omnigent`."
+    )
+
+
+def _sandbox_backend_for_platform() -> str:
+    if sys.platform.startswith("linux"):
+        return "linux_bwrap"
+    if sys.platform == "darwin":
+        return "darwin_seatbelt"
+    if os.name == "nt":
+        return "windows_jobobject"
+    raise OmnigentDriverError(f"Omnigent has no sandbox backend for platform {sys.platform!r}")
+
+
+@contextlib.contextmanager
+def _patched_environ(overrides: dict[str, str]) -> Generator[None]:
+    """Temporarily expose session environment values to Omnigent subprocesses."""
+    sentinel = object()
+    previous: dict[str, object] = {key: os.environ.get(key, sentinel) for key in overrides}
+    os.environ.update(overrides)
+    try:
+        yield
+    finally:
+        for key, old in previous.items():
+            if old is sentinel:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = str(old)
+
+
+def _flatten_tool_schema(tool: Any) -> dict[str, Any]:  # noqa: ANN401
+    function = tool.get_schema().get("function", {})
+    return {
+        "name": function.get("name"),
+        "description": function.get("description"),
+        "parameters": function.get("parameters", {"type": "object", "properties": {}}),
+    }
+
+
+def _build_os_tools(
+    os_env_spec: Any,  # noqa: ANN401
+    workspace: Path,
+) -> tuple[list[dict[str, Any]], Callable[[str, dict[str, Any]], Any]]:
+    """Build Omnigent's sandboxed filesystem tools and their dispatcher."""
+    try:
+        from omnigent.inner.os_env import create_os_environment  # noqa: PLC0415
+        from omnigent.tools.base import ToolContext  # noqa: PLC0415
+        from omnigent.tools.builtins.os_env import build_os_env_tools  # noqa: PLC0415
+    except ImportError as exc:
+        raise _missing_omnigent("Omnigent OS-environment tools", exc) from exc
+
+    try:
+        os_env = create_os_environment(os_env_spec)
+    except OSError as exc:
+        raise OmnigentDriverError(
+            f"Omnigent cannot provide its {_sandbox_backend_for_platform()!r} "
+            f"sandbox on this host: {exc}"
+        ) from exc
+    if os_env is None:
+        raise OmnigentDriverError(
+            f"Omnigent could not create a sandboxed OS environment for {workspace}"
+        )
+
+    tools = build_os_env_tools(os_env)
+    by_name = {tool.name(): tool for tool in tools}
+    schemas = [_flatten_tool_schema(tool) for tool in tools]
+    context = ToolContext(task_id="vibesys", agent_id="vibesys", workspace=workspace)
+
+    async def dispatch(name: str, args: dict[str, Any]) -> Any:  # noqa: ANN401
+        tool = by_name.get(name)
+        if tool is None:
+            return {"error": f"unknown tool {name!r}"}
+        return await asyncio.to_thread(tool.invoke, json.dumps(args), context)
+
+    return schemas, dispatch
+
+
+def _usage_from_mapping(usage: dict[str, Any]) -> AgentUsage:
+    return AgentUsage(
+        input_tokens=usage.get("input_tokens"),
+        cache_creation_input_tokens=usage.get("cache_creation_input_tokens"),
+        cache_read_input_tokens=usage.get("cache_read_input_tokens"),
+        output_tokens=usage.get("output_tokens"),
+        total_cost_usd=usage.get("total_cost_usd"),
+        duration_ms=usage.get("duration_ms"),
+    )
+
+
+def _emit(observer: AgentObserver | None, event: AgentEvent) -> None:
+    if observer is not None:
+        observer.on_event(event)
+
+
+async def _drive_turn(
+    executor: Any,  # noqa: ANN401
+    *,
+    request: AgentTurnRequest,
+    reasoning_effort: str | None,
+    tool_schemas: list[dict[str, Any]],
+    observer: AgentObserver | None,
+) -> AgentTurnResult:
+    """Translate one Omnigent event stream into neutral events and a result."""
+    try:
+        from omnigent import (  # noqa: PLC0415
+            ExecutorConfig,
+            TextChunk,
+            ToolCallComplete,
+            ToolCallRequest,
+            TurnComplete,
+        )
+    except ImportError as exc:
+        raise _missing_omnigent("Omnigent executor event types", exc) from exc
+
+    message = request.message
+    if request.output_schema is not None:
+        message += build_schema_hint(request.output_schema)
+    messages: list[Any] = [{"role": "user", "content": message}]
+    config = (
+        ExecutorConfig(extra={"reasoning_effort": reasoning_effort})
+        if reasoning_effort is not None
+        else None
+    )
+    chunks: list[str] = []
+    response: str | None = None
+    usage = AgentUsage()
+
+    async for event in executor.run_turn(messages, tool_schemas, request.instructions, config):
+        if isinstance(event, TextChunk):
+            chunks.append(event.text)
+            _emit(observer, AgentEvent(AgentEventKind.TEXT, text=event.text))
+        elif isinstance(event, ToolCallRequest):
+            _emit(
+                observer,
+                AgentEvent(
+                    AgentEventKind.TOOL_CALL,
+                    payload={"tool": event.name, "args": event.args},
+                ),
+            )
+        elif isinstance(event, ToolCallComplete):
+            _emit(
+                observer,
+                AgentEvent(
+                    AgentEventKind.TOOL_RESULT,
+                    payload={
+                        "tool": event.name,
+                        "stdout": str(event.result) if event.result is not None else "",
+                        "stderr": str(event.error) if event.error is not None else "",
+                        "exit_code": None,
+                        "duration": event.duration_ms / 1000,
+                        "status": getattr(event.status, "value", str(event.status)),
+                    },
+                ),
+            )
+        elif isinstance(event, TurnComplete):
+            response = event.response
+            usage = _usage_from_mapping(event.usage or {})
+            if event.usage:
+                _emit(observer, AgentEvent(AgentEventKind.USAGE, usage=usage))
+
+    provider_session_id = getattr(executor, "thread_id", None)
+    return AgentTurnResult(
+        text=response if response is not None else "".join(chunks),
+        usage=usage,
+        provider_session_id=(provider_session_id if isinstance(provider_session_id, str) else None),
+    )
+
+
+class OmnigentSession:
+    """One configured Omnigent executor and provider conversation."""
+
+    def __init__(
+        self,
+        *,
+        driver: OmnigentDriver,
+        spec: AgentSessionSpec,
+        executor: Any,  # noqa: ANN401
+        tool_schemas: list[dict[str, Any]],
+    ) -> None:
+        """Own ``executor`` until this session is closed."""
+        self._driver = driver
+        self._spec = spec
+        self._executor = executor
+        self._tool_schemas = tool_schemas
+        self._closed = False
+        self._failed = False
+
+    def run_turn(
+        self,
+        request: AgentTurnRequest,
+        observer: AgentObserver | None = None,
+    ) -> AgentTurnResult:
+        """Run one resumable Omnigent turn."""
+        if self._closed:
+            raise RuntimeError("Omnigent session is closed")
+        if self._failed:
+            raise RuntimeError("Omnigent session must be reset after a failed turn")
+
+        turn = _drive_turn(
+            self._executor,
+            request=request,
+            reasoning_effort=self._spec.reasoning_effort,
+            tool_schemas=self._tool_schemas,
+            observer=observer,
+        )
+        if request.timeout is not None:
+            turn = asyncio.wait_for(turn, timeout=request.timeout.total_seconds())
+        try:
+            with _patched_environ(dict(self._spec.environment)):
+                return self._driver.run_awaitable(turn)
+        except BaseException:
+            self._failed = True
+            raise
+
+    def close(self) -> None:
+        """Release the executor exactly once."""
+        if self._closed:
+            return
+        self._closed = True
+        self._driver.release_session(self, self._executor)
+
+
+class OmnigentDriver:
+    """Create sandboxed Omnigent sessions and own their async event loop."""
+
+    _CAPABILITIES = AgentCapabilities(
+        timeouts=True,
+        session_reuse=True,
+    )
+
+    def __init__(self) -> None:
+        """Create a driver with no live sessions or event loop."""
+        self._sessions: set[OmnigentSession] = set()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._closed = False
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        """Describe the requirements Omnigent 0.6.0 can satisfy."""
+        return self._CAPABILITIES
+
+    def create_session(self, spec: AgentSessionSpec) -> OmnigentSession:
+        """Validate setup requirements and create a confined session."""
+        if self._closed:
+            raise RuntimeError("Omnigent driver is closed")
+        self._validate_spec(spec)
+        executor, schemas = self._build_executor(spec)
+        session = OmnigentSession(
+            driver=self,
+            spec=spec,
+            executor=executor,
+            tool_schemas=schemas,
+        )
+        self._sessions.add(session)
+        return session
+
+    def close(self) -> None:
+        """Close every outstanding session and the shared event loop."""
+        if self._closed:
+            return
+        self._closed = True
+        first_error: Exception | None = None
+        for session in tuple(self._sessions):
+            try:
+                session.close()
+            except Exception as exc:  # noqa: BLE001
+                if first_error is None:
+                    first_error = exc
+        loop = self._loop
+        if loop is not None and not loop.is_closed():
+            try:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+                loop.run_until_complete(asyncio.sleep(0))
+            except Exception as exc:  # noqa: BLE001
+                if first_error is None:
+                    first_error = exc
+            finally:
+                loop.close()
+        self._loop = None
+        if first_error is not None:
+            raise first_error
+
+    def _validate_spec(self, spec: AgentSessionSpec) -> None:
+        _resolve_executor_spec(spec.provider)
+        if spec.mcp_servers:
+            names = [server.name for server in spec.mcp_servers]
+            raise OmnigentDriverError(f"Omnigent cannot install session MCP servers: {names}")
+        if spec.policy.host_resources:
+            raise OmnigentDriverError("Omnigent cannot enforce VibeSys host-resource grants")
+        if spec.policy.containerized:
+            raise OmnigentDriverError(
+                "Omnigent cannot run this agent in VibeSys's container execution path"
+            )
+        project_paths = spec.policy.project_paths
+        if project_paths is not None and (
+            project_paths.read_only_paths or project_paths.hidden_paths
+        ):
+            raise OmnigentDriverError(
+                "Omnigent 0.6.0 cannot enforce VibeSys nested read-only or hidden paths"
+            )
+
+    def run_awaitable(self, awaitable: Any) -> Any:  # noqa: ANN401
+        """Run one Omnigent awaitable on the driver-owned event loop."""
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            loop = asyncio.new_event_loop()
+            self._loop = loop
+        return loop.run_until_complete(awaitable)
+
+    def _executor_class(self, spec: OmnigentExecutorSpec) -> type[Any]:
+        try:
+            module = import_module(spec.module)
+        except ImportError as exc:
+            raise _missing_omnigent(spec.module, exc) from exc
+        try:
+            return getattr(module, spec.class_name)
+        except AttributeError as exc:
+            raise OmnigentDriverError(
+                f"Omnigent module {spec.module!r} has no {spec.class_name!r}; "
+                "this integration requires the Omnigent 0.6.0 executor API"
+            ) from exc
+
+    def _build_os_env(self, workspace: Path) -> Any:  # noqa: ANN401
+        try:
+            from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec  # noqa: PLC0415
+        except ImportError as exc:
+            raise _missing_omnigent("Omnigent OS-environment datamodel", exc) from exc
+        return OSEnvSpec(
+            type="caller_process",
+            cwd=str(workspace),
+            sandbox=OSEnvSandboxSpec(
+                type=_sandbox_backend_for_platform(),
+                write_paths=[str(workspace)],
+            ),
+        )
+
+    def _build_executor(self, spec: AgentSessionSpec) -> tuple[Any, list[dict[str, Any]]]:
+        executor_spec = _resolve_executor_spec(spec.provider)
+        executor_cls = self._executor_class(executor_spec)
+        os_env_spec = self._build_os_env(spec.workspace)
+        try:
+            executor = executor_cls(
+                cwd=str(spec.workspace),
+                model=spec.model,
+                os_env=os_env_spec,
+            )
+        except ImportError as exc:
+            raise OmnigentDriverError(
+                f"Omnigent provider {spec.provider!r} is unavailable: {exc}"
+            ) from exc
+        if not hasattr(executor, _TOOL_EXECUTOR_ATTR):
+            with contextlib.suppress(Exception):
+                self.close_executor(executor)
+            raise OmnigentDriverError(
+                f"{executor_cls.__name__} has no {_TOOL_EXECUTOR_ATTR!r} slot; "
+                "this integration requires the private Omnigent 0.6.0 tool-dispatch seam"
+            )
+        try:
+            schemas, dispatch = _build_os_tools(os_env_spec, spec.workspace)
+        except BaseException:
+            with contextlib.suppress(Exception):
+                self.close_executor(executor)
+            raise
+        setattr(executor, _TOOL_EXECUTOR_ATTR, dispatch)
+        return executor, schemas
+
+    def release_session(self, session: OmnigentSession, executor: Any) -> None:  # noqa: ANN401
+        """Forget a session and close its native executor."""
+        self._sessions.discard(session)
+        self.close_executor(executor)
+
+    def close_executor(self, executor: Any) -> None:  # noqa: ANN401
+        """Close a native executor, awaiting asynchronous cleanup when needed."""
+        close = getattr(executor, "close", None)
+        if close is None:
+            return
+        result = close()
+        if asyncio.iscoroutine(result):
+            self.run_awaitable(result)

--- a/src/vibesys/agents/factory.py
+++ b/src/vibesys/agents/factory.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import TextIO
 
-    from vibesys.agents.base import AgentRunner
     from vibesys.config import Config
     from vibesys.constants import ComputeBackend
     from vs_sandbox import HostResource, ProjectPathPolicy
@@ -35,7 +34,7 @@ def resolve_agent_driver(config: Config) -> str:
     return "omnigent" if flagged else DEFAULT_AGENT_DRIVER
 
 
-def build_agent_runner(  # noqa: C901, PLR0912, PLR0913
+def build_agent_client(  # noqa: C901, PLR0912, PLR0913
     config: Config,
     *,
     agent_backend: str | None,
@@ -52,7 +51,7 @@ def build_agent_runner(  # noqa: C901, PLR0912, PLR0913
     host_resources: Iterable[HostResource] = (),
     project_path_policy: ProjectPathPolicy | None = None,
     require_host_sandbox: bool = False,
-) -> AgentRunner:
+) -> AgentClient:
     """Build the configured application-level agent service."""
     host_resources = tuple(host_resources)
     agent_cfg = config.agent
@@ -72,12 +71,12 @@ def build_agent_runner(  # noqa: C901, PLR0912, PLR0913
     if backend == "deepagents":
         if backends is None:
             raise SystemExit(  # noqa: TRY003  # tracked: #288
-                "internal error: build_agent_runner called with backend='deepagents' "
+                "internal error: build_agent_client called with backend='deepagents' "
                 "but no backends dict was provided"
             )
-        from vibesys.agents.deepagents_runner import DeepAgentsRunner  # noqa: PLC0415
+        from vibesys.agents.deepagents_runner import DeepAgentsClient  # noqa: PLC0415
 
-        return DeepAgentsRunner(
+        return DeepAgentsClient(
             model=model,
             backends=backends,
             skills=skills,
@@ -86,9 +85,9 @@ def build_agent_runner(  # noqa: C901, PLR0912, PLR0913
         )
 
     if backend == "stub":
-        from vibesys.agents.stub_runner import StubAgentRunner  # noqa: PLC0415
+        from vibesys.agents.stub_runner import StubAgentClient  # noqa: PLC0415
 
-        return StubAgentRunner()
+        return StubAgentClient()
 
     if backend != "cli":
         raise SystemExit(f"unknown agent backend: {backend!r}")  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/agents/factory.py
+++ b/src/vibesys/agents/factory.py
@@ -1,0 +1,184 @@
+"""Application composition for agent clients and execution drivers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from vibesys.agents.client import AgentClient, AgentDiagnosticLog
+from vibesys.constants import DEFAULT_AGENT_BACKEND
+from vibesys.features import FeatureFlag, is_feature_enabled
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+    from typing import TextIO
+
+    from vibesys.agents.base import AgentRunner
+    from vibesys.config import Config
+    from vibesys.constants import ComputeBackend
+    from vs_sandbox import HostResource, ProjectPathPolicy
+
+DEFAULT_AGENT_DRIVER = "agentshim"
+
+
+def resolve_agent_driver(config: Config) -> str:
+    """Resolve the optional driver override and its feature-flag compatibility."""
+    configured = config.agent.driver
+    flagged = is_feature_enabled(FeatureFlag.OMNIGENT_AGENT_BACKEND, config)
+    if configured is not None and flagged and configured != "omnigent":
+        raise SystemExit(  # noqa: TRY003  # tracked: #288
+            "agent.driver='agentshim' conflicts with the enabled "
+            "'omnigent_agent_backend' compatibility feature flag"
+        )
+    if configured is not None:
+        return configured
+    return "omnigent" if flagged else DEFAULT_AGENT_DRIVER
+
+
+def build_agent_runner(  # noqa: C901, PLR0912, PLR0913
+    config: Config,
+    *,
+    agent_backend: str | None,
+    cli_provider: str | None,
+    backends: dict[str, Any] | None,
+    skills: list[str],
+    skill_source_dirs: list[Path],
+    compute_backend: ComputeBackend | None = None,
+    model: Any,  # noqa: ANN401
+    model_name: str,
+    run_log_file: TextIO | None,
+    use_docker: bool,
+    log_dir: Path | None = None,
+    host_resources: Iterable[HostResource] = (),
+    project_path_policy: ProjectPathPolicy | None = None,
+    require_host_sandbox: bool = False,
+) -> AgentRunner:
+    """Build the configured application-level agent service."""
+    host_resources = tuple(host_resources)
+    agent_cfg = config.agent
+    backend = agent_backend or agent_cfg.backend or DEFAULT_AGENT_BACKEND
+
+    if backend != "cli" and agent_cfg.driver is not None:
+        raise SystemExit(  # noqa: TRY003  # tracked: #288
+            f"agent driver {agent_cfg.driver!r} is valid only with backend='cli', not {backend!r}"
+        )
+
+    if require_host_sandbox and backend not in {"cli", "stub"}:
+        raise SystemExit(  # noqa: TRY003  # tracked: #288
+            "local project execution requires the CLI agent backend so VibeSys can "
+            "enforce nested read-only and hidden paths"
+        )
+
+    if backend == "deepagents":
+        if backends is None:
+            raise SystemExit(  # noqa: TRY003  # tracked: #288
+                "internal error: build_agent_runner called with backend='deepagents' "
+                "but no backends dict was provided"
+            )
+        from vibesys.agents.deepagents_runner import DeepAgentsRunner  # noqa: PLC0415
+
+        return DeepAgentsRunner(
+            model=model,
+            backends=backends,
+            skills=skills,
+            model_name=model_name,
+            run_log_file=run_log_file,
+        )
+
+    if backend == "stub":
+        from vibesys.agents.stub_runner import StubAgentRunner  # noqa: PLC0415
+
+        return StubAgentRunner()
+
+    if backend != "cli":
+        raise SystemExit(f"unknown agent backend: {backend!r}")  # noqa: TRY003  # tracked: #288
+
+    driver_name = resolve_agent_driver(config)
+    provider = cli_provider or agent_cfg.cli_provider or "codex"
+    timeout = agent_cfg.cli_timeout
+    driver_log = AgentDiagnosticLog(run_log_file)
+
+    if driver_name == "omnigent":
+        if use_docker:
+            raise SystemExit(  # noqa: TRY003  # tracked: #288
+                "agent.driver='omnigent' is not supported with --docker"
+            )
+        from vibesys.agents.drivers.omnigent import (  # noqa: PLC0415
+            OmnigentDriver,
+            OmnigentDriverError,
+        )
+        from vibesys.agents.omnigent.providers import (  # noqa: PLC0415
+            OMNIGENT_PROVIDER_EXECUTORS,
+            supported_providers,
+        )
+
+        if provider not in OMNIGENT_PROVIDER_EXECUTORS:
+            raise OmnigentDriverError(  # noqa: TRY003
+                f"Omnigent does not support agent provider {provider!r}; "
+                f"supported providers: {supported_providers()}. Select "
+                "agent.driver='agentshim' for other providers."
+            )
+        if host_resources or (
+            project_path_policy is not None
+            and (project_path_policy.read_only_paths or project_path_policy.hidden_paths)
+        ):
+            raise OmnigentDriverError(  # noqa: TRY003
+                "Omnigent cannot enforce the requested VibeSys host-resource "
+                f"grants ({[str(resource.path) for resource in host_resources]}), "
+                "nested read-only paths, or hidden paths. Select "
+                "agent.driver='agentshim' for this policy."
+            )
+
+        driver = OmnigentDriver()
+    else:
+        docker_sandboxes = None
+        if use_docker:
+            from vibesys.agents.cli_docker import DOCKER_PROVIDER_ENV  # noqa: PLC0415
+
+            if provider not in DOCKER_PROVIDER_ENV:
+                raise SystemExit(  # noqa: TRY003  # tracked: #288
+                    f"--cli-provider {provider!r} is not yet supported with --docker; "
+                    f"supported: {sorted(DOCKER_PROVIDER_ENV)}"
+                )
+            docker_sandboxes = backends
+        from vibesys.agents.drivers.agentshim import AgentShimDriver  # noqa: PLC0415
+
+        driver = AgentShimDriver(
+            provider=provider,
+            timeout=timeout,
+            docker_sandboxes=docker_sandboxes,
+            log=driver_log,
+        )
+
+    return AgentClient(
+        driver,
+        provider=provider,
+        skills=skill_source_dirs,
+        compute_backend=compute_backend,
+        model_name=model_name or provider,
+        timeout=timeout,
+        run_log_file=run_log_file,
+        log_dir=log_dir,
+        default_reasoning_effort=config.thinking.level,
+        role_models={
+            role: configured
+            for role, configured in {
+                "orchestrator": agent_cfg.outer.model,
+                "implementer": agent_cfg.inner.model,
+            }.items()
+            if configured is not None
+        },
+        role_reasoning_efforts={
+            role: configured
+            for role, configured in {
+                "orchestrator": agent_cfg.outer.reasoning_effort,
+                "implementer": agent_cfg.inner.reasoning_effort,
+            }.items()
+            if configured is not None
+        },
+        project_path_policy=project_path_policy,
+        host_resources=host_resources,
+        require_host_sandbox=require_host_sandbox,
+        containerized=use_docker,
+        driver_log=driver_log,
+    )

--- a/src/vibesys/agents/omnigent/__init__.py
+++ b/src/vibesys/agents/omnigent/__init__.py
@@ -1,17 +1,10 @@
-"""Opt-in Omnigent agent backend.
+"""Import-safe Omnigent provider metadata.
 
-Selected only when the ``omnigent_agent_backend`` feature flag is enabled;
-see :doc:`docs/omnigent-evaluation` for why this is opt-in rather than the
-default. Nothing in this package is imported on the agentshim path.
-
-``providers`` is import-safe everywhere (it holds only data). ``runner``
-imports ``omnigent`` lazily, inside the methods that need it, so importing
-this package never requires the optional dependency.
+The implementation lives in :mod:`vibesys.agents.drivers.omnigent` and imports
+the optional dependency only while creating or running a session.
 """
 
 from __future__ import annotations
-
-from typing import TYPE_CHECKING
 
 from vibesys.agents.omnigent.providers import (
     OMNIGENT_PROVIDER_EXECUTORS,
@@ -19,28 +12,8 @@ from vibesys.agents.omnigent.providers import (
     supported_providers,
 )
 
-if TYPE_CHECKING:
-    # Statically visible without triggering the runtime import below.
-    from vibesys.agents.omnigent.runner import (
-        OmnigentAgentRunner,
-        OmnigentUnavailableError,
-    )
-
 __all__ = [
     "OMNIGENT_PROVIDER_EXECUTORS",
-    "OmnigentAgentRunner",
     "OmnigentExecutorSpec",
-    "OmnigentUnavailableError",
     "supported_providers",
 ]
-
-
-def __getattr__(name: str) -> object:
-    # Deferred so that `import vibesys.agents.omnigent` stays cheap and does
-    # not pull in langchain/pydantic wiring for callers that only need the
-    # provider table (e.g. build_agent_runner's validation path).
-    if name in {"OmnigentAgentRunner", "OmnigentUnavailableError"}:
-        from vibesys.agents.omnigent import runner  # noqa: PLC0415  # tracked: #288
-
-        return getattr(runner, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/agents/omnigent/providers.py
+++ b/src/vibesys/agents/omnigent/providers.py
@@ -6,8 +6,7 @@ else. It deliberately does not import ``omnigent`` — the mapping is data, so
 it stays importable and unit-testable without the optional dependency
 installed.
 
-:mod:`vibesys.agents.omnigent.runner` is the implementation half: it resolves
-these entries to real classes at call time.
+:mod:`vibesys.agents.drivers.omnigent` resolves these entries at session setup.
 
 Coverage against ``omnigent==0.6.0``, verified by inspecting the installed
 package rather than its docs:
@@ -21,7 +20,7 @@ package rather than its docs:
   run a headless turn in a VibeSys workspace.
 
 Both supported entries accept ``cwd``/``model``/``os_env``, which is the
-constructor shape :class:`~vibesys.agents.omnigent.runner.OmnigentAgentRunner`
+constructor shape :class:`~vibesys.agents.drivers.omnigent.OmnigentDriver`
 depends on.
 """
 

--- a/src/vibesys/agents/omnigent/runner.py
+++ b/src/vibesys/agents/omnigent/runner.py
@@ -55,6 +55,7 @@ from vibesys.agents.cli_common import (
     build_schema_hint,
     materialize_skills,
 )
+from vibesys.agents.contracts import AgentCapabilities
 from vibesys.agents.omnigent.providers import (
     OMNIGENT_PROVIDER_EXECUTORS,
     OmnigentExecutorSpec,
@@ -341,6 +342,11 @@ class OmnigentAgentRunner:
     """
 
     backend_name = "omnigent"
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        """Compatibility metadata for the superseded concrete runner."""
+        return AgentCapabilities(timeouts=False)
 
     def __init__(  # noqa: D107, PLR0913  # tracked: #288
         self,

--- a/src/vibesys/agents/omnigent/runner.py
+++ b/src/vibesys/agents/omnigent/runner.py
@@ -1,4 +1,4 @@
-"""Omnigent-backed implementation of :class:`~vibesys.agents.base.AgentRunner`.
+"""Pre-driver Omnigent client retained for compatibility tests.
 
 This is the opt-in alternative to :class:`~vibesys.agents.cli_runner.CliAgentRunner`,
 selected only when :attr:`~vibesys.features.FeatureFlag.OMNIGENT_AGENT_BACKEND`
@@ -333,19 +333,17 @@ async def _drive_turn(
 
 
 class OmnigentAgentRunner:
-    """:class:`AgentRunner` backed by Omnigent's in-process executors.
+    """Direct compatibility client backed by Omnigent's in-process executors.
 
-    Constructed only by :func:`vibesys.agents.build_agent_runner` when the
-    ``omnigent_agent_backend`` flag is on. Construction validates the provider
-    eagerly so an unsupported combination fails before the loop starts rather
-    than mid-round.
+    Construction validates the provider eagerly so an unsupported combination
+    fails before the loop starts rather than mid-round.
     """
 
     backend_name = "omnigent"
 
     @property
     def capabilities(self) -> AgentCapabilities:
-        """Compatibility metadata for the superseded concrete runner."""
+        """Return the direct client's supported features."""
         return AgentCapabilities(timeouts=False)
 
     def __init__(  # noqa: D107, PLR0913  # tracked: #288

--- a/src/vibesys/agents/stub_runner.py
+++ b/src/vibesys/agents/stub_runner.py
@@ -1,4 +1,4 @@
-"""Fast deterministic agent runner for end-to-end interface smoke tests."""
+"""Fast deterministic agent client for end-to-end interface smoke tests."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, TypeVar
 from pydantic import BaseModel
 
 from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #288
+from vibesys.agents.client import AgentClient
 from vibesys.agents.contracts import AgentCapabilities
 from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 from vibesys.schemas import HypothesisOutcome
@@ -21,10 +22,13 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound=BaseModel)
 
 
-class StubAgentRunner:
+class StubAgentClient(AgentClient):
     """Return valid canned responses without invoking an external agent."""
 
     backend_name = "stub"
+
+    def __init__(self) -> None:
+        """Create a stateless deterministic client."""
 
     @property
     def capabilities(self) -> AgentCapabilities:
@@ -33,6 +37,10 @@ class StubAgentRunner:
 
     def close(self) -> None:
         """The deterministic stub owns no external resources."""
+
+    def set_log_file(self, stream: object) -> None:
+        """Accept log retargeting; the deterministic stub emits no file logs."""
+        del stream
 
     def invoke(  # noqa: D102, PLR0913  # tracked: #288
         self,

--- a/src/vibesys/agents/stub_runner.py
+++ b/src/vibesys/agents/stub_runner.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, TypeVar
 from pydantic import BaseModel
 
 from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #288
+from vibesys.agents.contracts import AgentCapabilities
 from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 from vibesys.schemas import HypothesisOutcome
 
@@ -24,6 +25,14 @@ class StubAgentRunner:
     """Return valid canned responses without invoking an external agent."""
 
     backend_name = "stub"
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        """The deterministic stub does not expose external tools."""
+        return AgentCapabilities(session_reuse=False)
+
+    def close(self) -> None:
+        """The deterministic stub owns no external resources."""
 
     def invoke(  # noqa: D102, PLR0913  # tracked: #288
         self,

--- a/src/vibesys/config.py
+++ b/src/vibesys/config.py
@@ -176,6 +176,14 @@ class AgentRoleCfg(_Strict):
 
 
 class AgentCfg(_Strict):  # noqa: D101  # tracked: #288
+    driver: Literal["agentshim", "omnigent"] | None = Field(
+        default=None,
+        description=(
+            "Optional agent execution driver override. When omitted, VibeSys "
+            "uses its current default driver. This is independent of the "
+            "agent provider selected below."
+        ),
+    )
     backend: str | None = Field(
         default=None,
         description=(

--- a/src/vibesys/constants.py
+++ b/src/vibesys/constants.py
@@ -65,5 +65,5 @@ KNOWN_COMPUTE_BACKENDS: tuple[str, ...] = tuple(b.value for b in ComputeBackend)
 
 # Agent backend used when neither the ``--agent-backend`` flag nor an
 # ``[agent].backend`` config key is set. Resolved in a single place so
-# build_agent_runner and ComputeContext cannot drift.
+# build_agent_client and ComputeContext cannot drift.
 DEFAULT_AGENT_BACKEND = "cli"

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -826,6 +826,9 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
         project_path_policy=project_path_policy,
         require_host_sandbox=not session.view.cli_sandboxed,
     )
+    close_agent_runner = getattr(agent_runner, "close", None)
+    if callable(close_agent_runner):
+        teardown_stack.callback(close_agent_runner)
 
     result = _RunContext(
         backend=backend,
@@ -1030,6 +1033,9 @@ def _assemble_candidate_context(  # noqa: PLR0913  # tracked: #288
         project_path_policy=project_path_policy,
         require_host_sandbox=not session.view.cli_sandboxed,
     )
+    close_agent_runner = getattr(agent_runner, "close", None)
+    if callable(close_agent_runner):
+        teardown_stack.callback(close_agent_runner)
 
     paths = RunPaths(
         project_root=workspace,
@@ -1501,8 +1507,14 @@ class _RunContext:
         self._paths = replace(self._paths, run_log_path=self.logger.path)
         # Update the agent runner's log file handle so subsequent
         # invoke() calls write to the new step log.
-        if hasattr(self, "agent_runner") and hasattr(self.agent_runner, "_run_log_file"):
-            self.agent_runner._run_log_file = self.logger.writer  # pyright: ignore[reportAttributeAccessIssue]  # noqa: SLF001  # tracked: #288
+        if hasattr(self, "agent_runner"):
+            set_log_file = getattr(self.agent_runner, "set_log_file", None)
+            if callable(set_log_file):
+                set_log_file(self.logger.writer)
+            elif hasattr(self.agent_runner, "_run_log_file"):
+                # Compatibility for deepagents/stub until they adopt the
+                # application-level client lifecycle.
+                self.agent_runner._run_log_file = self.logger.writer  # pyright: ignore[reportAttributeAccessIssue]  # noqa: SLF001  # tracked: #288
 
     def reselect_gpu(self) -> None:
         """Delegate mid-run device rebalance — see :meth:`DeviceLease.reselect`."""

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -15,8 +15,7 @@ from typing import TYPE_CHECKING, Any, TextIO, TypeVar, overload
 from pydantic import BaseModel
 
 from vibesys import backends
-from vibesys.agents import build_agent_runner
-from vibesys.agents.base import AgentRunner
+from vibesys.agents import AgentClient, build_agent_client
 from vibesys.agents.progress import AgentProgress
 from vibesys.backends.base import ComputeBackendImpl, ContentionMonitor
 from vibesys.config import Config, as_config
@@ -791,11 +790,11 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
     teardown_stack.callback(device.close)
     device.start_monitor()
 
-    # Build the backend-agnostic agent runner. Loops invoke this instead
+    # Build the backend-agnostic agent client. Loops invoke this instead
     # of calling create_deep_agent / vibesys._agent_cli directly. The cli
-    # backend is rejected if --docker is set; build_agent_runner raises
+    # backend is rejected if --docker is set; build_agent_client raises
     # SystemExit with a clear message in that case.
-    agent_runner = build_agent_runner(
+    agent_client = build_agent_client(
         config,
         agent_backend=agent_backend,
         cli_provider=cli_provider,
@@ -826,9 +825,9 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
         project_path_policy=project_path_policy,
         require_host_sandbox=not session.view.cli_sandboxed,
     )
-    close_agent_runner = getattr(agent_runner, "close", None)
-    if callable(close_agent_runner):
-        teardown_stack.callback(close_agent_runner)
+    close_agent_client = getattr(agent_client, "close", None)
+    if callable(close_agent_client):
+        teardown_stack.callback(close_agent_client)
 
     result = _RunContext(
         backend=backend,
@@ -862,7 +861,7 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
         run_environment_session=session,
         commands=commands,
         device=device,
-        agent_runner=agent_runner,
+        agent_client=agent_client,
         project=project,
         state=RunState(project, git, run_id),
         run_id=run_id,
@@ -892,7 +891,7 @@ def create_candidate_context(  # noqa: PLR0913  # tracked: #288
     - a **git worktree** checked out at ``parent_commit`` (isolated working
       tree / index / detached HEAD; edits never touch the shared tree);
     - a fresh **run-environment session** (its own isolated editor sandbox);
-    - its own **agent runner** (the CLI runner is not thread-safe);
+    - its own **agent client** (the CLI session is not thread-safe);
     - a **no-tee ``RunLogger``** writing only to the candidate's log file — only
       the top-level run logger may own the process ``sys.stderr``.
 
@@ -1010,7 +1009,7 @@ def _assemble_candidate_context(  # noqa: PLR0913  # tracked: #288
         profiler_benchmark_command=session.view.paths.benchmark_command,
     )
 
-    agent_runner = build_agent_runner(
+    agent_client = build_agent_client(
         config,
         agent_backend=agent_backend,
         cli_provider=cli_provider,
@@ -1033,9 +1032,9 @@ def _assemble_candidate_context(  # noqa: PLR0913  # tracked: #288
         project_path_policy=project_path_policy,
         require_host_sandbox=not session.view.cli_sandboxed,
     )
-    close_agent_runner = getattr(agent_runner, "close", None)
-    if callable(close_agent_runner):
-        teardown_stack.callback(close_agent_runner)
+    close_agent_client = getattr(agent_client, "close", None)
+    if callable(close_agent_client):
+        teardown_stack.callback(close_agent_client)
 
     paths = RunPaths(
         project_root=workspace,
@@ -1077,7 +1076,7 @@ def _assemble_candidate_context(  # noqa: PLR0913  # tracked: #288
         run_environment_session=session,
         commands=commands,
         device=parent.device,  # shared under the environment's parallel contract
-        agent_runner=agent_runner,
+        agent_client=agent_client,
         project=parent.project,
         state=parent.state,
         run_id=parent.run_id,
@@ -1094,7 +1093,7 @@ class _RunContext:
     Instances are assembled by :func:`create_run_context`, which owns every
     construction side effect (project state, log files, candidate worktree,
     model, compute backend, copied helper inputs, Git snapshot tracking,
-    run-environment session, agent runner, GPU monitor).  Environment-specific
+    run-environment session, agent client, GPU monitor). Environment-specific
     setup should stay in ``vibesys.sandbox.run_environment``; this class only
     asks the selected run environment for policy decisions and the opened
     sandbox session.
@@ -1134,7 +1133,7 @@ class _RunContext:
         run_environment_session: RunEnvironmentSession,
         commands: RunCommands,
         device: DeviceLease,
-        agent_runner: AgentRunner,
+        agent_client: AgentClient,
         project: Project,
         state: RunState,
         run_id: str,
@@ -1183,7 +1182,7 @@ class _RunContext:
         self.device = device
         # Expose the picked device for legacy callers (gpu monitor tests etc).
         self.selected_gpu = device.selected_device
-        self.agent_runner = agent_runner
+        self.agent_client = agent_client
         self._closed = False
         self._progress_stack: list[AgentProgress] = []
         self._chat_lock = threading.Lock()
@@ -1256,7 +1255,7 @@ class _RunContext:
         self.device.monitor = monitor
 
     def gpu_env(self) -> dict[str, str]:
-        """Env vars for the host-running cli agent runner — see :meth:`DeviceLease.gpu_env`."""
+        """Env vars for the host-running CLI agent; see :meth:`DeviceLease.gpu_env`."""
         return self.device.gpu_env()
 
     @contextmanager
@@ -1286,12 +1285,12 @@ class _RunContext:
         progress: AgentProgress | None = None,
         **extra: Any,  # noqa: ANN401  # tracked: #288
     ) -> T:
-        """Invoke an agent through ``self.agent_runner`` with workspace+env defaults.
+        """Invoke an agent through ``self.agent_client`` with workspace+env defaults.
 
-        Wraps ``self.agent_runner.invoke(...)`` so the per-call boilerplate
+        Wraps ``self.agent_client.invoke(...)`` so the per-call boilerplate
         (``workspace=self.workspace``, ``env=self.gpu_env()``) doesn't have
         to be repeated at every call site.  Extra kwargs are forwarded to
-        ``agent_runner.invoke`` unchanged so loop-specific options
+        ``agent_client.invoke`` unchanged so loop-specific options
         (e.g. ``iteration=`` for plain-loop runner extensions) still work.
         """
         supervisor = getattr(self, "supervisor", None)
@@ -1302,7 +1301,7 @@ class _RunContext:
         result: T | None = None
         error: BaseException | None = None
         try:
-            result = self.agent_runner.invoke(
+            result = self.agent_client.invoke(
                 kind=kind,
                 workspace=self.workspace,
                 system_prompt=system_prompt,
@@ -1347,7 +1346,7 @@ class _RunContext:
                 invocation_id=invocation_id,
             ):
                 try:
-                    answer = self.agent_runner.invoke_text(
+                    answer = self.agent_client.invoke_text(
                         kind="chat",
                         workspace=self.workspace,
                         system_prompt=system_prompt,
@@ -1505,16 +1504,10 @@ class _RunContext:
         """Switch to a per-phase log file — see :meth:`RunLogger.switch`."""
         self.logger.switch(label)
         self._paths = replace(self._paths, run_log_path=self.logger.path)
-        # Update the agent runner's log file handle so subsequent
+        # Update the agent client's log file handle so subsequent
         # invoke() calls write to the new step log.
-        if hasattr(self, "agent_runner"):
-            set_log_file = getattr(self.agent_runner, "set_log_file", None)
-            if callable(set_log_file):
-                set_log_file(self.logger.writer)
-            elif hasattr(self.agent_runner, "_run_log_file"):
-                # Compatibility for deepagents/stub until they adopt the
-                # application-level client lifecycle.
-                self.agent_runner._run_log_file = self.logger.writer  # pyright: ignore[reportAttributeAccessIssue]  # noqa: SLF001  # tracked: #288
+        if hasattr(self, "agent_client"):
+            self.agent_client.set_log_file(self.logger.writer)
 
     def reselect_gpu(self) -> None:
         """Delegate mid-run device rebalance — see :meth:`DeviceLease.reselect`."""

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -2092,7 +2092,7 @@ def _run_framework_gates(  # noqa: PLR0913  # tracked: #288
     carry its complete metric row to the round record; it is empty whenever the
     benchmark did not run.
     """
-    if ctx.agent_runner.backend_name == "stub":
+    if ctx.agent_client.backend_name == "stub":
         return None, FrameworkBenchmarkOutcome(), False
     resource_feedback = _reconcile_model_requests(ctx)
     if resource_feedback is not None:
@@ -3109,13 +3109,13 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     official_evaluation=(
                         passed
                         and completed_official_evaluation_reason is not None
-                        and ctx.agent_runner.backend_name != "stub"
+                        and ctx.agent_client.backend_name != "stub"
                         and (bool(ctx.judge_accuracy_command) or framework_benchmark_configured)
                     ),
                     official_evaluation_reason=(
                         completed_official_evaluation_reason
                         if (
-                            ctx.agent_runner.backend_name != "stub"
+                            ctx.agent_client.backend_name != "stub"
                             and (bool(ctx.judge_accuracy_command) or framework_benchmark_configured)
                         )
                         else None

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -17,6 +17,7 @@ from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any, Literal
 
 from vibesys.agents.base import ResponseFallback
+from vibesys.agents.factory import resolve_agent_driver
 from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config, as_config
 from vibesys.constants import DEFAULT_AGENT_BACKEND, DEFAULT_COMPUTE_BACKEND, ComputeBackend
@@ -2248,16 +2249,20 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
         modality = "text_generation"
     run_environment = run_environment or make_run_environment_spec()
     normalized_config = as_config(config)
+    resolved_agent_backend = (
+        "stub"
+        if agent_backend == "stub"
+        else agent_backend or normalized_config.agent.backend or DEFAULT_AGENT_BACKEND
+    )
     project_configuration = AgentRunConfiguration(
         outer_loop="agent",
         run_environment=run_environment_record(run_environment),
         inner_loop=inner_loop,
         interface=interface,
         model=normalized_config.model.name,
-        agent_backend=(
-            "stub"
-            if agent_backend == "stub"
-            else agent_backend or normalized_config.agent.backend or DEFAULT_AGENT_BACKEND
+        agent_backend=resolved_agent_backend,
+        agent_driver=(
+            resolve_agent_driver(normalized_config) if resolved_agent_backend == "cli" else None
         ),
         cli_provider=(
             cli_provider or normalized_config.agent.cli_provider or "codex"

--- a/src/vibesys/loops/evolve/loop.py
+++ b/src/vibesys/loops/evolve/loop.py
@@ -39,6 +39,7 @@ from typing import Any, cast
 
 from jinja2 import Environment, FileSystemLoader
 
+from vibesys.agents.factory import resolve_agent_driver
 from vibesys.agents.progress import CandidateProgress
 from vibesys.config import Config, as_config
 from vibesys.constants import DEFAULT_AGENT_BACKEND, DEFAULT_COMPUTE_BACKEND, ComputeBackend
@@ -1328,11 +1329,17 @@ def run_evolve_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     run_environment = run_environment or make_run_environment_spec()
     normalized_config = as_config(config)
     selected_policy = SearchPolicyName(search_policy).value if search_policy is not None else None
+    resolved_agent_backend = (
+        agent_backend or normalized_config.agent.backend or DEFAULT_AGENT_BACKEND
+    )
     run_configuration = EvolveRunConfiguration(
         outer_loop="evolve",
         run_environment=run_environment_record(run_environment),
         model=normalized_config.model.name,
-        agent_backend=(agent_backend or normalized_config.agent.backend or DEFAULT_AGENT_BACKEND),
+        agent_backend=resolved_agent_backend,
+        agent_driver=(
+            resolve_agent_driver(normalized_config) if resolved_agent_backend == "cli" else None
+        ),
         cli_provider=cli_provider or normalized_config.agent.cli_provider or "codex",
         cli_timeout=normalized_config.agent.cli_timeout,
         compute_backend=backend.value,

--- a/src/vibesys/loops/plain/loop.py
+++ b/src/vibesys/loops/plain/loop.py
@@ -25,6 +25,7 @@ from datetime import UTC, datetime
 from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any
 
+from vibesys.agents.factory import resolve_agent_driver
 from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config, as_config
 from vibesys.constants import DEFAULT_AGENT_BACKEND, DEFAULT_COMPUTE_BACKEND, ComputeBackend
@@ -300,11 +301,13 @@ def run_plain_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     config = as_config(config)
     domain_definition = resolve_domain(domain)
     run_environment = run_environment or make_run_environment_spec()
+    resolved_agent_backend = agent_backend or config.agent.backend or DEFAULT_AGENT_BACKEND
     run_configuration = PlainRunConfiguration(
         outer_loop="plain",
         run_environment=run_environment_record(run_environment),
         model=config.model.name,
-        agent_backend=agent_backend or config.agent.backend or DEFAULT_AGENT_BACKEND,
+        agent_backend=resolved_agent_backend,
+        agent_driver=(resolve_agent_driver(config) if resolved_agent_backend == "cli" else None),
         cli_provider=cli_provider or config.agent.cli_provider or "codex",
         cli_timeout=config.agent.cli_timeout,
         compute_backend=backend.value,

--- a/src/vibesys/loops/plain/loop.py
+++ b/src/vibesys/loops/plain/loop.py
@@ -34,7 +34,7 @@ from vibesys.domains.base import DomainName  # noqa: TC001  # tracked: #288
 from vibesys.domains.registry import resolve_domain
 from vibesys.input_manifest import WorkspaceSource  # noqa: TC001  # tracked: #288
 from vibesys.loops.plain.render import render_all
-from vibesys.loops.plain.runner_ext import PlainLoopAgentRunner
+from vibesys.loops.plain.runner_ext import PlainLoopAgentClient
 from vibesys.loops.plain.state import PlainStateStore
 from vibesys.profilers import ProfilerKind
 from vibesys.prompts import PROMPTS_DIR, Prompt
@@ -384,10 +384,9 @@ def run_plain_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
         # MCP server spec under cli). The wrapper consumes an extra
         # ``iteration=`` kwarg on invoke() that the loop passes per call.
         # See vibesys/plain/runner_ext.py.
-        # Duck-typed wrapper: preserves the AgentRunner surface the issue
-        # loop uses (see PlainLoopAgentRunner docstring).
-        ctx.agent_runner = PlainLoopAgentRunner(  # pyright: ignore[reportAttributeAccessIssue]
-            ctx.agent_runner,
+        # The wrapper preserves the AgentClient surface while adding issue tools.
+        ctx.agent_client = PlainLoopAgentClient(
+            ctx.agent_client,
             store=store,
             max_issues_per_perf_eval=max_issues_per_perf_eval,
         )
@@ -570,7 +569,7 @@ def run_plain_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
 
                     ctx.wait_for_debug(f"Judge step on issue #{issue.id}")
                     ctx.lprint(f"\n>>> Judge reviewing issue #{issue.id}...")
-                    # PlainLoopAgentRunner injects tracker access (in-process
+                    # PlainLoopAgentClient injects tracker access (in-process
                     # @tool callables under deepagents, MCPServerSpec under
                     # cli) for kind="judge" — see
                     # vibesys/plain/runner_ext.py. The judge may file
@@ -694,7 +693,7 @@ def run_plain_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
 
                 ctx.wait_for_debug("Perf evaluator step")
                 ctx.lprint("\n>>> Performance Evaluator benchmarking...")
-                # PlainLoopAgentRunner injects tracker access for kind="perf_eval"
+                # PlainLoopAgentClient injects tracker access for kind="perf_eval"
                 # and scopes the per-iteration cap by the iteration kwarg below,
                 # so issues filed here are counted against iter_label's budget.
                 # See vibesys/plain/runner_ext.py.

--- a/src/vibesys/loops/plain/mcp_config.py
+++ b/src/vibesys/loops/plain/mcp_config.py
@@ -1,6 +1,6 @@
 """Build the :class:`~vibesys._agent_cli.MCPServerSpec` for the issue tracker.
 
-The issue-loop hands one of these to ``CliAgentRunner.invoke(mcp_servers=...)``
+The issue-loop hands one of these to ``AgentClient.invoke(mcp_servers=...)``
 each phase. The runner then forwards it to the active provider's
 ``install_mcp_servers`` hook, which serializes the spec into whatever config
 format that CLI expects (``.mcp.json`` for Claude, ``.gemini/settings.json``

--- a/src/vibesys/loops/plain/runner_ext.py
+++ b/src/vibesys/loops/plain/runner_ext.py
@@ -2,9 +2,8 @@
 
 Wraps any :class:`~vibesys.agents.base.AgentRunner` and injects
 tracker access for the ``judge`` and ``perf_eval`` phases. The wrapper
-picks the right transport (MCP server spec for the cli backend, in-process
-``@tool`` callables for the deepagents backend) by inspecting the inner
-runner's ``backend_name``.
+picks the right transport (MCP server spec or in-process ``@tool`` callables)
+from the inner runner's declared capabilities.
 
 This module is the only place that knows BOTH:
   - the issue-tracker policy (creator/iteration/cap/types per phase)
@@ -27,6 +26,7 @@ from pydantic import BaseModel
 
 from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #288
 from vibesys.agents.base import AgentRunner  # noqa: TC001  # tracked: #288
+from vibesys.agents.contracts import AgentCapabilities  # noqa: TC001
 from vibesys.loops.plain.mcp_config import build_issue_mcp_spec
 from vibesys.loops.plain.tools import build_issue_tools
 from vs_issue_board import IssueBoard, IssueType
@@ -67,6 +67,21 @@ class PlainLoopAgentRunner:
     @property
     def backend_name(self) -> str:  # noqa: D102  # tracked: #288
         return self._inner.backend_name
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        """Preserve the inner runner's declared capabilities."""
+        return self._inner.capabilities
+
+    def set_log_file(self, stream: Any) -> None:  # noqa: ANN401
+        """Retarget inner-runner logs when the run changes log files."""
+        setter = getattr(self._inner, "set_log_file", None)
+        if callable(setter):
+            setter(stream)
+
+    def close(self) -> None:
+        """Close the inner runner."""
+        self._inner.close()
 
     def invoke(  # noqa: D102  # tracked: #288
         self,
@@ -119,16 +134,14 @@ class PlainLoopAgentRunner:
     ) -> dict[str, Any]:
         """Build the right injection-point kwarg for the inner backend.
 
-        Returns ``{"mcp_servers": [...]}`` under the cli backend (the cli
-        runner installs them as a stdio MCP server before ``generate()``)
-        and ``{"tools": [...]}`` under deepagents (the runner forwards
-        them straight to ``create_deep_agent(tools=...)``).
+        Returns ``{"mcp_servers": [...]}`` when the runtime supports MCP and
+        ``{"tools": [...]}`` when it supports in-process tools.
 
         Both factories share the policy semantics in
         :mod:`vs_issue_board.policy`, so cap and type-allowlist
         enforcement is byte-identical between backends.
         """
-        if self._inner.backend_name == "cli":
+        if self._inner.capabilities.mcp_servers:
             spec = build_issue_mcp_spec(
                 store_relpath="issues.json",
                 creator=creator,
@@ -137,7 +150,11 @@ class PlainLoopAgentRunner:
                 allowed_types=set(allowed_types),
             )
             return {"mcp_servers": [spec]}
-        # deepagents (and any future in-process backend)
+        if not self._inner.capabilities.in_process_tools:
+            raise RuntimeError(  # noqa: TRY003
+                f"agent backend {self._inner.backend_name!r} cannot expose issue-board tools"
+            )
+        # Deepagents and other explicitly in-process implementations.
         issue_tools = build_issue_tools(
             self._store,
             iteration=iteration,

--- a/src/vibesys/loops/plain/runner_ext.py
+++ b/src/vibesys/loops/plain/runner_ext.py
@@ -1,15 +1,15 @@
 """Issue-tracker runner customization.
 
-Wraps any :class:`~vibesys.agents.base.AgentRunner` and injects
+Wraps any :class:`~vibesys.agents.client.AgentClient` and injects
 tracker access for the ``judge`` and ``perf_eval`` phases. The wrapper
 picks the right transport (MCP server spec or in-process ``@tool`` callables)
-from the inner runner's declared capabilities.
+from the inner client's declared capabilities.
 
 This module is the only place that knows BOTH:
   - the issue-tracker policy (creator/iteration/cap/types per phase)
   - the per-backend translation (``MCPServerSpec`` vs ``list[BaseTool]``)
 
-The base AgentRunner implementations stay agnostic — they only see the
+The base AgentClient implementations stay agnostic — they only see the
 generic ``mcp_servers``/``tools`` injection-point kwargs.
 
 Implementer phase: passes through unmodified. The relevant issue is
@@ -19,14 +19,16 @@ tools are needed there.
 
 from __future__ import annotations
 
+from pathlib import Path  # noqa: TC003
 from typing import Any, TypeVar
 
 from langchain_core.tools import BaseTool  # noqa: TC002  # tracked: #288
 from pydantic import BaseModel
 
 from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #288
-from vibesys.agents.base import AgentRunner  # noqa: TC001  # tracked: #288
+from vibesys.agents.client import AgentClient
 from vibesys.agents.contracts import AgentCapabilities  # noqa: TC001
+from vibesys.agents.progress import AgentProgress  # noqa: TC001
 from vibesys.loops.plain.mcp_config import build_issue_mcp_spec
 from vibesys.loops.plain.tools import build_issue_tools
 from vs_issue_board import IssueBoard, IssueType
@@ -44,10 +46,10 @@ _PERF_EVAL_ALLOWED_TYPES: frozenset[IssueType] = frozenset(
 _JUDGE_CAP: int = 1
 
 
-class PlainLoopAgentRunner:
-    """Wrap an AgentRunner and inject tracker access for judge/perf_eval.
+class PlainLoopAgentClient(AgentClient):
+    """Wrap an AgentClient and inject tracker access for judge/perf_eval.
 
-    The wrapper preserves the AgentRunner Protocol surface for the kwargs
+    The wrapper preserves the AgentClient surface for the kwargs
     the issue loop actually uses. The only addition is an explicit
     ``iteration`` kwarg on ``invoke()`` that the wrapper consumes (it
     determines the per-iteration cap scope) and does not forward.
@@ -55,7 +57,7 @@ class PlainLoopAgentRunner:
 
     def __init__(  # noqa: ANN204, D107  # tracked: #288
         self,
-        inner: AgentRunner,
+        inner: AgentClient,
         *,
         store: IssueBoard,
         max_issues_per_perf_eval: int,
@@ -70,18 +72,50 @@ class PlainLoopAgentRunner:
 
     @property
     def capabilities(self) -> AgentCapabilities:
-        """Preserve the inner runner's declared capabilities."""
+        """Preserve the inner client's declared capabilities."""
         return self._inner.capabilities
 
     def set_log_file(self, stream: Any) -> None:  # noqa: ANN401
-        """Retarget inner-runner logs when the run changes log files."""
+        """Retarget inner-client logs when the run changes log files."""
         setter = getattr(self._inner, "set_log_file", None)
         if callable(setter):
             setter(stream)
 
     def close(self) -> None:
-        """Close the inner runner."""
+        """Close the inner client."""
         self._inner.close()
+
+    def invoke_text(  # noqa: PLR0913
+        self,
+        *,
+        kind: str,
+        workspace: Path,
+        system_prompt: str,
+        user_prompt: str,
+        round_label: str,
+        env: dict[str, str] | None = None,
+        invocation_id: str | None = None,
+        progress: AgentProgress | None = None,
+        mcp_servers: list[MCPServerSpec] | None = None,
+        tools: list[BaseTool] | None = None,
+        reuse_session: bool | None = None,
+        session_key: str | None = None,
+    ) -> str:
+        """Delegate an unstructured turn without changing tracker policy."""
+        return self._inner.invoke_text(
+            kind=kind,
+            workspace=workspace,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            round_label=round_label,
+            env=env,
+            invocation_id=invocation_id,
+            progress=progress,
+            mcp_servers=mcp_servers,
+            tools=tools,
+            reuse_session=reuse_session,
+            session_key=session_key,
+        )
 
     def invoke(  # noqa: D102  # tracked: #288
         self,
@@ -96,7 +130,7 @@ class PlainLoopAgentRunner:
         if kind in ("judge", "perf_eval"):
             if iteration is None:
                 raise ValueError(  # noqa: TRY003  # tracked: #288
-                    f"PlainLoopAgentRunner.invoke(kind={kind!r}) requires "
+                    f"PlainLoopAgentClient.invoke(kind={kind!r}) requires "
                     "iteration= so the cap can be scoped per-iteration"
                 )
             if kind == "judge":

--- a/src/vibesys/main.py
+++ b/src/vibesys/main.py
@@ -654,6 +654,7 @@ def _restore_project_config(
             frozenset({"agent_backend", "stub_agent"}),
             "agent_backend",
         ),
+        (("agent", "driver"), recorded.agent_driver, frozenset(), "agent_driver"),
         (
             ("agent", "cli_provider"),
             recorded.cli_provider,
@@ -705,6 +706,7 @@ def _restore_project_config(
     agent = config.agent.model_copy(
         update={
             "backend": None if recorded.agent_backend == "stub" else recorded.agent_backend,
+            "driver": recorded.agent_driver,
             "cli_provider": recorded.cli_provider,
             "cli_timeout": recorded.cli_timeout,
             "outer": outer,

--- a/src/vibesys/run/protocol.py
+++ b/src/vibesys/run/protocol.py
@@ -14,6 +14,7 @@ from typing import Any, Protocol, TypeVar
 
 from pydantic import BaseModel
 
+from vibesys.agents.client import AgentClient
 from vibesys.agents.progress import AgentProgress
 from vibesys.constants import ComputeBackend
 from vibesys.input_manifest import WorkspaceSource
@@ -36,7 +37,7 @@ class LoopContext(Protocol):  # noqa: D101  # tracked: #288
 
     # -- collaborators --------------------------------------------------------
     supervisor: Any
-    agent_runner: Any
+    agent_client: AgentClient
     judge_backend: Any
     run_environment: Any
     run_environment_view: Any

--- a/tests/agents/drivers/test_agentshim_driver.py
+++ b/tests/agents/drivers/test_agentshim_driver.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from vibesys.agents.contracts import (
+    AgentEvent,
+    AgentExecutionPolicy,
+    AgentSessionSpec,
+    AgentTurnRequest,
+    MCPServerSpec,
+)
+from vibesys.agents.drivers import agentshim as subject
+from vs_sandbox import ProjectPathPolicy
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass
+class _Observer:
+    events: list[AgentEvent] = field(default_factory=list)
+
+    def on_event(self, event: AgentEvent) -> None:
+        self.events.append(event)
+
+
+class _FakeAgent:
+    supports_native_output_schema = False
+    native_output_schema_allows_arbitrary_keys = False
+    native_output_schema_wants_absolute_path = False
+
+    def __init__(
+        self,
+        model: str | None = None,
+        event_handler: Any | None = None,  # noqa: ANN401  # tracked: #288
+        *,
+        executor: Any | None = None,  # noqa: ANN401  # tracked: #288
+    ) -> None:
+        self.model = model
+        self.event_handler = event_handler
+        self.executor = executor
+        self.env = {"BASE": "one"}
+        self.binary_path = "/bin/fake"
+        self.sandbox = None
+        self.session_id = "session-1"
+        self.generate_calls: list[tuple[str, str | None, int | None]] = []
+        self.install_calls: list[tuple[Path, list[Any]]] = []
+        self.uninstall_calls: list[tuple[Path, list[Any]]] = []
+        self.output_schema_paths: list[str | None] = []
+        self.reasoning_effort: str | None = None
+        self.error: BaseException | None = None
+        self._last_session = SimpleNamespace(
+            final_usage={"input_tokens": 12, "output_tokens": 3},
+            total_cost_usd=0.25,
+            duration_ms=90,
+        )
+
+    def set_reasoning_effort(self, effort: str) -> None:
+        self.reasoning_effort = effort
+
+    def set_output_schema_path(self, path: str | None) -> None:
+        self.output_schema_paths.append(path)
+
+    def install_mcp_servers(self, workspace: Path, servers: list[Any]) -> None:
+        self.install_calls.append((workspace, servers))
+
+    def uninstall_mcp_servers(self, workspace: Path, servers: list[Any]) -> None:
+        self.uninstall_calls.append((workspace, servers))
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        cwd: str | None,
+        timeout: int | None,
+        silent: bool,
+    ) -> str:
+        assert silent
+        assert self.event_handler is not None
+        self.generate_calls.append((prompt, cwd, timeout))
+        self.event_handler.on_thinking("working")
+        self.event_handler.on_usage({"input_tokens": 12, "output_tokens": 3})
+        if self.error is not None:
+            raise self.error
+        return "done"
+
+
+@pytest.fixture
+def fake_agent(monkeypatch: pytest.MonkeyPatch) -> list[_FakeAgent]:
+    built: list[_FakeAgent] = []
+
+    def factory(
+        model: str | None = None,
+        event_handler: Any | None = None,  # noqa: ANN401  # tracked: #288
+        *,
+        executor: Any | None = None,  # noqa: ANN401  # tracked: #288
+    ) -> _FakeAgent:
+        agent = _FakeAgent(model, event_handler, executor=executor)
+        built.append(agent)
+        return agent
+
+    monkeypatch.setitem(subject._PROVIDER_CLASSES, "codex", factory)  # noqa: SLF001
+    monkeypatch.setattr(subject, "declare_agent_host_resources", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(subject, "build_host_sandbox", lambda *_args, **_kwargs: "sandbox")
+    return built
+
+
+def _spec(tmp_path: Path, **changes: Any) -> AgentSessionSpec:  # noqa: ANN401
+    values: dict[str, Any] = {
+        "role": "implementer",
+        "provider": "codex",
+        "workspace": tmp_path,
+        "model": "gpt-test",
+        "policy": AgentExecutionPolicy(require_enforcement=True),
+        "environment": (("GPU", "0"),),
+        "reasoning_effort": "high",
+    }
+    values.update(changes)
+    return AgentSessionSpec(**values)
+
+
+def test_session_setup_applies_policy_model_environment_and_reasoning(
+    fake_agent: list[_FakeAgent],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy = ProjectPathPolicy(read_only_paths=("OBJECTIVE.md",))
+    captured: dict[str, Any] = {}
+
+    def build_sandbox(workspace: Path, **kwargs: Any) -> str:  # noqa: ANN401
+        captured.update(workspace=workspace, **kwargs)
+        return "confined"
+
+    monkeypatch.setattr(subject, "build_host_sandbox", build_sandbox)
+    driver = subject.AgentShimDriver(provider="codex")
+    driver.create_session(
+        _spec(
+            tmp_path,
+            policy=AgentExecutionPolicy(project_paths=policy, require_enforcement=True),
+        )
+    )
+
+    agent = fake_agent[0]
+    assert agent.model == "gpt-test"
+    assert agent.env == {"BASE": "one", "GPU": "0"}
+    assert agent.reasoning_effort == "high"
+    assert agent.sandbox == "confined"
+    assert captured["workspace"] == tmp_path
+    assert captured["project_path_policy"] is policy
+    assert captured["require_enforcement"] is True
+
+
+def test_turn_forwards_prompt_timeout_events_and_usage(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    driver = subject.AgentShimDriver(provider="codex", timeout=30)
+    session = driver.create_session(_spec(tmp_path))
+    observer = _Observer()
+
+    result = session.run_turn(
+        AgentTurnRequest(
+            message="Do it",
+            instructions="Follow these rules",
+            timeout=timedelta(seconds=7),
+        ),
+        observer,
+    )
+
+    assert result.text == "done"
+    assert result.usage.input_tokens == 12
+    assert result.usage.output_tokens == 3
+    assert result.usage.total_cost_usd == 0.25
+    assert result.provider_session_id == "session-1"
+    assert fake_agent[0].generate_calls == [("Follow these rules\n\nDo it", str(tmp_path), 7)]
+    assert [event.kind for event in observer.events] == [
+        subject.AgentEventKind.THINKING,
+        subject.AgentEventKind.USAGE,
+    ]
+
+
+def test_mcp_is_session_scoped_but_activated_only_around_turn(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    server = MCPServerSpec(name="issues", command="python", args=("-m", "issues"))
+    session = subject.AgentShimDriver(provider="codex").create_session(
+        _spec(tmp_path, mcp_servers=(server,))
+    )
+
+    session.run_turn(AgentTurnRequest(message="review"))
+
+    installed = fake_agent[0].install_calls[0][1][0]
+    assert installed.name == "issues"
+    assert installed.command == subject.sys.executable
+    assert installed.args == ["-m", "issues"]
+    assert fake_agent[0].uninstall_calls == fake_agent[0].install_calls
+
+
+def test_mcp_cleanup_preserves_original_turn_error(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    session = subject.AgentShimDriver(provider="codex").create_session(
+        _spec(tmp_path, mcp_servers=(MCPServerSpec(name="issues", command="server"),))
+    )
+    fake_agent[0].error = ValueError("turn failed")
+
+    def fail_cleanup(_workspace: Path, _servers: list[Any]) -> None:
+        raise OSError("cleanup failed")  # noqa: TRY003  # tracked: #288
+
+    fake_agent[0].uninstall_mcp_servers = fail_cleanup
+
+    with pytest.raises(ValueError, match="turn failed"):
+        session.run_turn(AgentTurnRequest(message="review"))
+
+
+def test_driver_and_session_close_are_idempotent(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    assert fake_agent == []
+    driver = subject.AgentShimDriver(provider="codex")
+    session = driver.create_session(_spec(tmp_path))
+
+    session.close()
+    session.close()
+    driver.close()
+    driver.close()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        session.run_turn(AgentTurnRequest(message="later"))
+    with pytest.raises(RuntimeError, match="closed"):
+        driver.create_session(_spec(tmp_path))

--- a/tests/agents/drivers/test_omnigent_driver.py
+++ b/tests/agents/drivers/test_omnigent_driver.py
@@ -1,0 +1,244 @@
+"""Focused tests for the Omnigent agent-driver adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field, replace
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vibesys.agents.contracts import (
+    AgentEvent,
+    AgentExecutionPolicy,
+    AgentSessionSpec,
+    AgentTurnRequest,
+    MCPServerSpec,
+)
+from vibesys.agents.drivers.omnigent import (
+    OmnigentDriver,
+    OmnigentDriverError,
+    OmnigentSession,
+)
+from vibesys.schemas import JudgeResponse
+from vs_sandbox import HostResource, ProjectPathPolicy
+
+omnigent = pytest.importorskip("omnigent")
+TextChunk = omnigent.TextChunk
+ToolCallComplete = omnigent.ToolCallComplete
+ToolCallRequest = omnigent.ToolCallRequest
+TurnComplete = omnigent.TurnComplete
+
+
+class _FakeExecutor:
+    def __init__(self, events: list[Any], *, delay: float = 0) -> None:
+        self.events = events
+        self.delay = delay
+        self.calls: list[tuple[Any, ...]] = []
+        self.close_calls = 0
+        self.thread_id = "provider-session"
+        self._tool_executor = None
+
+    def run_turn(self, messages, tools, instructions, config=None):  # noqa: ANN001, ANN202
+        self.calls.append((messages, tools, instructions, config, os.environ.get("DRIVER_TEST")))
+
+        async def stream():  # noqa: ANN202
+            if self.delay:
+                await asyncio.sleep(self.delay)
+            for event in self.events:
+                yield event
+
+        return stream()
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+@dataclass
+class _Observer:
+    events: list[AgentEvent] = field(default_factory=list)
+
+    def on_event(self, event: AgentEvent) -> None:
+        self.events.append(event)
+
+
+def _spec(tmp_path: Path, **changes: Any) -> AgentSessionSpec:  # noqa: ANN401
+    base = AgentSessionSpec(
+        role="judge",
+        provider="codex",
+        workspace=tmp_path,
+        model="gpt-5.5",
+        policy=AgentExecutionPolicy(),
+    )
+    return replace(base, **changes)
+
+
+def _session(tmp_path: Path, executor: _FakeExecutor) -> tuple[OmnigentDriver, OmnigentSession]:
+    driver = OmnigentDriver()
+    session = OmnigentSession(
+        driver=driver,
+        spec=_spec(tmp_path, reasoning_effort="high", environment=(("DRIVER_TEST", "set"),)),
+        executor=executor,
+        tool_schemas=[{"name": "sys_os_read"}],
+    )
+    driver._sessions.add(session)  # noqa: SLF001
+    return driver, session
+
+
+def test_turn_normalizes_events_usage_schema_and_session_id(tmp_path: Path) -> None:
+    executor = _FakeExecutor(
+        [
+            TextChunk("partial"),
+            ToolCallRequest(name="Read", args={"path": "a"}),
+            ToolCallComplete(name="Read", result="contents"),
+            TurnComplete(response="final", usage={"input_tokens": 3, "output_tokens": 5}),
+        ]
+    )
+    driver, session = _session(tmp_path, executor)
+    observer = _Observer()
+
+    result = session.run_turn(
+        AgentTurnRequest(
+            "answer",
+            instructions="system",
+            output_schema=JudgeResponse,
+        ),
+        observer,
+    )
+
+    assert result.text == "final"
+    assert result.usage.input_tokens == 3
+    assert result.usage.output_tokens == 5
+    assert result.provider_session_id == "provider-session"
+    messages, tools, instructions, config, environment = executor.calls[0]
+    assert messages[0]["content"].startswith("answer")
+    assert "JudgeResponse" in messages[0]["content"]
+    assert tools == [{"name": "sys_os_read"}]
+    assert instructions == "system"
+    assert config.extra["reasoning_effort"] == "high"
+    assert environment == "set"
+    assert "DRIVER_TEST" not in os.environ
+    assert [event.kind.value for event in observer.events] == [
+        "text",
+        "tool_call",
+        "tool_result",
+        "usage",
+    ]
+    driver.close()
+
+
+def test_turn_complete_response_wins_and_chunks_are_fallback(tmp_path: Path) -> None:
+    final_executor = _FakeExecutor([TextChunk("chunk"), TurnComplete(response="final")])
+    final_driver, final_session = _session(tmp_path, final_executor)
+    assert final_session.run_turn(AgentTurnRequest("one")).text == "final"
+    final_driver.close()
+
+    chunk_executor = _FakeExecutor([TextChunk("one "), TextChunk("two")])
+    chunk_driver, chunk_session = _session(tmp_path, chunk_executor)
+    assert chunk_session.run_turn(AgentTurnRequest("two")).text == "one two"
+    chunk_driver.close()
+
+
+def test_timeout_poisons_session_and_cleanup_is_idempotent(tmp_path: Path) -> None:
+    executor = _FakeExecutor([], delay=0.1)
+    driver, session = _session(tmp_path, executor)
+
+    with pytest.raises(TimeoutError):
+        session.run_turn(AgentTurnRequest("slow", timeout=timedelta(milliseconds=1)))
+    with pytest.raises(RuntimeError, match="must be reset"):
+        session.run_turn(AgentTurnRequest("again"))
+
+    session.close()
+    session.close()
+    driver.close()
+    assert executor.close_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        ({"mcp_servers": (MCPServerSpec("issues", "python"),)}, "MCP"),
+        (
+            {
+                "policy": AgentExecutionPolicy(
+                    host_resources=(HostResource(Path("model")),),
+                )
+            },
+            "host-resource",
+        ),
+        (
+            {
+                "policy": AgentExecutionPolicy(
+                    project_paths=ProjectPathPolicy(read_only_paths=(".vibesys",)),
+                )
+            },
+            "read-only",
+        ),
+        ({"policy": AgentExecutionPolicy(containerized=True)}, "container"),
+    ],
+)
+def test_create_session_rejects_unsupported_requirements_before_building(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    change: dict[str, Any],
+    message: str,
+) -> None:
+    driver = OmnigentDriver()
+
+    def build(_spec: AgentSessionSpec) -> tuple[Any, list[dict[str, Any]]]:
+        pytest.fail("executor must not be built")
+
+    monkeypatch.setattr(driver, "_build_executor", build)
+
+    with pytest.raises(OmnigentDriverError, match=message):
+        driver.create_session(_spec(tmp_path, **change))
+
+
+def test_driver_owns_session_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = _FakeExecutor([])
+    driver = OmnigentDriver()
+    monkeypatch.setattr(driver, "_build_executor", lambda _spec: (executor, []))
+
+    driver.create_session(_spec(tmp_path))
+    driver.close()
+    driver.close()
+
+    assert executor.close_calls == 1
+
+
+def test_missing_private_tool_executor_seam_fails_during_setup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ExecutorWithoutSeam:
+        close_calls = 0
+
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    driver = OmnigentDriver()
+    monkeypatch.setattr(driver, "_executor_class", lambda _spec: ExecutorWithoutSeam)
+    monkeypatch.setattr(driver, "_build_os_env", lambda _workspace: object())
+
+    with pytest.raises(OmnigentDriverError, match="_tool_executor"):
+        driver._build_executor(_spec(tmp_path))  # noqa: SLF001
+
+
+def test_os_policy_is_always_sandboxed_and_workspace_scoped(tmp_path: Path) -> None:
+    driver = OmnigentDriver()
+
+    spec = driver._build_os_env(tmp_path)  # noqa: SLF001
+
+    assert spec.sandbox is not None
+    assert spec.sandbox.type != "none"
+    assert spec.sandbox.write_paths == [str(tmp_path)]
+    assert spec.cwd == str(tmp_path)

--- a/tests/agents/test_agent_client.py
+++ b/tests/agents/test_agent_client.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from vibesys.agents.client import AgentClient
+from vibesys.agents.contracts import (
+    AgentCapabilities,
+    AgentEvent,
+    AgentEventKind,
+    AgentExecutionPolicy,
+    AgentObserver,
+    AgentSession,
+    AgentSessionSpec,
+    AgentTurnRequest,
+    AgentTurnResult,
+    AgentUsage,
+    SessionDisposition,
+)
+
+
+class _Response(BaseModel):
+    answer: str
+
+
+@dataclass
+class _FakeSession:
+    results: list[AgentTurnResult]
+    turns: list[AgentTurnRequest] = field(default_factory=list)
+    close_calls: int = 0
+    error: BaseException | None = None
+    observers: list[AgentObserver | None] = field(default_factory=list)
+
+    def run_turn(
+        self,
+        request: AgentTurnRequest,
+        observer: AgentObserver | None = None,
+    ) -> AgentTurnResult:
+        self.turns.append(request)
+        self.observers.append(observer)
+        if self.error is not None:
+            raise self.error
+        return self.results.pop(0)
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+@dataclass
+class _FakeDriver:
+    queued_sessions: list[_FakeSession]
+    specs: list[AgentSessionSpec] = field(default_factory=list)
+    close_calls: int = 0
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        return AgentCapabilities()
+
+    def create_session(self, spec: AgentSessionSpec) -> AgentSession:
+        self.specs.append(spec)
+        return self.queued_sessions.pop(0)
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def _spec(
+    *,
+    model: str = "model",
+    workspace: Path = Path("/workspace"),
+    skills: tuple[Path, ...] = (),
+) -> AgentSessionSpec:
+    return AgentSessionSpec(
+        role="implementer",
+        provider="codex",
+        model=model,
+        workspace=workspace,
+        policy=AgentExecutionPolicy(),
+        skills=skills,
+    )
+
+
+def test_keyed_turns_reuse_a_session() -> None:
+    session = _FakeSession(
+        results=[AgentTurnResult("first"), AgentTurnResult("second")],
+    )
+    driver = _FakeDriver([session])
+    client = AgentClient(driver)
+
+    assert (
+        client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="impl").text
+        == "first"
+    )
+    assert (
+        client.run(session_spec=_spec(), turn=AgentTurnRequest("two"), session_key="impl").text
+        == "second"
+    )
+
+    assert len(driver.specs) == 1
+    assert session.turns == [AgentTurnRequest("one"), AgentTurnRequest("two")]
+
+
+def test_session_setup_materializes_skills_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _FakeSession(results=[AgentTurnResult("first"), AgentTurnResult("second")])
+    client = AgentClient(_FakeDriver([session]))
+    skill = tmp_path / "source-skill"
+    calls: list[tuple[Path, list[Path]]] = []
+    monkeypatch.setattr(
+        "vibesys.agents.client.materialize_skills",
+        lambda workspace, skills, **_kwargs: calls.append((workspace, skills)),
+    )
+    spec = _spec(workspace=tmp_path, skills=(skill,))
+
+    client.run(session_spec=spec, turn=AgentTurnRequest("one"), session_key="impl")
+    client.run(session_spec=spec, turn=AgentTurnRequest("two"), session_key="impl")
+
+    assert calls == [(tmp_path, [skill])]
+
+
+def test_client_forwards_observer_to_session() -> None:
+    session = _FakeSession(results=[AgentTurnResult("done")])
+    client = AgentClient(_FakeDriver([session]))
+
+    @dataclass
+    class Observer:
+        events: list[AgentEvent] = field(default_factory=list)
+
+        def on_event(self, event: AgentEvent) -> None:
+            self.events.append(event)
+
+    observer = Observer()
+    client.run(
+        session_spec=_spec(),
+        turn=AgentTurnRequest("one"),
+        observer=observer,
+    )
+
+    assert session.observers == [observer]
+    observer.on_event(AgentEvent(AgentEventKind.TEXT, text="chunk"))
+    assert observer.events == [AgentEvent(AgentEventKind.TEXT, text="chunk")]
+
+
+def test_changed_session_spec_closes_and_replaces_cached_session() -> None:
+    old = _FakeSession(results=[AgentTurnResult("old")])
+    new = _FakeSession(results=[AgentTurnResult("new")])
+    driver = _FakeDriver([old, new])
+    client = AgentClient(driver)
+
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="impl")
+    result = client.run(
+        session_spec=_spec(model="changed"),
+        turn=AgentTurnRequest("two"),
+        session_key="impl",
+    )
+
+    assert result.text == "new"
+    assert old.close_calls == 1
+    assert len(driver.specs) == 2
+
+
+def test_unkeyed_turn_always_closes_ephemeral_session() -> None:
+    session = _FakeSession(results=[AgentTurnResult("done")])
+    client = AgentClient(_FakeDriver([session]))
+
+    result = client.run(session_spec=_spec(), turn=AgentTurnRequest("one"))
+
+    assert result.text == "done"
+    assert session.close_calls == 1
+
+
+@pytest.mark.parametrize(
+    "result",
+    [AgentTurnResult("reset", disposition=SessionDisposition.RESET_REQUIRED)],
+)
+def test_reset_disposition_evicts_session(result: AgentTurnResult) -> None:
+    first = _FakeSession(results=[result])
+    second = _FakeSession(results=[AgentTurnResult("recovered")])
+    driver = _FakeDriver([first, second])
+    client = AgentClient(driver)
+
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="impl")
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("two"), session_key="impl")
+
+    assert first.close_calls == 1
+    assert len(driver.specs) == 2
+
+
+def test_turn_exception_evicts_session() -> None:
+    failed = _FakeSession(results=[], error=ValueError("failed"))
+    recovered = _FakeSession(results=[AgentTurnResult("ok")])
+    driver = _FakeDriver([failed, recovered])
+    client = AgentClient(driver)
+
+    with pytest.raises(ValueError, match="failed"):
+        client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="impl")
+    result = client.run(session_spec=_spec(), turn=AgentTurnRequest("two"), session_key="impl")
+
+    assert failed.close_calls == 1
+    assert result.text == "ok"
+
+
+def test_close_is_idempotent_and_rejects_future_turns() -> None:
+    session = _FakeSession(results=[AgentTurnResult("ok")])
+    driver = _FakeDriver([session])
+    client = AgentClient(driver)
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="impl")
+
+    client.close()
+    client.close()
+
+    assert session.close_calls == 1
+    assert driver.close_calls == 1
+    with pytest.raises(RuntimeError, match="closed"):
+        client.run(session_spec=_spec(), turn=AgentTurnRequest("two"))
+
+
+def test_invoke_builds_session_and_turn_contracts_and_records_usage(tmp_path: Path) -> None:
+    usage = AgentUsage(input_tokens=12, output_tokens=4, total_cost_usd=0.02, duration_ms=30)
+    session = _FakeSession(results=[AgentTurnResult('{"answer":"done"}', usage=usage)])
+    driver = _FakeDriver([session])
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    client = AgentClient(
+        driver,
+        provider="codex",
+        model_name="gpt-test",
+        timeout=45,
+        log_dir=log_dir,
+        role_models={"judge": "gpt-judge"},
+        role_reasoning_efforts={"judge": "high"},
+    )
+
+    response = client.invoke(
+        kind="judge",
+        workspace=tmp_path,
+        system_prompt="system",
+        user_prompt="user",
+        response_cls=_Response,
+        fallback_factory=lambda: _Response(answer="fallback"),
+        round_label="judge #1",
+        env={"VISIBLE": "1"},
+        session_key="review",
+    )
+
+    assert response == _Response(answer="done")
+    assert driver.specs[0].model == "gpt-judge"
+    assert driver.specs[0].reasoning_effort == "high"
+    assert driver.specs[0].environment == (("VISIBLE", "1"),)
+    assert session.turns[0].instructions == "system"
+    assert session.turns[0].message == "user"
+    assert session.turns[0].output_schema is _Response
+    assert session.turns[0].timeout == timedelta(seconds=45)
+    record = json.loads((log_dir / "usage.jsonl").read_text())
+    expected = {
+        "kind": "judge",
+        "round_label": "judge #1",
+        "provider": "codex",
+        "model": "gpt-judge",
+        "reasoning_effort": "high",
+        "input_tokens": 12,
+        "output_tokens": 4,
+        "total_cost_usd": 0.02,
+        "duration_ms": 30,
+    }
+    assert {key: record[key] for key in expected} == expected
+
+
+def test_invoke_uses_fallback_only_for_unparseable_output(tmp_path: Path) -> None:
+    session = _FakeSession(results=[AgentTurnResult("not json")])
+    client = AgentClient(_FakeDriver([session]))
+    fallback_calls = 0
+
+    def fallback() -> _Response:
+        nonlocal fallback_calls
+        fallback_calls += 1
+        return _Response(answer="fallback")
+
+    response = client.invoke(
+        kind="judge",
+        workspace=tmp_path,
+        system_prompt="system",
+        user_prompt="user",
+        response_cls=_Response,
+        fallback_factory=fallback,
+        round_label="judge #1",
+    )
+
+    assert response == _Response(answer="fallback")
+    assert fallback_calls == 1

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -14,7 +14,9 @@ from vibesys.agent_runner import log_json_and_print, log_prompt_markdown_and_pri
 from vibesys.agents import ResponseFallback, build_agent_runner
 from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.cli_runner import CliAgentRunner
+from vibesys.agents.client import AgentClient
 from vibesys.agents.deepagents_runner import DeepAgentsRunner
+from vibesys.agents.drivers.agentshim import AgentShimDriver
 from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config
 from vibesys.constants import ComputeBackend
@@ -2134,8 +2136,9 @@ class TestBuildAgentRunner:
             run_log_file=None,
             use_docker=True,
         )
-        assert isinstance(runner, CliAgentRunner)
-        assert runner._docker_sandboxes is mock_backends  # noqa: SLF001  # tracked: #288
+        assert isinstance(runner, AgentClient)
+        assert isinstance(runner._driver, AgentShimDriver)  # noqa: SLF001
+        assert runner._driver._docker_sandboxes is mock_backends  # noqa: SLF001
 
     def test_build_agent_runner_rejects_unsupported_docker_provider(self):  # noqa: ANN201  # tracked: #288
         with pytest.raises(SystemExit, match="not yet supported with --docker"):
@@ -2183,7 +2186,7 @@ class TestBuildAgentRunner:
                 require_host_sandbox=True,
             )
 
-    def test_required_project_enforcement_rejects_omnigent(self):  # noqa: ANN201  # tracked: #288
+    def test_required_workspace_enforcement_permits_omnigent(self):  # noqa: ANN201
         config = Config.model_validate(
             {
                 "model": {"name": "m"},
@@ -2192,20 +2195,22 @@ class TestBuildAgentRunner:
             }
         )
 
-        with pytest.raises(SystemExit, match="does not yet support the Omnigent backend"):
-            build_agent_runner(
-                config,
-                agent_backend=None,
-                cli_provider=None,
-                backends=None,
-                skills=[],
-                skill_source_dirs=[],
-                model=None,
-                model_name="m",
-                run_log_file=None,
-                use_docker=False,
-                require_host_sandbox=True,
-            )
+        runner = build_agent_runner(
+            config,
+            agent_backend=None,
+            cli_provider=None,
+            backends=None,
+            skills=[],
+            skill_source_dirs=[],
+            model=None,
+            model_name="m",
+            run_log_file=None,
+            use_docker=False,
+            require_host_sandbox=True,
+        )
+
+        assert isinstance(runner, AgentClient)
+        assert type(runner._driver).__name__ == "OmnigentDriver"  # noqa: SLF001
 
     def test_required_project_enforcement_permits_stub(self):  # noqa: ANN201  # tracked: #288
         runner = build_agent_runner(
@@ -2245,9 +2250,9 @@ class TestBuildAgentRunner:
             require_host_sandbox=True,
         )
 
-        assert isinstance(runner, CliAgentRunner)
-        assert runner._project_path_policy is policy  # noqa: SLF001  # tracked: #288
-        assert runner._require_host_sandbox is True  # noqa: SLF001  # tracked: #288
+        assert isinstance(runner, AgentClient)
+        assert runner._policy.project_paths is policy  # noqa: SLF001
+        assert runner._policy.require_enforcement is True  # noqa: SLF001
 
     # --- model resolution for the cli backend ---------------------------------
     #
@@ -2277,7 +2282,7 @@ class TestBuildAgentRunner:
             _agent_config(backend="cli", cli_provider=provider),
             model_name="gpt-5.4",
         )
-        assert runner._model == "gpt-5.4"  # noqa: SLF001  # tracked: #288
+        assert runner._model_name == "gpt-5.4"  # noqa: SLF001  # tracked: #288
 
     def test_displayed_model_name_matches_model_passed(self):  # noqa: ANN201  # tracked: #288
         # The run-log header prints _model_name; it must equal the model
@@ -2287,7 +2292,7 @@ class TestBuildAgentRunner:
             _agent_config(backend="cli", cli_provider="codex"),
             model_name="gpt-5.4",
         )
-        assert runner._model_name == runner._model == "gpt-5.4"  # noqa: SLF001  # tracked: #288
+        assert runner._model_name == "gpt-5.4"  # noqa: SLF001  # tracked: #288
 
     def test_cli_backend_carries_outer_and_inner_role_configuration(self):  # noqa: ANN201  # tracked: #288
         config = _agent_config(
@@ -2387,20 +2392,20 @@ class TestBuildAgentRunnerBackendSelection:
 
     def test_default_backend_is_cli_with_empty_config(self):  # noqa: ANN201  # tracked: #288
         runner = self._build(_agent_config())
-        assert isinstance(runner, CliAgentRunner)
+        assert isinstance(runner, AgentClient)
         assert runner._provider == "codex"  # noqa: SLF001  # tracked: #288
 
     def test_empty_agent_section_defaults_to_cli(self):  # noqa: ANN201  # tracked: #288
         runner = self._build(_agent_config())
-        assert isinstance(runner, CliAgentRunner)
+        assert isinstance(runner, AgentClient)
         assert runner._provider == "codex"  # noqa: SLF001  # tracked: #288
 
     def test_agent_backend_flag_overrides_config(self):  # noqa: ANN201  # tracked: #288
         # An explicit --agent-backend flag wins over [agent].backend.
         runner = self._build(_agent_config(backend="deepagents"), agent_backend="cli")
-        assert isinstance(runner, CliAgentRunner)
+        assert isinstance(runner, AgentClient)
 
     def test_config_can_select_cli_provider(self):  # noqa: ANN201  # tracked: #288
         runner = self._build(_agent_config(backend="cli", cli_provider="claude"))
-        assert isinstance(runner, CliAgentRunner)
+        assert isinstance(runner, AgentClient)
         assert runner._provider == "claude"  # noqa: SLF001  # tracked: #288

--- a/tests/agents/test_agent_runners.py
+++ b/tests/agents/test_agent_runners.py
@@ -1,4 +1,4 @@
-"""Tests for the :mod:`vibesys.agents` runner abstraction."""
+"""Tests for application-level agent clients."""
 
 from __future__ import annotations
 
@@ -11,11 +11,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibesys.agent_runner import log_json_and_print, log_prompt_markdown_and_print
-from vibesys.agents import ResponseFallback, build_agent_runner
+from vibesys.agents import ResponseFallback, build_agent_client
 from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.cli_runner import CliAgentRunner
 from vibesys.agents.client import AgentClient
-from vibesys.agents.deepagents_runner import DeepAgentsRunner
+from vibesys.agents.deepagents_runner import DeepAgentsClient
 from vibesys.agents.drivers.agentshim import AgentShimDriver
 from vibesys.agents.progress import RoundProgress
 from vibesys.config import Config
@@ -70,8 +70,8 @@ def test_json_emitter_preserves_raw_log(capsys):  # noqa: ANN001, ANN201  # trac
     assert log.getvalue() == raw_json + "\n"
 
 
-class TestDeepAgentsRunner:
-    """Tests for :class:`DeepAgentsRunner`."""
+class TestDeepAgentsClient:
+    """Tests for :class:`DeepAgentsClient`."""
 
     def test_deepagents_runner_invoke_returns_structured_response(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         pass_response = JudgeResponse(
@@ -86,7 +86,7 @@ class TestDeepAgentsRunner:
             mock_create.return_value = MagicMock(name="deep_agent")
             mock_run.return_value = pass_response
 
-            runner = DeepAgentsRunner(
+            runner = DeepAgentsClient(
                 model="m",
                 backends={
                     "implementer": MagicMock(name="impl-backend"),
@@ -138,7 +138,7 @@ class TestDeepAgentsRunner:
                 return_value=_judge_fallback(),
             ),
         ):
-            runner = DeepAgentsRunner(
+            runner = DeepAgentsClient(
                 model="m",
                 backends={
                     "implementer": impl_backend,
@@ -172,7 +172,7 @@ class TestDeepAgentsRunner:
             ) as mock_run,
         ):
             mock_create.return_value = MagicMock(name="chat-agent")
-            runner = DeepAgentsRunner(
+            runner = DeepAgentsClient(
                 model="m",
                 backends={"chat": MagicMock(name="chat-backend")},
                 skills=[],
@@ -193,7 +193,7 @@ class TestDeepAgentsRunner:
         assert mock_run.call_args.args[1] == "what happened?"
 
     def test_deepagents_runner_sessions_are_explicit_and_role_scoped(self):  # noqa: ANN201  # tracked: #288
-        runner = DeepAgentsRunner(
+        runner = DeepAgentsClient(
             model="m",
             backends={},
             skills=[],
@@ -227,7 +227,7 @@ class TestDeepAgentsRunner:
             ) as mock_run,
         ):
             mock_create.return_value = MagicMock(name="deep_agent")
-            runner = DeepAgentsRunner(
+            runner = DeepAgentsClient(
                 model="m",
                 backends={"judge": MagicMock(name="judge-backend")},
                 skills=[],
@@ -260,7 +260,7 @@ class TestDeepAgentsRunner:
             ),
         ):
             mock_create.return_value = MagicMock(name="deep_agent")
-            runner = DeepAgentsRunner(
+            runner = DeepAgentsClient(
                 model="m",
                 backends={"judge": MagicMock(name="judge-backend")},
                 skills=[],
@@ -310,7 +310,7 @@ class TestDeepAgentsRunner:
             ),
         ):
             mock_create.return_value = MagicMock(name="deep_agent")
-            runner = DeepAgentsRunner(
+            runner = DeepAgentsClient(
                 model="m",
                 backends={"judge": MagicMock(name="judge-backend")},
                 skills=[],
@@ -345,7 +345,7 @@ class TestDeepAgentsRunner:
             ),
         ):
             mock_create.return_value = MagicMock(name="deep_agent")
-            runner = DeepAgentsRunner(
+            runner = DeepAgentsClient(
                 model="m",
                 backends={"judge": MagicMock(name="judge-backend")},
                 skills=[],
@@ -2059,11 +2059,11 @@ class TestCliAgentRunner:
         assert agent.event_log == ["generate"]
 
 
-class TestBuildAgentRunner:
-    """Tests for :func:`build_agent_runner`."""
+class TestBuildAgentClient:
+    """Tests for :func:`build_agent_client`."""
 
-    def test_build_agent_runner_default_is_cli(self):  # noqa: ANN201  # tracked: #288
-        runner = build_agent_runner(
+    def test_build_agent_client_default_is_cli(self):  # noqa: ANN201  # tracked: #288
+        runner = build_agent_client(
             _agent_config(),
             agent_backend=None,
             cli_provider=None,
@@ -2082,8 +2082,8 @@ class TestBuildAgentRunner:
         assert runner.backend_name == "cli"
         assert runner._provider == "codex"  # noqa: SLF001  # tracked: #288
 
-    def test_build_agent_runner_cli_provider_from_config(self):  # noqa: ANN201  # tracked: #288
-        runner = build_agent_runner(
+    def test_build_agent_client_cli_provider_from_config(self):  # noqa: ANN201  # tracked: #288
+        runner = build_agent_client(
             _agent_config(backend="cli", cli_provider="claude"),
             agent_backend=None,
             cli_provider=None,
@@ -2098,9 +2098,9 @@ class TestBuildAgentRunner:
         assert runner.backend_name == "cli"
         assert runner._provider == "claude"  # noqa: SLF001  # tracked: #288
 
-    def test_build_agent_runner_cli_defaults_to_codex(self):  # noqa: ANN201  # tracked: #288
+    def test_build_agent_client_cli_defaults_to_codex(self):  # noqa: ANN201  # tracked: #288
         """When backend=cli and no provider specified, defaults to codex."""
-        runner = build_agent_runner(
+        runner = build_agent_client(
             _agent_config(backend="cli"),
             agent_backend=None,
             cli_provider=None,
@@ -2115,7 +2115,7 @@ class TestBuildAgentRunner:
         assert runner.backend_name == "cli"
         assert runner._provider == "codex"  # noqa: SLF001  # tracked: #288
 
-    def test_build_agent_runner_cli_docker_returns_cli_runner(self):  # noqa: ANN201  # tracked: #288
+    def test_build_agent_client_cli_docker_returns_cli_runner(self):  # noqa: ANN201  # tracked: #288
         """cli backend + docker now returns a CliAgentRunner with docker_sandboxes."""
         from unittest.mock import MagicMock  # noqa: PLC0415  # tracked: #288
 
@@ -2124,7 +2124,7 @@ class TestBuildAgentRunner:
             "judge": MagicMock(),
             "perf_eval": MagicMock(),
         }
-        runner = build_agent_runner(
+        runner = build_agent_client(
             _agent_config(),
             agent_backend="cli",
             cli_provider="claude",
@@ -2140,9 +2140,9 @@ class TestBuildAgentRunner:
         assert isinstance(runner._driver, AgentShimDriver)  # noqa: SLF001
         assert runner._driver._docker_sandboxes is mock_backends  # noqa: SLF001
 
-    def test_build_agent_runner_rejects_unsupported_docker_provider(self):  # noqa: ANN201  # tracked: #288
+    def test_build_agent_client_rejects_unsupported_docker_provider(self):  # noqa: ANN201  # tracked: #288
         with pytest.raises(SystemExit, match="not yet supported with --docker"):
-            build_agent_runner(
+            build_agent_client(
                 _agent_config(),
                 agent_backend="cli",
                 cli_provider="nonexistent",
@@ -2155,9 +2155,9 @@ class TestBuildAgentRunner:
                 use_docker=True,
             )
 
-    def test_build_agent_runner_rejects_unknown_backend(self):  # noqa: ANN201  # tracked: #288
+    def test_build_agent_client_rejects_unknown_backend(self):  # noqa: ANN201  # tracked: #288
         with pytest.raises(SystemExit, match="unknown agent backend"):
-            build_agent_runner(
+            build_agent_client(
                 _agent_config(),
                 agent_backend="bogus",
                 cli_provider=None,
@@ -2172,7 +2172,7 @@ class TestBuildAgentRunner:
 
     def test_required_project_enforcement_rejects_deepagents(self):  # noqa: ANN201  # tracked: #288
         with pytest.raises(SystemExit, match="requires the CLI agent backend"):
-            build_agent_runner(
+            build_agent_client(
                 _agent_config(backend="deepagents"),
                 agent_backend=None,
                 cli_provider=None,
@@ -2195,7 +2195,7 @@ class TestBuildAgentRunner:
             }
         )
 
-        runner = build_agent_runner(
+        runner = build_agent_client(
             config,
             agent_backend=None,
             cli_provider=None,
@@ -2213,7 +2213,7 @@ class TestBuildAgentRunner:
         assert type(runner._driver).__name__ == "OmnigentDriver"  # noqa: SLF001
 
     def test_required_project_enforcement_permits_stub(self):  # noqa: ANN201  # tracked: #288
-        runner = build_agent_runner(
+        runner = build_agent_client(
             _agent_config(backend="stub"),
             agent_backend=None,
             cli_provider=None,
@@ -2229,13 +2229,13 @@ class TestBuildAgentRunner:
 
         assert runner.backend_name == "stub"
 
-    def test_build_agent_runner_forwards_project_policy_to_cli(self):  # noqa: ANN201  # tracked: #288
+    def test_build_agent_client_forwards_project_policy_to_cli(self):  # noqa: ANN201  # tracked: #288
         policy = ProjectPathPolicy(
             read_only_paths=(".state",),
             hidden_paths=(".state/local",),
         )
 
-        runner = build_agent_runner(
+        runner = build_agent_client(
             _agent_config(backend="cli", cli_provider="codex"),
             agent_backend=None,
             cli_provider=None,
@@ -2263,7 +2263,7 @@ class TestBuildAgentRunner:
 
     @staticmethod
     def _cli_runner(config, *, model_name):  # noqa: ANN001, ANN205  # tracked: #288
-        return build_agent_runner(
+        return build_agent_client(
             config,
             agent_backend=None,
             cli_provider=None,
@@ -2368,8 +2368,8 @@ class TestAgentLoggerEventHandler:
         assert logger._latest_usage == usage  # noqa: SLF001  # tracked: #288
 
 
-class TestBuildAgentRunnerBackendSelection:
-    """``build_agent_runner`` backend resolution.
+class TestBuildAgentClientBackendSelection:
+    """``build_agent_client`` backend resolution.
 
     The default agent backend is ``"cli"`` (provider ``"codex"``) when neither
     the ``--agent-backend`` flag nor an ``[agent].backend`` config key is set.
@@ -2377,7 +2377,7 @@ class TestBuildAgentRunnerBackendSelection:
     """
 
     def _build(self, config, *, agent_backend=None, cli_provider=None):  # noqa: ANN001, ANN202  # tracked: #288
-        return build_agent_runner(
+        return build_agent_client(
             config,
             agent_backend=agent_backend,
             cli_provider=cli_provider,

--- a/tests/agents/test_omnigent_backend.py
+++ b/tests/agents/test_omnigent_backend.py
@@ -2,7 +2,7 @@
 
 The contract these tests protect is asymmetric on purpose:
 
-- With ``omnigent_agent_backend`` off (the default), ``build_agent_runner``
+- With ``omnigent_agent_backend`` off (the default), ``build_agent_client``
   must behave exactly as it did before the flag existed — same runner class,
   same provider resolution, same Docker handling. Those cases are the
   regression guard for the agentshim path.
@@ -31,7 +31,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from vibesys.agents import build_agent_runner
+from vibesys.agents import build_agent_client
 from vibesys.agents.client import AgentClient
 from vibesys.agents.drivers.agentshim import AgentShimDriver
 from vibesys.agents.drivers.omnigent import OmnigentDriver, OmnigentDriverError
@@ -70,7 +70,7 @@ def _build(config: Config, **overrides):  # noqa: ANN003, ANN202  # tracked: #28
         "use_docker": False,
     }
     kwargs.update(overrides)
-    return build_agent_runner(config, **kwargs)  # pyright: ignore[reportArgumentType]  # tracked: #297
+    return build_agent_client(config, **kwargs)  # pyright: ignore[reportArgumentType]  # tracked: #297
 
 
 def _judge_fallback() -> JudgeResponse:

--- a/tests/agents/test_omnigent_backend.py
+++ b/tests/agents/test_omnigent_backend.py
@@ -32,7 +32,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from vibesys.agents import build_agent_runner
-from vibesys.agents.cli_runner import CliAgentRunner
+from vibesys.agents.client import AgentClient
+from vibesys.agents.drivers.agentshim import AgentShimDriver
+from vibesys.agents.drivers.omnigent import OmnigentDriver, OmnigentDriverError
 from vibesys.agents.omnigent import supported_providers
 from vibesys.agents.omnigent.providers import OMNIGENT_PROVIDER_EXECUTORS
 from vibesys.agents.omnigent.runner import (
@@ -84,14 +86,16 @@ class TestFlagDefaultsOff:
     def test_flag_absent_from_config_yields_cli_runner(self):  # noqa: ANN201  # tracked: #288
         runner = _build(_config(backend="cli", cli_provider="claude"))
 
-        assert isinstance(runner, CliAgentRunner)
+        assert isinstance(runner, AgentClient)
         assert runner.backend_name == "cli"
+        assert isinstance(runner._driver, AgentShimDriver)  # noqa: SLF001
         assert runner._provider == "claude"  # noqa: SLF001  # tracked: #288
 
     def test_flag_explicitly_false_yields_cli_runner(self):  # noqa: ANN201  # tracked: #288
         runner = _build(_config(omnigent=False, backend="cli", cli_provider="codex"))
 
-        assert isinstance(runner, CliAgentRunner)
+        assert isinstance(runner, AgentClient)
+        assert isinstance(runner._driver, AgentShimDriver)  # noqa: SLF001
         assert runner.backend_name == "cli"
 
     @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])
@@ -99,7 +103,8 @@ class TestFlagDefaultsOff:
         """Providers omnigent cannot run must keep working on the default path."""
         runner = _build(_config(backend="cli", cli_provider=provider))
 
-        assert isinstance(runner, CliAgentRunner)
+        assert isinstance(runner, AgentClient)
+        assert isinstance(runner._driver, AgentShimDriver)  # noqa: SLF001
         assert runner._provider == provider  # noqa: SLF001  # tracked: #288
 
     def test_docker_path_unchanged_with_flag_off(self):  # noqa: ANN201  # tracked: #288
@@ -111,16 +116,44 @@ class TestFlagDefaultsOff:
             use_docker=True,
         )
 
-        assert isinstance(runner, CliAgentRunner)
-        assert runner._docker_sandboxes is backends  # noqa: SLF001  # tracked: #288
+        assert isinstance(runner, AgentClient)
+        assert runner._driver._docker_sandboxes is backends  # noqa: SLF001
+
+
+class TestExplicitDriverSelection:
+    def test_omnigent_driver_can_be_selected_without_feature_flag(self):  # noqa: ANN201
+        runner = _build(_config(driver="omnigent", backend="cli", cli_provider="claude"))
+
+        assert isinstance(runner, AgentClient)
+        assert isinstance(runner._driver, OmnigentDriver)  # noqa: SLF001
+
+    def test_agentshim_driver_is_the_explicit_default(self):  # noqa: ANN201
+        runner = _build(_config(driver="agentshim", backend="cli", cli_provider="codex"))
+
+        assert isinstance(runner._driver, AgentShimDriver)  # noqa: SLF001
+
+    def test_conflicting_feature_flag_is_rejected(self):  # noqa: ANN201
+        with pytest.raises(SystemExit, match="conflicts"):
+            _build(
+                _config(
+                    omnigent=True,
+                    driver="agentshim",
+                    backend="cli",
+                    cli_provider="codex",
+                )
+            )
+
+    def test_driver_is_rejected_for_non_cli_backend(self):  # noqa: ANN201
+        with pytest.raises(SystemExit, match="valid only"):
+            _build(_config(driver="omnigent", backend="deepagents"), backends={})
 
 
 class TestFlagOnSelection:
     def test_flag_on_yields_omnigent_runner(self):  # noqa: ANN201  # tracked: #288
         runner = _build(_config(omnigent=True, backend="cli", cli_provider="claude"))
 
-        assert isinstance(runner, OmnigentAgentRunner)
-        assert runner.backend_name == "omnigent"
+        assert isinstance(runner, AgentClient)
+        assert isinstance(runner._driver, OmnigentDriver)  # noqa: SLF001
         assert runner._provider == "claude"  # noqa: SLF001  # tracked: #288
 
     def test_flag_on_passes_through_model_and_log_dir(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
@@ -130,7 +163,6 @@ class TestFlagOnSelection:
             log_dir=tmp_path,
         )
 
-        assert runner._model == "gpt-5"  # noqa: SLF001  # tracked: #288
         assert runner._model_name == "gpt-5"  # noqa: SLF001  # tracked: #288
         assert runner._log_dir == tmp_path  # noqa: SLF001  # tracked: #288
 
@@ -150,19 +182,18 @@ class TestFlagOnSelection:
 
     @pytest.mark.parametrize("provider", ["gemini", "opencode"])
     def test_unsupported_provider_names_the_remedy(self, provider):  # noqa: ANN001, ANN201  # tracked: #288
-        with pytest.raises(OmnigentUnavailableError) as exc:
+        with pytest.raises(OmnigentDriverError) as exc:
             _build(_config(omnigent=True, backend="cli", cli_provider=provider))
 
         message = str(exc.value)
         assert provider in message
-        assert "omnigent_agent_backend" in message
         assert "claude" in message and "codex" in message  # noqa: PT018  # tracked: #288
         assert "agentshim" in message
 
     def test_docker_combination_is_rejected(self):  # noqa: ANN201  # tracked: #288
         backends = {"implementer": MagicMock(), "judge": MagicMock(), "perf_eval": MagicMock()}
 
-        with pytest.raises(OmnigentUnavailableError) as exc:
+        with pytest.raises(SystemExit) as exc:
             _build(
                 _config(omnigent=True, backend="cli", cli_provider="claude"),
                 backends=backends,
@@ -175,7 +206,7 @@ class TestFlagOnSelection:
         """Silently dropping an operator's grant would weaken a security boundary."""
         grant = HostResource(tmp_path / "models", HostResourceAccess.READ_ONLY, "weights")
 
-        with pytest.raises(OmnigentUnavailableError) as exc:
+        with pytest.raises(OmnigentDriverError) as exc:
             _build(
                 _config(omnigent=True, backend="cli", cli_provider="claude"),
                 host_resources=[grant],
@@ -191,7 +222,8 @@ class TestFlagOnSelection:
             host_resources=(),
         )
 
-        assert isinstance(runner, OmnigentAgentRunner)
+        assert isinstance(runner, AgentClient)
+        assert isinstance(runner._driver, OmnigentDriver)  # noqa: SLF001
 
 
 class TestProviderRegistry:
@@ -1027,13 +1059,12 @@ class TestTurnPathWithFakeExecutor:
         assert runner._loop is None  # noqa: SLF001  # tracked: #288
 
 
-@requires_omnigent
-class TestLazyPackageExports:
-    def test_runner_symbols_resolve_through_package_getattr(self):  # noqa: ANN201  # tracked: #288
+class TestProviderPackageExports:
+    def test_package_exports_provider_metadata_only(self):  # noqa: ANN201  # tracked: #288
         import vibesys.agents.omnigent as pkg  # noqa: PLC0415  # tracked: #288
 
-        assert pkg.OmnigentAgentRunner is OmnigentAgentRunner
-        assert pkg.OmnigentUnavailableError is OmnigentUnavailableError
+        assert pkg.supported_providers() == supported_providers()
+        assert "OmnigentAgentRunner" not in pkg.__all__
 
     def test_unknown_attribute_still_raises(self):  # noqa: ANN201  # tracked: #288
         import vibesys.agents.omnigent as pkg  # noqa: PLC0415  # tracked: #288

--- a/tests/agents/test_stub_runner.py
+++ b/tests/agents/test_stub_runner.py
@@ -1,4 +1,4 @@
-from vibesys.agents.stub_runner import StubAgentRunner
+from vibesys.agents.stub_runner import StubAgentClient
 from vibesys.schemas import (
     ImplementerResponse,
     JudgeResponse,
@@ -9,7 +9,7 @@ from vibesys.schemas import (
 
 
 def test_stub_runner_returns_valid_agent_loop_responses(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
-    runner = StubAgentRunner()
+    runner = StubAgentClient()
 
     responses = [
         invoke(runner, tmp_path, "orchestrator", PreRoundDecision),
@@ -25,7 +25,7 @@ def test_stub_runner_returns_valid_agent_loop_responses(tmp_path):  # noqa: ANN0
 
 
 def test_stub_runner_returns_plain_chat_text(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
-    runner = StubAgentRunner()
+    runner = StubAgentClient()
 
     answer = runner.invoke_text(
         kind="chat",

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -7,7 +7,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
-from vibesys.agents import AgentRunner
+from vibesys.agents import AgentClient
 from vibesys.domains.base import DomainName
 from vibesys.errors import ConfigurationError
 from vibesys.loops.agent import issue_board
@@ -141,7 +141,7 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     implementer_next_steps: list[str] | None = None,
     implementer_parse_failures: list[bool] | None = None,
 ):
-    """Build a MagicMock AgentRunner whose invoke() returns scripted responses.
+    """Build a MagicMock AgentClient whose invoke() returns scripted responses.
 
     Arguments are consumed-in-order queues keyed by the agent kind / response
     class. Defaults: when the plan queue is exhausted, the harness returns a
@@ -164,7 +164,7 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     impl_parse_failure_q = list(implementer_parse_failures or [])
     counters = {"impl": 0, "judge": 0, "orch_pre": 0, "orch_plan": 0, "prof": 0}
 
-    runner = MagicMock(spec=AgentRunner)
+    runner = MagicMock(spec=AgentClient)
     runner.backend_name = "deepagents"
 
     def _invoke(*, kind, response_cls, fallback_factory, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001, PLR0911  # tracked: #288
@@ -267,7 +267,7 @@ def _invoke_orchestrate(tmp_path, ref_file, runner, **kwargs):  # noqa: ANN001, 
     with (
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.backends.cuda.LocalShellBackend"),
-        patch("vibesys.context.build_agent_runner", return_value=runner),
+        patch("vibesys.context.build_agent_client", return_value=runner),
         patch("vibesys.context.PROJECT_ROOT", tmp_path),
         patch(
             "vibesys.loops.agent.loop._run_framework_accuracy_gate",
@@ -1553,7 +1553,7 @@ def test_framework_gates_reuse_accuracy_pass_after_later_gate_failure(tmp_path):
     from vibesys.loops.agent.loop import _run_framework_gates  # noqa: PLC0415  # tracked: #288
 
     ctx = MagicMock()
-    ctx.agent_runner.backend_name = "deepagents"
+    ctx.agent_client.backend_name = "deepagents"
     ctx.judge_accuracy_command = "trusted-check"
     progress = tmp_path / "progress.md"
 

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -361,6 +361,7 @@ def test_project_configuration_captures_effective_agent_behavior(tmp_path: Path)
         "inner_loop": "single-agent",
         "interface": "service",
         "agent_backend": "cli",
+        "agent_driver": "agentshim",
         "cli_provider": "codex",
         "cli_timeout": 900,
         "compute_backend": "cuda",

--- a/tests/loops/evolve/test_evolutionary_loop.py
+++ b/tests/loops/evolve/test_evolutionary_loop.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vibesys.agents import AgentRunner
+from vibesys.agents import AgentClient
 from vibesys.context import create_run_context
 from vibesys.domains.base import DomainName
 from vibesys.domains.llm_serving.hooks import LLMServingEnvironmentHooks
@@ -102,7 +102,7 @@ def _make_runner(  # noqa: ANN202, C901, PLR0913  # tracked: #288
     capture_profiler_prompts: list[str] | None = None,
     mutator_writes: bool = False,
 ):
-    """Build a MagicMock AgentRunner with scripted responses.
+    """Build a MagicMock AgentClient with scripted responses.
 
     The mutator (``kind="implementer"`` + ``response_cls=MutatorResponse``)
     always returns a stub MutatorResponse. Judge verdicts default to
@@ -113,7 +113,7 @@ def _make_runner(  # noqa: ANN202, C901, PLR0913  # tracked: #288
     prof_q = list(profiler_responses or [])
     counters = {"mutator": 0, "judge": 0, "profiler": 0}
 
-    runner = MagicMock(spec=AgentRunner)
+    runner = MagicMock(spec=AgentClient)
     runner.backend_name = "deepagents"
 
     def _invoke(*, kind, response_cls, fallback_factory, system_prompt="", **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288
@@ -193,7 +193,7 @@ def _invoke_loop(tmp_path, ref_file, runner, **kwargs):  # noqa: ANN001, ANN003,
     with (
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.backends.cuda.LocalShellBackend"),
-        patch("vibesys.context.build_agent_runner", return_value=runner),
+        patch("vibesys.context.build_agent_client", return_value=runner),
         patch("vibesys.context.PROJECT_ROOT", tmp_path),
         patch(
             "vibesys.loops.evolve.loop._run_framework_accuracy_gate",
@@ -1272,7 +1272,7 @@ def test_evaluate_in_subcontext_builds_worktree_and_evaluates(tmp_path, ref_file
     with (
         patch("vibesys.context.build_model", return_value="mock-model"),
         patch("vibesys.backends.cuda.LocalShellBackend"),
-        patch("vibesys.context.build_agent_runner", return_value=runner),
+        patch("vibesys.context.build_agent_client", return_value=runner),
         patch("vibesys.context.PROJECT_ROOT", tmp_path),
         patch("vibesys.loops.evolve.loop._run_framework_accuracy_gate", return_value=None),
         create_run_context(

--- a/tests/loops/plain/test_plain_loop.py
+++ b/tests/loops/plain/test_plain_loop.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibesys.agents import AgentRunner
+from vibesys.agents.contracts import AgentCapabilities
 from vibesys.domains.base import DomainName
 from vibesys.loops.plain.loop import PlainLoopState
 from vibesys.loops.plain.loop import run_plain_loop as _run_plain_loop
@@ -83,11 +84,14 @@ def _make_issue_runner(responses: list, *, backend_name: str = "deepagents") -> 
 
     The mock is wrapped in PlainLoopAgentRunner inside ``run_plain_loop``,
     so the calls recorded on this mock reflect what the wrapper passed
-    after injecting tracker tools / MCP server specs based on
-    ``backend_name``.
+    after injecting tracker tools / MCP server specs based on capabilities.
     """
     runner = MagicMock(spec=AgentRunner)
     runner.backend_name = backend_name
+    runner.capabilities = AgentCapabilities(
+        mcp_servers=backend_name == "cli",
+        in_process_tools=backend_name == "deepagents",
+    )
     it = iter(responses)
 
     def _invoke(*, kind, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001  # tracked: #288

--- a/tests/loops/plain/test_plain_loop.py
+++ b/tests/loops/plain/test_plain_loop.py
@@ -1,6 +1,6 @@
 """Integration tests for the issue-loop orchestrator.
 
-These tests mock ``vibesys.context.build_agent_runner`` so the real
+These tests mock ``vibesys.context.build_agent_client`` so the real
 LangChain / CLI plumbing never executes. Each test exercises one focused
 behaviour of the drain-and-perf-eval outer loop in
 ``vibesys/plain/loop.py``.
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vibesys.agents import AgentRunner
+from vibesys.agents import AgentClient
 from vibesys.agents.contracts import AgentCapabilities
 from vibesys.domains.base import DomainName
 from vibesys.loops.plain.loop import PlainLoopState
@@ -77,16 +77,16 @@ def _make_perf_resp(new_issue_ids: list[int] | None = None) -> IssuePerfEvalResp
 
 
 def _make_issue_runner(responses: list, *, backend_name: str = "deepagents") -> MagicMock:
-    """Mock AgentRunner.invoke that yields scripted responses in order.
+    """Mock AgentClient.invoke that yields scripted responses in order.
 
     The script is consumed left-to-right regardless of ``kind``, so the test
     just lists responses in the order the loop will call invoke().
 
-    The mock is wrapped in PlainLoopAgentRunner inside ``run_plain_loop``,
+    The mock is wrapped in PlainLoopAgentClient inside ``run_plain_loop``,
     so the calls recorded on this mock reflect what the wrapper passed
     after injecting tracker tools / MCP server specs based on capabilities.
     """
-    runner = MagicMock(spec=AgentRunner)
+    runner = MagicMock(spec=AgentClient)
     runner.backend_name = backend_name
     runner.capabilities = AgentCapabilities(
         mcp_servers=backend_name == "cli",
@@ -164,7 +164,7 @@ command = ["python", "-c", "print('ok')"]
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_bootstrap_creates_initial_feature_issue_on_first_run(  # noqa: ANN201  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -211,7 +211,7 @@ def test_bootstrap_creates_initial_feature_issue_on_first_run(  # noqa: ANN201  
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_bootstrap_idempotent_on_resume(  # noqa: ANN201  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -279,7 +279,7 @@ def test_bootstrap_idempotent_on_resume(  # noqa: ANN201  # tracked: #288
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_judge_pass_closes_issue(mock_build_runner, mock_backend, mock_build, ref_file, tmp_path):  # noqa: ANN001, ANN201, ARG001  # tracked: #288
     mock_build.return_value = "anthropic:claude-sonnet-4-6"
     mock_build_runner.return_value = _make_issue_runner(
@@ -310,7 +310,7 @@ def test_judge_pass_closes_issue(mock_build_runner, mock_backend, mock_build, re
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_judge_fail_increments_attempts_and_keeps_open(  # noqa: ANN201  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -354,7 +354,7 @@ def test_judge_fail_increments_attempts_and_keeps_open(  # noqa: ANN201  # track
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_issue_blocks_after_max_attempts_exhausted(  # noqa: ANN201  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -395,7 +395,7 @@ def test_issue_blocks_after_max_attempts_exhausted(  # noqa: ANN201  # tracked: 
 
 
 # ---------------------------------------------------------------------------
-# Per-phase MCP server spec passed to AgentRunner.invoke
+# Per-phase MCP server spec passed to AgentClient.invoke
 # ---------------------------------------------------------------------------
 
 
@@ -432,7 +432,7 @@ _EXPECTED_TRACKER_TOOL_NAMES = {
 @pytest.mark.parametrize("backend_name", ["deepagents", "cli"])
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_judge_invoke_receives_tracker_kwargs(  # noqa: ANN201, PLR0913  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -444,7 +444,7 @@ def test_judge_invoke_receives_tracker_kwargs(  # noqa: ANN201, PLR0913  # track
     """The judge phase must receive issue-tracker access scoped to
     creator='judge', cap=1, allowed_types={BUG}.
 
-    The PlainLoopAgentRunner wrapper picks the right transport based on
+    The PlainLoopAgentClient wrapper picks the right transport based on
     the inner runner's backend_name: ``tools`` (in-process @tool callables)
     for the deepagents backend, ``mcp_servers`` (an MCPServerSpec) for
     the cli backend.
@@ -498,7 +498,7 @@ def test_judge_invoke_receives_tracker_kwargs(  # noqa: ANN201, PLR0913  # track
 @pytest.mark.parametrize("backend_name", ["deepagents", "cli"])
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_perf_eval_invoke_receives_tracker_kwargs(  # noqa: ANN201, PLR0913  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -512,7 +512,7 @@ def test_perf_eval_invoke_receives_tracker_kwargs(  # noqa: ANN201, PLR0913  # t
     BUG/FEATURE/PERF allowed-types set.
 
     Picks ``tools`` vs ``mcp_servers`` based on the inner runner's
-    backend_name (see PlainLoopAgentRunner).
+    backend_name (see PlainLoopAgentClient).
     """
     mock_build.return_value = "anthropic:claude-sonnet-4-6"
     runner = _make_issue_runner(
@@ -561,7 +561,7 @@ def test_perf_eval_invoke_receives_tracker_kwargs(  # noqa: ANN201, PLR0913  # t
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_judge_phase_calls_store_reload_after_invoke(  # noqa: ANN201  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -599,7 +599,7 @@ def test_judge_phase_calls_store_reload_after_invoke(  # noqa: ANN201  # tracked
             return _make_perf_resp(new_issue_ids=[])
         raise AssertionError(f"unexpected kind: {kind}")  # noqa: TRY003  # tracked: #288
 
-    runner = MagicMock(spec=AgentRunner)
+    runner = MagicMock(spec=AgentClient)
     runner.backend_name = "deepagents"
     runner.invoke.side_effect = tracking_invoke
     mock_build_runner.return_value = runner
@@ -631,7 +631,7 @@ def test_judge_phase_calls_store_reload_after_invoke(  # noqa: ANN201  # tracked
 @pytest.mark.parametrize("backend_name", ["deepagents", "cli"])
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_implementer_invoke_has_no_tracker_kwargs(  # noqa: ANN201, PLR0913  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -677,7 +677,7 @@ def test_implementer_invoke_has_no_tracker_kwargs(  # noqa: ANN201, PLR0913  # t
         assert not c.kwargs.get("tools")
 
     # The judge and perf_eval invokes both DO receive a tracker kwarg.
-    # Which one depends on the backend (see PlainLoopAgentRunner).
+    # Which one depends on the backend (see PlainLoopAgentClient).
     judge_calls = [c for c in runner.invoke.call_args_list if c.kwargs.get("kind") == "judge"]
     perf_calls = [c for c in runner.invoke.call_args_list if c.kwargs.get("kind") == "perf_eval"]
     assert len(judge_calls) == 1
@@ -697,7 +697,7 @@ def test_implementer_invoke_has_no_tracker_kwargs(  # noqa: ANN201, PLR0913  # t
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_perf_eval_runs_after_drain_complete(  # noqa: ANN201  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -751,7 +751,7 @@ def test_perf_eval_runs_after_drain_complete(  # noqa: ANN201  # tracked: #288
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_resume_with_bootstrap_done_skips_bootstrap_creation(  # noqa: ANN201  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -815,7 +815,7 @@ def test_resume_with_bootstrap_done_skips_bootstrap_creation(  # noqa: ANN201  #
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_resume_retries_previously_blocked_issue(  # noqa: ANN201  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -897,7 +897,7 @@ def test_resume_retries_previously_blocked_issue(  # noqa: ANN201  # tracked: #2
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_run_returns_true_when_perf_eval_files_no_issues_after_clean_drain(  # noqa: ANN201  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -938,7 +938,7 @@ def test_run_returns_true_when_perf_eval_files_no_issues_after_clean_drain(  # n
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_state_json_written_with_bootstrap_done_after_run(  # noqa: ANN201  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -986,7 +986,7 @@ def test_state_json_written_with_bootstrap_done_after_run(  # noqa: ANN201  # tr
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_issue_loop_writes_per_issue_markdown_via_callback(  # noqa: ANN201  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288
@@ -1049,7 +1049,7 @@ def test_issue_loop_writes_per_issue_markdown_via_callback(  # noqa: ANN201  # t
 
 @patch("vibesys.context.build_model")
 @patch("vibesys.backends.cuda.LocalShellBackend")
-@patch("vibesys.context.build_agent_runner")
+@patch("vibesys.context.build_agent_client")
 def test_implementer_retry_user_prompt_includes_prior_judge_feedback(  # noqa: ANN201  # tracked: #288
     mock_build_runner,  # noqa: ANN001  # tracked: #288
     mock_backend,  # noqa: ANN001, ARG001  # tracked: #288

--- a/tests/loops/plain/test_plain_runner_ext.py
+++ b/tests/loops/plain/test_plain_runner_ext.py
@@ -1,6 +1,6 @@
-"""Tests for PlainLoopAgentRunner — the issue-loop's runner customization.
+"""Tests for PlainLoopAgentClient — the issue-loop's runner customization.
 
-The wrapper sits in front of any AgentRunner and injects issue-tracker
+The wrapper sits in front of any AgentClient and injects issue-tracker
 access for ``judge`` and ``perf_eval`` phases. Under the cli backend it
 materializes an MCPServerSpec; under deepagents it materializes
 LangChain ``@tool`` callables. Implementer phase passes through.
@@ -12,9 +12,9 @@ import pytest
 from pydantic import BaseModel
 
 from vibesys._agent_cli.base import MCPServerSpec
-from vibesys.agents.base import AgentRunner
+from vibesys.agents.client import AgentClient
 from vibesys.agents.contracts import AgentCapabilities
-from vibesys.loops.plain.runner_ext import PlainLoopAgentRunner
+from vibesys.loops.plain.runner_ext import PlainLoopAgentClient
 from vs_issue_board import IssueBoard
 
 _EXPECTED_TOOL_NAMES = {"list_issues", "get_issue", "search_issues", "create_issue"}
@@ -25,7 +25,7 @@ class _Resp(BaseModel):
 
 
 def _mock_runner(backend_name: str) -> MagicMock:
-    runner = MagicMock(spec=AgentRunner)
+    runner = MagicMock(spec=AgentClient)
     runner.backend_name = backend_name
     runner.capabilities = AgentCapabilities(
         mcp_servers=backend_name == "cli",
@@ -52,7 +52,7 @@ class TestDeepAgentsBackend:
     def test_judge_receives_in_process_tools(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(response_cls=_Resp, kind="judge", iteration=2, round_label="r")
 
@@ -65,7 +65,7 @@ class TestDeepAgentsBackend:
     def test_perf_eval_receives_in_process_tools(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=4)
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=4)
 
         wrapper.invoke(response_cls=_Resp, kind="perf_eval", iteration=5, round_label="r")
 
@@ -79,7 +79,7 @@ class TestDeepAgentsBackend:
         issues and the 6th must be rejected with the cap-reached error."""
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=5)
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=5)
 
         wrapper.invoke(response_cls=_Resp, kind="perf_eval", iteration=1, round_label="r")
         tools = inner.invoke.call_args.kwargs["tools"]
@@ -96,7 +96,7 @@ class TestDeepAgentsBackend:
         """Judge is bug-only — feature/perf must be rejected by policy."""
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(response_cls=_Resp, kind="judge", iteration=1, round_label="r")
         tools = inner.invoke.call_args.kwargs["tools"]
@@ -116,7 +116,7 @@ class TestCliBackend:
     def test_judge_receives_mcp_server_spec(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("cli")
-        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(response_cls=_Resp, kind="judge", iteration=7, round_label="r")
 
@@ -139,7 +139,7 @@ class TestCliBackend:
     def test_perf_eval_receives_mcp_server_spec_with_all_types(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("cli")
-        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=4)
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=4)
 
         wrapper.invoke(response_cls=_Resp, kind="perf_eval", iteration=2, round_label="r")
 
@@ -160,10 +160,40 @@ class TestCliBackend:
 
 
 class TestPassThrough:
+    def test_text_turn_delegates_to_inner_client(self, tmp_path):  # noqa: ANN001, ANN201
+        store = _make_store(tmp_path)
+        inner = _mock_runner("cli")
+        inner.invoke_text.return_value = "answer"
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=3)
+
+        result = wrapper.invoke_text(
+            kind="chat",
+            workspace=tmp_path,
+            system_prompt="system",
+            user_prompt="question",
+            round_label="chat",
+        )
+
+        assert result == "answer"
+        inner.invoke_text.assert_called_once_with(
+            kind="chat",
+            workspace=tmp_path,
+            system_prompt="system",
+            user_prompt="question",
+            round_label="chat",
+            env=None,
+            invocation_id=None,
+            progress=None,
+            mcp_servers=None,
+            tools=None,
+            reuse_session=None,
+            session_key=None,
+        )
+
     def test_implementer_passes_through_under_deepagents(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(response_cls=_Resp, kind="implementer", round_label="r")
 
@@ -175,7 +205,7 @@ class TestPassThrough:
     def test_implementer_passes_through_under_cli(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("cli")
-        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(response_cls=_Resp, kind="implementer", round_label="r")
 
@@ -185,10 +215,10 @@ class TestPassThrough:
 
     def test_iteration_kwarg_is_consumed_not_forwarded(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         """The wrapper consumes ``iteration=`` and must not pass it to the
-        inner runner — the AgentRunner Protocol has no such kwarg."""
+        inner client, whose public invoke API has no such kwarg."""
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(response_cls=_Resp, kind="judge", iteration=1, round_label="r")
 
@@ -199,7 +229,7 @@ class TestPassThrough:
         reach the inner runner unchanged."""
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=3)
 
         wrapper.invoke(
             response_cls=_Resp,
@@ -221,7 +251,7 @@ class TestPassThrough:
 class TestValidation:
     def test_judge_without_iteration_raises(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
-        wrapper = PlainLoopAgentRunner(
+        wrapper = PlainLoopAgentClient(
             _mock_runner("deepagents"),
             store=store,
             max_issues_per_perf_eval=3,
@@ -231,7 +261,7 @@ class TestValidation:
 
     def test_perf_eval_without_iteration_raises(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
-        wrapper = PlainLoopAgentRunner(
+        wrapper = PlainLoopAgentClient(
             _mock_runner("cli"),
             store=store,
             max_issues_per_perf_eval=3,
@@ -244,9 +274,9 @@ class TestBackendName:
     def test_backend_name_proxies_inner(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         store = _make_store(tmp_path)
         inner = _mock_runner("deepagents")
-        wrapper = PlainLoopAgentRunner(inner, store=store, max_issues_per_perf_eval=3)
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=3)
         assert wrapper.backend_name == "deepagents"
 
         inner_cli = _mock_runner("cli")
-        wrapper_cli = PlainLoopAgentRunner(inner_cli, store=store, max_issues_per_perf_eval=3)
+        wrapper_cli = PlainLoopAgentClient(inner_cli, store=store, max_issues_per_perf_eval=3)
         assert wrapper_cli.backend_name == "cli"

--- a/tests/loops/plain/test_plain_runner_ext.py
+++ b/tests/loops/plain/test_plain_runner_ext.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from vibesys._agent_cli.base import MCPServerSpec
 from vibesys.agents.base import AgentRunner
+from vibesys.agents.contracts import AgentCapabilities
 from vibesys.loops.plain.runner_ext import PlainLoopAgentRunner
 from vs_issue_board import IssueBoard
 
@@ -26,6 +27,10 @@ class _Resp(BaseModel):
 def _mock_runner(backend_name: str) -> MagicMock:
     runner = MagicMock(spec=AgentRunner)
     runner.backend_name = backend_name
+    runner.capabilities = AgentCapabilities(
+        mcp_servers=backend_name == "cli",
+        in_process_tools=backend_name == "deepagents",
+    )
     runner.invoke.return_value = "ok"
     return runner
 

--- a/tests/test_agent_progress.py
+++ b/tests/test_agent_progress.py
@@ -23,8 +23,8 @@ def _make_context(tmp_path):  # noqa: ANN001, ANN202  # tracked: #288
         run_log_path=tmp_path / "run.log",
     )
     ctx.gpu_env = dict
-    ctx.agent_runner = MagicMock()
-    ctx.agent_runner.invoke.return_value = _judge_fallback()
+    ctx.agent_client = MagicMock()
+    ctx.agent_client.invoke.return_value = _judge_fallback()
     return ctx
 
 
@@ -61,7 +61,7 @@ def test_run_context_injects_current_progress(tmp_path):  # noqa: ANN001, ANN201
             round_label="judge #1",
         )
 
-    assert ctx.agent_runner.invoke.call_args.kwargs["progress"] is progress
+    assert ctx.agent_client.invoke.call_args.kwargs["progress"] is progress
 
 
 def test_run_context_explicit_progress_overrides_scope(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
@@ -80,4 +80,4 @@ def test_run_context_explicit_progress_overrides_scope(tmp_path):  # noqa: ANN00
             progress=explicit,
         )
 
-    assert ctx.agent_runner.invoke.call_args.kwargs["progress"] is explicit
+    assert ctx.agent_client.invoke.call_args.kwargs["progress"] is explicit

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -343,7 +343,7 @@ budget = -2
 
 class TestLoadConfigAgentSection:
     def test_agent_section_preserved(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
-        # The [agent] table drives build_agent_runner (cli_timeout, backend,
+        # The [agent] table drives build_agent_client (cli_timeout, backend,
         # cli_provider). load_config must carry it through; the previous
         # allowlist loader silently dropped it.
         cfg_file = tmp_path / "agent.toml"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -352,11 +352,13 @@ class TestLoadConfigAgentSection:
 name = "claude-sonnet-4-6"
 
 [agent]
+driver = "omnigent"
 backend = "cli"
 cli_provider = "claude"
 cli_timeout = 1800
 """)
         config = load_config(cfg_file)
+        assert config.agent.driver == "omnigent"
         assert config.agent.cli_timeout == 1800
         assert config.agent.backend == "cli"
         assert config.agent.cli_provider == "claude"
@@ -365,9 +367,23 @@ cli_timeout = 1800
         cfg_file = tmp_path / "agent.toml"
         cfg_file.write_text('[model]\nname = "claude-sonnet-4-6"\n')
         config = load_config(cfg_file)
+        assert config.agent.driver is None
         assert config.agent.backend is None
         assert config.agent.cli_provider is None
         assert config.agent.cli_timeout is None
+
+    def test_unknown_agent_driver_is_rejected(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        cfg_file = tmp_path / "agent.toml"
+        cfg_file.write_text("""\
+[model]
+name = "claude-sonnet-4-6"
+
+[agent]
+driver = "unknown"
+""")
+
+        with pytest.raises(ValueError, match="driver"):
+            load_config(cfg_file)
 
     @pytest.mark.parametrize("cli_timeout", [0, -1])
     def test_non_positive_cli_timeout_is_rejected(self, tmp_path, cli_timeout):  # noqa: ANN001, ANN201  # tracked: #288

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -179,8 +179,9 @@ def _git(project: Path, *args: str) -> str:
 def test_direct_run_uses_one_project_root_and_canonical_state(tmp_path):  # noqa: ANN001, ANN201
     project = tmp_path / "queue"
     evaluator = _write_project(project)
+    runner = MagicMock()
 
-    with patch("vibesys.context.build_agent_runner", return_value=MagicMock()) as build_runner:
+    with patch("vibesys.context.build_agent_runner", return_value=runner) as build_runner:
         with _create_context(project, evaluator=evaluator) as ctx:
             assert ctx.project_root == project
             assert ctx.workspace == project
@@ -203,6 +204,7 @@ def test_direct_run_uses_one_project_root_and_canonical_state(tmp_path):  # noqa
         state_paths = Project.open(project).state.sandbox_paths()
         assert state_paths.read_only_path in policy.read_only_paths
         assert state_paths.hidden_path in policy.hidden_paths
+        runner.close.assert_called_once_with()
 
     manifest = Project.open(project).state.load_run(ctx.run_id)
     assert manifest.branch == f"vibesys-runs/{ctx.run_id}"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,7 +1,6 @@
 import subprocess
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -50,7 +49,7 @@ class _RecordingHooks:
 @pytest.fixture(autouse=True)
 def _context_dependencies(monkeypatch):  # pyright: ignore[reportUnusedFunction]  # noqa: ANN001, ANN202
     monkeypatch.setattr("vibesys.context.backends.get", lambda *_args, **_kwargs: _FakeBackend())
-    monkeypatch.setattr("vibesys.context.build_agent_runner", lambda *_args, **_kwargs: MagicMock())
+    monkeypatch.setattr("vibesys.context.build_agent_client", lambda *_args, **_kwargs: MagicMock())
     monkeypatch.setattr(
         "vibesys.context.preflight_profiler_kind",
         lambda kind: ProfilerPreflightResult(kind, True),  # noqa: FBT003
@@ -181,7 +180,7 @@ def test_direct_run_uses_one_project_root_and_canonical_state(tmp_path):  # noqa
     evaluator = _write_project(project)
     runner = MagicMock()
 
-    with patch("vibesys.context.build_agent_runner", return_value=runner) as build_runner:
+    with patch("vibesys.context.build_agent_client", return_value=runner) as build_runner:
         with _create_context(project, evaluator=evaluator) as ctx:
             assert ctx.project_root == project
             assert ctx.workspace == project
@@ -539,7 +538,7 @@ def test_construction_failure_removes_new_copy_and_tears_down_hooks(tmp_path):  
     hooks = _RecordingHooks()
 
     with (
-        patch("vibesys.context.build_agent_runner", side_effect=RuntimeError("runner failed")),
+        patch("vibesys.context.build_agent_client", side_effect=RuntimeError("runner failed")),
         pytest.raises(RuntimeError, match="runner failed"),
     ):
         _create_context(source, runs_dir=runs_dir, evaluator=evaluator, hooks=hooks)
@@ -574,11 +573,12 @@ def test_log_switch_retargets_stderr_tee(tmp_path):  # noqa: ANN001, ANN201
         run_log_path=ctx.logger.path,
     )
     original_file = ctx.logger.file
-    ctx.agent_runner = SimpleNamespace(_run_log_file=ctx.run_log_file)
+    ctx.agent_client = MagicMock()
 
     ctx.switch_log_file("round001")
 
     assert original_file.closed
+    ctx.agent_client.set_log_file.assert_called_once_with(ctx.logger.writer)
     print("\033[31mcolored diagnostic\033[0m", file=sys.stderr)  # noqa: T201
     ctx.logger.close()
     assert sys.stderr is original_stderr

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -131,6 +131,7 @@ class _CommonConfiguration(TypedDict):
     run_environment: RunEnvironmentRecord
     model: str
     agent_backend: str
+    agent_driver: str
     cli_provider: str
     cli_timeout: int
     compute_backend: str
@@ -159,6 +160,7 @@ def _common_configuration(
         "run_environment": run_environment or _LOCAL_ENVIRONMENT,
         "model": "gpt-recorded",
         "agent_backend": "cli",
+        "agent_driver": "omnigent",
         "cli_provider": "claude",
         "cli_timeout": 321,
         "compute_backend": "cpu",
@@ -1199,6 +1201,7 @@ def test_agent_resume_restores_its_configuration(
     assert backend is ComputeBackend.CPU
     assert config.model.name == "gpt-recorded"
     assert config.agent.cli_timeout == 321
+    assert config.agent.driver == "omnigent"
     assert config.agent.outer.model == "gpt-outer"
     assert config.agent.inner.model == "gpt-inner"
 

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -722,8 +722,8 @@ def test_run_context_chat_exposes_trajectory_without_inlining_it_in_prompt(tmp_p
     supervisor.attach(store.state.log_directory(run_id), project=store, run_id=run_id)
     ctx = _RunContext.__new__(_RunContext)
     ctx.supervisor = supervisor
-    ctx.agent_runner = Mock()
-    ctx.agent_runner.invoke_text.return_value = "It improved in round 2."
+    ctx.agent_client = Mock()
+    ctx.agent_client.invoke_text.return_value = "It improved in round 2."
     ctx._paths = RunPaths(  # noqa: SLF001  # tracked: #288
         project_root=store.root,
         log_dir=store.state.log_directory(run_id),
@@ -741,7 +741,7 @@ def test_run_context_chat_exposes_trajectory_without_inlining_it_in_prompt(tmp_p
     answer = ctx.chat("what improved?")
 
     assert answer == "It improved in round 2."
-    invocation = ctx.agent_runner.invoke_text.call_args.kwargs
+    invocation = ctx.agent_client.invoke_text.call_args.kwargs
     assert invocation["kind"] == "chat"
     assert "response_cls" not in invocation
     assert invocation["user_prompt"] == "what improved?"
@@ -760,10 +760,10 @@ def test_run_context_chat_exposes_trajectory_without_inlining_it_in_prompt(tmp_p
         "answer": "It improved in round 2.",
     }
 
-    ctx.agent_runner.invoke_text.side_effect = RuntimeError("agent unavailable")
+    ctx.agent_client.invoke_text.side_effect = RuntimeError("agent unavailable")
     with pytest.raises(RuntimeError, match="Chat agent failed: RuntimeError: agent unavailable"):
         ctx.chat("what is the current status?")
-    continuation = ctx.agent_runner.invoke_text.call_args.kwargs
+    continuation = ctx.agent_client.invoke_text.call_args.kwargs
     assert continuation["user_prompt"] == "what is the current status?"
     assert "It improved in round 2." not in continuation["user_prompt"]
     assert "_vibesys_chat/instructions.md" in continuation["system_prompt"]
@@ -1049,8 +1049,8 @@ def test_run_context_records_invocation_boundary(tmp_path):  # noqa: ANN001, ANN
     supervisor.attach(tmp_path)
     ctx = _RunContext.__new__(_RunContext)
     ctx.supervisor = supervisor
-    ctx.agent_runner = Mock()
-    ctx.agent_runner.invoke.return_value = {"summary": "measured"}
+    ctx.agent_client = Mock()
+    ctx.agent_client.invoke.return_value = {"summary": "measured"}
     ctx._paths = RunPaths(  # noqa: SLF001  # tracked: #288
         project_root=tmp_path,
         log_dir=tmp_path / "logs",
@@ -1069,7 +1069,7 @@ def test_run_context_records_invocation_boundary(tmp_path):  # noqa: ANN001, ANN
     )
 
     assert result == {"summary": "measured"}
-    sent_prompt = ctx.agent_runner.invoke.call_args.kwargs["user_prompt"]
+    sent_prompt = ctx.agent_client.invoke.call_args.kwargs["user_prompt"]
     assert sent_prompt == "original"
     events = _events(tmp_path / "run-events.jsonl")
     started = next(event for event in events if event["type"] == "invocation_started")


### PR DESCRIPTION
## Problem

VibeSys's application-facing agent behavior was implemented separately inside the AgentShim and Omnigent runners. Session reuse, prompt handling, response parsing, usage accounting, policy setup, event translation, and cleanup were coupled to each runtime. The first refactor also introduced both `AgentRunner` and `AgentClient`, even though loops need only one application-level contract.

## Solution

Use `AgentClient` as the only loop-facing agent abstraction:

- `LoopContext.agent_client` is typed as `AgentClient`; loops no longer depend on `AgentRunner`.
- `build_agent_client` composes the selected application backend and runtime driver.
- `AgentClient` owns session reuse/reset, skill materialization, response parsing, logging, usage records, and lifecycle.
- `AgentSessionSpec` contains setup-time configuration: provider, model, workspace, policy, MCP servers, skills, environment, and reasoning effort.
- `AgentTurnRequest` contains turn-time context: instructions, message, output schema, timeout, and invocation metadata.
- `AgentShimDriver` and `OmnigentDriver` translate the neutral session contract to their native execution systems and normalize events and usage.
- Deepagents, the deterministic stub, and the plain-loop issue-tool wrapper implement or extend the same `AgentClient` surface.
- Loop tool routing uses declared capabilities instead of runtime implementation names.
- `[agent].driver` is optional. It defaults to `agentshim`; the existing Omnigent feature flag remains a compatibility alias.
- The resolved driver is persisted in run configuration so resume behavior is stable if the default changes.

The dependency direction is now:

`Loop -> AgentClient -> AgentDriver -> AgentShimDriver | OmnigentDriver`

VibeSys remains the policy authority. Drivers translate requested policy into native enforcement and reject requirements they cannot satisfy. Creating a session performs durable setup; `run_turn` adds conversation context and executes the next turn.

Unsupported policy requirements fail before runtime setup. Omnigent currently rejects MCP servers, VibeSys Docker execution, host-resource grants, and nested read-only or hidden paths instead of silently weakening policy.

## Verification

### Correctness properties

- Loops and run contexts depend on one application-level type, `AgentClient`.
- A keyed session is reused only while its immutable setup specification is unchanged.
- Setup changes close and replace the previous session.
- Failed or reset-required turns evict their session before reuse.
- Ephemeral sessions and all driver resources are closed idempotently.
- A primary turn error is preserved if cleanup also fails.
- Skills are materialized once per created session.
- Requested policies are enforced or rejected before agent execution.
- Driver selection defaults to AgentShim, supports explicit Omnigent selection, preserves the feature-flag alias, and is persisted for resume.
- Plain-loop structured and text turns delegate through the same `AgentClient` wrapper.

### Testing

- `uv run ruff check ...` on all changed source and test files: passed.
- Targeted Pyright on changed agent, context, loop, and test paths: 0 errors.
- `uv run pytest tests/agents/test_agent_client.py tests/agents/drivers tests/agents/test_agent_runners.py tests/agents/test_omnigent_backend.py tests/agents/test_stub_runner.py tests/loops/plain/test_plain_runner_ext.py tests/test_config.py tests/test_context.py tests/test_agent_progress.py -q`: 273 passed.
- Affected plain, evolutionary, agent-loop, TUI, and progress suites collect successfully.

### Live Linux spot checks

On `chelan4` (Debian Linux), an isolated worktree pinned to `ae95b9b` exercised both drivers against the real Codex CLI:

- AgentShim/Codex: two keyed turns returned the expected responses, retained exactly one cached session, and closed cleanly.
- Omnigent/Codex: the same two keyed turns passed with one cached session. Omnigent emitted a non-fatal warning about a completed stale turn ID during continuation; the second response was still correct.
- A full one-round SPSC queue run through AgentShim completed live orchestrator and implementer turns, streamed tool events, read and edited the sandboxed repository, produced and parsed structured responses, built `queue-candidate.so`, and passed 3 Rust unit tests. The trusted accuracy command could not start because this clone lacks the configured queue evaluator package path, so no evaluator result is claimed.
- A full SPSC queue run through Omnigent failed closed during client construction because Omnigent 0.6.0 cannot enforce the repository's nested read-only and hidden path policy. No model was launched for that full-loop check.

The full integration suite was not run or awaited because it is slow and flaky and is not a merge gate for this draft.
