### PR TITLE
Add hypothesis detail drill-down

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -39,27 +39,26 @@ input accepts these slash commands:
 The client opens on the experiment log rather than on the per-round
 transcript. It groups rounds by `hypothesis_id`, so one hypothesis held across
 continuation rounds is a single row showing the claim, the round range, what
-the implementation details, the measured result, the judge verdict, the outcome the loop
-resolved (`Accepted`, `Rejected`, or a terminal `HypothesisOutcome`), and whether
-the candidate was kept. The active hypothesis is marked with `▸` and carries no
-outcome until it resolves. `Accepted` reads in the theme's success color and
-`Rejected` in its error color; the word is always spelled out, so the reading
-does not depend on color.
+was implemented, the measured result, the outcome the loop resolved (`Accepted`,
+`Rejected`, or a terminal `HypothesisOutcome`), and whether the candidate was
+kept. The active hypothesis is marked with `▸` and carries no outcome until it
+resolves. `Accepted` reads in the theme's success color and `Rejected` in its
+error color; the word is always spelled out, so the reading does not depend on
+color.
 
 The log is the landing view and the root of the client, so no command is
 needed to reach it: it is what the client opens on, and Escape or Ctrl+L
 returns to it from anywhere.
 
-Arrow keys move the selection, the wheel and trackpad scroll the table
-independently of it, and clicking a row selects it. Enter on an empty input, or
-`/open-round`, opens the rounds behind the selected hypothesis: the ordinary
-transcript, rounds strip, and agent map, filtered to that hypothesis. The input
-keeps Enter whenever something is typed, so a command entered from the log runs
-on its first Enter and its result opens over the table. `/open-round --N`
-jumps straight to round N inside whichever hypothesis owns it. Escape steps
-back to the table with the selection intact. The log is the root view, so
-opening a hypothesis is the only route to per-round output; there is no
-unfiltered live transcript to fall back to.
+Arrow keys move the selection, and the wheel and trackpad scroll the table
+independently of it. Clicking a hypothesis, or pressing Enter on an empty input,
+opens its summary. The summary gives the full wrapped hypothesis text first,
+then brief decision metadata and its rounds. Arrow keys select a round; clicking
+it or pressing Enter opens the ordinary transcript, rounds strip, and agent map.
+Escape returns from a round to its hypothesis, then from the hypothesis to the
+index. The input keeps Enter whenever something is typed, so a command entered
+from the log runs on its first Enter. `/open-round` and `/open-round --N` remain
+explicit shortcuts directly to the selected or numbered round.
 
 The agent strip is headed `Round N flow · 45s` for the round on screen. That
 elapsed time is agent-active: wall clock minus the gaps where no agent was

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -647,6 +647,8 @@ describe('session controller', () => {
     const controller = new SocketSessionController(transport);
     await controller.start();
     controller.enterExperimentDrilldown();
+    expect(controller.state.hypothesisDetail).not.toBeNull();
+    controller.enterExperimentDrilldown();
     expect(controller.state.hypothesisScope).not.toBeNull();
 
     // What Ctrl+L and Escape are bound to.
@@ -715,6 +717,8 @@ describe('session controller', () => {
 
     // Per-round output is reachable only by opening a hypothesis.
     controller.enterExperimentDrilldown();
+    expect(controller.state.hypothesisDetail).not.toBeNull();
+    controller.enterExperimentDrilldown();
     expect(controller.state.hypothesisScope).not.toBeNull();
 
     // live() is the Ctrl+L path; it returns to the table rather than to an
@@ -744,11 +748,16 @@ describe('session controller', () => {
     controller.moveExperimentSelection(1);
 
     controller.enterExperimentDrilldown();
+    expect(controller.state.hypothesisDetail).toEqual({entryKey: 'H-02', selectedRound: 3});
+    expect(controller.state.hypothesisScope).toBeNull();
+
+    controller.enterExperimentDrilldown();
     expect(controller.state.hypothesisScope).toMatchObject({id: 'H-02', rounds: [2, 3]});
     expect(controller.state.hypothesisScope?.label).toBe('H-02 · r2-3');
 
     controller.leaveExperimentDrilldown();
     expect(controller.state.hypothesisScope).toBeNull();
+    expect(controller.state.hypothesisDetail).toEqual({entryKey: 'H-02', selectedRound: 3});
     expect(controller.state.experimentLog?.selectedId).toBe('H-02');
   });
 

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -31,12 +31,15 @@ import {
   focusRound,
   initialSessionState,
   leaveExperimentDrilldown,
+  leaveHypothesisDetail,
   markEventStreamUnavailable,
   moveExperimentSelection,
+  moveHypothesisRoundSelection,
   moveThemeSelection,
   normalizeFocus,
   openChat,
   openExperimentLog,
+  openHypothesisDetail,
   openPane,
   openThemePicker,
   type PaneFocus,
@@ -100,9 +103,12 @@ export interface SessionController {
   togglePaneZoom(): void;
   setChatDockFits(fits: boolean): void;
   moveExperimentSelection(delta: number): void;
+  openHypothesisDetail(entryKey?: string): void;
+  moveHypothesisRoundSelection(delta: number): void;
   selectExperimentActivity(): void;
   enterExperimentDrilldown(): void;
   leaveExperimentDrilldown(): void;
+  leaveHypothesisDetail(): void;
   openThemePicker(): void;
   moveThemeSelection(delta: number): void;
   applySelectedTheme(): void;
@@ -306,7 +312,14 @@ export class SocketSessionController implements SessionController {
         `Already inside ${scope.id}. Esc returns to the experiment log.`,
       );
     }
-    const opened = enterExperimentDrilldown(this.#state);
+    const firstStep = enterExperimentDrilldown(this.#state);
+    // The ordinary UI stops at the hypothesis summary. `/open-round` names a
+    // round-level action explicitly, so it advances through that summary to
+    // the currently selected (latest by default) round.
+    const opened =
+      firstStep.hypothesisDetail !== null && firstStep.hypothesisScope === null
+        ? enterExperimentDrilldown(firstStep)
+        : firstStep;
     return opened === this.#state
       ? showDetail(this.#state, 'Select a hypothesis first, or use /open-round --N.')
       : opened;
@@ -394,6 +407,14 @@ export class SocketSessionController implements SessionController {
     this.#setState(moveExperimentSelection(this.#state, delta));
   }
 
+  openHypothesisDetail(entryKey?: string): void {
+    this.#setState(openHypothesisDetail(this.#state, entryKey));
+  }
+
+  moveHypothesisRoundSelection(delta: number): void {
+    this.#setState(moveHypothesisRoundSelection(this.#state, delta));
+  }
+
   selectExperimentActivity(): void {
     this.#setState(selectExperimentActivity(this.#state));
   }
@@ -404,6 +425,10 @@ export class SocketSessionController implements SessionController {
 
   leaveExperimentDrilldown(): void {
     this.#setState(leaveExperimentDrilldown(this.#state));
+  }
+
+  leaveHypothesisDetail(): void {
+    this.#setState(leaveHypothesisDetail(this.#state));
   }
 
   async #loadExperiments(): Promise<void> {

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -22,8 +22,10 @@ import {
   hypothesisPlanningActivity,
   initialSessionState,
   leaveExperimentDrilldown,
+  leaveHypothesisDetail,
   markEventStreamUnavailable,
   moveExperimentSelection,
+  moveHypothesisRoundSelection,
   moveThemeSelection,
   openChat,
   openPane,
@@ -1422,6 +1424,47 @@ describe('session event model', () => {
   });
 });
 
+describe('hypothesis detail navigation', () => {
+  const hypothesis = {
+    hypothesis_id: 'H-01',
+    identified: true,
+    claim: 'A complete causal hypothesis that must never be truncated in its detail view.',
+    first_round: 1,
+    last_round: 2,
+    rounds: [
+      {round: 1, passed: true, reviewed: true},
+      {round: 2, passed: false, reviewed: true},
+    ],
+    kept: false,
+    active: false,
+  };
+
+  it('moves from index to hypothesis to round and unwinds one level at a time', () => {
+    const landing = setExperiments(initialSessionState(), [hypothesis]);
+    const detail = enterExperimentDrilldown(landing);
+
+    expect(detail.hypothesisDetail).toEqual({entryKey: 'H-01', selectedRound: 2});
+    expect(detail.hypothesisScope).toBeNull();
+
+    const earlier = moveHypothesisRoundSelection(detail, -1);
+    expect(earlier.hypothesisDetail?.selectedRound).toBe(1);
+
+    const round = enterExperimentDrilldown(earlier);
+    expect(round.hypothesisScope).toMatchObject({id: 'H-01', rounds: [1, 2]});
+    expect(round.selectedRound).toBe(1);
+
+    const backToDetail = leaveExperimentDrilldown(round);
+    expect(backToDetail.hypothesisDetail?.selectedRound).toBe(1);
+    expect(leaveHypothesisDetail(backToDetail).hypothesisDetail).toBeNull();
+  });
+
+  it('closes a detail whose hypothesis disappears during refresh', () => {
+    const detail = enterExperimentDrilldown(setExperiments(initialSessionState(), [hypothesis]));
+
+    expect(setExperiments(detail, []).hypothesisDetail).toBeNull();
+  });
+});
+
 describe('docked experiment chat', () => {
   const entry = {
     hypothesis_id: 'H-01',
@@ -1438,8 +1481,12 @@ describe('docked experiment chat', () => {
     expect(chatDocked(landing)).toBe(true);
     expect(chatPaneVisible(landing)).toBe(true);
 
-    // Inside a hypothesis the row belongs to the transcript.
-    const scoped = enterExperimentDrilldown(landing);
+    // The hypothesis summary and its trajectories both use the full content
+    // column rather than competing with experiment chat.
+    const detail = enterExperimentDrilldown(landing);
+    expect(detail.hypothesisDetail).not.toBeNull();
+    expect(chatDocked(detail)).toBe(false);
+    const scoped = enterExperimentDrilldown(detail);
     expect(scoped.hypothesisScope).not.toBeNull();
     expect(chatDocked(scoped)).toBe(false);
   });

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -43,6 +43,8 @@ export interface SessionState {
   todosExpanded: boolean;
   themeName: ThemeName;
   experimentLog: ExperimentLogState | null;
+  /** Hypothesis summary between the experiment index and a round trajectory. */
+  hypothesisDetail: HypothesisDetail | null;
   hypothesisScope: HypothesisScope | null;
   layout: LayoutState;
   /**
@@ -104,6 +106,12 @@ export interface ExperimentLogState {
   selectedUnownedRound?: number | null;
   pending: boolean;
   error: string | null;
+}
+
+/** UI-only navigation state for the selected hypothesis summary. */
+export interface HypothesisDetail {
+  entryKey: string;
+  selectedRound: number | null;
 }
 
 /** A planning phase that has not produced a hypothesis record yet. */
@@ -221,6 +229,7 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
     // The experiment log is the landing view: a run's history reads as a short
     // list of claims before it reads as a long list of rounds.
     experimentLog: {entries: [], selectedId: null, pending: true, error: null},
+    hypothesisDetail: null,
     hypothesisScope: null,
     layout: {right: null, focus: 'left', zoomedPane: null},
     // Docked until the renderer measures otherwise, so the landing view carries
@@ -259,7 +268,12 @@ export function experimentLogVisible(state: SessionState): boolean {
  * it was.
  */
 export function chatDocked(state: SessionState): boolean {
-  return state.chatDockFits && state.experimentLog !== null && state.hypothesisScope === null;
+  return (
+    state.chatDockFits &&
+    state.experimentLog !== null &&
+    state.hypothesisDetail === null &&
+    state.hypothesisScope === null
+  );
 }
 
 /** True when the docked chat is the thing on screen rather than the modal. */
@@ -301,6 +315,7 @@ export function openExperimentLog(state: SessionState): SessionState {
     ...state,
     overlay: null,
     chatOpen: false,
+    hypothesisDetail: null,
     hypothesisScope: null,
     selectedRound: null,
     selectedAgentKind: null,
@@ -340,8 +355,26 @@ export function setExperiments(state: SessionState, entries: HypothesisEntry[]):
       : orderedEntries.length === 0
         ? (unownedRounds[0] ?? null)
         : null;
+  const currentDetail = state.hypothesisDetail;
+  const detailEntry =
+    currentDetail === null
+      ? undefined
+      : orderedEntries.find((entry, index) => entryKey(entry, index) === currentDetail.entryKey);
+  const detailRounds = detailEntry === undefined ? [] : scopeRounds(detailEntry);
+  const hypothesisDetail =
+    currentDetail === null || detailEntry === undefined
+      ? null
+      : {
+          entryKey: currentDetail.entryKey,
+          selectedRound:
+            currentDetail.selectedRound !== null &&
+            detailRounds.includes(currentDetail.selectedRound)
+              ? currentDetail.selectedRound
+              : (detailRounds.at(-1) ?? null),
+        };
   return {
     ...state,
+    hypothesisDetail,
     experimentLog: {
       ...log,
       entries: orderedEntries,
@@ -363,7 +396,8 @@ export function failExperiments(state: SessionState, error: string): SessionStat
 
 export function moveExperimentSelection(state: SessionState, delta: number): SessionState {
   const log = state.experimentLog;
-  if (log === null || state.hypothesisScope !== null) return state;
+  if (log === null || state.hypothesisDetail !== null || state.hypothesisScope !== null)
+    return state;
   const items = experimentIndexItems(state);
   if (items.length === 0) return state;
   const selected = selectedExperimentIndexItem(state);
@@ -372,11 +406,63 @@ export function moveExperimentSelection(state: SessionState, delta: number): Ses
   return selectExperimentIndexItem(state, items[index]);
 }
 
+/** Open one hypothesis summary without entering any of its round trajectories. */
+export function openHypothesisDetail(state: SessionState, requestedKey?: string): SessionState {
+  const log = state.experimentLog;
+  if (log === null || state.hypothesisScope !== null) return state;
+  const key = requestedKey ?? log.selectedId;
+  if (key === null) return state;
+  const entry = log.entries.find((candidate, index) => entryKey(candidate, index) === key);
+  if (entry === undefined) return state;
+  const rounds = scopeRounds(entry);
+  return {
+    ...state,
+    overlay: null,
+    chatOpen: false,
+    layout: {right: null, focus: 'left', zoomedPane: null},
+    experimentLog: {
+      ...log,
+      selectedId: key,
+      selectedActivity: false,
+      selectedActivityRound: null,
+      selectedUnownedRound: null,
+    },
+    hypothesisDetail: {entryKey: key, selectedRound: rounds.at(-1) ?? null},
+  };
+}
+
+/** The durable hypothesis selected for the summary view. */
+export function detailedHypothesis(state: SessionState): HypothesisEntry | null {
+  const detail = state.hypothesisDetail;
+  const entries = state.experimentLog?.entries ?? [];
+  if (detail === null) return null;
+  return entries.find((entry, index) => entryKey(entry, index) === detail.entryKey) ?? null;
+}
+
+/** Move the round cursor within the open hypothesis summary. */
+export function moveHypothesisRoundSelection(state: SessionState, delta: number): SessionState {
+  const detail = state.hypothesisDetail;
+  const entry = detailedHypothesis(state);
+  if (detail === null || entry === null || state.hypothesisScope !== null) return state;
+  const rounds = scopeRounds(entry);
+  if (rounds.length === 0) return state;
+  const current = detail.selectedRound === null ? -1 : rounds.indexOf(detail.selectedRound);
+  const index = current === -1 ? 0 : Math.min(rounds.length - 1, Math.max(0, current + delta));
+  return {...state, hypothesisDetail: {...detail, selectedRound: rounds[index] ?? null}};
+}
+
+/** Return from a hypothesis summary to the experiment index. */
+export function leaveHypothesisDetail(state: SessionState): SessionState {
+  if (state.hypothesisDetail === null || state.hypothesisScope !== null) return state;
+  return {...state, hypothesisDetail: null};
+}
+
 /** Selects the current planning work so Enter opens its live agent turns. */
 export function selectExperimentActivity(state: SessionState): SessionState {
   const log = state.experimentLog;
   if (
     log === null ||
+    state.hypothesisDetail !== null ||
     state.hypothesisScope !== null ||
     hypothesisPlanningActivity(state) === null
   ) {
@@ -395,10 +481,14 @@ export function selectExperimentActivity(state: SessionState): SessionState {
 }
 
 /**
- * Opens the rounds behind the selected hypothesis. The log keeps its selection
- * so leaving the trajectory lands the operator back on the same row.
+ * Advances the experiment navigation by one level: index to hypothesis
+ * summary, then hypothesis summary to its selected round trajectory.
  */
 export function enterExperimentDrilldown(state: SessionState): SessionState {
+  if (state.hypothesisDetail !== null) {
+    const roundNumber = state.hypothesisDetail.selectedRound;
+    return roundNumber === null ? state : (enterExperimentRound(state, roundNumber) ?? state);
+  }
   const activity = hypothesisPlanningActivity(state);
   if (
     activity !== null &&
@@ -416,33 +506,10 @@ export function enterExperimentDrilldown(state: SessionState): SessionState {
   }
   const entry = selectedExperiment(state);
   if (entry === null || state.hypothesisScope !== null) return state;
-  const rounds = scopeRounds(entry);
-  if (rounds.length === 0) return state;
-  return {
-    ...state,
-    overlay: null,
-    // A visualization opened from the log belongs to the log. Carrying it into
-    // the round view would leave the operator reading one view's answer beside
-    // another view's transcript.
-    layout: {right: null, focus: 'left', zoomedPane: null},
-    hypothesisScope: {
-      id: entry.hypothesis_id,
-      label: hypothesisLabel(entry),
-      rounds,
-      source: 'hypothesis',
-    },
-    // Land on the hypothesis's latest round rather than on "no round". The
-    // round view is built around one round: the strip marks it, the agent graph
-    // draws its phases, the transcript carries its turns. Leaving the round
-    // unset drew an empty strip and an empty graph, and `[` walks back through
-    // the earlier rounds from here anyway.
-    selectedRound: rounds.at(-1) ?? null,
-    selectedAgentKind: null,
-    selectedEntryId: null,
-  };
+  return openHypothesisDetail(state);
 }
 
-/** Leaves the trajectory and returns to the table with the selection intact. */
+/** Leaves a trajectory for its hypothesis summary, preserving the round cursor. */
 export function leaveExperimentDrilldown(state: SessionState): SessionState {
   if (state.hypothesisScope === null) return state;
   return {...state, hypothesisScope: null, selectedRound: null, selectedAgentKind: null};
@@ -457,10 +524,11 @@ export function enterExperimentRound(
   state: SessionState,
   roundNumber: number,
 ): SessionState | null {
-  const entry = (state.experimentLog?.entries ?? []).find(candidate =>
-    scopeRounds(candidate).includes(roundNumber),
-  );
+  const entries = state.experimentLog?.entries ?? [];
+  const entryIndex = entries.findIndex(candidate => scopeRounds(candidate).includes(roundNumber));
+  const entry = entries[entryIndex];
   if (entry === undefined) return null;
+  const entryKeyValue = entryKey(entry, entryIndex);
   const scoped: SessionState = {
     ...state,
     overlay: null,
@@ -475,10 +543,9 @@ export function enterExperimentRound(
     selectedRound: roundNumber,
     selectedAgentKind: null,
     selectedEntryId: null,
+    hypothesisDetail: {entryKey: entryKeyValue, selectedRound: roundNumber},
     experimentLog:
-      state.experimentLog === null
-        ? null
-        : {...state.experimentLog, selectedId: entryKeyFor(state.experimentLog.entries, entry)},
+      state.experimentLog === null ? null : {...state.experimentLog, selectedId: entryKeyValue},
   };
   return scoped;
 }
@@ -498,6 +565,7 @@ export function enterUnownedExperimentRound(
     overlay: null,
     chatOpen: false,
     layout: {right: null, focus: 'left', zoomedPane: null},
+    hypothesisDetail: null,
     hypothesisScope: {
       id: `round-${roundNumber}`,
       label: `Round ${roundNumber}`,
@@ -525,6 +593,11 @@ function scopeRounds(entry: HypothesisEntry): number[] {
     {length: Math.max(0, entry.last_round - entry.first_round + 1)},
     (_, index) => entry.first_round + index,
   );
+}
+
+/** Ordered round identities owned by a hypothesis, including legacy range-only records. */
+export function hypothesisRoundNumbers(entry: HypothesisEntry): number[] {
+  return scopeRounds(entry);
 }
 
 function hypothesisLabel(entry: HypothesisEntry): string {
@@ -1272,6 +1345,7 @@ export function showLive(state: SessionState): SessionState {
     ...state,
     overlay: null,
     chatOpen: false,
+    hypothesisDetail: null,
     hypothesisScope: null,
     selectedRound: null,
     selectedAgentKind: null,

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -18,10 +18,13 @@ import {
   focusRound,
   initialSessionState,
   leaveExperimentDrilldown,
+  leaveHypothesisDetail,
   moveExperimentSelection,
+  moveHypothesisRoundSelection,
   moveThemeSelection,
   normalizeFocus,
   openExperimentLog,
+  openHypothesisDetail,
   openPane,
   type PaneFocus,
   type PaneView,
@@ -1904,7 +1907,7 @@ describe('theming', () => {
     expect(landing).not.toContain('Agents');
   });
 
-  it('opens the round trajectory behind a hypothesis and steps back out', async () => {
+  it('drills from a full hypothesis summary into a round trajectory and back', async () => {
     const testRenderer = await createTestRenderer({width: 120, height: 24});
     const controller = new FakeController({
       ...initialSessionState(),
@@ -1947,7 +1950,8 @@ describe('theming', () => {
         rounds: [{round: 41, passed: true, reviewed: true}],
       }),
       logEntry('H-08', 42, 43, {
-        claim: 'bigger KV cache block',
+        claim:
+          'Increasing the KV cache block should reduce allocator synchronization across producer and consumer operations without changing queue ordering.',
         resolved_outcome: 'rejected',
         rounds: [
           {round: 42, passed: false, reviewed: false},
@@ -1963,6 +1967,19 @@ describe('theming', () => {
     expect(table).not.toContain('grew the block');
 
     testRenderer.mockInput.pressKey('ARROW_DOWN');
+    testRenderer.mockInput.pressEnter();
+    const detail = await frameAfter(testRenderer);
+
+    expect(detail).toContain('Hypothesis H-08');
+    expect(detail).toContain(
+      'Increasing the KV cache block should reduce allocator synchronization',
+    );
+    expect(detail).toContain('without changing queue ordering.');
+    expect(detail).toContain('Decision Rejected');
+    expect(detail).toContain('Round 42 · Judge pending');
+    expect(detail).toContain('Round 43 · Judge fail');
+    expect(controller.state.hypothesisScope).toBeNull();
+
     testRenderer.mockInput.pressEnter();
     const trajectory = await frameAfter(testRenderer);
 
@@ -1980,9 +1997,13 @@ describe('theming', () => {
     expect(controller.state.hypothesisScope).toMatchObject({id: 'H-08', rounds: [42, 43]});
 
     testRenderer.mockInput.pressKey('ESCAPE');
-    const back = await frameAfterEscape(testRenderer);
-    expect(back).toContain('Implementation Details');
-    expect(back).not.toContain('grew the block');
+    const backToHypothesis = await frameAfterEscape(testRenderer);
+    expect(backToHypothesis).toContain('Increasing the KV cache block');
+    expect(backToHypothesis).not.toContain('grew the block');
+
+    testRenderer.mockInput.pressKey('ESCAPE');
+    const backToIndex = await frameAfterEscape(testRenderer);
+    expect(backToIndex).toContain('Implementation Details');
     expect(controller.state.experimentLog?.selectedId).toBe('H-08');
   });
 
@@ -2504,12 +2525,18 @@ describe('theming', () => {
     expect(controller.state.layout.focus).toBe('left');
   });
 
-  it('focuses hypothesis panes from their inner content and routes the next key', async () => {
+  it('opens hypothesis detail from a row click and keeps pane clicks routed', async () => {
     const testRenderer = await createTestRenderer({width: 200, height: 22});
     const controller = logController();
     controller.experiments = [
       logEntry('H-07', 41, 41, {claim: 'batch the prefill step'}),
-      logEntry('H-08', 42, 42, {claim: 'increase the cache block'}),
+      logEntry('H-08', 42, 43, {
+        claim: 'increase the cache block',
+        rounds: [
+          {round: 42, passed: true, reviewed: true},
+          {round: 43, passed: false, reviewed: true},
+        ],
+      }),
     ];
     controller.paneContent = 'Performance · tok_s\nbest r7 1135 tok_s';
     const app = createOpenTuiApp(testRenderer.renderer, controller);
@@ -2519,7 +2546,8 @@ describe('theming', () => {
     let frame = await frameAfter(testRenderer);
     expect(controller.state.layout.focus).toBe('right');
 
-    // A table row both selects its hypothesis and focuses Experiments.
+    // A table row opens the hypothesis summary directly and gives it the full
+    // content row, closing an unrelated visualization.
     let lines = frame.split('\n');
     let row = lines.findIndex(line => line.includes('H-08'));
     let column = (lines[row]?.indexOf('H-08') ?? 0) + 2;
@@ -2527,10 +2555,28 @@ describe('theming', () => {
     frame = await frameAfter(testRenderer);
     expect(controller.state.layout.focus).toBe('left');
     expect(controller.state.experimentLog?.selectedId).toBe('H-08');
-    expect(frame).toContain('▸ Experiments');
+    expect(controller.state.hypothesisDetail).toEqual({entryKey: 'H-08', selectedRound: 43});
+    expect(controller.state.layout.right).toBeNull();
+    expect(frame).toContain('▸ Hypothesis H-08');
     testRenderer.mockInput.pressKey('ARROW_UP');
+    frame = await frameAfter(testRenderer);
+    expect(controller.state.hypothesisDetail?.selectedRound).toBe(42);
+
+    lines = frame.split('\n');
+    row = lines.findIndex(line => line.includes('Round 42'));
+    column = (lines[row]?.indexOf('Round 42') ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
     await frameAfter(testRenderer);
-    expect(controller.state.experimentLog?.selectedId).toBe('H-07');
+    expect(controller.state.hypothesisScope).toMatchObject({id: 'H-08'});
+    expect(controller.state.selectedRound).toBe(42);
+
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await frameAfterEscape(testRenderer);
+    expect(controller.state.hypothesisDetail?.selectedRound).toBe(42);
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await frameAfterEscape(testRenderer);
+    await controller.openPane('perf');
+    frame = await frameAfter(testRenderer);
 
     // The chart body is inside a scroll surface. Clicking it focuses the
     // performance pane, so Escape is routed there and closes it.
@@ -3207,6 +3253,12 @@ class FakeController implements SessionController {
   moveExperimentSelection(delta: number): void {
     this.publish(moveExperimentSelection(this.state, delta));
   }
+  openHypothesisDetail(entryKey?: string): void {
+    this.publish(openHypothesisDetail(this.state, entryKey));
+  }
+  moveHypothesisRoundSelection(delta: number): void {
+    this.publish(moveHypothesisRoundSelection(this.state, delta));
+  }
   selectExperimentActivity(): void {
     this.publish(selectExperimentActivity(this.state));
   }
@@ -3252,6 +3304,9 @@ class FakeController implements SessionController {
   }
   leaveExperimentDrilldown(): void {
     this.publish(leaveExperimentDrilldown(this.state));
+  }
+  leaveHypothesisDetail(): void {
+    this.publish(leaveHypothesisDetail(this.state));
   }
 
   subscribe(listener: (state: SessionState) => void): () => void {

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -39,9 +39,11 @@ const KEY_HELP =
 const SCOPED_KEY_HELP =
   '[/]: round · ←→: pane · ↑↓/Tab: within it · F4: zoom · /todos · /prompt · Esc: back';
 const LOG_KEY_HELP =
-  '↑↓ or scroll: select · Enter or /open-round: open its rounds · F4: zoom · /open-round --N';
+  '↑↓ or scroll: select · Enter/click: open hypothesis · F4: zoom · /open-round --N';
 const LOG_CHAT_KEY_HELP =
-  '↑↓: select · Enter: open its rounds · Ctrl+W: chat and back · F4: zoom · /open-round --N';
+  '↑↓: select · Enter/click: hypothesis · Ctrl+W: chat · F4: zoom · /open-round --N';
+const HYPOTHESIS_KEY_HELP =
+  '↑↓: select round · Enter/click: trajectory · PgUp/PgDn: scroll · Esc: hypotheses';
 const SPLIT_KEY_HELP =
   'Ctrl+W: switch pane · F4: zoom focused pane · PgUp/PgDn: scroll · Esc: close pane';
 
@@ -262,7 +264,7 @@ export function createOpenTuiApp(
     // for the state to come back, so a resize never draws a stale row.
     const dockFits = chatDockFits(renderer.terminalWidth, rightWidth);
     if (state.chatDockFits !== dockFits) controller.setChatDockFits(dockFits);
-    const chatAvailable = showLog && dockFits && !state.chatOpen;
+    const chatAvailable = showLog && state.hypothesisDetail === null && dockFits && !state.chatOpen;
     const showChatPane = chatAvailable && (zoomedPane === null || zoomedPane === 'chat');
     const chatWidth = showChatPane
       ? zoomedPane === 'chat'
@@ -283,9 +285,11 @@ export function createOpenTuiApp(
     renderedKeyHelp = showSplit
       ? SPLIT_KEY_HELP
       : showLog
-        ? showChatPane
-          ? LOG_CHAT_KEY_HELP
-          : LOG_KEY_HELP
+        ? state.hypothesisDetail !== null
+          ? HYPOTHESIS_KEY_HELP
+          : showChatPane
+            ? LOG_CHAT_KEY_HELP
+            : LOG_KEY_HELP
         : state.hypothesisScope === null
           ? KEY_HELP
           : SCOPED_KEY_HELP;
@@ -386,6 +390,7 @@ export function createOpenTuiApp(
     toggleTodos: () => controller.toggleTodos(),
     scrollRightPane: delta => rightPane.scrollBy(delta),
     scrollChatPane: delta => chatPane.scrollBy(delta),
+    scrollExperimentDetail: delta => experimentLog.scrollBy(delta),
     scrollErrorBanner: delta => errorBanner.scrollBy(delta),
     clearTransientStatus: () => {
       if (transientStatus === null) return;

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -1,13 +1,15 @@
 import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
-import type {HypothesisEntry} from '@vibesys/backend-client';
+import type {HypothesisEntry, HypothesisRound} from '@vibesys/backend-client';
 import type {SessionController} from '../session-controller.js';
 import {
+  detailedHypothesis,
   type ExperimentIndexItem,
   experimentIndexItems,
   experimentLogVisible,
   focusedPane,
   type HypothesisPlanningActivity,
   hypothesisPlanningActivity,
+  hypothesisRoundNumbers,
   type SessionState,
   selectedExperimentIndexItem,
   unownedExperimentRounds,
@@ -155,9 +157,17 @@ export class ExperimentLogView {
     this.output.title = focused ? ' ▸ Experiments ' : ' Experiments ';
     const width = this.#availableWidth ?? this.renderer.terminalWidth;
     if (state === this.#renderedState && width === this.#renderedWidth) return;
+    const previousDetailKey = this.#renderedState?.hypothesisDetail?.entryKey ?? null;
     this.#renderedState = state;
     this.#renderedWidth = width;
     this.#clear();
+
+    const detail = detailedHypothesis(state);
+    if (detail !== null) {
+      this.#renderDetail(detail, state);
+      if (previousDetailKey !== state.hypothesisDetail?.entryKey) this.#rows.scrollTo(0);
+      return;
+    }
 
     if (log.error !== null) {
       this.#header.content = '';
@@ -230,7 +240,7 @@ export class ExperimentLogView {
       const isSelected = item.key === selected?.key;
       if (item.kind === 'hypothesis') {
         const entryIndex = log.entries.indexOf(item.entry);
-        this.#row(item.entry, columns, isSelected, entryIndex, navigationIndex);
+        this.#row(item.entry, item.key, columns, isSelected, entryIndex);
         if (isSelected) selectedRenderIndex = renderedRows;
         renderedRows += 1;
       } else if (item.kind === 'round') {
@@ -257,9 +267,49 @@ export class ExperimentLogView {
     // reads as breakage rather than as a narrow terminal.
     const hint =
       this.#bodyWidth() >= HINT_MIN_WIDTH
-        ? '↑↓ or scroll: select · Enter or /open-round: open its rounds'
+        ? '↑↓ or scroll: select · Enter or click: open hypothesis'
         : '↑↓ · Enter';
     this.#footerLine.content = `${position} · ${hint}`;
+  }
+
+  #renderDetail(entry: HypothesisEntry, state: SessionState): void {
+    const selectedRound = state.hypothesisDetail?.selectedRound ?? null;
+    this.output.title = ` ${focusedTitlePrefix(state)}Hypothesis ${entry.hypothesis_id} `;
+    this.#header.content = hypothesisMetadata(entry);
+    this.#line('HYPOTHESIS', this.#theme.textSubtle);
+    this.#wrappedLine(
+      entry.claim?.trim() || 'No hypothesis text was recorded.',
+      this.#theme.textPrimary,
+    );
+    this.#line('', this.#theme.textPrimary);
+    this.#line('ROUNDS', this.#theme.textSubtle);
+    const rounds = hypothesisRoundNumbers(entry);
+    if (rounds.length === 0) {
+      this.#line('No recorded rounds.', this.#theme.textSubtle);
+    } else {
+      for (const roundNumber of rounds) {
+        const round = entry.rounds?.find(candidate => candidate.round === roundNumber);
+        const selected = roundNumber === selectedRound;
+        const row = new BoxRenderable(this.renderer, {
+          id: `hypothesis-round-${roundNumber}`,
+          width: '100%',
+          height: 1,
+          flexShrink: 0,
+          ...(selected ? {backgroundColor: this.#theme.selectedSurface} : {}),
+          onMouseUp: () => this.controller.openRound(roundNumber),
+        });
+        row.add(
+          this.#cell(
+            `${selected ? '›' : ' '} ${roundMetadata(roundNumber, round)}`,
+            this.#theme.textPrimary,
+            selected,
+          ),
+        );
+        this.#rows.add(row);
+      }
+    }
+    this.#footerLine.content =
+      '↑↓: select round · Enter or click: open trajectory · Esc: hypotheses';
   }
 
   #renderActivity(
@@ -278,10 +328,10 @@ export class ExperimentLogView {
 
   #row(
     entry: HypothesisEntry,
+    entryKey: string,
     columns: Columns,
     isSelected: boolean,
     index: number,
-    navigationIndex: number,
   ): void {
     const cells = entryCells(entry, columns);
     // The active hypothesis is called out on its own, so it stays visible
@@ -297,7 +347,7 @@ export class ExperimentLogView {
       ...selection,
       onMouseUp: () => {
         this.controller.focusPane('left');
-        this.controller.moveExperimentSelection(navigationIndex - this.#selectedNavigationIndex());
+        this.controller.openHypothesisDetail(entryKey);
       },
     });
     // The outcome is its own renderable so the resolution can carry a color of
@@ -406,6 +456,23 @@ export class ExperimentLogView {
     });
     this.#rows.add(text);
     return text;
+  }
+
+  #wrappedLine(content: string, fg: string): TextRenderable {
+    const text = new TextRenderable(this.renderer, {
+      content,
+      fg,
+      width: '100%',
+      flexShrink: 0,
+      wrapMode: 'word',
+    });
+    this.#rows.add(text);
+    return text;
+  }
+
+  /** Scroll hypothesis prose without moving the round selection. */
+  scrollBy(delta: number): void {
+    this.#rows.scrollBy(delta, 'viewport');
   }
 
   #bodyWidth(): number {
@@ -568,6 +635,32 @@ export function formatMeasured(entry: HypothesisEntry): string {
   }
   if (typeof entry.perf_metric === 'number') return trimNumber(entry.perf_metric);
   return '—';
+}
+
+function focusedTitlePrefix(state: SessionState): string {
+  return focusedPane(state) === 'experiments' ? '▸ ' : '';
+}
+
+function hypothesisMetadata(entry: HypothesisEntry): string {
+  const parts = [`Rounds ${formatRounds(entry)}`];
+  if (entry.judge_verdict !== null && entry.judge_verdict !== undefined) {
+    parts.push(`Judge ${sentenceCase(entry.judge_verdict)}`);
+  }
+  parts.push(`Decision ${outcomeLabel(entry)}`);
+  if (entry.kept === true) parts.push('Candidate kept');
+  else if (entry.kept === false) parts.push('Candidate reverted');
+  return parts.join(' · ');
+}
+
+function roundMetadata(roundNumber: number, round: HypothesisRound | undefined): string {
+  const parts = [`Round ${roundNumber}`];
+  if (round !== undefined) {
+    parts.push(round.reviewed ? `Judge ${round.passed ? 'pass' : 'fail'}` : 'Judge pending');
+  }
+  if (typeof round?.perf_metric === 'number') {
+    parts.push(`${trimNumber(round.perf_metric)}${round.perf_unit ? ` ${round.perf_unit}` : ''}`);
+  }
+  return parts.join(' · ');
 }
 
 function planningHypothesisLabel(existingHypotheses: number): string {

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -17,6 +17,7 @@ export interface KeybindingActions {
   toggleTodos(): void;
   scrollRightPane(delta: number): void;
   scrollChatPane(delta: number): void;
+  scrollExperimentDetail(delta: number): void;
   scrollErrorBanner(delta: number): void;
   clearTransientStatus(): void;
   showClipboardStatus(result: Exclude<ClipboardCopyResult, 'no-selection'>): void;
@@ -145,20 +146,25 @@ export function bindKeybindings(
       key.preventDefault();
       return;
     }
-    // The experiment log owns navigation while the table is on screen: arrows
-    // move the selection instead of the input cursor, and Enter opens the
-    // rounds behind the selected hypothesis. The input keeps priority over the
-    // table, so a typed command runs on its own Enter and its result opens over
-    // the log rather than the log swallowing the keystroke.
+    // The experiment surface owns navigation while it is on screen. The index
+    // opens a hypothesis summary; that summary selects and opens one round.
+    // The input keeps priority over Enter so a typed command is never lost.
     if (experimentLogVisible(controller.state)) {
-      // Escape has nowhere to go from the root view: the log is the root.
-      // Arrows move the table's selection from the moment the log is on screen:
-      // the table is the view, so it should not need to be clicked into first.
-      if (key.name === 'up') controller.moveExperimentSelection(-1);
-      else if (key.name === 'down') controller.moveExperimentSelection(1);
-      else if (key.name === 'pageup') controller.moveExperimentSelection(-10);
-      else if (key.name === 'pagedown') controller.moveExperimentSelection(10);
-      else if (key.name === 'return' || key.name === 'enter') {
+      const detailOpen = controller.state.hypothesisDetail !== null;
+      if (key.name === 'escape' && detailOpen) controller.leaveHypothesisDetail();
+      else if (key.name === 'up') {
+        if (detailOpen) controller.moveHypothesisRoundSelection(-1);
+        else controller.moveExperimentSelection(-1);
+      } else if (key.name === 'down') {
+        if (detailOpen) controller.moveHypothesisRoundSelection(1);
+        else controller.moveExperimentSelection(1);
+      } else if (key.name === 'pageup') {
+        if (detailOpen) actions.scrollExperimentDetail(-1);
+        else controller.moveExperimentSelection(-10);
+      } else if (key.name === 'pagedown') {
+        if (detailOpen) actions.scrollExperimentDetail(1);
+        else controller.moveExperimentSelection(10);
+      } else if (key.name === 'return' || key.name === 'enter') {
         // A typed command belongs to the input; let its own handler run it so
         // one Enter is enough. An overlay is in front of the table, so Enter
         // behind it must not move the operator somewhere they cannot see.

--- a/scripts/verify_installed_release.py
+++ b/scripts/verify_installed_release.py
@@ -22,6 +22,7 @@ from typing import Never, cast
 from vibesys.cli import bundled_tui
 from vibesys.evaluators import EvaluatorPackageRequirement, resolve_evaluator_package
 from vibesys.input_project import materialize_input_project
+from vibesys.loops.agent.state import AgentRunStateStore
 from vibesys.profilers import ACTIVE_PROFILER_KINDS
 from vibesys.resource_paths import (
     default_skill_roots,
@@ -445,7 +446,10 @@ def _verify_project_state(project_root: Path) -> None:
     if len(runs) != 1 or not runs[0].run_id.endswith("-installed-release-smoke"):
         _fail(f"Project smoke did not create exactly one run: {runs}")
     run = runs[0]
-    completed_rounds = store.load_rounds(run.run_id)
+    agent_state = AgentRunStateStore(
+        store.portable_namespace(run.run_id, "agent")
+    ).load()
+    completed_rounds = agent_state.rounds
     if len(completed_rounds) != 1 or completed_rounds[0].round_number != 1:
         _fail("Project smoke did not persist exactly one completed round")
     if store.current_run_id() != run.run_id:

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -2127,6 +2127,10 @@ def test_resume_migrates_legacy_hypothesis_state_without_losing_continuation(
     subprocess.run(
         [  # noqa: S607  # test fixture
             "git",
+            "-c",
+            "user.name=VibeSys Test",
+            "-c",
+            "user.email=test@vibesys.invalid",
             "commit",
             "-m",
             "test: restore legacy hypothesis state",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -184,7 +184,14 @@ def _create_context(  # noqa: PLR0913
 
 def _git(project: Path, *args: str) -> str:
     return subprocess.run(  # noqa: S603
-        ["git", *args],  # noqa: S607
+        [
+            "git",
+            "-c",
+            "user.name=VibeSys Test",
+            "-c",
+            "user.email=test@vibesys.invalid",
+            *args,
+        ],  # noqa: S607
         cwd=project,
         check=True,
         capture_output=True,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -184,14 +184,14 @@ def _create_context(  # noqa: PLR0913
 
 def _git(project: Path, *args: str) -> str:
     return subprocess.run(  # noqa: S603
-        [
+        [  # noqa: S607
             "git",
             "-c",
             "user.name=VibeSys Test",
             "-c",
             "user.email=test@vibesys.invalid",
             *args,
-        ],  # noqa: S607
+        ],
         cwd=project,
         check=True,
         capture_output=True,

--- a/tests/test_installed_release_verifier.py
+++ b/tests/test_installed_release_verifier.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from scripts import verify_installed_release as verifier  # pyright: ignore[reportMissingImports]
@@ -294,3 +295,51 @@ def test_project_smoke_requires_exactly_one_run(
     monkeypatch.setattr(verifier, "Project", _ProjectWithoutRuns)
     with pytest.raises(verifier.InstalledReleaseError, match="exactly one run"):
         verifier._verify_project_state(tmp_path)  # noqa: SLF001
+
+
+def test_project_smoke_reads_rounds_from_authoritative_agent_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = "test-installed-release-smoke"
+    namespace = object()
+    log_directory = tmp_path / "logs"
+    log_directory.mkdir()
+    (tmp_path / ".git").mkdir()
+
+    class _State:
+        def load_project(self) -> object:
+            return object()
+
+        def list_runs(self) -> list[object]:
+            return [SimpleNamespace(run_id=run_id)]
+
+        def portable_namespace(self, actual_run_id: str, name: str) -> object:
+            assert (actual_run_id, name) == (run_id, "agent")
+            return namespace
+
+        def current_run_id(self) -> str:
+            return run_id
+
+        def log_directory(self, actual_run_id: str) -> Path:
+            assert actual_run_id == run_id
+            return log_directory
+
+    class _Project:
+        state = _State()
+
+        @classmethod
+        def open(cls, _root: Path) -> _Project:
+            return cls()
+
+    class _AgentStateStore:
+        def __init__(self, actual_namespace: object) -> None:
+            assert actual_namespace is namespace
+
+        def load(self) -> object:
+            return SimpleNamespace(rounds=[SimpleNamespace(round_number=1)])
+
+    monkeypatch.setattr(verifier, "Project", _Project)
+    monkeypatch.setattr(verifier, "AgentRunStateStore", _AgentStateStore)
+
+    verifier._verify_project_state(tmp_path)  # noqa: SLF001


### PR DESCRIPTION
## Problem

The experiment index truncates hypothesis text and jumps directly from a row into a round trajectory. Readers cannot inspect the complete causal claim before deciding whether to open the much larger agent history.

## Solution

Add a hypothesis summary between the experiment index and round trajectory. Clicking a hypothesis row or pressing Enter opens its complete wrapped hypothesis text, concise decision metadata, and chronological rounds. Clicking a round or pressing Enter opens its existing agent trajectory. Escape unwinds one level at a time.

`/open-round` and `/open-round --N` remain explicit shortcuts directly to round detail. The backend protocol is unchanged.

### Architecture

The backend-derived core remains presentation-neutral. `SessionState` owns the UI-only hypothesis detail and round cursor, pure transition functions implement navigation, the controller exposes those transitions, and OpenTUI renders and routes input.

```mermaid
flowchart LR
    Events[Backend event and query state] --> Core[core-state projection]
    Core --> Index[Hypothesis index]
    Index -->|click or Enter| Detail[Hypothesis detail]
    Detail -->|click round or Enter| Round[Round trajectory]
    Round -->|Esc| Detail
    Detail -->|Esc| Index
```

The release verifier also follows the authoritative hypothesis aggregate introduced on `main`, instead of querying removed legacy round files. Git-writing migration fixtures now provide repository-local test identities so they are hermetic on fresh CI runners.

## Verification

Automated tests cover pure navigation, refresh reconciliation, full wrapped text, keyboard traversal, row and round clicks, direct `/open-round` shortcuts, back navigation, and authoritative installed-release round lookup. A manual resume against queue-rs confirmed the complete persisted m1 hypothesis, round 1 agent graph, and prior transcript are reachable through the new hierarchy.

### Correctness properties

- Hypothesis text is displayed from the existing unmodified `claim` field and is never truncated in detail view.
- Index selection survives entering and leaving detail views.
- Round selection survives returning from a trajectory.
- Experiment refreshes preserve valid detail state and close it if its hypothesis disappears.
- Legacy range-only hypotheses keep navigable round links.
- Backend-derived state and protocol types do not depend on UI navigation.
- Direct round commands retain their previous behavior.
- Installed-release verification reads completed rounds from `agent/state.json`, the same authoritative aggregate used by the backend.

### Testing

- `pnpm --filter @vibesys/tui test`: 379 passed
- `pnpm check:clients`: passed
- `pnpm check:ts-architecture`: passed, 68 modules and 216 dependencies, no violations
- `pnpm test:ts-architecture`: 2 passed
- `uv run pytest -q tests/loops/agent/test_orchestrate.py::test_resume_migrates_legacy_hypothesis_state_without_losing_continuation tests/test_context.py::test_resume_migrates_legacy_objectives_with_dirty_candidate tests/test_installed_release_verifier.py`: 12 passed
- `uv run ruff format --check ...`: passed
- `uv run ruff check ...`: passed
- `uv run pyright ...`: 0 errors
- `git diff --check`: passed
- Manual: `cd queue-rs && vibesys --resume --max-rounds 7`, opened m1 summary, opened round 1, verified historical agents/transcript, escaped to summary and index
