### PR TITLE
Reprompt once when a plan reuses a hypothesis_id

### DIFF
--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -146,6 +146,20 @@ describe('hypothesis planning activity', () => {
     });
   });
 
+  it('still presents a reprompted plan as planning', () => {
+    // The framework reprompts the orchestrator once when a plan reuses a
+    // hypothesis_id, and labels that attempt `round-N-retry-K-plan`. It is the
+    // same stage of the same round, so the operator must not see planning
+    // silently stop just because the first attempt was rejected.
+    expect(
+      hypothesisPlanningActivity(stateFor('orchestrator', 'round-3-retry-1-plan')),
+    ).toMatchObject({stage: 'plan', roundNumber: 3});
+  });
+
+  it('does not treat an unrelated retry label as planning', () => {
+    expect(hypothesisPlanningActivity(stateFor('orchestrator', 'round-3-retry-1-judge'))).toBeNull();
+  });
+
   it('does not present a phase as planning after its round has a hypothesis', () => {
     const entries = [
       {

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -157,7 +157,9 @@ describe('hypothesis planning activity', () => {
   });
 
   it('does not treat an unrelated retry label as planning', () => {
-    expect(hypothesisPlanningActivity(stateFor('orchestrator', 'round-3-retry-1-judge'))).toBeNull();
+    expect(
+      hypothesisPlanningActivity(stateFor('orchestrator', 'round-3-retry-1-judge')),
+    ).toBeNull();
   });
 
   it('does not present a phase as planning after its round has a hypothesis', () => {

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -1161,7 +1161,13 @@ function planningStage(
   if (roundLabel === null) return null;
   if (agentKind === 'orchestrator' && /^round-\d+-pre$/.test(roundLabel)) return 'pre';
   if (agentKind === 'profiler' && /^round-\d+-profiler$/.test(roundLabel)) return 'profile';
-  if (agentKind === 'orchestrator' && /^round-\d+-plan$/.test(roundLabel)) return 'plan';
+  // A plan the framework reprompted carries `round-N-retry-K-plan`. It is the
+  // same planning stage, produced by the same role for the same round, so it
+  // must not fall out of the planning activity just because the first attempt
+  // was rejected.
+  if (agentKind === 'orchestrator' && /^round-\d+(?:-retry-\d+)?-plan$/.test(roundLabel)) {
+    return 'plan';
+  }
   return null;
 }
 

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -1013,16 +1013,32 @@ def _run_orchestrator_plan(  # noqa: PLR0913  # tracked: #288
         official_eval_cadence_due=official_eval_cadence_due,
     )
     # One corrective reprompt: a plan that fails lifecycle validation (for
-    # example a hypothesis_id reused after that investigation resolved) is a
-    # recoverable agent mistake, not a framework invariant violation. No
-    # artifact is written for a rejected attempt, so state stays untouched.
+    # example a hypothesis_id already used in this run) is a recoverable agent
+    # mistake, not a framework invariant violation.
+    #
+    # A rejected attempt writes no plan artifact and no progress note -- both
+    # happen after validation -- and leaves durable hypothesis state untouched,
+    # because `_validate_orchestrator_plan_state` applies strategy updates to a
+    # clone it discards. It is not a full rollback, though: the orchestrator's
+    # one allowlisted write, the roadmap index, is preserved by
+    # `_invoke_read_only_role` rather than reverted, so roadmap edits the
+    # rejected attempt made survive into the retry. That is deliberate. The
+    # roadmap is the orchestrator's own long-lived planning document, and the
+    # thinking it recorded there is not invalidated by the plan JSON being
+    # rejected for an identifier collision.
     corrective_feedback: str | None = None
+    attempt = 0
     while True:
-        retry_suffix = "" if corrective_feedback is None else "-retry"
+        attempt += 1
+        # `round-N-plan`, then `round-N-retry-1-plan`. Both the client's
+        # planning-stage matcher and `_attempt_from_label` parse this shape, so
+        # a reprompted plan still appears as a planning activity and still
+        # reports which attempt produced it.
+        label = f"round-{round_number}" + (f"-retry-{attempt - 1}" if attempt > 1 else "") + "-plan"
         plan = _invoke_read_only_role(
             ctx,
             role="orchestrator",
-            checkpoint_label=f"round-{round_number}-plan-input{retry_suffix}",
+            checkpoint_label=f"{label}-input",
             allowed_workspace_paths=(
                 f"{roadmap_location.rstrip('/')}/index.md"
                 if roadmap_location.endswith("/")
@@ -1039,7 +1055,7 @@ def _run_orchestrator_plan(  # noqa: PLR0913  # tracked: #288
                 pass_criteria="/health returns 200.",  # noqa: S106  # tracked: #288
                 reasoning="fallback: orchestrator produced no structured response",
             ),
-            round_label=f"round-{round_number}-plan{retry_suffix}",
+            round_label=label,
             reuse_session=False,
         )
         plan.hypothesis_id = plan.hypothesis_id.strip() or f"hypothesis-{round_number:04d}"
@@ -1050,12 +1066,17 @@ def _run_orchestrator_plan(  # noqa: PLR0913  # tracked: #288
             if corrective_feedback is not None:
                 raise
             ctx.lprint(f"[orchestrator] plan rejected ({error}); reprompting once")
+            rejected_updates = ", ".join(
+                sorted({update.hypothesis_id for update in plan.hypothesis_updates})
+            )
             corrective_feedback = (
                 f"Your previous plan was rejected: {error}. "
-                "A hypothesis_id permanently names one investigation; repeat it "
-                "only while that same investigation is still active, and pick a "
-                "new unique id for a new hypothesis. hypothesis_updates may name "
-                "each prior hypothesis at most once and never the new one. "
+                f"It proposed hypothesis_id {plan.hypothesis_id!r} and named "
+                f"{rejected_updates or '(no)'} in hypothesis_updates. "
+                "A hypothesis_id names one investigation permanently: never reuse "
+                "an identifier used earlier in this run, and choose one that has "
+                "not appeared before. hypothesis_updates may name each prior "
+                "hypothesis at most once, and never the new one. "
                 "Produce a corrected plan for this round. "
                 "Return only the JSON object."
             )

--- a/src/vibesys/loops/agent/loop.py
+++ b/src/vibesys/loops/agent/loop.py
@@ -1012,34 +1012,58 @@ def _run_orchestrator_plan(  # noqa: PLR0913  # tracked: #288
         provisional_candidates=provisional_candidates,
         official_eval_cadence_due=official_eval_cadence_due,
     )
-    plan = _invoke_read_only_role(
-        ctx,
-        role="orchestrator",
-        checkpoint_label=f"round-{round_number}-plan-input",
-        allowed_workspace_paths=(
-            f"{roadmap_location.rstrip('/')}/index.md"
-            if roadmap_location.endswith("/")
-            else roadmap_location,
-        ),
-        kind="orchestrator",
-        system_prompt=system_prompt,
-        user_prompt="Produce this round's plan. Return only the JSON object.",
-        response_cls=OrchestratorPlan,
-        fallback_factory=lambda: OrchestratorPlan(
-            task="Re-check minimal server boots and /health returns 200.",
-            pass_criteria="/health returns 200.",  # noqa: S106  # tracked: #288
-            reasoning="fallback: orchestrator produced no structured response",
-        ),
-        round_label=f"round-{round_number}-plan",
-        reuse_session=False,
-    )
-    plan.hypothesis_id = plan.hypothesis_id.strip() or f"hypothesis-{round_number:04d}"
-    plan.title = normalize_hypothesis_title(plan.title)
-    _validate_orchestrator_plan_state(plan, agent_run_state)
-    plan.recommended_skills, _ = _validate_skill_selections(ctx, plan.recommended_skills)
-    issue_board.write_plan_artifact(progress_path, round_number, plan)
-    issue_board.append_orchestrator_plan(progress_path, round_number, plan)
-    return plan
+    # One corrective reprompt: a plan that fails lifecycle validation (for
+    # example a hypothesis_id reused after that investigation resolved) is a
+    # recoverable agent mistake, not a framework invariant violation. No
+    # artifact is written for a rejected attempt, so state stays untouched.
+    corrective_feedback: str | None = None
+    while True:
+        retry_suffix = "" if corrective_feedback is None else "-retry"
+        plan = _invoke_read_only_role(
+            ctx,
+            role="orchestrator",
+            checkpoint_label=f"round-{round_number}-plan-input{retry_suffix}",
+            allowed_workspace_paths=(
+                f"{roadmap_location.rstrip('/')}/index.md"
+                if roadmap_location.endswith("/")
+                else roadmap_location,
+            ),
+            kind="orchestrator",
+            system_prompt=system_prompt,
+            user_prompt=(
+                corrective_feedback or "Produce this round's plan. Return only the JSON object."
+            ),
+            response_cls=OrchestratorPlan,
+            fallback_factory=lambda: OrchestratorPlan(
+                task="Re-check minimal server boots and /health returns 200.",
+                pass_criteria="/health returns 200.",  # noqa: S106  # tracked: #288
+                reasoning="fallback: orchestrator produced no structured response",
+            ),
+            round_label=f"round-{round_number}-plan{retry_suffix}",
+            reuse_session=False,
+        )
+        plan.hypothesis_id = plan.hypothesis_id.strip() or f"hypothesis-{round_number:04d}"
+        plan.title = normalize_hypothesis_title(plan.title)
+        try:
+            _validate_orchestrator_plan_state(plan, agent_run_state)
+        except ValueError as error:
+            if corrective_feedback is not None:
+                raise
+            ctx.lprint(f"[orchestrator] plan rejected ({error}); reprompting once")
+            corrective_feedback = (
+                f"Your previous plan was rejected: {error}. "
+                "A hypothesis_id permanently names one investigation; repeat it "
+                "only while that same investigation is still active, and pick a "
+                "new unique id for a new hypothesis. hypothesis_updates may name "
+                "each prior hypothesis at most once and never the new one. "
+                "Produce a corrected plan for this round. "
+                "Return only the JSON object."
+            )
+            continue
+        plan.recommended_skills, _ = _validate_skill_selections(ctx, plan.recommended_skills)
+        issue_board.write_plan_artifact(progress_path, round_number, plan)
+        issue_board.append_orchestrator_plan(progress_path, round_number, plan)
+        return plan
 
 
 def _validate_orchestrator_plan_state(

--- a/src/vibesys/schemas.py
+++ b/src/vibesys/schemas.py
@@ -623,8 +623,9 @@ class OrchestratorPlan(BaseModel):
     hypothesis_id: str = Field(
         default="",
         description=(
-            "Stable short identifier for the hypothesis. Reuse it across rounds while "
-            "the same implementer investigation remains active."
+            "Stable short identifier for the hypothesis. Repeat it only while the "
+            "same implementer investigation is still active; once a hypothesis "
+            "resolves its id is retired and must never be reused."
         ),
     )
     hypothesis_updates: list[HypothesisStrategyUpdate] = Field(

--- a/src/vibesys/schemas.py
+++ b/src/vibesys/schemas.py
@@ -623,9 +623,8 @@ class OrchestratorPlan(BaseModel):
     hypothesis_id: str = Field(
         default="",
         description=(
-            "Stable short identifier for the hypothesis. Repeat it only while the "
-            "same implementer investigation is still active; once a hypothesis "
-            "resolves its id is retired and must never be reused."
+            "Stable short identifier for this round's new hypothesis. Never reuse "
+            "an identifier used earlier in this run."
         ),
     )
     hypothesis_updates: list[HypothesisStrategyUpdate] = Field(

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -1337,6 +1337,10 @@ def test_reused_hypothesis_id_after_failed_reprompt_is_not_written(tmp_path, ref
     with pytest.raises(ValueError, match="already used"):
         _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=2)
 
+    # Exactly one reprompt: round one's plan, round two's rejected plan, and
+    # its single corrective retry. A third plan call for round two would mean
+    # the loop kept re-asking an agent that already ignored the correction.
+    assert runner.counters["orch_plan"] == 3
     project = _created_project(tmp_path)
     assert not list(project.rglob("plans/round-0002.json"))
     assert all(
@@ -4811,3 +4815,62 @@ def test_framework_measured_improvement_resolves_proven(tmp_path, ref_file):  # 
         "inconclusive",
         "proven",
     ]
+
+
+def test_reprompted_plan_is_labelled_as_a_retry_of_the_same_round(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    """The retry's label must stay parseable by both consumers.
+
+    `_attempt_from_label` in `vibesys.context` reads `retry-(\\d+)` to report
+    which attempt an execution belongs to, and the TUI's `planningStage` matches
+    `round-N[-retry-K]-plan` to keep showing the round as planning. A label the
+    framework invents that neither parses drops the retry out of the operator's
+    view of the round.
+    """
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                hypothesis_id="already-used",
+                task="complete the first investigation",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
+                reasoning="create the identifier",
+            ),
+            OrchestratorPlan(
+                hypothesis_id="already-used",
+                hypothesis_updates=[
+                    HypothesisStrategyUpdate(
+                        hypothesis_id="already-used",
+                        disposition="parked",
+                        reason="names the new hypothesis, which is also rejected",
+                    )
+                ],
+                task="incorrectly reuse the identifier",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
+                reasoning="exercise unique identity validation",
+            ),
+            OrchestratorPlan(
+                hypothesis_id="corrected-id",
+                task="proceed with a fresh identifier",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
+                reasoning="corrected after the reprompt",
+            ),
+        ]
+    )
+
+    _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=2)
+
+    plan_calls = [
+        call
+        for call in runner.invoke.call_args_list
+        if call.kwargs.get("response_cls") is OrchestratorPlan
+    ]
+    assert [call.kwargs["round_label"] for call in plan_calls] == [
+        "round-1-plan",
+        "round-2-plan",
+        "round-2-retry-1-plan",
+    ]
+
+    # The corrective prompt names what was rejected, so the orchestrator does
+    # not have to guess which identifier collided.
+    corrective = plan_calls[2].kwargs["user_prompt"]
+    assert "already-used" in corrective
+    assert "never reuse an identifier used earlier in this run" in corrective.lower()

--- a/tests/vibesys/loops/agent/test_orchestrate.py
+++ b/tests/vibesys/loops/agent/test_orchestrate.py
@@ -1245,27 +1245,27 @@ def test_progress_writes_orchestrator_plan(tmp_path):  # noqa: ANN001, ANN201  #
 
 
 def test_invalid_hypothesis_update_is_not_written_to_progress(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
-    runner = _make_orchestrate_runner(
-        plans=[
-            OrchestratorPlan(
-                hypothesis_id="new-hypothesis",
-                hypothesis_updates=[
-                    HypothesisStrategyUpdate(
-                        hypothesis_id="unknown-hypothesis",
-                        disposition="abandoned",
-                        reason="This identifier was never created.",
-                    )
-                ],
-                task="attempt an invalid transition",
-                pass_criteria="review",  # noqa: S106  # tracked: #288
-                reasoning="exercise fail-closed validation",
+    invalid_plan = OrchestratorPlan(
+        hypothesis_id="new-hypothesis",
+        hypothesis_updates=[
+            HypothesisStrategyUpdate(
+                hypothesis_id="unknown-hypothesis",
+                disposition="abandoned",
+                reason="This identifier was never created.",
             )
-        ]
+        ],
+        task="attempt an invalid transition",
+        pass_criteria="review",  # noqa: S106  # tracked: #288
+        reasoning="exercise fail-closed validation",
     )
+    # The first rejection triggers one corrective reprompt; a second invalid
+    # plan fails closed.
+    runner = _make_orchestrate_runner(plans=[invalid_plan, invalid_plan.model_copy(deep=True)])
 
     with pytest.raises(ValueError, match="unknown hypothesis"):
         _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=1)
 
+    assert runner.counters["orch_plan"] == 2
     project = _created_project(tmp_path)
     assert not list(project.rglob("plans/round-0001.json"))
     assert all(
@@ -1273,7 +1273,7 @@ def test_invalid_hypothesis_update_is_not_written_to_progress(tmp_path, ref_file
     )
 
 
-def test_reused_hypothesis_id_is_not_written_to_progress(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+def test_reused_hypothesis_id_is_reprompted_once_and_recovers(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
     runner = _make_orchestrate_runner(
         plans=[
             OrchestratorPlan(
@@ -1287,6 +1287,49 @@ def test_reused_hypothesis_id_is_not_written_to_progress(tmp_path, ref_file):  #
                 task="incorrectly reuse the identifier",
                 pass_criteria="review",  # noqa: S106  # tracked: #288
                 reasoning="exercise unique identity validation",
+            ),
+            OrchestratorPlan(
+                hypothesis_id="corrected-id",
+                task="proceed with a fresh identifier",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
+                reasoning="corrected after the reprompt",
+            ),
+        ]
+    )
+
+    _invoke_orchestrate(tmp_path, ref_file, runner, max_rounds=2)
+
+    # Round 2's invalid plan costs one corrective reprompt, not the run.
+    assert runner.counters["orch_plan"] == 3
+    project = _created_project(tmp_path)
+    plan_artifacts = list(project.rglob("plans/round-0002.json"))
+    assert len(plan_artifacts) == 1
+    assert "corrected-id" in plan_artifacts[0].read_text()
+    assert all(
+        "incorrectly reuse the identifier" not in path.read_text() for path in project.rglob("*.md")
+    )
+
+
+def test_reused_hypothesis_id_after_failed_reprompt_is_not_written(tmp_path, ref_file):  # noqa: ANN001, ANN201  # tracked: #288
+    runner = _make_orchestrate_runner(
+        plans=[
+            OrchestratorPlan(
+                hypothesis_id="already-used",
+                task="complete the first investigation",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
+                reasoning="create the identifier",
+            ),
+            OrchestratorPlan(
+                hypothesis_id="already-used",
+                task="incorrectly reuse the identifier",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
+                reasoning="exercise unique identity validation",
+            ),
+            OrchestratorPlan(
+                hypothesis_id="already-used",
+                task="reuse the identifier again after correction",
+                pass_criteria="review",  # noqa: S106  # tracked: #288
+                reasoning="ignore the corrective feedback",
             ),
         ]
     )

--- a/tests/vibesys/loops/agent/test_prompt_snapshots.py
+++ b/tests/vibesys/loops/agent/test_prompt_snapshots.py
@@ -580,9 +580,7 @@ _NATIVE_PROMPT_BYTE_BUDGETS = {
 }
 
 _FALLBACK_PROMPT_BYTE_BUDGETS = {
-    # 13_200 until the corrected hypothesis_id contract (retired ids are never
-    # reused) grew the OrchestratorPlan schema hint past it.
-    "orchestrator": 13_300,
+    "orchestrator": 13_200,
     "implementer": 17_000,
     "implementer_continuation": 10_000,
     "judge": 11_000,

--- a/tests/vibesys/loops/agent/test_prompt_snapshots.py
+++ b/tests/vibesys/loops/agent/test_prompt_snapshots.py
@@ -580,7 +580,9 @@ _NATIVE_PROMPT_BYTE_BUDGETS = {
 }
 
 _FALLBACK_PROMPT_BYTE_BUDGETS = {
-    "orchestrator": 13_200,
+    # 13_200 until the corrected hypothesis_id contract (retired ids are never
+    # reused) grew the OrchestratorPlan schema hint past it.
+    "orchestrator": 13_300,
     "implementer": 17_000,
     "implementer_continuation": 10_000,
     "judge": 11_000,


### PR DESCRIPTION
> Stacked PR 6/6, the top of the #495 split. Base branch: `main` (#532 through #536 have merged).

## Problem

An orchestrator plan that reused a `hypothesis_id` raised out of `_validate_orchestrator_plan_state` and terminated the whole run. That is a recoverable agent mistake being treated as a framework invariant violation: the run had produced valid work for every prior round, and one malformed plan threw it away.

The schema made the mistake likely. `hypothesis_id` was documented as "Reuse it across rounds while the same implementer investigation remains active", but the plan role runs only when no hypothesis is active (`loop.py`: "The designer runs only when selecting a new causal claim"), and validation rejects any identifier already in state. The described case cannot reach this code, and following the description as written produces exactly the collision that killed the run.

## Solution

Reprompt once, and tell the orchestrator the rule the framework actually enforces.

- A plan failing lifecycle validation gets one corrective reprompt. A second failure raises as before, so an agent that ignores the correction still fails closed rather than looping.
- The `hypothesis_id` description states the rule unconditionally: never reuse an identifier used earlier in this run. The corrective feedback says the same thing and additionally names the rejected plan's own `hypothesis_id` and `hypothesis_updates` ids, so the orchestrator does not have to infer which identifier collided.
- The retry is labelled `round-N-retry-K-plan`. The first attempt keeps `round-N-plan`.
- `planningStage` in `clients/tui/src/session-model.ts` accepts the retry shape, so a reprompted round still shows as planning instead of the operator watching planning silently stop.

### Why the label shape matters

Two consumers parse round labels, and the shape has to satisfy both:

| Consumer | Pattern | `round-2-plan-retry` | `round-2-retry-1-plan` |
| --- | --- | --- | --- |
| `planningStage` (`clients/tui/src/session-model.ts`) | `^round-\d+(?:-retry-\d+)?-plan$` | no match: round drops out of the planning activity | matches |
| `_attempt_from_label` (`src/vibesys/context.py`) | `retry-(\d+)` | no match: attempt reported as `None` | attempt 1 |

The client regex is widened in this PR; without that change the second column's first row would still apply.

## Verification

### Correctness properties

- A rejected plan costs one reprompt, never the run. A second rejection raises, so the loop cannot re-ask indefinitely.
- Every identifier the plan role proposes must be new. The framework enforces it, the schema says it, and the corrective feedback repeats it.
- A rejected attempt writes no plan artifact and no progress note, and leaves durable hypothesis state untouched: `_validate_orchestrator_plan_state` applies strategy updates to a clone it discards.
- It is **not** a full rollback, and the code now says so. The orchestrator's one allowlisted write, the roadmap index, is preserved by `_invoke_read_only_role` rather than reverted, so roadmap edits from a rejected attempt survive into the retry. That is deliberate: the roadmap is the orchestrator's own long-lived planning document, and the thinking recorded there is not invalidated by the plan JSON being rejected for an identifier collision.
- Both the retry label's consumers parse it.

### Testing

- `uv run pytest tests/vibesys/loops -q --no-cov`: 624 passed
- `uv run pytest libs/vs-loop-state/tests tests/server -q --no-cov`: 312 passed
- `cd clients/tui && bun test --max-concurrency 1 src`: 549 passed
- `pnpm check:clients`: clean
- `./scripts/check_format.sh`, `./scripts/check_lint.sh`, `./scripts/check_types.sh`: clean
- `uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=80`: 21 lines, 0 missing, 100%

Coverage:

- `test_reused_hypothesis_id_is_reprompted_once_and_recovers`: the recovery path, asserting the corrected plan is the one written.
- `test_reused_hypothesis_id_after_failed_reprompt_is_not_written`: asserts exactly three plan calls, so a second failure fails closed rather than reprompting again.
- `test_reprompted_plan_is_labelled_as_a_retry_of_the_same_round`: pins the exact label sequence and that the corrective prompt names the rejected identifier.
- `still presents a reprompted plan as planning` in `session-model.test.ts`, plus a negative case for an unrelated retry label. Verified to fail against the old regex.

### Prompt budget

No budget change. The earlier revision of this PR raised the orchestrator's fallback budget from 13,200 to 13,300 bytes to fit a longer description; the reworded contract is shorter than that and fits inside the original budget, which is restored. `tests/vibesys/loops/agent/test_prompt_snapshots.py` is unchanged by this PR.

### Prompt wording needs a maintainer decision

`src/vibesys/schemas.py` is not under CODEOWNERS, but its `Field(description=...)` strings are agent-visible product behavior: they are rendered into the fallback schema hint that every orchestrator turn sees. Please review the `hypothesis_id` wording specifically, both in the schema and in the corrective feedback in `_run_orchestrator_plan`, and say if you want it phrased differently. The behavioral claim I am making is that the unconditional rule is the only correct one because the plan role never runs while a hypothesis is active; if that assumption is wrong, the wording should change with it.

Closes #476.
