### PR TITLE
ci: consolidate Python checks, add path filters and a wall-time budget guard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,11 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.9.24"
+          enable-cache: true
+          # Same narrowing as .github/workflows/test.yml: `uv sync`
+          # installs exactly what uv.lock pins, so keying on the lock
+          # keeps the cache across pyproject edits that do not move it.
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.12
@@ -95,6 +100,11 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.9.24"
+          enable-cache: true
+          # Same narrowing as .github/workflows/test.yml: `uv sync`
+          # installs exactly what uv.lock pins, so keying on the lock
+          # keeps the cache across pyproject edits that do not move it.
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.12
@@ -204,6 +214,11 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.9.24"
+          enable-cache: true
+          # Same narrowing as .github/workflows/test.yml: `uv sync`
+          # installs exactly what uv.lock pins, so keying on the lock
+          # keeps the cache across pyproject edits that do not move it.
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,61 @@ on:
       - 'website/**'
       - '.github/workflows/website.yml'
 
+env:
+  # Wall-clock budget for a whole run, enforced as a warning by `ci-budget`
+  # below (issue #474). Kept here so raising or lowering the budget is a
+  # one-line change and the guard and the documentation can't disagree.
+  CI_WALL_TIME_BUDGET_SECONDS: '300'
+
 jobs:
-  format:
+  # The workflow-level `paths-ignore` above already skips everything for
+  # docs-only changes. This job covers the case it deliberately cannot express:
+  # which *parts* of the tree a non-doc change can affect. It is the only place
+  # that decides, so a new job opts in by reading one of these outputs.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      tui: ${{ steps.filter.outputs.tui }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          filters: |
+            # Ruff and ty never read clients/, so a change confined to the
+            # TypeScript workspace cannot change their verdict. Everything else
+            # (including this workflow) does.
+            python:
+              - '**'
+              - '!clients/**'
+            # Mirrors the rebuild watch set the repository launcher uses in
+            # src/vibesys/cli.py: the TUI is affected by the TypeScript
+            # workspace itself and by the Python modules that feed the
+            # generated protocol bindings, and by nothing else.
+            tui:
+              - 'clients/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'src/vibesys/server/schema.py'
+              - 'src/vibesys/server/events.py'
+              - 'src/vibesys/server/protocol.py'
+              - 'src/vibesys/server/diagnostics.py'
+              - 'scripts/fetch_bun.py'
+              - 'scripts/check_ts_architecture.test.mjs'
+              - 'scripts/check_ts_package_manifests.mjs'
+              - '.github/workflows/test.yml'
+
+  # One environment setup for every cheap Python check. Issue #89 split these
+  # apart so a failure names the check that failed; each check is still its own
+  # step, so the failing step, its log, and the red annotation stay exactly as
+  # attributable as they were when each check owned a runner.
+  python-checks:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -34,6 +87,13 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          # Narrower than the action's default glob, which also keys on every
+          # pyproject.toml and requirements.txt in the tree: `uv sync` installs
+          # exactly what uv.lock pins, so a pyproject edit that doesn't move the
+          # lock should keep hitting the same cache entry.
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.12
@@ -44,21 +104,6 @@ jobs:
       - name: Check Python formatting
         run: ./scripts/check_format.sh
 
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Install dependencies
-        run: uv sync --dev
-
       - name: Check Python lint
         run: ./scripts/check_lint.sh
 
@@ -68,7 +113,17 @@ jobs:
       - name: Check Markdown links
         run: python3 scripts/check_doc_links.py
 
+      # Lived in the `tui` job, which now skips for Python-only changes. It
+      # exercises the Python entry point rather than anything TypeScript, so it
+      # belongs with the other Python checks.
+      - name: Test repository launcher
+        run: uv run vibesys --headless --help >/dev/null
+
+  # Its own job rather than a step in `python-checks`, so a type error is
+  # attributable at a glance and the two run in parallel.
   typecheck:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -76,6 +131,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.12
@@ -87,6 +145,8 @@ jobs:
         run: ./scripts/check_types.sh
 
   tui:
+    needs: changes
+    if: needs.changes.outputs.tui == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -102,6 +162,20 @@ jobs:
           corepack enable
           corepack install --global pnpm@11.11.0
 
+      # Resolved after pnpm exists rather than hardcoded: the store location is
+      # pnpm's to choose, and a wrong path caches an empty directory silently.
+      - name: Locate the pnpm store
+        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+      - name: Cache the pnpm store
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.PNPM_STORE_PATH }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          # A lockfile bump usually changes a handful of packages, so an older
+          # store is still worth most of its download cost.
+          restore-keys: pnpm-store-${{ runner.os }}-
+
       - name: Set up verified Bun 1.3.9 for OpenTUI
         run: |
           python3 scripts/fetch_bun.py --target linux-x86_64 --output "$RUNNER_TEMP/bun/bin/bun"
@@ -109,6 +183,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.12
@@ -124,9 +201,6 @@ jobs:
 
       - name: Check TypeScript package boundaries
         run: pnpm check:ts-architecture
-
-      - name: Test repository launcher
-        run: uv run vibesys --headless --help >/dev/null
 
       - name: Check generated protocol bindings
         run: |
@@ -285,6 +359,9 @@ jobs:
           go run ./cmd/servicebench --workload "$GITHUB_WORKSPACE/examples/microservices/repositories/deathstarbench/.vibesys/tasks/hotel-reservation/benchmark/workload.toml" --telemetry-command-json '["go","run","./cmd/otelcapture","--input-json","/tmp/vibesys-hotel-traces.otlp.ndjson","--settle-seconds","5"]' --telemetry-output /tmp/vibesys-hotel-telemetry.json --telemetry-timeout 60 --validate-only
           go run ./cmd/servicebench --mode accuracy --workload "$GITHUB_WORKSPACE/examples/microservices/repositories/deathstarbench/.vibesys/tasks/hotel-reservation/benchmark/workload.toml" --validate-only
 
+  # Deliberately unfiltered: several tests read clients/ directly (packaging,
+  # theme, and distribution tests), so a TypeScript-only change still needs
+  # this job.
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -301,6 +378,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -327,6 +407,14 @@ jobs:
         with:
           name: coverage-xml
           path: coverage.xml
+
+      # Was its own `needs: test` job, which put a second checkout, uv install,
+      # dependency sync, and artifact download on the critical path after the
+      # longest job in the run just to spend a few seconds in diff-cover. This
+      # job already has the full history and the coverage report it needs.
+      - name: Check patch coverage
+        if: github.event_name == 'pull_request'
+        run: uv run diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref }} --fail-under=80
 
   # Exercises the real Linux workspace-confinement boundary (issue #149). The
   # main `test` job skips these (no bubblewrap), so this job installs it and
@@ -356,6 +444,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.12
@@ -380,6 +471,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.12
@@ -392,29 +486,99 @@ jobs:
           VIBESYS_REQUIRE_SANDBOX_TESTS: "1"
         run: uv run python -m pytest tests/_agent_cli/test_hostsandbox.py -v
 
-  patch-coverage:
+  # Reports the run's wall time against CI_WALL_TIME_BUDGET_SECONDS (issue
+  # #474). Warns rather than fails: a green run that is merely slow should still
+  # be mergeable, and macOS runner queueing can push a run over the budget for
+  # reasons no workflow change can fix, so the summary reports queue time
+  # separately from execution time.
+  ci-budget:
+    needs:
+      - changes
+      - python-checks
+      - typecheck
+      - tui
+      - queue-native
+      - test
+      - sandbox-linux
+      - sandbox-macos
+    if: always()
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    needs: test
+    permissions:
+      actions: read
+      contents: read
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
+      - name: Report wall time against the budget
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          BUDGET_SECONDS: ${{ env.CI_WALL_TIME_BUDGET_SECONDS }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.created_at' > run_created.txt
+          # This job is still running, so its own row has an empty
+          # completed_at and drops out of the wall-time math below.
+          gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" --paginate \
+            --jq '.jobs[] | [.name, (.conclusion // ""), (.started_at // ""), (.completed_at // "")] | @tsv' \
+            > jobs.tsv
+          python3 - <<'PY'
+          import os
+          from datetime import datetime
+          from pathlib import Path
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+          def moment(value: str) -> datetime | None:
+              return datetime.fromisoformat(value.replace("Z", "+00:00")) if value else None
 
-      - name: Set up Python
-        run: uv python install 3.12
+          budget = int(os.environ["BUDGET_SECONDS"])
+          created = moment(Path("run_created.txt").read_text().strip())
+          assert created is not None
 
-      - name: Install dependencies
-        run: uv sync --dev
+          rows = []
+          for line in Path("jobs.tsv").read_text().splitlines():
+              name, conclusion, started, completed = line.split("\t")
+              # Skipped jobs report a completed_at that precedes their
+              # started_at, and they cost the run nothing.
+              start, end = moment(started), moment(completed)
+              if start is None or end is None or conclusion == "skipped":
+                  continue
+              rows.append((
+                  name,
+                  conclusion,
+                  (start - created).total_seconds(),
+                  (end - start).total_seconds(),
+                  (end - created).total_seconds(),
+              ))
 
-      - name: Download coverage report
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: coverage-xml
+          if not rows:
+              print("Every job in this run was skipped; nothing to measure.")
+              raise SystemExit(0)
 
-      - name: Check patch coverage
-        run: uv run diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref }} --fail-under=80
+          rows.sort(key=lambda row: row[4], reverse=True)
+          wall = rows[0][4]
+          slowest, _, slowest_queue, slowest_run, _ = rows[0]
+
+          lines = [
+              f"## CI wall time: {wall:.0f}s (budget {budget}s)",
+              "",
+              "Measured from the run's `created_at` to the last job's `completed_at`,"
+              " which is what a reviewer waiting on the run experiences.",
+              "",
+              "| job | result | queued (s) | ran (s) | finished at (s) |",
+              "| --- | --- | ---: | ---: | ---: |",
+          ]
+          for name, conclusion, queued, ran, finished in rows:
+              lines.append(
+                  f"| {name} | {conclusion or 'n/a'} | {queued:.0f} | {ran:.0f} | {finished:.0f} |"
+              )
+          Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text("\n".join(lines) + "\n")
+
+          if wall > budget:
+              print(
+                  f"::warning title=CI over wall-time budget::Run took {wall:.0f}s against a"
+                  f" {budget}s budget. Long pole: {slowest} ({slowest_queue:.0f}s queued,"
+                  f" {slowest_run:.0f}s running)."
+              )
+          else:
+              print(f"Run took {wall:.0f}s, within the {budget}s budget.")
+          PY


### PR DESCRIPTION
## Problem

Part of #474. A PR's `test.yml` run does not fit the 5-minute wall-time budget,
and nothing in CI reports how close it is.

The issue's suspected cause (setup tax, from each cheap check owning its own
runner) turned out not to be the long pole. Measuring first is what shaped this
PR.

What the measurement showed on the original baseline (run
[33099896184](https://github.com/uw-syfi/vibesys/actions/runs/33099896184)):

- **The `setup-uv` cache was already hitting.** Every Linux job restored a
  256MB cache in ~4s and finished `uv sync --dev` in 1-3s. Per-job setup
  (checkout, uv, Python, sync) is ~13s. Removing it from `format` and `lint`
  saves runner minutes, not wall time: jobs run in parallel, and wall time is
  the slowest job.
- **`typecheck` was 99% of the wall time**, at 391s, and one file
  (`src/vibesys/loops/agent/loop.py`) was ~95% of it. That is no longer true:
  #486 replaced pyright with ty on `main` and `typecheck` now runs in ~20s.
  This branch has been rebased onto that, so the typecheck-shaped part of the
  original analysis is moot and the sharding experiment this branch once
  carried has been dropped.
- **`pnpm install` is 2s** (83 packages, cold store), so the pnpm store cache is
  close to a wash today. Added anyway so the cost does not creep back.

Post-ty baseline, the last green `main` run
[33211759383](https://github.com/uw-syfi/vibesys/actions/runs/33211759383)
(push, so `patch-coverage` was skipped):

| job | queued | ran | finished at |
| --- | ---: | ---: | ---: |
| test (3.12) | 4s | 250s | 254s |
| tui | 3s | 113s | 116s |
| queue-native | 4s | 64s | 68s |
| sandbox-linux | 3s | 36s | 39s |
| sandbox-macos | 4s | 40s | 44s |
| typecheck | 3s | 22s | 25s |
| format | 4s | 17s | 21s |
| lint | 3s | 17s | 20s |
| patch-coverage | skipped (push) | | |
| **total wall** | | | **254s** |

On a pull request `patch-coverage` is not skipped, and because it is a
`needs: test` job it lands ~40s *after* the longest job in the run, putting a
PR at roughly 294s against a 300s budget.

## Solution

Workflow-only. No check was removed, weakened, or had its command changed.

### Consolidate the cheap Python checks

`format`, `lint`, the Markdown link check, and the repository launcher smoke
test now share one `python-checks` job and one environment setup. #89 split
these apart for signal clarity; each check is still its own step, so the failing
step, its log, and its annotation are exactly as attributable as before.

`typecheck` stays its own job. It is cheap now, but keeping it separate keeps a
type error attributable at a glance and lets it run in parallel with the rest.

The launcher smoke test (`uv run vibesys --headless --help`) moved out of `tui`,
because `tui` now skips Python-only changes and the check is a Python entry
point test that never touched TypeScript.

### Fold `patch-coverage` into `test`

It was a `needs: test` job that paid a second checkout, uv install, dependency
sync, and artifact download *after* the longest job in the run, to spend a few
seconds in diff-cover. `test` already checks out with `fetch-depth: 0` and
already has `coverage.xml`. Measured at **1s** as a step. The coverage artifact
upload is kept.

### Path filters

A `changes` job (dorny/paths-filter, pinned by SHA like every other action here)
is the single place that decides what a diff can affect:

- `python-checks` and `typecheck` skip when every changed file is under
  `clients/`. Ruff and ty never read `clients/`.
- `tui` skips unless the diff touches the TypeScript workspace or the
  protocol-feeding modules the launcher watches in `src/vibesys/cli.py`
  (`src/vibesys/server/{schema,events,protocol,diagnostics}.py`).
- `test` is deliberately **not** filtered: `tests/test_tui_packaging.py`,
  `test_tui.py`, `test_tui_theme.py`, and `test_distribution_packaging.py` read
  `clients/` directly.

Docs-only changes already skip the whole workflow via the existing
workflow-level `paths-ignore`, which is left as is. `test`, `queue-native`, and
the sandbox jobs do not depend on `changes`, so the longest real-work job starts
immediately rather than waiting on the filter.

### Budget guard

`ci-budget` has `needs:` on every job and `if: always()`. It reads the run's
`created_at` and each job's timestamps from the API, computes wall time as
`max(completed_at) - created_at` (what a reviewer waiting on the run actually
experiences), writes a per-job table to the step summary, and emits a
`::warning::` naming the long pole when the run exceeds
`CI_WALL_TIME_BUDGET_SECONDS` (workflow-level env, `300`). It warns rather than
fails, so a green but slow run still merges, and it reports queue time
separately from execution time because macOS runner scarcity is an availability
constraint, not a workflow one.

### publish.yml

Only the shared `setup-uv` pattern: `enable-cache: true` with
`cache-dependency-glob: uv.lock`, matching `test.yml`. The action's default glob
also keys on every `pyproject.toml` and `requirements.txt` in the tree, so a
`pyproject` edit that does not move the lock currently throws the cache away.

### Architecture

```mermaid
flowchart LR
  C[changes] --> PC[python-checks]
  C --> TC[typecheck]
  C --> TUI[tui]
  T["test (3.12)<br/>+ patch coverage"] --> B
  QN[queue-native] --> B
  SL[sandbox-linux] --> B
  SM[sandbox-macos] --> B
  PC --> B
  TC --> B
  TUI --> B
  B["ci-budget<br/>always()"]
```

## Results

This branch's run after the rebase,
[33225823600](https://github.com/uw-syfi/vibesys/actions/runs/33225823600), a
pull request run, so `patch-coverage` is live rather than skipped:

| job | before (main, push) | after (this PR) | note |
| --- | ---: | ---: | --- |
| changes | | 4s | new |
| python-checks | 17s + 17s (two jobs) | **17s** | one job, one setup |
| typecheck | 22s | 19s | unchanged command |
| tui | 113s | 112s | pnpm store cache now hits |
| queue-native | 64s | 63s | |
| sandbox-linux | 36s | 35s | |
| sandbox-macos | 40s | 31s | |
| test (3.12) | 250s | 256s | now includes patch coverage |
| ...of which patch coverage | ~40s as a serialized job on a PR | **&lt;1s** as a step | |
| ci-budget | | 6s | new, `always()`, after everything |
| **total wall** | **254s (push) / ~294s (PR)** | **259s (PR)** | |

The guard's own verdict on that run: `Run took 259s, within the 300s budget.`

`test` is the long pole and stays that way. Reducing it, and the wheel builds
`publish.yml` runs on every PR (7.5-10.5 min), are follow-up work on #474 and
are deliberately out of scope here.

## Verification

### Correctness properties

- **Every check still runs.** `format`, `lint`, doc links, launcher smoke,
  types, TUI, Go/Rust, tests, coverage floor, patch coverage, and both sandbox
  boundaries all still execute, with unchanged commands.
- **Failure attribution is preserved.** Every consolidated check is its own step
  in `python-checks`.
- **`test` is never skipped by a filter**, because several tests read `clients/`.
- **The guard cannot block a merge.** It only prints `::warning::`.
- **Branch protection is unaffected.** `main` currently requires no status
  checks, so the renamed jobs break nothing; if required checks are added later
  they should reference `python-checks` rather than `format`/`lint`, and
  `patch-coverage` no longer exists as a job.

### Testing

- Full green run of this branch after the rebase:
  [33225823600](https://github.com/uw-syfi/vibesys/actions/runs/33225823600).
  Numbers in Results above.
- The `changes` filter resolved `python = true, tui = true` for this PR in 4s,
  with no checkout needed on `pull_request` events.
- `patch-coverage` as a step inside `test`: **&lt;1s**, and it passed.
- The `ci-budget` script was replayed offline against the original baseline
  run's job timestamps and reproduced it exactly
  (`Run took 394s against a 300s budget. Long pole: typecheck`), and stayed
  silent when the threshold was raised above the measured wall time. On this
  run it reported 259s and stayed silent, as intended.

## Note for the reviewer

Job names changed: `format`, `lint`, and `patch-coverage` are now
`python-checks` and a step inside `test`.

This branch was rebased onto `main` after #486 landed `ty`. The rebase dropped
the pyright-sharding commit (that experiment is moot now) and updated two
comments in `test.yml` that named pyright.
