### PR TITLE
Run local queue sessions through Omnigent

### DIFF
--- a/docs/contributing/feature-flags.md
+++ b/docs/contributing/feature-flags.md
@@ -93,9 +93,12 @@ Omnigent's vocabulary: an `OSEnvSpec` whose sandbox grants write access to the
 workspace and read access to the Rust toolchain, with the backend chosen per
 platform (bubblewrap on Linux, Seatbelt on macOS) and never set to `none`.
 VibeSys resolves the workspace's active Rust sysroot with auto-install disabled,
-exposes only its `bin`, `lib`, and optional `libexec` trees, and uses a writable
-Cargo cache under the workspace's `target` directory. This bypasses rustup's
-host metadata and avoids recursively exposing or scanning `~/.rustup`.
+exposes only its `bin`, `lib`, and optional `libexec` trees, and gives each
+executor an ephemeral writable Cargo home and target directory outside the
+workspace. The scratch directory is removed when the executor closes. This
+bypasses rustup's host metadata, avoids recursively exposing or scanning
+`~/.rustup`, and keeps Cargo's internal dotfiles out of Omnigent's workspace
+hidden-path masks.
 Omnigent 0.6.0 cannot make `.git` and `.vibesys` read-only beneath a writable
 workspace. The run contract therefore protects those control directories, and
 local operational state lives outside the repository by default. The two

--- a/docs/contributing/feature-flags.md
+++ b/docs/contributing/feature-flags.md
@@ -94,11 +94,12 @@ workspace and read access to the Rust toolchain, with the backend chosen per
 platform (bubblewrap on Linux, Seatbelt on macOS) and never set to `none`.
 VibeSys resolves the workspace's active Rust sysroot with auto-install disabled,
 exposes only its `bin`, `lib`, and optional `libexec` trees, and gives each
-executor an ephemeral writable Cargo home and target directory outside the
-workspace. The scratch directory is removed when the executor closes. This
-bypasses rustup's host metadata, avoids recursively exposing or scanning
-`~/.rustup`, and keeps Cargo's internal dotfiles out of Omnigent's workspace
-hidden-path masks.
+executor an ephemeral writable Cargo home. The scratch directory is removed
+when the executor closes. Cargo keeps its conventional workspace `target`
+directory; VibeSys permits Cargo's generated `.cargo-lock`, `.fingerprint`, and
+`.rustc_info.json` basenames through Omnigent's recursive hidden-path mask so
+later shell helpers can reuse the build. This bypasses rustup's host metadata
+and avoids recursively exposing or scanning `~/.rustup`.
 Omnigent 0.6.0 cannot make `.git` and `.vibesys` read-only beneath a writable
 workspace. The run contract therefore protects those control directories, and
 local operational state lives outside the repository by default. The two

--- a/docs/contributing/feature-flags.md
+++ b/docs/contributing/feature-flags.md
@@ -81,24 +81,30 @@ Current Omnigent constraints:
 - MCP server setup is rejected; the current Omnigent driver does not translate
   VibeSys MCP specifications.
 - Extra host resource grants are rejected. The agentshim path declares these
-  through `vs_sandbox`; this integration confines the agent to its workspace
-  and nothing else, so it cannot honour them.
-- Nested read-only and hidden project paths are rejected. Omnigent currently
-  enforces the workspace boundary but cannot express those finer-grained rules.
+  through `vs_sandbox`; the Omnigent path imports only the installed Rust
+  toolchain automatically, so it cannot honour arbitrary grants.
+- Top-level dot paths in the project policy are supported. Hidden dot paths
+  remain masked, while control directories such as `.git` and `.vibesys` are
+  exposed. Nested paths and non-dot paths are rejected.
 
 Sandboxing differs between the two backends. The agentshim path wraps the agent
 in a `vs_sandbox` host sandbox; the Omnigent path expresses the same intent in
-Omnigent's vocabulary — an `OSEnvSpec` whose sandbox grants write access to the
-workspace only, with the backend chosen per platform (bubblewrap on Linux,
-Seatbelt on macOS) and never set to `none`. The two mechanisms have **not** been
-proven equivalent, which is one more reason the flag is off by default.
+Omnigent's vocabulary: an `OSEnvSpec` whose sandbox grants write access to the
+workspace and read access to the Rust toolchain, with the backend chosen per
+platform (bubblewrap on Linux, Seatbelt on macOS) and never set to `none`.
+Omnigent 0.6.0 cannot make `.git` and `.vibesys` read-only beneath a writable
+workspace. The run contract therefore protects those control directories, and
+local operational state lives outside the repository by default. The two
+mechanisms have not been proven equivalent.
 
 Confining the agent is not the same as equipping it. Omnigent routes file and
 shell access through `sys_os_read` / `sys_os_write` / `sys_os_edit` /
 `sys_os_shell` MCP tools that the caller must build and dispatch, so the runner
 does that too — without it the agent starts sandboxed and toolless. Reaching
 that seam requires assigning Omnigent's private `_tool_executor` attribute,
-which is the most upgrade-fragile line in the integration.
+which is the most upgrade-fragile line in the integration. The Codex executor's
+native filesystem tools are disabled so all file and shell operations use this
+sandboxed path.
 
 Requires the platform sandbox backend — `bwrap` on Linux
 (`apt install bubblewrap`) or `sandbox-exec` on macOS. Omnigent resolves it when

--- a/docs/contributing/feature-flags.md
+++ b/docs/contributing/feature-flags.md
@@ -92,6 +92,10 @@ in a `vs_sandbox` host sandbox; the Omnigent path expresses the same intent in
 Omnigent's vocabulary: an `OSEnvSpec` whose sandbox grants write access to the
 workspace and read access to the Rust toolchain, with the backend chosen per
 platform (bubblewrap on Linux, Seatbelt on macOS) and never set to `none`.
+VibeSys resolves the workspace's active Rust sysroot with auto-install disabled,
+exposes only its `bin`, `lib`, and optional `libexec` trees, and uses a writable
+Cargo cache under the workspace's `target` directory. This bypasses rustup's
+host metadata and avoids recursively exposing or scanning `~/.rustup`.
 Omnigent 0.6.0 cannot make `.git` and `.vibesys` read-only beneath a writable
 workspace. The run contract therefore protects those control directories, and
 local operational state lives outside the repository by default. The two

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -24,7 +24,10 @@ from vibesys.agents.contracts import (
     AgentTurnResult,
     AgentUsage,
 )
-from vibesys.agents.host_resource_declarations import declare_rust_toolchain_resources
+from vibesys.agents.host_resource_declarations import (
+    declare_active_rust_toolchain_resources,
+    resolve_active_rust_toolchain,
+)
 from vibesys.agents.omnigent.providers import (
     OMNIGENT_PROVIDER_EXECUTORS,
     OmnigentExecutorSpec,
@@ -102,6 +105,7 @@ def _flatten_tool_schema(tool: Any) -> dict[str, Any]:  # noqa: ANN401
 def _build_os_tools(
     os_env_spec: Any,  # noqa: ANN401
     workspace: Path,
+    environment: dict[str, str] | None = None,
 ) -> tuple[list[dict[str, Any]], Callable[[str, dict[str, Any]], Any]]:
     """Build Omnigent's sandboxed filesystem tools and their dispatcher."""
     try:
@@ -132,7 +136,12 @@ def _build_os_tools(
         tool = by_name.get(name)
         if tool is None:
             return {"error": f"unknown tool {name!r}"}
-        return await asyncio.to_thread(tool.invoke, json.dumps(args), context)
+
+        def invoke() -> Any:  # noqa: ANN401
+            with _patched_environ(environment or {}):
+                return tool.invoke(json.dumps(args), context)
+
+        return await asyncio.to_thread(invoke)
 
     return schemas, dispatch
 
@@ -399,7 +408,10 @@ class OmnigentDriver:
             if entry.name.startswith(".") and Path(entry.name) not in hidden
         ]
         environment = {**os.environ, **dict(spec.environment)}
-        resources = declare_rust_toolchain_resources(HostResourceContext(env=environment))
+        resources = declare_active_rust_toolchain_resources(
+            HostResourceContext(env=environment),
+            workspace=workspace,
+        )
         read_paths = sorted(
             {str(workspace)}
             | {
@@ -447,8 +459,29 @@ class OmnigentDriver:
                 f"{executor_cls.__name__} has no {_TOOL_EXECUTOR_ATTR!r} slot; "
                 "this integration requires the private Omnigent 0.6.0 tool-dispatch seam"
             )
+        environment = {**os.environ, **dict(spec.environment)}
+        tool_environment = dict(spec.environment)
+        rust_toolchain = resolve_active_rust_toolchain(
+            HostResourceContext(env=environment),
+            workspace=spec.workspace,
+        )
+        if rust_toolchain is not None:
+            rust_bin = rust_toolchain[0] / "bin"
+            tool_environment.update(
+                {
+                    "CARGO_HOME": str(spec.workspace / "target" / "vibesys-cargo-home"),
+                    "PATH": os.pathsep.join((str(rust_bin), environment.get("PATH", ""))),
+                    "RUSTC": str(rust_bin / "rustc"),
+                    "RUSTDOC": str(rust_bin / "rustdoc"),
+                    "RUSTUP_AUTO_INSTALL": "0",
+                }
+            )
         try:
-            schemas, dispatch = _build_os_tools(os_env_spec, spec.workspace)
+            schemas, dispatch = _build_os_tools(
+                os_env_spec,
+                spec.workspace,
+                tool_environment,
+            )
         except BaseException:
             with contextlib.suppress(Exception):
                 self.close_executor(executor)

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -10,6 +10,7 @@ import json
 import os
 import shutil
 import sys
+import tempfile
 from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -317,6 +318,7 @@ class OmnigentDriver:
     def __init__(self) -> None:
         """Create a driver with no live sessions or event loop."""
         self._sessions: set[OmnigentSession] = set()
+        self._executor_scratch: dict[int, tempfile.TemporaryDirectory[str]] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
         self._closed = False
 
@@ -414,6 +416,8 @@ class OmnigentDriver:
         self,
         spec: AgentSessionSpec,
         *,
+        additional_write_paths: tuple[Path, ...] = (),
+        env_passthrough: tuple[str, ...] = (),
         include_toolchain: bool = False,
     ) -> Any:  # noqa: ANN401
         try:
@@ -447,8 +451,9 @@ class OmnigentDriver:
         sandbox = OSEnvSandboxSpec(
             type=_sandbox_backend_for_platform(),
             read_paths=read_paths,
-            write_paths=[str(workspace)],
+            write_paths=[str(workspace), *(str(path) for path in additional_write_paths)],
             cwd_allow_hidden=allow_hidden,
+            env_passthrough=list(env_passthrough) or None,
         )
         return OSEnvSpec(
             type="caller_process",
@@ -460,7 +465,43 @@ class OmnigentDriver:
         executor_spec = _resolve_executor_spec(spec.provider)
         executor_cls = self._executor_class(executor_spec)
         os_env_spec = self._build_os_env(spec)
-        shell_os_env_spec = self._build_os_env(spec, include_toolchain=True)
+        scratch = tempfile.TemporaryDirectory(prefix="vibesys-omnigent-")
+        scratch_path = Path(scratch.name)
+        environment = {**os.environ, **dict(spec.environment)}
+        tool_environment = dict(spec.environment)
+        rust_toolchain = resolve_active_rust_toolchain(
+            HostResourceContext(env=environment),
+            workspace=spec.workspace,
+        )
+        if rust_toolchain is not None:
+            rust_bin = rust_toolchain[0] / "bin"
+            tool_environment.update(
+                {
+                    "CARGO_HOME": str(scratch_path / "cargo-home"),
+                    "CARGO_TARGET_DIR": str(scratch_path / "target"),
+                    "PATH": os.pathsep.join((str(rust_bin), environment.get("PATH", ""))),
+                    "RUSTC": str(rust_bin / "rustc"),
+                    "RUSTDOC": str(rust_bin / "rustdoc"),
+                    "RUSTUP_AUTO_INSTALL": "0",
+                }
+            )
+            if sys.platform.startswith("linux"):
+                linker = shutil.which("cc", path=environment.get("PATH")) or shutil.which(
+                    "gcc", path=environment.get("PATH")
+                )
+                if linker is not None:
+                    host = rust_toolchain[1].parent.name.upper().replace("-", "_")
+                    tool_environment[f"CARGO_TARGET_{host}_LINKER"] = str(Path(linker).resolve())
+        try:
+            shell_os_env_spec = self._build_os_env(
+                spec,
+                additional_write_paths=(scratch_path,),
+                env_passthrough=tuple(tool_environment),
+                include_toolchain=True,
+            )
+        except BaseException:
+            scratch.cleanup()
+            raise
         executor_kwargs: dict[str, Any] = {
             "cwd": str(spec.workspace),
             "model": spec.model,
@@ -474,38 +515,21 @@ class OmnigentDriver:
         try:
             executor = executor_cls(**executor_kwargs)
         except ImportError as exc:
+            scratch.cleanup()
             raise OmnigentDriverError(
                 f"Omnigent provider {spec.provider!r} is unavailable: {exc}"
             ) from exc
+        except BaseException:
+            scratch.cleanup()
+            raise
         if not hasattr(executor, _TOOL_EXECUTOR_ATTR):
             with contextlib.suppress(Exception):
                 self.close_executor(executor)
+            scratch.cleanup()
             raise OmnigentDriverError(
                 f"{executor_cls.__name__} has no {_TOOL_EXECUTOR_ATTR!r} slot; "
                 "this integration requires the private Omnigent 0.6.0 tool-dispatch seam"
             )
-        environment = {**os.environ, **dict(spec.environment)}
-        tool_environment = dict(spec.environment)
-        rust_toolchain = resolve_active_rust_toolchain(
-            HostResourceContext(env=environment),
-            workspace=spec.workspace,
-        )
-        if rust_toolchain is not None:
-            rust_bin = rust_toolchain[0] / "bin"
-            tool_environment.update(
-                {
-                    "CARGO_HOME": str(spec.workspace / "target" / "vibesys-cargo-home"),
-                    "PATH": os.pathsep.join((str(rust_bin), environment.get("PATH", ""))),
-                    "RUSTC": str(rust_bin / "rustc"),
-                    "RUSTDOC": str(rust_bin / "rustdoc"),
-                    "RUSTUP_AUTO_INSTALL": "0",
-                }
-            )
-            if sys.platform.startswith("linux"):
-                linker = shutil.which("cc", path=environment.get("PATH"))
-                if linker is not None:
-                    host = rust_toolchain[1].parent.name.upper().replace("-", "_")
-                    tool_environment[f"CARGO_TARGET_{host}_LINKER"] = str(Path(linker).resolve())
         try:
             schemas, dispatch = _build_os_tools(
                 os_env_spec,
@@ -516,8 +540,10 @@ class OmnigentDriver:
         except BaseException:
             with contextlib.suppress(Exception):
                 self.close_executor(executor)
+            scratch.cleanup()
             raise
         setattr(executor, _TOOL_EXECUTOR_ATTR, dispatch)
+        self._executor_scratch[id(executor)] = scratch
         return executor, schemas
 
     def release_session(self, session: OmnigentSession, executor: Any) -> None:  # noqa: ANN401
@@ -527,9 +553,14 @@ class OmnigentDriver:
 
     def close_executor(self, executor: Any) -> None:  # noqa: ANN401
         """Close a native executor, awaiting asynchronous cleanup when needed."""
-        close = getattr(executor, "close", None)
-        if close is None:
-            return
-        result = close()
-        if asyncio.iscoroutine(result):
-            self.run_awaitable(result)
+        try:
+            close = getattr(executor, "close", None)
+            if close is None:
+                return
+            result = close()
+            if asyncio.iscoroutine(result):
+                self.run_awaitable(result)
+        finally:
+            scratch = self._executor_scratch.pop(id(executor), None)
+            if scratch is not None:
+                scratch.cleanup()

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -46,6 +46,9 @@ _TOOL_EXECUTOR_ATTR = "_tool_executor"
 _OMNIGENT_INTERNAL_HIDDEN = frozenset({".codex-tmp"})
 """Runtime-owned workspace paths that OS tools must not traverse."""
 
+_CARGO_GENERATED_HIDDEN = frozenset({".cargo-lock", ".fingerprint", ".rustc_info.json"})
+"""Cargo-generated basenames needed beneath the conventional target directory."""
+
 
 class OmnigentDriverError(RuntimeError):
     """An Omnigent driver requirement could not be satisfied safely."""
@@ -434,6 +437,7 @@ class OmnigentDriver:
             and entry.name not in _OMNIGENT_INTERNAL_HIDDEN
             and Path(entry.name) not in hidden
         ]
+        allow_hidden.extend(sorted(_CARGO_GENERATED_HIDDEN))
         environment = {**os.environ, **dict(spec.environment)}
         read_paths = None
         if include_toolchain:
@@ -478,7 +482,6 @@ class OmnigentDriver:
             tool_environment.update(
                 {
                     "CARGO_HOME": str(scratch_path / "cargo-home"),
-                    "CARGO_TARGET_DIR": str(scratch_path / "target"),
                     "PATH": os.pathsep.join((str(rust_bin), environment.get("PATH", ""))),
                     "RUSTC": str(rust_bin / "rustc"),
                     "RUSTDOC": str(rust_bin / "rustdoc"),

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -8,6 +8,7 @@ import asyncio
 import contextlib
 import json
 import os
+import shutil
 import sys
 from importlib import import_module
 from pathlib import Path
@@ -109,6 +110,7 @@ def _build_os_tools(
     os_env_spec: Any,  # noqa: ANN401
     workspace: Path,
     environment: dict[str, str] | None = None,
+    shell_os_env_spec: Any | None = None,  # noqa: ANN401
 ) -> tuple[list[dict[str, Any]], Callable[[str, dict[str, Any]], Any]]:
     """Build Omnigent's sandboxed filesystem tools and their dispatcher."""
     try:
@@ -131,6 +133,17 @@ def _build_os_tools(
         )
 
     tools = build_os_env_tools(os_env)
+    if shell_os_env_spec is not None:
+        shell_os_env = create_os_environment(shell_os_env_spec)
+        if shell_os_env is None:
+            raise OmnigentDriverError(
+                f"Omnigent could not create a sandboxed shell environment for {workspace}"
+            )
+        shell_tools = build_os_env_tools(shell_os_env)
+        shell_tool = next((tool for tool in shell_tools if tool.name() == "sys_os_shell"), None)
+        if shell_tool is None:  # pragma: no cover - guarded against Omnigent API drift
+            raise OmnigentDriverError("Omnigent did not provide its sys_os_shell tool")
+        tools = [shell_tool if tool.name() == "sys_os_shell" else tool for tool in tools]
     by_name = {tool.name(): tool for tool in tools}
     schemas = [_flatten_tool_schema(tool) for tool in tools]
     context = ToolContext(task_id="vibesys", agent_id="vibesys", workspace=workspace)
@@ -397,7 +410,12 @@ class OmnigentDriver:
                 "this integration requires the Omnigent 0.6.0 executor API"
             ) from exc
 
-    def _build_os_env(self, spec: AgentSessionSpec) -> Any:  # noqa: ANN401
+    def _build_os_env(
+        self,
+        spec: AgentSessionSpec,
+        *,
+        include_toolchain: bool = False,
+    ) -> Any:  # noqa: ANN401
         try:
             from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec  # noqa: PLC0415
         except ImportError as exc:
@@ -413,18 +431,19 @@ class OmnigentDriver:
             and Path(entry.name) not in hidden
         ]
         environment = {**os.environ, **dict(spec.environment)}
-        resources = declare_active_rust_toolchain_resources(
-            HostResourceContext(env=environment),
-            workspace=workspace,
-        )
-        read_paths = sorted(
-            {str(workspace)}
-            | {
-                str(resource.path.expanduser().resolve())
-                for resource in resources
-                if resource.path.exists()
-            }
-        )
+        read_paths = None
+        if include_toolchain:
+            resources = declare_active_rust_toolchain_resources(
+                HostResourceContext(env=environment),
+                workspace=workspace,
+            )
+            read_paths = sorted(
+                {
+                    str(resource.path.expanduser().resolve())
+                    for resource in resources
+                    if resource.path.exists()
+                }
+            )
         sandbox = OSEnvSandboxSpec(
             type=_sandbox_backend_for_platform(),
             read_paths=read_paths,
@@ -441,6 +460,7 @@ class OmnigentDriver:
         executor_spec = _resolve_executor_spec(spec.provider)
         executor_cls = self._executor_class(executor_spec)
         os_env_spec = self._build_os_env(spec)
+        shell_os_env_spec = self._build_os_env(spec, include_toolchain=True)
         executor_kwargs: dict[str, Any] = {
             "cwd": str(spec.workspace),
             "model": spec.model,
@@ -481,11 +501,17 @@ class OmnigentDriver:
                     "RUSTUP_AUTO_INSTALL": "0",
                 }
             )
+            if sys.platform.startswith("linux"):
+                linker = shutil.which("cc", path=environment.get("PATH"))
+                if linker is not None:
+                    host = rust_toolchain[1].parent.name.upper().replace("-", "_")
+                    tool_environment[f"CARGO_TARGET_{host}_LINKER"] = str(Path(linker).resolve())
         try:
             schemas, dispatch = _build_os_tools(
                 os_env_spec,
                 spec.workspace,
                 tool_environment,
+                shell_os_env_spec,
             )
         except BaseException:
             with contextlib.suppress(Exception):

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -10,6 +10,7 @@ import json
 import os
 import sys
 from importlib import import_module
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from vibesys.agents.cli_common import build_schema_hint
@@ -23,15 +24,16 @@ from vibesys.agents.contracts import (
     AgentTurnResult,
     AgentUsage,
 )
+from vibesys.agents.host_resource_declarations import declare_rust_toolchain_resources
 from vibesys.agents.omnigent.providers import (
     OMNIGENT_PROVIDER_EXECUTORS,
     OmnigentExecutorSpec,
     supported_providers,
 )
+from vs_sandbox import HostResourceContext
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
-    from pathlib import Path
 
 _TOOL_EXECUTOR_ATTR = "_tool_executor"
 """Private Omnigent 0.6.0 tool-dispatch seam, guarded before assignment."""
@@ -39,6 +41,10 @@ _TOOL_EXECUTOR_ATTR = "_tool_executor"
 
 class OmnigentDriverError(RuntimeError):
     """An Omnigent driver requirement could not be satisfied safely."""
+
+
+def _is_top_level_dot_path(path: Path) -> bool:
+    return len(path.parts) == 1 and path.name.startswith(".")
 
 
 def _resolve_executor_spec(provider: str) -> OmnigentExecutorSpec:
@@ -347,11 +353,15 @@ class OmnigentDriver:
                 "Omnigent cannot run this agent in VibeSys's container execution path"
             )
         project_paths = spec.policy.project_paths
-        if project_paths is not None and (
-            project_paths.read_only_paths or project_paths.hidden_paths
-        ):
+        read_only_paths = () if project_paths is None else project_paths.read_only_paths
+        hidden_paths = () if project_paths is None else project_paths.hidden_paths
+        unsupported_paths = [path for path in read_only_paths if not _is_top_level_dot_path(path)]
+        unsupported_paths.extend(path for path in hidden_paths if not _is_top_level_dot_path(path))
+        if unsupported_paths:
             raise OmnigentDriverError(
-                "Omnigent 0.6.0 cannot enforce VibeSys nested read-only or hidden paths"
+                "Omnigent 0.6.0 can support only top-level dot paths in the "
+                "VibeSys project policy; unsupported paths: "
+                f"{[str(path) for path in unsupported_paths]}"
             )
 
     def run_awaitable(self, awaitable: Any) -> Any:  # noqa: ANN401
@@ -375,30 +385,57 @@ class OmnigentDriver:
                 "this integration requires the Omnigent 0.6.0 executor API"
             ) from exc
 
-    def _build_os_env(self, workspace: Path) -> Any:  # noqa: ANN401
+    def _build_os_env(self, spec: AgentSessionSpec) -> Any:  # noqa: ANN401
         try:
             from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec  # noqa: PLC0415
         except ImportError as exc:
             raise _missing_omnigent("Omnigent OS-environment datamodel", exc) from exc
+        workspace = spec.workspace
+        project_paths = spec.policy.project_paths
+        hidden = set(() if project_paths is None else project_paths.hidden_paths)
+        allow_hidden = [
+            entry.name
+            for entry in sorted(workspace.iterdir(), key=lambda path: path.name)
+            if entry.name.startswith(".") and Path(entry.name) not in hidden
+        ]
+        environment = {**os.environ, **dict(spec.environment)}
+        resources = declare_rust_toolchain_resources(HostResourceContext(env=environment))
+        read_paths = sorted(
+            {str(workspace)}
+            | {
+                str(resource.path.expanduser().resolve())
+                for resource in resources
+                if resource.path.exists()
+            }
+        )
+        sandbox = OSEnvSandboxSpec(
+            type=_sandbox_backend_for_platform(),
+            read_paths=read_paths,
+            write_paths=[str(workspace)],
+            cwd_allow_hidden=allow_hidden,
+        )
         return OSEnvSpec(
             type="caller_process",
             cwd=str(workspace),
-            sandbox=OSEnvSandboxSpec(
-                type=_sandbox_backend_for_platform(),
-                write_paths=[str(workspace)],
-            ),
+            sandbox=sandbox,
         )
 
     def _build_executor(self, spec: AgentSessionSpec) -> tuple[Any, list[dict[str, Any]]]:
         executor_spec = _resolve_executor_spec(spec.provider)
         executor_cls = self._executor_class(executor_spec)
-        os_env_spec = self._build_os_env(spec.workspace)
+        os_env_spec = self._build_os_env(spec)
+        executor_kwargs: dict[str, Any] = {
+            "cwd": str(spec.workspace),
+            "model": spec.model,
+            "os_env": os_env_spec,
+        }
+        if spec.provider == "codex":
+            # Codex's native workspace sandbox cannot represent Omnigent's
+            # dot-path masks. Route all filesystem access through the
+            # sandboxed sys_os_* tools instead.
+            executor_kwargs["disable_native_tools"] = True
         try:
-            executor = executor_cls(
-                cwd=str(spec.workspace),
-                model=spec.model,
-                os_env=os_env_spec,
-            )
+            executor = executor_cls(**executor_kwargs)
         except ImportError as exc:
             raise OmnigentDriverError(
                 f"Omnigent provider {spec.provider!r} is unavailable: {exc}"

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -41,6 +41,9 @@ if TYPE_CHECKING:
 _TOOL_EXECUTOR_ATTR = "_tool_executor"
 """Private Omnigent 0.6.0 tool-dispatch seam, guarded before assignment."""
 
+_OMNIGENT_INTERNAL_HIDDEN = frozenset({".codex-tmp"})
+"""Runtime-owned workspace paths that OS tools must not traverse."""
+
 
 class OmnigentDriverError(RuntimeError):
     """An Omnigent driver requirement could not be satisfied safely."""
@@ -405,7 +408,9 @@ class OmnigentDriver:
         allow_hidden = [
             entry.name
             for entry in sorted(workspace.iterdir(), key=lambda path: path.name)
-            if entry.name.startswith(".") and Path(entry.name) not in hidden
+            if entry.name.startswith(".")
+            and entry.name not in _OMNIGENT_INTERNAL_HIDDEN
+            and Path(entry.name) not in hidden
         ]
         environment = {**os.environ, **dict(spec.environment)}
         resources = declare_active_rust_toolchain_resources(

--- a/src/vibesys/agents/factory.py
+++ b/src/vibesys/agents/factory.py
@@ -117,14 +117,10 @@ def build_agent_client(  # noqa: C901, PLR0912, PLR0913
                 f"supported providers: {supported_providers()}. Select "
                 "agent.driver='agentshim' for other providers."
             )
-        if host_resources or (
-            project_path_policy is not None
-            and (project_path_policy.read_only_paths or project_path_policy.hidden_paths)
-        ):
+        if host_resources:
             raise OmnigentDriverError(  # noqa: TRY003
                 "Omnigent cannot enforce the requested VibeSys host-resource "
-                f"grants ({[str(resource.path) for resource in host_resources]}), "
-                "nested read-only paths, or hidden paths. Select "
+                f"grants ({[str(resource.path) for resource in host_resources]}). Select "
                 "agent.driver='agentshim' for this policy."
             )
 

--- a/src/vibesys/agents/host_resource_declarations.py
+++ b/src/vibesys/agents/host_resource_declarations.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
 import sys
 from collections.abc import Iterable, Mapping  # noqa: TC003  # tracked: #288
 from pathlib import Path
@@ -95,6 +96,62 @@ def declare_rust_toolchain_resources(
         (cargo_home / "bin", cargo_home / "env", rustup_home),
         purpose="Rust toolchain",
     )
+
+
+def resolve_active_rust_toolchain(
+    ctx: HostResourceContext,
+    *,
+    workspace: Path | None = None,
+) -> tuple[Path, Path] | None:
+    """Return the active Rust sysroot and target library directory."""
+    rustc = shutil.which("rustc", path=ctx.env.get("PATH"))
+    if rustc is None:
+        return None
+
+    def rustc_print(name: str) -> str:
+        result = subprocess.run(  # noqa: S603
+            [rustc, "--print", name],
+            check=True,
+            capture_output=True,
+            cwd=workspace,
+            env={**ctx.env, "RUSTUP_AUTO_INSTALL": "0"},
+            text=True,
+            timeout=10,
+        )
+        return result.stdout.strip()
+
+    try:
+        sysroot_text = rustc_print("sysroot")
+        target_libdir_text = rustc_print("target-libdir")
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+    if not sysroot_text or not target_libdir_text:  # pragma: no cover - malformed compiler
+        return None
+    sysroot = Path(sysroot_text).expanduser().resolve()
+    target_libdir = Path(target_libdir_text).expanduser().resolve()
+    return sysroot, target_libdir
+
+
+def declare_active_rust_toolchain_resources(
+    ctx: HostResourceContext,
+    *,
+    workspace: Path | None = None,
+) -> Iterable[HostResource]:
+    """Declare a narrow view of the active Rust compiler and runtime.
+
+    Omnigent recursively scans every read grant for hidden paths. Granting all
+    of ``~/.rustup`` is both expensive and likely to exceed its scan cap, so
+    VibeSys bypasses the rustup proxy and exposes only the selected toolchain.
+    """
+    resolved = resolve_active_rust_toolchain(ctx, workspace=workspace)
+    if resolved is None:
+        return ()
+    sysroot, target_libdir = resolved
+    del target_libdir
+    paths = [sysroot / "bin", sysroot / "lib"]
+    if (sysroot / "libexec").is_dir():
+        paths.append(sysroot / "libexec")
+    return _resources(paths, purpose="active Rust toolchain")
 
 
 def _shell_setup(ctx: HostResourceContext) -> Iterable[HostResource]:

--- a/src/vibesys/agents/host_resource_declarations.py
+++ b/src/vibesys/agents/host_resource_declarations.py
@@ -81,7 +81,10 @@ def _path_toolchain(ctx: HostResourceContext) -> Iterable[HostResource]:
     return _resources(paths, purpose="launcher PATH toolchain")
 
 
-def _rust_toolchain(ctx: HostResourceContext) -> Iterable[HostResource]:
+def declare_rust_toolchain_resources(
+    ctx: HostResourceContext,
+) -> Iterable[HostResource]:
+    """Declare the host paths needed to run an installed Rust toolchain."""
     home = ctx.env.get("HOME")
     if not home:
         return ()
@@ -179,7 +182,7 @@ def _operator_allowlist(ctx: HostResourceContext) -> Iterable[HostResource]:
 DEFAULT_AGENT_HOST_RESOURCE_DECLARERS: tuple[HostResourceDeclarer, ...] = (
     _python_runtime,
     _path_toolchain,
-    _rust_toolchain,
+    declare_rust_toolchain_resources,
     _shell_setup,
     _agent_runtime,
     _provider_state,

--- a/src/vibesys/run/git_tracker.py
+++ b/src/vibesys/run/git_tracker.py
@@ -71,6 +71,7 @@ class GitTracker:
     )
 
     _PROJECT_LOCAL_EXCLUDE_PATTERNS: tuple[str, ...] = (
+        "/.codex-tmp/",
         "/.env",
         "/.env.*",
         "/agent.toml",

--- a/tests/agents/drivers/test_omnigent_driver.py
+++ b/tests/agents/drivers/test_omnigent_driver.py
@@ -297,7 +297,7 @@ def test_os_policy_exposes_control_dotdirs_and_keeps_hidden_dotfiles_masked(
     )
     driver = OmnigentDriver()
     monkeypatch.setattr(
-        "vibesys.agents.drivers.omnigent.declare_rust_toolchain_resources",
+        "vibesys.agents.drivers.omnigent.declare_active_rust_toolchain_resources",
         lambda *_args, **_kwargs: (HostResource(toolchain, purpose="Rust toolchain"),),
     )
 
@@ -326,12 +326,30 @@ def test_codex_executor_disables_native_tools(
     driver = OmnigentDriver()
     monkeypatch.setattr(driver, "_executor_class", lambda _spec: Executor)
     monkeypatch.setattr(driver, "_build_os_env", lambda _spec: object())
+    rust_sysroot = tmp_path / "rust"
+    monkeypatch.setattr(
+        "vibesys.agents.drivers.omnigent.resolve_active_rust_toolchain",
+        lambda _context, *, workspace: (rust_sysroot, workspace / "lib"),
+    )
+
+    def build_tools(
+        _os_env: object, _workspace: Path, environment: dict[str, str]
+    ) -> tuple[list[dict[str, Any]], object]:
+        captured["tool_environment"] = environment
+        return [], lambda _name, _args: None
+
     monkeypatch.setattr(
         "vibesys.agents.drivers.omnigent._build_os_tools",
-        lambda _os_env, _workspace: ([], lambda _name, _args: None),
+        build_tools,
     )
 
     executor, _schemas = driver._build_executor(_spec(tmp_path))  # noqa: SLF001
 
     assert captured["disable_native_tools"] is True
+    assert str(captured["tool_environment"]["PATH"]).split(os.pathsep)[0] == str(
+        rust_sysroot / "bin"
+    )
+    assert captured["tool_environment"]["CARGO_HOME"] == str(
+        tmp_path / "target" / "vibesys-cargo-home"
+    )
     driver.close_executor(executor)

--- a/tests/agents/drivers/test_omnigent_driver.py
+++ b/tests/agents/drivers/test_omnigent_driver.py
@@ -286,6 +286,7 @@ def test_os_policy_exposes_control_dotdirs_and_keeps_hidden_dotfiles_masked(
 ) -> None:
     (tmp_path / ".git").mkdir()
     (tmp_path / ".vibesys").mkdir()
+    (tmp_path / ".codex-tmp").mkdir()
     (tmp_path / ".env").write_text("secret", encoding="utf-8")
     (tmp_path / "src").mkdir()
     (tmp_path / "Cargo.toml").write_text("[package]", encoding="utf-8")

--- a/tests/agents/drivers/test_omnigent_driver.py
+++ b/tests/agents/drivers/test_omnigent_driver.py
@@ -263,7 +263,7 @@ def test_missing_private_tool_executor_seam_fails_during_setup(
 
     driver = OmnigentDriver()
     monkeypatch.setattr(driver, "_executor_class", lambda _spec: ExecutorWithoutSeam)
-    monkeypatch.setattr(driver, "_build_os_env", lambda _workspace: object())
+    monkeypatch.setattr(driver, "_build_os_env", lambda _workspace, **_kwargs: object())
 
     with pytest.raises(OmnigentDriverError, match="_tool_executor"):
         driver._build_executor(_spec(tmp_path))  # noqa: SLF001
@@ -276,6 +276,7 @@ def test_os_policy_is_always_sandboxed_and_workspace_scoped(tmp_path: Path) -> N
 
     assert spec.sandbox is not None
     assert spec.sandbox.type != "none"
+    assert spec.sandbox.read_paths is None
     assert spec.sandbox.write_paths == [str(tmp_path)]
     assert spec.cwd == str(tmp_path)
 
@@ -303,13 +304,14 @@ def test_os_policy_exposes_control_dotdirs_and_keeps_hidden_dotfiles_masked(
     )
 
     spec = driver._build_os_env(  # noqa: SLF001
-        _spec(tmp_path, policy=AgentExecutionPolicy(project_paths=policy))
+        _spec(tmp_path, policy=AgentExecutionPolicy(project_paths=policy)),
+        include_toolchain=True,
     )
 
     assert spec.sandbox is not None
     assert spec.sandbox.write_paths == [str(tmp_path)]
     assert spec.sandbox.write_files is None
-    assert spec.sandbox.read_paths == sorted((str(tmp_path), str(toolchain)))
+    assert spec.sandbox.read_paths == [str(toolchain)]
     assert set(spec.sandbox.cwd_allow_hidden or ()) == {".git", ".vibesys"}
 
 
@@ -326,15 +328,24 @@ def test_codex_executor_disables_native_tools(
 
     driver = OmnigentDriver()
     monkeypatch.setattr(driver, "_executor_class", lambda _spec: Executor)
-    monkeypatch.setattr(driver, "_build_os_env", lambda _spec: object())
+    monkeypatch.setattr(driver, "_build_os_env", lambda _spec, **_kwargs: object())
     rust_sysroot = tmp_path / "rust"
+    target_libdir = rust_sysroot / "lib" / "rustlib" / "x86_64-unknown-linux-gnu" / "lib"
     monkeypatch.setattr(
         "vibesys.agents.drivers.omnigent.resolve_active_rust_toolchain",
-        lambda _context, *, workspace: (rust_sysroot, workspace / "lib"),
+        lambda _context, *, workspace: (rust_sysroot, target_libdir),  # noqa: ARG005
+    )
+    monkeypatch.setattr("vibesys.agents.drivers.omnigent.sys.platform", "linux")
+    monkeypatch.setattr(
+        "vibesys.agents.drivers.omnigent.shutil.which",
+        lambda _name, *, path: "/usr/bin/cc",  # noqa: ARG005
     )
 
     def build_tools(
-        _os_env: object, _workspace: Path, environment: dict[str, str]
+        _os_env: object,
+        _workspace: Path,
+        environment: dict[str, str],
+        _shell_os_env: object,
     ) -> tuple[list[dict[str, Any]], object]:
         captured["tool_environment"] = environment
         return [], lambda _name, _args: None
@@ -352,5 +363,8 @@ def test_codex_executor_disables_native_tools(
     )
     assert captured["tool_environment"]["CARGO_HOME"] == str(
         tmp_path / "target" / "vibesys-cargo-home"
+    )
+    assert captured["tool_environment"]["CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER"] == str(
+        Path("/usr/bin/cc").resolve()
     )
     driver.close_executor(executor)

--- a/tests/agents/drivers/test_omnigent_driver.py
+++ b/tests/agents/drivers/test_omnigent_driver.py
@@ -305,6 +305,7 @@ def test_os_policy_exposes_control_dotdirs_and_keeps_hidden_dotfiles_masked(
 
     spec = driver._build_os_env(  # noqa: SLF001
         _spec(tmp_path, policy=AgentExecutionPolicy(project_paths=policy)),
+        env_passthrough=("CARGO_TARGET_DIR",),
         include_toolchain=True,
     )
 
@@ -312,6 +313,7 @@ def test_os_policy_exposes_control_dotdirs_and_keeps_hidden_dotfiles_masked(
     assert spec.sandbox.write_paths == [str(tmp_path)]
     assert spec.sandbox.write_files is None
     assert spec.sandbox.read_paths == [str(toolchain)]
+    assert spec.sandbox.env_passthrough == ["CARGO_TARGET_DIR"]
     assert set(spec.sandbox.cwd_allow_hidden or ()) == {".git", ".vibesys"}
 
 
@@ -338,7 +340,7 @@ def test_codex_executor_disables_native_tools(
     monkeypatch.setattr("vibesys.agents.drivers.omnigent.sys.platform", "linux")
     monkeypatch.setattr(
         "vibesys.agents.drivers.omnigent.shutil.which",
-        lambda _name, *, path: "/usr/bin/cc",  # noqa: ARG005
+        lambda name, *, path: "/usr/bin/gcc" if name == "gcc" else None,  # noqa: ARG005
     )
 
     def build_tools(
@@ -361,10 +363,15 @@ def test_codex_executor_disables_native_tools(
     assert str(captured["tool_environment"]["PATH"]).split(os.pathsep)[0] == str(
         rust_sysroot / "bin"
     )
-    assert captured["tool_environment"]["CARGO_HOME"] == str(
-        tmp_path / "target" / "vibesys-cargo-home"
-    )
+    cargo_home = Path(captured["tool_environment"]["CARGO_HOME"])
+    cargo_target = Path(captured["tool_environment"]["CARGO_TARGET_DIR"])
+    assert cargo_home.name == "cargo-home"
+    assert cargo_target.name == "target"
+    assert cargo_home.parent == cargo_target.parent
+    assert cargo_home.parent.is_dir()
+    assert not cargo_home.is_relative_to(tmp_path)
     assert captured["tool_environment"]["CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER"] == str(
-        Path("/usr/bin/cc").resolve()
+        Path("/usr/bin/gcc").resolve()
     )
     driver.close_executor(executor)
+    assert not cargo_home.parent.exists()

--- a/tests/agents/drivers/test_omnigent_driver.py
+++ b/tests/agents/drivers/test_omnigent_driver.py
@@ -305,7 +305,7 @@ def test_os_policy_exposes_control_dotdirs_and_keeps_hidden_dotfiles_masked(
 
     spec = driver._build_os_env(  # noqa: SLF001
         _spec(tmp_path, policy=AgentExecutionPolicy(project_paths=policy)),
-        env_passthrough=("CARGO_TARGET_DIR",),
+        env_passthrough=("CARGO_HOME",),
         include_toolchain=True,
     )
 
@@ -313,8 +313,14 @@ def test_os_policy_exposes_control_dotdirs_and_keeps_hidden_dotfiles_masked(
     assert spec.sandbox.write_paths == [str(tmp_path)]
     assert spec.sandbox.write_files is None
     assert spec.sandbox.read_paths == [str(toolchain)]
-    assert spec.sandbox.env_passthrough == ["CARGO_TARGET_DIR"]
-    assert set(spec.sandbox.cwd_allow_hidden or ()) == {".git", ".vibesys"}
+    assert spec.sandbox.env_passthrough == ["CARGO_HOME"]
+    assert set(spec.sandbox.cwd_allow_hidden or ()) == {
+        ".cargo-lock",
+        ".fingerprint",
+        ".git",
+        ".rustc_info.json",
+        ".vibesys",
+    }
 
 
 def test_codex_executor_disables_native_tools(
@@ -364,12 +370,10 @@ def test_codex_executor_disables_native_tools(
         rust_sysroot / "bin"
     )
     cargo_home = Path(captured["tool_environment"]["CARGO_HOME"])
-    cargo_target = Path(captured["tool_environment"]["CARGO_TARGET_DIR"])
     assert cargo_home.name == "cargo-home"
-    assert cargo_target.name == "target"
-    assert cargo_home.parent == cargo_target.parent
     assert cargo_home.parent.is_dir()
     assert not cargo_home.is_relative_to(tmp_path)
+    assert "CARGO_TARGET_DIR" not in captured["tool_environment"]
     assert captured["tool_environment"]["CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER"] == str(
         Path("/usr/bin/gcc").resolve()
     )

--- a/tests/agents/drivers/test_omnigent_driver.py
+++ b/tests/agents/drivers/test_omnigent_driver.py
@@ -172,10 +172,10 @@ def test_timeout_poisons_session_and_cleanup_is_idempotent(tmp_path: Path) -> No
         (
             {
                 "policy": AgentExecutionPolicy(
-                    project_paths=ProjectPathPolicy(read_only_paths=(".vibesys",)),
+                    project_paths=ProjectPathPolicy(read_only_paths=("src/protected",)),
                 )
             },
-            "read-only",
+            "top-level",
         ),
         ({"policy": AgentExecutionPolicy(containerized=True)}, "container"),
     ],
@@ -195,6 +195,42 @@ def test_create_session_rejects_unsupported_requirements_before_building(
 
     with pytest.raises(OmnigentDriverError, match=message):
         driver.create_session(_spec(tmp_path, **change))
+
+
+def test_create_session_accepts_supported_top_level_project_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    driver = OmnigentDriver()
+    executor = _FakeExecutor([])
+    monkeypatch.setattr(driver, "_build_executor", lambda _spec: (executor, []))
+    policy = ProjectPathPolicy(
+        read_only_paths=(".git", ".vibesys"),
+        hidden_paths=(".env",),
+    )
+
+    session = driver.create_session(
+        _spec(tmp_path, policy=AgentExecutionPolicy(project_paths=policy))
+    )
+
+    session.close()
+    driver.close()
+
+
+def test_create_session_rejects_non_dot_hidden_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    driver = OmnigentDriver()
+    monkeypatch.setattr(
+        driver,
+        "_build_executor",
+        lambda _spec: pytest.fail("executor must not be built"),
+    )
+    policy = ProjectPathPolicy(hidden_paths=("agent.toml",))
+
+    with pytest.raises(OmnigentDriverError, match=r"agent\.toml"):
+        driver.create_session(_spec(tmp_path, policy=AgentExecutionPolicy(project_paths=policy)))
 
 
 def test_driver_owns_session_cleanup(
@@ -236,9 +272,66 @@ def test_missing_private_tool_executor_seam_fails_during_setup(
 def test_os_policy_is_always_sandboxed_and_workspace_scoped(tmp_path: Path) -> None:
     driver = OmnigentDriver()
 
-    spec = driver._build_os_env(tmp_path)  # noqa: SLF001
+    spec = driver._build_os_env(_spec(tmp_path))  # noqa: SLF001
 
     assert spec.sandbox is not None
     assert spec.sandbox.type != "none"
     assert spec.sandbox.write_paths == [str(tmp_path)]
     assert spec.cwd == str(tmp_path)
+
+
+def test_os_policy_exposes_control_dotdirs_and_keeps_hidden_dotfiles_masked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".vibesys").mkdir()
+    (tmp_path / ".env").write_text("secret", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "Cargo.toml").write_text("[package]", encoding="utf-8")
+    toolchain = tmp_path.parent / "toolchain"
+    toolchain.mkdir(exist_ok=True)
+    policy = ProjectPathPolicy(
+        read_only_paths=(".git", ".vibesys"),
+        hidden_paths=(".env",),
+    )
+    driver = OmnigentDriver()
+    monkeypatch.setattr(
+        "vibesys.agents.drivers.omnigent.declare_rust_toolchain_resources",
+        lambda *_args, **_kwargs: (HostResource(toolchain, purpose="Rust toolchain"),),
+    )
+
+    spec = driver._build_os_env(  # noqa: SLF001
+        _spec(tmp_path, policy=AgentExecutionPolicy(project_paths=policy))
+    )
+
+    assert spec.sandbox is not None
+    assert spec.sandbox.write_paths == [str(tmp_path)]
+    assert spec.sandbox.write_files is None
+    assert spec.sandbox.read_paths == sorted((str(tmp_path), str(toolchain)))
+    assert set(spec.sandbox.cwd_allow_hidden or ()) == {".git", ".vibesys"}
+
+
+def test_codex_executor_disables_native_tools(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class Executor(_FakeExecutor):
+        def __init__(self, **kwargs: Any) -> None:  # noqa: ANN401
+            captured.update(kwargs)
+            super().__init__([])
+
+    driver = OmnigentDriver()
+    monkeypatch.setattr(driver, "_executor_class", lambda _spec: Executor)
+    monkeypatch.setattr(driver, "_build_os_env", lambda _spec: object())
+    monkeypatch.setattr(
+        "vibesys.agents.drivers.omnigent._build_os_tools",
+        lambda _os_env, _workspace: ([], lambda _name, _args: None),
+    )
+
+    executor, _schemas = driver._build_executor(_spec(tmp_path))  # noqa: SLF001
+
+    assert captured["disable_native_tools"] is True
+    driver.close_executor(executor)

--- a/tests/agents/test_host_resource_declarations.py
+++ b/tests/agents/test_host_resource_declarations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -80,6 +81,41 @@ def test_defaults_declare_path_rust_and_shell_resources(tmp_path):  # noqa: ANN0
     assert resources[rustup_home] is HostResourceAccess.READ_ONLY
     assert resources[bash_profile] is HostResourceAccess.READ_ONLY
     assert home not in resources
+
+
+def test_active_rust_toolchain_declaration_is_narrow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    rustup_home = home / ".rustup"
+    sysroot = rustup_home / "toolchains" / "stable"
+    target_libdir = sysroot / "lib" / "rustlib" / "host" / "lib"
+    lib_dir = sysroot / "lib"
+    lib_dir.mkdir(parents=True)
+    target_libdir.mkdir(parents=True)
+    monkeypatch.setattr(
+        host_resource_declarations.shutil, "which", lambda *_args, **_kwargs: "rustc"
+    )
+    outputs = iter((f"{sysroot}\n", f"{target_libdir}\n"))
+    monkeypatch.setattr(
+        host_resource_declarations.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(stdout=next(outputs)),
+    )
+
+    declarations = tuple(
+        host_resource_declarations.declare_active_rust_toolchain_resources(
+            host_resource_declarations.HostResourceContext(
+                env={"HOME": str(home), "PATH": str(home / ".cargo" / "bin")}
+            )
+        )
+    )
+    paths = {resource.path for resource in declarations}
+
+    assert sysroot / "bin" in paths
+    assert sysroot / "lib" in paths
+    assert rustup_home not in paths
 
 
 @pytest.mark.parametrize(

--- a/tests/test_git_tracker.py
+++ b/tests/test_git_tracker.py
@@ -126,6 +126,7 @@ def test_fresh_project_owns_repository_branch_and_local_excludes(tmp_path: Path)
         Project.open(tmp_path).state.git_integration("round-trip").local_exclude_pattern in excludes
     )
     assert "/agent.toml" in excludes
+    assert "/.codex-tmp/" in excludes
     assert "/.env.*" in excludes
     assert "attempts/" in excludes
     assert not (tmp_path / ".gitignore").exists()


### PR DESCRIPTION
## Problem

Omnigent could not run a normal local queue optimization session. VibeSys rejected the queue repository's `.git` and `.vibesys` project policy before session creation, Codex-native tools did not preserve that policy, and Omnigent could not safely reach or run the installed Rust toolchain on both macOS and Linux.

This PR is stacked on #404, which moves machine-local run state outside the project without changing serialized formats.

## Solution

Translate the queue runtime contract into Omnigent's OS environment:

- accept supported top-level dot-path policy while rejecting nested and non-dot paths before launch;
- disable Codex-native filesystem tools and route file and shell operations through sandboxed `sys_os_*` tools;
- keep file tools workspace-scoped, and give the shell a writable workspace plus narrow read-only access to the active Rust sysroot;
- bypass rustup proxies, disable auto-install, pass the selected compiler and Cargo environment explicitly, and resolve `gcc` on Linux when `cc` is only an unavailable alternatives link;
- keep Cargo's conventional workspace `target` path so existing Makefiles work, while allowing only Cargo's generated hidden basenames through Omnigent's recursive mask;
- use a per-executor external scratch directory for `CARGO_HOME` and remove it on close;
- mask and exclude Omnigent's `.codex-tmp` session contents from tools and run commits.

Omnigent 0.6.0 cannot make `.git` and `.vibesys` read-only beneath a writable workspace. This integration assumes coding agents obey the run contract and do not modify those control directories. PR #404 removes machine-local operational state from that workspace.

### Architecture

```mermaid
flowchart LR
  Client[AgentClient] --> Driver[OmnigentDriver]
  Driver --> Executor[Codex executor\nnative tools disabled]
  Executor --> FileTools[File tools\nworkspace read/write]
  Executor --> Shell[Shell tool\nworkspace read/write]
  Shell --> Rust[Active Rust sysroot\nread-only]
  Shell --> Scratch[Per-executor Cargo home\nwrite, cleanup on close]
```

## Verification

The cumulative top commit `ba3d014` passed the complete default-branch CI matrix through temporary validation PR #409: 4,962 tests, patch coverage, formatting, lint, typecheck, TUI, queue-native, Linux and macOS sandbox tests, website, four release-wheel builds, and aggregate artifact verification.

Credentialed one-round queue sessions passed through both drivers on Linux. Omnigent also passed a credentialed one-round queue session on macOS. The equivalent AgentShim macOS smoke still reproduces the known Codex state-database sandbox failure (`state_5.sqlite` is read-only); this PR does not change AgentShim sandbox behavior.

The separate slow and flaky integration workflow was not run, per request.

### Correctness properties

- Omnigent never falls back to an unsandboxed OS environment.
- Codex file and shell access uses Omnigent's sandboxed tool path.
- Explicitly hidden top-level project paths stay masked.
- Unsupported project policies and runtime requirements fail before session start.
- Arbitrary host resources remain unavailable; only the active Rust toolchain is imported read-only.
- Cargo works across fresh helpers without exposing all of `~/.rustup` or changing conventional artifact paths.
- Per-executor Cargo home and Omnigent session contents do not enter run commits.
- AgentShim remains the default driver and its behavior is unchanged.

### Testing

- `uv run pytest -q tests/agents/drivers/test_omnigent_driver.py tests/agents/test_agent_client.py tests/agents/test_host_resource_declarations.py tests/agents/test_omnigent_backend.py tests/test_git_tracker.py` (131 passed)
- `uv run ruff check src/vibesys/agents/drivers/omnigent.py tests/agents/drivers/test_omnigent_driver.py`
- `uv run ruff format --check src/vibesys/agents/drivers/omnigent.py tests/agents/drivers/test_omnigent_driver.py`
- `uv run pyright src/vibesys/agents/drivers/omnigent.py tests/agents/drivers/test_omnigent_driver.py`
- `uv run python scripts/check_doc_links.py`
- macOS Seatbelt production-driver smoke: two fresh executors both ran plain `cargo test --locked` against the same conventional workspace `target`
- macOS Omnigent one-round queue E2E: accuracy PASS; benchmark PASS (`64,639,227.995628 ops/s`)
- Linux AgentShim one-round queue E2E on `chelan4`: accuracy PASS; benchmark PASS (`36,443,184.872417 ops/s`)
- Linux Omnigent one-round queue E2E on `chelan4`: plain Cargo test/clippy/release and unchanged build conventions PASS; accuracy PASS; benchmark PASS (`11,733,522.637422 ops/s`); external state and scratch cleanup verified
- macOS AgentShim one-round queue E2E: reached live Codex, then reproduced the known read-only Codex state DB failure
