### PR TITLE
Resolve a hypothesis unmeasured when the framework measured nothing

### DIFF
--- a/clients/backend-client/src/generated/protocol.generated.ts
+++ b/clients/backend-client/src/generated/protocol.generated.ts
@@ -395,7 +395,7 @@ export type HypothesisOutcome1 =
  * Framework-owned resolution after all available evidence is known.
  */
 export type HypothesisResolution =
-  "proven" | "disproven" | "inconclusive" | "implementation_failed" | "blocked" | "rejected";
+  "proven" | "disproven" | "inconclusive" | "implementation_failed" | "blocked" | "rejected" | "unmeasured";
 export type JudgeVerdict1 = ("pass" | "fail" | "deferred") | null;
 export type PerfMetric2 = number | null;
 export type PerfUnit2 = string | null;

--- a/clients/backend-client/src/generated/protocol.schema.json
+++ b/clients/backend-client/src/generated/protocol.schema.json
@@ -1597,7 +1597,8 @@
         "inconclusive",
         "implementation_failed",
         "blocked",
-        "rejected"
+        "rejected",
+        "unmeasured"
       ],
       "title": "HypothesisResolution",
       "type": "string"

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -645,8 +645,10 @@ export function entryRow(entry: HypothesisEntry, columns: Columns): string {
 
 /**
  * Green for a hypothesis that held, red for one that did not, and the active
- * accent while it is still open. Outcomes with no such reading (``continue``,
- * ``inconclusive``) stay in body text rather than being forced into a verdict.
+ * accent while it is still open. Outcomes with no such reading stay in body
+ * text rather than being forced into a verdict: `inconclusive`, where a
+ * trusted measurement did not decide the claim, and `unmeasured`, where the
+ * framework measured nothing to decide it with.
  */
 export function outcomeColor(theme: Theme, entry: HypothesisEntry): string {
   const outcome = entry.resolved_outcome ?? null;

--- a/src/vibesys/loops/agent/hypotheses.py
+++ b/src/vibesys/loops/agent/hypotheses.py
@@ -339,14 +339,22 @@ def round_comparison(
 ) -> MetricComparison | None:
     """Return how one round's headline reading compared with its baseline.
 
-    ``None`` means the round recorded no official metric, so there was nothing
-    to order. A record that carries ``perf_comparison`` answers for itself: the
-    framework decided it once, when the round was written, and re-deriving it
-    later from a possibly re-configured space would let a resumed run disagree
-    with what it recorded. Older records have the comparison derived from
-    *space* instead.
+    ``None`` means there is nothing to order: the round recorded no official
+    metric, or the number it recorded is the implementer's own report. A record
+    that carries ``perf_comparison`` answers for itself: the framework decided
+    it once, when the round was written, and re-deriving it later from a
+    possibly re-configured space would let a resumed run disagree with what it
+    recorded. Older records have the comparison derived from *space* instead.
+
+    The provenance guard has to come before that re-derivation. A round the
+    implementer self-reported stores no comparison, which is indistinguishable
+    from a pre-#579 record; without this guard the fallback would re-derive one
+    from the space and resume, and the server read path, would resolve the
+    hypothesis INCONCLUSIVE where the loop resolved it UNMEASURED.
     """
     if not record.official_evaluation or record.perf_metric is None:
+        return None
+    if not trusted_perf_provenance(record.perf_provenance):
         return None
     if record.perf_comparison is not None:
         return record.perf_comparison

--- a/src/vibesys/loops/agent/hypotheses.py
+++ b/src/vibesys/loops/agent/hypotheses.py
@@ -23,7 +23,19 @@ from vibesys.schemas import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from vs_loop_state import RoundRecord
+    from vs_loop_state import PerfProvenance, RoundRecord
+
+
+def trusted_perf_provenance(provenance: PerfProvenance | None) -> bool:
+    """Whether a round's headline metric may drive a framework decision.
+
+    The one trust rule for :data:`~vs_loop_state.PerfProvenance`, shared by
+    hypothesis resolution, scalar and Pareto retention, the recorded delta, and
+    trusted Pareto-parent selection. Legacy records carry no provenance and stay
+    trusted, so reprojecting an old run does not rewrite its historical
+    resolutions; only an explicit agent self-report is untrusted.
+    """
+    return provenance != "implementer"
 
 
 @dataclass(frozen=True)
@@ -31,23 +43,30 @@ class ResolutionEvidence:
     """Inputs the framework needs to finalize one hypothesis declaration.
 
     ``comparison`` is the round's headline reading ordered against its causal
-    baseline. ``None`` means no official metric was recorded, which is a
-    different fact from ``MetricComparison.INCOMPARABLE``: one was recorded but
-    could not be ordered. Resolution consumes the comparison and never the
-    readings, the axis direction, or the measurement tolerance behind it.
+    baseline, and it is set only for a reading the framework measured itself.
+    ``None`` therefore covers both "no official metric was recorded" and "the
+    number on the record is the implementer's own report", which is a
+    different fact from ``MetricComparison.INCOMPARABLE``: there a trusted
+    reading exists but could not be ordered. Resolution consumes the
+    comparison and never the readings, the axis direction, or the measurement
+    tolerance behind it.
     """
 
     declared: HypothesisOutcome | None
     passed: bool
     reviewed: bool
     comparison: MetricComparison | None
-    benchmark_expected: bool = False
 
 
 def resolve_hypothesis_outcome(
     evidence: ResolutionEvidence,
 ) -> HypothesisResolution | None:
-    """Resolve one declaration only after review and trusted evidence."""
+    """Resolve one declaration only after review and trusted evidence.
+
+    A supportive declaration (``SUPPORTED``/``NOMINATED``) never resolves
+    ``PROVEN`` on the agent's word alone: without a trusted measurement it
+    resolves ``UNMEASURED``, and with one the measurement decides.
+    """
     if not evidence.reviewed:
         resolution = None
     elif not evidence.passed:
@@ -64,14 +83,10 @@ def resolve_hypothesis_outcome(
         if evidence.declared is HypothesisOutcome.CONTINUE:
             resolution = None
         elif resolution is None:
-            if not evidence.benchmark_expected:
-                resolution = HypothesisResolution.PROVEN
-            elif evidence.comparison is not None:
-                resolution = _resolve_metric_evidence(evidence.comparison)
-            elif evidence.declared is HypothesisOutcome.SUPPORTED:
-                resolution = HypothesisResolution.PROVEN
+            if evidence.comparison is None:
+                resolution = HypothesisResolution.UNMEASURED
             else:
-                resolution = HypothesisResolution.INCONCLUSIVE
+                resolution = _resolve_metric_evidence(evidence.comparison)
     return resolution
 
 
@@ -117,7 +132,10 @@ def metric_baseline(
     comparable = [
         item
         for item in rounds
-        if item.official_evaluation and item.perf_metric is not None and item.perf_unit == metric
+        if item.official_evaluation
+        and item.perf_metric is not None
+        and trusted_perf_provenance(item.perf_provenance)
+        and item.perf_unit == metric
     ]
     if parent_commit is not None:
         return next(
@@ -296,7 +314,6 @@ def project_round_evidence(
                 reviewed=updated.review
                 not in {HypothesisReview.PENDING, HypothesisReview.DEFERRED},
                 comparison=comparison,
-                benchmark_expected=record.official_evaluation,
             )
         )
     else:
@@ -483,7 +500,12 @@ def _measurement(
     prior_rounds: Sequence[RoundRecord],
     space: MetricSpace,
 ) -> HypothesisMeasurement | None:
-    if not record.official_evaluation or record.perf_metric is None or record.perf_unit is None:
+    if (
+        not record.official_evaluation
+        or record.perf_metric is None
+        or record.perf_unit is None
+        or not trusted_perf_provenance(record.perf_provenance)
+    ):
         return None
     direction = space.direction(
         Measurement(
@@ -559,6 +581,7 @@ def _retained(
             if prior.official_evaluation
             and prior.passed
             and prior.perf_metric is not None
+            and trusted_perf_provenance(prior.perf_provenance)
             and prior.perf_unit == record.perf_unit
         ]
         retained = scalar_candidate_retained(space.compare_to_best(candidate, comparable))

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -306,6 +306,11 @@ def _trusted_candidate_records(records: list[RoundRecord], space: MetricSpace) -
             continue
         if not record.commit or not record.passed or not record.reviewed:
             continue
+        if not trusted_perf_provenance(record.perf_provenance):
+            # An implementer self-reported headline metric may keep its commit
+            # as a provisional claim, but it must never seed the archive as a
+            # trusted Pareto parent or dominate later candidates.
+            continue
         if _record_candidate_retained(record) is not True:
             continue
         trusted.append(record)
@@ -3179,13 +3184,15 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     candidate_retained = _provisional_candidate_retained(disposition)
                 elif not passed:
                     candidate_retained = False
-                elif official_evaluation and objectives and accepted_metrics:
+                elif (
+                    official_evaluation and framework_provenance and objectives and accepted_metrics
+                ):
                     candidate_retained = not _pareto_archive_dominators(
                         accepted_metrics,
                         records,
                         space,
                     )
-                elif official_evaluation:
+                elif official_evaluation and framework_provenance:
                     prior_readings = [
                         Measurement(
                             metric=metric_name,
@@ -3202,10 +3209,14 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         space.compare_to_best(official_reading, prior_readings)
                     )
                 else:
+                    # No trusted framework measurement (or an implementer
+                    # self-report): retain provisionally on the implementer's
+                    # disposition, never on the untrusted metric.
                     candidate_retained = _provisional_candidate_retained(disposition)
                 perf_delta_pct = None
                 if (
-                    official_metric is not None
+                    framework_provenance
+                    and official_metric is not None
                     and baseline_metric is not None
                     and baseline_metric != 0
                 ):

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -396,8 +396,10 @@ def _pareto_archive_summary(records: list[RoundRecord], space: MetricSpace) -> s
     ]
     if pending:
         lines.append(
-            "Measured frontier claims awaiting independent review (retain the commit, but "
-            "do not treat it as a trusted parent until its hard invariants pass):"
+            "Measured frontier claims not yet usable as trusted parents (retain the commit, "
+            "but do not treat it as a parent). A row lands here because its hard invariants "
+            "have not passed independent review, or because its numbers are the "
+            "implementer's own report rather than a framework measurement:"
         )
         for record in pending[-8:]:
             assert record.commit is not None  # noqa: S101  # tracked: #288
@@ -460,6 +462,10 @@ def _detect_plateau(
     Rules:
     - ``profile_skipped`` rounds don't count as fresh measurements (their
       perf was reused from earlier).
+    - Only rounds the framework measured itself count. An implementer's
+      self-reported number is not evidence that the search has stopped
+      making progress, and telling the orchestrator it has plateaued on
+      the strength of its own reports is a feedback loop.
     - Only rounds with the *same* ``perf_unit`` as the latest fresh round
       count toward the streak — comparing latency_ms against tok/s as raw
       floats is a category error.
@@ -474,6 +480,7 @@ def _detect_plateau(
         if r.passed
         and r.official_evaluation
         and r.perf_metric is not None
+        and trusted_perf_provenance(r.perf_provenance)
         and not r.profile_skipped
     ]
     if len(fresh) < min_streak:

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -45,6 +45,7 @@ from vibesys.loops.agent.hypotheses import (
     resolve_hypothesis_outcome,
     scalar_candidate_retained,
     start_hypothesis,
+    trusted_perf_provenance,
     update_active_hypothesis,
 )
 from vibesys.loops.agent.model import (
@@ -564,7 +565,14 @@ def _provisional_candidates_since_official(records: list[RoundRecord]) -> int:
             and record.reviewed
             and (
                 _record_candidate_retained(record) is True
-                or record.hypothesis_outcome == HypothesisResolution.PROVEN.value
+                # An accepted-but-unmeasured hypothesis consumes cadence budget
+                # like a proven one: it is exactly the checkpoint the next
+                # official evaluation must measure.
+                or record.hypothesis_outcome
+                in {
+                    HypothesisResolution.PROVEN.value,
+                    HypothesisResolution.UNMEASURED.value,
+                }
             )
         ):
             count += 1
@@ -3119,10 +3127,21 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                 baseline_metric = (
                     _metric_value(parent_record, metric_name) if parent_record is not None else None
                 )
+                # A headline metric is framework-owned unless the implementer
+                # self-reported it. This is the trust boundary the rest of the
+                # round applies: resolution, scalar and Pareto retention, the
+                # recorded delta, and trusted Pareto-parent selection all read
+                # it, so an untrusted number never drives a dominance decision.
+                framework_provenance = trusted_perf_provenance(perf_provenance)
                 # The round's headline reading is ordered against its causal
                 # baseline exactly once, here, and stored on the record. Every
                 # later reader -- resume reprojection and the server -- consumes
                 # the stored answer instead of re-deriving it.
+                #
+                # An implementer-reported number is never ordered at all: the
+                # comparison stays None, which is what makes the hypothesis
+                # resolve UNMEASURED rather than borrowing a verdict from a
+                # number the framework did not measure.
                 space = agent_run_state.metrics
                 official_reading = (
                     Measurement(
@@ -3144,7 +3163,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         if metric_name is not None and baseline_metric is not None
                         else None,
                     )
-                    if official_evaluation and official_metric is not None
+                    if official_evaluation and official_metric is not None and framework_provenance
                     else None
                 )
                 hypothesis_resolution = resolve_hypothesis_outcome(
@@ -3153,7 +3172,6 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         passed=passed,
                         reviewed=reviewed,
                         comparison=perf_comparison,
-                        benchmark_expected=framework_benchmark_configured,
                     )
                 )
                 disposition = CandidateDisposition(candidate_disposition)
@@ -3177,6 +3195,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         for record in records
                         if metric_name is not None
                         and record.official_evaluation
+                        and trusted_perf_provenance(record.perf_provenance)
                         and (value := _metric_value(record, metric_name)) is not None
                     ]
                     candidate_retained = scalar_candidate_retained(

--- a/src/vibesys/loops/agent/model.py
+++ b/src/vibesys/loops/agent/model.py
@@ -25,6 +25,10 @@ class HypothesisResolution(StrEnum):
     IMPLEMENTATION_FAILED = "implementation_failed"
     BLOCKED = "blocked"
     REJECTED = "rejected"
+    # The review passed but no trusted framework measurement exists, so the
+    # empirical claim is neither proven nor failed. Distinct from INCONCLUSIVE,
+    # which reports a trusted measurement that could not decide the claim.
+    UNMEASURED = "unmeasured"
 
 
 class HypothesisReview(StrEnum):

--- a/tests/vibesys/loops/agent/test_hypotheses.py
+++ b/tests/vibesys/loops/agent/test_hypotheses.py
@@ -1,5 +1,6 @@
 """Tests for the unified hypothesis aggregate and its pure transitions."""
 
+from dataclasses import replace
 from typing import Literal
 
 import pytest

--- a/tests/vibesys/loops/agent/test_hypotheses.py
+++ b/tests/vibesys/loops/agent/test_hypotheses.py
@@ -1,6 +1,5 @@
 """Tests for the unified hypothesis aggregate and its pure transitions."""
 
-from dataclasses import replace
 from typing import Literal
 
 import pytest
@@ -362,7 +361,6 @@ def _declared(comparison: MetricComparison | None) -> ResolutionEvidence:
         passed=True,
         reviewed=True,
         comparison=comparison,
-        benchmark_expected=True,
     )
 
 
@@ -380,9 +378,11 @@ def test_resolution_consumes_the_comparison_rather_than_the_readings() -> None:
     assert resolve_hypothesis_outcome(_declared(MetricComparison.INCOMPARABLE)) is (
         HypothesisResolution.INCONCLUSIVE
     )
-    # ``None`` is a different fact: no official metric was recorded at all, so
-    # a nomination stays undecided rather than being ruled against.
-    assert resolve_hypothesis_outcome(_declared(None)) is HypothesisResolution.INCONCLUSIVE
+    # ``None`` is a different fact: no comparison exists, either because no
+    # official metric was recorded or because the number is the implementer's
+    # own. A nomination is then unmeasured, not inconclusive -- INCONCLUSIVE
+    # reports a trusted measurement that failed to decide the claim.
+    assert resolve_hypothesis_outcome(_declared(None)) is HypothesisResolution.UNMEASURED
 
 
 def test_retention_consumes_the_comparison_against_the_best_prior() -> None:

--- a/tests/vibesys/loops/agent/test_hypotheses.py
+++ b/tests/vibesys/loops/agent/test_hypotheses.py
@@ -30,7 +30,7 @@ from vibesys.schemas import (
     HypothesisStrategyUpdate,
     OrchestratorPlan,
 )
-from vs_loop_state import RoundRecord
+from vs_loop_state import PerfProvenance, RoundRecord
 
 
 def _plan(identifier: str, *, updates: list[HypothesisStrategyUpdate] | None = None):  # noqa: ANN202
@@ -56,6 +56,7 @@ def _round(  # noqa: PLR0913
     direction: Literal["max", "min"] = "max",
     retained: bool | None = True,
     comparison: MetricComparison | None = None,
+    provenance: PerfProvenance | None = "framework",
 ) -> RoundRecord:
     return RoundRecord(
         round_number=number,
@@ -76,6 +77,7 @@ def _round(  # noqa: PLR0913
         perf_direction=direction if metric is not None else None,
         candidate_retained=retained,
         perf_comparison=comparison,
+        perf_provenance=provenance if metric is not None else None,
     )
 
 
@@ -546,3 +548,102 @@ def _strip_stored_comparisons(state: AgentRunState) -> AgentRunState:
         for record in hypothesis["rounds"]:
             record["perf_comparison"] = None
     return AgentRunState.model_validate(payload)
+
+
+def _implementer_reported_run() -> AgentRunState:
+    """Two official rounds whose numbers the implementer reported itself.
+
+    Shaped so a trusted reading would resolve the second hypothesis: 100 then
+    200 on a maximize axis, an unmissable improvement. The only thing standing
+    between it and ``PROVEN`` is that the framework measured neither number.
+    """
+    state = AgentRunState(
+        metrics=MetricSpace(objectives=(Objective(name="total_ops_per_sec", direction="max"),))
+    )
+    baseline = append_round(
+        start_hypothesis(state, _plan("H-base"), started_round=1),
+        _round(1, 100.0, hypothesis_id="H-base", provenance="implementer"),
+        keep_active=False,
+    )
+    started = start_hypothesis(
+        baseline,
+        _plan("H-1"),
+        started_round=2,
+        parent_round=1,
+        parent_commit=f"{1:040x}",
+    )
+    return append_round(
+        started,
+        _round(
+            2,
+            200.0,
+            hypothesis_id="H-1",
+            parent_round=1,
+            parent_commit=f"{1:040x}",
+            outcome="unmeasured",
+            provenance="implementer",
+        ),
+        keep_active=False,
+    )
+
+
+def test_a_self_reported_improvement_never_resolves_proven() -> None:
+    """Regression for #475: the agent's own number cannot prove its own claim.
+
+    An implementer-reported round stores no comparison, so resolution has
+    nothing to order and the hypothesis is unmeasured, not proven.
+    """
+    hypothesis = _implementer_reported_run().by_id("H-1")
+
+    assert hypothesis is not None
+    assert hypothesis.resolution is HypothesisResolution.UNMEASURED
+
+
+def test_reprojection_of_a_self_reported_round_stays_unmeasured() -> None:
+    """The guard `round_comparison` needs, stated as the property it protects.
+
+    An implementer round stores no comparison, which on disk is
+    indistinguishable from a round written before the framework stored one.
+    The re-derivation fallback would happily order 200 against 100 and hand
+    back ``BETTER``, so ``--resume`` and the server read path would report
+    ``INCONCLUSIVE``-or-better where the loop recorded ``UNMEASURED``.
+    Reprojection must agree with the round record.
+    """
+    completed = _implementer_reported_run()
+    live = completed.by_id("H-1")
+    resumed = reproject_run_evidence(completed).by_id("H-1")
+
+    assert live is not None
+    assert resumed is not None
+    assert resumed.resolution is live.resolution
+    assert resumed.resolution is HypothesisResolution.UNMEASURED
+    assert [record.hypothesis_outcome for record in resumed.rounds] == ["unmeasured"]
+
+
+def test_a_self_reported_round_is_not_a_baseline_for_a_later_trusted_one() -> None:
+    """A trusted round is never ordered against an untrusted baseline."""
+    state = _implementer_reported_run()
+    started = start_hypothesis(
+        state,
+        _plan("H-2"),
+        started_round=3,
+        parent_round=2,
+        parent_commit=f"{2:040x}",
+    )
+    completed = append_round(
+        started,
+        _round(
+            3,
+            300.0,
+            hypothesis_id="H-2",
+            parent_round=2,
+            parent_commit=f"{2:040x}",
+        ),
+        keep_active=False,
+    )
+    hypothesis = completed.by_id("H-2")
+
+    assert hypothesis is not None
+    # Nothing trusted precedes round three, so its reading cannot be ordered:
+    # incomparable, not "better than the implementer's 200".
+    assert hypothesis.resolution is HypothesisResolution.INCONCLUSIVE

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -965,7 +965,12 @@ def test_pareto_archive_distinguishes_trusted_and_pending_candidates():  # noqa:
 
     assert "Trusted frontier parents" in summary
     assert "round 49" in summary
-    assert "awaiting independent review" in summary
+    # The pending row is listed separately and told apart by *why* it is not a
+    # trusted parent. Both reasons are named, because after #535 a row can land
+    # here for failing review or for carrying an implementer-reported number.
+    assert "not yet usable as trusted parents" in summary
+    assert "independent review" in summary
+    assert "implementer's own report" in summary
     assert "round 51" in summary
 
 
@@ -4407,8 +4412,8 @@ def test_loop_threads_roadmap_into_orchestrator_prompt(tmp_path, ref_file):  # n
 
 
 def test_loop_threads_plateau_warning_into_prompt(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
-    """When the prior rounds plateau on perf, the orchestrator's next prompt
-    must include the plateau warning."""
+    """When the prior rounds plateau on framework-measured perf, the
+    orchestrator's next prompt must include the plateau warning."""
     seen_prompts: list[str] = []
     # Five rounds: round 1 is cold-start (no profiler), rounds 2-4 produce
     # flat perf metrics, and round 5 is the round under test (its plan call
@@ -4453,7 +4458,6 @@ def test_loop_threads_plateau_warning_into_prompt(tmp_path, ref_file):  # noqa: 
                 perf_unit="tok/s",
             ),
         ],
-        implementer_perf_metrics=[None, 42.0, 42.1, 41.9, 42.05],
     )
     real = runner.invoke.side_effect
 
@@ -4464,13 +4468,31 @@ def test_loop_threads_plateau_warning_into_prompt(tmp_path, ref_file):  # noqa: 
 
     runner.invoke.side_effect = spy
 
-    _invoke_orchestrate(
-        tmp_path,
-        ref_file,
-        runner,
-        max_rounds=5,
-        official_eval_every=1,
-    )
+    # The plateau signal is built from framework measurements only, so the
+    # readings have to come from the benchmark gate. Round one measures
+    # nothing; rounds 2-5 are flat at 41.9-42.1.
+    with patch(
+        "vibesys.loops.agent.loop._run_framework_benchmark",
+        side_effect=[
+            FrameworkBenchmarkOutcome(),
+            *(
+                FrameworkBenchmarkOutcome(
+                    metric_name="total_ops_per_sec",
+                    metric_value=value,
+                    metric_direction="max",
+                )
+                for value in (42.0, 42.1, 41.9, 42.05)
+            ),
+        ],
+    ):
+        _invoke_orchestrate(
+            tmp_path,
+            ref_file,
+            runner,
+            max_rounds=5,
+            official_eval_every=1,
+            benchmark_result_protocol=2,
+        )
     assert len(seen_prompts) == 5
     # Rounds 1-4 have <3 valid perf records before each plan call → no
     # warning yet (round 1: 0 perf; round 2: 0 perf; round 3: 1 perf; round 4: 2 perf).
@@ -4483,6 +4505,53 @@ def test_loop_threads_plateau_warning_into_prompt(tmp_path, ref_file):  # noqa: 
     assert "Plateau detected" in seen_prompts[4]
     assert "Refresh an analytical performance model" in seen_prompts[4]
     assert "unexplained residual" in seen_prompts[4]
+
+
+def test_self_reported_numbers_do_not_raise_a_plateau_warning(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """The same flat trajectory, self-reported, is not evidence of a plateau.
+
+    Telling the orchestrator it has stopped making progress on the strength of
+    its own reports is a feedback loop: the agent would be reacting to numbers
+    it chose. The consequence is deliberate and worth stating -- a task that
+    declares no benchmark result contract gets no plateau warning at all,
+    because the framework has measured nothing to detect a plateau in.
+    """
+    seen_prompts: list[str] = []
+    plans = [
+        OrchestratorPlan(task=f"r{i}", pass_criteria="p", reasoning=f"r{i}")  # noqa: S106  # tracked: #288
+        for i in range(1, 6)  # noqa: RUF100, S106  # tracked: #288
+    ]
+    runner = _make_orchestrate_runner(
+        pre_decisions=[PreRoundDecision(need_profile=True, profile_focus="x", reasoning="ok")] * 4,
+        plans=plans,
+        profiler_responses=[
+            ProfilerSummary(
+                analysis="a",
+                bottlenecks="b",
+                suggestions="s",
+                perf_metric=value,
+                perf_unit="tok/s",
+            )
+            for value in (42.0, 42.1, 41.9, 42.05)
+        ],
+        implementer_perf_metrics=[None, 42.0, 42.1, 41.9, 42.05],
+    )
+    real = runner.invoke.side_effect
+
+    def spy(*, kind, response_cls, **kwargs):  # noqa: ANN001, ANN003, ANN202  # tracked: #288
+        if kind == "orchestrator" and response_cls is OrchestratorPlan:
+            seen_prompts.append(kwargs.get("system_prompt", ""))
+        return real(kind=kind, response_cls=response_cls, **kwargs)
+
+    runner.invoke.side_effect = spy
+
+    _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=5, official_eval_every=1)
+
+    assert len(seen_prompts) == 5
+    assert [round_data["perf_provenance"] for round_data in _round_payloads(tmp_path)][1:] == [
+        "implementer"
+    ] * 4
+    assert all("Plateau detected" not in prompt for prompt in seen_prompts)
 
 
 def test_completed_round_records_which_implementer_produced_it(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -26,12 +26,14 @@ from vibesys.loops.agent.loop import (
     _invoke_read_only_role,
     _missing_implementer_response,
     _official_evaluation_reason,
+    _pareto_archive_dominators,
     _pareto_archive_summary,
     _pareto_frontier_records,
     _provisional_candidates_since_official,
     _review_due,
     _run_framework_validation_gate,
     _terminal_workspace_notice,
+    _trusted_candidate_records,
     run_agent_loop,
 )
 from vibesys.loops.agent.model import Hypothesis, HypothesisResolution, HypothesisReview
@@ -965,6 +967,60 @@ def test_pareto_archive_distinguishes_trusted_and_pending_candidates():  # noqa:
     assert "round 49" in summary
     assert "awaiting independent review" in summary
     assert "round 51" in summary
+
+
+def _accuracy_row(
+    round_number: int,
+    accuracy: float,
+    *,
+    provenance: Literal["framework", "implementer"],
+) -> RoundRecord:
+    """A reviewed, accuracy-passing checkpoint with an objective row.
+
+    Models the finding's scenario: an objective-based task with an accuracy
+    command but no benchmark result contract, so the headline metric's
+    provenance is the only thing distinguishing a trusted framework
+    measurement from an implementer self-report.
+    """
+    return RoundRecord(
+        round_number,
+        str(round_number) * 40,
+        accuracy,
+        "accuracy",
+        True,  # noqa: FBT003  # tracked: #288
+        reviewed=True,
+        hypothesis_id="H-acc",
+        judge_verdict="pass",
+        hypothesis_outcome="proven",
+        metrics={"accuracy": accuracy},
+        official_evaluation=True,
+        candidate_disposition=CandidateDisposition.PARETO_FRONTIER.value,
+        candidate_retained=True,
+        perf_provenance=provenance,
+    )
+
+
+def test_implementer_report_cannot_seed_archive_or_dominate_candidates():  # noqa: ANN201  # tracked: #288
+    """Regression for #535: implementer provenance never becomes a trusted parent.
+
+    A reviewed, accuracy-passing implementer self-report that persisted
+    ``candidate_retained=True`` must not be selected by
+    ``_trusted_candidate_records`` and must not count as a dominator in a later
+    Pareto decision. A framework-provenance row of the same shape still does.
+    """
+    objectives = [Objective("accuracy", "max")]
+    implementer = _accuracy_row(1, 0.95, provenance="implementer")
+    framework = _accuracy_row(2, 0.95, provenance="framework")
+
+    # Trusted Pareto-parent selection is gated on framework provenance.
+    assert _trusted_candidate_records([implementer], objectives) == []
+    assert _trusted_candidate_records([framework], objectives) == [framework]
+
+    # A weaker later candidate is only dominated by the trusted framework row,
+    # never by the untrusted implementer self-report.
+    weaker = {"accuracy": 0.80}
+    assert _pareto_archive_dominators(weaker, [implementer], objectives) == []
+    assert _pareto_archive_dominators(weaker, [framework], objectives) == [framework]
 
 
 def test_official_evaluation_cadence_resets_at_verified_checkpoint():  # noqa: ANN201  # tracked: #288

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -4626,3 +4626,76 @@ def test_single_agent_round_without_a_metric_carries_no_provenance(tmp_path, ref
     rounds = _round_payloads(tmp_path)
     assert rounds[0]["perf_metric"] is None
     assert rounds[0]["perf_provenance"] is None
+
+
+def test_framework_measured_improvement_resolves_proven(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """The positive case: a trusted measurement can still prove a hypothesis.
+
+    Every other end-to-end expectation in this file reads `unmeasured`,
+    because the harness's rounds carry no framework-owned number. Strictness
+    is only correct if the gate still opens: a framework-stamped reading that
+    beats its causal baseline must resolve `proven`, or this change would have
+    made the resolution unreachable rather than honest.
+    """
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                hypothesis_id="baseline-claim",
+                hypothesis="first causal claim",
+                task="establish the baseline",
+                pass_criteria="collect evidence",  # noqa: S106  # tracked: #288
+                reasoning="first experiment",
+            ),
+            OrchestratorPlan(
+                hypothesis_id="improvement-claim",
+                hypothesis="second causal claim",
+                task="beat the baseline",
+                pass_criteria="collect evidence",  # noqa: S106  # tracked: #288
+                reasoning="second experiment",
+            ),
+        ],
+        implementer_outcomes=[
+            HypothesisOutcome.NOMINATED,
+            HypothesisOutcome.NOMINATED,
+        ],
+    )
+
+    with patch(
+        "vibesys.loops.agent.loop._run_framework_benchmark",
+        side_effect=[
+            FrameworkBenchmarkOutcome(
+                metric_name="total_ops_per_sec",
+                metric_value=100.0,
+                metric_direction="max",
+            ),
+            FrameworkBenchmarkOutcome(
+                metric_name="total_ops_per_sec",
+                metric_value=200.0,
+                metric_direction="max",
+            ),
+        ],
+    ):
+        _invoke_orchestrate(
+            tmp_path,
+            ref_file,
+            runner,
+            max_rounds=2,
+            judge_every=1,
+            official_eval_every=1,
+            benchmark_result_protocol=2,
+        )
+
+    rounds = _round_payloads(tmp_path)
+    assert [round_data["perf_provenance"] for round_data in rounds] == [
+        "framework",
+        "framework",
+    ]
+    # Round one has no causal baseline to order against; round two beats it.
+    assert [round_data["perf_comparison"] for round_data in rounds] == [
+        "incomparable",
+        "better",
+    ]
+    assert [round_data["hypothesis_outcome"] for round_data in rounds] == [
+        "inconclusive",
+        "proven",
+    ]

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -2744,9 +2744,11 @@ def test_supported_hypothesis_is_reviewed_without_global_gates_and_closes(tmp_pa
     assert runner.counters["impl"] == 2
     assert runner.counters["judge"] == 2
     rounds = _round_payloads(tmp_path)
+    # A supportive declaration without a trusted measurement closes the
+    # hypothesis as unmeasured, never as proven.
     assert [round_data["hypothesis_outcome"] for round_data in rounds] == [
-        "proven",
-        "proven",
+        "unmeasured",
+        "unmeasured",
     ]
     assert [round_data["official_evaluation"] for round_data in rounds] == [False, True]
     assert rounds[-1]["official_evaluation_reason"] == "final_round"
@@ -2788,7 +2790,7 @@ def test_cadence_pass_keeps_a_continuing_hypothesis_active(tmp_path, ref_file): 
     assert [round_data["hypothesis_outcome"] for round_data in rounds] == [
         "continue",
         "continue",
-        "proven",
+        "unmeasured",
     ]
 
 
@@ -2826,7 +2828,7 @@ def test_implementation_failure_with_repair_keeps_hypothesis_active(tmp_path, re
     ]
     assert [round_data["hypothesis_outcome"] for round_data in rounds] == [
         "implementation_failed",
-        "proven",
+        "unmeasured",
     ]
 
 
@@ -2993,7 +2995,7 @@ def test_resolvable_inconclusive_result_keeps_hypothesis_active(tmp_path, ref_fi
     ]
     assert [round_data["hypothesis_outcome"] for round_data in rounds] == [
         "inconclusive",
-        "proven",
+        "unmeasured",
     ]
 
 
@@ -3153,7 +3155,7 @@ def test_unreviewed_terminal_outcome_returns_control_to_designer(tmp_path, ref_f
     ]
     assert [round_data["hypothesis_outcome"] for round_data in rounds] == [
         "disproven",
-        "proven",
+        "unmeasured",
     ]
     plan_calls = [
         call
@@ -3234,7 +3236,7 @@ def test_disproven_retry_after_failed_review_returns_control_to_designer(tmp_pat
     assert [round_data["reviewed"] for round_data in rounds] == [True, True]
     assert [round_data["hypothesis_outcome"] for round_data in rounds] == [
         "disproven",
-        "proven",
+        "unmeasured",
     ]
 
 
@@ -3300,7 +3302,7 @@ def test_role_session_policy_is_explicit_and_hypothesis_scoped(tmp_path, ref_fil
     ]
     assert [round_data["hypothesis_outcome"] for round_data in rounds] == [
         "continue",
-        "proven",
+        "unmeasured",
     ]
 
 

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -1008,19 +1008,19 @@ def test_implementer_report_cannot_seed_archive_or_dominate_candidates():  # noq
     ``_trusted_candidate_records`` and must not count as a dominator in a later
     Pareto decision. A framework-provenance row of the same shape still does.
     """
-    objectives = [Objective("accuracy", "max")]
+    space = MetricSpace(objectives=(Objective(name="accuracy", direction="max"),))
     implementer = _accuracy_row(1, 0.95, provenance="implementer")
     framework = _accuracy_row(2, 0.95, provenance="framework")
 
     # Trusted Pareto-parent selection is gated on framework provenance.
-    assert _trusted_candidate_records([implementer], objectives) == []
-    assert _trusted_candidate_records([framework], objectives) == [framework]
+    assert _trusted_candidate_records([implementer], space) == []
+    assert _trusted_candidate_records([framework], space) == [framework]
 
     # A weaker later candidate is only dominated by the trusted framework row,
     # never by the untrusted implementer self-report.
     weaker = {"accuracy": 0.80}
-    assert _pareto_archive_dominators(weaker, [implementer], objectives) == []
-    assert _pareto_archive_dominators(weaker, [framework], objectives) == [framework]
+    assert _pareto_archive_dominators(weaker, [implementer], space) == []
+    assert _pareto_archive_dominators(weaker, [framework], space) == [framework]
 
 
 def test_official_evaluation_cadence_resets_at_verified_checkpoint():  # noqa: ANN201  # tracked: #288


### PR DESCRIPTION
> Stacked PR 4/6. Base branch: `main` (#532, #533, and #534 have merged). #536 and #537 stack on top.

## Problem

A hypothesis could resolve `PROVEN` on the agent's word alone. `resolve_hypothesis_outcome` treated the absence of a measurement as permission to accept a supportive declaration, so a "proven" hypothesis could carry no empirical weight, and the TUI rendered it as "Accepted".

#534 gave round records `perf_provenance`, but nothing consumed it. An agent self-reported number could still prove a hypothesis, seed a baseline, count as an official measurement, or dominate a later candidate in the Pareto archive.

## Solution

A hypothesis is proven by a measurement the framework took, or it is not proven.

- `HypothesisResolution.UNMEASURED` is a new resolution: the review passed but the framework measured nothing, so the empirical claim is neither proven nor failed. It is distinct from `INCONCLUSIVE`, which reports a trusted measurement that did not decide the claim.
- The trust boundary is applied **where the comparison is recorded**, not at the resolution call. #579 made the round store the `MetricComparison` the framework made; an implementer-reported number is now never ordered at all, so `perf_comparison` stays `None` and resolution has nothing to work from. `ResolutionEvidence` reduces to "no comparison means `UNMEASURED`, otherwise the comparison decides", and `benchmark_expected` is deleted (`main` fed it from two different facts: `record.official_evaluation` in one caller and `framework_benchmark_configured` in the other).
- `round_comparison` gains a provenance guard **before** its re-derivation fallback. An implementer round stores no comparison, which on disk is indistinguishable from a record written before #579; without the guard, `--resume` and the server read path would re-derive one and disagree with what the loop recorded.
- One exported predicate, `trusted_perf_provenance`, over #534's `PerfProvenance` closed set, is the only place the rule lives. It gates the five loop sites (retention, prior readings, the recorded delta, trusted Pareto-parent selection, and the provisional-candidate cadence) plus baseline selection and measurement projection in `hypotheses.py`.
- `_detect_plateau` stops counting implementer numbers. Telling the orchestrator it has plateaued on the strength of its own reports is a feedback loop: the agent would be reacting to numbers it chose. **This has a cost worth naming:** a task that declares no benchmark result contract now gets no plateau warning at all, because the framework has measured nothing to detect a plateau in. That is the same trade the rest of this PR makes, applied consistently, but it does remove a signal those runs used to get.
- `UNMEASURED` is not a failure: it does not feed strategy pruning or hypothesis retirement, and it consumes provisional-candidate cadence budget like `PROVEN`, because it is exactly the checkpoint the next official evaluation must measure.
- Legacy records carry no provenance and stay trusted, so reprojecting a run recorded before #534 does not rewrite its historical resolutions.

### Architecture

```mermaid
flowchart LR
    P[perf_provenance from #534] --> TP[trusted_perf_provenance<br/>the one rule]
    TP --> PC[perf_comparison recorded<br/>None when self-reported]
    PC --> RE[ResolutionEvidence.comparison]
    RE --> R[resolve_hypothesis_outcome<br/>None then UNMEASURED<br/>else the comparison decides]
    TP --> RC[round_comparison guard<br/>before re-derivation]
    RC --> RP[resume and server read path<br/>agree with the record]
    TP --> L[retention, delta, prior readings,<br/>Pareto parents, cadence, plateau]
```

## Verification

### Correctness properties

- A hypothesis never resolves `PROVEN` without a comparison the framework made. Without one a supportive declaration resolves `UNMEASURED`.
- An implementer-reported number is never ordered, never seeds a baseline, never enters a retention or dominance decision, and never contributes to plateau detection.
- Reprojection agrees with the round record. `--resume` and the server read path resolve a self-reported round `UNMEASURED`, the same value the loop wrote.
- Legacy records (`perf_provenance` is `None`) stay trusted and keep their historical resolutions.
- `UNMEASURED` is not a failed outcome for strategy pruning or retirement, and counts like `PROVEN` for the provisional-candidate cadence.

**Not a property**, despite the earlier draft of this body claiming it: "`INCONCLUSIVE` implies a trusted measurement". An agent can declare `HypothesisOutcome.INCONCLUSIVE`, and that declaration maps straight to `HypothesisResolution.INCONCLUSIVE` without consulting any measurement. `INCONCLUSIVE` therefore means either "a trusted measurement did not decide the claim" or "the agent said it was inconclusive".

## Policy this implements

Strict, by design. Framework provenance is stamped only for a benchmark the framework itself ran through a readable result contract. A task that declares neither a `[benchmark.result]` spec nor `result_protocol` has no trusted number, so its rounds resolve `UNMEASURED` rather than being credited with the implementer's self-report. That is the intended outcome, not a gap: #591 declared contracts for seven example tasks, and the six latency examples whose headline metric is a nested percentile with a `min` direction remain `UNMEASURED` until their `result_protocol` migration.

## Protocol change

`unmeasured` is a new member of `HypothesisResolution`, which crosses the backend boundary. `clients/backend-client/src/generated/protocol.{schema.json,generated.ts}` are regenerated through `pnpm run generate:protocol`; the diff is that one additive enum member in each. The TUI's two consumers, `outcomeColor` and `outcomeLabel`, already fall through correctly, so an unmeasured hypothesis renders as body-text "Unmeasured" rather than being forced into a verdict color. `outcomeColor`'s comment, which listed the outcomes with no verdict reading, is updated to name it.

The Pareto-archive prompt is also corrected: it told the orchestrator that a row outside the trusted frontier was "awaiting independent review", which after this change may instead be because the row's numbers are the implementer's own.

## Testing

- `uv run pytest tests/vibesys/loops -q --no-cov`: 617 passed
- `uv run pytest libs/vs-loop-state/tests tests/server -q --no-cov`: 299 passed
- `cd clients/tui && bun test --max-concurrency 1 src`: 513 passed
- `pnpm check:clients`: clean
- `./scripts/check_format.sh`, `./scripts/check_lint.sh`, `./scripts/check_types.sh`: clean
- `uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=80`: 14 lines, 0 missing, 100%

Both directions of the rule are covered, because a strict rule is only correct if the gate still opens:

- `test_framework_measured_improvement_resolves_proven` drives two rounds through the loop with a framework-stamped benchmark (100 then 200) and asserts the second resolves `proven`. Every other end-to-end expectation in that file reads `unmeasured`, so without this the change could have made `proven` unreachable rather than honest.
- `test_reprojection_of_a_self_reported_round_stays_unmeasured` pins the `round_comparison` guard through `reproject_run_evidence`. Verified to fail without the guard, resolving `INCONCLUSIVE` where the loop recorded `UNMEASURED`.
- `test_a_self_reported_improvement_never_resolves_proven` and `test_a_self_reported_round_is_not_a_baseline_for_a_later_trusted_one` cover the live path and baseline selection.
- `test_implementer_report_cannot_seed_archive_or_dominate_candidates` covers trusted Pareto-parent selection and dominance.

Closes #475.
