### PR TITLE
TUI: Persist provider session IDs so a quit run resumes mid-hypothesis

### DIFF
--- a/docs/contributing/agent-drivers.md
+++ b/docs/contributing/agent-drivers.md
@@ -16,6 +16,52 @@ driver = "omnigent"
 The `omnigent` package is a base dependency (pinned exactly in
 `pyproject.toml`), so every install carries it; `uv sync` is enough.
 
+## Provider session resume
+
+`AgentClient` keeps one live session per session key and, for keys whose scope
+opts into durability, checkpoints that session's provider conversation ID in
+the run's machine-local state. A resumed process offers the checkpoint to the
+first session it builds for that key, so a quit run continues the
+implementer's conversation instead of replaying the round.
+
+Two contract members carry this:
+
+- `AgentCapabilities.provider_session_resume` says whether a driver can adopt a
+  conversation created by an earlier process. `session_reuse` only promises
+  reuse within one process.
+- `AgentSession.resume_provider_session(session_id) -> bool` offers one
+  checkpoint and returns whether it was adopted. A driver returns `False` when
+  its provider cannot resume, or when the session already holds a live
+  conversation whose history is newer than the checkpoint. A `False` answer
+  tells the client the checkpoint is dead, so it drops it.
+
+Cross-process resume is AgentShim-only today, and within AgentShim only for the
+providers whose CLI has a resume flag: `codex exec resume <thread>` and
+`claude --resume <session>`. Gemini and opencode declare no resume support, so
+they always refuse a checkpoint. Omnigent 0.10 owns its executor's conversation
+lifecycle internally and exposes no attach point, so `OmnigentSession` reports
+`provider_session_resume=False` and always refuses.
+
+### Drivers must report restarts
+
+A driver that drops and restarts the conversation a session names must return
+`SessionDisposition.RESET_REQUIRED` on that turn's `AgentTurnResult`. The client
+then evicts the live session and clears the checkpoint, so nothing later claims
+continuity with history that no longer exists. The AgentShim session reports a
+reset for all three of its restarts:
+
+- retiring an over-budget Codex thread (turn count or heavy-turn usage),
+  evaluated after the turn so the decision reads the usage it just produced;
+- retrying a turn whose Codex thread has no rollout on disk;
+- retrying a resumed Claude turn once from a fresh conversation, because Claude
+  Code reports a refused `--resume` as a bare nonzero exit that would otherwise
+  end the run.
+
+A turn that merely raises is not a restart. Timeouts and cancellations say
+nothing about whether the conversation is still resumable, so the client keeps
+the checkpoint and only a driver-reported reset (or a refused adoption) clears
+it.
+
 ## Mock driver
 
 `driver = "mock"` is test infrastructure. It satisfies the same driver

--- a/libs/vs-loop-state/src/vs_loop_state/agent.py
+++ b/libs/vs-loop-state/src/vs_loop_state/agent.py
@@ -126,6 +126,16 @@ class RoundRecord:
     # run's persisted metric space.
     perf_comparison: MetricComparison | None = None
 
+    # Implementer attribution: which driver/provider/model produced this round
+    # attempt. The provider session ID itself is machine-local and never lives
+    # on this portable record; ``vibesys.agents.session_store`` owns it, keyed
+    # by the round's hypothesis ID. These three fields describe the *latest*
+    # attempt at the round: a resumed run that re-attempts the same round
+    # overwrites the manifest entry, so they are not an append-only audit log.
+    implementer_driver: str | None = None
+    implementer_provider: str | None = None
+    implementer_model: str | None = None
+
     @model_validator(mode="after")
     def _normalize_review(self) -> RoundRecord:
         """Keep the review state expressible only through ``judge_verdict``.

--- a/libs/vs-loop-state/tests/test_vs_loop_state_agent.py
+++ b/libs/vs-loop-state/tests/test_vs_loop_state_agent.py
@@ -66,7 +66,6 @@ def test_implementer_attribution_round_trips_and_defaults_to_none() -> None:
     assert bare.implementer_driver is None
     assert bare.implementer_provider is None
     assert bare.implementer_model is None
-    assert bare.implementer_session_key is None
 
     attributed = RoundRecord(
         round_number=2,
@@ -77,11 +76,10 @@ def test_implementer_attribution_round_trips_and_defaults_to_none() -> None:
         implementer_driver="agentshim",
         implementer_provider="codex",
         implementer_model="gpt-5.6-sol",
-        implementer_session_key="hypothesis:H-01",
     )
     payload = serialize_round_record(attributed)
     assert payload["implementer_provider"] == "codex"
-    assert payload["implementer_session_key"] == "hypothesis:H-01"
+    assert payload["implementer_model"] == "gpt-5.6-sol"
     assert parse_round_record(payload) == attributed
 
 
@@ -89,16 +87,11 @@ def test_legacy_record_without_attribution_still_loads() -> None:
     # A record written before attribution existed has none of the new keys;
     # ``extra="forbid"`` rejects unknown keys, not missing defaulted ones.
     legacy = serialize_round_record(_record(1, "a" * 40))
-    for key in (
-        "implementer_driver",
-        "implementer_provider",
-        "implementer_model",
-        "implementer_session_key",
-    ):
+    for key in ("implementer_driver", "implementer_provider", "implementer_model"):
         legacy.pop(key, None)
     restored = parse_round_record(legacy)
     assert restored.implementer_provider is None
-    assert restored.implementer_session_key is None
+    assert restored.implementer_driver is None
 
 
 def test_parse_round_record_applies_declared_defaults() -> None:

--- a/libs/vs-loop-state/tests/test_vs_loop_state_agent.py
+++ b/libs/vs-loop-state/tests/test_vs_loop_state_agent.py
@@ -61,6 +61,46 @@ def test_public_round_record_codec_round_trips_current_schema() -> None:
     assert parse_round_record(payload) == record
 
 
+def test_implementer_attribution_round_trips_and_defaults_to_none() -> None:
+    bare = _record(1, "a" * 40)
+    assert bare.implementer_driver is None
+    assert bare.implementer_provider is None
+    assert bare.implementer_model is None
+    assert bare.implementer_session_key is None
+
+    attributed = RoundRecord(
+        round_number=2,
+        commit="c" * 40,
+        perf_metric=None,
+        perf_unit=None,
+        passed=True,
+        implementer_driver="agentshim",
+        implementer_provider="codex",
+        implementer_model="gpt-5.6-sol",
+        implementer_session_key="hypothesis:H-01",
+    )
+    payload = serialize_round_record(attributed)
+    assert payload["implementer_provider"] == "codex"
+    assert payload["implementer_session_key"] == "hypothesis:H-01"
+    assert parse_round_record(payload) == attributed
+
+
+def test_legacy_record_without_attribution_still_loads() -> None:
+    # A record written before attribution existed has none of the new keys;
+    # ``extra="forbid"`` rejects unknown keys, not missing defaulted ones.
+    legacy = serialize_round_record(_record(1, "a" * 40))
+    for key in (
+        "implementer_driver",
+        "implementer_provider",
+        "implementer_model",
+        "implementer_session_key",
+    ):
+        legacy.pop(key, None)
+    restored = parse_round_record(legacy)
+    assert restored.implementer_provider is None
+    assert restored.implementer_session_key is None
+
+
 def test_parse_round_record_applies_declared_defaults() -> None:
     record = parse_round_record(
         {

--- a/src/vibesys/_agent_cli/base.py
+++ b/src/vibesys/_agent_cli/base.py
@@ -99,6 +99,22 @@ class CodingAgent(ABC):
     back to the prompt-level schema instruction.
     """
 
+    supports_session_resume = False
+    """Whether this provider's CLI can continue an earlier conversation.
+
+    Set by the providers that override :meth:`CLICodingAgent._get_resume_command`
+    (Codex and Claude Code today). It is the declared capability behind
+    :meth:`resume_from`, so callers never have to probe for a resume flag or
+    branch on the provider name.
+    """
+
+    session_id: str | None = None
+    """The provider conversation the next :meth:`generate` continues.
+
+    ``None`` means the next turn starts a fresh conversation. Concrete CLI
+    agents assign it after each turn from the provider's own transcript ID.
+    """
+
     # Declared (not assigned) here: every concrete provider sets these in its
     # ``__init__``.  ``env`` is the subprocess environment the CLI is spawned
     # with; ``executor`` is the agentshim ``CommandExecutor`` (host, docker,
@@ -274,3 +290,25 @@ class CodingAgent(ABC):
         Idempotent. Default implementation is a no-op.
         """
         return
+
+    def resume_from(self, session_id: str) -> bool:
+        """Continue *session_id* on the next turn, reporting whether it stuck.
+
+        Returns ``False`` when the ID was not adopted, which happens when the
+        provider has no resume flag or when a live conversation is already
+        attached: an in-flight conversation is never replaced, because its
+        history is newer than any checkpoint a caller could hold. Callers use
+        the return value to decide whether the checkpoint is still usable.
+        """
+        if not self.supports_session_resume or self.session_id is not None:
+            return False
+        self.session_id = session_id
+        return True
+
+    def forget_session(self) -> None:
+        """Drop the current conversation so the next turn starts fresh.
+
+        Idempotent. The caller is responsible for telling its own callers that
+        the conversation restarted; this only mutates the agent.
+        """
+        self.session_id = None

--- a/src/vibesys/_agent_cli/claude.py
+++ b/src/vibesys/_agent_cli/claude.py
@@ -60,6 +60,9 @@ class ClaudeCodeCodingAgent(CLICodingAgent[ClaudeGenerationSession]):
     """Coding agent implementation using the Claude Code CLI tool."""
 
     supports_native_output_schema = True
+    # ``claude --resume <session-id>`` continues a stored session, so a
+    # checkpointed session ID can be adopted before the next turn.
+    supports_session_resume = True
     # Claude Code's ``--json-schema`` flag takes the schema *inline*, not a
     # path, so the schema file must be read at command-build time. The runner
     # therefore hands this provider an absolute host path (readable on both the

--- a/src/vibesys/_agent_cli/codex.py
+++ b/src/vibesys/_agent_cli/codex.py
@@ -34,6 +34,9 @@ class CodexCodingAgent(CLICodingAgent[CodexGenerationSession]):
     """Coding agent implementation using the Codex CLI tool."""
 
     supports_native_output_schema = True
+    # ``codex exec resume <thread-id>`` continues a stored rollout, so a
+    # checkpointed thread ID can be adopted before the next turn.
+    supports_session_resume = True
 
     def __init__(  # noqa: ANN204  # tracked: #288
         self,

--- a/src/vibesys/agents/__init__.py
+++ b/src/vibesys/agents/__init__.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
     from .client import AgentClient
     from .deepagents_runner import DeepAgentsClient
+    from .session_store import SessionStore
 
 __all__ = [
     "AgentClient",
@@ -60,6 +61,7 @@ def build_agent_client(  # noqa: PLR0913
     host_resources: Iterable[HostResource] = (),
     project_path_policy: ProjectPathPolicy | None = None,
     require_host_sandbox: bool = False,
+    session_store: SessionStore | None = None,
 ) -> AgentClient:
     """Build an agent service through the application composition module."""
     from .factory import build_agent_client as build  # noqa: PLC0415
@@ -80,4 +82,5 @@ def build_agent_client(  # noqa: PLR0913
         host_resources=host_resources,
         project_path_policy=project_path_policy,
         require_host_sandbox=require_host_sandbox,
+        session_store=session_store,
     )

--- a/src/vibesys/agents/cli_runner.py
+++ b/src/vibesys/agents/cli_runner.py
@@ -53,6 +53,7 @@ from vibesys.agents.cli_common import (
 from vibesys.agents.contracts import AgentCapabilities
 from vibesys.agents.host_resource_declarations import declare_agent_host_resources
 from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
+from vibesys.agents.session_key import AgentSessionKey  # noqa: TC001  # tracked: #288
 from vibesys.constants import ComputeBackend  # noqa: TC001  # tracked: #288
 from vs_sandbox import HostResource, ProjectPathPolicy, build_host_sandbox
 
@@ -216,7 +217,7 @@ class CliAgentRunner:
         mcp_servers: list[MCPServerSpec] | None = None,
         tools: list[BaseTool] | None = None,  # noqa: ARG002 — deepagents-only injection point; cli uses mcp_servers
         reuse_session: bool | None = None,
-        session_key: str | None = None,
+        session_key: AgentSessionKey | None = None,
     ) -> T:
         native_schema_path: str | None = None
         native_schema_supported = bool(
@@ -305,7 +306,7 @@ class CliAgentRunner:
         mcp_servers: list[MCPServerSpec] | None = None,
         tools: list[BaseTool] | None = None,  # noqa: ARG002 — deepagents-only
         reuse_session: bool | None = None,
-        session_key: str | None = None,
+        session_key: AgentSessionKey | None = None,
     ) -> str:
         """Run a conversational CLI agent without requesting structured JSON."""
         text = self._generate(
@@ -345,7 +346,7 @@ class CliAgentRunner:
         progress: AgentProgress | None,
         mcp_servers: list[MCPServerSpec] | None,
         reuse_session: bool | None,
-        session_key: str | None,
+        session_key: AgentSessionKey | None,
         output_schema_path: str | None,
     ) -> str:
         """Run one CLI generation with shared setup, logging, and cleanup."""

--- a/src/vibesys/agents/client.py
+++ b/src/vibesys/agents/client.py
@@ -31,7 +31,9 @@ from vibesys.agents.contracts import (
     AgentUsage,
     MCPServerSpec,
     SessionDisposition,
+    session_spec_fingerprint,
 )
+from vibesys.agents.session_key import AgentSessionKey, SessionScope
 from vibesys.agents.session_store import NullSessionStore, SessionStore
 from vibesys.run.events import CommandResultPayload, JsonResultPayload
 
@@ -192,7 +194,7 @@ class AgentClient:
             require_enforcement=require_host_sandbox,
             containerized=containerized,
         )
-        self._sessions: dict[str, _CachedSession] = {}
+        self._sessions: dict[AgentSessionKey, _CachedSession] = {}
         self._closed = False
 
     @property
@@ -241,7 +243,7 @@ class AgentClient:
         mcp_servers: list[LegacyMCPServerSpec] | None = None,
         tools: list[BaseTool] | None = None,
         reuse_session: bool | None = None,
-        session_key: str | None = None,
+        session_key: AgentSessionKey | None = None,
     ) -> T:
         """Run one turn and parse its structured response."""
         del tools  # In-process tools remain a deepagents-only compatibility path.
@@ -292,7 +294,7 @@ class AgentClient:
         mcp_servers: list[LegacyMCPServerSpec] | None = None,
         tools: list[BaseTool] | None = None,
         reuse_session: bool | None = None,
-        session_key: str | None = None,
+        session_key: AgentSessionKey | None = None,
     ) -> str:
         """Run one conversational turn without a structured-output requirement."""
         del tools
@@ -333,7 +335,7 @@ class AgentClient:
         progress: AgentProgress | None,
         mcp_servers: list[LegacyMCPServerSpec] | None,
         reuse_session: bool | None,
-        session_key: str | None,
+        session_key: AgentSessionKey | None,
     ) -> AgentTurnResult:
         label = agent_label(kind)
         model = self._role_models.get(kind, self._model_name)
@@ -378,7 +380,10 @@ class AgentClient:
         log_and_print("--- input ---", self._run_log_file)
         log_prompt_markdown_and_print(f"{system_prompt}\n\n{user_prompt}", self._run_log_file)
         reuse = reuse_session if reuse_session is not None else True
-        cache_key = session_key or kind
+        # An unscoped call still needs one live conversation per role, but a
+        # bare role is not a conversation a later process could identify, so the
+        # fallback key deliberately lands in a scope that is never checkpointed.
+        cache_key = session_key or AgentSessionKey(SessionScope.ROLE, kind)
         result: AgentTurnResult | None = None
         observer = _LoggerObserver(logger)
         try:
@@ -442,7 +447,7 @@ class AgentClient:
         *,
         session_spec: AgentSessionSpec,
         turn: AgentTurnRequest,
-        session_key: str | None = None,
+        session_key: AgentSessionKey | None = None,
         observer: AgentObserver | None = None,
     ) -> AgentTurnResult:
         """Run one raw turn, optionally retaining its session for reuse."""
@@ -450,38 +455,31 @@ class AgentClient:
         if session_key is None:
             return self._run_ephemeral(session_spec, turn, observer)
 
+        fingerprint = session_spec_fingerprint(session_spec)
         cached = self._sessions.get(session_key)
-        seeded = False
         if cached is not None and cached.spec != session_spec:
-            # Provider/model/policy changed within this process: the persisted
-            # provider session no longer matches the new configuration, so drop
-            # both the live session and its durable ID before rebuilding.
+            # The configuration changed within this process. Drop the live
+            # session; the checkpoint is left alone because the fingerprint
+            # check below already refuses it, and this turn overwrites it.
             self._evict(session_key)
-            self._session_store.clear(session_key)
             cached = None
         if cached is None:
             session = self._create_session(session_spec)
-            # A fresh session on a resumed process starts with no in-memory
-            # conversation; seed the persisted provider session ID so the very
-            # first turn resumes (``codex exec resume`` / ``claude --resume``)
-            # instead of replaying the round.
-            seeded = self._seed_session(session, session_spec, session_key)
+            # A fresh session in a resumed process holds no conversation. Offer
+            # it the checkpointed provider ID so its very first turn resumes
+            # (``codex exec resume`` / ``claude --resume``) instead of replaying
+            # the round from scratch.
+            self._resume_checkpoint(session, session_key, fingerprint)
             cached = _CachedSession(spec=session_spec, session=session)
             self._sessions[session_key] = cached
 
         try:
             result = cached.session.run_turn(turn, observer)
         except BaseException as error:
-            if seeded:
-                # The first turn of a session just resumed from a persisted
-                # provider ID failed. That ID is most likely stale or deleted
-                # (Claude has no missing-rollout fallback), so forget it too:
-                # a retry or restart must start a fresh session instead of
-                # re-seeding the same failing ``--resume <id>`` indefinitely.
-                # A session that survives to a later call always had a
-                # successful turn (failure evicts here), so ``seeded`` is never
-                # set for a transient mid-conversation failure on a proven ID.
-                self._session_store.clear(session_key)
+            # The checkpoint is deliberately kept. A turn can fail for reasons
+            # that say nothing about the conversation's validity (a timeout, a
+            # cancelled run), and a driver that finds its conversation
+            # unusable reports RESET_REQUIRED instead of raising.
             try:
                 self._evict(session_key)
             except Exception as cleanup_error:  # noqa: BLE001  # preserve the turn failure
@@ -489,53 +487,52 @@ class AgentClient:
             raise
 
         if result.disposition is SessionDisposition.RESET_REQUIRED:
+            # The driver restarted or abandoned the conversation this key names,
+            # so both the live session and the checkpoint describe history that
+            # no longer exists.
             self._evict(session_key)
             self._session_store.clear(session_key)
         else:
-            self._persist_session(session_key, session_spec, result)
+            self._checkpoint(session_key, session_spec, fingerprint, result)
         return result
 
-    def _seed_session(
+    def _resume_checkpoint(
         self,
         session: AgentSession,
-        spec: AgentSessionSpec,
-        session_key: str,
-    ) -> bool:
-        """Seed a freshly created session with a matching persisted provider ID.
-
-        Return whether a stored ID was injected, so the caller can invalidate it
-        when the resumed session's first turn fails.
-        """
+        session_key: AgentSessionKey,
+        fingerprint: str,
+    ) -> None:
+        """Offer a freshly created session the checkpoint stored for its key."""
         record = self._session_store.get(session_key)
         if record is None:
-            return False
-        if record.provider != spec.provider or record.model != spec.model:
-            # A configuration change since the ID was stored: never resume with a
-            # mismatched provider/model. Leave the fresh session cold; the store
-            # is corrected once this turn persists a new ID.
-            return False
-        # ``seed_provider_session`` is an optional session capability; a driver
-        # whose provider cannot resume (or a session type without it) simply
-        # starts fresh, and a stale/deleted rollout falls back inside the driver.
-        seed = getattr(session, "seed_provider_session", None)
-        if callable(seed):
-            seed(record.session_id)
-            return True
-        return False
+            return
+        if record.spec_fingerprint != fingerprint:
+            # Configuration drifted since the checkpoint was written. Refusing
+            # it is the same rule that evicts a live session whose spec no
+            # longer matches; this turn replaces the entry.
+            self._session_store.clear(session_key)
+            return
+        if not session.resume_provider_session(record.session_id):
+            # The driver refused the ID, so nothing will ever resume it: the
+            # provider cannot resume at all, or the session already holds a
+            # newer conversation. Either way the checkpoint is dead.
+            self._session_store.clear(session_key)
 
-    def _persist_session(
+    def _checkpoint(
         self,
-        session_key: str,
+        session_key: AgentSessionKey,
         spec: AgentSessionSpec,
+        fingerprint: str,
         result: AgentTurnResult,
     ) -> None:
-        """Persist the provider session ID produced by a completed turn."""
+        """Checkpoint the provider session ID a completed turn reported."""
         if result.provider_session_id is None:
-            # No resumable ID this turn (e.g. a driver without session support);
-            # keep any prior ID rather than clobbering it with ``None``.
+            # No resumable ID this turn (e.g. a driver without provider session
+            # support); keep any prior ID rather than clobbering it with None.
             return
         self._session_store.record(
             session_key,
+            spec_fingerprint=fingerprint,
             provider=spec.provider,
             model=spec.model,
             session_id=result.provider_session_id,
@@ -583,7 +580,7 @@ class AgentClient:
                     raise
                 turn_error.add_note(f"agent session cleanup also failed: {cleanup_error}")
 
-    def _evict(self, key: str) -> None:
+    def _evict(self, key: AgentSessionKey) -> None:
         cached = self._sessions.pop(key, None)
         if cached is not None:
             cached.session.close()

--- a/src/vibesys/agents/client.py
+++ b/src/vibesys/agents/client.py
@@ -451,6 +451,7 @@ class AgentClient:
             return self._run_ephemeral(session_spec, turn, observer)
 
         cached = self._sessions.get(session_key)
+        seeded = False
         if cached is not None and cached.spec != session_spec:
             # Provider/model/policy changed within this process: the persisted
             # provider session no longer matches the new configuration, so drop
@@ -464,13 +465,23 @@ class AgentClient:
             # conversation; seed the persisted provider session ID so the very
             # first turn resumes (``codex exec resume`` / ``claude --resume``)
             # instead of replaying the round.
-            self._seed_session(session, session_spec, session_key)
+            seeded = self._seed_session(session, session_spec, session_key)
             cached = _CachedSession(spec=session_spec, session=session)
             self._sessions[session_key] = cached
 
         try:
             result = cached.session.run_turn(turn, observer)
         except BaseException as error:
+            if seeded:
+                # The first turn of a session just resumed from a persisted
+                # provider ID failed. That ID is most likely stale or deleted
+                # (Claude has no missing-rollout fallback), so forget it too:
+                # a retry or restart must start a fresh session instead of
+                # re-seeding the same failing ``--resume <id>`` indefinitely.
+                # A session that survives to a later call always had a
+                # successful turn (failure evicts here), so ``seeded`` is never
+                # set for a transient mid-conversation failure on a proven ID.
+                self._session_store.clear(session_key)
             try:
                 self._evict(session_key)
             except Exception as cleanup_error:  # noqa: BLE001  # preserve the turn failure
@@ -489,22 +500,28 @@ class AgentClient:
         session: AgentSession,
         spec: AgentSessionSpec,
         session_key: str,
-    ) -> None:
-        """Seed a freshly created session with a matching persisted provider ID."""
+    ) -> bool:
+        """Seed a freshly created session with a matching persisted provider ID.
+
+        Return whether a stored ID was injected, so the caller can invalidate it
+        when the resumed session's first turn fails.
+        """
         record = self._session_store.get(session_key)
         if record is None:
-            return
+            return False
         if record.provider != spec.provider or record.model != spec.model:
             # A configuration change since the ID was stored: never resume with a
             # mismatched provider/model. Leave the fresh session cold; the store
             # is corrected once this turn persists a new ID.
-            return
+            return False
         # ``seed_provider_session`` is an optional session capability; a driver
         # whose provider cannot resume (or a session type without it) simply
         # starts fresh, and a stale/deleted rollout falls back inside the driver.
         seed = getattr(session, "seed_provider_session", None)
         if callable(seed):
             seed(record.session_id)
+            return True
+        return False
 
     def _persist_session(
         self,

--- a/src/vibesys/agents/client.py
+++ b/src/vibesys/agents/client.py
@@ -32,6 +32,7 @@ from vibesys.agents.contracts import (
     MCPServerSpec,
     SessionDisposition,
 )
+from vibesys.agents.session_store import NullSessionStore, SessionStore
 from vibesys.run.events import CommandResultPayload, JsonResultPayload
 
 if TYPE_CHECKING:
@@ -168,10 +169,12 @@ class AgentClient:
         containerized: bool = False,
         driver_log: AgentDiagnosticLog | None = None,
         driver_name: str | None = None,
+        session_store: SessionStore | None = None,
     ) -> None:
         """Create a client that owns ``driver`` and every session it creates."""
         self._driver = driver
         self._driver_name = driver_name
+        self._session_store: SessionStore = session_store or NullSessionStore()
         self._provider = provider
         self._skills = tuple(skills)
         self._compute_backend = compute_backend
@@ -448,13 +451,21 @@ class AgentClient:
             return self._run_ephemeral(session_spec, turn, observer)
 
         cached = self._sessions.get(session_key)
-        if cached is None or cached.spec != session_spec:
-            if cached is not None:
-                self._evict(session_key)
-            cached = _CachedSession(
-                spec=session_spec,
-                session=self._create_session(session_spec),
-            )
+        if cached is not None and cached.spec != session_spec:
+            # Provider/model/policy changed within this process: the persisted
+            # provider session no longer matches the new configuration, so drop
+            # both the live session and its durable ID before rebuilding.
+            self._evict(session_key)
+            self._session_store.clear(session_key)
+            cached = None
+        if cached is None:
+            session = self._create_session(session_spec)
+            # A fresh session on a resumed process starts with no in-memory
+            # conversation; seed the persisted provider session ID so the very
+            # first turn resumes (``codex exec resume`` / ``claude --resume``)
+            # instead of replaying the round.
+            self._seed_session(session, session_spec, session_key)
+            cached = _CachedSession(spec=session_spec, session=session)
             self._sessions[session_key] = cached
 
         try:
@@ -468,7 +479,51 @@ class AgentClient:
 
         if result.disposition is SessionDisposition.RESET_REQUIRED:
             self._evict(session_key)
+            self._session_store.clear(session_key)
+        else:
+            self._persist_session(session_key, session_spec, result)
         return result
+
+    def _seed_session(
+        self,
+        session: AgentSession,
+        spec: AgentSessionSpec,
+        session_key: str,
+    ) -> None:
+        """Seed a freshly created session with a matching persisted provider ID."""
+        record = self._session_store.get(session_key)
+        if record is None:
+            return
+        if record.provider != spec.provider or record.model != spec.model:
+            # A configuration change since the ID was stored: never resume with a
+            # mismatched provider/model. Leave the fresh session cold; the store
+            # is corrected once this turn persists a new ID.
+            return
+        # ``seed_provider_session`` is an optional session capability; a driver
+        # whose provider cannot resume (or a session type without it) simply
+        # starts fresh, and a stale/deleted rollout falls back inside the driver.
+        seed = getattr(session, "seed_provider_session", None)
+        if callable(seed):
+            seed(record.session_id)
+
+    def _persist_session(
+        self,
+        session_key: str,
+        spec: AgentSessionSpec,
+        result: AgentTurnResult,
+    ) -> None:
+        """Persist the provider session ID produced by a completed turn."""
+        if result.provider_session_id is None:
+            # No resumable ID this turn (e.g. a driver without session support);
+            # keep any prior ID rather than clobbering it with ``None``.
+            return
+        self._session_store.record(
+            session_key,
+            provider=spec.provider,
+            model=spec.model,
+            session_id=result.provider_session_id,
+            role=spec.role,
+        )
 
     def close(self) -> None:
         """Close all cached sessions and the driver exactly once."""

--- a/src/vibesys/agents/contracts.py
+++ b/src/vibesys/agents/contracts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Protocol
@@ -70,6 +71,10 @@ class AgentCapabilities:
     container_execution: bool = False
     timeouts: bool = False
     session_reuse: bool = True
+    # Whether a session can adopt a provider conversation ID produced by an
+    # earlier process, so a resumed run continues the same conversation instead
+    # of replaying it. ``session_reuse`` only promises reuse within one process.
+    provider_session_resume: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -117,6 +122,19 @@ class AgentSessionSpec:
     reasoning_effort: str | None = None
 
 
+def session_spec_fingerprint(spec: AgentSessionSpec) -> str:
+    """Return a stable digest of the whole session spec.
+
+    ``AgentClient`` drops a cached session as soon as its spec stops matching
+    the requested one. A resumed process has no earlier spec object to compare
+    against, so it compares this digest instead: same inputs, same rule, so any
+    configuration change that would evict a live session also refuses a
+    checkpointed provider conversation. The digest is content-derived rather
+    than a Python ``hash``, which is not stable across processes.
+    """
+    return hashlib.sha256(repr(spec).encode("utf-8")).hexdigest()
+
+
 @dataclass(frozen=True, slots=True)
 class AgentTurnRequest:
     """Context added to an existing conversation for one agent turn."""
@@ -148,6 +166,21 @@ class AgentSession(Protocol):
         observer: AgentObserver | None = None,
     ) -> AgentTurnResult:
         """Add one turn to the conversation and return its raw result."""
+        ...
+
+    def resume_provider_session(self, session_id: str) -> bool:
+        """Continue ``session_id`` on this session's next turn.
+
+        Return whether the ID was actually adopted. A driver returns ``False``
+        when its provider cannot resume, or when the session already holds a
+        live conversation whose history is newer than the caller's checkpoint.
+        Callers must not assume adoption: the return value, not the call, is
+        what says the next turn resumes.
+
+        Implementations that report ``False`` must leave the session usable and
+        unchanged. Drivers whose capabilities set ``provider_session_resume``
+        to ``False`` always return ``False``.
+        """
         ...
 
     def close(self) -> None:

--- a/src/vibesys/agents/deepagents_runner.py
+++ b/src/vibesys/agents/deepagents_runner.py
@@ -29,6 +29,7 @@ from vibesys.agents.callbacks import AgentLogger
 from vibesys.agents.client import AgentClient
 from vibesys.agents.contracts import AgentCapabilities
 from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
+from vibesys.agents.session_key import AgentSessionKey  # noqa: TC001  # tracked: #288
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -87,7 +88,7 @@ class DeepAgentsClient(AgentClient):
         return checkpointer
 
     def _session(
-        self, *, kind: str, reuse_session: bool | None, session_key: str | None
+        self, *, kind: str, reuse_session: bool | None, session_key: AgentSessionKey | None
     ) -> tuple[MemorySaver, str]:
         """Return a fresh thread by default, or a durable thread for a key."""
         checkpointer = self._checkpointer(kind)
@@ -150,7 +151,7 @@ class DeepAgentsClient(AgentClient):
         mcp_servers: list[MCPServerSpec] | None = None,  # noqa: ARG002 — cli-only injection point; deepagents uses tools=
         tools: list[BaseTool] | None = None,
         reuse_session: bool | None = None,
-        session_key: str | None = None,
+        session_key: AgentSessionKey | None = None,
     ) -> T:
         label = _agent_label(kind)
 
@@ -205,7 +206,7 @@ class DeepAgentsClient(AgentClient):
         mcp_servers: list[MCPServerSpec] | None = None,  # noqa: ARG002 — cli-only
         tools: list[BaseTool] | None = None,
         reuse_session: bool | None = None,
-        session_key: str | None = None,
+        session_key: AgentSessionKey | None = None,
     ) -> str:
         """Run a conversational agent without imposing a response schema."""
         _, thread_id = self._session(

--- a/src/vibesys/agents/drivers/agentshim.py
+++ b/src/vibesys/agents/drivers/agentshim.py
@@ -291,6 +291,21 @@ class AgentShimSession:
         self._closed = True
         self._event_handler.observer = None
 
+    def seed_provider_session(self, session_id: str) -> None:
+        """Resume a prior provider conversation on the next turn.
+
+        Sets the underlying agent's ``session_id`` so the first ``generate``
+        takes the resume branch (``codex exec resume`` / ``claude --resume``).
+        A live in-memory ID (a mid-run continuation) is never overwritten, and
+        a stale or deleted rollout falls back to a fresh session inside
+        ``_generate_with_stale_rollout_retry``.
+        """
+        if hasattr(self._agent, "session_id") and self._agent.session_id is None:
+            # Mirror the stale-rollout retry's cast: the concrete session-capable
+            # agents (codex, claude) expose a writable ``session_id``, but the
+            # structural ``CodingAgent`` type does not declare it as assignable.
+            cast("CodexCodingAgent", self._agent).session_id = session_id
+
     def _prepare_prompt(self, request: AgentTurnRequest) -> tuple[str, str | None]:
         response_cls = request.output_schema
         native_schema_path: str | None = None

--- a/src/vibesys/agents/drivers/agentshim.py
+++ b/src/vibesys/agents/drivers/agentshim.py
@@ -26,6 +26,7 @@ from vibesys.agents.contracts import (
     AgentTurnResult,
     AgentUsage,
     MCPServerSpec,
+    SessionDisposition,
 )
 from vibesys.agents.docker_executor import DockerCommandExecutor
 from vibesys.agents.host_resource_declarations import declare_agent_host_resources
@@ -38,6 +39,7 @@ AGENTSHIM_CAPABILITIES = AgentCapabilities(
     hidden_paths=True,
     timeouts=True,
     session_reuse=True,
+    provider_session_resume=True,
 )
 """Capabilities invariant across AgentShim host and container execution."""
 
@@ -212,6 +214,9 @@ class AgentShimSession:
         self._docker_sandboxes = docker_sandboxes
         self._log = log
         self._turn_count = 0
+        # Set when the provider conversation was dropped and restarted while
+        # serving the current turn, so the turn's result can report it.
+        self._restarted = False
         self._closed = False
 
     def run_turn(  # noqa: C901, D102, PLR0912  # tracked: #288
@@ -226,7 +231,7 @@ class AgentShimSession:
         self._refresh_container()
         prompt, schema_path = self._prepare_prompt(request)
         self._set_output_schema(schema_path)
-        self._renew_codex_thread_if_needed()
+        self._restarted = False
 
         in_container = self._docker_sandboxes is not None
         mcp_servers = [
@@ -243,7 +248,7 @@ class AgentShimSession:
 
         turn_error: BaseException | None = None
         try:
-            text = self._generate_with_stale_rollout_retry(
+            text = self._generate_with_restart_fallback(
                 prompt,
                 cwd=workspace_arg,
                 timeout=timeout,
@@ -280,10 +285,17 @@ class AgentShimSession:
             if turn_error is None and cleanup_error is not None:
                 raise cleanup_error
 
+        # Read the conversation ID before the thread-budget check, which may
+        # drop it: the caller still deserves to know which conversation ran.
+        provider_session_id = self._agent.session_id
+        restarted = self._restarted or self._renew_codex_thread_if_needed()
         return AgentTurnResult(
             text=text,
             usage=_usage_from_agent(self._agent),
-            provider_session_id=getattr(self._agent, "session_id", None),
+            provider_session_id=provider_session_id,
+            disposition=(
+                SessionDisposition.RESET_REQUIRED if restarted else SessionDisposition.REUSABLE
+            ),
         )
 
     def close(self) -> None:
@@ -291,20 +303,15 @@ class AgentShimSession:
         self._closed = True
         self._event_handler.observer = None
 
-    def seed_provider_session(self, session_id: str) -> None:
-        """Resume a prior provider conversation on the next turn.
+    def resume_provider_session(self, session_id: str) -> bool:
+        """Continue ``session_id`` on the next turn, if the agent accepts it.
 
-        Sets the underlying agent's ``session_id`` so the first ``generate``
-        takes the resume branch (``codex exec resume`` / ``claude --resume``).
-        A live in-memory ID (a mid-run continuation) is never overwritten, and
-        a stale or deleted rollout falls back to a fresh session inside
-        ``_generate_with_stale_rollout_retry``.
+        The agent adopts the ID only when its provider has a resume flag and no
+        conversation is already attached, so a mid-run continuation is never
+        overwritten by an older checkpoint. A stale or deleted transcript is
+        handled later, by the restart fallback around ``generate``.
         """
-        if hasattr(self._agent, "session_id") and self._agent.session_id is None:
-            # Mirror the stale-rollout retry's cast: the concrete session-capable
-            # agents (codex, claude) expose a writable ``session_id``, but the
-            # structural ``CodingAgent`` type does not declare it as assignable.
-            cast("CodexCodingAgent", self._agent).session_id = session_id
+        return self._agent.resume_from(session_id)
 
     def _prepare_prompt(self, request: AgentTurnRequest) -> tuple[str, str | None]:
         response_cls = request.output_schema
@@ -353,42 +360,70 @@ class AgentShimSession:
                 "without implementing set_output_schema_path()"
             )
 
-    def _renew_codex_thread_if_needed(self) -> None:
+    def _renew_codex_thread_if_needed(self) -> bool:
+        """Retire an over-budget Codex thread, reporting whether it was dropped.
+
+        Evaluated after a turn rather than before one, so the decision reads the
+        usage of the turn that just finished and the caller learns about the
+        restart from that turn's result instead of discovering it on the next.
+        """
         if self._provider != "codex":
-            return
+            return False
         reason = (
             f"{_MAX_CODEX_SESSION_TURNS} successful turns"
             if self._turn_count >= _MAX_CODEX_SESSION_TURNS
             else _heavy_codex_turn_reason(self._agent)
         )
         if reason is None:
-            return
+            return False
         self._log(
             f"renewing Codex thread after {reason}; durable workspace state remains authoritative."
         )
-        cast("CodexCodingAgent", self._agent).session_id = None
+        self._agent.forget_session()
         self._turn_count = 0
+        return True
 
-    def _generate_with_stale_rollout_retry(
+    def _generate_with_restart_fallback(
         self,
         prompt: str,
         *,
         cwd: str | None,
         timeout: int | None,
     ) -> str:
+        """Run one turn, retrying once from a fresh conversation if a resume failed.
+
+        Only a resumed turn is retried, and only once: with the conversation
+        dropped, the retry takes the fresh-session branch, so a second failure
+        is a real agent failure and propagates. The retry loses the earlier
+        conversation, which ``self._restarted`` reports to the caller.
+        """
         try:
             return self._agent.generate(prompt, cwd=cwd, timeout=timeout, silent=True)
         except RuntimeError as exc:
-            if not (
-                self._provider == "codex"
-                and getattr(self._agent, "session_id", None)
-                and _is_missing_codex_rollout(exc)
-            ):
+            if not self._is_failed_resume(exc):
                 raise
-            self._log("Codex session is no longer available; retrying with a fresh thread.")
-            cast("CodexCodingAgent", self._agent).session_id = None
+            self._log(
+                f"{self._provider} session is no longer available; "
+                "retrying this turn with a fresh conversation."
+            )
+            self._agent.forget_session()
             self._turn_count = 0
+            self._restarted = True
             return self._agent.generate(prompt, cwd=cwd, timeout=timeout, silent=True)
+
+    def _is_failed_resume(self, exc: RuntimeError) -> bool:
+        """Whether ``exc`` is a resumed turn failing because of the resume."""
+        if self._agent.session_id is None:
+            return False
+        if self._provider == "codex":
+            # Codex names the cause: the rollout the thread ID points at is gone.
+            return _is_missing_codex_rollout(exc)
+        # Claude Code reports a rejected ``--resume`` as a plain nonzero exit
+        # with no distinguishing message, and a session it will not resume is
+        # unrecoverable, so any failed resumed turn is retried once from a
+        # fresh conversation rather than being allowed to kill the run.
+        # Timeouts do not reach here: they raise ``subprocess.TimeoutExpired``.
+        return self._provider == "claude"
 
     def _refresh_container(self) -> None:
         if self._docker_sandboxes is None:

--- a/src/vibesys/agents/drivers/mock.py
+++ b/src/vibesys/agents/drivers/mock.py
@@ -189,6 +189,7 @@ class MockSession:
         self._playbook = playbook
         self._turns = 0
         self._closed = False
+        self._seeded_session_id: str | None = None
 
     def run_turn(
         self,
@@ -214,12 +215,18 @@ class MockSession:
         return AgentTurnResult(
             text=_scripted_turn_text(request, round_index),
             usage=_scripted_usage(round_index),
-            provider_session_id=f"mock-{self._spec.role}-{id(self):x}",
+            # A seeded session ID is echoed back so a resumed run's continuity
+            # is observable; otherwise each session mints its own stable ID.
+            provider_session_id=(self._seeded_session_id or f"mock-{self._spec.role}-{id(self):x}"),
         )
 
     def close(self) -> None:
         """Release this session. Idempotent; the mock owns no resources."""
         self._closed = True
+
+    def seed_provider_session(self, session_id: str) -> None:
+        """Record a resumed provider session so its continuity is observable."""
+        self._seeded_session_id = session_id
 
 
 class MockDriver:

--- a/src/vibesys/agents/drivers/mock.py
+++ b/src/vibesys/agents/drivers/mock.py
@@ -75,6 +75,7 @@ MOCK_CAPABILITIES = AgentCapabilities(
     container_execution=True,
     timeouts=True,
     session_reuse=True,
+    provider_session_resume=True,
 )
 """What the mock can honor without weakening the semantics it was handed.
 
@@ -189,7 +190,7 @@ class MockSession:
         self._playbook = playbook
         self._turns = 0
         self._closed = False
-        self._seeded_session_id: str | None = None
+        self._resumed_session_id: str | None = None
 
     def run_turn(
         self,
@@ -215,18 +216,21 @@ class MockSession:
         return AgentTurnResult(
             text=_scripted_turn_text(request, round_index),
             usage=_scripted_usage(round_index),
-            # A seeded session ID is echoed back so a resumed run's continuity
+            # An adopted session ID is echoed back so a resumed run's continuity
             # is observable; otherwise each session mints its own stable ID.
-            provider_session_id=(self._seeded_session_id or f"mock-{self._spec.role}-{id(self):x}"),
+            provider_session_id=(
+                self._resumed_session_id or f"mock-{self._spec.role}-{id(self):x}"
+            ),
         )
 
     def close(self) -> None:
         """Release this session. Idempotent; the mock owns no resources."""
         self._closed = True
 
-    def seed_provider_session(self, session_id: str) -> None:
-        """Record a resumed provider session so its continuity is observable."""
-        self._seeded_session_id = session_id
+    def resume_provider_session(self, session_id: str) -> bool:
+        """Adopt ``session_id`` so a resumed run's continuity is observable."""
+        self._resumed_session_id = session_id
+        return True
 
 
 class MockDriver:

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -520,6 +520,16 @@ class OmnigentSession:
                     self._failed = True
                 raise
 
+    def seed_provider_session(self, session_id: str) -> None:
+        """Resuming an Omnigent executor thread from disk is not yet supported.
+
+        Omnigent owns its executor's ``thread_id`` lifecycle internally, so a
+        persisted ID cannot be injected the way a CLI provider's can. The turn
+        starts a fresh conversation; cross-process resume is scoped to the
+        agentshim codex/claude providers.
+        """
+        del session_id
+
     def close(self) -> None:
         """Release the executor exactly once."""
         if self.owns_current_loop_thread():

--- a/src/vibesys/agents/drivers/omnigent.py
+++ b/src/vibesys/agents/drivers/omnigent.py
@@ -520,15 +520,17 @@ class OmnigentSession:
                     self._failed = True
                 raise
 
-    def seed_provider_session(self, session_id: str) -> None:
-        """Resuming an Omnigent executor thread from disk is not yet supported.
+    def resume_provider_session(self, session_id: str) -> bool:
+        """Refuse the checkpoint: Omnigent executors have no resume entry point.
 
-        Omnigent owns its executor's ``thread_id`` lifecycle internally, so a
-        persisted ID cannot be injected the way a CLI provider's can. The turn
-        starts a fresh conversation; cross-process resume is scoped to the
-        agentshim codex/claude providers.
+        Omnigent 0.10 owns its executor's conversation lifecycle internally and
+        exposes no way to attach a thread created by an earlier process, so
+        there is nothing to adopt and the turn starts a fresh conversation.
+        Reported through ``provider_session_resume=False`` as well, so callers
+        can tell before they build a session.
         """
         del session_id
+        return False
 
     def close(self) -> None:
         """Release the executor exactly once."""

--- a/src/vibesys/agents/factory.py
+++ b/src/vibesys/agents/factory.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import TextIO
 
+    from vibesys.agents.session_store import SessionStore
     from vibesys.config import Config
     from vibesys.constants import ComputeBackend
     from vs_sandbox import HostResource, ProjectPathPolicy
@@ -103,6 +104,7 @@ def build_agent_client(  # noqa: C901, PLR0912, PLR0913
     host_resources: Iterable[HostResource] = (),
     project_path_policy: ProjectPathPolicy | None = None,
     require_host_sandbox: bool = False,
+    session_store: SessionStore | None = None,
 ) -> AgentClient:
     """Build the configured application-level agent service."""
     host_resources = tuple(host_resources)
@@ -235,4 +237,5 @@ def build_agent_client(  # noqa: C901, PLR0912, PLR0913
         require_host_sandbox=require_host_sandbox,
         containerized=use_docker,
         driver_log=driver_log,
+        session_store=session_store,
     )

--- a/src/vibesys/agents/session_key.py
+++ b/src/vibesys/agents/session_key.py
@@ -1,0 +1,71 @@
+"""Typed identity of one reusable agent conversation.
+
+:class:`AgentClient` caches a live session per key and, for the scopes that opt
+in, checkpoints that session's provider conversation ID under the same key. The
+key therefore decides two things at once: which turns share a conversation, and
+which conversations survive a restart.
+
+The serialized form is ``"<scope>:<identifier>"``, e.g. ``"hypothesis:H-01"``,
+which is what the machine-local session map is keyed by on disk.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class SessionScope(StrEnum):
+    """What a reusable agent conversation is scoped to."""
+
+    HYPOTHESIS = "hypothesis"
+    """One hypothesis of an agent-loop run, shared by its implementer attempts."""
+
+    CHAT = "chat"
+    """One operator chat thread."""
+
+    ROLE = "role"
+    """A bare agent role, used when a caller names no narrower conversation."""
+
+
+#: Scopes whose conversations are checkpointed across processes. A scope opts in
+#: only when its conversation belongs to durable run state that a resumed run
+#: continues. ``ROLE`` deliberately stays out: it is the fallback key every
+#: unscoped call lands on, so persisting it would resume the judge, perf_eval,
+#: and profiler conversations of an earlier process against unrelated work.
+_DURABLE_SCOPES = frozenset({SessionScope.HYPOTHESIS, SessionScope.CHAT})
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSessionKey:
+    """Identity of one reusable agent conversation."""
+
+    scope: SessionScope
+    identifier: str
+
+    def __post_init__(self) -> None:
+        """Reject identifiers that cannot round-trip through the stored form."""
+        if not self.identifier:
+            raise ValueError(f"{self.scope.value} session key needs an identifier")  # noqa: TRY003  # tracked: #288
+
+    def __str__(self) -> str:
+        """Return the stored form, ``"<scope>:<identifier>"``."""
+        return f"{self.scope.value}:{self.identifier}"
+
+    @property
+    def durable(self) -> bool:
+        """Whether this conversation is checkpointed across processes."""
+        return self.scope in _DURABLE_SCOPES
+
+    @classmethod
+    def parse(cls, stored: str) -> AgentSessionKey:
+        """Parse the stored form, rejecting anything this version cannot own.
+
+        Raises:
+            ValueError: if ``stored`` has no scope separator, names a scope this
+                version does not define, or carries an empty identifier.
+        """
+        scope_text, separator, identifier = stored.partition(":")
+        if not separator:
+            raise ValueError(f"session key is missing a scope prefix: {stored!r}")  # noqa: TRY003  # tracked: #288
+        return cls(SessionScope(scope_text), identifier)

--- a/src/vibesys/agents/session_store.py
+++ b/src/vibesys/agents/session_store.py
@@ -1,40 +1,53 @@
-"""Durable, machine-local persistence of coding-agent provider session IDs.
+"""Durable, machine-local checkpoints of coding-agent provider session IDs.
 
-A provider session ID (a codex thread, a claude session) lets a resumed run
-continue an implementor's conversation with ``codex exec resume <id>`` /
+A provider session ID (a Codex thread, a Claude session) lets a resumed run
+continue an implementer's conversation with ``codex exec resume <id>`` /
 ``claude --resume <id>`` instead of replaying the round from a fresh command.
 The IDs are machine-local: the provider transcripts they name live under the
 invoking user's home, so they must persist in the run's *local* state
 namespace, never in the portable ``agent/state.json`` snapshot that travels
 across machines.
 
-The store records the provider and model alongside each ID so a resume with a
-mismatched configuration never seeds a stale session, and it is intentionally a
-thin key-value map keyed by the caller's ``session_key`` (e.g.
-``"hypothesis:H-01"``). Callers persist after each successful turn and clear on
-a configuration change or a provider-signalled reset; nothing here decides when
-a session is invalid.
+Each record stores the fingerprint of the session spec that produced it, so a
+resumed process refuses a checkpoint whose configuration has since changed,
+using the same comparison an in-process client makes before reusing a live
+session. Nothing here decides when a session is invalid: callers persist after
+each completed turn and clear when a driver reports a restart.
+
+The map is keyed by the stored form of an :class:`AgentSessionKey`, and only
+keys whose scope opts into durability are ever written (see
+:mod:`vibesys.agents.session_key`).
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from vibesys.agents.session_key import AgentSessionKey
+from vs_project import ProjectError
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from vs_project import StateSlot
 
 
 class ProviderSessionRecord(BaseModel):
-    """One persisted provider session, keyed by the caller's ``session_key``."""
+    """One checkpointed provider conversation."""
 
     model_config = ConfigDict(extra="forbid")
 
+    #: Digest of the :class:`~vibesys.agents.contracts.AgentSessionSpec` whose
+    #: turn produced ``session_id``. It is the whole resume decision: a
+    #: checkpoint is adopted only by a session built from an identical spec.
+    spec_fingerprint: str
+    session_id: str
+    #: Human-facing provenance for anyone reading ``sessions.json``. Never read
+    #: when deciding whether to resume; ``spec_fingerprint`` owns that.
     provider: str
     model: str | None = None
-    session_id: str
-    turn_count: int = 0
     role: str | None = None
 
 
@@ -46,29 +59,53 @@ class AgentSessionState(BaseModel):
     schema_version: Literal[1] = 1
     sessions: dict[str, ProviderSessionRecord] = Field(default_factory=dict)
 
+    @field_validator("sessions")
+    @classmethod
+    def _reject_unownable_keys(
+        cls, sessions: dict[str, ProviderSessionRecord]
+    ) -> dict[str, ProviderSessionRecord]:
+        """Require every stored key to be one this version may resume.
+
+        A key that does not parse, or whose scope does not opt into durability,
+        was written by a different contract. Rejecting the file is safe because
+        :class:`DurableSessionStore` treats a load failure as "no checkpoints"
+        and rewrites the map on the next completed turn.
+        """
+        for stored in sessions:
+            key = AgentSessionKey.parse(stored)
+            if not key.durable:
+                raise ValueError(f"session scope is not persistable: {stored!r}")  # noqa: TRY003  # tracked: #288
+        return sessions
+
 
 @runtime_checkable
 class SessionStore(Protocol):
-    """Persist and look up provider session IDs by ``session_key``."""
+    """Checkpoint and look up provider session IDs by session key.
 
-    def get(self, key: str) -> ProviderSessionRecord | None:
-        """Return the persisted session for ``key``, or ``None``."""
+    Implementations must never raise. A store is a cache of an optimization
+    (resuming instead of replaying), so a broken backing file degrades to no
+    persistence rather than failing the turn that tried to use it.
+    """
+
+    def get(self, key: AgentSessionKey) -> ProviderSessionRecord | None:
+        """Return the checkpoint for ``key``, or ``None``."""
         ...
 
-    def record(
+    def record(  # noqa: PLR0913
         self,
-        key: str,
+        key: AgentSessionKey,
         *,
+        spec_fingerprint: str,
         provider: str,
         model: str | None,
         session_id: str,
         role: str | None = None,
     ) -> None:
-        """Persist ``session_id`` for ``key``, bumping its turn count."""
+        """Checkpoint ``session_id`` for ``key``, replacing any earlier one."""
         ...
 
-    def clear(self, key: str) -> None:
-        """Forget any persisted session for ``key``."""
+    def clear(self, key: AgentSessionKey) -> None:
+        """Forget any checkpoint for ``key``."""
         ...
 
 
@@ -80,67 +117,107 @@ class NullSessionStore:
     dependency of :class:`~vibesys.agents.client.AgentClient`.
     """
 
-    def get(self, key: str) -> ProviderSessionRecord | None:  # noqa: D102, ARG002
+    def get(self, key: AgentSessionKey) -> ProviderSessionRecord | None:  # noqa: D102, ARG002
         return None
 
-    def record(  # noqa: D102
+    def record(  # noqa: D102, PLR0913
         self,
-        key: str,
+        key: AgentSessionKey,
         *,
+        spec_fingerprint: str,
         provider: str,
         model: str | None,
         session_id: str,
         role: str | None = None,
     ) -> None:
-        del key, provider, model, session_id, role
+        del key, spec_fingerprint, provider, model, session_id, role
 
-    def clear(self, key: str) -> None:  # noqa: D102, ARG002
+    def clear(self, key: AgentSessionKey) -> None:  # noqa: D102, ARG002
         return
+
+
+def _ignore_diagnostic(_message: str) -> None:
+    """Discard a store diagnostic when no log sink was configured."""
 
 
 class DurableSessionStore:
     """A :class:`SessionStore` backed by one machine-local state slot.
 
-    Each mutation reloads the slot before writing so the on-disk map is the
-    source of truth even across process restarts; the file is small and written
-    at most once per agent turn.
+    Each operation reloads the slot so the on-disk map, not an in-memory cache,
+    is the source of truth across process restarts; the file is small and
+    written at most once per agent turn.
+
+    Every filesystem and schema failure is reported through ``log`` and then
+    swallowed: a malformed or unreadable map degrades this run to no session
+    persistence, and the next completed turn overwrites it with a valid one.
+    Keys whose scope does not opt into durability are ignored, so a caller
+    that falls back to a role key never leaves a checkpoint behind.
     """
 
-    def __init__(self, slot: StateSlot[AgentSessionState]) -> None:
+    def __init__(
+        self,
+        slot: StateSlot[AgentSessionState],
+        *,
+        log: Callable[[str], None] = _ignore_diagnostic,
+    ) -> None:
         """Bind the store to a local-namespace ``sessions.json`` slot."""
         self._slot = slot
+        self._log = log
 
-    def _load(self) -> AgentSessionState:
-        return self._slot.load_optional() or AgentSessionState()
+    def get(self, key: AgentSessionKey) -> ProviderSessionRecord | None:
+        """Return the checkpoint for ``key``, or ``None``."""
+        if not key.durable:
+            return None
+        return self._load().sessions.get(str(key))
 
-    def get(self, key: str) -> ProviderSessionRecord | None:
-        """Return the persisted session for ``key``, or ``None``."""
-        return self._load().sessions.get(key)
-
-    def record(
+    def record(  # noqa: PLR0913
         self,
-        key: str,
+        key: AgentSessionKey,
         *,
+        spec_fingerprint: str,
         provider: str,
         model: str | None,
         session_id: str,
         role: str | None = None,
     ) -> None:
-        """Persist ``session_id`` for ``key``, bumping its turn count."""
+        """Checkpoint ``session_id`` for ``key``, replacing any earlier one."""
+        if not key.durable:
+            # Not an error: unscoped calls fall back to a role key, and those
+            # conversations belong to one process only.
+            return
         state = self._load()
-        previous = state.sessions.get(key)
-        turn_count = (previous.turn_count if previous is not None else 0) + 1
-        state.sessions[key] = ProviderSessionRecord(
+        state.sessions[str(key)] = ProviderSessionRecord(
+            spec_fingerprint=spec_fingerprint,
+            session_id=session_id,
             provider=provider,
             model=model,
-            session_id=session_id,
-            turn_count=turn_count,
             role=role,
         )
-        self._slot.save(state)
+        self._save(state)
 
-    def clear(self, key: str) -> None:
-        """Forget any persisted session for ``key``."""
+    def clear(self, key: AgentSessionKey) -> None:
+        """Forget any checkpoint for ``key``."""
+        if not key.durable:
+            return
         state = self._load()
-        if state.sessions.pop(key, None) is not None:
+        if state.sessions.pop(str(key), None) is not None:
+            self._save(state)
+
+    def _load(self) -> AgentSessionState:
+        try:
+            return self._slot.load_optional() or AgentSessionState()
+        except (ProjectError, OSError) as exc:
+            self._log(
+                "[agent-session] ignoring unreadable provider-session checkpoints; "
+                f"this run will not resume conversations: {type(exc).__name__}: {exc}"
+            )
+            return AgentSessionState()
+
+    def _save(self, state: AgentSessionState) -> None:
+        try:
             self._slot.save(state)
+        except (ProjectError, OSError) as exc:
+            self._log(
+                "[agent-session] could not checkpoint the provider session; "
+                f"the completed turn is unaffected: {type(exc).__name__}: {exc}"
+            )

--- a/src/vibesys/agents/session_store.py
+++ b/src/vibesys/agents/session_store.py
@@ -1,0 +1,146 @@
+"""Durable, machine-local persistence of coding-agent provider session IDs.
+
+A provider session ID (a codex thread, a claude session) lets a resumed run
+continue an implementor's conversation with ``codex exec resume <id>`` /
+``claude --resume <id>`` instead of replaying the round from a fresh command.
+The IDs are machine-local: the provider transcripts they name live under the
+invoking user's home, so they must persist in the run's *local* state
+namespace, never in the portable ``agent/state.json`` snapshot that travels
+across machines.
+
+The store records the provider and model alongside each ID so a resume with a
+mismatched configuration never seeds a stale session, and it is intentionally a
+thin key-value map keyed by the caller's ``session_key`` (e.g.
+``"hypothesis:H-01"``). Callers persist after each successful turn and clear on
+a configuration change or a provider-signalled reset; nothing here decides when
+a session is invalid.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from vs_project import StateSlot
+
+
+class ProviderSessionRecord(BaseModel):
+    """One persisted provider session, keyed by the caller's ``session_key``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str
+    model: str | None = None
+    session_id: str
+    turn_count: int = 0
+    role: str | None = None
+
+
+class AgentSessionState(BaseModel):
+    """The machine-local session map for one run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    sessions: dict[str, ProviderSessionRecord] = Field(default_factory=dict)
+
+
+@runtime_checkable
+class SessionStore(Protocol):
+    """Persist and look up provider session IDs by ``session_key``."""
+
+    def get(self, key: str) -> ProviderSessionRecord | None:
+        """Return the persisted session for ``key``, or ``None``."""
+        ...
+
+    def record(
+        self,
+        key: str,
+        *,
+        provider: str,
+        model: str | None,
+        session_id: str,
+        role: str | None = None,
+    ) -> None:
+        """Persist ``session_id`` for ``key``, bumping its turn count."""
+        ...
+
+    def clear(self, key: str) -> None:
+        """Forget any persisted session for ``key``."""
+        ...
+
+
+class NullSessionStore:
+    """A no-op store: nothing is persisted, every lookup misses.
+
+    The default when no durable namespace is wired (ephemeral runs, tests, and
+    non-agent loops), so session persistence is opt-in and never a hard
+    dependency of :class:`~vibesys.agents.client.AgentClient`.
+    """
+
+    def get(self, key: str) -> ProviderSessionRecord | None:  # noqa: D102, ARG002
+        return None
+
+    def record(  # noqa: D102
+        self,
+        key: str,
+        *,
+        provider: str,
+        model: str | None,
+        session_id: str,
+        role: str | None = None,
+    ) -> None:
+        del key, provider, model, session_id, role
+
+    def clear(self, key: str) -> None:  # noqa: D102, ARG002
+        return
+
+
+class DurableSessionStore:
+    """A :class:`SessionStore` backed by one machine-local state slot.
+
+    Each mutation reloads the slot before writing so the on-disk map is the
+    source of truth even across process restarts; the file is small and written
+    at most once per agent turn.
+    """
+
+    def __init__(self, slot: StateSlot[AgentSessionState]) -> None:
+        """Bind the store to a local-namespace ``sessions.json`` slot."""
+        self._slot = slot
+
+    def _load(self) -> AgentSessionState:
+        return self._slot.load_optional() or AgentSessionState()
+
+    def get(self, key: str) -> ProviderSessionRecord | None:
+        """Return the persisted session for ``key``, or ``None``."""
+        return self._load().sessions.get(key)
+
+    def record(
+        self,
+        key: str,
+        *,
+        provider: str,
+        model: str | None,
+        session_id: str,
+        role: str | None = None,
+    ) -> None:
+        """Persist ``session_id`` for ``key``, bumping its turn count."""
+        state = self._load()
+        previous = state.sessions.get(key)
+        turn_count = (previous.turn_count if previous is not None else 0) + 1
+        state.sessions[key] = ProviderSessionRecord(
+            provider=provider,
+            model=model,
+            session_id=session_id,
+            turn_count=turn_count,
+            role=role,
+        )
+        self._slot.save(state)
+
+    def clear(self, key: str) -> None:
+        """Forget any persisted session for ``key``."""
+        state = self._load()
+        if state.sessions.pop(key, None) is not None:
+            self._slot.save(state)

--- a/src/vibesys/agents/stub_runner.py
+++ b/src/vibesys/agents/stub_runner.py
@@ -13,6 +13,7 @@ from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #28
 from vibesys.agents.contracts import AgentCapabilities
 from vibesys.agents.progress import AgentProgress  # noqa: TC001  # tracked: #288
 from vibesys.agents.scripted_rounds import round_number_from_label, scripted_round_payload
+from vibesys.agents.session_key import AgentSessionKey  # noqa: TC001  # tracked: #288
 
 if TYPE_CHECKING:
     from langchain_core.tools import BaseTool  # annotation only; avoid eager agent-stack import
@@ -86,7 +87,7 @@ class StubAgentClient:
         mcp_servers: list[MCPServerSpec] | None = None,
         tools: list[BaseTool] | None = None,
         reuse_session: bool | None = None,
-        session_key: str | None = None,
+        session_key: AgentSessionKey | None = None,
     ) -> str:
         """Return a deterministic answer for auxiliary-agent smoke tests."""
         del (

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -900,16 +900,17 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
             evaluator_tool_roots=evaluator_tool_roots,
         )
 
+        run_state = RunState(project, git, run_id)
+
         with boot_trace.span("agent_client_build"):
-            # Persist coding-agent provider session IDs in the run's
+            # Checkpoint coding-agent provider session IDs in the run's
             # machine-local namespace so a resumed run can continue the
-            # implementor's conversation instead of replaying the round. The
-            # store lives beside completed rounds under the local (never
-            # snapshotted) namespace because provider transcripts are host-local.
+            # implementer's conversation instead of replaying the round. The
+            # map lives under the local (never snapshotted) namespace because
+            # the provider transcripts it names are host-local.
             agent_session_store = DurableSessionStore(
-                project_state.local_namespace(run_id, RunStateNamespace.AGENT.value).slot(
-                    "sessions.json", AgentSessionState
-                )
+                run_state.local(RunStateNamespace.AGENT).slot("sessions.json", AgentSessionState),
+                log=logger.lprint,
             )
             # Build the backend-agnostic agent client. Loops invoke this instead
             # of calling create_deep_agent / vibesys._agent_cli directly. The cli
@@ -986,7 +987,7 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
             device=device,
             agent_client=agent_client,
             project=project,
-            state=RunState(project, git, run_id),
+            state=run_state,
             run_id=run_id,
             round_transaction_coordinator=round_transaction_coordinator,
             agent_host_resources=agent_host_resources,
@@ -1172,6 +1173,11 @@ def _assemble_candidate_context(  # noqa: PLR0913  # tracked: #288
         profiler_benchmark_command=session.view.paths.benchmark_command,
     )
 
+    # No session store: an evolve candidate names no conversation narrower than
+    # an agent role, so every one of its turns lands on a role-scoped key, and
+    # role-scoped conversations are never checkpointed (they belong to one
+    # process). Candidates also share the parent's run ID and local namespace
+    # and run concurrently, so a single per-run map would alias them anyway.
     agent_client = build_agent_client(
         config,
         agent_backend=agent_backend,

--- a/src/vibesys/context.py
+++ b/src/vibesys/context.py
@@ -22,6 +22,7 @@ from vibesys.agents.factory import (
 )
 from vibesys.agents.host_resource_declarations import task_agent_host_resources
 from vibesys.agents.progress import AgentProgress
+from vibesys.agents.session_store import AgentSessionState, DurableSessionStore
 from vibesys.backends.base import ComputeBackendImpl, ContentionMonitor
 from vibesys.config import Config, as_config
 from vibesys.constants import (
@@ -900,6 +901,16 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
         )
 
         with boot_trace.span("agent_client_build"):
+            # Persist coding-agent provider session IDs in the run's
+            # machine-local namespace so a resumed run can continue the
+            # implementor's conversation instead of replaying the round. The
+            # store lives beside completed rounds under the local (never
+            # snapshotted) namespace because provider transcripts are host-local.
+            agent_session_store = DurableSessionStore(
+                project_state.local_namespace(run_id, RunStateNamespace.AGENT.value).slot(
+                    "sessions.json", AgentSessionState
+                )
+            )
             # Build the backend-agnostic agent client. Loops invoke this instead
             # of calling create_deep_agent / vibesys._agent_cli directly. The cli
             # backend is rejected if --docker is set; build_agent_client raises
@@ -908,6 +919,7 @@ def _assemble_run_context(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: 
                 config,
                 agent_backend=agent_backend,
                 cli_provider=cli_provider,
+                session_store=agent_session_store,
                 backends={
                     "implementer": session.sandbox,
                     "judge": session.sandbox,

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -3461,6 +3461,9 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     perf_baseline_metric=baseline_metric,
                     perf_delta_pct=perf_delta_pct,
                     perf_comparison=perf_comparison,
+                    implementer_driver=ctx.agent_client.driver_name,
+                    implementer_provider=ctx.agent_client.provider,
+                    implementer_model=ctx.agent_client.model_for_kind("implementer"),
                 )
                 # Compute the completed lifecycle transition in memory so its
                 # exact representation can enter the write-ahead journal before

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -20,6 +20,7 @@ from typing import Any, Literal
 from vibesys.agents.base import ResponseFallback
 from vibesys.agents.factory import resolve_agent_driver
 from vibesys.agents.progress import RoundProgress
+from vibesys.agents.session_key import AgentSessionKey, SessionScope
 from vibesys.config import Config, as_config
 from vibesys.constants import DEFAULT_AGENT_BACKEND, DEFAULT_COMPUTE_BACKEND, ComputeBackend
 from vibesys.context import create_run_context
@@ -1250,7 +1251,7 @@ def _run_implementer(  # noqa: PLR0913  # tracked: #288
             fallback_factory=fallback,
             round_label=f"round-{round_number}-retry-{retry}-implementer",
             reuse_session=True,
-            session_key=f"hypothesis:{plan.hypothesis_id}",
+            session_key=AgentSessionKey(SessionScope.HYPOTHESIS, plan.hypothesis_id),
         )
     except subprocess.TimeoutExpired as exc:
         timed_out = True
@@ -1538,7 +1539,7 @@ def _run_single_agent_round(  # noqa: PLR0913  # tracked: #288
         ),
         round_label=f"round-{round_number}-retry-{retry}-single-agent",
         reuse_session=True,
-        session_key=f"hypothesis:{plan.hypothesis_id}",
+        session_key=AgentSessionKey(SessionScope.HYPOTHESIS, plan.hypothesis_id),
     )
     response.skill_context_updates, _ = _validate_skill_selections(
         ctx, response.skill_context_updates

--- a/src/vibesys/loops/plain/runner_ext.py
+++ b/src/vibesys/loops/plain/runner_ext.py
@@ -29,6 +29,7 @@ from vibesys._agent_cli.base import MCPServerSpec  # noqa: TC001  # tracked: #28
 from vibesys.agents.client import AgentClient
 from vibesys.agents.contracts import AgentCapabilities  # noqa: TC001
 from vibesys.agents.progress import AgentProgress  # noqa: TC001
+from vibesys.agents.session_key import AgentSessionKey  # noqa: TC001
 from vibesys.loops.plain.mcp_config import build_issue_mcp_spec
 from vibesys.loops.plain.tools import build_issue_tools
 from vs_issue_board import IssueBoard, IssueType
@@ -99,7 +100,7 @@ class PlainLoopAgentClient(AgentClient):
         mcp_servers: list[MCPServerSpec] | None = None,
         tools: list[BaseTool] | None = None,
         reuse_session: bool | None = None,
-        session_key: str | None = None,
+        session_key: AgentSessionKey | None = None,
     ) -> str:
         """Delegate an unstructured turn without changing tracker policy."""
         return self._inner.invoke_text(

--- a/tests/vibesys/_agent_cli/test_codex.py
+++ b/tests/vibesys/_agent_cli/test_codex.py
@@ -22,6 +22,7 @@ from vibesys._agent_cli.codex import (
     CodexGenerationSession,
     _shell_path_config_args,
 )
+from vibesys._agent_cli.gemini import GeminiCodingAgent
 
 
 def _agent() -> CodexCodingAgent:
@@ -380,3 +381,44 @@ class TestProcessStderr:
         session = _session(event_handler=handler)
         session._process_stderr("\n")  # noqa: SLF001  # tracked: #288
         handler.on_thinking.assert_not_called()
+
+
+def test_resume_from_adopts_a_checkpoint_when_no_conversation_is_live() -> None:
+    agent = _agent()
+    agent.session_id = None
+
+    assert agent.resume_from("thread-checkpoint") is True
+    assert agent.session_id == "thread-checkpoint"
+    assert agent._get_resume_command("prompt", "thread-checkpoint")[:4] == [  # noqa: SLF001
+        "/usr/local/bin/codex",
+        "exec",
+        "resume",
+        "thread-checkpoint",
+    ]
+
+
+def test_resume_from_refuses_to_replace_a_live_conversation() -> None:
+    agent = _agent()
+    agent.session_id = "thread-live"
+
+    assert agent.resume_from("thread-checkpoint") is False
+    assert agent.session_id == "thread-live"
+
+
+def test_forget_session_starts_the_next_turn_fresh() -> None:
+    agent = _agent()
+    agent.session_id = "thread-live"
+
+    agent.forget_session()
+    agent.forget_session()  # idempotent
+
+    assert agent.session_id is None
+
+
+def test_a_provider_without_a_resume_flag_never_adopts_a_checkpoint() -> None:
+    agent = GeminiCodingAgent.__new__(GeminiCodingAgent)
+    agent.session_id = None
+
+    assert agent.supports_session_resume is False
+    assert agent.resume_from("thread-checkpoint") is False
+    assert agent.session_id is None

--- a/tests/vibesys/agents/drivers/test_agentshim_driver.py
+++ b/tests/vibesys/agents/drivers/test_agentshim_driver.py
@@ -50,6 +50,7 @@ class _FakeAgent:
     supports_native_output_schema = False
     native_output_schema_allows_arbitrary_keys = False
     native_output_schema_wants_absolute_path = False
+    supports_session_resume = True
 
     def __init__(
         self,
@@ -82,6 +83,17 @@ class _FakeAgent:
 
     def set_reasoning_effort(self, effort: str) -> None:
         self.reasoning_effort = effort
+
+    def resume_from(self, session_id: str) -> bool:
+        # Same rule as ``CodingAgent.resume_from``; see the dedicated tests in
+        # tests/vibesys/_agent_cli/test_session_resume.py for the real thing.
+        if not self.supports_session_resume or self.session_id is not None:
+            return False
+        self.session_id = session_id
+        return True
+
+    def forget_session(self) -> None:
+        self.session_id = None
 
     def set_output_schema_path(self, path: str | None) -> None:
         self.output_schema_paths.append(path)
@@ -360,3 +372,176 @@ def test_driver_and_session_close_are_idempotent(
         session.run_turn(AgentTurnRequest(message="later"))
     with pytest.raises(RuntimeError, match="closed"):
         driver.create_session(_spec(tmp_path))
+
+
+def test_capabilities_declare_cross_process_provider_session_resume() -> None:
+    assert subject.AgentShimDriver(provider="codex").capabilities.provider_session_resume
+
+
+def test_resume_adopts_a_checkpoint_when_no_conversation_is_live(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    driver = subject.AgentShimDriver(provider="codex")
+    session = driver.create_session(_spec(tmp_path))
+    fake_agent[0].session_id = None
+
+    assert session.resume_provider_session("thread-checkpoint") is True
+    assert fake_agent[0].session_id == "thread-checkpoint"
+
+
+def test_resume_refuses_when_a_conversation_is_already_live(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    driver = subject.AgentShimDriver(provider="codex")
+    session = driver.create_session(_spec(tmp_path))
+
+    # The live conversation is newer than any checkpoint the caller holds.
+    assert session.resume_provider_session("thread-checkpoint") is False
+    assert fake_agent[0].session_id == "session-1"
+
+
+def test_resume_refuses_when_the_provider_cannot_resume(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    driver = subject.AgentShimDriver(provider="codex")
+    session = driver.create_session(_spec(tmp_path))
+    fake_agent[0].session_id = None
+    fake_agent[0].supports_session_resume = False
+
+    assert session.resume_provider_session("thread-checkpoint") is False
+    assert fake_agent[0].session_id is None
+
+
+def test_a_turn_that_kept_its_conversation_stays_reusable(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    driver = subject.AgentShimDriver(provider="codex")
+    session = driver.create_session(_spec(tmp_path))
+
+    result = session.run_turn(AgentTurnRequest(message="one"))
+
+    assert result.disposition is subject.SessionDisposition.REUSABLE
+    assert fake_agent[0].session_id == "session-1"
+
+
+def test_codex_thread_budget_renewal_reports_a_reset(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    driver = subject.AgentShimDriver(provider="codex")
+    session = driver.create_session(_spec(tmp_path))
+
+    first = session.run_turn(AgentTurnRequest(message="one"))
+    second = session.run_turn(AgentTurnRequest(message="two"))
+
+    assert first.disposition is subject.SessionDisposition.REUSABLE
+    # The budget is spent, so the thread is retired and the caller is told the
+    # conversation this session named no longer exists.
+    assert second.disposition is subject.SessionDisposition.RESET_REQUIRED
+    assert second.provider_session_id == "session-1"
+    assert fake_agent[0].session_id is None
+
+
+def test_heavy_codex_turn_renewal_reports_a_reset(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    driver = subject.AgentShimDriver(provider="codex")
+    session = driver.create_session(_spec(tmp_path))
+    fake_agent[0]._last_session.final_usage = {"input_tokens": 20_000_000}  # noqa: SLF001
+
+    result = session.run_turn(AgentTurnRequest(message="one"))
+
+    assert result.disposition is subject.SessionDisposition.RESET_REQUIRED
+    assert fake_agent[0].session_id is None
+
+
+def test_missing_codex_rollout_retries_fresh_and_reports_a_reset(
+    fake_agent: list[_FakeAgent], tmp_path: Path
+) -> None:
+    driver = subject.AgentShimDriver(provider="codex")
+    session = driver.create_session(_spec(tmp_path))
+    agent = fake_agent[0]
+    attempts: list[str | None] = []
+
+    def generate(prompt: str, /, *, cwd: str | None, timeout: int | None, silent: bool) -> str:  # noqa: ARG001
+        attempts.append(agent.session_id)
+        if len(attempts) == 1:
+            raise RuntimeError(  # noqa: TRY003
+                "thread/resume failed: no rollout found for thread id session-1"
+            )
+        return "recovered"
+
+    agent.generate_override = generate
+
+    result = session.run_turn(AgentTurnRequest(message="one"))
+
+    assert result.text == "recovered"
+    assert attempts == ["session-1", None]
+    assert result.disposition is subject.SessionDisposition.RESET_REQUIRED
+
+
+def _claude_driver(
+    monkeypatch: pytest.MonkeyPatch, built: list[_FakeAgent]
+) -> subject.AgentShimDriver:
+    """Register the fake agent under ``claude`` and build a driver for it."""
+
+    def factory(
+        model: str | None = None,
+        event_handler: Any | None = None,  # noqa: ANN401  # tracked: #288
+        *,
+        executor: Any | None = None,  # noqa: ANN401  # tracked: #288
+    ) -> _FakeAgent:
+        agent = _FakeAgent(model, event_handler, executor=executor)
+        built.append(agent)
+        return agent
+
+    monkeypatch.setitem(subject._PROVIDER_CLASSES, "claude", factory)  # noqa: SLF001
+    monkeypatch.setattr(subject, "declare_agent_host_resources", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(subject, "build_host_sandbox", lambda *_args, **_kwargs: "sandbox")
+    return subject.AgentShimDriver(provider="claude")
+
+
+def test_stale_claude_session_retries_fresh_instead_of_killing_the_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    built: list[_FakeAgent] = []
+    driver = _claude_driver(monkeypatch, built)
+    session = driver.create_session(_spec(tmp_path, provider="claude"))
+    agent = built[0]
+    attempts: list[str | None] = []
+
+    def generate(prompt: str, /, *, cwd: str | None, timeout: int | None, silent: bool) -> str:  # noqa: ARG001
+        attempts.append(agent.session_id)
+        if len(attempts) == 1:
+            # Claude Code reports a refused resume as a bare nonzero exit.
+            raise RuntimeError("claude exited with code 1: ")  # noqa: TRY003
+        return "recovered"
+
+    agent.generate_override = generate
+
+    result = session.run_turn(AgentTurnRequest(message="one"))
+
+    assert result.text == "recovered"
+    assert attempts == ["session-1", None]
+    assert result.disposition is subject.SessionDisposition.RESET_REQUIRED
+
+
+def test_a_fresh_claude_turn_that_fails_is_not_retried(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    built: list[_FakeAgent] = []
+    driver = _claude_driver(monkeypatch, built)
+    session = driver.create_session(_spec(tmp_path, provider="claude"))
+    agent = built[0]
+    agent.session_id = None
+    attempts: list[str | None] = []
+
+    def generate(prompt: str, /, *, cwd: str | None, timeout: int | None, silent: bool) -> str:  # noqa: ARG001
+        attempts.append(agent.session_id)
+        raise RuntimeError("claude exited with code 1: ")  # noqa: TRY003
+
+    agent.generate_override = generate
+
+    # Nothing was resumed, so the failure is the agent's own and propagates.
+    with pytest.raises(RuntimeError):
+        session.run_turn(AgentTurnRequest(message="one"))
+    assert attempts == [None]

--- a/tests/vibesys/agents/test_agent_client.py
+++ b/tests/vibesys/agents/test_agent_client.py
@@ -23,6 +23,7 @@ from vibesys.agents.contracts import (
     AgentUsage,
     SessionDisposition,
 )
+from vibesys.agents.session_key import AgentSessionKey, SessionScope
 from vibesys.render.sink import output_sink
 from vibesys.run.events import (
     AgentOutputChunkData,
@@ -44,6 +45,7 @@ class _FakeSession:
     error: BaseException | None = None
     observers: list[AgentObserver | None] = field(default_factory=list)
     events: list[AgentEvent] = field(default_factory=list)
+    resumed: list[str] = field(default_factory=list)
 
     def run_turn(
         self,
@@ -58,6 +60,11 @@ class _FakeSession:
         if self.error is not None:
             raise self.error
         return self.results.pop(0)
+
+    def resume_provider_session(self, session_id: str) -> bool:
+        """Adopt ``session_id``, recording it so tests can assert on it."""
+        self.resumed.append(session_id)
+        return True
 
     def close(self) -> None:
         self.close_calls += 1
@@ -79,6 +86,10 @@ class _FakeDriver:
 
     def close(self) -> None:
         self.close_calls += 1
+
+
+def _key(identifier: str) -> AgentSessionKey:
+    return AgentSessionKey(SessionScope.HYPOTHESIS, identifier)
 
 
 def _spec(
@@ -105,11 +116,15 @@ def test_keyed_turns_reuse_a_session() -> None:
     client = AgentClient(driver)
 
     assert (
-        client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="impl").text
+        client.run(
+            session_spec=_spec(), turn=AgentTurnRequest("one"), session_key=_key("impl")
+        ).text
         == "first"
     )
     assert (
-        client.run(session_spec=_spec(), turn=AgentTurnRequest("two"), session_key="impl").text
+        client.run(
+            session_spec=_spec(), turn=AgentTurnRequest("two"), session_key=_key("impl")
+        ).text
         == "second"
     )
 
@@ -131,8 +146,8 @@ def test_session_setup_materializes_skills_once(
     )
     spec = _spec(workspace=tmp_path, skills=(skill,))
 
-    client.run(session_spec=spec, turn=AgentTurnRequest("one"), session_key="impl")
-    client.run(session_spec=spec, turn=AgentTurnRequest("two"), session_key="impl")
+    client.run(session_spec=spec, turn=AgentTurnRequest("one"), session_key=_key("impl"))
+    client.run(session_spec=spec, turn=AgentTurnRequest("two"), session_key=_key("impl"))
 
     assert calls == [(tmp_path, [skill])]
 
@@ -338,11 +353,11 @@ def test_changed_session_spec_closes_and_replaces_cached_session() -> None:
     driver = _FakeDriver([old, new])
     client = AgentClient(driver)
 
-    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="impl")
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key=_key("impl"))
     result = client.run(
         session_spec=_spec(model="changed"),
         turn=AgentTurnRequest("two"),
-        session_key="impl",
+        session_key=_key("impl"),
     )
 
     assert result.text == "new"
@@ -370,8 +385,8 @@ def test_reset_disposition_evicts_session(result: AgentTurnResult) -> None:
     driver = _FakeDriver([first, second])
     client = AgentClient(driver)
 
-    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="impl")
-    client.run(session_spec=_spec(), turn=AgentTurnRequest("two"), session_key="impl")
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key=_key("impl"))
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("two"), session_key=_key("impl"))
 
     assert first.close_calls == 1
     assert len(driver.specs) == 2
@@ -384,8 +399,10 @@ def test_turn_exception_evicts_session() -> None:
     client = AgentClient(driver)
 
     with pytest.raises(ValueError, match="failed"):
-        client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="impl")
-    result = client.run(session_spec=_spec(), turn=AgentTurnRequest("two"), session_key="impl")
+        client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key=_key("impl"))
+    result = client.run(
+        session_spec=_spec(), turn=AgentTurnRequest("two"), session_key=_key("impl")
+    )
 
     assert failed.close_calls == 1
     assert result.text == "ok"
@@ -395,7 +412,7 @@ def test_close_is_idempotent_and_rejects_future_turns() -> None:
     session = _FakeSession(results=[AgentTurnResult("ok")])
     driver = _FakeDriver([session])
     client = AgentClient(driver)
-    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="impl")
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key=_key("impl"))
 
     client.close()
     client.close()
@@ -431,7 +448,7 @@ def test_invoke_builds_session_and_turn_contracts_and_records_usage(tmp_path: Pa
         fallback_factory=lambda: _Response(answer="fallback"),
         round_label="judge #1",
         env={"VISIBLE": "1"},
-        session_key="review",
+        session_key=_key("review"),
     )
 
     assert response == _Response(answer="done")

--- a/tests/vibesys/agents/test_agent_runners.py
+++ b/tests/vibesys/agents/test_agent_runners.py
@@ -18,6 +18,7 @@ from vibesys.agents.client import AgentClient
 from vibesys.agents.deepagents_runner import DeepAgentsClient
 from vibesys.agents.drivers.agentshim import AgentShimDriver
 from vibesys.agents.progress import RoundProgress
+from vibesys.agents.session_key import AgentSessionKey, SessionScope
 from vibesys.config import Config
 from vibesys.constants import ComputeBackend
 from vibesys.schemas import (
@@ -201,12 +202,26 @@ class TestDeepAgentsClient:
             run_log_file=None,
         )
 
-        first = runner._session(kind="implementer", reuse_session=True, session_key="hypothesis:a")  # noqa: SLF001  # tracked: #288
-        continued = runner._session(  # noqa: SLF001  # tracked: #288
-            kind="implementer", reuse_session=True, session_key="hypothesis:a"
+        first = runner._session(  # noqa: SLF001  # tracked: #288
+            kind="implementer",
+            reuse_session=True,
+            session_key=AgentSessionKey(SessionScope.HYPOTHESIS, "a"),
         )
-        other_role = runner._session(kind="judge", reuse_session=True, session_key="hypothesis:a")  # noqa: SLF001  # tracked: #288
-        fresh = runner._session(kind="implementer", reuse_session=False, session_key="hypothesis:a")  # noqa: SLF001  # tracked: #288
+        continued = runner._session(  # noqa: SLF001  # tracked: #288
+            kind="implementer",
+            reuse_session=True,
+            session_key=AgentSessionKey(SessionScope.HYPOTHESIS, "a"),
+        )
+        other_role = runner._session(  # noqa: SLF001  # tracked: #288
+            kind="judge",
+            reuse_session=True,
+            session_key=AgentSessionKey(SessionScope.HYPOTHESIS, "a"),
+        )
+        fresh = runner._session(  # noqa: SLF001  # tracked: #288
+            kind="implementer",
+            reuse_session=False,
+            session_key=AgentSessionKey(SessionScope.HYPOTHESIS, "a"),
+        )
 
         assert continued is first
         assert other_role is not first
@@ -518,7 +533,7 @@ class TestCliAgentRunner:
         workspace = tmp_path / "ws"
         workspace.mkdir()
 
-        def invoke(*, session_key: str, reuse_session: bool) -> None:
+        def invoke(*, session_key: AgentSessionKey, reuse_session: bool) -> None:
             runner.invoke(
                 kind="judge",
                 workspace=workspace,
@@ -531,12 +546,12 @@ class TestCliAgentRunner:
                 session_key=session_key,
             )
 
-        invoke(session_key="hypothesis:a", reuse_session=True)
-        invoke(session_key="hypothesis:a", reuse_session=True)
+        invoke(session_key=AgentSessionKey(SessionScope.HYPOTHESIS, "a"), reuse_session=True)
+        invoke(session_key=AgentSessionKey(SessionScope.HYPOTHESIS, "a"), reuse_session=True)
         assert len(captured) == 1
-        invoke(session_key="hypothesis:b", reuse_session=True)
+        invoke(session_key=AgentSessionKey(SessionScope.HYPOTHESIS, "b"), reuse_session=True)
         assert len(captured) == 2
-        invoke(session_key="hypothesis:a", reuse_session=False)
+        invoke(session_key=AgentSessionKey(SessionScope.HYPOTHESIS, "a"), reuse_session=False)
         assert len(captured) == 3
 
     def test_codex_persistent_session_renews_before_third_turn(self, monkeypatch, tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
@@ -577,7 +592,7 @@ class TestCliAgentRunner:
                 fallback_factory=_judge_fallback,
                 round_label="review",
                 reuse_session=True,
-                session_key="hypothesis:a",
+                session_key=AgentSessionKey(SessionScope.HYPOTHESIS, "a"),
             )
 
         assert len(captured) == 1
@@ -640,7 +655,7 @@ class TestCliAgentRunner:
                 fallback_factory=_judge_fallback,
                 round_label="review",
                 reuse_session=True,
-                session_key="hypothesis:a",
+                session_key=AgentSessionKey(SessionScope.HYPOTHESIS, "a"),
             )
 
         assert session_ids == ["thread-1", "thread-2"]

--- a/tests/vibesys/agents/test_session_store.py
+++ b/tests/vibesys/agents/test_session_store.py
@@ -1,0 +1,297 @@
+"""Durable provider-session persistence and AgentClient seeding on resume.
+
+These tests exercise the machine-local session store in isolation and its
+integration with :class:`~vibesys.agents.client.AgentClient`: a fresh client
+(standing in for a resumed process) must seed a persisted provider session ID
+into the very first turn, but only when the stored provider/model still match
+the requested spec, and it must forget the ID on a reset or a spec change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from vibesys.agents.client import AgentClient
+from vibesys.agents.contracts import (
+    AgentCapabilities,
+    AgentExecutionPolicy,
+    AgentObserver,
+    AgentSession,
+    AgentSessionSpec,
+    AgentTurnRequest,
+    AgentTurnResult,
+    SessionDisposition,
+)
+from vibesys.agents.session_store import (
+    AgentSessionState,
+    DurableSessionStore,
+    NullSessionStore,
+)
+from vs_project import (
+    PlainRunConfiguration,
+    Project,
+    RunEnvironmentRecord,
+)
+
+
+def _project(tmp_path: Path) -> Project:
+    (tmp_path / "OBJECTIVE.md").write_text("Make it fast.\n", encoding="utf-8")
+    project = Project.open(tmp_path)
+    project.state.create_project("test")
+    run = project.state.new_run_manifest(
+        "test",
+        run_id="run-1",
+        branch="vibesys/run-1",
+        vibesys_version="test",
+        trusted_input_baseline="a" * 40,
+        configuration=PlainRunConfiguration(
+            outer_loop="plain",
+            run_environment=RunEnvironmentRecord(name="local"),
+            agent_backend="stub",
+            compute_backend="cpu",
+            max_rounds=2,
+            max_attempts_per_issue=1,
+            max_issues_per_perf_eval=1,
+        ),
+    )
+    project.state.create_run(run)
+    return project
+
+
+def _store(tmp_path: Path) -> DurableSessionStore:
+    project = _project(tmp_path)
+    slot = project.state.local_namespace("run-1", "agent").slot("sessions.json", AgentSessionState)
+    return DurableSessionStore(slot)
+
+
+# --- DurableSessionStore ---------------------------------------------------
+
+
+def test_record_then_get_returns_the_persisted_session(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    store.record(
+        "hypothesis:H-01",
+        provider="codex",
+        model="gpt-5.6-sol",
+        session_id="thread-abc",
+        role="implementer",
+    )
+    record = store.get("hypothesis:H-01")
+
+    assert record is not None
+    assert record.session_id == "thread-abc"
+    assert record.provider == "codex"
+    assert record.model == "gpt-5.6-sol"
+    assert record.role == "implementer"
+    assert record.turn_count == 1
+
+
+def test_get_misses_return_none(tmp_path: Path) -> None:
+    assert _store(tmp_path).get("hypothesis:absent") is None
+
+
+def test_record_bumps_turn_count_across_turns(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    store.record("k", provider="codex", model="m", session_id="s1")
+    store.record("k", provider="codex", model="m", session_id="s2")
+
+    record = store.get("k")
+    assert record is not None
+    assert record.session_id == "s2"
+    assert record.turn_count == 2
+
+
+def test_persisted_session_survives_a_new_store_instance(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    namespace = project.state.local_namespace("run-1", "agent")
+
+    DurableSessionStore(namespace.slot("sessions.json", AgentSessionState)).record(
+        "k", provider="codex", model="m", session_id="thread-xyz"
+    )
+    # A fresh instance over the same slot models a resumed process: the on-disk
+    # map, not any in-memory cache, is the source of truth.
+    reloaded = DurableSessionStore(namespace.slot("sessions.json", AgentSessionState)).get("k")
+
+    assert reloaded is not None
+    assert reloaded.session_id == "thread-xyz"
+
+
+def test_clear_forgets_only_the_named_key(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.record("keep", provider="codex", model="m", session_id="s-keep")
+    store.record("drop", provider="codex", model="m", session_id="s-drop")
+
+    store.clear("drop")
+
+    assert store.get("drop") is None
+    assert store.get("keep") is not None
+
+
+def test_clear_of_missing_key_is_a_noop(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.clear("never-recorded")  # must not raise
+    assert store.get("never-recorded") is None
+
+
+# --- NullSessionStore ------------------------------------------------------
+
+
+def test_null_store_persists_nothing_and_always_misses() -> None:
+    store = NullSessionStore()
+
+    store.record("k", provider="codex", model="m", session_id="s")
+    store.clear("k")
+
+    assert store.get("k") is None
+
+
+# --- AgentClient seeding on resume -----------------------------------------
+
+
+@dataclass
+class _SeedableSession:
+    """A fake session that records seeds and returns queued turn results."""
+
+    results: list[AgentTurnResult]
+    seeded: list[str] = field(default_factory=list)
+    close_calls: int = 0
+
+    def run_turn(
+        self,
+        request: AgentTurnRequest,  # noqa: ARG002
+        observer: AgentObserver | None = None,  # noqa: ARG002
+    ) -> AgentTurnResult:
+        return self.results.pop(0)
+
+    def seed_provider_session(self, session_id: str) -> None:
+        self.seeded.append(session_id)
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+@dataclass
+class _FakeDriver:
+    queued_sessions: list[_SeedableSession]
+    specs: list[AgentSessionSpec] = field(default_factory=list)
+    close_calls: int = 0
+
+    @property
+    def capabilities(self) -> AgentCapabilities:
+        return AgentCapabilities()
+
+    def create_session(self, spec: AgentSessionSpec) -> AgentSession:
+        self.specs.append(spec)
+        return self.queued_sessions.pop(0)
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def _spec(*, provider: str = "codex", model: str = "gpt-5.6-sol") -> AgentSessionSpec:
+    return AgentSessionSpec(
+        role="implementer",
+        provider=provider,
+        model=model,
+        workspace=Path("/workspace"),
+        policy=AgentExecutionPolicy(),
+        skills=(),
+    )
+
+
+def test_completed_turn_persists_its_provider_session_id(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    session = _SeedableSession(results=[AgentTurnResult("done", provider_session_id="thread-1")])
+    client = AgentClient(_FakeDriver([session]), session_store=store)
+
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="hypothesis:H-01")
+
+    record = store.get("hypothesis:H-01")
+    assert record is not None
+    assert record.session_id == "thread-1"
+    assert record.turn_count == 1
+
+
+def test_turn_without_a_session_id_keeps_the_prior_id(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.record("hypothesis:H-01", provider="codex", model="gpt-5.6-sol", session_id="thread-old")
+    session = _SeedableSession(results=[AgentTurnResult("done", provider_session_id=None)])
+    client = AgentClient(_FakeDriver([session]), session_store=store)
+
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="hypothesis:H-01")
+
+    record = store.get("hypothesis:H-01")
+    assert record is not None
+    assert record.session_id == "thread-old"
+
+
+def test_fresh_client_seeds_the_persisted_session_on_first_turn(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.record("hypothesis:H-01", provider="codex", model="gpt-5.6-sol", session_id="thread-1")
+    session = _SeedableSession(results=[AgentTurnResult("resumed", provider_session_id="thread-1")])
+    # A brand new client with no in-memory session models a resumed process.
+    client = AgentClient(_FakeDriver([session]), session_store=store)
+
+    client.run(
+        session_spec=_spec(), turn=AgentTurnRequest("continue"), session_key="hypothesis:H-01"
+    )
+
+    assert session.seeded == ["thread-1"]
+
+
+def test_seed_is_skipped_when_the_stored_provider_or_model_differs(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.record("hypothesis:H-01", provider="claude", model="gpt-5.6-sol", session_id="thread-1")
+    session = _SeedableSession(results=[AgentTurnResult("fresh", provider_session_id="thread-2")])
+    client = AgentClient(_FakeDriver([session]), session_store=store)
+
+    # Requested provider is codex; the stored session is a claude thread.
+    client.run(
+        session_spec=_spec(provider="codex"),
+        turn=AgentTurnRequest("go"),
+        session_key="hypothesis:H-01",
+    )
+
+    assert session.seeded == []
+
+
+def test_reset_disposition_clears_the_persisted_session(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.record("hypothesis:H-01", provider="codex", model="gpt-5.6-sol", session_id="thread-1")
+    session = _SeedableSession(
+        results=[AgentTurnResult("reset", disposition=SessionDisposition.RESET_REQUIRED)]
+    )
+    client = AgentClient(_FakeDriver([session]), session_store=store)
+
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="hypothesis:H-01")
+
+    assert store.get("hypothesis:H-01") is None
+
+
+def test_spec_change_clears_the_persisted_session(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    first = _SeedableSession(results=[AgentTurnResult("one", provider_session_id="thread-1")])
+    second = _SeedableSession(results=[AgentTurnResult("two", provider_session_id="thread-2")])
+    client = AgentClient(_FakeDriver([first, second]), session_store=store)
+
+    client.run(
+        session_spec=_spec(model="gpt-5.6-sol"),
+        turn=AgentTurnRequest("one"),
+        session_key="hypothesis:H-01",
+    )
+    # A within-process model change evicts the live session and drops the stale
+    # durable ID before the new configuration persists its own.
+    client.run(
+        session_spec=_spec(model="gpt-6"),
+        turn=AgentTurnRequest("two"),
+        session_key="hypothesis:H-01",
+    )
+
+    record = store.get("hypothesis:H-01")
+    assert record is not None
+    assert record.session_id == "thread-2"
+    assert record.model == "gpt-6"
+    assert record.turn_count == 1

--- a/tests/vibesys/agents/test_session_store.py
+++ b/tests/vibesys/agents/test_session_store.py
@@ -1,10 +1,11 @@
-"""Durable provider-session persistence and AgentClient seeding on resume.
+"""Durable provider-session checkpoints and AgentClient resume on restart.
 
 These tests exercise the machine-local session store in isolation and its
 integration with :class:`~vibesys.agents.client.AgentClient`: a fresh client
-(standing in for a resumed process) must seed a persisted provider session ID
-into the very first turn, but only when the stored provider/model still match
-the requested spec, and it must forget the ID on a reset or a spec change.
+(standing in for a resumed process) must offer a checkpointed provider session
+ID to the very first turn, but only when the spec that produced it still
+matches, and it must forget the ID when a driver reports a restart or refuses
+to adopt it. A broken store must never cost a completed turn.
 """
 
 from __future__ import annotations
@@ -24,7 +25,9 @@ from vibesys.agents.contracts import (
     AgentTurnRequest,
     AgentTurnResult,
     SessionDisposition,
+    session_spec_fingerprint,
 )
+from vibesys.agents.session_key import AgentSessionKey, SessionScope
 from vibesys.agents.session_store import (
     AgentSessionState,
     DurableSessionStore,
@@ -35,6 +38,9 @@ from vs_project import (
     Project,
     RunEnvironmentRecord,
 )
+
+HYPOTHESIS = AgentSessionKey(SessionScope.HYPOTHESIS, "H-01")
+ROLE = AgentSessionKey(SessionScope.ROLE, "judge")
 
 
 def _project(tmp_path: Path) -> Project:
@@ -61,81 +67,206 @@ def _project(tmp_path: Path) -> Project:
     return project
 
 
-def _store(tmp_path: Path) -> DurableSessionStore:
+def _slot_path(project: Project) -> Path:
+    return project.state.local_namespace("run-1", "agent").external_directory() / "sessions.json"
+
+
+def _store(tmp_path: Path, log: list[str] | None = None) -> DurableSessionStore:
     project = _project(tmp_path)
     slot = project.state.local_namespace("run-1", "agent").slot("sessions.json", AgentSessionState)
-    return DurableSessionStore(slot)
+    if log is None:
+        return DurableSessionStore(slot)
+    return DurableSessionStore(slot, log=log.append)
+
+
+def _spec(*, provider: str = "codex", model: str = "gpt-5.6-sol") -> AgentSessionSpec:
+    return AgentSessionSpec(
+        role="implementer",
+        provider=provider,
+        model=model,
+        workspace=Path("/workspace"),
+        policy=AgentExecutionPolicy(),
+        skills=(),
+    )
+
+
+def _checkpoint(
+    store: DurableSessionStore,
+    session_id: str,
+    *,
+    key: AgentSessionKey = HYPOTHESIS,
+    spec: AgentSessionSpec | None = None,
+) -> None:
+    """Write the checkpoint a completed turn on ``spec`` would have written."""
+    spec = spec if spec is not None else _spec()
+    store.record(
+        key,
+        spec_fingerprint=session_spec_fingerprint(spec),
+        provider=spec.provider,
+        model=spec.model,
+        session_id=session_id,
+        role=spec.role,
+    )
+
+
+# --- session keys ----------------------------------------------------------
+
+
+def test_session_key_serializes_to_the_stored_form() -> None:
+    assert str(HYPOTHESIS) == "hypothesis:H-01"
+    assert AgentSessionKey.parse("hypothesis:H-01") == HYPOTHESIS
+
+
+def test_only_run_scoped_conversations_are_durable() -> None:
+    assert HYPOTHESIS.durable
+    assert AgentSessionKey(SessionScope.CHAT, "thread-9").durable
+    assert not ROLE.durable
+
+
+@pytest.mark.parametrize("stored", ["implementer", "unknown-scope:x", "hypothesis:"])
+def test_unparseable_keys_are_rejected(stored: str) -> None:
+    with pytest.raises(ValueError, match=r"scope|identifier"):
+        AgentSessionKey.parse(stored)
 
 
 # --- DurableSessionStore ---------------------------------------------------
 
 
-def test_record_then_get_returns_the_persisted_session(tmp_path: Path) -> None:
+def test_record_then_get_returns_the_checkpoint(tmp_path: Path) -> None:
     store = _store(tmp_path)
 
-    store.record(
-        "hypothesis:H-01",
-        provider="codex",
-        model="gpt-5.6-sol",
-        session_id="thread-abc",
-        role="implementer",
-    )
-    record = store.get("hypothesis:H-01")
+    _checkpoint(store, "thread-abc")
+    record = store.get(HYPOTHESIS)
 
     assert record is not None
     assert record.session_id == "thread-abc"
+    assert record.spec_fingerprint == session_spec_fingerprint(_spec())
     assert record.provider == "codex"
     assert record.model == "gpt-5.6-sol"
     assert record.role == "implementer"
-    assert record.turn_count == 1
 
 
 def test_get_misses_return_none(tmp_path: Path) -> None:
-    assert _store(tmp_path).get("hypothesis:absent") is None
+    assert _store(tmp_path).get(AgentSessionKey(SessionScope.HYPOTHESIS, "absent")) is None
 
 
-def test_record_bumps_turn_count_across_turns(tmp_path: Path) -> None:
+def test_record_replaces_the_previous_checkpoint(tmp_path: Path) -> None:
     store = _store(tmp_path)
 
-    store.record("k", provider="codex", model="m", session_id="s1")
-    store.record("k", provider="codex", model="m", session_id="s2")
+    _checkpoint(store, "s1")
+    _checkpoint(store, "s2")
 
-    record = store.get("k")
+    record = store.get(HYPOTHESIS)
     assert record is not None
     assert record.session_id == "s2"
-    assert record.turn_count == 2
 
 
-def test_persisted_session_survives_a_new_store_instance(tmp_path: Path) -> None:
+def test_checkpoint_survives_a_new_store_instance(tmp_path: Path) -> None:
     project = _project(tmp_path)
     namespace = project.state.local_namespace("run-1", "agent")
 
-    DurableSessionStore(namespace.slot("sessions.json", AgentSessionState)).record(
-        "k", provider="codex", model="m", session_id="thread-xyz"
-    )
+    _checkpoint(DurableSessionStore(namespace.slot("sessions.json", AgentSessionState)), "thr-xyz")
     # A fresh instance over the same slot models a resumed process: the on-disk
     # map, not any in-memory cache, is the source of truth.
-    reloaded = DurableSessionStore(namespace.slot("sessions.json", AgentSessionState)).get("k")
+    reloaded = DurableSessionStore(namespace.slot("sessions.json", AgentSessionState)).get(
+        HYPOTHESIS
+    )
 
     assert reloaded is not None
-    assert reloaded.session_id == "thread-xyz"
+    assert reloaded.session_id == "thr-xyz"
 
 
 def test_clear_forgets_only_the_named_key(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    store.record("keep", provider="codex", model="m", session_id="s-keep")
-    store.record("drop", provider="codex", model="m", session_id="s-drop")
+    keep = AgentSessionKey(SessionScope.HYPOTHESIS, "keep")
+    _checkpoint(store, "s-keep", key=keep)
+    _checkpoint(store, "s-drop")
 
-    store.clear("drop")
+    store.clear(HYPOTHESIS)
 
-    assert store.get("drop") is None
-    assert store.get("keep") is not None
+    assert store.get(HYPOTHESIS) is None
+    assert store.get(keep) is not None
 
 
 def test_clear_of_missing_key_is_a_noop(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    store.clear("never-recorded")  # must not raise
-    assert store.get("never-recorded") is None
+    store.clear(HYPOTHESIS)  # must not raise
+    assert store.get(HYPOTHESIS) is None
+
+
+def test_role_scoped_conversations_are_never_persisted(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    slot = project.state.local_namespace("run-1", "agent").slot("sessions.json", AgentSessionState)
+    store = DurableSessionStore(slot)
+
+    _checkpoint(store, "judge-thread", key=ROLE)
+
+    # Nothing was written at all: an unscoped role conversation belongs to the
+    # process that created it, so a later run must not resume it.
+    assert store.get(ROLE) is None
+    assert not _slot_path(project).exists()
+
+
+# --- store failures are non-fatal -----------------------------------------
+
+
+def test_malformed_map_degrades_to_no_persistence(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    slot = project.state.local_namespace("run-1", "agent").slot("sessions.json", AgentSessionState)
+    _slot_path(project).write_text("{not json", encoding="utf-8")
+    log: list[str] = []
+    store = DurableSessionStore(slot, log=log.append)
+
+    assert store.get(HYPOTHESIS) is None
+    assert any("unreadable" in message for message in log)
+
+    # The next completed turn replaces the broken file rather than inheriting it.
+    _checkpoint(store, "thread-new")
+    record = store.get(HYPOTHESIS)
+    assert record is not None
+    assert record.session_id == "thread-new"
+
+
+def test_map_written_by_a_foreign_key_contract_is_rejected(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    slot = project.state.local_namespace("run-1", "agent").slot("sessions.json", AgentSessionState)
+    # A role-scoped key could only come from a different contract; the whole
+    # map is refused rather than partially trusted.
+    _slot_path(project).write_text(
+        '{"schema_version": 1, "sessions": {"role:judge": '
+        '{"spec_fingerprint": "f", "session_id": "s", "provider": "codex"}}}',
+        encoding="utf-8",
+    )
+    log: list[str] = []
+
+    assert DurableSessionStore(slot, log=log.append).get(HYPOTHESIS) is None
+    assert log
+
+
+def test_unwritable_slot_does_not_fail_the_turn(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    slot = project.state.local_namespace("run-1", "agent").slot("sessions.json", AgentSessionState)
+    # A directory where the map belongs makes every write fail.
+    _slot_path(project).mkdir(parents=True)
+    log: list[str] = []
+    store = DurableSessionStore(slot, log=log.append)
+
+    _checkpoint(store, "thread-1")  # must not raise
+
+    assert any("could not checkpoint" in message for message in log)
+
+
+def test_a_broken_store_never_discards_a_completed_turn(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    slot = project.state.local_namespace("run-1", "agent").slot("sessions.json", AgentSessionState)
+    _slot_path(project).mkdir(parents=True)
+    store = DurableSessionStore(slot, log=lambda _message: None)
+    session = _FakeSession(results=[AgentTurnResult("done", provider_session_id="thread-1")])
+    client = AgentClient(_FakeDriver([session]), session_store=store)
+
+    result = client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key=HYPOTHESIS)
+
+    assert result.text == "done"
 
 
 # --- NullSessionStore ------------------------------------------------------
@@ -144,22 +275,25 @@ def test_clear_of_missing_key_is_a_noop(tmp_path: Path) -> None:
 def test_null_store_persists_nothing_and_always_misses() -> None:
     store = NullSessionStore()
 
-    store.record("k", provider="codex", model="m", session_id="s")
-    store.clear("k")
+    store.record(
+        HYPOTHESIS, spec_fingerprint="f", provider="codex", model="m", session_id="s", role="r"
+    )
+    store.clear(HYPOTHESIS)
 
-    assert store.get("k") is None
+    assert store.get(HYPOTHESIS) is None
 
 
-# --- AgentClient seeding on resume -----------------------------------------
+# --- AgentClient resume ----------------------------------------------------
 
 
 @dataclass
-class _SeedableSession:
-    """A fake session that records seeds and returns queued turn results."""
+class _FakeSession:
+    """A fake session that records adoption attempts and queued results."""
 
     results: list[AgentTurnResult]
     error: Exception | None = None
-    seeded: list[str] = field(default_factory=list)
+    adopts: bool = True
+    offered: list[str] = field(default_factory=list)
     close_calls: int = 0
 
     def run_turn(
@@ -171,8 +305,9 @@ class _SeedableSession:
             raise self.error
         return self.results.pop(0)
 
-    def seed_provider_session(self, session_id: str) -> None:
-        self.seeded.append(session_id)
+    def resume_provider_session(self, session_id: str) -> bool:
+        self.offered.append(session_id)
+        return self.adopts
 
     def close(self) -> None:
         self.close_calls += 1
@@ -180,7 +315,7 @@ class _SeedableSession:
 
 @dataclass
 class _FakeDriver:
-    queued_sessions: list[_SeedableSession]
+    queued_sessions: list[_FakeSession]
     specs: list[AgentSessionSpec] = field(default_factory=list)
     close_calls: int = 0
 
@@ -196,149 +331,161 @@ class _FakeDriver:
         self.close_calls += 1
 
 
-def _spec(*, provider: str = "codex", model: str = "gpt-5.6-sol") -> AgentSessionSpec:
-    return AgentSessionSpec(
-        role="implementer",
-        provider=provider,
-        model=model,
-        workspace=Path("/workspace"),
-        policy=AgentExecutionPolicy(),
-        skills=(),
-    )
-
-
-def test_completed_turn_persists_its_provider_session_id(tmp_path: Path) -> None:
+def test_completed_turn_checkpoints_its_provider_session_id(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    session = _SeedableSession(results=[AgentTurnResult("done", provider_session_id="thread-1")])
+    session = _FakeSession(results=[AgentTurnResult("done", provider_session_id="thread-1")])
     client = AgentClient(_FakeDriver([session]), session_store=store)
 
-    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="hypothesis:H-01")
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key=HYPOTHESIS)
 
-    record = store.get("hypothesis:H-01")
+    record = store.get(HYPOTHESIS)
     assert record is not None
     assert record.session_id == "thread-1"
-    assert record.turn_count == 1
+    assert record.spec_fingerprint == session_spec_fingerprint(_spec())
 
 
-def test_turn_without_a_session_id_keeps_the_prior_id(tmp_path: Path) -> None:
+def test_role_scoped_turn_checkpoints_nothing(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    store.record("hypothesis:H-01", provider="codex", model="gpt-5.6-sol", session_id="thread-old")
-    session = _SeedableSession(results=[AgentTurnResult("done", provider_session_id=None)])
+    session = _FakeSession(results=[AgentTurnResult("done", provider_session_id="thread-1")])
     client = AgentClient(_FakeDriver([session]), session_store=store)
 
-    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="hypothesis:H-01")
+    # No session_key: the client falls back to a role-scoped key.
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"))
 
-    record = store.get("hypothesis:H-01")
+    assert store.get(AgentSessionKey(SessionScope.ROLE, "implementer")) is None
+
+
+def test_turn_without_a_session_id_keeps_the_prior_checkpoint(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _checkpoint(store, "thread-old")
+    session = _FakeSession(results=[AgentTurnResult("done", provider_session_id=None)])
+    client = AgentClient(_FakeDriver([session]), session_store=store)
+
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key=HYPOTHESIS)
+
+    record = store.get(HYPOTHESIS)
     assert record is not None
     assert record.session_id == "thread-old"
 
 
-def test_fresh_client_seeds_the_persisted_session_on_first_turn(tmp_path: Path) -> None:
+def test_fresh_client_offers_the_checkpoint_to_its_first_turn(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    store.record("hypothesis:H-01", provider="codex", model="gpt-5.6-sol", session_id="thread-1")
-    session = _SeedableSession(results=[AgentTurnResult("resumed", provider_session_id="thread-1")])
+    _checkpoint(store, "thread-1")
+    session = _FakeSession(results=[AgentTurnResult("resumed", provider_session_id="thread-1")])
     # A brand new client with no in-memory session models a resumed process.
     client = AgentClient(_FakeDriver([session]), session_store=store)
 
-    client.run(
-        session_spec=_spec(), turn=AgentTurnRequest("continue"), session_key="hypothesis:H-01"
-    )
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("continue"), session_key=HYPOTHESIS)
 
-    assert session.seeded == ["thread-1"]
+    assert session.offered == ["thread-1"]
 
 
-def test_seed_is_skipped_when_the_stored_provider_or_model_differs(tmp_path: Path) -> None:
+def test_a_reused_live_session_is_not_offered_the_checkpoint_again(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    store.record("hypothesis:H-01", provider="claude", model="gpt-5.6-sol", session_id="thread-1")
-    session = _SeedableSession(results=[AgentTurnResult("fresh", provider_session_id="thread-2")])
+    session = _FakeSession(
+        results=[
+            AgentTurnResult("one", provider_session_id="thread-1"),
+            AgentTurnResult("two", provider_session_id="thread-1"),
+        ]
+    )
     client = AgentClient(_FakeDriver([session]), session_store=store)
 
-    # Requested provider is codex; the stored session is a claude thread.
-    client.run(
-        session_spec=_spec(provider="codex"),
-        turn=AgentTurnRequest("go"),
-        session_key="hypothesis:H-01",
-    )
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key=HYPOTHESIS)
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("two"), session_key=HYPOTHESIS)
 
-    assert session.seeded == []
+    # The live conversation is already the newest history there is.
+    assert session.offered == []
 
 
-def test_failed_seeded_turn_invalidates_the_persisted_session(tmp_path: Path) -> None:
+def test_checkpoint_from_a_different_spec_is_refused_and_dropped(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    store.record(
-        "hypothesis:H-01", provider="codex", model="gpt-5.6-sol", session_id="thread-stale"
+    # Reasoning effort is not provider or model, but it is part of the spec that
+    # in-process reuse compares, so it must also refuse a checkpoint.
+    other = AgentSessionSpec(
+        role="implementer",
+        provider="codex",
+        model="gpt-5.6-sol",
+        workspace=Path("/workspace"),
+        policy=AgentExecutionPolicy(),
+        skills=(),
+        reasoning_effort="high",
     )
-    # A fresh client models a resumed process: the first turn seeds the stored
-    # ID, then raises (e.g. a deleted/invalid Claude session with no fallback).
-    failing = _SeedableSession(results=[], error=RuntimeError("resume failed: unknown session"))
-    fresh = _SeedableSession(results=[AgentTurnResult("fresh", provider_session_id="thread-new")])
-    client = AgentClient(_FakeDriver([failing, fresh]), session_store=store)
-
-    with pytest.raises(RuntimeError):
-        client.run(
-            session_spec=_spec(), turn=AgentTurnRequest("resume"), session_key="hypothesis:H-01"
-        )
-
-    assert failing.seeded == ["thread-stale"]
-    # The stale ID must be forgotten so the next attempt does not re-seed it.
-    assert store.get("hypothesis:H-01") is None
-    client.run(session_spec=_spec(), turn=AgentTurnRequest("retry"), session_key="hypothesis:H-01")
-    assert fresh.seeded == []
-
-
-def test_failed_turn_on_a_proven_session_keeps_the_persisted_session(tmp_path: Path) -> None:
-    store = _store(tmp_path)
-    # Turn one succeeds (proving the resume), turn two on the same cached session
-    # fails transiently. The persisted ID stays: it named a valid rollout.
-    session = _SeedableSession(results=[AgentTurnResult("one", provider_session_id="thread-1")])
+    _checkpoint(store, "thread-1", spec=other)
+    session = _FakeSession(results=[AgentTurnResult("fresh", provider_session_id="thread-2")])
     client = AgentClient(_FakeDriver([session]), session_store=store)
-    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="hypothesis:H-01")
 
-    session.error = RuntimeError("transient network error")
-    with pytest.raises(RuntimeError):
-        client.run(
-            session_spec=_spec(), turn=AgentTurnRequest("two"), session_key="hypothesis:H-01"
-        )
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("go"), session_key=HYPOTHESIS)
 
-    record = store.get("hypothesis:H-01")
+    assert session.offered == []
+    record = store.get(HYPOTHESIS)
     assert record is not None
-    assert record.session_id == "thread-1"
+    assert record.session_id == "thread-2"
 
 
-def test_reset_disposition_clears_the_persisted_session(tmp_path: Path) -> None:
+def test_a_refused_adoption_drops_the_checkpoint(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    store.record("hypothesis:H-01", provider="codex", model="gpt-5.6-sol", session_id="thread-1")
-    session = _SeedableSession(
+    _checkpoint(store, "thread-1")
+    # A driver whose provider cannot resume (omnigent today) reports False.
+    session = _FakeSession(results=[AgentTurnResult("fresh")], adopts=False)
+    client = AgentClient(_FakeDriver([session]), session_store=store)
+
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("go"), session_key=HYPOTHESIS)
+
+    assert session.offered == ["thread-1"]
+    assert store.get(HYPOTHESIS) is None
+
+
+def test_reset_disposition_evicts_and_clears_the_checkpoint(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _checkpoint(store, "thread-1")
+    session = _FakeSession(
         results=[AgentTurnResult("reset", disposition=SessionDisposition.RESET_REQUIRED)]
     )
     client = AgentClient(_FakeDriver([session]), session_store=store)
 
-    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="hypothesis:H-01")
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key=HYPOTHESIS)
 
-    assert store.get("hypothesis:H-01") is None
+    assert store.get(HYPOTHESIS) is None
+    assert session.close_calls == 1
 
 
-def test_spec_change_clears_the_persisted_session(tmp_path: Path) -> None:
+def test_a_failed_turn_keeps_the_checkpoint(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    first = _SeedableSession(results=[AgentTurnResult("one", provider_session_id="thread-1")])
-    second = _SeedableSession(results=[AgentTurnResult("two", provider_session_id="thread-2")])
+    _checkpoint(store, "thread-1")
+    # A timeout or a cancelled run says nothing about whether the conversation
+    # is still resumable, so the checkpoint outlives it.
+    failing = _FakeSession(results=[], error=RuntimeError("transient network error"))
+    client = AgentClient(_FakeDriver([failing]), session_store=store)
+
+    with pytest.raises(RuntimeError):
+        client.run(session_spec=_spec(), turn=AgentTurnRequest("go"), session_key=HYPOTHESIS)
+
+    record = store.get(HYPOTHESIS)
+    assert record is not None
+    assert record.session_id == "thread-1"
+
+
+def test_in_process_spec_change_replaces_the_checkpoint(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    first = _FakeSession(results=[AgentTurnResult("one", provider_session_id="thread-1")])
+    second = _FakeSession(results=[AgentTurnResult("two", provider_session_id="thread-2")])
     client = AgentClient(_FakeDriver([first, second]), session_store=store)
 
     client.run(
         session_spec=_spec(model="gpt-5.6-sol"),
         turn=AgentTurnRequest("one"),
-        session_key="hypothesis:H-01",
+        session_key=HYPOTHESIS,
     )
-    # A within-process model change evicts the live session and drops the stale
-    # durable ID before the new configuration persists its own.
+    # A within-process model change evicts the live session; the new session
+    # refuses the stale checkpoint and writes its own.
     client.run(
         session_spec=_spec(model="gpt-6"),
         turn=AgentTurnRequest("two"),
-        session_key="hypothesis:H-01",
+        session_key=HYPOTHESIS,
     )
 
-    record = store.get("hypothesis:H-01")
+    assert second.offered == []
+    record = store.get(HYPOTHESIS)
     assert record is not None
     assert record.session_id == "thread-2"
     assert record.model == "gpt-6"
-    assert record.turn_count == 1

--- a/tests/vibesys/agents/test_session_store.py
+++ b/tests/vibesys/agents/test_session_store.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import pytest
+
 from vibesys.agents.client import AgentClient
 from vibesys.agents.contracts import (
     AgentCapabilities,
@@ -156,6 +158,7 @@ class _SeedableSession:
     """A fake session that records seeds and returns queued turn results."""
 
     results: list[AgentTurnResult]
+    error: Exception | None = None
     seeded: list[str] = field(default_factory=list)
     close_calls: int = 0
 
@@ -164,6 +167,8 @@ class _SeedableSession:
         request: AgentTurnRequest,  # noqa: ARG002
         observer: AgentObserver | None = None,  # noqa: ARG002
     ) -> AgentTurnResult:
+        if self.error is not None:
+            raise self.error
         return self.results.pop(0)
 
     def seed_provider_session(self, session_id: str) -> None:
@@ -256,6 +261,46 @@ def test_seed_is_skipped_when_the_stored_provider_or_model_differs(tmp_path: Pat
     )
 
     assert session.seeded == []
+
+
+def test_failed_seeded_turn_invalidates_the_persisted_session(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.record("hypothesis:H-01", provider="codex", model="gpt-5.6-sol", session_id="thread-stale")
+    # A fresh client models a resumed process: the first turn seeds the stored
+    # ID, then raises (e.g. a deleted/invalid Claude session with no fallback).
+    failing = _SeedableSession(results=[], error=RuntimeError("resume failed: unknown session"))
+    fresh = _SeedableSession(results=[AgentTurnResult("fresh", provider_session_id="thread-new")])
+    client = AgentClient(_FakeDriver([failing, fresh]), session_store=store)
+
+    with pytest.raises(RuntimeError):
+        client.run(
+            session_spec=_spec(), turn=AgentTurnRequest("resume"), session_key="hypothesis:H-01"
+        )
+
+    assert failing.seeded == ["thread-stale"]
+    # The stale ID must be forgotten so the next attempt does not re-seed it.
+    assert store.get("hypothesis:H-01") is None
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("retry"), session_key="hypothesis:H-01")
+    assert fresh.seeded == []
+
+
+def test_failed_turn_on_a_proven_session_keeps_the_persisted_session(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    # Turn one succeeds (proving the resume), turn two on the same cached session
+    # fails transiently. The persisted ID stays: it named a valid rollout.
+    session = _SeedableSession(results=[AgentTurnResult("one", provider_session_id="thread-1")])
+    client = AgentClient(_FakeDriver([session]), session_store=store)
+    client.run(session_spec=_spec(), turn=AgentTurnRequest("one"), session_key="hypothesis:H-01")
+
+    session.error = RuntimeError("transient network error")
+    with pytest.raises(RuntimeError):
+        client.run(
+            session_spec=_spec(), turn=AgentTurnRequest("two"), session_key="hypothesis:H-01"
+        )
+
+    record = store.get("hypothesis:H-01")
+    assert record is not None
+    assert record.session_id == "thread-1"
 
 
 def test_reset_disposition_clears_the_persisted_session(tmp_path: Path) -> None:

--- a/tests/vibesys/agents/test_session_store.py
+++ b/tests/vibesys/agents/test_session_store.py
@@ -265,7 +265,9 @@ def test_seed_is_skipped_when_the_stored_provider_or_model_differs(tmp_path: Pat
 
 def test_failed_seeded_turn_invalidates_the_persisted_session(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    store.record("hypothesis:H-01", provider="codex", model="gpt-5.6-sol", session_id="thread-stale")
+    store.record(
+        "hypothesis:H-01", provider="codex", model="gpt-5.6-sol", session_id="thread-stale"
+    )
     # A fresh client models a resumed process: the first turn seeds the stored
     # ID, then raises (e.g. a deleted/invalid Claude session with no fallback).
     failing = _SeedableSession(results=[], error=RuntimeError("resume failed: unknown session"))

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -11,6 +11,7 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 from vibesys.agents import AgentClient
+from vibesys.agents.session_key import AgentSessionKey, SessionScope
 from vibesys.config import Config, as_config
 from vibesys.constants import ComputeBackend
 from vibesys.domains.base import DomainName
@@ -2366,7 +2367,8 @@ def test_implementer_skill_updates_survive_a_renewed_continuation_prompt(tmp_pat
     calls = [
         call
         for call in runner.invoke.call_args_list
-        if call.kwargs.get("session_key") == "hypothesis:transport-boundary"
+        if call.kwargs.get("session_key")
+        == AgentSessionKey(SessionScope.HYPOTHESIS, "transport-boundary")
     ]
     assert len(calls) == 2
     assert "portable/references/transport.md" not in calls[0].kwargs["system_prompt"]
@@ -3237,7 +3239,7 @@ def test_role_session_policy_is_explicit_and_hypothesis_scoped(tmp_path, ref_fil
     assert all(call.kwargs["reuse_session"] is False for call in plan_calls)
     assert all(call.kwargs["reuse_session"] is True for call in implementer_calls)
     assert {call.kwargs["session_key"] for call in implementer_calls} == {
-        "hypothesis:stable-hypothesis"
+        AgentSessionKey(SessionScope.HYPOTHESIS, "stable-hypothesis")
     }
     assert (
         "Required continuation from the previous round"
@@ -3355,7 +3357,8 @@ def test_hypothesis_revert_is_applied_once_across_continuation_rounds(tmp_path, 
         call
         for call in runner.invoke.call_args_list
         if call.kwargs.get("response_cls") is ImplementerResponse
-        and call.kwargs.get("session_key") == "hypothesis:continued-repair"
+        and call.kwargs.get("session_key")
+        == AgentSessionKey(SessionScope.HYPOTHESIS, "continued-repair")
     ]
     assert len(repair_calls) == 2
     assert all(
@@ -3445,7 +3448,8 @@ def test_failed_hypothesis_revert_is_retried_and_not_claimed_as_applied(tmp_path
         call
         for call in runner.invoke.call_args_list
         if call.kwargs.get("response_cls") is ImplementerResponse
-        and call.kwargs.get("session_key") == "hypothesis:retry-rollback"
+        and call.kwargs.get("session_key")
+        == AgentSessionKey(SessionScope.HYPOTHESIS, "retry-rollback")
     ]
     assert len(retry_calls) == 2
     assert "framework already materialized" not in retry_calls[0].kwargs["system_prompt"].lower()
@@ -4377,3 +4381,25 @@ def test_loop_threads_plateau_warning_into_prompt(tmp_path, ref_file):  # noqa: 
     assert "Plateau detected" in seen_prompts[4]
     assert "Refresh an analytical performance model" in seen_prompts[4]
     assert "unexplained residual" in seen_prompts[4]
+
+
+def test_completed_round_records_which_implementer_produced_it(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """A round names the driver, provider, and model of its implementer.
+
+    The provider session ID itself stays machine-local in the session store;
+    the portable record carries only the attribution needed to tell whether a
+    resumed run is continuing the same configuration.
+    """
+    runner = _make_orchestrate_runner()
+    runner.driver_name = "agentshim"
+    runner.provider = "codex"
+    runner.model_for_kind.return_value = "gpt-5.6-sol"
+
+    _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1)
+
+    round_one = _round_payloads(tmp_path)[0]
+    assert round_one["implementer_driver"] == "agentshim"
+    assert round_one["implementer_provider"] == "codex"
+    assert round_one["implementer_model"] == "gpt-5.6-sol"
+    # The record is portable state; a host-local session ID must never reach it.
+    assert not [key for key in round_one if "session" in key]

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -179,6 +179,11 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
 
     runner = MagicMock(spec=AgentClient)
     runner.backend_name = "deepagents"
+    # The loop records implementer attribution on each round; give the mock
+    # real strings so the RoundRecord (str | None fields) validates.
+    runner.driver_name = "mock"
+    runner.provider = "mock"
+    runner.model_for_kind.return_value = "mock-model"
 
     def _invoke(*, kind, response_cls, fallback_factory, **kwargs):  # noqa: ANN001, ANN003, ANN202, ARG001, PLR0911  # tracked: #288
         if kind == "orchestrator" and response_cls is PreRoundDecision:

--- a/tests/vibesys/test_context.py
+++ b/tests/vibesys/test_context.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vibesys import boot_trace
+from vibesys.agents.session_key import AgentSessionKey, SessionScope
+from vibesys.agents.session_store import DurableSessionStore
 from vibesys.config import Config
 from vibesys.context import (
     _resume_configuration_update,
@@ -847,3 +849,53 @@ def test_log_switch_retargets_stderr_tee(tmp_path):  # noqa: ANN001, ANN201
     assert sys.stderr is original_stderr
     assert "colored diagnostic" in ctx.run_log_path.read_text()
     assert "\033[31m" not in ctx.run_log_path.read_text()
+
+
+def test_agent_client_gets_a_machine_local_provider_session_store(tmp_path):  # noqa: ANN001, ANN201
+    """The run's agent client checkpoints provider sessions outside the repo.
+
+    Provider transcripts are host-local, so the map must live in the run's
+    machine-local namespace, never in the portable snapshot that travels
+    between machines.
+    """
+    project = tmp_path / "queue"
+    evaluator = _write_project(project)
+
+    with (
+        patch("vibesys.context.build_agent_client", return_value=MagicMock()) as build_runner,
+        _create_context(project, evaluator=evaluator) as ctx,
+    ):
+        store = build_runner.call_args.kwargs["session_store"]
+        assert isinstance(store, DurableSessionStore)
+        store.record(
+            AgentSessionKey(SessionScope.HYPOTHESIS, "H-01"),
+            spec_fingerprint="fingerprint",
+            provider="codex",
+            model="gpt-test",
+            session_id="thread-1",
+        )
+        local_dir = ctx.state.local(RunStateNamespace.AGENT).external_directory()
+
+    assert (local_dir / "sessions.json").is_file()
+    assert not local_dir.is_relative_to(project)
+
+
+def test_evolve_candidate_clients_get_no_provider_session_store(tmp_path):  # noqa: ANN001, ANN201
+    """Candidates never name a durable conversation, so they checkpoint nothing."""
+    project = tmp_path / "queue"
+    evaluator = _write_project(project)
+
+    with _create_context(project, evaluator=evaluator) as parent:
+        parent_commit = parent.git.current_sha()
+        assert parent_commit is not None
+        with patch("vibesys.context.build_agent_client", return_value=MagicMock()) as build_runner:
+            candidate = create_candidate_context(
+                parent,
+                config=Config.model_validate({"model": {"name": "gpt-test"}}),
+                generation=2,
+                child_idx=3,
+                parent_commit=parent_commit,
+                agent_backend="stub",
+            )
+            assert "session_store" not in build_runner.call_args.kwargs
+            candidate.close()


### PR DESCRIPTION
## Problem

Quitting the TUI mid-run throws away everything about the in-flight implementer except its files. On TUI exit the launcher SIGTERMs the whole backend process group (`clients/tui/src/launcher.ts:208-224`), killing any in-flight codex/claude subprocess, and `--resume` restarts the interrupted round from its beginning with a brand-new CLI session. The provider session ID that would allow true continuation is produced but consumed nowhere: `AgentTurnResult.provider_session_id` is populated by the agentshim and omnigent drivers and stored in no durable place (not the event schema, not `usage.jsonl`, not `RoundRecord`), so after a restart `AgentClient._sessions` is empty, the underlying `session_id` is `None`, and the first call takes the fresh-command branch instead of `claude --resume <id>` or `codex exec resume <id>`, even though both CLIs support resuming and the provider transcripts survive on disk. Session continuity is already requested by the loop (`session_key=f"hypothesis:{id}"`) but that key resolves to an in-memory dict only, so it never survives a process exit. Also lost today: which driver/provider/model implemented each round attempt, because attribution was never part of the persisted `RoundRecord`.

Making a session resumable across processes exposes a second, pre-existing gap. Nothing in `src/` ever produced `SessionDisposition.RESET_REQUIRED`, so `AgentClient` had no way to learn that a driver had silently dropped and restarted the conversation a session key names. The AgentShim session does exactly that in three places (retiring an over-budget Codex thread, retrying a missing Codex rollout, and — once resume is possible — meeting a Claude session the CLI refuses to resume). Without a reported restart the last one is fatal: a refused `claude --resume` surfaces as a bare nonzero exit that propagates out of the first resumed turn and ends the run.

This implements issue #520.

## Solution

A durable, machine-local checkpoint of provider session IDs, plus the typed driver contract that makes adopting one safe.

### Driver contract

Two members carry cross-process resume, both typed, neither probed:

- `AgentCapabilities.provider_session_resume` says whether a driver can adopt a conversation created by an earlier process. `session_reuse` only ever promised reuse within one process.
- `AgentSession.resume_provider_session(session_id) -> bool` offers one checkpoint and returns whether it was **actually adopted**. AgentShim delegates to the agent; the mock adopts and echoes; Omnigent returns `False` and declares `provider_session_resume=False`, because Omnigent 0.10 owns its executor's conversation lifecycle internally and exposes no attach point.

Underneath, `CodingAgent` now declares `session_id`, `supports_session_resume` (set by Codex and Claude Code, the two providers with a resume flag), `resume_from(session_id) -> bool`, and `forget_session()`. That removes the `getattr(session, "seed_provider_session", None)` capability probe, the `hasattr(self._agent, "session_id")` checks, and both `cast("CodexCodingAgent", ...)` writes.

### Drivers report every restart

The AgentShim session returns `SessionDisposition.RESET_REQUIRED` whenever it drops the conversation its session named, so `AgentClient` evicts the live session and clears the checkpoint instead of later claiming continuity with history that no longer exists:

- **Codex thread budget.** Now evaluated *after* the turn rather than before it, so the decision reads the usage the turn just produced and the caller learns about the restart from that turn's result instead of discovering it on the next one. The renewal cadence is unchanged.
- **Missing Codex rollout.** The existing retry now reports the restart it performs.
- **Stale Claude session (new).** A resumed Claude turn that fails is retried once from a fresh conversation. Claude Code reports a refused `--resume` as a bare nonzero exit with no distinguishing message, so any failed *resumed* turn is retried; a fresh turn's failure is the agent's own and propagates unchanged. Timeouts never reach this path (they raise `subprocess.TimeoutExpired`). This is what stops a stale checkpoint from killing a run.

### Typed session keys and scoped persistence

`AgentSessionKey(scope: SessionScope, identifier: str)` replaces free-text keys through `AgentClient`, the runner shims, and the loop's two construction sites. It serializes to the same `"hypothesis:H-01"` strings the map already wrote, so the on-disk form is unchanged, and stored keys are parsed back on load.

Only `HYPOTHESIS` and `CHAT` opt into persistence. `ROLE` does not, and `ROLE` is exactly the fallback scope every unscoped `invoke` lands on, so judge, perf_eval, profiler, and evolve-candidate conversations are never checkpointed and never resumed across restarts. The store drops non-durable keys rather than trusting the caller to remember.

### Checkpoint rules

- A checkpoint is adopted only when the **full session-spec fingerprint** matches — the same comparison in-process reuse makes when it decides whether to evict a live session — not just provider and model. The fingerprint is persisted alongside the ID.
- It is dropped on a driver-reported reset, or when the driver reports it did not adopt the ID.
- It is **kept** through an ordinary turn failure. A timeout or a cancelled run says nothing about whether the conversation is still resumable; only a driver that finds it unusable says so, and it says so with `RESET_REQUIRED`.
- Every store failure (malformed file, schema mismatch, `OSError`) is logged through the run log and swallowed. A broken map degrades this run to no persistence and is overwritten by the next completed turn. A completed turn is never discarded because its checkpoint could not be written.

### Round attribution

`RoundRecord` gains `implementer_driver`, `implementer_provider`, and `implementer_model`, all defaulting to `None` so pre-existing records still load under `extra="forbid"`. They describe the *latest* attempt at the round: a resumed run that re-attempts the same round overwrites the entry, so they are not an append-only audit log. The session key field was dropped (derivable from `hypothesis_id`), and so was the persisted turn count: the Codex thread budget is enforced by the driver from the turns and usage it observes, and a resumed thread's first turn immediately reports its real input-token count, which is the signal the budget actually cares about.

### Wiring

`context.py` builds the store over `RunState.local(RunStateNamespace.AGENT).slot("sessions.json", AgentSessionState)` and hands it the run logger. Evolve candidate clients deliberately get no store: a candidate names no conversation narrower than an agent role, so all its turns land on role-scoped keys that are never checkpointed anyway, and candidates share the parent's run ID and local namespace while running concurrently, so one per-run map would alias them.

### Architecture

Who owns the provider session ID at each moment:

- **The driver**, during a turn. It is the only thing that knows whether the conversation still exists, and the only thing allowed to restart it. It reports a restart through the turn's disposition.
- **The store**, between processes. A checkpoint, not a handle: it is advisory, refusable, and losing it costs a resume, never a turn.
- **The client cache**, within a process. The live handle. A cached session's conversation is always newer than any checkpoint, which is why `resume_provider_session` refuses to overwrite it.

```mermaid
flowchart TD
    Loop["run_agent_loop"] -->|"AgentSessionKey(HYPOTHESIS, id)"| Client["AgentClient.run"]
    Loop -->|"driver / provider / model"| Record["RoundRecord (portable, no session ID)"]
    Client -->|"cache hit: live handle"| Cached["_sessions[key]"]
    Client -->|"cache miss: offer checkpoint"| Resume["_resume_checkpoint"]
    Resume -->|"fingerprint must match"| Store[("DurableSessionStore")]
    Resume -->|"resume_provider_session -> bool"| Session["AgentShim session"]
    Session -->|"codex exec resume / claude --resume"| Provider["CLI provider"]
    Session -->|"restart: budget / missing rollout / stale resume"| Reset["RESET_REQUIRED"]
    Reset --> Client
    Client -->|"reset or refused adoption: clear"| Store
    Client -->|"completed turn: record id + fingerprint"| Store
    Store -->|"machine-local, never snapshotted"| Slot["sessions.json"]
```

## Verification

### Correctness properties

- **Drivers report every restart.** Whenever the AgentShim session drops the conversation its key names, that turn's result is `RESET_REQUIRED`; the client then evicts the live session and clears the checkpoint. A turn that merely raises is not a restart.
- **A refused resume clears the checkpoint.** If `resume_provider_session` returns `False` — the provider cannot resume, or a live conversation is already attached — nothing will ever adopt that ID, so it is dropped immediately.
- **Only opted-in scopes persist.** `HYPOTHESIS` and `CHAT` are checkpointed; `ROLE`, the fallback for every unscoped call, is not, and the store refuses to write it even if asked.
- **Configuration drift never resumes.** A checkpoint is adopted only when the full session-spec fingerprint matches, so any change that would evict a live session also refuses a checkpointed one. The stale entry is dropped, and the turn writes its own.
- **The store never fails a turn.** Malformed JSON, a schema mismatch, and filesystem errors are logged and degrade to no persistence; the next completed turn overwrites the map.
- **Session IDs stay machine-local.** They live only in the local, never-Git-snapshotted namespace. `RoundRecord` carries driver/provider/model and no session identity at all.
- **On-disk compatibility.** Keys serialize to the same `"<scope>:<identifier>"` strings and are parsed back on load; `RoundRecord`'s new fields default to `None`, so older records still parse under `extra="forbid"`.

### Testing

```
uv run pytest tests/vibesys/agents tests/vibesys/_agent_cli tests/vibesys/test_context.py -q --no-cov  -> 538 passed, 1 skipped (macOS sandbox-exec)
uv run pytest tests/vibesys/loops/agent -q --no-cov                                                   -> 331 passed
uv run pytest tests/server libs/vs-loop-state/tests -q --no-cov                                       -> 308 passed (with tests/vibesys/test_context.py)
./scripts/check_format.sh                                                                             -> 479 files already formatted
./scripts/check_lint.sh                                                                               -> All checks passed
./scripts/check_types.sh                                                                              -> All checks passed
uv run python scripts/check_doc_links.py                                                              -> 326 Markdown files, no broken links
```

New or reworked coverage:

- `tests/vibesys/agents/drivers/test_agentshim_driver.py`: `resume_provider_session` adopts a checkpoint on a cold session, refuses when a conversation is already live, and refuses when the provider declares no resume support; the thread-budget renewal and the heavy-turn renewal each report `RESET_REQUIRED`; the missing-rollout retry and the stale-Claude fallback both retry from a fresh conversation and report the reset; a failed *fresh* Claude turn is not retried.
- `tests/vibesys/_agent_cli/test_codex.py`: the real `CodingAgent.resume_from` / `forget_session`, including a provider without a resume flag refusing to adopt.
- `tests/vibesys/agents/test_session_store.py`: scope durability and key parsing; store lifecycle across instances; a role-scoped key writing nothing at all; a malformed map, a foreign-key-contract map, and an unwritable slot each degrading without raising, with a completed turn surviving a broken store; and the client rules — checkpoint on completion, offer on a cold session, never re-offer to a live one, refuse on fingerprint drift, drop on refused adoption, drop on `RESET_REQUIRED`, keep through a failed turn.
- `tests/vibesys/test_context.py`: the run's client gets a `DurableSessionStore` whose map lands in the machine-local namespace outside the repository, and evolve candidate clients get none. (The author's P1 test, kept.)
- `libs/vs-loop-state/tests/test_vs_loop_state_agent.py`: attribution round-trip and legacy-record loading.

Not covered by the suite: credentialed live `codex exec resume` / `claude --resume` against a real quit-and-restart run.

### Docs

`docs/contributing/agent-drivers.md` documents the new capability and method, which providers can resume, that cross-process resume is AgentShim-only today, and the rule that drivers must report every restart.

### Non-goals (follow-up)

Deferred, tracked under #520 acceptance criterion 5: persisting the pause flag and the pending steer queue so a run paused at exit resumes paused. Also out of scope, per the issue: resuming mid-agent-turn (a turn killed in flight is re-run), the evolve loop's generation-counter reset, and Omnigent executor-thread resume. #484's chat session reuse should be rebuilt on this contract (a `CHAT`-scoped key plus `RESET_REQUIRED` handling) rather than a parallel mechanism.

Closes #520.
