### PR TITLE
fix(tui): render markdown in experiment chat pane (#464)

### DIFF
--- a/clients/tui/src/ui/chat-pane.ts
+++ b/clients/tui/src/ui/chat-pane.ts
@@ -103,7 +103,7 @@ export class ChatPaneView {
     this.#conversation = new ConversationView(renderer, controller, markdownStyle, theme, {
       selectConversation: state => state.chatConversation,
       emptyContent: 'Ask about this run: progress, a failure, or what a hypothesis changed.',
-      renderMarkdown: false,
+      renderMarkdown: true,
       onFocusRequest: () => controller.focusPane('chat'),
     });
     this.#composer = new ChatComposerView(


### PR DESCRIPTION
## Problem
The chat pane passed `renderMarkdown: false` to `ConversationView` despite the view already supporting markdown via `MarkdownRenderable`. Agent answers containing `**bold**`, headings, and lists rendered as raw marker characters instead of formatted text.

## Solution
Flip `renderMarkdown: false` to `true` in `chat-pane.ts`.

## Verification
### Testing
`bun test --cwd clients/tui`: 141 pass, 16 fail. The 16 failures are pre-existing on `main` (stale `core-state` dist, unrelated to this change).

Closes #464.