### PR TITLE
test: type the event helper and fixtures instead of waiving

### DIFF
--- a/tests/server/test_tail_subscription.py
+++ b/tests/server/test_tail_subscription.py
@@ -12,13 +12,14 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TypedDict, Unpack
 
 import pytest
 
 from vibesys.server.events import (
     ChatData,
     ChatThreadCreatedData,
+    EventData,
     EventStore,
     EventType,
     OutputData,
@@ -35,7 +36,16 @@ _TIMESTAMP = datetime(2026, 1, 1, tzinfo=UTC)
 _ROUND_EVERY = 25
 
 
-def _event(sequence: int, event_type: EventType, **fields: Any) -> RunEvent:  # noqa: ANN401  # tracked: #288
+class _EventFields(TypedDict, total=False):
+    """The RunEvent fields these tests vary; the helper fills the rest."""
+
+    data: EventData
+    chat_thread_id: str
+    round_label: str
+    text: str
+
+
+def _event(sequence: int, event_type: EventType, **fields: Unpack[_EventFields]) -> RunEvent:
     return RunEvent(
         sequence=sequence, run_id="persisted-run", timestamp=_TIMESTAMP, type=event_type, **fields
     )

--- a/tests/test_boot_trace.py
+++ b/tests/test_boot_trace.py
@@ -13,7 +13,7 @@ from vibesys import boot_trace
 
 
 @pytest.fixture(autouse=True)
-def _quiet_and_empty(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
+def quiet_and_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     """Start each test with the trace off and nothing left buffered."""
     monkeypatch.delenv(boot_trace.BOOT_TRACE_ENV, raising=False)
     boot_trace.drain_log_lines()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -60,7 +60,7 @@ class _RecordingHooks:
 
 
 @pytest.fixture(autouse=True)
-def _context_dependencies(monkeypatch):  # pyright: ignore[reportUnusedFunction]  # noqa: ANN001, ANN202
+def context_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("vibesys.context.backends.get", lambda *_args, **_kwargs: _FakeBackend())
     monkeypatch.setattr("vibesys.context.build_agent_client", lambda *_args, **_kwargs: MagicMock())
     monkeypatch.setattr(


### PR DESCRIPTION
## Problem

The pyright fixes that unblocked #468 used opt-out comments: `**fields: Any` with an ANN401 waiver and a `pyright: ignore[reportUnusedFunction]` on an autouse fixture. Ignore comments hide the type mismatch instead of expressing it.

## Solution

- `_event` takes `**fields: Unpack[_EventFields]`, a `TypedDict(total=False)` of the RunEvent fields the tests vary. Pyright checks each call site's kwargs; no waiver.
- Autouse fixtures get public names (`quiet_and_empty`, `context_dependencies`), which pyright does not flag as unused, with real parameter annotations. This also removes one pre-existing suppression in `test_context.py` rather than adding new ones.

## Verification

`uv run pyright` on the three files: 0 errors. `uv run ruff check`: clean. `pytest tests/server/test_tail_subscription.py tests/test_boot_trace.py tests/test_context.py`: 66 passed. `./scripts/check_format.sh`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)