### PR TITLE
fix(tui): swallow unhandled keys when todos strip is expanded (#471)

### DIFF
--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -233,6 +233,8 @@ export function bindKeybindings(
         key.preventDefault();
         return;
       }
+      key.preventDefault();
+      return;
     }
     if (key.name === 'left' || key.name === 'right') {
       controller.focusRound(key.name === 'left' ? 'agents' : 'transcript');


### PR DESCRIPTION
## Problem
When `todosExpanded` is true, keys not handled by the todos block (printable characters, `[`, `]`, and other navigation keys) leaked through to round-navigation and other handlers below it, causing the command input to lose characters and modals to receive stray keystrokes.

## Solution
Add `key.preventDefault(); return;` at the bottom of the `todosExpanded` block in `keybindings.ts` so all unhandled keys are contained to that surface.

## Verification
### Testing
`bun test --cwd clients/tui`: 141 pass, 16 fail. The 16 failures are pre-existing on `main` (stale `core-state` dist, unrelated to this change).

Closes #471.