### PR TITLE
TUI: One canonical slash-command registry shared by every input surface

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -21,19 +21,33 @@ the Python `vibesys` package in the Python environment you want to use, or set
 Use Experiment chat for ordinary questions about the current run. The command
 input accepts these slash commands:
 
+Every command below is defined once in a shared registry, so the command bar and
+the chat resolve the same name to the same action, match case-insensitively, and
+report the same errors.
+
 | Command | Behavior |
 | --- | --- |
-| `/help` | Show commands and planned controls. |
-| `/chat` | Put the pane keys on the docked chat, or open it as a modal where it cannot dock; `/chat <question>` asks immediately. |
-| | Slash commands work inside the chat too, and do the same thing as in the main input. |
+| `/help` | Show the commands available on the current surface. |
+| `/chat` | Put the pane keys on the docked chat, or open it as a modal where it cannot dock; `/chat <question>` asks immediately. Command bar only, since the chat has nothing to open. |
+| | Every command below works in the chat too, and does the same thing as in the command bar. |
 | `/pause` | Pause after the current agent call finishes. |
-| `/resume` | Resume a paused run. |
+| `/resume` | Resume a paused run. Works from the command bar and the chat. |
 | `/steer <message>` | Queue an instruction that is appended to the next agent invocation's prompt. |
 | `/open-round` | Open the rounds behind the selected hypothesis. |
 | `/open-round --N` | Open round N, inside whichever hypothesis owns it. |
 | `/perf` | Plot the recorded performance metric by round, in the right pane. |
 | `/design` | Summarize what each round changed in the workspace, in the right pane. |
+| `/todos` | Expand or collapse the visible agent's todo list. |
+| `/prompt` | Expand or collapse the latest prompt in view. |
 | `/theme` | Pick a theme from a keyboard-navigable list; `/theme <name>` switches immediately. |
+
+The chat composer adds its own thread commands, which exist only in the chat:
+
+| Command | Behavior |
+| --- | --- |
+| `/clear` | Start a fresh thread with the current thread's agent and model. |
+| `/model` | Pick a harness and model, and start a thread on it. |
+| `/switch` | Switch to another chat thread. |
 
 ### Experiment log
 
@@ -188,8 +202,7 @@ not support OSC52, VibeSys keeps the selection and shows a status explaining
 that the terminal's native copy command is the fallback. Rounds and agents can
 also be clicked: a round chip
 selects its round, an agent node filters the transcript to that agent, and
-clicking the selected node clears the filter. Commands listed under "Planned" in
-`/help` are not accepted yet.
+clicking the selected node clears the filter.
 
 The rounds strip covers the whole run, including rounds it has not reached yet,
 and windows onto the part that fits. The selected round is always in view, and

--- a/clients/tui/src/commands.test.ts
+++ b/clients/tui/src/commands.test.ts
@@ -1,196 +1,147 @@
 import {describe, expect, it} from 'bun:test';
 import {
   availableCommands,
+  COMMAND_NAMES,
   chatHelpText,
   helpText,
-  parseChatCommand,
+  type ParsedCommand,
   parseCommand,
-  SLASH_COMMANDS,
   slashCommandRange,
-  suggestChatSlashCommands,
   suggestSlashCommands,
 } from './commands.js';
 
+const onCommand = (text: string): ParsedCommand => parseCommand(text, {surface: 'command'});
+const onChat = (text: string): ParsedCommand => parseCommand(text, {surface: 'chat'});
+const names = (commands: readonly {name: string}[]): string[] =>
+  commands.map(command => command.name);
+
+/** The commands both surfaces resolve identically, so parity is asserted once. */
+const SHARED = [
+  '/help',
+  '/pause',
+  '/resume',
+  '/steer look at the cache',
+  '/open-round',
+  '/perf',
+  '/design',
+  '/todos',
+  '/prompt',
+  '/theme',
+];
+
 describe('parseCommand', () => {
-  it('accepts the intentionally small slash-command surface', () => {
-    expect(parseCommand('/open-round')).toEqual({openRound: {}});
-    expect(parseCommand('/open-round --3')).toEqual({openRound: {round: 3}});
-    expect(parseCommand('/open-round 3')).toEqual({openRound: {round: 3}});
-    expect(parseCommand('/open-round latest').error).toContain('Unknown round: latest');
-    // Visualization commands opt into the right pane through one field.
-    expect(parseCommand('/perf')).toMatchObject({
-      request: {type: 'query.performance'},
-      paneView: 'perf',
+  it('parses the command surface into discriminated actions', () => {
+    expect(onCommand('/help')).toEqual({kind: 'help'});
+    expect(onCommand('/pause')).toEqual({kind: 'request', request: {type: 'command.pause'}});
+    expect(onCommand('/resume')).toEqual({kind: 'request', request: {type: 'command.resume'}});
+    expect(onCommand('/steer prioritize the KV cache path')).toEqual({
+      kind: 'request',
+      request: {type: 'command.steer', text: 'prioritize the KV cache path'},
     });
-    // Modal surfaces stay modal: no pane routing on any of them.
-    expect(parseCommand('/help').paneView).toBeUndefined();
-    expect(parseCommand('/theme').paneView).toBeUndefined();
-    expect(parseCommand('/chat').paneView).toBeUndefined();
-    expect(parseCommand('/nope').paneView).toBeUndefined();
-    expect(parseCommand('/perf')).toMatchObject({
+    expect(onCommand('/open-round')).toEqual({kind: 'openRound'});
+    expect(onCommand('/open-round --3')).toEqual({kind: 'openRound', round: 3});
+    expect(onCommand('/open-round 3')).toEqual({kind: 'openRound', round: 3});
+    expect(onCommand('/perf')).toMatchObject({
+      kind: 'request',
       request: {type: 'query.performance'},
       responseView: 'perf',
-    });
-    expect(parseCommand('/chat what changed in the latest round?')).toEqual({
-      localView: 'chat',
-      chatMessage: 'what changed in the latest round?',
+      paneView: 'perf',
     });
     // Every visualization goes through the one pane mechanism, so /design
     // reaches the right pane exactly the way /perf does.
-    expect(parseCommand('/design')).toEqual({
+    expect(onCommand('/design')).toEqual({
+      kind: 'request',
       request: {type: 'query.design'},
       paneView: 'design',
     });
-    expect(SLASH_COMMANDS.map(command => command.name)).toContain('/design');
-  });
-
-  it('parses run-control commands', () => {
-    expect(parseCommand('/pause')).toEqual({request: {type: 'command.pause'}});
-    expect(parseCommand('/resume')).toEqual({request: {type: 'command.resume'}});
-    expect(parseCommand('/steer prioritize the KV cache path')).toEqual({
-      request: {type: 'command.steer', text: 'prioritize the KV cache path'},
-    });
-  });
-
-  it('requires a message for /steer', () => {
-    expect(parseCommand('/steer').error).toContain('Usage: /steer');
-    expect(parseCommand('/steer   ').error).toContain('Usage: /steer');
-  });
-
-  it('rejects text that belongs to Experiment chat', () => {
-    expect(parseCommand('what is happening?')).toEqual({
-      error: 'Commands start with /. Use Experiment chat for questions.',
-    });
-    expect(parseCommand('')).toEqual({error: 'Enter a slash command. Use /help.'});
-  });
-
-  it('rejects the removed experiment-log commands', () => {
-    expect(parseCommand('/history').error).toContain('Unknown command: /history');
-    expect(parseCommand('/history rounds').error).toContain('Unknown command: /history rounds');
-    expect(parseCommand('/experiments').error).toContain('Unknown command: /experiments');
-  });
-
-  it('keeps inspection commands out of the public command surface', () => {
-    expect(parseCommand('/round 4').error).toContain('Unknown command');
-    expect(parseCommand('/invocation abc').error).toContain('Unknown command');
-    expect(parseCommand('/show workspace/file').error).toContain('Unknown command');
-  });
-
-  it('provides local help without a backend request', () => {
-    expect(parseCommand('/help')).toEqual({localView: 'help'});
-  });
-
-  it('opens chat without requiring an initial question', () => {
-    expect(parseCommand('/chat')).toEqual({localView: 'chat'});
-    expect(parseCommand('/chat   ')).toEqual({localView: 'chat'});
-  });
-
-  it('lists themes bare and selects a known theme by name', () => {
-    expect(parseCommand('/theme')).toEqual({localView: 'theme'});
-    expect(parseCommand('/theme   ')).toEqual({localView: 'theme'});
-    expect(parseCommand('/theme solarized-light')).toEqual({
-      localView: 'theme',
+    // Modal surfaces stay modal: no pane routing on any of them.
+    expect(onCommand('/help')).not.toHaveProperty('paneView');
+    expect(onCommand('/theme')).not.toHaveProperty('paneView');
+    expect(onCommand('/chat')).not.toHaveProperty('paneView');
+    expect(onCommand('/todos')).toEqual({kind: 'toggle', toggle: 'todos'});
+    expect(onCommand('/prompt')).toEqual({kind: 'toggle', toggle: 'prompt'});
+    expect(onCommand('/theme')).toEqual({kind: 'theme'});
+    expect(onCommand('/theme solarized-light')).toEqual({
+      kind: 'theme',
       themeName: 'solarized-light',
     });
+    expect(onCommand('/chat')).toEqual({kind: 'openChat'});
+    expect(onCommand('/chat what changed in the latest round?')).toEqual({
+      kind: 'openChat',
+      chatMessage: 'what changed in the latest round?',
+    });
   });
 
-  it('rejects an unknown theme name with the available list', () => {
-    const parsed = parseCommand('/theme monokai');
-    expect(parsed.error).toContain('Unknown theme: monokai');
-    expect(parsed.error).toContain('catppuccin-mocha');
-    expect(parsed.localView).toBeUndefined();
-  });
-});
-
-describe('command surface by view', () => {
-  it('drops /chat where the chat is already a pane of the view', () => {
-    const docked = availableCommands({chatDocked: true}).map(command => command.name);
-
-    expect(docked).not.toContain('/chat');
-    expect(docked).toContain('/perf');
-    expect(helpText({chatDocked: true})).not.toMatch(/\/chat\s/);
-    expect(suggestSlashCommands('/c', {chatDocked: true}).map(command => command.name)).toEqual([]);
+  it('reports usage and validation errors from the registry', () => {
+    expect(onCommand('/steer')).toEqual({kind: 'error', error: 'Usage: /steer <message>'});
+    expect(onCommand('/steer   ')).toEqual({kind: 'error', error: 'Usage: /steer <message>'});
+    expect(onCommand('/open-round latest')).toMatchObject({kind: 'error'});
+    const badTheme = onCommand('/theme monokai');
+    expect(badTheme.kind).toBe('error');
+    if (badTheme.kind === 'error') {
+      expect(badTheme.error).toContain('Unknown theme: monokai');
+      expect(badTheme.error).toContain('catppuccin-mocha');
+    }
   });
 
-  it('offers /chat everywhere the chat is not already on screen', () => {
-    expect(availableCommands().map(command => command.name)).toContain('/chat');
-    expect(helpText()).toMatch(/\/chat\s/);
-    expect(suggestSlashCommands('/c').map(command => command.name)).toEqual(['/chat']);
-  });
-
-  it('keeps chat control out of the global command surface', () => {
-    // Chat is controlled from the chat composer, so the global registry
-    // carries no thread commands at all and never claims to.
-    const names = SLASH_COMMANDS.map(command => command.name);
-    expect(names).not.toContain('/new-chat');
-    expect(names).not.toContain('/chats');
-    expect(names).not.toContain('/model');
-    expect(names).not.toContain('/clear');
-    expect(helpText()).not.toContain('/new-chat');
-    expect(helpText()).not.toContain('/chats');
-    expect(parseCommand('/new-chat').error).toContain('Unknown command');
-    expect(parseCommand('/chats').error).toContain('Unknown command');
-  });
-
-  it('reaches the todo and prompt toggles by name', () => {
-    // macOS keeps the function keys for itself and a terminal may keep a
-    // Control chord, so both toggles have to be reachable without either.
-    expect(parseCommand('/todos')).toEqual({toggle: 'todos'});
-    expect(parseCommand('/prompt')).toEqual({toggle: 'prompt'});
-  });
-
-  it('still accepts /chat when it is not offered, since the chat is the point', () => {
-    // Hidden from the list, not removed from the client.
-    expect(parseCommand('/chat')).toEqual({localView: 'chat'});
+  it('diagnoses non-command and unknown input on the command surface', () => {
+    expect(onCommand('')).toEqual({kind: 'error', error: 'Enter a slash command. Use /help.'});
+    expect(onCommand('what is happening?')).toEqual({
+      kind: 'error',
+      error: 'Commands start with /. Use Experiment chat for questions.',
+    });
+    expect(onCommand('/round 4')).toEqual({kind: 'unknown', text: '/round 4'});
+    expect(onCommand('/invocation abc')).toEqual({kind: 'unknown', text: '/invocation abc'});
+    expect(onCommand('/history')).toEqual({kind: 'unknown', text: '/history'});
   });
 });
 
-describe('chat composer commands', () => {
-  it('resolves the chat-scoped commands', () => {
-    expect(parseChatCommand('/clear')).toEqual({command: 'clear'});
-    expect(parseChatCommand('/model')).toEqual({command: 'model'});
-    expect(parseChatCommand('/resume')).toEqual({command: 'resume'});
+describe('cross-surface parity', () => {
+  it('resolves shared commands identically on the command bar and in the chat', () => {
+    for (const text of SHARED) {
+      expect(onChat(text)).toEqual(onCommand(text));
+    }
   });
 
-  it('shadows /resume: in the chat it resumes a thread, not the run', () => {
-    // The global surface keeps /resume for a paused run; the composer's own
-    // command wins where it was typed, so the two never compete.
-    expect(parseChatCommand('/resume').command).toBe('resume');
-    expect(parseCommand('/resume')).toEqual({request: {type: 'command.resume'}});
+  it('matches command names case-insensitively on both surfaces', () => {
+    const resume = {kind: 'request', request: {type: 'command.resume'}} as const;
+    expect(onCommand('/Pause')).toEqual(onCommand('/pause'));
+    expect(onChat('/PAUSE')).toEqual(onCommand('/pause'));
+    expect(onChat('/Resume')).toEqual(resume);
   });
 
-  it('forwards global commands the composer has always accepted', () => {
-    expect(parseChatCommand('/pause')).toEqual({global: true});
-    expect(parseChatCommand('/steer look at the cache')).toEqual({global: true});
-    expect(parseChatCommand('/perf')).toEqual({global: true});
-  });
-
-  it('answers unknown slash input with the chat help, not the global error', () => {
-    const parsed = parseChatCommand('/threads');
-    expect(parsed.command).toBeUndefined();
-    expect(parsed.global).toBeUndefined();
-    expect(parsed.help).toBe(chatHelpText());
-    expect(parsed.help).toContain('/model');
-    expect(parsed.help).toContain('/resume');
-    expect(parsed.help).not.toContain('Unknown command');
-  });
-
-  it('suggests only the chat commands from a slash prefix', () => {
-    expect(suggestChatSlashCommands('/').map(command => command.name)).toEqual([
-      '/clear',
-      '/model',
-      '/resume',
-    ]);
-    expect(suggestChatSlashCommands('/m').map(command => command.name)).toEqual(['/model']);
-    expect(suggestChatSlashCommands('/pa')).toEqual([]);
-    expect(suggestChatSlashCommands('/model ')).toEqual([]);
-    expect(suggestChatSlashCommands('what changed?')).toEqual([]);
+  it('produces the same /steer usage error wherever it is typed', () => {
+    expect(onChat('/steer')).toEqual(onCommand('/steer'));
   });
 });
 
-describe('slash-command input helpers', () => {
-  it('suggests available commands from a slash prefix', () => {
-    expect(suggestSlashCommands('/').map(command => command.name)).toEqual([
+describe('chat-only commands', () => {
+  it('resolves the chat thread commands only in the chat', () => {
+    expect(onChat('/clear')).toEqual({kind: 'chatClear'});
+    expect(onChat('/model')).toEqual({kind: 'chatModel'});
+    expect(onChat('/switch')).toEqual({kind: 'chatSwitch'});
+    // On the command bar those names are not registered, so they are unknown.
+    expect(onCommand('/clear')).toEqual({kind: 'unknown', text: '/clear'});
+    expect(onCommand('/model')).toEqual({kind: 'unknown', text: '/model'});
+    expect(onCommand('/switch')).toEqual({kind: 'unknown', text: '/switch'});
+  });
+
+  it('resumes the paused run from /resume on both surfaces, and switches threads with /switch', () => {
+    // /resume no longer collides: it means the run everywhere, and the chat's
+    // own thread switch has its own name.
+    expect(onChat('/resume')).toEqual({kind: 'request', request: {type: 'command.resume'}});
+    expect(onChat('/switch')).toEqual({kind: 'chatSwitch'});
+  });
+
+  it('answers unknown slash input as unknown, leaving each surface to render its own help', () => {
+    expect(onChat('/threads')).toEqual({kind: 'unknown', text: '/threads'});
+    expect(onCommand('/threads')).toEqual({kind: 'unknown', text: '/threads'});
+  });
+});
+
+describe('suggestions filtered by surface', () => {
+  it('suggests the command-bar commands in registry order', () => {
+    expect(names(suggestSlashCommands('/', {surface: 'command'}))).toEqual([
       '/help',
       '/chat',
       '/pause',
@@ -203,11 +154,59 @@ describe('slash-command input helpers', () => {
       '/prompt',
       '/theme',
     ]);
-    expect(suggestSlashCommands('/h').map(command => command.name)).toEqual(['/help']);
-    expect(suggestSlashCommands('/e')).toEqual([]);
-    expect(suggestSlashCommands('/open').map(command => command.name)).toEqual(['/open-round']);
-    expect(suggestSlashCommands('/perf ')).toEqual([]);
-    expect(suggestSlashCommands('perf')).toEqual([]);
+    expect(names(suggestSlashCommands('/h', {surface: 'command'}))).toEqual(['/help']);
+    expect(names(suggestSlashCommands('/open', {surface: 'command'}))).toEqual(['/open-round']);
+    expect(suggestSlashCommands('/e', {surface: 'command'})).toEqual([]);
+    expect(suggestSlashCommands('/perf ', {surface: 'command'})).toEqual([]);
+    expect(suggestSlashCommands('perf', {surface: 'command'})).toEqual([]);
+  });
+
+  it('leads the chat with its thread commands, then the forwarded globals', () => {
+    const chat = names(suggestSlashCommands('/', {surface: 'chat'}));
+    expect(chat.slice(0, 3)).toEqual(['/clear', '/model', '/switch']);
+    // The headline fix: the chat now suggests the global commands it forwards.
+    expect(chat).toContain('/pause');
+    expect(chat).toContain('/perf');
+    // /chat is command-bar only: there is nothing for it to open inside the chat.
+    expect(chat).not.toContain('/chat');
+    expect(names(suggestSlashCommands('/pa', {surface: 'chat'}))).toEqual(['/pause']);
+    expect(names(suggestSlashCommands('/m', {surface: 'chat'}))).toEqual(['/model']);
+  });
+
+  it('drops /chat where the chat is already docked', () => {
+    const docked = names(availableCommands({surface: 'command', chatDocked: true}));
+    expect(docked).not.toContain('/chat');
+    expect(docked).toContain('/perf');
+    expect(suggestSlashCommands('/c', {surface: 'command', chatDocked: true})).toEqual([]);
+    // Hidden from the list, still parsed: the chat is the point.
+    expect(parseCommand('/chat', {surface: 'command', chatDocked: true})).toEqual({
+      kind: 'openChat',
+    });
+  });
+});
+
+describe('registry-derived help and helpers', () => {
+  it('generates command-bar help without the stale planned block', () => {
+    const help = helpText();
+    expect(help).toContain('/help');
+    expect(help).toContain('/design');
+    expect(help).not.toContain('Planned');
+    expect(help).not.toContain('/invocation');
+    expect(help).not.toContain('/round');
+  });
+
+  it('generates chat help from the chat surface', () => {
+    const help = chatHelpText();
+    expect(help).toContain('/clear');
+    expect(help).toContain('/model');
+    expect(help).toContain('/switch');
+    expect(help).toContain('/pause');
+  });
+
+  it('exposes the canonical name per command', () => {
+    expect(COMMAND_NAMES.todos).toBe('/todos');
+    expect(COMMAND_NAMES.prompt).toBe('/prompt');
+    expect(COMMAND_NAMES['open-round']).toBe('/open-round');
   });
 
   it('finds a leading slash-command token for syntax highlighting', () => {

--- a/clients/tui/src/commands.test.ts
+++ b/clients/tui/src/commands.test.ts
@@ -96,6 +96,54 @@ describe('parseCommand', () => {
   });
 });
 
+describe('argument-contract enforcement', () => {
+  it('rejects trailing text on no-argument commands on the command bar', () => {
+    // Before the registry refactor exact-match parsers rejected these; a
+    // no-argument parser must not silently ignore a slash-prefixed phrase.
+    expect(onCommand('/pause typo')).toEqual({kind: 'error', error: 'Usage: /pause'});
+    expect(onCommand('/perf extra')).toEqual({kind: 'error', error: 'Usage: /perf'});
+    expect(onCommand('/help ignored')).toEqual({kind: 'error', error: 'Usage: /help'});
+    expect(onCommand('/resume now')).toEqual({kind: 'error', error: 'Usage: /resume'});
+    expect(onCommand('/design later')).toEqual({kind: 'error', error: 'Usage: /design'});
+  });
+
+  it('rejects trailing text on no-argument commands in the chat', () => {
+    expect(onChat('/pause typo')).toEqual({kind: 'error', error: 'Usage: /pause'});
+    expect(onChat('/help ignored')).toEqual({kind: 'error', error: 'Usage: /help'});
+    // A chat-only, state-changing command must not fire from a phrase either.
+    expect(onChat('/clear definitely-not')).toEqual({kind: 'error', error: 'Usage: /clear'});
+    expect(onChat('/model gpt')).toEqual({kind: 'error', error: 'Usage: /model'});
+    expect(onChat('/switch elsewhere')).toEqual({kind: 'error', error: 'Usage: /switch'});
+  });
+
+  it('still accepts no-argument commands with no trailing text', () => {
+    expect(onCommand('/pause')).toEqual({kind: 'request', request: {type: 'command.pause'}});
+    // Trailing whitespace alone is not an argument.
+    expect(onCommand('/pause   ')).toEqual({kind: 'request', request: {type: 'command.pause'}});
+    expect(onChat('/clear')).toEqual({kind: 'chatClear'});
+  });
+
+  it('leaves commands that take arguments unaffected', () => {
+    expect(onCommand('/steer look at the cache')).toEqual({
+      kind: 'request',
+      request: {type: 'command.steer', text: 'look at the cache'},
+    });
+    expect(onCommand('/theme solarized-light')).toEqual({
+      kind: 'theme',
+      themeName: 'solarized-light',
+    });
+    expect(onCommand('/open-round 3')).toEqual({kind: 'openRound', round: 3});
+    // Optional-argument commands still resolve with no argument.
+    expect(onCommand('/theme')).toEqual({kind: 'theme'});
+    expect(onCommand('/open-round')).toEqual({kind: 'openRound'});
+  });
+
+  it('rejects an empty argument on required-argument commands with the registry usage', () => {
+    expect(onCommand('/steer')).toEqual({kind: 'error', error: 'Usage: /steer <message>'});
+    expect(onChat('/steer')).toEqual({kind: 'error', error: 'Usage: /steer <message>'});
+  });
+});
+
 describe('cross-surface parity', () => {
   it('resolves shared commands identically on the command bar and in the chat', () => {
     for (const text of SHARED) {

--- a/clients/tui/src/commands.test.ts
+++ b/clients/tui/src/commands.test.ts
@@ -1,7 +1,10 @@
 import {describe, expect, it} from 'bun:test';
+import {readFileSync} from 'node:fs';
 import {
   availableCommands,
   COMMAND_NAMES,
+  COMMAND_SPECS,
+  type CommandSurface,
   chatHelpText,
   helpText,
   type ParsedCommand,
@@ -141,6 +144,81 @@ describe('argument-contract enforcement', () => {
   it('rejects an empty argument on required-argument commands with the registry usage', () => {
     expect(onCommand('/steer')).toEqual({kind: 'error', error: 'Usage: /steer <message>'});
     expect(onChat('/steer')).toEqual({kind: 'error', error: 'Usage: /steer <message>'});
+  });
+
+  /**
+   * The cases above name the commands from the report. This one enumerates the
+   * registry instead, so a command registered later cannot be the one that
+   * still accepts a trailing phrase.
+   */
+  it('enforces the declared arity of every registered command on every surface', () => {
+    for (const spec of COMMAND_SPECS) {
+      const usage = `Usage: ${spec.usage ?? spec.name}`;
+      for (const surface of spec.surfaces as readonly CommandSurface[]) {
+        const parse = (text: string): ParsedCommand => parseCommand(text, {surface});
+        const where = `${spec.name} on ${surface}`;
+        if (spec.args === 'none') {
+          expect({where, ...parse(`${spec.name} trailing-text`)}).toEqual({
+            where,
+            kind: 'error',
+            error: usage,
+          });
+          // The bare command still resolves, so the check rejects arguments
+          // rather than the command.
+          expect({where, kind: parse(spec.name).kind}).not.toEqual({where, kind: 'error'});
+        } else if (spec.args === 'required') {
+          expect({where, ...parse(spec.name)}).toEqual({where, kind: 'error', error: usage});
+        } else {
+          expect({where, kind: parse(spec.name).kind}).not.toEqual({where, kind: 'error'});
+        }
+      }
+    }
+  });
+
+  it('covers every arity the registry declares, so the loop above is not vacuous', () => {
+    expect(new Set(COMMAND_SPECS.map(spec => spec.args))).toEqual(
+      new Set(['none', 'optional', 'required']),
+    );
+  });
+});
+
+/**
+ * The README is the only copy of the command list outside the registry, and it
+ * is what a reader consults before the help text. Asserting it against the
+ * registry is what keeps the two from drifting the way the pre-registry tables
+ * did.
+ */
+describe('README command tables', () => {
+  const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+
+  /** The `/name` of every table row in a section, deduplicated in document order. */
+  const documentedCommands = (heading: string, nextHeading: string): string[] => {
+    const start = readme.indexOf(heading);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = readme.indexOf(nextHeading, start + heading.length);
+    expect(end).toBeGreaterThan(start);
+    const section = readme.slice(start, end);
+    const documented: string[] = [];
+    for (const line of section.split('\n')) {
+      const name = /^\|\s*`(\/[a-z][a-z0-9-]*)/.exec(line)?.[1];
+      if (name !== undefined && !documented.includes(name)) documented.push(name);
+    }
+    return documented;
+  };
+
+  const specNames = (predicate: (surfaces: readonly CommandSurface[]) => boolean): string[] =>
+    COMMAND_SPECS.filter(spec => predicate(spec.surfaces)).map(spec => spec.name);
+
+  it('documents exactly the commands the command bar offers, in registry order', () => {
+    expect(documentedCommands('| Command | Behavior |', 'The chat composer adds')).toEqual(
+      specNames(surfaces => surfaces.includes('command')),
+    );
+  });
+
+  it('documents exactly the chat-only commands, in registry order', () => {
+    expect(documentedCommands('The chat composer adds', '### Experiment log')).toEqual(
+      specNames(surfaces => !surfaces.includes('command')),
+    );
   });
 });
 

--- a/clients/tui/src/commands.ts
+++ b/clients/tui/src/commands.ts
@@ -276,6 +276,23 @@ function findCommand(token: string, surface: CommandSurface): CommandDef | undef
 }
 
 /**
+ * Enforces a command's `args` contract before dispatch. A `none` command rejects
+ * any trailing text, and a `required` command rejects an empty argument, so a
+ * slash-prefixed phrase like `/pause typo` cannot slip past a parser that ignores
+ * its argument. Returns the registry usage error, or `undefined` when the
+ * argument is admissible and the parser should run.
+ */
+function checkArgument(command: CommandDef, argument: string): ParsedCommand | undefined {
+  if (command.args === 'none' && argument !== '') {
+    return {kind: 'error', error: `Usage: ${command.usage ?? command.name}`};
+  }
+  if (command.args === 'required' && argument === '') {
+    return {kind: 'error', error: `Usage: ${command.usage ?? command.name}`};
+  }
+  return undefined;
+}
+
+/**
  * The commands a surface offers, in the order suggestions and help list them.
  * The chat leads with its own thread commands, then the run and view commands
  * it forwards; the command bar keeps registry order.
@@ -313,6 +330,8 @@ export function parseCommand(text: string, {surface}: SurfaceContext): ParsedCom
   const argument = text.slice(token.length).replace(/^\s+/, '').trimEnd();
   const command = findCommand(token, surface);
   if (command === undefined) return {kind: 'unknown', text};
+  const argumentError = checkArgument(command, argument);
+  if (argumentError !== undefined) return argumentError;
   return command.parse(argument);
 }
 

--- a/clients/tui/src/commands.ts
+++ b/clients/tui/src/commands.ts
@@ -66,21 +66,33 @@ export interface SlashCommand {
   description: string;
 }
 
+/** How many arguments a command accepts, enforced before its parser runs. */
+export type CommandArity = 'none' | 'optional' | 'required';
+
+/**
+ * A command's declared contract, without its handler. This is what the
+ * suggestion menu, the help text, the README, and the argument check are all
+ * derived from, so tests can enumerate the contract without reaching into the
+ * parsers.
+ */
+export interface CommandSpec {
+  readonly id: CommandId;
+  readonly name: string;
+  readonly aliases?: readonly string[];
+  readonly description: string;
+  readonly args: CommandArity;
+  readonly usage?: string;
+  readonly surfaces: readonly CommandSurface[];
+  readonly section: CommandSection;
+}
+
 /**
  * The single definition of one slash command. `parse` is required, so a command
  * cannot be registered without a handler, and it is the only place the command's
  * behavior is spelled: parsers, suggestions, and help are all derived from this
  * table, so a match string can never drift from a registry name.
  */
-interface CommandDef {
-  readonly id: CommandId;
-  readonly name: string;
-  readonly aliases?: readonly string[];
-  readonly description: string;
-  readonly args: 'none' | 'optional' | 'required';
-  readonly usage?: string;
-  readonly surfaces: readonly CommandSurface[];
-  readonly section: CommandSection;
+interface CommandDef extends CommandSpec {
   /** Hides the command from suggestions and help in a context; parsing still accepts it. */
   readonly hiddenWhen?: (context: CommandContext) => boolean;
   readonly parse: (argument: string) => ParsedCommand;
@@ -258,6 +270,15 @@ const COMMAND_REGISTRY: readonly CommandDef[] = [
     parse: () => ({kind: 'chatSwitch'}),
   },
 ];
+
+/**
+ * Every registered command's declared contract, in registry order. Exposed so
+ * documentation and contract tests enumerate the same table the parser uses
+ * rather than restating it.
+ */
+export const COMMAND_SPECS: readonly CommandSpec[] = COMMAND_REGISTRY.map(
+  ({hiddenWhen: _hiddenWhen, parse: _parse, ...spec}) => spec,
+);
 
 /** The canonical name per command, so callers reference a command without a literal. */
 export const COMMAND_NAMES = Object.fromEntries(

--- a/clients/tui/src/commands.ts
+++ b/clients/tui/src/commands.ts
@@ -4,193 +4,349 @@ import {isThemeName, THEME_NAMES, type ThemeName} from './ui/theme.js';
 
 type CommandRequest = Exclude<RequestInput, {type: 'query.chat'}>;
 
-export type ParsedCommand = {
-  localView?: 'chat' | 'help' | 'theme';
-  /**
-   * Surfaces that also have a key. macOS reserves the function keys for system
-   * controls and a terminal may keep a Control chord for itself, so every
-   * toggle is reachable by name as well.
-   */
-  toggle?: 'todos' | 'prompt';
-  chatMessage?: string;
-  themeName?: ThemeName;
-  request?: CommandRequest;
-  responseView?: 'perf';
-  /** Opens a hypothesis trajectory: the selected row, or the given round. */
-  openRound?: {round?: number};
-  /**
-   * Renders the response in the right pane beside the transcript. Every
-   * visualization command opts in through this field; modal surfaces such as
-   * /help and errors leave it unset.
-   */
-  paneView?: PaneView;
-  error?: string;
-};
+/** Every input surface that resolves slash commands through this registry. */
+export type CommandSurface = 'command' | 'chat';
 
-export interface SlashCommand {
-  name: string;
-  description: string;
-}
+/** The help grouping a command is listed under. */
+export type CommandSection = 'general' | 'run' | 'view' | 'chat';
 
-export const SLASH_COMMANDS: readonly SlashCommand[] = [
-  {name: '/help', description: 'Show this help'},
-  {name: '/chat', description: 'Open experiment chat'},
-  {name: '/pause', description: 'Pause after the current agent call'},
-  {name: '/resume', description: 'Resume a paused run'},
-  {name: '/steer', description: 'Guide the next agent invocation: /steer <message>'},
-  {
-    name: '/open-round',
-    description: 'Open the selected hypothesis, or /open-round --N for round N',
-  },
-  {name: '/perf', description: 'Plot performance by round in the right pane'},
-  {name: '/design', description: 'Summarize each round’s file changes in the right pane'},
-  {name: '/todos', description: "Expand or collapse the visible agent's todo list"},
-  {name: '/prompt', description: 'Expand or collapse the latest prompt in view'},
-  {name: '/theme', description: 'List themes, or switch with /theme <name>'},
-];
+/** A stable identifier per command, used where code needs the name without spelling it. */
+export type CommandId =
+  | 'help'
+  | 'chat'
+  | 'pause'
+  | 'resume'
+  | 'steer'
+  | 'open-round'
+  | 'perf'
+  | 'design'
+  | 'todos'
+  | 'prompt'
+  | 'theme'
+  | 'clear'
+  | 'model'
+  | 'switch';
+
+/**
+ * The result of resolving one line of input. A discriminated union so every
+ * consumer switches on `kind`, the compiler can prove the switch exhaustive,
+ * and no consumer re-spells a command name.
+ */
+export type ParsedCommand =
+  | {kind: 'help'}
+  | {kind: 'openChat'; chatMessage?: string}
+  | {kind: 'toggle'; toggle: 'todos' | 'prompt'}
+  | {kind: 'theme'; themeName?: ThemeName}
+  | {kind: 'openRound'; round?: number}
+  | {kind: 'request'; request: CommandRequest; responseView?: 'perf'; paneView?: PaneView}
+  | {kind: 'chatClear'}
+  | {kind: 'chatModel'}
+  | {kind: 'chatSwitch'}
+  | {kind: 'unknown'; text: string}
+  | {kind: 'error'; error: string};
 
 /**
  * Where the chat is a pane of the current view there is nothing for `/chat` to
- * open, so it leaves the command surface rather than sitting in it as a command
- * that does nothing new. It is still accepted, and still opens the chat
+ * open, so it leaves the suggestion surface rather than sitting in it as a
+ * command that does nothing new. It is still accepted, and still opens the chat
  * anywhere the chat is not already on screen.
  */
 export interface CommandContext {
   chatDocked?: boolean;
 }
 
-export function availableCommands(context: CommandContext = {}): readonly SlashCommand[] {
-  if (!context.chatDocked) return SLASH_COMMANDS;
-  return SLASH_COMMANDS.filter(command => command.name !== '/chat');
+/** A context bound to the surface whose input is being resolved. */
+export interface SurfaceContext extends CommandContext {
+  surface: CommandSurface;
 }
 
-export function helpText(context: CommandContext = {}): string {
-  return [
-    'Available',
-    ...availableCommands(context).map(
-      command => `  ${command.name.padEnd(18)} ${command.description}`,
-    ),
-    '',
-    'Planned',
-    '  /round <number>    Inspect a completed round',
-    '  /invocation <id>   Inspect an agent invocation',
-  ].join('\n');
+/** The name/description shape the suggestion menu and its renderer consume. */
+export interface SlashCommand {
+  name: string;
+  description: string;
+}
+
+/**
+ * The single definition of one slash command. `parse` is required, so a command
+ * cannot be registered without a handler, and it is the only place the command's
+ * behavior is spelled: parsers, suggestions, and help are all derived from this
+ * table, so a match string can never drift from a registry name.
+ */
+interface CommandDef {
+  readonly id: CommandId;
+  readonly name: string;
+  readonly aliases?: readonly string[];
+  readonly description: string;
+  readonly args: 'none' | 'optional' | 'required';
+  readonly usage?: string;
+  readonly surfaces: readonly CommandSurface[];
+  readonly section: CommandSection;
+  /** Hides the command from suggestions and help in a context; parsing still accepts it. */
+  readonly hiddenWhen?: (context: CommandContext) => boolean;
+  readonly parse: (argument: string) => ParsedCommand;
+}
+
+const BOTH: readonly CommandSurface[] = ['command', 'chat'];
+const CHAT_ONLY: readonly CommandSurface[] = ['chat'];
+
+/**
+ * The one place every slash command is defined. Both the command bar and the
+ * chat composer resolve input through this table, so a fix to one is a fix to
+ * both. `/resume` resumes the paused run on every surface; the chat's own
+ * thread switch is `/switch`, so the two never collide by name.
+ */
+const COMMAND_REGISTRY: readonly CommandDef[] = [
+  {
+    id: 'help',
+    name: '/help',
+    description: 'Show this help',
+    args: 'none',
+    surfaces: BOTH,
+    section: 'general',
+    parse: () => ({kind: 'help'}),
+  },
+  {
+    id: 'chat',
+    name: '/chat',
+    description: 'Open experiment chat',
+    args: 'optional',
+    usage: '/chat <question>',
+    // Only the command bar offers /chat: inside the chat there is nothing to open.
+    surfaces: ['command'],
+    section: 'general',
+    hiddenWhen: context => context.chatDocked === true,
+    parse: argument => (argument ? {kind: 'openChat', chatMessage: argument} : {kind: 'openChat'}),
+  },
+  {
+    id: 'pause',
+    name: '/pause',
+    description: 'Pause after the current agent call',
+    args: 'none',
+    surfaces: BOTH,
+    section: 'run',
+    parse: () => ({kind: 'request', request: {type: 'command.pause'}}),
+  },
+  {
+    id: 'resume',
+    name: '/resume',
+    description: 'Resume a paused run',
+    args: 'none',
+    surfaces: BOTH,
+    section: 'run',
+    parse: () => ({kind: 'request', request: {type: 'command.resume'}}),
+  },
+  {
+    id: 'steer',
+    name: '/steer',
+    description: 'Guide the next agent invocation: /steer <message>',
+    args: 'required',
+    usage: '/steer <message>',
+    surfaces: BOTH,
+    section: 'run',
+    parse: argument =>
+      argument
+        ? {kind: 'request', request: {type: 'command.steer', text: argument}}
+        : {kind: 'error', error: 'Usage: /steer <message>'},
+  },
+  {
+    id: 'open-round',
+    name: '/open-round',
+    description: 'Open the selected hypothesis, or /open-round --N for round N',
+    args: 'optional',
+    usage: '/open-round --N',
+    surfaces: BOTH,
+    section: 'view',
+    parse: argument => {
+      if (!argument) return {kind: 'openRound'};
+      // ``--N`` is the documented form; a bare number is accepted because it is
+      // the obvious thing to type.
+      const match = argument.match(/^(?:--)?(\d+)$/);
+      if (!match) {
+        return {
+          kind: 'error',
+          error: `Unknown round: ${argument}. Use /open-round or /open-round --N.`,
+        };
+      }
+      return {kind: 'openRound', round: Number(match[1])};
+    },
+  },
+  {
+    id: 'perf',
+    name: '/perf',
+    description: 'Plot performance by round in the right pane',
+    args: 'none',
+    surfaces: BOTH,
+    section: 'view',
+    parse: () => ({
+      kind: 'request',
+      request: {type: 'query.performance'},
+      responseView: 'perf',
+      paneView: 'perf',
+    }),
+  },
+  {
+    id: 'design',
+    name: '/design',
+    description: 'Summarize each round’s file changes in the right pane',
+    args: 'none',
+    surfaces: BOTH,
+    section: 'view',
+    parse: () => ({kind: 'request', request: {type: 'query.design'}, paneView: 'design'}),
+  },
+  {
+    id: 'todos',
+    name: '/todos',
+    description: "Expand or collapse the visible agent's todo list",
+    args: 'none',
+    surfaces: BOTH,
+    section: 'view',
+    parse: () => ({kind: 'toggle', toggle: 'todos'}),
+  },
+  {
+    id: 'prompt',
+    name: '/prompt',
+    description: 'Expand or collapse the latest prompt in view',
+    args: 'none',
+    surfaces: BOTH,
+    section: 'view',
+    parse: () => ({kind: 'toggle', toggle: 'prompt'}),
+  },
+  {
+    id: 'theme',
+    name: '/theme',
+    description: 'List themes, or switch with /theme <name>',
+    args: 'optional',
+    usage: '/theme <name>',
+    surfaces: BOTH,
+    section: 'view',
+    parse: argument => {
+      if (!argument) return {kind: 'theme'};
+      if (!isThemeName(argument)) {
+        return {
+          kind: 'error',
+          error: `Unknown theme: ${argument}. Available: ${THEME_NAMES.join(', ')}.`,
+        };
+      }
+      return {kind: 'theme', themeName: argument};
+    },
+  },
+  {
+    id: 'clear',
+    name: '/clear',
+    description: 'Start a fresh thread with this thread’s agent and model',
+    args: 'none',
+    surfaces: CHAT_ONLY,
+    section: 'chat',
+    parse: () => ({kind: 'chatClear'}),
+  },
+  {
+    id: 'model',
+    name: '/model',
+    description: 'Pick a harness and model, and start a thread on it',
+    args: 'none',
+    surfaces: CHAT_ONLY,
+    section: 'chat',
+    parse: () => ({kind: 'chatModel'}),
+  },
+  {
+    id: 'switch',
+    name: '/switch',
+    description: 'Switch to another chat thread',
+    args: 'none',
+    surfaces: CHAT_ONLY,
+    section: 'chat',
+    parse: () => ({kind: 'chatSwitch'}),
+  },
+];
+
+/** The canonical name per command, so callers reference a command without a literal. */
+export const COMMAND_NAMES = Object.fromEntries(
+  COMMAND_REGISTRY.map(command => [command.id, command.name]),
+) as Record<CommandId, string>;
+
+const NAME_TOKEN = /^\/[a-z][a-z0-9-]*/i;
+
+function findCommand(token: string, surface: CommandSurface): CommandDef | undefined {
+  const lower = token.toLowerCase();
+  return COMMAND_REGISTRY.find(
+    command =>
+      command.surfaces.includes(surface) &&
+      (command.name === lower || command.aliases?.includes(lower) === true),
+  );
+}
+
+/**
+ * The commands a surface offers, in the order suggestions and help list them.
+ * The chat leads with its own thread commands, then the run and view commands
+ * it forwards; the command bar keeps registry order.
+ */
+export function availableCommands(context: SurfaceContext): readonly SlashCommand[] {
+  const matches = COMMAND_REGISTRY.filter(
+    command => command.surfaces.includes(context.surface) && command.hiddenWhen?.(context) !== true,
+  );
+  const ordered =
+    context.surface === 'chat'
+      ? [
+          ...matches.filter(command => command.section === 'chat'),
+          ...matches.filter(command => command.section !== 'chat'),
+        ]
+      : matches;
+  return ordered.map(command => ({name: command.name, description: command.description}));
+}
+
+/**
+ * Resolves one line of input for a surface. The command bar and chat composer
+ * both call this, so case handling, unknown-command diagnosis, and usage errors
+ * are identical everywhere. `hiddenWhen` gates suggestions, not parsing, so a
+ * docked `/chat` still opens the chat.
+ */
+export function parseCommand(text: string, {surface}: SurfaceContext): ParsedCommand {
+  const match = NAME_TOKEN.exec(text);
+  if (match === null) {
+    if (text === '') return {kind: 'error', error: 'Enter a slash command. Use /help.'};
+    if (!text.startsWith('/')) {
+      return {kind: 'error', error: 'Commands start with /. Use Experiment chat for questions.'};
+    }
+    return {kind: 'unknown', text};
+  }
+  const token = match[0];
+  const argument = text.slice(token.length).replace(/^\s+/, '').trimEnd();
+  const command = findCommand(token, surface);
+  if (command === undefined) return {kind: 'unknown', text};
+  return command.parse(argument);
 }
 
 export function suggestSlashCommands(
   text: string,
-  context: CommandContext = {},
+  context: SurfaceContext,
 ): readonly SlashCommand[] {
   if (!text.startsWith('/') || /\s/.test(text)) return [];
-  return availableCommands(context).filter(command => command.name.startsWith(text));
+  const lower = text.toLowerCase();
+  return availableCommands(context).filter(command => command.name.startsWith(lower));
 }
 
 export function slashCommandRange(text: string): {start: number; end: number} | null {
-  const match = /^\/[a-z][a-z0-9-]*/i.exec(text);
+  const match = NAME_TOKEN.exec(text);
   if (match === null) return null;
   return {start: 0, end: match[0].length};
 }
 
-/**
- * The chat composer's own command set. Chat is controlled from the chat, so
- * these live here rather than in the global registry above, and the composer
- * resolves them before anything else it might otherwise forward.
- */
-export const CHAT_SLASH_COMMANDS: readonly SlashCommand[] = [
-  {name: '/clear', description: 'Start a fresh thread with this thread’s agent and model'},
-  {name: '/model', description: 'Pick a harness and model, and start a thread on it'},
-  {name: '/resume', description: 'Switch to another chat thread'},
-];
-
-export type ChatCommandName = 'clear' | 'model' | 'resume';
-
-export type ParsedChatCommand = {
-  command?: ChatCommandName;
-  /**
-   * The text names a global command instead, e.g. `/pause`. The composer has
-   * always forwarded those, so it still does.
-   */
-  global?: boolean;
-  /** Unknown slash input: the chat answers with its own help, not the global. */
-  help?: string;
-};
-
-export function chatHelpText(): string {
+/** The command bar's help, generated from the registry for the command surface. */
+export function helpText(context: CommandContext = {}): string {
+  const commands = availableCommands({surface: 'command', ...context});
   return [
-    'Chat commands',
-    ...CHAT_SLASH_COMMANDS.map(command => `  ${command.name.padEnd(10)} ${command.description}`),
-    '',
-    'Anything else you type is a question for the chat agent.',
+    'Available',
+    ...commands.map(command => `  ${command.name.padEnd(18)} ${command.description}`),
   ].join('\n');
 }
 
-export function suggestChatSlashCommands(text: string): readonly SlashCommand[] {
-  if (!text.startsWith('/') || /\s/.test(text)) return [];
-  return CHAT_SLASH_COMMANDS.filter(command => command.name.startsWith(text));
-}
-
-/**
- * Resolves slash input typed into the chat composer.
- *
- * `/resume` is deliberately shadowed here: in the chat it resumes a *thread*,
- * while the global input keeps it for resuming a paused run. Chat commands are
- * matched first, so the two never compete for the same surface.
- */
-export function parseChatCommand(text: string): ParsedChatCommand {
-  if (text === '/clear') return {command: 'clear'};
-  if (text === '/model') return {command: 'model'};
-  if (text === '/resume') return {command: 'resume'};
-  const name = /^\/[a-z][a-z0-9-]*/i.exec(text)?.[0];
-  if (name !== undefined && SLASH_COMMANDS.some(command => command.name === name)) {
-    return {global: true};
-  }
-  return {help: chatHelpText()};
-}
-
-/** Parses the command surface. Ordinary questions belong to Experiment chat. */
-export function parseCommand(text: string): ParsedCommand {
-  if (text === '/help') return {localView: 'help'};
-  const chat = text.match(/^\/chat(?:\s+(.*))?$/);
-  if (chat) {
-    const message = chat[1]?.trim();
-    return {localView: 'chat', ...(message ? {chatMessage: message} : {})};
-  }
-  const theme = text.match(/^\/theme(?:\s+(.*))?$/);
-  if (theme) {
-    const requested = theme[1]?.trim();
-    if (!requested) return {localView: 'theme'};
-    if (!isThemeName(requested)) {
-      return {error: `Unknown theme: ${requested}. Available: ${THEME_NAMES.join(', ')}.`};
-    }
-    return {localView: 'theme', themeName: requested};
-  }
-  if (text === '/pause') return {request: {type: 'command.pause'}};
-  if (text === '/resume') return {request: {type: 'command.resume'}};
-  const steer = text.match(/^\/steer(?:\s+([\s\S]*))?$/);
-  if (steer) {
-    const message = steer[1]?.trim();
-    if (!message) return {error: 'Usage: /steer <message>'};
-    return {request: {type: 'command.steer', text: message}};
-  }
-  const openRound = text.match(/^\/open-round(?:\s+(.*))?$/);
-  if (openRound) {
-    const argument = openRound[1]?.trim();
-    if (!argument) return {openRound: {}};
-    // ``--N`` is the documented form; a bare number is accepted because it is
-    // the obvious thing to type.
-    const match = argument.match(/^(?:--)?(\d+)$/);
-    if (!match) {
-      return {error: `Unknown round: ${argument}. Use /open-round or /open-round --N.`};
-    }
-    return {openRound: {round: Number(match[1])}};
-  }
-  if (text === '/todos') return {toggle: 'todos'};
-  if (text === '/prompt') return {toggle: 'prompt'};
-  if (text === '/perf') {
-    return {request: {type: 'query.performance'}, responseView: 'perf', paneView: 'perf'};
-  }
-  if (text === '/design') return {request: {type: 'query.design'}, paneView: 'design'};
-  if (text.startsWith('/')) return {error: `Unknown command: ${text}. Use /help.`};
-  if (text === '') return {error: 'Enter a slash command. Use /help.'};
-  return {error: 'Commands start with /. Use Experiment chat for questions.'};
+/** The chat composer's help, generated from the registry for the chat surface. */
+export function chatHelpText(): string {
+  const commands = availableCommands({surface: 'chat'});
+  return [
+    'Chat commands',
+    ...commands.map(command => `  ${command.name.padEnd(13)} ${command.description}`),
+    '',
+    'Anything else you type is a question for the chat agent.',
+  ].join('\n');
 }

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -21,7 +21,8 @@ describe('session controller', () => {
 
     expect(controller.state.overlay?.kind).toBe('help');
     expect(controller.state.overlay?.content).toContain('/open-round');
-    expect(controller.state.overlay?.content).toContain('Planned');
+    expect(controller.state.overlay?.content).not.toContain('Planned');
+    expect(controller.state.overlay?.content).not.toContain('/invocation');
     expect(transport.requests).toEqual([]);
   });
 
@@ -1494,7 +1495,7 @@ describe('session controller', () => {
     ]);
   });
 
-  it('/resume lists the threads with their runtime and switches', async () => {
+  it('/switch lists the threads with their runtime and switches', async () => {
     const transport = new ThreadTransport();
     const controller = new SocketSessionController(transport);
     await controller.start();
@@ -1502,7 +1503,7 @@ describe('session controller', () => {
     await controller.confirmChatMenu();
     controller.switchChatThread('default');
 
-    await controller.submitChat('/resume');
+    await controller.submitChat('/switch');
 
     const menu = controller.state.chatMenu;
     expect(menu?.kind).toBe('resume');
@@ -1523,6 +1524,19 @@ describe('session controller', () => {
 
     expect(controller.state.chatMenu).toBeNull();
     expect(controller.state.activeChatThreadId).toBe('thread-1');
+  });
+
+  it('resumes the paused run from the chat, same as the command bar', async () => {
+    const transport = new ThreadTransport();
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+
+    await controller.submitChat('/resume');
+
+    // The chat forwards /resume to the one command executor: it resumes the run
+    // and opens no thread menu.
+    expect(transport.requests).toContainEqual({type: 'command.resume'});
+    expect(controller.state.chatMenu).toBeNull();
   });
 
   it('reports an unknown theme as an error without switching', async () => {

--- a/clients/tui/src/session-controller.test.ts
+++ b/clients/tui/src/session-controller.test.ts
@@ -1539,6 +1539,33 @@ describe('session controller', () => {
     expect(controller.state.chatMenu).toBeNull();
   });
 
+  it("reports a chat-only command's usage error rather than an unknown-command error", async () => {
+    const transport = new ThreadTransport();
+    const controller = new SocketSessionController(transport);
+    await controller.start();
+
+    // /clear takes no argument. The chat resolves it, so the error must be the
+    // registry usage error; re-parsing the text on the command bar, which does
+    // not offer /clear, would report "Unknown command" instead.
+    const before = transport.requests.length;
+    await controller.submitChat('/clear definitely-not');
+
+    expect(controller.state.errorBanner?.message).toBe('Usage: /clear');
+    // The phrase started no thread and sent no request.
+    expect(transport.requests.length).toBe(before);
+    expect(controller.state.chatMenu).toBeNull();
+  });
+
+  it('does not run a no-argument command typed with a trailing phrase', async () => {
+    const transport = new FakeTransport();
+    const controller = new SocketSessionController(transport);
+
+    await controller.submitCommand('/pause typo');
+
+    expect(controller.state.errorBanner).toMatchObject({scope: 'input', message: 'Usage: /pause'});
+    expect(transport.requests).toEqual([]);
+  });
+
   it('reports an unknown theme as an error without switching', async () => {
     const transport = new FakeTransport();
     const controller = new SocketSessionController(transport);

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -11,7 +11,7 @@ import {
 } from '@vibesys/backend-client';
 import {DEFAULT_CHAT_THREAD_ID, hasRunEnded} from '@vibesys/core-state';
 import type {StartupTrace} from './boot-trace.js';
-import {helpText, parseChatCommand, parseCommand} from './commands.js';
+import {chatHelpText, helpText, parseCommand} from './commands.js';
 import {renderPerformanceCurve} from './performance-chart.js';
 import {
   activeChatThreadSettings,
@@ -798,16 +798,29 @@ export class SocketSessionController implements SessionController {
   submitChat(value: string): Promise<void> {
     const text = value.trim();
     if (!text.startsWith('/')) return this.sendChat(value);
-    const parsed = parseChatCommand(text);
-    if (parsed.command === 'clear') return this.clearChatThread();
-    if (parsed.command === 'model') return this.openChatModelMenu();
-    if (parsed.command === 'resume') {
-      this.openChatResumeMenu();
-      return Promise.resolve();
+    const action = parseCommand(text, {surface: 'chat'});
+    switch (action.kind) {
+      case 'chatClear':
+        return this.clearChatThread();
+      case 'chatModel':
+        return this.openChatModelMenu();
+      case 'chatSwitch':
+        this.openChatResumeMenu();
+        return Promise.resolve();
+      case 'help':
+      case 'unknown':
+        // /help and any unrecognized slash input answer with the chat's own
+        // help rather than the global one or a global "unknown command" error.
+        this.#showChatHelp();
+        return Promise.resolve();
+      default:
+        // Everything else is a command the chat forwards to the one command
+        // executor, so it behaves exactly as it does in the command bar.
+        return this.submitCommand(text);
     }
-    if (parsed.global === true) return this.submitCommand(text);
-    // Unknown slash input answers with the chat's own help rather than
-    // falling through to a global "unknown command" error.
+  }
+
+  #showChatHelp(): void {
     this.#setState(
       updateChatConversation(this.#state, this.#state.activeChatThreadId, entries => [
         ...entries,
@@ -815,11 +828,10 @@ export class SocketSessionController implements SessionController {
           id: `chat-help-${++this.#chatMessageId}`,
           kind: 'status',
           label: 'Chat commands',
-          content: parsed.help ?? '',
+          content: chatHelpText(),
         },
       ]),
     );
-    return Promise.resolve();
   }
 
   sendChat(value: string): Promise<void> {
@@ -933,46 +945,56 @@ export class SocketSessionController implements SessionController {
   }
 
   async submitCommand(value: string): Promise<void> {
-    const parsed = parseCommand(value.trim());
-    if (parsed.error)
-      return this.#setState(reportError(this.#state, parsed.error, {scope: 'input'}));
-    if (parsed.localView === 'help') {
-      return this.#setState(
-        showDetail(this.#state, helpText({chatDocked: chatPaneVisible(this.#state)}), 'help'),
-      );
-    }
-    if (parsed.localView === 'chat') {
-      this.#setState(openChat(this.#state));
-      if (parsed.chatMessage) await this.sendChat(parsed.chatMessage);
-      return;
-    }
-    if (parsed.toggle === 'todos') {
-      this.toggleTodos();
-      return;
-    }
-    if (parsed.toggle === 'prompt') {
-      this.togglePrompt();
-      return;
-    }
-    if (parsed.openRound) {
-      this.openRound(parsed.openRound.round);
-      return;
-    }
-    if (parsed.localView === 'theme') {
-      if (parsed.themeName === undefined) return this.openThemePicker();
-      return this.setTheme(parsed.themeName);
-    }
-    if (!parsed.request) return;
-    if (parsed.paneView !== undefined) {
-      await this.openPane(parsed.paneView);
-      return;
-    }
-    try {
-      const response = await this.client.request(parsed.request);
-      const rendered = renderResponse(parsed.request, response, parsed.responseView);
-      if (rendered !== null) this.#setState(showDetail(this.#state, rendered));
-    } catch (error) {
-      this.#setState(reportCaughtError(this.#state, error, 'request'));
+    const text = value.trim();
+    const action = parseCommand(text, {
+      surface: 'command',
+      chatDocked: chatPaneVisible(this.#state),
+    });
+    switch (action.kind) {
+      case 'unknown':
+        return this.#setState(
+          reportError(this.#state, `Unknown command: ${action.text}. Use /help.`, {scope: 'input'}),
+        );
+      case 'error':
+        return this.#setState(reportError(this.#state, action.error, {scope: 'input'}));
+      case 'help':
+        return this.#setState(
+          showDetail(this.#state, helpText({chatDocked: chatPaneVisible(this.#state)}), 'help'),
+        );
+      case 'openChat':
+        this.#setState(openChat(this.#state));
+        if (action.chatMessage) await this.sendChat(action.chatMessage);
+        return;
+      case 'toggle':
+        if (action.toggle === 'todos') this.toggleTodos();
+        else this.togglePrompt();
+        return;
+      case 'openRound':
+        this.openRound(action.round);
+        return;
+      case 'theme':
+        if (action.themeName === undefined) return this.openThemePicker();
+        return this.setTheme(action.themeName);
+      case 'chatClear':
+        return this.clearChatThread();
+      case 'chatModel':
+        return this.openChatModelMenu();
+      case 'chatSwitch':
+        this.openChatResumeMenu();
+        return;
+      case 'request': {
+        if (action.paneView !== undefined) return this.openPane(action.paneView);
+        try {
+          const response = await this.client.request(action.request);
+          const rendered = renderResponse(action.request, response, action.responseView);
+          if (rendered !== null) this.#setState(showDetail(this.#state, rendered));
+        } catch (error) {
+          this.#setState(reportCaughtError(this.#state, error, 'request'));
+        }
+        return;
+      }
+      default:
+        return assertNever(action);
     }
   }
 
@@ -1106,6 +1128,11 @@ function reportCaughtError(
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/** Proves a switch over a discriminated union handles every case at compile time. */
+function assertNever(value: never): never {
+  throw new Error(`Unhandled command action: ${JSON.stringify(value)}`);
 }
 
 function renderResponse(

--- a/clients/tui/src/session-controller.ts
+++ b/clients/tui/src/session-controller.ts
@@ -11,7 +11,7 @@ import {
 } from '@vibesys/backend-client';
 import {DEFAULT_CHAT_THREAD_ID, hasRunEnded} from '@vibesys/core-state';
 import type {StartupTrace} from './boot-trace.js';
-import {chatHelpText, helpText, parseCommand} from './commands.js';
+import {chatHelpText, helpText, type ParsedCommand, parseCommand} from './commands.js';
 import {renderPerformanceCurve} from './performance-chart.js';
 import {
   activeChatThreadSettings,
@@ -814,9 +814,12 @@ export class SocketSessionController implements SessionController {
         this.#showChatHelp();
         return Promise.resolve();
       default:
-        // Everything else is a command the chat forwards to the one command
-        // executor, so it behaves exactly as it does in the command bar.
-        return this.submitCommand(text);
+        // Everything else, including a usage error, goes to the one command
+        // executor as the action the chat's own registry lookup produced. The
+        // text is not re-parsed on the command surface, so a chat-only
+        // command's usage error stays a usage error instead of becoming
+        // "unknown command" for a name that surface does not offer.
+        return this.#dispatchCommand(action);
     }
   }
 
@@ -944,12 +947,22 @@ export class SocketSessionController implements SessionController {
     }
   }
 
-  async submitCommand(value: string): Promise<void> {
-    const text = value.trim();
-    const action = parseCommand(text, {
-      surface: 'command',
-      chatDocked: chatPaneVisible(this.#state),
-    });
+  submitCommand(value: string): Promise<void> {
+    return this.#dispatchCommand(
+      parseCommand(value.trim(), {
+        surface: 'command',
+        chatDocked: chatPaneVisible(this.#state),
+      }),
+    );
+  }
+
+  /**
+   * Applies one resolved command action. Both input surfaces end here, so the
+   * behavior of a shared command cannot depend on where it was typed. The
+   * switch is exhaustive, so registering a new action kind without handling it
+   * is a compile error.
+   */
+  async #dispatchCommand(action: ParsedCommand): Promise<void> {
     switch (action.kind) {
       case 'unknown':
         return this.#setState(

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@opentui/core';
 import {createTestRenderer, type TestRendererSetup} from '@opentui/core/testing';
 import type {ChatOptions, HypothesisEntry} from '@vibesys/backend-client';
-import {parseChatCommand} from '../commands.js';
+import {chatHelpText, parseCommand} from '../commands.js';
 import type {SessionController} from '../session-controller.js';
 import {
   activeChatThreadSettings,
@@ -3170,7 +3170,7 @@ describe('theming', () => {
     expect(controller.createdThreads).toEqual([{provider: 'codex', model: 'gpt-5.5'}]);
   });
 
-  it('lists the chat threads for /resume and switches to the highlighted one', async () => {
+  it('lists the chat threads for /switch and switches to the highlighted one', async () => {
     const testRenderer = await createTestRenderer({width: 200, height: 30});
     const controller = new FakeController(initialSessionState());
     controller.publish({
@@ -3195,7 +3195,7 @@ describe('theming', () => {
     registerCleanup(testRenderer.renderer, app);
     await frameAfter(testRenderer);
 
-    await testRenderer.mockInput.typeText('/resume');
+    await testRenderer.mockInput.typeText('/switch');
     testRenderer.mockInput.pressEnter();
     const frame = await testRenderer.waitForFrame(value => value.includes('Chat threads'));
     // The implicit default is named by the client; a created thread shows the
@@ -3266,12 +3266,13 @@ describe('theming', () => {
     await frameAfter(testRenderer);
 
     await testRenderer.mockInput.typeText('/');
-    const frame = await testRenderer.waitForFrame(value => value.includes('/resume'));
+    const frame = await testRenderer.waitForFrame(value => value.includes('/switch'));
 
-    // Only the chat's own commands, and only beside the composer.
+    // The chat leads with its own thread commands, then the globals it forwards.
     expect(frame).toContain('/clear');
     expect(frame).toContain('/model');
-    expect(frame).toContain('/resume');
+    expect(frame).toContain('/switch');
+    expect(frame).toContain('/pause');
     const rows = frameRows(frame);
     expect(rows.findIndex(row => row.includes('/model'))).toBeLessThan(
       rows.findIndex(row => row.includes('Message')),
@@ -3286,7 +3287,7 @@ describe('theming', () => {
     registerCleanup(testRenderer.renderer, app);
     await frameAfter(testRenderer);
 
-    // /clear, /model, /resume: the composer's own command set, in that order.
+    // /clear, /model, /switch: the composer's own command set leads, in that order.
     await testRenderer.mockInput.typeText('/');
     const first = await testRenderer.waitForFrame(value => value.includes('[Tab]'));
     expect(first).toContain('› /clear');
@@ -3296,7 +3297,7 @@ describe('theming', () => {
     expect(second).not.toContain('› /clear');
 
     testRenderer.mockInput.pressArrow('down');
-    const third = await testRenderer.waitForFrame(value => value.includes('› /resume'));
+    const third = await testRenderer.waitForFrame(value => value.includes('› /switch'));
     expect(third).not.toContain('› /model');
   });
 
@@ -3361,7 +3362,7 @@ describe('theming', () => {
     const frame = await testRenderer.waitForFrame(value => value.includes('/zz'));
     expect(frame).not.toContain('/clear');
     expect(frame).not.toContain('/model');
-    expect(frame).not.toContain('/resume');
+    expect(frame).not.toContain('/switch');
 
     // Nothing to complete once the menu is gone: Tab is a no-op.
     testRenderer.mockInput.pressKey('TAB');
@@ -4371,16 +4372,22 @@ class FakeController implements SessionController {
   submitChat(value: string): Promise<void> {
     const text = value.trim();
     if (!text.startsWith('/')) return this.sendChat(value);
-    const parsed = parseChatCommand(text);
-    if (parsed.command === 'clear') return this.clearChatThread();
-    if (parsed.command === 'model') return this.openChatModelMenu();
-    if (parsed.command === 'resume') {
-      this.openChatResumeMenu();
-      return Promise.resolve();
+    const action = parseCommand(text, {surface: 'chat'});
+    switch (action.kind) {
+      case 'chatClear':
+        return this.clearChatThread();
+      case 'chatModel':
+        return this.openChatModelMenu();
+      case 'chatSwitch':
+        this.openChatResumeMenu();
+        return Promise.resolve();
+      case 'help':
+      case 'unknown':
+        this.chatHelpShown.push(chatHelpText());
+        return Promise.resolve();
+      default:
+        return this.submitCommand(text);
     }
-    if (parsed.global === true) return this.submitCommand(text);
-    this.chatHelpShown.push(parsed.help ?? '');
-    return Promise.resolve();
   }
 
   sendChat(value: string): Promise<void> {

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -1,4 +1,5 @@
 import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
+import {COMMAND_NAMES} from '../commands.js';
 import type {SessionController} from '../session-controller.js';
 import {
   experimentLogVisible,
@@ -34,14 +35,10 @@ export interface OpenTuiApp {
 /** Which of the client's editors currently holds the cursor. */
 type FocusTarget = 'command' | 'chat' | 'modal';
 
-const KEY_HELP =
-  '[/]: round · ←→: pane · ↑↓/Tab: within it · F4: zoom · /todos · /prompt · Ctrl+L: live';
-const SCOPED_KEY_HELP =
-  '[/]: round · ←→: pane · ↑↓/Tab: within it · F4: zoom · /todos · /prompt · Esc: back';
-const LOG_KEY_HELP =
-  '↑↓ or scroll: select · Enter/click: open hypothesis · F4: zoom · /open-round --N';
-const LOG_CHAT_KEY_HELP =
-  '↑↓: select · Enter/click: hypothesis · Ctrl+W: chat · F4: zoom · /open-round --N';
+const KEY_HELP = `[/]: round · ←→: pane · ↑↓/Tab: within it · F4: zoom · ${COMMAND_NAMES.todos} · ${COMMAND_NAMES.prompt} · Ctrl+L: live`;
+const SCOPED_KEY_HELP = `[/]: round · ←→: pane · ↑↓/Tab: within it · F4: zoom · ${COMMAND_NAMES.todos} · ${COMMAND_NAMES.prompt} · Esc: back`;
+const LOG_KEY_HELP = `↑↓ or scroll: select · Enter/click: open hypothesis · F4: zoom · ${COMMAND_NAMES['open-round']} --N`;
+const LOG_CHAT_KEY_HELP = `↑↓: select · Enter/click: hypothesis · Ctrl+W: chat · F4: zoom · ${COMMAND_NAMES['open-round']} --N`;
 const HYPOTHESIS_KEY_HELP =
   '↑↓: select round · Enter/click: trajectory · PgUp/PgDn: scroll · Esc: hypotheses';
 const SPLIT_KEY_HELP =

--- a/clients/tui/src/ui/chat-composer.ts
+++ b/clients/tui/src/ui/chat-composer.ts
@@ -5,7 +5,7 @@ import {
   TextareaRenderable,
   TextRenderable,
 } from '@opentui/core';
-import {suggestChatSlashCommands} from '../commands.js';
+import {suggestSlashCommands} from '../commands.js';
 import type {ChatMenuRow, SessionState} from '../session-model.js';
 import {SuggestionMenu} from './suggestion-menu.js';
 import type {Theme} from './theme.js';
@@ -217,7 +217,9 @@ export class ChatComposerView {
 
   /** Recomputes the typed-command matches for the draft's current text. */
   #syncSuggestions(): void {
-    this.draft.suggestions.setMatches(suggestChatSlashCommands(this.draft.value.trim()));
+    this.draft.suggestions.setMatches(
+      suggestSlashCommands(this.draft.value.trim(), {surface: 'chat'}),
+    );
   }
 
   /** Makes this editor authoritative when its presentation becomes visible. */

--- a/clients/tui/src/ui/command-input.ts
+++ b/clients/tui/src/ui/command-input.ts
@@ -95,7 +95,7 @@ export function createCommandInputPanel(
       input.addHighlightByCharRange({...range, styleId: commandStyleId});
     }
 
-    menu.setMatches(suggestSlashCommands(value, context));
+    menu.setMatches(suggestSlashCommands(value, {surface: 'command', ...context}));
     suggestions.visible = menu.visible;
     suggestions.height = menu.matches.length + 2;
     suggestionList.height = Math.max(1, menu.matches.length);


### PR DESCRIPTION
## Problem

Fixes #519.

Slash commands lived in `clients/tui/src/commands.ts` as two separate const tables (`SLASH_COMMANDS`, `CHAT_SLASH_COMMANDS`) with two hand-written parsers (`parseCommand`, `parseChatCommand`) that re-spelled every command name as string literals in match arms, unchecked by the type system. The command bar and the two chat composers diverged as a result:

- chat autocomplete could not suggest global commands (`suggestChatSlashCommands('/pa')` returned `[]` even though `/pause` worked in chat);
- `/Pause` produced `Unknown command` on one surface and a help card on the other, because one match was case-insensitive and the other was not;
- `/resume` meant two different things depending on focus, and blocked run-resume from the chat entirely;
- `/help` typed in chat showed the global help, while the chat-specific help was reachable only through an unrecognized command.

The copies drifted independently: a hand-maintained `Planned` block in `helpText` listed `/round` and `/invocation`, which do not exist; footer hint strings in `ui/app.ts` embedded `/todos`, `/prompt`, and `/open-round --N` as literals; and `clients/tui/README.md` omitted five real commands. A fix applied to one parser did not translate to the other.

## Solution

One registry, `COMMAND_REGISTRY` in `commands.ts`, defines every slash command exactly once: canonical name, aliases, argument arity, description, help section, the surfaces it is available on, its context availability, and a required `parse` handler that returns the command's action. Both the command bar and the chat composer resolve input through the same `parseCommand(text, {surface})` matcher, so case handling, unknown-command diagnosis, and usage errors are identical everywhere. Suggestions and per-surface help are generated from the registry filtered by surface, and footer hints reference it through an exported `COMMAND_NAMES` map instead of literals.

The matcher returns a discriminated `ParsedCommand` union. Both input surfaces resolve their own text once and hand the resulting action to one `#dispatchCommand` in `session-controller.ts`, which switches on `action.kind` with a `never` default: a command cannot be registered without a handler, and an unhandled action kind is a compile error.

The registry enforces each command's declared arity before dispatch, so a no-argument command rejects a trailing phrase (`/pause typo`) with its registered usage string rather than executing, and a required-argument command rejects an empty one. This restores what the pre-refactor exact-match parsers did.

The `/resume` collision is resolved explicitly: `/resume` resumes the paused run on every surface, and the chat's own thread switch is renamed `/switch` (chat only), so no command name appears twice and a paused run is now resumable from the chat as well as the command bar.

`/design` is an ordinary pane command in the registry, alongside `/perf`: it parses to `{kind: 'request', request: {type: 'query.design'}, paneView: 'design'}` and reaches the right pane through the same `PaneView` dispatch, with no special case.

### Architecture

`commands.ts` owns the registry and the matcher, and is the only place a command name string literal appears. The command bar (`ui/command-input.ts`) and the chat composer (`ui/chat-composer.ts`) each call `suggestSlashCommands` with their surface for autocomplete. `session-controller.ts` parses with the typing surface and dispatches the resulting action; the chat handles its three thread commands and its own help, and forwards every other resolved action to the shared dispatcher, so the chat and the command bar cannot diverge on a shared command or on its error text. The registry also exports `COMMAND_SPECS`, the contract half of each entry, which the contract tests and the README check enumerate. The backend protocol is unchanged: `command.pause`, `command.resume`, `command.steer`, `query.performance`, and `query.design` are the same requests as before.

```mermaid
flowchart TD
    CB[command bar input] --> P
    CH[chat composer input] --> P
    P["parseCommand(text, surface)"] --> R{"registry lookup:
name/alias, case-insensitive,
available on this surface?"}
    R -->|no| U["unknown: bar -> error,
chat -> chat help"]
    R -->|yes| C{"declared arity satisfied?"}
    C -->|no| E["error: registered usage string"]
    C -->|yes| A["entry.parse -> ParsedCommand action"]
    A --> S["#dispatchCommand: switch on action.kind
exhaustive, never default"]
    E --> S
    S --> Shared["shared: request / openChat / toggle /
theme / openRound / help"]
    S --> ChatOnly["chat only: chatClear / chatModel / chatSwitch"]
    REG[("COMMAND_REGISTRY:
one definition per command")] --> R
    REG --> Sug["suggestSlashCommands / helpText,
filtered by surface"]
    REG --> Names["COMMAND_NAMES -> app.ts footer hints"]
    REG --> Specs["COMMAND_SPECS -> arity and README contract tests"]
```

## Verification

Automated. The TUI test suite covers parsing parity across both surfaces exhaustively, so no manual verification of parsing is required. The one behavior that is stated in terminal geometry (chat autocomplete listing the forwarded globals) is covered through the OpenTUI test renderer in `ui/app.test.ts`.

### Correctness properties

- A command name string literal appears only in the registry. Parsers, suggestions, help, footer hints, and the README check are all derived from it, so the surfaces cannot drift.
- The same input typed on the command bar and in the chat yields the same parsed action, or an explicitly registry-declared surface difference (chat-only commands, and `/chat`, which the chat does not offer).
- Command names match case-insensitively on every surface, so `/Pause` and `/pause` resolve identically.
- Every command's declared arity is enforced before its parser runs, on every surface it is available on: a `none` command rejects any trailing text and a `required` command rejects an empty argument, both with the command's registered usage string.
- Each input is parsed exactly once, on the surface it was typed on, so a chat-only command's usage error is not re-diagnosed as an unknown command by the command bar.
- Chat autocomplete suggests every command available in the chat, including the forwarded global commands.
- A paused run resumes from `/resume` on every surface; the chat's thread switch is `/switch`, so the two never collide by name.
- A command cannot be registered without a `parse` handler, and an unhandled action kind is a compile error.
- `clients/tui/README.md`'s two command tables list exactly the registry's command-bar and chat-only commands, in registry order.

### Testing

- `commands.test.ts` is rewritten from divergence tests into cross-surface parity tests: shared commands parse identically on both surfaces, case handling is identical, `/steer` usage errors match, chat autocomplete includes forwarded globals (`suggestSlashCommands('/pa', {surface: 'chat'})` returns `/pause`), the chat-only `/clear`, `/model`, and `/switch` appear only in the chat, `/resume` resolves to `command.resume` on both surfaces, unknown input is an error on the command bar and chat help in the chat, and the generated help drops the stale `/round`, `/invocation`, and `Planned` entries.
- `commands.test.ts` argument-contract block: the reported cases (`/pause typo`, `/perf extra`, `/help ignored`, `/clear definitely-not`), plus a test that enumerates `COMMAND_SPECS` and asserts every command's declared arity on every surface it is available on, and a guard that all three arities occur so that loop cannot go vacuous. Removing the `checkArgument` call fails three of these tests.
- `commands.test.ts` README block: both `clients/tui/README.md` command tables are parsed and asserted against the registry, in registry order. Deleting a row fails the test.
- `session-controller.test.ts`: the help test asserts the `Planned` block is gone; the thread-list test drives `/switch`; a paused run resumes from the chat with the same `command.resume` request as the command bar; `/pause typo` reports `Usage: /pause` and sends no request; and `/clear definitely-not` typed in the chat reports `Usage: /clear` rather than an unknown-command error, and starts no thread.
- `ui/app.test.ts`: the fake controller's chat submit path and the chat-suggestion and thread-menu tests are updated to the registry API and the `/switch` rename, and assert the forwarded globals now appear in chat autocomplete.
- `clients/tui/README.md` lists every command the registry defines, including the previously undocumented `/todos`, `/prompt`, and the chat-only `/clear`, `/model`, and `/switch`, and drops the "planned controls" wording.

Commands run at the head of this branch:

- `cd clients/tui && bun test --max-concurrency 1 src`: 519 pass. (One local run also saw `launcher > returns the backend argument error for an explicitly empty runs directory` fail; that case spawns a real backend and was failing on a stale working directory in the sandbox, not on this change. It passes on a clean re-run and in CI.)
- `pnpm check:clients`: pass.
- `pnpm check:ts`: pass.
- `pnpm check:ts-architecture`: pass.
- No Python changed, so `pytest` was not run.

Closes #519.

