### PR TITLE
TUI: Reconnect the event stream and discard 2 answer-cases in experiment chat

### DIFF
--- a/clients/core-state/src/core-state-prefix.test.ts
+++ b/clients/core-state/src/core-state-prefix.test.ts
@@ -153,11 +153,12 @@ describe('prefix merges across the chunk boundary', () => {
         model: 'opus',
       },
     ]);
-    // Consecutive chat answers carry no turn id, so the fold concatenates them
-    // exactly as it does inside one batch. The point is that it still does when
-    // the two answers land on opposite sides of the boundary.
+    // Each chat answer is a complete turn and stays a separate entry. The point
+    // is that the prefix fold agrees with the in-batch fold even when the two
+    // answers land on opposite sides of the boundary.
     expect(merged.chatTranscripts['thread-a']?.map(entry => entry.content)).toEqual([
-      'first answersecond answer',
+      'first answer',
+      'second answer',
     ]);
   });
 

--- a/clients/core-state/src/core-state.test.ts
+++ b/clients/core-state/src/core-state.test.ts
@@ -400,6 +400,49 @@ describe('core state projection', () => {
     expect(state.transcript).toEqual([]);
   });
 
+  it('folds the final chat answer over its own streamed chunks', () => {
+    let state = initialCoreState();
+    state = reduceEvent(state, chatStreamEvent(1, 'The queue ', 'exec-1'));
+    state = reduceEvent(state, chatStreamEvent(2, 'is lock-free.', 'exec-1'));
+    state = reduceEvent(state, chatAnswerEvent(3, 'The queue is lock-free.'));
+
+    // One answer block, under the streamed entry's id so consumers tracking
+    // entries by id update in place, closed to any further folding.
+    expect(state.chatTranscript).toHaveLength(1);
+    expect(state.chatTranscript[0]).toMatchObject({
+      id: '1',
+      kind: 'assistant',
+      label: 'Answer',
+      content: 'The queue is lock-free.',
+    });
+    expect(state.chatTranscript[0]?.turnId).toBeUndefined();
+  });
+
+  it('reconciles each chat turn separately and appends unstreamed answers', () => {
+    const events = [
+      chatStreamEvent(1, 'first ', 'exec-1'),
+      chatStreamEvent(2, 'answer', 'exec-1'),
+      chatAnswerEvent(3, 'first answer'),
+      chatAnswerEvent(4, 'unstreamed answer'),
+      chatStreamEvent(5, 'second answer', 'exec-2'),
+      chatAnswerEvent(6, 'second answer'),
+    ];
+    const batched = reduceEventBatch(initialCoreState(), events);
+    let single = initialCoreState();
+    for (const item of events) single = reduceEvent(single, item);
+
+    // Both fold paths agree: a finalized turn cannot swallow the next answer,
+    // and an answer that never streamed still lands as its own entry.
+    for (const state of [batched, single]) {
+      expect(state.chatTranscript.map(item => [item.id, item.content])).toEqual([
+        ['1', 'first answer'],
+        ['4', 'unstreamed answer'],
+        ['5', 'second answer'],
+      ]);
+      expect(state.chatTranscript.every(item => item.turnId === undefined)).toBe(true);
+    }
+  });
+
   it('replays the thread list from creation events after the implicit default', () => {
     let state = initialCoreState();
     state = reduceEvent(state, threadCreatedEvent(1, 'thread-a', 'claude'));
@@ -796,6 +839,15 @@ function chatAnswerEvent(sequence: number, answer: string, threadId?: string): R
     round_label: 'experiment-chat',
     ...(threadId === undefined ? {} : {chat_thread_id: threadId}),
     data: {kind: 'chat', answer},
+  };
+}
+
+/** One assistant-channel chunk of a chat turn, as the chat agent streams it. */
+function chatStreamEvent(sequence: number, content: string, invocationId: string): RunEvent {
+  return {
+    ...outputEvent(sequence, content, invocationId),
+    agent_kind: 'chat',
+    round_label: 'experiment-chat',
   };
 }
 

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -685,7 +685,7 @@ function applyChatEvent(
   }
   const entry = eventToTranscriptEntry(event);
   if (entry === null || (entry.kind !== 'assistant' && entry.kind !== 'result')) return next;
-  return appendChatTranscript(next, threadId, entry, folder);
+  return appendChatTranscript(next, threadId, entry, folder, data?.kind === 'chat');
 }
 
 /** Registers a replayed thread, or refreshes the record it already has. */
@@ -729,18 +729,44 @@ function appendChatTranscript(
   threadId: string,
   entry: TranscriptEntry,
   folder: TranscriptFolder | null,
+  finalAnswer = false,
 ): CoreState {
   if (folder !== null) {
-    folder.buffer(threadId, state.chatTranscripts[threadId] ?? []).append(entry);
+    const buffer = folder.buffer(threadId, state.chatTranscripts[threadId] ?? []);
+    if (!(finalAnswer && foldChatAnswer(buffer.entries, entry))) buffer.append(entry);
     return state;
   }
-  const transcript = appendTranscript(state.chatTranscripts[threadId] ?? [], entry);
+  const transcript = [...(state.chatTranscripts[threadId] ?? [])];
+  if (!(finalAnswer && foldChatAnswer(transcript, entry))) {
+    foldTranscriptEntry(transcript, entry, null);
+  }
   const chatTranscripts = {...state.chatTranscripts, [threadId]: transcript};
   return {
     ...state,
     chatTranscripts,
     chatTranscript: threadId === DEFAULT_CHAT_THREAD_ID ? transcript : state.chatTranscript,
   };
+}
+
+/**
+ * Folds a turn's terminal answer over its own streamed chunks.
+ *
+ * The assistant chunks of one chat turn have already merged into a single
+ * entry keyed by the turn's invocation id, and the terminal `chat` event
+ * carries the same text once more. When such a turn is still open at the end
+ * of the transcript, the final answer replaces it in place rather than
+ * appearing as a second copy. The streamed entry's id is kept so consumers
+ * tracking entries by id update instead of duplicating, and the turn id is
+ * dropped because the turn is over: neither a later chunk nor a later answer
+ * may fold into it. Returns false when there is no open streamed turn, in
+ * which case the answer appends as its own entry.
+ */
+function foldChatAnswer(entries: TranscriptEntry[], incoming: TranscriptEntry): boolean {
+  const last = entries.at(-1);
+  if (last === undefined || last.kind !== 'assistant' || last.turnId === undefined) return false;
+  const {turnId: _closed, ...merged} = {...last, ...incoming, id: last.id};
+  entries[entries.length - 1] = merged;
+  return true;
 }
 
 function applyDiagnosticEvent(state: CoreState, event: RunEvent): CoreState {
@@ -1119,6 +1145,10 @@ function foldTranscriptEntry(
   if (
     last !== undefined &&
     last.kind === incoming.kind &&
+    // Chunks of one turn share its id; an entry without a turn (a terminal
+    // chat answer, or one already closed by `foldChatAnswer`) is complete and
+    // must not glue onto a neighbor that is just as complete.
+    last.turnId !== undefined &&
     last.turnId === incoming.turnId &&
     (incoming.kind === 'assistant' || incoming.kind === 'prompt' || incoming.kind === 'analysis')
   ) {

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -213,7 +213,9 @@ describe('session controller', () => {
 
   it('preserves backend execution state but suppresses live activity after a disconnect', async () => {
     const transport = new FakeTransport();
-    const controller = new SocketSessionController(transport);
+    // An empty backoff schedule: this test is about the disconnected state
+    // itself, not the reconnect that would otherwise follow.
+    const controller = new SocketSessionController(transport, undefined, undefined, []);
     await controller.start();
     transport.emit({
       type: 'event',
@@ -1709,6 +1711,106 @@ describe('a stream that re-bootstraps at a raised floor', () => {
   });
 });
 
+describe('stream reconnect', () => {
+  /** Lets the zero-delay reconnect timer and its subscribe settle. */
+  const settle = () => new Promise<void>(resolve => setTimeout(resolve, 1));
+
+  it('resumes from its own cursor, clears the outage, and folds nothing twice', async () => {
+    const transport = new ReconnectTransport();
+    const controller = new SocketSessionController(transport, undefined, undefined, [0]);
+    await controller.start();
+    transport.emitBatch([
+      event(1, 'agent_output_chunk', 'one\n'),
+      event(2, 'agent_output_chunk', 'two\n'),
+    ]);
+
+    transport.sever();
+    expect(controller.state.eventStreamAvailable).toBe(false);
+    expect(controller.state.errorBanner).toMatchObject({scope: 'transport'});
+
+    await settle();
+
+    // The resume asks for events after the last one folded, with no tail.
+    expect(transport.subscribeCalls).toEqual([
+      {afterSequence: 0, tail: 1_000},
+      {afterSequence: 2, tail: undefined},
+    ]);
+    expect(controller.state.eventStreamAvailable).toBe(true);
+    expect(controller.state.errorBanner).toBeNull();
+
+    // A server replaying the boundary event does not duplicate it.
+    transport.emitBatch([
+      event(2, 'agent_output_chunk', 'two\n'),
+      event(3, 'agent_output_chunk', 'three\n'),
+    ]);
+    expect(controller.state.core.sequence).toBe(3);
+    expect(controller.state.core.transcript.filter(item => item.content === 'two\n')).toHaveLength(
+      1,
+    );
+
+    // A success gives the next outage the full schedule again.
+    transport.sever();
+    await settle();
+    expect(transport.subscribeCalls).toHaveLength(3);
+    expect(transport.subscribeCalls[2]).toEqual({afterSequence: 3, tail: undefined});
+    expect(controller.state.eventStreamAvailable).toBe(true);
+  });
+
+  it('keeps the history floor a resumed stream cannot vouch for', async () => {
+    const transport = new ReconnectTransport();
+    const controller = new SocketSessionController(transport, undefined, undefined, [0]);
+    await controller.start();
+    // A tail bootstrap: everything at or below sequence 5 is unread history.
+    transport.emitBatch([event(6, 'agent_output_chunk', 'six\n')], 5);
+    expect(controller.state.core.historyAfterSequence).toBe(5);
+
+    transport.sever();
+    await settle();
+    // The resumed stream declares no floor of its own; taking its 0 literally
+    // would claim the unread history below 5 is already loaded.
+    transport.emitBatch([event(7, 'agent_output_chunk', 'seven\n')], 0);
+
+    expect(controller.state.core.sequence).toBe(7);
+    expect(controller.state.core.historyAfterSequence).toBe(5);
+  });
+
+  it('stops dialing when the schedule runs out and leaves the banner up', async () => {
+    const transport = new ReconnectTransport();
+    const controller = new SocketSessionController(transport, undefined, undefined, [0, 0]);
+    await controller.start();
+    transport.emitBatch([event(1, 'agent_output_chunk', 'one\n')]);
+
+    transport.refuseSubscribes = Number.POSITIVE_INFINITY;
+    transport.sever();
+    await settle();
+    await settle();
+    await settle();
+
+    // The boot subscribe plus one attempt per schedule entry, then silence.
+    expect(transport.subscribeCalls).toHaveLength(3);
+    expect(controller.state.eventStreamAvailable).toBe(false);
+    expect(controller.state.errorBanner).toMatchObject({scope: 'transport'});
+  });
+
+  it('does not reconnect after a terminal event or once stopped', async () => {
+    const finished = new ReconnectTransport();
+    const finishedController = new SocketSessionController(finished, undefined, undefined, [0]);
+    await finishedController.start();
+    finished.emitBatch([event(1, 'run_finished')]);
+    finished.sever();
+    await settle();
+    expect(finished.subscribeCalls).toHaveLength(1);
+
+    const stopped = new ReconnectTransport();
+    const stoppedController = new SocketSessionController(stopped, undefined, undefined, [0]);
+    await stoppedController.start();
+    await stoppedController.stop();
+    stopped.sever();
+    await settle();
+    expect(stopped.subscribeCalls).toHaveLength(1);
+  });
+});
+
 class FakeTransport implements SupervisionTransport {
   closed = false;
   /** Mutable so a test can change what a refetch returns mid-run. */
@@ -1771,6 +1873,63 @@ class FakeTransport implements SupervisionTransport {
 
   disconnect(error: Error): void {
     this.#disconnect?.(error);
+  }
+}
+
+/**
+ * A backend whose stream a test can sever and whose dials it can refuse:
+ * everything the reconnect path needs in order to be observed.
+ */
+class ReconnectTransport implements SupervisionTransport {
+  readonly requests: RequestInput[] = [];
+  /** Every subscribe: the cursor and tail it carried, in order. */
+  readonly subscribeCalls: Array<{afterSequence: number; tail: number | undefined}> = [];
+  /** How many upcoming subscribes to reject before letting one through. */
+  refuseSubscribes = 0;
+  #message: ((message: ServerMessage) => void) | null = null;
+  #disconnect: ((error: Error) => void) | null = null;
+
+  request(input: RequestInput): Promise<ProtocolResponse> {
+    this.requests.push(input);
+    return Promise.resolve({
+      protocol_version: 1,
+      request_id: 'request',
+      timestamp: '2026-01-01T00:00:00Z',
+      ok: true,
+      ...(input.type === 'query.experiments' ? {experiments: [], experiments_ready: true} : {}),
+    });
+  }
+
+  subscribe(
+    afterSequence: number,
+    onMessage: (message: ServerMessage) => void,
+    onDisconnect: (error: Error) => void,
+    options?: SubscribeOptions,
+  ): Promise<EventSubscription> {
+    this.subscribeCalls.push({afterSequence, tail: options?.tail});
+    if (this.refuseSubscribes > 0) {
+      this.refuseSubscribes -= 1;
+      return Promise.reject(new Error('connection refused'));
+    }
+    this.#message = onMessage;
+    this.#disconnect = onDisconnect;
+    return Promise.resolve({close: async () => undefined});
+  }
+
+  emitBatch(events: readonly RunEvent[], historyAfterSequence = 0): void {
+    this.#message?.({
+      type: 'event_batch',
+      events: [...events],
+      history_after_sequence: historyAfterSequence,
+    });
+  }
+
+  sever(message = 'Supervision event stream disconnected'): void {
+    this.#disconnect?.(new Error(message));
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
   }
 }
 

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -41,6 +41,7 @@ import {
   initialSessionState,
   leaveExperimentDrilldown,
   leaveHypothesisDetail,
+  markEventStreamAvailable,
   markEventStreamUnavailable,
   moveChatMenuSelection,
   moveExperimentSelection,
@@ -171,6 +172,15 @@ export interface SupervisionTransport {
 const BOOTSTRAP_TAIL = 1_000;
 const BACKFILL_CHUNK = 1_000;
 
+/**
+ * Backoff between reconnect attempts after the event stream drops. The
+ * schedule is finite: a server that refuses this many dials in a row is not
+ * coming back on its own, and the disconnect banner stays up as the
+ * persistent answer. A successful resubscribe resets the count, so the next
+ * outage gets the full schedule again.
+ */
+const RECONNECT_DELAYS_MS: readonly number[] = [500, 1_000, 2_000, 4_000, 8_000];
+
 export class SocketSessionController implements SessionController {
   #state: SessionState;
   readonly #listeners = new Set<(state: SessionState) => void>();
@@ -216,6 +226,16 @@ export class SocketSessionController implements SessionController {
    */
   #declaredFloor: number | null = null;
   #streamProtocolError = false;
+  /**
+   * True once the live subscription resumed from the client's own cursor
+   * instead of bootstrapping with a tail. A resumed subscription declares no
+   * history floor of its own, so its batches must not touch the floor
+   * bookkeeping the boot subscription established; see `#onMessage`.
+   */
+  #resumedStream = false;
+  #reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  #reconnectAttempt = 0;
+  #stopped = false;
 
   constructor(
     private readonly client: SupervisionTransport,
@@ -226,6 +246,12 @@ export class SocketSessionController implements SessionController {
      * (`boot-trace.ts`), which is why the default discards.
      */
     private readonly trace: StartupTrace = () => {},
+    /**
+     * Backoff schedule for stream reconnects; its length bounds the attempts
+     * per outage. Injected by tests so a retry is immediate instead of half a
+     * second away.
+     */
+    private readonly reconnectDelaysMs: readonly number[] = RECONNECT_DELAYS_MS,
   ) {
     this.#state = initialSessionState(themeName);
   }
@@ -273,33 +299,93 @@ export class SocketSessionController implements SessionController {
    * special case, since the server clamps the floor to 0 and the batch comes
    * back with `history_after_sequence` 0, which is today's behavior exactly.
    */
-  async #openEventStream(): Promise<void> {
+  async #openEventStream(): Promise<boolean> {
     const onMessage = (message: ServerMessage): void => this.#onMessage(message);
-    const onDisconnect = (error: Error): void => {
-      // A terminal event already carries the actual outcome. The socket
-      // closing afterward is lifecycle cleanup, not a second failure that
-      // should replace the useful diagnostic in the banner.
-      if (!this.#state.core.terminal && !this.#streamProtocolError) {
-        this.#setState(
-          reportCaughtError(markEventStreamUnavailable(this.#state), error, 'transport'),
-        );
-      }
-    };
+    const onDisconnect = (error: Error): void => this.#onStreamDisconnect(error);
     try {
       this.#eventSubscription = await this.client.subscribe(0, onMessage, onDisconnect, {
         tail: BOOTSTRAP_TAIL,
       });
-      return;
+      return true;
     } catch {
       // Reported only if the full replay fails too: one boot must not put two
       // banners up, and the first failure is expected against an old server.
     }
     try {
       this.#eventSubscription = await this.client.subscribe(0, onMessage, onDisconnect);
+      return true;
     } catch (error) {
       this.#setState(
         reportCaughtError(markEventStreamUnavailable(this.#state), error, 'transport'),
       );
+      return false;
+    }
+  }
+
+  #onStreamDisconnect(error: Error): void {
+    // A terminal event already carries the actual outcome. The socket
+    // closing afterward is lifecycle cleanup, not a second failure that
+    // should replace the useful diagnostic in the banner. The same applies
+    // to reconnecting: a finished run has nothing more to stream.
+    if (this.#stopped || this.#state.core.terminal || this.#streamProtocolError) return;
+    this.#setState(reportCaughtError(markEventStreamUnavailable(this.#state), error, 'transport'));
+    this.#scheduleReconnect();
+  }
+
+  #scheduleReconnect(): void {
+    if (this.#reconnectTimer !== null) return;
+    const delay = this.reconnectDelaysMs[this.#reconnectAttempt];
+    if (delay === undefined) return;
+    this.#reconnectAttempt += 1;
+    this.#reconnectTimer = setTimeout(() => {
+      this.#reconnectTimer = null;
+      void this.#resumeEventStream();
+    }, delay);
+  }
+
+  /**
+   * Re-opens the event stream after a disconnect, resuming from the client's
+   * own cursor: `core.sequence` is the last folded event, and the reducer
+   * skips anything at or below it, so a boundary event delivered twice folds
+   * once and an event the outage swallowed is replayed rather than lost.
+   *
+   * If the boot batch never arrived there is no cursor and no floor to
+   * preserve, so the resume is a fresh bootstrap instead, tail fallback and
+   * all.
+   */
+  async #resumeEventStream(): Promise<void> {
+    if (this.#stopped || this.#state.core.terminal || this.#streamProtocolError) return;
+    const stale = this.#eventSubscription;
+    this.#eventSubscription = null;
+    try {
+      await stale?.close();
+    } catch {
+      // The subscription is already dead; closing it owes nothing.
+    }
+    const recovered =
+      this.#declaredFloor === null ? await this.#openEventStream() : await this.#resubscribe();
+    if (this.#stopped) return;
+    if (recovered) {
+      this.#reconnectAttempt = 0;
+      this.#setState(markEventStreamAvailable(this.#state));
+    } else {
+      this.#scheduleReconnect();
+    }
+  }
+
+  async #resubscribe(): Promise<boolean> {
+    try {
+      this.#eventSubscription = await this.client.subscribe(
+        this.#state.core.sequence,
+        message => this.#onMessage(message),
+        error => this.#onStreamDisconnect(error),
+      );
+      this.#resumedStream = true;
+      return true;
+    } catch {
+      // The disconnect banner is still up and still accurate; the next
+      // attempt, if the schedule has one, speaks for itself.
+      return false;
     }
   }
 
@@ -348,6 +434,11 @@ export class SocketSessionController implements SessionController {
   }
 
   async stop(): Promise<void> {
+    this.#stopped = true;
+    if (this.#reconnectTimer !== null) {
+      clearTimeout(this.#reconnectTimer);
+      this.#reconnectTimer = null;
+    }
     await this.#eventSubscription?.close();
     this.#eventSubscription = null;
     await this.client.close();
@@ -914,23 +1005,41 @@ export class SocketSessionController implements SessionController {
       this.#refreshPaneFor([message.event]);
     }
     if (message.type === 'event_batch') {
-      const declared = message.history_after_sequence ?? 0;
-      const rebootstrap = this.#declaredFloor !== null && declared > this.#declaredFloor;
-      this.#declaredFloor = declared;
-      const floor = rebootstrap
-        ? this.#raiseHistoryFloor(declared)
-        : this.#lowerHistoryFloor(declared);
-      const apply = rebootstrap ? applyEventRebootstrap : applyEventBatch;
-      this.#setState(
-        apply(
-          this.#state,
-          message.events,
-          message.active_executions,
-          message.through_sequence,
-          floor,
-        ),
-      );
-      this.#recordSpine(message.events, declared);
+      if (this.#resumedStream) {
+        // A resumed subscription replays exactly the events after the
+        // client's own cursor and declares no history floor of its own
+        // (`history_after_sequence` 0 on every batch). Taking that literally
+        // would mark history complete and quietly break scroll-back, so the
+        // floor bookkeeping keeps the boot subscription's answers and the
+        // batch folds at the floor already in state.
+        this.#setState(
+          applyEventBatch(
+            this.#state,
+            message.events,
+            message.active_executions,
+            message.through_sequence,
+            this.#state.core.historyAfterSequence,
+          ),
+        );
+      } else {
+        const declared = message.history_after_sequence ?? 0;
+        const rebootstrap = this.#declaredFloor !== null && declared > this.#declaredFloor;
+        this.#declaredFloor = declared;
+        const floor = rebootstrap
+          ? this.#raiseHistoryFloor(declared)
+          : this.#lowerHistoryFloor(declared);
+        const apply = rebootstrap ? applyEventRebootstrap : applyEventBatch;
+        this.#setState(
+          apply(
+            this.#state,
+            message.events,
+            message.active_executions,
+            message.through_sequence,
+            floor,
+          ),
+        );
+        this.#recordSpine(message.events, declared);
+      }
       this.#refreshExperimentsFor(message.events);
       this.#refreshPaneFor(message.events);
     }

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -1283,6 +1283,17 @@ export function markEventStreamUnavailable(state: SessionState): SessionState {
   return state.eventStreamAvailable ? {...state, eventStreamAvailable: false} : state;
 }
 
+/**
+ * Record recovered transport health after a successful resubscribe. The
+ * transport banner describes a condition that no longer holds, so it retires
+ * with the outage; banners from other scopes stay untouched.
+ */
+export function markEventStreamAvailable(state: SessionState): SessionState {
+  const errorBanner = state.errorBanner?.scope === 'transport' ? null : state.errorBanner;
+  if (state.eventStreamAvailable && errorBanner === state.errorBanner) return state;
+  return {...state, eventStreamAvailable: true, errorBanner};
+}
+
 /** Active work is presentable only while its source stream remains trustworthy. */
 export function visibleActiveExecutions(state: SessionState): ActiveAgentExecution[] {
   if (!state.eventStreamAvailable) return [];

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -628,6 +628,51 @@ describe('OpenTUI presentation', () => {
     expect(early).toContain('[ r1 ]');
   });
 
+  it('leaves brackets and cursor keys to a typed command', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 20});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      core: {
+        ...initialSessionState().core,
+        rounds: [
+          {number: 1, status: 'completed' as const},
+          {number: 2, status: 'active' as const},
+        ],
+        transcript: [
+          {
+            id: 'live',
+            kind: 'assistant',
+            label: 'Agent',
+            content: 'live output',
+            roundNumber: 2,
+          },
+        ],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+    const focusBefore = controller.state.roundFocus;
+
+    // With text in the command input, brackets are characters and the cursor
+    // keys stay in the input: nothing navigates rounds or moves pane focus.
+    await testRenderer.mockInput.typeText('/steer fix arr[0]');
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    const typed = await frameAfter(testRenderer);
+    expect(typed).toContain('arr[0]');
+    expect(controller.state.selectedRound).toBeNull();
+    expect(controller.state.roundFocus).toBe(focusBefore);
+
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.submissions.length === 1);
+    expect(controller.submissions).toEqual(['/steer fix arr[0]']);
+
+    // With the input empty again, the same key is round navigation.
+    testRenderer.mockInput.pressKey('[');
+    await frameAfter(testRenderer);
+    expect(controller.state.selectedRound).toBe(1);
+  });
+
   it('filters the transcript to an agent node that is clicked', async () => {
     const testRenderer = await createTestRenderer({width: 150, height: 24});
     const controller = new FakeController({
@@ -2057,7 +2102,7 @@ describe('theming', () => {
     expect(controller.liveCalls).toBe(0);
   });
 
-  it('leaves Enter to a typed command while the theme list is open', async () => {
+  it('contains typing and Enter while the theme list is open', async () => {
     const testRenderer = await createTestRenderer({width: 90, height: 24});
     const controller = new FakeController(initialSessionState());
     const app = createOpenTuiApp(testRenderer.renderer, controller);
@@ -2069,14 +2114,19 @@ describe('theming', () => {
     testRenderer.mockInput.pressKey('ARROW_DOWN');
     await testRenderer.waitForFrame(value => value.includes('\u203a light'));
 
-    await testRenderer.mockInput.typeText('/help');
+    // The picker is modal: typed text is swallowed instead of reaching the
+    // command input hidden behind it, and Enter applies the highlighted theme
+    // rather than submitting whatever leaked through.
+    await testRenderer.mockInput.typeText('/quack');
     testRenderer.mockInput.pressEnter();
-    await testRenderer.waitForFrame(() => controller.submissions.length === 2);
+    await testRenderer.waitForFrame(() => controller.state.themePicker === null);
 
-    // The command ran; the highlighted theme was not applied by its Enter.
-    expect(controller.submissions).toEqual(['/theme', '/help']);
-    expect(controller.state.themeName).toBe('dark');
-    expect(controller.state.themePicker?.selected).toBe('light');
+    expect(controller.submissions).toEqual(['/theme']);
+    expect(controller.state.themeName).toBe('light');
+    const settled = testRenderer.captureCharFrame();
+    // The input still shows its placeholder: nothing typed reached it.
+    expect(settled).not.toContain('/quack');
+    expect(settled).toContain('Type /help for commands');
   });
 
   it('owns its keys over the chat it was opened from', async () => {
@@ -2423,6 +2473,52 @@ describe('theming', () => {
     const back = await frameAfterEscape(testRenderer);
     expect(back).toContain('Implementation Details');
     expect(back).not.toContain('Available commands');
+  });
+
+  it('swallows keys an overlay does not use instead of leaking them behind', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 24});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      overlay: {kind: 'help', content: 'Available commands'},
+      core: {
+        ...initialSessionState().core,
+        rounds: [
+          {number: 1, status: 'completed' as const},
+          {number: 2, status: 'active' as const},
+        ],
+        transcript: [
+          {
+            id: 'live',
+            kind: 'assistant',
+            label: 'Agent',
+            content: 'live output',
+            roundNumber: 2,
+          },
+        ],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('Available commands'));
+
+    // The overlay is modal: round navigation, pane focus, and typing are
+    // swallowed rather than applied to the panes or the hidden command input.
+    testRenderer.mockInput.pressKey('[');
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    await testRenderer.mockInput.typeText('/quack');
+    testRenderer.mockInput.pressEnter();
+    const held = await frameAfter(testRenderer);
+    expect(held).toContain('Available commands');
+    expect(controller.state.overlay).not.toBeNull();
+    expect(controller.state.selectedRound).toBeNull();
+    expect(controller.submissions).toEqual([]);
+
+    // Escape still closes it, and nothing typed while it was open surfaces.
+    testRenderer.mockInput.pressKey('ESCAPE');
+    const back = await frameAfterEscape(testRenderer);
+    expect(back).not.toContain('Available commands');
+    expect(back).toContain('live output');
+    expect(back).not.toContain('/quack');
   });
 
   it('colors the outcome cell from the active theme in light and dark', async () => {

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -142,10 +142,9 @@ export function bindKeybindings(
       else if (key.name === 'pageup') controller.moveThemeSelection(-10);
       else if (key.name === 'pagedown') controller.moveThemeSelection(10);
       else if (key.name === 'escape') controller.closeThemePicker();
-      else if (key.name === 'return' || key.name === 'enter') {
-        if (!actions.inputIsEmpty()) return;
-        controller.applySelectedTheme();
-      } else return;
+      else if (key.name === 'return' || key.name === 'enter') controller.applySelectedTheme();
+      // The picker is modal: keys it does not use are swallowed here so they
+      // cannot move panes or type into the still-focused input behind it.
       key.preventDefault();
       return;
     }
@@ -167,9 +166,13 @@ export function bindKeybindings(
       }
       return;
     }
-    if (key.name === 'escape' && controller.state.overlay !== null) {
-      controller.live();
-      viewport.scrollTo(viewport.scrollHeight);
+    if (controller.state.overlay !== null) {
+      if (key.name === 'escape') {
+        controller.live();
+        viewport.scrollTo(viewport.scrollHeight);
+      }
+      // The overlay is modal: everything it does not handle is swallowed so
+      // keys cannot reach the panes or the hidden command input behind it.
       key.preventDefault();
       return;
     }
@@ -234,7 +237,9 @@ export function bindKeybindings(
         return;
       }
     }
-    if (key.name === 'left' || key.name === 'right') {
+    // Like Enter above, pane focus and round navigation yield to a typed
+    // command: cursor keys and brackets belong to a non-empty input.
+    if ((key.name === 'left' || key.name === 'right') && actions.inputIsEmpty()) {
       controller.focusRound(key.name === 'left' ? 'agents' : 'transcript');
       key.preventDefault();
       return;
@@ -279,13 +284,13 @@ export function bindKeybindings(
       key.preventDefault();
       return;
     }
-    if (key.name === ']') {
+    if (key.name === ']' && actions.inputIsEmpty()) {
       actions.selectNextRound();
       viewport.scrollTo(viewport.scrollHeight);
       key.preventDefault();
       return;
     }
-    if (key.name === '[') {
+    if (key.name === '[' && actions.inputIsEmpty()) {
       actions.selectPreviousRound();
       viewport.scrollTo(viewport.scrollHeight);
       key.preventDefault();


### PR DESCRIPTION
## Problem

Three TUI client defects, all in the keystroke-to-state path:

- #471: `[`, `]`, Left, and Right were handled globally with no `inputIsEmpty()` guard, unlike Enter. Typing `/steer fix arr[0]` silently dropped both brackets and jumped round focus mid-command. The theme picker intercepted only its navigation keys and let every other key leak to the input and global bindings behind it, and the /help and round-detail overlays handled only Escape, so all other keys acted on the UI underneath an open overlay.
- #472: `subscribe()` was called exactly once at startup. The disconnect callback only painted a banner; nothing ever redialed, and `eventStreamAvailable` was never reset. One transient socket drop left the TUI permanently frozen on stale state for the rest of the run.
- #473: every experiment chat answer rendered twice. The streamed assistant deltas fold into one transcript entry keyed by `turnId` (the invocation id), and then the terminal `chat` event, which carries no turn id, appended a second entry with the identical full text under the label "Answer".

## Solution

- Keystroke containment (#471, `keybindings.ts`): `[`, `]`, Left, and Right now fire round navigation only when the command input is empty, the same contract Enter already had; with text present they fall through to the input untouched. The theme picker and the overlays are modal: each handles its own keys (navigation, apply, Escape) and `preventDefault`s everything else, so no key reaches the input, round focus, or any global binding while one is open. Escape on an overlay returns to the live tail.
- Stream reconnect (#472, `session-controller.ts`, `session-model.ts`): on disconnect the controller paints the transport banner as before, then schedules a reconnect on a finite backoff schedule (500 ms, 1 s, 2 s, 4 s, 8 s). Each attempt resubscribes from `CoreState.sequence`, the client's own applied cursor, with no tail, so the server replays exactly the events the client missed; the reducers' existing `sequence <= state.sequence` guard makes any boundary replay idempotent. On success a new `markEventStreamAvailable` clears the flag and retires the transport-scope banner (banners from other scopes are untouched), and the attempt counter resets so the next outage gets the full schedule. If the schedule runs out the banner stays up as the persistent answer. Reconnect is suppressed once the run is terminal, after a stream protocol error, and after `stop()`, which also cancels any pending timer: a server closing the socket after the final event is lifecycle cleanup, not an outage.
- One answer per chat turn (#473, `core-state.ts`): the terminal chat answer now folds over its own streamed entry in place (`foldChatAnswer`). It replaces the last entry when that entry is an assistant entry with a defined turn id, keeps the streamed entry's id so `reconcileChatTranscript`'s replace-by-id stays stable, takes the terminal event's fields (label "Answer", authoritative full text), and drops the turn id to mark the turn closed. The assistant-merge rule in `foldTranscriptEntry` additionally requires a defined turn id, so two complete answers (both with no turn id) can never glue into one block. Answers that were never streamed still append as their own entry.

### Reconnect flow

```mermaid
flowchart LR
    D[onDisconnect] -->|not terminal, not stopped,<br/>no protocol error| B[banner + eventStreamAvailable=false]
    B --> S[backoff timer<br/>500ms..8s, 5 tries]
    S --> R[resubscribe from<br/>CoreState.sequence, no tail]
    R -->|ok| C[clear banner, reset tries,<br/>fold batches at existing history floor]
    R -->|refused| S
    S -->|schedule exhausted| P[persistent banner]
```

A resumed subscription declares no history floor of its own (`history_after_sequence` is 0 on every batch). Taking that literally would mark history complete and silently break scroll-back backfill, so resumed batches keep the floor bookkeeping the boot subscription established and fold at the floor already in state.

## Verification

Automated: the full TypeScript pipeline passes on top of current `main`. Manual: a live `--cli-provider claude` run with the TUI attached, exercising #471 and #473 end to end (details below).

### Correctness properties

- A key pressed with text in the command input always goes to the input; round navigation via `[`, `]`, Left, Right fires only when the input is empty, matching Enter's existing guard.
- An open theme picker or overlay captures every key: its own keys act, everything else is swallowed, and nothing reaches the surfaces behind it. Escape closes and returns to the live tail.
- After a disconnect the client resumes from its own applied sequence: no event is missed and none is applied twice (the reducer skips `sequence <= state.sequence`).
- A resumed subscription never lowers the history floor the boot subscription established, so scroll-back backfill is unaffected by reconnects.
- Reconnect attempts stop exactly when one of these holds: an attempt succeeded (banner cleared, counter reset), the run is terminal, a stream protocol error occurred, the controller stopped, or the schedule is exhausted (banner stays up).
- Exactly one transcript entry exists per chat turn: streamed chunks merge into it, the terminal answer replaces it in place keeping its id, unstreamed answers append once, and two complete answers never merge.
- The prefix (scroll-back backfill) fold and the in-batch fold agree on chat transcripts even when a turn's events straddle the chunk boundary.
- The wire protocol is unchanged: regenerating the TypeScript protocol bindings produces a zero diff.

### Testing

- New unit tests. Keybindings (`app.test.ts`, 3 tests): typing and Enter are contained while the theme picker is open (the typed command is discarded, the highlighted theme applies); an open overlay swallows `[`, Left, and a typed command, and Escape restores the live tail with the input untouched; brackets and cursor keys stay in a non-empty command input, and `[` still navigates rounds once the input is empty. Reconnect (`session-controller.test.ts`, 4 tests with a `ReconnectTransport` fake): resume from the client's own cursor with no tail, idempotent boundary replay, banner cleared, and attempt counter reset for the next outage; the history floor survives a resumed stream that declares floor 0; an exhausted schedule stops dialing and leaves the transport banner; no reconnect after a terminal event or after `stop()`. Chat fold (`core-state.test.ts`, 2 tests): the final answer folds over its own streamed chunks keeping the streamed id; multiple turns, including an unstreamed answer landing between two streamed turns, stay separate entries, asserted identically through `reduceEventBatch` and sequential `reduceEvent`.
- Two pre-existing tests asserted the old behavior and were updated: one app test pinned the theme picker's Enter leak (now asserts containment), and one prefix test pinned consecutive chat answers concatenating into one entry (now asserts two entries; the boundary-consistency property it exists for still holds and is also asserted by the new dual-path test).
- Full pipeline: `pnpm check:ts` (biome), `pnpm check:ts-architecture`, protocol drift (`generate:protocol` then `git diff`: zero), `pnpm check:clients` (tsc), `pnpm test:clients` (backend-client 16, core-state 66, tui 474, 0 failures), `pnpm build:clients`, and both CI TUI package smokes (packed tarball self-test and deployed workspace self-test) all pass.
- Merge safety: the branch is based on the current `main` tip, and of the open PRs (#484, #485, #487, #488, #495) only #488 touches a shared file (`session-controller.ts`) in functions this PR does not modify, so either merge order is clean.
- Manual, real provider: a live `--cli-provider claude` run on the queue demo task with the TUI attached.
  - #471: `/steer fix arr[0]` renders both brackets in the input and Left moves the cursor without touching round focus; with the input empty `[` still navigates rounds. The open theme picker swallows typed letters and closes on Escape. The open /help overlay swallows `[`, Left, and a typed command; Escape returns to the live tail with the command input still empty.
  - #473: two questions asked in experiment chat each produced exactly one Answer block, and the second answer stayed its own block. Before the fix the terminal event appended a duplicate of the streamed text, and consecutive answers merged into one block. No duplicate appeared after later event-driven reconciliations either.
  - #472 is covered by the unit suite; a mid-run transport drop is not stageable in the manual harness.

## Additional findings while solving these issues

- Pre-existing bug found and fixed alongside #473: consecutive chat answers glued into a single transcript entry, because the assistant-merge rule treated two missing turn ids as equal. This affected any thread with more than one answer, independent of the duplication bug. The tightened rule is safe beyond chat: streamed entries always carry a turn id, so only complete answers are affected.
- Resume semantics subtlety worth recording: the server answers a no-tail subscription with `history_after_sequence` 0 on every batch, meaning "I replayed from your cursor", not "history is complete". A naive reconnect that trusted it would silently break scroll-back backfill; with a tail instead, it would trigger the rebootstrap path and discard live state. The `#resumedStream` flag exists to route around both, and a dedicated test pins the floor's survival.
- The disconnect callback also fires when the server closes the socket after a finished run. Reconnecting then would redial a finished run until the schedule ran out and replace the run's terminal status with a spurious outage banner, which is why terminal state suppresses the whole path.

Closes #471. Closes #472. Closes #473.