### PR TITLE
Copy selected TUI text without exiting

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -179,7 +179,11 @@ Control chord for itself, and on macOS several do.
 
 Escape unwinds the round view one step at a time: the entry cursor, then the
 agent filter, then the hypothesis. Ctrl+L returns to the experiment log from
-anywhere, and Ctrl+C exits. Rounds and agents can also be clicked: a round chip
+anywhere. Drag to select rendered text, then press Ctrl+C to copy it through
+OSC52; Ctrl+C exits when there is no nonempty selection. If the terminal does
+not support OSC52, VibeSys keeps the selection and shows a status explaining
+that the terminal's native copy command is the fallback. Rounds and agents can
+also be clicked: a round chip
 selects its round, an agent node filters the transcript to that agent, and
 clicking the selected node clears the filter. Commands listed under "Planned" in
 `/help` are not accepted yet.

--- a/clients/tui/src/index.ts
+++ b/clients/tui/src/index.ts
@@ -10,7 +10,10 @@ const socketPath = process.env['VIBESYS_CONTROL_SOCKET'];
 if (!socketPath) throw new Error('VIBESYS_CONTROL_SOCKET is required');
 
 const client = await SupervisionClient.connect(socketPath);
-const renderer = await createCliRenderer({exitOnCtrlC: true});
+// VibeSys owns Ctrl+C so a nonempty OpenTUI selection can be copied before the
+// same chord falls back to exiting. Enabling OpenTUI's parallel exit handler
+// would make those two outcomes race.
+const renderer = await createCliRenderer({exitOnCtrlC: false});
 const controller = new SocketSessionController(
   client,
   resolveTheme(process.env['VIBESYS_THEME']).name,

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -39,6 +39,7 @@ import {
   togglePaneZoom,
 } from '../session-model.js';
 import {createOpenTuiApp, type OpenTuiApp} from './app.js';
+import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 import {resolveTheme, type ThemeName} from './theme.js';
 
 const cleanup: Array<() => void> = [];
@@ -1044,7 +1045,7 @@ describe('OpenTUI presentation', () => {
   });
 
   it('exits on the first Ctrl-C even while the input is focused', async () => {
-    const testRenderer = await createTestRenderer({width: 80, height: 16});
+    const testRenderer = await createTestRenderer({width: 80, height: 16, exitOnCtrlC: false});
     const controller = new FakeController(initialSessionState());
     const app = createOpenTuiApp(testRenderer.renderer, controller);
     cleanup.push(() => app.destroy());
@@ -1053,6 +1054,40 @@ describe('OpenTUI presentation', () => {
     testRenderer.mockInput.pressKey('c', {ctrl: true});
 
     await destroyed;
+  });
+
+  it('copies a selected range on Ctrl-C without exiting', async () => {
+    const testRenderer = await createTestRenderer({width: 80, height: 16, exitOnCtrlC: false});
+    const controller = new FakeController(initialSessionState());
+    const clipboard = clipboardReturning('copied');
+    const app = createOpenTuiApp(testRenderer.renderer, controller, clipboard);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('Ask or command'));
+
+    testRenderer.mockInput.pressKey('c', {ctrl: true});
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('Copied selected text'));
+    expect(frame).toContain('Ctrl+C exits when no text is selected');
+    expect(clipboard.calls).toBe(1);
+
+    testRenderer.mockInput.pressKey('x');
+    await testRenderer.waitForFrame(value => !value.includes('Copied selected text'));
+  });
+
+  it('keeps running and explains the fallback when OSC52 copy is unavailable', async () => {
+    const testRenderer = await createTestRenderer({width: 90, height: 16, exitOnCtrlC: false});
+    const controller = new FakeController(initialSessionState());
+    const clipboard = clipboardReturning('unsupported');
+    const app = createOpenTuiApp(testRenderer.renderer, controller, clipboard);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('Ask or command'));
+
+    testRenderer.mockInput.pressKey('c', {ctrl: true});
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('Copy unavailable'));
+    expect(frame).toContain('selection kept');
+    expect(frame).toContain('terminal copy command');
+    expect(clipboard.calls).toBe(1);
   });
 
   it('advertises Escape and returns a non-live view to live output', async () => {
@@ -2754,6 +2789,21 @@ function registerCleanup(
     app.destroy();
     renderer.destroy();
   });
+}
+
+function clipboardReturning(
+  result: ClipboardCopyResult,
+): SelectionClipboard & {readonly calls: number} {
+  let calls = 0;
+  return {
+    get calls(): number {
+      return calls;
+    },
+    copySelection(): ClipboardCopyResult {
+      calls += 1;
+      return result;
+    },
+  };
 }
 
 class FakeController implements SessionController {

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -13,6 +13,7 @@ import {AgentMapView} from './agent-map.js';
 import {createChatDraft} from './chat-composer.js';
 import {ChatOverlayView} from './chat-overlay.js';
 import {ChatPaneView, chatDockFits, chatPaneWidth} from './chat-pane.js';
+import {RendererSelectionClipboard, type SelectionClipboard} from './clipboard.js';
 import {ConversationView} from './conversation.js';
 import {ErrorBannerView} from './error-banner.js';
 import {ExperimentLogView} from './experiment-log.js';
@@ -56,7 +57,11 @@ function emptyTranscriptMessage(state: SessionState): string {
   return 'Waiting for run events…';
 }
 
-export function createOpenTuiApp(renderer: CliRenderer, controller: SessionController): OpenTuiApp {
+export function createOpenTuiApp(
+  renderer: CliRenderer,
+  controller: SessionController,
+  clipboard: SelectionClipboard = new RendererSelectionClipboard(renderer),
+): OpenTuiApp {
   let themeName: ThemeName = controller.state.themeName;
   let theme = resolveTheme(themeName);
   const root = new BoxRenderable(renderer, {
@@ -124,6 +129,8 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     fg: theme.textSubtle,
     content: KEY_HELP,
   });
+  let renderedKeyHelp = KEY_HELP;
+  let transientStatus: string | null = null;
   let markdownStyle = createMarkdownStyle(theme);
   const roundStrip = new RoundStripView(renderer, controller, theme);
   const todoStrip = new TodoStripView(renderer, controller, theme);
@@ -273,7 +280,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     errorBanner.render(state);
     // The log carries its own key hints in its footer, so when it shares the
     // row with a pane the global line is the place for the pane's keys.
-    help.content = showSplit
+    renderedKeyHelp = showSplit
       ? SPLIT_KEY_HELP
       : showLog
         ? showChatPane
@@ -282,6 +289,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
         : state.hypothesisScope === null
           ? KEY_HELP
           : SCOPED_KEY_HELP;
+    help.content = transientStatus ?? renderedKeyHelp;
     // The round strip and agent map are per-round detail. They belong to a
     // hypothesis trajectory, not to the list of claims.
     const showAgents = !showLog && (zoomedPane === null ? !showSplit : zoomedPane === 'agents');
@@ -358,7 +366,7 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     }
     releasePreviousStyle?.();
   };
-  const unbindKeys = bindKeybindings(renderer, controller, viewport, {
+  const unbindKeys = bindKeybindings(renderer, controller, viewport, clipboard, {
     completeInput: () => input.completeSuggestion(),
     // Enter belongs to a pane only when nothing is typed anywhere. Asking which
     // box has the cursor is not enough: a question waiting in the other box is
@@ -378,6 +386,18 @@ export function createOpenTuiApp(renderer: CliRenderer, controller: SessionContr
     scrollRightPane: delta => rightPane.scrollBy(delta),
     scrollChatPane: delta => chatPane.scrollBy(delta),
     scrollErrorBanner: delta => errorBanner.scrollBy(delta),
+    clearTransientStatus: () => {
+      if (transientStatus === null) return;
+      transientStatus = null;
+      help.content = renderedKeyHelp;
+    },
+    showClipboardStatus: result => {
+      transientStatus =
+        result === 'copied'
+          ? 'Copied selected text · Ctrl+C exits when no text is selected'
+          : 'Copy unavailable (OSC52) · selection kept · use your terminal copy command';
+      help.content = transientStatus;
+    },
   });
   // Pane widths come from the terminal, so a resize has to redraw even though
   // no state changed.

--- a/clients/tui/src/ui/clipboard.test.ts
+++ b/clients/tui/src/ui/clipboard.test.ts
@@ -1,0 +1,58 @@
+import {describe, expect, it} from 'bun:test';
+import type {CliRenderer} from '@opentui/core';
+import {RendererSelectionClipboard} from './clipboard.js';
+
+type ClipboardRenderer = Pick<
+  CliRenderer,
+  'copyToClipboardOSC52' | 'getSelection' | 'isOsc52Supported'
+>;
+
+describe('renderer selection clipboard', () => {
+  it('distinguishes an empty selection from a copy failure', () => {
+    const renderer = fakeRenderer({selectedText: ''});
+
+    expect(new RendererSelectionClipboard(renderer).copySelection()).toBe('no-selection');
+    expect(renderer.copyCalls).toEqual([]);
+  });
+
+  it('copies the exact selected text through OSC52', () => {
+    const renderer = fakeRenderer({selectedText: 'line one\nline two'});
+
+    expect(new RendererSelectionClipboard(renderer).copySelection()).toBe('copied');
+    expect(renderer.copyCalls).toEqual(['line one\nline two']);
+  });
+
+  it('does not attempt a write when OSC52 is unsupported', () => {
+    const renderer = fakeRenderer({selectedText: 'keep me selected', supported: false});
+
+    expect(new RendererSelectionClipboard(renderer).copySelection()).toBe('unsupported');
+    expect(renderer.copyCalls).toEqual([]);
+  });
+
+  it('reports rejected and throwing OSC52 writes as unsupported', () => {
+    const rejected = fakeRenderer({selectedText: 'selected', copySucceeds: false});
+    const throwing = fakeRenderer({selectedText: 'selected', copyError: new Error('terminal')});
+
+    expect(new RendererSelectionClipboard(rejected).copySelection()).toBe('unsupported');
+    expect(new RendererSelectionClipboard(throwing).copySelection()).toBe('unsupported');
+  });
+});
+
+function fakeRenderer(options: {
+  selectedText: string;
+  supported?: boolean;
+  copySucceeds?: boolean;
+  copyError?: Error;
+}): ClipboardRenderer & {copyCalls: string[]} {
+  const copyCalls: string[] = [];
+  return {
+    copyCalls,
+    getSelection: () => ({getSelectedText: () => options.selectedText}) as never,
+    isOsc52Supported: () => options.supported ?? true,
+    copyToClipboardOSC52: text => {
+      copyCalls.push(text);
+      if (options.copyError) throw options.copyError;
+      return options.copySucceeds ?? true;
+    },
+  };
+}

--- a/clients/tui/src/ui/clipboard.ts
+++ b/clients/tui/src/ui/clipboard.ts
@@ -1,0 +1,36 @@
+import type {CliRenderer} from '@opentui/core';
+
+export type ClipboardCopyResult = 'no-selection' | 'copied' | 'unsupported';
+
+/** Clipboard behavior owned by the terminal renderer boundary. */
+export interface SelectionClipboard {
+  copySelection(): ClipboardCopyResult;
+}
+
+type ClipboardRenderer = Pick<
+  CliRenderer,
+  'copyToClipboardOSC52' | 'getSelection' | 'isOsc52Supported'
+>;
+
+/**
+ * Copies OpenTUI's current text selection without exposing renderer details to
+ * key routing or session state.
+ *
+ * A failed copy deliberately leaves the selection intact. The operator can
+ * then use the terminal's native selection and copy path instead.
+ */
+export class RendererSelectionClipboard implements SelectionClipboard {
+  constructor(private readonly renderer: ClipboardRenderer) {}
+
+  copySelection(): ClipboardCopyResult {
+    const text = this.renderer.getSelection()?.getSelectedText() ?? '';
+    if (text.length === 0) return 'no-selection';
+
+    try {
+      if (!this.renderer.isOsc52Supported()) return 'unsupported';
+      return this.renderer.copyToClipboardOSC52(text) ? 'copied' : 'unsupported';
+    } catch {
+      return 'unsupported';
+    }
+  }
+}

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -1,6 +1,7 @@
 import type {CliRenderer, KeyEvent, ScrollBoxRenderable} from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
 import {chatPaneFocused, chatPaneVisible, experimentLogVisible} from '../session-model.js';
+import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 
 export interface KeybindingActions {
   completeInput(): boolean;
@@ -17,20 +18,26 @@ export interface KeybindingActions {
   scrollRightPane(delta: number): void;
   scrollChatPane(delta: number): void;
   scrollErrorBanner(delta: number): void;
+  clearTransientStatus(): void;
+  showClipboardStatus(result: Exclude<ClipboardCopyResult, 'no-selection'>): void;
 }
 
 export function bindKeybindings(
   renderer: CliRenderer,
   controller: SessionController,
   viewport: ScrollBoxRenderable,
+  clipboard: SelectionClipboard,
   actions: KeybindingActions,
 ): () => void {
   const onKey = (key: KeyEvent): void => {
-    if (key.ctrl && key.name === 'c') {
+    if (key.ctrl && !key.shift && key.name === 'c') {
       key.preventDefault();
-      renderer.destroy();
+      const result = clipboard.copySelection();
+      if (result === 'no-selection') renderer.destroy();
+      else actions.showClipboardStatus(result);
       return;
     }
+    actions.clearTransientStatus();
     // F4 is delivered consistently by terminal emulators and has no text-input
     // meaning. Zoom is a presentation toggle, so it is disabled only while a
     // modal surface owns the screen.


### PR DESCRIPTION
## Problem

OpenTUI owned mouse selection, but VibeSys never transferred selected text to the clipboard. Its built-in `exitOnCtrlC` behavior could terminate the app before VibeSys inspected the selection, so the conventional copy gesture was unavailable and terminal-specific modifier selection was the only workaround.

Fixes #429.

## Solution

Make VibeSys the sole owner of Ctrl+C and put selection/clipboard behavior behind a typed renderer-boundary adapter. Ctrl+C with a nonempty application selection copies the exact text through OSC52 without exiting. Ctrl+C with no selection retains the established exit behavior.

If OSC52 is unsupported, rejects the write, or throws, the app stays alive, preserves the selection, and shows a terminal-native-copy fallback in the help line.

### Architecture

```mermaid
flowchart LR
  K[Ctrl+C] --> A[Keybinding owner]
  A --> C[RendererSelectionClipboard]
  C -->|selection exists| O[OSC52 copy]
  C -->|no selection| X[Exit TUI]
  O -->|unsupported or failed| H[Preserve selection and show fallback]
```

## Verification

Adapter and rendering tests cover exact text copying, empty selection, unsupported terminals, rejected and throwing clipboard writes, preservation of the running app, help feedback, and the no-selection exit path. The full stacked TUI suite passes.

### Correctness properties

- Exactly one component owns Ctrl+C behavior.
- A nonempty selection is never interpreted as an exit request.
- Clipboard failure never destroys the TUI or clears the selection.
- No selection preserves the existing Ctrl+C exit contract.
- Clipboard handling remains a frontend renderer concern.

### Testing

- `pnpm check` (passed)
- `pnpm test` on the stacked branch (382 passed)
- TypeScript build and Biome checks before stacking (passed)
- `git diff --check` (passed)
