### PR TITLE
fix(tui): use optional chain for output.collapsible check (#501)

### DIFF
--- a/clients/tui/src/ui/conversation.ts
+++ b/clients/tui/src/ui/conversation.ts
@@ -381,7 +381,7 @@ export class ConversationView {
           : null;
       const content = prompt ? prompt.content : (output?.content ?? entry.content);
       card.add(new TextRenderable(this.renderer, {content, fg: palette.content, width: '100%'}));
-      if (output && output.collapsible) {
+      if (output?.collapsible) {
         const hidden =
           output.hiddenLines > 0
             ? `${output.hiddenLines} more line${output.hiddenLines === 1 ? '' : 's'}`


### PR DESCRIPTION
## Problem
`conversation.ts:384` used `if (output && output.collapsible)` while line 382 in the same function already uses `output?.content`. biome flags this as `lint/complexity/useOptionalChain` — an error that appeared in CI output for multiple PRs as a pre-existing issue on `main`.

## Solution
Replace `if (output && output.collapsible)` with `if (output?.collapsible)`.

## Verification
### Testing
`bun test --cwd clients/tui`: 141 pass, 16 fail. The 16 failures are pre-existing on `main` (stale `core-state` dist, unrelated to this change).

Closes #501.