### PR TITLE
Keep the experiment index chronological and quiet

### DIFF
--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -12,6 +12,7 @@ import {
   enterExperimentDrilldown,
   enterExperimentRound,
   enterUnownedExperimentRound,
+  experimentIndexItems,
   failPane,
   focusedPane,
   focusPane,
@@ -124,7 +125,7 @@ describe('hypothesis planning activity', () => {
     expect(hypothesisPlanningActivity(stateFor('profiler', 'round-3-profile-retry'))).toBeNull();
   });
 
-  it('selects planning activity ahead of existing hypotheses and opens its recorded round', () => {
+  it('selects planning activity after existing hypotheses and opens its recorded round', () => {
     let state = setExperiments(
       {
         ...stateFor('orchestrator', 'round-3-plan'),
@@ -143,7 +144,7 @@ describe('hypothesis planning activity', () => {
       ],
     );
 
-    state = moveExperimentSelection(state, -1);
+    state = moveExperimentSelection(state, 1);
     expect(state.experimentLog?.selectedActivity).toBe(true);
 
     const opened = enterExperimentDrilldown(state);
@@ -168,6 +169,91 @@ describe('hypothesis planning activity', () => {
     };
 
     expect(unownedExperimentRounds(state)).toEqual([]);
+  });
+
+  it('orders mixed history by round and keeps live planning last', () => {
+    const state = setExperiments(
+      {
+        ...initialSessionState(),
+        phases: [
+          {
+            kind: 'orchestrator',
+            status: 'active' as const,
+            roundNumber: 5,
+            roundLabel: 'round-5-plan',
+          },
+        ],
+        rounds: [
+          {number: 4, status: 'completed' as const},
+          {number: 2, status: 'completed' as const},
+          {number: 5, status: 'active' as const},
+        ],
+      },
+      [
+        {
+          hypothesis_id: 'H-03',
+          identified: true,
+          first_round: 3,
+          last_round: 3,
+          rounds: [],
+          kept: false,
+          active: false,
+        },
+        {
+          hypothesis_id: 'H-01',
+          identified: true,
+          first_round: 1,
+          last_round: 1,
+          rounds: [],
+          kept: true,
+          active: false,
+        },
+      ],
+    );
+
+    expect(
+      experimentIndexItems(state).map(item =>
+        item.kind === 'hypothesis'
+          ? item.entry.hypothesis_id
+          : item.kind === 'round'
+            ? `round-${item.roundNumber}`
+            : `planning-${item.activity.roundNumber}`,
+      ),
+    ).toEqual(['H-01', 'round-2', 'H-03', 'round-4', 'planning-5']);
+  });
+
+  it('moves a selected planning row onto the hypothesis that materializes from it', () => {
+    let state = selectExperimentActivity(
+      setExperiments(
+        {
+          ...stateFor('orchestrator', 'round-3-plan'),
+          rounds: [{number: 3, status: 'active' as const}],
+        },
+        [],
+      ),
+    );
+    // Phase completion may arrive before the refreshed experiment response.
+    state = {
+      ...state,
+      phases: state.phases.map(phase => ({...phase, status: 'completed' as const})),
+    };
+    state = setExperiments(state, [
+      {
+        hypothesis_id: 'H-03',
+        identified: true,
+        first_round: 3,
+        last_round: 3,
+        rounds: [],
+        kept: false,
+        active: true,
+      },
+    ]);
+
+    expect(state.experimentLog).toMatchObject({
+      selectedId: 'H-03',
+      selectedActivity: false,
+      selectedActivityRound: null,
+    });
   });
 });
 

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -143,6 +143,8 @@ export interface ExperimentLogState {
   selectedId: string | null;
   /** The transient planning activity is selected instead of a recorded claim. */
   selectedActivity?: boolean;
+  /** Round anchor retained while selected planning becomes a persisted hypothesis. */
+  selectedActivityRound?: number | null;
   /** A recorded round that has no hypothesis entry is selected. */
   selectedUnownedRound?: number | null;
   pending: boolean;
@@ -292,9 +294,9 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
 }
 
 /**
- * Rows are keyed by hypothesis id, which the server orders by first round and
- * never reshuffles. Selection therefore survives a refresh even when a new
- * hypothesis lands above the current one.
+ * Rows are keyed by hypothesis identity rather than response position, so
+ * selection survives refreshes even when the backend returns a different
+ * order. The canonical index sorts the rows before presenting them.
  */
 export function entryKey(entry: HypothesisEntry, index: number): string {
   return entry.identified === false
@@ -371,30 +373,43 @@ export function openExperimentLog(state: SessionState): SessionState {
 export function setExperiments(state: SessionState, entries: HypothesisEntry[]): SessionState {
   const log = state.experimentLog;
   if (log === null) return state;
-  const keys = entries.map(entryKey);
+  const activity = hypothesisPlanningActivity(state);
+  const selectedActivityRound =
+    log.selectedActivity === true
+      ? (log.selectedActivityRound ?? activity?.roundNumber ?? null)
+      : null;
+  const orderedEntries = [...entries].sort(compareHypothesisEntries);
+  const keys = orderedEntries.map(entryKey);
+  const materializedActivity =
+    selectedActivityRound === null
+      ? undefined
+      : orderedEntries.find(entry => scopeRounds(entry).includes(selectedActivityRound));
   // Keep the operator's row when it still exists; otherwise fall back to the
   // active hypothesis, then to the first row.
   const selectedId =
-    log.selectedId !== null && keys.includes(log.selectedId)
-      ? log.selectedId
-      : (keys[entries.findIndex(entry => entry.active === true)] ?? keys[0] ?? null);
-  const unownedRounds = unownedExperimentRounds(state, entries);
+    materializedActivity !== undefined
+      ? entryKeyFor(orderedEntries, materializedActivity)
+      : log.selectedId !== null && keys.includes(log.selectedId)
+        ? log.selectedId
+        : (keys[orderedEntries.findIndex(entry => entry.active === true)] ?? keys[0] ?? null);
+  const unownedRounds = unownedExperimentRounds(state, orderedEntries);
   const currentUnownedRound = log.selectedUnownedRound;
   const selectedUnownedRound =
     currentUnownedRound !== undefined &&
     currentUnownedRound !== null &&
     unownedRounds.includes(currentUnownedRound)
       ? currentUnownedRound
-      : entries.length === 0
+      : orderedEntries.length === 0
         ? (unownedRounds[0] ?? null)
         : null;
   return {
     ...state,
     experimentLog: {
       ...log,
-      entries,
+      entries: orderedEntries,
       selectedId,
-      selectedActivity: hypothesisPlanningActivity(state) !== null && log.selectedActivity === true,
+      selectedActivity: materializedActivity === undefined && log.selectedActivity === true,
+      selectedActivityRound: materializedActivity === undefined ? selectedActivityRound : null,
       selectedUnownedRound,
       pending: false,
       error: null,
@@ -429,7 +444,16 @@ export function selectExperimentActivity(state: SessionState): SessionState {
   ) {
     return state;
   }
-  return {...state, experimentLog: {...log, selectedActivity: true, selectedUnownedRound: null}};
+  const activity = hypothesisPlanningActivity(state);
+  return {
+    ...state,
+    experimentLog: {
+      ...log,
+      selectedActivity: true,
+      selectedActivityRound: activity?.roundNumber ?? null,
+      selectedUnownedRound: null,
+    },
+  };
 }
 
 /**
@@ -596,28 +620,49 @@ export function unownedExperimentRounds(
       round =>
         !owned.has(round.number) && round.number !== planningRound && round.status !== 'planned',
     )
-    .map(round => round.number);
+    .map(round => round.number)
+    .sort((left, right) => left - right);
 }
 
-/** The visual index: live planning, hypotheses, then observed unowned rounds. */
+/**
+ * The canonical visual index. Historical work is chronological regardless of
+ * server response order, and transient planning is always the newest item.
+ */
 export function experimentIndexItems(state: SessionState): ExperimentIndexItem[] {
-  const items: ExperimentIndexItem[] = [];
-  const activity = hypothesisPlanningActivity(state);
-  if (activity !== null) items.push({kind: 'activity', key: 'activity', activity});
+  const history: ExperimentIndexItem[] = [];
   for (const [index, entry] of (state.experimentLog?.entries ?? []).entries()) {
-    items.push({kind: 'hypothesis', key: entryKey(entry, index), entry});
+    history.push({kind: 'hypothesis', key: entryKey(entry, index), entry});
   }
   for (const roundNumber of unownedExperimentRounds(state)) {
-    items.push({kind: 'round', key: `round-${roundNumber}`, roundNumber});
+    history.push({kind: 'round', key: `round-${roundNumber}`, roundNumber});
   }
-  return items;
+  history.sort((left, right) => experimentItemRound(left) - experimentItemRound(right));
+  const activity = hypothesisPlanningActivity(state);
+  return activity === null ? history : [...history, {kind: 'activity', key: 'activity', activity}];
+}
+
+function experimentItemRound(item: ExperimentIndexItem): number {
+  if (item.kind === 'hypothesis') return item.entry.first_round;
+  if (item.kind === 'round') return item.roundNumber;
+  return item.activity.roundNumber;
+}
+
+function compareHypothesisEntries(left: HypothesisEntry, right: HypothesisEntry): number {
+  return (
+    left.first_round - right.first_round ||
+    left.last_round - right.last_round ||
+    left.hypothesis_id.localeCompare(right.hypothesis_id)
+  );
 }
 
 export function selectedExperimentIndexItem(state: SessionState): ExperimentIndexItem | null {
   const log = state.experimentLog;
   if (log === null) return null;
   const items = experimentIndexItems(state);
-  if (log.selectedActivity === true) return items.find(item => item.kind === 'activity') ?? null;
+  if (log.selectedActivity === true) {
+    const activity = items.find(item => item.kind === 'activity');
+    if (activity !== undefined) return activity;
+  }
   if (log.selectedUnownedRound !== undefined && log.selectedUnownedRound !== null) {
     return (
       items.find(item => item.kind === 'round' && item.roundNumber === log.selectedUnownedRound) ??
@@ -636,11 +681,24 @@ function selectExperimentIndexItem(
   const log = state.experimentLog;
   if (log === null || item === undefined) return state;
   if (item.kind === 'activity')
-    return {...state, experimentLog: {...log, selectedActivity: true, selectedUnownedRound: null}};
+    return {
+      ...state,
+      experimentLog: {
+        ...log,
+        selectedActivity: true,
+        selectedActivityRound: item.activity.roundNumber,
+        selectedUnownedRound: null,
+      },
+    };
   if (item.kind === 'round') {
     return {
       ...state,
-      experimentLog: {...log, selectedActivity: false, selectedUnownedRound: item.roundNumber},
+      experimentLog: {
+        ...log,
+        selectedActivity: false,
+        selectedActivityRound: null,
+        selectedUnownedRound: item.roundNumber,
+      },
     };
   }
   return {
@@ -649,6 +707,7 @@ function selectExperimentIndexItem(
       ...log,
       selectedId: item.key,
       selectedActivity: false,
+      selectedActivityRound: null,
       selectedUnownedRound: null,
     },
   };

--- a/clients/tui/src/ui/activity-bar.ts
+++ b/clients/tui/src/ui/activity-bar.ts
@@ -5,9 +5,7 @@ import type {Theme} from './theme.js';
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const SPINNER_INTERVAL_MS = 120;
-export type ActivityBarScope = 'global' | 'conversation';
-
-/** Stable, selection-aware status line for backend-authoritative execution activity. */
+/** Status for executions visible in the selected agent conversation. */
 export class ActivityBarView {
   readonly output: TextRenderable;
   #executions: ActiveAgentExecution[] = [];
@@ -27,17 +25,15 @@ export class ActivityBarView {
     });
   }
 
-  render(state: SessionState, scope: ActivityBarScope, visible = true): void {
+  render(state: SessionState, visible = true): void {
     const all = Object.values(state.activeExecutions);
     const roundNumber = visibleRoundNumber(state);
     this.#executions = visible
-      ? scope === 'global'
-        ? all
-        : all.filter(
-            execution =>
-              (roundNumber === null || execution.roundNumber === roundNumber) &&
-              (state.selectedAgentKind === null || execution.agentKind === state.selectedAgentKind),
-          )
+      ? all.filter(
+          execution =>
+            (roundNumber === null || execution.roundNumber === roundNumber) &&
+            (state.selectedAgentKind === null || execution.agentKind === state.selectedAgentKind),
+        )
       : [];
     this.output.visible = this.#executions.length > 0;
     this.#refresh();

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -473,7 +473,7 @@ describe('OpenTUI presentation', () => {
     expect(firstTurn?.x).toBe(activity.x);
   });
 
-  it('keeps the global working indicator on the hypothesis log', async () => {
+  it('keeps working indicators scoped to agent conversations', async () => {
     const testRenderer = await createTestRenderer({width: 100, height: 20});
     const controller = new FakeController({
       ...initialSessionState(),
@@ -495,8 +495,9 @@ describe('OpenTUI presentation', () => {
     const app = createOpenTuiApp(testRenderer.renderer, controller);
     registerCleanup(testRenderer.renderer, app);
 
-    const frame = await testRenderer.waitForFrame(value => value.includes('Implementer · Working'));
+    const frame = await frameAfter(testRenderer);
     expect(frame).toContain('Experiments');
+    expect(frame).not.toContain('Implementer · Working');
     expect(frame).not.toContain('Editing the queue');
   });
 
@@ -2447,8 +2448,8 @@ describe('theming', () => {
     await controller.openExperimentLog();
 
     const kickoff = await frameAfter(testRenderer);
-    expect(kickoff).toContain('Planning Hypothesis 1 · Round 2');
-    expect(kickoff).toContain('UNASSOCIATED ROUNDS');
+    expect(kickoff).toContain('Planning Hypothesis 1');
+    expect(kickoff).toContain('Round 2');
     expect(kickoff).toContain('Round 1 · recorded agent turns · no hypothesis');
 
     testRenderer.mockInput.pressEnter();
@@ -2482,10 +2483,12 @@ describe('theming', () => {
     expect(detail).not.toContain('other round');
 
     testRenderer.mockInput.pressKey('ESCAPE');
-    expect(await frameAfterEscape(testRenderer)).toContain('UNASSOCIATED ROUNDS');
+    expect(await frameAfterEscape(testRenderer)).toContain(
+      'Round 7 · recorded agent turns · no hypothesis',
+    );
   });
 
-  it('pins later hypothesis planning above the existing history', async () => {
+  it('keeps later hypothesis planning below the existing history', async () => {
     const testRenderer = await createTestRenderer({width: 120, height: 18});
     const controller = new FakeController({
       ...initialSessionState(),
@@ -2503,7 +2506,42 @@ describe('theming', () => {
     expect(frame).toContain('CURRENT ACTIVITY');
     expect(frame).toContain('Planning Hypothesis 2 · forming it · Round 42');
     expect(frame).toContain('H-07');
+    expect(frame.indexOf('H-07')).toBeLessThan(frame.indexOf('Planning Hypothesis 2'));
     expect(frame).not.toContain('UNASSOCIATED ROUNDS');
+  });
+
+  it('renders shuffled hypotheses and unassociated rounds in one ascending index', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 20});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      status: 'running',
+      rounds: [
+        {number: 4, status: 'completed'},
+        {number: 2, status: 'completed'},
+        {number: 5, status: 'active'},
+      ],
+      phases: [
+        {kind: 'orchestrator', status: 'active', roundNumber: 5, roundLabel: 'round-5-plan'},
+      ],
+    });
+    controller.experiments = [
+      logEntry('H-03', 3, 3, {claim: 'third'}),
+      logEntry('H-01', 1, 1, {claim: 'first'}),
+    ];
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    const frame = await frameAfter(testRenderer);
+    const positions = [
+      frame.indexOf('H-01'),
+      frame.indexOf('Round 2 · recorded'),
+      frame.indexOf('H-03'),
+      frame.indexOf('Round 4 · recorded'),
+      frame.indexOf('Planning Hypothesis 3'),
+    ];
+    expect(positions.every(position => position >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
   });
 
   it('labels an explicit profiler phase without claiming it will happen earlier', async () => {

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -123,7 +123,6 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   const todoStrip = new TodoStripView(renderer, controller, theme);
   const errorBanner = new ErrorBannerView(renderer, theme);
   const agentMap = new AgentMapView(renderer, controller, theme);
-  const globalActivityBar = new ActivityBarView(renderer, theme, 'global-activity-bar');
   const conversationActivityBar = new ActivityBarView(renderer, theme, 'conversation-activity-bar');
   const overlay = new OverlayView(renderer, theme);
   const experimentLog = new ExperimentLogView(renderer, controller, theme);
@@ -213,7 +212,6 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
   root.add(roundStrip.output);
   root.add(main);
   root.add(todoStrip.output);
-  root.add(globalActivityBar.output);
   root.add(bottom);
   root.add(overlay.output);
   root.add(themePicker.output);
@@ -234,7 +232,6 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     todoStrip.applyTheme(theme);
     errorBanner.applyTheme(theme);
     agentMap.applyTheme(theme);
-    globalActivityBar.applyTheme(theme);
     conversationActivityBar.applyTheme(theme);
     overlay.applyTheme(theme);
     experimentLog.applyTheme(theme);
@@ -381,8 +378,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     );
     themePicker.render(state);
     chat.render(state);
-    globalActivityBar.render(state, 'global', showLog);
-    conversationActivityBar.render(state, 'conversation', !showLog);
+    conversationActivityBar.render(state, !showLog);
     // One cursor, three places it can be. The modal owns it while it is open;
     // otherwise it belongs to whichever input the pane focus points at.
     const target: FocusTarget = state.chatOpen ? 'modal' : chatInputFocused ? 'chat' : 'command';
@@ -429,7 +425,6 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
       input.destroy();
       chatInput.destroy();
       chat.destroy();
-      globalActivityBar.destroy();
       conversationActivityBar.destroy();
       roundStrip.destroy();
       agentMap.destroy();

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -2,7 +2,7 @@ import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} fr
 import type {HypothesisEntry} from '../protocol.js';
 import type {SessionController} from '../session-controller.js';
 import {
-  entryKey,
+  type ExperimentIndexItem,
   experimentIndexItems,
   experimentLogVisible,
   focusedPane,
@@ -174,18 +174,12 @@ export class ExperimentLogView {
     }
     const activity = hypothesisPlanningActivity(state);
     if (log.entries.length === 0) {
-      if (activity !== null) {
+      if (activity !== null && unownedExperimentRounds(state).length === 0) {
         this.#renderKickoff(activity, state);
         return;
       }
       if (unownedExperimentRounds(state).length > 0) {
-        this.#renderTable(
-          log.entries,
-          log.selectedId,
-          log.selectedUnownedRound ?? null,
-          null,
-          state,
-        );
+        this.#renderTable(state);
         return;
       }
       this.#header.content = '';
@@ -193,13 +187,7 @@ export class ExperimentLogView {
       this.#footerLine.content = 'The first one appears once the orchestrator has planned a round.';
       return;
     }
-    this.#renderTable(
-      log.entries,
-      log.selectedId,
-      log.selectedUnownedRound ?? null,
-      activity,
-      state,
-    );
+    this.#renderTable(state);
   }
 
   #renderKickoff(activity: HypothesisPlanningActivity, state: SessionState): void {
@@ -230,66 +218,42 @@ export class ExperimentLogView {
         : '↑↓: select activity or recorded round · Enter: open';
   }
 
-  #renderTable(
-    entries: HypothesisEntry[],
-    selectedId: string | null,
-    selectedUnownedRound: number | null,
-    activity: HypothesisPlanningActivity | null,
-    state: SessionState,
-  ): void {
+  #renderTable(state: SessionState): void {
+    const log = state.experimentLog;
+    if (log === null) return;
     const columns = resolveColumns(this.#bodyWidth());
-    const keys = entries.map(entryKey);
-    const selected = selectedId === null ? 0 : Math.max(0, keys.indexOf(selectedId));
-    const activitySelected =
-      activity !== null && this.#renderedState?.experimentLog?.selectedActivity === true;
-
+    const items = experimentIndexItems(state);
+    const selected = selectedExperimentIndexItem(state);
     this.#header.content = headerRow(columns);
-    const activityRows =
-      activity === null ? 0 : this.#renderActivity(activity, entries.length, activitySelected);
-    for (const [index, entry] of entries.entries()) {
-      this.#row(
-        entry,
-        columns,
-        keys[index] === selectedId && !activitySelected,
-        index,
-        activity === null ? 0 : 1,
-      );
-    }
-    const unowned = unownedExperimentRounds(state);
-    if (unowned.length > 0) {
-      this.#line('UNASSOCIATED ROUNDS', this.#theme.textSubtle);
-      for (const [index, roundNumber] of unowned.entries()) {
-        this.#roundRow(
-          roundNumber,
-          selectedUnownedRound === roundNumber,
-          (activity === null ? 0 : 1) + entries.length + index,
-        );
+    let selectedRenderIndex = 0;
+    let renderedRows = 0;
+    for (const [navigationIndex, item] of items.entries()) {
+      const isSelected = item.key === selected?.key;
+      if (item.kind === 'hypothesis') {
+        const entryIndex = log.entries.indexOf(item.entry);
+        this.#row(item.entry, columns, isSelected, entryIndex, navigationIndex);
+        if (isSelected) selectedRenderIndex = renderedRows;
+        renderedRows += 1;
+      } else if (item.kind === 'round') {
+        this.#roundRow(item.roundNumber, isSelected, navigationIndex);
+        if (isSelected) selectedRenderIndex = renderedRows;
+        renderedRows += 1;
+      } else {
+        this.#line('CURRENT ACTIVITY', this.#theme.textSubtle);
+        renderedRows += 1;
+        this.#renderActivity(item, log.entries.length, isSelected);
+        if (isSelected) selectedRenderIndex = renderedRows;
+        renderedRows += 1;
       }
     }
     // Keyboard selection nudges the scroll position only when the row would
     // otherwise be off screen, so the wheel stays in charge the rest of the
     // time. Computed rather than deferred to scrollChildIntoView, which needs
     // a layout pass the freshly added rows have not had yet.
-    this.#followSelection(
-      this.#selectedRenderIndex(
-        entries.length,
-        activity,
-        selected,
-        activitySelected,
-        selectedUnownedRound,
-        unowned,
-      ),
-      entries.length + activityRows + (unowned.length === 0 ? 0 : unowned.length + 1),
-    );
-    const selectedUnownedIndex =
-      selectedUnownedRound === null ? -1 : unowned.indexOf(selectedUnownedRound);
-    const totalIndexItems = entries.length + unowned.length + (activity === null ? 0 : 1);
-    const positionIndex = activitySelected
-      ? 1
-      : selectedUnownedIndex === -1
-        ? selected + (activity === null ? 1 : 2)
-        : entries.length + selectedUnownedIndex + (activity === null ? 1 : 2);
-    const position = `${positionIndex}/${totalIndexItems}`;
+    this.#followSelection(selectedRenderIndex, renderedRows);
+    const selectedNavigationIndex =
+      selected === null ? 0 : items.findIndex(item => item.key === selected.key);
+    const position = `${Math.max(0, selectedNavigationIndex) + 1}/${items.length}`;
     // The hint is the first thing to give up room; truncating it mid-word
     // reads as breakage rather than as a narrow terminal.
     const hint =
@@ -300,18 +264,17 @@ export class ExperimentLogView {
   }
 
   #renderActivity(
-    activity: HypothesisPlanningActivity,
+    item: Extract<ExperimentIndexItem, {kind: 'activity'}>,
     existingHypotheses: number,
     selected: boolean,
-  ): number {
+  ): void {
+    const {activity} = item;
     const hypothesis = planningHypothesisLabel(existingHypotheses);
-    this.#line('CURRENT ACTIVITY', this.#theme.textSubtle);
     this.#activityLine(
       `● Planning ${hypothesis} · ${planningStageSummary(activity.stage)} · Round ${activity.roundNumber}`,
       activity,
       selected,
     );
-    return 2;
   }
 
   #row(
@@ -319,7 +282,7 @@ export class ExperimentLogView {
     columns: Columns,
     isSelected: boolean,
     index: number,
-    activityOffset: number,
+    navigationIndex: number,
   ): void {
     const cells = entryCells(entry, columns);
     // The active hypothesis is called out on its own, so it stays visible
@@ -335,9 +298,7 @@ export class ExperimentLogView {
       ...selection,
       onMouseUp: () => {
         this.controller.focusPane('left');
-        this.controller.moveExperimentSelection(
-          index + activityOffset - this.#selectedNavigationIndex(),
-        );
+        this.controller.moveExperimentSelection(navigationIndex - this.#selectedNavigationIndex());
       },
     });
     // The outcome is its own renderable so the resolution can carry a color of
@@ -349,7 +310,7 @@ export class ExperimentLogView {
     this.#rows.add(row);
   }
 
-  #roundRow(roundNumber: number, isSelected: boolean, index: number): void {
+  #roundRow(roundNumber: number, isSelected: boolean, navigationIndex: number): void {
     const row = new BoxRenderable(this.renderer, {
       id: `unowned-round-${roundNumber}`,
       width: '100%',
@@ -358,7 +319,7 @@ export class ExperimentLogView {
       ...(isSelected ? {backgroundColor: this.#theme.selectedSurface} : {}),
       onMouseUp: () => {
         this.controller.focusPane('left');
-        this.controller.moveExperimentSelection(index - this.#selectedNavigationIndex());
+        this.controller.moveExperimentSelection(navigationIndex - this.#selectedNavigationIndex());
       },
     });
     row.add(
@@ -405,20 +366,6 @@ export class ExperimentLogView {
         ? 0
         : experimentIndexItems(state).findIndex(item => item.key === selected.key);
     return Math.max(0, index);
-  }
-
-  #selectedRenderIndex(
-    entriesLength: number,
-    activity: HypothesisPlanningActivity | null,
-    selectedHypothesis: number,
-    activitySelected: boolean,
-    selectedUnownedRound: number | null,
-    unowned: number[],
-  ): number {
-    if (activitySelected) return 1;
-    const unownedIndex = selectedUnownedRound === null ? -1 : unowned.indexOf(selectedUnownedRound);
-    if (unownedIndex !== -1) return (activity === null ? 1 : 3) + entriesLength + unownedIndex;
-    return selectedHypothesis + (activity === null ? 0 : 2);
   }
 
   #activityLine(content: string, activity: HypothesisPlanningActivity, selected: boolean): void {


### PR DESCRIPTION
## Problem

The hypothesis index mixed presentation-specific ordering rules: persisted hypotheses were ascending, but live planning was inserted at the top and later jumped to the bottom when persisted. Rendering, keyboard movement, mouse offsets, and selection restoration computed that mixed list separately. The same landing page also showed a global agent spinner even though activity belongs to detailed agent conversations.

Fixes #430. Fixes #431.

## Solution

Define one canonical chronological experiment-index sequence. Persisted hypotheses and unowned rounds are normalized by round, and live planning is appended as the newest item. Rendering, navigation, scroll positioning, mouse selection, and drill-down consume that same typed sequence.

Track the planning round as a selection anchor so a selected live item remains selected when it becomes a persisted hypothesis, including when phase completion and experiment refresh arrive in either order.

Remove the global activity-bar scope and instance. Agent activity remains conversation-scoped inside the detailed agent transcript.

### Architecture

```mermaid
flowchart LR
  E[Persisted experiments] --> I[Canonical index items]
  R[Observed rounds] --> I
  P[Live planning] --> I
  I --> V[Rendering]
  I --> K[Keyboard navigation]
  I --> M[Mouse selection]
  I --> S[Selection persistence]
```

## Verification

Tests cover shuffled backend entries, mixed hypothesis and unowned-round rows, live planning at the bottom, selection continuity through persistence, mouse and keyboard ordering, and absence of the spinner from the landing page while retaining conversation activity.

### Correctness properties

- The experiment index remains ascending, with its newest item at the bottom.
- Every index interaction consumes the same ordered item sequence.
- A selected planning item remains logically selected after persistence.
- The hypothesis landing page never renders global agent activity.
- Detailed agent conversations retain authoritative activity state.

### Testing

- `pnpm check` (passed)
- `pnpm test` (372 passed)
- `./scripts/check_format.sh` (passed)
- `git diff --check` (passed)
