### PR TITLE
Honor agent.toml TUI theme during interactive launch

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -200,7 +200,8 @@ overlay, round labels use the same body-text color as card content, and the
 chat panel's inner border matches its outer one. `theme.test.ts` pins all of
 this so the baseline cannot drift.
 
-Pick one with `--theme <name>`; launches without the flag use `dark`. The
+Pick one with `--theme <name>` or set `[tui].theme` in `agent.toml`. An explicit
+flag wins over the config value, and launches with neither use `dark`. The
 launcher passes the selected name to the client through `VIBESYS_THEME`.
 Inside a session, `/theme` opens the list as a selection: it starts on the
 theme in use, Up and Down move the highlight, Enter applies it, and Escape

--- a/clients/tui/src/launcher.test.ts
+++ b/clients/tui/src/launcher.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, describe, expect, it} from 'bun:test';
-import {access, chmod, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {access, chmod, mkdtemp, readFile, realpath, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {dirname, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
@@ -55,6 +55,10 @@ describe('launcher', () => {
 import {writeFileSync} from 'node:fs';
 import {createServer} from 'node:net';
 
+if (process.argv.includes('tui-defaults')) {
+  console.log(JSON.stringify({theme: 'dark'}));
+  process.exit(0);
+}
 const socketPath = process.argv[process.argv.indexOf('--control-socket') + 1];
 const server = createServer(socket => {
   let buffer = '';
@@ -106,6 +110,10 @@ process.exit(0);
 import {writeFileSync} from 'node:fs';
 import {createServer} from 'node:net';
 
+if (process.argv.includes('tui-defaults')) {
+  console.log(JSON.stringify({theme: 'dark'}));
+  process.exit(0);
+}
 const socketPath = process.argv[process.argv.indexOf('--control-socket') + 1];
 const server = createServer(socket => {
   socket.once('data', data => {
@@ -185,8 +193,9 @@ import {writeFileSync} from 'node:fs';
 import {createServer} from 'node:net';
 
 if (process.argv.includes('tui-defaults')) {
-  writeFileSync(${JSON.stringify(defaultsInvoked)}, 'invoked');
-  process.exit(9);
+  writeFileSync(${JSON.stringify(defaultsInvoked)}, JSON.stringify(process.argv.slice(2)));
+  console.log(JSON.stringify({theme: 'solarized-light'}));
+  process.exit(0);
 }
 writeFileSync(${JSON.stringify(backendCwd)}, process.cwd());
 writeFileSync(process.env.VIBESYS_FAKE_BACKEND_ARGS_FILE, JSON.stringify(process.argv.slice(2)));
@@ -234,10 +243,12 @@ process.exit(0);
     expect(implicitArgs).not.toContain('--input');
     expect(implicitArgs).not.toContain('--repo');
     expect(implicitArgs).not.toContain('--exp-name');
-    await expect(access(defaultsInvoked)).rejects.toThrow();
-    expect(await readFile(backendCwd, 'utf8')).toBe(tempDir);
-    expect(await readFile(frontendTheme, 'utf8')).toBe('dark');
+    const defaultsArgs = JSON.parse(await readFile(defaultsInvoked, 'utf8')) as string[];
+    expect(defaultsArgs).toContain('--directory-only');
+    expect(await realpath(await readFile(backendCwd, 'utf8'))).toBe(await realpath(tempDir));
+    expect(await readFile(frontendTheme, 'utf8')).toBe('solarized-light');
 
+    await rm(defaultsInvoked);
     await expect(
       launch([
         '--input',
@@ -251,6 +262,7 @@ process.exit(0);
     const explicitArgs = JSON.parse(await readFile(backendArgs, 'utf8')) as string[];
     expect(explicitArgs.filter(argument => argument === '--runs-dir')).toHaveLength(1);
     expect(explicitArgs[explicitArgs.indexOf('--runs-dir') + 1]).toBe('/repo/legacy-runs');
+    await expect(access(defaultsInvoked)).rejects.toThrow();
     expect(await readFile(frontendTheme, 'utf8')).toBe('solarized-dark');
     await access(backendTerminated);
   });

--- a/clients/tui/src/launcher.ts
+++ b/clients/tui/src/launcher.ts
@@ -143,7 +143,9 @@ async function themeFromBackend(
     }
     return {theme: defaults.theme};
   } catch (error) {
-    console.error(`vs: invalid TUI defaults: ${error instanceof Error ? error.message : String(error)}`);
+    console.error(
+      `vs: invalid TUI defaults: ${error instanceof Error ? error.message : String(error)}`,
+    );
     return {exitCode: 1};
   }
 }

--- a/clients/tui/src/launcher.ts
+++ b/clients/tui/src/launcher.ts
@@ -8,7 +8,7 @@ import {createConnection} from 'node:net';
 import {tmpdir} from 'node:os';
 import {dirname, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {DEFAULT_THEME_NAME, isThemeName, THEME_NAMES, type ThemeName} from './ui/theme.js';
+import {isThemeName, THEME_NAMES, type ThemeName} from './ui/theme.js';
 
 const READY_TIMEOUT_MS = 30_000;
 const SHUTDOWN_TIMEOUT_MS = 10_000;
@@ -40,7 +40,7 @@ export async function launch(argv: string[]): Promise<number> {
     return 1;
   }
 
-  const prepared = prepareInteractiveArgs(argv);
+  const prepared = await prepareInteractiveArgs(backend, argv);
   if ('exitCode' in prepared) return prepared.exitCode;
   const runArgv = prepared.argv;
   const theme = prepared.theme;
@@ -105,13 +105,47 @@ interface BackendCommand {
 
 type PreparedArguments = {argv: string[]; theme: ThemeName} | {exitCode: number};
 
-function prepareInteractiveArgs(argv: string[]): PreparedArguments {
+async function prepareInteractiveArgs(
+  backend: BackendCommand,
+  argv: string[],
+): Promise<PreparedArguments> {
   const requestedTheme = optionValue(argv, '--theme');
   if (requestedTheme !== undefined && !isThemeName(requestedTheme)) {
     console.error(`vs: unknown --theme ${requestedTheme}. Available: ${THEME_NAMES.join(', ')}.`);
     return {exitCode: 2};
   }
-  return {argv, theme: requestedTheme ?? DEFAULT_THEME_NAME};
+  if (requestedTheme !== undefined) return {argv, theme: requestedTheme};
+
+  const configuredTheme = await themeFromBackend(backend, argv);
+  if ('exitCode' in configuredTheme) return configuredTheme;
+  return {argv, theme: configuredTheme.theme};
+}
+
+async function themeFromBackend(
+  backend: BackendCommand,
+  argv: string[],
+): Promise<{theme: ThemeName} | {exitCode: number}> {
+  const args = [...backend.args, 'tui-defaults', '--directory-only'];
+  const config = optionValue(argv, '--config');
+  if (config !== undefined) args.push('--config', config);
+  if (argv.includes('--stub-agent')) args.push('--stub-agent');
+
+  const result = await runCaptured(backend.command, args);
+  if (result.exitCode !== 0) {
+    console.error(result.stderr.trim() || 'vs: could not resolve TUI defaults');
+    return {exitCode: result.exitCode};
+  }
+
+  try {
+    const defaults = JSON.parse(result.stdout) as {theme?: unknown};
+    if (typeof defaults.theme !== 'string' || !isThemeName(defaults.theme)) {
+      throw new Error('resolved an unknown theme');
+    }
+    return {theme: defaults.theme};
+  } catch (error) {
+    console.error(`vs: invalid TUI defaults: ${error instanceof Error ? error.message : String(error)}`);
+    return {exitCode: 1};
+  }
 }
 
 function optionValue(argv: string[], option: string): string | undefined {
@@ -285,6 +319,29 @@ function runToCompletion(command: string, args: string[]): Promise<number> {
       console.error(`vs: failed to start backend: ${error.message}`);
       resolve(1);
     });
+  });
+}
+
+function runCaptured(
+  command: string,
+  args: string[],
+): Promise<{exitCode: number; stdout: string; stderr: string}> {
+  return new Promise(resolve => {
+    const child = spawn(command, args, {stdio: ['ignore', 'pipe', 'pipe']});
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', chunk => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on('data', chunk => {
+      stderr += String(chunk);
+    });
+    child.once('exit', (code, signal) =>
+      resolve({exitCode: code ?? signalExitCode(signal), stdout, stderr}),
+    );
+    child.once('error', error => resolve({exitCode: 1, stdout, stderr: error.message}));
   });
 }
 

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -413,7 +413,8 @@ run state, and it is ignored in headless mode.
 Resolution order, highest first:
 
 1. `--theme <name>` on the command line.
-2. `dark`.
+2. `[tui].theme` in `agent.toml`.
+3. `dark`.
 
 An unknown name is rejected before any process starts. Inside a running
 session, `/theme` opens the theme list as a keyboard selection (Up/Down to


### PR DESCRIPTION
## Problem

Interactive launches ignored `[tui].theme` from `agent.toml` and always initialized the frontend with `dark` unless the operator repeated the value with `--theme`. The Python configuration boundary still resolved the configured value correctly, but PR #341 removed the launcher bridge that consumed it while deleting the obsolete interactive setup UI. This regressed the intended `--theme` > `[tui].theme` > `dark` contract.

Closes #410.

## Solution

Restore only theme-default resolution in the TypeScript launcher. When `--theme` is absent, the launcher calls the existing Python `tui-defaults --directory-only` boundary, forwarding `--config` and `--stub-agent`, validates the returned theme, and passes it to the frontend through `VIBESYS_THEME`. An explicit `--theme` remains authoritative and skips the defaults lookup.

Update the launcher integration test and TUI documentation to reflect the restored precedence. The removed setup UI remains removed.

### Architecture

The Python config layer remains the sole owner of `agent.toml` parsing and defaults. The Node launcher asks that boundary for the semantic theme, then the frontend owns rendering it. Theme selection remains presentation-only and is not added to backend run arguments or persisted run state.

## Verification

Focused launcher coverage verifies configured-theme resolution, the `--directory-only` lookup, explicit CLI precedence, unchanged backend arguments, and unknown-theme rejection. Python tests verify valid configured themes and the launch-directory config boundary. Type checking, lint, formatting, and documentation links pass.

### Correctness properties

- `--theme` overrides `[tui].theme` and skips config-theme resolution.
- Without `--theme`, the launcher passes the theme resolved from `agent.toml` to the frontend.
- Without either override, Python resolves the existing `dark` default.
- Theme remains frontend-only; backend run arguments and persisted state are unchanged.
- Unknown CLI themes still exit with status 2 before starting a process.
- Invalid or failed defaults resolution stops launch with an explicit error instead of accepting an unvalidated frontend theme.

### Testing

- `pnpm --dir clients/tui exec bun test --max-concurrency 1 src/launcher.test.ts` (7 passed)
- `pnpm --dir clients/tui check` (passed)
- `uv run pytest tests/test_config.py::TestLoadConfigTui tests/test_main.py::test_tui_defaults_use_launch_config_and_normalize_runs_dir -q` (15 passed)
- `uv run python scripts/check_doc_links.py` (312 Markdown files checked)
- `./scripts/check_format.sh` (passed)
- `./scripts/check_lint.sh` (passed)