### PR TITLE
Add trusted sandbox lifecycle hooks

### DIFF
--- a/libs/vs-sandbox/README.md
+++ b/libs/vs-sandbox/README.md
@@ -26,5 +26,10 @@ Applications wire these into their own run-environment policy.
 - `ModalSandbox` mirrors `DockerSandbox` semantics on remote Modal GPUs,
   backing the workspace with an ephemeral Modal Volume that is synced at
   start and stop.
+- `SandboxLifecycleHandler` lets trusted application code prepare an
+  execution-capable sandbox in `before_ready`. Handlers run in registration
+  order before startup completes, and rerun whenever a backend
+  creates a replacement execution environment. Handlers must be idempotent;
+  a raised exception aborts startup and triggers backend-owned cleanup.
 - `ensure_model_volume` provisions a per-model Modal Volume populated with
   HuggingFace model weights, reusing already-populated volumes.

--- a/libs/vs-sandbox/README.md
+++ b/libs/vs-sandbox/README.md
@@ -26,10 +26,10 @@ Applications wire these into their own run-environment policy.
 - `ModalSandbox` mirrors `DockerSandbox` semantics on remote Modal GPUs,
   backing the workspace with an ephemeral Modal Volume that is synced at
   start and stop.
-- `SandboxLifecycleHandler` lets trusted application code prepare an
-  execution-capable sandbox in `before_ready`. Handlers run in registration
+- `SandboxLifecycleHooks` lets trusted application code prepare an
+  execution-capable sandbox in `before_ready`. Hooks run in registration
   order before startup completes, and rerun whenever a backend
-  creates a replacement execution environment. Handlers must be idempotent;
+  creates a replacement execution environment. Hooks must be idempotent;
   a raised exception aborts startup and triggers backend-owned cleanup.
 - `ensure_model_volume` provisions a per-model Modal Volume populated with
   HuggingFace model weights, reusing already-populated volumes.

--- a/libs/vs-sandbox/src/vs_sandbox/__init__.py
+++ b/libs/vs-sandbox/src/vs_sandbox/__init__.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
         BeforeReadyContext,
         SandboxLifecycle,
         SandboxLifecycleError,
-        SandboxLifecycleHandler,
+        SandboxLifecycleHooks,
     )
     from vs_sandbox.modal_model_setup import ensure_model_volume
     from vs_sandbox.modal_sandbox import ModalSandbox
@@ -55,7 +55,7 @@ __all__ = [
     "ProjectPathPolicyError",
     "SandboxLifecycle",
     "SandboxLifecycleError",
-    "SandboxLifecycleHandler",
+    "SandboxLifecycleHooks",
     "SandboxUnavailableError",
     "SeatbeltSandbox",
     "WorkspaceSandbox",
@@ -109,7 +109,7 @@ def __getattr__(name: str) -> Any:  # noqa: ANN401, PLR0911  # tracked: #288
         "BeforeReadyContext",
         "SandboxLifecycle",
         "SandboxLifecycleError",
-        "SandboxLifecycleHandler",
+        "SandboxLifecycleHooks",
     }:
         from vs_sandbox import lifecycle  # noqa: PLC0415
 

--- a/libs/vs-sandbox/src/vs_sandbox/__init__.py
+++ b/libs/vs-sandbox/src/vs_sandbox/__init__.py
@@ -31,10 +31,17 @@ if TYPE_CHECKING:
     from vs_sandbox.host_sandbox import (
         build as build_host_sandbox,
     )
+    from vs_sandbox.lifecycle import (
+        BeforeReadyContext,
+        SandboxLifecycle,
+        SandboxLifecycleError,
+        SandboxLifecycleHandler,
+    )
     from vs_sandbox.modal_model_setup import ensure_model_volume
     from vs_sandbox.modal_sandbox import ModalSandbox
 
 __all__ = [
+    "BeforeReadyContext",
     "DockerSandbox",
     "HostResource",
     "HostResourceAccess",
@@ -46,6 +53,9 @@ __all__ = [
     "ModalSandbox",
     "ProjectPathPolicy",
     "ProjectPathPolicyError",
+    "SandboxLifecycle",
+    "SandboxLifecycleError",
+    "SandboxLifecycleHandler",
     "SandboxUnavailableError",
     "SeatbeltSandbox",
     "WorkspaceSandbox",
@@ -55,7 +65,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str) -> Any:  # noqa: ANN401  # tracked: #288
+def __getattr__(name: str) -> Any:  # noqa: ANN401, PLR0911  # tracked: #288
     if name == "DockerSandbox":
         from vs_sandbox.docker_sandbox import DockerSandbox  # noqa: PLC0415  # tracked: #288
 
@@ -95,4 +105,13 @@ def __getattr__(name: str) -> Any:  # noqa: ANN401  # tracked: #288
         )
 
         return ensure_model_volume
+    if name in {
+        "BeforeReadyContext",
+        "SandboxLifecycle",
+        "SandboxLifecycleError",
+        "SandboxLifecycleHandler",
+    }:
+        from vs_sandbox import lifecycle  # noqa: PLC0415
+
+        return getattr(lifecycle, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")  # noqa: TRY003  # tracked: #288

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -11,7 +11,6 @@ import signal
 import subprocess
 import tempfile
 import uuid
-from collections.abc import Callable  # noqa: TC003  # tracked: #288
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -23,6 +22,8 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.sandbox import BaseSandbox
+
+from vs_sandbox.lifecycle import SandboxLifecycle, SandboxLifecycleHandler
 
 if TYPE_CHECKING:
     from types import FrameType
@@ -154,7 +155,7 @@ class DockerSandbox(BaseSandbox):
         passthrough_paths: list[str] | None = None,
         log_path: str | Path | None = None,
         extra_init_commands: list[str] | None = None,
-        setup_fns: list[Callable[[BaseSandbox], None]] | None = None,
+        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
     ) -> None:
         """Initialize Docker sandbox configuration.
 
@@ -198,6 +199,9 @@ class DockerSandbox(BaseSandbox):
                 ``uv``, failures here **raise RuntimeError** — use this for
                 commands that must succeed (e.g. installing a CLI binary the
                 loop depends on).
+            lifecycle_handlers: Trusted extensions invoked in order after
+                built-in initialization and before the sandbox becomes ready.
+                They run again after every container recreation.
         """
         self._host_workspace = host_workspace
         self._image = image
@@ -215,7 +219,7 @@ class DockerSandbox(BaseSandbox):
         self._container_id: str | None = None
         self._logger = self._setup_logger(log_path)
         self._extra_init_commands: list[str] = list(extra_init_commands or [])
-        self._setup_fns: list[Callable[[BaseSandbox], None]] = list(setup_fns or [])
+        self._lifecycle = SandboxLifecycle(lifecycle_handlers)
 
         # Container paths outside /workspace that _vpath must not rewrite.
         self._passthrough_prefixes: list[str] = list(passthrough_paths or [])
@@ -524,10 +528,7 @@ class DockerSandbox(BaseSandbox):
                     f"Container init command timed out after 600s: {init_cmd_str}"
                 ) from exc
 
-        # Run caller-supplied setup functions.  These re-execute on every
-        # restart (so e.g. docker symlinks survive ``reselect_device``).
-        for fn in self._setup_fns:
-            fn(self)
+        self._lifecycle.before_ready(self)
 
     def _discard_started_container(self) -> None:
         """Best-effort rollback for a container whose startup did not finish."""

--- a/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/docker_sandbox.py
@@ -23,7 +23,7 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.sandbox import BaseSandbox
 
-from vs_sandbox.lifecycle import SandboxLifecycle, SandboxLifecycleHandler
+from vs_sandbox.lifecycle import SandboxLifecycle, SandboxLifecycleHooks
 
 if TYPE_CHECKING:
     from types import FrameType
@@ -155,7 +155,7 @@ class DockerSandbox(BaseSandbox):
         passthrough_paths: list[str] | None = None,
         log_path: str | Path | None = None,
         extra_init_commands: list[str] | None = None,
-        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
+        lifecycle_hooks: list[SandboxLifecycleHooks] | None = None,
     ) -> None:
         """Initialize Docker sandbox configuration.
 
@@ -199,7 +199,7 @@ class DockerSandbox(BaseSandbox):
                 ``uv``, failures here **raise RuntimeError** — use this for
                 commands that must succeed (e.g. installing a CLI binary the
                 loop depends on).
-            lifecycle_handlers: Trusted extensions invoked in order after
+            lifecycle_hooks: Trusted extensions invoked in order after
                 built-in initialization and before the sandbox becomes ready.
                 They run again after every container recreation.
         """
@@ -219,7 +219,7 @@ class DockerSandbox(BaseSandbox):
         self._container_id: str | None = None
         self._logger = self._setup_logger(log_path)
         self._extra_init_commands: list[str] = list(extra_init_commands or [])
-        self._lifecycle = SandboxLifecycle(lifecycle_handlers)
+        self._lifecycle = SandboxLifecycle(lifecycle_hooks)
 
         # Container paths outside /workspace that _vpath must not rewrite.
         self._passthrough_prefixes: list[str] = list(passthrough_paths or [])

--- a/libs/vs-sandbox/src/vs_sandbox/lifecycle.py
+++ b/libs/vs-sandbox/src/vs_sandbox/lifecycle.py
@@ -1,9 +1,9 @@
 """Trusted lifecycle extensions for sandbox startup.
 
-Lifecycle handlers are registered by framework code, not by candidate code.
-The sandbox invokes :meth:`SandboxLifecycleHandler.before_ready` after its
+Lifecycle hooks are registered by framework code, not by candidate code.
+The sandbox invokes :meth:`SandboxLifecycleHooks.before_ready` after its
 execution environment accepts commands and before it is exposed to callers.
-Handlers run again whenever a backend creates a replacement execution
+Hooks run again whenever a backend creates a replacement execution
 environment, so implementations must be idempotent.
 """
 
@@ -25,11 +25,11 @@ class BeforeReadyContext:
     sandbox: SandboxBackendProtocol
 
 
-class SandboxLifecycleHandler:
-    """Base class for trusted sandbox lifecycle extensions.
+class SandboxLifecycleHooks:
+    """Base class for trusted sandbox lifecycle hooks.
 
     Future lifecycle points can be added here as concrete no-op methods. That
-    keeps existing subclasses compatible while allowing one handler instance
+    keeps existing subclasses compatible while allowing one hooks provider
     to participate in more than one phase.
     """
 
@@ -38,34 +38,34 @@ class SandboxLifecycleHandler:
 
 
 class SandboxLifecycleError(RuntimeError):
-    """Raised when a lifecycle handler prevents a sandbox becoming ready."""
+    """Raised when a lifecycle hook prevents a sandbox becoming ready."""
 
-    def __init__(self, hook: str, handler: str, cause: Exception) -> None:
-        """Name the failed hook and handler while retaining the cause."""
-        super().__init__(f"{hook} lifecycle handler {handler} failed: {cause}")
+    def __init__(self, hook: str, provider: str, cause: Exception) -> None:
+        """Name the failed hook and provider while retaining the cause."""
+        super().__init__(f"{hook} hook in {provider} failed: {cause}")
 
 
 class SandboxLifecycle:
-    """Run an ordered, immutable snapshot of lifecycle handlers."""
+    """Run an ordered, immutable snapshot of lifecycle hooks."""
 
     def __init__(
         self,
-        handlers: Sequence[SandboxLifecycleHandler] | None = None,
+        hooks: Sequence[SandboxLifecycleHooks] | None = None,
     ) -> None:
-        """Snapshot handlers in their deterministic execution order."""
-        self._handlers = tuple(handlers or ())
+        """Snapshot hooks providers in their deterministic execution order."""
+        self._hooks = tuple(hooks or ())
 
     @property
-    def handlers(self) -> tuple[SandboxLifecycleHandler, ...]:
-        """Return the handlers in their deterministic execution order."""
-        return self._handlers
+    def hooks(self) -> tuple[SandboxLifecycleHooks, ...]:
+        """Return the hooks providers in their deterministic execution order."""
+        return self._hooks
 
     def before_ready(self, sandbox: SandboxBackendProtocol) -> None:
-        """Run every handler, stopping at the first failure."""
+        """Run every provider's hook, stopping at the first failure."""
         context = BeforeReadyContext(sandbox=sandbox)
-        for handler in self._handlers:
+        for provider in self._hooks:
             try:
-                handler.before_ready(context)
+                provider.before_ready(context)
             except Exception as exc:
-                name = type(handler).__name__
+                name = type(provider).__name__
                 raise SandboxLifecycleError("before_ready", name, exc) from exc

--- a/libs/vs-sandbox/src/vs_sandbox/lifecycle.py
+++ b/libs/vs-sandbox/src/vs_sandbox/lifecycle.py
@@ -1,0 +1,71 @@
+"""Trusted lifecycle extensions for sandbox startup.
+
+Lifecycle handlers are registered by framework code, not by candidate code.
+The sandbox invokes :meth:`SandboxLifecycleHandler.before_ready` after its
+execution environment accepts commands and before it is exposed to callers.
+Handlers run again whenever a backend creates a replacement execution
+environment, so implementations must be idempotent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from deepagents.backends.protocol import SandboxBackendProtocol
+
+
+@dataclass(frozen=True)
+class BeforeReadyContext:
+    """Resources available while a sandbox is transitioning to ready."""
+
+    sandbox: SandboxBackendProtocol
+
+
+class SandboxLifecycleHandler:
+    """Base class for trusted sandbox lifecycle extensions.
+
+    Future lifecycle points can be added here as concrete no-op methods. That
+    keeps existing subclasses compatible while allowing one handler instance
+    to participate in more than one phase.
+    """
+
+    def before_ready(self, context: BeforeReadyContext) -> None:
+        """Prepare an execution-capable sandbox before callers can use it."""
+
+
+class SandboxLifecycleError(RuntimeError):
+    """Raised when a lifecycle handler prevents a sandbox becoming ready."""
+
+    def __init__(self, hook: str, handler: str, cause: Exception) -> None:
+        """Name the failed hook and handler while retaining the cause."""
+        super().__init__(f"{hook} lifecycle handler {handler} failed: {cause}")
+
+
+class SandboxLifecycle:
+    """Run an ordered, immutable snapshot of lifecycle handlers."""
+
+    def __init__(
+        self,
+        handlers: Sequence[SandboxLifecycleHandler] | None = None,
+    ) -> None:
+        """Snapshot handlers in their deterministic execution order."""
+        self._handlers = tuple(handlers or ())
+
+    @property
+    def handlers(self) -> tuple[SandboxLifecycleHandler, ...]:
+        """Return the handlers in their deterministic execution order."""
+        return self._handlers
+
+    def before_ready(self, sandbox: SandboxBackendProtocol) -> None:
+        """Run every handler, stopping at the first failure."""
+        context = BeforeReadyContext(sandbox=sandbox)
+        for handler in self._handlers:
+            try:
+                handler.before_ready(context)
+            except Exception as exc:
+                name = type(handler).__name__
+                raise SandboxLifecycleError("before_ready", name, exc) from exc

--- a/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
@@ -40,7 +40,7 @@ from deepagents.backends.protocol import (
 from deepagents.backends.sandbox import BaseSandbox
 from modal.volume import AbstractVolumeUploadContextManager  # noqa: TC002  # tracked: #288
 
-from vs_sandbox.lifecycle import SandboxLifecycle, SandboxLifecycleHandler
+from vs_sandbox.lifecycle import SandboxLifecycle, SandboxLifecycleHooks
 
 if TYPE_CHECKING:
     from types import FrameType
@@ -195,7 +195,7 @@ class ModalSandbox(BaseSandbox):
         extra_writable_volumes: dict[str, str] | None = None,
         log_path: str | Path | None = None,
         extra_init_commands: list[str] | None = None,
-        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
+        lifecycle_hooks: list[SandboxLifecycleHooks] | None = None,
         app_name: str = "vibesys",
         enable_fallback_restart: bool = True,  # noqa: FBT001, FBT002  # tracked: #288
         max_restart_attempts: int = 2,
@@ -239,7 +239,7 @@ class ModalSandbox(BaseSandbox):
             extra_init_commands: Additional bash one-liners run inside the
                 sandbox after the default ``pip install uv``.  Failures
                 raise ``RuntimeError``.
-            lifecycle_handlers: Trusted extensions invoked in order after
+            lifecycle_hooks: Trusted extensions invoked in order after
                 built-in initialization and before the sandbox becomes ready.
                 They run again after every container recreation.
             app_name: Modal App name to attach the sandbox to.  Created if
@@ -259,7 +259,7 @@ class ModalSandbox(BaseSandbox):
         self._extra_readonly_volumes = dict(extra_readonly_volumes or {})
         self._extra_writable_volumes = dict(extra_writable_volumes or {})
         self._extra_init_commands = list(extra_init_commands or [])
-        self._lifecycle = SandboxLifecycle(lifecycle_handlers)
+        self._lifecycle = SandboxLifecycle(lifecycle_hooks)
         self._app_name = app_name
         self._enable_fallback_restart = enable_fallback_restart
         self._max_restart_attempts = max_restart_attempts

--- a/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
+++ b/libs/vs-sandbox/src/vs_sandbox/modal_sandbox.py
@@ -40,6 +40,8 @@ from deepagents.backends.protocol import (
 from deepagents.backends.sandbox import BaseSandbox
 from modal.volume import AbstractVolumeUploadContextManager  # noqa: TC002  # tracked: #288
 
+from vs_sandbox.lifecycle import SandboxLifecycle, SandboxLifecycleHandler
+
 if TYPE_CHECKING:
     from types import FrameType
 
@@ -193,7 +195,7 @@ class ModalSandbox(BaseSandbox):
         extra_writable_volumes: dict[str, str] | None = None,
         log_path: str | Path | None = None,
         extra_init_commands: list[str] | None = None,
-        setup_fns: list[Callable[[BaseSandbox], None]] | None = None,
+        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
         app_name: str = "vibesys",
         enable_fallback_restart: bool = True,  # noqa: FBT001, FBT002  # tracked: #288
         max_restart_attempts: int = 2,
@@ -237,6 +239,9 @@ class ModalSandbox(BaseSandbox):
             extra_init_commands: Additional bash one-liners run inside the
                 sandbox after the default ``pip install uv``.  Failures
                 raise ``RuntimeError``.
+            lifecycle_handlers: Trusted extensions invoked in order after
+                built-in initialization and before the sandbox becomes ready.
+                They run again after every container recreation.
             app_name: Modal App name to attach the sandbox to.  Created if
                 missing.
         """
@@ -254,7 +259,7 @@ class ModalSandbox(BaseSandbox):
         self._extra_readonly_volumes = dict(extra_readonly_volumes or {})
         self._extra_writable_volumes = dict(extra_writable_volumes or {})
         self._extra_init_commands = list(extra_init_commands or [])
-        self._setup_fns = list(setup_fns or [])
+        self._lifecycle = SandboxLifecycle(lifecycle_handlers)
         self._app_name = app_name
         self._enable_fallback_restart = enable_fallback_restart
         self._max_restart_attempts = max_restart_attempts
@@ -328,8 +333,13 @@ class ModalSandbox(BaseSandbox):
         )
         self._log(f"created workspace volume {self._workspace_volume_name}")
 
-        self._populate_workspace_volume()
-        self._create_container()
+        try:
+            self._populate_workspace_volume()
+            self._create_container()
+        except BaseException:
+            self._discard_started_sandbox()
+            self._delete_workspace_volume()
+            raise
 
     def _create_container(self) -> None:  # noqa: C901  # tracked: #288
         """Create (or recreate) the Modal sandbox container on top of the
@@ -432,10 +442,7 @@ class ModalSandbox(BaseSandbox):
                     self._log(f"init command stdout: {out.strip()[:500]}")
             self._log(f"init command completed: {cmd}")
 
-        # Run caller-supplied setup functions.  These re-execute on every
-        # restart so transient in-container state (symlinks etc.) survives.
-        for fn in self._setup_fns:
-            fn(self)
+        self._lifecycle.before_ready(self)
 
     def _restart_sandbox(self) -> bool:
         """Terminate the (likely dead) sandbox container and recreate it.
@@ -476,6 +483,7 @@ class ModalSandbox(BaseSandbox):
             self._log(f"[fallback] restart succeeded (new id={self._sandbox_id})")
             return True  # noqa: TRY300  # tracked: #288
         except Exception as exc:  # noqa: BLE001  # tracked: #288
+            self._discard_started_sandbox()
             self._log(f"[fallback] restart failed: {exc}")
             return False
 
@@ -785,28 +793,33 @@ class ModalSandbox(BaseSandbox):
 
     def stop(self) -> None:
         """Terminate the sandbox and sync the workspace back to the host."""
-        if self._sandbox is None:
-            return
+        if self._sandbox is not None:
+            # Download BEFORE clearing self._sandbox — _download_workspace
+            # early-returns when self._sandbox is None.
+            try:
+                self._download_workspace()
+            except Exception as exc:  # noqa: BLE001  # tracked: #288
+                self._log(f"workspace download failed: {exc}")
+            self._discard_started_sandbox()
+        self._delete_workspace_volume()
 
-        # Download BEFORE clearing self._sandbox — _download_workspace
-        # early-returns when self._sandbox is None.
-        try:
-            self._download_workspace()
-        except Exception as exc:  # noqa: BLE001  # tracked: #288
-            self._log(f"workspace download failed: {exc}")
-
+    def _discard_started_sandbox(self) -> None:
+        """Best-effort rollback for a container that did not become ready."""
         sandbox = self._sandbox
         sandbox_id = self._sandbox_id
         self._sandbox = None
         self._sandbox_id = None
         if sandbox_id is not None:
             _live_sandboxes.pop(sandbox_id, None)
-
+        if sandbox is None:
+            return
         try:
             sandbox.terminate()
         except Exception as exc:  # noqa: BLE001  # tracked: #288
             self._log(f"terminate failed: {exc}")
 
+    def _delete_workspace_volume(self) -> None:
+        """Best-effort deletion of the workspace volume owned by this sandbox."""
         if self._workspace_volume_name:
             try:
                 modal.Volume.objects.delete(

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -7,11 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
-from vs_sandbox import BeforeReadyContext, SandboxLifecycleError, SandboxLifecycleHandler
+from vs_sandbox import BeforeReadyContext, SandboxLifecycleError, SandboxLifecycleHooks
 from vs_sandbox.docker_sandbox import DockerSandbox
 
 
-class _RecordingHandler(SandboxLifecycleHandler):
+class _RecordingHooks(SandboxLifecycleHooks):
     def __init__(self, invocations: list[object]) -> None:
         self._invocations = invocations
 
@@ -19,7 +19,7 @@ class _RecordingHandler(SandboxLifecycleHandler):
         self._invocations.append(context.sandbox)
 
 
-class _FailingHandler(SandboxLifecycleHandler):
+class _FailingHooks(SandboxLifecycleHooks):
     def before_ready(self, context: BeforeReadyContext) -> None:  # noqa: ARG002
         raise ValueError("setup exploded")  # noqa: TRY003
 
@@ -213,7 +213,7 @@ class TestStart:
             host_workspace=str(tmp_path / "workspace"),
             image="test-image",
             extra_init_commands=["install-required-tool"],
-            lifecycle_handlers=[_RecordingHandler(invocations)],
+            lifecycle_hooks=[_RecordingHooks(invocations)],
         )
         mock_run.side_effect = [
             subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
@@ -322,9 +322,9 @@ class TestExecute:
             sandbox.execute("echo hello")
 
 
-class TestLifecycleHandlers:
+class TestLifecycleHooks:
     @patch("subprocess.run")
-    def test_handlers_run_before_ready(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    def test_hooks_run_before_ready(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
@@ -336,14 +336,14 @@ class TestLifecycleHandlers:
         s = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
-            lifecycle_handlers=[_RecordingHandler(invocations)],
+            lifecycle_hooks=[_RecordingHooks(invocations)],
         )
         s.start()
         assert invocations == [s]
 
     @patch("subprocess.run")
-    def test_handlers_re_run_on_restart(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
-        """A second start, such as device reselection, reruns the handlers."""
+    def test_hooks_re_run_on_restart(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        """A second start, such as device reselection, reruns the hooks."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
@@ -355,7 +355,7 @@ class TestLifecycleHandlers:
         s = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
-            lifecycle_handlers=[_RecordingHandler(invocations)],
+            lifecycle_hooks=[_RecordingHooks(invocations)],
         )
         s.start()
         s.start()
@@ -378,11 +378,11 @@ class TestLifecycleHandlers:
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="test-image",
-            lifecycle_handlers=[_FailingHandler()],
+            lifecycle_hooks=[_FailingHooks()],
         )
 
         try:
-            with pytest.raises(SandboxLifecycleError, match="_FailingHandler failed") as error:
+            with pytest.raises(SandboxLifecycleError, match="_FailingHooks failed") as error:
                 sandbox.start()
 
             assert isinstance(error.value.__cause__, ValueError)
@@ -421,11 +421,11 @@ class TestLifecycleHandlers:
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="test-image",
-            lifecycle_handlers=[_FailingHandler()],
+            lifecycle_hooks=[_FailingHooks()],
         )
 
         try:
-            with pytest.raises(SandboxLifecycleError, match="_FailingHandler failed"):
+            with pytest.raises(SandboxLifecycleError, match="_FailingHooks failed"):
                 sandbox.start()
 
             assert sandbox._container_id == "abc123"  # noqa: SLF001  # tracked: #288

--- a/libs/vs-sandbox/tests/test_docker_sandbox.py
+++ b/libs/vs-sandbox/tests/test_docker_sandbox.py
@@ -6,9 +6,22 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from deepagents.backends.sandbox import BaseSandbox
 
+from vs_sandbox import BeforeReadyContext, SandboxLifecycleError, SandboxLifecycleHandler
 from vs_sandbox.docker_sandbox import DockerSandbox
+
+
+class _RecordingHandler(SandboxLifecycleHandler):
+    def __init__(self, invocations: list[object]) -> None:
+        self._invocations = invocations
+
+    def before_ready(self, context: BeforeReadyContext) -> None:
+        self._invocations.append(context.sandbox)
+
+
+class _FailingHandler(SandboxLifecycleHandler):
+    def before_ready(self, context: BeforeReadyContext) -> None:  # noqa: ARG002
+        raise ValueError("setup exploded")  # noqa: TRY003
 
 
 @pytest.fixture
@@ -195,10 +208,12 @@ class TestStart:
     def test_init_failure_stops_and_removes_created_container(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
+        invocations: list[object] = []
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="test-image",
             extra_init_commands=["install-required-tool"],
+            lifecycle_handlers=[_RecordingHandler(invocations)],
         )
         mock_run.side_effect = [
             subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
@@ -216,6 +231,7 @@ class TestStart:
 
             assert sandbox._container_id is None  # noqa: SLF001  # tracked: #288
             assert "abc123" not in _live_containers
+            assert invocations == []
             assert mock_run.call_args_list[-2][0][0] == ["docker", "stop", "abc123"]
             assert mock_run.call_args_list[-1][0][0] == ["docker", "rm", "-f", "abc123"]
         finally:
@@ -306,59 +322,48 @@ class TestExecute:
             sandbox.execute("echo hello")
 
 
-class TestSetupFns:
+class TestLifecycleHandlers:
     @patch("subprocess.run")
-    def test_setup_fns_run_after_start(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
-        """setup_fns receive the sandbox and run at the end of start()."""
+    def test_handlers_run_before_ready(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout="abc123container\n",
             stderr="",
         )
-        invocations: list[BaseSandbox] = []
-
-        def fn(sb: BaseSandbox) -> None:
-            invocations.append(sb)
+        invocations: list[object] = []
 
         s = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
-            setup_fns=[fn],
+            lifecycle_handlers=[_RecordingHandler(invocations)],
         )
         s.start()
         assert invocations == [s]
 
     @patch("subprocess.run")
-    def test_setup_fns_re_run_on_restart(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
-        """A second start() (e.g. after stop() from reselect_device) re-runs."""
+    def test_handlers_re_run_on_restart(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+        """A second start, such as device reselection, reruns the handlers."""
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout="abc123container\n",
             stderr="",
         )
-        calls = 0
-
-        def fn(_sb: BaseSandbox) -> None:
-            nonlocal calls
-            calls += 1
+        invocations: list[object] = []
 
         s = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
-            setup_fns=[fn],
+            lifecycle_handlers=[_RecordingHandler(invocations)],
         )
         s.start()
         s.start()
-        assert calls == 2
+        assert invocations == [s, s]
 
     @patch("subprocess.run")
     def test_setup_failure_preserves_error_when_stop_fails(self, mock_run, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
-
-        def fail_setup(_sandbox: BaseSandbox) -> None:
-            raise ValueError("setup exploded")  # noqa: TRY003  # tracked: #288
 
         def run(cmd, **_kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
             if cmd[:2] == ["docker", "run"]:
@@ -373,13 +378,14 @@ class TestSetupFns:
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="test-image",
-            setup_fns=[fail_setup],
+            lifecycle_handlers=[_FailingHandler()],
         )
 
         try:
-            with pytest.raises(ValueError, match="setup exploded"):
+            with pytest.raises(SandboxLifecycleError, match="_FailingHandler failed") as error:
                 sandbox.start()
 
+            assert isinstance(error.value.__cause__, ValueError)
             assert sandbox._container_id is None  # noqa: SLF001  # tracked: #288
             assert "abc123" not in _live_containers
             commands = [call.args[0] for call in mock_run.call_args_list]
@@ -398,9 +404,6 @@ class TestSetupFns:
     ):
         from vs_sandbox.docker_sandbox import _live_containers  # noqa: PLC0415  # tracked: #288
 
-        def fail_setup(_sandbox: BaseSandbox) -> None:
-            raise ValueError("setup exploded")  # noqa: TRY003  # tracked: #288
-
         def run(cmd, **_kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
             if cmd[:2] == ["docker", "run"]:
                 return subprocess.CompletedProcess(
@@ -418,11 +421,11 @@ class TestSetupFns:
         sandbox = DockerSandbox(
             host_workspace=str(tmp_path / "workspace"),
             image="test-image",
-            setup_fns=[fail_setup],
+            lifecycle_handlers=[_FailingHandler()],
         )
 
         try:
-            with pytest.raises(ValueError, match="setup exploded"):
+            with pytest.raises(SandboxLifecycleError, match="_FailingHandler failed"):
                 sandbox.start()
 
             assert sandbox._container_id == "abc123"  # noqa: SLF001  # tracked: #288

--- a/libs/vs-sandbox/tests/test_lifecycle.py
+++ b/libs/vs-sandbox/tests/test_lifecycle.py
@@ -11,7 +11,7 @@ from vs_sandbox import (
     BeforeReadyContext,
     SandboxLifecycle,
     SandboxLifecycleError,
-    SandboxLifecycleHandler,
+    SandboxLifecycleHooks,
 )
 
 if TYPE_CHECKING:
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class _RecordingHandler(SandboxLifecycleHandler):
+class _RecordingHooks(SandboxLifecycleHooks):
     name: str
     events: list[tuple[str, object]]
 
@@ -27,7 +27,7 @@ class _RecordingHandler(SandboxLifecycleHandler):
         self.events.append((self.name, context.sandbox))
 
 
-class _FailingHandler(SandboxLifecycleHandler):
+class _FailingHooks(SandboxLifecycleHooks):
     def before_ready(self, context: BeforeReadyContext) -> None:  # noqa: ARG002
         raise ValueError("setup exploded")  # noqa: TRY003
 
@@ -36,17 +36,17 @@ def _sandbox() -> SandboxBackendProtocol:
     return cast("SandboxBackendProtocol", object())
 
 
-def test_base_handler_is_a_noop() -> None:
-    SandboxLifecycle([SandboxLifecycleHandler()]).before_ready(_sandbox())
+def test_base_hooks_are_a_noop() -> None:
+    SandboxLifecycle([SandboxLifecycleHooks()]).before_ready(_sandbox())
 
 
-def test_before_ready_passes_sandbox_to_handlers_in_registration_order() -> None:
+def test_before_ready_passes_sandbox_to_hooks_in_registration_order() -> None:
     sandbox = _sandbox()
     events: list[tuple[str, object]] = []
     lifecycle = SandboxLifecycle(
         [
-            _RecordingHandler("first", events),
-            _RecordingHandler("second", events),
+            _RecordingHooks("first", events),
+            _RecordingHooks("second", events),
         ]
     )
 
@@ -55,30 +55,30 @@ def test_before_ready_passes_sandbox_to_handlers_in_registration_order() -> None
     assert events == [("first", sandbox), ("second", sandbox)]
 
 
-def test_constructor_snapshots_mutable_handler_sequence() -> None:
+def test_constructor_snapshots_mutable_hooks_sequence() -> None:
     events: list[tuple[str, object]] = []
-    handlers: list[SandboxLifecycleHandler] = [_RecordingHandler("first", events)]
-    lifecycle = SandboxLifecycle(handlers)
-    handlers.append(_RecordingHandler("late", events))
+    hooks: list[SandboxLifecycleHooks] = [_RecordingHooks("first", events)]
+    lifecycle = SandboxLifecycle(hooks)
+    hooks.append(_RecordingHooks("late", events))
 
     lifecycle.before_ready(_sandbox())
 
     assert [name for name, _ in events] == ["first"]
-    assert lifecycle.handlers == (handlers[0],)
+    assert lifecycle.hooks == (hooks[0],)
 
 
-def test_failure_names_handler_preserves_cause_and_stops_dispatch() -> None:
+def test_failure_names_hooks_provider_preserves_cause_and_stops_dispatch() -> None:
     events: list[tuple[str, object]] = []
     lifecycle = SandboxLifecycle(
         [
-            _FailingHandler(),
-            _RecordingHandler("not-run", events),
+            _FailingHooks(),
+            _RecordingHooks("not-run", events),
         ]
     )
 
     with pytest.raises(
         SandboxLifecycleError,
-        match=r"before_ready lifecycle handler _FailingHandler failed: setup exploded",
+        match=r"before_ready hook in _FailingHooks failed: setup exploded",
     ) as error:
         lifecycle.before_ready(_sandbox())
 

--- a/libs/vs-sandbox/tests/test_lifecycle.py
+++ b/libs/vs-sandbox/tests/test_lifecycle.py
@@ -1,0 +1,86 @@
+"""Contract tests for backend-independent sandbox lifecycle handling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from vs_sandbox import (
+    BeforeReadyContext,
+    SandboxLifecycle,
+    SandboxLifecycleError,
+    SandboxLifecycleHandler,
+)
+
+if TYPE_CHECKING:
+    from deepagents.backends.protocol import SandboxBackendProtocol
+
+
+@dataclass
+class _RecordingHandler(SandboxLifecycleHandler):
+    name: str
+    events: list[tuple[str, object]]
+
+    def before_ready(self, context: BeforeReadyContext) -> None:
+        self.events.append((self.name, context.sandbox))
+
+
+class _FailingHandler(SandboxLifecycleHandler):
+    def before_ready(self, context: BeforeReadyContext) -> None:  # noqa: ARG002
+        raise ValueError("setup exploded")  # noqa: TRY003
+
+
+def _sandbox() -> SandboxBackendProtocol:
+    return cast("SandboxBackendProtocol", object())
+
+
+def test_base_handler_is_a_noop() -> None:
+    SandboxLifecycle([SandboxLifecycleHandler()]).before_ready(_sandbox())
+
+
+def test_before_ready_passes_sandbox_to_handlers_in_registration_order() -> None:
+    sandbox = _sandbox()
+    events: list[tuple[str, object]] = []
+    lifecycle = SandboxLifecycle(
+        [
+            _RecordingHandler("first", events),
+            _RecordingHandler("second", events),
+        ]
+    )
+
+    lifecycle.before_ready(sandbox)
+
+    assert events == [("first", sandbox), ("second", sandbox)]
+
+
+def test_constructor_snapshots_mutable_handler_sequence() -> None:
+    events: list[tuple[str, object]] = []
+    handlers: list[SandboxLifecycleHandler] = [_RecordingHandler("first", events)]
+    lifecycle = SandboxLifecycle(handlers)
+    handlers.append(_RecordingHandler("late", events))
+
+    lifecycle.before_ready(_sandbox())
+
+    assert [name for name, _ in events] == ["first"]
+    assert lifecycle.handlers == (handlers[0],)
+
+
+def test_failure_names_handler_preserves_cause_and_stops_dispatch() -> None:
+    events: list[tuple[str, object]] = []
+    lifecycle = SandboxLifecycle(
+        [
+            _FailingHandler(),
+            _RecordingHandler("not-run", events),
+        ]
+    )
+
+    with pytest.raises(
+        SandboxLifecycleError,
+        match=r"before_ready lifecycle handler _FailingHandler failed: setup exploded",
+    ) as error:
+        lifecycle.before_ready(_sandbox())
+
+    assert isinstance(error.value.__cause__, ValueError)
+    assert events == []

--- a/libs/vs-sandbox/tests/test_modal_sandbox.py
+++ b/libs/vs-sandbox/tests/test_modal_sandbox.py
@@ -4,6 +4,31 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from vs_sandbox import BeforeReadyContext, SandboxLifecycleError, SandboxLifecycleHandler
+
+
+class _RecordingHandler(SandboxLifecycleHandler):
+    def __init__(self, invocations: list[object]) -> None:
+        self._invocations = invocations
+
+    def before_ready(self, context: BeforeReadyContext) -> None:
+        self._invocations.append(context.sandbox)
+
+
+class _FailingHandler(SandboxLifecycleHandler):
+    def before_ready(self, context: BeforeReadyContext) -> None:  # noqa: ARG002
+        raise ValueError("setup exploded")  # noqa: TRY003
+
+
+class _FailOnSecondInvocationHandler(SandboxLifecycleHandler):
+    def __init__(self) -> None:
+        self.invocations = 0
+
+    def before_ready(self, context: BeforeReadyContext) -> None:  # noqa: ARG002
+        self.invocations += 1
+        if self.invocations == 2:
+            raise ValueError("replacement setup exploded")  # noqa: TRY003
+
 
 @pytest.fixture
 def mock_modal(monkeypatch):  # noqa: ANN001, ANN201  # tracked: #288
@@ -204,6 +229,108 @@ class TestStart:
             assert not any("exp_env" in c for c in uploaded)
             assert not any(".venv" in c for c in uploaded)
             assert not any(".git" in c for c in uploaded)
+
+    def test_lifecycle_handlers_run_before_ready(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201, ARG002
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415
+
+        invocations: list[object] = []
+        sb = ModalSandbox(
+            host_workspace=str(tmp_path),
+            image="nvcr.io/nvidia/pytorch:25.04-py3",
+            lifecycle_handlers=[_RecordingHandler(invocations)],
+        )
+
+        try:
+            sb.start()
+            assert invocations == [sb]
+        finally:
+            sb.stop()
+
+    def test_init_failure_skips_handlers_and_cleans_up(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
+        from vs_sandbox.modal_sandbox import ModalSandbox, _live_sandboxes  # noqa: PLC0415
+
+        invocations: list[object] = []
+        mock_modal["proc"].wait.side_effect = [0, 17]
+        sb = ModalSandbox(
+            host_workspace=str(tmp_path),
+            image="nvcr.io/nvidia/pytorch:25.04-py3",
+            extra_init_commands=["install-required-tool"],
+            lifecycle_handlers=[_RecordingHandler(invocations)],
+        )
+
+        with pytest.raises(RuntimeError, match="Modal sandbox init command failed"):
+            sb.start()
+
+        assert invocations == []
+        assert sb._sandbox is None  # noqa: SLF001
+        assert not _live_sandboxes
+        mock_modal["sandbox"].terminate.assert_called_once()
+        mock_modal["objects"].delete.assert_called_once()
+
+    def test_lifecycle_failure_cleans_up_sandbox_and_volume(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
+        from vs_sandbox.modal_sandbox import ModalSandbox, _live_sandboxes  # noqa: PLC0415
+
+        sb = ModalSandbox(
+            host_workspace=str(tmp_path),
+            image="nvcr.io/nvidia/pytorch:25.04-py3",
+            lifecycle_handlers=[_FailingHandler()],
+        )
+
+        with pytest.raises(SandboxLifecycleError, match="_FailingHandler failed") as error:
+            sb.start()
+
+        assert isinstance(error.value.__cause__, ValueError)
+        assert sb._sandbox is None  # noqa: SLF001
+        assert not _live_sandboxes
+        mock_modal["sandbox"].terminate.assert_called_once()
+        mock_modal["objects"].delete.assert_called_once()
+
+    def test_lifecycle_handlers_replay_on_fallback_replacement(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
+        from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415
+
+        invocations: list[object] = []
+        sb = ModalSandbox(
+            host_workspace=str(tmp_path),
+            image="nvcr.io/nvidia/pytorch:25.04-py3",
+            lifecycle_handlers=[_RecordingHandler(invocations)],
+        )
+
+        try:
+            sb.start()
+            assert sb._restart_sandbox()  # noqa: SLF001
+            assert invocations == [sb, sb]
+            assert mock_modal["create"].call_count == 2
+        finally:
+            sb.stop()
+
+    def test_failed_replacement_cleans_container_but_preserves_volume_until_stop(  # noqa: ANN201
+        self,
+        tmp_path,  # noqa: ANN001
+        mock_modal,  # noqa: ANN001
+    ):
+        from vs_sandbox.modal_sandbox import ModalSandbox, _live_sandboxes  # noqa: PLC0415
+
+        handler = _FailOnSecondInvocationHandler()
+        sb = ModalSandbox(
+            host_workspace=str(tmp_path),
+            image="nvcr.io/nvidia/pytorch:25.04-py3",
+            lifecycle_handlers=[handler],
+        )
+
+        sb.start()
+        workspace_volume_name = sb._workspace_volume_name  # noqa: SLF001
+        assert not sb._restart_sandbox()  # noqa: SLF001
+        assert handler.invocations == 2
+        assert sb._sandbox is None  # noqa: SLF001
+        assert not _live_sandboxes
+        assert sb._workspace_volume_name == workspace_volume_name  # noqa: SLF001
+        mock_modal["objects"].delete.assert_not_called()
+
+        sb.stop()
+        mock_modal["objects"].delete.assert_called_once_with(
+            workspace_volume_name,
+            allow_missing=True,
+        )
 
     def test_start_uploads_minimal_codex_auth_snapshot(  # noqa: ANN201  # tracked: #288
         self,

--- a/libs/vs-sandbox/tests/test_modal_sandbox.py
+++ b/libs/vs-sandbox/tests/test_modal_sandbox.py
@@ -4,10 +4,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from vs_sandbox import BeforeReadyContext, SandboxLifecycleError, SandboxLifecycleHandler
+from vs_sandbox import BeforeReadyContext, SandboxLifecycleError, SandboxLifecycleHooks
 
 
-class _RecordingHandler(SandboxLifecycleHandler):
+class _RecordingHooks(SandboxLifecycleHooks):
     def __init__(self, invocations: list[object]) -> None:
         self._invocations = invocations
 
@@ -15,12 +15,12 @@ class _RecordingHandler(SandboxLifecycleHandler):
         self._invocations.append(context.sandbox)
 
 
-class _FailingHandler(SandboxLifecycleHandler):
+class _FailingHooks(SandboxLifecycleHooks):
     def before_ready(self, context: BeforeReadyContext) -> None:  # noqa: ARG002
         raise ValueError("setup exploded")  # noqa: TRY003
 
 
-class _FailOnSecondInvocationHandler(SandboxLifecycleHandler):
+class _FailOnSecondInvocationHooks(SandboxLifecycleHooks):
     def __init__(self) -> None:
         self.invocations = 0
 
@@ -230,14 +230,14 @@ class TestStart:
             assert not any(".venv" in c for c in uploaded)
             assert not any(".git" in c for c in uploaded)
 
-    def test_lifecycle_handlers_run_before_ready(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201, ARG002
+    def test_lifecycle_hooks_run_before_ready(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201, ARG002
         from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415
 
         invocations: list[object] = []
         sb = ModalSandbox(
             host_workspace=str(tmp_path),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
-            lifecycle_handlers=[_RecordingHandler(invocations)],
+            lifecycle_hooks=[_RecordingHooks(invocations)],
         )
 
         try:
@@ -246,7 +246,7 @@ class TestStart:
         finally:
             sb.stop()
 
-    def test_init_failure_skips_handlers_and_cleans_up(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
+    def test_init_failure_skips_hooks_and_cleans_up(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
         from vs_sandbox.modal_sandbox import ModalSandbox, _live_sandboxes  # noqa: PLC0415
 
         invocations: list[object] = []
@@ -255,7 +255,7 @@ class TestStart:
             host_workspace=str(tmp_path),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
             extra_init_commands=["install-required-tool"],
-            lifecycle_handlers=[_RecordingHandler(invocations)],
+            lifecycle_hooks=[_RecordingHooks(invocations)],
         )
 
         with pytest.raises(RuntimeError, match="Modal sandbox init command failed"):
@@ -273,10 +273,10 @@ class TestStart:
         sb = ModalSandbox(
             host_workspace=str(tmp_path),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
-            lifecycle_handlers=[_FailingHandler()],
+            lifecycle_hooks=[_FailingHooks()],
         )
 
-        with pytest.raises(SandboxLifecycleError, match="_FailingHandler failed") as error:
+        with pytest.raises(SandboxLifecycleError, match="_FailingHooks failed") as error:
             sb.start()
 
         assert isinstance(error.value.__cause__, ValueError)
@@ -285,14 +285,14 @@ class TestStart:
         mock_modal["sandbox"].terminate.assert_called_once()
         mock_modal["objects"].delete.assert_called_once()
 
-    def test_lifecycle_handlers_replay_on_fallback_replacement(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
+    def test_lifecycle_hooks_replay_on_fallback_replacement(self, tmp_path, mock_modal):  # noqa: ANN001, ANN201
         from vs_sandbox.modal_sandbox import ModalSandbox  # noqa: PLC0415
 
         invocations: list[object] = []
         sb = ModalSandbox(
             host_workspace=str(tmp_path),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
-            lifecycle_handlers=[_RecordingHandler(invocations)],
+            lifecycle_hooks=[_RecordingHooks(invocations)],
         )
 
         try:
@@ -310,17 +310,17 @@ class TestStart:
     ):
         from vs_sandbox.modal_sandbox import ModalSandbox, _live_sandboxes  # noqa: PLC0415
 
-        handler = _FailOnSecondInvocationHandler()
+        hooks = _FailOnSecondInvocationHooks()
         sb = ModalSandbox(
             host_workspace=str(tmp_path),
             image="nvcr.io/nvidia/pytorch:25.04-py3",
-            lifecycle_handlers=[handler],
+            lifecycle_hooks=[hooks],
         )
 
         sb.start()
         workspace_volume_name = sb._workspace_volume_name  # noqa: SLF001
         assert not sb._restart_sandbox()  # noqa: SLF001
-        assert handler.invocations == 2
+        assert hooks.invocations == 2
         assert sb._sandbox is None  # noqa: SLF001
         assert not _live_sandboxes
         assert sb._workspace_volume_name == workspace_volume_name  # noqa: SLF001

--- a/src/vibesys/backends/base.py
+++ b/src/vibesys/backends/base.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
 
-    from vs_sandbox.lifecycle import SandboxLifecycleHandler
+    from vs_sandbox.lifecycle import SandboxLifecycleHooks
 
 
 class SandboxKind(StrEnum):
@@ -69,13 +69,13 @@ class ComputeBackendImpl(Protocol):
         passthrough_paths: list[str],
         extra_env: dict[str, str],
         extra_init_commands: list[str],
-        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
+        lifecycle_hooks: list[SandboxLifecycleHooks] | None = None,
         modal_options: ModalOptions | None = None,
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
         """Construct (do not start) a sandbox configured for this backend.
 
-        ``lifecycle_handlers`` are invoked before the sandbox becomes ready,
+        ``lifecycle_hooks`` are invoked before the sandbox becomes ready,
         during both initial creation and replacement.
 
         ``attach_accelerator=False`` creates a CPU-only control-plane sandbox
@@ -90,7 +90,7 @@ class ComputeBackendImpl(Protocol):
         """Re-pick the optimal device for this backend (e.g. migrate to a
         less-loaded GPU) and restart affected sandboxes in place.
 
-        Each restarted sandbox re-runs its lifecycle handlers automatically as
+        Each restarted sandbox re-runs its lifecycle hooks automatically as
         part of ``start()``.  No-op for backends without rebalancing.
         """  # noqa: D205  # tracked: #288
         ...
@@ -100,7 +100,7 @@ def make_local_shell_sandbox(
     *,
     host_workspace: str,
     env: dict[str, str],
-    lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
+    lifecycle_hooks: list[SandboxLifecycleHooks] | None = None,
 ) -> SandboxBackendProtocol:
     """Construct deepagents' local-shell sandbox, importing deepagents on first use.
 
@@ -117,7 +117,7 @@ def make_local_shell_sandbox(
         inherit_env=True,
         env=env,
     )
-    SandboxLifecycle(lifecycle_handlers).before_ready(sandbox)
+    SandboxLifecycle(lifecycle_hooks).before_ready(sandbox)
     return sandbox
 
 

--- a/src/vibesys/backends/base.py
+++ b/src/vibesys/backends/base.py
@@ -15,18 +15,19 @@ compute backend supplies the right values for its platform inside
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from enum import StrEnum
 from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from vibesys.constants import ComputeBackend  # noqa: TC001  # tracked: #288
 from vibesys.profilers import ProfilerKind  # noqa: TC001  # tracked: #288
+from vs_sandbox.lifecycle import SandboxLifecycle
 
 if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
-    from deepagents.backends.sandbox import BaseSandbox
+
+    from vs_sandbox.lifecycle import SandboxLifecycleHandler
 
 
 class SandboxKind(StrEnum):
@@ -51,15 +52,6 @@ class ContentionMonitor(Protocol):
     def stop(self) -> None: ...  # noqa: D102  # tracked: #288
 
 
-type SetupFn = Callable[[BaseSandbox], None]
-"""A function the sandbox runs after every ``start()`` (initial or restart).
-
-Use it to install setup that doesn't survive container restart and that the
-sandbox class itself doesn't know about — e.g. ``ln -sfn`` symlinks pointing
-into HuggingFace-cache-style bind mounts.
-"""
-
-
 @runtime_checkable
 class ComputeBackendImpl(Protocol):
     """Per-platform backend.  See module docstring for the contract."""
@@ -77,14 +69,14 @@ class ComputeBackendImpl(Protocol):
         passthrough_paths: list[str],
         extra_env: dict[str, str],
         extra_init_commands: list[str],
-        setup_fns: list[SetupFn] | None = None,
+        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
         modal_options: ModalOptions | None = None,
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
         """Construct (do not start) a sandbox configured for this backend.
 
-        ``setup_fns`` are invoked by the sandbox at the end of every
-        ``start()`` — initial and restart alike.
+        ``lifecycle_handlers`` are invoked before the sandbox becomes ready,
+        during both initial creation and replacement.
 
         ``attach_accelerator=False`` creates a CPU-only control-plane sandbox
         while preserving the target backend's image and tooling. Remote
@@ -98,7 +90,7 @@ class ComputeBackendImpl(Protocol):
         """Re-pick the optimal device for this backend (e.g. migrate to a
         less-loaded GPU) and restart affected sandboxes in place.
 
-        Each restarted sandbox re-runs its ``setup_fns`` automatically as
+        Each restarted sandbox re-runs its lifecycle handlers automatically as
         part of ``start()``.  No-op for backends without rebalancing.
         """  # noqa: D205  # tracked: #288
         ...
@@ -108,6 +100,7 @@ def make_local_shell_sandbox(
     *,
     host_workspace: str,
     env: dict[str, str],
+    lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
 ) -> SandboxBackendProtocol:
     """Construct deepagents' local-shell sandbox, importing deepagents on first use.
 
@@ -118,12 +111,14 @@ def make_local_shell_sandbox(
     """
     from deepagents.backends import LocalShellBackend  # noqa: PLC0415  # tracked: #288
 
-    return LocalShellBackend(
+    sandbox = LocalShellBackend(
         root_dir=host_workspace,
         virtual_mode=True,
         inherit_env=True,
         env=env,
     )
+    SandboxLifecycle(lifecycle_handlers).before_ready(sandbox)
+    return sandbox
 
 
 class ModalOptions:

--- a/src/vibesys/backends/cuda/__init__.py
+++ b/src/vibesys/backends/cuda/__init__.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
 
-    from vs_sandbox.lifecycle import SandboxLifecycleHandler
+    from vs_sandbox.lifecycle import SandboxLifecycleHooks
 
 # Default container image for the cuda backend.  Carries CUDA toolkit + PyTorch.
 _DEFAULT_IMAGE = "nvcr.io/nvidia/pytorch:25.04-py3"
@@ -77,7 +77,7 @@ class CudaBackend:
         passthrough_paths: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         extra_init_commands: list[str] | None = None,
-        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
+        lifecycle_hooks: list[SandboxLifecycleHooks] | None = None,
         modal_options: ModalOptions | None = None,
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
@@ -90,7 +90,7 @@ class CudaBackend:
         passthrough_paths = passthrough_paths or []
         extra_env = extra_env or {}
         extra_init_commands = extra_init_commands or []
-        lifecycle_handlers = lifecycle_handlers or []
+        lifecycle_hooks = lifecycle_hooks or []
 
         # Pick a GPU lazily on first sandbox creation (modal manages its own).
         if attach_accelerator and kind is not SandboxKind.MODAL and self.selected_device is None:
@@ -106,7 +106,7 @@ class CudaBackend:
             sandbox = make_local_shell_sandbox(
                 host_workspace=host_workspace,
                 env=env,
-                lifecycle_handlers=lifecycle_handlers,
+                lifecycle_hooks=lifecycle_hooks,
             )
         elif kind is SandboxKind.DOCKER:
             sandbox = DockerSandbox(
@@ -118,7 +118,7 @@ class CudaBackend:
                 env=env,
                 log_path=log_path,
                 extra_init_commands=extra_init_commands,
-                lifecycle_handlers=lifecycle_handlers,
+                lifecycle_hooks=lifecycle_hooks,
             )
         elif kind is SandboxKind.MODAL:
             if modal_options is None:
@@ -137,7 +137,7 @@ class CudaBackend:
                 extra_writable_volumes=modal_options.extra_writable_volumes,
                 log_path=log_path,
                 extra_init_commands=extra_init_commands,
-                lifecycle_handlers=lifecycle_handlers,
+                lifecycle_hooks=lifecycle_hooks,
                 app_name=modal_options.app_name,
             )
         else:
@@ -158,7 +158,7 @@ class CudaBackend:
     def reselect_device(self) -> None:
         """Re-pick the least-loaded GPU; restart any docker sandboxes affected.
 
-        Each restarted sandbox re-runs its lifecycle handlers automatically as
+        Each restarted sandbox re-runs its lifecycle hooks automatically as
         part of ``start()`` — callers don't need to replay anything.
         """
         if os.environ.get("CUDA_VISIBLE_DEVICES"):
@@ -194,7 +194,7 @@ class CudaBackend:
                 assert isinstance(sb, DockerSandbox)  # noqa: S101  # registration invariant
                 sb.stop()
                 sb._gpus = self._docker_gpu_spec()  # noqa: SLF001  # tracked: #288
-                sb.start()  # re-runs lifecycle handlers
+                sb.start()  # re-runs lifecycle hooks
             elif kind is SandboxKind.LOCAL:
                 assert isinstance(sb, LocalShellBackend)  # noqa: S101  # registration invariant
                 env: dict[str, str] | None = getattr(sb, "_env", None)

--- a/src/vibesys/backends/cuda/__init__.py
+++ b/src/vibesys/backends/cuda/__init__.py
@@ -14,7 +14,6 @@ from vibesys.backends.base import (
     ContentionMonitor,
     ModalOptions,
     SandboxKind,
-    SetupFn,
     make_local_shell_sandbox,
 )
 from vibesys.backends.cuda.gpu_monitor import (
@@ -29,6 +28,8 @@ from vibesys.profilers import ProfilerKind
 if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
+
+    from vs_sandbox.lifecycle import SandboxLifecycleHandler
 
 # Default container image for the cuda backend.  Carries CUDA toolkit + PyTorch.
 _DEFAULT_IMAGE = "nvcr.io/nvidia/pytorch:25.04-py3"
@@ -76,7 +77,7 @@ class CudaBackend:
         passthrough_paths: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         extra_init_commands: list[str] | None = None,
-        setup_fns: list[SetupFn] | None = None,
+        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
         modal_options: ModalOptions | None = None,
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
@@ -89,7 +90,7 @@ class CudaBackend:
         passthrough_paths = passthrough_paths or []
         extra_env = extra_env or {}
         extra_init_commands = extra_init_commands or []
-        setup_fns = setup_fns or []
+        lifecycle_handlers = lifecycle_handlers or []
 
         # Pick a GPU lazily on first sandbox creation (modal manages its own).
         if attach_accelerator and kind is not SandboxKind.MODAL and self.selected_device is None:
@@ -102,10 +103,11 @@ class CudaBackend:
         )
 
         if kind is SandboxKind.LOCAL:
-            # LocalShellBackend (deepagents) has no setup_fns concept; for the
-            # local sandbox there's nothing to install post-start anyway (no
-            # docker symlinks, no restart scenarios), so we drop them silently.
-            sandbox = make_local_shell_sandbox(host_workspace=host_workspace, env=env)
+            sandbox = make_local_shell_sandbox(
+                host_workspace=host_workspace,
+                env=env,
+                lifecycle_handlers=lifecycle_handlers,
+            )
         elif kind is SandboxKind.DOCKER:
             sandbox = DockerSandbox(
                 host_workspace=host_workspace,
@@ -116,7 +118,7 @@ class CudaBackend:
                 env=env,
                 log_path=log_path,
                 extra_init_commands=extra_init_commands,
-                setup_fns=setup_fns,
+                lifecycle_handlers=lifecycle_handlers,
             )
         elif kind is SandboxKind.MODAL:
             if modal_options is None:
@@ -135,7 +137,7 @@ class CudaBackend:
                 extra_writable_volumes=modal_options.extra_writable_volumes,
                 log_path=log_path,
                 extra_init_commands=extra_init_commands,
-                setup_fns=setup_fns,
+                lifecycle_handlers=lifecycle_handlers,
                 app_name=modal_options.app_name,
             )
         else:
@@ -156,7 +158,7 @@ class CudaBackend:
     def reselect_device(self) -> None:
         """Re-pick the least-loaded GPU; restart any docker sandboxes affected.
 
-        Each restarted sandbox re-runs its ``setup_fns`` automatically as
+        Each restarted sandbox re-runs its lifecycle handlers automatically as
         part of ``start()`` — callers don't need to replay anything.
         """
         if os.environ.get("CUDA_VISIBLE_DEVICES"):
@@ -192,7 +194,7 @@ class CudaBackend:
                 assert isinstance(sb, DockerSandbox)  # noqa: S101  # registration invariant
                 sb.stop()
                 sb._gpus = self._docker_gpu_spec()  # noqa: SLF001  # tracked: #288
-                sb.start()  # re-runs setup_fns
+                sb.start()  # re-runs lifecycle handlers
             elif kind is SandboxKind.LOCAL:
                 assert isinstance(sb, LocalShellBackend)  # noqa: S101  # registration invariant
                 env: dict[str, str] | None = getattr(sb, "_env", None)

--- a/src/vibesys/backends/local.py
+++ b/src/vibesys/backends/local.py
@@ -23,7 +23,6 @@ from vibesys.backends.base import (
     ContentionMonitor,
     ModalOptions,
     SandboxKind,
-    SetupFn,
     make_local_shell_sandbox,
 )
 from vibesys.constants import ComputeBackend
@@ -32,6 +31,8 @@ from vibesys.profilers import ProfilerKind
 if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
+
+    from vs_sandbox.lifecycle import SandboxLifecycleHandler
 
 _DEFAULT_CPU_IMAGE = "python:3.12-bookworm"
 
@@ -73,7 +74,7 @@ class LocalBackend:
         passthrough_paths: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         extra_init_commands: list[str] | None = None,
-        setup_fns: list[SetupFn] | None = None,
+        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
         modal_options: ModalOptions | None = None,  # noqa: ARG002  # tracked: #288
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
@@ -86,10 +87,14 @@ class LocalBackend:
         passthrough_paths = list(passthrough_paths or [])
         extra_env = dict(extra_env or {})
         extra_init_commands = list(extra_init_commands or [])
-        setup_fns = setup_fns or []
+        lifecycle_handlers = lifecycle_handlers or []
 
         if kind is SandboxKind.LOCAL:
-            return make_local_shell_sandbox(host_workspace=host_workspace, env=extra_env)
+            return make_local_shell_sandbox(
+                host_workspace=host_workspace,
+                env=extra_env,
+                lifecycle_handlers=lifecycle_handlers,
+            )
         if kind is SandboxKind.DOCKER and self._supports_docker:
             if self.image is None:
                 raise ValueError(f"{self.name.value} backend requires a Docker image")  # noqa: TRY003  # tracked: #288
@@ -102,7 +107,7 @@ class LocalBackend:
                 env=extra_env,
                 log_path=log_path,
                 extra_init_commands=extra_init_commands,
-                setup_fns=setup_fns,
+                lifecycle_handlers=lifecycle_handlers,
             )
         if kind in (SandboxKind.DOCKER, SandboxKind.MODAL):
             raise ValueError(  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/backends/local.py
+++ b/src/vibesys/backends/local.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
 
-    from vs_sandbox.lifecycle import SandboxLifecycleHandler
+    from vs_sandbox.lifecycle import SandboxLifecycleHooks
 
 _DEFAULT_CPU_IMAGE = "python:3.12-bookworm"
 
@@ -74,7 +74,7 @@ class LocalBackend:
         passthrough_paths: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         extra_init_commands: list[str] | None = None,
-        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
+        lifecycle_hooks: list[SandboxLifecycleHooks] | None = None,
         modal_options: ModalOptions | None = None,  # noqa: ARG002  # tracked: #288
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
@@ -87,13 +87,13 @@ class LocalBackend:
         passthrough_paths = list(passthrough_paths or [])
         extra_env = dict(extra_env or {})
         extra_init_commands = list(extra_init_commands or [])
-        lifecycle_handlers = lifecycle_handlers or []
+        lifecycle_hooks = lifecycle_hooks or []
 
         if kind is SandboxKind.LOCAL:
             return make_local_shell_sandbox(
                 host_workspace=host_workspace,
                 env=extra_env,
-                lifecycle_handlers=lifecycle_handlers,
+                lifecycle_hooks=lifecycle_hooks,
             )
         if kind is SandboxKind.DOCKER and self._supports_docker:
             if self.image is None:
@@ -107,7 +107,7 @@ class LocalBackend:
                 env=extra_env,
                 log_path=log_path,
                 extra_init_commands=extra_init_commands,
-                lifecycle_handlers=lifecycle_handlers,
+                lifecycle_hooks=lifecycle_hooks,
             )
         if kind in (SandboxKind.DOCKER, SandboxKind.MODAL):
             raise ValueError(  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/backends/rocm/__init__.py
+++ b/src/vibesys/backends/rocm/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
 
-    from vs_sandbox.lifecycle import SandboxLifecycleHandler
+    from vs_sandbox.lifecycle import SandboxLifecycleHooks
 
 # ROCm PyTorch image. Carries the ROCm runtime + a matching torch build.
 # Pinned rather than ``:latest`` for reproducibility and because the
@@ -158,7 +158,7 @@ class RocmBackend:
         passthrough_paths: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         extra_init_commands: list[str] | None = None,
-        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
+        lifecycle_hooks: list[SandboxLifecycleHooks] | None = None,
         modal_options: ModalOptions | None = None,  # noqa: ARG002  # tracked: #288
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
@@ -170,7 +170,7 @@ class RocmBackend:
         passthrough_paths = list(passthrough_paths or [])
         extra_env = dict(extra_env or {})
         extra_init_commands = list(extra_init_commands or [])
-        lifecycle_handlers = lifecycle_handlers or []
+        lifecycle_hooks = lifecycle_hooks or []
 
         if kind is SandboxKind.MODAL:
             raise ValueError(  # noqa: TRY003  # tracked: #288
@@ -185,7 +185,7 @@ class RocmBackend:
             return make_local_shell_sandbox(
                 host_workspace=host_workspace,
                 env=env,
-                lifecycle_handlers=lifecycle_handlers,
+                lifecycle_hooks=lifecycle_hooks,
             )
 
         if kind is SandboxKind.DOCKER:
@@ -201,7 +201,7 @@ class RocmBackend:
                 env=env,
                 log_path=log_path,
                 extra_init_commands=extra_init_commands,
-                lifecycle_handlers=lifecycle_handlers,
+                lifecycle_hooks=lifecycle_hooks,
             )
 
         raise ValueError(f"Unknown sandbox kind: {kind!r}")  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/backends/rocm/__init__.py
+++ b/src/vibesys/backends/rocm/__init__.py
@@ -40,7 +40,6 @@ from vibesys.backends.base import (
     ContentionMonitor,
     ModalOptions,
     SandboxKind,
-    SetupFn,
     make_local_shell_sandbox,
 )
 from vibesys.constants import ComputeBackend
@@ -49,6 +48,8 @@ from vibesys.profilers import ProfilerKind
 if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
+
+    from vs_sandbox.lifecycle import SandboxLifecycleHandler
 
 # ROCm PyTorch image. Carries the ROCm runtime + a matching torch build.
 # Pinned rather than ``:latest`` for reproducibility and because the
@@ -157,7 +158,7 @@ class RocmBackend:
         passthrough_paths: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         extra_init_commands: list[str] | None = None,
-        setup_fns: list[SetupFn] | None = None,
+        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
         modal_options: ModalOptions | None = None,  # noqa: ARG002  # tracked: #288
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
@@ -169,7 +170,7 @@ class RocmBackend:
         passthrough_paths = list(passthrough_paths or [])
         extra_env = dict(extra_env or {})
         extra_init_commands = list(extra_init_commands or [])
-        setup_fns = setup_fns or []
+        lifecycle_handlers = lifecycle_handlers or []
 
         if kind is SandboxKind.MODAL:
             raise ValueError(  # noqa: TRY003  # tracked: #288
@@ -181,7 +182,11 @@ class RocmBackend:
         env = self._build_env(extra_env)
 
         if kind is SandboxKind.LOCAL:
-            return make_local_shell_sandbox(host_workspace=host_workspace, env=env)
+            return make_local_shell_sandbox(
+                host_workspace=host_workspace,
+                env=env,
+                lifecycle_handlers=lifecycle_handlers,
+            )
 
         if kind is SandboxKind.DOCKER:
             return DockerSandbox(
@@ -196,7 +201,7 @@ class RocmBackend:
                 env=env,
                 log_path=log_path,
                 extra_init_commands=extra_init_commands,
-                setup_fns=setup_fns,
+                lifecycle_handlers=lifecycle_handlers,
             )
 
         raise ValueError(f"Unknown sandbox kind: {kind!r}")  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/backends/trainium/__init__.py
+++ b/src/vibesys/backends/trainium/__init__.py
@@ -31,7 +31,6 @@ from vibesys.backends.base import (
     ContentionMonitor,
     ModalOptions,
     SandboxKind,
-    SetupFn,
     make_local_shell_sandbox,
 )
 from vibesys.constants import ComputeBackend
@@ -40,6 +39,8 @@ from vibesys.profilers import ProfilerKind
 if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
+
+    from vs_sandbox.lifecycle import SandboxLifecycleHandler
 
 # AWS Neuron DLC.  Tag chosen to match the host's Neuron tools (2.30):
 # PyTorch 2.9 / Python 3.12 / Neuron SDK 2.30 on Ubuntu 24.04.  Carries
@@ -117,7 +118,7 @@ class TrainiumBackend:
         passthrough_paths: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         extra_init_commands: list[str] | None = None,
-        setup_fns: list[SetupFn] | None = None,
+        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
         modal_options: ModalOptions | None = None,  # noqa: ARG002  # tracked: #288
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
@@ -129,7 +130,7 @@ class TrainiumBackend:
         passthrough_paths = list(passthrough_paths or [])
         extra_env = dict(extra_env or {})
         extra_init_commands = list(extra_init_commands or [])
-        setup_fns = setup_fns or []
+        lifecycle_handlers = lifecycle_handlers or []
 
         if kind is SandboxKind.MODAL:
             raise ValueError(  # noqa: TRY003  # tracked: #288
@@ -156,7 +157,11 @@ class TrainiumBackend:
                 "TMPDIR": str(host_tmp),
             }
             local_env.update(extra_env)
-            return make_local_shell_sandbox(host_workspace=host_workspace, env=local_env)
+            return make_local_shell_sandbox(
+                host_workspace=host_workspace,
+                env=local_env,
+                lifecycle_handlers=lifecycle_handlers,
+            )
 
         if kind is SandboxKind.DOCKER:
             # Persistent host-side compile cache → container, kept out of
@@ -195,7 +200,7 @@ class TrainiumBackend:
                 env=env,
                 log_path=log_path,
                 extra_init_commands=extra_init_commands,
-                setup_fns=setup_fns,
+                lifecycle_handlers=lifecycle_handlers,
             )
 
         raise ValueError(f"Unknown sandbox kind: {kind!r}")  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/backends/trainium/__init__.py
+++ b/src/vibesys/backends/trainium/__init__.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
 
-    from vs_sandbox.lifecycle import SandboxLifecycleHandler
+    from vs_sandbox.lifecycle import SandboxLifecycleHooks
 
 # AWS Neuron DLC.  Tag chosen to match the host's Neuron tools (2.30):
 # PyTorch 2.9 / Python 3.12 / Neuron SDK 2.30 on Ubuntu 24.04.  Carries
@@ -118,7 +118,7 @@ class TrainiumBackend:
         passthrough_paths: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         extra_init_commands: list[str] | None = None,
-        lifecycle_handlers: list[SandboxLifecycleHandler] | None = None,
+        lifecycle_hooks: list[SandboxLifecycleHooks] | None = None,
         modal_options: ModalOptions | None = None,  # noqa: ARG002  # tracked: #288
         attach_accelerator: bool = True,
     ) -> SandboxBackendProtocol:
@@ -130,7 +130,7 @@ class TrainiumBackend:
         passthrough_paths = list(passthrough_paths or [])
         extra_env = dict(extra_env or {})
         extra_init_commands = list(extra_init_commands or [])
-        lifecycle_handlers = lifecycle_handlers or []
+        lifecycle_hooks = lifecycle_hooks or []
 
         if kind is SandboxKind.MODAL:
             raise ValueError(  # noqa: TRY003  # tracked: #288
@@ -160,7 +160,7 @@ class TrainiumBackend:
             return make_local_shell_sandbox(
                 host_workspace=host_workspace,
                 env=local_env,
-                lifecycle_handlers=lifecycle_handlers,
+                lifecycle_hooks=lifecycle_hooks,
             )
 
         if kind is SandboxKind.DOCKER:
@@ -200,7 +200,7 @@ class TrainiumBackend:
                 env=env,
                 log_path=log_path,
                 extra_init_commands=extra_init_commands,
-                lifecycle_handlers=lifecycle_handlers,
+                lifecycle_hooks=lifecycle_hooks,
             )
 
         raise ValueError(f"Unknown sandbox kind: {kind!r}")  # noqa: TRY003  # tracked: #288

--- a/src/vibesys/run/device.py
+++ b/src/vibesys/run/device.py
@@ -57,7 +57,7 @@ class DeviceLease:  # noqa: D101  # tracked: #288
     def reselect(self) -> None:
         """Delegate mid-run device rebalance to the backend.
 
-        Restarted sandboxes re-run their lifecycle handlers (e.g. Docker symlinks)
+        Restarted sandboxes re-run their lifecycle hooks (e.g. Docker symlinks)
         as part of ``start()`` — no replay logic needed here.
         """
         if self._view is not None and not self._view.host_device_reselect:

--- a/src/vibesys/run/device.py
+++ b/src/vibesys/run/device.py
@@ -57,7 +57,7 @@ class DeviceLease:  # noqa: D101  # tracked: #288
     def reselect(self) -> None:
         """Delegate mid-run device rebalance to the backend.
 
-        Restarted sandboxes re-run their ``setup_fns`` (e.g. docker symlinks)
+        Restarted sandboxes re-run their lifecycle handlers (e.g. Docker symlinks)
         as part of ``start()`` — no replay logic needed here.
         """
         if self._view is not None and not self._view.host_device_reselect:

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -47,7 +47,7 @@ from vibesys.skypilot.bridge import SkyPilotBridge
 from vibesys.skypilot.config import load_cluster_profiles, resolve_profile
 from vibesys.skypilot.runner import SkyPilotJobRunner, stable_cluster_name
 from vs_project import RunEnvironmentRecord, RunResourceRequest
-from vs_sandbox import BeforeReadyContext, ProjectPathPolicy, SandboxLifecycleHandler
+from vs_sandbox import BeforeReadyContext, ProjectPathPolicy, SandboxLifecycleHooks
 
 _SHELL_COMMAND_ARG_COUNT = 3
 _RunEnvironmentName = Literal["local", "docker", "modal", "skypilot"]
@@ -328,7 +328,7 @@ class DockerEnvironment:  # noqa: D101  # tracked: #288
         if request.git_history_root is not None:
             cli_provider_env.setdefault("VIBESYS_GIT_HISTORY", "/opt/vibesys-history")
         bind_mounts = _dedupe_mounts(bind_mounts)
-        lifecycle_handlers = _symlink_lifecycle_handlers(docker_symlinks)
+        lifecycle_hooks = _symlink_lifecycle_hooks(docker_symlinks)
 
         sandbox = request.backend.make_sandbox(
             SandboxKind.DOCKER,
@@ -338,7 +338,7 @@ class DockerEnvironment:  # noqa: D101  # tracked: #288
             passthrough_paths=passthrough,
             extra_env=cli_provider_env,
             extra_init_commands=extra_init_commands,
-            lifecycle_handlers=lifecycle_handlers,
+            lifecycle_hooks=lifecycle_hooks,
         )
         log: Callable[[str], None] = request.log or (lambda _: None)
         label = getattr(request.backend, "image", self.config.image or "<backend-default>")
@@ -571,7 +571,7 @@ class SkyPilotEnvironment(DockerEnvironment):
                 passthrough_paths=passthrough,
                 extra_env=cli_provider_env,
                 extra_init_commands=extra_init_commands,
-                lifecycle_handlers=_symlink_lifecycle_handlers(docker_symlinks),
+                lifecycle_hooks=_symlink_lifecycle_hooks(docker_symlinks),
                 attach_accelerator=False,
             )
             _start_sandbox(sandbox)
@@ -702,7 +702,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
         extra_init_commands.insert(0, "pip install --quiet 'modal>=0.66'")
 
         bind_mounts = _dedupe_mounts(bind_mounts)
-        lifecycle_handlers = _symlink_lifecycle_handlers(docker_symlinks)
+        lifecycle_hooks = _symlink_lifecycle_hooks(docker_symlinks)
 
         sandbox = request.backend.make_sandbox(
             SandboxKind.DOCKER,
@@ -712,7 +712,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
             passthrough_paths=passthrough,
             extra_env=cli_provider_env,
             extra_init_commands=extra_init_commands,
-            lifecycle_handlers=lifecycle_handlers,
+            lifecycle_hooks=lifecycle_hooks,
             attach_accelerator=False,
         )
         log: Callable[[str], None] = request.log or (lambda _: None)
@@ -1518,7 +1518,7 @@ def _dedupe_mounts(
 
 
 @dataclass(frozen=True)
-class _SymlinkLifecycleHandler(SandboxLifecycleHandler):
+class _SymlinkLifecycleHooks(SandboxLifecycleHooks):
     commands: tuple[str, ...]
 
     def before_ready(self, context: BeforeReadyContext) -> None:
@@ -1533,15 +1533,15 @@ class _SymlinkLifecycleHandler(SandboxLifecycleHandler):
             save_symlink_commands(list(self.commands))
 
 
-def _symlink_lifecycle_handlers(
+def _symlink_lifecycle_hooks(
     symlinks: list[tuple[str, str]],
-) -> list[SandboxLifecycleHandler]:
+) -> list[SandboxLifecycleHooks]:
     if not symlinks:
         return []
     commands = tuple(
         f"ln -sfn {shlex.quote(target)} {shlex.quote(link)}" for link, target in symlinks
     )
-    return [_SymlinkLifecycleHandler(commands)]
+    return [_SymlinkLifecycleHooks(commands)]
 
 
 def _collect_symlink_mounts(

--- a/src/vibesys/sandbox/run_environment.py
+++ b/src/vibesys/sandbox/run_environment.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol
 
 from vibesys.backends import SandboxKind
-from vibesys.backends.base import ComputeBackendImpl, SetupFn  # noqa: TC001  # tracked: #288
+from vibesys.backends.base import ComputeBackendImpl  # noqa: TC001  # tracked: #288
 from vibesys.constants import DEFAULT_AGENT_BACKEND, PROJECT_ROOT
 from vibesys.domains.environment import EnvironmentBindMount  # noqa: TC001  # tracked: #288
 from vibesys.evaluators import PROJECT_ROOT_TOKEN, load_evaluator_package
@@ -47,7 +47,7 @@ from vibesys.skypilot.bridge import SkyPilotBridge
 from vibesys.skypilot.config import load_cluster_profiles, resolve_profile
 from vibesys.skypilot.runner import SkyPilotJobRunner, stable_cluster_name
 from vs_project import RunEnvironmentRecord, RunResourceRequest
-from vs_sandbox import ProjectPathPolicy
+from vs_sandbox import BeforeReadyContext, ProjectPathPolicy, SandboxLifecycleHandler
 
 _SHELL_COMMAND_ARG_COUNT = 3
 _RunEnvironmentName = Literal["local", "docker", "modal", "skypilot"]
@@ -62,7 +62,6 @@ _ENVIRONMENTS_TEMPLATE_DIR = PROMPTS_DIR / "environments"
 if TYPE_CHECKING:
     # Annotation only; deepagents pulls langchain + anthropic (~seconds).
     from deepagents.backends.protocol import SandboxBackendProtocol
-    from deepagents.backends.sandbox import BaseSandbox
 
     from vs_project import StateNamespace
 
@@ -329,7 +328,7 @@ class DockerEnvironment:  # noqa: D101  # tracked: #288
         if request.git_history_root is not None:
             cli_provider_env.setdefault("VIBESYS_GIT_HISTORY", "/opt/vibesys-history")
         bind_mounts = _dedupe_mounts(bind_mounts)
-        setup_fns = _symlink_setup_fns(docker_symlinks)
+        lifecycle_handlers = _symlink_lifecycle_handlers(docker_symlinks)
 
         sandbox = request.backend.make_sandbox(
             SandboxKind.DOCKER,
@@ -339,7 +338,7 @@ class DockerEnvironment:  # noqa: D101  # tracked: #288
             passthrough_paths=passthrough,
             extra_env=cli_provider_env,
             extra_init_commands=extra_init_commands,
-            setup_fns=setup_fns,
+            lifecycle_handlers=lifecycle_handlers,
         )
         log: Callable[[str], None] = request.log or (lambda _: None)
         label = getattr(request.backend, "image", self.config.image or "<backend-default>")
@@ -572,7 +571,7 @@ class SkyPilotEnvironment(DockerEnvironment):
                 passthrough_paths=passthrough,
                 extra_env=cli_provider_env,
                 extra_init_commands=extra_init_commands,
-                setup_fns=_symlink_setup_fns(docker_symlinks),
+                lifecycle_handlers=_symlink_lifecycle_handlers(docker_symlinks),
                 attach_accelerator=False,
             )
             _start_sandbox(sandbox)
@@ -703,7 +702,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
         extra_init_commands.insert(0, "pip install --quiet 'modal>=0.66'")
 
         bind_mounts = _dedupe_mounts(bind_mounts)
-        setup_fns = _symlink_setup_fns(docker_symlinks)
+        lifecycle_handlers = _symlink_lifecycle_handlers(docker_symlinks)
 
         sandbox = request.backend.make_sandbox(
             SandboxKind.DOCKER,
@@ -713,7 +712,7 @@ class ModalEnvironment(_NoopWorkspaceRecovery):  # noqa: D101  # tracked: #288
             passthrough_paths=passthrough,
             extra_env=cli_provider_env,
             extra_init_commands=extra_init_commands,
-            setup_fns=setup_fns,
+            lifecycle_handlers=lifecycle_handlers,
             attach_accelerator=False,
         )
         log: Callable[[str], None] = request.log or (lambda _: None)
@@ -1518,19 +1517,31 @@ def _dedupe_mounts(
     return list(seen.values())
 
 
-def _symlink_setup_fns(symlinks: list[tuple[str, str]]) -> list[SetupFn]:
+@dataclass(frozen=True)
+class _SymlinkLifecycleHandler(SandboxLifecycleHandler):
+    commands: tuple[str, ...]
+
+    def before_ready(self, context: BeforeReadyContext) -> None:
+        for command in self.commands:
+            result = context.sandbox.execute(command)
+            if result.exit_code != 0:
+                raise RuntimeError(  # noqa: TRY003
+                    f"failed to create sandbox symlink with {command!r}: {result.output}"
+                )
+        save_symlink_commands = getattr(context.sandbox, "save_symlink_commands", None)
+        if callable(save_symlink_commands):
+            save_symlink_commands(list(self.commands))
+
+
+def _symlink_lifecycle_handlers(
+    symlinks: list[tuple[str, str]],
+) -> list[SandboxLifecycleHandler]:
     if not symlinks:
         return []
-    symlink_cmds = [f"ln -sfn {target} {link}" for link, target in symlinks]
-
-    def install_symlinks(sb: BaseSandbox) -> None:
-        for cmd in symlink_cmds:
-            sb.execute(cmd)
-        save_symlink_commands = getattr(sb, "save_symlink_commands", None)
-        if callable(save_symlink_commands):
-            save_symlink_commands(symlink_cmds)
-
-    return [install_symlinks]
+    commands = tuple(
+        f"ln -sfn {shlex.quote(target)} {shlex.quote(link)}" for link, target in symlinks
+    )
+    return [_SymlinkLifecycleHandler(commands)]
 
 
 def _collect_symlink_mounts(

--- a/tests/vibesys/backends/test_cpu_backend.py
+++ b/tests/vibesys/backends/test_cpu_backend.py
@@ -13,7 +13,15 @@ from vibesys.backends import SandboxKind
 from vibesys.backends.local import LocalBackend
 from vibesys.constants import ComputeBackend
 from vibesys.profilers import ProfilerKind
-from vs_sandbox import DockerSandbox
+from vs_sandbox import BeforeReadyContext, DockerSandbox, SandboxLifecycleHandler
+
+
+class _RecordingHandler(SandboxLifecycleHandler):
+    def __init__(self) -> None:
+        self.sandbox: object | None = None
+
+    def before_ready(self, context: BeforeReadyContext) -> None:
+        self.sandbox = context.sandbox
 
 
 def _make_backend(tmp_path) -> LocalBackend:  # noqa: ANN001  # tracked: #288
@@ -42,6 +50,21 @@ class TestCpuSandbox:
             extra_env={"FOO": "bar"},
         )
         assert isinstance(sb, LocalShellBackend)
+
+    def test_local_runs_lifecycle_handlers_before_returning(self, tmp_path):  # noqa: ANN001, ANN201
+        impl = _make_backend(tmp_path)
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        handler = _RecordingHandler()
+
+        sb = impl.make_sandbox(
+            SandboxKind.LOCAL,
+            host_workspace=str(workspace),
+            log_path=None,
+            lifecycle_handlers=[handler],
+        )
+
+        assert handler.sandbox is sb
 
     def test_docker_returns_docker_sandbox_without_gpus(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)

--- a/tests/vibesys/backends/test_cpu_backend.py
+++ b/tests/vibesys/backends/test_cpu_backend.py
@@ -13,10 +13,10 @@ from vibesys.backends import SandboxKind
 from vibesys.backends.local import LocalBackend
 from vibesys.constants import ComputeBackend
 from vibesys.profilers import ProfilerKind
-from vs_sandbox import BeforeReadyContext, DockerSandbox, SandboxLifecycleHandler
+from vs_sandbox import BeforeReadyContext, DockerSandbox, SandboxLifecycleHooks
 
 
-class _RecordingHandler(SandboxLifecycleHandler):
+class _RecordingHooks(SandboxLifecycleHooks):
     def __init__(self) -> None:
         self.sandbox: object | None = None
 
@@ -51,20 +51,20 @@ class TestCpuSandbox:
         )
         assert isinstance(sb, LocalShellBackend)
 
-    def test_local_runs_lifecycle_handlers_before_returning(self, tmp_path):  # noqa: ANN001, ANN201
+    def test_local_runs_lifecycle_hooks_before_returning(self, tmp_path):  # noqa: ANN001, ANN201
         impl = _make_backend(tmp_path)
         workspace = tmp_path / "ws"
         workspace.mkdir()
-        handler = _RecordingHandler()
+        hooks = _RecordingHooks()
 
         sb = impl.make_sandbox(
             SandboxKind.LOCAL,
             host_workspace=str(workspace),
             log_path=None,
-            lifecycle_handlers=[handler],
+            lifecycle_hooks=[hooks],
         )
 
-        assert handler.sandbox is sb
+        assert hooks.sandbox is sb
 
     def test_docker_returns_docker_sandbox_without_gpus(self, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
         impl = _make_backend(tmp_path)

--- a/tests/vibesys/backends/test_gpu_monitor.py
+++ b/tests/vibesys/backends/test_gpu_monitor.py
@@ -407,7 +407,7 @@ class TestReselectGpu:
         ctx.gpu_monitor.stop()
 
     # Note: symlink replay on restart is now the sandbox class's
-    # responsibility (it runs setup_fns at the end of start()).  That
+    # responsibility (it runs lifecycle hooks before becoming ready). That
     # behaviour is tested in libs/vs-sandbox/tests/test_docker_sandbox.py; reselect_gpu
     # itself just calls sb.stop()/sb.start() and the rest happens for free.
 

--- a/tests/vibesys/sandbox/test_run_environment.py
+++ b/tests/vibesys/sandbox/test_run_environment.py
@@ -20,12 +20,13 @@ from vibesys.sandbox.run_environment import (
     RunEnvironmentRequest,
     RunEnvironmentSpec,
     _SkyPilotRunEnvironmentSession,
+    _symlink_lifecycle_handlers,
     build_run_environment,
     make_run_environment_spec,
     run_environment_record,
 )
 from vs_project import Project, RunEnvironmentRecord, RunResourceRequest
-from vs_sandbox import ProjectPathPolicy
+from vs_sandbox import BeforeReadyContext, ProjectPathPolicy
 
 if TYPE_CHECKING:
     from deepagents.backends.protocol import SandboxBackendProtocol
@@ -243,10 +244,36 @@ def test_docker_environment_opens_one_started_sandbox_with_agent_paths(tmp_path)
     assert session.view.paths.accuracy_command == "uv run python accuracy_checker/checker.py"
     assert session.view.paths.benchmark_command == "uv run python benchmark/benchmark.py"
     assert backend.calls[0][1]["extra_env"]["UV_CACHE_DIR"] == "/workspace/.cache/uv"
+    assert backend.calls[0][1]["lifecycle_handlers"] == []
     backend.sandbox.start.assert_called_once()
 
     session.close()
     backend.sandbox.stop.assert_called_once()
+
+
+def test_symlink_lifecycle_handler_installs_and_records_quoted_commands() -> None:
+    sandbox = MagicMock()
+    sandbox.execute.return_value = MagicMock(exit_code=0, output="")
+    handlers = _symlink_lifecycle_handlers(
+        [("/workspace/model link", "/workspace/_mounts/model target")]
+    )
+
+    handlers[0].before_ready(BeforeReadyContext(sandbox=sandbox))
+
+    command = "ln -sfn '/workspace/_mounts/model target' '/workspace/model link'"
+    sandbox.execute.assert_called_once_with(command)
+    sandbox.save_symlink_commands.assert_called_once_with([command])
+
+
+def test_symlink_lifecycle_handler_rejects_failed_setup() -> None:
+    sandbox = MagicMock()
+    sandbox.execute.return_value = MagicMock(exit_code=17, output="permission denied")
+    handlers = _symlink_lifecycle_handlers([("/workspace/model", "/mount/model")])
+
+    with pytest.raises(RuntimeError, match="permission denied"):
+        handlers[0].before_ready(BeforeReadyContext(sandbox=sandbox))
+
+    sandbox.save_symlink_commands.assert_not_called()
 
 
 def test_isolated_environment_mounts_and_translates_evaluator_package(tmp_path: Path) -> None:

--- a/tests/vibesys/sandbox/test_run_environment.py
+++ b/tests/vibesys/sandbox/test_run_environment.py
@@ -20,7 +20,7 @@ from vibesys.sandbox.run_environment import (
     RunEnvironmentRequest,
     RunEnvironmentSpec,
     _SkyPilotRunEnvironmentSession,
-    _symlink_lifecycle_handlers,
+    _symlink_lifecycle_hooks,
     build_run_environment,
     make_run_environment_spec,
     run_environment_record,
@@ -244,34 +244,32 @@ def test_docker_environment_opens_one_started_sandbox_with_agent_paths(tmp_path)
     assert session.view.paths.accuracy_command == "uv run python accuracy_checker/checker.py"
     assert session.view.paths.benchmark_command == "uv run python benchmark/benchmark.py"
     assert backend.calls[0][1]["extra_env"]["UV_CACHE_DIR"] == "/workspace/.cache/uv"
-    assert backend.calls[0][1]["lifecycle_handlers"] == []
+    assert backend.calls[0][1]["lifecycle_hooks"] == []
     backend.sandbox.start.assert_called_once()
 
     session.close()
     backend.sandbox.stop.assert_called_once()
 
 
-def test_symlink_lifecycle_handler_installs_and_records_quoted_commands() -> None:
+def test_symlink_lifecycle_hooks_install_and_record_quoted_commands() -> None:
     sandbox = MagicMock()
     sandbox.execute.return_value = MagicMock(exit_code=0, output="")
-    handlers = _symlink_lifecycle_handlers(
-        [("/workspace/model link", "/workspace/_mounts/model target")]
-    )
+    hooks = _symlink_lifecycle_hooks([("/workspace/model link", "/workspace/_mounts/model target")])
 
-    handlers[0].before_ready(BeforeReadyContext(sandbox=sandbox))
+    hooks[0].before_ready(BeforeReadyContext(sandbox=sandbox))
 
     command = "ln -sfn '/workspace/_mounts/model target' '/workspace/model link'"
     sandbox.execute.assert_called_once_with(command)
     sandbox.save_symlink_commands.assert_called_once_with([command])
 
 
-def test_symlink_lifecycle_handler_rejects_failed_setup() -> None:
+def test_symlink_lifecycle_hooks_reject_failed_setup() -> None:
     sandbox = MagicMock()
     sandbox.execute.return_value = MagicMock(exit_code=17, output="permission denied")
-    handlers = _symlink_lifecycle_handlers([("/workspace/model", "/mount/model")])
+    hooks = _symlink_lifecycle_hooks([("/workspace/model", "/mount/model")])
 
     with pytest.raises(RuntimeError, match="permission denied"):
-        handlers[0].before_ready(BeforeReadyContext(sandbox=sandbox))
+        hooks[0].before_ready(BeforeReadyContext(sandbox=sandbox))
 
     sandbox.save_symlink_commands.assert_not_called()
 


### PR DESCRIPTION
## Problem

Sandbox startup extensions are currently expressed as untyped `setup_fns` callbacks owned by VibeSys and implemented only by Docker and Modal. Local backends silently discard them, the callback contract is not part of `vs-sandbox`, and Modal does not reliably clean up a newly created sandbox when initialization fails. This prevents evaluator packages and other trusted framework components from using one backend-independent setup mechanism.

## Solution

Add a public class-based lifecycle contract to `vs-sandbox` with one hook point, `before_ready`. Framework code registers ordered `SandboxLifecycleHooks` providers. The dispatcher snapshots the registration list, supplies a typed `BeforeReadyContext`, stops on the first failure, and reports the failing provider while preserving the original exception as its cause.

Migrate the existing symlink setup closure to immutable lifecycle hooks, thread hooks through every compute backend, and run them for Local, Docker, and Modal execution. Remove the legacy `SetupFn` and `setup_fns` API. Keep backend-native required init commands separate because they retain backend-specific timeout and logging behavior.

The migration also gives Modal Docker-equivalent rollback: failed initial setup terminates the container and deletes its workspace volume; failed fallback replacement terminates the replacement while preserving the volume until normal session cleanup.

### Architecture

```mermaid
flowchart LR
    A[Trusted framework component] -->|register hooks providers| B[Compute backend]
    B --> C[Local, Docker, or Modal sandbox]
    C --> D[Create execution-capable environment]
    D --> E[Run built-in initialization]
    E --> F[SandboxLifecycle.before_ready]
    F -->|success| G[Startup returns ready]
    F -->|failure| H[Backend-owned rollback]
```

The shared interface and dispatcher live in `vs-sandbox`. VibeSys owns concrete application hooks such as symlink restoration. Sandbox implementations own invocation timing and cleanup.

## Verification

The lifecycle dispatcher has direct contract tests, plus backend tests for Docker, Modal, and Local behavior. The broader sandbox, backend, and run-environment suites pass.

### Correctness properties

- Hooks execute synchronously in registration order after built-in initialization and before startup completes.
- The registration sequence is defensively snapshotted.
- The first failing hook prevents readiness, skips later hooks, names the failing provider, and preserves the original cause.
- Hooks replay whenever Docker or Modal creates a replacement execution environment, so the contract requires idempotence.
- Local execution invokes hooks before returning its execution backend instead of silently dropping them.
- Docker and Modal clean up containers that fail lifecycle setup; Modal also preserves or deletes its workspace volume according to ownership.
- Existing CLI, evaluator-toolchain, and Modal SDK init-command ordering is unchanged.
- The legacy `SetupFn` and `setup_fns` paths are removed.

### Testing

- `uv run pytest -q libs/vs-sandbox/tests tests/vibesys/backends/test_cpu_backend.py tests/vibesys/backends/test_gpu_monitor.py tests/vibesys/sandbox/test_run_environment.py` (271 passed, 4 skipped for unavailable host devices/Landlock ABI)
- Targeted `uv run ruff check` over changed library, backend, and test files (passed)
- Targeted `uv run ty check` over changed production modules (passed)
- `git diff --check` (passed)

