### PR TITLE
Make omnigent a base dependency

### DIFF
--- a/docs/contributing/agent-drivers.md
+++ b/docs/contributing/agent-drivers.md
@@ -5,8 +5,7 @@ owns session reuse, skill setup, response parsing, logging, usage records, and
 lifecycle. A driver owns native executor setup, policy translation, turns,
 events, and cleanup. Unsupported requirements fail before a session starts.
 
-Omitting `driver` selects `agentshim`. Select the optional Omnigent driver
-directly:
+Omitting `driver` selects `agentshim`. Select the Omnigent driver directly:
 
 ```toml
 [agent]
@@ -14,12 +13,8 @@ backend = "cli"
 driver = "omnigent"
 ```
 
-Contributors get the dependency from `uv sync --dev`. End-user installations
-need the optional extra:
-
-```bash
-uv sync --extra omnigent
-```
+The `omnigent` package is a base dependency (pinned exactly in
+`pyproject.toml`), so every install carries it; `uv sync` is enough.
 
 ## Omnigent constraints
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,18 +32,15 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "loguru>=0.7.2",
     "openevolve==0.3.1",
+    # Agent driver selected with `[agent].driver = "omnigent"`. A fast-moving
+    # alpha, pinned exactly; carried in the base dependencies so every install
+    # can run omnigent-configured projects without an extra.
+    "omnigent==0.10.0",
 ]
 
 [project.urls]
 Repository = "https://github.com/uw-syfi/vibesys"
 Issues = "https://github.com/uw-syfi/vibesys/issues"
-
-[project.optional-dependencies]
-# Optional agent driver selected with `[agent].driver = "omnigent"`. Kept out
-# of the base dependencies because it is a fast-moving alpha with no stability
-# policy, so users of other drivers should not carry it. Install with
-# `uv sync --extra omnigent`.
-omnigent = ["omnigent==0.10.0"]
 
 [project.scripts]
 vibesys-issue-mcp = "vs_issue_board.mcp:main"
@@ -83,11 +80,6 @@ dev = [
     # could silently change what CI enforces under the strict rule set below.
     "ruff==0.15.12",
     "twine",
-    # Optional for users, required for contributors: without it pyright cannot
-    # resolve the Omnigent backend and its tests silently skip. `uv sync --dev`
-    # (what CI runs) therefore installs it. Version comes from the extra, so
-    # there is one pin.
-    "vibesys[omnigent]",
 ]
 test = [
     "hypothesis",

--- a/src/vibesys/agents/drivers/_omnigent_mcp.py
+++ b/src/vibesys/agents/drivers/_omnigent_mcp.py
@@ -42,7 +42,7 @@ def _native_mcp_api() -> _NativeMCPAPI:
     except ImportError as exc:
         raise OmnigentMCPError(
             f"Omnigent MCP support is not importable ({type(exc).__name__}: {exc}). "
-            "Install the Omnigent optional dependency with `uv sync --extra omnigent`."
+            "Reinstall dependencies with `uv sync` (omnigent is a base dependency)."
         ) from exc
     return _NativeMCPAPI(
         agent_spec=AgentSpec,

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -177,7 +177,7 @@ def _resolve_executor_spec(provider: str) -> OmnigentExecutorSpec:
 def _missing_omnigent(what: str, exc: ImportError) -> OmnigentDriverError:
     return OmnigentDriverError(
         f"{what} is not importable ({type(exc).__name__}: {exc}). "
-        "Install the Omnigent optional dependency with `uv sync --extra omnigent`."
+        "Reinstall dependencies with `uv sync` (omnigent is a base dependency)."
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -4518,15 +4518,11 @@ dependencies = [
     { name = "loguru" },
     { name = "mcp" },
     { name = "modal" },
+    { name = "omnigent" },
     { name = "openevolve" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
-]
-
-[package.optional-dependencies]
-omnigent = [
-    { name = "omnigent" },
 ]
 
 [package.dev-dependencies]
@@ -4544,7 +4540,6 @@ dev = [
     { name = "respx" },
     { name = "ruff" },
     { name = "twine" },
-    { name = "vibesys", extra = ["omnigent"] },
     { name = "vs-bench" },
 ]
 test = [
@@ -4566,13 +4561,12 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "mcp", specifier = ">=1.0,<2" },
     { name = "modal", specifier = ">=1.4.2" },
-    { name = "omnigent", marker = "extra == 'omnigent'", specifier = "==0.10.0" },
+    { name = "omnigent", specifier = "==0.10.0" },
     { name = "openevolve", specifier = "==0.3.1" },
     { name = "pydantic", specifier = ">=2" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pyyaml", specifier = ">=6" },
 ]
-provides-extras = ["omnigent"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4589,7 +4583,6 @@ dev = [
     { name = "respx" },
     { name = "ruff", specifier = "==0.15.12" },
     { name = "twine" },
-    { name = "vibesys", extras = ["omnigent"] },
     { name = "vs-bench", editable = "sdk/vs-bench" },
 ]
 test = [


### PR DESCRIPTION
## Problem

The omnigent driver is selected by project config (`[agent].driver = "omnigent"`), but the package was an optional extra. Any install without `--extra omnigent` fails at agent execution time with `ModuleNotFoundError: No module named 'omnigent'` — a recurring foot-gun for tool installs and fresh environments.

## Solution

Move the exact pin (`omnigent==0.10.0`) into base dependencies; drop the extra and the dev-group indirection (`vibesys[omnigent]`). Error hints in the driver and the agent-drivers doc now point at plain `uv sync`.

### Architecture

Dependency policy only; no code paths changed. The driver's lazy import and its error type stay (they still guard against a broken environment).

## Verification

### Correctness properties
- `uv sync` (no extras) yields an importable `omnigent`; driver selection by config cannot fail on a missing extra.
- One version pin remains, now in one place (base deps).

### Testing
- `uv sync --dev && uv run python -m pytest tests/agents/drivers -q`: 61 passed.
- `uv run ruff check` on touched files: clean.
- `uv lock` regenerated; `uv tool install -e .` verified omnigent importable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)