### PR TITLE
Make TUI pane focus explicit and zoomable

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -127,10 +127,18 @@ live. A second visualization command replaces the pane's contents rather than
 stacking another surface on top.
 
 `Ctrl+W` moves focus one column to the right and wraps, through whichever
-columns are actually on screen; the focused one carries the theme's focus
-border and says so in its title. Page Up and Page Down scroll whichever pane
-has focus, and Escape on the right pane closes it and restores the full-width
-view. Chat and transcript state survive the pane closing.
+columns are actually on screen. Every pane reads the same authoritative focus
+state: the focused pane carries the theme's focus border and a `▸` in its title,
+while every other pane uses the neutral border. Page Up and Page Down scroll
+whichever pane has focus, and Escape on the right pane closes it and restores
+the full-width view. Chat and transcript state survive the pane closing.
+
+`F4` toggles zoom for the focused pane. Zoom gives that pane the complete
+content row; pressing `F4` again restores the previous split and focus. It does
+not create a second pane or move its data, so hypothesis and agent selection,
+chat drafts, and pane scroll positions remain in place. The shortcut works for
+the hypothesis list, agent graph, transcript, experiment chat, and performance
+pane. Modal dialogs keep `F4` to themselves until they close.
 
 Pane widths are computed from the terminal, so a wide terminal gives the
 visualization real room while the left pane keeps a readable floor. Below 100

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -51,6 +51,7 @@ import {
   setTheme,
   showDetail,
   showLive,
+  togglePaneZoom,
   toggleTodos,
 } from './session-model.js';
 import {DEFAULT_THEME_NAME, type ThemeName} from './ui/theme.js';
@@ -87,6 +88,7 @@ export interface SessionController {
   closeOverlays(): void;
   cyclePaneFocus(): void;
   focusPane(focus: PaneFocus): void;
+  togglePaneZoom(): void;
   setChatDockFits(fits: boolean): void;
   moveExperimentSelection(delta: number): void;
   selectExperimentActivity(): void;
@@ -318,6 +320,10 @@ export class SocketSessionController implements SessionController {
 
   focusPane(focus: PaneFocus): void {
     this.#setState(focusPane(this.#state, focus));
+  }
+
+  togglePaneZoom(): void {
+    this.#setState(togglePaneZoom(this.#state));
   }
 
   /**

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -13,7 +13,9 @@ import {
   enterExperimentRound,
   enterUnownedExperimentRound,
   failPane,
+  focusedPane,
   focusPane,
+  focusRound,
   hypothesisPlanningActivity,
   initialSessionState,
   leaveExperimentDrilldown,
@@ -32,6 +34,7 @@ import {
   setTheme,
   showDetail,
   statusText,
+  togglePaneZoom,
   toggleTodos,
   unownedExperimentRounds,
   visibleConversation,
@@ -1291,6 +1294,39 @@ describe('right pane layout', () => {
 
     expect(closed.chatOpen).toBe(true);
     expect(closed.chatConversation).toEqual(withChat.chatConversation);
+  });
+
+  it('zooms the semantic focused pane and restores the unchanged split state', () => {
+    const split = setPaneContent(openPane(initialSessionState(), 'perf'), 'perf', 'chart');
+    const chat = focusPane(split, 'chat');
+    const zoomed = togglePaneZoom(chat);
+
+    expect(focusedPane(zoomed)).toBe('chat');
+    expect(zoomed.layout.zoomedPane).toBe('chat');
+    expect(zoomed.layout.right).toBe(split.layout.right);
+    expect(zoomed.chatConversation).toBe(split.chatConversation);
+    expect(cyclePaneFocus(zoomed)).toBe(zoomed);
+
+    const restored = togglePaneZoom(zoomed);
+    expect(restored.layout).toEqual(chat.layout);
+  });
+
+  it('uses round focus to zoom agents and transcript', () => {
+    const round = {...initialSessionState(), experimentLog: null};
+    const agents = focusRound(round, 'agents');
+
+    expect(togglePaneZoom(agents).layout.zoomedPane).toBe('agents');
+    expect(togglePaneZoom(round).layout.zoomedPane).toBe('transcript');
+  });
+
+  it('never reports the hidden agents pane as focused beside a visualization', () => {
+    const agents = focusRound({...initialSessionState(), experimentLog: null}, 'agents');
+    const split = focusPane(openPane(agents, 'perf'), 'left');
+
+    expect(split.roundFocus).toBe('agents');
+    expect(focusedPane(split)).toBe('transcript');
+    expect(togglePaneZoom(split).layout.zoomedPane).toBe('transcript');
+    expect(focusedPane(closePane(split))).toBe('agents');
   });
 });
 

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -201,7 +201,12 @@ export interface LayoutState {
   /** null means no visualization pane: the left side has the rest of the row. */
   right: RightPane | null;
   focus: PaneFocus;
+  /** The pane temporarily occupying the full content row, or null for the split layout. */
+  zoomedPane: PaneId | null;
 }
+
+/** Semantic pane identities, independent of their current screen position. */
+export type PaneId = 'agents' | 'chat' | 'experiments' | 'performance' | 'transcript';
 
 export interface ThemePicker {
   selected: ThemeName;
@@ -276,7 +281,7 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
     // list of claims before it reads as a long list of rounds.
     experimentLog: {entries: [], selectedId: null, pending: true, error: null},
     hypothesisScope: null,
-    layout: {right: null, focus: 'left'},
+    layout: {right: null, focus: 'left', zoomedPane: null},
     // Docked until the renderer measures otherwise, so the landing view carries
     // the chat from the first frame rather than after a resize.
     chatDockFits: true,
@@ -457,7 +462,7 @@ export function enterExperimentDrilldown(state: SessionState): SessionState {
     // A visualization opened from the log belongs to the log. Carrying it into
     // the round view would leave the operator reading one view's answer beside
     // another view's transcript.
-    layout: {right: null, focus: 'left'},
+    layout: {right: null, focus: 'left', zoomedPane: null},
     hypothesisScope: {
       id: entry.hypothesis_id,
       label: hypothesisLabel(entry),
@@ -498,7 +503,7 @@ export function enterExperimentRound(
     ...state,
     overlay: null,
     chatOpen: false,
-    layout: {right: null, focus: 'left'},
+    layout: {right: null, focus: 'left', zoomedPane: null},
     hypothesisScope: {
       id: entry.hypothesis_id,
       label: hypothesisLabel(entry),
@@ -530,7 +535,7 @@ export function enterUnownedExperimentRound(
     ...state,
     overlay: null,
     chatOpen: false,
-    layout: {right: null, focus: 'left'},
+    layout: {right: null, focus: 'left', zoomedPane: null},
     hypothesisScope: {
       id: `round-${roundNumber}`,
       label: `Round ${roundNumber}`,
@@ -731,6 +736,7 @@ export function openPane(state: SessionState, view: PaneView): SessionState {
         error: null,
       },
       focus: 'right',
+      zoomedPane: state.layout.zoomedPane,
     },
   };
 }
@@ -754,7 +760,7 @@ export function failPane(state: SessionState, view: PaneView, error: string): Se
 
 export function closePane(state: SessionState): SessionState {
   if (state.layout.right === null) return state;
-  return {...state, layout: {right: null, focus: 'left'}};
+  return {...state, layout: {right: null, focus: 'left', zoomedPane: null}};
 }
 
 /**
@@ -763,6 +769,7 @@ export function closePane(state: SessionState): SessionState {
  * cannot see.
  */
 export function cyclePaneFocus(state: SessionState): SessionState {
+  if (state.layout.zoomedPane !== null) return state;
   const order = visiblePaneOrder(state);
   if (order.length < 2) return state;
   const next = order[(order.indexOf(state.layout.focus) + 1) % order.length] ?? 'left';
@@ -777,8 +784,14 @@ export function cyclePaneFocus(state: SessionState): SessionState {
  */
 export function normalizeFocus(state: SessionState): SessionState {
   const order = visiblePaneOrder(state);
-  if (order.includes(state.layout.focus)) return state;
-  return {...state, layout: {...state.layout, focus: 'left'}};
+  const focus = order.includes(state.layout.focus) ? state.layout.focus : 'left';
+  const zoomedPane =
+    state.layout.zoomedPane === null ||
+    visiblePaneIds({...state, layout: {...state.layout, focus}}).includes(state.layout.zoomedPane)
+      ? state.layout.zoomedPane
+      : null;
+  if (focus === state.layout.focus && zoomedPane === state.layout.zoomedPane) return state;
+  return {...state, layout: {...state.layout, focus, zoomedPane}};
 }
 
 /** Escape from a round view: close whatever is layered over it, all of it. */
@@ -788,7 +801,7 @@ export function closeOverlays(state: SessionState): SessionState {
     ...state,
     overlay: null,
     chatOpen: false,
-    layout: {right: null, focus: 'left'},
+    layout: {right: null, focus: 'left', zoomedPane: null},
   };
 }
 
@@ -796,6 +809,49 @@ export function focusPane(state: SessionState, focus: PaneFocus): SessionState {
   if (state.layout.focus === focus) return state;
   if (!visiblePaneOrder(state).includes(focus)) return state;
   return {...state, layout: {...state.layout, focus}};
+}
+
+/** The semantic pane currently receiving pane navigation keys. */
+export function focusedPane(state: SessionState): PaneId {
+  if (experimentLogVisible(state)) {
+    if (state.layout.focus === 'chat' && chatPaneVisible(state)) return 'chat';
+    if (state.layout.focus === 'right' && state.layout.right !== null) return 'performance';
+    return 'experiments';
+  }
+  // Opening a visualization replaces the agent summary in the left column
+  // with the transcript. Keep roundFocus intact so closing the visualization
+  // can restore it, but never report the hidden Agents pane as focused.
+  if (state.layout.right !== null) {
+    return state.layout.focus === 'right' ? 'performance' : 'transcript';
+  }
+  return state.roundFocus;
+}
+
+/**
+ * Gives the focused pane the content row, or restores the existing split.
+ * Pane content and selection stay in their owning models; zoom only changes
+ * presentation, so toggling cannot replace or reconstruct pane state.
+ */
+export function togglePaneZoom(state: SessionState): SessionState {
+  return {
+    ...state,
+    layout: {
+      ...state.layout,
+      zoomedPane: state.layout.zoomedPane === null ? focusedPane(state) : null,
+    },
+  };
+}
+
+/** Every pane currently available to focus or zoom in the active view. */
+export function visiblePaneIds(state: SessionState): PaneId[] {
+  if (experimentLogVisible(state)) {
+    return [
+      ...(chatPaneVisible(state) ? (['chat'] as const) : []),
+      'experiments',
+      ...(state.layout.right !== null ? (['performance'] as const) : []),
+    ];
+  }
+  return state.layout.right === null ? ['agents', 'transcript'] : ['transcript', 'performance'];
 }
 
 function visiblePaneOrder(state: SessionState): PaneFocus[] {

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -90,6 +90,7 @@ export class AgentMapView {
       borderStyle: 'rounded',
       borderColor: theme.border,
       title: ' Agents ',
+      onMouseUp: () => this.controller.focusRound('agents'),
     });
   }
 
@@ -99,11 +100,12 @@ export class AgentMapView {
     this.#renderedState = null;
   }
 
-  render(state: SessionState): void {
+  render(state: SessionState, widthOverride?: number): void {
     const phases = visiblePhases(state);
     // The pane's width follows the terminal, so a resize has to redraw even
     // when the state is unchanged.
-    const width = agentPaneWidth(this.renderer.terminalWidth, stageKinds(phases).length);
+    const width =
+      widthOverride ?? agentPaneWidth(this.renderer.terminalWidth, stageKinds(phases).length);
     const paneWidth = width ?? STACKED_WIDTH;
     if (state === this.#renderedState && paneWidth === this.#renderedWidth) return;
     // Selection and focus are drawn into the nodes, so a change to either is a
@@ -198,12 +200,14 @@ export class AgentMapView {
       flexShrink: 1,
       flexDirection: 'column',
       justifyContent: 'center',
+      onMouseUp: () => this.controller.focusRound('agents'),
     });
     const canvas = new BoxRenderable(this.renderer, {
       id: 'agent-graph-canvas',
       width: '100%',
       height: graph.height,
       flexShrink: 0,
+      onMouseUp: () => this.controller.focusRound('agents'),
     });
     this.output.add(area);
     area.add(canvas);
@@ -303,6 +307,7 @@ export class AgentMapView {
           }
         : {}),
       ...(selected ? {backgroundColor: this.#theme.selectedSurface} : {}),
+      onMouseUp: () => this.controller.selectAgent(phase.kind),
     });
     const color = statusColor(this.#theme, phase.status);
     row.add(

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -36,6 +36,7 @@ import {
   setExperiments,
   setPaneContent,
   setTheme,
+  togglePaneZoom,
 } from '../session-model.js';
 import {createOpenTuiApp, type OpenTuiApp} from './app.js';
 import {resolveTheme, type ThemeName} from './theme.js';
@@ -646,6 +647,85 @@ describe('OpenTUI presentation', () => {
     testRenderer.mockInput.pressKey('TAB');
     await frameAfter(testRenderer);
     expect(controller.state.selectedAgentKind).not.toBe(firstAgent);
+  });
+
+  it('focuses round panes from blank and interactive click targets', async () => {
+    const testRenderer = await createTestRenderer({width: 150, height: 26});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      experimentLog: null,
+      rounds: [{number: 1, status: 'active'}],
+      selectedRound: 1,
+      phases: [
+        {kind: 'implementer', status: 'completed', roundNumber: 1, roundLabel: 'round-1-impl'},
+        {kind: 'judge', status: 'active', roundNumber: 1, roundLabel: 'round-1-judge'},
+      ],
+      conversation: [
+        {
+          id: 'e1',
+          kind: 'assistant',
+          label: 'implementer',
+          content: 'edited the kernel',
+          roundNumber: 1,
+        },
+        {
+          id: 'e2',
+          kind: 'assistant',
+          label: 'judge',
+          content: 'checking the diff',
+          roundNumber: 1,
+        },
+      ],
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    let frame = await testRenderer.waitForFrame(value => value.includes('edited the kernel'));
+
+    // The graph heading has no action of its own. Clicking it still focuses
+    // the containing pane rather than requiring a click on an agent.
+    let lines = frame.split('\n');
+    let row = lines.findIndex(line => line.includes('Round 1'));
+    let column = (lines[row]?.indexOf('Round 1') ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
+    frame = await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('agents');
+    expect(frame).toContain('▸ Agents');
+
+    // Entering the pane selects its active agent. Clicking that inner node
+    // keeps Agents focused and clears the filter, preserving node semantics.
+    lines = frame.split('\n');
+    row = lines.findIndex(line => line.includes('● judge'));
+    column = (lines[row]?.indexOf('judge') ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
+    frame = await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('agents');
+    expect(controller.state.selectedAgentKind).toBeNull();
+
+    // A turn card has its own selection action. It composes pane focus with
+    // that action, and the next arrow is consequently routed to transcript.
+    lines = frame.split('\n');
+    row = lines.findIndex(line => line.includes('edited the kernel'));
+    column = (lines[row]?.indexOf('edited the kernel') ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
+    await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('transcript');
+    expect(controller.state.selectedEntryId).toBe('e1');
+    testRenderer.mockInput.pressKey('ARROW_DOWN');
+    await frameAfter(testRenderer);
+    expect(controller.state.selectedEntryId).toBe('e2');
+
+    // Agent nodes likewise keep their selection behavior while taking focus.
+    frame = testRenderer.captureCharFrame();
+    lines = frame.split('\n');
+    row = lines.findIndex(line => line.includes('✓ implementer'));
+    column = (lines[row]?.indexOf('implementer') ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
+    await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('agents');
+    expect(controller.state.selectedAgentKind).toBe('implementer');
+    testRenderer.mockInput.pressKey('TAB');
+    await frameAfter(testRenderer);
+    expect(controller.state.selectedAgentKind).toBe('judge');
   });
 
   it('marks the chat input as focused when it is clicked', async () => {
@@ -1837,7 +1917,7 @@ describe('theming', () => {
     const paneTop = lines.find(line => line.includes('╭─ Experiment chat')) ?? '';
     const inputTop = lines.find(line => line.includes('╭─ Chat ')) ?? '';
     expect(inputTop).toContain('╭─ Ask or command');
-    expect(inputTop.indexOf('╭─ Ask or command')).toBe(paneTop.indexOf('╭─ Experiments'));
+    expect(inputTop.indexOf('╭─ Ask or command')).toBe(paneTop.indexOf('╭─ ▸ Experiments'));
   });
 
   it('routes typing to whichever input Ctrl+W points at', async () => {
@@ -2063,15 +2143,131 @@ describe('theming', () => {
     await controller.openPane('perf');
 
     const onRight = await frameAfter(testRenderer);
-    expect(onRight).toContain('· focused');
+    expect(onRight).toContain('▸ Performance');
     const theme = resolveTheme('dark');
-    expect(spanColors(testRenderer, 'Performance · focused')?.fg).toBe(theme.borderFocus);
+    expect(spanColors(testRenderer, '▸ Performance')?.fg).toBe(theme.borderFocus);
 
     testRenderer.mockInput.pressKey('w', {ctrl: true});
     const onLeft = await frameAfter(testRenderer);
 
     expect(controller.state.layout.focus).toBe('left');
-    expect(onLeft).not.toContain('· focused');
+    expect(onLeft).toContain('▸ Transcript');
+  });
+
+  it('marks exactly one focused pane across the hypothesis layout', async () => {
+    const testRenderer = await createTestRenderer({width: 200, height: 20});
+    const controller = logController();
+    controller.paneContent = 'Performance · tok_s\nbest r7 1135 tok_s';
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await controller.openPane('perf');
+
+    expect(await frameAfter(testRenderer)).toContain('▸ Performance');
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    expect(await frameAfter(testRenderer)).toContain('▸ Experiment chat');
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    expect(await frameAfter(testRenderer)).toContain('▸ Experiments');
+    expect(controller.state.layout.focus).toBe('left');
+  });
+
+  it('focuses hypothesis panes from their inner content and routes the next key', async () => {
+    const testRenderer = await createTestRenderer({width: 200, height: 22});
+    const controller = logController();
+    controller.experiments = [
+      logEntry('H-07', 41, 41, {claim: 'batch the prefill step'}),
+      logEntry('H-08', 42, 42, {claim: 'increase the cache block'}),
+    ];
+    controller.paneContent = 'Performance · tok_s\nbest r7 1135 tok_s';
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await controller.openPane('perf');
+    let frame = await frameAfter(testRenderer);
+    expect(controller.state.layout.focus).toBe('right');
+
+    // A table row both selects its hypothesis and focuses Experiments.
+    let lines = frame.split('\n');
+    let row = lines.findIndex(line => line.includes('H-08'));
+    let column = (lines[row]?.indexOf('H-08') ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
+    frame = await frameAfter(testRenderer);
+    expect(controller.state.layout.focus).toBe('left');
+    expect(controller.state.experimentLog?.selectedId).toBe('H-08');
+    expect(frame).toContain('▸ Experiments');
+    testRenderer.mockInput.pressKey('ARROW_UP');
+    await frameAfter(testRenderer);
+    expect(controller.state.experimentLog?.selectedId).toBe('H-07');
+
+    // The chart body is inside a scroll surface. Clicking it focuses the
+    // performance pane, so Escape is routed there and closes it.
+    frame = testRenderer.captureCharFrame();
+    lines = frame.split('\n');
+    row = lines.findIndex(line => line.includes('best r7 1135 tok_s'));
+    column = (lines[row]?.indexOf('best r7 1135 tok_s') ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.focus).toBe('right');
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await frameAfterEscape(testRenderer);
+    expect(controller.state.layout.right).toBeNull();
+  });
+
+  it('zooms and restores every pane without replacing its model state', async () => {
+    const testRenderer = await createTestRenderer({width: 200, height: 20});
+    const controller = logController();
+    controller.paneContent = 'Performance · tok_s\nbest r7 1135 tok_s';
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await controller.openPane('perf');
+    const right = controller.state.layout.right;
+
+    testRenderer.mockInput.pressKey('F4');
+    const performance = await frameAfter(testRenderer);
+    expect(performance).toContain('best r7 1135 tok_s');
+    expect(performance).not.toContain('H-07');
+    expect(performance).not.toContain('Experiment chat');
+
+    testRenderer.mockInput.pressKey('F4');
+    const restored = await frameAfter(testRenderer);
+    expect(restored).toContain('H-07');
+    expect(restored).toContain('Experiment chat');
+    expect(controller.state.layout.right).toBe(right);
+
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    testRenderer.mockInput.pressKey('F4');
+    const chat = await frameAfter(testRenderer);
+    expect(chat).toContain('Experiment chat');
+    expect(chat).not.toContain('H-07');
+
+    testRenderer.mockInput.pressKey('F4');
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    testRenderer.mockInput.pressKey('F4');
+    const experiments = await frameAfter(testRenderer);
+    expect(experiments).toContain('H-07');
+    expect(experiments).not.toContain('Experiment chat');
+    expect(experiments).not.toContain('best r7 1135 tok_s');
+  });
+
+  it('zooms the selected agents or transcript pane in a round', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = splitController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    controller.focusRound('agents');
+    testRenderer.mockInput.pressKey('F4');
+    const agents = await frameAfter(testRenderer);
+    expect(agents).toContain('▸ Agents');
+    expect(agents).not.toContain('batched the prefill step');
+
+    testRenderer.mockInput.pressKey('F4');
+    controller.focusRound('transcript');
+    testRenderer.mockInput.pressKey('F4');
+    const transcript = await frameAfter(testRenderer);
+    expect(transcript).toContain('batched the prefill step');
+    expect(transcript).not.toContain('Agents');
   });
 
   it('closes the pane with Escape and restores the full-width transcript', async () => {
@@ -2146,7 +2342,7 @@ describe('theming', () => {
     await controller.openPane('perf');
     await frameAfter(testRenderer);
 
-    expect(spanColors(testRenderer, 'Performance · focused')?.fg).toBe(theme.borderFocus);
+    expect(spanColors(testRenderer, '▸ Performance')?.fg).toBe(theme.borderFocus);
     expect(spanColors(testRenderer, 'best r7 1135 tok_s')?.fg).toBe(theme.textPrimary);
 
     controller.cyclePaneFocus();
@@ -2613,6 +2809,9 @@ class FakeController implements SessionController {
   }
   focusPane(focus: PaneFocus): void {
     this.publish(focusPane(this.state, focus));
+  }
+  togglePaneZoom(): void {
+    this.publish(togglePaneZoom(this.state));
   }
   setChatDockFits(fits: boolean): void {
     this.publish(setChatDockFits(this.state, fits));

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -2,6 +2,7 @@ import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} fr
 import type {SessionController} from '../session-controller.js';
 import {
   experimentLogVisible,
+  focusedPane,
   type SessionState,
   statusText,
   stripRounds,
@@ -31,12 +32,14 @@ export interface OpenTuiApp {
 /** Which of the client's inputs currently holds the cursor. */
 type FocusTarget = 'command' | 'chat' | 'modal';
 
-const KEY_HELP = '[/]: round · ←→: pane · ↑↓/Tab: within it · /todos · /prompt · Ctrl+L: live';
-const SCOPED_KEY_HELP = '[/]: round · ←→: pane · ↑↓/Tab: within it · /todos · /prompt · Esc: back';
+const KEY_HELP =
+  '[/]: round · ←→: pane · ↑↓/Tab: within it · F4: zoom · /todos · /prompt · Ctrl+L: live';
+const SCOPED_KEY_HELP =
+  '[/]: round · ←→: pane · ↑↓/Tab: within it · F4: zoom · /todos · /prompt · Esc: back';
 const LOG_KEY_HELP =
-  '↑↓ or scroll: select · Enter or /open-round: open its rounds · /open-round --N';
+  '↑↓ or scroll: select · Enter or /open-round: open its rounds · F4: zoom · /open-round --N';
 const LOG_CHAT_KEY_HELP =
-  '↑↓: select · Enter: open its rounds · Ctrl+W: chat and back · /open-round --N';
+  '↑↓: select · Enter: open its rounds · Ctrl+W: chat and back · F4: zoom · /open-round --N';
 /**
  * Shown above the docked chat's own input. Short enough to leave a gap before
  * the key hints beside it even in the narrowest column that docks, and it says
@@ -47,7 +50,7 @@ const CHAT_INPUT_HINT = 'Ask about this run';
 const CHAT_INPUT_PENDING_HINT = 'Awaiting the agent';
 const CHAT_INPUT_BLURRED_HINT = 'Ctrl+W to type here';
 const SPLIT_KEY_HELP =
-  'Ctrl+W: switch pane · PgUp/PgDn: scroll focused pane · Esc on the pane: close it';
+  'Ctrl+W: switch pane · F4: zoom focused pane · PgUp/PgDn: scroll · Esc: close pane';
 
 /**
  * A round the run has not reached has no turns and never will until it runs.
@@ -77,6 +80,10 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     fg: theme.accent,
     content: 'VibeSys · connecting',
   });
+  const focusTranscript = (): void => {
+    controller.focusPane('left');
+    controller.focusRound('transcript');
+  };
   const transcriptFrame = new BoxRenderable(renderer, {
     id: 'viewport',
     width: 'auto',
@@ -87,6 +94,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     border: true,
     borderStyle: 'rounded',
     borderColor: theme.border,
+    onMouseUp: focusTranscript,
   });
   const viewport = new ScrollBoxRenderable(renderer, {
     id: 'transcript-scroll',
@@ -96,6 +104,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     stickyStart: 'bottom',
     viewportCulling: true,
     verticalScrollbarOptions: {showArrows: true},
+    onMouseUp: focusTranscript,
   });
   const main = new BoxRenderable(renderer, {
     id: 'main',
@@ -118,10 +127,11 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   const conversationActivityBar = new ActivityBarView(renderer, theme, 'conversation-activity-bar');
   const overlay = new OverlayView(renderer, theme);
   const experimentLog = new ExperimentLogView(renderer, controller, theme);
-  const rightPane = new RightPaneView(renderer, theme);
+  const rightPane = new RightPaneView(renderer, theme, () => controller.focusPane('right'));
   const themePicker = new ThemePickerView(renderer, theme);
   const conversation = new ConversationView(renderer, controller, markdownStyle, theme, {
     showsSelection: true,
+    onFocusRequest: focusTranscript,
   });
   const chat = new ChatOverlayView(renderer, controller, markdownStyle, theme);
   const chatPane = new ChatPaneView(renderer, controller, markdownStyle, theme);
@@ -246,15 +256,23 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     const releasePreviousStyle =
       state.themeName === themeName ? undefined : applyTheme(state.themeName);
     const showLog = experimentLogVisible(state);
+    const paneFocus = focusedPane(state);
+    const zoomedPane = state.layout.zoomedPane;
     // A split only happens when the terminal can carry both panes. Narrower
     // than that, a visualization keeps the modal it had before the split
     // existed rather than squeezing two unreadable columns onto the screen.
     const splitOpen = state.layout.right !== null;
-    const showSplit = splitOpen && splitFits(renderer.terminalWidth);
-    const paneFallback = splitOpen && !showSplit ? state.layout.right : null;
+    const showSplit = zoomedPane === null && splitOpen && splitFits(renderer.terminalWidth);
+    const showRightPane = zoomedPane === 'performance' || (zoomedPane === null && showSplit);
+    const paneFallback = zoomedPane === null && splitOpen && !showSplit ? state.layout.right : null;
     // Whatever holds the left side, log or transcript, shares the row with the
     // pane rather than being replaced by it.
-    const rightWidth = showSplit ? rightPaneWidth(renderer.terminalWidth) : 0;
+    const rightWidth =
+      zoomedPane === 'performance'
+        ? renderer.terminalWidth
+        : showSplit
+          ? rightPaneWidth(renderer.terminalWidth)
+          : 0;
     const leftWidth = renderer.terminalWidth - rightWidth;
     // Measured here because this is the only place that knows the width, and
     // reported to the controller so a question goes where the operator can see
@@ -262,8 +280,14 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     // for the state to come back, so a resize never draws a stale row.
     const dockFits = chatDockFits(renderer.terminalWidth, rightWidth);
     if (state.chatDockFits !== dockFits) controller.setChatDockFits(dockFits);
-    const showChatPane = showLog && dockFits && !state.chatOpen;
-    const chatWidth = showChatPane ? chatPaneWidth(renderer.terminalWidth, rightWidth) : 0;
+    const chatAvailable = showLog && dockFits && !state.chatOpen;
+    const showChatPane = chatAvailable && (zoomedPane === null || zoomedPane === 'chat');
+    const chatWidth = showChatPane
+      ? zoomedPane === 'chat'
+        ? renderer.terminalWidth
+        : chatPaneWidth(renderer.terminalWidth, rightWidth)
+      : 0;
+    const showExperimentLog = showLog && (zoomedPane === null || zoomedPane === 'experiments');
     const dialogOpen = state.chatOpen || state.overlay !== null || state.themePicker !== null;
     const returnHint = dialogOpen ? ' · Esc: close dialog' : '';
     const selection = state.selectedAgentKind ? ` · selected ${state.selectedAgentKind}` : '';
@@ -285,13 +309,15 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
           : SCOPED_KEY_HELP;
     // The round strip and agent map are per-round detail. They belong to a
     // hypothesis trajectory, not to the list of claims.
-    agentMap.output.visible = !showLog;
-    transcriptFrame.visible = !showLog;
-    roundStrip.output.visible = !showLog;
-    todoStrip.output.visible = !showLog;
+    const showAgents = !showLog && (zoomedPane === null ? !showSplit : zoomedPane === 'agents');
+    const showTranscript = !showLog && (zoomedPane === null || zoomedPane === 'transcript');
+    agentMap.output.visible = showAgents;
+    transcriptFrame.visible = showTranscript;
+    roundStrip.output.visible = !showLog && zoomedPane === null;
+    todoStrip.output.visible = !showLog && zoomedPane === null;
     if (!showLog) {
       roundStrip.render(state);
-      agentMap.render(state);
+      agentMap.render(state, zoomedPane === 'agents' ? renderer.terminalWidth : undefined);
       // The todo box sits under the agent pane and stops where it stops: the
       // todos belong to an agent, so running them under the transcript would
       // attach them to the wrong thing.
@@ -305,13 +331,12 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     }
     // The agent map is the first thing to give up room: it is a summary the
     // visualization largely supersedes while the split is open.
-    agentMap.output.visible = !showLog && !showSplit;
+    agentMap.output.visible = showAgents;
     // Inside a round the transcript is one of two navigable panes, so it carries
     // the focus border whenever the round view's keys are on it.
-    const transcriptFocused = showLog
-      ? showSplit && state.layout.focus === 'left'
-      : state.roundFocus === 'transcript';
+    const transcriptFocused = !showLog && paneFocus === 'transcript';
     transcriptFrame.borderColor = transcriptFocused ? theme.borderFocus : theme.border;
+    transcriptFrame.title = transcriptFocused ? ' ▸ Transcript ' : ' Transcript ';
     // Match the chat to the left pane's rectangle so it sits beside the
     // visualization instead of over it. Bounds come from the siblings that
     // actually occupy those rows, so a taller todo strip still fits.
@@ -340,12 +365,15 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
         ? CHAT_INPUT_HINT
         : CHAT_INPUT_BLURRED_HINT;
     chatInput.setFocused(chatInputFocused);
+    commandColumn.visible = zoomedPane !== 'chat';
+    input.setFocused(paneFocus === 'experiments' || paneFocus === 'transcript');
     // The command list completes the box it belongs to, and on this view that
     // box cannot open a chat that is already beside it.
     input.setCommandContext({chatDocked: showChatPane});
     experimentLog.setAvailableWidth(showSplit || showChatPane ? leftWidth - chatWidth : null);
     experimentLog.render(state);
-    rightPane.render(state, showSplit);
+    experimentLog.output.visible = showExperimentLog;
+    rightPane.render(state, showRightPane, rightWidth);
     overlay.render(
       paneFallback === null
         ? state

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -5,7 +5,7 @@ import {
   type SyntaxStyle,
 } from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
-import {chatPaneFocused, type SessionState} from '../session-model.js';
+import {type ConversationEntry, chatPaneFocused, type SessionState} from '../session-model.js';
 import {ConversationView} from './conversation.js';
 import {LOG_CLAIM_PANEL_WIDTH, LOG_COMPACT_PANEL_WIDTH} from './experiment-log.js';
 import type {Theme} from './theme.js';
@@ -54,7 +54,7 @@ export class ChatPaneView {
   readonly #scroll: ScrollBoxRenderable;
   readonly #conversation: ConversationView;
   #theme: Theme;
-  #renderedState: SessionState | null = null;
+  #renderedConversation: ConversationEntry[] | null = null;
 
   constructor(
     renderer: CliRenderer,
@@ -72,7 +72,7 @@ export class ChatPaneView {
       paddingRight: 1,
       border: true,
       borderStyle: 'rounded',
-      borderColor: theme.info,
+      borderColor: theme.border,
       title: ' Experiment chat ',
       visible: false,
       // Clicking into the chat gives it the keys, the same thing Ctrl+W does.
@@ -97,6 +97,7 @@ export class ChatPaneView {
       selectConversation: state => state.chatConversation,
       emptyContent: 'Ask about this run: progress, a failure, or what a hypothesis changed.',
       renderMarkdown: false,
+      onFocusRequest: () => controller.focusPane('chat'),
     });
     this.#scroll.add(this.#conversation.output);
     this.output.add(this.#scroll);
@@ -104,9 +105,9 @@ export class ChatPaneView {
 
   applyTheme(theme: Theme, markdownStyle: SyntaxStyle): void {
     this.#theme = theme;
-    this.output.borderColor = theme.info;
+    this.output.borderColor = theme.border;
     this.#conversation.applyTheme(theme, markdownStyle);
-    this.#renderedState = null;
+    this.#renderedConversation = null;
   }
 
   /** Scrolled by Page Up/Page Down while this pane holds focus. */
@@ -117,21 +118,17 @@ export class ChatPaneView {
   render(state: SessionState, visible: boolean, width: number): void {
     this.output.visible = visible;
     if (!visible) {
-      this.#renderedState = null;
       return;
     }
     this.output.width = width;
     const focused = chatPaneFocused(state);
-    // The chat keeps a colour of its own at rest, the way the command input
-    // keeps green: which box a keystroke lands in should be readable without
-    // moving focus around to find out.
-    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.info;
+    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
     // The column can be as narrow as its minimum, where a spelled-out "focused"
     // costs the title itself: a box with no title reads as nothing at all. The
     // marker is the one the table already uses for the row that has the keys.
     this.output.title = focused ? ' ▸ Experiment chat ' : ' Experiment chat ';
-    if (state === this.#renderedState) return;
-    this.#renderedState = state;
+    if (state.chatConversation === this.#renderedConversation) return;
+    this.#renderedConversation = state.chatConversation;
     this.#conversation.render(state);
     this.#scroll.scrollTo(this.#scroll.scrollHeight);
   }

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -18,6 +18,8 @@ export interface ConversationViewOptions {
   renderMarkdown?: boolean;
   /** Whether this view draws the entry cursor. */
   showsSelection?: boolean;
+  /** Gives the containing semantic pane focus when any conversation surface is clicked. */
+  onFocusRequest?: () => void;
 }
 
 export class ConversationView {
@@ -29,6 +31,7 @@ export class ConversationView {
   #emptyContent: string;
   readonly #renderMarkdown: boolean;
   readonly #showsSelection: boolean;
+  readonly #onFocusRequest: (() => void) | undefined;
   #renderedConversation: ConversationEntry[] = [];
   #renderedCards: BoxRenderable[] = [];
   #renderedSelection: string | null = null;
@@ -47,12 +50,14 @@ export class ConversationView {
     this.#emptyContent = options.emptyContent ?? 'Waiting for run events…';
     this.#renderMarkdown = options.renderMarkdown ?? true;
     this.#showsSelection = options.showsSelection ?? false;
+    this.#onFocusRequest = options.onFocusRequest;
     // The bordered surface owns horizontal inset so transcript siblings, such
     // as a fixed footer, share the same content origin as these turn cards.
     this.output = new BoxRenderable(renderer, {
       id: 'output',
       width: '100%',
       flexDirection: 'column',
+      ...(this.#onFocusRequest === undefined ? {} : {onMouseUp: this.#onFocusRequest}),
     });
   }
 
@@ -184,13 +189,19 @@ export class ConversationView {
       backgroundColor: palette.background,
       ...(this.#showsSelection
         ? {
-            onMouseUp: () =>
-              entry.kind === 'prompt'
-                ? this.#togglePrompt(entry.id)
-                : this.controller.selectNextEntry(0, entry.id),
+            onMouseUp: () => {
+              this.#onFocusRequest?.();
+              if (entry.kind === 'prompt') this.#togglePrompt(entry.id);
+              else this.controller.selectNextEntry(0, entry.id);
+            },
           }
         : entry.kind === 'prompt'
-          ? {onMouseUp: () => this.#togglePrompt(entry.id)}
+          ? {
+              onMouseUp: () => {
+                this.#onFocusRequest?.();
+                this.#togglePrompt(entry.id);
+              },
+            }
           : {}),
     });
     const heading = new BoxRenderable(this.renderer, {

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -5,6 +5,7 @@ import {
   entryKey,
   experimentIndexItems,
   experimentLogVisible,
+  focusedPane,
   type HypothesisPlanningActivity,
   hypothesisPlanningActivity,
   type SessionState,
@@ -77,10 +78,11 @@ export class ExperimentLogView {
       paddingRight: 1,
       border: true,
       borderStyle: 'rounded',
-      borderColor: theme.accent,
+      borderColor: theme.border,
       backgroundColor: theme.elevatedSurface,
       visible: false,
       title: ' Experiments ',
+      onMouseUp: () => this.controller.focusPane('left'),
     });
     this.#header = new TextRenderable(renderer, {
       content: '',
@@ -103,6 +105,7 @@ export class ExperimentLogView {
       stickyScroll: false,
       viewportCulling: true,
       verticalScrollbarOptions: {showArrows: false},
+      onMouseUp: () => this.controller.focusPane('left'),
     });
     this.#footerLine = new TextRenderable(renderer, {
       content: '',
@@ -129,7 +132,7 @@ export class ExperimentLogView {
 
   applyTheme(theme: Theme): void {
     this.#theme = theme;
-    this.output.borderColor = theme.accent;
+    this.output.borderColor = theme.border;
     this.output.backgroundColor = theme.elevatedSurface;
     this.#header.fg = theme.textSubtle;
     this.#footerLine.fg = theme.textSubtle;
@@ -148,6 +151,9 @@ export class ExperimentLogView {
       return;
     }
     this.output.visible = true;
+    const focused = focusedPane(state) === 'experiments';
+    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
+    this.output.title = focused ? ' ▸ Experiments ' : ' Experiments ';
     const width = this.#availableWidth ?? this.renderer.terminalWidth;
     if (state === this.#renderedState && width === this.#renderedWidth) return;
     this.#renderedState = state;
@@ -328,6 +334,7 @@ export class ExperimentLogView {
       flexDirection: 'row',
       ...selection,
       onMouseUp: () => {
+        this.controller.focusPane('left');
         this.controller.moveExperimentSelection(
           index + activityOffset - this.#selectedNavigationIndex(),
         );
@@ -349,8 +356,10 @@ export class ExperimentLogView {
       height: 1,
       flexShrink: 0,
       ...(isSelected ? {backgroundColor: this.#theme.selectedSurface} : {}),
-      onMouseUp: () =>
-        this.controller.moveExperimentSelection(index - this.#selectedNavigationIndex()),
+      onMouseUp: () => {
+        this.controller.focusPane('left');
+        this.controller.moveExperimentSelection(index - this.#selectedNavigationIndex());
+      },
     });
     row.add(
       this.#cell(
@@ -419,7 +428,10 @@ export class ExperimentLogView {
       height: 1,
       flexShrink: 0,
       ...(selected ? {backgroundColor: this.#theme.selectedSurface} : {}),
-      onMouseUp: () => this.controller.selectExperimentActivity(),
+      onMouseUp: () => {
+        this.controller.focusPane('left');
+        this.controller.selectExperimentActivity();
+      },
     });
     const text = new TextRenderable(this.renderer, {
       content,

--- a/clients/tui/src/ui/input.ts
+++ b/clients/tui/src/ui/input.ts
@@ -23,6 +23,7 @@ export interface InputPanel {
   /** True when nothing is typed, so Enter belongs to whatever pane is behind. */
   isEmpty(): boolean;
   focus(): void;
+  setFocused(focused: boolean): void;
   applyTheme(theme: Theme): void;
   destroy(): void;
 }
@@ -123,7 +124,7 @@ export function createInputPanel(
     width: '100%',
     border: true,
     borderStyle: 'rounded',
-    borderColor: theme.success,
+    borderColor: theme.borderFocus,
     title: ' Ask or command ',
     paddingLeft: 1,
     paddingRight: 1,
@@ -197,6 +198,8 @@ export function createInputPanel(
   input.on(InputRenderableEvents.INPUT, updateDecorations);
   input.on(InputRenderableEvents.ENTER, submit);
   box.add(input);
+  let focused = true;
+  let current = theme;
   return {
     box,
     suggestions,
@@ -213,8 +216,13 @@ export function createInputPanel(
     },
     isEmpty: () => input.value.trim() === '',
     focus: () => input.focus(),
+    setFocused(next: boolean): void {
+      focused = next;
+      box.borderColor = next ? current.borderFocus : current.border;
+    },
     applyTheme(next: Theme): void {
-      box.borderColor = next.success;
+      current = next;
+      box.borderColor = focused ? next.borderFocus : next.border;
       input.textColor = next.textStrong;
       input.focusedTextColor = next.textStrong;
       suggestions.borderColor = next.border;

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -31,6 +31,19 @@ export function bindKeybindings(
       renderer.destroy();
       return;
     }
+    // F4 is delivered consistently by terminal emulators and has no text-input
+    // meaning. Zoom is a presentation toggle, so it is disabled only while a
+    // modal surface owns the screen.
+    if (
+      key.name === 'f4' &&
+      controller.state.chatOpen === false &&
+      controller.state.overlay === null &&
+      controller.state.themePicker === null
+    ) {
+      controller.togglePaneZoom();
+      key.preventDefault();
+      return;
+    }
     if (
       controller.state.errorBanner !== null &&
       key.ctrl &&

--- a/clients/tui/src/ui/right-pane.ts
+++ b/clients/tui/src/ui/right-pane.ts
@@ -1,5 +1,5 @@
 import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
-import type {SessionState} from '../session-model.js';
+import type {RightPane, SessionState} from '../session-model.js';
 import type {Theme} from './theme.js';
 
 /**
@@ -38,12 +38,12 @@ export class RightPaneView {
   readonly output: BoxRenderable;
   readonly #scroll: ScrollBoxRenderable;
   #theme: Theme;
-  #renderedState: SessionState | null = null;
-  #renderedWidth = 0;
+  #renderedPane: RightPane | null = null;
 
   constructor(
     private readonly renderer: CliRenderer,
     theme: Theme,
+    onFocusRequest: () => void,
   ) {
     this.#theme = theme;
     this.output = new BoxRenderable(renderer, {
@@ -58,6 +58,7 @@ export class RightPaneView {
       borderColor: theme.border,
       title: ' Pane ',
       visible: false,
+      onMouseUp: onFocusRequest,
     });
     this.#scroll = new ScrollBoxRenderable(renderer, {
       id: 'right-pane-scroll',
@@ -66,13 +67,14 @@ export class RightPaneView {
       stickyScroll: false,
       viewportCulling: true,
       verticalScrollbarOptions: {showArrows: false},
+      onMouseUp: onFocusRequest,
     });
     this.output.add(this.#scroll);
   }
 
   applyTheme(theme: Theme): void {
     this.#theme = theme;
-    this.#renderedState = null;
+    this.#renderedPane = null;
   }
 
   /** Scrolled by Page Up/Page Down while this pane holds focus. */
@@ -80,24 +82,25 @@ export class RightPaneView {
     this.#scroll.scrollBy(delta, 'viewport');
   }
 
-  render(state: SessionState, visible: boolean): void {
+  render(
+    state: SessionState,
+    visible: boolean,
+    width = rightPaneWidth(this.renderer.terminalWidth),
+  ): void {
     const right = visible ? state.layout.right : null;
     if (right === null) {
       this.output.visible = false;
-      this.#renderedState = null;
       return;
     }
     this.output.visible = true;
-    const width = rightPaneWidth(this.renderer.terminalWidth);
     this.output.width = width;
     // The focused pane is the one that takes keys, so it carries the focus
     // border colour and says so in its title.
     const focused = state.layout.focus === 'right';
     this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
-    this.output.title = focused ? ` ${right.title} · focused ` : ` ${right.title} `;
-    if (state === this.#renderedState && width === this.#renderedWidth) return;
-    this.#renderedState = state;
-    this.#renderedWidth = width;
+    this.output.title = focused ? ` ▸ ${right.title} ` : ` ${right.title} `;
+    if (right === this.#renderedPane) return;
+    this.#renderedPane = right;
     this.#clear();
 
     if (right.error !== null) {


### PR DESCRIPTION
## Problem

The TUI did not indicate focus consistently across panes. In particular, the Experiments pane did not change when it owned keyboard input, which made focus-sensitive actions such as Escape-to-close Performance appear broken. Users also had no way to temporarily enlarge a dense pane for focused reading.

Pointer focus was incomplete as well. Clicking pane backgrounds or nested content such as transcript cards, experiment rows, agent nodes, and performance output could leave keyboard input routed to the previously focused pane.

Fixes #432. Fixes #433.

## Solution

Introduce semantic pane identities and model-owned zoom state. One `focusedPane()` selector is the authority for focus styling and input routing. Every pane now uses a neutral inactive border and the same focused border and title marker.

Each pane owns a semantic focus callback on both its outer surface and inner scroll/content surfaces. Interactive rows, cards, and agent nodes compose focus transfer with their existing selection behavior. A visualization may preserve Agents as the focus to restore after closing, but `focusedPane()` reports Transcript while Agents is hidden.

F4 toggles the focused pane between the normal layout and a full-canvas presentation. Zoom changes visibility only: pane instances, input drafts, selection, content, and scroll state remain intact.

### Architecture

```mermaid
flowchart LR
  I[Keyboard or pointer input] --> M[Session layout model]
  M --> F[focusedPane selector]
  F --> R[Pane rendering and key routing]
  M --> Z[zoomedPane visibility]
  Z --> R
  C[Nested row, card, or node click] --> I
  C --> S[Existing item selection]
```

## Verification

Model, renderer, and mouse interaction coverage verifies focus cycling, pointer focus from blank and nested surfaces, selection composition, follow-up key routing, styling, F4 zoom and restoration, state preservation, and visibility across pane combinations.

### Correctness properties

- One model selector determines which visible pane is focused.
- Only the focused pane receives focused styling.
- Clicking any pane surface transfers semantic focus to that pane.
- Interactive clicks preserve their row, card, or agent selection behavior.
- A hidden Agents pane cannot receive keyboard routing or zoom while a visualization replaces it.
- Zoom never reconstructs or clears pane state.
- Closing or hiding a pane cannot leave focus or zoom targeting a nonexistent pane.
- F4 does not conflict with existing bindings and is documented in the TUI.

### Testing

- `pnpm check` (passed)
- `pnpm test` (372 passed, 0 failed)
- `./scripts/format.sh` (passed)
- `./scripts/check_format.sh` (passed)
- `git diff --check` (passed)
