### PR TITLE
Require orchestrator-generated short titles for hypotheses

### DIFF
--- a/clients/backend-client/src/generated/protocol.generated.ts
+++ b/clients/backend-client/src/generated/protocol.generated.ts
@@ -259,6 +259,7 @@ export type ProfileSkipped = boolean;
 export type Performance = PerformanceRound[];
 export type HypothesisId = string;
 export type Identified = boolean;
+export type Title = string | null;
 export type Claim = string | null;
 export type Action1 = string | null;
 export type FirstRound = number;
@@ -658,6 +659,7 @@ export interface PerformanceRound {
 export interface HypothesisEntry {
   hypothesis_id: HypothesisId;
   identified?: Identified;
+  title?: Title;
   claim?: Claim;
   action?: Action1;
   first_round: FirstRound;

--- a/clients/backend-client/src/generated/protocol.schema.json
+++ b/clients/backend-client/src/generated/protocol.schema.json
@@ -809,6 +809,18 @@
           "title": "Identified",
           "type": "boolean"
         },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        },
         "claim": {
           "anyOf": [
             {

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -336,6 +336,45 @@ describe('hypothesis planning activity', () => {
   });
 });
 
+describe('hypothesis scope label', () => {
+  it('prefers the backend-supplied title over the hypothesis id', () => {
+    const state = setExperiments(initialSessionState(), [
+      {
+        hypothesis_id: 'H-01',
+        identified: true,
+        title: 'Batch decode requests',
+        first_round: 1,
+        last_round: 1,
+        rounds: [{round: 1, passed: true, reviewed: true}],
+        kept: false,
+        active: false,
+      },
+    ]);
+
+    const opened = enterExperimentDrilldown(state);
+
+    expect(opened.hypothesisScope).toMatchObject({id: 'H-01', label: 'Batch decode requests · r1'});
+  });
+
+  it('falls back to the hypothesis id when there is no title', () => {
+    const state = setExperiments(initialSessionState(), [
+      {
+        hypothesis_id: 'H-01',
+        identified: true,
+        first_round: 1,
+        last_round: 1,
+        rounds: [{round: 1, passed: true, reviewed: true}],
+        kept: false,
+        active: false,
+      },
+    ]);
+
+    const opened = enterExperimentDrilldown(state);
+
+    expect(opened.hypothesisScope).toMatchObject({id: 'H-01', label: 'H-01 · r1'});
+  });
+});
+
 describe('unowned rounds', () => {
   it('opens an observed round and keeps its turns scoped to that round', () => {
     const state = {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -532,7 +532,7 @@ function hypothesisLabel(entry: HypothesisEntry): string {
     entry.first_round === entry.last_round
       ? `r${entry.first_round}`
       : `r${entry.first_round}-${entry.last_round}`;
-  return `${entry.hypothesis_id} · ${range}`;
+  return `${entry.title ?? entry.hypothesis_id} · ${range}`;
 }
 
 export function selectedExperiment(state: SessionState): HypothesisEntry | null {

--- a/clients/tui/src/ui/experiment-log.test.ts
+++ b/clients/tui/src/ui/experiment-log.test.ts
@@ -157,6 +157,34 @@ describe('experiment log rows', () => {
     expect(cells.outcome.startsWith('  ')).toBe(true);
     expect(cells.trailing.startsWith('  ')).toBe(true);
   });
+
+  it('prefers the backend-supplied title over the claim and action', () => {
+    const cells = entryCells(
+      entry({
+        title: 'Batch decode requests',
+        claim: 'batch the prefill step',
+        action: 'batch prefill',
+      }),
+      resolveColumns(WIDE),
+    );
+
+    expect(cells.leading).toContain('Batch decode requests');
+    expect(cells.leading).not.toContain('batch the prefill step');
+  });
+
+  it('falls back to the claim, then the action, when there is no title', () => {
+    const withClaim = entryCells(
+      entry({title: null, claim: 'batch the prefill step', action: 'batch prefill'}),
+      resolveColumns(WIDE),
+    );
+    expect(withClaim.leading).toContain('Batch the prefill step');
+
+    const withActionOnly = entryCells(
+      entry({title: null, claim: null, action: 'batch prefill'}),
+      resolveColumns(WIDE),
+    );
+    expect(withActionOnly.leading).toContain('Batch prefill');
+  });
 });
 
 describe('experiment log layout', () => {

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -498,7 +498,12 @@ export function entryCells(entry: HypothesisEntry, columns: Columns): EntryCells
     fitColumn(formatRounds(entry), ROUNDS_WIDTH),
   ];
   if (columns.claim) {
-    leading.push(fitColumn(sentenceCase(entry.claim ?? entry.action ?? '—'), columns.claimWidth));
+    leading.push(
+      fitColumn(
+        sentenceCase(entry.title ?? entry.claim ?? entry.action ?? '—'),
+        columns.claimWidth,
+      ),
+    );
   }
   if (columns.measured) leading.push(fitColumn(formatMeasured(entry), MEASURED_WIDTH));
   return {

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -72,6 +72,7 @@ from vibesys.schemas import (
     ValidationRecipe,
     ValidationRecipeArtifact,
     Verdict,
+    normalize_hypothesis_title,
 )
 from vibesys.server.events import (
     BenchmarkResultData,
@@ -1079,6 +1080,7 @@ def _run_orchestrator_plan(  # noqa: PLR0913  # tracked: #288
         reuse_session=False,
     )
     plan.hypothesis_id = plan.hypothesis_id.strip() or f"hypothesis-{round_number:04d}"
+    plan.title = normalize_hypothesis_title(plan.title)
     _validate_orchestrator_plan_state(plan, agent_run_state)
     plan.recommended_skills, _ = _validate_skill_selections(ctx, plan.recommended_skills)
     issue_board.write_plan_artifact(progress_path, round_number, plan)

--- a/src/vibesys/prompts/loops/agent/orchestrator_plan_prompt.j2
+++ b/src/vibesys/prompts/loops/agent/orchestrator_plan_prompt.j2
@@ -106,7 +106,7 @@ task. Keep the handoff under 4,000 output tokens: `invariants` cites stable file
 and adds only hypothesis diagnostics; `task` states the component/interface and
 stages without an exhaustive shell recipe; `pass_criteria` adds only activation,
 correctness, cleanup, and evidence gates; `reasoning` gives the decisive
-comparison and rejected alternatives briefly.
+comparison and rejected alternatives briefly. Also give a short `title`.
 
 Include in `task` a verification strategy: the cheapest checks the implementer
 should run before declaring the work done. These are not exhaustive test plans;

--- a/src/vibesys/schemas.py
+++ b/src/vibesys/schemas.py
@@ -563,6 +563,53 @@ class PreRoundDecision(BaseModel):
     reasoning: str = Field(description="Short explanation of the decision. One or two sentences.")
 
 
+HYPOTHESIS_TITLE_MAX_LEN = 60
+
+
+def truncate_hypothesis_title(text: str) -> str:
+    """Truncate ``text`` to ``HYPOTHESIS_TITLE_MAX_LEN`` on a word boundary.
+
+    Adds a trailing ellipsis when truncation occurs. ``text`` is assumed to
+    already be stripped and whitespace-collapsed; this only shortens it.
+    """
+    if len(text) <= HYPOTHESIS_TITLE_MAX_LEN:
+        return text
+    truncated = text[: HYPOTHESIS_TITLE_MAX_LEN - 1]
+    boundary = truncated.rfind(" ")
+    if boundary > 0:
+        truncated = truncated[:boundary]
+    return truncated.rstrip() + "…"
+
+
+def normalize_hypothesis_title(title: str) -> str:
+    """Strip, collapse internal whitespace, and truncate an orchestrator title.
+
+    Returns ``""`` when ``title`` carries no text, so callers can tell an
+    absent title apart from one that was merely whitespace.
+    """
+    collapsed = " ".join(title.split())
+    return truncate_hypothesis_title(collapsed)
+
+
+def derive_hypothesis_title(claim: str) -> str | None:
+    """Derive a display title from a hypothesis claim.
+
+    Takes the claim's first line, then its first sentence, strips a trailing
+    period, and truncates to ``HYPOTHESIS_TITLE_MAX_LEN``. Returns ``None``
+    when the claim carries no text, so callers can distinguish "no claim" from
+    a claim that happened to produce an empty title.
+    """
+    stripped = claim.strip()
+    if not stripped:
+        return None
+    first_line = stripped.splitlines()[0]
+    first_sentence = first_line.split(". ", 1)[0].rstrip(". ")
+    collapsed = " ".join(first_sentence.split())
+    if not collapsed:
+        return None
+    return truncate_hypothesis_title(collapsed)
+
+
 class OrchestratorPlan(BaseModel):
     """The per-round plan produced by the orchestrator.
 
@@ -590,6 +637,13 @@ class OrchestratorPlan(BaseModel):
     hypothesis: str = Field(
         default="",
         description="Causal, falsifiable claim explaining why the proposed change should help.",
+    )
+    title: str = Field(
+        default="",
+        description=(
+            f"Short plain-language title (<={HYPOTHESIS_TITLE_MAX_LEN} chars, no "
+            f"trailing period or 'Hypothesis:' prefix)."
+        ),
     )
     activation_evidence: str = Field(
         default="",

--- a/src/vibesys/server/experiments.py
+++ b/src/vibesys/server/experiments.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
+from vibesys.schemas import derive_hypothesis_title
 from vibesys.server.protocol import HypothesisEntry, HypothesisRound
 
 if TYPE_CHECKING:
@@ -33,6 +34,7 @@ def _entry(hypothesis: Hypothesis, *, active_id: str | None) -> HypothesisEntry:
     measurement = hypothesis.measurement
     return HypothesisEntry(
         hypothesis_id=hypothesis.hypothesis_id,
+        title=_text(hypothesis.plan.title) or derive_hypothesis_title(hypothesis.plan.hypothesis),
         claim=_text(hypothesis.plan.hypothesis),
         action=_text(hypothesis.plan.task),
         first_round=hypothesis.started_round,

--- a/src/vibesys/server/protocol.py
+++ b/src/vibesys/server/protocol.py
@@ -155,6 +155,10 @@ class HypothesisEntry(ProtocolModel):
     # directory written before hypothesis tracking. The row is still returned
     # so history stays complete; clients render it as an explicit placeholder.
     identified: bool = True
+    # Backend-derived display title: the orchestrator's own title, or a
+    # fallback derived from ``claim`` when the orchestrator gave none. None
+    # when there is no text to title at all.
+    title: str | None = None
     claim: str | None = None
     action: str | None = None
     first_round: int

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/orchestrator.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/full/orchestrator.md
@@ -75,7 +75,7 @@ task. Keep the handoff under 4,000 output tokens: `invariants` cites stable file
 and adds only hypothesis diagnostics; `task` states the component/interface and
 stages without an exhaustive shell recipe; `pass_criteria` adds only activation,
 correctness, cleanup, and evidence gates; `reasoning` gives the decisive
-comparison and rejected alternatives briefly.
+comparison and rejected alternatives briefly. Also give a short `title`.
 
 Include in `task` a verification strategy: the cheapest checks the implementer
 should run before declaring the work done. These are not exhaustive test plans;

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/orchestrator.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/minimal/orchestrator.md
@@ -74,7 +74,7 @@ task. Keep the handoff under 4,000 output tokens: `invariants` cites stable file
 and adds only hypothesis diagnostics; `task` states the component/interface and
 stages without an exhaustive shell recipe; `pass_criteria` adds only activation,
 correctness, cleanup, and evidence gates; `reasoning` gives the decisive
-comparison and rejected alternatives briefly.
+comparison and rejected alternatives briefly. Also give a short `title`.
 
 Include in `task` a verification strategy: the cheapest checks the implementer
 should run before declaring the work done. These are not exhaustive test plans;

--- a/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/seeded/orchestrator.md
+++ b/tests/loops/agent/fixtures/prompt_snapshots/llm-serving/seeded/orchestrator.md
@@ -75,7 +75,7 @@ task. Keep the handoff under 4,000 output tokens: `invariants` cites stable file
 and adds only hypothesis diagnostics; `task` states the component/interface and
 stages without an exhaustive shell recipe; `pass_criteria` adds only activation,
 correctness, cleanup, and evidence gates; `reasoning` gives the decisive
-comparison and rejected alternatives briefly.
+comparison and rejected alternatives briefly. Also give a short `title`.
 
 Include in `task` a verification strategy: the cheapest checks the implementer
 should run before declaring the work done. These are not exhaustive test plans;

--- a/tests/loops/agent/test_orchestrate.py
+++ b/tests/loops/agent/test_orchestrate.py
@@ -2030,6 +2030,48 @@ def test_continuing_hypothesis_uses_unified_run_state(tmp_path, ref_file):  # no
     assert [round_data["round"] for round_data in _round_payloads(tmp_path)] == [1]
 
 
+def test_orchestrator_title_is_normalized_after_the_structured_call(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    raw_title = "  " + ("A" * 50 + " " + "B" * 20) + "  "
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                hypothesis_id="normalize-title",
+                title=raw_title,
+                task="normalize the title",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
+                reasoning="exercise title normalization",
+            )
+        ],
+        implementer_outcomes=[HypothesisOutcome.CONTINUE],
+    )
+
+    assert _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1) is True
+
+    active = _active_hypothesis(tmp_path)
+    assert active is not None
+    assert active.plan.title == "A" * 50 + "…"
+
+
+def test_orchestrator_title_stays_empty_when_the_model_gives_none(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                hypothesis_id="no-title",
+                task="proceed without a title",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
+                reasoning="exercise the empty-title passthrough",
+            )
+        ],
+        implementer_outcomes=[HypothesisOutcome.CONTINUE],
+    )
+
+    assert _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1) is True
+
+    active = _active_hypothesis(tmp_path)
+    assert active is not None
+    assert active.plan.title == ""
+
+
 def test_resume_migrates_legacy_hypothesis_state_without_losing_continuation(
     tmp_path: Path,
     ref_file: str,

--- a/tests/server/test_experiments.py
+++ b/tests/server/test_experiments.py
@@ -108,6 +108,61 @@ def test_projection_surfaces_active_hypothesis_before_a_round_finishes() -> None
     assert entry.claim == "claim for H-02"
 
 
+def test_projection_uses_the_orchestrator_title_when_present() -> None:
+    hypothesis = _hypothesis(
+        "H-01",
+        1,
+        plan=OrchestratorPlan(
+            hypothesis_id="H-01",
+            title="Batch decode requests",
+            hypothesis="claim for H-01",
+            task="test H-01",
+            pass_criteria="",
+            reasoning="",
+        ),
+    )
+
+    (entry,) = build_experiment_log(AgentRunState(hypotheses=[hypothesis]))
+
+    assert entry.title == "Batch decode requests"
+
+
+def test_projection_derives_a_title_from_the_claim_when_the_plan_title_is_empty() -> None:
+    hypothesis = _hypothesis(
+        "H-01",
+        1,
+        plan=OrchestratorPlan(
+            hypothesis_id="H-01",
+            hypothesis="Batching decode requests reduces overhead. More detail follows.",
+            task="test H-01",
+            pass_criteria="",
+            reasoning="",
+        ),
+    )
+
+    (entry,) = build_experiment_log(AgentRunState(hypotheses=[hypothesis]))
+
+    assert entry.title == "Batching decode requests reduces overhead"
+
+
+def test_projection_title_is_none_without_any_text() -> None:
+    hypothesis = _hypothesis(
+        "H-01",
+        1,
+        plan=OrchestratorPlan(
+            hypothesis_id="H-01",
+            hypothesis="",
+            task="test H-01",
+            pass_criteria="",
+            reasoning="",
+        ),
+    )
+
+    (entry,) = build_experiment_log(AgentRunState(hypotheses=[hypothesis]))
+
+    assert entry.title is None
+
+
 def test_projection_orders_hypotheses_by_started_round() -> None:
     state = AgentRunState(
         hypotheses=[

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from vibesys.schemas import (
+    HYPOTHESIS_TITLE_MAX_LEN,
     ImplementerResponse,
     JudgeResponse,
     LatencyStats,
@@ -14,6 +15,8 @@ from vibesys.schemas import (
     SkillResourceSelection,
     ThroughputStats,
     Verdict,
+    derive_hypothesis_title,
+    normalize_hypothesis_title,
 )
 from vibesys.server.protocol import PerformanceRound
 
@@ -133,3 +136,84 @@ def test_performance_stats_reject_non_finite_values(value):  # noqa: ANN001, ANN
             perf_unit="req/s",
             passed=True,
         )
+
+
+def test_orchestrator_plan_title_defaults_to_empty_string():  # noqa: ANN201  # tracked: #288
+    plan = OrchestratorPlan(task="work", pass_criteria="passes", reasoning="reason")  # noqa: S106  # tracked: #288
+
+    assert plan.title == ""
+
+
+def test_orchestrator_plan_loads_old_shaped_data_without_a_title_key():  # noqa: ANN201  # tracked: #288
+    """A state file persisted before the title field existed has no ``title`` key."""
+    legacy_payload = {
+        "hypothesis_id": "legacy",
+        "hypothesis": "old claim",
+        "task": "work",
+        "pass_criteria": "passes",
+        "reasoning": "reason",
+    }
+
+    plan = OrchestratorPlan.model_validate(legacy_payload)
+
+    assert plan.title == ""
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "\n\t "])
+def test_normalize_hypothesis_title_passes_through_empty_input(raw):  # noqa: ANN001, ANN201  # tracked: #288
+    assert normalize_hypothesis_title(raw) == ""
+
+
+def test_normalize_hypothesis_title_strips_and_collapses_whitespace():  # noqa: ANN201  # tracked: #288
+    assert normalize_hypothesis_title("  Batch   the\n\tdecode   path  ") == "Batch the decode path"
+
+
+def test_normalize_hypothesis_title_truncates_on_a_word_boundary_with_ellipsis():  # noqa: ANN201  # tracked: #288
+    title = "A" * 50 + " " + "B" * 20
+
+    result = normalize_hypothesis_title(title)
+
+    assert result == "A" * 50 + "…"
+    assert len(result) <= HYPOTHESIS_TITLE_MAX_LEN
+
+
+def test_normalize_hypothesis_title_truncates_without_a_boundary():  # noqa: ANN201  # tracked: #288
+    title = "A" * 65
+
+    result = normalize_hypothesis_title(title)
+
+    assert result == "A" * 59 + "…"
+    assert len(result) == HYPOTHESIS_TITLE_MAX_LEN
+
+
+def test_normalize_hypothesis_title_leaves_a_title_within_budget_untouched():  # noqa: ANN201  # tracked: #288
+    title = "Batch decode requests by KV-cache page"
+
+    assert normalize_hypothesis_title(title) == title
+
+
+@pytest.mark.parametrize("claim", ["", "   ", "\n\t "])
+def test_derive_hypothesis_title_returns_none_for_empty_claim(claim):  # noqa: ANN001, ANN201  # tracked: #288
+    assert derive_hypothesis_title(claim) is None
+
+
+def test_derive_hypothesis_title_takes_the_first_sentence():  # noqa: ANN201  # tracked: #288
+    claim = "Batching decode requests reduces overhead. It also raises latency variance."
+
+    assert derive_hypothesis_title(claim) == "Batching decode requests reduces overhead"
+
+
+def test_derive_hypothesis_title_takes_the_first_line_when_there_is_no_sentence_break():  # noqa: ANN201  # tracked: #288
+    claim = "Batching decode requests reduces overhead\nfurther detail on the mechanism"
+
+    assert derive_hypothesis_title(claim) == "Batching decode requests reduces overhead"
+
+
+def test_derive_hypothesis_title_truncates_long_claims():  # noqa: ANN201  # tracked: #288
+    claim = ("A" * 50 + " " + "B" * 20) + "."
+
+    result = derive_hypothesis_title(claim)
+
+    assert result == "A" * 50 + "…"
+    assert result is not None
+    assert len(result) <= HYPOTHESIS_TITLE_MAX_LEN


### PR DESCRIPTION
## Problem

The TUI hypothesis table shows the full hypothesis claim truncated to whatever fits the column, which is lossy and hard to scan. A short, purpose-written title per hypothesis makes the table readable and gives the drilldown a proper heading. The orchestrator is the right author: it writes the hypothesis, so it can name it.

## Solution

`OrchestratorPlan` gains a `title` field (structured output, so the schema description is the contract) capped at `HYPOTHESIS_TITLE_MAX_LEN = 60`. The field defaults to empty rather than being pydantic-required so structured-output retries aren't triggered by omission; enforcement is a normalization step in `_run_orchestrator_plan` next to the existing `hypothesis_id` idiom (strip, collapse whitespace, word-boundary truncate with ellipsis). The wire projection (`experiments.py:_entry()`) emits the title, deriving a fallback from the claim's first sentence when the plan has none, so clients never invent titles. The TUI table cell prefers `entry.title` over the truncated claim, and `hypothesisLabel()` prefers it for human-facing labels.

The prompt change is one clause; the fuller guidance lives in the schema field description because the fallback-prompt byte budget (13,200) had almost no headroom.

### Architecture

Ownership: `schemas.py` owns the cap and the normalize/derive helpers (stdlib-only); `loop.py` normalizes at creation; `server/experiments.py` owns the display fallback in the one-way `Hypothesis` → `HypothesisEntry` projection; clients render only. Old `state.json` files and legacy ledgers deserialize with `title=""` (defaulted field) and get the projection fallback, so no migration is needed.

## Verification

Behavior-driven tests at the contract boundaries; prompt snapshots regenerated and byte-budget checks pass; protocol codegen idempotent.

### Correctness properties

- `title` is additive and optional on the wire (`HypothesisEntry.title: str | None`); old clients and replayed logs are unaffected.
- Titles are backend-authored only: orchestrator-generated, normalized at creation, fallback-derived in the projection; the TUI never derives titles.
- Old persisted state (pre-title `state.json`, legacy ledgers) loads unchanged with `title=""`.
- Prompt fallback stays within its 13,200-byte budget.

### Testing

- `uv run pytest tests/test_schemas.py tests/server/test_experiments.py tests/loops/agent/test_orchestrate.py -q --no-cov`: 172 passed.
- `uv run pytest tests/loops/agent/test_prompt_snapshots.py -q --no-cov`: 44 passed (snapshots regenerated, diff reviewed).
- `uv run ruff check` (touched files): clean.
- `bun test src/ui/experiment-log.test.ts src/session-model.test.ts` (clients/tui): 96 passed; full `pnpm test`: 380/381 (1 pre-existing unrelated `launcher.test.ts` flake); `pnpm check` (tsc) and `pnpm check:format:ts` (biome): clean.
- `pnpm --dir clients/backend-client generate:protocol` re-run: no diff.

Note: the hypothesis detail drilldown (#451) is not in this branch's history; the title heading for that view lands as a small follow-up once #451 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
