### PR TITLE
fix(types): drive pyright to zero errors and make typecheck a real gate

### DIFF
--- a/libs/vs-sandbox/src/vs_sandbox/landlock.py
+++ b/libs/vs-sandbox/src/vs_sandbox/landlock.py
@@ -88,6 +88,13 @@ _PR_SET_NO_NEW_PRIVS = 38
 _LANDLOCK_CREATE_RULESET_VERSION = 1 << 0
 _LANDLOCK_RULE_PATH_BENEATH = 1
 
+# ``O_PATH`` is Linux-only, so it is absent from ``os`` when a type checker runs
+# on another host. Take the kernel's value rather than hardcoding one (it is
+# arch-dependent), and fall back to a value that is never used: every caller
+# sits below :func:`restrict`, which is unreachable off Linux because
+# :func:`abi_version` returns ``None`` there.
+_O_PATH = os.O_PATH if sys.platform == "linux" else 0
+
 
 class LandlockUnavailableError(RuntimeError):
     """Raised when Landlock cannot confine this process on this host."""
@@ -358,7 +365,7 @@ def _add_path_rule(
 ) -> None:
     """Add one ``PATH_BENEATH`` rule, skipping paths absent from this host."""
     try:
-        parent_fd = os.open(rule.path, os.O_PATH | os.O_CLOEXEC)
+        parent_fd = os.open(rule.path, _O_PATH | os.O_CLOEXEC)
     except OSError:
         return
     try:

--- a/src/vibesys/boot_trace.py
+++ b/src/vibesys/boot_trace.py
@@ -44,7 +44,7 @@ import functools
 import os
 import sys
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from typing import ParamSpec, TypeVar
 
@@ -119,7 +119,7 @@ _TRACE = _BootTrace()
 
 
 @contextmanager
-def span(name: str) -> Iterator[None]:
+def span(name: str) -> Generator[None]:
     """Time this block and record ``boot span <qualified name>: <ms>ms``.
 
     Spans nest: *name* is qualified by whatever spans are still open, so an

--- a/tests/server/test_chat_threads.py
+++ b/tests/server/test_chat_threads.py
@@ -258,6 +258,7 @@ def test_chat_thread_create_defaults_its_driver_to_the_runs(tmp_path):  # noqa: 
     # The client sends provider and model only; the driver stays the run's.
     created = service.execute(ChatThreadCreateQuery(provider="claude", model="opus"))
 
+    assert created.chat_thread is not None
     assert calls == [(created.chat_thread.thread_id, None, "claude", "opus")]
     assert created.chat_thread.driver == "agentshim"
 

--- a/tests/server/test_lazy_event_store.py
+++ b/tests/server/test_lazy_event_store.py
@@ -9,6 +9,7 @@ fully eager path would, at every cursor and every bounded range.
 import random
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TypedDict
 
 import pytest
 from pydantic import ValidationError
@@ -68,6 +69,14 @@ def _legacy_sequence_plan(count: int) -> list[int]:
     return plan
 
 
+class _CommonFields(TypedDict):
+    """The ``RunEvent`` fields every generated event shares, spread as kwargs."""
+
+    sequence: int
+    run_id: str
+    timestamp: datetime
+
+
 def _generated_events(
     seed: int, count: int, *, legacy_sequences: bool = False, legacy_invocations: bool = False
 ) -> list[RunEvent]:
@@ -77,7 +86,7 @@ def _generated_events(
     events: list[RunEvent] = []
     open_execution: str | None = None
     for index, sequence in enumerate(plan):
-        common = {
+        common: _CommonFields = {
             "sequence": sequence,
             "run_id": "persisted-run",
             "timestamp": _TIMESTAMP,


### PR DESCRIPTION
## Problem

The `typecheck` job in `.github/workflows/test.yml` has been failing on every
run of `main`. On the latest main run ([33199529525](https://github.com/uw-syfi/vibesys/actions/runs/33199529525))
it is the *only* failing job: `43 errors, 0 warnings, 0 informations`.

A check that is always red carries no signal. Nobody can tell a regression
they just introduced from the standing baseline, so in practice the job is
ignored and new type errors land unnoticed. Issue #474 explicitly scoped this
out of the CI wall-time work ("Fixing the `typecheck` job's existing failures
... Making it green or ratcheted is separate follow-up work"). This is that
follow-up.

Before: 43 errors on CI (Linux), 44 locally on macOS.
After: 0 on both.

## Solution

No new suppressions. There are no added `# pyright: ignore`, `# type: ignore`,
`cast`, or `Any` escapes in this PR, and no pyright configuration was changed.
Every error is fixed by stating the type that was already true. The repo
already sets `reportUnnecessaryTypeIgnoreComment = "error"`, so a suppression
baseline would have been a permanent hole rather than a ratchet.

The 43/44 errors came from four causes:

| Cause | Errors | Fix |
| --- | --- | --- |
| `RunEvent(**common, ...)` spread of an untyped dict | 40 | `TypedDict` for the shared fields |
| `created.chat_thread` reached without narrowing | 2 | `assert ... is not None` |
| `@contextmanager` over `-> Iterator[None]` | 1 | `-> Generator[None]` |
| `os.O_PATH` (Linux-only attribute) | 1 (macOS only) | bind under the module's `sys.platform` guard |

**The 40-error cluster.** `tests/server/test_lazy_event_store.py` builds a
generated event log by spreading a shared dict of fields into each `RunEvent`.
Pyright joined the value types to `dict[str, int | str | datetime]`, then
reported that union against every keyword parameter of `RunEvent.__init__` at
each of the four call sites. Declaring the dict as a `TypedDict` restores each
key's real type and the spread checks cleanly.

**`os.O_PATH`.** This is the one error that is platform-dependent, and it is
why the local count (44) differed from CI's (43). Typeshed gates `os.O_PATH`
behind `sys.platform == "linux"`, so it is invisible to a type checker running
on macOS. `landlock.py` now binds it once under the same platform guard the
rest of the module already uses:

```python
_O_PATH = os.O_PATH if sys.platform == "linux" else 0
```

The fallback is never reached: every caller sits below `restrict()`, which
raises off Linux because `abi_version()` returns `None` there. Taking the
value from `os` rather than hardcoding `0o10000000` matters because `O_PATH`
is arch-dependent (alpha and sparc use different values), so a literal would
have been a latent portability bug rather than a fix.

### Architecture

No architectural change. Every edit is an annotation, a narrowing assertion, or
a constant binding. Runtime behavior is unchanged on all four files:

- `boot_trace.span`: `@contextmanager` does not inspect the return annotation,
  so `Iterator[None]` to `Generator[None]` is annotation-only.
- `landlock`: on Linux `_O_PATH` is `os.O_PATH`, bit for bit.
- Both test changes add type information and one assertion; neither changes
  what is exercised.

## Verification

### Correctness properties

- `./scripts/check_types.sh` reports zero errors, so the `typecheck` job now
  fails only on a type error a change actually introduces.
- Zero errors holds on **both** platforms, verified with an explicit
  `--pythonplatform Linux` run as well as the default macOS one. The check no
  longer disagrees with itself between a contributor's laptop and CI.
- Landlock still passes the kernel's own `O_PATH` on Linux, not a hardcoded
  ABI number, so the arch-dependent value stays correct.
- The added `assert created.chat_thread is not None` strengthens the test: the
  response's optional field is now asserted present rather than reached
  through, matching what the other tests in that file already do.

**No product bugs were found.** All 43 errors were annotation gaps in code
that was already correct at runtime. The `os.O_PATH` case is the closest to a
real defect, but it is a portability/typing issue, not a live bug: the code
path only ever executes on Linux, where the attribute exists.

### Testing

```
./scripts/check_types.sh                      # 0 errors, 0 warnings (was 44 local / 43 CI)
uv run pyright --pythonplatform Linux         # 0 errors, 0 warnings
uv run python -m pytest tests/server tests/agents tests/test_boot_trace.py \
    tests/test_cli_launcher.py tests/test_context.py libs/vs-sandbox/tests
                                              # 740 passed, 13 skipped, 1 failed
uv run ruff check <touched files>             # All checks passed
./scripts/check_format.sh                     # All checks passed, 430 files
```

The single pytest failure is
`test_landlock_sandbox.py::TestLinuxBackendSelection::test_unknown_backend_value_is_rejected`.
It is pre-existing and macOS-only: it reproduces identically on `main` with
this branch stashed, and the Linux `sandbox-linux` job is green on main. Not
caused by, and not in scope for, this PR.

No `clients/` or server protocol/event model files were touched, so the
protocol generation and client checks do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
