### PR TITLE
feat(tui): integrate hypothesis titles with detail drilldown

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -3254,6 +3254,36 @@ describe('theming', () => {
     expect(controller.state.layout.focus).toBe('left');
   });
 
+  it('shows the hypothesis title as a heading in the detail view', async () => {
+    const testRenderer = await createTestRenderer({width: 200, height: 22});
+    const controller = logController();
+    controller.experiments = [
+      logEntry('H-01', 1, 1, {
+        title: 'Batch prefill to cut latency',
+        claim: 'batching the prefill step reduces latency',
+      }),
+      logEntry('H-02', 2, 2, {claim: 'untitled legacy hypothesis'}),
+    ];
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    controller.publish({
+      ...controller.state,
+      hypothesisDetail: {entryKey: 'H-01', selectedRound: 1},
+    });
+
+    const titled = await testRenderer.waitForFrame(value => value.includes('Hypothesis H-01'));
+    expect(titled).toContain('Batch prefill to cut latency');
+
+    controller.publish({
+      ...controller.state,
+      hypothesisDetail: {entryKey: 'H-02', selectedRound: 2},
+    });
+    const untitled = await testRenderer.waitForFrame(value => value.includes('Hypothesis H-02'));
+    expect(untitled).toContain('untitled legacy hypothesis');
+    expect(untitled).not.toContain('Batch prefill to cut latency');
+  });
+
   it('opens hypothesis detail from a row click and keeps pane clicks routed', async () => {
     const testRenderer = await createTestRenderer({width: 200, height: 22});
     const controller = logController();

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -276,6 +276,8 @@ export class ExperimentLogView {
     const selectedRound = state.hypothesisDetail?.selectedRound ?? null;
     this.output.title = ` ${focusedTitlePrefix(state)}Hypothesis ${entry.hypothesis_id} `;
     this.#header.content = hypothesisMetadata(entry);
+    const title = entry.title?.trim();
+    if (title) this.#line(title, this.#theme.textStrong);
     this.#line('HYPOTHESIS', this.#theme.textSubtle);
     this.#wrappedLine(
       entry.claim?.trim() || 'No hypothesis text was recorded.',


### PR DESCRIPTION
## Problem

The hypothesis detail drilldown in the TUI experiment log shows the claim text
and metadata, but not the backend-supplied hypothesis title, so users have to
infer what a hypothesis is about from its id and raw claim text alone.

## Solution

Render `entry.title` as a heading in `ExperimentLogView`'s hypothesis detail
view, right above the existing `HYPOTHESIS` claim section. When no title is
recorded (legacy hypotheses), the heading is omitted and the view falls back
to the claim text as before.

### Architecture

Purely a view-layer change in `clients/tui/src/ui/experiment-log.ts`: no new
state, no changes to `session-model.ts` or event handling. `entry.title` was
already present on `HypothesisEntry` (used elsewhere for scope labels); this
just surfaces it in one more place.

## Verification

### Correctness properties

- A hypothesis with a title shows that title as a heading in the detail view.
- A hypothesis without a title shows no heading (no blank/placeholder line).
- Switching the drilldown between hypotheses swaps the heading correctly with
  no stale title bleeding across entries.

### Testing

- `pnpm check:clients` — clean
- `pnpm --dir clients/tui test` — 467 pass, 1 pre-existing unrelated failure
  (`launcher > returns the backend argument error for an explicitly empty runs
  directory`, fails locally because `.venv/bin/python` isn't built in this
  sandbox; a known rare flake unrelated to this change)
- `pnpm check:ts` (biome) — clean on touched files (one pre-existing warning
  in `conversation.ts`, a file untouched by this PR)
- `./scripts/check_format.sh` — all checks passed
- `./scripts/check_types.sh` — all checks passed

Cherry-picked from an earlier feature batch (commit `5d7a1df`). Main had
moved substantially since (the `enterExperimentDrilldown` →
`enterExperimentRound` refactor already landed), so the
`session-model.test.ts` hunk from the original commit applied as a no-op
(the assertions it introduced were already present on main in their
post-refactor form); `experiment-log.ts` and `app.test.ts` applied cleanly
with git's auto-merge.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
