### PR TITLE
Focus the hypothesis table on outcomes

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1892,7 +1892,11 @@ describe('theming', () => {
     const landing = await frameAfter(testRenderer);
     expect(landing).toContain('Experiments');
     expect(landing).toContain('Implementation Details');
+    expect(landing).toContain('Outcome');
     expect(landing).toContain('H-07');
+    expect(landing).toContain('Proven');
+    expect(landing).not.toContain('Verdict');
+    expect(landing).not.toContain('Pass');
     // Per-round detail is what the operator opts into, not what greets them.
     expect(landing).not.toContain('round 41 detail');
     // The rounds strip and agent map are per-round chrome; neither is drawn.

--- a/clients/tui/src/ui/experiment-log.test.ts
+++ b/clients/tui/src/ui/experiment-log.test.ts
@@ -56,7 +56,6 @@ describe('experiment log rows', () => {
       'Rounds',
       'Implementation Details',
       'Measured',
-      'Verdict',
       'Outcome',
       'Kept',
     ]) {
@@ -66,9 +65,27 @@ describe('experiment log rows', () => {
     expect(row).toContain('41');
     expect(row).toContain('Batch the prefill step');
     expect(row).toContain('+12%');
-    expect(row).toContain('Pass');
     expect(row).toContain('Proven');
+    expect(row).not.toContain('Pass');
     expect(row.trimEnd().endsWith('Yes')).toBe(true);
+  });
+
+  it('shows hypothesis resolution without rendering the judge verdict', () => {
+    const columns = resolveColumns(WIDE);
+
+    const accepted = entryRow(
+      entry({judge_verdict: 'pass', resolved_outcome: 'disproven'}),
+      columns,
+    );
+    const rejected = entryRow(
+      entry({judge_verdict: 'fail', resolved_outcome: 'rejected'}),
+      columns,
+    );
+
+    expect(accepted).toContain('Disproven');
+    expect(accepted).not.toContain('Pass');
+    expect(rejected).toContain('Rejected');
+    expect(rejected).not.toContain('Fail');
   });
 
   it('keeps hypothesis, rounds, and outcome when the terminal is narrow', () => {
@@ -119,6 +136,7 @@ describe('experiment log rows', () => {
 
     expect(row).toContain('(unidentified)');
     expect(row).toContain('—');
+    expect(row).not.toContain('Active');
   });
 
   it('keeps an explicit gutter after a hypothesis id that fills its column', () => {
@@ -166,6 +184,7 @@ describe('experiment log outcome color', () => {
 
     expect(outcomeColor(theme, entry({resolved_outcome: 'continue'}))).toBe(theme.textPrimary);
     expect(outcomeColor(theme, entry({resolved_outcome: 'inconclusive'}))).toBe(theme.textPrimary);
+    expect(outcomeColor(theme, entry({resolved_outcome: null}))).toBe(theme.textPrimary);
   });
 
   it('uses the active accent while a hypothesis is still open', () => {

--- a/clients/tui/src/ui/experiment-log.test.ts
+++ b/clients/tui/src/ui/experiment-log.test.ts
@@ -9,6 +9,7 @@ import {
   setExperiments,
 } from '../session-model.js';
 import {
+  entryCells,
   entryRow,
   formatMeasured,
   formatRounds,
@@ -119,11 +120,29 @@ describe('experiment log rows', () => {
     expect(row).toContain('(unidentified)');
     expect(row).toContain('—');
   });
+
+  it('keeps an explicit gutter after a hypothesis id that fills its column', () => {
+    const columns = resolveColumns(WIDE);
+    const header = headerRow(columns);
+    const row = entryRow(entry({hypothesis_id: 'm1-preallocated-spsc-ring'}), columns);
+    const roundsStart = header.indexOf('Rounds');
+
+    expect(row).toContain('m1-preallocat…  41');
+    expect(row[roundsStart - 1]).toBe(' ');
+    expect(row.slice(roundsStart).startsWith('41')).toBe(true);
+  });
+
+  it('keeps gutters across the separately colored outcome segments', () => {
+    const cells = entryCells(entry(), resolveColumns(WIDE));
+
+    expect(cells.outcome.startsWith('  ')).toBe(true);
+    expect(cells.trailing.startsWith('  ')).toBe(true);
+  });
 });
 
 describe('experiment log layout', () => {
   it('fits the panel exactly at every width it degrades through', () => {
-    for (const width of [120, 104, 90, 72, 62, 54, 40]) {
+    for (const width of [120, 104, 103, 90, 89, 72, 62, 61, 54, 40]) {
       const columns = resolveColumns(width);
       const header = headerRow(columns);
       const row = entryRow(entry(), columns);

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -40,13 +40,12 @@ const KEPT_MIN_WIDTH = 104;
  * rather than restating the threshold.
  */
 export const LOG_CLAIM_PANEL_WIDTH = CLAIM_MIN_WIDTH + PANEL_CHROME_COLUMNS;
-/** Panel width that still carries the measured and verdict columns. */
+/** Panel width that still carries the measured column. */
 export const LOG_COMPACT_PANEL_WIDTH = MEASURED_MIN_WIDTH + PANEL_CHROME_COLUMNS;
 
 interface Columns {
   claim: boolean;
   measured: boolean;
-  verdict: boolean;
   kept: boolean;
   claimWidth: number;
 }
@@ -447,7 +446,6 @@ export class ExperimentLogView {
 const ID_WIDTH = 15;
 const ROUNDS_WIDTH = 8;
 const MEASURED_WIDTH = 11;
-const VERDICT_WIDTH = 8;
 const OUTCOME_WIDTH = 11;
 const KEPT_WIDTH = 4;
 const COLUMN_GAP = '  ';
@@ -460,14 +458,13 @@ export function resolveColumns(width: number): Columns {
     ID_WIDTH +
     ROUNDS_WIDTH +
     OUTCOME_WIDTH +
-    (measured ? MEASURED_WIDTH + VERDICT_WIDTH : 0) +
+    (measured ? MEASURED_WIDTH : 0) +
     (kept ? KEPT_WIDTH : 0);
-  const visibleColumns = 3 + (claim ? 1 : 0) + (measured ? 2 : 0) + (kept ? 1 : 0);
+  const visibleColumns = 3 + (claim ? 1 : 0) + (measured ? 1 : 0) + (kept ? 1 : 0);
   const gutterWidth = (visibleColumns - 1) * COLUMN_GAP.length;
   return {
     claim,
     measured,
-    verdict: measured,
     kept,
     // Exactly the remaining width, so the row fills the panel without
     // overflowing it and losing the trailing columns to truncation.
@@ -479,7 +476,6 @@ export function headerRow(columns: Columns): string {
   const parts = [' Hypothesis'.padEnd(ID_WIDTH), 'Rounds'.padEnd(ROUNDS_WIDTH)];
   if (columns.claim) parts.push('Implementation Details'.padEnd(columns.claimWidth));
   if (columns.measured) parts.push('Measured'.padEnd(MEASURED_WIDTH));
-  if (columns.verdict) parts.push('Verdict'.padEnd(VERDICT_WIDTH));
   parts.push('Outcome'.padEnd(OUTCOME_WIDTH));
   if (columns.kept) parts.push('Kept'.padEnd(KEPT_WIDTH));
   return parts.join(COLUMN_GAP);
@@ -505,16 +501,13 @@ export function entryCells(entry: HypothesisEntry, columns: Columns): EntryCells
     leading.push(fitColumn(sentenceCase(entry.claim ?? entry.action ?? '—'), columns.claimWidth));
   }
   if (columns.measured) leading.push(fitColumn(formatMeasured(entry), MEASURED_WIDTH));
-  if (columns.verdict) {
-    leading.push(fitColumn(sentenceCase(entry.judge_verdict ?? '—'), VERDICT_WIDTH));
-  }
   return {
     leading: leading.join(COLUMN_GAP),
     // These are separate renderables so outcome can carry semantic color.
     // Put gutters on the following segment rather than relying on trailing
     // padding surviving across renderable boundaries.
     outcome: `${COLUMN_GAP}${fitColumn(
-      sentenceCase(entry.resolved_outcome ?? 'active'),
+      sentenceCase(entry.active === true ? 'active' : (entry.resolved_outcome ?? '—')),
       OUTCOME_WIDTH,
     )}`,
     trailing: columns.kept
@@ -539,7 +532,8 @@ export function entryRow(entry: HypothesisEntry, columns: Columns): string {
  */
 export function outcomeColor(theme: Theme, entry: HypothesisEntry): string {
   const outcome = entry.resolved_outcome ?? null;
-  if (entry.active === true || outcome === null) return theme.warning;
+  if (entry.active === true) return theme.warning;
+  if (outcome === null) return theme.textPrimary;
   if (outcome === 'proven') return theme.success;
   if (outcome === 'disproven' || outcome === 'rejected') return theme.error;
   return theme.textPrimary;

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -444,12 +444,13 @@ export class ExperimentLogView {
 }
 
 /** Widths of every column except the claim, which absorbs what is left over. */
-const ID_WIDTH = 16;
-const ROUNDS_WIDTH = 9;
-const MEASURED_WIDTH = 12;
-const VERDICT_WIDTH = 9;
-const OUTCOME_WIDTH = 12;
+const ID_WIDTH = 15;
+const ROUNDS_WIDTH = 8;
+const MEASURED_WIDTH = 11;
+const VERDICT_WIDTH = 8;
+const OUTCOME_WIDTH = 11;
 const KEPT_WIDTH = 4;
+const COLUMN_GAP = '  ';
 
 export function resolveColumns(width: number): Columns {
   const claim = width >= CLAIM_MIN_WIDTH;
@@ -461,6 +462,8 @@ export function resolveColumns(width: number): Columns {
     OUTCOME_WIDTH +
     (measured ? MEASURED_WIDTH + VERDICT_WIDTH : 0) +
     (kept ? KEPT_WIDTH : 0);
+  const visibleColumns = 3 + (claim ? 1 : 0) + (measured ? 2 : 0) + (kept ? 1 : 0);
+  const gutterWidth = (visibleColumns - 1) * COLUMN_GAP.length;
   return {
     claim,
     measured,
@@ -468,7 +471,7 @@ export function resolveColumns(width: number): Columns {
     kept,
     // Exactly the remaining width, so the row fills the panel without
     // overflowing it and losing the trailing columns to truncation.
-    claimWidth: claim ? Math.max(20, width - fixed) : 0,
+    claimWidth: claim ? Math.max(20, width - fixed - gutterWidth) : 0,
   };
 }
 
@@ -478,8 +481,8 @@ export function headerRow(columns: Columns): string {
   if (columns.measured) parts.push('Measured'.padEnd(MEASURED_WIDTH));
   if (columns.verdict) parts.push('Verdict'.padEnd(VERDICT_WIDTH));
   parts.push('Outcome'.padEnd(OUTCOME_WIDTH));
-  if (columns.kept) parts.push('Kept');
-  return parts.join('');
+  if (columns.kept) parts.push('Kept'.padEnd(KEPT_WIDTH));
+  return parts.join(COLUMN_GAP);
 }
 
 /**
@@ -495,27 +498,33 @@ export interface EntryCells {
 export function entryCells(entry: HypothesisEntry, columns: Columns): EntryCells {
   const marker = entry.active === true ? '▸' : ' ';
   const leading = [
-    `${marker}${truncate(entry.hypothesis_id, ID_WIDTH - 1)}`.padEnd(ID_WIDTH),
-    formatRounds(entry).padEnd(ROUNDS_WIDTH),
+    fitColumn(`${marker}${truncate(entry.hypothesis_id, ID_WIDTH - 1)}`, ID_WIDTH),
+    fitColumn(formatRounds(entry), ROUNDS_WIDTH),
   ];
   if (columns.claim) {
-    leading.push(
-      truncate(sentenceCase(entry.claim ?? entry.action ?? '—'), columns.claimWidth - 1).padEnd(
-        columns.claimWidth,
-      ),
-    );
+    leading.push(fitColumn(sentenceCase(entry.claim ?? entry.action ?? '—'), columns.claimWidth));
   }
-  if (columns.measured) leading.push(formatMeasured(entry).padEnd(MEASURED_WIDTH));
+  if (columns.measured) leading.push(fitColumn(formatMeasured(entry), MEASURED_WIDTH));
   if (columns.verdict) {
-    leading.push(sentenceCase(entry.judge_verdict ?? '—').padEnd(VERDICT_WIDTH));
+    leading.push(fitColumn(sentenceCase(entry.judge_verdict ?? '—'), VERDICT_WIDTH));
   }
   return {
-    leading: leading.join(''),
-    outcome: truncate(sentenceCase(entry.resolved_outcome ?? 'active'), OUTCOME_WIDTH - 1).padEnd(
+    leading: leading.join(COLUMN_GAP),
+    // These are separate renderables so outcome can carry semantic color.
+    // Put gutters on the following segment rather than relying on trailing
+    // padding surviving across renderable boundaries.
+    outcome: `${COLUMN_GAP}${fitColumn(
+      sentenceCase(entry.resolved_outcome ?? 'active'),
       OUTCOME_WIDTH,
-    ),
-    trailing: columns.kept ? (entry.kept === true ? 'Yes' : 'No') : '',
+    )}`,
+    trailing: columns.kept
+      ? `${COLUMN_GAP}${fitColumn(entry.kept === true ? 'Yes' : 'No', KEPT_WIDTH)}`
+      : '',
   };
+}
+
+function fitColumn(value: string, width: number): string {
+  return truncate(value, width).padEnd(width);
 }
 
 export function entryRow(entry: HypothesisEntry, columns: Columns): string {


### PR DESCRIPTION
## Problem

The experiment log concatenated fixed-width cells without explicit gutters, so a long hypothesis ID could run directly into its round number. The table also displayed the judge pass/fail verdict beside the hypothesis outcome. Pass describes acceptance of the declared evidence, not whether the hypothesis was proven, which made the primary hypothesis index ambiguous.

## Solution

Add explicit two-column gutters between every visible table column and account for those gutters in responsive width calculations. Remove the judge verdict from this summary view and keep the backend-provided hypothesis outcome as the sole resolution signal. Inactive historical rows without a recorded outcome now display a neutral placeholder instead of incorrectly appearing Active.

### Architecture

This is a presentation-only change in the TUI. The backend protocol and core state retain judge metadata for other detailed views. The table renderer consumes resolved_outcome directly and owns spacing, truncation, labels, and colors.

## Verification

The full TUI suite passed after the layout and outcome changes. Focused rendered-frame coverage verifies the final table omits Verdict and Pass while showing Outcome and Proven. TypeScript and package-boundary checks also pass.

### Correctness properties

- Every adjacent visible table column has an explicit gutter, including independently colored renderables.
- Rows and headers remain within the available width at each responsive breakpoint.
- The hypothesis index displays resolved_outcome and never substitutes judge_verdict.
- Only an active hypothesis is labeled Active.
- Missing historical outcomes render neutrally as a placeholder.
- Backend contracts and judge metadata remain unchanged.

### Testing

- pnpm --filter @vibesys/tui test -- src/ui/experiment-log.test.ts: 373 tests passed, 0 failed.
- cd clients/tui && bun test --max-concurrency 1 src/ui/experiment-log.test.ts src/ui/app.test.ts -t 'experiment log|lands on the experiment log': 21 tests passed, 0 failed.
- pnpm --filter @vibesys/tui check: passed.
- pnpm check:ts-architecture: passed, 0 dependency violations.
- git diff --check: passed.
