### PR TITLE
fix(tui): update hypothesis scope label tests for two-step drilldown

### DIFF
--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -353,9 +353,12 @@ describe('hypothesis scope label', () => {
       },
     ]);
 
-    const opened = enterExperimentDrilldown(state);
+    const opened = enterExperimentRound(state, 1);
 
-    expect(opened.hypothesisScope).toMatchObject({id: 'H-01', label: 'Batch decode requests · r1'});
+    expect(opened?.hypothesisScope).toMatchObject({
+      id: 'H-01',
+      label: 'Batch decode requests · r1',
+    });
   });
 
   it('falls back to the hypothesis id when there is no title', () => {
@@ -371,9 +374,9 @@ describe('hypothesis scope label', () => {
       },
     ]);
 
-    const opened = enterExperimentDrilldown(state);
+    const opened = enterExperimentRound(state, 1);
 
-    expect(opened.hypothesisScope).toMatchObject({id: 'H-01', label: 'H-01 · r1'});
+    expect(opened?.hypothesisScope).toMatchObject({id: 'H-01', label: 'H-01 · r1'});
   });
 });
 


### PR DESCRIPTION
## Problem

`origin/main` has two deterministically failing tests in
`clients/tui/src/session-model.test.ts` (`hypothesis scope label`), even
though each of the PRs that landed recently passed CI on its own.

Main merged, in sequence: #451 (hypothesis detail drilldown), #457 (typed
payloads), #454 (runtime badges), #453 (hypothesis titles), #455 (chat
threads), #449 (theme preview). #451 and #453 conflict semantically:

- #451 changed `enterExperimentDrilldown` from a single jump straight into
  `hypothesisScope` into a two-step navigation: index -> hypothesis summary
  (`hypothesisDetail`) -> round trajectory (`hypothesisScope`), via
  `openHypothesisDetail`.
- #453's `hypothesis scope label` tests were written against the old,
  pre-drilldown behavior: they call `enterExperimentDrilldown(state)` once
  from the index and assert `opened.hypothesisScope` directly.

Neither PR's test suite could see this: #451 had no titled hypotheses to
assert labels on, and #453 was written before the drilldown's two-step
navigation existed. Once merged together, a single `enterExperimentDrilldown`
call now only opens the hypothesis summary (setting `hypothesisDetail`), so
`opened.hypothesisScope` is `null` and `toMatchObject` fails with "received
value must be a non-null object".

(The task that motivated this also flagged a suspected stale `--theme
monokai` launcher fixture. That does not reproduce: `--theme monokai` is
still correctly rejected as unknown in all runs. The only launcher.test.ts
failures observed are the known nondeterministic backend-process-spawn
flakes, unrelated to themes, which are being tracked separately.)

## Solution

Update the two `hypothesis scope label` tests to call
`enterExperimentRound(state, 1)` instead of `enterExperimentDrilldown(state)`.
`enterExperimentRound` is the entry point that actually sets
`hypothesisScope` under the merged (post-#451) drilldown flow — it is what a
second `enterExperimentDrilldown` call (from a summary view) or a direct
round-open action would invoke. This is a test-only fix: the tests were
asserting stale, pre-drilldown behavior, not exercising a real product bug.
`hypothesisLabel()`'s title-preference logic (from #453) is otherwise
untouched and still correct — the tests confirm it now via the code path
that is actually intended to reach `hypothesisScope`.

No production code changed.

### Architecture

Not applicable — test-only change, no cross-boundary or control-flow change.

## Verification

- `clients/tui/src/session-model.test.ts` run 3x standalone: 77/77 pass each
  time (previously 2 deterministic failures each time).
- `clients/tui/src/launcher.test.ts` run 3x standalone: the previously
  suspected `--theme monokai` case passes every run; the only failures seen
  are the pre-existing, known nondeterministic backend-process-spawn flakes
  (a separate deflake effort is tracked for those), reproduced both with and
  without a synced `uv` Python environment.
- `pnpm --dir clients/tui test`: 410/410 pass (18 files), 0 fail.
- `pnpm --dir clients/tui check`: passes (tsc, no errors).
- `pnpm check:format:ts`: passes (63 files checked, no fixes needed).

### Correctness properties

- `enterExperimentDrilldown` still advances hypothesis navigation exactly
  one level per call (index -> summary -> round trajectory), per #451's
  intended design; unchanged by this PR.
- `hypothesisLabel()` still prefers `entry.title` over `entry.hypothesis_id`
  when a title is present, and falls back to the id otherwise, per #453;
  unchanged by this PR.
- `hypothesisScope` is only non-null once a round trajectory is actually
  entered (via `enterExperimentRound` or `enterUnownedExperimentRound`), not
  merely after opening a hypothesis summary.

### Testing

```
cd clients/tui
bun test src/session-model.test.ts   # x3, 77 pass / 0 fail each run
bun test src/launcher.test.ts        # x3, monokai case passes each run;
                                      # remaining failures are known process-spawn flakes
pnpm --dir clients/tui test          # 410 pass / 0 fail
pnpm --dir clients/tui check         # clean
pnpm check:format:ts                 # clean
```

Note: a related but out-of-scope gap was found while diagnosing this — the
TUI's hypothesis detail summary view (`#renderDetail` in
`clients/tui/src/ui/experiment-log.ts`) never surfaces `entry.title`, even
though `hypothesisLabel()` already prefers it. No test on `main` currently
covers this, so it's left for separate follow-up rather than folded into
this test-fix PR.
