### PR TITLE
Make TUI error banners dismissible

### DIFF
--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -556,6 +556,12 @@ describe('session controller', () => {
     await controller.submit('/experiments');
     expect(controller.state.errorBanner?.message).toContain('Unknown command: /experiments');
 
+    controller.dismissErrorBanner();
+    expect(controller.state.errorBanner).toBeNull();
+
+    await controller.submit('/history');
+    expect(controller.state.errorBanner?.message).toContain('Unknown command: /history');
+
     expect(transport.requests).toEqual([]);
   });
 

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -15,6 +15,7 @@ import {
   closePane,
   closeThemePicker,
   cyclePaneFocus,
+  dismissErrorBanner,
   enterExperimentDrilldown,
   enterExperimentRound,
   enterUnownedExperimentRound,
@@ -86,6 +87,7 @@ export interface SessionController {
   openPane(view: PaneView): Promise<void>;
   closePane(): void;
   closeOverlays(): void;
+  dismissErrorBanner(): void;
   cyclePaneFocus(): void;
   focusPane(focus: PaneFocus): void;
   togglePaneZoom(): void;
@@ -312,6 +314,10 @@ export class SocketSessionController implements SessionController {
 
   closeOverlays(): void {
     this.#setState(closeOverlays(this.#state));
+  }
+
+  dismissErrorBanner(): void {
+    this.#setState(dismissErrorBanner(this.#state));
   }
 
   cyclePaneFocus(): void {

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -9,6 +9,7 @@ import {
   closePane,
   closeThemePicker,
   cyclePaneFocus,
+  dismissErrorBanner,
   enterExperimentDrilldown,
   enterExperimentRound,
   enterUnownedExperimentRound,
@@ -25,6 +26,7 @@ import {
   openChat,
   openPane,
   openThemePicker,
+  reportError,
   selectExperimentActivity,
   selectNextAgent,
   selectNextRound,
@@ -597,6 +599,20 @@ describe('session event model', () => {
       severity: 'fatal',
       count: 2,
     });
+  });
+
+  it('dismisses an error without changing session state or suppressing later errors', () => {
+    const state = reportError({...initialSessionState(), selectedRound: 2}, 'The request failed.', {
+      scope: 'request',
+    });
+    const dismissed = dismissErrorBanner(state);
+
+    expect(dismissed.errorBanner).toBeNull();
+    expect(dismissed.selectedRound).toBe(2);
+    expect(dismissErrorBanner(dismissed)).toBe(dismissed);
+    expect(
+      reportError(dismissed, 'A later failure.', {scope: 'transport'}).errorBanner,
+    ).toMatchObject({message: 'A later failure.', scope: 'transport'});
   });
 
   it('prefers structured diagnostics and deduplicates their ids across terminal events', () => {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -1317,6 +1317,12 @@ export interface ErrorReport {
   invocationId?: string | null;
 }
 
+/** Acknowledges the visible diagnostic without changing any run or view state. */
+export function dismissErrorBanner(state: SessionState): SessionState {
+  if (state.errorBanner === null) return state;
+  return {...state, errorBanner: null};
+}
+
 /**
  * Records an error independently of any particular view. A terminal event
  * commonly repeats an invocation failure, so equivalent reports promote the

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -10,6 +10,7 @@ import {
   closePane,
   closeThemePicker,
   cyclePaneFocus,
+  dismissErrorBanner,
   enterExperimentDrilldown,
   enterExperimentRound,
   enterUnownedExperimentRound,
@@ -88,30 +89,32 @@ describe('OpenTUI presentation', () => {
     expect(frame).toContain('Type a question or /help');
   });
 
-  it('keeps a fatal error visible above the empty experiment log', async () => {
+  it('shows and dismisses a fatal error above the empty experiment log', async () => {
     const testRenderer = await createTestRenderer({width: 100, height: 24});
     const controller = new FakeController(initialSessionState());
     const app = createOpenTuiApp(testRenderer.renderer, controller);
     registerCleanup(testRenderer.renderer, app);
+    await controller.openPane('perf');
+    const fatalBanner: NonNullable<SessionState['errorBanner']> = {
+      title: 'Run failed',
+      message: 'RuntimeError: app-server initialization was denied\nOperation not permitted',
+      detail: 'The run server exited before accepting a client.',
+      hint: 'Check the startup log and retry.',
+      diagnosticId: 'diagnostic-1',
+      severity: 'fatal',
+      scope: 'run',
+      agentKind: 'orchestrator',
+      roundLabel: 'round-1-pre',
+      invocationId: null,
+      count: 1,
+    };
     controller.publish({
       ...controller.state,
       experimentLog: {entries: [], selectedId: null, pending: false, error: null},
-      errorBanner: {
-        title: 'Run failed',
-        message: 'RuntimeError: app-server initialization was denied\nOperation not permitted',
-        detail: 'The run server exited before accepting a client.',
-        hint: 'Check the startup log and retry.',
-        diagnosticId: 'diagnostic-1',
-        severity: 'fatal',
-        scope: 'run',
-        agentKind: 'orchestrator',
-        roundLabel: 'round-1-pre',
-        invocationId: null,
-        count: 1,
-      },
+      errorBanner: fatalBanner,
     });
 
-    const frame = await testRenderer.waitForFrame(value =>
+    let frame = await testRenderer.waitForFrame(value =>
       value.includes('app-server initialization was denied'),
     );
     expect(frame).toContain('Run failed · orchestrator · round-1-pre');
@@ -120,7 +123,29 @@ describe('OpenTUI presentation', () => {
     expect(frame).toContain('Hint: Check the startup log and retry.');
     expect(frame).toContain('Experiments');
 
-    expect(frame).toContain('Ctrl+PgUp/PgDn: scroll');
+    expect(frame).toContain('[× Dismiss] · Esc: dismiss · Ctrl+PgUp/PgDn: scroll');
+
+    const lines = frame.split('\n');
+    const row = lines.findIndex(line => line.includes('[× Dismiss]'));
+    const column = (lines[row]?.indexOf('[× Dismiss]') ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
+    frame = await frameAfter(testRenderer);
+    expect(controller.state.errorBanner).toBeNull();
+    expect(frame).not.toContain('app-server initialization was denied');
+    expect(frame).toContain('Experiments');
+
+    controller.publish({
+      ...controller.state,
+      errorBanner: {...fatalBanner, title: 'Request failed', message: 'A later failure.'},
+    });
+    frame = await testRenderer.waitForFrame(value => value.includes('A later failure.'));
+    expect(frame).toContain('Esc: dismiss');
+
+    testRenderer.mockInput.pressKey('ESCAPE');
+    frame = await frameAfterEscape(testRenderer);
+    expect(controller.state.errorBanner).toBeNull();
+    expect(controller.state.layout.right?.view).toBe('perf');
+    expect(frame).not.toContain('A later failure.');
   });
 
   it('renders quiet round labels without status text or symbols', async () => {
@@ -2988,6 +3013,9 @@ class FakeController implements SessionController {
   }
   closeOverlays(): void {
     this.publish(closeOverlays(this.state));
+  }
+  dismissErrorBanner(): void {
+    this.publish(dismissErrorBanner(this.state));
   }
   cyclePaneFocus(): void {
     this.publish(cyclePaneFocus(this.state));

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -134,7 +134,7 @@ export function createOpenTuiApp(
   let markdownStyle = createMarkdownStyle(theme);
   const roundStrip = new RoundStripView(renderer, controller, theme);
   const todoStrip = new TodoStripView(renderer, controller, theme);
-  const errorBanner = new ErrorBannerView(renderer, theme);
+  const errorBanner = new ErrorBannerView(renderer, theme, () => controller.dismissErrorBanner());
   const agentMap = new AgentMapView(renderer, controller, theme);
   const conversationActivityBar = new ActivityBarView(renderer, theme, 'conversation-activity-bar');
   const overlay = new OverlayView(renderer, theme);

--- a/clients/tui/src/ui/error-banner.ts
+++ b/clients/tui/src/ui/error-banner.ts
@@ -13,7 +13,8 @@ function context(banner: ErrorBannerState): string {
 
 /**
  * A single, always-rooted, fixed-height error surface. It does not take input
- * focus, while Ctrl+PgUp/Ctrl+PgDn scroll a long diagnostic.
+ * focus. Its footer owns explicit pointer dismissal, while global keybindings
+ * own Escape and Ctrl+PgUp/Ctrl+PgDn.
  */
 export class ErrorBannerView {
   readonly output: BoxRenderable;
@@ -24,6 +25,7 @@ export class ErrorBannerView {
   constructor(
     private readonly renderer: CliRenderer,
     theme: Theme,
+    private readonly onDismiss: () => void,
   ) {
     this.#theme = theme;
     this.output = new BoxRenderable(renderer, {
@@ -79,7 +81,7 @@ export class ErrorBannerView {
   #renderContent(banner: ErrorBannerState): void {
     const where = context(banner);
     const count = banner.count > 1 ? ` · ${banner.count} reports` : '';
-    this.output.title = ` × ${banner.title}${where ? ` · ${where}` : ''}${count} `;
+    this.output.title = ` ${banner.title}${where ? ` · ${where}` : ''}${count} `;
     this.output.add(this.#scroll);
     this.#scroll.add(
       new TextRenderable(this.renderer, {
@@ -114,12 +116,13 @@ export class ErrorBannerView {
     }
     this.output.add(
       new TextRenderable(this.renderer, {
-        content: 'Ctrl+PgUp/PgDn: scroll',
+        content: '[× Dismiss] · Esc: dismiss · Ctrl+PgUp/PgDn: scroll',
         fg: this.#theme.textSubtle,
         width: '100%',
         height: 1,
         wrapMode: 'none',
         truncate: true,
+        onMouseUp: this.onDismiss,
       }),
     );
     this.#scroll.scrollTo(0);

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -60,6 +60,13 @@ export function bindKeybindings(
       key.preventDefault();
       return;
     }
+    // The fixed error surface is the topmost global layer. Escape acknowledges
+    // it first; a second Escape can then act on the pane or dialog underneath.
+    if (controller.state.errorBanner !== null && key.name === 'escape') {
+      controller.dismissErrorBanner();
+      key.preventDefault();
+      return;
+    }
     // Pane switching works from anywhere a second column is on screen, which
     // on the landing view includes the docked chat, so the operator never has
     // to leave the table to scroll back through an answer.


### PR DESCRIPTION
## Problem

A root-level TUI error banner remained visible for the rest of the session after any recoverable or fatal diagnostic. It permanently consumed ten rows, and its decorative `×` suggested a clickable close action even though the title was not interactive. Restarting the TUI was the only way to remove it.

Fixes #440.

## Solution

Add one idempotent `dismissErrorBanner()` transition to the session model and expose it through the session controller. Remove the misleading `×` from the non-interactive box title. The banner footer now contains the explicit clickable `[× Dismiss]` target and advertises Escape. Global key routing gives a visible error banner first use of Escape, so one keypress acknowledges it without modifying the pane or dialog underneath.

Dismissal clears only the currently presented banner. It does not suppress future diagnostics, alter terminal failure state, or discard transcript, hypothesis, pane, chat, or run state.

### Architecture

```mermaid
flowchart LR
  K[Escape] --> C[SessionController.dismissErrorBanner]
  P[Click Dismiss footer] --> C
  C --> M[Pure model transition]
  M --> S[errorBanner = null]
  S --> V[ErrorBannerView hidden]
  E[Later error event] --> R[reportError]
  R --> V
```

## Verification

Model coverage verifies idempotence, preservation of unrelated state, and later error reporting. Controller coverage verifies command errors can be dismissed and reported again. Renderer-level tests use real keyboard and mouse coordinates to dismiss fatal and subsequent banners while preserving an open performance pane.

### Correctness properties

- Dismissal changes only `SessionState.errorBanner`.
- Dismissal is idempotent when no banner is visible.
- Escape dismisses the visible banner before acting on an underlying pane.
- The explicit footer target is pointer-clickable; the box title has no false close affordance.
- Fatal run state and diagnostics in the transcript remain intact.
- A later error displays normally after dismissal.

### Testing

- `pnpm --dir clients/tui check` (passed)
- `pnpm --dir clients/tui test` (386 passed, 0 failed)
- Focused model, controller, and renderer tests (213 passed, 0 failed)
- `./scripts/format.sh` (passed)
- `./scripts/check_format.sh` (passed)
- `pnpm --dir clients/tui exec biome check src` (passed)
- `git diff --check` (passed)
