### PR TITLE
Resolve a baseline when the causal parent is a provisional round

### DIFF
--- a/src/vibesys/loops/agent/hypotheses.py
+++ b/src/vibesys/loops/agent/hypotheses.py
@@ -128,26 +128,37 @@ def metric_baseline(
     metric: str | None,
     rounds: Sequence[RoundRecord],
 ) -> RoundRecord | None:
-    """Find the exact causal baseline for one metric when provenance permits."""
+    """Find the baseline for one metric, preferring the exact causal parent.
+
+    The parent of an official round is usually a provisional round whenever
+    ``official_eval_every`` exceeds 1, so an exact parent match rarely exists.
+    Fall back to the newest trusted official measurement that does not
+    postdate the parent round; comparing against a later measurement would
+    invert cause and effect.
+    """
     comparable = [
         item
         for item in rounds
         if item.official_evaluation
         and item.perf_metric is not None
         and trusted_perf_provenance(item.perf_provenance)
-        and item.perf_unit == metric
+        and (item.perf_unit == metric or (metric is not None and metric in item.metrics))
     ]
+    if not comparable:
+        return None
     if parent_commit is not None:
-        return next(
+        exact = next(
             (item for item in reversed(comparable) if item.commit == parent_commit),
             None,
         )
+        if exact is not None:
+            return exact
     if parent_round is not None:
         return next(
-            (item for item in reversed(comparable) if item.round_number == parent_round),
+            (item for item in reversed(comparable) if item.round_number <= parent_round),
             None,
         )
-    return comparable[-1] if comparable else None
+    return comparable[-1]
 
 
 def start_hypothesis(
@@ -525,7 +536,7 @@ def _measurement(
     baseline = _baseline(record, prior_rounds)
     baseline_value = record.perf_baseline_metric
     if baseline_value is None and baseline is not None:
-        baseline_value = baseline.perf_metric
+        baseline_value = _baseline_metric_value(baseline, record.perf_unit)
     delta = record.perf_delta_pct
     if delta is None and baseline_value not in {None, 0}:
         assert baseline_value is not None  # noqa: S101  # narrowed above
@@ -556,6 +567,13 @@ def _baseline(record: RoundRecord, prior_rounds: Sequence[RoundRecord]) -> Round
         metric=record.perf_unit,
         rounds=prior_rounds,
     )
+
+
+def _baseline_metric_value(baseline: RoundRecord, metric: str | None) -> float | None:
+    """Read a baseline's value for *metric*, tolerating a renamed headline unit."""
+    if metric is not None and metric in baseline.metrics:
+        return baseline.metrics[metric]
+    return baseline.perf_metric
 
 
 def _retained(

--- a/src/vibesys/loops/agent/hypotheses.py
+++ b/src/vibesys/loops/agent/hypotheses.py
@@ -121,6 +121,23 @@ def scalar_candidate_retained(comparison: MetricComparison) -> bool | None:
             return None
 
 
+def record_metric_value(record: RoundRecord, metric: str | None) -> float | None:
+    """Read one official metric off *record* without guessing across axes.
+
+    The objective row wins when it names *metric*, which is what lets a record
+    whose headline unit was later renamed still answer for the axis it
+    measured. The headline scalar answers only when it is the axis asked for,
+    or when the record carries no row to disagree with.
+    """
+    if metric is not None and metric in record.metrics:
+        return record.metrics[metric]
+    if record.perf_metric is not None and (
+        metric is None or record.perf_unit == metric or not record.metrics
+    ):
+        return record.perf_metric
+    return None
+
+
 def metric_baseline(
     *,
     parent_round: int | None,
@@ -158,6 +175,13 @@ def metric_baseline(
             (item for item in reversed(comparable) if item.round_number <= parent_round),
             None,
         )
+    if parent_commit is not None:
+        # The caller named a causal parent, no trusted official round carries
+        # that commit, and there is no round number to bound the fallback by.
+        # Falling through to the newest measurement here would let a round that
+        # came *after* the parent serve as its baseline, inverting cause and
+        # effect. Fail closed instead.
+        return None
     return comparable[-1]
 
 
@@ -536,7 +560,7 @@ def _measurement(
     baseline = _baseline(record, prior_rounds)
     baseline_value = record.perf_baseline_metric
     if baseline_value is None and baseline is not None:
-        baseline_value = _baseline_metric_value(baseline, record.perf_unit)
+        baseline_value = record_metric_value(baseline, record.perf_unit)
     delta = record.perf_delta_pct
     if delta is None and baseline_value not in {None, 0}:
         assert baseline_value is not None  # noqa: S101  # narrowed above
@@ -554,7 +578,13 @@ def _measurement(
             if baseline is not None
             else None
         ),
-        baseline_commit=record.perf_baseline_commit or record.hypothesis_parent_commit,
+        # The commit of the record actually used as the baseline, which the
+        # fallback makes distinct from the hypothesis's parent commit: with
+        # `official_eval_every > 1` the causal parent is usually a provisional
+        # round, and the baseline is an earlier official one.
+        baseline_commit=(
+            record.perf_baseline_commit or (baseline.commit if baseline is not None else None)
+        ),
         baseline_value=baseline_value,
         delta_pct=delta,
     )
@@ -567,13 +597,6 @@ def _baseline(record: RoundRecord, prior_rounds: Sequence[RoundRecord]) -> Round
         metric=record.perf_unit,
         rounds=prior_rounds,
     )
-
-
-def _baseline_metric_value(baseline: RoundRecord, metric: str | None) -> float | None:
-    """Read a baseline's value for *metric*, tolerating a renamed headline unit."""
-    if metric is not None and metric in baseline.metrics:
-        return baseline.metrics[metric]
-    return baseline.perf_metric
 
 
 def _retained(
@@ -601,14 +624,18 @@ def _retained(
             direction=record.perf_direction,
         )
         axis = space.direction(candidate)
+        # Same admissibility rule as `metric_baseline`: a prior round counts
+        # when it carries this axis, whether as its headline unit or in its
+        # objective row. Matching on the headline unit alone would silently
+        # drop a round whose unit was later renamed, and retention would then
+        # compare against a shorter history than resolution did.
         comparable = [
-            Measurement(metric=record.perf_unit, value=prior.perf_metric, direction=axis)
+            Measurement(metric=record.perf_unit, value=value, direction=axis)
             for prior in prior_rounds
             if prior.official_evaluation
             and prior.passed
-            and prior.perf_metric is not None
             and trusted_perf_provenance(prior.perf_provenance)
-            and prior.perf_unit == record.perf_unit
+            and (value := record_metric_value(prior, record.perf_unit)) is not None
         ]
         retained = scalar_candidate_retained(space.compare_to_best(candidate, comparable))
     return retained

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -42,6 +42,7 @@ from vibesys.loops.agent.hypotheses import (
     append_round,
     apply_strategy_updates,
     metric_baseline,
+    record_metric_value,
     resolve_hypothesis_outcome,
     scalar_candidate_retained,
     start_hypothesis,
@@ -231,17 +232,6 @@ def _implementation_keeps_hypothesis_active(
         _implementation_requests_continuation(implementation)
         and continuation_rounds < _MAX_CONTINUATION_ROUNDS_WITHOUT_DESIGN_REVIEW
     )
-
-
-def _metric_value(record: RoundRecord, metric_name: str | None) -> float | None:
-    """Read one official metric without guessing across objective names."""
-    if metric_name is not None and metric_name in record.metrics:
-        return record.metrics[metric_name]
-    if record.perf_metric is not None and (
-        metric_name is None or record.perf_unit == metric_name or not record.metrics
-    ):
-        return record.perf_metric
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -3137,7 +3127,9 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                     rounds=records,
                 )
                 baseline_metric = (
-                    _metric_value(parent_record, metric_name) if parent_record is not None else None
+                    record_metric_value(parent_record, metric_name)
+                    if parent_record is not None
+                    else None
                 )
                 # A headline metric is framework-owned unless the implementer
                 # self-reported it. This is the trust boundary the rest of the
@@ -3210,7 +3202,7 @@ def run_agent_loop(  # noqa: C901, PLR0912, PLR0913, PLR0915  # tracked: #288
                         if metric_name is not None
                         and record.official_evaluation
                         and trusted_perf_provenance(record.perf_provenance)
-                        and (value := _metric_value(record, metric_name)) is not None
+                        and (value := record_metric_value(record, metric_name)) is not None
                     ]
                     candidate_retained = scalar_candidate_retained(
                         space.compare_to_best(official_reading, prior_readings)

--- a/tests/vibesys/loops/agent/test_hypotheses.py
+++ b/tests/vibesys/loops/agent/test_hypotheses.py
@@ -1,5 +1,6 @@
 """Tests for the unified hypothesis aggregate and its pure transitions."""
 
+from dataclasses import replace
 from typing import Literal
 
 import pytest
@@ -333,7 +334,7 @@ def test_reprojection_uses_the_stored_space_for_resolution_and_retention(
     assert hypothesis.measurement.direction == direction
 
 
-def test_metric_baseline_prefers_exact_parent_commit_and_fails_closed() -> None:
+def test_metric_baseline_prefers_exact_parent_and_falls_back_to_latest_official() -> None:
     parent = _round(1, 100.0, hypothesis_id="parent")
     later = _round(2, 120.0, hypothesis_id="later")
 
@@ -346,6 +347,8 @@ def test_metric_baseline_prefers_exact_parent_commit_and_fails_closed() -> None:
         )
         is parent
     )
+    # A provisional parent has no exact official match; fall back to the
+    # newest official measurement that does not postdate the parent round.
     assert (
         metric_baseline(
             parent_round=2,
@@ -353,7 +356,56 @@ def test_metric_baseline_prefers_exact_parent_commit_and_fails_closed() -> None:
             metric="total_ops_per_sec",
             rounds=[parent, later],
         )
+        is later
+    )
+    # A fallback baseline must never postdate the parent round.
+    assert (
+        metric_baseline(
+            parent_round=0,
+            parent_commit="missing",
+            metric="total_ops_per_sec",
+            rounds=[parent, later],
+        )
         is None
+    )
+    # Without any parent linkage the newest official measurement wins.
+    assert (
+        metric_baseline(
+            parent_round=None,
+            parent_commit=None,
+            metric="total_ops_per_sec",
+            rounds=[parent, later],
+        )
+        is later
+    )
+
+
+def test_metric_baseline_skips_untrusted_and_matches_renamed_metrics() -> None:
+    trusted = _round(1, 100.0, hypothesis_id="trusted")
+    self_reported = replace(
+        _round(2, 130.0, hypothesis_id="selfrep"), perf_provenance="implementer"
+    )
+    renamed = replace(_round(3, 120.0, hypothesis_id="renamed"), perf_unit="renamed_headline_unit")
+
+    # An agent self-reported metric never serves as a baseline.
+    assert (
+        metric_baseline(
+            parent_round=2,
+            parent_commit="missing",
+            metric="total_ops_per_sec",
+            rounds=[trusted, self_reported],
+        )
+        is trusted
+    )
+    # A renamed headline unit still matches through the metrics row.
+    assert (
+        metric_baseline(
+            parent_round=3,
+            parent_commit="missing",
+            metric="total_ops_per_sec",
+            rounds=[trusted, renamed],
+        )
+        is renamed
     )
 
 
@@ -647,3 +699,38 @@ def test_a_self_reported_round_is_not_a_baseline_for_a_later_trusted_one() -> No
     # Nothing trusted precedes round three, so its reading cannot be ordered:
     # incomparable, not "better than the implementer's 200".
     assert hypothesis.resolution is HypothesisResolution.INCONCLUSIVE
+
+
+def test_provisional_parent_baseline_now_resolves_via_fallback() -> None:
+    # official_eval_every >= 2: the causal parent is a provisional round, so
+    # an exact parent-commit match cannot exist among official records. The
+    # fallback baseline still lets the measurement and resolution land.
+    official = _round(1, 100.0, hypothesis_id="H-1")
+    provisional = _round(2, None, hypothesis_id="H-2", declared="continue", outcome="continue")
+    child = _round(
+        3,
+        120.0,
+        hypothesis_id="H-3",
+        parent_round=2,
+        parent_commit=provisional.commit,
+    )
+
+    state = start_hypothesis(AgentRunState(), _plan("H-1"), started_round=1)
+    state = append_round(state, official, keep_active=False)
+    state = start_hypothesis(state, _plan("H-2"), started_round=2)
+    state = append_round(state, provisional, keep_active=False)
+    state = start_hypothesis(
+        state,
+        _plan("H-3"),
+        started_round=3,
+        parent_round=2,
+        parent_commit=provisional.commit,
+    )
+    state = append_round(state, child, keep_active=False)
+
+    resolved = state.by_id("H-3")
+    assert resolved is not None
+    assert resolved.measurement is not None
+    assert resolved.measurement.baseline_round == 1
+    assert resolved.measurement.baseline_value == 100.0
+    assert resolved.resolution is HypothesisResolution.PROVEN

--- a/tests/vibesys/loops/agent/test_hypotheses.py
+++ b/tests/vibesys/loops/agent/test_hypotheses.py
@@ -733,4 +733,123 @@ def test_provisional_parent_baseline_now_resolves_via_fallback() -> None:
     assert resolved.measurement is not None
     assert resolved.measurement.baseline_round == 1
     assert resolved.measurement.baseline_value == 100.0
+    # The reported baseline commit is the round the value came from, not the
+    # hypothesis's parent commit. Those are the same only when the exact parent
+    # match wins; here the fallback chose round one, so reporting the
+    # provisional round two's commit would name a commit whose measurement was
+    # never used.
+    assert resolved.measurement.baseline_commit == official.commit
+    assert resolved.measurement.baseline_commit != provisional.commit
     assert resolved.resolution is HypothesisResolution.PROVEN
+
+
+def test_an_unfindable_parent_commit_with_no_round_bound_fails_closed() -> None:
+    """A named parent we cannot place is not an invitation to guess.
+
+    With a parent round the fallback is bounded: it takes the newest official
+    measurement that does not postdate the parent. With no round at all there
+    is nothing to bound it, so returning the newest measurement could hand back
+    a round recorded *after* the parent and invert cause and effect. Return
+    nothing instead; the hypothesis then resolves unmeasured rather than
+    against an arbitrary comparison.
+    """
+    parent = _round(1, 100.0, hypothesis_id="parent")
+    later = _round(2, 120.0, hypothesis_id="later")
+
+    assert (
+        metric_baseline(
+            parent_round=None,
+            parent_commit="a commit no official round carries",
+            metric="total_ops_per_sec",
+            rounds=[parent, later],
+        )
+        is None
+    )
+    # Contrast: no parent linkage at all is not a failure to place a parent, so
+    # the newest official measurement is still the right baseline.
+    assert (
+        metric_baseline(
+            parent_round=None,
+            parent_commit=None,
+            metric="total_ops_per_sec",
+            rounds=[parent, later],
+        )
+        is later
+    )
+
+
+def _derived_round(  # noqa: PLR0913
+    number: int,
+    metric: float,
+    *,
+    unit: str,
+    metrics: dict[str, float],
+    parent_round: int | None = None,
+    parent_commit: str | None = None,
+) -> RoundRecord:
+    """A round whose retention the framework must derive rather than read.
+
+    ``_retained`` short-circuits on a stored ``candidate_retained`` and on a
+    recorded ``judge_verdict``, so neither is set here: this is the
+    compatibility path where the comparison history actually gets walked.
+    """
+    return RoundRecord(
+        round_number=number,
+        commit=f"{number:040x}",
+        perf_metric=metric,
+        perf_unit=unit,
+        passed=True,
+        reviewed=True,
+        hypothesis_id=f"H-{number}",
+        hypothesis_declared_outcome="nominated",
+        hypothesis_outcome="proven",
+        hypothesis_claim=f"claim H-{number}",
+        hypothesis_task=f"implement H-{number}",
+        hypothesis_parent_round=parent_round,
+        hypothesis_parent_commit=parent_commit,
+        metrics=metrics,
+        official_evaluation=True,
+        perf_direction="max",
+    )
+
+
+def test_retention_sees_the_same_history_the_baseline_does() -> None:
+    """A renamed headline unit must not shorten retention's comparison set.
+
+    ``metric_baseline`` admits a prior round that carries the axis in its
+    objective row even when its headline unit was renamed. Retention used to
+    match on the headline unit alone, so the two disagreed about how much
+    history existed: resolution compared against the renamed round while
+    retention behaved as if this were the first reading ever taken, which it
+    always retains.
+    """
+    renamed = _derived_round(
+        1, 100.0, unit="old_headline_name", metrics={"total_ops_per_sec": 100.0}
+    )
+    worse = _derived_round(
+        2,
+        90.0,
+        unit="total_ops_per_sec",
+        metrics={"total_ops_per_sec": 90.0},
+        parent_round=1,
+        parent_commit=renamed.commit,
+    )
+
+    state = start_hypothesis(AgentRunState(), _plan("H-1"), started_round=1)
+    state = append_round(state, renamed, keep_active=False)
+    state = start_hypothesis(
+        state,
+        _plan("H-2"),
+        started_round=2,
+        parent_round=1,
+        parent_commit=renamed.commit,
+    )
+    state = append_round(state, worse, keep_active=False)
+
+    resolved = state.by_id("H-2")
+    assert resolved is not None
+    # Resolution saw the renamed round through its objective row...
+    assert resolved.measurement is not None
+    assert resolved.measurement.baseline_value == 100.0
+    # ...and so must retention: 90 does not advance a best of 100.
+    assert resolved.candidate_retained is False


### PR DESCRIPTION
> Stacked PR 5/6. Base branch: `main` (#532 through #535 have merged). #537 stacks on top.

## Problem

A performance baseline never resolved on an official round at any `official_eval_every` above 1.

`metric_baseline` demanded an exact parent-commit match among official rounds. `parent_commit` is round N-1's commit, and for any cadence >= 2 a round being official implies round N-1 was provisional, so the exact match could never hit an official record. Replaying eight rounds at the default cadence of 3, `perf_delta_pct` is `None` in every round, and a baseline resolves only on rounds that have no official metric to compare it against.

The comparable filter also required `perf_unit == metric`, so a record whose headline unit was later renamed was dropped even when its `metrics` row still carried the value for that axis.

## Solution

Keep preferring the exact causal baseline; fall back to the newest trusted official measurement that does not postdate the parent round.

- `metric_baseline` prefers the exact parent-commit match. When the parent is provisional, it falls back to the newest trusted official measurement with `round_number <= parent_round`, so a comparison never inverts cause and effect by measuring against a later round.
- A named parent commit that matches nothing, **with no parent round to bound the search**, now returns nothing rather than falling through to the newest measurement. That fall-through could hand back a round recorded after the parent, which is exactly the inversion the bound exists to prevent. Failing closed there means the hypothesis resolves `UNMEASURED` (#535) rather than against an arbitrary comparison.
- The comparable filter accepts a record when `perf_unit` matches the metric **or** the metric is present in the record's `metrics` row, so a renamed headline unit still answers for the axis it measured. Trust is unchanged: `trusted_perf_provenance` still means an implementer-reported number never seeds a baseline.
- `baseline_commit` reports the commit of the record the baseline value actually came from, symmetric with `baseline_round`. It previously reported `hypothesis_parent_commit`, which is correct only when the exact parent match wins; whenever the fallback supplies the baseline (the case this PR exists for) it named a commit whose measurement was never used.
- Retention and baseline selection now admit the same rounds. `_retained` matched on the headline unit alone while `metric_baseline` also accepts the objective row, so with a renamed unit the two disagreed about how much history existed: resolution compared against the renamed round while retention behaved as if it were the first reading ever taken, which it always retains.
- One reader, `record_metric_value`, serves both. It replaces `_baseline_metric_value` here and `_metric_value` in the agent loop, which were two spellings of the same lookup.

### Architecture

```mermaid
flowchart LR
    P[parent round / commit] --> EX{exact parent-commit<br/>trusted match?}
    EX -- yes --> BX[use exact baseline]
    EX -- no --> RB{parent round known?}
    RB -- yes --> FB[newest trusted official<br/>round_number &lt;= parent_round]
    RB -- no --> NC[fail closed: no baseline]
    BX --> RV[record_metric_value<br/>objective row, else headline]
    FB --> RV
    RV --> D[baseline value, commit, delta]
    RV --> RET[retention history<br/>same admissibility rule]
```

## Verification

### Correctness properties

- A baseline never postdates the round compared against it: the exact parent commit first, else the newest trusted official measurement at or before the parent round, else nothing.
- A provisional-parent chain (any `official_eval_every` above 1) resolves a baseline through the fallback instead of producing none.
- `baseline_commit` names the record the baseline value came from, not the hypothesis's parent.
- A renamed headline unit still resolves a baseline through the objective row, and retention walks the same history that resolution does.
- An implementer-reported measurement is never eligible as a baseline (unchanged from #535).

### Testing

- `uv run pytest tests/vibesys/loops -q --no-cov`: 621 passed
- `uv run pytest libs/vs-loop-state/tests tests/server -q --no-cov`: 299 passed
- `./scripts/check_format.sh`, `./scripts/check_lint.sh`, `./scripts/check_types.sh`: clean
- `uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=80`: 15 lines, 0 missing, 100%

Each of the three fixes above its own regression test, all verified to fail at the merge base:

- `test_provisional_parent_baseline_now_resolves_via_fallback` asserts the reported `baseline_commit` is the official round's, and explicitly not the provisional parent's. Pre-fix it reported the provisional commit.
- `test_an_unfindable_parent_commit_with_no_round_bound_fails_closed`, contrasted against no parent linkage at all, which legitimately takes the newest measurement.
- `test_retention_sees_the_same_history_the_baseline_does` drives a renamed headline unit through the derived-retention path and asserts a worse reading is not retained. Pre-fix, retention saw no history and retained it.

Part of #478. This PR fixes the baseline-lookup half of the issue. The issue's other half, telling an unresolved baseline apart from a measured non-improvement in the operator-facing projection, is only partly closed elsewhere:

- `perf_baseline_value`, `perf_metric_name`, and `perf_direction` **are** projected by `src/server/api/experiments.py::_entry`, and the TUI renders `Baseline <value> <unit>` in the hypothesis drill-down (`measurementMetadata` in `clients/tui/src/ui/experiment-log.ts`). That landed with #465. An earlier revision of this body said otherwise, quoting #478's grounding at commit `3a2fd8b` without re-checking it; that was wrong and is corrected here.
- `baseline_round` and `baseline_commit` are still not projected, and `formatMeasured` still falls back to a bare absolute number when `delta_pct` is null, so in the Measured column an unresolved baseline still looks like a round legitimately showing an absolute value.

#535 addressed the resolution half of the ambiguity by separating `UNMEASURED` from `INCONCLUSIVE`. What remains of the projection gap is tracked separately.
