### PR TITLE
Show authoritative agent execution activity in the TUI

### DIFF
--- a/clients/tui/src/generated/protocol.generated.ts
+++ b/clients/tui/src/generated/protocol.generated.ts
@@ -92,6 +92,18 @@ export type Sequence = number;
 export type Status1 = string;
 export type AgentKind = string | null;
 export type RoundLabel = string | null;
+export type ExecutionId = string;
+export type AgentKind1 = string;
+export type RoundLabel1 = string;
+export type Stage = string;
+export type Attempt = number | null;
+export type Assignment = string;
+export type StartedAt = string;
+export type Kind = "agent_execution_activity_changed";
+export type Mode1 = "thinking" | "responding" | "tool" | "waiting";
+export type Summary1 = string;
+export type Tool = string | null;
+export type ActiveExecutions = ActiveAgentExecution[];
 export type ProtocolVersion12 = 1;
 export type Sequence1 = number;
 export type RunId1 = string;
@@ -108,6 +120,9 @@ export type EventType =
   | "control"
   | "invocation_started"
   | "invocation_finished"
+  | "agent_execution_started"
+  | "agent_execution_activity_changed"
+  | "agent_execution_finished"
   | "phase_started"
   | "phase_finished"
   | "agent_output_chunk"
@@ -123,15 +138,20 @@ export type EventType =
   | "todo_update"
   | "usage_update";
 export type Text2 = string;
-export type EventStatus = "active" | "answered" | "pending" | "consumed" | "completed" | "failed";
-export type RoundLabel1 = string | null;
-export type AgentKind1 = string | null;
+export type EventStatus =
+  "active" | "answered" | "pending" | "consumed" | "completed" | "failed" | "cancelled" | "interrupted";
+export type RoundLabel2 = string | null;
+export type AgentKind2 = string | null;
 export type InvocationId = string | null;
+export type ExecutionId1 = string | null;
 export type Data =
   | (
       | ChatData
       | InvocationStartedData
       | InvocationFinishedData
+      | AgentExecutionStartedData
+      | AgentExecutionActivityData
+      | AgentExecutionFinishedData
       | OutputData
       | ServerReadyData
       | RunStartedData
@@ -150,38 +170,45 @@ export type Data =
       | UsageUpdateData
     )
   | null;
-export type Kind = "chat";
+export type Kind1 = "chat";
 export type Answer1 = string;
-export type Kind1 = "invocation_started";
+export type Kind2 = "invocation_started";
 export type SystemPrompt = string;
 export type UserPrompt = string;
-export type Kind2 = "invocation_finished";
+export type Kind3 = "invocation_finished";
 export type Error1 = string | null;
-export type Kind3 = "output";
+export type Kind4 = "agent_execution_started";
+export type Stage1 = string;
+export type Attempt1 = number | null;
+export type SystemPrompt1 = string;
+export type UserPrompt1 = string;
+export type Kind5 = "agent_execution_finished";
+export type Error2 = string | null;
+export type Kind6 = "output";
 export type Stream = "stdout" | "stderr";
 export type Source = string;
 export type Content = string;
-export type Kind4 = "server_ready";
+export type Kind7 = "server_ready";
 export type SocketProtocol = "jsonl";
-export type Kind5 = "run_started";
+export type Kind8 = "run_started";
 export type OuterLoop = string;
 export type Input = string;
 export type MaxRounds = number;
-export type Kind6 = "run_interrupted";
+export type Kind9 = "run_interrupted";
 export type Reason = string;
 export type Signal = string | null;
-export type Kind7 = "experiments_changed";
+export type Kind10 = "experiments_changed";
 export type Reason1 = "project_attached" | "active_hypothesis_changed" | "round_persisted";
-export type Kind8 = "configuration_failed";
+export type Kind11 = "configuration_failed";
 export type Code1 = string;
-export type Stage = string;
+export type Stage2 = string;
 export type Message = string;
 export type Usage = string | null;
 export type ExitCode = number;
-export type Kind9 = "phase";
+export type Kind12 = "phase";
 export type Phase = string;
-export type Attempt = number | null;
-export type Kind10 = "agent_output_chunk";
+export type Attempt2 = number | null;
+export type Kind13 = "agent_output_chunk";
 export type Channel = "assistant" | "analysis" | "tool" | "diagnostic" | "prompt";
 export type Content1 = string;
 export type Progress = string | null;
@@ -189,37 +216,37 @@ export type AgentLabel = string | null;
 export type ElapsedSeconds = number;
 export type InputTokens = number;
 export type ContextWindow = number | null;
-export type Kind11 = "subprocess_output";
+export type Kind14 = "subprocess_output";
 export type ProcessId = string;
 export type ProcessKind = string;
 export type Stream1 = "stdout" | "stderr";
 export type Content2 = string;
-export type Kind12 = "judge_result";
+export type Kind15 = "judge_result";
 export type Verdict = "pass" | "fail";
 export type Feedback = string;
-export type Attempt1 = number;
-export type Kind13 = "benchmark_result";
+export type Attempt3 = number;
+export type Kind16 = "benchmark_result";
 export type Metric = string;
 export type Value = number;
 export type Unit = string;
-export type Kind14 = "round_finished";
+export type Kind17 = "round_finished";
 export type Attempts = number;
 export type JudgeVerdict = "pass" | "fail" | "skipped";
 export type PerfMetric = number | null;
 export type PerfUnit = string | null;
-export type Kind15 = "tool_call";
-export type Tool = string;
-export type CallId = string | null;
-export type Kind16 = "tool_result";
+export type Kind18 = "tool_call";
 export type Tool1 = string;
+export type CallId = string | null;
+export type Kind19 = "tool_result";
+export type Tool2 = string;
 export type CallId1 = string | null;
 export type Content3 = string;
 export type IsError = boolean;
-export type Kind17 = "todo_update";
+export type Kind20 = "todo_update";
 export type Content4 = string;
 export type Status2 = string;
 export type Todos = TodoItemData[];
-export type Kind18 = "usage_update";
+export type Kind21 = "usage_update";
 export type InputTokens1 = number;
 export type ContextWindow1 = number | null;
 export type Model = string | null;
@@ -263,6 +290,8 @@ export type LatestSequence = number;
 export type Type11 = "event";
 export type Type12 = "event_batch";
 export type Events1 = RunEvent[];
+export type ThroughSequence = number;
+export type ActiveExecutions1 = ActiveAgentExecution[];
 export type Type13 = "protocol_error";
 export type RequestId12 = string | null;
 export type Code2 = string;
@@ -391,6 +420,30 @@ export interface RunSnapshot {
   status: Status1;
   agent_kind?: AgentKind;
   round_label?: RoundLabel;
+  active_executions?: ActiveExecutions;
+}
+/**
+ * Authoritative activity checkpoint for one running agent execution.
+ */
+export interface ActiveAgentExecution {
+  execution_id: ExecutionId;
+  agent_kind: AgentKind1;
+  round_label: RoundLabel1;
+  stage: Stage;
+  attempt?: Attempt;
+  assignment: Assignment;
+  started_at: StartedAt;
+  activity: AgentExecutionActivityData;
+}
+/**
+ * Complete current activity for an active agent execution.
+ */
+export interface AgentExecutionActivityData {
+  kind?: Kind;
+  mode: Mode1;
+  summary: Summary1;
+  tool?: Tool;
+  [k: string]: unknown;
 }
 /**
  * One reproducible human, control, or invocation event.
@@ -404,24 +457,25 @@ export interface RunEvent {
   text?: Text2;
   diagnostic?: Diagnostic | null;
   status?: EventStatus | null;
-  round_label?: RoundLabel1;
-  agent_kind?: AgentKind1;
+  round_label?: RoundLabel2;
+  agent_kind?: AgentKind2;
   invocation_id?: InvocationId;
+  execution_id?: ExecutionId1;
   data?: Data;
 }
 export interface ChatData {
-  kind?: Kind;
+  kind?: Kind1;
   answer: Answer1;
   [k: string]: unknown;
 }
 export interface InvocationStartedData {
-  kind?: Kind1;
+  kind?: Kind2;
   system_prompt: SystemPrompt;
   user_prompt: UserPrompt;
   [k: string]: unknown;
 }
 export interface InvocationFinishedData {
-  kind?: Kind2;
+  kind?: Kind3;
   result?: Result;
   error?: Error1;
   [k: string]: unknown;
@@ -429,53 +483,77 @@ export interface InvocationFinishedData {
 export interface Result {
   [k: string]: unknown;
 }
+/**
+ * Semantic context for one prompt-to-result agent execution.
+ */
+export interface AgentExecutionStartedData {
+  kind?: Kind4;
+  stage: Stage1;
+  attempt?: Attempt1;
+  system_prompt?: SystemPrompt1;
+  user_prompt?: UserPrompt1;
+  activity: AgentExecutionActivityData;
+  [k: string]: unknown;
+}
+/**
+ * Terminal result for one agent execution.
+ */
+export interface AgentExecutionFinishedData {
+  kind?: Kind5;
+  result?: Result1;
+  error?: Error2;
+  [k: string]: unknown;
+}
+export interface Result1 {
+  [k: string]: unknown;
+}
 export interface OutputData {
-  kind?: Kind3;
+  kind?: Kind6;
   stream: Stream;
   source?: Source;
   content: Content;
   [k: string]: unknown;
 }
 export interface ServerReadyData {
-  kind?: Kind4;
+  kind?: Kind7;
   socket_protocol?: SocketProtocol;
   [k: string]: unknown;
 }
 export interface RunStartedData {
-  kind?: Kind5;
+  kind?: Kind8;
   outer_loop: OuterLoop;
   input: Input;
   max_rounds: MaxRounds;
   [k: string]: unknown;
 }
 export interface RunInterruptedData {
-  kind?: Kind6;
+  kind?: Kind9;
   reason: Reason;
   signal?: Signal;
   [k: string]: unknown;
 }
 export interface ExperimentsChangedData {
-  kind?: Kind7;
+  kind?: Kind10;
   reason: Reason1;
   [k: string]: unknown;
 }
 export interface ConfigurationFailedData {
-  kind?: Kind8;
+  kind?: Kind11;
   code: Code1;
-  stage: Stage;
+  stage: Stage2;
   message: Message;
   usage?: Usage;
   exit_code: ExitCode;
   [k: string]: unknown;
 }
 export interface PhaseData {
-  kind?: Kind9;
+  kind?: Kind12;
   phase: Phase;
-  attempt?: Attempt;
+  attempt?: Attempt2;
   [k: string]: unknown;
 }
 export interface AgentOutputChunkData {
-  kind?: Kind10;
+  kind?: Kind13;
   channel: Channel;
   content: Content1;
   status?: AgentStatusData | null;
@@ -497,7 +575,7 @@ export interface AgentStatusData {
   [k: string]: unknown;
 }
 export interface SubprocessOutputData {
-  kind?: Kind11;
+  kind?: Kind14;
   process_id: ProcessId;
   process_kind: ProcessKind;
   stream: Stream1;
@@ -505,21 +583,21 @@ export interface SubprocessOutputData {
   [k: string]: unknown;
 }
 export interface JudgeResultData {
-  kind?: Kind12;
+  kind?: Kind15;
   verdict: Verdict;
   feedback: Feedback;
-  attempt: Attempt1;
+  attempt: Attempt3;
   [k: string]: unknown;
 }
 export interface BenchmarkResultData {
-  kind?: Kind13;
+  kind?: Kind16;
   metric: Metric;
   value: Value;
   unit: Unit;
   [k: string]: unknown;
 }
 export interface RoundFinishedData {
-  kind?: Kind14;
+  kind?: Kind17;
   attempts: Attempts;
   judge_verdict: JudgeVerdict;
   perf_metric?: PerfMetric;
@@ -527,8 +605,8 @@ export interface RoundFinishedData {
   [k: string]: unknown;
 }
 export interface ToolCallData {
-  kind?: Kind15;
-  tool: Tool;
+  kind?: Kind18;
+  tool: Tool1;
   call_id?: CallId;
   args?: Args;
   status?: AgentStatusData | null;
@@ -538,15 +616,15 @@ export interface Args {
   [k: string]: unknown;
 }
 export interface ToolResultData {
-  kind?: Kind16;
-  tool: Tool1;
+  kind?: Kind19;
+  tool: Tool2;
   call_id?: CallId1;
   content: Content3;
   is_error?: IsError;
   [k: string]: unknown;
 }
 export interface TodoUpdateData {
-  kind?: Kind17;
+  kind?: Kind20;
   todos?: Todos;
   [k: string]: unknown;
 }
@@ -556,7 +634,7 @@ export interface TodoItemData {
   [k: string]: unknown;
 }
 export interface UsageUpdateData {
-  kind?: Kind18;
+  kind?: Kind21;
   input_tokens: InputTokens1;
   context_window?: ContextWindow1;
   model?: Model;
@@ -620,6 +698,8 @@ export interface EventMessage {
 export interface EventBatchMessage {
   type?: Type12;
   events: Events1;
+  through_sequence?: ThroughSequence;
+  active_executions?: ActiveExecutions1;
 }
 export interface ProtocolErrorMessage {
   type?: Type13;

--- a/clients/tui/src/generated/protocol.schema.json
+++ b/clients/tui/src/generated/protocol.schema.json
@@ -1,5 +1,180 @@
 {
   "$defs": {
+    "ActiveAgentExecution": {
+      "additionalProperties": false,
+      "description": "Authoritative activity checkpoint for one running agent execution.",
+      "properties": {
+        "execution_id": {
+          "title": "Execution Id",
+          "type": "string"
+        },
+        "agent_kind": {
+          "title": "Agent Kind",
+          "type": "string"
+        },
+        "round_label": {
+          "title": "Round Label",
+          "type": "string"
+        },
+        "stage": {
+          "title": "Stage",
+          "type": "string"
+        },
+        "attempt": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Attempt"
+        },
+        "assignment": {
+          "title": "Assignment",
+          "type": "string"
+        },
+        "started_at": {
+          "format": "date-time",
+          "title": "Started At",
+          "type": "string"
+        },
+        "activity": {
+          "$ref": "#/$defs/AgentExecutionActivityData"
+        }
+      },
+      "required": [
+        "execution_id",
+        "agent_kind",
+        "round_label",
+        "stage",
+        "assignment",
+        "started_at",
+        "activity"
+      ],
+      "title": "ActiveAgentExecution",
+      "type": "object"
+    },
+    "AgentExecutionActivityData": {
+      "description": "Complete current activity for an active agent execution.",
+      "properties": {
+        "kind": {
+          "const": "agent_execution_activity_changed",
+          "default": "agent_execution_activity_changed",
+          "title": "Kind",
+          "type": "string"
+        },
+        "mode": {
+          "enum": [
+            "thinking",
+            "responding",
+            "tool",
+            "waiting"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
+        "summary": {
+          "title": "Summary",
+          "type": "string"
+        },
+        "tool": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool"
+        }
+      },
+      "required": [
+        "mode",
+        "summary"
+      ],
+      "title": "AgentExecutionActivityData",
+      "type": "object"
+    },
+    "AgentExecutionFinishedData": {
+      "description": "Terminal result for one agent execution.",
+      "properties": {
+        "kind": {
+          "const": "agent_execution_finished",
+          "default": "agent_execution_finished",
+          "title": "Kind",
+          "type": "string"
+        },
+        "result": {
+          "default": null,
+          "title": "Result"
+        },
+        "error": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Error"
+        }
+      },
+      "title": "AgentExecutionFinishedData",
+      "type": "object"
+    },
+    "AgentExecutionStartedData": {
+      "description": "Semantic context for one prompt-to-result agent execution.",
+      "properties": {
+        "kind": {
+          "const": "agent_execution_started",
+          "default": "agent_execution_started",
+          "title": "Kind",
+          "type": "string"
+        },
+        "stage": {
+          "title": "Stage",
+          "type": "string"
+        },
+        "attempt": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Attempt"
+        },
+        "system_prompt": {
+          "default": "",
+          "title": "System Prompt",
+          "type": "string"
+        },
+        "user_prompt": {
+          "default": "",
+          "title": "User Prompt",
+          "type": "string"
+        },
+        "activity": {
+          "$ref": "#/$defs/AgentExecutionActivityData"
+        }
+      },
+      "required": [
+        "stage",
+        "activity"
+      ],
+      "title": "AgentExecutionStartedData",
+      "type": "object"
+    },
     "AgentOutputChunkData": {
       "properties": {
         "kind": {
@@ -411,6 +586,19 @@
           },
           "title": "Events",
           "type": "array"
+        },
+        "through_sequence": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Through Sequence",
+          "type": "integer"
+        },
+        "active_executions": {
+          "items": {
+            "$ref": "#/$defs/ActiveAgentExecution"
+          },
+          "title": "Active Executions",
+          "type": "array"
         }
       },
       "required": [
@@ -445,7 +633,9 @@
         "pending",
         "consumed",
         "completed",
-        "failed"
+        "failed",
+        "cancelled",
+        "interrupted"
       ],
       "title": "EventStatus",
       "type": "string"
@@ -463,6 +653,9 @@
         "control",
         "invocation_started",
         "invocation_finished",
+        "agent_execution_started",
+        "agent_execution_activity_changed",
+        "agent_execution_finished",
         "phase_started",
         "phase_finished",
         "agent_output_chunk",
@@ -1413,11 +1606,26 @@
           "default": null,
           "title": "Invocation Id"
         },
+        "execution_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Execution Id"
+        },
         "data": {
           "anyOf": [
             {
               "discriminator": {
                 "mapping": {
+                  "agent_execution_activity_changed": "#/$defs/AgentExecutionActivityData",
+                  "agent_execution_finished": "#/$defs/AgentExecutionFinishedData",
+                  "agent_execution_started": "#/$defs/AgentExecutionStartedData",
                   "agent_output_chunk": "#/$defs/AgentOutputChunkData",
                   "benchmark_result": "#/$defs/BenchmarkResultData",
                   "chat": "#/$defs/ChatData",
@@ -1449,6 +1657,15 @@
                 },
                 {
                   "$ref": "#/$defs/InvocationFinishedData"
+                },
+                {
+                  "$ref": "#/$defs/AgentExecutionStartedData"
+                },
+                {
+                  "$ref": "#/$defs/AgentExecutionActivityData"
+                },
+                {
+                  "$ref": "#/$defs/AgentExecutionFinishedData"
                 },
                 {
                   "$ref": "#/$defs/OutputData"
@@ -1590,6 +1807,13 @@
           ],
           "default": null,
           "title": "Round Label"
+        },
+        "active_executions": {
+          "items": {
+            "$ref": "#/$defs/ActiveAgentExecution"
+          },
+          "title": "Active Executions",
+          "type": "array"
         }
       },
       "required": [

--- a/clients/tui/src/round-timing.ts
+++ b/clients/tui/src/round-timing.ts
@@ -11,6 +11,7 @@ export interface RoundTimingState {
 export interface AgentTimingEvent {
   agent_kind?: string | null;
   invocation_id?: string | null;
+  execution_id?: string | null;
   timestamp: string;
 }
 
@@ -78,7 +79,7 @@ export function hasActiveAgentTiming(state: RoundTimingState): boolean {
 
 function timingKey(event: AgentTimingEvent): string | null {
   if (!event.agent_kind) return null;
-  return `${event.agent_kind}:${event.invocation_id ?? ''}`;
+  return `${event.agent_kind}:${event.execution_id ?? event.invocation_id ?? ''}`;
 }
 
 function findActiveTimingKey(

--- a/clients/tui/src/run-map.test.ts
+++ b/clients/tui/src/run-map.test.ts
@@ -13,10 +13,7 @@ describe('run map round timing', () => {
 
   it('closes a phase by agent role when the exact invocation key is absent', () => {
     let state = initialRunMapState();
-    state = applyRunMapEvent(
-      state,
-      phaseEvent(1, 'phase_started', '2026-01-01T00:00:00Z', undefined),
-    );
+    state = applyRunMapEvent(state, phaseEvent(1, 'phase_started', '2026-01-01T00:00:00Z'));
     state = applyRunMapEvent(
       state,
       phaseEvent(2, 'phase_finished', '2026-01-01T00:00:05Z', 'finish-only'),
@@ -24,6 +21,7 @@ describe('run map round timing', () => {
 
     expect(state.rounds[0]?.activeAgentStarts).toEqual({});
     expect(roundAgentElapsedMs(onlyRound(state), new Date('2026-01-01T00:01:00Z'))).toBe(5000);
+    expect(state.phases[0]?.executionId).toBe('invocation-1');
   });
 
   it('does not reopen a completed round when the run finishes', () => {
@@ -57,6 +55,84 @@ describe('run map round timing', () => {
     expect(state.rounds[0]?.activeAgentStarts).toEqual({});
     expect(state.phases[0]?.status).toBe('failed');
   });
+
+  it('keeps concurrent same-role executions distinct until each one finishes', () => {
+    let state = initialRunMapState();
+    state = applyRunMapEvent(
+      state,
+      executionEvent(1, 'agent_execution_started', 'impl-a', 'active'),
+    );
+    state = applyRunMapEvent(
+      state,
+      executionEvent(2, 'agent_execution_started', 'impl-b', 'active'),
+    );
+    state = applyRunMapEvent(
+      state,
+      executionEvent(3, 'agent_execution_finished', 'impl-a', 'completed'),
+    );
+
+    expect(state.phases.map(phase => [phase.executionId, phase.status])).toEqual([
+      ['impl-a', 'completed'],
+      ['impl-b', 'active'],
+    ]);
+    expect(state.rounds[0]?.activeAgentStarts).toEqual({
+      'implementer:impl-b': '2026-01-01T00:00:02Z',
+    });
+  });
+
+  it('does not let compatibility phase events close a concurrent execution', () => {
+    let state = initialRunMapState();
+    state = applyRunMapEvent(
+      state,
+      executionEvent(1, 'agent_execution_started', 'impl-a', 'active'),
+    );
+    state = applyRunMapEvent(
+      state,
+      phaseEvent(2, 'phase_started', '2026-01-01T00:00:02Z', 'impl-a'),
+    );
+    state = applyRunMapEvent(
+      state,
+      executionEvent(3, 'agent_execution_started', 'impl-b', 'active'),
+    );
+    state = applyRunMapEvent(
+      state,
+      phaseEvent(4, 'phase_started', '2026-01-01T00:00:04Z', 'impl-b'),
+    );
+    state = applyRunMapEvent(
+      state,
+      executionEvent(5, 'agent_execution_finished', 'impl-a', 'completed'),
+    );
+    state = applyRunMapEvent(
+      state,
+      phaseEvent(6, 'phase_finished', '2026-01-01T00:00:06Z', 'impl-a'),
+    );
+
+    expect(state.rounds[0]?.activeAgentStarts).toEqual({
+      'implementer:impl-b': '2026-01-01T00:00:03Z',
+    });
+  });
+
+  it('preserves cancelled and interrupted execution outcomes', () => {
+    let state = initialRunMapState();
+    state = applyRunMapEvent(
+      state,
+      executionEvent(1, 'agent_execution_started', 'impl-a', 'active'),
+    );
+    state = applyRunMapEvent(
+      state,
+      executionEvent(2, 'agent_execution_finished', 'impl-a', 'cancelled'),
+    );
+    state = applyRunMapEvent(
+      state,
+      executionEvent(3, 'agent_execution_started', 'impl-b', 'active'),
+    );
+    state = applyRunMapEvent(
+      state,
+      executionEvent(4, 'agent_execution_finished', 'impl-b', 'interrupted'),
+    );
+
+    expect(state.phases.map(phase => phase.status)).toEqual(['cancelled', 'interrupted']);
+  });
 });
 
 function initialRunMapState(): RunMapState {
@@ -81,5 +157,22 @@ function phaseEvent(
     round_label: 'round-1',
     agent_kind: 'implementer',
     ...(invocationId === undefined ? {} : {invocation_id: invocationId}),
+  };
+}
+
+function executionEvent(
+  sequence: number,
+  type: 'agent_execution_started' | 'agent_execution_finished',
+  executionId: string,
+  status: NonNullable<RunEvent['status']>,
+): RunEvent {
+  return {
+    sequence,
+    timestamp: `2026-01-01T00:00:0${sequence}Z`,
+    type,
+    status,
+    round_label: 'round-1',
+    agent_kind: 'implementer',
+    execution_id: executionId,
   };
 }

--- a/clients/tui/src/run-map.ts
+++ b/clients/tui/src/run-map.ts
@@ -7,7 +7,13 @@ import {
   startAgentTiming,
 } from './round-timing.js';
 
-export type AgentPhaseStatus = 'pending' | 'active' | 'completed' | 'failed';
+export type AgentPhaseStatus =
+  | 'pending'
+  | 'active'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'interrupted';
 /**
  * ``planned`` is not an observed state: it stands for a round the run intends to
  * reach, so the strip can show the whole run rather than only what has happened.
@@ -26,6 +32,8 @@ export interface AgentPhase {
   status: AgentPhaseStatus;
   roundNumber: number | null;
   roundLabel: string | null;
+  executionId?: string;
+  /** Legacy alias retained while persisted phase events still use it. */
   invocationId?: string;
   startedAt?: string;
   finishedAt?: string;
@@ -42,7 +50,7 @@ export function applyRunMapEvent(state: RunMapState, event: RunEvent): RunMapSta
     event.type === 'run_started' && event.data?.kind === 'run_started'
       ? event.data.outer_loop
       : state.outerLoop;
-  const rounds = applyRoundEvent(state.rounds, event);
+  const rounds = applyRoundEvent(state.rounds, state.phases, event);
   const phases = applyPhaseEvent({...state, outerLoop, rounds}, event);
   return {outerLoop, rounds, phases};
 }
@@ -82,24 +90,35 @@ function applyPhaseEvent(state: RunMapState, event: RunEvent): AgentPhase[] {
         : phase,
     );
   }
-  if (event.type !== 'phase_started' && event.type !== 'phase_finished') {
+  const started = event.type === 'agent_execution_started' || event.type === 'phase_started';
+  const finished = event.type === 'agent_execution_finished' || event.type === 'phase_finished';
+  if (!started && !finished) {
     return ensurePhase(phases, kind, roundNumber);
   }
-  const status =
-    event.type === 'phase_started' ? 'active' : event.status === 'failed' ? 'failed' : 'completed';
+  const status = started ? 'active' : terminalPhaseStatus(event.status);
+  const executionId = event.execution_id ?? event.invocation_id ?? undefined;
   return upsertPhase(phases, {
     kind,
     status,
     roundNumber,
     roundLabel: event.round_label ?? null,
-    ...(event.invocation_id ? {invocationId: event.invocation_id} : {}),
-    ...(event.type === 'phase_started'
-      ? {startedAt: event.timestamp}
-      : {finishedAt: event.timestamp}),
+    ...(executionId ? {executionId, invocationId: executionId} : {}),
+    ...(started ? {startedAt: event.timestamp} : {finishedAt: event.timestamp}),
   });
 }
 
-function applyRoundEvent(rounds: RoundSummary[], event: RunEvent): RoundSummary[] {
+function terminalPhaseStatus(status: RunEvent['status']): AgentPhaseStatus {
+  if (status === 'failed') return 'failed';
+  if (status === 'cancelled') return 'cancelled';
+  if (status === 'interrupted') return 'interrupted';
+  return 'completed';
+}
+
+function applyRoundEvent(
+  rounds: RoundSummary[],
+  phases: AgentPhase[],
+  event: RunEvent,
+): RoundSummary[] {
   const number = roundNumberFromLabel(event.round_label);
   if (number === null) return rounds;
   const existing = rounds.find(round => round.number === number);
@@ -121,7 +140,7 @@ function applyRoundEvent(rounds: RoundSummary[], event: RunEvent): RoundSummary[
     ...(terminal ? {finishedAt: event.timestamp} : {startedAt: event.timestamp}),
   };
   const round = existing ? mergeRound(existing, patch) : patch;
-  return replaceRound(rounds, updateRoundAgentElapsed(round, event));
+  return replaceRound(rounds, updateRoundAgentElapsed(round, phases, event));
 }
 
 function seedExpectedPhases(
@@ -152,15 +171,35 @@ function ensurePhase(phases: AgentPhase[], kind: string, roundNumber: number | n
 }
 
 function upsertPhase(phases: AgentPhase[], patch: AgentPhase): AgentPhase[] {
-  const existing = phases.findIndex(
-    phase => phase.kind === patch.kind && phase.roundNumber === patch.roundNumber,
-  );
+  const sameRoleAndRound = (phase: AgentPhase): boolean =>
+    phase.kind === patch.kind && phase.roundNumber === patch.roundNumber;
+  let existing =
+    patch.executionId === undefined
+      ? -1
+      : phases.findIndex(
+          phase => sameRoleAndRound(phase) && phase.executionId === patch.executionId,
+        );
+  if (existing === -1 && patch.status === 'active') {
+    // Seeded expected stages have no execution identity. The first execution
+    // claims that placeholder; concurrent same-role executions append nodes.
+    existing = phases.findIndex(
+      phase => sameRoleAndRound(phase) && phase.executionId === undefined,
+    );
+  }
+  if (existing === -1 && patch.status !== 'active') {
+    // Legacy finishes may omit or disagree on identity. Close one active
+    // execution of the same role rather than creating a completed phantom.
+    existing = phases.findIndex(phase => sameRoleAndRound(phase) && phase.status === 'active');
+  }
   if (existing === -1) return [...phases, patch];
   return phases.map((phase, index) =>
     index === existing
       ? {
           ...phase,
           ...patch,
+          ...(phase.executionId !== undefined && phase.executionId !== patch.executionId
+            ? {executionId: phase.executionId, invocationId: phase.invocationId}
+            : {}),
           ...((patch.startedAt ?? phase.startedAt)
             ? {startedAt: patch.startedAt ?? phase.startedAt}
             : {}),
@@ -205,8 +244,14 @@ function earliestTimestamp(
   return new Date(right).getTime() < new Date(left).getTime() ? right : left;
 }
 
-function updateRoundAgentElapsed(round: RoundSummary, event: RunEvent): RoundSummary {
-  if (event.type !== 'phase_started' && event.type !== 'phase_finished') {
+function updateRoundAgentElapsed(
+  round: RoundSummary,
+  phases: AgentPhase[],
+  event: RunEvent,
+): RoundSummary {
+  const started = event.type === 'agent_execution_started' || event.type === 'phase_started';
+  const finished = event.type === 'agent_execution_finished' || event.type === 'phase_finished';
+  if (!started && !finished) {
     if (
       event.type !== 'round_finished' &&
       event.type !== 'run_failed' &&
@@ -216,9 +261,27 @@ function updateRoundAgentElapsed(round: RoundSummary, event: RunEvent): RoundSum
     }
     return closeActiveAgentTimings(round, event.timestamp);
   }
-  return event.type === 'phase_started'
-    ? startAgentTiming(round, event)
-    : finishAgentTiming(round, event);
+  if (event.type === 'phase_started' || event.type === 'phase_finished') {
+    const executionId = event.execution_id ?? event.invocation_id;
+    const existing = phases.find(
+      phase =>
+        executionId != null &&
+        phase.executionId === executionId &&
+        phase.kind === event.agent_kind &&
+        phase.roundNumber === roundNumberFromLabel(event.round_label),
+    );
+    // New backends retain phase events for old clients after emitting the
+    // canonical lifecycle event. Do not apply that compatibility duplicate a
+    // second time, especially because role fallback could close a concurrent
+    // same-role execution.
+    if (
+      (started && existing?.status === 'active') ||
+      (finished && existing !== undefined && existing.status !== 'active')
+    ) {
+      return round;
+    }
+  }
+  return started ? startAgentTiming(round, event) : finishAgentTiming(round, event);
 }
 
 export function roundAgentElapsedMs(round: RoundSummary, now = new Date()): number {

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -48,6 +48,46 @@ describe('session controller', () => {
     expect(transport.closed).toBe(true);
   });
 
+  it('applies a replay batch before reconciling its active execution checkpoint', async () => {
+    const transport = new FakeTransport();
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+
+    transport.emit({
+      type: 'event_batch',
+      events: [
+        {
+          sequence: 1,
+          timestamp: '2026-01-01T00:00:00Z',
+          type: 'agent_execution_started',
+          execution_id: 'stale-execution',
+          agent_kind: 'implementer',
+          round_label: 'round-1-implementer',
+          data: {
+            kind: 'agent_execution_started',
+            stage: 'implementation',
+            attempt: 1,
+            system_prompt: '',
+            user_prompt: 'Implement the queue',
+            activity: {
+              kind: 'agent_execution_activity_changed',
+              mode: 'thinking',
+              summary: 'Inspecting the queue',
+              tool: null,
+            },
+          },
+        },
+        event(2, 'agent_output_chunk', 'persisted output\n'),
+      ],
+      through_sequence: 2,
+      active_executions: [],
+    });
+
+    expect(controller.state.sequence).toBe(2);
+    expect(controller.state.conversation.at(-1)?.content).toBe('persisted output\n');
+    expect(controller.state.activeExecutions).toEqual({});
+  });
+
   it('keeps terminal state when the stream closes after completion', async () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
@@ -58,6 +98,42 @@ describe('session controller', () => {
     expect(controller.state.status).toBe('completed');
     expect(controller.state.overlay).toBeNull();
     expect(controller.state.errorBanner).toBeNull();
+  });
+
+  it('clears active executions when the event stream disconnects unexpectedly', async () => {
+    const transport = new FakeTransport();
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+    transport.emit({
+      type: 'event',
+      event: {
+        sequence: 1,
+        timestamp: '2026-01-01T00:00:00Z',
+        type: 'agent_execution_started',
+        execution_id: 'impl-1',
+        agent_kind: 'implementer',
+        round_label: 'round-1-implementer',
+        data: {
+          kind: 'agent_execution_started',
+          stage: 'implementation',
+          attempt: 1,
+          system_prompt: '',
+          user_prompt: 'Implement the queue',
+          activity: {
+            kind: 'agent_execution_activity_changed',
+            mode: 'thinking',
+            summary: 'Inspecting the queue',
+            tool: null,
+          },
+        },
+      },
+    });
+    expect(controller.state.activeExecutions['impl-1']).toBeDefined();
+
+    transport.disconnect(new Error('Supervision event stream disconnected'));
+
+    expect(controller.state.activeExecutions).toEqual({});
+    expect(controller.state.errorBanner).toMatchObject({scope: 'transport'});
   });
 
   it('prefers structured response and protocol diagnostics over legacy messages', async () => {

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -3,6 +3,7 @@ import {helpText, parseInput} from './commands.js';
 import {renderPerformanceCurve} from './performance-chart.js';
 import type {ProtocolResponse, RequestInput, RunEvent, ServerMessage} from './protocol.js';
 import {
+  applyActiveExecutionCheckpoint,
   applyEvent,
   applySnapshot,
   type ConversationEntry,
@@ -151,12 +152,14 @@ export class SocketSessionController implements SessionController {
           // closing afterward is lifecycle cleanup, not a second failure that
           // should replace the useful diagnostic in the banner.
           if (!this.#state.terminal && !this.#streamProtocolError) {
-            this.#setState(reportCaughtError(this.#state, error, 'transport'));
+            this.#setState(
+              reportCaughtError({...this.#state, activeExecutions: {}}, error, 'transport'),
+            );
           }
         },
       );
     } catch (error) {
-      this.#setState(reportCaughtError(this.#state, error, 'transport'));
+      this.#setState(reportCaughtError({...this.#state, activeExecutions: {}}, error, 'transport'));
     }
   }
 
@@ -553,6 +556,16 @@ export class SocketSessionController implements SessionController {
     if (message.type === 'event_batch') {
       let state = this.#state;
       for (const event of message.events) state = applyEvent(state, event);
+      // Replay first, then reconcile with the checkpoint captured at the
+      // batch's watermark. This closes dangling starts from interrupted logs
+      // without letting the replay overwrite authoritative live state.
+      if (message.active_executions !== undefined) {
+        state = applyActiveExecutionCheckpoint(
+          state,
+          message.active_executions,
+          message.through_sequence,
+        );
+      }
       this.#setState(state);
       this.#refreshExperimentsFor(message.events);
       this.#refreshPaneFor(message.events);
@@ -560,7 +573,7 @@ export class SocketSessionController implements SessionController {
     if (message.type === 'protocol_error') {
       this.#streamProtocolError = true;
       this.#setState(
-        reportError(this.#state, message.message, {
+        reportError({...this.#state, activeExecutions: {}}, message.message, {
           scope: 'protocol',
           diagnostic: message.diagnostic ?? null,
         }),

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it, test} from 'bun:test';
 import type {RunEvent} from './protocol.js';
 import type {SessionState} from './session-model.js';
 import {
+  applyActiveExecutionCheckpoint,
   applyEvent,
   chatDocked,
   chatPaneVisible,
@@ -206,6 +207,197 @@ describe('unowned rounds', () => {
 });
 
 describe('session event model', () => {
+  it('tracks concurrent agent executions independently through activity and finish events', () => {
+    let state = initialSessionState();
+    state = applyEvent(
+      state,
+      executionEvent(
+        1,
+        'agent_execution_started',
+        'impl-1',
+        {
+          kind: 'agent_execution_started',
+          stage: 'implementation',
+          attempt: 1,
+          system_prompt: '',
+          user_prompt: 'Implement the queue',
+          activity: {
+            kind: 'agent_execution_activity_changed',
+            mode: 'thinking',
+            summary: 'Inspecting the queue',
+            tool: null,
+          },
+        },
+        'implementer',
+      ),
+    );
+    state = applyEvent(
+      state,
+      executionEvent(
+        2,
+        'agent_execution_started',
+        'review-1',
+        {
+          kind: 'agent_execution_started',
+          stage: 'review',
+          attempt: null,
+          system_prompt: '',
+          user_prompt: 'Review the diff',
+          activity: {
+            kind: 'agent_execution_activity_changed',
+            mode: 'waiting',
+            summary: 'Waiting for the implementation',
+            tool: null,
+          },
+        },
+        'reviewer',
+      ),
+    );
+    state = applyEvent(
+      state,
+      executionEvent(
+        3,
+        'agent_execution_activity_changed',
+        'impl-1',
+        {
+          kind: 'agent_execution_activity_changed',
+          mode: 'tool',
+          summary: 'Running queue tests',
+          tool: 'Bash',
+        },
+        'implementer',
+      ),
+    );
+
+    expect(Object.keys(state.activeExecutions)).toEqual(['impl-1', 'review-1']);
+    expect(state.activeExecutions['impl-1']?.activity).toEqual({
+      mode: 'tool',
+      summary: 'Running queue tests',
+      tool: 'Bash',
+    });
+    expect(state.activeExecutions['review-1']?.activity.summary).toBe(
+      'Waiting for the implementation',
+    );
+
+    state = applyEvent(
+      state,
+      executionEvent(
+        4,
+        'agent_execution_finished',
+        'impl-1',
+        {
+          kind: 'agent_execution_finished',
+          error: null,
+        },
+        'implementer',
+      ),
+    );
+    expect(Object.keys(state.activeExecutions)).toEqual(['review-1']);
+  });
+
+  it('reconciles from a checkpoint without advancing the replay cursor', () => {
+    const state = applyActiveExecutionCheckpoint(initialSessionState(), [
+      {
+        execution_id: 'judge-2',
+        agent_kind: 'judge',
+        round_label: 'round-2-judge',
+        stage: 'evaluation',
+        attempt: 1,
+        assignment: 'Evaluate the candidate',
+        started_at: '2026-01-01T00:00:00Z',
+        activity: {
+          kind: 'agent_execution_activity_changed',
+          mode: 'thinking',
+          summary: 'Inspecting the diff',
+          tool: null,
+        },
+      },
+    ]);
+
+    expect(state.sequence).toBe(0);
+    expect(state.activeExecutions['judge-2']).toMatchObject({
+      agentKind: 'judge',
+      roundNumber: 2,
+      activity: {summary: 'Inspecting the diff'},
+    });
+
+    const newer = {...state, sequence: 5};
+    expect(applyActiveExecutionCheckpoint(newer, [], 4).activeExecutions).toEqual(
+      state.activeExecutions,
+    );
+  });
+
+  it('clears every active execution when the run is interrupted', () => {
+    const active = applyEvent(
+      initialSessionState(),
+      executionEvent(
+        1,
+        'agent_execution_started',
+        'impl-1',
+        {
+          kind: 'agent_execution_started',
+          stage: 'implementation',
+          attempt: 1,
+          system_prompt: '',
+          user_prompt: 'Implement the queue',
+          activity: {
+            kind: 'agent_execution_activity_changed',
+            mode: 'thinking',
+            summary: 'Inspecting the queue',
+            tool: null,
+          },
+        },
+        'implementer',
+      ),
+    );
+    const interrupted = applyEvent(active, {
+      sequence: 2,
+      timestamp: '2026-01-01T00:00:01Z',
+      type: 'run_interrupted',
+      data: {kind: 'run_interrupted', reason: 'SIGINT', signal: 'SIGINT'},
+    });
+
+    expect(interrupted.activeExecutions).toEqual({});
+  });
+
+  it('tracks and finishes chat executions before routing their transcript', () => {
+    let state = applyEvent(
+      initialSessionState(),
+      executionEvent(
+        1,
+        'agent_execution_started',
+        'chat-execution',
+        {
+          kind: 'agent_execution_started',
+          stage: 'chat',
+          attempt: null,
+          system_prompt: '',
+          user_prompt: 'What is running?',
+          activity: {
+            kind: 'agent_execution_activity_changed',
+            mode: 'thinking',
+            summary: 'Inspecting the run',
+            tool: null,
+          },
+        },
+        'chat',
+      ),
+    );
+
+    expect(state.activeExecutions['chat-execution']?.activity.summary).toBe('Inspecting the run');
+    state = applyEvent(
+      state,
+      executionEvent(
+        2,
+        'agent_execution_finished',
+        'chat-execution',
+        {kind: 'agent_execution_finished', error: null},
+        'chat',
+      ),
+    );
+    expect(state.activeExecutions).toEqual({});
+  });
+
   it('reduces semantic events into a presentation-neutral transcript', () => {
     let state = initialSessionState();
     state = applyEvent(
@@ -691,6 +883,7 @@ describe('session event model', () => {
 
     expect(state.todoPhases).toEqual([
       {
+        executionId: null,
         agentKind: 'judge',
         roundNumber: 1,
         items: [
@@ -737,6 +930,42 @@ describe('session event model', () => {
     // Selecting only a round shows the round's most recently updated list.
     const withRound = {...state, selectedRound: 1};
     expect(visibleTodos(withRound)).toEqual([{content: 'Check behavior', status: 'pending'}]);
+  });
+
+  it('keeps todos separate for concurrent executions of the same agent role', () => {
+    let state = initialSessionState();
+    state = applyEvent(
+      state,
+      executionEvent(
+        1,
+        'todo_update',
+        'impl-a',
+        {
+          kind: 'todo_update',
+          todos: [{content: 'Edit implementation A', status: 'in_progress'}],
+        },
+        'implementer',
+      ),
+    );
+    state = applyEvent(
+      state,
+      executionEvent(
+        2,
+        'todo_update',
+        'impl-b',
+        {
+          kind: 'todo_update',
+          todos: [{content: 'Edit implementation B', status: 'in_progress'}],
+        },
+        'implementer',
+      ),
+    );
+
+    expect(state.todoPhases).toHaveLength(2);
+    expect(state.todoPhases.map(phase => phase.executionId)).toEqual(['impl-a', 'impl-b']);
+    expect(visibleTodos({...state, selectedRound: 1, selectedAgentKind: 'implementer'})).toEqual([
+      {content: 'Edit implementation B', status: 'in_progress'},
+    ]);
   });
 
   it('hides todos when the active phase has not emitted any', () => {
@@ -1079,6 +1308,24 @@ function event(
     ...(type === 'run_started' ? {} : {agent_kind: 'judge'}),
     ...(invocationId === undefined ? {} : {invocation_id: invocationId}),
     ...(data === undefined ? {} : {data}),
+  };
+}
+
+function executionEvent(
+  sequence: number,
+  type: RunEvent['type'],
+  executionId: string,
+  data: NonNullable<RunEvent['data']>,
+  agentKind: string,
+): RunEvent {
+  return {
+    sequence,
+    timestamp: '2026-01-01T00:00:00Z',
+    type,
+    execution_id: executionId,
+    round_label: 'round-1',
+    agent_kind: agentKind,
+    data,
   };
 }
 

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -19,6 +19,8 @@ export interface SessionState {
   /** Rounds the run intends to reach, from ``run_started``; null until it arrives. */
   maxRounds: number | null;
   phases: AgentPhase[];
+  /** Backend-authoritative agent executions that have started but not finished. */
+  activeExecutions: Record<string, ActiveAgentExecution>;
   selectedRound: number | null;
   selectedAgentKind: string | null;
   /** Transcript entry the arrow keys are on, so a trace is readable without a mouse. */
@@ -64,6 +66,27 @@ export interface SessionState {
   errorBanner: ErrorBannerState | null;
 }
 
+export type AgentExecutionMode = 'thinking' | 'responding' | 'tool' | 'waiting';
+
+export interface AgentExecutionActivity {
+  mode: AgentExecutionMode;
+  summary: string;
+  tool?: string | null;
+}
+
+/** Semantic execution state. Spinner frames and elapsed-time formatting stay in the UI. */
+export interface ActiveAgentExecution {
+  executionId: string;
+  agentKind: string;
+  roundLabel: string | null;
+  roundNumber: number | null;
+  stage: string;
+  attempt: number | null;
+  assignment: string;
+  startedAt: string;
+  activity: AgentExecutionActivity;
+}
+
 export type ErrorSeverity = 'recoverable' | 'fatal';
 export type ErrorScope =
   | 'configuration'
@@ -100,11 +123,11 @@ export interface TodoItem {
 }
 
 /**
- * One agent phase's latest todo-list snapshot. Todos are keyed per
- * (round, agent) so concurrent or successive phases never clobber each
- * other's lists, mirroring how the conversation filter scopes entries.
+ * One agent execution's latest todo-list snapshot. Canonical events are keyed
+ * by execution ID; legacy streams without one retain their round/agent scope.
  */
 export interface PhaseTodos {
+  executionId?: string | null;
   agentKind: string | null;
   roundNumber: number | null;
   items: TodoItem[];
@@ -232,6 +255,7 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
     rounds: [],
     maxRounds: null,
     phases: [],
+    activeExecutions: {},
     selectedRound: null,
     selectedAgentKind: null,
     selectedEntryId: null,
@@ -823,7 +847,48 @@ export function applySnapshot(state: SessionState, snapshot: RunSnapshot): Sessi
     agentKind: snapshot.agent_kind ?? null,
     roundLabel: snapshot.round_label ?? null,
     terminal: snapshot.status === 'completed' || snapshot.status === 'failed',
+    activeExecutions: activeExecutionsFromCheckpoint(snapshot.active_executions ?? []),
   };
+}
+
+type ActiveExecutionCheckpoint = NonNullable<RunSnapshot['active_executions']>;
+
+/** Replace activity with the backend checkpoint without advancing the event replay cursor. */
+export function applyActiveExecutionCheckpoint(
+  state: SessionState,
+  executions: ActiveExecutionCheckpoint,
+  throughSequence?: number,
+): SessionState {
+  if (throughSequence !== undefined && throughSequence < state.sequence) return state;
+  return {
+    ...state,
+    activeExecutions: activeExecutionsFromCheckpoint(executions),
+  };
+}
+
+function activeExecutionsFromCheckpoint(
+  executions: ActiveExecutionCheckpoint,
+): Record<string, ActiveAgentExecution> {
+  return Object.fromEntries(
+    executions.map(execution => [
+      execution.execution_id,
+      {
+        executionId: execution.execution_id,
+        agentKind: execution.agent_kind,
+        roundLabel: execution.round_label ?? null,
+        roundNumber: roundNumberFromLabel(execution.round_label),
+        stage: execution.stage,
+        attempt: execution.attempt ?? null,
+        assignment: execution.assignment,
+        startedAt: execution.started_at,
+        activity: {
+          mode: execution.activity.mode,
+          summary: execution.activity.summary,
+          tool: execution.activity.tool ?? null,
+        },
+      },
+    ]),
+  );
 }
 
 export function applyEvent(state: SessionState, event: RunEvent): SessionState {
@@ -831,6 +896,7 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
   if (sequence > 0 && sequence <= state.sequence) return state;
   let next = {...state, sequence: Math.max(state.sequence, sequence)};
   next = applyFailureEvent(next, event);
+  next = applyAgentExecutionEvent(next, event);
   if (event.agent_kind === 'chat') return applyChatEvent(next, event);
   if (event.agent_kind) next.agentKind = event.agent_kind;
   if (event.round_label) next.roundLabel = event.round_label;
@@ -853,11 +919,16 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
     }));
     const agentKind = event.agent_kind ?? null;
     const roundNumber = roundNumberFromLabel(event.round_label);
+    const todoExecutionId = event.execution_id ?? event.invocation_id ?? null;
     next.todoPhases = [
-      ...next.todoPhases.filter(
-        phase => phase.agentKind !== agentKind || phase.roundNumber !== roundNumber,
+      ...next.todoPhases.filter(phase =>
+        todoExecutionId === null
+          ? phase.executionId != null ||
+            phase.agentKind !== agentKind ||
+            phase.roundNumber !== roundNumber
+          : phase.executionId !== todoExecutionId,
       ),
-      {agentKind, roundNumber, items},
+      {executionId: todoExecutionId, agentKind, roundNumber, items},
     ].slice(-100);
   }
   if (data?.kind === 'usage_update') {
@@ -884,16 +955,68 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
   if (event.type === 'configuration_failed') {
     next.status = 'failed';
     next.terminal = true;
+    next.activeExecutions = {};
   }
   if (event.type === 'run_finished') {
     next.status = 'completed';
     next.terminal = true;
+    next.activeExecutions = {};
   }
   if (event.type === 'run_failed' || event.type === 'run_interrupted') {
     next.status = 'failed';
     next.terminal = true;
+    next.activeExecutions = {};
   }
   return next;
+}
+
+/** Reduce canonical execution lifecycle before agent-specific transcript routing. */
+function applyAgentExecutionEvent(state: SessionState, event: RunEvent): SessionState {
+  const data = event.data;
+  const executionId = event.execution_id;
+  if (executionId == null) return state;
+  if (data?.kind === 'agent_execution_started') {
+    return {
+      ...state,
+      activeExecutions: {
+        ...state.activeExecutions,
+        [executionId]: {
+          executionId,
+          agentKind: event.agent_kind ?? 'agent',
+          roundLabel: event.round_label ?? null,
+          roundNumber: roundNumberFromLabel(event.round_label),
+          stage: data.stage,
+          attempt: data.attempt ?? null,
+          assignment: data.user_prompt ?? '',
+          startedAt: event.timestamp,
+          activity: {
+            mode: data.activity.mode,
+            summary: data.activity.summary,
+            tool: data.activity.tool ?? null,
+          },
+        },
+      },
+    };
+  }
+  if (data?.kind === 'agent_execution_activity_changed') {
+    const current = state.activeExecutions[executionId];
+    if (current === undefined) return state;
+    return {
+      ...state,
+      activeExecutions: {
+        ...state.activeExecutions,
+        [executionId]: {
+          ...current,
+          activity: {mode: data.mode, summary: data.summary, tool: data.tool ?? null},
+        },
+      },
+    };
+  }
+  if (data?.kind === 'agent_execution_finished') {
+    const {[executionId]: _finished, ...remaining} = state.activeExecutions;
+    return {...state, activeExecutions: remaining};
+  }
+  return state;
 }
 
 /**
@@ -1550,7 +1673,7 @@ export function toggleTodos(state: SessionState): SessionState {
 }
 
 /**
- * The todo list for the phase the operator is looking at, following the same
+ * The todo list for the execution the operator is looking at, following the same
  * scoping rules as the conversation filter. Entries whose events carried no
  * agent or round stamp (legacy streams) match any scope rather than vanish.
  */

--- a/clients/tui/src/ui/activity-bar.test.ts
+++ b/clients/tui/src/ui/activity-bar.test.ts
@@ -1,10 +1,8 @@
 import {describe, expect, it} from 'bun:test';
 import type {ActiveAgentExecution} from '../session-model.js';
-import {activitySummary, THINKING_WORDS} from './activity-bar.js';
+import {activitySummary} from './activity-bar.js';
 
 const STARTED_AT = '2026-08-25T12:00:00.000Z';
-const STARTED_AT_MS = Date.parse(STARTED_AT);
-
 function execution(
   activity: ActiveAgentExecution['activity'],
   executionId = 'execution-1',
@@ -23,29 +21,11 @@ function execution(
 }
 
 describe('activity summary', () => {
-  it('cycles generic thinking words on a stable five-second cadence', () => {
-    const active = execution({mode: 'thinking', summary: 'Thinking'});
-    const first = activitySummary(active, STARTED_AT_MS);
-
-    expect(first).not.toBe('Thinking');
-    expect(activitySummary(active, STARTED_AT_MS + 4_999)).toBe(first);
-    expect(activitySummary(active, STARTED_AT_MS + 5_000)).not.toBe(first);
-    expect(activitySummary(active, STARTED_AT_MS + 5_000)).toBe(
-      activitySummary(active, STARTED_AT_MS + 5_000),
-    );
-
-    const cycle = THINKING_WORDS.map((_, index) =>
-      activitySummary(active, STARTED_AT_MS + index * 5_000),
-    );
-    expect(new Set(cycle).size).toBe(THINKING_WORDS.length);
-    expect(activitySummary(active, STARTED_AT_MS + THINKING_WORDS.length * 5_000)).toBe(first);
-  });
-
-  it('uses a large pool of present-participle activity words', () => {
-    expect(THINKING_WORDS.length).toBeGreaterThanOrEqual(40);
-    expect(new Set(THINKING_WORDS).size).toBe(THINKING_WORDS.length);
-    expect(THINKING_WORDS.every(word => /ing$/i.test(word))).toBe(true);
-    expect(THINKING_WORDS).not.toContain('Thinking');
+  it('uses Working for generic thinking activity', () => {
+    expect(activitySummary(execution({mode: 'thinking', summary: ''}))).toBe('Working');
+    expect(activitySummary(execution({mode: 'thinking', summary: 'Thinking'}))).toBe('Working');
+    expect(activitySummary(execution({mode: 'thinking', summary: 'Thinking...'}))).toBe('Working');
+    expect(activitySummary(execution({mode: 'thinking', summary: 'Thinking…'}))).toBe('Working');
   });
 
   it('preserves specific semantic summaries and tool fallbacks', () => {
@@ -54,19 +34,9 @@ describe('activity summary', () => {
     const tool = execution({mode: 'tool', summary: 'Running queue tests', tool: 'Bash'});
     const blankTool = execution({mode: 'tool', summary: '', tool: 'Bash'});
 
-    expect(activitySummary(planning, STARTED_AT_MS + 10_000)).toBe('Planning');
-    expect(activitySummary(todo, STARTED_AT_MS + 10_000)).toBe('Reviewing queue invariants');
-    expect(activitySummary(tool, STARTED_AT_MS + 10_000)).toBe('Running queue tests');
-    expect(activitySummary(blankTool, STARTED_AT_MS + 10_000)).toBe('Using Bash');
-  });
-
-  it('uses the same deterministic sequence for a resumed execution', () => {
-    const first = execution({mode: 'thinking', summary: ''}, 'stable-execution');
-    const resumed = execution({mode: 'thinking', summary: 'Thinking'}, 'stable-execution');
-    const timestamps = [0, 5_000, 55_000, 235_000].map(offset => STARTED_AT_MS + offset);
-
-    expect(timestamps.map(now => activitySummary(first, now))).toEqual(
-      timestamps.map(now => activitySummary(resumed, now)),
-    );
+    expect(activitySummary(planning)).toBe('Planning');
+    expect(activitySummary(todo)).toBe('Reviewing queue invariants');
+    expect(activitySummary(tool)).toBe('Running queue tests');
+    expect(activitySummary(blankTool)).toBe('Using Bash');
   });
 });

--- a/clients/tui/src/ui/activity-bar.test.ts
+++ b/clients/tui/src/ui/activity-bar.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from 'bun:test';
+import type {ActiveAgentExecution} from '../session-model.js';
+import {activitySummary, THINKING_WORDS} from './activity-bar.js';
+
+const STARTED_AT = '2026-08-25T12:00:00.000Z';
+const STARTED_AT_MS = Date.parse(STARTED_AT);
+
+function execution(
+  activity: ActiveAgentExecution['activity'],
+  executionId = 'execution-1',
+): ActiveAgentExecution {
+  return {
+    executionId,
+    agentKind: 'implementer',
+    roundLabel: 'round-1-implementer',
+    roundNumber: 1,
+    stage: 'implementation',
+    attempt: 1,
+    assignment: 'Implement the queue',
+    startedAt: STARTED_AT,
+    activity,
+  };
+}
+
+describe('activity summary', () => {
+  it('cycles generic thinking words on a stable five-second cadence', () => {
+    const active = execution({mode: 'thinking', summary: 'Thinking'});
+    const first = activitySummary(active, STARTED_AT_MS);
+
+    expect(first).not.toBe('Thinking');
+    expect(activitySummary(active, STARTED_AT_MS + 4_999)).toBe(first);
+    expect(activitySummary(active, STARTED_AT_MS + 5_000)).not.toBe(first);
+    expect(activitySummary(active, STARTED_AT_MS + 5_000)).toBe(
+      activitySummary(active, STARTED_AT_MS + 5_000),
+    );
+
+    const cycle = THINKING_WORDS.map((_, index) =>
+      activitySummary(active, STARTED_AT_MS + index * 5_000),
+    );
+    expect(new Set(cycle).size).toBe(THINKING_WORDS.length);
+    expect(activitySummary(active, STARTED_AT_MS + THINKING_WORDS.length * 5_000)).toBe(first);
+  });
+
+  it('uses a large pool of present-participle activity words', () => {
+    expect(THINKING_WORDS.length).toBeGreaterThanOrEqual(40);
+    expect(new Set(THINKING_WORDS).size).toBe(THINKING_WORDS.length);
+    expect(THINKING_WORDS.every(word => /ing$/i.test(word))).toBe(true);
+    expect(THINKING_WORDS).not.toContain('Thinking');
+  });
+
+  it('preserves specific semantic summaries and tool fallbacks', () => {
+    const planning = execution({mode: 'thinking', summary: 'Planning'});
+    const todo = execution({mode: 'thinking', summary: 'Reviewing queue invariants'});
+    const tool = execution({mode: 'tool', summary: 'Running queue tests', tool: 'Bash'});
+    const blankTool = execution({mode: 'tool', summary: '', tool: 'Bash'});
+
+    expect(activitySummary(planning, STARTED_AT_MS + 10_000)).toBe('Planning');
+    expect(activitySummary(todo, STARTED_AT_MS + 10_000)).toBe('Reviewing queue invariants');
+    expect(activitySummary(tool, STARTED_AT_MS + 10_000)).toBe('Running queue tests');
+    expect(activitySummary(blankTool, STARTED_AT_MS + 10_000)).toBe('Using Bash');
+  });
+
+  it('uses the same deterministic sequence for a resumed execution', () => {
+    const first = execution({mode: 'thinking', summary: ''}, 'stable-execution');
+    const resumed = execution({mode: 'thinking', summary: 'Thinking'}, 'stable-execution');
+    const timestamps = [0, 5_000, 55_000, 235_000].map(offset => STARTED_AT_MS + offset);
+
+    expect(timestamps.map(now => activitySummary(first, now))).toEqual(
+      timestamps.map(now => activitySummary(resumed, now)),
+    );
+  });
+});

--- a/clients/tui/src/ui/activity-bar.test.ts
+++ b/clients/tui/src/ui/activity-bar.test.ts
@@ -21,22 +21,17 @@ function execution(
 }
 
 describe('activity summary', () => {
-  it('uses Working for generic thinking activity', () => {
+  it('uses Working for every activity update', () => {
     expect(activitySummary(execution({mode: 'thinking', summary: ''}))).toBe('Working');
-    expect(activitySummary(execution({mode: 'thinking', summary: 'Thinking'}))).toBe('Working');
-    expect(activitySummary(execution({mode: 'thinking', summary: 'Thinking...'}))).toBe('Working');
-    expect(activitySummary(execution({mode: 'thinking', summary: 'Thinking…'}))).toBe('Working');
-  });
-
-  it('preserves specific semantic summaries and tool fallbacks', () => {
-    const planning = execution({mode: 'thinking', summary: 'Planning'});
-    const todo = execution({mode: 'thinking', summary: 'Reviewing queue invariants'});
-    const tool = execution({mode: 'tool', summary: 'Running queue tests', tool: 'Bash'});
-    const blankTool = execution({mode: 'tool', summary: '', tool: 'Bash'});
-
-    expect(activitySummary(planning)).toBe('Planning');
-    expect(activitySummary(todo)).toBe('Reviewing queue invariants');
-    expect(activitySummary(tool)).toBe('Running queue tests');
-    expect(activitySummary(blankTool)).toBe('Using Bash');
+    expect(activitySummary(execution({mode: 'thinking', summary: 'Planning'}))).toBe('Working');
+    expect(activitySummary(execution({mode: 'responding', summary: 'Writing a response'}))).toBe(
+      'Working',
+    );
+    expect(
+      activitySummary(execution({mode: 'tool', summary: 'Running queue tests', tool: 'Bash'})),
+    ).toBe('Working');
+    expect(activitySummary(execution({mode: 'waiting', summary: 'Waiting for output'}))).toBe(
+      'Working',
+    );
   });
 });

--- a/clients/tui/src/ui/activity-bar.ts
+++ b/clients/tui/src/ui/activity-bar.ts
@@ -5,57 +5,6 @@ import type {Theme} from './theme.js';
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const SPINNER_INTERVAL_MS = 120;
-const THINKING_WORD_INTERVAL_MS = 5_000;
-
-export const THINKING_WORDS = [
-  'Pondering',
-  'Reasoning',
-  'Exploring',
-  'Inspecting',
-  'Analyzing',
-  'Searching',
-  'Reading',
-  'Reviewing',
-  'Checking',
-  'Tracing',
-  'Mapping',
-  'Comparing',
-  'Testing',
-  'Building',
-  'Editing',
-  'Refining',
-  'Validating',
-  'Measuring',
-  'Profiling',
-  'Debugging',
-  'Investigating',
-  'Calculating',
-  'Modeling',
-  'Simulating',
-  'Organizing',
-  'Synthesizing',
-  'Drafting',
-  'Evaluating',
-  'Verifying',
-  'Considering',
-  'Preparing',
-  'Coordinating',
-  'Sequencing',
-  'Optimizing',
-  'Experimenting',
-  'Discovering',
-  'Resolving',
-  'Learning',
-  'Parsing',
-  'Compiling',
-  'Linking',
-  'Sampling',
-  'Forecasting',
-  'Rechecking',
-  'Rethinking',
-  'Iterating',
-  'Focusing',
-] as const;
 export type ActivityBarScope = 'global' | 'conversation';
 
 /** Stable, selection-aware status line for backend-authoritative execution activity. */
@@ -123,64 +72,31 @@ export class ActivityBarView {
     if (this.#executions.length === 1) {
       const execution = this.#executions[0];
       if (execution === undefined) return;
-      this.output.content = `${spinner} ${roleLabel(execution.agentKind)} · ${activitySummary(execution, nowMs)} · ${elapsed(execution.startedAt, nowMs)}`;
+      this.output.content = `${spinner} ${roleLabel(execution.agentKind)} · ${activitySummary(execution)} · ${elapsed(execution.startedAt, nowMs)}`;
       return;
     }
     const summaries = this.#executions
       .slice(0, 3)
-      .map(execution => `${roleLabel(execution.agentKind)}: ${activitySummary(execution, nowMs)}`)
+      .map(execution => `${roleLabel(execution.agentKind)}: ${activitySummary(execution)}`)
       .join(' · ');
     const remainder = this.#executions.length > 3 ? ` · +${this.#executions.length - 3} more` : '';
     this.output.content = `${spinner} ${this.#executions.length} agents active · ${summaries}${remainder}`;
   }
 }
 
-export function activitySummary(execution: ActiveAgentExecution, nowMs = Date.now()): string {
+export function activitySummary(execution: ActiveAgentExecution): string {
   const summary = execution.activity.summary.trim();
   if (
     execution.activity.mode === 'thinking' &&
     (summary === '' || /^thinking(?:\.\.\.|\u2026)?$/i.test(summary))
   ) {
-    return thinkingWord(execution, nowMs);
+    return 'Working';
   }
   if (summary !== '') return summary;
   if (execution.activity.mode === 'tool' && execution.activity.tool) {
     return `Using ${execution.activity.tool}`;
   }
   return modeLabel(execution.activity.mode);
-}
-
-function thinkingWord(execution: ActiveAgentExecution, nowMs: number): string {
-  const hash = stableHash(execution.executionId);
-  const offset = hash % THINKING_WORDS.length;
-  let stride = 1 + ((hash >>> 8) % (THINKING_WORDS.length - 1));
-  while (greatestCommonDivisor(stride, THINKING_WORDS.length) !== 1) stride += 1;
-  if (stride >= THINKING_WORDS.length) stride = 1;
-
-  const startedAtMs = Date.parse(execution.startedAt);
-  const elapsedMs = Number.isFinite(startedAtMs) ? Math.max(0, nowMs - startedAtMs) : 0;
-  const tick = Math.floor(elapsedMs / THINKING_WORD_INTERVAL_MS);
-  return THINKING_WORDS[(offset + tick * stride) % THINKING_WORDS.length] ?? 'Pondering';
-}
-
-function stableHash(value: string): number {
-  let hash = 2_166_136_261;
-  for (const character of value) {
-    hash ^= character.codePointAt(0) ?? 0;
-    hash = Math.imul(hash, 16_777_619);
-  }
-  return hash >>> 0;
-}
-
-function greatestCommonDivisor(left: number, right: number): number {
-  let a = left;
-  let b = right;
-  while (b !== 0) {
-    const remainder = a % b;
-    a = b;
-    b = remainder;
-  }
-  return a;
 }
 
 function roleLabel(role: string): string {
@@ -190,7 +106,7 @@ function roleLabel(role: string): string {
 
 function modeLabel(mode: ActiveAgentExecution['activity']['mode']): string {
   const labels: Record<typeof mode, string> = {
-    thinking: 'Thinking',
+    thinking: 'Working',
     responding: 'Responding',
     tool: 'Using a tool',
     waiting: 'Waiting',

--- a/clients/tui/src/ui/activity-bar.ts
+++ b/clients/tui/src/ui/activity-bar.ts
@@ -1,9 +1,11 @@
 import {type CliRenderer, TextRenderable} from '@opentui/core';
 import type {ActiveAgentExecution, SessionState} from '../session-model.js';
+import {visibleRoundNumber} from '../session-model.js';
 import type {Theme} from './theme.js';
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const SPINNER_INTERVAL_MS = 120;
+export type ActivityBarScope = 'global' | 'conversation';
 
 /** Stable, selection-aware status line for backend-authoritative execution activity. */
 export class ActivityBarView {
@@ -12,9 +14,9 @@ export class ActivityBarView {
   #frame = 0;
   #timer: ReturnType<typeof setInterval> | null = null;
 
-  constructor(renderer: CliRenderer, theme: Theme) {
+  constructor(renderer: CliRenderer, theme: Theme, id = 'activity-bar') {
     this.output = new TextRenderable(renderer, {
-      id: 'activity-bar',
+      id,
       height: 1,
       width: '100%',
       wrapMode: 'none',
@@ -25,18 +27,18 @@ export class ActivityBarView {
     });
   }
 
-  render(state: SessionState): void {
+  render(state: SessionState, scope: ActivityBarScope, visible = true): void {
     const all = Object.values(state.activeExecutions);
-    const selected = all.filter(execution => {
-      if (state.selectedRound !== null && execution.roundNumber !== state.selectedRound)
-        return false;
-      if (state.selectedAgentKind !== null && execution.agentKind !== state.selectedAgentKind)
-        return false;
-      return true;
-    });
-    // Selection gives relevant active work priority. When that selection is
-    // completed, still report other work rather than making the run look idle.
-    this.#executions = selected.length > 0 ? selected : all;
+    const roundNumber = visibleRoundNumber(state);
+    this.#executions = visible
+      ? scope === 'global'
+        ? all
+        : all.filter(
+            execution =>
+              (roundNumber === null || execution.roundNumber === roundNumber) &&
+              (state.selectedAgentKind === null || execution.agentKind === state.selectedAgentKind),
+          )
+      : [];
     this.output.visible = this.#executions.length > 0;
     this.#refresh();
     this.#syncTimer();

--- a/clients/tui/src/ui/activity-bar.ts
+++ b/clients/tui/src/ui/activity-bar.ts
@@ -5,6 +5,57 @@ import type {Theme} from './theme.js';
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const SPINNER_INTERVAL_MS = 120;
+const THINKING_WORD_INTERVAL_MS = 5_000;
+
+export const THINKING_WORDS = [
+  'Pondering',
+  'Reasoning',
+  'Exploring',
+  'Inspecting',
+  'Analyzing',
+  'Searching',
+  'Reading',
+  'Reviewing',
+  'Checking',
+  'Tracing',
+  'Mapping',
+  'Comparing',
+  'Testing',
+  'Building',
+  'Editing',
+  'Refining',
+  'Validating',
+  'Measuring',
+  'Profiling',
+  'Debugging',
+  'Investigating',
+  'Calculating',
+  'Modeling',
+  'Simulating',
+  'Organizing',
+  'Synthesizing',
+  'Drafting',
+  'Evaluating',
+  'Verifying',
+  'Considering',
+  'Preparing',
+  'Coordinating',
+  'Sequencing',
+  'Optimizing',
+  'Experimenting',
+  'Discovering',
+  'Resolving',
+  'Learning',
+  'Parsing',
+  'Compiling',
+  'Linking',
+  'Sampling',
+  'Forecasting',
+  'Rechecking',
+  'Rethinking',
+  'Iterating',
+  'Focusing',
+] as const;
 export type ActivityBarScope = 'global' | 'conversation';
 
 /** Stable, selection-aware status line for backend-authoritative execution activity. */
@@ -68,28 +119,68 @@ export class ActivityBarView {
 
   #refresh(): void {
     const spinner = SPINNER_FRAMES[this.#frame] ?? SPINNER_FRAMES[0];
+    const nowMs = Date.now();
     if (this.#executions.length === 1) {
       const execution = this.#executions[0];
       if (execution === undefined) return;
-      this.output.content = `${spinner} ${roleLabel(execution.agentKind)} · ${activitySummary(execution)} · ${elapsed(execution.startedAt)}`;
+      this.output.content = `${spinner} ${roleLabel(execution.agentKind)} · ${activitySummary(execution, nowMs)} · ${elapsed(execution.startedAt, nowMs)}`;
       return;
     }
     const summaries = this.#executions
       .slice(0, 3)
-      .map(execution => `${roleLabel(execution.agentKind)}: ${activitySummary(execution)}`)
+      .map(execution => `${roleLabel(execution.agentKind)}: ${activitySummary(execution, nowMs)}`)
       .join(' · ');
     const remainder = this.#executions.length > 3 ? ` · +${this.#executions.length - 3} more` : '';
     this.output.content = `${spinner} ${this.#executions.length} agents active · ${summaries}${remainder}`;
   }
 }
 
-function activitySummary(execution: ActiveAgentExecution): string {
+export function activitySummary(execution: ActiveAgentExecution, nowMs = Date.now()): string {
   const summary = execution.activity.summary.trim();
+  if (
+    execution.activity.mode === 'thinking' &&
+    (summary === '' || /^thinking(?:\.\.\.|\u2026)?$/i.test(summary))
+  ) {
+    return thinkingWord(execution, nowMs);
+  }
   if (summary !== '') return summary;
   if (execution.activity.mode === 'tool' && execution.activity.tool) {
     return `Using ${execution.activity.tool}`;
   }
   return modeLabel(execution.activity.mode);
+}
+
+function thinkingWord(execution: ActiveAgentExecution, nowMs: number): string {
+  const hash = stableHash(execution.executionId);
+  const offset = hash % THINKING_WORDS.length;
+  let stride = 1 + ((hash >>> 8) % (THINKING_WORDS.length - 1));
+  while (greatestCommonDivisor(stride, THINKING_WORDS.length) !== 1) stride += 1;
+  if (stride >= THINKING_WORDS.length) stride = 1;
+
+  const startedAtMs = Date.parse(execution.startedAt);
+  const elapsedMs = Number.isFinite(startedAtMs) ? Math.max(0, nowMs - startedAtMs) : 0;
+  const tick = Math.floor(elapsedMs / THINKING_WORD_INTERVAL_MS);
+  return THINKING_WORDS[(offset + tick * stride) % THINKING_WORDS.length] ?? 'Pondering';
+}
+
+function stableHash(value: string): number {
+  let hash = 2_166_136_261;
+  for (const character of value) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return hash >>> 0;
+}
+
+function greatestCommonDivisor(left: number, right: number): number {
+  let a = left;
+  let b = right;
+  while (b !== 0) {
+    const remainder = a % b;
+    a = b;
+    b = remainder;
+  }
+  return a;
 }
 
 function roleLabel(role: string): string {
@@ -107,8 +198,8 @@ function modeLabel(mode: ActiveAgentExecution['activity']['mode']): string {
   return labels[mode];
 }
 
-function elapsed(startedAt: string): string {
-  const milliseconds = Date.now() - Date.parse(startedAt);
+function elapsed(startedAt: string, nowMs: number): string {
+  const milliseconds = nowMs - Date.parse(startedAt);
   const seconds = Number.isFinite(milliseconds) ? Math.max(0, Math.floor(milliseconds / 1000)) : 0;
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);

--- a/clients/tui/src/ui/activity-bar.ts
+++ b/clients/tui/src/ui/activity-bar.ts
@@ -84,34 +84,13 @@ export class ActivityBarView {
   }
 }
 
-export function activitySummary(execution: ActiveAgentExecution): string {
-  const summary = execution.activity.summary.trim();
-  if (
-    execution.activity.mode === 'thinking' &&
-    (summary === '' || /^thinking(?:\.\.\.|\u2026)?$/i.test(summary))
-  ) {
-    return 'Working';
-  }
-  if (summary !== '') return summary;
-  if (execution.activity.mode === 'tool' && execution.activity.tool) {
-    return `Using ${execution.activity.tool}`;
-  }
-  return modeLabel(execution.activity.mode);
+export function activitySummary(_execution: ActiveAgentExecution): string {
+  return 'Working';
 }
 
 function roleLabel(role: string): string {
   if (role === '') return 'Agent';
   return role.charAt(0).toUpperCase() + role.slice(1).replaceAll('_', ' ');
-}
-
-function modeLabel(mode: ActiveAgentExecution['activity']['mode']): string {
-  const labels: Record<typeof mode, string> = {
-    thinking: 'Working',
-    responding: 'Responding',
-    tool: 'Using a tool',
-    waiting: 'Waiting',
-  };
-  return labels[mode];
 }
 
 function elapsed(startedAt: string, nowMs: number): string {

--- a/clients/tui/src/ui/activity-bar.ts
+++ b/clients/tui/src/ui/activity-bar.ts
@@ -1,0 +1,114 @@
+import {type CliRenderer, TextRenderable} from '@opentui/core';
+import type {ActiveAgentExecution, SessionState} from '../session-model.js';
+import type {Theme} from './theme.js';
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const SPINNER_INTERVAL_MS = 120;
+
+/** Stable, selection-aware status line for backend-authoritative execution activity. */
+export class ActivityBarView {
+  readonly output: TextRenderable;
+  #executions: ActiveAgentExecution[] = [];
+  #frame = 0;
+  #timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(renderer: CliRenderer, theme: Theme) {
+    this.output = new TextRenderable(renderer, {
+      id: 'activity-bar',
+      height: 1,
+      width: '100%',
+      wrapMode: 'none',
+      truncate: true,
+      fg: theme.textMuted,
+      content: '',
+      visible: false,
+    });
+  }
+
+  render(state: SessionState): void {
+    const all = Object.values(state.activeExecutions);
+    const selected = all.filter(execution => {
+      if (state.selectedRound !== null && execution.roundNumber !== state.selectedRound)
+        return false;
+      if (state.selectedAgentKind !== null && execution.agentKind !== state.selectedAgentKind)
+        return false;
+      return true;
+    });
+    // Selection gives relevant active work priority. When that selection is
+    // completed, still report other work rather than making the run look idle.
+    this.#executions = selected.length > 0 ? selected : all;
+    this.output.visible = this.#executions.length > 0;
+    this.#refresh();
+    this.#syncTimer();
+  }
+
+  applyTheme(theme: Theme): void {
+    this.output.fg = theme.textMuted;
+  }
+
+  destroy(): void {
+    if (this.#timer !== null) clearInterval(this.#timer);
+    this.#timer = null;
+  }
+
+  #syncTimer(): void {
+    if (this.#executions.length === 0) {
+      if (this.#timer !== null) clearInterval(this.#timer);
+      this.#timer = null;
+      return;
+    }
+    if (this.#timer !== null) return;
+    this.#timer = setInterval(() => {
+      this.#frame = (this.#frame + 1) % SPINNER_FRAMES.length;
+      this.#refresh();
+    }, SPINNER_INTERVAL_MS);
+  }
+
+  #refresh(): void {
+    const spinner = SPINNER_FRAMES[this.#frame] ?? SPINNER_FRAMES[0];
+    if (this.#executions.length === 1) {
+      const execution = this.#executions[0];
+      if (execution === undefined) return;
+      this.output.content = `${spinner} ${roleLabel(execution.agentKind)} · ${activitySummary(execution)} · ${elapsed(execution.startedAt)}`;
+      return;
+    }
+    const summaries = this.#executions
+      .slice(0, 3)
+      .map(execution => `${roleLabel(execution.agentKind)}: ${activitySummary(execution)}`)
+      .join(' · ');
+    const remainder = this.#executions.length > 3 ? ` · +${this.#executions.length - 3} more` : '';
+    this.output.content = `${spinner} ${this.#executions.length} agents active · ${summaries}${remainder}`;
+  }
+}
+
+function activitySummary(execution: ActiveAgentExecution): string {
+  const summary = execution.activity.summary.trim();
+  if (summary !== '') return summary;
+  if (execution.activity.mode === 'tool' && execution.activity.tool) {
+    return `Using ${execution.activity.tool}`;
+  }
+  return modeLabel(execution.activity.mode);
+}
+
+function roleLabel(role: string): string {
+  if (role === '') return 'Agent';
+  return role.charAt(0).toUpperCase() + role.slice(1).replaceAll('_', ' ');
+}
+
+function modeLabel(mode: ActiveAgentExecution['activity']['mode']): string {
+  const labels: Record<typeof mode, string> = {
+    thinking: 'Thinking',
+    responding: 'Responding',
+    tool: 'Using a tool',
+    waiting: 'Waiting',
+  };
+  return labels[mode];
+}
+
+function elapsed(startedAt: string): string {
+  const milliseconds = Date.now() - Date.parse(startedAt);
+  const seconds = Number.isFinite(milliseconds) ? Math.max(0, Math.floor(milliseconds / 1000)) : 0;
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${seconds % 60}s`;
+}

--- a/clients/tui/src/ui/agent-graph.ts
+++ b/clients/tui/src/ui/agent-graph.ts
@@ -282,7 +282,12 @@ function direction(deltaX: number, deltaY: number): number {
 }
 
 function edgeTone(source: AgentPhase, target: AgentPhase): EdgeTone {
-  if (source.status === 'failed') return 'failed';
+  if (
+    source.status === 'failed' ||
+    source.status === 'cancelled' ||
+    source.status === 'interrupted'
+  )
+    return 'failed';
   if (source.status === 'active' || (source.status === 'completed' && target.status === 'active')) {
     return 'live';
   }

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -21,6 +21,8 @@ const STATUS_MARKER: Record<AgentPhase['status'], string> = {
   active: '●',
   completed: '✓',
   failed: '×',
+  cancelled: '■',
+  interrupted: '!',
 };
 
 /** Width the stacked fallback uses, and the width this pane had before. */
@@ -34,6 +36,7 @@ function statusColor(theme: Theme, status: AgentPhase['status']): string {
   if (status === 'active') return theme.success;
   if (status === 'completed') return theme.info;
   if (status === 'failed') return theme.error;
+  if (status === 'cancelled' || status === 'interrupted') return theme.warning;
   return theme.textSubtle;
 }
 
@@ -388,6 +391,8 @@ export function phaseSummary(phases: AgentPhase[]): string {
     `${count('completed')} done`,
   ];
   if (count('failed') > 0) parts.push(`${count('failed')} failed`);
+  if (count('cancelled') > 0) parts.push(`${count('cancelled')} cancelled`);
+  if (count('interrupted') > 0) parts.push(`${count('interrupted')} interrupted`);
   const pending = count('pending');
   if (pending > 0) parts.push(`${pending} waiting`);
   return parts.join(' · ');

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -377,8 +377,20 @@ describe('OpenTUI presentation', () => {
       line.includes('Implementer · Editing the queue'),
     );
     const helpLine = lines.findIndex(line => line.includes('[/]: round'));
+    const viewportBottomBorder = lines.findIndex(
+      (line, index) =>
+        index > activityLineIndex && index < helpLine && line.trimEnd().endsWith('╯'),
+    );
     expect(activityLineIndex).toBeGreaterThan(promptLine);
-    expect(activityLineIndex).toBeLessThan(helpLine);
+    expect(activityLine?.trimEnd().endsWith('│')).toBe(true);
+    expect(viewportBottomBorder).toBeGreaterThan(activityLineIndex);
+    expect(viewportBottomBorder).toBeLessThan(helpLine);
+    const transcriptColumn = Math.max(0, (activityLine?.indexOf('Implementer') ?? 2) - 2);
+    expect(
+      lines
+        .slice(activityLineIndex + 1, viewportBottomBorder)
+        .every(line => line.slice(transcriptColumn).replaceAll('│', '').trim() === ''),
+    ).toBe(true);
 
     controller.selectAgent('implementer');
     await frameAfter(testRenderer);

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -253,8 +253,8 @@ describe('OpenTUI presentation', () => {
     // A phase is running, but individual turn cards do not claim ownership of
     // that activity because the transcript may be filtered to another agent.
     const live = await testRenderer.waitForFrame(value => value.includes('checking the diff'));
-    expect(live).not.toContain('Working');
-    expect(live).toContain('Judge · Checking the diff');
+    expect(live).toContain('Judge · Working');
+    expect(live).not.toContain('Judge · Checking the diff');
 
     // Arrows put a cursor on an entry without touching the input.
     testRenderer.mockInput.pressKey('ARROW_UP');
@@ -268,8 +268,8 @@ describe('OpenTUI presentation', () => {
     expect(filtered).toContain('edited the kernel');
     expect(filtered).not.toContain('checking the diff');
     // A completed filtered transcript must not inherit another agent's live
-    // activity. The global summary remains available on the experiment log.
-    expect(filtered).not.toContain('Judge · Checking the diff');
+    // activity. The global working indicator remains available on the experiment log.
+    expect(filtered).not.toContain('Judge · Working');
   });
 
   it('summarizes concurrent executions and disappears when they finish', async () => {
@@ -307,8 +307,10 @@ describe('OpenTUI presentation', () => {
     registerCleanup(testRenderer.renderer, app);
 
     const active = await testRenderer.waitForFrame(value => value.includes('2 agents active'));
-    expect(active).toContain('Implementer: Running queue tests');
-    expect(active).toContain('Reviewer: Inspecting the diff');
+    expect(active).toContain('Implementer: Working');
+    expect(active).toContain('Reviewer: Working');
+    expect(active).not.toContain('Running queue tests');
+    expect(active).not.toContain('Inspecting the diff');
 
     controller.publish({...controller.state, activeExecutions: {}});
     const finished = await frameAfter(testRenderer);
@@ -344,7 +346,7 @@ describe('OpenTUI presentation', () => {
     const app = createOpenTuiApp(testRenderer.renderer, controller);
     registerCleanup(testRenderer.renderer, app);
     const idle = await testRenderer.waitForFrame(value => value.includes('Implement the queue'));
-    expect(idle).not.toContain('Implementer · Editing the queue');
+    expect(idle).not.toContain('Implementer · Working');
 
     controller.publish({
       ...controller.state,
@@ -364,18 +366,15 @@ describe('OpenTUI presentation', () => {
     });
 
     const active = await testRenderer.waitForFrame(value =>
-      value.includes('Implementer · Editing the queue'),
+      value.includes('Implementer · Working'),
     );
-    expect(active).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] Implementer · Editing the queue · \d+s/);
-    const activityLine = active
-      .split('\n')
-      .find(line => line.includes('Implementer · Editing the queue'));
+    expect(active).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] Implementer · Working · \d+s/);
+    expect(active).not.toContain('Editing the queue');
+    const activityLine = active.split('\n').find(line => line.includes('Implementer · Working'));
     expect(activityLine?.indexOf('Implementer')).toBeGreaterThan(20);
     const lines = active.split('\n');
     const promptLine = lines.findIndex(line => line.includes('Implement the queue'));
-    const activityLineIndex = lines.findIndex(line =>
-      line.includes('Implementer · Editing the queue'),
-    );
+    const activityLineIndex = lines.findIndex(line => line.includes('Implementer · Working'));
     const helpLine = lines.findIndex(line => line.includes('[/]: round'));
     const viewportBottomBorder = lines.findIndex(
       (line, index) =>
@@ -396,7 +395,7 @@ describe('OpenTUI presentation', () => {
     await frameAfter(testRenderer);
     controller.selectAgent('implementer');
     const reopened = await frameAfter(testRenderer);
-    expect(reopened).toContain('Implementer · Editing the queue');
+    expect(reopened).toContain('Implementer · Working');
   });
 
   it('keeps activity fixed while a new turn changes the scroll height', async () => {
@@ -464,12 +463,14 @@ describe('OpenTUI presentation', () => {
     const frame = testRenderer.renderer.root.findDescendantById('viewport');
     const scroll = testRenderer.renderer.root.findDescendantById('transcript-scroll');
     const activity = testRenderer.renderer.root.findDescendantById('conversation-activity-bar');
+    if (frame === undefined || activity === undefined)
+      throw new Error('transcript frame was missing');
     if (!(scroll instanceof ScrollBoxRenderable)) throw new Error('transcript was not scrollable');
     expect(scroll.parent).toBe(frame);
     expect(activity?.parent).toBe(frame);
   });
 
-  it('keeps the global activity summary on the hypothesis log', async () => {
+  it('keeps the global working indicator on the hypothesis log', async () => {
     const testRenderer = await createTestRenderer({width: 100, height: 20});
     const controller = new FakeController({
       ...initialSessionState(),
@@ -491,10 +492,9 @@ describe('OpenTUI presentation', () => {
     const app = createOpenTuiApp(testRenderer.renderer, controller);
     registerCleanup(testRenderer.renderer, app);
 
-    const frame = await testRenderer.waitForFrame(value =>
-      value.includes('Implementer · Editing the queue'),
-    );
+    const frame = await testRenderer.waitForFrame(value => value.includes('Implementer · Working'));
     expect(frame).toContain('Experiments');
+    expect(frame).not.toContain('Editing the queue');
   });
 
   it('shows the whole run in the strip and keeps early rounds reachable', async () => {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -267,9 +267,9 @@ describe('OpenTUI presentation', () => {
     const filtered = await frameAfter(testRenderer);
     expect(filtered).toContain('edited the kernel');
     expect(filtered).not.toContain('checking the diff');
-    // The selected implementer is complete, so the stable status line still
-    // reports the judge that is actually active.
-    expect(filtered).toContain('Judge · Checking the diff');
+    // A completed filtered transcript must not inherit another agent's live
+    // activity. The global summary remains available on the experiment log.
+    expect(filtered).not.toContain('Judge · Checking the diff');
   });
 
   it('summarizes concurrent executions and disappears when they finish', async () => {
@@ -314,6 +314,105 @@ describe('OpenTUI presentation', () => {
     const finished = await frameAfter(testRenderer);
     expect(finished).not.toContain('agents active');
     expect(finished).not.toContain('Running queue tests');
+  });
+
+  it('shows activity when an execution starts after its agent conversation is opened', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 20});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      rounds: [{number: 1, status: 'active'}],
+      phases: [
+        {
+          kind: 'implementer',
+          status: 'pending',
+          roundNumber: 1,
+          roundLabel: 'round-1-implementer',
+        },
+      ],
+      selectedRound: 1,
+      selectedAgentKind: 'implementer',
+      conversation: [
+        {
+          id: 'prompt',
+          kind: 'prompt',
+          content: 'Implement the queue',
+          agentKind: 'implementer',
+          roundNumber: 1,
+        },
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    const idle = await testRenderer.waitForFrame(value => value.includes('Implement the queue'));
+    expect(idle).not.toContain('Implementer · Editing the queue');
+
+    controller.publish({
+      ...controller.state,
+      activeExecutions: {
+        'impl-1': {
+          executionId: 'impl-1',
+          agentKind: 'implementer',
+          roundLabel: 'round-1-implementer',
+          roundNumber: 1,
+          stage: 'implementation',
+          attempt: 1,
+          assignment: 'Implement the queue',
+          startedAt: new Date().toISOString(),
+          activity: {mode: 'responding', summary: 'Editing the queue'},
+        },
+      },
+    });
+
+    const active = await testRenderer.waitForFrame(value =>
+      value.includes('Implementer · Editing the queue'),
+    );
+    expect(active).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] Implementer · Editing the queue · \d+s/);
+    const activityLine = active
+      .split('\n')
+      .find(line => line.includes('Implementer · Editing the queue'));
+    expect(activityLine?.indexOf('Implementer')).toBeGreaterThan(20);
+    const lines = active.split('\n');
+    const promptLine = lines.findIndex(line => line.includes('Implement the queue'));
+    const activityLineIndex = lines.findIndex(line =>
+      line.includes('Implementer · Editing the queue'),
+    );
+    const helpLine = lines.findIndex(line => line.includes('[/]: round'));
+    expect(activityLineIndex).toBeGreaterThan(promptLine);
+    expect(activityLineIndex).toBeLessThan(helpLine);
+
+    controller.selectAgent('implementer');
+    await frameAfter(testRenderer);
+    controller.selectAgent('implementer');
+    const reopened = await frameAfter(testRenderer);
+    expect(reopened).toContain('Implementer · Editing the queue');
+  });
+
+  it('keeps the global activity summary on the hypothesis log', async () => {
+    const testRenderer = await createTestRenderer({width: 100, height: 20});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      activeExecutions: {
+        'impl-1': {
+          executionId: 'impl-1',
+          agentKind: 'implementer',
+          roundLabel: 'round-1-implementer',
+          roundNumber: 1,
+          stage: 'implementation',
+          attempt: 1,
+          assignment: 'Implement the queue',
+          startedAt: new Date().toISOString(),
+          activity: {mode: 'responding', summary: 'Editing the queue'},
+        },
+      },
+    });
+    controller.publish({...controller.state, experimentLog: initialSessionState().experimentLog});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value =>
+      value.includes('Implementer · Editing the queue'),
+    );
+    expect(frame).toContain('Experiments');
   });
 
   it('shows the whole run in the strip and keeps early rounds reachable', async () => {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -398,7 +398,7 @@ describe('OpenTUI presentation', () => {
     expect(reopened).toContain('Implementer · Working');
   });
 
-  it('keeps activity fixed while a new turn changes the scroll height', async () => {
+  it('keeps activity fixed and aligned while a new turn changes the scroll height', async () => {
     const conversation = Array.from({length: 12}, (_, index) => ({
       id: `turn-${index}`,
       kind: 'status' as const,
@@ -463,11 +463,13 @@ describe('OpenTUI presentation', () => {
     const frame = testRenderer.renderer.root.findDescendantById('viewport');
     const scroll = testRenderer.renderer.root.findDescendantById('transcript-scroll');
     const activity = testRenderer.renderer.root.findDescendantById('conversation-activity-bar');
+    const firstTurn = testRenderer.renderer.root.findDescendantById('event-turn-0');
     if (frame === undefined || activity === undefined)
       throw new Error('transcript frame was missing');
     if (!(scroll instanceof ScrollBoxRenderable)) throw new Error('transcript was not scrollable');
     expect(scroll.parent).toBe(frame);
     expect(activity?.parent).toBe(frame);
+    expect(firstTurn?.x).toBe(activity.x);
   });
 
   it('keeps the global working indicator on the hypothesis log', async () => {
@@ -1277,6 +1279,21 @@ describe('OpenTUI presentation', () => {
     expect(answer).toContain('Inspecting configuration events');
     expect(answer).toContain('→ Read(run-events.jsonl)');
 
+    const overlay = testRenderer.renderer.root.findDescendantById('chat-overlay');
+    const transcript = testRenderer.renderer.root.findDescendantById('chat-transcript');
+    const turn = testRenderer.renderer.root.findDescendantById('event-chat-user');
+    const input = testRenderer.renderer.root.findDescendantById('chat-input-box');
+    if (
+      overlay === undefined ||
+      transcript === undefined ||
+      turn === undefined ||
+      input === undefined
+    )
+      throw new Error('modal chat geometry was missing');
+    expect(transcript.x).toBe(overlay.x + 2);
+    expect(turn.x).toBe(transcript.x);
+    expect(input.x).toBe(transcript.x);
+
     testRenderer.mockInput.pressKey('ESCAPE');
     await testRenderer.waitForFrame(value => !value.includes('Experiment chat'));
     expect(controller.state.chatOpen).toBe(false);
@@ -1920,6 +1937,14 @@ describe('theming', () => {
     expect(answered).toContain('Prefill dominates.');
     expect(answered).toContain('H-07');
     expect(answered).toContain('Implementation Details');
+
+    const pane = testRenderer.renderer.root.findDescendantById('chat-pane');
+    const scroll = testRenderer.renderer.root.findDescendantById('chat-pane-scroll');
+    const turn = testRenderer.renderer.root.findDescendantById('event-q');
+    if (pane === undefined || scroll === undefined || turn === undefined)
+      throw new Error('docked chat geometry was missing');
+    expect(scroll.x).toBe(pane.x + 2);
+    expect(turn.x).toBe(scroll.x);
   });
 
   it('keeps the chat, the table, and the visualization on screen together', async () => {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, describe, expect, it} from 'bun:test';
-import {InputRenderable, rgbToHex, ScrollBoxRenderable} from '@opentui/core';
+import {CliRenderEvents, InputRenderable, rgbToHex, ScrollBoxRenderable} from '@opentui/core';
 import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
 import type {HypothesisEntry} from '../protocol.js';
 import type {SessionController} from '../session-controller.js';
@@ -397,6 +397,76 @@ describe('OpenTUI presentation', () => {
     controller.selectAgent('implementer');
     const reopened = await frameAfter(testRenderer);
     expect(reopened).toContain('Implementer · Editing the queue');
+  });
+
+  it('keeps activity fixed while a new turn changes the scroll height', async () => {
+    const conversation = Array.from({length: 12}, (_, index) => ({
+      id: `turn-${index}`,
+      kind: 'status' as const,
+      content: `recorded turn ${index}`,
+      agentKind: 'implementer',
+      roundNumber: 1,
+    }));
+    const testRenderer = await createTestRenderer({width: 100, height: 20});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      rounds: [{number: 1, status: 'active'}],
+      selectedRound: 1,
+      selectedAgentKind: 'implementer',
+      conversation,
+      activeExecutions: {
+        'impl-1': {
+          executionId: 'impl-1',
+          agentKind: 'implementer',
+          roundLabel: 'round-1-implementer',
+          roundNumber: 1,
+          stage: 'implementation',
+          attempt: 1,
+          assignment: 'Implement the queue',
+          startedAt: new Date().toISOString(),
+          activity: {mode: 'thinking', summary: 'Thinking'},
+        },
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('Implementer · Working'));
+
+    const frames: string[] = [];
+    const captureFrame = (): void => {
+      frames.push(testRenderer.captureCharFrame());
+    };
+    testRenderer.renderer.on(CliRenderEvents.FRAME, captureFrame);
+    controller.publish({
+      ...controller.state,
+      conversation: [
+        ...conversation,
+        {
+          id: 'new-turn',
+          kind: 'assistant',
+          content: 'newly rendered turn',
+          agentKind: 'implementer',
+          roundNumber: 1,
+        },
+      ],
+    });
+    await testRenderer.waitForVisualIdle();
+    testRenderer.renderer.off(CliRenderEvents.FRAME, captureFrame);
+
+    expect(frames.length).toBeGreaterThan(0);
+    const activityRows = frames.map(frame =>
+      frame.split('\n').findIndex(line => line.includes('Implementer · Working')),
+    );
+    expect(activityRows.every(row => row >= 0)).toBe(true);
+    expect(new Set(activityRows).size).toBe(1);
+    expect(frames.at(-1)).toContain('newly rendered turn');
+
+    const frame = testRenderer.renderer.root.findDescendantById('viewport');
+    const scroll = testRenderer.renderer.root.findDescendantById('transcript-scroll');
+    const activity = testRenderer.renderer.root.findDescendantById('conversation-activity-bar');
+    if (!(scroll instanceof ScrollBoxRenderable)) throw new Error('transcript was not scrollable');
+    expect(scroll.parent).toBe(frame);
+    expect(activity?.parent).toBe(frame);
   });
 
   it('keeps the global activity summary on the hypothesis log', async () => {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -214,6 +214,19 @@ describe('OpenTUI presentation', () => {
         {kind: 'implementer', status: 'completed', roundNumber: 1, roundLabel: 'round-1-impl'},
         {kind: 'judge', status: 'active', roundNumber: 1, roundLabel: 'round-1-judge'},
       ],
+      activeExecutions: {
+        'judge-1': {
+          executionId: 'judge-1',
+          agentKind: 'judge',
+          roundLabel: 'round-1-judge',
+          roundNumber: 1,
+          stage: 'evaluation',
+          attempt: 1,
+          assignment: 'Evaluate the candidate',
+          startedAt: new Date().toISOString(),
+          activity: {mode: 'thinking', summary: 'Checking the diff'},
+        },
+      },
       selectedRound: 1,
       conversation: [
         {
@@ -237,9 +250,11 @@ describe('OpenTUI presentation', () => {
     const app = createOpenTuiApp(testRenderer.renderer, controller);
     registerCleanup(testRenderer.renderer, app);
 
-    // A phase is running, so the newest entry is marked as still working.
+    // A phase is running, but individual turn cards do not claim ownership of
+    // that activity because the transcript may be filtered to another agent.
     const live = await testRenderer.waitForFrame(value => value.includes('checking the diff'));
-    expect(live).toContain('Working');
+    expect(live).not.toContain('Working');
+    expect(live).toContain('Judge · Checking the diff');
 
     // Arrows put a cursor on an entry without touching the input.
     testRenderer.mockInput.pressKey('ARROW_UP');
@@ -252,6 +267,53 @@ describe('OpenTUI presentation', () => {
     const filtered = await frameAfter(testRenderer);
     expect(filtered).toContain('edited the kernel');
     expect(filtered).not.toContain('checking the diff');
+    // The selected implementer is complete, so the stable status line still
+    // reports the judge that is actually active.
+    expect(filtered).toContain('Judge · Checking the diff');
+  });
+
+  it('summarizes concurrent executions and disappears when they finish', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 24});
+    const base = initialSessionState();
+    const controller = new FakeController({
+      ...base,
+      selectedRound: 2,
+      activeExecutions: {
+        implementer: {
+          executionId: 'implementer',
+          agentKind: 'implementer',
+          roundLabel: 'round-2-implementer',
+          roundNumber: 2,
+          stage: 'implementation',
+          attempt: 1,
+          assignment: 'Implement the queue',
+          startedAt: new Date().toISOString(),
+          activity: {mode: 'tool', summary: 'Running queue tests', tool: 'Bash'},
+        },
+        reviewer: {
+          executionId: 'reviewer',
+          agentKind: 'reviewer',
+          roundLabel: 'round-2-review',
+          roundNumber: 2,
+          stage: 'review',
+          attempt: 1,
+          assignment: 'Review the diff',
+          startedAt: new Date().toISOString(),
+          activity: {mode: 'thinking', summary: 'Inspecting the diff'},
+        },
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const active = await testRenderer.waitForFrame(value => value.includes('2 agents active'));
+    expect(active).toContain('Implementer: Running queue tests');
+    expect(active).toContain('Reviewer: Inspecting the diff');
+
+    controller.publish({...controller.state, activeExecutions: {}});
+    const finished = await frameAfter(testRenderer);
+    expect(finished).not.toContain('agents active');
+    expect(finished).not.toContain('Running queue tests');
   });
 
   it('shows the whole run in the strip and keeps early rounds reachable', async () => {
@@ -1275,6 +1337,8 @@ describe('theming', () => {
       phases: [
         {kind: 'implementer', status: 'completed', roundNumber: 1, roundLabel: 'round-1'},
         {kind: 'judge', status: 'failed', roundNumber: 1, roundLabel: 'round-1'},
+        {kind: 'profiler', status: 'cancelled', roundNumber: 1, roundLabel: 'round-1'},
+        {kind: 'reviewer', status: 'interrupted', roundNumber: 1, roundLabel: 'round-1'},
       ],
       todoPhases: [
         {
@@ -1296,6 +1360,10 @@ describe('theming', () => {
     expect(frame).toContain('× judge');
     expect(frame).toContain('completed');
     expect(frame).toContain('failed');
+    expect(frame).toContain('■ profiler');
+    expect(frame).toContain('cancelled');
+    expect(frame).toContain('! reviewer');
+    expect(frame).toContain('interrupted');
     expect(frame).toContain('✓ write the kernel');
     expect(frame).toContain('▶ benchmark it');
   });

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -82,6 +82,8 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     width: 'auto',
     flexGrow: 1,
     flexDirection: 'column',
+    paddingLeft: 1,
+    paddingRight: 1,
     border: true,
     borderStyle: 'rounded',
     borderColor: theme.border,
@@ -174,8 +176,9 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   controller.onTogglePrompt(() => conversation.toggleLatestPrompt());
   viewport.add(conversation.output);
   transcriptFrame.add(viewport);
-  // Activity belongs inside the transcript frame, but outside its scrolling
-  // content. A new turn can then change scroll height without moving the line.
+  // The frame owns the shared horizontal inset for both turn cards and the
+  // fixed activity row. Activity stays outside scrolling content, so a new
+  // turn can change scroll height without moving the line.
   transcriptFrame.add(conversationActivityBar.output);
   main.add(agentMap.output);
   // The chat is the leftmost column of the landing view, so it is added before

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -106,13 +106,21 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   const todoStrip = new TodoStripView(renderer, controller, theme);
   const errorBanner = new ErrorBannerView(renderer, theme);
   const agentMap = new AgentMapView(renderer, controller, theme);
-  const activityBar = new ActivityBarView(renderer, theme);
+  const globalActivityBar = new ActivityBarView(renderer, theme, 'global-activity-bar');
+  const conversationActivityBar = new ActivityBarView(renderer, theme, 'conversation-activity-bar');
   const overlay = new OverlayView(renderer, theme);
   const experimentLog = new ExperimentLogView(renderer, controller, theme);
   const rightPane = new RightPaneView(renderer, theme);
   const themePicker = new ThemePickerView(renderer, theme);
   const conversation = new ConversationView(renderer, controller, markdownStyle, theme, {
     showsSelection: true,
+  });
+  const transcriptColumn = new BoxRenderable(renderer, {
+    id: 'transcript-column',
+    width: 'auto',
+    flexGrow: 1,
+    flexShrink: 1,
+    flexDirection: 'column',
   });
   const chat = new ChatOverlayView(renderer, controller, markdownStyle, theme);
   const chatPane = new ChatPaneView(renderer, controller, markdownStyle, theme);
@@ -166,11 +174,13 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   // request, the transcript decides which prompt it applies to.
   controller.onTogglePrompt(() => conversation.toggleLatestPrompt());
   viewport.add(conversation.output);
+  transcriptColumn.add(viewport);
+  transcriptColumn.add(conversationActivityBar.output);
   main.add(agentMap.output);
   // The chat is the leftmost column of the landing view, so it is added before
   // the surfaces it sits beside.
   main.add(chatPane.output);
-  main.add(viewport);
+  main.add(transcriptColumn);
   // The log lives in the main pane rather than floating over it: it is the
   // landing view, not a dialog.
   main.add(experimentLog.output);
@@ -189,7 +199,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   root.add(roundStrip.output);
   root.add(main);
   root.add(todoStrip.output);
-  root.add(activityBar.output);
+  root.add(globalActivityBar.output);
   root.add(bottom);
   root.add(overlay.output);
   root.add(themePicker.output);
@@ -210,7 +220,8 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     todoStrip.applyTheme(theme);
     errorBanner.applyTheme(theme);
     agentMap.applyTheme(theme);
-    activityBar.applyTheme(theme);
+    globalActivityBar.applyTheme(theme);
+    conversationActivityBar.applyTheme(theme);
     overlay.applyTheme(theme);
     experimentLog.applyTheme(theme);
     rightPane.applyTheme(theme);
@@ -272,6 +283,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     // hypothesis trajectory, not to the list of claims.
     agentMap.output.visible = !showLog;
     viewport.visible = !showLog;
+    transcriptColumn.visible = !showLog;
     roundStrip.output.visible = !showLog;
     todoStrip.output.visible = !showLog;
     if (!showLog) {
@@ -338,7 +350,8 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     );
     themePicker.render(state);
     chat.render(state);
-    activityBar.render(state);
+    globalActivityBar.render(state, 'global', showLog);
+    conversationActivityBar.render(state, 'conversation', !showLog);
     // One cursor, three places it can be. The modal owns it while it is open;
     // otherwise it belongs to whichever input the pane focus points at.
     const target: FocusTarget = state.chatOpen ? 'modal' : chatInputFocused ? 'chat' : 'command';
@@ -385,7 +398,8 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
       input.destroy();
       chatInput.destroy();
       chat.destroy();
-      activityBar.destroy();
+      globalActivityBar.destroy();
+      conversationActivityBar.destroy();
       roundStrip.destroy();
       agentMap.destroy();
       experimentLog.destroy();

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -7,6 +7,7 @@ import {
   stripRounds,
   visibleRoundNumber,
 } from '../session-model.js';
+import {ActivityBarView} from './activity-bar.js';
 import {AgentMapView} from './agent-map.js';
 import {ChatOverlayView} from './chat-overlay.js';
 import {ChatPaneView, chatDockFits, chatPaneWidth} from './chat-pane.js';
@@ -105,6 +106,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   const todoStrip = new TodoStripView(renderer, controller, theme);
   const errorBanner = new ErrorBannerView(renderer, theme);
   const agentMap = new AgentMapView(renderer, controller, theme);
+  const activityBar = new ActivityBarView(renderer, theme);
   const overlay = new OverlayView(renderer, theme);
   const experimentLog = new ExperimentLogView(renderer, controller, theme);
   const rightPane = new RightPaneView(renderer, theme);
@@ -187,6 +189,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   root.add(roundStrip.output);
   root.add(main);
   root.add(todoStrip.output);
+  root.add(activityBar.output);
   root.add(bottom);
   root.add(overlay.output);
   root.add(themePicker.output);
@@ -207,6 +210,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     todoStrip.applyTheme(theme);
     errorBanner.applyTheme(theme);
     agentMap.applyTheme(theme);
+    activityBar.applyTheme(theme);
     overlay.applyTheme(theme);
     experimentLog.applyTheme(theme);
     rightPane.applyTheme(theme);
@@ -334,6 +338,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     );
     themePicker.render(state);
     chat.render(state);
+    activityBar.render(state);
     // One cursor, three places it can be. The modal owns it while it is open;
     // otherwise it belongs to whichever input the pane focus points at.
     const target: FocusTarget = state.chatOpen ? 'modal' : chatInputFocused ? 'chat' : 'command';
@@ -380,7 +385,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
       input.destroy();
       chatInput.destroy();
       chat.destroy();
-      conversation.destroy();
+      activityBar.destroy();
       roundStrip.destroy();
       agentMap.destroy();
       experimentLog.destroy();

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -77,13 +77,19 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     fg: theme.accent,
     content: 'VibeSys · connecting',
   });
-  const viewport = new ScrollBoxRenderable(renderer, {
+  const transcriptFrame = new BoxRenderable(renderer, {
     id: 'viewport',
     width: 'auto',
     flexGrow: 1,
+    flexDirection: 'column',
     border: true,
     borderStyle: 'rounded',
     borderColor: theme.border,
+  });
+  const viewport = new ScrollBoxRenderable(renderer, {
+    id: 'transcript-scroll',
+    width: '100%',
+    flexGrow: 1,
     stickyScroll: true,
     stickyStart: 'bottom',
     viewportCulling: true,
@@ -167,15 +173,15 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   // request, the transcript decides which prompt it applies to.
   controller.onTogglePrompt(() => conversation.toggleLatestPrompt());
   viewport.add(conversation.output);
-  // The selected agent's activity is part of the turn stream: keep it as the
-  // final row inside the bordered, scrollable transcript rather than as chrome
-  // beneath the conversation.
-  viewport.add(conversationActivityBar.output);
+  transcriptFrame.add(viewport);
+  // Activity belongs inside the transcript frame, but outside its scrolling
+  // content. A new turn can then change scroll height without moving the line.
+  transcriptFrame.add(conversationActivityBar.output);
   main.add(agentMap.output);
   // The chat is the leftmost column of the landing view, so it is added before
   // the surfaces it sits beside.
   main.add(chatPane.output);
-  main.add(viewport);
+  main.add(transcriptFrame);
   // The log lives in the main pane rather than floating over it: it is the
   // landing view, not a dialog.
   main.add(experimentLog.output);
@@ -209,7 +215,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     markdownStyle = createMarkdownStyle(theme);
     root.backgroundColor = theme.canvas;
     header.fg = theme.accent;
-    viewport.borderColor = theme.border;
+    transcriptFrame.borderColor = theme.border;
     help.fg = theme.textSubtle;
     roundStrip.applyTheme(theme);
     todoStrip.applyTheme(theme);
@@ -277,7 +283,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     // The round strip and agent map are per-round detail. They belong to a
     // hypothesis trajectory, not to the list of claims.
     agentMap.output.visible = !showLog;
-    viewport.visible = !showLog;
+    transcriptFrame.visible = !showLog;
     roundStrip.output.visible = !showLog;
     todoStrip.output.visible = !showLog;
     if (!showLog) {
@@ -302,7 +308,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     const transcriptFocused = showLog
       ? showSplit && state.layout.focus === 'left'
       : state.roundFocus === 'transcript';
-    viewport.borderColor = transcriptFocused ? theme.borderFocus : theme.border;
+    transcriptFrame.borderColor = transcriptFocused ? theme.borderFocus : theme.border;
     // Match the chat to the left pane's rectangle so it sits beside the
     // visualization instead of over it. Bounds come from the siblings that
     // actually occupy those rows, so a taller todo strip still fits.

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -115,13 +115,6 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   const conversation = new ConversationView(renderer, controller, markdownStyle, theme, {
     showsSelection: true,
   });
-  const transcriptColumn = new BoxRenderable(renderer, {
-    id: 'transcript-column',
-    width: 'auto',
-    flexGrow: 1,
-    flexShrink: 1,
-    flexDirection: 'column',
-  });
   const chat = new ChatOverlayView(renderer, controller, markdownStyle, theme);
   const chatPane = new ChatPaneView(renderer, controller, markdownStyle, theme);
   // Clicking either box moves the pane focus to it, so the border, the hint,
@@ -174,13 +167,15 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   // request, the transcript decides which prompt it applies to.
   controller.onTogglePrompt(() => conversation.toggleLatestPrompt());
   viewport.add(conversation.output);
-  transcriptColumn.add(viewport);
-  transcriptColumn.add(conversationActivityBar.output);
+  // The selected agent's activity is part of the turn stream: keep it as the
+  // final row inside the bordered, scrollable transcript rather than as chrome
+  // beneath the conversation.
+  viewport.add(conversationActivityBar.output);
   main.add(agentMap.output);
   // The chat is the leftmost column of the landing view, so it is added before
   // the surfaces it sits beside.
   main.add(chatPane.output);
-  main.add(transcriptColumn);
+  main.add(viewport);
   // The log lives in the main pane rather than floating over it: it is the
   // landing view, not a dialog.
   main.add(experimentLog.output);
@@ -283,7 +278,6 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     // hypothesis trajectory, not to the list of claims.
     agentMap.output.visible = !showLog;
     viewport.visible = !showLog;
-    transcriptColumn.visible = !showLog;
     roundStrip.output.visible = !showLog;
     todoStrip.output.visible = !showLog;
     if (!showLog) {

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -47,12 +47,12 @@ export class ConversationView {
     this.#emptyContent = options.emptyContent ?? 'Waiting for run events…';
     this.#renderMarkdown = options.renderMarkdown ?? true;
     this.#showsSelection = options.showsSelection ?? false;
+    // The bordered surface owns horizontal inset so transcript siblings, such
+    // as a fixed footer, share the same content origin as these turn cards.
     this.output = new BoxRenderable(renderer, {
       id: 'output',
       width: '100%',
       flexDirection: 'column',
-      paddingLeft: 1,
-      paddingRight: 1,
     });
   }
 

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -7,7 +7,7 @@ import {
 } from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
 import type {ConversationEntry, SessionState} from '../session-model.js';
-import {visibleConversation, visiblePhases} from '../session-model.js';
+import {visibleConversation} from '../session-model.js';
 import {promptPreview, toolOutputPreview} from './previews.js';
 import {entryPalette} from './styles.js';
 import type {Theme} from './theme.js';
@@ -16,12 +16,9 @@ export interface ConversationViewOptions {
   selectConversation?: (state: SessionState) => ConversationEntry[];
   emptyContent?: string;
   renderMarkdown?: boolean;
-  /** Whether this view draws the entry cursor and the working marker. */
+  /** Whether this view draws the entry cursor. */
   showsSelection?: boolean;
 }
-
-/** Braille dots: one cell wide in every terminal, unlike a spinner of glyphs. */
-const WORKING_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
 export class ConversationView {
   readonly output: BoxRenderable;
@@ -35,12 +32,7 @@ export class ConversationView {
   #renderedConversation: ConversationEntry[] = [];
   #renderedCards: BoxRenderable[] = [];
   #renderedSelection: string | null = null;
-  #renderedPending = false;
   #selectedId: string | null = null;
-  /** True while the run is still producing output for the last entry. */
-  #pending = false;
-  #workingFrame = 0;
-  #workingTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     private readonly renderer: CliRenderer,
@@ -66,35 +58,19 @@ export class ConversationView {
 
   render(state: SessionState): void {
     const selection = this.#selectionFor(state);
-    const pending = this.#pendingFor(state);
-    if (selection !== this.#renderedSelection || pending !== this.#renderedPending) {
-      // The cursor and the working marker are drawn into the cards, so a change
-      // to either has to redraw them even when the entries are identical.
+    if (selection !== this.#renderedSelection) {
+      // The cursor is drawn into the cards, so a change has to redraw them even
+      // when the entries are identical.
       this.#renderedConversation = [];
       this.#renderedSelection = selection;
-      this.#renderedPending = pending;
     }
     this.#selectedId = selection;
-    this.#pending = pending;
     this.#renderConversation(this.#selectConversation(state));
-    this.#syncWorkingTimer();
   }
 
   /** The transcript owns the entry cursor; the chat panes never show one. */
   #selectionFor(state: SessionState): string | null {
     return this.#showsSelection ? state.selectedEntryId : null;
-  }
-
-  /**
-   * An agent that has started and not finished is still working, so its last
-   * entry carries a marker. Read from the phases rather than from the text, so
-   * it clears the moment the phase does.
-   */
-  #pendingFor(state: SessionState): boolean {
-    // Only the round transcript carries it: in the chat the marker sat on the
-    // answer, where an agent's phase says nothing about the reply.
-    if (!this.#showsSelection) return false;
-    return visiblePhases(state).some(phase => phase.status === 'active');
   }
 
   /**
@@ -113,37 +89,6 @@ export class ConversationView {
     if (this.#selectedId === null) return null;
     const index = this.#renderedConversation.findIndex(entry => entry.id === this.#selectedId);
     return index === -1 ? null : (this.#renderedCards[index] ?? null);
-  }
-
-  /**
-   * The marker animates on its own clock: nothing else about the transcript
-   * changes between frames, so redrawing the whole view would be waste.
-   */
-  #syncWorkingTimer(): void {
-    if (!this.#pending) {
-      this.#stopWorkingTimer();
-      return;
-    }
-    if (this.#workingTimer !== null) return;
-    this.#workingTimer = setInterval(() => {
-      this.#workingFrame = (this.#workingFrame + 1) % WORKING_FRAMES.length;
-      const card = this.#renderedCards.at(-1);
-      const heading = card?.getChildren()[0];
-      const marker = heading?.getChildren()[1];
-      if (marker instanceof TextRenderable) {
-        marker.content = ` ${WORKING_FRAMES[this.#workingFrame]} Working `;
-      }
-    }, 120);
-  }
-
-  #stopWorkingTimer(): void {
-    if (this.#workingTimer === null) return;
-    clearInterval(this.#workingTimer);
-    this.#workingTimer = null;
-  }
-
-  destroy(): void {
-    this.#stopWorkingTimer();
   }
 
   applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {
@@ -176,7 +121,7 @@ export class ConversationView {
       return;
     if (isEntryPrefix(this.#renderedConversation, entries)) {
       for (const entry of entries.slice(this.#renderedConversation.length)) {
-        const card = this.#renderEntry(entry, entry === entries.at(-1));
+        const card = this.#renderEntry(entry);
         this.output.add(card);
         this.#renderedCards.push(card);
       }
@@ -190,7 +135,7 @@ export class ConversationView {
       if (previousCard !== undefined && entry !== undefined) {
         this.output.remove(previousCard);
         previousCard.destroyRecursively();
-        const card = this.#renderEntry(entry, changedIndex === entries.length - 1);
+        const card = this.#renderEntry(entry);
         this.output.add(card, changedIndex);
         this.#renderedCards[changedIndex] = card;
         this.#renderedConversation = entries;
@@ -208,7 +153,7 @@ export class ConversationView {
       return;
     }
     for (const entry of entries) {
-      const card = this.#renderEntry(entry, entry === entries.at(-1));
+      const card = this.#renderEntry(entry);
       this.output.add(card);
       this.#renderedCards.push(card);
     }
@@ -221,7 +166,7 @@ export class ConversationView {
     this.#renderConversation(this.#selectConversation(this.controller.state));
   }
 
-  #renderEntry(entry: ConversationEntry, isLast = false): BoxRenderable {
+  #renderEntry(entry: ConversationEntry): BoxRenderable {
     const palette = entryPalette(entry, this.#theme);
     const selected = this.#selectedId === entry.id;
     const card = new BoxRenderable(this.renderer, {
@@ -262,18 +207,6 @@ export class ConversationView {
         height: 1,
       }),
     );
-    // The last entry of an agent that is still running gets a marker, so a
-    // transcript that has paused mid-turn is told apart from one that is done.
-    if (isLast && this.#pending) {
-      heading.add(
-        new TextRenderable(this.renderer, {
-          content: ` ${WORKING_FRAMES[this.#workingFrame]} Working `,
-          fg: this.#theme.canvas,
-          bg: this.#theme.success,
-          height: 1,
-        }),
-      );
-    }
     card.add(heading);
     if (
       this.#renderMarkdown &&

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -3,7 +3,6 @@
 import json
 import shutil
 import threading
-import uuid
 from collections.abc import Callable, Generator
 from contextlib import ExitStack, contextmanager
 from dataclasses import replace
@@ -1309,10 +1308,13 @@ class _RunContext:
         (e.g. ``iteration=`` for plain-loop runner extensions) still work.
         """
         supervisor = getattr(self, "supervisor", None)
+        execution_id: str | None = None
         if supervisor is not None:
-            # before_agent blocks while paused and returns the prompt with any
-            # queued operator steering appended, so the next invocation sees it.
-            user_prompt = supervisor.before_agent(kind, round_label, user_prompt, system_prompt)
+            execution = supervisor.start_agent_execution(
+                kind, round_label, user_prompt, system_prompt
+            )
+            user_prompt = execution.user_prompt
+            execution_id = execution.execution_id
         result: T | None = None
         error: BaseException | None = None
         try:
@@ -1325,6 +1327,7 @@ class _RunContext:
                 response_cls=response_cls,
                 fallback_factory=fallback_factory,
                 round_label=round_label,
+                invocation_id=execution_id,
                 progress=progress if progress is not None else self.current_progress(),
                 **extra,
             )
@@ -1334,7 +1337,13 @@ class _RunContext:
             raise
         finally:
             if supervisor is not None:
-                supervisor.after_agent(kind, round_label, result=result, error=error)
+                supervisor.after_agent(
+                    kind,
+                    round_label,
+                    result=result,
+                    error=error,
+                    execution_id=execution_id,
+                )
 
     def chat(self, question: str) -> str:
         """Ask a read-only peer agent about the live experiment."""
@@ -1349,16 +1358,25 @@ class _RunContext:
                 return f"Chat agent did not return an answer.\n\nFallback diagnostic:\n{diagnostic}"
 
             assert self.supervisor is not None  # noqa: S101  # tracked: #288
-            invocation_id = uuid.uuid4().hex
             system_prompt = (
                 _EXPERIMENT_CHAT_CONTINUATION_PROMPT
                 if self._chat_history
                 else _EXPERIMENT_CHAT_SYSTEM_PROMPT
             )
+            execution = self.supervisor.start_agent_execution(
+                "chat",
+                "experiment-chat",
+                question,
+                system_prompt,
+                consume_steering=False,
+                participates_in_run_control=False,
+            )
+            answer: str | None = None
+            error: BaseException | None = None
             with self.supervisor.presentation_scope(
                 agent_kind="chat",
                 round_label="experiment-chat",
-                invocation_id=invocation_id,
+                invocation_id=execution.execution_id,
             ):
                 try:
                     answer = self.agent_client.invoke_text(
@@ -1368,11 +1386,25 @@ class _RunContext:
                         env=self.gpu_env(),
                         user_prompt=question,
                         round_label="experiment chat",
-                        invocation_id=invocation_id,
+                        invocation_id=execution.execution_id,
                         progress=self.current_progress(),
                     )
-                except Exception as exc:
-                    raise RuntimeError(f"Chat agent failed: {type(exc).__name__}: {exc}") from exc  # noqa: TRY003  # tracked: #288
+                except BaseException as exc:
+                    error = exc
+                    if isinstance(exc, Exception):
+                        raise RuntimeError(  # noqa: TRY003, TRY004  # tracked: #288
+                            f"Chat agent failed: {type(exc).__name__}: {exc}"
+                        ) from exc
+                    raise
+                finally:
+                    self.supervisor.after_agent(
+                        "chat",
+                        "experiment-chat",
+                        result=answer,
+                        error=error,
+                        execution_id=execution.execution_id,
+                    )
+            assert answer is not None  # noqa: S101  # successful invoke_text returns str
             if not answer.strip():
                 answer = fallback()
             self._chat_history.append((question, answer))

--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -10,7 +10,7 @@ from enum import StrEnum
 from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, ValidationError, model_validator
 
 from vibesys.server.diagnostics import Diagnostic
 
@@ -27,6 +27,9 @@ class EventType(StrEnum):  # noqa: D101  # tracked: #288
     CONTROL = "control"
     INVOCATION_STARTED = "invocation_started"
     INVOCATION_FINISHED = "invocation_finished"
+    AGENT_EXECUTION_STARTED = "agent_execution_started"
+    AGENT_EXECUTION_ACTIVITY_CHANGED = "agent_execution_activity_changed"
+    AGENT_EXECUTION_FINISHED = "agent_execution_finished"
     PHASE_STARTED = "phase_started"
     PHASE_FINISHED = "phase_finished"
     AGENT_OUTPUT_CHUNK = "agent_output_chunk"
@@ -50,6 +53,8 @@ class EventStatus(StrEnum):  # noqa: D101  # tracked: #288
     CONSUMED = "consumed"
     COMPLETED = "completed"
     FAILED = "failed"
+    CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
 
 
 OutputStream = Literal["stdout", "stderr"]
@@ -72,6 +77,37 @@ class InvocationStartedData(BaseModel):  # noqa: D101  # tracked: #288
 
 class InvocationFinishedData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["invocation_finished"] = "invocation_finished"
+    result: Any = None
+    error: str | None = None
+
+
+ExecutionActivityMode = Literal["thinking", "responding", "tool", "waiting"]
+
+
+class AgentExecutionActivityData(BaseModel):
+    """Complete current activity for an active agent execution."""
+
+    kind: Literal["agent_execution_activity_changed"] = "agent_execution_activity_changed"
+    mode: ExecutionActivityMode
+    summary: str
+    tool: str | None = None
+
+
+class AgentExecutionStartedData(BaseModel):
+    """Semantic context for one prompt-to-result agent execution."""
+
+    kind: Literal["agent_execution_started"] = "agent_execution_started"
+    stage: str
+    attempt: int | None = None
+    system_prompt: str = ""
+    user_prompt: str = ""
+    activity: AgentExecutionActivityData
+
+
+class AgentExecutionFinishedData(BaseModel):
+    """Terminal result for one agent execution."""
+
+    kind: Literal["agent_execution_finished"] = "agent_execution_finished"
     result: Any = None
     error: str | None = None
 
@@ -213,6 +249,9 @@ EventData = Annotated[
     ChatData
     | InvocationStartedData
     | InvocationFinishedData
+    | AgentExecutionStartedData
+    | AgentExecutionActivityData
+    | AgentExecutionFinishedData
     | OutputData
     | ServerReadyData
     | RunStartedData
@@ -249,7 +288,25 @@ class RunEvent(BaseModel):
     round_label: str | None = None
     agent_kind: str | None = None
     invocation_id: str | None = None
+    execution_id: str | None = None
     data: EventData | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _execution_identity_compatibility(cls, value: Any) -> Any:  # noqa: ANN401
+        """Expose legacy invocation identity through the canonical field."""
+        if not isinstance(value, dict):
+            return value
+        result = dict(value)
+        execution_id = result.get("execution_id")
+        invocation_id = result.get("invocation_id")
+        if execution_id is None and invocation_id is not None:
+            result["execution_id"] = invocation_id
+        elif invocation_id is None and execution_id is not None:
+            # Retain the old field during the protocol migration so older
+            # presentation clients can still correlate streamed output.
+            result["invocation_id"] = execution_id
+        return result
 
 
 class EventStore:

--- a/src/vibesys/server/inspector.py
+++ b/src/vibesys/server/inspector.py
@@ -36,17 +36,17 @@ class RunInspector:
         if any(word in query for word in ("doing", "current", "status", "now")):
             return self._status_answer(question, self.supervisor.status())
         if any(word in query for word in ("failed", "failure", "why")):
-            failed = self._latest_invocation(status=EventStatus.FAILED)
+            failed = self._latest_execution(status=EventStatus.FAILED)
             answer = (
-                "Latest failed agent invocation:\n" + failed
+                "Latest failed agent execution:\n" + failed
                 if failed
                 else self._search_latest(("judge", "fail", "feedback", "verdict"), "judge result")
             )
             return self._status_answer(question, answer)
         if "judge" in query:
-            judge = self._latest_invocation(agent_kind="judge")
+            judge = self._latest_execution(agent_kind="judge")
             answer = (
-                "Latest judge invocation:\n" + judge
+                "Latest judge execution:\n" + judge
                 if judge
                 else self._search_latest(("judge", "feedback", "verdict"), "judge result")
             )
@@ -138,11 +138,11 @@ class RunInspector:
                 )
         return f"No {label} has been persisted yet."
 
-    def _latest_invocation(
+    def _latest_execution(
         self, *, status: EventStatus | None = None, agent_kind: str | None = None
     ) -> str | None:
         for event in reversed(self.supervisor.read_events()):
-            if event.type is not EventType.INVOCATION_FINISHED:
+            if event.type is not EventType.AGENT_EXECUTION_FINISHED:
                 continue
             if status is not None and event.status is not status:
                 continue

--- a/src/vibesys/server/protocol.py
+++ b/src/vibesys/server/protocol.py
@@ -9,7 +9,7 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Field, FiniteFloat
 
 from vibesys.server.diagnostics import Diagnostic, DiagnosticScope, exception_to_diagnostic
-from vibesys.server.events import RunEvent
+from vibesys.server.events import AgentExecutionActivityData, RunEvent
 
 PROTOCOL_VERSION = 1
 
@@ -87,6 +87,19 @@ ProtocolRequest = Annotated[
 ]
 
 
+class ActiveAgentExecution(ProtocolModel):
+    """Authoritative activity checkpoint for one running agent execution."""
+
+    execution_id: str
+    agent_kind: str
+    round_label: str
+    stage: str
+    attempt: int | None = None
+    assignment: str
+    started_at: datetime
+    activity: AgentExecutionActivityData
+
+
 class RunSnapshot(ProtocolModel):  # noqa: D101  # tracked: #288
     protocol_version: Literal[1] = PROTOCOL_VERSION
     run_id: str
@@ -94,6 +107,7 @@ class RunSnapshot(ProtocolModel):  # noqa: D101  # tracked: #288
     status: str
     agent_kind: str | None = None
     round_label: str | None = None
+    active_executions: list[ActiveAgentExecution] = Field(default_factory=list)
 
 
 class CommandAck(ProtocolModel):  # noqa: D101  # tracked: #288
@@ -212,6 +226,8 @@ class EventMessage(ProtocolModel):  # noqa: D101  # tracked: #288
 class EventBatchMessage(ProtocolModel):  # noqa: D101  # tracked: #288
     type: Literal["event_batch"] = "event_batch"
     events: list[RunEvent]
+    through_sequence: int = Field(default=0, ge=0)
+    active_executions: list[ActiveAgentExecution] = Field(default_factory=list)
 
 
 class ProtocolErrorMessage(ProtocolModel):  # noqa: D101  # tracked: #288

--- a/src/vibesys/server/service.py
+++ b/src/vibesys/server/service.py
@@ -8,6 +8,7 @@ from vibesys.server.events import EventType, RunEvent
 from vibesys.server.experiments import apply_baselines, build_experiment_log
 from vibesys.server.inspector import RunInspector
 from vibesys.server.protocol import (
+    ActiveAgentExecution,
     ChatQuery,
     ChatResult,
     CommandAck,
@@ -94,6 +95,12 @@ class SupervisionService:
 
     def events(self, after_sequence: int = 0) -> list[RunEvent]:  # noqa: D102  # tracked: #288
         return self.supervisor.read_events(after_sequence)
+
+    def subscription_checkpoint(
+        self, after_sequence: int
+    ) -> tuple[int, list[RunEvent], list[ActiveAgentExecution]]:
+        """Return one sequence-consistent replay and activity checkpoint."""
+        return self.supervisor.subscription_checkpoint(after_sequence)
 
     def history_events(self) -> list[RunEvent]:  # noqa: D102  # tracked: #288
         return self.supervisor.read_history_events()

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 import threading
 import uuid
 from collections.abc import Callable, Generator  # noqa: TC003  # tracked: #288
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path  # noqa: TC003  # tracked: #288
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from vibesys.server.diagnostics import (
     Diagnostic,
@@ -20,6 +22,9 @@ from vibesys.server.diagnostics import (
     exception_to_diagnostic,
 )
 from vibesys.server.events import (
+    AgentExecutionActivityData,
+    AgentExecutionFinishedData,
+    AgentExecutionStartedData,
     AgentOutputChannel,
     AgentOutputChunkData,
     ChatData,
@@ -33,22 +38,32 @@ from vibesys.server.events import (
     OutputStream,
     PhaseData,
     RunEvent,
+    TodoUpdateData,
+    ToolCallData,
+    ToolResultData,
     json_value,
     make_event,
 )
-from vibesys.server.protocol import RunSnapshot
+from vibesys.server.protocol import ActiveAgentExecution, RunSnapshot
 
 _MAX_EXCEPTION_CHAIN = 8
 _DIAGNOSTIC_FAILURE_EVENTS = frozenset(
     {
         EventType.CONFIGURATION_FAILED,
         EventType.INVOCATION_FINISHED,
+        EventType.AGENT_EXECUTION_FINISHED,
         EventType.PHASE_FINISHED,
         EventType.RUN_FAILED,
         EventType.RUN_INTERRUPTED,
     }
 )
-_NONTERMINAL_FAILURE_EVENTS = frozenset({EventType.INVOCATION_FINISHED, EventType.PHASE_FINISHED})
+_NONTERMINAL_FAILURE_EVENTS = frozenset(
+    {
+        EventType.INVOCATION_FINISHED,
+        EventType.AGENT_EXECUTION_FINISHED,
+        EventType.PHASE_FINISHED,
+    }
+)
 
 if TYPE_CHECKING:
     from vs_project import Project, StateSnapshot
@@ -69,6 +84,14 @@ class ProjectRunState:
         )
 
 
+@dataclass(frozen=True)
+class AgentExecutionHandle:
+    """Identity and effective prompt returned by an execution start boundary."""
+
+    execution_id: str
+    user_prompt: str
+
+
 class RunSupervisor:
     """Own pause state, invocation metadata, and the run audit store."""
 
@@ -77,7 +100,12 @@ class RunSupervisor:
         self._pause_after_call = False
         self._paused = False
         self._pending_steer: list[str] = []
-        self._active_invocation: str | None = None
+        self._active_executions: dict[str, ActiveAgentExecution] = {}
+        self._execution_todo_summaries: dict[str, str] = {}
+        self._execution_active_tools: dict[str, list[str]] = {}
+        self._run_control_execution_ids: set[str] = set()
+        self._canonical_execution_ids: set[str] = set()
+        self._legacy_invocation_ids: set[str] = set()
         self._run_status = "starting"
         self._store: EventStore | None = None
         self._audit_store: EventStore | None = None
@@ -88,6 +116,7 @@ class RunSupervisor:
         self._current_round: str | None = None
         self._chat_handler: Callable[[str], str] | None = None
         self._presentation_local = threading.local()
+        self._legacy_execution_local = threading.local()
         # An invocation and its terminal run failure often carry the same
         # exception. Keep one diagnostic object so both events identify the
         # same operator-visible failure without reformatting it at each layer.
@@ -133,6 +162,7 @@ class RunSupervisor:
             if store is None:
                 store = EventStore(events_path, run_id=run_id or log_dir.parent.name)
                 self._store = store
+                self._index_execution_lifecycle(store.read())
                 pending, self._pending_events = self._pending_events, []
             else:
                 self._audit_store = EventStore(events_path, run_id=run_id or log_dir.parent.name)
@@ -184,13 +214,91 @@ class RunSupervisor:
         scoped_kind = getattr(self._presentation_local, "agent_kind", None)
         scoped_round = getattr(self._presentation_local, "round_label", None)
         scoped_invocation = getattr(self._presentation_local, "invocation_id", None)
+        execution_id = invocation_id or scoped_invocation
+        if execution_id is not None:
+            activity = self._activity_for_presentation(event_type, data, execution_id)
+            if activity is not None:
+                self.update_agent_execution_activity(execution_id, activity)
         self.record(
             event_type,
             agent_kind=agent_kind or scoped_kind or self._current_kind,
             round_label=round_label or scoped_round or self._current_round,
-            invocation_id=invocation_id or scoped_invocation or self._active_invocation,
+            execution_id=execution_id,
             data=data,
         )
+
+    def _activity_for_presentation(
+        self, event_type: EventType, data: EventData, execution_id: str
+    ) -> AgentExecutionActivityData | None:
+        if event_type is EventType.AGENT_OUTPUT_CHUNK and isinstance(data, AgentOutputChunkData):
+            with self._condition:
+                if self._execution_active_tools.get(execution_id):
+                    return None
+            return _text_activity(data)
+        if event_type is EventType.TOOL_CALL and isinstance(data, ToolCallData):
+            return self._tool_call_activity(execution_id, data)
+        if event_type is EventType.TODO_UPDATE and isinstance(data, TodoUpdateData):
+            return self._todo_activity(execution_id, data)
+        if event_type is EventType.TOOL_RESULT and isinstance(data, ToolResultData):
+            return self._tool_result_activity(execution_id, data)
+        return None
+
+    def _tool_call_activity(
+        self, execution_id: str, data: ToolCallData
+    ) -> AgentExecutionActivityData:
+        with self._condition:
+            self._execution_active_tools.setdefault(execution_id, []).append(data.tool)
+        return AgentExecutionActivityData(mode="tool", summary=f"Using {data.tool}", tool=data.tool)
+
+    def _todo_activity(
+        self, execution_id: str, data: TodoUpdateData
+    ) -> AgentExecutionActivityData | None:
+        current = next((todo.content for todo in data.todos if todo.status == "in_progress"), None)
+        with self._condition:
+            if current is None:
+                self._execution_todo_summaries.pop(execution_id, None)
+                if self._execution_active_tools.get(execution_id):
+                    return None
+                return AgentExecutionActivityData(mode="thinking", summary="Thinking")
+            self._execution_todo_summaries[execution_id] = current
+            if self._execution_active_tools.get(execution_id):
+                return None
+        return AgentExecutionActivityData(mode="thinking", summary=current)
+
+    def _tool_result_activity(
+        self, execution_id: str, data: ToolResultData
+    ) -> AgentExecutionActivityData | None:
+        with self._condition:
+            if execution_id not in self._active_executions:
+                return None
+            tools = self._execution_active_tools.get(execution_id, [])
+            if data.tool in tools:
+                tools.remove(data.tool)
+            remaining_tool = tools[-1] if tools else None
+            todo_summary = self._execution_todo_summaries.get(execution_id)
+        if remaining_tool is not None:
+            return AgentExecutionActivityData(
+                mode="tool", summary=f"Using {remaining_tool}", tool=remaining_tool
+            )
+        return AgentExecutionActivityData(mode="thinking", summary=todo_summary or "Thinking")
+
+    def update_agent_execution_activity(
+        self, execution_id: str, activity: AgentExecutionActivityData
+    ) -> None:
+        """Replace one active execution's semantic activity and publish it once."""
+        with self._condition:
+            active = self._active_executions.get(execution_id)
+            if active is None or active.activity == activity:
+                return
+            self.record(
+                EventType.AGENT_EXECUTION_ACTIVITY_CHANGED,
+                status=EventStatus.ACTIVE,
+                agent_kind=active.agent_kind,
+                round_label=active.round_label,
+                execution_id=execution_id,
+                data=activity,
+            )
+            self._active_executions[execution_id] = active.model_copy(update={"activity": activity})
 
     def record(  # noqa: D102  # tracked: #288
         self,
@@ -212,11 +320,12 @@ class RunSupervisor:
             if store is None:
                 self._pending_events.append(event)
                 return event
-        recorded = store.append(event)
-        audit_store = self._audit_store
-        if audit_store is not None:
-            audit_store.append(event)
-        return recorded
+            recorded = store.append(event)
+            self._index_execution_lifecycle([recorded])
+            audit_store = self._audit_store
+            if audit_store is not None:
+                audit_store.append(event)
+            return recorded
 
     def record_failure(  # noqa: PLR0913  # failure event fields belong at this boundary
         self,
@@ -228,6 +337,7 @@ class RunSupervisor:
         data: EventData | Callable[[Diagnostic], EventData] | None = None,
         text: str | None = None,
         severity: DiagnosticSeverity = DiagnosticSeverity.ERROR,
+        status: EventStatus = EventStatus.FAILED,
         diagnostic: Diagnostic | None = None,
         **fields: Any,  # noqa: ANN401  # tracked: #288
     ) -> RunEvent:
@@ -247,6 +357,7 @@ class RunSupervisor:
             data=data,
             text=text,
             severity=severity,
+            status=status,
             diagnostic=diagnostic,
             **fields,
         )
@@ -261,6 +372,7 @@ class RunSupervisor:
         data: EventData | Callable[[Diagnostic], EventData] | None = None,
         text: str | None = None,
         severity: DiagnosticSeverity = DiagnosticSeverity.ERROR,
+        status: EventStatus = EventStatus.FAILED,
         diagnostic: Diagnostic | None = None,
         **fields: Any,  # noqa: ANN401  # tracked: #288
     ) -> RunEvent:
@@ -274,7 +386,7 @@ class RunSupervisor:
         return self.record(
             event_type,
             diagnostic.summary if text is None else text,
-            status=EventStatus.FAILED,
+            status=status,
             data=event_data,
             diagnostic=diagnostic,
             **fields,
@@ -317,17 +429,32 @@ class RunSupervisor:
             raise
 
     def read_events(self, after_sequence: int = 0) -> list[RunEvent]:  # noqa: D102  # tracked: #288
-        store = self._store
-        return store.read(after_sequence) if store else []
+        with self._condition:
+            store = self._store
+            if store is None:
+                return []
+            return _canonical_execution_events(
+                store.read(after_sequence),
+                canonical_lifecycle_ids=self._canonical_execution_ids,
+                invocation_lifecycle_ids=self._legacy_invocation_ids,
+            )
 
     def read_history_events(self) -> list[RunEvent]:
         """Return the durable session history, including earlier attachments."""
         store = self._audit_store or self._store
-        return store.read() if store else []
+        return _canonical_execution_events(store.read()) if store else []
 
     def wait_for_events(self, after_sequence: int, timeout: float | None = None) -> list[RunEvent]:  # noqa: D102  # tracked: #288
         store = self._store
-        return store.wait(after_sequence, timeout) if store else []
+        if store is None:
+            return []
+        store.wait(after_sequence, timeout)
+        with self._condition:
+            return _canonical_execution_events(
+                store.read(after_sequence),
+                canonical_lifecycle_ids=self._canonical_execution_ids,
+                invocation_lifecycle_ids=self._legacy_invocation_ids,
+            )
 
     def snapshot(self) -> RunSnapshot:  # noqa: D102  # tracked: #288
         with self._condition:
@@ -338,7 +465,42 @@ class RunSupervisor:
                 status="paused" if self._paused else self._run_status,
                 agent_kind=self._current_kind,
                 round_label=self._current_round,
+                active_executions=[
+                    execution.model_copy(deep=True)
+                    for execution in self._active_executions.values()
+                ],
             )
+
+    def subscription_checkpoint(
+        self, after_sequence: int
+    ) -> tuple[int, list[RunEvent], list[ActiveAgentExecution]]:
+        """Atomically capture replay events and active state at one watermark."""
+        with self._condition:
+            store = self._store
+            through_sequence = store.last_sequence if store else 0
+            events = store.read(after_sequence) if store else []
+            events = _canonical_execution_events(
+                events,
+                canonical_lifecycle_ids=self._canonical_execution_ids,
+                invocation_lifecycle_ids=self._legacy_invocation_ids,
+            )
+            events = [event for event in events if event.sequence <= through_sequence]
+            active = [
+                execution.model_copy(deep=True) for execution in self._active_executions.values()
+            ]
+            return through_sequence, events, active
+
+    def _index_execution_lifecycle(self, events: list[RunEvent]) -> None:
+        for event in events:
+            if event.execution_id is None:
+                continue
+            if event.type in {
+                EventType.AGENT_EXECUTION_STARTED,
+                EventType.AGENT_EXECUTION_FINISHED,
+            }:
+                self._canonical_execution_ids.add(event.execution_id)
+            elif event.type in {EventType.INVOCATION_STARTED, EventType.INVOCATION_FINISHED}:
+                self._legacy_invocation_ids.add(event.execution_id)
 
     def chat_agent_available(self) -> bool:
         """True when an agent-backed chat handler is installed for this run.
@@ -433,47 +595,97 @@ class RunSupervisor:
             self._pending_steer.append(text)
         self.record(EventType.CONTROL, f"/steer: {text}", status=EventStatus.PENDING)
 
-    def before_agent(  # noqa: D102  # tracked: #288
-        self, kind: str, round_label: str, user_prompt: str, system_prompt: str = ""
-    ) -> str:
+    def start_agent_execution(  # noqa: PLR0913  # lifecycle and control semantics meet here
+        self,
+        kind: str,
+        round_label: str,
+        user_prompt: str,
+        system_prompt: str = "",
+        *,
+        consume_steering: bool = True,
+        participates_in_run_control: bool = True,
+    ) -> AgentExecutionHandle:
+        """Start one prompt-to-result execution and return its explicit identity."""
         with self._condition:
-            while self._paused:
+            while participates_in_run_control and self._paused:
                 self._condition.wait()
-            steer_messages = self._pending_steer
-            self._pending_steer = []
-            self._current_kind, self._current_round = kind, round_label
-            invocation_id = uuid.uuid4().hex
-            self._active_invocation = invocation_id
-
-        effective_prompt = _with_steering(user_prompt, steer_messages)
-
-        phase = PhaseData(phase=kind, attempt=_attempt_from_label(round_label))
-        self.record(
-            EventType.PHASE_STARTED,
-            status=EventStatus.ACTIVE,
-            agent_kind=kind,
-            round_label=round_label,
-            invocation_id=invocation_id,
-            data=phase,
-        )
-        self.record(
-            EventType.INVOCATION_STARTED,
-            status=EventStatus.ACTIVE,
-            agent_kind=kind,
-            round_label=round_label,
-            invocation_id=invocation_id,
-            data=InvocationStartedData(system_prompt=system_prompt, user_prompt=effective_prompt),
-        )
-        if steer_messages:
-            self.record(
-                EventType.CONTROL,
-                "/steer",
-                status=EventStatus.CONSUMED,
+            steer_messages = (
+                self._pending_steer if consume_steering and participates_in_run_control else []
+            )
+            if consume_steering and participates_in_run_control:
+                self._pending_steer = []
+            if participates_in_run_control:
+                self._current_kind, self._current_round = kind, round_label
+            execution_id = uuid.uuid4().hex
+            effective_prompt = _with_steering(user_prompt, steer_messages)
+            attempt = _attempt_from_label(round_label)
+            activity = AgentExecutionActivityData(
+                mode="thinking", summary=_initial_activity_summary(kind)
+            )
+            active = ActiveAgentExecution(
+                execution_id=execution_id,
                 agent_kind=kind,
                 round_label=round_label,
-                invocation_id=invocation_id,
+                stage=kind,
+                attempt=attempt,
+                assignment=effective_prompt,
+                started_at=datetime.now(UTC),
+                activity=activity,
             )
-        return effective_prompt
+            self.record(
+                EventType.AGENT_EXECUTION_STARTED,
+                status=EventStatus.ACTIVE,
+                agent_kind=kind,
+                round_label=round_label,
+                execution_id=execution_id,
+                data=AgentExecutionStartedData(
+                    stage=kind,
+                    attempt=attempt,
+                    system_prompt=system_prompt,
+                    user_prompt=effective_prompt,
+                    activity=activity,
+                ),
+            )
+            self._active_executions[execution_id] = active
+            if participates_in_run_control:
+                self._run_control_execution_ids.add(execution_id)
+            legacy_phase = PhaseData(phase=kind, attempt=attempt)
+            self.record(
+                EventType.PHASE_STARTED,
+                status=EventStatus.ACTIVE,
+                agent_kind=kind,
+                round_label=round_label,
+                execution_id=execution_id,
+                data=legacy_phase,
+            )
+            self.record(
+                EventType.INVOCATION_STARTED,
+                status=EventStatus.ACTIVE,
+                agent_kind=kind,
+                round_label=round_label,
+                execution_id=execution_id,
+                data=InvocationStartedData(
+                    system_prompt=system_prompt, user_prompt=effective_prompt
+                ),
+            )
+            if steer_messages:
+                self.record(
+                    EventType.CONTROL,
+                    "/steer",
+                    status=EventStatus.CONSUMED,
+                    agent_kind=kind,
+                    round_label=round_label,
+                    execution_id=execution_id,
+                )
+        return AgentExecutionHandle(execution_id=execution_id, user_prompt=effective_prompt)
+
+    def before_agent(
+        self, kind: str, round_label: str, user_prompt: str, system_prompt: str = ""
+    ) -> str:
+        """Compatibility wrapper for callers not yet carrying execution identity."""
+        execution = self.start_agent_execution(kind, round_label, user_prompt, system_prompt)
+        self._legacy_execution_local.execution_id = execution.execution_id
+        return execution.user_prompt
 
     def after_agent(  # noqa: D102  # tracked: #288
         self,
@@ -482,67 +694,115 @@ class RunSupervisor:
         *,
         result: Any = None,  # noqa: ANN401  # tracked: #288
         error: BaseException | None = None,  # noqa: ANN401, RUF100  # tracked: #288
+        execution_id: str | None = None,
     ) -> None:
+        del kind, round_label
+        execution_id = execution_id or getattr(self._legacy_execution_local, "execution_id", None)
+        if execution_id is None:
+            # Compatibility for an old boundary-only caller that reports a
+            # safe point without first opening an invocation.
+            with self._condition:
+                if self._pause_after_call:
+                    self._pause_after_call = False
+                    self._paused = True
+            return
         with self._condition:
-            invocation_id = self._active_invocation
-            self._active_invocation = None
-            should_pause = self._pause_after_call
+            active = self._active_executions.get(execution_id)
+            if active is None:
+                return
+            participates_in_run_control = execution_id in self._run_control_execution_ids
+            should_pause = participates_in_run_control and self._pause_after_call
+            terminal_status = (
+                _execution_error_status(error) if error is not None else EventStatus.COMPLETED
+            )
+            if error is not None:
+                execution_event = self.record_failure(
+                    EventType.AGENT_EXECUTION_FINISHED,
+                    error,
+                    scope=DiagnosticScope.INVOCATION,
+                    operation="Agent execution",
+                    status=terminal_status,
+                    data=lambda diagnostic: AgentExecutionFinishedData(
+                        result=json_value(result), error=diagnostic.summary
+                    ),
+                    agent_kind=active.agent_kind,
+                    round_label=active.round_label,
+                    execution_id=execution_id,
+                )
+                diagnostic = execution_event.diagnostic
+            else:
+                self.record(
+                    EventType.AGENT_EXECUTION_FINISHED,
+                    status=EventStatus.COMPLETED,
+                    data=AgentExecutionFinishedData(result=json_value(result)),
+                    agent_kind=active.agent_kind,
+                    round_label=active.round_label,
+                    execution_id=execution_id,
+                )
+                diagnostic = None
+            self._active_executions.pop(execution_id, None)
+            self._run_control_execution_ids.discard(execution_id)
+            self._execution_todo_summaries.pop(execution_id, None)
+            self._execution_active_tools.pop(execution_id, None)
             if should_pause:
                 self._pause_after_call = False
                 self._paused = True
-
-        phase = PhaseData(phase=kind, attempt=_attempt_from_label(round_label))
-        if error is not None:
-            invocation_event = self.record_failure(
-                EventType.INVOCATION_FINISHED,
-                error,
-                scope=DiagnosticScope.INVOCATION,
-                operation="Agent invocation",
-                data=lambda diagnostic: InvocationFinishedData(
-                    result=json_value(result), error=diagnostic.summary
-                ),
-                agent_kind=kind,
-                round_label=round_label,
-                invocation_id=invocation_id,
+            legacy_finished = InvocationFinishedData(
+                result=json_value(result), error=diagnostic.summary if diagnostic else None
             )
-            invocation_diagnostic = cast("Diagnostic", invocation_event.diagnostic)
-            self.record_failure(
-                EventType.PHASE_FINISHED,
-                error,
-                scope=DiagnosticScope.INVOCATION,
-                operation="Agent invocation",
-                data=phase,
-                diagnostic=invocation_diagnostic,
-                agent_kind=kind,
-                round_label=round_label,
-                invocation_id=invocation_id,
-            )
-        else:
-            self.record(
-                EventType.INVOCATION_FINISHED,
-                status=EventStatus.COMPLETED,
-                data=InvocationFinishedData(result=json_value(result)),
-                agent_kind=kind,
-                round_label=round_label,
-                invocation_id=invocation_id,
-            )
-            self.record(
-                EventType.PHASE_FINISHED,
-                status=EventStatus.COMPLETED,
-                data=phase,
-                agent_kind=kind,
-                round_label=round_label,
-                invocation_id=invocation_id,
-            )
-        if should_pause:
-            self.record(
-                EventType.CONTROL,
-                "/pause",
-                status=EventStatus.CONSUMED,
-                agent_kind=kind,
-                round_label=round_label,
-                invocation_id=invocation_id,
-            )
+            if error is not None:
+                self.record_failure(
+                    EventType.INVOCATION_FINISHED,
+                    error,
+                    scope=DiagnosticScope.INVOCATION,
+                    operation="Agent execution",
+                    status=terminal_status,
+                    data=legacy_finished,
+                    diagnostic=diagnostic,
+                    agent_kind=active.agent_kind,
+                    round_label=active.round_label,
+                    execution_id=execution_id,
+                )
+                self.record_failure(
+                    EventType.PHASE_FINISHED,
+                    error,
+                    scope=DiagnosticScope.INVOCATION,
+                    operation="Agent execution",
+                    status=terminal_status,
+                    data=PhaseData(phase=active.stage, attempt=active.attempt),
+                    diagnostic=diagnostic,
+                    agent_kind=active.agent_kind,
+                    round_label=active.round_label,
+                    execution_id=execution_id,
+                )
+            else:
+                self.record(
+                    EventType.INVOCATION_FINISHED,
+                    status=EventStatus.COMPLETED,
+                    agent_kind=active.agent_kind,
+                    round_label=active.round_label,
+                    execution_id=execution_id,
+                    data=legacy_finished,
+                )
+                self.record(
+                    EventType.PHASE_FINISHED,
+                    status=EventStatus.COMPLETED,
+                    agent_kind=active.agent_kind,
+                    round_label=active.round_label,
+                    execution_id=execution_id,
+                    data=PhaseData(phase=active.stage, attempt=active.attempt),
+                )
+            if should_pause:
+                self.record(
+                    EventType.CONTROL,
+                    "/pause",
+                    status=EventStatus.CONSUMED,
+                    agent_kind=active.agent_kind,
+                    round_label=active.round_label,
+                    execution_id=execution_id,
+                )
+        if getattr(self._legacy_execution_local, "execution_id", None) == execution_id:
+            self._legacy_execution_local.execution_id = None
 
     def status(self) -> str:  # noqa: D102  # tracked: #288
         with self._condition:
@@ -561,6 +821,39 @@ class RunSupervisor:
         with self._condition:
             if self._run_status in {"completed", "failed"}:
                 return
+            for execution_id, active in tuple(self._active_executions.items()):
+                message = "Run ended before the agent execution completed"
+                self.record(
+                    EventType.AGENT_EXECUTION_FINISHED,
+                    message,
+                    status=EventStatus.INTERRUPTED,
+                    data=AgentExecutionFinishedData(error=message),
+                    agent_kind=active.agent_kind,
+                    round_label=active.round_label,
+                    execution_id=execution_id,
+                )
+                self._active_executions.pop(execution_id, None)
+                self._run_control_execution_ids.discard(execution_id)
+                self._execution_todo_summaries.pop(execution_id, None)
+                self._execution_active_tools.pop(execution_id, None)
+                self.record(
+                    EventType.INVOCATION_FINISHED,
+                    message,
+                    status=EventStatus.INTERRUPTED,
+                    data=InvocationFinishedData(error=message),
+                    agent_kind=active.agent_kind,
+                    round_label=active.round_label,
+                    execution_id=execution_id,
+                )
+                self.record(
+                    EventType.PHASE_FINISHED,
+                    message,
+                    status=EventStatus.INTERRUPTED,
+                    data=PhaseData(phase=active.stage, attempt=active.attempt),
+                    agent_kind=active.agent_kind,
+                    round_label=active.round_label,
+                    execution_id=execution_id,
+                )
             self._run_status = "failed" if error else "completed"
             self._condition.notify_all()
 
@@ -626,6 +919,37 @@ def _attempt_from_label(round_label: str) -> int | None:
     return int(match.group(1)) if match else None
 
 
+def _execution_error_status(error: BaseException) -> EventStatus:
+    if isinstance(error, asyncio.CancelledError) or type(error).__name__ == "CancelledError":
+        return EventStatus.CANCELLED
+    if isinstance(error, (KeyboardInterrupt, SystemExit)):
+        return EventStatus.INTERRUPTED
+    return EventStatus.FAILED
+
+
+def _initial_activity_summary(kind: str) -> str:
+    normalized = kind.lower()
+    if "orchestrat" in normalized or "plan" in normalized:
+        return "Planning"
+    if "implement" in normalized:
+        return "Implementing"
+    if "judge" in normalized or "review" in normalized:
+        return "Reviewing"
+    if "profil" in normalized or "benchmark" in normalized:
+        return "Profiling"
+    if normalized == "chat":
+        return "Answering question"
+    return f"Running {kind}"
+
+
+def _text_activity(data: AgentOutputChunkData) -> AgentExecutionActivityData | None:
+    if data.channel == "analysis":
+        return AgentExecutionActivityData(mode="thinking", summary="Thinking")
+    if data.channel == "assistant":
+        return AgentExecutionActivityData(mode="responding", summary="Responding")
+    return None
+
+
 def _exception_chain(error: BaseException) -> list[BaseException]:
     """Follow causes and contexts without depending on diagnostic internals."""
     chain: list[BaseException] = []
@@ -658,3 +982,109 @@ def _with_steering(user_prompt: str, messages: list[str]) -> str:
         "Treat them as high-priority guidance for the work you do now:\n\n"
         f"{block}\n"
     )
+
+
+def _canonical_execution_events(
+    events: list[RunEvent],
+    *,
+    canonical_lifecycle_ids: set[str] | None = None,
+    invocation_lifecycle_ids: set[str] | None = None,
+) -> list[RunEvent]:
+    """Translate persisted legacy lifecycle events without rewriting their log."""
+    if canonical_lifecycle_ids is None:
+        canonical_lifecycle_ids = {
+            event.execution_id
+            for event in events
+            if event.type in {EventType.AGENT_EXECUTION_STARTED, EventType.AGENT_EXECUTION_FINISHED}
+            and event.execution_id is not None
+        }
+    if invocation_lifecycle_ids is None:
+        invocation_lifecycle_ids = {
+            event.execution_id
+            for event in events
+            if event.type in {EventType.INVOCATION_STARTED, EventType.INVOCATION_FINISHED}
+            and event.execution_id is not None
+        }
+    canonical: list[RunEvent] = []
+    for event in events:
+        if event.execution_id in canonical_lifecycle_ids and event.type in {
+            EventType.INVOCATION_STARTED,
+            EventType.INVOCATION_FINISHED,
+        }:
+            continue
+        if event.type is EventType.INVOCATION_STARTED and isinstance(
+            event.data, InvocationStartedData
+        ):
+            canonical.append(
+                event.model_copy(
+                    update={
+                        "type": EventType.AGENT_EXECUTION_STARTED,
+                        "data": AgentExecutionStartedData(
+                            stage=event.agent_kind or "agent",
+                            attempt=_attempt_from_label(event.round_label or ""),
+                            system_prompt=event.data.system_prompt,
+                            user_prompt=event.data.user_prompt,
+                            activity=AgentExecutionActivityData(
+                                mode="thinking",
+                                summary=_initial_activity_summary(event.agent_kind or "agent"),
+                            ),
+                        ),
+                    }
+                )
+            )
+            continue
+        if event.type is EventType.INVOCATION_FINISHED and isinstance(
+            event.data, InvocationFinishedData
+        ):
+            canonical.append(
+                event.model_copy(
+                    update={
+                        "type": EventType.AGENT_EXECUTION_FINISHED,
+                        "data": AgentExecutionFinishedData(
+                            result=event.data.result, error=event.data.error
+                        ),
+                    }
+                )
+            )
+            continue
+        if event.type in {EventType.PHASE_STARTED, EventType.PHASE_FINISHED} and isinstance(
+            event.data, PhaseData
+        ):
+            if (
+                event.execution_id is not None
+                and event.execution_id not in invocation_lifecycle_ids
+                and event.execution_id not in canonical_lifecycle_ids
+                and event.type is EventType.PHASE_STARTED
+            ):
+                canonical.append(
+                    event.model_copy(
+                        update={
+                            "type": EventType.AGENT_EXECUTION_STARTED,
+                            "data": AgentExecutionStartedData(
+                                stage=event.data.phase,
+                                attempt=event.data.attempt,
+                                activity=AgentExecutionActivityData(
+                                    mode="thinking",
+                                    summary=_initial_activity_summary(event.data.phase),
+                                ),
+                            ),
+                        }
+                    )
+                )
+            elif (
+                event.execution_id is not None
+                and event.execution_id not in invocation_lifecycle_ids
+                and event.execution_id not in canonical_lifecycle_ids
+            ):
+                canonical.append(
+                    event.model_copy(
+                        update={
+                            "type": EventType.AGENT_EXECUTION_FINISHED,
+                            "data": AgentExecutionFinishedData(error=event.text or None),
+                        }
+                    )
+                )
+            canonical.append(event)
+            continue
+        canonical.append(event)
+    return canonical

--- a/src/vibesys/server/transport.py
+++ b/src/vibesys/server/transport.py
@@ -67,11 +67,17 @@ class _RequestHandler(socketserver.StreamRequestHandler):
                 latest_sequence=snapshot.sequence,
             )
         )
-        cursor = request.after_sequence
-        replay = service.events(cursor)
-        if replay:
-            self._write_message(EventBatchMessage(events=replay))
-            cursor = max(event.sequence for event in replay)
+        through_sequence, replay, active_executions = service.subscription_checkpoint(
+            request.after_sequence
+        )
+        self._write_message(
+            EventBatchMessage(
+                events=replay,
+                through_sequence=through_sequence,
+                active_executions=active_executions,
+            )
+        )
+        cursor = through_sequence
         while True:
             events = service.wait_for_events(cursor, timeout=1.0)
             if not events:

--- a/tests/server/test_agent_execution_lifecycle.py
+++ b/tests/server/test_agent_execution_lifecycle.py
@@ -1,0 +1,316 @@
+"""Contract tests for authoritative agent-execution activity state."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from vibesys.server.events import (
+    AgentExecutionActivityData,
+    EventStatus,
+    EventStore,
+    EventType,
+    InvocationFinishedData,
+    InvocationStartedData,
+    RunEvent,
+    TodoItemData,
+    TodoUpdateData,
+    ToolCallData,
+    ToolResultData,
+)
+from vibesys.server.supervisor import RunSupervisor
+
+
+def test_explicit_executions_remain_independent_and_finish_idempotently(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    first = supervisor.start_agent_execution("implementer", "round-1", "first")
+    second = supervisor.start_agent_execution("implementer", "round-1-retry-2", "second")
+
+    assert {item.execution_id for item in supervisor.snapshot().active_executions} == {
+        first.execution_id,
+        second.execution_id,
+    }
+    supervisor.after_agent("implementer", "round-1", result="done", execution_id=first.execution_id)
+    supervisor.after_agent(
+        "implementer", "round-1", result="ignored", execution_id=first.execution_id
+    )
+    assert [item.execution_id for item in supervisor.snapshot().active_executions] == [
+        second.execution_id
+    ]
+
+    events = supervisor.read_events()
+    assert sum(event.type is EventType.AGENT_EXECUTION_STARTED for event in events) == 2
+    assert sum(event.type is EventType.AGENT_EXECUTION_FINISHED for event in events) == 1
+    assert all(
+        event.type
+        not in {
+            EventType.INVOCATION_STARTED,
+            EventType.INVOCATION_FINISHED,
+        }
+        for event in events
+    )
+    assert sum(event.type is EventType.PHASE_STARTED for event in events) == 2
+    first_start = next(
+        event
+        for event in events
+        if event.type is EventType.AGENT_EXECUTION_STARTED
+        and event.execution_id == first.execution_id
+    )
+    assert not any(
+        event.type is EventType.AGENT_EXECUTION_STARTED and event.execution_id == first.execution_id
+        for event in supervisor.read_events(first_start.sequence)
+    )
+
+
+def test_activity_tracks_todo_and_parallel_tools(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    execution = supervisor.start_agent_execution("implementer", "round-1", "work")
+
+    supervisor.publish_presentation(
+        EventType.TODO_UPDATE,
+        TodoUpdateData(todos=[TodoItemData(content="Run queue tests", status="in_progress")]),
+        invocation_id=execution.execution_id,
+    )
+    supervisor.publish_presentation(
+        EventType.TOOL_CALL,
+        ToolCallData(tool="Bash", args={}),
+        invocation_id=execution.execution_id,
+    )
+    supervisor.publish_presentation(
+        EventType.TOOL_CALL,
+        ToolCallData(tool="Read", args={}),
+        invocation_id=execution.execution_id,
+    )
+    supervisor.publish_presentation(
+        EventType.TOOL_RESULT,
+        ToolResultData(tool="Read", content="ok"),
+        invocation_id=execution.execution_id,
+    )
+    assert supervisor.snapshot().active_executions[0].activity.tool == "Bash"
+
+    supervisor.publish_presentation(
+        EventType.TOOL_RESULT,
+        ToolResultData(tool="Bash", content="ok"),
+        invocation_id=execution.execution_id,
+    )
+    activity = supervisor.snapshot().active_executions[0].activity
+    assert activity == AgentExecutionActivityData(mode="thinking", summary="Run queue tests")
+
+
+@pytest.mark.parametrize("terminal_todo_status", ["pending", "completed"])
+def test_todo_without_in_progress_item_clears_stale_summary(tmp_path, terminal_todo_status):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    execution = supervisor.start_agent_execution("implementer", "round-1", "work")
+    supervisor.publish_presentation(
+        EventType.TODO_UPDATE,
+        TodoUpdateData(todos=[TodoItemData(content="Run tests", status="in_progress")]),
+        invocation_id=execution.execution_id,
+    )
+
+    supervisor.publish_presentation(
+        EventType.TODO_UPDATE,
+        TodoUpdateData(todos=[TodoItemData(content="Run tests", status=terminal_todo_status)]),
+        invocation_id=execution.execution_id,
+    )
+
+    assert supervisor.snapshot().active_executions[0].activity == AgentExecutionActivityData(
+        mode="thinking", summary="Thinking"
+    )
+
+
+def test_todo_without_in_progress_item_preserves_active_tool(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    execution = supervisor.start_agent_execution("implementer", "round-1", "work")
+    supervisor.publish_presentation(
+        EventType.TOOL_CALL,
+        ToolCallData(tool="Bash", args={}),
+        invocation_id=execution.execution_id,
+    )
+
+    supervisor.publish_presentation(
+        EventType.TODO_UPDATE,
+        TodoUpdateData(todos=[TodoItemData(content="Run tests", status="completed")]),
+        invocation_id=execution.execution_id,
+    )
+
+    assert supervisor.snapshot().active_executions[0].activity == AgentExecutionActivityData(
+        mode="tool", summary="Using Bash", tool="Bash"
+    )
+
+
+def test_checkpoint_watermark_and_active_state_are_consistent(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    execution = supervisor.start_agent_execution("judge", "round-2", "review")
+
+    through_sequence, events, active = supervisor.subscription_checkpoint(0)
+
+    assert all(event.sequence <= through_sequence for event in events)
+    assert [item.execution_id for item in active] == [execution.execution_id]
+    assert active[0].activity.summary == "Reviewing"
+    started = next(event for event in events if event.type is EventType.AGENT_EXECUTION_STARTED)
+    assert started.data is not None
+    assert started.data.kind == "agent_execution_started"
+    assert started.data.activity == active[0].activity
+    supervisor.after_agent("judge", "round-2", execution_id=execution.execution_id)
+    through_sequence, events, active = supervisor.subscription_checkpoint(through_sequence)
+    assert events[-1].sequence == through_sequence
+    assert active == []
+
+
+def test_streamed_text_does_not_override_active_tool(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    execution = supervisor.start_agent_execution("implementer", "round-1", "work")
+    supervisor.publish_presentation(
+        EventType.TOOL_CALL,
+        ToolCallData(tool="Bash", args={}),
+        invocation_id=execution.execution_id,
+    )
+
+    supervisor.publish_agent_output("still working", invocation_id=execution.execution_id)
+
+    assert supervisor.snapshot().active_executions[0].activity == AgentExecutionActivityData(
+        mode="tool", summary="Using Bash", tool="Bash"
+    )
+
+
+def test_chat_execution_is_isolated_from_main_run_control(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    main = supervisor.start_agent_execution("implementer", "round-1", "work")
+    supervisor.pause_after_call()
+    chat = supervisor.start_agent_execution(
+        "chat",
+        "experiment-chat",
+        "status?",
+        consume_steering=False,
+        participates_in_run_control=False,
+    )
+
+    assert supervisor.snapshot().agent_kind == "implementer"
+    assert supervisor.snapshot().round_label == "round-1"
+    supervisor.after_agent("chat", "experiment-chat", execution_id=chat.execution_id)
+    assert supervisor.snapshot().status == "running"
+    assert supervisor.snapshot().agent_kind == "implementer"
+
+    supervisor.after_agent("implementer", "round-1", execution_id=main.execution_id)
+    assert supervisor.snapshot().status == "paused"
+    paused_chat = supervisor.start_agent_execution(
+        "chat",
+        "experiment-chat",
+        "status?",
+        consume_steering=False,
+        participates_in_run_control=False,
+    )
+    supervisor.after_agent("chat", "experiment-chat", execution_id=paused_chat.execution_id)
+    assert supervisor.snapshot().status == "paused"
+    assert supervisor.snapshot().agent_kind == "implementer"
+
+
+def test_cancellation_and_run_finish_terminalize_activity(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    cancelled = supervisor.start_agent_execution("implementer", "round-1", "work")
+    supervisor.after_agent(
+        "implementer",
+        "round-1",
+        error=asyncio.CancelledError(),
+        execution_id=cancelled.execution_id,
+    )
+    dangling = supervisor.start_agent_execution("judge", "round-1", "review")
+    supervisor.finish()
+
+    terminal = {
+        event.execution_id: event.status
+        for event in supervisor.read_events()
+        if event.type is EventType.AGENT_EXECUTION_FINISHED
+    }
+    assert terminal[cancelled.execution_id] is EventStatus.CANCELLED
+    assert terminal[dangling.execution_id] is EventStatus.INTERRUPTED
+    assert supervisor.snapshot().active_executions == []
+
+
+def test_legacy_invocation_log_is_projected_without_becoming_live(tmp_path):  # noqa: ANN001, ANN201
+    execution_id = "a" * 32
+    store = EventStore(tmp_path / "run-events.jsonl", "legacy")
+    store.append(
+        RunEvent(
+            timestamp=datetime.now(UTC),
+            type=EventType.INVOCATION_STARTED,
+            status=EventStatus.ACTIVE,
+            agent_kind="implementer",
+            round_label="round-1",
+            invocation_id=execution_id,
+            data=InvocationStartedData(system_prompt="system", user_prompt="work"),
+        )
+    )
+
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    event = next(
+        event
+        for event in supervisor.read_events()
+        if event.type is EventType.AGENT_EXECUTION_STARTED
+    )
+    assert event.execution_id == execution_id
+    assert event.data is not None
+    assert event.data.kind == "agent_execution_started"
+    assert supervisor.snapshot().active_executions == []
+
+    # A legacy terminal event remains readable through the same projection.
+    store = supervisor._store  # noqa: SLF001
+    assert store is not None
+    store.append(
+        RunEvent(
+            timestamp=datetime.now(UTC),
+            type=EventType.INVOCATION_FINISHED,
+            status=EventStatus.COMPLETED,
+            agent_kind="implementer",
+            round_label="round-1",
+            invocation_id=execution_id,
+            data=InvocationFinishedData(result="done"),
+        )
+    )
+    assert supervisor.read_events()[-1].type is EventType.AGENT_EXECUTION_FINISHED
+
+
+def test_failed_lifecycle_append_does_not_advance_active_state(tmp_path, monkeypatch):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    store = supervisor._store  # noqa: SLF001
+    assert store is not None
+    append = store.append
+
+    def fail_start(event):  # noqa: ANN001, ANN202
+        if event.type is EventType.AGENT_EXECUTION_STARTED:
+            raise OSError("disk full")  # noqa: TRY003
+        return append(event)
+
+    monkeypatch.setattr(store, "append", fail_start)
+    with pytest.raises(OSError, match="disk full"):
+        supervisor.start_agent_execution("implementer", "round-1", "work")
+    assert supervisor.snapshot().active_executions == []
+
+    monkeypatch.setattr(store, "append", append)
+    execution = supervisor.start_agent_execution("implementer", "round-1", "work")
+
+    def fail_finish(event):  # noqa: ANN001, ANN202
+        if event.type is EventType.AGENT_EXECUTION_FINISHED:
+            raise OSError("disk full")  # noqa: TRY003
+        return append(event)
+
+    monkeypatch.setattr(store, "append", fail_finish)
+    with pytest.raises(OSError, match="disk full"):
+        supervisor.after_agent("implementer", "round-1", execution_id=execution.execution_id)
+    assert [item.execution_id for item in supervisor.snapshot().active_executions] == [
+        execution.execution_id
+    ]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -111,7 +111,7 @@ def test_chat_is_audited_but_not_injected(tmp_path):  # noqa: ANN001, ANN201  # 
     supervisor.record(EventType.CHAT, "What is happening?", status="answered")
     supervisor.before_agent("judge", "round 2", "original prompt")
     started = next(
-        event for event in supervisor.read_events() if event.type == "invocation_started"
+        event for event in supervisor.read_events() if event.type == "agent_execution_started"
     )
     assert started.data.user_prompt == "original prompt"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     event_types = [event["type"] for event in _events(tmp_path / "run-events.jsonl")]
@@ -146,7 +146,7 @@ def test_steer_injects_into_next_invocation(tmp_path):  # noqa: ANN001, ANN201  
     assert "Do the work" in effective
     assert "focus on the KV cache" in effective
     assert "Operator steering" in effective
-    started = next(e for e in supervisor.read_events() if e.type == "invocation_started")
+    started = next(e for e in supervisor.read_events() if e.type == "agent_execution_started")
     assert started.data.user_prompt == effective  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
     # Steering is one-shot: a later invocation without a new /steer is unchanged.
     supervisor.after_agent("implementer", "round 1")
@@ -397,7 +397,7 @@ def test_chat_reports_structured_failed_invocation(tmp_path):  # noqa: ANN001, A
     supervisor.before_agent("implementer", "round 5", "prompt")
     supervisor.after_agent("implementer", "round 5", error=RuntimeError("agent process exited"))
     answer = supervisor.chat("why did the agent fail?")
-    assert "Latest failed agent invocation" in answer
+    assert "Latest failed agent execution" in answer
     assert "agent process exited" in answer
 
 
@@ -409,28 +409,28 @@ def test_failure_events_share_and_promote_a_human_facing_diagnostic(tmp_path):  
     supervisor.after_agent("implementer", "round 5", error=error)
     supervisor.finish(error)
 
-    invocation, phase, terminal = [
+    execution, phase, terminal = [
         event
         for event in supervisor.read_events()
         if event.type
         in {
-            EventType.INVOCATION_FINISHED,
+            EventType.AGENT_EXECUTION_FINISHED,
             EventType.PHASE_FINISHED,
             EventType.RUN_FAILED,
         }
     ]
-    assert invocation.diagnostic is not None
-    assert phase.diagnostic == invocation.diagnostic
+    assert execution.diagnostic is not None
+    assert phase.diagnostic == execution.diagnostic
     assert terminal.diagnostic is not None
-    assert terminal.diagnostic.id == invocation.diagnostic.id
+    assert terminal.diagnostic.id == execution.diagnostic.id
     assert terminal.diagnostic.scope is DiagnosticScope.INVOCATION
-    assert terminal.diagnostic.summary == invocation.diagnostic.summary
-    assert terminal.diagnostic.detail == invocation.diagnostic.detail
-    assert invocation.diagnostic.severity is DiagnosticSeverity.ERROR
+    assert terminal.diagnostic.summary == execution.diagnostic.summary
+    assert terminal.diagnostic.detail == execution.diagnostic.detail
+    assert execution.diagnostic.severity is DiagnosticSeverity.ERROR
     assert terminal.diagnostic.severity is DiagnosticSeverity.FATAL
     assert terminal.diagnostic.retryability is DiagnosticRetryability.UNKNOWN
-    assert invocation.data.error == "Agent invocation failed"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
-    assert terminal.text == "Agent invocation failed"
+    assert execution.data.error == "Agent execution failed"  # pyright: ignore[reportOptionalMemberAccess]  # tracked: #297
+    assert terminal.text == "Agent execution failed"
     assert terminal.diagnostic.detail == "RuntimeError: token=[REDACTED] agent process exited"
     assert "RuntimeError(" not in terminal.text
 
@@ -589,14 +589,14 @@ def test_terminal_wrapper_reuses_an_invocation_diagnostic(tmp_path):  # noqa: AN
     wrapper.__cause__ = cause
     supervisor.finish(wrapper)
 
-    invocation, terminal = [
+    execution, terminal = [
         event
         for event in supervisor.read_events()
-        if event.type in {EventType.INVOCATION_FINISHED, EventType.RUN_FAILED}
+        if event.type in {EventType.AGENT_EXECUTION_FINISHED, EventType.RUN_FAILED}
     ]
-    assert invocation.diagnostic is not None
+    assert execution.diagnostic is not None
     assert terminal.diagnostic is not None
-    assert terminal.diagnostic.id == invocation.diagnostic.id
+    assert terminal.diagnostic.id == execution.diagnostic.id
     assert terminal.diagnostic.detail == (
         "RuntimeError: run cleanup failed <- RuntimeError: token=[REDACTED] agent process exited"
     )
@@ -864,7 +864,7 @@ def test_socket_subscription_reports_structured_stream_failures(tmp_path, monkey
         del after_sequence
         raise RuntimeError("event store is unavailable")  # noqa: TRY003  # tracked: #288
 
-    monkeypatch.setattr(service, "events", fail_replay)
+    monkeypatch.setattr(service, "subscription_checkpoint", fail_replay)
     with SupervisionSocketServer(socket_path, service):  # noqa: SIM117  # tracked: #288
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
             client.settimeout(2)


### PR DESCRIPTION
## Problem

Long-running agent executions can leave the TUI looking idle, especially while the orchestrator plans before the first hypothesis. The existing per-turn working marker also guesses activity from transcript state, cannot represent concurrent agents reliably, and can remain stale after interruption or reconnect.

## Solution

Add an authoritative agent-execution lifecycle to protocol v1. The backend assigns each prompt-to-result execution an ID, tracks its current semantic activity, persists start/activity/finish events, and includes a sequence-consistent active-execution checkpoint when a TUI subscribes. The TUI reduces that state into one stable, selection-aware activity bar above the input, with local spinner and elapsed-time rendering. Per-turn working badges are removed.

Legacy invocation and phase records remain readable through a server-side compatibility projection. Concurrent executions, chat executions, todos, tools, cancellation, interruption, reconnect, and unexpected stream loss have explicit cleanup behavior.

### Architecture

```mermaid
flowchart LR
  A[Agent provider callbacks] --> B[RunSupervisor active execution map]
  B --> C[Append-only execution events]
  B --> D[Replay watermark and active checkpoint]
  C --> E[TUI session reducer]
  D --> E
  E --> F[Stable ActivityBar]
```

The backend owns execution identity, lifecycle, and semantic activity. The TUI owns only presentation state such as spinner frames, elapsed formatting, and selection-aware prioritization.

## Verification

### Correctness properties

- Every started execution has a stable identity and exactly one terminal projection.
- Replay events and the active checkpoint are captured at one sequence watermark.
- Concurrent same-role executions remain independent in activity, timing, todos, and terminal status.
- Chat activity does not participate in main-run pause, steering, or status control.
- Tool activity has priority over streamed text and todo summaries cannot remain stale.
- Interrupted, cancelled, disconnected, and terminal runs do not leave a spinner active.
- Existing persisted invocation and phase events remain readable without rewriting logs.

### Testing

- `./scripts/check_format.sh`
- `./scripts/check_lint.sh`
- `pnpm check:ts`
- `pnpm --dir clients/tui generate:protocol`
- `pnpm --dir clients/tui check`
- `pnpm --dir clients/tui test` (359 passed)
- `pnpm --dir clients/tui build`
- Focused Python server, transport, agent callback/driver, and render suites (293 passed)
- Broad Python suite (4,998 passed, 17 platform skips, 1 external-fixture deselection; 7 unrelated macOS/Linux platform and native-wheel failures)

`./scripts/check_types.sh` has no errors in this change. It retains the existing macOS `os.O_PATH` error in `libs/vs-sandbox/src/vs_sandbox/landlock.py`.
