### PR TITLE
TUI: Render one answer per experiment chat turn

### DIFF
--- a/clients/core-state/src/core-state-prefix.test.ts
+++ b/clients/core-state/src/core-state-prefix.test.ts
@@ -162,6 +162,26 @@ describe('prefix merges across the chunk boundary', () => {
     ]);
   });
 
+  it('folds a tail answer over a streamed chat turn left in the chunk', () => {
+    const events = [
+      threadCreatedEvent(1, 'thread-a'),
+      chatChunkEvent(2, 'thread-a', 'partial '),
+      chatChunkEvent(3, 'thread-a', 'stream'),
+      chatEvent(4, 'thread-a', 'complete answer'),
+    ];
+
+    // The turn's streamed chunks fall below the floor; only its terminal answer
+    // lands in the tail. A full replay folds the answer over its streamed turn
+    // and renders it once, so the backfilled merge must too rather than leaving
+    // the streamed entry beside a second answer entry.
+    const merged = foldAsPrefix(events, 3);
+
+    expect(merged).toEqual(reduceEventBatch(initialCoreState(), events));
+    expect(merged.chatTranscripts['thread-a']?.map(entry => entry.content)).toEqual([
+      'complete answer',
+    ]);
+  });
+
   it('keeps a round started in the chunk and finished in the tail', () => {
     const events = [chunkEvent(1, 'work'), roundFinishedEvent(2)];
 
@@ -759,6 +779,17 @@ function chatEvent(sequence: number, threadId: string, answer: string, title?: s
     chat_thread_id: threadId,
     status: 'answered',
     data: {kind: 'chat', answer, ...(title === undefined ? {} : {thread_title: title})},
+  };
+}
+
+function chatChunkEvent(sequence: number, threadId: string, content: string): RunEvent {
+  return {
+    ...baseEvent(sequence, 'agent_output_chunk'),
+    agent_kind: 'chat',
+    round_label: 'experiment-chat',
+    chat_thread_id: threadId,
+    invocation_id: `${threadId}-turn`,
+    data: {kind: 'agent_output_chunk', channel: 'assistant', content},
   };
 }
 

--- a/clients/core-state/src/core-state-prefix.test.ts
+++ b/clients/core-state/src/core-state-prefix.test.ts
@@ -153,11 +153,12 @@ describe('prefix merges across the chunk boundary', () => {
         model: 'opus',
       },
     ]);
-    // Consecutive chat answers carry no turn id, so the fold concatenates them
-    // exactly as it does inside one batch. The point is that it still does when
-    // the two answers land on opposite sides of the boundary.
+    // Each chat answer is a complete turn and stays a separate entry. The point
+    // is that the prefix fold agrees with the in-batch fold even when the two
+    // answers land on opposite sides of the boundary.
     expect(merged.chatTranscripts['thread-a']?.map(entry => entry.content)).toEqual([
-      'first answersecond answer',
+      'first answer',
+      'second answer',
     ]);
   });
 

--- a/clients/core-state/src/core-state.test.ts
+++ b/clients/core-state/src/core-state.test.ts
@@ -400,6 +400,49 @@ describe('core state projection', () => {
     expect(state.transcript).toEqual([]);
   });
 
+  it('folds the final chat answer over its own streamed chunks', () => {
+    let state = initialCoreState();
+    state = reduceEvent(state, chatStreamEvent(1, 'The queue ', 'exec-1'));
+    state = reduceEvent(state, chatStreamEvent(2, 'is lock-free.', 'exec-1'));
+    state = reduceEvent(state, chatAnswerEvent(3, 'The queue is lock-free.'));
+
+    // One answer block, under the streamed entry's id so consumers tracking
+    // entries by id update in place, closed to any further folding.
+    expect(state.chatTranscript).toHaveLength(1);
+    expect(state.chatTranscript[0]).toMatchObject({
+      id: '1',
+      kind: 'assistant',
+      label: 'Answer',
+      content: 'The queue is lock-free.',
+    });
+    expect(state.chatTranscript[0]?.turnId).toBeUndefined();
+  });
+
+  it('reconciles each chat turn separately and appends unstreamed answers', () => {
+    const events = [
+      chatStreamEvent(1, 'first ', 'exec-1'),
+      chatStreamEvent(2, 'answer', 'exec-1'),
+      chatAnswerEvent(3, 'first answer'),
+      chatAnswerEvent(4, 'unstreamed answer'),
+      chatStreamEvent(5, 'second answer', 'exec-2'),
+      chatAnswerEvent(6, 'second answer'),
+    ];
+    const batched = reduceEventBatch(initialCoreState(), events);
+    let single = initialCoreState();
+    for (const item of events) single = reduceEvent(single, item);
+
+    // Both fold paths agree: a finalized turn cannot swallow the next answer,
+    // and an answer that never streamed still lands as its own entry.
+    for (const state of [batched, single]) {
+      expect(state.chatTranscript.map(item => [item.id, item.content])).toEqual([
+        ['1', 'first answer'],
+        ['4', 'unstreamed answer'],
+        ['5', 'second answer'],
+      ]);
+      expect(state.chatTranscript.every(item => item.turnId === undefined)).toBe(true);
+    }
+  });
+
   it('replays the thread list from creation events after the implicit default', () => {
     let state = initialCoreState();
     state = reduceEvent(state, threadCreatedEvent(1, 'thread-a', 'claude'));
@@ -796,6 +839,15 @@ function chatAnswerEvent(sequence: number, answer: string, threadId?: string): R
     round_label: 'experiment-chat',
     ...(threadId === undefined ? {} : {chat_thread_id: threadId}),
     data: {kind: 'chat', answer},
+  };
+}
+
+/** One assistant-channel chunk of a chat turn, as the chat agent streams it. */
+function chatStreamEvent(sequence: number, content: string, invocationId: string): RunEvent {
+  return {
+    ...outputEvent(sequence, content, invocationId),
+    agent_kind: 'chat',
+    round_label: 'experiment-chat',
   };
 }
 

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -685,7 +685,7 @@ function applyChatEvent(
   }
   const entry = eventToTranscriptEntry(event);
   if (entry === null || (entry.kind !== 'assistant' && entry.kind !== 'result')) return next;
-  return appendChatTranscript(next, threadId, entry, folder);
+  return appendChatTranscript(next, threadId, entry, folder, data?.kind === 'chat');
 }
 
 /** Registers a replayed thread, or refreshes the record it already has. */
@@ -729,18 +729,44 @@ function appendChatTranscript(
   threadId: string,
   entry: TranscriptEntry,
   folder: TranscriptFolder | null,
+  finalAnswer = false,
 ): CoreState {
   if (folder !== null) {
-    folder.buffer(threadId, state.chatTranscripts[threadId] ?? []).append(entry);
+    const buffer = folder.buffer(threadId, state.chatTranscripts[threadId] ?? []);
+    if (!(finalAnswer && foldChatAnswer(buffer.entries, entry))) buffer.append(entry);
     return state;
   }
-  const transcript = appendTranscript(state.chatTranscripts[threadId] ?? [], entry);
+  const transcript = [...(state.chatTranscripts[threadId] ?? [])];
+  if (!(finalAnswer && foldChatAnswer(transcript, entry))) {
+    foldTranscriptEntry(transcript, entry, null);
+  }
   const chatTranscripts = {...state.chatTranscripts, [threadId]: transcript};
   return {
     ...state,
     chatTranscripts,
     chatTranscript: threadId === DEFAULT_CHAT_THREAD_ID ? transcript : state.chatTranscript,
   };
+}
+
+/**
+ * Folds a turn's terminal answer over its own streamed chunks.
+ *
+ * The assistant chunks of one chat turn have already merged into a single
+ * entry keyed by the turn's invocation id, and the terminal `chat` event
+ * carries the same text once more. When such a turn is still open at the end
+ * of the transcript, the final answer replaces it in place rather than
+ * appearing as a second copy. The streamed entry's id is kept so consumers
+ * tracking entries by id update instead of duplicating, and the turn id is
+ * dropped because the turn is over: neither a later chunk nor a later answer
+ * may fold into it. Returns false when there is no open streamed turn, in
+ * which case the answer appends as its own entry.
+ */
+function foldChatAnswer(entries: TranscriptEntry[], incoming: TranscriptEntry): boolean {
+  const last = entries.at(-1);
+  if (last === undefined || last.kind !== 'assistant' || last.turnId === undefined) return false;
+  const {turnId: _closed, ...merged} = {...last, ...incoming, id: last.id};
+  entries[entries.length - 1] = merged;
+  return true;
 }
 
 function applyDiagnosticEvent(state: CoreState, event: RunEvent): CoreState {
@@ -1119,6 +1145,10 @@ function foldTranscriptEntry(
   if (
     last !== undefined &&
     last.kind === incoming.kind &&
+    // Chunks of one turn share its id; an entry without a turn (a terminal
+    // chat answer, or one already closed by `foldChatAnswer`) is complete and
+    // must not glue onto a neighbor that is just as complete.
+    last.turnId !== undefined &&
     last.turnId === incoming.turnId &&
     (incoming.kind === 'assistant' || incoming.kind === 'prompt' || incoming.kind === 'analysis')
   ) {

--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -345,7 +345,9 @@ export function reduceEventPrefix(
  * than sitting wholly before it.
  *
  * So the two sequence-ordered lists are merged in sequence order and each entry
- * re-folded through `foldTranscriptEntry`. That is exact: entries are already
+ * re-folded through `foldTranscriptEntry`, with terminal chat answers taking the
+ * `foldChatAnswer` step instead so an answer folds over the streamed turn it
+ * closes even when the two straddle the floor. That is exact: entries are already
  * maximally merged within each list and the step is idempotent over an
  * already merged entry, so re-folding in replay order reproduces replay.
  *
@@ -378,7 +380,20 @@ function mergeTranscriptPrefix(
             ? newer
             : older;
     const entry = source === older ? older[left++] : newer[right++];
-    if (entry !== undefined) foldTranscriptEntry(entries, entry, index);
+    if (entry === undefined) continue;
+    // A terminal chat answer carries no turn id and, in replay, folds over its
+    // own still-open streamed turn through `foldChatAnswer`. When the turn's
+    // chunks sit below the history floor and the answer above it, the two
+    // arrive from opposite lists, so reconcile them here as replay would; a
+    // second entry would otherwise survive. Anything else takes the normal step.
+    if (
+      entry.kind === 'assistant' &&
+      entry.turnId === undefined &&
+      foldChatAnswer(entries, entry)
+    ) {
+      continue;
+    }
+    foldTranscriptEntry(entries, entry, index);
   }
   return entries;
 }


### PR DESCRIPTION
## Problem

Every experiment chat answer rendered twice. The streamed assistant deltas of one turn fold into a single transcript entry keyed by `turnId` (the invocation id), and then the terminal `chat` event, which carries no turn id, appended a second entry with the identical full text under the label "Answer". A related pre-existing bug compounded it: consecutive chat answers glued into a single transcript entry, because the assistant-merge rule in `foldTranscriptEntry` treated two missing turn ids as equal, so any thread with more than one answer merged its answers into one block independent of the duplication.

## Solution

The terminal chat answer now folds over its own streamed entry in place (`foldChatAnswer`) rather than appending. It replaces the last entry when that entry is an assistant entry with a defined turn id, keeps the streamed entry's id so `reconcileChatTranscript`'s replace-by-id stays stable, takes the terminal event's fields (label "Answer", authoritative full text), and drops the turn id to mark the turn closed. The assistant-merge rule in `foldTranscriptEntry` additionally requires a defined turn id, so two complete answers (both with no turn id) can never glue into one block. Answers that were never streamed still append as their own entry. The change is confined to the chat-transcript fold in `core-state.ts`; the event contract and every other reducer are unchanged.

### Architecture

`core-state.ts` owns the chat transcript reduction, and both the streamed-chunk fold and the terminal-answer fold live there, so the two paths agree on what one turn is. `appendChatTranscript` now consults `foldChatAnswer` on the terminal answer before falling back to a plain append, on both the streaming (`TranscriptFolder`) path and the direct path; `foldTranscriptEntry` carries the tightened turn-id predicate that keeps two complete answers separate. The server, the streaming protocol, and the TUI views are unchanged: the same events arrive in the same order and one entry per turn now comes out.

```mermaid
flowchart TD
    S[streamed assistant chunks<br/>share turnId] --> E[one open entry keyed by turnId]
    T[terminal chat event<br/>no turnId, full text] --> F{foldChatAnswer:<br/>last entry assistant<br/>with a turnId?}
    E --> F
    F -->|yes| R[replace in place: keep entry id,<br/>take Answer label + full text, drop turnId]
    F -->|no| A[append as its own entry]
    R --> O[exactly one entry per turn]
    A --> O
```

## Verification

Automated: the `core-state` TypeScript pipeline (`tsc`, biome) and the `core-state` test suite pass on top of current `main`; the new assertions fail without the change and pass with it. Manual: a live `--cli-provider claude` run with the TUI attached, exercising the chat path end to end.

### Correctness properties

- Exactly one transcript entry exists per chat turn: streamed chunks merge into it, the terminal answer replaces it in place keeping its id, unstreamed answers append once, and two complete answers never merge.
- The prefix (scroll-back backfill) fold and the in-batch fold agree on chat transcripts even when a turn's events straddle the chunk boundary.
- The wire protocol is unchanged: no event shape or ordering assumption is altered.

### Testing

- New unit tests in `core-state.test.ts` (2 tests): the final answer folds over its own streamed chunks keeping the streamed id; multiple turns, including an unstreamed answer landing between two streamed turns, stay separate entries, asserted identically through `reduceEventBatch` and sequential `reduceEvent`.
- One pre-existing prefix test that pinned consecutive chat answers concatenating into one entry was updated to assert two entries; the boundary-consistency property it exists for still holds and is also asserted by the new dual-path test.
- `pnpm --filter @vibesys/core-state check` (tsc), biome over the changed files, and `pnpm --filter @vibesys/core-state test` (66 tests, 0 failures) all pass.
- Manual, real provider: two questions asked in experiment chat each produced exactly one Answer block, and the second answer stayed its own block. No duplicate appeared after later event-driven reconciliations.

### Additional findings while solving this issue

- Pre-existing bug found and fixed alongside the duplication: consecutive chat answers glued into a single transcript entry, because the assistant-merge rule treated two missing turn ids as equal. This affected any thread with more than one answer, independent of the duplication bug. The tightened rule is safe beyond chat: streamed entries always carry a turn id, so only complete answers are affected.

Closes #473.
