### PR TITLE
Run session MCP servers through native Omnigent

### DIFF
--- a/docs/contributing/agent-drivers.md
+++ b/docs/contributing/agent-drivers.md
@@ -27,8 +27,19 @@ uv sync --extra omnigent
   Gemini harness, and its `opencode-native` executor cannot run a headless
   VibeSys turn.
 - `--docker` is rejected because the integration has no container launcher.
-- MCP server setup is rejected because the driver does not translate VibeSys
-  MCP specifications.
+- Session-scoped stdio MCP servers use Omnigent's native MCP manager. VibeSys
+  translates its provider-independent server declarations into Omnigent
+  `MCPServerConfig` values, discovers namespaced tools before the first turn,
+  and owns each session's MCP connections and subprocess cleanup.
+  These generated specs declare no Omnigent guardrails; VibeSys remains the
+  authority for which session-scoped servers are supplied to each role.
+  Omnigent 0.10 launches stdio MCP subprocesses directly as children of the
+  VibeSys process, outside the agent's OS-tool sandbox. Session MCP specs must
+  therefore remain trusted framework configuration, not candidate input. With
+  an explicit server `env`, the subprocess inherits the VibeSys process
+  environment after Omnigent removes runner authentication secrets, then
+  overlays those values. Without an explicit `env`, Omnigent delegates to the
+  MCP SDK's restricted default environment.
 - Extra host resource grants are rejected. The Omnigent path imports only the
   installed Rust toolchain automatically.
 - Hidden project paths become explicit Omnigent masks. Read-only declarations

--- a/src/vibesys/agents/drivers/_omnigent_mcp.py
+++ b/src/vibesys/agents/drivers/_omnigent_mcp.py
@@ -1,0 +1,211 @@
+"""Native Omnigent MCP integration for one VibeSys agent session."""
+
+# ruff: noqa: TRY003
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from vibesys.agents.contracts import MCPServerSpec
+
+
+class OmnigentMCPError(RuntimeError):
+    """Omnigent could not initialize the requested MCP tool surface."""
+
+
+@dataclass(frozen=True)
+class _NativeMCPAPI:
+    agent_spec: type[Any]
+    executor_spec: type[Any]
+    server_config: type[Any]
+    manager: type[Any]
+    validate: Callable[[Any], Any]
+
+
+def _native_mcp_api() -> _NativeMCPAPI:
+    """Load the pinned Omnigent MCP API only when the extra is selected."""
+    try:
+        from omnigent.runner.mcp_manager import RunnerMcpManager  # noqa: PLC0415
+        from omnigent.spec import (  # noqa: PLC0415
+            AgentSpec,
+            ExecutorSpec,
+            MCPServerConfig,
+            validate,
+        )
+    except ImportError as exc:
+        raise OmnigentMCPError(
+            f"Omnigent MCP support is not importable ({type(exc).__name__}: {exc}). "
+            "Install the Omnigent optional dependency with `uv sync --extra omnigent`."
+        ) from exc
+    return _NativeMCPAPI(
+        agent_spec=AgentSpec,
+        executor_spec=ExecutorSpec,
+        server_config=MCPServerConfig,
+        manager=RunnerMcpManager,
+        validate=validate,
+    )
+
+
+def _translate_servers(
+    servers: tuple[MCPServerSpec, ...],
+    server_config: type[Any],
+) -> list[Any]:
+    """Translate neutral stdio declarations into Omnigent configurations."""
+    names = [server.name for server in servers]
+    duplicate_names = sorted({name for name in names if names.count(name) > 1})
+    if duplicate_names:
+        raise OmnigentMCPError(f"MCP server names must be unique: {duplicate_names}")
+
+    return [
+        server_config(
+            name=server.name,
+            transport="stdio",
+            command=sys.executable if server.command in {"python", "python3"} else server.command,
+            args=list(server.args),
+            env=dict(server.env),
+        )
+        for server in servers
+    ]
+
+
+def _redact_environment_values(message: str, servers: tuple[MCPServerSpec, ...]) -> str:
+    """Remove configured environment values from native diagnostics."""
+    redacted = message
+    for server in servers:
+        for _, value in server.env:
+            if value:
+                redacted = redacted.replace(value, "<redacted>")
+    return redacted
+
+
+@dataclass
+class OmnigentMCPTools:
+    """Schemas, dispatch, and lifecycle for native session-scoped MCP tools."""
+
+    schemas: list[dict[str, Any]]
+    _tool_names: frozenset[str]
+    _manager: Any
+    _agent_spec: Any
+    _session_id: Callable[[], str | None]
+    _servers: tuple[MCPServerSpec, ...]
+    _initialized: bool = False
+    _closed: bool = False
+    _close_lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        servers: tuple[MCPServerSpec, ...],
+        workspace: Path,
+        harness: str,
+        session_id: Callable[[], str | None],
+    ) -> OmnigentMCPTools | None:
+        """Build an owned native manager without starting MCP subprocesses."""
+        if not servers:
+            return None
+
+        native = _native_mcp_api()
+        agent_spec = native.agent_spec(
+            spec_version=1,
+            name="vibesys-session-mcp",
+            executor=native.executor_spec(config={"harness": harness}),
+            mcp_servers=_translate_servers(servers, native.server_config),
+        )
+        validation = native.validate(agent_spec)
+        if not validation.valid:
+            details = "; ".join(f"{error.path}: {error.message}" for error in validation.errors)
+            raise OmnigentMCPError(
+                "Invalid Omnigent MCP configuration: "
+                f"{_redact_environment_values(details, servers)}"
+            )
+
+        manager = native.manager(stdio_cwd=workspace)
+        return cls(
+            schemas=[],
+            _tool_names=frozenset(),
+            _manager=manager,
+            _agent_spec=agent_spec,
+            _session_id=session_id,
+            _servers=servers,
+        )
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        servers: tuple[MCPServerSpec, ...],
+        workspace: Path,
+        harness: str,
+        session_id: Callable[[], str | None],
+    ) -> OmnigentMCPTools | None:
+        """Build and initialize native session-scoped MCP tools."""
+        tools = cls.build(
+            servers=servers,
+            workspace=workspace,
+            harness=harness,
+            session_id=session_id,
+        )
+        if tools is not None:
+            await tools.initialize()
+        return tools
+
+    async def initialize(self) -> None:
+        """Connect servers and discover their namespaced native schemas."""
+        if self._initialized:
+            raise RuntimeError("Omnigent MCP tools are already initialized")
+        if self._closed:
+            raise RuntimeError("Omnigent MCP tools are closed")
+        try:
+            result = await self._manager.schemas_for(self._agent_spec)
+            if result.failures:
+                details = "; ".join(
+                    f"{name}: {error}" for name, error in sorted(result.failures.items())
+                )
+                raise OmnigentMCPError(  # noqa: TRY301
+                    "Omnigent could not connect MCP servers: "
+                    f"{_redact_environment_values(details, self._servers)}"
+                )
+            self.schemas = list(result.schemas)
+            self._tool_names = frozenset(result.tool_names)
+            self._initialized = True
+        except BaseException as error:
+            try:
+                await self.close()
+            except BaseException as cleanup_error:  # noqa: BLE001
+                error.add_note(f"Omnigent MCP cleanup also failed: {cleanup_error}")
+            raise
+
+    def handles(self, name: str) -> bool:
+        """Return whether ``name`` belongs to this session's MCP surface."""
+        return name in self._tool_names
+
+    async def dispatch(self, name: str, arguments: dict[str, Any]) -> str:
+        """Invoke one namespaced MCP tool through Omnigent's native manager."""
+        if self._closed:
+            raise RuntimeError("Omnigent MCP tools are closed")
+        if not self._initialized:
+            raise RuntimeError("Omnigent MCP tools are not initialized")
+        if name not in self._tool_names:
+            raise RuntimeError(f"Omnigent MCP tools do not contain {name!r}")
+        return await self._manager.call_tool(
+            self._agent_spec,
+            name,
+            arguments,
+            session_id=self._session_id(),
+        )
+
+    async def close(self) -> None:
+        """Shut down all native MCP connections and subprocesses once."""
+        async with self._close_lock:
+            if self._closed:
+                return
+            await self._manager.shutdown()
+            self._closed = True

--- a/src/vibesys/agents/drivers/agentshim.py
+++ b/src/vibesys/agents/drivers/agentshim.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import sys
 import weakref
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from vibesys._agent_cli.base import CodingAgent
@@ -29,6 +30,15 @@ from vibesys.agents.contracts import (
 from vibesys.agents.docker_executor import DockerCommandExecutor
 from vibesys.agents.host_resource_declarations import declare_agent_host_resources
 from vs_sandbox import build_host_sandbox
+
+AGENTSHIM_CAPABILITIES = AgentCapabilities(
+    mcp_servers=True,
+    nested_read_only_paths=True,
+    hidden_paths=True,
+    timeouts=True,
+    session_reuse=True,
+)
+"""Capabilities invariant across AgentShim host and container execution."""
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -391,14 +401,10 @@ class AgentShimDriver:
     @property
     def capabilities(self) -> AgentCapabilities:
         """Describe the policy and lifecycle features this driver enforces."""
-        return AgentCapabilities(
-            mcp_servers=True,
-            nested_read_only_paths=True,
-            hidden_paths=True,
+        return replace(
+            AGENTSHIM_CAPABILITIES,
             host_path_grants=self._docker_sandboxes is None,
             container_execution=self._docker_sandboxes is not None,
-            timeouts=True,
-            session_reuse=True,
         )
 
     def create_session(self, spec: AgentSessionSpec) -> AgentSession:

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -30,6 +30,7 @@ from vibesys.agents.contracts import (
 )
 from vibesys.agents.drivers._omnigent_lifecycle import CloseLifecycle as _CloseLifecycle
 from vibesys.agents.drivers._omnigent_lifecycle import LifecycleState as _LifecycleState
+from vibesys.agents.drivers._omnigent_mcp import OmnigentMCPTools as _OmnigentMCPTools
 from vibesys.agents.drivers._omnigent_runtime import (
     OmnigentAsyncRuntime as _OmnigentAsyncRuntime,
 )
@@ -66,6 +67,13 @@ _OMNIGENT_INTERNAL_HIDDEN = frozenset({".codex-tmp"})
 
 _SESSION_SHUTDOWN_TIMEOUT = 5.0
 
+OMNIGENT_CAPABILITIES = AgentCapabilities(
+    mcp_servers=True,
+    timeouts=True,
+    session_reuse=True,
+)
+"""Capabilities available before constructing Omnigent runtime resources."""
+
 
 def _unwrap_turn(
     outcome: tuple[AgentTurnResult | None, BaseException | None],
@@ -101,6 +109,10 @@ class _OwnedOSTools:
     schemas: list[dict[str, Any]]
     dispatch: Callable[[str, dict[str, Any]], Any]
     environments: tuple[Any, ...]
+
+    def handles(self, name: str) -> bool:
+        """Return whether ``name`` belongs to this sandboxed tool surface."""
+        return any(schema.get("name") == name for schema in self.schemas)
 
     def close(self) -> None:
         """Close every environment exactly once and preserve the first failure."""
@@ -416,13 +428,14 @@ async def _drive_turn(
 class OmnigentSession:
     """One configured Omnigent executor and provider conversation."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         driver: OmnigentDriver,
         spec: AgentSessionSpec,
         executor: Any,  # noqa: ANN401
         tool_schemas: list[dict[str, Any]],
+        mcp_tools: _OmnigentMCPTools | None = None,
         resources: _ExecutorResources | None = None,
     ) -> None:
         """Own ``executor`` until this session is closed."""
@@ -430,6 +443,7 @@ class OmnigentSession:
         self._spec = spec
         self._executor = executor
         self._tool_schemas = tool_schemas
+        self._mcp_tools = mcp_tools
         self._resources: _ExecutorResources | None = resources or _ExecutorResources()
         self._lifecycle = threading.Condition()
         self._close_lifecycle = _CloseLifecycle(self._lifecycle)
@@ -563,7 +577,7 @@ class OmnigentSession:
             return None, exc
 
     async def _shutdown(self) -> BaseException | None:
-        """Close this session's executor on the driver runtime."""
+        """Close this session's native resources on the driver runtime."""
         first_error: BaseException | None = None
         try:
             close = getattr(self._executor, "close", None)
@@ -573,16 +587,20 @@ class OmnigentSession:
                     await result
         except BaseException as exc:  # noqa: BLE001
             first_error = exc
+        mcp_tools = self._mcp_tools
+        if mcp_tools is not None:
+            try:
+                await mcp_tools.close()
+            except BaseException as exc:  # noqa: BLE001
+                if first_error is None:
+                    first_error = exc
+            else:
+                self._mcp_tools = None
         return first_error
 
 
 class OmnigentDriver:
     """Create sandboxed Omnigent sessions and own their native resources."""
-
-    _CAPABILITIES = AgentCapabilities(
-        timeouts=True,
-        session_reuse=True,
-    )
 
     def __init__(self) -> None:
         """Create a driver with no live sessions."""
@@ -596,7 +614,7 @@ class OmnigentDriver:
     @property
     def capabilities(self) -> AgentCapabilities:
         """Describe the requirements Omnigent 0.10.0 can satisfy."""
-        return self._CAPABILITIES
+        return OMNIGENT_CAPABILITIES
 
     def create_session(self, spec: AgentSessionSpec) -> OmnigentSession:
         """Validate setup requirements and create a confined session."""
@@ -606,12 +624,13 @@ class OmnigentDriver:
             self._creating_sessions += 1
         try:
             self._validate_spec(spec)
-            executor, schemas, resources = self._build_executor(spec)
+            executor, schemas, mcp_tools, resources = self._build_executor(spec)
             session = OmnigentSession(
                 driver=self,
                 spec=spec,
                 executor=executor,
                 tool_schemas=schemas,
+                mcp_tools=mcp_tools,
                 resources=resources,
             )
             with self._lifecycle:
@@ -668,9 +687,6 @@ class OmnigentDriver:
 
     def _validate_spec(self, spec: AgentSessionSpec) -> None:
         _resolve_executor_spec(spec.provider)
-        if spec.mcp_servers:
-            names = [server.name for server in spec.mcp_servers]
-            raise OmnigentDriverError(f"Omnigent cannot install session MCP servers: {names}")
         if spec.policy.host_resources:
             raise OmnigentDriverError("Omnigent cannot enforce VibeSys host-resource grants")
         if spec.policy.containerized:
@@ -688,8 +704,13 @@ class OmnigentDriver:
             )
 
     def run_awaitable(self, awaitable: Any) -> Any:  # noqa: ANN401
-        """Run isolated cleanup on the driver-owned async runtime."""
-        return self.submit(awaitable).result()
+        """Run and drain one coroutine on the driver-owned async runtime."""
+        task = self.start_task(awaitable)
+        try:
+            return task.result()
+        except BaseException:
+            task.cancel_and_wait()
+            raise
 
     def submit[Result](
         self,
@@ -779,9 +800,9 @@ class OmnigentDriver:
             sandbox=sandbox,
         )
 
-    def _build_executor(
+    def _build_executor(  # noqa: C901, PLR0915
         self, spec: AgentSessionSpec
-    ) -> tuple[Any, list[dict[str, Any]], _ExecutorResources]:
+    ) -> tuple[Any, list[dict[str, Any]], _OmnigentMCPTools | None, _ExecutorResources]:
         executor_spec = _resolve_executor_spec(spec.provider)
         executor_cls = self._executor_class(executor_spec)
         os_env_spec = self._build_os_env(spec)
@@ -874,6 +895,7 @@ class OmnigentDriver:
                 description="Omnigent executor cleanup",
             )
             raise
+        mcp_tools: _OmnigentMCPTools | None = None
         try:
             os_tools = _build_os_tools(
                 os_env_spec,
@@ -882,15 +904,56 @@ class OmnigentDriver:
                 shell_os_env_spec,
             )
             resources.os_tools = os_tools
-            setattr(executor, _TOOL_EXECUTOR_ATTR, os_tools.dispatch)
+            mcp_tools = _OmnigentMCPTools.build(
+                servers=spec.mcp_servers,
+                workspace=spec.workspace,
+                harness=executor_spec.harness,
+                session_id=lambda: cast("str | None", getattr(executor, "thread_id", None)),
+            )
+            if mcp_tools is not None:
+                self.run_awaitable(mcp_tools.initialize())
+
+            async def dispatch(name: str, args: dict[str, Any]) -> Any:  # noqa: ANN401
+                if mcp_tools is not None and mcp_tools.handles(name):
+                    return await mcp_tools.dispatch(name, args)
+                if os_tools.handles(name):
+                    return await os_tools.dispatch(name, args)
+                return {"error": f"unknown tool {name!r}"}
+
+            setattr(executor, _TOOL_EXECUTOR_ATTR, dispatch)
         except BaseException as error:
+            if mcp_tools is not None:
+                try:
+                    self.run_awaitable(mcp_tools.close())
+                except BaseException as cleanup_error:  # noqa: BLE001
+                    error.add_note(f"Omnigent MCP cleanup also failed: {cleanup_error}")
             _cleanup_after_failure(
                 error,
                 lambda: self.close_executor(executor, resources=resources),
                 description="Omnigent executor cleanup",
             )
             raise
-        return executor, os_tools.schemas, resources
+        mcp_schemas = [] if mcp_tools is None else mcp_tools.schemas
+        duplicate_names = {schema["name"] for schema in os_tools.schemas} & {
+            schema["name"] for schema in mcp_schemas
+        }
+        if duplicate_names:
+            error = OmnigentDriverError(
+                f"Omnigent MCP tools conflict with OS tools: {sorted(duplicate_names)}"
+            )
+            assert mcp_tools is not None  # noqa: S101  # duplicate MCP schema implies owner
+            _cleanup_after_failure(
+                error,
+                lambda: self.run_awaitable(mcp_tools.close()),
+                description="Omnigent MCP cleanup",
+            )
+            _cleanup_after_failure(
+                error,
+                lambda: self.close_executor(executor, resources=resources),
+                description="Omnigent executor cleanup",
+            )
+            raise error
+        return executor, [*os_tools.schemas, *mcp_schemas], mcp_tools, resources
 
     def release_session(self, session: OmnigentSession) -> None:
         """Forget a closed session after it has released its owned resources."""

--- a/src/vibesys/agents/factory.py
+++ b/src/vibesys/agents/factory.py
@@ -24,6 +24,32 @@ def resolve_agent_driver(config: Config) -> str:
     return config.agent.driver or DEFAULT_AGENT_DRIVER
 
 
+def agent_driver_supports_mcp_servers(
+    config: Config,
+    *,
+    agent_backend: str | None,
+) -> bool | None:
+    """Return whether the configured external driver supports session MCP.
+
+    This query has no runtime side effects, so wiring code can reject an
+    incompatible feature before creating a project or driver resources.
+    Non-CLI backends do not use the external-driver contract.
+    """
+    backend = agent_backend or config.agent.backend or DEFAULT_AGENT_BACKEND
+    if backend != "cli":
+        return None
+
+    driver_name = resolve_agent_driver(config)
+    if driver_name == "omnigent":
+        from vibesys.agents.drivers.omnigent import OMNIGENT_CAPABILITIES  # noqa: PLC0415
+
+        return OMNIGENT_CAPABILITIES.mcp_servers
+
+    from vibesys.agents.drivers.agentshim import AGENTSHIM_CAPABILITIES  # noqa: PLC0415
+
+    return AGENTSHIM_CAPABILITIES.mcp_servers
+
+
 def build_agent_client(  # noqa: C901, PLR0912, PLR0913
     config: Config,
     *,

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 
 from vibesys import backends
 from vibesys.agents import AgentClient, build_agent_client
+from vibesys.agents.factory import agent_driver_supports_mcp_servers, resolve_agent_driver
 from vibesys.agents.progress import AgentProgress
 from vibesys.backends.base import ComputeBackendImpl, ContentionMonitor
 from vibesys.config import Config, as_config
@@ -410,6 +411,25 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
         environment_default_profiler_kind=environment.default_profiler_kind,
         environment_supported_profiler_kinds=environment.supported_profiler_kinds,
     )
+    driver_supports_mcp = agent_driver_supports_mcp_servers(
+        config,
+        agent_backend=agent_backend,
+    )
+    if resolved_profiler_kind in ACTIVE_PROFILER_KINDS and driver_supports_mcp is False:
+        driver_name = resolve_agent_driver(config)
+        definition = profiler_definition(resolved_profiler_kind)
+        raise ConfigurationError(
+            ConfigurationDiagnostic(
+                code="agent_profiler_incompatible",
+                stage="agent_capability_validation",
+                message=(
+                    f"Profiler {resolved_profiler_kind.value!r} requires session MCP server "
+                    f"{definition.mcp_name!r}, but agent driver {driver_name!r} does not "
+                    "support session MCP servers. Select agent.driver='agentshim' or "
+                    "disable profiling with --profiler none."
+                ),
+            )
+        )
     profiler_preflight = preflight_profiler_kind(resolved_profiler_kind)
     if not profiler_preflight.usable:
         raise ConfigurationError(

--- a/src/vibesys/run/logger.py
+++ b/src/vibesys/run/logger.py
@@ -38,6 +38,10 @@ class _TeeWriter:
     def isatty(self):  # noqa: ANN202  # tracked: #288
         return False
 
+    def fileno(self) -> int:
+        """Expose the real stream descriptor to subprocess launchers."""
+        return self._primary.fileno()
+
 
 class _CurrentLogWriter:
     """Stable writer that follows a :class:`RunLogger` across file switches."""

--- a/tests/agents/drivers/test_omnigent_driver.py
+++ b/tests/agents/drivers/test_omnigent_driver.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field, replace
 from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 
@@ -775,7 +775,7 @@ def test_independent_sessions_overlap_on_one_driver_loop(
     monkeypatch.setattr(
         driver,
         "_build_executor",
-        lambda _spec: (next(remaining), [], _resources()),
+        lambda _spec: (next(remaining), [], None, _resources()),
     )
     sessions = [driver.create_session(_spec(tmp_path)) for _ in executors]
 
@@ -879,7 +879,7 @@ def test_driver_close_continues_after_cleanup_base_exception(
     monkeypatch.setattr(
         driver,
         "_build_executor",
-        lambda _spec: (next(remaining), [], _resources()),
+        lambda _spec: (next(remaining), [], None, _resources()),
     )
     for _ in executors:
         driver.create_session(_spec(tmp_path))
@@ -936,10 +936,15 @@ def test_driver_close_waits_for_in_flight_session_creation(
 
     def build(
         _spec: AgentSessionSpec,
-    ) -> tuple[_FakeExecutor, list[dict[str, Any]], driver_subject._ExecutorResources]:
+    ) -> tuple[
+        _FakeExecutor,
+        list[dict[str, Any]],
+        None,
+        driver_subject._ExecutorResources,
+    ]:
         build_started.set()
         assert release_build.wait(timeout=2)
-        return executor, [], _resources()
+        return executor, [], None, _resources()
 
     monkeypatch.setattr(driver, "_build_executor", build)
     with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
@@ -967,7 +972,6 @@ def test_driver_close_waits_for_in_flight_session_creation(
 @pytest.mark.parametrize(
     ("change", "message"),
     [
-        ({"mcp_servers": (MCPServerSpec("issues", "python"),)}, "MCP"),
         (
             {
                 "policy": AgentExecutionPolicy(
@@ -1013,7 +1017,7 @@ def test_create_session_accepts_supported_top_level_project_policy(
     monkeypatch.setattr(
         driver,
         "_build_executor",
-        lambda _spec: (executor, [], _resources()),
+        lambda _spec: (executor, [], None, _resources()),
     )
     policy = ProjectPathPolicy(
         read_only_paths=(".git", ".vibesys"),
@@ -1037,7 +1041,7 @@ def test_create_session_accepts_non_dot_hidden_path(
     monkeypatch.setattr(
         driver,
         "_build_executor",
-        lambda _spec: (executor, [], _resources()),
+        lambda _spec: (executor, [], None, _resources()),
     )
     policy = ProjectPathPolicy(hidden_paths=("agent.toml",))
 
@@ -1058,7 +1062,7 @@ def test_driver_owns_session_cleanup(
     monkeypatch.setattr(
         driver,
         "_build_executor",
-        lambda _spec: (executor, [], _resources()),
+        lambda _spec: (executor, [], None, _resources()),
     )
 
     driver.create_session(_spec(tmp_path))
@@ -1240,7 +1244,7 @@ def test_codex_executor_disables_native_tools(
         build_tools,
     )
 
-    executor, _schemas, resources = driver._build_executor(  # noqa: SLF001
+    executor, _schemas, mcp_tools, resources = driver._build_executor(  # noqa: SLF001
         _spec(tmp_path, environment=(("DRIVER_TEST", "session"),))
     )
 
@@ -1255,5 +1259,245 @@ def test_codex_executor_disables_native_tools(
     assert not cargo_home.is_relative_to(tmp_path)
     assert "CARGO_TARGET_DIR" not in captured["tool_environment"]
     assert not any(key.endswith("_LINKER") for key in captured["tool_environment"])
+    assert mcp_tools is None
     driver.close_executor(executor, resources=resources)
     assert not cargo_home.parent.exists()
+
+
+@pytest.mark.parametrize(
+    ("provider", "harness", "environment_attribute"),
+    [("claude", "claude-sdk", "_extra_env"), ("codex", "codex", "_env")],
+)
+def test_executor_routes_only_declared_os_and_mcp_tools(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    harness: str,
+    environment_attribute: str,
+) -> None:
+    dispatched: list[tuple[str, str, dict[str, Any]]] = []
+
+    class Executor(_FakeExecutor):
+        def __init__(self, **_kwargs: Any) -> None:  # noqa: ANN401
+            super().__init__([])
+            setattr(self, environment_attribute, {})
+
+    class MCPTools:
+        schemas: ClassVar[list[dict[str, Any]]] = [{"name": "profiler__analyze", "parameters": {}}]
+        close_calls = 0
+        initialize_calls = 0
+
+        @staticmethod
+        def handles(name: str) -> bool:
+            return name == "profiler__analyze"
+
+        async def dispatch(self, name: str, args: dict[str, Any]) -> str:
+            dispatched.append(("mcp", name, args))
+            return "mcp result"
+
+        async def initialize(self) -> None:
+            self.initialize_calls += 1
+
+        async def close(self) -> None:
+            self.close_calls += 1
+
+    mcp_tools = MCPTools()
+
+    class MCPFactory:
+        @staticmethod
+        def build(**kwargs: Any) -> MCPTools:  # noqa: ANN401
+            assert kwargs["harness"] == harness
+            return mcp_tools
+
+    async def dispatch_os(name: str, args: dict[str, Any]) -> str:
+        dispatched.append(("os", name, args))
+        return "os result"
+
+    driver = OmnigentDriver()
+    monkeypatch.setattr(driver, "_executor_class", lambda _spec: Executor)
+    monkeypatch.setattr(driver, "_build_os_env", lambda _spec, **_kwargs: object())
+    monkeypatch.setattr(driver_subject, "resolve_active_rust_toolchain", lambda *_a, **_k: None)
+    monkeypatch.setattr(driver_subject, "_OmnigentMCPTools", MCPFactory)
+    monkeypatch.setattr(
+        driver_subject,
+        "_build_os_tools",
+        lambda *_args, **_kwargs: driver_subject._OwnedOSTools(  # noqa: SLF001
+            schemas=[{"name": "sys_os_read", "parameters": {}}],
+            dispatch=dispatch_os,
+            environments=(),
+        ),
+    )
+
+    executor, schemas, built_mcp, resources = driver._build_executor(  # noqa: SLF001
+        _spec(
+            tmp_path,
+            provider=provider,
+            mcp_servers=(MCPServerSpec("profiler", "python"),),
+        )
+    )
+
+    assert built_mcp is mcp_tools
+    assert mcp_tools.initialize_calls == 1
+    assert [schema["name"] for schema in schemas] == ["sys_os_read", "profiler__analyze"]
+    assert asyncio.run(executor._tool_executor("sys_os_read", {"path": "x"})) == "os result"  # noqa: SLF001
+    assert (
+        asyncio.run(executor._tool_executor("profiler__analyze", {"pid": 1}))  # noqa: SLF001
+        == "mcp result"
+    )
+    assert asyncio.run(executor._tool_executor("undeclared", {})) == {  # noqa: SLF001
+        "error": "unknown tool 'undeclared'"
+    }
+    assert dispatched == [
+        ("os", "sys_os_read", {"path": "x"}),
+        ("mcp", "profiler__analyze", {"pid": 1}),
+    ]
+
+    asyncio.run(mcp_tools.close())
+    driver.close_executor(executor, resources=resources)
+    driver.close()
+    assert mcp_tools.close_calls == 1
+
+
+def test_tool_schema_conflict_attempts_all_cleanup_and_preserves_conflict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor: _FakeExecutor | None = None
+
+    class Executor(_FakeExecutor):
+        def __init__(self, **_kwargs: Any) -> None:  # noqa: ANN401
+            nonlocal executor
+            super().__init__([])
+            self._env: dict[str, str] = {}
+            executor = self
+
+    class MCPTools:
+        schemas: ClassVar[list[dict[str, Any]]] = [{"name": "sys_os_read", "parameters": {}}]
+        close_calls = 0
+
+        async def initialize(self) -> None:
+            pass
+
+        @staticmethod
+        def handles(_name: str) -> bool:
+            return False
+
+        async def close(self) -> None:
+            self.close_calls += 1
+            raise RuntimeError("MCP cleanup failed")  # noqa: TRY003
+
+    mcp_tools = MCPTools()
+
+    class MCPFactory:
+        @staticmethod
+        def build(**_kwargs: Any) -> MCPTools:  # noqa: ANN401
+            return mcp_tools
+
+    class Resource:
+        close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    resource = Resource()
+    driver = OmnigentDriver()
+    monkeypatch.setattr(driver, "_executor_class", lambda _spec: Executor)
+    monkeypatch.setattr(driver, "_build_os_env", lambda _spec, **_kwargs: object())
+    monkeypatch.setattr(driver_subject, "resolve_active_rust_toolchain", lambda *_a, **_k: None)
+    monkeypatch.setattr(driver_subject, "_OmnigentMCPTools", MCPFactory)
+    monkeypatch.setattr(
+        driver_subject,
+        "_build_os_tools",
+        lambda *_args, **_kwargs: driver_subject._OwnedOSTools(  # noqa: SLF001
+            schemas=[{"name": "sys_os_read", "parameters": {}}],
+            dispatch=lambda *_args: None,
+            environments=(resource,),
+        ),
+    )
+
+    with pytest.raises(OmnigentDriverError, match="conflict") as caught:
+        driver._build_executor(  # noqa: SLF001
+            _spec(tmp_path, mcp_servers=(MCPServerSpec("profiler", "python"),))
+        )
+
+    assert any("MCP cleanup also failed" in note for note in caught.value.__notes__)
+    assert mcp_tools.close_calls == 1
+    assert executor is not None
+    assert executor.close_calls == 1
+    assert resource.close_calls == 1
+    driver.close()
+
+
+def test_interrupted_mcp_initialization_keeps_owner_for_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Executor:
+        close_calls = 0
+
+        def __init__(self, **_kwargs: Any) -> None:  # noqa: ANN401
+            self._env: dict[str, str] = {}
+            self._tool_executor = None
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    class MCPTools:
+        schemas: ClassVar[list[dict[str, Any]]] = []
+        close_calls = 0
+
+        async def initialize(self) -> None:
+            await asyncio.Future()
+
+        async def close(self) -> None:
+            self.close_calls += 1
+
+    mcp_tools = MCPTools()
+
+    class MCPFactory:
+        @staticmethod
+        def build(**_kwargs: Any) -> MCPTools:  # noqa: ANN401
+            return mcp_tools
+
+    resource = SimpleNamespace(close_calls=0)
+
+    def close_resource() -> None:
+        resource.close_calls += 1
+
+    resource.close = close_resource
+    driver = OmnigentDriver()
+    executor = Executor()
+    monkeypatch.setattr(driver, "_executor_class", lambda _spec: lambda **_kwargs: executor)
+    monkeypatch.setattr(driver, "_build_os_env", lambda _spec, **_kwargs: object())
+    monkeypatch.setattr(driver_subject, "resolve_active_rust_toolchain", lambda *_a, **_k: None)
+    monkeypatch.setattr(driver_subject, "_OmnigentMCPTools", MCPFactory)
+    monkeypatch.setattr(
+        driver_subject,
+        "_build_os_tools",
+        lambda *_args, **_kwargs: driver_subject._OwnedOSTools(  # noqa: SLF001
+            schemas=[],
+            dispatch=lambda *_args: None,
+            environments=(resource,),
+        ),
+    )
+    run_calls = 0
+
+    def interrupt_first(awaitable: Any) -> Any:  # noqa: ANN401
+        nonlocal run_calls
+        run_calls += 1
+        if run_calls == 1:
+            awaitable.close()
+            raise KeyboardInterrupt
+        return asyncio.run(awaitable)
+
+    monkeypatch.setattr(driver, "run_awaitable", interrupt_first)
+
+    with pytest.raises(KeyboardInterrupt):
+        driver._build_executor(  # noqa: SLF001
+            _spec(tmp_path, mcp_servers=(MCPServerSpec("profiler", "python"),))
+        )
+
+    assert mcp_tools.close_calls == 1
+    assert executor.close_calls == 1
+    assert resource.close_calls == 1
+    driver.close()

--- a/tests/agents/drivers/test_omnigent_mcp.py
+++ b/tests/agents/drivers/test_omnigent_mcp.py
@@ -1,0 +1,372 @@
+"""Contract tests for VibeSys's native Omnigent MCP adapter."""
+
+# ruff: noqa: TRY003
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, ClassVar
+
+import pytest
+
+from vibesys.agents.contracts import MCPServerSpec
+from vibesys.agents.drivers import _omnigent_mcp as subject
+from vibesys.agents.drivers._omnigent_mcp import OmnigentMCPError, OmnigentMCPTools
+
+
+@dataclass
+class _FakeMCPServerConfig:
+    name: str
+    transport: str
+    command: str
+    args: list[str]
+    env: dict[str, str]
+
+
+@dataclass
+class _FakeAgentSpec:
+    spec_version: int
+    name: str
+    executor: _FakeExecutorSpec
+    mcp_servers: list[_FakeMCPServerConfig]
+
+
+@dataclass
+class _FakeExecutorSpec:
+    config: dict[str, Any]
+
+
+class _FakeManager:
+    instances: ClassVar[list[_FakeManager]] = []
+    schemas: ClassVar[list[dict[str, Any]]] = [
+        {
+            "type": "function",
+            "name": "profiler__analyze",
+            "description": "Analyze a profile",
+            "parameters": {"type": "object"},
+        }
+    ]
+    tool_names: ClassVar[set[str]] = {"profiler__analyze"}
+    failures: ClassVar[dict[str, str]] = {}
+
+    def __init__(self, *, stdio_cwd: Any) -> None:  # noqa: ANN401
+        self.stdio_cwd = stdio_cwd
+        self.specs: list[_FakeAgentSpec] = []
+        self.calls: list[tuple[Any, ...]] = []
+        self.shutdown_calls = 0
+        self.instances.append(self)
+
+    async def schemas_for(self, spec: _FakeAgentSpec) -> Any:  # noqa: ANN401
+        self.specs.append(spec)
+        return SimpleNamespace(
+            schemas=list(self.schemas),
+            tool_names=set(self.tool_names),
+            failures=dict(self.failures),
+        )
+
+    async def call_tool(
+        self,
+        spec: _FakeAgentSpec,
+        name: str,
+        arguments: dict[str, Any],
+        *,
+        session_id: str | None,
+    ) -> str:
+        self.calls.append((spec, name, arguments, session_id))
+        return "profile result"
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+@pytest.fixture(autouse=True)
+def fake_native_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeManager.instances.clear()
+    _FakeManager.schemas = [
+        {
+            "type": "function",
+            "name": "profiler__analyze",
+            "description": "Analyze a profile",
+            "parameters": {"type": "object"},
+        }
+    ]
+    _FakeManager.tool_names = {"profiler__analyze"}
+    _FakeManager.failures = {}
+    monkeypatch.setattr(
+        subject,
+        "_native_mcp_api",
+        lambda: subject._NativeMCPAPI(  # noqa: SLF001
+            agent_spec=_FakeAgentSpec,
+            executor_spec=_FakeExecutorSpec,
+            server_config=_FakeMCPServerConfig,
+            manager=_FakeManager,
+            validate=lambda _spec: SimpleNamespace(valid=True, errors=[]),
+        ),
+    )
+
+
+def _servers() -> tuple[MCPServerSpec, ...]:
+    return (
+        MCPServerSpec(
+            name="profiler",
+            command="python",
+            args=("-m", "vibesys.macos_cpu_profiler"),
+            env=(("PROFILE_DIR", "/profiles"),),
+        ),
+        MCPServerSpec(
+            name="issues",
+            command="uvx",
+            args=("issue-board", "serve"),
+            env=(("BOARD", "local"),),
+        ),
+    )
+
+
+def test_create_translates_multiple_servers_and_preserves_native_schemas(tmp_path) -> None:  # noqa: ANN001
+    tools = asyncio.run(
+        OmnigentMCPTools.create(
+            servers=_servers(),
+            workspace=tmp_path,
+            harness="codex",
+            session_id=lambda: "session-1",
+        )
+    )
+
+    assert tools is not None
+    manager = _FakeManager.instances[0]
+    assert manager.stdio_cwd == tmp_path
+    assert manager.specs[0].mcp_servers == [
+        _FakeMCPServerConfig(
+            name="profiler",
+            transport="stdio",
+            command=sys.executable,
+            args=["-m", "vibesys.macos_cpu_profiler"],
+            env={"PROFILE_DIR": "/profiles"},
+        ),
+        _FakeMCPServerConfig(
+            name="issues",
+            transport="stdio",
+            command="uvx",
+            args=["issue-board", "serve"],
+            env={"BOARD": "local"},
+        ),
+    ]
+    assert tools.schemas == _FakeManager.schemas
+    assert tools.handles("profiler__analyze")
+    assert not tools.handles("sys_os_read")
+
+
+def test_dispatch_uses_native_manager_and_current_provider_session_id(tmp_path) -> None:  # noqa: ANN001
+    session_id = ["provider-session-1"]
+    tools = asyncio.run(
+        OmnigentMCPTools.create(
+            servers=_servers()[:1],
+            workspace=tmp_path,
+            harness="claude-sdk",
+            session_id=lambda: session_id[0],
+        )
+    )
+    assert tools is not None
+    session_id[0] = "provider-session-2"
+
+    result = asyncio.run(tools.dispatch("profiler__analyze", {"pid": 42}))
+
+    manager = _FakeManager.instances[0]
+    assert result == "profile result"
+    assert manager.calls == [
+        (manager.specs[0], "profiler__analyze", {"pid": 42}, "provider-session-2")
+    ]
+
+
+def test_connection_failure_closes_manager_without_exposing_server_environment(tmp_path) -> None:  # noqa: ANN001
+    _FakeManager.failures = {"profiler": "connection refused"}
+    sensitive_value = "must-not-appear"
+    server = MCPServerSpec(
+        name="profiler",
+        command="server",
+        env=(("API_TOKEN", sensitive_value),),
+    )
+
+    with pytest.raises(OmnigentMCPError, match="profiler: connection refused") as caught:
+        asyncio.run(
+            OmnigentMCPTools.create(
+                servers=(server,),
+                workspace=tmp_path,
+                harness="codex",
+                session_id=lambda: None,
+            )
+        )
+
+    assert sensitive_value not in str(caught.value)
+    assert _FakeManager.instances[0].shutdown_calls == 1
+
+
+def test_cancelled_discovery_closes_manager(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ANN001
+    started = asyncio.Event()
+
+    class BlockingManager(_FakeManager):
+        async def schemas_for(self, spec: _FakeAgentSpec) -> Any:  # noqa: ANN401
+            self.specs.append(spec)
+            started.set()
+            await asyncio.Future()
+
+    monkeypatch.setattr(
+        subject,
+        "_native_mcp_api",
+        lambda: subject._NativeMCPAPI(  # noqa: SLF001
+            agent_spec=_FakeAgentSpec,
+            executor_spec=_FakeExecutorSpec,
+            server_config=_FakeMCPServerConfig,
+            manager=BlockingManager,
+            validate=lambda _spec: SimpleNamespace(valid=True, errors=[]),
+        ),
+    )
+
+    async def cancel_setup() -> None:
+        setup = asyncio.create_task(
+            OmnigentMCPTools.create(
+                servers=_servers()[:1],
+                workspace=tmp_path,
+                harness="codex",
+                session_id=lambda: None,
+            )
+        )
+        await started.wait()
+        setup.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await setup
+
+    asyncio.run(cancel_setup())
+
+    assert BlockingManager.instances[-1].shutdown_calls == 1
+
+
+def test_close_is_idempotent_and_closed_tools_cannot_dispatch(tmp_path) -> None:  # noqa: ANN001
+    async def exercise() -> tuple[OmnigentMCPTools, _FakeManager]:
+        tools = await OmnigentMCPTools.create(
+            servers=_servers()[:1],
+            workspace=tmp_path,
+            harness="codex",
+            session_id=lambda: None,
+        )
+        assert tools is not None
+        manager = _FakeManager.instances[0]
+        await tools.close()
+        await tools.close()
+        return tools, manager
+
+    tools, manager = asyncio.run(exercise())
+
+    assert manager.shutdown_calls == 1
+    with pytest.raises(RuntimeError, match="closed"):
+        asyncio.run(tools.dispatch("profiler__analyze", {}))
+
+
+def test_duplicate_server_names_are_rejected_before_manager_creation(tmp_path) -> None:  # noqa: ANN001
+    duplicated = (
+        MCPServerSpec(name="same", command="one"),
+        MCPServerSpec(name="same", command="two"),
+    )
+
+    with pytest.raises(OmnigentMCPError, match="must be unique"):
+        asyncio.run(
+            OmnigentMCPTools.create(
+                servers=duplicated,
+                workspace=tmp_path,
+                harness="codex",
+                session_id=lambda: None,
+            )
+        )
+
+    assert _FakeManager.instances == []
+
+
+def test_native_validation_error_preserves_field_path_and_skips_connection(
+    tmp_path,  # noqa: ANN001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    validation_error = SimpleNamespace(
+        path="mcp_servers[0].name",
+        message="tool name 'sys_os_read' collides with a reserved builtin tool name",
+    )
+    monkeypatch.setattr(
+        subject,
+        "_native_mcp_api",
+        lambda: subject._NativeMCPAPI(  # noqa: SLF001
+            agent_spec=_FakeAgentSpec,
+            executor_spec=_FakeExecutorSpec,
+            server_config=_FakeMCPServerConfig,
+            manager=_FakeManager,
+            validate=lambda _spec: SimpleNamespace(valid=False, errors=[validation_error]),
+        ),
+    )
+
+    with pytest.raises(
+        OmnigentMCPError,
+        match=r"mcp_servers\[0\]\.name: tool name 'sys_os_read' collides",
+    ):
+        asyncio.run(
+            OmnigentMCPTools.create(
+                servers=(MCPServerSpec(name="sys_os_read", command="server"),),
+                workspace=tmp_path,
+                harness="codex",
+                session_id=lambda: None,
+            )
+        )
+
+    assert _FakeManager.instances == []
+
+
+def test_close_can_retry_after_shutdown_failure(tmp_path) -> None:  # noqa: ANN001
+    tools = asyncio.run(
+        OmnigentMCPTools.create(
+            servers=_servers()[:1],
+            workspace=tmp_path,
+            harness="codex",
+            session_id=lambda: None,
+        )
+    )
+    assert tools is not None
+    manager = _FakeManager.instances[0]
+    shutdown_attempts = 0
+
+    async def flaky_shutdown() -> None:
+        nonlocal shutdown_attempts
+        shutdown_attempts += 1
+        if shutdown_attempts == 1:
+            raise RuntimeError("cleanup failed")
+
+    manager.shutdown = flaky_shutdown
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        asyncio.run(tools.close())
+    asyncio.run(tools.close())
+
+    assert shutdown_attempts == 2
+
+
+def test_same_bare_tool_name_from_multiple_servers_stays_namespaced(tmp_path) -> None:  # noqa: ANN001
+    _FakeManager.schemas = [
+        {"type": "function", "name": "one__status", "parameters": {}},
+        {"type": "function", "name": "two__status", "parameters": {}},
+    ]
+    _FakeManager.tool_names = {"one__status", "two__status"}
+    servers = (
+        MCPServerSpec(name="one", command="server-one"),
+        MCPServerSpec(name="two", command="server-two"),
+    )
+
+    tools = asyncio.run(
+        OmnigentMCPTools.create(
+            servers=servers,
+            workspace=tmp_path,
+            harness="codex",
+            session_id=lambda: None,
+        )
+    )
+
+    assert tools is not None
+    assert [schema["name"] for schema in tools.schemas] == ["one__status", "two__status"]

--- a/tests/agents/test_agent_driver_selection.py
+++ b/tests/agents/test_agent_driver_selection.py
@@ -10,6 +10,7 @@ import pytest
 from vibesys.agents import build_agent_client
 from vibesys.agents.drivers.agentshim import AgentShimDriver
 from vibesys.agents.drivers.omnigent import OmnigentDriver, OmnigentDriverError
+from vibesys.agents.factory import agent_driver_supports_mcp_servers
 from vibesys.agents.omnigent import supported_providers
 from vibesys.agents.omnigent.providers import OMNIGENT_PROVIDER_EXECUTORS
 from vibesys.config import Config
@@ -69,6 +70,28 @@ def test_omnigent_driver_can_be_selected() -> None:
     client = _build(_config(driver="omnigent", backend="cli", cli_provider="claude"))
 
     assert isinstance(client._driver, OmnigentDriver)  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    ("driver", "supports_mcp"),
+    [(None, True), ("agentshim", True), ("omnigent", True)],
+)
+def test_preflight_capabilities_match_constructed_driver(
+    driver: str | None,
+    supports_mcp: object,
+) -> None:
+    config = _config(driver=driver, backend="cli", cli_provider="codex")
+    declared = agent_driver_supports_mcp_servers(config, agent_backend=None)
+    client = _build(config)
+
+    assert declared is supports_mcp
+    assert declared is client.capabilities.mcp_servers
+
+
+def test_non_cli_backend_has_no_external_driver_capabilities() -> None:
+    config = _config(backend="deepagents")
+
+    assert agent_driver_supports_mcp_servers(config, agent_backend=None) is None
 
 
 def test_omnigent_selection_passes_model_and_log_dir(tmp_path) -> None:  # noqa: ANN001

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -575,6 +575,38 @@ def test_direct_run_rejects_unmaterialized_workspace_source(tmp_path):  # noqa: 
         )
 
 
+def test_omnigent_accepts_active_profiler_configuration(tmp_path):  # noqa: ANN001, ANN201
+    project = tmp_path / "queue"
+    evaluator = _write_project(project)
+    configuration = _configuration().model_copy(
+        update={
+            "agent_backend": "cli",
+            "agent_driver": "omnigent",
+            "cli_provider": "codex",
+            "profiler": "macos_cpu",
+        }
+    )
+
+    with create_run_context(
+        config={  # pyright: ignore[reportArgumentType]
+            "model": {"name": "gpt-test"},
+            "agent": {"backend": "cli", "driver": "omnigent", "cli_provider": "codex"},
+        },
+        exp_name="queue",
+        runs_dir=None,
+        input_path=str(project),
+        accuracy_command="python _evaluator/checker/check.py",
+        benchmark_command="python _evaluator/checker/check.py",
+        evaluator_path=evaluator,
+        project_configuration=configuration,
+        profiler_kind=ProfilerKind.MACOS_CPU,
+        profiler_domain=DomainName.GENERIC,
+        run_environment=RunEnvironmentSpec("local"),
+        active_state_model_type=ActiveHypothesis,
+    ) as context:
+        assert context.profiler_kind is ProfilerKind.MACOS_CPU
+
+
 def test_portable_state_snapshot_replaces_namespace_exactly(tmp_path):  # noqa: ANN001, ANN201
     project = tmp_path / "queue"
     evaluator = _write_project(project)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -19,6 +19,15 @@ def test_tee_logger_owns_and_restores_stderr(tmp_path):  # noqa: ANN001, ANN201 
     assert "diagnostic" in logger.path.read_text()
 
 
+def test_tee_logger_preserves_real_stderr_file_descriptor(tmp_path):  # noqa: ANN001, ANN201
+    original = sys.stderr
+    logger = RunLogger(tmp_path)
+    try:
+        assert sys.stderr.fileno() == original.fileno()
+    finally:
+        logger.close()
+
+
 def test_no_tee_logger_leaves_stderr_untouched(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     original = sys.stderr
     logger = RunLogger(tmp_path, tee_stderr=False)


### PR DESCRIPTION
## Problem

VibeSys rejected every Omnigent session MCP server even though the pinned Omnigent 0.10.0 library supports native stdio MCP discovery and dispatch. On macOS this blocked the default CPU profiler and stranded existing Omnigent runs at resume-time capability validation.

The first end-to-end pass also found that VibeSys's stderr tee did not preserve `fileno()`, so Omnigent's native stdio launcher could not start an MCP subprocess while the normal TUI run logger was active.

Fixes #428.

## Solution

Add a focused Omnigent MCP adapter that translates neutral VibeSys `MCPServerSpec` values into validated native `AgentSpec` and `MCPServerConfig` values. Each agent session owns one `RunnerMcpManager`, its discovered namespaced schemas, dispatch routing, and deterministic shutdown.

The adapter:

- supports multiple stdio servers and preserves explicit environment overlays;
- normalizes `python` and `python3` to the active VibeSys interpreter;
- routes only exact discovered MCP or declared OS tool names;
- forwards the current provider session ID to native MCP calls;
- redacts configured environment values from diagnostics;
- allocates ownership before asynchronous discovery, then cancels and drains interrupted initialization;
- closes native connections and subprocesses on setup failure, cancellation, session close, and driver shutdown.

Omnigent now advertises MCP support through the shared capability contract, so active profilers pass preflight validation. The stderr tee delegates `fileno()` to its primary stream, preserving the standard stream contract required by subprocess launchers.

Generated Omnigent specs configure no guardrails. VibeSys remains responsible for authorizing the session server set. Native stdio MCP subprocesses are trusted framework configuration and run outside the agent OS-tool sandbox, matching Omnigent 0.10 semantics.

### Architecture

```mermaid
flowchart LR
  S[VibeSys session MCP specs] --> A[Omnigent MCP adapter]
  A --> V[Validated AgentSpec and MCPServerConfig]
  V --> M[Session-owned RunnerMcpManager]
  M --> D[Namespaced schema discovery]
  D --> R[Exact MCP or OS tool router]
  R --> E[Claude SDK or Codex executor]
  C[Session close or setup cancellation] --> M
```

## Verification

The exact `vibesys --resume --max-rounds 6` command in queue-rs passed capability validation and completed round 6 successfully. During E2E, the profiler reached native MCP startup, which exposed the stderr tee regression. After fixing it, a real native smoke test with the normal `RunLogger` active discovered the macOS profiler tools, invoked `capabilities`, selected `sample`, and shut down cleanly.

The editable local tool was refreshed with `uv tool install --editable '.[omnigent]' --force`.

### Correctness properties

- Driver preflight and runtime capabilities agree that Omnigent supports session MCP servers.
- Provider-independent MCP declarations are translated once at the Omnigent boundary.
- Only discovered namespaced MCP tools and declared OS tools can be dispatched.
- One session owns one native manager and all of its MCP subprocesses.
- Initialization is cancel-and-drain safe, including synchronous caller interruption.
- Cleanup is best-effort across executor, MCP, and OS resources while preserving the primary failure.
- Configured environment values are not exposed by adapter diagnostics.
- Both Claude and Codex receive the correct native harness and merged tool schemas.
- Existing persisted Omnigent profiler configuration resumes without mutation.
- The TUI stderr tee remains usable as a real subprocess stderr target.

### Testing

- `uv run pytest tests/agents/drivers/test_omnigent_mcp.py tests/agents/drivers/test_omnigent_driver.py tests/agents/test_agent_driver_selection.py tests/test_context.py -q` (94 passed)
- `uv run pytest tests/agents tests/test_context.py tests/test_tui.py tests/test_logger.py -q` (404 passed)
- `./scripts/check_format.sh` (414 files already formatted)
- `./scripts/check_lint.sh` (passed)
- `uv run python scripts/check_doc_links.py` (315 Markdown files checked)
- Targeted Pyright over changed Python and tests (0 errors)
- `git diff --check` (passed)
- Real Omnigent 0.10 macOS profiler discovery, `capabilities` call, and shutdown with `RunLogger` active (passed)
- queue-rs `vibesys --resume --max-rounds 6` (round 6 completed, +4.0%, proven)

Full-repo `./scripts/check_types.sh` still reports the existing macOS-only `os.O_PATH` typing error in `libs/vs-sandbox/src/vs_sandbox/landlock.py:361`; changed-file Pyright is clean.
