### PR TITLE
fix(core-state): reset terminal flag on run_started for resumed runs

### DIFF
--- a/clients/core-state/src/core-state.ts
+++ b/clients/core-state/src/core-state.ts
@@ -524,6 +524,7 @@ function foldEvent(state: CoreState, event: RunEvent, folder: TranscriptFolder |
 
   if (event.type === 'run_started') {
     next.status = 'running';
+    next.terminal = false;
     if (data?.kind === 'run_started') next.maxRounds = data.max_rounds;
   }
   if (event.type === 'configuration_failed') return terminate(next, 'failed');

--- a/clients/tui/src/session-model.test.ts
+++ b/clients/tui/src/session-model.test.ts
@@ -74,6 +74,7 @@ describe('event batch projection', () => {
     ]);
 
     expect(state.core.status).toBe('running');
+    expect(state.core.terminal).toBe(false);
     expect(state.core.diagnostics).toHaveLength(1);
     expect(state.errorBanner).toEqual(before.errorBanner);
   });


### PR DESCRIPTION
Fixes #505

## Background
VibeSys persists run events to a durable log. When a run is resumed 
with `--resume`, the TUI replays the full event history from that log 
to reconstruct its state. This replay always includes the terminal 
event from the previous session (`run_failed` or `run_interrupted`) 
followed by the new `run_started`.

## The Bug
The `run_started` handler in `core-state.ts` only sets 
`status: 'running'` and `maxRounds` — it never resets `terminal`. 
So after replay, the session ends up with `status: 'running'` and 
`terminal: true` simultaneously, which is a self-contradictory state 
the rest of the TUI was never designed to handle.

## User-Visible Impact
Three things break silently for the entire resumed session:
- **No disconnect banner** — if the backend socket drops, the error 
  banner and `markEventStreamUnavailable` are both skipped
- **No planning indicator** — the hypothesis planning-activity 
  spinner never appears
- **Non-streaming output** — live agent output renders as static 
  instead of streaming

## Fix
Add `next.terminal = false` to the `run_started` handler in 
`clients/core-state/src/core-state.ts`. This mirrors the symmetry 
that `terminate()` sets `terminal: true` — `run_started` should 
always undo it.

## Tests
Added `expect(state.core.terminal).toBe(false)` to the existing 
resumed-run reducer test in `clients/tui/src/session-model.test.ts`. 
The assertion failed before this fix and passes now. 
All 77 tests pass, 0 fail.