### PR TITLE
TUI: Contain keystrokes for modal surfaces and a non-empty command input

### DIFF
--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -628,6 +628,51 @@ describe('OpenTUI presentation', () => {
     expect(early).toContain('[ r1 ]');
   });
 
+  it('leaves brackets and cursor keys to a typed command', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 20});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      core: {
+        ...initialSessionState().core,
+        rounds: [
+          {number: 1, status: 'completed' as const},
+          {number: 2, status: 'active' as const},
+        ],
+        transcript: [
+          {
+            id: 'live',
+            kind: 'assistant',
+            label: 'Agent',
+            content: 'live output',
+            roundNumber: 2,
+          },
+        ],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('live output'));
+    const focusBefore = controller.state.roundFocus;
+
+    // With text in the command input, brackets are characters and the cursor
+    // keys stay in the input: nothing navigates rounds or moves pane focus.
+    await testRenderer.mockInput.typeText('/steer fix arr[0]');
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    const typed = await frameAfter(testRenderer);
+    expect(typed).toContain('arr[0]');
+    expect(controller.state.selectedRound).toBeNull();
+    expect(controller.state.roundFocus).toBe(focusBefore);
+
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.submissions.length === 1);
+    expect(controller.submissions).toEqual(['/steer fix arr[0]']);
+
+    // With the input empty again, the same key is round navigation.
+    testRenderer.mockInput.pressKey('[');
+    await frameAfter(testRenderer);
+    expect(controller.state.selectedRound).toBe(1);
+  });
+
   it('filters the transcript to an agent node that is clicked', async () => {
     const testRenderer = await createTestRenderer({width: 150, height: 24});
     const controller = new FakeController({
@@ -2057,7 +2102,7 @@ describe('theming', () => {
     expect(controller.liveCalls).toBe(0);
   });
 
-  it('leaves Enter to a typed command while the theme list is open', async () => {
+  it('contains typing and Enter while the theme list is open', async () => {
     const testRenderer = await createTestRenderer({width: 90, height: 24});
     const controller = new FakeController(initialSessionState());
     const app = createOpenTuiApp(testRenderer.renderer, controller);
@@ -2069,14 +2114,19 @@ describe('theming', () => {
     testRenderer.mockInput.pressKey('ARROW_DOWN');
     await testRenderer.waitForFrame(value => value.includes('\u203a light'));
 
-    await testRenderer.mockInput.typeText('/help');
+    // The picker is modal: typed text is swallowed instead of reaching the
+    // command input hidden behind it, and Enter applies the highlighted theme
+    // rather than submitting whatever leaked through.
+    await testRenderer.mockInput.typeText('/quack');
     testRenderer.mockInput.pressEnter();
-    await testRenderer.waitForFrame(() => controller.submissions.length === 2);
+    await testRenderer.waitForFrame(() => controller.state.themePicker === null);
 
-    // The command ran; the highlighted theme was not applied by its Enter.
-    expect(controller.submissions).toEqual(['/theme', '/help']);
-    expect(controller.state.themeName).toBe('dark');
-    expect(controller.state.themePicker?.selected).toBe('light');
+    expect(controller.submissions).toEqual(['/theme']);
+    expect(controller.state.themeName).toBe('light');
+    const settled = testRenderer.captureCharFrame();
+    // The input still shows its placeholder: nothing typed reached it.
+    expect(settled).not.toContain('/quack');
+    expect(settled).toContain('Type /help for commands');
   });
 
   it('owns its keys over the chat it was opened from', async () => {
@@ -2423,6 +2473,52 @@ describe('theming', () => {
     const back = await frameAfterEscape(testRenderer);
     expect(back).toContain('Implementation Details');
     expect(back).not.toContain('Available commands');
+  });
+
+  it('swallows keys an overlay does not use instead of leaking them behind', async () => {
+    const testRenderer = await createTestRenderer({width: 120, height: 24});
+    const controller = new FakeController({
+      ...initialSessionState(),
+      overlay: {kind: 'help', content: 'Available commands'},
+      core: {
+        ...initialSessionState().core,
+        rounds: [
+          {number: 1, status: 'completed' as const},
+          {number: 2, status: 'active' as const},
+        ],
+        transcript: [
+          {
+            id: 'live',
+            kind: 'assistant',
+            label: 'Agent',
+            content: 'live output',
+            roundNumber: 2,
+          },
+        ],
+      },
+    });
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await testRenderer.waitForFrame(value => value.includes('Available commands'));
+
+    // The overlay is modal: round navigation, pane focus, and typing are
+    // swallowed rather than applied to the panes or the hidden command input.
+    testRenderer.mockInput.pressKey('[');
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    await testRenderer.mockInput.typeText('/quack');
+    testRenderer.mockInput.pressEnter();
+    const held = await frameAfter(testRenderer);
+    expect(held).toContain('Available commands');
+    expect(controller.state.overlay).not.toBeNull();
+    expect(controller.state.selectedRound).toBeNull();
+    expect(controller.submissions).toEqual([]);
+
+    // Escape still closes it, and nothing typed while it was open surfaces.
+    testRenderer.mockInput.pressKey('ESCAPE');
+    const back = await frameAfterEscape(testRenderer);
+    expect(back).not.toContain('Available commands');
+    expect(back).toContain('live output');
+    expect(back).not.toContain('/quack');
   });
 
   it('colors the outcome cell from the active theme in light and dark', async () => {

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -2713,6 +2713,89 @@ describe('theming', () => {
     expect(controller.chatSubmissions).toEqual(['first line\nsecond line']);
   });
 
+  it('contains the theme picker over a focused docked chat', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    // Put the keys on the docked chat and start a draft in its composer.
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
+    await testRenderer.mockInput.typeText('keep this');
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.focus).toBe('chat');
+
+    // A global command opens the picker without moving focus off the chat, so
+    // the composer stays focused behind it.
+    controller.openThemePicker();
+    await testRenderer.waitForFrame(value => value.includes('Themes'));
+
+    // The picker is modal: arrows drive it rather than the chat suggestions.
+    testRenderer.mockInput.pressKey('ARROW_DOWN');
+    await frameAfter(testRenderer);
+    expect(controller.state.themePicker?.selected).toBe('light');
+
+    // A printable key is swallowed instead of leaking into the composer.
+    await testRenderer.mockInput.typeText('z');
+    await frameAfter(testRenderer);
+
+    // Escape closes the picker rather than focusing the left pane behind it.
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await frameAfterEscape(testRenderer);
+    expect(controller.state.themePicker).toBeNull();
+    expect(controller.state.layout.focus).toBe('chat');
+
+    // The draft is exactly what was typed before the picker opened: the arrow
+    // and the 'z' never reached the composer.
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.chatSubmissions.length === 1);
+    expect(controller.chatSubmissions).toEqual(['keep this']);
+    expect(controller.submissions).toEqual([]);
+  });
+
+  it('contains a help overlay over a focused docked chat', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = logController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+    await frameAfter(testRenderer);
+
+    testRenderer.mockInput.pressKey('w', {ctrl: true});
+    await frameAfter(testRenderer);
+    await testRenderer.mockInput.typeText('keep this');
+    await frameAfter(testRenderer);
+    expect(controller.state.layout.focus).toBe('chat');
+
+    // /help opens an overlay without moving focus off the docked chat.
+    controller.publish({
+      ...controller.state,
+      overlay: {kind: 'help', content: 'Available commands'},
+    });
+    await testRenderer.waitForFrame(value => value.includes('Available commands'));
+
+    // The overlay is modal: a printable key is swallowed instead of leaking
+    // into the composer focused behind it.
+    await testRenderer.mockInput.typeText('z');
+    await frameAfter(testRenderer);
+
+    // Escape closes the overlay (goes live) rather than focusing the left pane.
+    testRenderer.mockInput.pressKey('ESCAPE');
+    await frameAfterEscape(testRenderer);
+    expect(controller.state.overlay).toBeNull();
+    expect(controller.liveCalls).toBe(1);
+    expect(controller.state.layout.focus).toBe('chat');
+
+    // The draft still holds only what was typed before the overlay: the 'z'
+    // never reached the composer.
+    testRenderer.mockInput.pressEnter();
+    await testRenderer.waitForFrame(() => controller.chatSubmissions.length === 1);
+    expect(controller.chatSubmissions).toEqual(['keep this']);
+  });
+
   it('preserves a draft when a resize moves chat from dock to modal', async () => {
     const testRenderer = await createTestRenderer({width: 140, height: 20});
     const controller = logController();

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -116,26 +116,11 @@ export function bindKeybindings(
       key.preventDefault();
       return;
     }
-    if (chatPaneFocused(controller.state)) {
-      if (key.name === 'pageup' || key.name === 'pagedown' || key.name === 'escape') {
-        if (key.name === 'escape') controller.focusPane('left');
-        else actions.scrollChatPane(key.name === 'pageup' ? -1 : 1);
-        key.preventDefault();
-        return;
-      }
-      // The typed-command suggestions take Up/Down/Tab only while they are
-      // showing; otherwise the keys fall through to the editor underneath
-      // (multiline cursor movement, and Tab's ordinary no-op).
-      if (key.name === 'up' || key.name === 'down') {
-        if (actions.navigateChatSuggestions(key.name === 'up' ? -1 : 1)) key.preventDefault();
-        return;
-      }
-      if (key.name === 'tab' && !key.shift) {
-        if (actions.completeChatInput()) key.preventDefault();
-        return;
-      }
-      return;
-    }
+    // Modal state is authoritative: the theme picker, the modal chat, and any
+    // overlay must contain input before the focused docked chat runs. Otherwise
+    // a modal opened while the docked chat has focus would leak printable keys
+    // into the hidden composer, let Up/Down drive chat suggestions, and route
+    // Escape to the left pane instead of closing the modal.
     if (controller.state.themePicker !== null) {
       if (key.name === 'up') controller.moveThemeSelection(-1);
       else if (key.name === 'down') controller.moveThemeSelection(1);
@@ -155,7 +140,7 @@ export function bindKeybindings(
         key.preventDefault();
         return;
       }
-      // Same suggestion-menu priority as the docked chat above.
+      // Same suggestion-menu priority as the docked chat below.
       if (key.name === 'up' || key.name === 'down') {
         if (actions.navigateChatSuggestions(key.name === 'up' ? -1 : 1)) key.preventDefault();
         return;
@@ -174,6 +159,26 @@ export function bindKeybindings(
       // The overlay is modal: everything it does not handle is swallowed so
       // keys cannot reach the panes or the hidden command input behind it.
       key.preventDefault();
+      return;
+    }
+    if (chatPaneFocused(controller.state)) {
+      if (key.name === 'pageup' || key.name === 'pagedown' || key.name === 'escape') {
+        if (key.name === 'escape') controller.focusPane('left');
+        else actions.scrollChatPane(key.name === 'pageup' ? -1 : 1);
+        key.preventDefault();
+        return;
+      }
+      // The typed-command suggestions take Up/Down/Tab only while they are
+      // showing; otherwise the keys fall through to the editor underneath
+      // (multiline cursor movement, and Tab's ordinary no-op).
+      if (key.name === 'up' || key.name === 'down') {
+        if (actions.navigateChatSuggestions(key.name === 'up' ? -1 : 1)) key.preventDefault();
+        return;
+      }
+      if (key.name === 'tab' && !key.shift) {
+        if (actions.completeChatInput()) key.preventDefault();
+        return;
+      }
       return;
     }
     // The experiment surface owns navigation while it is on screen. The index

--- a/clients/tui/src/ui/keybindings.ts
+++ b/clients/tui/src/ui/keybindings.ts
@@ -142,10 +142,9 @@ export function bindKeybindings(
       else if (key.name === 'pageup') controller.moveThemeSelection(-10);
       else if (key.name === 'pagedown') controller.moveThemeSelection(10);
       else if (key.name === 'escape') controller.closeThemePicker();
-      else if (key.name === 'return' || key.name === 'enter') {
-        if (!actions.inputIsEmpty()) return;
-        controller.applySelectedTheme();
-      } else return;
+      else if (key.name === 'return' || key.name === 'enter') controller.applySelectedTheme();
+      // The picker is modal: keys it does not use are swallowed here so they
+      // cannot move panes or type into the still-focused input behind it.
       key.preventDefault();
       return;
     }
@@ -167,9 +166,13 @@ export function bindKeybindings(
       }
       return;
     }
-    if (key.name === 'escape' && controller.state.overlay !== null) {
-      controller.live();
-      viewport.scrollTo(viewport.scrollHeight);
+    if (controller.state.overlay !== null) {
+      if (key.name === 'escape') {
+        controller.live();
+        viewport.scrollTo(viewport.scrollHeight);
+      }
+      // The overlay is modal: everything it does not handle is swallowed so
+      // keys cannot reach the panes or the hidden command input behind it.
       key.preventDefault();
       return;
     }
@@ -234,7 +237,9 @@ export function bindKeybindings(
         return;
       }
     }
-    if (key.name === 'left' || key.name === 'right') {
+    // Like Enter above, pane focus and round navigation yield to a typed
+    // command: cursor keys and brackets belong to a non-empty input.
+    if ((key.name === 'left' || key.name === 'right') && actions.inputIsEmpty()) {
       controller.focusRound(key.name === 'left' ? 'agents' : 'transcript');
       key.preventDefault();
       return;
@@ -279,13 +284,13 @@ export function bindKeybindings(
       key.preventDefault();
       return;
     }
-    if (key.name === ']') {
+    if (key.name === ']' && actions.inputIsEmpty()) {
       actions.selectNextRound();
       viewport.scrollTo(viewport.scrollHeight);
       key.preventDefault();
       return;
     }
-    if (key.name === '[') {
+    if (key.name === '[' && actions.inputIsEmpty()) {
       actions.selectPreviousRound();
       viewport.scrollTo(viewport.scrollHeight);
       key.preventDefault();


### PR DESCRIPTION
## Problem

Three overlapping keystroke-routing defects in the TUI client, all in `keybindings.ts`, let keys reach the wrong surface. First, `[`, `]`, Left, and Right were handled globally with no `inputIsEmpty()` guard, unlike Enter. Typing a command that contains those characters (for example `/steer fix arr[0]`) silently dropped both brackets and jumped round focus mid-command instead of inserting them into the command input. Second, the theme picker intercepted only its own navigation keys and let every other key leak through to the command input and the global bindings behind it, so typing while the picker was open both edited the hidden input and triggered pane or round actions. Third, the `/help` and round-detail overlays handled only Escape, so every other key acted on the UI underneath an open overlay. In all three cases a key that should have been either inserted as text or swallowed by a modal instead mutated round focus or pane state.

## Solution

Make the guarded bindings and the two modal surfaces obey the same contract Enter already had. `[`, `]`, Left, and Right now fire round navigation and pane focus only when the command input is empty; with text present they fall through to the input untouched, so cursor keys and brackets belong to a non-empty command. The theme picker and the overlays are treated as modal: each handles its own keys (navigation, apply, Escape) and `preventDefault`s everything else, so no key reaches the command input, round focus, or any global binding while one is open. Escape on an overlay returns to the live tail. The change is confined to the key-dispatch order in `bindKeybindings`; no controller state, event flow, or rendering path is touched.

### Architecture

`keybindings.ts` owns the single global key handler and is the only place that decides, per keystroke, whether a key belongs to a modal surface, the command input, or a global binding. The controller and the views are unchanged: they still expose the same actions (`applySelectedTheme`, `closeThemePicker`, `live`, `focusRound`, `selectNextRound`, `selectPreviousRound`) and the same `inputIsEmpty()` predicate the handler consults. The fix reorders and guards the dispatch so a modal short-circuits first, then the empty-input guard gates round and pane navigation, then text falls through to the input.

```mermaid
flowchart TD
    K[keydown] --> M{theme picker or<br/>overlay open?}
    M -->|yes| MK{key the modal<br/>handles?}
    MK -->|yes| A[act: navigate / apply / Escape to live tail]
    MK -->|no| S[preventDefault: swallow<br/>never reaches input or globals]
    M -->|no| E{command input<br/>empty?}
    E -->|no| I[insert into command input:<br/>brackets, Left, Right stay as text]
    E -->|yes| G[global nav: focusRound,<br/>selectPreviousRound / selectNextRound]
```

## Verification

Automated: the TUI TypeScript pipeline (`tsc`, biome) and the TUI test suite pass on top of current `main`; the new assertions fail without the change and pass with it. Manual: a live `--cli-provider claude` run with the TUI attached, exercising the three cases end to end.

### Correctness properties

- A key pressed with text in the command input always goes to the input; round navigation and pane focus via `[`, `]`, Left, and Right fire only when the input is empty, matching Enter's existing guard.
- An open theme picker or overlay captures every key: its own keys act, everything else is swallowed, and nothing reaches the command input, round focus, or any global binding behind it.
- Escape on an open overlay closes it and returns to the live tail with the command input untouched.

### Testing

- New unit tests in `app.test.ts` (3 tests): typing and Enter are contained while the theme picker is open (the typed command is discarded and the highlighted theme applies); an open overlay swallows `[`, Left, and a typed command, and Escape restores the live tail with the input untouched; brackets and cursor keys stay in a non-empty command input, and `[` still navigates rounds once the input is empty.
- One pre-existing test that pinned the theme picker's Enter leak was updated to assert containment.
- `pnpm --filter @vibesys/tui check` (tsc), biome over the changed files, and `pnpm --filter @vibesys/tui test` all pass; the only failing test is the pre-existing environment-specific `launcher` case, which fails identically on unmodified `main`.
- Manual, real provider: a live `--cli-provider claude` run on the queue demo task. `/steer fix arr[0]` renders both brackets in the input and Left moves the cursor without touching round focus; with the input empty `[` still navigates rounds. The open theme picker swallows typed letters and closes on Escape. The open `/help` overlay swallows `[`, Left, and a typed command; Escape returns to the live tail with the command input still empty.

Closes #471.
