### PR TITLE
TUI: Reuse one provider conversation per experiment-chat thread

### DIFF
--- a/docs/contributing/agent-drivers.md
+++ b/docs/contributing/agent-drivers.md
@@ -62,6 +62,26 @@ nothing about whether the conversation is still resumable, so the client keeps
 the checkpoint and only a driver-reported reset (or a refused adoption) clears
 it.
 
+### Retired after a turn, or replaced during one
+
+A reset says the conversation is gone, not when it went. The two cases differ
+for any caller that shortens a prompt because a conversation already carries
+its instructions, so `AgentClient` answers both questions separately:
+
+- `provider_session_id(key)` names the conversation the **next** turn
+  continues, or `None` when the next turn starts from nothing. A reset clears
+  it.
+- `last_turn_provider_session_id(key)` names the conversation the **last
+  completed** turn ran in. A reset does not clear it.
+
+An over-budget Codex thread is retired after it has answered, so the two
+disagree only from the next turn onward: that answer stands, and the next
+prompt is a cold one. A missing rollout or a refused `claude --resume` is
+replaced mid-turn, so the last turn ran somewhere the caller did not intend,
+and a caller that shortened its prompt has to ask again in full. The
+experiment chat is the caller that does this today
+(`src/server/chat/session.py`).
+
 ## Mock driver
 
 `driver = "mock"` is test infrastructure. It satisfies the same driver

--- a/src/server/chat/factory.py
+++ b/src/server/chat/factory.py
@@ -19,6 +19,7 @@ from server.chat.session import (
 )
 from server.events import ChatThreadCreatedData
 from vibesys.agents import build_agent_client
+from vibesys.agents.session_key import AgentSessionKey, SessionScope
 from vibesys.domains.environment import EnvironmentBindMount
 from vibesys.run import RunLogger
 from vibesys.run.integration import AgentSelection, RunAttachment
@@ -32,6 +33,13 @@ if TYPE_CHECKING:
     from server.controller import RunController
     from server.execution import ExecutionTracker
     from vs_project import Project
+
+
+#: Session-key identifier for the run's default chat, which has no thread ID of
+#: its own. Threads are ``uuid4().hex``, so this cannot collide with one; it is
+#: the same name the client already shows the default thread under
+#: (``DEFAULT_CHAT_THREAD_ID`` in ``clients/core-state``).
+DEFAULT_CHAT_THREAD = "default"
 
 
 class SelectionResolver(Protocol):
@@ -288,6 +296,12 @@ class ExperimentChatFactory:
                 controller=self._controller,
                 executions=self._executions,
                 agent_client=resources.client,
+                # One conversation per thread. The run's default chat has no
+                # thread ID of its own, so it names the identifier the threads
+                # cannot collide with.
+                session_key=AgentSessionKey(
+                    SessionScope.CHAT, DEFAULT_CHAT_THREAD if thread_id is None else thread_id
+                ),
                 workspace=self._workspace,
                 state_dir=state_dir,
                 agent_shared_state_dir=resources.agent_shared_state_dir,

--- a/src/server/chat/session.py
+++ b/src/server/chat/session.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from server.chat.evidence import TrajectoryEvidence
     from server.controller import RunController
     from server.execution import ExecutionTracker
+    from vibesys.agents.session_key import AgentSessionKey
 
 
 class ChatAgentClient(Protocol):
@@ -26,6 +27,14 @@ class ChatAgentClient(Protocol):
 
     def invoke_text(self, **kwargs: Any) -> str:  # noqa: ANN401  # Mirrors agent clients.
         """Invoke the agent with the driver-specific keyword contract."""
+        ...
+
+    def provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Name the provider conversation the next turn on the key continues."""
+        ...
+
+    def last_turn_provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Name the provider conversation the key's last completed turn ran in."""
         ...
 
 
@@ -44,6 +53,9 @@ class ExperimentChatDependencies:
     controller: RunController
     executions: ExecutionTracker
     agent_client: ChatAgentClient
+    #: Identity of this thread's provider conversation. Follow-ups reuse it so
+    #: the agent keeps the context of the questions before them.
+    session_key: AgentSessionKey
     workspace: Path
     state_dir: Path
     agent_shared_state_dir: str
@@ -66,10 +78,11 @@ class ExperimentChatSession:
         dependencies: ExperimentChatDependencies,
         resources: Closeable | None = None,
     ) -> None:
-        """Initialize a serialized chat session and load its transcript."""
+        """Initialize a serialized chat session over one provider conversation."""
         self._controller = dependencies.controller
         self._executions = dependencies.executions
         self._agent_client = dependencies.agent_client
+        self._session_key = dependencies.session_key
         self._workspace = dependencies.workspace
         self._state_dir = dependencies.state_dir
         self._evidence = dependencies.evidence
@@ -89,89 +102,102 @@ class ExperimentChatSession:
         self._continuation_prompt = experiment_chat_continuation_prompt(
             dependencies.agent_state_dir
         )
-        self._history = self._load_history()
 
     def ask(self, question: str) -> str:
         """Refresh evidence, invoke the chat agent, and persist its answer."""
         with self._lock:
             self._evidence.refresh(self._system_prompt)
-            system_prompt = self._continuation_prompt if self._history else self._system_prompt
-            execution = self._controller.start_agent_execution(
-                "chat",
-                "experiment-chat",
-                question,
-                system_prompt,
-                consume_steering=False,
-                participates_in_run_control=False,
-                driver=self._driver,
-                provider=self._provider,
-                model=self._model,
-            )
-            answer: str | None = None
-            error: BaseException | None = None
-            with self._executions.presentation_scope(
-                agent_kind="chat",
-                round_label="experiment-chat",
-                invocation_id=execution.execution_id,
+            # The shortened prompt assumes the agent is still in the
+            # conversation that was given the full instructions, so it is
+            # justified by a live provider conversation rather than by the
+            # transcript on disk. Without one the turn cold-starts and carries
+            # the whole prompt. This is also what puts the instructions back
+            # after a driver retires a conversation it has finished serving,
+            # such as a renewed Codex thread.
+            continued = self._agent_client.provider_session_id(self._session_key)
+            answer = self._invoke(question, resumed=continued is not None)
+            if (
+                continued is not None
+                and self._agent_client.last_turn_provider_session_id(self._session_key) != continued
             ):
-                try:
-                    answer = self._agent_client.invoke_text(
-                        kind="chat",
-                        workspace=self._workspace,
-                        system_prompt=system_prompt,
-                        env=self._environment(),
-                        user_prompt=question,
-                        round_label="experiment chat",
-                        invocation_id=execution.execution_id,
-                        progress=self._progress(),
-                        reuse_session=False,
-                    )
-                except BaseException as exc:
-                    error = exc
-                    if isinstance(exc, Exception):
-                        raise RuntimeError(  # noqa: TRY003, TRY004  # Normalize agent errors.
-                            f"Chat agent failed: {type(exc).__name__}: {exc}"
-                        ) from exc
-                    raise
-                finally:
-                    self._controller.after_agent(
-                        "chat",
-                        "experiment-chat",
-                        result=answer,
-                        error=error,
-                        execution_id=execution.execution_id,
-                    )
-            assert answer is not None  # noqa: S101
+                # The driver replaced that conversation *while* serving the
+                # turn (a Codex thread whose rollout was gone, a Claude session
+                # the CLI refused to resume), so the answer above came from an
+                # agent that was never given the read-only rules. Ask once
+                # more, with them. The retry cold-starts by construction: the
+                # client evicted the session and cleared its checkpoint when
+                # the driver reported the restart, so a second restart has
+                # nothing left to lose and the loop cannot repeat.
+                self._log(
+                    "[chat] provider session was replaced mid-question; "
+                    "re-asking with the full instructions"
+                )
+                answer = self._invoke(question, resumed=False)
             if not answer.strip():
                 answer = (
                     "Chat agent did not return an answer.\n\n"
                     f"Fallback diagnostic:\n{self._fallback(question)}"
                 )
-            self._history.append((question, answer))
             self._append_exchange(question, answer)
             return answer
+
+    def _invoke(self, question: str, *, resumed: bool) -> str:
+        """Run one chat turn, reusing this thread's provider conversation."""
+        system_prompt = self._continuation_prompt if resumed else self._system_prompt
+        execution = self._controller.start_agent_execution(
+            "chat",
+            "experiment-chat",
+            question,
+            system_prompt,
+            consume_steering=False,
+            participates_in_run_control=False,
+            driver=self._driver,
+            provider=self._provider,
+            model=self._model,
+        )
+        answer: str | None = None
+        error: BaseException | None = None
+        with self._executions.presentation_scope(
+            agent_kind="chat",
+            round_label="experiment-chat",
+            invocation_id=execution.execution_id,
+        ):
+            try:
+                answer = self._agent_client.invoke_text(
+                    kind="chat",
+                    workspace=self._workspace,
+                    system_prompt=system_prompt,
+                    env=self._environment(),
+                    user_prompt=question,
+                    round_label="experiment chat",
+                    invocation_id=execution.execution_id,
+                    progress=self._progress(),
+                    reuse_session=True,
+                    session_key=self._session_key,
+                )
+            except BaseException as exc:
+                error = exc
+                if isinstance(exc, Exception):
+                    raise RuntimeError(  # noqa: TRY003, TRY004  # Normalize agent errors.
+                        f"Chat agent failed: {type(exc).__name__}: {exc}"
+                    ) from exc
+                raise
+            finally:
+                self._controller.after_agent(
+                    "chat",
+                    "experiment-chat",
+                    result=answer,
+                    error=error,
+                    execution_id=execution.execution_id,
+                )
+        assert answer is not None  # noqa: S101
+        return answer
 
     def close(self) -> None:
         """Release resources owned by this chat session once."""
         resources, self._resources = self._resources, None
         if resources is not None:
             resources.close()
-
-    def _load_history(self) -> list[tuple[str, str]]:
-        transcript = self._state_dir / "conversation.jsonl"
-        if not transcript.is_file():
-            return []
-        history: list[tuple[str, str]] = []
-        try:
-            for line in transcript.read_text(encoding="utf-8").splitlines():
-                payload = json.loads(line)
-                question = payload.get("question")
-                answer = payload.get("answer")
-                if isinstance(question, str) and isinstance(answer, str):
-                    history.append((question, answer))
-        except (OSError, json.JSONDecodeError, AttributeError):
-            return []
-        return history
 
     def _append_exchange(self, question: str, answer: str) -> None:
         try:

--- a/src/vibesys/agents/client.py
+++ b/src/vibesys/agents/client.py
@@ -57,6 +57,10 @@ T = TypeVar("T", bound=BaseModel)
 class _CachedSession:
     spec: AgentSessionSpec
     session: AgentSession
+    #: The provider conversation the last completed turn on this session ran
+    #: in. Kept beside the live handle so a caller can name the conversation
+    #: its next turn continues without a durable store being wired.
+    provider_session_id: str | None = None
 
 
 class AgentDiagnosticLog:
@@ -195,6 +199,9 @@ class AgentClient:
             containerized=containerized,
         )
         self._sessions: dict[AgentSessionKey, _CachedSession] = {}
+        # Where each key's last completed turn ran, kept across evictions so a
+        # caller can tell a retired conversation from a replaced one.
+        self._last_turn_sessions: dict[AgentSessionKey, str | None] = {}
         self._closed = False
 
     @property
@@ -486,6 +493,9 @@ class AgentClient:
                 error.add_note(f"agent session cleanup also failed: {cleanup_error}")
             raise
 
+        # Recorded for both dispositions, and exactly as reported: this is where
+        # the turn ran, which a reset afterwards does not change.
+        self._last_turn_sessions[session_key] = result.provider_session_id
         if result.disposition is SessionDisposition.RESET_REQUIRED:
             # The driver restarted or abandoned the conversation this key names,
             # so both the live session and the checkpoint describe history that
@@ -493,8 +503,36 @@ class AgentClient:
             self._evict(session_key)
             self._session_store.clear(session_key)
         else:
+            if result.provider_session_id is not None:
+                cached.provider_session_id = result.provider_session_id
             self._checkpoint(session_key, session_spec, fingerprint, result)
         return result
+
+    def provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Name the provider conversation the next turn on ``session_key`` continues.
+
+        ``None`` means the next turn starts from no history at all: no live
+        session holds a conversation, and no checkpoint survives for the key.
+        A caller that shortens a prompt because a conversation already carries
+        its instructions asks this first.
+        """
+        cached = self._sessions.get(session_key)
+        if cached is not None and cached.provider_session_id is not None:
+            return cached.provider_session_id
+        record = self._session_store.get(session_key)
+        return None if record is None else record.session_id
+
+    def last_turn_provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Name the provider conversation the last completed turn on the key ran in.
+
+        A driver-reported restart does not clear this, which is what separates
+        it from :meth:`provider_session_id`: a conversation retired *after* it
+        served a turn still answered that turn, while one replaced *while*
+        serving it did not. A caller that shortened a prompt compares this
+        against the conversation that justified the shortening; a difference
+        means the shortened prompt reached an agent without its instructions.
+        """
+        return self._last_turn_sessions.get(session_key)
 
     def _resume_checkpoint(
         self,

--- a/src/vibesys/agents/deepagents_runner.py
+++ b/src/vibesys/agents/deepagents_runner.py
@@ -52,6 +52,22 @@ class DeepAgentsClient(AgentClient):
     def close(self) -> None:
         """Deepagents owns no resources beyond each invocation."""
 
+    def provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Never name a conversation: deepagents threads are in-process only.
+
+        A deepagents thread is a LangGraph checkpointer entry, not a provider
+        conversation another process could resume, and this client never runs
+        ``AgentClient.__init__``, so it owns neither a session cache nor a
+        store for the base implementation to read.
+        """
+        del session_key
+        return None
+
+    def last_turn_provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Never name a conversation, for the reason above."""
+        del session_key
+        return None
+
     def set_log_file(self, stream: TextIO | None) -> None:
         """Direct subsequent logs to ``stream``."""
         self._run_log_file = stream

--- a/src/vibesys/agents/stub_runner.py
+++ b/src/vibesys/agents/stub_runner.py
@@ -37,6 +37,16 @@ class StubAgentClient:
     def close(self) -> None:
         """The deterministic stub owns no external resources."""
 
+    def provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Never name a conversation: the stub runs no provider at all."""
+        del session_key
+        return None
+
+    def last_turn_provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Never name a conversation: the stub runs no provider at all."""
+        del session_key
+        return None
+
     def set_log_file(self, stream: object) -> None:
         """Accept log retargeting; the deterministic stub emits no file logs."""
         del stream

--- a/src/vibesys/loops/plain/runner_ext.py
+++ b/src/vibesys/loops/plain/runner_ext.py
@@ -86,6 +86,14 @@ class PlainLoopAgentClient(AgentClient):
         """Close the inner client."""
         self._inner.close()
 
+    def provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Report the inner client's conversation for ``session_key``."""
+        return self._inner.provider_session_id(session_key)
+
+    def last_turn_provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Report where the inner client's last turn on ``session_key`` ran."""
+        return self._inner.last_turn_provider_session_id(session_key)
+
     def invoke_text(  # noqa: PLR0913
         self,
         *,

--- a/tests/server/test_chat_session.py
+++ b/tests/server/test_chat_session.py
@@ -1,0 +1,271 @@
+"""Experiment-chat prompt selection over a reused provider conversation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# The agentshim driver's own fake agent, reused rather than copied: these tests
+# are about what the real driver reports to the real client, so a second fake
+# that drifted from it would stop testing that.
+from tests.vibesys.agents.drivers.test_agentshim_driver import _FakeAgent
+
+from server.chat.prompts import (
+    experiment_chat_continuation_prompt,
+    experiment_chat_system_prompt,
+)
+from server.chat.session import ExperimentChatDependencies, ExperimentChatSession
+from vibesys.agents.client import AgentClient
+from vibesys.agents.drivers import agentshim
+from vibesys.agents.session_key import AgentSessionKey, SessionScope
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_SHARED_STATE_DIR = "/state/server/chat"
+_FULL_PROMPT = experiment_chat_system_prompt(_SHARED_STATE_DIR, _SHARED_STATE_DIR)
+_CONTINUATION_PROMPT = experiment_chat_continuation_prompt(_SHARED_STATE_DIR)
+
+
+class _FakeClient:
+    """Record chat invocations and answer both conversation questions."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        #: The conversation a next turn would continue.
+        self.continues: str | None = None
+        #: The conversation the last completed turn ran in.
+        self.ran_in: str | None = None
+
+    def invoke_text(self, **kwargs: Any) -> str:  # noqa: ANN401  # Mirrors agent clients.
+        self.calls.append(kwargs)
+        return "It improved in round 2."
+
+    def provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        del session_key
+        return self.continues
+
+    def last_turn_provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        del session_key
+        return self.ran_in
+
+
+def _chat(
+    tmp_path: Path,
+    client: Any,  # noqa: ANN401  # Any ChatAgentClient implementation.
+    *,
+    thread_id: str | None = None,
+) -> ExperimentChatSession:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    controller = MagicMock()
+    controller.start_agent_execution.return_value = SimpleNamespace(execution_id="exec-1")
+    return ExperimentChatSession(
+        ExperimentChatDependencies(
+            controller=controller,
+            executions=MagicMock(),
+            agent_client=client,
+            session_key=AgentSessionKey(SessionScope.CHAT, thread_id or "default"),
+            workspace=workspace,
+            state_dir=tmp_path / "state",
+            agent_shared_state_dir=_SHARED_STATE_DIR,
+            agent_state_dir=_SHARED_STATE_DIR,
+            evidence=MagicMock(),
+            log=lambda _message: None,
+            environment=dict,
+            progress=lambda: None,
+            driver="agentshim",
+            provider="codex",
+            model="gpt-test",
+            fallback=lambda _question: "fallback",
+        )
+    )
+
+
+def test_chat_reuses_a_conversation_keyed_by_thread(tmp_path: Path) -> None:
+    client = _FakeClient()
+    chat = _chat(tmp_path, client, thread_id="thread-a")
+
+    chat.ask("what happened?")
+
+    kwargs = client.calls[0]
+    assert kwargs["reuse_session"] is True
+    assert kwargs["session_key"] == AgentSessionKey(SessionScope.CHAT, "thread-a")
+
+
+def test_chat_sends_the_full_prompt_when_no_conversation_is_named(tmp_path: Path) -> None:
+    client = _FakeClient()
+    chat = _chat(tmp_path, client)
+
+    chat.ask("what happened?")
+
+    assert [call["system_prompt"] for call in client.calls] == [_FULL_PROMPT]
+
+
+def test_chat_shortens_the_prompt_inside_a_named_conversation(tmp_path: Path) -> None:
+    client = _FakeClient()
+    client.continues = "session-1"
+    client.ran_in = "session-1"
+    chat = _chat(tmp_path, client)
+
+    chat.ask("what happened?")
+
+    assert [call["system_prompt"] for call in client.calls] == [_CONTINUATION_PROMPT]
+
+
+def test_chat_reasks_when_the_turn_ran_in_a_different_conversation(tmp_path: Path) -> None:
+    client = _FakeClient()
+    client.continues = "session-1"
+    # The driver replaced the conversation while serving the turn, so the
+    # shortened prompt reached an agent that never saw the read-only rules.
+    client.ran_in = "session-2"
+    chat = _chat(tmp_path, client)
+
+    answer = chat.ask("what happened?")
+
+    assert [call["system_prompt"] for call in client.calls] == [
+        _CONTINUATION_PROMPT,
+        _FULL_PROMPT,
+    ]
+    assert answer == "It improved in round 2."
+
+
+def test_chat_keeps_one_answer_when_the_conversation_retires_after_the_turn(
+    tmp_path: Path,
+) -> None:
+    client = _FakeClient()
+    client.continues = "session-1"
+    # The turn ran where the shortened prompt assumed; the conversation was
+    # retired only afterwards, so its answer stands.
+    client.ran_in = "session-1"
+    chat = _chat(tmp_path, client)
+    chat.ask("what happened?")
+    client.continues = None
+
+    chat.ask("and then?")
+
+    assert [call["system_prompt"] for call in client.calls] == [
+        _CONTINUATION_PROMPT,
+        _FULL_PROMPT,
+    ]
+
+
+def test_chat_never_reasks_a_cold_turn(tmp_path: Path) -> None:
+    client = _FakeClient()
+    client.ran_in = "session-1"
+    chat = _chat(tmp_path, client)
+
+    chat.ask("what happened?")
+
+    # Nothing justified a shortened prompt, so a new conversation is expected.
+    assert len(client.calls) == 1
+
+
+@pytest.fixture
+def fake_agents(monkeypatch: pytest.MonkeyPatch) -> list[_FakeAgent]:
+    """Build every provider conversation from the driver's own fake agent."""
+    built: list[_FakeAgent] = []
+
+    def factory(
+        model: str | None = None,
+        event_handler: Any | None = None,  # noqa: ANN401  # Mirrors the agent constructor.
+        *,
+        executor: Any | None = None,  # noqa: ANN401  # Mirrors the agent constructor.
+    ) -> _FakeAgent:
+        agent = _FakeAgent(model, event_handler, executor=executor)
+        built.append(agent)
+        return agent
+
+    for provider in ("codex", "claude"):
+        monkeypatch.setitem(agentshim._PROVIDER_CLASSES, provider, factory)  # noqa: SLF001
+    monkeypatch.setattr(agentshim, "declare_agent_host_resources", lambda *_a, **_k: ())
+    monkeypatch.setattr(agentshim, "build_host_sandbox", lambda *_a, **_k: "sandbox")
+    return built
+
+
+def _prompts(agents: list[_FakeAgent]) -> list[str]:
+    """Every prompt the provider was given, in the order the turns ran."""
+    return [prompt for agent in agents for prompt, _cwd, _timeout in agent.generate_calls]
+
+
+def test_codex_thread_renewal_puts_the_read_only_rules_back(
+    fake_agents: list[_FakeAgent], tmp_path: Path
+) -> None:
+    # The Codex thread budget retires a thread after a fixed number of turns.
+    # Before drivers reported that, chat kept shortening its prompt into the
+    # replacement thread, so a question periodically ran with no read-only
+    # rules at all. The driver now reports the restart, the client drops the
+    # conversation, and the next question carries the full instructions again.
+    client = AgentClient(agentshim.AgentShimDriver(provider="codex"), provider="codex")
+    chat = _chat(tmp_path, client)
+
+    for question in ("what happened?", "and then?", "why?"):
+        chat.ask(question)
+
+    prompts = _prompts(fake_agents)
+    assert len(prompts) == 3, "one provider turn per question, with no re-asks"
+    assert prompts[0].startswith(_FULL_PROMPT)
+    assert prompts[1].startswith(_CONTINUATION_PROMPT)
+    assert prompts[2].startswith(_FULL_PROMPT)
+    assert agentshim._MAX_CODEX_SESSION_TURNS == 2  # noqa: SLF001  # the cadence above
+
+
+def test_stale_claude_session_reasks_instead_of_failing_the_question(
+    fake_agents: list[_FakeAgent], tmp_path: Path
+) -> None:
+    client = AgentClient(agentshim.AgentShimDriver(provider="claude"), provider="claude")
+    chat = _chat(tmp_path, client)
+    chat.ask("what happened?")
+
+    resumed = fake_agents[0]
+    failures = [RuntimeError("claude exited with code 1")]
+
+    def refuse_the_resume(prompt: str, /, **kwargs: Any) -> str:  # noqa: ANN401
+        del kwargs
+        resumed.generate_calls.append((prompt, None, None))
+        if failures:
+            raise failures.pop()
+        return "done"
+
+    resumed.generate_override = refuse_the_resume
+
+    answer = chat.ask("and then?")
+
+    prompts = _prompts(fake_agents)
+    # The shortened prompt, the driver's own retry of it from a fresh
+    # conversation, then the question asked again with the rules restored.
+    assert prompts[1].startswith(_CONTINUATION_PROMPT)
+    assert prompts[2].startswith(_CONTINUATION_PROMPT)
+    assert prompts[3].startswith(_FULL_PROMPT)
+    assert answer == "done"
+
+
+def test_chat_normalizes_an_agent_failure(tmp_path: Path) -> None:
+    class _FailingClient(_FakeClient):
+        def invoke_text(self, **kwargs: Any) -> str:  # noqa: ANN401
+            super().invoke_text(**kwargs)
+            raise ValueError("no such workspace")  # noqa: TRY003  # test fixture
+
+    client = _FailingClient()
+    chat = _chat(tmp_path, client)
+
+    with pytest.raises(RuntimeError, match="Chat agent failed: ValueError: no such workspace"):
+        chat.ask("what happened?")
+
+    assert len(client.calls) == 1
+
+
+def test_chat_propagates_a_cancellation_unwrapped(tmp_path: Path) -> None:
+    class _CancelledClient(_FakeClient):
+        def invoke_text(self, **kwargs: Any) -> str:  # noqa: ANN401
+            super().invoke_text(**kwargs)
+            raise KeyboardInterrupt
+
+    chat = _chat(tmp_path, _CancelledClient())
+
+    # A cancellation is not an agent error and must not be reported as one.
+    with pytest.raises(KeyboardInterrupt):
+        chat.ask("what happened?")

--- a/tests/server/test_integration.py
+++ b/tests/server/test_integration.py
@@ -11,6 +11,7 @@ from tests.server.support import build_server_parts
 from server.api.protocol import ChatQuery, ChatThreadCreateQuery
 from server.chat.factory import ChatAgentResources
 from server.events import EventType
+from vibesys.agents.session_key import AgentSessionKey, SessionScope
 from vibesys.run.events import (
     AgentOutputChunkData,
     CoreEventType,
@@ -35,6 +36,16 @@ class _ChatClient:
     def invoke_text(self, **kwargs: Any) -> str:  # noqa: ANN401
         self.calls.append(kwargs)
         return "It improved in round 2."
+
+    def provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Report no conversation, so every turn carries the full prompt."""
+        del session_key
+        return None
+
+    def last_turn_provider_session_id(self, session_key: AgentSessionKey) -> str | None:
+        """Report no conversation, matching ``provider_session_id``."""
+        del session_key
+        return None
 
 
 def _project_run(root: Path) -> tuple[Project, str]:
@@ -160,7 +171,8 @@ def test_attach_run_installs_chat_with_isolated_session_state(tmp_path):  # noqa
 
     assert response.chat is not None
     assert response.chat.answer == "It improved in round 2."
-    assert client.calls[0]["reuse_session"] is False
+    assert client.calls[0]["reuse_session"] is True
+    assert client.calls[0]["session_key"] == AgentSessionKey(SessionScope.CHAT, "default")
     assert client.calls[0]["user_prompt"] == "what improved?"
     transcript = project.state.log_directory(run_id).parent / "server/chat/conversation.jsonl"
     assert json.loads(transcript.read_text()) == {

--- a/tests/vibesys/agents/test_agent_runners.py
+++ b/tests/vibesys/agents/test_agent_runners.py
@@ -74,6 +74,22 @@ def test_json_emitter_preserves_raw_log(capsys):  # noqa: ANN001, ANN201  # trac
 class TestDeepAgentsClient:
     """Tests for :class:`DeepAgentsClient`."""
 
+    def test_deepagents_runner_names_no_provider_conversation(self) -> None:
+        runner = DeepAgentsClient(
+            model="m",
+            backends={"judge": MagicMock(name="judge-backend")},
+            skills=[],
+            model_name="m",
+            run_log_file=None,
+        )
+        key = AgentSessionKey(SessionScope.CHAT, "thread-a")
+
+        # A deepagents thread is a checkpointer entry, not a provider
+        # conversation, and this client never runs ``AgentClient.__init__``, so
+        # the inherited implementation would have no cache or store to read.
+        assert runner.provider_session_id(key) is None
+        assert runner.last_turn_provider_session_id(key) is None
+
     def test_deepagents_runner_invoke_returns_structured_response(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         pass_response = JudgeResponse(
             analysis="looks good",

--- a/tests/vibesys/agents/test_stub_runner.py
+++ b/tests/vibesys/agents/test_stub_runner.py
@@ -1,3 +1,4 @@
+from vibesys.agents.session_key import AgentSessionKey, SessionScope
 from vibesys.agents.stub_runner import StubAgentClient
 from vibesys.schemas import (
     ImplementerResponse,
@@ -49,3 +50,12 @@ def invoke(runner, workspace, kind, response_cls):  # noqa: ANN001, ANN201  # tr
         fallback_factory=lambda: None,
         round_label=f"stub-{kind}",
     )
+
+
+def test_stub_runner_names_no_provider_conversation():  # noqa: ANN201
+    runner = StubAgentClient()
+    key = AgentSessionKey(SessionScope.CHAT, "thread-a")
+
+    # The stub runs no provider, so nothing can be resumed or compared against.
+    assert runner.provider_session_id(key) is None
+    assert runner.last_turn_provider_session_id(key) is None

--- a/tests/vibesys/loops/plain/test_plain_runner_ext.py
+++ b/tests/vibesys/loops/plain/test_plain_runner_ext.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from vibesys._agent_cli.base import MCPServerSpec
 from vibesys.agents.client import AgentClient
 from vibesys.agents.contracts import AgentCapabilities
+from vibesys.agents.session_key import AgentSessionKey, SessionScope
 from vibesys.loops.plain.runner_ext import PlainLoopAgentClient
 from vs_issue_board import IssueBoard
 
@@ -280,3 +281,18 @@ class TestBackendName:
         inner_cli = _mock_runner("cli")
         wrapper_cli = PlainLoopAgentClient(inner_cli, store=store, max_issues_per_perf_eval=3)
         assert wrapper_cli.backend_name == "cli"
+
+
+class TestProviderConversation:
+    def test_conversation_accessors_proxy_inner(self, tmp_path):  # noqa: ANN001, ANN201
+        store = _make_store(tmp_path)
+        inner = _mock_runner("cli")
+        inner.provider_session_id.return_value = "session-1"
+        inner.last_turn_provider_session_id.return_value = "session-2"
+        wrapper = PlainLoopAgentClient(inner, store=store, max_issues_per_perf_eval=3)
+        key = AgentSessionKey(SessionScope.CHAT, "thread-a")
+
+        assert wrapper.provider_session_id(key) == "session-1"
+        assert wrapper.last_turn_provider_session_id(key) == "session-2"
+        inner.provider_session_id.assert_called_once_with(key)
+        inner.last_turn_provider_session_id.assert_called_once_with(key)


### PR DESCRIPTION
## Problem

Experiment chat throws away its provider session after every question. Each
question therefore pays a full context reload: the whole read-only
investigation prompt plus a transcript re-read, delivered to an agent that was
told exactly the same thing a minute earlier. A CLI process is spawned per
question either way; what is wasted is the conversation, not the process.

Worse, `main` decides which prompt to send from the transcript on disk: any
question after the first gets the short continuation prompt, which points at
`instructions.md` rather than carrying the read-only rules. The rules are
reachable only if the agent chooses to open that file.

The mechanism for fixing this landed separately in #523: `AgentSessionKey`
with a `CHAT` scope, a durable `SessionStore`, and drivers that report
`SessionDisposition.RESET_REQUIRED` whenever they drop and restart the
conversation a session names. This PR is that PR's stated follow-up.

Original diagnosis, per-thread key design, and the first implementation are
@AyanBinRafaih's. The branch has been force-pushed with the session half
rebuilt on #523's contract; the incremental trajectory sync and the composer
spinner it also carried are now #592, which depends on nothing here.

Part of #463. Streaming partial tokens into the chat pane is still deferred:
chat is request/response over `query.chat` and the claude CLI emits an answer
as one message-level chunk, so it needs a new server event kind plus
`--include-partial-messages` driver support.

## Solution

Chat opens its session with `AgentSessionKey(SessionScope.CHAT, thread_id)`
and `reuse_session=True`, so a follow-up continues the same codex/claude
conversation (`codex exec resume` / `claude --resume`) and carries only the
short continuation prompt. The run's default chat, which has no thread ID,
uses the identifier `default`; threads are `uuid4().hex` and cannot collide
with it.

### Shortening a prompt safely

A shortened prompt is only correct inside the conversation that was given the
full instructions. `AgentClient` therefore answers two questions about a key,
not one:

- `provider_session_id(key)` names the conversation the **next** turn
  continues, or `None` when the next turn starts from nothing. A
  driver-reported reset clears it.
- `last_turn_provider_session_id(key)` names the conversation the **last
  completed** turn ran in. A reset does not clear it.

Chat reads the first before its turn to decide whether to shorten, and
compares the second afterwards. This distinguishes the two restarts a reset
reports, which need different responses:

| Restart | When | Response |
| --- | --- | --- |
| Codex thread budget | after the turn it retires | the answer stands; the *next* question cold-starts with the full prompt |
| Missing Codex rollout, refused `claude --resume` | during the turn | the answer came from an agent without the rules; ask once more, in full |

Making `RESET_REQUIRED` itself the re-ask trigger would re-run every second
Codex question in full (three questions, five provider invocations), which is
slower than `main` for no correctness gain.

The re-ask cannot loop: the client evicted the session and cleared the
checkpoint when the driver reported the restart, so the retry cold-starts by
construction and nothing justifies a shortened prompt on the way in.

### Removed

`has_resumable_session`, the `reuse = ... kind != "chat"` special case in
`client.py`, `AgentTurnRequest.cold_start_instructions` with its agentshim
threading, `cold_start_system_prompt` on `invoke_text` and every
implementation, and `experiment_chat_resumed_prompt`. All of them existed to
work around drivers that restarted a conversation without saying so; #523 made
them say so. `ExperimentChatSession._history` and `_load_history` went with
them: nothing reads the loaded transcript now that the prompt choice is driven
by the conversation. `_append_exchange` still writes `conversation.jsonl`,
which is what the agent reads.

### Architecture

Ownership is unchanged from #523: the driver owns the conversation during a
turn and reports restarts; the client owns the live handle and the checkpoint;
the chat session owns the prompt decision. Chat still runs on its dedicated
connection with `participates_in_run_control=False`.

```mermaid
flowchart TD
  Ask["ExperimentChatSession.ask"] -->|"provider_session_id(CHAT:thread)"| Client["AgentClient"]
  Client -->|"named"| Short["continuation prompt"]
  Client -->|"None"| Full["full read-only prompt"]
  Short --> Turn["invoke_text(reuse_session=True, session_key)"]
  Full --> Turn
  Turn --> Driver["AgentShim session"]
  Driver -->|"codex exec resume / claude --resume"| Provider["CLI provider"]
  Driver -->|"restart: budget / rollout / stale resume"| Reset["RESET_REQUIRED"]
  Reset --> Client
  Turn -->|"last_turn_provider_session_id"| Compare{"ran where the<br/>shortened prompt assumed?"}
  Compare -->|yes| Answer["answer stands"]
  Compare -->|no| Reask["re-ask once, full prompt"]
  Reask --> Answer
```

## Verification

### Correctness properties

- A shortened prompt is sent only into a conversation that a completed turn
  reported, never because a transcript exists on disk. Providers that never
  report a conversation always get the full prompt.
- An answer is returned from a shortened prompt only if that turn ran in the
  conversation that justified it.
- A conversation retired *after* serving a turn costs one answer nothing; the
  next question carries the full instructions.
- A conversation replaced *during* a turn costs exactly one extra invocation,
  never more: the retry cold-starts by construction, so the re-ask cannot
  recur.
- A stale Claude session ends in an answer, not a `RuntimeError`.
- Per-thread keys: two chat threads never share a provider conversation, and
  the default chat's identifier cannot collide with a thread's.
- `CHAT` is a durable scope, so a wired store checkpoints it; chat clients
  currently get the null store, and reuse is in-process. Nothing depends on
  which.
- Non-CLI backends (deepagents, stub) name no conversation and behave exactly
  as before.
- Run-control isolation is untouched: `participates_in_run_control=False`.

### Testing

```
uv run pytest tests/server tests/vibesys/agents -q --no-cov   -> 630 passed
uv run pytest tests/vibesys/loops -q --no-cov                 -> 605 passed
./scripts/check_format.sh                                      -> 481 files already formatted
./scripts/check_lint.sh                                        -> All checks passed
./scripts/check_types.sh                                       -> All checks passed
uv run python scripts/check_doc_links.py                       -> 326 files, no broken links
clients/tui: bun test --max-concurrency 1 src                  -> 495 passed (unchanged by this PR)
pnpm check:clients / check:ts                                  -> clean
```

New coverage in `tests/server/test_chat_session.py`:

- Prompt selection and the re-ask rule against a scripted client: the key and
  `reuse_session` chat asks for; the full prompt with no conversation named;
  the shortened prompt inside one; a re-ask when the turn ran elsewhere; no
  re-ask when the conversation was retired only afterwards; no re-ask for a
  cold turn.
- The Codex renewal, end to end through a real `AgentShimDriver`, the real
  `AgentClient`, and a real `ExperimentChatSession`, using the driver suite's
  own `_FakeAgent`: three questions produce three provider turns whose prompts
  are `[full, continuation, full]`. Checked against a driver patched to renew
  silently (the pre-#523 behavior), which produces
  `[full, continuation, continuation, full]` — the bug this fixes.
- The stale-Claude path, likewise end to end: the shortened prompt, the
  driver's own retry of it from a fresh conversation, then the question again
  with the rules restored, and an answer rather than an exception.

Not covered by the suite: a credentialed live run measuring resumed answer
latency. @AyanBinRafaih's manual smoke on this branch's earlier form measured
30.3s cold against 14.2s resumed on a comparable question, with `--resume`
visible on the follow-up process.

### Docs

`docs/contributing/agent-drivers.md` gains "Retired after a turn, or replaced
during one" under Provider session resume: the two accessors, which restarts
fall on which side, and that the experiment chat is the caller that cares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
