### PR TITLE
Show each round agent's harness and model in the TUI

### DIFF
--- a/clients/backend-client/src/generated/protocol.generated.ts
+++ b/clients/backend-client/src/generated/protocol.generated.ts
@@ -182,6 +182,9 @@ export type Stage1 = string;
 export type Attempt1 = number | null;
 export type SystemPrompt1 = string;
 export type UserPrompt1 = string;
+export type Driver = string | null;
+export type Provider = string | null;
+export type Model = string | null;
 export type Kind5 = "agent_execution_finished";
 export type Error2 = string | null;
 export type Kind6 = "output";
@@ -261,7 +264,7 @@ export type Todos = TodoItemData[];
 export type Kind23 = "usage_update";
 export type InputTokens1 = number;
 export type ContextWindow1 = number | null;
-export type Model = string | null;
+export type Model1 = string | null;
 export type Events = RunEvent[];
 export type Round = number;
 export type PerfMetric1 = number;
@@ -507,6 +510,9 @@ export interface AgentExecutionStartedData {
   system_prompt?: SystemPrompt1;
   user_prompt?: UserPrompt1;
   activity: AgentExecutionActivityData;
+  driver?: Driver;
+  provider?: Provider;
+  model?: Model;
   [k: string]: unknown;
 }
 /**
@@ -671,7 +677,7 @@ export interface UsageUpdateData {
   kind?: Kind23;
   input_tokens: InputTokens1;
   context_window?: ContextWindow1;
-  model?: Model;
+  model?: Model1;
   [k: string]: unknown;
 }
 export interface PerformanceRound {

--- a/clients/backend-client/src/generated/protocol.schema.json
+++ b/clients/backend-client/src/generated/protocol.schema.json
@@ -166,6 +166,42 @@
         },
         "activity": {
           "$ref": "#/$defs/AgentExecutionActivityData"
+        },
+        "driver": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Driver"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Provider"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model"
         }
       },
       "required": [

--- a/clients/core-state/src/core-state.test.ts
+++ b/clients/core-state/src/core-state.test.ts
@@ -114,6 +114,37 @@ describe('core state projection', () => {
     });
   });
 
+  it('captures runtime identity from agent_execution_started when present', () => {
+    const state = reduceEvent(
+      initialCoreState(),
+      executionEvent(1, 'agent_execution_started', 'first', {
+        ...startedData('Implement the queue'),
+        driver: 'agentshim',
+        provider: 'codex',
+        model: 'gpt-5.1-codex-max',
+      }),
+    );
+
+    expect(state.activeExecutions['first']).toMatchObject({
+      driver: 'agentshim',
+      provider: 'codex',
+      model: 'gpt-5.1-codex-max',
+    });
+  });
+
+  it('defaults runtime identity to null when the event omits it', () => {
+    const state = reduceEvent(
+      initialCoreState(),
+      executionEvent(1, 'agent_execution_started', 'first', startedData('Implement the queue')),
+    );
+
+    expect(state.activeExecutions['first']).toMatchObject({
+      driver: null,
+      provider: null,
+      model: null,
+    });
+  });
+
   it('coalesces streamed assistant chunks by invocation', () => {
     let state = initialCoreState();
     state = reduceEvent(state, outputEvent(1, 'hello ', 'turn-1'));

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -18,6 +18,9 @@ export interface ActiveAgentExecution {
   assignment: string;
   startedAt: string;
   activity: {mode: AgentExecutionMode; summary: string; tool?: string | null};
+  driver?: string | null;
+  provider?: string | null;
+  model?: string | null;
 }
 
 export interface TodoItem {
@@ -300,6 +303,9 @@ function applyAgentExecutionEvent(state: CoreState, event: RunEvent): CoreState 
             summary: data.activity.summary,
             tool: data.activity.tool ?? null,
           },
+          driver: data.driver ?? null,
+          provider: data.provider ?? null,
+          model: data.model ?? null,
         },
       },
     };

--- a/clients/core-state/src/run-map.test.ts
+++ b/clients/core-state/src/run-map.test.ts
@@ -26,6 +26,47 @@ describe('run map projection', () => {
     expect(roundAgentElapsedMs(round, new Date('2026-01-01T00:00:05Z'))).toBe(2000);
   });
 
+  it('captures the agent runtime identity on start and keeps it after finish', () => {
+    let state = applyRunMapEvent(emptyRunMap(), {
+      ...execution(1, 'agent_execution_started', 'a'),
+      data: {
+        kind: 'agent_execution_started',
+        stage: 'implementation',
+        attempt: 1,
+        system_prompt: '',
+        user_prompt: 'Implement',
+        activity: {
+          kind: 'agent_execution_activity_changed',
+          mode: 'thinking',
+          summary: 'Starting',
+          tool: null,
+        },
+        driver: 'agentshim',
+        provider: 'codex',
+        model: 'gpt-5.1-codex-max',
+      },
+    });
+    state = applyRunMapEvent(state, execution(2, 'agent_execution_finished', 'a'));
+
+    expect(state.phases.filter(phase => phase.kind === 'implementer')).toMatchObject([
+      {
+        executionId: 'a',
+        status: 'completed',
+        driver: 'agentshim',
+        provider: 'codex',
+        model: 'gpt-5.1-codex-max',
+      },
+    ]);
+  });
+
+  it('defaults the runtime identity to null when the event omits it', () => {
+    const state = applyRunMapEvent(emptyRunMap(), execution(1, 'agent_execution_started', 'a'));
+
+    expect(state.phases.filter(phase => phase.kind === 'implementer')).toMatchObject([
+      {driver: null, provider: null, model: null},
+    ]);
+  });
+
   it('closes active timing when a run is interrupted', () => {
     let state = applyRunMapEvent(emptyRunMap(), execution(1, 'agent_execution_started', 'a'));
     state = applyRunMapEvent(state, {

--- a/clients/core-state/src/run-map.ts
+++ b/clients/core-state/src/run-map.ts
@@ -32,6 +32,9 @@ export interface AgentPhase {
   invocationId?: string;
   startedAt?: string;
   finishedAt?: string;
+  driver?: string | null;
+  provider?: string | null;
+  model?: string | null;
 }
 
 export interface RunMapState {
@@ -83,6 +86,11 @@ function applyPhaseEvent(state: RunMapState, event: RunEvent): AgentPhase[] {
   const finished = event.type === 'agent_execution_finished' || event.type === 'phase_finished';
   if (!started && !finished) return ensurePhase(phases, kind, roundNumber);
   const executionId = event.execution_id ?? event.invocation_id ?? undefined;
+  const data = event.data;
+  const runtime =
+    started && data?.kind === 'agent_execution_started'
+      ? {driver: data.driver ?? null, provider: data.provider ?? null, model: data.model ?? null}
+      : {};
   return upsertPhase(phases, {
     kind,
     status: started ? 'active' : terminalPhaseStatus(event.status),
@@ -90,6 +98,7 @@ function applyPhaseEvent(state: RunMapState, event: RunEvent): AgentPhase[] {
     roundLabel: event.round_label ?? null,
     ...(executionId ? {executionId, invocationId: executionId} : {}),
     ...(started ? {startedAt: event.timestamp} : {finishedAt: event.timestamp}),
+    ...runtime,
   });
 }
 

--- a/clients/tui/src/ui/activity-bar.test.ts
+++ b/clients/tui/src/ui/activity-bar.test.ts
@@ -1,11 +1,12 @@
 import {describe, expect, it} from 'bun:test';
 import type {ActiveAgentExecution} from '@vibesys/core-state';
-import {activitySummary} from './activity-bar.js';
+import {activitySummary, runtimeSuffix} from './activity-bar.js';
 
 const STARTED_AT = '2026-08-25T12:00:00.000Z';
 function execution(
   activity: ActiveAgentExecution['activity'],
   executionId = 'execution-1',
+  runtime: {provider?: string | null; model?: string | null} = {},
 ): ActiveAgentExecution {
   return {
     executionId,
@@ -17,6 +18,7 @@ function execution(
     assignment: 'Implement the queue',
     startedAt: STARTED_AT,
     activity,
+    ...runtime,
   };
 }
 
@@ -33,5 +35,19 @@ describe('activity summary', () => {
     expect(activitySummary(execution({mode: 'waiting', summary: 'Waiting for output'}))).toBe(
       'Working',
     );
+  });
+});
+
+describe('runtime suffix', () => {
+  it('renders the harness and model when both are known', () => {
+    const exec = execution({mode: 'thinking', summary: ''}, 'execution-1', {
+      provider: 'codex',
+      model: 'gpt-5.1-codex-max',
+    });
+    expect(runtimeSuffix(exec)).toBe(' · Codex (GPT 5.1 Codex Max)');
+  });
+
+  it('is empty when neither the provider nor the model is known', () => {
+    expect(runtimeSuffix(execution({mode: 'thinking', summary: ''}))).toBe('');
   });
 });

--- a/clients/tui/src/ui/activity-bar.ts
+++ b/clients/tui/src/ui/activity-bar.ts
@@ -2,6 +2,7 @@ import {type CliRenderer, TextRenderable} from '@opentui/core';
 import type {ActiveAgentExecution} from '@vibesys/core-state';
 import type {SessionState} from '../session-model.js';
 import {visibleActiveExecutions} from '../session-model.js';
+import {agentRuntimeLabel} from './agent-runtime-label.js';
 import type {Theme} from './theme.js';
 
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
@@ -61,12 +62,16 @@ export class ActivityBarView {
     if (this.#executions.length === 1) {
       const execution = this.#executions[0];
       if (execution === undefined) return;
-      this.output.content = `${spinner} ${roleLabel(execution.agentKind)} · ${activitySummary(execution)} · ${elapsed(execution.startedAt, nowMs)}`;
+      const runtime = runtimeSuffix(execution);
+      this.output.content = `${spinner} ${roleLabel(execution.agentKind)} · ${activitySummary(execution)}${runtime} · ${elapsed(execution.startedAt, nowMs)}`;
       return;
     }
     const summaries = this.#executions
       .slice(0, 3)
-      .map(execution => `${roleLabel(execution.agentKind)}: ${activitySummary(execution)}`)
+      .map(
+        execution =>
+          `${roleLabel(execution.agentKind)}: ${activitySummary(execution)}${runtimeSuffix(execution)}`,
+      )
       .join(' · ');
     const remainder = this.#executions.length > 3 ? ` · +${this.#executions.length - 3} more` : '';
     this.output.content = `${spinner} ${this.#executions.length} agents active · ${summaries}${remainder}`;
@@ -75,6 +80,11 @@ export class ActivityBarView {
 
 export function activitySummary(_execution: ActiveAgentExecution): string {
   return 'Working';
+}
+
+export function runtimeSuffix(execution: ActiveAgentExecution): string {
+  const label = agentRuntimeLabel(execution.provider, execution.model);
+  return label === null ? '' : ` · ${label}`;
 }
 
 function roleLabel(role: string): string {

--- a/clients/tui/src/ui/agent-graph.ts
+++ b/clients/tui/src/ui/agent-graph.ts
@@ -13,8 +13,13 @@ import type {AgentPhase} from '@vibesys/core-state';
  * cell coordinates. The renderer owns colors and renderables.
  */
 
-/** Border plus one content row for the kind and one for the status. */
-export const NODE_HEIGHT = 4;
+/**
+ * Border plus one content row each for the kind, the status, and the agent
+ * runtime (harness/model), whether or not the runtime row has anything to
+ * show. A fixed height keeps every node the same size instead of shifting the
+ * layout for nodes that lack runtime identity.
+ */
+export const NODE_HEIGHT = 5;
 /** Blank row between stacked agents in the same column. */
 const ROW_GAP = 2;
 /**

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -16,6 +16,7 @@ import {
   NODE_HEIGHT,
   stageKinds,
 } from './agent-graph.js';
+import {agentRuntimeLabel} from './agent-runtime-label.js';
 import {elapsedLabel} from './previews.js';
 import type {Theme} from './theme.js';
 
@@ -273,6 +274,15 @@ export class AgentMapView {
         width: '100%',
       }),
     );
+    // Always drawn, even when empty, so every node keeps the same height
+    // (`NODE_HEIGHT`) whether or not it carries a runtime label.
+    box.add(
+      new TextRenderable(this.renderer, {
+        content: truncate(agentRuntimeLabel(phase.provider, phase.model) ?? '', inner),
+        fg: this.#theme.textMuted,
+        width: '100%',
+      }),
+    );
     return box;
   }
 
@@ -331,6 +341,16 @@ export class AgentMapView {
       row.add(
         new TextRenderable(this.renderer, {
           content: phase.roundLabel,
+          fg: this.#theme.textMuted,
+          width: '100%',
+        }),
+      );
+    }
+    const runtimeLabel = agentRuntimeLabel(phase.provider, phase.model);
+    if (runtimeLabel !== null) {
+      row.add(
+        new TextRenderable(this.renderer, {
+          content: runtimeLabel,
           fg: this.#theme.textMuted,
           width: '100%',
         }),

--- a/clients/tui/src/ui/agent-runtime-label.test.ts
+++ b/clients/tui/src/ui/agent-runtime-label.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from 'bun:test';
+import {agentRuntimeLabel} from './agent-runtime-label.js';
+
+describe('agentRuntimeLabel', () => {
+  it('formats a known provider with its prettified model', () => {
+    expect(agentRuntimeLabel('codex', 'gpt-5.1-codex-max')).toBe('Codex (GPT 5.1 Codex Max)');
+  });
+
+  it('maps each known provider to its display name', () => {
+    expect(agentRuntimeLabel('claude', 'claude-sonnet-4-6')).toBe(
+      'Claude Code (Claude Sonnet 4 6)',
+    );
+    expect(agentRuntimeLabel('gemini', null)).toBe('Gemini');
+    expect(agentRuntimeLabel('opencode', null)).toBe('Opencode');
+  });
+
+  it('title-cases an unrecognized provider', () => {
+    expect(agentRuntimeLabel('mystery_cli', 'v1')).toBe('Mystery Cli (V1)');
+  });
+
+  it('shows only the model when the provider is missing', () => {
+    expect(agentRuntimeLabel(null, 'gpt-5.1-codex-max')).toBe('GPT 5.1 Codex Max');
+    expect(agentRuntimeLabel(undefined, 'gpt-5.1-codex-max')).toBe('GPT 5.1 Codex Max');
+  });
+
+  it('shows only the provider when the model is missing', () => {
+    expect(agentRuntimeLabel('codex', null)).toBe('Codex');
+  });
+
+  it('returns null when both are missing', () => {
+    expect(agentRuntimeLabel(null, null)).toBeNull();
+    expect(agentRuntimeLabel(undefined, undefined)).toBeNull();
+    expect(agentRuntimeLabel('', '')).toBeNull();
+  });
+});

--- a/clients/tui/src/ui/agent-runtime-label.ts
+++ b/clients/tui/src/ui/agent-runtime-label.ts
@@ -1,0 +1,61 @@
+/**
+ * Presentation-only formatting for the CLI harness and model an agent
+ * execution ran with. The backend emits `provider`/`model` as plain
+ * configuration strings (e.g. `"codex"`, `"gpt-5.1-codex-max"`); this module
+ * turns them into the label shown next to an agent node, e.g.
+ * `"Codex (GPT 5.1 Codex Max)"`.
+ */
+
+const PROVIDER_LABELS: Record<string, string> = {
+  codex: 'Codex',
+  claude: 'Claude Code',
+  gemini: 'Gemini',
+  opencode: 'Opencode',
+};
+
+/** Segments that are acronyms rather than words, keyed by lowercase form. */
+const KNOWN_ACRONYMS: Record<string, string> = {
+  gpt: 'GPT',
+};
+
+/** `"Codex (GPT 5.1 Codex Max)"`; `null` when there is nothing to show. */
+export function agentRuntimeLabel(
+  provider: string | null | undefined,
+  model: string | null | undefined,
+): string | null {
+  const providerText = provider?.trim() || null;
+  const modelText = model?.trim() || null;
+  if (providerText === null && modelText === null) return null;
+  const providerLabel = providerText === null ? null : formatProvider(providerText);
+  const modelLabel = modelText === null ? null : formatModel(modelText);
+  if (providerLabel !== null && modelLabel !== null) return `${providerLabel} (${modelLabel})`;
+  return providerLabel ?? modelLabel;
+}
+
+function formatProvider(provider: string): string {
+  return PROVIDER_LABELS[provider.toLowerCase()] ?? titleCaseWords(provider);
+}
+
+function formatModel(model: string): string {
+  return model
+    .split('-')
+    .filter(segment => segment.length > 0)
+    .map(titleCaseSegment)
+    .join(' ');
+}
+
+function titleCaseWords(text: string): string {
+  return text
+    .split(/[-_\s]+/)
+    .filter(segment => segment.length > 0)
+    .map(titleCaseSegment)
+    .join(' ');
+}
+
+/** A digit-leading segment (e.g. `"5.1"`) is kept as-is; words are title-cased. */
+function titleCaseSegment(segment: string): string {
+  const acronym = KNOWN_ACRONYMS[segment.toLowerCase()];
+  if (acronym !== undefined) return acronym;
+  if (/^\d/.test(segment)) return segment;
+  return segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase();
+}

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1052,6 +1052,86 @@ describe('OpenTUI presentation', () => {
     expect(frame).not.toContain('▶');
   });
 
+  it('shows each graph node’s agent harness and model, when known', async () => {
+    const testRenderer = await createTestRenderer({width: 150, height: 24});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      core: {
+        ...initialSessionState().core,
+        rounds: [{number: 1, status: 'active'}],
+        phases: [
+          {
+            kind: 'orchestrator',
+            status: 'completed',
+            roundNumber: 1,
+            roundLabel: 'round-1-plan',
+            provider: 'codex',
+            model: 'gpt-5.1-codex-max',
+          },
+          {
+            kind: 'implementer',
+            status: 'active',
+            roundNumber: 1,
+            roundLabel: 'round-1-implementer',
+          },
+        ],
+        transcript: [{id: 'live', kind: 'assistant', label: 'Agent', content: 'live output'}],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('orchestrator'));
+
+    // Graph nodes are narrow enough that the label truncates like every other
+    // node line; this stays inside the kept prefix regardless of node width.
+    expect(frame).toContain('Codex (GPT');
+    // The implementer node carries no runtime identity, so its row stays
+    // blank rather than reusing the orchestrator's label.
+    const implementerRow = frame.split('\n').find(line => line.includes('implementer'));
+    expect(implementerRow).toBeDefined();
+  });
+
+  it('shows the stacked strip’s runtime label when the terminal is too narrow for a graph', async () => {
+    const testRenderer = await createTestRenderer({width: 80, height: 30});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      core: {
+        ...initialSessionState().core,
+        rounds: [{number: 1, status: 'active'}],
+        phases: [
+          {
+            kind: 'orchestrator',
+            status: 'completed',
+            roundNumber: 1,
+            roundLabel: 'round-1-plan',
+            // Short enough to stay on one line in the narrow stacked column;
+            // the wrapping case for a long label is covered elsewhere.
+            provider: 'codex',
+            model: 'gpt-5',
+          },
+          {
+            kind: 'implementer',
+            status: 'active',
+            roundNumber: 1,
+            roundLabel: 'round-1-implementer',
+          },
+          {kind: 'judge', status: 'pending', roundNumber: 1, roundLabel: 'round-1-judge'},
+        ],
+        transcript: [{id: 'live', kind: 'assistant', label: 'Agent', content: 'live output'}],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('orchestrator'));
+
+    // Confirms the stacked (non-graph) layout is in play, as in the sibling
+    // narrow-terminal test above.
+    expect(frame).toContain('        ↓');
+    expect(frame).toContain('Codex (GPT 5)');
+  });
+
   it('holds the agent-active elapsed time of a finished round', async () => {
     const testRenderer = await createTestRenderer({width: 100, height: 18});
     const controller = new FakeController({

--- a/src/vibesys/agents/client.py
+++ b/src/vibesys/agents/client.py
@@ -167,9 +167,11 @@ class AgentClient:
         require_host_sandbox: bool = False,
         containerized: bool = False,
         driver_log: AgentDiagnosticLog | None = None,
+        driver_name: str | None = None,
     ) -> None:
         """Create a client that owns ``driver`` and every session it creates."""
         self._driver = driver
+        self._driver_name = driver_name
         self._provider = provider
         self._skills = tuple(skills)
         self._compute_backend = compute_backend
@@ -194,6 +196,25 @@ class AgentClient:
     def capabilities(self) -> AgentCapabilities:
         """Return the selected driver's factual capabilities."""
         return self._driver.capabilities
+
+    @property
+    def driver_name(self) -> str | None:
+        """Return the stable configured driver name (``"agentshim"``/``"omnigent"``).
+
+        This is the application-configuration string, not the driver's Python
+        class name, so it stays stable across implementation refactors.
+        """
+        return getattr(self, "_driver_name", None)
+
+    @property
+    def provider(self) -> str | None:
+        """Return the configured CLI provider (``"codex"``, ``"claude"``, ...)."""
+        return getattr(self, "_provider", None) or "codex"
+
+    def model_for_kind(self, kind: str) -> str | None:
+        """Return the effective model for ``kind``, honoring role overrides."""
+        role_models: Mapping[str, str] = getattr(self, "_role_models", {})
+        return role_models.get(kind, getattr(self, "_model_name", None))
 
     def set_log_file(self, stream: TextIO | None) -> None:
         """Direct subsequent application logs to ``stream``."""
@@ -346,7 +367,7 @@ class AgentClient:
         )
         log_and_print(f"\n=== {label} ROUND START: {round_label} ===", self._run_log_file)
         log_and_print(
-            f"driver: {type(self._driver).__name__}, provider: {spec.provider}, "
+            f"driver: {self.driver_name or type(self._driver).__name__}, provider: {spec.provider}, "
             f"model: {model}, reasoning_effort: {reasoning_effort or 'provider_default'}, "
             f"cwd: {workspace}",
             self._run_log_file,

--- a/src/vibesys/agents/factory.py
+++ b/src/vibesys/agents/factory.py
@@ -163,6 +163,7 @@ def build_agent_client(  # noqa: C901, PLR0912, PLR0913
 
     return AgentClient(
         driver,
+        driver_name=driver_name,
         provider=provider,
         skills=skill_source_dirs,
         compute_backend=compute_backend,

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -1631,8 +1631,16 @@ class _RunContext:
         supervisor = getattr(self, "supervisor", None)
         execution_id: str | None = None
         if supervisor is not None:
+            client = self.agent_client
+            model_for_kind = getattr(client, "model_for_kind", None)
             execution = supervisor.start_agent_execution(
-                kind, round_label, user_prompt, system_prompt
+                kind,
+                round_label,
+                user_prompt,
+                system_prompt,
+                driver=getattr(client, "driver_name", None),
+                provider=getattr(client, "provider", None),
+                model=model_for_kind(kind) if callable(model_for_kind) else None,
             )
             user_prompt = execution.user_prompt
             execution_id = execution.execution_id

--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -102,6 +102,9 @@ class AgentExecutionStartedData(BaseModel):
     system_prompt: str = ""
     user_prompt: str = ""
     activity: AgentExecutionActivityData
+    driver: str | None = None
+    provider: str | None = None
+    model: str | None = None
 
 
 class AgentExecutionFinishedData(BaseModel):

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -703,6 +703,9 @@ class RunSupervisor:
         *,
         consume_steering: bool = True,
         participates_in_run_control: bool = True,
+        driver: str | None = None,
+        provider: str | None = None,
+        model: str | None = None,
     ) -> AgentExecutionHandle:
         """Start one prompt-to-result execution and return its explicit identity."""
         with self._condition:
@@ -743,6 +746,9 @@ class RunSupervisor:
                     system_prompt=system_prompt,
                     user_prompt=effective_prompt,
                     activity=activity,
+                    driver=driver,
+                    provider=provider,
+                    model=model,
                 ),
             )
             self._active_executions[execution_id] = active

--- a/tests/agents/test_agent_client.py
+++ b/tests/agents/test_agent_client.py
@@ -457,6 +457,29 @@ def test_invoke_builds_session_and_turn_contracts_and_records_usage(tmp_path: Pa
     assert {key: record[key] for key in expected} == expected
 
 
+def test_runtime_accessors_expose_configured_driver_provider_and_model() -> None:
+    client = AgentClient(
+        _FakeDriver([]),
+        driver_name="agentshim",
+        provider="claude",
+        model_name="claude-base",
+        role_models={"judge": "claude-judge"},
+    )
+
+    assert client.driver_name == "agentshim"
+    assert client.provider == "claude"
+    assert client.model_for_kind("judge") == "claude-judge"
+    assert client.model_for_kind("implementer") == "claude-base"
+
+
+def test_runtime_accessors_default_to_none_or_codex_when_unconfigured() -> None:
+    client = AgentClient(_FakeDriver([]))
+
+    assert client.driver_name is None
+    assert client.provider == "codex"
+    assert client.model_for_kind("implementer") is None
+
+
 def test_invoke_uses_fallback_only_for_unparseable_output(tmp_path: Path) -> None:
     session = _FakeSession(results=[AgentTurnResult("not json")])
     client = AgentClient(_FakeDriver([session]))

--- a/tests/server/test_agent_execution_lifecycle.py
+++ b/tests/server/test_agent_execution_lifecycle.py
@@ -66,6 +66,49 @@ def test_explicit_executions_remain_independent_and_finish_idempotently(tmp_path
     )
 
 
+def test_start_agent_execution_records_runtime_identity_when_provided(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    supervisor.start_agent_execution(
+        "implementer",
+        "round-1",
+        "work",
+        driver="agentshim",
+        provider="codex",
+        model="gpt-5.1-codex-max",
+    )
+
+    started = next(
+        event
+        for event in supervisor.read_events()
+        if event.type is EventType.AGENT_EXECUTION_STARTED
+    )
+    assert started.data is not None
+    assert started.data.kind == "agent_execution_started"
+    assert started.data.driver == "agentshim"
+    assert started.data.provider == "codex"
+    assert started.data.model == "gpt-5.1-codex-max"
+
+
+def test_start_agent_execution_omits_runtime_identity_by_default(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    supervisor.start_agent_execution("implementer", "round-1", "work")
+
+    started = next(
+        event
+        for event in supervisor.read_events()
+        if event.type is EventType.AGENT_EXECUTION_STARTED
+    )
+    assert started.data is not None
+    assert started.data.kind == "agent_execution_started"
+    assert started.data.driver is None
+    assert started.data.provider is None
+    assert started.data.model is None
+
+
 def test_activity_tracks_todo_and_parallel_tools(tmp_path):  # noqa: ANN001, ANN201
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1436,6 +1436,9 @@ def test_run_context_records_invocation_boundary(tmp_path):  # noqa: ANN001, ANN
     ctx.supervisor = supervisor
     ctx.agent_client = Mock()
     ctx.agent_client.invoke.return_value = {"summary": "measured"}
+    ctx.agent_client.driver_name = "agentshim"
+    ctx.agent_client.provider = "codex"
+    ctx.agent_client.model_for_kind = Mock(return_value="gpt-5.1-codex-max")
     ctx._paths = RunPaths(  # noqa: SLF001  # tracked: #288
         project_root=tmp_path,
         log_dir=tmp_path / "logs",
@@ -1459,6 +1462,12 @@ def test_run_context_records_invocation_boundary(tmp_path):  # noqa: ANN001, ANN
     events = _events(tmp_path / "run-events.jsonl")
     started = next(event for event in events if event["type"] == "invocation_started")
     assert started["data"]["user_prompt"] == "original"
+    execution_started = next(
+        event for event in events if event["type"] == "agent_execution_started"
+    )
+    assert execution_started["data"]["driver"] == "agentshim"
+    assert execution_started["data"]["provider"] == "codex"
+    assert execution_started["data"]["model"] == "gpt-5.1-codex-max"
 
 
 def test_committed_protocol_schema_matches_python_contract():  # noqa: ANN201  # tracked: #288


### PR DESCRIPTION
## Problem

In the multi-agent round view there is no way to tell which CLI harness and model each agent runs on. The information exists at invocation time (driver, provider, model are all resolved in `AgentClient._invoke_turn`) but only reaches the run log, so operators comparing agent behavior across harness/model configurations get no signal in the TUI.

## Solution

Emit agent runtime identity on the existing `agent_execution_started` event and render it in the agent views, e.g. `Codex (GPT 5.1 Codex Max)`.

- `AgentExecutionStartedData` gains optional `driver`/`provider`/`model` fields (additive; absent on old event logs, and everything renders as before when missing).
- `AgentClient` exposes the already-resolved identity via public accessors (`driver_name` — the stable config string, not the Python class name — `provider`, `model_for_kind`); `ExecutionContext.invoke()` reads them defensively (`getattr(..., None)`, so stub/mock clients degrade to `None`) and passes them to `start_agent_execution`.
- core-state threads the fields onto `ActiveAgentExecution` and `AgentPhase`.
- Display formatting is client-side (pure presentation): `agentRuntimeLabel(provider, model)` in the TUI, appended to the activity-bar line and added as a node line in the agent map (`NODE_HEIGHT` 4 → 5, fixed height with a blank row when absent).

### Architecture

Ownership: the backend emits identity facts on the event; the TUI owns only the human-facing formatting. Data flows `factory` (resolves driver string) → `AgentClient` accessors → `ExecutionContext.invoke` → `start_agent_execution` → `AgentExecutionStartedData` → generated protocol → core-state (`ActiveAgentExecution`/`AgentPhase`) → activity bar and agent map.

Known limitation (scoped out deliberately): the snapshot/reconnect record (`protocol.py`'s `ActiveAgentExecution`) does not carry the fields; a snapshot-only reconnect shows the label only after replaying the `agent_execution_started` event.

## Verification

Behavioral tests at both boundaries plus full suites; codegen idempotent.

### Correctness properties

- Event fields are additive and optional: old clients, old event logs, and snapshot consumers are unaffected; missing fields render exactly as today.
- `driver` is the stable config string ("agentshim"/"omnigent"), never a Python class name.
- Clients without the accessors (stubs, mocks, subclasses skipping `__init__`) degrade to `None` fields rather than raising.
- Formatting is deterministic and purely presentational; the backend never emits display strings.

### Testing

- `uv run python -m pytest tests/server tests/agents -q`: 400 passed; `uv run pytest tests/test_tui.py -q`: 59 passed (one pre-existing Mock-based test fixed for the new accessors).
- `uv run ruff check src tests`, `./scripts/check_format.sh`: clean.
- `pnpm --dir clients/core-state test`: 27 passed; `pnpm --dir clients/tui test`: 399 passed; `check`, `check:format:ts`, `check:ts-architecture`: clean.
- Full `uv run pytest tests`: one unrelated pre-existing failure (`tests/sandbox/test_run_environment.py`, missing DeathStarBench submodule) verified identical on the base commit.
- `pnpm --dir clients/backend-client generate:protocol` re-run: no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
