### PR TITLE
fix(tui): append unit to absolute metric in measured column (#465)

### DIFF
--- a/clients/tui/src/ui/experiment-log.test.ts
+++ b/clients/tui/src/ui/experiment-log.test.ts
@@ -119,7 +119,9 @@ describe('experiment log rows', () => {
   it('falls back from a delta to an absolute metric and then to a placeholder', () => {
     expect(formatMeasured(entry({perf_delta_pct: -2}))).toBe('-2.0%');
     expect(formatMeasured(entry({perf_delta_pct: null, perf_metric: 2412.5}))).toBe('2412.5');
-    expect(formatMeasured(entry({perf_delta_pct: null, perf_metric: 2412.5, perf_unit: 'ops/s'}))).toBe('2412.5 ops/s');
+    expect(
+      formatMeasured(entry({perf_delta_pct: null, perf_metric: 2412.5, perf_unit: 'ops/s'})),
+    ).toBe('2412.5 ops/s');
     expect(formatMeasured(entry({perf_delta_pct: null, perf_metric: null}))).toBe('—');
   });
 

--- a/clients/tui/src/ui/experiment-log.test.ts
+++ b/clients/tui/src/ui/experiment-log.test.ts
@@ -119,6 +119,7 @@ describe('experiment log rows', () => {
   it('falls back from a delta to an absolute metric and then to a placeholder', () => {
     expect(formatMeasured(entry({perf_delta_pct: -2}))).toBe('-2.0%');
     expect(formatMeasured(entry({perf_delta_pct: null, perf_metric: 2412.5}))).toBe('2412.5');
+    expect(formatMeasured(entry({perf_delta_pct: null, perf_metric: 2412.5, perf_unit: 'ops/s'}))).toBe('2412.5 ops/s');
     expect(formatMeasured(entry({perf_delta_pct: null, perf_metric: null}))).toBe('—');
   });
 

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -640,7 +640,7 @@ export function formatMeasured(entry: HypothesisEntry): string {
     const sign = delta > 0 ? '+' : '';
     return `${sign}${delta.toFixed(delta >= 10 || delta <= -10 ? 0 : 1)}%`;
   }
-  if (typeof entry.perf_metric === 'number') return trimNumber(entry.perf_metric);
+  if (typeof entry.perf_metric === 'number') return `${trimNumber(entry.perf_metric)}${entry.perf_unit ? ` ${entry.perf_unit}` : ''}`; 
   return '—';
 }
 
@@ -721,3 +721,4 @@ function truncate(value: string, width: number): string {
 function trimNumber(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/\.?0+$/, '');
 }
+

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -641,7 +641,7 @@ export function formatMeasured(entry: HypothesisEntry): string {
     return `${sign}${delta.toFixed(delta >= 10 || delta <= -10 ? 0 : 1)}%`;
   }
   if (typeof entry.perf_metric === 'number')
-    return `${trimNumber(entry.perf_metric)}${entry.perf_unit ? ` ${entry.perf_unit}` : ''}`; 
+    return `${trimNumber(entry.perf_metric)}${entry.perf_unit ? ` ${entry.perf_unit}` : ''}`;
   return '—';
 }
 

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -640,7 +640,8 @@ export function formatMeasured(entry: HypothesisEntry): string {
     const sign = delta > 0 ? '+' : '';
     return `${sign}${delta.toFixed(delta >= 10 || delta <= -10 ? 0 : 1)}%`;
   }
-  if (typeof entry.perf_metric === 'number') return `${trimNumber(entry.perf_metric)}${entry.perf_unit ? ` ${entry.perf_unit}` : ''}`; 
+  if (typeof entry.perf_metric === 'number')
+    return `${trimNumber(entry.perf_metric)}${entry.perf_unit ? ` ${entry.perf_unit}` : ''}`; 
   return '—';
 }
 
@@ -721,4 +722,3 @@ function truncate(value: string, width: number): string {
 function trimNumber(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/\.?0+$/, '');
 }
-


### PR DESCRIPTION
## Problem
`formatMeasured` returned a bare unlabeled number (e.g. `9337789`) when no delta was available, giving no indication of what the number meant. The unit was already present on `HypothesisEntry.perf_unit` and used correctly in `roundMetadata` but not in the hypothesis-level fallback path.

## Solution
Append `entry.perf_unit` to the absolute metric return in `formatMeasured`, matching the pattern already used in `roundMetadata`. A test case is added for the unit-bearing path.

## Verification
### Testing
`bun test --cwd clients/tui`: 141 pass, 16 fail. The 16 failures are pre-existing on `main` (stale `core-state` dist, unrelated to this change). New assertion: `formatMeasured` with `perf_unit: 'ops/s'` returns `'2412.5 ops/s'`.

Closes #465.