### PR TITLE
Preserve streamed agent text spacing

### DIFF
--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -84,6 +84,8 @@ class AgentLogger(BaseCallbackHandler):
         invocation_id: str | None = None,
     ):
         self._streaming = False
+        self._external_text_streaming = False
+        self._external_text_ends_with_newline = False
         self._log_file = log_file
         self._call_count = 0
         self._model_name = model_name
@@ -448,17 +450,26 @@ class AgentLogger(BaseCallbackHandler):
             self._publish_usage()
 
     def log_text(self, text: str) -> None:
-        """Emit *text* as one complete assistant line.
-
-        Mirrors how ``on_llm_new_token`` streams tokens, but for complete
-        chunks of text emitted by the cli backend — hence the appended
-        newline, which the streaming path only adds at stream end.
-        """
+        """Emit one exact assistant-text delta from an external driver."""
         if not text:
             return
         status = self._status()
-        self._publish(text + "\n", "assistant", status=status)
-        self._log_line(f"{format_status_prefix(status)}{text}")
+        self._publish(text, "assistant", status=status)
+        if not self._external_text_streaming:
+            self._log_write(format_status_prefix(status))
+        self._log_write(text)
+        self._external_text_streaming = True
+        self._external_text_ends_with_newline = text.endswith("\n")
+
+    def end_text(self) -> None:
+        """Close the current external-driver assistant-text segment."""
+        if not self._external_text_streaming:
+            return
+        if not self._external_text_ends_with_newline:
+            self._publish("\n", "assistant")
+            self._log_write("\n")
+        self._external_text_streaming = False
+        self._external_text_ends_with_newline = False
 
     def log_tool_call(self, name: str, args: dict[str, Any]) -> None:
         """Emit a tool invocation the same way the deepagents path does."""

--- a/src/vibesys/agents/client.py
+++ b/src/vibesys/agents/client.py
@@ -77,7 +77,10 @@ class _LoggerObserver:
         """Render one normalized driver event."""
         if event.kind is AgentEventKind.TEXT:
             self._logger.log_text(event.text or "")
-        elif event.kind is AgentEventKind.THINKING:
+            return
+
+        self._logger.end_text()
+        if event.kind is AgentEventKind.THINKING:
             self._logger.on_thinking(event.text or "")
         elif event.kind is AgentEventKind.TOOL_CALL:
             tool = str(event.payload.get("tool", "unknown"))
@@ -95,6 +98,10 @@ class _LoggerObserver:
             )
         elif event.kind is AgentEventKind.USAGE and event.usage is not None:
             self._logger.update_usage(_usage_dict(event.usage))
+
+    def close(self) -> None:
+        """Close any assistant-text segment left open at turn completion."""
+        self._logger.end_text()
 
 
 def _usage_dict(usage: AgentUsage) -> dict[str, int | float | None]:
@@ -342,18 +349,21 @@ class AgentClient:
         reuse = kind != "chat" and (reuse_session if reuse_session is not None else True)
         cache_key = session_key or kind
         result: AgentTurnResult | None = None
+        observer = _LoggerObserver(logger)
         try:
             result = self.run(
                 session_spec=spec,
                 turn=turn,
                 session_key=cache_key if reuse else None,
-                observer=_LoggerObserver(logger),
+                observer=observer,
             )
         except Exception as exc:
+            observer.close()
             log_and_print(f"\n=== {label} ROUND ERROR: {round_label} ===", self._run_log_file)
             log_and_print(f"{type(exc).__name__}: {exc}", self._run_log_file)
             raise
         finally:
+            observer.close()
             # The result may not exist after a setup/turn failure. The empty
             # record preserves one audit row per attempted invocation.
             self._write_usage_record(

--- a/tests/agents/test_agent_client.py
+++ b/tests/agents/test_agent_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 from dataclasses import dataclass, field
 from datetime import timedelta
@@ -22,6 +23,8 @@ from vibesys.agents.contracts import (
     AgentUsage,
     SessionDisposition,
 )
+from vibesys.render.sink import output_sink
+from vibesys.server.events import AgentOutputChunkData, EventType
 
 
 class _Response(BaseModel):
@@ -35,6 +38,7 @@ class _FakeSession:
     close_calls: int = 0
     error: BaseException | None = None
     observers: list[AgentObserver | None] = field(default_factory=list)
+    events: list[AgentEvent] = field(default_factory=list)
 
     def run_turn(
         self,
@@ -43,6 +47,9 @@ class _FakeSession:
     ) -> AgentTurnResult:
         self.turns.append(request)
         self.observers.append(observer)
+        if observer is not None:
+            for event in self.events:
+                observer.on_event(event)
         if self.error is not None:
             raise self.error
         return self.results.pop(0)
@@ -146,6 +153,132 @@ def test_client_forwards_observer_to_session() -> None:
     assert session.observers == [observer]
     observer.on_event(AgentEvent(AgentEventKind.TEXT, text="chunk"))
     assert observer.events == [AgentEvent(AgentEventKind.TEXT, text="chunk")]
+
+
+def test_invoke_preserves_streamed_text_deltas_and_paragraphs(tmp_path: Path) -> None:
+    deltas = ["Tokens", " stay", " together.\n\n", "Next paragraph."]
+    session = _FakeSession(
+        results=[AgentTurnResult("".join(deltas))],
+        events=[AgentEvent(AgentEventKind.TEXT, text=delta) for delta in deltas],
+    )
+    log = io.StringIO()
+    client = AgentClient(_FakeDriver([session]), run_log_file=log)
+    seen = []
+    unsubscribe = output_sink().subscribe(seen.append)
+    try:
+        client.invoke_text(
+            kind="implementer",
+            workspace=tmp_path,
+            system_prompt="system",
+            user_prompt="user",
+            round_label="round-1",
+        )
+    finally:
+        unsubscribe()
+
+    assistant_chunks = [
+        event.data.content
+        for event in seen
+        if event.type is EventType.AGENT_OUTPUT_CHUNK
+        and isinstance(event.data, AgentOutputChunkData)
+        and event.data.channel == "assistant"
+        and event.agent_kind == "implementer"
+    ]
+    assert assistant_chunks == [*deltas, "\n"]
+    assert "Tokens stay together.\n\nNext paragraph.\n" in log.getvalue()
+
+
+def test_invoke_closes_text_before_tool_event(tmp_path: Path) -> None:
+    session = _FakeSession(
+        results=[AgentTurnResult("Done")],
+        events=[
+            AgentEvent(AgentEventKind.TEXT, text="Checking"),
+            AgentEvent(AgentEventKind.TEXT, text=" now"),
+            AgentEvent(AgentEventKind.TOOL_CALL, payload={"tool": "shell", "args": {}}),
+            AgentEvent(AgentEventKind.TEXT, text="Done"),
+        ],
+    )
+    client = AgentClient(_FakeDriver([session]))
+    seen = []
+    unsubscribe = output_sink().subscribe(seen.append)
+    try:
+        client.invoke_text(
+            kind="implementer",
+            workspace=tmp_path,
+            system_prompt="system",
+            user_prompt="user",
+            round_label="round-1",
+        )
+    finally:
+        unsubscribe()
+
+    relevant = [
+        (event.type, getattr(event.data, "content", None))
+        for event in seen
+        if event.type in (EventType.AGENT_OUTPUT_CHUNK, EventType.TOOL_CALL)
+        and event.agent_kind == "implementer"
+    ]
+    assert relevant == [
+        (EventType.AGENT_OUTPUT_CHUNK, "Checking"),
+        (EventType.AGENT_OUTPUT_CHUNK, " now"),
+        (EventType.AGENT_OUTPUT_CHUNK, "\n"),
+        (EventType.TOOL_CALL, None),
+        (EventType.AGENT_OUTPUT_CHUNK, "Done"),
+        (EventType.AGENT_OUTPUT_CHUNK, "\n"),
+    ]
+
+
+def test_invoke_closes_streamed_text_before_reporting_error(tmp_path: Path) -> None:
+    session = _FakeSession(
+        results=[],
+        error=ValueError("failed"),
+        events=[AgentEvent(AgentEventKind.TEXT, text="partial output")],
+    )
+    log = io.StringIO()
+    client = AgentClient(_FakeDriver([session]), run_log_file=log)
+
+    with pytest.raises(ValueError, match="failed"):
+        client.invoke_text(
+            kind="implementer",
+            workspace=tmp_path,
+            system_prompt="system",
+            user_prompt="user",
+            round_label="round-1",
+        )
+
+    assert "partial output\n\n=== Implementer ROUND ERROR" in log.getvalue()
+
+
+def test_invoke_preserves_terminal_newline_on_cancellation(tmp_path: Path) -> None:
+    session = _FakeSession(
+        results=[],
+        error=KeyboardInterrupt(),
+        events=[AgentEvent(AgentEventKind.TEXT, text="partial output\n")],
+    )
+    client = AgentClient(_FakeDriver([session]))
+    seen = []
+    unsubscribe = output_sink().subscribe(seen.append)
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            client.invoke_text(
+                kind="implementer",
+                workspace=tmp_path,
+                system_prompt="system",
+                user_prompt="user",
+                round_label="round-1",
+            )
+    finally:
+        unsubscribe()
+
+    assistant_chunks = [
+        event.data.content
+        for event in seen
+        if event.type is EventType.AGENT_OUTPUT_CHUNK
+        and isinstance(event.data, AgentOutputChunkData)
+        and event.data.channel == "assistant"
+        and event.agent_kind == "implementer"
+    ]
+    assert assistant_chunks == ["partial output\n"]
 
 
 def test_changed_session_spec_closes_and_replaces_cached_session() -> None:


### PR DESCRIPTION
## Problem

Omnigent emits assistant output as incremental text deltas, but the VibeSys logger treated each delta as a complete line and appended `\n`. In the TUI this rendered long agent turns one token per line, consuming excessive vertical space and making the transcript difficult to read.

Fixes #418.

## Solution

Preserve external-driver text deltas exactly. The logger now tracks an explicit external text segment, writes its status prefix once, and adds a final line terminator only when the segment does not already end with one. The observer closes the segment before tool, thinking, and usage events, and the agent client closes it on normal completion, failure, timeout, or cancellation.

### Architecture

Text normalization remains at the agent presentation boundary. Drivers emit provider-neutral deltas, the observer manages segment transitions, and downstream event consumers receive intentional text structure without knowing which driver produced it.

```mermaid
flowchart LR
    D[Agent driver text deltas] --> O[Logger observer]
    O --> L[AgentLogger text segment]
    L --> E[Presentation events]
    E --> T[TUI transcript]
    E --> H[Headless renderer]
```

## Verification

Focused agent-client, logger, and Omnigent-driver tests pass. Ruff lint, Ruff formatting, and whitespace validation pass. The regression uses the reproduced token-delta shape and verifies paragraphs, tool boundaries, errors, and Ctrl-C-style cancellation.

### Correctness properties

- Text chunk boundaries do not introduce displayed newlines.
- Newlines already present in driver text remain unchanged.
- Each text segment receives exactly one terminal newline when needed.
- Tool and other non-text events cannot be concatenated onto an open assistant line.
- Segment cleanup runs for success, ordinary errors, timeouts, and `BaseException` cancellation.
- Durable logs continue to flush each text delta immediately.
- Driver and presentation event contracts are unchanged.

### Testing

- `uv run pytest tests/agents/test_agent_client.py tests/agents/test_callbacks.py tests/agents/drivers/test_omnigent_driver.py -q` (103 passed)
- `uv run ruff check src/vibesys/agents/callbacks.py src/vibesys/agents/client.py tests/agents/test_agent_client.py`
- `uv run ruff format --check src/vibesys/agents/callbacks.py src/vibesys/agents/client.py tests/agents/test_agent_client.py`
- `git diff --check`
