### PR TITLE
Restore active hypotheses immediately after resume

### DIFF
--- a/clients/tui/src/generated/protocol.generated.ts
+++ b/clients/tui/src/generated/protocol.generated.ts
@@ -101,6 +101,7 @@ export type EventType =
   | "server_ready"
   | "configuration_failed"
   | "run_started"
+  | "experiments_changed"
   | "run_interrupted"
   | "chat"
   | "status_query"
@@ -135,6 +136,7 @@ export type Data =
       | ServerReadyData
       | RunStartedData
       | RunInterruptedData
+      | ExperimentsChangedData
       | ConfigurationFailedData
       | PhaseData
       | AgentOutputChunkData
@@ -168,16 +170,18 @@ export type MaxRounds = number;
 export type Kind6 = "run_interrupted";
 export type Reason = string;
 export type Signal = string | null;
-export type Kind7 = "configuration_failed";
+export type Kind7 = "experiments_changed";
+export type Reason1 = "project_attached" | "active_hypothesis_changed" | "round_persisted";
+export type Kind8 = "configuration_failed";
 export type Code1 = string;
 export type Stage = string;
 export type Message = string;
 export type Usage = string | null;
 export type ExitCode = number;
-export type Kind8 = "phase";
+export type Kind9 = "phase";
 export type Phase = string;
 export type Attempt = number | null;
-export type Kind9 = "agent_output_chunk";
+export type Kind10 = "agent_output_chunk";
 export type Channel = "assistant" | "analysis" | "tool" | "diagnostic" | "prompt";
 export type Content1 = string;
 export type Progress = string | null;
@@ -185,37 +189,37 @@ export type AgentLabel = string | null;
 export type ElapsedSeconds = number;
 export type InputTokens = number;
 export type ContextWindow = number | null;
-export type Kind10 = "subprocess_output";
+export type Kind11 = "subprocess_output";
 export type ProcessId = string;
 export type ProcessKind = string;
 export type Stream1 = "stdout" | "stderr";
 export type Content2 = string;
-export type Kind11 = "judge_result";
+export type Kind12 = "judge_result";
 export type Verdict = "pass" | "fail";
 export type Feedback = string;
 export type Attempt1 = number;
-export type Kind12 = "benchmark_result";
+export type Kind13 = "benchmark_result";
 export type Metric = string;
 export type Value = number;
 export type Unit = string;
-export type Kind13 = "round_finished";
+export type Kind14 = "round_finished";
 export type Attempts = number;
 export type JudgeVerdict = "pass" | "fail" | "skipped";
 export type PerfMetric = number | null;
 export type PerfUnit = string | null;
-export type Kind14 = "tool_call";
+export type Kind15 = "tool_call";
 export type Tool = string;
 export type CallId = string | null;
-export type Kind15 = "tool_result";
+export type Kind16 = "tool_result";
 export type Tool1 = string;
 export type CallId1 = string | null;
 export type Content3 = string;
 export type IsError = boolean;
-export type Kind16 = "todo_update";
+export type Kind17 = "todo_update";
 export type Content4 = string;
 export type Status2 = string;
 export type Todos = TodoItemData[];
-export type Kind17 = "usage_update";
+export type Kind18 = "usage_update";
 export type InputTokens1 = number;
 export type ContextWindow1 = number | null;
 export type Model = string | null;
@@ -250,6 +254,7 @@ export type PerfDeltaPct = number | null;
 export type Kept = boolean;
 export type Active = boolean;
 export type Experiments = HypothesisEntry[];
+export type ExperimentsReady = boolean | null;
 export type ServerMessage = SubscribedMessage | EventMessage | EventBatchMessage | ProtocolErrorMessage;
 export type Type10 = "subscribed";
 export type RequestId11 = string;
@@ -353,6 +358,7 @@ export interface Response {
   events?: Events;
   performance?: Performance;
   experiments?: Experiments;
+  experiments_ready?: ExperimentsReady;
 }
 /**
  * Structured, provider-neutral description of an operator diagnostic.
@@ -448,8 +454,13 @@ export interface RunInterruptedData {
   signal?: Signal;
   [k: string]: unknown;
 }
-export interface ConfigurationFailedData {
+export interface ExperimentsChangedData {
   kind?: Kind7;
+  reason: Reason1;
+  [k: string]: unknown;
+}
+export interface ConfigurationFailedData {
+  kind?: Kind8;
   code: Code1;
   stage: Stage;
   message: Message;
@@ -458,13 +469,13 @@ export interface ConfigurationFailedData {
   [k: string]: unknown;
 }
 export interface PhaseData {
-  kind?: Kind8;
+  kind?: Kind9;
   phase: Phase;
   attempt?: Attempt;
   [k: string]: unknown;
 }
 export interface AgentOutputChunkData {
-  kind?: Kind9;
+  kind?: Kind10;
   channel: Channel;
   content: Content1;
   status?: AgentStatusData | null;
@@ -486,7 +497,7 @@ export interface AgentStatusData {
   [k: string]: unknown;
 }
 export interface SubprocessOutputData {
-  kind?: Kind10;
+  kind?: Kind11;
   process_id: ProcessId;
   process_kind: ProcessKind;
   stream: Stream1;
@@ -494,21 +505,21 @@ export interface SubprocessOutputData {
   [k: string]: unknown;
 }
 export interface JudgeResultData {
-  kind?: Kind11;
+  kind?: Kind12;
   verdict: Verdict;
   feedback: Feedback;
   attempt: Attempt1;
   [k: string]: unknown;
 }
 export interface BenchmarkResultData {
-  kind?: Kind12;
+  kind?: Kind13;
   metric: Metric;
   value: Value;
   unit: Unit;
   [k: string]: unknown;
 }
 export interface RoundFinishedData {
-  kind?: Kind13;
+  kind?: Kind14;
   attempts: Attempts;
   judge_verdict: JudgeVerdict;
   perf_metric?: PerfMetric;
@@ -516,7 +527,7 @@ export interface RoundFinishedData {
   [k: string]: unknown;
 }
 export interface ToolCallData {
-  kind?: Kind14;
+  kind?: Kind15;
   tool: Tool;
   call_id?: CallId;
   args?: Args;
@@ -527,7 +538,7 @@ export interface Args {
   [k: string]: unknown;
 }
 export interface ToolResultData {
-  kind?: Kind15;
+  kind?: Kind16;
   tool: Tool1;
   call_id?: CallId1;
   content: Content3;
@@ -535,7 +546,7 @@ export interface ToolResultData {
   [k: string]: unknown;
 }
 export interface TodoUpdateData {
-  kind?: Kind16;
+  kind?: Kind17;
   todos?: Todos;
   [k: string]: unknown;
 }
@@ -545,7 +556,7 @@ export interface TodoItemData {
   [k: string]: unknown;
 }
 export interface UsageUpdateData {
-  kind?: Kind17;
+  kind?: Kind18;
   input_tokens: InputTokens1;
   context_window?: ContextWindow1;
   model?: Model;

--- a/clients/tui/src/generated/protocol.schema.json
+++ b/clients/tui/src/generated/protocol.schema.json
@@ -456,6 +456,7 @@
         "server_ready",
         "configuration_failed",
         "run_started",
+        "experiments_changed",
         "run_interrupted",
         "chat",
         "status_query",
@@ -548,6 +549,30 @@
         }
       },
       "title": "ExperimentQuery",
+      "type": "object"
+    },
+    "ExperimentsChangedData": {
+      "properties": {
+        "kind": {
+          "const": "experiments_changed",
+          "default": "experiments_changed",
+          "title": "Kind",
+          "type": "string"
+        },
+        "reason": {
+          "enum": [
+            "project_attached",
+            "active_hypothesis_changed",
+            "round_persisted"
+          ],
+          "title": "Reason",
+          "type": "string"
+        }
+      },
+      "required": [
+        "reason"
+      ],
+      "title": "ExperimentsChangedData",
       "type": "object"
     },
     "HistoryQuery": {
@@ -1195,6 +1220,18 @@
           },
           "title": "Experiments",
           "type": "array"
+        },
+        "experiments_ready": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Experiments Ready"
         }
       },
       "required": [
@@ -1385,6 +1422,7 @@
                   "benchmark_result": "#/$defs/BenchmarkResultData",
                   "chat": "#/$defs/ChatData",
                   "configuration_failed": "#/$defs/ConfigurationFailedData",
+                  "experiments_changed": "#/$defs/ExperimentsChangedData",
                   "invocation_finished": "#/$defs/InvocationFinishedData",
                   "invocation_started": "#/$defs/InvocationStartedData",
                   "judge_result": "#/$defs/JudgeResultData",
@@ -1423,6 +1461,9 @@
                 },
                 {
                   "$ref": "#/$defs/RunInterruptedData"
+                },
+                {
+                  "$ref": "#/$defs/ExperimentsChangedData"
                 },
                 {
                   "$ref": "#/$defs/ConfigurationFailedData"

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -500,7 +500,7 @@ describe('session controller', () => {
     expect(controller.state.experimentLog?.entries).toHaveLength(1);
   });
 
-  it('refetches the log when a round finishes and keeps the selected row', async () => {
+  it('refetches the log when experiments change and keeps the selected row', async () => {
     const transport = new FakeTransport();
     transport.experiments = [
       entry('H-01', 1, 1, {resolved_outcome: 'proven'}),
@@ -518,7 +518,7 @@ describe('session controller', () => {
       entry('H-02', 2, 3, {resolved_outcome: 'rejected'}),
       entry('H-03', 4, 4, {active: true}),
     ];
-    transport.emit({type: 'event', event: event(9, 'round_finished')});
+    transport.emit({type: 'event', event: event(9, 'experiments_changed')});
     await Promise.resolve();
     await Promise.resolve();
 
@@ -536,6 +536,8 @@ describe('session controller', () => {
 
     transport.emit({type: 'event', event: event(1, 'agent_output_chunk', 'noise\n')});
     transport.emit({type: 'event', event: event(2, 'tool_call')});
+    transport.emit({type: 'event', event: event(3, 'phase_finished')});
+    transport.emit({type: 'event', event: event(4, 'round_finished')});
     await Promise.resolve();
 
     expect(transport.requests).toHaveLength(before);
@@ -607,7 +609,26 @@ describe('session controller', () => {
     expect(controller.state.experimentLog?.selectedId).toBe('H-01');
   });
 
-  it('coalesces refetches when a burst of phase events lands', async () => {
+  it('keeps bootstrap pending until attached experiments become ready', async () => {
+    const transport = new FakeTransport();
+    transport.experimentsReady = false;
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+
+    expect(controller.state.experimentLog?.pending).toBe(true);
+    expect(controller.state.experimentLog?.entries).toEqual([]);
+
+    transport.experiments = [entry('H-resumed', 1, 1, {active: true})];
+    transport.experimentsReady = true;
+    transport.emit({type: 'event', event: event(1, 'experiments_changed')});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(controller.state.experimentLog?.pending).toBe(false);
+    expect(controller.state.experimentLog?.selectedId).toBe('H-resumed');
+  });
+
+  it('coalesces refetches when a burst of experiment changes lands', async () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
     await controller.start();
@@ -615,13 +636,35 @@ describe('session controller', () => {
 
     transport.emit({
       type: 'event_batch',
-      events: [event(1, 'phase_finished'), event(2, 'phase_finished'), event(3, 'round_finished')],
+      events: [event(1, 'experiments_changed'), event(2, 'experiments_changed')],
     });
-    transport.emit({type: 'event', event: event(4, 'phase_finished')});
     await Promise.resolve();
     await Promise.resolve();
 
     expect(transport.requests.length - before).toBe(1);
+  });
+
+  it('refetches again when experiments change during an in-flight fetch', async () => {
+    const transport = new DeferredExperimentsTransport();
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+
+    transport.emit(event(1, 'experiments_changed'));
+    expect(transport.experimentRequests).toBe(2);
+
+    transport.emit(event(2, 'experiments_changed'));
+    transport.emit(event(3, 'experiments_changed'));
+    transport.resolveExperiment([entry('H-stale', 1, 1, {active: true})]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(transport.experimentRequests).toBe(3);
+    transport.resolveExperiment([entry('H-current', 1, 2, {resolved_outcome: 'proven'})]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(controller.state.experimentLog?.selectedId).toBe('H-current');
+    expect(transport.experimentRequests).toBe(3);
   });
 
   it('opens the selected hypothesis with /open-round', async () => {
@@ -863,6 +906,7 @@ class FakeTransport implements SupervisionTransport {
   closed = false;
   /** Mutable so a test can change what a refetch returns mid-run. */
   experiments: NonNullable<ProtocolResponse['experiments']> = [];
+  experimentsReady = true;
   readonly requests: RequestInput[] = [];
   #message: ((message: ServerMessage) => void) | null = null;
   #disconnect: ((error: Error) => void) | null = null;
@@ -885,6 +929,7 @@ class FakeTransport implements SupervisionTransport {
       events: this.responseEvents,
       performance: this.responsePerformance,
       experiments: this.experiments,
+      experiments_ready: this.experimentsReady,
       ...(input.type === 'query.chat'
         ? {
             chat: this.responseChat ?? {
@@ -919,6 +964,63 @@ class FakeTransport implements SupervisionTransport {
 
   disconnect(error: Error): void {
     this.#disconnect?.(error);
+  }
+}
+
+class DeferredExperimentsTransport implements SupervisionTransport {
+  experimentRequests = 0;
+  readonly #pending: Array<(response: ProtocolResponse) => void> = [];
+  #message: ((message: ServerMessage) => void) | null = null;
+
+  request(input: RequestInput): Promise<ProtocolResponse> {
+    const base = {
+      protocol_version: 1 as const,
+      request_id: 'request',
+      timestamp: '2026-01-01T00:00:00Z',
+      ok: true,
+    };
+    if (input.type === 'query.snapshot') {
+      return Promise.resolve({
+        ...base,
+        snapshot: {run_id: 'run', status: 'running', sequence: 0},
+      });
+    }
+    if (input.type !== 'query.experiments') return Promise.resolve(base);
+    this.experimentRequests += 1;
+    if (this.experimentRequests === 1) {
+      return Promise.resolve({...base, experiments: [], experiments_ready: true});
+    }
+    return new Promise(resolve => this.#pending.push(resolve));
+  }
+
+  resolveExperiment(experiments: NonNullable<ProtocolResponse['experiments']>): void {
+    const resolve = this.#pending.shift();
+    if (!resolve) throw new Error('No pending experiment request');
+    resolve({
+      protocol_version: 1,
+      request_id: 'request',
+      timestamp: '2026-01-01T00:00:00Z',
+      ok: true,
+      experiments,
+      experiments_ready: true,
+    });
+  }
+
+  subscribe(
+    _afterSequence: number,
+    onMessage: (message: ServerMessage) => void,
+    _onDisconnect: (error: Error) => void,
+  ): Promise<EventSubscription> {
+    this.#message = onMessage;
+    return Promise.resolve({close: async () => undefined});
+  }
+
+  emit(runEvent: RunEvent): void {
+    this.#message?.({type: 'event', event: runEvent});
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
   }
 }
 

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -112,8 +112,9 @@ export class SocketSessionController implements SessionController {
   #chatMessageId = 0;
   readonly #chatQueue: Array<{id: string; text: string}> = [];
   #chatDrain: Promise<void> | null = null;
-  /** Single-flight guard: phase events arrive faster than the fetch settles. */
+  /** Single-flight guard for semantic experiment-log invalidations. */
   #experimentFetch: Promise<void> | null = null;
+  #experimentRefreshPending = false;
   #paneFetch: Promise<void> | null = null;
   #streamProtocolError = false;
 
@@ -377,6 +378,10 @@ export class SocketSessionController implements SessionController {
     if (this.#experimentFetch !== null) return this.#experimentFetch;
     const fetch = this.#requestExperiments().finally(() => {
       this.#experimentFetch = null;
+      if (this.#experimentRefreshPending) {
+        this.#experimentRefreshPending = false;
+        void this.#loadExperiments();
+      }
     });
     this.#experimentFetch = fetch;
     return fetch;
@@ -385,6 +390,7 @@ export class SocketSessionController implements SessionController {
   async #requestExperiments(): Promise<void> {
     try {
       const response = await this.client.request({type: 'query.experiments'});
+      if (response.experiments_ready === false) return;
       this.#setState(setExperiments(this.#state, response.experiments ?? []));
     } catch (error) {
       const message = errorMessage(error);
@@ -555,17 +561,15 @@ export class SocketSessionController implements SessionController {
   }
 
   /**
-   * A hypothesis appears when the orchestrator phase finishes writing its plan
-   * and resolves when the round finishes, so those two events bound every
-   * change to the log. Refetching on them keeps the landing view live without
-   * polling; the single-flight guard absorbs bursts.
+   * The backend publishes this semantic event after the canonical project is
+   * attached and whenever persisted hypothesis state changes. The client does
+   * not infer storage readiness or mutations from execution phases.
    */
   #refreshExperimentsFor(events: readonly RunEvent[]): void {
     if (this.#state.experimentLog === null) return;
-    const relevant = events.some(
-      event => event.type === 'round_finished' || event.type === 'phase_finished',
-    );
+    const relevant = events.some(event => event.type === 'experiments_changed');
     if (!relevant) return;
+    if (this.#experimentFetch !== null) this.#experimentRefreshPending = true;
     void this.#loadExperiments();
   }
 

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -625,9 +625,6 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
             project_state.initialization_snapshot(run_id),
         )
 
-    if supervisor is not None:
-        supervisor.attach(log_dir, project=project, run_id=run_id)
-
     if project_configuration.outer_loop == "agent":
         if active_state_model_type is None:
             raise ValueError("agent runs require an active state model type")  # noqa: TRY003  # tracked: #288
@@ -641,6 +638,18 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
             recovery = round_transaction_coordinator.recover()
             if recovery is not RoundRecoveryOutcome.NO_TRANSACTION:
                 logger.lprint(f"[project] recovered round transaction: {recovery.value}")
+
+    if supervisor is not None:
+        supervisor.attach(log_dir, project=project, run_id=run_id)
+        from vibesys.server.events import (  # noqa: PLC0415  # tracked: #288
+            EventType,
+            ExperimentsChangedData,
+        )
+
+        supervisor.record(
+            EventType.EXPERIMENTS_CHANGED,
+            data=ExperimentsChangedData(reason="project_attached"),
+        )
 
     project_ref_dir = (
         project_root / task_root.relative_to(input_dir) / "reference"

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -63,6 +63,7 @@ from vibesys.server.events import (
     BenchmarkResultData,
     EventStatus,
     EventType,
+    ExperimentsChangedData,
     JudgeResultData,
     RoundFinishedData,
     SubprocessOutputData,
@@ -2447,6 +2448,11 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         parent_commit=ctx.git.current_sha(),
                     )
                     agent_state.save_active(active_hypothesis)
+                    if ctx.supervisor is not None:
+                        ctx.supervisor.record(
+                            EventType.EXPERIMENTS_CHANGED,
+                            data=ExperimentsChangedData(reason="active_hypothesis_changed"),
+                        )
                 else:
                     plan = active_hypothesis.plan
                     issue_board.append_hypothesis_continuation(
@@ -3252,6 +3258,10 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                 agent_state.apply_active_transition(active_transition)
                 ctx.persist_completed_round()
                 if ctx.supervisor is not None:
+                    ctx.supervisor.record(
+                        EventType.EXPERIMENTS_CHANGED,
+                        data=ExperimentsChangedData(reason="round_persisted"),
+                    )
                     ctx.supervisor.record(
                         EventType.ROUND_FINISHED,
                         status=(

--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -20,6 +20,7 @@ class EventType(StrEnum):  # noqa: D101  # tracked: #288
     SERVER_READY = "server_ready"
     CONFIGURATION_FAILED = "configuration_failed"
     RUN_STARTED = "run_started"
+    EXPERIMENTS_CHANGED = "experiments_changed"
     RUN_INTERRUPTED = "run_interrupted"
     CHAT = "chat"
     STATUS_QUERY = "status_query"
@@ -98,6 +99,11 @@ class RunInterruptedData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["run_interrupted"] = "run_interrupted"
     reason: str
     signal: str | None = None
+
+
+class ExperimentsChangedData(BaseModel):  # noqa: D101  # tracked: #288
+    kind: Literal["experiments_changed"] = "experiments_changed"
+    reason: Literal["project_attached", "active_hypothesis_changed", "round_persisted"]
 
 
 class ConfigurationFailedData(BaseModel):  # noqa: D101  # tracked: #288
@@ -211,6 +217,7 @@ EventData = Annotated[
     | ServerReadyData
     | RunStartedData
     | RunInterruptedData
+    | ExperimentsChangedData
     | ConfigurationFailedData
     | PhaseData
     | AgentOutputChunkData

--- a/src/vibesys/server/protocol.py
+++ b/src/vibesys/server/protocol.py
@@ -177,6 +177,10 @@ class Response(ProtocolModel):  # noqa: D101  # tracked: #288
     events: list[RunEvent] = Field(default_factory=list)
     performance: list[PerformanceRound] = Field(default_factory=list)
     experiments: list[HypothesisEntry] = Field(default_factory=list)
+    # False means canonical project/run state is not attached yet. Keeping the
+    # readiness marker separate preserves the protocol-v1 list contract while
+    # distinguishing bootstrap from an authoritative empty experiment log.
+    experiments_ready: bool | None = None
 
     @classmethod
     def from_exception(

--- a/src/vibesys/server/service.py
+++ b/src/vibesys/server/service.py
@@ -70,7 +70,13 @@ class SupervisionService:
             return Response(request_id=request.request_id, performance=self.performance_rounds())
         if isinstance(request, ExperimentQuery):
             self.supervisor.record(EventType.STATUS_QUERY, "/experiments")
-            return Response(request_id=request.request_id, experiments=self.experiments())
+            ready = self.supervisor.project_run is not None
+            experiments = self.experiments() if ready else []
+            return Response(
+                request_id=request.request_id,
+                experiments=experiments,
+                experiments_ready=ready,
+            )
         if isinstance(request, SnapshotQuery):
             return Response(request_id=request.request_id, snapshot=self.snapshot())
         if isinstance(request, EventsQuery):

--- a/tests/server/test_experiments.py
+++ b/tests/server/test_experiments.py
@@ -258,16 +258,31 @@ def test_service_reads_rounds_and_the_active_plan_through_the_store(tmp_path: Pa
 
     assert [entry.hypothesis_id for entry in response.experiments] == ["H-01", "H-02"]
     assert response.experiments[1].active is True
+    assert response.experiments_ready is True
     recorded = [event.type for event in supervisor.read_events()]
     assert EventType.STATUS_QUERY.value in recorded
 
 
 def test_service_returns_nothing_before_a_run_is_attached(tmp_path: Path) -> None:
-    """The client queries the log before the run context exists; that is not an error."""
+    """Bootstrap is distinct from an attached run with an empty log."""
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path / "logs")
 
-    assert SupervisionService(supervisor).experiments() == []
+    response = SupervisionService(supervisor).execute(ExperimentQuery())
+
+    assert response.experiments == []
+    assert response.experiments_ready is False
+
+
+def test_service_returns_authoritative_empty_log_after_attach(tmp_path: Path) -> None:
+    project, run_id = _project_run(tmp_path / "project")
+    supervisor = RunSupervisor()
+    supervisor.attach(project.state.log_directory(run_id), project=project, run_id=run_id)
+
+    response = SupervisionService(supervisor).execute(ExperimentQuery())
+
+    assert response.experiments == []
+    assert response.experiments_ready is True
 
 
 def test_service_returns_nothing_for_a_non_agent_outer_loop(tmp_path: Path) -> None:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -15,6 +15,8 @@ from vibesys.loops.agent.model import ActiveHypothesis
 from vibesys.profilers import ProfilerKind, ProfilerPreflightResult
 from vibesys.run import RunLogger, RunPaths, RunStateNamespace
 from vibesys.sandbox.run_environment import RunEnvironmentSpec
+from vibesys.server import EventType, RunSupervisor
+from vibesys.server.registry import REGISTRY
 from vs_loop_state import PlainLoopCursor
 from vs_project import AgentRunConfiguration, Project, RunEnvironmentRecord
 
@@ -209,6 +211,30 @@ def test_direct_run_uses_one_project_root_and_canonical_state(tmp_path):  # noqa
     assert manifest.branch == f"vibesys-runs/{ctx.run_id}"
     assert _git(project, "branch", "--show-current") == manifest.branch
     assert _git(project, "status", "--porcelain") == ""
+
+
+def test_run_context_announces_canonical_experiment_state(tmp_path):  # noqa: ANN001, ANN201
+    project = tmp_path / "queue"
+    evaluator = _write_project(project)
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path / "bootstrap")
+    REGISTRY.activate(supervisor)
+    try:
+        with _create_context(project, evaluator=evaluator) as ctx:
+            changed = [
+                event
+                for event in supervisor.read_events()
+                if event.type is EventType.EXPERIMENTS_CHANGED
+            ]
+
+            assert supervisor.project_run is not None
+            assert supervisor.project_run.run_id == ctx.run_id
+            assert len(changed) == 1
+            assert changed[0].data is not None
+            assert changed[0].data.kind == "experiments_changed"
+            assert changed[0].data.reason == "project_attached"
+    finally:
+        REGISTRY.deactivate(supervisor)
 
 
 def test_repository_task_exposes_its_actual_reference_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Closes #420.

The TUI queries the experiment log before subscribing, while the backend waits for a subscriber before attaching canonical project/run state. The bootstrap query therefore returned an authoritative-looking empty list. On resume, the agent loop can skip hypothesis planning and enter a long implementer turn, leaving the persisted active hypothesis absent from the primary screen.

The client also inferred experiment-log mutations from phase and round lifecycle events. That duplicated backend semantics and could race persistence.

## Solution

Keep the protocol-v1 experiment list contract and add an `experiments_ready` marker. Before canonical state is attached, the backend returns `experiments_ready: false`; after attachment, an empty list is authoritative.

Add a typed, replayable `experiments_changed` event. The backend emits it only after:

- interrupted round recovery and project/run attachment,
- a new active hypothesis is persisted,
- a completed round and its active-state transition are persisted.

The TUI stays in its loading state while the backend is not ready and refetches only on this semantic event. If an invalidation arrives during an in-flight query, it schedules one trailing refetch so the last persisted state cannot be lost.

### Architecture

```mermaid
sequenceDiagram
    participant TUI
    participant Service as Python service
    participant State as Project state
    TUI->>Service: query.experiments
    Service-->>TUI: experiments_ready=false, experiments=[]
    TUI->>Service: subscribe
    Service->>State: recover interrupted transaction
    Service->>State: attach canonical project/run
    Service-->>TUI: experiments_changed
    TUI->>Service: query.experiments
    Service->>State: load rounds and active hypothesis
    Service-->>TUI: experiments_ready=true, authoritative entries
```

Python owns persistence, readiness, and hypothesis-log invalidation. The TUI owns loading and rendering only.

## Verification

Focused backend, context, protocol-schema, and full TUI suites pass. Python and TypeScript format, lint, type, and generated binding checks pass.

### Correctness properties

- Bootstrap unavailability is distinct from a genuinely empty attached run.
- Readiness is not published until interrupted round recovery completes.
- The active hypothesis is queryable before a resumed agent phase finishes.
- Experiment-log invalidations follow persisted state changes, not presentation phases.
- In-flight refetches cannot drop the final invalidation.
- Protocol v1 retains the existing `experiments` array shape; readiness is additive.
- The pre-subscribe query never blocks, so startup cannot deadlock.

### Testing

- `uv run pytest tests/server/test_experiments.py tests/test_context.py tests/test_tui.py -q` (75 passed)
- `pnpm --dir clients/tui test` (331 passed)
- `pnpm --dir clients/tui check`
- `pnpm check:ts`
- `pnpm --dir clients/tui generate:protocol`
- `./scripts/check_format.sh`
- `./scripts/check_lint.sh`
- `git diff --check`
