### PR TITLE
fix(cli): narrow TUI rebuild watch set, add progress messages, skip pnpm install

### DIFF
--- a/src/vibesys/cli.py
+++ b/src/vibesys/cli.py
@@ -32,6 +32,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 import tomllib
 from dataclasses import dataclass
 from importlib.resources import files
@@ -42,6 +43,18 @@ _MIN_NODE_MAJOR = 20
 
 #: Files and directories whose changes trigger a source-TUI rebuild, relative to
 #: the repository root. Mirrors the staleness check the old ``./vs`` script used.
+#:
+#: Principle: watch only inputs to the *shipped bundle* (``clients/tui/dist``),
+#: not everything that happens to live nearby. On the Python side that means
+#: the modules that actually shape ``ProtocolDocument`` in
+#: ``vibesys.server.schema`` -- ``events.py``, ``protocol.py``, and
+#: ``diagnostics.py`` -- not all of ``src/vibesys/server``. (Running
+#: ``python -m vibesys.server.schema`` also imports the rest of
+#: ``vibesys.server``'s package ``__init__.py``, and transitively much of
+#: ``vibesys``, purely because Python must execute a package's ``__init__``
+#: before importing one of its submodules; none of those extra modules feed
+#: the Pydantic models that get serialized into the schema, so changes to them
+#: cannot change the generated output and are deliberately excluded here.)
 _REBUILD_WATCH_FILES: tuple[str, ...] = (
     "clients/backend-client/package.json",
     "clients/backend-client/tsconfig.json",
@@ -56,12 +69,18 @@ _REBUILD_WATCH_FILES: tuple[str, ...] = (
     "pnpm-lock.yaml",
     "pnpm-workspace.yaml",
     "biome.json",
+    # Inputs to `generate:protocol` (python -m vibesys.server.schema), which
+    # feeds clients/backend-client's generated types and, downstream, the TUI
+    # bundle. See the principle above for why this is the full set, no more.
+    "src/vibesys/server/schema.py",
+    "src/vibesys/server/events.py",
+    "src/vibesys/server/protocol.py",
+    "src/vibesys/server/diagnostics.py",
 )
 _REBUILD_WATCH_DIRS: tuple[str, ...] = (
     "clients/backend-client/src",
     "clients/core-state/src",
     "clients/tui/src",
-    "src/vibesys/server",
 )
 
 
@@ -206,39 +225,92 @@ def _pnpm_argv() -> list[str] | None:
     return None
 
 
-def _needs_rebuild(root: Path) -> bool:
+def _stale_reason(root: Path) -> str | None:
+    """Return why the source TUI bundle needs a rebuild, or ``None`` if fresh.
+
+    The result is a path relative to ``root`` (or a short description for the
+    missing-output case), meant for a user-facing message. It names the first
+    offending input found while scanning ``_REBUILD_WATCH_FILES`` then
+    ``_REBUILD_WATCH_DIRS`` in order, not necessarily the most-recently-changed
+    one.
+    """
     dist = root / "clients" / "tui" / "dist"
     entry = dist / "index.js"
     launcher = dist / "launcher.js"
     if not entry.is_file() or not launcher.is_file():
-        return True
+        return "clients/tui/dist/index.js (missing)"
     reference = entry.stat().st_mtime
     for rel in _REBUILD_WATCH_FILES:
         path = root / rel
         if path.is_file() and path.stat().st_mtime > reference:
-            return True
+            return rel
     for rel in _REBUILD_WATCH_DIRS:
         base = root / rel
         if not base.is_dir():
             continue
         for path in base.rglob("*"):
             if path.is_file() and path.stat().st_mtime > reference:
-                return True
-    return False
+                return str(path.relative_to(root))
+    return None
 
 
-def _ensure_source_tui_built(root: Path) -> bool:
-    pnpm = _pnpm_argv()
-    if pnpm is None:
-        print(  # noqa: T201  # tracked: #288
-            "vibesys: pnpm is required to build the interactive client. Install pnpm "
-            "or enable Corepack, or run headless with --headless.",
-            file=sys.stderr,
-        )
-        return False
-    print("vibesys: building the interactive client...", file=sys.stderr)  # noqa: T201  # tracked: #288
-    steps = (
+def _needs_rebuild(root: Path) -> bool:
+    return _stale_reason(root) is not None
+
+
+#: Marker written under `node_modules` after a successful `pnpm install`, so
+#: later launches can skip reinstalling when nothing changed. Relative to the
+#: repository root, matching `_REBUILD_WATCH_FILES`/`_REBUILD_WATCH_DIRS`.
+_INSTALL_STAMP_REL = "node_modules/.vibesys-install-stamp"
+
+
+def _needs_install(root: Path) -> bool:
+    """Whether `pnpm install --frozen-lockfile` must run before codegen/build.
+
+    Skipped when `node_modules` already exists and the lockfile is no newer
+    than the stamp file written after the last successful install.
+    """
+    if not (root / "node_modules").is_dir():
+        return True
+    stamp = root / _INSTALL_STAMP_REL
+    if not stamp.is_file():
+        return True
+    lockfile = root / "pnpm-lock.yaml"
+    return lockfile.is_file() and lockfile.stat().st_mtime > stamp.stat().st_mtime
+
+
+def _write_install_stamp(root: Path) -> None:
+    stamp = root / _INSTALL_STAMP_REL
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.touch()
+
+
+def _run_pnpm_install(pnpm: list[str], root: Path) -> bool:
+    print(  # noqa: T201  # tracked: #288
+        "vibesys: installing JS dependencies (pnpm install --frozen-lockfile)...",
+        file=sys.stderr,
+    )
+    started = time.monotonic()
+    result = subprocess.run(  # noqa: S603  # tracked: #288
         [*pnpm, "install", "--frozen-lockfile"],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write("vibesys: failed to install JS dependencies:\n")
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        return False
+    _write_install_stamp(root)
+    elapsed = time.monotonic() - started
+    print(f"vibesys: dependencies installed ({elapsed:.1f}s)", file=sys.stderr)  # noqa: T201  # tracked: #288
+    return True
+
+
+def _run_codegen_and_build(pnpm: list[str], root: Path) -> bool:
+    steps = (
         [*pnpm, "--dir", "clients/backend-client", "generate:protocol"],
         [*pnpm, "build:clients"],
     )
@@ -252,6 +324,31 @@ def _ensure_source_tui_built(root: Path) -> bool:
             sys.stderr.write(result.stderr)
             return False
     return True
+
+
+def _ensure_source_tui_built(root: Path) -> bool:
+    pnpm = _pnpm_argv()
+    if pnpm is None:
+        print(  # noqa: T201  # tracked: #288
+            "vibesys: pnpm is required to build the interactive client. Install pnpm "
+            "or enable Corepack, or run headless with --headless.",
+            file=sys.stderr,
+        )
+        return False
+
+    if _needs_install(root) and not _run_pnpm_install(pnpm, root):
+        return False
+    if _run_codegen_and_build(pnpm, root):
+        return True
+
+    # The build failed even though the install-skip heuristic considered
+    # dependencies fresh (e.g. a partially removed node_modules). Fall back to
+    # a full install and retry once before giving up.
+    print(  # noqa: T201  # tracked: #288
+        "vibesys: build failed; retrying after a full dependency install...",
+        file=sys.stderr,
+    )
+    return _run_pnpm_install(pnpm, root) and _run_codegen_and_build(pnpm, root)
 
 
 def _run_source_tui(root: Path, args: list[str]) -> int:
@@ -271,8 +368,17 @@ def _run_source_tui(root: Path, args: list[str]) -> int:
             file=sys.stderr,
         )
         return 1
-    if _needs_rebuild(root) and not _ensure_source_tui_built(root):
-        return 1
+    if _needs_rebuild(root):
+        reason = _stale_reason(root) or "clients/tui/dist/index.js (missing)"
+        print(  # noqa: T201  # tracked: #288
+            f"vibesys: TUI bundle is stale (changed: {reason}); rebuilding (~30-60s)...",
+            file=sys.stderr,
+        )
+        started = time.monotonic()
+        if not _ensure_source_tui_built(root):
+            return 1
+        elapsed = time.monotonic() - started
+        print(f"vibesys: TUI bundle rebuilt ({elapsed:.1f}s)", file=sys.stderr)  # noqa: T201  # tracked: #288
 
     launcher = root / "clients" / "tui" / "dist" / "launcher.js"
     env = {

--- a/tests/test_cli_launcher.py
+++ b/tests/test_cli_launcher.py
@@ -356,7 +356,9 @@ def test_ensure_built_runs_pnpm_steps(monkeypatch, tmp_path):  # noqa: ANN001, A
     assert [c[1] for c in calls] == ["install", "--dir", "build:clients"]
 
 
-def test_ensure_built_reports_failure(monkeypatch, tmp_path, capsys):  # noqa: ANN001, ANN201  # tracked: #288
+def test_ensure_built_reports_install_failure(monkeypatch, tmp_path, capsys):  # noqa: ANN001, ANN201
+    # tmp_path has no node_modules, so this exercises the install step (not
+    # the codegen/build steps).
     from types import SimpleNamespace  # noqa: PLC0415  # tracked: #288
 
     monkeypatch.setattr(cli, "_pnpm_argv", lambda: ["/usr/bin/pnpm"])
@@ -367,8 +369,114 @@ def test_ensure_built_reports_failure(monkeypatch, tmp_path, capsys):  # noqa: A
     monkeypatch.setattr(cli.subprocess, "run", _run)
     assert cli._ensure_source_tui_built(tmp_path) is False  # noqa: SLF001  # tracked: #288
     err = capsys.readouterr().err
-    assert "failed to build" in err
+    assert "failed to install" in err
     assert "boom-err" in err
+
+
+def test_ensure_built_skips_install_when_fresh(monkeypatch, tmp_path):  # noqa: ANN001, ANN201
+    from types import SimpleNamespace  # noqa: PLC0415  # tracked: #288
+
+    monkeypatch.setattr(cli, "_pnpm_argv", lambda: ["/usr/bin/pnpm"])
+    monkeypatch.setattr(cli, "_needs_install", lambda _root: False)
+    calls: list[list[str]] = []
+
+    def _run(cmd, cwd=None, capture_output=False, text=False, check=False):  # noqa: ANN001, ANN202, ARG001, FBT002  # tracked: #288
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(cli.subprocess, "run", _run)
+    assert cli._ensure_source_tui_built(tmp_path) is True  # noqa: SLF001  # tracked: #288
+    # No "install" call: codegen/build run directly.
+    assert [c[1] for c in calls] == ["--dir", "build:clients"]
+
+
+def test_ensure_built_retries_with_install_after_build_failure(monkeypatch, tmp_path):  # noqa: ANN001, ANN201
+    from types import SimpleNamespace  # noqa: PLC0415  # tracked: #288
+
+    monkeypatch.setattr(cli, "_pnpm_argv", lambda: ["/usr/bin/pnpm"])
+    monkeypatch.setattr(cli, "_needs_install", lambda _root: False)
+    monkeypatch.setattr(cli, "_write_install_stamp", lambda _root: None)
+    calls: list[list[str]] = []
+    state = {"failed_once": False}
+
+    def _run(cmd, cwd=None, capture_output=False, text=False, check=False):  # noqa: ANN001, ANN202, ARG001, FBT002  # tracked: #288
+        calls.append(cmd)
+        if cmd[-1] == "generate:protocol" and not state["failed_once"]:
+            state["failed_once"] = True
+            return SimpleNamespace(returncode=1, stdout="", stderr="stale-deps")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(cli.subprocess, "run", _run)
+    assert cli._ensure_source_tui_built(tmp_path) is True  # noqa: SLF001  # tracked: #288
+    # generate:protocol failed once -> forced install -> generate:protocol and
+    # build:clients both retried and succeeded.
+    assert [c[1] for c in calls] == ["--dir", "install", "--dir", "build:clients"]
+
+
+def test_ensure_built_reports_build_failure_after_retry(monkeypatch, tmp_path, capsys):  # noqa: ANN001, ANN201
+    from types import SimpleNamespace  # noqa: PLC0415  # tracked: #288
+
+    monkeypatch.setattr(cli, "_pnpm_argv", lambda: ["/usr/bin/pnpm"])
+    monkeypatch.setattr(cli, "_needs_install", lambda _root: False)
+    monkeypatch.setattr(cli, "_write_install_stamp", lambda _root: None)
+
+    def _run(cmd, cwd=None, capture_output=False, text=False, check=False):  # noqa: ANN001, ANN202, ARG001, FBT002  # tracked: #288
+        if cmd[-1] == "generate:protocol":
+            return SimpleNamespace(returncode=1, stdout="proto-out", stderr="proto-err")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(cli.subprocess, "run", _run)
+    assert cli._ensure_source_tui_built(tmp_path) is False  # noqa: SLF001  # tracked: #288
+    err = capsys.readouterr().err
+    assert "retrying after a full dependency install" in err
+    assert "failed to build" in err
+    assert "proto-err" in err
+
+
+def test_run_pnpm_install_prints_messages_and_writes_stamp(monkeypatch, tmp_path, capsys):  # noqa: ANN001, ANN201
+    from types import SimpleNamespace  # noqa: PLC0415  # tracked: #288
+
+    def _run(cmd, cwd=None, capture_output=False, text=False, check=False):  # noqa: ANN001, ANN202, ARG001, FBT002  # tracked: #288
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(cli.subprocess, "run", _run)
+
+    assert cli._run_pnpm_install(["/usr/bin/pnpm"], tmp_path) is True  # noqa: SLF001  # tracked: #288
+    err = capsys.readouterr().err
+    assert "installing JS dependencies" in err
+    assert "dependencies installed (" in err
+    assert (tmp_path / cli._INSTALL_STAMP_REL).is_file()  # noqa: SLF001  # tracked: #288
+
+
+def test_needs_install_when_node_modules_missing(tmp_path):  # noqa: ANN001, ANN201
+    assert cli._needs_install(tmp_path) is True  # noqa: SLF001  # tracked: #288
+
+
+def test_needs_install_when_stamp_missing(tmp_path):  # noqa: ANN001, ANN201
+    (tmp_path / "node_modules").mkdir()
+    assert cli._needs_install(tmp_path) is True  # noqa: SLF001  # tracked: #288
+
+
+def test_needs_install_skips_when_stamp_is_fresh(tmp_path):  # noqa: ANN001, ANN201
+    (tmp_path / "node_modules").mkdir()
+    lockfile = tmp_path / "pnpm-lock.yaml"
+    lockfile.write_text("lockfileVersion: 9\n")
+    _set_mtime(lockfile, 1000)
+    cli._write_install_stamp(tmp_path)  # noqa: SLF001  # tracked: #288
+    _set_mtime(tmp_path / cli._INSTALL_STAMP_REL, 2000)  # noqa: SLF001  # tracked: #288
+
+    assert cli._needs_install(tmp_path) is False  # noqa: SLF001  # tracked: #288
+
+
+def test_needs_install_when_lockfile_newer_than_stamp(tmp_path):  # noqa: ANN001, ANN201
+    (tmp_path / "node_modules").mkdir()
+    cli._write_install_stamp(tmp_path)  # noqa: SLF001  # tracked: #288
+    _set_mtime(tmp_path / cli._INSTALL_STAMP_REL, 1000)  # noqa: SLF001  # tracked: #288
+    lockfile = tmp_path / "pnpm-lock.yaml"
+    lockfile.write_text("lockfileVersion: 9\n")
+    _set_mtime(lockfile, 2000)
+
+    assert cli._needs_install(tmp_path) is True  # noqa: SLF001  # tracked: #288
 
 
 def test_bundled_tui_missing_launcher_errors(monkeypatch, tmp_path, capsys):  # noqa: ANN001, ANN201  # tracked: #288
@@ -443,6 +551,101 @@ def test_needs_rebuild_on_core_state_source_change(tmp_path):  # noqa: ANN001, A
     _set_mtime(core_source, 3000)
 
     assert cli._needs_rebuild(root) is True  # noqa: SLF001
+
+
+def test_needs_rebuild_ignores_unrelated_backend_file(tmp_path):  # noqa: ANN001, ANN201
+    # src/vibesys/server no longer feeds `generate:protocol` in its entirety;
+    # a change to an unrelated module in that package must not trigger a
+    # rebuild.
+    root = _make_checkout(tmp_path)
+    dist = root / "clients" / "tui" / "dist"
+    unrelated = root / "src" / "vibesys" / "server" / "inspector.py"
+    unrelated.parent.mkdir(parents=True)
+    unrelated.write_text("# inspector\n")
+    _set_mtime(root / "clients" / "tui" / "src" / "app.ts", 1000)
+    _set_mtime(dist / "index.js", 2000)
+    _set_mtime(dist / "launcher.js", 2000)
+    _set_mtime(unrelated, 3000)
+
+    assert cli._needs_rebuild(root) is False  # noqa: SLF001
+
+
+def test_needs_rebuild_on_protocol_codegen_file(tmp_path):  # noqa: ANN001, ANN201
+    # protocol.py directly shapes the generated JSON schema, so it must still
+    # trigger a rebuild even though src/vibesys/server is no longer watched
+    # wholesale.
+    root = _make_checkout(tmp_path)
+    dist = root / "clients" / "tui" / "dist"
+    protocol = root / "src" / "vibesys" / "server" / "protocol.py"
+    protocol.parent.mkdir(parents=True)
+    protocol.write_text("# protocol\n")
+    _set_mtime(root / "clients" / "tui" / "src" / "app.ts", 1000)
+    _set_mtime(dist / "index.js", 2000)
+    _set_mtime(dist / "launcher.js", 2000)
+    _set_mtime(protocol, 3000)
+
+    assert cli._needs_rebuild(root) is True  # noqa: SLF001
+
+
+def test_stale_reason_reports_first_offending_path(tmp_path):  # noqa: ANN001, ANN201
+    root = _make_checkout(tmp_path)
+    dist = root / "clients" / "tui" / "dist"
+    protocol = root / "src" / "vibesys" / "server" / "protocol.py"
+    protocol.parent.mkdir(parents=True)
+    protocol.write_text("# protocol\n")
+    _set_mtime(root / "clients" / "tui" / "src" / "app.ts", 1000)
+    _set_mtime(dist / "index.js", 2000)
+    _set_mtime(dist / "launcher.js", 2000)
+    _set_mtime(protocol, 3000)
+
+    assert cli._stale_reason(root) == "src/vibesys/server/protocol.py"  # noqa: SLF001
+
+
+def test_stale_reason_none_when_fresh(tmp_path):  # noqa: ANN001, ANN201
+    root = _make_checkout(tmp_path)
+    dist = root / "clients" / "tui" / "dist"
+    _set_mtime(root / "clients" / "tui" / "src" / "app.ts", 1000)
+    _set_mtime(dist / "index.js", 2000)
+    _set_mtime(dist / "launcher.js", 2000)
+
+    assert cli._stale_reason(root) is None  # noqa: SLF001
+
+
+def test_run_source_tui_prints_stale_and_rebuilt_messages(monkeypatch, tmp_path, capsys):  # noqa: ANN001, ANN201
+    monkeypatch.setattr(cli, "_bun_executable", lambda: Path("/usr/bin/bun"))
+    monkeypatch.setattr(cli, "_node_executable", lambda: Path("/usr/bin/node"))
+    monkeypatch.setattr(cli, "_node_major", lambda _node: 20)
+    monkeypatch.setattr(cli, "_needs_rebuild", lambda _root: True)
+    monkeypatch.setattr(cli, "_stale_reason", lambda _root: "src/vibesys/server/protocol.py")
+    monkeypatch.setattr(cli, "_ensure_source_tui_built", lambda _root: True)
+    monkeypatch.setattr(cli.subprocess, "call", lambda *a, **k: 0)  # noqa: ARG005
+
+    rc = cli._run_source_tui(tmp_path, [])  # noqa: SLF001
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "TUI bundle is stale (changed: src/vibesys/server/protocol.py); rebuilding" in err
+    assert "TUI bundle rebuilt (" in err
+
+
+def test_run_source_tui_skips_message_when_fresh(monkeypatch, tmp_path, capsys):  # noqa: ANN001, ANN201
+    monkeypatch.setattr(cli, "_bun_executable", lambda: Path("/usr/bin/bun"))
+    monkeypatch.setattr(cli, "_node_executable", lambda: Path("/usr/bin/node"))
+    monkeypatch.setattr(cli, "_node_major", lambda _node: 20)
+    monkeypatch.setattr(cli, "_needs_rebuild", lambda _root: False)
+
+    message = "must not compute a stale reason for a fresh checkout"
+
+    def _boom(_root):  # noqa: ANN001, ANN202
+        raise AssertionError(message)
+
+    monkeypatch.setattr(cli, "_stale_reason", _boom)
+    monkeypatch.setattr(cli.subprocess, "call", lambda *a, **k: 0)  # noqa: ARG005
+
+    rc = cli._run_source_tui(tmp_path, [])  # noqa: SLF001
+
+    assert rc == 0
+    assert capsys.readouterr().err == ""
 
 
 def test_source_checkout_build_failure_returns_one(monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288


### PR DESCRIPTION
## Problem

`src/vibesys/cli.py`'s `_needs_rebuild()` triggers a full, silent TUI rebuild
(`pnpm install --frozen-lockfile` + `generate:protocol` + `build:clients`)
before the interactive TUI process starts, whenever any file under
`_REBUILD_WATCH_DIRS` is newer than `clients/tui/dist/index.js`. That watch
set included all of `src/vibesys/server`, so any backend churn (git pull,
merge, checkout) forced a multi-second-to-minute rebuild on the next
`vibesys` launch, with no indication of what was happening — it reads as "the
app takes forever to load."

## Solution

Three narrowly-scoped changes to `src/vibesys/cli.py`:

1. **Narrow the staleness inputs.** `_REBUILD_WATCH_DIRS` no longer includes
   `src/vibesys/server` wholesale. Instead, `_REBUILD_WATCH_FILES` now lists
   the exact four files that shape the generated protocol schema:
   `schema.py`, `events.py`, `protocol.py`, `diagnostics.py`. I verified this
   set by reading `schema.py`'s `ProtocolDocument` model and its direct
   imports — it only pulls from `events.py` (`RunEvent`) and `protocol.py`
   (`ProtocolRequest`, `Response`, `RunSnapshot`, `ServerMessage`), and
   `protocol.py`/`events.py` both import `Diagnostic` from `diagnostics.py`.
   No other `vibesys` module is imported by any of the three.

   Note: actually running `python -m vibesys.server.schema` imports far more
   than these four files, because Python must execute
   `vibesys/server/__init__.py` (which imports `inspector`, `registry`,
   `runtime`, `service`, `supervisor`, ...) before it can import the
   `schema` submodule, and that package `__init__` transitively pulls in much
   of `vibesys`. None of that extra code feeds the Pydantic models that
   `ProtocolDocument.model_json_schema()` serializes, so it can't change the
   generated schema and is deliberately excluded from the watch set. This is
   documented in a comment above `_REBUILD_WATCH_FILES`.

2. **Tell the user what's happening.** `_run_source_tui` now prints one
   stderr line before a rebuild starts, naming the first offending path
   (`vibesys: TUI bundle is stale (changed: <path>); rebuilding (~30-60s)...`)
   and one after, with elapsed seconds. The pnpm-install step (when it runs)
   gets the same before/after treatment.

3. **Skip `pnpm install` when possible.** New `_needs_install()` only
   requires install when `node_modules` is missing, or
   `pnpm-lock.yaml` is newer than a stamp file
   (`node_modules/.vibesys-install-stamp`) written after the last successful
   install. Otherwise codegen+build run directly. If codegen+build still
   fails (e.g. a partially-removed `node_modules`), `_ensure_source_tui_built`
   falls back to a full install and retries the build once before reporting
   failure.

### Architecture

No ownership/boundary changes; this is all internal to the CLI launcher's
Tier-2 (source-checkout) build path. Refactored `_ensure_source_tui_built`
into three units: `_run_pnpm_install`, `_run_codegen_and_build`, and the
orchestrating `_ensure_source_tui_built` (install-if-needed, build, retry-once
on failure). Staleness detection is split into `_stale_reason` (returns the
first offending path, or `None`) with `_needs_rebuild` as a thin boolean
wrapper kept for existing call sites/tests.

## Verification

### Correctness properties

- Touching a file outside the narrowed watch set (e.g. any `src/vibesys`
  module other than the four protocol-codegen files) does not trigger a
  rebuild.
- Touching any of `schema.py`/`events.py`/`protocol.py`/`diagnostics.py`, or
  any `clients/{tui,core-state,backend-client}/src` source, or a watched
  config file, still triggers a rebuild (unchanged from before for those
  paths).
- `pnpm install` is skipped when `node_modules` exists and the lockfile is no
  newer than the install stamp; it still runs when `node_modules` is missing,
  the stamp is missing, or the lockfile changed.
- A build failure after a skipped install is retried once with a full
  install before being reported as a failure.
- A rebuild always prints a stderr line before and after, naming the
  triggering path and elapsed time.

### Testing

```
uv run python -m pytest tests/test_cli_launcher.py -q   # 42 passed
uv run ruff check src tests                              # All checks passed
./scripts/check_format.sh                                 # All checks passed
```

Manual: built a throwaway `clients/tui/dist/{index.js,launcher.js}` in this
checkout, then touched `src/vibesys/agents/base.py` (unrelated backend file)
and confirmed `cli._needs_rebuild(root)` stayed `False`; touched
`src/vibesys/server/protocol.py` and confirmed it flipped to `True` with
`_stale_reason(root) == "src/vibesys/server/protocol.py"`. Also drove
`cli._run_source_tui` with `_bun_executable`/`_node_executable`/
`_ensure_source_tui_built` mocked out (did not launch pnpm/bun/the real TUI)
and confirmed the stderr messages read as intended:

```
vibesys: TUI bundle is stale (changed: src/vibesys/server/protocol.py); rebuilding (~30-60s)...
vibesys: TUI bundle rebuilt (0.0s)
```

Did not touch `clients/tui/src/launcher.test.ts` (flaky process tests, out of
scope per the task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)