### PR TITLE
Support optional task Dockerfiles

### DIFF
--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -330,6 +330,14 @@ starts with an actionable error.
 | `--modal` | Modal workflow. | Mutually exclusive with `--docker`. Intended for remote GPU dispatch. |
 | `--run-environment skypilot` | Local CPU editor with SkyPilot evaluators. | Requires portable task resources and an operator-owned cluster profile. See [Remote Slurm execution](remote-slurm-execution.md). |
 
+A repository-native task may provide
+`.vibesys/tasks/<task>/Dockerfile`. Its presence automatically selects the
+Docker environment, builds with the task directory as its complete context,
+and uses the resulting immutable image ID. No manifest field or pre-build step
+is required. Explicit alternative environments and `--docker-image` conflict
+with this convention; explicit `--docker` is harmless. Root Dockerfiles in
+legacy bundles remain candidate files and are not auto-detected.
+
 `--docker-image` overrides the backend's default container image when Docker or
 Modal is active, and the local CPU editor image for SkyPilot.
 

--- a/docs/contributing/coding-best-practices.md
+++ b/docs/contributing/coding-best-practices.md
@@ -16,8 +16,10 @@ path.
   code or prompt skeletons.
 - Keep reusable targets in their candidate repository under
   `.vibesys/tasks/<name>/`: `OBJECTIVE.md`, `vibesys.input.toml`, optional
-  `reference/`, task-owned checker/benchmark programs, and an optional
-  `README.md`.
+  `reference/`, task-owned checker/benchmark programs, an optional `Dockerfile`,
+  and an optional `README.md`. A task Dockerfile installs the execution
+  environment only. Its build context is the task directory, while VibeSys
+  mounts the current candidate repository at runtime.
   Evaluator commands run from the repository root. Reusable evaluator
   implementations belong in versioned packages, not copied task directories.
 - Access the `.vibesys` layout and generated state through `vs-project`. Open one

--- a/docs/running-vibesys.md
+++ b/docs/running-vibesys.md
@@ -13,6 +13,7 @@ project/
 │   │   └── <task>/
 │   │       ├── OBJECTIVE.md
 │   │       ├── vibesys.input.toml
+│   │       ├── Dockerfile           # optional task execution environment
 │   │       ├── accuracy_checker/    # optional task-owned program
 │   │       ├── benchmark/           # optional task-owned program
 │   │       └── reference/           # optional held-out inputs
@@ -57,6 +58,20 @@ The task name may be omitted when `.vibesys/tasks` contains exactly one task.
 The repository must be its Git root, or outside any Git repository so VibeSys
 can initialize one. An existing repository needs a baseline commit and a clean
 worktree. Keep `agent.toml` and root `.env*` files out of Git history.
+
+When the selected repository-native task contains a conventional
+`.vibesys/tasks/<task>/Dockerfile`, VibeSys builds it with that task directory
+as the complete build context and automatically selects Docker execution. The
+resolved immutable image ID is recorded with the run. Docker's native layer
+cache makes later launches incremental. The candidate repository is mounted at
+runtime and is never part of the image build context.
+
+Task Dockerfiles are intentionally convention-based: they require no manifest
+field or image-build command. A task Dockerfile cannot be combined with another
+image source or a different run environment. `--docker` and
+`--run-environment docker` are redundant but accepted. Legacy root input
+bundles do not opt in through a root `Dockerfile`, because that file commonly
+belongs to the candidate application.
 
 The `agent`, `plain`, and `evolve` outer loops all use this model. Local, Docker,
 and Modal execution change where commands run, not the task layout. Task

--- a/libs/vs-project/src/vs_project/_layout.py
+++ b/libs/vs-project/src/vs_project/_layout.py
@@ -23,6 +23,7 @@ _CONFIGURATION_DIRECTORY_NAME = project_paths.CONFIGURATION_DIRECTORY_NAME
 _TASKS_DIRECTORY_NAME = project_paths.TASKS_DIRECTORY_NAME
 _OBJECTIVE_FILE_NAME = project_paths.OBJECTIVE_FILE_NAME
 _MANIFEST_FILE_NAME = project_paths.MANIFEST_FILE_NAME
+_DOCKERFILE_NAME = "Dockerfile"
 _TASK_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
 
 
@@ -128,12 +129,13 @@ class TasksRoot:
 
 @dataclass(frozen=True)
 class TaskDirectory:
-    """Validated task directory and its required trusted inputs."""
+    """Validated task directory and its conventional trusted inputs."""
 
     name: TaskName
     path: Path
     objective_path: Path
     manifest_path: Path
+    dockerfile_path: Path | None
 
     def resolve(self, relative_path: Path | str, *, must_exist: bool = True) -> Path:
         """Resolve a safe task-relative resource without leaving this task."""
@@ -264,11 +266,13 @@ class ProjectLayout:
         )
         objective_path = _resolve_required_file(path, _OBJECTIVE_FILE_NAME, name)
         manifest_path = _resolve_required_file(path, _MANIFEST_FILE_NAME, name)
+        dockerfile_path = _resolve_optional_file(path, _DOCKERFILE_NAME, name)
         return TaskDirectory(
             name=name,
             path=path,
             objective_path=objective_path,
             manifest_path=manifest_path,
+            dockerfile_path=dockerfile_path,
         )
 
     def _configuration_path(self) -> Path:
@@ -308,6 +312,32 @@ def _resolve_required_file(task_root: Path, filename: str, task_name: TaskName) 
     if not path.is_file():
         raise InvalidTaskDefinitionError(
             f"VibeSys task {task_name.value!r} required path is not a file: {lexical_path}"
+        )
+    return path
+
+
+def _resolve_optional_file(
+    task_root: Path,
+    filename: str,
+    task_name: TaskName,
+) -> Path | None:
+    lexical_path = task_root / filename
+    if lexical_path.is_symlink():
+        raise UnsafeProjectPathError(
+            f"optional file {filename} must not be a symlink: {lexical_path}"
+        )
+    if not lexical_path.exists():
+        return None
+    try:
+        path = lexical_path.resolve(strict=True)
+    except OSError as exc:
+        raise InvalidTaskDefinitionError(
+            f"VibeSys task {task_name.value!r} could not resolve optional file {filename}"
+        ) from exc
+    _require_contained(path, task_root, f"optional file {filename}")
+    if not path.is_file():
+        raise InvalidTaskDefinitionError(
+            f"VibeSys task {task_name.value!r} optional path is not a file: {lexical_path}"
         )
     return path
 

--- a/libs/vs-project/tests/test_layout.py
+++ b/libs/vs-project/tests/test_layout.py
@@ -73,7 +73,48 @@ def test_tasks_are_typed_validated_and_sorted(tmp_path: Path) -> None:
     assert tasks[0].path == alpha.resolve()
     assert tasks[0].objective_path == (alpha / "OBJECTIVE.md").resolve()
     assert tasks[0].manifest_path == (alpha / "vibesys.input.toml").resolve()
+    assert tasks[0].dockerfile_path is None
     assert tasks[1].path == beta.resolve()
+
+
+def test_task_discovers_optional_dockerfile(tmp_path: Path) -> None:
+    task_path = _write_task(tmp_path, "latency")
+    dockerfile = task_path / "Dockerfile"
+    dockerfile.write_text("FROM ubuntu:24.04\n", encoding="utf-8")
+
+    task = Project.open(tmp_path).select_task("latency")
+
+    assert task.dockerfile_path == dockerfile.resolve()
+
+
+def test_optional_dockerfile_must_be_a_file(tmp_path: Path) -> None:
+    task_path = _write_task(tmp_path, "latency")
+    (task_path / "Dockerfile").mkdir()
+
+    with pytest.raises(InvalidTaskDefinitionError, match="optional path is not a file"):
+        Project.open(tmp_path).select_task("latency")
+
+
+def test_optional_dockerfile_symlink_cannot_escape_task_root(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    task_path = _write_task(project, "latency")
+    external_dockerfile = project / "Dockerfile"
+    external_dockerfile.write_text("FROM ubuntu:24.04\n", encoding="utf-8")
+    (task_path / "Dockerfile").symlink_to(external_dockerfile)
+
+    with pytest.raises(UnsafeProjectPathError, match=r"Dockerfile must not be a symlink"):
+        Project.open(project).select_task("latency")
+
+
+def test_optional_dockerfile_symlink_is_rejected_within_task_root(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    task_path = _write_task(project, "latency")
+    target = task_path / "container.Dockerfile"
+    target.write_text("FROM ubuntu:24.04\n", encoding="utf-8")
+    (task_path / "Dockerfile").symlink_to(target.name)
+
+    with pytest.raises(UnsafeProjectPathError, match=r"Dockerfile must not be a symlink"):
+        Project.open(project).select_task("latency")
 
 
 def test_select_task_supports_explicit_and_single_implicit_selection(tmp_path: Path) -> None:

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -57,6 +57,7 @@ from vibesys.sandbox.run_environment import (
     make_run_environment_spec,
     run_environment_record,
 )
+from vibesys.sandbox.task_image import build_task_image
 from vibesys.skills import resolve_skill_source_dirs
 from vs_github import GitHubCLI, GitHubCLIError
 from vs_project import (
@@ -870,7 +871,11 @@ def _prepare_stub_agent_smoke_defaults(argv: list[str]) -> list[str]:
     return argv
 
 
-def run_environment_spec_from_args(args: argparse.Namespace) -> RunEnvironmentSpec:  # tracked: #288
+def run_environment_spec_from_args(  # tracked: #288
+    args: argparse.Namespace,
+    *,
+    build_task_docker_image: bool = False,
+) -> RunEnvironmentSpec:
     bundle = getattr(args, "input_bundle", None)
     selected = getattr(args, "run_environment", None)
     explicit = getattr(args, "explicit_cli_dests", frozenset())
@@ -878,15 +883,57 @@ def run_environment_spec_from_args(args: argparse.Namespace) -> RunEnvironmentSp
         raise ValueError(  # noqa: TRY003
             "--run-environment cannot be combined with --docker, --modal, or --skypilot"
         )
+    compatibility_selections = (
+        args.docker,
+        args.modal,
+        getattr(args, "skypilot", False),
+    )
+    if sum(compatibility_selections) > 1:
+        raise ValueError("--docker, --modal, and --skypilot are mutually exclusive")  # noqa: TRY003
+
+    dockerfile_path = bundle.dockerfile_path if bundle is not None else None
+    resuming = getattr(args, "resume", None) is not None
+    requested_environment = (
+        selected
+        or ("skypilot" if getattr(args, "skypilot", False) else None)
+        or ("modal" if args.modal else None)
+        or ("docker" if args.docker else None)
+        or "local"
+    )
+    if dockerfile_path is not None and not resuming:
+        conflicts: list[str] = []
+        if requested_environment == "local" and "run_environment" in explicit:
+            conflicts.append("--run-environment local")
+        elif requested_environment == "modal":
+            conflicts.append("--run-environment modal" if selected else "--modal")
+        elif requested_environment == "skypilot":
+            conflicts.append("--run-environment skypilot" if selected else "--skypilot")
+        if "docker_image" in explicit:
+            conflicts.append("--docker-image")
+        if conflicts:
+            joined = ", ".join(conflicts)
+            raise ValueError(  # noqa: TRY003
+                f"task Dockerfile {dockerfile_path} cannot be combined with {joined}"
+            )
+        requested_environment = "docker"
+
+    task_image = None
+    if (
+        dockerfile_path is not None
+        and requested_environment == "docker"
+        and build_task_docker_image
+    ):
+        task_image = build_task_image(dockerfile_path)
+
     return make_run_environment_spec(
-        use_docker=args.docker or selected == "docker",
-        docker_image=args.docker_image,
-        use_modal=args.modal or selected == "modal",
+        use_docker=requested_environment == "docker",
+        docker_image=task_image or args.docker_image,
+        use_modal=requested_environment == "modal",
         modal_gpu=args.modal_gpu,
         modal_model_volume=args.modal_model_volume,
         modal_app=args.modal_app,
         modal_entrypoint=bundle.modal_entrypoint if bundle is not None else None,
-        use_skypilot=getattr(args, "skypilot", False) or selected == "skypilot",
+        use_skypilot=requested_environment == "skypilot",
         cluster_profile=getattr(args, "cluster_profile", None),
         cluster_profiles_file=getattr(args, "cluster_profiles_file", None),
         skypilot_executable=getattr(args, "skypilot_executable", "sky"),
@@ -2026,7 +2073,10 @@ def _run_agent(args: argparse.Namespace, integration: RunIntegration) -> None:
             pareto_relative_noise = _load_pareto_relative_noise_toml(bundle.task_root)
 
         with boot_trace.span("run_environment_spec"):
-            run_environment = run_environment_spec_from_args(args)
+            run_environment = run_environment_spec_from_args(
+                args,
+                build_task_docker_image=True,
+            )
 
     success = run_agent_loop(
         config=config,
@@ -2361,7 +2411,7 @@ def _run_evolve(args: argparse.Namespace, integration: RunIntegration) -> None:
         debug=args.debug,
         profiler_kind=args.profiler,
         skills_dirs=skills,
-        run_environment=run_environment_spec_from_args(args),
+        run_environment=run_environment_spec_from_args(args, build_task_docker_image=True),
         agent_backend=args.agent_backend,
         cli_provider=args.cli_provider,
         backend=backend,
@@ -2445,7 +2495,7 @@ def _run_plain(args: argparse.Namespace, integration: RunIntegration) -> None:
         debug=args.debug,
         profiler_kind=args.profiler,
         skills_dirs=skills,
-        run_environment=run_environment_spec_from_args(args),
+        run_environment=run_environment_spec_from_args(args, build_task_docker_image=True),
         agent_backend=args.agent_backend,
         cli_provider=args.cli_provider,
         backend=backend,

--- a/src/vibesys/agents/cli_docker.py
+++ b/src/vibesys/agents/cli_docker.py
@@ -99,8 +99,8 @@ _COMMON_DOCKER_TOOLING_INSTALL = [
     _apt_install("curl ca-certificates", check_bin="curl"),
     _RUST_TOOLCHAIN_INSTALL,
     _apt_install("ripgrep", check_bin="rg"),
-    _apt_install("python3 python3-pip"),
-    "python3 -m pip install --quiet 'mcp>=1.0,<2'",
+    _apt_install("python3 python3-pip", check_bin="pip3"),
+    "PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install --quiet 'mcp>=1.0,<2'",
 ]
 
 _DOCKER_INSTALL_COMMANDS: dict[str, list[str]] = {

--- a/src/vibesys/input_manifest.py
+++ b/src/vibesys/input_manifest.py
@@ -422,6 +422,7 @@ class InputBundle(BaseModel):
     task_name: str | None = None
     manifest_path: Path
     objective_path: Path
+    dockerfile_path: Path | None
     reference_path: Path | None
     evaluator_path: Path | None
     evaluator_package_digest: str | None = None
@@ -635,6 +636,7 @@ def _load_input_bundle(  # noqa: C901, PLR0912, PLR0915  # tracked: #288
         task_name=task_name,
         manifest_path=manifest_path,
         objective_path=objective_path,
+        dockerfile_path=(task_directory.dockerfile_path if task_directory is not None else None),
         reference_path=reference_path,
         evaluator_path=evaluator_path,
         evaluator_package_digest=(

--- a/src/vibesys/sandbox/task_image.py
+++ b/src/vibesys/sandbox/task_image.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 import re
 import subprocess
-import tempfile
-from pathlib import Path
+import uuid
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from pathlib import Path
 
 _DEFAULT_BUILD_TIMEOUT_SECONDS = 1200.0
 _IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}")
 _DIAGNOSTIC_LIMIT = 1000
+_TASK_IMAGE_REPOSITORY = "vibesys-task-build"
 
 
 class TaskImageBuildError(RuntimeError):
@@ -68,9 +69,12 @@ def build_task_image(
     The task directory is the complete Docker build context. Candidate source,
     Git metadata, and other project inputs therefore cannot be copied into the
     image. Docker owns layer caching; VibeSys invokes the build once per launch
-    and consumes the exact image ID Docker reports through ``--iidfile``.
+    and consumes the runnable manifest ID resolved from a unique local tag.
     Default provenance attestations are disabled because their generated
-    metadata otherwise changes the image ID when all filesystem layers match.
+    metadata otherwise changes the manifest ID when all filesystem layers
+    match. The unique tag remains as a local reachability anchor: containerd's
+    image store cannot run the stable config digest emitted by ``--iidfile``
+    when an otherwise untagged image has no retained manifest reference.
     """
     # Keep the lexical parent as the build context. Resolving the Dockerfile
     # itself could silently widen the context to a symlink target elsewhere.
@@ -84,44 +88,76 @@ def build_task_image(
         raise ValueError("task image build timeout must be positive")  # noqa: TRY003
 
     runner = command_runner or SubprocessDockerBuildRunner()
-    with tempfile.TemporaryDirectory(prefix="vibesys-task-image-") as temporary:
-        iidfile = Path(temporary) / "image-id"
-        argv = (
-            "docker",
-            "build",
-            "--provenance=false",
-            "--iidfile",
-            str(iidfile),
-            "--file",
-            str(dockerfile),
-            str(root),
+    image_tag = f"{_TASK_IMAGE_REPOSITORY}:{uuid.uuid4().hex}"
+    build_argv = (
+        "docker",
+        "build",
+        "--provenance=false",
+        "--tag",
+        image_tag,
+        "--file",
+        str(dockerfile),
+        str(root),
+    )
+    build_result = _run_docker(
+        runner,
+        build_argv,
+        timeout=timeout,
+        action="building",
+        dockerfile=dockerfile,
+    )
+    if build_result.returncode != 0:
+        detail = (build_result.stderr or build_result.stdout or "docker build failed").strip()
+        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+            f"Could not build task image from {dockerfile} "
+            f"(exit {build_result.returncode}): {detail[:_DIAGNOSTIC_LIMIT]}"
         )
-        try:
-            result = runner.run(argv, cwd=root, timeout=timeout)
-        except FileNotFoundError as exc:
-            raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
-                f"Docker was not found while building task image: {dockerfile}"
-            ) from exc
-        except subprocess.TimeoutExpired as exc:
-            raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
-                f"Docker task image build timed out after {timeout:g} seconds: {dockerfile}"
-            ) from exc
 
-        if result.returncode != 0:
-            detail = (result.stderr or result.stdout or "docker build failed").strip()
-            raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
-                f"Could not build task image from {dockerfile} "
-                f"(exit {result.returncode}): {detail[:_DIAGNOSTIC_LIMIT]}"
-            )
-        try:
-            image_id = iidfile.read_text(encoding="utf-8").strip()
-        except FileNotFoundError as exc:
-            raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
-                f"Docker built task image but did not write its image ID: {dockerfile}"
-            ) from exc
-        if _IMAGE_ID.fullmatch(image_id) is None:
-            displayed = image_id[:_DIAGNOSTIC_LIMIT] or "<empty>"
-            raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
-                f"Docker wrote an invalid task image ID for {dockerfile}: {displayed!r}"
-            )
-        return image_id
+    inspect_argv = (
+        "docker",
+        "image",
+        "inspect",
+        "--format",
+        "{{.Id}}",
+        image_tag,
+    )
+    inspect_result = _run_docker(
+        runner,
+        inspect_argv,
+        timeout=timeout,
+        action="inspecting",
+        dockerfile=dockerfile,
+    )
+    if inspect_result.returncode != 0:
+        detail = (inspect_result.stderr or inspect_result.stdout or "docker inspect failed").strip()
+        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+            f"Could not resolve runnable task image {image_tag} built from {dockerfile} "
+            f"(exit {inspect_result.returncode}): {detail[:_DIAGNOSTIC_LIMIT]}"
+        )
+    image_id = inspect_result.stdout.strip()
+    if _IMAGE_ID.fullmatch(image_id) is None:
+        displayed = image_id[:_DIAGNOSTIC_LIMIT] or "<empty>"
+        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+            f"Docker returned an invalid runnable task image ID for {dockerfile}: {displayed!r}"
+        )
+    return image_id
+
+
+def _run_docker(
+    runner: DockerBuildRunner,
+    argv: Sequence[str],
+    *,
+    timeout: float,
+    action: str,
+    dockerfile: Path,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return runner.run(argv, cwd=dockerfile.parent, timeout=timeout)
+    except FileNotFoundError as exc:
+        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+            f"Docker was not found while {action} task image: {dockerfile}"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+            f"Docker timed out after {timeout:g} seconds while {action} task image: {dockerfile}"
+        ) from exc

--- a/src/vibesys/sandbox/task_image.py
+++ b/src/vibesys/sandbox/task_image.py
@@ -1,0 +1,124 @@
+"""Build the conventional Docker image owned by a repository-native task."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+_DEFAULT_BUILD_TIMEOUT_SECONDS = 1200.0
+_IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}")
+_DIAGNOSTIC_LIMIT = 1000
+
+
+class TaskImageBuildError(RuntimeError):
+    """Raised when Docker cannot produce a valid immutable task image."""
+
+
+class DockerBuildRunner(Protocol):
+    """Injectable process boundary for a Docker image build."""
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run one Docker command without a shell."""
+        ...
+
+
+class SubprocessDockerBuildRunner:
+    """Run Docker directly and capture its diagnostics."""
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run one Docker command without invoking a shell."""
+        return subprocess.run(  # noqa: S603
+            tuple(argv),
+            cwd=cwd,
+            capture_output=True,
+            check=False,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+
+
+def build_task_image(
+    dockerfile_path: Path,
+    *,
+    command_runner: DockerBuildRunner | None = None,
+    timeout: float = _DEFAULT_BUILD_TIMEOUT_SECONDS,
+) -> str:
+    """Build a task Dockerfile and return its immutable Docker image ID.
+
+    The task directory is the complete Docker build context. Candidate source,
+    Git metadata, and other project inputs therefore cannot be copied into the
+    image. Docker owns layer caching; VibeSys invokes the build once per launch
+    and consumes the exact image ID Docker reports through ``--iidfile``.
+    """
+    # Keep the lexical parent as the build context. Resolving the Dockerfile
+    # itself could silently widen the context to a symlink target elsewhere.
+    dockerfile = dockerfile_path.expanduser().absolute()
+    root = dockerfile.parent
+    if not dockerfile.is_file() or dockerfile.is_symlink():
+        raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+            f"Task Dockerfile must be a regular file: {dockerfile}"
+        )
+    if timeout <= 0:
+        raise ValueError("task image build timeout must be positive")  # noqa: TRY003
+
+    runner = command_runner or SubprocessDockerBuildRunner()
+    with tempfile.TemporaryDirectory(prefix="vibesys-task-image-") as temporary:
+        iidfile = Path(temporary) / "image-id"
+        argv = (
+            "docker",
+            "build",
+            "--iidfile",
+            str(iidfile),
+            "--file",
+            str(dockerfile),
+            str(root),
+        )
+        try:
+            result = runner.run(argv, cwd=root, timeout=timeout)
+        except FileNotFoundError as exc:
+            raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+                f"Docker was not found while building task image: {dockerfile}"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+                f"Docker task image build timed out after {timeout:g} seconds: {dockerfile}"
+            ) from exc
+
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "docker build failed").strip()
+            raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+                f"Could not build task image from {dockerfile} "
+                f"(exit {result.returncode}): {detail[:_DIAGNOSTIC_LIMIT]}"
+            )
+        try:
+            image_id = iidfile.read_text(encoding="utf-8").strip()
+        except FileNotFoundError as exc:
+            raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+                f"Docker built task image but did not write its image ID: {dockerfile}"
+            ) from exc
+        if _IMAGE_ID.fullmatch(image_id) is None:
+            displayed = image_id[:_DIAGNOSTIC_LIMIT] or "<empty>"
+            raise TaskImageBuildError(  # noqa: TRY003  # external CLI diagnostic
+                f"Docker wrote an invalid task image ID for {dockerfile}: {displayed!r}"
+            )
+        return image_id

--- a/src/vibesys/sandbox/task_image.py
+++ b/src/vibesys/sandbox/task_image.py
@@ -69,6 +69,8 @@ def build_task_image(
     Git metadata, and other project inputs therefore cannot be copied into the
     image. Docker owns layer caching; VibeSys invokes the build once per launch
     and consumes the exact image ID Docker reports through ``--iidfile``.
+    Default provenance attestations are disabled because their generated
+    metadata otherwise changes the image ID when all filesystem layers match.
     """
     # Keep the lexical parent as the build context. Resolving the Dockerfile
     # itself could silently widen the context to a symlink target elsewhere.
@@ -87,6 +89,7 @@ def build_task_image(
         argv = (
             "docker",
             "build",
+            "--provenance=false",
             "--iidfile",
             str(iidfile),
             "--file",

--- a/tests/entrypoints/test_headless.py
+++ b/tests/entrypoints/test_headless.py
@@ -369,6 +369,111 @@ def test_repository_native_project_selects_a_named_task(tmp_path: Path) -> None:
     assert invocation.args.input_bundle.task_root == selected.resolve()
 
 
+@pytest.mark.parametrize("environment_flag", [[], ["--docker"], ["--run-environment", "docker"]])
+def test_task_dockerfile_selects_docker_without_building_during_validation(
+    environment_flag: list[str],
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "repository"
+    project.mkdir()
+    task = _write_repository_task(project, "latency")
+    dockerfile = task / "Dockerfile"
+    dockerfile.write_text("FROM python:3.12-bookworm\n")
+
+    with patch("entrypoints.headless.build_task_image") as build:
+        invocation = parse_cli_invocation(
+            ["--project", str(project), "--task", "latency", *environment_flag]
+        )
+        spec = run_environment_spec_from_args(invocation.args)
+
+    assert spec.name == "docker"
+    assert spec.options["image"] is None
+    build.assert_not_called()
+
+
+def test_task_dockerfile_builds_once_for_a_launch(tmp_path: Path) -> None:
+    project = tmp_path / "repository"
+    project.mkdir()
+    task = _write_repository_task(project, "latency")
+    dockerfile = task / "Dockerfile"
+    dockerfile.write_text("FROM python:3.12-bookworm\n")
+    invocation = parse_cli_invocation(["--project", str(project), "--task", "latency"])
+    image_id = f"sha256:{'a' * 64}"
+
+    with patch("entrypoints.headless.build_task_image", return_value=image_id) as build:
+        spec = run_environment_spec_from_args(
+            invocation.args,
+            build_task_docker_image=True,
+        )
+
+    assert spec.name == "docker"
+    assert spec.options["image"] == image_id
+    build.assert_called_once_with(dockerfile.resolve())
+
+
+@pytest.mark.parametrize(
+    ("loop_name", "runner_path"),
+    [
+        ("agent", "vibesys.loops.agent.loop.run_agent_loop"),
+        ("plain", "vibesys.loops.plain.loop.run_plain_loop"),
+        ("evolve", "vibesys.loops.evolve.loop.run_evolve_loop"),
+    ],
+)
+def test_each_outer_loop_builds_the_task_image_once(
+    loop_name: str,
+    runner_path: str,
+    tmp_path: Path,
+) -> None:
+    import entrypoints.headless as cli  # noqa: PLC0415
+
+    project = tmp_path / "repository"
+    project.mkdir()
+    task = _write_repository_task(project, "latency")
+    dockerfile = task / "Dockerfile"
+    dockerfile.write_text("FROM python:3.12-bookworm\n")
+    invocation = parse_cli_invocation(
+        ["--outer-loop", loop_name, "--project", str(project), "--task", "latency"]
+    )
+    image_id = f"sha256:{'a' * 64}"
+    run = getattr(cli, f"_run_{loop_name}")
+
+    with (
+        patch("entrypoints.headless.build_task_image", return_value=image_id) as build,
+        patch(
+            "entrypoints.headless.load_config_and_skills",
+            return_value=(Mock(), (), ComputeBackend.CPU),
+        ),
+        patch("entrypoints.headless._prepare_experiment_repository"),
+        patch(runner_path, return_value=True) as loop_runner,
+    ):
+        run(invocation.args, Mock())
+
+    build.assert_called_once_with(dockerfile.resolve())
+    assert loop_runner.call_args.kwargs["run_environment"].options["image"] == image_id
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        ["--run-environment", "local"],
+        ["--modal"],
+        ["--skypilot"],
+        ["--docker-image", "custom:latest"],
+    ],
+)
+def test_fresh_task_dockerfile_rejects_conflicting_environment_flags(
+    flags: list[str],
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "repository"
+    project.mkdir()
+    task = _write_repository_task(project, "latency")
+    (task / "Dockerfile").write_text("FROM python:3.12-bookworm\n")
+
+    with pytest.raises(ValueError, match="task Dockerfile"):
+        parse_cli_invocation(["--project", str(project), "--task", "latency", *flags])
+
+
 def test_repository_native_project_implicitly_selects_its_only_task(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -829,6 +934,64 @@ def test_repository_resume_restores_the_recorded_task(
 
     assert invocation.args.task == "latency"
     assert invocation.args.input_bundle.task_root == selected.resolve()
+
+
+def test_repository_resume_keeps_a_recorded_local_environment_despite_task_dockerfile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "repository"
+    project.mkdir()
+    task = _write_repository_task(project, "latency")
+    (task / "Dockerfile").write_text("FROM python:3.12-bookworm\n")
+    run_id = "20260811-120000-11111111-agent"
+    _write_project_run(
+        project,
+        run_id,
+        configuration=_agent_configuration(run_environment=_LOCAL_ENVIRONMENT),
+        created_at=datetime(2026, 8, 11, 12, tzinfo=UTC),
+        task_name="latency",
+    )
+    monkeypatch.chdir(project)
+
+    args = parse_cli_invocation(["--resume", run_id]).args
+    with patch("entrypoints.headless.build_task_image") as build:
+        spec = run_environment_spec_from_args(args, build_task_docker_image=True)
+
+    assert spec.name == "local"
+    build.assert_not_called()
+
+
+def test_repository_resume_rebuilds_a_recorded_task_docker_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "repository"
+    project.mkdir()
+    task = _write_repository_task(project, "latency")
+    dockerfile = task / "Dockerfile"
+    dockerfile.write_text("FROM python:3.12-bookworm\n")
+    recorded_image = f"sha256:{'a' * 64}"
+    rebuilt_image = f"sha256:{'b' * 64}"
+    run_id = "20260811-120000-11111111-agent"
+    _write_project_run(
+        project,
+        run_id,
+        configuration=_agent_configuration(
+            run_environment=RunEnvironmentRecord(name="docker", image=recorded_image)
+        ),
+        created_at=datetime(2026, 8, 11, 12, tzinfo=UTC),
+        task_name="latency",
+    )
+    monkeypatch.chdir(project)
+
+    args = parse_cli_invocation(["--resume", run_id]).args
+    with patch("entrypoints.headless.build_task_image", return_value=rebuilt_image) as build:
+        spec = run_environment_spec_from_args(args, build_task_docker_image=True)
+
+    assert spec.name == "docker"
+    assert spec.options["image"] == rebuilt_image
+    build.assert_called_once_with(dockerfile.resolve())
 
 
 def test_repository_resume_rejects_a_different_task(tmp_path: Path) -> None:

--- a/tests/vibesys/agents/test_cli_docker.py
+++ b/tests/vibesys/agents/test_cli_docker.py
@@ -147,7 +147,8 @@ def test_codex_container_installs_luna_capable_cli_version():  # noqa: ANN201  #
 def test_editor_container_installs_only_mcp_v1(provider: str) -> None:
     commands = cli_docker.docker_init_commands(provider)
 
-    assert "python3 -m pip install --quiet 'mcp>=1.0,<2'" in commands
+    assert any("command -v pip3" in command for command in commands)
+    assert "PIP_BREAK_SYSTEM_PACKAGES=1 python3 -m pip install --quiet 'mcp>=1.0,<2'" in commands
 
 
 @pytest.mark.parametrize("provider", ["claude", "gemini", "codex", "opencode"])

--- a/tests/vibesys/sandbox/test_task_image.py
+++ b/tests/vibesys/sandbox/test_task_image.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from vibesys.sandbox.task_image import (
+    SubprocessDockerBuildRunner,
+    TaskImageBuildError,
+    build_task_image,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+_IMAGE_ID = "sha256:" + "a" * 64
+
+
+class FakeDockerBuildRunner:
+    def __init__(
+        self,
+        *,
+        result: subprocess.CompletedProcess[str] | BaseException | None = None,
+        image_id: str | None = _IMAGE_ID,
+    ) -> None:
+        self.result = result or subprocess.CompletedProcess(("docker",), 0, "", "")
+        self.image_id = image_id
+        self.calls: list[tuple[tuple[str, ...], Path, float]] = []
+        self.iidfile: Path | None = None
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        normalized = tuple(argv)
+        self.calls.append((normalized, cwd, timeout))
+        self.iidfile = Path(normalized[normalized.index("--iidfile") + 1])
+        if isinstance(self.result, BaseException):
+            raise self.result
+        if self.image_id is not None:
+            self.iidfile.write_text(self.image_id, encoding="utf-8")
+        return self.result
+
+
+def _task(tmp_path: Path) -> Path:
+    root = tmp_path / "task"
+    root.mkdir()
+    (root / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    return root
+
+
+def test_build_uses_task_context_and_returns_immutable_image_id(tmp_path: Path) -> None:
+    task_root = _task(tmp_path)
+    runner = FakeDockerBuildRunner()
+
+    assert (
+        build_task_image(task_root / "Dockerfile", command_runner=runner, timeout=42) == _IMAGE_ID
+    )
+
+    argv, cwd, timeout = runner.calls[0]
+    assert argv == (
+        "docker",
+        "build",
+        "--iidfile",
+        str(runner.iidfile),
+        "--file",
+        str(task_root / "Dockerfile"),
+        str(task_root),
+    )
+    assert cwd == task_root
+    assert timeout == 42
+    assert runner.iidfile is not None
+    assert not runner.iidfile.parent.exists()
+
+
+def test_subprocess_runner_uses_no_shell(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    run = MagicMock(return_value=subprocess.CompletedProcess(("docker",), 0, "", ""))
+    monkeypatch.setattr("vibesys.sandbox.task_image.subprocess.run", run)
+
+    SubprocessDockerBuildRunner().run(("docker", "build", "."), cwd=tmp_path, timeout=5)
+
+    assert run.call_args.args == (("docker", "build", "."),)
+    assert run.call_args.kwargs == {
+        "cwd": tmp_path,
+        "capture_output": True,
+        "check": False,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+        "timeout": 5,
+    }
+
+
+@pytest.mark.parametrize(
+    ("failure", "match"),
+    [
+        (FileNotFoundError(), "Docker was not found"),
+        (
+            subprocess.TimeoutExpired(("docker", "build"), 7),
+            "timed out after 7 seconds",
+        ),
+    ],
+)
+def test_build_translates_process_failures(
+    tmp_path: Path, failure: BaseException, match: str
+) -> None:
+    runner = FakeDockerBuildRunner(result=failure, image_id=None)
+
+    with pytest.raises(TaskImageBuildError, match=match):
+        build_task_image(_task(tmp_path) / "Dockerfile", command_runner=runner, timeout=7)
+
+    assert runner.iidfile is not None
+    assert not runner.iidfile.parent.exists()
+
+
+def test_build_reports_bounded_docker_failure(tmp_path: Path) -> None:
+    runner = FakeDockerBuildRunner(
+        result=subprocess.CompletedProcess(("docker",), 17, "ignored", "specific failure"),
+        image_id=None,
+    )
+
+    with pytest.raises(TaskImageBuildError, match=r"exit 17.*specific failure"):
+        build_task_image(_task(tmp_path) / "Dockerfile", command_runner=runner)
+
+
+@pytest.mark.parametrize(
+    ("image_id", "match"),
+    [
+        (None, "did not write its image ID"),
+        ("", "invalid task image ID.*<empty>"),
+        ("sha256:not-hex", "invalid task image ID"),
+        ("sha256:" + "a" * 63, "invalid task image ID"),
+        ("example:latest", "invalid task image ID"),
+    ],
+)
+def test_build_rejects_missing_or_malformed_image_id(
+    tmp_path: Path, image_id: str | None, match: str
+) -> None:
+    runner = FakeDockerBuildRunner(image_id=image_id)
+
+    with pytest.raises(TaskImageBuildError, match=match):
+        build_task_image(_task(tmp_path) / "Dockerfile", command_runner=runner)
+
+    assert runner.iidfile is not None
+    assert not runner.iidfile.parent.exists()
+
+
+def test_build_validates_dockerfile_before_running_docker(tmp_path: Path) -> None:
+    runner = FakeDockerBuildRunner()
+
+    task_root = tmp_path / "task"
+    task_root.mkdir()
+    with pytest.raises(TaskImageBuildError, match="Dockerfile must be a regular file"):
+        build_task_image(task_root / "Dockerfile", command_runner=runner)
+    (task_root / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="timeout must be positive"):
+        build_task_image(task_root / "Dockerfile", command_runner=runner, timeout=0)
+    assert runner.calls == []
+
+
+def test_build_rejects_dockerfile_symlink_without_widening_context(tmp_path: Path) -> None:
+    task_root = tmp_path / "task"
+    task_root.mkdir()
+    outside = tmp_path / "outside.Dockerfile"
+    outside.write_text("FROM scratch\n", encoding="utf-8")
+    dockerfile = task_root / "Dockerfile"
+    dockerfile.symlink_to(outside)
+    runner = FakeDockerBuildRunner()
+
+    with pytest.raises(TaskImageBuildError, match="must be a regular file"):
+        build_task_image(dockerfile, command_runner=runner)
+
+    assert runner.calls == []

--- a/tests/vibesys/sandbox/test_task_image.py
+++ b/tests/vibesys/sandbox/test_task_image.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -15,6 +14,7 @@ from vibesys.sandbox.task_image import (
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from pathlib import Path
 
 _IMAGE_ID = "sha256:" + "a" * 64
 
@@ -23,13 +23,15 @@ class FakeDockerBuildRunner:
     def __init__(
         self,
         *,
-        result: subprocess.CompletedProcess[str] | BaseException | None = None,
-        image_id: str | None = _IMAGE_ID,
+        build_result: subprocess.CompletedProcess[str] | BaseException | None = None,
+        inspect_result: subprocess.CompletedProcess[str] | BaseException | None = None,
+        image_id: str = _IMAGE_ID,
     ) -> None:
-        self.result = result or subprocess.CompletedProcess(("docker",), 0, "", "")
-        self.image_id = image_id
+        self.build_result = build_result or subprocess.CompletedProcess(("docker",), 0, "", "")
+        self.inspect_result = inspect_result or subprocess.CompletedProcess(
+            ("docker",), 0, image_id, ""
+        )
         self.calls: list[tuple[tuple[str, ...], Path, float]] = []
-        self.iidfile: Path | None = None
 
     def run(
         self,
@@ -40,12 +42,10 @@ class FakeDockerBuildRunner:
     ) -> subprocess.CompletedProcess[str]:
         normalized = tuple(argv)
         self.calls.append((normalized, cwd, timeout))
-        self.iidfile = Path(normalized[normalized.index("--iidfile") + 1])
-        if isinstance(self.result, BaseException):
-            raise self.result
-        if self.image_id is not None:
-            self.iidfile.write_text(self.image_id, encoding="utf-8")
-        return self.result
+        result = self.build_result if normalized[1] == "build" else self.inspect_result
+        if isinstance(result, BaseException):
+            raise result
+        return result
 
 
 def _task(tmp_path: Path) -> Path:
@@ -55,29 +55,42 @@ def _task(tmp_path: Path) -> Path:
     return root
 
 
-def test_build_uses_task_context_and_returns_immutable_image_id(tmp_path: Path) -> None:
+def test_build_uses_task_context_and_returns_runnable_image_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     task_root = _task(tmp_path)
     runner = FakeDockerBuildRunner()
+    monkeypatch.setattr("vibesys.sandbox.task_image.uuid.uuid4", lambda: MagicMock(hex="build-id"))
 
     assert (
         build_task_image(task_root / "Dockerfile", command_runner=runner, timeout=42) == _IMAGE_ID
     )
 
-    argv, cwd, timeout = runner.calls[0]
-    assert argv == (
+    build_argv, cwd, timeout = runner.calls[0]
+    assert build_argv == (
         "docker",
         "build",
         "--provenance=false",
-        "--iidfile",
-        str(runner.iidfile),
+        "--tag",
+        "vibesys-task-build:build-id",
         "--file",
         str(task_root / "Dockerfile"),
         str(task_root),
     )
     assert cwd == task_root
     assert timeout == 42
-    assert runner.iidfile is not None
-    assert not runner.iidfile.parent.exists()
+    assert runner.calls[1] == (
+        (
+            "docker",
+            "image",
+            "inspect",
+            "--format",
+            "{{.Id}}",
+            "vibesys-task-build:build-id",
+        ),
+        task_root,
+        42,
+    )
 
 
 def test_subprocess_runner_uses_no_shell(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -101,29 +114,27 @@ def test_subprocess_runner_uses_no_shell(tmp_path: Path, monkeypatch: pytest.Mon
 @pytest.mark.parametrize(
     ("failure", "match"),
     [
-        (FileNotFoundError(), "Docker was not found"),
+        (FileNotFoundError(), "Docker was not found while building"),
         (
             subprocess.TimeoutExpired(("docker", "build"), 7),
-            "timed out after 7 seconds",
+            "timed out after 7 seconds while building",
         ),
     ],
 )
 def test_build_translates_process_failures(
     tmp_path: Path, failure: BaseException, match: str
 ) -> None:
-    runner = FakeDockerBuildRunner(result=failure, image_id=None)
+    runner = FakeDockerBuildRunner(build_result=failure)
 
     with pytest.raises(TaskImageBuildError, match=match):
         build_task_image(_task(tmp_path) / "Dockerfile", command_runner=runner, timeout=7)
 
-    assert runner.iidfile is not None
-    assert not runner.iidfile.parent.exists()
+    assert len(runner.calls) == 1
 
 
 def test_build_reports_bounded_docker_failure(tmp_path: Path) -> None:
     runner = FakeDockerBuildRunner(
-        result=subprocess.CompletedProcess(("docker",), 17, "ignored", "specific failure"),
-        image_id=None,
+        build_result=subprocess.CompletedProcess(("docker",), 17, "ignored", "specific failure"),
     )
 
     with pytest.raises(TaskImageBuildError, match=r"exit 17.*specific failure"):
@@ -133,23 +144,48 @@ def test_build_reports_bounded_docker_failure(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("image_id", "match"),
     [
-        (None, "did not write its image ID"),
-        ("", "invalid task image ID.*<empty>"),
-        ("sha256:not-hex", "invalid task image ID"),
-        ("sha256:" + "a" * 63, "invalid task image ID"),
-        ("example:latest", "invalid task image ID"),
+        ("", "invalid runnable task image ID.*<empty>"),
+        ("sha256:not-hex", "invalid runnable task image ID"),
+        ("sha256:" + "a" * 63, "invalid runnable task image ID"),
+        ("example:latest", "invalid runnable task image ID"),
     ],
 )
-def test_build_rejects_missing_or_malformed_image_id(
-    tmp_path: Path, image_id: str | None, match: str
+def test_build_rejects_malformed_runnable_image_id(
+    tmp_path: Path, image_id: str, match: str
 ) -> None:
     runner = FakeDockerBuildRunner(image_id=image_id)
 
     with pytest.raises(TaskImageBuildError, match=match):
         build_task_image(_task(tmp_path) / "Dockerfile", command_runner=runner)
 
-    assert runner.iidfile is not None
-    assert not runner.iidfile.parent.exists()
+    assert len(runner.calls) == 2
+
+
+@pytest.mark.parametrize(
+    ("failure", "match"),
+    [
+        (FileNotFoundError(), "Docker was not found while inspecting"),
+        (
+            subprocess.TimeoutExpired(("docker", "image", "inspect"), 7),
+            "timed out after 7 seconds while inspecting",
+        ),
+        (
+            subprocess.CompletedProcess(("docker",), 17, "ignored", "inspect failure"),
+            r"Could not resolve runnable task image.*exit 17.*inspect failure",
+        ),
+    ],
+)
+def test_build_translates_inspect_failures(
+    tmp_path: Path,
+    failure: subprocess.CompletedProcess[str] | BaseException,
+    match: str,
+) -> None:
+    runner = FakeDockerBuildRunner(inspect_result=failure)
+
+    with pytest.raises(TaskImageBuildError, match=match):
+        build_task_image(_task(tmp_path) / "Dockerfile", command_runner=runner, timeout=7)
+
+    assert len(runner.calls) == 2
 
 
 def test_build_validates_dockerfile_before_running_docker(tmp_path: Path) -> None:

--- a/tests/vibesys/sandbox/test_task_image.py
+++ b/tests/vibesys/sandbox/test_task_image.py
@@ -67,6 +67,7 @@ def test_build_uses_task_context_and_returns_immutable_image_id(tmp_path: Path) 
     assert argv == (
         "docker",
         "build",
+        "--provenance=false",
         "--iidfile",
         str(runner.iidfile),
         "--file",

--- a/tests/vibesys/test_input_sources.py
+++ b/tests/vibesys/test_input_sources.py
@@ -8,8 +8,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from vibesys.input_manifest import InputBundle, WorkspaceSource, load_input_bundle
+from vibesys.input_manifest import (
+    InputBundle,
+    WorkspaceSource,
+    load_input_bundle,
+    load_project_task,
+)
 from vibesys.run import Workspace
+from vs_project import Project
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -64,6 +70,45 @@ def test_manifest_without_external_sources_is_valid(tmp_path: Path) -> None:
 
     assert loaded.workspace_sources == ()
     assert loaded.evaluator_path is None
+    assert loaded.dockerfile_path is None
+
+
+def test_repository_task_exposes_its_optional_dockerfile(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    task_root = project_root / ".vibesys" / "tasks" / "queue"
+    task_root.mkdir(parents=True)
+    (task_root / "OBJECTIVE.md").write_text("Build a queue.\n", encoding="utf-8")
+    (task_root / "vibesys.input.toml").write_text(
+        """version = 1
+
+[agent]
+domain = "generic"
+
+[accuracy]
+command = ["accuracy-checker"]
+
+[benchmark]
+command = ["benchmark"]
+""",
+        encoding="utf-8",
+    )
+    dockerfile = task_root / "Dockerfile"
+    dockerfile.write_text("FROM ubuntu:24.04\n", encoding="utf-8")
+    project = Project.open(project_root)
+
+    loaded = load_project_task(project, project.select_task("queue"))
+
+    assert loaded.dockerfile_path == dockerfile.resolve()
+
+
+def test_legacy_bundle_does_not_discover_dockerfile(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    bundle = _write_bundle(project_root)
+    (bundle / "Dockerfile").write_text("FROM ubuntu:24.04\n", encoding="utf-8")
+
+    loaded = load_input_bundle(bundle)
+
+    assert loaded.dockerfile_path is None
 
 
 def test_manifest_resolves_modal_entrypoint_from_project_root(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Repository-native tasks cannot currently declare the execution environment they require. Authors must document a separate `docker build` step and pass `--docker-image`, which makes task bundles less self-contained and gives each task an ad hoc launch procedure.

## Solution

Recognize an optional `.vibesys/tasks/<task>/Dockerfile` by convention. Its presence automatically selects Docker for fresh runs. VibeSys builds it once per launch with the task directory as the complete build context and launches the run using the immutable image ID returned by Docker.

This adds no manifest fields or image naming/cache policy. Docker layer caching remains the cache. Explicit `--docker` and `--run-environment docker` are accepted, while `--docker-image` and non-Docker environments fail as conflicting inputs. Legacy root bundles do not auto-detect a root Dockerfile because it commonly belongs to the candidate application.

### Architecture

`vs-project` discovers and validates the conventional file. `InputBundle` carries its resolved path. The headless launch boundary chooses the environment and invokes a focused image builder. The builder uses direct argv, a task-only context, a bounded timeout, and Docker's `--iidfile`; the existing run-environment record persists the resulting image ID.

Resume behavior remains explicit: a run recorded as local remains local even if a Dockerfile is later added. A run recorded as Docker rebuilds the task image and the existing configuration comparison detects image drift.

This does not add evaluator isolation within Docker. The existing Docker run environment still uses the same writable container for agent and gate commands.

## Verification

The change was checked with focused layout, input loading, CLI/environment selection, launch wiring, and image-builder tests. Documentation link checking, Ruff, formatting, and whitespace checks pass.

### Correctness properties

- Only repository-native task Dockerfiles opt in.
- The Docker build context is exactly the selected task directory, so candidate source and Git metadata are unavailable to `COPY`.
- Symlinked and non-regular Dockerfiles are rejected.
- Successful builds must return a full immutable `sha256:` image ID.
- Validation does not build images, and each actual outer-loop launch builds at most once.
- Explicit conflicting image or environment selections fail instead of being silently overridden.
- Resume preserves the recorded environment and detects rebuilt-image drift through the existing run configuration contract.

### Testing

- `uv run pytest -q tests/entrypoints/test_headless.py` (109 passed)
- `uv run pytest -q libs/vs-project/tests/test_layout.py tests/vibesys/test_input_sources.py tests/vibesys/sandbox/test_task_image.py` (75 passed)
- `uv run ruff check libs/vs-project/src/vs_project/_layout.py libs/vs-project/tests/test_layout.py src/entrypoints/headless.py src/vibesys/input_manifest.py src/vibesys/sandbox/task_image.py tests/entrypoints/test_headless.py tests/vibesys/test_input_sources.py tests/vibesys/sandbox/test_task_image.py`
- `uv run ruff format --check libs/vs-project/src/vs_project/_layout.py libs/vs-project/tests/test_layout.py src/entrypoints/headless.py src/vibesys/input_manifest.py src/vibesys/sandbox/task_image.py tests/entrypoints/test_headless.py tests/vibesys/test_input_sources.py tests/vibesys/sandbox/test_task_image.py`
- `uv run python scripts/check_doc_links.py` (321 Markdown files checked)
- `git diff --check`
