### PR TITLE
TUI: Add objective context for /perf

### DIFF
--- a/clients/backend-client/src/generated/protocol.generated.ts
+++ b/clients/backend-client/src/generated/protocol.generated.ts
@@ -342,6 +342,13 @@ export type PerfUnit1 = string;
 export type Passed = boolean;
 export type ProfileSkipped = boolean;
 export type Performance = PerformanceRound[];
+export type ObjectiveMetric = string | null;
+export type ObjectiveUnit = string | null;
+export type ObjectiveDirection = ("max" | "min") | null;
+export type ObjectiveBaselineValue = number | null;
+export type ObjectiveBaselineRound = number | null;
+export type ObjectiveBaselineCommit = string | null;
+export type ObjectiveDescription = string | null;
 export type HypothesisId = string;
 export type Identified = boolean;
 export type Title3 = string | null;
@@ -522,6 +529,7 @@ export interface Response {
   snapshot?: RunSnapshot | null;
   events?: Events;
   performance?: Performance;
+  performance_context?: PerformanceContext | null;
   experiments?: Experiments;
   experiments_ready?: ExperimentsReady;
 }
@@ -885,6 +893,23 @@ export interface PerformanceRound {
   perf_unit: PerfUnit1;
   passed: Passed;
   profile_skipped?: ProfileSkipped;
+}
+/**
+ * What the performance plot measures and how to read it.
+ *
+ * Copied from recorded run state and the run manifest, never recomputed.
+ * Every field is optional so the section can describe the objective before
+ * the first measurement and omit facts a run never recorded; a run whose
+ * prose is known before its metric still gets a description-only context.
+ */
+export interface PerformanceContext {
+  objective_metric?: ObjectiveMetric;
+  objective_unit?: ObjectiveUnit;
+  objective_direction?: ObjectiveDirection;
+  objective_baseline_value?: ObjectiveBaselineValue;
+  objective_baseline_round?: ObjectiveBaselineRound;
+  objective_baseline_commit?: ObjectiveBaselineCommit;
+  objective_description?: ObjectiveDescription;
 }
 /**
  * One unit of investigation: a hypothesis and every round it spans.

--- a/clients/backend-client/src/generated/protocol.schema.json
+++ b/clients/backend-client/src/generated/protocol.schema.json
@@ -1735,6 +1735,102 @@
       "title": "PauseCommand",
       "type": "object"
     },
+    "PerformanceContext": {
+      "additionalProperties": false,
+      "description": "What the performance plot measures and how to read it.\n\nCopied from recorded run state and the run manifest, never recomputed.\nEvery field is optional so the section can describe the objective before\nthe first measurement and omit facts a run never recorded; a run whose\nprose is known before its metric still gets a description-only context.",
+      "properties": {
+        "objective_metric": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Objective Metric"
+        },
+        "objective_unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Objective Unit"
+        },
+        "objective_direction": {
+          "anyOf": [
+            {
+              "enum": [
+                "max",
+                "min"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Objective Direction"
+        },
+        "objective_baseline_value": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Objective Baseline Value"
+        },
+        "objective_baseline_round": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Objective Baseline Round"
+        },
+        "objective_baseline_commit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Objective Baseline Commit"
+        },
+        "objective_description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Objective Description"
+        }
+      },
+      "title": "PerformanceContext",
+      "type": "object"
+    },
     "PerformanceQuery": {
       "additionalProperties": false,
       "properties": {
@@ -2011,6 +2107,17 @@
           },
           "title": "Performance",
           "type": "array"
+        },
+        "performance_context": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PerformanceContext"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "experiments": {
           "items": {

--- a/clients/tui/src/performance-chart.test.ts
+++ b/clients/tui/src/performance-chart.test.ts
@@ -35,7 +35,94 @@ describe('renderPerformanceCurve', () => {
   it('handles missing data', () => {
     expect(renderPerformanceCurve([])).toBe('No performance data yet.');
   });
+
+  it('titles the plot with the backend metric name instead of the unit', () => {
+    const record = {...performance(1, 1000), perf_unit: 'ops/s'};
+    const chart = renderPerformanceCurve([record], [], context({objective_unit: 'ops/s'}));
+
+    expect(chart).toContain('Performance · total_ops_per_sec');
+    expect(chart).not.toContain('Performance · ops/s');
+    expect(chart.match(/●/g)).toHaveLength(1);
+  });
+
+  it('states metric, unit, direction, and baseline above the plot', () => {
+    const chart = renderPerformanceCurve(
+      [performance(1, 1000), performance(2, 2000)],
+      [],
+      context({
+        objective_unit: 'ops/s',
+        objective_direction: 'max',
+        objective_baseline_value: 1234.5,
+        objective_baseline_round: 1,
+        objective_baseline_commit: 'e17fce8123abc',
+        objective_description: 'Throughput of the MPMC queue benchmark.',
+      }),
+    );
+
+    expect(chart).toContain('Metric    total_ops_per_sec (ops/s) · maximize ↑');
+    expect(chart).toContain('Baseline  1234.5 · r1 · commit e17fce8');
+    expect(chart).toContain('Measures  Throughput of the MPMC queue benchmark.');
+  });
+
+  it('spells minimize with its glyph for a lower-is-better objective', () => {
+    const chart = renderPerformanceCurve(
+      [performance(1, 1000)],
+      [],
+      context({objective_metric: 'p99_latency_us', objective_direction: 'min'}),
+    );
+
+    expect(chart).toContain('Metric    p99_latency_us · minimize ↓');
+  });
+
+  it('drops the lines for facts the run never recorded', () => {
+    const chart = renderPerformanceCurve([performance(1, 1000)], [], context({}));
+
+    expect(chart).toContain('Metric    total_ops_per_sec');
+    expect(chart).not.toContain('maximize');
+    expect(chart).not.toContain('minimize');
+    expect(chart).not.toContain('Baseline');
+    expect(chart).not.toContain('Measures');
+  });
+
+  it('does not repeat a unit slot that just holds the metric name', () => {
+    const chart = renderPerformanceCurve(
+      [performance(1, 1000)],
+      [],
+      context({objective_unit: 'total_ops_per_sec'}),
+    );
+
+    expect(chart).not.toContain('(total_ops_per_sec)');
+  });
+
+  it('renders a description-only context when only the prose is known', () => {
+    const chart = renderPerformanceCurve([], [], {
+      objective_description: 'Maximize queue throughput.',
+    });
+
+    expect(chart).toContain('Measures  Maximize queue throughput.');
+    expect(chart).not.toContain('Metric ');
+    expect(chart.endsWith('No performance data yet.')).toBe(true);
+  });
+
+  it('shows the objective before the first measurement', () => {
+    const chart = renderPerformanceCurve(
+      [],
+      [],
+      context({objective_direction: 'max', objective_description: 'Ops per second.'}),
+    );
+
+    expect(chart).toContain('Metric    total_ops_per_sec · maximize ↑');
+    expect(chart).toContain('Measures  Ops per second.');
+    expect(chart.endsWith('No performance data yet.')).toBe(true);
+    expect(chart).not.toContain('●');
+  });
 });
+
+function context(
+  overrides: Partial<NonNullable<ProtocolResponse['performance_context']>>,
+): NonNullable<ProtocolResponse['performance_context']> {
+  return {objective_metric: 'total_ops_per_sec', ...overrides};
+}
 
 function performance(
   round: number,

--- a/clients/tui/src/performance-chart.ts
+++ b/clients/tui/src/performance-chart.ts
@@ -8,18 +8,28 @@ interface PerfPoint {
   unit: string;
 }
 
+type PerformanceContext = NonNullable<ProtocolResponse['performance_context']>;
+
 const PLOT_HEIGHT = 8;
 const PLOT_WIDTH = 48;
+const CONTEXT_LABEL_WIDTH = 10;
 
 export function renderPerformanceCurve(
   performance: ProtocolResponse['performance'] | undefined,
   events?: RunEvent[],
+  context?: ProtocolResponse['performance_context'],
 ): string {
   const points = performancePoints(performance, events);
-  if (points.length === 0) return 'No performance data yet.';
+  const contextLines = contextSection(context ?? null);
+  if (points.length === 0) {
+    return [...contextLines, 'No performance data yet.'].join('\n');
+  }
 
-  const metric = latestMetric(points);
-  const visible = points.filter(point => point.metric === metric);
+  // Points are still keyed by the recorded unit string; the backend context
+  // only names the series, so it must not change which points are plotted.
+  const series = latestMetric(points);
+  const metric = context?.objective_metric ?? series;
+  const visible = points.filter(point => point.metric === series);
   const values = visible.map(point => point.value);
   const minValue = Math.min(...values);
   const maxValue = Math.max(...values);
@@ -35,7 +45,7 @@ export function renderPerformanceCurve(
     if (row) row[x] = '●';
   }
 
-  const lines = [`Performance · ${metric}`];
+  const lines = [`Performance · ${metric}`, ...contextLines];
   for (let row = 0; row < PLOT_HEIGHT; row += 1) {
     const value = maxValue - ((maxValue - minValue) * row) / Math.max(1, PLOT_HEIGHT - 1);
     lines.push(`${formatAxis(value).padStart(8)} ┤${(grid[row] ?? []).join('')}`);
@@ -92,6 +102,54 @@ function performancePoints(
 
 function latestMetric(points: PerfPoint[]): string {
   return points.at(-1)?.metric ?? 'performance';
+}
+
+/**
+ * The objective facts above the plot: metric, unit, direction, baseline, and
+ * how the benchmark measures. Direction is words plus a glyph, never color,
+ * and absent facts drop their line rather than render a placeholder.
+ */
+function contextSection(context: PerformanceContext | null): string[] {
+  if (context === null) return [];
+  const lines: string[] = [];
+  if (context.objective_metric) {
+    lines.push(contextLine('Metric', metricSummary(context.objective_metric, context)));
+  }
+  const baseline = baselineSummary(context);
+  if (baseline !== null) lines.push(contextLine('Baseline', baseline));
+  if (context.objective_description) {
+    lines.push(contextLine('Measures', context.objective_description));
+  }
+  if (lines.length === 0) return [];
+  lines.push('');
+  return lines;
+}
+
+function contextLine(label: string, value: string): string {
+  return `${label.padEnd(CONTEXT_LABEL_WIDTH)}${value}`;
+}
+
+function metricSummary(metric: string, context: PerformanceContext): string {
+  const parts = [metric];
+  // Legacy rounds record the metric name in the unit slot; repeating it as a
+  // parenthesized unit would read as noise.
+  if (context.objective_unit && context.objective_unit !== metric) {
+    parts.push(`(${context.objective_unit})`);
+  }
+  const summary = parts.join(' ');
+  if (context.objective_direction === 'max') return `${summary} · maximize ↑`;
+  if (context.objective_direction === 'min') return `${summary} · minimize ↓`;
+  return summary;
+}
+
+function baselineSummary(context: PerformanceContext): string | null {
+  const parts: string[] = [];
+  if (context.objective_baseline_value != null) parts.push(trim(context.objective_baseline_value));
+  if (context.objective_baseline_round != null) parts.push(`r${context.objective_baseline_round}`);
+  if (context.objective_baseline_commit) {
+    parts.push(`commit ${context.objective_baseline_commit.slice(0, 7)}`);
+  }
+  return parts.length > 0 ? parts.join(' · ') : null;
 }
 
 function scale(

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -633,7 +633,11 @@ export class SocketSessionController implements SessionController {
   async #requestPane(view: PaneView): Promise<void> {
     try {
       const response = await this.client.request({type: 'query.performance'});
-      const content = renderPerformanceCurve(response.performance ?? [], response.events ?? []);
+      const content = renderPerformanceCurve(
+        response.performance ?? [],
+        response.events ?? [],
+        response.performance_context,
+      );
       this.#setState(setPaneContent(this.#state, view, content));
     } catch (error) {
       const message = errorMessage(error);
@@ -1028,7 +1032,11 @@ function renderResponse(
 ): string | null {
   if (response.ack) return `${response.ack.action}: ${response.ack.status}`;
   if (request.type === 'query.performance' || responseView === 'perf') {
-    return renderPerformanceCurve(response.performance ?? [], response.events ?? []);
+    return renderPerformanceCurve(
+      response.performance ?? [],
+      response.events ?? [],
+      response.performance_context,
+    );
   }
   return null;
 }

--- a/src/vibesys/server/performance.py
+++ b/src/vibesys/server/performance.py
@@ -1,0 +1,98 @@
+"""Project performance-plot context from authoritative run state.
+
+Like the experiment log, this is a one-way projection: recorded measurement
+facts and manifest objectives are copied onto the wire, never recomputed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from vibesys.server.protocol import PerformanceContext
+
+if TYPE_CHECKING:
+    from vibesys.loops.agent.model import AgentRunState, HypothesisMeasurement
+
+# The objective document is operator-authored markdown of arbitrary length,
+# and the payload must stay bounded, so only one capped paragraph is sent.
+_DESCRIPTION_LIMIT = 280
+
+
+def build_performance_context(
+    state: AgentRunState | None,
+    *,
+    objectives: tuple[str, ...],
+    objective_description: str | None = None,
+) -> PerformanceContext | None:
+    """Assemble the /perf context, preferring the newest official measurement.
+
+    Before any measurement exists the manifest objectives alone can name the
+    metric and its direction, so the section can render from round zero.
+    """
+    measurement = _latest_measurement(state)
+    metric = measurement.metric if measurement is not None else primary_objective_metric(objectives)
+    if metric is None and objective_description is None:
+        return None
+    direction = measurement.direction if measurement is not None else None
+    if direction is None and metric is not None:
+        direction = metric_directions(objectives).get(metric)
+    return PerformanceContext(
+        objective_metric=metric,
+        objective_unit=measurement.unit if measurement is not None else None,
+        objective_direction=direction,
+        # Baseline facts are copied as one tuple from the same measurement so
+        # the value can never pair with another comparison's round or commit.
+        objective_baseline_value=measurement.baseline_value if measurement is not None else None,
+        objective_baseline_round=measurement.baseline_round if measurement is not None else None,
+        objective_baseline_commit=measurement.baseline_commit if measurement is not None else None,
+        objective_description=objective_description,
+    )
+
+
+def summarize_objective(text: str) -> str | None:
+    """Return the first prose paragraph of an objective document, bounded."""
+    for block in text.split("\n\n"):
+        lines = (line.strip() for line in block.splitlines())
+        prose = " ".join(line for line in lines if line and not line.startswith("#"))
+        if not prose:
+            continue
+        if len(prose) > _DESCRIPTION_LIMIT:
+            prose = prose[: _DESCRIPTION_LIMIT - 1].rstrip() + "…"
+        return prose
+    return None
+
+
+def primary_objective_metric(encoded: tuple[str, ...]) -> str | None:
+    """Return the first objective's metric name from its encoded form."""
+    for value in encoded:
+        name, separator, _ = value.rpartition(":")
+        metric = name if separator else value
+        if metric:
+            return metric
+    return None
+
+
+def metric_directions(encoded: tuple[str, ...]) -> dict[str, Literal["max", "min"]]:
+    """Decode objective directions stored with an agent run."""
+    directions: dict[str, Literal["max", "min"]] = {}
+    for value in encoded:
+        name, separator, direction = value.rpartition(":")
+        if separator and name:
+            if direction == "max":
+                directions[name] = "max"
+            elif direction == "min":
+                directions[name] = "min"
+    return directions
+
+
+def _latest_measurement(state: AgentRunState | None) -> HypothesisMeasurement | None:
+    if state is None:
+        return None
+    latest: HypothesisMeasurement | None = None
+    for hypothesis in state.hypotheses:
+        measurement = hypothesis.measurement
+        if measurement is None:
+            continue
+        if latest is None or measurement.round > latest.round:
+            latest = measurement
+    return latest

--- a/src/vibesys/server/protocol.py
+++ b/src/vibesys/server/protocol.py
@@ -228,6 +228,24 @@ class PerformanceRound(ProtocolModel):  # noqa: D101  # tracked: #288
     profile_skipped: bool = False
 
 
+class PerformanceContext(ProtocolModel):
+    """What the performance plot measures and how to read it.
+
+    Copied from recorded run state and the run manifest, never recomputed.
+    Every field is optional so the section can describe the objective before
+    the first measurement and omit facts a run never recorded; a run whose
+    prose is known before its metric still gets a description-only context.
+    """
+
+    objective_metric: str | None = None
+    objective_unit: str | None = None
+    objective_direction: Literal["max", "min"] | None = None
+    objective_baseline_value: FiniteFloat | None = None
+    objective_baseline_round: int | None = None
+    objective_baseline_commit: str | None = None
+    objective_description: str | None = None
+
+
 class HypothesisRound(ProtocolModel):
     """One round belonging to a hypothesis, for the experiment-log drill-down."""
 
@@ -300,6 +318,9 @@ class Response(ProtocolModel):  # noqa: D101  # tracked: #288
     snapshot: RunSnapshot | None = None
     events: list[RunEvent] = Field(default_factory=list)
     performance: list[PerformanceRound] = Field(default_factory=list)
+    # None means the run has not recorded what its metric is, which is
+    # distinct from a run whose plot is merely empty so far.
+    performance_context: PerformanceContext | None = None
     experiments: list[HypothesisEntry] = Field(default_factory=list)
     # False means canonical project/run state is not attached yet. Keeping the
     # readiness marker separate preserves the protocol-v1 list contract while

--- a/src/vibesys/server/service.py
+++ b/src/vibesys/server/service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import threading
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from vibesys.loops.agent.hypotheses import reproject_run_evidence
 from vibesys.loops.agent.state import AgentRunStateStore
@@ -11,6 +11,11 @@ from vibesys.server.chat_options import build_chat_options
 from vibesys.server.events import EventType, RunEvent
 from vibesys.server.experiments import build_experiment_log
 from vibesys.server.inspector import RunInspector
+from vibesys.server.performance import (
+    build_performance_context,
+    metric_directions,
+    summarize_objective,
+)
 from vibesys.server.protocol import (
     ActiveAgentExecution,
     ChatOptions,
@@ -25,6 +30,7 @@ from vibesys.server.protocol import (
     HistoryQuery,
     HypothesisEntry,
     PauseCommand,
+    PerformanceContext,
     PerformanceQuery,
     PerformanceRound,
     ProtocolRequest,
@@ -36,6 +42,7 @@ from vibesys.server.protocol import (
     TuiDefaultsQuery,
 )
 from vibesys.server.supervisor import RunSupervisor  # noqa: TC001  # tracked: #288
+from vs_project import ProjectStateError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -77,7 +84,11 @@ class SupervisionService:
             return Response(request_id=request.request_id, events=self.history_events())
         if isinstance(request, PerformanceQuery):
             self.supervisor.record(EventType.STATUS_QUERY, "/perf")
-            return Response(request_id=request.request_id, performance=self.performance_rounds())
+            return Response(
+                request_id=request.request_id,
+                performance=self.performance_rounds(),
+                performance_context=self.performance_context(),
+            )
         if isinstance(request, ExperimentQuery):
             self.supervisor.record(EventType.STATUS_QUERY, "/experiments")
             ready = self.supervisor.project_run is not None
@@ -191,6 +202,35 @@ class SupervisionService:
             )
         return rounds
 
+    def performance_context(self) -> PerformanceContext | None:
+        """Describe what the performance plot measures, for presentation clients."""
+        project_run = self.supervisor.project_run
+        if project_run is None:
+            return None
+        manifest = project_run.project.state.load_run(project_run.run_id)
+        if manifest.configuration.outer_loop != "agent":
+            return None
+        return build_performance_context(
+            self._agent_run_state(),
+            objectives=manifest.configuration.objectives,
+            objective_description=self._objective_description(),
+        )
+
+    def _objective_description(self) -> str | None:
+        """Read the bounded summary of the run's recorded objective prose."""
+        project_run = self.supervisor.project_run
+        if project_run is None:
+            return None
+        try:
+            runtime = project_run.project.state.portable_namespace(project_run.run_id, "runtime")
+            document = runtime.external_directory() / "effective-objective.md"
+            if not document.is_file():
+                return None
+            text = document.read_text(encoding="utf-8")
+        except (OSError, ProjectStateError):
+            return None
+        return summarize_objective(text)
+
     def experiments(self) -> list[HypothesisEntry]:
         """Project the run's authoritative hypothesis aggregate for clients."""
         state = self._agent_run_state()
@@ -218,10 +258,10 @@ class SupervisionService:
             return store.migrate_legacy(
                 rounds=project_run.project.state.load_rounds(project_run.run_id),
                 local_namespace=local,
-                legacy_directions=_metric_directions(manifest.configuration.objectives),
+                legacy_directions=metric_directions(manifest.configuration.objectives),
             )
         return reproject_run_evidence(
-            state, legacy_directions=_metric_directions(manifest.configuration.objectives)
+            state, legacy_directions=metric_directions(manifest.configuration.objectives)
         )
 
     def wait_for_events(
@@ -241,18 +281,3 @@ class SupervisionService:
     def latest_sequence(self) -> int:
         """The newest sequence in the run's log, without a snapshot's copies."""
         return self.supervisor.latest_sequence
-
-
-def _metric_directions(
-    encoded: tuple[str, ...],
-) -> dict[str, Literal["max", "min"]]:
-    """Decode objective directions stored with an agent run."""
-    directions: dict[str, Literal["max", "min"]] = {}
-    for value in encoded:
-        name, separator, direction = value.rpartition(":")
-        if separator and name:
-            if direction == "max":
-                directions[name] = "max"
-            elif direction == "min":
-                directions[name] = "min"
-    return directions

--- a/tests/server/test_performance_context.py
+++ b/tests/server/test_performance_context.py
@@ -1,0 +1,228 @@
+"""Server projection tests for the /perf objective context."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from vibesys.loops.agent.model import AgentRunState, Hypothesis, HypothesisMeasurement
+from vibesys.loops.agent.state import AgentRunStateStore
+from vibesys.schemas import OrchestratorPlan
+from vibesys.server import RunSupervisor
+from vibesys.server.performance import build_performance_context, summarize_objective
+from vibesys.server.protocol import PerformanceQuery
+from vibesys.server.service import SupervisionService
+from vs_loop_state import RoundRecord
+from vs_project import AgentRunConfiguration, Project, RunEnvironmentRecord
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _hypothesis(identifier: str, started_round: int, **overrides: object) -> Hypothesis:
+    fields: dict[str, object] = {
+        "hypothesis_id": identifier,
+        "plan": OrchestratorPlan(
+            hypothesis_id=identifier,
+            hypothesis=f"claim for {identifier}",
+            task=f"test {identifier}",
+            pass_criteria="",
+            reasoning="",
+        ),
+        "started_round": started_round,
+    }
+    fields.update(overrides)
+    return Hypothesis.model_validate(fields)
+
+
+def _measurement(round_number: int, **overrides: object) -> HypothesisMeasurement:
+    fields: dict[str, object] = {
+        "round": round_number,
+        "metric": "total_ops_per_sec",
+        "value": 2000.0,
+    }
+    fields.update(overrides)
+    return HypothesisMeasurement.model_validate(fields)
+
+
+def _configuration(objectives: tuple[str, ...]) -> AgentRunConfiguration:
+    return AgentRunConfiguration(
+        outer_loop="agent",
+        inner_loop="single-agent",
+        interface="inprocess",
+        agent_backend="stub",
+        compute_backend="cpu",
+        profiler="none",
+        max_rounds=3,
+        max_retries_per_round=1,
+        judge_every=1,
+        official_eval_every=1,
+        memory_layout="files",
+        run_environment=RunEnvironmentRecord(name="local"),
+        objectives=objectives,
+    )
+
+
+def _project_run(project: Path, objectives: tuple[str, ...]) -> tuple[Project, str]:
+    project.mkdir()
+    (project / "OBJECTIVE.md").write_text("Make the queue fast.\n", encoding="utf-8")
+    vibesys_project = Project.open(project)
+    vibesys_project.state.create_project("queue")
+    manifest = vibesys_project.state.new_run_manifest(
+        "queue",
+        run_id="queue-run",
+        branch="vibesys/queue-run",
+        vibesys_version="0.2.0-test",
+        configuration=_configuration(objectives),
+        trusted_input_baseline="0" * 40,
+    )
+    vibesys_project.state.create_run(manifest)
+    return vibesys_project, manifest.run_id
+
+
+def _service(project: Project, run_id: str) -> SupervisionService:
+    supervisor = RunSupervisor()
+    supervisor.attach(project.state.log_directory(run_id), project=project, run_id=run_id)
+    return SupervisionService(supervisor)
+
+
+def test_service_projects_context_from_round_evidence_and_objective_prose(
+    tmp_path: Path,
+) -> None:
+    project, run_id = _project_run(tmp_path / "project", ("total_ops_per_sec:max",))
+    document = project.state.portable_namespace(run_id, "runtime").external_directory()
+    (document / "effective-objective.md").write_text(
+        "# Objective\n\nMaximize queue throughput measured by the mpmc benchmark.\n\nMore detail.\n",
+        encoding="utf-8",
+    )
+    AgentRunStateStore(project.state.portable_namespace(run_id, "agent")).save(
+        AgentRunState(
+            hypotheses=[
+                _hypothesis(
+                    "H-01",
+                    1,
+                    rounds=[
+                        RoundRecord(
+                            round_number=2,
+                            commit="c2",
+                            hypothesis_id="H-01",
+                            passed=True,
+                            official_evaluation=True,
+                            perf_metric=2000.0,
+                            perf_unit="total_ops_per_sec",
+                            perf_baseline_round=1,
+                            perf_baseline_commit="e17fce8123abc",
+                            perf_baseline_metric=1000.0,
+                        )
+                    ],
+                )
+            ]
+        )
+    )
+
+    response = _service(project, run_id).execute(PerformanceQuery())
+
+    context = response.performance_context
+    assert context is not None
+    assert context.objective_metric == "total_ops_per_sec"
+    assert context.objective_unit == "total_ops_per_sec"
+    assert context.objective_direction == "max"
+    assert context.objective_baseline_value == 1000.0
+    assert context.objective_baseline_round == 1
+    assert context.objective_baseline_commit == "e17fce8123abc"
+    assert context.objective_description == (
+        "Maximize queue throughput measured by the mpmc benchmark."
+    )
+
+
+def test_service_names_the_objective_before_the_first_measurement(tmp_path: Path) -> None:
+    project, run_id = _project_run(tmp_path / "project", ("total_ops_per_sec:max",))
+    AgentRunStateStore(project.state.portable_namespace(run_id, "agent")).save(AgentRunState())
+
+    response = _service(project, run_id).execute(PerformanceQuery())
+
+    assert response.performance == []
+    context = response.performance_context
+    assert context is not None
+    assert context.objective_metric == "total_ops_per_sec"
+    assert context.objective_direction == "max"
+    assert context.objective_baseline_value is None
+    assert context.objective_description is None
+
+
+def test_service_returns_no_context_without_an_attached_run() -> None:
+    response = SupervisionService(RunSupervisor()).execute(PerformanceQuery())
+
+    assert response.performance == []
+    assert response.performance_context is None
+
+
+def test_build_context_copies_the_newest_measurement_as_one_tuple() -> None:
+    state = AgentRunState(
+        hypotheses=[
+            _hypothesis(
+                "H-01",
+                1,
+                measurement=_measurement(1, value=1000.0, baseline_value=900.0),
+            ),
+            _hypothesis(
+                "H-02",
+                2,
+                measurement=_measurement(
+                    3,
+                    value=2000.0,
+                    unit="ops/s",
+                    direction="max",
+                    baseline_round=1,
+                    baseline_commit="abc1234",
+                    baseline_value=1000.0,
+                ),
+            ),
+        ]
+    )
+
+    context = build_performance_context(state, objectives=())
+
+    assert context is not None
+    assert context.objective_unit == "ops/s"
+    assert context.objective_direction == "max"
+    assert context.objective_baseline_value == 1000.0
+    assert context.objective_baseline_round == 1
+    assert context.objective_baseline_commit == "abc1234"
+
+
+def test_build_context_falls_back_to_the_manifest_direction() -> None:
+    state = AgentRunState(hypotheses=[_hypothesis("H-01", 1, measurement=_measurement(1))])
+
+    context = build_performance_context(state, objectives=("total_ops_per_sec:min",))
+
+    assert context is not None
+    assert context.objective_direction == "min"
+
+
+def test_build_context_is_none_with_nothing_to_say() -> None:
+    assert build_performance_context(AgentRunState(), objectives=()) is None
+    assert build_performance_context(None, objectives=()) is None
+
+
+def test_build_context_carries_prose_before_the_metric_is_known() -> None:
+    context = build_performance_context(None, objectives=(), objective_description="How it runs.")
+
+    assert context is not None
+    assert context.objective_metric is None
+    assert context.objective_description == "How it runs."
+
+
+def test_summarize_objective_returns_the_first_prose_paragraph() -> None:
+    text = "# Objective\n\nLine one\ncontinues here.\n\nSecond paragraph.\n"
+
+    assert summarize_objective(text) == "Line one continues here."
+    assert summarize_objective("# Heading only\n") is None
+    assert summarize_objective("") is None
+
+
+def test_summarize_objective_bounds_a_long_paragraph() -> None:
+    summary = summarize_objective("word " * 200)
+
+    assert summary is not None
+    assert len(summary) <= 280
+    assert summary.endswith("…")


### PR DESCRIPTION
## Problem

The /perf pane plots one value per round under the title `Performance · ${metric}`, but that `metric` is really the latest point's `perf_unit` string, so the plot is labeled with a unit, not the metric. Nothing in the pane states the metric name, the direction of improvement, the baseline the values are compared against, or how the benchmark is measured. All of that already exists in backend run state (`HypothesisMeasurement`, `RoundRecord.perf_*` baseline fields, `manifest.configuration.objectives`, the committed `effective-objective.md` prose) and simply was not projected onto the `query.performance` payload.

## Solution

Project a `PerformanceContext` onto the /perf response and render it as a compact labeled section above the plot.

Backend:

- `PerformanceContext` is a new protocol model with `objective_metric`, `objective_unit`, `objective_direction` (`"max" | "min"`), `objective_baseline_value`, `objective_baseline_round`, `objective_baseline_commit`, and `objective_description`. Every field is optional, so the section can describe the objective before the first measurement and omit facts a run never recorded. `Response` gains an optional `performance_context` alongside `performance`. The generated schema and TypeScript client are regenerated and committed; the diff is purely additive and the field names were chosen so json2ts introduces no alias renumbering, including when combined with the experiment-log PR.
- A new projection module, `server/performance.py`, assembles the context the same way `experiments.py` builds the log: a one-way copy, never a recomputation. The newest official `HypothesisMeasurement` supplies metric, unit, direction, and the baseline tuple (all from the same measurement, so the value can never pair with another comparison's round or commit). Before any measurement, the manifest's `name:direction` objectives name the metric and direction. `metric_directions` moved here from `service.py` unchanged, since objective decoding now belongs to this module.
- The optional description is a bounded slice of the run's committed `effective-objective.md`: the first prose paragraph, headings skipped, capped at 280 characters. The full document is never sent. A missing or unreadable document degrades to no description.

TUI (`performance-chart.ts`):

- The title uses `objective_metric` when the backend provides it, falling back to the old unit-derived label for older backends. Point selection still keys on the recorded unit string, so the context can never change which points are plotted.
- The context section renders as aligned `Metric` / `Baseline` / `Measures` lines: `Metric    total_ops_per_sec (ops/s) · maximize ↑` (direction as a word plus a glyph, never color; the unit is not repeated when a legacy round recorded the metric name in the unit slot), `Baseline  1234.5 · r1 · commit e17fce8`, and the prose line. Absent facts drop their line rather than render a placeholder. The section precedes the plot and is followed by a blank separator line, so the fixed-width plot rows are untouched; long lines word-wrap in `RightPaneView` and in the modal fallback, which both render per line with wrapping enabled.
- The empty state is preserved: with no points and no context the pane still reads exactly `No performance data yet.`; with context but no points the section shows above that line, so the objective is visible from round zero.

### Architecture

```mermaid
flowchart LR
    S[AgentRunState<br/>newest HypothesisMeasurement] --> B[build_performance_context<br/>one-way projection]
    O[manifest objectives<br/>name:direction] --> B
    D[effective-objective.md<br/>first paragraph, capped] --> B
    B --> W[PerformanceContext on Response]
    W --> R[renderPerformanceCurve<br/>title + Metric/Baseline/Measures lines]
```

Ownership is unchanged: the agent loop owns measurement facts, the server copies them onto the wire, and the TUI owns presentation (labels, glyphs, dedupe, wrapping).

## Verification

Automated: new backend projection and summary tests, seven new TUI renderer tests, the schema drift test, full client build, lint, type checks, and architecture checks all pass. Manual: a real `--cli-provider claude` 2-round run on the queue mpmc task, exercising split, zoom, and modal layouts plus width and theme sweeps.

### Correctness properties

- The plot title names the backend's metric whenever a context is present; the unit-derived label is only a fallback for backends that predate the field.
- Metric, unit, direction, and the baseline value/round/commit all come from the single newest official `HypothesisMeasurement`; only when no measurement exists do the manifest objectives name the metric and direction.
- Direction renders as maximize/minimize words plus a glyph, never color alone, so it reads identically on every theme.
- Every context field is optional and its line is omitted when absent; a run with only objective prose still gets a description-only section.
- The description payload is bounded (first prose paragraph, 280 characters max); the full objective document is never sent.
- The empty state string and the plot geometry (axis gutter, 48-column plot, round labels) are byte-identical when no context is present.
- The committed generated schema and TypeScript client match the Python contract, both on this branch and on a simulated merge with the experiment-log PR (regenerated on the merged tree, zero diff).

### Testing

- `uv run pytest tests/server/ "tests/test_tui.py::test_committed_protocol_schema_matches_python_contract"`: 155 passed. The new `tests/server/test_performance_context.py` covers the service projection from round evidence plus objective prose, the pre-measurement objective-only context, the detached-server case, newest-measurement selection as one tuple, the manifest direction fallback, the description-only context, and the summary bounds.
- `pnpm --dir clients/backend-client generate:protocol` then `git diff`: regenerated output committed, purely additive.
- `bun test` (clients/tui): 474 pass, 0 fail. New renderer tests cover the metric-name title, the full context section, minimize with its glyph, graceful omission, unit dedupe, description-only context, and the pre-measurement empty state.
- `pnpm run build:clients`, `pnpm run check:clients`, `pnpm run check:ts-architecture`: pass. `biome check` clean on the changed TS files; `ruff check`, `ruff format --check`, and `uv run ty check` clean.
- Manual, real provider: a fresh `--agent-backend cli --cli-provider claude` 2-round run on the queue mpmc example in a tmux-driven terminal. After round 1's official measurement the open pane refreshed in place to `Performance · total_ops_per_sec` with `Metric total_ops_per_sec` (unit slot deduped), a partial `Baseline commit 6e63866` (no measured baseline value yet, other parts omitted), and `Measures Optimize a multi-producer, multi-consumer bounded FIFO queue.` from the committed objective prose. After round 2 the baseline read `Baseline 8041883.16 · r1 · commit 4dca2d8` while the plot rose 8.04M to 9.19M. This evaluator records no direction and the metric line correctly showed none; after recording `perf_direction` on the round evidence and resuming, it read `Metric total_ops_per_sec · maximize ↑`. Layout sweep: split at 170 columns, zoomed full width, modal fallback at 95 columns (prose word-wrapped, plot intact), and the minimum 62-wide split pane at exactly 100 columns (prose wrapped, plot rows unchanged). All 8 bundled themes rendered the glyph and baseline, and the escape codes show the context lines use the same theme text colors as the existing chart lines, so direction is never conveyed by color.

Closes #466.