### PR TITLE
Make the test suite pass on macOS, and guard Unix socket path length

### DIFF
--- a/libs/vs-sandbox/tests/test_landlock_sandbox.py
+++ b/libs/vs-sandbox/tests/test_landlock_sandbox.py
@@ -387,8 +387,11 @@ class TestLinuxBackendSelection:
         with pytest.raises(host_sandbox.SandboxUnavailableError, match="user namespace"):
             host_sandbox.build(workspace, env={}, require_enforcement=True)
 
-    def test_unknown_backend_value_is_rejected(self, tmp_path: Path) -> None:
+    def test_unknown_backend_value_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         workspace = _workspace(tmp_path)
+        monkeypatch.setattr(host_sandbox.sys, "platform", "linux")
 
         with pytest.raises(host_sandbox.SandboxUnavailableError, match="unknown"):
             host_sandbox.build(

--- a/src/vibesys/server/transport.py
+++ b/src/vibesys/server/transport.py
@@ -22,6 +22,7 @@ from vibesys.server.protocol import (
     SubscribeRequest,
 )
 from vibesys.server.service import SupervisionService  # noqa: TC001  # tracked: #288
+from vibesys.unix_socket import validate_socket_path
 
 _REQUEST_ADAPTER = TypeAdapter(ProtocolRequest)
 
@@ -187,6 +188,7 @@ class SupervisionSocketServer:
         self._client_disconnected = threading.Event()
 
     def start(self) -> None:  # noqa: D102  # tracked: #288
+        validate_socket_path(self.path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.path.unlink(missing_ok=True)
         self._server = _UnixServer(

--- a/src/vibesys/skypilot/bridge.py
+++ b/src/vibesys/skypilot/bridge.py
@@ -44,6 +44,7 @@ from vibesys.skypilot.runner import (
     SkyPilotControlPlaneError,
     SkyPilotJobStateError,
 )
+from vibesys.unix_socket import validate_socket_path
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
@@ -266,6 +267,7 @@ class SkyPilotBridge:
             raise RuntimeError(  # noqa: TRY003
                 "SkyPilot bridge cannot be restarted after close"
             )
+        validate_socket_path(self.socket_path)
         self.socket_path.parent.mkdir(parents=True, exist_ok=True)
         self.socket_path.unlink(missing_ok=True)
         try:

--- a/src/vibesys/unix_socket.py
+++ b/src/vibesys/unix_socket.py
@@ -1,0 +1,51 @@
+"""Length validation for the Unix domain sockets VibeSys listens on.
+
+A ``AF_UNIX`` address is a fixed-size ``sockaddr_un.sun_path`` character array,
+so the kernel refuses to bind a path that does not fit: 108 bytes on Linux and
+104 on macOS, both counting the terminating NUL. Every listening path VibeSys
+builds is derived from a user-chosen directory (a run's log directory for the
+SkyPilot bridge, a session directory for the supervision server), so a deep
+enough workspace pushes the socket past the limit.
+
+The raw failure is an ``OSError`` reading ``AF_UNIX path too long`` that names
+neither the path nor the limit, which is a poor diagnostic for something the
+user controls. Bind sites call :func:`validate_socket_path` first so the error
+says which path is too long, by how much, and on which platform.
+"""
+
+from __future__ import annotations
+
+import errno
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+MAX_SOCKET_PATH_BYTES: int = 103 if sys.platform == "darwin" else 107
+"""Longest bindable ``sun_path``, in bytes, excluding the trailing NUL."""
+
+
+class SocketPathTooLongError(OSError):
+    """A listening path does not fit in ``sockaddr_un.sun_path``.
+
+    Subclasses ``OSError`` because it replaces the kernel's own ``OSError``:
+    callers that already treat a failed bind as an ``OSError`` keep working.
+    """
+
+    def __init__(self, path: Path, limit: int):  # noqa: ANN204, D107  # tracked: #288
+        encoded = len(str(path).encode())
+        super().__init__(
+            errno.ENAMETOOLONG,
+            f"Unix socket path is {encoded} bytes, over this platform's "
+            f"{limit}-byte limit: {path}. Choose a shorter directory.",
+        )
+        self.path = path
+        self.limit = limit
+
+
+def validate_socket_path(path: Path) -> Path:
+    """Return ``path`` if it is bindable, else raise :class:`SocketPathTooLongError`."""
+    if len(str(path).encode()) > MAX_SOCKET_PATH_BYTES:
+        raise SocketPathTooLongError(path, MAX_SOCKET_PATH_BYTES)
+    return path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import shutil
+import tempfile
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -37,6 +39,26 @@ def headless_renderer() -> Iterator[HeadlessRenderer]:
         yield renderer
     finally:
         unsubscribe()
+
+
+@pytest.fixture
+def socket_dir() -> Iterator[Path]:
+    """A directory shallow enough to hold a bindable Unix socket.
+
+    ``tmp_path`` is not usable for this. It nests a per-user, per-session and
+    per-test directory under the platform temp root, and on macOS that root is
+    already a ~50-byte ``/var/folders/...`` path, so the result overruns
+    ``sockaddr_un.sun_path`` (104 bytes there, 108 on Linux) before a socket
+    name is even appended and ``bind`` fails with "AF_UNIX path too long".
+
+    Rooting the directory at ``/tmp`` keeps every path it yields far under the
+    limit on both platforms.
+    """
+    directory = Path(tempfile.mkdtemp(prefix="vibesys-sock-", dir="/tmp"))
+    try:
+        yield directory
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/skypilot/test_bridge.py
+++ b/tests/skypilot/test_bridge.py
@@ -36,6 +36,7 @@ from vibesys.skypilot.runner import (
     JobStatus,
     SkyPilotJobRunner,
 )
+from vibesys.unix_socket import MAX_SOCKET_PATH_BYTES, SocketPathTooLongError
 from vs_project import StateNamespace
 
 if TYPE_CHECKING:
@@ -224,6 +225,7 @@ def test_decoded_log_spool_replays_persisted_undelivered_suffix(tmp_path: Path) 
 
 def test_startup_replacement_evidence_applies_only_to_preexisting_invocations(
     tmp_path: Path,
+    socket_dir: Path,
 ) -> None:
     namespace = _namespace(tmp_path)
     runner = FakeRunner()
@@ -239,7 +241,7 @@ def test_startup_replacement_evidence_applies_only_to_preexisting_invocations(
         commands={"accuracy": ("true",)},
         benchmark_output_argument=None,
         state_namespace=namespace,
-        socket_path=tmp_path / "bridge.sock",
+        socket_path=socket_dir / "bridge.sock",
         log=lambda _: None,
     )
     journal = InvocationJournal(namespace)
@@ -259,7 +261,9 @@ def test_startup_replacement_evidence_applies_only_to_preexisting_invocations(
     assert set(runner.release_names) == {"lease", "old-lease"}
 
 
-def test_terminal_replay_tracks_persisted_cluster_for_release(tmp_path: Path) -> None:
+def test_terminal_replay_tracks_persisted_cluster_for_release(
+    tmp_path: Path, socket_dir: Path
+) -> None:
     namespace = _namespace(tmp_path)
     runner = FakeRunner()
     workspace = tmp_path / "workspace"
@@ -274,7 +278,7 @@ def test_terminal_replay_tracks_persisted_cluster_for_release(tmp_path: Path) ->
         commands={"accuracy": ("true",)},
         benchmark_output_argument=None,
         state_namespace=namespace,
-        socket_path=tmp_path / "bridge.sock",
+        socket_path=socket_dir / "bridge.sock",
         log=lambda _: None,
     )
     request = EvaluationRequest(kind="accuracy", invocation_id="e" * 32)
@@ -327,7 +331,9 @@ def test_terminal_replay_tracks_persisted_cluster_for_release(tmp_path: Path) ->
     assert set(runner.release_names) == {"new-lease", "old-lease"}
 
 
-def test_job_discovered_during_close_is_cancelled_and_released(tmp_path: Path) -> None:
+def test_job_discovered_during_close_is_cancelled_and_released(
+    tmp_path: Path, socket_dir: Path
+) -> None:
     namespace = _namespace(tmp_path)
     runner = FakeRunner()
     workspace = tmp_path / "workspace"
@@ -342,7 +348,7 @@ def test_job_discovered_during_close_is_cancelled_and_released(tmp_path: Path) -
         commands={"accuracy": ("true",)},
         benchmark_output_argument=None,
         state_namespace=namespace,
-        socket_path=tmp_path / "bridge.sock",
+        socket_path=socket_dir / "bridge.sock",
         log=lambda _: None,
     )
     journal = InvocationJournal(namespace)
@@ -363,7 +369,9 @@ def test_job_discovered_during_close_is_cancelled_and_released(tmp_path: Path) -
     assert set(runner.release_names) == {"new-lease", "old-lease"}
 
 
-def test_bridge_stages_allowlisted_command_streams_and_cleans_up(tmp_path: Path) -> None:
+def test_bridge_stages_allowlisted_command_streams_and_cleans_up(
+    tmp_path: Path, socket_dir: Path
+) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "candidate.py").write_text("candidate")
@@ -386,7 +394,7 @@ def test_bridge_stages_allowlisted_command_streams_and_cleans_up(tmp_path: Path)
         commands={"benchmark": ("python", ".vibesys-evaluator-package/checker.py")},
         benchmark_output_argument="--output-json",
         state_namespace=_namespace(tmp_path),
-        socket_path=tmp_path / "bridge.sock",
+        socket_path=socket_dir / "bridge.sock",
         log=lambda _: None,
     )
     bridge.start()
@@ -420,7 +428,7 @@ def test_bridge_stages_allowlisted_command_streams_and_cleans_up(tmp_path: Path)
 
 
 def test_bridge_releases_cluster_when_socket_startup_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, socket_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -442,7 +450,7 @@ def test_bridge_releases_cluster_when_socket_startup_fails(
         commands={"accuracy": ("true",)},
         benchmark_output_argument=None,
         state_namespace=_namespace(tmp_path),
-        socket_path=tmp_path / "bridge.sock",
+        socket_path=socket_dir / "bridge.sock",
         log=lambda _: None,
     )
 
@@ -451,10 +459,38 @@ def test_bridge_releases_cluster_when_socket_startup_fails(
 
     assert runner.ensure_calls == 1
     assert runner.release_calls == 1
+
+
+def test_bridge_rejects_an_unservable_socket_path_before_allocating_compute(
+    tmp_path: Path,
+) -> None:
+    """A log directory too deep for ``sun_path`` must not cost a cluster lease."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    runner = FakeRunner()
+    bridge = SkyPilotBridge(
+        runner=runner,
+        cluster_name="lease",
+        resources=_resources(),
+        workspace=workspace,
+        evaluator_package_root=None,
+        hidden_paths=(),
+        commands={"accuracy": ("true",)},
+        benchmark_output_argument=None,
+        state_namespace=_namespace(tmp_path),
+        socket_path=tmp_path / ("d" * MAX_SOCKET_PATH_BYTES) / "bridge.sock",
+        log=lambda _: None,
+    )
+
+    with pytest.raises(SocketPathTooLongError):
+        bridge.start()
+
+    assert runner.ensure_calls == 0
+    assert runner.release_calls == 0
     assert not bridge.socket_path.exists()
 
 
-def test_bridge_rejects_special_workspace_file(tmp_path: Path) -> None:
+def test_bridge_rejects_special_workspace_file(tmp_path: Path, socket_dir: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     os.mkfifo(workspace / "pipe")
@@ -469,7 +505,7 @@ def test_bridge_rejects_special_workspace_file(tmp_path: Path) -> None:
         commands={"accuracy": ("true",)},
         benchmark_output_argument=None,
         state_namespace=_namespace(tmp_path),
-        socket_path=tmp_path / "bridge.sock",
+        socket_path=socket_dir / "bridge.sock",
         log=lambda _: None,
     )
     bridge.start()
@@ -492,7 +528,7 @@ def test_bridge_rejects_special_workspace_file(tmp_path: Path) -> None:
     assert not bridge.socket_path.exists()
 
 
-def test_bridge_rejects_workspace_symlink_escape(tmp_path: Path) -> None:
+def test_bridge_rejects_workspace_symlink_escape(tmp_path: Path, socket_dir: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     outside = tmp_path / "secret"
@@ -509,7 +545,7 @@ def test_bridge_rejects_workspace_symlink_escape(tmp_path: Path) -> None:
         commands={"accuracy": ("python", "checker.py")},
         benchmark_output_argument=None,
         state_namespace=_namespace(tmp_path),
-        socket_path=tmp_path / "bridge.sock",
+        socket_path=socket_dir / "bridge.sock",
         log=lambda _: None,
     )
     bridge.start()

--- a/tests/skypilot/test_evaluator_helper.py
+++ b/tests/skypilot/test_evaluator_helper.py
@@ -26,25 +26,34 @@ type _Frame = ArtifactFrame | ErrorFrame | OutputFrame | ResultFrame
 
 
 def _serve_frames(socket_path: Path, frames: list[_Frame]) -> threading.Thread:
+    """Serve one bridge conversation on ``socket_path``, then exit.
+
+    ``ready`` is released from a ``finally`` so a server thread that dies
+    during setup surfaces as a connection failure in the test rather than
+    parking the main thread on ``ready.wait()`` for the life of the run.
+    """
     ready = threading.Event()
 
     def serve() -> None:
-        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
-            server.bind(str(socket_path))
-            server.listen(1)
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+                server.bind(str(socket_path))
+                server.listen(1)
+                ready.set()
+                connection, _ = server.accept()
+                with connection:
+                    reader = connection.makefile("rb")
+                    request = json.loads(reader.readline())
+                    for frame in frames:
+                        connection.sendall(encode_message(frame))
+                    if any(isinstance(frame, ResultFrame) for frame in frames):
+                        acknowledgement = json.loads(reader.readline())
+                        assert acknowledgement["type"] == "ack"
+                        connection.sendall(
+                            encode_message(AckedFrame(invocation_id=request["invocation_id"]))
+                        )
+        finally:
             ready.set()
-            connection, _ = server.accept()
-            with connection:
-                reader = connection.makefile("rb")
-                request = json.loads(reader.readline())
-                for frame in frames:
-                    connection.sendall(encode_message(frame))
-                if any(isinstance(frame, ResultFrame) for frame in frames):
-                    acknowledgement = json.loads(reader.readline())
-                    assert acknowledgement["type"] == "ack"
-                    connection.sendall(
-                        encode_message(AckedFrame(invocation_id=request["invocation_id"]))
-                    )
 
     thread = threading.Thread(target=serve)
     thread.start()
@@ -57,11 +66,11 @@ def _serve_frames(socket_path: Path, frames: list[_Frame]) -> threading.Thread:
     [("COMPLETED", 0), ("APPLICATION_FAILED", 1), ("CANCELLED", 130)],
 )
 def test_helper_relays_streams_and_maps_terminal_status(
-    tmp_path: Path,
+    socket_dir: Path,
     status: Literal["COMPLETED", "APPLICATION_FAILED", "CANCELLED"],
     expected: int,
 ) -> None:
-    path = tmp_path / "bridge.sock"
+    path = socket_dir / "bridge.sock"
     thread = _serve_frames(
         path,
         [
@@ -78,8 +87,8 @@ def test_helper_relays_streams_and_maps_terminal_status(
     assert stderr.getvalue() == "err\n"
 
 
-def test_helper_reports_bridge_error_as_transport_failure(tmp_path: Path) -> None:
-    path = tmp_path / "bridge.sock"
+def test_helper_reports_bridge_error_as_transport_failure(socket_dir: Path) -> None:
+    path = socket_dir / "bridge.sock"
     thread = _serve_frames(path, [ErrorFrame(error="SkyPilotTimeoutError")])
     stderr = io.StringIO()
 
@@ -88,19 +97,22 @@ def test_helper_reports_bridge_error_as_transport_failure(tmp_path: Path) -> Non
     assert "SkyPilotTimeoutError" in stderr.getvalue()
 
 
-def test_helper_rejects_incomplete_terminal_result(tmp_path: Path) -> None:
-    path = tmp_path / "bridge.sock"
+def test_helper_rejects_incomplete_terminal_result(socket_dir: Path) -> None:
+    path = socket_dir / "bridge.sock"
     ready = threading.Event()
 
     def serve() -> None:
-        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
-            server.bind(str(path))
-            server.listen(1)
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+                server.bind(str(path))
+                server.listen(1)
+                ready.set()
+                connection, _ = server.accept()
+                with connection:
+                    connection.makefile("rb").readline()
+                    connection.sendall(b'{"version":2,"type":"result","status":"COMPLETED"}\n')
+        finally:
             ready.set()
-            connection, _ = server.accept()
-            with connection:
-                connection.makefile("rb").readline()
-                connection.sendall(b'{"version":2,"type":"result","status":"COMPLETED"}\n')
 
     raw_thread = threading.Thread(target=serve)
     raw_thread.start()
@@ -112,8 +124,8 @@ def test_helper_rejects_incomplete_terminal_result(tmp_path: Path) -> None:
     assert "invalid result" in stderr.getvalue()
 
 
-def test_helper_materializes_narrow_framework_result_artifact(tmp_path: Path) -> None:
-    socket_path = tmp_path / "bridge.sock"
+def test_helper_materializes_narrow_framework_result_artifact(socket_dir: Path) -> None:
+    socket_path = socket_dir / "bridge.sock"
     output_path = Path("/tmp/vibesys-framework-benchmark-helper-test.json")  # noqa: S108
     output_path.unlink(missing_ok=True)
     thread = _serve_frames(
@@ -159,13 +171,13 @@ def test_pending_invocation_identity_survives_helper_process_state_reload(
 
 
 def test_acknowledged_pending_invocation_removal_is_directory_durable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, socket_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("VIBESYS_SKYPILOT_CALLER_STATE", str(tmp_path))
     _, pending_path = helper_module._pending_invocation("accuracy", ())  # noqa: SLF001
     fsynced: list[Path] = []
     monkeypatch.setattr(helper_module, "_fsync_directory", fsynced.append)
-    socket_path = tmp_path / "bridge.sock"
+    socket_path = socket_dir / "bridge.sock"
     thread = _serve_frames(
         socket_path,
         [ResultFrame(status="COMPLETED", sky_exit_code=0, remote_job_id=7)],

--- a/tests/test_release_wheel_verifier.py
+++ b/tests/test_release_wheel_verifier.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import platform
 import shutil
 import stat
 import subprocess
@@ -589,11 +590,15 @@ def test_rejects_symlinks_and_source_maps(release_fixture: tuple[Path, Path]) ->
 
 
 def test_bdist_wheel_revalidates_the_native_host(tmp_path: Path) -> None:
-    env = {
-        **os.environ,
-        "VIBESYS_WHEEL_TARGET": "macos-arm64",
-        "VIBESYS_TUI_BUNDLE": str(tmp_path / "missing"),
-    }
+    # The guard can only fire for a target the build host is not, so pick one
+    # rather than naming a fixed target that happens to be foreign to CI. In
+    # reverse declaration order the first non-native target is ``macos-arm64``
+    # everywhere except an Apple Silicon Mac, so CI keeps its existing case.
+    host = (platform.system(), platform.machine())
+    target_key = next(
+        key for key, target in reversed(TARGETS.items()) if (target.system, target.machine) != host
+    )
+    env = {**os.environ, "VIBESYS_WHEEL_TARGET": target_key}
 
     uv = shutil.which("uv")
     assert uv is not None
@@ -606,5 +611,7 @@ def test_bdist_wheel_revalidates_the_native_host(tmp_path: Path) -> None:
         check=False,
     )
 
+    # Name the target as well: a bare "nonzero exit" also matches unrelated
+    # build failures, which is how this assertion stayed green off-target.
     assert result.returncode != 0
-    assert "must be built natively" in result.stderr
+    assert f"{target_key} must be built natively" in result.stderr

--- a/tests/test_unix_socket.py
+++ b/tests/test_unix_socket.py
@@ -1,0 +1,65 @@
+"""The listening-path length guard shared by the supervision and bridge servers."""
+
+from __future__ import annotations
+
+import socket
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vibesys.server.service import SupervisionService
+from vibesys.server.supervisor import RunSupervisor
+from vibesys.server.transport import SupervisionSocketServer
+from vibesys.unix_socket import (
+    MAX_SOCKET_PATH_BYTES,
+    SocketPathTooLongError,
+    validate_socket_path,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _too_long(root: Path) -> Path:
+    return root / ("d" * MAX_SOCKET_PATH_BYTES) / "supervision.sock"
+
+
+def test_a_bindable_path_passes_through_unchanged(socket_dir: Path) -> None:
+    path = socket_dir / "supervision.sock"
+
+    assert validate_socket_path(path) is path
+
+
+def test_the_limit_matches_what_the_kernel_actually_accepts(socket_dir: Path) -> None:
+    """Pin the constant to real ``bind`` behavior rather than to a copied number."""
+    name = "a" * (MAX_SOCKET_PATH_BYTES - len(str(socket_dir)) - 1)
+    longest = socket_dir / name
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as accepted:
+        accepted.bind(str(longest))
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as rejected:  # noqa: SIM117
+        with pytest.raises(OSError, match="too long"):
+            rejected.bind(f"{longest}a")
+
+
+def test_an_overlong_path_is_rejected_by_name_and_size(tmp_path: Path) -> None:
+    path = _too_long(tmp_path)
+
+    with pytest.raises(SocketPathTooLongError) as failure:
+        validate_socket_path(path)
+
+    message = str(failure.value)
+    assert str(path) in message
+    assert str(MAX_SOCKET_PATH_BYTES) in message
+    assert failure.value.path == path
+
+
+def test_the_supervision_server_reports_an_overlong_path_before_binding(tmp_path: Path) -> None:
+    """The parent directory must not be created for a path that cannot be served."""
+    path = _too_long(tmp_path)
+    service = SupervisionService(RunSupervisor())
+
+    with pytest.raises(SocketPathTooLongError):
+        SupervisionSocketServer(path, service).start()
+
+    assert not path.parent.exists()


### PR DESCRIPTION
## Problem

The test suite does not pass on macOS, and one of the failures takes the whole
run down rather than reporting itself. All three are invisible to Linux CI.

1. **`tests/skypilot` hangs forever.** `_serve_frames` binds an `AF_UNIX`
   socket at `tmp_path / "bridge.sock"`. On macOS `tmp_path` lands under
   `/var/folders/<...>/T/pytest-of-<user>/pytest-N/<test-name>/`, making the
   path ~119 bytes, past the 104-byte `sockaddr_un.sun_path` limit (Linux
   allows 108). `bind` raises before `ready.set()`, the server thread dies, and
   the main thread blocks on `ready.wait()`, which has no timeout. Under
   `-n auto` that parks an xdist worker and the suite never finishes.
   `tests/skypilot/test_bridge.py` builds its socket the same way at 7 sites.

   The same limit is latent in production. Both listening paths derive from a
   user-chosen directory and neither checks length before binding:
   `SkyPilotBridge` (`socket_path` comes from `request.log_dir` in
   `run_environment.py`) and `SupervisionSocketServer`. A deep enough log or
   session directory surfaces a bare `OSError: AF_UNIX path too long` naming
   neither the path nor the limit, and in the bridge case only after
   `ensure_cluster` has already taken a compute lease.

2. **`test_unknown_backend_value_is_rejected` fails on macOS.** It is the only
   member of `TestLinuxBackendSelection` that does not patch the platform, so
   `host_sandbox.build` takes the `darwin` branch and returns a
   `SeatbeltSandbox`. The Linux backend validation under test
   (`_requested_linux_backend`, reachable only from `_build_linux`) is never
   entered, so nothing raises.

3. **`test_bdist_wheel_revalidates_the_native_host` fails on arm64 macOS.** It
   hardcodes `VIBESYS_WHEEL_TARGET=macos-arm64`. The guard in
   `bdist_wheel.finalize_options` fires only when the target's
   `(system, machine)` differs from the host's, and on Apple Silicon the target
   *is* the host, so it cannot fire. Worse, the test also points
   `VIBESYS_TUI_BUNDLE` at a missing directory, so `assert returncode != 0` was
   being satisfied by `TuiPackagingError: Required TUI payload directory is
   missing` rather than by the guard: the assertion was weak on every host.

Fixes #491
Fixes #492
Fixes #493

## Solution

Real fixes throughout; no test is skipped and nothing that ran on Linux stops
running there.

**Socket paths.** A `socket_dir` fixture in `tests/conftest.py` hands out a
`mkdtemp` directory under `/tmp`, far below the limit on both platforms, and
cleans it up. The skypilot tests take sockets from it. Both test servers now
release `ready` from a `finally`, so a server thread that dies during setup
surfaces as a connection failure in its own test instead of deadlocking the
run: the hang was a second, independent defect, and it would have hidden the
next environment quirk just as thoroughly.

New `vibesys/unix_socket.py` owns the platform limit and
`validate_socket_path`. `SupervisionSocketServer.start` and
`SkyPilotBridge.start` call it before doing anything else, so an unservable
path is named with its byte count and the platform limit, the directory is not
created, and no cluster is leased. `SocketPathTooLongError` subclasses
`OSError` with `ENAMETOOLONG` so it substitutes for the kernel's own error and
existing `except OSError` handlers are unaffected.

**Landlock test.** Add the `monkeypatch.setattr(host_sandbox.sys, "platform",
"linux")` its three siblings already use. The rejection logic is pure and needs
no kernel, so this keeps the coverage on both platforms rather than skipping
it. The repo's sandbox tests skip on capability probes, never on `sys.platform`,
and this change stays inside that convention.

**Wheel test.** Select a target the build host is not, by scanning `TARGETS` in
reverse declaration order. On Linux x86_64 CI the first non-native entry is
`macos-arm64`, so CI exercises byte-identical coverage; on an arm64 Mac it
picks `macos-x86_64`. The assertion now names the resolved target
(`f"{target_key} must be built natively"`), and `VIBESYS_TUI_BUNDLE` is dropped
because the guard fires in `finalize_options` before any TUI staging: it was
only ever masking why the build failed.

### Architecture

`unix_socket.py` is a leaf module with no `vibesys` imports, so both the
supervision transport and the SkyPilot bridge depend on it without either
depending on the other, and the limit has one definition.

```mermaid
flowchart LR
    RE[sandbox/run_environment.py<br/>log_dir] --> BR[SkyPilotBridge.start]
    RT[server/runtime.py<br/>session dir] --> SS[SupervisionSocketServer.start]
    BR --> V[unix_socket.validate_socket_path]
    SS --> V
    V -->|ok| BIND[bind]
    V -->|too long| ERR[SocketPathTooLongError<br/>names path, size, limit]
```

The guard sits ahead of every side effect in both `start` methods: directory
creation, stale-socket removal, and, for the bridge, `ensure_cluster`.

## Verification

Everything below was run on the host that reproduces all three bugs: macOS
27.0, arm64, Python 3.12.2.

### Correctness properties

- The full suite terminates on macOS. No test can park the run on a socket
  server that failed to start.
- `validate_socket_path` accepts exactly what `bind` accepts. A test binds a
  path of exactly `MAX_SOCKET_PATH_BYTES` and asserts one byte more is refused
  by the kernel, so the constant is pinned to real behavior on whichever
  platform runs it rather than to a copied number.
- An unservable path is rejected before any side effect: no parent directory is
  created, and no cluster lease is taken.
- `SocketPathTooLongError` is an `OSError` with `ENAMETOOLONG`, so it remains
  substitutable for the error it replaces.
- Linux coverage is unchanged. The wheel test still resolves `macos-arm64` on
  Linux x86_64, and the landlock test asserts the same Linux contract it always
  did, now on both platforms.
- The wheel guard test fails if the guard stops firing, instead of accepting
  any nonzero exit.

### Testing

```
uv run python -m pytest -q -n auto
  → 5281 passed, 17 skipped, 1 warning in 153.33s     (macOS, exit 0)

# before this change, on the same host:
uv run python -m pytest -q -n auto
  → hangs indefinitely in tests/skypilot
uv run python -m pytest -q -n auto --ignore=tests/skypilot
  → 2 failed, 5205 passed, 17 skipped in 123.56s

uv run python -m pytest tests/skypilot/ tests/test_unix_socket.py -q
  → 74 passed

./scripts/check_format.sh   → All checks passed!
./scripts/check_types.sh    → All checks passed!
uv run ruff check <touched files>  → All checks passed!
```

The 17 skips are unchanged from before this PR: Landlock/bwrap capability
probes and device-node checks that a macOS host cannot satisfy, plus
`tests/test_microservice_inputs.py`, which was separately confirmed to skip
cleanly when the DeathStarBench submodule is absent.
