### PR TITLE
Support multiple experiment chat threads with per-thread agent and model

### DIFF
--- a/clients/backend-client/src/generated/protocol.generated.ts
+++ b/clients/backend-client/src/generated/protocol.generated.ts
@@ -6,6 +6,7 @@ export type Request =
   | SteerCommand
   | SnapshotQuery
   | ChatQuery
+  | ChatThreadCreateQuery
   | HistoryQuery
   | PerformanceQuery
   | ExperimentQuery
@@ -34,32 +35,41 @@ export type RequestId4 = string;
 export type Timestamp4 = string;
 export type Type4 = "query.chat";
 export type Text1 = string;
+export type ThreadId = string | null;
 export type ProtocolVersion5 = 1;
 export type RequestId5 = string;
 export type Timestamp5 = string;
-export type Type5 = "query.history";
+export type Type5 = "query.chat_thread_create";
+export type Driver = ("agentshim" | "omnigent") | null;
+export type Provider = string | null;
+export type Model = string | null;
+export type Title = string | null;
 export type ProtocolVersion6 = 1;
 export type RequestId6 = string;
 export type Timestamp6 = string;
-export type Type6 = "query.performance";
+export type Type6 = "query.history";
 export type ProtocolVersion7 = 1;
 export type RequestId7 = string;
 export type Timestamp7 = string;
-export type Type7 = "query.experiments";
+export type Type7 = "query.performance";
 export type ProtocolVersion8 = 1;
 export type RequestId8 = string;
 export type Timestamp8 = string;
-export type Type8 = "query.events";
-export type AfterSequence = number;
-export type TimeoutMs = number;
+export type Type8 = "query.experiments";
 export type ProtocolVersion9 = 1;
 export type RequestId9 = string;
 export type Timestamp9 = string;
-export type Type9 = "subscribe";
-export type AfterSequence1 = number;
+export type Type9 = "query.events";
+export type AfterSequence = number;
+export type TimeoutMs = number;
 export type ProtocolVersion10 = 1;
 export type RequestId10 = string;
 export type Timestamp10 = string;
+export type Type10 = "subscribe";
+export type AfterSequence1 = number;
+export type ProtocolVersion11 = 1;
+export type RequestId11 = string;
+export type Timestamp11 = string;
 export type Ok = boolean;
 export type Error = string | null;
 export type Id = string;
@@ -86,7 +96,13 @@ export type Status = "pending" | "consumed";
 export type Question = string;
 export type Answer = string;
 export type Effect = "none";
-export type ProtocolVersion11 = 1;
+export type ThreadId1 = string | null;
+export type ThreadId2 = string;
+export type Title1 = string;
+export type Driver1 = string;
+export type Provider1 = string;
+export type Model1 = string;
+export type ProtocolVersion12 = 1;
 export type RunId = string;
 export type Sequence = number;
 export type Status1 = string;
@@ -104,10 +120,10 @@ export type Mode1 = "thinking" | "responding" | "tool" | "waiting";
 export type Summary1 = string;
 export type Tool = string | null;
 export type ActiveExecutions = ActiveAgentExecution[];
-export type ProtocolVersion12 = 1;
+export type ProtocolVersion13 = 1;
 export type Sequence1 = number;
 export type RunId1 = string;
-export type Timestamp11 = string;
+export type Timestamp12 = string;
 export type EventType =
   | "server_started"
   | "server_ready"
@@ -116,6 +132,7 @@ export type EventType =
   | "experiments_changed"
   | "run_interrupted"
   | "chat"
+  | "chat_thread_created"
   | "status_query"
   | "control"
   | "invocation_started"
@@ -144,9 +161,11 @@ export type RoundLabel2 = string | null;
 export type AgentKind2 = string | null;
 export type InvocationId = string | null;
 export type ExecutionId1 = string | null;
+export type ChatThreadId = string | null;
 export type Data =
   | (
       | ChatData
+      | ChatThreadCreatedData
       | InvocationStartedData
       | InvocationFinishedData
       | AgentExecutionStartedData
@@ -172,43 +191,51 @@ export type Data =
   | null;
 export type Kind1 = "chat";
 export type Answer1 = string;
-export type Kind2 = "invocation_started";
+export type ThreadTitle = string | null;
+export type Kind2 = "chat_thread_created";
+export type ThreadId3 = string;
+export type Title2 = string;
+export type Driver2 = string;
+export type Provider2 = string;
+export type Model2 = string;
+export type CreatedAt = string;
+export type Kind3 = "invocation_started";
 export type SystemPrompt = string;
 export type UserPrompt = string;
-export type Kind3 = "invocation_finished";
+export type Kind4 = "invocation_finished";
 export type Error1 = string | null;
-export type Kind4 = "agent_execution_started";
+export type Kind5 = "agent_execution_started";
 export type Stage1 = string;
 export type Attempt1 = number | null;
 export type SystemPrompt1 = string;
 export type UserPrompt1 = string;
-export type Kind5 = "agent_execution_finished";
+export type Kind6 = "agent_execution_finished";
 export type Error2 = string | null;
-export type Kind6 = "output";
+export type Kind7 = "output";
 export type Stream = "stdout" | "stderr";
 export type Source = string;
 export type Content = string;
-export type Kind7 = "server_ready";
+export type Kind8 = "server_ready";
 export type SocketProtocol = "jsonl";
-export type Kind8 = "run_started";
+export type Kind9 = "run_started";
 export type OuterLoop = string;
 export type Input = string;
 export type MaxRounds = number;
-export type Kind9 = "run_interrupted";
+export type Kind10 = "run_interrupted";
 export type Reason = string;
 export type Signal = string | null;
-export type Kind10 = "experiments_changed";
+export type Kind11 = "experiments_changed";
 export type Reason1 = "project_attached" | "active_hypothesis_changed" | "round_persisted";
-export type Kind11 = "configuration_failed";
+export type Kind12 = "configuration_failed";
 export type Code1 = string;
 export type Stage2 = string;
 export type Message = string;
 export type Usage = string | null;
 export type ExitCode = number;
-export type Kind12 = "phase";
+export type Kind13 = "phase";
 export type Phase = string;
 export type Attempt2 = number | null;
-export type Kind13 = "agent_output_chunk";
+export type Kind14 = "agent_output_chunk";
 export type Channel = "assistant" | "analysis" | "tool" | "diagnostic" | "prompt";
 export type Content1 = string;
 export type Progress = string | null;
@@ -216,40 +243,40 @@ export type AgentLabel = string | null;
 export type ElapsedSeconds = number;
 export type InputTokens = number;
 export type ContextWindow = number | null;
-export type Kind14 = "subprocess_output";
+export type Kind15 = "subprocess_output";
 export type ProcessId = string;
 export type ProcessKind = string;
 export type Stream1 = "stdout" | "stderr";
 export type Content2 = string;
-export type Kind15 = "judge_result";
+export type Kind16 = "judge_result";
 export type Verdict = "pass" | "fail";
 export type Feedback = string;
 export type Attempt3 = number;
-export type Kind16 = "benchmark_result";
+export type Kind17 = "benchmark_result";
 export type Metric = string;
 export type Value = number;
 export type Unit = string;
-export type Kind17 = "round_finished";
+export type Kind18 = "round_finished";
 export type Attempts = number;
 export type JudgeVerdict = "pass" | "fail" | "skipped";
 export type PerfMetric = number | null;
 export type PerfUnit = string | null;
-export type Kind18 = "tool_call";
+export type Kind19 = "tool_call";
 export type Tool1 = string;
 export type CallId = string | null;
-export type Kind19 = "tool_result";
+export type Kind20 = "tool_result";
 export type Tool2 = string;
 export type CallId1 = string | null;
 export type Content3 = string;
 export type IsError = boolean;
-export type Kind20 = "todo_update";
+export type Kind21 = "todo_update";
 export type Content4 = string;
 export type Status2 = string;
 export type Todos = TodoItemData[];
-export type Kind21 = "usage_update";
+export type Kind22 = "usage_update";
 export type InputTokens1 = number;
 export type ContextWindow1 = number | null;
-export type Model = string | null;
+export type Model3 = string | null;
 export type Events = RunEvent[];
 export type Round = number;
 export type PerfMetric1 = number;
@@ -285,17 +312,17 @@ export type Active = boolean;
 export type Experiments = HypothesisEntry[];
 export type ExperimentsReady = boolean | null;
 export type ServerMessage = SubscribedMessage | EventMessage | EventBatchMessage | ProtocolErrorMessage;
-export type Type10 = "subscribed";
-export type RequestId11 = string;
+export type Type11 = "subscribed";
+export type RequestId12 = string;
 export type RunId2 = string;
 export type LatestSequence = number;
-export type Type11 = "event";
-export type Type12 = "event_batch";
+export type Type12 = "event";
+export type Type13 = "event_batch";
 export type Events1 = RunEvent[];
 export type ThroughSequence = number;
 export type ActiveExecutions1 = ActiveAgentExecution[];
-export type Type13 = "protocol_error";
-export type RequestId12 = string | null;
+export type Type14 = "protocol_error";
+export type RequestId13 = string | null;
 export type Code2 = string;
 export type Message1 = string;
 
@@ -339,52 +366,70 @@ export interface ChatQuery {
   timestamp?: Timestamp4;
   type?: Type4;
   text: Text1;
+  thread_id?: ThreadId;
 }
-export interface HistoryQuery {
+/**
+ * Create a new experiment-chat thread with its own agent selection.
+ *
+ * Omitted fields resolve to the run's configured driver, provider, and
+ * model. The response carries the resolved settings and thread identity.
+ */
+export interface ChatThreadCreateQuery {
   protocol_version?: ProtocolVersion5;
   request_id?: RequestId5;
   timestamp?: Timestamp5;
   type?: Type5;
+  driver?: Driver;
+  provider?: Provider;
+  model?: Model;
+  title?: Title;
 }
-export interface PerformanceQuery {
+export interface HistoryQuery {
   protocol_version?: ProtocolVersion6;
   request_id?: RequestId6;
   timestamp?: Timestamp6;
   type?: Type6;
 }
-/**
- * Request the hypothesis-level experiment log for the attached run.
- */
-export interface ExperimentQuery {
+export interface PerformanceQuery {
   protocol_version?: ProtocolVersion7;
   request_id?: RequestId7;
   timestamp?: Timestamp7;
   type?: Type7;
 }
-export interface EventsQuery {
+/**
+ * Request the hypothesis-level experiment log for the attached run.
+ */
+export interface ExperimentQuery {
   protocol_version?: ProtocolVersion8;
   request_id?: RequestId8;
   timestamp?: Timestamp8;
   type?: Type8;
-  after_sequence?: AfterSequence;
-  timeout_ms?: TimeoutMs;
 }
-export interface SubscribeRequest {
+export interface EventsQuery {
   protocol_version?: ProtocolVersion9;
   request_id?: RequestId9;
   timestamp?: Timestamp9;
   type?: Type9;
+  after_sequence?: AfterSequence;
+  timeout_ms?: TimeoutMs;
+}
+export interface SubscribeRequest {
+  protocol_version?: ProtocolVersion10;
+  request_id?: RequestId10;
+  timestamp?: Timestamp10;
+  type?: Type10;
   after_sequence?: AfterSequence1;
 }
 export interface Response {
-  protocol_version?: ProtocolVersion10;
-  request_id: RequestId10;
-  timestamp?: Timestamp10;
+  protocol_version?: ProtocolVersion11;
+  request_id: RequestId11;
+  timestamp?: Timestamp11;
   ok?: Ok;
   error?: Error;
   diagnostic?: Diagnostic | null;
   ack?: CommandAck | null;
   chat?: ChatResult | null;
+  chat_thread?: ChatThreadInfo | null;
   snapshot?: RunSnapshot | null;
   events?: Events;
   performance?: Performance;
@@ -414,9 +459,20 @@ export interface ChatResult {
   question: Question;
   answer: Answer;
   effect?: Effect;
+  thread_id?: ThreadId1;
+}
+/**
+ * Resolved identity and agent settings of one experiment-chat thread.
+ */
+export interface ChatThreadInfo {
+  thread_id: ThreadId2;
+  title?: Title1;
+  driver: Driver1;
+  provider: Provider1;
+  model: Model1;
 }
 export interface RunSnapshot {
-  protocol_version?: ProtocolVersion11;
+  protocol_version?: ProtocolVersion12;
   run_id: RunId;
   sequence: Sequence;
   status: Status1;
@@ -451,10 +507,10 @@ export interface AgentExecutionActivityData {
  * One reproducible human, control, or invocation event.
  */
 export interface RunEvent {
-  protocol_version?: ProtocolVersion12;
+  protocol_version?: ProtocolVersion13;
   sequence?: Sequence1;
   run_id?: RunId1;
-  timestamp: Timestamp11;
+  timestamp: Timestamp12;
   type: EventType;
   text?: Text2;
   diagnostic?: Diagnostic | null;
@@ -463,21 +519,39 @@ export interface RunEvent {
   agent_kind?: AgentKind2;
   invocation_id?: InvocationId;
   execution_id?: ExecutionId1;
+  chat_thread_id?: ChatThreadId;
   data?: Data;
 }
 export interface ChatData {
   kind?: Kind1;
   answer: Answer1;
+  thread_title?: ThreadTitle;
+  [k: string]: unknown;
+}
+/**
+ * Identity and resolved agent settings for one experiment-chat thread.
+ *
+ * Replayed by clients to rebuild the thread list; the default thread is
+ * implicit and never records one of these.
+ */
+export interface ChatThreadCreatedData {
+  kind?: Kind2;
+  thread_id: ThreadId3;
+  title?: Title2;
+  driver: Driver2;
+  provider: Provider2;
+  model: Model2;
+  created_at: CreatedAt;
   [k: string]: unknown;
 }
 export interface InvocationStartedData {
-  kind?: Kind2;
+  kind?: Kind3;
   system_prompt: SystemPrompt;
   user_prompt: UserPrompt;
   [k: string]: unknown;
 }
 export interface InvocationFinishedData {
-  kind?: Kind3;
+  kind?: Kind4;
   result?: Result;
   error?: Error1;
   [k: string]: unknown;
@@ -489,7 +563,7 @@ export interface Result {
  * Semantic context for one prompt-to-result agent execution.
  */
 export interface AgentExecutionStartedData {
-  kind?: Kind4;
+  kind?: Kind5;
   stage: Stage1;
   attempt?: Attempt1;
   system_prompt?: SystemPrompt1;
@@ -501,7 +575,7 @@ export interface AgentExecutionStartedData {
  * Terminal result for one agent execution.
  */
 export interface AgentExecutionFinishedData {
-  kind?: Kind5;
+  kind?: Kind6;
   result?: Result1;
   error?: Error2;
   [k: string]: unknown;
@@ -510,37 +584,37 @@ export interface Result1 {
   [k: string]: unknown;
 }
 export interface OutputData {
-  kind?: Kind6;
+  kind?: Kind7;
   stream: Stream;
   source?: Source;
   content: Content;
   [k: string]: unknown;
 }
 export interface ServerReadyData {
-  kind?: Kind7;
+  kind?: Kind8;
   socket_protocol?: SocketProtocol;
   [k: string]: unknown;
 }
 export interface RunStartedData {
-  kind?: Kind8;
+  kind?: Kind9;
   outer_loop: OuterLoop;
   input: Input;
   max_rounds: MaxRounds;
   [k: string]: unknown;
 }
 export interface RunInterruptedData {
-  kind?: Kind9;
+  kind?: Kind10;
   reason: Reason;
   signal?: Signal;
   [k: string]: unknown;
 }
 export interface ExperimentsChangedData {
-  kind?: Kind10;
+  kind?: Kind11;
   reason: Reason1;
   [k: string]: unknown;
 }
 export interface ConfigurationFailedData {
-  kind?: Kind11;
+  kind?: Kind12;
   code: Code1;
   stage: Stage2;
   message: Message;
@@ -549,13 +623,13 @@ export interface ConfigurationFailedData {
   [k: string]: unknown;
 }
 export interface PhaseData {
-  kind?: Kind12;
+  kind?: Kind13;
   phase: Phase;
   attempt?: Attempt2;
   [k: string]: unknown;
 }
 export interface AgentOutputChunkData {
-  kind?: Kind13;
+  kind?: Kind14;
   channel: Channel;
   content: Content1;
   status?: AgentStatusData | null;
@@ -577,7 +651,7 @@ export interface AgentStatusData {
   [k: string]: unknown;
 }
 export interface SubprocessOutputData {
-  kind?: Kind14;
+  kind?: Kind15;
   process_id: ProcessId;
   process_kind: ProcessKind;
   stream: Stream1;
@@ -585,21 +659,21 @@ export interface SubprocessOutputData {
   [k: string]: unknown;
 }
 export interface JudgeResultData {
-  kind?: Kind15;
+  kind?: Kind16;
   verdict: Verdict;
   feedback: Feedback;
   attempt: Attempt3;
   [k: string]: unknown;
 }
 export interface BenchmarkResultData {
-  kind?: Kind16;
+  kind?: Kind17;
   metric: Metric;
   value: Value;
   unit: Unit;
   [k: string]: unknown;
 }
 export interface RoundFinishedData {
-  kind?: Kind17;
+  kind?: Kind18;
   attempts: Attempts;
   judge_verdict: JudgeVerdict;
   perf_metric?: PerfMetric;
@@ -607,7 +681,7 @@ export interface RoundFinishedData {
   [k: string]: unknown;
 }
 export interface ToolCallData {
-  kind?: Kind18;
+  kind?: Kind19;
   tool: Tool1;
   call_id?: CallId;
   args?: Args;
@@ -618,7 +692,7 @@ export interface Args {
   [k: string]: unknown;
 }
 export interface ToolResultData {
-  kind?: Kind19;
+  kind?: Kind20;
   tool: Tool2;
   call_id?: CallId1;
   content: Content3;
@@ -626,7 +700,7 @@ export interface ToolResultData {
   [k: string]: unknown;
 }
 export interface TodoUpdateData {
-  kind?: Kind20;
+  kind?: Kind21;
   todos?: Todos;
   [k: string]: unknown;
 }
@@ -636,10 +710,10 @@ export interface TodoItemData {
   [k: string]: unknown;
 }
 export interface UsageUpdateData {
-  kind?: Kind21;
+  kind?: Kind22;
   input_tokens: InputTokens1;
   context_window?: ContextWindow1;
-  model?: Model;
+  model?: Model3;
   [k: string]: unknown;
 }
 export interface PerformanceRound {
@@ -688,24 +762,24 @@ export interface HypothesisRound {
   candidate_disposition?: CandidateDisposition;
 }
 export interface SubscribedMessage {
-  type?: Type10;
-  request_id: RequestId11;
+  type?: Type11;
+  request_id: RequestId12;
   run_id: RunId2;
   latest_sequence: LatestSequence;
 }
 export interface EventMessage {
-  type?: Type11;
+  type?: Type12;
   event: RunEvent;
 }
 export interface EventBatchMessage {
-  type?: Type12;
+  type?: Type13;
   events: Events1;
   through_sequence?: ThroughSequence;
   active_executions?: ActiveExecutions1;
 }
 export interface ProtocolErrorMessage {
-  type?: Type13;
-  request_id?: RequestId12;
+  type?: Type14;
+  request_id?: RequestId13;
   code: Code2;
   message: Message1;
   diagnostic?: Diagnostic | null;

--- a/clients/backend-client/src/generated/protocol.schema.json
+++ b/clients/backend-client/src/generated/protocol.schema.json
@@ -310,6 +310,18 @@
         "answer": {
           "title": "Answer",
           "type": "string"
+        },
+        "thread_title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Thread Title"
         }
       },
       "required": [
@@ -345,6 +357,18 @@
         "text": {
           "title": "Text",
           "type": "string"
+        },
+        "thread_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Thread Id"
         }
       },
       "required": [
@@ -369,6 +393,18 @@
           "default": "none",
           "title": "Effect",
           "type": "string"
+        },
+        "thread_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Thread Id"
         }
       },
       "required": [
@@ -376,6 +412,168 @@
         "answer"
       ],
       "title": "ChatResult",
+      "type": "object"
+    },
+    "ChatThreadCreateQuery": {
+      "additionalProperties": false,
+      "description": "Create a new experiment-chat thread with its own agent selection.\n\nOmitted fields resolve to the run's configured driver, provider, and\nmodel. The response carries the resolved settings and thread identity.",
+      "properties": {
+        "protocol_version": {
+          "const": 1,
+          "default": 1,
+          "title": "Protocol Version",
+          "type": "integer"
+        },
+        "request_id": {
+          "title": "Request Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "format": "date-time",
+          "title": "Timestamp",
+          "type": "string"
+        },
+        "type": {
+          "const": "query.chat_thread_create",
+          "default": "query.chat_thread_create",
+          "title": "Type",
+          "type": "string"
+        },
+        "driver": {
+          "anyOf": [
+            {
+              "enum": [
+                "agentshim",
+                "omnigent"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Driver"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Provider"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        }
+      },
+      "title": "ChatThreadCreateQuery",
+      "type": "object"
+    },
+    "ChatThreadCreatedData": {
+      "description": "Identity and resolved agent settings for one experiment-chat thread.\n\nReplayed by clients to rebuild the thread list; the default thread is\nimplicit and never records one of these.",
+      "properties": {
+        "kind": {
+          "const": "chat_thread_created",
+          "default": "chat_thread_created",
+          "title": "Kind",
+          "type": "string"
+        },
+        "thread_id": {
+          "title": "Thread Id",
+          "type": "string"
+        },
+        "title": {
+          "default": "",
+          "title": "Title",
+          "type": "string"
+        },
+        "driver": {
+          "title": "Driver",
+          "type": "string"
+        },
+        "provider": {
+          "title": "Provider",
+          "type": "string"
+        },
+        "model": {
+          "title": "Model",
+          "type": "string"
+        },
+        "created_at": {
+          "format": "date-time",
+          "title": "Created At",
+          "type": "string"
+        }
+      },
+      "required": [
+        "thread_id",
+        "driver",
+        "provider",
+        "model",
+        "created_at"
+      ],
+      "title": "ChatThreadCreatedData",
+      "type": "object"
+    },
+    "ChatThreadInfo": {
+      "additionalProperties": false,
+      "description": "Resolved identity and agent settings of one experiment-chat thread.",
+      "properties": {
+        "thread_id": {
+          "title": "Thread Id",
+          "type": "string"
+        },
+        "title": {
+          "default": "",
+          "title": "Title",
+          "type": "string"
+        },
+        "driver": {
+          "title": "Driver",
+          "type": "string"
+        },
+        "provider": {
+          "title": "Provider",
+          "type": "string"
+        },
+        "model": {
+          "title": "Model",
+          "type": "string"
+        }
+      },
+      "required": [
+        "thread_id",
+        "driver",
+        "provider",
+        "model"
+      ],
+      "title": "ChatThreadInfo",
       "type": "object"
     },
     "CommandAck": {
@@ -649,6 +847,7 @@
         "experiments_changed",
         "run_interrupted",
         "chat",
+        "chat_thread_created",
         "status_query",
         "control",
         "invocation_started",
@@ -1418,6 +1617,17 @@
           ],
           "default": null
         },
+        "chat_thread": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ChatThreadInfo"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "snapshot": {
           "anyOf": [
             {
@@ -1654,6 +1864,18 @@
           "default": null,
           "title": "Execution Id"
         },
+        "chat_thread_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Chat Thread Id"
+        },
         "data": {
           "anyOf": [
             {
@@ -1665,6 +1887,7 @@
                   "agent_output_chunk": "#/$defs/AgentOutputChunkData",
                   "benchmark_result": "#/$defs/BenchmarkResultData",
                   "chat": "#/$defs/ChatData",
+                  "chat_thread_created": "#/$defs/ChatThreadCreatedData",
                   "configuration_failed": "#/$defs/ConfigurationFailedData",
                   "experiments_changed": "#/$defs/ExperimentsChangedData",
                   "invocation_finished": "#/$defs/InvocationFinishedData",
@@ -1687,6 +1910,9 @@
               "oneOf": [
                 {
                   "$ref": "#/$defs/ChatData"
+                },
+                {
+                  "$ref": "#/$defs/ChatThreadCreatedData"
                 },
                 {
                   "$ref": "#/$defs/InvocationStartedData"
@@ -2250,6 +2476,7 @@
           "command.resume": "#/$defs/ResumeCommand",
           "command.steer": "#/$defs/SteerCommand",
           "query.chat": "#/$defs/ChatQuery",
+          "query.chat_thread_create": "#/$defs/ChatThreadCreateQuery",
           "query.events": "#/$defs/EventsQuery",
           "query.experiments": "#/$defs/ExperimentQuery",
           "query.history": "#/$defs/HistoryQuery",
@@ -2274,6 +2501,9 @@
         },
         {
           "$ref": "#/$defs/ChatQuery"
+        },
+        {
+          "$ref": "#/$defs/ChatThreadCreateQuery"
         },
         {
           "$ref": "#/$defs/HistoryQuery"

--- a/clients/core-state/src/core-state.test.ts
+++ b/clients/core-state/src/core-state.test.ts
@@ -182,6 +182,83 @@ describe('core state projection', () => {
     expect(state.chatTranscript.map(entry => entry.content)).toEqual(['answer']);
   });
 
+  it('partitions chat transcripts by thread, defaulting unstamped events', () => {
+    let state = initialCoreState();
+    state = reduceEvent(state, chatAnswerEvent(1, 'default answer'));
+    state = reduceEvent(state, chatAnswerEvent(2, 'thread answer', 'thread-a'));
+
+    // Neither thread sees the other's answer, and unstamped events land on
+    // the default thread so pre-thread logs replay unchanged.
+    expect(state.chatTranscripts['default']?.map(entry => entry.content)).toEqual([
+      'default answer',
+    ]);
+    expect(state.chatTranscripts['thread-a']?.map(entry => entry.content)).toEqual([
+      'thread answer',
+    ]);
+    // The legacy selector still reads the default thread.
+    expect(state.chatTranscript.map(entry => entry.content)).toEqual(['default answer']);
+    expect(state.transcript).toEqual([]);
+  });
+
+  it('replays the thread list from creation events after the implicit default', () => {
+    let state = initialCoreState();
+    state = reduceEvent(state, threadCreatedEvent(1, 'thread-a', 'claude'));
+    state = reduceEvent(state, threadCreatedEvent(2, 'thread-b', 'codex'));
+
+    expect(state.chatThreads.map(thread => thread.id)).toEqual(['default', 'thread-a', 'thread-b']);
+    // The implicit default carries no backend title; consumers name it.
+    expect(state.chatThreads[0]).toMatchObject({title: '', driver: null, provider: null});
+    expect(state.chatThreads[1]).toMatchObject({
+      title: '',
+      driver: 'agentshim',
+      provider: 'claude',
+      model: 'opus',
+    });
+    // A created thread has a transcript from the start, even before it talks.
+    expect(state.chatTranscripts['thread-b']).toEqual([]);
+  });
+
+  it('adopts the backend-derived title carried on a chat event', () => {
+    let state = initialCoreState();
+    state = reduceEvent(state, threadCreatedEvent(1, 'thread-a', 'claude'));
+    state = reduceEvent(state, {
+      ...chatAnswerEvent(2, 'first answer', 'thread-a'),
+      data: {kind: 'chat', answer: 'first answer', thread_title: 'why did r2 regress'},
+    });
+
+    expect(state.chatThreads.find(thread => thread.id === 'thread-a')?.title).toBe(
+      'why did r2 regress',
+    );
+  });
+
+  it('names a thread from a titled turn even when its creation replayed away', () => {
+    const state = reduceEvent(initialCoreState(), {
+      ...chatAnswerEvent(1, 'answer', 'thread-x'),
+      data: {kind: 'chat', answer: 'answer', thread_title: 'orphan thread'},
+    });
+
+    expect(state.chatThreads.find(thread => thread.id === 'thread-x')?.title).toBe('orphan thread');
+    expect(state.chatTranscripts['thread-x']?.map(entry => entry.content)).toEqual(['answer']);
+  });
+
+  it('drops legacy chat tool chunks per thread once typed events appear', () => {
+    let state = initialCoreState();
+    state = reduceEvent(state, {
+      ...baseEvent(1, 'tool_call'),
+      agent_kind: 'chat',
+      chat_thread_id: 'thread-a',
+      data: {kind: 'tool_call', tool: 'read_file', args: {}},
+    });
+    // The default thread saw no typed events, so its legacy chunks survive.
+    state = reduceEvent(state, {
+      ...outputEvent(2, 'legacy default output'),
+      agent_kind: 'chat',
+    });
+
+    expect(state.chatTypedToolEvents).toEqual({'thread-a': true});
+    expect(state.chatTranscript.map(entry => entry.content)).toEqual(['legacy default output']);
+  });
+
   it('scopes todo snapshots by execution', () => {
     let state = initialCoreState();
     state = reduceEvent(state, todoEvent(1, 'exec-a', 'first'));
@@ -350,6 +427,34 @@ function baseEvent(sequence: number, type: RunEvent['type']): RunEvent {
     type,
     agent_kind: 'implementer',
     round_label: 'round-1-implementer',
+  };
+}
+
+function chatAnswerEvent(sequence: number, answer: string, threadId?: string): RunEvent {
+  return {
+    ...baseEvent(sequence, 'chat'),
+    agent_kind: 'chat',
+    round_label: 'experiment-chat',
+    ...(threadId === undefined ? {} : {chat_thread_id: threadId}),
+    data: {kind: 'chat', answer},
+  };
+}
+
+function threadCreatedEvent(sequence: number, threadId: string, provider: string): RunEvent {
+  return {
+    ...baseEvent(sequence, 'chat_thread_created'),
+    agent_kind: 'chat',
+    round_label: 'experiment-chat',
+    chat_thread_id: threadId,
+    data: {
+      kind: 'chat_thread_created',
+      thread_id: threadId,
+      title: '',
+      driver: 'agentshim',
+      provider,
+      model: 'opus',
+      created_at: `2026-01-01T00:00:0${sequence}Z`,
+    },
   };
 }
 

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -49,6 +49,23 @@ export interface BenchmarkRecord {
 type RunEventData = NonNullable<RunEvent['data']>;
 export type TypedToolResult = Extract<RunEventData, {kind?: 'tool_result'}>;
 
+/** Thread id used for chat events recorded without one. */
+export const DEFAULT_CHAT_THREAD_ID = 'default';
+
+/**
+ * One experiment-chat thread, replayed from `chat_thread_created` events. The
+ * default thread is implicit: it exists from the first frame and carries no
+ * agent selection of its own.
+ */
+export interface ChatThread {
+  id: string;
+  /** Backend-owned title; empty until the server has derived or been given one. */
+  title: string;
+  driver: string | null;
+  provider: string | null;
+  model: string | null;
+}
+
 export interface TranscriptEntry {
   id: string;
   kind:
@@ -105,7 +122,12 @@ export interface CoreState {
   phases: AgentPhase[];
   activeExecutions: Record<string, ActiveAgentExecution>;
   transcript: TranscriptEntry[];
+  /** The default thread's transcript; equals `chatTranscripts[DEFAULT_CHAT_THREAD_ID]`. */
   chatTranscript: TranscriptEntry[];
+  /** Every thread's transcript, keyed by thread id. */
+  chatTranscripts: Record<string, TranscriptEntry[]>;
+  /** The default thread first, then created threads in replay order. */
+  chatThreads: ChatThread[];
   todos: ExecutionTodos[];
   usage: UsageMeter | null;
   benchmarks: BenchmarkRecord[];
@@ -113,7 +135,8 @@ export interface CoreState {
   /** Sequence of the latest semantic experiment invalidation. */
   experimentsRevision: number;
   typedToolEvents: boolean;
-  chatTypedToolEvents: boolean;
+  /** Per thread id: typed tool events seen, so legacy tool chunks are dropped. */
+  chatTypedToolEvents: Record<string, boolean>;
 }
 
 export function initialCoreState(): CoreState {
@@ -130,14 +153,25 @@ export function initialCoreState(): CoreState {
     activeExecutions: {},
     transcript: [],
     chatTranscript: [],
+    chatTranscripts: {[DEFAULT_CHAT_THREAD_ID]: []},
+    // The default thread has no backend record, so it has no backend-owned
+    // title either. Naming it is the consumer's job.
+    chatThreads: [
+      {id: DEFAULT_CHAT_THREAD_ID, title: '', driver: null, provider: null, model: null},
+    ],
     todos: [],
     usage: null,
     benchmarks: [],
     diagnostics: [],
     experimentsRevision: 0,
     typedToolEvents: false,
-    chatTypedToolEvents: false,
+    chatTypedToolEvents: {},
   };
+}
+
+/** The transcript for one chat thread; unknown threads read as empty. */
+export function chatTranscriptFor(state: CoreState, threadId: string): TranscriptEntry[] {
+  return state.chatTranscripts[threadId] ?? [];
 }
 
 export function reduceSnapshot(state: CoreState, snapshot: RunSnapshot): CoreState {
@@ -350,14 +384,82 @@ function updateTodos(previous: ExecutionTodos[], event: RunEvent): ExecutionTodo
 
 function applyChatEvent(state: CoreState, event: RunEvent): CoreState {
   const data = event.data;
+  const threadId = event.chat_thread_id ?? DEFAULT_CHAT_THREAD_ID;
+  if (data?.kind === 'chat_thread_created') {
+    return upsertChatThread(state, {
+      id: data.thread_id,
+      title: data.title ?? '',
+      driver: data.driver,
+      provider: data.provider,
+      model: data.model,
+    });
+  }
+  let next = state;
   const typed = data?.kind === 'tool_call' || data?.kind === 'tool_result';
-  const next = typed ? {...state, chatTypedToolEvents: true} : state;
+  if (typed && next.chatTypedToolEvents[threadId] !== true) {
+    next = {...next, chatTypedToolEvents: {...next.chatTypedToolEvents, [threadId]: true}};
+  }
   const legacyToolChunk =
-    data?.kind === 'agent_output_chunk' && data.channel === 'tool' && next.chatTypedToolEvents;
+    data?.kind === 'agent_output_chunk' &&
+    data.channel === 'tool' &&
+    next.chatTypedToolEvents[threadId] === true;
   if (legacyToolChunk) return next;
+  if (data?.kind === 'chat' && data.thread_title) {
+    next = setChatThreadTitle(next, threadId, data.thread_title);
+  }
   const entry = eventToTranscriptEntry(event);
   if (entry === null || (entry.kind !== 'assistant' && entry.kind !== 'result')) return next;
-  return {...next, chatTranscript: appendTranscript(next.chatTranscript, entry)};
+  return appendChatTranscript(next, threadId, entry);
+}
+
+/** Registers a replayed thread, or refreshes the record it already has. */
+function upsertChatThread(state: CoreState, thread: ChatThread): CoreState {
+  const existing = state.chatThreads.find(candidate => candidate.id === thread.id);
+  const chatThreads =
+    existing === undefined
+      ? [...state.chatThreads, thread]
+      : state.chatThreads.map(candidate =>
+          candidate.id === thread.id
+            ? {...thread, title: thread.title || candidate.title}
+            : candidate,
+        );
+  const chatTranscripts =
+    state.chatTranscripts[thread.id] === undefined
+      ? {...state.chatTranscripts, [thread.id]: []}
+      : state.chatTranscripts;
+  return {...state, chatThreads, chatTranscripts};
+}
+
+function setChatThreadTitle(state: CoreState, threadId: string, title: string): CoreState {
+  if (!state.chatThreads.some(thread => thread.id === threadId)) {
+    // A titled turn for a thread whose creation event is missing from the
+    // replay window still names a thread the operator can select.
+    return setChatThreadTitle(
+      upsertChatThread(state, {id: threadId, title: '', driver: null, provider: null, model: null}),
+      threadId,
+      title,
+    );
+  }
+  return {
+    ...state,
+    chatThreads: state.chatThreads.map(thread =>
+      thread.id === threadId ? {...thread, title} : thread,
+    ),
+  };
+}
+
+function appendChatTranscript(
+  state: CoreState,
+  threadId: string,
+  entry: TranscriptEntry,
+): CoreState {
+  const transcript = appendTranscript(state.chatTranscripts[threadId] ?? [], entry);
+  const chatTranscripts = {...state.chatTranscripts, [threadId]: transcript};
+  return {
+    ...state,
+    chatTranscripts,
+    chatTranscript: threadId === DEFAULT_CHAT_THREAD_ID ? transcript : state.chatTranscript,
+  };
 }
 
 function applyDiagnosticEvent(state: CoreState, event: RunEvent): CoreState {

--- a/clients/tui/src/commands.test.ts
+++ b/clients/tui/src/commands.test.ts
@@ -97,14 +97,28 @@ describe('command surface by view', () => {
 
     expect(docked).not.toContain('/chat');
     expect(docked).toContain('/perf');
-    expect(helpText({chatDocked: true})).not.toContain('/chat');
-    expect(suggestSlashCommands('/c', {chatDocked: true})).toEqual([]);
+    // The thread commands stay: they are about which thread, not about
+    // opening a chat that is already on screen.
+    expect(docked).toContain('/chats');
+    expect(docked).toContain('/new-chat');
+    expect(helpText({chatDocked: true})).not.toMatch(/\/chat\s/);
+    expect(suggestSlashCommands('/c', {chatDocked: true}).map(command => command.name)).toEqual([
+      '/chats',
+    ]);
   });
 
   it('offers /chat everywhere the chat is not already on screen', () => {
     expect(availableCommands().map(command => command.name)).toContain('/chat');
-    expect(helpText()).toContain('/chat');
-    expect(suggestSlashCommands('/c').map(command => command.name)).toEqual(['/chat']);
+    expect(helpText()).toMatch(/\/chat\s/);
+    expect(suggestSlashCommands('/c').map(command => command.name)).toEqual(['/chat', '/chats']);
+  });
+
+  it('parses the chat thread commands as local views', () => {
+    expect(parseCommand('/new-chat')).toEqual({localView: 'new-chat'});
+    expect(parseCommand('/chats')).toEqual({localView: 'chats'});
+    // Arguments are not part of this iteration's surface.
+    expect(parseCommand('/chats extra').error).toContain('Unknown command');
+    expect(parseCommand('/new-chat codex').error).toContain('Unknown command');
   });
 
   it('reaches the todo and prompt toggles by name', () => {
@@ -125,6 +139,8 @@ describe('slash-command input helpers', () => {
     expect(suggestSlashCommands('/').map(command => command.name)).toEqual([
       '/help',
       '/chat',
+      '/new-chat',
+      '/chats',
       '/pause',
       '/resume',
       '/steer',

--- a/clients/tui/src/commands.ts
+++ b/clients/tui/src/commands.ts
@@ -5,7 +5,7 @@ import {isThemeName, THEME_NAMES, type ThemeName} from './ui/theme.js';
 type CommandRequest = Exclude<RequestInput, {type: 'query.chat'}>;
 
 export type ParsedCommand = {
-  localView?: 'chat' | 'help' | 'theme';
+  localView?: 'chat' | 'chats' | 'help' | 'new-chat' | 'theme';
   /**
    * Surfaces that also have a key. macOS reserves the function keys for system
    * controls and a terminal may keep a Control chord for itself, so every
@@ -35,6 +35,8 @@ export interface SlashCommand {
 export const SLASH_COMMANDS: readonly SlashCommand[] = [
   {name: '/help', description: 'Show this help'},
   {name: '/chat', description: 'Open experiment chat'},
+  {name: '/new-chat', description: 'Start a chat thread with its own agent and model'},
+  {name: '/chats', description: 'List chat threads and switch between them'},
   {name: '/pause', description: 'Pause after the current agent call'},
   {name: '/resume', description: 'Resume a paused run'},
   {name: '/steer', description: 'Guide the next agent invocation: /steer <message>'},
@@ -98,6 +100,8 @@ export function parseCommand(text: string): ParsedCommand {
     const message = chat[1]?.trim();
     return {localView: 'chat', ...(message ? {chatMessage: message} : {})};
   }
+  if (text === '/new-chat') return {localView: 'new-chat'};
+  if (text === '/chats') return {localView: 'chats'};
   const theme = text.match(/^\/theme(?:\s+(.*))?$/);
   if (theme) {
     const requested = theme[1]?.trim();

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -389,12 +389,12 @@ describe('session controller', () => {
     await controller.start();
 
     await controller.submitCommand('/help');
-    expect(controller.state.overlay?.content).not.toContain('/chat');
+    expect(controller.state.overlay?.content).not.toMatch(/\/chat\s/);
 
     // Inside a hypothesis the chat is a dialog again, so the command returns.
     controller.enterExperimentDrilldown();
     await controller.submitCommand('/help');
-    expect(controller.state.overlay?.content).toContain('/chat');
+    expect(controller.state.overlay?.content).toMatch(/\/chat\s/);
   });
 
   it('carries the modal conversation back into the docked pane', async () => {
@@ -1072,6 +1072,96 @@ describe('session controller', () => {
     expect(controller.state.chatConversation.at(-1)?.content).toBe('Nothing yet.');
   });
 
+  it('creates a chat thread from the wizard and switches to it', async () => {
+    const transport = new ThreadTransport();
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+
+    await controller.submitCommand('/new-chat');
+    expect(controller.state.newChatPicker).toMatchObject({step: 'driver', driver: 'agentshim'});
+
+    controller.moveNewChatSelection(1);
+    await controller.confirmNewChatPicker();
+    expect(controller.state.newChatPicker).toMatchObject({step: 'provider', driver: 'omnigent'});
+    controller.moveNewChatSelection(1);
+    await controller.confirmNewChatPicker();
+    expect(controller.state.newChatPicker?.step).toBe('model');
+    controller.typeNewChatModel('o4');
+    await controller.confirmNewChatPicker();
+
+    expect(transport.requests.at(-1)).toEqual({
+      type: 'query.chat_thread_create',
+      driver: 'omnigent',
+      provider: 'codex',
+      model: 'o4',
+    });
+    expect(controller.state.newChatPicker).toBeNull();
+    // The thread record comes from the replayed backend event, and the
+    // client switches the chat surfaces to it.
+    expect(controller.state.core.chatThreads.map(thread => thread.id)).toEqual([
+      'default',
+      'thread-1',
+    ]);
+    expect(controller.state.activeChatThreadId).toBe('thread-1');
+  });
+
+  it('sends chat to the active thread and keeps transcripts apart', async () => {
+    const transport = new ThreadTransport();
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+    await controller.submitCommand('/new-chat');
+    await controller.confirmNewChatPicker();
+    await controller.confirmNewChatPicker();
+    await controller.confirmNewChatPicker();
+    expect(controller.state.activeChatThreadId).toBe('thread-1');
+
+    await controller.sendChat('which kernel changed?');
+
+    expect(transport.requests.at(-1)).toEqual({
+      type: 'query.chat',
+      text: 'which kernel changed?',
+      thread_id: 'thread-1',
+    });
+    expect(controller.state.chatConversations['thread-1']?.map(entry => entry.content)).toEqual([
+      'which kernel changed?',
+      'Thread answer.',
+    ]);
+    expect(controller.state.chatConversations['default'] ?? []).toEqual([]);
+
+    // Switching swaps what the singular selectors show; nothing is lost.
+    controller.switchChatThread('default');
+    expect(controller.state.chatConversation).toEqual([]);
+    await controller.sendChat('and the default thread?');
+    expect(transport.requests.at(-1)).toEqual({
+      type: 'query.chat',
+      text: 'and the default thread?',
+    });
+    controller.switchChatThread('thread-1');
+    expect(controller.state.chatConversation.map(entry => entry.content)).toEqual([
+      'which kernel changed?',
+      'Thread answer.',
+    ]);
+  });
+
+  it('opens the thread picker and switches with the selection', async () => {
+    const transport = new ThreadTransport();
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+    await controller.submitCommand('/new-chat');
+    await controller.confirmNewChatPicker();
+    await controller.confirmNewChatPicker();
+    await controller.confirmNewChatPicker();
+    controller.switchChatThread('default');
+
+    await controller.submitCommand('/chats');
+    expect(controller.state.chatThreadPicker).toEqual({selected: 'default'});
+    controller.moveChatThreadSelection(1);
+    controller.applySelectedChatThread();
+
+    expect(controller.state.chatThreadPicker).toBeNull();
+    expect(controller.state.activeChatThreadId).toBe('thread-1');
+  });
+
   it('reports an unknown theme as an error without switching', async () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);
@@ -1230,6 +1320,91 @@ class DeferredChatTransport implements SupervisionTransport {
         effect: 'none',
       },
     });
+  }
+
+  subscribe(
+    _afterSequence: number,
+    _onMessage: (message: ServerMessage) => void,
+    _onDisconnect: (error: Error) => void,
+  ): Promise<EventSubscription> {
+    return Promise.resolve({close: async () => undefined});
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+/** A backend that creates one thread and answers threaded chat. */
+class ThreadTransport implements SupervisionTransport {
+  readonly requests: RequestInput[] = [];
+  #sequence = 0;
+
+  request(input: RequestInput): Promise<ProtocolResponse> {
+    this.requests.push(input);
+    const base = {
+      protocol_version: 1 as const,
+      request_id: 'request',
+      timestamp: '2026-01-01T00:00:00Z',
+      ok: true,
+    };
+    if (input.type === 'query.snapshot') {
+      return Promise.resolve({...base, snapshot: {run_id: 'run', status: 'running', sequence: 0}});
+    }
+    if (input.type === 'query.experiments') {
+      return Promise.resolve({...base, experiments: [], experiments_ready: true});
+    }
+    if (input.type === 'query.chat_thread_create') {
+      return Promise.resolve({
+        ...base,
+        chat_thread: {
+          thread_id: 'thread-1',
+          title: '',
+          driver: input.driver ?? 'agentshim',
+          provider: input.provider ?? 'codex',
+          model: input.model ?? 'gpt-run',
+        },
+        events: [
+          {
+            sequence: ++this.#sequence,
+            timestamp: '2026-01-01T00:00:01Z',
+            type: 'chat_thread_created' as const,
+            agent_kind: 'chat',
+            round_label: 'experiment-chat',
+            chat_thread_id: 'thread-1',
+            data: {
+              kind: 'chat_thread_created' as const,
+              thread_id: 'thread-1',
+              title: '',
+              driver: input.driver ?? 'agentshim',
+              provider: input.provider ?? 'codex',
+              model: input.model ?? 'gpt-run',
+              created_at: '2026-01-01T00:00:01Z',
+            },
+          },
+        ],
+      });
+    }
+    if (input.type === 'query.chat') {
+      const threadId = input.thread_id ?? null;
+      return Promise.resolve({
+        ...base,
+        chat: {question: input.text, answer: 'Thread answer.', effect: 'none' as const},
+        events: [
+          {
+            sequence: ++this.#sequence,
+            timestamp: '2026-01-01T00:00:02Z',
+            type: 'chat' as const,
+            agent_kind: 'chat',
+            round_label: 'experiment-chat',
+            text: input.text,
+            ...(threadId === null ? {} : {chat_thread_id: threadId}),
+            data: {kind: 'chat' as const, answer: 'Thread answer.'},
+          },
+        ],
+      });
+    }
+    return Promise.resolve(base);
   }
 
   subscribe(

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -9,14 +9,15 @@ import {
 import {helpText, parseCommand} from './commands.js';
 import {renderPerformanceCurve} from './performance-chart.js';
 import {
+  advanceNewChatPicker,
   applyEvent,
   applyEventBatch,
   applySnapshot,
-  type ConversationEntry,
   chatDocked,
   chatPaneVisible,
   clearAgentSelection,
   clearEntrySelection,
+  closeChatThreadPicker,
   closeOverlays,
   closePane,
   closeThemePicker,
@@ -32,15 +33,21 @@ import {
   initialSessionState,
   leaveExperimentDrilldown,
   markEventStreamUnavailable,
+  moveChatThreadSelection,
   moveExperimentSelection,
+  moveNewChatSelection,
   moveThemeSelection,
+  type NewChatPicker,
   normalizeFocus,
   openChat,
+  openChatThreadPicker,
   openExperimentLog,
+  openNewChatPicker,
   openPane,
   openThemePicker,
   type PaneFocus,
   type PaneView,
+  retreatNewChatPicker,
   type RoundFocus,
   reportError,
   type SessionState,
@@ -54,14 +61,19 @@ import {
   selectPreviousRound,
   selectRound,
   setChatDockFits,
+  setChatThreadPending,
   setExperiments,
+  setNewChatModel,
   setPaneContent,
   setTheme,
   showDetail,
   showLive,
+  switchChatThread,
   togglePaneZoom,
   toggleTodos,
+  updateChatConversation,
 } from './session-model.js';
+import {DEFAULT_CHAT_THREAD_ID} from '@vibesys/core-state';
 import {DEFAULT_THEME_NAME, type ThemeName} from './ui/theme.js';
 
 export interface SessionController {
@@ -72,6 +84,20 @@ export interface SessionController {
   closeChat(): void;
   sendChat(value: string): Promise<void>;
   submitChat(value: string): Promise<void>;
+  /** Makes one thread the chat surfaces' subject. */
+  switchChatThread(threadId: string): void;
+  openChatThreadPicker(): void;
+  moveChatThreadSelection(delta: number): void;
+  /** Enter in the thread picker: switch to the highlighted thread. */
+  applySelectedChatThread(): void;
+  closeChatThreadPicker(): void;
+  openNewChatPicker(): void;
+  moveNewChatSelection(delta: number): void;
+  /** Enter in the wizard: next step, or create the thread on the last one. */
+  confirmNewChatPicker(): Promise<void>;
+  retreatNewChatPicker(): void;
+  typeNewChatModel(text: string): void;
+  backspaceNewChatModel(): void;
   live(): void;
   selectNextAgent(): void;
   selectPreviousAgent(): void;
@@ -125,7 +151,7 @@ export class SocketSessionController implements SessionController {
   readonly #listeners = new Set<(state: SessionState) => void>();
   #eventSubscription: EventSubscription | null = null;
   #chatMessageId = 0;
-  readonly #chatQueue: Array<{id: string; text: string}> = [];
+  readonly #chatQueue: Array<{id: string; text: string; threadId: string}> = [];
   #chatDrain: Promise<void> | null = null;
   /** Single-flight guard for semantic experiment-log invalidations. */
   #experimentFetch: Promise<void> | null = null;
@@ -280,6 +306,85 @@ export class SocketSessionController implements SessionController {
 
   closeChat(): void {
     this.#setState({...this.#state, chatOpen: false});
+  }
+
+  switchChatThread(threadId: string): void {
+    this.#setState(switchChatThread(this.#state, threadId));
+  }
+
+  openChatThreadPicker(): void {
+    this.#setState(openChatThreadPicker(this.#state));
+  }
+
+  moveChatThreadSelection(delta: number): void {
+    this.#setState(moveChatThreadSelection(this.#state, delta));
+  }
+
+  applySelectedChatThread(): void {
+    const picker = this.#state.chatThreadPicker;
+    if (picker === null) return;
+    this.switchChatThread(picker.selected);
+  }
+
+  closeChatThreadPicker(): void {
+    this.#setState(closeChatThreadPicker(this.#state));
+  }
+
+  openNewChatPicker(): void {
+    this.#setState(openNewChatPicker(this.#state));
+  }
+
+  moveNewChatSelection(delta: number): void {
+    this.#setState(moveNewChatSelection(this.#state, delta));
+  }
+
+  async confirmNewChatPicker(): Promise<void> {
+    const picker = this.#state.newChatPicker;
+    if (picker === null) return;
+    if (picker.step !== 'model') {
+      this.#setState(advanceNewChatPicker(this.#state));
+      return;
+    }
+    this.#setState({...this.#state, newChatPicker: null});
+    await this.#createChatThread(picker);
+  }
+
+  retreatNewChatPicker(): void {
+    this.#setState(retreatNewChatPicker(this.#state));
+  }
+
+  typeNewChatModel(text: string): void {
+    const picker = this.#state.newChatPicker;
+    if (picker === null) return;
+    this.#setState(setNewChatModel(this.#state, picker.model + text));
+  }
+
+  backspaceNewChatModel(): void {
+    const picker = this.#state.newChatPicker;
+    if (picker === null) return;
+    this.#setState(setNewChatModel(this.#state, picker.model.slice(0, -1)));
+  }
+
+  /**
+   * Asks the backend for a new thread. The response's replayed events carry
+   * the authoritative thread record; the client only switches to it.
+   */
+  async #createChatThread(picker: NewChatPicker): Promise<void> {
+    const model = picker.model.trim();
+    try {
+      const response = await this.client.request({
+        type: 'query.chat_thread_create',
+        driver: picker.driver,
+        provider: picker.provider,
+        ...(model === '' ? {} : {model}),
+      });
+      let state = this.#state;
+      for (const event of response.events ?? []) state = applyEvent(state, event);
+      const threadId = response.chat_thread?.thread_id;
+      this.#setState(threadId === undefined ? state : switchChatThread(state, threadId));
+    } catch (error) {
+      this.#setState(reportCaughtError(this.#state, error, 'request'));
+    }
   }
 
   async openExperimentLog(): Promise<void> {
@@ -445,20 +550,26 @@ export class SocketSessionController implements SessionController {
     const text = value.trim();
     if (!text) return Promise.resolve();
     const id = `chat-user-${++this.#chatMessageId}`;
+    // The message belongs to the thread on screen when it was typed, even if
+    // the operator switches threads before the agent gets to it.
+    const threadId = this.#state.activeChatThreadId;
     const queued = this.#state.chatPending || this.#chatQueue.length > 0;
-    this.#chatQueue.push({id, text});
-    this.#setState({
-      ...this.#state,
-      // Docked, the answer lands in the pane the operator is already looking
-      // at, so nothing has to open over the log to show it.
-      ...(chatDocked(this.#state) ? {} : {chatOpen: true}),
-      chatConversation: appendChatEntry(this.#state.chatConversation, {
-        id,
-        kind: 'user',
-        label: queued ? 'You · queued' : 'You',
-        content: text,
-      }),
-    });
+    this.#chatQueue.push({id, text, threadId});
+    this.#setState(
+      updateChatConversation(
+        {
+          ...this.#state,
+          // Docked, the answer lands in the pane the operator is already
+          // looking at, so nothing has to open over the log to show it.
+          ...(chatDocked(this.#state) ? {} : {chatOpen: true}),
+        },
+        threadId,
+        entries => [
+          ...entries,
+          {id, kind: 'user', label: queued ? 'You · queued' : 'You', content: text},
+        ],
+      ),
+    );
     if (this.#chatDrain === null) {
       const drain = this.#drainChatQueue();
       this.#chatDrain = drain.finally(() => {
@@ -469,54 +580,79 @@ export class SocketSessionController implements SessionController {
   }
 
   async #drainChatQueue(): Promise<void> {
+    const pendingThreads = new Set<string>();
     try {
       while (this.#chatQueue.length > 0) {
-        const messages = this.#chatQueue.splice(0);
+        // One request per thread: batching across threads would hand one
+        // agent another thread's question.
+        const threadId = this.#chatQueue[0]?.threadId ?? DEFAULT_CHAT_THREAD_ID;
+        const messages = this.#chatQueue.filter(message => message.threadId === threadId);
+        for (const message of messages) {
+          this.#chatQueue.splice(this.#chatQueue.indexOf(message), 1);
+        }
         const messageIds = new Set(messages.map(message => message.id));
-        this.#setState({
-          ...this.#state,
-          chatPending: true,
-          chatConversation: this.#state.chatConversation.map(entry =>
-            messageIds.has(entry.id) ? {...entry, label: 'You'} : entry,
+        pendingThreads.add(threadId);
+        this.#setState(
+          updateChatConversation(
+            setChatThreadPending(this.#state, threadId, true),
+            threadId,
+            entries =>
+              entries.map(entry => (messageIds.has(entry.id) ? {...entry, label: 'You'} : entry)),
           ),
-        });
-        await this.#requestChat(messages.map(message => message.text).join('\n\n'));
+        );
+        await this.#requestChat(messages.map(message => message.text).join('\n\n'), threadId);
+        pendingThreads.delete(threadId);
+        this.#setState(setChatThreadPending(this.#state, threadId, false));
       }
     } finally {
-      this.#setState({...this.#state, chatPending: false});
+      let state = this.#state;
+      for (const threadId of pendingThreads) {
+        state = setChatThreadPending(state, threadId, false);
+      }
+      this.#setState(state);
     }
   }
 
-  async #requestChat(text: string): Promise<void> {
+  async #requestChat(text: string, threadId: string): Promise<void> {
     try {
-      const response = await this.client.request({type: 'query.chat', text});
+      const response = await this.client.request({
+        type: 'query.chat',
+        text,
+        ...(threadId === DEFAULT_CHAT_THREAD_ID ? {} : {thread_id: threadId}),
+      });
       const answer = response.chat?.answer ?? 'No chat answer was returned.';
       let state = this.#state;
       for (const event of response.events ?? []) state = applyEvent(state, event);
       if (!(response.events ?? []).some(event => event.data?.kind === 'chat')) {
-        state = {
-          ...state,
-          chatConversation: appendChatEntry(state.chatConversation, {
+        state = updateChatConversation(state, threadId, entries => [
+          ...entries,
+          {
             id: `chat-answer-${++this.#chatMessageId}`,
             kind: 'assistant',
             label: 'Answer',
             content: answer,
-          }),
-        };
+          },
+        ]);
       }
       this.#setState(state);
     } catch (error) {
       const message = errorMessage(error);
-      this.#setState({
-        ...reportCaughtError(this.#state, error, 'request'),
-        chatConversation: appendChatEntry(this.#state.chatConversation, {
-          id: `chat-error-${++this.#chatMessageId}`,
-          kind: 'result',
-          label: 'Chat failed',
-          tone: 'failure',
-          content: message,
-        }),
-      });
+      this.#setState(
+        updateChatConversation(
+          reportCaughtError(this.#state, error, 'request'),
+          threadId,
+          entries => [
+            ...entries,
+            {
+              id: `chat-error-${++this.#chatMessageId}`,
+              kind: 'result',
+              label: 'Chat failed',
+              tone: 'failure',
+              content: message,
+            },
+          ],
+        ),
+      );
     }
   }
 
@@ -532,6 +668,14 @@ export class SocketSessionController implements SessionController {
     if (parsed.localView === 'chat') {
       this.#setState(openChat(this.#state));
       if (parsed.chatMessage) await this.sendChat(parsed.chatMessage);
+      return;
+    }
+    if (parsed.localView === 'new-chat') {
+      this.openNewChatPicker();
+      return;
+    }
+    if (parsed.localView === 'chats') {
+      this.openChatThreadPicker();
       return;
     }
     if (parsed.toggle === 'todos') {
@@ -628,13 +772,6 @@ function reportCaughtError(
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function appendChatEntry(
-  conversation: ConversationEntry[],
-  entry: ConversationEntry,
-): ConversationEntry[] {
-  return [...conversation, entry].slice(-500);
 }
 
 function renderResponse(

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -3,8 +3,10 @@ import {
   type ActiveAgentExecution,
   type ActiveExecutionCheckpoint,
   type AgentPhase,
+  type ChatThread,
   type CoreDiagnostic,
   type CoreState,
+  DEFAULT_CHAT_THREAD_ID,
   type ExecutionTodos,
   initialCoreState,
   latestDiagnosticChange,
@@ -38,8 +40,19 @@ export interface SessionState {
   roundFocus: RoundFocus;
   overlay: OverlayPanel | null;
   chatOpen: boolean;
+  /** The thread the chat surfaces show and the composer submits to. */
+  activeChatThreadId: string;
+  /** The active thread's conversation, derived from `chatConversations`. */
   chatConversation: ConversationEntry[];
+  /** Every thread's conversation (local user entries merged with replay). */
+  chatConversations: Record<string, ConversationEntry[]>;
+  /** True while the active thread awaits an answer; from `chatPendingThreads`. */
   chatPending: boolean;
+  chatPendingThreads: Record<string, boolean>;
+  /** Non-null while the thread list is open as a keyboard selection. */
+  chatThreadPicker: ChatThreadPicker | null;
+  /** Non-null while the new-thread wizard is open. */
+  newChatPicker: NewChatPicker | null;
   todosExpanded: boolean;
   themeName: ThemeName;
   experimentLog: ExperimentLogState | null;
@@ -169,6 +182,35 @@ export interface ThemePicker {
   selected: ThemeName;
 }
 
+/**
+ * Picker choices for the new-thread wizard. This is a UI affordance only:
+ * the backend is the authority and re-validates every combination, so a
+ * stale catalog degrades to a server error rather than a wrong thread.
+ */
+export const CHAT_DRIVERS = ['agentshim', 'omnigent'] as const;
+export type ChatDriverName = (typeof CHAT_DRIVERS)[number];
+export const CHAT_DRIVER_PROVIDERS: Record<ChatDriverName, readonly string[]> = {
+  agentshim: ['claude', 'gemini', 'codex', 'opencode'],
+  omnigent: ['claude', 'codex'],
+};
+
+export interface ChatThreadPicker {
+  /** Thread id the highlight is on; Enter switches to it. */
+  selected: string;
+}
+
+/**
+ * The new-thread wizard: driver, then a provider the driver supports, then a
+ * free-text model. An empty model means the run's configured default, which
+ * only the backend knows authoritatively.
+ */
+export interface NewChatPicker {
+  step: 'driver' | 'provider' | 'model';
+  driver: ChatDriverName;
+  provider: string;
+  model: string;
+}
+
 export interface OverlayPanel {
   kind: 'detail' | 'help' | 'error';
   content: string;
@@ -214,8 +256,13 @@ export function initialSessionState(themeName: ThemeName = DEFAULT_THEME_NAME): 
     roundFocus: 'transcript',
     overlay: null,
     chatOpen: false,
+    activeChatThreadId: DEFAULT_CHAT_THREAD_ID,
     chatConversation: [],
+    chatConversations: {},
     chatPending: false,
+    chatPendingThreads: {},
+    chatThreadPicker: null,
+    newChatPicker: null,
     todosExpanded: false,
     themeName,
     // The experiment log is the landing view: a run's history reads as a short
@@ -293,6 +340,171 @@ export function openChat(state: SessionState): SessionState {
     return {...state, overlay: null, layout: {...state.layout, focus: 'chat'}};
   }
   return {...state, overlay: null, chatOpen: true};
+}
+
+/** Keeps the singular chat fields pointing at the active thread. */
+function deriveActiveChat(state: SessionState): SessionState {
+  const chatConversation = state.chatConversations[state.activeChatThreadId] ?? [];
+  const chatPending = state.chatPendingThreads[state.activeChatThreadId] === true;
+  if (state.chatConversation === chatConversation && state.chatPending === chatPending) {
+    return state;
+  }
+  return {...state, chatConversation, chatPending};
+}
+
+/** Every thread the run knows about, the implicit default first. */
+export function chatThreads(state: SessionState): ChatThread[] {
+  return state.core.chatThreads;
+}
+
+/**
+ * What the chat surfaces call one thread. Titles are backend-owned and arrive
+ * through events; an untitled created thread reads as its agent selection.
+ */
+export function chatThreadLabel(
+  state: SessionState,
+  threadId: string = state.activeChatThreadId,
+): string {
+  const thread = state.core.chatThreads.find(candidate => candidate.id === threadId);
+  if (thread === undefined) return 'Experiment chat';
+  if (thread.title) return thread.title;
+  if (thread.driver === null && thread.provider === null) return 'Experiment chat';
+  const model = thread.model === null ? '' : ` · ${thread.model}`;
+  return `${thread.driver ?? '?'}/${thread.provider ?? '?'}${model}`;
+}
+
+/** Makes one thread the chat surface's subject and puts the keys on the chat. */
+export function switchChatThread(state: SessionState, threadId: string): SessionState {
+  return openChat(
+    deriveActiveChat({
+      ...state,
+      activeChatThreadId: threadId,
+      chatThreadPicker: null,
+      newChatPicker: null,
+    }),
+  );
+}
+
+/** Applies one thread's conversation change and refreshes the derived fields. */
+export function updateChatConversation(
+  state: SessionState,
+  threadId: string,
+  update: (entries: ConversationEntry[]) => ConversationEntry[],
+): SessionState {
+  const entries = update(state.chatConversations[threadId] ?? []).slice(-500);
+  return deriveActiveChat({
+    ...state,
+    chatConversations: {...state.chatConversations, [threadId]: entries},
+  });
+}
+
+export function setChatThreadPending(
+  state: SessionState,
+  threadId: string,
+  pending: boolean,
+): SessionState {
+  return deriveActiveChat({
+    ...state,
+    chatPendingThreads: {...state.chatPendingThreads, [threadId]: pending},
+  });
+}
+
+/** Opens the thread list as a selection, starting on the active thread. */
+export function openChatThreadPicker(state: SessionState): SessionState {
+  return {
+    ...state,
+    overlay: null,
+    themePicker: null,
+    newChatPicker: null,
+    chatThreadPicker: {selected: state.activeChatThreadId},
+  };
+}
+
+export function moveChatThreadSelection(state: SessionState, delta: number): SessionState {
+  const picker = state.chatThreadPicker;
+  if (picker === null) return state;
+  const ids = state.core.chatThreads.map(thread => thread.id);
+  const current = ids.indexOf(picker.selected);
+  const index = Math.min(ids.length - 1, Math.max(0, (current === -1 ? 0 : current) + delta));
+  const selected = ids[index];
+  if (selected === undefined || selected === picker.selected) return state;
+  return {...state, chatThreadPicker: {selected}};
+}
+
+export function closeChatThreadPicker(state: SessionState): SessionState {
+  if (state.chatThreadPicker === null) return state;
+  return {...state, chatThreadPicker: null};
+}
+
+/**
+ * Opens the new-thread wizard on its first step. The model prefill is the
+ * backend-reported live model when one has streamed in; empty text submits no
+ * override, so the backend resolves the run's configured default.
+ */
+export function openNewChatPicker(state: SessionState): SessionState {
+  const driver = CHAT_DRIVERS[0];
+  return {
+    ...state,
+    overlay: null,
+    themePicker: null,
+    chatThreadPicker: null,
+    newChatPicker: {
+      step: 'driver',
+      driver,
+      provider: CHAT_DRIVER_PROVIDERS[driver][0] ?? '',
+      model: state.core.usage?.model ?? '',
+    },
+  };
+}
+
+export function moveNewChatSelection(state: SessionState, delta: number): SessionState {
+  const picker = state.newChatPicker;
+  if (picker === null) return state;
+  if (picker.step === 'driver') {
+    const current = CHAT_DRIVERS.indexOf(picker.driver);
+    const index = Math.min(CHAT_DRIVERS.length - 1, Math.max(0, current + delta));
+    const driver = CHAT_DRIVERS[index];
+    if (driver === undefined || driver === picker.driver) return state;
+    const providers = CHAT_DRIVER_PROVIDERS[driver];
+    // The provider survives the driver change only where it stays supported.
+    const provider = providers.includes(picker.provider) ? picker.provider : (providers[0] ?? '');
+    return {...state, newChatPicker: {...picker, driver, provider}};
+  }
+  if (picker.step === 'provider') {
+    const providers = CHAT_DRIVER_PROVIDERS[picker.driver];
+    const current = providers.indexOf(picker.provider);
+    const index = Math.min(
+      providers.length - 1,
+      Math.max(0, (current === -1 ? 0 : current) + delta),
+    );
+    const provider = providers[index];
+    if (provider === undefined || provider === picker.provider) return state;
+    return {...state, newChatPicker: {...picker, provider}};
+  }
+  return state;
+}
+
+/** Enter on a non-final step: the wizard moves on with the choice kept. */
+export function advanceNewChatPicker(state: SessionState): SessionState {
+  const picker = state.newChatPicker;
+  if (picker === null || picker.step === 'model') return state;
+  const step = picker.step === 'driver' ? 'provider' : 'model';
+  return {...state, newChatPicker: {...picker, step}};
+}
+
+/** Escape: one step back, and off the first step the wizard closes. */
+export function retreatNewChatPicker(state: SessionState): SessionState {
+  const picker = state.newChatPicker;
+  if (picker === null) return state;
+  if (picker.step === 'driver') return {...state, newChatPicker: null};
+  const step = picker.step === 'model' ? 'provider' : 'driver';
+  return {...state, newChatPicker: {...picker, step}};
+}
+
+export function setNewChatModel(state: SessionState, model: string): SessionState {
+  const picker = state.newChatPicker;
+  if (picker === null || picker.step !== 'model') return state;
+  return {...state, newChatPicker: {...picker, model}};
 }
 
 export function openExperimentLog(state: SessionState): SessionState {
@@ -928,11 +1140,11 @@ export function applyEvent(state: SessionState, event: RunEvent): SessionState {
   const core = reduceEvent(state.core, event);
   if (core === state.core) return state;
   const diagnostic = latestDiagnosticChange(state.core, core);
-  let next: SessionState = {
+  let next: SessionState = deriveActiveChat({
     ...state,
     core,
-    chatConversation: reconcileChatTranscript(state.chatConversation, core.chatTranscript),
-  };
+    chatConversations: reconcileChatConversations(state.chatConversations, core.chatTranscripts),
+  });
   if (diagnostic !== null) next = reportProjectedDiagnostic(next, diagnostic);
   return next;
 }
@@ -953,14 +1165,26 @@ export function applyEventBatch(
 ): SessionState {
   const core = reduceEventBatch(state.core, events, activeExecutions, throughSequence);
   if (core === state.core) return state;
-  let next: SessionState = {
+  let next: SessionState = deriveActiveChat({
     ...state,
     core,
-    chatConversation: reconcileChatTranscript(state.chatConversation, core.chatTranscript),
-  };
+    chatConversations: reconcileChatConversations(state.chatConversations, core.chatTranscripts),
+  });
   if (core.status === 'failed') {
     const finalDiagnostic = core.diagnostics.at(-1);
     if (finalDiagnostic !== undefined) next = reportProjectedDiagnostic(next, finalDiagnostic);
+  }
+  return next;
+}
+
+/** Folds every thread's replayed transcript into its local conversation. */
+function reconcileChatConversations(
+  conversations: Record<string, ConversationEntry[]>,
+  transcripts: Record<string, TranscriptEntry[]>,
+): Record<string, ConversationEntry[]> {
+  const next = {...conversations};
+  for (const [threadId, transcript] of Object.entries(transcripts)) {
+    next[threadId] = reconcileChatTranscript(next[threadId] ?? [], transcript);
   }
   return next;
 }

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -4,11 +4,20 @@ import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing'
 import type {HypothesisEntry} from '@vibesys/backend-client';
 import type {SessionController} from '../session-controller.js';
 import {
+  advanceNewChatPicker,
   clearAgentSelection,
   clearEntrySelection,
+  closeChatThreadPicker,
   closeOverlays,
   closePane,
   closeThemePicker,
+  moveChatThreadSelection,
+  moveNewChatSelection,
+  openChatThreadPicker,
+  openNewChatPicker,
+  retreatNewChatPicker,
+  setNewChatModel,
+  switchChatThread,
   cyclePaneFocus,
   dismissErrorBanner,
   enterExperimentDrilldown,
@@ -2309,8 +2318,9 @@ describe('theming', () => {
     await testRenderer.mockInput.typeText('/c');
     const frame = await frameAfter(testRenderer);
 
-    // Nothing to open: the chat is the column beside the table.
-    expect(frame).not.toContain('/chat');
+    // Nothing to open: the chat is the column beside the table. The thread
+    // commands (/chats, /new-chat) remain, so match /chat as a whole word.
+    expect(frame).not.toMatch(/\/chat\s/);
   });
 
   it('says when the docked chat is waiting on the agent', async () => {
@@ -2358,6 +2368,140 @@ describe('theming', () => {
       throw new Error('docked chat geometry was missing');
     expect(scroll.x).toBe(pane.x + 2);
     expect(turn.x).toBe(scroll.x);
+  });
+
+  it('switches chat threads, swapping the transcript and the composer draft', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    controller.publish({
+      ...controller.state,
+      core: {
+        ...controller.state.core,
+        chatThreads: [
+          ...controller.state.core.chatThreads,
+          {
+            id: 'thread-a',
+            title: 'GPU stalls',
+            driver: 'omnigent',
+            provider: 'claude',
+            model: 'opus',
+          },
+        ],
+      },
+      chatConversations: {
+        default: [
+          {id: 'd1', kind: 'assistant', label: 'Answer', content: 'Default thread answer.'},
+        ],
+        'thread-a': [
+          {id: 't1', kind: 'assistant', label: 'Answer', content: 'Stalls come from prefill.'},
+        ],
+      },
+      chatConversation: [
+        {id: 'd1', kind: 'assistant', label: 'Answer', content: 'Default thread answer.'},
+      ],
+    });
+
+    // Focus the docked chat and leave a half-typed question on the default thread.
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
+    await testRenderer.mockInput.typeText('half-typed question');
+    let frame = await frameAfter(testRenderer);
+    expect(frame).toContain('Default thread answer.');
+    expect(frame).toContain('half-typed question');
+
+    controller.switchChatThread('thread-a');
+    frame = await frameAfter(testRenderer);
+    // The pane is titled by the backend-owned thread title, shows the
+    // thread's own transcript, and the other thread's draft is parked.
+    expect(frame).toContain('GPU stalls');
+    expect(frame).toContain('Stalls come from prefill.');
+    expect(frame).not.toContain('Default thread answer.');
+    expect(frame).not.toContain('half-typed question');
+
+    controller.switchChatThread('default');
+    frame = await frameAfter(testRenderer);
+    expect(frame).toContain('Default thread answer.');
+    expect(frame).not.toContain('Stalls come from prefill.');
+    // The parked draft returns with its thread.
+    expect(frame).toContain('half-typed question');
+  });
+
+  it('walks the new-thread wizard from driver to provider to model', async () => {
+    const testRenderer = await createTestRenderer({width: 90, height: 26});
+    const controller = new FakeController(initialSessionState());
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    await testRenderer.mockInput.typeText('/new-chat');
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(value => value.includes('New chat thread'));
+    expect(testRenderer.captureCharFrame()).toContain('› agentshim');
+
+    testRenderer.mockInput.pressKey('ARROW_DOWN');
+    await testRenderer.waitForFrame(value => value.includes('› omnigent'));
+    testRenderer.mockInput.pressEnter();
+    // The provider list is narrowed to what the chosen driver supports.
+    let frame = await testRenderer.waitForFrame(value =>
+      value.includes('Provider: claude  ◂ choose'),
+    );
+    expect(frame).toContain('› claude');
+    expect(frame).not.toContain('gemini');
+
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(value => value.includes('Model:'));
+    // The model step takes ordinary typing instead of the composer beneath it.
+    await testRenderer.mockInput.typeText('opus');
+    frame = await testRenderer.waitForFrame(value => value.includes('Model: opus'));
+    expect(controller.state.newChatPicker).toMatchObject({
+      step: 'model',
+      driver: 'omnigent',
+      provider: 'claude',
+      model: 'opus',
+    });
+    expect(controller.chatSubmissions).toEqual([]);
+  });
+
+  it('lists the chat threads and switches to the highlighted one', async () => {
+    const testRenderer = await createTestRenderer({width: 90, height: 26});
+    const controller = new FakeController(initialSessionState());
+    controller.publish({
+      ...controller.state,
+      core: {
+        ...controller.state.core,
+        chatThreads: [
+          ...controller.state.core.chatThreads,
+          {
+            id: 'thread-a',
+            title: 'GPU stalls',
+            driver: 'omnigent',
+            provider: 'claude',
+            model: 'opus',
+          },
+        ],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    await testRenderer.mockInput.typeText('/chats');
+    testRenderer.mockInput.pressEnter();
+    const frame = await testRenderer.waitForFrame(value => value.includes('Chat threads'));
+    // The implicit default is named by the client; a created thread shows the
+    // backend-owned title beside the agent it was created with.
+    expect(frame).toContain('Experiment chat');
+    expect(frame).toContain('active');
+    expect(frame).toContain('GPU stalls');
+    expect(frame).toContain('omnigent/claude');
+
+    testRenderer.mockInput.pressKey('ARROW_DOWN');
+    await testRenderer.waitForFrame(value => value.includes('› GPU stalls'));
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.state.chatThreadPicker === null);
+
+    expect(controller.state.activeChatThreadId).toBe('thread-a');
   });
 
   it('keeps the chat, the table, and the visualization on screen together', async () => {
@@ -3076,11 +3220,53 @@ class FakeController implements SessionController {
       this.#notify();
     }
     if (value.trim() === '/theme') this.openThemePicker();
+    if (value.trim() === '/new-chat') this.openNewChatPicker();
+    if (value.trim() === '/chats') this.openChatThreadPicker();
     return Promise.resolve();
   }
   closeChat(): void {
     this.state = {...this.state, chatOpen: false};
     this.#notify();
+  }
+  switchChatThread(threadId: string): void {
+    this.publish(switchChatThread(this.state, threadId));
+  }
+  openChatThreadPicker(): void {
+    this.publish(openChatThreadPicker(this.state));
+  }
+  moveChatThreadSelection(delta: number): void {
+    this.publish(moveChatThreadSelection(this.state, delta));
+  }
+  applySelectedChatThread(): void {
+    const picker = this.state.chatThreadPicker;
+    if (picker !== null) this.switchChatThread(picker.selected);
+  }
+  closeChatThreadPicker(): void {
+    this.publish(closeChatThreadPicker(this.state));
+  }
+  openNewChatPicker(): void {
+    this.publish(openNewChatPicker(this.state));
+  }
+  moveNewChatSelection(delta: number): void {
+    this.publish(moveNewChatSelection(this.state, delta));
+  }
+  confirmNewChatPicker(): Promise<void> {
+    const picker = this.state.newChatPicker;
+    if (picker === null) return Promise.resolve();
+    if (picker.step !== 'model') this.publish(advanceNewChatPicker(this.state));
+    else this.publish({...this.state, newChatPicker: null});
+    return Promise.resolve();
+  }
+  retreatNewChatPicker(): void {
+    this.publish(retreatNewChatPicker(this.state));
+  }
+  typeNewChatModel(text: string): void {
+    const picker = this.state.newChatPicker;
+    if (picker !== null) this.publish(setNewChatModel(this.state, picker.model + text));
+  }
+  backspaceNewChatModel(): void {
+    const picker = this.state.newChatPicker;
+    if (picker !== null) this.publish(setNewChatModel(this.state, picker.model.slice(0, -1)));
   }
   setTheme(themeName: ThemeName): void {
     this.state = {...this.state, themeName};

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -13,6 +13,7 @@ import {AgentMapView} from './agent-map.js';
 import {createChatDraft} from './chat-composer.js';
 import {ChatOverlayView} from './chat-overlay.js';
 import {ChatPaneView, chatDockFits, chatPaneWidth} from './chat-pane.js';
+import {ChatThreadPickerView, NewChatPickerView} from './chat-pickers.js';
 import {RendererSelectionClipboard, type SelectionClipboard} from './clipboard.js';
 import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
@@ -148,6 +149,13 @@ export function createOpenTuiApp(
   const chatDraft = createChatDraft();
   const chat = new ChatOverlayView(renderer, controller, markdownStyle, theme, chatDraft);
   const chatPane = new ChatPaneView(renderer, controller, markdownStyle, theme, chatDraft);
+  const chatThreadPicker = new ChatThreadPickerView(renderer, theme);
+  const newChatPicker = new NewChatPickerView(renderer, theme);
+  // Composer drafts are per-thread. The shared ChatDraft stays the single
+  // authority both chat surfaces read; switching threads swaps its content
+  // and parks the outgoing thread's half-typed question for its return.
+  const parkedDrafts = new Map<string, string>();
+  let draftThreadId = controller.state.activeChatThreadId;
   // Clicking either box moves the pane focus to it, so the border, the hint,
   // and the cursor never disagree about which surface is taking keystrokes.
   const commandInput = createCommandInputPanel(
@@ -202,6 +210,8 @@ export function createOpenTuiApp(
   root.add(body);
   root.add(overlay.output);
   root.add(themePicker.output);
+  root.add(chatThreadPicker.output);
+  root.add(newChatPicker.output);
   root.add(chat.output);
   renderer.root.add(root);
   commandInput.focus();
@@ -224,6 +234,8 @@ export function createOpenTuiApp(
     experimentLog.applyTheme(theme);
     rightPane.applyTheme(theme);
     themePicker.applyTheme(theme);
+    chatThreadPicker.applyTheme(theme);
+    newChatPicker.applyTheme(theme);
     conversation.applyTheme(theme, markdownStyle);
     chat.applyTheme(theme, markdownStyle);
     chatPane.applyTheme(theme, markdownStyle);
@@ -237,6 +249,13 @@ export function createOpenTuiApp(
     lastState = state;
     const releasePreviousStyle =
       state.themeName === themeName ? undefined : applyTheme(state.themeName);
+    if (state.activeChatThreadId !== draftThreadId) {
+      // Park the outgoing thread's draft and restore the incoming thread's,
+      // so switching never sends one thread's question to another's agent.
+      parkedDrafts.set(draftThreadId, chatDraft.value);
+      chatDraft.value = parkedDrafts.get(state.activeChatThreadId) ?? '';
+      draftThreadId = state.activeChatThreadId;
+    }
     const showLog = experimentLogVisible(state);
     const paneFocus = focusedPane(state);
     const zoomedPane = state.layout.zoomedPane;
@@ -353,6 +372,8 @@ export function createOpenTuiApp(
         : {...state, overlay: {kind: 'detail' as const, content: paneFallback.content}},
     );
     themePicker.render(state);
+    chatThreadPicker.render(state);
+    newChatPicker.render(state);
     chat.render(state);
     conversationActivityBar.render(state, !showLog);
     // One cursor, three places it can be. The modal owns it while it is open;

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -5,7 +5,7 @@ import {
   type SyntaxStyle,
 } from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
-import type {SessionState} from '../session-model.js';
+import {chatThreadLabel, type SessionState} from '../session-model.js';
 import {ChatComposerView, type ChatDraft} from './chat-composer.js';
 import {ConversationView} from './conversation.js';
 import type {Theme} from './theme.js';
@@ -117,6 +117,7 @@ export class ChatOverlayView {
   render(state: SessionState): void {
     this.output.visible = state.chatOpen;
     if (!state.chatOpen) return;
+    this.output.title = ` ${chatThreadLabel(state)} `;
     this.#composer.activate(Math.max(1, this.output.width - 4), true, state.chatPending);
     this.#conversation.render(state);
     this.#transcript.scrollTo(this.#transcript.scrollHeight);

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -5,7 +5,12 @@ import {
   type SyntaxStyle,
 } from '@opentui/core';
 import type {SessionController} from '../session-controller.js';
-import {type ConversationEntry, chatPaneFocused, type SessionState} from '../session-model.js';
+import {
+  type ConversationEntry,
+  chatPaneFocused,
+  chatThreadLabel,
+  type SessionState,
+} from '../session-model.js';
 import {ChatComposerView, type ChatDraft} from './chat-composer.js';
 import {ConversationView} from './conversation.js';
 import {LOG_CLAIM_PANEL_WIDTH, LOG_COMPACT_PANEL_WIDTH} from './experiment-log.js';
@@ -146,7 +151,9 @@ export class ChatPaneView {
     // The column can be as narrow as its minimum, where a spelled-out "focused"
     // costs the title itself: a box with no title reads as nothing at all. The
     // marker is the one the table already uses for the row that has the keys.
-    this.output.title = focused ? ' ▸ Experiment chat ' : ' Experiment chat ';
+    // The title names the active thread so switching is visible at a glance.
+    const label = chatThreadLabel(state);
+    this.output.title = focused ? ` ▸ ${label} ` : ` ${label} `;
     this.#composer.activate(Math.max(1, width - 4), focused, state.chatPending);
     if (state.chatConversation === this.#renderedConversation) return;
     this.#renderedConversation = state.chatConversation;

--- a/clients/tui/src/ui/chat-pickers.ts
+++ b/clients/tui/src/ui/chat-pickers.ts
@@ -1,0 +1,199 @@
+import {BoxRenderable, type CliRenderer, TextRenderable} from '@opentui/core';
+import {
+  CHAT_DRIVER_PROVIDERS,
+  CHAT_DRIVERS,
+  chatThreadLabel,
+  chatThreads,
+  type SessionState,
+} from '../session-model.js';
+import type {Theme} from './theme.js';
+
+const NAME_WIDTH = 20;
+
+/**
+ * The chat thread list as a keyboard selection, following the theme picker's
+ * shape: the highlighted row is the one Enter switches to, and the active
+ * thread is spelled out so the two are never confused when they differ.
+ */
+export class ChatThreadPickerView {
+  readonly output: BoxRenderable;
+  #theme: Theme;
+  #renderedRows: string | null = null;
+
+  constructor(
+    private readonly renderer: CliRenderer,
+    theme: Theme,
+  ) {
+    this.#theme = theme;
+    this.output = new BoxRenderable(renderer, {
+      id: 'chat-thread-picker',
+      width: '70%',
+      height: '60%',
+      position: 'absolute',
+      left: '15%',
+      top: '18%',
+      flexDirection: 'column',
+      paddingLeft: 1,
+      paddingRight: 1,
+      border: true,
+      borderStyle: 'rounded',
+      borderColor: theme.info,
+      backgroundColor: theme.elevatedSurface,
+      title: ' Chat threads ',
+      visible: false,
+      zIndex: 30,
+    });
+  }
+
+  applyTheme(theme: Theme): void {
+    this.#theme = theme;
+    this.output.borderColor = theme.info;
+    this.output.backgroundColor = theme.elevatedSurface;
+    this.#renderedRows = null;
+  }
+
+  render(state: SessionState): void {
+    const picker = state.chatThreadPicker;
+    if (picker === null) {
+      this.output.visible = false;
+      this.#renderedRows = null;
+      return;
+    }
+    this.output.visible = true;
+    const threads = chatThreads(state);
+    const fingerprint = JSON.stringify([picker.selected, state.activeChatThreadId, threads]);
+    if (this.#renderedRows === fingerprint) return;
+    this.#renderedRows = fingerprint;
+    clearChildren(this.output);
+    for (const thread of threads) {
+      const selected = thread.id === picker.selected;
+      const active = thread.id === state.activeChatThreadId;
+      const marker = selected ? '›' : ' ';
+      const agent =
+        thread.driver === null ? 'run agent' : `${thread.driver}/${thread.provider ?? '?'}`;
+      const model = thread.model === null ? '' : ` · ${thread.model}`;
+      const suffix = active ? ' · active' : '';
+      this.output.add(
+        new TextRenderable(this.renderer, {
+          content: `${marker} ${chatThreadLabel(state, thread.id).padEnd(NAME_WIDTH)} ${agent}${model}${suffix}`,
+          fg: selected ? this.#theme.textStrong : this.#theme.textPrimary,
+          bg: selected ? this.#theme.selectedSurface : this.#theme.elevatedSurface,
+          width: '100%',
+        }),
+      );
+    }
+    this.output.add(new TextRenderable(this.renderer, {content: '', width: '100%'}));
+    this.output.add(
+      new TextRenderable(this.renderer, {
+        content: '↑↓: select · Enter: switch · Esc: close · /new-chat starts another thread',
+        fg: this.#theme.textSubtle,
+        width: '100%',
+      }),
+    );
+  }
+}
+
+/**
+ * The new-thread wizard: driver, then a provider that driver supports, then a
+ * free-text model. The client only collects the choice; the backend resolves
+ * defaults and is the authority on what combinations exist.
+ */
+export class NewChatPickerView {
+  readonly output: BoxRenderable;
+  #theme: Theme;
+  #renderedRows: string | null = null;
+
+  constructor(
+    private readonly renderer: CliRenderer,
+    theme: Theme,
+  ) {
+    this.#theme = theme;
+    this.output = new BoxRenderable(renderer, {
+      id: 'new-chat-picker',
+      width: '70%',
+      height: '60%',
+      position: 'absolute',
+      left: '15%',
+      top: '18%',
+      flexDirection: 'column',
+      paddingLeft: 1,
+      paddingRight: 1,
+      border: true,
+      borderStyle: 'rounded',
+      borderColor: theme.info,
+      backgroundColor: theme.elevatedSurface,
+      title: ' New chat thread ',
+      visible: false,
+      zIndex: 30,
+    });
+  }
+
+  applyTheme(theme: Theme): void {
+    this.#theme = theme;
+    this.output.borderColor = theme.info;
+    this.output.backgroundColor = theme.elevatedSurface;
+    this.#renderedRows = null;
+  }
+
+  render(state: SessionState): void {
+    const picker = state.newChatPicker;
+    if (picker === null) {
+      this.output.visible = false;
+      this.#renderedRows = null;
+      return;
+    }
+    this.output.visible = true;
+    const fingerprint = JSON.stringify(picker);
+    if (this.#renderedRows === fingerprint) return;
+    this.#renderedRows = fingerprint;
+    clearChildren(this.output);
+    this.#addLine(`Driver: ${picker.driver}${picker.step === 'driver' ? '  ◂ choose' : ''}`);
+    if (picker.step === 'driver') {
+      for (const driver of CHAT_DRIVERS) this.#addChoice(driver, driver === picker.driver);
+    }
+    this.#addLine(`Provider: ${picker.provider}${picker.step === 'provider' ? '  ◂ choose' : ''}`);
+    if (picker.step === 'provider') {
+      for (const provider of CHAT_DRIVER_PROVIDERS[picker.driver]) {
+        this.#addChoice(provider, provider === picker.provider);
+      }
+    }
+    if (picker.step === 'model') {
+      this.#addLine(`Model: ${picker.model === '' ? '(run default)' : picker.model}▏`);
+    }
+    this.#addLine('');
+    this.#addLine(
+      picker.step === 'model'
+        ? 'Type a model, or leave empty for the run default · Enter: create · Esc: back'
+        : '↑↓: select · Enter: next · Esc: back',
+      this.#theme.textSubtle,
+    );
+  }
+
+  #addLine(content: string, fg?: string): void {
+    this.output.add(
+      new TextRenderable(this.renderer, {
+        content,
+        fg: fg ?? this.#theme.textPrimary,
+        width: '100%',
+      }),
+    );
+  }
+
+  #addChoice(name: string, selected: boolean): void {
+    this.output.add(
+      new TextRenderable(this.renderer, {
+        content: `  ${selected ? '›' : ' '} ${name}`,
+        fg: selected ? this.#theme.textStrong : this.#theme.textPrimary,
+        bg: selected ? this.#theme.selectedSurface : this.#theme.elevatedSurface,
+        width: '100%',
+      }),
+    );
+  }
+}
+
+function clearChildren(box: BoxRenderable): void {
+  for (const child of [...box.getChildren()]) {
+    box.remove(child);
+    child.destroyRecursively();
+  }
+}

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -45,7 +45,9 @@ export function bindKeybindings(
       key.name === 'f4' &&
       controller.state.chatOpen === false &&
       controller.state.overlay === null &&
-      controller.state.themePicker === null
+      controller.state.themePicker === null &&
+      controller.state.chatThreadPicker === null &&
+      controller.state.newChatPicker === null
     ) {
       controller.togglePaneZoom();
       key.preventDefault();
@@ -76,6 +78,35 @@ export function bindKeybindings(
       (controller.state.layout.right !== null || chatPaneVisible(controller.state))
     ) {
       controller.cyclePaneFocus();
+      key.preventDefault();
+      return;
+    }
+    // The new-thread wizard owns the keys wherever it was opened from — on its
+    // model step that includes ordinary typing, which must never leak into the
+    // composer or command input underneath.
+    const newChatPicker = controller.state.newChatPicker;
+    if (newChatPicker !== null) {
+      if (key.name === 'up') controller.moveNewChatSelection(-1);
+      else if (key.name === 'down') controller.moveNewChatSelection(1);
+      else if (key.name === 'escape') controller.retreatNewChatPicker();
+      else if (key.name === 'return' || key.name === 'enter' || key.name === 'kpenter') {
+        void controller.confirmNewChatPicker();
+      } else if (newChatPicker.step === 'model' && key.name === 'backspace') {
+        controller.backspaceNewChatModel();
+      } else if (newChatPicker.step === 'model' && isPrintable(key)) {
+        controller.typeNewChatModel(key.sequence);
+      } else return;
+      key.preventDefault();
+      return;
+    }
+    // The thread list is a selection: Enter switches to the highlighted thread.
+    if (controller.state.chatThreadPicker !== null) {
+      if (key.name === 'up') controller.moveChatThreadSelection(-1);
+      else if (key.name === 'down') controller.moveChatThreadSelection(1);
+      else if (key.name === 'escape') controller.closeChatThreadPicker();
+      else if (key.name === 'return' || key.name === 'enter' || key.name === 'kpenter') {
+        controller.applySelectedChatThread();
+      } else return;
       key.preventDefault();
       return;
     }
@@ -269,4 +300,16 @@ export function bindKeybindings(
 
   renderer.keyInput.on('keypress', onKey);
   return () => renderer.keyInput.off('keypress', onKey);
+}
+
+/** One typed character, as opposed to a chord or a control key. */
+function isPrintable(key: KeyEvent): boolean {
+  return (
+    !key.ctrl &&
+    !key.meta &&
+    typeof key.sequence === 'string' &&
+    key.sequence.length === 1 &&
+    key.sequence >= ' ' &&
+    key.sequence !== ''
+  );
 }

--- a/src/vibesys/agents/drivers/agentshim.py
+++ b/src/vibesys/agents/drivers/agentshim.py
@@ -63,6 +63,12 @@ _PROVIDER_CLASSES: dict[str, _ProviderFactory] = {
     "opencode": OpencodeCodingAgent,
 }
 
+
+def supported_providers() -> list[str]:
+    """Return the sorted provider names the AgentShim driver can run."""
+    return sorted(_PROVIDER_CLASSES)
+
+
 _REASONING_EFFORT_PROVIDERS = frozenset({"codex", "claude"})
 _PYTHON_MCP_COMMANDS = frozenset({"python", "python3"})
 

--- a/src/vibesys/agents/factory.py
+++ b/src/vibesys/agents/factory.py
@@ -50,6 +50,24 @@ def agent_driver_supports_mcp_servers(
     return AGENTSHIM_CAPABILITIES.mcp_servers
 
 
+def supported_cli_providers(driver_name: str) -> tuple[str, ...]:
+    """Return the provider names one external driver supports.
+
+    Raises ``ValueError`` for an unknown driver so callers validating a
+    requested driver/provider pair reject both halves before building
+    anything.
+    """
+    if driver_name == "omnigent":
+        from vibesys.agents.omnigent.providers import supported_providers  # noqa: PLC0415
+
+        return tuple(supported_providers())
+    if driver_name == "agentshim":
+        from vibesys.agents.drivers.agentshim import supported_providers  # noqa: PLC0415
+
+        return tuple(supported_providers())
+    raise ValueError(f"unknown agent driver {driver_name!r}; expected 'agentshim' or 'omnigent'")  # noqa: TRY003  # tracked: #288
+
+
 def build_agent_client(  # noqa: C901, PLR0912, PLR0913
     config: Config,
     *,

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -6,6 +6,7 @@ import threading
 from collections.abc import Callable, Generator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, replace
+from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as distribution_version
 from pathlib import Path
@@ -15,7 +16,11 @@ from pydantic import BaseModel
 
 from vibesys import backends
 from vibesys.agents import AgentClient, build_agent_client
-from vibesys.agents.factory import agent_driver_supports_mcp_servers, resolve_agent_driver
+from vibesys.agents.factory import (
+    agent_driver_supports_mcp_servers,
+    resolve_agent_driver,
+    supported_cli_providers,
+)
 from vibesys.agents.progress import AgentProgress
 from vibesys.backends.base import ComputeBackendImpl, ContentionMonitor
 from vibesys.config import Config, as_config
@@ -84,22 +89,29 @@ from vs_project import (
 )
 
 if TYPE_CHECKING:
-    from vibesys.server.supervisor import RunSupervisor
+    from vibesys.server.supervisor import ChatThreadHandle, RunSupervisor
 
 T = TypeVar("T", bound=BaseModel)
 
 _CHAT_STATE_DIR = "_vibesys_chat"
 _CHAT_TRAJECTORY_SUFFIXES = frozenset({".json", ".jsonl", ".log", ".md", ".txt"})
+# Trajectory snapshots are shared, read-only context for every chat thread, so
+# concurrent thread syncs must not interleave their rebuild of the directory.
+_CHAT_TRAJECTORY_SYNC_LOCK = threading.Lock()
+
+
 # This is an agent instruction, not a filesystem guarantee. ProjectPathPolicy
 # cannot currently express a read-only workspace root.
-_EXPERIMENT_CHAT_SYSTEM_PROMPT = """\
+def _experiment_chat_system_prompt(conversation_path: str) -> str:
+    """Render the chat system prompt for one thread's conversation file."""
+    return f"""\
 You are the read-only investigation agent for a live VibeSys experiment. Answer the
 user's question by examining evidence instead of relying on a precomputed summary.
 
 Your working directory is the current experiment workspace. Relevant evidence is:
 - `_vibesys_chat/trajectory/state/`: the canonical portable state for this run.
 - `_vibesys_chat/trajectory/logs/`: machine-local event and run logs for this run.
-- `_vibesys_chat/conversation.jsonl`: successful earlier exchanges in this chat.
+- `{conversation_path}`: successful earlier exchanges in this chat.
 - the rest of the workspace: the current implementation, evaluator inputs, and git
   history/diffs when available.
 
@@ -111,11 +123,56 @@ inference, mention important missing evidence, and give a concise answer.
 Do not edit files, run mutating commands, start workloads, steer optimization agents,
 or claim actions you did not take. Your role is analysis only.
 """
-_EXPERIMENT_CHAT_CONTINUATION_PROMPT = """\
-Continue the read-only experiment chat. Follow `_vibesys_chat/instructions.md`,
-consult `_vibesys_chat/conversation.jsonl` when the question depends on an earlier
+
+
+def _experiment_chat_continuation_prompt(instructions_path: str, conversation_path: str) -> str:
+    """Render the follow-up prompt for one thread's chat state paths."""
+    return f"""\
+Continue the read-only experiment chat. Follow `{instructions_path}`,
+consult `{conversation_path}` when the question depends on an earlier
 exchange, and investigate the refreshed trajectory evidence before making claims.
 """
+
+
+_EXPERIMENT_CHAT_SYSTEM_PROMPT = _experiment_chat_system_prompt(
+    f"{_CHAT_STATE_DIR}/conversation.jsonl"
+)
+_EXPERIMENT_CHAT_CONTINUATION_PROMPT = _experiment_chat_continuation_prompt(
+    f"{_CHAT_STATE_DIR}/instructions.md", f"{_CHAT_STATE_DIR}/conversation.jsonl"
+)
+
+
+def _resolve_chat_thread_settings(  # noqa: PLR0913  # one boundary resolves all defaults
+    *,
+    agent_backend: str,
+    default_driver: str,
+    default_provider: str,
+    default_model: str,
+    driver: str | None,
+    provider: str | None,
+    model: str | None,
+) -> tuple[str, str, str]:
+    """Resolve one chat thread's agent selection against the run's defaults.
+
+    Rejects unsupported driver/provider combinations at creation time, with
+    errors naming the offending value, so a thread never fails only when its
+    first question arrives.
+    """
+    if agent_backend != "cli":
+        raise ValueError(  # noqa: TRY003  # surfaced to the requesting client
+            "experiment chat threads require the CLI agent backend, "
+            f"but this run uses agent backend {agent_backend!r}"
+        )
+    resolved_driver = driver or default_driver
+    resolved_provider = provider or default_provider
+    resolved_model = model or default_model
+    supported = supported_cli_providers(resolved_driver)
+    if resolved_provider not in supported:
+        raise ValueError(  # noqa: TRY003  # surfaced to the requesting client
+            f"agent driver {resolved_driver!r} does not support provider "
+            f"{resolved_provider!r}; supported providers: {', '.join(supported)}"
+        )
+    return resolved_driver, resolved_provider, resolved_model
 
 
 def _coerce_dir(raw: str | Path | None, label: str) -> Path | None:
@@ -888,15 +945,30 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
 
     experiment_chat: _ExperimentChatService | None = None
     experiment_chat_owner = ExitStack()
+    chat_thread_services: list[_ExperimentChatService] = []
     if supervisor is not None:
+        chat_supervisor = supervisor
 
-        def _build_experiment_chat() -> _ExperimentChatService:
-            """Build resources owned only by the experiment chat service."""
+        def _build_experiment_chat(
+            *,
+            thread_id: str | None = None,
+            chat_driver: str | None = None,
+            chat_provider: str | None = None,
+            chat_model_name: str | None = None,
+        ) -> _ExperimentChatService:
+            """Build resources owned only by one experiment chat service.
+
+            The default thread (``thread_id=None``) reuses the run's agent
+            selection; a created thread carries its own resolved driver,
+            provider, and model.
+            """
             resources = ExitStack()
             try:
                 chat_logger = RunLogger(log_dir, tee_stderr=False)
                 resources.callback(chat_logger.close)
-                chat_logger.switch("experiment-chat")
+                chat_logger.switch(
+                    "experiment-chat" if thread_id is None else f"experiment-chat-{thread_id[:8]}"
+                )
 
                 chat_backends: dict[str, Any] | None = None
                 chat_use_docker = False
@@ -907,16 +979,21 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
                     chat_backends = {"chat": chat_environment_session.sandbox}
                     chat_use_docker = chat_environment_session.view.cli_sandboxed
 
+                chat_config = config
+                if chat_driver is not None:
+                    chat_config = config.model_copy(
+                        update={"agent": config.agent.model_copy(update={"driver": chat_driver})}
+                    )
                 chat_client = build_agent_client(
-                    config,
+                    chat_config,
                     agent_backend=agent_backend,
-                    cli_provider=cli_provider,
+                    cli_provider=chat_provider if chat_provider is not None else cli_provider,
                     backends=chat_backends,
                     skills=[src.name for src in skill_source_paths],
                     skill_source_dirs=skill_source_paths,
                     compute_backend=backend,
                     model=model,
-                    model_name=model_name,
+                    model_name=chat_model_name if chat_model_name is not None else model_name,
                     run_log_file=chat_logger.writer,
                     use_docker=chat_use_docker,
                     log_dir=log_dir,
@@ -926,7 +1003,7 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
                 resources.callback(chat_client.close)
                 return _ExperimentChatService(
                     _ExperimentChatDependencies(
-                        supervisor=supervisor,
+                        supervisor=chat_supervisor,
                         agent_client=chat_client,
                         workspace=project_root,
                         log_dir=log_dir,
@@ -936,6 +1013,7 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
                         flush_logs=chat_logger.writer.flush,
                         environment=dict,
                         progress=lambda: None,
+                        thread_id=thread_id,
                     ),
                     resources.pop_all(),
                 )
@@ -943,6 +1021,44 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
                 _close_after_construction_failure(resources, construction_error)
                 raise
 
+        def _chat_thread_factory(
+            thread_id: str,
+            driver: str | None,
+            provider: str | None,
+            model_override: str | None,
+        ) -> "ChatThreadHandle":
+            """Create one thread's chat service; the run context owns cleanup."""
+            from vibesys.server.events import ChatThreadCreatedData  # noqa: PLC0415
+            from vibesys.server.supervisor import ChatThreadHandle  # noqa: PLC0415
+
+            resolved_driver, resolved_provider, resolved_model = _resolve_chat_thread_settings(
+                agent_backend=resolved_backend,
+                default_driver=resolve_agent_driver(config),
+                default_provider=resolved_cli_provider,
+                default_model=model_name,
+                driver=driver,
+                provider=provider,
+                model=model_override,
+            )
+            service = _build_experiment_chat(
+                thread_id=thread_id,
+                chat_driver=resolved_driver,
+                chat_provider=resolved_provider,
+                chat_model_name=resolved_model,
+            )
+            chat_thread_services.append(service)
+            return ChatThreadHandle(
+                spec=ChatThreadCreatedData(
+                    thread_id=thread_id,
+                    driver=resolved_driver,
+                    provider=resolved_provider,
+                    model=resolved_model,
+                    created_at=datetime.now(UTC),
+                ),
+                handler=service.ask,
+            )
+
+        supervisor.set_chat_thread_factory(_chat_thread_factory)
         try:
             experiment_chat = _build_experiment_chat()
         except Exception as exc:  # noqa: BLE001  # experiment chat is an optional surface
@@ -1009,8 +1125,11 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
             run_id=run_id,
             round_transaction_coordinator=round_transaction_coordinator,
             experiment_chat=experiment_chat,
+            chat_thread_services=chat_thread_services,
         )
     except BaseException as construction_error:
+        if supervisor is not None:
+            supervisor.set_chat_thread_factory(None)
         _close_after_construction_failure(experiment_chat_owner, construction_error)
         raise
     experiment_chat_owner.pop_all()
@@ -1243,6 +1362,10 @@ class _ExperimentChatDependencies:
     flush_logs: Callable[[], None]
     environment: Callable[[], dict[str, str]]
     progress: Callable[[], AgentProgress | None]
+    # None is the default thread, which keeps the legacy _vibesys_chat/ layout
+    # so existing workspaces resume their conversation unchanged. A created
+    # thread owns _vibesys_chat/threads/<thread-id>/ instead.
+    thread_id: str | None = None
 
 
 class _ExperimentChatService:
@@ -1261,8 +1384,14 @@ class _ExperimentChatService:
         self._flush_logs = dependencies.flush_logs
         self._environment = dependencies.environment
         self._progress = dependencies.progress
+        self._thread_id = dependencies.thread_id
         self._resources = resources
         self._lock = threading.Lock()
+        relative = (self._state_dir).relative_to(self._workspace).as_posix()
+        self._system_prompt = _experiment_chat_system_prompt(f"{relative}/conversation.jsonl")
+        self._continuation_prompt = _experiment_chat_continuation_prompt(
+            f"{relative}/instructions.md", f"{relative}/conversation.jsonl"
+        )
         self._history = self._load_history()
 
     def ask(self, question: str) -> str:
@@ -1276,11 +1405,7 @@ class _ExperimentChatService:
                 diagnostic = RunInspector(self._supervisor).answer(question)
                 return f"Chat agent did not return an answer.\n\nFallback diagnostic:\n{diagnostic}"
 
-            system_prompt = (
-                _EXPERIMENT_CHAT_CONTINUATION_PROMPT
-                if self._history
-                else _EXPERIMENT_CHAT_SYSTEM_PROMPT
-            )
+            system_prompt = self._continuation_prompt if self._history else self._system_prompt
             execution = self._supervisor.start_agent_execution(
                 "chat",
                 "experiment-chat",
@@ -1337,6 +1462,12 @@ class _ExperimentChatService:
 
     @property
     def _state_dir(self) -> Path:
+        base = self._workspace / _CHAT_STATE_DIR
+        return base if self._thread_id is None else base / "threads" / self._thread_id
+
+    @property
+    def _shared_state_dir(self) -> Path:
+        """Root of the trajectory snapshots every thread reads."""
         return self._workspace / _CHAT_STATE_DIR
 
     def _load_history(self) -> list[tuple[str, str]]:
@@ -1366,26 +1497,28 @@ class _ExperimentChatService:
             self._log(f"[warn] could not persist experiment chat: {exc}")
 
     def _sync_trajectory(self) -> None:
-        trajectory_dir = self._state_dir / "trajectory"
-        if self._state_dir.is_symlink():
+        # Trajectory snapshots stay in the shared chat root: they are the same
+        # read-only evidence for every thread, refreshed by whichever thread
+        # asks next.
+        trajectory_dir = self._shared_state_dir / "trajectory"
+        if self._state_dir.is_symlink() or self._shared_state_dir.is_symlink():
             self._log(f"[warn] experiment chat state is a symlink: {self._state_dir}")
             return
         try:
             self._state_dir.mkdir(parents=True, exist_ok=True)
-            if trajectory_dir.is_symlink():
-                trajectory_dir.unlink()
-            elif trajectory_dir.exists():
-                shutil.rmtree(trajectory_dir)
-            trajectory_dir.mkdir(parents=True, exist_ok=True)
-            (self._state_dir / "instructions.md").write_text(
-                _EXPERIMENT_CHAT_SYSTEM_PROMPT, encoding="utf-8"
-            )
+            (self._state_dir / "instructions.md").write_text(self._system_prompt, encoding="utf-8")
             self._flush_logs()
-            self._write_trajectory_snapshot(
-                self._project.state.portable_run_export(self._run_id),
-                trajectory_dir / "state",
-            )
-            self._copy_trajectory_files(self._log_dir, trajectory_dir / "logs")
+            with _CHAT_TRAJECTORY_SYNC_LOCK:
+                if trajectory_dir.is_symlink():
+                    trajectory_dir.unlink()
+                elif trajectory_dir.exists():
+                    shutil.rmtree(trajectory_dir)
+                trajectory_dir.mkdir(parents=True, exist_ok=True)
+                self._write_trajectory_snapshot(
+                    self._project.state.portable_run_export(self._run_id),
+                    trajectory_dir / "state",
+                )
+                self._copy_trajectory_files(self._log_dir, trajectory_dir / "logs")
         except (OSError, ValueError) as exc:
             self._log(f"[warn] could not refresh experiment chat trajectory: {exc}")
 
@@ -1474,6 +1607,7 @@ class _RunContext:
         run_id: str,
         round_transaction_coordinator: RoundTransactionCoordinator | None = None,
         experiment_chat: _ExperimentChatService | None = None,
+        chat_thread_services: list[_ExperimentChatService] | None = None,
     ):
         self.backend = backend
         self.run_environment = run_environment
@@ -1521,6 +1655,11 @@ class _RunContext:
         self.agent_client = agent_client
         self._closed = False
         self._experiment_chat = experiment_chat
+        # Created chat threads share the run's lifetime: the factory that
+        # builds them appends here, and close() below tears them down.
+        self._chat_thread_services = (
+            chat_thread_services if chat_thread_services is not None else []
+        )
         self._progress_stack: list[AgentProgress] = []
         if self.supervisor is not None and self._experiment_chat is not None:
             self.supervisor.set_chat_handler(self._experiment_chat.ask)
@@ -1733,20 +1872,26 @@ class _RunContext:
         # Mirror backend state on _RunContext for legacy callers/tests.
         self.selected_gpu = self.device.selected_device
 
-    def close(self) -> None:  # noqa: C901  # preserve independent cleanup failures
-        if self._closed:
-            return
-        self._closed = True
+    def _close_chat_surfaces(self) -> BaseException | None:
+        """Tear down the default chat and every created thread's resources."""
         chat_error: BaseException | None = None
         experiment_chat, self._experiment_chat = self._experiment_chat, None
+        chat_threads, self._chat_thread_services = list(self._chat_thread_services), []
+        if self.supervisor is not None:
+            try:
+                # Threads never outlive the run context, even when a retained
+                # terminal presentation keeps the default chat handler alive.
+                self.supervisor.clear_chat_threads_and_drain()
+            except BaseException as exc:  # noqa: BLE001  # resource close must still run
+                chat_error = exc
         if self.supervisor is not None and experiment_chat is not None:
             try:
                 self.supervisor.clear_chat_handler_and_drain()
             except BaseException as exc:  # noqa: BLE001  # resource close must still run
-                chat_error = exc
-        if experiment_chat is not None:
+                chat_error = chat_error or exc
+        for chat_service in [*chat_threads, *([experiment_chat] if experiment_chat else [])]:
             try:
-                experiment_chat.close()
+                chat_service.close()
             except BaseException as exc:  # noqa: BLE001  # primary teardown must still run
                 if chat_error is None:
                     chat_error = exc
@@ -1754,6 +1899,13 @@ class _RunContext:
                     chat_error.add_note(
                         f"Experiment chat cleanup also failed: {type(exc).__name__}: {exc}"
                     )
+        return chat_error
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        chat_error = self._close_chat_surfaces()
         primary_error: BaseException | None = None
         try:
             # Unwinds in reverse construction order: device monitor stop +

--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -23,6 +23,7 @@ class EventType(StrEnum):  # noqa: D101  # tracked: #288
     EXPERIMENTS_CHANGED = "experiments_changed"
     RUN_INTERRUPTED = "run_interrupted"
     CHAT = "chat"
+    CHAT_THREAD_CREATED = "chat_thread_created"
     STATUS_QUERY = "status_query"
     CONTROL = "control"
     INVOCATION_STARTED = "invocation_started"
@@ -67,6 +68,25 @@ AgentOutputChannel = Literal["assistant", "analysis", "tool", "diagnostic", "pro
 class ChatData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["chat"] = "chat"
     answer: str
+    # The authoritative thread title, set by the server on the turn that
+    # titles a previously untitled thread so clients learn it from replay.
+    thread_title: str | None = None
+
+
+class ChatThreadCreatedData(BaseModel):
+    """Identity and resolved agent settings for one experiment-chat thread.
+
+    Replayed by clients to rebuild the thread list; the default thread is
+    implicit and never records one of these.
+    """
+
+    kind: Literal["chat_thread_created"] = "chat_thread_created"
+    thread_id: str
+    title: str = ""
+    driver: str
+    provider: str
+    model: str
+    created_at: datetime
 
 
 class InvocationStartedData(BaseModel):  # noqa: D101  # tracked: #288
@@ -247,6 +267,7 @@ class RoundFinishedData(BaseModel):  # noqa: D101  # tracked: #288
 
 EventData = Annotated[
     ChatData
+    | ChatThreadCreatedData
     | InvocationStartedData
     | InvocationFinishedData
     | AgentExecutionStartedData
@@ -289,6 +310,9 @@ class RunEvent(BaseModel):
     agent_kind: str | None = None
     invocation_id: str | None = None
     execution_id: str | None = None
+    # Which experiment-chat thread a chat event belongs to. None is the
+    # default thread, preserving events written before threads existed.
+    chat_thread_id: str | None = None
     data: EventData | None = None
 
     @model_validator(mode="before")

--- a/src/vibesys/server/protocol.py
+++ b/src/vibesys/server/protocol.py
@@ -45,6 +45,23 @@ class SnapshotQuery(Request):  # noqa: D101  # tracked: #288
 class ChatQuery(Request):  # noqa: D101  # tracked: #288
     type: Literal["query.chat"] = "query.chat"
     text: str
+    # None targets the default thread, preserving pre-thread clients.
+    thread_id: str | None = None
+
+
+class ChatThreadCreateQuery(Request):
+    """Create a new experiment-chat thread with its own agent selection.
+
+    Omitted fields resolve to the run's configured driver, provider, and
+    model. The response carries the resolved settings and thread identity.
+    """
+
+    type: Literal["query.chat_thread_create"] = "query.chat_thread_create"
+    driver: Literal["agentshim", "omnigent"] | None = None
+    provider: str | None = None
+    model: str | None = None
+    # Without a title the server derives one from the thread's first message.
+    title: str | None = None
 
 
 class HistoryQuery(Request):  # noqa: D101  # tracked: #288
@@ -78,6 +95,7 @@ ProtocolRequest = Annotated[
     | SteerCommand
     | SnapshotQuery
     | ChatQuery
+    | ChatThreadCreateQuery
     | HistoryQuery
     | PerformanceQuery
     | ExperimentQuery
@@ -119,6 +137,18 @@ class ChatResult(ProtocolModel):  # noqa: D101  # tracked: #288
     question: str
     answer: str
     effect: Literal["none"] = "none"
+    # Echoes the requested thread; None is the default thread.
+    thread_id: str | None = None
+
+
+class ChatThreadInfo(ProtocolModel):
+    """Resolved identity and agent settings of one experiment-chat thread."""
+
+    thread_id: str
+    title: str = ""
+    driver: str
+    provider: str
+    model: str
 
 
 class PerformanceRound(ProtocolModel):  # noqa: D101  # tracked: #288
@@ -187,6 +217,7 @@ class Response(ProtocolModel):  # noqa: D101  # tracked: #288
     diagnostic: Diagnostic | None = None
     ack: CommandAck | None = None
     chat: ChatResult | None = None
+    chat_thread: ChatThreadInfo | None = None
     snapshot: RunSnapshot | None = None
     events: list[RunEvent] = Field(default_factory=list)
     performance: list[PerformanceRound] = Field(default_factory=list)

--- a/src/vibesys/server/service.py
+++ b/src/vibesys/server/service.py
@@ -13,6 +13,8 @@ from vibesys.server.protocol import (
     ActiveAgentExecution,
     ChatQuery,
     ChatResult,
+    ChatThreadCreateQuery,
+    ChatThreadInfo,
     CommandAck,
     EventsQuery,
     ExperimentQuery,
@@ -42,32 +44,12 @@ class SupervisionService:
         self.inspector = RunInspector(supervisor)
 
     def execute(self, request: ProtocolRequest) -> Response:  # noqa: D102, PLR0911  # tracked: #288
-        if isinstance(request, PauseCommand):
-            self.supervisor.pause_after_call()
-            return Response(
-                request_id=request.request_id,
-                ack=CommandAck(action="pause", status="pending"),
-            )
-        if isinstance(request, ResumeCommand):
-            self.supervisor.resume()
-            return Response(
-                request_id=request.request_id,
-                ack=CommandAck(action="resume", status="consumed"),
-            )
-        if isinstance(request, SteerCommand):
-            self.supervisor.steer(request.text)
-            return Response(
-                request_id=request.request_id,
-                ack=CommandAck(action="steer", status="pending"),
-            )
+        if isinstance(request, (PauseCommand, ResumeCommand, SteerCommand)):
+            return self._execute_command(request)
         if isinstance(request, ChatQuery):
-            sequence = self.supervisor.snapshot().sequence
-            answer = self.supervisor.chat(request.text)
-            return Response(
-                request_id=request.request_id,
-                chat=ChatResult(question=request.text, answer=answer),
-                events=self.supervisor.read_events(sequence),
-            )
+            return self._execute_chat(request)
+        if isinstance(request, ChatThreadCreateQuery):
+            return self._execute_chat_thread_create(request)
         if isinstance(request, HistoryQuery):
             self.supervisor.record(EventType.STATUS_QUERY, "/history")
             return Response(request_id=request.request_id, events=self.history_events())
@@ -94,6 +76,47 @@ class SupervisionService:
             )
             return Response(request_id=request.request_id, events=events)
         raise TypeError(f"Unsupported protocol request: {type(request).__name__}")  # noqa: TRY003  # tracked: #288
+
+    def _execute_command(self, request: PauseCommand | ResumeCommand | SteerCommand) -> Response:
+        if isinstance(request, PauseCommand):
+            self.supervisor.pause_after_call()
+            ack = CommandAck(action="pause", status="pending")
+        elif isinstance(request, ResumeCommand):
+            self.supervisor.resume()
+            ack = CommandAck(action="resume", status="consumed")
+        else:
+            self.supervisor.steer(request.text)
+            ack = CommandAck(action="steer", status="pending")
+        return Response(request_id=request.request_id, ack=ack)
+
+    def _execute_chat(self, request: ChatQuery) -> Response:
+        sequence = self.supervisor.snapshot().sequence
+        answer = self.supervisor.chat(request.text, thread_id=request.thread_id)
+        return Response(
+            request_id=request.request_id,
+            chat=ChatResult(question=request.text, answer=answer, thread_id=request.thread_id),
+            events=self.supervisor.read_events(sequence),
+        )
+
+    def _execute_chat_thread_create(self, request: ChatThreadCreateQuery) -> Response:
+        sequence = self.supervisor.snapshot().sequence
+        spec = self.supervisor.create_chat_thread(
+            driver=request.driver,
+            provider=request.provider,
+            model=request.model,
+            title=request.title,
+        )
+        return Response(
+            request_id=request.request_id,
+            chat_thread=ChatThreadInfo(
+                thread_id=spec.thread_id,
+                title=spec.title,
+                driver=spec.driver,
+                provider=spec.provider,
+                model=spec.model,
+            ),
+            events=self.supervisor.read_events(sequence),
+        )
 
     def snapshot(self) -> RunSnapshot:  # noqa: D102  # tracked: #288
         return self.supervisor.snapshot()

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -7,7 +7,7 @@ import re
 import threading
 import time
 import uuid
-from collections.abc import Callable, Generator  # noqa: TC003  # tracked: #288
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -29,6 +29,7 @@ from vibesys.server.events import (
     AgentOutputChannel,
     AgentOutputChunkData,
     ChatData,
+    ChatThreadCreatedData,
     EventData,
     EventStatus,
     EventStore,
@@ -102,6 +103,23 @@ class TerminalChatResource:
     close: Callable[[], None]
 
 
+@dataclass(frozen=True)
+class ChatThreadHandle:
+    """Resolved thread settings and the handler that answers its questions."""
+
+    spec: ChatThreadCreatedData
+    handler: Callable[[str], str]
+
+
+ChatThreadFactory = Callable[[str, str | None, str | None, str | None], ChatThreadHandle]
+"""Builds one thread's chat service: (thread_id, driver, provider, model).
+
+None arguments resolve to the run's configured defaults. The factory raises
+``ValueError`` for an unsupported driver/provider combination; resource
+cleanup for the built service stays with the factory's owner (the run
+context), not the supervisor."""
+
+
 class RunSupervisor:
     """Own pause state, invocation metadata, and the run audit store."""
 
@@ -128,6 +146,12 @@ class RunSupervisor:
         self._current_kind: str | None = None
         self._current_round: str | None = None
         self._chat_handler: Callable[[str], str] | None = None
+        # Per-thread chat routing. Specs replay from CHAT_THREAD_CREATED
+        # events so a resumed run can rebuild handlers on demand through the
+        # context-owned factory.
+        self._chat_thread_factory: ChatThreadFactory | None = None
+        self._chat_thread_handlers: dict[str, Callable[[str], str]] = {}
+        self._chat_thread_specs: dict[str, ChatThreadCreatedData] = {}
         self._active_chat_calls = 0
         self._retain_terminal_chat = False
         self._terminal_chat_resource: TerminalChatResource | None = None
@@ -511,6 +535,21 @@ class RunSupervisor:
 
     def _index_execution_lifecycle(self, events: list[RunEvent]) -> None:
         for event in events:
+            if event.type is EventType.CHAT_THREAD_CREATED and isinstance(
+                event.data, ChatThreadCreatedData
+            ):
+                self._chat_thread_specs.setdefault(event.data.thread_id, event.data)
+            if (
+                event.type is EventType.CHAT
+                and event.chat_thread_id is not None
+                and isinstance(event.data, ChatData)
+                and event.data.thread_title
+            ):
+                spec = self._chat_thread_specs.get(event.chat_thread_id)
+                if spec is not None and not spec.title:
+                    self._chat_thread_specs[event.chat_thread_id] = spec.model_copy(
+                        update={"title": event.data.thread_title}
+                    )
             if event.execution_id is None:
                 continue
             if event.type in {
@@ -530,7 +569,9 @@ class RunSupervisor:
         with self._condition:
             return self._chat_handler is not None
 
-    def chat(self, text: str) -> str:  # noqa: D102  # tracked: #288
+    def chat(self, text: str, thread_id: str | None = None) -> str:  # noqa: D102  # tracked: #288
+        if thread_id is not None:
+            return self._thread_chat(text, thread_id)
         with self._condition:
             handler = self._chat_handler
             if handler is not None:
@@ -562,6 +603,124 @@ class RunSupervisor:
         finally:
             if handler is not None:
                 self._release_chat_call()
+
+    def _thread_chat(self, text: str, thread_id: str) -> str:
+        """Route one question to a created thread's handler and audit it."""
+        handler = self._resolve_thread_handler(thread_id)
+        if isinstance(handler, str):
+            # A routing failure is an answer to this caller, not run history:
+            # no CHAT event is recorded for a thread that cannot answer.
+            return handler
+        with self._condition:
+            self._active_chat_calls += 1
+        try:
+            answer = handler(text)
+            thread_title = self._title_thread_if_needed(thread_id, text)
+            self.record(
+                EventType.CHAT,
+                text,
+                status=EventStatus.ANSWERED,
+                agent_kind="chat",
+                round_label="experiment-chat",
+                chat_thread_id=thread_id,
+                data=ChatData(answer=answer, thread_title=thread_title),
+            )
+            return answer
+        finally:
+            self._release_chat_call()
+
+    def _title_thread_if_needed(self, thread_id: str, question: str) -> str | None:
+        """Derive and store an untitled thread's title from its first message."""
+        with self._condition:
+            spec = self._chat_thread_specs.get(thread_id)
+            if spec is None or spec.title:
+                return None
+            title = _chat_thread_title(question)
+            if not title:
+                return None
+            self._chat_thread_specs[thread_id] = spec.model_copy(update={"title": title})
+            return title
+
+    def _resolve_thread_handler(self, thread_id: str) -> Callable[[str], str] | str:
+        """Return the thread's handler, or the error answer explaining why not."""
+        with self._condition:
+            handler = self._chat_thread_handlers.get(thread_id)
+            spec = self._chat_thread_specs.get(thread_id)
+            factory = self._chat_thread_factory
+        if handler is not None:
+            return handler
+        if spec is None:
+            return (
+                f"Unknown experiment chat thread {thread_id!r}. Create one with "
+                "/new-chat, or omit the thread to use the default experiment chat."
+            )
+        if factory is None:
+            return (
+                f"Experiment chat thread {thread_id!r} cannot answer right now "
+                f"({self._chat_unavailable_reason()})."
+            )
+        try:
+            handle = factory(thread_id, spec.driver, spec.provider, spec.model)
+        except Exception as exc:  # noqa: BLE001  # routing failures become answers
+            return (
+                f"Could not restore experiment chat thread {thread_id!r}: "
+                f"{type(exc).__name__}: {exc}"
+            )
+        with self._condition:
+            return self._chat_thread_handlers.setdefault(thread_id, handle.handler)
+
+    def set_chat_thread_factory(self, factory: ChatThreadFactory | None) -> None:
+        """Install the context-owned builder for per-thread chat services."""
+        with self._condition:
+            self._chat_thread_factory = factory
+
+    def create_chat_thread(
+        self,
+        *,
+        driver: str | None = None,
+        provider: str | None = None,
+        model: str | None = None,
+        title: str | None = None,
+    ) -> ChatThreadCreatedData:
+        """Create one chat thread, record its durable event, and register it.
+
+        An untitled thread is titled by the server from its first message.
+        """
+        with self._condition:
+            factory = self._chat_thread_factory
+        if factory is None:
+            raise RuntimeError(  # noqa: TRY003  # surfaced to the requesting client
+                "Experiment chat threads are not available for this run "
+                f"({self._chat_unavailable_reason()})"
+            )
+        thread_id = uuid.uuid4().hex
+        handle = factory(thread_id, driver, provider, model)
+        spec = handle.spec
+        if title is not None and title.strip():
+            spec = spec.model_copy(update={"title": title.strip()})
+        with self._condition:
+            self._chat_thread_specs[spec.thread_id] = spec
+            self._chat_thread_handlers[spec.thread_id] = handle.handler
+        self.record(
+            EventType.CHAT_THREAD_CREATED,
+            agent_kind="chat",
+            round_label="experiment-chat",
+            chat_thread_id=spec.thread_id,
+            data=spec,
+        )
+        return spec
+
+    def chat_threads(self) -> list[ChatThreadCreatedData]:
+        """Return every created thread's replayable spec, oldest first."""
+        with self._condition:
+            return sorted(self._chat_thread_specs.values(), key=lambda spec: spec.created_at)
+
+    def clear_chat_threads_and_drain(self) -> None:
+        """Stop routing thread chat and wait for in-flight calls to release."""
+        with self._condition:
+            self._chat_thread_factory = None
+            self._chat_thread_handlers.clear()
+            self._wait_for_chat_drain_locked(timeout=_TERMINAL_CHAT_DRAIN_TIMEOUT_SECONDS)
 
     def _release_chat_call(self) -> None:
         """Release one handler lease and close a retired resource when safe."""
@@ -1013,6 +1172,19 @@ class RunSupervisor:
         with self._condition:
             self._error_diagnostics[key] = (error, diagnostic)
         return diagnostic
+
+
+_CHAT_THREAD_TITLE_MAX_CHARS = 40
+
+
+def _chat_thread_title(question: str) -> str:
+    """Title a thread from its first message: first line, cut on a word."""
+    line = next((part.strip() for part in question.strip().splitlines() if part.strip()), "")
+    if len(line) <= _CHAT_THREAD_TITLE_MAX_CHARS:
+        return line
+    cut = line[:_CHAT_THREAD_TITLE_MAX_CHARS]
+    head, separator, _rest = cut.rpartition(" ")
+    return f"{head.rstrip() if separator else cut}…"
 
 
 def _attempt_from_label(round_label: str) -> int | None:

--- a/tests/server/test_chat_threads.py
+++ b/tests/server/test_chat_threads.py
@@ -1,0 +1,249 @@
+"""Per-thread experiment chat: registry, routing, replay, and wire shapes."""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from vibesys.server import RunSupervisor
+from vibesys.server.events import ChatData, ChatThreadCreatedData, EventType, RunEvent, make_event
+from vibesys.server.protocol import (
+    ChatQuery,
+    ChatThreadCreateQuery,
+    ChatThreadInfo,
+    Response,
+)
+from vibesys.server.service import SupervisionService
+from vibesys.server.supervisor import ChatThreadFactory, ChatThreadHandle
+
+
+def _factory(
+    calls: list[tuple[str, str | None, str | None, str | None]], answer: str
+) -> ChatThreadFactory:
+    def factory(
+        thread_id: str, driver: str | None, provider: str | None, model: str | None
+    ) -> ChatThreadHandle:
+        calls.append((thread_id, driver, provider, model))
+        return ChatThreadHandle(
+            spec=ChatThreadCreatedData(
+                thread_id=thread_id,
+                driver=driver or "agentshim",
+                provider=provider or "codex",
+                model=model or "gpt-default",
+                created_at=datetime.now(UTC),
+            ),
+            handler=lambda question: f"{answer}: {question}",
+        )
+
+    return factory
+
+
+def _events(path: Path) -> list[dict]:
+    return [
+        json.loads(line) for line in (path / "run-events.jsonl").read_text().splitlines() if line
+    ]
+
+
+def test_created_thread_routes_chat_and_stamps_its_events(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.set_chat_handler(lambda question: f"default: {question}")
+    calls: list[tuple[str, str | None, str | None, str | None]] = []
+    supervisor.set_chat_thread_factory(_factory(calls, "omnigent-claude"))
+
+    spec = supervisor.create_chat_thread(driver="omnigent", provider="claude", model="opus")
+
+    assert calls == [(spec.thread_id, "omnigent", "claude", "opus")]
+    assert supervisor.chat("what changed?", thread_id=spec.thread_id) == (
+        "omnigent-claude: what changed?"
+    )
+    # The default thread is untouched by thread routing.
+    assert supervisor.chat("what changed?") == "default: what changed?"
+
+    events = _events(tmp_path)
+    created = [event for event in events if event["type"] == "chat_thread_created"]
+    assert len(created) == 1
+    assert created[0]["chat_thread_id"] == spec.thread_id
+    assert created[0]["data"]["driver"] == "omnigent"
+    assert created[0]["data"]["provider"] == "claude"
+    assert created[0]["data"]["model"] == "opus"
+    chats = [event for event in events if event["type"] == "chat"]
+    assert [event["chat_thread_id"] for event in chats] == [spec.thread_id, None]
+    assert chats[0]["agent_kind"] == "chat"
+
+
+def test_unknown_thread_gets_a_clear_error_answer_without_an_event(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    answer = supervisor.chat("hello?", thread_id="missing-thread")
+
+    assert "Unknown experiment chat thread 'missing-thread'" in answer
+    assert all(event["type"] != "chat" for event in _events(tmp_path))
+
+
+def test_thread_creation_without_a_factory_is_rejected(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    with pytest.raises(RuntimeError, match="chat threads are not available"):
+        supervisor.create_chat_thread()
+
+
+def test_invalid_combination_error_from_factory_propagates(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    rejection = "agent driver 'omnigent' does not support provider 'gemini'"
+
+    def rejecting_factory(*_args: object) -> ChatThreadHandle:
+        raise ValueError(rejection)
+
+    supervisor.set_chat_thread_factory(rejecting_factory)
+
+    with pytest.raises(ValueError, match="does not support provider 'gemini'"):
+        supervisor.create_chat_thread(driver="omnigent", provider="gemini")
+    assert all(event["type"] != "chat_thread_created" for event in _events(tmp_path))
+
+
+def test_threads_replay_from_the_event_log_and_rebuild_on_demand(tmp_path):  # noqa: ANN001, ANN201
+    first = RunSupervisor()
+    first.attach(tmp_path)
+    first.set_chat_thread_factory(_factory([], "first"))
+    spec = first.create_chat_thread(driver="agentshim", provider="claude")
+    assert first.chat("why did round two regress so much?", thread_id=spec.thread_id)
+
+    resumed = RunSupervisor()
+    resumed.attach(tmp_path)
+    replayed = resumed.chat_threads()
+    assert [thread.thread_id for thread in replayed] == [spec.thread_id]
+    # The replayed spec carries the backend-derived title from the first turn.
+    assert replayed[0].title == "why did round two regress so much?"
+
+    # Without a factory the thread is known but cannot answer.
+    unavailable = resumed.chat("still there?", thread_id=spec.thread_id)
+    assert "cannot answer right now" in unavailable
+
+    calls: list[tuple[str, str | None, str | None, str | None]] = []
+    resumed.set_chat_thread_factory(_factory(calls, "rebuilt"))
+    assert resumed.chat("still there?", thread_id=spec.thread_id) == "rebuilt: still there?"
+    # The handler was rebuilt from the recorded spec, not from defaults.
+    assert calls == [(spec.thread_id, "agentshim", "claude", "gpt-default")]
+
+
+def test_first_message_titles_an_untitled_thread_once(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.set_chat_thread_factory(_factory([], "answer"))
+    spec = supervisor.create_chat_thread()
+    assert spec.title == ""
+
+    supervisor.chat("explain why the benchmark throughput regressed in round four", spec.thread_id)
+    supervisor.chat("and round five?", thread_id=spec.thread_id)
+
+    chats = [event for event in _events(tmp_path) if event["type"] == "chat"]
+    # Long first lines cut on a word boundary near 40 characters.
+    assert chats[0]["data"]["thread_title"] == "explain why the benchmark throughput…"
+    assert chats[1]["data"]["thread_title"] is None
+    assert supervisor.chat_threads()[0].title == "explain why the benchmark throughput…"
+
+
+def test_explicit_title_is_authoritative(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.set_chat_thread_factory(_factory([], "answer"))
+
+    spec = supervisor.create_chat_thread(title="  perf deep dive  ")
+    supervisor.chat("first question", thread_id=spec.thread_id)
+
+    assert spec.title == "perf deep dive"
+    chats = [event for event in _events(tmp_path) if event["type"] == "chat"]
+    assert chats[0]["data"]["thread_title"] is None
+    assert supervisor.chat_threads()[0].title == "perf deep dive"
+
+
+def test_cleared_threads_stop_routing_but_keep_replayable_specs(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.set_chat_thread_factory(_factory([], "answer"))
+    spec = supervisor.create_chat_thread()
+
+    supervisor.clear_chat_threads_and_drain()
+
+    assert "cannot answer right now" in supervisor.chat("hello", thread_id=spec.thread_id)
+    assert [thread.thread_id for thread in supervisor.chat_threads()] == [spec.thread_id]
+
+
+def test_service_creates_threads_and_routes_threaded_chat(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+    supervisor.set_chat_thread_factory(_factory([], "thread-agent"))
+    service = SupervisionService(supervisor)
+
+    created = service.execute(ChatThreadCreateQuery(provider="claude"))
+    assert created.chat_thread is not None
+    assert created.chat_thread.provider == "claude"
+    assert created.chat_thread.driver == "agentshim"
+    assert any(event.type is EventType.CHAT_THREAD_CREATED for event in created.events)
+
+    response = service.execute(
+        ChatQuery(text="what changed?", thread_id=created.chat_thread.thread_id)
+    )
+    assert response.chat is not None
+    assert response.chat.answer == "thread-agent: what changed?"
+    assert response.chat.thread_id == created.chat_thread.thread_id
+    chat_events = [event for event in response.events if event.type is EventType.CHAT]
+    assert [event.chat_thread_id for event in chat_events] == [created.chat_thread.thread_id]
+
+
+def test_chat_thread_wire_shapes_round_trip():  # noqa: ANN201
+    request = ChatThreadCreateQuery(driver="omnigent", provider="codex", model="o4", title="t")
+    assert ChatThreadCreateQuery.model_validate_json(request.model_dump_json()) == request
+
+    query = ChatQuery(text="why?", thread_id="thread-1")
+    assert ChatQuery.model_validate_json(query.model_dump_json()) == query
+    # Old clients omit the field entirely and land on the default thread.
+    assert ChatQuery.model_validate({"type": "query.chat", "text": "why?"}).thread_id is None
+
+    event = make_event(
+        EventType.CHAT_THREAD_CREATED,
+        chat_thread_id="thread-1",
+        agent_kind="chat",
+        data=ChatThreadCreatedData(
+            thread_id="thread-1",
+            title="",
+            driver="agentshim",
+            provider="claude",
+            model="opus",
+            created_at=datetime.now(UTC),
+        ),
+    )
+    restored = RunEvent.model_validate_json(event.model_dump_json())
+    assert restored.chat_thread_id == "thread-1"
+    assert isinstance(restored.data, ChatThreadCreatedData)
+    assert restored.data.provider == "claude"
+
+    chat_event = make_event(
+        EventType.CHAT,
+        "why?",
+        chat_thread_id="thread-1",
+        data=ChatData(answer="because", thread_title="why?"),
+    )
+    restored_chat = RunEvent.model_validate_json(chat_event.model_dump_json())
+    assert isinstance(restored_chat.data, ChatData)
+    assert restored_chat.data.thread_title == "why?"
+
+    response = Response.model_validate_json(
+        Response(
+            request_id="r1",
+            chat_thread=ChatThreadInfo(
+                thread_id="thread-1",
+                driver="agentshim",
+                provider="claude",
+                model="opus",
+            ),
+        ).model_dump_json()
+    )
+    assert response.chat_thread is not None
+    assert response.chat_thread.thread_id == "thread-1"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -7,6 +7,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibesys.context import (
+    _EXPERIMENT_CHAT_SYSTEM_PROMPT,
+    _ExperimentChatDependencies,
+    _ExperimentChatService,
+    _resolve_chat_thread_settings,
     _resume_configuration_update,
     _RunContext,
     create_candidate_context,
@@ -315,6 +319,111 @@ def test_nonretained_experiment_chat_closes_when_context_construction_fails(
         chat_client.close.assert_called_once_with()
     finally:
         REGISTRY.deactivate(supervisor)
+
+
+def test_chat_thread_settings_resolve_run_defaults() -> None:
+    resolved = _resolve_chat_thread_settings(
+        agent_backend="cli",
+        default_driver="agentshim",
+        default_provider="codex",
+        default_model="gpt-run",
+        driver=None,
+        provider=None,
+        model=None,
+    )
+    assert resolved == ("agentshim", "codex", "gpt-run")
+
+
+def test_chat_thread_settings_reject_invalid_combinations() -> None:
+    def resolve(agent_backend: str, driver: str | None, provider: str | None) -> tuple[str, ...]:
+        return _resolve_chat_thread_settings(
+            agent_backend=agent_backend,
+            default_driver="agentshim",
+            default_provider="codex",
+            default_model="gpt-run",
+            driver=driver,
+            provider=provider,
+            model=None,
+        )
+
+    with pytest.raises(ValueError, match="does not support provider 'gemini'"):
+        resolve("cli", "omnigent", "gemini")
+    with pytest.raises(ValueError, match="unknown agent driver 'other'"):
+        resolve("cli", "other", None)
+    with pytest.raises(ValueError, match="require the CLI agent backend"):
+        resolve("deepagents", None, None)
+
+
+def _chat_service(
+    tmp_path: Path, thread_id: str | None, answer: str = "the answer"
+) -> tuple[_ExperimentChatService, MagicMock]:
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path / "logs")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    agent_client = MagicMock()
+    agent_client.invoke_text.return_value = answer
+    project = MagicMock()
+    project.state.portable_run_export.return_value = MagicMock(files=[])
+    service = _ExperimentChatService(
+        _ExperimentChatDependencies(
+            supervisor=supervisor,
+            agent_client=agent_client,
+            workspace=workspace,
+            log_dir=tmp_path / "logs",
+            project=project,
+            run_id="run-1",
+            log=lambda _line: None,
+            flush_logs=lambda: None,
+            environment=dict,
+            progress=lambda: None,
+            thread_id=thread_id,
+        )
+    )
+    return service, agent_client
+
+
+def test_default_chat_thread_keeps_the_legacy_state_layout(tmp_path: Path) -> None:
+    service, agent_client = _chat_service(tmp_path, thread_id=None)
+
+    service.ask("what happened?")
+
+    workspace = tmp_path / "workspace"
+    transcript = workspace / "_vibesys_chat" / "conversation.jsonl"
+    assert json.loads(transcript.read_text()) == {
+        "question": "what happened?",
+        "answer": "the answer",
+    }
+    prompt = agent_client.invoke_text.call_args.kwargs["system_prompt"]
+    assert prompt == _EXPERIMENT_CHAT_SYSTEM_PROMPT
+    assert (workspace / "_vibesys_chat" / "instructions.md").read_text() == prompt
+
+
+def test_created_chat_thread_owns_its_state_dir_and_shares_trajectory(tmp_path: Path) -> None:
+    service, agent_client = _chat_service(tmp_path, thread_id="thread-a")
+
+    service.ask("what happened?")
+
+    workspace = tmp_path / "workspace"
+    thread_dir = workspace / "_vibesys_chat" / "threads" / "thread-a"
+    assert json.loads((thread_dir / "conversation.jsonl").read_text()) == {
+        "question": "what happened?",
+        "answer": "the answer",
+    }
+    prompt = agent_client.invoke_text.call_args.kwargs["system_prompt"]
+    # The thread reads its own conversation but the shared trajectory.
+    assert "_vibesys_chat/threads/thread-a/conversation.jsonl" in prompt
+    assert "_vibesys_chat/trajectory/state/" in prompt
+    assert (thread_dir / "instructions.md").read_text() == prompt
+    assert (workspace / "_vibesys_chat" / "trajectory").is_dir()
+    assert not (thread_dir / "trajectory").exists()
+    # The legacy transcript is untouched by thread traffic.
+    assert not (workspace / "_vibesys_chat" / "conversation.jsonl").exists()
+
+    # A follow-up turn continues from the thread's own instructions file.
+    service.ask("and then?")
+    continuation = agent_client.invoke_text.call_args.kwargs["system_prompt"]
+    assert "_vibesys_chat/threads/thread-a/instructions.md" in continuation
 
 
 def test_repository_task_exposes_its_actual_reference_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

The experiment chat is a per-run singleton: one hardcoded handler, one flat transcript tagged `round_label="experiment-chat"`, and the chat agent silently inherits the run's driver/provider/model. Operators can't keep separate conversations (e.g. one thread digging into a regression, another drafting next steps), can't resume a prior conversation distinctly, and can't point a chat at a different harness or model than the run.

## Solution

Experiment chat becomes multi-threaded, with per-thread agent harness + model choice at creation.

- **Wire**: `thread_id` on `ChatQuery`/`ChatResult` (absent = the default thread, so old clients are unaffected), `chat_thread_id` on `RunEvent`, a `CHAT_THREAD_CREATED` event carrying `{thread_id, title, driver, provider, model, created_at}`, and a create-thread request returning the resolved settings. Thread listing is replay-based — clients rebuild the thread list from `CHAT_THREAD_CREATED` events, no extra RPC.
- **Supervisor**: the singleton `_chat_handler` becomes a registry with on-demand handler construction via a context-owned factory; unknown thread ids answer with a clear error rather than raising; replay rebuilds thread specs on reconnect.
- **Per-thread chat services**: each thread gets its own `_ExperimentChatService` with its own `AgentClient` (driver/provider validated at creation — agentshim allows claude/gemini/codex/opencode, omnigent only claude/codex) and its own `_vibesys_chat/threads/<id>/` state dir; the default thread keeps the legacy `_vibesys_chat/` layout; trajectory snapshots are shared under a lock.
- **Titles are backend-owned**: derived from the thread's first user message (40-char word-boundary cut) in the supervisor and shipped on the CHAT event (`thread_title`); clients only render titles received from events.
- **TUI**: `/new-chat` opens a picker wizard (driver → provider narrowed by driver → free-text model prefilled with the run default), `/chats` lists and switches threads; per-thread composer drafts, pending state, and submit queues so replies land in the right transcript; the pane/overlay header shows the active thread.

### Architecture

Ownership: the backend owns thread identity, registry, validation, titling, and persistence; events are the only channel to clients; core-state partitions transcripts on `chat_thread_id ?? "default"` and derives the existing single-transcript selectors from the active thread; the TUI owns pickers, drafts, and rendering only.

```mermaid
flowchart LR
    U[/"/new-chat picker"/] -->|chat_thread_create| S[RunSupervisor\nthread registry]
    S -->|factory| C[per-thread\n_ExperimentChatService\n+ own AgentClient]
    C --> D[("_vibesys_chat/threads/&lt;id&gt;/")]
    S -->|CHAT_THREAD_CREATED\nCHAT + chat_thread_id + thread_title| E[(event log)]
    E -->|replay| CS[core-state\nthreads + partitioned transcripts]
    CS --> T[TUI panes, /chats picker]
```

## Verification

Behavioral tests at both boundaries (backend: emitted events, persisted state, responses; clients: mocked event sequences and frame assertions), full suites, idempotent codegen.

### Correctness properties

- Absent `thread_id`/`chat_thread_id` means the default thread: old clients, old event logs, and existing `_vibesys_chat/` workspaces behave exactly as before.
- Thread state survives reconnect purely via event replay (`CHAT_THREAD_CREATED` + stamped CHAT events); no client-side registry.
- Invalid driver/provider combinations are rejected at thread creation, not at first message; unknown thread ids produce an error answer, never an exception.
- Titles are computed exactly once, backend-side; clients render only what events carry.
- Main-run agent configuration is untouched; scope is agentshim + omnigent.

### Testing

- `uv run python -m pytest tests/server tests/agents tests/test_context.py -q`: 410 passed; `uv run ruff check src tests`: clean; `./scripts/check_format.sh`: clean; pyright strict: 1 pre-existing unrelated error (`landlock.py` `os.O_PATH`, Linux-only attribute, present on the base commit).
- `pnpm --dir clients/core-state test`: 27 pass; `pnpm --dir clients/tui test`: 383 pass, 1 known pre-existing launcher flake (passes 7/7 in isolation); `pnpm --dir clients/tui check` and `pnpm check:format:ts`: clean.
- `pnpm --dir clients/backend-client generate:protocol` re-run: no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
