### PR TITLE
fix(tui): make pane focus unambiguous and legible in every theme

### DIFF
--- a/clients/tui/README.md
+++ b/clients/tui/README.md
@@ -93,12 +93,15 @@ list rises out of the command input rather than across the chat.
 
 The cursor starts in the command input, and `Ctrl+W` moves both it and the pane
 keys to the chat and back; the chat's instruction line says so (`Ctrl+W to type
-here`) until it holds them, and the focused input carries the focus border, so
-where a keystroke lands is never a guess. Only the chat composer accepts
-ordinary questions; the command input accepts slash commands. Page Up and Page Down scroll the focused pane, and
-Escape hands the keys back to the table. Arrows, Enter, and the rest of the
-table's keys are unaffected by the dock. A slash command typed into the chat
-input runs through the same command path as the command box.
+here`) until it holds them, and the chat pane carries the focus border while it
+does, so where a keystroke lands is never a guess. The command box is shared by
+every pane in its column rather than being one of them, so it keeps the neutral
+border in every theme and never competes with the pane that holds the keys.
+Only the chat composer accepts ordinary questions; the command input accepts
+slash commands. Page Up and Page Down scroll the focused pane, and Escape hands
+the keys back to the table. Arrows, Enter, and the rest of the table's keys are
+unaffected by the dock. A slash command typed into the chat input runs through
+the same command path as the command box.
 
 `/chat` leaves the command surface on this view, since the chat is already
 beside the table: it is absent from `/help` and from the completions, though it

--- a/clients/tui/src/session-model.ts
+++ b/clients/tui/src/session-model.ts
@@ -1223,7 +1223,12 @@ export function focusPane(state: SessionState, focus: PaneFocus): SessionState {
   return {...state, layout: {...state.layout, focus}};
 }
 
-/** The semantic pane currently receiving pane navigation keys. */
+/**
+ * The semantic pane currently receiving pane navigation keys, and the single
+ * authority for the focus treatment: every pane view compares its own `PaneId`
+ * against this, so at most one of them can be lit at a time. Surfaces that are
+ * not panes, the command box above all, never wear that treatment.
+ */
 export function focusedPane(state: SessionState): PaneId {
   if (experimentLogVisible(state)) {
     if (state.layout.focus === 'chat' && chatPaneVisible(state)) return 'chat';

--- a/clients/tui/src/ui/agent-map.ts
+++ b/clients/tui/src/ui/agent-map.ts
@@ -7,7 +7,13 @@ import {
 } from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
-import {scopedRounds, stripRounds, visiblePhases, visibleRoundNumber} from '../session-model.js';
+import {
+  focusedPane,
+  scopedRounds,
+  stripRounds,
+  visiblePhases,
+  visibleRoundNumber,
+} from '../session-model.js';
 import {
   type AgentGraph,
   type EdgeTone,
@@ -17,6 +23,7 @@ import {
   stageKinds,
 } from './agent-graph.js';
 import {agentRuntimeLabel} from './agent-runtime-label.js';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {elapsedLabel} from './previews.js';
 import type {Theme} from './theme.js';
 
@@ -68,6 +75,8 @@ export function agentPaneWidth(terminalWidth: number, stageCount: number): numbe
   return Math.min(ceiling, room, Math.max(floor, share));
 }
 
+const AGENTS_TITLE = 'Agents';
+
 export class AgentMapView {
   readonly output: BoxRenderable;
   #theme: Theme;
@@ -91,9 +100,9 @@ export class AgentMapView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
-      borderColor: theme.border,
-      title: ' Agents ',
+      borderStyle: paneBorderStyle(false),
+      borderColor: paneBorderColor(theme, false),
+      title: paneTitle(AGENTS_TITLE, false),
       onMouseUp: () => this.controller.focusRound('agents'),
     });
   }
@@ -118,10 +127,10 @@ export class AgentMapView {
     this.#renderedWidth = paneWidth;
     this.output.width = paneWidth;
     // The pane that owns the arrow keys says so, the way every other focusable
-    // surface in the client does.
-    this.output.borderColor =
-      state.roundFocus === 'agents' ? this.#theme.borderFocus : this.#theme.border;
-    this.output.title = state.roundFocus === 'agents' ? ' ▸ Agents ' : ' Agents ';
+    // surface in the client does. `focusedPane` is that single authority:
+    // reading `roundFocus` directly lit this pane while a visualization too
+    // narrow to split held the keys.
+    applyPaneFocus(this.output, this.#theme, AGENTS_TITLE, focusedPane(state) === 'agents');
     this.#clear();
     if (phases.length === 0) {
       // A round the run has not reached has no agents, and never will until it

--- a/clients/tui/src/ui/app.test.ts
+++ b/clients/tui/src/ui/app.test.ts
@@ -63,7 +63,8 @@ import {
 } from '../session-model.js';
 import {createOpenTuiApp, type OpenTuiApp} from './app.js';
 import type {ClipboardCopyResult, SelectionClipboard} from './clipboard.js';
-import {resolveTheme, type ThemeName} from './theme.js';
+import {paneTitle} from './focus.js';
+import {resolveTheme, THEME_NAMES, type ThemeName} from './theme.js';
 
 const cleanup: Array<() => void> = [];
 
@@ -466,17 +467,17 @@ describe('OpenTUI presentation', () => {
     const helpLine = lines.findIndex(line => line.includes('[/]: round'));
     const viewportBottomBorder = lines.findIndex(
       (line, index) =>
-        index > activityLineIndex && index < helpLine && line.trimEnd().endsWith('╯'),
+        index > activityLineIndex && index < helpLine && FRAME_BOTTOM_RIGHT.test(line.trimEnd()),
     );
     expect(activityLineIndex).toBeGreaterThan(promptLine);
-    expect(activityLine?.trimEnd().endsWith('│')).toBe(true);
+    expect(FRAME_VERTICAL.test(activityLine?.trimEnd() ?? '')).toBe(true);
     expect(viewportBottomBorder).toBeGreaterThan(activityLineIndex);
     expect(viewportBottomBorder).toBeLessThan(helpLine);
     const transcriptColumn = Math.max(0, (activityLine?.indexOf('Implementer') ?? 2) - 2);
     expect(
       lines
         .slice(activityLineIndex + 1, viewportBottomBorder)
-        .every(line => line.slice(transcriptColumn).replaceAll('│', '').trim() === ''),
+        .every(line => line.slice(transcriptColumn).replaceAll(FRAME_VERTICALS, '').trim() === ''),
     ).toBe(true);
 
     controller.selectAgent('implementer');
@@ -1459,7 +1460,9 @@ describe('OpenTUI presentation', () => {
     const frame = await testRenderer.waitForFrame(value => value.includes('2 passed'));
     expect(frame).toContain('→ Bash(command="pytest")');
     expect(frame).toContain('← 2 passed');
-    expect(frame.match(/╭/g)).toHaveLength(5);
+    // Rounds, Agents, Transcript, the card, and Command. The focused panes
+    // draw a heavy corner, so the count is over both frame styles.
+    expect(frame.match(/[╭┏]/g)).toHaveLength(5);
   });
 
   it('renders a typed command payload with labeled stderr and exit code', async () => {
@@ -2268,6 +2271,7 @@ describe('theming', () => {
     expect(landing).not.toContain('round 41 detail');
     // The rounds strip and agent map are per-round chrome; neither is drawn.
     expect(landing).not.toContain('─ Rounds ─');
+    expect(paneFrameColumn(landing, 'Agents')).toBeNull();
     expect(landing).not.toContain('Agents');
   });
 
@@ -2627,12 +2631,9 @@ describe('theming', () => {
     // it.
     // The cursor starts in the command box, and the chat says how to reach it.
     expect(landing).toContain('Ctrl+W to type here');
-    const lines = landing.split('\n');
-    const paneTop = lines.find(line => line.includes('╭─ Experiment chat')) ?? '';
-    const messageTop = lines.find(line => line.includes('╭─ Message ')) ?? '';
-    const commandTop = lines.find(line => line.includes('╭─ Command')) ?? '';
-    expect(messageTop).not.toBe('');
-    expect(commandTop.indexOf('╭─ Command')).toBe(paneTop.indexOf('╭─ ▸ Experiments'));
+    expect(paneFrameColumn(landing, 'Experiment chat')).not.toBeNull();
+    expect(paneFrameColumn(landing, 'Message')).not.toBeNull();
+    expect(paneFrameColumn(landing, 'Command')).toBe(paneFrameColumn(landing, 'Experiments'));
   });
 
   it('routes typing to whichever input Ctrl+W points at', async () => {
@@ -2859,12 +2860,12 @@ describe('theming', () => {
     await testRenderer.mockInput.typeText('/pe');
     const frame = await testRenderer.waitForFrame(value => value.includes('[Tab]'));
 
-    const lines = frame.split('\n');
-    const suggestion = lines.find(line => line.includes('/perf')) ?? '';
-    const commandInput = lines.find(line => line.includes('╭─ Command')) ?? '';
+    const suggestion = frame.split('\n').find(line => line.includes('/perf')) ?? '';
+    const commandColumn = paneFrameColumn(frame, 'Command');
     // The list belongs to the box it completes, so it starts where that box
     // starts rather than running back across the chat column.
-    expect(suggestion.indexOf('/perf')).toBeGreaterThan(commandInput.indexOf('╭─ Command'));
+    expect(commandColumn).not.toBeNull();
+    expect(suggestion.indexOf('/perf')).toBeGreaterThan(commandColumn ?? 0);
   });
 
   it('drops /chat from the command surface while the chat is already docked', async () => {
@@ -3350,7 +3351,7 @@ describe('theming', () => {
     expect(frame).toContain('H-07');
     // The per-round chrome belongs to a hypothesis the operator never opened.
     expect(frame).not.toContain('─ Rounds ─');
-    expect(frame).not.toContain('─ Agents ─');
+    expect(paneFrameColumn(frame, 'Agents')).toBeNull();
   });
 
   it('moves the pane keys onto the docked chat and back with Ctrl+W', async () => {
@@ -3440,6 +3441,126 @@ describe('theming', () => {
     testRenderer.mockInput.pressKey('w', {ctrl: true});
     expect(await frameAfter(testRenderer)).toContain('▸ Experiments');
     expect(controller.state.layout.focus).toBe('left');
+  });
+
+  it('lights one pane and never the command box, in every built-in theme', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 24});
+    const controller = splitController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await frameAfter(testRenderer);
+
+    for (const name of THEME_NAMES) {
+      controller.setTheme(name);
+      const theme = resolveTheme(name);
+      await frameAfter(testRenderer);
+
+      // The transcript holds the round view's keys by default. Every other
+      // titled surface, the shared command box included, stays neutral.
+      expect(paneBorders(testRenderer)).toEqual({
+        Rounds: theme.borderStrong,
+        Agents: theme.border,
+        '▸ Transcript': theme.borderFocus,
+        Command: theme.border,
+      });
+
+      testRenderer.mockInput.pressKey('ARROW_LEFT');
+      await frameAfter(testRenderer);
+      // The treatment moves whole: the pane that gains it and the pane that
+      // loses it are repainted in the same frame.
+      expect(paneBorders(testRenderer)).toEqual({
+        Rounds: theme.borderStrong,
+        '▸ Agents': theme.borderFocus,
+        Transcript: theme.border,
+        Command: theme.border,
+      });
+
+      testRenderer.mockInput.pressKey('ARROW_RIGHT');
+      await frameAfter(testRenderer);
+    }
+  });
+
+  it('keeps the command box neutral while a proven hypothesis is on screen', async () => {
+    // Issue #433: the command box was painted in the success colour, so it read
+    // as the focused surface while the keys were on the table beside it. A
+    // success outcome on screen must not put any focus treatment on that box.
+    const testRenderer = await createTestRenderer({width: 160, height: 22});
+    const controller = logController();
+    controller.experiments = [
+      logEntry('H-07', 41, 41, {claim: 'batch the prefill step', resolved_outcome: 'disproven'}),
+      logEntry('H-08', 42, 42, {claim: 'bigger KV cache block', resolved_outcome: 'proven'}),
+    ];
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openExperimentLog();
+
+    for (const name of THEME_NAMES) {
+      controller.setTheme(name);
+      const theme = resolveTheme(name);
+      const frame = await frameAfter(testRenderer);
+
+      // The success colour really is on screen, which is the state #433 was
+      // reported in rather than a hypothetical one.
+      expect(frame).toContain('Accepted');
+      expect(spanColors(testRenderer, 'Accepted')?.fg).toBe(theme.success);
+
+      const borders = paneBorders(testRenderer);
+      expect(borders['▸ Experiments']).toBe(theme.borderFocus);
+      expect(borders['Command']).toBe(theme.border);
+      expect(borders['Command']).not.toBe(theme.success);
+      expect(borders['Command']).not.toBe(theme.borderFocus);
+    }
+  });
+
+  it('leaves every round pane neutral when a fallback modal takes the keys', async () => {
+    // Under the split width the visualization has no pane to be focused in, so
+    // it falls back to a modal and takes the keys with it. Reading `roundFocus`
+    // instead of `focusedPane` left the Agents pane lit behind that modal. The
+    // terminal is tall enough that the modal starts below the pane headings it
+    // would otherwise cover.
+    const testRenderer = await createTestRenderer({width: 90, height: 40});
+    const controller = splitController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    await frameAfter(testRenderer);
+    expect(controller.state.roundFocus).toBe('agents');
+
+    await controller.openPane('perf');
+    const frame = await frameAfter(testRenderer);
+
+    expect(controller.state.layout.focus).toBe('right');
+    expect(frame).not.toContain('▸ Agents');
+    expect(frame).not.toContain('▸ Transcript');
+    const theme = resolveTheme('dark');
+    const borders = paneBorders(testRenderer);
+    expect(borders['Agents']).toBe(theme.border);
+    expect(borders['Transcript']).toBe(theme.border);
+  });
+
+  it('moves the focus treatment on a click, not only on a keystroke', async () => {
+    const testRenderer = await createTestRenderer({width: 140, height: 24});
+    const controller = splitController();
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    testRenderer.mockInput.pressKey('ARROW_LEFT');
+    let frame = await frameAfter(testRenderer);
+    const theme = resolveTheme('dark');
+    expect(paneBorders(testRenderer)['▸ Agents']).toBe(theme.borderFocus);
+
+    const lines = frame.split('\n');
+    const row = lines.findIndex(line => line.includes('batched the prefill step'));
+    const column = (lines[row]?.indexOf('batched the prefill step') ?? 0) + 2;
+    await testRenderer.mockMouse.click(column, row);
+    frame = await frameAfter(testRenderer);
+
+    expect(controller.state.roundFocus).toBe('transcript');
+    expect(paneBorders(testRenderer)).toEqual({
+      Rounds: theme.borderStrong,
+      Agents: theme.border,
+      '▸ Transcript': theme.borderFocus,
+      Command: theme.border,
+    });
   });
 
   it('shows the hypothesis title as a heading in the detail view', async () => {
@@ -3677,6 +3798,40 @@ describe('theming', () => {
     // Focus moved to the transcript, so the pane border drops back to the
     // ordinary border colour and the transcript takes the focus colour.
     expect(spanColors(testRenderer, 'Performance')?.fg).toBe(theme.border);
+  });
+
+  /**
+   * Focus has to survive a palette that cannot express it. `borderFocus` and
+   * `border` are within 1.5x of each other in five of the eight themes, so the
+   * marker in the title's reserved gutter and the frame style are what actually
+   * carry the change, and neither may move the label they sit beside.
+   */
+  it.each(
+    THEME_NAMES.map(name => [name] as const),
+  )('marks focus in %s without moving the title', async (name: ThemeName) => {
+    const testRenderer = await createTestRenderer({width: 140, height: 20});
+    const controller = splitController();
+    controller.publish({...controller.state, themeName: name});
+    const app = createOpenTuiApp(testRenderer.renderer, controller);
+    registerCleanup(testRenderer.renderer, app);
+    await controller.openPane('perf');
+
+    const onRight = await frameAfter(testRenderer);
+    controller.cyclePaneFocus();
+    const onLeft = await frameAfter(testRenderer);
+
+    const focused = paneFrameCorner(onRight, 'Performance');
+    const resting = paneFrameCorner(onLeft, 'Performance');
+    expect(focused).toBeDefined();
+    expect(resting).toBeDefined();
+    // The marker is the non-colour channel, and it is independent of the theme.
+    expect(onRight).toContain(paneTitle('Performance', true));
+    expect(onLeft).toContain(paneTitle('Performance', false));
+    // The frame does not change: focus never alters a pane's shape.
+    expect(focused?.glyph).toBe(resting?.glyph);
+    // And the label itself does not move when either changes.
+    expect(focused?.column).toBe(resting?.column);
+    expect(onRight.split('\n')[0]?.length).toBe(onLeft.split('\n')[0]?.length);
   });
 
   it('keeps the pane current while the run advances', async () => {
@@ -4060,6 +4215,54 @@ function logEntry(
     active: false,
     ...overrides,
   };
+}
+
+/**
+ * Every titled box on screen, as its rendered title and border colour. The
+ * focus treatment is a frame style, a border colour, and a `▸` in the title's
+ * reserved gutter, so keying on the title as drawn asserts the marker and the
+ * colour together, and asserting the whole record catches a second surface
+ * lighting up as well as the right one going dark.
+ */
+function paneBorders(testRenderer: TestRendererSetup): Record<string, string> {
+  const borders: Record<string, string> = {};
+  for (const line of testRenderer.captureSpans().lines) {
+    for (const span of line.spans) {
+      // Either frame style, since a focused pane draws the heavy one.
+      for (const match of span.text.matchAll(/[╭┏][─━]([^─━╮┓]+)[─━]/g)) {
+        borders[(match[1] ?? '').trim()] = rgbToHex(span.fg).toLowerCase();
+      }
+    }
+  }
+  return borders;
+}
+
+/** The frame glyphs a pane draws, in either border style. */
+const FRAME_VERTICAL = /[│┃]$/;
+const FRAME_VERTICALS = /[│┃]/g;
+const FRAME_BOTTOM_RIGHT = /[╯┛]$/;
+
+/**
+ * The column a pane's frame starts at, or null when the pane is not on screen.
+ *
+ * Focus swaps the frame's glyphs and the marker in the title's reserved
+ * gutter, so a test about layout has to match on neither.
+ */
+function paneFrameColumn(frame: string, label: string): number | null {
+  return paneFrameCorner(frame, label)?.column ?? null;
+}
+
+/** The frame's top-left glyph and column, which together say how it is drawn. */
+function paneFrameCorner(
+  frame: string,
+  label: string,
+): {glyph: string; column: number} | undefined {
+  const top = new RegExp(`[╭┏][─━] [▸ ] ${label} `);
+  for (const line of frame.split('\n')) {
+    const match = top.exec(line);
+    if (match !== null) return {glyph: match[0][0] ?? '', column: match.index};
+  }
+  return undefined;
 }
 
 function spanColors(

--- a/clients/tui/src/ui/app.ts
+++ b/clients/tui/src/ui/app.ts
@@ -23,6 +23,7 @@ import {createCommandInputPanel} from './command-input.js';
 import {ConversationView} from './conversation.js';
 import {ErrorBannerView} from './error-banner.js';
 import {ExperimentLogView} from './experiment-log.js';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {type HeaderSpan, headerSpanStyle, MAX_HEADER_SPANS, renderHeader} from './header.js';
 import {bindKeybindings} from './keybindings.js';
 import {OverlayView} from './overlay.js';
@@ -58,6 +59,8 @@ const HEADER_CHROME = 4;
 
 const SPLIT_KEY_HELP =
   'Ctrl+W: switch pane · F4: zoom focused pane · PgUp/PgDn: scroll · Esc: close pane';
+
+const TRANSCRIPT_TITLE = 'Transcript';
 
 /**
  * A round the run has not reached has no turns and never will until it runs.
@@ -171,8 +174,9 @@ export function createOpenTuiApp(
     paddingLeft: 1,
     paddingRight: 1,
     border: true,
-    borderStyle: 'rounded',
-    borderColor: theme.border,
+    borderStyle: paneBorderStyle(false),
+    borderColor: paneBorderColor(theme, false),
+    title: paneTitle(TRANSCRIPT_TITLE, false),
     onMouseUp: focusTranscript,
   });
   const viewport = new ScrollBoxRenderable(renderer, {
@@ -435,8 +439,7 @@ export function createOpenTuiApp(
     // Inside a round the transcript is one of two navigable panes, so it carries
     // the focus border whenever the round view's keys are on it.
     const transcriptFocused = !showLog && paneFocus === 'transcript';
-    transcriptFrame.borderColor = transcriptFocused ? theme.borderFocus : theme.border;
-    transcriptFrame.title = transcriptFocused ? ' ▸ Transcript ' : ' Transcript ';
+    applyPaneFocus(transcriptFrame, theme, TRANSCRIPT_TITLE, transcriptFocused);
     // Match the chat to the left pane's rectangle so it sits beside the
     // visualization instead of over it. Bounds come from the siblings that
     // actually occupy those rows, so a taller todo strip still fits.
@@ -456,7 +459,6 @@ export function createOpenTuiApp(
     chatPane.render(state, showChatPane, chatWidth);
     const chatInputFocused = showChatPane && state.layout.focus === 'chat';
     commandColumn.visible = zoomedPane !== 'chat';
-    commandInput.setFocused(paneFocus === 'experiments' || paneFocus === 'transcript');
     // The command list completes the box it belongs to, and on this view that
     // box cannot open a chat that is already beside it.
     commandInput.setCommandContext({chatDocked: showChatPane});

--- a/clients/tui/src/ui/chat-composer.ts
+++ b/clients/tui/src/ui/chat-composer.ts
@@ -7,6 +7,7 @@ import {
 } from '@opentui/core';
 import {suggestChatSlashCommands} from '../commands.js';
 import type {ChatMenuRow, SessionState} from '../session-model.js';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {SuggestionMenu} from './suggestion-menu.js';
 import type {Theme} from './theme.js';
 
@@ -17,6 +18,8 @@ const EDITOR_HORIZONTAL_CHROME = 4;
 /** Rows the menu shows at once before it scrolls its selection into view. */
 const MAX_MENU_ROWS = 10;
 const MENU_CHROME = 2;
+const COMPOSER_TITLE = 'Message';
+const PENDING_COMPOSER_TITLE = `${COMPOSER_TITLE} · awaiting agent`;
 
 class ChatTextareaRenderable extends TextareaRenderable {
   override handleKeyPress(key: KeyEvent): boolean {
@@ -69,6 +72,8 @@ export class ChatComposerView {
   readonly #menuList: TextRenderable;
   #availableWidth = 1;
   #focused = false;
+  /** Whether the agent still owes an answer, which the title says. */
+  #pending = false;
   #theme: Theme;
   #renderedMenu: string | null = null;
   #lastState: SessionState | null = null;
@@ -94,9 +99,9 @@ export class ChatComposerView {
       width: '100%',
       height: MIN_EDITOR_ROWS + 2,
       border: true,
-      borderStyle: 'rounded',
-      borderColor: theme.border,
-      title: ' Message ',
+      borderStyle: paneBorderStyle(false),
+      borderColor: paneBorderColor(theme, false),
+      title: paneTitle(COMPOSER_TITLE, false),
       paddingLeft: 1,
       paddingRight: 1,
       onMouseUp: this.onFocusRequest,
@@ -227,8 +232,8 @@ export class ChatComposerView {
       this.#editor.setText(this.draft.value);
       this.#syncSuggestions();
     }
+    this.#pending = pending;
     this.setFocused(focused);
-    this.#box.title = pending ? ' Message · awaiting agent ' : ' Message ';
     this.#hint.content = pending
       ? 'Awaiting the agent · Enter: queue follow-up'
       : focused
@@ -247,12 +252,17 @@ export class ChatComposerView {
 
   setFocused(focused: boolean): void {
     this.#focused = focused;
-    this.#box.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
+    this.#applyFocus();
+  }
+
+  #applyFocus(): void {
+    const label = this.#pending ? PENDING_COMPOSER_TITLE : COMPOSER_TITLE;
+    applyPaneFocus(this.#box, this.#theme, label, this.#focused);
   }
 
   applyTheme(theme: Theme): void {
     this.#theme = theme;
-    this.#box.borderColor = this.#focused ? theme.borderFocus : theme.border;
+    this.#applyFocus();
     this.#editor.textColor = theme.textStrong;
     this.#editor.focusedTextColor = theme.textStrong;
     this.#hint.fg = theme.textSubtle;

--- a/clients/tui/src/ui/command-input.ts
+++ b/clients/tui/src/ui/command-input.ts
@@ -7,6 +7,7 @@ import {
   TextRenderable,
 } from '@opentui/core';
 import {type CommandContext, slashCommandRange, suggestSlashCommands} from '../commands.js';
+import {paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {SuggestionMenu} from './suggestion-menu.js';
 import type {Theme} from './theme.js';
 
@@ -20,10 +21,11 @@ export interface CommandInputPanel {
   /** True when nothing is typed, so Enter belongs to whatever pane is behind. */
   isEmpty(): boolean;
   focus(): void;
-  setFocused(focused: boolean): void;
   applyTheme(theme: Theme): void;
   destroy(): void;
 }
+
+const COMMAND_TITLE = 'Command';
 
 function commandSyntaxStyle(theme: Theme): SyntaxStyle {
   return SyntaxStyle.fromStyles({'slash-command': {fg: theme.accent, bold: true}});
@@ -41,9 +43,16 @@ export function createCommandInputPanel(
     height: 3,
     width: '100%',
     border: true,
-    borderStyle: 'rounded',
-    borderColor: theme.borderFocus,
-    title: ' Command ',
+    // The focus treatment names the one pane the navigation keys are on. The
+    // command box is shared by every pane in the column rather than being one of
+    // them, so it never wears that treatment: resting frame, resting colour, and
+    // the gutter cell where a pane would put its marker. A second lit border
+    // made the marked pane ambiguous, which is the whole complaint behind #433.
+    // It still takes the title from `focus.ts` so its label sits at the same
+    // column as the panes it shares the column with.
+    borderStyle: paneBorderStyle(false),
+    borderColor: paneBorderColor(theme, false),
+    title: paneTitle(COMMAND_TITLE, false),
     paddingLeft: 1,
     paddingRight: 1,
     onMouseUp: onFocusRequest,
@@ -108,8 +117,6 @@ export function createCommandInputPanel(
   input.on(InputRenderableEvents.INPUT, updateDecorations);
   input.on(InputRenderableEvents.ENTER, submit);
   box.add(input);
-  let focused = true;
-  let current = theme;
   return {
     box,
     suggestions,
@@ -131,13 +138,8 @@ export function createCommandInputPanel(
     },
     isEmpty: () => input.value.trim() === '',
     focus: () => input.focus(),
-    setFocused(next: boolean): void {
-      focused = next;
-      box.borderColor = next ? current.borderFocus : current.border;
-    },
     applyTheme(next: Theme): void {
-      current = next;
-      box.borderColor = focused ? next.borderFocus : next.border;
+      box.borderColor = paneBorderColor(next, false);
       input.textColor = next.textStrong;
       input.focusedTextColor = next.textStrong;
       suggestions.borderColor = next.border;

--- a/clients/tui/src/ui/experiment-log.ts
+++ b/clients/tui/src/ui/experiment-log.ts
@@ -14,6 +14,7 @@ import {
   selectedExperimentIndexItem,
   unownedExperimentRounds,
 } from '../session-model.js';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import {elapsedLabel} from './previews.js';
 import type {Theme} from './theme.js';
 
@@ -35,6 +36,7 @@ const HINT_MIN_WIDTH = 60;
 const CLAIM_MIN_WIDTH = 90;
 const MEASURED_MIN_WIDTH = 62;
 const KEPT_MIN_WIDTH = 104;
+const EXPERIMENTS_TITLE = 'Experiments';
 
 /**
  * Panel width at which the table still shows the claim, which is the row's
@@ -78,11 +80,11 @@ export class ExperimentLogView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
-      borderColor: theme.border,
+      borderStyle: paneBorderStyle(false),
+      borderColor: paneBorderColor(theme, false),
       backgroundColor: theme.elevatedSurface,
       visible: false,
-      title: ' Experiments ',
+      title: paneTitle(EXPERIMENTS_TITLE, false),
       onMouseUp: () => this.controller.focusPane('left'),
     });
     this.#header = new TextRenderable(renderer, {
@@ -152,9 +154,12 @@ export class ExperimentLogView {
       return;
     }
     this.output.visible = true;
-    const focused = focusedPane(state) === 'experiments';
-    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
-    this.output.title = focused ? ' ▸ Experiments ' : ' Experiments ';
+    applyPaneFocus(
+      this.output,
+      this.#theme,
+      EXPERIMENTS_TITLE,
+      focusedPane(state) === 'experiments',
+    );
     const width = this.#availableWidth ?? this.renderer.terminalWidth;
     if (state === this.#renderedState && width === this.#renderedWidth) return;
     const previousDetailKey = this.#renderedState?.hypothesisDetail?.entryKey ?? null;
@@ -274,7 +279,12 @@ export class ExperimentLogView {
 
   #renderDetail(entry: HypothesisEntry, state: SessionState): void {
     const selectedRound = state.hypothesisDetail?.selectedRound ?? null;
-    this.output.title = ` ${focusedTitlePrefix(state)}Hypothesis ${entry.hypothesis_id} `;
+    // Only the title: `render` already set the frame and the border colour on
+    // the box this draws into.
+    this.output.title = paneTitle(
+      `Hypothesis ${entry.hypothesis_id}`,
+      focusedPane(state) === 'experiments',
+    );
     this.#header.content = hypothesisMetadata(entry);
     const title = entry.title?.trim();
     if (title) this.#line(title, this.#theme.textStrong);
@@ -671,10 +681,6 @@ export function measuredDirection(entries: readonly HypothesisEntry[]): 'max' | 
     else if (direction !== candidate) return null;
   }
   return direction;
-}
-
-function focusedTitlePrefix(state: SessionState): string {
-  return focusedPane(state) === 'experiments' ? '▸ ' : '';
 }
 
 export function hypothesisMetadata(entry: HypothesisEntry): string {

--- a/clients/tui/src/ui/focus.test.ts
+++ b/clients/tui/src/ui/focus.test.ts
@@ -1,0 +1,86 @@
+import {describe, expect, it} from 'bun:test';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
+import {contrastRatio, listThemes, resolveTheme, type Theme} from './theme.js';
+
+const THEMES = listThemes().map(theme => [theme.name, theme] as const);
+
+describe('focus channels', () => {
+  it('reserves the marker cell so the label never moves', () => {
+    expect(paneTitle('Transcript', true)).toBe(' ▸ Transcript   ');
+    expect(paneTitle('Transcript', false)).toBe('   Transcript   ');
+    // Whitespace is symmetric about the label: three cells each side, the
+    // marker occupying one of the three on the left.
+    for (const focused of [true, false]) {
+      const title = paneTitle('Transcript', focused);
+      const lead = title.indexOf('Transcript');
+      const trail = title.length - lead - 'Transcript'.length;
+      expect(trail).toBe(lead);
+    }
+    for (const label of ['Transcript', 'Experiments', 'Hypothesis H-08', 'Message']) {
+      const focused = paneTitle(label, true);
+      const resting = paneTitle(label, false);
+      expect(focused.length).toBe(resting.length);
+      expect(focused.indexOf(label)).toBe(resting.indexOf(label));
+    }
+  });
+
+  it('keeps the same frame whether or not a pane holds focus', () => {
+    // Focus does not change the frame. A heavier weight would mean square
+    // corners, since Unicode has no heavy rounded corner, and that reads as a
+    // different kind of object rather than a louder one. The marker carries
+    // the non-colour signal instead.
+    expect(paneBorderStyle(true)).toBe(paneBorderStyle(false));
+    expect(paneBorderStyle(true)).toBe('rounded');
+  });
+
+  /**
+   * The property that keeps focus legible when a palette cannot carry it.
+   * Colour alone was the whole signal until this: `borderFocus` and `border`
+   * sit within 1.5x of each other in five of the eight built-in themes, and
+   * `high-contrast-light` had them inverted, so focusing a pane made it
+   * quieter. Any regression that puts the signal back into colour alone fails
+   * here rather than shipping.
+   */
+  it.each(
+    THEMES,
+  )('%s tells a focused pane from a resting one without using colour', (_name, theme: Theme) => {
+    const focused = {
+      title: paneTitle('Transcript', true),
+      borderStyle: paneBorderStyle(true),
+    };
+    const resting = {
+      title: paneTitle('Transcript', false),
+      borderStyle: paneBorderStyle(false),
+    };
+    const nonColorChannels = [
+      focused.title !== resting.title,
+      focused.borderStyle !== resting.borderStyle,
+    ].filter(Boolean);
+    expect(nonColorChannels.length).toBeGreaterThanOrEqual(1);
+    // The colour channel is allowed to be useless here, and in several
+    // themes it is. It must never be worse than useless: a focused border
+    // that is quieter than a resting one reads as focus being taken away.
+    const focusColor = paneBorderColor(theme, true);
+    const restingColor = paneBorderColor(theme, false);
+    expect(contrastRatio(focusColor, theme.canvas)).toBeGreaterThanOrEqual(
+      contrastRatio(restingColor, theme.canvas),
+    );
+  });
+
+  it('applies every channel to one frame', () => {
+    const theme = resolveTheme('dark');
+    const box = {title: '', borderStyle: 'rounded', borderColor: ''};
+    applyPaneFocus(box as never, theme, 'Agents', true);
+    expect(box).toEqual({
+      title: ' ▸ Agents   ',
+      borderStyle: paneBorderStyle(true),
+      borderColor: theme.borderFocus,
+    });
+    applyPaneFocus(box as never, theme, 'Agents', false);
+    expect(box).toEqual({
+      title: '   Agents   ',
+      borderStyle: paneBorderStyle(false),
+      borderColor: theme.border,
+    });
+  });
+});

--- a/clients/tui/src/ui/focus.ts
+++ b/clients/tui/src/ui/focus.ts
@@ -1,0 +1,90 @@
+import type {BorderStyle, BoxRenderable} from '@opentui/core';
+import type {Theme} from './theme.js';
+
+/**
+ * How a pane says it is the one taking keys.
+ *
+ * Three channels, in priority order: a marker in a reserved title gutter, the
+ * border style, then colour. Colour is last because it cannot carry the signal
+ * on its own. `borderFocus` and `border` sit within 1.5x of each other in five
+ * of the eight built-in themes, and the high-contrast pair collapses them by
+ * construction: those palettes are deliberately tiny, so there is no shade to
+ * move to. The first two channels hold in any palette, and in a terminal with
+ * no colour at all.
+ *
+ * This module owns how focus looks, never which surface has it: `focusedPane`
+ * is that authority, and each pane compares its own `PaneId` against it. A
+ * surface that is not a pane never wears the treatment. The command box is the
+ * case worth naming: it sits under the pane column and is shared by every pane
+ * in it rather than being one of them, so it takes the resting title, frame and
+ * colour and no focused variant. It calls in only to keep its label at the same
+ * column as the panes above it. Lighting it made the marked pane ambiguous,
+ * which is #433.
+ */
+
+/** Marks the title of the pane that currently takes keys. */
+const FOCUS_MARKER = '▸';
+
+/** Occupies the marker's cell while a pane is at rest. */
+const MARKER_GUTTER = ' ';
+
+/**
+ * Every pane keeps the rounded frame, focused or not.
+ *
+ * A heavier frame was tried as a second non-colour channel and dropped: the
+ * only heavier box-drawing weights are square (`┏┓┗┛`), because Unicode has no
+ * heavy rounded corner. The rounded arcs at U+256D-2570 are light-only. So the
+ * swap traded rounded corners for square ones, which is a change of shape
+ * rather than of weight, and reads as the pane becoming a different kind of
+ * object rather than a louder one.
+ *
+ * That leaves the reserved title marker as the non-colour channel. It is
+ * enough for WCAG 1.4.1, and unlike a frame weight it cannot be mistaken for a
+ * different component.
+ */
+const PANE_BORDER: BorderStyle = 'rounded';
+
+/**
+ * A pane title with the marker's cell reserved whether or not the pane holds
+ * focus.
+ *
+ * Prepending the marker instead slides the label two columns right, so the eye,
+ * which uses the title's left edge as a landmark, reads a focus change as the
+ * layout moving. Reserving the cell turns it into a glyph swap at a fixed
+ * column, and keeps a narrow pane's title truncating identically either way.
+ */
+export function paneTitle(label: string, focused: boolean): string {
+  // Symmetric: the gutter and the lead space together are two cells, and the
+  // label gets two on the other side, so the label sits centred in its own
+  // inset rather than pushed against the trailing edge.
+  return ` ${focused ? FOCUS_MARKER : MARKER_GUTTER} ${label}   `;
+}
+
+/**
+ * The frame a pane draws.
+ *
+ * Both styles are one cell per side, and OpenTUI invalidates only the raster
+ * when `borderStyle` changes, so a focus change cannot move the layout. A
+ * border of a different *width* would, which is why this channel is a style
+ * swap and not a thicker frame.
+ */
+export function paneBorderStyle(_focused: boolean): BorderStyle {
+  return PANE_BORDER;
+}
+
+/** Reinforces the two channels above, as far as a given palette allows. */
+export function paneBorderColor(theme: Theme, focused: boolean): string {
+  return focused ? theme.borderFocus : theme.border;
+}
+
+/** Applies every focus channel to one pane frame. */
+export function applyPaneFocus(
+  box: BoxRenderable,
+  theme: Theme,
+  label: string,
+  focused: boolean,
+): void {
+  box.title = paneTitle(label, focused);
+  box.borderStyle = paneBorderStyle(focused);
+  box.borderColor = paneBorderColor(theme, focused);
+}

--- a/clients/tui/src/ui/right-pane.ts
+++ b/clients/tui/src/ui/right-pane.ts
@@ -1,5 +1,6 @@
 import {BoxRenderable, type CliRenderer, ScrollBoxRenderable, TextRenderable} from '@opentui/core';
-import type {RightPane, SessionState} from '../session-model.js';
+import {focusedPane, type RightPane, type SessionState} from '../session-model.js';
+import {applyPaneFocus, paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import type {Theme} from './theme.js';
 
 /**
@@ -54,9 +55,9 @@ export class RightPaneView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
-      borderColor: theme.border,
-      title: ' Pane ',
+      borderStyle: paneBorderStyle(false),
+      borderColor: paneBorderColor(theme, false),
+      title: paneTitle('Pane', false),
       visible: false,
       onMouseUp: onFocusRequest,
     });
@@ -94,11 +95,11 @@ export class RightPaneView {
     }
     this.output.visible = true;
     this.output.width = width;
-    // The focused pane is the one that takes keys, so it carries the focus
-    // border colour and says so in its title.
-    const focused = state.layout.focus === 'right';
-    this.output.borderColor = focused ? this.#theme.borderFocus : this.#theme.border;
-    this.output.title = focused ? ` ▸ ${right.title} ` : ` ${right.title} `;
+    // The focused pane is the one that takes keys, and says so in its title
+    // marker, its frame, and its border colour. Every pane asks `focusedPane`,
+    // so exactly one of them can answer yes.
+    const focused = focusedPane(state) === 'performance';
+    applyPaneFocus(this.output, this.#theme, right.title, focused);
     if (right === this.#renderedPane) return;
     this.#renderedPane = right;
     this.#clear();

--- a/clients/tui/src/ui/theme.test.ts
+++ b/clients/tui/src/ui/theme.test.ts
@@ -152,10 +152,35 @@ describe('semantic roles', () => {
 
   it.each(
     themes.map(theme => [theme.name, theme] as const),
+  )('%s reserves the focus border for focus alone', (_name, theme: Theme) => {
+    // The focus border names the one pane the keys are on. A status colour that
+    // equals it turns a passing check or a warning into a claim about focus,
+    // which is what made a green command box read as the focused surface.
+    expect(theme.borderFocus).not.toBe(theme.border);
+    expect(theme.borderFocus).not.toBe(theme.borderStrong);
+    for (const status of [theme.success, theme.warning, theme.error] as const) {
+      expect(theme.borderFocus).not.toBe(status);
+    }
+  });
+
+  it.each(
+    themes.map(theme => [theme.name, theme] as const),
   )('%s keeps panel borders visible against the canvas', (_name, theme: Theme) => {
     for (const border of [theme.border, theme.borderStrong, theme.borderFocus] as const) {
       expect(contrastRatio(border, theme.canvas)).toBeGreaterThanOrEqual(1.7);
     }
+  });
+
+  it.each(
+    themes.map(theme => [theme.name, theme] as const),
+  )('%s never makes a focused border quieter than a resting one', (_name, theme: Theme) => {
+    // `high-contrast-light` shipped inverted: #0000cc reached 11.22 against a
+    // white canvas where the resting #333333 reached 12.63, so focusing a pane
+    // dimmed it. Colour is the weakest of the three focus channels, but it
+    // still may not point the wrong way.
+    expect(contrastRatio(theme.borderFocus, theme.canvas)).toBeGreaterThanOrEqual(
+      contrastRatio(theme.border, theme.canvas),
+    );
   });
 
   it('orients light and dark themes in opposite luminance directions', () => {

--- a/clients/tui/src/ui/theme.ts
+++ b/clients/tui/src/ui/theme.ts
@@ -554,7 +554,11 @@ const HIGH_CONTRAST_LIGHT: ThemeSpec = {
   textStrong: '#000000',
   border: '#333333',
   borderStrong: '#000000',
-  borderFocus: '#0000cc',
+  // Navy, not the brighter #0000cc this used to be. Against a white canvas
+  // that blue was *quieter* than the resting #333333 border (11.22 against
+  // 12.63), so focusing a pane made it recede. Focus must never be quieter
+  // than rest; `focus.test.ts` pins that for every theme.
+  borderFocus: '#000080',
   accent: '#006466',
   info: '#0033cc',
   success: '#006400',

--- a/clients/tui/src/ui/todo-strip.ts
+++ b/clients/tui/src/ui/todo-strip.ts
@@ -3,6 +3,7 @@ import type {TodoItem} from '@vibesys/core-state';
 import type {SessionController} from '../session-controller.js';
 import type {SessionState} from '../session-model.js';
 import {visibleTodos} from '../session-model.js';
+import {paneBorderColor, paneBorderStyle, paneTitle} from './focus.js';
 import type {Theme} from './theme.js';
 
 const STATUS_MARKER: Record<string, string> = {
@@ -158,11 +159,12 @@ export class TodoStripView {
       paddingLeft: 1,
       paddingRight: 1,
       border: true,
-      borderStyle: 'rounded',
-      // The open list owns the arrow keys, so it carries the focus border: the
-      // operator can see where the keys are going without being told.
-      borderColor: this.#theme.borderFocus,
-      title: ` ${todoTitle(todos)} `,
+      // The open list owns the arrow keys, so it carries the focused pane's
+      // chrome: the operator can see where the keys are going without being
+      // told.
+      borderStyle: paneBorderStyle(true),
+      borderColor: paneBorderColor(this.#theme, true),
+      title: paneTitle(todoTitle(todos), true),
     });
     this.output.add(list);
     for (const [index, todo] of shown.entries()) {

--- a/docs/contributing/tui-conventions.md
+++ b/docs/contributing/tui-conventions.md
@@ -1,0 +1,93 @@
+# TUI conventions
+
+What a key does in the VibeSys TUI is a citation, not a preference. This page
+records the sources so a binding argument resolves against prior art rather than
+taste, and so a reviewer can check a change against something.
+
+There is no single TUI standard. There are four bodies of prior art that between
+them settle most questions.
+
+## Sources
+
+**IBM Common User Access.** Introduced in 1987 under Systems Application
+Architecture and documented in [Panel Design and User
+Interaction](https://www.edm2.com/index.php/Common_User_Access) (1987) and the
+[Advanced Interface Design Guide](http://www.susandoreydesigns.com/software/CommonUserAccessGUIDesign.pdf)
+(1990). CUA 91 was adopted by Windows 95, and GNOME and KDE still track it. It is
+the closest thing to a formal standard for keyboard-driven interfaces, and it is
+where Tab-between-fields, F1-for-help, and Esc-cancels come from.
+
+**WCAG 2.2.** Written for the web, but four criteria describe properties a
+terminal can hold and fail:
+
+| Criterion | Requirement | Why it applies here |
+| --- | --- | --- |
+| [1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color) | Colour is never the only carrier of information | Two of the eight themes are high-contrast and have almost no palette, so a colour-only signal says nothing in them |
+| [2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible) | Keyboard focus has a visible indicator | The operator has to know where a keystroke lands before pressing it |
+| [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order) | Focus order is meaningful and predictable | Panes are a hierarchy, and movement has to match it |
+| [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard) | Everything is reachable by keyboard | A TUI has no other input |
+
+**De facto terminal conventions**, unwritten but near-universal across `less`,
+`vi`, `man`, `htop`, `tig`, `lazygit`, and `k9s`.
+
+**readline line editing.** `Ctrl+A`, `Ctrl+E`, `Ctrl+K`, `Ctrl+W`, `Ctrl+U` in
+any text input. This is what every shell does, so it is what fingers expect.
+
+## Rules
+
+### Movement
+
+**Arrows move within the focused pane. Tab moves between panes.** This is CUA,
+and it is the rule most often broken by accident. A binding that makes an arrow
+key change which pane is focused is wrong, however convenient it seems in one
+view, because it makes the same key mean two levels of movement depending on
+where you are.
+
+`Esc` moves out one level: cancel a modal, leave a pane, return to pane focus.
+It never quits the application.
+
+### Naming
+
+| Key | Meaning | Source |
+| --- | --- | --- |
+| `/` | Search within the focused content | `less`, `vi`, `man`, `htop`, `tig`, `k9s` |
+| `:` | Command | `vi` |
+| `?` | Help | `less`, `htop`, `tig`, `lazygit` |
+| `q` | Quit a read-only view | `less`, `man`, `htop` |
+| `Esc` | Back one level | CUA |
+| `Tab` / `Shift+Tab` | Next / previous pane | CUA |
+| `F1` | Help | CUA |
+
+`/` for search is about as strong as unwritten consensus gets. Where a command
+prefix and a search prefix compete for `/`, search wins and commands move to `:`.
+
+### Focus must not be colour alone
+
+WCAG 1.4.1. A focused pane differs from an unfocused one by at least one channel
+that is not colour. The TUI uses two: a marker in a reserved title gutter, and a
+heavier frame. Colour reinforces them and is never the only signal.
+
+The gutter is reserved rather than inserted, so the marker swaps a glyph instead
+of pushing the title sideways. A title that moves on focus reads as the layout
+shifting rather than the pane lighting up.
+
+`focus.test.ts` holds this for every built-in theme, so it is a property rather
+than an intention.
+
+### Nothing moves that does not have to
+
+Reserve space for anything that appears conditionally: focus markers, status
+lines, counts, and variable-width numbers. A row that appears and disappears
+resizes everything under it, and a list that jumps under the cursor costs more
+than the row saved.
+
+### Bindings are visible
+
+The active bindings are shown at the bottom of the screen. A binding a person
+has to already know is a binding they do not have.
+
+## Applying this
+
+A PR that adds or moves a binding names the rule it follows. If no rule covers
+it, say so and propose one here in the same change, so the next person inherits
+a decision rather than a precedent.


### PR DESCRIPTION
Closes #561. Regression of #433, which PR #434 recoloured rather than resolved.

## Problem

Two problems with one cause: nothing owned what focus means.

**Which surface is focused had no single authority.** `experiment-log` and the transcript asked `focusedPane(state)`, `agent-map` asked `state.roundFocus`, and `command-input` was driven by a pane-focus expression despite the command box being shared by every pane in its column. Two boxes lit at once.

**How focus is shown was carried by colour alone.** Across the eight built-in themes, focused-versus-resting border contrast is 4.33 at best and under 1.5 in five. `high-contrast-light` was inverted: focus at 11.22 against the canvas was *quieter* than the 12.63 resting border, so focusing a pane made it recede.

![before and after](https://raw.githubusercontent.com/Nano-AI/vibesys/assets/screenshots/m544.png)

## Solution

Every surface compares its own `PaneId` against `focusedPane`, documented as the sole authority. `focus.ts` owns three channels, colour last:

1. Marker in a **reserved** title gutter, so focus swaps a glyph rather than inserting one and the label never shifts.
2. `high-contrast-light` focus becomes navy `#000080` (16.01), removing the inversion.

A heavier frame was tried as a second non-colour channel and dropped. Unicode has no heavy rounded corner: the arcs at U+256D-2570 are light-only and the heavier weights are square, so the swap traded rounded corners for square ones. That reads as the pane becoming a different kind of object rather than a louder one. Focus never changes a pane's shape.

No other palette changes: every resting border already sits below the 3:1 non-text floor, so there is no headroom to quiet one further.

The command box calls the same helpers but only ever in the resting form. It takes the title so its label aligns with the panes above, never the marker or the heavy frame.

The high-contrast palettes are deliberately small, so no retune fixes this. Colour cannot be the primary channel: WCAG 1.4.1 and 2.4.7.

## Verification

`focus.test.ts` pins the invariant **for every built-in theme**: a focused pane differs from a resting one by at least one non-colour channel, and no theme makes a focused border quieter than a resting one.

| Check | Result |
| --- | --- |
| `bun test clients/tui/src/` | 524 pass, 0 fail |
| `check:ts` / `check:clients` / `check:ts-architecture` | clean |

Reverting the source while keeping the tests fails exactly the new assertions.

