### PR TITLE
TUI: Render experiment chat answers as markdown format, removing unreadable text

### DIFF
--- a/clients/tui/src/ui/chat-overlay.ts
+++ b/clients/tui/src/ui/chat-overlay.ts
@@ -72,7 +72,12 @@ export class ChatOverlayView {
     this.#conversation = new ConversationView(renderer, controller, markdownStyle, theme, {
       selectConversation: state => state.chatConversation,
       emptyContent: 'Ask a question about the current experiment, its progress, or a failure.',
-      renderMarkdown: false,
+      // Answers are agent-authored markdown; the operator's own messages stay
+      // verbatim so typed ** or # is never concealed as markup. The chat keeps
+      // answering after the run turns terminal, so it never switches to the
+      // finalized parse that would leave a fresh answer blank until a redraw.
+      markdownKinds: ['assistant'],
+      markdownStreaming: true,
     });
     this.#composer = new ChatComposerView(
       renderer,

--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -103,7 +103,12 @@ export class ChatPaneView {
     this.#conversation = new ConversationView(renderer, controller, markdownStyle, theme, {
       selectConversation: state => state.chatConversation,
       emptyContent: 'Ask about this run: progress, a failure, or what a hypothesis changed.',
-      renderMarkdown: false,
+      // Answers are agent-authored markdown; the operator's own messages stay
+      // verbatim so typed ** or # is never concealed as markup. The chat keeps
+      // answering after the run turns terminal, so it never switches to the
+      // finalized parse that would leave a fresh answer blank until a redraw.
+      markdownKinds: ['assistant'],
+      markdownStreaming: true,
       onFocusRequest: () => controller.focusPane('chat'),
     });
     this.#composer = new ChatComposerView(

--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -17,7 +17,21 @@ import type {Theme} from './theme.js';
 export interface ConversationViewOptions {
   selectConversation?: (state: SessionState) => ConversationEntry[];
   emptyContent?: string;
-  renderMarkdown?: boolean;
+  /**
+   * Entry kinds drawn through the markdown pipeline; every other kind draws
+   * its content verbatim. Defaults to all prose-bearing kinds, which is what
+   * the main transcript wants; the chat narrows this to assistant answers so
+   * the operator's own typed markers are never concealed as markup.
+   */
+  markdownKinds?: readonly ConversationEntry['kind'][];
+  /**
+   * Forces the markdown parser's incremental mode. By default cards finalize
+   * once the run is terminal, but finalized parsing is asynchronous and draws
+   * nothing until a later redraw; a view that still receives entries after the
+   * run ends (the chat answering a post-mortem question) sets this so a fresh
+   * answer is never an invisible card waiting on a keypress.
+   */
+  markdownStreaming?: boolean;
   /** Whether this view draws the entry cursor. */
   showsSelection?: boolean;
   /** Gives the containing semantic pane focus when any conversation surface is clicked. */
@@ -48,7 +62,8 @@ export class ConversationView {
   readonly #expandedTools = new Set<string>();
   readonly #selectConversation: (state: SessionState) => ConversationEntry[];
   #emptyContent: string;
-  readonly #renderMarkdown: boolean;
+  readonly #markdownKinds: ReadonlySet<ConversationEntry['kind']>;
+  readonly #markdownStreaming: boolean | undefined;
   readonly #showsSelection: boolean;
   readonly #onFocusRequest: (() => void) | undefined;
   #renderedConversation: ConversationEntry[] = [];
@@ -75,7 +90,8 @@ export class ConversationView {
     this.#theme = theme;
     this.#selectConversation = options.selectConversation ?? visibleConversation;
     this.#emptyContent = options.emptyContent ?? 'Waiting for run events…';
-    this.#renderMarkdown = options.renderMarkdown ?? true;
+    this.#markdownKinds = new Set(options.markdownKinds ?? ['assistant', 'prompt', 'user']);
+    this.#markdownStreaming = options.markdownStreaming;
     this.#showsSelection = options.showsSelection ?? false;
     this.#onFocusRequest = options.onFocusRequest;
     const onRevealOlder = options.onRevealOlder;
@@ -358,10 +374,7 @@ export class ConversationView {
       }),
     );
     card.add(heading);
-    if (
-      this.#renderMarkdown &&
-      (entry.kind === 'assistant' || entry.kind === 'prompt' || entry.kind === 'user')
-    ) {
+    if (this.#markdownKinds.has(entry.kind)) {
       this.#renderMarkdownEntry(card, entry);
     } else if (
       entry.kind === 'tool' &&
@@ -420,7 +433,7 @@ export class ConversationView {
         content: preview.content,
         syntaxStyle: this.#markdownStyle,
         conceal: true,
-        streaming: !this.controller.state.core.terminal,
+        streaming: this.#markdownStreaming ?? !this.controller.state.core.terminal,
         width: '100%',
       }),
     );

--- a/clients/tui/src/ui/styles.ts
+++ b/clients/tui/src/ui/styles.ts
@@ -6,14 +6,30 @@ export type EntryPalette = ConversationRoleColors;
 
 export function createMarkdownStyle(theme: Theme): SyntaxStyle {
   const {markdown} = theme;
+  // Style names are the markup.* capture groups the markdown renderer emits.
+  // Lookup tries the exact capture and then only its first dotted segment, so
+  // the numbered heading captures each need their own entry: a plain
+  // "heading" entry is never consulted, which left every markdown color
+  // except default unused.
+  const heading = {fg: markdown.heading, bold: true};
+  const code = {fg: markdown.code, bg: markdown.codeBackground};
   return SyntaxStyle.fromStyles({
     default: {fg: markdown.default},
-    heading: {fg: markdown.heading, bold: true},
-    strong: {fg: markdown.strong, bold: true},
-    em: {fg: markdown.em, italic: true},
-    code: {fg: markdown.code, bg: markdown.codeBackground},
-    link: {fg: markdown.link, underline: true},
-    blockquote: {fg: markdown.blockquote, italic: true},
+    'markup.heading': heading,
+    'markup.heading.1': heading,
+    'markup.heading.2': heading,
+    'markup.heading.3': heading,
+    'markup.heading.4': heading,
+    'markup.heading.5': heading,
+    'markup.heading.6': heading,
+    'markup.strong': {fg: markdown.strong, bold: true},
+    'markup.italic': {fg: markdown.em, italic: true},
+    'markup.raw': code,
+    'markup.raw.block': code,
+    'markup.link': {fg: markdown.link, underline: true},
+    'markup.link.url': {fg: markdown.link, underline: true},
+    'markup.link.label': {fg: markdown.link},
+    'markup.quote': {fg: markdown.blockquote, italic: true},
   });
 }
 

--- a/clients/tui/src/ui/theme.test.ts
+++ b/clients/tui/src/ui/theme.test.ts
@@ -115,6 +115,9 @@ describe('semantic roles', () => {
     expect(contrastRatio(theme.textPrimary, theme.canvas)).toBeGreaterThanOrEqual(minimum);
     expect(contrastRatio(theme.textStrong, theme.canvas)).toBeGreaterThanOrEqual(minimum);
     expect(contrastRatio(theme.markdown.default, theme.canvas)).toBeGreaterThanOrEqual(minimum);
+    expect(contrastRatio(theme.markdown.strong, theme.canvas)).toBeGreaterThanOrEqual(minimum);
+    expect(contrastRatio(theme.markdown.heading, theme.canvas)).toBeGreaterThanOrEqual(minimum);
+    expect(contrastRatio(theme.markdown.em, theme.canvas)).toBeGreaterThanOrEqual(minimum);
     expect(contrastRatio(theme.textMuted, theme.canvas)).toBeGreaterThanOrEqual(3);
     expect(contrastRatio(theme.textSubtle, theme.canvas)).toBeGreaterThanOrEqual(3);
   });

--- a/clients/tui/src/ui/theme.ts
+++ b/clients/tui/src/ui/theme.ts
@@ -245,7 +245,7 @@ function buildMarkdown(spec: ThemeSpec): MarkdownColors {
   const derived: MarkdownColors = {
     default: ensureContrast(spec.textPrimary, spec.canvas, spec.minContrast),
     heading: ensureContrast(spec.accent, spec.canvas, spec.minContrast),
-    strong: spec.textStrong,
+    strong: ensureContrast(spec.textStrong, spec.canvas, spec.minContrast),
     em: ensureContrast(spec.textMuted, spec.canvas, spec.minContrast),
     code: ensureContrast(spec.accent, codeBackground, spec.minContrast),
     codeBackground,


### PR DESCRIPTION
## Problem

The experiment chat answers in agent-authored markdown, but both chat surfaces (the docked pane and the modal) passed `renderMarkdown: false` to `ConversationView`, so every answer showed raw `**`, `#`, and backtick markers as literal text.

Two deeper defects surfaced while fixing this. First, markdown syntax styling has never applied anywhere in the TUI: `createMarkdownStyle` registered names like `heading` and `strong`, but the markdown renderer emits `markup.*` capture groups (`markup.heading.1`, `markup.strong`, ...) and the style lookup falls back only to the first dotted segment (`markup`), never to a bare `heading`. Every markdown color in every theme except `default` was dead configuration, in the chat and in the main transcript alike. Second, `markdown.strong` was the one markdown color that bypassed `ensureContrast` in `buildMarkdown`, so a theme could ship bold text below the readability floor.

## Solution

`ConversationView` replaces the `renderMarkdown` boolean with `markdownKinds`, the set of entry kinds drawn through the markdown pipeline. The default (`assistant`, `prompt`, `user`) reproduces the main transcript's existing behavior exactly. The chat surfaces pass `['assistant']`: answers render formatted with markers concealed, while the operator's own messages stay verbatim, so a typed `**bold**` is never silently concealed as markup.

Rendering chat entries as markdown exposed a timing problem: the finalized (non-streaming) parse is asynchronous and draws nothing until a later redraw, and the chat keeps answering after the run turns terminal, which is exactly when `ConversationView` switches to the finalized parse. A fresh answer would arrive as a blank card until the next keypress. A new `markdownStreaming` option forces the synchronous incremental parse; the chat surfaces set it, the main transcript keeps its default.

`createMarkdownStyle` now registers the `markup.*` capture names the renderer actually emits: `markup.heading` plus the per-level `markup.heading.1` through `.6` (the numbered captures each need their own entry because the lookup fallback is not progressive), `markup.strong`, `markup.italic`, `markup.raw` and `markup.raw.block`, `markup.link` with `.url` and `.label`, and `markup.quote`. Heading, bold, italic, code, link, and quote styling now paint for the first time, in the chat and the main transcript.

`buildMarkdown` clamps `markdown.strong` through `ensureContrast` against the canvas like every other derived markdown color, so bold meets each theme's minimum contrast (4.5 standard, 7 high contrast) even under theme overrides.

### Architecture

Ownership is unchanged: themes own colors, `styles.ts` owns the mapping from theme colors to syntax style entries, `ConversationView` owns how entries become renderables, and the chat surfaces own their per-surface options.

```mermaid
flowchart LR
    E[ConversationEntry] --> K{kind in markdownKinds?}
    K -- no --> T[TextRenderable, verbatim]
    K -- yes --> M[MarkdownRenderable, markers concealed]
    M --> S[markdownStreaming true: incremental parse, never blank post-terminal]
    S --> Y[SyntaxStyle markup.* entries]
    Y --> C[theme.markdown colors, ensureContrast clamped]
```

## Verification

Automated: full TUI suite, typecheck, architecture check, build, and lint on the changed files all pass. Manual: a real `--cli-provider claude` run on a live experiment, verifying both chat surfaces and all 8 themes with ANSI capture.

### Correctness properties

- Chat assistant answers render with `**`, `#`, and backtick markers concealed and heading, bold, and code colored, identically in the docked pane and the modal, for streamed and post-terminal answers.
- Non-assistant chat entries (the operator's questions, queued prompts) render verbatim; typed markdown characters are never concealed.
- The main transcript's markdown gating is byte-for-byte the previous behavior (`assistant`, `prompt`, `user`).
- A chat answer arriving after the run is terminal renders immediately, never as a blank card waiting for a redraw (regression-covered by the existing configuration-failure popup test, which fails without `markdownStreaming`).
- `markdown.strong`, `markdown.heading`, and `markdown.em` meet each theme's minimum contrast against the canvas in all 8 themes, asserted per theme in `theme.test.ts`.

### Testing

- `bun test` in `clients/tui`: 467 pass, 0 fail.
- `bun run check:clients`, `bun run check:ts-architecture`, `bun run build:clients`: pass.
- `npx biome check` on the changed files: clean.
- Live TUI (`--cli-provider claude`): asked questions in the docked pane and the modal; verified via ANSI capture that headings paint the theme heading color with bold set, inline code paints on the code background, markers are concealed, and a typed `**bold**` in the You card stays verbatim. Repeated a post-terminal question to confirm the answer renders without a keypress.
- Theme sweep across all 8 themes via `/theme`: captured the heading color in each and confirmed it matches the theme's markdown palette; contrast is enforced by the new unit assertions.

Closes #464.