### PR TITLE
Keep experiment chat available throughout run lifecycle

### DIFF
--- a/clients/tui/src/client.test.ts
+++ b/clients/tui/src/client.test.ts
@@ -146,6 +146,46 @@ describe('SupervisionClient', () => {
     );
   });
 
+  it('runs long agent chat on a dedicated connection without a response timeout', async () => {
+    let connections = 0;
+    let resolveChatSocketClosed: (() => void) | undefined;
+    const chatSocketClosed = new Promise<void>(resolve => {
+      resolveChatSocketClosed = resolve;
+    });
+    await withServer(
+      socket => {
+        connections += 1;
+        respondToLines(socket, request => {
+          if (request['type'] !== 'query.chat') return;
+          socket.once('close', () => resolveChatSocketClosed?.());
+          setTimeout(() => {
+            socket.write(
+              `${JSON.stringify({
+                ...successResponse(request['request_id'] as string),
+                chat: {
+                  question: 'what happened?',
+                  answer: 'The agent finished its investigation.',
+                  effect: 'none',
+                },
+              })}\n`,
+            );
+          }, 50);
+        });
+      },
+      async client => {
+        const chat = client.request({type: 'query.chat', text: 'what happened?'});
+        await expect(client.request({type: 'query.snapshot'})).rejects.toThrow(
+          'Supervision request timed out after 20ms',
+        );
+        const response = await chat;
+        expect(response.chat?.answer).toBe('The agent finished its investigation.');
+        expect(connections).toBe(2);
+        await chatSocketClosed;
+      },
+      {requestTimeoutMs: 20},
+    );
+  });
+
   it('reassembles and validates fragmented subscription messages', async () => {
     await withServer(
       socket =>

--- a/clients/tui/src/client.ts
+++ b/clients/tui/src/client.ts
@@ -44,6 +44,7 @@ export class SupervisionClient {
   >();
   readonly #connectTimeoutMs: number;
   readonly #requestTimeoutMs: number;
+  readonly #longRunningSockets = new Set<Socket>();
   #buffer = '';
 
   private constructor(socket: Socket, path: string, options: SupervisionClientOptions) {
@@ -92,6 +93,7 @@ export class SupervisionClient {
       timestamp: new Date().toISOString(),
       ...input,
     } as ProtocolRequest;
+    if (input.type === 'query.chat') return this.#requestLongRunning(request);
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.#pending.delete(requestId);
@@ -192,10 +194,90 @@ export class SupervisionClient {
   }
 
   close(): Promise<void> {
+    for (const socket of this.#longRunningSockets) socket.destroy();
+    this.#longRunningSockets.clear();
     return new Promise(resolve => {
       if (this.#socket.destroyed) return resolve();
       this.#socket.once('close', resolve);
       this.#socket.end();
+    });
+  }
+
+  /**
+   * Run an agent-backed request on its own connection without a response timer.
+   *
+   * Chat duration is bounded by the configured agent, not by the control RPC
+   * timeout. A dedicated connection also prevents a long chat from blocking
+   * pause, resume, and snapshot requests in the server's per-connection loop.
+   */
+  #requestLongRunning(request: ProtocolRequest): Promise<ProtocolResponse> {
+    return new Promise((resolve, reject) => {
+      const socket = createConnection(this.#path);
+      this.#longRunningSockets.add(socket);
+      let buffer = '';
+      let settled = false;
+      const connectTimeout = setTimeout(() => {
+        fail(
+          new Error(`Timed out connecting to supervision server after ${this.#connectTimeoutMs}ms`),
+        );
+      }, this.#connectTimeoutMs);
+
+      const cleanup = (): void => {
+        clearTimeout(connectTimeout);
+        this.#longRunningSockets.delete(socket);
+        socket.off('error', fail);
+        socket.off('close', disconnected);
+      };
+      const fail = (error: Error): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        socket.destroy();
+        reject(error);
+      };
+      const disconnected = (): void =>
+        fail(new Error('Supervision server disconnected during chat'));
+      const finish = (response: ProtocolResponse): void => {
+        if (settled) return;
+        if (response.request_id !== request.request_id) {
+          fail(new Error('Supervision chat response has an unexpected request ID'));
+          return;
+        }
+        settled = true;
+        cleanup();
+        // Keep the one-shot error listener until the socket actually closes.
+        // A peer reset during the FIN handshake must not become an unhandled
+        // EventEmitter error after the response promise has settled.
+        socket.once('error', fail);
+        socket.once('close', () => socket.off('error', fail));
+        socket.end();
+        if (response.ok) resolve(response);
+        else reject(responseError(response));
+      };
+
+      socket.setEncoding('utf8');
+      socket.once('connect', () => {
+        clearTimeout(connectTimeout);
+        socket.write(`${JSON.stringify(request)}\n`, error => {
+          if (error) fail(error);
+        });
+      });
+      socket.on('data', chunk => {
+        buffer += chunk.toString();
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+          if (!line) continue;
+          try {
+            finish(parseProtocolResponse(line));
+          } catch (error) {
+            fail(error instanceof Error ? error : new Error(String(error)));
+          }
+          return;
+        }
+      });
+      socket.once('error', fail);
+      socket.once('close', disconnected);
     });
   }
 
@@ -219,13 +301,7 @@ export class SupervisionClient {
       this.#pending.delete(response.request_id);
       clearTimeout(pending.timeout);
       if (response.ok) pending.resolve(response);
-      else
-        pending.reject(
-          new SupervisionError(
-            response.error ?? 'Unknown supervision error',
-            response.diagnostic ?? null,
-          ),
-        );
+      else pending.reject(responseError(response));
     }
   }
 
@@ -244,6 +320,13 @@ export class SupervisionClient {
     clearTimeout(pending.timeout);
     pending.reject(error);
   }
+}
+
+function responseError(response: ProtocolResponse): SupervisionError {
+  return new SupervisionError(
+    response.error ?? 'Unknown supervision error',
+    response.diagnostic ?? null,
+  );
 }
 
 function closeSocket(socket: Socket): Promise<void> {

--- a/src/vibesys/agents/drivers/_omnigent_lifecycle.py
+++ b/src/vibesys/agents/drivers/_omnigent_lifecycle.py
@@ -1,0 +1,47 @@
+"""Thread-safe close lifecycle coordination for Omnigent-owned resources."""
+
+from __future__ import annotations
+
+import threading
+from enum import StrEnum
+
+
+class LifecycleState(StrEnum):
+    """Exclusive close state shared by session and driver owners."""
+
+    OPEN = "open"
+    CLOSING = "closing"
+    CLOSED = "closed"
+
+
+class CloseLifecycle:
+    """Coordinate one close owner, recursive calls, waiters, and failures."""
+
+    def __init__(self, condition: threading.Condition | None = None) -> None:
+        self.condition = condition or threading.Condition()
+        self.state = LifecycleState.OPEN
+        self._owner: threading.Thread | None = None
+        self._error: BaseException | None = None
+
+    def begin_close(self) -> bool:
+        """Claim close ownership, or wait for the current owner to finish."""
+        current = threading.current_thread()
+        with self.condition:
+            if self.state is LifecycleState.OPEN:
+                self.state = LifecycleState.CLOSING
+                self._owner = current
+                return True
+            if self.state is LifecycleState.CLOSING and self._owner is current:
+                return False
+            self.condition.wait_for(lambda: self.state is LifecycleState.CLOSED)
+            if self._error is not None:
+                raise self._error
+            return False
+
+    def finish_close(self, error: BaseException | None) -> None:
+        """Publish the owner's terminal result and release every waiter."""
+        with self.condition:
+            self._error = error
+            self._owner = None
+            self.state = LifecycleState.CLOSED
+            self.condition.notify_all()

--- a/src/vibesys/agents/drivers/_omnigent_runtime.py
+++ b/src/vibesys/agents/drivers/_omnigent_runtime.py
@@ -1,0 +1,195 @@
+"""Driver-owned asynchronous runtime for Omnigent sessions."""
+
+# ruff: noqa: TRY003, TRY301
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import contextlib
+import threading
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
+
+def _publish_completion[Result](
+    task: asyncio.Task[Result],
+    completion: concurrent.futures.Future[Result],
+) -> None:
+    """Transfer one loop task's terminal result to its thread-safe future."""
+    if task.cancelled():
+        completion.cancel()
+        return
+    try:
+        completion.set_result(task.result())
+    except BaseException as exc:  # noqa: BLE001
+        completion.set_exception(exc)
+
+
+class OmnigentAsyncTask[Result]:
+    """Cross-thread handle for one task owned by the Omnigent event loop."""
+
+    def __init__(
+        self,
+        *,
+        loop: asyncio.AbstractEventLoop,
+        task: asyncio.Task[Result],
+        completion: concurrent.futures.Future[Result],
+    ) -> None:
+        self._loop = loop
+        self._task = task
+        self._completion = completion
+
+    def result(self) -> Result:
+        """Wait for and return the task's result on the calling thread."""
+        return self._completion.result()
+
+    def cancel_and_wait(self) -> None:
+        """Cancel the loop task and wait until its coroutine has fully unwound."""
+        if self._completion.done():
+            return
+        cancellation = asyncio.run_coroutine_threadsafe(
+            self._cancel_and_wait(),
+            self._loop,
+        )
+        cancellation.result()
+
+    async def _cancel_and_wait(self) -> None:
+        self._task.cancel()
+        await asyncio.gather(self._task, return_exceptions=True)
+
+
+class OmnigentAsyncRuntime:
+    """Own one event loop thread shared by every session in a driver."""
+
+    def __init__(self, *, start_timeout: float) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._ready = threading.Event()
+        self._state_lock = threading.Lock()
+        self._closed = False
+        self._thread = threading.Thread(
+            target=self._serve,
+            name="vibesys-omnigent-runtime",
+            daemon=True,
+        )
+        started = False
+        try:
+            self._thread.start()
+            started = True
+            if not self._ready.wait(timeout=start_timeout):
+                raise RuntimeError("Omnigent event loop did not start")
+        except BaseException:
+            if started:
+                with contextlib.suppress(BaseException):
+                    self._loop.call_soon_threadsafe(self._loop.stop)
+                self._thread.join()
+            if not self._thread.is_alive():
+                with contextlib.suppress(BaseException):
+                    self._loop.close()
+            raise
+
+    def submit[Result](
+        self,
+        awaitable: Coroutine[Any, Any, Result],
+    ) -> concurrent.futures.Future[Result]:
+        """Schedule an awaitable while the runtime accepts work."""
+        with self._state_lock:
+            if self._closed:
+                awaitable.close()
+                raise RuntimeError("Omnigent async runtime is closed")
+            return asyncio.run_coroutine_threadsafe(awaitable, self._loop)
+
+    def start_task[Result](
+        self,
+        awaitable: Coroutine[Any, Any, Result],
+    ) -> OmnigentAsyncTask[Result]:
+        """Create a loop-owned task whose cancellation can be drained exactly."""
+        if self.is_current_thread():
+            awaitable.close()
+            raise RuntimeError("Omnigent task cannot be started synchronously on its event loop")
+        with self._state_lock:
+            if self._closed:
+                awaitable.close()
+                raise RuntimeError("Omnigent async runtime is closed")
+            completion: concurrent.futures.Future[Result] = concurrent.futures.Future()
+            spawn = asyncio.run_coroutine_threadsafe(
+                self._spawn(awaitable, completion),
+                self._loop,
+            )
+            try:
+                task = spawn.result()
+            except BaseException:
+                awaitable.close()
+                raise
+        return OmnigentAsyncTask(loop=self._loop, task=task, completion=completion)
+
+    def is_current_thread(self) -> bool:
+        """Return whether the caller is executing on the runtime loop."""
+        return threading.current_thread() is self._thread
+
+    def close(self) -> None:  # noqa: C901  # cleanup continues after every failure
+        """Drain loop-owned facilities, stop the thread, and close the loop."""
+        if self.is_current_thread():
+            raise RuntimeError("Omnigent async runtime cannot close from its event-loop thread")
+        with self._state_lock:
+            if self._closed:
+                return
+            self._closed = True
+
+        first_error: BaseException | None = None
+        try:
+            cleanup = asyncio.run_coroutine_threadsafe(self._shutdown(), self._loop)
+            first_error = cleanup.result()
+        except BaseException as exc:  # noqa: BLE001
+            first_error = exc
+        try:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        except BaseException as exc:  # noqa: BLE001
+            if first_error is None:
+                first_error = exc
+        self._thread.join()
+        if self._thread.is_alive() and first_error is None:
+            first_error = RuntimeError("Omnigent event loop did not stop")
+        if not self._thread.is_alive():
+            try:
+                self._loop.close()
+            except BaseException as exc:  # noqa: BLE001
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
+
+    async def _shutdown(self) -> BaseException | None:
+        first_error: BaseException | None = None
+        current = asyncio.current_task()
+        pending = [task for task in asyncio.all_tasks() if task is not current]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        for cleanup in (
+            self._loop.shutdown_asyncgens,
+            self._loop.shutdown_default_executor,
+        ):
+            try:
+                await cleanup()
+            except BaseException as exc:  # noqa: BLE001
+                if first_error is None:
+                    first_error = exc
+        return first_error
+
+    @staticmethod
+    async def _spawn[Result](
+        awaitable: Coroutine[Any, Any, Result],
+        completion: concurrent.futures.Future[Result],
+    ) -> asyncio.Task[Result]:
+        task = asyncio.create_task(awaitable)
+        task.add_done_callback(lambda finished: _publish_completion(finished, completion))
+        return task
+
+    def _serve(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._ready.set()
+        self._loop.run_forever()

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -10,9 +10,12 @@ import json
 import os
 import sys
 import tempfile
+import threading
+from dataclasses import dataclass
 from importlib import import_module
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, cast
 
 from vibesys.agents.cli_common import build_schema_hint
 from vibesys.agents.contracts import (
@@ -25,6 +28,12 @@ from vibesys.agents.contracts import (
     AgentTurnResult,
     AgentUsage,
 )
+from vibesys.agents.drivers._omnigent_lifecycle import CloseLifecycle as _CloseLifecycle
+from vibesys.agents.drivers._omnigent_lifecycle import LifecycleState as _LifecycleState
+from vibesys.agents.drivers._omnigent_runtime import (
+    OmnigentAsyncRuntime as _OmnigentAsyncRuntime,
+)
+from vibesys.agents.drivers._omnigent_runtime import OmnigentAsyncTask as _OmnigentAsyncTask
 from vibesys.agents.host_resource_declarations import (
     declare_active_rust_toolchain_resources,
     resolve_active_rust_toolchain,
@@ -37,17 +46,106 @@ from vibesys.agents.omnigent.providers import (
 from vs_sandbox import HostResourceContext
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator
+    import concurrent.futures
+    from collections.abc import Callable, Coroutine
 
 _TOOL_EXECUTOR_ATTR = "_tool_executor"
 """Private Omnigent 0.10.0 tool-dispatch seam, guarded before assignment."""
 
+_OS_ENV_HELPER_ATTR = "_helper"
+_HELPER_SANDBOX_ATTR = "sandbox"
+_EXPLICIT_HELPER_ENV_ATTR = "_vibesys_explicit_parent_environment"
+_PROVIDER_ENVIRONMENT_ATTRS = {
+    "claude": "_extra_env",
+    "codex": "_env",
+}
+"""Private Omnigent 0.10.0 environment seams, centralized by adapters below."""
+
 _OMNIGENT_INTERNAL_HIDDEN = frozenset({".codex-tmp"})
 """Runtime-owned workspace paths that OS tools must not traverse."""
+
+_SESSION_SHUTDOWN_TIMEOUT = 5.0
+
+
+def _unwrap_turn(
+    outcome: tuple[AgentTurnResult | None, BaseException | None],
+) -> AgentTurnResult:
+    result, error = outcome
+    if error is not None:
+        raise error
+    assert result is not None  # noqa: S101  # paired result/error contract
+    return result
 
 
 class OmnigentDriverError(RuntimeError):
     """An Omnigent driver requirement could not be satisfied safely."""
+
+
+def _cleanup_after_failure(
+    error: BaseException,
+    cleanup: Callable[[], None],
+    *,
+    description: str,
+) -> None:
+    """Run setup cleanup without replacing the error that triggered it."""
+    try:
+        cleanup()
+    except BaseException as cleanup_error:  # noqa: BLE001
+        error.add_note(f"{description} also failed: {cleanup_error}")
+
+
+@dataclass
+class _OwnedOSTools:
+    """Schemas, dispatcher, and OS environments created as one owned unit."""
+
+    schemas: list[dict[str, Any]]
+    dispatch: Callable[[str, dict[str, Any]], Any]
+    environments: tuple[Any, ...]
+
+    def close(self) -> None:
+        """Close every environment exactly once and preserve the first failure."""
+        environments, self.environments = self.environments, ()
+        first_error: BaseException | None = None
+        for environment in environments:
+            try:
+                environment.close()
+            except BaseException as exc:  # noqa: BLE001
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
+
+
+@dataclass
+class _ExecutorResources:
+    """Synchronous resources transferred atomically to one session.
+
+    The executor is intentionally separate: its async ``close`` must run on the
+    driver event loop. These synchronous resources are retained by the driver
+    until shared loop workers from a cancelled turn have drained.
+    """
+
+    scratch: tempfile.TemporaryDirectory[str] | None = None
+    os_tools: _OwnedOSTools | None = None
+
+    def close(self) -> None:
+        """Close all resources exactly once and preserve the first failure."""
+        os_tools, self.os_tools = self.os_tools, None
+        scratch, self.scratch = self.scratch, None
+        first_error: BaseException | None = None
+        if os_tools is not None:
+            try:
+                os_tools.close()
+            except BaseException as exc:  # noqa: BLE001
+                first_error = exc
+        if scratch is not None:
+            try:
+                scratch.cleanup()
+            except BaseException as exc:  # noqa: BLE001
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
 
 
 def _is_top_level_dot_path(path: Path) -> bool:
@@ -81,22 +179,6 @@ def _sandbox_backend_for_platform() -> str:
     raise OmnigentDriverError(f"Omnigent has no sandbox backend for platform {sys.platform!r}")
 
 
-@contextlib.contextmanager
-def _patched_environ(overrides: dict[str, str]) -> Generator[None]:
-    """Temporarily expose session environment values to Omnigent subprocesses."""
-    sentinel = object()
-    previous: dict[str, object] = {key: os.environ.get(key, sentinel) for key in overrides}
-    os.environ.update(overrides)
-    try:
-        yield
-    finally:
-        for key, old in previous.items():
-            if old is sentinel:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = str(old)
-
-
 def _flatten_tool_schema(tool: Any) -> dict[str, Any]:  # noqa: ANN401
     function = tool.get_schema().get("function", {})
     return {
@@ -106,12 +188,77 @@ def _flatten_tool_schema(tool: Any) -> dict[str, Any]:  # noqa: ANN401
     }
 
 
-def _build_os_tools(
+_HELPER_ENVIRONMENT_HOOK_LOCK = threading.Lock()
+_helper_environment_hook_installed = False
+
+
+def _install_helper_environment_hook() -> None:
+    """Teach Omnigent 0.10's helper builder about per-helper parent environments."""
+    global _helper_environment_hook_installed  # noqa: PLW0603
+    with _HELPER_ENVIRONMENT_HOOK_LOCK:
+        if _helper_environment_hook_installed:
+            return
+        try:
+            from omnigent.inner import os_env as omnigent_os_env  # noqa: PLC0415
+        except ImportError as exc:
+            raise _missing_omnigent("Omnigent OS-environment tools", exc) from exc
+        original = getattr(omnigent_os_env, "build_helper_env", None)
+        if not callable(original):
+            raise OmnigentDriverError(
+                "Omnigent OS environment has no callable 'build_helper_env' seam; "
+                "this integration requires the private Omnigent 0.10.0 helper API"
+            )
+
+        def build_helper_env(parent_environment: Any, sandbox: Any) -> dict[str, str]:  # noqa: ANN401
+            explicit = getattr(sandbox, _EXPLICIT_HELPER_ENV_ATTR, None)
+            source = explicit if isinstance(explicit, MappingProxyType) else parent_environment
+            return cast("dict[str, str]", original(source, sandbox))
+
+        omnigent_os_env.build_helper_env = build_helper_env
+        _helper_environment_hook_installed = True
+
+
+def _adapt_helper_environment(os_environment: Any, environment: dict[str, str]) -> None:  # noqa: ANN401
+    """Bind an immutable parent environment to one Omnigent 0.10 helper."""
+    helper = getattr(os_environment, _OS_ENV_HELPER_ATTR, None)
+    sandbox = getattr(helper, _HELPER_SANDBOX_ATTR, None)
+    if helper is None or sandbox is None:
+        raise OmnigentDriverError(
+            f"Omnigent OS environment has no {_OS_ENV_HELPER_ATTR!r}."
+            f"{_HELPER_SANDBOX_ATTR!r} seam; this integration requires the private "
+            "Omnigent 0.10.0 helper API"
+        )
+    _install_helper_environment_hook()
+    setattr(
+        sandbox,
+        _EXPLICIT_HELPER_ENV_ATTR,
+        MappingProxyType({**os.environ, **environment}),
+    )
+
+
+def _adapt_provider_environment(
+    executor: Any,  # noqa: ANN401
+    *,
+    provider: str,
+    environment: dict[str, str],
+) -> None:
+    """Merge explicit values into Omnigent's version-pinned provider spawn env."""
+    attribute = _PROVIDER_ENVIRONMENT_ATTRS.get(provider)
+    provider_environment = getattr(executor, attribute, None) if attribute is not None else None
+    if not isinstance(provider_environment, dict):
+        raise OmnigentDriverError(
+            f"Omnigent {provider!r} executor has no mutable environment seam; "
+            "this integration requires the private Omnigent 0.10.0 provider API"
+        )
+    provider_environment.update(environment)
+
+
+def _build_os_tools(  # noqa: C901  # construction cleans every partially-created helper
     os_env_spec: Any,  # noqa: ANN401
     workspace: Path,
     environment: dict[str, str] | None = None,
     shell_os_env_spec: Any | None = None,  # noqa: ANN401
-) -> tuple[list[dict[str, Any]], Callable[[str, dict[str, Any]], Any]]:
+) -> _OwnedOSTools:
     """Build Omnigent's sandboxed filesystem tools and their dispatcher."""
     try:
         from omnigent.inner.os_env import create_os_environment  # noqa: PLC0415
@@ -132,21 +279,36 @@ def _build_os_tools(
             f"Omnigent could not create a sandboxed OS environment for {workspace}"
         )
 
-    tools = build_os_env_tools(os_env)
-    if shell_os_env_spec is not None:
-        shell_os_env = create_os_environment(shell_os_env_spec)
-        if shell_os_env is None:
-            raise OmnigentDriverError(
-                f"Omnigent could not create a sandboxed shell environment for {workspace}"
-            )
-        shell_tools = build_os_env_tools(shell_os_env)
-        shell_tool = next((tool for tool in shell_tools if tool.name() == "sys_os_shell"), None)
-        if shell_tool is None:  # pragma: no cover - guarded against Omnigent API drift
-            raise OmnigentDriverError("Omnigent did not provide its sys_os_shell tool")
-        tools = [shell_tool if tool.name() == "sys_os_shell" else tool for tool in tools]
-    by_name = {tool.name(): tool for tool in tools}
-    schemas = [_flatten_tool_schema(tool) for tool in tools]
-    context = ToolContext(task_id="vibesys", agent_id="vibesys", workspace=workspace)
+    environments = [os_env]
+    try:
+        if shell_os_env_spec is not None:
+            shell_os_env = create_os_environment(shell_os_env_spec)
+            if shell_os_env is None:
+                raise OmnigentDriverError(  # noqa: TRY301
+                    f"Omnigent could not create a sandboxed shell environment for {workspace}"
+                )
+            environments.append(shell_os_env)
+            _adapt_helper_environment(os_env, {})
+            _adapt_helper_environment(shell_os_env, environment or {})
+            tools = build_os_env_tools(os_env)
+            shell_tools = build_os_env_tools(shell_os_env)
+            shell_tool = next((tool for tool in shell_tools if tool.name() == "sys_os_shell"), None)
+            if shell_tool is None:  # pragma: no cover - guarded against Omnigent API drift
+                raise OmnigentDriverError(  # noqa: TRY301
+                    "Omnigent did not provide its sys_os_shell tool"
+                )
+            tools = [shell_tool if tool.name() == "sys_os_shell" else tool for tool in tools]
+        else:
+            _adapt_helper_environment(os_env, environment or {})
+            tools = build_os_env_tools(os_env)
+        by_name = {tool.name(): tool for tool in tools}
+        schemas = [_flatten_tool_schema(tool) for tool in tools]
+        context = ToolContext(task_id="vibesys", agent_id="vibesys", workspace=workspace)
+    except BaseException:
+        for resource in environments:
+            with contextlib.suppress(BaseException):
+                resource.close()
+        raise
 
     async def dispatch(name: str, args: dict[str, Any]) -> Any:  # noqa: ANN401
         tool = by_name.get(name)
@@ -154,12 +316,11 @@ def _build_os_tools(
             return {"error": f"unknown tool {name!r}"}
 
         def invoke() -> Any:  # noqa: ANN401
-            with _patched_environ(environment or {}):
-                return tool.invoke(json.dumps(args), context)
+            return tool.invoke(json.dumps(args), context)
 
         return await asyncio.to_thread(invoke)
 
-    return schemas, dispatch
+    return _OwnedOSTools(schemas=schemas, dispatch=dispatch, environments=tuple(environments))
 
 
 def _usage_from_mapping(usage: dict[str, Any]) -> AgentUsage:
@@ -262,13 +423,20 @@ class OmnigentSession:
         spec: AgentSessionSpec,
         executor: Any,  # noqa: ANN401
         tool_schemas: list[dict[str, Any]],
+        resources: _ExecutorResources | None = None,
     ) -> None:
         """Own ``executor`` until this session is closed."""
         self._driver = driver
         self._spec = spec
         self._executor = executor
         self._tool_schemas = tool_schemas
-        self._closed = False
+        self._resources: _ExecutorResources | None = resources or _ExecutorResources()
+        self._lifecycle = threading.Condition()
+        self._close_lifecycle = _CloseLifecycle(self._lifecycle)
+        self._turn_lock = threading.Lock()
+        self._active_turn: (
+            _OmnigentAsyncTask[tuple[AgentTurnResult | None, BaseException | None]] | None
+        ) = None
         self._failed = False
 
     def run_turn(
@@ -277,37 +445,139 @@ class OmnigentSession:
         observer: AgentObserver | None = None,
     ) -> AgentTurnResult:
         """Run one resumable Omnigent turn."""
-        if self._closed:
-            raise RuntimeError("Omnigent session is closed")
-        if self._failed:
-            raise RuntimeError("Omnigent session must be reset after a failed turn")
-
-        turn = _drive_turn(
-            self._executor,
-            request=request,
-            reasoning_effort=self._spec.reasoning_effort,
-            tool_schemas=self._tool_schemas,
-            observer=observer,
-        )
-        if request.timeout is not None:
-            turn = asyncio.wait_for(turn, timeout=request.timeout.total_seconds())
-        try:
-            with _patched_environ(dict(self._spec.environment)):
-                return self._driver.run_awaitable(turn)
-        except BaseException:
-            self._failed = True
-            raise
+        # A session is one provider conversation and remains sequential. Other
+        # sessions submit independent tasks to the driver runtime and can overlap.
+        with self._turn_lock:
+            with self._lifecycle:
+                if self._close_lifecycle.state is not _LifecycleState.OPEN:
+                    raise RuntimeError("Omnigent session is closed")
+                if self._failed:
+                    raise RuntimeError("Omnigent session must be reset after a failed turn")
+            try:
+                with self._lifecycle:
+                    if self._close_lifecycle.state is not _LifecycleState.OPEN:
+                        raise RuntimeError(  # noqa: TRY301
+                            "Omnigent session is closed"
+                        )
+                    task = self._driver.start_task(self._run_turn(request, observer))
+                    self._active_turn = task
+                try:
+                    return _unwrap_turn(task.result())
+                except BaseException:
+                    task.cancel_and_wait()
+                    raise
+                finally:
+                    with self._lifecycle:
+                        if self._active_turn is task:
+                            self._active_turn = None
+            except BaseException:
+                with self._lifecycle:
+                    self._failed = True
+                raise
 
     def close(self) -> None:
         """Release the executor exactly once."""
-        if self._closed:
+        if self.owns_current_loop_thread():
+            raise RuntimeError("Omnigent session cannot be closed from its event-loop thread")
+        active: _OmnigentAsyncTask[Any] | None = None
+        owner = self._close_lifecycle.begin_close()
+        if owner:
+            with self._lifecycle:
+                active = self._active_turn
+        else:
             return
-        self._closed = True
-        self._driver.release_session(self, self._executor)
+        first_error: BaseException | None = None
+        try:
+            first_error = self._close_resources(active)
+        except BaseException as exc:  # noqa: BLE001  # completion must still be signaled
+            first_error = exc
+        finally:
+            self._close_lifecycle.finish_close(first_error)
+        if first_error is not None:
+            raise first_error
+
+    def owns_current_loop_thread(self) -> bool:
+        """Return whether the caller is the driver async runtime thread."""
+        return self._driver.owns_current_loop_thread()
+
+    def _close_resources(
+        self,
+        active: _OmnigentAsyncTask[Any] | None,
+    ) -> BaseException | None:
+        """Best-effort all resources and preserve the first cleanup failure."""
+        if active is not None:
+            active.cancel_and_wait()
+
+        first_error: BaseException | None = None
+        try:
+            cleanup = self._driver.submit(self._shutdown())
+            try:
+                first_error = cleanup.result()
+            except BaseException as exc:  # noqa: BLE001
+                first_error = exc
+                cleanup.cancel()
+        except BaseException as exc:  # noqa: BLE001
+            first_error = exc
+        try:
+            self._driver.release_session(self)
+        except BaseException as exc:  # noqa: BLE001
+            if first_error is None:
+                first_error = exc
+        resources, self._resources = self._resources, None
+        if resources is not None:
+            try:
+                if active is None:
+                    resources.close()
+                else:
+                    self._driver.defer_resources(resources)
+            except BaseException as exc:  # noqa: BLE001
+                if first_error is None:
+                    first_error = exc
+        return first_error
+
+    async def _run_turn(
+        self,
+        request: AgentTurnRequest,
+        observer: AgentObserver | None,
+    ) -> tuple[AgentTurnResult | None, BaseException | None]:
+        try:
+            turn = _drive_turn(
+                self._executor,
+                request=request,
+                reasoning_effort=self._spec.reasoning_effort,
+                tool_schemas=self._tool_schemas,
+                observer=observer,
+            )
+            if request.timeout is not None:
+                return (
+                    await asyncio.wait_for(turn, timeout=request.timeout.total_seconds()),
+                    None,
+                )
+            return await turn, None
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:  # noqa: BLE001
+            # asyncio deliberately re-raises KeyboardInterrupt/SystemExit out
+            # of tasks. Encode it so it is re-raised on the invoking thread
+            # without terminating this session's loop thread.
+            return None, exc
+
+    async def _shutdown(self) -> BaseException | None:
+        """Close this session's executor on the driver runtime."""
+        first_error: BaseException | None = None
+        try:
+            close = getattr(self._executor, "close", None)
+            if close is not None:
+                result = close()
+                if asyncio.iscoroutine(result):
+                    await result
+        except BaseException as exc:  # noqa: BLE001
+            first_error = exc
+        return first_error
 
 
 class OmnigentDriver:
-    """Create sandboxed Omnigent sessions and own their async event loop."""
+    """Create sandboxed Omnigent sessions and own their native resources."""
 
     _CAPABILITIES = AgentCapabilities(
         timeouts=True,
@@ -315,11 +585,13 @@ class OmnigentDriver:
     )
 
     def __init__(self) -> None:
-        """Create a driver with no live sessions or event loop."""
+        """Create a driver with no live sessions."""
+        self._runtime = _OmnigentAsyncRuntime(start_timeout=_SESSION_SHUTDOWN_TIMEOUT)
         self._sessions: set[OmnigentSession] = set()
-        self._executor_scratch: dict[int, tempfile.TemporaryDirectory[str]] = {}
-        self._loop: asyncio.AbstractEventLoop | None = None
-        self._closed = False
+        self._lifecycle = threading.Condition()
+        self._close_lifecycle = _CloseLifecycle(self._lifecycle)
+        self._creating_sessions = 0
+        self._deferred_resources: list[_ExecutorResources] = []
 
     @property
     def capabilities(self) -> AgentCapabilities:
@@ -328,42 +600,69 @@ class OmnigentDriver:
 
     def create_session(self, spec: AgentSessionSpec) -> OmnigentSession:
         """Validate setup requirements and create a confined session."""
-        if self._closed:
-            raise RuntimeError("Omnigent driver is closed")
-        self._validate_spec(spec)
-        executor, schemas = self._build_executor(spec)
-        session = OmnigentSession(
-            driver=self,
-            spec=spec,
-            executor=executor,
-            tool_schemas=schemas,
-        )
-        self._sessions.add(session)
-        return session
-
-    def close(self) -> None:
-        """Close every outstanding session and the shared event loop."""
-        if self._closed:
-            return
-        self._closed = True
-        first_error: Exception | None = None
-        for session in tuple(self._sessions):
-            try:
+        with self._lifecycle:
+            if self._close_lifecycle.state is not _LifecycleState.OPEN:
+                raise RuntimeError("Omnigent driver is closed")
+            self._creating_sessions += 1
+        try:
+            self._validate_spec(spec)
+            executor, schemas, resources = self._build_executor(spec)
+            session = OmnigentSession(
+                driver=self,
+                spec=spec,
+                executor=executor,
+                tool_schemas=schemas,
+                resources=resources,
+            )
+            with self._lifecycle:
+                closed = self._close_lifecycle.state is not _LifecycleState.OPEN
+                if not closed:
+                    self._sessions.add(session)
+            if closed:
                 session.close()
-            except Exception as exc:  # noqa: BLE001
-                if first_error is None:
-                    first_error = exc
-        loop = self._loop
-        if loop is not None and not loop.is_closed():
+                raise RuntimeError("Omnigent driver is closed")
+            return session
+        finally:
+            with self._lifecycle:
+                self._creating_sessions -= 1
+                self._lifecycle.notify_all()
+
+    def close(self) -> None:  # noqa: C901, PLR0912  # exhaustive owner cleanup
+        """Close every outstanding session."""
+        if self.owns_current_loop_thread():
+            raise RuntimeError("Omnigent driver cannot be closed from its event-loop thread")
+        owner = self._close_lifecycle.begin_close()
+        if not owner:
+            return
+        first_error: BaseException | None = None
+        try:
+            with self._lifecycle:
+                while self._creating_sessions > 0:
+                    self._lifecycle.wait()
+                sessions = tuple(self._sessions)
+            for session in sessions:
+                try:
+                    session.close()
+                except BaseException as exc:  # noqa: BLE001
+                    if first_error is None:
+                        first_error = exc
             try:
-                loop.run_until_complete(loop.shutdown_asyncgens())
-                loop.run_until_complete(asyncio.sleep(0))
-            except Exception as exc:  # noqa: BLE001
+                self._runtime.close()
+            except BaseException as exc:  # noqa: BLE001
                 if first_error is None:
                     first_error = exc
-            finally:
-                loop.close()
-        self._loop = None
+            with self._lifecycle:
+                deferred, self._deferred_resources = self._deferred_resources, []
+            for resources in deferred:
+                try:
+                    resources.close()
+                except BaseException as exc:  # noqa: BLE001
+                    if first_error is None:
+                        first_error = exc
+        except BaseException as exc:  # noqa: BLE001  # completion must still be signaled
+            first_error = exc
+        finally:
+            self._close_lifecycle.finish_close(first_error)
         if first_error is not None:
             raise first_error
 
@@ -389,12 +688,31 @@ class OmnigentDriver:
             )
 
     def run_awaitable(self, awaitable: Any) -> Any:  # noqa: ANN401
-        """Run one Omnigent awaitable on the driver-owned event loop."""
-        loop = self._loop
-        if loop is None or loop.is_closed():
-            loop = asyncio.new_event_loop()
-            self._loop = loop
-        return loop.run_until_complete(awaitable)
+        """Run isolated cleanup on the driver-owned async runtime."""
+        return self.submit(awaitable).result()
+
+    def submit[Result](
+        self,
+        awaitable: Coroutine[Any, Any, Result],
+    ) -> concurrent.futures.Future[Result]:
+        """Submit session work to this driver's async runtime."""
+        return self._runtime.submit(awaitable)
+
+    def start_task[Result](
+        self,
+        awaitable: Coroutine[Any, Any, Result],
+    ) -> _OmnigentAsyncTask[Result]:
+        """Start one turn as an explicitly owned runtime task."""
+        return self._runtime.start_task(awaitable)
+
+    def owns_current_loop_thread(self) -> bool:
+        """Return whether the caller is the driver async runtime thread."""
+        return self._runtime.is_current_thread()
+
+    def defer_resources(self, resources: _ExecutorResources) -> None:
+        """Retain resources until shared default-executor workers have drained."""
+        with self._lifecycle:
+            self._deferred_resources.append(resources)
 
     def _executor_class(self, spec: OmnigentExecutorSpec) -> type[Any]:
         try:
@@ -461,12 +779,17 @@ class OmnigentDriver:
             sandbox=sandbox,
         )
 
-    def _build_executor(self, spec: AgentSessionSpec) -> tuple[Any, list[dict[str, Any]]]:
+    def _build_executor(
+        self, spec: AgentSessionSpec
+    ) -> tuple[Any, list[dict[str, Any]], _ExecutorResources]:
         executor_spec = _resolve_executor_spec(spec.provider)
         executor_cls = self._executor_class(executor_spec)
         os_env_spec = self._build_os_env(spec)
-        scratch = tempfile.TemporaryDirectory(prefix="vibesys-omnigent-")
-        scratch_path = Path(scratch.name)
+        resources = _ExecutorResources(
+            scratch=tempfile.TemporaryDirectory(prefix="vibesys-omnigent-")
+        )
+        assert resources.scratch is not None  # noqa: S101  # initialized above
+        scratch_path = Path(resources.scratch.name)
         environment = {**os.environ, **dict(spec.environment)}
         tool_environment = dict(spec.environment)
         rust_toolchain = resolve_active_rust_toolchain(
@@ -491,8 +814,12 @@ class OmnigentDriver:
                 env_passthrough=tuple(tool_environment),
                 include_toolchain=True,
             )
-        except BaseException:
-            scratch.cleanup()
+        except BaseException as error:
+            _cleanup_after_failure(
+                error,
+                resources.close,
+                description="Omnigent executor resource cleanup",
+            )
             raise
         executor_kwargs: dict[str, Any] = {
             "cwd": str(spec.workspace),
@@ -507,52 +834,91 @@ class OmnigentDriver:
         try:
             executor = executor_cls(**executor_kwargs)
         except ImportError as exc:
-            scratch.cleanup()
-            raise OmnigentDriverError(
+            error = OmnigentDriverError(
                 f"Omnigent provider {spec.provider!r} is unavailable: {exc}"
-            ) from exc
-        except BaseException:
-            scratch.cleanup()
+            )
+            _cleanup_after_failure(
+                error,
+                resources.close,
+                description="Omnigent executor resource cleanup",
+            )
+            raise error from exc
+        except BaseException as error:
+            _cleanup_after_failure(
+                error,
+                resources.close,
+                description="Omnigent executor resource cleanup",
+            )
             raise
         if not hasattr(executor, _TOOL_EXECUTOR_ATTR):
-            with contextlib.suppress(Exception):
-                self.close_executor(executor)
-            scratch.cleanup()
-            raise OmnigentDriverError(
+            error = OmnigentDriverError(
                 f"{executor_cls.__name__} has no {_TOOL_EXECUTOR_ATTR!r} slot; "
                 "this integration requires the private Omnigent 0.10.0 tool-dispatch seam"
             )
+            _cleanup_after_failure(
+                error,
+                lambda: self.close_executor(executor, resources=resources),
+                description="Omnigent executor cleanup",
+            )
+            raise error
         try:
-            schemas, dispatch = _build_os_tools(
+            _adapt_provider_environment(
+                executor,
+                provider=spec.provider,
+                environment=dict(spec.environment),
+            )
+        except BaseException as error:
+            _cleanup_after_failure(
+                error,
+                lambda: self.close_executor(executor, resources=resources),
+                description="Omnigent executor cleanup",
+            )
+            raise
+        try:
+            os_tools = _build_os_tools(
                 os_env_spec,
                 spec.workspace,
                 tool_environment,
                 shell_os_env_spec,
             )
-        except BaseException:
-            with contextlib.suppress(Exception):
-                self.close_executor(executor)
-            scratch.cleanup()
+            resources.os_tools = os_tools
+            setattr(executor, _TOOL_EXECUTOR_ATTR, os_tools.dispatch)
+        except BaseException as error:
+            _cleanup_after_failure(
+                error,
+                lambda: self.close_executor(executor, resources=resources),
+                description="Omnigent executor cleanup",
+            )
             raise
-        setattr(executor, _TOOL_EXECUTOR_ATTR, dispatch)
-        self._executor_scratch[id(executor)] = scratch
-        return executor, schemas
+        return executor, os_tools.schemas, resources
 
-    def release_session(self, session: OmnigentSession, executor: Any) -> None:  # noqa: ANN401
-        """Forget a session and close its native executor."""
-        self._sessions.discard(session)
-        self.close_executor(executor)
+    def release_session(self, session: OmnigentSession) -> None:
+        """Forget a closed session after it has released its owned resources."""
+        with self._lifecycle:
+            self._sessions.discard(session)
 
-    def close_executor(self, executor: Any) -> None:  # noqa: ANN401
+    def close_executor(
+        self,
+        executor: Any,  # noqa: ANN401
+        *,
+        run_awaitable: Callable[[Any], Any] | None = None,
+        resources: _ExecutorResources | None = None,
+    ) -> None:
         """Close a native executor, awaiting asynchronous cleanup when needed."""
+        first_error: BaseException | None = None
         try:
             close = getattr(executor, "close", None)
-            if close is None:
-                return
-            result = close()
-            if asyncio.iscoroutine(result):
-                self.run_awaitable(result)
-        finally:
-            scratch = self._executor_scratch.pop(id(executor), None)
-            if scratch is not None:
-                scratch.cleanup()
+            if close is not None:
+                result = close()
+                if asyncio.iscoroutine(result):
+                    (run_awaitable or self.run_awaitable)(result)
+        except BaseException as exc:  # noqa: BLE001
+            first_error = exc
+        if resources is not None:
+            try:
+                resources.close()
+            except BaseException as exc:  # noqa: BLE001
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -5,7 +5,7 @@ import shutil
 import threading
 from collections.abc import Callable, Generator
 from contextlib import ExitStack, contextmanager
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as distribution_version
 from pathlib import Path
@@ -90,6 +90,8 @@ T = TypeVar("T", bound=BaseModel)
 
 _CHAT_STATE_DIR = "_vibesys_chat"
 _CHAT_TRAJECTORY_SUFFIXES = frozenset({".json", ".jsonl", ".log", ".md", ".txt"})
+# This is an agent instruction, not a filesystem guarantee. ProjectPathPolicy
+# cannot currently express a read-only workspace root.
 _EXPERIMENT_CHAT_SYSTEM_PROMPT = """\
 You are the read-only investigation agent for a live VibeSys experiment. Answer the
 user's question by examining evidence instead of relying on a precomputed summary.
@@ -293,12 +295,12 @@ def create_run_context(  # noqa: PLR0913  # tracked: #288
 def _close_after_construction_failure(
     teardown_stack: ExitStack, construction_error: BaseException
 ) -> None:
-    """Unwind partial construction without replacing its root-cause error."""
+    """Unwind partial resource construction without replacing its root cause."""
     try:
         teardown_stack.close()
     except BaseException as cleanup_error:  # noqa: BLE001  # tracked: #288
         construction_error.add_note(
-            "Additional error while cleaning up partial context construction: "
+            "Additional error while cleaning up partial resource construction: "
             f"{type(cleanup_error).__name__}: {cleanup_error}"
         )
 
@@ -761,34 +763,31 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
 
         teardown_stack.callback(_push_experiment_repository)
 
-    session = teardown_stack.enter_context(
-        environment.open(
-            RunEnvironmentRequest(
-                log_dir=log_dir,
-                workspace=project_root,
-                workspace_sources=(),
-                ref_dir=ref_dir,
-                backend=backend_impl,
-                agent_backend=resolved_backend,
-                cli_provider=resolved_cli_provider,
-                run_id=run_id,
-                objective=objective,
-                objective_document=objective_document,
-                accuracy_command=accuracy_command,
-                benchmark_command=benchmark_command,
-                benchmark_output_argument=benchmark_output_argument,
-                evaluator_package_root=evaluator_package_root,
-                profiler_support_path=profiler_support_path,
-                profiler_support_name=profiler_support_name,
-                git_history_root=git.history_root,
-                environment_bind_mounts=environment_patch.bind_mounts,
-                log=logger.lprint,
-                framework_root=PROJECT_ROOT,
-                project_path_policy=project_path_policy,
-                state_namespace=project_state.local_namespace(run_id, "skypilot"),
-            )
-        )
+    run_environment_request = RunEnvironmentRequest(
+        log_dir=log_dir,
+        workspace=project_root,
+        workspace_sources=(),
+        ref_dir=ref_dir,
+        backend=backend_impl,
+        agent_backend=resolved_backend,
+        cli_provider=resolved_cli_provider,
+        run_id=run_id,
+        objective=objective,
+        objective_document=objective_document,
+        accuracy_command=accuracy_command,
+        benchmark_command=benchmark_command,
+        benchmark_output_argument=benchmark_output_argument,
+        evaluator_package_root=evaluator_package_root,
+        profiler_support_path=profiler_support_path,
+        profiler_support_name=profiler_support_name,
+        git_history_root=git.history_root,
+        environment_bind_mounts=environment_patch.bind_mounts,
+        log=logger.lprint,
+        framework_root=PROJECT_ROOT,
+        project_path_policy=project_path_policy,
+        state_namespace=project_state.local_namespace(run_id, "skypilot"),
     )
+    session = teardown_stack.enter_context(environment.open(run_environment_request))
     # Snapshot the agent-facing commands once the session is open; the
     # view's paths are fixed for the session lifetime.
     commands = RunCommands(
@@ -814,8 +813,6 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
         backends={
             "implementer": session.sandbox,
             "judge": session.sandbox,
-            # TUI chat is a read-only peer agent over the current workspace.
-            "chat": session.sandbox,
             # Perf eval reuses the implementer's backend today (loop.py:564),
             # so the runner picks the same one when kind="perf_eval".
             "perf_eval": session.sandbox,
@@ -842,44 +839,134 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
     if callable(close_agent_client):
         teardown_stack.callback(close_agent_client)
 
-    result = _RunContext(
-        backend=backend,
-        run_environment=environment,
-        supervisor=supervisor,
-        logger=logger,
-        paths=paths,
-        debug=debug,
-        backend_impl=backend_impl,
-        model=model,
-        model_name=model_name,
-        input_path=input_path_str,
-        workspace_sources=(),
-        evaluator_path=evaluator_source,
-        evaluator_package_root=evaluator_package_root,
-        effective_objective=objective,
-        accuracy_command=accuracy_command,
-        benchmark_command=benchmark_command,
-        profiler_kind=resolved_profiler_kind,
-        profiler_support_path=profiler_support_path,
-        profiler_support_name=profiler_support_name,
-        skill_source_paths=skill_source_paths,
-        ref_name=ref_name,
-        environment_hooks=hooks,
-        environment_context=environment_context,
-        environment_patch=environment_patch,
-        workspace_files=workspace_files,
-        git=git,
-        experiment_repository=tracked_experiment_repository,
-        teardown_stack=teardown_stack,
-        run_environment_session=session,
-        commands=commands,
-        device=device,
-        agent_client=agent_client,
-        project=project,
-        state=RunState(project, git, run_id),
-        run_id=run_id,
-        round_transaction_coordinator=round_transaction_coordinator,
-    )
+    experiment_chat: _ExperimentChatService | None = None
+    experiment_chat_owner = ExitStack()
+    if supervisor is not None:
+
+        def _build_experiment_chat() -> _ExperimentChatService:
+            """Build resources owned only by the experiment chat service."""
+            resources = ExitStack()
+            try:
+                chat_logger = RunLogger(log_dir, tee_stderr=False)
+                resources.callback(chat_logger.close)
+                chat_logger.switch("experiment-chat")
+
+                chat_backends: dict[str, Any] | None = None
+                chat_use_docker = False
+                if resolved_backend == "deepagents" or session.view.cli_sandboxed:
+                    chat_environment_session = resources.enter_context(
+                        environment.open(replace(run_environment_request, log=chat_logger.lprint))
+                    )
+                    chat_backends = {"chat": chat_environment_session.sandbox}
+                    chat_use_docker = chat_environment_session.view.cli_sandboxed
+
+                chat_client = build_agent_client(
+                    config,
+                    agent_backend=agent_backend,
+                    cli_provider=cli_provider,
+                    backends=chat_backends,
+                    skills=[src.name for src in skill_source_paths],
+                    skill_source_dirs=skill_source_paths,
+                    compute_backend=backend,
+                    model=model,
+                    model_name=model_name,
+                    run_log_file=chat_logger.writer,
+                    use_docker=chat_use_docker,
+                    log_dir=log_dir,
+                    project_path_policy=project_path_policy,
+                    require_host_sandbox=not chat_use_docker,
+                )
+                resources.callback(chat_client.close)
+                return _ExperimentChatService(
+                    _ExperimentChatDependencies(
+                        supervisor=supervisor,
+                        agent_client=chat_client,
+                        workspace=project_root,
+                        log_dir=log_dir,
+                        project=project,
+                        run_id=run_id,
+                        log=chat_logger.lprint,
+                        flush_logs=chat_logger.writer.flush,
+                        environment=dict,
+                        progress=lambda: None,
+                    ),
+                    resources.pop_all(),
+                )
+            except BaseException as construction_error:
+                _close_after_construction_failure(resources, construction_error)
+                raise
+
+        try:
+            experiment_chat = _build_experiment_chat()
+        except Exception as exc:  # noqa: BLE001  # experiment chat is an optional surface
+            supervisor.publish_output(
+                "stderr",
+                f"Experiment chat is unavailable: {type(exc).__name__}: {exc}\n",
+                source="experiment-chat",
+            )
+        else:
+            from vibesys.server.supervisor import TerminalChatResource  # noqa: PLC0415
+
+            experiment_chat_owner.callback(experiment_chat.close)
+            resource = TerminalChatResource(
+                handler=experiment_chat.ask,
+                close=experiment_chat.close,
+            )
+            try:
+                retained = supervisor.retain_terminal_chat_resource(resource)
+            except BaseException as transfer_error:
+                _close_after_construction_failure(experiment_chat_owner, transfer_error)
+                raise
+            if retained:
+                # Presentation lifetime now owns the session. Primary teardown
+                # must neither drain nor close it.
+                experiment_chat_owner.pop_all()
+                experiment_chat = None
+
+    try:
+        result = _RunContext(
+            backend=backend,
+            run_environment=environment,
+            supervisor=supervisor,
+            logger=logger,
+            paths=paths,
+            debug=debug,
+            backend_impl=backend_impl,
+            model=model,
+            model_name=model_name,
+            input_path=input_path_str,
+            workspace_sources=(),
+            evaluator_path=evaluator_source,
+            evaluator_package_root=evaluator_package_root,
+            effective_objective=objective,
+            accuracy_command=accuracy_command,
+            benchmark_command=benchmark_command,
+            profiler_kind=resolved_profiler_kind,
+            profiler_support_path=profiler_support_path,
+            profiler_support_name=profiler_support_name,
+            skill_source_paths=skill_source_paths,
+            ref_name=ref_name,
+            environment_hooks=hooks,
+            environment_context=environment_context,
+            environment_patch=environment_patch,
+            workspace_files=workspace_files,
+            git=git,
+            experiment_repository=tracked_experiment_repository,
+            teardown_stack=teardown_stack,
+            run_environment_session=session,
+            commands=commands,
+            device=device,
+            agent_client=agent_client,
+            project=project,
+            state=RunState(project, git, run_id),
+            run_id=run_id,
+            round_transaction_coordinator=round_transaction_coordinator,
+            experiment_chat=experiment_chat,
+        )
+    except BaseException as construction_error:
+        _close_after_construction_failure(experiment_chat_owner, construction_error)
+        raise
+    experiment_chat_owner.pop_all()
     construction_complete = True
     return result
 
@@ -1097,6 +1184,193 @@ def _assemble_candidate_context(  # noqa: PLR0913  # tracked: #288
     )
 
 
+@dataclass(frozen=True)
+class _ExperimentChatDependencies:
+    supervisor: "RunSupervisor"
+    agent_client: AgentClient
+    workspace: Path
+    log_dir: Path
+    project: Project
+    run_id: str
+    log: Callable[[str], None]
+    flush_logs: Callable[[], None]
+    environment: Callable[[], dict[str, str]]
+    progress: Callable[[], AgentProgress | None]
+
+
+class _ExperimentChatService:
+    """Own one chat agent and the durable evidence it may inspect."""
+
+    def __init__(
+        self, dependencies: _ExperimentChatDependencies, resources: ExitStack | None = None
+    ) -> None:
+        self._supervisor = dependencies.supervisor
+        self._agent_client = dependencies.agent_client
+        self._workspace = dependencies.workspace
+        self._log_dir = dependencies.log_dir
+        self._project = dependencies.project
+        self._run_id = dependencies.run_id
+        self._log = dependencies.log
+        self._flush_logs = dependencies.flush_logs
+        self._environment = dependencies.environment
+        self._progress = dependencies.progress
+        self._resources = resources
+        self._lock = threading.Lock()
+        self._history = self._load_history()
+
+    def ask(self, question: str) -> str:
+        """Answer one question from current run evidence."""
+        from vibesys.server.inspector import RunInspector  # noqa: PLC0415
+
+        with self._lock:
+            self._sync_trajectory()
+
+            def fallback() -> str:
+                diagnostic = RunInspector(self._supervisor).answer(question)
+                return f"Chat agent did not return an answer.\n\nFallback diagnostic:\n{diagnostic}"
+
+            system_prompt = (
+                _EXPERIMENT_CHAT_CONTINUATION_PROMPT
+                if self._history
+                else _EXPERIMENT_CHAT_SYSTEM_PROMPT
+            )
+            execution = self._supervisor.start_agent_execution(
+                "chat",
+                "experiment-chat",
+                question,
+                system_prompt,
+                consume_steering=False,
+                participates_in_run_control=False,
+            )
+            answer: str | None = None
+            error: BaseException | None = None
+            with self._supervisor.presentation_scope(
+                agent_kind="chat",
+                round_label="experiment-chat",
+                invocation_id=execution.execution_id,
+            ):
+                try:
+                    answer = self._agent_client.invoke_text(
+                        kind="chat",
+                        workspace=self._workspace,
+                        system_prompt=system_prompt,
+                        env=self._environment(),
+                        user_prompt=question,
+                        round_label="experiment chat",
+                        invocation_id=execution.execution_id,
+                        progress=self._progress(),
+                    )
+                except BaseException as exc:
+                    error = exc
+                    if isinstance(exc, Exception):
+                        raise RuntimeError(  # noqa: TRY003, TRY004
+                            f"Chat agent failed: {type(exc).__name__}: {exc}"
+                        ) from exc
+                    raise
+                finally:
+                    self._supervisor.after_agent(
+                        "chat",
+                        "experiment-chat",
+                        result=answer,
+                        error=error,
+                        execution_id=execution.execution_id,
+                    )
+            assert answer is not None  # noqa: S101
+            if not answer.strip():
+                answer = fallback()
+            self._history.append((question, answer))
+            self._append_exchange(question, answer)
+            return answer
+
+    def close(self) -> None:
+        """Close resources owned by a dedicated terminal chat session."""
+        resources, self._resources = self._resources, None
+        if resources is not None:
+            resources.close()
+
+    @property
+    def _state_dir(self) -> Path:
+        return self._workspace / _CHAT_STATE_DIR
+
+    def _load_history(self) -> list[tuple[str, str]]:
+        transcript = self._state_dir / "conversation.jsonl"
+        if not transcript.is_file():
+            return []
+        history: list[tuple[str, str]] = []
+        try:
+            for line in transcript.read_text(encoding="utf-8").splitlines():
+                payload = json.loads(line)
+                question = payload.get("question")
+                answer = payload.get("answer")
+                if isinstance(question, str) and isinstance(answer, str):
+                    history.append((question, answer))
+        except (OSError, json.JSONDecodeError, AttributeError):
+            return []
+        return history
+
+    def _append_exchange(self, question: str, answer: str) -> None:
+        try:
+            self._state_dir.mkdir(parents=True, exist_ok=True)
+            with (self._state_dir / "conversation.jsonl").open("a", encoding="utf-8") as transcript:
+                transcript.write(
+                    json.dumps({"question": question, "answer": answer}, ensure_ascii=False) + "\n"
+                )
+        except OSError as exc:
+            self._log(f"[warn] could not persist experiment chat: {exc}")
+
+    def _sync_trajectory(self) -> None:
+        trajectory_dir = self._state_dir / "trajectory"
+        if self._state_dir.is_symlink():
+            self._log(f"[warn] experiment chat state is a symlink: {self._state_dir}")
+            return
+        try:
+            self._state_dir.mkdir(parents=True, exist_ok=True)
+            if trajectory_dir.is_symlink():
+                trajectory_dir.unlink()
+            elif trajectory_dir.exists():
+                shutil.rmtree(trajectory_dir)
+            trajectory_dir.mkdir(parents=True, exist_ok=True)
+            (self._state_dir / "instructions.md").write_text(
+                _EXPERIMENT_CHAT_SYSTEM_PROMPT, encoding="utf-8"
+            )
+            self._flush_logs()
+            self._write_trajectory_snapshot(
+                self._project.state.portable_run_export(self._run_id),
+                trajectory_dir / "state",
+            )
+            self._copy_trajectory_files(self._log_dir, trajectory_dir / "logs")
+        except (OSError, ValueError) as exc:
+            self._log(f"[warn] could not refresh experiment chat trajectory: {exc}")
+
+    @staticmethod
+    def _write_trajectory_snapshot(snapshot: StateSnapshot, destination_root: Path) -> None:
+        for state_file in snapshot.files:
+            if state_file.relative_path.suffix not in _CHAT_TRAJECTORY_SUFFIXES:
+                continue
+            destination = destination_root.joinpath(*state_file.relative_path.parts)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            temporary = destination.with_name(f".{destination.name}.tmp")
+            temporary.write_bytes(state_file.contents)
+            temporary.replace(destination)
+
+    @staticmethod
+    def _copy_trajectory_files(source_root: Path, destination_root: Path) -> None:
+        if not source_root.is_dir():
+            return
+        for source in sorted(source_root.rglob("*")):
+            if (
+                not source.is_file()
+                or source.is_symlink()
+                or source.suffix not in _CHAT_TRAJECTORY_SUFFIXES
+            ):
+                continue
+            destination = destination_root / source.relative_to(source_root)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            temporary = destination.with_name(f".{destination.name}.tmp")
+            shutil.copyfile(source, temporary)
+            temporary.replace(destination)
+
+
 class _RunContext:
     """Experiment lifecycle owner shared by simple, orchestrate, and issue loops.
 
@@ -1152,6 +1426,7 @@ class _RunContext:
         state: RunState,
         run_id: str,
         round_transaction_coordinator: RoundTransactionCoordinator | None = None,
+        experiment_chat: _ExperimentChatService | None = None,
     ):
         self.backend = backend
         self.run_environment = run_environment
@@ -1198,11 +1473,10 @@ class _RunContext:
         self.selected_gpu = device.selected_device
         self.agent_client = agent_client
         self._closed = False
+        self._experiment_chat = experiment_chat
         self._progress_stack: list[AgentProgress] = []
-        self._chat_lock = threading.Lock()
-        self._chat_history = self._load_chat_history()
-        if self.supervisor is not None:
-            self.supervisor.set_chat_handler(self.chat)
+        if self.supervisor is not None and self._experiment_chat is not None:
+            self.supervisor.set_chat_handler(self._experiment_chat.ask)
 
     # -- path passthroughs ----------------------------------------------------
     # Canonical values live in the frozen ``RunPaths`` record.
@@ -1346,162 +1620,12 @@ class _RunContext:
                 )
 
     def chat(self, question: str) -> str:
-        """Ask a read-only peer agent about the live experiment."""
-        from vibesys.server.inspector import RunInspector  # noqa: PLC0415  # tracked: #288
-
-        with self._chat_lock:
-            self._sync_chat_trajectory()
-
-            def fallback() -> str:
-                assert self.supervisor is not None  # noqa: S101  # tracked: #288
-                diagnostic = RunInspector(self.supervisor).answer(question)
-                return f"Chat agent did not return an answer.\n\nFallback diagnostic:\n{diagnostic}"
-
-            assert self.supervisor is not None  # noqa: S101  # tracked: #288
-            system_prompt = (
-                _EXPERIMENT_CHAT_CONTINUATION_PROMPT
-                if self._chat_history
-                else _EXPERIMENT_CHAT_SYSTEM_PROMPT
+        """Ask the experiment analysis agent about current run evidence."""
+        if self._experiment_chat is None:
+            raise RuntimeError(  # noqa: TRY003
+                "Experiment chat is not owned by this run context"
             )
-            execution = self.supervisor.start_agent_execution(
-                "chat",
-                "experiment-chat",
-                question,
-                system_prompt,
-                consume_steering=False,
-                participates_in_run_control=False,
-            )
-            answer: str | None = None
-            error: BaseException | None = None
-            with self.supervisor.presentation_scope(
-                agent_kind="chat",
-                round_label="experiment-chat",
-                invocation_id=execution.execution_id,
-            ):
-                try:
-                    answer = self.agent_client.invoke_text(
-                        kind="chat",
-                        workspace=self.workspace,
-                        system_prompt=system_prompt,
-                        env=self.gpu_env(),
-                        user_prompt=question,
-                        round_label="experiment chat",
-                        invocation_id=execution.execution_id,
-                        progress=self.current_progress(),
-                    )
-                except BaseException as exc:
-                    error = exc
-                    if isinstance(exc, Exception):
-                        raise RuntimeError(  # noqa: TRY003, TRY004  # tracked: #288
-                            f"Chat agent failed: {type(exc).__name__}: {exc}"
-                        ) from exc
-                    raise
-                finally:
-                    self.supervisor.after_agent(
-                        "chat",
-                        "experiment-chat",
-                        result=answer,
-                        error=error,
-                        execution_id=execution.execution_id,
-                    )
-            assert answer is not None  # noqa: S101  # successful invoke_text returns str
-            if not answer.strip():
-                answer = fallback()
-            self._chat_history.append((question, answer))
-            self._append_chat_exchange(question, answer)
-            return answer
-
-    @property
-    def _chat_state_dir(self) -> Path:
-        return self.workspace / _CHAT_STATE_DIR
-
-    def _load_chat_history(self) -> list[tuple[str, str]]:
-        """Load successful prior exchanges so reopening a run resumes its chat."""
-        transcript = self._chat_state_dir / "conversation.jsonl"
-        if not transcript.is_file():
-            return []
-        history: list[tuple[str, str]] = []
-        try:
-            for line in transcript.read_text(encoding="utf-8").splitlines():
-                payload = json.loads(line)
-                question = payload.get("question")
-                answer = payload.get("answer")
-                if isinstance(question, str) and isinstance(answer, str):
-                    history.append((question, answer))
-        except (OSError, json.JSONDecodeError, AttributeError):
-            return []
-        return history
-
-    def _append_chat_exchange(self, question: str, answer: str) -> None:
-        """Persist one successful exchange for later agent investigation."""
-        try:
-            self._chat_state_dir.mkdir(parents=True, exist_ok=True)
-            with (self._chat_state_dir / "conversation.jsonl").open(
-                "a", encoding="utf-8"
-            ) as transcript:
-                transcript.write(
-                    json.dumps({"question": question, "answer": answer}, ensure_ascii=False) + "\n"
-                )
-        except OSError as exc:
-            self.logger.lprint(f"[warn] could not persist experiment chat: {exc}")
-
-    def _sync_chat_trajectory(self) -> None:
-        """Refresh canonical portable state and local logs for experiment chat."""
-        trajectory_dir = self._chat_state_dir / "trajectory"
-        if self._chat_state_dir.is_symlink():
-            self.logger.lprint(f"[warn] experiment chat state is a symlink: {self._chat_state_dir}")
-            return
-        try:
-            self._chat_state_dir.mkdir(parents=True, exist_ok=True)
-            if trajectory_dir.is_symlink():
-                trajectory_dir.unlink()
-            elif trajectory_dir.exists():
-                shutil.rmtree(trajectory_dir)
-            trajectory_dir.mkdir(parents=True, exist_ok=True)
-            (self._chat_state_dir / "instructions.md").write_text(
-                _EXPERIMENT_CHAT_SYSTEM_PROMPT, encoding="utf-8"
-            )
-            self.run_log_file.flush()
-            self._write_chat_trajectory_snapshot(
-                self.project.state.portable_run_export(self.run_id),
-                trajectory_dir / "state",
-            )
-            self._copy_chat_trajectory_files(self.log_dir, trajectory_dir / "logs")
-        except OSError as exc:
-            self.logger.lprint(f"[warn] could not refresh experiment chat trajectory: {exc}")
-
-    @staticmethod
-    def _write_chat_trajectory_snapshot(
-        snapshot: StateSnapshot,
-        destination_root: Path,
-    ) -> None:
-        """Write textual files from an immutable portable-state export."""
-        for state_file in snapshot.files:
-            if state_file.relative_path.suffix not in _CHAT_TRAJECTORY_SUFFIXES:
-                continue
-            destination = destination_root.joinpath(*state_file.relative_path.parts)
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            temporary = destination.with_name(f".{destination.name}.tmp")
-            temporary.write_bytes(state_file.contents)
-            temporary.replace(destination)
-
-    @staticmethod
-    def _copy_chat_trajectory_files(source_root: Path, destination_root: Path) -> None:
-        """Copy textual regular files from one canonical state tree."""
-        if not source_root.is_dir():
-            return
-        for source in sorted(source_root.rglob("*")):
-            if (
-                not source.is_file()
-                or source.is_symlink()
-                or source.suffix not in _CHAT_TRAJECTORY_SUFFIXES
-            ):
-                continue
-            destination = destination_root / source.relative_to(source_root)
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            temporary = destination.with_name(f".{destination.name}.tmp")
-            shutil.copyfile(source, temporary)
-            temporary.replace(destination)
+        return self._experiment_chat.ask(question)
 
     def wait_for_debug(self, step: str) -> None:
         if self.debug:
@@ -1562,16 +1686,44 @@ class _RunContext:
         # Mirror backend state on _RunContext for legacy callers/tests.
         self.selected_gpu = self.device.selected_device
 
-    def close(self) -> None:
+    def close(self) -> None:  # noqa: C901  # preserve independent cleanup failures
         if self._closed:
             return
         self._closed = True
-        if self.supervisor is not None:
-            self.supervisor.set_chat_handler(None)
-        # Unwinds in reverse construction order: device monitor stop +
-        # gpu.json finalization, environment hook teardown, run-environment
-        # session exit, stderr restore + log file close.
-        self._teardown_stack.close()
+        chat_error: BaseException | None = None
+        experiment_chat, self._experiment_chat = self._experiment_chat, None
+        if self.supervisor is not None and experiment_chat is not None:
+            try:
+                self.supervisor.clear_chat_handler_and_drain()
+            except BaseException as exc:  # noqa: BLE001  # resource close must still run
+                chat_error = exc
+        if experiment_chat is not None:
+            try:
+                experiment_chat.close()
+            except BaseException as exc:  # noqa: BLE001  # primary teardown must still run
+                if chat_error is None:
+                    chat_error = exc
+                else:
+                    chat_error.add_note(
+                        f"Experiment chat cleanup also failed: {type(exc).__name__}: {exc}"
+                    )
+        primary_error: BaseException | None = None
+        try:
+            # Unwinds in reverse construction order: device monitor stop +
+            # gpu.json finalization, environment hook teardown, run-environment
+            # session exit, stderr restore + log file close.
+            self._teardown_stack.close()
+        except BaseException as exc:  # noqa: BLE001
+            primary_error = exc
+        if primary_error is not None:
+            if chat_error is not None:
+                primary_error.add_note(
+                    "Experiment chat teardown also failed: "
+                    f"{type(chat_error).__name__}: {chat_error}"
+                )
+            raise primary_error
+        if chat_error is not None:
+            raise chat_error
 
     def __enter__(self) -> "_RunContext":
         return self

--- a/src/vibesys/server/runtime.py
+++ b/src/vibesys/server/runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import signal
 from collections.abc import Callable  # noqa: TC003  # tracked: #288
+from contextlib import suppress
 from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any
 
@@ -28,7 +29,7 @@ from vibesys.server.supervisor import RunSupervisor
 from vibesys.server.transport import SupervisionSocketServer
 
 
-def run_server(
+def run_server(  # noqa: PLR0915
     run: Callable[[], Any],
     *,
     socket_path: Path,
@@ -43,6 +44,7 @@ def run_server(
 
     signal.signal(signal.SIGTERM, interrupt_from_launcher)
     service = SupervisionService(supervisor)
+    supervisor.enable_terminal_chat_retention()
     REGISTRY.activate(supervisor)
     supervisor.attach(socket_path.parent)
     supervisor.record(
@@ -50,10 +52,11 @@ def run_server(
         status=EventStatus.ACTIVE,
         data=ServerReadyData(),
     )
+    run_error: BaseException | None = None
     try:
         with SupervisionSocketServer(socket_path, service) as server:
             if not server.wait_for_subscriber(timeout=30.0):
-                raise RuntimeError("Timed out waiting for a supervision client")  # noqa: TRY003  # tracked: #288
+                raise RuntimeError("Timed out waiting for a supervision client")  # noqa: TRY003, TRY301  # tracked: #288
             try:
                 value = run()
             except KeyboardInterrupt:
@@ -114,6 +117,29 @@ def run_server(
             supervisor.finish()
             server.wait_for_subscriber_disconnect()
             return value
+    except BaseException as exc:
+        run_error = exc
+        raise
     finally:
-        REGISTRY.deactivate(supervisor)
-        signal.signal(signal.SIGTERM, previous_sigterm)
+        try:
+            try:
+                supervisor.close_terminal_chat_resource()
+            except BaseException as cleanup_error:  # noqa: BLE001  # presentation cleanup is optional
+                message = (
+                    "Terminal chat cleanup also failed: "
+                    f"{type(cleanup_error).__name__}: {cleanup_error}"
+                )
+                if run_error is not None:
+                    run_error.add_note(message)
+                else:
+                    # Terminal chat is a presentation facility. Its cleanup
+                    # cannot retroactively fail a completed experiment.
+                    with suppress(BaseException):
+                        supervisor.publish_output(
+                            "stderr",
+                            f"{message}\n",
+                            source="terminal-chat",
+                        )
+        finally:
+            REGISTRY.deactivate(supervisor)
+            signal.signal(signal.SIGTERM, previous_sigterm)

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import re
 import threading
+import time
 import uuid
 from collections.abc import Callable, Generator  # noqa: TC003  # tracked: #288
 from contextlib import contextmanager
@@ -47,6 +48,7 @@ from vibesys.server.events import (
 from vibesys.server.protocol import ActiveAgentExecution, RunSnapshot
 
 _MAX_EXCEPTION_CHAIN = 8
+_TERMINAL_CHAT_DRAIN_TIMEOUT_SECONDS = 5.0
 _DIAGNOSTIC_FAILURE_EVENTS = frozenset(
     {
         EventType.CONFIGURATION_FAILED,
@@ -92,6 +94,14 @@ class AgentExecutionHandle:
     user_prompt: str
 
 
+@dataclass(frozen=True)
+class TerminalChatResource:
+    """Chat handler and resources retained while the terminal UI is open."""
+
+    handler: Callable[[str], str]
+    close: Callable[[], None]
+
+
 class RunSupervisor:
     """Own pause state, invocation metadata, and the run audit store."""
 
@@ -115,6 +125,10 @@ class RunSupervisor:
         self._current_kind: str | None = None
         self._current_round: str | None = None
         self._chat_handler: Callable[[str], str] | None = None
+        self._active_chat_calls = 0
+        self._retain_terminal_chat = False
+        self._terminal_chat_resource: TerminalChatResource | None = None
+        self._retired_terminal_chat_resource: TerminalChatResource | None = None
         self._presentation_local = threading.local()
         self._legacy_execution_local = threading.local()
         # An invocation and its terminal run failure often carry the same
@@ -505,8 +519,8 @@ class RunSupervisor:
     def chat_agent_available(self) -> bool:
         """True when an agent-backed chat handler is installed for this run.
 
-        The handler exists only for the lifetime of the run context, so chat
-        asked during setup or after teardown has no agent to reach.
+        A server-backed run may replace its live handler with a separately
+        owned terminal handler after normal run teardown.
         """
         with self._condition:
             return self._chat_handler is not None
@@ -514,29 +528,55 @@ class RunSupervisor:
     def chat(self, text: str) -> str:  # noqa: D102  # tracked: #288
         with self._condition:
             handler = self._chat_handler
-        if handler is None:
-            from vibesys.server.inspector import RunInspector  # noqa: PLC0415  # tracked: #288
+            if handler is not None:
+                self._active_chat_calls += 1
+        try:
+            if handler is None:
+                from vibesys.server.inspector import RunInspector  # noqa: PLC0415  # tracked: #288
 
-            # No agent is reachable, so say that rather than answering as if
-            # this were the normal path. The keyword diagnostic is still worth
-            # showing, but it is supporting detail, not the answer.
-            answer = (
-                "The experiment chat agent is not available for this run"
-                f" ({self._chat_unavailable_reason()}), so this is a read-only"
-                " summary from the recorded events rather than an answer.\n\n"
-                + RunInspector(self).answer(text)
+                # No agent is reachable, so say that rather than answering as if
+                # this were the normal path. The keyword diagnostic is still worth
+                # showing, but it is supporting detail, not the answer.
+                answer = (
+                    "The experiment chat agent is not available for this run"
+                    f" ({self._chat_unavailable_reason()}), so this is a read-only"
+                    " summary from the recorded events rather than an answer.\n\n"
+                    + RunInspector(self).answer(text)
+                )
+            else:
+                answer = handler(text)
+            self.record(
+                EventType.CHAT,
+                text,
+                status=EventStatus.ANSWERED,
+                agent_kind="chat",
+                round_label="experiment-chat",
+                data=ChatData(answer=answer),
             )
-        else:
-            answer = handler(text)
-        self.record(
-            EventType.CHAT,
-            text,
-            status=EventStatus.ANSWERED,
-            agent_kind="chat",
-            round_label="experiment-chat",
-            data=ChatData(answer=answer),
-        )
-        return answer
+            return answer
+        finally:
+            if handler is not None:
+                self._release_chat_call()
+
+    def _release_chat_call(self) -> None:
+        """Release one handler lease and close a retired resource when safe."""
+        retired: TerminalChatResource | None = None
+        with self._condition:
+            self._active_chat_calls -= 1
+            if self._active_chat_calls == 0:
+                retired = self._retired_terminal_chat_resource
+                self._retired_terminal_chat_resource = None
+            self._condition.notify_all()
+        if retired is None:
+            return
+        try:
+            retired.close()
+        except Exception as exc:  # noqa: BLE001  # deferred cleanup cannot reach its caller
+            self.publish_output(
+                "stderr",
+                f"Terminal experiment chat cleanup failed: {type(exc).__name__}: {exc}\n",
+                source="terminal-chat",
+            )
 
     def _chat_unavailable_reason(self) -> str:
         with self._condition:
@@ -549,6 +589,60 @@ class RunSupervisor:
         """Install the current experiment's agent-backed chat handler."""
         with self._condition:
             self._chat_handler = handler
+
+    def clear_chat_handler_and_drain(self) -> None:
+        """Stop accepting chat and wait until callers release the live handler."""
+        with self._condition:
+            self._chat_handler = None
+            self._wait_for_chat_drain_locked(timeout=None)
+
+    def enable_terminal_chat_retention(self) -> None:
+        """Keep a run context's chat resources until its presentation exits."""
+        with self._condition:
+            self._retain_terminal_chat = True
+
+    def terminal_chat_retention_enabled(self) -> bool:
+        """Return whether the presentation runtime accepts a terminal chat resource."""
+        with self._condition:
+            return self._retain_terminal_chat
+
+    def retain_terminal_chat_resource(self, resource: TerminalChatResource) -> bool:
+        """Take ownership of terminal chat cleanup when retention is enabled."""
+        with self._condition:
+            if not self._retain_terminal_chat:
+                return False
+            if self._terminal_chat_resource is not None:
+                raise RuntimeError(  # noqa: TRY003
+                    "Terminal chat resources are already retained"
+                )
+            self._terminal_chat_resource = resource
+            self._chat_handler = resource.handler
+            return True
+
+    def close_terminal_chat_resource(self) -> None:
+        """Retire the terminal resource, closing it after its last borrower."""
+        with self._condition:
+            resource = self._terminal_chat_resource
+            self._terminal_chat_resource = None
+            self._retain_terminal_chat = False
+            if resource is not None and self._chat_handler == resource.handler:
+                self._chat_handler = None
+            if resource is not None and not self._wait_for_chat_drain_locked(
+                timeout=_TERMINAL_CHAT_DRAIN_TIMEOUT_SECONDS
+            ):
+                self._retired_terminal_chat_resource = resource
+                resource = None
+        if resource is not None:
+            resource.close()
+
+    def _wait_for_chat_drain_locked(self, *, timeout: float | None) -> bool:
+        deadline = time.monotonic() + timeout if timeout is not None else None
+        while self._active_chat_calls > 0:
+            remaining = None if deadline is None else deadline - time.monotonic()
+            if remaining is not None and remaining <= 0:
+                return False
+            self._condition.wait(timeout=remaining)
+        return True
 
     @contextmanager
     def presentation_scope(
@@ -822,6 +916,8 @@ class RunSupervisor:
             if self._run_status in {"completed", "failed"}:
                 return
             for execution_id, active in tuple(self._active_executions.items()):
+                if execution_id not in self._run_control_execution_ids:
+                    continue
                 message = "Run ended before the agent execution completed"
                 self.record(
                     EventType.AGENT_EXECUTION_FINISHED,

--- a/tests/agents/drivers/test_agentshim_driver.py
+++ b/tests/agents/drivers/test_agentshim_driver.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import concurrent.futures
+import threading
 from dataclasses import dataclass, field
 from datetime import timedelta
 from types import SimpleNamespace
@@ -181,6 +183,77 @@ def test_turn_forwards_prompt_timeout_events_and_usage(
         subject.AgentEventKind.THINKING,
         subject.AgentEventKind.USAGE,
     ]
+
+
+def test_independent_sessions_overlap_and_chat_cleanup_does_not_interrupt_optimizer(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    barrier = threading.Barrier(2)
+    release_optimizer = threading.Event()
+    optimizer_observer = _Observer()
+    chat_observer = _Observer()
+    driver = subject.AgentShimDriver(provider="codex")
+    optimizer = driver.create_session(_spec(tmp_path, role="implementer"))
+    chat = driver.create_session(
+        _spec(tmp_path, role="chat", environment=(("CHAT_MODE", "read-only"),))
+    )
+
+    def generate_optimizer(
+        _prompt: str,
+        *,
+        cwd: str | None,
+        timeout: int | None,
+        silent: bool,
+    ) -> str:
+        assert cwd == str(tmp_path)
+        assert timeout is None
+        assert silent
+        barrier.wait(timeout=2)
+        assert fake_agent[0].event_handler is not None
+        fake_agent[0].event_handler.on_thinking("optimizer event")
+        assert release_optimizer.wait(timeout=2)
+        return "optimizer result"
+
+    def generate_chat(
+        _prompt: str,
+        *,
+        cwd: str | None,
+        timeout: int | None,
+        silent: bool,
+    ) -> str:
+        assert cwd == str(tmp_path)
+        assert timeout is None
+        assert silent
+        barrier.wait(timeout=2)
+        assert fake_agent[1].event_handler is not None
+        fake_agent[1].event_handler.on_thinking("chat event")
+        return "chat result"
+
+    fake_agent[0].generate = generate_optimizer
+    fake_agent[1].generate = generate_chat
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        optimizer_turn = pool.submit(
+            optimizer.run_turn,
+            AgentTurnRequest(message="optimize"),
+            optimizer_observer,
+        )
+        chat_turn = pool.submit(
+            chat.run_turn,
+            AgentTurnRequest(message="explain the run"),
+            chat_observer,
+        )
+        assert chat_turn.result(timeout=3).text == "chat result"
+        chat.close()
+        assert not optimizer_turn.done()
+        release_optimizer.set()
+        assert optimizer_turn.result(timeout=3).text == "optimizer result"
+
+    assert fake_agent[0].env == {"BASE": "one", "GPU": "0"}
+    assert fake_agent[1].env == {"BASE": "one", "CHAT_MODE": "read-only"}
+    assert [event.text for event in optimizer_observer.events] == ["optimizer event"]
+    assert [event.text for event in chat_observer.events] == ["chat event"]
+    driver.close()
 
 
 def test_mcp_is_session_scoped_but_activated_only_around_turn(

--- a/tests/agents/drivers/test_omnigent_driver.py
+++ b/tests/agents/drivers/test_omnigent_driver.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
+import contextlib
 import inspect
+import json
 import os
 import shutil
+import subprocess
 import sys
+import threading
 from dataclasses import dataclass, field, replace
 from datetime import timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -21,12 +27,15 @@ from vibesys.agents.contracts import (
     AgentTurnRequest,
     MCPServerSpec,
 )
+from vibesys.agents.drivers import omnigent as driver_subject
+from vibesys.agents.drivers._omnigent_runtime import OmnigentAsyncRuntime
 from vibesys.agents.drivers.omnigent import (
     _TOOL_EXECUTOR_ATTR,
     OmnigentDriver,
     OmnigentDriverError,
     OmnigentSession,
     _build_os_tools,
+    _LifecycleState,
 )
 from vibesys.agents.omnigent.providers import OMNIGENT_PROVIDER_EXECUTORS
 from vibesys.schemas import JudgeResponse
@@ -86,6 +95,8 @@ def test_registered_executor_exposes_tool_dispatch_seam(
     executor = executor_class(cwd=".", model=None)
     try:
         assert hasattr(executor, _TOOL_EXECUTOR_ATTR)
+        environment_attribute = driver_subject._PROVIDER_ENVIRONMENT_ATTRS[provider]  # noqa: SLF001
+        assert isinstance(getattr(executor, environment_attribute, None), dict)
     finally:
         driver.close_executor(executor)
 
@@ -133,16 +144,279 @@ def _spec(tmp_path: Path, **changes: Any) -> AgentSessionSpec:  # noqa: ANN401
     return replace(base, **changes)
 
 
-def _session(tmp_path: Path, executor: _FakeExecutor) -> tuple[OmnigentDriver, OmnigentSession]:
+def _session(
+    tmp_path: Path,
+    executor: _FakeExecutor,
+    resources: driver_subject._ExecutorResources | None = None,
+) -> tuple[OmnigentDriver, OmnigentSession]:
     driver = OmnigentDriver()
     session = OmnigentSession(
         driver=driver,
         spec=_spec(tmp_path, reasoning_effort="high", environment=(("DRIVER_TEST", "set"),)),
         executor=executor,
         tool_schemas=[{"name": "sys_os_read"}],
+        resources=resources,
     )
     driver._sessions.add(session)  # noqa: SLF001
     return driver, session
+
+
+def _resources() -> driver_subject._ExecutorResources:
+    return driver_subject._ExecutorResources()  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    ("provider", "attribute"),
+    [("codex", "_env"), ("claude", "_extra_env")],
+)
+def test_provider_environment_is_explicit_and_does_not_modify_process_environment(
+    provider: str,
+    attribute: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = "VIBESYS_TEST_PROVIDER_ENV"
+    monkeypatch.setenv(key, "ambient")
+    executor = SimpleNamespace(**{attribute: {"BASE": "preserved"}})
+
+    driver_subject._adapt_provider_environment(  # noqa: SLF001
+        executor,
+        provider=provider,
+        environment={key: "session"},
+    )
+
+    assert getattr(executor, attribute) == {"BASE": "preserved", key: "session"}
+    assert os.environ[key] == "ambient"
+    inherited = subprocess.check_output(  # noqa: S603
+        [sys.executable, "-c", f"import os; print(os.environ[{key!r}])"],
+        text=True,
+    ).strip()
+    assert inherited == "ambient"
+
+
+def test_distinct_tool_helpers_snapshot_their_own_environment_without_command_rewrite(  # noqa: C901
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent.inner import os_env as omnigent_os_env  # noqa: PLC0415
+    from omnigent.inner.sandbox import SandboxPolicy  # noqa: PLC0415
+    from omnigent.tools.builtins import os_env as omnigent_os_tools  # noqa: PLC0415
+
+    key = "CARGO_HOME"
+    monkeypatch.setenv(key, "ambient")
+    start_together = threading.Barrier(2)
+    environment_ready = threading.Barrier(3)
+    captured: list[str] = []
+
+    class Resource:
+        def __init__(self) -> None:
+            self.close_calls = 0
+            self._helper = Helper()
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    class Helper:
+        def __init__(self) -> None:
+            self.sandbox = SandboxPolicy(
+                backend_type="none",
+                active=False,
+                read_roots=None,
+                write_roots=[],
+                write_files=[],
+                allow_network=True,
+            )
+
+        def _start_locked(self) -> None:
+            helper_environment = omnigent_os_env.build_helper_env(os.environ, self.sandbox)
+            captured.append(helper_environment[key])
+            environment_ready.wait(timeout=2)
+
+    class ShellTool:
+        @staticmethod
+        def name() -> str:
+            return "sys_os_shell"
+
+        @staticmethod
+        def get_schema() -> dict[str, Any]:
+            return {
+                "function": {
+                    "name": "sys_os_shell",
+                    "description": "shell",
+                    "parameters": {"type": "object"},
+                }
+            }
+
+        def __init__(self, resource: Resource) -> None:
+            self._resource = resource
+
+        def invoke(self, arguments: str, _context: Any) -> str:  # noqa: ANN401
+            start_together.wait(timeout=2)
+            self._resource._helper._start_locked()  # noqa: SLF001
+            return arguments
+
+    resources: list[Resource] = []
+
+    def create_environment(_spec: Any) -> Resource:  # noqa: ANN401
+        resource = Resource()
+        resources.append(resource)
+        return resource
+
+    monkeypatch.setattr(omnigent_os_env, "create_os_environment", create_environment)
+    monkeypatch.setattr(
+        omnigent_os_tools,
+        "build_os_env_tools",
+        lambda environment: [ShellTool(environment)],
+    )
+    cargo_homes = [str(tmp_path / "optimizer cargo"), str(tmp_path / "chat cargo")]
+    built = [
+        _build_os_tools(object(), tmp_path, {key: cargo_home}, object())
+        for cargo_home in cargo_homes
+    ]
+
+    def dispatch_together() -> tuple[list[str], str]:
+        def unrelated_subprocess() -> str:
+            environment_ready.wait(timeout=2)
+            return subprocess.check_output(  # noqa: S603
+                [sys.executable, "-c", f"import os; print(os.environ[{key!r}])"],
+                text=True,
+            ).strip()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+            futures = [
+                pool.submit(
+                    asyncio.run,
+                    os_tools.dispatch("sys_os_shell", {"command": "cargo test"}),
+                )
+                for os_tools in built
+            ]
+            inherited = pool.submit(unrelated_subprocess)
+            return [future.result(timeout=2) for future in futures], inherited.result(timeout=2)
+
+    commands, first_inherited = dispatch_together()
+    monkeypatch.setenv(key, "new ambient")
+    restarted_commands, second_inherited = dispatch_together()
+
+    assert commands == ['{"command": "cargo test"}', '{"command": "cargo test"}']
+    assert restarted_commands == commands
+    assert sorted(captured) == sorted(cargo_homes * 2)
+    assert os.environ[key] == "new ambient"
+    assert (first_inherited, second_inherited) == ("ambient", "new ambient")
+    for os_tools in built:
+        os_tools.close()
+    assert [resource.close_calls for resource in resources] == [1, 1, 1, 1]
+
+
+def test_os_tool_setup_closes_all_environments_when_schema_building_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent.inner import os_env as omnigent_os_env  # noqa: PLC0415
+    from omnigent.tools.builtins import os_env as omnigent_os_tools  # noqa: PLC0415
+
+    class Helper:
+        sandbox = SimpleNamespace()
+
+        @staticmethod
+        def _start_locked() -> None:
+            pass
+
+    class Resource:
+        def __init__(self) -> None:
+            self.close_calls = 0
+            self._helper = Helper()
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    schema_error = RuntimeError("schema exploded")
+
+    class BrokenTool:
+        @staticmethod
+        def name() -> str:
+            return "sys_os_shell"
+
+        @staticmethod
+        def get_schema() -> dict[str, Any]:
+            raise schema_error
+
+    resources: list[Resource] = []
+
+    def create_environment(_spec: Any) -> Resource:  # noqa: ANN401
+        resource = Resource()
+        resources.append(resource)
+        return resource
+
+    monkeypatch.setattr(omnigent_os_env, "create_os_environment", create_environment)
+    monkeypatch.setattr(
+        omnigent_os_tools,
+        "build_os_env_tools",
+        lambda _environment: [BrokenTool()],
+    )
+
+    with pytest.raises(RuntimeError, match="schema exploded"):
+        _build_os_tools(object(), tmp_path, {"CARGO_HOME": "isolated"}, object())
+
+    assert [resource.close_calls for resource in resources] == [1, 1]
+
+
+def test_os_tool_setup_validates_helper_seam_and_closes_partial_resources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent.inner import os_env as omnigent_os_env  # noqa: PLC0415
+
+    class Resource:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    resources: list[Resource] = []
+
+    def create_environment(_spec: Any) -> Resource:  # noqa: ANN401
+        resource = Resource()
+        resources.append(resource)
+        return resource
+
+    monkeypatch.setattr(omnigent_os_env, "create_os_environment", create_environment)
+
+    with pytest.raises(OmnigentDriverError, match=r"_helper.*sandbox"):
+        _build_os_tools(object(), tmp_path, {"CARGO_HOME": "isolated"}, object())
+
+    assert [resource.close_calls for resource in resources] == [1, 1]
+
+
+def test_owned_os_tools_close_all_resources_once_and_preserve_first_failure() -> None:
+    closed: list[str] = []
+
+    class Resource:
+        def __init__(self, name: str, error: BaseException | None = None) -> None:
+            self.name = name
+            self.error = error
+
+        def close(self) -> None:
+            closed.append(self.name)
+            if self.error is not None:
+                raise self.error
+
+    first_error = KeyboardInterrupt("first")
+    os_tools = driver_subject._OwnedOSTools(  # noqa: SLF001
+        schemas=[],
+        dispatch=lambda _name, _args: None,
+        environments=(
+            Resource("first", first_error),
+            Resource("second", RuntimeError("second")),
+        ),
+    )
+
+    with pytest.raises(KeyboardInterrupt) as raised:
+        os_tools.close()
+
+    assert raised.value is first_error
+    assert closed == ["first", "second"]
+    os_tools.close()
+    assert closed == ["first", "second"]
 
 
 def test_turn_normalizes_events_usage_schema_and_session_id(tmp_path: Path) -> None:
@@ -176,7 +450,7 @@ def test_turn_normalizes_events_usage_schema_and_session_id(tmp_path: Path) -> N
     assert tools == [{"name": "sys_os_read"}]
     assert instructions == "system"
     assert config.extra["reasoning_effort"] == "high"
-    assert environment == "set"
+    assert environment is None
     assert "DRIVER_TEST" not in os.environ
     assert [event.kind.value for event in observer.events] == [
         "text",
@@ -212,6 +486,482 @@ def test_timeout_poisons_session_and_cleanup_is_idempotent(tmp_path: Path) -> No
     session.close()
     driver.close()
     assert executor.close_calls == 1
+
+
+def test_session_cleanup_closes_owned_os_environments(tmp_path: Path) -> None:
+    class Resource:
+        close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    executor = _FakeExecutor([])
+    resource = Resource()
+    os_tools = driver_subject._OwnedOSTools(  # noqa: SLF001
+        schemas=[],
+        dispatch=lambda _name, _args: None,
+        environments=(resource,),
+    )
+    resources = driver_subject._ExecutorResources(os_tools=os_tools)  # noqa: SLF001
+    driver, _session_instance = _session(tmp_path, executor, resources)
+
+    driver.close()
+
+    assert resource.close_calls == 1
+
+
+def test_close_cancels_an_active_turn_from_another_thread(tmp_path: Path) -> None:
+    started = threading.Event()
+    finalized = threading.Event()
+
+    class NeverEndingExecutor(_FakeExecutor):
+        def run_turn(self, *_args: object, **_kwargs: object):  # noqa: ANN202
+            async def stream():  # noqa: ANN202
+                started.set()
+                try:
+                    await asyncio.Future()
+                finally:
+                    finalized.set()
+                if False:
+                    yield None
+
+            return stream()
+
+    executor = NeverEndingExecutor([])
+    driver, session = _session(tmp_path, executor)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        turn = pool.submit(session.run_turn, AgentTurnRequest("work forever"))
+        assert started.wait(timeout=2)
+        session.close()
+        with pytest.raises(concurrent.futures.CancelledError):
+            turn.result(timeout=2)
+
+    assert finalized.is_set()
+    driver.close()
+    assert executor.close_calls == 1
+
+
+def test_close_waits_for_turn_cancellation_cleanup_before_executor_close(
+    tmp_path: Path,
+) -> None:
+    started = threading.Event()
+    cleanup_started = threading.Event()
+    release_cleanup = threading.Event()
+    cleanup_finished = threading.Event()
+    executor_closed = threading.Event()
+
+    class CleanupExecutor(_FakeExecutor):
+        def run_turn(self, *_args: object, **_kwargs: object):  # noqa: ANN202
+            async def stream():  # noqa: ANN202
+                started.set()
+                try:
+                    await asyncio.Future()
+                finally:
+                    cleanup_started.set()
+                    await asyncio.to_thread(release_cleanup.wait, 2)
+                    cleanup_finished.set()
+                if False:
+                    yield None
+
+            return stream()
+
+        async def close(self) -> None:
+            assert cleanup_finished.is_set()
+            executor_closed.set()
+            await super().close()
+
+    executor = CleanupExecutor([])
+    driver, session = _session(tmp_path, executor)
+    turn_thread = threading.Thread(target=lambda: _ignore_cancelled_turn(session))
+    close_thread = threading.Thread(target=session.close)
+    turn_thread.start()
+    assert started.wait(timeout=2)
+
+    close_thread.start()
+    assert cleanup_started.wait(timeout=2)
+    assert not executor_closed.wait(timeout=0.05)
+    release_cleanup.set()
+    close_thread.join(timeout=2)
+    turn_thread.join(timeout=2)
+
+    assert not close_thread.is_alive()
+    assert not turn_thread.is_alive()
+    assert executor_closed.is_set()
+    driver.close()
+    assert executor.close_calls == 1
+
+
+@pytest.mark.parametrize("close_target", ["session", "driver"])
+def test_close_from_observer_rejects_without_deadlocking_loop(
+    tmp_path: Path,
+    close_target: str,
+) -> None:
+    executor = _FakeExecutor([TextChunk("event")])
+    driver, session = _session(tmp_path, executor)
+
+    class ClosingObserver:
+        def on_event(self, event: AgentEvent) -> None:
+            del event
+            if close_target == "session":
+                session.close()
+            else:
+                driver.close()
+
+    with pytest.raises(RuntimeError, match="event-loop thread"):
+        session.run_turn(AgentTurnRequest("trigger callback"), ClosingObserver())
+
+    assert session._close_lifecycle.state is _LifecycleState.OPEN  # noqa: SLF001
+    assert driver._close_lifecycle.state is _LifecycleState.OPEN  # noqa: SLF001
+    driver.close()
+    assert executor.close_calls == 1
+
+
+def test_driver_close_drains_blocking_default_executor_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(driver_subject, "_SESSION_SHUTDOWN_TIMEOUT", 0.01)
+    worker_started = threading.Event()
+    finalized = threading.Event()
+    release_worker = threading.Event()
+    close_finished = threading.Event()
+    resource_closed = threading.Event()
+
+    class ThreadedExecutor(_FakeExecutor):
+        def run_turn(self, *_args: object, **_kwargs: object):  # noqa: ANN202
+            async def stream():  # noqa: ANN202
+                def block() -> None:
+                    worker_started.set()
+                    release_worker.wait(timeout=2)
+                    finalized.set()
+
+                await asyncio.to_thread(block)
+                if False:
+                    yield None
+
+            return stream()
+
+    class Scratch:
+        def cleanup(self) -> None:
+            assert finalized.is_set()
+            resource_closed.set()
+
+    executor = ThreadedExecutor([])
+    scratch: Any = Scratch()
+    resources = driver_subject._ExecutorResources(scratch=scratch)  # noqa: SLF001
+    driver, session = _session(tmp_path, executor, resources)
+    turn_thread = threading.Thread(target=lambda: _ignore_cancelled_turn(session))
+    turn_thread.start()
+    assert worker_started.wait(timeout=2)
+    close_thread = threading.Thread(target=lambda: (driver.close(), close_finished.set()))
+    close_thread.start()
+
+    assert not close_finished.wait(timeout=0.05)
+    release_worker.set()
+    close_thread.join(timeout=2)
+    turn_thread.join(timeout=2)
+
+    assert close_finished.is_set()
+    assert not close_thread.is_alive()
+    assert not turn_thread.is_alive()
+    assert resource_closed.is_set()
+    assert executor.close_calls == 1
+
+
+@pytest.mark.parametrize("failure", ["start", "ready"])
+def test_driver_runtime_setup_failure_closes_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    monkeypatch.setattr(driver_subject, "_SESSION_SHUTDOWN_TIMEOUT", 0.01)
+    created_loops: list[asyncio.AbstractEventLoop] = []
+    new_event_loop = asyncio.new_event_loop
+
+    def capture_loop() -> asyncio.AbstractEventLoop:
+        loop = new_event_loop()
+        created_loops.append(loop)
+        return loop
+
+    monkeypatch.setattr(driver_subject.asyncio, "new_event_loop", capture_loop)
+    if failure == "start":
+
+        def fail_start(_thread: threading.Thread) -> None:
+            raise RuntimeError("thread start failed")  # noqa: TRY003  # test sentinel
+
+        monkeypatch.setattr(driver_subject.threading.Thread, "start", fail_start)
+        error = "thread start failed"
+    else:
+        monkeypatch.setattr(OmnigentAsyncRuntime, "_serve", lambda _self: None)
+        error = "event loop did not start"
+
+    with pytest.raises(RuntimeError, match=error):
+        OmnigentDriver()
+
+    assert len(created_loops) == 1
+    assert created_loops[0].is_closed()
+
+
+def _ignore_cancelled_turn(session: OmnigentSession) -> None:
+    with contextlib.suppress(concurrent.futures.CancelledError):
+        session.run_turn(AgentTurnRequest("use a worker"))
+
+
+def test_concurrent_session_close_callers_receive_base_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    driver, session = _session(tmp_path, _FakeExecutor([]))
+    cleanup_started = threading.Event()
+    release_cleanup = threading.Event()
+
+    def fail_cleanup(_active: concurrent.futures.Future[Any] | None) -> None:
+        cleanup_started.set()
+        assert release_cleanup.wait(timeout=2)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(session, "_close_resources", fail_cleanup)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        owner = pool.submit(session.close)
+        assert cleanup_started.wait(timeout=2)
+        waiter = pool.submit(session.close)
+        release_cleanup.set()
+        for future in (owner, waiter):
+            with pytest.raises(KeyboardInterrupt):
+                future.result(timeout=2)
+
+    assert session._close_lifecycle.state is _LifecycleState.CLOSED  # noqa: SLF001
+    with pytest.raises(KeyboardInterrupt):
+        session.close()
+    driver._sessions.clear()  # noqa: SLF001
+    driver.close()
+
+
+def test_independent_sessions_overlap_on_one_driver_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    barrier = threading.Barrier(2)
+    active_lock = threading.Lock()
+    active = 0
+    maximum_active = 0
+    runtime_threads: set[int] = set()
+
+    class OverlappingExecutor(_FakeExecutor):
+        def __init__(self, answer: str) -> None:
+            super().__init__([])
+            self.answer = answer
+
+        def run_turn(self, *_args: object, **_kwargs: object):  # noqa: ANN202
+            async def stream():  # noqa: ANN202
+                nonlocal active, maximum_active
+                runtime_threads.add(threading.get_ident())
+                with active_lock:
+                    active += 1
+                    maximum_active = max(maximum_active, active)
+                try:
+                    await asyncio.to_thread(barrier.wait, 2)
+                    await asyncio.sleep(0)
+                    yield TurnComplete(response=self.answer)
+                finally:
+                    with active_lock:
+                        active -= 1
+
+            return stream()
+
+    driver = OmnigentDriver()
+    executors = [OverlappingExecutor("optimizer"), OverlappingExecutor("chat")]
+    remaining = iter(executors)
+    monkeypatch.setattr(
+        driver,
+        "_build_executor",
+        lambda _spec: (next(remaining), [], _resources()),
+    )
+    sessions = [driver.create_session(_spec(tmp_path)) for _ in executors]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(session.run_turn, AgentTurnRequest("work")) for session in sessions]
+        results = [future.result(timeout=3) for future in futures]
+
+    assert [result.text for result in results] == ["optimizer", "chat"]
+    assert maximum_active == 2
+    assert active == 0
+    assert len(runtime_threads) == 1
+
+    driver.close()
+    assert [executor.close_calls for executor in executors] == [1, 1]
+    assert driver._runtime._loop.is_closed()  # noqa: SLF001
+    assert driver._sessions == set()  # noqa: SLF001
+
+
+def test_turns_in_one_session_run_in_submission_order(tmp_path: Path) -> None:
+    first_started = threading.Event()
+    release_first = threading.Event()
+    observed_messages: list[str] = []
+
+    class OrderedExecutor(_FakeExecutor):
+        def run_turn(  # noqa: ANN202
+            self,
+            messages: list[dict[str, Any]],
+            *_args: object,
+            **_kwargs: object,
+        ):
+            async def stream():  # noqa: ANN202
+                message = messages[0]["content"]
+                observed_messages.append(message)
+                if message == "first":
+                    first_started.set()
+                    await asyncio.to_thread(release_first.wait, 2)
+                yield TurnComplete(response=message)
+
+            return stream()
+
+    driver, session = _session(tmp_path, OrderedExecutor([]))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(session.run_turn, AgentTurnRequest("first"))
+        assert first_started.wait(timeout=2)
+        second = pool.submit(session.run_turn, AgentTurnRequest("second"))
+        assert observed_messages == ["first"]
+        release_first.set()
+        assert first.result(timeout=2).text == "first"
+        assert second.result(timeout=2).text == "second"
+
+    assert observed_messages == ["first", "second"]
+    driver.close()
+
+
+def test_close_racing_a_queued_turn_cancels_active_and_rejects_queued(
+    tmp_path: Path,
+) -> None:
+    first_started = threading.Event()
+    starts = 0
+
+    class BlockingExecutor(_FakeExecutor):
+        def run_turn(self, *_args: object, **_kwargs: object):  # noqa: ANN202
+            async def stream():  # noqa: ANN202
+                nonlocal starts
+                starts += 1
+                first_started.set()
+                await asyncio.Future()
+                if False:
+                    yield None
+
+            return stream()
+
+    executor = BlockingExecutor([])
+    driver, session = _session(tmp_path, executor)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        active = pool.submit(session.run_turn, AgentTurnRequest("active"))
+        assert first_started.wait(timeout=2)
+        queued = pool.submit(session.run_turn, AgentTurnRequest("queued"))
+        session.close()
+        with pytest.raises(concurrent.futures.CancelledError):
+            active.result(timeout=2)
+        with pytest.raises(RuntimeError, match="closed"):
+            queued.result(timeout=2)
+
+    assert starts == 1
+    driver.close()
+
+
+def test_driver_close_continues_after_cleanup_base_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FailingCloseExecutor(_FakeExecutor):
+        async def close(self) -> None:
+            self.close_calls += 1
+            raise KeyboardInterrupt
+
+    driver = OmnigentDriver()
+    executors = [FailingCloseExecutor([]), _FakeExecutor([])]
+    remaining = iter(executors)
+    monkeypatch.setattr(
+        driver,
+        "_build_executor",
+        lambda _spec: (next(remaining), [], _resources()),
+    )
+    for _ in executors:
+        driver.create_session(_spec(tmp_path))
+
+    with pytest.raises(KeyboardInterrupt):
+        driver.close()
+
+    assert [executor.close_calls for executor in executors] == [1, 1]
+    assert driver._runtime._loop.is_closed()  # noqa: SLF001
+    assert driver._sessions == set()  # noqa: SLF001
+
+
+def test_concurrent_driver_close_callers_receive_base_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = _FakeExecutor([])
+    driver, session = _session(tmp_path, executor)
+    cleanup_started = threading.Event()
+    release_cleanup = threading.Event()
+    original_close = session.close
+
+    def fail_close() -> None:
+        cleanup_started.set()
+        assert release_cleanup.wait(timeout=2)
+        original_close()
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(session, "close", fail_close)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        owner = pool.submit(driver.close)
+        assert cleanup_started.wait(timeout=2)
+        waiter = pool.submit(driver.close)
+        release_cleanup.set()
+        for future in (owner, waiter):
+            with pytest.raises(KeyboardInterrupt):
+                future.result(timeout=2)
+
+    assert driver._close_lifecycle.state is _LifecycleState.CLOSED  # noqa: SLF001
+    with pytest.raises(KeyboardInterrupt):
+        driver.close()
+    assert executor.close_calls == 1
+
+
+def test_driver_close_waits_for_in_flight_session_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    build_started = threading.Event()
+    release_build = threading.Event()
+    close_finished = [threading.Event(), threading.Event()]
+    executor = _FakeExecutor([])
+    driver = OmnigentDriver()
+
+    def build(
+        _spec: AgentSessionSpec,
+    ) -> tuple[_FakeExecutor, list[dict[str, Any]], driver_subject._ExecutorResources]:
+        build_started.set()
+        assert release_build.wait(timeout=2)
+        return executor, [], _resources()
+
+    monkeypatch.setattr(driver, "_build_executor", build)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+        creation = pool.submit(driver.create_session, _spec(tmp_path))
+        assert build_started.wait(timeout=2)
+        closing = pool.submit(lambda: (driver.close(), close_finished[0].set()))
+        while True:
+            with driver._lifecycle:  # noqa: SLF001
+                if driver._close_lifecycle.state is _LifecycleState.CLOSING:  # noqa: SLF001
+                    break
+        second_closing = pool.submit(lambda: (driver.close(), close_finished[1].set()))
+        assert not close_finished[0].wait(timeout=0.05)
+        assert not close_finished[1].wait(timeout=0.05)
+        release_build.set()
+        with pytest.raises(RuntimeError, match="closed"):
+            creation.result(timeout=2)
+        closing.result(timeout=2)
+        second_closing.result(timeout=2)
+
+    assert all(finished.is_set() for finished in close_finished)
+    assert executor.close_calls == 1
+    assert driver._sessions == set()  # noqa: SLF001
 
 
 @pytest.mark.parametrize(
@@ -260,7 +1010,11 @@ def test_create_session_accepts_supported_top_level_project_policy(
 ) -> None:
     driver = OmnigentDriver()
     executor = _FakeExecutor([])
-    monkeypatch.setattr(driver, "_build_executor", lambda _spec: (executor, []))
+    monkeypatch.setattr(
+        driver,
+        "_build_executor",
+        lambda _spec: (executor, [], _resources()),
+    )
     policy = ProjectPathPolicy(
         read_only_paths=(".git", ".vibesys"),
         hidden_paths=(".env",),
@@ -280,7 +1034,11 @@ def test_create_session_accepts_non_dot_hidden_path(
 ) -> None:
     driver = OmnigentDriver()
     executor = _FakeExecutor([])
-    monkeypatch.setattr(driver, "_build_executor", lambda _spec: (executor, []))
+    monkeypatch.setattr(
+        driver,
+        "_build_executor",
+        lambda _spec: (executor, [], _resources()),
+    )
     policy = ProjectPathPolicy(hidden_paths=("agent.toml",))
 
     session = driver.create_session(
@@ -297,7 +1055,11 @@ def test_driver_owns_session_cleanup(
 ) -> None:
     executor = _FakeExecutor([])
     driver = OmnigentDriver()
-    monkeypatch.setattr(driver, "_build_executor", lambda _spec: (executor, []))
+    monkeypatch.setattr(
+        driver,
+        "_build_executor",
+        lambda _spec: (executor, [], _resources()),
+    )
 
     driver.create_session(_spec(tmp_path))
     driver.close()
@@ -397,17 +1159,45 @@ def test_os_policy_masks_declared_non_dot_and_nested_paths(tmp_path: Path) -> No
     spec = driver._build_os_env(  # noqa: SLF001
         _spec(tmp_path, policy=AgentExecutionPolicy(project_paths=policy))
     )
-    _, dispatch = _build_os_tools(spec, tmp_path)
+    os_tools = _build_os_tools(spec, tmp_path)
 
-    public = asyncio.run(dispatch("sys_os_read", {"path": "public.txt"}))
-    hidden = asyncio.run(dispatch("sys_os_read", {"path": "agent.toml"}))
-    nested = asyncio.run(dispatch("sys_os_read", {"path": "config/secret"}))
+    try:
+        public = asyncio.run(os_tools.dispatch("sys_os_read", {"path": "public.txt"}))
+        hidden = asyncio.run(os_tools.dispatch("sys_os_read", {"path": "agent.toml"}))
+        nested = asyncio.run(os_tools.dispatch("sys_os_read", {"path": "config/secret"}))
+    finally:
+        os_tools.close()
 
     assert "public-4417" in str(public)
     assert "secret-9913" not in str(hidden)
     assert "error" in str(hidden).lower()
     assert "secret-7729" not in str(nested)
     assert "error" in str(nested).lower()
+
+
+@requires_sandbox_backend
+def test_real_os_shell_receives_explicit_environment_without_changing_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = "VIBESYS_TEST_REAL_HELPER_ENV"
+    monkeypatch.setenv(key, "ambient")
+    driver = OmnigentDriver()
+    spec = driver._build_os_env(  # noqa: SLF001
+        _spec(tmp_path),
+        env_passthrough=(key,),
+    )
+    os_tools = _build_os_tools(spec, tmp_path, {key: "session"})
+
+    try:
+        result = asyncio.run(os_tools.dispatch("sys_os_shell", {"command": f'printf %s "${key}"'}))
+    finally:
+        os_tools.close()
+        driver.close()
+
+    assert isinstance(result, str)
+    assert json.loads(result)["stdout"] == "session"
+    assert os.environ[key] == "ambient"
 
 
 def test_codex_executor_disables_native_tools(
@@ -420,6 +1210,7 @@ def test_codex_executor_disables_native_tools(
         def __init__(self, **kwargs: Any) -> None:  # noqa: ANN401
             captured.update(kwargs)
             super().__init__([])
+            self._env = {"BASE": "preserved"}
 
     driver = OmnigentDriver()
     monkeypatch.setattr(driver, "_executor_class", lambda _spec: Executor)
@@ -436,18 +1227,25 @@ def test_codex_executor_disables_native_tools(
         _workspace: Path,
         environment: dict[str, str],
         _shell_os_env: object,
-    ) -> tuple[list[dict[str, Any]], object]:
+    ) -> driver_subject._OwnedOSTools:
         captured["tool_environment"] = environment
-        return [], lambda _name, _args: None
+        return driver_subject._OwnedOSTools(  # noqa: SLF001
+            schemas=[],
+            dispatch=lambda _name, _args: None,
+            environments=(),
+        )
 
     monkeypatch.setattr(
         "vibesys.agents.drivers.omnigent._build_os_tools",
         build_tools,
     )
 
-    executor, _schemas = driver._build_executor(_spec(tmp_path))  # noqa: SLF001
+    executor, _schemas, resources = driver._build_executor(  # noqa: SLF001
+        _spec(tmp_path, environment=(("DRIVER_TEST", "session"),))
+    )
 
     assert captured["disable_native_tools"] is True
+    assert executor._env == {"BASE": "preserved", "DRIVER_TEST": "session"}  # noqa: SLF001
     assert str(captured["tool_environment"]["PATH"]).split(os.pathsep)[0] == str(
         rust_sysroot / "bin"
     )
@@ -457,5 +1255,5 @@ def test_codex_executor_disables_native_tools(
     assert not cargo_home.is_relative_to(tmp_path)
     assert "CARGO_TARGET_DIR" not in captured["tool_environment"]
     assert not any(key.endswith("_LINKER") for key in captured["tool_environment"])
-    driver.close_executor(executor)
+    driver.close_executor(executor, resources=resources)
     assert not cargo_home.parent.exists()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -237,6 +237,71 @@ def test_run_context_announces_canonical_experiment_state(tmp_path):  # noqa: AN
         REGISTRY.deactivate(supervisor)
 
 
+def test_retained_experiment_chat_uses_one_dedicated_client_across_run_teardown(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "queue"
+    evaluator = _write_project(project)
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path / "bootstrap")
+    supervisor.enable_terminal_chat_retention()
+    primary_client = MagicMock()
+    chat_client = MagicMock()
+    chat_client.invoke_text.side_effect = ["live answer", "terminal answer"]
+    REGISTRY.activate(supervisor)
+    try:
+        with patch(
+            "vibesys.context.build_agent_client",
+            side_effect=[primary_client, chat_client],
+        ) as build_client:
+            ctx = _create_context(project, evaluator=evaluator)
+            assert build_client.call_count == 2
+            assert "chat" not in build_client.call_args_list[0].kwargs["backends"]
+            assert supervisor.chat("what is happening?") == "live answer"
+
+            ctx.close()
+
+            primary_client.close.assert_called_once_with()
+            chat_client.close.assert_not_called()
+            assert supervisor.chat("what happened?") == "terminal answer"
+            assert chat_client.invoke_text.call_count == 2
+
+        supervisor.close_terminal_chat_resource()
+        chat_client.close.assert_called_once_with()
+    finally:
+        supervisor.close_terminal_chat_resource()
+        REGISTRY.deactivate(supervisor)
+
+
+def test_nonretained_experiment_chat_closes_when_context_construction_fails(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "queue"
+    evaluator = _write_project(project)
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path / "bootstrap")
+    primary_client = MagicMock()
+    chat_client = MagicMock()
+    construction_error = RuntimeError("context construction failed")
+    REGISTRY.activate(supervisor)
+    try:
+        with (
+            patch(
+                "vibesys.context.build_agent_client",
+                side_effect=[primary_client, chat_client],
+            ),
+            patch("vibesys.context._RunContext", side_effect=construction_error),
+            pytest.raises(RuntimeError) as raised,
+        ):
+            _create_context(project, evaluator=evaluator)
+
+        assert raised.value is construction_error
+        primary_client.close.assert_called_once_with()
+        chat_client.close.assert_called_once_with()
+    finally:
+        REGISTRY.deactivate(supervisor)
+
+
 def test_repository_task_exposes_its_actual_reference_path(tmp_path: Path) -> None:
     project = tmp_path / "queue"
     evaluator = _write_project(project)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import json
 import os
 import shutil
@@ -7,18 +8,26 @@ import sys
 import threading
 import time
 import uuid
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 
-from vibesys.context import _RunContext
+import vibesys.server.supervisor as supervisor_module
+from vibesys.context import (
+    _close_after_construction_failure,
+    _ExperimentChatDependencies,
+    _ExperimentChatService,
+    _RunContext,
+)
 from vibesys.errors import ConfigurationDiagnostic, ConfigurationError
 from vibesys.run import RunPaths
 from vibesys.server import (
     EventType,
     RunInspector,
     RunSupervisor,
+    active_supervisor,
 )
 from vibesys.server.diagnostics import (
     DiagnosticRetryability,
@@ -47,6 +56,7 @@ from vibesys.server.protocol import (
 from vibesys.server.runtime import run_server
 from vibesys.server.schema import ProtocolDocument
 from vibesys.server.service import SupervisionService
+from vibesys.server.supervisor import TerminalChatResource
 from vibesys.server.transport import SupervisionSocketServer
 from vs_loop_state import RoundRecord
 from vs_project import AgentRunConfiguration, Project, RunEnvironmentRecord
@@ -671,6 +681,261 @@ def test_installing_an_agent_handler_takes_over_from_the_fallback(tmp_path):  # 
     assert "chat agent is not available" in supervisor.chat("and round 4?")
 
 
+def test_run_context_retains_agent_chat_until_terminal_presentation_closes(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.enable_terminal_chat_retention()
+    lifecycle: list[str] = []
+    teardown = ExitStack()
+    teardown.callback(lambda: lifecycle.append("main-finalized"))
+    terminal_chat = Mock()
+    terminal_chat.ask.return_value = "terminal agent answer"
+    terminal_chat.close.side_effect = lambda: lifecycle.append("terminal-closed")
+
+    lifecycle.append("terminal-created")
+    assert supervisor.retain_terminal_chat_resource(
+        TerminalChatResource(handler=terminal_chat.ask, close=terminal_chat.close)
+    )
+
+    ctx = _RunContext.__new__(_RunContext)
+    ctx.supervisor = supervisor
+    ctx._teardown_stack = teardown  # noqa: SLF001
+    ctx._closed = False  # noqa: SLF001
+    ctx._experiment_chat = None  # noqa: SLF001
+
+    ctx.close()
+    supervisor.finish()
+
+    assert lifecycle == ["terminal-created", "main-finalized"]
+    assert ctx._closed is True  # noqa: SLF001
+    assert supervisor.chat("what was the result?") == "terminal agent answer"
+
+    supervisor.close_terminal_chat_resource()
+    supervisor.close_terminal_chat_resource()
+
+    assert lifecycle == ["terminal-created", "main-finalized", "terminal-closed"]
+    assert supervisor.chat_agent_available() is False
+
+
+def test_nonretained_run_context_closes_its_dedicated_chat(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    experiment_chat = Mock()
+    experiment_chat.ask.return_value = "agent answer"
+    supervisor.set_chat_handler(experiment_chat.ask)
+    teardown_finished = threading.Event()
+    teardown = ExitStack()
+    teardown.callback(teardown_finished.set)
+    ctx = _RunContext.__new__(_RunContext)
+    ctx.supervisor = supervisor
+    ctx._teardown_stack = teardown  # noqa: SLF001
+    ctx._closed = False  # noqa: SLF001
+    ctx._experiment_chat = experiment_chat  # noqa: SLF001
+
+    ctx.close()
+
+    experiment_chat.close.assert_called_once_with()
+    assert teardown_finished.is_set()
+    assert supervisor.chat_agent_available() is False
+
+
+def test_primary_teardown_error_precedes_nonretained_chat_cleanup(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    chat_error = RuntimeError("experiment chat cleanup failed")
+    primary_error = RuntimeError("primary teardown failed")
+    experiment_chat = Mock()
+    experiment_chat.close.side_effect = chat_error
+    supervisor.set_chat_handler(experiment_chat.ask)
+    teardown = ExitStack()
+    teardown.callback(lambda: (_ for _ in ()).throw(primary_error))
+    ctx = _RunContext.__new__(_RunContext)
+    ctx.supervisor = supervisor
+    ctx._teardown_stack = teardown  # noqa: SLF001
+    ctx._closed = False  # noqa: SLF001
+    ctx._experiment_chat = experiment_chat  # noqa: SLF001
+
+    with pytest.raises(RuntimeError) as raised:
+        ctx.close()
+
+    assert raised.value is primary_error
+    assert raised.value.__notes__ == [
+        "Experiment chat teardown also failed: RuntimeError: experiment chat cleanup failed"
+    ]
+
+
+def test_terminal_chat_cleanup_waits_for_an_in_flight_answer(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.enable_terminal_chat_retention()
+    handler_started = threading.Event()
+    release_handler = threading.Event()
+    cleanup_finished = threading.Event()
+
+    def handler(_question: str) -> str:
+        handler_started.set()
+        release_handler.wait()
+        return "finished answer"
+
+    supervisor.set_chat_handler(handler)
+    assert supervisor.retain_terminal_chat_resource(
+        TerminalChatResource(handler=handler, close=cleanup_finished.set)
+    )
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        answer = pool.submit(supervisor.chat, "what happened?")
+        assert handler_started.wait(timeout=2)
+        cleanup = pool.submit(supervisor.close_terminal_chat_resource)
+        assert not cleanup_finished.wait(timeout=0.05)
+        assert not cleanup.done()
+        release_handler.set()
+        assert answer.result(timeout=2) == "finished answer"
+        cleanup.result(timeout=2)
+
+    assert cleanup_finished.is_set()
+
+
+def test_run_context_teardown_does_not_wait_for_retained_chat(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    handler_started = threading.Event()
+    release_handler = threading.Event()
+    teardown_finished = threading.Event()
+    resource_closed = threading.Event()
+
+    def handler(_question: str) -> str:
+        handler_started.set()
+        release_handler.wait()
+        return "finished answer"
+
+    supervisor.enable_terminal_chat_retention()
+    assert supervisor.retain_terminal_chat_resource(
+        TerminalChatResource(handler=handler, close=resource_closed.set)
+    )
+    teardown = ExitStack()
+    teardown.callback(teardown_finished.set)
+    ctx = _RunContext.__new__(_RunContext)
+    ctx.supervisor = supervisor
+    ctx._teardown_stack = teardown  # noqa: SLF001
+    ctx._closed = False  # noqa: SLF001
+    ctx._experiment_chat = None  # noqa: SLF001
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        answer = pool.submit(supervisor.chat, "what happened?")
+        assert handler_started.wait(timeout=2)
+        cleanup = pool.submit(ctx.close)
+        cleanup.result(timeout=2)
+        assert teardown_finished.is_set()
+        assert not resource_closed.is_set()
+        release_handler.set()
+        assert answer.result(timeout=2) == "finished answer"
+
+    supervisor.close_terminal_chat_resource()
+    assert resource_closed.is_set()
+
+
+def test_terminal_chat_cleanup_bounds_an_in_flight_answer(tmp_path, monkeypatch):  # noqa: ANN001, ANN201
+    monkeypatch.setattr(supervisor_module, "_TERMINAL_CHAT_DRAIN_TIMEOUT_SECONDS", 0.01)
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.enable_terminal_chat_retention()
+    handler_started = threading.Event()
+    release_handler = threading.Event()
+    resource_closed = threading.Event()
+
+    def handler(_question: str) -> str:
+        handler_started.set()
+        release_handler.wait()
+        return "late answer"
+
+    assert supervisor.retain_terminal_chat_resource(
+        TerminalChatResource(handler=handler, close=resource_closed.set)
+    )
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        answer = pool.submit(supervisor.chat, "what happened?")
+        assert handler_started.wait(timeout=2)
+        started = time.monotonic()
+        supervisor.close_terminal_chat_resource()
+        assert time.monotonic() - started < 0.5
+        assert not resource_closed.is_set()
+        release_handler.set()
+        assert answer.result(timeout=2) == "late answer"
+        assert resource_closed.wait(timeout=2)
+
+
+def test_run_finish_does_not_interrupt_presentation_chat(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    execution = supervisor.start_agent_execution(
+        "chat",
+        "experiment-chat",
+        "what happened?",
+        "inspect the experiment",
+        consume_steering=False,
+        participates_in_run_control=False,
+    )
+
+    supervisor.finish()
+
+    assert [active.execution_id for active in supervisor.snapshot().active_executions] == [
+        execution.execution_id
+    ]
+    supervisor.after_agent(
+        "chat",
+        "experiment-chat",
+        result="answer",
+        execution_id=execution.execution_id,
+    )
+    finished = [
+        event
+        for event in supervisor.read_events()
+        if event.type is EventType.AGENT_EXECUTION_FINISHED
+        and event.execution_id == execution.execution_id
+    ]
+    assert len(finished) == 1
+    assert finished[0].status is EventStatus.COMPLETED
+
+
+def test_run_context_retains_terminal_chat_when_primary_teardown_fails(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.enable_terminal_chat_retention()
+    teardown_failure = RuntimeError("primary teardown failed")
+    teardown = ExitStack()
+    teardown.callback(lambda: (_ for _ in ()).throw(teardown_failure))
+    terminal_chat = Mock()
+    terminal_chat.ask.return_value = "terminal agent answer"
+    assert supervisor.retain_terminal_chat_resource(
+        TerminalChatResource(handler=terminal_chat.ask, close=terminal_chat.close)
+    )
+    ctx = _RunContext.__new__(_RunContext)
+    ctx.supervisor = supervisor
+    ctx._teardown_stack = teardown  # noqa: SLF001
+    ctx._closed = False  # noqa: SLF001
+    ctx._experiment_chat = None  # noqa: SLF001
+
+    with pytest.raises(RuntimeError) as raised:
+        ctx.close()
+
+    assert raised.value is teardown_failure
+    assert supervisor.chat("what happened?") == "terminal agent answer"
+    supervisor.close_terminal_chat_resource()
+    terminal_chat.close.assert_called_once_with()
+
+
+def test_partial_terminal_chat_cleanup_preserves_construction_error() -> None:
+    construction_error = RuntimeError("terminal client construction failed")
+    cleanup_error = RuntimeError("partial terminal cleanup failed")
+    resources = ExitStack()
+    resources.callback(lambda: (_ for _ in ()).throw(cleanup_error))
+
+    _close_after_construction_failure(resources, construction_error)
+
+    assert construction_error.__notes__ == [
+        "Additional error while cleaning up partial resource construction: "
+        "RuntimeError: partial terminal cleanup failed"
+    ]
+
+
 def test_keyword_fallback_does_not_advertise_slash_commands(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)
@@ -737,6 +1002,20 @@ def test_run_context_chat_exposes_trajectory_without_inlining_it_in_prompt(tmp_p
     ctx._chat_history = []  # noqa: SLF001  # tracked: #288
     ctx.logger = Mock()
     ctx.logger.file = Mock()
+    ctx._experiment_chat = _ExperimentChatService(  # noqa: SLF001
+        _ExperimentChatDependencies(
+            supervisor=supervisor,
+            agent_client=ctx.agent_client,
+            workspace=store.root,
+            log_dir=store.state.log_directory(run_id),
+            project=store,
+            run_id=run_id,
+            log=ctx.logger.lprint,
+            flush_logs=ctx.logger.file.flush,
+            environment=dict,
+            progress=lambda: None,
+        )
+    )
 
     answer = ctx.chat("what improved?")
 
@@ -768,7 +1047,9 @@ def test_run_context_chat_exposes_trajectory_without_inlining_it_in_prompt(tmp_p
     assert "It improved in round 2." not in continuation["user_prompt"]
     assert "_vibesys_chat/instructions.md" in continuation["system_prompt"]
     assert "Prefer targeted commands" not in continuation["system_prompt"]
-    assert ctx._load_chat_history() == [("what improved?", "It improved in round 2.")]  # noqa: SLF001  # tracked: #288
+    assert ctx._experiment_chat._load_history() == [  # noqa: SLF001
+        ("what improved?", "It improved in round 2.")
+    ]
 
 
 def test_socket_transport_supports_multiple_clients_and_event_replay(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
@@ -1039,6 +1320,104 @@ def test_supervision_runtime_streams_configuration_failure_before_exiting():  # 
         assert not any(event["type"] == "run_failed" for event in received_events)
         assert chat_responses[0]["ok"] is True
         assert "unknown token=[REDACTED] option --bad" in chat_responses[0]["chat"]["answer"]
+    finally:
+        subscriber.join(timeout=5)
+        shutil.rmtree(session_dir, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    ("run_fails", "cleanup_fails"),
+    [(False, False), (False, True), (True, False), (True, True)],
+)
+def test_supervision_runtime_releases_terminal_chat_after_disconnect(  # noqa: C901, PLR0915
+    run_fails: bool,  # noqa: FBT001
+    cleanup_fails: bool,  # noqa: FBT001
+) -> None:
+    session_dir = Path("/tmp") / f"vs-terminal-chat-{uuid.uuid4().hex}"  # noqa: S108
+    socket_path = session_dir / "control.sock"
+    cleanup_finished = threading.Event()
+    chat_responses = []
+
+    def subscribe_through_terminal_chat() -> None:
+        deadline = time.monotonic() + 5
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(5)
+            client.connect(str(socket_path))
+            stream = client.makefile("rwb")
+            stream.write(SubscribeRequest(after_sequence=0).model_dump_json().encode() + b"\n")
+            stream.flush()
+            terminal_type = "run_failed" if run_fails else "run_finished"
+            while True:
+                message = json.loads(stream.readline())
+                events = message.get("events", [])
+                if message["type"] == "event":
+                    events = [message["event"]]
+                if any(event["type"] == terminal_type for event in events):
+                    break
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as chat_client:
+                chat_client.settimeout(5)
+                chat_client.connect(str(socket_path))
+                chat_stream = chat_client.makefile("rwb")
+                chat_stream.write(
+                    ChatQuery(text="what happened?").model_dump_json().encode() + b"\n"
+                )
+                chat_stream.flush()
+                chat_responses.append(json.loads(chat_stream.readline()))
+            assert cleanup_finished.is_set()
+
+    subscriber = threading.Thread(target=subscribe_through_terminal_chat)
+    subscriber.start()
+    failure = RuntimeError("run failed after context teardown")
+    cleanup_failure = RuntimeError("terminal chat cleanup failed")
+
+    def close_resources() -> None:
+        cleanup_finished.set()
+
+    def run() -> None:
+        supervisor = active_supervisor()
+        assert supervisor is not None
+        ctx = _RunContext.__new__(_RunContext)
+        ctx.supervisor = supervisor
+        teardown = ExitStack()
+        teardown.callback(close_resources)
+        ctx._teardown_stack = teardown  # noqa: SLF001
+        ctx._closed = False  # noqa: SLF001
+        terminal_chat = Mock()
+        terminal_chat.ask.return_value = "terminal agent answer"
+        if cleanup_fails:
+            terminal_chat.close.side_effect = cleanup_failure
+        assert supervisor.retain_terminal_chat_resource(
+            TerminalChatResource(handler=terminal_chat.ask, close=terminal_chat.close)
+        )
+        ctx._experiment_chat = None  # noqa: SLF001
+        ctx.close()
+        if run_fails:
+            raise failure
+
+    try:
+        if run_fails:
+            with pytest.raises(RuntimeError) as raised:
+                run_server(run, socket_path=socket_path)
+            assert raised.value is failure
+            if cleanup_fails:
+                assert raised.value.__notes__ == [
+                    "Terminal chat cleanup also failed: RuntimeError: terminal chat cleanup failed"
+                ]
+        else:
+            run_server(run, socket_path=socket_path)
+            if cleanup_fails:
+                assert any(
+                    event["type"] == "output"
+                    and "Terminal chat cleanup also failed" in event["data"]["content"]
+                    for event in _events(session_dir / "run-events.jsonl")
+                )
+        subscriber.join(timeout=5)
+        assert not subscriber.is_alive()
+        assert chat_responses[0]["ok"] is True
+        assert chat_responses[0]["chat"]["answer"] == "terminal agent answer"
+        assert cleanup_finished.is_set()
     finally:
         subscriber.join(timeout=5)
         shutil.rmtree(session_dir, ignore_errors=True)


### PR DESCRIPTION
## Problem

Experiment chat was not reliable across the full run lifecycle. Concurrent Omnigent sessions could re-enter shared asyncio state, long answers were falsely failed by the TUI after 30 seconds, and chat resources were coupled to primary run teardown, so post-run chat could stop working.

Fixes #425.

## Solution

Add explicit ownership and lifecycle boundaries for agent execution and experiment chat:

- Omnigent drivers own one dedicated async runtime thread shared by their sessions. Sessions retain per-conversation serialization while independent sessions can overlap.
- The supervisor retains a dedicated experiment-chat service, client, logger, and environment session for the TUI lifetime. Primary run teardown does not wait for or close retained chat work.
- Chat calls borrow resources through leases. Terminal disconnect waits briefly, then defers cleanup until the final active borrower releases instead of closing resources under a live turn.
- `query.chat` uses a dedicated one-shot Unix socket. Connection setup keeps the normal timeout, but answer generation has no frontend response deadline and cannot block control or snapshot traffic on the primary socket.
- Omnigent shutdown cancels and gathers real asyncio tasks before closing executors, and provider environments are passed through explicit executor seams without mutating process-global `os.environ`.

Analysis-only chat behavior remains prompt-enforced because the current project path policy cannot make the workspace root read-only.

### Architecture

```mermaid
flowchart LR
  T[TUI] -->|control and snapshots| S[Run supervisor]
  T -->|query.chat, dedicated socket| S
  S --> C[Experiment chat service]
  C --> CC[Dedicated AgentClient]
  R[Optimizer] --> RC[Primary AgentClient]
  CC --> O[Omnigent driver runtime]
  RC --> O
```

The run context owns primary optimization resources. The supervisor owns retained presentation resources. The Omnigent driver owns its runtime; each session owns its conversation and executor resources. AgentShim keeps its independent subprocess-backed session behavior and uses the same experiment-chat service boundary.

## Verification

Automated coverage exercises overlapping Omnigent and AgentShim sessions, async cancellation and shutdown ordering, construction and cleanup failures, terminal chat retention, resource leases, execution interruption scope, socket timeout isolation, and socket close races.

Manual validation used the editable local VibeSys package from the queue-rs repository. An experiment-chat answer streamed for more than 60 seconds during an active optimizer turn, returned successfully without the former 30-second timeout, and `Ctrl+C` exited cleanly.

### Correctness properties

- Independent sessions overlap; turns within one provider conversation remain sequential.
- Async tasks reach terminal completion before their executor resources close.
- Primary run completion does not close or wait for retained chat resources.
- Terminal cleanup never closes a chat client beneath an active borrowed turn.
- Run interruption targets optimization executions, not presentation chat executions.
- A successful run remains successful if later presentation cleanup fails.
- Chat response latency does not block normal TUI supervision traffic or trigger a frontend answer deadline.
- Session-specific provider environments do not mutate process-global environment state.

### Testing

- `COVERAGE_FILE=/tmp/vibesys-pr426-postreview.coverage uv run pytest tests/agents/drivers/test_omnigent_driver.py tests/agents/drivers/test_agentshim_driver.py tests/test_tui.py tests/test_context.py -q` (125 passed)
- `COVERAGE_FILE=/tmp/vibesys-pr426-postreview-broad.coverage uv run pytest tests/agents tests/test_tui.py tests/test_context.py -q` (382 passed)
- `cd clients/tui && pnpm check && pnpm test` (364 passed)
- `./scripts/check_format.sh` (412 files already formatted)
- Targeted Ruff checks for changed Python files (passed)
- Targeted Pyright checks for changed Python files (0 errors)
- `git diff --check` (passed)
- Manual queue-rs run using `vibesys --resume --max-rounds 4` with concurrent optimizer and experiment-chat activity (passed)
