### PR TITLE
Make hypotheses the TUI run index

### DIFF
--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -670,7 +670,7 @@ describe('session controller', () => {
     expect(controller.state.experimentLog?.selectedId).toBe('H-02');
   });
 
-  it('reports a round that belongs to no hypothesis', async () => {
+  it('opens a recorded round that belongs to no hypothesis', async () => {
     const transport = new FakeTransport();
     transport.experiments = [
       entry('H-01', 1, 1, {rounds: [{round: 1, passed: true, reviewed: true}]}),
@@ -678,11 +678,38 @@ describe('session controller', () => {
     const controller = new SocketSessionController(transport);
     await controller.start();
 
+    transport.emit({
+      type: 'event',
+      event: {...event(1, 'phase_started'), agent_kind: 'orchestrator', round_label: 'round-9-pre'},
+    });
+
     await controller.submit('/open-round --9');
 
-    expect(controller.state.overlay?.content).toContain(
-      'Round 9 is not in any recorded hypothesis.',
-    );
+    expect(controller.state.hypothesisScope).toMatchObject({id: 'round-9', rounds: [9]});
+    expect(controller.state.selectedRound).toBe(9);
+  });
+
+  it('opens the first planning activity before it has a hypothesis record', async () => {
+    const transport = new FakeTransport();
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+    transport.emit({
+      type: 'event',
+      event: {...event(1, 'phase_started'), agent_kind: 'orchestrator', round_label: 'round-1-pre'},
+    });
+
+    controller.enterExperimentDrilldown();
+
+    expect(controller.state.hypothesisScope).toMatchObject({id: 'round-1', rounds: [1]});
+    expect(controller.state.selectedRound).toBe(1);
+  });
+
+  it('reports a round that has not been observed', async () => {
+    const controller = new SocketSessionController(new FakeTransport());
+
+    await controller.submit('/open-round --9');
+
+    expect(controller.state.overlay?.content).toContain('Round 9 has not been recorded.');
     expect(controller.state.hypothesisScope).toBeNull();
   });
 

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -16,6 +16,7 @@ import {
   cyclePaneFocus,
   enterExperimentDrilldown,
   enterExperimentRound,
+  enterUnownedExperimentRound,
   failExperiments,
   failPane,
   focusPane,
@@ -35,6 +36,7 @@ import {
   reportError,
   type SessionState,
   selectAgent,
+  selectExperimentActivity,
   selectNextAgent,
   selectNextEntry,
   selectNextRound,
@@ -86,6 +88,7 @@ export interface SessionController {
   focusPane(focus: PaneFocus): void;
   setChatDockFits(fits: boolean): void;
   moveExperimentSelection(delta: number): void;
+  selectExperimentActivity(): void;
   enterExperimentDrilldown(): void;
   leaveExperimentDrilldown(): void;
   openThemePicker(): void;
@@ -275,7 +278,8 @@ export class SocketSessionController implements SessionController {
     if (roundNumber !== undefined) {
       return (
         enterExperimentRound(this.#state, roundNumber) ??
-        showDetail(this.#state, `Round ${roundNumber} is not in any recorded hypothesis.`)
+        enterUnownedExperimentRound(this.#state, roundNumber) ??
+        showDetail(this.#state, `Round ${roundNumber} has not been recorded.`)
       );
     }
     const scope = this.#state.hypothesisScope;
@@ -363,6 +367,10 @@ export class SocketSessionController implements SessionController {
 
   moveExperimentSelection(delta: number): void {
     this.#setState(moveExperimentSelection(this.#state, delta));
+  }
+
+  selectExperimentActivity(): void {
+    this.#setState(selectExperimentActivity(this.#state));
   }
 
   enterExperimentDrilldown(): void {

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -10,14 +10,18 @@ import {
   cyclePaneFocus,
   enterExperimentDrilldown,
   enterExperimentRound,
+  enterUnownedExperimentRound,
   failPane,
   focusPane,
+  hypothesisPlanningActivity,
   initialSessionState,
   leaveExperimentDrilldown,
+  moveExperimentSelection,
   moveThemeSelection,
   openChat,
   openPane,
   openThemePicker,
+  selectExperimentActivity,
   selectNextAgent,
   selectNextRound,
   selectRound,
@@ -28,10 +32,178 @@ import {
   showDetail,
   statusText,
   toggleTodos,
+  unownedExperimentRounds,
   visibleConversation,
   visiblePhases,
   visibleTodos,
 } from './session-model.js';
+
+describe('hypothesis planning activity', () => {
+  function stateFor(
+    kind: string,
+    roundLabel: string,
+    entries: Parameters<typeof setExperiments>[1] = [],
+  ): SessionState {
+    return setExperiments(
+      {
+        ...initialSessionState(),
+        phases: [
+          {
+            kind,
+            status: 'active',
+            roundNumber: 3,
+            roundLabel,
+            startedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      },
+      entries,
+    );
+  }
+
+  it("maps the loop's named pre, profiler, and plan phases", () => {
+    expect(hypothesisPlanningActivity(stateFor('orchestrator', 'round-3-pre'))).toMatchObject({
+      stage: 'pre',
+      roundNumber: 3,
+    });
+    expect(hypothesisPlanningActivity(stateFor('profiler', 'round-3-profiler'))).toMatchObject({
+      stage: 'profile',
+      roundNumber: 3,
+    });
+    expect(hypothesisPlanningActivity(stateFor('orchestrator', 'round-3-plan'))).toMatchObject({
+      stage: 'plan',
+      roundNumber: 3,
+    });
+  });
+
+  it('does not present a phase as planning after its round has a hypothesis', () => {
+    const entries = [
+      {
+        hypothesis_id: 'H-03',
+        identified: true,
+        first_round: 3,
+        last_round: 3,
+        rounds: [],
+        kept: false,
+        active: true,
+      },
+    ] as Parameters<typeof setExperiments>[1];
+
+    expect(
+      hypothesisPlanningActivity(stateFor('orchestrator', 'round-3-plan', entries)),
+    ).toBeNull();
+  });
+
+  it('keeps elapsed planning time from the earliest observed planning phase', () => {
+    const state = stateFor('orchestrator', 'round-3-plan');
+    state.phases = [
+      {
+        kind: 'orchestrator',
+        status: 'completed',
+        roundNumber: 3,
+        roundLabel: 'round-3-pre',
+        startedAt: '2026-01-01T00:00:00Z',
+      },
+      {
+        kind: 'orchestrator',
+        status: 'active',
+        roundNumber: 3,
+        roundLabel: 'round-3-plan',
+        startedAt: '2026-01-01T00:01:00Z',
+      },
+    ];
+
+    expect(hypothesisPlanningActivity(state)?.startedAt).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('ignores similarly named phases outside the loop contract', () => {
+    expect(hypothesisPlanningActivity(stateFor('profiler', 'round-3-profile-retry'))).toBeNull();
+  });
+
+  it('selects planning activity ahead of existing hypotheses and opens its recorded round', () => {
+    let state = setExperiments(
+      {
+        ...stateFor('orchestrator', 'round-3-plan'),
+        rounds: [{number: 3, status: 'active' as const}],
+      },
+      [
+        {
+          hypothesis_id: 'H-02',
+          identified: true,
+          first_round: 2,
+          last_round: 2,
+          rounds: [{round: 2, passed: true, reviewed: true}],
+          kept: true,
+          active: false,
+        },
+      ],
+    );
+
+    state = moveExperimentSelection(state, -1);
+    expect(state.experimentLog?.selectedActivity).toBe(true);
+
+    const opened = enterExperimentDrilldown(state);
+    expect(opened.hypothesisScope).toMatchObject({id: 'round-3', rounds: [3], source: 'round'});
+    expect(opened.selectedRound).toBe(3);
+  });
+
+  it('opens the first planning activity without a synthetic hypothesis row', () => {
+    const state = {
+      ...stateFor('orchestrator', 'round-3-pre'),
+      rounds: [{number: 3, status: 'active' as const}],
+    };
+
+    const opened = enterExperimentDrilldown(selectExperimentActivity(state));
+    expect(opened.hypothesisScope).toMatchObject({id: 'round-3', label: 'Round 3'});
+  });
+
+  it('does not duplicate the planning round as an unowned index item', () => {
+    const state = {
+      ...stateFor('orchestrator', 'round-3-plan'),
+      rounds: [{number: 3, status: 'active' as const}],
+    };
+
+    expect(unownedExperimentRounds(state)).toEqual([]);
+  });
+});
+
+describe('unowned rounds', () => {
+  it('opens an observed round and keeps its turns scoped to that round', () => {
+    const state = {
+      ...initialSessionState(),
+      rounds: [{number: 9, status: 'completed' as const}],
+      conversation: [
+        {id: 'r8', kind: 'assistant' as const, content: 'old', roundNumber: 8},
+        {id: 'r9', kind: 'assistant' as const, content: 'kept', roundNumber: 9},
+      ],
+    };
+    const opened = enterUnownedExperimentRound(state, 9);
+
+    expect(opened?.hypothesisScope).toMatchObject({id: 'round-9', source: 'round'});
+    expect(opened && visibleConversation(opened).map(entry => entry.content)).toEqual(['kept']);
+  });
+
+  it('does not turn an announced but unobserved round into historical work', () => {
+    const state = {...initialSessionState(), maxRounds: 9};
+    expect(enterUnownedExperimentRound(state, 9)).toBeNull();
+  });
+
+  it('does not assign invalid zero-based ranges to a hypothesis', () => {
+    const state = setExperiments(initialSessionState(), [
+      {
+        hypothesis_id: 'H-invalid',
+        identified: true,
+        first_round: 0,
+        last_round: 0,
+        rounds: [],
+        kept: false,
+        active: false,
+      },
+    ]);
+
+    expect(enterExperimentRound(state, 0)).toBeNull();
+  });
+});
 
 describe('session event model', () => {
   it('reduces semantic events into a presentation-neutral transcript', () => {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -118,9 +118,26 @@ export interface PhaseTodos {
 export interface ExperimentLogState {
   entries: HypothesisEntry[];
   selectedId: string | null;
+  /** The transient planning activity is selected instead of a recorded claim. */
+  selectedActivity?: boolean;
+  /** A recorded round that has no hypothesis entry is selected. */
+  selectedUnownedRound?: number | null;
   pending: boolean;
   error: string | null;
 }
+
+/** A planning phase that has not produced a hypothesis record yet. */
+export interface HypothesisPlanningActivity {
+  stage: 'pre' | 'profile' | 'plan';
+  roundNumber: number;
+  startedAt?: string;
+}
+
+/** Every selectable item in the hypotheses-first index. */
+export type ExperimentIndexItem =
+  | {kind: 'activity'; key: 'activity'; activity: HypothesisPlanningActivity}
+  | {kind: 'hypothesis'; key: string; entry: HypothesisEntry}
+  | {kind: 'round'; key: `round-${number}`; roundNumber: number};
 
 /**
  * The hypothesis whose rounds the operator opened. While this is set the
@@ -131,6 +148,8 @@ export interface HypothesisScope {
   id: string;
   label: string;
   rounds: number[];
+  /** A single recorded round not yet associated with a hypothesis. */
+  source?: 'hypothesis' | 'round';
 }
 
 /**
@@ -330,9 +349,27 @@ export function setExperiments(state: SessionState, entries: HypothesisEntry[]):
     log.selectedId !== null && keys.includes(log.selectedId)
       ? log.selectedId
       : (keys[entries.findIndex(entry => entry.active === true)] ?? keys[0] ?? null);
+  const unownedRounds = unownedExperimentRounds(state, entries);
+  const currentUnownedRound = log.selectedUnownedRound;
+  const selectedUnownedRound =
+    currentUnownedRound !== undefined &&
+    currentUnownedRound !== null &&
+    unownedRounds.includes(currentUnownedRound)
+      ? currentUnownedRound
+      : entries.length === 0
+        ? (unownedRounds[0] ?? null)
+        : null;
   return {
     ...state,
-    experimentLog: {...log, entries, selectedId, pending: false, error: null},
+    experimentLog: {
+      ...log,
+      entries,
+      selectedId,
+      selectedActivity: hypothesisPlanningActivity(state) !== null && log.selectedActivity === true,
+      selectedUnownedRound,
+      pending: false,
+      error: null,
+    },
   };
 }
 
@@ -344,16 +381,26 @@ export function failExperiments(state: SessionState, error: string): SessionStat
 
 export function moveExperimentSelection(state: SessionState, delta: number): SessionState {
   const log = state.experimentLog;
-  if (log === null || state.hypothesisScope !== null || log.entries.length === 0) return state;
-  const keys = log.entries.map(entryKey);
-  const current = log.selectedId === null ? -1 : keys.indexOf(log.selectedId);
-  // With nothing selected the first key lands on the first row rather than
-  // stepping past it: the table has a selection the moment it is used.
-  if (current === -1) {
-    return {...state, experimentLog: {...log, selectedId: keys[0] ?? null}};
+  if (log === null || state.hypothesisScope !== null) return state;
+  const items = experimentIndexItems(state);
+  if (items.length === 0) return state;
+  const selected = selectedExperimentIndexItem(state);
+  const current = selected === null ? -1 : items.findIndex(item => item.key === selected.key);
+  const index = current === -1 ? 0 : Math.min(items.length - 1, Math.max(0, current + delta));
+  return selectExperimentIndexItem(state, items[index]);
+}
+
+/** Selects the current planning work so Enter opens its live agent turns. */
+export function selectExperimentActivity(state: SessionState): SessionState {
+  const log = state.experimentLog;
+  if (
+    log === null ||
+    state.hypothesisScope !== null ||
+    hypothesisPlanningActivity(state) === null
+  ) {
+    return state;
   }
-  const index = Math.min(keys.length - 1, Math.max(0, current + delta));
-  return {...state, experimentLog: {...log, selectedId: keys[index] ?? null}};
+  return {...state, experimentLog: {...log, selectedActivity: true, selectedUnownedRound: null}};
 }
 
 /**
@@ -361,6 +408,21 @@ export function moveExperimentSelection(state: SessionState, delta: number): Ses
  * so leaving the trajectory lands the operator back on the same row.
  */
 export function enterExperimentDrilldown(state: SessionState): SessionState {
+  const activity = hypothesisPlanningActivity(state);
+  if (
+    activity !== null &&
+    (state.experimentLog?.selectedActivity === true ||
+      (state.experimentLog?.entries.length === 0 &&
+        (state.experimentLog?.selectedUnownedRound ?? null) === null))
+  ) {
+    return enterUnownedExperimentRound(state, activity.roundNumber) ?? state;
+  }
+  const selectedRound =
+    state.experimentLog?.selectedUnownedRound ??
+    (selectedExperiment(state) === null ? unownedExperimentRounds(state)[0] : undefined);
+  if (selectedRound !== undefined && selectedRound !== null) {
+    return enterUnownedExperimentRound(state, selectedRound) ?? state;
+  }
   const entry = selectedExperiment(state);
   if (entry === null || state.hypothesisScope !== null) return state;
   const rounds = scopeRounds(entry);
@@ -372,7 +434,12 @@ export function enterExperimentDrilldown(state: SessionState): SessionState {
     // the round view would leave the operator reading one view's answer beside
     // another view's transcript.
     layout: {right: null, focus: 'left'},
-    hypothesisScope: {id: entry.hypothesis_id, label: hypothesisLabel(entry), rounds},
+    hypothesisScope: {
+      id: entry.hypothesis_id,
+      label: hypothesisLabel(entry),
+      rounds,
+      source: 'hypothesis',
+    },
     // Land on the hypothesis's latest round rather than on "no round". The
     // round view is built around one round: the strip marks it, the agent graph
     // draws its phases, the transcript carries its turns. Leaving the round
@@ -412,6 +479,7 @@ export function enterExperimentRound(
       id: entry.hypothesis_id,
       label: hypothesisLabel(entry),
       rounds: scopeRounds(entry),
+      source: 'hypothesis',
     },
     selectedRound: roundNumber,
     selectedAgentKind: null,
@@ -424,6 +492,33 @@ export function enterExperimentRound(
   return scoped;
 }
 
+/**
+ * Opens a recorded round that is not currently indexed by a hypothesis. This
+ * is intentionally derived only from observed rounds, never from the planned
+ * round count, so an empty future round is not presented as historical work.
+ */
+export function enterUnownedExperimentRound(
+  state: SessionState,
+  roundNumber: number,
+): SessionState | null {
+  if (!state.rounds.some(round => round.number === roundNumber)) return null;
+  return {
+    ...state,
+    overlay: null,
+    chatOpen: false,
+    layout: {right: null, focus: 'left'},
+    hypothesisScope: {
+      id: `round-${roundNumber}`,
+      label: `Round ${roundNumber}`,
+      rounds: [roundNumber],
+      source: 'round',
+    },
+    selectedRound: roundNumber,
+    selectedAgentKind: null,
+    selectedEntryId: null,
+  };
+}
+
 function entryKeyFor(entries: HypothesisEntry[], entry: HypothesisEntry): string | null {
   const index = entries.indexOf(entry);
   return index === -1 ? null : entryKey(entry, index);
@@ -432,9 +527,13 @@ function entryKeyFor(entries: HypothesisEntry[], entry: HypothesisEntry): string
 function scopeRounds(entry: HypothesisEntry): number[] {
   const listed = (entry.rounds ?? []).map(round => round.round);
   if (listed.length > 0) return [...listed].sort((a, b) => a - b);
-  // An active hypothesis whose first round has not finished has no round
-  // records yet, but its opening round is still worth showing.
-  return entry.first_round > 0 ? [entry.first_round] : [];
+  // A record can summarize a continuation before its per-round outcomes have
+  // been persisted. Its declared range is still the server's ownership claim.
+  if (entry.first_round <= 0 || entry.last_round < entry.first_round) return [];
+  return Array.from(
+    {length: Math.max(0, entry.last_round - entry.first_round + 1)},
+    (_, index) => entry.first_round + index,
+  );
 }
 
 function hypothesisLabel(entry: HypothesisEntry): string {
@@ -450,6 +549,136 @@ export function selectedExperiment(state: SessionState): HypothesisEntry | null 
   if (log === null || log.selectedId === null) return null;
   const index = log.entries.map(entryKey).indexOf(log.selectedId);
   return index === -1 ? null : (log.entries[index] ?? null);
+}
+
+/**
+ * Observed numeric rounds not represented by any hypothesis record. Events
+ * without a numeric round label remain in the run transcript but cannot be
+ * honestly assigned an index row.
+ */
+export function unownedExperimentRounds(
+  state: SessionState,
+  entries: HypothesisEntry[] = state.experimentLog?.entries ?? [],
+): number[] {
+  const owned = new Set(entries.flatMap(scopeRounds));
+  const planningRound = hypothesisPlanningActivity(state)?.roundNumber;
+  return state.rounds
+    .filter(
+      round =>
+        !owned.has(round.number) && round.number !== planningRound && round.status !== 'planned',
+    )
+    .map(round => round.number);
+}
+
+/** The visual index: live planning, hypotheses, then observed unowned rounds. */
+export function experimentIndexItems(state: SessionState): ExperimentIndexItem[] {
+  const items: ExperimentIndexItem[] = [];
+  const activity = hypothesisPlanningActivity(state);
+  if (activity !== null) items.push({kind: 'activity', key: 'activity', activity});
+  for (const [index, entry] of (state.experimentLog?.entries ?? []).entries()) {
+    items.push({kind: 'hypothesis', key: entryKey(entry, index), entry});
+  }
+  for (const roundNumber of unownedExperimentRounds(state)) {
+    items.push({kind: 'round', key: `round-${roundNumber}`, roundNumber});
+  }
+  return items;
+}
+
+export function selectedExperimentIndexItem(state: SessionState): ExperimentIndexItem | null {
+  const log = state.experimentLog;
+  if (log === null) return null;
+  const items = experimentIndexItems(state);
+  if (log.selectedActivity === true) return items.find(item => item.kind === 'activity') ?? null;
+  if (log.selectedUnownedRound !== undefined && log.selectedUnownedRound !== null) {
+    return (
+      items.find(item => item.kind === 'round' && item.roundNumber === log.selectedUnownedRound) ??
+      null
+    );
+  }
+  return log.selectedId === null
+    ? null
+    : (items.find(item => item.kind === 'hypothesis' && item.key === log.selectedId) ?? null);
+}
+
+function selectExperimentIndexItem(
+  state: SessionState,
+  item: ExperimentIndexItem | undefined,
+): SessionState {
+  const log = state.experimentLog;
+  if (log === null || item === undefined) return state;
+  if (item.kind === 'activity')
+    return {...state, experimentLog: {...log, selectedActivity: true, selectedUnownedRound: null}};
+  if (item.kind === 'round') {
+    return {
+      ...state,
+      experimentLog: {...log, selectedActivity: false, selectedUnownedRound: item.roundNumber},
+    };
+  }
+  return {
+    ...state,
+    experimentLog: {
+      ...log,
+      selectedId: item.key,
+      selectedActivity: false,
+      selectedUnownedRound: null,
+    },
+  };
+}
+
+/**
+ * The loop publishes these labels before it writes a hypothesis record. Keep
+ * this derived from active, named phases: an old phase must never make the
+ * experiment log look live, and unrelated profiler work must not be presented
+ * as hypothesis planning.
+ */
+export function hypothesisPlanningActivity(state: SessionState): HypothesisPlanningActivity | null {
+  if (state.terminal || state.experimentLog === null) return null;
+  const phase = [...state.phases]
+    .reverse()
+    .find(
+      candidate =>
+        candidate.status === 'active' && planningStage(candidate.kind, candidate.roundLabel),
+    );
+  if (phase === undefined || phase.roundNumber === null) return null;
+  const roundNumber = phase.roundNumber;
+  if (state.experimentLog.entries.some(entry => scopeRounds(entry).includes(roundNumber)))
+    return null;
+  const stage = planningStage(phase.kind, phase.roundLabel);
+  if (stage === null) return null;
+  const startedAt = earliestPlanningStartedAt(state.phases, roundNumber);
+  return {
+    stage,
+    roundNumber,
+    ...(startedAt === undefined ? {} : {startedAt}),
+  };
+}
+
+function earliestPlanningStartedAt(phases: AgentPhase[], roundNumber: number): string | undefined {
+  const starts = phases
+    .filter(
+      phase => phase.roundNumber === roundNumber && planningStage(phase.kind, phase.roundLabel),
+    )
+    .flatMap(phase =>
+      phase.startedAt === undefined
+        ? []
+        : [[phase.startedAt, Date.parse(phase.startedAt)] as const],
+    )
+    .filter(([, timestamp]) => Number.isFinite(timestamp));
+  if (starts.length === 0) return undefined;
+  return starts.reduce((earliest, candidate) =>
+    candidate[1] < earliest[1] ? candidate : earliest,
+  )[0];
+}
+
+function planningStage(
+  agentKind: string,
+  roundLabel: string | null,
+): HypothesisPlanningActivity['stage'] | null {
+  if (roundLabel === null) return null;
+  if (agentKind === 'orchestrator' && /^round-\d+-pre$/.test(roundLabel)) return 'pre';
+  if (agentKind === 'profiler' && /^round-\d+-profiler$/.test(roundLabel)) return 'profile';
+  if (agentKind === 'orchestrator' && /^round-\d+-plan$/.test(roundLabel)) return 'plan';
+  return null;
 }
 
 export const PANE_TITLES: Record<PaneView, string> = {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -12,6 +12,7 @@ import {
   cyclePaneFocus,
   enterExperimentDrilldown,
   enterExperimentRound,
+  enterUnownedExperimentRound,
   focusPane,
   focusRound,
   initialSessionState,
@@ -26,6 +27,7 @@ import {
   type RoundFocus,
   type SessionState,
   selectAgent,
+  selectExperimentActivity,
   selectNextEntry,
   selectNextRound,
   selectNextTodo,
@@ -1926,6 +1928,129 @@ describe('theming', () => {
     // The log is the root view: nothing offers a way out of it.
     expect(frame).not.toContain('Esc');
   });
+
+  it('uses the empty hypotheses screen as a truthful planning kickoff', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 16});
+    const planningStartedAt = new Date(Date.now() - 65_000).toISOString();
+    const controller = new FakeController({
+      ...initialSessionState(),
+      status: 'running',
+      phases: [
+        {
+          kind: 'orchestrator',
+          status: 'active',
+          roundNumber: 1,
+          roundLabel: 'round-1-pre',
+          startedAt: planningStartedAt,
+        },
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    const frame = await frameAfter(testRenderer);
+    expect(frame).toContain('Planning Hypothesis 1 · Round 1');
+    expect(frame).toContain('Run kickoff');
+    expect(frame).toContain('Decide whether profiling is needed');
+    expect(frame).toContain('Profile if needed');
+    expect(frame).toContain('Form Hypothesis 1');
+    expect(frame).toMatch(/1m \d+s/);
+    expect(frame).toContain('This activity becomes');
+    expect(frame).not.toContain('No hypotheses have been recorded yet.');
+  });
+
+  it('keeps earlier unassociated rounds visible and openable during kickoff', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 18});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      status: 'running',
+      rounds: [{number: 1, status: 'completed'}],
+      phases: [{kind: 'orchestrator', status: 'active', roundNumber: 2, roundLabel: 'round-2-pre'}],
+      conversation: [
+        {id: 'r1', kind: 'assistant', content: 'earlier unassociated turn', roundNumber: 1},
+        {id: 'r2', kind: 'assistant', content: 'planning turn', roundNumber: 2},
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    const kickoff = await frameAfter(testRenderer);
+    expect(kickoff).toContain('Planning Hypothesis 1 · Round 2');
+    expect(kickoff).toContain('UNASSOCIATED ROUNDS');
+    expect(kickoff).toContain('Round 1 · recorded agent turns · no hypothesis');
+
+    testRenderer.mockInput.pressEnter();
+    const round = await frameAfter(testRenderer);
+    expect(round).toContain('earlier unassociated turn');
+    expect(round).not.toContain('planning turn');
+  });
+
+  it('indexes and opens recorded rounds that have no hypothesis', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 18});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      rounds: [{number: 7, status: 'completed'}],
+      conversation: [
+        {id: 'r6', kind: 'assistant', content: 'other round', roundNumber: 6},
+        {id: 'r7', kind: 'assistant', content: 'unindexed turn', roundNumber: 7},
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    expect(await frameAfter(testRenderer)).toContain(
+      'Round 7 · recorded agent turns · no hypothesis',
+    );
+
+    testRenderer.mockInput.pressEnter();
+    const detail = await frameAfter(testRenderer);
+    expect(detail).toContain('Round 7');
+    expect(detail).toContain('unindexed turn');
+    expect(detail).not.toContain('other round');
+
+    testRenderer.mockInput.pressKey('ESCAPE');
+    expect(await frameAfterEscape(testRenderer)).toContain('UNASSOCIATED ROUNDS');
+  });
+
+  it('pins later hypothesis planning above the existing history', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 18});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      status: 'running',
+      phases: [
+        {kind: 'orchestrator', status: 'active', roundNumber: 42, roundLabel: 'round-42-plan'},
+      ],
+    });
+    controller.experiments = [logEntry('H-07', 41, 41, {claim: 'batch the prefill step'})];
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    const frame = await frameAfter(testRenderer);
+    expect(frame).toContain('CURRENT ACTIVITY');
+    expect(frame).toContain('Planning Hypothesis 2 · forming it · Round 42');
+    expect(frame).toContain('H-07');
+    expect(frame).not.toContain('UNASSOCIATED ROUNDS');
+  });
+
+  it('labels an explicit profiler phase without claiming it will happen earlier', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 16});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      status: 'running',
+      phases: [
+        {kind: 'profiler', status: 'active', roundNumber: 1, roundLabel: 'round-1-profiler'},
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    expect(await frameAfter(testRenderer)).toContain('Profile before Hypothesis 1');
+  });
 });
 
 /**
@@ -2193,6 +2318,9 @@ class FakeController implements SessionController {
   moveExperimentSelection(delta: number): void {
     this.publish(moveExperimentSelection(this.state, delta));
   }
+  selectExperimentActivity(): void {
+    this.publish(selectExperimentActivity(this.state));
+  }
   enterExperimentDrilldown(): void {
     this.publish(enterExperimentDrilldown(this.state));
   }
@@ -2225,7 +2353,7 @@ class FakeController implements SessionController {
       return;
     }
     const scoped = enterExperimentRound(this.state, roundNumber);
-    if (scoped !== null) this.publish(scoped);
+    this.publish(scoped ?? enterUnownedExperimentRound(this.state, roundNumber) ?? this.state);
   }
   leaveExperimentDrilldown(): void {
     this.publish(leaveExperimentDrilldown(this.state));

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -383,6 +383,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
       conversation.destroy();
       roundStrip.destroy();
       agentMap.destroy();
+      experimentLog.destroy();
       root.destroyRecursively();
       markdownStyle.destroy();
     },

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -1,7 +1,17 @@
 import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
 import type {HypothesisEntry} from '../protocol.js';
 import type {SessionController} from '../session-controller.js';
-import {entryKey, experimentLogVisible, type SessionState} from '../session-model.js';
+import {
+  entryKey,
+  experimentIndexItems,
+  experimentLogVisible,
+  type HypothesisPlanningActivity,
+  hypothesisPlanningActivity,
+  type SessionState,
+  selectedExperimentIndexItem,
+  unownedExperimentRounds,
+} from '../session-model.js';
+import {elapsedLabel} from './previews.js';
 import type {Theme} from './theme.js';
 
 const MIN_BODY_WIDTH = 40;
@@ -49,6 +59,8 @@ export class ExperimentLogView {
   #renderedState: SessionState | null = null;
   #renderedWidth = 0;
   #availableWidth: number | null = null;
+  #elapsedTimer: ReturnType<typeof setInterval> | null = null;
+  #activeActivityLine: {text: TextRenderable; content: string; startedAt: string} | null = null;
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -124,6 +136,10 @@ export class ExperimentLogView {
     this.#renderedState = null;
   }
 
+  destroy(): void {
+    this.#stopElapsedTimer();
+  }
+
   render(state: SessionState): void {
     const log = experimentLogVisible(state) ? state.experimentLog : null;
     if (log === null) {
@@ -150,30 +166,124 @@ export class ExperimentLogView {
       this.#footerLine.content = '';
       return;
     }
+    const activity = hypothesisPlanningActivity(state);
     if (log.entries.length === 0) {
+      if (activity !== null) {
+        this.#renderKickoff(activity, state);
+        return;
+      }
+      if (unownedExperimentRounds(state).length > 0) {
+        this.#renderTable(
+          log.entries,
+          log.selectedId,
+          log.selectedUnownedRound ?? null,
+          null,
+          state,
+        );
+        return;
+      }
       this.#header.content = '';
       this.#line('No hypotheses have been recorded yet.', this.#theme.textSubtle);
       this.#footerLine.content = 'The first one appears once the orchestrator has planned a round.';
       return;
     }
-    this.#renderTable(log.entries, log.selectedId);
+    this.#renderTable(
+      log.entries,
+      log.selectedId,
+      log.selectedUnownedRound ?? null,
+      activity,
+      state,
+    );
   }
 
-  #renderTable(entries: HypothesisEntry[], selectedId: string | null): void {
+  #renderKickoff(activity: HypothesisPlanningActivity, state: SessionState): void {
+    const hypothesis = planningHypothesisLabel(0);
+    const selectedUnownedRound = state.experimentLog?.selectedUnownedRound ?? null;
+    const activitySelected = selectedUnownedRound === null;
+    this.#header.content = `Planning ${hypothesis} · Round ${activity.roundNumber}`;
+    this.#line('Run kickoff', this.#theme.textSubtle);
+    for (const stage of kickoffStages(activity.stage, hypothesis)) {
+      if (stage.current) {
+        this.#activityLine(`${stage.marker} ${stage.label}`, activity, activitySelected);
+      } else this.#line(`${stage.marker} ${stage.label}`, this.#theme.textSubtle);
+    }
+    this.#line(
+      'This activity becomes the first hypothesis when the orchestrator finishes its plan.',
+      this.#theme.textPrimary,
+    );
+    const unowned = unownedExperimentRounds(state);
+    if (unowned.length > 0) {
+      this.#line('UNASSOCIATED ROUNDS', this.#theme.textSubtle);
+      for (const [index, roundNumber] of unowned.entries()) {
+        this.#roundRow(roundNumber, selectedUnownedRound === roundNumber, index + 1);
+      }
+    }
+    this.#footerLine.content =
+      unowned.length === 0
+        ? 'The hypothesis list will appear here when planning completes.'
+        : '↑↓: select activity or recorded round · Enter: open';
+  }
+
+  #renderTable(
+    entries: HypothesisEntry[],
+    selectedId: string | null,
+    selectedUnownedRound: number | null,
+    activity: HypothesisPlanningActivity | null,
+    state: SessionState,
+  ): void {
     const columns = resolveColumns(this.#bodyWidth());
     const keys = entries.map(entryKey);
     const selected = selectedId === null ? 0 : Math.max(0, keys.indexOf(selectedId));
+    const activitySelected =
+      activity !== null && this.#renderedState?.experimentLog?.selectedActivity === true;
 
     this.#header.content = headerRow(columns);
+    const activityRows =
+      activity === null ? 0 : this.#renderActivity(activity, entries.length, activitySelected);
     for (const [index, entry] of entries.entries()) {
-      this.#row(entry, columns, keys[index] === selectedId, index);
+      this.#row(
+        entry,
+        columns,
+        keys[index] === selectedId && !activitySelected,
+        index,
+        activity === null ? 0 : 1,
+      );
+    }
+    const unowned = unownedExperimentRounds(state);
+    if (unowned.length > 0) {
+      this.#line('UNASSOCIATED ROUNDS', this.#theme.textSubtle);
+      for (const [index, roundNumber] of unowned.entries()) {
+        this.#roundRow(
+          roundNumber,
+          selectedUnownedRound === roundNumber,
+          (activity === null ? 0 : 1) + entries.length + index,
+        );
+      }
     }
     // Keyboard selection nudges the scroll position only when the row would
     // otherwise be off screen, so the wheel stays in charge the rest of the
     // time. Computed rather than deferred to scrollChildIntoView, which needs
     // a layout pass the freshly added rows have not had yet.
-    this.#followSelection(selected, entries.length);
-    const position = `${selected + 1}/${entries.length}`;
+    this.#followSelection(
+      this.#selectedRenderIndex(
+        entries.length,
+        activity,
+        selected,
+        activitySelected,
+        selectedUnownedRound,
+        unowned,
+      ),
+      entries.length + activityRows + (unowned.length === 0 ? 0 : unowned.length + 1),
+    );
+    const selectedUnownedIndex =
+      selectedUnownedRound === null ? -1 : unowned.indexOf(selectedUnownedRound);
+    const totalIndexItems = entries.length + unowned.length + (activity === null ? 0 : 1);
+    const positionIndex = activitySelected
+      ? 1
+      : selectedUnownedIndex === -1
+        ? selected + (activity === null ? 1 : 2)
+        : entries.length + selectedUnownedIndex + (activity === null ? 1 : 2);
+    const position = `${positionIndex}/${totalIndexItems}`;
     // The hint is the first thing to give up room; truncating it mid-word
     // reads as breakage rather than as a narrow terminal.
     const hint =
@@ -183,7 +293,28 @@ export class ExperimentLogView {
     this.#footerLine.content = `${position} · ${hint}`;
   }
 
-  #row(entry: HypothesisEntry, columns: Columns, isSelected: boolean, index: number): void {
+  #renderActivity(
+    activity: HypothesisPlanningActivity,
+    existingHypotheses: number,
+    selected: boolean,
+  ): number {
+    const hypothesis = planningHypothesisLabel(existingHypotheses);
+    this.#line('CURRENT ACTIVITY', this.#theme.textSubtle);
+    this.#activityLine(
+      `● Planning ${hypothesis} · ${planningStageSummary(activity.stage)} · Round ${activity.roundNumber}`,
+      activity,
+      selected,
+    );
+    return 2;
+  }
+
+  #row(
+    entry: HypothesisEntry,
+    columns: Columns,
+    isSelected: boolean,
+    index: number,
+    activityOffset: number,
+  ): void {
     const cells = entryCells(entry, columns);
     // The active hypothesis is called out on its own, so it stays visible
     // whether or not it happens to be the selected row.
@@ -197,7 +328,9 @@ export class ExperimentLogView {
       flexDirection: 'row',
       ...selection,
       onMouseUp: () => {
-        this.controller.moveExperimentSelection(index - this.#selectedIndex());
+        this.controller.moveExperimentSelection(
+          index + activityOffset - this.#selectedNavigationIndex(),
+        );
       },
     });
     // The outcome is its own renderable so the resolution can carry a color of
@@ -206,6 +339,26 @@ export class ExperimentLogView {
     row.add(this.#cell(cells.leading, base, isSelected));
     row.add(this.#cell(cells.outcome, outcomeColor(this.#theme, entry), isSelected));
     if (cells.trailing) row.add(this.#cell(cells.trailing, base, isSelected));
+    this.#rows.add(row);
+  }
+
+  #roundRow(roundNumber: number, isSelected: boolean, index: number): void {
+    const row = new BoxRenderable(this.renderer, {
+      id: `unowned-round-${roundNumber}`,
+      width: '100%',
+      height: 1,
+      flexShrink: 0,
+      ...(isSelected ? {backgroundColor: this.#theme.selectedSurface} : {}),
+      onMouseUp: () =>
+        this.controller.moveExperimentSelection(index - this.#selectedNavigationIndex()),
+    });
+    row.add(
+      this.#cell(
+        ` Round ${roundNumber} · recorded agent turns · no hypothesis`,
+        this.#theme.textPrimary,
+        isSelected,
+      ),
+    );
     this.#rows.add(row);
   }
 
@@ -234,22 +387,67 @@ export class ExperimentLogView {
     return Math.max(MIN_VIEWPORT_ROWS, this.renderer.terminalHeight - CHROME_ROWS);
   }
 
-  #selectedIndex(): number {
-    const log = this.#renderedState?.experimentLog;
-    if (log === undefined || log === null || log.selectedId === null) return 0;
-    return Math.max(0, log.entries.map(entryKey).indexOf(log.selectedId));
+  #selectedNavigationIndex(): number {
+    const state = this.#renderedState;
+    if (state === null) return 0;
+    const selected = selectedExperimentIndexItem(state);
+    const index =
+      selected === null
+        ? 0
+        : experimentIndexItems(state).findIndex(item => item.key === selected.key);
+    return Math.max(0, index);
   }
 
-  #line(content: string, fg: string): void {
-    this.#rows.add(
-      new TextRenderable(this.renderer, {
-        content,
-        fg,
-        width: '100%',
-        wrapMode: 'none',
-        truncate: true,
-      }),
-    );
+  #selectedRenderIndex(
+    entriesLength: number,
+    activity: HypothesisPlanningActivity | null,
+    selectedHypothesis: number,
+    activitySelected: boolean,
+    selectedUnownedRound: number | null,
+    unowned: number[],
+  ): number {
+    if (activitySelected) return 1;
+    const unownedIndex = selectedUnownedRound === null ? -1 : unowned.indexOf(selectedUnownedRound);
+    if (unownedIndex !== -1) return (activity === null ? 1 : 3) + entriesLength + unownedIndex;
+    return selectedHypothesis + (activity === null ? 0 : 2);
+  }
+
+  #activityLine(content: string, activity: HypothesisPlanningActivity, selected: boolean): void {
+    const row = new BoxRenderable(this.renderer, {
+      id: 'planning-activity',
+      width: '100%',
+      height: 1,
+      flexShrink: 0,
+      ...(selected ? {backgroundColor: this.#theme.selectedSurface} : {}),
+      onMouseUp: () => this.controller.selectExperimentActivity(),
+    });
+    const text = new TextRenderable(this.renderer, {
+      content,
+      fg: this.#theme.warning,
+      width: '100%',
+      ...(selected ? {bg: this.#theme.selectedSurface} : {}),
+      wrapMode: 'none',
+      truncate: true,
+    });
+    row.add(text);
+    this.#rows.add(row);
+    if (activity.startedAt === undefined || !Number.isFinite(Date.parse(activity.startedAt)))
+      return;
+    this.#activeActivityLine = {text, content, startedAt: activity.startedAt};
+    this.#refreshElapsedActivity();
+    this.#syncElapsedTimer();
+  }
+
+  #line(content: string, fg: string): TextRenderable {
+    const text = new TextRenderable(this.renderer, {
+      content,
+      fg,
+      width: '100%',
+      wrapMode: 'none',
+      truncate: true,
+    });
+    this.#rows.add(text);
+    return text;
   }
 
   #bodyWidth(): number {
@@ -258,10 +456,31 @@ export class ExperimentLogView {
   }
 
   #clear(): void {
+    this.#activeActivityLine = null;
+    this.#stopElapsedTimer();
     for (const child of [...this.#rows.getChildren()]) {
       this.#rows.remove(child);
       child.destroyRecursively();
     }
+  }
+
+  #syncElapsedTimer(): void {
+    if (this.#activeActivityLine === null || this.#elapsedTimer !== null) return;
+    this.#elapsedTimer = setInterval(() => this.#refreshElapsedActivity(), 1000);
+  }
+
+  #refreshElapsedActivity(): void {
+    const activity = this.#activeActivityLine;
+    if (activity === null) return;
+    const elapsed = Date.now() - Date.parse(activity.startedAt);
+    if (!Number.isFinite(elapsed)) return;
+    activity.text.content = `${activity.content} · ${elapsedLabel(elapsed)}`;
+  }
+
+  #stopElapsedTimer(): void {
+    if (this.#elapsedTimer === null) return;
+    clearInterval(this.#elapsedTimer);
+    this.#elapsedTimer = null;
   }
 }
 
@@ -379,6 +598,45 @@ export function formatMeasured(entry: HypothesisEntry): string {
   }
   if (typeof entry.perf_metric === 'number') return trimNumber(entry.perf_metric);
   return '—';
+}
+
+function planningHypothesisLabel(existingHypotheses: number): string {
+  return `Hypothesis ${existingHypotheses + 1}`;
+}
+
+function kickoffStages(
+  stage: HypothesisPlanningActivity['stage'],
+  hypothesis: string,
+): Array<{marker: string; label: string; current: boolean}> {
+  const current = (target: HypothesisPlanningActivity['stage']): boolean => stage === target;
+  const completed = (target: HypothesisPlanningActivity['stage']): boolean =>
+    (stage === 'profile' || stage === 'plan') && target === 'pre';
+  return [
+    {
+      marker: current('pre') ? '●' : completed('pre') ? '✓' : '○',
+      label: 'Decide whether profiling is needed',
+      current: current('pre'),
+    },
+    {
+      marker: current('profile') ? '●' : '○',
+      label: current('profile') ? `Profile before ${hypothesis}` : 'Profile if needed',
+      current: current('profile'),
+    },
+    {
+      marker: current('plan') ? '●' : '○',
+      label: `Form ${hypothesis}`,
+      current: current('plan'),
+    },
+  ];
+}
+
+function planningStageSummary(stage: HypothesisPlanningActivity['stage']): string {
+  const labels: Record<HypothesisPlanningActivity['stage'], string> = {
+    pre: 'deciding whether profiling is needed',
+    profile: 'profiling',
+    plan: 'forming it',
+  };
+  return labels[stage];
 }
 
 function rowId(index: number): string {


### PR DESCRIPTION
## Problem

Long VibeSys runs are organized around hypotheses, but the TUI previously landed on a per-round transcript and could leave planning work blank or make pre-hypothesis agent turns difficult to reach. Readers need a stable visual index that preserves access to every observed round while keeping hypotheses as the primary navigation unit.

## Solution

Make the hypothesis log the persistent landing screen and navigation root. Live planning is rendered as a selectable activity, hypotheses remain the primary grouped rows, and observed rounds without a hypothesis are shown as explicit fallback rows. Opening any row reuses the existing round trajectory and agent-session detail view, and Escape returns to the same index selection.

### Architecture

The session model derives one typed experiment index from protocol state. The experiment-log view renders that index and forwards selection to the controller. Detail views remain round-scoped consumers of the existing conversation and phase data, so no backend protocol changes are required.

```mermaid
flowchart LR
    E[Run events and experiment query] --> M[Session model index]
    M --> L[Hypothesis log]
    L -->|planning activity| R[Round trajectory]
    L -->|hypothesis| R
    L -->|unassociated round| R
    R --> A[Agent turns]
    R -->|Escape| L
```

## Verification

TypeScript checking, focused state/controller/rendering tests, Biome checks, and whitespace validation pass.

### Correctness properties

- Every observed round is reachable through either its hypothesis, the active planning row, or an explicit unassociated-round row.
- Planned but unobserved rounds are not presented as historical work.
- A planning round is not duplicated as an unassociated round.
- Invalid zero-based hypothesis ranges own no rounds.
- Selection and scroll state remain aligned with visible rows.
- Opening and leaving detail preserves the hypothesis-index navigation context.
- Backend event and protocol contracts are unchanged.

### Testing

- `pnpm --dir clients/tui check`
- `bun test --max-concurrency 1 clients/tui/src/session-model.test.ts clients/tui/src/session-controller.test.ts clients/tui/src/ui/app.test.ts clients/tui/src/ui/experiment-log.test.ts` (198 passed)
- `pnpm --dir clients/tui test` (345 passed before the final kickoff regression; the affected 198-test suite passed afterward)
- `pnpm exec biome check clients/tui/src/session-controller.test.ts clients/tui/src/session-controller.ts clients/tui/src/session-model.test.ts clients/tui/src/session-model.ts clients/tui/src/ui/app.test.ts clients/tui/src/ui/app.ts clients/tui/src/ui/experiment-log.ts`
- `git diff --check`
