### PR TITLE
TUI: Persist deferred verdict on unjudged final retry

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -2736,6 +2736,15 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                 for retry in range(first_retry, max_retries_per_round + 1):
                     ctx.lprint(f"\n--- attempt {retry}/{max_retries_per_round} ---\n")
                     final_attempt_reviewed = False
+                    # Reset alongside ``final_attempt_reviewed``: the persisted
+                    # record must reflect the final attempt, not an earlier
+                    # audit.  A cadence review of attempt N sets a verdict; if
+                    # the final attempt N+1 defers re-review (the sparse-review
+                    # break below), that stale verdict must not survive.
+                    # Otherwise the round is recorded with attempt N's
+                    # ``judge_verdict`` while ``reviewed=False``/outcome=continue,
+                    # and projection rejects a still-active hypothesis.
+                    judge_verdict = None
                     if inner_loop == "multi-agent":
                         prior_attempt_artifact_locations = tuple(
                             issue_board.display_path(path, ctx.workspace)

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -17,6 +17,7 @@ from vibesys.domains.base import DomainName
 from vibesys.errors import ConfigurationError
 from vibesys.input_manifest import BenchmarkResult, WorkspaceSource
 from vibesys.loops.agent import issue_board
+from vibesys.loops.agent.hypotheses import reproject_run_evidence
 from vibesys.loops.agent.loop import (
     FrameworkBenchmarkOutcome,
     _backfill_revert_commit,
@@ -33,7 +34,7 @@ from vibesys.loops.agent.loop import (
     _terminal_workspace_notice,
     run_agent_loop,
 )
-from vibesys.loops.agent.model import Hypothesis
+from vibesys.loops.agent.model import Hypothesis, HypothesisResolution, HypothesisReview
 from vibesys.loops.agent.state import AgentRunStateStore
 from vibesys.loops.evolve.population import Objective
 from vibesys.profilers import ProfilerKind, ProfilerPreflightResult
@@ -2928,6 +2929,27 @@ def test_cadence_review_is_not_duplicated_for_provisional_retry(tmp_path, ref_fi
     # The final-round nomination is still reviewed immediately.
     assert runner.counters["impl"] == 5
     assert runner.counters["judge"] == 2
+
+    # Round 3's final attempt is an unreviewed continuation: the cadence review
+    # judged attempt 1 (a different implementation), then attempt 2 deferred
+    # re-review.  The record must not persist attempt 1's stale verdict; it
+    # carries ``deferred`` so it agrees with ``reviewed=False``/outcome=continue.
+    round_three = _round_payloads(tmp_path)[2]
+    assert round_three["round"] == 3
+    assert round_three["reviewed"] is False
+    assert round_three["hypothesis_outcome"] == "continue"
+    assert round_three["judge_verdict"] == "deferred"
+
+    # Projection must not reject the still-active, continuing hypothesis: an
+    # unreviewed round leaves it deferred and unresolved, not failed/rejected.
+    project = _created_project(tmp_path)
+    state = Project.open(project).state
+    unified = AgentRunStateStore(state.portable_namespace(_run_id(project), "agent")).load()
+    stable = reproject_run_evidence(unified).by_id("stable-hypothesis")
+    assert stable is not None
+    assert stable.review is HypothesisReview.DEFERRED
+    assert stable.resolution is not HypothesisResolution.REJECTED
+    assert stable.resolution is None
 
 
 def test_unreviewed_terminal_outcome_returns_control_to_designer(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288


### PR DESCRIPTION
## Problem

In `run_agent_loop`, `judge_verdict` is initialized once per round (`src/vibesys/loops/agent/loop.py`) and, unlike `final_attempt_reviewed`, was never reset per retry attempt. When a cadence-triggered review judged attempt N and the final attempt N+1 was a continuation that skipped re-review (the sparse-review deferral branch sets `review_due = False`, logs `append_judge_skipped`, and breaks), the round record was persisted with attempt N's verdict even though that verdict judged a different implementation.

The loop itself resolves control correctly from `final_attempt_reviewed`, so the record simultaneously carried `judge_verdict="fail"`, `reviewed=False`, and `hypothesis_outcome="continue"`. Evidence projection then treats the verdict as authoritative: `hypotheses.py` returns `HypothesisReview("fail")` and recomputes resolution with `reviewed=True`, so a still-active, continuing hypothesis was persisted with `resolution=rejected`. The corruption is written by `append_round`, re-derived on every resume by `reproject_run_evidence`, and surfaced to the TUI through `server/experiments.py`. It is permanent even without an interruption: the continuation lease can expire at the deferral round itself, leaving the hypothesis forever recorded rejected while its own final round says unreviewed/continue. A symmetric stale-"pass" variant existed via the validation-recipe gate path, which retries without setting `framework_revalidation_required`.

The streamed `ROUND_FINISHED` event already computed `skipped` correctly from `records[-1].reviewed`, so the event stream and the persisted record disagreed about the same round.

## Solution

Reset `judge_verdict = None` at the top of each retry attempt, alongside the existing `final_attempt_reviewed = False` reset. The post-loop persistence already falls back to the documented `"deferred"` when `judge_verdict is None`, so a round whose final attempt was not judged now persists `judge_verdict="deferred"`, matching the loop's own `reviewed=False` / outcome=continue decision.

This is symmetric with `final_attempt_reviewed`: when the final attempt *is* reviewed, `judge_verdict` is set from that attempt's judge run before any break, so a real verdict is always recorded; when it is not reviewed, the reset leaves `None` and the fallback records `"deferred"`. The same reset covers the stale-"pass" validation-gate variant, since the gate's `continue` re-enters the loop and clears the prior attempt's verdict. No ownership or control-flow changes: the fix is one added reset inside the existing implementer/judge retry loop, and every downstream consumer is unchanged.

### Architecture

```mermaid
flowchart LR
    L[run_agent_loop retry loop<br/>reset judge_verdict AND<br/>final_attempt_reviewed per attempt] --> J{final attempt<br/>reviewed?}
    J -->|yes| V[judge_verdict set to pass or fail<br/>from this attempt's judge run]
    J -->|no, deferred re-review| D[judge_verdict stays None<br/>persist documented fallback deferred]
    V --> R[RoundRecord]
    D --> R
    R --> AR[append_round writes state.json]
    AR --> RP[reproject_run_evidence / hypotheses.py<br/>_review, resolve_hypothesis_outcome]
    RP --> EX[server/experiments.py projection]
    EX --> T[TUI hypothesis view]
```

The agent loop owns the retry loop and stamps `judge_verdict` per attempt; `hypotheses.py` owns projection and only ever consumes a `judge_verdict` that is consistent with `reviewed`; `server/experiments.py` and the TUI own presentation and are unchanged. The fix keeps the single writer (the retry loop) from leaking one attempt's verdict onto another attempt's record, so every reader downstream sees `deferred` exactly when the round was not judged.

## Verification

Automated: the targeted orchestrate test, the affected loop and state modules (150 tests), and ruff over the changed files all pass on top of current `main`; the new assertions fail without the fix and pass with it.

### Correctness properties

- A round record's `judge_verdict` reflects only the final attempt: if the final attempt was not judged (`reviewed=False`), it is `"deferred"`, never a stale verdict carried over from an earlier retry.
- Projection no longer rejects a still-active, continuing hypothesis: an unreviewed final round leaves `review=deferred` and `resolution=None`, not `review=fail` / `resolution=rejected`.
- When the final attempt *is* reviewed, the real verdict is preserved unchanged, so there is no behavior change on the judged path.
- The persisted record now agrees with the streamed `ROUND_FINISHED` event, which already derived `skipped` from `records[-1].reviewed`.
- Both failure modes are covered by the single reset: the sparse-review stale-"fail" deferral and the validation-gate stale-"pass" retry.

### Testing

Extended `test_cadence_review_is_not_duplicated_for_provisional_retry` in `tests/loops/agent/test_orchestrate.py` (the existing test that already produced the corrupted record but never asserted on it) to assert on the round-3 record and its projected hypothesis. The new assertions fail on `main` (`assert 'fail' == 'deferred'`) and pass with the fix.

Commands run from the repo root with `VIBESYS_PYTHON=.venv/bin/python`:

- `python -m pytest tests/loops/agent/test_orchestrate.py::test_cadence_review_is_not_duplicated_for_provisional_retry` — passes with the fix, fails without it (`assert 'fail' == 'deferred'`).
- `python -m pytest tests/loops/agent/test_orchestrate.py tests/loops/agent/test_hypotheses.py tests/loops/agent/test_agent_state_store.py` — 150 passed, no regressions.
- `ruff check src/vibesys/loops/agent/loop.py tests/loops/agent/test_orchestrate.py` — all checks passed.

Closes #503.
