### PR TITLE
Record who produced each round's headline metric

### DIFF
--- a/libs/vs-loop-state/src/vs_loop_state/__init__.py
+++ b/libs/vs-loop-state/src/vs_loop_state/__init__.py
@@ -7,6 +7,7 @@ all three loops. Project layout and filesystem persistence belong to
 
 from vs_loop_state.agent import (
     JudgeVerdict,
+    PerfProvenance,
     RoundHistory,
     RoundRecord,
     parse_round_record,
@@ -33,6 +34,7 @@ __all__ = [
     "IndividualRecord",
     "JudgeVerdict",
     "MetricComparison",
+    "PerfProvenance",
     "PlainLoopCursor",
     "PlainPerformanceRecord",
     "PlainPerformanceSnapshot",

--- a/libs/vs-loop-state/src/vs_loop_state/agent.py
+++ b/libs/vs-loop-state/src/vs_loop_state/agent.py
@@ -49,6 +49,12 @@ if TYPE_CHECKING:
 #: is the only value compatible with an unreviewed round.
 JudgeVerdict = Literal["pass", "fail", "deferred"]
 
+#: Who produced a round's headline ``perf_metric``. ``framework`` means a
+#: framework-owned benchmark result contract measured it; ``implementer`` means
+#: the agent reported it about its own work. Only the framework may write
+#: ``framework``, so this is the trust boundary every consumer branches on.
+PerfProvenance = Literal["framework", "implementer"]
+
 
 @dataclass(config=ConfigDict(extra="forbid", populate_by_name=True, serialize_by_alias=True))
 class RoundRecord:
@@ -92,9 +98,13 @@ class RoundRecord:
     hypothesis_parent_commit: str | None = None
     metrics: dict[str, float] = Field(default_factory=dict)
     evaluation_artifact: str | None = None
-    # Only framework-owned gates can set this. A judge-approved hypothesis may
-    # be a useful provisional working checkpoint without becoming the latest
-    # officially verified checkpoint.
+    # Whether the framework's own gates ran this round. Only framework-owned
+    # gates can set it: a judge-approved hypothesis may be a useful provisional
+    # working checkpoint without becoming the latest officially verified
+    # checkpoint. It says nothing about who produced ``perf_metric`` -- the
+    # gates can run in a round whose headline number is still the agent's own
+    # report -- so consumers deciding whether to trust a measurement read
+    # ``perf_provenance``, not this flag.
     official_evaluation: bool = False
     official_evaluation_reason: str | None = None
     # Candidate evidence is deliberately separate from official tracking. It
@@ -125,6 +135,13 @@ class RoundRecord:
     # framework stored the comparison; readers then re-derive it from the
     # run's persisted metric space.
     perf_comparison: MetricComparison | None = None
+
+    # Who produced ``perf_metric``. ``None`` identifies a legacy record written
+    # before provenance was tracked; consumers treat those as trusted so
+    # reprojection does not rewrite their historical resolutions. On every
+    # record the framework writes now, ``perf_provenance`` is non-None whenever
+    # ``perf_metric`` is non-None.
+    perf_provenance: PerfProvenance | None = None
 
     # Implementer attribution: which driver/provider/model produced this round
     # attempt. The provider session ID itself is machine-local and never lives

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -108,7 +108,7 @@ from vibesys.skills import (
     build_skill_catalog,
     resolve_skill_selections,
 )
-from vs_loop_state.agent import RoundHistory, RoundRecord
+from vs_loop_state.agent import PerfProvenance, RoundHistory, RoundRecord
 from vs_project import AgentRunConfiguration
 
 # Candidate process boundaries selected by ``--interface``. Language, tooling,
@@ -2933,6 +2933,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                 # For single-agent inner loop, `profiler_summary` carries the
                 # PREVIOUS round's profile (fed forward to the orchestrator),
                 # so this round's perf comes from `single_agent_response` instead.
+                perf_provenance: PerfProvenance | None = None
                 if inner_loop == "single-agent":
                     if (
                         single_agent_response is not None
@@ -2941,6 +2942,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     ):
                         single_agent_response.perf_metric = framework_perf_metric
                         single_agent_response.perf_unit = framework_benchmark.metric_name
+                        perf_provenance = "framework"
                     profile_skipped = single_agent_response is None or (
                         single_agent_response.perf_metric is None
                     )
@@ -2962,6 +2964,10 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         )
                         else None
                     )
+                    if perf_metric is not None and perf_provenance is None:
+                        # Not overridden by the framework benchmark above, so
+                        # this headline number is the agent's own report.
+                        perf_provenance = "implementer"
                     # Remember the latest profile for the orchestrator's next plan
                     # and carry forward the implicit profile focus.
                     if single_agent_response is not None:
@@ -2996,8 +3002,10 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     ):
                         perf_metric = framework_perf_metric
                         perf_unit = framework_benchmark.metric_name
+                        perf_provenance = "framework"
                     elif implementation_metric is not None:
                         perf_metric = implementation_metric
+                        perf_provenance = "implementer"
                         if implementation is not None and implementation.perf_metric is not None:
                             perf_unit = implementation.perf_unit
                             accepted_metrics = dict(implementation.metrics)
@@ -3237,6 +3245,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     perf_baseline_metric=baseline_metric,
                     perf_delta_pct=perf_delta_pct,
                     perf_comparison=perf_comparison,
+                    perf_provenance=perf_provenance,
                     implementer_driver=ctx.agent_client.driver_name,
                     implementer_provider=ctx.agent_client.provider,
                     implementer_model=ctx.agent_client.model_for_kind("implementer"),

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -4420,3 +4420,59 @@ def test_completed_round_records_which_implementer_produced_it(tmp_path, ref_fil
     assert round_one["implementer_model"] == "gpt-5.6-sol"
     # The record is portable state; a host-local session ID must never reach it.
     assert not [key for key in round_one if "session" in key]
+
+
+def test_round_records_stamp_who_produced_the_headline_metric(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """A round's `perf_provenance` names the source of its `perf_metric`.
+
+    `official_evaluation` only says the framework's gates ran; it is true for
+    both rounds below. Without a separate stamp, a consumer deciding whether a
+    number is trustworthy cannot tell the agent's self-report from a
+    framework-owned measurement, which is what #479 is about.
+    """
+    runner = _make_orchestrate_runner(implementer_perf_metrics=[321.5])
+
+    _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1, judge_every=10)
+
+    rounds = _round_payloads(tmp_path)
+    assert rounds[0]["official_evaluation"] is True
+    assert rounds[0]["perf_metric"] == 321.5
+    assert rounds[0]["perf_provenance"] == "implementer"
+
+
+def test_framework_measured_round_is_stamped_framework(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """The framework benchmark's number overrides the agent's, stamp included."""
+    runner = _make_orchestrate_runner(implementer_perf_metrics=[321.5])
+
+    with patch(
+        "vibesys.loops.agent.loop._run_framework_benchmark",
+        return_value=FrameworkBenchmarkOutcome(
+            metric_name="total_ops_per_sec",
+            metric_value=41250.3,
+            metric_direction="max",
+        ),
+    ):
+        _invoke_orchestrate(
+            tmp_path,
+            ref_file,
+            runner,
+            max_rounds=1,
+            judge_every=10,
+            benchmark_result_protocol=2,
+        )
+
+    rounds = _round_payloads(tmp_path)
+    assert rounds[0]["official_evaluation"] is True
+    assert rounds[0]["perf_metric"] == 41250.3
+    assert rounds[0]["perf_provenance"] == "framework"
+
+
+def test_a_round_with_no_headline_metric_carries_no_provenance(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """The invariant: provenance is set exactly when a metric is recorded."""
+    runner = _make_orchestrate_runner(implementer_perf_metrics=[None])
+
+    _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1, judge_every=10)
+
+    rounds = _round_payloads(tmp_path)
+    assert rounds[0]["perf_metric"] is None
+    assert rounds[0]["perf_provenance"] is None

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -50,6 +50,7 @@ from vibesys.schemas import (
     OrchestratorPlan,
     PreRoundDecision,
     ProfilerSummary,
+    SingleAgentRoundResponse,
     SkillResourceSelection,
     ValidationRecipe,
     ValidationRecipeArtifact,
@@ -142,7 +143,28 @@ command = ["uv", "run", "python", "benchmark/benchmark.py"]
     return str(ref)
 
 
-def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
+def _single_agent_round(perf_metric: float | None) -> SingleAgentRoundResponse:
+    """One `--inner-loop=single-agent` round's combined response.
+
+    That ablation has one agent implement, self-judge, and profile, so this
+    response is the round's only source of a headline number unless the
+    framework benchmark overrides it.
+    """
+    return SingleAgentRoundResponse(
+        summary="Done.",
+        expected_behavior="ok",
+        self_review="gates hold",
+        feedback="",
+        verdict=Verdict.PASS,
+        bottlenecks="none",
+        suggestions="none",
+        profile_analysis="ok",
+        perf_metric=perf_metric,
+        perf_unit="tok/s" if perf_metric is not None else None,
+    )
+
+
+def _make_orchestrate_runner(  # noqa: ANN202, C901, PLR0913  # tracked: #288
     *,
     pre_decisions: list[PreRoundDecision] | None = None,
     plans: list[OrchestratorPlan] | None = None,
@@ -150,6 +172,7 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     judge_verdicts: list[str] | None = None,
     profiler_responses: list[ProfilerSummary] | None = None,
     implementer_perf_metrics: list[float | None] | None = None,
+    single_agent_perf_metrics: list[float | None] | None = None,
     implementer_skill_updates: list[list[SkillResourceSelection]] | None = None,
     implementer_validation_artifacts: list[str | None] | None = None,
     implementer_next_steps: list[str] | None = None,
@@ -172,6 +195,7 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
     judge_q = list(judge_verdicts or [])
     prof_q = list(profiler_responses or [])
     impl_perf_q = list(implementer_perf_metrics or [])
+    single_agent_perf_q = list(single_agent_perf_metrics or [])
     impl_skill_q = list(implementer_skill_updates or [])
     impl_validation_q = list(implementer_validation_artifacts or [])
     impl_next_step_q = list(implementer_next_steps or [])
@@ -205,6 +229,9 @@ def _make_orchestrate_runner(  # noqa: ANN202, PLR0913  # tracked: #288
                 pass_criteria="no criteria",  # noqa: S106  # tracked: #288
                 reasoning="default noop plan — the loop's max_rounds bounds the test",
             )
+        if kind == "implementer" and response_cls is SingleAgentRoundResponse:
+            counters["impl"] += 1
+            return _single_agent_round(single_agent_perf_q.pop(0) if single_agent_perf_q else None)
         if kind == "implementer":
             counters["impl"] += 1
             if impl_parse_failure_q and impl_parse_failure_q.pop(0):
@@ -4472,6 +4499,71 @@ def test_a_round_with_no_headline_metric_carries_no_provenance(tmp_path, ref_fil
     runner = _make_orchestrate_runner(implementer_perf_metrics=[None])
 
     _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1, judge_every=10)
+
+    rounds = _round_payloads(tmp_path)
+    assert rounds[0]["perf_metric"] is None
+    assert rounds[0]["perf_provenance"] is None
+
+
+def test_single_agent_self_reported_metric_is_stamped_implementer(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """The `--inner-loop=single-agent` ablation stamps provenance too.
+
+    One agent implements, self-judges, and profiles, so its `perf_metric` is
+    the agent's own report by construction. Nothing about that round makes it
+    more trustworthy than the multi-agent implementer's number.
+    """
+    runner = _make_orchestrate_runner(single_agent_perf_metrics=[123.5])
+
+    _invoke_orchestrate(
+        tmp_path,
+        ref_file,
+        runner,
+        max_rounds=1,
+        inner_loop="single-agent",
+    )
+
+    rounds = _round_payloads(tmp_path)
+    assert rounds[0]["perf_metric"] == 123.5
+    assert rounds[0]["perf_provenance"] == "implementer"
+
+
+def test_single_agent_framework_benchmark_overrides_and_stamps_framework(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """A framework benchmark replaces the single agent's number and its stamp."""
+    runner = _make_orchestrate_runner(single_agent_perf_metrics=[123.5])
+
+    with patch(
+        "vibesys.loops.agent.loop._run_framework_benchmark",
+        return_value=FrameworkBenchmarkOutcome(
+            metric_name="total_ops_per_sec",
+            metric_value=41250.3,
+            metric_direction="max",
+        ),
+    ):
+        _invoke_orchestrate(
+            tmp_path,
+            ref_file,
+            runner,
+            max_rounds=1,
+            inner_loop="single-agent",
+            benchmark_result_protocol=2,
+        )
+
+    rounds = _round_payloads(tmp_path)
+    assert rounds[0]["perf_metric"] == 41250.3
+    assert rounds[0]["perf_provenance"] == "framework"
+
+
+def test_single_agent_round_without_a_metric_carries_no_provenance(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """The invariant holds on the single-agent path as well."""
+    runner = _make_orchestrate_runner(single_agent_perf_metrics=[None])
+
+    _invoke_orchestrate(
+        tmp_path,
+        ref_file,
+        runner,
+        max_rounds=1,
+        inner_loop="single-agent",
+    )
 
     rounds = _round_payloads(tmp_path)
     assert rounds[0]["perf_metric"] is None


### PR DESCRIPTION
> Stacked PR 3/6. Base branch: `main` (#532 and #533 have merged). #535, #536, and #537 stack on top in that order.

## Problem

A round could write `official_evaluation=True` with a `perf_metric` the agent reported about its own work, and nothing on the record said which. `official_evaluation` means "the framework's own gates ran this round"; it does not say who produced the headline number, because the gates can run in a round whose metric is still the implementer's self-report. Every downstream consumer (hypothesis resolution, baselines, measurements, retention) had only that flag to go on, so an agent's own claim could seed a baseline or stand in as an official measurement. The gap starts at the record itself: there was no field for where a round's headline metric came from.

## Solution

Record provenance on every round record and stamp it wherever the agent loop produces a headline metric.

- `vs_loop_state` exports `PerfProvenance = Literal["framework", "implementer"]`, alongside `JudgeVerdict`, and `RoundRecord` gains `perf_provenance: PerfProvenance | None`. One exported definition, so the loop and the consumers that stack above this PR name the closed set rather than restating its literals.
- The agent loop stamps `"framework"` when the benchmark gate produced the number and `"implementer"` when the agent self-reported it, on both the single-agent and multi-agent paths. The stamped value rides on the `RoundRecord` written to the write-ahead journal.
- `None` marks a legacy record written before provenance was tracked. Those stay trusted, so reprojecting an old run does not rewrite its historical resolutions.
- `official_evaluation`'s comment is corrected: it says the framework's gates ran, and consumers deciding whether to trust a measurement read `perf_provenance` instead.

**Out of scope.** Nothing gates on the field yet; the consumers ship in #535. The operator-facing projection is also out of scope: `HypothesisRound` does not surface provenance, so the TUI cannot yet show an operator that a number was self-reported. That needs its own change.

### Architecture

```mermaid
flowchart LR
    G[framework benchmark gate] --> A[round record<br/>perf_provenance=framework]
    S[agent self-report] --> A2[round record<br/>perf_provenance=implementer]
    L[record written before #534] --> AN[perf_provenance=None<br/>stays trusted]
    A --> J[write-ahead journal / RoundRecord]
    A2 --> J
    AN --> J
    J -. consumed in #535 .-> R[resolution, retention, baselines]
```

The agent loop owns provenance stamping; `vs_loop_state` owns the closed set and the field; nothing gates on it in this PR.

## Verification

### Correctness properties

- On every record the framework writes now, `perf_provenance` is non-None whenever `perf_metric` is non-None: `"framework"` from a benchmark gate, `"implementer"` from a self-report. `None` only ever identifies a legacy record.
- `official_evaluation` and `perf_provenance` are independent: a round can have the gates run and still carry an implementer-produced number.
- The field is additive loop state. Existing resolutions are unchanged at this layer and legacy records keep their historical values.
- The field is confined to persisted loop state. `perf_provenance` appears nowhere under `src/server/` or `clients/`: no event payload carries it and no client type references it, so nothing on the wire changes.

### Testing

- `uv run pytest tests/vibesys/loops -q --no-cov`
- `uv run pytest libs/vs-loop-state/tests tests/server -q --no-cov`: 280 passed
- `./scripts/check_format.sh`, `./scripts/check_lint.sh`, `./scripts/check_types.sh`: clean

New loop-level coverage in `tests/vibesys/loops/agent/test_orchestrate.py`, driven through the orchestrate harness rather than asserting the field in isolation:

- `test_round_records_stamp_who_produced_the_headline_metric`: an implementer-reported number is stamped `implementer` even though `official_evaluation` is true.
- `test_framework_measured_round_is_stamped_framework`: the framework benchmark's number overrides the agent's and is stamped `framework`.
- `test_a_round_with_no_headline_metric_carries_no_provenance`: the invariant's other half.

The first two were verified to fail with the stamp removed from the record write.

Part of #479. The issue also asks that an operator be able to see which numbers are self-reported; that projection is not in this PR.
