### PR TITLE
fix(server,core-state): carry agent runtime identity through active-execution checkpoints

### DIFF
--- a/clients/backend-client/src/generated/protocol.generated.ts
+++ b/clients/backend-client/src/generated/protocol.generated.ts
@@ -130,6 +130,9 @@ export type Kind = "agent_execution_activity_changed";
 export type Mode1 = "thinking" | "responding" | "tool" | "waiting";
 export type Summary1 = string;
 export type Tool = string | null;
+export type Driver2 = string | null;
+export type Provider3 = string | null;
+export type Model3 = string | null;
 export type ActiveExecutions = ActiveAgentExecution[];
 export type ProtocolVersion14 = 1;
 export type Sequence1 = number;
@@ -206,9 +209,9 @@ export type ThreadTitle = string | null;
 export type Kind2 = "chat_thread_created";
 export type ThreadId3 = string;
 export type Title2 = string;
-export type Driver2 = string;
-export type Provider3 = string;
-export type Model3 = string;
+export type Driver3 = string;
+export type Provider4 = string;
+export type Model4 = string;
 export type CreatedAt = string;
 export type Kind3 = "invocation_started";
 export type SystemPrompt = string;
@@ -220,9 +223,9 @@ export type Stage1 = string;
 export type Attempt1 = number | null;
 export type SystemPrompt1 = string;
 export type UserPrompt1 = string;
-export type Driver3 = string | null;
-export type Provider4 = string | null;
-export type Model4 = string | null;
+export type Driver4 = string | null;
+export type Provider5 = string | null;
+export type Model5 = string | null;
 export type Kind6 = "agent_execution_finished";
 export type Error2 = string | null;
 export type Kind7 = "output";
@@ -302,7 +305,7 @@ export type Todos = TodoItemData[];
 export type Kind24 = "usage_update";
 export type InputTokens1 = number;
 export type ContextWindow1 = number | null;
-export type Model5 = string | null;
+export type Model6 = string | null;
 export type Events = RunEvent[];
 export type Round = number;
 export type PerfMetric1 = number;
@@ -560,6 +563,9 @@ export interface ActiveAgentExecution {
   assignment: Assignment;
   started_at: StartedAt;
   activity: AgentExecutionActivityData;
+  driver?: Driver2;
+  provider?: Provider3;
+  model?: Model3;
 }
 /**
  * Complete current activity for an active agent execution.
@@ -606,9 +612,9 @@ export interface ChatThreadCreatedData {
   kind?: Kind2;
   thread_id: ThreadId3;
   title?: Title2;
-  driver: Driver2;
-  provider: Provider3;
-  model: Model3;
+  driver: Driver3;
+  provider: Provider4;
+  model: Model4;
   created_at: CreatedAt;
   [k: string]: unknown;
 }
@@ -637,9 +643,9 @@ export interface AgentExecutionStartedData {
   system_prompt?: SystemPrompt1;
   user_prompt?: UserPrompt1;
   activity: AgentExecutionActivityData;
-  driver?: Driver3;
-  provider?: Provider4;
-  model?: Model4;
+  driver?: Driver4;
+  provider?: Provider5;
+  model?: Model5;
   [k: string]: unknown;
 }
 /**
@@ -804,7 +810,7 @@ export interface UsageUpdateData {
   kind?: Kind24;
   input_tokens: InputTokens1;
   context_window?: ContextWindow1;
-  model?: Model5;
+  model?: Model6;
   [k: string]: unknown;
 }
 export interface PerformanceRound {

--- a/clients/backend-client/src/generated/protocol.schema.json
+++ b/clients/backend-client/src/generated/protocol.schema.json
@@ -43,6 +43,42 @@
         },
         "activity": {
           "$ref": "#/$defs/AgentExecutionActivityData"
+        },
+        "driver": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Driver"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Provider"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Model"
         }
       },
       "required": [

--- a/clients/core-state/src/core-state.test.ts
+++ b/clients/core-state/src/core-state.test.ts
@@ -145,6 +145,42 @@ describe('core state projection', () => {
     });
   });
 
+  // A round drilldown's activity bar sources a running agent's harness/model
+  // from this checkpoint, not only from the live agent_execution_started
+  // event: the checkpoint replaces the whole activeExecutions record (see
+  // reconcileActiveExecutions), so if it dropped the identity fields, any
+  // event_batch or reconnect would erase a label the live event had just set.
+  it('carries runtime identity through a snapshot checkpoint', () => {
+    const snapshot = {
+      run_id: 'run',
+      status: 'running',
+      sequence: 1,
+      agent_kind: 'judge',
+      round_label: 'round-2-judge',
+      active_executions: [
+        checkpoint('exec-1', {driver: 'agentshim', provider: 'codex', model: 'gpt-5.1-codex-max'}),
+      ],
+    } satisfies RunSnapshot;
+
+    const state = reduceSnapshot(initialCoreState(), snapshot);
+
+    expect(state.activeExecutions['exec-1']).toMatchObject({
+      driver: 'agentshim',
+      provider: 'codex',
+      model: 'gpt-5.1-codex-max',
+    });
+  });
+
+  it('defaults runtime identity to null for a checkpoint that omits it', () => {
+    const state = reconcileActiveExecutions(initialCoreState(), [checkpoint('exec-1')]);
+
+    expect(state.activeExecutions['exec-1']).toMatchObject({
+      driver: null,
+      provider: null,
+      model: null,
+    });
+  });
+
   it('coalesces streamed assistant chunks by invocation', () => {
     let state = initialCoreState();
     state = reduceEvent(state, outputEvent(1, 'hello ', 'turn-1'));
@@ -550,7 +586,10 @@ function startedData(assignment: string): NonNullable<RunEvent['data']> {
   };
 }
 
-function checkpoint(executionId: string): NonNullable<RunSnapshot['active_executions']>[number] {
+function checkpoint(
+  executionId: string,
+  overrides: Partial<NonNullable<RunSnapshot['active_executions']>[number]> = {},
+): NonNullable<RunSnapshot['active_executions']>[number] {
   return {
     execution_id: executionId,
     agent_kind: 'judge',
@@ -565,6 +604,7 @@ function checkpoint(executionId: string): NonNullable<RunSnapshot['active_execut
       summary: 'Reviewing',
       tool: null,
     },
+    ...overrides,
   };
 }
 

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -309,6 +309,9 @@ function activeExecutionsFromCheckpoint(
           summary: execution.activity.summary,
           tool: execution.activity.tool ?? null,
         },
+        driver: execution.driver ?? null,
+        provider: execution.provider ?? null,
+        model: execution.model ?? null,
       },
     ]),
   );

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -2128,6 +2128,58 @@ describe('theming', () => {
     expect(landing).not.toContain('Agents');
   });
 
+  it('shows a round’s agent harness and model inside a hypothesis round drilldown', async () => {
+    // The Agents pane inside a hypothesis round drilldown is the same
+    // AgentMapView the live run uses, driven by the same core.phases replayed
+    // from the full event history, so a completed historical round must
+    // carry its runtime label exactly like a live one does.
+    const testRenderer = await createTestRenderer({width: 120, height: 24});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      core: {
+        ...initialSessionState().core,
+        rounds: [{number: 42, status: 'completed'}],
+        phases: [
+          {
+            kind: 'implementer',
+            status: 'completed',
+            roundNumber: 42,
+            roundLabel: 'round-42-implementer',
+            provider: 'codex',
+            model: 'gpt-5.1-codex-max',
+          },
+        ],
+        transcript: [
+          {
+            id: 'b',
+            kind: 'assistant',
+            label: 'implementer',
+            content: 'grew the block',
+            roundNumber: 42,
+          },
+        ],
+      },
+    });
+    controller.experiments = [
+      logEntry('H-08', 42, 42, {
+        claim: 'increase kv cache block',
+        resolved_outcome: 'proven',
+        rounds: [{round: 42, passed: true, reviewed: true}],
+      }),
+    ];
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    testRenderer.mockInput.pressEnter(); // hypothesis summary
+    await frameAfter(testRenderer);
+    testRenderer.mockInput.pressEnter(); // round trajectory
+    const trajectory = await frameAfter(testRenderer);
+
+    expect(trajectory).toContain('Codex (GPT');
+  });
+
   it('drills from a full hypothesis summary into a round trajectory and back', async () => {
     const testRenderer = await createTestRenderer({width: 120, height: 24});
     const controller = new FakeController({

--- a/src/vibesys/server/protocol.py
+++ b/src/vibesys/server/protocol.py
@@ -126,6 +126,9 @@ class ActiveAgentExecution(ProtocolModel):
     assignment: str
     started_at: datetime
     activity: AgentExecutionActivityData
+    driver: str | None = None
+    provider: str | None = None
+    model: str | None = None
 
 
 class RunSnapshot(ProtocolModel):  # noqa: D101  # tracked: #288

--- a/src/vibesys/server/supervisor.py
+++ b/src/vibesys/server/supervisor.py
@@ -907,6 +907,9 @@ class RunSupervisor:
                 assignment=effective_prompt,
                 started_at=datetime.now(UTC),
                 activity=activity,
+                driver=driver,
+                provider=provider,
+                model=model,
             )
             self.record(
                 EventType.AGENT_EXECUTION_STARTED,

--- a/tests/server/test_agent_execution_lifecycle.py
+++ b/tests/server/test_agent_execution_lifecycle.py
@@ -109,6 +109,52 @@ def test_start_agent_execution_omits_runtime_identity_by_default(tmp_path):  # n
     assert started.data.model is None
 
 
+def test_active_execution_checkpoint_carries_runtime_identity(tmp_path):  # noqa: ANN001, ANN201
+    """The snapshot/checkpoint record must match the live event's identity.
+
+    A TUI reconnecting mid-round, or reconciling a periodic subscription
+    checkpoint, reads this record instead of the agent_execution_started
+    event: if it dropped driver/provider/model, the harness+model label would
+    disappear from any round whose checkpoint arrived after the round's own
+    start event.
+    """
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    supervisor.start_agent_execution(
+        "implementer",
+        "round-1",
+        "work",
+        driver="agentshim",
+        provider="codex",
+        model="gpt-5.1-codex-max",
+    )
+
+    active = supervisor.snapshot().active_executions
+    assert len(active) == 1
+    assert active[0].driver == "agentshim"
+    assert active[0].provider == "codex"
+    assert active[0].model == "gpt-5.1-codex-max"
+
+    _, _, checkpointed = supervisor.subscription_checkpoint(0)
+    assert len(checkpointed) == 1
+    assert checkpointed[0].driver == "agentshim"
+    assert checkpointed[0].provider == "codex"
+    assert checkpointed[0].model == "gpt-5.1-codex-max"
+
+
+def test_active_execution_checkpoint_omits_runtime_identity_by_default(tmp_path):  # noqa: ANN001, ANN201
+    supervisor = RunSupervisor()
+    supervisor.attach(tmp_path)
+
+    supervisor.start_agent_execution("implementer", "round-1", "work")
+
+    active = supervisor.snapshot().active_executions
+    assert active[0].driver is None
+    assert active[0].provider is None
+    assert active[0].model is None
+
+
 def test_activity_tracks_todo_and_parallel_tools(tmp_path):  # noqa: ANN001, ANN201
     supervisor = RunSupervisor()
     supervisor.attach(tmp_path)


### PR DESCRIPTION
## Problem

`ActiveAgentExecution` (`RunSnapshot.active_executions`, and the periodic
`subscription_checkpoint` used for `event_batch` messages) was never
extended with `driver`/`provider`/`model` when `agent_execution_started`
gained those fields. Every checkpoint reconciliation on the frontend fully
replaces `CoreState.activeExecutions` (`reconcileActiveExecutions`), so any
`event_batch` or reconnect silently dropped the harness+model label a live
event had just set. This was most visible for an agent still running
inside a hypothesis round drilldown, whose activity bar sources its label
from this same record: the label would appear correctly on the live event,
then vanish on the next checkpoint.

## Solution

Extend `ActiveAgentExecution` end-to-end with the same
driver/provider/model fields `AgentExecutionStartedData` already carries,
and populate/consume them everywhere that record flows through.

The round-drilldown Agents pane (`AgentMapView`) itself was unaffected by
this bug: its `AgentPhase` data comes from full event replay, which already
preserved the fields. Added a regression test covering the previously
untested combination of `hypothesisScope` with populated phases, to lock
that path in alongside the fix.

### Architecture

- `protocol.py`: add `driver`/`provider`/`model` to `ActiveAgentExecution`.
- `supervisor.py`: populate them in `start_agent_execution`'s
  `ActiveAgentExecution`, mirroring the sibling `AgentExecutionStartedData`
  four lines below.
- Protocol codegen regenerated (`protocol.schema.json`,
  `protocol.generated.ts`) for the extended type.
- `core-state.ts`: map the new checkpoint fields in
  `activeExecutionsFromCheckpoint`.
- This layer stacks on the chat-composer-rework PR (`vic/chat-composer-rework`)
  since the checkpoint plumbing is exercised by chat executions as well as
  round executions.

## Verification

Ran the full validation suite (backend, core-state, TUI) with this commit
applied on top of the chat-composer-rework layer.

### Correctness properties

- `RunSnapshot.active_executions` and `subscription_checkpoint` carry
  `driver`/`provider`/`model` whenever `start_agent_execution` set them.
- `reconcileActiveExecutions` on old snapshots (fields absent) does not
  crash and leaves the label unset rather than erroring, preserving
  backward compatibility with older checkpoints.
- A live `agent_execution_started` label and a subsequent checkpoint
  reconciliation agree on driver/provider/model for the same execution.
- The hypothesis round drilldown's activity bar label persists across an
  `event_batch`/reconnect instead of reverting to blank.

### Testing

- `uv run python -m pytest tests/server tests/test_context.py -q` — 120
  passed
- `uv run ruff check src tests` — all checks passed
- `pnpm --dir clients/core-state test` — 34 passed
- `pnpm --dir clients/tui test` — 435 passed (includes new
  hypothesis-drilldown checkpoint-label regression test)
- `pnpm --dir clients/backend-client generate:protocol` then `git status`
  — no diff (idempotent)
