### PR TITLE
Render tool results from typed payloads with compact, expandable previews

### DIFF
--- a/clients/backend-client/src/generated/protocol.generated.ts
+++ b/clients/backend-client/src/generated/protocol.generated.ts
@@ -242,11 +242,23 @@ export type Tool2 = string;
 export type CallId1 = string | null;
 export type Content3 = string;
 export type IsError = boolean;
-export type Kind20 = "todo_update";
+export type Payload = (CommandResultPayload | JsonResultPayload) | null;
+export type Kind20 = "command";
+export type Stdout = string;
+export type Stderr = string;
+export type ExitCode1 = number | null;
+export type Duration = number | null;
+export type Kind21 = "json";
+export type Value1 =
+  | {
+      [k: string]: unknown;
+    }
+  | unknown[];
+export type Kind22 = "todo_update";
 export type Content4 = string;
 export type Status2 = string;
 export type Todos = TodoItemData[];
-export type Kind21 = "usage_update";
+export type Kind23 = "usage_update";
 export type InputTokens1 = number;
 export type ContextWindow1 = number | null;
 export type Model = string | null;
@@ -623,10 +635,30 @@ export interface ToolResultData {
   call_id?: CallId1;
   content: Content3;
   is_error?: IsError;
+  payload?: Payload;
+  [k: string]: unknown;
+}
+/**
+ * Structured result of a command-style tool execution.
+ */
+export interface CommandResultPayload {
+  kind?: Kind20;
+  stdout: Stdout;
+  stderr: Stderr;
+  exit_code?: ExitCode1;
+  duration?: Duration;
+  [k: string]: unknown;
+}
+/**
+ * A tool result that is a JSON object or array, already parsed.
+ */
+export interface JsonResultPayload {
+  kind?: Kind21;
+  value: Value1;
   [k: string]: unknown;
 }
 export interface TodoUpdateData {
-  kind?: Kind20;
+  kind?: Kind22;
   todos?: Todos;
   [k: string]: unknown;
 }
@@ -636,7 +668,7 @@ export interface TodoItemData {
   [k: string]: unknown;
 }
 export interface UsageUpdateData {
-  kind?: Kind21;
+  kind?: Kind23;
   input_tokens: InputTokens1;
   context_window?: ContextWindow1;
   model?: Model;

--- a/clients/backend-client/src/generated/protocol.schema.json
+++ b/clients/backend-client/src/generated/protocol.schema.json
@@ -406,6 +406,55 @@
       "title": "CommandAck",
       "type": "object"
     },
+    "CommandResultPayload": {
+      "description": "Structured result of a command-style tool execution.",
+      "properties": {
+        "kind": {
+          "const": "command",
+          "default": "command",
+          "title": "Kind",
+          "type": "string"
+        },
+        "stdout": {
+          "title": "Stdout",
+          "type": "string"
+        },
+        "stderr": {
+          "title": "Stderr",
+          "type": "string"
+        },
+        "exit_code": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exit Code"
+        },
+        "duration": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Duration"
+        }
+      },
+      "required": [
+        "stdout",
+        "stderr"
+      ],
+      "title": "CommandResultPayload",
+      "type": "object"
+    },
     "ConfigurationFailedData": {
       "properties": {
         "kind": {
@@ -1107,6 +1156,35 @@
         "user_prompt"
       ],
       "title": "InvocationStartedData",
+      "type": "object"
+    },
+    "JsonResultPayload": {
+      "description": "A tool result that is a JSON object or array, already parsed.",
+      "properties": {
+        "kind": {
+          "const": "json",
+          "default": "json",
+          "title": "Kind",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "items": {},
+              "type": "array"
+            }
+          ],
+          "title": "Value"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "title": "JsonResultPayload",
       "type": "object"
     },
     "JudgeResultData": {
@@ -2189,6 +2267,32 @@
           "default": false,
           "title": "Is Error",
           "type": "boolean"
+        },
+        "payload": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "command": "#/$defs/CommandResultPayload",
+                  "json": "#/$defs/JsonResultPayload"
+                },
+                "propertyName": "kind"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/CommandResultPayload"
+                },
+                {
+                  "$ref": "#/$defs/JsonResultPayload"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Payload"
         }
       },
       "required": [

--- a/clients/core-state/src/core-state.test.ts
+++ b/clients/core-state/src/core-state.test.ts
@@ -169,6 +169,34 @@ describe('core state projection', () => {
     expect(state.transcript[0]?.toolResponse).toBeUndefined();
   });
 
+  it('carries the typed result payload onto the merged transcript entry', () => {
+    let state = reduceEvent(initialCoreState(), {
+      ...baseEvent(1, 'tool_call'),
+      invocation_id: 'turn',
+      data: {kind: 'tool_call', tool: 'shell', call_id: 'call-1', args: {cmd: 'ls'}},
+    });
+    state = reduceEvent(state, {
+      ...baseEvent(2, 'tool_result'),
+      invocation_id: 'turn',
+      data: {
+        kind: 'tool_result',
+        tool: 'shell',
+        call_id: 'call-1',
+        content: 'file.txt',
+        payload: {kind: 'command', stdout: 'file.txt', stderr: '', exit_code: 0, duration: 0.1},
+      },
+    });
+
+    expect(state.transcript).toHaveLength(1);
+    expect(state.transcript[0]?.toolResult?.payload).toEqual({
+      kind: 'command',
+      stdout: 'file.txt',
+      stderr: '',
+      exit_code: 0,
+      duration: 0.1,
+    });
+  });
+
   it('keeps chat-agent events out of the experiment transcript', () => {
     const chat = {
       ...outputEvent(1, 'answer'),

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -48,6 +48,8 @@ export interface BenchmarkRecord {
 
 type RunEventData = NonNullable<RunEvent['data']>;
 export type TypedToolResult = Extract<RunEventData, {kind?: 'tool_result'}>;
+/** Typed structure a producer preserved alongside the raw tool-result text. */
+export type ToolResultPayload = NonNullable<TypedToolResult['payload']>;
 
 export interface TranscriptEntry {
   id: string;

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1272,7 +1272,58 @@ describe('OpenTUI presentation', () => {
 
     const frame = await testRenderer.waitForFrame(value => value.includes('2 passed'));
     expect(frame).toContain('→ Bash(command="pytest")');
+    expect(frame).toContain('← 2 passed');
     expect(frame.match(/╭/g)).toHaveLength(5);
+  });
+
+  it('collapses, prettifies, and expands long JSON tool responses', async () => {
+    const response = JSON.stringify(
+      Object.fromEntries(Array.from({length: 12}, (_, index) => [`field_${index}`, index])),
+    );
+    const testRenderer = await createTestRenderer({width: 100, height: 24});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      selectedEntryId: 'tool',
+      core: {
+        ...initialSessionState().core,
+        transcript: [
+          {
+            id: 'tool',
+            kind: 'tool',
+            label: 'implementer · round 1',
+            content: response,
+            toolName: 'Read',
+            toolArguments: {path: 'run-state.json'},
+            toolResult: {kind: 'tool_result', tool: 'Read', content: response},
+          },
+        ],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const collapsed = await testRenderer.waitForFrame(value =>
+      value.includes('Show full response'),
+    );
+    expect(collapsed).toContain('← {');
+    expect(collapsed).toContain('"field_0": 0');
+    expect(collapsed).not.toContain('"field_11": 11');
+
+    testRenderer.mockInput.pressEnter();
+    const expanded = await testRenderer.waitForFrame(value => value.includes('"field_11": 11'));
+    expect(expanded).toContain('click or Enter to collapse response');
+
+    // Expanding scrolls the card's tail into view, so click the collapse hint,
+    // which the previous assertion proves is on screen.
+    const hint = 'click or Enter to collapse response';
+    const lines = expanded.split('\n');
+    const row = lines.findIndex(line => line.includes(hint));
+    const column = (lines[row]?.indexOf(hint) ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
+    const recollapsed = await testRenderer.waitForFrame(value =>
+      value.includes('Show full response'),
+    );
+    expect(recollapsed).not.toContain('"field_11": 11');
   });
 
   it('collapses prompts and expands the latest prompt with Ctrl+P', async () => {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1276,6 +1276,45 @@ describe('OpenTUI presentation', () => {
     expect(frame.match(/╭/g)).toHaveLength(5);
   });
 
+  it('renders a typed command payload with labeled stderr and exit code', async () => {
+    const testRenderer = await createTestRenderer({width: 80, height: 16});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      core: {
+        ...initialSessionState().core,
+        transcript: [
+          {
+            id: 'tool',
+            kind: 'tool',
+            label: 'implementer · round 1',
+            content: '1 failed',
+            toolName: 'Bash',
+            toolArguments: {command: 'pytest'},
+            toolResult: {
+              kind: 'tool_result',
+              tool: 'Bash',
+              content: '1 failed',
+              payload: {
+                kind: 'command',
+                stdout: '1 failed',
+                stderr: 'assertion error',
+                exit_code: 1,
+                duration: 0.4,
+              },
+            },
+          },
+        ],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+
+    const frame = await testRenderer.waitForFrame(value => value.includes('exit code: 1'));
+    expect(frame).toContain('← 1 failed');
+    expect(frame).toContain('stderr:');
+    expect(frame).toContain('assertion error');
+  });
+
   it('collapses, prettifies, and expands long JSON tool responses', async () => {
     const response = JSON.stringify(
       Object.fromEntries(Array.from({length: 12}, (_, index) => [`field_${index}`, index])),

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -379,6 +379,7 @@ export function createOpenTuiApp(
       commandInput.isEmpty() && chatPane.isComposerEmpty() && chat.isComposerEmpty(),
     closeChat: () => controller.closeChat(),
     toggleLatestPrompt: () => conversation.toggleLatestPrompt(),
+    toggleSelectedTool: () => conversation.toggleSelectedTool(),
     revealSelectedEntry: () => {
       const card = conversation.selectedCard();
       if (card !== null) viewport.scrollChildIntoView(card.id);

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -27,6 +27,7 @@ export class ConversationView {
   #theme: Theme;
   #markdownStyle: SyntaxStyle;
   readonly #expandedPrompts = new Set<string>();
+  readonly #expandedTools = new Set<string>();
   readonly #selectConversation: (state: SessionState) => ConversationEntry[];
   #emptyContent: string;
   readonly #renderMarkdown: boolean;
@@ -110,6 +111,15 @@ export class ConversationView {
     if (latestPrompt) this.#togglePrompt(latestPrompt.id);
   }
 
+  toggleSelectedTool(): boolean {
+    if (this.#selectedId === null) return false;
+    const entry = this.#selectConversation(this.controller.state).find(
+      candidate => candidate.id === this.#selectedId,
+    );
+    if (entry?.kind !== 'tool') return false;
+    return this.#toggleTool(entry);
+  }
+
   #clear(): void {
     for (const child of [...this.output.getChildren()]) {
       this.output.remove(child);
@@ -171,6 +181,16 @@ export class ConversationView {
     this.#renderConversation(this.#selectConversation(this.controller.state));
   }
 
+  #toggleTool(entry: ConversationEntry): boolean {
+    const response = entry.toolResult?.content ?? entry.toolResponse;
+    if (response === undefined || !toolOutputPreview(response).collapsible) return false;
+    if (this.#expandedTools.has(entry.id)) this.#expandedTools.delete(entry.id);
+    else this.#expandedTools.add(entry.id);
+    this.#renderedConversation = [];
+    this.#renderConversation(this.#selectConversation(this.controller.state));
+    return true;
+  }
+
   #renderEntry(entry: ConversationEntry): BoxRenderable {
     const palette = entryPalette(entry, this.#theme);
     const selected = this.#selectedId === entry.id;
@@ -192,14 +212,18 @@ export class ConversationView {
             onMouseUp: () => {
               this.#onFocusRequest?.();
               if (entry.kind === 'prompt') this.#togglePrompt(entry.id);
-              else this.controller.selectNextEntry(0, entry.id);
+              else {
+                this.controller.selectNextEntry(0, entry.id);
+                if (entry.kind === 'tool') this.#toggleTool(entry);
+              }
             },
           }
-        : entry.kind === 'prompt'
+        : entry.kind === 'prompt' || entry.kind === 'tool'
           ? {
               onMouseUp: () => {
                 this.#onFocusRequest?.();
-                this.#togglePrompt(entry.id);
+                if (entry.kind === 'prompt') this.#togglePrompt(entry.id);
+                else this.#toggleTool(entry);
               },
             }
           : {}),
@@ -235,12 +259,26 @@ export class ConversationView {
         entry.kind === 'prompt'
           ? promptPreview(entry.content, this.#expandedPrompts.has(entry.id))
           : null;
-      const content = prompt
-        ? prompt.content
-        : entry.kind === 'tool' || entry.kind === 'diagnostic' || entry.kind === 'subprocess'
+      const output =
+        !prompt &&
+        (entry.kind === 'tool' || entry.kind === 'diagnostic' || entry.kind === 'subprocess')
           ? toolOutputPreview(entry.content)
-          : entry.content;
+          : null;
+      const content = prompt ? prompt.content : (output?.content ?? entry.content);
       card.add(new TextRenderable(this.renderer, {content, fg: palette.content, width: '100%'}));
+      if (output && output.collapsible) {
+        const hidden =
+          output.hiddenLines > 0
+            ? `${output.hiddenLines} more line${output.hiddenLines === 1 ? '' : 's'}`
+            : `${output.hiddenCharacters} more characters`;
+        card.add(
+          new TextRenderable(this.renderer, {
+            content: `… ${hidden} hidden`,
+            fg: this.#theme.info,
+            width: '100%',
+          }),
+        );
+      }
       if (prompt && (prompt.hiddenLines > 0 || this.#expandedPrompts.has(entry.id))) {
         card.add(
           new TextRenderable(this.renderer, {
@@ -299,14 +337,31 @@ export class ConversationView {
       }),
     );
     if (toolResponse) {
+      const expanded = this.#expandedTools.has(entry.id);
+      const response = toolOutputPreview(toolResponse, expanded);
       card.add(
         new TextRenderable(this.renderer, {
-          content: toolOutputPreview(toolResponse),
+          content: `← ${response.content}`,
           fg: this.#theme.toolResult.foreground,
           bg: this.#theme.toolResult.background,
           width: '100%',
         }),
       );
+      if (response.collapsible) {
+        const hidden =
+          response.hiddenLines > 0
+            ? `${response.hiddenLines} more line${response.hiddenLines === 1 ? '' : 's'}`
+            : `${response.hiddenCharacters} more characters`;
+        card.add(
+          new TextRenderable(this.renderer, {
+            content: expanded
+              ? '▴ click or Enter to collapse response'
+              : `▾ Show full response · ${hidden} · click or Enter`,
+            fg: this.#theme.info,
+            width: '100%',
+          }),
+        );
+      }
     }
   }
 }

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -8,7 +8,7 @@ import {
 import type {SessionController} from '../session-controller.js';
 import type {ConversationEntry, SessionState} from '../session-model.js';
 import {visibleConversation} from '../session-model.js';
-import {promptPreview, toolCallPreview, toolOutputPreview} from './previews.js';
+import {promptPreview, toolCallPreview, toolResultPreview} from './previews.js';
 import {entryPalette} from './styles.js';
 import type {Theme} from './theme.js';
 
@@ -183,7 +183,11 @@ export class ConversationView {
 
   #toggleTool(entry: ConversationEntry): boolean {
     const response = entry.toolResult?.content ?? entry.toolResponse;
-    if (response === undefined || !toolOutputPreview(response).collapsible) return false;
+    if (
+      response === undefined ||
+      !toolResultPreview(response, entry.toolResult?.payload).collapsible
+    )
+      return false;
     if (this.#expandedTools.has(entry.id)) this.#expandedTools.delete(entry.id);
     else this.#expandedTools.add(entry.id);
     this.#renderedConversation = [];
@@ -262,7 +266,7 @@ export class ConversationView {
       const output =
         !prompt &&
         (entry.kind === 'tool' || entry.kind === 'diagnostic' || entry.kind === 'subprocess')
-          ? toolOutputPreview(entry.content)
+          ? toolResultPreview(entry.content, entry.toolResult?.payload)
           : null;
       const content = prompt ? prompt.content : (output?.content ?? entry.content);
       card.add(new TextRenderable(this.renderer, {content, fg: palette.content, width: '100%'}));
@@ -338,7 +342,7 @@ export class ConversationView {
     );
     if (toolResponse) {
       const expanded = this.#expandedTools.has(entry.id);
-      const response = toolOutputPreview(toolResponse, expanded);
+      const response = toolResultPreview(toolResponse, entry.toolResult?.payload, expanded);
       card.add(
         new TextRenderable(this.renderer, {
           content: `← ${response.content}`,

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -8,6 +8,7 @@ export interface KeybindingActions {
   inputIsEmpty(): boolean;
   closeChat(): void;
   toggleLatestPrompt(): void;
+  toggleSelectedTool(): boolean;
   /** Brings the entry the cursor moved to into view. */
   revealSelectedEntry(): void;
   selectNextAgent(): void;
@@ -231,6 +232,16 @@ export function bindKeybindings(
         controller.selectNextEntry(key.name === 'down' ? 1 : -1);
         actions.revealSelectedEntry();
       }
+      key.preventDefault();
+      return;
+    }
+    if (
+      (key.name === 'return' || key.name === 'enter') &&
+      controller.state.roundFocus === 'transcript' &&
+      actions.inputIsEmpty() &&
+      actions.toggleSelectedTool()
+    ) {
+      actions.revealSelectedEntry();
       key.preventDefault();
       return;
     }

--- a/clients/tui/src/ui/previews.test.ts
+++ b/clients/tui/src/ui/previews.test.ts
@@ -1,5 +1,11 @@
 import {describe, expect, it} from 'bun:test';
-import {elapsedLabel, promptPreview, toolCallPreview, toolOutputPreview} from './previews.js';
+import {
+  elapsedLabel,
+  promptPreview,
+  toolCallPreview,
+  toolOutputPreview,
+  toolResultPreview,
+} from './previews.js';
 
 describe('conversation previews', () => {
   it('formats and truncates typed tool arguments without changing the source data', () => {
@@ -54,6 +60,72 @@ describe('conversation previews', () => {
     expect(promptPreview(content, false)).toMatchObject({hiddenLines: 8});
     expect(promptPreview(content, false).content).not.toContain('prompt line 13');
     expect(promptPreview(content, true).content).toContain('prompt line 20');
+  });
+});
+
+describe('typed tool result previews', () => {
+  it('pretty-prints a json payload from the parsed value without re-sniffing', () => {
+    // Python-repr content would defeat the string sniffer; the payload wins.
+    const preview = toolResultPreview("{'rows': [1, 2]}", {
+      kind: 'json',
+      value: {rows: [1, 2]},
+    });
+
+    expect(preview.content).toBe('{\n  "rows": [\n    1,\n    2\n  ]\n}');
+  });
+
+  it('lays out a command payload as stdout, labeled stderr, and exit code', () => {
+    const preview = toolResultPreview('build output\n', {
+      kind: 'command',
+      stdout: 'build output\n',
+      stderr: 'warning: deprecated\n',
+      exit_code: 2,
+      duration: 1.5,
+    });
+
+    expect(preview.content).toBe('build output\nstderr:\nwarning: deprecated\nexit code: 2');
+  });
+
+  it('omits the stderr label and exit-code line when they carry nothing', () => {
+    const preview = toolResultPreview('ok', {
+      kind: 'command',
+      stdout: 'ok',
+      stderr: '',
+      exit_code: null,
+      duration: null,
+    });
+
+    expect(preview.content).toBe('ok');
+  });
+
+  it('falls back to the raw content when a command payload is empty', () => {
+    const preview = toolResultPreview('raw text', {
+      kind: 'command',
+      stdout: '',
+      stderr: '',
+      exit_code: null,
+      duration: null,
+    });
+
+    expect(preview.content).toBe('raw text');
+  });
+
+  it('keeps the string-sniffing fallback for events without a payload', () => {
+    const json = JSON.stringify({field: 'value'});
+
+    expect(toolResultPreview(json, undefined).content).toBe('{\n  "field": "value"\n}');
+    expect(toolResultPreview('plain text', null).content).toBe('plain text');
+  });
+
+  it('collapses long payload-rendered output like the fallback path', () => {
+    const value = Object.fromEntries(Array.from({length: 20}, (_, index) => [`k${index}`, index]));
+
+    const collapsed = toolResultPreview('irrelevant', {kind: 'json', value});
+    const expanded = toolResultPreview('irrelevant', {kind: 'json', value}, true);
+
+    expect(collapsed.collapsible).toBe(true);
+    expect(collapsed.hiddenLines).toBeGreaterThan(0);
+    expect(expanded.content).toContain('"k19": 19');
   });
 });
 

--- a/clients/tui/src/ui/previews.test.ts
+++ b/clients/tui/src/ui/previews.test.ts
@@ -19,10 +19,33 @@ describe('conversation previews', () => {
     const content = Array.from({length: 20}, (_, index) => `line ${index + 1}`).join('\n');
     const preview = toolOutputPreview(content);
 
-    expect(preview).toContain('line 12');
-    expect(preview).not.toContain('line 13');
-    expect(preview).toContain('8 more lines hidden');
+    expect(preview.content).toContain('line 6');
+    expect(preview.content).not.toContain('line 7');
+    expect(preview).toMatchObject({hiddenLines: 14, collapsible: true});
     expect(content).toContain('line 20');
+  });
+
+  it('pretty-prints JSON responses and restores the complete value when expanded', () => {
+    const content = JSON.stringify(
+      Object.fromEntries(Array.from({length: 10}, (_, index) => [`field_${index}`, index])),
+    );
+
+    const collapsed = toolOutputPreview(content);
+    const expanded = toolOutputPreview(content, true);
+
+    expect(collapsed.content).toStartWith('{\n  "field_0": 0,');
+    expect(collapsed.content).not.toContain('"field_9"');
+    expect(collapsed.hiddenLines).toBeGreaterThan(0);
+    expect(expanded.content).toContain('  "field_9": 9\n}');
+    expect(expanded).toMatchObject({hiddenLines: 0, hiddenCharacters: 0, collapsible: true});
+  });
+
+  it('collapses long single-line responses by character count', () => {
+    const content = 'x'.repeat(1_000);
+    const preview = toolOutputPreview(content);
+
+    expect(preview.content).toHaveLength(600);
+    expect(preview).toMatchObject({hiddenLines: 0, hiddenCharacters: 400, collapsible: true});
   });
 
   it('collapses and expands long prompts', () => {

--- a/clients/tui/src/ui/previews.ts
+++ b/clients/tui/src/ui/previews.ts
@@ -1,3 +1,5 @@
+import type {ToolResultPayload} from '@vibesys/core-state';
+
 const MAX_TOOL_OUTPUT_LINES = 6;
 const MAX_TOOL_OUTPUT_CHARACTERS = 600;
 const MAX_PROMPT_LINES = 12;
@@ -28,7 +30,45 @@ export function toolOutputPreview(
   maxLines = MAX_TOOL_OUTPUT_LINES,
   maxCharacters = MAX_TOOL_OUTPUT_CHARACTERS,
 ): CollapsiblePreview {
-  const formatted = formatJsonObject(content);
+  return collapsePreview(formatJsonObject(content), expanded, maxLines, maxCharacters);
+}
+
+/**
+ * Renders a tool result from its typed payload when the backend preserved
+ * one, falling back to the string-sniffing path for older event logs.
+ */
+export function toolResultPreview(
+  content: string,
+  payload: ToolResultPayload | null | undefined,
+  expanded = false,
+): CollapsiblePreview {
+  if (payload == null) return toolOutputPreview(content, expanded);
+  return collapsePreview(
+    formatToolResultPayload(payload, content),
+    expanded,
+    MAX_TOOL_OUTPUT_LINES,
+    MAX_TOOL_OUTPUT_CHARACTERS,
+  );
+}
+
+function formatToolResultPayload(payload: ToolResultPayload, fallback: string): string {
+  if (payload.kind === 'json') return JSON.stringify(payload.value, null, 2);
+  if (payload.kind === 'command') {
+    const sections: string[] = [];
+    if (payload.stdout !== '') sections.push(payload.stdout.replace(/\n+$/, ''));
+    if (payload.stderr !== '') sections.push(`stderr:\n${payload.stderr.replace(/\n+$/, '')}`);
+    if (payload.exit_code != null) sections.push(`exit code: ${payload.exit_code}`);
+    if (sections.length > 0) return sections.join('\n');
+  }
+  return fallback;
+}
+
+function collapsePreview(
+  formatted: string,
+  expanded: boolean,
+  maxLines: number,
+  maxCharacters: number,
+): CollapsiblePreview {
   const lines = formatted.split('\n');
   if (lines.at(-1) === '') lines.pop();
   const full = lines.join('\n');

--- a/clients/tui/src/ui/previews.ts
+++ b/clients/tui/src/ui/previews.ts
@@ -1,6 +1,14 @@
-const MAX_TOOL_OUTPUT_LINES = 12;
+const MAX_TOOL_OUTPUT_LINES = 6;
+const MAX_TOOL_OUTPUT_CHARACTERS = 600;
 const MAX_PROMPT_LINES = 12;
 const MAX_TOOL_ARG_LENGTH = 80;
+
+export interface CollapsiblePreview {
+  content: string;
+  hiddenLines: number;
+  hiddenCharacters: number;
+  collapsible: boolean;
+}
 
 export function toolCallPreview(tool: string, args: Record<string, unknown>): string {
   const parts = Object.entries(args).map(([key, value]) => {
@@ -14,13 +22,42 @@ export function toolCallPreview(tool: string, args: Record<string, unknown>): st
   return `→ ${tool}(${parts.join(', ')})\n`;
 }
 
-export function toolOutputPreview(content: string, maxLines = MAX_TOOL_OUTPUT_LINES): string {
-  const lines = content.split('\n');
-  const hasTrailingNewline = lines.at(-1) === '';
-  if (hasTrailingNewline) lines.pop();
-  if (lines.length <= maxLines) return content;
-  const hidden = lines.length - maxLines;
-  return `${lines.slice(0, maxLines).join('\n')}\n… ${hidden} more line${hidden === 1 ? '' : 's'} hidden`;
+export function toolOutputPreview(
+  content: string,
+  expanded = false,
+  maxLines = MAX_TOOL_OUTPUT_LINES,
+  maxCharacters = MAX_TOOL_OUTPUT_CHARACTERS,
+): CollapsiblePreview {
+  const formatted = formatJsonObject(content);
+  const lines = formatted.split('\n');
+  if (lines.at(-1) === '') lines.pop();
+  const full = lines.join('\n');
+  const collapsible = lines.length > maxLines || full.length > maxCharacters;
+  if (expanded || !collapsible) {
+    return {content: full, hiddenLines: 0, hiddenCharacters: 0, collapsible};
+  }
+
+  const lineLimited = lines.slice(0, maxLines).join('\n');
+  const preview = lineLimited.slice(0, maxCharacters).trimEnd();
+  const visibleLines = preview === '' ? 0 : preview.split('\n').length;
+  return {
+    content: preview,
+    hiddenLines: Math.max(0, lines.length - visibleLines),
+    hiddenCharacters: Math.max(0, full.length - preview.length),
+    collapsible,
+  };
+}
+
+function formatJsonObject(content: string): string {
+  const trimmed = content.trim();
+  if (!(trimmed.startsWith('{') || trimmed.startsWith('['))) return content;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed === null || typeof parsed !== 'object') return content;
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return content;
+  }
 }
 
 export function promptPreview(

--- a/src/vibesys/agents/callbacks.py
+++ b/src/vibesys/agents/callbacks.py
@@ -13,7 +13,7 @@ from vibesys.agents.progress import AgentProgress
 from vibesys.agents.todos import todos_from_tool_call
 from vibesys.render.format import format_status_prefix
 from vibesys.render.sink import output_sink
-from vibesys.server.events import AgentOutputChannel, AgentStatusData
+from vibesys.server.events import AgentOutputChannel, AgentStatusData, ToolResultPayload
 
 ContextWindowLookup = Callable[[str | None], int | None]
 """Resolves a model name to its context window size in tokens.
@@ -339,6 +339,7 @@ class AgentLogger(BaseCallbackHandler):
         *,
         call_id: str | None = None,
         is_error: bool = False,
+        payload: ToolResultPayload | None = None,
     ) -> None:
         full_text = str(content)
         pending = self._pending_tool_calls[name]
@@ -355,6 +356,7 @@ class AgentLogger(BaseCallbackHandler):
             full_text,
             call_id=resolved_call_id,
             is_error=is_error,
+            payload=payload,
             agent_kind=self._agent_kind,
             round_label=self._round_label,
             invocation_id=self._invocation_id,
@@ -413,17 +415,19 @@ class AgentLogger(BaseCallbackHandler):
             normalized = {"args": str(args)}
         self.log_tool_call(tool, normalized)
 
-    def on_tool_result(  # noqa: D102  # tracked: #288
+    def on_tool_result(  # noqa: D102, PLR0913  # tracked: #288
         self,
         tool: str,
         stdout: str = "",
         stderr: str = "",
         exit_code: int | None = None,
         duration: float | None = None,  # noqa: ARG002 - protocol parity
+        *,
+        payload: ToolResultPayload | None = None,
     ) -> None:
         is_error = bool(stderr) or (exit_code not in (None, 0))
         content = stdout or stderr
-        self.log_tool_result(tool, content, is_error=is_error)
+        self.log_tool_result(tool, content, is_error=is_error, payload=payload)
 
     def on_usage(self, usage: dict[str, Any]) -> None:  # noqa: D102  # tracked: #288
         self.update_usage(usage)
@@ -481,9 +485,10 @@ class AgentLogger(BaseCallbackHandler):
         content: str,
         *,
         is_error: bool = False,
+        payload: ToolResultPayload | None = None,
     ) -> None:
         """Emit a tool result the same way ``on_tool_end`` does."""
-        self._emit_tool_result(name, content, is_error=is_error)
+        self._emit_tool_result(name, content, is_error=is_error, payload=payload)
 
     def _publish(
         self,

--- a/src/vibesys/agents/client.py
+++ b/src/vibesys/agents/client.py
@@ -32,6 +32,7 @@ from vibesys.agents.contracts import (
     MCPServerSpec,
     SessionDisposition,
 )
+from vibesys.server.events import CommandResultPayload, JsonResultPayload
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Mapping
@@ -89,12 +90,18 @@ class _LoggerObserver:
         elif event.kind is AgentEventKind.TOOL_RESULT:
             exit_code = event.payload.get("exit_code")
             duration = event.payload.get("duration")
+            result_payload = event.payload.get("result_payload")
             self._logger.on_tool_result(
                 str(event.payload.get("tool", "unknown")),
                 stdout=str(event.payload.get("stdout", event.text or "")),
                 stderr=str(event.payload.get("stderr", "")),
                 exit_code=exit_code if isinstance(exit_code, int) else None,
                 duration=float(duration) if isinstance(duration, (int, float)) else None,
+                payload=(
+                    result_payload
+                    if isinstance(result_payload, (CommandResultPayload, JsonResultPayload))
+                    else None
+                ),
             )
         elif event.kind is AgentEventKind.USAGE and event.usage is not None:
             self._logger.update_usage(_usage_dict(event.usage))

--- a/src/vibesys/agents/drivers/agentshim.py
+++ b/src/vibesys/agents/drivers/agentshim.py
@@ -29,6 +29,7 @@ from vibesys.agents.contracts import (
 )
 from vibesys.agents.docker_executor import DockerCommandExecutor
 from vibesys.agents.host_resource_declarations import declare_agent_host_resources
+from vibesys.server.events import CommandResultPayload
 from vs_sandbox import build_host_sandbox
 
 AGENTSHIM_CAPABILITIES = AgentCapabilities(
@@ -157,6 +158,12 @@ class _AgentShimEventHandler:
                     "stderr": stderr,
                     "exit_code": exit_code,
                     "duration": duration,
+                    "result_payload": CommandResultPayload(
+                        stdout=stdout,
+                        stderr=stderr,
+                        exit_code=exit_code,
+                        duration=duration,
+                    ),
                 },
             )
         )

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -44,6 +44,7 @@ from vibesys.agents.omnigent.providers import (
     OmnigentExecutorSpec,
     supported_providers,
 )
+from vibesys.server.events import CommandResultPayload, JsonResultPayload, ToolResultPayload
 from vs_sandbox import HostResourceContext
 
 if TYPE_CHECKING:
@@ -351,6 +352,28 @@ def _emit(observer: AgentObserver | None, event: AgentEvent) -> None:
         observer.on_event(event)
 
 
+def _tool_result_payload(
+    result: Any,  # noqa: ANN401
+    error: str | None,
+    duration: float,
+) -> ToolResultPayload:
+    """Map the structure Omnigent actually reported, never guessing.
+
+    A dict or list result is preserved as parsed JSON (coerced through
+    ``json.dumps`` so the event always serializes); anything else keeps the
+    command shape the flattened ``stdout``/``stderr`` strings already carry.
+    """
+    if isinstance(result, (dict, list)):
+        value = json.loads(json.dumps(result, default=repr))
+        return JsonResultPayload(value=value)
+    return CommandResultPayload(
+        stdout=str(result) if result is not None else "",
+        stderr=str(error) if error is not None else "",
+        exit_code=None,
+        duration=duration,
+    )
+
+
 async def _drive_turn(
     executor: Any,  # noqa: ANN401
     *,
@@ -397,6 +420,7 @@ async def _drive_turn(
                 ),
             )
         elif isinstance(event, ToolCallComplete):
+            duration = event.duration_ms / 1000
             _emit(
                 observer,
                 AgentEvent(
@@ -406,8 +430,9 @@ async def _drive_turn(
                         "stdout": str(event.result) if event.result is not None else "",
                         "stderr": str(event.error) if event.error is not None else "",
                         "exit_code": None,
-                        "duration": event.duration_ms / 1000,
+                        "duration": duration,
                         "status": getattr(event.status, "value", str(event.status)),
+                        "result_payload": _tool_result_payload(event.result, event.error, duration),
                     },
                 ),
             )

--- a/src/vibesys/render/sink.py
+++ b/src/vibesys/render/sink.py
@@ -27,9 +27,11 @@ from vibesys.server.events import (
     TodoUpdateData,
     ToolCallData,
     ToolResultData,
+    ToolResultPayload,
     UsageUpdateData,
     make_event,
 )
+from vibesys.server.tool_payloads import classify_tool_result
 
 EventHandler = Callable[[RunEvent], None]
 
@@ -105,13 +107,24 @@ class OutputSink:
         *,
         call_id: str | None = None,
         is_error: bool = False,
+        payload: ToolResultPayload | None = None,
         agent_kind: str | None = None,
         round_label: str | None = None,
         invocation_id: str | None = None,
     ) -> None:
+        # A producer that received real structure pre-empts the classifier's
+        # best-effort guess over the flattened text.
+        if payload is None:
+            payload = classify_tool_result(content)
         self._emit(
             EventType.TOOL_RESULT,
-            ToolResultData(tool=tool, call_id=call_id, content=content, is_error=is_error),
+            ToolResultData(
+                tool=tool,
+                call_id=call_id,
+                content=content,
+                is_error=is_error,
+                payload=payload,
+            ),
             agent_kind=agent_kind,
             round_label=round_label,
             invocation_id=invocation_id,

--- a/src/vibesys/server/events.py
+++ b/src/vibesys/server/events.py
@@ -187,12 +187,40 @@ class ToolCallData(BaseModel):  # noqa: D101  # tracked: #288
     status: AgentStatusData | None = None
 
 
+class CommandResultPayload(BaseModel):
+    """Structured result of a command-style tool execution."""
+
+    kind: Literal["command"] = "command"
+    stdout: str
+    stderr: str
+    exit_code: int | None = None
+    duration: float | None = None
+    """Wall-clock execution time in seconds."""
+
+
+class JsonResultPayload(BaseModel):
+    """A tool result that is a JSON object or array, already parsed."""
+
+    kind: Literal["json"] = "json"
+    value: dict[str, Any] | list[Any]
+
+
+ToolResultPayload = Annotated[
+    CommandResultPayload | JsonResultPayload,
+    Field(discriminator="kind"),
+]
+"""Typed structure a producer preserved alongside the raw result text."""
+
+
 class ToolResultData(BaseModel):  # noqa: D101  # tracked: #288
     kind: Literal["tool_result"] = "tool_result"
     tool: str
     call_id: str | None = None
     content: str
     is_error: bool = False
+    # ``content`` stays the raw, always-present text (fidelity, logs, replay).
+    # Frontends render ``payload`` when present and fall back to ``content``.
+    payload: ToolResultPayload | None = None
 
 
 class TodoItemData(BaseModel):  # noqa: D101  # tracked: #288

--- a/src/vibesys/server/tool_payloads.py
+++ b/src/vibesys/server/tool_payloads.py
@@ -1,0 +1,30 @@
+"""Best-effort classification of raw tool-result text into typed payloads.
+
+Producers that received real structure attach a typed payload themselves;
+this module is the ONLY place allowed to guess structure from flattened
+text, and it guesses conservatively: strict JSON, objects and arrays only.
+"""
+
+from __future__ import annotations
+
+import json
+
+from vibesys.server.events import JsonResultPayload, ToolResultPayload
+
+
+def classify_tool_result(content: str) -> ToolResultPayload | None:
+    """Return a typed payload for *content* when it is a JSON object or array.
+
+    Scalars, text with trailing garbage, and anything that fails strict
+    parsing stay unclassified so the raw text renders unchanged.
+    """
+    trimmed = content.strip()
+    if not trimmed.startswith(("{", "[")):
+        return None
+    try:
+        value = json.loads(trimmed)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(value, (dict, list)):
+        return None
+    return JsonResultPayload(value=value)

--- a/tests/agents/drivers/test_agentshim_driver.py
+++ b/tests/agents/drivers/test_agentshim_driver.py
@@ -17,6 +17,7 @@ from vibesys.agents.contracts import (
     MCPServerSpec,
 )
 from vibesys.agents.drivers import agentshim as subject
+from vibesys.server.events import CommandResultPayload
 from vs_sandbox import ProjectPathPolicy
 
 if TYPE_CHECKING:
@@ -56,6 +57,7 @@ class _FakeAgent:
         self.output_schema_paths: list[str | None] = []
         self.reasoning_effort: str | None = None
         self.error: BaseException | None = None
+        self.tool_result_events: list[dict[str, Any]] = []
         self._last_session = SimpleNamespace(
             final_usage={"input_tokens": 12, "output_tokens": 3},
             total_cost_usd=0.25,
@@ -86,6 +88,8 @@ class _FakeAgent:
         assert self.event_handler is not None
         self.generate_calls.append((prompt, cwd, timeout))
         self.event_handler.on_thinking("working")
+        for tool_result in self.tool_result_events:
+            self.event_handler.on_tool_result(**tool_result)
         self.event_handler.on_usage({"input_tokens": 12, "output_tokens": 3})
         if self.error is not None:
             raise self.error
@@ -183,6 +187,35 @@ def test_turn_forwards_prompt_timeout_events_and_usage(
         subject.AgentEventKind.THINKING,
         subject.AgentEventKind.USAGE,
     ]
+
+
+def test_turn_translates_tool_results_into_typed_command_payloads(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    driver = subject.AgentShimDriver(provider="codex")
+    session = driver.create_session(_spec(tmp_path))
+    fake_agent[0].tool_result_events = [
+        {"tool": "shell", "stdout": "out", "stderr": "warn", "exit_code": 3, "duration": 0.7}
+    ]
+    observer = _Observer()
+
+    session.run_turn(AgentTurnRequest(message="Do it"), observer)
+
+    event = next(
+        event for event in observer.events if event.kind is subject.AgentEventKind.TOOL_RESULT
+    )
+    assert event.text == "out"
+    assert event.payload["result_payload"] == CommandResultPayload(
+        stdout="out",
+        stderr="warn",
+        exit_code=3,
+        duration=0.7,
+    )
+    # The flat fields remain for consumers that predate the typed payload.
+    assert event.payload["stdout"] == "out"
+    assert event.payload["stderr"] == "warn"
+    assert event.payload["exit_code"] == 3
+    assert event.payload["duration"] == 0.7
 
 
 def test_independent_sessions_overlap_and_chat_cleanup_does_not_interrupt_optimizer(

--- a/tests/agents/drivers/test_omnigent_driver.py
+++ b/tests/agents/drivers/test_omnigent_driver.py
@@ -39,6 +39,7 @@ from vibesys.agents.drivers.omnigent import (
 )
 from vibesys.agents.omnigent.providers import OMNIGENT_PROVIDER_EXECUTORS
 from vibesys.schemas import JudgeResponse
+from vibesys.server.events import CommandResultPayload, JsonResultPayload
 from vs_sandbox import HostResource, ProjectPathPolicy
 
 omnigent = pytest.importorskip("omnigent")
@@ -459,6 +460,43 @@ def test_turn_normalizes_events_usage_schema_and_session_id(tmp_path: Path) -> N
         "usage",
     ]
     driver.close()
+
+
+def test_tool_call_complete_attaches_typed_result_payloads(tmp_path: Path) -> None:
+    executor = _FakeExecutor(
+        [
+            ToolCallComplete(name="query", result={"rows": [1, 2]}, duration_ms=250),
+            ToolCallComplete(name="list", result=["a", "b"], duration_ms=100),
+            ToolCallComplete(name="shell", result="stdout text", error="boom", duration_ms=500),
+            TurnComplete(response="final"),
+        ]
+    )
+    driver, session = _session(tmp_path, executor)
+    observer = _Observer()
+
+    session.run_turn(AgentTurnRequest("go"), observer)
+    driver.close()
+
+    results = [event.payload for event in observer.events if event.kind.value == "tool_result"]
+    assert [payload["tool"] for payload in results] == ["query", "list", "shell"]
+
+    json_payload = results[0]["result_payload"]
+    assert isinstance(json_payload, JsonResultPayload)
+    assert json_payload.value == {"rows": [1, 2]}
+    # content stays the flattened string even when the payload is typed JSON.
+    assert results[0]["stdout"] == str({"rows": [1, 2]})
+
+    list_payload = results[1]["result_payload"]
+    assert isinstance(list_payload, JsonResultPayload)
+    assert list_payload.value == ["a", "b"]
+
+    command_payload = results[2]["result_payload"]
+    assert command_payload == CommandResultPayload(
+        stdout="stdout text",
+        stderr="boom",
+        exit_code=None,
+        duration=0.5,
+    )
 
 
 def test_turn_complete_response_wins_and_chunks_are_fallback(tmp_path: Path) -> None:

--- a/tests/agents/test_agent_client.py
+++ b/tests/agents/test_agent_client.py
@@ -24,7 +24,12 @@ from vibesys.agents.contracts import (
     SessionDisposition,
 )
 from vibesys.render.sink import output_sink
-from vibesys.server.events import AgentOutputChunkData, EventType
+from vibesys.server.events import (
+    AgentOutputChunkData,
+    CommandResultPayload,
+    EventType,
+    ToolResultData,
+)
 
 
 class _Response(BaseModel):
@@ -186,6 +191,52 @@ def test_invoke_preserves_streamed_text_deltas_and_paragraphs(tmp_path: Path) ->
     ]
     assert assistant_chunks == [*deltas, "\n"]
     assert "Tokens stay together.\n\nNext paragraph.\n" in log.getvalue()
+
+
+def test_invoke_threads_typed_tool_result_payload_to_sink(tmp_path: Path) -> None:
+    payload = CommandResultPayload(stdout="ok", stderr="warn", exit_code=1, duration=0.4)
+    session = _FakeSession(
+        results=[AgentTurnResult("Done")],
+        events=[
+            AgentEvent(
+                AgentEventKind.TOOL_RESULT,
+                payload={
+                    "tool": "shell",
+                    "stdout": "ok",
+                    "stderr": "warn",
+                    "exit_code": 1,
+                    "duration": 0.4,
+                    "result_payload": payload,
+                },
+            ),
+            AgentEvent(AgentEventKind.TOOL_RESULT, payload={"tool": "shim", "stdout": "plain"}),
+        ],
+    )
+    client = AgentClient(_FakeDriver([session]))
+    seen = []
+    unsubscribe = output_sink().subscribe(seen.append)
+    try:
+        client.invoke_text(
+            kind="implementer",
+            workspace=tmp_path,
+            system_prompt="system",
+            user_prompt="user",
+            round_label="round-1",
+        )
+    finally:
+        unsubscribe()
+
+    results = [
+        event.data
+        for event in seen
+        if event.type is EventType.TOOL_RESULT and isinstance(event.data, ToolResultData)
+    ]
+    assert [data.tool for data in results] == ["shell", "shim"]
+    assert results[0].payload == payload
+    assert results[0].content == "ok"
+    # A driver event without typed structure falls back to the classifier,
+    # which leaves plain text unclassified.
+    assert results[1].payload is None
 
 
 def test_invoke_closes_text_before_tool_event(tmp_path: Path) -> None:

--- a/tests/render/test_sink.py
+++ b/tests/render/test_sink.py
@@ -7,7 +7,9 @@ from vibesys.agents.callbacks import AgentLogger
 from vibesys.render.sink import OutputSink
 from vibesys.server.events import (
     AgentOutputChunkData,
+    CommandResultPayload,
     EventType,
+    JsonResultPayload,
     RunEvent,
     TodoItemData,
     TodoUpdateData,
@@ -85,6 +87,28 @@ class TestTypedEmitters:
         assert data.call_id == "call-1"
         assert data.content == "output text"
         assert data.is_error is True
+        assert data.payload is None
+
+    def test_tool_result_classifies_json_content_when_no_payload_given(self):  # noqa: ANN201  # tracked: #288
+        sink = OutputSink()
+        seen, _ = _collect(sink)
+        sink.tool_result("query", '{"count": 3}')
+        data = seen[0].data
+        assert isinstance(data, ToolResultData)
+        assert data.content == '{"count": 3}'
+        assert isinstance(data.payload, JsonResultPayload)
+        assert data.payload.value == {"count": 3}
+
+    def test_tool_result_provided_payload_preempts_classifier(self):  # noqa: ANN201  # tracked: #288
+        sink = OutputSink()
+        seen, _ = _collect(sink)
+        provided = CommandResultPayload(stdout='{"count": 3}', stderr="", exit_code=0, duration=0.2)
+        # JSON-looking content must not be re-guessed when the producer
+        # already attached real structure.
+        sink.tool_result("shell", '{"count": 3}', payload=provided)
+        data = seen[0].data
+        assert isinstance(data, ToolResultData)
+        assert data.payload == provided
 
     def test_todo_update_event(self):  # noqa: ANN201  # tracked: #288
         sink = OutputSink()

--- a/tests/server/test_events.py
+++ b/tests/server/test_events.py
@@ -7,7 +7,9 @@ from vibesys.server.events import (
     AgentOutputChunkData,
     AgentStatusData,
     BenchmarkResultData,
+    CommandResultPayload,
     EventType,
+    JsonResultPayload,
     RoundFinishedData,
     RunEvent,
     TodoItemData,
@@ -50,6 +52,49 @@ class TestNewEventDataRoundTrip:
         restored = _round_trip(event)
         assert isinstance(restored.data, ToolResultData)
         assert restored.data.is_error is True
+        assert restored.data.payload is None
+
+    def test_tool_result_with_command_payload(self):  # noqa: ANN201  # tracked: #288
+        payload = CommandResultPayload(stdout="out", stderr="warn", exit_code=2, duration=1.5)
+        event = make_event(
+            EventType.TOOL_RESULT,
+            data=ToolResultData(tool="shell", content="out", payload=payload),
+        )
+        restored = _round_trip(event)
+        assert isinstance(restored.data, ToolResultData)
+        assert isinstance(restored.data.payload, CommandResultPayload)
+        assert restored.data.payload == payload
+        assert restored.data.content == "out"
+
+    def test_tool_result_with_json_payload(self):  # noqa: ANN201  # tracked: #288
+        payload = JsonResultPayload(value={"rows": [1, 2], "ok": True})
+        event = make_event(
+            EventType.TOOL_RESULT,
+            data=ToolResultData(
+                tool="query", content='{"rows": [1, 2], "ok": true}', payload=payload
+            ),
+        )
+        restored = _round_trip(event)
+        assert isinstance(restored.data, ToolResultData)
+        assert isinstance(restored.data.payload, JsonResultPayload)
+        assert restored.data.payload.value == {"rows": [1, 2], "ok": True}
+
+    def test_tool_result_payload_rejects_unknown_kind(self):  # noqa: ANN201  # tracked: #288
+        with pytest.raises(ValidationError):
+            ToolResultData.model_validate(
+                {"tool": "shell", "content": "out", "payload": {"kind": "mystery"}}
+            )
+
+    def test_json_payload_rejects_scalar_value(self):  # noqa: ANN201  # tracked: #288
+        with pytest.raises(ValidationError):
+            JsonResultPayload(value=42)  # pyright: ignore[reportArgumentType]
+
+    def test_tool_result_without_payload_field_still_validates(self):  # noqa: ANN201  # tracked: #288
+        # Old event logs predate the payload field and must keep replaying.
+        restored = ToolResultData.model_validate(
+            {"kind": "tool_result", "tool": "t", "content": "c"}
+        )
+        assert restored.payload is None
 
     def test_todo_update(self):  # noqa: ANN201  # tracked: #288
         event = make_event(

--- a/tests/server/test_tool_payloads.py
+++ b/tests/server/test_tool_payloads.py
@@ -1,0 +1,36 @@
+"""Tests for the best-effort tool-result classifier."""
+
+import pytest
+
+from vibesys.server.events import JsonResultPayload
+from vibesys.server.tool_payloads import classify_tool_result
+
+
+class TestClassifyToolResult:
+    def test_json_object_is_classified_with_parsed_value(self) -> None:
+        payload = classify_tool_result('{"metric": "throughput", "value": 2400}')
+        assert isinstance(payload, JsonResultPayload)
+        assert payload.value == {"metric": "throughput", "value": 2400}
+
+    def test_json_array_is_classified_despite_surrounding_whitespace(self) -> None:
+        payload = classify_tool_result('  \n [1, {"a": true}, null] \n')
+        assert isinstance(payload, JsonResultPayload)
+        assert payload.value == [1, {"a": True}, None]
+
+    @pytest.mark.parametrize("content", ["42", '"text"', "null", "true"])
+    def test_scalar_json_is_not_classified(self, content: str) -> None:
+        assert classify_tool_result(content) is None
+
+    @pytest.mark.parametrize(
+        "content",
+        ['{"a": 1} trailing text', "[1, 2] and more", '{"a": 1}{"b": 2}'],
+    )
+    def test_trailing_garbage_is_not_classified(self, content: str) -> None:
+        assert classify_tool_result(content) is None
+
+    @pytest.mark.parametrize(
+        "content",
+        ["plain command output", "{not json", "[broken", "", "   \n\t "],
+    )
+    def test_plain_malformed_and_empty_text_is_not_classified(self, content: str) -> None:
+        assert classify_tool_result(content) is None


### PR DESCRIPTION
Supersedes #452, which GitHub auto-closed when its stacked base branch (`vic/hypothesis-detail-drilldown`, merged as #451) was deleted. Identical content; see #452 for the full description and verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)