### PR TITLE
Give each framework benchmark run its own result file and share the gate

### DIFF
--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -9,11 +9,10 @@ from __future__ import annotations
 
 import hashlib
 import json
-import math
 import shlex
 import subprocess
-from collections.abc import Mapping, Sequence  # noqa: TC003  # tracked: #288
-from dataclasses import dataclass, replace
+from collections.abc import Sequence  # noqa: TC003  # tracked: #288
+from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003  # tracked: #288
 from typing import Any, Literal
 
@@ -57,7 +56,10 @@ from vibesys.loops.gates import (
     GATE_FEEDBACK_TAIL_CHARS,
     GATE_LOG_TAIL_CHARS,
     GATE_RECORD_TAIL_CHARS,
+    PROTOCOL_OUTPUT_FLAG,
+    FrameworkBenchmarkOutcome,
     run_accuracy_gate,
+    run_benchmark_gate,
 )
 from vibesys.loops.metrics import (
     Measurement,
@@ -79,7 +81,6 @@ from vibesys.run.events import (
     ExperimentsChangedData,
     JudgeResultData,
     RoundFinishedData,
-    SubprocessOutputData,
 )
 from vibesys.sandbox.run_environment import (
     RunEnvironmentSpec,
@@ -106,13 +107,6 @@ from vibesys.skills import (
     ResolvedSkillSelection,
     build_skill_catalog,
     resolve_skill_selections,
-)
-from vs_evaluator_protocol import (
-    Hello,
-    ProtocolError,
-    check_objectives,
-    parse_records,
-    read_measurement,
 )
 from vs_loop_state.agent import RoundHistory, RoundRecord
 from vs_project import AgentRunConfiguration
@@ -1864,115 +1858,7 @@ def _run_framework_accuracy_gate(  # noqa: PLR0913  # tracked: #288
     return result.feedback
 
 
-_FRAMEWORK_BENCHMARK_MARKER = "__VIBESYS_FRAMEWORK_BENCHMARK_JSON__"
-_FRAMEWORK_BENCHMARK_END_MARKER = "__VIBESYS_FRAMEWORK_BENCHMARK_JSON_END__"
-
-# The flag every result-protocol evaluator registers for its output file; see
-# ``OutputFlag`` in the evaluator SDK (``sdk/vs-evaluator/vseval/schema.go``).
-_PROTOCOL_OUTPUT_FLAG = "--vs-output"
-
-
-@dataclass(frozen=True, slots=True)
-class FrameworkBenchmarkOutcome:
-    """What one framework benchmark run reported.
-
-    ``feedback`` is set exactly when the run failed and the round must retry.
-    On success ``metric_name`` and ``metric_value`` carry the headline scalar
-    both result contracts produce, and ``row`` carries the complete validated
-    metric row, which only the evaluator result protocol reports.
-    """
-
-    feedback: str | None = None
-    metric_name: str | None = None
-    metric_value: float | None = None
-    metric_direction: Literal["max", "min"] | None = None
-    row: Mapping[str, float] | None = None
-
-
-def _read_protocol_benchmark(
-    text: str, *, objectives: Sequence[Objective]
-) -> FrameworkBenchmarkOutcome:
-    """Turn a recovered evaluator record stream into a benchmark outcome.
-
-    Never raises for a bad stream: an invalid stream, a structured evaluator
-    failure, and an undecidable headline metric all become round feedback.
-    Objectives belong to the task rather than to the evaluator, so the check
-    that the evaluator declares every optimized metric happens here and not in
-    the protocol reader.
-    """
-    hello: Hello | None = None
-    try:
-        records = parse_records(text)
-        hello = next((record for record in records if isinstance(record, Hello)), None)
-        measurement = read_measurement(records)
-        if objectives and hello is not None:
-            check_objectives(hello, {objective.name for objective in objectives})
-    except ProtocolError as error:
-        return FrameworkBenchmarkOutcome(feedback=_protocol_feedback(error, hello))
-    if measurement.values is None:
-        return FrameworkBenchmarkOutcome(
-            feedback=f"benchmark evaluator reported a failure: {measurement.failure}"
-        )
-    outcome = _select_headline_metric(measurement.values, objectives)
-    if outcome.metric_name is not None:
-        configured = next(
-            (item.direction for item in objectives if item.name == outcome.metric_name),
-            None,
-        )
-        declared = (
-            hello.metrics[outcome.metric_name].direction
-            if hello is not None and outcome.metric_name in hello.metrics
-            else None
-        )
-        outcome = replace(outcome, metric_direction=configured or declared)
-    return outcome
-
-
-def _protocol_feedback(error: ProtocolError, hello: Hello | None) -> str:
-    """Render a rejected record stream, naming its reason code and metrics."""
-    declared = ", ".join(sorted(hello.metrics)) if hello is not None else "(none declared)"
-    return f"invalid benchmark result [{error.code}]: {error}; evaluator declares: {declared}"
-
-
-def _select_headline_metric(
-    values: Mapping[str, float], objectives: Sequence[Objective]
-) -> FrameworkBenchmarkOutcome:
-    """Select the back-compat headline scalar out of a complete metric row.
-
-    The first configured objective names it. With no objectives configured a
-    single-metric evaluator is unambiguous; anything else is a task
-    configuration error to report rather than a row to guess through.
-    """
-    if objectives:
-        name = objectives[0].name
-        return FrameworkBenchmarkOutcome(metric_name=name, metric_value=values[name], row=values)
-    if len(values) == 1:
-        name, value = next(iter(values.items()))
-        return FrameworkBenchmarkOutcome(metric_name=name, metric_value=value, row=values)
-    return FrameworkBenchmarkOutcome(
-        feedback=(
-            f"benchmark evaluator reported metrics {', '.join(sorted(values))} but the task "
-            "configures no objectives, so no headline metric is defined; declare the optimized "
-            "metrics in objectives.toml"
-        )
-    )
-
-
-def _metric_values(value: object, metric: str) -> list[object]:
-    if isinstance(value, dict):
-        matches = [item for key, item in value.items() if key == metric]
-        for item in value.values():
-            matches.extend(_metric_values(item, metric))
-        return matches
-    if isinstance(value, list):
-        matches: list[object] = []
-        for item in value:
-            matches.extend(_metric_values(item, metric))
-        return matches
-    return []
-
-
-def _run_framework_benchmark(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
+def _run_framework_benchmark(  # noqa: PLR0913  # tracked: #288
     ctx: LoopContext,
     *,
     result_spec: BenchmarkResult | None,
@@ -1984,158 +1870,62 @@ def _run_framework_benchmark(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracke
     timeout_seconds: int | None = None,
     candidate_revision: str | None = None,
 ) -> FrameworkBenchmarkOutcome:
-    """Run and parse an opt-in trusted benchmark result contract.
+    """Run the shared benchmark gate and record its agent-loop bookkeeping.
 
-    ``result_spec`` scrapes one declared scalar out of arbitrary benchmark
-    JSON; ``result_protocol`` reads a complete validated metric row from the
-    evaluator result protocol. The manifest rejects declaring both.
+    The gate itself (result recovery, parsing, and the collision-proof result
+    path) lives in :mod:`vibesys.loops.gates`; this wrapper owns what is
+    agent-loop specific: progress notes, workspace snapshots, and the
+    supervisor's benchmark-result event.
     """
-    if result_spec is None and result_protocol is None:
-        return FrameworkBenchmarkOutcome()
-
-    base_command = ctx.judge_benchmark_command
-    if not base_command:
-        return FrameworkBenchmarkOutcome(
-            feedback="Benchmark result contract is configured without a benchmark command."
+    execution_base = None
+    if ctx.judge_benchmark_command:
+        execution_base = _with_candidate_revision(
+            ctx.judge_benchmark_command,
+            candidate_revision,
+            release_deployment_env_var=_deployment_release_env_var(ctx),
         )
-
-    output_path = f"/tmp/vibesys-framework-benchmark-{round_number}-{retry}.json"  # noqa: S108  # tracked: #288
-    output_argument = (
-        result_spec.json_argument if result_spec is not None else _PROTOCOL_OUTPUT_FLAG
+    result = run_benchmark_gate(
+        ctx,
+        result_spec=result_spec,
+        result_protocol=result_protocol,
+        objectives=objectives,
+        process_id=f"benchmark-{round_number}-{retry}",
+        output_slug=f"{round_number}-{retry}",
+        timeout_seconds=_framework_command_timeout(ctx, timeout_seconds),
+        execution_base=execution_base,
     )
-    execution_base = _with_candidate_revision(
-        base_command,
-        candidate_revision,
-        release_deployment_env_var=_deployment_release_env_var(ctx),
-    )
-    # The markers recover the result file through stdout, which is what makes
-    # the contract work for remote execution. Both contracts share that
-    # transport; only the recovered text is parsed differently.
-    command = (
-        f"{execution_base} {shlex.quote(output_argument)} {shlex.quote(output_path)}"
-        f" && printf '\\n{_FRAMEWORK_BENCHMARK_MARKER}\\n'"
-        f" && cat {shlex.quote(output_path)}"
-        f" && printf '\\n{_FRAMEWORK_BENCHMARK_END_MARKER}\\n'"
-    )
-    ctx.lprint(f"[framework-benchmark] running: {base_command}")
-    metric_name = result_spec.metric if result_spec is not None else None
-    metric_value: float | None = None
-    row: Mapping[str, float] | None = None
-    changed_before_execution = ctx.trusted_input_changes()
-    if changed_before_execution:
-        output = "Evaluator-owned files were modified: " + ", ".join(changed_before_execution)
-        passed = False
-    else:
-        try:
-            effective_timeout = _framework_command_timeout(ctx, timeout_seconds)
-            if effective_timeout is None:
-                result = ctx.judge_backend.execute(command)
-            else:
-                result = ctx.judge_backend.execute(command, timeout=effective_timeout)
-            output = result.output.strip()
-            passed = result.exit_code == 0
-            _publish_subprocess_output(
-                ctx,
-                process_id=f"benchmark-{round_number}-{retry}",
-                process_kind="benchmark",
-                content=result.output,
-            )
-        except Exception as exc:  # noqa: BLE001  # tracked: #288
-            output = f"benchmark command could not be executed: {exc}"
-            passed = False
-
-    if passed:
-        _, marker, framed = output.rpartition(_FRAMEWORK_BENCHMARK_MARKER)
-        encoded, end_marker, _ = framed.partition(_FRAMEWORK_BENCHMARK_END_MARKER)
-        if not marker or not end_marker:
-            output = f"{output}\nbenchmark output did not include its result JSON".strip()
-            passed = False
-        elif result_spec is None:
-            # No scalar spec, so the caller declared `result_protocol`: the
-            # recovered text is a record stream, not arbitrary benchmark JSON.
-            outcome = _read_protocol_benchmark(encoded, objectives=objectives)
-            if outcome.feedback is not None:
-                output = f"{output}\n{outcome.feedback}".strip()
-                passed = False
-            else:
-                metric_name = outcome.metric_name
-                metric_value = outcome.metric_value
-                row = outcome.row
-        else:
-            try:
-                payload = json.loads(encoded.strip())
-                # A result object owns its top-level metric. Rich benchmark
-                # reports may repeat that name in per-trial diagnostics, which
-                # must not make the declared aggregate ambiguous. Preserve the
-                # recursive lookup for legacy list-shaped result payloads.
-                if isinstance(payload, dict) and result_spec.metric in payload:
-                    values = [payload[result_spec.metric]]
-                else:
-                    values = _metric_values(payload, result_spec.metric)
-                if len(values) != 1:
-                    raise ValueError(  # noqa: TRY003, TRY301  # tracked: #288
-                        f"expected exactly one {result_spec.metric!r} field, found {len(values)}"
-                    )
-                value = values[0]
-                if isinstance(value, bool) or not isinstance(value, int | float):
-                    raise ValueError(f"{result_spec.metric!r} is not numeric")  # noqa: TRY003, TRY004, TRY301  # tracked: #288
-                metric_value = float(value)
-                if not math.isfinite(metric_value):
-                    raise ValueError(f"{result_spec.metric!r} is not finite")  # noqa: TRY003, TRY301  # tracked: #288
-            except (ValueError, TypeError, json.JSONDecodeError) as exc:
-                output = f"{output}\ninvalid benchmark result: {exc}".strip()
-                passed = False
-
-    changed = [] if changed_before_execution else ctx.trusted_input_changes()
-    if changed:
-        output = (
-            f"{output}\nEvaluator-owned files changed during benchmark execution: "
-            + ", ".join(changed)
-        ).strip()
-        passed = False
-        metric_value = None
-        row = None
+    if not result.executed:
+        return result.outcome
 
     issue_board.append_framework_benchmark(
         progress_path,
         round_number,
         retry,
-        command=base_command,
-        passed=passed,
-        metric_name=metric_name,
-        metric_value=metric_value,
-        output=output[-GATE_RECORD_TAIL_CHARS:],
+        command=result.command or "(not configured)",
+        passed=result.passed,
+        metric_name=(
+            result.outcome.metric_name or (result_spec.metric if result_spec is not None else None)
+        ),
+        metric_value=result.outcome.metric_value,
+        output=result.output[-GATE_RECORD_TAIL_CHARS:],
     )
     ctx.snapshot_workspace(f"round-{round_number}-retry-{retry}-framework-benchmark")
-    if passed:
-        ctx.lprint(f"[framework-benchmark] PASS: {metric_name}={metric_value}")
-        if metric_name is not None and metric_value is not None:
-            ctx.events.emit(
-                CoreEventType.BENCHMARK_RESULT,
-                status=EventStatus.COMPLETED,
-                round_label=f"round-{round_number}",
-                data=BenchmarkResultData(
-                    metric=metric_name,
-                    value=metric_value,
-                    unit=metric_name,
-                ),
-            )
-        return FrameworkBenchmarkOutcome(
-            metric_name=metric_name,
-            metric_value=metric_value,
-            metric_direction=(
-                next(
-                    (item.direction for item in objectives if item.name == metric_name),
-                    None,
-                )
-                or ("max" if result_spec is not None else None)
+    if (
+        result.passed
+        and result.outcome.metric_name is not None
+        and result.outcome.metric_value is not None
+    ):
+        ctx.events.emit(
+            CoreEventType.BENCHMARK_RESULT,
+            status=EventStatus.COMPLETED,
+            round_label=f"round-{round_number}",
+            data=BenchmarkResultData(
+                metric=result.outcome.metric_name,
+                value=result.outcome.metric_value,
+                unit=result.outcome.metric_name,
             ),
-            row=row,
         )
-
-    feedback = f"Framework benchmark failed.\n{output[-GATE_FEEDBACK_TAIL_CHARS:]}"
-    ctx.lprint(f"[framework-benchmark] FAIL: {output[-GATE_LOG_TAIL_CHARS:]}")
-    return FrameworkBenchmarkOutcome(feedback=feedback)
+    return result.outcome
 
 
 def _reconcile_model_requests(ctx: LoopContext) -> str | None:
@@ -2402,7 +2192,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
         benchmark_output_argument=(
             benchmark_result.json_argument
             if benchmark_result is not None
-            else _PROTOCOL_OUTPUT_FLAG
+            else PROTOCOL_OUTPUT_FLAG
             if benchmark_result_protocol is not None
             else None
         ),
@@ -3610,23 +3400,3 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
         return True
     finally:
         ctx.close()
-
-
-def _publish_subprocess_output(
-    ctx: LoopContext,
-    *,
-    process_id: str,
-    process_kind: str,
-    content: str,
-) -> None:
-    if not content:
-        return
-    ctx.events.emit(
-        CoreEventType.SUBPROCESS_OUTPUT,
-        data=SubprocessOutputData(
-            process_id=process_id,
-            process_kind=process_kind,
-            stream="stdout",
-            content=content,
-        ),
-    )

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -53,8 +53,6 @@ from vibesys.loops.agent.model import (
 )
 from vibesys.loops.agent.state import AgentRunStateStore
 from vibesys.loops.gates import (
-    GATE_FEEDBACK_TAIL_CHARS,
-    GATE_LOG_TAIL_CHARS,
     GATE_RECORD_TAIL_CHARS,
     PROTOCOL_OUTPUT_FLAG,
     FrameworkBenchmarkOutcome,

--- a/src/vibesys/loops/gates.py
+++ b/src/vibesys/loops/gates.py
@@ -172,10 +172,19 @@ class BenchmarkGateResult:
     """
 
     command: str | None
-    passed: bool
     output: str
     executed: bool
     outcome: FrameworkBenchmarkOutcome
+
+    @property
+    def passed(self) -> bool:
+        """Whether the round may keep this benchmark reading.
+
+        Derived rather than stored: ``FrameworkBenchmarkOutcome.feedback`` is
+        set exactly when the run failed, so a stored boolean beside it would be
+        a second writer of the same fact.
+        """
+        return self.outcome.feedback is None
 
 
 def read_protocol_benchmark(
@@ -261,6 +270,22 @@ def _metric_values(value: object, metric: str) -> list[object]:
     return []
 
 
+def _check_output_slug(output_slug: str) -> None:
+    """Reject a slug that would move the result file out of its directory.
+
+    The slug reaches the shell inside a quoted path, so this is not an
+    injection guard: it keeps a caller from silently writing (and removing)
+    a file outside ``_BENCHMARK_OUTPUT_PREFIX``'s directory, which the
+    SkyPilot artifact allowlist and the cleanup both assume.
+    """
+    if not output_slug:
+        raise ValueError("output_slug must not be empty")  # noqa: TRY003  # tracked: #288
+    if "/" in output_slug or ".." in output_slug:
+        raise ValueError(  # noqa: TRY003  # tracked: #288
+            f"output_slug must be a single path segment, got {output_slug!r}"
+        )
+
+
 def run_benchmark_gate(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
     ctx: LoopContext,
     *,
@@ -283,11 +308,19 @@ def run_benchmark_gate(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #28
     (including another user on a shared ``/tmp``) can never satisfy this
     invocation's ``cat``: a benchmark that does not write its own fresh result
     fails instead of silently reporting a stale one.
+
+    ``output_slug`` names the caller's invocation (round and retry, or a
+    candidate id) and is interpolated into that path, so it must stay a single
+    path segment.
+
+    Raises:
+        ValueError: when ``output_slug`` is empty or would escape the result
+            directory.
     """
+    _check_output_slug(output_slug)
     if result_spec is None and result_protocol is None:
         return BenchmarkGateResult(
             command=None,
-            passed=True,
             output="",
             executed=False,
             outcome=FrameworkBenchmarkOutcome(),
@@ -298,7 +331,6 @@ def run_benchmark_gate(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #28
         feedback = "Benchmark result contract is configured without a benchmark command."
         return BenchmarkGateResult(
             command=None,
-            passed=False,
             output=feedback,
             executed=False,
             outcome=FrameworkBenchmarkOutcome(feedback=feedback),
@@ -349,6 +381,14 @@ def run_benchmark_gate(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #28
             # already recovered from stdout, so the file is dead weight; leaving
             # it leaks one JSON per benchmark on hosts where /tmp persists for
             # weeks. Best-effort: a cleanup failure must not mask the result.
+            #
+            # Limitation on the timeout path: the Docker and Modal backends
+            # report a timeout as exit code -1 rather than raising, so this
+            # cleanup runs while the timed-out benchmark may still be alive in
+            # the sandbox and can write its result file afterwards. The nonce
+            # keeps that orphan from being read by any later invocation -- the
+            # correctness property this gate owns -- but it can survive as a
+            # leaked file until the sandbox is torn down.
             with contextlib.suppress(Exception):
                 ctx.judge_backend.execute(f"rm -f -- {shlex.quote(output_path)}")
 
@@ -430,7 +470,6 @@ def run_benchmark_gate(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #28
         )
     return BenchmarkGateResult(
         command=base_command,
-        passed=passed,
         output=output,
         executed=True,
         outcome=outcome,

--- a/src/vibesys/loops/gates.py
+++ b/src/vibesys/loops/gates.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import math
 import shlex
@@ -342,6 +343,14 @@ def run_benchmark_gate(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #28
         except Exception as exc:  # noqa: BLE001  # tracked: #288
             output = f"benchmark command could not be executed: {exc}"
             passed = False
+        finally:
+            # Remove the per-invocation transport artifact on every exit path
+            # (success, nonzero exit, timeout, malformed output). The result is
+            # already recovered from stdout, so the file is dead weight; leaving
+            # it leaks one JSON per benchmark on hosts where /tmp persists for
+            # weeks. Best-effort: a cleanup failure must not mask the result.
+            with contextlib.suppress(Exception):
+                ctx.judge_backend.execute(f"rm -f -- {shlex.quote(output_path)}")
 
     if passed:
         _, marker, framed = output.rpartition(FRAMEWORK_BENCHMARK_MARKER)

--- a/src/vibesys/loops/gates.py
+++ b/src/vibesys/loops/gates.py
@@ -1,11 +1,28 @@
-"""Framework-owned correctness gates shared by optimization loops."""
+"""Framework-owned correctness and measurement gates shared by optimization loops."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+import math
+import shlex
+import uuid
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Literal
 
+from vibesys.input_manifest import BenchmarkResult  # noqa: TC001  # tracked: #288
+from vibesys.loops.metrics import Objective  # noqa: TC001  # tracked: #288
 from vibesys.run import LoopContext  # noqa: TC001  # tracked: #288
 from vibesys.run.events import CoreEventType, SubprocessOutputData
+from vs_evaluator_protocol import (
+    Hello,
+    ProtocolError,
+    check_objectives,
+    parse_records,
+    read_measurement,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
 
 # Truncation lengths for gate failure output. All three values are defined
 # here so that the logged window, the agent-feedback window, and the record
@@ -98,6 +115,7 @@ def _publish_subprocess_output(
     *,
     process_id: str,
     content: str,
+    process_kind: str = "accuracy_checker",
 ) -> None:
     if not content:
         return
@@ -105,8 +123,306 @@ def _publish_subprocess_output(
         CoreEventType.SUBPROCESS_OUTPUT,
         data=SubprocessOutputData(
             process_id=process_id,
-            process_kind="accuracy_checker",
+            process_kind=process_kind,
             stream="stdout",
             content=content,
         ),
+    )
+
+
+FRAMEWORK_BENCHMARK_MARKER = "__VIBESYS_FRAMEWORK_BENCHMARK_JSON__"
+FRAMEWORK_BENCHMARK_END_MARKER = "__VIBESYS_FRAMEWORK_BENCHMARK_JSON_END__"
+
+# The flag every result-protocol evaluator registers for its output file; see
+# ``OutputFlag`` in the evaluator SDK (``sdk/vs-evaluator/vseval/schema.go``).
+PROTOCOL_OUTPUT_FLAG = "--vs-output"
+
+# The SkyPilot bridge allowlists framework result artifacts by this path
+# shape (``_FRAMEWORK_ARTIFACT`` in ``vibesys.skypilot.bridge``); the nonce
+# appended per invocation must stay within its ``[a-zA-Z0-9._-]`` alphabet.
+_BENCHMARK_OUTPUT_PREFIX = "/tmp/vibesys-framework-benchmark-"  # noqa: S108  # tracked: #288
+
+
+@dataclass(frozen=True, slots=True)
+class FrameworkBenchmarkOutcome:
+    """What one framework benchmark run reported.
+
+    ``feedback`` is set exactly when the run failed and the round must retry.
+    On success ``metric_name`` and ``metric_value`` carry the headline scalar
+    both result contracts produce, and ``row`` carries the complete validated
+    metric row, which only the evaluator result protocol reports.
+    """
+
+    feedback: str | None = None
+    metric_name: str | None = None
+    metric_value: float | None = None
+    metric_direction: Literal["max", "min"] | None = None
+    row: Mapping[str, float] | None = None
+
+
+@dataclass(frozen=True)
+class BenchmarkGateResult:
+    """Outcome of running the benchmark result contract for a candidate.
+
+    ``executed`` is False when the gate never reached a recordable conclusion:
+    no contract is declared, or the contract is declared without a benchmark
+    command. Loop-side bookkeeping (progress notes, snapshots) applies only to
+    executed gates.
+    """
+
+    command: str | None
+    passed: bool
+    output: str
+    executed: bool
+    outcome: FrameworkBenchmarkOutcome
+
+
+def read_protocol_benchmark(
+    text: str, *, objectives: Sequence[Objective]
+) -> FrameworkBenchmarkOutcome:
+    """Turn a recovered evaluator record stream into a benchmark outcome.
+
+    Never raises for a bad stream: an invalid stream, a structured evaluator
+    failure, and an undecidable headline metric all become round feedback.
+    Objectives belong to the task rather than to the evaluator, so the check
+    that the evaluator declares every optimized metric happens here and not in
+    the protocol reader.
+    """
+    hello: Hello | None = None
+    try:
+        records = parse_records(text)
+        hello = next((record for record in records if isinstance(record, Hello)), None)
+        measurement = read_measurement(records)
+        if objectives and hello is not None:
+            check_objectives(hello, {objective.name for objective in objectives})
+    except ProtocolError as error:
+        return FrameworkBenchmarkOutcome(feedback=_protocol_feedback(error, hello))
+    if measurement.values is None:
+        return FrameworkBenchmarkOutcome(
+            feedback=f"benchmark evaluator reported a failure: {measurement.failure}"
+        )
+    outcome = _select_headline_metric(measurement.values, objectives)
+    if outcome.metric_name is not None:
+        configured = next(
+            (item.direction for item in objectives if item.name == outcome.metric_name),
+            None,
+        )
+        declared = (
+            hello.metrics[outcome.metric_name].direction
+            if hello is not None and outcome.metric_name in hello.metrics
+            else None
+        )
+        outcome = replace(outcome, metric_direction=configured or declared)
+    return outcome
+
+
+def _protocol_feedback(error: ProtocolError, hello: Hello | None) -> str:
+    """Render a rejected record stream, naming its reason code and metrics."""
+    declared = ", ".join(sorted(hello.metrics)) if hello is not None else "(none declared)"
+    return f"invalid benchmark result [{error.code}]: {error}; evaluator declares: {declared}"
+
+
+def _select_headline_metric(
+    values: Mapping[str, float], objectives: Sequence[Objective]
+) -> FrameworkBenchmarkOutcome:
+    """Select the back-compat headline scalar out of a complete metric row.
+
+    The first configured objective names it. With no objectives configured a
+    single-metric evaluator is unambiguous; anything else is a task
+    configuration error to report rather than a row to guess through.
+    """
+    if objectives:
+        name = objectives[0].name
+        return FrameworkBenchmarkOutcome(metric_name=name, metric_value=values[name], row=values)
+    if len(values) == 1:
+        name, value = next(iter(values.items()))
+        return FrameworkBenchmarkOutcome(metric_name=name, metric_value=value, row=values)
+    return FrameworkBenchmarkOutcome(
+        feedback=(
+            f"benchmark evaluator reported metrics {', '.join(sorted(values))} but the task "
+            "configures no objectives, so no headline metric is defined; declare the optimized "
+            "metrics in objectives.toml"
+        )
+    )
+
+
+def _metric_values(value: object, metric: str) -> list[object]:
+    if isinstance(value, dict):
+        matches = [item for key, item in value.items() if key == metric]
+        for item in value.values():
+            matches.extend(_metric_values(item, metric))
+        return matches
+    if isinstance(value, list):
+        matches: list[object] = []
+        for item in value:
+            matches.extend(_metric_values(item, metric))
+        return matches
+    return []
+
+
+def run_benchmark_gate(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
+    ctx: LoopContext,
+    *,
+    result_spec: BenchmarkResult | None,
+    result_protocol: Literal[2] | None = None,
+    objectives: Sequence[Objective] = (),
+    process_id: str,
+    output_slug: str,
+    timeout_seconds: int | None = None,
+    execution_base: str | None = None,
+) -> BenchmarkGateResult:
+    """Run and parse an opt-in trusted benchmark result contract.
+
+    ``result_spec`` scrapes one declared scalar out of arbitrary benchmark
+    JSON; ``result_protocol`` reads a complete validated metric row from the
+    evaluator result protocol. The manifest rejects declaring both.
+
+    The result file path carries ``output_slug`` plus a per-invocation nonce,
+    and is removed before the benchmark runs, so a concurrent or earlier run
+    (including another user on a shared ``/tmp``) can never satisfy this
+    invocation's ``cat``: a benchmark that does not write its own fresh result
+    fails instead of silently reporting a stale one.
+    """
+    if result_spec is None and result_protocol is None:
+        return BenchmarkGateResult(
+            command=None,
+            passed=True,
+            output="",
+            executed=False,
+            outcome=FrameworkBenchmarkOutcome(),
+        )
+
+    base_command = ctx.judge_benchmark_command
+    if not base_command:
+        feedback = "Benchmark result contract is configured without a benchmark command."
+        return BenchmarkGateResult(
+            command=None,
+            passed=False,
+            output=feedback,
+            executed=False,
+            outcome=FrameworkBenchmarkOutcome(feedback=feedback),
+        )
+
+    output_path = f"{_BENCHMARK_OUTPUT_PREFIX}{output_slug}-{uuid.uuid4().hex[:12]}.json"
+    output_argument = result_spec.json_argument if result_spec is not None else PROTOCOL_OUTPUT_FLAG
+    # The markers recover the result file through stdout, which is what makes
+    # the contract work for remote execution. Both contracts share that
+    # transport; only the recovered text is parsed differently.
+    command = (
+        f"rm -f -- {shlex.quote(output_path)}"
+        f" && {execution_base or base_command}"
+        f" {shlex.quote(output_argument)} {shlex.quote(output_path)}"
+        f" && printf '\\n{FRAMEWORK_BENCHMARK_MARKER}\\n'"
+        f" && cat {shlex.quote(output_path)}"
+        f" && printf '\\n{FRAMEWORK_BENCHMARK_END_MARKER}\\n'"
+    )
+    ctx.lprint(f"[framework-benchmark] running: {base_command}")
+    metric_name = result_spec.metric if result_spec is not None else None
+    metric_value: float | None = None
+    metric_direction: Literal["max", "min"] | None = None
+    row: Mapping[str, float] | None = None
+    changed_before_execution = ctx.trusted_input_changes()
+    if changed_before_execution:
+        output = "Evaluator-owned files were modified: " + ", ".join(changed_before_execution)
+        passed = False
+    else:
+        try:
+            if timeout_seconds is None:
+                result = ctx.judge_backend.execute(command)
+            else:
+                result = ctx.judge_backend.execute(command, timeout=timeout_seconds)
+            output = result.output.strip()
+            passed = result.exit_code == 0
+            _publish_subprocess_output(
+                ctx,
+                process_id=process_id,
+                content=result.output,
+                process_kind="benchmark",
+            )
+        except Exception as exc:  # noqa: BLE001  # tracked: #288
+            output = f"benchmark command could not be executed: {exc}"
+            passed = False
+
+    if passed:
+        _, marker, framed = output.rpartition(FRAMEWORK_BENCHMARK_MARKER)
+        encoded, end_marker, _ = framed.partition(FRAMEWORK_BENCHMARK_END_MARKER)
+        if not marker or not end_marker:
+            output = f"{output}\nbenchmark output did not include its result JSON".strip()
+            passed = False
+        elif result_spec is None:
+            # No scalar spec, so the caller declared `result_protocol`: the
+            # recovered text is a record stream, not arbitrary benchmark JSON.
+            protocol_outcome = read_protocol_benchmark(encoded, objectives=objectives)
+            if protocol_outcome.feedback is not None:
+                output = f"{output}\n{protocol_outcome.feedback}".strip()
+                passed = False
+            else:
+                metric_name = protocol_outcome.metric_name
+                metric_value = protocol_outcome.metric_value
+                metric_direction = protocol_outcome.metric_direction
+                row = protocol_outcome.row
+        else:
+            try:
+                payload = json.loads(encoded.strip())
+                # A result object owns its top-level metric. Rich benchmark
+                # reports may repeat that name in per-trial diagnostics, which
+                # must not make the declared aggregate ambiguous. Preserve the
+                # recursive lookup for legacy list-shaped result payloads.
+                if isinstance(payload, dict) and result_spec.metric in payload:
+                    values = [payload[result_spec.metric]]
+                else:
+                    values = _metric_values(payload, result_spec.metric)
+                if len(values) != 1:
+                    raise ValueError(  # noqa: TRY003, TRY301  # tracked: #288
+                        f"expected exactly one {result_spec.metric!r} field, found {len(values)}"
+                    )
+                value = values[0]
+                if isinstance(value, bool) or not isinstance(value, int | float):
+                    raise ValueError(f"{result_spec.metric!r} is not numeric")  # noqa: TRY003, TRY004, TRY301  # tracked: #288
+                metric_value = float(value)
+                if not math.isfinite(metric_value):
+                    raise ValueError(f"{result_spec.metric!r} is not finite")  # noqa: TRY003, TRY301  # tracked: #288
+            except (ValueError, TypeError, json.JSONDecodeError) as exc:
+                output = f"{output}\ninvalid benchmark result: {exc}".strip()
+                passed = False
+
+    changed = [] if changed_before_execution else ctx.trusted_input_changes()
+    if changed:
+        output = (
+            f"{output}\nEvaluator-owned files changed during benchmark execution: "
+            + ", ".join(changed)
+        ).strip()
+        passed = False
+        metric_value = None
+        row = None
+
+    if passed:
+        ctx.lprint(f"[framework-benchmark] PASS: {metric_name}={metric_value}")
+        outcome = FrameworkBenchmarkOutcome(
+            metric_name=metric_name,
+            metric_value=metric_value,
+            # The protocol path resolves the direction while reading the row
+            # (configured objective first, then the evaluator's declaration);
+            # the legacy scalar contract keeps its historical maximize default.
+            metric_direction=(
+                metric_direction
+                or next(
+                    (item.direction for item in objectives if item.name == metric_name),
+                    None,
+                )
+                or ("max" if result_spec is not None else None)
+            ),
+            row=row,
+        )
+    else:
+        ctx.lprint(f"[framework-benchmark] FAIL: {output[-GATE_LOG_TAIL_CHARS:]}")
+        outcome = FrameworkBenchmarkOutcome(
+            feedback=f"Framework benchmark failed.\n{output[-GATE_FEEDBACK_TAIL_CHARS:]}"
+        )
+    return BenchmarkGateResult(
+        command=base_command,
+        passed=passed,
+        output=output,
+        executed=True,
+        outcome=outcome,
     )

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -1884,8 +1884,10 @@ def test_framework_benchmark_removes_transport_artifact(tmp_path):  # noqa: ANN0
     """Regression for #532: the per-nonce result file is removed on every path.
 
     Runs the gate against a real shell backend so the transport JSON is
-    genuinely written under ``/tmp``, then asserts it no longer exists after
-    both a successful parse and a malformed-output failure.
+    genuinely written under ``/tmp``, then asserts it no longer exists after a
+    successful parse, a malformed-output failure, and a nonzero-exit benchmark
+    that writes the file before failing. Success, nonzero exit, timeout, and
+    malformed output all leave through the same ``finally`` cleanup.
     """
     import sys  # noqa: PLC0415  # tracked: #288
 
@@ -1909,14 +1911,17 @@ def test_framework_benchmark_removes_transport_artifact(tmp_path):  # noqa: ANN0
             )
             return SimpleNamespace(exit_code=proc.returncode, output=proc.stdout)
 
-    def run_once(payload):  # noqa: ANN001, ANN202  # tracked: #288
+    def run_once(payload, *, fail_after_write=False):  # noqa: ANN001, ANN202  # tracked: #288
         # The benchmark "command" copies a fixed source file to the result path
         # the gate appends as its last argument, so the payload text controls
-        # whether the recovered JSON parses.
+        # whether the recovered JSON parses. ``fail_after_write`` writes the
+        # file and then exits nonzero, exercising the leaked-artifact path.
         src = tmp_path / "payload.json"
         src.write_text(payload)
+        tail = "; sys.exit(1)" if fail_after_write else ""
         writer = (
-            f"{sys.executable} -c \"import sys, shutil; shutil.copyfile('{src}', sys.argv[-1])\""
+            f'{sys.executable} -c "import sys, shutil; '
+            f"shutil.copyfile('{src}', sys.argv[-1]){tail}\""
         )
         ctx = MagicMock()
         ctx.judge_benchmark_command = writer
@@ -1943,6 +1948,12 @@ def test_framework_benchmark_removes_transport_artifact(tmp_path):  # noqa: ANN0
 
     # Malformed output: parsing fails, but the artifact is still removed.
     result, artifact = run_once("this is not json")
+    assert not result.passed
+    assert not artifact.exists()
+
+    # Nonzero exit: the benchmark writes the result file and then fails, the
+    # exact leak the fixed-name path used to strand; still removed.
+    result, artifact = run_once('{"tok_per_sec": 42.0}', fail_after_write=True)
     assert not result.passed
     assert not artifact.exists()
 

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -1,7 +1,6 @@
 """Tests for vibesys.loops.agent — orchestrator-driven build loop."""
 
 import json
-import re
 import subprocess
 from collections.abc import Sequence
 from pathlib import Path
@@ -1804,13 +1803,6 @@ def test_framework_benchmark_extracts_declared_metric(tmp_path):  # noqa: ANN001
     executed = benchmark_call.args[0]
     assert benchmark_call.kwargs == {"timeout": 300}
     assert "trusted-benchmark --repetitions 3 --output-json" in executed
-    # The result path carries a per-invocation nonce and is removed up front,
-    # so a stale or cross-run file can never satisfy this invocation's cat.
-    result_path = re.search(
-        r"cat (/tmp/vibesys-framework-benchmark-3-1-[0-9a-f]{12}\.json)", executed
-    )
-    assert result_path is not None
-    assert executed.startswith(f"rm -f -- {result_path.group(1)} && ")
     assert FRAMEWORK_BENCHMARK_END_MARKER in executed
     assert "total_ops_per_sec**: 42.5" in (tmp_path / "progress.md").read_text()
 
@@ -1880,84 +1872,6 @@ def test_framework_benchmark_rejects_ambiguous_metric(tmp_path):  # noqa: ANN001
     assert "expected exactly one 'ops' field" in outcome.feedback
 
 
-def test_framework_benchmark_removes_transport_artifact(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
-    """Regression for #532: the per-nonce result file is removed on every path.
-
-    Runs the gate against a real shell backend so the transport JSON is
-    genuinely written under ``/tmp``, then asserts it no longer exists after a
-    successful parse, a malformed-output failure, and a nonzero-exit benchmark
-    that writes the file before failing. Success, nonzero exit, timeout, and
-    malformed output all leave through the same ``finally`` cleanup.
-    """
-    import sys  # noqa: PLC0415  # tracked: #288
-
-    from vibesys.loops.gates import (  # noqa: PLC0415  # tracked: #288
-        _BENCHMARK_OUTPUT_PREFIX,
-        run_benchmark_gate,
-    )
-
-    class _ShellJudgeBackend:
-        def __init__(self) -> None:
-            self.commands: list[str] = []
-
-        def execute(self, command, timeout=None):  # noqa: ANN001, ANN202  # tracked: #288
-            self.commands.append(command)
-            proc = subprocess.run(  # noqa: S603  # tracked: #288
-                ["bash", "-c", command],  # noqa: S607  # tracked: #288
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                check=False,
-            )
-            return SimpleNamespace(exit_code=proc.returncode, output=proc.stdout)
-
-    def run_once(payload, *, fail_after_write=False):  # noqa: ANN001, ANN202  # tracked: #288
-        # The benchmark "command" copies a fixed source file to the result path
-        # the gate appends as its last argument, so the payload text controls
-        # whether the recovered JSON parses. ``fail_after_write`` writes the
-        # file and then exits nonzero, exercising the leaked-artifact path.
-        src = tmp_path / "payload.json"
-        src.write_text(payload)
-        tail = "; sys.exit(1)" if fail_after_write else ""
-        writer = (
-            f'{sys.executable} -c "import sys, shutil; '
-            f"shutil.copyfile('{src}', sys.argv[-1]){tail}\""
-        )
-        ctx = MagicMock()
-        ctx.judge_benchmark_command = writer
-        ctx.trusted_input_changes.return_value = []
-        backend = _ShellJudgeBackend()
-        ctx.judge_backend = backend
-        result = run_benchmark_gate(
-            ctx,
-            result_spec=BenchmarkResult(json_argument="--out", metric="tok_per_sec"),
-            process_id="benchmark",
-            output_slug="round-9-retry-2",
-        )
-        match = re.search(
-            rf"cat ({re.escape(_BENCHMARK_OUTPUT_PREFIX)}\S+\.json)", backend.commands[0]
-        )
-        assert match is not None
-        return result, Path(match.group(1))
-
-    # Success: valid JSON parses and the transport artifact is cleaned up.
-    result, artifact = run_once('{"tok_per_sec": 42.0}')
-    assert result.passed
-    assert result.outcome.metric_value == 42.0
-    assert not artifact.exists()
-
-    # Malformed output: parsing fails, but the artifact is still removed.
-    result, artifact = run_once("this is not json")
-    assert not result.passed
-    assert not artifact.exists()
-
-    # Nonzero exit: the benchmark writes the result file and then fails, the
-    # exact leak the fixed-name path used to strand; still removed.
-    result, artifact = run_once('{"tok_per_sec": 42.0}', fail_after_write=True)
-    assert not result.passed
-    assert not artifact.exists()
-
-
 # ---------------------------------------------------------------------------
 # Evaluator result protocol benchmarks
 # ---------------------------------------------------------------------------
@@ -1993,6 +1907,7 @@ def _protocol_benchmark_ctx(stream: str) -> MagicMock:
 
 def test_protocol_benchmark_reads_complete_row(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     from vibesys.loops.agent.loop import _run_framework_benchmark  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.gates import PROTOCOL_OUTPUT_FLAG  # noqa: PLC0415  # tracked: #288
 
     ctx = _protocol_benchmark_ctx(f"{_HELLO}\n{_RESULT}")
 
@@ -2012,12 +1927,7 @@ def test_protocol_benchmark_reads_complete_row(tmp_path):  # noqa: ANN001, ANN20
     assert outcome.metric_name == "total_ops_per_sec"
     assert outcome.metric_value == 41250.3
     executed = ctx.judge_backend.execute.call_args_list[0].args[0]
-    result_path = re.search(
-        r"--vs-output (/tmp/vibesys-framework-benchmark-3-1-[0-9a-f]{12}\.json)", executed
-    )
-    assert result_path is not None
-    assert f"cat {result_path.group(1)}" in executed
-    assert executed.startswith(f"rm -f -- {result_path.group(1)} && ")
+    assert PROTOCOL_OUTPUT_FLAG in executed
     assert "total_ops_per_sec**: 41250.3" in (tmp_path / "progress.md").read_text()
 
 

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -1,6 +1,7 @@
 """Tests for vibesys.loops.agent — orchestrator-driven build loop."""
 
 import json
+import re
 import subprocess
 from collections.abc import Sequence
 from pathlib import Path
@@ -1764,10 +1765,10 @@ def test_framework_gates_reuse_accuracy_pass_after_later_gate_failure(tmp_path):
 
 def test_framework_benchmark_extracts_declared_metric(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     from vibesys.input_manifest import BenchmarkResult  # noqa: PLC0415  # tracked: #288
-    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
-        _FRAMEWORK_BENCHMARK_END_MARKER,
-        _FRAMEWORK_BENCHMARK_MARKER,
-        _run_framework_benchmark,
+    from vibesys.loops.agent.loop import _run_framework_benchmark  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.gates import (  # noqa: PLC0415  # tracked: #288
+        FRAMEWORK_BENCHMARK_END_MARKER,
+        FRAMEWORK_BENCHMARK_MARKER,
     )
 
     ctx = MagicMock()
@@ -1776,8 +1777,8 @@ def test_framework_benchmark_extracts_declared_metric(tmp_path):  # noqa: ANN001
     ctx.judge_backend.execute.return_value = SimpleNamespace(
         exit_code=0,
         output=(
-            f"benchmark diagnostics\n{_FRAMEWORK_BENCHMARK_MARKER}\n"
-            f'[{{"total_ops_per_sec": 42.5}}]\n{_FRAMEWORK_BENCHMARK_END_MARKER}\n'
+            f"benchmark diagnostics\n{FRAMEWORK_BENCHMARK_MARKER}\n"
+            f'[{{"total_ops_per_sec": 42.5}}]\n{FRAMEWORK_BENCHMARK_END_MARKER}\n'
             "[stderr] benchmark diagnostics emitted after stdout"
         ),
     )
@@ -1802,17 +1803,23 @@ def test_framework_benchmark_extracts_declared_metric(tmp_path):  # noqa: ANN001
     executed = ctx.judge_backend.execute.call_args.args[0]
     assert ctx.judge_backend.execute.call_args.kwargs == {"timeout": 300}
     assert "trusted-benchmark --repetitions 3 --output-json" in executed
-    assert "cat /tmp/vibesys-framework-benchmark-3-1.json" in executed
-    assert _FRAMEWORK_BENCHMARK_END_MARKER in executed
+    # The result path carries a per-invocation nonce and is removed up front,
+    # so a stale or cross-run file can never satisfy this invocation's cat.
+    result_path = re.search(
+        r"cat (/tmp/vibesys-framework-benchmark-3-1-[0-9a-f]{12}\.json)", executed
+    )
+    assert result_path is not None
+    assert executed.startswith(f"rm -f -- {result_path.group(1)} && ")
+    assert FRAMEWORK_BENCHMARK_END_MARKER in executed
     assert "total_ops_per_sec**: 42.5" in (tmp_path / "progress.md").read_text()
 
 
 def test_framework_benchmark_prefers_top_level_metric_over_trial_diagnostics(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     from vibesys.input_manifest import BenchmarkResult  # noqa: PLC0415  # tracked: #288
-    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
-        _FRAMEWORK_BENCHMARK_END_MARKER,
-        _FRAMEWORK_BENCHMARK_MARKER,
-        _run_framework_benchmark,
+    from vibesys.loops.agent.loop import _run_framework_benchmark  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.gates import (  # noqa: PLC0415  # tracked: #288
+        FRAMEWORK_BENCHMARK_END_MARKER,
+        FRAMEWORK_BENCHMARK_MARKER,
     )
 
     ctx = MagicMock()
@@ -1821,10 +1828,10 @@ def test_framework_benchmark_prefers_top_level_metric_over_trial_diagnostics(tmp
     ctx.judge_backend.execute.return_value = SimpleNamespace(
         exit_code=0,
         output=(
-            f"{_FRAMEWORK_BENCHMARK_MARKER}\n"
+            f"{FRAMEWORK_BENCHMARK_MARKER}\n"
             '{"primary_value": 42.5, "trials": [{"primary_value": 41.0}, '
             '{"primary_value": 44.0}]}\n'
-            f"{_FRAMEWORK_BENCHMARK_END_MARKER}"
+            f"{FRAMEWORK_BENCHMARK_END_MARKER}"
         ),
     )
 
@@ -1842,10 +1849,10 @@ def test_framework_benchmark_prefers_top_level_metric_over_trial_diagnostics(tmp
 
 def test_framework_benchmark_rejects_ambiguous_metric(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
     from vibesys.input_manifest import BenchmarkResult  # noqa: PLC0415  # tracked: #288
-    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
-        _FRAMEWORK_BENCHMARK_END_MARKER,
-        _FRAMEWORK_BENCHMARK_MARKER,
-        _run_framework_benchmark,
+    from vibesys.loops.agent.loop import _run_framework_benchmark  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.gates import (  # noqa: PLC0415  # tracked: #288
+        FRAMEWORK_BENCHMARK_END_MARKER,
+        FRAMEWORK_BENCHMARK_MARKER,
     )
 
     ctx = MagicMock()
@@ -1854,8 +1861,8 @@ def test_framework_benchmark_rejects_ambiguous_metric(tmp_path):  # noqa: ANN001
     ctx.judge_backend.execute.return_value = SimpleNamespace(
         exit_code=0,
         output=(
-            f'{_FRAMEWORK_BENCHMARK_MARKER}\n[{{"ops": 1}}, {{"ops": 2}}]\n'
-            f"{_FRAMEWORK_BENCHMARK_END_MARKER}"
+            f'{FRAMEWORK_BENCHMARK_MARKER}\n[{{"ops": 1}}, {{"ops": 2}}]\n'
+            f"{FRAMEWORK_BENCHMARK_END_MARKER}"
         ),
     )
 
@@ -1887,9 +1894,9 @@ _RESULT = '{"kind":"result","values":{"total_ops_per_sec":41250.3,"p99_latency_n
 
 def _protocol_benchmark_ctx(stream: str) -> MagicMock:
     """A LoopContext whose benchmark recovers *stream* through stdout."""
-    from vibesys.loops.agent.loop import (  # noqa: PLC0415  # tracked: #288
-        _FRAMEWORK_BENCHMARK_END_MARKER,
-        _FRAMEWORK_BENCHMARK_MARKER,
+    from vibesys.loops.gates import (  # noqa: PLC0415  # tracked: #288
+        FRAMEWORK_BENCHMARK_END_MARKER,
+        FRAMEWORK_BENCHMARK_MARKER,
     )
 
     ctx = MagicMock()
@@ -1898,8 +1905,8 @@ def _protocol_benchmark_ctx(stream: str) -> MagicMock:
     ctx.judge_backend.execute.return_value = SimpleNamespace(
         exit_code=0,
         output=(
-            f"benchmark diagnostics\n{_FRAMEWORK_BENCHMARK_MARKER}\n"
-            f"{stream}\n{_FRAMEWORK_BENCHMARK_END_MARKER}\n"
+            f"benchmark diagnostics\n{FRAMEWORK_BENCHMARK_MARKER}\n"
+            f"{stream}\n{FRAMEWORK_BENCHMARK_END_MARKER}\n"
         ),
     )
     return ctx
@@ -1926,8 +1933,12 @@ def test_protocol_benchmark_reads_complete_row(tmp_path):  # noqa: ANN001, ANN20
     assert outcome.metric_name == "total_ops_per_sec"
     assert outcome.metric_value == 41250.3
     executed = ctx.judge_backend.execute.call_args.args[0]
-    assert "trusted-benchmark --vs-output /tmp/vibesys-framework-benchmark-3-1.json" in executed
-    assert "cat /tmp/vibesys-framework-benchmark-3-1.json" in executed
+    result_path = re.search(
+        r"--vs-output (/tmp/vibesys-framework-benchmark-3-1-[0-9a-f]{12}\.json)", executed
+    )
+    assert result_path is not None
+    assert f"cat {result_path.group(1)}" in executed
+    assert executed.startswith(f"rm -f -- {result_path.group(1)} && ")
     assert "total_ops_per_sec**: 41250.3" in (tmp_path / "progress.md").read_text()
 
 
@@ -1994,14 +2005,14 @@ def test_protocol_benchmark_surfaces_reason_code_for_malformed_stream(tmp_path):
 
 
 def test_read_protocol_benchmark_uses_the_only_declared_metric_without_objectives():  # noqa: ANN201  # tracked: #288
-    from vibesys.loops.agent.loop import _read_protocol_benchmark  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.gates import read_protocol_benchmark  # noqa: PLC0415  # tracked: #288
 
     stream = (
         '{"kind":"hello","protocol":2,"metrics":{"total_ops_per_sec":{"unit":"ops/s"}}}\n'
         '{"kind":"result","values":{"total_ops_per_sec":7.5}}'
     )
 
-    outcome = _read_protocol_benchmark(stream, objectives=[])
+    outcome = read_protocol_benchmark(stream, objectives=[])
 
     assert outcome.feedback is None
     assert outcome.metric_name == "total_ops_per_sec"
@@ -2010,9 +2021,9 @@ def test_read_protocol_benchmark_uses_the_only_declared_metric_without_objective
 
 
 def test_read_protocol_benchmark_refuses_to_guess_a_headline_metric():  # noqa: ANN201  # tracked: #288
-    from vibesys.loops.agent.loop import _read_protocol_benchmark  # noqa: PLC0415  # tracked: #288
+    from vibesys.loops.gates import read_protocol_benchmark  # noqa: PLC0415  # tracked: #288
 
-    outcome = _read_protocol_benchmark(f"{_HELLO}\n{_RESULT}", objectives=[])
+    outcome = read_protocol_benchmark(f"{_HELLO}\n{_RESULT}", objectives=[])
 
     assert outcome.metric_value is None
     feedback = outcome.feedback or ""

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -1800,8 +1800,9 @@ def test_framework_benchmark_extracts_declared_metric(tmp_path):  # noqa: ANN001
     assert outcome.metric_name == "total_ops_per_sec"
     # The legacy contract reports one scalar, never a complete row.
     assert outcome.row is None
-    executed = ctx.judge_backend.execute.call_args.args[0]
-    assert ctx.judge_backend.execute.call_args.kwargs == {"timeout": 300}
+    benchmark_call = ctx.judge_backend.execute.call_args_list[0]
+    executed = benchmark_call.args[0]
+    assert benchmark_call.kwargs == {"timeout": 300}
     assert "trusted-benchmark --repetitions 3 --output-json" in executed
     # The result path carries a per-invocation nonce and is removed up front,
     # so a stale or cross-run file can never satisfy this invocation's cat.
@@ -1879,6 +1880,73 @@ def test_framework_benchmark_rejects_ambiguous_metric(tmp_path):  # noqa: ANN001
     assert "expected exactly one 'ops' field" in outcome.feedback
 
 
+def test_framework_benchmark_removes_transport_artifact(tmp_path):  # noqa: ANN001, ANN201  # tracked: #288
+    """Regression for #532: the per-nonce result file is removed on every path.
+
+    Runs the gate against a real shell backend so the transport JSON is
+    genuinely written under ``/tmp``, then asserts it no longer exists after
+    both a successful parse and a malformed-output failure.
+    """
+    import sys  # noqa: PLC0415  # tracked: #288
+
+    from vibesys.loops.gates import (  # noqa: PLC0415  # tracked: #288
+        _BENCHMARK_OUTPUT_PREFIX,
+        run_benchmark_gate,
+    )
+
+    class _ShellJudgeBackend:
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+
+        def execute(self, command, timeout=None):  # noqa: ANN001, ANN202  # tracked: #288
+            self.commands.append(command)
+            proc = subprocess.run(  # noqa: S603  # tracked: #288
+                ["bash", "-c", command],  # noqa: S607  # tracked: #288
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+            return SimpleNamespace(exit_code=proc.returncode, output=proc.stdout)
+
+    def run_once(payload):  # noqa: ANN001, ANN202  # tracked: #288
+        # The benchmark "command" copies a fixed source file to the result path
+        # the gate appends as its last argument, so the payload text controls
+        # whether the recovered JSON parses.
+        src = tmp_path / "payload.json"
+        src.write_text(payload)
+        writer = (
+            f"{sys.executable} -c \"import sys, shutil; shutil.copyfile('{src}', sys.argv[-1])\""
+        )
+        ctx = MagicMock()
+        ctx.judge_benchmark_command = writer
+        ctx.trusted_input_changes.return_value = []
+        backend = _ShellJudgeBackend()
+        ctx.judge_backend = backend
+        result = run_benchmark_gate(
+            ctx,
+            result_spec=BenchmarkResult(json_argument="--out", metric="tok_per_sec"),
+            process_id="benchmark",
+            output_slug="round-9-retry-2",
+        )
+        match = re.search(
+            rf"cat ({re.escape(_BENCHMARK_OUTPUT_PREFIX)}\S+\.json)", backend.commands[0]
+        )
+        assert match is not None
+        return result, Path(match.group(1))
+
+    # Success: valid JSON parses and the transport artifact is cleaned up.
+    result, artifact = run_once('{"tok_per_sec": 42.0}')
+    assert result.passed
+    assert result.outcome.metric_value == 42.0
+    assert not artifact.exists()
+
+    # Malformed output: parsing fails, but the artifact is still removed.
+    result, artifact = run_once("this is not json")
+    assert not result.passed
+    assert not artifact.exists()
+
+
 # ---------------------------------------------------------------------------
 # Evaluator result protocol benchmarks
 # ---------------------------------------------------------------------------
@@ -1932,7 +2000,7 @@ def test_protocol_benchmark_reads_complete_row(tmp_path):  # noqa: ANN001, ANN20
     # The headline scalar is the first configured objective.
     assert outcome.metric_name == "total_ops_per_sec"
     assert outcome.metric_value == 41250.3
-    executed = ctx.judge_backend.execute.call_args.args[0]
+    executed = ctx.judge_backend.execute.call_args_list[0].args[0]
     result_path = re.search(
         r"--vs-output (/tmp/vibesys-framework-benchmark-3-1-[0-9a-f]{12}\.json)", executed
     )

--- a/tests/vibesys/loops/test_gates.py
+++ b/tests/vibesys/loops/test_gates.py
@@ -1,0 +1,251 @@
+"""Tests for ``vibesys.loops.gates`` -- the framework gates shared by loops.
+
+These exercise the benchmark gate through a real ``bash`` judge backend so the
+transport file it writes under ``/tmp`` genuinely exists. The gate's guarantee
+is about a file on disk, so a mocked backend cannot observe it.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from vibesys.input_manifest import BenchmarkResult
+from vibesys.loops.gates import (
+    _BENCHMARK_OUTPUT_PREFIX,
+    read_protocol_benchmark,
+    run_benchmark_gate,
+)
+from vibesys.loops.metrics import Objective
+
+_SCALAR_SPEC = BenchmarkResult(json_argument="--out", metric="tok_per_sec")
+
+
+class _ShellJudgeBackend:
+    """A judge backend that really runs the gate's command line under bash."""
+
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+
+    def execute(self, command, timeout=None):  # noqa: ANN001, ANN202  # tracked: #288
+        self.commands.append(command)
+        proc = subprocess.run(  # noqa: S603  # tracked: #288
+            ["bash", "-c", command],  # noqa: S607  # tracked: #288
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return SimpleNamespace(exit_code=proc.returncode, output=proc.stdout)
+
+
+def _gate_ctx_with(backend: object, benchmark_command: str = "benchmark") -> MagicMock:
+    """A loop context that runs its benchmark through *backend*."""
+    ctx = MagicMock()
+    ctx.judge_benchmark_command = benchmark_command
+    ctx.trusted_input_changes.return_value = []
+    ctx.judge_backend = backend
+    return ctx
+
+
+def _gate_ctx(benchmark_command: str) -> MagicMock:
+    """A loop context whose benchmark command really runs."""
+    return _gate_ctx_with(_ShellJudgeBackend(), benchmark_command)
+
+
+def _writer_command(payload: str, tmp_path: Path, *, fail_after_write: bool = False) -> str:
+    """A benchmark command that copies *payload* to the path passed last.
+
+    The gate appends ``<output flag> <output path>`` to the configured
+    benchmark command, so a writer that reads ``sys.argv[-1]`` stands in for a
+    real benchmark honoring its result contract. ``fail_after_write`` writes
+    the file and then exits nonzero.
+    """
+    source = tmp_path / "payload.json"
+    source.write_text(payload)
+    tail = "; sys.exit(1)" if fail_after_write else ""
+    return (
+        f'{sys.executable} -c "import sys, shutil; '
+        f"shutil.copyfile('{source}', sys.argv[-1]){tail}\""
+    )
+
+
+def _transport_artifact(command: str) -> Path:
+    """The result file the gate told the benchmark to write."""
+    match = re.search(rf"cat ({re.escape(_BENCHMARK_OUTPUT_PREFIX)}\S+\.json)", command)
+    assert match is not None
+    return Path(match.group(1))
+
+
+def test_benchmark_gate_fails_instead_of_reporting_a_stale_result() -> None:
+    """Regression for #480: a benchmark that writes nothing cannot pass.
+
+    The result path used to be a fixed
+    ``/tmp/vibesys-framework-benchmark-<round>-<retry>.json``. A file left
+    there by an earlier round, a concurrent run, or another user on the same
+    host satisfied this invocation's ``cat``, and the gate reported that stale
+    number as the candidate's measurement. Plant exactly such a file, then run
+    a benchmark that writes no result at all: the gate must fail rather than
+    hand the loop 999.0.
+    """
+    slug = f"stale-{os.getpid()}"
+    stale = Path(f"{_BENCHMARK_OUTPUT_PREFIX}{slug}.json")
+    stale.write_text('{"tok_per_sec": 999.0}')
+    try:
+        result = run_benchmark_gate(
+            _gate_ctx("true"),
+            result_spec=_SCALAR_SPEC,
+            process_id="benchmark",
+            output_slug=slug,
+        )
+    finally:
+        stale.unlink(missing_ok=True)
+
+    assert not result.passed
+    assert result.outcome.feedback is not None
+    assert result.outcome.metric_value is None
+
+
+def test_benchmark_gate_removes_its_transport_artifact(tmp_path: Path) -> None:
+    """The per-invocation result file is removed on every exit path.
+
+    The result is recovered from stdout, so the file is dead weight once the
+    command returns; leaving it behind leaks one JSON per benchmark on hosts
+    where ``/tmp`` persists. Success, malformed output, and a nonzero exit
+    after the file was written all leave through the same cleanup.
+    """
+    ctx = _gate_ctx(_writer_command('{"tok_per_sec": 42.0}', tmp_path))
+    result = run_benchmark_gate(
+        ctx, result_spec=_SCALAR_SPEC, process_id="benchmark", output_slug="9-2"
+    )
+    assert result.passed
+    assert result.outcome.metric_value == 42.0
+    assert not _transport_artifact(ctx.judge_backend.commands[0]).exists()
+
+    ctx = _gate_ctx(_writer_command("this is not json", tmp_path))
+    result = run_benchmark_gate(
+        ctx, result_spec=_SCALAR_SPEC, process_id="benchmark", output_slug="9-2"
+    )
+    assert not result.passed
+    assert not _transport_artifact(ctx.judge_backend.commands[0]).exists()
+
+    ctx = _gate_ctx(_writer_command('{"tok_per_sec": 42.0}', tmp_path, fail_after_write=True))
+    result = run_benchmark_gate(
+        ctx, result_spec=_SCALAR_SPEC, process_id="benchmark", output_slug="9-2"
+    )
+    assert not result.passed
+    assert not _transport_artifact(ctx.judge_backend.commands[0]).exists()
+
+
+def test_a_timed_out_benchmarks_late_result_cannot_be_read_by_the_next_run() -> None:
+    """The documented limit of the cleanup, and the property that survives it.
+
+    ``DockerSandbox.execute`` and ``ModalSandbox.execute`` report a timeout as
+    exit code -1 instead of raising, so the gate's cleanup runs while the
+    timed-out benchmark may still be alive and can write its result file
+    afterwards. That orphan can outlive the gate. What it must never do is
+    satisfy a later invocation's ``cat``, which the per-invocation nonce
+    guarantees: the next run fails rather than reporting the orphan's number.
+    """
+    orphans: list[Path] = []
+
+    class _TimingOutBackend:
+        """Times out the benchmark, then writes its result file too late."""
+
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+
+        def execute(self, command, timeout=None):  # noqa: ANN001, ANN202, ARG002  # tracked: #288
+            self.commands.append(command)
+            if "cat " not in command:  # the cleanup rm
+                return SimpleNamespace(exit_code=0, output="")
+            path = _transport_artifact(command)
+            path.write_text('{"tok_per_sec": 999.0}')
+            orphans.append(path)
+            return SimpleNamespace(exit_code=-1, output="Command timed out after 5s")
+
+    try:
+        first = run_benchmark_gate(
+            _gate_ctx_with(_TimingOutBackend()),
+            result_spec=_SCALAR_SPEC,
+            process_id="benchmark",
+            output_slug="7-0",
+        )
+        assert not first.passed
+        assert len(orphans) == 1
+        assert orphans[0].exists()
+
+        second = run_benchmark_gate(
+            _gate_ctx("true"),
+            result_spec=_SCALAR_SPEC,
+            process_id="benchmark",
+            output_slug="7-0",
+        )
+        assert not second.passed
+        assert second.outcome.metric_value is None
+    finally:
+        for orphan in orphans:
+            orphan.unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("slug", ["", "../escape", "nested/slug"])
+def test_benchmark_gate_rejects_an_output_slug_that_is_not_one_segment(slug: str) -> None:
+    """A slug is interpolated into the result path, so it stays one segment."""
+    with pytest.raises(ValueError, match="output_slug"):
+        run_benchmark_gate(
+            _gate_ctx("true"),
+            result_spec=_SCALAR_SPEC,
+            process_id="benchmark",
+            output_slug=slug,
+        )
+
+
+def test_benchmark_gate_keeps_the_evaluator_declared_direction(tmp_path: Path) -> None:
+    """Regression for #477: an unconfigured axis keeps the declared direction.
+
+    The gate used to derive the direction from ``objectives.toml`` alone and
+    fall back to ``max`` for the legacy scalar contract, so a protocol-2
+    evaluator declaring a latency metric as ``min`` had its reading compared
+    the wrong way round whenever the task configured no objectives. The
+    evaluator's declaration is now the fallback, and an axis with no known
+    direction stays ``None`` so ``MetricSpace`` reports ``INCOMPARABLE``
+    instead of guessing.
+    """
+    stream = (
+        '{"kind":"hello","protocol":2,'
+        '"metrics":{"p99_latency_ns":{"unit":"ns","direction":"min"}}}\n'
+        '{"kind":"result","values":{"p99_latency_ns":1250.0}}'
+    )
+    result = run_benchmark_gate(
+        _gate_ctx(_writer_command(stream, tmp_path)),
+        result_spec=None,
+        result_protocol=2,
+        objectives=(),
+        process_id="benchmark",
+        output_slug="4-0",
+    )
+
+    assert result.passed, result.outcome.feedback
+    assert result.outcome.metric_name == "p99_latency_ns"
+    assert result.outcome.metric_direction == "min"
+
+
+def test_configured_objective_overrides_the_declared_direction() -> None:
+    """``objectives.toml`` still wins over the evaluator's declaration."""
+    stream = (
+        '{"kind":"hello","protocol":2,'
+        '"metrics":{"score":{"unit":"points","direction":"min"}}}\n'
+        '{"kind":"result","values":{"score":3.0}}'
+    )
+
+    outcome = read_protocol_benchmark(stream, objectives=[Objective(name="score", direction="max")])
+
+    assert outcome.feedback is None
+    assert outcome.metric_direction == "max"


### PR DESCRIPTION
> Stacked PR 1/6. Base branch: `main`. This is the bottom of the #495 split; the remaining five PRs (#533, #534, #535, #536, #537) stack on top in that order.

## Problem

Two independent bugs in the framework benchmark gate, both rooted in the same place.

**The result file had no per-invocation identity (#480).** The gate wrote to the fixed path `/tmp/vibesys-framework-benchmark-{round}-{retry}.json` and then read it back with `cat`. Nothing removed the file first, so any file already at that path satisfied the read: a leftover from a crashed earlier round, a concurrent run on the same host, or another user's file on a shared `/tmp`. A benchmark that wrote no result at all could therefore be reported as a successful measurement, with someone else's number attached to this candidate. On a shared `/tmp` a file owned by another user also makes the write fail outright with permission denied.

**The evaluator-declared metric direction was resolved and then discarded (#477).** `_read_protocol_benchmark` resolved `metric_direction` from the configured objective, falling back to the evaluator's `hello` declaration, and then the caller threw that away and recomputed the direction from `objectives.toml` alone (defaulting to `max` for the legacy scalar contract). Every shipped `result_protocol = 2` task configures bare metric names without directions, so the recomputed direction was always `None`, and every metric comparison that needed it came back undecided.

Benchmark execution and parsing also lived inline in the agent loop (`_read_protocol_benchmark`, `_run_framework_benchmark`, `_PROTOCOL_OUTPUT_FLAG`), so the evolve loop had no way to share the same trusted reader.

## Solution

Move benchmark execution and parsing out of the agent loop into `vibesys.loops.gates` so both optimization loops share one trusted implementation, make every benchmark invocation read only a file it created itself, and keep the direction the reader resolved.

- `run_benchmark_gate` writes to `/tmp/vibesys-framework-benchmark-{slug}-{12-hex-nonce}.json` and removes that path with `rm -f --` before executing. The result is recovered from stdout between explicit markers produced by the same invocation, and a missing or unparseable result is a hard gate failure, never a silent fallback to whatever is on disk. A `finally` block removes the transport artifact on every exit path so the gate does not leak one JSON per benchmark.
- `output_slug` is validated at the boundary: it is interpolated into the result path, so an empty slug or one containing `/` or `..` is rejected with an error naming the field.
- The metric direction the reader resolved (configured objective first, then the evaluator's `hello` declaration) now travels out on `FrameworkBenchmarkOutcome.metric_direction` and is what the loop records. The legacy scalar contract keeps its historical `max`; a protocol metric with no direction anywhere stays `None`, which `MetricSpace` reports as `INCOMPARABLE` rather than guessing an order.
- The relocated machinery is otherwise verbatim: `FrameworkBenchmarkOutcome`, `read_protocol_benchmark`, `_select_headline_metric`, and the marker transport move into `gates` unchanged, and the output flag and markers become the public `PROTOCOL_OUTPUT_FLAG` / `FRAMEWORK_BENCHMARK_*` constants.
- `BenchmarkGateResult` wraps the outcome with the command text and whether the gate reached a recordable conclusion. `passed` is a property derived from `outcome.feedback is None` rather than a second stored copy of the same fact.
- The agent loop's `_run_framework_benchmark` becomes a thin wrapper over `run_benchmark_gate`, and the dead private `_publish_subprocess_output` copy left behind in the agent loop is removed.

### Architecture

```mermaid
flowchart LR
    L[agent loop<br/>_run_framework_benchmark thin wrapper] --> G[gates.run_benchmark_gate]
    E[evolve loop] -. shares from #533 .-> G
    G --> P[nonce path<br/>rm -f -- before run<br/>rm -f -- in finally]
    G --> M[marker-delimited readback<br/>from same invocation]
    G --> O[FrameworkBenchmarkOutcome<br/>name, value, direction, row]
    O --> R[BenchmarkGateResult<br/>command, output, executed<br/>passed = feedback is None]
```

The gate layer (`vibesys.loops.gates`) now owns benchmark execution and parsing for every loop; callers receive a `BenchmarkGateResult` and never touch `/tmp` paths or output markers directly.

## Verification

### Correctness properties

- Every benchmark gate invocation reads only a file it created itself. A benchmark that writes no result fails the gate instead of reporting a number it did not produce, and no two concurrent or sequential runs on one host can read or overwrite each other's result file.
- The transport artifact is removed on success, nonzero exit, and malformed output. Known limitation, documented in the code and covered by a test: `DockerSandbox.execute` and `ModalSandbox.execute` report a timeout as exit code `-1` rather than raising, so a timed-out benchmark may still write its result file after the cleanup ran. The nonce keeps that orphan from ever being read by a later invocation, which is the property the gate owns; the file itself can survive until the sandbox is torn down.
- `output_slug` is a single path segment; an empty slug or one containing `/` or `..` raises with the field named.
- A protocol metric's direction comes from the configured objective when there is one, else the evaluator's `hello` declaration. A metric with no direction from either source stays `None` so `MetricSpace` reports `INCOMPARABLE` instead of assuming an order.
- The benchmark outcome (metric name, value, full row) is otherwise identical to the pre-move agent-loop implementation; only the file path, the direction fallback, and the module boundary change.
- `BenchmarkGateResult` stores no field that another field determines.

### Testing

- `uv run pytest tests/vibesys/loops -q --no-cov`: all pass.
- `uv run pytest libs/vs-loop-state/tests tests/server -q --no-cov`: 278 passed.
- `./scripts/check_format.sh`, `./scripts/check_lint.sh`, `./scripts/check_types.sh`: all clean.

New `tests/vibesys/loops/test_gates.py` drives the gate through a real `bash` judge backend so the transport file genuinely exists on disk:

- `test_benchmark_gate_fails_instead_of_reporting_a_stale_result` plants a file at the old fixed path and runs a benchmark that writes nothing. Verified to fail at the pre-fix path shape, reporting the planted `999.0` as the candidate's measurement.
- `test_a_timed_out_benchmarks_late_result_cannot_be_read_by_the_next_run` covers the documented timeout limitation. Also verified to fail at the pre-fix path shape.
- `test_benchmark_gate_removes_its_transport_artifact` covers success, malformed output, and a nonzero exit after the file was written.
- `test_benchmark_gate_keeps_the_evaluator_declared_direction` pins the #477 fix: a protocol-2 `hello` declaring `direction: "min"` with no configured objectives yields `min`. Verified to fail when the direction fallback is reverted to objectives-only.
- `test_benchmark_gate_rejects_an_output_slug_that_is_not_one_segment` and `test_configured_objective_overrides_the_declared_direction` cover the boundary and the precedence rule.

Closes #480. Closes #477.
