### PR TITLE
ci: fit a pull request inside the wall-time budget

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,17 +3,51 @@ name: Build and publish release wheels
 on:
   pull_request:
     branches: [main]
-    # Skip the wheel-build matrix (two paid macOS runners plus a Docker
-    # clean-room verification pass) for changes that can't affect native
-    # packaging: pure documentation and the Docusaurus site. Ignored by exact
-    # filename, not `.github/workflows/**`, so edits to this workflow still
-    # run the full matrix. `release` events don't support path filters and
-    # are unaffected.
-    paths-ignore:
-      - '*.md'
-      - 'docs/**'
-      - 'website/**'
-      - '.github/workflows/website.yml'
+    # This matrix builds and clean-room-verifies four release wheels, two of
+    # them on paid macOS runners, and `macos-x86_64` alone takes 4.5-7 minutes.
+    # That is the wall-clock long pole of a pull request (issue #474), and
+    # almost none of it is about the diff: a wheel is a copy of tracked files
+    # plus a bundled TUI payload, so only a change to the packaging machinery,
+    # its metadata, or the bundle's own inputs can change the verdict.
+    #
+    # Listed positively rather than as `paths-ignore`, because the safe default
+    # for a new path is "does not affect the wheel". A `release` event ignores
+    # path filters entirely, so the production build is untouched by this list.
+    paths:
+      # Wheel metadata and the resolved dependency set.
+      - 'pyproject.toml'
+      - 'uv.lock'
+      # The build itself: what gets staged, under which platform tag, and the
+      # contracts every built wheel is checked against.
+      - 'setup.py'
+      - 'MANIFEST.in'
+      - 'packaging_support.py'
+      - 'resources_packaging.py'
+      - 'tui_packaging.py'
+      - 'wheel_targets.py'
+      - 'release_versions.py'
+      - 'packaging/**'
+      - 'scripts/__init__.py'
+      - 'scripts/build_release_wheel.py'
+      - 'scripts/audit_release_wheel.py'
+      - 'scripts/verify_release_wheel.py'
+      - 'scripts/verify_installed_release.py'
+      - 'scripts/check_release_version.py'
+      - 'scripts/test_release_wheel.sh'
+      - 'scripts/fetch_bun.py'
+      # The bundled TUI payload: the workspace `pnpm build:clients` builds and
+      # `pnpm deploy` stages, and the launcher in cli.py that resolves it.
+      - 'clients/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'src/vibesys/cli.py'
+      # Licenses whose digests the wheel verifier compares.
+      - 'LICENSE'
+      - 'third_party/bun/LICENSE'
+      # By exact filename, not `.github/workflows/**`, so an edit to this
+      # workflow still runs the full matrix.
+      - '.github/workflows/publish.yml'
   release:
     types: [published]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
     outputs:
       python: ${{ steps.filter.outputs.python }}
       tui: ${{ steps.filter.outputs.tui }}
+      examples: ${{ steps.filter.outputs.examples }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -71,6 +72,21 @@ jobs:
               - 'scripts/fetch_bun.py'
               - 'scripts/check_ts_architecture.test.mjs'
               - 'scripts/check_ts_package_manifests.mjs'
+              - '.github/workflows/test.yml'
+            # What `validate-examples` checks: the example repositories
+            # themselves (a submodule bump shows up as a change to the gitlink
+            # path under examples/), the two validators, and the fetcher that
+            # materializes the overlays.
+            examples:
+              - 'examples/**'
+              - '.gitmodules'
+              - 'src/vibesys/main.py'
+              - 'src/vibesys/input_manifest.py'
+              - 'src/vibesys/evaluators/**'
+              - 'resources/evaluators/microservice/**'
+              - 'scripts/example_repositories.py'
+              - 'tests/test_microservice_inputs.py'
+              - 'tests/test_input_sources.py'
               - '.github/workflows/test.yml'
 
   # One environment setup for every cheap Python check. Issue #89 split these
@@ -119,11 +135,10 @@ jobs:
       - name: Test repository launcher
         run: uv run vibesys --headless --help >/dev/null
 
-  # Its own job rather than a step in `python-checks`, so a type error is
-  # attributable at a glance and the two run in parallel.
+  # Fully independent: no `needs:`, so it starts with the run rather than after
+  # the filter, and nothing waits on it. Type checking is not sequenced with
+  # anything else, and at ~20s it is not worth a filter's latency.
   typecheck:
-    needs: changes
-    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -346,8 +361,61 @@ jobs:
           VIBESYS_REQUIRE_MANAGED_CANDIDATE_TESTS: "1"
         run: go test -race ./...
 
-      - name: Initialize repository-native microservice examples
-        run: git submodule update --init --depth 1 examples/microservices/repositories/deathstarbench
+  # Owns everything that needs a repository-native example's `.vibesys` overlay,
+  # so no other job pays for one. It fetches the overlay alone (blob-filtered,
+  # depth-1, sparse) at the pinned gitlink rather than checking the submodule
+  # out: ~7s and ~8MB for all four examples, against ~95s for one full
+  # submodule clone.
+  #
+  # Data-driven over .gitmodules and over each overlay's own tasks, so a new
+  # example repository or a new task needs no edit here. The `servicebench`
+  # workload checks below stay explicit because their flags differ per task.
+  validate-examples:
+    needs: changes
+    if: needs.changes.outputs.examples == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: resources/evaluators/microservice/go.mod
+          cache-dependency-path: resources/evaluators/microservice/go.sum
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Fetch repository-native example overlays
+        run: uv run python scripts/example_repositories.py
+
+      - name: Validate example tasks
+        run: |
+          set -euo pipefail
+          for manifest in examples/*/repositories/*/.vibesys/tasks/*/vibesys.input.toml; do
+            repository="${manifest%%/.vibesys/*}"
+            task="$(basename "$(dirname "$manifest")")"
+            echo "::group::$repository --task $task"
+            uv run python -m vibesys validate "$repository" --task "$task"
+            echo "::endgroup::"
+          done
+
+      # The overlay is present here and nowhere else, so force the module to
+      # fail rather than skip if the fetch above ever stops producing it.
+      - name: Check microservice input contracts
+        env:
+          VIBESYS_REQUIRE_EXAMPLE_OVERLAYS: "1"
+        run: uv run python -m pytest tests/test_microservice_inputs.py tests/test_input_sources.py -v --no-cov
 
       - name: Validate microservice workloads
         working-directory: resources/evaluators/microservice
@@ -373,9 +441,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Initialize repository-native microservice examples
-        run: git submodule update --init --depth 1 examples/microservices/repositories/deathstarbench
-
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
@@ -393,7 +458,16 @@ jobs:
         # against the source list in `[tool.coverage.run]` (vibesys, vs_feature_flags,
         # vs_github, vs_issue_board, vs_sandbox). Add the report formats CI needs on
         # top of that instead of repeating `--cov=...` for each package.
-        run: uv run python -m pytest -v --cov-report=xml --cov-report=json --cov-fail-under=75
+        #
+        # `-n auto` fans the suite across the runner's cores; pytest-cov
+        # collects per worker and combines, so the two `--cov-fail-under`
+        # gates below still measure the whole suite. `--dist loadgroup` keeps
+        # each `xdist_group` on one worker, which is what the `serial` marker
+        # in conftest.py relies on. `--durations` keeps the slowest tests
+        # visible in every run instead of needing a local bisect.
+        run: >-
+          uv run python -m pytest -v -n auto --dist loadgroup --durations=25
+          --cov-report=xml --cov-report=json --cov-fail-under=75
 
       - name: Enforce per-module coverage floor
         # Repo-wide --cov-fail-under is an average and can't see a single
@@ -491,13 +565,18 @@ jobs:
   # be mergeable, and macOS runner queueing can push a run over the budget for
   # reasons no workflow change can fix, so the summary reports queue time
   # separately from execution time.
+  #
+  # `typecheck` is deliberately absent from `needs` so that nothing in this
+  # workflow sequences it. It still appears in the table: the step reads every
+  # job of the run from the API, not just the ones listed here, and at ~20s it
+  # has long finished by the time the jobs below have.
   ci-budget:
     needs:
       - changes
       - python-checks
-      - typecheck
       - tui
       - queue-native
+      - validate-examples
       - test
       - sandbox-linux
       - sandbox-macos

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,34 @@
+"""Suite-wide pytest configuration shared by every ``testpaths`` root.
+
+Lives at the repository root rather than under ``tests/`` because the marker it
+defines has to mean the same thing for ``tests/``, ``libs/*/tests``, and
+``sdk/*/tests``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+#: xdist scheduling group for tests that cannot run beside one another.
+_SERIAL_GROUP = "serial"
+
+
+def pytest_collection_modifyitems(items: Iterable[pytest.Item]) -> None:
+    """Pin every ``serial`` test to one xdist worker.
+
+    CI runs the suite with ``-n auto --dist loadgroup``. A test marked
+    ``serial`` claims a process-wide or host-wide resource (a fixed port, a
+    fixed path, the process environment), so two of them running at once is a
+    flake. ``loadgroup`` sends every item in one ``xdist_group`` to the same
+    worker, which serializes them with respect to each other while the rest of
+    the suite keeps fanning out. Without xdist the marker is inert, and the
+    suite is serial anyway.
+    """
+    for item in items:
+        if item.get_closest_marker(_SERIAL_GROUP) is not None:
+            item.add_marker(pytest.mark.xdist_group(_SERIAL_GROUP))

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -82,6 +82,17 @@ vendored sources, using `--checkout` to override their default update policy:
 git submodule update --init --recursive --checkout
 ```
 
+`uv run pytest` does not need any of them. The tests that assert on a
+repository-native example's tasks skip when its submodule is absent, and CI's
+`validate-examples` job covers them instead. To get the same coverage locally
+without cloning the candidate repositories, fetch just their `.vibesys`
+overlays (a few MB and a few seconds, against hundreds of MB for a full
+checkout):
+
+```bash
+uv run python scripts/example_repositories.py
+```
+
 Run the Python checks from the repository root:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
+    "pytest-xdist",
     "respx",
     "vs-bench",
     # Pinned exactly (not `>=`): a routine lock refresh with a floating bound
@@ -96,6 +97,12 @@ testpaths = ["tests", "libs/vs-evaluator-protocol/tests", "libs/vs-feature-flags
 # flags.
 addopts = "-ra --cov --cov-report=term-missing"
 pythonpath = ["."]
+markers = [
+    # Applied by `pytest_collection_modifyitems` in the root conftest.py, which
+    # maps it onto an xdist scheduling group so CI's `-n auto --dist loadgroup`
+    # keeps these tests off each other's worker.
+    "serial: claims a process-wide or host-wide resource and must not run beside another such test",
+]
 
 [tool.coverage.run]
 branch = true

--- a/scripts/example_repositories.py
+++ b/scripts/example_repositories.py
@@ -1,0 +1,266 @@
+"""Discovery and overlay fetching for the repository-native example submodules.
+
+A repository-native example is a candidate repository that carries its VibeSys
+tasks in a ``.vibesys/`` overlay (``docs/running-vibesys.md``). The repository
+tracks each one as a submodule under ``examples/<family>/repositories/<name>``.
+
+Validating those tasks only needs the overlay, not the candidate source, so
+this module fetches ``.vibesys/`` alone: a blob-filtered, depth-1 fetch of the
+pinned gitlink commit with a sparse checkout. On the DeathStarBench example
+that is ~3MB and ~2s, against ~95s and hundreds of MB for a full submodule
+checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: The one directory a repository-native example must contribute.
+OVERLAY_DIRNAME = ".vibesys"
+
+#: ``examples/<family>/repositories/<name>``: the path shape that marks a
+#: submodule as a runnable candidate repository rather than a reference one.
+_EXAMPLE_PATH_PARTS = 4
+
+#: Git's mode for a gitlink entry, as reported by ``git ls-tree``.
+_GITLINK_MODE = "160000"
+
+
+class ExampleRepositoryError(RuntimeError):
+    """Raised when a submodule declaration or its overlay cannot be resolved."""
+
+    @classmethod
+    def command_failed(cls, command: str, cwd: Path, stderr: str) -> ExampleRepositoryError:
+        """Report a git invocation that exited nonzero, with git's own message."""
+        return cls(f"`{command}` failed in {cwd}: {stderr}")
+
+    @classmethod
+    def untracked(cls, path: Path) -> ExampleRepositoryError:
+        """Report a ``.gitmodules`` path that HEAD does not track."""
+        return cls(f"{path} is not tracked in HEAD")
+
+    @classmethod
+    def not_a_gitlink(cls, path: Path, mode: str) -> ExampleRepositoryError:
+        """Report a tracked path that is an ordinary tree rather than a submodule."""
+        return cls(f"{path} is not a submodule gitlink (mode {mode})")
+
+    @classmethod
+    def missing_overlay(cls, path: Path, commit: str) -> ExampleRepositoryError:
+        """Report an example whose pinned commit carries no task overlay."""
+        return cls(f"{path} at {commit} has no {OVERLAY_DIRNAME}/ overlay")
+
+
+@dataclass(frozen=True)
+class ExampleRepository:
+    """One ``examples/<family>/repositories/<name>`` submodule.
+
+    ``path`` is relative to the repository root; ``commit`` is the gitlink SHA
+    the superproject pins, which is what CI must validate rather than whatever
+    the tracked branch happens to point at today.
+    """
+
+    path: Path
+    url: str
+    branch: str
+    commit: str
+
+    @property
+    def name(self) -> str:
+        """Return the example's directory name, which is how docs refer to it."""
+        return self.path.name
+
+
+def is_example_repository_path(path: Path) -> bool:
+    """Report whether ``path`` has the repository-native example shape.
+
+    The layout ``examples/<family>/repositories/<name>`` is what distinguishes a
+    runnable candidate repository from the reference and tooling submodules,
+    which are opt-in (``update = none``) and carry no tasks.
+    """
+    parts = path.parts
+    return (
+        len(parts) == _EXAMPLE_PATH_PARTS and parts[0] == "examples" and parts[2] == "repositories"
+    )
+
+
+def _git(*args: str, cwd: Path) -> str:
+    result = subprocess.run(  # noqa: S603
+        ["git", *args],  # noqa: S607
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ExampleRepositoryError.command_failed(
+            " ".join(("git", *args)), cwd, result.stderr.strip()
+        )
+    return result.stdout
+
+
+def _pinned_commit(repo_root: Path, path: Path) -> str:
+    entry = _git("ls-tree", "HEAD", "--", str(path), cwd=repo_root).strip()
+    if not entry:
+        raise ExampleRepositoryError.untracked(path)
+    mode, object_type, rest = entry.split(" ", 2)
+    if mode != _GITLINK_MODE or object_type != "commit":
+        raise ExampleRepositoryError.not_a_gitlink(path, mode)
+    return rest.split("\t", 1)[0]
+
+
+def discover_example_repositories(repo_root: Path = REPO_ROOT) -> tuple[ExampleRepository, ...]:
+    """Read ``.gitmodules`` and return every repository-native example it declares.
+
+    Data-driven on purpose: adding an example repository is a ``.gitmodules``
+    change, and neither CI nor this module should need editing for it.
+    """
+    config = configparser.ConfigParser()
+    config.read(repo_root / ".gitmodules")
+
+    repositories: list[ExampleRepository] = []
+    for section in config.sections():
+        if not section.startswith('submodule "'):
+            continue
+        path = Path(config.get(section, "path"))
+        if not is_example_repository_path(path):
+            continue
+        repositories.append(
+            ExampleRepository(
+                path=path,
+                url=config.get(section, "url"),
+                branch=config.get(section, "branch"),
+                commit=_pinned_commit(repo_root, path),
+            )
+        )
+    return tuple(sorted(repositories, key=lambda repository: repository.path))
+
+
+def _manifest_paths(overlay: Path) -> Iterator[Path]:
+    yield from sorted(overlay.glob("tasks/*/vibesys.input.toml"))
+
+
+def _declared_project_paths(manifest: Path) -> Iterator[str]:
+    """Yield the project-root-relative paths a manifest points at outside the overlay.
+
+    Two manifest fields can name a file in the candidate repository rather than
+    in the task directory, and ``vibesys validate`` requires both to exist:
+    ``[environment.modal] entrypoint``, and an ``accuracy``/``benchmark``
+    ``command`` whose executable is a repository path rather than a bare
+    program name.
+
+    Parsed with ``tomllib`` rather than through ``vibesys.input_manifest`` on
+    purpose: this runs *before* validation, so it has to tolerate a manifest
+    that validation is about to reject.
+    """
+    try:
+        document = tomllib.loads(manifest.read_text())
+    except (OSError, tomllib.TOMLDecodeError):
+        return
+
+    modal = document.get("environment", {}).get("modal", {})
+    entrypoint = modal.get("entrypoint")
+    if isinstance(entrypoint, str):
+        yield entrypoint
+
+    for section in ("accuracy", "benchmark"):
+        command = document.get(section, {}).get("command")
+        if isinstance(command, list) and command and isinstance(command[0], str):
+            executable = command[0]
+            if "/" in executable:
+                yield executable
+
+
+def _sparse_directories(overlay: Path) -> tuple[str, ...]:
+    """Return the extra cone-mode directories the overlay's manifests depend on."""
+    directories: set[str] = set()
+    for manifest in _manifest_paths(overlay):
+        for declared in _declared_project_paths(manifest):
+            candidate = Path(declared)
+            if candidate.is_absolute() or ".." in candidate.parts:
+                # `vibesys validate` rejects these itself, with a better message.
+                continue
+            parent = candidate.parent
+            if parent != Path():
+                directories.add(parent.as_posix())
+    return tuple(sorted(directories))
+
+
+def fetch_overlay(repository: ExampleRepository, repo_root: Path = REPO_ROOT) -> Path:
+    """Materialize ``<repository>/.vibesys`` at the pinned commit, and little else.
+
+    Idempotent: a checkout already sitting at the pinned commit is left alone.
+    The resulting directory is a real git repository whose ``HEAD`` matches the
+    gitlink, so the superproject sees the submodule as checked out and clean.
+
+    A second sparse-checkout pass widens the cone to the directories the
+    overlay's own manifests reference (see ``_declared_project_paths``), so a
+    task that names a deployment entrypoint in the candidate repository still
+    validates without cloning the repository.
+    """
+    target = repo_root / repository.path
+    target.mkdir(parents=True, exist_ok=True)
+
+    if not (target / ".git").exists() or _git("rev-parse", "HEAD", cwd=target).strip() != (
+        repository.commit
+    ):
+        _git("init", "--quiet", cwd=target)
+        remotes = _git("remote", cwd=target).split()
+        if "origin" in remotes:
+            _git("remote", "set-url", "origin", repository.url, cwd=target)
+        else:
+            _git("remote", "add", "origin", repository.url, cwd=target)
+
+        # Cone mode also materializes the root-level files, which is both cheap
+        # and what a reader expects from a checkout; nothing else comes down.
+        _git("sparse-checkout", "init", "--cone", cwd=target)
+        _git("sparse-checkout", "set", OVERLAY_DIRNAME, cwd=target)
+        _git("fetch", "--depth", "1", "--filter=blob:none", "origin", repository.commit, cwd=target)
+        _git("checkout", "--detach", repository.commit, cwd=target)
+
+    overlay = target / OVERLAY_DIRNAME
+    if not overlay.is_dir():
+        raise ExampleRepositoryError.missing_overlay(repository.path, repository.commit)
+
+    extra = _sparse_directories(overlay)
+    if extra:
+        _git("sparse-checkout", "set", OVERLAY_DIRNAME, *extra, cwd=target)
+    return target
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Fetch every declared example repository's overlay, reporting each one."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root to read .gitmodules and gitlinks from.",
+    )
+    arguments = parser.parse_args(argv)
+    repo_root = arguments.repo_root.expanduser().resolve()
+
+    repositories = discover_example_repositories(repo_root)
+    if not repositories:
+        print(f"No repository-native example submodules declared in {repo_root / '.gitmodules'}")
+        return 1
+
+    for repository in repositories:
+        fetch_overlay(repository, repo_root)
+        print(f"{repository.path}: {OVERLAY_DIRNAME}/ at {repository.commit}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/sandbox/fixtures/nested_shell_project/.vibesys/tasks/nested-shell/OBJECTIVE.md
+++ b/tests/sandbox/fixtures/nested_shell_project/.vibesys/tasks/nested-shell/OBJECTIVE.md
@@ -1,0 +1,8 @@
+# Nested shell command objective
+
+Test fixture. Its only job is to declare a benchmark command whose
+`--run-command-json` argument nests a second argv containing `${PROJECT_ROOT}`
+and `${PACKAGE_ROOT}` tokens, so the run environment's token expansion and
+shell quoting can be exercised without a candidate repository.
+
+Nothing runs this task.

--- a/tests/sandbox/fixtures/nested_shell_project/.vibesys/tasks/nested-shell/vibesys.input.toml
+++ b/tests/sandbox/fixtures/nested_shell_project/.vibesys/tasks/nested-shell/vibesys.input.toml
@@ -1,0 +1,30 @@
+version = 1
+
+[agent]
+domain = "microservices"
+
+[evaluator]
+name = "vibesys-evaluator-microservice"
+version = "0.1.0"
+
+[accuracy]
+entrypoint = "servicebench"
+args = [
+  "--mode", "accuracy",
+  "--candidate-dir", "${PROJECT_ROOT}/service",
+  "--run-command-json", "[\"docker\",\"compose\",\"up\",\"-d\",\"--build\"]",
+]
+timeout_seconds = 300
+
+[benchmark]
+entrypoint = "servicebench"
+args = [
+  "trace",
+  "--candidate-dir", "${PROJECT_ROOT}/service",
+  "--run-command-json", "[\"sh\",\"-c\",\"go -C \\\"$1\\\" run ./cmd/otelinject --compose \\\"$2\\\" --config \\\"$3\\\"\",\"vibesys-nested-run\",\"${PACKAGE_ROOT}\",\"${PROJECT_ROOT}/service/docker-compose.yml\",\"${PROJECT_ROOT}/.vibesys/tasks/nested-shell/telemetry.toml\"]",
+]
+timeout_seconds = 360
+
+[benchmark.result]
+json_argument = "--output-json"
+metric = "primary_value"

--- a/tests/sandbox/test_run_environment.py
+++ b/tests/sandbox/test_run_environment.py
@@ -33,6 +33,12 @@ if TYPE_CHECKING:
     from vibesys.backends.base import ContentionMonitor
 
 
+# A committed two-file overlay, not a submodule: the contract under test is
+# how the run environment expands and quotes nested shell argv, not any
+# particular candidate repository.
+NESTED_SHELL_PROJECT = Path(__file__).parent / "fixtures" / "nested_shell_project"
+
+
 class FakeBackend:
     """Structural stand-in for ``ComputeBackendImpl`` that records sandbox calls."""
 
@@ -312,13 +318,12 @@ def test_environment_quotes_project_root_after_token_expansion(tmp_path: Path) -
     ]
 
 
-def test_environment_quotes_hotel_nested_shell_paths(tmp_path: Path) -> None:
+def test_environment_quotes_nested_shell_paths(tmp_path: Path) -> None:
     backend = FakeBackend()
     workspace = tmp_path / "candidate's; touch injected"
     workspace.mkdir()
-    project = Path("examples/microservices/repositories/deathstarbench").resolve()
-    vibesys_project = Project.open(project)
-    bundle = load_project_task(vibesys_project, vibesys_project.select_task("hotel-reservation"))
+    vibesys_project = Project.open(NESTED_SHELL_PROJECT)
+    bundle = load_project_task(vibesys_project, vibesys_project.select_task("nested-shell"))
     env = build_run_environment(RunEnvironmentSpec("local"))
 
     session = env.open(
@@ -336,7 +341,7 @@ def test_environment_quotes_hotel_nested_shell_paths(tmp_path: Path) -> None:
     assert command is not None
     outer = shlex.split(command)
     nested = json.loads(outer[outer.index("--run-command-json") + 1])
-    assert nested[5] == str(workspace / "hotelReservation" / "docker-compose.yml")
+    assert nested[5] == str(workspace / "service" / "docker-compose.yml")
     assert "${PROJECT_ROOT}" not in json.dumps(nested)
 
 

--- a/tests/test_distribution_packaging.py
+++ b/tests/test_distribution_packaging.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from packaging.requirements import Requirement
+from scripts.example_repositories import is_example_repository_path
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -79,8 +80,9 @@ def _submodule_configuration() -> tuple[configparser.ConfigParser, list[str]]:
 
 
 def _is_repository_example(config: configparser.ConfigParser, section: str) -> bool:
-    path = Path(config.get(section, "path"))
-    return len(path.parts) == 4 and path.parts[0] == "examples" and path.parts[2] == "repositories"
+    # One definition, shared with the CI fetcher that materializes these
+    # examples' task overlays.
+    return is_example_repository_path(Path(config.get(section, "path")))
 
 
 def test_vcs_installs_do_not_initialize_supporting_submodules() -> None:

--- a/tests/test_microservice_inputs.py
+++ b/tests/test_microservice_inputs.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tomllib
 from itertools import pairwise
 from pathlib import Path
@@ -12,11 +13,22 @@ from vs_project import Project, ProjectLayoutError
 PROJECT_ROOT = Path(__file__).parents[1]
 MICROSERVICE_ROOT = PROJECT_ROOT / "examples" / "microservices"
 DEATHSTAR_ROOT = MICROSERVICE_ROOT / "repositories" / "deathstarbench"
+# The DeathStarBench tasks live in a submodule, so a plain checkout does not
+# have them and these assertions skip. CI's ``validate-examples`` job fetches
+# the ``.vibesys`` overlay and sets this, turning a missing overlay into a
+# failure rather than a silent loss of coverage.
+_REQUIRE_EXAMPLE_OVERLAYS = os.environ.get("VIBESYS_REQUIRE_EXAMPLE_OVERLAYS") == "1"
 try:
     DEATHSTAR_LAYOUT = Project.open(DEATHSTAR_ROOT)
     DEATHSTAR_LAYOUT.discover_tasks()
-except ProjectLayoutError:
-    pytest.skip("DeathStarBench repository example is not initialized", allow_module_level=True)
+except ProjectLayoutError as error:
+    if _REQUIRE_EXAMPLE_OVERLAYS:
+        raise
+    pytest.skip(
+        f"DeathStarBench repository example is not initialized: {error}"
+        " (set VIBESYS_REQUIRE_EXAMPLE_OVERLAYS=1 to force)",
+        allow_module_level=True,
+    )
 DEATHSTAR_TASKS = {task.name.value: task for task in DEATHSTAR_LAYOUT.discover_tasks()}
 LEGACY_SCENARIOS = (MICROSERVICE_ROOT / "train-ticket",)
 HOTEL_TEMP_ROOT = Path("/") / "tmp" / "vibesys-hotel-reservation" / "otel"

--- a/uv.lock
+++ b/uv.lock
@@ -855,6 +855,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.140.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3641,6 +3650,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -4539,6 +4561,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "respx" },
     { name = "ruff" },
     { name = "twine" },
@@ -4582,6 +4605,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "respx" },
     { name = "ruff", specifier = "==0.15.12" },
     { name = "twine" },


### PR DESCRIPTION
## Problem

Closes the rest of #474. #482 restructured `test.yml` and added the `ci-budget`
guard; it left the run at 254s on a push and ~294s on a pull request, and it
deliberately did not touch the two things a reviewer actually waits on.

Measured on `main` (run
[33226273142](https://github.com/uw-syfi/vibesys/actions/runs/33226273142),
the merge of #482):

| job | ran | finished at |
| --- | ---: | ---: |
| test (3.12) | 251s | 254s |
| tui | 104s | 116s |
| queue-native | 57s | 60s |
| sandbox-linux | 36s | 39s |
| sandbox-macos | 32s | 35s |
| python-checks | 17s | 30s |
| typecheck | 16s | 29s |
| changes | 8s | 11s |
| **test.yml wall** | | **254s** |

And, in parallel, `publish.yml` builds four release wheels on every PR. Recent
PR runs: 5m46s, 7m29s, 8m20s, driven by `Build macos-x86_64` on the scarce
`macos-15-intel` runner (4m25s to 6m46s). That, not `test.yml`, is what a PR
waits on.

Inside `test`, two costs stand out:

- **`git submodule update --init --depth 1`** for DeathStarBench, paid twice
  (once in `test`, once in `queue-native`), to read two manifests and two
  workload TOMLs out of a `.vibesys/` overlay. Measured between **5s and 104s**
  on the same command across recent runs; 9s in the baseline above.
- **The pytest run itself, 222s single-process.** Locally `--durations=30`
  shows no single dominant test: the slowest is 8.2s and the top 30 sum to
  ~110s of a 354s run. The remaining ~244s is a flat tail across 5,216 tests.

## Solution

### `validate-examples`, and no submodule anywhere else

A new job owns everything that needs a repository-native example's tasks, and
fetches only those tasks: `git init` + `sparse-checkout set .vibesys` +
`fetch --depth 1 --filter=blob:none <pinned gitlink>` + `checkout`. All four
example repositories cost **2s in CI** and 8MB on disk, against a full
submodule checkout of one of them. `HEAD` in the result equals the gitlink, so
the superproject still sees the submodule as checked out and clean.

`scripts/example_repositories.py` is data-driven over `.gitmodules`: it reads
every `examples/<family>/repositories/<name>` submodule and its pinned commit,
so a new example repository needs no workflow edit. `test_distribution_packaging`
now imports that same path predicate instead of restating it.

A second sparse pass widens the cone to whatever the overlay's own manifests
reference outside it, namely `[environment.modal] entrypoint` and a
`command[0]` that is a repository path. That is not hypothetical: `vllm`'s
`qwen3-coder-tracelab-h100` names
`examples/deployment/vibesys_qwen3_coder_tracelab.py`, and validation fails
without it.

The job then discovers tasks by glob and runs `vibesys validate` per task. That
is **17 tasks across 5 example repositories**, where CI previously validated
none of them through the CLI. The `servicebench --validate-only` invocations
move here verbatim from `queue-native`; they stay explicit because their flags
differ per task.

Both `git submodule update --init` steps are gone.

### The default test run no longer needs a submodule

- `tests/sandbox/test_run_environment.py` exercised nested-shell `${PROJECT_ROOT}`
  quoting through DeathStarBench's `hotel-reservation` task, and **failed** (not
  skipped) in a fresh checkout. It now reads a committed two-file overlay under
  `tests/sandbox/fixtures/nested_shell_project/`. The contract under test is the
  run environment's expansion and quoting, not any candidate repository.
- `tests/test_microservice_inputs.py` still skips when the overlay is absent,
  but raises instead under `VIBESYS_REQUIRE_EXAMPLE_OVERLAYS=1`, which
  `validate-examples` sets. The coverage moves rather than disappearing, and it
  cannot silently stop running. Same idiom as `VIBESYS_REQUIRE_SANDBOX_TESTS`.

`uv run pytest` is green in a fresh checkout for the first time.

### pytest under xdist

`-n auto --dist loadgroup`, plus a `serial` marker that a root `conftest.py`
maps onto an xdist scheduling group. The marker exists so the first test that
does claim a fixed port or a fixed path has somewhere to go; **no test needed it
yet**, and none was weakened to get there. Every socket path in the suite is
already `uuid4`-scoped and every environment mutation goes through `monkeypatch`,
which is per-worker.

Coverage is unaffected. pytest-cov collects per worker and combines, so
`--cov-fail-under=75` and `scripts/check_coverage_floor.py` still measure the
whole suite; locally the combined total is 84% against 83% serial, a
one-statement difference.

`--durations=25` stays in the CI command so the slowest tests are visible in
every run instead of requiring a local bisect.

### Wheel builds off the every-PR path

`publish.yml`'s `pull_request` trigger becomes a positive `paths:` filter over
the packaging machinery (`setup.py`, the four root packaging modules, the
`scripts/*_release_*` helpers, `packaging/`), the wheel's metadata
(`pyproject.toml`, `uv.lock`), the TUI bundle's inputs (`clients/**`, the three
pnpm files, `src/vibesys/cli.py`), the digest-checked licenses, and the
workflow itself.

Listed positively, not as `paths-ignore`, because the safe default for a new
path is "cannot change the wheel". `release` events ignore path filters
entirely, so the production build is untouched, and no job gained an `if:` that
could misfire on a release.

### Typecheck

No `needs:` on it and none from it, per review. It is checkout, `uv sync`,
`scripts/check_types.sh`, starting with the run. It is deliberately absent from
`ci-budget`'s `needs:` too; the guard reads every job of the run from the API
rather than only the ones it waits on, so `typecheck` still appears in the
table.

### Architecture

```mermaid
flowchart LR
  C[changes] --> PC[python-checks]
  C --> TUI[tui]
  C --> VE[validate-examples]
  TC[typecheck] -.-> X(( ))
  T["test (3.12)<br/>-n auto"] --> B
  QN[queue-native] --> B
  SL[sandbox-linux] --> B
  SM[sandbox-macos] --> B
  PC --> B
  TUI --> B
  VE --> B
  B["ci-budget<br/>always()"]
```

`typecheck` is intentionally disconnected. `validate-examples` is the only job
that fetches an example overlay.

## Results

### `test.yml`

Before: `main` at the merge of #482, run
[33226273142](https://github.com/uw-syfi/vibesys/actions/runs/33226273142).
After: this PR, run
[33227366543](https://github.com/uw-syfi/vibesys/actions/runs/33227366543).
Both numbers are the guard's own `finished at` column, so they include queue
time.

| job | before | after | note |
| --- | ---: | ---: | --- |
| test (3.12) | 254s | **178s** | no submodule, `-n auto` |
| tui | 116s | 128s | unchanged |
| sandbox-macos | 35s | 64s | unchanged; macOS runner queue |
| queue-native | 60s | 56s | lost the submodule clone and the workload checks |
| validate-examples | | 57s | new |
| sandbox-linux | 39s | 38s | unchanged |
| python-checks | 30s | 30s | unchanged |
| typecheck | 29s | 19s | no longer waits on `changes` |
| changes | 11s | 10s | one more filter |
| **wall** | **254s** | **178s** | |

The guard's verdict on this run: `Run took 178s, within the 300s budget.`

Inside `test`:

| step | before | after |
| --- | ---: | ---: |
| Initialize repository-native microservice examples | 9s | **gone** |
| Run tests | 222s | **159s** |

`-n auto` is worth 1.40x on a 4-core hosted runner (222s to 159s), against 4.8x
locally on 12 cores (354s to 73s). The submodule clone was 9s in this
particular baseline; it has been measured anywhere from 5s to 104s on the same
command, so removing it also removes that variance.

`validate-examples` breaks down as 17s of setup (checkout, Go, uv, sync), **2s
to fetch all four overlays**, 7s to validate **17 tasks across 5 example
repositories**, 4s for the microservice input contracts, and 10s for the six
`servicebench --validate-only` invocations.

### `publish.yml`

This PR edits `publish.yml`, so it is in the filter and the full matrix ran
here, which is the behavior to preserve. What changes is every other PR:

| | before | after |
| --- | --- | --- |
| PR touching packaging | full matrix | full matrix (unchanged) |
| PR touching only `src/`, `tests/`, `docs/`, `resources/` | full matrix, 5m46s-8m20s | no run |
| tag / release | full matrix | full matrix (unchanged) |

Recent PR-run wall times for reference: 5m46s, 7m29s, 8m20s, with
`Build macos-x86_64` at 4m25s-6m46s in each. On this PR's own run it took
**10m4s**, most of it waiting for a `macos-15-intel` runner while every other
check had been green for eight minutes.

### The budget, end to end

On a PR that does not touch packaging, the wheel matrix no longer runs, so the
PR's wall time is `test.yml`'s: **178s against a 300s budget**, with `test` at
178s still the long pole.

## Verification

### Correctness properties

- **No check was removed or weakened.** Every `servicebench --validate-only`
  invocation moved verbatim. `tests/test_microservice_inputs.py` keeps every
  assertion and gains a mode where its absence is a failure. The nested-shell
  test keeps both assertions, against a fixture that reproduces the exact
  nested-argv shape.
- **Coverage gates still measure the whole suite under xdist**, and the
  per-module floor still reads the combined `coverage.json`.
- **The overlay fetch is idempotent** and refuses to proceed if the pinned
  commit carries no `.vibesys/`.
- **A gitlink bump re-runs `validate-examples`**: a submodule bump appears to
  paths-filter as a change to the gitlink path, which `examples/**` covers.
- **Release wheel builds are unchanged.** The new filter is under
  `pull_request:` only, and `release` events do not honor path filters.
- **`uv run pytest` is green in a fresh checkout**, with no submodule
  initialized.
- **Branch protection is unaffected**: `main` requires no status checks
  (verified against the API), so `validate-examples` appearing and the
  `publish.yml` checks disappearing on non-packaging PRs block nothing.

### Testing

Locally, on a 12-core macOS host, with `tests/skypilot/` excluded (see below):

| command | result |
| --- | --- |
| `uv run python -m pytest --durations=30` (serial, before) | 5,216 passed, 16 skipped, **354s** |
| `uv run python -m pytest -n auto --dist loadgroup` | 5,216 passed, 16 skipped, **73s** |
| repeat, with the exact CI flags and the coverage floor | same counts, **75s**, no flakes |
| `uv run python scripts/example_repositories.py` | 4 overlays, **7.3s**, 8.0MB total |
| `vibesys validate` over every discovered task | **17/17 pass**, 3.7s |
| `uv run pytest tests/sandbox tests/test_microservice_inputs.py tests/test_input_sources.py tests/test_distribution_packaging.py` with no overlay | 155 passed, 1 skipped |
| the same with `VIBESYS_REQUIRE_EXAMPLE_OVERLAYS=1` and no overlay | fails at collection, as intended |
| `./scripts/check_format.sh`, `./scripts/check_lint.sh`, `./scripts/check_types.sh` | all pass |
| `uv run python scripts/check_doc_links.py` | 318 files, no broken links |

`clients/` is untouched, so the pnpm checks were not run.

Two tests fail on this macOS host both before and after this branch, and both
are environment-specific rather than regressions (verified by re-running them
with this PR's `pyproject.toml` and `uv.lock` stashed):
`tests/test_release_wheel_verifier.py::test_bdist_wheel_revalidates_the_native_host`
(the `uv build` subprocess fails for an unrelated local reason) and
`libs/vs-sandbox/tests/test_landlock_sandbox.py::TestLinuxBackendSelection::test_unknown_backend_value_is_rejected`
(Linux backend selection). Both pass in CI.

## Not done, and why

- **`tests/skypilot/` hangs on macOS**, before and after this branch, so local
  runs excluded it. `_serve_frames` binds an `AF_UNIX` socket under `tmp_path`;
  on macOS that path exceeds the 104-byte `sun_path` limit, the server thread
  dies before setting its ready event, and the test blocks forever on
  `ready.wait()`. It is green on Linux CI. Unrelated to CI wall time, and filed
  separately rather than fixed here.
- **No wall-clock waits were worth removing.** The brief asked for
  sleep/timeout-based waits in the slowest tests to be replaced with injected
  clocks or event signaling. Measured, they are not there: the top 30 durations
  are `tests/loops/agent/test_orchestrate.py` (no `sleep` anywhere in the file;
  the cost is mocked-loop CPU work) and the `test_prioqueue_evaluator` /
  `test_queue_evaluator` session fixtures (real `cargo` and `cc` builds). The
  suite's real sleeps are `tests/backends/test_gpu_monitor.py` (about ten waits
  of 0.05-0.2s, ~2s total) and a handful of 5-50ms waits elsewhere, together
  well under 1% of the run. Replacing them would mean injecting a clock into
  the contention monitor for no measurable gain, so they are listed here rather
  than changed.
- **A `src/`-only change no longer builds a wheel on its PR.** A wheel is a copy
  of tracked files, and the verifier derives its expected member set from
  `git ls-files` over the same checkout with the same exclusions, so adding or
  editing a file under `src/`, `libs/*/src/`, or `resources/` cannot make the
  build and the check disagree. What is no longer covered per-PR is a new
  runtime import that breaks `verify_installed_release.py` under a sanitized
  PATH. `publish.yml` has no `push` trigger, so that class of break already
  surfaces at release rather than on merge; this PR does not widen that window
  on merge, only on the PR itself.
