### PR TITLE
Recover meta-optimization runs across snapshots and timeouts

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import math
 import shlex
+import subprocess
 from collections.abc import Mapping, Sequence  # noqa: TC003  # tracked: #288
 from dataclasses import dataclass, replace
 from pathlib import Path  # noqa: TC003  # tracked: #288
@@ -1126,6 +1127,23 @@ def _missing_implementer_response() -> ImplementerResponse:
     )
 
 
+def _timed_out_implementer_response(timeout_seconds: float) -> ImplementerResponse:
+    """Fail closed while retaining durable evidence for a timed-out turn."""
+    return ImplementerResponse(
+        summary="Implementer invocation timed out.",
+        expected_behavior="unknown",
+        hypothesis_outcome=HypothesisOutcome.INCONCLUSIVE,
+        evidence=(
+            "The framework stopped the implementer after "
+            f"{timeout_seconds:g} seconds without a structured response."
+        ),
+        next_step=(
+            "Inspect the retained workspace and prior-attempt artifact, then return "
+            "a schema-valid ImplementerResponse on the configured retry."
+        ),
+    )
+
+
 @dataclass(frozen=True)
 class _ImplementerAttempt:
     """One implementer turn plus who authored its response.
@@ -1268,21 +1286,30 @@ def _run_implementer(  # noqa: PLR0913  # tracked: #288
         prior_attempt_artifact_locations=prior_attempt_artifact_locations,
     )
     fallback = ResponseFallback(_missing_implementer_response)
-    response = ctx.invoke(
-        kind="implementer",
-        system_prompt=system_prompt,
-        user_prompt=(
-            "Execute the required continuation step for the active hypothesis; "
-            "do not merely restate prior work. Return only the JSON object."
-            if continuation_step
-            else "Work persistently on the active hypothesis and return only the JSON object."
-        ),
-        response_cls=ImplementerResponse,
-        fallback_factory=fallback,
-        round_label=f"round-{round_number}-retry-{retry}-implementer",
-        reuse_session=True,
-        session_key=f"hypothesis:{plan.hypothesis_id}",
-    )
+    timed_out = False
+    try:
+        response = ctx.invoke(
+            kind="implementer",
+            system_prompt=system_prompt,
+            user_prompt=(
+                "Execute the required continuation step for the active hypothesis; "
+                "do not merely restate prior work. Return only the JSON object."
+                if continuation_step
+                else "Work persistently on the active hypothesis and return only the JSON object."
+            ),
+            response_cls=ImplementerResponse,
+            fallback_factory=fallback,
+            round_label=f"round-{round_number}-retry-{retry}-implementer",
+            reuse_session=True,
+            session_key=f"hypothesis:{plan.hypothesis_id}",
+        )
+    except subprocess.TimeoutExpired as exc:
+        timed_out = True
+        response = _timed_out_implementer_response(exc.timeout)
+        ctx.lprint(
+            f"[implementer] attempt {retry} timed out after {exc.timeout:g} seconds; "
+            "persisting fail-closed evidence."
+        )
     response.skill_context_updates, _ = _validate_skill_selections(
         ctx, response.skill_context_updates
     )
@@ -1294,7 +1321,10 @@ def _run_implementer(  # noqa: PLR0913  # tracked: #288
     issue_board.write_implementer_artifact(progress_path, round_number, retry, response)
     issue_board.append_implementer(progress_path, round_number, retry, response)
     ctx.snapshot_workspace(f"round-{round_number}-retry-{retry}-implementer")
-    return _ImplementerAttempt(response=response, synthesized=fallback.synthesized)
+    return _ImplementerAttempt(
+        response=response,
+        synthesized=fallback.synthesized or timed_out,
+    )
 
 
 def _run_judge(  # noqa: PLR0913  # tracked: #288

--- a/src/vibesys/run/git_tracker.py
+++ b/src/vibesys/run/git_tracker.py
@@ -373,6 +373,36 @@ class GitTracker:
             return FrameworkSnapshotStatus.EXACT
         return FrameworkSnapshotStatus.DIFFERENT
 
+    @staticmethod
+    def _replace_framework_namespace_contents(plan: GitSnapshotPlan) -> None:
+        """Reconcile one namespace without replacing retained file inodes."""
+        if plan.destination_root.exists():
+            if not plan.destination_root.is_dir():
+                raise ValueError(  # noqa: TRY003  # tracked: #288
+                    f"framework state namespace is not a directory: {plan.destination_root}"
+                )
+            retained_files = {state_file.destination for state_file in plan.files}
+            retained_directories = {
+                parent
+                for destination in retained_files
+                for parent in destination.parents
+                if parent != plan.destination_root and parent.is_relative_to(plan.destination_root)
+            }
+            existing_paths = sorted(
+                plan.destination_root.rglob("*"),
+                key=lambda path: len(path.relative_to(plan.destination_root).parts),
+                reverse=True,
+            )
+            for path in existing_paths:
+                if path.is_symlink() or path.is_file():
+                    if path.is_symlink() or path not in retained_files:
+                        path.unlink()
+                elif path.is_dir() and path not in retained_directories:
+                    path.rmdir()
+        for state_file in plan.files:
+            state_file.destination.parent.mkdir(parents=True, exist_ok=True)
+            state_file.destination.write_bytes(state_file.contents)
+
     def snapshot_framework_state(
         self,
         label: str,
@@ -397,15 +427,7 @@ class GitTracker:
             )
 
         tracked = self.run(["git", "ls-files", "--", plan.scope_pathspec]).stdout.strip()
-        if plan.destination_root.exists():
-            if not plan.destination_root.is_dir():
-                raise ValueError(  # noqa: TRY003  # tracked: #288
-                    f"framework state namespace is not a directory: {plan.destination_root}"
-                )
-            shutil.rmtree(plan.destination_root)
-        for state_file in plan.files:
-            state_file.destination.parent.mkdir(parents=True, exist_ok=True)
-            state_file.destination.write_bytes(state_file.contents)
+        self._replace_framework_namespace_contents(plan)
         if plan.files or tracked:
             self.run(["git", "add", "--force", "-A", "--", plan.scope_pathspec])
         has_changes = (

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -2434,6 +2434,60 @@ def test_unparseable_implementer_response_consumes_a_retry(tmp_path, ref_file): 
     assert rounds[0]["reviewed"] is True
 
 
+def test_timed_out_implementer_persists_fail_closed_attempt_and_retries(
+    tmp_path: Path,
+    ref_file: str,
+) -> None:
+    """A CLI timeout is durable attempt evidence, not a campaign-level failure."""
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                task="Build server",
+                pass_criteria="tests pass",  # noqa: S106  # tracked: #288
+                reasoning="cold start",
+            ),
+        ],
+        implementer_outcomes=[HypothesisOutcome.NOMINATED],
+    )
+    delegate = runner.invoke.side_effect
+    timed_out = False
+
+    def invoke_with_timeout(**kwargs):  # noqa: ANN003, ANN202  # tracked: #288
+        nonlocal timed_out
+        if kwargs["kind"] == "implementer" and not timed_out:
+            timed_out = True
+            runner.counters["impl"] += 1
+            raise subprocess.TimeoutExpired(cmd=["agent", "secret-argument"], timeout=3600)
+        return delegate(**kwargs)
+
+    runner.invoke.side_effect = invoke_with_timeout
+
+    result = _invoke_orchestrate(
+        tmp_path,
+        ref_file,
+        runner,
+        max_rounds=1,
+        max_retries_per_round=2,
+    )
+
+    assert result is True
+    assert runner.counters["impl"] == 2
+    assert runner.counters["judge"] == 1
+    project = _created_project(tmp_path)
+    artifact = next(project.rglob("round-0001-attempt-01-implementer.json"))
+    payload = json.loads(artifact.read_text())
+    assert payload["hypothesis_outcome"] == HypothesisOutcome.INCONCLUSIVE.value
+    assert payload["perf_metric"] is None
+    assert "3600 seconds" in payload["evidence"]
+    assert "secret-argument" not in artifact.read_text()
+    implementer_calls = [
+        call
+        for call in runner.invoke.call_args_list
+        if call.kwargs.get("response_cls") is ImplementerResponse
+    ]
+    assert "round-0001-attempt-01-implementer.json" in implementer_calls[1].kwargs["system_prompt"]
+
+
 def test_unparseable_implementer_responses_commit_fail_closed_once_exhausted(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     """Only genuine retry exhaustion may commit the synthesized response."""
     runner = _make_orchestrate_runner(

--- a/tests/vibesys/test_git_tracker.py
+++ b/tests/vibesys/test_git_tracker.py
@@ -325,6 +325,34 @@ def test_framework_state_snapshot_replaces_one_namespace_exactly(tmp_path: Path)
     }
 
 
+def test_framework_state_snapshot_preserves_retained_file_inode(tmp_path: Path) -> None:
+    tracker = _initialized_tracker(tmp_path)
+    store = _project(tmp_path, tracker)
+    initial = _namespace_snapshot(
+        store,
+        "test-run",
+        "runtime",
+        ("effective-objective.md", "old\n"),
+    )
+    tracker.snapshot_with_framework_metadata("initialize runtime", initial)
+    runtime_file = (
+        store.state.portable_namespace("test-run", "runtime").external_directory()
+        / "effective-objective.md"
+    )
+    initial_inode = runtime_file.stat().st_ino
+    replacement = _namespace_snapshot(
+        store,
+        "test-run",
+        "runtime",
+        ("effective-objective.md", "new\n"),
+    )
+
+    tracker.snapshot_framework_state("update runtime", replacement)
+
+    assert runtime_file.read_text(encoding="utf-8") == "new\n"
+    assert runtime_file.stat().st_ino == initial_inode
+
+
 def test_framework_state_snapshot_leaves_candidate_changes_pending(tmp_path: Path) -> None:
     tracker = _initialized_tracker(tmp_path)
     store = _project(tmp_path, tracker)


### PR DESCRIPTION
## Problem

Long-running Docker-backed agent campaigns exposed two recovery failures:

1. Exact framework-state snapshots unlinked retained files before recreating them. If Docker still bind-mounted one of those files on NFS, the unlink produced an undeletable `.nfs*` entry and resume failed before transaction recovery.
2. An implementer CLI timeout propagated out of the agent loop. The round stopped without a durable implementer artifact, leaving preserved candidate edits whose verification status was ambiguous on resume.

The failures were reproduced while auditing the Verus MPMC campaign stacked on #527. They are generic run-lifecycle problems, not queue-specific optimization changes.

## Solution

- Reconcile portable framework state in place. Remove omitted paths, retain included regular-file inodes, and overwrite their validated contents without weakening exact omission or symlink rules.
- Catch implementer `TimeoutExpired` at the phase boundary. Produce a fail-closed `implementation_failed` response, persist the normal implementer evidence/progress/snapshot, and let the existing judge/retry policy continue.
- Keep timeout diagnostics free of the full launcher command and environment.

### Architecture

```mermaid
flowchart LR
    A[Resume snapshot] --> B{Path retained?}
    B -->|yes| C[Rewrite existing inode]
    B -->|no| D[Remove omitted path]
    C --> E[Git snapshot]
    D --> E

    F[Implementer invocation] --> G{Completed?}
    G -->|yes| H[Persist normal result]
    G -->|timeout| I[Create fail-closed result]
    I --> J[Persist artifact and checkpoint]
    J --> K[Judge or bounded retry]
```

### Campaign evidence

Campaign: `20260901-151528-c5e62f0a-input-v4-20260901-151527`, GPT-5.6 Luna, xhigh, Codex CLI.

| Round | Candidate | Verification | Official throughput | Disposition |
| --- | --- | --- | ---: | --- |
| 1 | Fixed-capacity ring under the coarse lock | 15 verified, 0 errors | 1,179,467.1269 ops/s | Retained as first comparable point |
| 2 | Candidate-owned verified single-writer mutex | 19 verified, 0 errors | 1,281,173.7015 ops/s | Retained, +8.6231% over round 1 |
| 3 | Split producer/consumer atomic publication | Gate version verified but violated activation; gate-free version ended at 29 verified, 3 errors | Not run | Verification-incomplete |
| 4 | Continued AU/count handoff redesign | Cargo passes; 29 verified, 3 errors | Not run | Verification-incomplete; campaign stopped |

Round 3 first exposed an apparently verified but globally serialized `PublicationGate`; the independent judge rejected it before measurement. Gate-free retries in rounds 3 and 4 consistently failed at Verus atomic-update/invariant-mask composition. No invalid or unverifiable M3 candidate entered official evaluation. Round 2 remains the trusted frontier.

## Verification

### Correctness properties

- Exact snapshots still remove paths omitted from the framework namespace.
- Included regular files retain their inode, avoiding conflicts with active read-only bind mounts.
- Existing path validation and symlink rejection remain authoritative.
- An implementer timeout cannot nominate a candidate or claim verification success.
- Timeout recovery persists the same evidence and checkpoint boundaries used by ordinary implementer outcomes.
- Existing bounded retry and judge behavior remains responsible for subsequent disposition.
- Timeout evidence does not expose the full CLI command or environment.

### Testing

- `uv run pytest -q tests/vibesys/test_git_tracker.py tests/vibesys/loops/agent/test_orchestrate.py`: 153 passed.
- `uv run ruff check src/vibesys/run/git_tracker.py src/vibesys/loops/agent/loop.py tests/vibesys/test_git_tracker.py tests/vibesys/loops/agent/test_orchestrate.py`: passed.
- `uv run ruff format --check src/vibesys/run/git_tracker.py src/vibesys/loops/agent/loop.py tests/vibesys/test_git_tracker.py tests/vibesys/loops/agent/test_orchestrate.py`: passed.
- GitHub checks on the current head: all required checks passed.
- Prospective campaign validation: interrupted round 3 resumed through durable exhaustion, round 4 completed under the same run, and the supervisor stopped at the requested four-round limit.

### Disposition

Campaign complete and stopped after round 4. The run worktree is clean, no campaign VibeSys process or task container remains, and unrelated containers were left untouched. PR remains draft for review and is stacked on #527.
