### PR TITLE
Store machine-local run state outside projects

### DIFF
--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -92,7 +92,8 @@ missing and reported at startup rather than failing once per round. Evaluator,
 checker, and benchmark paths are visible to agents but enforced read-only and
 protected by integrity checks. The agent also cannot write `.git`, `.vibesys`,
 legacy root-level task inputs, or `_evaluator/`, and cannot read
-`.vibesys/state/local/`, root `.env*` files, or root `agent.toml`. A run is
+root `.env*` files or root `agent.toml`. Machine-local VibeSys state is stored
+outside the project. A run is
 rejected when a root `.env*` file or `agent.toml` is recoverable from Git refs
 or reflogs.
 
@@ -113,8 +114,8 @@ Set the variable to `0`/`false`/`off`/`no` to disable confinement entirely; any
 other value is rejected.
 
 VibeSys initializes Git when needed and creates one `vibesys-runs/<run-id>` branch
-per run. Agent-authored source stays at its normal project paths. Portable and
-machine-local state are separated under `.vibesys/state/`:
+per run. Agent-authored source stays at its normal project paths. Portable state
+remains in the project, while machine-local state defaults to `~/.vibesys`:
 
 ```text
 .vibesys/
@@ -127,14 +128,19 @@ machine-local state are separated under `.vibesys/state/`:
     │   ├── plain/                          # plain-loop portable cursor
     │   ├── evolve/                         # evolve population and policy state
     │   └── runtime/effective-objective.md  # objective plus run constraints
-    └── local/                             # ignored operational state
-        ├── current-run
-        └── runs/<run-id>/
-            ├── agent/active.json
-            ├── round-transaction.json      # during round commit/recovery
-            ├── logs/
-            └── worktrees/                  # temporary evolve worktrees
+    └── local/runs/<run-id>/worktrees/     # ignored temporary evolve worktrees
+
+~/.vibesys/projects/<project-key>/
+├── current-run
+└── runs/<run-id>/
+    ├── agent/active.json
+    ├── round-transaction.json             # during round commit/recovery
+    └── logs/
 ```
+
+Set `VIBESYS_STATE_HOME` to an absolute directory to override `~/.vibesys`.
+VibeSys moves an existing `.vibesys/state/local/` tree on first open, preserving
+the existing bytes and paths; temporary worktrees remain in the project.
 
 The committed files contain portable configuration, fingerprints, metrics, and
 round outcomes. They exclude provider credentials, environment variables,
@@ -142,7 +148,7 @@ absolute source paths, sessions, and raw logs. Resume restores the saved branch
 and run configuration:
 
 ```bash
-# Resume the run named by .vibesys/state/local/current-run, or newest if unset
+# Resume the machine-local current run, or newest if unset
 vibesys --resume
 
 # Select a run explicitly
@@ -226,7 +232,7 @@ overrides it. Creation goes through the authenticated `gh` CLI.
 
 The project repository records candidate history and portable
 `.vibesys/state/runs/` state. Provider and agent logs under
-`.vibesys/state/local/` are excluded. On context shutdown, VibeSys pushes the
+the configured VibeSys state home are excluded. On context shutdown, VibeSys pushes the
 already-authored run branch and retained evolve candidate refs. Publication
 never stages files or creates a synchronization commit. A non-fast-forward or
 authentication failure is reported rather than force-pushing.

--- a/docs/running-vibesys.md
+++ b/docs/running-vibesys.md
@@ -19,14 +19,20 @@ project/
 │   └── state/
 │       ├── project.json
 │       ├── runs/<run-id>/          # committed run metadata and loop state
-│       └── local/runs/<run-id>/    # logs and machine-local state
+│       └── local/runs/<run-id>/worktrees/ # temporary evolve worktrees only
 └── candidate source
+
+~/.vibesys/projects/<project-key>/
+├── current-run
+└── runs/<run-id>/                  # logs and machine-local state
 ```
 
 VibeSys commits candidate evolution and portable `.vibesys/state/runs/`
-metadata on a `vibesys-runs/<run-id>` branch. `.vibesys/state/local/`, `agent.toml`,
-and root `.env*` files stay uncommitted and are hidden from coding agents. The
-entire `.vibesys/` directory is read-only to coding agents.
+metadata on a `vibesys-runs/<run-id>` branch. Machine-local metadata defaults to
+`~/.vibesys`; set `VIBESYS_STATE_HOME` to an absolute directory to override it.
+Existing `.vibesys/state/local/` metadata moves there on first open without
+changing its file formats. Temporary evolve worktrees remain repository-local.
+The entire `.vibesys/` directory is read-only to coding agents.
 
 ## Start a Task
 
@@ -55,7 +61,7 @@ worktree. Keep `agent.toml` and root `.env*` files out of Git history.
 The `agent`, `plain`, and `evolve` outer loops all use this model. Local, Docker,
 and Modal execution change where commands run, not the task layout. Task
 commands always start in the repository root. `.vibesys` is mounted read-only
-for coding agents; `.vibesys/state/local` is also hidden from them.
+for coding agents. Machine-local state is outside their workspace.
 
 Modal tasks may set a project-relative deployment file. Omit this block to use
 the legacy `main.py` default:
@@ -114,8 +120,9 @@ for the source, evaluator, and publication contracts.
 
 ## Resume
 
-Inside a project, resume the machine-local current run, then the newest run if
-no current pointer exists. A run ID selects a specific run:
+Inside a project, resume the machine-local current run from the configured
+VibeSys state home, then the newest run if no current pointer exists. A run ID
+selects a specific run:
 
 ```bash
 cd /path/to/project

--- a/libs/vs-project/src/vs_project/_state.py
+++ b/libs/vs-project/src/vs_project/_state.py
@@ -19,6 +19,7 @@ import json
 import math
 import os
 import re
+import shutil
 import stat
 import tempfile
 import unicodedata
@@ -50,6 +51,8 @@ _IDENTIFIER_PATTERN = r"^[a-z0-9][a-z0-9._-]{0,127}$"
 _DIGEST_PATTERN = r"^[0-9a-f]{64}$"
 _GIT_OBJECT_ID_PATTERN = r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$"
 _ROUND_FILE_PATTERN = re.compile(r"^(?P<round>0*[1-9][0-9]*)\.json$")
+_STATE_HOME_ENV = "VIBESYS_STATE_HOME"
+_LEGACY_WORKTREE_MIN_PARTS = 3
 _EXCLUDED_NAMES = frozenset(
     {
         ".cache",
@@ -359,7 +362,14 @@ class StateNamespace:
     converted into portable snapshots.
     """
 
-    __slots__ = ("_kind", "_portable", "_project_root", "_root")
+    __slots__ = (
+        "_containment_root",
+        "_kind",
+        "_namespace_root",
+        "_portable",
+        "_project_root",
+        "_root",
+    )
 
     def __init__(
         self,
@@ -367,12 +377,19 @@ class StateNamespace:
         project_root: Path,
         root: Path,
         portable: bool,
+        containment_root: Path | None = None,
+        namespace_root: PurePosixPath | None = None,
     ) -> None:
         """Bind one validated project-owned namespace root."""
         self._project_root = project_root
         self._root = root
         self._portable = portable
         self._kind = "portable" if portable else "local"
+        self._containment_root = containment_root or project_root
+        self._namespace_root = namespace_root or PurePosixPath(
+            root.relative_to(project_root).as_posix()
+        )
+        _validate_project_state_path(self._namespace_root)
         self._validated_root()
 
     def load[ModelT: BaseModel](
@@ -418,8 +435,8 @@ class StateNamespace:
         model: BaseModel | None,
     ) -> StateTransition:
         """Prepare an immutable replacement or deletion without applying it."""
-        path = self._resolve_file(relative_path)
-        project_relative_path = PurePosixPath(path.relative_to(self._project_root).as_posix())
+        self._resolve_file(relative_path)
+        project_relative_path = self._project_relative_path(relative_path)
         document = (
             None
             if model is None
@@ -429,10 +446,9 @@ class StateNamespace:
 
     def apply(self, transition: StateTransition) -> None:
         """Atomically apply a transition prepared for this namespace."""
-        root = self._validated_root()
-        namespace_root = PurePosixPath(root.relative_to(self._project_root).as_posix())
+        self._validated_root()
         try:
-            relative_path = transition._project_relative_path.relative_to(namespace_root)
+            relative_path = transition._project_relative_path.relative_to(self._namespace_root)
         except ValueError as exc:
             raise ProjectStateError(
                 f"State transition target is outside this namespace: "
@@ -471,9 +487,8 @@ class StateNamespace:
         if not self._portable:
             raise ProjectStateError("Machine-local VibeSys state namespaces cannot be snapshotted")
         root = self._validated_root()
-        namespace_root = PurePosixPath(root.relative_to(self._project_root).as_posix())
         if not root.exists():
-            return StateSnapshot._create(namespace_root, ())
+            return StateSnapshot._create(self._namespace_root, ())
 
         files: list[StateFile] = []
         try:
@@ -500,13 +515,15 @@ class StateNamespace:
             raise ProjectStateError(
                 f"Could not snapshot VibeSys {self._kind} state at {root}: {exc}"
             ) from exc
-        return StateSnapshot._create(namespace_root, tuple(files))
+        return StateSnapshot._create(self._namespace_root, tuple(files))
 
     def agent_visible_path(self, relative_path: str | PurePosixPath | None = None) -> str:
         """Return a safe project-relative location for an agent-facing prompt.
 
         Filesystem reads and writes must still use this namespace's typed methods.
         """
+        if not self._portable:
+            raise ProjectStateError("Machine-local VibeSys state is not agent-visible")
         return self._project_relative_path(relative_path).as_posix()
 
     def equivalent_external_file(
@@ -515,6 +532,8 @@ class StateNamespace:
         relative_path: str | PurePosixPath,
     ) -> Path:
         """Resolve the equivalent state file inside another project worktree."""
+        if not self._portable:
+            raise ProjectStateError("Machine-local VibeSys state has no worktree equivalent")
         root = Path(project_root).resolve()
         if not root.is_dir():
             raise ProjectStateError(f"Project root is not a directory: {root}")
@@ -530,8 +549,8 @@ class StateNamespace:
         relative_path: str | PurePosixPath | None = None,
     ) -> PurePosixPath:
         """Return this namespace's validated project-relative location."""
-        root = self._validated_root()
-        result = PurePosixPath(root.relative_to(self._project_root).as_posix())
+        self._validated_root()
+        result = self._namespace_root
         if relative_path is not None:
             result /= _validate_state_relative_path(relative_path)
         return result
@@ -567,7 +586,7 @@ class StateNamespace:
 
     def _validated_root(self) -> Path:
         root = _contained_without_symlinks(
-            self._project_root,
+            self._containment_root,
             self._root,
             kind=f"{self._kind} state namespace",
         )
@@ -872,9 +891,13 @@ class ProjectState:
         self._metadata_dir = root / _STATE_DIRECTORY_PATH
         self._project_manifest_path = self._metadata_dir / "project.json"
         self._metadata_gitignore_path = self._metadata_dir / ".gitignore"
-        self._local_dir = self._metadata_dir / "local"
+        self._legacy_local_dir = self._metadata_dir / "local"
+        self._state_home = _state_home()
+        _prepare_state_home(self._state_home)
+        self._local_dir = _external_project_state_directory(self._state_home, root)
         self._current_run_path = self._local_dir / "current-run"
         self._validate_storage_roots()
+        self._migrate_legacy_local_state()
 
     @classmethod
     def is_project_root(cls, path: Path | str) -> bool:
@@ -922,9 +945,15 @@ class ProjectState:
         if root.exists() and not root.is_dir():
             raise ProjectStateError(f"Project root is not a directory: {root}")
         normalized = _validate_run_id(run_id)
+        state_home = _state_home()
+        _prepare_state_home(state_home)
+        local_dir = _external_project_state_directory(state_home, root)
+        legacy_local_dir = root / _STATE_DIRECTORY_PATH / "local"
+        _validate_storage_root(local_dir, state_home, name="local metadata")
+        _migrate_legacy_local_directory(legacy_local_dir, local_dir)
         return _contained_without_symlinks(
-            root,
-            root / _STATE_DIRECTORY_PATH / "local" / "runs" / normalized / "logs",
+            local_dir,
+            local_dir / "runs" / normalized / "logs",
             kind="run log directory",
         )
 
@@ -933,7 +962,9 @@ class ProjectState:
         self._validate_storage_roots()
         return ProjectSandboxPaths(
             read_only_path=(Path(_CONFIG_DIRECTORY_NAME) if self._config_dir.exists() else None),
-            hidden_path=(_STATE_DIRECTORY_PATH / "local" if self._local_dir.exists() else None),
+            hidden_path=(
+                _STATE_DIRECTORY_PATH / "local" if self._legacy_local_dir.exists() else None
+            ),
         )
 
     def log_directory(self, run_id: str) -> Path:
@@ -1361,6 +1392,8 @@ class ProjectState:
             project_root=self.project_root,
             root=self._local_state_dir(run_id, namespace),
             portable=False,
+            containment_root=self._local_dir,
+            namespace_root=(_STATE_DIRECTORY_POSIX / "local" / "runs" / run_id / namespace),
         )
 
     def _round_transaction_path(self, run_id: str) -> Path:
@@ -1369,8 +1402,14 @@ class ProjectState:
 
     def _worktrees_dir(self, run_id: str) -> Path:
         """Return the machine-local directory reserved for candidate worktrees."""
+        normalized = _validate_run_id(run_id)
+        legacy_run_dir = _contained_without_symlinks(
+            self._legacy_local_dir,
+            self._legacy_local_dir / "runs" / normalized,
+            kind="candidate worktree run",
+        )
         return _contained_state_dir(
-            self._contained_local_run_dir(run_id),
+            legacy_run_dir,
             "worktrees",
             kind="worktrees",
         )
@@ -1396,7 +1435,16 @@ class ProjectState:
     def _validate_storage_roots(self) -> None:
         _validate_storage_root(self._config_dir, self.project_root, name="configuration")
         _validate_storage_root(self._metadata_dir, self._config_dir, name="metadata")
-        _validate_storage_root(self._local_dir, self._metadata_dir, name="local metadata")
+        _validate_storage_root(
+            self._legacy_local_dir,
+            self._metadata_dir,
+            name="legacy local metadata",
+        )
+        _validate_storage_root(self._local_dir, self._state_home, name="local metadata")
+
+    def _migrate_legacy_local_state(self) -> None:
+        """Move legacy repository-local operational state to the user state home."""
+        _migrate_legacy_local_directory(self._legacy_local_dir, self._local_dir)
 
     def _ensure_local_gitignore(self) -> None:
         self._validate_storage_roots()
@@ -1480,6 +1528,119 @@ def _project_id(display_name: str, fingerprint: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", normalized.lower()).strip("-") or "project"
     slug = slug[:64].rstrip("-") or "project"
     return f"{slug}-{fingerprint[:12]}"
+
+
+def _state_home() -> Path:
+    """Resolve the operator-configurable root for machine-local VibeSys state."""
+    configured = os.environ.get(_STATE_HOME_ENV)
+    if configured is not None:
+        if not configured.strip():
+            raise ProjectStateError(f"{_STATE_HOME_ENV} must not be empty")
+        root = Path(configured).expanduser()
+        if not root.is_absolute():
+            raise ProjectStateError(f"{_STATE_HOME_ENV} must be an absolute path: {configured}")
+    else:
+        root = Path.home() / ".vibesys"
+    return root.resolve()
+
+
+def _external_project_state_directory(state_home: Path, project_root: Path) -> Path:
+    """Return a collision-resistant local directory for one canonical project path."""
+    normalized = unicodedata.normalize("NFKD", project_root.name).encode("ascii", "ignore").decode()
+    slug = re.sub(r"[^a-z0-9]+", "-", normalized.lower()).strip("-") or "project"
+    slug = slug[:64].rstrip("-") or "project"
+    digest = hashlib.sha256(project_root.as_posix().encode("utf-8")).hexdigest()[:12]
+    destination = state_home / "projects" / f"{slug}-{digest}"
+    if destination.resolve().is_relative_to(project_root.resolve()):
+        raise ProjectStateError(
+            f"{_STATE_HOME_ENV} must place machine-local state outside the project: {state_home}"
+        )
+    return destination
+
+
+def _prepare_state_home(state_home: Path) -> None:
+    """Create private user-state parents before any run metadata is written."""
+    try:
+        state_home.mkdir(parents=True, exist_ok=True, mode=0o700)
+        (state_home / "projects").mkdir(exist_ok=True, mode=0o700)
+    except OSError as exc:
+        raise ProjectStateError(f"Could not create VibeSys state home {state_home}: {exc}") from exc
+
+
+def _migrate_legacy_local_directory(source: Path, destination: Path) -> None:
+    """Atomically relocate legacy local metadata while leaving worktrees in place."""
+    if destination.exists() or not source.is_dir():
+        return
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(
+        tempfile.mkdtemp(prefix=f".{destination.name}.migrating-", dir=destination.parent)
+    )
+    try:
+        _validate_legacy_migration_tree(source)
+        shutil.copytree(source, temporary, dirs_exist_ok=True)
+        for run_worktrees in temporary.glob("runs/*/worktrees"):
+            shutil.rmtree(run_worktrees)
+        try:
+            temporary.replace(destination)
+        except OSError:
+            if not destination.is_dir():
+                raise
+        _remove_migrated_legacy_entries(source)
+    except OSError as exc:
+        raise ProjectStateError(
+            f"Could not migrate VibeSys local state from {source} to {destination}: {exc}"
+        ) from exc
+    finally:
+        shutil.rmtree(temporary, ignore_errors=True)
+
+
+def _remove_migrated_legacy_entries(source: Path) -> None:
+    """Remove copied metadata from the legacy tree without touching worktrees."""
+    for entry in tuple(source.iterdir()):
+        if entry.name != "runs":
+            _remove_path(entry)
+            continue
+        if entry.is_symlink() or not entry.is_dir():
+            _remove_path(entry)
+            continue
+        _remove_migrated_run_entries(entry)
+        if not any(entry.iterdir()):
+            entry.rmdir()
+    if not any(source.iterdir()):
+        source.rmdir()
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def _remove_migrated_run_entries(runs_directory: Path) -> None:
+    for run_dir in tuple(runs_directory.iterdir()):
+        if not run_dir.is_dir() or run_dir.is_symlink():
+            _remove_path(run_dir)
+            continue
+        for run_entry in tuple(run_dir.iterdir()):
+            if run_entry.name != "worktrees":
+                _remove_path(run_entry)
+        if not any(run_dir.iterdir()):
+            run_dir.rmdir()
+
+
+def _validate_legacy_migration_tree(source: Path) -> None:
+    """Reject legacy metadata aliases while allowing untouched worktree contents."""
+    for path in source.rglob("*"):
+        relative = path.relative_to(source)
+        if (
+            len(relative.parts) >= _LEGACY_WORKTREE_MIN_PARTS
+            and relative.parts[0] == "runs"
+            and relative.parts[2] == "worktrees"
+        ):
+            continue
+        if path.is_symlink():
+            raise ProjectStateError(f"VibeSys local metadata path must not be a symlink: {path}")
 
 
 def _validate_run_id(run_id: str, *, source: Path | None = None) -> str:

--- a/libs/vs-project/tests/conftest.py
+++ b/libs/vs-project/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Shared isolation for vs-project filesystem tests."""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_vibesys_state_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep machine-local project state inside each test's temporary directory."""
+    monkeypatch.setenv(
+        "VIBESYS_STATE_HOME",
+        str(tmp_path.parent / f".vibesys-state-{tmp_path.name}"),
+    )

--- a/libs/vs-project/tests/test_store.py
+++ b/libs/vs-project/tests/test_store.py
@@ -405,17 +405,17 @@ def test_semantic_runtime_and_sandbox_paths(tmp_path: Path) -> None:
     project.mkdir()
     run_id = "run-1"
 
-    assert Project.log_directory_for(project, run_id) == (
-        project / ".vibesys/state" / "local" / "runs" / run_id / "logs"
-    )
+    early_log_directory = Project.log_directory_for(project, run_id)
     store = _store(project)
     run = _run(store)
 
+    assert early_log_directory == store.state.log_directory(run_id)
     assert store.state.log_directory(run.run_id).is_dir()
-    assert store.state.model_cache_directory("huggingface").is_relative_to(project)
+    assert store.state.log_directory(run.run_id).is_relative_to(store.state._local_dir)
+    assert store.state.model_cache_directory("huggingface").is_relative_to(store.state._local_dir)
     assert store.state.candidate_worktree_directory(run.run_id, "g1c1").is_relative_to(project)
     assert store.state.sandbox_paths().read_only_path == Path(".vibesys")
-    assert store.state.sandbox_paths().hidden_path == Path(".vibesys/state/local")
+    assert store.state.sandbox_paths().hidden_path is None
     git = store.state.git_integration(run.run_id)
     assert git.local_exclude_pattern == "/.vibesys/state/local/"
     assert git.metadata_pathspec == ".vibesys/state"
@@ -424,6 +424,80 @@ def test_semantic_runtime_and_sandbox_paths(tmp_path: Path) -> None:
         ":(exclude).vibesys/**",
     )
     assert git.metadata_clean_exclusion == ".vibesys/"
+
+
+def test_default_state_home_uses_home_dot_vibesys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VIBESYS_STATE_HOME")
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    project = tmp_path / "project"
+    project.mkdir()
+
+    log_directory = Project.log_directory_for(project, "run-1")
+
+    assert log_directory.is_relative_to(tmp_path / "home" / ".vibesys" / "projects")
+
+
+@pytest.mark.parametrize("configured", ["", "relative/state"])
+def test_state_home_rejects_invalid_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    configured: str,
+) -> None:
+    monkeypatch.setenv("VIBESYS_STATE_HOME", configured)
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with pytest.raises(ProjectStateError, match="VIBESYS_STATE_HOME"):
+        Project.log_directory_for(project, "run-1")
+
+
+def test_same_named_projects_have_distinct_external_state_directories(tmp_path: Path) -> None:
+    first = tmp_path / "first" / "project"
+    second = tmp_path / "second" / "project"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+
+    first_log = Project.log_directory_for(first, "run-1")
+    second_log = Project.log_directory_for(second, "run-1")
+
+    assert first_log != second_log
+    assert first_log.parent.parent.parent.name.startswith("project-")
+    assert second_log.parent.parent.parent.name.startswith("project-")
+
+
+def test_legacy_local_state_moves_without_rewriting_and_leaves_worktrees(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    legacy = project / ".vibesys/state/local"
+    logs = legacy / "runs/run-1/logs"
+    agent = legacy / "runs/run-1/agent"
+    worktree = legacy / "runs/run-1/worktrees/g1c1/workspace"
+    logs.mkdir(parents=True)
+    agent.mkdir(parents=True)
+    worktree.mkdir(parents=True)
+    (legacy / "current-run").write_bytes(b"run-1\n")
+    (logs / "run-events.jsonl").write_bytes(b'{"type":"server_started"}\n')
+    (agent / "active.json").write_bytes(b'{"schema_version":1}\n')
+    (worktree / "candidate.py").write_bytes(b"candidate = True\n")
+
+    state = Project.open(project).state
+
+    assert (state._local_dir / "current-run").read_bytes() == b"run-1\n"
+    assert (state._local_dir / "runs/run-1/logs/run-events.jsonl").read_bytes() == (
+        b'{"type":"server_started"}\n'
+    )
+    assert (state._local_dir / "runs/run-1/agent/active.json").read_bytes() == (
+        b'{"schema_version":1}\n'
+    )
+    assert not (legacy / "current-run").exists()
+    assert not (legacy / "runs/run-1/logs").exists()
+    assert not (legacy / "runs/run-1/agent").exists()
+    assert (worktree / "candidate.py").read_bytes() == b"candidate = True\n"
+    assert state.sandbox_paths().hidden_path == Path(".vibesys/state/local")
 
 
 def test_log_directory_rejects_symlinked_parent(tmp_path: Path) -> None:
@@ -544,6 +618,7 @@ def test_create_run_rejects_symlinked_local_root_before_writing(tmp_path: Path) 
     )
     outside = tmp_path / "outside"
     outside.mkdir()
+    store.state._local_dir.parent.mkdir(parents=True, exist_ok=True)
     store.state._local_dir.symlink_to(outside, target_is_directory=True)
 
     with pytest.raises(ProjectStateError, match="local metadata root must not be a symlink"):
@@ -596,24 +671,22 @@ def test_run_manifest_and_local_state_use_separate_trees(tmp_path: Path) -> None
         tmp_path / ".vibesys/state" / "runs" / manifest.run_id / "run.json"
     )
     assert store.state.log_directory(manifest.run_id) == (
-        tmp_path / ".vibesys/state" / "local" / "runs" / manifest.run_id / "logs"
+        store.state._local_dir / "runs" / manifest.run_id / "logs"
     )
     assert store.state._rounds_dir(manifest.run_id) == (
         tmp_path / ".vibesys/state" / "runs" / manifest.run_id / "agent" / "rounds"
     )
-    assert (
+    with pytest.raises(ProjectStateError, match="not agent-visible"):
         store.state.local_namespace(manifest.run_id, "agent").agent_visible_path("active.json")
-        == f".vibesys/state/local/runs/{manifest.run_id}/agent/active.json"
-    )
     assert store.state._round_transaction_path(manifest.run_id) == (
-        tmp_path / ".vibesys/state" / "local" / "runs" / manifest.run_id / "round-transaction.json"
+        store.state._local_dir / "runs" / manifest.run_id / "round-transaction.json"
     )
     assert store.state._worktrees_dir(manifest.run_id) == (
         tmp_path / ".vibesys/state" / "local" / "runs" / manifest.run_id / "worktrees"
     )
     assert store.state.log_directory(manifest.run_id).is_dir()
     assert not (tmp_path / ".vibesys/state" / "runs" / manifest.run_id / "agent").exists()
-    assert not (tmp_path / ".vibesys/state" / "local" / "runs" / manifest.run_id / "agent").exists()
+    assert not (store.state._local_dir / "runs" / manifest.run_id / "agent").exists()
     assert not store.state._worktrees_dir(manifest.run_id).exists()
     committed = store.state._run_manifest_path(manifest.run_id).read_text(encoding="utf-8")
     assert str(tmp_path) not in committed
@@ -927,7 +1000,7 @@ def test_state_namespace_rejects_symlink_aliases(tmp_path: Path, *, local: bool)
     outside = tmp_path / "outside"
     outside.mkdir()
     parent = (
-        tmp_path / ".vibesys/state" / "local" / "runs" / run.run_id
+        store.state._local_dir / "runs" / run.run_id
         if local
         else tmp_path / ".vibesys/state" / "runs" / run.run_id
     )
@@ -965,6 +1038,7 @@ def test_worktrees_directory_rejects_symlink_alias(tmp_path: Path) -> None:
     outside = tmp_path / "outside"
     outside.mkdir()
     worktrees = tmp_path / ".vibesys/state" / "local" / "runs" / run.run_id / "worktrees"
+    worktrees.parent.mkdir(parents=True)
     worktrees.symlink_to(outside, target_is_directory=True)
 
     with pytest.raises(ProjectStateError, match=r"(?:escapes|must not be a symlink)"):

--- a/src/vibesys/agent_runner.py
+++ b/src/vibesys/agent_runner.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 
     from langchain_core.callbacks import BaseCallbackHandler
 
-from vibesys.agents.callbacks import AgentLogger
 from vibesys.render.sink import output_sink
 from vibesys.schemas import (
     ImplementerResponse,
@@ -278,6 +277,8 @@ def run_agent(  # noqa: PLR0913  # tracked: #288
     terminal display is handled by the subscribed renderer.
     """
     if callbacks is None:
+        from vibesys.agents.callbacks import AgentLogger  # noqa: PLC0415
+
         callbacks = [AgentLogger()]
     callbacks_label = " + ".join(type(cb).__name__ for cb in callbacks)
     if thread_id is None:
@@ -331,6 +332,8 @@ def run_typed_agent(  # noqa: PLR0913  # tracked: #288
     label, and a fallback constructor for when no structured response arrives.
     """
     if callbacks is None:
+        from vibesys.agents.callbacks import AgentLogger  # noqa: PLC0415
+
         callbacks = [AgentLogger()]
     if thread_id is None:
         thread_id = uuid.uuid4().hex
@@ -536,6 +539,8 @@ def run_profiler_agent(  # noqa: PLR0913  # tracked: #288
 ) -> ProfilerResponse:
     """Run profiler agent, return structured ProfilerResponse."""
     if callbacks is None:
+        from vibesys.agents.callbacks import AgentLogger  # noqa: PLC0415
+
         callbacks = [AgentLogger()]
     if thread_id is None:
         thread_id = uuid.uuid4().hex

--- a/src/vibesys/agents/client.py
+++ b/src/vibesys/agents/client.py
@@ -16,7 +16,6 @@ from vibesys.agent_runner import (
     log_prompt_markdown_and_print,
     parse_typed_response_text,
 )
-from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.cli_common import agent_label, materialize_skills
 from vibesys.agents.contracts import (
     AgentCapabilities,
@@ -42,6 +41,7 @@ if TYPE_CHECKING:
     from langchain_core.tools import BaseTool
 
     from vibesys._agent_cli.base import MCPServerSpec as LegacyMCPServerSpec
+    from vibesys.agents.callbacks import AgentLogger
     from vibesys.agents.progress import AgentProgress
     from vibesys.constants import ComputeBackend
     from vs_sandbox import HostResource, ProjectPathPolicy
@@ -319,6 +319,8 @@ class AgentClient:
             invocation_id=invocation_id,
             label=round_label,
         )
+        from vibesys.agents.callbacks import AgentLogger  # noqa: PLC0415
+
         logger = AgentLogger(
             log_file=self._run_log_file,
             model_name=model,

--- a/src/vibesys/agents/drivers/__init__.py
+++ b/src/vibesys/agents/drivers/__init__.py
@@ -1,2 +1,3 @@
 """Concrete implementations of the VibeSys agent-driver contract."""
+
 """Runtime adapters implementing the driver-neutral agent session contract."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,15 @@ from vs_project import Project, ProjectNotInitializedError
 
 
 @pytest.fixture(autouse=True)
+def isolated_vibesys_state_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep machine-local project state inside each test's temporary directory."""
+    monkeypatch.setenv(
+        "VIBESYS_STATE_HOME",
+        str(tmp_path.parent / f".vibesys-state-{tmp_path.name}"),
+    )
+
+
+@pytest.fixture(autouse=True)
 def headless_renderer() -> Iterator[HeadlessRenderer]:
     """Compose a headless renderer for every test, mirroring production.
 

--- a/tests/loops/plain/test_plain_loop_cli.py
+++ b/tests/loops/plain/test_plain_loop_cli.py
@@ -130,7 +130,7 @@ class TestMain:
             assert kwargs["max_rounds"] == 7
             assert kwargs["max_attempts_per_issue"] == 4
             assert kwargs["max_issues_per_perf_eval"] == 2
-            assert kwargs["runs_dir"] == Path("/tmp/vibesys-test-runs")  # noqa: S108
+            assert kwargs["runs_dir"] == Path("/tmp/vibesys-test-runs").resolve()  # noqa: S108
 
     def test_main_forwards_agent_backend_and_cli_provider(self):  # noqa: ANN201  # tracked: #288
         with (

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -187,9 +187,9 @@ def test_direct_run_uses_one_project_root_and_canonical_state(tmp_path):  # noqa
             assert ctx.project.root == project
             assert ctx.log_dir == ctx.project.state.log_directory(ctx.run_id)
             assert (
-                ctx.state.local(RunStateNamespace.AGENT)
-                .agent_visible_path("active.json")
-                .endswith("agent/active.json")
+                not ctx.state.local(RunStateNamespace.AGENT)
+                .external_directory()
+                .is_relative_to(project)
             )
             objective_path = Path(ctx.objective_location)
             assert objective_path == (
@@ -202,7 +202,7 @@ def test_direct_run_uses_one_project_root_and_canonical_state(tmp_path):  # noqa
         policy = build_runner.call_args.kwargs["project_path_policy"]
         state_paths = Project.open(project).state.sandbox_paths()
         assert state_paths.read_only_path in policy.read_only_paths
-        assert state_paths.hidden_path in policy.hidden_paths
+        assert state_paths.hidden_path is None
         runner.close.assert_called_once_with()
 
     manifest = Project.open(project).state.load_run(ctx.run_id)

--- a/tests/test_in_place_project_policy.py
+++ b/tests/test_in_place_project_policy.py
@@ -7,7 +7,7 @@ from vibesys.run.project_policy import (
 from vs_project import Project
 
 
-def test_legacy_project_policy_protects_trusted_inputs_and_hides_local_state(
+def test_legacy_project_policy_protects_trusted_inputs_without_project_local_state(
     tmp_path: Path,
 ) -> None:
     project = tmp_path / "project"
@@ -36,11 +36,8 @@ def test_legacy_project_policy_protects_trusted_inputs_and_hides_local_state(
         state_paths.read_only_path,
         *(Path(relative) for relative in LEGACY_TRUSTED_PROJECT_INPUT_PATHS),
     }
-    assert set(policy.hidden_paths) == {
-        state_paths.hidden_path,
-        Path(".env.local"),
-        Path("agent.toml"),
-    }
+    assert state_paths.hidden_path is None
+    assert set(policy.hidden_paths) == {Path(".env.local"), Path("agent.toml")}
 
 
 def test_project_policy_ignores_external_evaluator_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

VibeSys stores machine-local run data under `.vibesys/state/local/`. That couples operational state to the agent workspace, forces every agent runtime to enforce nested path policy, and exposes host-specific state to repository cleanup and sandbox behavior.

The merged runtime-driver refactor also imported the optional LangChain callback stack during launcher startup, violating the lightweight launch contract and failing two CI import assertions.

## Solution

Store machine-local state under `~/.vibesys/projects/<project-key>/` by default. `VIBESYS_STATE_HOME` accepts an absolute override. The project key combines a readable repository-name slug with a digest of its canonical path, so same-named repositories remain distinct.

On first access, existing `.vibesys/state/local/` contents move to the external directory without rewriting their bytes or changing any serialized format. Evolve worktrees remain repository-local for now. Portable committed state remains under `.vibesys/state/runs/`.

Defer `AgentLogger` and its LangChain dependencies until an actual agent invocation constructs callbacks. Canonicalize the explicit plain-loop runs path in its cross-platform test.

### Architecture

```mermaid
flowchart LR
    P[Project path] --> K[Canonical path key]
    K --> L[~/.vibesys/projects/project-key]
    L --> O[Logs, session state, current-run]
    P --> C[.vibesys/state/runs]
    P --> W[.vibesys/state/local/.../worktrees]
    C --> G[Committed portable state]
```

## Verification

All default-branch CI checks passed at `2a9b670`: 4,962 tests, patch coverage, formatting, lint, typecheck, TUI, queue-native, Linux and macOS sandbox tests, website, four release-wheel builds, and aggregate artifact verification.

The separate slow and flaky integration workflow was not run, per request.

### Correctness properties

- No JSON or other persisted file format changes.
- Portable state paths and Git integration remain unchanged.
- Existing local files retain their exact bytes during migration.
- Existing evolve worktrees are never moved or removed.
- The default and configured state homes must resolve outside the project.
- Same-named projects at different canonical paths receive distinct state directories.
- Symlinked legacy state is rejected before migration.
- Lightweight launch paths do not import LangChain; real agent invocations retain the same callback behavior.

### Testing

- `uv run pytest -q tests/loops/plain/test_plain_loop_cli.py::TestMain::test_main_passes_round_args_to_run_loop tests/test_launch_imports.py tests/agents/test_agent_runners.py tests/agents/test_agent_client.py tests/agents/test_callbacks.py tests/agents/test_stub_runner.py tests/loops/test_profiler.py tests/test_todo_display.py` (188 passed)
- `uv run pyright src/vibesys/agent_runner.py src/vibesys/agents/client.py tests/loops/plain/test_plain_loop_cli.py` (passed)
- `./scripts/check_format.sh` (passed)
- `./scripts/check_lint.sh` (passed)
- GitHub Actions Tests, Website, and release-wheel workflows (passed)
