### PR TITLE
Restore TUI formatting check after architecture merge

### DIFF
--- a/scripts/check_ts_architecture.test.mjs
+++ b/scripts/check_ts_architecture.test.mjs
@@ -61,16 +61,19 @@ test('dependency-cruiser rejects forbidden package and runtime edges', async () 
     result.output.summary.violations.map(violation => violation.rule.name),
   );
 
-  assert.deepEqual(violatedRules, new Set([
-    'backend-client-is-lowest-layer',
-    'core-state-does-not-depend-on-tui',
-    'workspace-packages-use-public-exports',
-    'core-state-has-no-node-runtime',
-    'core-state-has-no-ui-runtime',
-    'production-dependencies-are-declared',
-    'no-circular-dependencies',
-    'no-unresolvable-imports',
-  ]));
+  assert.deepEqual(
+    violatedRules,
+    new Set([
+      'backend-client-is-lowest-layer',
+      'core-state-does-not-depend-on-tui',
+      'workspace-packages-use-public-exports',
+      'core-state-has-no-node-runtime',
+      'core-state-has-no-ui-runtime',
+      'production-dependencies-are-declared',
+      'no-circular-dependencies',
+      'no-unresolvable-imports',
+    ]),
+  );
 });
 
 test('manifest policy rejects declared reverse dependencies', async () => {


### PR DESCRIPTION
## Problem

Post-merge CI for the TUI bug-fix and architecture stack stopped at `pnpm check:ts`. The new dependency-cruiser rule test was not in Biome's canonical multiline layout, so the remaining TUI validation never ran on `main`.

## Solution

Apply Biome 2.5.3 formatting to the affected assertion.

### Architecture

No architecture or runtime behavior changes. This only restores the repository formatting contract for the architecture test.

## Verification

The full TypeScript formatting and lint check passes, and the architecture rule tests still pass.

### Correctness properties

- The expected dependency-cruiser violation set is unchanged.
- No production source or package contract changes.

### Testing

- `pnpm check:ts` (60 files passed)
- `pnpm test:ts-architecture` (2 passed)
- `git diff --check`
