### PR TITLE
feat(tui): share suggestion/Tab-completion mechanics across input boxes

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -1,5 +1,11 @@
 import {afterEach, describe, expect, it} from 'bun:test';
-import {CliRenderEvents, InputRenderable, rgbToHex, ScrollBoxRenderable} from '@opentui/core';
+import {
+  CliRenderEvents,
+  InputRenderable,
+  rgbToHex,
+  ScrollBoxRenderable,
+  TextareaRenderable,
+} from '@opentui/core';
 import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
 import type {ChatOptions, HypothesisEntry} from '@vibesys/backend-client';
 import {parseChatCommand} from '../commands.js';
@@ -2887,6 +2893,123 @@ describe('theming', () => {
     expect(rows.findIndex(row => row.includes('/model'))).toBeLessThan(
       rows.findIndex(row => row.includes('Message')),
     );
+  });
+
+  it('highlights and navigates the chat composer suggestions like the command bar', async () => {
+    const testRenderer = await createTestRenderer({width: 200, height: 30});
+    const controller = new FakeController(initialSessionState());
+    controller.publish({...controller.state, experimentLog: emptyLog(), layout: chatFocus()});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+
+    // /clear, /model, /resume: the composer's own command set, in that order.
+    await testRenderer.mockInput.typeText('/');
+    const first = await testRenderer.waitForFrame(value => value.includes('[Tab]'));
+    expect(first).toContain('› /clear');
+
+    testRenderer.mockInput.pressArrow('down');
+    const second = await testRenderer.waitForFrame(value => value.includes('› /model'));
+    expect(second).not.toContain('› /clear');
+
+    testRenderer.mockInput.pressArrow('down');
+    const third = await testRenderer.waitForFrame(value => value.includes('› /resume'));
+    expect(third).not.toContain('› /model');
+  });
+
+  it('fills the highlighted chat composer suggestion into the composer with Tab', async () => {
+    const testRenderer = await createTestRenderer({width: 200, height: 30});
+    const controller = new FakeController(initialSessionState());
+    controller.publish({...controller.state, experimentLog: emptyLog(), layout: chatFocus()});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+
+    await testRenderer.mockInput.typeText('/');
+    await testRenderer.waitForFrame(value => value.includes('[Tab]'));
+    testRenderer.mockInput.pressArrow('down');
+    await testRenderer.waitForFrame(value => value.includes('› /model'));
+
+    testRenderer.mockInput.pressKey('TAB');
+    await frameAfter(testRenderer);
+    const editor = testRenderer.renderer.root.findDescendantById('chat-dock-composer-editor');
+    expect(editor).toBeInstanceOf(TextareaRenderable);
+    if (!(editor instanceof TextareaRenderable)) throw new Error('composer editor was missing');
+    expect(editor.plainText).toBe('/model');
+
+    // The highlighted match already equals the typed text, so a second Tab
+    // does not clobber what was just filled in.
+    testRenderer.mockInput.pressKey('TAB');
+    await frameAfter(testRenderer);
+    expect(editor.plainText).toBe('/model');
+  });
+
+  it('leaves the chat composer alone when Tab has no suggestion to complete', async () => {
+    const testRenderer = await createTestRenderer({width: 200, height: 30});
+    const controller = new FakeController(initialSessionState());
+    controller.publish({...controller.state, experimentLog: emptyLog(), layout: chatFocus()});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+
+    await testRenderer.mockInput.typeText('what is running?');
+    testRenderer.mockInput.pressKey('TAB');
+    await frameAfter(testRenderer);
+
+    const editor = testRenderer.renderer.root.findDescendantById('chat-dock-composer-editor');
+    expect(editor).toBeInstanceOf(TextareaRenderable);
+    if (!(editor instanceof TextareaRenderable)) throw new Error('composer editor was missing');
+    expect(editor.plainText).toBe('what is running?');
+    expect(controller.chatSubmissions).toEqual([]);
+  });
+
+  it('dismisses the chat composer suggestion menu once nothing matches', async () => {
+    const testRenderer = await createTestRenderer({width: 200, height: 30});
+    const controller = new FakeController(initialSessionState());
+    controller.publish({...controller.state, experimentLog: emptyLog(), layout: chatFocus()});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+
+    await testRenderer.mockInput.typeText('/');
+    await testRenderer.waitForFrame(value => value.includes('[Tab]'));
+
+    await testRenderer.mockInput.typeText('zz');
+    const frame = await testRenderer.waitForFrame(value => value.includes('/zz'));
+    expect(frame).not.toContain('/clear');
+    expect(frame).not.toContain('/model');
+    expect(frame).not.toContain('/resume');
+
+    // Nothing to complete once the menu is gone: Tab is a no-op.
+    testRenderer.mockInput.pressKey('TAB');
+    await frameAfter(testRenderer);
+    const editor = testRenderer.renderer.root.findDescendantById('chat-dock-composer-editor');
+    expect(editor).toBeInstanceOf(TextareaRenderable);
+    if (!(editor instanceof TextareaRenderable)) throw new Error('composer editor was missing');
+    expect(editor.plainText).toBe('/zz');
+  });
+
+  it('fills the highlighted suggestion into the modal chat composer with Tab', async () => {
+    const testRenderer = await createTestRenderer({width: 90, height: 26});
+    const controller = new FakeController({...initialSessionState(), chatOpen: true});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('Ask a question about'));
+
+    await testRenderer.mockInput.typeText('/');
+    await testRenderer.waitForFrame(value => value.includes('[Tab]'));
+    testRenderer.mockInput.pressArrow('down');
+    await testRenderer.waitForFrame(value => value.includes('› /model'));
+
+    testRenderer.mockInput.pressKey('TAB');
+    await frameAfter(testRenderer);
+    const editor = testRenderer.renderer.root.findDescendantById('chat-modal-composer-editor');
+    expect(editor).toBeInstanceOf(TextareaRenderable);
+    if (!(editor instanceof TextareaRenderable))
+      throw new Error('modal composer editor was missing');
+    expect(editor.plainText).toBe('/model');
+    // Only the modal moved; the docked chat is not on screen to disturb.
+    expect(controller.state.chatOpen).toBe(true);
   });
 
   it('answers unknown composer slash input with the chat help', async () => {

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -385,6 +385,14 @@ export function createOpenTuiApp(
   const unbindKeys = bindKeybindings(renderer, controller, viewport, clipboard, {
     completeInput: () => commandInput.completeSuggestion(),
     navigateSuggestions: direction => commandInput.navigateSuggestions(direction),
+    // Routed to whichever chat presentation is currently on screen: the
+    // modal wins while it is open, otherwise the docked pane.
+    navigateChatSuggestions: direction =>
+      controller.state.chatOpen
+        ? chat.navigateSuggestions(direction)
+        : chatPane.navigateSuggestions(direction),
+    completeChatInput: () =>
+      controller.state.chatOpen ? chat.completeSuggestion() : chatPane.completeSuggestion(),
     // Enter belongs to a pane only when nothing is typed anywhere. Asking which
     // box has the cursor is not enough: a question waiting in the other box is
     // still a question, and Enter must never discard it to open a hypothesis.

--- a/clients/tui/src/ui/chat-composer.ts
+++ b/clients/tui/src/ui/chat-composer.ts
@@ -7,6 +7,7 @@ import {
 } from '@opentui/core';
 import {suggestChatSlashCommands} from '../commands.js';
 import type {ChatMenuRow, SessionState} from '../session-model.js';
+import {SuggestionMenu} from './suggestion-menu.js';
 import type {Theme} from './theme.js';
 
 const MIN_EDITOR_ROWS = 1;
@@ -27,13 +28,20 @@ class ChatTextareaRenderable extends TextareaRenderable {
   }
 }
 
-/** Draft shared by the docked and modal presentations of experiment chat. */
+/**
+ * Draft shared by the docked and modal presentations of experiment chat. The
+ * typed-command suggestion menu lives here too, alongside the text it is
+ * derived from, so switching which presentation is on screen never resets or
+ * duplicates the highlighted suggestion (see the multi-parent note on
+ * `ChatComposerView` below).
+ */
 export interface ChatDraft {
   value: string;
+  readonly suggestions: SuggestionMenu;
 }
 
 export function createChatDraft(): ChatDraft {
-  return {value: ''};
+  return {value: '', suggestions: new SuggestionMenu()};
 }
 
 /**
@@ -106,6 +114,7 @@ export class ChatComposerView {
       onContentChange: () => {
         this.draft.value = this.#editor.plainText;
         this.#resize();
+        this.#syncSuggestions();
         // Typing does not go through the controller, so the command
         // suggestions have to follow the draft rather than a state change.
         if (this.#lastState !== null) this.renderMenu(this.#lastState);
@@ -182,15 +191,42 @@ export class ChatComposerView {
         ...rows.map(({row, index}) => menuRowText(row, index === menu.selected, menu.customModels)),
       ];
     }
-    const suggestions = suggestChatSlashCommands(this.draft.value.trim());
-    if (suggestions.length === 0) return null;
-    return suggestions.map(command => `  ${command.name.padEnd(10)} ${command.description}`);
+    if (!this.draft.suggestions.visible) return null;
+    return this.draft.suggestions.renderLines(this.draft.value.trim());
+  }
+
+  /**
+   * Highlights, navigates, and Tab-completes the typed-command suggestions
+   * the same way the command bar does. Callers gate these on the menu
+   * actually showing suggestions (rather than the controller-owned
+   * `ChatMenu`), since both share the one inline list.
+   */
+  navigateSuggestions(direction: 1 | -1): boolean {
+    if (!this.draft.suggestions.navigate(direction)) return false;
+    if (this.#lastState !== null) this.renderMenu(this.#lastState);
+    return true;
+  }
+
+  completeSuggestion(): boolean {
+    const value = this.draft.suggestions.complete(this.draft.value);
+    if (value === null) return false;
+    this.#editor.setText(value);
+    this.#editor.cursorOffset = value.length;
+    return true;
+  }
+
+  /** Recomputes the typed-command matches for the draft's current text. */
+  #syncSuggestions(): void {
+    this.draft.suggestions.setMatches(suggestChatSlashCommands(this.draft.value.trim()));
   }
 
   /** Makes this editor authoritative when its presentation becomes visible. */
   activate(availableWidth: number, focused: boolean, pending: boolean): void {
     this.#availableWidth = Math.max(1, availableWidth);
-    if (this.#editor.plainText !== this.draft.value) this.#editor.setText(this.draft.value);
+    if (this.#editor.plainText !== this.draft.value) {
+      this.#editor.setText(this.draft.value);
+      this.#syncSuggestions();
+    }
     this.setFocused(focused);
     this.#box.title = pending ? ' Message · awaiting agent ' : ' Message ';
     this.#hint.content = pending
@@ -244,6 +280,7 @@ export class ChatComposerView {
     this.draft.value = '';
     this.#editor.clear();
     this.#resize();
+    this.#syncSuggestions();
     this.onSubmit(value);
   }
 }

--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -134,4 +134,12 @@ export class ChatOverlayView {
   isComposerEmpty(): boolean {
     return this.#composer.isEmpty();
   }
+
+  navigateSuggestions(direction: 1 | -1): boolean {
+    return this.#composer.navigateSuggestions(direction);
+  }
+
+  completeSuggestion(): boolean {
+    return this.#composer.completeSuggestion();
+  }
 }

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -143,6 +143,14 @@ export class ChatPaneView {
     this.#composer.focus();
   }
 
+  navigateSuggestions(direction: 1 | -1): boolean {
+    return this.#composer.navigateSuggestions(direction);
+  }
+
+  completeSuggestion(): boolean {
+    return this.#composer.completeSuggestion();
+  }
+
   render(state: SessionState, visible: boolean, width: number): void {
     this.output.visible = visible;
     if (!visible) {

--- a/clients/tui/src/ui/command-input.ts
+++ b/clients/tui/src/ui/command-input.ts
@@ -6,12 +6,8 @@ import {
   SyntaxStyle,
   TextRenderable,
 } from '@opentui/core';
-import {
-  type CommandContext,
-  type SlashCommand,
-  slashCommandRange,
-  suggestSlashCommands,
-} from '../commands.js';
+import {type CommandContext, slashCommandRange, suggestSlashCommands} from '../commands.js';
+import {SuggestionMenu} from './suggestion-menu.js';
 import type {Theme} from './theme.js';
 
 export interface CommandInputPanel {
@@ -31,21 +27,6 @@ export interface CommandInputPanel {
 
 function commandSyntaxStyle(theme: Theme): SyntaxStyle {
   return SyntaxStyle.fromStyles({'slash-command': {fg: theme.accent, bold: true}});
-}
-
-function renderSuggestions(
-  matches: readonly SlashCommand[],
-  selectedIndex: number,
-  value: string,
-): string {
-  return matches
-    .map(
-      (command, index) =>
-        `${index === selectedIndex ? '›' : ' '} ${command.name.padEnd(10)} ${command.description}${
-          index === selectedIndex && command.name !== value ? '  [Tab]' : ''
-        }`,
-    )
-    .join('\n');
 }
 
 export function createCommandInputPanel(
@@ -104,8 +85,7 @@ export function createCommandInputPanel(
     content: '',
   });
   suggestions.add(suggestionList);
-  let matches: readonly SlashCommand[] = [];
-  let selectedIndex = 0;
+  const menu = new SuggestionMenu();
   let context: CommandContext = {};
 
   const updateDecorations = (value: string): void => {
@@ -115,13 +95,11 @@ export function createCommandInputPanel(
       input.addHighlightByCharRange({...range, styleId: commandStyleId});
     }
 
-    matches = suggestSlashCommands(value, context);
-    selectedIndex = 0;
-    const visible = matches.length > 0;
-    suggestions.visible = visible;
-    suggestions.height = matches.length + 2;
-    suggestionList.height = Math.max(1, matches.length);
-    suggestionList.content = renderSuggestions(matches, selectedIndex, value);
+    menu.setMatches(suggestSlashCommands(value, context));
+    suggestions.visible = menu.visible;
+    suggestions.height = menu.matches.length + 2;
+    suggestionList.height = Math.max(1, menu.matches.length);
+    suggestionList.content = menu.renderLines(value).join('\n');
   };
   const submit = (value: string): void => {
     input.value = '';
@@ -141,16 +119,14 @@ export function createCommandInputPanel(
       updateDecorations(input.value);
     },
     completeSuggestion(): boolean {
-      const suggestion = matches[selectedIndex];
-      if (suggestion === undefined || suggestion.name === input.value) return false;
-      input.value = suggestion.name;
-      selectedIndex = 0;
+      const value = menu.complete(input.value);
+      if (value === null) return false;
+      input.value = value;
       return true;
     },
     navigateSuggestions(direction: 1 | -1): boolean {
-      if (matches.length === 0) return false;
-      selectedIndex = (selectedIndex + direction + matches.length) % matches.length;
-      suggestionList.content = renderSuggestions(matches, selectedIndex, input.value);
+      if (!menu.navigate(direction)) return false;
+      suggestionList.content = menu.renderLines(input.value).join('\n');
       return true;
     },
     isEmpty: () => input.value.trim() === '',

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -6,6 +6,10 @@ import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
 export interface KeybindingActions {
   completeInput(): boolean;
   navigateSuggestions(direction: 1 | -1): boolean;
+  /** Navigates the chat composer's own typed-command suggestions, docked or modal. */
+  navigateChatSuggestions(direction: 1 | -1): boolean;
+  /** Tab-completes the chat composer's highlighted typed-command suggestion. */
+  completeChatInput(): boolean;
   inputIsEmpty(): boolean;
   closeChat(): void;
   toggleLatestPrompt(): void;
@@ -110,16 +114,26 @@ export function bindKeybindings(
       key.preventDefault();
       return;
     }
-    if (
-      chatPaneFocused(controller.state) &&
-      (key.name === 'pageup' || key.name === 'pagedown' || key.name === 'escape')
-    ) {
-      if (key.name === 'escape') controller.focusPane('left');
-      else actions.scrollChatPane(key.name === 'pageup' ? -1 : 1);
-      key.preventDefault();
+    if (chatPaneFocused(controller.state)) {
+      if (key.name === 'pageup' || key.name === 'pagedown' || key.name === 'escape') {
+        if (key.name === 'escape') controller.focusPane('left');
+        else actions.scrollChatPane(key.name === 'pageup' ? -1 : 1);
+        key.preventDefault();
+        return;
+      }
+      // The typed-command suggestions take Up/Down/Tab only while they are
+      // showing; otherwise the keys fall through to the editor underneath
+      // (multiline cursor movement, and Tab's ordinary no-op).
+      if (key.name === 'up' || key.name === 'down') {
+        if (actions.navigateChatSuggestions(key.name === 'up' ? -1 : 1)) key.preventDefault();
+        return;
+      }
+      if (key.name === 'tab' && !key.shift) {
+        if (actions.completeChatInput()) key.preventDefault();
+        return;
+      }
       return;
     }
-    if (chatPaneFocused(controller.state)) return;
     if (controller.state.themePicker !== null) {
       if (key.name === 'up') controller.moveThemeSelection(-1);
       else if (key.name === 'down') controller.moveThemeSelection(1);
@@ -138,6 +152,16 @@ export function bindKeybindings(
         if (controller.state.layout.right !== null) controller.closeOverlays();
         else actions.closeChat();
         key.preventDefault();
+        return;
+      }
+      // Same suggestion-menu priority as the docked chat above.
+      if (key.name === 'up' || key.name === 'down') {
+        if (actions.navigateChatSuggestions(key.name === 'up' ? -1 : 1)) key.preventDefault();
+        return;
+      }
+      if (key.name === 'tab' && !key.shift) {
+        if (actions.completeChatInput()) key.preventDefault();
+        return;
       }
       return;
     }

--- a/clients/tui/src/ui/suggestion-menu.ts
+++ b/clients/tui/src/ui/suggestion-menu.ts
@@ -1,0 +1,60 @@
+import type {SlashCommand} from '../commands.js';
+
+/**
+ * Selection, navigation, and Tab-completion mechanics shared by every slash
+ * command suggestion list in the client: the command bar's global commands
+ * and the chat composer's own command set. Owns the current matches and the
+ * highlighted index; callers own when matches are recomputed and how (or
+ * whether) the result is drawn.
+ */
+export class SuggestionMenu {
+  #matches: readonly SlashCommand[] = [];
+  #selectedIndex = 0;
+
+  get matches(): readonly SlashCommand[] {
+    return this.#matches;
+  }
+
+  get selectedIndex(): number {
+    return this.#selectedIndex;
+  }
+
+  get visible(): boolean {
+    return this.#matches.length > 0;
+  }
+
+  /** Replaces the matches for newly typed text. The highlight resets to the first match. */
+  setMatches(matches: readonly SlashCommand[]): void {
+    this.#matches = matches;
+    this.#selectedIndex = 0;
+  }
+
+  /** Moves the highlight. Returns false, and does nothing, when there is nothing to navigate. */
+  navigate(direction: 1 | -1): boolean {
+    if (this.#matches.length === 0) return false;
+    this.#selectedIndex =
+      (this.#selectedIndex + direction + this.#matches.length) % this.#matches.length;
+    return true;
+  }
+
+  /**
+   * The command name to fill in for the highlighted match, or null when
+   * there is no highlighted match or it already equals `value`.
+   */
+  complete(value: string): string | null {
+    const suggestion = this.#matches[this.#selectedIndex];
+    if (suggestion === undefined || suggestion.name === value) return null;
+    this.#selectedIndex = 0;
+    return suggestion.name;
+  }
+
+  /** Render-ready lines, one per match, marking the highlighted row. */
+  renderLines(value: string): string[] {
+    return this.#matches.map(
+      (command, index) =>
+        `${index === this.#selectedIndex ? '›' : ' '} ${command.name.padEnd(10)} ${command.description}${
+          index === this.#selectedIndex && command.name !== value ? '  [Tab]' : ''
+        }`,
+    );
+  }
+}


### PR DESCRIPTION
## Problem

The command bar's suggestion list (selection, arrow navigation,
Tab-completion) was implemented once, inline in `command-input.ts`. The
chat composer rework (`vic/chat-composer-rework`) added its own inline
anchored menus for `/model` and `/resume`, but typed slash commands typed
directly into the chat composer had no highlight, no Up/Down navigation,
and no Tab-completion, unlike the command bar's equivalent UI. Duplicating
the mechanics a second time would drift the two surfaces apart over time.

## Solution

Extract selection, arrow navigation, and Tab-completion into a new shared
`SuggestionMenu` (`clients/tui/src/ui/suggestion-menu.ts`), refactor the
command bar (`command-input.ts`) onto it with zero behavior change, and
wire it into the experiment chat composer so typed slash commands there
highlight, navigate with Up/Down, and Tab-complete exactly like the
command bar. The suggestion state lives on the shared `ChatDraft` so the
docked and modal composer instances never duplicate or reset it.

### Architecture

- `clients/tui/src/ui/suggestion-menu.ts` (new): owns suggestion-list
  state (items, highlighted index, navigation, completion) independent of
  any specific input widget.
- `command-input.ts`: refactored onto `SuggestionMenu`; existing tests are
  unmodified, confirming zero behavior change for the command bar.
- `chat-composer.ts`: gains highlight/Up-Down/Tab completion via the same
  `SuggestionMenu`, layered on top of the inline anchored `/model` and
  `/resume` menus from the chat-composer-rework layer below.
- `chat-overlay.ts` / `chat-pane.ts` / `app.ts` / `keybindings.ts`: minor
  wiring so both the docked and modal composer instances share suggestion
  state via `ChatDraft` instead of each owning their own.
- Depends on both layers below it in this stack (chat composer's slash
  commands) and on `main`'s `command-input.ts` (PR #448, already merged),
  which this layer refactors rather than duplicates.

## Verification

Ran the full validation suite (backend, core-state, TUI, typecheck,
format) with all three stacked layers applied.

### Correctness properties

- Command bar behavior is unchanged: existing `command-input.ts` tests
  pass without modification against the `SuggestionMenu`-backed
  implementation.
- Chat composer slash-command suggestions highlight, navigate with
  Up/Down, and Tab-complete identically to the command bar's mechanics.
- Suggestion state is not duplicated or reset between the docked and
  modal chat composer instances, since both read/write the same
  `ChatDraft`-held state.

### Testing

- `uv run python -m pytest tests/server tests/test_context.py -q` — 120
  passed
- `uv run ruff check src tests` — all checks passed
- `pnpm --dir clients/core-state test` — 34 passed
- `pnpm --dir clients/tui test` — 435 passed, 0 failed (existing
  `command-input.ts` suite passes unmodified against the new
  `SuggestionMenu` backing)
- `pnpm --dir clients/tui check` — typecheck clean
- `pnpm check:format:ts` — clean
