### PR TITLE
Separate TUI command and chat submission

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -18,8 +18,8 @@ the Python `vibesys` package in the Python environment you want to use, or set
 
 ## Operator interface
 
-Enter ordinary text to ask the supervision backend about the current run. The
-available slash commands are:
+Use Experiment chat for ordinary questions about the current run. The command
+input accepts these slash commands:
 
 | Command | Behavior |
 | --- | --- |
@@ -90,13 +90,11 @@ list rises out of the command input rather than across the chat.
 The cursor starts in the command input, and `Ctrl+W` moves both it and the pane
 keys to the chat and back; the chat's instruction line says so (`Ctrl+W to type
 here`) until it holds them, and the focused input carries the focus border, so
-where a keystroke lands is never a guess. A question typed into either box
-reaches the same agent and is answered in the same column. Page Up and Page Down scroll the focused pane, and
+where a keystroke lands is never a guess. Only the chat composer accepts
+ordinary questions; the command input accepts slash commands. Page Up and Page Down scroll the focused pane, and
 Escape hands the keys back to the table. Arrows, Enter, and the rest of the
 table's keys are unaffected by the dock. A slash command typed into the chat
-input runs through the same path as anywhere else, and ordinary text typed into
-the command input is still a question for the agent: the two boxes are a
-division of attention, not of capability.
+input runs through the same command path as the command box.
 
 `/chat` leaves the command surface on this view, since the chat is already
 beside the table: it is absent from `/help` and from the completions, though it

--- a/clients/tui/src/commands.test.ts
+++ b/clients/tui/src/commands.test.ts
@@ -2,89 +2,89 @@ import {describe, expect, it} from 'bun:test';
 import {
   availableCommands,
   helpText,
-  parseInput,
+  parseCommand,
   slashCommandRange,
   suggestSlashCommands,
 } from './commands.js';
 
-describe('parseInput', () => {
+describe('parseCommand', () => {
   it('accepts the intentionally small slash-command surface', () => {
-    expect(parseInput('/open-round')).toEqual({openRound: {}});
-    expect(parseInput('/open-round --3')).toEqual({openRound: {round: 3}});
-    expect(parseInput('/open-round 3')).toEqual({openRound: {round: 3}});
-    expect(parseInput('/open-round latest').error).toContain('Unknown round: latest');
+    expect(parseCommand('/open-round')).toEqual({openRound: {}});
+    expect(parseCommand('/open-round --3')).toEqual({openRound: {round: 3}});
+    expect(parseCommand('/open-round 3')).toEqual({openRound: {round: 3}});
+    expect(parseCommand('/open-round latest').error).toContain('Unknown round: latest');
     // Visualization commands opt into the right pane through one field.
-    expect(parseInput('/perf')).toMatchObject({
+    expect(parseCommand('/perf')).toMatchObject({
       request: {type: 'query.performance'},
       paneView: 'perf',
     });
     // Modal surfaces stay modal: no pane routing on any of them.
-    expect(parseInput('/help').paneView).toBeUndefined();
-    expect(parseInput('/theme').paneView).toBeUndefined();
-    expect(parseInput('/chat').paneView).toBeUndefined();
-    expect(parseInput('/nope').paneView).toBeUndefined();
-    expect(parseInput('/perf')).toMatchObject({
+    expect(parseCommand('/help').paneView).toBeUndefined();
+    expect(parseCommand('/theme').paneView).toBeUndefined();
+    expect(parseCommand('/chat').paneView).toBeUndefined();
+    expect(parseCommand('/nope').paneView).toBeUndefined();
+    expect(parseCommand('/perf')).toMatchObject({
       request: {type: 'query.performance'},
       responseView: 'perf',
     });
-    expect(parseInput('/chat what changed in the latest round?')).toEqual({
+    expect(parseCommand('/chat what changed in the latest round?')).toEqual({
       localView: 'chat',
       chatMessage: 'what changed in the latest round?',
     });
   });
 
   it('parses run-control commands', () => {
-    expect(parseInput('/pause')).toEqual({request: {type: 'command.pause'}});
-    expect(parseInput('/resume')).toEqual({request: {type: 'command.resume'}});
-    expect(parseInput('/steer prioritize the KV cache path')).toEqual({
+    expect(parseCommand('/pause')).toEqual({request: {type: 'command.pause'}});
+    expect(parseCommand('/resume')).toEqual({request: {type: 'command.resume'}});
+    expect(parseCommand('/steer prioritize the KV cache path')).toEqual({
       request: {type: 'command.steer', text: 'prioritize the KV cache path'},
     });
   });
 
   it('requires a message for /steer', () => {
-    expect(parseInput('/steer').error).toContain('Usage: /steer');
-    expect(parseInput('/steer   ').error).toContain('Usage: /steer');
+    expect(parseCommand('/steer').error).toContain('Usage: /steer');
+    expect(parseCommand('/steer   ').error).toContain('Usage: /steer');
   });
 
-  it('sends ordinary text to the supervision chat endpoint', () => {
-    expect(parseInput('what is happening?')).toEqual({
-      request: {type: 'query.chat', text: 'what is happening?'},
+  it('rejects text that belongs to Experiment chat', () => {
+    expect(parseCommand('what is happening?')).toEqual({
+      error: 'Commands start with /. Use Experiment chat for questions.',
     });
-    expect(parseInput('')).toEqual({error: 'Enter a question or use /help.'});
+    expect(parseCommand('')).toEqual({error: 'Enter a slash command. Use /help.'});
   });
 
   it('rejects the removed experiment-log commands', () => {
-    expect(parseInput('/history').error).toContain('Unknown command: /history');
-    expect(parseInput('/history rounds').error).toContain('Unknown command: /history rounds');
-    expect(parseInput('/experiments').error).toContain('Unknown command: /experiments');
+    expect(parseCommand('/history').error).toContain('Unknown command: /history');
+    expect(parseCommand('/history rounds').error).toContain('Unknown command: /history rounds');
+    expect(parseCommand('/experiments').error).toContain('Unknown command: /experiments');
   });
 
   it('keeps inspection commands out of the public command surface', () => {
-    expect(parseInput('/round 4').error).toContain('Unknown command');
-    expect(parseInput('/invocation abc').error).toContain('Unknown command');
-    expect(parseInput('/show workspace/file').error).toContain('Unknown command');
+    expect(parseCommand('/round 4').error).toContain('Unknown command');
+    expect(parseCommand('/invocation abc').error).toContain('Unknown command');
+    expect(parseCommand('/show workspace/file').error).toContain('Unknown command');
   });
 
   it('provides local help without a backend request', () => {
-    expect(parseInput('/help')).toEqual({localView: 'help'});
+    expect(parseCommand('/help')).toEqual({localView: 'help'});
   });
 
   it('opens chat without requiring an initial question', () => {
-    expect(parseInput('/chat')).toEqual({localView: 'chat'});
-    expect(parseInput('/chat   ')).toEqual({localView: 'chat'});
+    expect(parseCommand('/chat')).toEqual({localView: 'chat'});
+    expect(parseCommand('/chat   ')).toEqual({localView: 'chat'});
   });
 
   it('lists themes bare and selects a known theme by name', () => {
-    expect(parseInput('/theme')).toEqual({localView: 'theme'});
-    expect(parseInput('/theme   ')).toEqual({localView: 'theme'});
-    expect(parseInput('/theme solarized-light')).toEqual({
+    expect(parseCommand('/theme')).toEqual({localView: 'theme'});
+    expect(parseCommand('/theme   ')).toEqual({localView: 'theme'});
+    expect(parseCommand('/theme solarized-light')).toEqual({
       localView: 'theme',
       themeName: 'solarized-light',
     });
   });
 
   it('rejects an unknown theme name with the available list', () => {
-    const parsed = parseInput('/theme monokai');
+    const parsed = parseCommand('/theme monokai');
     expect(parsed.error).toContain('Unknown theme: monokai');
     expect(parsed.error).toContain('catppuccin-mocha');
     expect(parsed.localView).toBeUndefined();
@@ -110,13 +110,13 @@ describe('command surface by view', () => {
   it('reaches the todo and prompt toggles by name', () => {
     // macOS keeps the function keys for itself and a terminal may keep a
     // Control chord, so both toggles have to be reachable without either.
-    expect(parseInput('/todos')).toEqual({toggle: 'todos'});
-    expect(parseInput('/prompt')).toEqual({toggle: 'prompt'});
+    expect(parseCommand('/todos')).toEqual({toggle: 'todos'});
+    expect(parseCommand('/prompt')).toEqual({toggle: 'prompt'});
   });
 
   it('still accepts /chat when it is not offered, since the chat is the point', () => {
     // Hidden from the list, not removed from the client.
-    expect(parseInput('/chat')).toEqual({localView: 'chat'});
+    expect(parseCommand('/chat')).toEqual({localView: 'chat'});
   });
 });
 

--- a/clients/tui/src/commands.ts
+++ b/clients/tui/src/commands.ts
@@ -2,7 +2,9 @@ import type {RequestInput} from './protocol.js';
 import type {PaneView} from './session-model.js';
 import {isThemeName, THEME_NAMES, type ThemeName} from './ui/theme.js';
 
-export type ParsedInput = {
+type CommandRequest = Exclude<RequestInput, {type: 'query.chat'}>;
+
+export type ParsedCommand = {
   localView?: 'chat' | 'help' | 'theme';
   /**
    * Surfaces that also have a key. macOS reserves the function keys for system
@@ -12,7 +14,7 @@ export type ParsedInput = {
   toggle?: 'todos' | 'prompt';
   chatMessage?: string;
   themeName?: ThemeName;
-  request?: RequestInput;
+  request?: CommandRequest;
   responseView?: 'perf';
   /** Opens a hypothesis trajectory: the selected row, or the given round. */
   openRound?: {round?: number};
@@ -88,7 +90,8 @@ export function slashCommandRange(text: string): {start: number; end: number} | 
   return {start: 0, end: match[0].length};
 }
 
-export function parseInput(text: string): ParsedInput {
+/** Parses the command surface. Ordinary questions belong to Experiment chat. */
+export function parseCommand(text: string): ParsedCommand {
   if (text === '/help') return {localView: 'help'};
   const chat = text.match(/^\/chat(?:\s+(.*))?$/);
   if (chat) {
@@ -130,6 +133,6 @@ export function parseInput(text: string): ParsedInput {
     return {request: {type: 'query.performance'}, responseView: 'perf', paneView: 'perf'};
   }
   if (text.startsWith('/')) return {error: `Unknown command: ${text}. Use /help.`};
-  if (text === '') return {error: 'Enter a question or use /help.'};
-  return {request: {type: 'query.chat', text}};
+  if (text === '') return {error: 'Enter a slash command. Use /help.'};
+  return {error: 'Commands start with /. Use Experiment chat for questions.'};
 }

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -9,7 +9,7 @@ describe('session controller', () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
 
-    await controller.submit('/help');
+    await controller.submitCommand('/help');
 
     expect(controller.state.overlay?.kind).toBe('help');
     expect(controller.state.overlay?.content).toContain('/open-round');
@@ -17,11 +17,18 @@ describe('session controller', () => {
     expect(transport.requests).toEqual([]);
   });
 
-  it('sends ordinary text to the chat docked beside the log', async () => {
+  it('keeps ordinary text out of commands and accepts it from Experiment chat', async () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
 
-    await controller.submit('what is happening?');
+    await controller.submitCommand('what is happening?');
+
+    expect(transport.requests).toEqual([]);
+    expect(controller.state.chatConversation).toEqual([]);
+    expect(controller.state.errorBanner?.message).toContain('Commands start with /');
+
+    controller.dismissErrorBanner();
+    await controller.submitChat('what is happening?');
 
     expect(transport.requests).toEqual([{type: 'query.chat', text: 'what is happening?'}]);
     // The pane is part of the landing view, so nothing opens over the table.
@@ -155,7 +162,7 @@ describe('session controller', () => {
     );
     const controller = new SocketSessionController(transport);
 
-    await controller.submit('/resume');
+    await controller.submitCommand('/resume');
 
     expect(controller.state.errorBanner).toMatchObject({
       message: diagnostic.summary,
@@ -211,7 +218,7 @@ describe('session controller', () => {
     );
     const controller = new SocketSessionController(transport);
 
-    await controller.submit('/perf');
+    await controller.submitCommand('/perf');
 
     expect(transport.requests).toEqual([{type: 'query.performance'}]);
     // The chart lands beside the transcript, not over it.
@@ -251,7 +258,7 @@ describe('session controller', () => {
     );
     const controller = new SocketSessionController(transport);
 
-    await controller.submit('/chat');
+    await controller.submitCommand('/chat');
 
     // Already on screen: /chat puts the pane keys on it instead of opening a
     // modal over the log.
@@ -281,7 +288,7 @@ describe('session controller', () => {
     // A terminal too narrow for two columns, reported by the renderer.
     controller.setChatDockFits(false);
 
-    await controller.submit('what is happening?');
+    await controller.submitChat('what is happening?');
 
     expect(controller.state.chatOpen).toBe(true);
     expect(chatPaneVisible(controller.state)).toBe(false);
@@ -314,12 +321,12 @@ describe('session controller', () => {
     const controller = new SocketSessionController(transport);
     await controller.start();
 
-    await controller.submit('/help');
+    await controller.submitCommand('/help');
     expect(controller.state.overlay?.content).not.toContain('/chat');
 
     // Inside a hypothesis the chat is a dialog again, so the command returns.
     controller.enterExperimentDrilldown();
-    await controller.submit('/help');
+    await controller.submitCommand('/help');
     expect(controller.state.overlay?.content).toContain('/chat');
   });
 
@@ -333,7 +340,7 @@ describe('session controller', () => {
     controller.enterExperimentDrilldown();
 
     // Asked from the trajectory view, where the chat is a pop-up.
-    await controller.submit('/chat why did r1 fail?');
+    await controller.submitCommand('/chat why did r1 fail?');
     expect(controller.state.chatOpen).toBe(true);
 
     controller.live();
@@ -376,7 +383,7 @@ describe('session controller', () => {
     });
     const controller = new SocketSessionController(transport);
 
-    await controller.submit('/chat why?');
+    await controller.submitCommand('/chat why?');
 
     expect(controller.state.chatOpen).toBe(false);
     expect(controller.state.layout.focus).toBe('chat');
@@ -450,7 +457,7 @@ describe('session controller', () => {
     const transport = new FakeTransport([], [], undefined, new Error('Codex exited with code 1'));
     const controller = new SocketSessionController(transport);
 
-    await controller.submit('/chat');
+    await controller.submitCommand('/chat');
     await controller.sendChat('what happened?');
 
     expect(controller.state.chatPending).toBe(false);
@@ -473,7 +480,7 @@ describe('session controller', () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport, 'solarized-dark');
 
-    await controller.submit('/theme');
+    await controller.submitCommand('/theme');
 
     expect(controller.state.themePicker?.selected).toBe('solarized-dark');
     // The list is a selection, not a text overlay.
@@ -486,7 +493,7 @@ describe('session controller', () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
 
-    await controller.submit('/theme');
+    await controller.submitCommand('/theme');
     controller.moveThemeSelection(2);
     controller.applySelectedTheme();
 
@@ -498,7 +505,7 @@ describe('session controller', () => {
   it('closes the picker without switching when it is dismissed', async () => {
     const controller = new SocketSessionController(new FakeTransport(), 'light');
 
-    await controller.submit('/theme');
+    await controller.submitCommand('/theme');
     controller.moveThemeSelection(1);
     controller.closeThemePicker();
 
@@ -509,7 +516,7 @@ describe('session controller', () => {
   it('closes the picker when the selection is the theme already in use', async () => {
     const controller = new SocketSessionController(new FakeTransport(), 'light');
 
-    await controller.submit('/theme');
+    await controller.submitCommand('/theme');
     controller.applySelectedTheme();
 
     expect(controller.state.themeName).toBe('light');
@@ -520,8 +527,8 @@ describe('session controller', () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
 
-    await controller.submit('/theme');
-    await controller.submit('/theme high-contrast-dark');
+    await controller.submitCommand('/theme');
+    await controller.submitCommand('/theme high-contrast-dark');
 
     expect(controller.state.themeName).toBe('high-contrast-dark');
     expect(controller.state.themePicker).toBeNull();
@@ -546,20 +553,20 @@ describe('session controller', () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
 
-    await controller.submit('/history');
+    await controller.submitCommand('/history');
     expect(controller.state.errorBanner?.scope).toBe('input');
     expect(controller.state.errorBanner?.message).toContain('Unknown command: /history');
 
-    await controller.submit('/history rounds');
+    await controller.submitCommand('/history rounds');
     expect(controller.state.errorBanner?.message).toContain('Unknown command: /history rounds');
 
-    await controller.submit('/experiments');
+    await controller.submitCommand('/experiments');
     expect(controller.state.errorBanner?.message).toContain('Unknown command: /experiments');
 
     controller.dismissErrorBanner();
     expect(controller.state.errorBanner).toBeNull();
 
-    await controller.submit('/history');
+    await controller.submitCommand('/history');
     expect(controller.state.errorBanner?.message).toContain('Unknown command: /history');
 
     expect(transport.requests).toEqual([]);
@@ -764,7 +771,7 @@ describe('session controller', () => {
     await controller.start();
     controller.moveExperimentSelection(1);
 
-    await controller.submit('/open-round');
+    await controller.submitCommand('/open-round');
 
     expect(controller.state.hypothesisScope).toMatchObject({id: 'H-02', rounds: [2, 3]});
     // Lands on the hypothesis's latest round: the round view is built around
@@ -786,7 +793,7 @@ describe('session controller', () => {
     const controller = new SocketSessionController(transport);
     await controller.start();
 
-    await controller.submit('/open-round --3');
+    await controller.submitCommand('/open-round --3');
 
     // Lands on the requested round, inside the hypothesis that owns it, and
     // moves the table selection to match.
@@ -808,7 +815,7 @@ describe('session controller', () => {
       event: {...event(1, 'phase_started'), agent_kind: 'orchestrator', round_label: 'round-9-pre'},
     });
 
-    await controller.submit('/open-round --9');
+    await controller.submitCommand('/open-round --9');
 
     expect(controller.state.hypothesisScope).toMatchObject({id: 'round-9', rounds: [9]});
     expect(controller.state.selectedRound).toBe(9);
@@ -832,7 +839,7 @@ describe('session controller', () => {
   it('reports a round that has not been observed', async () => {
     const controller = new SocketSessionController(new FakeTransport());
 
-    await controller.submit('/open-round --9');
+    await controller.submitCommand('/open-round --9');
 
     expect(controller.state.overlay?.content).toContain('Round 9 has not been recorded.');
     expect(controller.state.hypothesisScope).toBeNull();
@@ -845,9 +852,9 @@ describe('session controller', () => {
     ];
     const controller = new SocketSessionController(transport);
     await controller.start();
-    await controller.submit('/open-round');
+    await controller.submitCommand('/open-round');
 
-    await controller.submit('/open-round');
+    await controller.submitCommand('/open-round');
 
     expect(controller.state.overlay?.content).toContain('Already inside H-01');
     expect(controller.state.hypothesisScope).toMatchObject({id: 'H-01'});
@@ -860,7 +867,7 @@ describe('session controller', () => {
     );
     const controller = new SocketSessionController(transport);
     await controller.start();
-    await controller.submit('/perf');
+    await controller.submitCommand('/perf');
     const before = perfRequests(transport);
 
     transport.emit({type: 'event', event: event(9, 'round_finished')});
@@ -875,7 +882,7 @@ describe('session controller', () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
     await controller.start();
-    await controller.submit('/perf');
+    await controller.submitCommand('/perf');
     controller.closePane();
     const before = perfRequests(transport);
 
@@ -895,7 +902,7 @@ describe('session controller', () => {
     const controller = new SocketSessionController(transport);
     await controller.start();
     await controller.sendChat('why?');
-    await controller.submit('/perf');
+    await controller.submitCommand('/perf');
 
     controller.closePane();
 
@@ -915,7 +922,7 @@ describe('session controller', () => {
     const controller = new SocketSessionController(transport);
     await controller.start();
 
-    await controller.submit('/perf');
+    await controller.submitCommand('/perf');
     await controller.sendChat('what changed in r1?');
 
     // Three columns: chat, log, pane. None of them replaced another.
@@ -933,7 +940,7 @@ describe('session controller', () => {
     });
     const controller = new SocketSessionController(transport);
     await controller.start();
-    await controller.submit('/perf');
+    await controller.submitCommand('/perf');
     const pane = controller.state.layout.right;
 
     await controller.sendChat('what regressed?');
@@ -956,7 +963,7 @@ describe('session controller', () => {
   it('runs a slash command typed in the chat through the main input path', async () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
-    await controller.submit('/chat');
+    await controller.submitCommand('/chat');
     const before = transport.requests.length;
 
     // The performance plot, which is the command that answers in the right
@@ -1002,7 +1009,7 @@ describe('session controller', () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
 
-    await controller.submit('/theme monokai');
+    await controller.submitCommand('/theme monokai');
 
     expect(controller.state.errorBanner).toMatchObject({scope: 'input'});
     expect(controller.state.errorBanner?.message).toContain('Unknown theme: monokai');

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -1,5 +1,5 @@
 import {type EventSubscription, SupervisionError} from './client.js';
-import {helpText, parseInput} from './commands.js';
+import {helpText, parseCommand} from './commands.js';
 import {renderPerformanceCurve} from './performance-chart.js';
 import type {ProtocolResponse, RequestInput, RunEvent, ServerMessage} from './protocol.js';
 import {
@@ -61,7 +61,7 @@ export interface SessionController {
   readonly state: SessionState;
   start(): Promise<void>;
   stop(): Promise<void>;
-  submit(value: string): Promise<void>;
+  submitCommand(value: string): Promise<void>;
   closeChat(): void;
   sendChat(value: string): Promise<void>;
   submitChat(value: string): Promise<void>;
@@ -429,7 +429,7 @@ export class SocketSessionController implements SessionController {
   submitChat(value: string): Promise<void> {
     const text = value.trim();
     if (!text.startsWith('/')) return this.sendChat(value);
-    return this.submit(text);
+    return this.submitCommand(text);
   }
 
   sendChat(value: string): Promise<void> {
@@ -511,8 +511,8 @@ export class SocketSessionController implements SessionController {
     }
   }
 
-  async submit(value: string): Promise<void> {
-    const parsed = parseInput(value.trim());
+  async submitCommand(value: string): Promise<void> {
+    const parsed = parseCommand(value.trim());
     if (parsed.error)
       return this.#setState(reportError(this.#state, parsed.error, {scope: 'input'}));
     if (parsed.localView === 'help') {
@@ -542,10 +542,6 @@ export class SocketSessionController implements SessionController {
       return this.setTheme(parsed.themeName);
     }
     if (!parsed.request) return;
-    if (parsed.request.type === 'query.chat') {
-      await this.sendChat(parsed.request.text);
-      return;
-    }
     if (parsed.paneView !== undefined) {
       await this.openPane(parsed.paneView);
       return;

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -26,6 +26,7 @@ import {
   type PaneFocus,
   type PaneView,
   type RoundFocus,
+  reportError,
   type SessionState,
   selectAgent,
   selectExperimentActivity,
@@ -85,8 +86,8 @@ describe('OpenTUI presentation', () => {
     expect(frame).toContain('Rounds');
     expect(frame).toContain('● optimizer');
     expect(frame).toContain('Result');
-    expect(frame).toContain('Ask or command');
-    expect(frame).toContain('Type a question or /help');
+    expect(frame).toContain('Command');
+    expect(frame).toContain('Type /help for commands');
   });
 
   it('shows and dismisses a fatal error above the empty experiment log', async () => {
@@ -1024,7 +1025,7 @@ describe('OpenTUI presentation', () => {
     expect(controller.submissions).toEqual(['/help']);
   });
 
-  it('submits ordinary text as an operator question', async () => {
+  it('rejects ordinary text from the command input without sending chat', async () => {
     const testRenderer = await createTestRenderer({width: 80, height: 16});
     const controller = new FakeController(initialSessionState());
     const app = createOpenTuiApp(testRenderer.renderer, controller);
@@ -1032,8 +1033,10 @@ describe('OpenTUI presentation', () => {
 
     await testRenderer.mockInput.typeText('what is running?');
     testRenderer.mockInput.pressEnter();
-    await testRenderer.waitForFrame(() => controller.submissions.length === 1);
-    expect(controller.submissions).toEqual(['what is running?']);
+    const frame = await testRenderer.waitForFrame(value => value.includes('Commands start with /'));
+    expect(frame).toContain('Use Experiment chat for questions.');
+    expect(controller.submissions).toEqual([]);
+    expect(controller.chatSubmissions).toEqual([]);
   });
 
   it('suggests and completes slash commands with Tab', async () => {
@@ -1047,8 +1050,8 @@ describe('OpenTUI presentation', () => {
     expect(suggestions).toContain('/pause');
     expect(suggestions).not.toContain('/help  ');
     expect(suggestions).not.toContain('/perf');
-    expect(suggestions.indexOf('/pause')).toBeLessThan(suggestions.indexOf('Ask or command'));
-    expect(testRenderer.renderer.root.findDescendantById('input-box')?.height).toBe(3);
+    expect(suggestions.indexOf('/pause')).toBeLessThan(suggestions.indexOf('Command'));
+    expect(testRenderer.renderer.root.findDescendantById('command-input-box')?.height).toBe(3);
 
     testRenderer.mockInput.pressKey('TAB');
     testRenderer.mockInput.pressEnter();
@@ -1063,7 +1066,7 @@ describe('OpenTUI presentation', () => {
     registerCleanup(testRenderer.renderer, app);
 
     await testRenderer.mockInput.typeText('/steer inspect the cache');
-    const input = testRenderer.renderer.root.findDescendantById('input');
+    const input = testRenderer.renderer.root.findDescendantById('command-input');
     expect(input).toBeInstanceOf(InputRenderable);
     if (!(input instanceof InputRenderable)) throw new Error('input was not rendered');
     expect(input.getLineHighlights(0)).toMatchObject([{start: 0, end: 6}]);
@@ -1087,7 +1090,7 @@ describe('OpenTUI presentation', () => {
     const clipboard = clipboardReturning('copied');
     const app = createOpenTuiApp(testRenderer.renderer, controller, clipboard);
     registerCleanup(testRenderer.renderer, app);
-    await testRenderer.waitForFrame(value => value.includes('Ask or command'));
+    await testRenderer.waitForFrame(value => value.includes('Command'));
 
     testRenderer.mockInput.pressKey('c', {ctrl: true});
 
@@ -1105,7 +1108,7 @@ describe('OpenTUI presentation', () => {
     const clipboard = clipboardReturning('unsupported');
     const app = createOpenTuiApp(testRenderer.renderer, controller, clipboard);
     registerCleanup(testRenderer.renderer, app);
-    await testRenderer.waitForFrame(value => value.includes('Ask or command'));
+    await testRenderer.waitForFrame(value => value.includes('Command'));
 
     testRenderer.mockInput.pressKey('c', {ctrl: true});
 
@@ -1979,9 +1982,9 @@ describe('theming', () => {
     const lines = landing.split('\n');
     const paneTop = lines.find(line => line.includes('╭─ Experiment chat')) ?? '';
     const messageTop = lines.find(line => line.includes('╭─ Message ')) ?? '';
-    const commandTop = lines.find(line => line.includes('╭─ Ask or command')) ?? '';
+    const commandTop = lines.find(line => line.includes('╭─ Command')) ?? '';
     expect(messageTop).not.toBe('');
-    expect(commandTop.indexOf('╭─ Ask or command')).toBe(paneTop.indexOf('╭─ ▸ Experiments'));
+    expect(commandTop.indexOf('╭─ Command')).toBe(paneTop.indexOf('╭─ ▸ Experiments'));
   });
 
   it('routes typing to whichever input Ctrl+W points at', async () => {
@@ -1991,6 +1994,14 @@ describe('theming', () => {
     registerCleanup(testRenderer.renderer, app);
     await controller.openExperimentLog();
     await frameAfter(testRenderer);
+
+    await testRenderer.mockInput.typeText('this belongs in chat');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(value => value.includes('Commands start with /'));
+    expect(controller.submissions).toEqual([]);
+    expect(controller.chatSubmissions).toEqual([]);
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await frameAfterEscape(testRenderer);
 
     testRenderer.mockInput.pressKey('w', {ctrl: true});
     await frameAfter(testRenderer);
@@ -2119,10 +2130,10 @@ describe('theming', () => {
 
     const lines = frame.split('\n');
     const suggestion = lines.find(line => line.includes('/perf')) ?? '';
-    const commandInput = lines.find(line => line.includes('╭─ Ask or command')) ?? '';
+    const commandInput = lines.find(line => line.includes('╭─ Command')) ?? '';
     // The list belongs to the box it completes, so it starts where that box
     // starts rather than running back across the chat column.
-    expect(suggestion.indexOf('/perf')).toBeGreaterThan(commandInput.indexOf('╭─ Ask or command'));
+    expect(suggestion.indexOf('/perf')).toBeGreaterThan(commandInput.indexOf('╭─ Command'));
   });
 
   it('drops /chat from the command surface while the chat is already docked', async () => {
@@ -2159,9 +2170,11 @@ describe('theming', () => {
     registerCleanup(testRenderer.renderer, app);
     await controller.openExperimentLog();
 
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
     await testRenderer.mockInput.typeText('why is r41 slow?');
     testRenderer.mockInput.pressEnter();
-    await testRenderer.waitForFrame(() => controller.submissions.length === 1);
+    await testRenderer.waitForFrame(() => controller.chatSubmissions.length === 1);
     controller.publish({
       ...controller.state,
       chatConversation: [
@@ -2860,7 +2873,15 @@ class FakeController implements SessionController {
   stop(): Promise<void> {
     return Promise.resolve();
   }
-  submit(value: string): Promise<void> {
+  submitCommand(value: string): Promise<void> {
+    if (!value.trim().startsWith('/')) {
+      this.publish(
+        reportError(this.state, 'Commands start with /. Use Experiment chat for questions.', {
+          scope: 'input',
+        }),
+      );
+      return Promise.resolve();
+    }
     this.submissions.push(value);
     if (value.trim() === '/chat') {
       this.state = {...this.state, chatOpen: true, overlay: null};
@@ -2893,7 +2914,7 @@ class FakeController implements SessionController {
   submitChat(value: string): Promise<void> {
     const text = value.trim();
     if (!text.startsWith('/')) return this.sendChat(value);
-    return this.submit(text);
+    return this.submitCommand(text);
   }
 
   sendChat(value: string): Promise<void> {

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -14,10 +14,10 @@ import {createChatDraft} from './chat-composer.js';
 import {ChatOverlayView} from './chat-overlay.js';
 import {ChatPaneView, chatDockFits, chatPaneWidth} from './chat-pane.js';
 import {RendererSelectionClipboard, type SelectionClipboard} from './clipboard.js';
+import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
 import {ErrorBannerView} from './error-banner.js';
 import {ExperimentLogView} from './experiment-log.js';
-import {createInputPanel} from './input.js';
 import {bindKeybindings} from './keybindings.js';
 import {OverlayView} from './overlay.js';
 import {RightPaneView, rightPaneWidth, splitFits} from './right-pane.js';
@@ -150,9 +150,9 @@ export function createOpenTuiApp(
   const chatPane = new ChatPaneView(renderer, controller, markdownStyle, theme, chatDraft);
   // Clicking either box moves the pane focus to it, so the border, the hint,
   // and the cursor never disagree about which surface is taking keystrokes.
-  const input = createInputPanel(
+  const commandInput = createCommandInputPanel(
     renderer,
-    value => void controller.submit(value),
+    value => void controller.submitCommand(value),
     theme,
     () => controller.focusPane('left'),
   );
@@ -188,8 +188,8 @@ export function createOpenTuiApp(
   commandColumn.add(help);
   // Absolute inside the command column rather than the root, so the list rises
   // out of the input it belongs to instead of across the chat beside it.
-  commandColumn.add(input.suggestions);
-  commandColumn.add(input.box);
+  commandColumn.add(commandInput.suggestions);
+  commandColumn.add(commandInput.box);
   bottom.add(commandColumn);
   root.add(header);
   root.add(errorBanner.output);
@@ -204,7 +204,7 @@ export function createOpenTuiApp(
   root.add(themePicker.output);
   root.add(chat.output);
   renderer.root.add(root);
-  input.focus();
+  commandInput.focus();
 
   const applyTheme = (next: ThemeName): (() => void) => {
     themeName = next;
@@ -227,7 +227,7 @@ export function createOpenTuiApp(
     conversation.applyTheme(theme, markdownStyle);
     chat.applyTheme(theme, markdownStyle);
     chatPane.applyTheme(theme, markdownStyle);
-    input.applyTheme(theme);
+    commandInput.applyTheme(theme);
     return () => previousMarkdownStyle.destroy();
   };
 
@@ -326,7 +326,7 @@ export function createOpenTuiApp(
     if (showSplit) {
       const errorHeight = state.errorBanner === null ? 0 : errorBanner.output.height;
       const top = header.height + errorHeight + (showLog ? 0 : roundStrip.output.height);
-      const below = todoStrip.output.height + help.height + input.box.height;
+      const below = todoStrip.output.height + help.height + commandInput.box.height;
       chat.setPaneBounds({
         left: 1,
         width: leftWidth - 2,
@@ -339,10 +339,10 @@ export function createOpenTuiApp(
     chatPane.render(state, showChatPane, chatWidth);
     const chatInputFocused = showChatPane && state.layout.focus === 'chat';
     commandColumn.visible = zoomedPane !== 'chat';
-    input.setFocused(paneFocus === 'experiments' || paneFocus === 'transcript');
+    commandInput.setFocused(paneFocus === 'experiments' || paneFocus === 'transcript');
     // The command list completes the box it belongs to, and on this view that
     // box cannot open a chat that is already beside it.
-    input.setCommandContext({chatDocked: showChatPane});
+    commandInput.setCommandContext({chatDocked: showChatPane});
     experimentLog.setAvailableWidth(showSplit || showChatPane ? leftWidth - chatWidth : null);
     experimentLog.render(state);
     experimentLog.output.visible = showExperimentLog;
@@ -362,16 +362,17 @@ export function createOpenTuiApp(
       focusTarget = target;
       if (target === 'modal') chat.focus();
       else if (target === 'chat') chatPane.focusComposer();
-      else input.focus();
+      else commandInput.focus();
     }
     releasePreviousStyle?.();
   };
   const unbindKeys = bindKeybindings(renderer, controller, viewport, clipboard, {
-    completeInput: () => input.completeSuggestion(),
+    completeInput: () => commandInput.completeSuggestion(),
     // Enter belongs to a pane only when nothing is typed anywhere. Asking which
     // box has the cursor is not enough: a question waiting in the other box is
     // still a question, and Enter must never discard it to open a hypothesis.
-    inputIsEmpty: () => input.isEmpty() && chatPane.isComposerEmpty() && chat.isComposerEmpty(),
+    inputIsEmpty: () =>
+      commandInput.isEmpty() && chatPane.isComposerEmpty() && chat.isComposerEmpty(),
     closeChat: () => controller.closeChat(),
     toggleLatestPrompt: () => conversation.toggleLatestPrompt(),
     revealSelectedEntry: () => {
@@ -410,7 +411,7 @@ export function createOpenTuiApp(
       renderer.off('resize', onResize);
       unsubscribe();
       unbindKeys();
-      input.destroy();
+      commandInput.destroy();
       conversationActivityBar.destroy();
       roundStrip.destroy();
       agentMap.destroy();

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -46,9 +46,8 @@ export function chatPaneWidth(terminalWidth: number, rightPaneWidth = 0): number
 
 /**
  * The experiment chat as a column of the landing view rather than a dialog over
- * it. It has no input of its own: the client already has one, and plain text
- * typed there is a question for the agent, so a second box would only split the
- * operator's attention.
+ * it. Its composer is the only surface where ordinary text becomes a question;
+ * slash-prefixed text delegates to the shared command path.
  */
 export class ChatPaneView {
   readonly output: BoxRenderable;

--- a/clients/tui/src/ui/command-input.ts
+++ b/clients/tui/src/ui/command-input.ts
@@ -14,7 +14,7 @@ import {
 } from '../commands.js';
 import type {Theme} from './theme.js';
 
-export interface InputPanel {
+export interface CommandInputPanel {
   box: BoxRenderable;
   suggestions: BoxRenderable;
   /** Narrows the completions to the commands the current view offers. */
@@ -32,21 +32,21 @@ function commandSyntaxStyle(theme: Theme): SyntaxStyle {
   return SyntaxStyle.fromStyles({'slash-command': {fg: theme.accent, bold: true}});
 }
 
-export function createInputPanel(
+export function createCommandInputPanel(
   renderer: CliRenderer,
   onSubmit: (value: string) => void,
   theme: Theme,
   /** Called when the box is clicked, so the pane focus follows the cursor. */
   onFocusRequest: () => void = () => {},
-): InputPanel {
+): CommandInputPanel {
   const box = new BoxRenderable(renderer, {
-    id: 'input-box',
+    id: 'command-input-box',
     height: 3,
     width: '100%',
     border: true,
     borderStyle: 'rounded',
     borderColor: theme.borderFocus,
-    title: ' Ask or command ',
+    title: ' Command ',
     paddingLeft: 1,
     paddingRight: 1,
     onMouseUp: onFocusRequest,
@@ -54,16 +54,16 @@ export function createInputPanel(
   let syntaxStyle = commandSyntaxStyle(theme);
   let commandStyleId = syntaxStyle.getStyleId('slash-command');
   const input = new InputRenderable(renderer, {
-    id: 'input',
+    id: 'command-input',
     width: '100%',
-    placeholder: 'Type a question or /help',
+    placeholder: 'Type /help for commands',
     textColor: theme.textStrong,
     focusedTextColor: theme.textStrong,
     syntaxStyle,
     onMouseUp: onFocusRequest,
   });
   const suggestions = new BoxRenderable(renderer, {
-    id: 'input-suggestions',
+    id: 'command-input-suggestions',
     position: 'absolute',
     bottom: 3,
     left: 0,
@@ -79,7 +79,7 @@ export function createInputPanel(
     paddingRight: 1,
   });
   const suggestionList = new TextRenderable(renderer, {
-    id: 'input-suggestion-list',
+    id: 'command-input-suggestion-list',
     width: '100%',
     height: 1,
     fg: theme.textMuted,


### PR DESCRIPTION
## Problem

The hypothesis view has two distinct inputs, Experiment chat on the left and a command box on the right. Ordinary text entered in the right box was nevertheless converted into `query.chat` and appeared in the left conversation. That could unexpectedly launch an agent request and incur time or cost.

The behavior survived because the original one-box TUI contract remained underneath the newer two-box UI. Generic `submit(string)` and `parseInput(string)` APIs mixed commands and questions, while tests and documentation continued to require the obsolete fallback.

Fixes #442. Supersedes the dual-purpose global-input expectation documented in #256.

## Solution

Replace the generic input boundary with surface-specific contracts:

- `submitCommand()` and `parseCommand()` own slash-command execution.
- `submitChat()` owns ordinary questions and delegates slash-prefixed text to `submitCommand()`.
- The command parser's request type explicitly excludes `query.chat`, so command parsing cannot create a chat request.
- The right-side component is renamed to `CommandInputPanel`, with `Command` and `Type /help for commands` affordances.
- Ordinary right-side text produces an actionable input error and never reaches chat.

The shared command parser and executor remain the single implementation for slash commands from either surface.

### Architecture

```mermaid
flowchart LR
  R[Right Command input] --> SC[submitCommand]
  SC --> PC[parseCommand]
  PC --> A[Slash-command action]
  PC -. type excludes query.chat .-> X[No chat request]

  L[Experiment chat composer] --> ST[submitChat]
  ST -->|ordinary text| Q[sendChat / query.chat]
  ST -->|slash-prefixed text| SC
```

## Verification

Parser tests enforce that ordinary text cannot become a chat request. Controller tests verify the command path rejects ordinary text while docked and modal chat accept it. Renderer tests type into both visible boxes, verify zero chat submissions from the right, one chat submission from the left, and unchanged slash-command behavior from both surfaces.

### Correctness properties

- Only chat-owned APIs can turn ordinary text into `query.chat`.
- Command parsing cannot represent a chat query at the type boundary.
- Ordinary command-box text never reaches the backend chat endpoint.
- Docked and modal chat continue accepting ordinary questions.
- Slash commands have one parser and executor regardless of their input surface.
- Labels, placeholders, focus, and submission ownership describe the same surface.

### Testing

- `pnpm --dir clients/tui check` (passed)
- `pnpm --dir clients/tui test` (386 passed, 0 failed)
- Focused parser, controller, and renderer tests (160 passed, 0 failed)
- `./scripts/format.sh` (passed)
- `./scripts/check_format.sh` (passed)
- `pnpm --dir clients/tui exec biome check src` (passed)
- `git diff --check` (passed)
